### PR TITLE
fix include in installed header

### DIFF
--- a/src/impl/Kokkos_Sparse_impl_spmv_def.hpp
+++ b/src/impl/Kokkos_Sparse_impl_spmv_def.hpp
@@ -47,7 +47,7 @@
 #include "Kokkos_InnerProductSpaceTraits.hpp"
 #include "Kokkos_CrsMatrix.hpp" // only included for backwards compatibility
 #include "Kokkos_Blas1_MV.hpp"
-#include "impl/Kokkos_Sparse_impl_spmv_omp.hpp"
+#include "Kokkos_Sparse_impl_spmv_omp.hpp"
 
 #ifdef HAVE_KOKKOSKERNELS_ETI_ONLY
 #define KOKKOSSPARSE_ETI_ONLY


### PR DESCRIPTION
The headers in kokkos-kernels/src/impl/ get
installed to the include/ directory same
as the rest, so they should not include
each other as "impl/foo.hpp" because that
will not work in the installed location.
This fixes a compile error when building
Albany against current Trilinos.

@crtrott @mhoemmen 
Its pretty urgent that this gets through to Trilinos,
I'm pretty sure all compiles against installed
kokkos-kernels will fail until then.
The Albany CDash failure that spotted this is here:
http://my.cdash.org/viewBuildError.php?buildid=1146035