### PR TITLE
use numeric_limits<T>::quiet_NaN

### DIFF
--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -57,7 +57,6 @@
 #include <cfloat>
 #include <climits>
 #include <cmath>
-#include <cstdlib> // strtof, strtod, strtold
 #include <complex> // std::complex
 #include <limits> // std::numeric_limits
 #ifdef __CUDACC__
@@ -645,10 +644,8 @@ public:
   static KOKKOS_FORCEINLINE_FUNCTION float nan () {
 #ifdef __CUDA_ARCH__
     return CUDART_NAN_F;
-    //return nan (); //this returns 0???
 #else
-    // http://pubs.opengroup.org/onlinepubs/009696899/functions/nan.html
-    return strtof ("NAN()", (char**) NULL);
+    return std::numeric_limits<float>::quiet_NaN();
 #endif // __CUDA_ARCH__
   }
   static KOKKOS_FORCEINLINE_FUNCTION mag_type eps () {
@@ -886,10 +883,8 @@ public:
   static KOKKOS_FORCEINLINE_FUNCTION val_type nan () {
 #ifdef __CUDA_ARCH__
     return CUDART_NAN;
-    //return nan (); // this returns 0 ???
 #else
-    // http://pubs.opengroup.org/onlinepubs/009696899/functions/nan.html
-    return strtod ("NAN", (char**) NULL);
+    return std::numeric_limits<val_type>::quiet_NaN();
 #endif // __CUDA_ARCH__
   }
   static KOKKOS_FORCEINLINE_FUNCTION mag_type epsilon () {
@@ -1020,7 +1015,7 @@ public:
     return ::log10 (x);
   }
   static val_type nan () {
-    return strtold ("NAN()", (char**) NULL);
+    return std::numeric_limits<val_type>::quiet_NaN();
   }
   static mag_type epsilon () {
     return LDBL_EPSILON;

--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -644,6 +644,7 @@ public:
   static KOKKOS_FORCEINLINE_FUNCTION float nan () {
 #ifdef __CUDA_ARCH__
     return CUDART_NAN_F;
+    //return nan (); //this returns 0???
 #else
     return std::numeric_limits<float>::quiet_NaN();
 #endif // __CUDA_ARCH__
@@ -883,6 +884,7 @@ public:
   static KOKKOS_FORCEINLINE_FUNCTION val_type nan () {
 #ifdef __CUDA_ARCH__
     return CUDART_NAN;
+    //return nan (); // this returns 0 ???
 #else
     return std::numeric_limits<val_type>::quiet_NaN();
 #endif // __CUDA_ARCH__


### PR DESCRIPTION
using this instead of strtod() and friends
dramatically speeds up the
Kokkos::ArithTraits<T>::nan()
function.
The performance test
Trilinos/packages/minitensor/test/perf_test_01.cc
went from 5.5 seconds to 0.6 seconds.

see #35