### PR TITLE
fixes to sparse test that fails with uvm without lanch blocking

### DIFF
--- a/src/common/KokkosKernels_IOUtils.hpp
+++ b/src/common/KokkosKernels_IOUtils.hpp
@@ -306,6 +306,7 @@ crsMat_t kk_generate_triangular_sparse_matrix(
     Kokkos::deep_copy (rowmap_view , hr);
     Kokkos::deep_copy (columns_view , hc);
     Kokkos::deep_copy (values_view , hv);
+    Kokkos::fence();
   }
 
   graph_t static_graph (columns_view, rowmap_view);

--- a/unit_test/sparse/Test_Sparse_spmv.hpp
+++ b/unit_test/sparse/Test_Sparse_spmv.hpp
@@ -38,6 +38,7 @@ void sequential_spmv(crsMat_t input_mat, x_vector_type x, y_vector_type y,
 
   typename size_type_view_t::HostMirror h_rowmap = Kokkos::create_mirror_view(input_mat.graph.row_map);
   Kokkos::deep_copy(h_rowmap,input_mat.graph.row_map);
+  Kokkos::fence();
 
 
 
@@ -46,6 +47,7 @@ void sequential_spmv(crsMat_t input_mat, x_vector_type x, y_vector_type y,
 
   KokkosKernels::Impl::safe_device_to_host_deep_copy (x.dimension_0(), x, h_x);
   KokkosKernels::Impl::safe_device_to_host_deep_copy (y.dimension_0(), y, h_y);
+  Kokkos::fence();
 
 
   lno_t nr = input_mat.numRows();
@@ -105,6 +107,8 @@ void check_spmv_mv(crsMat_t input_mat, x_vector_type x, y_vector_type y, y_vecto
     auto x_i = Kokkos::subview (x, Kokkos::ALL (), i);
 
     auto y_i = Kokkos::subview (expected_y, Kokkos::ALL (), i);
+    Kokkos::fence();
+
     sequential_spmv(input_mat, x_i, y_i, alpha, beta);
 
     auto y_spmv = Kokkos::subview (y, Kokkos::ALL (), i);

--- a/unit_test/sparse/Test_Sparse_trsv.hpp
+++ b/unit_test/sparse/Test_Sparse_trsv.hpp
@@ -24,7 +24,7 @@ void check_trsv_mv(crsMat_t input_mat, x_vector_type x, y_vector_type b, y_vecto
   typedef typename scalar_view_t::value_type ScalarA;
   double eps = std::is_same<ScalarA,float>::value?2*1e-2:1e-7;
 
-
+  Kokkos::fence();
   KokkosSparse::trsv(uplo, "N", "N", input_mat, b, x);
 
   for (int i = 0; i < numMV; ++i){
@@ -61,7 +61,6 @@ void test_trsv_mv(lno_t numRows,size_type nnz, lno_t bandwidth, lno_t row_size_v
   //this function creates a dense lower and upper triangular matrix.
   //TODO: SHOULD CHANGE IT TO SPARSE
   crsMat_t lower_part = KokkosKernels::Impl::kk_generate_triangular_sparse_matrix<crsMat_t>('L', numRows,numCols,nnz,row_size_variance, bandwidth);
-
   KokkosSparse::spmv("N", alpha, lower_part, b_x_copy, beta, b_y);
   Test::check_trsv_mv(lower_part, b_x, b_y, b_x_copy, numMV, "L");
   //typedef typename Kokkos::View<lno_t*, layout, Device> indexview;


### PR DESCRIPTION
Some sparse tests were failing with UVM without launchblocking. This should fix them. 