### PR TITLE
Batched - for team impl, reduce blksize to 1.

### DIFF
--- a/src/batched/KokkosBatched_Gemv_Team_Internal.hpp
+++ b/src/batched/KokkosBatched_Gemv_Team_Internal.hpp
@@ -62,7 +62,7 @@ namespace KokkosBatched {
       if (alpha != zero) {
         if (m <= 0 || n <= 0) return 0;
         
-        if (beta != 1) 
+        if (beta != one) 
           member.team_barrier();
         
         Kokkos::parallel_for(Kokkos::TeamThreadRange(member,0,m),[&](const int &i) {

--- a/src/batched/KokkosBatched_Util.hpp
+++ b/src/batched/KokkosBatched_Util.hpp
@@ -308,7 +308,7 @@ namespace KokkosBatched {
 #if defined(KOKKOS_HAVE_CUDA)
 	  template<typename ActiveMemorySpaceType> KOKKOS_INLINE_FUNCTION static constexpr
 	  typename std::enable_if<std::is_same<ActiveMemorySpaceType,Kokkos::CudaSpace>::value,int>
-	  ::type mb() { return 2; }
+	  ::type mb() { return 1; }
 #endif
 	  template<typename ActiveMemorySpaceType> KOKKOS_INLINE_FUNCTION static constexpr
 	  typename std::enable_if<std::is_same<ActiveMemorySpaceType,Kokkos::HostSpace>::value,int>


### PR DESCRIPTION
The error is revealed from TRSV, LOWER, NOTRANS, NONUNIT for complex(valuetype)/complex(scalartype). The other combinations are all passed. For snapshot without breaking unit tests, lower the default blksize ( 2-> 1) we use for CUDA.  