### PR TITLE
Disable AVX float test (we do not have impl for that) -- #86

### DIFF
--- a/unit_test/batched/Test_Batched_VectorArithmatic.hpp
+++ b/unit_test/batched/Test_Batched_VectorArithmatic.hpp
@@ -197,10 +197,10 @@ TEST_F( TestCategory, batched_vector_arithmatic_simd_dcomplex2 ) {
 
 #if defined(__AVX__) || defined(__AVX2__)
 #if defined(KOKKOSKERNELS_INST_FLOAT)
-TEST_F( TestCategory, batched_vector_arithmatic_avx_float8 ) {
-  typedef VectorTag<AVX<float,TestExecSpace>, 8> vector_tag_type;
-  test_batched_vector_arithmatic<TestExecSpace,vector_tag_type>();
-}
+// TEST_F( TestCategory, batched_vector_arithmatic_avx_float8 ) {
+//   typedef VectorTag<AVX<float,TestExecSpace>, 8> vector_tag_type;
+//   test_batched_vector_arithmatic<TestExecSpace,vector_tag_type>();
+// }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE)
@@ -224,10 +224,10 @@ TEST_F( TestCategory, batched_vector_arithmatic_avx_dcomplex2 ) {
 
 #if defined(__AVX512F__)
 #if defined(KOKKOSKERNELS_INST_FLOAT)
-TEST_F( TestCategory, batched_vector_arithmatic_avx_float16 ) {
-  typedef VectorTag<AVX<float,TestExecSpace>, 16> vector_tag_type;
-  test_batched_vector_arithmatic<TestExecSpace,vector_tag_type>();
-}
+// TEST_F( TestCategory, batched_vector_arithmatic_avx_float16 ) {
+//   typedef VectorTag<AVX<float,TestExecSpace>, 16> vector_tag_type;
+//   test_batched_vector_arithmatic<TestExecSpace,vector_tag_type>();
+// }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE)


### PR DESCRIPTION
We do not provid float test for batch operation. With float test on, following tests are failed.

With floats, we have following failures.

[  PASSED  ] 378 tests.
[  FAILED  ] 14 tests, listed below:
[  FAILED  ] openmp.abs_float
[  FAILED  ] openmp.abs_mv_float
[  FAILED  ] openmp.nrm2_squared_float
[  FAILED  ] openmp.nrm2_squared_mv_float
[  FAILED  ] openmp.reciprocal_mv_float
[  FAILED  ] openmp.scal_mv_float
[  FAILED  ] openmp.sparse_trsv_mv_kokkos_complex_float_int_int_LayoutLeft_TestExecSpace
[  FAILED  ] openmp.sparse_trsv_mv_kokkos_complex_float_int64_t_int_LayoutLeft_TestExecSpace
[  FAILED  ] openmp.sparse_trsv_mv_kokkos_complex_float_int_size_t_LayoutLeft_TestExecSpace
[  FAILED  ] openmp.sparse_trsv_mv_kokkos_complex_float_int64_t_size_t_LayoutLeft_TestExecSpace
[  FAILED  ] openmp.sparse_trsv_mv_kokkos_complex_float_int_int_LayoutRight_TestExecSpace
[  FAILED  ] openmp.sparse_trsv_mv_kokkos_complex_float_int64_t_int_LayoutRight_TestExecSpace
[  FAILED  ] openmp.sparse_trsv_mv_kokkos_complex_float_int_size_t_LayoutRight_TestExecSpace
[  FAILED  ] openmp.sparse_trsv_mv_kokkos_complex_float_int64_t_size_t_LayoutRight_TestExecSpace