### PR TITLE
 Adding serial node to graph coloring test.

### DIFF
--- a/perf_test/common/KokkosKernels_TestParameters.hpp
+++ b/perf_test/common/KokkosKernels_TestParameters.hpp
@@ -67,6 +67,7 @@ struct Parameters{
   int use_threads;
   int use_openmp;
   int use_cuda;
+  int use_serial;
   int a_mem_space, b_mem_space, c_mem_space, work_mem_space;
 
 
@@ -109,6 +110,7 @@ struct Parameters{
     use_threads = 0;
     use_openmp = 0;
     use_cuda = 0;
+    use_serial = 0;
     a_mem_space = b_mem_space = c_mem_space = work_mem_space = 1;
     a_mtx_bin_file = b_mtx_bin_file = c_mtx_bin_file = NULL;
     compression2step = true;

--- a/perf_test/graph/KokkosGraph_color.cpp
+++ b/perf_test/graph/KokkosGraph_color.cpp
@@ -64,6 +64,9 @@ int parse_inputs (KokkosKernels::Experiment::Parameters &params, int argc, char 
     if ( 0 == strcasecmp( argv[i] , "threads" ) ) {
       params.use_threads = atoi( argv[++i] );
     }
+    else if ( 0 == strcasecmp( argv[i] , "serial" ) ) {
+      params.use_serial = atoi( argv[++i] );
+    }
     else if ( 0 == strcasecmp( argv[i] , "openmp" ) ) {
       params.use_openmp = atoi( argv[++i] );
     }
@@ -477,6 +480,26 @@ int main (int argc, char ** argv){
   }
 
 #endif
+
+#if defined( KOKKOS_HAVE_SERIAL )
+  if (params.use_serial) {
+    Kokkos::Serial::initialize( params.use_openmp );
+    Kokkos::Serial::print_configuration(std::cout);
+#ifdef KOKKOSKERNELS_MULTI_MEM
+    KokkosKernels::Experiment::run_multi_mem_experiment
+    <size_type, idx, Kokkos::Serial, Kokkos::Serial::memory_space, Kokkos::HostSpace>(
+        params
+        );
+#else
+
+    KokkosKernels::Experiment::run_multi_mem_experiment
+    <size_type, idx, Kokkos::Serial, Kokkos::Serial::memory_space, Kokkos::Serial::memory_space>(
+        params
+        );
+#endif
+    Kokkos::Serial::finalize();
+#endif
+  }
 
 
   return 0;


### PR DESCRIPTION
 Serial is now an option for all performance tests through parameters.

Fixing #93.