### PR TITLE
Adding directory for wiki examples including generic Makefile

### DIFF
--- a/Makefile.kokkos-kernels
+++ b/Makefile.kokkos-kernels
@@ -389,8 +389,10 @@ endif
 KOKKOSKERNELS_INTERNAL_HEADERS = $(wildcard ${KOKKOSKERNELS_PATH}/src/impl/*.hpp)
 KOKKOSKERNELS_INTERNAL_HEADERS += $(wildcard ${KOKKOSKERNELS_PATH}/src/impl/generated_specializations_hpp/*/*eti_spec*.hpp)
 
+ifdef KOKKOSKERNELS_INTERNAL_SRC_SPARSE
 vpath %.cpp $(sort $(dir $(KOKKOSKERNELS_INTERNAL_SRC_SPARSE)))
 vpath %.cpp $(sort $(dir $(KOKKOSKERNELS_INTERNAL_SRC_BLAS)))
+endif
 
 DEPFLAGS = -M
 

--- a/example/wiki/Makefile
+++ b/example/wiki/Makefile
@@ -1,0 +1,54 @@
+KOKKOS_PATH ?= ${HOME}/Kokkos/kokkos
+KOKKOSKERNELS_PATH ?= ${HOME}/Kokkos/kokkos-kernels
+
+# Turn of ETI
+KOKKOSKERNELS_SCALARS =  
+
+SRC ?= $(wildcard *.cpp)
+HDR ?= $(wildcard *.hpp)
+
+KOKKOS_DEVICES=OpenMP
+KOKKOS_ARCH = "SNB,Kepler35"
+KOKKOS_CUDA_OPTIONS=enable_lambda
+
+default: build
+	echo "Start Build"
+
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
+CXX = ${KOKKOS_PATH}/config/nvcc_wrapper
+else
+CXX = g++
+endif
+
+LINK = ${CXX}
+
+CXXFLAGS = -O3 -g 
+override CXXFLAGS += -I./
+LINKFLAGS = 
+
+EXE = test.x
+DEPFLAGS = -M
+
+vpath %.cpp $(sort $(dir $(SRC)))
+
+OBJ = $(notdir $(SRC:.cpp=.o))
+LIB =
+
+include $(KOKKOS_PATH)/Makefile.kokkos
+include ${KOKKOSKERNELS_PATH}/Makefile.kokkos-kernels
+
+$(warning $(OBJ) $(EXE) $(sort $(dir $(SRC))))
+
+build: $(EXE)
+
+$(EXE): $(OBJ) $(KOKKOS_LINK_DEPENDS) $(KOKKOSKERNELS_LINK_DEPENDS)
+	$(LINK) $(KOKKOS_LDFLAGS) $(KOKKOSKERNELS_LDFLAGS) $(LINKFLAGS) $(EXTRA_PATH) $(OBJ) $(KOKKOS_LIBS) $(KOKKOSKERNELS_LIBS) $(LIB) -o $(EXE)
+
+clean: kokkos-clean 
+	rm -f *.o *.cuda *.host
+
+# Compilation rules
+
+%.o:%.cpp $(KOKKOS_CPP_DEPENDS) $(HDR)
+	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(KOKKOSKERNELS_CPPFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $< -o $(notdir $@)
+

--- a/example/wiki/blas/abs/Makefile
+++ b/example/wiki/blas/abs/Makefile
@@ -1,0 +1,14 @@
+MAKEFILE_PATH := $(subst Makefile,,$(abspath $(lastword $(MAKEFILE_LIST))))
+
+ifndef KOKKOSKERNELS_PATH
+  KOKKOSKERNELS_PATH = $(MAKEFILE_PATH)../../../..
+endif
+ifndef KOKKOS_PATH
+  KOKKOS_PATH = $(KOKKOSKERNELS_PATH)/../kokkos
+endif
+
+SRC = $(wildcard $(MAKEFILE_PATH)*.cpp)
+HDR = $(wildcard $(MAKEFILE_PATH)*.hpp)
+
+include $(KOKKOSKERNELS_PATH)/example/wiki/Makefile
+

--- a/example/wiki/blas/abs/abs.cpp
+++ b/example/wiki/blas/abs/abs.cpp
@@ -1,0 +1,24 @@
+#include<Kokkos_Core.hpp>
+#include<KokkosBlas1_abs.hpp>
+
+int main(int argc, char* argv[]) {
+   Kokkos::initialize();
+
+   int N = atoi(argv[1]);
+
+   Kokkos::View<double*> x("X",N);
+   Kokkos::View<double*> y("Y",N);
+   Kokkos::deep_copy(x,-1.0);
+
+   KokkosBlas::abs(y,x);
+
+   double sum = 0.0;
+   Kokkos::parallel_reduce("CheckValue", N, KOKKOS_LAMBDA (const int& i, double& lsum) {
+     lsum += y(i);
+   },sum);
+
+   printf("Sum: %lf Expected: %lf Diff: %e\n",sum,1.0*N,sum-1.0*N);
+  
+   Kokkos::finalize();
+}
+


### PR DESCRIPTION
Also fixes a small issue in Makefile.kokkos-kernels for cases where
no ETI is done (e.g. when the list of scalars to instantiate is empty).