### PR TITLE
Spgemm: Static assert failures fixed 

### DIFF
--- a/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
@@ -899,8 +899,8 @@ bool KokkosSPGEMM
     	nnz_lno_t compressed_maxNumRoughZeros = 0;
     	size_t compressedoverall_flops = 0;
   		Kokkos::Impl::Timer timer1_t;
-  		auto new_row_mapB_begin = Kokkos::subview (out_row_map, std::make_pair (0, b_row_cnt - 1));
-  		auto new_row_mapB_end = Kokkos::subview (out_row_map, std::make_pair (1, b_row_cnt));
+  		auto new_row_mapB_begin = Kokkos::subview (out_row_map, std::make_pair (nnz_lno_t(0), b_row_cnt - 1));
+  		auto new_row_mapB_end = Kokkos::subview (out_row_map, std::make_pair (nnz_lno_t(1), b_row_cnt));
   		row_lno_persistent_work_view_t compressed_flops_per_row(Kokkos::ViewAllocateWithoutInitializing("origianal row flops"), a_row_cnt);
 
   		compressed_maxNumRoughZeros = this->getMaxRoughRowNNZ(a_row_cnt, row_mapA, entriesA, new_row_mapB_begin, new_row_mapB_end, compressed_flops_per_row.data());

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_def.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_def.hpp
@@ -96,8 +96,8 @@ void KokkosSPGEMM
 		nnz_lno_t maxNumRoughZeros = 0;
 		size_t overall_flops = 0;
 		Kokkos::Impl::Timer timer1;
-		auto new_row_mapB_begin = Kokkos::subview (row_mapB, std::make_pair (0, b_row_cnt - 1));
-		auto new_row_mapB_end = Kokkos::subview (row_mapB, std::make_pair (1, b_row_cnt));
+		auto new_row_mapB_begin = Kokkos::subview (row_mapB, std::make_pair (nnz_lno_t(0), b_row_cnt - 1));
+		auto new_row_mapB_end = Kokkos::subview (row_mapB, std::make_pair (nnz_lno_t(1), b_row_cnt));
 		row_lno_persistent_work_view_t flops_per_row(Kokkos::ViewAllocateWithoutInitializing("origianal row flops"), a_row_cnt);
 
 		//get maximum row flops.
@@ -189,8 +189,8 @@ void KokkosSPGEMM
     		std::cout << "SYMBOLIC PHASE -- NO COMPRESSION: maxNumRoughZeros:" << maxNumRoughZeros << std::endl;
     	}
 
-    	auto new_row_mapB_begin = Kokkos::subview (this->row_mapB, std::make_pair (0, n - 1));
-    	auto new_row_mapB_end = Kokkos::subview (this->row_mapB, std::make_pair (1, n));
+    	auto new_row_mapB_begin = Kokkos::subview (this->row_mapB, std::make_pair (nnz_lno_t(0), n - 1));
+    	auto new_row_mapB_end = Kokkos::subview (this->row_mapB, std::make_pair (nnz_lno_t(1), n));
 
     	//calling symbolic structure
     	this->symbolic_c_no_compression(


### PR DESCRIPTION
std::make_pair seems to require casting when used numeric constants. 
Fixing with a simple cast. 