### PR TITLE
atomic_fetch_add fix for Kokkos::Serial

### DIFF
--- a/src/common/KokkosKernels_HashmapAccumulator.hpp
+++ b/src/common/KokkosKernels_HashmapAccumulator.hpp
@@ -737,7 +737,7 @@ struct HashmapAccumulator{
       (*used_size_) += num_writes;
     });
      */
-    size_type my_write_index = Kokkos::atomic_fetch_add(used_size_, 1);
+    size_type my_write_index = Kokkos::atomic_fetch_add(used_size_, (size_type)1);
 
 
     if (my_write_index >= max_value_size_) {
@@ -749,7 +749,7 @@ struct HashmapAccumulator{
       values[my_write_index] = value;
       size_type hashbeginning = Kokkos::atomic_exchange(hash_begins+hash, my_write_index);
       if (hashbeginning == -1){
-        used_hashes[Kokkos::atomic_fetch_add(used_hash_size, 1)] = hash;
+        used_hashes[Kokkos::atomic_fetch_add(used_hash_size, (size_type)1)] = hash;
       }
       hash_nexts[my_write_index] = hashbeginning;
       return INSERT_SUCCESS;
@@ -821,7 +821,7 @@ struct HashmapAccumulator{
 	    if (used_size_[0] >= max_value_size_){
 	    	return INSERT_FULL;
 	    }
-	    size_type my_write_index = Kokkos::atomic_fetch_add(used_size_, 1);
+	    size_type my_write_index = Kokkos::atomic_fetch_add(used_size_, (size_type)1);
 
 
 	    if (my_write_index >= max_value_size_) {
@@ -886,7 +886,7 @@ struct HashmapAccumulator{
 
     size_type my_write_index = 0;
     if (key_not_found){
-    	my_write_index = Kokkos::atomic_fetch_add(used_size_, 1);
+    	my_write_index = Kokkos::atomic_fetch_add(used_size_, (size_type)1);
     	//my_write_index = used_size_[0]++;
     }
     else {
@@ -910,7 +910,7 @@ struct HashmapAccumulator{
       hash_nexts[my_write_index] = hashbeginning;
 
       if (hashbeginning == -1){
-        used_hashes[Kokkos::atomic_fetch_add(used_hash_size, 1)] = hash;
+        used_hashes[Kokkos::atomic_fetch_add(used_hash_size, (size_type)1)] = hash;
       }
       return INSERT_SUCCESS;
     }
@@ -975,7 +975,7 @@ struct HashmapAccumulator{
 
     size_type my_write_index = 0;
     if (key_not_found){
-    	my_write_index = Kokkos::atomic_fetch_add(used_size_, 1);
+    	my_write_index = Kokkos::atomic_fetch_add(used_size_, (size_type)1);
     	//my_write_index = used_size_[0]++;
     }
     else {
@@ -1103,7 +1103,7 @@ struct HashmapAccumulator{
     		//md note somehow commented part
     		if (initial_hash_begin == end_of_link || (keys[initial_hash_begin] > key)){
     			{
-    				volatile size_type my_write_index = Kokkos::atomic_fetch_add(used_size_, 1);
+    				volatile size_type my_write_index = Kokkos::atomic_fetch_add(used_size_, (size_type)1);
 #if 0
     				if (print) std::cout << "\t 8 my_write_index :" << my_write_index << " max_value_size_:" << max_value_size_ << std::endl;
 #endif
@@ -1255,7 +1255,7 @@ struct HashmapAccumulator{
 #endif
     			//we need to insert it to beginning.
     			{
-    				size_type my_write_index = Kokkos::atomic_fetch_add(used_size_, 1);
+    				size_type my_write_index = Kokkos::atomic_fetch_add(used_size_, (size_type)1);
 #if 0
     				if (print) std::cout << "\t 13 my_write_index :" << my_write_index << " max_value_size_:" << max_value_size_ << std::endl;
 #endif
@@ -1708,7 +1708,7 @@ struct HashmapAccumulator{
     values[my_write_index] = value;
     size_type hashbeginning = Kokkos::atomic_exchange(hash_begins+hash, my_write_index);
     if (hashbeginning == -1){
-      used_hashes[Kokkos::atomic_fetch_add(used_hash_size, 1)] = hash;
+      used_hashes[Kokkos::atomic_fetch_add(used_hash_size, (size_type)1)] = hash;
     }
     hash_nexts[my_write_index] = hashbeginning;
     vals_counts_gmem[my_write_index] = 1;
@@ -1742,7 +1742,7 @@ struct HashmapAccumulator{
         return INSERT_SUCCESS;
     }
 
-    size_type my_write_index = Kokkos::atomic_fetch_add(used_size_,1 );
+    size_type my_write_index = Kokkos::atomic_fetch_add(used_size_, (size_type)1);
 
     if (my_write_index >= max_value_size_) {
       return INSERT_FULL;
@@ -1790,7 +1790,7 @@ struct HashmapAccumulator{
         return INSERT_SUCCESS;
     }
 
-    size_type my_write_index = Kokkos::atomic_fetch_add(used_size_,1 );
+    size_type my_write_index = Kokkos::atomic_fetch_add(used_size_,(size_type)1);
 
     if (my_write_index >= max_value_size_) {
       return INSERT_FULL;
@@ -1877,7 +1877,7 @@ struct HashmapAccumulator{
 		  return INSERT_SUCCESS;
 	  }
 
-	  size_type my_write_index = Kokkos::atomic_fetch_add(used_size_,1 );
+	  size_type my_write_index = Kokkos::atomic_fetch_add(used_size_,(size_type)1);
 
 	  if (my_write_index >= max_value_size_) {
 		  return INSERT_FULL;
@@ -1888,7 +1888,7 @@ struct HashmapAccumulator{
 		  values[my_write_index] = value;
 		  size_type hashbeginning = Kokkos::atomic_exchange(hash_begins+hash, my_write_index);
 		  if (hashbeginning == -1){
-			  used_hashes[Kokkos::atomic_fetch_add(used_hash_size, 1)] = hash;
+			  used_hashes[Kokkos::atomic_fetch_add(used_hash_size, (size_type)1)] = hash;
 		  }
 		  hash_nexts[my_write_index] = hashbeginning;
 		  return INSERT_SUCCESS;
@@ -1921,7 +1921,7 @@ struct HashmapAccumulator{
 		  return INSERT_SUCCESS;
 	  }
 
-	  size_type my_write_index = Kokkos::atomic_fetch_add(used_size_,1 );
+	  size_type my_write_index = Kokkos::atomic_fetch_add(used_size_, (size_type)1 );
 
 	  if (my_write_index >= max_value_size_) {
 		  return INSERT_FULL;
@@ -1932,7 +1932,7 @@ struct HashmapAccumulator{
 		  //values[my_write_index] = value;
 		  size_type hashbeginning = Kokkos::atomic_exchange(hash_begins+hash, my_write_index);
 		  if (hashbeginning == -1){
-			  used_hashes[Kokkos::atomic_fetch_add(used_hash_size, 1)] = hash;
+			  used_hashes[Kokkos::atomic_fetch_add(used_hash_size,  (size_type)1)] = hash;
 		  }
 		  hash_nexts[my_write_index] = hashbeginning;
 		  return INSERT_SUCCESS;

--- a/src/common/KokkosKernels_PrintUtils.hpp
+++ b/src/common/KokkosKernels_PrintUtils.hpp
@@ -57,13 +57,15 @@ namespace Impl{
 template <typename in_lno_view_t,
           typename out_lno_view_t>
 struct Histogram{
+  typedef typename out_lno_view_t::value_type atomic_increment_type;
+
   in_lno_view_t inview;
   out_lno_view_t outview;
   Histogram (in_lno_view_t inview_, out_lno_view_t outview_): inview(inview_), outview(outview_){}
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const size_t &ii) const {
-    Kokkos::atomic_fetch_add(&(outview(inview(ii))),1);
+    Kokkos::atomic_fetch_add(&(outview(inview(ii))),(atomic_increment_type)1);
   }
 };
 

--- a/src/common/KokkosKernels_Utils.hpp
+++ b/src/common/KokkosKernels_Utils.hpp
@@ -209,6 +209,7 @@ template <typename in_lno_row_view_t,
           typename team_member>
 struct FillSymmetricEdgesHashMap{
   typedef typename in_lno_row_view_t::value_type idx;
+  typedef typename out_lno_row_view_t::value_type atomic_increment_type;
   idx num_rows;
   idx nnz;
   in_lno_row_view_t xadj;
@@ -244,22 +245,22 @@ struct FillSymmetricEdgesHashMap{
           Kokkos::UnorderedMapInsertResult r = umap.insert(Kokkos::pair<idx, idx>(colIndex, ii));
           if (r.success()){
 
-            Kokkos::atomic_fetch_add(&(pre_pps(ii)),1);
+            Kokkos::atomic_fetch_add(&(pre_pps(ii)),(atomic_increment_type)1);
 
-            Kokkos::atomic_fetch_add(&(pre_pps(colIndex)),1);
+            Kokkos::atomic_fetch_add(&(pre_pps(colIndex)),(atomic_increment_type)1);
           }
         }
         else if (colIndex > ii){
 
           Kokkos::UnorderedMapInsertResult r = umap.insert(Kokkos::pair<idx, idx>(ii, colIndex));
           if (r.success()){
-            Kokkos::atomic_fetch_add(&(pre_pps(colIndex)),1);
+            Kokkos::atomic_fetch_add(&(pre_pps(colIndex)),(atomic_increment_type)1);
 
-            Kokkos::atomic_fetch_add(&(pre_pps(ii)),1);
+            Kokkos::atomic_fetch_add(&(pre_pps(ii)),(atomic_increment_type)1);
           }
         }
         else {
-          Kokkos::atomic_fetch_add(&(pre_pps(ii)),1);
+          Kokkos::atomic_fetch_add(&(pre_pps(ii)),(atomic_increment_type)1);
         }
       }
 
@@ -275,6 +276,7 @@ template <typename in_lno_row_view_t,
           typename team_member>
 struct FillSymmetricLowerEdgesHashMap{
   typedef typename in_lno_row_view_t::value_type idx;
+  typedef typename out_lno_row_view_t::value_type atomic_increment_type;
   idx num_rows;
   idx nnz;
   in_lno_row_view_t xadj;
@@ -312,14 +314,14 @@ struct FillSymmetricLowerEdgesHashMap{
           Kokkos::UnorderedMapInsertResult r = umap.insert(Kokkos::pair<idx, idx>(colIndex, ii));
           if (r.success()){
 
-            Kokkos::atomic_fetch_add(&(pre_pps(colIndex)),1);
+            Kokkos::atomic_fetch_add(&(pre_pps(colIndex)),(atomic_increment_type)1);
           }
         }
         else if (colIndex > ii){
 
           Kokkos::UnorderedMapInsertResult r = umap.insert(Kokkos::pair<idx, idx>(ii, colIndex));
           if (r.success()){
-            Kokkos::atomic_fetch_add(&(pre_pps(ii)),1);
+            Kokkos::atomic_fetch_add(&(pre_pps(ii)),(atomic_increment_type)1);
           }
         }
 
@@ -337,6 +339,7 @@ template <typename in_lno_row_view_t,
           typename team_member_t>
 struct FillSymmetricCRS_HashMap{
   typedef typename in_lno_row_view_t::value_type idx;
+  typedef typename out_lno_row_view_t::value_type atomic_increment_type;
   idx num_rows;
   idx nnz;
   in_lno_row_view_t xadj;
@@ -372,22 +375,22 @@ struct FillSymmetricCRS_HashMap{
       if (colIndex < num_rows){
         if (colIndex < ii){
           if (umap.insert(Kokkos::pair<idx, idx>(colIndex, ii)).success()){
-            idx cAdjInd = Kokkos::atomic_fetch_add(&(pre_pps(colIndex)),1);
-            idx iAdjInd = Kokkos::atomic_fetch_add(&(pre_pps(ii)),1);
+            idx cAdjInd = Kokkos::atomic_fetch_add(&(pre_pps(colIndex)),(atomic_increment_type)1);
+            idx iAdjInd = Kokkos::atomic_fetch_add(&(pre_pps(ii)),(atomic_increment_type)1);
             sym_adj[cAdjInd] = ii;
             sym_adj[iAdjInd] = colIndex;
           }
         }
         else if (colIndex > ii){
           if (umap.insert(Kokkos::pair<idx, idx>(ii, colIndex)).success()){
-            idx cAdjInd = Kokkos::atomic_fetch_add(&(pre_pps(colIndex)),1);
-            idx iAdjInd = Kokkos::atomic_fetch_add(&(pre_pps(ii)),1);
+            idx cAdjInd = Kokkos::atomic_fetch_add(&(pre_pps(colIndex)),(atomic_increment_type)1);
+            idx iAdjInd = Kokkos::atomic_fetch_add(&(pre_pps(ii)),(atomic_increment_type)1);
             sym_adj[cAdjInd] = ii;
             sym_adj[iAdjInd] = colIndex;
           }
         }
         else {
-          idx cAdjInd = Kokkos::atomic_fetch_add(&(pre_pps(colIndex)),1);
+          idx cAdjInd = Kokkos::atomic_fetch_add(&(pre_pps(colIndex)),(atomic_increment_type)1);
           sym_adj[cAdjInd] = ii;
         }
       }
@@ -405,6 +408,7 @@ template <typename in_lno_row_view_t,
           typename team_member_t>
 struct FillSymmetricEdgeList_HashMap{
   typedef typename in_lno_row_view_t::value_type idx;
+  typedef typename out_lno_row_view_t::value_type atomic_increment_type;
   idx num_rows;
   idx nnz;
   in_lno_row_view_t xadj;
@@ -443,14 +447,14 @@ struct FillSymmetricEdgeList_HashMap{
       if (colIndex < num_rows){
         if (colIndex < ii){
           if (umap.insert(Kokkos::pair<idx, idx>(colIndex, ii)).success()){
-            idx cAdjInd = Kokkos::atomic_fetch_add(&(pps(colIndex)),1);
+            idx cAdjInd = Kokkos::atomic_fetch_add(&(pps(colIndex)),(atomic_increment_type)1);
             sym_src[cAdjInd] = colIndex;
             sym_dst[cAdjInd] = ii;
           }
         }
         else if (colIndex > ii){
           if (umap.insert(Kokkos::pair<idx, idx>(ii, colIndex)).success()){
-            idx cAdjInd = Kokkos::atomic_fetch_add(&(pps(ii)),1);
+            idx cAdjInd = Kokkos::atomic_fetch_add(&(pps(ii)),(atomic_increment_type)1);
             sym_src[cAdjInd] = ii;
             sym_dst[cAdjInd] = colIndex;
           }
@@ -486,7 +490,7 @@ struct Reverse_Map_Init{
   KOKKOS_INLINE_FUNCTION
   void operator()(const size_t &ii) const {
     forward_type fm = forward_map[ii];
-    Kokkos::atomic_fetch_add( &(reverse_map_xadj(fm)), 1);
+    Kokkos::atomic_fetch_add( &(reverse_map_xadj(fm)), (reverse_type)1);
   }
 
   /*

--- a/src/graph/KokkosGraph_GraphColorHandle.hpp
+++ b/src/graph/KokkosGraph_GraphColorHandle.hpp
@@ -350,6 +350,7 @@ private:
 
   template<typename v1, typename v2, typename v3, typename v4>
   struct FillLowerTriangleTeam{
+    typedef typename v3::value_type atomic_increment_type;
     nnz_lno_t nv;
     v1 xadj;
     v2 adj;
@@ -390,7 +391,7 @@ private:
         nnz_lno_t n = adj[adjind];
         if (ii < n && n < nv){
           size_type position =
-              Kokkos::atomic_fetch_add( &(lower_xadj_counts(ii)), 1);
+              Kokkos::atomic_fetch_add( &(lower_xadj_counts(ii)), (atomic_increment_type)1);
           lower_srcs(position) = ii;
           lower_dsts(position) = n;
         }

--- a/src/graph/impl/KokkosGraph_Distance2Color_impl.hpp
+++ b/src/graph/impl/KokkosGraph_Distance2Color_impl.hpp
@@ -817,6 +817,7 @@ private:
   template <typename adj_view_t>
   struct functorFindConflicts_Atomic
   {
+    typedef typename single_dim_index_view_type::value_type atomic_increment_type;
     nnz_lno_t                  nv;           // num verts
     const_lno_row_view_t       _idx;
     adj_view_t                 _adj;
@@ -865,7 +866,7 @@ private:
           {
             _colors(vid) = 0;   // uncolor vertex
             // Atomically add vertex to recolorList
-            const nnz_lno_t k = Kokkos::atomic_fetch_add( &_recolorListLength(), 1);
+            const nnz_lno_t k = Kokkos::atomic_fetch_add( &_recolorListLength(), (atomic_increment_type)1);
             _recolorList(k) = vid;
             numConflicts += 1;
             break;  // Can exit if vertex gets marked as a conflict.

--- a/src/graph/impl/KokkosGraph_GraphColor_impl.hpp
+++ b/src/graph/impl/KokkosGraph_GraphColor_impl.hpp
@@ -2050,7 +2050,7 @@ public:
         ) {
           _colors(i) = 0; // Uncolor vertex i
           // Atomically add vertex i to recolorList
-          const nnz_lno_t k = Kokkos::atomic_fetch_add( &_recolorListLength(), 1);
+          const nnz_lno_t k = Kokkos::atomic_fetch_add( &_recolorListLength(), (typename single_dim_index_view_type::value_type)1);
           _recolorList(k) = i;
           numConflicts += 1;
           break; // Once i is uncolored and marked conflict
@@ -2229,7 +2229,7 @@ public:
       color_t my_color = _colors(i);
       if (my_color == 0){
         // this should only happen when one_color_set_per_iteration is set to true.
-        const nnz_lno_t k = Kokkos::atomic_fetch_add( &_recolorListLength(), 1);
+        const nnz_lno_t k = Kokkos::atomic_fetch_add( &_recolorListLength(), (typename single_dim_index_view_type::value_type)1);
         _recolorList(k) = i;
         numConflicts++;
       }
@@ -2257,7 +2257,7 @@ public:
             _colors(i) = 0; // Uncolor vertex i
             _color_sets(i) = 0;
             // Atomically add vertex i to recolorList
-            const nnz_lno_t k = Kokkos::atomic_fetch_add( &_recolorListLength(), 1);
+            const nnz_lno_t k = Kokkos::atomic_fetch_add( &_recolorListLength(), (typename single_dim_index_view_type::value_type)1);
             _recolorList(k) = i;
             numConflicts++;
             break; // Once i is uncolored and marked conflict
@@ -2968,7 +2968,7 @@ public:
     void operator()(const size_type ii) const {
       size_type w = _edge_conflict_indices(ii);
       if(_edge_conflict_marker(w)){
-        const size_type future_index = Kokkos::atomic_fetch_add( &_new_index(), 1);
+        const size_type future_index = Kokkos::atomic_fetch_add( &_new_index(), (typename single_dim_index_view_type::value_type)1);
         _new_edge_conflict_indices(future_index) = w;
       }
     }

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
@@ -57,6 +57,8 @@ struct KokkosSPGEMM
     b_lno_row_view_t_, b_lno_nnz_view_t_, b_scalar_nnz_view_t_>::
     PortableNumericCHASH{
 
+  typedef nnz_lno_t atomic_increment_type;
+
   nnz_lno_t numrows;
 
   a_row_view_t row_mapA;
@@ -870,7 +872,7 @@ struct KokkosSPGEMM
     			  }
     			  if (fail){
     				  nnz_lno_t write_index = 0;
-    				  write_index = Kokkos::atomic_fetch_add(used_hash_sizes + 1, 1);
+    				  write_index = Kokkos::atomic_fetch_add(used_hash_sizes + 1, (atomic_increment_type)1);
     				  c_row[write_index] = my_b_col;
     				  c_row_vals[write_index] = my_b_val;
     			  }
@@ -890,7 +892,7 @@ struct KokkosSPGEMM
     	  if (my_key != init_value){
     		  scalar_t my_val = vals[my_index];
     		  nnz_lno_t write_index = 0;
-    		  write_index = Kokkos::atomic_fetch_add(used_hash_sizes + 1, 1);
+    		  write_index = Kokkos::atomic_fetch_add(used_hash_sizes + 1, (atomic_increment_type)1);
     		  c_row[write_index] = my_key;
     		  c_row_vals[write_index] = my_val;
     	  }
@@ -1084,7 +1086,7 @@ struct KokkosSPGEMM
     	  nnz_lno_t my_key = keys[my_index];
     	  if (my_key != init_value){
     		  scalar_t my_val = vals[my_index];
-    		  nnz_lno_t write_index = Kokkos::atomic_fetch_add(used_hash_sizes, 1);
+    		  nnz_lno_t write_index = Kokkos::atomic_fetch_add(used_hash_sizes, (atomic_increment_type)1);
     		  c_row[write_index] = my_key;
     		  c_row_vals[write_index] = my_val;
     	  }

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
@@ -2484,6 +2484,8 @@ struct KokkosSPGEMM
   <HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_view_t_,
     b_lno_row_view_t_, b_lno_nnz_view_t_, b_scalar_nnz_view_t_>::
   NonzeroesC{
+  typedef typename nnz_lno_t::value_type atomic_increment_type;
+
   nnz_lno_t numrows;
 
   a_row_view_t row_mapA;
@@ -2847,7 +2849,7 @@ struct KokkosSPGEMM
       while (c_rows){
         if (c_rows & unit){
 
-          size_type wind = Kokkos::atomic_fetch_add(used_hash_sizes, 1);
+          size_type wind = Kokkos::atomic_fetch_add(used_hash_sizes, (atomic_increment_type)1);
           entriesSetIndicesC(wind + row_begin) = set_size * c_rows_setind + current_row;
         }
         current_row++;
@@ -2871,7 +2873,7 @@ struct KokkosSPGEMM
         while (c_rows){
           if (c_rows & unit){
 
-            size_type wind = Kokkos::atomic_fetch_add(used_hash_sizes, 1);
+            size_type wind = Kokkos::atomic_fetch_add(used_hash_sizes, (atomic_increment_type)1);
             entriesSetIndicesC(wind + row_begin) = set_size * c_rows_setind + current_row;
           }
           current_row++;


### PR DESCRIPTION
Casting required when passing '1' as the increment argument to Kokkos
for cases where the View's data_type is not an int