### PR TITLE
missing typecast 

### DIFF
--- a/src/batched/KokkosBatched_AddRadial_Internal.hpp
+++ b/src/batched/KokkosBatched_AddRadial_Internal.hpp
@@ -28,8 +28,8 @@ namespace KokkosBatched {
 #endif
         for (int i=0;i<m;++i) {
           const auto a_real = RealPart(A[i*as]);
-          A[i*as] +=  ValueType(minus_abs_tiny)*(a_real <  0);
-          A[i*as] +=  ValueType(      abs_tiny)*(a_real >= 0);
+          A[i*as] +=  ValueType(minus_abs_tiny)*ValueType(a_real <  0);
+          A[i*as] +=  ValueType(      abs_tiny)*ValueType(a_real >= 0);
         }
         
         return 0;
@@ -56,8 +56,8 @@ namespace KokkosBatched {
           (Kokkos::TeamThreadRange(member,m),
            [&](const int &i) {
             const auto a_real = RealPart(A[i*as]);
-            A[i*as] +=  ValueType(minus_abs_tiny)*(a_real <  0);
-            A[i*as] +=  ValueType(      abs_tiny)*(a_real >= 0);
+            A[i*as] +=  ValueType(minus_abs_tiny)*ValueType(a_real <  0);
+            A[i*as] +=  ValueType(      abs_tiny)*ValueType(a_real >= 0);
           });
 
         return 0;

--- a/src/batched/KokkosBatched_LU_Serial_Internal.hpp
+++ b/src/batched/KokkosBatched_LU_Serial_Internal.hpp
@@ -57,8 +57,8 @@ namespace KokkosBatched {
 
         if (tiny != 0) {
           const auto alpha11_real = RealPart(alpha11);
-          alpha11 += minus_abs_tiny*(alpha11_real <  0);
-          alpha11 +=       abs_tiny*(alpha11_real >= 0);
+          alpha11 += minus_abs_tiny*ValueType(alpha11_real <  0);
+          alpha11 +=       abs_tiny*ValueType(alpha11_real >= 0);
         }
         for (int i=0;i<iend;++i) {
           // a21[i*as0] *= inv_alpha11; 

--- a/src/batched/KokkosBatched_LU_Team_Internal.hpp
+++ b/src/batched/KokkosBatched_LU_Team_Internal.hpp
@@ -63,8 +63,8 @@ namespace KokkosBatched {
         if (tiny != 0) {
           if (member.team_rank() == 0) {
             const auto alpha11_real = RealPart(alpha11);
-            alpha11 += minus_abs_tiny*(alpha11_real <  0);
-            alpha11 +=       abs_tiny*(alpha11_real >= 0);
+            alpha11 += minus_abs_tiny*ValueType(alpha11_real <  0);
+            alpha11 +=       abs_tiny*ValueType(alpha11_real >= 0);
           }
         }
         member.team_barrier();

--- a/src/batched/KokkosBatched_Test_BlockCrs.hpp
+++ b/src/batched/KokkosBatched_Test_BlockCrs.hpp
@@ -282,12 +282,14 @@ namespace KokkosBatched {
 
         // parallel over the instances of tridiagonal matrices
         if (!fake) {
+#if defined(KOKKOS_ENABLE_CUDA) && defined(__KOKKOSBATCHED_TEST_ENABLE_CUDA__)
           typedef FactorizeBlockTridiagMatrices<exec_space,value_type,array_layout,
 	    VectorLength,
 	    LU_AlgoTagType,
 	    Trsm_AlgoTagType,
 	    Gemm_AlgoTagType> functor_type;
-          
+#endif
+
           switch (op) {
           case 0: {
             std::cout << "KokkosBatched::RangeTag::" << Gemm_AlgoTagType::name() << "\n";
@@ -817,10 +819,13 @@ namespace KokkosBatched {
         _b = b.Values();
 
         {
+#if defined(KOKKOS_ENABLE_CUDA) && defined(__KOKKOSBATCHED_TEST_ENABLE_CUDA__)
           typedef SolveBlockTridiagMatrices<exec_space,value_type,array_layout,
 	    VectorLength,
 	    Trsv_AlgoTagType,
 	    Gemv_AlgoTagType> functor_type;
+#endif
+
           switch (op) {
           case 0: {
             const Kokkos::RangePolicy<exec_space,RangeTag> policy(0, _ntridiag);

--- a/src/batched/KokkosBatched_Test_BlockCrs_Util.hpp
+++ b/src/batched/KokkosBatched_Test_BlockCrs_Util.hpp
@@ -21,7 +21,7 @@ namespace KokkosBatched {
     typedef int ordinal_type;
     typedef int size_type;
     typedef double scalar_type;
-
+#define BLOCKCRS_MAX_BLOCKSIZE 32
 #define FLOP_MUL 1.0
 #define FLOP_ADD 1.0
     
@@ -233,7 +233,7 @@ namespace KokkosBatched {
     public:
       typedef ExeSpace exec_space;
       typedef ArrayLayout array_layout;
-      typedef CrsGraph<exec_space,array_layout> crs_graph_type;
+      typedef Test::CrsGraph<exec_space,array_layout> crs_graph_type;
 
       typedef scalar_type value_type;
       typedef Kokkos::View<scalar_type***,array_layout,exec_space> value_array_type;
@@ -300,9 +300,9 @@ namespace KokkosBatched {
       const ordinal_type blocksize = A.BlockSize();
 
       scalar_type 
-        tmp[blocksize*blocksize], 
-        diag_block[blocksize][blocksize], 
-        offdiag_block[blocksize][blocksize];
+        tmp[BLOCKCRS_MAX_BLOCKSIZE*BLOCKCRS_MAX_BLOCKSIZE], //[blocksize*blocksize], 
+        diag_block[BLOCKCRS_MAX_BLOCKSIZE][BLOCKCRS_MAX_BLOCKSIZE], //[blocksize][blocksize], 
+        offdiag_block[BLOCKCRS_MAX_BLOCKSIZE][BLOCKCRS_MAX_BLOCKSIZE]; //[blocksize][blocksize];
       
       Random<scalar_type> random;
 

--- a/unit_test/batched/Test_Batched_VectorRelation.hpp
+++ b/unit_test/batched/Test_Batched_VectorRelation.hpp
@@ -20,8 +20,8 @@ namespace Test {
     typedef typename vector_type::value_type value_type;    
     const int vector_length = vector_type::vector_length;
     
-    typedef Kokkos::Details::ArithTraits<value_type> ats;
-    typedef typename ats::mag_type mag_type;
+    //typedef Kokkos::Details::ArithTraits<value_type> ats;
+    //typedef typename ats::mag_type mag_type;
 
     vector_type a, b;
 

--- a/unit_test/batched/Test_Batched_VectorView.hpp
+++ b/unit_test/batched/Test_Batched_VectorView.hpp
@@ -113,7 +113,7 @@ namespace Test {
     /// random data initialization
     typedef Vector<VectorTagType,VectorLength> vector_type;
     
-    typedef typename vector_type::value_type value_type;    
+    //typedef typename vector_type::value_type value_type;    
     //const int vector_length = vector_type::vector_length;
     const int test_view_size = 4;
     { /// rank 1 array


### PR DESCRIPTION
@ndellingwood 

I tested this on my workstation (g++). Ifpack2 block cars test is compiled and tested. However, I see an weird error from ``Ifpack2_unit_tests_MPI_4``. BTW, I use trillions/ kokkos-develop branch for testing.

```

Program received signal SIGFPE, Arithmetic exception.
0x0000000002280496 in _ZN6Kokkos13MDRangePolicyIJNS_6SerialENS_4RankILj2ELNS_7IterateE2ELS3_2EEENS_9IndexTypeIiEEEEC2IimlEERKSt16initializer_listIT_ERKS9_IT0_ERKS9_IT1_E () at /home/kyukim/Work/lib/trilinos/master/kokkos/core/src/KokkosExp_MDRangePolicy.hpp:312
312	        m_tile_end[i] = static_cast<index_type>((span + m_tile[i] - 1) / m_tile[i]);
Missing separate debuginfos, use: debuginfo-install glibc-2.12-1.209.el6_9.2.x86_64
(gdb) bt
#0  0x0000000002280496 in _ZN6Kokkos13MDRangePolicyIJNS_6SerialENS_4RankILj2ELNS_7IterateE2ELS3_2EEENS_9IndexTypeIiEEEEC2IimlEERKSt16initializer_listIT_ERKS9_IT0_ERKS9_IT1_E () at /home/kyukim/Work/lib/trilinos/master/kokkos/core/src/KokkosExp_MDRangePolicy.hpp:312
#1  0x0000000002595cb3 in _ZN6Kokkos4Impl8ViewCopyINS_4ViewIPPdJNS_11LayoutRightENS_6DeviceINS_6SerialENS_9HostSpaceEEENS_12MemoryTraitsILj0EEEEEESC_S5_S7_Li2EiEC2ERKSC_SF_ () at /home/kyukim/Work/lib/trilinos/master/kokkos/core/src/Kokkos_CopyViews.hpp:283
#2  0x000000000258bd4d in _ZN6Kokkos4Impl9view_copyINS_4ViewIPPdJNS_11LayoutRightENS_6DeviceINS_6SerialENS_9HostSpaceEEENS_12MemoryTraitsILj0EEEEEESC_EEvRKT_RKT0_ () at /home/kyukim/Work/lib/trilinos/master/kokkos/core/src/Kokkos_CopyViews.hpp:494
#3  0x000000000257ebf3 in _ZN6Kokkos4Impl9ViewRemapINS_4ViewIPPdJNS_11LayoutRightENS_6DeviceINS_6SerialENS_9HostSpaceEEEEEESA_S7_Li2EEC2ERKSA_SD_ () at /home/kyukim/Work/lib/trilinos/master/kokkos/core/src/Kokkos_CopyViews.hpp:655
#4  0x0000000002576b46 in _ZN6Kokkos6resizeIPPdJNS_11LayoutRightENS_6DeviceINS_6SerialENS_9HostSpaceEEEEEENSt9enable_ifIXoosrSt7is_sameINS_4ViewIT_JDpT0_EE12array_layoutENS_10LayoutLeftEE5valuesrS9_ISF_S3_E5valueEvE4typeERSE_mmmmmmmm () at /home/kyukim/Work/lib/trilinos/master/kokkos/core/src/Kokkos_CopyViews.hpp:1654
#5  0x000000000257102f in _ZN7Ifpack24Impl16InvertDiagBlocksIN6Kokkos4ViewIPPPdJNS2_6DeviceINS2_6SerialENS2_9HostSpaceEEENS2_12MemoryTraitsILj1EEEEEEEC2ERSD_ () at /home/kyukim/Work/lib/trilinos/master/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp:689
#6  0x00000000025360b5 in Ifpack2::Relaxation<Tpetra::RowMatrix<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::Serial, Kokkos::HostSpace> > >::computeBlockCrs() () at /home/kyukim/Work/lib/trilinos/master/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp:821
#7  0x0000000002527e4c in Ifpack2::Relaxation<Tpetra::RowMatrix<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::Serial, Kokkos::HostSpace> > >::compute() () at /home/kyukim/Work/lib/trilinos/master/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp:889
#8  0x00000000022cd903 in void (anonymous namespace)::check_precond_basics<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::Serial, Kokkos::HostSpace> >(Teuchos::RCP<Ifpack2::Preconditioner<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::Serial, Kokkos::HostSpace> > >&, Teuchos::basic_FancyOStream<char, std::char_traits<char> >&, bool&) () at /home/kyukim/Work/lib/trilinos/master/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestFactory.cpp:76
#9  0x00000000022cb3d7 in (anonymous namespace)::Ifpack2Factory_BlockCrs_UnitTest<double, int, int>::runUnitTestImpl(Teuchos::basic_FancyOStream<char, std::char_traits<char> >&, bool&) const () at /home/kyukim/Work/lib/trilinos/master/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestFactory.cpp:188
#10 0x0000000003292ab6 in Teuchos::UnitTestBase::runUnitTest(Teuchos::basic_FancyOStream<char, std::char_traits<char> >&) const () at /home/kyukim/Work/lib/trilinos/master/packages/teuchos/core/src/Teuchos_UnitTestBase.cpp:62
#11 0x000000000326eb41 in Teuchos::UnitTestRepository::runUnitTestImpl(Teuchos::UnitTestBase const&, Teuchos::basic_FancyOStream<char, std::char_traits<char> >&) () at /home/kyukim/Work/lib/trilinos/master/packages/teuchos/core/src/Teuchos_UnitTestRepository.cpp:539
#12 0x000000000326d5a2 in Teuchos::UnitTestRepository::runUnitTests(Teuchos::basic_FancyOStream<char, std::char_traits<char> >&) () at /home/kyukim/Work/lib/trilinos/master/packages/teuchos/core/src/Teuchos_UnitTestRepository.cpp:317
#13 0x000000000326e5cb in Teuchos::UnitTestRepository::runUnitTestsFromMain(int, char**) () at /home/kyukim/Work/lib/trilinos/master/packages/teuchos/core/src/Teuchos_UnitTestRepository.cpp:423
#14 0x00000000022449c7 in main () at /home/kyukim/Work/lib/trilinos/master/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestMain.cpp:75
```

Is this something new ? is this kind of error fixed in kokkos ? To proceed the integration test, I submit this PR but if this error is something new, I will try to fix it.  

@ndellingwood I am sorry that I did not make sure this solves the problem or not. I do not know what is changed in kokkos and trillions integration branch. If you are okay, could you use this ``dimd-dev``branch with overriding flag for testing ? 