### PR TITLE
Fix intel error with pthreads

### DIFF
--- a/src/batched/KokkosBatched_Test_BlockCrs_Util.hpp
+++ b/src/batched/KokkosBatched_Test_BlockCrs_Util.hpp
@@ -2,6 +2,8 @@
 #include <vector>
 #include <algorithm>
 
+#include <stdexcept>
+
 #include "Kokkos_Core.hpp"
 #include "impl/Kokkos_Timer.hpp"
 


### PR DESCRIPTION
Intel 14.0.4, 15.0.2. 16.0.1,3 error
KokkosBatched_Test_BlockCrs_Util.hpp(897): error: namespace "std" has no
member "runtime_error"
Fix: Added #include <stdexcept> to file