### PR TITLE
Fix pragma error with gcc/4.8.4

### DIFF
--- a/src/blas/impl/KokkosBlas3_gemm_impl.hpp
+++ b/src/blas/impl/KokkosBlas3_gemm_impl.hpp
@@ -340,7 +340,10 @@ void impl_team_gemm_block(const TeamHandle& team, const ViewTypeC& C, const View
 #if defined(__CUDA_ARCH__) || !defined(KOKKOS_ENABLE_OPENMP)
     Kokkos::parallel_for(Kokkos::ThreadVectorRange(team,blockB1/4), [&] (const int B_j) {
 #else
-  #if (KOKKOS_COMPILER_GNU < 485 )
+  #if defined(KOKKOS_COMPILER_GNU)
+    #if (KOKKOS_COMPILER_GNU > 485 )
+    #pragma omp simd
+    #endif
   #else
     #pragma omp simd
   #endif

--- a/src/blas/impl/KokkosBlas3_gemm_impl.hpp
+++ b/src/blas/impl/KokkosBlas3_gemm_impl.hpp
@@ -340,7 +340,10 @@ void impl_team_gemm_block(const TeamHandle& team, const ViewTypeC& C, const View
 #if defined(__CUDA_ARCH__) || !defined(KOKKOS_ENABLE_OPENMP)
     Kokkos::parallel_for(Kokkos::ThreadVectorRange(team,blockB1/4), [&] (const int B_j) {
 #else
+  #if (KOKKOS_COMPILER_GNU < 485 )
+  #else
     #pragma omp simd
+  #endif
     for(int B_j=0; B_j<blockB1/4; B_j++) {
 #endif
       ScalarC C_ij0 = 0;


### PR DESCRIPTION
Error with gcc/4.8.4 and OpenMP backend
kokkos-kernels/src/blas/impl/KokkosBlas3_gemm_impl.hpp:343:0: error:
ignoring #pragma omp simd [-Werror=unknown-pragmas]

Fixed by adding preprocessor #if to remove the pragma if gnu compiler
less than 4.8.5