### PR TITLE
Fix out-of-bounds and timeout with bounds checking

### DIFF
--- a/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
@@ -899,8 +899,8 @@ bool KokkosSPGEMM
     	nnz_lno_t compressed_maxNumRoughZeros = 0;
     	size_t compressedoverall_flops = 0;
   		Kokkos::Impl::Timer timer1_t;
-  		auto new_row_mapB_begin = Kokkos::subview (out_row_map, std::make_pair (nnz_lno_t(0), b_row_cnt - 1));
-  		auto new_row_mapB_end = Kokkos::subview (out_row_map, std::make_pair (nnz_lno_t(1), b_row_cnt));
+  		auto new_row_mapB_begin = Kokkos::subview (out_row_map, std::make_pair (nnz_lno_t(0), b_row_cnt));
+  		auto new_row_mapB_end = Kokkos::subview (out_row_map, std::make_pair (nnz_lno_t(1), b_row_cnt + 1));
   		row_lno_persistent_work_view_t compressed_flops_per_row(Kokkos::ViewAllocateWithoutInitializing("origianal row flops"), a_row_cnt);
 
   		compressed_maxNumRoughZeros = this->getMaxRoughRowNNZ(a_row_cnt, row_mapA, entriesA, new_row_mapB_begin, new_row_mapB_end, compressed_flops_per_row.data());

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_def.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_def.hpp
@@ -96,8 +96,8 @@ void KokkosSPGEMM
 		nnz_lno_t maxNumRoughZeros = 0;
 		size_t overall_flops = 0;
 		Kokkos::Impl::Timer timer1;
-		auto new_row_mapB_begin = Kokkos::subview (row_mapB, std::make_pair (nnz_lno_t(0), b_row_cnt - 1));
-		auto new_row_mapB_end = Kokkos::subview (row_mapB, std::make_pair (nnz_lno_t(1), b_row_cnt));
+		auto new_row_mapB_begin = Kokkos::subview (row_mapB, std::make_pair (nnz_lno_t(0), b_row_cnt));
+		auto new_row_mapB_end = Kokkos::subview (row_mapB, std::make_pair (nnz_lno_t(1), b_row_cnt + 1));
 		row_lno_persistent_work_view_t flops_per_row(Kokkos::ViewAllocateWithoutInitializing("origianal row flops"), a_row_cnt);
 
 		//get maximum row flops.
@@ -170,8 +170,8 @@ void KokkosSPGEMM
     	}
     	else {
     		nnz_lno_t begin = 0;
-    		auto new_row_mapB_begin = Kokkos::subview (new_row_mapB, std::make_pair (begin, n - 1));
-    		auto new_row_mapB_end = Kokkos::subview (new_row_mapB, std::make_pair (begin + 1, n));
+    		auto new_row_mapB_begin = Kokkos::subview (new_row_mapB, std::make_pair (begin, n));
+    		auto new_row_mapB_end = Kokkos::subview (new_row_mapB, std::make_pair (begin + 1, n + 1));
 
     		//calling symbolic structure
     		this->symbolic_c(a_row_cnt, row_mapA, entriesA,
@@ -189,8 +189,8 @@ void KokkosSPGEMM
     		std::cout << "SYMBOLIC PHASE -- NO COMPRESSION: maxNumRoughZeros:" << maxNumRoughZeros << std::endl;
     	}
 
-    	auto new_row_mapB_begin = Kokkos::subview (this->row_mapB, std::make_pair (nnz_lno_t(0), n - 1));
-    	auto new_row_mapB_end = Kokkos::subview (this->row_mapB, std::make_pair (nnz_lno_t(1), n));
+    	auto new_row_mapB_begin = Kokkos::subview (this->row_mapB, std::make_pair (nnz_lno_t(0), n));
+    	auto new_row_mapB_end = Kokkos::subview (this->row_mapB, std::make_pair (nnz_lno_t(1), n + 1));
 
     	//calling symbolic structure
     	this->symbolic_c_no_compression(

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -136,11 +136,18 @@ IF (Kokkos_ENABLE_Serial)
   
   APPEND_GLOB(SERIAL_BLAS_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/serial/Test_Serial_Blas*.cpp)
 
+  IF ("NIGHTLY" IN_LIST ${PROJECT_NAME}_TEST_CATEGORIES)
+    IF (KOKKOS_ENABLE_DEBUG)
+      SET(DISABLE_SLOW_DGEMM_DOUBLE_TEST "--gtest_filter=-serial.gemm_double")
+    ENDIF()
+  ENDIF()
+
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     blas_serial
     SOURCES
       Test_Main.cpp
       ${SERIAL_BLAS_SOURCES}
+    ARGS ${DISABLE_SLOW_DGEMM_DOUBLE_TEST}
     COMM serial mpi
     NUM_MPI_PROCS 1
     TESTONLYLIBS kokkoskernels_gtest


### PR DESCRIPTION
This is a backport of the changes proposed in trilinos/Trilinos#2452 .

There was an off-by-one error when constructing subviews to supply as begin/end arrays. Also, the `dgemm_double` test is very slow with bounds checking on, so until it is modified such that it runs faster, I've added code to disable it when bounds checking is on.