### PR TITLE
Disable expensive debug openmp unit test

### DIFF
--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -85,11 +85,16 @@ IF (Kokkos_ENABLE_OpenMP)
   
   APPEND_GLOB(OPENMP_BLAS_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/openmp/Test_OpenMP_Blas*.cpp)
 
+  IF (KOKKOS_ENABLE_DEBUG)
+    SET(DISABLE_SLOW_DGEMM_DOUBLE_TEST "--gtest_filter=-openmp.gemm_double")
+  ENDIF()
+
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     blas_openmp
     SOURCES
       Test_Main.cpp
       ${OPENMP_BLAS_SOURCES}
+    ARGS ${DISABLE_SLOW_DGEMM_DOUBLE_TEST}
     COMM serial mpi
     NUM_MPI_PROCS 1
     TESTONLYLIBS kokkoskernels_gtest


### PR DESCRIPTION
CC: @ibaned, @mhoemmen 

This goes along with the PR #193.  This PR branch and that PR branch must be merged before the next time that KokkosKernels get snapshotted into Trilinos, it will wipe out matching changes there (and cause ATDM and other builds of Trilinos to fail).
