### PR TITLE
test_all_sandia: updates for apollo

### DIFF
--- a/scripts/test_all_sandia
+++ b/scripts/test_all_sandia
@@ -279,7 +279,7 @@ elif [ "$MACHINE" = "apollo" ]; then
 
   SKIP_HWLOC=True
 
-  BASE_MODULE_LIST="sems-env,kokkos-env,sems-<COMPILER_NAME>/<COMPILER_VERSION>,kokkos-hwloc/1.10.1/base"
+  BASE_MODULE_LIST="sems-env,kokkos-env,kokkos-hwloc/1.10.1/base,sems-<COMPILER_NAME>/<COMPILER_VERSION>"
   CUDA_MODULE_LIST="sems-env,kokkos-env,kokkos-<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/4.8.4,kokkos-hwloc/1.10.1/base"
   CUDA8_MODULE_LIST="sems-env,kokkos-env,kokkos-<COMPILER_NAME>/<COMPILER_VERSION>,sems-gcc/5.3.0,kokkos-hwloc/1.10.1/base"
 
@@ -319,7 +319,7 @@ elif [ "$MACHINE" = "apollo" ]; then
   fi
 
   if [ -z "$ARCH_FLAG" ]; then
-    ARCH_FLAG="--arch=SNB,Kepler35"
+    ARCH_FLAG="--arch=SNB,Volta70"
   fi
 
   NUM_JOBS_TO_RUN_IN_PARALLEL=1


### PR DESCRIPTION
1. change default arch from Kepler37 to Volta70
2. change order that modules load due to error with hwloc and intel
   loading hwloc prior to compiler fixed the issue; did not see
   this with other compilers.