### PR TITLE
Block sgs

### DIFF
--- a/perf_test/batched/KokkosBatched_Test_BlockCrs_Cuda.cpp
+++ b/perf_test/batched/KokkosBatched_Test_BlockCrs_Cuda.cpp
@@ -54,7 +54,6 @@ using namespace KokkosBatched;
 int main (int argc, char *argv[]) {
   Kokkos::initialize(argc, argv); 
 
-  typedef Kokkos::DefaultHostExecutionSpace HostSpaceType;
   typedef Kokkos::DefaultExecutionSpace DeviceSpaceType;
 
   const bool detail = false;

--- a/perf_test/batched/KokkosBatched_Test_Gemm_Cuda.cpp
+++ b/perf_test/batched/KokkosBatched_Test_Gemm_Cuda.cpp
@@ -362,7 +362,6 @@ namespace KokkosBatched {
           double tavg = 0, tmin = tmax;
           {
             typedef Kokkos::TeamPolicy<DeviceSpaceType,ScheduleType,TeamTagV1> policy_type;
-            typedef typename policy_type::member_type member_type;
 
             typedef Functor<view_type,AlgoTagType,VectorLength> functor_type;
             typedef Kokkos::Impl::ParallelFor<functor_type,policy_type,DeviceSpaceType> parallel_for_type;
@@ -429,7 +428,6 @@ namespace KokkosBatched {
           double tavg = 0, tmin = tmax;
           {
             typedef Kokkos::TeamPolicy<DeviceSpaceType,ScheduleType,TeamTagV2> policy_type;
-            typedef typename policy_type::member_type member_type;
 
             typedef Functor<view_type,AlgoTagType,VectorLength> functor_type;
             typedef Kokkos::Impl::ParallelFor<functor_type,policy_type,DeviceSpaceType> parallel_for_type;
@@ -504,7 +502,6 @@ namespace KokkosBatched {
           double tavg = 0, tmin = tmax;
           {
             typedef Kokkos::TeamPolicy<DeviceSpaceType,ScheduleType,TeamTagV3> policy_type;
-            typedef typename policy_type::member_type member_type;
 
             typedef Functor<view_type,AlgoTagType,VectorLength> functor_type;
             typedef Kokkos::Impl::ParallelFor<functor_type,policy_type,DeviceSpaceType> parallel_for_type;
@@ -589,7 +586,6 @@ namespace KokkosBatched {
           double tavg = 0, tmin = tmax;
           {
             typedef Kokkos::TeamPolicy<DeviceSpaceType,ScheduleType,TeamTagHandmade> policy_type;
-            typedef typename policy_type::member_type member_type;
 
             typedef Functor<view_type,AlgoTagType,VectorLength> functor_type;
             typedef Kokkos::Impl::ParallelFor<functor_type,policy_type,DeviceSpaceType> parallel_for_type;

--- a/perf_test/batched/KokkosBatched_Test_LU_Cuda.cpp
+++ b/perf_test/batched/KokkosBatched_Test_LU_Cuda.cpp
@@ -72,7 +72,7 @@ namespace KokkosBatched {
             (Kokkos::ThreadVectorRange(member, VectorLength),
              [&](const int &k) {
               const int kk = kbeg + k;
-              if (kk < _a.extent(0)) {
+              if (kk < _a.extent_int(0)) {
                 auto aa = Kokkos::subview(_a, kk, Kokkos::ALL(), Kokkos::ALL());
                 SerialLU<AlgoTagType>::invoke(aa);
               }
@@ -87,7 +87,7 @@ namespace KokkosBatched {
             (Kokkos::ThreadVectorRange(member, VectorLength),
              [&](const int &k) {
               const int kk = kbeg + k;
-              if (kk < _a.extent(0)) {
+              if (kk < _a.extent_int(0)) {
                 auto aa = Kokkos::subview(_a, kk, Kokkos::ALL(), Kokkos::ALL());
                 TeamLU<MemberType,AlgoTagType>::invoke(member, aa);
               }
@@ -105,7 +105,7 @@ namespace KokkosBatched {
             (Kokkos::ThreadVectorRange(member, VectorLength),
              [&](const int &k) {
               const int kk = kbeg + k;
-              if (kk < _a.extent(0)) {
+              if (kk < _a.extent_int(0)) {
                 auto aa  = Kokkos::subview(_a, kk, Kokkos::ALL(), Kokkos::ALL());
                 auto saa = Kokkos::subview(sa,  k, Kokkos::ALL(), Kokkos::ALL());
 

--- a/perf_test/batched/KokkosBatched_Test_LU_Cuda.cpp
+++ b/perf_test/batched/KokkosBatched_Test_LU_Cuda.cpp
@@ -329,7 +329,6 @@ namespace KokkosBatched {
           double tavg = 0, tmin = tmax;
           {
             typedef Kokkos::TeamPolicy<DeviceSpaceType,ScheduleType,TeamTagV1> policy_type;
-            typedef typename policy_type::member_type member_type;
 
             typedef Functor<view_type,AlgoTagType,VectorLength> functor_type;
             typedef Kokkos::Impl::ParallelFor<functor_type,policy_type,DeviceSpaceType> parallel_for_type;
@@ -391,7 +390,6 @@ namespace KokkosBatched {
           double tavg = 0, tmin = tmax;
           {
             typedef Kokkos::TeamPolicy<DeviceSpaceType,ScheduleType,TeamTagV2> policy_type;
-            typedef typename policy_type::member_type member_type;
 
             typedef Functor<view_type,AlgoTagType,VectorLength> functor_type;
             typedef Kokkos::Impl::ParallelFor<functor_type,policy_type,DeviceSpaceType> parallel_for_type;
@@ -462,7 +460,6 @@ namespace KokkosBatched {
           double tavg = 0, tmin = tmax;
           {
             typedef Kokkos::TeamPolicy<DeviceSpaceType,ScheduleType,TeamTagV3> policy_type;
-            typedef typename policy_type::member_type member_type;
 
             typedef Functor<view_type,AlgoTagType,VectorLength> functor_type;
             typedef Kokkos::Impl::ParallelFor<functor_type,policy_type,DeviceSpaceType> parallel_for_type;

--- a/perf_test/batched/KokkosBatched_Test_Trsm_Cuda.cpp
+++ b/perf_test/batched/KokkosBatched_Test_Trsm_Cuda.cpp
@@ -523,7 +523,6 @@ namespace KokkosBatched {
           double tavg = 0, tmin = tmax;        
           {
             typedef Kokkos::TeamPolicy<DeviceSpaceType,ScheduleType,TeamTagV1> policy_type;
-            typedef typename policy_type::member_type member_type;
 
             typedef Functor<test,view_type,AlgoTagType,VectorLength> functor_type;
             typedef Kokkos::Impl::ParallelFor<functor_type,policy_type,DeviceSpaceType> parallel_for_type;
@@ -589,7 +588,6 @@ namespace KokkosBatched {
           double tavg = 0, tmin = tmax;        
           {
             typedef Kokkos::TeamPolicy<DeviceSpaceType,ScheduleType,TeamTagV2> policy_type;
-            typedef typename policy_type::member_type member_type;
 
             typedef Functor<test,view_type,AlgoTagType,VectorLength> functor_type;
             typedef Kokkos::Impl::ParallelFor<functor_type,policy_type,DeviceSpaceType> parallel_for_type;
@@ -663,7 +661,6 @@ namespace KokkosBatched {
           double tavg = 0, tmin = tmax;        
           {
             typedef Kokkos::TeamPolicy<DeviceSpaceType,ScheduleType,TeamTagV3> policy_type;
-            typedef typename policy_type::member_type member_type;
 
             typedef Functor<test,view_type,AlgoTagType,VectorLength> functor_type;
             typedef Kokkos::Impl::ParallelFor<functor_type,policy_type,DeviceSpaceType> parallel_for_type;

--- a/perf_test/sparse/KokkosSparse_block_pcg.cpp
+++ b/perf_test/sparse/KokkosSparse_block_pcg.cpp
@@ -124,7 +124,6 @@ void run_point_experiment(
 
 	  KernelHandle kh;
 
-
 	  kh.create_gs_handle(/*KokkosSparse::GS_TEAM*/);
 	  Kokkos::Impl::Timer timer1;
 	  KokkosKernels::Experimental::Example::pcgsolve(
@@ -719,9 +718,11 @@ int main (int argc, char ** argv){
       delete [] ew;
 
       values_view_t kok_x_original = create_x_vector<values_view_t>(((nv /block_size) + 1) * block_size, MAXVAL);
+/*
       for (INDEX_TYPE i = nv; i < ((nv /block_size) + 1) * block_size; ++i){
     	  kok_x_original(i) = 0;
       }
+*/
       run_experiment<myExecSpace, crsMat_t>(crsmat, kok_x_original, block_size);
 
       //run_experiment<myExecSpace, crsMat_t>(crsmat, kok_x_original);

--- a/perf_test/sparse/KokkosSparse_block_pcg.cpp
+++ b/perf_test/sparse/KokkosSparse_block_pcg.cpp
@@ -153,7 +153,7 @@ void run_point_experiment(
 	      << std::endl ;
 
 
-#if 0
+#if PRINTDEBUG
 	  kok_x_vector = scalar_view_t("kok_x_vector", nv);
 
 	  kh.create_gs_handle(KokkosSparse::GS_TEAM);
@@ -289,7 +289,7 @@ void run_experiment(
 		  pf_rm, pf_e, pf_v);
 
 
-#if 0
+#if PRINTDEBUG
   std::cout << "nr:" << crsmat.numRows() << " nc:" << crsmat.numCols() << std::endl;
 
   KokkosKernels::Impl::print_1Dview(crsmat.graph.row_map);
@@ -318,8 +318,7 @@ void run_experiment(
 		  but_r, but_c,
 		  bf_rm, bf_e, bf_v);
 
-  //std::cout << "bnr:" << but_r << " bc:" << but_c<< std::endl;
-#if 0
+#if PRINTDEBUG
   KokkosKernels::Impl::print_1Dview(bf_rm);
   KokkosKernels::Impl::print_1Dview(bf_e);
   KokkosKernels::Impl::print_1Dview(bf_v);
@@ -328,155 +327,6 @@ void run_experiment(
   crsMat_t crsmat3("CrsMatrix3", but_c, bf_v, static_graph3);
   run_block_experiment<ExecSpace, crsMat_t>(crsmat2, crsmat3, block_size, kok_x_original);
 
-  /*
-  INDEX_TYPE nv = crsmat.numRows();
-  scalar_view_t kok_x_original = create_x_vector<scalar_view_t>(nv, MAXVAL);
-
-  KokkosKernels::Impl::print_1Dview(kok_x_original);
-  scalar_view_t kok_b_vector = create_y_vector(crsmat, kok_x_original);
-
-  //create X vector
-  scalar_view_t kok_x_vector("kok_x_vector", nv);
-
-
-  double solve_time = 0;
-  const unsigned cg_iteration_limit = 100000;
-  const double   cg_iteration_tolerance     = 1e-7 ;
-
-  KokkosKernels::Experimental::Example::CGSolveResult cg_result ;
-
-
-
-
-  typedef KokkosKernels::Experimental::KokkosKernelsHandle
-        < size_type,
-		  lno_t,
-		  scalar_t,
-          ExecSpace, ExecSpace, ExecSpace > KernelHandle;
-
-  KernelHandle kh;
-
-
-  kh.create_gs_handle();
-  Kokkos::Impl::Timer timer1;
-  KokkosKernels::Experimental::Example::pcgsolve(
-        kh
-      , crsmat
-      , kok_b_vector
-      , kok_x_vector
-      , cg_iteration_limit
-      , cg_iteration_tolerance
-      , & cg_result
-      , true
-  );
-  Kokkos::fence();
-
-  solve_time = timer1.seconds();
-
-
-  std::cout  << "DEFAULT SOLVE:"
-      << "\n\t(P)CG_NUM_ITER              [" << cg_result.iteration << "]"
-      << "\n\tMATVEC_TIME                 [" << cg_result.matvec_time << "]"
-      << "\n\tCG_RESIDUAL                 [" << cg_result.norm_res << "]"
-      << "\n\tCG_ITERATION_TIME           [" << cg_result.iter_time << "]"
-      << "\n\tPRECONDITIONER_TIME         [" << cg_result.precond_time << "]"
-      << "\n\tPRECONDITIONER_INIT_TIME    [" << cg_result.precond_init_time << "]"
-      << "\n\tPRECOND_APPLY_TIME_PER_ITER [" << cg_result.precond_time / (cg_result.iteration  + 1) << "]"
-      << "\n\tSOLVE_TIME                  [" << solve_time<< "]"
-      << std::endl ;
- */
-
-
-
-  /*
-  kh.destroy_gs_handle();
-  kh.create_gs_handle(KokkosKernels::Experimental::Graph::GS_PERMUTED);
-
-  kok_x_vector = scalar_view_t("kok_x_vector", nv);
-  timer1.reset();
-  KokkosKernels::Experimental::Example::pcgsolve(
-        kh
-      , crsmat
-      , kok_b_vector
-      , kok_x_vector
-      , cg_iteration_limit
-      , cg_iteration_tolerance
-      , & cg_result
-      , true
-  );
-
-  Kokkos::fence();
-  solve_time = timer1.seconds();
-  std::cout  << "\nPERMUTED SGS SOLVE:"
-      << "\n\t(P)CG_NUM_ITER              [" << cg_result.iteration << "]"
-      << "\n\tMATVEC_TIME                 [" << cg_result.matvec_time << "]"
-      << "\n\tCG_RESIDUAL                 [" << cg_result.norm_res << "]"
-      << "\n\tCG_ITERATION_TIME           [" << cg_result.iter_time << "]"
-      << "\n\tPRECONDITIONER_TIME         [" << cg_result.precond_time << "]"
-      << "\n\tPRECONDITIONER_INIT_TIME    [" << cg_result.precond_init_time << "]"
-      << "\n\tPRECOND_APPLY_TIME_PER_ITER [" << cg_result.precond_time / (cg_result.iteration  + 1) << "]"
-      << "\n\tSOLVE_TIME                  [" << solve_time<< "]"
-      << std::endl ;
-
-
-  kh.destroy_gs_handle();
-  kh.create_gs_handle(KokkosKernels::Experimental::Graph::GS_TEAM);
-
-  kok_x_vector = scalar_view_t("kok_x_vector", nv);
-  timer1.reset();
-  KokkosKernels::Experimental::Example::pcgsolve(
-        kh
-      , crsmat
-      , kok_b_vector
-      , kok_x_vector
-      , cg_iteration_limit
-      , cg_iteration_tolerance
-      , & cg_result
-      , true
-  );
-  Kokkos::fence();
-
-  solve_time = timer1.seconds();
-  std::cout  << "\nTEAM SGS SOLVE:"
-      << "\n\t(P)CG_NUM_ITER              [" << cg_result.iteration << "]"
-      << "\n\tMATVEC_TIME                 [" << cg_result.matvec_time << "]"
-      << "\n\tCG_RESIDUAL                 [" << cg_result.norm_res << "]"
-      << "\n\tCG_ITERATION_TIME           [" << cg_result.iter_time << "]"
-      << "\n\tPRECONDITIONER_TIME         [" << cg_result.precond_time << "]"
-      << "\n\tPRECONDITIONER_INIT_TIME    [" << cg_result.precond_init_time << "]"
-      << "\n\tPRECOND_APPLY_TIME_PER_ITER [" << cg_result.precond_time / (cg_result.iteration  + 1) << "]"
-      << "\n\tSOLVE_TIME                  [" << solve_time<< "]"
-      << std::endl ;
-
-
-
-
-  kok_x_vector = scalar_view_t("kok_x_vector", nv);
-  timer1.reset();
-  KokkosKernels::Experimental::Example::pcgsolve(
-        kh
-      , crsmat
-      , kok_b_vector
-      , kok_x_vector
-      , cg_iteration_limit
-      , cg_iteration_tolerance
-      , & cg_result
-      , false
-  );
-  Kokkos::fence();
-
-  solve_time = timer1.seconds();
-  std::cout  << "\nCG SOLVE (With no Preconditioner):"
-      << "\n\t(P)CG_NUM_ITER              [" << cg_result.iteration << "]"
-      << "\n\tMATVEC_TIME                 [" << cg_result.matvec_time << "]"
-      << "\n\tCG_RESIDUAL                 [" << cg_result.norm_res << "]"
-      << "\n\tCG_ITERATION_TIME           [" << cg_result.iter_time << "]"
-      << "\n\tPRECONDITIONER_TIME         [" << cg_result.precond_time << "]"
-      << "\n\tPRECONDITIONER_INIT_TIME    [" << cg_result.precond_init_time << "]"
-      << "\n\tPRECOND_APPLY_TIME_PER_ITER [" << cg_result.precond_time / (cg_result.iteration  + 1) << "]"
-      << "\n\tSOLVE_TIME                  [" << solve_time<< "]"
-      << std::endl ;
-  */
 }
 
 
@@ -711,21 +561,13 @@ int main (int argc, char ** argv){
       graph_t static_graph (columns_view, rowmap_view);
       crsMat_t crsmat("CrsMatrix", nv, values_view, static_graph);
 
-//      typedef typename KokkosSparse::CrsMatrix<SCALAR_TYPE, INDEX_TYPE, Kokkos::Cuda> crsMat_t;
-//      crsMat_t crsmat("CrsMatrix", nv, nv, ne, ew, xadj, adj);
       delete [] xadj;
       delete [] adj;
       delete [] ew;
 
       values_view_t kok_x_original = create_x_vector<values_view_t>(((nv /block_size) + 1) * block_size, MAXVAL);
-/*
-      for (INDEX_TYPE i = nv; i < ((nv /block_size) + 1) * block_size; ++i){
-    	  kok_x_original(i) = 0;
-      }
-*/
       run_experiment<myExecSpace, crsMat_t>(crsmat, kok_x_original, block_size);
 
-      //run_experiment<myExecSpace, crsMat_t>(crsmat, kok_x_original);
 
       myExecSpace::finalize();
       Kokkos::HostSpace::execution_space::finalize();
@@ -737,7 +579,9 @@ int main (int argc, char ** argv){
 
   return 0;
 }
-#else
+#else //defined(KOKKOSKERNELS_INST_DOUBLE) &&  defined(KOKKOSKERNELS_INST_OFFSET_INT) &&     defined(KOKKOSKERNELS_INST_ORDINAL_INT)
+
 int main() {
+  std::cerr << "PCG is configured with INT, INT, DOUBLE. Test is not compiled as these are not instantiated." << std::endl; 
 }
 #endif

--- a/perf_test/sparse/KokkosSparse_block_pcg.cpp
+++ b/perf_test/sparse/KokkosSparse_block_pcg.cpp
@@ -1,0 +1,742 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//               KokkosKernels 0.9: Linear Algebra and Graph Kernels
+//                 Copyright 2017 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <KokkosKernels_config.h>
+#if defined(KOKKOSKERNELS_INST_DOUBLE) &&  \
+    defined(KOKKOSKERNELS_INST_OFFSET_INT) && \
+    defined(KOKKOSKERNELS_INST_ORDINAL_INT)
+#include "KokkosSparse_pcg.hpp"
+
+#include "KokkosKernels_Utils.hpp"
+#include <iostream>
+#include "KokkosKernels_IOUtils.hpp"
+
+#define MAXVAL 1
+
+#define SIZE_TYPE int
+#define INDEX_TYPE int
+#define SCALAR_TYPE double
+unsigned cg_iteration_limit = 10;
+
+
+
+template<typename scalar_view_t>
+scalar_view_t create_x_vector(INDEX_TYPE nv, SCALAR_TYPE max_value = 1.0){
+  scalar_view_t kok_x ("X", nv);
+
+  typename scalar_view_t::HostMirror h_x =  Kokkos::create_mirror_view (kok_x);
+
+
+  for (INDEX_TYPE i = 0; i < nv; ++i){
+    SCALAR_TYPE r = static_cast <SCALAR_TYPE> (rand()) / static_cast <SCALAR_TYPE> (RAND_MAX / max_value);
+    h_x(i) = r;
+  }
+  Kokkos::deep_copy (kok_x, h_x);
+  return kok_x;
+}
+
+
+
+template <typename crsMat_t, typename vector_t>
+vector_t create_y_vector(crsMat_t crsMat, vector_t x_vector){
+  vector_t y_vector ("Y VECTOR", crsMat.numRows());
+  KokkosSparse::spmv("N", 1, crsMat, x_vector, 1, y_vector);
+  return y_vector;
+}
+
+template <typename ExecSpace, typename crsMat_t>
+void run_point_experiment(
+    crsMat_t crsmat,
+	typename  crsMat_t::values_type::non_const_type kok_x_original){
+
+
+	  //typedef typename crsMat_t::StaticCrsGraphType graph_t;
+	  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
+	  typedef typename crsMat_t::StaticCrsGraphType::row_map_type::non_const_type lno_view_t;
+	  typedef typename crsMat_t::StaticCrsGraphType::entries_type::non_const_type lno_nnz_view_t;
+
+	  typedef typename lno_nnz_view_t::value_type lno_t;
+	  typedef typename lno_view_t::value_type size_type;
+	  typedef typename scalar_view_t::value_type scalar_t;
+	  INDEX_TYPE nv = crsmat.numRows();
+	  //scalar_view_t kok_x_original = create_x_vector<scalar_view_t>(nv, MAXVAL);
+
+	  //KokkosKernels::Impl::print_1Dview(kok_x_original);
+	  scalar_view_t kok_b_vector = create_y_vector(crsmat, kok_x_original);
+
+	  //create X vector
+	  scalar_view_t kok_x_vector("kok_x_vector", nv);
+
+
+	  double solve_time = 0;
+	  const double   cg_iteration_tolerance     = 1e-7 ;
+
+	  KokkosKernels::Experimental::Example::CGSolveResult cg_result ;
+
+
+
+
+	  typedef KokkosKernels::Experimental::KokkosKernelsHandle
+	        < size_type,
+			  lno_t,
+			  scalar_t,
+	          ExecSpace, ExecSpace, ExecSpace > KernelHandle;
+
+	  KernelHandle kh;
+
+
+	  kh.create_gs_handle(/*KokkosSparse::GS_TEAM*/);
+	  Kokkos::Impl::Timer timer1;
+	  KokkosKernels::Experimental::Example::pcgsolve(
+	        kh
+	      , crsmat
+	      , kok_b_vector
+	      , kok_x_vector
+	      , cg_iteration_limit
+	      , cg_iteration_tolerance
+	      , & cg_result
+	      , true
+	  );
+	  Kokkos::fence();
+
+	  solve_time = timer1.seconds();
+
+
+	  std::cout  << "DEFAULT SOLVE:"
+	      << "\n\t(P)CG_NUM_ITER              [" << cg_result.iteration << "]"
+	      << "\n\tMATVEC_TIME                 [" << cg_result.matvec_time << "]"
+	      << "\n\tCG_RESIDUAL                 [" << cg_result.norm_res << "]"
+	      << "\n\tCG_ITERATION_TIME           [" << cg_result.iter_time << "]"
+	      << "\n\tPRECONDITIONER_TIME         [" << cg_result.precond_time << "]"
+	      << "\n\tPRECONDITIONER_INIT_TIME    [" << cg_result.precond_init_time << "]"
+	      << "\n\tPRECOND_APPLY_TIME_PER_ITER [" << cg_result.precond_time / (cg_result.iteration  + 1) << "]"
+	      << "\n\tSOLVE_TIME                  [" << solve_time<< "]"
+	      << std::endl ;
+
+
+#if 0
+	  kok_x_vector = scalar_view_t("kok_x_vector", nv);
+
+	  kh.create_gs_handle(KokkosSparse::GS_TEAM);
+	  timer1.reset();
+	  KokkosKernels::Experimental::Example::pcgsolve(
+	        kh
+	      , crsmat
+	      , kok_b_vector
+	      , kok_x_vector
+	      , cg_iteration_limit
+	      , cg_iteration_tolerance
+	      , & cg_result
+	      , true
+	  );
+	  Kokkos::fence();
+
+	  solve_time = timer1.seconds();
+
+
+
+	  std::cout  << "TEAM SOLVE:"
+	      << "\n\t(P)CG_NUM_ITER              [" << cg_result.iteration << "]"
+	      << "\n\tMATVEC_TIME                 [" << cg_result.matvec_time << "]"
+	      << "\n\tCG_RESIDUAL                 [" << cg_result.norm_res << "]"
+	      << "\n\tCG_ITERATION_TIME           [" << cg_result.iter_time << "]"
+	      << "\n\tPRECONDITIONER_TIME         [" << cg_result.precond_time << "]"
+	      << "\n\tPRECONDITIONER_INIT_TIME    [" << cg_result.precond_init_time << "]"
+	      << "\n\tPRECOND_APPLY_TIME_PER_ITER [" << cg_result.precond_time / (cg_result.iteration  + 1) << "]"
+	      << "\n\tSOLVE_TIME                  [" << solve_time<< "]"
+	      << std::endl ;
+#endif
+}
+
+
+template <typename ExecSpace, typename crsMat_t>
+void run_block_experiment(
+    crsMat_t point_crsmat,
+	crsMat_t block_crsmat, int block_size,
+	typename crsMat_t::values_type::non_const_type kok_x_original){
+
+
+	  //typedef typename crsMat_t::StaticCrsGraphType graph_t;
+	  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
+	  typedef typename crsMat_t::StaticCrsGraphType::row_map_type::non_const_type lno_view_t;
+	  typedef typename crsMat_t::StaticCrsGraphType::entries_type::non_const_type lno_nnz_view_t;
+
+	  typedef typename lno_nnz_view_t::value_type lno_t;
+	  typedef typename lno_view_t::value_type size_type;
+	  typedef typename scalar_view_t::value_type scalar_t;
+	  INDEX_TYPE nv = point_crsmat.numRows();
+	  //scalar_view_t kok_x_original = create_x_vector<scalar_view_t>(nv, MAXVAL);
+
+	  //KokkosKernels::Impl::print_1Dview(kok_x_original);
+	  scalar_view_t kok_b_vector = create_y_vector(point_crsmat, kok_x_original);
+
+	  //create X vector
+	  scalar_view_t kok_x_vector("kok_x_vector", nv);
+
+
+	  double solve_time = 0;
+	  //const unsigned cg_iteration_limit = 10;
+	  const double   cg_iteration_tolerance     = 1e-7 ;
+
+	  KokkosKernels::Experimental::Example::CGSolveResult cg_result ;
+
+
+
+
+	  typedef KokkosKernels::Experimental::KokkosKernelsHandle
+	        < size_type,
+			  lno_t,
+			  scalar_t,
+	          ExecSpace, ExecSpace, ExecSpace > KernelHandle;
+
+	  KernelHandle kh;
+
+
+	  kh.create_gs_handle();
+	  Kokkos::Impl::Timer timer1;
+	  KokkosKernels::Experimental::Example::block_pcgsolve(
+	        kh
+	      , point_crsmat
+		  , block_crsmat, block_size
+	      , kok_b_vector
+	      , kok_x_vector
+	      , cg_iteration_limit
+	      , cg_iteration_tolerance
+	      , & cg_result
+	      , true
+	  );
+	  Kokkos::fence();
+
+	  solve_time = timer1.seconds();
+
+
+	  std::cout  << "DEFAULT SOLVE:"
+	      << "\n\t(P)CG_NUM_ITER              [" << cg_result.iteration << "]"
+	      << "\n\tMATVEC_TIME                 [" << cg_result.matvec_time << "]"
+	      << "\n\tCG_RESIDUAL                 [" << cg_result.norm_res << "]"
+	      << "\n\tCG_ITERATION_TIME           [" << cg_result.iter_time << "]"
+	      << "\n\tPRECONDITIONER_TIME         [" << cg_result.precond_time << "]"
+	      << "\n\tPRECONDITIONER_INIT_TIME    [" << cg_result.precond_init_time << "]"
+	      << "\n\tPRECOND_APPLY_TIME_PER_ITER [" << cg_result.precond_time / (cg_result.iteration  + 1) << "]"
+	      << "\n\tSOLVE_TIME                  [" << solve_time<< "]"
+	      << std::endl ;
+}
+
+
+template <typename ExecSpace, typename crsMat_t>
+void run_experiment(
+    crsMat_t crsmat,
+	typename  crsMat_t::values_type::non_const_type kok_x_original, int block_size = 5 ){
+
+	//run_point_experiment<ExecSpace, crsMat_t>(crsmat, kok_x_original);
+
+  typedef typename crsMat_t::StaticCrsGraphType graph_t;
+  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
+  typedef typename crsMat_t::StaticCrsGraphType::row_map_type::non_const_type lno_view_t;
+  typedef typename crsMat_t::StaticCrsGraphType::entries_type::non_const_type lno_nnz_view_t;
+
+  lno_view_t pf_rm;
+  lno_nnz_view_t pf_e;
+  scalar_view_t pf_v;
+  size_t out_r, out_c;
+
+  //typedef typename lno_nnz_view_t::value_type lno_t;
+  //typedef typename lno_view_t::value_type size_type;
+  //typedef typename scalar_view_t::value_type scalar_t;
+  KokkosKernels::Impl::kk_create_blockcrs_formated_point_crsmatrix(
+		  block_size , crsmat.numRows(), crsmat.numCols(),
+		  crsmat.graph.row_map, crsmat.graph.entries, crsmat.values,
+		  out_r, out_c,
+		  pf_rm, pf_e, pf_v);
+
+
+#if 0
+  std::cout << "nr:" << crsmat.numRows() << " nc:" << crsmat.numCols() << std::endl;
+
+  KokkosKernels::Impl::print_1Dview(crsmat.graph.row_map);
+  KokkosKernels::Impl::print_1Dview(crsmat.graph.entries);
+  KokkosKernels::Impl::print_1Dview(crsmat.values);
+  std::cout << "onr:" << out_r << " oc:" << out_c<< std::endl;
+
+  KokkosKernels::Impl::print_1Dview(pf_rm);
+  KokkosKernels::Impl::print_1Dview(pf_e);
+  KokkosKernels::Impl::print_1Dview(pf_v);
+#endif
+
+  graph_t static_graph2 (pf_e, pf_rm);
+  crsMat_t crsmat2("CrsMatrix2", out_c, pf_v, static_graph2);
+  run_point_experiment<ExecSpace, crsMat_t>(crsmat2, kok_x_original);
+
+
+  lno_view_t bf_rm;
+  lno_nnz_view_t bf_e;
+  scalar_view_t bf_v;
+  size_t but_r, but_c;
+
+  KokkosKernels::Impl::kk_create_blockcrs_from_blockcrs_formatted_point_crs(
+		  block_size , out_r, out_c,
+		  pf_rm, pf_e, pf_v,
+		  but_r, but_c,
+		  bf_rm, bf_e, bf_v);
+
+  //std::cout << "bnr:" << but_r << " bc:" << but_c<< std::endl;
+#if 0
+  KokkosKernels::Impl::print_1Dview(bf_rm);
+  KokkosKernels::Impl::print_1Dview(bf_e);
+  KokkosKernels::Impl::print_1Dview(bf_v);
+#endif
+  graph_t static_graph3 (bf_e, bf_rm);
+  crsMat_t crsmat3("CrsMatrix3", but_c, bf_v, static_graph3);
+  run_block_experiment<ExecSpace, crsMat_t>(crsmat2, crsmat3, block_size, kok_x_original);
+
+  /*
+  INDEX_TYPE nv = crsmat.numRows();
+  scalar_view_t kok_x_original = create_x_vector<scalar_view_t>(nv, MAXVAL);
+
+  KokkosKernels::Impl::print_1Dview(kok_x_original);
+  scalar_view_t kok_b_vector = create_y_vector(crsmat, kok_x_original);
+
+  //create X vector
+  scalar_view_t kok_x_vector("kok_x_vector", nv);
+
+
+  double solve_time = 0;
+  const unsigned cg_iteration_limit = 100000;
+  const double   cg_iteration_tolerance     = 1e-7 ;
+
+  KokkosKernels::Experimental::Example::CGSolveResult cg_result ;
+
+
+
+
+  typedef KokkosKernels::Experimental::KokkosKernelsHandle
+        < size_type,
+		  lno_t,
+		  scalar_t,
+          ExecSpace, ExecSpace, ExecSpace > KernelHandle;
+
+  KernelHandle kh;
+
+
+  kh.create_gs_handle();
+  Kokkos::Impl::Timer timer1;
+  KokkosKernels::Experimental::Example::pcgsolve(
+        kh
+      , crsmat
+      , kok_b_vector
+      , kok_x_vector
+      , cg_iteration_limit
+      , cg_iteration_tolerance
+      , & cg_result
+      , true
+  );
+  Kokkos::fence();
+
+  solve_time = timer1.seconds();
+
+
+  std::cout  << "DEFAULT SOLVE:"
+      << "\n\t(P)CG_NUM_ITER              [" << cg_result.iteration << "]"
+      << "\n\tMATVEC_TIME                 [" << cg_result.matvec_time << "]"
+      << "\n\tCG_RESIDUAL                 [" << cg_result.norm_res << "]"
+      << "\n\tCG_ITERATION_TIME           [" << cg_result.iter_time << "]"
+      << "\n\tPRECONDITIONER_TIME         [" << cg_result.precond_time << "]"
+      << "\n\tPRECONDITIONER_INIT_TIME    [" << cg_result.precond_init_time << "]"
+      << "\n\tPRECOND_APPLY_TIME_PER_ITER [" << cg_result.precond_time / (cg_result.iteration  + 1) << "]"
+      << "\n\tSOLVE_TIME                  [" << solve_time<< "]"
+      << std::endl ;
+ */
+
+
+
+  /*
+  kh.destroy_gs_handle();
+  kh.create_gs_handle(KokkosKernels::Experimental::Graph::GS_PERMUTED);
+
+  kok_x_vector = scalar_view_t("kok_x_vector", nv);
+  timer1.reset();
+  KokkosKernels::Experimental::Example::pcgsolve(
+        kh
+      , crsmat
+      , kok_b_vector
+      , kok_x_vector
+      , cg_iteration_limit
+      , cg_iteration_tolerance
+      , & cg_result
+      , true
+  );
+
+  Kokkos::fence();
+  solve_time = timer1.seconds();
+  std::cout  << "\nPERMUTED SGS SOLVE:"
+      << "\n\t(P)CG_NUM_ITER              [" << cg_result.iteration << "]"
+      << "\n\tMATVEC_TIME                 [" << cg_result.matvec_time << "]"
+      << "\n\tCG_RESIDUAL                 [" << cg_result.norm_res << "]"
+      << "\n\tCG_ITERATION_TIME           [" << cg_result.iter_time << "]"
+      << "\n\tPRECONDITIONER_TIME         [" << cg_result.precond_time << "]"
+      << "\n\tPRECONDITIONER_INIT_TIME    [" << cg_result.precond_init_time << "]"
+      << "\n\tPRECOND_APPLY_TIME_PER_ITER [" << cg_result.precond_time / (cg_result.iteration  + 1) << "]"
+      << "\n\tSOLVE_TIME                  [" << solve_time<< "]"
+      << std::endl ;
+
+
+  kh.destroy_gs_handle();
+  kh.create_gs_handle(KokkosKernels::Experimental::Graph::GS_TEAM);
+
+  kok_x_vector = scalar_view_t("kok_x_vector", nv);
+  timer1.reset();
+  KokkosKernels::Experimental::Example::pcgsolve(
+        kh
+      , crsmat
+      , kok_b_vector
+      , kok_x_vector
+      , cg_iteration_limit
+      , cg_iteration_tolerance
+      , & cg_result
+      , true
+  );
+  Kokkos::fence();
+
+  solve_time = timer1.seconds();
+  std::cout  << "\nTEAM SGS SOLVE:"
+      << "\n\t(P)CG_NUM_ITER              [" << cg_result.iteration << "]"
+      << "\n\tMATVEC_TIME                 [" << cg_result.matvec_time << "]"
+      << "\n\tCG_RESIDUAL                 [" << cg_result.norm_res << "]"
+      << "\n\tCG_ITERATION_TIME           [" << cg_result.iter_time << "]"
+      << "\n\tPRECONDITIONER_TIME         [" << cg_result.precond_time << "]"
+      << "\n\tPRECONDITIONER_INIT_TIME    [" << cg_result.precond_init_time << "]"
+      << "\n\tPRECOND_APPLY_TIME_PER_ITER [" << cg_result.precond_time / (cg_result.iteration  + 1) << "]"
+      << "\n\tSOLVE_TIME                  [" << solve_time<< "]"
+      << std::endl ;
+
+
+
+
+  kok_x_vector = scalar_view_t("kok_x_vector", nv);
+  timer1.reset();
+  KokkosKernels::Experimental::Example::pcgsolve(
+        kh
+      , crsmat
+      , kok_b_vector
+      , kok_x_vector
+      , cg_iteration_limit
+      , cg_iteration_tolerance
+      , & cg_result
+      , false
+  );
+  Kokkos::fence();
+
+  solve_time = timer1.seconds();
+  std::cout  << "\nCG SOLVE (With no Preconditioner):"
+      << "\n\t(P)CG_NUM_ITER              [" << cg_result.iteration << "]"
+      << "\n\tMATVEC_TIME                 [" << cg_result.matvec_time << "]"
+      << "\n\tCG_RESIDUAL                 [" << cg_result.norm_res << "]"
+      << "\n\tCG_ITERATION_TIME           [" << cg_result.iter_time << "]"
+      << "\n\tPRECONDITIONER_TIME         [" << cg_result.precond_time << "]"
+      << "\n\tPRECONDITIONER_INIT_TIME    [" << cg_result.precond_init_time << "]"
+      << "\n\tPRECOND_APPLY_TIME_PER_ITER [" << cg_result.precond_time / (cg_result.iteration  + 1) << "]"
+      << "\n\tSOLVE_TIME                  [" << solve_time<< "]"
+      << std::endl ;
+  */
+}
+
+
+
+
+enum { CMD_USE_THREADS = 0
+     , CMD_USE_NUMA
+     , CMD_USE_CORE_PER_NUMA
+     , CMD_USE_CUDA
+     , CMD_USE_OPENMP
+     , CMD_USE_CUDA_DEV
+     , CMD_BIN_MTX
+     , CMD_ERROR
+     , CMD_COUNT };
+
+int main (int argc, char ** argv){
+
+
+  int cmdline[ CMD_COUNT ] ;
+  char *mtx_bin_file = NULL;
+  int block_size = 5;
+  for ( int i = 0 ; i < CMD_COUNT ; ++i ) cmdline[i] = 0 ;
+
+
+  for ( int i = 1 ; i < argc ; ++i ) {
+    if ( 0 == strcasecmp( argv[i] , "--threads" ) ) {
+      cmdline[ CMD_USE_THREADS ] = atoi( argv[++i] );
+    }
+    else if ( 0 == strcasecmp( argv[i] , "--openmp" ) ) {
+      cmdline[ CMD_USE_OPENMP ] = atoi( argv[++i] );
+    }
+    else if ( 0 == strcasecmp( argv[i] , "--cores" ) ) {
+      sscanf( argv[++i] , "%dx%d" ,
+              cmdline + CMD_USE_NUMA ,
+              cmdline + CMD_USE_CORE_PER_NUMA );
+    }
+    else if ( 0 == strcasecmp( argv[i] , "--cuda" ) ) {
+      cmdline[ CMD_USE_CUDA ] = 1 ;
+    }
+    else if ( 0 == strcasecmp( argv[i] , "--cuda-dev" ) ) {
+      cmdline[ CMD_USE_CUDA ] = 1 ;
+      cmdline[ CMD_USE_CUDA_DEV ] = atoi( argv[++i] ) ;
+    }
+
+    else if ( 0 == strcasecmp( argv[i] , "--mtx" ) ) {
+      mtx_bin_file = argv[++i];
+    }
+
+    else if ( 0 == strcasecmp( argv[i] , "--block_size" ) ) {
+    	block_size = atoi( argv[++i] );
+    }
+
+    else if ( 0 == strcasecmp( argv[i] , "--iteration" ) ) {
+    	cg_iteration_limit = atoi( argv[++i] );
+    }
+    else {
+      cmdline[ CMD_ERROR ] = 1 ;
+      std::cerr << "Unrecognized command line argument #" << i << ": " << argv[i] << std::endl ;
+      std::cerr << "OPTIONS\n\t--threads [numThreads]\n\t--openmp [numThreads]\n\t--cuda\n\t--cuda-dev[DeviceIndex]\n\t--mtx[binary_mtx_file]" << std::endl;
+
+      return 0;
+    }
+  }
+
+  if (mtx_bin_file == NULL){
+    std::cerr << "Provide a mtx binary file" << std::endl ;
+    std::cerr << "OPTIONS\n\t--threads [numThreads]\n\t--openmp [numThreads]\n\t--cuda\n\t--cuda-dev[DeviceIndex]\n\t--mtx[binary_mtx_file]" << std::endl;
+
+    return 0;
+  }
+
+
+
+
+
+
+#if defined( KOKKOS_HAVE_PTHREAD )
+
+    if ( cmdline[ CMD_USE_THREADS ] ) {
+      INDEX_TYPE nv = 0, ne = 0;
+      INDEX_TYPE *xadj, *adj;
+      SCALAR_TYPE *ew;
+
+
+      if ( cmdline[ CMD_USE_NUMA ] && cmdline[ CMD_USE_CORE_PER_NUMA ] ) {
+        Kokkos::Threads::initialize( cmdline[ CMD_USE_THREADS ] ,
+                                     cmdline[ CMD_USE_NUMA ] ,
+                                     cmdline[ CMD_USE_CORE_PER_NUMA ] );
+      }
+      else {
+        Kokkos::Threads::initialize( cmdline[ CMD_USE_THREADS ] );
+      }
+
+      KokkosKernels::Impl::read_matrix<INDEX_TYPE,INDEX_TYPE, SCALAR_TYPE> (&nv, &ne, &xadj, &adj, &ew, mtx_bin_file);
+      Kokkos::Threads::print_configuration(std::cout);
+
+      typedef Kokkos::Threads myExecSpace;
+      typedef typename KokkosSparse::CrsMatrix<SCALAR_TYPE, INDEX_TYPE, myExecSpace, void, SIZE_TYPE > crsMat_t;
+
+      typedef typename crsMat_t::StaticCrsGraphType graph_t;
+      typedef typename graph_t::row_map_type::non_const_type row_map_view_t;
+      typedef typename graph_t::entries_type::non_const_type   cols_view_t;
+      typedef typename crsMat_t::values_type::non_const_type values_view_t;
+
+      row_map_view_t rowmap_view("rowmap_view", nv+1);
+      cols_view_t columns_view("colsmap_view", ne);
+      values_view_t values_view("values_view", ne);
+
+      KokkosKernels::Impl::copy_vector<SCALAR_TYPE * , values_view_t, myExecSpace>(ne, ew, values_view);
+      KokkosKernels::Impl::copy_vector<INDEX_TYPE * , cols_view_t, myExecSpace>(ne, adj, columns_view);
+      KokkosKernels::Impl::copy_vector<INDEX_TYPE * , row_map_view_t, myExecSpace>(nv+1, xadj, rowmap_view);
+
+      graph_t static_graph (columns_view, rowmap_view);
+      crsMat_t crsmat("CrsMatrix", nv, values_view, static_graph);
+      delete [] xadj;
+      delete [] adj;
+      delete [] ew;
+
+      values_view_t kok_x_original = create_x_vector<values_view_t>(((nv /block_size) + 1) * block_size, MAXVAL);
+      for (INDEX_TYPE i = nv; i < ((nv /block_size) + 1) * block_size; ++i){
+    	  kok_x_original(i) = 0;
+      }
+      run_experiment<myExecSpace, crsMat_t>(crsmat, kok_x_original, block_size);
+
+      myExecSpace::finalize();
+    }
+
+#endif
+
+#if defined( KOKKOS_HAVE_OPENMP )
+
+    if ( cmdline[ CMD_USE_OPENMP ] ) {
+      INDEX_TYPE nv = 0, ne = 0;
+      INDEX_TYPE *xadj, *adj;
+      SCALAR_TYPE *ew;
+
+
+      if ( cmdline[ CMD_USE_NUMA ] && cmdline[ CMD_USE_CORE_PER_NUMA ] ) {
+        Kokkos::OpenMP::initialize( cmdline[ CMD_USE_OPENMP ] ,
+                                     cmdline[ CMD_USE_NUMA ] ,
+                                     cmdline[ CMD_USE_CORE_PER_NUMA ] );
+      }
+      else {
+        Kokkos::OpenMP::initialize( cmdline[ CMD_USE_OPENMP ] );
+      }
+      Kokkos::OpenMP::print_configuration(std::cout);
+
+      KokkosKernels::Impl::read_matrix<INDEX_TYPE,INDEX_TYPE, SCALAR_TYPE> (&nv, &ne, &xadj, &adj, &ew, mtx_bin_file);
+
+
+      typedef Kokkos::OpenMP myExecSpace;
+      typedef typename KokkosSparse::CrsMatrix<SCALAR_TYPE, INDEX_TYPE, myExecSpace, void, SIZE_TYPE > crsMat_t;
+
+      typedef typename crsMat_t::StaticCrsGraphType graph_t;
+      typedef typename crsMat_t::row_map_type::non_const_type row_map_view_t;
+      typedef typename crsMat_t::index_type::non_const_type   cols_view_t;
+      typedef typename crsMat_t::values_type::non_const_type values_view_t;
+
+      row_map_view_t rowmap_view("rowmap_view", nv+1);
+      cols_view_t columns_view("colsmap_view", ne);
+      values_view_t values_view("values_view", ne);
+
+      KokkosKernels::Impl::copy_vector<SCALAR_TYPE * , values_view_t, myExecSpace>(ne, ew, values_view);
+      KokkosKernels::Impl::copy_vector<INDEX_TYPE * , cols_view_t, myExecSpace>(ne, adj, columns_view);
+      KokkosKernels::Impl::copy_vector<INDEX_TYPE * , row_map_view_t, myExecSpace>(nv+1, xadj, rowmap_view);
+
+      graph_t static_graph (columns_view, rowmap_view);
+      crsMat_t crsmat("CrsMatrix", nv, values_view, static_graph);
+
+      //crsMat_t crsmat("CrsMatrix", nv, nv, ne, ew, xadj, adj);
+      delete [] xadj;
+      delete [] adj;
+      delete [] ew;
+
+
+      values_view_t kok_x_original = create_x_vector<values_view_t>(((nv /block_size) + 1) * block_size, MAXVAL);
+      for (INDEX_TYPE i = nv; i < ((nv /block_size) + 1) * block_size; ++i){
+    	  kok_x_original(i) = 0;
+      }
+      run_experiment<myExecSpace, crsMat_t>(crsmat, kok_x_original, block_size);
+
+      myExecSpace::finalize();
+    }
+
+#endif
+
+#if defined( KOKKOS_ENABLE_CUDA )
+    if ( cmdline[ CMD_USE_CUDA ] ) {
+      // Use the last device:
+      INDEX_TYPE nv = 0, ne = 0;
+      INDEX_TYPE *xadj, *adj;
+      SCALAR_TYPE *ew;
+      Kokkos::HostSpace::execution_space::initialize();
+      Kokkos::Cuda::initialize( Kokkos::Cuda::SelectDevice( cmdline[ CMD_USE_CUDA_DEV ] ) );
+      Kokkos::Cuda::print_configuration(std::cout);
+
+      KokkosKernels::Impl::read_matrix<INDEX_TYPE,INDEX_TYPE, SCALAR_TYPE> (&nv, &ne, &xadj, &adj, &ew, mtx_bin_file);
+
+
+      typedef Kokkos::Cuda myExecSpace;
+      typedef typename KokkosSparse::CrsMatrix<SCALAR_TYPE, INDEX_TYPE, myExecSpace, void, SIZE_TYPE > crsMat_t;
+
+      typedef typename crsMat_t::StaticCrsGraphType graph_t;
+      typedef typename crsMat_t::row_map_type::non_const_type row_map_view_t;
+      typedef typename crsMat_t::index_type::non_const_type   cols_view_t;
+      typedef typename crsMat_t::values_type::non_const_type values_view_t;
+
+      row_map_view_t rowmap_view("rowmap_view", nv+1);
+      cols_view_t columns_view("colsmap_view", ne);
+      values_view_t values_view("values_view", ne);
+
+
+      {
+        typename row_map_view_t::HostMirror hr = Kokkos::create_mirror_view (rowmap_view);
+        typename cols_view_t::HostMirror hc = Kokkos::create_mirror_view (columns_view);
+        typename values_view_t::HostMirror hv = Kokkos::create_mirror_view (values_view);
+
+        for (INDEX_TYPE i = 0; i <= nv; ++i){
+          hr(i) = xadj[i];
+        }
+
+        for (INDEX_TYPE i = 0; i < ne; ++i){
+          hc(i) = adj[i];
+          hv(i) = ew[i];
+        }
+        Kokkos::deep_copy (rowmap_view , hr);
+        Kokkos::deep_copy (columns_view , hc);
+        Kokkos::deep_copy (values_view , hv);
+
+
+      }
+      graph_t static_graph (columns_view, rowmap_view);
+      crsMat_t crsmat("CrsMatrix", nv, values_view, static_graph);
+
+//      typedef typename KokkosSparse::CrsMatrix<SCALAR_TYPE, INDEX_TYPE, Kokkos::Cuda> crsMat_t;
+//      crsMat_t crsmat("CrsMatrix", nv, nv, ne, ew, xadj, adj);
+      delete [] xadj;
+      delete [] adj;
+      delete [] ew;
+
+      values_view_t kok_x_original = create_x_vector<values_view_t>(((nv /block_size) + 1) * block_size, MAXVAL);
+      for (INDEX_TYPE i = nv; i < ((nv /block_size) + 1) * block_size; ++i){
+    	  kok_x_original(i) = 0;
+      }
+      run_experiment<myExecSpace, crsMat_t>(crsmat, kok_x_original, block_size);
+
+      //run_experiment<myExecSpace, crsMat_t>(crsmat, kok_x_original);
+
+      myExecSpace::finalize();
+      Kokkos::HostSpace::execution_space::finalize();
+    }
+
+#endif
+
+
+
+  return 0;
+}
+#else
+int main() {
+}
+#endif

--- a/perf_test/sparse/KokkosSparse_block_pcg.cpp
+++ b/perf_test/sparse/KokkosSparse_block_pcg.cpp
@@ -153,7 +153,7 @@ void run_point_experiment(
 	      << std::endl ;
 
 
-#if PRINTDEBUG
+#if KOKKOSSPARSE_IMPL_PRINTDEBUG
 	  kok_x_vector = scalar_view_t("kok_x_vector", nv);
 
 	  kh.create_gs_handle(KokkosSparse::GS_TEAM);
@@ -289,7 +289,7 @@ void run_experiment(
 		  pf_rm, pf_e, pf_v);
 
 
-#if PRINTDEBUG
+#if KOKKOSSPARSE_IMPL_PRINTDEBUG
   std::cout << "nr:" << crsmat.numRows() << " nc:" << crsmat.numCols() << std::endl;
 
   KokkosKernels::Impl::print_1Dview(crsmat.graph.row_map);
@@ -318,7 +318,7 @@ void run_experiment(
 		  but_r, but_c,
 		  bf_rm, bf_e, bf_v);
 
-#if PRINTDEBUG
+#if KOKKOSSPARSE_IMPL_PRINTDEBUG
   KokkosKernels::Impl::print_1Dview(bf_rm);
   KokkosKernels::Impl::print_1Dview(bf_e);
   KokkosKernels::Impl::print_1Dview(bf_v);
@@ -386,9 +386,10 @@ int main (int argc, char ** argv){
   if (mtx_bin_file == NULL){
     std::cerr << "Provide a mtx binary file" << std::endl ;
     std::cerr << "OPTIONS\n\t--threads [numThreads]\n\t--openmp [numThreads]\n\t--cuda\n\t--cuda-dev[DeviceIndex]\n\t--mtx[binary_mtx_file]" << std::endl;
-
     return 0;
   }
+  std::cout << "Running experiments with block size:" << block_size << std::endl;
+
 
   Kokkos::initialize(kargs);
 

--- a/perf_test/sparse/KokkosSparse_pcg.hpp
+++ b/perf_test/sparse/KokkosSparse_pcg.hpp
@@ -60,6 +60,8 @@
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
+
+//#define KK_TICTOCPRINT
 namespace KokkosKernels {
 namespace Experimental{
 namespace Example {
@@ -73,6 +75,215 @@ struct CGSolveResult {
   double precond_time;
   double precond_init_time;
 };
+
+template< typename KernelHandle_t,
+          typename crsMatrix_t,
+          typename y_vector_t,
+          typename x_vector_t
+          >
+void block_pcgsolve(
+               KernelHandle_t &kh
+            ,  const crsMatrix_t &point_crsMat
+			,  const crsMatrix_t &_block_crsMat, int block_size
+            ,  const y_vector_t &y_vector
+            ,  x_vector_t x_vector
+            ,  const size_t  maximum_iteration = 200
+            ,  const double  tolerance = std::numeric_limits<double>::epsilon()
+            ,  CGSolveResult * result = 0
+            ,  bool use_sgs = true) {
+
+  using namespace KokkosSparse;
+  using namespace KokkosSparse::Experimental;
+  typedef typename KernelHandle_t::HandleExecSpace Space;
+
+
+  const size_t count_total = point_crsMat.numRows();
+
+  size_t  iteration = 0 ;
+  double  iter_time = 0 ;
+  double  matvec_time = 0 ;
+  double  norm_res = 0 ;
+  double precond_time = 0;
+  double precond_init_time = 0;
+
+  Kokkos::Impl::Timer wall_clock ;
+  Kokkos::Impl::Timer timer;
+
+  // Need input vector to matvec to be owned + received
+  y_vector_t pAll ( "cg::p" , count_total );
+
+  y_vector_t p = Kokkos::subview( pAll , std::pair<size_t,size_t>(0,count_total) );
+  y_vector_t r ( "cg::r" , count_total );
+  y_vector_t Ap( "cg::Ap", count_total );
+
+  /* r = b - A * x ; */
+  /* p  = x       */  Kokkos::deep_copy( p , x_vector );
+
+  /* Ap = A * p   */  KokkosSparse::spmv("N", 1, point_crsMat, pAll, 0, Ap);
+
+  /* r  = Ap       */  Kokkos::deep_copy( r , Ap );
+
+  /* r = b - r   */  KokkosBlas::axpby(1.0, y_vector, -1.0, r);
+
+  /* p  = r       */  Kokkos::deep_copy( p , r );
+;
+  double old_rdot = KokkosBlas::dot( r , r );
+  norm_res  = sqrt( old_rdot );
+
+  int apply_count = 1;
+  y_vector_t z;
+
+  double precond_old_rdot = 1;
+  //Kokkos::deep_copy( p , z );
+
+  bool owner_handle = false;
+
+  KernelHandle_t block_kh; block_kh.create_gs_handle(); block_kh.get_gs_handle()->set_block_size(block_size);
+
+  if (use_sgs){
+    if (kh.get_gs_handle() == NULL){
+      owner_handle = true;
+      kh.create_gs_handle();
+    }
+
+    timer.reset();
+/*
+    gauss_seidel_numeric
+      (&kh, count_total, count_total, point_crsMat.graph.row_map, point_crsMat.graph.entries, point_crsMat.values);
+
+    Space::fence();
+    timer.reset();
+*/
+
+    //block_kh.set_verbose(true);
+    block_gauss_seidel_numeric
+          (&block_kh, _block_crsMat.numRows(), _block_crsMat.numCols(), block_size, _block_crsMat.graph.row_map, _block_crsMat.graph.entries, _block_crsMat.values);
+
+    precond_init_time += timer.seconds();
+
+    z = y_vector_t( "pcg::z" , count_total );
+    Space::fence();
+    timer.reset();
+    symmetric_block_gauss_seidel_apply
+            (&block_kh, _block_crsMat.numRows(), _block_crsMat.numCols(),block_size,  _block_crsMat.graph.row_map, _block_crsMat.graph.entries, _block_crsMat.values,
+            		z, r, true, true, apply_count);
+/*
+    symmetric_gauss_seidel_apply
+        (&kh, count_total, count_total, point_crsMat.graph.row_map, point_crsMat.graph.entries, point_crsMat.values, z, r, true, true, apply_count);
+*/
+    Space::fence();
+    precond_time += timer.seconds();
+    precond_old_rdot = KokkosBlas::dot( r , z );
+    Kokkos::deep_copy( p , z );
+  }
+
+  iteration = 0 ;
+
+#ifdef KK_TICTOCPRINT
+
+  std::cout << "norm_res:" << norm_res << " old_rdot:" << old_rdot<<  std::endl;
+
+#endif
+  while ( tolerance < norm_res && iteration < maximum_iteration ) {
+
+
+    timer.reset();
+    /* Ap = A * p   */  KokkosSparse::spmv("N", 1, point_crsMat, pAll, 0, Ap);
+
+
+    Space::fence();
+    matvec_time += timer.seconds();
+
+    //const double pAp_dot = Kokkos::Example::all_reduce( dot( count_owned , p , Ap ) , import.comm );
+    //const double pAp_dot = dot<y_vector_t,y_vector_t, Space>( count_total , p , Ap ) ;
+
+    /* pAp_dot = dot(Ap , p ) */ const double pAp_dot = KokkosBlas::dot( p , Ap ) ;
+
+
+    double alpha  = 0;
+    if (use_sgs){
+      alpha = precond_old_rdot / pAp_dot ;
+    }
+    else {
+      alpha = old_rdot / pAp_dot ;
+    }
+
+    /* x +=  alpha * p ;  */  KokkosBlas::axpby(alpha, p, 1.0, x_vector);
+
+    /* r += -alpha * Ap ; */  KokkosBlas::axpby(-alpha, Ap, 1.0, r);
+
+    const double r_dot = KokkosBlas::dot( r , r );
+
+    const double beta_original  = r_dot / old_rdot ;
+    double precond_r_dot = 1;
+    double precond_beta = 1;
+    if (use_sgs){
+      Space::fence();
+      timer.reset();
+      symmetric_block_gauss_seidel_apply
+                  (&block_kh, _block_crsMat.numRows(), _block_crsMat.numCols(),block_size, _block_crsMat.graph.row_map, _block_crsMat.graph.entries, _block_crsMat.values,
+                  		z, r, true, true, apply_count);
+      /*
+
+      symmetric_gauss_seidel_apply(
+          &kh,
+          count_total, count_total,
+          point_crsMat.graph.row_map,
+          point_crsMat.graph.entries,
+          point_crsMat.values, z, r, true,
+          apply_count);
+          */
+
+      Space::fence();
+      precond_time += timer.seconds();
+      precond_r_dot = KokkosBlas::dot(r , z );
+      precond_beta  = precond_r_dot / precond_old_rdot ;
+    }
+
+    double beta  = 1;
+    if (!use_sgs){
+      beta = beta_original;
+      /* p = r + beta * p ; */  KokkosBlas::axpby(1.0, r, beta, p);
+    }
+    else {
+      beta = precond_beta;
+      KokkosBlas::axpby(1.0, z, beta, p);
+    }
+
+#ifdef KK_TICTOCPRINT
+    std::cout << "\tbeta_original:" << beta_original <<  std::endl;
+    if (use_sgs)
+    std::cout << "\tprecond_beta:" << precond_beta <<  std::endl;
+
+#endif
+
+
+    norm_res = sqrt( old_rdot = r_dot );
+    precond_old_rdot = precond_r_dot;
+
+#ifdef KK_TICTOCPRINT
+    std::cout << "\tnorm_res:" << norm_res << " old_rdot:" << old_rdot<<  std::endl;
+#endif
+    ++iteration ;
+  }
+
+  Space::fence();
+  iter_time = wall_clock.seconds();
+
+  if ( 0 != result ) {
+    result->iteration   = iteration ;
+    result->iter_time   = iter_time ;
+    result->matvec_time = matvec_time ;
+    result->norm_res    = norm_res ;
+    result->precond_time = precond_time;
+    result->precond_init_time = precond_init_time;
+  }
+
+  if (use_sgs & owner_handle ){
+
+    kh.destroy_gs_handle();
+  }
+}
 
 
 template< typename KernelHandle_t,
@@ -169,7 +380,7 @@ void pcgsolve(
   std::cout << "norm_res:" << norm_res << " old_rdot:" << old_rdot<<  std::endl;
 
 #endif
-  while ( tolerance < norm_res && iteration < maximum_iteration ) {
+  while (tolerance < norm_res && iteration < maximum_iteration ) {
 
 
     timer.reset();

--- a/perf_test/sparse/KokkosSparse_pcg.hpp
+++ b/perf_test/sparse/KokkosSparse_pcg.hpp
@@ -139,7 +139,7 @@ void block_pcgsolve(
   bool owner_handle = false;
 
   KernelHandle_t block_kh; block_kh.create_gs_handle(); block_kh.get_gs_handle()->set_block_size(block_size);
-
+    //block_kh.set_shmem_size(8032);
   if (use_sgs){
     if (kh.get_gs_handle() == NULL){
       owner_handle = true;
@@ -353,6 +353,7 @@ void pcgsolve(
     }
 
     timer.reset();
+    //kh.set_verbose(true);
 
     gauss_seidel_numeric
       (&kh, count_total, count_total, crsMat.graph.row_map, crsMat.graph.entries, crsMat.values);

--- a/src/batched/KokkosBatched_Test_BlockCrs.hpp
+++ b/src/batched/KokkosBatched_Test_BlockCrs.hpp
@@ -300,7 +300,6 @@ namespace KokkosBatched {
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__KOKKOSBATCHED_TEST_ENABLE_CUDA__)
           case 1: {
             typedef Kokkos::TeamPolicy<exec_space,TeamTag> policy_type;
-            typedef typename policy_type::member_type member_type;
             typedef Kokkos::Impl::ParallelFor<functor_type,policy_type,exec_space> parallel_for_type;
 
             int team_size = 0;
@@ -330,7 +329,6 @@ namespace KokkosBatched {
           case 2: {
             typedef Kokkos::View<ValueType***,exec_space> packed_view_type;
             typedef Kokkos::TeamPolicy<exec_space,TeamShmemTag> policy_type;
-            typedef typename policy_type::member_type member_type;
             typedef Kokkos::Impl::ParallelFor<functor_type,policy_type,exec_space> parallel_for_type;
             
             const int per_team_scratch 
@@ -835,7 +833,6 @@ namespace KokkosBatched {
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__KOKKOSBATCHED_TEST_ENABLE_CUDA__)
           case 1: {
             typedef Kokkos::TeamPolicy<exec_space,TeamTag> policy_type;
-            typedef typename policy_type::member_type member_type;
             typedef Kokkos::Impl::ParallelFor<functor_type,policy_type,exec_space> parallel_for_type;
             
             int team_size = 0;
@@ -862,7 +859,6 @@ namespace KokkosBatched {
           case 2: {
             typedef Kokkos::View<ValueType***,exec_space> packed_view_type;
             typedef Kokkos::TeamPolicy<exec_space,TeamShmemTag> policy_type;
-            typedef typename policy_type::member_type member_type;
             typedef Kokkos::Impl::ParallelFor<functor_type,policy_type,exec_space> parallel_for_type;
             
             const int per_team_scratch 

--- a/src/batched/KokkosBatched_Vector.hpp
+++ b/src/batched/KokkosBatched_Vector.hpp
@@ -106,17 +106,29 @@ namespace KokkosBatched {
     template<int l> struct ValueScalarType<Vector<SIMD<Kokkos::complex<float> >,l> > { typedef Kokkos::complex<float> type; };
     template<int l> struct ValueScalarType<Vector<SIMD<Kokkos::complex<double> >,l> > { typedef Kokkos::complex<double> type; };
 
-    template<typename T> typename Kokkos::Details::ArithTraits<T>::mag_type RealPart(const T &val) { return val; }
-    template<typename T> typename Kokkos::Details::ArithTraits<Kokkos::complex<T> >::mag_type RealPart(const Kokkos::complex<T> &val) { return val.real(); }
-    template<typename T, int l> typename Kokkos::Details::ArithTraits<Vector<SIMD<Kokkos::complex<T> >,l> >::mag_type
+    template<typename T>
+    KOKKOS_INLINE_FUNCTION
+    typename Kokkos::Details::ArithTraits<T>::mag_type RealPart(const T &val) { return val; }
+    template<typename T>
+    KOKKOS_INLINE_FUNCTION
+    typename Kokkos::Details::ArithTraits<Kokkos::complex<T> >::mag_type RealPart(const Kokkos::complex<T> &val) { return val.real(); }
+    template<typename T, int l>
+    KOKKOS_INLINE_FUNCTION
+    typename Kokkos::Details::ArithTraits<Vector<SIMD<Kokkos::complex<T> >,l> >::mag_type
     RealPart(const Vector<SIMD<Kokkos::complex<T> >,l> &val) {
       typename Kokkos::Details::ArithTraits<Vector<SIMD<Kokkos::complex<T> >,l> >::mag_type r_val;
       for (int i=0;i<l;++i) { r_val[i] = val[i].real(); }
       return r_val;
     }
-    template<typename T> typename Kokkos::Details::ArithTraits<T>::mag_type ImagPart(const T &val) { return 0; }
-    template<typename T> typename Kokkos::Details::ArithTraits<Kokkos::complex<T> >::mag_type ImagPart(const Kokkos::complex<T> &val) { return val.imag(); }
-    template<typename T, int l> typename Kokkos::Details::ArithTraits<Vector<SIMD<Kokkos::complex<T> >,l> >::mag_type
+    template<typename T>
+    KOKKOS_INLINE_FUNCTION
+    typename Kokkos::Details::ArithTraits<T>::mag_type ImagPart(const T &val) { return 0; }
+    template<typename T>
+    KOKKOS_INLINE_FUNCTION
+    typename Kokkos::Details::ArithTraits<Kokkos::complex<T> >::mag_type ImagPart(const Kokkos::complex<T> &val) { return val.imag(); }
+    template<typename T, int l>
+    KOKKOS_INLINE_FUNCTION
+    typename Kokkos::Details::ArithTraits<Vector<SIMD<Kokkos::complex<T> >,l> >::mag_type
     ImagPart(const Vector<SIMD<Kokkos::complex<T> >,l> &val) {
       typename Kokkos::Details::ArithTraits<Vector<SIMD<Kokkos::complex<T> >,l> >::mag_type r_val;
       for (int i=0;i<l;++i) { r_val[i] = val[i].imag(); }

--- a/src/blas/impl/KokkosBlas1_mult_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_mult_spec.hpp
@@ -227,8 +227,6 @@ struct Mult<YV, AV, XV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
     }
     #endif
  
-    typedef typename YV::size_type size_type;
-
     const size_type numRows = Y.dimension_0 ();
     if (numRows < static_cast<int> (INT_MAX)) {
       V_Mult_Generic<YV, AV, XV, int> (gamma, Y, alpha, A, X);

--- a/src/common/KokkosKernels_SparseUtils.hpp
+++ b/src/common/KokkosKernels_SparseUtils.hpp
@@ -62,6 +62,254 @@ namespace Impl{
 
 template <typename in_row_view_t,
           typename in_nnz_view_t,
+		  typename in_val_view_t,
+		  typename out_row_view_t,
+		  typename out_nnz_view_t,
+		  typename out_val_view_t>
+void kk_create_blockcrs_formated_point_crsmatrix(
+		int block_size,
+	    size_t num_rows,
+	    size_t num_cols,
+	    in_row_view_t in_xadj,
+	    in_nnz_view_t in_adj,
+		in_val_view_t in_vals,
+
+
+	    size_t &out_num_rows,
+	    size_t &out_num_cols,
+	    out_row_view_t &out_xadj,
+	    out_nnz_view_t &out_adj,
+		out_val_view_t &out_vals
+	    ){
+
+	typedef typename in_nnz_view_t::non_const_value_type lno_t;
+	typedef typename in_row_view_t::non_const_value_type size_type;
+	typedef typename in_val_view_t::non_const_value_type scalar_t;
+
+
+    typename in_row_view_t::HostMirror hr = Kokkos::create_mirror_view (in_xadj);
+    Kokkos::deep_copy (hr, in_xadj);
+    typename in_nnz_view_t::HostMirror he = Kokkos::create_mirror_view (in_adj);
+    Kokkos::deep_copy (he, in_adj);
+    typename in_val_view_t::HostMirror hv = Kokkos::create_mirror_view (in_vals);
+    Kokkos::deep_copy (hv, in_vals);
+
+    out_num_rows = (num_rows / block_size) * block_size;
+    if (num_rows % block_size) out_num_rows += block_size;
+
+    out_num_cols = (num_cols / block_size) * block_size;
+    if (num_cols % block_size) out_num_cols += block_size;
+
+
+    std::vector<size_type> block_rows_xadj (out_num_rows + 1, 0);
+    std::vector<lno_t>     block_adj; //(in_adj.extent(0), 0);
+    std::vector<scalar_t>  block_vals;// (in_adj.extent(0), 0);
+
+    std::vector<scalar_t> block_columns (out_num_cols, 0);
+    std::vector<scalar_t> block_accumulators (out_num_cols, 0);
+    std::vector<bool> block_flags (out_num_cols, false);
+
+    size_type output_index = 0;
+    for (lno_t i = 0; i < lno_t(num_rows); i += block_size){
+    	//std::cout << "row:" << i << std::endl;
+    	lno_t outputrowsize = 0;
+
+    	for (lno_t block_ind = 0; block_ind < block_size; ++block_ind){
+    		lno_t row_ind = block_ind + i;
+    		//std::cout << "\nrow_ind:" << row_ind << std::endl;
+    		if (row_ind < lno_t(num_rows)){
+    			size_type adj_begin = hr(row_ind);
+    			size_type adj_end = hr(row_ind + 1);
+
+    			lno_t row_size = adj_end - adj_begin;
+
+    			for (lno_t col_ind = 0; col_ind < row_size; ++col_ind){
+
+    				lno_t colid = he(col_ind + adj_begin);
+    				//scalar_t colval = hv(col_ind);
+
+    				lno_t block_column_start = (colid / block_size) * block_size;
+
+    				for (lno_t kk = 0; kk < block_size; ++kk){
+    					lno_t col_id_to_insert = block_column_start + kk;
+        				//std::cout << colid << " " << block_column_start << " " << col_id_to_insert << " " << block_flags[col_id_to_insert] << " ## ";
+
+    					if (block_flags[col_id_to_insert] == false) {
+    						block_flags[col_id_to_insert] = true;
+    						//block_adj[output_index + outputrowsize++] = col_id_to_insert;
+    						//block_adj.push_back(col_id_to_insert);
+    						block_columns[outputrowsize++] = col_id_to_insert;
+
+    					}
+    				}
+    			}
+    		}
+    		else {
+
+				lno_t colid = row_ind;
+				//scalar_t colval = hv(col_ind);
+
+				lno_t block_column_start = (colid / block_size) * block_size;
+
+				for (lno_t kk = 0; kk < block_size; ++kk){
+					lno_t col_id_to_insert = block_column_start + kk;
+					if (block_flags[col_id_to_insert] == false) {
+						block_flags[col_id_to_insert] = true;
+						//block_adj[output_index + outputrowsize++] = col_id_to_insert;
+						//block_adj.push_back(col_id_to_insert);
+						block_columns[outputrowsize++] = col_id_to_insert;
+					}
+				}
+    		}
+    	}
+		std::sort(block_columns.begin(), block_columns.begin() + outputrowsize);
+		//std::cout << "\nrow:" << i << " outputrowsize:" << outputrowsize << std::endl;
+    	for(lno_t kk = 0; kk < outputrowsize; ++kk){
+    		block_flags[block_columns[kk]] = false;
+    		//std::cout << block_columns[kk] << " ";
+    	}
+    	//std::cout << std::endl;
+
+    	for (lno_t block_ind = 0; block_ind < block_size; ++block_ind){
+    		lno_t row_ind = block_ind + i;
+    		if (row_ind < lno_t(num_rows)){
+    			size_type adj_begin = hr(row_ind);
+    			size_type adj_end = hr(row_ind + 1);
+
+    			lno_t row_size = adj_end - adj_begin;
+
+    			for (lno_t col_ind = 0; col_ind < row_size; ++col_ind){
+    				lno_t colid = he(col_ind + adj_begin);
+    				scalar_t colval = hv(col_ind + adj_begin);
+    				block_accumulators[colid] = colval;
+    			}
+    		}
+    		else {
+    			block_accumulators[row_ind] = 1;
+    		}
+
+        	for(lno_t kk = 0; kk < outputrowsize; ++kk){
+        		lno_t outcol = block_columns[kk];
+        		block_adj.push_back(outcol );
+        		block_vals.push_back(block_accumulators[outcol]);
+        		block_accumulators[outcol] = 0;
+        	}
+        	block_rows_xadj[row_ind + 1] = block_rows_xadj[row_ind] + outputrowsize;
+    	}
+    }
+
+
+    out_xadj = out_row_view_t ("BlockedPointCRS XADJ", out_num_rows + 1);
+    out_adj = out_nnz_view_t("BlockedPointCRS ADJ", block_adj.size());
+    out_vals = out_val_view_t("BlockedPointCRS VALS", block_vals.size());
+
+
+    typename out_row_view_t::HostMirror hor = Kokkos::create_mirror_view (out_xadj);
+    typename out_nnz_view_t::HostMirror hoe = Kokkos::create_mirror_view (out_adj);
+    typename out_val_view_t::HostMirror hov = Kokkos::create_mirror_view (out_vals);
+
+    for (lno_t i = 0; i < lno_t(out_num_rows) + 1; ++i ){
+    	hor(i) = block_rows_xadj[i];
+    }
+
+    size_type ne = block_adj.size();
+    for (size_type i = 0; i < ne; ++i ){
+    	hoe(i) = block_adj[i];
+    }
+    for (size_type i = 0; i < ne; ++i ){
+    	hov(i) = block_vals[i];
+    }
+
+    Kokkos::deep_copy (out_xadj, hor);
+    Kokkos::deep_copy (out_adj, hoe);
+    Kokkos::deep_copy (out_vals, hov);
+}
+
+template <typename in_row_view_t,
+          typename in_nnz_view_t,
+		  typename in_val_view_t,
+		  typename out_row_view_t,
+		  typename out_nnz_view_t,
+		  typename out_val_view_t>
+void kk_create_blockcrs_from_blockcrs_formatted_point_crs(
+		int block_size,
+	    size_t num_rows,
+	    size_t num_cols,
+	    in_row_view_t in_xadj,
+	    in_nnz_view_t in_adj,
+		in_val_view_t in_vals,
+
+
+	    size_t &out_num_rows,
+	    size_t &out_num_cols,
+	    out_row_view_t &out_xadj,
+	    out_nnz_view_t &out_adj,
+		out_val_view_t &out_vals
+	    ){
+
+    typename in_row_view_t::HostMirror hr = Kokkos::create_mirror_view (in_xadj);
+    Kokkos::deep_copy (hr, in_xadj);
+    typename in_nnz_view_t::HostMirror he = Kokkos::create_mirror_view (in_adj);
+    Kokkos::deep_copy (he, in_adj);
+    typename in_val_view_t::HostMirror hv = Kokkos::create_mirror_view (in_vals);
+    Kokkos::deep_copy (hv, in_vals);
+
+
+	out_num_rows = num_rows / block_size;
+	out_num_cols = num_cols / block_size;
+
+
+    out_xadj = out_row_view_t ("BlockedCRS XADJ", out_num_rows + 1);
+    out_adj = out_nnz_view_t("BlockedCRS ADJ", in_adj.extent(0) / (block_size * block_size));
+    out_vals = out_val_view_t("BlockedCRS VALS", in_vals.extent(0));
+
+
+    typename out_row_view_t::HostMirror hor = Kokkos::create_mirror_view (out_xadj);
+    typename out_nnz_view_t::HostMirror hoe = Kokkos::create_mirror_view (out_adj);
+    typename out_val_view_t::HostMirror hov = Kokkos::create_mirror_view (out_vals);
+
+
+	typedef typename in_nnz_view_t::non_const_value_type lno_t;
+	typedef typename in_row_view_t::non_const_value_type size_type;
+	//typedef typename in_val_view_t::non_const_value_type scalar_t;
+
+    for(lno_t i = 0; i < lno_t(out_num_rows); ++i ){
+    	hor(i) = hr(i * block_size) / (block_size * block_size);
+
+    	size_type ib = hr(i * block_size);
+    	size_type ie = hr(i * block_size + 1);
+
+    	lno_t is = ie - ib;
+
+    	size_type ob = hor(i);
+    	//size_type oe = hr(i * block_size + 1) / block_size;
+    	lno_t os = (ie - ib) / block_size;
+    	lno_t write_index = 0;
+    	for (lno_t j = 0; j < is; ++j){
+    		lno_t e = he(ib + j);
+    		if (e % block_size == 0){
+    			hoe(ob + write_index++) = e / block_size;
+    		}
+    	}
+    	if (write_index != os) {
+    		std::cerr << "row:" << i << " expected size:" << os << " written size:" << write_index << std::endl;
+    		exit(1);
+    	}
+    }
+    hor(out_num_rows) = hr(out_num_rows * block_size) / (block_size * block_size);
+    Kokkos::deep_copy (out_xadj, hor);
+    Kokkos::deep_copy (out_adj, hoe);
+
+    size_type ne = in_adj.extent(0);
+    for(size_type i = 0; i < ne; ++i ){
+    	hov(i) = hv(i);
+    }
+    Kokkos::deep_copy (out_vals, hov);
+
+}
+
+template <typename in_row_view_t,
+          typename in_nnz_view_t,
           typename in_scalar_view_t,
           typename out_row_view_t,
           typename out_nnz_view_t,
@@ -1861,6 +2109,30 @@ void kk_create_incidence_matrix_from_original_matrix(
       out_entries = outcols;*/
 #endif
   }
+
+
+
+template<typename view_type>
+struct ReduceLargerRowCount{
+
+  view_type rowmap;
+  typename view_type::const_value_type threshold;
+
+  ReduceLargerRowCount(view_type view_to_reduce_, typename view_type::const_value_type threshold_): rowmap(view_to_reduce_), threshold(threshold_){}
+
+  void operator()(const size_t &i, typename view_type::non_const_value_type &sum_reduction) const {
+	  if (rowmap(i+1) - rowmap(i) > threshold){
+		  sum_reduction += 1;
+	  }
+  }
+};
+
+template <typename view_type , typename MyExecSpace>
+void kk_reduce_numrows_larger_than_threshold(size_t num_elements, view_type view_to_reduce,
+		typename view_type::const_value_type threshold, typename view_type::non_const_value_type &sum_reduction){
+  typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
+  Kokkos::parallel_reduce( my_exec_space(0,num_elements), ReduceLargerRowCount<view_type>(view_to_reduce, threshold), sum_reduction);
+}
 
 }
 }

--- a/src/common/KokkosKernels_SparseUtils.hpp
+++ b/src/common/KokkosKernels_SparseUtils.hpp
@@ -105,7 +105,7 @@ void kk_create_blockcrs_formated_point_crsmatrix(
     std::vector<lno_t>     block_adj; //(in_adj.extent(0), 0);
     std::vector<scalar_t>  block_vals;// (in_adj.extent(0), 0);
 
-    std::vector<scalar_t> block_columns (out_num_cols, 0);
+    std::vector<lno_t> block_columns (out_num_cols, 0);
     std::vector<scalar_t> block_accumulators (out_num_cols, 0);
     std::vector<bool> block_flags (out_num_cols, false);
 

--- a/src/common/KokkosKernels_SparseUtils.hpp
+++ b/src/common/KokkosKernels_SparseUtils.hpp
@@ -109,7 +109,6 @@ void kk_create_blockcrs_formated_point_crsmatrix(
     std::vector<scalar_t> block_accumulators (out_num_cols, 0);
     std::vector<bool> block_flags (out_num_cols, false);
 
-    size_type output_index = 0;
     for (lno_t i = 0; i < lno_t(num_rows); i += block_size){
     	//std::cout << "row:" << i << std::endl;
     	lno_t outputrowsize = 0;
@@ -2119,7 +2118,7 @@ struct ReduceLargerRowCount{
   typename view_type::const_value_type threshold;
 
   ReduceLargerRowCount(view_type view_to_reduce_, typename view_type::const_value_type threshold_): rowmap(view_to_reduce_), threshold(threshold_){}
-
+  KOKKOS_INLINE_FUNCTION
   void operator()(const size_t &i, typename view_type::non_const_value_type &sum_reduction) const {
 	  if (rowmap(i+1) - rowmap(i) > threshold){
 		  sum_reduction += 1;

--- a/src/common/KokkosKernels_Uniform_Initialized_MemoryPool.hpp
+++ b/src/common/KokkosKernels_Uniform_Initialized_MemoryPool.hpp
@@ -178,7 +178,8 @@ public:
   UniformMemoryPool(const size_t num_chunks_,
                     const size_t set_chunk_size_,
                     const data_type initialized_value = 0,
-                    const PoolType pool_type_ = OneThread2OneChunk):
+                    const PoolType pool_type_ = OneThread2OneChunk,
+					bool initialize = true):
                       num_chunks(1),
                     num_set_chunks(num_chunks_), modular_num_chunks(0),
                     chunk_size(set_chunk_size_),
@@ -199,11 +200,16 @@ public:
     }
     modular_num_chunks = num_chunks -1;
     overall_size = num_chunks * chunk_size;
-    data_view = data_view_t(Kokkos::ViewAllocateWithoutInitializing("pool data"), overall_size),
-    data = (data_view.ptr_on_device()),
+    if (num_set_chunks > 0){
+    	data_view = data_view_t(Kokkos::ViewAllocateWithoutInitializing("pool data"), overall_size);
+    }
+    data = (data_view.ptr_on_device());
 
     this->set_pool_type(pool_type_);
-    Kokkos::deep_copy(data_view, initialized_value);
+
+    if (initialize){
+    	Kokkos::deep_copy(data_view, initialized_value);
+    }
 
   }
 
@@ -242,8 +248,9 @@ public:
    */
   void set_pool_type (PoolType pool_type_){
     if (pool_type_ == ManyThread2OneChunk){
-      //free_chunks = index_view_t (Kokkos::ViewAllocateWithoutInitializing("free_chunk_indices"), num_chunks),
-      chunk_locks = lock_view_t("locks", num_chunks);
+      if (num_set_chunks){
+    	  chunk_locks = lock_view_t("locks", num_chunks);
+      }
       pchunk_locks = chunk_locks.ptr_on_device();
     }
   }

--- a/src/sparse/KokkosSparse_gauss_seidel.hpp
+++ b/src/sparse/KokkosSparse_gauss_seidel.hpp
@@ -51,73 +51,6 @@ namespace KokkosSparse{
 
 namespace Experimental{
 
-/*
-template <typename KernelHandle, typename lno_row_view_t_, typename lno_nnz_view_t_>
-void gauss_seidel_symbolic_spec(
-    KernelHandle *handle,
-    typename KernelHandle::const_nnz_lno_t num_rows,
-    typename KernelHandle::const_nnz_lno_t num_cols,
-    lno_row_view_t_ row_map,
-    lno_nnz_view_t_ entries,
-	bool is_graph_symmetric){
-
-	typedef typename Impl::GaussSeidel<KernelHandle, lno_row_view_t_,
-			lno_nnz_view_t_, typename KernelHandle::in_scalar_nnz_view_t> SGS;
-	SGS sgs(handle,num_rows, num_cols, row_map, entries, is_graph_symmetric);
-	sgs.initialize_symbolic();
-}
-
-template <typename KernelHandle,
-          typename lno_row_view_t_,
-          typename lno_nnz_view_t_,
-          typename scalar_nnz_view_t_>
-void gauss_seidel_numeric_spec(KernelHandle *handle,
-    typename KernelHandle::const_nnz_lno_t num_rows,
-    typename KernelHandle::const_nnz_lno_t num_cols,
-    lno_row_view_t_ row_map,
-    lno_nnz_view_t_ entries,
-    scalar_nnz_view_t_ values,
-    bool is_graph_symmetric
-    ){
-	    typedef typename Impl::GaussSeidel
-	        <KernelHandle,lno_row_view_t_,
-	        lno_nnz_view_t_,scalar_nnz_view_t_> SGS;
-	    SGS sgs(handle, num_rows, num_cols, row_map, entries, values, is_graph_symmetric);
-	    sgs.initialize_numeric();
-}
-
-template <typename KernelHandle,
-  typename lno_row_view_t_,
-  typename lno_nnz_view_t_,
-  typename scalar_nnz_view_t_,
-  typename x_scalar_view_t,
-  typename y_scalar_view_t>
-void gauss_seidel_apply_spec(
-		  KernelHandle *handle,
-    typename KernelHandle::const_nnz_lno_t num_rows,
-    typename KernelHandle::const_nnz_lno_t num_cols,
-    lno_row_view_t_ row_map,
-    lno_nnz_view_t_ entries,
-    scalar_nnz_view_t_ values,
-    x_scalar_view_t x_lhs_output_vec,
-    y_scalar_view_t y_rhs_input_vec,
-    bool init_zero_x_vector,
-    bool update_y_vector,
-    int numIter, bool apply_forward, bool apply_backward){
-
-	    typedef typename Impl::GaussSeidel <KernelHandle,
-	            lno_row_view_t_, lno_nnz_view_t_,scalar_nnz_view_t_ > SGS;
-	    SGS sgs(handle, num_rows, num_cols, row_map, entries, values);
-	    sgs.apply(
-	        x_lhs_output_vec,
-	        y_rhs_input_vec,
-	        init_zero_x_vector,
-	        numIter,
-			apply_forward,
-			apply_backward, update_y_vector);
-}
-*/
-
   template <typename KernelHandle, typename lno_row_view_t_, typename lno_nnz_view_t_>
   void gauss_seidel_symbolic(
       KernelHandle *handle,
@@ -172,6 +105,25 @@ void gauss_seidel_apply_spec(
 
 	  GAUSS_SEIDEL_SYMBOLIC<const_handle_type, Internal_alno_row_view_t_, Internal_alno_nnz_view_t_>::gauss_seidel_symbolic
 	  (&tmp_handle, num_rows, num_cols, const_a_r, const_a_l, is_graph_symmetric);
+
+  }
+
+  template <typename KernelHandle, typename lno_row_view_t_, typename lno_nnz_view_t_>
+  void block_gauss_seidel_symbolic(
+      KernelHandle *handle,
+      typename KernelHandle::const_nnz_lno_t num_rows,
+      typename KernelHandle::const_nnz_lno_t num_cols,
+	  typename KernelHandle::const_nnz_lno_t block_size,
+      lno_row_view_t_ row_map,
+      lno_nnz_view_t_ entries,
+	  bool is_graph_symmetric = true){
+
+
+	  handle->get_gs_handle()->set_block_size(block_size);
+
+	  gauss_seidel_symbolic(handle,
+			  num_rows, num_cols,
+			  row_map, entries, is_graph_symmetric);
 
   }
 
@@ -231,11 +183,6 @@ void gauss_seidel_apply_spec(
 			  typename KokkosKernels::Impl::GetUnifiedLayout<scalar_nnz_view_t_>::array_layout,
 			  typename scalar_nnz_view_t_::device_type,
 			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_ascalar_nnz_view_t_;
-	  /*
-	  Internal_alno_row_view_t_ const_a_r  = row_map;
-	  Internal_alno_nnz_view_t_ const_a_l  = entries;
-	  Internal_ascalar_nnz_view_t_ const_a_v  = values;
-	  */
 
 	  Internal_alno_row_view_t_ const_a_r (row_map.data(), row_map.dimension_0());
 	  Internal_alno_nnz_view_t_ const_a_l (entries.data(), entries.dimension_0());
@@ -247,6 +194,28 @@ void gauss_seidel_apply_spec(
 	  GAUSS_SEIDEL_NUMERIC<const_handle_type, Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_>::gauss_seidel_numeric
 	  	  (&tmp_handle, num_rows, num_cols, const_a_r, const_a_l, const_a_v, is_graph_symmetric);
 
+  }
+
+  template <typename KernelHandle,
+            typename lno_row_view_t_,
+            typename lno_nnz_view_t_,
+            typename scalar_nnz_view_t_>
+  void block_gauss_seidel_numeric(KernelHandle *handle,
+      typename KernelHandle::const_nnz_lno_t num_rows,
+      typename KernelHandle::const_nnz_lno_t num_cols,
+	  typename KernelHandle::const_nnz_lno_t block_size,
+      lno_row_view_t_ row_map,
+      lno_nnz_view_t_ entries,
+      scalar_nnz_view_t_ values,
+      bool is_graph_symmetric = true
+      ){
+	  handle->get_gs_handle()->set_block_size(block_size);
+
+	  gauss_seidel_numeric(handle,
+			  num_rows,num_cols,
+			  row_map, entries, values,
+			  is_graph_symmetric
+	        );
   }
 
   template <typename KernelHandle,
@@ -364,6 +333,36 @@ void gauss_seidel_apply_spec(
 
   }
 
+  template <typename KernelHandle,
+    typename lno_row_view_t_,
+    typename lno_nnz_view_t_,
+    typename scalar_nnz_view_t_,
+    typename x_scalar_view_t,
+    typename y_scalar_view_t>
+  void symmetric_block_gauss_seidel_apply(KernelHandle *handle,
+      typename KernelHandle::const_nnz_lno_t num_rows,
+      typename KernelHandle::const_nnz_lno_t num_cols,
+	  typename KernelHandle::const_nnz_lno_t block_size,
+
+      lno_row_view_t_ row_map,
+      lno_nnz_view_t_ entries,
+      scalar_nnz_view_t_ values,
+      x_scalar_view_t x_lhs_output_vec,
+      y_scalar_view_t y_rhs_input_vec,
+      bool init_zero_x_vector = false,
+      bool update_y_vector = true,
+      int numIter = 1){
+	  handle->get_gs_handle()->set_block_size(block_size);
+	  symmetric_gauss_seidel_apply(handle,num_rows,num_cols,
+			  row_map,
+		      entries,
+		      values,
+		      x_lhs_output_vec,
+		      y_rhs_input_vec,
+		      init_zero_x_vector,
+		      update_y_vector,
+		      numIter);
+  }
   template <class KernelHandle,
   typename lno_row_view_t_,
   typename lno_nnz_view_t_,
@@ -479,6 +478,38 @@ void gauss_seidel_apply_spec(
 
 
   }
+
+
+  template <typename KernelHandle,
+    typename lno_row_view_t_,
+    typename lno_nnz_view_t_,
+    typename scalar_nnz_view_t_,
+    typename x_scalar_view_t,
+    typename y_scalar_view_t>
+  void forward_sweep_block_gauss_seidel_apply(KernelHandle *handle,
+      typename KernelHandle::const_nnz_lno_t num_rows,
+      typename KernelHandle::const_nnz_lno_t num_cols,
+	  typename KernelHandle::const_nnz_lno_t block_size,
+
+      lno_row_view_t_ row_map,
+      lno_nnz_view_t_ entries,
+      scalar_nnz_view_t_ values,
+      x_scalar_view_t x_lhs_output_vec,
+      y_scalar_view_t y_rhs_input_vec,
+      bool init_zero_x_vector = false,
+      bool update_y_vector = true,
+      int numIter = 1){
+	  handle->get_gs_handle()->set_block_size(block_size);
+	  forward_sweep_gauss_seidel_apply(handle,num_rows,num_cols,
+			  row_map,
+		      entries,
+		      values,
+		      x_lhs_output_vec,
+		      y_rhs_input_vec,
+		      init_zero_x_vector,
+		      update_y_vector,
+		      numIter);
+  }
   template <class KernelHandle,
   typename lno_row_view_t_,
   typename lno_nnz_view_t_,
@@ -591,6 +622,37 @@ void gauss_seidel_apply_spec(
 			  numIter, false, true);
 
 
+  }
+
+  template <typename KernelHandle,
+    typename lno_row_view_t_,
+    typename lno_nnz_view_t_,
+    typename scalar_nnz_view_t_,
+    typename x_scalar_view_t,
+    typename y_scalar_view_t>
+  void backward_sweep_block_gauss_seidel_apply(KernelHandle *handle,
+      typename KernelHandle::const_nnz_lno_t num_rows,
+      typename KernelHandle::const_nnz_lno_t num_cols,
+	  typename KernelHandle::const_nnz_lno_t block_size,
+
+      lno_row_view_t_ row_map,
+      lno_nnz_view_t_ entries,
+      scalar_nnz_view_t_ values,
+      x_scalar_view_t x_lhs_output_vec,
+      y_scalar_view_t y_rhs_input_vec,
+      bool init_zero_x_vector = false,
+      bool update_y_vector = true,
+      int numIter = 1){
+	  handle->get_gs_handle()->set_block_size(block_size);
+	  backward_sweep_gauss_seidel_apply(handle,num_rows,num_cols,
+			  row_map,
+		      entries,
+		      values,
+		      x_lhs_output_vec,
+		      y_rhs_input_vec,
+		      init_zero_x_vector,
+		      update_y_vector,
+		      numIter);
   }
 }
 }

--- a/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
+++ b/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
@@ -109,6 +109,10 @@ private:
   int suggested_team_size;
 
   scalar_persistent_work_view_t permuted_diagonals;
+  nnz_lno_t block_size; //this is for block sgs
+
+  nnz_lno_t max_nnz_input_row, num_values_in_l1, num_values_in_l2, num_big_rows;
+  size_t level_1_mem, level_2_mem;
   public:
 
   /**
@@ -120,7 +124,8 @@ private:
     color_set_xadj(), color_sets(), numColors(0),
     permuted_xadj(),  permuted_adj(), permuted_adj_vals(), old_to_new_map(),
     called_symbolic(false), called_numeric(false), permuted_y_vector(), permuted_x_vector(),
-    suggested_vector_size(0), suggested_team_size(0), permuted_diagonals()
+    suggested_vector_size(0), suggested_team_size(0), permuted_diagonals(), block_size(1), max_nnz_input_row(-1),
+	num_values_in_l1(-1), num_values_in_l2(-1),num_big_rows(0), level_1_mem(0), level_2_mem(0)
     {
     if (gs == GS_DEFAULT){
       this->choose_default_algorithm();
@@ -128,6 +133,9 @@ private:
 
 
   }
+
+  void set_block_size(nnz_lno_t bs){this->block_size = bs; }
+  nnz_lno_t get_block_size(){return this->block_size;}
 
     /** \brief Chooses best algorithm based on the execution space. COLORING_EB if cuda, COLORING_VB otherwise.
    */
@@ -246,6 +254,53 @@ private:
   scalar_persistent_work_view_t get_permuted_diagonals (){
     return this->permuted_diagonals;
   }
+
+
+  void set_level_1_mem(size_t _level_1_mem){
+	  this->level_1_mem = _level_1_mem;
+  }
+  void set_level_2_mem(size_t _level_2_mem){
+	  this->level_2_mem = _level_2_mem;
+  }
+
+  void set_num_values_in_l1(nnz_lno_t _num_values_in_l1){
+	  this->num_values_in_l1 = _num_values_in_l1;
+  }
+  void set_num_values_in_l2(nnz_lno_t _num_values_in_l2){
+	  this->num_values_in_l2 = _num_values_in_l2;
+  }
+
+  void set_num_big_rows(nnz_lno_t _big_rows){
+	  this->num_big_rows = _big_rows;
+  }
+
+  size_t get_level_1_mem() const {
+	  return this->level_1_mem;
+  }
+  size_t get_level_2_mem()const {
+	  return this->level_2_mem;
+  }
+
+  nnz_lno_t get_num_values_in_l1()const {
+	  return this->num_values_in_l1 ;
+  }
+  nnz_lno_t get_num_values_in_l2()const {
+	  return this->num_values_in_l2 ;
+  }
+  nnz_lno_t get_num_big_rows()const {
+	  return this->num_big_rows;
+  }
+
+
+  nnz_lno_t get_max_nnz() const{
+    return this->max_nnz_input_row ;
+  }
+
+
+  void set_max_nnz(nnz_lno_t num_result_nnz_){
+    this->max_nnz_input_row = num_result_nnz_;
+  }
+
 
   void allocate_x_y_vectors(nnz_lno_t num_rows, nnz_lno_t num_cols){
     if(permuted_y_vector.dimension_0() != size_t(num_rows)){

--- a/src/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
@@ -745,7 +745,7 @@ public:
         int suggested_vector_size = this->handle->get_suggested_vector_size(brows, bnnz);
         int suggested_team_size = this->handle->get_suggested_team_size(suggested_vector_size);
         size_t shmem_size_to_use = this->handle->get_shmem_size();
-        nnz_lno_t team_row_chunk_size = this->handle->get_team_work_size(suggested_team_size,MyExecSpace::concurrency(), brows);
+        //nnz_lno_t team_row_chunk_size = this->handle->get_team_work_size(suggested_team_size,MyExecSpace::concurrency(), brows);
 
 	//MD: now we calculate how much memory is needed for shared memory.
 	//we have two-level vectors: as in spgemm hashmaps.

--- a/src/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
@@ -366,7 +366,7 @@ public:
 		
 
 
-#if 0
+#if PRINTDEBUG
 			  if (/*i == 0 && ii == 1*/ ii == 0 || (block_size == 1 && ii < 2) ){
 				  std::cout << "\n\n\nrow:" << ii * block_size + i;
 				  std::cout << "\nneighbors:";
@@ -413,7 +413,7 @@ public:
 
 
 	  Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end), [&] (const nnz_lno_t& ii) {
-#if 0
+#if PRINTDEBUG
 	      Kokkos::single(Kokkos::PerThread(teamMember),[=] () {
 	    	  for(nnz_lno_t i = 0; i < block_size; diagonal_positions[i++] = -1);
 	      });
@@ -459,12 +459,6 @@ public:
 
 				  valueToUpdate += all_shared_memory[colind] * _adj_vals(current_row_begin + colind);
 
-#if 00
-				  size_type adjind = i / block_size + old_row_b;
-				  nnz_lno_t colIndex = _adj[adjind];
-
-				  valueToUpdate += _Xvector[colIndex * block_size + i % block_size] * _adj_vals(current_row_begin  + colind);
-#endif
 			  },
 			  product);
 
@@ -482,7 +476,7 @@ public:
 		      });
 
 #if !defined(__CUDA_ARCH__)
-#if 0
+#if PRINTDEBUG
 			  if (/*i == 0 && ii == 1*/ ii == 0 || (block_size == 1 && ii < 2) ){
 				  std::cout << "\n\n\nrow:" << ii * block_size + i;
 				  std::cout << "\nneighbors:";
@@ -1239,7 +1233,7 @@ public:
     scalar_persistent_work_view_t permuted_adj_vals = gsHandler->get_new_adj_val();
     scalar_persistent_work_view_t permuted_diagonals = gsHandler->get_permuted_diagonals();
 
-#if 0
+#if PRINTDEBUG
     std::cout << "Y:";
     KokkosKernels::Impl::print_1Dview(Permuted_Yvector);
     std::cout << "Original Y:";
@@ -1275,7 +1269,7 @@ public:
 
     pool_memory_space m_space(num_chunks, level_2_mem / sizeof(nnz_scalar_t), 0,  KokkosKernels::Impl::ManyThread2OneChunk, false);
 
-#if 0
+#if PRINTDEBUG
     std::cout 	<< "l1_shmem_size:" << l1_shmem_size << " num_values_in_l1:" << num_values_in_l1
     			<< " level_2_mem:" << level_2_mem << " num_values_in_l2:" << num_values_in_l2
 				<< " num_chunks:" << num_chunks << std::endl;
@@ -1308,7 +1302,7 @@ public:
         );
     MyExecSpace::fence();
 
-#if 0
+#if PRINTDEBUG
     std::cout << "After X:";
     KokkosKernels::Impl::print_1Dview(Permuted_Xvector);
     std::cout << "Result X:";
@@ -1418,7 +1412,7 @@ public:
         x_lhs_output_vec
         );
     MyExecSpace::fence();
-#if 0
+#if PRINTDEBUG
     std::cout << "--point After X:";
     KokkosKernels::Impl::print_1Dview(Permuted_Xvector);
     std::cout << "--point Result X:";

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
@@ -1233,11 +1233,16 @@ struct KokkosSPGEMM
 
     Kokkos::parallel_reduce( Kokkos::ThreadVectorRange(teamMember, num_compressed_elements),
         [&] (const nnz_lno_t ii, nnz_lno_t &num_nnz_in_row) {
+
       nnz_lno_t c_rows = hm.values[ii];
+      nnz_lno_t num_el = KokkosKernels::Impl::pop_count(c_rows);
+
+      /*
       nnz_lno_t num_el = 0;
       for (; c_rows; num_el++) {
         c_rows &= c_rows - 1; // clear the least significant bit set
       }
+      */
       num_nnz_in_row += num_el;
     }, num_elements);
 

--- a/src/sparse/impl/KokkosSparse_spmv_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_spec.hpp
@@ -253,7 +253,6 @@ struct SPMV < AT, AO, AD, AM, AS,
   {
     typedef Kokkos::Details::ArithTraits<coefficient_type> KAT;
 
-    typedef typename YVector::non_const_value_type coefficient_type;
     typedef Kokkos::Details::ArithTraits<coefficient_type> KAT;
 
     if (alpha == KAT::zero ()) {

--- a/unit_test/Makefile
+++ b/unit_test/Makefile
@@ -108,6 +108,7 @@ ifeq ($(KOKKOSKERNELS_INTERNAL_TEST_OPENMP), 1)
   OBJ_OPENMP += Test_OpenMP_Sparse_spgemm.o
   OBJ_OPENMP += Test_OpenMP_Sparse_spadd.o
   OBJ_OPENMP += Test_OpenMP_Sparse_gauss_seidel.o
+  OBJ_OPENMP += Test_OpenMP_Sparse_block_gauss_seidel.o
   OBJ_OPENMP += Test_OpenMP_Sparse_CrsMatrix.o
   OBJ_OPENMP += Test_OpenMP_Sparse_findRelOffset.o
   OBJ_OPENMP += Test_OpenMP_Sparse_replaceSumIntoLonger.o
@@ -200,6 +201,7 @@ ifeq ($(KOKKOSKERNELS_INTERNAL_TEST_CUDA), 1)
   OBJ_CUDA += Test_Cuda_Sparse_spgemm.o
   OBJ_CUDA += Test_Cuda_Sparse_spadd.o
   OBJ_CUDA += Test_Cuda_Sparse_gauss_seidel.o
+  OBJ_CUDA += Test_Cuda_Sparse_block_gauss_seidel.o
   OBJ_CUDA += Test_Cuda_Sparse_CrsMatrix.o
  #OBJ_CUDA += Test_Cuda_Sparse_findRelOffset.o #removing findRelOffset from cuda test as the implementation is sequential.
   OBJ_CUDA += Test_Cuda_Sparse_replaceSumIntoLonger.o
@@ -285,6 +287,7 @@ ifeq ($(KOKKOSKERNELS_INTERNAL_TEST_SERIAL), 1)
   OBJ_SERIAL += Test_Serial_Sparse_spgemm.o
   OBJ_SERIAL += Test_Serial_Sparse_spadd.o
   OBJ_SERIAL += Test_Serial_Sparse_gauss_seidel.o
+  OBJ_SERIAL += Test_Serial_Sparse_block_gauss_seidel.o
   OBJ_SERIAL += Test_Serial_Sparse_CrsMatrix.o
   OBJ_SERIAL += Test_Serial_Sparse_findRelOffset.o
   OBJ_SERIAL += Test_Serial_Sparse_replaceSumIntoLonger.o
@@ -377,6 +380,7 @@ ifeq ($(KOKKOSKERNELS_INTERNAL_TEST_THREADS), 1)
   OBJ_THREADS += Test_Threads_Sparse_spgemm.o
   OBJ_THREADS += Test_Threads_Sparse_spadd.o
   OBJ_THREADS += Test_Threads_Sparse_gauss_seidel.o
+  OBJ_THREADS += Test_Threads_Sparse_block_gauss_seidel.o
   OBJ_THREADS += Test_Threads_Sparse_findRelOffset.o
   OBJ_THREADS += Test_Threads_Sparse_replaceSumIntoLonger.o
   OBJ_THREADS += Test_Threads_Sparse_replaceSumInto.o

--- a/unit_test/cuda/Test_Cuda_Sparse_block_gauss_seidel.cpp
+++ b/unit_test/cuda/Test_Cuda_Sparse_block_gauss_seidel.cpp
@@ -1,0 +1,2 @@
+#include<Test_Cuda.hpp>
+#include<Test_Sparse_block_gauss_seidel.hpp>

--- a/unit_test/openmp/Test_OpenMP_Sparse_block_gauss_seidel.cpp
+++ b/unit_test/openmp/Test_OpenMP_Sparse_block_gauss_seidel.cpp
@@ -1,0 +1,2 @@
+#include<Test_OpenMP.hpp>
+#include<Test_Sparse_block_gauss_seidel.hpp>

--- a/unit_test/serial/Test_Serial_Sparse_block_gauss_seidel.cpp
+++ b/unit_test/serial/Test_Serial_Sparse_block_gauss_seidel.cpp
@@ -1,0 +1,2 @@
+#include<Test_Serial.hpp>
+#include<Test_Sparse_block_gauss_seidel.hpp>

--- a/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
@@ -1,0 +1,390 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//               KokkosKernels 0.9: Linear Algebra and Graph Kernels
+//                 Copyright 2017 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Core.hpp>
+#include "KokkosKernels_Handle.hpp"
+#include "KokkosKernels_IOUtils.hpp"
+//#include <Kokkos_Sparse_CrsMatrix.hpp>
+#include <KokkosSparse_spmv.hpp>
+#include <KokkosBlas1_dot.hpp>
+#include <KokkosBlas1_axpby.hpp>
+#include <cstdlib>
+#include <iostream>
+#include <complex>
+#include "KokkosSparse_gauss_seidel.hpp"
+
+#ifndef kokkos_complex_double
+#define kokkos_complex_double Kokkos::complex<double>
+#define kokkos_complex_float Kokkos::complex<float>
+#endif
+
+using namespace KokkosKernels;
+using namespace KokkosKernels::Experimental;
+using namespace KokkosSparse;
+using namespace KokkosSparse::Experimental;
+namespace Test {
+
+template <typename crsMat_t, typename device>
+int run_block_gauss_seidel_1(
+    crsMat_t input_mat, int block_size,
+    KokkosSparse::GSAlgorithm gs_algorithm,
+    typename crsMat_t::values_type::non_const_type x_vector,
+    typename crsMat_t::values_type::const_type y_vector,
+    bool is_symmetric_graph,
+    int apply_type = 0, // 0 for symmetric, 1 for forward, 2 for backward.
+    bool skip_symbolic = false,
+    bool skip_numeric = false
+    ){
+  typedef typename crsMat_t::StaticCrsGraphType graph_t;
+  typedef typename graph_t::row_map_type lno_view_t;
+  typedef typename graph_t::entries_type   lno_nnz_view_t;
+  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
+
+
+
+  typedef typename lno_view_t::value_type size_type;
+  typedef typename lno_nnz_view_t::value_type lno_t;
+  typedef typename scalar_view_t::value_type scalar_t;
+
+  typedef KokkosKernelsHandle
+      <size_type,lno_t, scalar_t,
+      typename device::execution_space, typename device::memory_space,typename device::memory_space > KernelHandle;
+
+
+
+  KernelHandle kh;
+  kh.set_team_work_size(16);
+  kh.set_dynamic_scheduling(true);
+  kh.create_gs_handle(gs_algorithm);
+
+
+  const size_t num_rows_1 = input_mat.numRows();
+  const size_t num_cols_1 = input_mat.numCols();
+  //std::cout << "num_rows_1:" << num_rows_1 << " num_cols_1:" << num_cols_1 << std::endl;
+  const int apply_count = 100;
+
+  if (!skip_symbolic){
+	  block_gauss_seidel_symbolic
+      (&kh, num_rows_1, num_cols_1, block_size, input_mat.graph.row_map, input_mat.graph.entries, is_symmetric_graph);
+  }
+
+  if (!skip_numeric){
+	  block_gauss_seidel_numeric
+    (&kh, num_rows_1, num_cols_1, block_size, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, is_symmetric_graph);
+  }
+
+  switch (apply_type){
+  case 0:
+    symmetric_block_gauss_seidel_apply
+    (&kh, num_rows_1, num_cols_1, block_size, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, apply_count);
+    break;
+  case 1:
+    forward_sweep_block_gauss_seidel_apply
+    (&kh, num_rows_1, num_cols_1, block_size, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, apply_count);
+    break;
+  case 2:
+    backward_sweep_block_gauss_seidel_apply
+    (&kh, num_rows_1, num_cols_1, block_size, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, apply_count);
+    break;
+  default:
+    symmetric_block_gauss_seidel_apply
+    (&kh, num_rows_1, num_cols_1, block_size, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, apply_count);
+    break;
+  }
+
+
+  kh.destroy_gs_handle();
+  return 0;
+}
+
+template<typename scalar_view_t>
+scalar_view_t create_x_vector(size_t nv, double max_value = 10.0){
+  scalar_view_t kok_x ("X", nv);
+
+
+  typename scalar_view_t::HostMirror h_x =  Kokkos::create_mirror_view (kok_x);
+
+
+  for (size_t i = 0; i < nv; ++i){
+    typename scalar_view_t::value_type r =
+        static_cast <typename scalar_view_t::value_type> (rand()) /
+        static_cast <typename scalar_view_t::value_type> (RAND_MAX / max_value);
+    h_x(i) = r;
+    //h_x(i) = 1;
+  }
+  Kokkos::deep_copy (kok_x, h_x);
+
+
+  return kok_x;
+}
+template <typename crsMat_t, typename vector_t>
+vector_t create_y_vector(crsMat_t crsMat, vector_t x_vector){
+  vector_t y_vector ("Y VECTOR", crsMat.numRows());
+  KokkosSparse::spmv("N", 1, crsMat, x_vector, 1, y_vector);
+  return y_vector;
+}
+
+}
+
+template <typename scalar_t, typename lno_t, typename size_type, typename device>
+void test_block_gauss_seidel(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_variance) {
+
+  using namespace Test;
+  srand(245);
+  typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type> crsMat_t;
+
+  typedef typename crsMat_t::StaticCrsGraphType graph_t;
+  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
+  typedef typename crsMat_t::StaticCrsGraphType::row_map_type::non_const_type lno_view_t;
+  typedef typename crsMat_t::StaticCrsGraphType::entries_type::non_const_type lno_nnz_view_t;
+
+
+  lno_t numCols = numRows;
+  crsMat_t crsmat = KokkosKernels::Impl::kk_generate_diagonally_dominant_sparse_matrix<crsMat_t>(numRows,numCols,nnz,row_size_variance, bandwidth);
+
+
+  lno_view_t pf_rm;
+  lno_nnz_view_t pf_e;
+  scalar_view_t pf_v;
+  size_t out_r, out_c;
+  int block_size = 7;
+
+  //this makes consecutive 5 rows to have same columns.
+  //it will add scalar 0's for those entries that does not exists.
+  //the result is still a point crs matrix.
+  KokkosKernels::Impl::kk_create_blockcrs_formated_point_crsmatrix(
+		  block_size , crsmat.numRows(), crsmat.numCols(),
+		  crsmat.graph.row_map, crsmat.graph.entries, crsmat.values,
+		  out_r, out_c,
+		  pf_rm, pf_e, pf_v);
+  graph_t static_graph2 (pf_e, pf_rm);
+  crsMat_t crsmat2("CrsMatrix2", out_c, pf_v, static_graph2);
+
+  lno_view_t bf_rm;
+  lno_nnz_view_t bf_e;
+  scalar_view_t bf_v;
+  size_t but_r, but_c;
+
+  //this converts the previous generated matrix to block crs matrix.
+  KokkosKernels::Impl::kk_create_blockcrs_from_blockcrs_formatted_point_crs(
+		  block_size , out_r, out_c,
+		  pf_rm, pf_e, pf_v,
+		  but_r, but_c,
+		  bf_rm, bf_e, bf_v);
+  graph_t static_graph (bf_e, bf_rm);
+  crsMat_t input_mat("CrsMatrix", but_c, bf_v, static_graph);
+
+  lno_t nv = ((crsmat2.numRows() / block_size)+1) * block_size;
+
+
+  //scalar_view_t solution_x ("sol", nv);
+  //Kokkos::Random_XorShift64_Pool<ExecutionSpace> g(1931);
+  //Kokkos::fill_random(solution_x,g,Kokkos::Random_XorShift64_Pool<ExecutionSpace>::generator_type::MAX_URAND);
+  //values_view_t kok_x_original = create_x_vector<values_view_t>(((nv /5) + 1) * 5, MAXVAL);
+
+  const scalar_view_t solution_x = create_x_vector<scalar_view_t>(nv);
+  scalar_view_t y_vector = create_y_vector(crsmat2, solution_x);
+#ifdef gauss_seidel_testmore
+  GSAlgorithm gs_algorithms[] ={GS_DEFAULT, GS_TEAM, GS_PERMUTED};
+  int apply_count = 3;
+  for (int ii = 0; ii < 3; ++ii){
+#else
+  int apply_count = 1;
+  GSAlgorithm gs_algorithms[] ={GS_DEFAULT};
+  for (int ii = 0; ii < 1; ++ii){
+#endif
+    GSAlgorithm gs_algorithm = gs_algorithms[ii];
+    scalar_view_t x_vector ("x vector", nv);
+    const scalar_t alpha = 1.0;
+    KokkosBlas::axpby(alpha, solution_x, -alpha, x_vector);
+    scalar_t dot_product = KokkosBlas::dot( x_vector , x_vector );
+    typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;
+    mag_t initial_norm_res = Kokkos::Details::ArithTraits<scalar_t>::abs (dot_product);
+    initial_norm_res  = Kokkos::Details::ArithTraits<mag_t>::sqrt( initial_norm_res );
+    Kokkos::deep_copy (x_vector , 0);
+
+    //bool is_symmetric_graph = false;
+    //int apply_type = 0;
+    //bool skip_symbolic = false;
+    //bool skip_numeric = false;
+
+
+    bool is_symmetric_graph = true;
+    {
+
+      for (int apply_type = 0; apply_type < apply_count; ++apply_type){
+        for (int skip_symbolic = 0; skip_symbolic < 2; ++skip_symbolic){
+          for (int skip_numeric = 0; skip_numeric < 2; ++skip_numeric){
+
+            Kokkos::Impl::Timer timer1;
+            //int res =
+            run_block_gauss_seidel_1<crsMat_t, device>(input_mat, block_size, gs_algorithm, x_vector, y_vector, is_symmetric_graph, apply_type, skip_symbolic, skip_numeric);
+            //double gs = timer1.seconds();
+
+            //KokkosKernels::Impl::print_1Dview(x_vector);
+            KokkosBlas::axpby(alpha, solution_x, -alpha, x_vector);
+            //KokkosKernels::Impl::print_1Dview(x_vector);
+            scalar_t result_dot_product = KokkosBlas::dot( x_vector , x_vector );
+            mag_t result_norm_res  = Kokkos::Details::ArithTraits<scalar_t>::abs( result_dot_product );
+            result_norm_res = Kokkos::Details::ArithTraits<mag_t>::sqrt(result_norm_res);
+            //std::cout << "result_norm_res:" << result_norm_res << " initial_norm_res:" << initial_norm_res << std::endl;
+            EXPECT_TRUE( (result_norm_res < initial_norm_res));
+          }
+        }
+      }
+    }
+  }
+  //device::execution_space::finalize();
+}
+
+
+
+#define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE) \
+TEST_F( TestCategory, sparse ## _ ## block_gauss_seidel ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
+	test_block_gauss_seidel<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 30, 200, 10); \
+}
+
+
+#if (defined (KOKKOSKERNELS_INST_DOUBLE) \
+ && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_INT) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(double, int, int, TestExecSpace)
+#endif
+
+#if (defined (KOKKOSKERNELS_INST_DOUBLE) \
+ && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_INT) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(double, int64_t, int, TestExecSpace)
+#endif
+
+#if (defined (KOKKOSKERNELS_INST_DOUBLE) \
+ && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(double, int, size_t, TestExecSpace)
+#endif
+
+#if (defined (KOKKOSKERNELS_INST_DOUBLE) \
+ && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(double, int64_t, size_t, TestExecSpace)
+#endif
+
+#if (defined (KOKKOSKERNELS_INST_FLOAT) \
+ && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_INT) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(float, int, int, TestExecSpace)
+#endif
+
+#if (defined (KOKKOSKERNELS_INST_FLOAT) \
+ && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_INT) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(float, int64_t, int, TestExecSpace)
+#endif
+
+#if (defined (KOKKOSKERNELS_INST_FLOAT) \
+ && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(float, int, size_t, TestExecSpace)
+#endif
+
+#if (defined (KOKKOSKERNELS_INST_FLOAT) \
+ && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(float, int64_t, size_t, TestExecSpace)
+#endif
+
+
+#if (defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
+ && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_INT) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(kokkos_complex_double, int, int, TestExecSpace)
+#endif
+
+#if (defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
+ && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_INT) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(kokkos_complex_double, int64_t, int, TestExecSpace)
+#endif
+
+#if (defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
+ && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(kokkos_complex_double, int, size_t, TestExecSpace)
+#endif
+
+#if (defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
+ && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(kokkos_complex_double, int64_t, size_t, TestExecSpace)
+#endif
+
+#if (defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
+ && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_INT) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(kokkos_complex_float, int, int, TestExecSpace)
+#endif
+
+#if (defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
+ && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_INT) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(kokkos_complex_float, int64_t, int, TestExecSpace)
+#endif
+
+#if (defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
+ && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(kokkos_complex_float, int, size_t, TestExecSpace)
+#endif
+
+#if (defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
+ && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(kokkos_complex_float, int64_t, size_t, TestExecSpace)
+#endif
+
+
+
+

--- a/unit_test/threads/Test_Threads_Sparse_block_gauss_seidel.cpp
+++ b/unit_test/threads/Test_Threads_Sparse_block_gauss_seidel.cpp
@@ -1,0 +1,2 @@
+#include<Test_Threads.hpp>
+#include<Test_Sparse_block_gauss_seidel.hpp>


### PR DESCRIPTION
Block Gauss Seidel Method is completed.

The method assumes that consecutive *block_size* rows have the same structure. It brings them into shared memory and performs a dot product for the rows that have the same structure.
    
It uses 2 level vectors. Basically, the size of the vector entries can be larger than the available shared memory.
       1) On CPUs: this is not likely to be an issue. Therefore, we increase the size of level-1 vector so that it can hold all entries.    
       2) On GPUs:
             if the required entries is larger than shared memory can hold, we allocated level-2 vector on global memory. This will use memory pools as well. Dot product is called twice first for level-1 vector, then for level-2 vector. Functor tag: BigBlockTeam
          If it fits, we only use level-1 vector. Functor tag is BlockTeam.

Unit tests will practice all cases by reducing the max allowed allocatable shared memory.