### PR TITLE
Graph: Deterministic coloring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .cproject
 .project
 *.o
+TAGS

--- a/perf_test/graph/KokkosGraph_color.cpp
+++ b/perf_test/graph/KokkosGraph_color.cpp
@@ -184,6 +184,8 @@ void run_experiment(
     kh.set_verbose(true);
   }
 
+  std::cout << "algorithm: " << algorithm << std::endl;
+
   for (int i = 0; i < repeat; ++i){
 
     switch (algorithm){

--- a/perf_test/graph/KokkosGraph_color.cpp
+++ b/perf_test/graph/KokkosGraph_color.cpp
@@ -115,6 +115,9 @@ int parse_inputs (KokkosKernels::Experiment::Parameters &params, int argc, char 
       else if ( 0 == strcasecmp( argv[i] , "COLORING_EB" ) ) {
         params.algorithm = 6;
       }
+      else if ( 0 == strcasecmp( argv[i] , "COLORING_VBD" ) ) {
+        params.algorithm = 7;
+      }
       else {
         std::cerr << "2-Unrecognized command line argument #" << i << ": " << argv[i] << std::endl ;
         print_options();
@@ -206,13 +209,20 @@ void run_experiment(
     case 6:
       kh.create_graph_coloring_handle(COLORING_EB);
       break;
+
+    case 7:
+      kh.create_graph_coloring_handle(COLORING_VBD);
+      break;
+
     default:
       kh.create_graph_coloring_handle(COLORING_DEFAULT);
 
     }
+
     graph_color_symbolic(&kh,crsGraph.numRows(), crsGraph.numCols(), crsGraph.row_map, crsGraph.entries);
 
-    std::cout <<
+
+    std::cout << std::endl <<
         "Time:" << kh.get_graph_coloring_handle()->get_overall_coloring_time() << " "
         "Num colors:" << kh.get_graph_coloring_handle()->get_num_colors() << " "
         "Num Phases:" << kh.get_graph_coloring_handle()->get_num_phases() << std::endl;

--- a/perf_test/graph/KokkosGraph_color.cpp
+++ b/perf_test/graph/KokkosGraph_color.cpp
@@ -221,7 +221,6 @@ void run_experiment(
 
     graph_color_symbolic(&kh,crsGraph.numRows(), crsGraph.numCols(), crsGraph.row_map, crsGraph.entries);
 
-
     std::cout << std::endl <<
         "Time:" << kh.get_graph_coloring_handle()->get_overall_coloring_time() << " "
         "Num colors:" << kh.get_graph_coloring_handle()->get_num_colors() << " "

--- a/perf_test/graph/KokkosGraph_color.cpp
+++ b/perf_test/graph/KokkosGraph_color.cpp
@@ -118,6 +118,9 @@ int parse_inputs (KokkosKernels::Experiment::Parameters &params, int argc, char 
       else if ( 0 == strcasecmp( argv[i] , "COLORING_VBD" ) ) {
         params.algorithm = 7;
       }
+      else if ( 0 == strcasecmp( argv[i] , "COLORING_VBDBIT" ) ) {
+        params.algorithm = 8;
+      }
       else {
         std::cerr << "2-Unrecognized command line argument #" << i << ": " << argv[i] << std::endl ;
         print_options();
@@ -214,6 +217,10 @@ void run_experiment(
 
     case 7:
       kh.create_graph_coloring_handle(COLORING_VBD);
+      break;
+
+    case 8:
+      kh.create_graph_coloring_handle(COLORING_VBDBIT);
       break;
 
     default:

--- a/src/blas/KokkosBlas1_dot.hpp
+++ b/src/blas/KokkosBlas1_dot.hpp
@@ -95,7 +95,7 @@ dot (const XVector& x, const YVector& y)
     Kokkos::HostSpace,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RVector_Internal;
 
-  typename XVector::non_const_value_type result;
+  typename XVector::non_const_value_type result = 0;
   RVector_Internal R = RVector_Internal(&result);
   XVector_Internal X = x;
   YVector_Internal Y = y;

--- a/src/blas/impl/KokkosBlas1_team_dot_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_team_dot_spec.hpp
@@ -74,7 +74,7 @@ struct TeamDot<TeamType, XV, YV, false> {
   typedef typename IPT::dot_type dot_type;
 
   static KOKKOS_INLINE_FUNCTION dot_type team_dot (const TeamType& team, const XV& X, const YV& Y) {
-    dot_type result;
+    dot_type result = 0.0; //Kokkos::Details::ArithTraits<dot_type>zero();
     int N = X.extent(0);
     Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team,N), [&] (const int& i, dot_type& val) {
       val += IPT::dot(X(i),Y(i));// X(i) * Y(i)

--- a/src/blas/impl/KokkosBlas1_team_nrm2_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_team_nrm2_spec.hpp
@@ -76,7 +76,7 @@ struct TeamNrm2<TeamType, XV, false> {
   typedef Kokkos::Details::ArithTraits<typename IPT::mag_type>   AT;
 
   static KOKKOS_INLINE_FUNCTION mag_type team_nrm2 (const TeamType& team, const XV& X) {
-    mag_type result;
+    mag_type result = 0.0; //Kokkos::Details::ArithTraits<mag_type>zero();
     int N = X.extent(0);
     Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team,N), [&] (const int& i, mag_type& val) {
       const typename IPT::mag_type tmp = IPT::norm (X(i));

--- a/src/graph/KokkosGraph_GraphColorHandle.hpp
+++ b/src/graph/KokkosGraph_GraphColorHandle.hpp
@@ -54,7 +54,8 @@ enum ColoringAlgorithm { COLORING_DEFAULT,
                          COLORING_SERIAL,
                          COLORING_VB,
                          COLORING_VBBIT,
-                         COLORING_VBCS,
+                         COLORING_VBCS,                       // Vertex Based Color Set
+                         COLORING_VBD,                        // Vertex Based Deterministic Coloring
                          COLORING_EB,
                          COLORING_SERIAL2,
                          COLORING_SPGEMM,
@@ -113,7 +114,7 @@ private:
 
   ColoringType GraphColoringType;
   //Parameters
-  ColoringAlgorithm coloring_algorithm_type; //VB, VBBIT or EB.
+  ColoringAlgorithm coloring_algorithm_type; //VB, VBBIT, VBCS, VBD or EB.
   ConflictList conflict_list_type;  // whether to use a conflict list or not, and
                                     // if using it wheter to create it with atomic or parallel prefix sum.
 
@@ -593,6 +594,7 @@ private:
     case COLORING_VB:
     case COLORING_VBBIT:
     case COLORING_VBCS:
+    case COLORING_VBD:
     case COLORING_SERIAL:
     case COLORING_SERIAL2:
     case COLORING_SPGEMM:

--- a/src/graph/KokkosGraph_GraphColorHandle.hpp
+++ b/src/graph/KokkosGraph_GraphColorHandle.hpp
@@ -51,12 +51,13 @@
 namespace KokkosGraph {
 
 enum ColoringAlgorithm { COLORING_DEFAULT,
-                         COLORING_SERIAL,
-                         COLORING_VB,
-                         COLORING_VBBIT,
+                         COLORING_SERIAL,                     // Serial Greedy Coloring
+                         COLORING_VB,                         // Vertex Based Coloring
+                         COLORING_VBBIT,                      // Vertex Based Coloring with bit array
                          COLORING_VBCS,                       // Vertex Based Color Set
                          COLORING_VBD,                        // Vertex Based Deterministic Coloring
-                         COLORING_EB,
+                         COLORING_VBDBIT,                     // Vertex Based Deterministic Coloring with bit array
+                         COLORING_EB,                         // Edge Based Coloring
                          COLORING_SERIAL2,
                          COLORING_SPGEMM,
                          COLORING_D2_MATRIX_SQUARED,          // Distance-2 Graph Coloring (Brian's Code)
@@ -67,7 +68,7 @@ enum ConflictList{COLORING_NOCONFLICT, COLORING_ATOMIC, COLORING_PPS};
 
 enum ColoringType {Distance1, Distance2};
 
-template <class size_type_, class color_t_, class lno_t_, 
+template <class size_type_, class color_t_, class lno_t_,
          //class lno_row_view_t_, class nonconst_color_view_t_, class lno_nnz_view_t_,
           class ExecutionSpace, class TemporaryMemorySpace, class PersistentMemorySpace>
 class GraphColoringHandle
@@ -595,6 +596,7 @@ private:
     case COLORING_VBBIT:
     case COLORING_VBCS:
     case COLORING_VBD:
+    case COLORING_VBDBIT:
     case COLORING_SERIAL:
     case COLORING_SERIAL2:
     case COLORING_SPGEMM:

--- a/src/graph/KokkosGraph_graph_color.hpp
+++ b/src/graph/KokkosGraph_graph_color.hpp
@@ -79,7 +79,6 @@ void graph_color_symbolic(
       <typename KernelHandle::GraphColoringHandleType, lno_row_view_t_, lno_nnz_view_t_> BaseGraphColoring;
   BaseGraphColoring *gc = NULL;
 
-
   switch (algorithm){
   case COLORING_SERIAL:
     gc = new BaseGraphColoring(num_rows, entries.extent(0), row_map, entries, gch);
@@ -98,11 +97,16 @@ void graph_color_symbolic(
     gc = new VBGraphColoring(num_rows, entries.extent(0), row_map, entries, gch);
     break;
 
+  case COLORING_VBD:
+    typedef typename Impl::GraphColor_VBD <typename KernelHandle::GraphColoringHandleType, lno_row_view_t_, lno_nnz_view_t_> VBDGraphColoring;
+    gc = new VBDGraphColoring(num_rows, entries.dimension_0(), row_map, entries, gch);
+    break;
+
   case COLORING_EB:
     typedef typename Impl::GraphColor_EB <typename KernelHandle::GraphColoringHandleType, lno_row_view_t_, lno_nnz_view_t_> EBGraphColoring;
     gc = new EBGraphColoring(num_rows, entries.extent(0),row_map, entries, gch);
     break;
- 
+
   case COLORING_SPGEMM:
   case COLORING_D2_MATRIX_SQUARED:
     //std::cout << ">>> WCMCLEN graph_color_symbolic (KokkosGraph_graph_color.hpp) [ COLORING_SPGEMM / COLORING_D2_MATRIX_SQUARED ]" << std::endl;

--- a/src/graph/KokkosGraph_graph_color.hpp
+++ b/src/graph/KokkosGraph_graph_color.hpp
@@ -98,6 +98,7 @@ void graph_color_symbolic(
     break;
 
   case COLORING_VBD:
+  case COLORING_VBDBIT:
     typedef typename Impl::GraphColor_VBD <typename KernelHandle::GraphColoringHandleType, lno_row_view_t_, lno_nnz_view_t_> VBDGraphColoring;
     gc = new VBDGraphColoring(num_rows, entries.dimension_0(), row_map, entries, gch);
     break;
@@ -157,7 +158,6 @@ void graph_color(
     lno_nnz_view_t_ entries,
     bool is_symmetric = true)
 {
-  //std::cout << ">>> WCMCLEN graph_color (KokkosGraph_graph_color.hpp)" << std::endl;
   graph_color_symbolic(handle, num_rows, num_cols, row_map, entries, is_symmetric);
 }
 

--- a/src/graph/impl/KokkosGraph_GraphColor_impl.hpp
+++ b/src/graph/impl/KokkosGraph_GraphColor_impl.hpp
@@ -2598,7 +2598,7 @@ public:
                                    break;
                                  }
                                } // Loop over banned colors
-                               delete bannedColors;
+                               delete [] bannedColors;
                              }); // Loop over current frontier
 
         // Second variant with bit array for efficiency on GPU

--- a/src/graph/impl/KokkosGraph_GraphColor_impl.hpp
+++ b/src/graph/impl/KokkosGraph_GraphColor_impl.hpp
@@ -2493,18 +2493,16 @@ public:
     }
 
     std::cout << std::endl << "Step 1: compute the score array" << std::endl;
-    std::cout << "Score: {";
     size_type maxColors = 0;
     nnz_lno_persistent_work_view_t score = nnz_lno_persistent_work_view_t(Kokkos::ViewAllocateWithoutInitializing("score"), this->nv);
     for(nnz_lno_t node = 0; node < this->nv; ++node) {
       score(node) = this->xadj(node + 1) - this->xadj(node);
       if(maxColors < (size_type) score(node)) {maxColors = score(node);}
-      std::cout << score(node) << " - ";
     }
-    std::cout << "}" << std::endl;
+    std::cout << "Score: ";
+    print1DView(this->nv, score);
 
     std::cout << std::endl << "Step 2: compute the dependency list and the initial new frontier" << std::endl;
-    std::cout << "Dependency: {";
 
     // Create the dependency list of the graph
     nnz_lno_persistent_work_view_t dependency = nnz_lno_persistent_work_view_t("dependency", this->nv);
@@ -2528,18 +2526,14 @@ public:
         newFrontier(newFrontierSize) = node;
         ++newFrontierSize;
       }
-      std::cout << dependency(node) << " - ";
     }
-    std::cout << "}" << std::endl;
+    std::cout << "Dependency: ";
+    print1DView(this->nv, dependency);
 
-    // std::cout << "newFrontier: {";
-    // for(size_type newFrontierIdx = 0; newFrontierIdx < newFrontierSize-1; ++newFrontierIdx) {
-    //   std::cout << newFrontier(newFrontierIdx) << " - ";
-    // }
-    // std::cout << newFrontier(newFrontierSize-1) << "}" << std::endl;
-
+    std::cout << std::endl << "Step 3: loop until newFrontier is empty" << std::endl;
     while(newFrontierSize > 0) {
-      printFrontier(newFrontierSize, newFrontier);
+      std::cout << "Frontier: ";
+      print1DView(newFrontierSize, newFrontier);
       // First swap fontier with newFrontier and fontierSize with newFrontierSize
       // reset newFrontierSize
       frontierSize = newFrontierSize;
@@ -2572,13 +2566,13 @@ public:
       } // Loop over current frontier
     } // while newFrontierSize
 
-    std::cout << "actually printing the colors now!" << std::endl;
-    printFrontier(this->nv, colors);
+    std::cout << "Colors: ";
+    print1DView(this->nv, colors);
 
   } // color_graph()
 
-  void printFrontier(const size_type frontierSize, const nnz_lno_temp_work_view_t frontier) {
-    std::cout << "frontier: {";
+  void print1DView(const size_type frontierSize, const nnz_lno_temp_work_view_t frontier) {
+    std::cout << "{";
     for(size_type frontierIdx = 0; frontierIdx < frontierSize-1; ++frontierIdx) {
       std::cout << frontier(frontierIdx) << " - ";
     }

--- a/unit_test/Makefile
+++ b/unit_test/Makefile
@@ -123,6 +123,7 @@ ifeq ($(KOKKOSKERNELS_INTERNAL_TEST_OPENMP), 1)
   OBJ_OPENMP += Test_OpenMP_Sparse_replaceSumIntoLonger.o
   OBJ_OPENMP += Test_OpenMP_Sparse_replaceSumInto.o
   OBJ_OPENMP += Test_OpenMP_Graph_graph_color.o
+  OBJ_OPENMP += Test_OpenMP_Graph_graph_color_deterministic.o
   OBJ_OPENMP += Test_OpenMP_Graph_graph_color_d2.o
   OBJ_OPENMP += Test_OpenMP_Common_ArithTraits.o
   OBJ_OPENMP += Test_OpenMP_Common_set_bit_count.o
@@ -225,6 +226,7 @@ ifeq ($(KOKKOSKERNELS_INTERNAL_TEST_CUDA), 1)
   OBJ_CUDA += Test_Cuda_Sparse_replaceSumIntoLonger.o
   OBJ_CUDA += Test_Cuda_Sparse_replaceSumInto.o
   OBJ_CUDA += Test_Cuda_Graph_graph_color.o
+  OBJ_CUDA += Test_Cuda_Graph_graph_color_deterministic.o
   OBJ_CUDA += Test_Cuda_Graph_graph_color_d2.o
   OBJ_CUDA += Test_Cuda_Common_ArithTraits.o
   OBJ_CUDA += Test_Cuda_Common_set_bit_count.o
@@ -320,6 +322,7 @@ ifeq ($(KOKKOSKERNELS_INTERNAL_TEST_SERIAL), 1)
   OBJ_SERIAL += Test_Serial_Sparse_replaceSumIntoLonger.o
   OBJ_SERIAL += Test_Serial_Sparse_replaceSumInto.o
   OBJ_SERIAL += Test_Serial_Graph_graph_color.o
+  OBJ_SERIAL += Test_Serial_Graph_graph_color_deterministic.o
   OBJ_SERIAL += Test_Serial_Graph_graph_color_d2.o
   OBJ_SERIAL += Test_Serial_Common_ArithTraits.o
   OBJ_SERIAL += Test_Serial_Common_set_bit_count.o
@@ -422,6 +425,7 @@ ifeq ($(KOKKOSKERNELS_INTERNAL_TEST_THREADS), 1)
   OBJ_THREADS += Test_Threads_Sparse_replaceSumInto.o
   OBJ_THREADS += Test_Threads_Sparse_CrsMatrix.o
   OBJ_THREADS += Test_Threads_Graph_graph_color.o
+  OBJ_THREADS += Test_Threads_Graph_graph_color_deterministic.o
   OBJ_THREADS += Test_Threads_Graph_graph_color_d2.o
   OBJ_THREADS += Test_Threads_Common_ArithTraits.o
   OBJ_THREADS += Test_Threads_Common_set_bit_count.o

--- a/unit_test/cuda/Test_Cuda_Graph_graph_color_deterministic.cpp
+++ b/unit_test/cuda/Test_Cuda_Graph_graph_color_deterministic.cpp
@@ -1,0 +1,2 @@
+#include<Test_Cuda.hpp>
+#include<Test_Graph_graph_color_deterministic.hpp>

--- a/unit_test/graph/Test_Graph_graph_color_deterministic.hpp
+++ b/unit_test/graph/Test_Graph_graph_color_deterministic.hpp
@@ -58,11 +58,11 @@ using namespace KokkosGraph::Experimental;
 
 namespace Test {
 template <typename crsMat_t, typename device>
-int run_graphcolor(
+int run_graphcolor_deter(
     crsMat_t input_mat,
     ColoringAlgorithm coloring_algorithm,
     size_t &num_colors,
-    typename crsMat_t::StaticCrsGraphType::entries_type::non_const_type & vertex_colors){
+    typename crsMat_t::StaticCrsGraphType::entries_type::non_const_type & vertex_colors) {
   typedef typename crsMat_t::StaticCrsGraphType graph_t;
   typedef typename graph_t::row_map_type lno_view_t;
   typedef typename graph_t::entries_type   lno_nnz_view_t;
@@ -100,7 +100,7 @@ int run_graphcolor(
 }
 
 template <typename scalar_t, typename lno_t, typename size_type, typename device>
-void test_coloring(lno_t numRows,size_type nnz, lno_t bandwidth, lno_t row_size_variance) {
+void test_coloring_deterministic(lno_t numRows, size_type nnz) {
   using namespace Test;
   typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type> crsMat_t;
   typedef typename crsMat_t::StaticCrsGraphType graph_t;
@@ -111,75 +111,76 @@ void test_coloring(lno_t numRows,size_type nnz, lno_t bandwidth, lno_t row_size_
   //typedef typename lno_view_t::non_const_value_type size_type;
 
   lno_t numCols = numRows;
-  crsMat_t input_mat = KokkosKernels::Impl::kk_generate_sparse_matrix<crsMat_t>(numRows,numCols,nnz,row_size_variance, bandwidth);
 
-  typename lno_view_t::non_const_type sym_xadj;
-  typename lno_nnz_view_t::non_const_type sym_adj;
+  typename lno_view_t::non_const_type xadj("xadj", numRows + 1);
+  typename lno_view_t::non_const_type::HostMirror h_xadj = Kokkos::create_mirror_view(xadj);
+  typename lno_nnz_view_t::non_const_type adj("adj", nnz);
+  typename lno_nnz_view_t::non_const_type::HostMirror h_adj = Kokkos::create_mirror_view(adj);
 
-  KokkosKernels::Impl::symmetrize_graph_symbolic_hashmap<lno_view_t, lno_nnz_view_t,  typename lno_view_t::non_const_type, typename lno_nnz_view_t::non_const_type, device>
-    (numRows, input_mat.graph.row_map, input_mat.graph.entries, sym_xadj, sym_adj);
-  size_type numentries = sym_adj.extent(0);
+  // Fill up the rowPtr array
+  h_xadj(0) = 0;
+  h_xadj(1) = 3; h_xadj(2) = 7; h_xadj(3) = 11; h_xadj(4) = 14; h_xadj(5) = 18; h_xadj(6) = 23;
+  h_xadj(7) = 29; h_xadj(8) = 33; h_xadj(9) = 37; h_xadj(10) = 42; h_xadj(11) = 47; h_xadj(12) = 51;
+  h_xadj(13) = 55; h_xadj(14) = 58; h_xadj(15) = 62; h_xadj(16) = 66; h_xadj(17) = 70; h_xadj(18) = 74;
+  Kokkos::deep_copy(xadj, h_xadj);
+
+  // Fill up the column indices array
+  h_adj(0)  =  0; h_adj(1)  =  1; h_adj(2)  =  4;
+  h_adj(3)  =  0; h_adj(4)  =  1; h_adj(5)  =  2; h_adj(6)  =  5;
+  h_adj(7)  =  1; h_adj(8)  =  2; h_adj(9)  =  3; h_adj(10) =  6;
+  h_adj(11) =  2; h_adj(12) =  3; h_adj(13) =  7;
+  h_adj(14) =  0; h_adj(15) =  4; h_adj(16) =  5; h_adj(17) =  8;
+  h_adj(18) =  1; h_adj(19) =  4; h_adj(20) =  5; h_adj(21) =  6; h_adj(22) =  9;
+  h_adj(23) =  2; h_adj(24) =  5; h_adj(25) =  6; h_adj(26) =  7; h_adj(27) = 10; h_adj(28) = 12;
+  h_adj(29) =  3; h_adj(30) =  6; h_adj(31) =  7; h_adj(32) = 17;
+  h_adj(33) =  4; h_adj(34) =  8; h_adj(35) =  9; h_adj(36) = 13;
+  h_adj(37) =  5; h_adj(38) =  8; h_adj(39) =  9; h_adj(40) = 10; h_adj(41) = 14;
+  h_adj(42) =  6; h_adj(43) =  9; h_adj(44) = 10; h_adj(45) = 11; h_adj(46) = 15;
+  h_adj(47) = 10; h_adj(48) = 11; h_adj(49) = 12; h_adj(50) = 16;
+  h_adj(51) =  6; h_adj(52) = 11; h_adj(53) = 12; h_adj(54) = 17;
+  h_adj(55) =  8; h_adj(56) = 13; h_adj(57) = 14;
+  h_adj(58) =  9; h_adj(59) = 13; h_adj(60) = 14; h_adj(61) = 15;
+  h_adj(62) = 10; h_adj(63) = 14; h_adj(64) = 15; h_adj(65) = 16;
+  h_adj(66) = 11; h_adj(67) = 15; h_adj(68) = 16; h_adj(69) = 17;
+  h_adj(70) =  7; h_adj(71) = 12; h_adj(72) = 16; h_adj(73) = 17;
+  Kokkos::deep_copy(adj, h_adj);
+  
+  size_type numentries = adj.extent(0);
   scalar_view_t newValues("vals", numentries);
 
-  graph_t static_graph (sym_adj, sym_xadj);
-  input_mat = crsMat_t("CrsMatrix", numCols, newValues, static_graph);
+  graph_t static_graph (adj, xadj);
+  crsMat_t input_mat("CrsMatrix", numCols, newValues, static_graph);
 
-  ColoringAlgorithm coloring_algorithms[] = {COLORING_DEFAULT, COLORING_SERIAL, COLORING_VB, COLORING_VBBIT, COLORING_VBCS, COLORING_EB, COLORING_VBD, COLORING_VBDBIT};
+  ColoringAlgorithm coloring_algorithms[] = {COLORING_VBD, COLORING_VBDBIT};
 
-  for (int ii = 0; ii < 8; ++ii){
+  for (int ii = 0; ii < 2; ++ii){
     ColoringAlgorithm coloring_algorithm = coloring_algorithms[ii];
     color_view_t vector_colors;
     size_t num_colors;
 
 
     Kokkos::Impl::Timer timer1;
-    crsMat_t output_mat;
-    int res = run_graphcolor<crsMat_t, device>(input_mat, coloring_algorithm, num_colors, vector_colors);
-    //double coloring_time = timer1.seconds();
+    int res = run_graphcolor_deter<crsMat_t, device>(input_mat, coloring_algorithm, num_colors, vector_colors);
     EXPECT_TRUE( (res == 0));
 
+    std::cout << "num_colors=" << num_colors << std::endl;
+    EXPECT_TRUE( (num_colors == 2));
 
-    const lno_t num_rows_1 = input_mat.numRows();
-    const lno_t num_cols_1 = input_mat.numCols();
-    lno_t num_conflict = KokkosKernels::Impl::kk_is_d1_coloring_valid
-        <lno_view_t,lno_nnz_view_t, color_view_t, typename device::execution_space>
-    (num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, vector_colors);
-
-    lno_t conf = 0;
-    {
-      //also check the correctness of the validation code :)
-      typename lno_view_t::HostMirror hrm = Kokkos::create_mirror_view (input_mat.graph.row_map);
-      typename lno_nnz_view_t::HostMirror hentries = Kokkos::create_mirror_view (input_mat.graph.entries);
-      typename color_view_t::HostMirror hcolor = Kokkos::create_mirror_view (vector_colors);
-      Kokkos::deep_copy (hrm , input_mat.graph.row_map);
-      Kokkos::deep_copy (hentries , input_mat.graph.entries);
-      Kokkos::deep_copy (hcolor , vector_colors);
-
-      for (lno_t i = 0; i < num_rows_1; ++i){
-        const size_type b = hrm(i);
-        const size_type e = hrm(i + 1);
-        for (size_type j = b; j < e; ++j){
-          lno_t d = hentries(j);
-          if (i != d){
-            if (hcolor(d) == hcolor(i)){
-              conf++;
-            }
-          }
-        }
-      }
-    }
-    EXPECT_TRUE( (num_conflict == conf));
-
+    size_type num_conflict = 0;
+    typename color_view_t::HostMirror h_vector_colors = Kokkos::create_mirror_view(vector_colors);
+    Kokkos::deep_copy(h_vector_colors, vector_colors);
+    int exact_colors[18] = {2, 1, 2, 1, 1, 2, 1, 2, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1};
     EXPECT_TRUE( (num_conflict == 0));
-  }
   //device::execution_space::finalize();
+
+  }
 
 }
 
 #define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE) \
-TEST_F( TestCategory, graph ## _ ## graph_color ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
-  test_coloring<SCALAR,ORDINAL,OFFSET,DEVICE>(50000, 50000 * 30, 200, 10); \
-  test_coloring<SCALAR,ORDINAL,OFFSET,DEVICE>(50000, 50000 * 30, 100, 10); \
+TEST_F( TestCategory, graph ## _ ## graph_color_deterministic ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
+  test_coloring_deterministic<SCALAR,ORDINAL,OFFSET,DEVICE>(18, 74); \
+  test_coloring_deterministic<SCALAR,ORDINAL,OFFSET,DEVICE>(18, 74); \
 }
 
 #if (defined (KOKKOSKERNELS_INST_ORDINAL_INT) \

--- a/unit_test/graph/Test_Graph_graph_color_deterministic.hpp
+++ b/unit_test/graph/Test_Graph_graph_color_deterministic.hpp
@@ -163,13 +163,17 @@ void test_coloring_deterministic(lno_t numRows, size_type nnz) {
     int res = run_graphcolor_deter<crsMat_t, device>(input_mat, coloring_algorithm, num_colors, vector_colors);
     EXPECT_TRUE( (res == 0));
 
-    std::cout << "num_colors=" << num_colors << std::endl;
     EXPECT_TRUE( (num_colors == 2));
 
     size_type num_conflict = 0;
     typename color_view_t::HostMirror h_vector_colors = Kokkos::create_mirror_view(vector_colors);
     Kokkos::deep_copy(h_vector_colors, vector_colors);
     int exact_colors[18] = {2, 1, 2, 1, 1, 2, 1, 2, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1};
+
+    for(lno_t vertexIdx = 0; vertexIdx < numRows; ++vertexIdx) {
+      if(h_vector_colors(vertexIdx) != exact_colors[vertexIdx]) {++num_conflict;}
+    }
+
     EXPECT_TRUE( (num_conflict == 0));
   //device::execution_space::finalize();
 

--- a/unit_test/openmp/Test_OpenMP_Graph_graph_color_deterministic.cpp
+++ b/unit_test/openmp/Test_OpenMP_Graph_graph_color_deterministic.cpp
@@ -1,0 +1,2 @@
+#include<Test_OpenMP.hpp>
+#include<Test_Graph_graph_color_deterministic.hpp>

--- a/unit_test/serial/Test_Serial_Graph_graph_color_deterministic.cpp
+++ b/unit_test/serial/Test_Serial_Graph_graph_color_deterministic.cpp
@@ -1,0 +1,2 @@
+#include<Test_Serial.hpp>
+#include<Test_Graph_graph_color_deterministic.hpp>

--- a/unit_test/threads/Test_Threads_Graph_graph_color_deterministic.cpp
+++ b/unit_test/threads/Test_Threads_Graph_graph_color_deterministic.cpp
@@ -1,0 +1,3 @@
+#include<Test_Threads.hpp>
+#include<Test_Graph_graph_color_deterministic.hpp>
+


### PR DESCRIPTION
@srajama1 
Adding deterministic graph coloring based on dependency list.
This is a simple version that parallelizes using range policies and uses only one atomic to update `newFrontierSize`.
In a next step I am planning on switching `bannedColors` to use a bit array that will be more compact in memory.