### PR TITLE
KokkosKernels - remove is_convertible #250

### DIFF
--- a/src/batched/KokkosBatched_Util.hpp
+++ b/src/batched/KokkosBatched_Util.hpp
@@ -3,7 +3,7 @@
 
 /// \author Kyungjoo Kim (kyukim@sandia.gov)
 
-#define __KOKKOSBATCHED_PROMOTION__ 1
+//#define __KOKKOSBATCHED_PROMOTION__ 1
 
 #include <iomanip>
 #include <random>

--- a/src/batched/KokkosBatched_Vector_SIMD.hpp
+++ b/src/batched/KokkosBatched_Vector_SIMD.hpp
@@ -75,7 +75,6 @@ namespace KokkosBatched {
       }
       template<typename ArgValueType>
       KOKKOS_INLINE_FUNCTION Vector(const Vector<SIMD<ArgValueType>,vector_length> &b) {
-        static_assert(std::is_convertible<value_type,ArgValueType>::value, "input type is not convertible");
 #if defined( KOKKOS_ENABLE_PRAGMA_IVDEP )
 #pragma ivdep
 #endif
@@ -171,7 +170,6 @@ namespace KokkosBatched {
 
       template<typename ArgValueType>
       KOKKOS_INLINE_FUNCTION Vector(const Vector<SIMD<ArgValueType>,vector_length> &b) {
-        static_assert(std::is_convertible<value_type,ArgValueType>::value, "input type is not convertible");
 	auto dd = reinterpret_cast<value_type*>(&_data);
 	auto bb = reinterpret_cast<ArgValueType*>(&b._data);
 #if defined( KOKKOS_ENABLE_PRAGMA_IVDEP )
@@ -262,7 +260,6 @@ namespace KokkosBatched {
 //       }
       template<typename ArgValueType>
       KOKKOS_INLINE_FUNCTION Vector(const Vector<SIMD<ArgValueType>,vector_length> &b) {
-        static_assert(std::is_convertible<value_type,ArgValueType>::value, "input type is not convertible");
 	auto dd = reinterpret_cast<value_type*>(&_data);
 	auto bb = reinterpret_cast<ArgValueType*>(&b._data);
 #if defined( KOKKOS_ENABLE_PRAGMA_IVDEP )
@@ -353,7 +350,6 @@ namespace KokkosBatched {
       }
       template<typename ArgValueType>
       KOKKOS_INLINE_FUNCTION Vector(const Vector<SIMD<ArgValueType>,vector_length> &b) {
-        static_assert(std::is_convertible<value_type,ArgValueType>::value, "input type is not convertible");
 	auto dd = reinterpret_cast<value_type*>(&_data);
 	auto bb = reinterpret_cast<ArgValueType*>(&b._data);
 #if defined( KOKKOS_ENABLE_PRAGMA_IVDEP )
@@ -449,7 +445,6 @@ namespace KokkosBatched {
       }
       template<typename ArgValueType>
       KOKKOS_INLINE_FUNCTION Vector(const Vector<SIMD<ArgValueType>,vector_length> &b) {
-        static_assert(std::is_convertible<value_type,ArgValueType>::value, "input type is not convertible");
 	auto dd = reinterpret_cast<value_type*>(&_data);
 	auto bb = reinterpret_cast<value_type*>(&b._data);
 #if defined( KOKKOS_ENABLE_PRAGMA_IVDEP )

--- a/src/batched/KokkosBatched_Vector_SIMD_Misc.hpp
+++ b/src/batched/KokkosBatched_Vector_SIMD_Misc.hpp
@@ -9,7 +9,8 @@ namespace KokkosBatched {
   namespace Experimental {
 
 #define KOKKOSKERNELS_SIMD_MISC_RETURN_TYPE(T,l) Vector< SIMD< T >, l >
-#define KOKKOSKERNELS_SIMD_MISC_CONVERTIBLE_RETURN_VOID_TYPE(T0,T1,T2,l) typename std::enable_if<std::is_convertible< T0 , T1 >::value && std::is_convertible< T0 , T2 >::value, void >::type
+#define KOKKOSKERNELS_SIMD_MISC_CONVERTIBLE_RETURN_VOID_TYPE(T0,T1,T2,l) void
+    //typename std::enable_if<std::is_convertible< T1 , T0 >::value && std::is_convertible< T2 , T0 >::value, void >::type
 
     // scalar, scalar
 

--- a/src/batched/KokkosBatched_Vector_SIMD_Relation.hpp
+++ b/src/batched/KokkosBatched_Vector_SIMD_Relation.hpp
@@ -15,7 +15,6 @@ namespace KokkosBatched {
     template<typename T1, typename T2, int l>                           \
     inline                                                              \
     const Vector<SIMD<bool>,l> operator op (const Vector<SIMD<T1>,l> &a, const Vector<SIMD<T2>,l> &b) { \
-      static_assert(std::is_convertible<T1,T2>::value, "value types must be convertible"); \
       Vector<SIMD<bool>,l> r_val;                                       \
       for (int i=0;i<l;++i)                                             \
         r_val[i] = a[i] op b[i];                                        \
@@ -35,7 +34,6 @@ namespace KokkosBatched {
     template<typename T1, typename T2, int l>                           \
     inline                                                              \
     const Vector<SIMD<bool>,l> operator op (const Vector<SIMD<T1>,l> &a, const T2 &b) { \
-      static_assert(std::is_convertible<T1,T2>::value, "value types must be convertible"); \
       Vector<SIMD<bool>,l> r_val;                                       \
       for (int i=0;i<l;++i)                                             \
         r_val[i] = a[i] op b;                                           \
@@ -55,7 +53,6 @@ namespace KokkosBatched {
     template<typename T1, typename T2, int l>                           \
     inline                                                              \
     const Vector<SIMD<bool>,l> operator op (const T1 &a, const Vector<SIMD<T2>,l> &b) { \
-      static_assert(std::is_convertible<T1,T2>::value, "value types must be convertible"); \
       Vector<SIMD<bool>,l> r_val;                                       \
       for (int i=0;i<l;++i)                                             \
         r_val[i] = a op b[i];                                           \


### PR DESCRIPTION
  To assert is_convertible, it needs over-riding for complex variables and overriding std::is_convertible is forbidden by the language. So, we relax the condition and remove is_convertible. 