### PR TITLE
MT Gauss-Seidel fixups

### DIFF
--- a/src/sparse/KokkosSparse_gauss_seidel.hpp
+++ b/src/sparse/KokkosSparse_gauss_seidel.hpp
@@ -421,6 +421,7 @@ namespace KokkosSparse{
                                             y_scalar_view_t y_rhs_input_vec,
                                             bool init_zero_x_vector = false,
                                             bool update_y_vector = true,
+                                            typename KernelHandle::nnz_scalar_t omega = Kokkos::Details::ArithTraits<typename KernelHandle::nnz_scalar_t>::one(),
                                             int numIter = 1){
       handle->get_gs_handle()->set_block_size(block_size);
       symmetric_gauss_seidel_apply(handle,num_rows,num_cols,
@@ -431,6 +432,7 @@ namespace KokkosSparse{
                                    y_rhs_input_vec,
                                    init_zero_x_vector,
                                    update_y_vector,
+                                   omega,
                                    numIter);
     }
     template <class KernelHandle,

--- a/src/sparse/KokkosSparse_gauss_seidel.hpp
+++ b/src/sparse/KokkosSparse_gauss_seidel.hpp
@@ -49,689 +49,689 @@
 
 namespace KokkosSparse{
 
-namespace Experimental{
+  namespace Experimental{
 
-  template <typename KernelHandle, typename lno_row_view_t_, typename lno_nnz_view_t_>
-  void gauss_seidel_symbolic(
-      KernelHandle *handle,
-      typename KernelHandle::const_nnz_lno_t num_rows,
-      typename KernelHandle::const_nnz_lno_t num_cols,
-      lno_row_view_t_ row_map,
-      lno_nnz_view_t_ entries,
-	  bool is_graph_symmetric = true){
-
-
-
-	  static_assert (std::is_same<typename KernelHandle::const_size_type,
-			  typename lno_row_view_t_::const_value_type>::value,
-			  "KokkosSparse::gauss_seidel_symbolic: Size type of the matrix should be same as kernelHandle sizetype.");
-
-	  static_assert (std::is_same<typename KernelHandle::const_nnz_lno_t,
-			  typename lno_nnz_view_t_::const_value_type>::value,
-			  "KokkosSparse::gauss_seidel_symbolic: lno type of the matrix should be same as kernelHandle lno_t.");
+    template <typename KernelHandle, typename lno_row_view_t_, typename lno_nnz_view_t_>
+    void gauss_seidel_symbolic(
+                               KernelHandle *handle,
+                               typename KernelHandle::const_nnz_lno_t num_rows,
+                               typename KernelHandle::const_nnz_lno_t num_cols,
+                               lno_row_view_t_ row_map,
+                               lno_nnz_view_t_ entries,
+                               bool is_graph_symmetric = true){
 
 
-	  typedef typename KernelHandle::const_size_type c_size_t;
-	  typedef typename KernelHandle::const_nnz_lno_t c_lno_t;
-	  typedef typename KernelHandle::const_nnz_scalar_t c_scalar_t;
 
-	  typedef typename KernelHandle::HandleExecSpace c_exec_t;
-	  typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
-	  typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
+      static_assert (std::is_same<typename KernelHandle::const_size_type,
+                     typename lno_row_view_t_::const_value_type>::value,
+                     "KokkosSparse::gauss_seidel_symbolic: Size type of the matrix should be same as kernelHandle sizetype.");
 
-	  typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
-	  //const_handle_type tmp_handle = *handle;
-	  const_handle_type tmp_handle (*handle);
-
-	  typedef Kokkos::View<
-			  typename lno_row_view_t_::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<lno_row_view_t_>::array_layout,
-			  typename lno_row_view_t_::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_row_view_t_;
-
-	  typedef Kokkos::View<
-			  typename lno_nnz_view_t_::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<lno_nnz_view_t_>::array_layout,
-			  typename lno_nnz_view_t_::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_nnz_view_t_;
+      static_assert (std::is_same<typename KernelHandle::const_nnz_lno_t,
+                     typename lno_nnz_view_t_::const_value_type>::value,
+                     "KokkosSparse::gauss_seidel_symbolic: lno type of the matrix should be same as kernelHandle lno_t.");
 
 
-	  //Internal_alno_row_view_t_ const_a_r  = row_map;
-	  //Internal_alno_nnz_view_t_ const_a_l  = entries;
-          Internal_alno_row_view_t_ const_a_r (row_map.data(), row_map.extent(0));
-          Internal_alno_nnz_view_t_ const_a_l (entries.data(), entries.extent(0));
+      typedef typename KernelHandle::const_size_type c_size_t;
+      typedef typename KernelHandle::const_nnz_lno_t c_lno_t;
+      typedef typename KernelHandle::const_nnz_scalar_t c_scalar_t;
 
-	  using namespace KokkosSparse::Impl;
+      typedef typename KernelHandle::HandleExecSpace c_exec_t;
+      typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
+      typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
 
-	  GAUSS_SEIDEL_SYMBOLIC<const_handle_type, Internal_alno_row_view_t_, Internal_alno_nnz_view_t_>::gauss_seidel_symbolic
-	  (&tmp_handle, num_rows, num_cols, const_a_r, const_a_l, is_graph_symmetric);
+      typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+      //const_handle_type tmp_handle = *handle;
+      const_handle_type tmp_handle (*handle);
 
+      typedef Kokkos::View<
+        typename lno_row_view_t_::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<lno_row_view_t_>::array_layout,
+        typename lno_row_view_t_::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_row_view_t_;
+
+      typedef Kokkos::View<
+        typename lno_nnz_view_t_::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<lno_nnz_view_t_>::array_layout,
+        typename lno_nnz_view_t_::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_nnz_view_t_;
+
+
+      //Internal_alno_row_view_t_ const_a_r  = row_map;
+      //Internal_alno_nnz_view_t_ const_a_l  = entries;
+      Internal_alno_row_view_t_ const_a_r (row_map.data(), row_map.extent(0));
+      Internal_alno_nnz_view_t_ const_a_l (entries.data(), entries.extent(0));
+
+      using namespace KokkosSparse::Impl;
+
+      GAUSS_SEIDEL_SYMBOLIC<const_handle_type, Internal_alno_row_view_t_, Internal_alno_nnz_view_t_>::gauss_seidel_symbolic
+        (&tmp_handle, num_rows, num_cols, const_a_r, const_a_l, is_graph_symmetric);
+
+    }
+
+    template <typename KernelHandle, typename lno_row_view_t_, typename lno_nnz_view_t_>
+    void block_gauss_seidel_symbolic(
+                                     KernelHandle *handle,
+                                     typename KernelHandle::const_nnz_lno_t num_rows,
+                                     typename KernelHandle::const_nnz_lno_t num_cols,
+                                     typename KernelHandle::const_nnz_lno_t block_size,
+                                     lno_row_view_t_ row_map,
+                                     lno_nnz_view_t_ entries,
+                                     bool is_graph_symmetric = true){
+
+
+      handle->get_gs_handle()->set_block_size(block_size);
+
+      gauss_seidel_symbolic(handle,
+                            num_rows, num_cols,
+                            row_map, entries, is_graph_symmetric);
+
+    }
+
+
+    template <typename KernelHandle,
+              typename lno_row_view_t_,
+              typename lno_nnz_view_t_,
+              typename scalar_nnz_view_t_>
+    void gauss_seidel_numeric(KernelHandle *handle,
+                              typename KernelHandle::const_nnz_lno_t num_rows,
+                              typename KernelHandle::const_nnz_lno_t num_cols,
+                              lno_row_view_t_ row_map,
+                              lno_nnz_view_t_ entries,
+                              scalar_nnz_view_t_ values,
+                              bool is_graph_symmetric = true
+                              ){
+
+      static_assert (std::is_same<typename KernelHandle::const_size_type,
+                     typename lno_row_view_t_::const_value_type>::value,
+                     "KokkosSparse::gauss_seidel_symbolic: Size type of the matrix should be same as kernelHandle sizetype.");
+
+      static_assert (std::is_same<typename KernelHandle::const_nnz_lno_t,
+                     typename lno_nnz_view_t_::const_value_type>::value,
+                     "KokkosSparse::gauss_seidel_symbolic: lno type of the matrix should be same as kernelHandle lno_t.");
+
+      static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
+                     typename scalar_nnz_view_t_::const_value_type>::value,
+                     "KokkosSparse::gauss_seidel_symbolic: scalar type of the matrix should be same as kernelHandle scalar_t.");
+
+
+      typedef typename KernelHandle::const_size_type c_size_t;
+      typedef typename KernelHandle::const_nnz_lno_t c_lno_t;
+      typedef typename KernelHandle::const_nnz_scalar_t c_scalar_t;
+
+      typedef typename KernelHandle::HandleExecSpace c_exec_t;
+      typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
+      typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
+
+      typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+      //const_handle_type tmp_handle = *handle;
+      const_handle_type tmp_handle (*handle);
+
+      typedef Kokkos::View<
+        typename lno_row_view_t_::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<lno_row_view_t_>::array_layout,
+        typename lno_row_view_t_::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_row_view_t_;
+
+      typedef Kokkos::View<
+        typename lno_nnz_view_t_::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<lno_nnz_view_t_>::array_layout,
+        typename lno_nnz_view_t_::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_nnz_view_t_;
+
+      typedef Kokkos::View<
+        typename scalar_nnz_view_t_::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<scalar_nnz_view_t_>::array_layout,
+        typename scalar_nnz_view_t_::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_ascalar_nnz_view_t_;
+
+      Internal_alno_row_view_t_ const_a_r (row_map.data(), row_map.extent(0));
+      Internal_alno_nnz_view_t_ const_a_l (entries.data(), entries.extent(0));
+      Internal_ascalar_nnz_view_t_ const_a_v (values.data(), values.extent(0));
+
+
+      using namespace KokkosSparse::Impl;
+
+      GAUSS_SEIDEL_NUMERIC<const_handle_type, Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_>::gauss_seidel_numeric
+        (&tmp_handle, num_rows, num_cols, const_a_r, const_a_l, const_a_v, is_graph_symmetric);
+    }
+
+    template <typename KernelHandle,
+              typename lno_row_view_t_,
+              typename lno_nnz_view_t_,
+              typename scalar_nnz_view_t_>
+    void gauss_seidel_numeric(KernelHandle *handle,
+                              typename KernelHandle::const_nnz_lno_t num_rows,
+                              typename KernelHandle::const_nnz_lno_t num_cols,
+                              lno_row_view_t_ row_map,
+                              lno_nnz_view_t_ entries,
+                              scalar_nnz_view_t_ values,
+                              scalar_nnz_view_t_ given_inverse_diagonal,
+                              bool is_graph_symmetric = true
+                              ){
+
+      static_assert (std::is_same<typename KernelHandle::const_size_type,
+                     typename lno_row_view_t_::const_value_type>::value,
+                     "KokkosSparse::gauss_seidel_symbolic: Size type of the matrix should be same as kernelHandle sizetype.");
+
+      static_assert (std::is_same<typename KernelHandle::const_nnz_lno_t,
+                     typename lno_nnz_view_t_::const_value_type>::value,
+                     "KokkosSparse::gauss_seidel_symbolic: lno type of the matrix should be same as kernelHandle lno_t.");
+
+      static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
+                     typename scalar_nnz_view_t_::const_value_type>::value,
+                     "KokkosSparse::gauss_seidel_symbolic: scalar type of the matrix should be same as kernelHandle scalar_t.");
+
+
+      typedef typename KernelHandle::const_size_type c_size_t;
+      typedef typename KernelHandle::const_nnz_lno_t c_lno_t;
+      typedef typename KernelHandle::const_nnz_scalar_t c_scalar_t;
+
+      typedef typename KernelHandle::HandleExecSpace c_exec_t;
+      typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
+      typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
+
+      typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+      //const_handle_type tmp_handle = *handle;
+      const_handle_type tmp_handle (*handle);
+
+      typedef Kokkos::View<
+        typename lno_row_view_t_::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<lno_row_view_t_>::array_layout,
+        typename lno_row_view_t_::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_row_view_t_;
+
+      typedef Kokkos::View<
+        typename lno_nnz_view_t_::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<lno_nnz_view_t_>::array_layout,
+        typename lno_nnz_view_t_::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_nnz_view_t_;
+
+      typedef Kokkos::View<
+        typename scalar_nnz_view_t_::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<scalar_nnz_view_t_>::array_layout,
+        typename scalar_nnz_view_t_::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_ascalar_nnz_view_t_;
+
+      Internal_alno_row_view_t_ const_a_r (row_map.data(), row_map.extent(0));
+      Internal_alno_nnz_view_t_ const_a_l (entries.data(), entries.extent(0));
+      Internal_ascalar_nnz_view_t_ const_a_v (values.data(), values.extent(0));
+      Internal_ascalar_nnz_view_t_ const_a_d (given_inverse_diagonal.data(), given_inverse_diagonal.extent(0));
+
+
+      using namespace KokkosSparse::Impl;
+
+      GAUSS_SEIDEL_NUMERIC<const_handle_type, Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_>::gauss_seidel_numeric
+        (&tmp_handle, num_rows, num_cols, const_a_r, const_a_l, const_a_v, const_a_d, is_graph_symmetric);
+    }
+
+    template <typename KernelHandle,
+              typename lno_row_view_t_,
+              typename lno_nnz_view_t_,
+              typename scalar_nnz_view_t_>
+    void block_gauss_seidel_numeric(KernelHandle *handle,
+                                    typename KernelHandle::const_nnz_lno_t num_rows,
+                                    typename KernelHandle::const_nnz_lno_t num_cols,
+                                    typename KernelHandle::const_nnz_lno_t block_size,
+                                    lno_row_view_t_ row_map,
+                                    lno_nnz_view_t_ entries,
+                                    scalar_nnz_view_t_ values,
+                                    bool is_graph_symmetric = true
+                                    ){
+      handle->get_gs_handle()->set_block_size(block_size);
+
+      gauss_seidel_numeric(handle,
+                           num_rows,num_cols,
+                           row_map, entries, values,
+                           is_graph_symmetric
+                           );
+    }
+
+    template <typename KernelHandle,
+              typename lno_row_view_t_,
+              typename lno_nnz_view_t_,
+              typename scalar_nnz_view_t_,
+              typename x_scalar_view_t,
+              typename y_scalar_view_t>
+    void symmetric_gauss_seidel_apply(KernelHandle *handle,
+                                      typename KernelHandle::const_nnz_lno_t num_rows,
+                                      typename KernelHandle::const_nnz_lno_t num_cols,
+                                      lno_row_view_t_ row_map,
+                                      lno_nnz_view_t_ entries,
+                                      scalar_nnz_view_t_ values,
+                                      x_scalar_view_t x_lhs_output_vec,
+                                      y_scalar_view_t y_rhs_input_vec,
+                                      bool init_zero_x_vector = false,
+                                      bool update_y_vector = true,
+                                      typename KernelHandle::nnz_scalar_t omega = Kokkos::Details::ArithTraits<typename KernelHandle::nnz_scalar_t>::one(),
+                                      int numIter = 1){
+
+      static_assert (std::is_same<typename KernelHandle::const_size_type,
+                     typename lno_row_view_t_::const_value_type>::value,
+                     "KokkosSparse::symmetric_gauss_seidel_apply: Size type of the matrix should be same as kernelHandle sizetype.");
+
+      static_assert (std::is_same<typename KernelHandle::const_nnz_lno_t,
+                     typename lno_nnz_view_t_::const_value_type>::value,
+                     "KokkosSparse::symmetric_gauss_seidel_apply: lno type of the matrix should be same as kernelHandle lno_t.");
+
+      static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
+                     typename scalar_nnz_view_t_::const_value_type>::value,
+                     "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the matrix should be same as kernelHandle scalar_t.");
+
+      static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
+                     typename y_scalar_view_t::const_value_type>::value,
+                     "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the y-vector should be same as kernelHandle scalar_t.");
+
+      static_assert (std::is_same<typename KernelHandle::nnz_scalar_t,
+                     typename x_scalar_view_t::value_type>::value,
+                     "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the x-vector should be same as kernelHandle non-const scalar_t.");
+
+
+
+
+      typedef typename KernelHandle::const_size_type c_size_t;
+      typedef typename KernelHandle::const_nnz_lno_t c_lno_t;
+      typedef typename KernelHandle::const_nnz_scalar_t c_scalar_t;
+
+      typedef typename KernelHandle::HandleExecSpace c_exec_t;
+      typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
+      typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
+
+      typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+      //const_handle_type tmp_handle = *handle;
+      const_handle_type tmp_handle (*handle);
+
+      typedef Kokkos::View<
+        typename lno_row_view_t_::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<lno_row_view_t_>::array_layout,
+        typename lno_row_view_t_::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_row_view_t_;
+
+      typedef Kokkos::View<
+        typename lno_nnz_view_t_::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<lno_nnz_view_t_>::array_layout,
+        typename lno_nnz_view_t_::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_nnz_view_t_;
+
+      typedef Kokkos::View<
+        typename scalar_nnz_view_t_::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<scalar_nnz_view_t_>::array_layout,
+        typename scalar_nnz_view_t_::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_ascalar_nnz_view_t_;
+
+
+      typedef Kokkos::View<
+        typename y_scalar_view_t::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<y_scalar_view_t>::array_layout,
+        typename y_scalar_view_t::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_yscalar_nnz_view_t_;
+
+      typedef Kokkos::View<
+        typename x_scalar_view_t::non_const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<x_scalar_view_t>::array_layout,
+        typename x_scalar_view_t::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_xscalar_nnz_view_t_;
+
+      /*
+
+        Internal_alno_row_view_t_ const_a_r  = row_map;
+        Internal_alno_nnz_view_t_ const_a_l  = entries;
+        Internal_ascalar_nnz_view_t_ const_a_v  = values;
+        Internal_xscalar_nnz_view_t_ nonconst_x_v = x_lhs_output_vec;
+        Internal_yscalar_nnz_view_t_ const_y_v = y_rhs_input_vec;
+      */
+
+      Internal_alno_row_view_t_ const_a_r (row_map.data(), row_map.extent(0));
+      Internal_alno_nnz_view_t_ const_a_l (entries.data(), entries.extent(0));
+      Internal_ascalar_nnz_view_t_ const_a_v (values.data(), values.extent(0));
+
+      Internal_xscalar_nnz_view_t_ nonconst_x_v (x_lhs_output_vec.data(), x_lhs_output_vec.extent(0));
+      Internal_yscalar_nnz_view_t_ const_y_v (y_rhs_input_vec.data(), y_rhs_input_vec.extent(0));
+
+      using namespace KokkosSparse::Impl;
+
+      GAUSS_SEIDEL_APPLY<const_handle_type,
+                         Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_,
+                         Internal_xscalar_nnz_view_t_, Internal_yscalar_nnz_view_t_>::gauss_seidel_apply (
+                                                                                                          &tmp_handle, num_rows, num_cols,
+                                                                                                          const_a_r, const_a_l, const_a_v,
+                                                                                                          nonconst_x_v, const_y_v,
+                                                                                                          init_zero_x_vector,
+                                                                                                          update_y_vector,
+                                                                                                          omega,
+                                                                                                          numIter, true, true);
+
+
+    }
+
+    template <typename KernelHandle,
+              typename lno_row_view_t_,
+              typename lno_nnz_view_t_,
+              typename scalar_nnz_view_t_,
+              typename x_scalar_view_t,
+              typename y_scalar_view_t>
+    void symmetric_block_gauss_seidel_apply(KernelHandle *handle,
+                                            typename KernelHandle::const_nnz_lno_t num_rows,
+                                            typename KernelHandle::const_nnz_lno_t num_cols,
+                                            typename KernelHandle::const_nnz_lno_t block_size,
+
+                                            lno_row_view_t_ row_map,
+                                            lno_nnz_view_t_ entries,
+                                            scalar_nnz_view_t_ values,
+                                            x_scalar_view_t x_lhs_output_vec,
+                                            y_scalar_view_t y_rhs_input_vec,
+                                            bool init_zero_x_vector = false,
+                                            bool update_y_vector = true,
+                                            int numIter = 1){
+      handle->get_gs_handle()->set_block_size(block_size);
+      symmetric_gauss_seidel_apply(handle,num_rows,num_cols,
+                                   row_map,
+                                   entries,
+                                   values,
+                                   x_lhs_output_vec,
+                                   y_rhs_input_vec,
+                                   init_zero_x_vector,
+                                   update_y_vector,
+                                   numIter);
+    }
+    template <class KernelHandle,
+              typename lno_row_view_t_,
+              typename lno_nnz_view_t_,
+              typename scalar_nnz_view_t_,
+              typename x_scalar_view_t, typename y_scalar_view_t>
+    void forward_sweep_gauss_seidel_apply(
+                                          KernelHandle *handle,
+                                          typename KernelHandle::const_nnz_lno_t num_rows,
+                                          typename KernelHandle::const_nnz_lno_t num_cols,
+                                          lno_row_view_t_ row_map,
+                                          lno_nnz_view_t_ entries,
+                                          scalar_nnz_view_t_ values,
+                                          x_scalar_view_t x_lhs_output_vec,
+                                          y_scalar_view_t y_rhs_input_vec,
+                                          bool init_zero_x_vector = false,
+                                          bool update_y_vector = true,
+                                          typename KernelHandle::nnz_scalar_t omega = Kokkos::Details::ArithTraits<typename KernelHandle::nnz_scalar_t>::one(),
+                                          int numIter = 1){
+
+      static_assert (std::is_same<typename KernelHandle::const_size_type,
+                     typename lno_row_view_t_::const_value_type>::value,
+                     "KokkosSparse::symmetric_gauss_seidel_apply: Size type of the matrix should be same as kernelHandle sizetype.");
+
+      static_assert (std::is_same<typename KernelHandle::const_nnz_lno_t,
+                     typename lno_nnz_view_t_::const_value_type>::value,
+                     "KokkosSparse::symmetric_gauss_seidel_apply: lno type of the matrix should be same as kernelHandle lno_t.");
+
+      static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
+                     typename scalar_nnz_view_t_::const_value_type>::value,
+                     "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the matrix should be same as kernelHandle scalar_t.");
+
+      static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
+                     typename y_scalar_view_t::const_value_type>::value,
+                     "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the y-vector should be same as kernelHandle scalar_t.");
+
+      static_assert (std::is_same<typename KernelHandle::nnz_scalar_t,
+                     typename x_scalar_view_t::value_type>::value,
+                     "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the x-vector should be same as kernelHandle non-const scalar_t.");
+
+
+
+
+      typedef typename KernelHandle::const_size_type c_size_t;
+      typedef typename KernelHandle::const_nnz_lno_t c_lno_t;
+      typedef typename KernelHandle::const_nnz_scalar_t c_scalar_t;
+
+      typedef typename KernelHandle::HandleExecSpace c_exec_t;
+      typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
+      typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
+
+      typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+      //const_handle_type tmp_handle = *handle;
+      const_handle_type tmp_handle (*handle);
+
+      typedef Kokkos::View<
+        typename lno_row_view_t_::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<lno_row_view_t_>::array_layout,
+        typename lno_row_view_t_::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_row_view_t_;
+
+      typedef Kokkos::View<
+        typename lno_nnz_view_t_::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<lno_nnz_view_t_>::array_layout,
+        typename lno_nnz_view_t_::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_nnz_view_t_;
+
+      typedef Kokkos::View<
+        typename scalar_nnz_view_t_::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<scalar_nnz_view_t_>::array_layout,
+        typename scalar_nnz_view_t_::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_ascalar_nnz_view_t_;
+
+
+      typedef Kokkos::View<
+        typename y_scalar_view_t::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<y_scalar_view_t>::array_layout,
+        typename y_scalar_view_t::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_yscalar_nnz_view_t_;
+
+      typedef Kokkos::View<
+        typename x_scalar_view_t::non_const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<x_scalar_view_t>::array_layout,
+        typename x_scalar_view_t::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_xscalar_nnz_view_t_;
+
+      /*
+        Internal_alno_row_view_t_ const_a_r  = row_map;
+        Internal_alno_nnz_view_t_ const_a_l  = entries;
+        Internal_ascalar_nnz_view_t_ const_a_v  = values;
+        Internal_xscalar_nnz_view_t_ nonconst_x_v = x_lhs_output_vec;
+        Internal_yscalar_nnz_view_t_ const_y_v = y_rhs_input_vec;
+      */
+
+      Internal_alno_row_view_t_ const_a_r (row_map.data(), row_map.extent(0));
+      Internal_alno_nnz_view_t_ const_a_l (entries.data(), entries.extent(0));
+      Internal_ascalar_nnz_view_t_ const_a_v (values.data(), values.extent(0));
+
+      Internal_xscalar_nnz_view_t_ nonconst_x_v (x_lhs_output_vec.data(), x_lhs_output_vec.extent(0));
+      Internal_yscalar_nnz_view_t_ const_y_v (y_rhs_input_vec.data(), y_rhs_input_vec.extent(0));
+
+
+
+      using namespace KokkosSparse::Impl;
+
+      GAUSS_SEIDEL_APPLY<const_handle_type,
+                         Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_,
+                         Internal_xscalar_nnz_view_t_, Internal_yscalar_nnz_view_t_>::gauss_seidel_apply(
+                                                                                                         &tmp_handle, num_rows, num_cols,
+                                                                                                         const_a_r, const_a_l, const_a_v,
+                                                                                                         nonconst_x_v, const_y_v,
+                                                                                                         init_zero_x_vector,
+                                                                                                         update_y_vector,
+                                                                                                         omega,
+                                                                                                         numIter, true, false);
+
+
+    }
+
+
+    template <typename KernelHandle,
+              typename lno_row_view_t_,
+              typename lno_nnz_view_t_,
+              typename scalar_nnz_view_t_,
+              typename x_scalar_view_t,
+              typename y_scalar_view_t>
+    void forward_sweep_block_gauss_seidel_apply(KernelHandle *handle,
+                                                typename KernelHandle::const_nnz_lno_t num_rows,
+                                                typename KernelHandle::const_nnz_lno_t num_cols,
+                                                typename KernelHandle::const_nnz_lno_t block_size,
+
+                                                lno_row_view_t_ row_map,
+                                                lno_nnz_view_t_ entries,
+                                                scalar_nnz_view_t_ values,
+                                                x_scalar_view_t x_lhs_output_vec,
+                                                y_scalar_view_t y_rhs_input_vec,
+                                                bool init_zero_x_vector = false,
+                                                bool update_y_vector = true,
+                                                typename KernelHandle::nnz_scalar_t omega = Kokkos::Details::ArithTraits<typename KernelHandle::nnz_scalar_t>::one(),
+                                                int numIter = 1){
+      handle->get_gs_handle()->set_block_size(block_size);
+      forward_sweep_gauss_seidel_apply(handle,num_rows,num_cols,
+                                       row_map,
+                                       entries,
+                                       values,
+                                       x_lhs_output_vec,
+                                       y_rhs_input_vec,
+                                       init_zero_x_vector,
+                                       update_y_vector,
+                                       omega,
+                                       numIter);
+    }
+    template <class KernelHandle,
+              typename lno_row_view_t_,
+              typename lno_nnz_view_t_,
+              typename scalar_nnz_view_t_,
+              typename x_scalar_view_t, typename y_scalar_view_t>
+    void backward_sweep_gauss_seidel_apply(
+                                           KernelHandle *handle,
+                                           typename KernelHandle::const_nnz_lno_t num_rows,
+                                           typename KernelHandle::const_nnz_lno_t num_cols,
+                                           lno_row_view_t_ row_map,
+                                           lno_nnz_view_t_ entries,
+                                           scalar_nnz_view_t_ values,
+                                           x_scalar_view_t x_lhs_output_vec,
+                                           y_scalar_view_t y_rhs_input_vec,
+                                           bool init_zero_x_vector = false,
+                                           bool update_y_vector = true,
+                                           typename KernelHandle::nnz_scalar_t omega = Kokkos::Details::ArithTraits<typename KernelHandle::nnz_scalar_t>::one(),
+                                           int numIter = 1){
+
+      static_assert (std::is_same<typename KernelHandle::const_size_type,
+                     typename lno_row_view_t_::const_value_type>::value,
+                     "KokkosSparse::symmetric_gauss_seidel_apply: Size type of the matrix should be same as kernelHandle sizetype.");
+
+      static_assert (std::is_same<typename KernelHandle::const_nnz_lno_t,
+                     typename lno_nnz_view_t_::const_value_type>::value,
+                     "KokkosSparse::symmetric_gauss_seidel_apply: lno type of the matrix should be same as kernelHandle lno_t.");
+
+      static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
+                     typename scalar_nnz_view_t_::const_value_type>::value,
+                     "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the matrix should be same as kernelHandle scalar_t.");
+
+      static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
+                     typename y_scalar_view_t::const_value_type>::value,
+                     "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the y-vector should be same as kernelHandle scalar_t.");
+
+      static_assert (std::is_same<typename KernelHandle::nnz_scalar_t,
+                     typename x_scalar_view_t::value_type>::value,
+                     "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the x-vector should be same as kernelHandle non-const scalar_t.");
+
+
+
+
+      typedef typename KernelHandle::const_size_type c_size_t;
+      typedef typename KernelHandle::const_nnz_lno_t c_lno_t;
+      typedef typename KernelHandle::const_nnz_scalar_t c_scalar_t;
+
+      typedef typename KernelHandle::HandleExecSpace c_exec_t;
+      typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
+      typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
+
+      typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+      //const_handle_type tmp_handle = *handle;
+      const_handle_type tmp_handle (*handle);
+
+      typedef Kokkos::View<
+        typename lno_row_view_t_::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<lno_row_view_t_>::array_layout,
+        typename lno_row_view_t_::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_row_view_t_;
+
+      typedef Kokkos::View<
+        typename lno_nnz_view_t_::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<lno_nnz_view_t_>::array_layout,
+        typename lno_nnz_view_t_::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_nnz_view_t_;
+
+      typedef Kokkos::View<
+        typename scalar_nnz_view_t_::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<scalar_nnz_view_t_>::array_layout,
+        typename scalar_nnz_view_t_::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_ascalar_nnz_view_t_;
+
+
+      typedef Kokkos::View<
+        typename y_scalar_view_t::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<y_scalar_view_t>::array_layout,
+        typename y_scalar_view_t::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_yscalar_nnz_view_t_;
+
+      typedef Kokkos::View<
+        typename x_scalar_view_t::non_const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<x_scalar_view_t>::array_layout,
+        typename x_scalar_view_t::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_xscalar_nnz_view_t_;
+
+      /*
+        Internal_alno_row_view_t_ const_a_r  = row_map;
+        Internal_alno_nnz_view_t_ const_a_l  = entries;
+        Internal_ascalar_nnz_view_t_ const_a_v  = values;
+        Internal_xscalar_nnz_view_t_ nonconst_x_v = x_lhs_output_vec;
+        Internal_yscalar_nnz_view_t_ const_y_v = y_rhs_input_vec;
+      */
+      Internal_alno_row_view_t_ const_a_r (row_map.data(), row_map.extent(0));
+      Internal_alno_nnz_view_t_ const_a_l (entries.data(), entries.extent(0));
+      Internal_ascalar_nnz_view_t_ const_a_v (values.data(), values.extent(0));
+
+      Internal_xscalar_nnz_view_t_ nonconst_x_v (x_lhs_output_vec.data(), x_lhs_output_vec.extent(0));
+      Internal_yscalar_nnz_view_t_ const_y_v (y_rhs_input_vec.data(), y_rhs_input_vec.extent(0));
+
+
+      using namespace KokkosSparse::Impl;
+
+      GAUSS_SEIDEL_APPLY<const_handle_type,
+                         Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_,
+                         Internal_xscalar_nnz_view_t_, Internal_yscalar_nnz_view_t_>::gauss_seidel_apply (
+                                                                                                          &tmp_handle, num_rows, num_cols,
+                                                                                                          const_a_r, const_a_l, const_a_v,
+                                                                                                          nonconst_x_v, const_y_v,
+                                                                                                          init_zero_x_vector,
+                                                                                                          update_y_vector,
+                                                                                                          omega,
+                                                                                                          numIter, false, true);
+
+
+    }
+
+    template <typename KernelHandle,
+              typename lno_row_view_t_,
+              typename lno_nnz_view_t_,
+              typename scalar_nnz_view_t_,
+              typename x_scalar_view_t,
+              typename y_scalar_view_t>
+    void backward_sweep_block_gauss_seidel_apply(KernelHandle *handle,
+                                                 typename KernelHandle::const_nnz_lno_t num_rows,
+                                                 typename KernelHandle::const_nnz_lno_t num_cols,
+                                                 typename KernelHandle::const_nnz_lno_t block_size,
+
+                                                 lno_row_view_t_ row_map,
+                                                 lno_nnz_view_t_ entries,
+                                                 scalar_nnz_view_t_ values,
+                                                 x_scalar_view_t x_lhs_output_vec,
+                                                 y_scalar_view_t y_rhs_input_vec,
+                                                 bool init_zero_x_vector = false,
+                                                 bool update_y_vector = true,
+                                                 typename KernelHandle::nnz_scalar_t omega = Kokkos::Details::ArithTraits<typename KernelHandle::nnz_scalar_t>::one(),
+                                                 int numIter = 1){
+      handle->get_gs_handle()->set_block_size(block_size);
+      backward_sweep_gauss_seidel_apply(handle,num_rows,num_cols,
+                                        row_map,
+                                        entries,
+                                        values,
+                                        x_lhs_output_vec,
+                                        y_rhs_input_vec,
+                                        init_zero_x_vector,
+                                        update_y_vector,
+                                        omega,
+                                        numIter);
+    }
   }
-
-  template <typename KernelHandle, typename lno_row_view_t_, typename lno_nnz_view_t_>
-  void block_gauss_seidel_symbolic(
-      KernelHandle *handle,
-      typename KernelHandle::const_nnz_lno_t num_rows,
-      typename KernelHandle::const_nnz_lno_t num_cols,
-	  typename KernelHandle::const_nnz_lno_t block_size,
-      lno_row_view_t_ row_map,
-      lno_nnz_view_t_ entries,
-	  bool is_graph_symmetric = true){
-
-
-	  handle->get_gs_handle()->set_block_size(block_size);
-
-	  gauss_seidel_symbolic(handle,
-			  num_rows, num_cols,
-			  row_map, entries, is_graph_symmetric);
-
-  }
-
-
-  template <typename KernelHandle,
-            typename lno_row_view_t_,
-            typename lno_nnz_view_t_,
-            typename scalar_nnz_view_t_>
-  void gauss_seidel_numeric(KernelHandle *handle,
-      typename KernelHandle::const_nnz_lno_t num_rows,
-      typename KernelHandle::const_nnz_lno_t num_cols,
-      lno_row_view_t_ row_map,
-      lno_nnz_view_t_ entries,
-      scalar_nnz_view_t_ values,
-      bool is_graph_symmetric = true
-      ){
-
-	  static_assert (std::is_same<typename KernelHandle::const_size_type,
-			  typename lno_row_view_t_::const_value_type>::value,
-			  "KokkosSparse::gauss_seidel_symbolic: Size type of the matrix should be same as kernelHandle sizetype.");
-
-	  static_assert (std::is_same<typename KernelHandle::const_nnz_lno_t,
-			  typename lno_nnz_view_t_::const_value_type>::value,
-			  "KokkosSparse::gauss_seidel_symbolic: lno type of the matrix should be same as kernelHandle lno_t.");
-
-	  static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
-	  			  typename scalar_nnz_view_t_::const_value_type>::value,
-	  			  "KokkosSparse::gauss_seidel_symbolic: scalar type of the matrix should be same as kernelHandle scalar_t.");
-
-
-	  typedef typename KernelHandle::const_size_type c_size_t;
-	  typedef typename KernelHandle::const_nnz_lno_t c_lno_t;
-	  typedef typename KernelHandle::const_nnz_scalar_t c_scalar_t;
-
-	  typedef typename KernelHandle::HandleExecSpace c_exec_t;
-	  typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
-	  typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
-
-	  typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
-	  //const_handle_type tmp_handle = *handle;
-	  const_handle_type tmp_handle (*handle);
-
-	  typedef Kokkos::View<
-			  typename lno_row_view_t_::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<lno_row_view_t_>::array_layout,
-			  typename lno_row_view_t_::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_row_view_t_;
-
-	  typedef Kokkos::View<
-			  typename lno_nnz_view_t_::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<lno_nnz_view_t_>::array_layout,
-			  typename lno_nnz_view_t_::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_nnz_view_t_;
-
-	  typedef Kokkos::View<
-			  typename scalar_nnz_view_t_::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<scalar_nnz_view_t_>::array_layout,
-			  typename scalar_nnz_view_t_::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_ascalar_nnz_view_t_;
-
-	  Internal_alno_row_view_t_ const_a_r (row_map.data(), row_map.extent(0));
-	  Internal_alno_nnz_view_t_ const_a_l (entries.data(), entries.extent(0));
-	  Internal_ascalar_nnz_view_t_ const_a_v (values.data(), values.extent(0));
-
-
-	  using namespace KokkosSparse::Impl;
-
-	  GAUSS_SEIDEL_NUMERIC<const_handle_type, Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_>::gauss_seidel_numeric
-	  	  (&tmp_handle, num_rows, num_cols, const_a_r, const_a_l, const_a_v, is_graph_symmetric);
-  }
-
-  template <typename KernelHandle,
-            typename lno_row_view_t_,
-            typename lno_nnz_view_t_,
-            typename scalar_nnz_view_t_>
-  void gauss_seidel_numeric(KernelHandle *handle,
-                            typename KernelHandle::const_nnz_lno_t num_rows,
-                            typename KernelHandle::const_nnz_lno_t num_cols,
-                            lno_row_view_t_ row_map,
-                            lno_nnz_view_t_ entries,
-                            scalar_nnz_view_t_ values,
-                            scalar_nnz_view_t_ given_inverse_diagonal,
-                            bool is_graph_symmetric = true
-      ){
-
-	  static_assert (std::is_same<typename KernelHandle::const_size_type,
-			  typename lno_row_view_t_::const_value_type>::value,
-			  "KokkosSparse::gauss_seidel_symbolic: Size type of the matrix should be same as kernelHandle sizetype.");
-
-	  static_assert (std::is_same<typename KernelHandle::const_nnz_lno_t,
-			  typename lno_nnz_view_t_::const_value_type>::value,
-			  "KokkosSparse::gauss_seidel_symbolic: lno type of the matrix should be same as kernelHandle lno_t.");
-
-	  static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
-	  			  typename scalar_nnz_view_t_::const_value_type>::value,
-	  			  "KokkosSparse::gauss_seidel_symbolic: scalar type of the matrix should be same as kernelHandle scalar_t.");
-
-
-	  typedef typename KernelHandle::const_size_type c_size_t;
-	  typedef typename KernelHandle::const_nnz_lno_t c_lno_t;
-	  typedef typename KernelHandle::const_nnz_scalar_t c_scalar_t;
-
-	  typedef typename KernelHandle::HandleExecSpace c_exec_t;
-	  typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
-	  typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
-
-	  typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
-	  //const_handle_type tmp_handle = *handle;
-	  const_handle_type tmp_handle (*handle);
-
-	  typedef Kokkos::View<
-			  typename lno_row_view_t_::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<lno_row_view_t_>::array_layout,
-			  typename lno_row_view_t_::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_row_view_t_;
-
-	  typedef Kokkos::View<
-			  typename lno_nnz_view_t_::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<lno_nnz_view_t_>::array_layout,
-			  typename lno_nnz_view_t_::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_nnz_view_t_;
-
-	  typedef Kokkos::View<
-			  typename scalar_nnz_view_t_::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<scalar_nnz_view_t_>::array_layout,
-			  typename scalar_nnz_view_t_::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_ascalar_nnz_view_t_;
-
-	  Internal_alno_row_view_t_ const_a_r (row_map.data(), row_map.extent(0));
-	  Internal_alno_nnz_view_t_ const_a_l (entries.data(), entries.extent(0));
-	  Internal_ascalar_nnz_view_t_ const_a_v (values.data(), values.extent(0));
-          Internal_ascalar_nnz_view_t_ const_a_d (given_inverse_diagonal.data(), given_inverse_diagonal.extent(0));
-
-
-	  using namespace KokkosSparse::Impl;
-
-	  GAUSS_SEIDEL_NUMERIC<const_handle_type, Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_>::gauss_seidel_numeric
-            (&tmp_handle, num_rows, num_cols, const_a_r, const_a_l, const_a_v, const_a_d, is_graph_symmetric);
-  }
-
-  template <typename KernelHandle,
-            typename lno_row_view_t_,
-            typename lno_nnz_view_t_,
-            typename scalar_nnz_view_t_>
-  void block_gauss_seidel_numeric(KernelHandle *handle,
-      typename KernelHandle::const_nnz_lno_t num_rows,
-      typename KernelHandle::const_nnz_lno_t num_cols,
-	  typename KernelHandle::const_nnz_lno_t block_size,
-      lno_row_view_t_ row_map,
-      lno_nnz_view_t_ entries,
-      scalar_nnz_view_t_ values,
-      bool is_graph_symmetric = true
-      ){
-	  handle->get_gs_handle()->set_block_size(block_size);
-
-	  gauss_seidel_numeric(handle,
-			  num_rows,num_cols,
-			  row_map, entries, values,
-			  is_graph_symmetric
-	        );
-  }
-
-  template <typename KernelHandle,
-    typename lno_row_view_t_,
-    typename lno_nnz_view_t_,
-    typename scalar_nnz_view_t_,
-    typename x_scalar_view_t,
-    typename y_scalar_view_t>
-  void symmetric_gauss_seidel_apply(KernelHandle *handle,
-      typename KernelHandle::const_nnz_lno_t num_rows,
-      typename KernelHandle::const_nnz_lno_t num_cols,
-      lno_row_view_t_ row_map,
-      lno_nnz_view_t_ entries,
-      scalar_nnz_view_t_ values,
-      x_scalar_view_t x_lhs_output_vec,
-      y_scalar_view_t y_rhs_input_vec,
-      bool init_zero_x_vector = false,
-      bool update_y_vector = true,
-      typename KernelHandle::nnz_scalar_t omega = Kokkos::Details::ArithTraits<typename KernelHandle::nnz_scalar_t>::one(),
-      int numIter = 1){
-
-	  static_assert (std::is_same<typename KernelHandle::const_size_type,
-			  typename lno_row_view_t_::const_value_type>::value,
-			  "KokkosSparse::symmetric_gauss_seidel_apply: Size type of the matrix should be same as kernelHandle sizetype.");
-
-	  static_assert (std::is_same<typename KernelHandle::const_nnz_lno_t,
-			  typename lno_nnz_view_t_::const_value_type>::value,
-			  "KokkosSparse::symmetric_gauss_seidel_apply: lno type of the matrix should be same as kernelHandle lno_t.");
-
-	  static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
-	  			  typename scalar_nnz_view_t_::const_value_type>::value,
-	  			  "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the matrix should be same as kernelHandle scalar_t.");
-
-	  static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
-	  			  typename y_scalar_view_t::const_value_type>::value,
-	  			  "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the y-vector should be same as kernelHandle scalar_t.");
-
-	  static_assert (std::is_same<typename KernelHandle::nnz_scalar_t,
-	  			  typename x_scalar_view_t::value_type>::value,
-	  			  "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the x-vector should be same as kernelHandle non-const scalar_t.");
-
-
-
-
-	  typedef typename KernelHandle::const_size_type c_size_t;
-	  typedef typename KernelHandle::const_nnz_lno_t c_lno_t;
-	  typedef typename KernelHandle::const_nnz_scalar_t c_scalar_t;
-
-	  typedef typename KernelHandle::HandleExecSpace c_exec_t;
-	  typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
-	  typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
-
-	  typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
-	  //const_handle_type tmp_handle = *handle;
-	  const_handle_type tmp_handle (*handle);
-
-	  typedef Kokkos::View<
-			  typename lno_row_view_t_::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<lno_row_view_t_>::array_layout,
-			  typename lno_row_view_t_::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_row_view_t_;
-
-	  typedef Kokkos::View<
-			  typename lno_nnz_view_t_::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<lno_nnz_view_t_>::array_layout,
-			  typename lno_nnz_view_t_::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_nnz_view_t_;
-
-	  typedef Kokkos::View<
-			  typename scalar_nnz_view_t_::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<scalar_nnz_view_t_>::array_layout,
-			  typename scalar_nnz_view_t_::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_ascalar_nnz_view_t_;
-
-
-	  typedef Kokkos::View<
-			  typename y_scalar_view_t::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<y_scalar_view_t>::array_layout,
-			  typename y_scalar_view_t::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_yscalar_nnz_view_t_;
-
-	  typedef Kokkos::View<
-			  typename x_scalar_view_t::non_const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<x_scalar_view_t>::array_layout,
-			  typename x_scalar_view_t::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_xscalar_nnz_view_t_;
-
-	  /*
-
-	  Internal_alno_row_view_t_ const_a_r  = row_map;
-	  Internal_alno_nnz_view_t_ const_a_l  = entries;
-	  Internal_ascalar_nnz_view_t_ const_a_v  = values;
-	  Internal_xscalar_nnz_view_t_ nonconst_x_v = x_lhs_output_vec;
-	  Internal_yscalar_nnz_view_t_ const_y_v = y_rhs_input_vec;
-	  */
-
-          Internal_alno_row_view_t_ const_a_r (row_map.data(), row_map.extent(0));
-          Internal_alno_nnz_view_t_ const_a_l (entries.data(), entries.extent(0));
-          Internal_ascalar_nnz_view_t_ const_a_v (values.data(), values.extent(0));
-
-          Internal_xscalar_nnz_view_t_ nonconst_x_v (x_lhs_output_vec.data(), x_lhs_output_vec.extent(0));
-          Internal_yscalar_nnz_view_t_ const_y_v (y_rhs_input_vec.data(), y_rhs_input_vec.extent(0));
-
-	  using namespace KokkosSparse::Impl;
-
-	  GAUSS_SEIDEL_APPLY<const_handle_type,
-	  Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_,
-	  Internal_xscalar_nnz_view_t_, Internal_yscalar_nnz_view_t_>::gauss_seidel_apply (
-	  		  &tmp_handle, num_rows, num_cols,
-			  const_a_r, const_a_l, const_a_v,
-			  nonconst_x_v, const_y_v,
-			  init_zero_x_vector,
-			  update_y_vector,
-                          omega,
-			  numIter, true, true);
-
-
-  }
-
-  template <typename KernelHandle,
-    typename lno_row_view_t_,
-    typename lno_nnz_view_t_,
-    typename scalar_nnz_view_t_,
-    typename x_scalar_view_t,
-    typename y_scalar_view_t>
-  void symmetric_block_gauss_seidel_apply(KernelHandle *handle,
-      typename KernelHandle::const_nnz_lno_t num_rows,
-      typename KernelHandle::const_nnz_lno_t num_cols,
-	  typename KernelHandle::const_nnz_lno_t block_size,
-
-      lno_row_view_t_ row_map,
-      lno_nnz_view_t_ entries,
-      scalar_nnz_view_t_ values,
-      x_scalar_view_t x_lhs_output_vec,
-      y_scalar_view_t y_rhs_input_vec,
-      bool init_zero_x_vector = false,
-      bool update_y_vector = true,
-      int numIter = 1){
-	  handle->get_gs_handle()->set_block_size(block_size);
-	  symmetric_gauss_seidel_apply(handle,num_rows,num_cols,
-			  row_map,
-		      entries,
-		      values,
-		      x_lhs_output_vec,
-		      y_rhs_input_vec,
-		      init_zero_x_vector,
-		      update_y_vector,
-		      numIter);
-  }
-  template <class KernelHandle,
-  typename lno_row_view_t_,
-  typename lno_nnz_view_t_,
-  typename scalar_nnz_view_t_,
-  typename x_scalar_view_t, typename y_scalar_view_t>
-  void forward_sweep_gauss_seidel_apply(
-      KernelHandle *handle,
-      typename KernelHandle::const_nnz_lno_t num_rows,
-      typename KernelHandle::const_nnz_lno_t num_cols,
-      lno_row_view_t_ row_map,
-      lno_nnz_view_t_ entries,
-      scalar_nnz_view_t_ values,
-      x_scalar_view_t x_lhs_output_vec,
-      y_scalar_view_t y_rhs_input_vec,
-      bool init_zero_x_vector = false,
-      bool update_y_vector = true,
-      typename KernelHandle::nnz_scalar_t omega = Kokkos::Details::ArithTraits<typename KernelHandle::nnz_scalar_t>::one(),
-      int numIter = 1){
-
-	  static_assert (std::is_same<typename KernelHandle::const_size_type,
-			  typename lno_row_view_t_::const_value_type>::value,
-			  "KokkosSparse::symmetric_gauss_seidel_apply: Size type of the matrix should be same as kernelHandle sizetype.");
-
-	  static_assert (std::is_same<typename KernelHandle::const_nnz_lno_t,
-			  typename lno_nnz_view_t_::const_value_type>::value,
-			  "KokkosSparse::symmetric_gauss_seidel_apply: lno type of the matrix should be same as kernelHandle lno_t.");
-
-	  static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
-	  			  typename scalar_nnz_view_t_::const_value_type>::value,
-	  			  "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the matrix should be same as kernelHandle scalar_t.");
-
-	  static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
-	  			  typename y_scalar_view_t::const_value_type>::value,
-	  			  "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the y-vector should be same as kernelHandle scalar_t.");
-
-	  static_assert (std::is_same<typename KernelHandle::nnz_scalar_t,
-	  			  typename x_scalar_view_t::value_type>::value,
-	  			  "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the x-vector should be same as kernelHandle non-const scalar_t.");
-
-
-
-
-	  typedef typename KernelHandle::const_size_type c_size_t;
-	  typedef typename KernelHandle::const_nnz_lno_t c_lno_t;
-	  typedef typename KernelHandle::const_nnz_scalar_t c_scalar_t;
-
-	  typedef typename KernelHandle::HandleExecSpace c_exec_t;
-	  typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
-	  typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
-
-	  typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
-	  //const_handle_type tmp_handle = *handle;
-	  const_handle_type tmp_handle (*handle);
-
-	  typedef Kokkos::View<
-			  typename lno_row_view_t_::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<lno_row_view_t_>::array_layout,
-			  typename lno_row_view_t_::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_row_view_t_;
-
-	  typedef Kokkos::View<
-			  typename lno_nnz_view_t_::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<lno_nnz_view_t_>::array_layout,
-			  typename lno_nnz_view_t_::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_nnz_view_t_;
-
-	  typedef Kokkos::View<
-			  typename scalar_nnz_view_t_::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<scalar_nnz_view_t_>::array_layout,
-			  typename scalar_nnz_view_t_::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_ascalar_nnz_view_t_;
-
-
-	  typedef Kokkos::View<
-			  typename y_scalar_view_t::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<y_scalar_view_t>::array_layout,
-			  typename y_scalar_view_t::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_yscalar_nnz_view_t_;
-
-	  typedef Kokkos::View<
-			  typename x_scalar_view_t::non_const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<x_scalar_view_t>::array_layout,
-			  typename x_scalar_view_t::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_xscalar_nnz_view_t_;
-
-	  /*
-	  Internal_alno_row_view_t_ const_a_r  = row_map;
-	  Internal_alno_nnz_view_t_ const_a_l  = entries;
-	  Internal_ascalar_nnz_view_t_ const_a_v  = values;
-	  Internal_xscalar_nnz_view_t_ nonconst_x_v = x_lhs_output_vec;
-	  Internal_yscalar_nnz_view_t_ const_y_v = y_rhs_input_vec;
-	  */
-
-          Internal_alno_row_view_t_ const_a_r (row_map.data(), row_map.extent(0));
-          Internal_alno_nnz_view_t_ const_a_l (entries.data(), entries.extent(0));
-          Internal_ascalar_nnz_view_t_ const_a_v (values.data(), values.extent(0));
-
-          Internal_xscalar_nnz_view_t_ nonconst_x_v (x_lhs_output_vec.data(), x_lhs_output_vec.extent(0));
-          Internal_yscalar_nnz_view_t_ const_y_v (y_rhs_input_vec.data(), y_rhs_input_vec.extent(0));
-
-
-
-	  using namespace KokkosSparse::Impl;
-
-	  GAUSS_SEIDEL_APPLY<const_handle_type,
-	  Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_,
-	  Internal_xscalar_nnz_view_t_, Internal_yscalar_nnz_view_t_>::gauss_seidel_apply(
-	  		  &tmp_handle, num_rows, num_cols,
-			  const_a_r, const_a_l, const_a_v,
-			  nonconst_x_v, const_y_v,
-			  init_zero_x_vector,
-			  update_y_vector,
-                          omega,
-			  numIter, true, false);
-
-
-  }
-
-
-  template <typename KernelHandle,
-    typename lno_row_view_t_,
-    typename lno_nnz_view_t_,
-    typename scalar_nnz_view_t_,
-    typename x_scalar_view_t,
-    typename y_scalar_view_t>
-  void forward_sweep_block_gauss_seidel_apply(KernelHandle *handle,
-      typename KernelHandle::const_nnz_lno_t num_rows,
-      typename KernelHandle::const_nnz_lno_t num_cols,
-	  typename KernelHandle::const_nnz_lno_t block_size,
-
-      lno_row_view_t_ row_map,
-      lno_nnz_view_t_ entries,
-      scalar_nnz_view_t_ values,
-      x_scalar_view_t x_lhs_output_vec,
-      y_scalar_view_t y_rhs_input_vec,
-      bool init_zero_x_vector = false,
-      bool update_y_vector = true,
-      typename KernelHandle::nnz_scalar_t omega = Kokkos::Details::ArithTraits<typename KernelHandle::nnz_scalar_t>::one(),
-      int numIter = 1){
-	  handle->get_gs_handle()->set_block_size(block_size);
-	  forward_sweep_gauss_seidel_apply(handle,num_rows,num_cols,
-			  row_map,
-		      entries,
-		      values,
-		      x_lhs_output_vec,
-		      y_rhs_input_vec,
-		      init_zero_x_vector,
-		      update_y_vector,
-                      omega,
-		      numIter);
-  }
-  template <class KernelHandle,
-  typename lno_row_view_t_,
-  typename lno_nnz_view_t_,
-  typename scalar_nnz_view_t_,
-  typename x_scalar_view_t, typename y_scalar_view_t>
-  void backward_sweep_gauss_seidel_apply(
-      KernelHandle *handle,
-      typename KernelHandle::const_nnz_lno_t num_rows,
-      typename KernelHandle::const_nnz_lno_t num_cols,
-      lno_row_view_t_ row_map,
-      lno_nnz_view_t_ entries,
-      scalar_nnz_view_t_ values,
-      x_scalar_view_t x_lhs_output_vec,
-      y_scalar_view_t y_rhs_input_vec,
-      bool init_zero_x_vector = false,
-      bool update_y_vector = true,
-      typename KernelHandle::nnz_scalar_t omega = Kokkos::Details::ArithTraits<typename KernelHandle::nnz_scalar_t>::one(),
-      int numIter = 1){
-
-	  static_assert (std::is_same<typename KernelHandle::const_size_type,
-			  typename lno_row_view_t_::const_value_type>::value,
-			  "KokkosSparse::symmetric_gauss_seidel_apply: Size type of the matrix should be same as kernelHandle sizetype.");
-
-	  static_assert (std::is_same<typename KernelHandle::const_nnz_lno_t,
-			  typename lno_nnz_view_t_::const_value_type>::value,
-			  "KokkosSparse::symmetric_gauss_seidel_apply: lno type of the matrix should be same as kernelHandle lno_t.");
-
-	  static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
-	  			  typename scalar_nnz_view_t_::const_value_type>::value,
-	  			  "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the matrix should be same as kernelHandle scalar_t.");
-
-	  static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
-	  			  typename y_scalar_view_t::const_value_type>::value,
-	  			  "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the y-vector should be same as kernelHandle scalar_t.");
-
-	  static_assert (std::is_same<typename KernelHandle::nnz_scalar_t,
-	  			  typename x_scalar_view_t::value_type>::value,
-	  			  "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the x-vector should be same as kernelHandle non-const scalar_t.");
-
-
-
-
-	  typedef typename KernelHandle::const_size_type c_size_t;
-	  typedef typename KernelHandle::const_nnz_lno_t c_lno_t;
-	  typedef typename KernelHandle::const_nnz_scalar_t c_scalar_t;
-
-	  typedef typename KernelHandle::HandleExecSpace c_exec_t;
-	  typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
-	  typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
-
-	  typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
-	  //const_handle_type tmp_handle = *handle;
-	  const_handle_type tmp_handle (*handle);
-
-	  typedef Kokkos::View<
-			  typename lno_row_view_t_::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<lno_row_view_t_>::array_layout,
-			  typename lno_row_view_t_::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_row_view_t_;
-
-	  typedef Kokkos::View<
-			  typename lno_nnz_view_t_::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<lno_nnz_view_t_>::array_layout,
-			  typename lno_nnz_view_t_::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_alno_nnz_view_t_;
-
-	  typedef Kokkos::View<
-			  typename scalar_nnz_view_t_::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<scalar_nnz_view_t_>::array_layout,
-			  typename scalar_nnz_view_t_::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_ascalar_nnz_view_t_;
-
-
-	  typedef Kokkos::View<
-			  typename y_scalar_view_t::const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<y_scalar_view_t>::array_layout,
-			  typename y_scalar_view_t::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_yscalar_nnz_view_t_;
-
-	  typedef Kokkos::View<
-			  typename x_scalar_view_t::non_const_value_type*,
-			  typename KokkosKernels::Impl::GetUnifiedLayout<x_scalar_view_t>::array_layout,
-			  typename x_scalar_view_t::device_type,
-			  Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_xscalar_nnz_view_t_;
-
-	  /*
-	  Internal_alno_row_view_t_ const_a_r  = row_map;
-	  Internal_alno_nnz_view_t_ const_a_l  = entries;
-	  Internal_ascalar_nnz_view_t_ const_a_v  = values;
-	  Internal_xscalar_nnz_view_t_ nonconst_x_v = x_lhs_output_vec;
-	  Internal_yscalar_nnz_view_t_ const_y_v = y_rhs_input_vec;
-	  */
-          Internal_alno_row_view_t_ const_a_r (row_map.data(), row_map.extent(0));
-          Internal_alno_nnz_view_t_ const_a_l (entries.data(), entries.extent(0));
-          Internal_ascalar_nnz_view_t_ const_a_v (values.data(), values.extent(0));
-
-          Internal_xscalar_nnz_view_t_ nonconst_x_v (x_lhs_output_vec.data(), x_lhs_output_vec.extent(0));
-          Internal_yscalar_nnz_view_t_ const_y_v (y_rhs_input_vec.data(), y_rhs_input_vec.extent(0));
-
-
-	  using namespace KokkosSparse::Impl;
-
-	  GAUSS_SEIDEL_APPLY<const_handle_type,
-	  Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_,
-	  Internal_xscalar_nnz_view_t_, Internal_yscalar_nnz_view_t_>::gauss_seidel_apply (
-	  		  &tmp_handle, num_rows, num_cols,
-			  const_a_r, const_a_l, const_a_v,
-			  nonconst_x_v, const_y_v,
-			  init_zero_x_vector,
-			  update_y_vector,
-                          omega,
-			  numIter, false, true);
-
-
-  }
-
-  template <typename KernelHandle,
-    typename lno_row_view_t_,
-    typename lno_nnz_view_t_,
-    typename scalar_nnz_view_t_,
-    typename x_scalar_view_t,
-    typename y_scalar_view_t>
-  void backward_sweep_block_gauss_seidel_apply(KernelHandle *handle,
-      typename KernelHandle::const_nnz_lno_t num_rows,
-      typename KernelHandle::const_nnz_lno_t num_cols,
-	  typename KernelHandle::const_nnz_lno_t block_size,
-
-      lno_row_view_t_ row_map,
-      lno_nnz_view_t_ entries,
-      scalar_nnz_view_t_ values,
-      x_scalar_view_t x_lhs_output_vec,
-      y_scalar_view_t y_rhs_input_vec,
-      bool init_zero_x_vector = false,
-      bool update_y_vector = true,
-      typename KernelHandle::nnz_scalar_t omega = Kokkos::Details::ArithTraits<typename KernelHandle::nnz_scalar_t>::one(),
-      int numIter = 1){
-	  handle->get_gs_handle()->set_block_size(block_size);
-	  backward_sweep_gauss_seidel_apply(handle,num_rows,num_cols,
-			  row_map,
-		      entries,
-		      values,
-		      x_lhs_output_vec,
-		      y_rhs_input_vec,
-		      init_zero_x_vector,
-		      update_y_vector,
-                      omega,
-		      numIter);
-  }
-}
 }
 #endif

--- a/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
+++ b/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
@@ -50,292 +50,292 @@
 
 namespace KokkosSparse{
 
-enum GSAlgorithm{GS_DEFAULT, GS_PERMUTED, GS_TEAM};
+  enum GSAlgorithm{GS_DEFAULT, GS_PERMUTED, GS_TEAM};
 
-template <class size_type_, class lno_t_, class scalar_t_,
-          class ExecutionSpace,
-          class TemporaryMemorySpace,
-          class PersistentMemorySpace>
-class GaussSeidelHandle{
-public:
-  typedef ExecutionSpace HandleExecSpace;
-  typedef TemporaryMemorySpace HandleTempMemorySpace;
-  typedef PersistentMemorySpace HandlePersistentMemorySpace;
+  template <class size_type_, class lno_t_, class scalar_t_,
+            class ExecutionSpace,
+            class TemporaryMemorySpace,
+            class PersistentMemorySpace>
+  class GaussSeidelHandle{
+  public:
+    typedef ExecutionSpace HandleExecSpace;
+    typedef TemporaryMemorySpace HandleTempMemorySpace;
+    typedef PersistentMemorySpace HandlePersistentMemorySpace;
 
-  typedef typename std::remove_const<size_type_>::type  size_type;
-  typedef const size_type const_size_type;
+    typedef typename std::remove_const<size_type_>::type  size_type;
+    typedef const size_type const_size_type;
 
-  typedef typename std::remove_const<lno_t_>::type  nnz_lno_t;
-  typedef const nnz_lno_t const_nnz_lno_t;
+    typedef typename std::remove_const<lno_t_>::type  nnz_lno_t;
+    typedef const nnz_lno_t const_nnz_lno_t;
 
-  typedef typename std::remove_const<scalar_t_>::type  nnz_scalar_t;
-  typedef const nnz_scalar_t const_nnz_scalar_t;
-
-
-  typedef typename Kokkos::View<size_type *, HandleTempMemorySpace> row_lno_temp_work_view_t;
-  typedef typename Kokkos::View<size_type *, HandlePersistentMemorySpace> row_lno_persistent_work_view_t;
-  typedef typename row_lno_persistent_work_view_t::HostMirror row_lno_persistent_work_host_view_t; //Host view type
-
-  typedef typename Kokkos::View<nnz_scalar_t *, HandleTempMemorySpace> scalar_temp_work_view_t;
-  typedef typename Kokkos::View<nnz_scalar_t *, HandlePersistentMemorySpace> scalar_persistent_work_view_t;
-  typedef typename scalar_persistent_work_view_t::HostMirror scalar_persistent_work_host_view_t; //Host view type
-
-  typedef typename Kokkos::View<nnz_lno_t *, HandleTempMemorySpace> nnz_lno_temp_work_view_t;
-  typedef typename Kokkos::View<nnz_lno_t *, HandlePersistentMemorySpace> nnz_lno_persistent_work_view_t;
-  typedef typename nnz_lno_persistent_work_view_t::HostMirror nnz_lno_persistent_work_host_view_t; //Host view type
+    typedef typename std::remove_const<scalar_t_>::type  nnz_scalar_t;
+    typedef const nnz_scalar_t const_nnz_scalar_t;
 
 
-private:
-  bool owner_of_coloring;
-  GSAlgorithm algorithm_type;
+    typedef typename Kokkos::View<size_type *, HandleTempMemorySpace> row_lno_temp_work_view_t;
+    typedef typename Kokkos::View<size_type *, HandlePersistentMemorySpace> row_lno_persistent_work_view_t;
+    typedef typename row_lno_persistent_work_view_t::HostMirror row_lno_persistent_work_host_view_t; //Host view type
 
-  nnz_lno_persistent_work_host_view_t color_set_xadj;
-  nnz_lno_persistent_work_view_t color_sets;
-  nnz_lno_t numColors;
+    typedef typename Kokkos::View<nnz_scalar_t *, HandleTempMemorySpace> scalar_temp_work_view_t;
+    typedef typename Kokkos::View<nnz_scalar_t *, HandlePersistentMemorySpace> scalar_persistent_work_view_t;
+    typedef typename scalar_persistent_work_view_t::HostMirror scalar_persistent_work_host_view_t; //Host view type
 
-  row_lno_persistent_work_view_t permuted_xadj;
-  nnz_lno_persistent_work_view_t permuted_adj;
-  scalar_persistent_work_view_t permuted_adj_vals;
-  nnz_lno_persistent_work_view_t old_to_new_map;
-
-  bool called_symbolic;
-  bool called_numeric;
+    typedef typename Kokkos::View<nnz_lno_t *, HandleTempMemorySpace> nnz_lno_temp_work_view_t;
+    typedef typename Kokkos::View<nnz_lno_t *, HandlePersistentMemorySpace> nnz_lno_persistent_work_view_t;
+    typedef typename nnz_lno_persistent_work_view_t::HostMirror nnz_lno_persistent_work_host_view_t; //Host view type
 
 
-  scalar_persistent_work_view_t permuted_y_vector;
-  scalar_persistent_work_view_t permuted_x_vector;
+  private:
+    bool owner_of_coloring;
+    GSAlgorithm algorithm_type;
 
-  int suggested_vector_size;
-  int suggested_team_size;
+    nnz_lno_persistent_work_host_view_t color_set_xadj;
+    nnz_lno_persistent_work_view_t color_sets;
+    nnz_lno_t numColors;
 
-  scalar_persistent_work_view_t permuted_inverse_diagonal;
-  nnz_lno_t block_size; //this is for block sgs
+    row_lno_persistent_work_view_t permuted_xadj;
+    nnz_lno_persistent_work_view_t permuted_adj;
+    scalar_persistent_work_view_t permuted_adj_vals;
+    nnz_lno_persistent_work_view_t old_to_new_map;
 
-  nnz_lno_t max_nnz_input_row, num_values_in_l1, num_values_in_l2, num_big_rows;
-  size_t level_1_mem, level_2_mem;
+    bool called_symbolic;
+    bool called_numeric;
+
+
+    scalar_persistent_work_view_t permuted_y_vector;
+    scalar_persistent_work_view_t permuted_x_vector;
+
+    int suggested_vector_size;
+    int suggested_team_size;
+
+    scalar_persistent_work_view_t permuted_inverse_diagonal;
+    nnz_lno_t block_size; //this is for block sgs
+
+    nnz_lno_t max_nnz_input_row, num_values_in_l1, num_values_in_l2, num_big_rows;
+    size_t level_1_mem, level_2_mem;
   public:
 
-  /**
-   * \brief Default constructor.
-   */
-  GaussSeidelHandle(GSAlgorithm gs = GS_DEFAULT):
-    owner_of_coloring(false),
-    algorithm_type(gs),
-    color_set_xadj(), color_sets(), numColors(0),
-    permuted_xadj(),  permuted_adj(), permuted_adj_vals(), old_to_new_map(),
-    called_symbolic(false), called_numeric(false), permuted_y_vector(), permuted_x_vector(),
-    suggested_vector_size(0), suggested_team_size(0), permuted_inverse_diagonal(), block_size(1), max_nnz_input_row(-1),
-	num_values_in_l1(-1), num_values_in_l2(-1),num_big_rows(0), level_1_mem(0), level_2_mem(0)
+    /**
+     * \brief Default constructor.
+     */
+    GaussSeidelHandle(GSAlgorithm gs = GS_DEFAULT):
+      owner_of_coloring(false),
+      algorithm_type(gs),
+      color_set_xadj(), color_sets(), numColors(0),
+      permuted_xadj(),  permuted_adj(), permuted_adj_vals(), old_to_new_map(),
+      called_symbolic(false), called_numeric(false), permuted_y_vector(), permuted_x_vector(),
+      suggested_vector_size(0), suggested_team_size(0), permuted_inverse_diagonal(), block_size(1), max_nnz_input_row(-1),
+      num_values_in_l1(-1), num_values_in_l2(-1),num_big_rows(0), level_1_mem(0), level_2_mem(0)
     {
-    if (gs == GS_DEFAULT){
-      this->choose_default_algorithm();
+      if (gs == GS_DEFAULT){
+        this->choose_default_algorithm();
+      }
+
+
     }
 
-
-  }
-
-  void set_block_size(nnz_lno_t bs){this->block_size = bs; }
-  nnz_lno_t get_block_size(){return this->block_size;}
+    void set_block_size(nnz_lno_t bs){this->block_size = bs; }
+    nnz_lno_t get_block_size(){return this->block_size;}
 
     /** \brief Chooses best algorithm based on the execution space. COLORING_EB if cuda, COLORING_VB otherwise.
-   */
-  void choose_default_algorithm(){
+     */
+    void choose_default_algorithm(){
 #if defined( KOKKOS_ENABLE_SERIAL )
-    if (Kokkos::Impl::is_same< Kokkos::Serial , ExecutionSpace >::value){
-      this->algorithm_type = GS_PERMUTED;
+      if (Kokkos::Impl::is_same< Kokkos::Serial , ExecutionSpace >::value){
+        this->algorithm_type = GS_PERMUTED;
 #ifdef VERBOSE
-      std::cout << "Serial Execution Space, Default Algorithm: GS_PERMUTED" << std::endl;
+        std::cout << "Serial Execution Space, Default Algorithm: GS_PERMUTED" << std::endl;
 #endif
-    }
+      }
 #endif
 
 #if defined( KOKKOS_ENABLE_THREADS )
-    if (Kokkos::Impl::is_same< Kokkos::Threads , ExecutionSpace >::value){
-      this->algorithm_type = GS_PERMUTED;
+      if (Kokkos::Impl::is_same< Kokkos::Threads , ExecutionSpace >::value){
+        this->algorithm_type = GS_PERMUTED;
 #ifdef VERBOSE
-      std::cout << "PTHREAD Execution Space, Default Algorithm: GS_PERMUTED" << std::endl;
+        std::cout << "PTHREAD Execution Space, Default Algorithm: GS_PERMUTED" << std::endl;
 #endif
-    }
+      }
 #endif
 
 #if defined( KOKKOS_ENABLE_OPENMP )
-    if (Kokkos::Impl::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
-      this->algorithm_type = GS_PERMUTED;
+      if (Kokkos::Impl::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
+        this->algorithm_type = GS_PERMUTED;
 #ifdef VERBOSE
-      std::cout << "OpenMP Execution Space, Default Algorithm: GS_PERMUTED" << std::endl;
+        std::cout << "OpenMP Execution Space, Default Algorithm: GS_PERMUTED" << std::endl;
 #endif
-    }
+      }
 #endif
 
 #if defined( KOKKOS_ENABLE_CUDA )
-    if (Kokkos::Impl::is_same<Kokkos::Cuda, ExecutionSpace >::value){
-      this->algorithm_type = GS_TEAM;
+      if (Kokkos::Impl::is_same<Kokkos::Cuda, ExecutionSpace >::value){
+        this->algorithm_type = GS_TEAM;
 #ifdef VERBOSE
-      std::cout << "Cuda Execution Space, Default Algorithm: GS_TEAM" << std::endl;
+        std::cout << "Cuda Execution Space, Default Algorithm: GS_TEAM" << std::endl;
 #endif
-    }
+      }
 #endif
 
 #if defined( KOKKOS_ENABLE_QTHREAD)
-    if (Kokkos::Impl::is_same< Kokkos::Qthread, ExecutionSpace >::value){
-      this->algorithm_type = GS_PERMUTED;
+      if (Kokkos::Impl::is_same< Kokkos::Qthread, ExecutionSpace >::value){
+        this->algorithm_type = GS_PERMUTED;
 #ifdef VERBOSE
-      std::cout << "Qthread Execution Space, Default Algorithm: GS_PERMUTED" << std::endl;
+        std::cout << "Qthread Execution Space, Default Algorithm: GS_PERMUTED" << std::endl;
+#endif
+      }
 #endif
     }
-#endif
-  }
 
-  virtual ~GaussSeidelHandle(){};
+    virtual ~GaussSeidelHandle(){};
 
-  //getters
-  GSAlgorithm get_algorithm_type() const {return this->algorithm_type;}
-  bool is_owner_of_coloring() const {return this->owner_of_coloring;}
+    //getters
+    GSAlgorithm get_algorithm_type() const {return this->algorithm_type;}
+    bool is_owner_of_coloring() const {return this->owner_of_coloring;}
 
-  nnz_lno_persistent_work_host_view_t get_color_xadj() {
-    return this->color_set_xadj;
-  }
-  nnz_lno_persistent_work_view_t get_color_adj() {
-    return this->color_sets;
-  }
-  nnz_lno_t get_num_colors() {
-    return this->numColors;
-  }
-
-  row_lno_persistent_work_view_t get_new_xadj() {
-    return this->permuted_xadj;
-  }
-  nnz_lno_persistent_work_view_t get_new_adj() {
-    return this->permuted_adj;
-  }
-  scalar_persistent_work_view_t get_new_adj_val() {
-    return this->permuted_adj_vals;
-  }
-  nnz_lno_persistent_work_view_t get_old_to_new_map() {
-    return this->old_to_new_map;
-  }
-
-  bool is_symbolic_called(){return this->called_symbolic;}
-  bool is_numeric_called(){return this->called_numeric;}
-
-  //setters
-  void set_algorithm_type(const GSAlgorithm &sgs_algo){this->algorithm_type = sgs_algo;}
-  void set_owner_of_coloring(bool owner = true){this->owner_of_coloring = owner;}
-
-  void set_call_symbolic(bool call = true){this->called_symbolic = call;}
-  void set_call_numeric(bool call = true){this->called_numeric = call;}
-
-  void set_color_set_xadj(const nnz_lno_persistent_work_host_view_t &color_set_xadj_) {
-    this->color_set_xadj = color_set_xadj_;
-  }
-  void set_color_set_adj(const nnz_lno_persistent_work_view_t &color_sets_) {
-    this->color_sets = color_sets_;
-  }
-  void set_num_colors(const nnz_lno_t &numColors_) {
-    this->numColors = numColors_;
-  }
-
-  void set_new_xadj(const row_lno_persistent_work_view_t &xadj_) {
-    this->permuted_xadj = xadj_;
-  }
-  void set_new_adj(const nnz_lno_persistent_work_view_t &adj_) {
-    this->permuted_adj = adj_;
-  }
-  void set_new_adj_val(const scalar_persistent_work_view_t &adj_vals_) {
-    this->permuted_adj_vals = adj_vals_;
-  }
-  void set_old_to_new_map(const nnz_lno_persistent_work_view_t &old_to_new_map_) {
-    this->old_to_new_map = old_to_new_map_;
-  }
-  void set_permuted_inverse_diagonal (const scalar_persistent_work_view_t permuted_inverse_diagonal_){
-    this->permuted_inverse_diagonal = permuted_inverse_diagonal_;
-  }
-
-  scalar_persistent_work_view_t get_permuted_inverse_diagonal (){
-    return this->permuted_inverse_diagonal;
-  }
-
-
-  void set_level_1_mem(size_t _level_1_mem){
-	  this->level_1_mem = _level_1_mem;
-  }
-  void set_level_2_mem(size_t _level_2_mem){
-	  this->level_2_mem = _level_2_mem;
-  }
-
-  void set_num_values_in_l1(nnz_lno_t _num_values_in_l1){
-	  this->num_values_in_l1 = _num_values_in_l1;
-  }
-  void set_num_values_in_l2(nnz_lno_t _num_values_in_l2){
-	  this->num_values_in_l2 = _num_values_in_l2;
-  }
-
-  void set_num_big_rows(nnz_lno_t _big_rows){
-	  this->num_big_rows = _big_rows;
-  }
-
-  size_t get_level_1_mem() const {
-	  return this->level_1_mem;
-  }
-  size_t get_level_2_mem()const {
-	  return this->level_2_mem;
-  }
-
-  nnz_lno_t get_num_values_in_l1()const {
-	  return this->num_values_in_l1 ;
-  }
-  nnz_lno_t get_num_values_in_l2()const {
-	  return this->num_values_in_l2 ;
-  }
-  nnz_lno_t get_num_big_rows()const {
-	  return this->num_big_rows;
-  }
-
-
-  nnz_lno_t get_max_nnz() const{
-    return this->max_nnz_input_row ;
-  }
-
-
-  void set_max_nnz(nnz_lno_t num_result_nnz_){
-    this->max_nnz_input_row = num_result_nnz_;
-  }
-
-
-  void allocate_x_y_vectors(nnz_lno_t num_rows, nnz_lno_t num_cols){
-    if(permuted_y_vector.extent(0) != size_t(num_rows)){
-      permuted_y_vector = scalar_persistent_work_view_t("PERMUTED Y VECTOR", num_rows);
+    nnz_lno_persistent_work_host_view_t get_color_xadj() {
+      return this->color_set_xadj;
     }
-    if(permuted_x_vector.extent(0) != size_t(num_cols)){
-      permuted_x_vector = scalar_persistent_work_view_t("PERMUTED X VECTOR", num_cols);
+    nnz_lno_persistent_work_view_t get_color_adj() {
+      return this->color_sets;
     }
-  }
-
-  scalar_persistent_work_view_t get_permuted_y_vector (){return this->permuted_y_vector;}
-  scalar_persistent_work_view_t get_permuted_x_vector (){return this->permuted_x_vector;}
-  void vector_team_size(
-      int max_allowed_team_size,
-      int &suggested_vector_size_,
-      int &suggested_team_size_,
-      size_type nr, size_type nnz){
-    //suggested_team_size_ =  this->suggested_team_size = 1;
-    //suggested_vector_size_=this->suggested_vector_size = 1;
-    //return;
-    if (this->suggested_team_size && this->suggested_vector_size) {
-      suggested_vector_size_ = this->suggested_vector_size;
-      suggested_team_size_ = this->suggested_team_size;
-      return;
+    nnz_lno_t get_num_colors() {
+      return this->numColors;
     }
-    else {
-      KokkosKernels::Impl::get_suggested_vector_team_size<size_type, ExecutionSpace>(
-          max_allowed_team_size, suggested_vector_size_, suggested_team_size_, nr, nnz);
-      this->suggested_team_size = suggested_vector_size_;
-      this->suggested_vector_size = suggested_vector_size_;
 
+    row_lno_persistent_work_view_t get_new_xadj() {
+      return this->permuted_xadj;
     }
-  }
+    nnz_lno_persistent_work_view_t get_new_adj() {
+      return this->permuted_adj;
+    }
+    scalar_persistent_work_view_t get_new_adj_val() {
+      return this->permuted_adj_vals;
+    }
+    nnz_lno_persistent_work_view_t get_old_to_new_map() {
+      return this->old_to_new_map;
+    }
 
-};
+    bool is_symbolic_called(){return this->called_symbolic;}
+    bool is_numeric_called(){return this->called_numeric;}
+
+    //setters
+    void set_algorithm_type(const GSAlgorithm &sgs_algo){this->algorithm_type = sgs_algo;}
+    void set_owner_of_coloring(bool owner = true){this->owner_of_coloring = owner;}
+
+    void set_call_symbolic(bool call = true){this->called_symbolic = call;}
+    void set_call_numeric(bool call = true){this->called_numeric = call;}
+
+    void set_color_set_xadj(const nnz_lno_persistent_work_host_view_t &color_set_xadj_) {
+      this->color_set_xadj = color_set_xadj_;
+    }
+    void set_color_set_adj(const nnz_lno_persistent_work_view_t &color_sets_) {
+      this->color_sets = color_sets_;
+    }
+    void set_num_colors(const nnz_lno_t &numColors_) {
+      this->numColors = numColors_;
+    }
+
+    void set_new_xadj(const row_lno_persistent_work_view_t &xadj_) {
+      this->permuted_xadj = xadj_;
+    }
+    void set_new_adj(const nnz_lno_persistent_work_view_t &adj_) {
+      this->permuted_adj = adj_;
+    }
+    void set_new_adj_val(const scalar_persistent_work_view_t &adj_vals_) {
+      this->permuted_adj_vals = adj_vals_;
+    }
+    void set_old_to_new_map(const nnz_lno_persistent_work_view_t &old_to_new_map_) {
+      this->old_to_new_map = old_to_new_map_;
+    }
+    void set_permuted_inverse_diagonal (const scalar_persistent_work_view_t permuted_inverse_diagonal_){
+      this->permuted_inverse_diagonal = permuted_inverse_diagonal_;
+    }
+
+    scalar_persistent_work_view_t get_permuted_inverse_diagonal (){
+      return this->permuted_inverse_diagonal;
+    }
+
+
+    void set_level_1_mem(size_t _level_1_mem){
+      this->level_1_mem = _level_1_mem;
+    }
+    void set_level_2_mem(size_t _level_2_mem){
+      this->level_2_mem = _level_2_mem;
+    }
+
+    void set_num_values_in_l1(nnz_lno_t _num_values_in_l1){
+      this->num_values_in_l1 = _num_values_in_l1;
+    }
+    void set_num_values_in_l2(nnz_lno_t _num_values_in_l2){
+      this->num_values_in_l2 = _num_values_in_l2;
+    }
+
+    void set_num_big_rows(nnz_lno_t _big_rows){
+      this->num_big_rows = _big_rows;
+    }
+
+    size_t get_level_1_mem() const {
+      return this->level_1_mem;
+    }
+    size_t get_level_2_mem()const {
+      return this->level_2_mem;
+    }
+
+    nnz_lno_t get_num_values_in_l1()const {
+      return this->num_values_in_l1 ;
+    }
+    nnz_lno_t get_num_values_in_l2()const {
+      return this->num_values_in_l2 ;
+    }
+    nnz_lno_t get_num_big_rows()const {
+      return this->num_big_rows;
+    }
+
+
+    nnz_lno_t get_max_nnz() const{
+      return this->max_nnz_input_row ;
+    }
+
+
+    void set_max_nnz(nnz_lno_t num_result_nnz_){
+      this->max_nnz_input_row = num_result_nnz_;
+    }
+
+
+    void allocate_x_y_vectors(nnz_lno_t num_rows, nnz_lno_t num_cols){
+      if(permuted_y_vector.extent(0) != size_t(num_rows)){
+        permuted_y_vector = scalar_persistent_work_view_t("PERMUTED Y VECTOR", num_rows);
+      }
+      if(permuted_x_vector.extent(0) != size_t(num_cols)){
+        permuted_x_vector = scalar_persistent_work_view_t("PERMUTED X VECTOR", num_cols);
+      }
+    }
+
+    scalar_persistent_work_view_t get_permuted_y_vector (){return this->permuted_y_vector;}
+    scalar_persistent_work_view_t get_permuted_x_vector (){return this->permuted_x_vector;}
+    void vector_team_size(
+                          int max_allowed_team_size,
+                          int &suggested_vector_size_,
+                          int &suggested_team_size_,
+                          size_type nr, size_type nnz){
+      //suggested_team_size_ =  this->suggested_team_size = 1;
+      //suggested_vector_size_=this->suggested_vector_size = 1;
+      //return;
+      if (this->suggested_team_size && this->suggested_vector_size) {
+        suggested_vector_size_ = this->suggested_vector_size;
+        suggested_team_size_ = this->suggested_team_size;
+        return;
+      }
+      else {
+        KokkosKernels::Impl::get_suggested_vector_team_size<size_type, ExecutionSpace>(
+                                                                                       max_allowed_team_size, suggested_vector_size_, suggested_team_size_, nr, nnz);
+        this->suggested_team_size = suggested_vector_size_;
+        this->suggested_vector_size = suggested_vector_size_;
+
+      }
+    }
+
+  };
 }
 
 #endif

--- a/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
+++ b/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
@@ -108,7 +108,7 @@ private:
   int suggested_vector_size;
   int suggested_team_size;
 
-  scalar_persistent_work_view_t permuted_diagonals;
+  scalar_persistent_work_view_t permuted_inverse_diagonal;
   nnz_lno_t block_size; //this is for block sgs
 
   nnz_lno_t max_nnz_input_row, num_values_in_l1, num_values_in_l2, num_big_rows;
@@ -124,7 +124,7 @@ private:
     color_set_xadj(), color_sets(), numColors(0),
     permuted_xadj(),  permuted_adj(), permuted_adj_vals(), old_to_new_map(),
     called_symbolic(false), called_numeric(false), permuted_y_vector(), permuted_x_vector(),
-    suggested_vector_size(0), suggested_team_size(0), permuted_diagonals(), block_size(1), max_nnz_input_row(-1),
+    suggested_vector_size(0), suggested_team_size(0), permuted_inverse_diagonal(), block_size(1), max_nnz_input_row(-1),
 	num_values_in_l1(-1), num_values_in_l2(-1),num_big_rows(0), level_1_mem(0), level_2_mem(0)
     {
     if (gs == GS_DEFAULT){
@@ -247,12 +247,12 @@ private:
   void set_old_to_new_map(const nnz_lno_persistent_work_view_t &old_to_new_map_) {
     this->old_to_new_map = old_to_new_map_;
   }
-  void set_permuted_diagonals (const scalar_persistent_work_view_t permuted_diagonals_){
-    this->permuted_diagonals = permuted_diagonals_;
+  void set_permuted_inverse_diagonal (const scalar_persistent_work_view_t permuted_inverse_diagonal_){
+    this->permuted_inverse_diagonal = permuted_inverse_diagonal_;
   }
 
-  scalar_persistent_work_view_t get_permuted_diagonals (){
-    return this->permuted_diagonals;
+  scalar_persistent_work_view_t get_permuted_inverse_diagonal (){
+    return this->permuted_inverse_diagonal;
   }
 
 

--- a/src/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
@@ -55,99 +55,99 @@
 namespace KokkosSparse{
 
 
-namespace Impl{
+  namespace Impl{
 
 
-template <typename HandleType, typename lno_row_view_t_, typename lno_nnz_view_t_, typename scalar_nnz_view_t_>
-class GaussSeidel{
+    template <typename HandleType, typename lno_row_view_t_, typename lno_nnz_view_t_, typename scalar_nnz_view_t_>
+    class GaussSeidel{
 
-public:
+    public:
 
-  typedef lno_row_view_t_ in_lno_row_view_t;
-  typedef lno_nnz_view_t_ in_lno_nnz_view_t;
-  typedef scalar_nnz_view_t_ in_scalar_nnz_view_t;
+      typedef lno_row_view_t_ in_lno_row_view_t;
+      typedef lno_nnz_view_t_ in_lno_nnz_view_t;
+      typedef scalar_nnz_view_t_ in_scalar_nnz_view_t;
 
-  typedef typename HandleType::HandleExecSpace MyExecSpace;
-  typedef typename HandleType::HandleTempMemorySpace MyTempMemorySpace;
-  typedef typename HandleType::HandlePersistentMemorySpace MyPersistentMemorySpace;
-
-
-  typedef typename in_lno_row_view_t::non_const_value_type row_lno_t;
-
-  typedef typename HandleType::size_type size_type;
-  typedef typename HandleType::nnz_lno_t nnz_lno_t;
-  typedef typename HandleType::nnz_scalar_t nnz_scalar_t;
+      typedef typename HandleType::HandleExecSpace MyExecSpace;
+      typedef typename HandleType::HandleTempMemorySpace MyTempMemorySpace;
+      typedef typename HandleType::HandlePersistentMemorySpace MyPersistentMemorySpace;
 
 
-  typedef typename in_lno_row_view_t::const_type const_lno_row_view_t;
-  typedef typename in_lno_row_view_t::non_const_type non_const_lno_row_view_t;
+      typedef typename in_lno_row_view_t::non_const_value_type row_lno_t;
 
-  typedef typename lno_nnz_view_t_::const_type const_lno_nnz_view_t;
-  typedef typename lno_nnz_view_t_::non_const_type non_const_lno_nnz_view_t;
-
-  typedef typename scalar_nnz_view_t_::const_type const_scalar_nnz_view_t;
-  typedef typename scalar_nnz_view_t_::non_const_type non_const_scalar_nnz_view_t;
+      typedef typename HandleType::size_type size_type;
+      typedef typename HandleType::nnz_lno_t nnz_lno_t;
+      typedef typename HandleType::nnz_scalar_t nnz_scalar_t;
 
 
+      typedef typename in_lno_row_view_t::const_type const_lno_row_view_t;
+      typedef typename in_lno_row_view_t::non_const_type non_const_lno_row_view_t;
 
+      typedef typename lno_nnz_view_t_::const_type const_lno_nnz_view_t;
+      typedef typename lno_nnz_view_t_::non_const_type non_const_lno_nnz_view_t;
 
-  typedef typename HandleType::row_lno_temp_work_view_t row_lno_temp_work_view_t;
-  typedef typename HandleType::row_lno_persistent_work_view_t row_lno_persistent_work_view_t;
-  typedef typename HandleType::row_lno_persistent_work_host_view_t row_lno_persistent_work_host_view_t; //Host view type
+      typedef typename scalar_nnz_view_t_::const_type const_scalar_nnz_view_t;
+      typedef typename scalar_nnz_view_t_::non_const_type non_const_scalar_nnz_view_t;
 
 
 
-  typedef typename HandleType::nnz_lno_temp_work_view_t nnz_lno_temp_work_view_t;
-  typedef typename HandleType::nnz_lno_persistent_work_view_t nnz_lno_persistent_work_view_t;
-  typedef typename HandleType::nnz_lno_persistent_work_host_view_t nnz_lno_persistent_work_host_view_t; //Host view type
+
+      typedef typename HandleType::row_lno_temp_work_view_t row_lno_temp_work_view_t;
+      typedef typename HandleType::row_lno_persistent_work_view_t row_lno_persistent_work_view_t;
+      typedef typename HandleType::row_lno_persistent_work_host_view_t row_lno_persistent_work_host_view_t; //Host view type
 
 
-  typedef typename HandleType::scalar_temp_work_view_t scalar_temp_work_view_t;
-  typedef typename HandleType::scalar_persistent_work_view_t scalar_persistent_work_view_t;
 
-  typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
-  typedef nnz_lno_t color_t;
-  typedef Kokkos::View<color_t *, MyTempMemorySpace> color_view_t;
+      typedef typename HandleType::nnz_lno_temp_work_view_t nnz_lno_temp_work_view_t;
+      typedef typename HandleType::nnz_lno_persistent_work_view_t nnz_lno_persistent_work_view_t;
+      typedef typename HandleType::nnz_lno_persistent_work_host_view_t nnz_lno_persistent_work_host_view_t; //Host view type
 
-  typedef Kokkos::TeamPolicy<MyExecSpace> team_policy_t ;
-  typedef typename team_policy_t::member_type team_member_t ;
 
-  struct BlockTag{};
-  struct BigBlockTag{};
+      typedef typename HandleType::scalar_temp_work_view_t scalar_temp_work_view_t;
+      typedef typename HandleType::scalar_persistent_work_view_t scalar_persistent_work_view_t;
 
-  typedef Kokkos::TeamPolicy<BlockTag, MyExecSpace> block_team_fill_policy_t ;
-  typedef Kokkos::TeamPolicy<BigBlockTag, MyExecSpace> bigblock_team_fill_policy_t ;
-  typedef KokkosKernels::Impl::UniformMemoryPool< MyTempMemorySpace, nnz_scalar_t> pool_memory_space;
+      typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
+      typedef nnz_lno_t color_t;
+      typedef Kokkos::View<color_t *, MyTempMemorySpace> color_view_t;
 
-private:
-  HandleType *handle;
-  nnz_lno_t num_rows, num_cols;
+      typedef Kokkos::TeamPolicy<MyExecSpace> team_policy_t ;
+      typedef typename team_policy_t::member_type team_member_t ;
 
-  const_lno_row_view_t row_map;
-  const_lno_nnz_view_t entries;
-  const_scalar_nnz_view_t values;
+      struct BlockTag{};
+      struct BigBlockTag{};
 
-  const_scalar_nnz_view_t given_inverse_diagonal;
+      typedef Kokkos::TeamPolicy<BlockTag, MyExecSpace> block_team_fill_policy_t ;
+      typedef Kokkos::TeamPolicy<BigBlockTag, MyExecSpace> bigblock_team_fill_policy_t ;
+      typedef KokkosKernels::Impl::UniformMemoryPool< MyTempMemorySpace, nnz_scalar_t> pool_memory_space;
 
-  bool have_diagonal_given;
-  bool is_symmetric;
-public:
+    private:
+      HandleType *handle;
+      nnz_lno_t num_rows, num_cols;
 
-  struct PSGS{
-    row_lno_persistent_work_view_t _xadj;
-    nnz_lno_persistent_work_view_t _adj; // CSR storage of the graph.
-    scalar_persistent_work_view_t _adj_vals; // CSR storage of the graph.
+      const_lno_row_view_t row_map;
+      const_lno_nnz_view_t entries;
+      const_scalar_nnz_view_t values;
 
-    scalar_persistent_work_view_t _Xvector /*output*/;
-    scalar_persistent_work_view_t _Yvector;
+      const_scalar_nnz_view_t given_inverse_diagonal;
 
-    scalar_persistent_work_view_t _permuted_inverse_diagonal;
+      bool have_diagonal_given;
+      bool is_symmetric;
+    public:
 
-    nnz_scalar_t omega;
+      struct PSGS{
+        row_lno_persistent_work_view_t _xadj;
+        nnz_lno_persistent_work_view_t _adj; // CSR storage of the graph.
+        scalar_persistent_work_view_t _adj_vals; // CSR storage of the graph.
 
-    PSGS(row_lno_persistent_work_view_t xadj_, nnz_lno_persistent_work_view_t adj_, scalar_persistent_work_view_t adj_vals_,
-        scalar_persistent_work_view_t Xvector_, scalar_persistent_work_view_t Yvector_, nnz_lno_persistent_work_view_t color_adj_,
-        scalar_persistent_work_view_t permuted_inverse_diagonal_):
+        scalar_persistent_work_view_t _Xvector /*output*/;
+        scalar_persistent_work_view_t _Yvector;
+
+        scalar_persistent_work_view_t _permuted_inverse_diagonal;
+
+        nnz_scalar_t omega;
+
+        PSGS(row_lno_persistent_work_view_t xadj_, nnz_lno_persistent_work_view_t adj_, scalar_persistent_work_view_t adj_vals_,
+             scalar_persistent_work_view_t Xvector_, scalar_persistent_work_view_t Yvector_, nnz_lno_persistent_work_view_t color_adj_,
+             scalar_persistent_work_view_t permuted_inverse_diagonal_):
           _xadj( xadj_),
           _adj( adj_),
           _adj_vals( adj_vals_),
@@ -155,63 +155,63 @@ public:
           _Yvector( Yvector_), _permuted_inverse_diagonal(permuted_inverse_diagonal_),
           omega(Kokkos::Details::ArithTraits<nnz_scalar_t>::one()){}
 
-    KOKKOS_INLINE_FUNCTION
-    void operator()(const nnz_lno_t &ii) const {
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const nnz_lno_t &ii) const {
 
-      size_type row_begin = _xadj[ii];
-      size_type row_end = _xadj[ii + 1];
+          size_type row_begin = _xadj[ii];
+          size_type row_end = _xadj[ii + 1];
 
-      nnz_scalar_t sum = _Yvector[ii];
+          nnz_scalar_t sum = _Yvector[ii];
 
-      for (size_type adjind = row_begin; adjind < row_end; ++adjind){
-        nnz_lno_t colIndex = _adj[adjind];
-        nnz_scalar_t val = _adj_vals[adjind];
-        sum -= val * _Xvector[colIndex];
-      }
-      nnz_scalar_t invDiagonalVal = _permuted_inverse_diagonal[ii];
-      _Xvector[ii] = _Xvector[ii] + omega * sum * invDiagonalVal;
-    }
-  };
+          for (size_type adjind = row_begin; adjind < row_end; ++adjind){
+            nnz_lno_t colIndex = _adj[adjind];
+            nnz_scalar_t val = _adj_vals[adjind];
+            sum -= val * _Xvector[colIndex];
+          }
+          nnz_scalar_t invDiagonalVal = _permuted_inverse_diagonal[ii];
+          _Xvector[ii] = _Xvector[ii] + omega * sum * invDiagonalVal;
+        }
+      };
 
-  struct Team_PSGS{
+      struct Team_PSGS{
 
-    row_lno_persistent_work_view_t _xadj;
-    nnz_lno_persistent_work_view_t _adj; // CSR storage of the graph.
-    scalar_persistent_work_view_t _adj_vals; // CSR storage of the graph.
+        row_lno_persistent_work_view_t _xadj;
+        nnz_lno_persistent_work_view_t _adj; // CSR storage of the graph.
+        scalar_persistent_work_view_t _adj_vals; // CSR storage of the graph.
 
-    scalar_persistent_work_view_t _Xvector /*output*/;
-    scalar_persistent_work_view_t _Yvector;
-    nnz_lno_t _color_set_begin;
-    nnz_lno_t _color_set_end;
+        scalar_persistent_work_view_t _Xvector /*output*/;
+        scalar_persistent_work_view_t _Yvector;
+        nnz_lno_t _color_set_begin;
+        nnz_lno_t _color_set_end;
 
-    scalar_persistent_work_view_t _permuted_inverse_diagonal;
-    nnz_lno_t block_size;
-    nnz_lno_t team_work_size;
-    const size_t shared_memory_size;
+        scalar_persistent_work_view_t _permuted_inverse_diagonal;
+        nnz_lno_t block_size;
+        nnz_lno_t team_work_size;
+        const size_t shared_memory_size;
 
-    int suggested_team_size;
-    const size_t thread_shared_memory_scalar_size;
-    int vector_size;
-	const pool_memory_space pool;
-	const nnz_lno_t num_max_vals_in_l1, num_max_vals_in_l2;
-    bool is_backward;
+        int suggested_team_size;
+        const size_t thread_shared_memory_scalar_size;
+        int vector_size;
+        const pool_memory_space pool;
+        const nnz_lno_t num_max_vals_in_l1, num_max_vals_in_l2;
+        bool is_backward;
 
-    nnz_scalar_t omega;
+        nnz_scalar_t omega;
 
 
-    Team_PSGS(row_lno_persistent_work_view_t xadj_, nnz_lno_persistent_work_view_t adj_, scalar_persistent_work_view_t adj_vals_,
-        scalar_persistent_work_view_t Xvector_, scalar_persistent_work_view_t Yvector_,
-        nnz_lno_t color_set_begin, nnz_lno_t color_set_end,
-        scalar_persistent_work_view_t permuted_inverse_diagonal_,
-		pool_memory_space pms,
-		nnz_lno_t _num_max_vals_in_l1 = 0,
-		nnz_lno_t _num_max_vals_in_l2 = 0,
+        Team_PSGS(row_lno_persistent_work_view_t xadj_, nnz_lno_persistent_work_view_t adj_, scalar_persistent_work_view_t adj_vals_,
+                  scalar_persistent_work_view_t Xvector_, scalar_persistent_work_view_t Yvector_,
+                  nnz_lno_t color_set_begin, nnz_lno_t color_set_end,
+                  scalar_persistent_work_view_t permuted_inverse_diagonal_,
+                  pool_memory_space pms,
+                  nnz_lno_t _num_max_vals_in_l1 = 0,
+                  nnz_lno_t _num_max_vals_in_l2 = 0,
 
-	    nnz_lno_t block_size_ = 1,
-	    nnz_lno_t team_work_size_ = 1,
-		size_t shared_memory_size_ = 16,
-		int suggested_team_size_ = 1,
-		int vector_size_ = 1):
+                  nnz_lno_t block_size_ = 1,
+                  nnz_lno_t team_work_size_ = 1,
+                  size_t shared_memory_size_ = 16,
+                  int suggested_team_size_ = 1,
+                  int vector_size_ = 1):
           _xadj( xadj_),
           _adj( adj_),
           _adj_vals( adj_vals_),
@@ -219,1444 +219,1444 @@ public:
           _Yvector( Yvector_),
           _color_set_begin(color_set_begin),
           _color_set_end(color_set_end), _permuted_inverse_diagonal(permuted_inverse_diagonal_),
-		  block_size(block_size_),
-		  team_work_size(team_work_size_),
-		  shared_memory_size(shared_memory_size_),
-		  suggested_team_size(suggested_team_size_),
-		  thread_shared_memory_scalar_size(((shared_memory_size / suggested_team_size / 8) * 8 ) / sizeof(nnz_scalar_t) ),
-		  vector_size(vector_size_), pool (pms), num_max_vals_in_l1(_num_max_vals_in_l1),
-                  num_max_vals_in_l2(_num_max_vals_in_l2), is_backward(false),
-                  omega(Kokkos::Details::ArithTraits<nnz_scalar_t>::one()){}
+          block_size(block_size_),
+          team_work_size(team_work_size_),
+          shared_memory_size(shared_memory_size_),
+          suggested_team_size(suggested_team_size_),
+          thread_shared_memory_scalar_size(((shared_memory_size / suggested_team_size / 8) * 8 ) / sizeof(nnz_scalar_t) ),
+          vector_size(vector_size_), pool (pms), num_max_vals_in_l1(_num_max_vals_in_l1),
+          num_max_vals_in_l2(_num_max_vals_in_l2), is_backward(false),
+          omega(Kokkos::Details::ArithTraits<nnz_scalar_t>::one()){}
 
-    KOKKOS_INLINE_FUNCTION
-    void operator()(const team_member_t & teamMember) const {
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const team_member_t & teamMember) const {
 
-      nnz_lno_t ii = teamMember.league_rank()  * teamMember.team_size()+ teamMember.team_rank() + _color_set_begin;
-      if (ii >= _color_set_end)
-        return;
-
-
-
-      size_type row_begin = _xadj[ii];
-      size_type row_end = _xadj[ii + 1];
-
-      nnz_scalar_t product = 0 ;
-      Kokkos::parallel_reduce(
-          Kokkos::ThreadVectorRange(teamMember, row_end - row_begin),
-          [&] (size_type i, nnz_scalar_t & valueToUpdate) {
-        size_type adjind = i + row_begin;
-        nnz_lno_t colIndex = _adj[adjind];
-        nnz_scalar_t val = _adj_vals[adjind];
-        valueToUpdate += val * _Xvector[colIndex];
-      },
-      product);
-
-      Kokkos::single(Kokkos::PerThread(teamMember),[=] () {
-        nnz_scalar_t invDiagonalVal = _permuted_inverse_diagonal[ii];
-        _Xvector[ii] += omega * (_Yvector[ii] - product) * invDiagonalVal;
-      });
-     }
-
-    KOKKOS_INLINE_FUNCTION
-    void operator()(const BigBlockTag&, const team_member_t & teamMember) const {
+          nnz_lno_t ii = teamMember.league_rank()  * teamMember.team_size()+ teamMember.team_rank() + _color_set_begin;
+          if (ii >= _color_set_end)
+            return;
 
 
-      const nnz_lno_t team_row_begin = teamMember.league_rank() * team_work_size + _color_set_begin;
-      const nnz_lno_t team_row_end = KOKKOSKERNELS_MACRO_MIN(team_row_begin + team_work_size, _color_set_end);
-      //get the shared memory and shift it based on the thread index so that each thread has private memory.
-      nnz_scalar_t *all_shared_memory = (nnz_scalar_t *) (teamMember.team_shmem().get_shmem(shared_memory_size));
 
-	  all_shared_memory += thread_shared_memory_scalar_size * teamMember.team_rank();
+          size_type row_begin = _xadj[ii];
+          size_type row_end = _xadj[ii + 1];
 
-	  //store the diagonal positions, because we want to update them on shared memory if we update them on global memory. 
-	  nnz_lno_t *diagonal_positions = (nnz_lno_t *)all_shared_memory;
-	  all_shared_memory =  (nnz_scalar_t *) (((nnz_lno_t *)all_shared_memory) + ((block_size / 8) + 1) * 8);
+          nnz_scalar_t product = 0 ;
+          Kokkos::parallel_reduce(
+                                  Kokkos::ThreadVectorRange(teamMember, row_end - row_begin),
+                                  [&] (size_type i, nnz_scalar_t & valueToUpdate) {
+                                    size_type adjind = i + row_begin;
+                                    nnz_lno_t colIndex = _adj[adjind];
+                                    nnz_scalar_t val = _adj_vals[adjind];
+                                    valueToUpdate += val * _Xvector[colIndex];
+                                  },
+                                  product);
 
-	  nnz_scalar_t *all_global_memory = NULL;
+          Kokkos::single(Kokkos::PerThread(teamMember),[=] () {
+              nnz_scalar_t invDiagonalVal = _permuted_inverse_diagonal[ii];
+              _Xvector[ii] += omega * (_Yvector[ii] - product) * invDiagonalVal;
+            });
+        }
+
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const BigBlockTag&, const team_member_t & teamMember) const {
 
 
-	  Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end), [&] (const nnz_lno_t& ii) {
+          const nnz_lno_t team_row_begin = teamMember.league_rank() * team_work_size + _color_set_begin;
+          const nnz_lno_t team_row_end = KOKKOSKERNELS_MACRO_MIN(team_row_begin + team_work_size, _color_set_end);
+          //get the shared memory and shift it based on the thread index so that each thread has private memory.
+          nnz_scalar_t *all_shared_memory = (nnz_scalar_t *) (teamMember.team_shmem().get_shmem(shared_memory_size));
+
+          all_shared_memory += thread_shared_memory_scalar_size * teamMember.team_rank();
+
+          //store the diagonal positions, because we want to update them on shared memory if we update them on global memory.
+          nnz_lno_t *diagonal_positions = (nnz_lno_t *)all_shared_memory;
+          all_shared_memory =  (nnz_scalar_t *) (((nnz_lno_t *)all_shared_memory) + ((block_size / 8) + 1) * 8);
+
+          nnz_scalar_t *all_global_memory = NULL;
 
 
-		  Kokkos::parallel_for(
-				  Kokkos::ThreadVectorRange(teamMember, block_size),
-				  [&] (nnz_lno_t i) {
-			  diagonal_positions[i] = -1;
-		  });
+          Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end), [&] (const nnz_lno_t& ii) {
 
-		  size_type row_begin = _xadj[ii];
-		  size_type row_end = _xadj[ii + 1];
-		  nnz_lno_t row_size = row_end - row_begin;
 
-		  nnz_lno_t l1_val_size = row_size * block_size, l2_val_size = 0;
-		  //if the current row size is larger than shared memory size,
-		  //than allocate l2 vector.
-		  if (row_size > num_max_vals_in_l1){
-			  volatile nnz_scalar_t * tmp = NULL;
-			  while (tmp == NULL){
-				  Kokkos::single(Kokkos::PerThread(teamMember),[&] (volatile nnz_scalar_t * &memptr) {
-					  memptr = (volatile nnz_scalar_t * )( pool.allocate_chunk(ii));
-				  }, tmp);
-			  }
-			  all_global_memory = (nnz_scalar_t *)tmp;
-			  l1_val_size = num_max_vals_in_l1 * block_size;
-			  l2_val_size = (row_size * block_size - l1_val_size);
-		  }
-		  //bring values to l1 vector
-		  Kokkos::parallel_for(
-				  Kokkos::ThreadVectorRange(teamMember, l1_val_size),
-				  [&] (nnz_lno_t i) {
-			  size_type adjind = i / block_size + row_begin;
-			  nnz_lno_t colIndex = _adj[adjind];
+              Kokkos::parallel_for(
+                                   Kokkos::ThreadVectorRange(teamMember, block_size),
+                                   [&] (nnz_lno_t i) {
+                                     diagonal_positions[i] = -1;
+                                   });
 
-			  if (colIndex == ii){
-				  diagonal_positions[i % block_size] = i;
-			  }
-			  all_shared_memory[i] = _Xvector[colIndex * block_size + i % block_size];
-		  });
-		 //bring values to l2 vector.
-		  Kokkos::parallel_for(
-				  Kokkos::ThreadVectorRange(teamMember, l2_val_size),
-				  [&] (nnz_lno_t k) {
-			  nnz_lno_t i = l1_val_size + k;
+              size_type row_begin = _xadj[ii];
+              size_type row_end = _xadj[ii + 1];
+              nnz_lno_t row_size = row_end - row_begin;
 
-			  size_type adjind = i / block_size + row_begin;
-			  nnz_lno_t colIndex = _adj[adjind];
+              nnz_lno_t l1_val_size = row_size * block_size, l2_val_size = 0;
+              //if the current row size is larger than shared memory size,
+              //than allocate l2 vector.
+              if (row_size > num_max_vals_in_l1){
+                volatile nnz_scalar_t * tmp = NULL;
+                while (tmp == NULL){
+                  Kokkos::single(Kokkos::PerThread(teamMember),[&] (volatile nnz_scalar_t * &memptr) {
+                      memptr = (volatile nnz_scalar_t * )( pool.allocate_chunk(ii));
+                    }, tmp);
+                }
+                all_global_memory = (nnz_scalar_t *)tmp;
+                l1_val_size = num_max_vals_in_l1 * block_size;
+                l2_val_size = (row_size * block_size - l1_val_size);
+              }
+              //bring values to l1 vector
+              Kokkos::parallel_for(
+                                   Kokkos::ThreadVectorRange(teamMember, l1_val_size),
+                                   [&] (nnz_lno_t i) {
+                                     size_type adjind = i / block_size + row_begin;
+                                     nnz_lno_t colIndex = _adj[adjind];
 
-			  if (colIndex == ii){
-				  diagonal_positions[i % block_size] = i;
-			  }
-			  all_global_memory[k] = _Xvector[colIndex * block_size + i % block_size];
-		  });
+                                     if (colIndex == ii){
+                                       diagonal_positions[i % block_size] = i;
+                                     }
+                                     all_shared_memory[i] = _Xvector[colIndex * block_size + i % block_size];
+                                   });
+              //bring values to l2 vector.
+              Kokkos::parallel_for(
+                                   Kokkos::ThreadVectorRange(teamMember, l2_val_size),
+                                   [&] (nnz_lno_t k) {
+                                     nnz_lno_t i = l1_val_size + k;
 
-		  row_begin = row_begin * block_size * block_size;
-		  //sequentially solve in the block. 
-		  //this respects backward and forward sweeps.
-                  for (int m = 0; m < block_size; ++m ){
-                          int i = m;
-                          if (is_backward) i = block_size - m - 1;
-                          size_type current_row_begin = row_begin + i * row_size * block_size;
-			  //first reduce l1 dot product. 
-			  //MD: TODO: if thread dot product is implemented it should be called here.
-			  nnz_scalar_t product = 0 ;
-			  Kokkos::parallel_reduce(
-					  Kokkos::ThreadVectorRange(teamMember, l1_val_size),
-					  [&] (nnz_lno_t colind, nnz_scalar_t & valueToUpdate) {
+                                     size_type adjind = i / block_size + row_begin;
+                                     nnz_lno_t colIndex = _adj[adjind];
 
-				  valueToUpdate += all_shared_memory[colind] * _adj_vals(current_row_begin + colind);
+                                     if (colIndex == ii){
+                                       diagonal_positions[i % block_size] = i;
+                                     }
+                                     all_global_memory[k] = _Xvector[colIndex * block_size + i % block_size];
+                                   });
 
-			  },
-			  product);
-			  //l2 dot product.
-			  //MD: TODO: if thread dot product is implemented, it should be called here again.
-			  nnz_scalar_t product2 = 0 ;
-			  Kokkos::parallel_reduce(
-					  Kokkos::ThreadVectorRange(teamMember, l2_val_size),
-					  [&] (nnz_lno_t colind2, nnz_scalar_t & valueToUpdate) {
-				  nnz_lno_t colind = colind2 + l1_val_size;
-				  valueToUpdate += all_global_memory[colind2] * _adj_vals(current_row_begin + colind);
-			  },
-			  product2);
+              row_begin = row_begin * block_size * block_size;
+              //sequentially solve in the block.
+              //this respects backward and forward sweeps.
+              for (int m = 0; m < block_size; ++m ){
+                int i = m;
+                if (is_backward) i = block_size - m - 1;
+                size_type current_row_begin = row_begin + i * row_size * block_size;
+                //first reduce l1 dot product.
+                //MD: TODO: if thread dot product is implemented it should be called here.
+                nnz_scalar_t product = 0 ;
+                Kokkos::parallel_reduce(
+                                        Kokkos::ThreadVectorRange(teamMember, l1_val_size),
+                                        [&] (nnz_lno_t colind, nnz_scalar_t & valueToUpdate) {
 
-			  product += product2;
-	 		//update the new vector entries.
-		      Kokkos::single(Kokkos::PerThread(teamMember),[=] () {
-		    	nnz_lno_t block_row_index = ii * block_size + i;
-		        nnz_scalar_t invDiagonalVal = _permuted_inverse_diagonal[block_row_index];
-                        _Xvector[block_row_index] += omega * (_Yvector[block_row_index] - product) * invDiagonalVal;
+                                          valueToUpdate += all_shared_memory[colind] * _adj_vals(current_row_begin + colind);
 
-			      //we need to update the values of the vector entries if they are already brought to shared memory to sync with global memory.
-			      if (diagonal_positions[i] != -1){
-			    	  if (diagonal_positions[i] < l1_val_size)
-			    		  all_shared_memory[diagonal_positions[i]] = _Xvector[block_row_index];
-			    	  else
-			    		  all_global_memory[diagonal_positions[i] - l1_val_size] = _Xvector[block_row_index];
-			      }
-		      });
-		
+                                        },
+                                        product);
+                //l2 dot product.
+                //MD: TODO: if thread dot product is implemented, it should be called here again.
+                nnz_scalar_t product2 = 0 ;
+                Kokkos::parallel_reduce(
+                                        Kokkos::ThreadVectorRange(teamMember, l2_val_size),
+                                        [&] (nnz_lno_t colind2, nnz_scalar_t & valueToUpdate) {
+                                          nnz_lno_t colind = colind2 + l1_val_size;
+                                          valueToUpdate += all_global_memory[colind2] * _adj_vals(current_row_begin + colind);
+                                        },
+                                        product2);
+
+                product += product2;
+                //update the new vector entries.
+                Kokkos::single(Kokkos::PerThread(teamMember),[=] () {
+                    nnz_lno_t block_row_index = ii * block_size + i;
+                    nnz_scalar_t invDiagonalVal = _permuted_inverse_diagonal[block_row_index];
+                    _Xvector[block_row_index] += omega * (_Yvector[block_row_index] - product) * invDiagonalVal;
+
+                    //we need to update the values of the vector entries if they are already brought to shared memory to sync with global memory.
+                    if (diagonal_positions[i] != -1){
+                      if (diagonal_positions[i] < l1_val_size)
+                        all_shared_memory[diagonal_positions[i]] = _Xvector[block_row_index];
+                      else
+                        all_global_memory[diagonal_positions[i] - l1_val_size] = _Xvector[block_row_index];
+                    }
+                  });
+
 
 
 #if KOKKOSSPARSE_IMPL_PRINTDEBUG
-			  if (/*i == 0 && ii == 1*/ ii == 0 || (block_size == 1 && ii < 2) ){
-				  std::cout << "\n\n\nrow:" << ii * block_size + i;
-				  std::cout << "\nneighbors:";
-				  for (int z = 0; z < int (row_size); ++z){
-					  std::cout << _adj[_xadj[ii] + z] << " ";
-				  }
+                if (/*i == 0 && ii == 1*/ ii == 0 || (block_size == 1 && ii < 2) ){
+                  std::cout << "\n\n\nrow:" << ii * block_size + i;
+                  std::cout << "\nneighbors:";
+                  for (int z = 0; z < int (row_size); ++z){
+                    std::cout << _adj[_xadj[ii] + z] << " ";
+                  }
 
-				  std::cout <<"\n\nrow-0:X -- all-shared-memory:";
-				  for (int z = 0; z < int (row_size * block_size); ++z){
-					  std::cout << all_shared_memory[z] << " ";
-				  }
-				  std::cout << std::endl << "product:" << product << std::endl;
-				  std::cout << "diagonal" << _permuted_inverse_diagonal[ii * block_size + i] << std::endl;
-				  std::cout << "_Yvector" << _Yvector[ii * block_size + i] << std::endl;
+                  std::cout <<"\n\nrow-0:X -- all-shared-memory:";
+                  for (int z = 0; z < int (row_size * block_size); ++z){
+                    std::cout << all_shared_memory[z] << " ";
+                  }
+                  std::cout << std::endl << "product:" << product << std::endl;
+                  std::cout << "diagonal" << _permuted_inverse_diagonal[ii * block_size + i] << std::endl;
+                  std::cout << "_Yvector" << _Yvector[ii * block_size + i] << std::endl;
 
-				  std::cout << std::endl << "block_row_index:" << ii * block_size + i <<  " _Xvector[block_row_index]:" << _Xvector[ii * block_size + i] << std::endl;
-			  }
+                  std::cout << std::endl << "block_row_index:" << ii * block_size + i <<  " _Xvector[block_row_index]:" << _Xvector[ii * block_size + i] << std::endl;
+                }
 #endif
-		  }
-		  if (row_size > num_max_vals_in_l1)
-		  Kokkos::single(Kokkos::PerThread(teamMember),[&] () {
-			  pool.release_chunk(all_global_memory);
-		  });
-	  });
+              }
+              if (row_size > num_max_vals_in_l1)
+                Kokkos::single(Kokkos::PerThread(teamMember),[&] () {
+                    pool.release_chunk(all_global_memory);
+                  });
+            });
 
 
-    }
+        }
 
-    KOKKOS_INLINE_FUNCTION
-    void operator()(const BlockTag&, const team_member_t & teamMember) const {
-
-
-      const nnz_lno_t team_row_begin = teamMember.league_rank() * team_work_size + _color_set_begin;
-      const nnz_lno_t team_row_end = KOKKOSKERNELS_MACRO_MIN(team_row_begin + team_work_size, _color_set_end);
-
-      nnz_scalar_t *all_shared_memory = (nnz_scalar_t *) (teamMember.team_shmem().get_shmem(shared_memory_size));
-
-	  all_shared_memory += thread_shared_memory_scalar_size * teamMember.team_rank();
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const BlockTag&, const team_member_t & teamMember) const {
 
 
-	  nnz_lno_t *diagonal_positions = (nnz_lno_t *)all_shared_memory;
-	  all_shared_memory =  (nnz_scalar_t *) (((nnz_lno_t *)all_shared_memory) + ((block_size / 8) + 1) * 8);
+          const nnz_lno_t team_row_begin = teamMember.league_rank() * team_work_size + _color_set_begin;
+          const nnz_lno_t team_row_end = KOKKOSKERNELS_MACRO_MIN(team_row_begin + team_work_size, _color_set_end);
+
+          nnz_scalar_t *all_shared_memory = (nnz_scalar_t *) (teamMember.team_shmem().get_shmem(shared_memory_size));
+
+          all_shared_memory += thread_shared_memory_scalar_size * teamMember.team_rank();
+
+
+          nnz_lno_t *diagonal_positions = (nnz_lno_t *)all_shared_memory;
+          all_shared_memory =  (nnz_scalar_t *) (((nnz_lno_t *)all_shared_memory) + ((block_size / 8) + 1) * 8);
 
 
 
-	  Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end), [&] (const nnz_lno_t& ii) {
+          Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end), [&] (const nnz_lno_t& ii) {
 #if KOKKOSSPARSE_IMPL_PRINTDEBUG
-	      Kokkos::single(Kokkos::PerThread(teamMember),[=] () {
-	    	  for(nnz_lno_t i = 0; i < block_size; diagonal_positions[i++] = -1);
-	      });
+              Kokkos::single(Kokkos::PerThread(teamMember),[=] () {
+                  for(nnz_lno_t i = 0; i < block_size; diagonal_positions[i++] = -1);
+                });
 #endif
 
 
-		  Kokkos::parallel_for(
-				  Kokkos::ThreadVectorRange(teamMember, block_size),
-				  [&] (nnz_lno_t i) {
-			  diagonal_positions[i] = -1;
-		  });
+              Kokkos::parallel_for(
+                                   Kokkos::ThreadVectorRange(teamMember, block_size),
+                                   [&] (nnz_lno_t i) {
+                                     diagonal_positions[i] = -1;
+                                   });
 
-		  size_type row_begin = _xadj[ii];
-		  size_type row_end = _xadj[ii + 1];
-		  nnz_lno_t row_size = row_end - row_begin;
+              size_type row_begin = _xadj[ii];
+              size_type row_end = _xadj[ii + 1];
+              nnz_lno_t row_size = row_end - row_begin;
 
-		  Kokkos::parallel_for(
-				  Kokkos::ThreadVectorRange(teamMember, row_size * block_size),
-				  [&] (nnz_lno_t i) {
-
-
-			  size_type adjind = i / block_size + row_begin;
-			  nnz_lno_t colIndex = _adj[adjind];
-
-			  if (colIndex == ii){
-				  diagonal_positions[i % block_size] = i;
-			  }
-			  all_shared_memory[i] = _Xvector[colIndex * block_size + i % block_size];
-
-		  });
-
-		  row_begin = row_begin * block_size * block_size;
-                  
-		  for (int m = 0; m < block_size; ++m ){
-  			  int i = m;
-			  if (is_backward) i = block_size - m - 1;
-                          size_type current_row_begin = row_begin + i * row_size * block_size;
-
-			  nnz_scalar_t product = 0 ;
-			  Kokkos::parallel_reduce(
-					  Kokkos::ThreadVectorRange(teamMember, row_size * block_size),
-					  [&] (nnz_lno_t colind, nnz_scalar_t & valueToUpdate) {
-
-				  valueToUpdate += all_shared_memory[colind] * _adj_vals(current_row_begin + colind);
-
-			  },
-			  product);
+              Kokkos::parallel_for(
+                                   Kokkos::ThreadVectorRange(teamMember, row_size * block_size),
+                                   [&] (nnz_lno_t i) {
 
 
-		      Kokkos::single(Kokkos::PerThread(teamMember),[=] () {
-		    	nnz_lno_t block_row_index = ii * block_size + i;
-		        nnz_scalar_t invDiagonalVal = _permuted_inverse_diagonal[block_row_index];
-		        _Xvector[block_row_index] += omega * (_Yvector[block_row_index] - product) * invDiagonalVal;
+                                     size_type adjind = i / block_size + row_begin;
+                                     nnz_lno_t colIndex = _adj[adjind];
+
+                                     if (colIndex == ii){
+                                       diagonal_positions[i % block_size] = i;
+                                     }
+                                     all_shared_memory[i] = _Xvector[colIndex * block_size + i % block_size];
+
+                                   });
+
+              row_begin = row_begin * block_size * block_size;
+
+              for (int m = 0; m < block_size; ++m ){
+                int i = m;
+                if (is_backward) i = block_size - m - 1;
+                size_type current_row_begin = row_begin + i * row_size * block_size;
+
+                nnz_scalar_t product = 0 ;
+                Kokkos::parallel_reduce(
+                                        Kokkos::ThreadVectorRange(teamMember, row_size * block_size),
+                                        [&] (nnz_lno_t colind, nnz_scalar_t & valueToUpdate) {
+
+                                          valueToUpdate += all_shared_memory[colind] * _adj_vals(current_row_begin + colind);
+
+                                        },
+                                        product);
 
 
-			      if (diagonal_positions[i] != -1){
-			    	  all_shared_memory[diagonal_positions[i]] = _Xvector[block_row_index];
-			      }
+                Kokkos::single(Kokkos::PerThread(teamMember),[=] () {
+                    nnz_lno_t block_row_index = ii * block_size + i;
+                    nnz_scalar_t invDiagonalVal = _permuted_inverse_diagonal[block_row_index];
+                    _Xvector[block_row_index] += omega * (_Yvector[block_row_index] - product) * invDiagonalVal;
 
-		      });
+
+                    if (diagonal_positions[i] != -1){
+                      all_shared_memory[diagonal_positions[i]] = _Xvector[block_row_index];
+                    }
+
+                  });
 
 #if !defined(__CUDA_ARCH__)
 #if KOKKOSSPARSE_IMPL_PRINTDEBUG
-			  if (/*i == 0 && ii == 1*/ ii == 0 || (block_size == 1 && ii < 2) ){
-				  std::cout << "\n\n\nrow:" << ii * block_size + i;
-				  std::cout << "\nneighbors:";
-				  for (int z = 0; z < int (row_size); ++z){
-					  std::cout << _adj[_xadj[ii] + z] << " ";
-				  }
+                if (/*i == 0 && ii == 1*/ ii == 0 || (block_size == 1 && ii < 2) ){
+                  std::cout << "\n\n\nrow:" << ii * block_size + i;
+                  std::cout << "\nneighbors:";
+                  for (int z = 0; z < int (row_size); ++z){
+                    std::cout << _adj[_xadj[ii] + z] << " ";
+                  }
 
-				  std::cout <<"\n\nrow-0:X -- all-shared-memory:";
-				  for (int z = 0; z < int (row_size * block_size); ++z){
-					  std::cout << all_shared_memory[z] << " ";
-				  }
-				  std::cout << std::endl << "product:" << product << std::endl;
-				  std::cout << "diagonal" << _permuted_inverse_diagonal[ii * block_size + i] << std::endl;
-				  std::cout << "_Yvector" << _Yvector[ii * block_size + i] << std::endl;
+                  std::cout <<"\n\nrow-0:X -- all-shared-memory:";
+                  for (int z = 0; z < int (row_size * block_size); ++z){
+                    std::cout << all_shared_memory[z] << " ";
+                  }
+                  std::cout << std::endl << "product:" << product << std::endl;
+                  std::cout << "diagonal" << _permuted_inverse_diagonal[ii * block_size + i] << std::endl;
+                  std::cout << "_Yvector" << _Yvector[ii * block_size + i] << std::endl;
 
-				  std::cout << std::endl << "block_row_index:" << ii * block_size + i <<  " _Xvector[block_row_index]:" << _Xvector[ii * block_size + i] << std::endl << std::endl<< std::endl;
-			  }
+                  std::cout << std::endl << "block_row_index:" << ii * block_size + i <<  " _Xvector[block_row_index]:" << _Xvector[ii * block_size + i] << std::endl << std::endl<< std::endl;
+                }
 #endif
 #endif
-			  //row_begin += row_size * block_size;
-		  }
-	  });
+                //row_begin += row_size * block_size;
+              }
+            });
 
 
-    }
+        }
 
-    size_t team_shmem_size (int team_size) const {
-      return shared_memory_size;
-    }
-  };
-
-
-
-  /**
-   * \brief constructor
-   */
-
-  GaussSeidel(HandleType *handle_,
-              nnz_lno_t num_rows_,
-              nnz_lno_t num_cols_,
-              const_lno_row_view_t row_map_,
-              const_lno_nnz_view_t entries_,
-              const_scalar_nnz_view_t values_):
-    handle(handle_), num_rows(num_rows_), num_cols(num_cols_),
-    row_map(row_map_), entries(entries_), values(values_),
-    have_diagonal_given(false),
-    is_symmetric(true){}
-
-
-  GaussSeidel(HandleType *handle_,
-              nnz_lno_t num_rows_,
-              nnz_lno_t num_cols_,
-              const_lno_row_view_t row_map_,
-              const_lno_nnz_view_t entries_,
-              bool is_symmetric_ = true):
-    handle(handle_),
-    num_rows(num_rows_), num_cols(num_cols_),
-    row_map(row_map_),
-    entries(entries_),
-    values(),
-    have_diagonal_given(false),
-    is_symmetric(is_symmetric_){}
+        size_t team_shmem_size (int team_size) const {
+          return shared_memory_size;
+        }
+      };
 
 
 
-  /**
-   * \brief constructor
-   */
-  GaussSeidel(HandleType *handle_,
-              nnz_lno_t num_rows_,
-              nnz_lno_t num_cols_,
-              const_lno_row_view_t row_map_,
-              const_lno_nnz_view_t entries_,
-              const_scalar_nnz_view_t values_,
-              bool is_symmetric_):
-    handle(handle_),
-    num_rows(num_rows_), num_cols(num_cols_),
-    row_map(row_map_), entries(entries_), values(values_),
-    have_diagonal_given(false),
-    is_symmetric(is_symmetric_){}
+      /**
+       * \brief constructor
+       */
+
+      GaussSeidel(HandleType *handle_,
+                  nnz_lno_t num_rows_,
+                  nnz_lno_t num_cols_,
+                  const_lno_row_view_t row_map_,
+                  const_lno_nnz_view_t entries_,
+                  const_scalar_nnz_view_t values_):
+        handle(handle_), num_rows(num_rows_), num_cols(num_cols_),
+        row_map(row_map_), entries(entries_), values(values_),
+        have_diagonal_given(false),
+        is_symmetric(true){}
 
 
-  GaussSeidel(HandleType *handle_,
-              nnz_lno_t num_rows_,
-              nnz_lno_t num_cols_,
-              const_lno_row_view_t row_map_,
-              const_lno_nnz_view_t entries_,
-              const_scalar_nnz_view_t values_,
-              const_scalar_nnz_view_t given_inverse_diagonal_,
-              bool is_symmetric_):
-    handle(handle_),
-    num_rows(num_rows_), num_cols(num_cols_),
-    row_map(row_map_), entries(entries_), values(values_),
-    given_inverse_diagonal(given_inverse_diagonal_),
-    have_diagonal_given(true),
-    is_symmetric(is_symmetric_){}
-
-
-
-  void initialize_symbolic(){
-    typename HandleType::GraphColoringHandleType *gchandle = this->handle->get_graph_coloring_handle();
-
-
-    if (gchandle == NULL){
-
-      this->handle->create_graph_coloring_handle();
-      //this->handle->create_gs_handle();
-      this->handle->get_gs_handle()->set_owner_of_coloring();
-      gchandle = this->handle->get_graph_coloring_handle();
-    }
+      GaussSeidel(HandleType *handle_,
+                  nnz_lno_t num_rows_,
+                  nnz_lno_t num_cols_,
+                  const_lno_row_view_t row_map_,
+                  const_lno_nnz_view_t entries_,
+                  bool is_symmetric_ = true):
+        handle(handle_),
+        num_rows(num_rows_), num_cols(num_cols_),
+        row_map(row_map_),
+        entries(entries_),
+        values(),
+        have_diagonal_given(false),
+        is_symmetric(is_symmetric_){}
 
 
 
-    const_lno_row_view_t xadj = this->row_map;
-    const_lno_nnz_view_t adj = this->entries;
-    size_type nnz = adj.extent(0);
+      /**
+       * \brief constructor
+       */
+      GaussSeidel(HandleType *handle_,
+                  nnz_lno_t num_rows_,
+                  nnz_lno_t num_cols_,
+                  const_lno_row_view_t row_map_,
+                  const_lno_nnz_view_t entries_,
+                  const_scalar_nnz_view_t values_,
+                  bool is_symmetric_):
+        handle(handle_),
+        num_rows(num_rows_), num_cols(num_cols_),
+        row_map(row_map_), entries(entries_), values(values_),
+        have_diagonal_given(false),
+        is_symmetric(is_symmetric_){}
+
+
+      GaussSeidel(HandleType *handle_,
+                  nnz_lno_t num_rows_,
+                  nnz_lno_t num_cols_,
+                  const_lno_row_view_t row_map_,
+                  const_lno_nnz_view_t entries_,
+                  const_scalar_nnz_view_t values_,
+                  const_scalar_nnz_view_t given_inverse_diagonal_,
+                  bool is_symmetric_):
+        handle(handle_),
+        num_rows(num_rows_), num_cols(num_cols_),
+        row_map(row_map_), entries(entries_), values(values_),
+        given_inverse_diagonal(given_inverse_diagonal_),
+        have_diagonal_given(true),
+        is_symmetric(is_symmetric_){}
+
+
+
+      void initialize_symbolic(){
+        typename HandleType::GraphColoringHandleType *gchandle = this->handle->get_graph_coloring_handle();
+
+
+        if (gchandle == NULL){
+
+          this->handle->create_graph_coloring_handle();
+          //this->handle->create_gs_handle();
+          this->handle->get_gs_handle()->set_owner_of_coloring();
+          gchandle = this->handle->get_graph_coloring_handle();
+        }
+
+
+
+        const_lno_row_view_t xadj = this->row_map;
+        const_lno_nnz_view_t adj = this->entries;
+        size_type nnz = adj.extent(0);
 
 #ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
-    Kokkos::Impl::Timer timer;
+        Kokkos::Impl::Timer timer;
 #endif
-    {
-      if (!is_symmetric){
+        {
+          if (!is_symmetric){
 
-        if (gchandle->get_coloring_algo_type() == KokkosGraph::COLORING_EB){
-	 
-          gchandle->symmetrize_and_calculate_lower_diagonal_edge_list(num_rows, xadj, adj);
-          KokkosGraph::Experimental::graph_color_symbolic <HandleType, const_lno_row_view_t, const_lno_nnz_view_t>
-              (this->handle, num_rows, num_rows, xadj , adj);
+            if (gchandle->get_coloring_algo_type() == KokkosGraph::COLORING_EB){
+
+              gchandle->symmetrize_and_calculate_lower_diagonal_edge_list(num_rows, xadj, adj);
+              KokkosGraph::Experimental::graph_color_symbolic <HandleType, const_lno_row_view_t, const_lno_nnz_view_t>
+                (this->handle, num_rows, num_rows, xadj , adj);
+            }
+            else {
+              row_lno_temp_work_view_t tmp_xadj;
+              nnz_lno_temp_work_view_t tmp_adj;
+              KokkosKernels::Impl::symmetrize_graph_symbolic_hashmap
+                < const_lno_row_view_t, const_lno_nnz_view_t,
+                  row_lno_temp_work_view_t, nnz_lno_temp_work_view_t,
+                  MyExecSpace>
+                (num_rows, xadj, adj, tmp_xadj, tmp_adj );
+              KokkosGraph::Experimental::graph_color_symbolic <HandleType, row_lno_temp_work_view_t, nnz_lno_temp_work_view_t> (this->handle, num_rows, num_rows, tmp_xadj , tmp_adj);
+            }
+          }
+          else {
+            KokkosGraph::Experimental::graph_color_symbolic <HandleType, const_lno_row_view_t, const_lno_nnz_view_t> (this->handle, num_rows, num_rows, xadj , adj);
+          }
         }
-        else {
-          row_lno_temp_work_view_t tmp_xadj;
-          nnz_lno_temp_work_view_t tmp_adj;
-          KokkosKernels::Impl::symmetrize_graph_symbolic_hashmap
-          < const_lno_row_view_t, const_lno_nnz_view_t,
-          row_lno_temp_work_view_t, nnz_lno_temp_work_view_t,
-          MyExecSpace>
-          (num_rows, xadj, adj, tmp_xadj, tmp_adj );
-          KokkosGraph::Experimental::graph_color_symbolic <HandleType, row_lno_temp_work_view_t, nnz_lno_temp_work_view_t> (this->handle, num_rows, num_rows, tmp_xadj , tmp_adj);
-        }
-      }
-      else {
-        KokkosGraph::Experimental::graph_color_symbolic <HandleType, const_lno_row_view_t, const_lno_nnz_view_t> (this->handle, num_rows, num_rows, xadj , adj);
-      }
-    }
-    color_t numColors = gchandle->get_num_colors();
+        color_t numColors = gchandle->get_num_colors();
 #ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
-    std::cout << "COLORING_TIME:" << timer.seconds() << std::endl;
+        std::cout << "COLORING_TIME:" << timer.seconds() << std::endl;
 #endif
 
 
-    typename HandleType::GraphColoringHandleType::color_view_t colors =  gchandle->get_vertex_colors();
+        typename HandleType::GraphColoringHandleType::color_view_t colors =  gchandle->get_vertex_colors();
 #if KOKKOSSPARSE_IMPL_RUNSEQUENTIAL
-    numColors = num_rows;
-    KokkosKernels::Impl::print_1Dview(colors);
-    std::cout << "numCol:" << numColors << " numRows:" << num_rows << " cols:" << num_cols << " nnz:" << adj.extent(0) <<  std::endl;
-    typename HandleType::GraphColoringHandleType::color_view_t::HostMirror  h_colors = Kokkos::create_mirror_view (colors);
-    for(int i = 0; i < num_rows; ++i){
-	h_colors(i) = i + 1;
-    }
-    Kokkos::deep_copy(colors, h_colors);
+        numColors = num_rows;
+        KokkosKernels::Impl::print_1Dview(colors);
+        std::cout << "numCol:" << numColors << " numRows:" << num_rows << " cols:" << num_cols << " nnz:" << adj.extent(0) <<  std::endl;
+        typename HandleType::GraphColoringHandleType::color_view_t::HostMirror  h_colors = Kokkos::create_mirror_view (colors);
+        for(int i = 0; i < num_rows; ++i){
+          h_colors(i) = i + 1;
+        }
+        Kokkos::deep_copy(colors, h_colors);
 #endif
-    nnz_lno_persistent_work_view_t color_xadj;
+        nnz_lno_persistent_work_view_t color_xadj;
 
-    nnz_lno_persistent_work_view_t color_adj;
+        nnz_lno_persistent_work_view_t color_adj;
 
 
 #ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
-    timer.reset();
+        timer.reset();
 #endif
 
-    KokkosKernels::Impl::create_reverse_map
-      <typename HandleType::GraphColoringHandleType::color_view_t,
-        nnz_lno_persistent_work_view_t, MyExecSpace>
-        (num_rows, numColors, colors, color_xadj, color_adj);
-    MyExecSpace::fence();
+        KokkosKernels::Impl::create_reverse_map
+          <typename HandleType::GraphColoringHandleType::color_view_t,
+           nnz_lno_persistent_work_view_t, MyExecSpace>
+          (num_rows, numColors, colors, color_xadj, color_adj);
+        MyExecSpace::fence();
 
 
 #ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
-    std::cout << "CREATE_REVERSE_MAP:" << timer.seconds() << std::endl;
-    timer.reset();
+        std::cout << "CREATE_REVERSE_MAP:" << timer.seconds() << std::endl;
+        timer.reset();
 #endif
 
-    nnz_lno_persistent_work_host_view_t  h_color_xadj = Kokkos::create_mirror_view (color_xadj);
-    Kokkos::deep_copy (h_color_xadj , color_xadj);
-    MyExecSpace::fence();
+        nnz_lno_persistent_work_host_view_t  h_color_xadj = Kokkos::create_mirror_view (color_xadj);
+        Kokkos::deep_copy (h_color_xadj , color_xadj);
+        MyExecSpace::fence();
 
 
 #ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
-    std::cout << "DEEP_COPY:" << timer.seconds() << std::endl;
-    timer.reset();
+        std::cout << "DEEP_COPY:" << timer.seconds() << std::endl;
+        timer.reset();
 #endif
 
 
 #if defined( KOKKOS_ENABLE_CUDA )
-    if (Kokkos::Impl::is_same<Kokkos::Cuda, MyExecSpace >::value){
-      for (nnz_lno_t i = 0; i < numColors; ++i){
-        nnz_lno_t color_index_begin = h_color_xadj(i);
-        nnz_lno_t color_index_end = h_color_xadj(i + 1);
+        if (Kokkos::Impl::is_same<Kokkos::Cuda, MyExecSpace >::value){
+          for (nnz_lno_t i = 0; i < numColors; ++i){
+            nnz_lno_t color_index_begin = h_color_xadj(i);
+            nnz_lno_t color_index_end = h_color_xadj(i + 1);
 
-        if (color_index_begin + 1 >= color_index_end ) continue;
-        auto colorsubset =
-            subview(color_adj, Kokkos::pair<row_lno_t, row_lno_t> (color_index_begin, color_index_end));
+            if (color_index_begin + 1 >= color_index_end ) continue;
+            auto colorsubset =
+              subview(color_adj, Kokkos::pair<row_lno_t, row_lno_t> (color_index_begin, color_index_end));
+            MyExecSpace::fence();
+            Kokkos::sort (colorsubset);
+            //TODO: MD 08/2017: If I remove the below fence, code fails on cuda.
+            //I do not see any reason yet it to fail.
+            MyExecSpace::fence();
+          }
+        }
+#endif
+
+
+
         MyExecSpace::fence();
-        Kokkos::sort (colorsubset);
-        //TODO: MD 08/2017: If I remove the below fence, code fails on cuda.
-        //I do not see any reason yet it to fail.
+#ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
+        std::cout << "SORT_TIME:" << timer.seconds() << std::endl;
+        timer.reset();
+        //std::cout << "sort" << std::endl;
+#endif
+
+        row_lno_persistent_work_view_t permuted_xadj ("new xadj", num_rows + 1);
+        nnz_lno_persistent_work_view_t old_to_new_map ("old_to_new_index_", num_rows );
+        nnz_lno_persistent_work_view_t permuted_adj ("newadj_", nnz );
+
+        Kokkos::parallel_for( "KokkosSparse::GaussSeidel::create_permuted_xadj", my_exec_space(0,num_rows),
+                              create_permuted_xadj(
+                                                   color_adj,
+                                                   xadj,
+                                                   permuted_xadj,
+                                                   old_to_new_map));
+        //std::cout << "create_permuted_xadj" << std::endl;
         MyExecSpace::fence();
+
+#ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
+        std::cout << "CREATE_PERMUTED_XADJ:" << timer.seconds() << std::endl;
+
+        timer.reset();
+#endif
+
+
+        KokkosKernels::Impl::inclusive_parallel_prefix_sum
+          <row_lno_persistent_work_view_t, MyExecSpace>
+          (num_rows + 1, permuted_xadj);
+        MyExecSpace::fence();
+
+#ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
+        std::cout << "INCLUSIVE_PPS:" << timer.seconds() << std::endl;
+        timer.reset();
+#endif
+
+
+        Kokkos::parallel_for( "KokkosSparse::GaussSeidel::fill_matrix_symbolic",my_exec_space(0,num_rows),
+                              fill_matrix_symbolic(
+                                                   num_rows,
+                                                   color_adj,
+                                                   xadj,
+                                                   adj,
+                                                   //adj_vals,
+                                                   permuted_xadj,
+                                                   permuted_adj,
+                                                   //newvals_,
+                                                   old_to_new_map));
+        MyExecSpace::fence();
+
+#ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
+        std::cout << "SYMBOLIC_FILL:" << timer.seconds() << std::endl;
+        timer.reset();
+#endif
+
+        typename HandleType::GaussSeidelHandleType *gsHandler = this->handle->get_gs_handle();
+        nnz_lno_t block_size = this->handle->get_gs_handle()->get_block_size();
+
+        //MD: if block size is larger than 1;
+        //the algorithm copies the vector entries into shared memory and reuses this small shared memory for vector entries.
+        if (block_size > 1)
+          {
+            //first calculate max row size.
+            size_type max_row_size = 0;
+            KokkosKernels::Impl::kk_view_reduce_max_row_size<size_type, MyExecSpace>(num_rows, permuted_xadj.data(), permuted_xadj.data() + 1, max_row_size);
+            gsHandler->set_max_nnz(max_row_size);
+
+
+            nnz_lno_t brows = permuted_xadj.extent(0) - 1;
+            size_type bnnz =  permuted_adj.extent(0) * block_size * block_size;
+
+            int suggested_vector_size = this->handle->get_suggested_vector_size(brows, bnnz);
+            int suggested_team_size = this->handle->get_suggested_team_size(suggested_vector_size);
+            size_t shmem_size_to_use = this->handle->get_shmem_size();
+            //nnz_lno_t team_row_chunk_size = this->handle->get_team_work_size(suggested_team_size,MyExecSpace::concurrency(), brows);
+
+            //MD: now we calculate how much memory is needed for shared memory.
+            //we have two-level vectors: as in spgemm hashmaps.
+            //we try to fit everything into shared memory.
+            //if they fit, we can use BlockTeam function in Team_SGS functor.
+            //on CPUs, we make L1 vector big enough so that it will always hold it.
+            //on GPUs, we have a upper bound for shared memory: handle->get_shmem_size(): this is set to 32128 bytes.
+            //If things do not fit into shared memory, we allocate vectors in global memory and run BigBlockTeam in Team_SGS functor.
+            size_t level_1_mem = max_row_size * block_size * sizeof(nnz_scalar_t) + ((block_size / 8 ) + 1) * 8 * sizeof(nnz_lno_t);
+            level_1_mem = suggested_team_size * level_1_mem;
+            size_t level_2_mem = 0;
+            nnz_lno_t num_values_in_l1 = max_row_size;
+            nnz_lno_t num_values_in_l2 = 0;
+            nnz_lno_t num_big_rows = 0;
+
+            KokkosKernels::Impl::ExecSpaceType ex_sp = this->handle->get_handle_exec_space();
+            if (ex_sp != KokkosKernels::Impl::Exec_CUDA){
+              //again, if it is on CPUs, we make L1 as big as we need.
+              size_t l1mem = 1;
+              while(l1mem < level_1_mem){
+                l1mem *= 2;
+              }
+              gsHandler->set_level_1_mem(l1mem);
+              level_1_mem = l1mem;
+              level_2_mem = 0;
+            }
+            else {
+              //on GPUs set the L1 size to max shmem and calculate how much we need for L2.
+              //we try to shift with 8 always because of the errors we experience with memory shifts on GPUs.
+              level_1_mem = shmem_size_to_use;
+              num_values_in_l1 = (shmem_size_to_use / suggested_team_size - ((block_size / 8 ) + 1) * 8 * sizeof(nnz_lno_t)) / sizeof(nnz_scalar_t) / block_size;
+              if (((block_size / 8 ) + 1) * 8 * sizeof(nnz_lno_t) > shmem_size_to_use / suggested_team_size ) throw "Shared memory size is to small for the given block size\n";
+              if (num_values_in_l1 >= (nnz_lno_t) (max_row_size) ){
+                num_values_in_l2 = 0;
+                level_2_mem = 0;
+                num_big_rows = 0;
+              }
+              else {
+
+                num_values_in_l2 = max_row_size - num_values_in_l1;
+                level_2_mem = num_values_in_l2 * block_size  * sizeof(nnz_scalar_t);
+                //std::cout << "level_2_mem:" << level_2_mem << std::endl;
+                size_t l2mem = 1;
+                while(l2mem < level_2_mem){
+                  l2mem *= 2;
+                }
+                level_2_mem  = l2mem;
+                //std::cout << "level_2_mem:" << level_2_mem << std::endl;
+
+                size_type num_large_rows = 0;
+                KokkosKernels::Impl::kk_reduce_numrows_larger_than_threshold<row_lno_persistent_work_view_t, MyExecSpace>(brows, permuted_xadj, num_values_in_l1, num_large_rows);
+                num_big_rows = KOKKOSKERNELS_MACRO_MIN(num_large_rows, (size_type)(MyExecSpace::concurrency() / suggested_vector_size));
+                //std::cout << "num_big_rows:" << num_big_rows << std::endl;
+
+#if defined( KOKKOS_ENABLE_CUDA )
+                if (ex_sp == KokkosKernels::Impl::Exec_CUDA) {
+                  //check if we have enough memory for this. lower the concurrency if we do not have enugh memory.
+                  size_t free_byte ;
+                  size_t total_byte ;
+                  cudaMemGetInfo( &free_byte, &total_byte ) ;
+                  size_t required_size = size_t (num_big_rows) * level_2_mem;
+                  if (required_size + num_big_rows * sizeof(int) > free_byte){
+                    num_big_rows = ((((free_byte - num_big_rows * sizeof(int))* 0.8) /8 ) * 8) / level_2_mem;
+                  }
+                  {
+                    nnz_lno_t min_chunk_size = 1;
+                    while (min_chunk_size * 2 <= num_big_rows) {
+                      min_chunk_size *= 2;
+                    }
+                    num_big_rows = min_chunk_size;
+                  }
+                }
+#endif
+              }
+
+            }
+
+            gsHandler->set_max_nnz(max_row_size);
+            gsHandler->set_level_1_mem(level_1_mem);
+            gsHandler->set_level_2_mem(level_2_mem);
+
+            gsHandler->set_num_values_in_l1(num_values_in_l1);
+            gsHandler->set_num_values_in_l2(num_values_in_l2);
+            gsHandler->set_num_big_rows(num_big_rows);
+
+          }
+
+
+        gsHandler->set_color_set_xadj(h_color_xadj);
+        gsHandler->set_color_set_adj(color_adj);
+        gsHandler->set_num_colors(numColors);
+        gsHandler->set_new_xadj(permuted_xadj);
+        gsHandler->set_new_adj(permuted_adj);
+        //gsHandler->set_new_adj_val(newvals_);
+        gsHandler->set_old_to_new_map(old_to_new_map);
+        if (this->handle->get_gs_handle()->is_owner_of_coloring()){
+          this->handle->destroy_graph_coloring_handle();
+          this->handle->get_gs_handle()->set_owner_of_coloring(false);
+        }
+        this->handle->get_gs_handle()->set_call_symbolic(true);
+
+
+        this->handle->get_gs_handle()->allocate_x_y_vectors(this->num_rows * block_size, this->num_cols * block_size);
+        //std::cout << "all end" << std::endl;
+#ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
+        std::cout << "ALLOC:" << timer.seconds() << std::endl;
+#endif
       }
-    }
-#endif
 
-
-
-    MyExecSpace::fence();
-#ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
-    std::cout << "SORT_TIME:" << timer.seconds() << std::endl;
-    timer.reset();
-    //std::cout << "sort" << std::endl;
-#endif
-
-    row_lno_persistent_work_view_t permuted_xadj ("new xadj", num_rows + 1);
-    nnz_lno_persistent_work_view_t old_to_new_map ("old_to_new_index_", num_rows );
-    nnz_lno_persistent_work_view_t permuted_adj ("newadj_", nnz );
-
-    Kokkos::parallel_for( "KokkosSparse::GaussSeidel::create_permuted_xadj", my_exec_space(0,num_rows),
+      struct create_permuted_xadj{
+        nnz_lno_persistent_work_view_t color_adj;
+        const_lno_row_view_t oldxadj;
+        row_lno_persistent_work_view_t newxadj;
+        nnz_lno_persistent_work_view_t old_to_new_index;
         create_permuted_xadj(
-            color_adj,
-            xadj,
-            permuted_xadj,
-            old_to_new_map));
-    //std::cout << "create_permuted_xadj" << std::endl;
-    MyExecSpace::fence();
-
-#ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
-    std::cout << "CREATE_PERMUTED_XADJ:" << timer.seconds() << std::endl;
-
-    timer.reset();
-#endif
-
-
-    KokkosKernels::Impl::inclusive_parallel_prefix_sum
-        <row_lno_persistent_work_view_t, MyExecSpace>
-        (num_rows + 1, permuted_xadj);
-    MyExecSpace::fence();
-
-#ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
-    std::cout << "INCLUSIVE_PPS:" << timer.seconds() << std::endl;
-    timer.reset();
-#endif
-
-
-    Kokkos::parallel_for( "KokkosSparse::GaussSeidel::fill_matrix_symbolic",my_exec_space(0,num_rows),
-        fill_matrix_symbolic(
-            num_rows,
-            color_adj,
-            xadj,
-            adj,
-            //adj_vals,
-            permuted_xadj,
-            permuted_adj,
-            //newvals_,
-            old_to_new_map));
-    MyExecSpace::fence();
-
-#ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
-    std::cout << "SYMBOLIC_FILL:" << timer.seconds() << std::endl;
-    timer.reset();
-#endif
-
-    typename HandleType::GaussSeidelHandleType *gsHandler = this->handle->get_gs_handle();
-    nnz_lno_t block_size = this->handle->get_gs_handle()->get_block_size();
-
-    //MD: if block size is larger than 1;
-    //the algorithm copies the vector entries into shared memory and reuses this small shared memory for vector entries.
-    if (block_size > 1)
-    {
-	//first calculate max row size.
-    	size_type max_row_size = 0;
-    	KokkosKernels::Impl::kk_view_reduce_max_row_size<size_type, MyExecSpace>(num_rows, permuted_xadj.data(), permuted_xadj.data() + 1, max_row_size);
-    	gsHandler->set_max_nnz(max_row_size);
-
-
-        nnz_lno_t brows = permuted_xadj.extent(0) - 1;
-        size_type bnnz =  permuted_adj.extent(0) * block_size * block_size;
-
-        int suggested_vector_size = this->handle->get_suggested_vector_size(brows, bnnz);
-        int suggested_team_size = this->handle->get_suggested_team_size(suggested_vector_size);
-        size_t shmem_size_to_use = this->handle->get_shmem_size();
-        //nnz_lno_t team_row_chunk_size = this->handle->get_team_work_size(suggested_team_size,MyExecSpace::concurrency(), brows);
-
-	//MD: now we calculate how much memory is needed for shared memory.
-	//we have two-level vectors: as in spgemm hashmaps.
-	//we try to fit everything into shared memory. 
-	//if they fit, we can use BlockTeam function in Team_SGS functor.
-	//on CPUs, we make L1 vector big enough so that it will always hold it.
-	//on GPUs, we have a upper bound for shared memory: handle->get_shmem_size(): this is set to 32128 bytes. 
-	//If things do not fit into shared memory, we allocate vectors in global memory and run BigBlockTeam in Team_SGS functor.
-	size_t level_1_mem = max_row_size * block_size * sizeof(nnz_scalar_t) + ((block_size / 8 ) + 1) * 8 * sizeof(nnz_lno_t);
-	level_1_mem = suggested_team_size * level_1_mem;
-	size_t level_2_mem = 0;
-	nnz_lno_t num_values_in_l1 = max_row_size;
-	nnz_lno_t num_values_in_l2 = 0;
-	nnz_lno_t num_big_rows = 0;
-
-	KokkosKernels::Impl::ExecSpaceType ex_sp = this->handle->get_handle_exec_space();
-    	if (ex_sp != KokkosKernels::Impl::Exec_CUDA){
-		//again, if it is on CPUs, we make L1 as big as we need.
-    		size_t l1mem = 1;
-    		while(l1mem < level_1_mem){
-    			l1mem *= 2;
-    		}
-        	gsHandler->set_level_1_mem(l1mem);
-        	level_1_mem = l1mem;
-        	level_2_mem = 0;
-    	}
-    	else {
-		//on GPUs set the L1 size to max shmem and calculate how much we need for L2.
-		//we try to shift with 8 always because of the errors we experience with memory shifts on GPUs.
-    		level_1_mem = shmem_size_to_use;
-    		num_values_in_l1 = (shmem_size_to_use / suggested_team_size - ((block_size / 8 ) + 1) * 8 * sizeof(nnz_lno_t)) / sizeof(nnz_scalar_t) / block_size;
-                if (((block_size / 8 ) + 1) * 8 * sizeof(nnz_lno_t) > shmem_size_to_use / suggested_team_size ) throw "Shared memory size is to small for the given block size\n";
-		if (num_values_in_l1 >= (nnz_lno_t) (max_row_size) ){
-		num_values_in_l2 = 0;
-		level_2_mem = 0;
-		num_big_rows = 0;
-		}
-		else {
-
-			num_values_in_l2 = max_row_size - num_values_in_l1;
-			level_2_mem = num_values_in_l2 * block_size  * sizeof(nnz_scalar_t);
-			//std::cout << "level_2_mem:" << level_2_mem << std::endl; 
-			size_t l2mem = 1; 
-			while(l2mem < level_2_mem){
-				l2mem *= 2;
-			}
-			level_2_mem  = l2mem;
-			//std::cout << "level_2_mem:" << level_2_mem << std::endl;
-
-			size_type num_large_rows = 0;
-			KokkosKernels::Impl::kk_reduce_numrows_larger_than_threshold<row_lno_persistent_work_view_t, MyExecSpace>(brows, permuted_xadj, num_values_in_l1, num_large_rows);
-			num_big_rows = KOKKOSKERNELS_MACRO_MIN(num_large_rows, (size_type)(MyExecSpace::concurrency() / suggested_vector_size));
-			//std::cout << "num_big_rows:" << num_big_rows << std::endl;
-
-#if defined( KOKKOS_ENABLE_CUDA )
-			if (ex_sp == KokkosKernels::Impl::Exec_CUDA) {
-				//check if we have enough memory for this. lower the concurrency if we do not have enugh memory.
-				size_t free_byte ;
-				size_t total_byte ;
-				cudaMemGetInfo( &free_byte, &total_byte ) ;
-				size_t required_size = size_t (num_big_rows) * level_2_mem;
-				if (required_size + num_big_rows * sizeof(int) > free_byte){
-					num_big_rows = ((((free_byte - num_big_rows * sizeof(int))* 0.8) /8 ) * 8) / level_2_mem;
-				}
-				{
-					nnz_lno_t min_chunk_size = 1;
-					while (min_chunk_size * 2 <= num_big_rows) {
-						min_chunk_size *= 2;
-					}
-					num_big_rows = min_chunk_size;
-				}
-			}
-#endif
-		}
-
-	}
-
-    	gsHandler->set_max_nnz(max_row_size);
-    	gsHandler->set_level_1_mem(level_1_mem);
-    	gsHandler->set_level_2_mem(level_2_mem);
-
-    	gsHandler->set_num_values_in_l1(num_values_in_l1);
-    	gsHandler->set_num_values_in_l2(num_values_in_l2);
-    	gsHandler->set_num_big_rows(num_big_rows);
-
-    }
-
-
-    gsHandler->set_color_set_xadj(h_color_xadj);
-    gsHandler->set_color_set_adj(color_adj);
-    gsHandler->set_num_colors(numColors);
-    gsHandler->set_new_xadj(permuted_xadj);
-    gsHandler->set_new_adj(permuted_adj);
-    //gsHandler->set_new_adj_val(newvals_);
-    gsHandler->set_old_to_new_map(old_to_new_map);
-    if (this->handle->get_gs_handle()->is_owner_of_coloring()){
-      this->handle->destroy_graph_coloring_handle();
-      this->handle->get_gs_handle()->set_owner_of_coloring(false);
-    }
-    this->handle->get_gs_handle()->set_call_symbolic(true);
-
-
-    this->handle->get_gs_handle()->allocate_x_y_vectors(this->num_rows * block_size, this->num_cols * block_size);
-    //std::cout << "all end" << std::endl;
-#ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
-    std::cout << "ALLOC:" << timer.seconds() << std::endl;
-#endif
-  }
-
-  struct create_permuted_xadj{
-    nnz_lno_persistent_work_view_t color_adj;
-    const_lno_row_view_t oldxadj;
-    row_lno_persistent_work_view_t newxadj;
-    nnz_lno_persistent_work_view_t old_to_new_index;
-    create_permuted_xadj(
-        nnz_lno_persistent_work_view_t color_adj_,
-        const_lno_row_view_t oldxadj_,
-        row_lno_persistent_work_view_t newxadj_,
-        nnz_lno_persistent_work_view_t old_to_new_index_):
+                             nnz_lno_persistent_work_view_t color_adj_,
+                             const_lno_row_view_t oldxadj_,
+                             row_lno_persistent_work_view_t newxadj_,
+                             nnz_lno_persistent_work_view_t old_to_new_index_):
           color_adj(color_adj_), oldxadj(oldxadj_),
           newxadj(newxadj_),old_to_new_index(old_to_new_index_){}
 
-    KOKKOS_INLINE_FUNCTION
-    void operator()(const nnz_lno_t &i) const{
-      nnz_lno_t index = color_adj(i);
-      newxadj(i + 1) = oldxadj[index + 1] - oldxadj[index];
-      old_to_new_index[index] = i;
-    }
-  };
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const nnz_lno_t &i) const{
+          nnz_lno_t index = color_adj(i);
+          newxadj(i + 1) = oldxadj[index + 1] - oldxadj[index];
+          old_to_new_index[index] = i;
+        }
+      };
 
-  struct fill_matrix_symbolic{
-    nnz_lno_t num_rows;
-    nnz_lno_persistent_work_view_t color_adj;
-    const_lno_row_view_t oldxadj;
-    const_lno_nnz_view_t oldadj;
-    //value_array_type oldadjvals;
-    row_lno_persistent_work_view_t newxadj;
-    nnz_lno_persistent_work_view_t newadj;
-    //value_persistent_work_array_type newadjvals;
-    nnz_lno_persistent_work_view_t old_to_new_index;
-    fill_matrix_symbolic(
-        nnz_lno_t num_rows_,
-        nnz_lno_persistent_work_view_t color_adj_,
-        const_lno_row_view_t oldxadj_,
-        const_lno_nnz_view_t oldadj_,
-        //value_array_type oldadjvals_,
-        row_lno_persistent_work_view_t newxadj_,
-        nnz_lno_persistent_work_view_t newadj_,
-        //value_persistent_work_array_type newadjvals_,
-        nnz_lno_persistent_work_view_t old_to_new_index_):
+      struct fill_matrix_symbolic{
+        nnz_lno_t num_rows;
+        nnz_lno_persistent_work_view_t color_adj;
+        const_lno_row_view_t oldxadj;
+        const_lno_nnz_view_t oldadj;
+        //value_array_type oldadjvals;
+        row_lno_persistent_work_view_t newxadj;
+        nnz_lno_persistent_work_view_t newadj;
+        //value_persistent_work_array_type newadjvals;
+        nnz_lno_persistent_work_view_t old_to_new_index;
+        fill_matrix_symbolic(
+                             nnz_lno_t num_rows_,
+                             nnz_lno_persistent_work_view_t color_adj_,
+                             const_lno_row_view_t oldxadj_,
+                             const_lno_nnz_view_t oldadj_,
+                             //value_array_type oldadjvals_,
+                             row_lno_persistent_work_view_t newxadj_,
+                             nnz_lno_persistent_work_view_t newadj_,
+                             //value_persistent_work_array_type newadjvals_,
+                             nnz_lno_persistent_work_view_t old_to_new_index_):
           num_rows(num_rows_),
           color_adj(color_adj_), oldxadj(oldxadj_), oldadj(oldadj_), //oldadjvals(oldadjvals_),
           newxadj(newxadj_), newadj(newadj_), //newadjvals(newadjvals_),
           old_to_new_index(old_to_new_index_){}
 
-    KOKKOS_INLINE_FUNCTION
-    void operator()(const nnz_lno_t &i) const{
-      nnz_lno_t index = color_adj(i);
-      size_type xadj_begin = newxadj(i);
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const nnz_lno_t &i) const{
+          nnz_lno_t index = color_adj(i);
+          size_type xadj_begin = newxadj(i);
 
-      size_type old_xadj_end = oldxadj[index + 1];
-      for (size_type j = oldxadj[index]; j < old_xadj_end; ++j){
-        nnz_lno_t neighbor = oldadj[j];
-        if(neighbor < num_rows) neighbor = old_to_new_index[neighbor];
-        newadj[xadj_begin++] = neighbor;
-        //newadjvals[xadj_begin++] = oldadjvals[j];
-      }
-    }
-  };
+          size_type old_xadj_end = oldxadj[index + 1];
+          for (size_type j = oldxadj[index]; j < old_xadj_end; ++j){
+            nnz_lno_t neighbor = oldadj[j];
+            if(neighbor < num_rows) neighbor = old_to_new_index[neighbor];
+            newadj[xadj_begin++] = neighbor;
+            //newadjvals[xadj_begin++] = oldadjvals[j];
+          }
+        }
+      };
 
 
-  struct fill_matrix_numeric{
-    nnz_lno_persistent_work_view_t color_adj;
-    const_lno_row_view_t oldxadj;
-    const_scalar_nnz_view_t oldadjvals;
-    row_lno_persistent_work_view_t newxadj;
-    scalar_persistent_work_view_t newadjvals;
+      struct fill_matrix_numeric{
+        nnz_lno_persistent_work_view_t color_adj;
+        const_lno_row_view_t oldxadj;
+        const_scalar_nnz_view_t oldadjvals;
+        row_lno_persistent_work_view_t newxadj;
+        scalar_persistent_work_view_t newadjvals;
 
-    nnz_lno_t num_total_rows;
-    nnz_lno_t rows_per_team;
-    nnz_lno_t block_matrix_size;
-    fill_matrix_numeric(
-        nnz_lno_persistent_work_view_t color_adj_,
-        const_lno_row_view_t oldxadj_,
-        const_scalar_nnz_view_t oldadjvals_,
-        row_lno_persistent_work_view_t newxadj_,
-        scalar_persistent_work_view_t newadjvals_,
-		nnz_lno_t num_total_rows_,
-		nnz_lno_t rows_per_team_ , nnz_lno_t block_matrix_size_):
+        nnz_lno_t num_total_rows;
+        nnz_lno_t rows_per_team;
+        nnz_lno_t block_matrix_size;
+        fill_matrix_numeric(
+                            nnz_lno_persistent_work_view_t color_adj_,
+                            const_lno_row_view_t oldxadj_,
+                            const_scalar_nnz_view_t oldadjvals_,
+                            row_lno_persistent_work_view_t newxadj_,
+                            scalar_persistent_work_view_t newadjvals_,
+                            nnz_lno_t num_total_rows_,
+                            nnz_lno_t rows_per_team_ , nnz_lno_t block_matrix_size_):
           color_adj(color_adj_), oldxadj(oldxadj_),  oldadjvals(oldadjvals_),
           newxadj(newxadj_), newadjvals(newadjvals_),
-		  num_total_rows(num_total_rows_), rows_per_team(rows_per_team_), block_matrix_size(block_matrix_size_){}
+          num_total_rows(num_total_rows_), rows_per_team(rows_per_team_), block_matrix_size(block_matrix_size_){}
 
-    KOKKOS_INLINE_FUNCTION
-    void operator()(const nnz_lno_t &i) const{
-      nnz_lno_t index = color_adj(i);
-      size_type xadj_begin = newxadj(i) * block_matrix_size;
-      size_type old_xadj_end = oldxadj[index + 1] * block_matrix_size;
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const nnz_lno_t &i) const{
+          nnz_lno_t index = color_adj(i);
+          size_type xadj_begin = newxadj(i) * block_matrix_size;
+          size_type old_xadj_end = oldxadj[index + 1] * block_matrix_size;
 
-      for (size_type j = oldxadj[index] * block_matrix_size ; j < old_xadj_end; ++j){
-        newadjvals[xadj_begin++] = oldadjvals[j];
-      }
-    }
+          for (size_type j = oldxadj[index] * block_matrix_size ; j < old_xadj_end; ++j){
+            newadjvals[xadj_begin++] = oldadjvals[j];
+          }
+        }
 
-    KOKKOS_INLINE_FUNCTION
-    void operator()(const team_member_t &team) const{
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const team_member_t &team) const{
 
-    	const nnz_lno_t i_begin = team.league_rank() * rows_per_team;
-    	const nnz_lno_t i_end = i_begin + rows_per_team <= num_total_rows ? i_begin + rows_per_team : num_total_rows;
-    	Kokkos::parallel_for(Kokkos::TeamThreadRange(team,i_begin,i_end), [&] (const nnz_lno_t& i) {
-    		nnz_lno_t index = color_adj(i);
-			size_type xadj_begin = newxadj(i) * block_matrix_size;
+          const nnz_lno_t i_begin = team.league_rank() * rows_per_team;
+          const nnz_lno_t i_end = i_begin + rows_per_team <= num_total_rows ? i_begin + rows_per_team : num_total_rows;
+          Kokkos::parallel_for(Kokkos::TeamThreadRange(team,i_begin,i_end), [&] (const nnz_lno_t& i) {
+              nnz_lno_t index = color_adj(i);
+              size_type xadj_begin = newxadj(i) * block_matrix_size;
 
-    		size_type old_xadj_begin = oldxadj[index] * block_matrix_size;
-    		size_type old_xadj_end = oldxadj[index + 1] * block_matrix_size;
-    		Kokkos::parallel_for (Kokkos::ThreadVectorRange(team,old_xadj_end-old_xadj_begin), [&] (const nnz_lno_t& j) {
-    			newadjvals[xadj_begin + j] = oldadjvals[old_xadj_begin + j];
-    		});
-    	});
-    }
-  };
-
-
-  struct Get_Matrix_Diagonals{
-
-    row_lno_persistent_work_view_t _xadj;
-    nnz_lno_persistent_work_view_t _adj; // CSR storage of the graph.
-    scalar_persistent_work_view_t _adj_vals; // CSR storage of the graph.
-    scalar_persistent_work_view_t _diagonals;
-
-    nnz_lno_t num_total_rows;
-    nnz_lno_t rows_per_team;
-    nnz_lno_t block_size;
-    nnz_lno_t block_matrix_size;
-
-    nnz_scalar_t one;
+              size_type old_xadj_begin = oldxadj[index] * block_matrix_size;
+              size_type old_xadj_end = oldxadj[index + 1] * block_matrix_size;
+              Kokkos::parallel_for (Kokkos::ThreadVectorRange(team,old_xadj_end-old_xadj_begin), [&] (const nnz_lno_t& j) {
+                  newadjvals[xadj_begin + j] = oldadjvals[old_xadj_begin + j];
+                });
+            });
+        }
+      };
 
 
-    Get_Matrix_Diagonals(
-        row_lno_persistent_work_view_t xadj_,
-        nnz_lno_persistent_work_view_t adj_,
-        scalar_persistent_work_view_t adj_vals_,
-        scalar_persistent_work_view_t diagonals_,
-		nnz_lno_t num_total_rows_,
-		nnz_lno_t rows_per_team_ ,
-		nnz_lno_t block_size_,
-		nnz_lno_t block_matrix_size_):
+      struct Get_Matrix_Diagonals{
+
+        row_lno_persistent_work_view_t _xadj;
+        nnz_lno_persistent_work_view_t _adj; // CSR storage of the graph.
+        scalar_persistent_work_view_t _adj_vals; // CSR storage of the graph.
+        scalar_persistent_work_view_t _diagonals;
+
+        nnz_lno_t num_total_rows;
+        nnz_lno_t rows_per_team;
+        nnz_lno_t block_size;
+        nnz_lno_t block_matrix_size;
+
+        nnz_scalar_t one;
+
+
+        Get_Matrix_Diagonals(
+                             row_lno_persistent_work_view_t xadj_,
+                             nnz_lno_persistent_work_view_t adj_,
+                             scalar_persistent_work_view_t adj_vals_,
+                             scalar_persistent_work_view_t diagonals_,
+                             nnz_lno_t num_total_rows_,
+                             nnz_lno_t rows_per_team_ ,
+                             nnz_lno_t block_size_,
+                             nnz_lno_t block_matrix_size_):
           _xadj( xadj_),
           _adj( adj_),
           _adj_vals( adj_vals_), _diagonals(diagonals_),
-		  num_total_rows(num_total_rows_), rows_per_team(rows_per_team_),
-                  block_size(block_size_),block_matrix_size(block_matrix_size_),one(Kokkos::Details::ArithTraits<nnz_scalar_t>::one()){}
+          num_total_rows(num_total_rows_), rows_per_team(rows_per_team_),
+          block_size(block_size_),block_matrix_size(block_matrix_size_),one(Kokkos::Details::ArithTraits<nnz_scalar_t>::one()){}
 
-    KOKKOS_INLINE_FUNCTION
-    void operator()(const nnz_lno_t & row_id) const {
-      size_type row_begin = _xadj[row_id];
-      size_type row_end = _xadj[row_id + 1] ;
-      nnz_lno_t row_size = row_end - row_begin;
-      for (nnz_lno_t col_ind = 0; col_ind < row_size; ++col_ind){
-    	size_type nnz_ind = col_ind + row_begin;
-        nnz_lno_t column_id = _adj[nnz_ind];
-        if (column_id == row_id){
-        	size_type val_index = row_begin * block_matrix_size + col_ind;
-        	for (nnz_lno_t r = 0; r < block_size; ++r){
-        		nnz_scalar_t val = _adj_vals[val_index];
-        		_diagonals[row_id * block_size + r] = one / val;
-        		val_index += row_size + 1;
-        	}
-        	break;
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const nnz_lno_t & row_id) const {
+          size_type row_begin = _xadj[row_id];
+          size_type row_end = _xadj[row_id + 1] ;
+          nnz_lno_t row_size = row_end - row_begin;
+          for (nnz_lno_t col_ind = 0; col_ind < row_size; ++col_ind){
+            size_type nnz_ind = col_ind + row_begin;
+            nnz_lno_t column_id = _adj[nnz_ind];
+            if (column_id == row_id){
+              size_type val_index = row_begin * block_matrix_size + col_ind;
+              for (nnz_lno_t r = 0; r < block_size; ++r){
+                nnz_scalar_t val = _adj_vals[val_index];
+                _diagonals[row_id * block_size + r] = one / val;
+                val_index += row_size + 1;
+              }
+              break;
+            }
+          }
         }
-      }
-    }
 
-    KOKKOS_INLINE_FUNCTION
-    void operator()(const team_member_t &team) const{
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const team_member_t &team) const{
 
-    	const nnz_lno_t i_begin = team.league_rank() * rows_per_team;
-    	const nnz_lno_t i_end = i_begin + rows_per_team <= num_total_rows ? i_begin + rows_per_team : num_total_rows;
-    	Kokkos::parallel_for(Kokkos::TeamThreadRange(team,i_begin,i_end), [&] (const nnz_lno_t& row_id) {
-    		size_type row_begin = _xadj[row_id];
-    		size_type row_end = _xadj[row_id + 1] ;
-    		nnz_lno_t row_size = row_end - row_begin;
+          const nnz_lno_t i_begin = team.league_rank() * rows_per_team;
+          const nnz_lno_t i_end = i_begin + rows_per_team <= num_total_rows ? i_begin + rows_per_team : num_total_rows;
+          Kokkos::parallel_for(Kokkos::TeamThreadRange(team,i_begin,i_end), [&] (const nnz_lno_t& row_id) {
+              size_type row_begin = _xadj[row_id];
+              size_type row_end = _xadj[row_id + 1] ;
+              nnz_lno_t row_size = row_end - row_begin;
 
-    		Kokkos::parallel_for (Kokkos::ThreadVectorRange(team,row_size), [&] (const nnz_lno_t& col_ind) {
-    			size_type val_index = col_ind + row_begin;
-    	        nnz_lno_t column_id = _adj[val_index];
-    	        if (column_id == row_id){
-    	        	size_type _val_index = row_begin * block_matrix_size + col_ind * block_size;
-    	        	for (nnz_lno_t r = 0; r < block_size; ++r){
-    	        		nnz_scalar_t val = _adj_vals[_val_index];
-    	        		_diagonals[row_id * block_size + r] = one / val;
-    	        		_val_index += row_size * block_size + 1;
+              Kokkos::parallel_for (Kokkos::ThreadVectorRange(team,row_size), [&] (const nnz_lno_t& col_ind) {
+                  size_type val_index = col_ind + row_begin;
+                  nnz_lno_t column_id = _adj[val_index];
+                  if (column_id == row_id){
+                    size_type _val_index = row_begin * block_matrix_size + col_ind * block_size;
+                    for (nnz_lno_t r = 0; r < block_size; ++r){
+                      nnz_scalar_t val = _adj_vals[_val_index];
+                      _diagonals[row_id * block_size + r] = one / val;
+                      _val_index += row_size * block_size + 1;
 
-    	        		//std::cout << "row_id * block_size + r:" << row_id * block_size + r << " _diagonals[row_id * block_size + r]:" << _diagonals[row_id * block_size + r] << std::endl;
-    	        	}
-    	        }
-    		});
-    	});
-    }
-  };
+                      //std::cout << "row_id * block_size + r:" << row_id * block_size + r << " _diagonals[row_id * block_size + r]:" << _diagonals[row_id * block_size + r] << std::endl;
+                    }
+                  }
+                });
+            });
+        }
+      };
 
-  void initialize_numeric(){
+      void initialize_numeric(){
 
-    if (this->handle->get_gs_handle()->is_symbolic_called() == false){
-      this->initialize_symbolic();
-    }
-    //else
+        if (this->handle->get_gs_handle()->is_symbolic_called() == false){
+          this->initialize_symbolic();
+        }
+        //else
 #ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
-    Kokkos::Impl::Timer timer;
+        Kokkos::Impl::Timer timer;
 #endif
-    {
+        {
 
 
-      const_lno_row_view_t xadj = this->row_map;
-      const_lno_nnz_view_t adj = this->entries;
-      const_scalar_nnz_view_t adj_vals = this->values;
+          const_lno_row_view_t xadj = this->row_map;
+          const_lno_nnz_view_t adj = this->entries;
+          const_scalar_nnz_view_t adj_vals = this->values;
 
-      size_type nnz = adj_vals.extent(0);
+          size_type nnz = adj_vals.extent(0);
 
-      typename HandleType::GaussSeidelHandleType *gsHandler = this->handle->get_gs_handle();
-
-
-
-      row_lno_persistent_work_view_t newxadj_ = gsHandler->get_new_xadj();
-      nnz_lno_persistent_work_view_t old_to_new_map = gsHandler->get_old_to_new_map();
-      nnz_lno_persistent_work_view_t newadj_ = gsHandler->get_new_adj();
-
-      nnz_lno_persistent_work_view_t color_adj = gsHandler->get_color_adj();
-      scalar_persistent_work_view_t permuted_adj_vals (Kokkos::ViewAllocateWithoutInitializing("newvals_"), nnz );
+          typename HandleType::GaussSeidelHandleType *gsHandler = this->handle->get_gs_handle();
 
 
-      int suggested_vector_size = this->handle->get_suggested_vector_size(num_rows, nnz);
-      int suggested_team_size = this->handle->get_suggested_team_size(suggested_vector_size);
-      nnz_lno_t rows_per_team = this->handle->get_team_work_size(suggested_team_size,MyExecSpace::concurrency(), num_rows);
+
+          row_lno_persistent_work_view_t newxadj_ = gsHandler->get_new_xadj();
+          nnz_lno_persistent_work_view_t old_to_new_map = gsHandler->get_old_to_new_map();
+          nnz_lno_persistent_work_view_t newadj_ = gsHandler->get_new_adj();
+
+          nnz_lno_persistent_work_view_t color_adj = gsHandler->get_color_adj();
+          scalar_persistent_work_view_t permuted_adj_vals (Kokkos::ViewAllocateWithoutInitializing("newvals_"), nnz );
 
 
-      nnz_lno_t block_size = this->handle->get_gs_handle()->get_block_size();
-      nnz_lno_t block_matrix_size = block_size  * block_size ;
+          int suggested_vector_size = this->handle->get_suggested_vector_size(num_rows, nnz);
+          int suggested_team_size = this->handle->get_suggested_team_size(suggested_vector_size);
+          nnz_lno_t rows_per_team = this->handle->get_team_work_size(suggested_team_size,MyExecSpace::concurrency(), num_rows);
 
-      //MD NOTE: 03/27/2018: below fill matrix operations will work fine with block size 1.
-      //If the block size is more than 1, below code assumes that the rows are sorted similar to point crs.
-      //for example given a block crs with 3 blocks in a column a,b,c where each of them is 3x3 matrix as below.
-      // a11 a12 a13   b11 b12 b13    c11 c12 c13
-      // a21 a22 a23   b21 b22 b23    c21 c22 c23
-      // a31 a32 a33   b31 b32 b33    c31 c32 c33
-      // this copy assumes the storage in the following order
-      // a11 a12 a13   b11 b12 b13    c11 c12 c13 a21 a22 a23   b21 b22 b23    c21 c22 c23 a31 a32 a33   b31 b32 b33    c31 c32 c33
-      // this is the order that is used in the rest of the algorithm.
-      // !!!!!!!!!!!!if the input has different format than this!!!!!!!!!!!!!!!!!!
-      // change fill_matrix_numeric so that they store the internal matrix as above.
-      // the rest will wok fine.
 
-      if (this->handle->get_handle_exec_space() == KokkosKernels::Impl::Exec_CUDA){
-    	  Kokkos::parallel_for( "KokkosSparse::GaussSeidel::Team_fill_matrix_numeric",
-    			  team_policy_t(num_rows / rows_per_team + 1 , suggested_team_size, suggested_vector_size),
-    			  fill_matrix_numeric(
-    					  color_adj,
-						  xadj,
-						  //adj,
-						  adj_vals,
-						  newxadj_,
-						  //newadj_,
-						  permuted_adj_vals,
-						  //,old_to_new_map
-						  this->num_rows,
-						  rows_per_team,
-                                                  block_matrix_size
-    			  ));
-      }
-      else {
-    	  Kokkos::parallel_for( "KokkosSparse::GaussSeidel::fill_matrix_numeric",my_exec_space(0,num_rows),
-    			  fill_matrix_numeric(
-    					  color_adj,
-						  xadj,
-						  //adj,
-						  adj_vals,
-						  newxadj_,
-						  //newadj_,
-						  permuted_adj_vals,
-						  //,old_to_new_map
-						  this->num_rows,
-						  rows_per_team,
-						  block_matrix_size
-    			  ));
-      }
-      MyExecSpace::fence();
-      gsHandler->set_new_adj_val(permuted_adj_vals);
+          nnz_lno_t block_size = this->handle->get_gs_handle()->get_block_size();
+          nnz_lno_t block_matrix_size = block_size  * block_size ;
 
-      scalar_persistent_work_view_t permuted_inverse_diagonal (Kokkos::ViewAllocateWithoutInitializing("permuted_inverse_diagonal"), num_rows * block_size );
-      if (!have_diagonal_given) {
-        Get_Matrix_Diagonals gmd(newxadj_, newadj_, permuted_adj_vals, permuted_inverse_diagonal,
-                                 this->num_rows,
-                                 rows_per_team,
-                                 block_size,
-                                 block_matrix_size);
+          //MD NOTE: 03/27/2018: below fill matrix operations will work fine with block size 1.
+          //If the block size is more than 1, below code assumes that the rows are sorted similar to point crs.
+          //for example given a block crs with 3 blocks in a column a,b,c where each of them is 3x3 matrix as below.
+          // a11 a12 a13   b11 b12 b13    c11 c12 c13
+          // a21 a22 a23   b21 b22 b23    c21 c22 c23
+          // a31 a32 a33   b31 b32 b33    c31 c32 c33
+          // this copy assumes the storage in the following order
+          // a11 a12 a13   b11 b12 b13    c11 c12 c13 a21 a22 a23   b21 b22 b23    c21 c22 c23 a31 a32 a33   b31 b32 b33    c31 c32 c33
+          // this is the order that is used in the rest of the algorithm.
+          // !!!!!!!!!!!!if the input has different format than this!!!!!!!!!!!!!!!!!!
+          // change fill_matrix_numeric so that they store the internal matrix as above.
+          // the rest will wok fine.
 
-        if (this->handle->get_handle_exec_space() == KokkosKernels::Impl::Exec_CUDA || block_size > 1){
-          Kokkos::parallel_for("KokkosSparse::GaussSeidel::team_get_matrix_diagonals",
-                               team_policy_t(num_rows / rows_per_team + 1 , suggested_team_size, suggested_vector_size),
-                               gmd );
+          if (this->handle->get_handle_exec_space() == KokkosKernels::Impl::Exec_CUDA){
+            Kokkos::parallel_for( "KokkosSparse::GaussSeidel::Team_fill_matrix_numeric",
+                                  team_policy_t(num_rows / rows_per_team + 1 , suggested_team_size, suggested_vector_size),
+                                  fill_matrix_numeric(
+                                                      color_adj,
+                                                      xadj,
+                                                      //adj,
+                                                      adj_vals,
+                                                      newxadj_,
+                                                      //newadj_,
+                                                      permuted_adj_vals,
+                                                      //,old_to_new_map
+                                                      this->num_rows,
+                                                      rows_per_team,
+                                                      block_matrix_size
+                                                      ));
+          }
+          else {
+            Kokkos::parallel_for( "KokkosSparse::GaussSeidel::fill_matrix_numeric",my_exec_space(0,num_rows),
+                                  fill_matrix_numeric(
+                                                      color_adj,
+                                                      xadj,
+                                                      //adj,
+                                                      adj_vals,
+                                                      newxadj_,
+                                                      //newadj_,
+                                                      permuted_adj_vals,
+                                                      //,old_to_new_map
+                                                      this->num_rows,
+                                                      rows_per_team,
+                                                      block_matrix_size
+                                                      ));
+          }
+          MyExecSpace::fence();
+          gsHandler->set_new_adj_val(permuted_adj_vals);
+
+          scalar_persistent_work_view_t permuted_inverse_diagonal (Kokkos::ViewAllocateWithoutInitializing("permuted_inverse_diagonal"), num_rows * block_size );
+          if (!have_diagonal_given) {
+            Get_Matrix_Diagonals gmd(newxadj_, newadj_, permuted_adj_vals, permuted_inverse_diagonal,
+                                     this->num_rows,
+                                     rows_per_team,
+                                     block_size,
+                                     block_matrix_size);
+
+            if (this->handle->get_handle_exec_space() == KokkosKernels::Impl::Exec_CUDA || block_size > 1){
+              Kokkos::parallel_for("KokkosSparse::GaussSeidel::team_get_matrix_diagonals",
+                                   team_policy_t(num_rows / rows_per_team + 1 , suggested_team_size, suggested_vector_size),
+                                   gmd );
+            }
+            else {
+              Kokkos::parallel_for("KokkosSparse::GaussSeidel::get_matrix_diagonals",
+                                   my_exec_space(0,num_rows),
+                                   gmd );
+            }
+
+          } else {
+
+            if (block_size > 1)
+              KokkosKernels::Impl::permute_block_vector
+                <const_scalar_nnz_view_t,
+                 scalar_persistent_work_view_t,
+                 nnz_lno_persistent_work_view_t, MyExecSpace>(
+                                                              num_rows, block_size,
+                                                              old_to_new_map,
+                                                              given_inverse_diagonal,
+                                                              permuted_inverse_diagonal
+                                                              );
+            else
+              KokkosKernels::Impl::permute_vector
+                <const_scalar_nnz_view_t,
+                 scalar_persistent_work_view_t,
+                 nnz_lno_persistent_work_view_t, MyExecSpace>(
+                                                              num_rows,
+                                                              old_to_new_map,
+                                                              given_inverse_diagonal,
+                                                              permuted_inverse_diagonal
+                                                              );
+
+          }
+
+          MyExecSpace::fence();
+          this->handle->get_gs_handle()->set_permuted_inverse_diagonal(permuted_inverse_diagonal);
+
+          this->handle->get_gs_handle()->set_call_numeric(true);
+
         }
-        else {
-          Kokkos::parallel_for("KokkosSparse::GaussSeidel::get_matrix_diagonals",
-                               my_exec_space(0,num_rows),
-                               gmd );
+#ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
+        std::cout << "NUMERIC:" << timer.seconds() << std::endl;
+#endif
+      }
+
+      template <typename x_value_array_type, typename y_value_array_type>
+      void block_apply(
+                       x_value_array_type x_lhs_output_vec,
+                       y_value_array_type y_rhs_input_vec,
+                       bool init_zero_x_vector = false,
+                       int numIter = 1,
+                       bool apply_forward = true,
+                       bool apply_backward = true,
+                       bool update_y_vector = true){
+        if (this->handle->get_gs_handle()->is_numeric_called() == false){
+          this->initialize_numeric();
         }
 
-      } else {
+        typename HandleType::GaussSeidelHandleType *gsHandler = this->handle->get_gs_handle();
 
-        if (block_size > 1)
+        nnz_lno_t block_size = this->handle->get_gs_handle()->get_block_size();
+        //nnz_lno_t block_matrix_size = block_size  * block_size ;
+
+
+        scalar_persistent_work_view_t Permuted_Yvector = gsHandler->get_permuted_y_vector();
+        scalar_persistent_work_view_t Permuted_Xvector = gsHandler->get_permuted_x_vector();
+
+
+
+        row_lno_persistent_work_view_t newxadj_ = gsHandler->get_new_xadj();
+        nnz_lno_persistent_work_view_t old_to_new_map = gsHandler->get_old_to_new_map();
+        nnz_lno_persistent_work_view_t newadj_ = gsHandler->get_new_adj();
+        nnz_lno_persistent_work_view_t color_adj = gsHandler->get_color_adj();
+
+        color_t numColors = gsHandler->get_num_colors();
+
+
+
+        if (update_y_vector){
+
+
           KokkosKernels::Impl::permute_block_vector
-            <const_scalar_nnz_view_t,
+            <y_value_array_type,
              scalar_persistent_work_view_t,
              nnz_lno_persistent_work_view_t, MyExecSpace>(
                                                           num_rows, block_size,
                                                           old_to_new_map,
-                                                          given_inverse_diagonal,
-                                                          permuted_inverse_diagonal
+                                                          y_rhs_input_vec,
+                                                          Permuted_Yvector
                                                           );
-        else
+        }
+        MyExecSpace::fence();
+        if(init_zero_x_vector){
+          KokkosKernels::Impl::zero_vector<scalar_persistent_work_view_t, MyExecSpace>(num_cols * block_size, Permuted_Xvector);
+        }
+        else{
+          KokkosKernels::Impl::permute_block_vector
+            <x_value_array_type, scalar_persistent_work_view_t, nnz_lno_persistent_work_view_t, MyExecSpace>(
+                                                                                                             num_cols, block_size,
+                                                                                                             old_to_new_map,
+                                                                                                             x_lhs_output_vec,
+                                                                                                             Permuted_Xvector
+                                                                                                             );
+        }
+        MyExecSpace::fence();
+
+
+
+        row_lno_persistent_work_view_t permuted_xadj = gsHandler->get_new_xadj();
+        nnz_lno_persistent_work_view_t permuted_adj = gsHandler->get_new_adj();
+        scalar_persistent_work_view_t permuted_adj_vals = gsHandler->get_new_adj_val();
+        scalar_persistent_work_view_t permuted_inverse_diagonal = gsHandler->get_permuted_inverse_diagonal();
+
+#if KOKKOSSPARSE_IMPL_PRINTDEBUG
+        std::cout << "Y:";
+        KokkosKernels::Impl::print_1Dview(Permuted_Yvector);
+        std::cout << "Original Y:";
+        KokkosKernels::Impl::print_1Dview(y_rhs_input_vec);
+
+        std::cout << "X:";
+        KokkosKernels::Impl::print_1Dview(Permuted_Xvector);
+
+        std::cout << "permuted_xadj:"; KokkosKernels::Impl::print_1Dview(permuted_xadj);
+        std::cout << "permuted_adj:"; KokkosKernels::Impl::print_1Dview(permuted_adj);
+        std::cout << "permuted_adj_vals:"; KokkosKernels::Impl::print_1Dview(permuted_adj_vals);
+        std::cout << "permuted_diagonals:"; KokkosKernels::Impl::print_1Dview(permuted_inverse_diagonal);
+#endif
+        nnz_lno_persistent_work_host_view_t h_color_xadj = gsHandler->get_color_xadj();
+
+
+
+        nnz_lno_t brows = permuted_xadj.extent(0) - 1;
+        size_type bnnz =  permuted_adj_vals.extent(0);
+
+        int suggested_vector_size = this->handle->get_suggested_vector_size(brows, bnnz);
+        int suggested_team_size = this->handle->get_suggested_team_size(suggested_vector_size);
+        nnz_lno_t team_row_chunk_size = this->handle->get_team_work_size(suggested_team_size,MyExecSpace::concurrency(), brows);
+
+
+        //size_t shmem_size_to_use = this->handle->get_shmem_size();
+        size_t l1_shmem_size = gsHandler->get_level_1_mem();
+        nnz_lno_t num_values_in_l1 = gsHandler->get_num_values_in_l1();
+
+        size_t level_2_mem = gsHandler->get_level_2_mem();
+        nnz_lno_t num_values_in_l2 = gsHandler->get_num_values_in_l2();
+        nnz_lno_t num_chunks = gsHandler->get_num_big_rows();
+
+        pool_memory_space m_space(num_chunks, level_2_mem / sizeof(nnz_scalar_t), 0,  KokkosKernels::Impl::ManyThread2OneChunk, false);
+
+#if KOKKOSSPARSE_IMPL_PRINTDEBUG
+        std::cout   << "l1_shmem_size:" << l1_shmem_size << " num_values_in_l1:" << num_values_in_l1
+                    << " level_2_mem:" << level_2_mem << " num_values_in_l2:" << num_values_in_l2
+                    << " num_chunks:" << num_chunks << std::endl;
+#endif
+
+        Team_PSGS gs(permuted_xadj, permuted_adj, permuted_adj_vals,
+                     Permuted_Xvector, Permuted_Yvector,0,0, permuted_inverse_diagonal, m_space,
+                     num_values_in_l1, num_values_in_l2,
+                     block_size, team_row_chunk_size, l1_shmem_size, suggested_team_size,
+                     suggested_vector_size);
+
+        this->IterativePSGS(
+                            gs,
+                            numColors,
+                            h_color_xadj,
+                            numIter,
+                            apply_forward,
+                            apply_backward);
+
+
+        //Kokkos::parallel_for( my_exec_space(0,nr), PermuteVector(x_lhs_output_vec, Permuted_Xvector, color_adj));
+
+
+        KokkosKernels::Impl::permute_block_vector
+          <scalar_persistent_work_view_t,x_value_array_type,  nnz_lno_persistent_work_view_t, MyExecSpace>(
+                                                                                                           num_cols, block_size,
+                                                                                                           color_adj,
+                                                                                                           Permuted_Xvector,
+                                                                                                           x_lhs_output_vec
+                                                                                                           );
+        MyExecSpace::fence();
+
+#if KOKKOSSPARSE_IMPL_PRINTDEBUG
+        std::cout << "After X:";
+        KokkosKernels::Impl::print_1Dview(Permuted_Xvector);
+        std::cout << "Result X:";
+        KokkosKernels::Impl::print_1Dview(x_lhs_output_vec);
+        std::cout << "Y:";
+        KokkosKernels::Impl::print_1Dview(Permuted_Yvector);
+
+#endif
+
+      }
+
+      template <typename x_value_array_type, typename y_value_array_type>
+      void point_apply(
+                       x_value_array_type x_lhs_output_vec,
+                       y_value_array_type y_rhs_input_vec,
+                       bool init_zero_x_vector = false,
+                       int numIter = 1,
+                       nnz_scalar_t omega = Kokkos::Details::ArithTraits<nnz_scalar_t>::one(),
+                       bool apply_forward = true,
+                       bool apply_backward = true,
+                       bool update_y_vector = true){
+
+        typename HandleType::GaussSeidelHandleType *gsHandler = this->handle->get_gs_handle();
+        scalar_persistent_work_view_t Permuted_Yvector = gsHandler->get_permuted_y_vector();
+        scalar_persistent_work_view_t Permuted_Xvector = gsHandler->get_permuted_x_vector();
+
+
+        row_lno_persistent_work_view_t newxadj_ = gsHandler->get_new_xadj();
+        nnz_lno_persistent_work_view_t old_to_new_map = gsHandler->get_old_to_new_map();
+        nnz_lno_persistent_work_view_t newadj_ = gsHandler->get_new_adj();
+        nnz_lno_persistent_work_view_t color_adj = gsHandler->get_color_adj();
+
+        color_t numColors = gsHandler->get_num_colors();
+
+
+
+        if (update_y_vector){
           KokkosKernels::Impl::permute_vector
-            <const_scalar_nnz_view_t,
+            <y_value_array_type,
              scalar_persistent_work_view_t,
              nnz_lno_persistent_work_view_t, MyExecSpace>(
                                                           num_rows,
                                                           old_to_new_map,
-                                                          given_inverse_diagonal,
-                                                          permuted_inverse_diagonal
+                                                          y_rhs_input_vec,
+                                                          Permuted_Yvector
                                                           );
+        }
+        MyExecSpace::fence();
+        if(init_zero_x_vector){
+          KokkosKernels::Impl::zero_vector<scalar_persistent_work_view_t, MyExecSpace>(num_cols, Permuted_Xvector);
+        }
+        else{
+          KokkosKernels::Impl::permute_vector
+            <x_value_array_type, scalar_persistent_work_view_t, nnz_lno_persistent_work_view_t, MyExecSpace>(
+                                                                                                             num_cols,
+                                                                                                             old_to_new_map,
+                                                                                                             x_lhs_output_vec,
+                                                                                                             Permuted_Xvector
+                                                                                                             );
+        }
+        MyExecSpace::fence();
+
+        row_lno_persistent_work_view_t permuted_xadj = gsHandler->get_new_xadj();
+        nnz_lno_persistent_work_view_t permuted_adj = gsHandler->get_new_adj();
+        scalar_persistent_work_view_t permuted_adj_vals = gsHandler->get_new_adj_val();
+        scalar_persistent_work_view_t permuted_inverse_diagonal = gsHandler->get_permuted_inverse_diagonal();
+
+        nnz_lno_persistent_work_host_view_t h_color_xadj = gsHandler->get_color_xadj();
+
+
+#if KOKKOSSPARSE_IMPL_PRINTDEBUG
+        std::cout << "--point Before X:";
+        KokkosKernels::Impl::print_1Dview(Permuted_Xvector,true);
+        std::cout << "--point Before Y:";
+        KokkosKernels::Impl::print_1Dview(Permuted_Yvector,true);
+#endif
+
+        if (gsHandler->get_algorithm_type()== GS_PERMUTED){
+          PSGS gs(permuted_xadj, permuted_adj, permuted_adj_vals,
+                  Permuted_Xvector, Permuted_Yvector, color_adj, permuted_inverse_diagonal);
+
+          this->IterativePSGS(
+                              gs,
+                              numColors,
+                              h_color_xadj,
+                              numIter,
+                              apply_forward,
+                              apply_backward);
+        }
+        else{
+
+          pool_memory_space m_space(0, 0, 0,  KokkosKernels::Impl::ManyThread2OneChunk, false);
+
+          Team_PSGS gs(permuted_xadj, permuted_adj, permuted_adj_vals,
+                       Permuted_Xvector, Permuted_Yvector,0,0, permuted_inverse_diagonal, m_space);
+
+          this->IterativePSGS(
+                              gs,
+                              numColors,
+                              h_color_xadj,
+                              numIter,
+                              apply_forward,
+                              apply_backward);
+        }
+
+        //Kokkos::parallel_for( my_exec_space(0,nr), PermuteVector(x_lhs_output_vec, Permuted_Xvector, color_adj));
+
+
+        KokkosKernels::Impl::permute_vector
+          <scalar_persistent_work_view_t,x_value_array_type,  nnz_lno_persistent_work_view_t, MyExecSpace>(
+                                                                                                           num_cols,
+                                                                                                           color_adj,
+                                                                                                           Permuted_Xvector,
+                                                                                                           x_lhs_output_vec
+                                                                                                           );
+        MyExecSpace::fence();
+#if KOKKOSSPARSE_IMPL_PRINTDEBUG
+        std::cout << "--point After X:";
+        KokkosKernels::Impl::print_1Dview(Permuted_Xvector);
+        std::cout << "--point Result X:";
+        KokkosKernels::Impl::print_1Dview(x_lhs_output_vec);
+#endif
 
       }
 
-      MyExecSpace::fence();
-      this->handle->get_gs_handle()->set_permuted_inverse_diagonal(permuted_inverse_diagonal);
-
-      this->handle->get_gs_handle()->set_call_numeric(true);
-
-    }
-#ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
-    std::cout << "NUMERIC:" << timer.seconds() << std::endl;
-#endif
-  }
-
-  template <typename x_value_array_type, typename y_value_array_type>
-  void block_apply(
-      x_value_array_type x_lhs_output_vec,
-      y_value_array_type y_rhs_input_vec,
-      bool init_zero_x_vector = false,
-      int numIter = 1,
-      bool apply_forward = true,
-      bool apply_backward = true,
-      bool update_y_vector = true){
-    if (this->handle->get_gs_handle()->is_numeric_called() == false){
-      this->initialize_numeric();
-    }
-
-    typename HandleType::GaussSeidelHandleType *gsHandler = this->handle->get_gs_handle();
-
-    nnz_lno_t block_size = this->handle->get_gs_handle()->get_block_size();
-    //nnz_lno_t block_matrix_size = block_size  * block_size ;
-
-
-    scalar_persistent_work_view_t Permuted_Yvector = gsHandler->get_permuted_y_vector();
-    scalar_persistent_work_view_t Permuted_Xvector = gsHandler->get_permuted_x_vector();
-
-
-
-    row_lno_persistent_work_view_t newxadj_ = gsHandler->get_new_xadj();
-    nnz_lno_persistent_work_view_t old_to_new_map = gsHandler->get_old_to_new_map();
-    nnz_lno_persistent_work_view_t newadj_ = gsHandler->get_new_adj();
-    nnz_lno_persistent_work_view_t color_adj = gsHandler->get_color_adj();
-
-    color_t numColors = gsHandler->get_num_colors();
-
-
-
-    if (update_y_vector){
-
-
-      KokkosKernels::Impl::permute_block_vector
-        <y_value_array_type,
-        scalar_persistent_work_view_t,
-        nnz_lno_persistent_work_view_t, MyExecSpace>(
-          num_rows, block_size,
-          old_to_new_map,
-          y_rhs_input_vec,
-          Permuted_Yvector
-      );
-    }
-    MyExecSpace::fence();
-    if(init_zero_x_vector){
-      KokkosKernels::Impl::zero_vector<scalar_persistent_work_view_t, MyExecSpace>(num_cols * block_size, Permuted_Xvector);
-    }
-    else{
-      KokkosKernels::Impl::permute_block_vector
-        <x_value_array_type, scalar_persistent_work_view_t, nnz_lno_persistent_work_view_t, MyExecSpace>(
-          num_cols, block_size,
-          old_to_new_map,
-          x_lhs_output_vec,
-          Permuted_Xvector
-          );
-    }
-    MyExecSpace::fence();
-
-
-
-    row_lno_persistent_work_view_t permuted_xadj = gsHandler->get_new_xadj();
-    nnz_lno_persistent_work_view_t permuted_adj = gsHandler->get_new_adj();
-    scalar_persistent_work_view_t permuted_adj_vals = gsHandler->get_new_adj_val();
-    scalar_persistent_work_view_t permuted_inverse_diagonal = gsHandler->get_permuted_inverse_diagonal();
-
-#if KOKKOSSPARSE_IMPL_PRINTDEBUG
-    std::cout << "Y:";
-    KokkosKernels::Impl::print_1Dview(Permuted_Yvector);
-    std::cout << "Original Y:";
-    KokkosKernels::Impl::print_1Dview(y_rhs_input_vec);
-
-    std::cout << "X:";
-    KokkosKernels::Impl::print_1Dview(Permuted_Xvector);
-
-    std::cout << "permuted_xadj:"; KokkosKernels::Impl::print_1Dview(permuted_xadj);
-    std::cout << "permuted_adj:"; KokkosKernels::Impl::print_1Dview(permuted_adj);
-    std::cout << "permuted_adj_vals:"; KokkosKernels::Impl::print_1Dview(permuted_adj_vals);
-    std::cout << "permuted_diagonals:"; KokkosKernels::Impl::print_1Dview(permuted_inverse_diagonal);
-#endif
-    nnz_lno_persistent_work_host_view_t h_color_xadj = gsHandler->get_color_xadj();
-
-
-
-    nnz_lno_t brows = permuted_xadj.extent(0) - 1;
-    size_type bnnz =  permuted_adj_vals.extent(0);
-
-    int suggested_vector_size = this->handle->get_suggested_vector_size(brows, bnnz);
-    int suggested_team_size = this->handle->get_suggested_team_size(suggested_vector_size);
-    nnz_lno_t team_row_chunk_size = this->handle->get_team_work_size(suggested_team_size,MyExecSpace::concurrency(), brows);
-
-
-    //size_t shmem_size_to_use = this->handle->get_shmem_size();
-	size_t l1_shmem_size = gsHandler->get_level_1_mem();
-	nnz_lno_t num_values_in_l1 = gsHandler->get_num_values_in_l1();
-
-	size_t level_2_mem = gsHandler->get_level_2_mem();
-	nnz_lno_t num_values_in_l2 = gsHandler->get_num_values_in_l2();
-	nnz_lno_t num_chunks = gsHandler->get_num_big_rows();
-
-    pool_memory_space m_space(num_chunks, level_2_mem / sizeof(nnz_scalar_t), 0,  KokkosKernels::Impl::ManyThread2OneChunk, false);
-
-#if KOKKOSSPARSE_IMPL_PRINTDEBUG
-    std::cout 	<< "l1_shmem_size:" << l1_shmem_size << " num_values_in_l1:" << num_values_in_l1
-    			<< " level_2_mem:" << level_2_mem << " num_values_in_l2:" << num_values_in_l2
-				<< " num_chunks:" << num_chunks << std::endl;
-#endif
-
-    Team_PSGS gs(permuted_xadj, permuted_adj, permuted_adj_vals,
-    		Permuted_Xvector, Permuted_Yvector,0,0, permuted_inverse_diagonal, m_space,
-			num_values_in_l1, num_values_in_l2,
-			block_size, team_row_chunk_size, l1_shmem_size, suggested_team_size,
-			suggested_vector_size);
-
-    this->IterativePSGS(
-        gs,
-        numColors,
-        h_color_xadj,
-        numIter,
-        apply_forward,
-        apply_backward);
-
-
-    //Kokkos::parallel_for( my_exec_space(0,nr), PermuteVector(x_lhs_output_vec, Permuted_Xvector, color_adj));
-
-
-    KokkosKernels::Impl::permute_block_vector
-    <scalar_persistent_work_view_t,x_value_array_type,  nnz_lno_persistent_work_view_t, MyExecSpace>(
-        num_cols, block_size,
-        color_adj,
-        Permuted_Xvector,
-        x_lhs_output_vec
-        );
-    MyExecSpace::fence();
-
-#if KOKKOSSPARSE_IMPL_PRINTDEBUG
-    std::cout << "After X:";
-    KokkosKernels::Impl::print_1Dview(Permuted_Xvector);
-    std::cout << "Result X:";
-    KokkosKernels::Impl::print_1Dview(x_lhs_output_vec);
-    std::cout << "Y:";
-    KokkosKernels::Impl::print_1Dview(Permuted_Yvector);
-
-#endif
-
-  }
-
-  template <typename x_value_array_type, typename y_value_array_type>
-  void point_apply(
-      x_value_array_type x_lhs_output_vec,
-      y_value_array_type y_rhs_input_vec,
-      bool init_zero_x_vector = false,
-      int numIter = 1,
-      nnz_scalar_t omega = Kokkos::Details::ArithTraits<nnz_scalar_t>::one(),
-      bool apply_forward = true,
-      bool apply_backward = true,
-      bool update_y_vector = true){
-
-    typename HandleType::GaussSeidelHandleType *gsHandler = this->handle->get_gs_handle();
-    scalar_persistent_work_view_t Permuted_Yvector = gsHandler->get_permuted_y_vector();
-    scalar_persistent_work_view_t Permuted_Xvector = gsHandler->get_permuted_x_vector();
-
-
-    row_lno_persistent_work_view_t newxadj_ = gsHandler->get_new_xadj();
-    nnz_lno_persistent_work_view_t old_to_new_map = gsHandler->get_old_to_new_map();
-    nnz_lno_persistent_work_view_t newadj_ = gsHandler->get_new_adj();
-    nnz_lno_persistent_work_view_t color_adj = gsHandler->get_color_adj();
-
-    color_t numColors = gsHandler->get_num_colors();
-
-
-
-    if (update_y_vector){
-      KokkosKernels::Impl::permute_vector
-        <y_value_array_type,
-        scalar_persistent_work_view_t,
-        nnz_lno_persistent_work_view_t, MyExecSpace>(
-          num_rows,
-          old_to_new_map,
-          y_rhs_input_vec,
-          Permuted_Yvector
-      );
-    }
-    MyExecSpace::fence();
-    if(init_zero_x_vector){
-      KokkosKernels::Impl::zero_vector<scalar_persistent_work_view_t, MyExecSpace>(num_cols, Permuted_Xvector);
-    }
-    else{
-      KokkosKernels::Impl::permute_vector
-        <x_value_array_type, scalar_persistent_work_view_t, nnz_lno_persistent_work_view_t, MyExecSpace>(
-          num_cols,
-          old_to_new_map,
-          x_lhs_output_vec,
-          Permuted_Xvector
-          );
-    }
-    MyExecSpace::fence();
-
-    row_lno_persistent_work_view_t permuted_xadj = gsHandler->get_new_xadj();
-    nnz_lno_persistent_work_view_t permuted_adj = gsHandler->get_new_adj();
-    scalar_persistent_work_view_t permuted_adj_vals = gsHandler->get_new_adj_val();
-    scalar_persistent_work_view_t permuted_inverse_diagonal = gsHandler->get_permuted_inverse_diagonal();
-
-    nnz_lno_persistent_work_host_view_t h_color_xadj = gsHandler->get_color_xadj();
-
-
-#if KOKKOSSPARSE_IMPL_PRINTDEBUG
-    std::cout << "--point Before X:";
-    KokkosKernels::Impl::print_1Dview(Permuted_Xvector,true);
-    std::cout << "--point Before Y:";
-    KokkosKernels::Impl::print_1Dview(Permuted_Yvector,true);
-#endif
-
-    if (gsHandler->get_algorithm_type()== GS_PERMUTED){
-      PSGS gs(permuted_xadj, permuted_adj, permuted_adj_vals,
-          Permuted_Xvector, Permuted_Yvector, color_adj, permuted_inverse_diagonal);
-
-      this->IterativePSGS(
-          gs,
-          numColors,
-          h_color_xadj,
-          numIter,
-          apply_forward,
-          apply_backward);
-    }
-    else{
-
-      pool_memory_space m_space(0, 0, 0,  KokkosKernels::Impl::ManyThread2OneChunk, false);
-
-      Team_PSGS gs(permuted_xadj, permuted_adj, permuted_adj_vals,
-          Permuted_Xvector, Permuted_Yvector,0,0, permuted_inverse_diagonal, m_space);
-
-      this->IterativePSGS(
-          gs,
-          numColors,
-          h_color_xadj,
-          numIter,
-          apply_forward,
-          apply_backward);
-    }
-
-    //Kokkos::parallel_for( my_exec_space(0,nr), PermuteVector(x_lhs_output_vec, Permuted_Xvector, color_adj));
-
-
-    KokkosKernels::Impl::permute_vector
-    <scalar_persistent_work_view_t,x_value_array_type,  nnz_lno_persistent_work_view_t, MyExecSpace>(
-        num_cols,
-        color_adj,
-        Permuted_Xvector,
-        x_lhs_output_vec
-        );
-    MyExecSpace::fence();
-#if KOKKOSSPARSE_IMPL_PRINTDEBUG
-    std::cout << "--point After X:";
-    KokkosKernels::Impl::print_1Dview(Permuted_Xvector);
-    std::cout << "--point Result X:";
-    KokkosKernels::Impl::print_1Dview(x_lhs_output_vec);
-#endif
-
-  }
-
-  template <typename x_value_array_type, typename y_value_array_type>
-  void apply(
-      x_value_array_type x_lhs_output_vec,
-      y_value_array_type y_rhs_input_vec,
-      bool init_zero_x_vector = false,
-      int numIter = 1,
-      nnz_scalar_t omega = Kokkos::Details::ArithTraits<nnz_scalar_t>::one(),
-      bool apply_forward = true,
-      bool apply_backward = true,
-      bool update_y_vector = true){
-    if (this->handle->get_gs_handle()->is_numeric_called() == false){
-      this->initialize_numeric();
-    }
-    nnz_lno_t block_size = this->handle->get_gs_handle()->get_block_size();
-    if (block_size == 1){
-    	this->point_apply(
-    			x_lhs_output_vec, y_rhs_input_vec,
-				init_zero_x_vector, numIter ,
-                        omega,
-    	      apply_forward, apply_backward,
-    	      update_y_vector);
-    }
-    else {
-    	this->block_apply(
-    	    			x_lhs_output_vec, y_rhs_input_vec,
-    					init_zero_x_vector, numIter ,
-    	    	      apply_forward, apply_backward,
-    	    	      update_y_vector);
-    }
-  }
-
-  void IterativePSGS(
-      Team_PSGS &gs,
-      color_t numColors,
-      nnz_lno_persistent_work_host_view_t h_color_xadj,
-      int num_iteration,
-      bool apply_forward,
-      bool apply_backward){
-
-    for (int i = 0; i < num_iteration; ++i){
-      this->DoPSGS(gs, numColors, h_color_xadj, apply_forward, apply_backward);
-    }
-  }
-
-  void DoPSGS(Team_PSGS &gs, color_t numColors, nnz_lno_persistent_work_host_view_t h_color_xadj,
-      bool apply_forward,
-	  bool apply_backward){
-
-	  nnz_lno_t suggested_team_size = gs.suggested_team_size;
-	  nnz_lno_t team_row_chunk_size = gs.team_work_size;
-	  int vector_size = gs.vector_size;
-	  nnz_lno_t block_size = this->handle->get_gs_handle()->get_block_size();
-
-	  /*
-    size_type nnz = this->values.extent(0);
-    int suggested_vector_size = this->handle->get_suggested_vector_size(num_rows, nnz);
-    int suggested_team_size = this->handle->get_suggested_team_size(suggested_vector_size);
-    nnz_lno_t team_row_chunk_size = this->handle->get_team_work_size(suggested_team_size,MyExecSpace::concurrency(), brows);
-    this->handle->get_gs_handle()->vector_team_size(max_allowed_team_size, vector_size, teamSizeMax, num_rows, nnz);
-	   */
-
-          
-	  if (apply_forward){
-                  gs.is_backward = false;
-
-		  for (color_t i = 0; i < numColors; ++i){
-			  nnz_lno_t color_index_begin = h_color_xadj(i);
-			  nnz_lno_t color_index_end = h_color_xadj(i + 1);
-			  int overall_work = color_index_end - color_index_begin;// /256 + 1;
-			  gs._color_set_begin = color_index_begin;
-			  gs._color_set_end = color_index_end;
-
-			  if (block_size == 1){
-			  Kokkos::parallel_for("KokkosSparse::GaussSeidel::Team_PSGS::forward",
-					  team_policy_t(overall_work / team_row_chunk_size + 1 , suggested_team_size, vector_size),
-					  gs );
-			  } else if (gs.num_max_vals_in_l2 == 0){
-				  //if (i == 0)std::cout << "block_team" << std::endl;
-			  Kokkos::parallel_for("KokkosSparse::GaussSeidel::BLOCK_Team_PSGS::forward",
-					  block_team_fill_policy_t(overall_work / team_row_chunk_size + 1 , suggested_team_size, vector_size),
-					  gs );
-			  }
-			  else {
-                      		//if (i == 0)    std::cout << "big block_team" << std::endl;
-
-				  Kokkos::parallel_for("KokkosSparse::GaussSeidel::BIGBLOCK_Team_PSGS::forward",
-				  					  bigblock_team_fill_policy_t(overall_work / team_row_chunk_size + 1 , suggested_team_size, vector_size),
-				  					  gs );
-			  }
-
-			  MyExecSpace::fence();
-		  }
-	  }
-	  if (apply_backward){
-                  gs.is_backward = true;
-		  if (numColors > 0)
-			  for (color_t i = numColors - 1;  ; --i){
-				  nnz_lno_t color_index_begin = h_color_xadj(i);
-				  nnz_lno_t color_index_end = h_color_xadj(i + 1);
-				  nnz_lno_t numberOfTeams = color_index_end - color_index_begin;// /256 + 1;
-				  gs._color_set_begin = color_index_begin;
-				  gs._color_set_end = color_index_end;
-				  if (block_size == 1){
-
-					  Kokkos::parallel_for("KokkosSparse::GaussSeidel::Team_PSGS::backward",
-							  team_policy_t(numberOfTeams / team_row_chunk_size + 1 , suggested_team_size, vector_size),
-							  gs );
-				  }
-				  else if ( gs.num_max_vals_in_l2 == 0){
-					//if (i == 0) std::cout << "block_team backward" << std::endl;
-
-					  Kokkos::parallel_for("KokkosSparse::GaussSeidel::BLOCK_Team_PSGS::backward",
-							  block_team_fill_policy_t(numberOfTeams / team_row_chunk_size + 1 , suggested_team_size, vector_size),
-							  gs );
-				  }
-				  else {
-           				//if (i == 0)               std::cout << "big block_team backward" << std::endl;
-
-					  Kokkos::parallel_for("KokkosSparse::GaussSeidel::BIGBLOCK_Team_PSGS::backward",
-					  							  bigblock_team_fill_policy_t(numberOfTeams / team_row_chunk_size + 1 , suggested_team_size, vector_size),
-					  							  gs );
-				  }
-				  MyExecSpace::fence();
-				  if (i == 0){
-					  break;
-				  }
-			  }
-	  }
-  }
-
-  void IterativePSGS(
-      PSGS &gs,
-      color_t numColors,
-      nnz_lno_persistent_work_host_view_t h_color_xadj,
-      int num_iteration,
-      bool apply_forward,
-      bool apply_backward){
-
-    for (int i = 0; i < num_iteration; ++i){
-    	//std::cout << "ier:" << i << std::endl;
-      this->DoPSGS(gs, numColors, h_color_xadj, apply_forward, apply_backward);
-    }
-  }
-
-
-
-  void DoPSGS(PSGS &gs, color_t numColors, nnz_lno_persistent_work_host_view_t h_color_xadj,
-      bool apply_forward,
-      bool apply_backward){
-    if (apply_forward){
-    	//std::cout <<  "numColors:" << numColors << std::endl;
-      for (color_t i = 0; i < numColors; ++i){
-        nnz_lno_t color_index_begin = h_color_xadj(i);
-        nnz_lno_t color_index_end = h_color_xadj(i + 1);
-        //std::cout <<  "i:" << i << " color_index_begin:" << color_index_begin << " color_index_end:" << color_index_end << std::endl;
-        Kokkos::parallel_for ("KokkosSparse::GaussSeidel::PSGS::forward",
-            my_exec_space (color_index_begin, color_index_end) , gs);
-        MyExecSpace::fence();
-      }
-    }
-    if (apply_backward && numColors){
-      for (size_type i = numColors - 1; ; --i){
-        nnz_lno_t color_index_begin = h_color_xadj(i);
-        nnz_lno_t color_index_end = h_color_xadj(i + 1);
-        Kokkos::parallel_for ("KokkosSparse::GaussSeidel::PSGS::backward",
-            my_exec_space (color_index_begin, color_index_end) , gs);
-        MyExecSpace::fence();
-        if (i == 0){
-          break;
+      template <typename x_value_array_type, typename y_value_array_type>
+      void apply(
+                 x_value_array_type x_lhs_output_vec,
+                 y_value_array_type y_rhs_input_vec,
+                 bool init_zero_x_vector = false,
+                 int numIter = 1,
+                 nnz_scalar_t omega = Kokkos::Details::ArithTraits<nnz_scalar_t>::one(),
+                 bool apply_forward = true,
+                 bool apply_backward = true,
+                 bool update_y_vector = true){
+        if (this->handle->get_gs_handle()->is_numeric_called() == false){
+          this->initialize_numeric();
+        }
+        nnz_lno_t block_size = this->handle->get_gs_handle()->get_block_size();
+        if (block_size == 1){
+          this->point_apply(
+                            x_lhs_output_vec, y_rhs_input_vec,
+                            init_zero_x_vector, numIter ,
+                            omega,
+                            apply_forward, apply_backward,
+                            update_y_vector);
+        }
+        else {
+          this->block_apply(
+                            x_lhs_output_vec, y_rhs_input_vec,
+                            init_zero_x_vector, numIter ,
+                            apply_forward, apply_backward,
+                            update_y_vector);
         }
       }
-    }
-  }
-};
 
-}
+      void IterativePSGS(
+                         Team_PSGS &gs,
+                         color_t numColors,
+                         nnz_lno_persistent_work_host_view_t h_color_xadj,
+                         int num_iteration,
+                         bool apply_forward,
+                         bool apply_backward){
+
+        for (int i = 0; i < num_iteration; ++i){
+          this->DoPSGS(gs, numColors, h_color_xadj, apply_forward, apply_backward);
+        }
+      }
+
+      void DoPSGS(Team_PSGS &gs, color_t numColors, nnz_lno_persistent_work_host_view_t h_color_xadj,
+                  bool apply_forward,
+                  bool apply_backward){
+
+        nnz_lno_t suggested_team_size = gs.suggested_team_size;
+        nnz_lno_t team_row_chunk_size = gs.team_work_size;
+        int vector_size = gs.vector_size;
+        nnz_lno_t block_size = this->handle->get_gs_handle()->get_block_size();
+
+        /*
+          size_type nnz = this->values.extent(0);
+          int suggested_vector_size = this->handle->get_suggested_vector_size(num_rows, nnz);
+          int suggested_team_size = this->handle->get_suggested_team_size(suggested_vector_size);
+          nnz_lno_t team_row_chunk_size = this->handle->get_team_work_size(suggested_team_size,MyExecSpace::concurrency(), brows);
+          this->handle->get_gs_handle()->vector_team_size(max_allowed_team_size, vector_size, teamSizeMax, num_rows, nnz);
+        */
+
+
+        if (apply_forward){
+          gs.is_backward = false;
+
+          for (color_t i = 0; i < numColors; ++i){
+            nnz_lno_t color_index_begin = h_color_xadj(i);
+            nnz_lno_t color_index_end = h_color_xadj(i + 1);
+            int overall_work = color_index_end - color_index_begin;// /256 + 1;
+            gs._color_set_begin = color_index_begin;
+            gs._color_set_end = color_index_end;
+
+            if (block_size == 1){
+              Kokkos::parallel_for("KokkosSparse::GaussSeidel::Team_PSGS::forward",
+                                   team_policy_t(overall_work / team_row_chunk_size + 1 , suggested_team_size, vector_size),
+                                   gs );
+            } else if (gs.num_max_vals_in_l2 == 0){
+              //if (i == 0)std::cout << "block_team" << std::endl;
+              Kokkos::parallel_for("KokkosSparse::GaussSeidel::BLOCK_Team_PSGS::forward",
+                                   block_team_fill_policy_t(overall_work / team_row_chunk_size + 1 , suggested_team_size, vector_size),
+                                   gs );
+            }
+            else {
+              //if (i == 0)    std::cout << "big block_team" << std::endl;
+
+              Kokkos::parallel_for("KokkosSparse::GaussSeidel::BIGBLOCK_Team_PSGS::forward",
+                                   bigblock_team_fill_policy_t(overall_work / team_row_chunk_size + 1 , suggested_team_size, vector_size),
+                                   gs );
+            }
+
+            MyExecSpace::fence();
+          }
+        }
+        if (apply_backward){
+          gs.is_backward = true;
+          if (numColors > 0)
+            for (color_t i = numColors - 1;  ; --i){
+              nnz_lno_t color_index_begin = h_color_xadj(i);
+              nnz_lno_t color_index_end = h_color_xadj(i + 1);
+              nnz_lno_t numberOfTeams = color_index_end - color_index_begin;// /256 + 1;
+              gs._color_set_begin = color_index_begin;
+              gs._color_set_end = color_index_end;
+              if (block_size == 1){
+
+                Kokkos::parallel_for("KokkosSparse::GaussSeidel::Team_PSGS::backward",
+                                     team_policy_t(numberOfTeams / team_row_chunk_size + 1 , suggested_team_size, vector_size),
+                                     gs );
+              }
+              else if ( gs.num_max_vals_in_l2 == 0){
+                //if (i == 0) std::cout << "block_team backward" << std::endl;
+
+                Kokkos::parallel_for("KokkosSparse::GaussSeidel::BLOCK_Team_PSGS::backward",
+                                     block_team_fill_policy_t(numberOfTeams / team_row_chunk_size + 1 , suggested_team_size, vector_size),
+                                     gs );
+              }
+              else {
+                //if (i == 0)               std::cout << "big block_team backward" << std::endl;
+
+                Kokkos::parallel_for("KokkosSparse::GaussSeidel::BIGBLOCK_Team_PSGS::backward",
+                                     bigblock_team_fill_policy_t(numberOfTeams / team_row_chunk_size + 1 , suggested_team_size, vector_size),
+                                     gs );
+              }
+              MyExecSpace::fence();
+              if (i == 0){
+                break;
+              }
+            }
+        }
+      }
+
+      void IterativePSGS(
+                         PSGS &gs,
+                         color_t numColors,
+                         nnz_lno_persistent_work_host_view_t h_color_xadj,
+                         int num_iteration,
+                         bool apply_forward,
+                         bool apply_backward){
+
+        for (int i = 0; i < num_iteration; ++i){
+          //std::cout << "ier:" << i << std::endl;
+          this->DoPSGS(gs, numColors, h_color_xadj, apply_forward, apply_backward);
+        }
+      }
+
+
+
+      void DoPSGS(PSGS &gs, color_t numColors, nnz_lno_persistent_work_host_view_t h_color_xadj,
+                  bool apply_forward,
+                  bool apply_backward){
+        if (apply_forward){
+          //std::cout <<  "numColors:" << numColors << std::endl;
+          for (color_t i = 0; i < numColors; ++i){
+            nnz_lno_t color_index_begin = h_color_xadj(i);
+            nnz_lno_t color_index_end = h_color_xadj(i + 1);
+            //std::cout <<  "i:" << i << " color_index_begin:" << color_index_begin << " color_index_end:" << color_index_end << std::endl;
+            Kokkos::parallel_for ("KokkosSparse::GaussSeidel::PSGS::forward",
+                                  my_exec_space (color_index_begin, color_index_end) , gs);
+            MyExecSpace::fence();
+          }
+        }
+        if (apply_backward && numColors){
+          for (size_type i = numColors - 1; ; --i){
+            nnz_lno_t color_index_begin = h_color_xadj(i);
+            nnz_lno_t color_index_end = h_color_xadj(i + 1);
+            Kokkos::parallel_for ("KokkosSparse::GaussSeidel::PSGS::backward",
+                                  my_exec_space (color_index_begin, color_index_end) , gs);
+            MyExecSpace::fence();
+            if (i == 0){
+              break;
+            }
+          }
+        }
+      }
+    };
+
+  }
 }
 #endif

--- a/src/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
@@ -126,6 +126,10 @@ private:
   const_lno_row_view_t row_map;
   const_lno_nnz_view_t entries;
   const_scalar_nnz_view_t values;
+
+  const_scalar_nnz_view_t given_inverse_diagonal;
+
+  bool have_diagonal_given;
   bool is_symmetric;
 public:
 
@@ -137,16 +141,19 @@ public:
     scalar_persistent_work_view_t _Xvector /*output*/;
     scalar_persistent_work_view_t _Yvector;
 
-    scalar_persistent_work_view_t _permuted_diagonals;
+    scalar_persistent_work_view_t _permuted_inverse_diagonal;
+
+    nnz_scalar_t omega;
 
     PSGS(row_lno_persistent_work_view_t xadj_, nnz_lno_persistent_work_view_t adj_, scalar_persistent_work_view_t adj_vals_,
         scalar_persistent_work_view_t Xvector_, scalar_persistent_work_view_t Yvector_, nnz_lno_persistent_work_view_t color_adj_,
-        scalar_persistent_work_view_t permuted_diagonals_):
+        scalar_persistent_work_view_t permuted_inverse_diagonal_):
           _xadj( xadj_),
           _adj( adj_),
           _adj_vals( adj_vals_),
           _Xvector( Xvector_),
-          _Yvector( Yvector_), _permuted_diagonals(permuted_diagonals_){}
+          _Yvector( Yvector_), _permuted_inverse_diagonal(permuted_inverse_diagonal_),
+          omega(Kokkos::Details::ArithTraits<nnz_scalar_t>::one()){}
 
     KOKKOS_INLINE_FUNCTION
     void operator()(const nnz_lno_t &ii) const {
@@ -161,8 +168,8 @@ public:
         nnz_scalar_t val = _adj_vals[adjind];
         sum -= val * _Xvector[colIndex];
       }
-      nnz_scalar_t diagonalVal = _permuted_diagonals[ii];
-      _Xvector[ii] = (sum + diagonalVal * _Xvector[ii])/ diagonalVal;
+      nnz_scalar_t invDiagonalVal = _permuted_inverse_diagonal[ii];
+      _Xvector[ii] = _Xvector[ii] + omega * sum * invDiagonalVal;
     }
   };
 
@@ -177,7 +184,7 @@ public:
     nnz_lno_t _color_set_begin;
     nnz_lno_t _color_set_end;
 
-    scalar_persistent_work_view_t _permuted_diagonals;
+    scalar_persistent_work_view_t _permuted_inverse_diagonal;
     nnz_lno_t block_size;
     nnz_lno_t team_work_size;
     const size_t shared_memory_size;
@@ -189,11 +196,13 @@ public:
 	const nnz_lno_t num_max_vals_in_l1, num_max_vals_in_l2;
     bool is_backward;
 
+    nnz_scalar_t omega;
+
 
     Team_PSGS(row_lno_persistent_work_view_t xadj_, nnz_lno_persistent_work_view_t adj_, scalar_persistent_work_view_t adj_vals_,
         scalar_persistent_work_view_t Xvector_, scalar_persistent_work_view_t Yvector_,
         nnz_lno_t color_set_begin, nnz_lno_t color_set_end,
-        scalar_persistent_work_view_t permuted_diagonals_,
+        scalar_persistent_work_view_t permuted_inverse_diagonal_,
 		pool_memory_space pms,
 		nnz_lno_t _num_max_vals_in_l1 = 0,
 		nnz_lno_t _num_max_vals_in_l2 = 0,
@@ -209,14 +218,15 @@ public:
           _Xvector( Xvector_),
           _Yvector( Yvector_),
           _color_set_begin(color_set_begin),
-          _color_set_end(color_set_end), _permuted_diagonals(permuted_diagonals_),
+          _color_set_end(color_set_end), _permuted_inverse_diagonal(permuted_inverse_diagonal_),
 		  block_size(block_size_),
 		  team_work_size(team_work_size_),
 		  shared_memory_size(shared_memory_size_),
 		  suggested_team_size(suggested_team_size_),
 		  thread_shared_memory_scalar_size(((shared_memory_size / suggested_team_size / 8) * 8 ) / sizeof(nnz_scalar_t) ),
 		  vector_size(vector_size_), pool (pms), num_max_vals_in_l1(_num_max_vals_in_l1),
-		  num_max_vals_in_l2(_num_max_vals_in_l2), is_backward(false){}
+                  num_max_vals_in_l2(_num_max_vals_in_l2), is_backward(false),
+                  omega(Kokkos::Details::ArithTraits<nnz_scalar_t>::one()){}
 
     KOKKOS_INLINE_FUNCTION
     void operator()(const team_member_t & teamMember) const {
@@ -242,8 +252,8 @@ public:
       product);
 
       Kokkos::single(Kokkos::PerThread(teamMember),[=] () {
-        nnz_scalar_t diagonalVal = _permuted_diagonals[ii];
-        _Xvector[ii] = (_Yvector[ii] - product + diagonalVal * _Xvector[ii])/ diagonalVal;
+        nnz_scalar_t invDiagonalVal = _permuted_inverse_diagonal[ii];
+        _Xvector[ii] += omega * (_Yvector[ii] - product) * invDiagonalVal;
       });
      }
 
@@ -352,8 +362,8 @@ public:
 	 		//update the new vector entries.
 		      Kokkos::single(Kokkos::PerThread(teamMember),[=] () {
 		    	nnz_lno_t block_row_index = ii * block_size + i;
-		        nnz_scalar_t diagonalVal = _permuted_diagonals[block_row_index];
-		        _Xvector[block_row_index] = (_Yvector[block_row_index] - product + diagonalVal * _Xvector[block_row_index])/ diagonalVal;
+		        nnz_scalar_t invDiagonalVal = _permuted_inverse_diagonal[block_row_index];
+                        _Xvector[block_row_index] += omega * (_Yvector[block_row_index] - product) * invDiagonalVal;
 
 			      //we need to update the values of the vector entries if they are already brought to shared memory to sync with global memory.
 			      if (diagonal_positions[i] != -1){
@@ -379,7 +389,7 @@ public:
 					  std::cout << all_shared_memory[z] << " ";
 				  }
 				  std::cout << std::endl << "product:" << product << std::endl;
-				  std::cout << "diagonal" << _permuted_diagonals[ii * block_size + i] << std::endl;
+				  std::cout << "diagonal" << _permuted_inverse_diagonal[ii * block_size + i] << std::endl;
 				  std::cout << "_Yvector" << _Yvector[ii * block_size + i] << std::endl;
 
 				  std::cout << std::endl << "block_row_index:" << ii * block_size + i <<  " _Xvector[block_row_index]:" << _Xvector[ii * block_size + i] << std::endl;
@@ -465,8 +475,8 @@ public:
 
 		      Kokkos::single(Kokkos::PerThread(teamMember),[=] () {
 		    	nnz_lno_t block_row_index = ii * block_size + i;
-		        nnz_scalar_t diagonalVal = _permuted_diagonals[block_row_index];
-		        _Xvector[block_row_index] = (_Yvector[block_row_index] - product + diagonalVal * _Xvector[block_row_index])/ diagonalVal;
+		        nnz_scalar_t invDiagonalVal = _permuted_inverse_diagonal[block_row_index];
+		        _Xvector[block_row_index] += omega * (_Yvector[block_row_index] - product) * invDiagonalVal;
 
 
 			      if (diagonal_positions[i] != -1){
@@ -489,7 +499,7 @@ public:
 					  std::cout << all_shared_memory[z] << " ";
 				  }
 				  std::cout << std::endl << "product:" << product << std::endl;
-				  std::cout << "diagonal" << _permuted_diagonals[ii * block_size + i] << std::endl;
+				  std::cout << "diagonal" << _permuted_inverse_diagonal[ii * block_size + i] << std::endl;
 				  std::cout << "_Yvector" << _Yvector[ii * block_size + i] << std::endl;
 
 				  std::cout << std::endl << "block_row_index:" << ii * block_size + i <<  " _Xvector[block_row_index]:" << _Xvector[ii * block_size + i] << std::endl << std::endl<< std::endl;
@@ -515,27 +525,30 @@ public:
    */
 
   GaussSeidel(HandleType *handle_,
-      nnz_lno_t num_rows_,
-      nnz_lno_t num_cols_,
-      const_lno_row_view_t row_map_,
-      const_lno_nnz_view_t entries_,
-      const_scalar_nnz_view_t values_):
-        handle(handle_), num_rows(num_rows_), num_cols(num_cols_),
-        row_map(row_map_), entries(entries_), values(values_), is_symmetric(true){}
+              nnz_lno_t num_rows_,
+              nnz_lno_t num_cols_,
+              const_lno_row_view_t row_map_,
+              const_lno_nnz_view_t entries_,
+              const_scalar_nnz_view_t values_):
+    handle(handle_), num_rows(num_rows_), num_cols(num_cols_),
+    row_map(row_map_), entries(entries_), values(values_),
+    have_diagonal_given(false),
+    is_symmetric(true){}
 
 
   GaussSeidel(HandleType *handle_,
-      nnz_lno_t num_rows_,
-      nnz_lno_t num_cols_,
-      const_lno_row_view_t row_map_,
-      const_lno_nnz_view_t entries_,
-      bool is_symmetric_ = true):
-        handle(handle_),
-        num_rows(num_rows_), num_cols(num_cols_),
-
-        row_map(row_map_),
-        entries(entries_),
-        values(), is_symmetric(is_symmetric_){}
+              nnz_lno_t num_rows_,
+              nnz_lno_t num_cols_,
+              const_lno_row_view_t row_map_,
+              const_lno_nnz_view_t entries_,
+              bool is_symmetric_ = true):
+    handle(handle_),
+    num_rows(num_rows_), num_cols(num_cols_),
+    row_map(row_map_),
+    entries(entries_),
+    values(),
+    have_diagonal_given(false),
+    is_symmetric(is_symmetric_){}
 
 
 
@@ -543,16 +556,33 @@ public:
    * \brief constructor
    */
   GaussSeidel(HandleType *handle_,
-      nnz_lno_t num_rows_,
-      nnz_lno_t num_cols_,
-      const_lno_row_view_t row_map_,
-      const_lno_nnz_view_t entries_,
-      const_scalar_nnz_view_t values_,
-      bool is_symmetric_):
-        handle(handle_),
-        num_rows(num_rows_), num_cols(num_cols_),
-        row_map(row_map_), entries(entries_), values(values_), is_symmetric(is_symmetric_){}
+              nnz_lno_t num_rows_,
+              nnz_lno_t num_cols_,
+              const_lno_row_view_t row_map_,
+              const_lno_nnz_view_t entries_,
+              const_scalar_nnz_view_t values_,
+              bool is_symmetric_):
+    handle(handle_),
+    num_rows(num_rows_), num_cols(num_cols_),
+    row_map(row_map_), entries(entries_), values(values_),
+    have_diagonal_given(false),
+    is_symmetric(is_symmetric_){}
 
+
+  GaussSeidel(HandleType *handle_,
+              nnz_lno_t num_rows_,
+              nnz_lno_t num_cols_,
+              const_lno_row_view_t row_map_,
+              const_lno_nnz_view_t entries_,
+              const_scalar_nnz_view_t values_,
+              const_scalar_nnz_view_t given_inverse_diagonal_,
+              bool is_symmetric_):
+    handle(handle_),
+    num_rows(num_rows_), num_cols(num_cols_),
+    row_map(row_map_), entries(entries_), values(values_),
+    given_inverse_diagonal(given_inverse_diagonal_),
+    have_diagonal_given(true),
+    is_symmetric(is_symmetric_){}
 
 
 
@@ -981,6 +1011,8 @@ public:
     nnz_lno_t block_size;
     nnz_lno_t block_matrix_size;
 
+    nnz_scalar_t one;
+
 
     Get_Matrix_Diagonals(
         row_lno_persistent_work_view_t xadj_,
@@ -995,7 +1027,7 @@ public:
           _adj( adj_),
           _adj_vals( adj_vals_), _diagonals(diagonals_),
 		  num_total_rows(num_total_rows_), rows_per_team(rows_per_team_),
-		  block_size(block_size_),block_matrix_size(block_matrix_size_){}
+                  block_size(block_size_),block_matrix_size(block_matrix_size_),one(Kokkos::Details::ArithTraits<nnz_scalar_t>::one()){}
 
     KOKKOS_INLINE_FUNCTION
     void operator()(const nnz_lno_t & row_id) const {
@@ -1009,7 +1041,7 @@ public:
         	size_type val_index = row_begin * block_matrix_size + col_ind;
         	for (nnz_lno_t r = 0; r < block_size; ++r){
         		nnz_scalar_t val = _adj_vals[val_index];
-        		_diagonals[row_id + r] = val;
+        		_diagonals[row_id * block_size + r] = one / val;
         		val_index += row_size + 1;
         	}
         	break;
@@ -1034,7 +1066,7 @@ public:
     	        	size_type _val_index = row_begin * block_matrix_size + col_ind * block_size;
     	        	for (nnz_lno_t r = 0; r < block_size; ++r){
     	        		nnz_scalar_t val = _adj_vals[_val_index];
-    	        		_diagonals[row_id * block_size + r] = val;
+    	        		_diagonals[row_id * block_size + r] = one / val;
     	        		_val_index += row_size * block_size + 1;
 
     	        		//std::cout << "row_id * block_size + r:" << row_id * block_size + r << " _diagonals[row_id * block_size + r]:" << _diagonals[row_id * block_size + r] << std::endl;
@@ -1110,7 +1142,7 @@ public:
 						  //,old_to_new_map
 						  this->num_rows,
 						  rows_per_team,
-						  block_matrix_size
+                                                  block_matrix_size
     			  ));
       }
       else {
@@ -1132,30 +1164,52 @@ public:
       MyExecSpace::fence();
       gsHandler->set_new_adj_val(permuted_adj_vals);
 
+      scalar_persistent_work_view_t permuted_inverse_diagonal (Kokkos::ViewAllocateWithoutInitializing("permuted_inverse_diagonal"), num_rows * block_size );
+      if (!have_diagonal_given) {
+        Get_Matrix_Diagonals gmd(newxadj_, newadj_, permuted_adj_vals, permuted_inverse_diagonal,
+                                 this->num_rows,
+                                 rows_per_team,
+                                 block_size,
+                                 block_matrix_size);
 
-
-      scalar_persistent_work_view_t permuted_diagonals (Kokkos::ViewAllocateWithoutInitializing("permuted_diagonals"), num_rows * block_size );
-
-      Get_Matrix_Diagonals gmd(newxadj_, newadj_, permuted_adj_vals, permuted_diagonals,
-			  	  this->num_rows,
-				  rows_per_team,
-				  block_size,
-				  block_matrix_size);
-
-      if (this->handle->get_handle_exec_space() == KokkosKernels::Impl::Exec_CUDA || block_size > 1){
+        if (this->handle->get_handle_exec_space() == KokkosKernels::Impl::Exec_CUDA || block_size > 1){
           Kokkos::parallel_for("KokkosSparse::GaussSeidel::team_get_matrix_diagonals",
-    			  team_policy_t(num_rows / rows_per_team + 1 , suggested_team_size, suggested_vector_size),
-                    gmd );
-      }
-      else {
+                               team_policy_t(num_rows / rows_per_team + 1 , suggested_team_size, suggested_vector_size),
+                               gmd );
+        }
+        else {
           Kokkos::parallel_for("KokkosSparse::GaussSeidel::get_matrix_diagonals",
-                    my_exec_space(0,num_rows),
-                    gmd );
+                               my_exec_space(0,num_rows),
+                               gmd );
+        }
+
+      } else {
+
+        if (block_size > 1)
+          KokkosKernels::Impl::permute_block_vector
+            <const_scalar_nnz_view_t,
+             scalar_persistent_work_view_t,
+             nnz_lno_persistent_work_view_t, MyExecSpace>(
+                                                          num_rows, block_size,
+                                                          old_to_new_map,
+                                                          given_inverse_diagonal,
+                                                          permuted_inverse_diagonal
+                                                          );
+        else
+          KokkosKernels::Impl::permute_vector
+            <const_scalar_nnz_view_t,
+             scalar_persistent_work_view_t,
+             nnz_lno_persistent_work_view_t, MyExecSpace>(
+                                                          num_rows,
+                                                          old_to_new_map,
+                                                          given_inverse_diagonal,
+                                                          permuted_inverse_diagonal
+                                                          );
+
       }
 
       MyExecSpace::fence();
-      this->handle->get_gs_handle()->set_permuted_diagonals(permuted_diagonals);
-
+      this->handle->get_gs_handle()->set_permuted_inverse_diagonal(permuted_inverse_diagonal);
 
       this->handle->get_gs_handle()->set_call_numeric(true);
 
@@ -1231,7 +1285,7 @@ public:
     row_lno_persistent_work_view_t permuted_xadj = gsHandler->get_new_xadj();
     nnz_lno_persistent_work_view_t permuted_adj = gsHandler->get_new_adj();
     scalar_persistent_work_view_t permuted_adj_vals = gsHandler->get_new_adj_val();
-    scalar_persistent_work_view_t permuted_diagonals = gsHandler->get_permuted_diagonals();
+    scalar_persistent_work_view_t permuted_inverse_diagonal = gsHandler->get_permuted_inverse_diagonal();
 
 #if KOKKOSSPARSE_IMPL_PRINTDEBUG
     std::cout << "Y:";
@@ -1245,7 +1299,7 @@ public:
     std::cout << "permuted_xadj:"; KokkosKernels::Impl::print_1Dview(permuted_xadj);
     std::cout << "permuted_adj:"; KokkosKernels::Impl::print_1Dview(permuted_adj);
     std::cout << "permuted_adj_vals:"; KokkosKernels::Impl::print_1Dview(permuted_adj_vals);
-    std::cout << "permuted_diagonals:"; KokkosKernels::Impl::print_1Dview(permuted_diagonals);
+    std::cout << "permuted_diagonals:"; KokkosKernels::Impl::print_1Dview(permuted_inverse_diagonal);
 #endif
     nnz_lno_persistent_work_host_view_t h_color_xadj = gsHandler->get_color_xadj();
 
@@ -1276,7 +1330,7 @@ public:
 #endif
 
     Team_PSGS gs(permuted_xadj, permuted_adj, permuted_adj_vals,
-    		Permuted_Xvector, Permuted_Yvector,0,0, permuted_diagonals, m_space,
+    		Permuted_Xvector, Permuted_Yvector,0,0, permuted_inverse_diagonal, m_space,
 			num_values_in_l1, num_values_in_l2,
 			block_size, team_row_chunk_size, l1_shmem_size, suggested_team_size,
 			suggested_vector_size);
@@ -1320,6 +1374,7 @@ public:
       y_value_array_type y_rhs_input_vec,
       bool init_zero_x_vector = false,
       int numIter = 1,
+      nnz_scalar_t omega = Kokkos::Details::ArithTraits<nnz_scalar_t>::one(),
       bool apply_forward = true,
       bool apply_backward = true,
       bool update_y_vector = true){
@@ -1367,15 +1422,21 @@ public:
     row_lno_persistent_work_view_t permuted_xadj = gsHandler->get_new_xadj();
     nnz_lno_persistent_work_view_t permuted_adj = gsHandler->get_new_adj();
     scalar_persistent_work_view_t permuted_adj_vals = gsHandler->get_new_adj_val();
-    scalar_persistent_work_view_t permuted_diagonals = gsHandler->get_permuted_diagonals();
+    scalar_persistent_work_view_t permuted_inverse_diagonal = gsHandler->get_permuted_inverse_diagonal();
 
     nnz_lno_persistent_work_host_view_t h_color_xadj = gsHandler->get_color_xadj();
 
 
+#if KOKKOSSPARSE_IMPL_PRINTDEBUG
+    std::cout << "--point Before X:";
+    KokkosKernels::Impl::print_1Dview(Permuted_Xvector,true);
+    std::cout << "--point Before Y:";
+    KokkosKernels::Impl::print_1Dview(Permuted_Yvector,true);
+#endif
 
     if (gsHandler->get_algorithm_type()== GS_PERMUTED){
       PSGS gs(permuted_xadj, permuted_adj, permuted_adj_vals,
-          Permuted_Xvector, Permuted_Yvector, color_adj, permuted_diagonals);
+          Permuted_Xvector, Permuted_Yvector, color_adj, permuted_inverse_diagonal);
 
       this->IterativePSGS(
           gs,
@@ -1390,7 +1451,7 @@ public:
       pool_memory_space m_space(0, 0, 0,  KokkosKernels::Impl::ManyThread2OneChunk, false);
 
       Team_PSGS gs(permuted_xadj, permuted_adj, permuted_adj_vals,
-          Permuted_Xvector, Permuted_Yvector,0,0, permuted_diagonals, m_space);
+          Permuted_Xvector, Permuted_Yvector,0,0, permuted_inverse_diagonal, m_space);
 
       this->IterativePSGS(
           gs,
@@ -1427,6 +1488,7 @@ public:
       y_value_array_type y_rhs_input_vec,
       bool init_zero_x_vector = false,
       int numIter = 1,
+      nnz_scalar_t omega = Kokkos::Details::ArithTraits<nnz_scalar_t>::one(),
       bool apply_forward = true,
       bool apply_backward = true,
       bool update_y_vector = true){
@@ -1438,6 +1500,7 @@ public:
     	this->point_apply(
     			x_lhs_output_vec, y_rhs_input_vec,
 				init_zero_x_vector, numIter ,
+                        omega,
     	      apply_forward, apply_backward,
     	      update_y_vector);
     }

--- a/src/sparse/impl/KokkosSparse_gauss_seidel_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_gauss_seidel_spec.hpp
@@ -54,77 +54,77 @@
 #endif
 
 namespace KokkosSparse {
-namespace Impl {
-// Specialization struct which defines whether a specialization exists
-template<class KernelHandle, class a_size_view_t_, class a_lno_view_t>
-struct gauss_seidel_symbolic_eti_spec_avail {
-  enum : bool { value = false };
-};
-template<class KernelHandle, class a_size_view_t_, class a_lno_view_t, class a_scalar_view_t>
-struct gauss_seidel_numeric_eti_spec_avail {
-  enum : bool { value = false };
-};
-template<class KernelHandle, class a_size_view_t_, class a_lno_view_t, class a_scalar_view_t, class x_scalar_view_t, class y_scalar_view_t>
-struct gauss_seidel_apply_eti_spec_avail {
-  enum : bool { value = false };
-};
-}
+  namespace Impl {
+    // Specialization struct which defines whether a specialization exists
+    template<class KernelHandle, class a_size_view_t_, class a_lno_view_t>
+    struct gauss_seidel_symbolic_eti_spec_avail {
+      enum : bool { value = false };
+    };
+    template<class KernelHandle, class a_size_view_t_, class a_lno_view_t, class a_scalar_view_t>
+    struct gauss_seidel_numeric_eti_spec_avail {
+      enum : bool { value = false };
+    };
+    template<class KernelHandle, class a_size_view_t_, class a_lno_view_t, class a_scalar_view_t, class x_scalar_view_t, class y_scalar_view_t>
+    struct gauss_seidel_apply_eti_spec_avail {
+      enum : bool { value = false };
+    };
+  }
 }
 
 
 #define KOKKOSSPARSE_GAUSS_SEIDEL_SYMBOLIC_ETI_SPEC_AVAIL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE ) \
-    template<> \
-    struct gauss_seidel_symbolic_eti_spec_avail< \
-        KokkosKernels::Experimental::KokkosKernelsHandle<\
-        const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
-          EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
-        Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
-          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,  \
-          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged> > > \
-    { enum : bool { value = true }; };
+  template<>                                                            \
+  struct gauss_seidel_symbolic_eti_spec_avail<                          \
+                                               KokkosKernels::Experimental::KokkosKernelsHandle< \
+                                                                                                const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
+                                                                                                EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
+                                               Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE, \
+                                                            Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                                               Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE, \
+                                                            Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                                            Kokkos::MemoryTraits<Kokkos::Unmanaged> > > \
+  { enum : bool { value = true }; };
 
 #define KOKKOSSPARSE_GAUSS_SEIDEL_NUMERIC_ETI_SPEC_AVAIL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE ) \
-    template<> \
-    struct gauss_seidel_numeric_eti_spec_avail< \
-        KokkosKernels::Experimental::KokkosKernelsHandle<\
-        const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
-          EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
-        Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
-          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,  \
-          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,  \
-          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged> > >\
-    { enum : bool { value = true }; };
+  template<>                                                            \
+  struct gauss_seidel_numeric_eti_spec_avail<                           \
+                                              KokkosKernels::Experimental::KokkosKernelsHandle< \
+                                                                                               const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
+                                                                                               EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
+                                              Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE, \
+                                                           Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                                           Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                                              Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE, \
+                                                           Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                                           Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                                              Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE, \
+                                                           Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                                           Kokkos::MemoryTraits<Kokkos::Unmanaged> > > \
+  { enum : bool { value = true }; };
 
 #define KOKKOSSPARSE_GAUSS_SEIDEL_APPLY_ETI_SPEC_AVAIL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE ) \
-    template<> \
-    struct gauss_seidel_apply_eti_spec_avail< \
-        KokkosKernels::Experimental::KokkosKernelsHandle<\
-        const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
-          EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
-        Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
-          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,  \
-          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,  \
-          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View< SCALAR_TYPE *, LAYOUT_TYPE,  \
-          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,  \
-          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged> > > \
-    { enum : bool { value = true }; };
+  template<>                                                            \
+  struct gauss_seidel_apply_eti_spec_avail<                             \
+                                            KokkosKernels::Experimental::KokkosKernelsHandle< \
+                                                                                             const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
+                                                                                             EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
+                                            Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE, \
+                                                         Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                                            Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE, \
+                                                         Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                                            Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE, \
+                                                         Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                                            Kokkos::View< SCALAR_TYPE *, LAYOUT_TYPE, \
+                                                          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                                            Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE, \
+                                                         Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                                         Kokkos::MemoryTraits<Kokkos::Unmanaged> > > \
+  { enum : bool { value = true }; };
 
 // Include the actual specialization declarations
 #include<KokkosSparse_gauss_seidel_tpl_spec_avail.hpp>
@@ -133,304 +133,304 @@ struct gauss_seidel_apply_eti_spec_avail {
 #include<generated_specializations_hpp/KokkosSparse_gauss_seidel_apply_eti_spec_avail.hpp>
 
 namespace KokkosSparse {
-namespace Impl {
+  namespace Impl {
 
 
 
-template<
-    class KernelHandle,
-    class a_size_view_t_, class a_lno_view_t,
-         bool tpl_spec_avail =
-             gauss_seidel_symbolic_tpl_spec_avail<
-               KernelHandle, a_size_view_t_,  a_lno_view_t>::value,
-         bool eti_spec_avail =
-             gauss_seidel_symbolic_eti_spec_avail<
-               KernelHandle,
-               a_size_view_t_,  a_lno_view_t>::value >
-struct GAUSS_SEIDEL_SYMBOLIC{
-  static void
-  gauss_seidel_symbolic (
-      KernelHandle *handle,
-      typename KernelHandle::const_nnz_lno_t num_rows,
-      typename KernelHandle::const_nnz_lno_t num_cols,
-      a_size_view_t_ row_map,
-      a_lno_view_t entries,
-      bool is_graph_symmetric);
-};
+    template<
+      class KernelHandle,
+      class a_size_view_t_, class a_lno_view_t,
+      bool tpl_spec_avail =
+      gauss_seidel_symbolic_tpl_spec_avail<
+        KernelHandle, a_size_view_t_,  a_lno_view_t>::value,
+      bool eti_spec_avail =
+      gauss_seidel_symbolic_eti_spec_avail<
+        KernelHandle,
+        a_size_view_t_,  a_lno_view_t>::value >
+    struct GAUSS_SEIDEL_SYMBOLIC{
+      static void
+      gauss_seidel_symbolic (
+                             KernelHandle *handle,
+                             typename KernelHandle::const_nnz_lno_t num_rows,
+                             typename KernelHandle::const_nnz_lno_t num_cols,
+                             a_size_view_t_ row_map,
+                             a_lno_view_t entries,
+                             bool is_graph_symmetric);
+    };
 
-template<
-    class KernelHandle,
-    class a_size_view_t_, class a_lno_view_t, class  a_scalar_view_t,
-         bool tpl_spec_avail =
-             gauss_seidel_numeric_tpl_spec_avail<
-               KernelHandle, a_size_view_t_,  a_lno_view_t, a_scalar_view_t>::value,
-         bool eti_spec_avail =
-             gauss_seidel_numeric_eti_spec_avail<
-               KernelHandle,
-               a_size_view_t_,  a_lno_view_t, a_scalar_view_t>::value >
-struct GAUSS_SEIDEL_NUMERIC{
-  static void
-  gauss_seidel_numeric (KernelHandle *handle,
-      typename KernelHandle::const_nnz_lno_t num_rows,
-      typename KernelHandle::const_nnz_lno_t num_cols,
-      a_size_view_t_ row_map,
-      a_lno_view_t entries,
-      a_scalar_view_t values,
-      bool is_graph_symmetric
-      );
+    template<
+      class KernelHandle,
+      class a_size_view_t_, class a_lno_view_t, class  a_scalar_view_t,
+      bool tpl_spec_avail =
+      gauss_seidel_numeric_tpl_spec_avail<
+        KernelHandle, a_size_view_t_,  a_lno_view_t, a_scalar_view_t>::value,
+      bool eti_spec_avail =
+      gauss_seidel_numeric_eti_spec_avail<
+        KernelHandle,
+        a_size_view_t_,  a_lno_view_t, a_scalar_view_t>::value >
+    struct GAUSS_SEIDEL_NUMERIC{
+      static void
+      gauss_seidel_numeric (KernelHandle *handle,
+                            typename KernelHandle::const_nnz_lno_t num_rows,
+                            typename KernelHandle::const_nnz_lno_t num_cols,
+                            a_size_view_t_ row_map,
+                            a_lno_view_t entries,
+                            a_scalar_view_t values,
+                            bool is_graph_symmetric
+                            );
 
-  static void
-  gauss_seidel_numeric (KernelHandle *handle,
-      typename KernelHandle::const_nnz_lno_t num_rows,
-      typename KernelHandle::const_nnz_lno_t num_cols,
-      a_size_view_t_ row_map,
-      a_lno_view_t entries,
-      a_scalar_view_t values,
-      a_scalar_view_t given_inverse_diagonal,
-      bool is_graph_symmetric
-      );
-};
+      static void
+      gauss_seidel_numeric (KernelHandle *handle,
+                            typename KernelHandle::const_nnz_lno_t num_rows,
+                            typename KernelHandle::const_nnz_lno_t num_cols,
+                            a_size_view_t_ row_map,
+                            a_lno_view_t entries,
+                            a_scalar_view_t values,
+                            a_scalar_view_t given_inverse_diagonal,
+                            bool is_graph_symmetric
+                            );
+    };
 
 
-template<
-    class KernelHandle,
-    class a_size_view_t_, class a_lno_view_t, class  a_scalar_view_t, class x_scalar_view_t, class y_scalar_view_t,
-         bool tpl_spec_avail =
-             gauss_seidel_apply_tpl_spec_avail<
-               KernelHandle, a_size_view_t_,  a_lno_view_t, a_scalar_view_t,x_scalar_view_t, y_scalar_view_t>::value,
-         bool eti_spec_avail =
-             gauss_seidel_apply_eti_spec_avail<
-               KernelHandle,
-               a_size_view_t_,  a_lno_view_t, a_scalar_view_t,x_scalar_view_t, y_scalar_view_t>::value >
-struct GAUSS_SEIDEL_APPLY{
-  static void
-  gauss_seidel_apply (
-      KernelHandle *handle,
-    typename KernelHandle::const_nnz_lno_t num_rows,
-    typename KernelHandle::const_nnz_lno_t num_cols,
-    a_size_view_t_ row_map,
-    a_lno_view_t entries,
-    a_scalar_view_t values,
-    x_scalar_view_t x_lhs_output_vec,
-    y_scalar_view_t y_rhs_input_vec,
-    bool init_zero_x_vector,
-    bool update_y_vector,
-    typename KernelHandle::nnz_scalar_t omega, int numIter, bool apply_forward, bool apply_backward);
-};
+    template<
+      class KernelHandle,
+      class a_size_view_t_, class a_lno_view_t, class  a_scalar_view_t, class x_scalar_view_t, class y_scalar_view_t,
+      bool tpl_spec_avail =
+      gauss_seidel_apply_tpl_spec_avail<
+        KernelHandle, a_size_view_t_,  a_lno_view_t, a_scalar_view_t,x_scalar_view_t, y_scalar_view_t>::value,
+      bool eti_spec_avail =
+      gauss_seidel_apply_eti_spec_avail<
+        KernelHandle,
+        a_size_view_t_,  a_lno_view_t, a_scalar_view_t,x_scalar_view_t, y_scalar_view_t>::value >
+    struct GAUSS_SEIDEL_APPLY{
+      static void
+      gauss_seidel_apply (
+                          KernelHandle *handle,
+                          typename KernelHandle::const_nnz_lno_t num_rows,
+                          typename KernelHandle::const_nnz_lno_t num_cols,
+                          a_size_view_t_ row_map,
+                          a_lno_view_t entries,
+                          a_scalar_view_t values,
+                          x_scalar_view_t x_lhs_output_vec,
+                          y_scalar_view_t y_rhs_input_vec,
+                          bool init_zero_x_vector,
+                          bool update_y_vector,
+                          typename KernelHandle::nnz_scalar_t omega, int numIter, bool apply_forward, bool apply_backward);
+    };
 
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 
 
-template<class KernelHandle, class a_size_view_t_, class a_lno_view_t>
-struct GAUSS_SEIDEL_SYMBOLIC<KernelHandle,
-        a_size_view_t_,  a_lno_view_t,
-        false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>{
+    template<class KernelHandle, class a_size_view_t_, class a_lno_view_t>
+    struct GAUSS_SEIDEL_SYMBOLIC<KernelHandle,
+                                 a_size_view_t_,  a_lno_view_t,
+                                 false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>{
 
-  static void
-  gauss_seidel_symbolic (
-      KernelHandle *handle,
-      typename KernelHandle::const_nnz_lno_t num_rows,
-      typename KernelHandle::const_nnz_lno_t num_cols,
-      a_size_view_t_ row_map,
-      a_lno_view_t entries,
-      bool is_graph_symmetric){
+      static void
+      gauss_seidel_symbolic (
+                             KernelHandle *handle,
+                             typename KernelHandle::const_nnz_lno_t num_rows,
+                             typename KernelHandle::const_nnz_lno_t num_cols,
+                             a_size_view_t_ row_map,
+                             a_lno_view_t entries,
+                             bool is_graph_symmetric){
 
-      typedef typename Impl::GaussSeidel<KernelHandle, a_size_view_t_,
-          a_lno_view_t, typename KernelHandle::in_scalar_nnz_view_t> SGS;
-      SGS sgs(handle,num_rows, num_cols, row_map, entries, is_graph_symmetric);
-      sgs.initialize_symbolic();
-  }
-};
+        typedef typename Impl::GaussSeidel<KernelHandle, a_size_view_t_,
+                                           a_lno_view_t, typename KernelHandle::in_scalar_nnz_view_t> SGS;
+        SGS sgs(handle,num_rows, num_cols, row_map, entries, is_graph_symmetric);
+        sgs.initialize_symbolic();
+      }
+    };
 
-template<class KernelHandle, class a_size_view_t_, class a_lno_view_t, class a_scalar_view_t>
-struct GAUSS_SEIDEL_NUMERIC<KernelHandle,
-        a_size_view_t_,  a_lno_view_t, a_scalar_view_t,
-        false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>{
+    template<class KernelHandle, class a_size_view_t_, class a_lno_view_t, class a_scalar_view_t>
+    struct GAUSS_SEIDEL_NUMERIC<KernelHandle,
+                                a_size_view_t_,  a_lno_view_t, a_scalar_view_t,
+                                false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>{
 
-  static void
-  gauss_seidel_numeric(KernelHandle *handle,
-      typename KernelHandle::const_nnz_lno_t num_rows,
-      typename KernelHandle::const_nnz_lno_t num_cols,
-      a_size_view_t_ row_map,
-      a_lno_view_t entries,
-      a_scalar_view_t values,
-      bool is_graph_symmetric
-      ){
-    typedef typename Impl::GaussSeidel
-        <KernelHandle,a_size_view_t_,
-        a_lno_view_t,a_scalar_view_t> SGS;
-    SGS sgs(handle, num_rows, num_cols, row_map, entries, values, is_graph_symmetric);
-    sgs.initialize_numeric();
-  }
+      static void
+      gauss_seidel_numeric(KernelHandle *handle,
+                           typename KernelHandle::const_nnz_lno_t num_rows,
+                           typename KernelHandle::const_nnz_lno_t num_cols,
+                           a_size_view_t_ row_map,
+                           a_lno_view_t entries,
+                           a_scalar_view_t values,
+                           bool is_graph_symmetric
+                           ){
+        typedef typename Impl::GaussSeidel
+          <KernelHandle,a_size_view_t_,
+           a_lno_view_t,a_scalar_view_t> SGS;
+        SGS sgs(handle, num_rows, num_cols, row_map, entries, values, is_graph_symmetric);
+        sgs.initialize_numeric();
+      }
 
-  static void
-  gauss_seidel_numeric(KernelHandle *handle,
-      typename KernelHandle::const_nnz_lno_t num_rows,
-      typename KernelHandle::const_nnz_lno_t num_cols,
-      a_size_view_t_ row_map,
-      a_lno_view_t entries,
-      a_scalar_view_t values,
-      a_scalar_view_t given_inverse_diagonal,
-      bool is_graph_symmetric
-      ){
-    typedef typename Impl::GaussSeidel
-        <KernelHandle,a_size_view_t_,
-        a_lno_view_t,a_scalar_view_t> SGS;
-    SGS sgs(handle, num_rows, num_cols, row_map, entries, values, given_inverse_diagonal, is_graph_symmetric);
-    sgs.initialize_numeric();
-}
-};
+      static void
+      gauss_seidel_numeric(KernelHandle *handle,
+                           typename KernelHandle::const_nnz_lno_t num_rows,
+                           typename KernelHandle::const_nnz_lno_t num_cols,
+                           a_size_view_t_ row_map,
+                           a_lno_view_t entries,
+                           a_scalar_view_t values,
+                           a_scalar_view_t given_inverse_diagonal,
+                           bool is_graph_symmetric
+                           ){
+        typedef typename Impl::GaussSeidel
+          <KernelHandle,a_size_view_t_,
+           a_lno_view_t,a_scalar_view_t> SGS;
+        SGS sgs(handle, num_rows, num_cols, row_map, entries, values, given_inverse_diagonal, is_graph_symmetric);
+        sgs.initialize_numeric();
+      }
+    };
 
-template<class KernelHandle, class a_size_view_t_, class a_lno_view_t, class a_scalar_view_t, class x_scalar_view_t, class y_scalar_view_t>
-struct GAUSS_SEIDEL_APPLY<KernelHandle,
-        a_size_view_t_,  a_lno_view_t, a_scalar_view_t,x_scalar_view_t, y_scalar_view_t,
-        false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>{
+    template<class KernelHandle, class a_size_view_t_, class a_lno_view_t, class a_scalar_view_t, class x_scalar_view_t, class y_scalar_view_t>
+    struct GAUSS_SEIDEL_APPLY<KernelHandle,
+                              a_size_view_t_,  a_lno_view_t, a_scalar_view_t,x_scalar_view_t, y_scalar_view_t,
+                              false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>{
 
-  static void
-  gauss_seidel_apply(
-      KernelHandle *handle,
-    typename KernelHandle::const_nnz_lno_t num_rows,
-    typename KernelHandle::const_nnz_lno_t num_cols,
-    a_size_view_t_ row_map,
-    a_lno_view_t entries,
-    a_scalar_view_t values,
-    x_scalar_view_t x_lhs_output_vec,
-    y_scalar_view_t y_rhs_input_vec,
-    bool init_zero_x_vector,
-    bool update_y_vector,
-    typename KernelHandle::nnz_scalar_t omega, int numIter, bool apply_forward, bool apply_backward){
+      static void
+      gauss_seidel_apply(
+                         KernelHandle *handle,
+                         typename KernelHandle::const_nnz_lno_t num_rows,
+                         typename KernelHandle::const_nnz_lno_t num_cols,
+                         a_size_view_t_ row_map,
+                         a_lno_view_t entries,
+                         a_scalar_view_t values,
+                         x_scalar_view_t x_lhs_output_vec,
+                         y_scalar_view_t y_rhs_input_vec,
+                         bool init_zero_x_vector,
+                         bool update_y_vector,
+                         typename KernelHandle::nnz_scalar_t omega, int numIter, bool apply_forward, bool apply_backward){
 
-    typedef typename Impl::GaussSeidel <KernelHandle,
-            a_size_view_t_, a_lno_view_t,a_scalar_view_t > SGS;
-    SGS sgs(handle, num_rows, num_cols, row_map, entries, values);
-    sgs.apply(
-        x_lhs_output_vec,
-        y_rhs_input_vec,
-        init_zero_x_vector,
-        numIter,
-        omega,
-    apply_forward,
-    apply_backward, update_y_vector);
-}
-};
+        typedef typename Impl::GaussSeidel <KernelHandle,
+                                            a_size_view_t_, a_lno_view_t,a_scalar_view_t > SGS;
+        SGS sgs(handle, num_rows, num_cols, row_map, entries, values);
+        sgs.apply(
+                  x_lhs_output_vec,
+                  y_rhs_input_vec,
+                  init_zero_x_vector,
+                  numIter,
+                  omega,
+                  apply_forward,
+                  apply_backward, update_y_vector);
+      }
+    };
 #endif
 
 
 
-}
+  }
 }
 
 #define KOKKOSSPARSE_GAUSS_SEIDEL_SYMBOLIC_ETI_SPEC_DECL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE ) \
-    extern template struct  \
-    GAUSS_SEIDEL_SYMBOLIC< \
-        KokkosKernels::Experimental::KokkosKernelsHandle<\
-        const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
-          EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
-        Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
-          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,  \
-          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged> > , \
-            false, true >;
+  extern template struct                                                \
+  GAUSS_SEIDEL_SYMBOLIC<                                                \
+                         KokkosKernels::Experimental::KokkosKernelsHandle< \
+                                                                          const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
+                                                                          EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
+                         Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE, \
+                                      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                         Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE, \
+                                      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                      Kokkos::MemoryTraits<Kokkos::Unmanaged> > , \
+                         false, true >;
 
 
 #define KOKKOSSPARSE_GAUSS_SEIDEL_SYMBOLIC_ETI_SPEC_INST( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE) \
-    template struct  \
-    GAUSS_SEIDEL_SYMBOLIC< \
-    KokkosKernels::Experimental::KokkosKernelsHandle<\
-    const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
-      EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
-    Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-    Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,  \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> > , \
-            false, true > ;
+  template struct                                                       \
+  GAUSS_SEIDEL_SYMBOLIC<                                                \
+                         KokkosKernels::Experimental::KokkosKernelsHandle< \
+                                                                          const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
+                                                                          EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
+                         Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE, \
+                                      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                         Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE, \
+                                      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                      Kokkos::MemoryTraits<Kokkos::Unmanaged> > , \
+                         false, true > ;
 
 #define KOKKOSSPARSE_GAUSS_SEIDEL_NUMERIC_ETI_SPEC_DECL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE,SLOW_MEM_SPACE ) \
-    extern template struct  \
-    GAUSS_SEIDEL_NUMERIC< \
-    KokkosKernels::Experimental::KokkosKernelsHandle<\
-    const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
-      EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
-    Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-    Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,  \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-    Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,  \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> > , \
-            false, true >;
+  extern template struct                                                \
+  GAUSS_SEIDEL_NUMERIC<                                                 \
+                        KokkosKernels::Experimental::KokkosKernelsHandle< \
+                                                                         const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
+                                                                         EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
+                        Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
+                                     Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                        Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE, \
+                                     Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                        Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,  \
+                                     Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                     Kokkos::MemoryTraits<Kokkos::Unmanaged> > , \
+                        false, true >;
 
 
 #define KOKKOSSPARSE_GAUSS_SEIDEL_NUMERIC_ETI_SPEC_INST( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE) \
-    template struct  \
-    GAUSS_SEIDEL_NUMERIC< \
-    KokkosKernels::Experimental::KokkosKernelsHandle<\
-    const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
-      EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
-    Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-    Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,  \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-    Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,  \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> > , \
-            false, true > ;
+  template struct                                                       \
+  GAUSS_SEIDEL_NUMERIC<                                                 \
+                        KokkosKernels::Experimental::KokkosKernelsHandle< \
+                                                                         const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
+                                                                         EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
+                        Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
+                                     Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                        Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE, \
+                                     Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                        Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,  \
+                                     Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                     Kokkos::MemoryTraits<Kokkos::Unmanaged> > , \
+                        false, true > ;
 
 #define KOKKOSSPARSE_GAUSS_SEIDEL_APPLY_ETI_SPEC_DECL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE) \
-    extern template struct  \
-    GAUSS_SEIDEL_APPLY< \
-    KokkosKernels::Experimental::KokkosKernelsHandle<\
-    const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
-      EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
-    Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-    Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,  \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-    Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,  \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-    Kokkos::View<SCALAR_TYPE *, LAYOUT_TYPE,  \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-    Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,  \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> > , \
-            false, true >;
+  extern template struct                                                \
+  GAUSS_SEIDEL_APPLY<                                                   \
+                      KokkosKernels::Experimental::KokkosKernelsHandle< \
+                                                                       const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
+                                                                       EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
+                      Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,    \
+                                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                      Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,   \
+                                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                      Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,    \
+                                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                      Kokkos::View<SCALAR_TYPE *, LAYOUT_TYPE,          \
+                                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                      Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,    \
+                                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > , \
+                      false, true >;
 
 
 #define KOKKOSSPARSE_GAUSS_SEIDEL_APPLY_ETI_SPEC_INST( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE) \
-    template struct  \
-    GAUSS_SEIDEL_APPLY< \
-    KokkosKernels::Experimental::KokkosKernelsHandle<\
-    const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
-      EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
-    Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-    Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,  \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-    Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,  \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-    Kokkos::View<SCALAR_TYPE *, LAYOUT_TYPE,  \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-    Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,  \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> > , \
-            false, true > ;
+  template struct                                                       \
+  GAUSS_SEIDEL_APPLY<                                                   \
+                      KokkosKernels::Experimental::KokkosKernelsHandle< \
+                                                                       const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
+                                                                       EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
+                      Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,    \
+                                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                      Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,   \
+                                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                      Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,    \
+                                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                      Kokkos::View<SCALAR_TYPE *, LAYOUT_TYPE,          \
+                                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                      Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,    \
+                                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > , \
+                      false, true > ;
 
 #include<KokkosSparse_gauss_seidel_tpl_spec_decl.hpp>
 #include<generated_specializations_hpp/KokkosSparse_gauss_seidel_symbolic_eti_spec_decl.hpp>

--- a/src/sparse/impl/KokkosSparse_gauss_seidel_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_gauss_seidel_spec.hpp
@@ -178,6 +178,17 @@ struct GAUSS_SEIDEL_NUMERIC{
       a_scalar_view_t values,
       bool is_graph_symmetric
       );
+
+  static void
+  gauss_seidel_numeric (KernelHandle *handle,
+      typename KernelHandle::const_nnz_lno_t num_rows,
+      typename KernelHandle::const_nnz_lno_t num_cols,
+      a_size_view_t_ row_map,
+      a_lno_view_t entries,
+      a_scalar_view_t values,
+      a_scalar_view_t given_inverse_diagonal,
+      bool is_graph_symmetric
+      );
 };
 
 
@@ -204,7 +215,7 @@ struct GAUSS_SEIDEL_APPLY{
     y_scalar_view_t y_rhs_input_vec,
     bool init_zero_x_vector,
     bool update_y_vector,
-    int numIter, bool apply_forward, bool apply_backward);
+    typename KernelHandle::nnz_scalar_t omega, int numIter, bool apply_forward, bool apply_backward);
 };
 
 
@@ -251,6 +262,23 @@ struct GAUSS_SEIDEL_NUMERIC<KernelHandle,
         a_lno_view_t,a_scalar_view_t> SGS;
     SGS sgs(handle, num_rows, num_cols, row_map, entries, values, is_graph_symmetric);
     sgs.initialize_numeric();
+  }
+
+  static void
+  gauss_seidel_numeric(KernelHandle *handle,
+      typename KernelHandle::const_nnz_lno_t num_rows,
+      typename KernelHandle::const_nnz_lno_t num_cols,
+      a_size_view_t_ row_map,
+      a_lno_view_t entries,
+      a_scalar_view_t values,
+      a_scalar_view_t given_inverse_diagonal,
+      bool is_graph_symmetric
+      ){
+    typedef typename Impl::GaussSeidel
+        <KernelHandle,a_size_view_t_,
+        a_lno_view_t,a_scalar_view_t> SGS;
+    SGS sgs(handle, num_rows, num_cols, row_map, entries, values, given_inverse_diagonal, is_graph_symmetric);
+    sgs.initialize_numeric();
 }
 };
 
@@ -271,7 +299,7 @@ struct GAUSS_SEIDEL_APPLY<KernelHandle,
     y_scalar_view_t y_rhs_input_vec,
     bool init_zero_x_vector,
     bool update_y_vector,
-    int numIter, bool apply_forward, bool apply_backward){
+    typename KernelHandle::nnz_scalar_t omega, int numIter, bool apply_forward, bool apply_backward){
 
     typedef typename Impl::GaussSeidel <KernelHandle,
             a_size_view_t_, a_lno_view_t,a_scalar_view_t > SGS;
@@ -281,6 +309,7 @@ struct GAUSS_SEIDEL_APPLY<KernelHandle,
         y_rhs_input_vec,
         init_zero_x_vector,
         numIter,
+        omega,
     apply_forward,
     apply_backward, update_y_vector);
 }

--- a/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
@@ -77,7 +77,8 @@ int run_block_gauss_seidel_1(
     int apply_type = 0, // 0 for symmetric, 1 for forward, 2 for backward.
     bool skip_symbolic = false,
     bool skip_numeric = false,
-    size_t shmem_size = 32128
+    size_t shmem_size = 32128,
+    typename crsMat_t::value_type omega = Kokkos::Details::ArithTraits<typename crsMat_t::value_type>::one()
     ){
   typedef typename crsMat_t::StaticCrsGraphType graph_t;
   typedef typename graph_t::row_map_type lno_view_t;
@@ -121,19 +122,19 @@ int run_block_gauss_seidel_1(
   switch (apply_type){
   case 0:
     symmetric_block_gauss_seidel_apply
-    (&kh, num_rows_1, num_cols_1, block_size, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, apply_count);
+    (&kh, num_rows_1, num_cols_1, block_size, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, omega, apply_count);
     break;
   case 1:
     forward_sweep_block_gauss_seidel_apply
-    (&kh, num_rows_1, num_cols_1, block_size, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, apply_count);
+    (&kh, num_rows_1, num_cols_1, block_size, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, omega, apply_count);
     break;
   case 2:
     backward_sweep_block_gauss_seidel_apply
-    (&kh, num_rows_1, num_cols_1, block_size, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, apply_count);
+    (&kh, num_rows_1, num_cols_1, block_size, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, omega, apply_count);
     break;
   default:
     symmetric_block_gauss_seidel_apply
-    (&kh, num_rows_1, num_cols_1, block_size, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, apply_count);
+    (&kh, num_rows_1, num_cols_1, block_size, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, omega, apply_count);
     break;
   }
 
@@ -252,6 +253,7 @@ void test_block_gauss_seidel(lno_t numRows, size_type nnz, lno_t bandwidth, lno_
     //int apply_type = 0;
     //bool skip_symbolic = false;
     //bool skip_numeric = false;
+    scalar_t omega = 0.9;
 
 
     bool is_symmetric_graph = true;
@@ -266,7 +268,7 @@ void test_block_gauss_seidel(lno_t numRows, size_type nnz, lno_t bandwidth, lno_
 
             Kokkos::Impl::Timer timer1;
             //int res =
-            run_block_gauss_seidel_1<crsMat_t, device>(input_mat, block_size, gs_algorithm, x_vector, y_vector, is_symmetric_graph, apply_type, skip_symbolic, skip_numeric, shmem_size);
+            run_block_gauss_seidel_1<crsMat_t, device>(input_mat, block_size, gs_algorithm, x_vector, y_vector, is_symmetric_graph, apply_type, skip_symbolic, skip_numeric, shmem_size, omega);
             //double gs = timer1.seconds();
 
             //KokkosKernels::Impl::print_1Dview(x_vector);

--- a/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
@@ -76,7 +76,8 @@ int run_gauss_seidel_1(
     bool is_symmetric_graph,
     int apply_type = 0, // 0 for symmetric, 1 for forward, 2 for backward.
     bool skip_symbolic = false,
-    bool skip_numeric = false
+    bool skip_numeric = false,
+    typename crsMat_t::value_type omega = Kokkos::Details::ArithTraits<typename crsMat_t::value_type>::one()
     ){
   typedef typename crsMat_t::StaticCrsGraphType graph_t;
   typedef typename graph_t::row_map_type lno_view_t;
@@ -118,19 +119,19 @@ int run_gauss_seidel_1(
   switch (apply_type){
   case 0:
     symmetric_gauss_seidel_apply
-    (&kh, num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, apply_count);
+      (&kh, num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, omega, apply_count);
     break;
   case 1:
     forward_sweep_gauss_seidel_apply
-    (&kh, num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, apply_count);
+    (&kh, num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, omega, apply_count);
     break;
   case 2:
     backward_sweep_gauss_seidel_apply
-    (&kh, num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, apply_count);
+    (&kh, num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, omega, apply_count);
     break;
   default:
     symmetric_gauss_seidel_apply
-    (&kh, num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, apply_count);
+    (&kh, num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, omega, apply_count);
     break;
   }
 
@@ -218,8 +219,7 @@ void test_gauss_seidel(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_
     //int apply_type = 0;
     //bool skip_symbolic = false;
     //bool skip_numeric = false;
-
-
+    scalar_t omega = 0.9;
 
     for (int is_symmetric_graph = 0; is_symmetric_graph < 2; ++is_symmetric_graph){
 
@@ -229,7 +229,7 @@ void test_gauss_seidel(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_
 
             Kokkos::Impl::Timer timer1;
             //int res =
-            run_gauss_seidel_1<crsMat_t, device>(input_mat, gs_algorithm, x_vector, y_vector, is_symmetric_graph, apply_type, skip_symbolic, skip_numeric);
+            run_gauss_seidel_1<crsMat_t, device>(input_mat, gs_algorithm, x_vector, y_vector, is_symmetric_graph, apply_type, skip_symbolic, skip_numeric, omega);
             //double gs = timer1.seconds();
 
             //KokkosKernels::Impl::print_1Dview(x_vector);


### PR DESCRIPTION
- Add damping option
- Instead of inverting the diagonal in every iteration, save the inverse of the diagonal
- Allow to pass a precomputed diagonal. 

The last item is necessary for MT GS to work correctly with Ifpack2. The diagonal of a Tpetra matrix might not be given by pairs (i, i) of local IDs (depending on the rowmap and the colmap). Moreover, this allows to use MT GS with the l1 option from Ifpack2.

I also added some routines to dump to MatrixMarket format.

This addresses Issues #221 and #240 