### PR TITLE
KokkosKernels - cmake modifications for TPLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,44 @@ IF (KokkosKernels_INST_OFFSET_SIZE_T)
   LIST(APPEND OFFSET_LIST "size_t")
 ENDIF()
 
+# ==================================================================
+# Enable Third Party Libraries
+# ==================================================================
+
+IF (TPL_ENABLE_BLAS)
+  SET(KOKKOSKERNELS_ENABLE_TPL_BLAS ${TPL_ENABLE_BLAS})
+ENDIF()
+IF (TPL_ENABLE_MKL)
+  SET(KOKKOSKERNELS_ENABLE_TPL_MKL ${TPL_ENABLE_MKL})
+ENDIF()
+
+IF(${Kokkos_ENABLE_Cuda})
+  # CUBLAS is ON by default when CUDA is enabled
+  SET(KOKKOSKERNELS_ENABLE_TPL_CUBLAS ON)
+  # Tribit provides TPL mechanism for CUSPARSE; thus, use it
+  IF (TPL_ENABLE_CUSPARSE)
+    SET(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE ${TPL_ENABLE_CUSPARSE})
+  ENDIF()
+ENDIF()
+
+IF (KOKKOSKERNELS_ENABLE_TPL_BLAS)
+  LIST(APPEND TPL_LIST "BLAS")
+ENDIF()
+IF (KOKKOSKERNELS_ENABLE_TPL_MKL)
+  LIST(APPEND TPL_LIST "MKL")
+ENDIF()
+IF (KOKKOSKERNELS_ENABLE_TPL_CUSPARSE)
+  LIST(APPEND TPL_LIST "CUSPARSE")
+ENDIF()
+IF (KOKKOSKERNELS_ENABLE_TPL_CUBLAS)
+  LIST(APPEND TPL_LIST "CUBLAS")
+ENDIF()
+
+# ==================================================================
+# CMake Summary
+# ==================================================================
+
+
 MESSAGE("")
 MESSAGE("=======================")
 MESSAGE("KokkosKernels ETI Types")
@@ -293,6 +331,9 @@ MESSAGE("   Devices:  ${DEVICE_LIST}")
 MESSAGE("   Scalars:  ${SCALAR_LIST}")
 MESSAGE("   Ordinals: ${ORDINAL_LIST}")
 MESSAGE("   Offsets:  ${OFFSET_LIST}")
+MESSAGE("")
+MESSAGE("KokkosKernels TPLs")
+MESSAGE("   ${TPL_LIST}")
 MESSAGE("=======================")
 MESSAGE("")
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,9 +1,4 @@
-# FIXME (mfh 18 Dec 2014) MKL and CUSPARSE are optional TPLs, in the
-# sense that one need not include the MKL resp. CUSPARSE header files
-# if those TPLs aren't enabled.  However, we should still list them as
-# optional TPLs.
-
 TRIBITS_PACKAGE_DEFINE_DEPENDENCIES(
   LIB_REQUIRED_PACKAGES KokkosCore KokkosContainers KokkosAlgorithms 
-  LIB_OPTIONAL_TPLS quadmath MKL
+  LIB_OPTIONAL_TPLS quadmath MKL BLAS LAPACK CUSPARSE
 )

--- a/cmake/KokkosKernels_config.h.in
+++ b/cmake/KokkosKernels_config.h.in
@@ -66,6 +66,26 @@
 /* Whether to build kernels for offset type size_t */
 #cmakedefine KOKKOSKERNELS_INST_OFFSET_SIZE_T
 
+/*
+ * Third Party Libraries
+ */
+
+/* BLAS library */
+#cmakedefine KOKKOSKERNELS_ENABLE_TPL_BLAS
+/* MKL library */
+#cmakedefine KOKKOSKERNELS_ENABLE_TPL_MKL
+/* CUSPARSE */
+#cmakedefine KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+/* CUBLAS */
+#cmakedefine KOKKOSKERNELS_ENABLE_TPL_CUBLAS
+
+/* if MKL or CUBLAS is defined, BLAS is also defined */
+#if defined(KOKKOSKERNELS_ENABLE_TPL_MKL) || defined(KOKKOSKERNELS_ENABLE_TPL_CUBLAS)
+#if !defined(KOKKOSKERNELS_ENABLE_TPL_BLAS)
+#define KOKKOSKERNELS_ENABLE_TPL_BLAS
+#endif
+#endif
+
 
 /*
  * "Optimization level" for computational kernels in this subpackage.

--- a/src/blas/KokkosBlas.hpp
+++ b/src/blas/KokkosBlas.hpp
@@ -62,4 +62,7 @@
 
 
 #include<KokkosBlas2_gemv.hpp>
+
+
+#include<KokkosBlas3_gemm.hpp>
 #endif

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -17,6 +17,9 @@ INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_CURRENT_SOURCE_
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/../test_common)
 INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_CURRENT_SOURCE_DIR}/../test_common)
 
+# Kyungjoo: when kokkoskernels and kokkos are symbolic link and their src directories are overrided
+#           the following relative path does not work or users should put kokkoskernels and kokkos
+#           at the same place
 SET(GTEST_SOURCE_DIR ${${PARENT_PACKAGE_NAME}_SOURCE_DIR}/../kokkos/tpls/gtest)
 INCLUDE_DIRECTORIES(${GTEST_SOURCE_DIR})
 


### PR DESCRIPTION
  Reference issue #276
  - add BLAS, LAPACK, CUBLAS, CUSPARSE TPL dependence
  - KokkosBlas.hpp includes gemm
  - comment regarding to gtest path
    - when we use override src directory, the relative path to other
      package (kokkos) may not be correct.

This PR is necessary in order to remove Tpetra BLAS functions.