### PR TITLE
KokkosKernels - fix the automatic tpl blas enabling logic

### DIFF
--- a/Makefile.kokkos-kernels
+++ b/Makefile.kokkos-kernels
@@ -261,7 +261,7 @@ ifeq (${KOKKOSKERNELS_INTERNAL_ENABLE_CUBLAS}, 1)
   tmp := $(shell echo "\#define KOKKOSKERNELS_ENABLE_TPL_CUBLAS" >> KokkosKernels_config.tmp )
 endif
 
-  tmp := $(shell echo "\#if defined(KOKKOSKERNELS_ENABLE_TPL_MKL) || defined(KOKKOSKERNELS_ENABLE_TPL_CUBLAS)" >> KokkosKernels_config.tmp )
+  tmp := $(shell echo "\#if defined(KOKKOSKERNELS_ENABLE_TPL_MKL)" >> KokkosKernels_config.tmp )
   tmp := $(shell echo "\#if !defined(KOKKOSKERNELS_ENABLE_TPL_BLAS)" >> KokkosKernels_config.tmp )  
   tmp := $(shell echo "\#define KOKKOSKERNELS_ENABLE_TPL_BLAS" >> KokkosKernels_config.tmp )
   tmp := $(shell echo "\#endif" >> KokkosKernels_config.tmp )

--- a/cmake/KokkosKernels_config.h.in
+++ b/cmake/KokkosKernels_config.h.in
@@ -79,8 +79,8 @@
 /* CUBLAS */
 #cmakedefine KOKKOSKERNELS_ENABLE_TPL_CUBLAS
 
-/* if MKL or CUBLAS is defined, BLAS is also defined */
-#if defined(KOKKOSKERNELS_ENABLE_TPL_MKL) || defined(KOKKOSKERNELS_ENABLE_TPL_CUBLAS)
+/* if MKL, BLAS is also defined */
+#if defined(KOKKOSKERNELS_ENABLE_TPL_MKL) 
 #if !defined(KOKKOSKERNELS_ENABLE_TPL_BLAS)
 #define KOKKOSKERNELS_ENABLE_TPL_BLAS
 #endif


### PR DESCRIPTION
Currently, tpl blas is automatically enabled when mkl or cublas is enabled.

This is wrong when cublas is only provided without host blas library. 

This fixes the problem. 