### PR TITLE
Query positive infinity value of floating-point type using Kokkos::ArithTraits

### DIFF
--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -849,7 +849,7 @@ template<class RealFloatType>
 class ArithTraits<std::complex<RealFloatType> > {
 public:
   //! Kokkos internally replaces std::complex with Kokkos::complex.
-  typedef ::Kokkos::complex<RealFloatType> val_type;
+  typedef std::complex<RealFloatType> val_type;
   typedef RealFloatType mag_type;
 
   static const bool is_specialized = true;

--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -427,6 +427,17 @@ public:
   //! The one value of T; the multiplicative identity.
   static KOKKOS_FORCEINLINE_FUNCTION T one ();
 
+  /// \brief True if this type T is capable of representing the
+  /// positive infinity as a distinct special value, as with
+  /// std::numeric_limits<T>::has_infinity.
+  static constexpr bool hasInfinity = false;
+
+  /// \brief Returns the special value "positive infinity", as
+  /// represented by the floating-point type T. Only meaningful if
+  /// KokkosArithTraits<T>::hasInfinity == true. Provides same
+  /// functionality as std::numeric_limits<T>::infinity().
+  static KOKKOS_FORCEINLINE_FUNCTION T infinity();
+
   /// \brief The minimum possible value of T.
   ///
   /// If T is a real floating-point type, then this is the minimum
@@ -670,6 +681,9 @@ public:
   static const bool is_integer = false;
   static const bool is_exact = false;
   static const bool is_complex = false;
+
+  static constexpr bool hasInfinity = true;
+  static KOKKOS_FORCEINLINE_FUNCTION float infinity() { return HUGE_VALF; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const float x) {
     #ifndef __CUDA_ARCH__
@@ -1017,6 +1031,9 @@ public:
   static const bool is_exact = false;
   static const bool is_complex = false;
 
+  static constexpr bool hasInfinity = true;
+  static KOKKOS_FORCEINLINE_FUNCTION double infinity() { return HUGE_VAL; }
+
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type x) {
     #ifndef __CUDA_ARCH__
     using std::isinf;
@@ -1184,6 +1201,9 @@ public:
   static const bool is_integer = false;
   static const bool is_exact = false;
   static const bool is_complex = false;
+
+  static constexpr bool hasInfinity = true;
+  static KOKKOS_FORCEINLINE_FUNCTION long double infinity() { return HUGE_VALL; }
 
   static bool isInf (const val_type& x) {
     #ifndef __CUDA_ARCH__

--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -1948,6 +1948,9 @@ public:
   static const bool is_exact = true;
   static const bool is_complex = false;
 
+  static constexpr bool hasInfinity = false;
+  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
+
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
     return false;
   }
@@ -2090,6 +2093,9 @@ public:
   static const bool is_exact = true;
   static const bool is_complex = false;
 
+  static constexpr bool hasInfinity = false;
+  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
+
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
     return false;
   }
@@ -2208,6 +2214,9 @@ public:
   static const bool is_integer = true;
   static const bool is_exact = true;
   static const bool is_complex = false;
+
+  static constexpr bool hasInfinity = false;
+  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
     return false;
@@ -2330,6 +2339,9 @@ public:
   static const bool is_integer = true;
   static const bool is_exact = true;
   static const bool is_complex = false;
+
+  static constexpr bool hasInfinity = false;
+  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
     return false;
@@ -2467,6 +2479,9 @@ public:
   static const bool is_exact = true;
   static const bool is_complex = false;
 
+  static constexpr bool hasInfinity = false;
+  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
+
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
     return false;
   }
@@ -2594,6 +2609,9 @@ public:
   static const bool is_integer = true;
   static const bool is_exact = true;
   static const bool is_complex = false;
+
+  static constexpr bool hasInfinity = false;
+  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
     return false;
@@ -2731,6 +2749,9 @@ public:
   static const bool is_exact = true;
   static const bool is_complex = false;
 
+  static constexpr bool hasInfinity = false;
+  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
+
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
     return false;
   }
@@ -2859,6 +2880,9 @@ public:
   static const bool is_exact = true;
   static const bool is_complex = false;
 
+  static constexpr bool hasInfinity = false;
+  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
+
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
     return false;
   }
@@ -2981,6 +3005,9 @@ public:
   static const bool is_integer = true;
   static const bool is_exact = true;
   static const bool is_complex = false;
+
+  static constexpr bool hasInfinity = false;
+  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
     return false;
@@ -3113,6 +3140,9 @@ public:
   static const bool is_integer = true;
   static const bool is_exact = true;
   static const bool is_complex = false;
+
+  static constexpr bool hasInfinity = false;
+  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
     return false;
@@ -3260,6 +3290,9 @@ public:
   static const bool is_integer = true;
   static const bool is_exact = true;
   static const bool is_complex = false;
+
+  static constexpr bool hasInfinity = false;
+  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
     return false;

--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -859,7 +859,7 @@ public:
   static const bool is_complex = true;
 
   static constexpr bool has_infinity = false;
-  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return val_type(); }
+  static val_type infinity() { return val_type(); }
 
   static bool isInf (const std::complex<RealFloatType>& x) {
     #ifndef __CUDA_ARCH__

--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -858,6 +858,11 @@ public:
   static const bool is_exact = false;
   static const bool is_complex = true;
 
+  static constexpr bool hasInfinity = false;
+  static KOKKOS_FORCEINLINE_FUNCTION std::complex<RealFloatType> infinity() {
+    return std::complex<RealFloatType>();
+  }
+
   static bool isInf (const std::complex<RealFloatType>& x) {
     #ifndef __CUDA_ARCH__
     using std::isinf;
@@ -1524,6 +1529,9 @@ public:
   static const bool is_exact = false;
   static const bool is_complex = true;
 
+  static constexpr bool hasInfinity = false;
+  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return val_type(); }
+
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type x) {
     return ArithTraits<mag_type>::isInf (x.real ()) ||
       ArithTraits<mag_type>::isInf (x.imag ());
@@ -1726,6 +1734,9 @@ public:
   static const bool is_integer = false;
   static const bool is_exact = false;
   static const bool is_complex = true;
+
+  static constexpr bool hasInfinity = false;
+  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return val_type(); }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type x) {
     return ArithTraits<mag_type>::isInf (x.real ()) ||

--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -430,11 +430,11 @@ public:
   /// \brief True if this type T is capable of representing the
   /// positive infinity as a distinct special value, as with
   /// std::numeric_limits<T>::has_infinity.
-  static constexpr bool hasInfinity = false;
+  static constexpr bool has_infinity = false;
 
   /// \brief Returns the special value "positive infinity", as
   /// represented by the floating-point type T. Only meaningful if
-  /// KokkosArithTraits<T>::hasInfinity == true. Provides same
+  /// KokkosArithTraits<T>::has_infinity == true. Provides same
   /// functionality as std::numeric_limits<T>::infinity().
   ///
   /// \note Would have liked to mark it as constexpr but then would
@@ -686,7 +686,7 @@ public:
   static const bool is_exact = false;
   static const bool is_complex = false;
 
-  static constexpr bool hasInfinity = true;
+  static constexpr bool has_infinity = true;
   static KOKKOS_FORCEINLINE_FUNCTION float infinity() { return HUGE_VALF; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const float x) {
@@ -858,7 +858,7 @@ public:
   static const bool is_exact = false;
   static const bool is_complex = true;
 
-  static constexpr bool hasInfinity = false;
+  static constexpr bool has_infinity = false;
   static KOKKOS_FORCEINLINE_FUNCTION std::complex<RealFloatType> infinity() {
     return std::complex<RealFloatType>();
   }
@@ -1040,7 +1040,7 @@ public:
   static const bool is_exact = false;
   static const bool is_complex = false;
 
-  static constexpr bool hasInfinity = true;
+  static constexpr bool has_infinity = true;
   static KOKKOS_FORCEINLINE_FUNCTION double infinity() { return HUGE_VAL; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type x) {
@@ -1211,7 +1211,7 @@ public:
   static const bool is_exact = false;
   static const bool is_complex = false;
 
-  static constexpr bool hasInfinity = true;
+  static constexpr bool has_infinity = true;
   static KOKKOS_FORCEINLINE_FUNCTION long double infinity() { return HUGE_VALL; }
 
   static bool isInf (const val_type& x) {
@@ -1377,7 +1377,7 @@ public:
   static const bool is_exact = false;
   static const bool is_complex = false;
 
-  static constexpr bool hasInfinity = true;
+  static constexpr bool has_infinity = true;
   static KOKKOS_FORCEINLINE_FUNCTION __float128 infinity() { return 1.0q / 0.0q; }
 
   static bool isInf (const __float128 x) {
@@ -1532,7 +1532,7 @@ public:
   static const bool is_exact = false;
   static const bool is_complex = true;
 
-  static constexpr bool hasInfinity = false;
+  static constexpr bool has_infinity = false;
   static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return val_type(); }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type x) {
@@ -1738,7 +1738,7 @@ public:
   static const bool is_exact = false;
   static const bool is_complex = true;
 
-  static constexpr bool hasInfinity = false;
+  static constexpr bool has_infinity = false;
   static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return val_type(); }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type x) {
@@ -1948,7 +1948,7 @@ public:
   static const bool is_exact = true;
   static const bool is_complex = false;
 
-  static constexpr bool hasInfinity = false;
+  static constexpr bool has_infinity = false;
   static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
@@ -2093,7 +2093,7 @@ public:
   static const bool is_exact = true;
   static const bool is_complex = false;
 
-  static constexpr bool hasInfinity = false;
+  static constexpr bool has_infinity = false;
   static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
@@ -2215,7 +2215,7 @@ public:
   static const bool is_exact = true;
   static const bool is_complex = false;
 
-  static constexpr bool hasInfinity = false;
+  static constexpr bool has_infinity = false;
   static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
@@ -2340,7 +2340,7 @@ public:
   static const bool is_exact = true;
   static const bool is_complex = false;
 
-  static constexpr bool hasInfinity = false;
+  static constexpr bool has_infinity = false;
   static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
@@ -2479,7 +2479,7 @@ public:
   static const bool is_exact = true;
   static const bool is_complex = false;
 
-  static constexpr bool hasInfinity = false;
+  static constexpr bool has_infinity = false;
   static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
@@ -2610,7 +2610,7 @@ public:
   static const bool is_exact = true;
   static const bool is_complex = false;
 
-  static constexpr bool hasInfinity = false;
+  static constexpr bool has_infinity = false;
   static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
@@ -2749,7 +2749,7 @@ public:
   static const bool is_exact = true;
   static const bool is_complex = false;
 
-  static constexpr bool hasInfinity = false;
+  static constexpr bool has_infinity = false;
   static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
@@ -2880,7 +2880,7 @@ public:
   static const bool is_exact = true;
   static const bool is_complex = false;
 
-  static constexpr bool hasInfinity = false;
+  static constexpr bool has_infinity = false;
   static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
@@ -3006,7 +3006,7 @@ public:
   static const bool is_exact = true;
   static const bool is_complex = false;
 
-  static constexpr bool hasInfinity = false;
+  static constexpr bool has_infinity = false;
   static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
@@ -3141,7 +3141,7 @@ public:
   static const bool is_exact = true;
   static const bool is_complex = false;
 
-  static constexpr bool hasInfinity = false;
+  static constexpr bool has_infinity = false;
   static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {
@@ -3291,7 +3291,7 @@ public:
   static const bool is_exact = true;
   static const bool is_complex = false;
 
-  static constexpr bool hasInfinity = false;
+  static constexpr bool has_infinity = false;
   static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return 0; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type ) {

--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -1378,7 +1378,7 @@ public:
   static const bool is_complex = false;
 
   static constexpr bool has_infinity = true;
-  static KOKKOS_FORCEINLINE_FUNCTION __float128 infinity() { return 1.0q / 0.0q; }
+  static __float128 infinity() { return 1.0q / 0.0q; }
 
   static bool isInf (const __float128 x) {
     return isinfq (x);

--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -859,9 +859,7 @@ public:
   static const bool is_complex = true;
 
   static constexpr bool has_infinity = false;
-  static KOKKOS_FORCEINLINE_FUNCTION std::complex<RealFloatType> infinity() {
-    return std::complex<RealFloatType>();
-  }
+  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return val_type(); }
 
   static bool isInf (const std::complex<RealFloatType>& x) {
     #ifndef __CUDA_ARCH__

--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -849,7 +849,7 @@ template<class RealFloatType>
 class ArithTraits<std::complex<RealFloatType> > {
 public:
   //! Kokkos internally replaces std::complex with Kokkos::complex.
-  typedef std::complex<RealFloatType> val_type;
+  typedef ::Kokkos::complex<RealFloatType> val_type;
   typedef RealFloatType mag_type;
 
   static const bool is_specialized = true;

--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -436,6 +436,10 @@ public:
   /// represented by the floating-point type T. Only meaningful if
   /// KokkosArithTraits<T>::hasInfinity == true. Provides same
   /// functionality as std::numeric_limits<T>::infinity().
+  ///
+  /// \note Would have liked to mark it as constexpr but then would
+  /// not be able to provide the specialization for std::complex<T>
+  /// since its constructor only becomes constexpr with C++14.
   static KOKKOS_FORCEINLINE_FUNCTION T infinity();
 
   /// \brief The minimum possible value of T.

--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -1533,7 +1533,9 @@ public:
   static const bool is_complex = true;
 
   static constexpr bool has_infinity = false;
-  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return val_type(); }
+  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() {
+    return val_type (ArithTraits<mag_type>::infinity (), ArithTraits<mag_type>::infinity ());
+  }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type x) {
     return ArithTraits<mag_type>::isInf (x.real ()) ||
@@ -1739,7 +1741,9 @@ public:
   static const bool is_complex = true;
 
   static constexpr bool has_infinity = false;
-  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return val_type(); }
+  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() {
+    return val_type (ArithTraits<mag_type>::infinity (), ArithTraits<mag_type>::infinity ());
+  }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type x) {
     return ArithTraits<mag_type>::isInf (x.real ()) ||

--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -858,7 +858,7 @@ public:
   static const bool is_exact = false;
   static const bool is_complex = true;
 
-  static constexpr bool has_infinity = false;
+  static constexpr bool has_infinity = true;
   static std::complex<RealFloatType> infinity() {
     return std::complex<RealFloatType> (ArithTraits<mag_type>::infinity (), ArithTraits<mag_type>::infinity ());
   }
@@ -1532,7 +1532,7 @@ public:
   static const bool is_exact = false;
   static const bool is_complex = true;
 
-  static constexpr bool has_infinity = false;
+  static constexpr bool has_infinity = true;
   static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() {
     return val_type (ArithTraits<mag_type>::infinity (), ArithTraits<mag_type>::infinity ());
   }
@@ -1740,7 +1740,7 @@ public:
   static const bool is_exact = false;
   static const bool is_complex = true;
 
-  static constexpr bool has_infinity = false;
+  static constexpr bool has_infinity = true;
   static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() {
     return val_type (ArithTraits<mag_type>::infinity (), ArithTraits<mag_type>::infinity ());
   }

--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -859,7 +859,9 @@ public:
   static const bool is_complex = true;
 
   static constexpr bool has_infinity = false;
-  static val_type infinity() { return val_type(); }
+  static std::complex<RealFloatType> infinity() {
+    return std::complex<RealFloatType> (ArithTraits<mag_type>::infinity (), ArithTraits<mag_type>::infinity ());
+  }
 
   static bool isInf (const std::complex<RealFloatType>& x) {
     #ifndef __CUDA_ARCH__

--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -1377,6 +1377,9 @@ public:
   static const bool is_exact = false;
   static const bool is_complex = false;
 
+  static constexpr bool hasInfinity = true;
+  static KOKKOS_FORCEINLINE_FUNCTION __float128 infinity() { return 1.0q / 0.0q; }
+
   static bool isInf (const __float128 x) {
     return isinfq (x);
   }

--- a/test_common/Test_Common_ArithTraits.hpp
+++ b/test_common/Test_Common_ArithTraits.hpp
@@ -395,7 +395,7 @@ public:
         success = 0;
        }
     }
-    if ( ! std::is_same< ScalarType, typename std::result_of<decltype(&AT::infinity)()>::type >::value )
+    if ( ! std::is_same< ScalarType, decltype(AT::infinity()) >::value )
     {
       std::cout << "AT::infinity() return value has wrong type" << endl;
       success = 0;

--- a/test_common/Test_Common_ArithTraits.hpp
+++ b/test_common/Test_Common_ArithTraits.hpp
@@ -377,9 +377,21 @@ public:
         success = 0;
       }
     } else {
-       // We expect that real floating-point types had has_infinity == true
-       if ( ! (AT::is_integer || AT::is_complex)) {
-        out << "AT::has_infinity != true" << endl;
+       // We expect that real floating-point and complex numbers types had
+       // has_infinity == true.  Either we have an integer type or the
+       // ArithTraits class has not been specialized for that type.
+       if ( AT::is_integer ) {
+       // Return value of ArithTraits<T>::inifinity is only meaningfull when
+       // has_infinity == true but nevertheless let's check that the return
+       // value is 0 for integer types because that's how it is defined for
+       // std::numeric_limits::infinity() and how we intended to implement it.
+         if (AT::infinity() != 0 ) {
+          out << "AT::is_integer && AT::infinity() != 0" << endl;
+          success = 0;
+         }
+       } else if ( AT::is_specialized ) {
+       // Check that no specialized type slipped through the net
+        out << "AT::is_specialized && ! AT::is_integer && ! AT::has_infinity" << endl;
         success = 0;
        }
     }

--- a/test_common/Test_Common_ArithTraits.hpp
+++ b/test_common/Test_Common_ArithTraits.hpp
@@ -371,6 +371,19 @@ public:
       success = 0;
     }
 
+    if (AT::hasInfinity) {
+      if (! AT::isInf (AT::infinity())) {
+        out << "AT::isInf (inf) != true" << endl;
+        success = 0;
+      }
+    } else {
+       // We expect that real floating-point types had hasInfinity == true
+       if ( ! (AT::is_integer || AT::is_complex)) {
+        out << "AT::hasInfinity != true" << endl;
+        success = 0;
+       }
+    }
+
     // Run the parent class' remaining tests, if any.
     const int parentSuccess = testHostImpl (out);
     success = success && parentSuccess;

--- a/test_common/Test_Common_ArithTraits.hpp
+++ b/test_common/Test_Common_ArithTraits.hpp
@@ -381,7 +381,7 @@ public:
        // has_infinity == true.  Either we have an integer type or the
        // ArithTraits class has not been specialized for that type.
        if ( AT::is_integer ) {
-       // Return value of ArithTraits<T>::inifinity is only meaningfull when
+       // Return value of ArithTraits<T>::infinity is only meaningful when
        // has_infinity == true but nevertheless let's check that the return
        // value is 0 for integer types because that's how it is defined for
        // std::numeric_limits::infinity() and how we intended to implement it.

--- a/test_common/Test_Common_ArithTraits.hpp
+++ b/test_common/Test_Common_ArithTraits.hpp
@@ -395,6 +395,11 @@ public:
         success = 0;
        }
     }
+    if ( ! std::is_same< ScalarType, typename std::result_of<decltype(&AT::infinity)()>::type >::value )
+    {
+      std::cout << "AT::infinity() return value has wrong type" << endl;
+      success = 0;
+    }
 
     // Run the parent class' remaining tests, if any.
     const int parentSuccess = testHostImpl (out);

--- a/test_common/Test_Common_ArithTraits.hpp
+++ b/test_common/Test_Common_ArithTraits.hpp
@@ -371,15 +371,15 @@ public:
       success = 0;
     }
 
-    if (AT::hasInfinity) {
+    if (AT::has_infinity) {
       if (! AT::isInf (AT::infinity())) {
         out << "AT::isInf (inf) != true" << endl;
         success = 0;
       }
     } else {
-       // We expect that real floating-point types had hasInfinity == true
+       // We expect that real floating-point types had has_infinity == true
        if ( ! (AT::is_integer || AT::is_complex)) {
-        out << "AT::hasInfinity != true" << endl;
+        out << "AT::has_infinity != true" << endl;
         success = 0;
        }
     }

--- a/test_common/Test_Common_ArithTraits.hpp
+++ b/test_common/Test_Common_ArithTraits.hpp
@@ -376,24 +376,6 @@ public:
         out << "AT::isInf (inf) != true" << endl;
         success = 0;
       }
-    } else {
-       // We expect that real floating-point and complex numbers types had
-       // has_infinity == true.  Either we have an integer type or the
-       // ArithTraits class has not been specialized for that type.
-       if ( AT::is_integer ) {
-       // Return value of ArithTraits<T>::infinity is only meaningful when
-       // has_infinity == true but nevertheless let's check that the return
-       // value is 0 for integer types because that's how it is defined for
-       // std::numeric_limits::infinity() and how we intended to implement it.
-         if (AT::infinity() != 0 ) {
-          out << "AT::is_integer && AT::infinity() != 0" << endl;
-          success = 0;
-         }
-       } else if ( AT::is_specialized ) {
-       // Check that no specialized type slipped through the net
-        out << "AT::is_specialized && ! AT::is_integer && ! AT::has_infinity" << endl;
-        success = 0;
-       }
     }
     if ( ! std::is_same< ScalarType, decltype(AT::infinity()) >::value )
     {


### PR DESCRIPTION
Are `hasInfinity` and `infinity()` something you would consider add to `Kokkos::ArithTraits<T>`?