### PR TITLE
dot,axpby,spmv: First round selecting execspace for small sizes

### DIFF
--- a/src/blas/KokkosBlas1_axpby.hpp
+++ b/src/blas/KokkosBlas1_axpby.hpp
@@ -153,7 +153,6 @@ axpby (const AV& a, const XMV& X, const BV& b, const YMV& Y)
   Impl::Axpby<AV_Internal, XMV_Internal, BV_Internal,
     YMV_Internal>::axpby (a_internal, X_internal, b_internal, Y_internal);
   }
-#undef KOKKOSKERNELS_EXPERIMENTAL_ENABLE_SERIAL_LIMITS
 }
 
 template<class AV, class XMV, class YMV>

--- a/src/blas/KokkosBlas1_axpby.hpp
+++ b/src/blas/KokkosBlas1_axpby.hpp
@@ -47,6 +47,8 @@
 #include<KokkosBlas1_axpby_spec.hpp>
 #include<KokkosKernels_helpers.hpp>
 
+#include "KokkosKernels_Serial_Limits.hpp"
+
 // axpby() accepts both scalar coefficients a and b, and vector
 // coefficients (apply one for each column of the input multivectors).
 // This traits class helps axpby() select the correct specialization

--- a/src/blas/KokkosBlas1_axpby.hpp
+++ b/src/blas/KokkosBlas1_axpby.hpp
@@ -90,7 +90,6 @@ axpby (const AV& a, const XMV& X, const BV& b, const YMV& Y)
   // rank 1 or rank 2.  AV and BV may be either rank-1 Views, or
   // scalar values.
 
-#define KOKKOSKERNELS_EXPERIMENTAL_ENABLE_SERIAL_LIMITS
   #ifdef KOKKOSKERNELS_EXPERIMENTAL_ENABLE_SERIAL_LIMITS
   if ( X.extent(0) < KokkosKernels::ThresholdSizes<typename XMV::size_type>::axpby_serial_limit ) {
   typedef typename KokkosKernels::Impl::GetUnifiedScalarViewType<

--- a/src/blas/KokkosBlas1_dot.hpp
+++ b/src/blas/KokkosBlas1_dot.hpp
@@ -99,7 +99,7 @@ dot (const XVector& x, const YVector& y)
 
   typedef Kokkos::View<typename XVector::non_const_value_type,
     Kokkos::LayoutLeft,
-    typename KokkosKernels::Impl::GetSmallProblemDeviceType<Kokkos::HostSpace>::type,
+    typename KokkosKernels::Impl::GetSmallProblemDeviceType<typename XVector::device_type>::type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RVector_Internal;
 
   RVector_Internal R = RVector_Internal(&result);

--- a/src/blas/KokkosBlas1_dot.hpp
+++ b/src/blas/KokkosBlas1_dot.hpp
@@ -47,7 +47,7 @@
 #include<KokkosBlas1_dot_spec.hpp>
 #include<KokkosKernels_helpers.hpp>
 
-#include<common/KokkosKernels_Serial_Limits.hpp>
+#include "KokkosKernels_Serial_Limits.hpp"
 
 namespace KokkosBlas {
 

--- a/src/blas/KokkosBlas1_dot.hpp
+++ b/src/blas/KokkosBlas1_dot.hpp
@@ -132,7 +132,6 @@ dot (const XVector& x, const YVector& y)
   Impl::Dot<RVector_Internal,XVector_Internal,YVector_Internal>::dot (R,X,Y);
   Kokkos::fence();
   }
-#undef KOKKOSKERNELS_EXPERIMENTAL_ENABLE_SERIAL_LIMITS
 
   return result;
 }

--- a/src/blas/KokkosBlas1_dot.hpp
+++ b/src/blas/KokkosBlas1_dot.hpp
@@ -85,7 +85,6 @@ dot (const XVector& x, const YVector& y)
 
   typename XVector::non_const_value_type result = 0;
 
-#define KOKKOSKERNELS_EXPERIMENTAL_ENABLE_SERIAL_LIMITS
   #ifdef KOKKOSKERNELS_EXPERIMENTAL_ENABLE_SERIAL_LIMITS
   if ( x.extent(0) < KokkosKernels::ThresholdSizes<typename XVector::size_type>::dot_serial_limit ) {
   typedef Kokkos::View<typename XVector::const_value_type*,

--- a/src/impl/KokkosKernels_helpers.hpp
+++ b/src/impl/KokkosKernels_helpers.hpp
@@ -79,7 +79,6 @@ struct GetUnifiedScalarViewType<T,TX,true,true> {
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> > type;
 };
 
-
 }
 }
 #endif

--- a/src/sparse/KokkosSparse_spmv.hpp
+++ b/src/sparse/KokkosSparse_spmv.hpp
@@ -52,6 +52,7 @@
 #include <type_traits>
 #include "KokkosSparse_CrsMatrix.hpp"
 
+#include "KokkosKernels_Serial_Limits.hpp"
 
 namespace KokkosSparse {
 

--- a/src/sparse/KokkosSparse_spmv.hpp
+++ b/src/sparse/KokkosSparse_spmv.hpp
@@ -195,7 +195,6 @@ spmv (const char mode[],
               typename YVector_Internal::device_type,
               typename YVector_Internal::memory_traits>::spmv (mode, alpha, A_i, x_i, beta, y_i);
   }
-#undef KOKKOSKERNELS_EXPERIMENTAL_ENABLE_SERIAL_LIMITS
 }
 
 

--- a/src/sparse/KokkosSparse_spmv.hpp
+++ b/src/sparse/KokkosSparse_spmv.hpp
@@ -114,7 +114,6 @@ spmv (const char mode[],
   }
 
 
-#define KOKKOSKERNELS_EXPERIMENTAL_ENABLE_SERIAL_LIMITS
   #ifdef KOKKOSKERNELS_EXPERIMENTAL_ENABLE_SERIAL_LIMITS
   if ( x.extent(0) < KokkosKernels::ThresholdSizes<typename XVector::size_type>::spmv_serial_limit ) {
   typedef KokkosSparse::CrsMatrix<


### PR DESCRIPTION
If problem size is smaller than a certain threshold use Serial
execution space.