### PR TITLE
 Fixes #287

### DIFF
--- a/perf_test/sparse/KokkosSparse_block_pcg.cpp
+++ b/perf_test/sparse/KokkosSparse_block_pcg.cpp
@@ -42,13 +42,13 @@
 */
 
 #include <KokkosKernels_config.h>
+#include <iostream>
 #if defined(KOKKOSKERNELS_INST_DOUBLE) &&  \
     defined(KOKKOSKERNELS_INST_OFFSET_INT) && \
     defined(KOKKOSKERNELS_INST_ORDINAL_INT)
 #include "KokkosSparse_pcg.hpp"
 
 #include "KokkosKernels_Utils.hpp"
-#include <iostream>
 #include "KokkosKernels_IOUtils.hpp"
 
 #define MAXVAL 1


### PR DESCRIPTION
 There was a compile error on the perf_test for block PCG when offsets
 are size_t. Minor fix.