### PR TITLE
MKL fixes: Add extra macro checks

### DIFF
--- a/src/sparse/impl/KokkosSparse_spgemm_mkl2phase_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_mkl2phase_impl.hpp
@@ -169,7 +169,7 @@ void mkl2phase_symbolic(
     }
 #endif
 
-#if __INTEL_MKL__ >= 2018
+#if __INTEL_MKL__ == 2018 && __INTEL_MKL_UPDATE__ == 2
     MKL_INT mklm = m, mkln = n;
     double *mynullptr = NULL;
 
@@ -261,6 +261,10 @@ void mkl2phase_symbolic(
     if (SPARSE_STATUS_SUCCESS != mkl_sparse_destroy (C)){
       throw std::runtime_error ("Error at mkl_sparse_destroy C\n");
     }
+#elif __INTEL_MKL__ == 2018 && __INTEL_MKL_UPDATE__ < 2
+    throw std::runtime_error ("MKL version 18 must have update 2 - use intel/18.2.xyz compiler\n");
+#else
+    throw std::runtime_error ("MKL versions > 18 are not yet tested/supported\n");
 #endif
 
   }
@@ -400,7 +404,7 @@ void mkl2phase_symbolic(
       }
 #endif
 
-#if __INTEL_MKL__ >= 2018
+#if __INTEL_MKL__ == 2018 && __INTEL_MKL_UPDATE__ == 2
       value_type *a_ew = const_cast<value_type*>(valuesA.data());
       value_type *b_ew = const_cast<value_type*>(valuesB.data());
 
@@ -529,6 +533,10 @@ void mkl2phase_symbolic(
       if (SPARSE_STATUS_SUCCESS != mkl_sparse_destroy (C)){
         throw std::runtime_error ("Error at mkl_sparse_destroy C\n");
       }
+#elif __INTEL_MKL__ == 2018 && __INTEL_MKL_UPDATE__ < 2
+      throw std::runtime_error ("MKL version 18 must have update 2 - use intel/18.2.xyz compiler\n");
+#else
+      throw std::runtime_error ("MKL versions > 18 are not yet tested/supported\n");
 #endif
 
     }

--- a/unit_test/sparse/Test_Sparse_spgemm.hpp
+++ b/unit_test/sparse/Test_Sparse_spgemm.hpp
@@ -308,7 +308,7 @@ void test_spgemm(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_v
 
     case SPGEMM_MKL:
       algo = "SPGEMM_MKL";
-#ifndef HAVE_KOKKOSKERNELS_MKL
+#if !defined(HAVE_KOKKOSKERNELS_MKL) && !defined(KOKKOSKERNELS_ENABLE_TPL_MKL)
       is_expected_to_fail = true;
 #endif
       //MKL requires scalar to be either float or double


### PR DESCRIPTION
Address issue #289 - fix macro use for unit test,
and #268 - update macro check for INTEL 18 to also check that update is 2,
needed due to changes in MKL interface with updated version.