### PR TITLE
Cleanup fix for issue #309

### DIFF
--- a/src/batched/KokkosBatched_Vector_SIMD.hpp
+++ b/src/batched/KokkosBatched_Vector_SIMD.hpp
@@ -126,9 +126,14 @@ namespace KokkosBatched {
       }
     };
 
+}}
+
 #if defined(__KOKKOSBATCHED_ENABLE_AVX__)
 #if defined(__AVX__) || defined(__AVX2__)
 #include <immintrin.h>
+
+namespace KokkosBatched {
+  namespace Experimental {
 
     template<>
     class Vector<SIMD<double>,4> {
@@ -311,9 +316,14 @@ namespace KokkosBatched {
       }
     };
 #endif
+}}
 
 #if defined(__AVX512F__)
 #include <immintrin.h>
+
+namespace KokkosBatched {
+  namespace Experimental {
+
     template<>
     class Vector<SIMD<double>,8> {
     public:


### PR DESCRIPTION
Cleanup fix for issue #309 - move includes to external headers outside of internal namespaces.