### PR TITLE
Fix COLORING_VBD test failures on Cuda

### DIFF
--- a/src/graph/KokkosGraph_graph_color.hpp
+++ b/src/graph/KokkosGraph_graph_color.hpp
@@ -100,7 +100,7 @@ void graph_color_symbolic(
   case COLORING_VBD:
   case COLORING_VBDBIT:
     typedef typename Impl::GraphColor_VBD <typename KernelHandle::GraphColoringHandleType, lno_row_view_t_, lno_nnz_view_t_> VBDGraphColoring;
-    gc = new VBDGraphColoring(num_rows, entries.dimension_0(), row_map, entries, gch);
+    gc = new VBDGraphColoring(num_rows, entries.extent(0), row_map, entries, gch);
     break;
 
   case COLORING_EB:

--- a/unit_test/graph/Test_Graph_graph_color.hpp
+++ b/unit_test/graph/Test_Graph_graph_color.hpp
@@ -130,16 +130,17 @@ void test_coloring(lno_t numRows,size_type nnz, lno_t bandwidth, lno_t row_size_
                                                        , COLORING_VBBIT 
                                                        , COLORING_VBCS 
                                                        , COLORING_EB
-                                                       , COLORING_VBDBIT
                                                        };
 
   #ifdef KOKKOS_ENABLE_CUDA
   if( !std::is_same< typename device::execution_space, Kokkos::Cuda >::value )
   {
     coloring_algorithms.push_back(COLORING_VBD);
+    coloring_algorithms.push_back(COLORING_VBDBIT);
   }
   #else
   coloring_algorithms.push_back(COLORING_VBD);
+  coloring_algorithms.push_back(COLORING_VBDBIT);
   #endif
 
   for (size_t ii = 0; ii < coloring_algorithms.size(); ++ii) {

--- a/unit_test/graph/Test_Graph_graph_color.hpp
+++ b/unit_test/graph/Test_Graph_graph_color.hpp
@@ -124,9 +124,24 @@ void test_coloring(lno_t numRows,size_type nnz, lno_t bandwidth, lno_t row_size_
   graph_t static_graph (sym_adj, sym_xadj);
   input_mat = crsMat_t("CrsMatrix", numCols, newValues, static_graph);
 
-  ColoringAlgorithm coloring_algorithms[] = {COLORING_DEFAULT, COLORING_SERIAL, COLORING_VB, COLORING_VBBIT, COLORING_VBCS, COLORING_EB, COLORING_VBD, COLORING_VBDBIT};
+  std::vector<ColoringAlgorithm> coloring_algorithms = { COLORING_DEFAULT, 
+                                                         COLORING_SERIAL, 
+                                                         COLORING_VB, 
+                                                         COLORING_VBBIT, 
+                                                         COLORING_VBCS, 
+                                                         COLORING_EB, 
+                                                         COLORING_VBDBIT };
 
-  for (int ii = 0; ii < 8; ++ii){
+#ifdef KOKKOS_ENABLE_CUDA
+  if( !std::is_same< typename device::execution_space, Kokkos::Cuda >::value )
+  {
+    coloring_algorithms.push_back(COLORING_VBD);
+  }
+#else
+  coloring_algorithms.push_back(COLORING_VBD);
+#endif
+
+  for (size_t ii = 0; ii < coloring_algorithms.size(); ++ii){
     ColoringAlgorithm coloring_algorithm = coloring_algorithms[ii];
     color_view_t vector_colors;
     size_t num_colors;

--- a/unit_test/graph/Test_Graph_graph_color.hpp
+++ b/unit_test/graph/Test_Graph_graph_color.hpp
@@ -124,24 +124,25 @@ void test_coloring(lno_t numRows,size_type nnz, lno_t bandwidth, lno_t row_size_
   graph_t static_graph (sym_adj, sym_xadj);
   input_mat = crsMat_t("CrsMatrix", numCols, newValues, static_graph);
 
-  std::vector<ColoringAlgorithm> coloring_algorithms = { COLORING_DEFAULT, 
-                                                         COLORING_SERIAL, 
-                                                         COLORING_VB, 
-                                                         COLORING_VBBIT, 
-                                                         COLORING_VBCS, 
-                                                         COLORING_EB, 
-                                                         COLORING_VBDBIT };
+  std::vector<ColoringAlgorithm> coloring_algorithms = { COLORING_DEFAULT 
+                                                       , COLORING_SERIAL 
+                                                       , COLORING_VB 
+                                                       , COLORING_VBBIT 
+                                                       , COLORING_VBCS 
+                                                       , COLORING_EB
+                                                       , COLORING_VBDBIT
+                                                       };
 
-#ifdef KOKKOS_ENABLE_CUDA
+  #ifdef KOKKOS_ENABLE_CUDA
   if( !std::is_same< typename device::execution_space, Kokkos::Cuda >::value )
   {
     coloring_algorithms.push_back(COLORING_VBD);
   }
-#else
+  #else
   coloring_algorithms.push_back(COLORING_VBD);
-#endif
+  #endif
 
-  for (size_t ii = 0; ii < coloring_algorithms.size(); ++ii){
+  for (size_t ii = 0; ii < coloring_algorithms.size(); ++ii) {
     ColoringAlgorithm coloring_algorithm = coloring_algorithms[ii];
     color_view_t vector_colors;
     size_t num_colors;

--- a/unit_test/graph/Test_Graph_graph_color_deterministic.hpp
+++ b/unit_test/graph/Test_Graph_graph_color_deterministic.hpp
@@ -151,15 +151,17 @@ void test_coloring_deterministic(lno_t numRows, size_type nnz) {
   graph_t static_graph (adj, xadj);
   crsMat_t input_mat("CrsMatrix", numCols, newValues, static_graph);
 
-  std::vector<ColoringAlgorithm> coloring_algorithms = { COLORING_VBDBIT };
+  std::vector<ColoringAlgorithm> coloring_algorithms;
 
   #ifdef KOKKOS_ENABLE_CUDA
   if( !std::is_same< typename device::execution_space, Kokkos::Cuda >::value )
   {
-    coloring_algorithms.push_back(COLORING_VBD);
+     coloring_algorithms.push_back(COLORING_VBD);
+     coloring_algorithms.push_back(COLORING_VBDBIT);
   }
   #else
   coloring_algorithms.push_back(COLORING_VBD);
+  coloring_algorithms.push_back(COLORING_VBDBIT);
   #endif
 
   for (size_t ii = 0; ii < coloring_algorithms.size(); ++ii) {
@@ -184,7 +186,7 @@ void test_coloring_deterministic(lno_t numRows, size_type nnz) {
     }
 
     EXPECT_TRUE( (num_conflict == 0));
-  //device::execution_space::finalize();
+    //device::execution_space::finalize();
 
   }
 

--- a/unit_test/graph/Test_Graph_graph_color_deterministic.hpp
+++ b/unit_test/graph/Test_Graph_graph_color_deterministic.hpp
@@ -151,9 +151,18 @@ void test_coloring_deterministic(lno_t numRows, size_type nnz) {
   graph_t static_graph (adj, xadj);
   crsMat_t input_mat("CrsMatrix", numCols, newValues, static_graph);
 
-  ColoringAlgorithm coloring_algorithms[] = {COLORING_VBD, COLORING_VBDBIT};
+  std::vector<ColoringAlgorithm> coloring_algorithms = { COLORING_VBDBIT };
 
-  for (int ii = 0; ii < 2; ++ii){
+  #ifdef KOKKOS_ENABLE_CUDA
+  if( !std::is_same< typename device::execution_space, Kokkos::Cuda >::value )
+  {
+    coloring_algorithms.push_back(COLORING_VBD);
+  }
+  #else
+  coloring_algorithms.push_back(COLORING_VBD);
+  #endif
+
+  for (size_t ii = 0; ii < coloring_algorithms.size(); ++ii) {
     ColoringAlgorithm coloring_algorithm = coloring_algorithms[ii];
     color_view_t vector_colors;
     size_t num_colors;


### PR DESCRIPTION
Added a guard to include COLORING_VBD for non Cuda tests.

This resolves #317

@ndellingwood 
I added the fix we discussed this morning.
I'm running the spot check on the Kepler nodes on White, when it completes I'll post the results.