### PR TITLE
src/CMakeLists.txt: Fix for cublas

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,6 +97,7 @@ IF (KokkosKernels_INST_EXECSPACE_OPENMP)
 ENDIF()
 
 IF (KokkosKernels_INST_EXECSPACE_CUDA)
+  APPEND_GLOB(SOURCES ${DIR}/tpls/*_Cuda_*.cpp)
   IF (KokkosKernels_INST_DOUBLE)
     APPEND_GLOB(SOURCES ${DIR}/generated_specializations_cpp/*/*inst_double_*_Cuda_*.cpp)
   ENDIF()


### PR DESCRIPTION
Thanks @kyungjoo-kim for debugging and help with fix.

Potential fix for linking error exposed by Trilinos integration testing
due to undefined reference for
KokkosBlas::Impl::CudaBlasSingleton::singleton()
The object files for the tpls were not being included, added APPEND_GLOB
for the relevant files when Cuda is built for.