### PR TITLE
Fixes 1: code broken when deprecated code disabled

### DIFF
--- a/example/fenl/BoxElemFixture.hpp
+++ b/example/fenl/BoxElemFixture.hpp
@@ -286,7 +286,7 @@ public:
       std::max( m_node_grid.extent(0) ,
                 m_elem_node.extent(0) * m_elem_node.extent(1) ))));
 
-    Kokkos::parallel_for( nwork , *this );
+    Kokkos::parallel_for( "kokkos-kernels/example/fen: BoxElemFixture", nwork , *this );
   }
 
 

--- a/example/fenl/VectorImport.hpp
+++ b/example/fenl/VectorImport.hpp
@@ -152,7 +152,7 @@ public:
       , source( arg_source )
       , buffer( arg_buffer )
     {
-      Kokkos::parallel_for( index.extent(0) , *this );
+      Kokkos::parallel_for( "kokkos-kernels/example/fenl: Pack", index.extent(0) , *this );
       execution_space::fence();
     }
   };

--- a/example/fenl/fenl_functors.hpp
+++ b/example/fenl/fenl_functors.hpp
@@ -148,7 +148,7 @@ public:
         // May be larger that requested:
         set_span = node_node_set.span();
 
-        Kokkos::parallel_for( elem_node_id.extent(0) , *this );
+        Kokkos::parallel_for( "kokkos-kernels/example/fenl: NodeNodeGraph" , elem_node_id.extent(0) , *this );
       }
 
       execution_space::fence();

--- a/perf_test/batched/KokkosBatched_Test_Gemm_Cuda.cpp
+++ b/perf_test/batched/KokkosBatched_Test_Gemm_Cuda.cpp
@@ -315,7 +315,7 @@ namespace KokkosBatched {
               DeviceSpaceType::fence();
               timer.reset();
 
-              Kokkos::parallel_for(policy, functor_type(a,b,c));
+              Kokkos::parallel_for("GEMM: RangePolicy version", policy, functor_type(a,b,c));
                 
               DeviceSpaceType::fence();
               const double t = timer.seconds();
@@ -382,7 +382,7 @@ namespace KokkosBatched {
               DeviceSpaceType::fence();
               timer.reset();
 
-              Kokkos::parallel_for(policy,functor_type(a,b,c));
+              Kokkos::parallel_for("GEMM: TeamPolicy version 1", policy,functor_type(a,b,c));
                 
               DeviceSpaceType::fence();
               const double t = timer.seconds();
@@ -455,7 +455,7 @@ namespace KokkosBatched {
               DeviceSpaceType::fence();
               timer.reset();
 
-              Kokkos::parallel_for(policy, functor_type(a,b,c));
+              Kokkos::parallel_for("GEMM: TeamPolicy version 2", policy, functor_type(a,b,c));
                 
               DeviceSpaceType::fence();
               const double t = timer.seconds();
@@ -532,7 +532,7 @@ namespace KokkosBatched {
                 DeviceSpaceType::fence();
                 timer.reset();
 
-                Kokkos::parallel_for(policy, functor_type(a,b,c));
+                Kokkos::parallel_for("GEMM: TeamPolicy version 3", policy, functor_type(a,b,c));
                 
                 DeviceSpaceType::fence();
                 const double t = timer.seconds();
@@ -604,7 +604,7 @@ namespace KokkosBatched {
               DeviceSpaceType::fence();
               timer.reset();
 
-              Kokkos::parallel_for(policy, functor_type(a,b,c));
+              Kokkos::parallel_for("GEMM: TeamPolicy handmade", policy, functor_type(a,b,c));
                 
               DeviceSpaceType::fence();
               const double t = timer.seconds();

--- a/src/batched/KokkosBatched_Test_BlockCrs_Util.hpp
+++ b/src/batched/KokkosBatched_Test_BlockCrs_Util.hpp
@@ -651,7 +651,7 @@ namespace KokkosBatched {
         _y = y.Values();
 
         Kokkos::RangePolicy<ExecSpace> policy(0, _x.extent(1)*_blocksize);
-        Kokkos::parallel_for(policy, *this);
+        Kokkos::parallel_for("BlockCrsMatrixVectorProductByRow::run", policy, *this);
       }
     };
 

--- a/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
+++ b/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
@@ -327,8 +327,13 @@ namespace KokkosSparse{
         return;
       }
       else {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
         KokkosKernels::Impl::get_suggested_vector_team_size<size_type, ExecutionSpace>(
                                                                                        max_allowed_team_size, suggested_vector_size_, suggested_team_size_, nr, nnz);
+#else
+        KokkosKernels::Impl::get_suggested_vector_size<size_type, ExecutionSpace>(suggested_vector_size_, nr, nnz);
+        KokkosKernels::Impl::get_suggested_team_size<ExecutionSpace>(max_allowed_team_size, suggested_vector_size_, suggested_team_size_);
+#endif
         this->suggested_team_size = suggested_vector_size_;
         this->suggested_vector_size = suggested_vector_size_;
 

--- a/src/sparse/KokkosSparse_spgemm_handle.hpp
+++ b/src/sparse/KokkosSparse_spgemm_handle.hpp
@@ -466,9 +466,9 @@ private:
     incidence_matrix_entries(),compress_second_matrix(true),
 
     multi_color_scale(1), mkl_sort_option(7), calculate_read_write_cost(false),
-	coloring_input_file(""),
-	coloring_output_file(""), min_hash_size_scale(1), compression_cut_off(0.85), first_level_hash_cut_off(0.50),
-	original_max_row_flops(std::numeric_limits<size_t>::max()), original_overall_flops(std::numeric_limits<size_t>::max()),
+    coloring_input_file(""),
+    coloring_output_file(""), min_hash_size_scale(1), compression_cut_off(0.85), first_level_hash_cut_off(0.50),
+    original_max_row_flops(std::numeric_limits<size_t>::max()), original_overall_flops(std::numeric_limits<size_t>::max()),
     persistent_a_xadj(), persistent_b_xadj(), persistent_a_adj(), persistent_b_adj(), MaxColDenseAcc(250001),
     mkl_keep_output(true),
     mkl_convert_to_1base(true), is_compression_single_step(false)

--- a/src/sparse/impl/KokkosSparse_spgemm_imp_outer.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_imp_outer.hpp
@@ -371,8 +371,8 @@ size_t KokkosSPGEMM
 
   //size_t write_index = num_collapsed_triplets_per_thread[0];
 
-  entriesC_ = c_lno_nnz_view_t(Kokkos::ViewAllocateWithoutInitializing(""),overall_size);
-  valuesC_ = c_scalar_nnz_view_t(Kokkos::ViewAllocateWithoutInitializing(""),overall_size);
+  entriesC_ = c_lno_nnz_view_t(Kokkos::ViewAllocateWithoutInitializing("entriesC_"),overall_size);
+  valuesC_ = c_scalar_nnz_view_t(Kokkos::ViewAllocateWithoutInitializing("valuesC_"),overall_size);
   rowmapC_(0) = 0;
   rowmapC_(this->a_row_cnt) = overall_size;
 #pragma omp parallel
@@ -830,7 +830,7 @@ void KokkosSPGEMM
   //AND MULTI-WAY-MERGE THEM
   ////////////////////////////////////////
   timer1.reset();
-  slow_triplet_view_t output_triplets("",overall_size);
+  slow_triplet_view_t output_triplets("output_triplets",overall_size);
 
   this->merge_triplets_on_slow_memory(
       &(host_triplet_arrays[0]),
@@ -848,7 +848,7 @@ void KokkosSPGEMM
   ////////////////////////////////////////
   //COLLAPSE TRIPLETS, MERGE SAME ONES
   ////////////////////////////////////////
-  //triplet_host_view_t collapsed_output_triplets("",overall_size);
+  //triplet_host_view_t collapsed_output_triplets("collapsed_output_triplets",overall_size);
 
   size_type outsize = this->final_collapse_triplets_omp(
       output_triplets,

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_def.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_def.hpp
@@ -180,10 +180,10 @@ void KokkosSPGEMM
     	}
     }
     else {
-    	new_row_mapB = row_lno_temp_work_view_t ("");
-    	new_row_mapB_begins = row_lno_temp_work_view_t ("");
-    	set_index_entries = nnz_lno_temp_work_view_t ("");
-    	set_entries = nnz_lno_temp_work_view_t ("");
+    	new_row_mapB = row_lno_temp_work_view_t();
+    	new_row_mapB_begins = row_lno_temp_work_view_t();
+    	set_index_entries = nnz_lno_temp_work_view_t();
+    	set_entries = nnz_lno_temp_work_view_t();
     	nnz_lno_t maxNumRoughZeros = this->handle->get_spgemm_handle()->original_max_row_flops;
     	if (KOKKOSKERNELS_VERBOSE){
     		std::cout << "SYMBOLIC PHASE -- NO COMPRESSION: maxNumRoughZeros:" << maxNumRoughZeros << std::endl;

--- a/src/sparse/impl/KokkosSparse_spmv_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_impl.hpp
@@ -246,8 +246,12 @@ int64_t spmv_launch_parameters(int64_t numRows, int64_t nnz, int64_t rows_per_th
   }
 
   #ifdef KOKKOS_ENABLE_CUDA
-  if(team_size < 1)
-    team_size = 256/vector_length;
+  if(team_size < 1) {
+    if(std::is_same<Kokkos::Cuda,execution_space>::value)
+    { team_size = 256/vector_length; }
+    else
+    { team_size = 1; }
+  }
   #endif
 
   rows_per_team = rows_per_thread * team_size;
@@ -361,7 +365,11 @@ spmv_beta_transpose (typename YVector::const_value_type& alpha,
   OpType op (alpha, A, x, beta, y, RowsPerThread<typename AMatrix::execution_space> (NNZPerRow));
 
   const int rows_per_thread = RowsPerThread<typename AMatrix::execution_space > (NNZPerRow);
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   const int team_size = Kokkos::TeamPolicy<typename AMatrix::execution_space>::team_size_recommended (op, vector_length);
+#else
+  const int team_size = Kokkos::TeamPolicy<typename AMatrix::execution_space>(rows_per_thread, Kokkos::AUTO, vector_length).team_size_recommended(op, Kokkos::ParallelForTag());
+#endif
   const int rows_per_team = rows_per_thread * team_size;
   const size_type nteams = (nrow+rows_per_team-1)/rows_per_team;
   Kokkos::parallel_for("KokkosSparse::spmv<Transpose>", Kokkos::TeamPolicy< typename AMatrix::execution_space >
@@ -919,7 +927,11 @@ spmv_alpha_beta_mv_no_transpose (const typename YVector::non_const_value_type& a
     // team_size is a hardware resource thing so it might legitimately
     // be int.
     const int rows_per_thread = RowsPerThread<typename AMatrix::execution_space >(NNZPerRow);
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
     const int team_size = Kokkos::TeamPolicy< typename AMatrix::execution_space >::team_size_recommended(op,vector_length);
+#else
+  const int team_size = Kokkos::TeamPolicy<typename AMatrix::execution_space>(rows_per_thread, Kokkos::AUTO, vector_length).team_size_recommended(op, Kokkos::ParallelForTag());
+#endif
     const int rows_per_team = rows_per_thread * team_size;
     const size_type nteams = (nrow+rows_per_team-1)/rows_per_team;
     Kokkos::parallel_for("KokkosSparse::spmv<MV,NoTranspose>", Kokkos::TeamPolicy< typename AMatrix::execution_space >
@@ -940,7 +952,11 @@ spmv_alpha_beta_mv_no_transpose (const typename YVector::non_const_value_type& a
     // team_size is a hardware resource thing so it might legitimately
     // be int.
     const int rows_per_thread = RowsPerThread<typename AMatrix::execution_space >(NNZPerRow);
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
     const int team_size = Kokkos::TeamPolicy< typename AMatrix::execution_space >::team_size_recommended(op,vector_length);
+#else
+  const int team_size = Kokkos::TeamPolicy<typename AMatrix::execution_space>(rows_per_thread, Kokkos::AUTO, vector_length).team_size_recommended(op, Kokkos::ParallelForTag());
+#endif
     const int rows_per_team = rows_per_thread * team_size;
     const size_type nteams = (nrow+rows_per_team-1)/rows_per_team;
     Kokkos::parallel_for("KokkosSparse::spmv<MV,NoTranspose>",  Kokkos::TeamPolicy< typename AMatrix::execution_space >
@@ -1000,7 +1016,11 @@ spmv_alpha_beta_mv_transpose (const typename YVector::non_const_value_type& alph
     // team_size is a hardware resource thing so it might legitimately
     // be int.
     const int rows_per_thread = RowsPerThread<typename AMatrix::execution_space >(NNZPerRow);
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
     const int team_size = Kokkos::TeamPolicy< typename AMatrix::execution_space >::team_size_recommended(op,vector_length);
+#else
+  const int team_size = Kokkos::TeamPolicy<typename AMatrix::execution_space>(rows_per_thread, Kokkos::AUTO, vector_length).team_size_recommended(op, Kokkos::ParallelForTag());
+#endif
     const int rows_per_team = rows_per_thread * team_size;
     const size_type nteams = (nrow+rows_per_team-1)/rows_per_team;
     Kokkos::parallel_for ("KokkosSparse::spmv<MV,Transpose>",  Kokkos::TeamPolicy< typename AMatrix::execution_space >
@@ -1021,7 +1041,11 @@ spmv_alpha_beta_mv_transpose (const typename YVector::non_const_value_type& alph
     // team_size is a hardware resource thing so it might legitimately
     // be int.
     const int rows_per_thread = RowsPerThread<typename AMatrix::execution_space >(NNZPerRow);
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
     const int team_size = Kokkos::TeamPolicy< typename AMatrix::execution_space >::team_size_recommended(op,vector_length);
+#else
+  const int team_size = Kokkos::TeamPolicy<typename AMatrix::execution_space>(rows_per_thread, Kokkos::AUTO, vector_length).team_size_recommended(op, Kokkos::ParallelForTag());
+#endif
     const int rows_per_team = rows_per_thread * team_size;
     const size_type nteams = (nrow+rows_per_team-1)/rows_per_team;
     Kokkos::parallel_for("KokkosSparse::spmv<MV,Transpose>",  Kokkos::TeamPolicy< typename AMatrix::execution_space >

--- a/test_common/KokkosKernels_MatrixConverter.cpp
+++ b/test_common/KokkosKernels_MatrixConverter.cpp
@@ -218,10 +218,10 @@ int main (int argc, char* argv[]){
     KokkosKernels::Impl::symmetrize_graph_symbolic_hashmap
     <c_row_map_view_t, c_cols_view_t, row_map_view_t, cols_view_t,MyExecSpace>
     (numrows, orm, oentries, new_rowmap, new_entries);
-    values_view_t new_values("",new_entries.extent(0));
+    values_view_t new_values("new_values",new_entries.extent(0));
 
-    cols_view_t out_adj ("", new_entries.extent(0));
-    values_view_t out_vals("",new_entries.extent(0));
+    cols_view_t out_adj ("out_adj", new_entries.extent(0));
+    values_view_t out_vals("out_vals", new_entries.extent(0));
 
     KokkosKernels::Impl::kk_sort_graph<row_map_view_t, cols_view_t,values_view_t, cols_view_t,values_view_t,MyExecSpace>
 		(new_rowmap, new_entries, new_values, out_adj, out_vals);
@@ -257,8 +257,8 @@ int main (int argc, char* argv[]){
           new_rowmap, new_entries, new_values);
 
     std::cout << 1 << std::endl;
-    cols_view_t out_adj ("", new_entries.extent(0));
-    values_view_t out_vals("",new_entries.extent(0));
+    cols_view_t out_adj ("out_adj", new_entries.extent(0));
+    values_view_t out_vals("out_vals", new_entries.extent(0));
     std::cout << 2 << std::endl;
     KokkosKernels::Impl::kk_sort_graph<row_map_view_t, cols_view_t,values_view_t, cols_view_t,values_view_t,MyExecSpace>
                 (new_rowmap, new_entries, new_values, out_adj, out_vals);


### PR DESCRIPTION
Issues:
1. team_size_max and team_size_recommended are no longer static
member functions when deprecated code is disabled; must be called as a
member function of an instantiated team policy

2. spmv sets an incorrect team_size with Cuda_Serial configuration
 Changes to be committed:
	modified:   src/common/KokkosKernels_Utils.hpp
	modified:   src/graph/KokkosGraph_GraphColorHandle.hpp
	modified:   src/sparse/KokkosSparse_gauss_seidel_handle.hpp
	modified:   src/sparse/impl/KokkosSparse_spmv_impl.hpp