### PR TITLE
getrs implementation

### DIFF
--- a/src/batched/KokkosBatched_InverseLU_Serial_Impl.hpp
+++ b/src/batched/KokkosBatched_InverseLU_Serial_Impl.hpp
@@ -5,8 +5,8 @@
 /// \author Vinh Dang (vqdang@sandia.gov)
 
 #include "KokkosBatched_Util.hpp"
-#include "KokkosBatched_Trsm_Decl.hpp"
-#include "KokkosBatched_Trsm_Serial_Impl.hpp"
+#include "KokkosBatched_SolveLU_Decl.hpp"
+#include "KokkosBatched_SolveLU_Serial_Impl.hpp"
 
 namespace KokkosBatched {
   namespace Experimental {
@@ -97,9 +97,8 @@ namespace KokkosBatched {
         }
         
         //First, compute L inverse by solving the system L*Linv = I for Linv
-        SerialTrsm<Side::Left,Uplo::Lower,Trans::NoTranspose,Diag::Unit,Algo::Trsm::Unblocked>::invoke(one, A, B);
         //Second, compute A inverse by solving the system U*Ainv = Linv for Ainv
-        SerialTrsm<Side::Left,Uplo::Upper,Trans::NoTranspose,Diag::NonUnit,Algo::Trsm::Unblocked>::invoke(one, A, B);
+        SerialSolveLU<Algo::SolveLU::Unblocked,Trans::NoTranspose>::invoke(A,B);
 		
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
@@ -140,9 +139,8 @@ namespace KokkosBatched {
         }
 
         //First, compute L inverse by solving the system L*Linv = I for Linv
-        SerialTrsm<Side::Left,Uplo::Lower,Trans::NoTranspose,Diag::Unit,Algo::Trsm::Blocked>::invoke(one, A, B);
         //Second, compute A inverse by solving the system U*Ainv = Linv for Ainv
-        SerialTrsm<Side::Left,Uplo::Upper,Trans::NoTranspose,Diag::NonUnit,Algo::Trsm::Blocked>::invoke(one, A, B);
+        SerialSolveLU<Algo::SolveLU::Blocked,Trans::NoTranspose>::invoke(A,B);
 
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll

--- a/src/batched/KokkosBatched_InverseLU_Serial_Impl.hpp
+++ b/src/batched/KokkosBatched_InverseLU_Serial_Impl.hpp
@@ -88,7 +88,7 @@ namespace KokkosBatched {
         auto B = Kokkos::View<ScalarType**, Kokkos::LayoutLeft, typename WViewType::memory_space, Kokkos::MemoryTraits<Kokkos::Unmanaged> >(W.data(), A.extent(0), A.extent(1));
         
         const ScalarType one(1.0);
-        
+
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
 #endif

--- a/src/batched/KokkosBatched_InverseLU_Team_Impl.hpp
+++ b/src/batched/KokkosBatched_InverseLU_Team_Impl.hpp
@@ -5,8 +5,8 @@
 /// \author Vinh Dang (vqdang@sandia.gov)
 
 #include "KokkosBatched_Util.hpp"
-#include "KokkosBatched_Trsm_Decl.hpp"
-#include "KokkosBatched_Trsm_Team_Impl.hpp"
+#include "KokkosBatched_SolveLU_Decl.hpp"
+#include "KokkosBatched_SolveLU_Team_Impl.hpp"
 
 namespace KokkosBatched {
   namespace Experimental {
@@ -43,9 +43,8 @@ namespace KokkosBatched {
         });
 
         //First, compute L inverse by solving the system L*Linv = I for Linv
-        TeamTrsm<MemberType,Side::Left,Uplo::Lower,Trans::NoTranspose,Diag::Unit,Algo::Trsm::Unblocked>::invoke(member, one, A, B);
         //Second, compute A inverse by solving the system U*Ainv = Linv for Ainv
-        TeamTrsm<MemberType,Side::Left,Uplo::Upper,Trans::NoTranspose,Diag::NonUnit,Algo::Trsm::Unblocked>::invoke(member, one, A, B);
+        TeamSolveLU<MemberType,Algo::SolveLU::Unblocked,Trans::NoTranspose>::invoke(member, A, B);
 
         Kokkos::parallel_for(Kokkos::TeamThreadRange(member,A.extent(0)*A.extent(1)),[&](const int &tid) {
             int i = tid/A.extent(1);
@@ -82,9 +81,8 @@ namespace KokkosBatched {
         });
 
         //First, compute L inverse by solving the system L*Linv = I for Linv
-        TeamTrsm<MemberType,Side::Left,Uplo::Lower,Trans::NoTranspose,Diag::Unit,Algo::Trsm::Blocked>::invoke(member, one, A, B);
         //Second, compute A inverse by solving the system U*Ainv = Linv for Ainv
-        TeamTrsm<MemberType,Side::Left,Uplo::Upper,Trans::NoTranspose,Diag::NonUnit,Algo::Trsm::Blocked>::invoke(member, one, A, B);
+        TeamSolveLU<MemberType,Algo::SolveLU::Blocked,Trans::NoTranspose>::invoke(member, A, B);
 
         Kokkos::parallel_for(Kokkos::TeamThreadRange(member,A.extent(0)*A.extent(1)),[&](const int &tid) {
             int i = tid/A.extent(1);

--- a/src/batched/KokkosBatched_SolveLU_Decl.hpp
+++ b/src/batched/KokkosBatched_SolveLU_Decl.hpp
@@ -1,0 +1,41 @@
+#ifndef __KOKKOSBATCHED_SOLVELU_DECL_HPP__
+#define __KOKKOSBATCHED_SOLVELU_DECL_HPP__
+
+
+/// \author Vinh Dang (vqdang@sandia.gov)
+
+#include "KokkosBatched_Vector.hpp"
+
+namespace KokkosBatched {
+  namespace Experimental {
+      
+    template<typename ArgAlgo,
+             typename TransType>
+    struct SerialSolveLU {
+      // no piv version
+      template<typename AViewType,
+               typename BViewType>
+      KOKKOS_INLINE_FUNCTION
+      static int
+      invoke(const AViewType &A,
+             const BViewType &B);
+    };       
+
+    template<typename MemberType,
+             typename ArgAlgo,
+             typename TransType>
+    struct TeamSolveLU {
+      // no piv version
+      template<typename AViewType,
+               typename BViewType>
+      KOKKOS_INLINE_FUNCTION
+      static int
+      invoke(const MemberType &member, 
+             const AViewType &A,
+             const BViewType &B);
+    };       
+      
+  }
+}
+
+#endif

--- a/src/batched/KokkosBatched_SolveLU_Serial_Impl.hpp
+++ b/src/batched/KokkosBatched_SolveLU_Serial_Impl.hpp
@@ -40,7 +40,7 @@ namespace KokkosBatched {
         SerialTrsm<Side::Left,Uplo::Lower,Trans::NoTranspose,Diag::Unit,Algo::Trsm::Unblocked>::invoke(one, A, B);
         //Second, compute X by solving the system U*X = Y for X
         SerialTrsm<Side::Left,Uplo::Upper,Trans::NoTranspose,Diag::NonUnit,Algo::Trsm::Unblocked>::invoke(one, A, B);
-        
+
         return 0;
     }
     

--- a/src/batched/KokkosBatched_SolveLU_Serial_Impl.hpp
+++ b/src/batched/KokkosBatched_SolveLU_Serial_Impl.hpp
@@ -1,0 +1,128 @@
+#ifndef __KOKKOSBATCHED_SOLVELU_SERIAL_IMPL_HPP__
+#define __KOKKOSBATCHED_SOLVELU_SERIAL_IMPL_HPP__
+
+
+/// \author Vinh Dang (vqdang@sandia.gov)
+
+#include "KokkosBatched_Util.hpp"
+#include "KokkosBatched_Trsm_Decl.hpp"
+#include "KokkosBatched_Trsm_Serial_Impl.hpp"
+
+namespace KokkosBatched {
+  namespace Experimental {
+    ///
+    /// Serial Impl
+    /// =========
+
+    ///
+    /// SolveLU no piv
+    ///
+
+    template<>
+    template<typename AViewType,
+             typename BViewType>
+    KOKKOS_INLINE_FUNCTION
+    int
+    SerialSolveLU<Algo::SolveLU::Unblocked,Trans::NoTranspose>::
+    invoke(const AViewType &A, 
+           const BViewType &B) {
+        static_assert(AViewType::rank == 2, "A should have two dimensions");
+        static_assert((BViewType::rank == 1)||(BViewType::rank == 2), "B should have either one dimension or two dimensions");
+        static_assert(std::is_same<typename AViewType::memory_space, typename BViewType::memory_space>::value, "A and B should be on the same memory space");
+        assert(A.extent(0)==A.extent(1));
+        assert(A.extent(1)==B.extent(0));
+
+        typedef typename AViewType::value_type ScalarType;
+
+        const ScalarType one(1.0);
+        
+        //First, compute Y (= U*X) by solving the system L*Y = B for Y
+        SerialTrsm<Side::Left,Uplo::Lower,Trans::NoTranspose,Diag::Unit,Algo::Trsm::Unblocked>::invoke(one, A, B);
+        //Second, compute X by solving the system U*X = Y for X
+        SerialTrsm<Side::Left,Uplo::Upper,Trans::NoTranspose,Diag::NonUnit,Algo::Trsm::Unblocked>::invoke(one, A, B);
+        
+        return 0;
+    }
+    
+    template<>
+    template<typename AViewType,
+             typename BViewType>
+    KOKKOS_INLINE_FUNCTION
+    int
+    SerialSolveLU<Algo::SolveLU::Blocked,Trans::NoTranspose>::
+    invoke(const AViewType &A,
+           const BViewType &B) {
+        static_assert(AViewType::rank == 2, "A should have two dimensions");
+        static_assert((BViewType::rank == 1)||(BViewType::rank == 2), "B should have either one dimension or two dimensions");
+        static_assert(std::is_same<typename AViewType::memory_space, typename BViewType::memory_space>::value, "A and B should be on the same memory space");
+        assert(A.extent(0)==A.extent(1));
+        assert(A.extent(1)==B.extent(0));
+
+        typedef typename AViewType::value_type ScalarType;
+        
+        const ScalarType one(1.0);
+
+        //First, compute Y (= U*X) by solving the system L*Y = B for Y
+        SerialTrsm<Side::Left,Uplo::Lower,Trans::NoTranspose,Diag::Unit,Algo::Trsm::Blocked>::invoke(one, A, B);
+        //Second, compute X by solving the system U*X = Y for X
+        SerialTrsm<Side::Left,Uplo::Upper,Trans::NoTranspose,Diag::NonUnit,Algo::Trsm::Blocked>::invoke(one, A, B);
+
+        return 0;
+    }
+
+    template<>
+    template<typename AViewType,
+             typename BViewType>
+    KOKKOS_INLINE_FUNCTION
+    int
+    SerialSolveLU<Algo::SolveLU::Unblocked,Trans::Transpose>::
+    invoke(const AViewType &A, 
+           const BViewType &B) {
+        static_assert(AViewType::rank == 2, "A should have two dimensions");
+        static_assert((BViewType::rank == 1)||(BViewType::rank == 2), "B should have either one dimension or two dimensions");
+        static_assert(std::is_same<typename AViewType::memory_space, typename BViewType::memory_space>::value, "A and B should be on the same memory space");
+        assert(A.extent(0)==A.extent(1));
+        assert(A.extent(1)==B.extent(0));
+
+        typedef typename AViewType::value_type ScalarType;
+
+        const ScalarType one(1.0);
+        
+        //First, compute Y (= L'*X) by solving the system U'*Y = B for Y
+        SerialTrsm<Side::Left,Uplo::Lower,Trans::Transpose,Diag::NonUnit,Algo::Trsm::Unblocked>::invoke(one, A, B);
+        //Second, compute X by solving the system L'*X = Y for X
+        SerialTrsm<Side::Left,Uplo::Upper,Trans::Transpose,Diag::Unit,Algo::Trsm::Unblocked>::invoke(one, A, B);
+        
+        return 0;
+    }
+
+    template<>
+    template<typename AViewType,
+             typename BViewType>
+    KOKKOS_INLINE_FUNCTION
+    int
+    SerialSolveLU<Algo::SolveLU::Blocked,Trans::Transpose>::
+    invoke(const AViewType &A, 
+           const BViewType &B) {
+        static_assert(AViewType::rank == 2, "A should have two dimensions");
+        static_assert((BViewType::rank == 1)||(BViewType::rank == 2), "B should have either one dimension or two dimensions");
+        static_assert(std::is_same<typename AViewType::memory_space, typename BViewType::memory_space>::value, "A and B should be on the same memory space");
+        assert(A.extent(0)==A.extent(1));
+        assert(A.extent(1)==B.extent(0));
+
+        typedef typename AViewType::value_type ScalarType;
+
+        const ScalarType one(1.0);
+        
+        //First, compute Y (= L'*X) by solving the system U'*Y = B for Y
+        SerialTrsm<Side::Left,Uplo::Lower,Trans::Transpose,Diag::NonUnit,Algo::Trsm::Blocked>::invoke(one, A, B);
+        //Second, compute X by solving the system L'*X = Y for X
+        SerialTrsm<Side::Left,Uplo::Upper,Trans::Transpose,Diag::Unit,Algo::Trsm::Blocked>::invoke(one, A, B);
+        
+        return 0;
+    }
+
+  }
+}
+
+#endif

--- a/src/batched/KokkosBatched_SolveLU_Team_Impl.hpp
+++ b/src/batched/KokkosBatched_SolveLU_Team_Impl.hpp
@@ -1,0 +1,128 @@
+#ifndef __KOKKOSBATCHED_SOLVELU_TEAM_IMPL_HPP__
+#define __KOKKOSBATCHED_SOLVELU_TEAM_IMPL_HPP__
+
+
+/// \author Vinh Dang (vqdang@sandia.gov)
+
+#include "KokkosBatched_Util.hpp"
+#include "KokkosBatched_Trsm_Decl.hpp"
+#include "KokkosBatched_Trsm_Team_Impl.hpp"
+
+namespace KokkosBatched {
+  namespace Experimental {
+    ///
+    /// Team Impl
+    /// =========
+
+    ///
+    /// SolveLU no piv
+    ///
+    
+    template<typename MemberType>
+    struct TeamSolveLU<MemberType,Algo::SolveLU::Unblocked,Trans::NoTranspose> {
+      template<typename AViewType,
+               typename BViewType>
+      KOKKOS_INLINE_FUNCTION
+      static int
+      invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
+        static_assert(AViewType::rank == 2, "A should have two dimensions");
+        static_assert((BViewType::rank == 1)||(BViewType::rank == 2), "B should have either one dimension or two dimensions");
+        static_assert(std::is_same<typename AViewType::memory_space, typename BViewType::memory_space>::value, "A and B should be on the same memory space");
+        assert(A.extent(0)==A.extent(1));
+        assert(A.extent(1)==B.extent(0));
+
+        typedef typename AViewType::value_type ScalarType;
+
+        const ScalarType one(1.0);
+
+        //First, compute Y (= U*X) by solving the system L*Y = B for Y
+        TeamTrsm<MemberType,Side::Left,Uplo::Lower,Trans::NoTranspose,Diag::Unit,Algo::Trsm::Unblocked>::invoke(member, one, A, B);
+        //Second, compute X by solving the system U*X = Y for X
+        TeamTrsm<MemberType,Side::Left,Uplo::Upper,Trans::NoTranspose,Diag::NonUnit,Algo::Trsm::Unblocked>::invoke(member, one, A, B);
+
+        return 0;
+      }
+    };
+    
+    template<typename MemberType>
+    struct TeamSolveLU<MemberType,Algo::SolveLU::Blocked,Trans::NoTranspose> {
+      template<typename AViewType,
+               typename BViewType>
+      KOKKOS_INLINE_FUNCTION
+      static int
+      invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
+        static_assert(AViewType::rank == 2, "A should have two dimensions");
+        static_assert((BViewType::rank == 1)||(BViewType::rank == 2), "B should have either one dimension or two dimensions");
+        static_assert(std::is_same<typename AViewType::memory_space, typename BViewType::memory_space>::value, "A and B should be on the same memory space");
+        assert(A.extent(0)==A.extent(1));
+        assert(A.extent(1)==B.extent(0));
+
+        typedef typename AViewType::value_type ScalarType;
+
+        const ScalarType one(1.0);
+
+        //First, compute Y (= U*X) by solving the system L*Y = B for Y
+        TeamTrsm<MemberType,Side::Left,Uplo::Lower,Trans::NoTranspose,Diag::Unit,Algo::Trsm::Blocked>::invoke(member, one, A, B);
+        //Second, compute X by solving the system U*X = Y for X
+        TeamTrsm<MemberType,Side::Left,Uplo::Upper,Trans::NoTranspose,Diag::NonUnit,Algo::Trsm::Blocked>::invoke(member, one, A, B);
+
+        return 0;
+      }
+    };
+	
+    template<typename MemberType>
+    struct TeamSolveLU<MemberType,Algo::SolveLU::Unblocked,Trans::Transpose> {
+      template<typename AViewType,
+               typename BViewType>
+      KOKKOS_INLINE_FUNCTION
+      static int
+      invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
+        static_assert(AViewType::rank == 2, "A should have two dimensions");
+        static_assert((BViewType::rank == 1)||(BViewType::rank == 2), "B should have either one dimension or two dimensions");
+        static_assert(std::is_same<typename AViewType::memory_space, typename BViewType::memory_space>::value, "A and B should be on the same memory space");
+        assert(A.extent(0)==A.extent(1));
+        assert(A.extent(1)==B.extent(0));
+
+        typedef typename AViewType::value_type ScalarType;
+
+        const ScalarType one(1.0);
+
+        //First, compute Y (= L'*X) by solving the system U'*Y = B for Y
+        TeamTrsm<MemberType,Side::Left,Uplo::Lower,Trans::Transpose,Diag::NonUnit,Algo::Trsm::Unblocked>::invoke(member, one, A, B);
+        //Second, compute X by solving the system L'*X = Y for X
+        TeamTrsm<MemberType,Side::Left,Uplo::Upper,Trans::Transpose,Diag::Unit,Algo::Trsm::Unblocked>::invoke(member, one, A, B);
+
+        return 0;
+      }
+    };
+
+    template<typename MemberType>
+    struct TeamSolveLU<MemberType,Algo::SolveLU::Blocked,Trans::Transpose> {
+      template<typename AViewType,
+               typename BViewType>
+      KOKKOS_INLINE_FUNCTION
+      static int
+      invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
+        static_assert(AViewType::rank == 2, "A should have two dimensions");
+        static_assert((BViewType::rank == 1)||(BViewType::rank == 2), "B should have either one dimension or two dimensions");
+        static_assert(std::is_same<typename AViewType::memory_space, typename BViewType::memory_space>::value, "A and B should be on the same memory space");
+        assert(A.extent(0)==A.extent(1));
+        assert(A.extent(1)==B.extent(0));
+
+        typedef typename AViewType::value_type ScalarType;
+
+        const ScalarType one(1.0);
+
+        //First, compute Y (= L'*X) by solving the system U'*Y = B for Y
+        TeamTrsm<MemberType,Side::Left,Uplo::Lower,Trans::Transpose,Diag::NonUnit,Algo::Trsm::Blocked>::invoke(member, one, A, B);
+        //Second, compute X by solving the system L'*X = Y for X
+        TeamTrsm<MemberType,Side::Left,Uplo::Upper,Trans::Transpose,Diag::Unit,Algo::Trsm::Blocked>::invoke(member, one, A, B);
+
+        return 0;
+      }
+    };
+
+  }
+}
+
+#endif

--- a/src/batched/KokkosBatched_Trsm_Serial_Impl.hpp
+++ b/src/batched/KokkosBatched_Trsm_Serial_Impl.hpp
@@ -297,6 +297,196 @@ namespace KokkosBatched {
       }
     };
 
+    ///
+    /// L/L/T
+    ///
+    /// B := inv(tril(AT)) (alpha*B)
+    /// A(m x m), B(m x n)
+
+#if                                                     \
+  defined(__KOKKOSBATCHED_INTEL_MKL__) &&               \
+  defined(__KOKKOSBATCHED_INTEL_MKL_BATCHED__) &&       \
+  defined(__KOKKOSBATCHED_INTEL_MKL_COMPACT_BATCHED__)    
+    template<typename ArgDiag>
+    struct SerialTrsm<Side::Left,Uplo::Lower,Trans::Transpose,ArgDiag,Algo::Trsm::CompactMKL> {
+      template<typename ScalarType,
+               typename AViewType,
+               typename BViewType>
+      KOKKOS_INLINE_FUNCTION
+      static int
+      invoke(const ScalarType alpha,
+             const AViewType &A,
+             const BViewType &B) {
+        typedef typename BViewType::value_type vector_type;
+        //typedef typename vector_type::value_type value_type;
+        
+        const int
+          m = B.dimension(0),
+          n = B.dimension(1);
+
+        static_assert(is_vector<vector_type>::value, "value type is not vector type");      
+        static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8, 
+                      "AVX, AVX2 and AVX512 is supported");
+        const MKL_COMPACT_PACK format = vector_type::vector_length == 8 ?  MKL_COMPACT_AVX512 : MKL_COMPACT_AVX;
+        
+        // no error check
+        int r_val = 0;
+        if (A.stride_0() == 1 && B.stride_0() == 1) {
+          mkl_dtrsm_compact(MKL_COL_MAJOR, 
+                            MKL_LEFT, MKL_LOWER, MKL_TRANS, 
+                            ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT,
+                            m, n, 
+                            alpha, 
+                            (const double*)A.data(), A.stride_1(), 
+                            (double*)B.data(), B.stride_1(), 
+                            format, (MKL_INT)vector_type::vector_length);
+        } else if (A.stride_1() == 1 && B.stride_1() == 1) {
+          mkl_dtrsm_compact(MKL_ROW_MAJOR, 
+                            MKL_LEFT, MKL_LOWER, MKL_TRANS, 
+                            ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT,
+                            m, n, 
+                            alpha, 
+                            (const double*)A.data(), A.stride_0(), 
+                            (double*)B.data(), B.stride_0(), 
+                            format, (MKL_INT)vector_type::vector_length);
+        } else {
+          r_val = -1;
+        }
+        return r_val;
+      }
+    };
+#endif    
+
+    template<typename ArgDiag>
+    struct SerialTrsm<Side::Left,Uplo::Lower,Trans::Transpose,ArgDiag,Algo::Trsm::Unblocked> {
+      template<typename ScalarType,
+               typename AViewType,
+               typename BViewType>
+      KOKKOS_INLINE_FUNCTION
+      static int
+      invoke(const ScalarType alpha,
+             const AViewType &A,
+             const BViewType &B) {
+        return SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(ArgDiag::use_unit_diag,
+                                                                    B.extent(0), B.extent(1),
+                                                                    alpha, 
+                                                                    A.data(), A.stride_1(), A.stride_0(),
+                                                                    B.data(), B.stride_0(), B.stride_1());
+      }
+    };
+
+    template<typename ArgDiag>
+    struct SerialTrsm<Side::Left,Uplo::Lower,Trans::Transpose,ArgDiag,Algo::Trsm::Blocked> {
+      template<typename ScalarType,
+               typename AViewType,
+               typename BViewType>
+      KOKKOS_INLINE_FUNCTION
+      static int
+      invoke(const ScalarType alpha,
+             const AViewType &A,
+             const BViewType &B) {
+        return SerialTrsmInternalLeftLower<Algo::Trsm::Blocked>::invoke(ArgDiag::use_unit_diag,
+                                                                  B.extent(0), B.extent(1),
+                                                                  alpha, 
+                                                                  A.data(), A.stride_1(), A.stride_0(),
+                                                                  B.data(), B.stride_0(), B.stride_1());
+      }
+    };
+    ///
+    /// L/U/NT
+    ///
+    /// B := inv(triu(AT)) (alpha*B) 
+    /// A(m x m), B(m x n)
+#if                                                     \
+  defined(__KOKKOSBATCHED_INTEL_MKL__) &&               \
+  defined(__KOKKOSBATCHED_INTEL_MKL_BATCHED__) &&       \
+  defined(__KOKKOSBATCHED_INTEL_MKL_COMPACT_BATCHED__)
+    template<typename ArgDiag>
+    struct SerialTrsm<Side::Left,Uplo::Upper,Trans::Transpose,ArgDiag,Algo::Trsm::CompactMKL> {
+      template<typename ScalarType,
+               typename AViewType,
+               typename BViewType>
+      KOKKOS_INLINE_FUNCTION
+      static int
+      invoke(const ScalarType alpha,
+             const AViewType &A,
+             const BViewType &B) {
+        typedef typename BViewType::value_type vector_type;
+        //typedef typename vector_type::value_type value_type;
+        
+        const int
+          m = B.dimension(0),
+          n = B.dimension(1);
+
+        static_assert(is_vector<vector_type>::value, "value type is not vector type");      
+        static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8, 
+                      "AVX, AVX2 and AVX512 is supported");
+        const MKL_COMPACT_PACK format = vector_type::vector_length == 8 ?  MKL_COMPACT_AVX512 : MKL_COMPACT_AVX;
+
+        // no error check
+        int r_val = 0;
+        if (A.stride_0() == 1 && B.stride_0() == 1) {
+          mkl_dtrsm_compact(MKL_COL_MAJOR, 
+                            MKL_LEFT, MKL_UPPER, MKL_TRANS, 
+                            ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT,
+                            m, n, 
+                            alpha, 
+                            (const double*)A.data(), A.stride_1(), 
+                            (double*)B.data(), B.stride_1(), 
+                            format, (MKL_INT)vector_type::vector_length);
+        } else if (A.stride_1() == 1 && B.stride_1() == 1) {
+          mkl_dtrsm_compact(MKL_ROW_MAJOR, 
+                            MKL_LEFT, MKL_UPPER, MKL_TRANS, 
+                            ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT,
+                            m, n, 
+                            alpha, 
+                            (const double*)A.data(), A.stride_0(), 
+                            (double*)B.data(), B.stride_0(), 
+                            format, (MKL_INT)vector_type::vector_length);
+        } else {
+          r_val = -1;
+        }
+        return r_val;
+      }
+    };
+#endif
+
+    template<typename ArgDiag>
+    struct SerialTrsm<Side::Left,Uplo::Upper,Trans::Transpose,ArgDiag,Algo::Trsm::Unblocked> {
+      template<typename ScalarType,
+               typename AViewType,
+               typename BViewType>
+      KOKKOS_INLINE_FUNCTION
+      static int
+      invoke(const ScalarType alpha,
+             const AViewType &A,
+             const BViewType &B) {
+        return SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(ArgDiag::use_unit_diag,
+                                                                    B.extent(0), B.extent(1),
+                                                                    alpha, 
+                                                                    A.data(), A.stride_1(), A.stride_0(),
+                                                                    B.data(), B.stride_0(), B.stride_1());
+      }
+    };
+
+    template<typename ArgDiag>
+    struct SerialTrsm<Side::Left,Uplo::Upper,Trans::Transpose,ArgDiag,Algo::Trsm::Blocked> {
+      template<typename ScalarType,
+               typename AViewType,
+               typename BViewType>
+      KOKKOS_INLINE_FUNCTION
+      static int
+      invoke(const ScalarType alpha,
+             const AViewType &A,
+             const BViewType &B) {
+        return SerialTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(ArgDiag::use_unit_diag,
+                                                                  B.extent(0), B.extent(1),
+                                                                  alpha, 
+                                                                  A.data(), A.stride_1(), A.stride_0(),
+                                                                  B.data(), B.stride_0(), B.stride_1());
+      }
+    };
+
   }
 }
 

--- a/src/batched/KokkosBatched_Trsm_Serial_Internal.hpp
+++ b/src/batched/KokkosBatched_Trsm_Serial_Internal.hpp
@@ -180,8 +180,8 @@ namespace KokkosBatched {
           const int iend = p, jend = n;
 
           const ValueType *__restrict__ a01 = A+p*as1;
-          /**/  ValueType *__restrict__ b1t = B+p*bs0;
-            
+                ValueType *__restrict__ b1t = B+p*bs0;
+
           if (!use_unit_diag) {
             const ValueType alpha11 = A[p*as0+p*as1];
                 
@@ -191,13 +191,16 @@ namespace KokkosBatched {
             for (int j=0;j<n;++j)
               b1t[j*bs1] = b1t[j*bs1] / alpha11;
           }
-          for (int i=0;i<iend;++i)
+          
+          if (p>0){
+            for (int i=0;i<iend;++i)
                 
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
 #endif
-            for (int j=0;j<jend;++j)
-              B0[i*bs0+j*bs1] -= a01[i*as0] * b1t[j*bs1];
+              for (int j=0;j<jend;++j)
+                B0[i*bs0+j*bs1] -= a01[i*as0] * b1t[j*bs1];
+          }
         }
       }
       return 0;

--- a/src/batched/KokkosBatched_Trsm_Serial_Internal.hpp
+++ b/src/batched/KokkosBatched_Trsm_Serial_Internal.hpp
@@ -192,7 +192,7 @@ namespace KokkosBatched {
               b1t[j*bs1] = b1t[j*bs1] / alpha11;
           }
           
-          if (p>0){
+          if (p>0){//Note: A workaround to produce correct results for complex<double> with Intel-18.2.199
             for (int i=0;i<iend;++i)
                 
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)

--- a/src/batched/KokkosBatched_Trsm_Team_Impl.hpp
+++ b/src/batched/KokkosBatched_Trsm_Team_Impl.hpp
@@ -152,6 +152,98 @@ namespace KokkosBatched {
       }
     };
 
+    ///
+    /// L/L/T
+    ///
+    /// B := inv(tril(AT)) (alpha*B)
+    /// A(m x m), B(m x n)
+
+    template<typename MemberType, typename ArgDiag>
+    struct TeamTrsm<MemberType,Side::Left,Uplo::Lower,Trans::Transpose,ArgDiag,Algo::Trsm::Unblocked> {
+      template<typename ScalarType,
+               typename AViewType,
+               typename BViewType>
+      KOKKOS_INLINE_FUNCTION
+      static int
+      invoke(const MemberType &member, 
+             const ScalarType alpha,
+             const AViewType &A,
+             const BViewType &B) {
+        return TeamTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(member,
+                                                                        ArgDiag::use_unit_diag,
+                                                                        B.extent(0), B.extent(1),
+                                                                        alpha, 
+                                                                        A.data(), A.stride_1(), A.stride_0(),
+                                                                        B.data(), B.stride_0(), B.stride_1());
+      }
+    };
+
+    template<typename MemberType, typename ArgDiag>
+    struct TeamTrsm<MemberType,Side::Left,Uplo::Lower,Trans::Transpose,ArgDiag,Algo::Trsm::Blocked> {
+      template<typename ScalarType,
+               typename AViewType,
+               typename BViewType>
+      KOKKOS_INLINE_FUNCTION
+      static int
+      invoke(const MemberType &member,
+             const ScalarType alpha,
+             const AViewType &A,
+             const BViewType &B) {
+        return TeamTrsmInternalLeftLower<Algo::Trsm::Blocked>::invoke(member,
+                                                                      ArgDiag::use_unit_diag,
+                                                                      B.extent(0), B.extent(1),
+                                                                      alpha, 
+                                                                      A.data(), A.stride_1(), A.stride_0(),
+                                                                      B.data(), B.stride_0(), B.stride_1());
+      }
+    };
+
+    ///
+    /// L/U/T
+    ///
+    /// B := inv(triu(AT)) (alpha*B) 
+    /// A(m x m), B(m x n)
+
+    template<typename MemberType, typename ArgDiag>
+    struct TeamTrsm<MemberType,Side::Left,Uplo::Upper,Trans::Transpose,ArgDiag,Algo::Trsm::Unblocked> {
+      template<typename ScalarType,
+               typename AViewType,
+               typename BViewType>
+      KOKKOS_INLINE_FUNCTION
+      static int
+      invoke(const MemberType &member, 
+             const ScalarType alpha,
+             const AViewType &A,
+             const BViewType &B) {
+        return TeamTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(member,
+                                                                        ArgDiag::use_unit_diag,
+                                                                        B.extent(0), B.extent(1),
+                                                                        alpha, 
+                                                                        A.data(), A.stride_1(), A.stride_0(),
+                                                                        B.data(), B.stride_0(), B.stride_1());
+      }
+    };
+
+    template<typename MemberType, typename ArgDiag>
+    struct TeamTrsm<MemberType,Side::Left,Uplo::Upper,Trans::Transpose,ArgDiag,Algo::Trsm::Blocked> {
+      template<typename ScalarType,
+               typename AViewType,
+               typename BViewType>
+      KOKKOS_INLINE_FUNCTION
+      static int
+      invoke(const MemberType &member,
+             const ScalarType alpha,
+             const AViewType &A,
+             const BViewType &B) {
+        return TeamTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(member, 
+                                                                      ArgDiag::use_unit_diag,
+                                                                      B.extent(0), B.extent(1),
+                                                                      alpha, 
+                                                                      A.data(), A.stride_1(), A.stride_0(),
+                                                                      B.data(), B.stride_0(), B.stride_1());
+      }
+    };
+	
   }
 }
 

--- a/src/batched/KokkosBatched_Util.hpp
+++ b/src/batched/KokkosBatched_Util.hpp
@@ -273,7 +273,8 @@ namespace KokkosBatched {
       using Gemm = Level3;
       using Trsm = Level3;
       using LU   = Level3;
-      using InverseLU   = Level3;
+      using InverseLU = Level3;
+      using SolveLU   = Level3;
 
       struct Level2 {
 	struct Unblocked {};

--- a/unit_test/Makefile
+++ b/unit_test/Makefile
@@ -143,6 +143,8 @@ ifeq ($(KOKKOSKERNELS_INTERNAL_TEST_OPENMP), 1)
   OBJ_OPENMP += Test_OpenMP_Batched_TeamTrsv_Real.o
   OBJ_OPENMP += Test_OpenMP_Batched_SerialInverseLU_Real.o
   OBJ_OPENMP += Test_OpenMP_Batched_TeamInverseLU_Real.o
+  OBJ_OPENMP += Test_OpenMP_Batched_SerialSolveLU_Real.o
+  OBJ_OPENMP += Test_OpenMP_Batched_TeamSolveLU_Real.o
  # Complex
   OBJ_OPENMP += Test_OpenMP_Batched_SerialMatUtil_Complex.o
   OBJ_OPENMP += Test_OpenMP_Batched_SerialGemm_Complex.o
@@ -158,6 +160,8 @@ ifeq ($(KOKKOSKERNELS_INTERNAL_TEST_OPENMP), 1)
   OBJ_OPENMP += Test_OpenMP_Batched_TeamTrsv_Complex.o
   OBJ_OPENMP += Test_OpenMP_Batched_SerialInverseLU_Complex.o
   OBJ_OPENMP += Test_OpenMP_Batched_TeamInverseLU_Complex.o
+  OBJ_OPENMP += Test_OpenMP_Batched_SerialSolveLU_Complex.o
+  OBJ_OPENMP += Test_OpenMP_Batched_TeamSolveLU_Complex.o
   # Vector
   OBJ_OPENMP += Test_OpenMP_Batched_VectorArithmatic.o
   OBJ_OPENMP += Test_OpenMP_Batched_VectorMath.o
@@ -249,6 +253,8 @@ ifeq ($(KOKKOSKERNELS_INTERNAL_TEST_CUDA), 1)
   OBJ_CUDA += Test_Cuda_Batched_TeamTrsv_Real.o
   OBJ_CUDA += Test_Cuda_Batched_SerialInverseLU_Real.o
   OBJ_CUDA += Test_Cuda_Batched_TeamInverseLU_Real.o
+  OBJ_CUDA += Test_Cuda_Batched_SerialSolveLU_Real.o
+  OBJ_CUDA += Test_Cuda_Batched_TeamSolveLU_Real.o
   # Complex
   OBJ_CUDA += Test_Cuda_Batched_SerialMatUtil_Complex.o
   OBJ_CUDA += Test_Cuda_Batched_SerialGemm_Complex.o
@@ -264,6 +270,8 @@ ifeq ($(KOKKOSKERNELS_INTERNAL_TEST_CUDA), 1)
   OBJ_CUDA += Test_Cuda_Batched_TeamTrsv_Complex.o
   OBJ_CUDA += Test_Cuda_Batched_SerialInverseLU_Complex.o
   OBJ_CUDA += Test_Cuda_Batched_TeamInverseLU_Complex.o
+  OBJ_CUDA += Test_Cuda_Batched_SerialSolveLU_Complex.o
+  OBJ_CUDA += Test_Cuda_Batched_TeamSolveLU_Complex.o
   TARGETS += KokkosKernels_UnitTest_Cuda
   TEST_TARGETS += test-cuda
 endif
@@ -350,6 +358,8 @@ ifeq ($(KOKKOSKERNELS_INTERNAL_TEST_SERIAL), 1)
   OBJ_SERIAL += Test_Serial_Batched_TeamTrsv_Real.o
   OBJ_SERIAL += Test_Serial_Batched_SerialInverseLU_Real.o
   OBJ_SERIAL += Test_Serial_Batched_TeamInverseLU_Real.o
+  OBJ_SERIAL += Test_Serial_Batched_SerialSolveLU_Real.o
+  OBJ_SERIAL += Test_Serial_Batched_TeamSolveLU_Real.o
   # Complex
   OBJ_SERIAL += Test_Serial_Batched_SerialMatUtil_Complex.o
   OBJ_SERIAL += Test_Serial_Batched_SerialGemm_Complex.o
@@ -365,6 +375,8 @@ ifeq ($(KOKKOSKERNELS_INTERNAL_TEST_SERIAL), 1)
   OBJ_SERIAL += Test_Serial_Batched_TeamTrsv_Complex.o
   OBJ_SERIAL += Test_Serial_Batched_SerialInverseLU_Complex.o
   OBJ_SERIAL += Test_Serial_Batched_TeamInverseLU_Complex.o
+  OBJ_SERIAL += Test_Serial_Batched_SerialSolveLU_Complex.o
+  OBJ_SERIAL += Test_Serial_Batched_TeamSolveLU_Complex.o
   # Vector
   OBJ_SERIAL += Test_Serial_Batched_VectorArithmatic.o
   OBJ_SERIAL += Test_Serial_Batched_VectorMath.o

--- a/unit_test/batched/Test_Batched_SerialInverseLU.hpp
+++ b/unit_test/batched/Test_Batched_SerialInverseLU.hpp
@@ -142,7 +142,7 @@ namespace Test {
     Kokkos::deep_copy(w, value_type(0.0));
 
     Functor_BatchedSerialLU<DeviceType,AViewType,AlgoTagType>(a1).run();
-	
+
     Functor_TestBatchedSerialInverseLU<DeviceType,AViewType,WViewType,AlgoTagType>(a1,w).run();
 
     value_type alpha = 1.0, beta = 0.0;   

--- a/unit_test/batched/Test_Batched_SerialInverseLU_Complex.hpp
+++ b/unit_test/batched/Test_Batched_SerialInverseLU_Complex.hpp
@@ -4,6 +4,6 @@ TEST_F( TestCategory, batched_scalar_serial_inverselu_dcomplex ) {
   //printf("Batched serial inverse LU - double complex - algorithm type: Unblocked\n");
   test_batched_inverselu<TestExecSpace,Kokkos::complex<double>,Algo::InverseLU::Unblocked>();
   //printf("Batched serial inverse LU - double complex - algorithm type: Blocked\n");
-  test_batched_inverselu<TestExecSpace,Kokkos::complex<double>,Algo::InverseLU::Blocked>();
+  test_batched_inverselu<TestExecSpace,Kokkos::complex<double>,Algo::InverseLU::Blocked>();  
 }
 #endif

--- a/unit_test/batched/Test_Batched_SerialSolveLU.hpp
+++ b/unit_test/batched/Test_Batched_SerialSolveLU.hpp
@@ -1,0 +1,229 @@
+/// \author Vinh Dang (vqdang@sandia.gov)
+
+#include "gtest/gtest.h"
+#include "Kokkos_Core.hpp"
+#include "Kokkos_Random.hpp"
+
+//#include "KokkosBatched_Vector.hpp"
+
+#include "KokkosBatched_Gemm_Decl.hpp"
+#include "KokkosBatched_Gemm_Serial_Impl.hpp"
+#include "KokkosBatched_LU_Decl.hpp"
+#include "KokkosBatched_LU_Serial_Impl.hpp"
+#include "KokkosBatched_SolveLU_Decl.hpp"
+#include "KokkosBatched_SolveLU_Serial_Impl.hpp"
+
+#include "KokkosKernels_TestUtils.hpp"
+
+using namespace KokkosBatched::Experimental;
+
+namespace Test {
+
+  template<typename TA, typename TB>
+  struct ParamTag { 
+    typedef TA transA;
+    typedef TB transB;
+  };
+ 
+  template<typename DeviceType,
+           typename ViewType,
+           typename ScalarType,
+           typename ParamTagType, 
+           typename AlgoTagType>
+  struct Functor_BatchedSerialGemm {
+    ViewType _a, _b, _c;
+    
+    ScalarType _alpha, _beta;
+    
+    KOKKOS_INLINE_FUNCTION
+    Functor_BatchedSerialGemm(const ScalarType alpha, 
+            const ViewType &a,
+            const ViewType &b,
+            const ScalarType beta,
+            const ViewType &c)
+      : _a(a), _b(b), _c(c), _alpha(alpha), _beta(beta) {}
+    
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const ParamTagType &, const int k) const {
+      auto aa = Kokkos::subview(_a, k, Kokkos::ALL(), Kokkos::ALL());
+      auto bb = Kokkos::subview(_b, k, Kokkos::ALL(), Kokkos::ALL());
+      auto cc = Kokkos::subview(_c, k, Kokkos::ALL(), Kokkos::ALL());
+
+      for (int i=0;i<static_cast<int>(aa.extent(0));++i)
+        aa(i,i) += 10.0;
+     
+      SerialGemm<typename ParamTagType::transA,
+        typename ParamTagType::transB,
+        AlgoTagType>::
+        invoke(_alpha, aa, bb, _beta, cc);
+    }
+    
+    inline
+    void run() {
+      Kokkos::RangePolicy<DeviceType,ParamTagType> policy(0, _c.extent(0));
+      Kokkos::parallel_for(policy, *this);            
+    }
+  };
+
+  template<typename DeviceType,
+           typename ViewType,
+           typename AlgoTagType>
+  struct Functor_BatchedSerialLU {
+    ViewType _a;
+
+    KOKKOS_INLINE_FUNCTION
+    Functor_BatchedSerialLU(const ViewType &a) 
+      : _a(a) {} 
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const int k) const {
+      auto aa = Kokkos::subview(_a, k, Kokkos::ALL(), Kokkos::ALL());
+
+      for (int i=0;i<static_cast<int>(aa.extent(0));++i)
+        aa(i,i) += 10.0;
+
+      SerialLU<AlgoTagType>::invoke(aa);
+    }
+
+    inline
+    void run() {
+      Kokkos::RangePolicy<DeviceType> policy(0, _a.extent(0));
+      Kokkos::parallel_for(policy, *this);
+    }
+  };
+
+  template<typename DeviceType,
+           typename ViewType,
+           typename AlgoTagType,
+           typename TransType>
+  struct Functor_TestBatchedSerialSolveLU {
+    ViewType _a;
+    ViewType _b;
+
+    KOKKOS_INLINE_FUNCTION
+    Functor_TestBatchedSerialSolveLU(const ViewType &a, const ViewType &b) 
+      : _a(a), _b(b) {} 
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const int k) const {
+      auto aa = Kokkos::subview(_a, k, Kokkos::ALL(), Kokkos::ALL());
+      auto bb = Kokkos::subview(_b, k, Kokkos::ALL(), Kokkos::ALL());
+
+      SerialSolveLU<AlgoTagType,TransType>::invoke(aa,bb);
+    }
+
+    inline
+    void run() {
+      Kokkos::RangePolicy<DeviceType> policy(0, _a.extent(0));
+      Kokkos::parallel_for(policy, *this);
+    }
+  };
+
+  template<typename DeviceType,
+           typename ViewType,
+           typename AlgoTagType>
+  void impl_test_batched_solvelu(const int N, const int BlkSize) {
+    typedef typename ViewType::value_type value_type;
+    typedef Kokkos::Details::ArithTraits<value_type> ats;
+
+    /// randomized input testing views
+    ViewType a0("a0", N, BlkSize, BlkSize);
+    ViewType a1("a1", N, BlkSize, BlkSize);
+    ViewType b ("b",  N, BlkSize, 5 );
+	ViewType x0("x0", N, BlkSize, 5 );
+    ViewType a0_T("a0_T", N, BlkSize, BlkSize);
+    ViewType b_T ("b_T",  N, BlkSize, 5 );
+	
+    Kokkos::Random_XorShift64_Pool<typename DeviceType::execution_space> random(13718);
+    Kokkos::fill_random(a0, random, value_type(1.0));
+    Kokkos::fill_random(x0, random, value_type(1.0));
+
+    Kokkos::fence();
+
+    Kokkos::deep_copy(a1, a0);
+    Kokkos::deep_copy(a0_T, a0);
+
+    value_type alpha = 1.0, beta = 0.0;   
+    typedef ParamTag<Trans::NoTranspose,Trans::NoTranspose> param_tag_type;
+
+    Functor_BatchedSerialGemm<DeviceType,ViewType,value_type,
+      param_tag_type,AlgoTagType>(alpha, a0, x0, beta, b).run();
+
+    Functor_BatchedSerialLU<DeviceType,ViewType,AlgoTagType>(a1).run();
+
+    Functor_TestBatchedSerialSolveLU<DeviceType,ViewType,AlgoTagType,Trans::NoTranspose>(a1,b).run();
+	  
+    Kokkos::fence();
+
+    //Transpose
+    typedef ParamTag<Trans::Transpose,Trans::NoTranspose> param_tag_type_T;
+
+    Functor_BatchedSerialGemm<DeviceType,ViewType,value_type,
+      param_tag_type_T,AlgoTagType>(alpha, a0_T, x0, beta, b_T).run();
+
+    Functor_TestBatchedSerialSolveLU<DeviceType,ViewType,AlgoTagType,Trans::Transpose>(a1,b_T).run();
+
+    Kokkos::fence();
+
+    /// for comparison send it to host
+    typename ViewType::HostMirror x0_host  = Kokkos::create_mirror_view(x0);
+    typename ViewType::HostMirror b_host   = Kokkos::create_mirror_view(b);
+    typename ViewType::HostMirror b_T_host = Kokkos::create_mirror_view(b_T);
+
+    Kokkos::deep_copy(x0_host, x0);
+    Kokkos::deep_copy(b_host, b);
+    Kokkos::deep_copy(b_T_host, b_T);
+
+    /// check x0 = b ; this eps is about 10^-14
+    typedef typename ats::mag_type mag_type;
+    mag_type sum(1), diff(0);
+    const mag_type eps = 1.0e3 * ats::epsilon();
+
+    for (int k=0;k<N;++k)
+      for (int i=0;i<BlkSize;++i)
+        for (int j=0;j<5;++j) {
+          sum  += ats::abs(x0_host(k,i,j));
+          diff += ats::abs(x0_host(k,i,j)-b_host(k,i,j));
+        }
+    //printf("NoTranspose -- N=%d, BlkSize=%d, sum=%f, diff=%f\n", N, BlkSize, sum, diff);
+    EXPECT_NEAR_KK( diff/sum, 0.0, eps);
+
+    /// check x0 = b_T ; this eps is about 10^-14
+    mag_type sum_T(1), diff_T(0);
+    
+    for (int k=0;k<N;++k)
+      for (int i=0;i<BlkSize;++i)
+        for (int j=0;j<5;++j) {
+          sum_T  += ats::abs(x0_host(k,i,j));
+          diff_T += ats::abs(x0_host(k,i,j)-b_T_host(k,i,j));
+        }
+    //printf("Transpose -- N=%d, BlkSize=%d, sum=%f, diff=%f\n", N, BlkSize, sum_T, diff_T);
+    EXPECT_NEAR_KK( diff_T/sum_T, 0.0, eps);
+  }
+}
+
+template<typename DeviceType,
+         typename ValueType,
+         typename AlgoTagType>
+int test_batched_solvelu() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
+  {
+    typedef Kokkos::View<ValueType***,Kokkos::LayoutLeft,DeviceType> ViewType;
+    Test::impl_test_batched_solvelu<DeviceType,ViewType,AlgoTagType>(     0, 10);
+    for (int i=0;i<10;++i) {
+      Test::impl_test_batched_solvelu<DeviceType,ViewType,AlgoTagType>(1024,  i);
+    }
+  }
+#endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
+  {
+    typedef Kokkos::View<ValueType***,Kokkos::LayoutRight,DeviceType> ViewType;
+    Test::impl_test_batched_solvelu<DeviceType,ViewType,AlgoTagType>(     0, 10);
+    for (int i=0;i<10;++i) {
+      Test::impl_test_batched_solvelu<DeviceType,ViewType,AlgoTagType>(1024,  i);
+    }
+  }
+#endif
+
+  return 0;
+}

--- a/unit_test/batched/Test_Batched_SerialSolveLU_Complex.hpp
+++ b/unit_test/batched/Test_Batched_SerialSolveLU_Complex.hpp
@@ -1,0 +1,9 @@
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
+TEST_F( TestCategory, batched_scalar_serial_solvelu_dcomplex ) {
+  //printf("Batched serial solveLU - double complex - algorithm type: Unblocked\n");
+  test_batched_solvelu<TestExecSpace,Kokkos::complex<double>,Algo::SolveLU::Unblocked>();
+  //printf("Batched serial solveLU - double complex - algorithm type: Blocked\n");
+  test_batched_solvelu<TestExecSpace,Kokkos::complex<double>,Algo::SolveLU::Blocked>();
+}
+#endif

--- a/unit_test/batched/Test_Batched_SerialSolveLU_Real.hpp
+++ b/unit_test/batched/Test_Batched_SerialSolveLU_Real.hpp
@@ -1,0 +1,20 @@
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+TEST_F( TestCategory, batched_scalar_serial_solvelu_float ) {
+  //printf("Batched serial solveLU - float - algorithm type: Unblocked\n");
+  test_batched_solvelu<TestExecSpace,float,Algo::SolveLU::Unblocked>();
+  //printf("Batched serial solveLU - float - algorithm type: Blocked\n");
+  test_batched_solvelu<TestExecSpace,float,Algo::SolveLU::Blocked>();
+}
+#endif
+
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+TEST_F( TestCategory, batched_scalar_serial_solvelu_double ) {
+  //printf("Batched serial solveLU - double - algorithm type: Unblocked\n");
+  test_batched_solvelu<TestExecSpace,double,Algo::SolveLU::Unblocked>();
+  //printf("Batched serial solveLU - double - algorithm type: Blocked\n");
+  test_batched_solvelu<TestExecSpace,double,Algo::SolveLU::Blocked>();
+}
+#endif
+

--- a/unit_test/batched/Test_Batched_SerialTrsm_Complex.hpp
+++ b/unit_test/batched/Test_Batched_SerialTrsm_Complex.hpp
@@ -31,7 +31,27 @@ TEST_F( TestCategory, batched_scalar_serial_trsm_r_u_nt_n_dcomplex_dcomplex ) {
   typedef Algo::Trsm::Blocked algo_tag_type;
   test_batched_trsm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
 }
-
+//
+TEST_F( TestCategory, batched_scalar_serial_trsm_l_l_t_u_dcomplex_dcomplex ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::Unit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_serial_trsm_l_l_t_n_dcomplex_dcomplex ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::NonUnit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_serial_trsm_l_u_t_u_dcomplex_dcomplex ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::Unit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+}
+// TEST_F( TestCategory, batched_scalar_serial_trsm_l_u_t_n_dcomplex_dcomplex ) {
+//   typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::NonUnit> param_tag_type;
+//   typedef Algo::Trsm::Blocked algo_tag_type;
+//   test_batched_trsm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+// }
 
 
 TEST_F( TestCategory, batched_scalar_serial_trsm_l_l_nt_u_dcomplex_double ) {
@@ -64,4 +84,25 @@ TEST_F( TestCategory, batched_scalar_serial_trsm_r_u_nt_n_dcomplex_double ) {
   typedef Algo::Trsm::Blocked algo_tag_type;
   test_batched_trsm<TestExecSpace,Kokkos::complex<double>,double,param_tag_type,algo_tag_type>();
 }
+//
+TEST_F( TestCategory, batched_scalar_serial_trsm_l_l_t_u_dcomplex_double ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::Unit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,Kokkos::complex<double>,double,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_serial_trsm_l_l_t_n_dcomplex_double ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::NonUnit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,Kokkos::complex<double>,double,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_serial_trsm_l_u_t_u_dcomplex_double ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::Unit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,Kokkos::complex<double>,double,param_tag_type,algo_tag_type>();
+}
+// TEST_F( TestCategory, batched_scalar_serial_trsm_l_u_t_n_dcomplex_double ) {
+//   typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::NonUnit> param_tag_type;
+//   typedef Algo::Trsm::Blocked algo_tag_type;
+//   test_batched_trsm<TestExecSpace,Kokkos::complex<double>,double,param_tag_type,algo_tag_type>();
+// }
 #endif

--- a/unit_test/batched/Test_Batched_SerialTrsm_Real.hpp
+++ b/unit_test/batched/Test_Batched_SerialTrsm_Real.hpp
@@ -30,6 +30,27 @@ TEST_F( TestCategory, batched_scalar_serial_trsm_r_u_nt_n_float_float ) {
   typedef Algo::Trsm::Blocked algo_tag_type;
   test_batched_trsm<TestExecSpace,float,float,param_tag_type,algo_tag_type>();
 }
+//
+TEST_F( TestCategory, batched_scalar_serial_trsm_l_l_t_u_float_float ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::Unit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,float,float,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_serial_trsm_l_l_t_n_float_float ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::NonUnit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,float,float,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_serial_trsm_l_u_t_u_float_float ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::Unit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,float,float,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_serial_trsm_l_u_t_n_float_float ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::NonUnit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,float,float,param_tag_type,algo_tag_type>();
+}
 #endif
 
 
@@ -61,6 +82,27 @@ TEST_F( TestCategory, batched_scalar_serial_trsm_r_u_nt_u_double_double ) {
 }
 TEST_F( TestCategory, batched_scalar_serial_trsm_r_u_nt_n_double_double ) {
   typedef ::Test::ParamTag<Side::Right,Uplo::Upper,Trans::NoTranspose,Diag::NonUnit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,double,double,param_tag_type,algo_tag_type>();
+}
+//
+TEST_F( TestCategory, batched_scalar_serial_trsm_l_l_t_u_double_double ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::Unit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,double,double,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_serial_trsm_l_l_t_n_double_double ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::NonUnit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,double,double,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_serial_trsm_l_u_t_u_double_double ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::Unit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,double,double,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_serial_trsm_l_u_t_n_double_double ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trsm::Blocked algo_tag_type;
   test_batched_trsm<TestExecSpace,double,double,param_tag_type,algo_tag_type>();
 }

--- a/unit_test/batched/Test_Batched_TeamSolveLU.hpp
+++ b/unit_test/batched/Test_Batched_TeamSolveLU.hpp
@@ -1,0 +1,246 @@
+/// \author Vinh Dang (vqdang@sandia.gov)
+
+#include "gtest/gtest.h"
+#include "Kokkos_Core.hpp"
+#include "Kokkos_Random.hpp"
+
+//#include "KokkosBatched_Vector.hpp"
+
+#include "KokkosBatched_Gemm_Decl.hpp"
+#include "KokkosBatched_Gemm_Team_Impl.hpp"
+#include "KokkosBatched_LU_Decl.hpp"
+#include "KokkosBatched_LU_Team_Impl.hpp"
+#include "KokkosBatched_SolveLU_Decl.hpp"
+#include "KokkosBatched_SolveLU_Team_Impl.hpp"
+
+#include "KokkosKernels_TestUtils.hpp"
+
+using namespace KokkosBatched::Experimental;
+
+namespace Test {
+	
+  template<typename TA, typename TB>
+  struct ParamTag { 
+    typedef TA transA;
+    typedef TB transB;
+  };
+ 
+  template<typename DeviceType,
+           typename ViewType,
+           typename ScalarType,
+           typename ParamTagType, 
+           typename AlgoTagType>
+  struct Functor_BatchedTeamGemm {
+    ViewType _a, _b, _c;
+    
+    ScalarType _alpha, _beta;
+    
+    KOKKOS_INLINE_FUNCTION
+    Functor_BatchedTeamGemm(const ScalarType alpha, 
+            const ViewType &a,
+            const ViewType &b,
+            const ScalarType beta,
+            const ViewType &c)
+      : _a(a), _b(b), _c(c), _alpha(alpha), _beta(beta) {}
+
+    template<typename MemberType>
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const ParamTagType &, const MemberType &member) const {
+      const int k = member.league_rank();
+
+      auto aa = Kokkos::subview(_a, k, Kokkos::ALL(), Kokkos::ALL());
+      auto bb = Kokkos::subview(_b, k, Kokkos::ALL(), Kokkos::ALL());
+      auto cc = Kokkos::subview(_c, k, Kokkos::ALL(), Kokkos::ALL());
+
+      if (member.team_rank() == 0) {
+        for (int i=0;i<static_cast<int>(aa.extent(0));++i)                                                                          
+          aa(i,i) += 10.0;  
+      }
+      member.team_barrier();
+	  
+      TeamGemm<MemberType,
+        typename ParamTagType::transA,
+        typename ParamTagType::transB,
+        AlgoTagType>::
+        invoke(member, _alpha, aa, bb, _beta, cc);
+    }
+    
+    inline
+    void run() {
+      const int league_size = _c.extent(0);
+      Kokkos::TeamPolicy<DeviceType,ParamTagType> policy(league_size, Kokkos::AUTO);
+      Kokkos::parallel_for(policy, *this);            
+    }
+  };
+
+  template<typename DeviceType,
+           typename ViewType,
+           typename AlgoTagType>
+  struct Functor_BatchedTeamLU {
+    ViewType _a;
+
+    KOKKOS_INLINE_FUNCTION
+    Functor_BatchedTeamLU(const ViewType &a) 
+      : _a(a) {} 
+
+    template<typename MemberType>
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const MemberType &member) const {
+      const int k = member.league_rank();
+      auto aa = Kokkos::subview(_a, k, Kokkos::ALL(), Kokkos::ALL());
+
+      if (member.team_rank() == 0) {
+        for (int i=0;i<static_cast<int>(aa.extent(0));++i)                                                                          
+          aa(i,i) += 10.0;  
+      }
+      member.team_barrier();
+
+      TeamLU<MemberType,AlgoTagType>::invoke(member, aa);
+    }
+
+    inline
+    void run() {
+      const int league_size = _a.extent(0);
+      Kokkos::TeamPolicy<DeviceType> policy(league_size, Kokkos::AUTO);
+      Kokkos::parallel_for(policy, *this);
+    }
+  };
+
+  template<typename DeviceType,
+           typename ViewType,
+           typename AlgoTagType,
+           typename TransType>
+  struct Functor_TestBatchedTeamSolveLU {
+    ViewType _a;
+    ViewType _b;
+
+    KOKKOS_INLINE_FUNCTION
+    Functor_TestBatchedTeamSolveLU(const ViewType &a, const ViewType &b) 
+      : _a(a), _b(b) {} 
+
+    template<typename MemberType>
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const MemberType &member) const {
+      const int k = member.league_rank();
+      auto aa = Kokkos::subview(_a, k, Kokkos::ALL(), Kokkos::ALL());
+      auto bb = Kokkos::subview(_b, k, Kokkos::ALL(), Kokkos::ALL());
+
+      TeamSolveLU<MemberType,AlgoTagType,TransType>::invoke(member, aa, bb);
+    }
+
+    inline
+    void run() {
+      const int league_size = _a.extent(0);
+      Kokkos::TeamPolicy<DeviceType> policy(league_size, Kokkos::AUTO);
+      Kokkos::parallel_for(policy, *this);
+    }
+  };
+
+  template<typename DeviceType,
+           typename ViewType,
+           typename AlgoTagType>
+  void impl_test_batched_solvelu(const int N, const int BlkSize) {
+    typedef typename ViewType::value_type value_type;
+    typedef Kokkos::Details::ArithTraits<value_type> ats;
+
+    /// randomized input testing views
+    ViewType a0("a0", N, BlkSize, BlkSize);
+    ViewType a1("a1", N, BlkSize, BlkSize);
+    ViewType b ("b",  N, BlkSize, 5 );
+	ViewType x0("x0", N, BlkSize, 5 );
+    ViewType a0_T("a0_T", N, BlkSize, BlkSize);
+    ViewType b_T ("b_T",  N, BlkSize, 5 );
+
+    Kokkos::Random_XorShift64_Pool<typename DeviceType::execution_space> random(13718);
+    Kokkos::fill_random(a0, random, value_type(1.0));
+    Kokkos::fill_random(x0, random, value_type(1.0));
+
+    Kokkos::fence();
+
+    Kokkos::deep_copy(a1, a0);
+    Kokkos::deep_copy(a0_T, a0);
+
+    value_type alpha = 1.0, beta = 0.0;   
+    typedef ParamTag<Trans::NoTranspose,Trans::NoTranspose> param_tag_type;
+
+    Functor_BatchedTeamGemm<DeviceType,ViewType,value_type,
+      param_tag_type,AlgoTagType>(alpha, a0, x0, beta, b).run();
+
+    Functor_BatchedTeamLU<DeviceType,ViewType,AlgoTagType>(a1).run();
+	
+    Functor_TestBatchedTeamSolveLU<DeviceType,ViewType,AlgoTagType,Trans::NoTranspose>(a1,b).run();
+
+    Kokkos::fence();
+
+    //Transpose
+    typedef ParamTag<Trans::Transpose,Trans::NoTranspose> param_tag_type_T;
+
+    Functor_BatchedTeamGemm<DeviceType,ViewType,value_type,
+      param_tag_type_T,AlgoTagType>(alpha, a0_T, x0, beta, b_T).run();
+
+    Functor_TestBatchedTeamSolveLU<DeviceType,ViewType,AlgoTagType,Trans::Transpose>(a1,b_T).run();
+
+    Kokkos::fence();
+
+    /// for comparison send it to host
+    typename ViewType::HostMirror x0_host = Kokkos::create_mirror_view(x0);
+    typename ViewType::HostMirror b_host  = Kokkos::create_mirror_view(b);
+    typename ViewType::HostMirror b_T_host = Kokkos::create_mirror_view(b_T);
+
+    Kokkos::deep_copy(x0_host, x0);
+    Kokkos::deep_copy(b_host, b);
+    Kokkos::deep_copy(b_T_host, b_T);
+	
+    /// check x0 = b ; this eps is about 10^-14
+    typedef typename ats::mag_type mag_type;
+    mag_type sum(1), diff(0);
+    const mag_type eps = 1.0e3 * ats::epsilon();
+
+    for (int k=0;k<N;++k)
+      for (int i=0;i<BlkSize;++i)
+        for (int j=0;j<5;++j) {
+          sum  += ats::abs(x0_host(k,i,j));
+          diff += ats::abs(x0_host(k,i,j)-b_host(k,i,j));
+        }
+    //printf("NoTranspose -- N=%d, BlkSize=%d, sum=%f, diff=%f\n", N, BlkSize, sum, diff);
+    EXPECT_NEAR_KK( diff/sum, 0.0, eps);
+	
+   /// check x0 = b_T ; this eps is about 10^-14
+    mag_type sum_T(1), diff_T(0);
+    
+    for (int k=0;k<N;++k)
+      for (int i=0;i<BlkSize;++i)
+        for (int j=0;j<5;++j) {
+          sum_T  += ats::abs(x0_host(k,i,j));
+          diff_T += ats::abs(x0_host(k,i,j)-b_T_host(k,i,j));
+        }
+    //printf("Transpose -- N=%d, BlkSize=%d, sum=%f, diff=%f\n", N, BlkSize, sum_T, diff_T);
+    EXPECT_NEAR_KK( diff_T/sum_T, 0.0, eps);
+  }
+}
+
+template<typename DeviceType,
+         typename ValueType,
+         typename AlgoTagType>
+int test_batched_solvelu() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
+  {
+    typedef Kokkos::View<ValueType***,Kokkos::LayoutLeft,DeviceType> ViewType;
+    Test::impl_test_batched_solvelu<DeviceType,ViewType,AlgoTagType>(     0, 10);
+    for (int i=0;i<10;++i) {                                                                                         
+      Test::impl_test_batched_solvelu<DeviceType,ViewType,AlgoTagType>(1024,  i);
+    }
+  }
+#endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
+  {
+    typedef Kokkos::View<ValueType***,Kokkos::LayoutRight,DeviceType> ViewType;
+    Test::impl_test_batched_solvelu<DeviceType,ViewType,AlgoTagType>(     0, 10);
+    for (int i=0;i<10;++i) {                                                                                        
+      Test::impl_test_batched_solvelu<DeviceType,ViewType,AlgoTagType>(1024,  i);
+    }
+  }
+#endif
+
+  return 0;
+}

--- a/unit_test/batched/Test_Batched_TeamSolveLU_Complex.hpp
+++ b/unit_test/batched/Test_Batched_TeamSolveLU_Complex.hpp
@@ -1,0 +1,9 @@
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
+TEST_F( TestCategory, batched_scalar_team_solvelu_dcomplex ) {
+  //printf("Batched team solveLU - double complex - algorithm type: Unblocked\n");
+  test_batched_solvelu<TestExecSpace,Kokkos::complex<double>,Algo::SolveLU::Unblocked>();
+  //printf("Batched team solveLU - double complex - algorithm type: Blocked\n");
+  test_batched_solvelu<TestExecSpace,Kokkos::complex<double>,Algo::SolveLU::Blocked>();
+}
+#endif

--- a/unit_test/batched/Test_Batched_TeamSolveLU_Real.hpp
+++ b/unit_test/batched/Test_Batched_TeamSolveLU_Real.hpp
@@ -1,0 +1,20 @@
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+TEST_F( TestCategory, batched_scalar_team_solvelu_float ) {
+  //printf("Batched team solveLU - float - algorithm type: Unblocked\n");
+  test_batched_solvelu<TestExecSpace,float,Algo::SolveLU::Unblocked>();
+  //printf("Batched team solveLU - float - algorithm type: Blocked\n");
+  test_batched_solvelu<TestExecSpace,float,Algo::SolveLU::Blocked>();
+}
+#endif
+
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+TEST_F( TestCategory, batched_scalar_team_solvelu_double ) {
+  //printf("Batched team solveLU - double - algorithm type: Unblocked\n");
+  test_batched_solvelu<TestExecSpace,double,Algo::SolveLU::Unblocked>();
+  //printf("Batched team solveLU - double - algorithm type: Blocked\n");
+  test_batched_solvelu<TestExecSpace,double,Algo::SolveLU::Blocked>();
+}
+#endif
+

--- a/unit_test/batched/Test_Batched_TeamTrsm_Complex.hpp
+++ b/unit_test/batched/Test_Batched_TeamTrsm_Complex.hpp
@@ -31,7 +31,27 @@ TEST_F( TestCategory, batched_scalar_team_trsm_r_u_nt_n_dcomplex_dcomplex ) {
   typedef Algo::Trsm::Blocked algo_tag_type;
   test_batched_trsm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
 }
-
+//
+TEST_F( TestCategory, batched_scalar_team_trsm_l_l_t_u_dcomplex_dcomplex ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::Unit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_team_trsm_l_l_t_n_dcomplex_dcomplex ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::NonUnit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_team_trsm_l_u_t_u_dcomplex_dcomplex ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::Unit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_team_trsm_l_u_t_n_dcomplex_dcomplex ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::NonUnit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+}
 
 
 TEST_F( TestCategory, batched_scalar_team_trsm_l_l_nt_u_dcomplex_double ) {
@@ -61,6 +81,27 @@ TEST_F( TestCategory, batched_scalar_team_trsm_r_u_nt_u_dcomplex_double ) {
 }
 TEST_F( TestCategory, batched_scalar_team_trsm_r_u_nt_n_dcomplex_double ) {
   typedef ::Test::ParamTag<Side::Right,Uplo::Upper,Trans::NoTranspose,Diag::NonUnit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,Kokkos::complex<double>,double,param_tag_type,algo_tag_type>();
+}
+//
+TEST_F( TestCategory, batched_scalar_team_trsm_l_l_t_u_dcomplex_double ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::Unit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,Kokkos::complex<double>,double,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_team_trsm_l_l_t_n_dcomplex_double ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::NonUnit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,Kokkos::complex<double>,double,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_team_trsm_l_u_t_u_dcomplex_double ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::Unit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,Kokkos::complex<double>,double,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_team_trsm_l_u_t_n_dcomplex_double ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trsm::Blocked algo_tag_type;
   test_batched_trsm<TestExecSpace,Kokkos::complex<double>,double,param_tag_type,algo_tag_type>();
 }

--- a/unit_test/batched/Test_Batched_TeamTrsm_Real.hpp
+++ b/unit_test/batched/Test_Batched_TeamTrsm_Real.hpp
@@ -30,6 +30,27 @@ TEST_F( TestCategory, batched_scalar_team_trsm_r_u_nt_n_float_float ) {
   typedef Algo::Trsm::Blocked algo_tag_type;
   test_batched_trsm<TestExecSpace,float,float,param_tag_type,algo_tag_type>();
 }
+//
+TEST_F( TestCategory, batched_scalar_team_trsm_l_l_t_u_float_float ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::Unit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,float,float,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_team_trsm_l_l_t_n_float_float ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::NonUnit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,float,float,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_team_trsm_l_u_t_u_float_float ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::Unit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,float,float,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_team_trsm_l_u_t_n_float_float ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::NonUnit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,float,float,param_tag_type,algo_tag_type>();
+}
 #endif
 
 
@@ -61,6 +82,27 @@ TEST_F( TestCategory, batched_scalar_team_trsm_r_u_nt_u_double_double ) {
 }
 TEST_F( TestCategory, batched_scalar_team_trsm_r_u_nt_n_double_double ) {
   typedef ::Test::ParamTag<Side::Right,Uplo::Upper,Trans::NoTranspose,Diag::NonUnit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,double,double,param_tag_type,algo_tag_type>();
+}
+//
+TEST_F( TestCategory, batched_scalar_team_trsm_l_l_t_u_double_double ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::Unit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,double,double,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_team_trsm_l_l_t_n_double_double ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::NonUnit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,double,double,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_team_trsm_l_u_t_u_double_double ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::Unit> param_tag_type;
+  typedef Algo::Trsm::Blocked algo_tag_type;
+  test_batched_trsm<TestExecSpace,double,double,param_tag_type,algo_tag_type>();
+}
+TEST_F( TestCategory, batched_scalar_team_trsm_l_u_t_n_double_double ) {
+  typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trsm::Blocked algo_tag_type;
   test_batched_trsm<TestExecSpace,double,double,param_tag_type,algo_tag_type>();
 }

--- a/unit_test/cuda/Test_Cuda_Batched_SerialSolveLU_Complex.cpp
+++ b/unit_test/cuda/Test_Cuda_Batched_SerialSolveLU_Complex.cpp
@@ -1,0 +1,3 @@
+#include "Test_Cuda.hpp"
+#include "Test_Batched_SerialSolveLU.hpp"
+#include "Test_Batched_SerialSolveLU_Complex.hpp"

--- a/unit_test/cuda/Test_Cuda_Batched_SerialSolveLU_Real.cpp
+++ b/unit_test/cuda/Test_Cuda_Batched_SerialSolveLU_Real.cpp
@@ -1,0 +1,3 @@
+#include "Test_Cuda.hpp"
+#include "Test_Batched_SerialSolveLU.hpp"
+#include "Test_Batched_SerialSolveLU_Real.hpp"

--- a/unit_test/cuda/Test_Cuda_Batched_TeamSolveLU_Complex.cpp
+++ b/unit_test/cuda/Test_Cuda_Batched_TeamSolveLU_Complex.cpp
@@ -1,0 +1,3 @@
+#include "Test_Cuda.hpp"
+#include "Test_Batched_TeamSolveLU.hpp"
+#include "Test_Batched_TeamSolveLU_Complex.hpp"

--- a/unit_test/cuda/Test_Cuda_Batched_TeamSolveLU_Real.cpp
+++ b/unit_test/cuda/Test_Cuda_Batched_TeamSolveLU_Real.cpp
@@ -1,0 +1,3 @@
+#include "Test_Cuda.hpp"
+#include "Test_Batched_TeamSolveLU.hpp"
+#include "Test_Batched_TeamSolveLU_Real.hpp"

--- a/unit_test/openmp/Test_OpenMP_Batched_SerialSolveLU_Complex.cpp
+++ b/unit_test/openmp/Test_OpenMP_Batched_SerialSolveLU_Complex.cpp
@@ -1,0 +1,3 @@
+#include "Test_OpenMP.hpp"
+#include "Test_Batched_SerialSolveLU.hpp"
+#include "Test_Batched_SerialSolveLU_Complex.hpp"

--- a/unit_test/openmp/Test_OpenMP_Batched_SerialSolveLU_Real.cpp
+++ b/unit_test/openmp/Test_OpenMP_Batched_SerialSolveLU_Real.cpp
@@ -1,0 +1,3 @@
+#include "Test_OpenMP.hpp"
+#include "Test_Batched_SerialSolveLU.hpp"
+#include "Test_Batched_SerialSolveLU_Real.hpp"

--- a/unit_test/openmp/Test_OpenMP_Batched_TeamSolveLU_Complex.cpp
+++ b/unit_test/openmp/Test_OpenMP_Batched_TeamSolveLU_Complex.cpp
@@ -1,0 +1,3 @@
+#include "Test_OpenMP.hpp"
+#include "Test_Batched_TeamSolveLU.hpp"
+#include "Test_Batched_TeamSolveLU_Complex.hpp"

--- a/unit_test/openmp/Test_OpenMP_Batched_TeamSolveLU_Real.cpp
+++ b/unit_test/openmp/Test_OpenMP_Batched_TeamSolveLU_Real.cpp
@@ -1,0 +1,3 @@
+#include "Test_OpenMP.hpp"
+#include "Test_Batched_TeamSolveLU.hpp"
+#include "Test_Batched_TeamSolveLU_Real.hpp"

--- a/unit_test/serial/Test_Serial_Batched_SerialSolveLU_Complex.cpp
+++ b/unit_test/serial/Test_Serial_Batched_SerialSolveLU_Complex.cpp
@@ -1,0 +1,3 @@
+#include "Test_Serial.hpp"
+#include "Test_Batched_SerialSolveLU.hpp"
+#include "Test_Batched_SerialSolveLU_Complex.hpp"

--- a/unit_test/serial/Test_Serial_Batched_SerialSolveLU_Real.cpp
+++ b/unit_test/serial/Test_Serial_Batched_SerialSolveLU_Real.cpp
@@ -1,0 +1,3 @@
+#include "Test_Serial.hpp"
+#include "Test_Batched_SerialSolveLU.hpp"
+#include "Test_Batched_SerialSolveLU_Real.hpp"

--- a/unit_test/serial/Test_Serial_Batched_TeamSolveLU_Complex.cpp
+++ b/unit_test/serial/Test_Serial_Batched_TeamSolveLU_Complex.cpp
@@ -1,0 +1,3 @@
+#include "Test_Serial.hpp"
+#include "Test_Batched_TeamSolveLU.hpp"
+#include "Test_Batched_TeamSolveLU_Complex.hpp"

--- a/unit_test/serial/Test_Serial_Batched_TeamSolveLU_Real.cpp
+++ b/unit_test/serial/Test_Serial_Batched_TeamSolveLU_Real.cpp
@@ -1,0 +1,3 @@
+#include "Test_Serial.hpp"
+#include "Test_Batched_TeamSolveLU.hpp"
+#include "Test_Batched_TeamSolveLU_Real.hpp"


### PR DESCRIPTION
Address #332: An implementation of batched ```getrs``` (serial and team) and unit tests.

Modified InverseLU (```getri```) such that it just calls SolveLU (```getrs```) with B as identity matrix.

Added new ```trsm``` interfaces to support ```transpose``` (not conjugate) operation in ```getrs``` and unit tests for these interfaces.
