### PR TITLE
Disable Pthreads in Gtest

### DIFF
--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -21,6 +21,8 @@ INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_CURRENT_SOURCE_
 #           the following relative path does not work or users should put kokkoskernels and kokkos
 #           at the same place
 SET(GTEST_SOURCE_DIR ${${PARENT_PACKAGE_NAME}_SOURCE_DIR}/../kokkos/tpls/gtest)
+# Disables pthreads, this is a problem for serial builds in Trilinos & Sierra if it's enabled.
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGTEST_HAS_PTHREAD=0")
 INCLUDE_DIRECTORIES(${GTEST_SOURCE_DIR})
 
 INCLUDE_DIRECTORIES(${GTEST_SOURCE_DIR})


### PR DESCRIPTION
This relates to the issue in Trilinos where serial builds were failing
because they tried to load the pthreads library as requested by gtest
in KokkosKernels.

This PR mirrors changes made in the Trilinos repository so that the next KokkosKernels push doesn't reintroduce the bug.

See: https://github.com/trilinos/Trilinos/issues/3773