### PR TITLE
Modify team gemm interface

### DIFF
--- a/src/batched/KokkosBatched_Gemm_Decl.hpp
+++ b/src/batched/KokkosBatched_Gemm_Decl.hpp
@@ -32,12 +32,12 @@ namespace KokkosBatched {
     /// Team Gemm
     ///
 
-    template<typename MemberType,
-             typename ArgTransA,
+    template<typename ArgTransA,
              typename ArgTransB,
              typename ArgAlgo>
     struct TeamGemm {
-      template<typename ScalarType,
+      template<typename MemberType,
+               typename ScalarType,
                typename AViewType,
                typename BViewType,
                typename CViewType>

--- a/src/batched/KokkosBatched_Gemm_Team_Impl.hpp
+++ b/src/batched/KokkosBatched_Gemm_Team_Impl.hpp
@@ -26,10 +26,11 @@ namespace KokkosBatched {
     /// NT/NT
     ///
     
-    template<typename MemberType>
-    struct TeamGemm<MemberType,Trans::NoTranspose,Trans::NoTranspose,Algo::Gemm::Unblocked> {
+    template<>
+    struct TeamGemm<Trans::NoTranspose,Trans::NoTranspose,Algo::Gemm::Unblocked> {
 
-      template<typename ScalarType,
+      template<typename MemberType,
+               typename ScalarType,
                typename AViewType,
                typename BViewType,
                typename CViewType>
@@ -54,9 +55,10 @@ namespace KokkosBatched {
       }
     };
     
-    template<typename MemberType>
-    struct TeamGemm<MemberType,Trans::NoTranspose,Trans::NoTranspose,Algo::Gemm::Blocked> {
-      template<typename ScalarType,
+    template<>
+    struct TeamGemm<Trans::NoTranspose,Trans::NoTranspose,Algo::Gemm::Blocked> {
+      template<typename MemberType,
+               typename ScalarType,
                typename AViewType,
                typename BViewType,
                typename CViewType>
@@ -85,10 +87,11 @@ namespace KokkosBatched {
     /// T/NT
     ///
     
-    template<typename MemberType>
-    struct TeamGemm<MemberType,Trans::Transpose,Trans::NoTranspose,Algo::Gemm::Unblocked> {
+    template<>
+    struct TeamGemm<Trans::Transpose,Trans::NoTranspose,Algo::Gemm::Unblocked> {
 
-      template<typename ScalarType,
+      template<typename MemberType,
+               typename ScalarType,
                typename AViewType,
                typename BViewType,
                typename CViewType>
@@ -113,9 +116,10 @@ namespace KokkosBatched {
       }
     };
     
-    template<typename MemberType>
-    struct TeamGemm<MemberType,Trans::Transpose,Trans::NoTranspose,Algo::Gemm::Blocked> {
-      template<typename ScalarType,
+    template<>
+    struct TeamGemm<Trans::Transpose,Trans::NoTranspose,Algo::Gemm::Blocked> {
+      template<typename MemberType,
+               typename ScalarType,
                typename AViewType,
                typename BViewType,
                typename CViewType>
@@ -144,10 +148,11 @@ namespace KokkosBatched {
     /// NT/T
     ///
     
-    template<typename MemberType>
-    struct TeamGemm<MemberType,Trans::NoTranspose,Trans::Transpose,Algo::Gemm::Unblocked> {
+    template<>
+    struct TeamGemm<Trans::NoTranspose,Trans::Transpose,Algo::Gemm::Unblocked> {
 
-      template<typename ScalarType,
+      template<typename MemberType,
+               typename ScalarType,
                typename AViewType,
                typename BViewType,
                typename CViewType>
@@ -172,9 +177,10 @@ namespace KokkosBatched {
       }
     };
     
-    template<typename MemberType>
-    struct TeamGemm<MemberType,Trans::NoTranspose,Trans::Transpose,Algo::Gemm::Blocked> {
-      template<typename ScalarType,
+    template<>
+    struct TeamGemm<Trans::NoTranspose,Trans::Transpose,Algo::Gemm::Blocked> {
+      template<typename MemberType,
+               typename ScalarType,
                typename AViewType,
                typename BViewType,
                typename CViewType>
@@ -203,10 +209,11 @@ namespace KokkosBatched {
     /// T/T
     ///
     
-    template<typename MemberType>
-    struct TeamGemm<MemberType,Trans::Transpose,Trans::Transpose,Algo::Gemm::Unblocked> {
+    template<>
+    struct TeamGemm<Trans::Transpose,Trans::Transpose,Algo::Gemm::Unblocked> {
 
-      template<typename ScalarType,
+      template<typename MemberType,
+               typename ScalarType,
                typename AViewType,
                typename BViewType,
                typename CViewType>
@@ -231,9 +238,10 @@ namespace KokkosBatched {
       }
     };
     
-    template<typename MemberType>
-    struct TeamGemm<MemberType,Trans::Transpose,Trans::Transpose,Algo::Gemm::Blocked> {
-      template<typename ScalarType,
+    template<>
+    struct TeamGemm<Trans::Transpose,Trans::Transpose,Algo::Gemm::Blocked> {
+      template<typename MemberType,
+               typename ScalarType,
                typename AViewType,
                typename BViewType,
                typename CViewType>

--- a/unit_test/batched/Test_Batched_TeamGemm.hpp
+++ b/unit_test/batched/Test_Batched_TeamGemm.hpp
@@ -49,8 +49,7 @@ namespace Test {
       auto bb = Kokkos::subview(_b, k, Kokkos::ALL(), Kokkos::ALL());
       auto cc = Kokkos::subview(_c, k, Kokkos::ALL(), Kokkos::ALL());
       
-      TeamGemm<MemberType,
-        typename ParamTagType::transA,
+      TeamGemm<typename ParamTagType::transA,
         typename ParamTagType::transB,
         AlgoTagType>::
         invoke(member, _alpha, aa, bb, _beta, cc);

--- a/unit_test/batched/Test_Batched_TeamInverseLU.hpp
+++ b/unit_test/batched/Test_Batched_TeamInverseLU.hpp
@@ -58,8 +58,7 @@ namespace Test {
       }
       member.team_barrier();
 	  
-      TeamGemm<MemberType,
-        typename ParamTagType::transA,
+      TeamGemm<typename ParamTagType::transA,
         typename ParamTagType::transB,
         AlgoTagType>::
         invoke(member, _alpha, aa, bb, _beta, cc);


### PR DESCRIPTION
I moved TeamGemm's MemberType template parameter from the class-template level the function-template level. This template parameter can always be deduced and thus should not need to be explicitely specified by the user. This change also allows SerialGemm and TeamGemm to have the same interface. I suspect other class templates like TeamGemv can also be changed.

The use case for this is I want to be able to pass SerialGemm and TeamGemm as policy classes for a Gemm policy. In order for this to be possible, the interfaces must match. With these changes, each class template shares the same three class-level template parameters.

I did the following steps, with no errors:
```
make install-lib -j16
cd unit_test
make -j
```