### PR TITLE
Profiling Labels

### DIFF
--- a/perf_test/batched/KokkosBatched_Test_Gemm_Cuda.cpp
+++ b/perf_test/batched/KokkosBatched_Test_Gemm_Cuda.cpp
@@ -74,8 +74,7 @@ namespace KokkosBatched {
         void operator()(const TeamTagV1 &, const MemberType &member) const {
           const int kbeg = (member.league_rank()*(member.team_size()*VectorLength) +
                             member.team_rank()*VectorLength);
-          Kokkos::parallel_for
-            (Kokkos::ThreadVectorRange(member, VectorLength),
+          Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, VectorLength),
              [&](const int &k) {
               const int kk = kbeg + k;
               if (kk < int(_c.extent(0))) {
@@ -93,8 +92,7 @@ namespace KokkosBatched {
         KOKKOS_INLINE_FUNCTION
         void operator()(const TeamTagV2 &, const MemberType &member) const {
           const int kbeg = member.league_rank()*VectorLength;
-          Kokkos::parallel_for
-            (Kokkos::ThreadVectorRange(member, VectorLength),
+          Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, VectorLength),
              [&](const int &k) {
               const int kk = kbeg + k;
               if (kk < int(_c.extent(0))) {
@@ -116,8 +114,7 @@ namespace KokkosBatched {
           ScratchViewType<ViewType> sb(member.team_scratch(lvl), VectorLength, _b.extent(1), _b.extent(2));
 
           const int kbeg = member.league_rank()*VectorLength;
-          Kokkos::parallel_for
-            (Kokkos::ThreadVectorRange(member, VectorLength),
+          Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, VectorLength),
              [&](const int &k) {
               const int kk = kbeg + k;
               if (kk < int(_c.extent(0))) {                  
@@ -142,14 +139,12 @@ namespace KokkosBatched {
         KOKKOS_INLINE_FUNCTION
         void operator()(const TeamTagHandmade &, const MemberType &member) const {
           const int kbeg = member.league_rank()*VectorLength;
-          Kokkos::parallel_for
-            (Kokkos::ThreadVectorRange(member, VectorLength),
+          Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, VectorLength),
              [&](const int &k) {
               const int kk = kbeg + k;
               if (kk < int(_c.extent(0))) {
                 const int m = _c.extent(1), n = _c.extent(2), q = _a.extent(2);
-                Kokkos::parallel_for
-                  (Kokkos::TeamThreadRange(member,0,m*n),
+                Kokkos::parallel_for(Kokkos::TeamThreadRange(member,0,m*n),
                    [&](const int &ij) {
                     const int i = ij%m, j = ij/m;                              
                     typename ViewType::non_const_value_type cval = 0;
@@ -315,7 +310,7 @@ namespace KokkosBatched {
               DeviceSpaceType::fence();
               timer.reset();
 
-              Kokkos::parallel_for("GEMM: RangePolicy version", policy, functor_type(a,b,c));
+              Kokkos::parallel_for("KokkosBatched::PerfTest::GemmCuda::RangeTag", policy, functor_type(a,b,c));
                 
               DeviceSpaceType::fence();
               const double t = timer.seconds();
@@ -382,7 +377,7 @@ namespace KokkosBatched {
               DeviceSpaceType::fence();
               timer.reset();
 
-              Kokkos::parallel_for("GEMM: TeamPolicy version 1", policy,functor_type(a,b,c));
+              Kokkos::parallel_for("KokkosBatched::PerfTest::GemmCuda::TeamPolicyV1", policy,functor_type(a,b,c));
                 
               DeviceSpaceType::fence();
               const double t = timer.seconds();
@@ -455,7 +450,7 @@ namespace KokkosBatched {
               DeviceSpaceType::fence();
               timer.reset();
 
-              Kokkos::parallel_for("GEMM: TeamPolicy version 2", policy, functor_type(a,b,c));
+              Kokkos::parallel_for("KokkosBatched::PerfTest::GemmCuda::TeamPolicyV2", policy, functor_type(a,b,c));
                 
               DeviceSpaceType::fence();
               const double t = timer.seconds();
@@ -532,7 +527,7 @@ namespace KokkosBatched {
                 DeviceSpaceType::fence();
                 timer.reset();
 
-                Kokkos::parallel_for("GEMM: TeamPolicy version 3", policy, functor_type(a,b,c));
+                Kokkos::parallel_for("KokkosBatched::PerfTest::GemmCuda::TeamPolicyV3", policy, functor_type(a,b,c));
                 
                 DeviceSpaceType::fence();
                 const double t = timer.seconds();
@@ -604,7 +599,7 @@ namespace KokkosBatched {
               DeviceSpaceType::fence();
               timer.reset();
 
-              Kokkos::parallel_for("GEMM: TeamPolicy handmade", policy, functor_type(a,b,c));
+              Kokkos::parallel_for("KokkosBatched::PerfTest::GemmCuda::TeamPolicyHandmade", policy, functor_type(a,b,c));
                 
               DeviceSpaceType::fence();
               const double t = timer.seconds();

--- a/perf_test/batched/KokkosBatched_Test_Gemm_Host.hpp
+++ b/perf_test/batched/KokkosBatched_Test_Gemm_Host.hpp
@@ -87,8 +87,8 @@ namespace KokkosBatched {
           amat_simd("amat_simd", N, BlkSize, BlkSize),
           bmat_simd("bmat_simd", N, BlkSize, BlkSize);
 
-        Kokkos::parallel_for
-          (Kokkos::RangePolicy<HostSpaceType>(0, N*VectorLength),
+        Kokkos::parallel_for("KokkosBatched::PerfTest::GemmHost::Pack",
+           Kokkos::RangePolicy<HostSpaceType>(0, N*VectorLength),
            KOKKOS_LAMBDA(const int k) {
             const int k0 = k/VectorLength, k1 = k%VectorLength;
             for (int i=0;i<BlkSize;++i)
@@ -128,8 +128,8 @@ namespace KokkosBatched {
               HostSpaceType::fence();
               timer.reset();
 
-              Kokkos::parallel_for
-                (policy, 
+              Kokkos::parallel_for("KokkosBatched::PerfTest::GemmHost::CblasOpenMP",
+                 policy, 
                  KOKKOS_LAMBDA(const int k) {
                   auto aa = Kokkos::subview(a, k, Kokkos::ALL(), Kokkos::ALL());
                   auto bb = Kokkos::subview(b, k, Kokkos::ALL(), Kokkos::ALL());
@@ -385,8 +385,8 @@ namespace KokkosBatched {
               HostSpaceType::fence();
               timer.reset();
 
-              Kokkos::parallel_for
-                (policy, 
+              Kokkos::parallel_for("KokkosBatched::PerfTest::GemmHost::libxswmmOpenMP",
+                 policy, 
                  KOKKOS_LAMBDA(const int k) {
                   auto aa = Kokkos::subview(a, k, Kokkos::ALL(), Kokkos::ALL());
                   auto bb = Kokkos::subview(b, k, Kokkos::ALL(), Kokkos::ALL());
@@ -515,8 +515,8 @@ namespace KokkosBatched {
               HostSpaceType::fence();
               timer.reset();
 
-              Kokkos::parallel_for
-                (policy, 
+              Kokkos::parallel_for("KokkosBatched::PerfTest::GemmHost::SIMDSerialOpenMP",
+                 policy, 
                  KOKKOS_LAMBDA(const int k) {
                   auto aa = Kokkos::subview(a, k, Kokkos::ALL(), Kokkos::ALL());
                   auto bb = Kokkos::subview(b, k, Kokkos::ALL(), Kokkos::ALL());

--- a/perf_test/batched/KokkosBatched_Test_Gemv_Host.hpp
+++ b/perf_test/batched/KokkosBatched_Test_Gemv_Host.hpp
@@ -114,8 +114,8 @@ namespace KokkosBatched {
               HostSpaceType::fence();
               timer.reset();
             
-              Kokkos::parallel_for
-                (policy, 
+              Kokkos::parallel_for("KokkosBatched::PerfTest::GemvHost::CblasOpenMP",
+                 policy, 
                  KOKKOS_LAMBDA(const int k) {
                   auto aa = Kokkos::subview(a, k, Kokkos::ALL(), Kokkos::ALL());
                   for (int j=0;j<NumVecs;++j) {
@@ -174,8 +174,8 @@ namespace KokkosBatched {
               HostSpaceType::fence();
               timer.reset();
 
-              Kokkos::parallel_for
-                (policy, 
+              Kokkos::parallel_for("KokkosBatched::PerfTest::GemvHost::SerialOpenMP",
+                 policy, 
                  KOKKOS_LAMBDA(const int k) {
                   auto aa = Kokkos::subview(a, k, Kokkos::ALL(), Kokkos::ALL());
 
@@ -249,8 +249,8 @@ namespace KokkosBatched {
               HostSpaceType::fence();
               timer.reset();
 
-              Kokkos::parallel_for
-                (policy, 
+              Kokkos::parallel_for("KokkosBatched::PerfTest::GemvHost::SIMDSerialOpenMP",
+                 policy, 
                  KOKKOS_LAMBDA(const int k) {
                   auto aa = Kokkos::subview(a, k, Kokkos::ALL(), Kokkos::ALL());
 

--- a/perf_test/batched/KokkosBatched_Test_LU_Cuda.cpp
+++ b/perf_test/batched/KokkosBatched_Test_LU_Cuda.cpp
@@ -286,7 +286,7 @@ namespace KokkosBatched {
               DeviceSpaceType::fence();
               timer.reset();
 
-              Kokkos::parallel_for(policy, functor_type(a));
+              Kokkos::parallel_for("KokkosBatched::PerfTest::LUCuda::RangeTag", policy, functor_type(a));
 
               DeviceSpaceType::fence();
               const double t = timer.seconds();
@@ -345,7 +345,7 @@ namespace KokkosBatched {
               DeviceSpaceType::fence();
               timer.reset();
 
-              Kokkos::parallel_for(policy, functor_type(a));
+              Kokkos::parallel_for("KokkosBatched::PerfTest::LUCuda::TeamTagV1", policy, functor_type(a));
 
               DeviceSpaceType::fence();
               const double t = timer.seconds();
@@ -414,7 +414,7 @@ namespace KokkosBatched {
               DeviceSpaceType::fence();
               timer.reset();
 
-              Kokkos::parallel_for(policy, functor_type(a));
+              Kokkos::parallel_for("KokkosBatched::PerfTest::LUCuda::TeamTagV2", policy, functor_type(a));
 
               DeviceSpaceType::fence();
               const double t = timer.seconds();
@@ -486,7 +486,7 @@ namespace KokkosBatched {
                 DeviceSpaceType::fence();
                 timer.reset();
 
-                Kokkos::parallel_for(policy.set_scratch_size(lvl, Kokkos::PerTeam(per_team_scratch)),
+                Kokkos::parallel_for("KokkosBatched::PerfTest::LUCuda::TeamTagV3", policy.set_scratch_size(lvl, Kokkos::PerTeam(per_team_scratch)),
                                      functor_type(a));
 
                 DeviceSpaceType::fence();

--- a/perf_test/batched/KokkosBatched_Test_LU_Host.hpp
+++ b/perf_test/batched/KokkosBatched_Test_LU_Host.hpp
@@ -102,8 +102,8 @@ namespace KokkosBatched {
         Kokkos::View<VectorType***,Kokkos::LayoutRight,HostSpaceType>
           amat_simd("amat_simd", N, BlkSize, BlkSize); //, a("a", N, BlkSize, BlkSize);
       
-        Kokkos::parallel_for
-          (Kokkos::RangePolicy<HostSpaceType>(0, N*VectorLength),
+        Kokkos::parallel_for("KokkosBatched::PerfTest::LUHost::Pack", 
+           Kokkos::RangePolicy<HostSpaceType>(0, N*VectorLength),
            KOKKOS_LAMBDA(const int k) {
             const int k0 = k/VectorLength, k1 = k%VectorLength;
             for (int i=0;i<BlkSize;++i)
@@ -136,8 +136,8 @@ namespace KokkosBatched {
               timer.reset();
 
               Kokkos::RangePolicy<HostSpaceType,ScheduleType> policy(0, N*VectorLength);
-              Kokkos::parallel_for
-                (policy,
+              Kokkos::parallel_for("KokkosBatched::PerfTest::LUHost::LAPACKE_dgetrfOpenMP", 
+                 policy,
                  KOKKOS_LAMBDA(const int k) {
                   auto aa = Kokkos::subview(a, k, Kokkos::ALL(), Kokkos::ALL());
                   auto pp = Kokkos::subview(p, k, Kokkos::ALL());
@@ -295,8 +295,8 @@ namespace KokkosBatched {
               timer.reset();
 
               Kokkos::RangePolicy<HostSpaceType,ScheduleType > policy(0, N);
-              Kokkos::parallel_for
-                (policy,
+              Kokkos::parallel_for("KokkosBatched::PerfTest::LUHost::SIMDSerialOpenMP", 
+                 policy,
                  KOKKOS_LAMBDA(const int k) {
                   auto aa = Kokkos::subview(a, k, Kokkos::ALL(), Kokkos::ALL());
 

--- a/perf_test/batched/KokkosBatched_Test_Trsm_Cuda.cpp
+++ b/perf_test/batched/KokkosBatched_Test_Trsm_Cuda.cpp
@@ -477,7 +477,7 @@ namespace KokkosBatched {
               DeviceSpaceType::fence();
               timer.reset();
             
-              Kokkos::parallel_for(policy, functor_type(a, b));
+              Kokkos::parallel_for("KokkosBatched::PerfTest::RangeTag", policy, functor_type(a, b));
 
               DeviceSpaceType::fence();
               const double t = timer.seconds();
@@ -540,7 +540,7 @@ namespace KokkosBatched {
               DeviceSpaceType::fence();
               timer.reset();
             
-              Kokkos::parallel_for(policy, functor_type(a, b));
+              Kokkos::parallel_for("KokkosBatched::PerfTest::TeamTagV1", policy, functor_type(a, b));
 
               DeviceSpaceType::fence();
               const double t = timer.seconds();
@@ -612,7 +612,7 @@ namespace KokkosBatched {
               DeviceSpaceType::fence();
               timer.reset();
             
-              Kokkos::parallel_for(policy, functor_type(a, b));
+              Kokkos::parallel_for("KokkosBatched::PerfTest::TeamTagV2", policy, functor_type(a, b));
 
               DeviceSpaceType::fence();
               const double t = timer.seconds();
@@ -689,7 +689,7 @@ namespace KokkosBatched {
                 DeviceSpaceType::fence();
                 timer.reset();
             
-                Kokkos::parallel_for(policy, functor_type(a, b));
+                Kokkos::parallel_for("KokkosBatched::PerfTest::TeamTagV3", policy, functor_type(a, b));
 
                 DeviceSpaceType::fence();
                 const double t = timer.seconds();

--- a/perf_test/batched/KokkosBatched_Test_Trsm_Host.hpp
+++ b/perf_test/batched/KokkosBatched_Test_Trsm_Host.hpp
@@ -153,8 +153,7 @@ namespace KokkosBatched {
               timer.reset();
 
               Kokkos::RangePolicy<HostSpaceType,ScheduleType> policy(0, N*VectorLength);
-              Kokkos::parallel_for
-                (policy,
+              Kokkos::parallel_for("KokkosBatched::PerfTest::TrsmHost::MKLOpenMP", policy,
                  KOKKOS_LAMBDA(const int k) {
                   auto aa = Kokkos::subview(a, k, Kokkos::ALL(), Kokkos::ALL());
                   auto bb = Kokkos::subview(b, k, Kokkos::ALL(), Kokkos::ALL());
@@ -600,8 +599,8 @@ namespace KokkosBatched {
               timer.reset();
 
               Kokkos::RangePolicy<HostSpaceType,ScheduleType> policy(0, N);
-              Kokkos::parallel_for
-                (policy,
+              Kokkos::parallel_for("KokkosBatched::PerfTest::TrsmHost::SIMDSerialOpenMP", 
+                 policy,
                  KOKKOS_LAMBDA(const int k) {
                   auto aa = Kokkos::subview(a, k, Kokkos::ALL(), Kokkos::ALL());
                   auto bb = Kokkos::subview(b, k, Kokkos::ALL(), Kokkos::ALL());

--- a/perf_test/graph/KokkosGraph_run_triangle.hpp
+++ b/perf_test/graph/KokkosGraph_run_triangle.hpp
@@ -151,7 +151,7 @@ struct Flush {
 
   void run() {
     double sum = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<SpaceType>(0,BufSize/sizeof(double)), *this, sum);
+    Kokkos::parallel_reduce("KokkosGraph::PerfTest::Flush", Kokkos::RangePolicy<SpaceType>(0,BufSize/sizeof(double)), *this, sum);
     SpaceType::fence();
     std::cout << "Flush sum:" << sum << std::endl;
     FILE *fp = fopen("/dev/null", "w");

--- a/perf_test/sparse/spmv/Kokkos_SPMV.hpp
+++ b/perf_test/sparse/spmv/Kokkos_SPMV.hpp
@@ -186,7 +186,7 @@ void kk_matvec(AType A, XType x, YType y, int rows_per_thread, int team_size, in
   else
     policy = Kokkos::TeamPolicy<Kokkos::Schedule<ScheduleType> >(worksets,Kokkos::AUTO,vector_length);
 
-  Kokkos::parallel_for(policy,func);
+  Kokkos::parallel_for("KokkosSparse::PerfTest::SpMV", policy,func);
 }
 
 

--- a/perf_test/sparse/spmv/Kokkos_SPMV_Inspector.hpp
+++ b/perf_test/sparse/spmv/Kokkos_SPMV_Inspector.hpp
@@ -164,7 +164,7 @@ void kk_inspector_matvec(AType A, XType x, YType y, int rows_per_thread, int tea
   else
     policy = Kokkos::TeamPolicy<Kokkos::Schedule<Schedule> >(worksets,Kokkos::AUTO,vector_length);
 
-  Kokkos::parallel_for(policy,func);
+  Kokkos::parallel_for("KokkosSparse::PerfTest::SpMV_Inspector", policy,func);
 }
 
 

--- a/src/blas/KokkosBlas1_fill.hpp
+++ b/src/blas/KokkosBlas1_fill.hpp
@@ -56,7 +56,9 @@ namespace KokkosBlas {
 /// \param val [in] Value with which to fill the entries of X.
 template<class XMV>
 void fill (const XMV& X, const typename XMV::non_const_value_type& val) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::fill");
   Kokkos::deep_copy(X,val);
+  Kokkos::Profiling::popRegion();
 }
 
 }

--- a/src/blas/impl/KokkosBlas1_abs_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_abs_impl.hpp
@@ -199,11 +199,11 @@ MV_Abs_Generic (const RMV& R, const XMV& X)
 
   if (R == X) { // if R and X are the same (alias one another)
     MV_AbsSelf_Functor<RMV, SizeType> op (R);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Abs::S0", policy, op);
   }
   else {
     MV_Abs_Functor<RMV, XMV, SizeType> op (R, X);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Abs::S1", policy, op);
   }
 }
 
@@ -227,11 +227,11 @@ V_Abs_Generic (const RV& R, const XV& X)
 
   if (R == X) { // if R and X are the same (alias one another)
     V_AbsSelf_Functor<RV, SizeType> op (R);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Abs::S2", policy, op);
   }
   else {
     V_Abs_Functor<RV, XV, SizeType> op (R, X);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Abs::S3", policy, op);
   }
 }
 

--- a/src/blas/impl/KokkosBlas1_abs_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_abs_spec.hpp
@@ -127,7 +127,7 @@ struct Abs<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "RMV is not rank 1.");
     static_assert (XMV::rank == 1, "KokkosBlas::Impl::Abs<1-D>: "
                    "XMV is not rank 1.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::abs[ETI]":"KokkosBlas::abs[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::abs[ETI]":"KokkosBlas::abs[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::abs<> ETI specialization for < %s , %s >\n",typeid(RMV).name(),typeid(XMV).name());
@@ -163,7 +163,7 @@ struct Abs<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
                    "RMV is not rank 2.");
     static_assert (XMV::rank == 2, "KokkosBlas::Impl::Abs<2-D>: "
                    "XMV is not rank 2.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::abs[ETI]":"KokkosBlas::abs[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::abs[ETI]":"KokkosBlas::abs[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::abs<> ETI specialization for < %s , %s >\n",typeid(RMV).name(),typeid(XMV).name());

--- a/src/blas/impl/KokkosBlas1_abs_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_abs_spec.hpp
@@ -127,7 +127,7 @@ struct Abs<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "RMV is not rank 1.");
     static_assert (XMV::rank == 1, "KokkosBlas::Impl::Abs<1-D>: "
                    "XMV is not rank 1.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::abs[ETI]":"KokkosBlas::abs[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::abs<> ETI specialization for < %s , %s >\n",typeid(RMV).name(),typeid(XMV).name());
@@ -145,9 +145,10 @@ struct Abs<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
       typedef std::int64_t index_type;
       V_Abs_Generic<RMV, XMV, index_type> (R, X);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
-
+  
 template<class RMV, class XMV>
 struct Abs<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
@@ -162,7 +163,7 @@ struct Abs<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
                    "RMV is not rank 2.");
     static_assert (XMV::rank == 2, "KokkosBlas::Impl::Abs<2-D>: "
                    "XMV is not rank 2.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::abs[ETI]":"KokkosBlas::abs[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::abs<> ETI specialization for < %s , %s >\n",typeid(RMV).name(),typeid(XMV).name());
@@ -182,6 +183,7 @@ struct Abs<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
       typedef std::int64_t index_type;
       MV_Abs_Generic<RMV, XMV, index_type> (R, X);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 #endif

--- a/src/blas/impl/KokkosBlas1_axpby_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_axpby_impl.hpp
@@ -352,26 +352,26 @@ Axpby_Generic (const AV& av, const XV& x,
 
   if (a == 0 && b == 0) {
     Axpby_Functor<AV, XV, BV, YV, 0, 0, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::S0", policy, op);
     return;
   }
 
 #if KOKKOSBLAS_OPTIMIZATION_LEVEL_AXPBY > 2
   if (a == 0 && b == -1) {
     Axpby_Functor<AV, XV, BV, YV, 0, -1, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::S1", policy, op);
     return;
   }
   if (a == 0 && b == 1) {
     Axpby_Functor<AV, XV, BV, YV, 0, 1, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::S2", policy, op);
     return;
   }
 #endif // KOKKOSBLAS_OPTIMIZATION_LEVEL_AXPBY > 2
 
   if (a == 0 && b == 2) {
     Axpby_Functor<AV, XV, BV, YV, 0, 2, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::S3", policy, op);
     return;
   }
 
@@ -379,43 +379,43 @@ Axpby_Generic (const AV& av, const XV& x,
   // a == -1
   if (a == -1 && b == 0) {
     Axpby_Functor<AV, XV, BV, YV, -1, 0, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::S4", policy, op);
     return;
   }
   if (a == -1 && b == -1) {
     Axpby_Functor<AV, XV, BV, YV, -1, -1, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::S5", policy, op);
     return;
   }
   if (a == -1 && b == 1) {
     Axpby_Functor<AV, XV, BV, YV, -1, 1, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::S6", policy, op);
     return;
   }
   if (a == -1 && b == 2) {
     Axpby_Functor<AV, XV, BV, YV, -1, 2, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::S7", policy, op);
     return;
   }
   // a == 1
   if (a == 1 && b == 0) {
     Axpby_Functor<AV, XV, BV, YV, 1, 0, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::S8", policy, op);
     return;
   }
   if (a == 1 && b == -1) {
     Axpby_Functor<AV, XV, BV, YV, 1, -1, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::S9", policy, op);
     return;
   }
   if (a == 1 && b == 1) {
     Axpby_Functor<AV, XV, BV, YV, 1, 1, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::S10", policy, op);
     return;
   }
   if (a == 1 && b == 2) {
     Axpby_Functor<AV, XV, BV, YV, 1, 2, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::S11", policy, op);
     return;
   }
 #endif // KOKKOSBLAS_OPTIMIZATION_LEVEL_AXPBY > 2
@@ -423,26 +423,26 @@ Axpby_Generic (const AV& av, const XV& x,
   // a == 2
   if (a == 2 && b == 0) {
     Axpby_Functor<AV, XV, BV, YV, 2, 0, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::S12", policy, op);
     return;
   }
 
 #if KOKKOSBLAS_OPTIMIZATION_LEVEL_AXPBY > 2
   if (a == 2 && b == -1) {
     Axpby_Functor<AV, XV, BV, YV, 2, -1, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::S13", policy, op);
     return;
   }
   if (a == 2 && b == 1) {
     Axpby_Functor<AV, XV, BV, YV, 2, 1, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::S14", policy, op);
     return;
   }
 #endif // KOKKOSBLAS_OPTIMIZATION_LEVEL_AXPBY > 2
 
   // a and b arbitrary (not -1, 0, or 1)
   Axpby_Functor<AV, XV, BV, YV, 2, 2, SizeType> op (x, y, av, bv, startingColumn);
-  Kokkos::parallel_for (policy, op);
+  Kokkos::parallel_for ("KokkosBlas::Axpby::S15", policy, op);
 }
 
 }

--- a/src/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
@@ -996,26 +996,26 @@ Axpby_MV_Unrolled (const AV& av, const XMV& x,
 
   if (a == 0 && b == 0) {
     Axpby_MV_Unroll_Functor<AV, XMV, BV, YMV, 0, 0, UNROLL, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S0", policy, op);
     return;
   }
 
 #if KOKKOSBLAS_OPTIMIZATION_LEVEL_AXPBY > 2
   if (a == 0 && b == -1) {
     Axpby_MV_Unroll_Functor<AV, XMV, BV, YMV, 0, -1, UNROLL, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S1", policy, op);
     return;
   }
   if (a == 0 && b == 1) {
     Axpby_MV_Unroll_Functor<AV, XMV, BV, YMV, 0, 1, UNROLL, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S2", policy, op);
     return;
   }
 #endif // KOKKOSBLAS_OPTIMIZATION_LEVEL_AXPBY
 
   if (a == 0 && b == 2) {
     Axpby_MV_Unroll_Functor<AV, XMV, BV, YMV, 0, 2, UNROLL, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S3", policy, op);
     return;
   }
 
@@ -1023,43 +1023,43 @@ Axpby_MV_Unrolled (const AV& av, const XMV& x,
   // a == -1
   if (a == -1 && b == 0) {
     Axpby_MV_Unroll_Functor<AV, XMV, BV, YMV, -1, 0, UNROLL, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S4", policy, op);
     return;
   }
   if (a == -1 && b == -1) {
     Axpby_MV_Unroll_Functor<AV, XMV, BV, YMV, -1, -1, UNROLL, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S5", policy, op);
     return;
   }
   if (a == -1 && b == 1) {
     Axpby_MV_Unroll_Functor<AV, XMV, BV, YMV, -1, 1, UNROLL, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S6", policy, op);
     return;
   }
   if (a == -1 && b == 2) {
     Axpby_MV_Unroll_Functor<AV, XMV, BV, YMV, -1, 2, UNROLL, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S7", policy, op);
     return;
   }
   // a == 1
   if (a == 1 && b == 0) {
     Axpby_MV_Unroll_Functor<AV, XMV, BV, YMV, 1, 0, UNROLL, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S8", policy, op);
     return;
   }
   if (a == 1 && b == -1) {
     Axpby_MV_Unroll_Functor<AV, XMV, BV, YMV, 1, -1, UNROLL, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S9", policy, op);
     return;
   }
   if (a == 1 && b == 1) {
     Axpby_MV_Unroll_Functor<AV, XMV, BV, YMV, 1, 1, UNROLL, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S10", policy, op);
     return;
   }
   if (a == 1 && b == 2) {
     Axpby_MV_Unroll_Functor<AV, XMV, BV, YMV, 1, 2, UNROLL, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S11", policy, op);
     return;
   }
 #endif // KOKKOSBLAS_OPTIMIZATION_LEVEL_AXPBY > 2
@@ -1067,26 +1067,26 @@ Axpby_MV_Unrolled (const AV& av, const XMV& x,
   // a == 2
   if (a == 2 && b == 0) {
     Axpby_MV_Unroll_Functor<AV, XMV, BV, YMV, 2, 0, UNROLL, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S12", policy, op);
     return;
   }
 
 #if KOKKOSBLAS_OPTIMIZATION_LEVEL_AXPBY > 2
   if (a == 2 && b == -1) {
     Axpby_MV_Unroll_Functor<AV, XMV, BV, YMV, 2, -1, UNROLL, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S13", policy, op);
     return;
   }
   if (a == 2 && b == 1) {
     Axpby_MV_Unroll_Functor<AV, XMV, BV, YMV, 2, 1, UNROLL, SizeType> op (x, y, av, bv, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S14", policy, op);
     return;
   }
 #endif // KOKKOSBLAS_OPTIMIZATION_LEVEL_AXPBY > 2
 
   // a and b arbitrary (not -1, 0, or 1)
   Axpby_MV_Unroll_Functor<AV, XMV, BV, YMV, 2, 2, UNROLL, SizeType> op (x, y, av, bv, startingColumn);
-  Kokkos::parallel_for (policy, op);
+  Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S15", policy, op);
 }
 
 // Invoke the "generic" (not unrolled) multivector functor that
@@ -1134,26 +1134,26 @@ Axpby_MV_Generic (const AV& av, const XMV& x,
 
   if (a == 0 && b == 0) {
     Axpby_MV_Functor<AV, XMV, BV, YMV, 0, 0, SizeType> op (x, y, av, bv);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S16", policy, op);
     return;
   }
 
 #if KOKKOSBLAS_OPTIMIZATION_LEVEL_AXPBY > 2
   if (a == 0 && b == -1) {
     Axpby_MV_Functor<AV, XMV, BV, YMV, 0, -1, SizeType> op (x, y, av, bv);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S17", policy, op);
     return;
   }
   if (a == 0 && b == 1) {
     Axpby_MV_Functor<AV, XMV, BV, YMV, 0, 1, SizeType> op (x, y, av, bv);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S18", policy, op);
     return;
   }
 #endif // KOKKOSBLAS_OPTIMIZATION_LEVEL_AXPBY > 2
 
   if (a == 0 && b == 2) {
     Axpby_MV_Functor<AV, XMV, BV, YMV, 0, 2, SizeType> op (x, y, av, bv);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S19", policy, op);
     return;
   }
 
@@ -1161,43 +1161,43 @@ Axpby_MV_Generic (const AV& av, const XMV& x,
   // a == -1
   if (a == -1 && b == 0) {
     Axpby_MV_Functor<AV, XMV, BV, YMV, -1, 0, SizeType> op (x, y, av, bv);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S20", policy, op);
     return;
   }
   if (a == -1 && b == -1) {
     Axpby_MV_Functor<AV, XMV, BV, YMV, -1, -1, SizeType> op (x, y, av, bv);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S21", policy, op);
     return;
   }
   if (a == -1 && b == 1) {
     Axpby_MV_Functor<AV, XMV, BV, YMV, -1, 1, SizeType> op (x, y, av, bv);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S22", policy, op);
     return;
   }
   if (a == -1 && b == 2) {
     Axpby_MV_Functor<AV, XMV, BV, YMV, -1, 2, SizeType> op (x, y, av, bv);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S23", policy, op);
     return;
   }
   // a == 1
   if (a == 1 && b == 0) {
     Axpby_MV_Functor<AV, XMV, BV, YMV, 1, 0, SizeType> op (x, y, av, bv);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S24", policy, op);
     return;
   }
   if (a == 1 && b == -1) {
     Axpby_MV_Functor<AV, XMV, BV, YMV, 1, -1, SizeType> op (x, y, av, bv);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S25", policy, op);
     return;
   }
   if (a == 1 && b == 1) {
     Axpby_MV_Functor<AV, XMV, BV, YMV, 1, 1, SizeType> op (x, y, av, bv);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S26", policy, op);
     return;
   }
   if (a == 1 && b == 2) {
     Axpby_MV_Functor<AV, XMV, BV, YMV, 1, 2, SizeType> op (x, y, av, bv);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S27", policy, op);
     return;
   }
 #endif // KOKKOSBLAS_OPTIMIZATION_LEVEL_AXPBY > 2
@@ -1205,26 +1205,26 @@ Axpby_MV_Generic (const AV& av, const XMV& x,
   // a == 2
   if (a == 2 && b == 0) {
     Axpby_MV_Functor<AV, XMV, BV, YMV, 2, 0, SizeType> op (x, y, av, bv);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S28", policy, op);
     return;
   }
 
 #if KOKKOSBLAS_OPTIMIZATION_LEVEL_AXPBY > 2
   if (a == 2 && b == -1) {
     Axpby_MV_Functor<AV, XMV, BV, YMV, 2, -1, SizeType> op (x, y, av, bv);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S29", policy, op);
     return;
   }
   if (a == 2 && b == 1) {
     Axpby_MV_Functor<AV, XMV, BV, YMV, 2, 1, SizeType> op (x, y, av, bv);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S30", policy, op);
     return;
   }
 #endif // KOKKOSBLAS_OPTIMIZATION_LEVEL_AXPBY > 2
 
   // a and b arbitrary (not -1, 0, or 1)
   Axpby_MV_Functor<AV, XMV, BV, YMV, 2, 2, SizeType> op (x, y, av, bv);
-  Kokkos::parallel_for (policy, op);
+  Kokkos::parallel_for ("KokkosBlas::Axpby::MV::S31", policy, op);
 }
 
 // Compute any of the following, in a way optimized for X and Y

--- a/src/blas/impl/KokkosBlas1_axpby_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_axpby_spec.hpp
@@ -179,7 +179,7 @@ struct Axpby<AV, XMV, BV, YMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "X and Y must have the same rank.");
     static_assert (YMV::Rank == 2, "KokkosBlas::Impl::Axpby<rank-2>::axpby: "
                    "X and Y must have rank 2.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::axpby[ETI]":"KokkosBlas::axpby[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::axpby<> ETI specialization for < %s , %s , %s , %s >\n",typeid(AV).name(),typeid(XMV).name(),typeid(BV).name(),typeid(YMV).name());
@@ -213,6 +213,7 @@ struct Axpby<AV, XMV, BV, YMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
         Axpby_MV_Invoke_Left<AV, XMV, BV, YMV, index_type> >::type Axpby_MV_Invoke_Layout;
       Axpby_MV_Invoke_Layout::run(av, X, bv, Y, a, b);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 
@@ -247,7 +248,7 @@ struct Axpby<typename XMV::non_const_value_type, XMV,
                    "X and Y must have the same rank.");
     static_assert (YMV::Rank == 2, "KokkosBlas::Impl::Axpby::axpby (MV): "
                    "X and Y must have rank 2.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::axpby[ETI]":"KokkosBlas::axpby[noETI]");
 
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
@@ -307,6 +308,7 @@ struct Axpby<typename XMV::non_const_value_type, XMV,
       Axpby_MV_Invoke_Layout::run(alpha, X,
                                                           beta, Y, a, b);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 
@@ -339,6 +341,7 @@ struct Axpby<typename XV::non_const_value_type, XV,
     static_assert (YV::Rank == 1, "KokkosBlas::Impl::Axpby<rank-1>::axpby: "
                    "X and Y must have rank 1.");
 
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::axpby[ETI]":"KokkosBlas::axpby[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::axpby<> ETI specialization for < %s , %s , %s , %s >\n",typeid(AV).name(),typeid(XV).name(),typeid(BV).name(),typeid(YV).name());
@@ -386,6 +389,7 @@ struct Axpby<typename XV::non_const_value_type, XV,
         typename YV::non_const_value_type, YV,
         index_type> (alpha, X, beta, Y, 0, a, b);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 #endif //!defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY

--- a/src/blas/impl/KokkosBlas1_axpby_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_axpby_spec.hpp
@@ -179,7 +179,7 @@ struct Axpby<AV, XMV, BV, YMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "X and Y must have the same rank.");
     static_assert (YMV::Rank == 2, "KokkosBlas::Impl::Axpby<rank-2>::axpby: "
                    "X and Y must have rank 2.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::axpby[ETI]":"KokkosBlas::axpby[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::axpby[ETI]":"KokkosBlas::axpby[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::axpby<> ETI specialization for < %s , %s , %s , %s >\n",typeid(AV).name(),typeid(XMV).name(),typeid(BV).name(),typeid(YMV).name());
@@ -248,7 +248,7 @@ struct Axpby<typename XMV::non_const_value_type, XMV,
                    "X and Y must have the same rank.");
     static_assert (YMV::Rank == 2, "KokkosBlas::Impl::Axpby::axpby (MV): "
                    "X and Y must have rank 2.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::axpby[ETI]":"KokkosBlas::axpby[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::axpby[ETI]":"KokkosBlas::axpby[noETI]");
 
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
@@ -341,7 +341,7 @@ struct Axpby<typename XV::non_const_value_type, XV,
     static_assert (YV::Rank == 1, "KokkosBlas::Impl::Axpby<rank-1>::axpby: "
                    "X and Y must have rank 1.");
 
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::axpby[ETI]":"KokkosBlas::axpby[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::axpby[ETI]":"KokkosBlas::axpby[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::axpby<> ETI specialization for < %s , %s , %s , %s >\n",typeid(AV).name(),typeid(XV).name(),typeid(BV).name(),typeid(YV).name());

--- a/src/blas/impl/KokkosBlas1_dot_mv_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_dot_mv_impl.hpp
@@ -415,7 +415,7 @@ struct MV_V_Dot_Invoke_Impl<RV, XMV, YMV, SizeType, 2, 1>
     typedef MV_V_Dot_Functor<RV, XMV, YMV, size_type> op_type;
     constexpr bool reverseOrder = false;
     op_type op (r, X, Y, reverseOrder);
-    Kokkos::parallel_reduce (range_type (0, numRows), op, r);
+    Kokkos::parallel_reduce ("KokkosBlas::Dot::2_1", range_type (0, numRows), op, r);
   }
 };
 
@@ -439,7 +439,7 @@ struct MV_V_Dot_Invoke_Impl<RV, XMV, YMV, SizeType, 1, 2>
     typedef MV_V_Dot_Functor<RV, YMV, XMV, size_type> op_type;
     constexpr bool reverseOrder = true;
     op_type op (r, Y, X, reverseOrder);
-    Kokkos::parallel_reduce (range_type (0, numRows), op, r);
+    Kokkos::parallel_reduce ("KokkosBlas::Dot::1_2", range_type (0, numRows), op, r);
   }
 };
 
@@ -488,7 +488,7 @@ MV_Dot_Invoke (const RV& r, const XMV& X, const YMV& Y)
     auto r_cur = Kokkos::subview (r, std::make_pair (j, j+8));
 
     MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 8, SizeType> op (r_cur, X_cur, Y_cur);
-    Kokkos::parallel_reduce (policy, op, r_cur);
+    Kokkos::parallel_reduce ("KokkosBlas::Dot::2_2::8", policy, op, r_cur);
   }
   for ( ; j + 4 <= numCols; j += 4) {
     auto X_cur = Kokkos::subview (X, Kokkos::ALL (), std::make_pair (j, j+4));
@@ -496,7 +496,7 @@ MV_Dot_Invoke (const RV& r, const XMV& X, const YMV& Y)
     auto r_cur = Kokkos::subview (r, std::make_pair (j, j+4));
 
     MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 4, SizeType> op (r_cur, X_cur, Y_cur);
-    Kokkos::parallel_reduce (policy, op, r_cur);
+    Kokkos::parallel_reduce ("KokkosBlas::Dot::2_2::4", policy, op, r_cur);
   }
   for ( ; j < numCols; ++j) {
     // RV needs to turn 0-D, and XMV and YMV need to turn 1-D.
@@ -508,90 +508,90 @@ MV_Dot_Invoke (const RV& r, const XMV& X, const YMV& Y)
     typedef decltype (y_cur) YMV1D;
 
     DotFunctor<RV0D, XMV1D, YMV1D, SizeType> op(x_cur, y_cur);
-    Kokkos::parallel_reduce (policy, op, r_cur);
+    Kokkos::parallel_reduce ("KokkosBlas::Dot::2_2::1", policy, op, r_cur);
   }
 
 #else // KOKKOSBLAS_OPTIMIZATION_LEVEL_DOT > 2
 
   if (numCols > 16) {
     MV_Dot_Right_FunctorVector<RV, XMV, YMV, SizeType> op (r, X, Y);
-    Kokkos::parallel_reduce (policy, op, r);
+    Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::16Above", policy, op, r);
   }
   else {
     switch (numCols) {
     case 16: {
       MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 16, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce (policy, op, r);
+      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::16", policy, op, r);
       break;
     }
     case 15: {
       MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 15, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce (policy, op, r);
+      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::15", policy, op, r);
       break;
     }
     case 14: {
       MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 14, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce (policy, op, r);
+      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::14", policy, op, r);
       break;
     }
     case 13: {
       MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 13, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce (policy, op, r);
+      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::13", policy, op, r);
       break;
     }
     case 12: {
       MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 12, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce (policy, op, r);
+      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::12", policy, op, r);
       break;
     }
     case 11: {
       MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 11, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce (policy, op, r);
+      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::11", policy, op, r);
       break;
     }
     case 10: {
       MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 10, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce (policy, op, r);
+      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::10", policy, op, r);
       break;
     }
     case 9: {
       MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 9, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce (policy, op, r);
+      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::9", policy, op, r);
       break;
     }
     case 8: {
       MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 8, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce (policy, op, r);
+      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::8", policy, op, r);
       break;
     }
     case 7: {
       MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 7, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce (policy, op, r);
+      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::7", policy, op, r);
       break;
     }
     case 6: {
       MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 6, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce (policy, op, r);
+      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::6", policy, op, r);
       break;
     }
     case 5: {
       MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 5, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce (policy, op, r);
+      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::5", policy, op, r);
       break;
     }
     case 4: {
       MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 4, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce (policy, op, r);
+      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::4", policy, op, r);
       break;
     }
     case 3: {
       MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 3, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce (policy, op, r);
+      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::3", policy, op, r);
       break;
     }
     case 2: {
       MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 2, SizeType> op (r, X, Y);
-      Kokkos::parallel_reduce (policy, op, r);
+      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::2", policy, op, r);
       break;
     }
     case 1: {
@@ -605,7 +605,7 @@ MV_Dot_Invoke (const RV& r, const XMV& X, const YMV& Y)
 
       typedef V_Dot_Functor<RV0D, XMV1D, YMV1D, SizeType> op_type;
       op_type op (r_0, X_0, Y_0);
-      Kokkos::parallel_reduce (policy, op, r_0);
+      Kokkos::parallel_reduce ("KokkosBlas::Dot::NumCols::1", policy, op, r_0);
       break;
     }
     } // switch

--- a/src/blas/impl/KokkosBlas1_dot_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_dot_spec.hpp
@@ -177,7 +177,7 @@ struct Dot<RV, XV, YV, 1, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "It must be nonconst, because it is an output argument "
                    "(we have to be able to write to its entries).");
 
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::dot[ETI]":"KokkosBlas::dot[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::dot[ETI]":"KokkosBlas::dot[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas::dot<> ETI specialization for < %s , %s >\n",typeid(XV).name(),typeid(YV).name());
@@ -214,7 +214,7 @@ struct Dot<RV, XV, YV, X_Rank, Y_Rank, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
     static_assert (RV::rank == 1, "KokkosBlas::Impl::Dot<2-D>: "
                    "RV is not rank 1.");
 
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::dot[ETI]":"KokkosBlas::dot[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::dot[ETI]":"KokkosBlas::dot[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::dot<> ETI specialization for < %s , %s , %s >\n",typeid(RV).name(),typeid(XV).name(),typeid(YV).name());

--- a/src/blas/impl/KokkosBlas1_dot_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_dot_spec.hpp
@@ -177,6 +177,7 @@ struct Dot<RV, XV, YV, 1, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "It must be nonconst, because it is an output argument "
                    "(we have to be able to write to its entries).");
 
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::dot[ETI]":"KokkosBlas::dot[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas::dot<> ETI specialization for < %s , %s >\n",typeid(XV).name(),typeid(YV).name());
@@ -196,6 +197,7 @@ struct Dot<RV, XV, YV, 1, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
       DotFunctor<RV,XV,YV,index_type> f(X,Y);
       f.run("KokkosBlas::dot<1D>",R);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 
@@ -212,6 +214,7 @@ struct Dot<RV, XV, YV, X_Rank, Y_Rank, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
     static_assert (RV::rank == 1, "KokkosBlas::Impl::Dot<2-D>: "
                    "RV is not rank 1.");
 
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::dot[ETI]":"KokkosBlas::dot[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::dot<> ETI specialization for < %s , %s , %s >\n",typeid(RV).name(),typeid(XV).name(),typeid(YV).name());
@@ -231,6 +234,7 @@ struct Dot<RV, XV, YV, X_Rank, Y_Rank, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
       typedef std::int64_t index_type;
       Dot_MV<RV,XV,YV,index_type>::dot(R,X,Y);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 #endif

--- a/src/blas/impl/KokkosBlas1_mult_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_mult_impl.hpp
@@ -215,24 +215,24 @@ V_Mult_Generic (typename CV::const_value_type& c,
     if (ab == ATA::zero ()) {
       typedef V_MultFunctor<CV, AV, BV, 0, 0, SizeType> functor_type;
       functor_type op (c, C, ab, A, B);
-      Kokkos::parallel_for (policy, op);
+      Kokkos::parallel_for ("KokkosBlas::Mult::S0", policy, op);
     }
     else {
       typedef V_MultFunctor<CV, AV, BV, 2, 0, SizeType> functor_type;
       functor_type op (c, C, ab, A, B);
-      Kokkos::parallel_for (policy, op);
+      Kokkos::parallel_for ("KokkosBlas::Mult::S1", policy, op);
     }
   }
   else { // c != 0
     if (ab == ATA::zero ()) {
       typedef V_MultFunctor<CV, AV, BV, 0, 2, SizeType> functor_type;
       functor_type op (c, C, ab, A, B);
-      Kokkos::parallel_for (policy, op);
+      Kokkos::parallel_for ("KokkosBlas::Mult::S2", policy, op);
     }
     else {
       typedef V_MultFunctor<CV, AV, BV, 2, 2, SizeType> functor_type;
       functor_type op (c, C, ab, A, B);
-      Kokkos::parallel_for (policy, op);
+      Kokkos::parallel_for ("KokkosBlas::Mult::S3", policy, op);
     }
   }
 }
@@ -277,24 +277,24 @@ MV_Mult_Generic (typename CMV::const_value_type& c,
     if (ab == ATA::zero ()) {
       typedef MV_MultFunctor<CMV, AV, BMV, 0, 0, SizeType> functor_type;
       functor_type op (c, C, ab, A, B);
-      Kokkos::parallel_for (policy, op);
+      Kokkos::parallel_for ("KokkosBlas::Mult::S4", policy, op);
     }
     else {
       typedef MV_MultFunctor<CMV, AV, BMV, 2, 0, SizeType> functor_type;
       functor_type op (c, C, ab, A, B);
-      Kokkos::parallel_for (policy, op);
+      Kokkos::parallel_for ("KokkosBlas::Mult::S5", policy, op);
     }
   }
   else { // c != 0
     if (ab == ATA::zero ()) {
       typedef MV_MultFunctor<CMV, AV, BMV, 0, 2, SizeType> functor_type;
       functor_type op (c, C, ab, A, B);
-      Kokkos::parallel_for (policy, op);
+      Kokkos::parallel_for ("KokkosBlas::Mult::S6", policy, op);
     }
     else {
       typedef MV_MultFunctor<CMV, AV, BMV, 2, 2, SizeType> functor_type;
       functor_type op (c, C, ab, A, B);
-      Kokkos::parallel_for (policy, op);
+      Kokkos::parallel_for ("KokkosBlas::Mult::S7", policy, op);
     }
   }
 }

--- a/src/blas/impl/KokkosBlas1_mult_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_mult_spec.hpp
@@ -167,7 +167,7 @@ struct Mult<YMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "X, and Y must have the rank 2.");
     static_assert (AV::rank == 1, "KokkosBlas::Impl::Mult<rank 2>::mult: "
                    "AV must have rank 1.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::mult[ETI]":"KokkosBlas::mult[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::mult[ETI]":"KokkosBlas::mult[noETI]");
 
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
@@ -219,7 +219,7 @@ struct Mult<YV, AV, XV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
     static_assert ((int) XV::rank == (int) YV::rank && (int) AV::rank == 1,
                    "KokkosBlas::Impl::Mult<rank 1>::mult: "
                    "X, Y, and Z must have rank 1.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::mult[ETI]":"KokkosBlas::mult[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::mult[ETI]":"KokkosBlas::mult[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::mult<> ETI specialization for < %s , %s , %s >\n",typeid(YV).name(),typeid(AV).name(),typeid(XV).name());

--- a/src/blas/impl/KokkosBlas1_mult_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_mult_spec.hpp
@@ -167,7 +167,7 @@ struct Mult<YMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "X, and Y must have the rank 2.");
     static_assert (AV::rank == 1, "KokkosBlas::Impl::Mult<rank 2>::mult: "
                    "AV must have rank 1.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::mult[ETI]":"KokkosBlas::mult[noETI]");
 
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
@@ -187,6 +187,7 @@ struct Mult<YMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
     else {
       MV_Mult_Generic<YMV, AV, XMV, int64_t> (gamma, Y, alpha, A, X);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 
@@ -218,7 +219,7 @@ struct Mult<YV, AV, XV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
     static_assert ((int) XV::rank == (int) YV::rank && (int) AV::rank == 1,
                    "KokkosBlas::Impl::Mult<rank 1>::mult: "
                    "X, Y, and Z must have rank 1.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::mult[ETI]":"KokkosBlas::mult[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::mult<> ETI specialization for < %s , %s , %s >\n",typeid(YV).name(),typeid(AV).name(),typeid(XV).name());
@@ -234,6 +235,7 @@ struct Mult<YV, AV, XV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
     else {
       V_Mult_Generic<YV, AV, XV, int64_t> (gamma, Y, alpha, A, X);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 #endif //!defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY

--- a/src/blas/impl/KokkosBlas1_nrm1_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm1_impl.hpp
@@ -230,7 +230,7 @@ V_Nrm1_Invoke (const RV& r, const XV& X)
 
   typedef V_Nrm1_Functor<RV, XV, SizeType> functor_type;
   functor_type op (X);
-  Kokkos::parallel_reduce (policy, op, r);
+  Kokkos::parallel_reduce ("KokkosBlas1::Nrm1::S0", policy, op, r);
 }
 
 
@@ -256,7 +256,7 @@ MV_Nrm1_Invoke (const RV& r, const XMV& X)
   else {
     typedef MV_Nrm1_Right_FunctorVector<RV, XMV, SizeType> functor_type;
     functor_type op (X);
-    Kokkos::parallel_reduce (policy, op, r);
+    Kokkos::parallel_reduce ("KokkosBlas1::Nrm1::S1", policy, op, r);
   }
 }
 

--- a/src/blas/impl/KokkosBlas1_nrm1_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm1_spec.hpp
@@ -131,7 +131,7 @@ struct Nrm1<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "RMV is not rank 0.");
     static_assert (XMV::rank == 1, "KokkosBlas::Impl::Nrm1<1-D>: "
                    "XMV is not rank 1.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::nrm1[ETI]":"KokkosBlas::nrm1[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::nrm1[ETI]":"KokkosBlas::nrm1[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::nrm1<> ETI specialization for < %s , %s >\n",typeid(RMV).name(),typeid(XMV).name());
@@ -175,7 +175,7 @@ struct Nrm1<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
       printf("KokkosBlas1::nrm1<> non-ETI specialization for < %s , %s >\n",typeid(RV).name(),typeid(XMV).name());
     }
     #endif
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::nrm1[ETI]":"KokkosBlas::nrm1[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::nrm1[ETI]":"KokkosBlas::nrm1[noETI]");
     const size_type numRows = X.extent(0);
     const size_type numCols = X.extent(1);
     if (numRows < static_cast<size_type> (INT_MAX) &&

--- a/src/blas/impl/KokkosBlas1_nrm1_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm1_spec.hpp
@@ -131,7 +131,7 @@ struct Nrm1<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "RMV is not rank 0.");
     static_assert (XMV::rank == 1, "KokkosBlas::Impl::Nrm1<1-D>: "
                    "XMV is not rank 1.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::nrm1[ETI]":"KokkosBlas::nrm1[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::nrm1<> ETI specialization for < %s , %s >\n",typeid(RMV).name(),typeid(XMV).name());
@@ -148,6 +148,7 @@ struct Nrm1<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
       typedef std::int64_t index_type;
       V_Nrm1_Invoke<RMV, XMV, index_type> (R, X);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 
@@ -174,7 +175,7 @@ struct Nrm1<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
       printf("KokkosBlas1::nrm1<> non-ETI specialization for < %s , %s >\n",typeid(RV).name(),typeid(XMV).name());
     }
     #endif
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::nrm1[ETI]":"KokkosBlas::nrm1[noETI]");
     const size_type numRows = X.extent(0);
     const size_type numCols = X.extent(1);
     if (numRows < static_cast<size_type> (INT_MAX) &&
@@ -185,6 +186,7 @@ struct Nrm1<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
       typedef std::int64_t index_type;
       MV_Nrm1_Invoke<RV, XMV, index_type> (R, X);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 #endif

--- a/src/blas/impl/KokkosBlas1_nrm2_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm2_impl.hpp
@@ -256,7 +256,7 @@ V_Nrm2_Invoke (const RV& r, const XV& X, const bool& take_sqrt)
 
   typedef V_Nrm2_Functor<RV, XV, SizeType> functor_type;
   functor_type op (X, take_sqrt);
-  Kokkos::parallel_reduce (policy, op, r);
+  Kokkos::parallel_reduce ("KokkosBlas::Nrm2::S0", policy,  op, r);
 }
 
 
@@ -282,7 +282,7 @@ MV_Nrm2_Invoke (const RV& r, const XMV& X, const bool& take_sqrt)
   else {
     typedef MV_Nrm2_Right_FunctorVector<RV, XMV, SizeType> functor_type;
     functor_type op (X, take_sqrt);
-    Kokkos::parallel_reduce (policy, op, r);
+    Kokkos::parallel_reduce ("KokkosBlas::Nrm2::S1", policy,  op, r);
   }
 }
 

--- a/src/blas/impl/KokkosBlas1_nrm2_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm2_spec.hpp
@@ -131,7 +131,7 @@ struct Nrm2<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "RMV is not rank 0.");
     static_assert (XMV::rank == 1, "KokkosBlas::Impl::Nrm2<1-D>: "
                    "XMV is not rank 1.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::nrm2[ETI]":"KokkosBlas::nrm2[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::nrm2[ETI]":"KokkosBlas::nrm2[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::nrm2<> ETI specialization for < %s , %s >\n",typeid(RMV).name(),typeid(XMV).name());
@@ -167,7 +167,7 @@ struct Nrm2<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
                    "RV is not rank 1.");
     static_assert (XMV::rank == 2, "KokkosBlas::Impl::Nrm2<2-D>: "
                    "XMV is not rank 2.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::nrm2[ETI]":"KokkosBlas::nrm2[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::nrm2[ETI]":"KokkosBlas::nrm2[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::nrm2<> ETI specialization for < %s , %s >\n",typeid(RV).name(),typeid(XMV).name());

--- a/src/blas/impl/KokkosBlas1_nrm2_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm2_spec.hpp
@@ -131,7 +131,7 @@ struct Nrm2<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "RMV is not rank 0.");
     static_assert (XMV::rank == 1, "KokkosBlas::Impl::Nrm2<1-D>: "
                    "XMV is not rank 1.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::nrm2[ETI]":"KokkosBlas::nrm2[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::nrm2<> ETI specialization for < %s , %s >\n",typeid(RMV).name(),typeid(XMV).name());
@@ -148,6 +148,7 @@ struct Nrm2<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
       typedef std::int64_t index_type;
       V_Nrm2_Invoke<RMV, XMV, index_type> (R, X, take_sqrt);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 
@@ -166,7 +167,7 @@ struct Nrm2<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
                    "RV is not rank 1.");
     static_assert (XMV::rank == 2, "KokkosBlas::Impl::Nrm2<2-D>: "
                    "XMV is not rank 2.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::nrm2[ETI]":"KokkosBlas::nrm2[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::nrm2<> ETI specialization for < %s , %s >\n",typeid(RV).name(),typeid(XMV).name());
@@ -185,6 +186,7 @@ struct Nrm2<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
       typedef std::int64_t index_type;
       MV_Nrm2_Invoke<RV, XMV, index_type> (R, X, take_sqrt);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 #endif

--- a/src/blas/impl/KokkosBlas1_nrm2w_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm2w_impl.hpp
@@ -257,7 +257,7 @@ V_Nrm2w_Invoke (const RV& r, const XV& X, const XV& W, const bool& take_sqrt)
 
   typedef V_Nrm2w_Functor<RV, XV, SizeType> functor_type;
   functor_type op (X, W, take_sqrt);
-  Kokkos::parallel_reduce (policy, op, r);
+  Kokkos::parallel_reduce ("KokkosBlas::Nrm2w::S0", policy, op, r);
 }
 
 
@@ -284,7 +284,7 @@ MV_Nrm2w_Invoke (const RV& r, const XMV& X, const XMV& W, const bool& take_sqrt)
   else {
     typedef MV_Nrm2w_Right_FunctorVector<RV, XMV, SizeType> functor_type;
     functor_type op (X, W, take_sqrt);
-    Kokkos::parallel_reduce (policy, op, r);
+    Kokkos::parallel_reduce ("KokkosBlas::Nrm2w::S1", policy, op, r);
   }
 }
 

--- a/src/blas/impl/KokkosBlas1_nrm2w_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm2w_spec.hpp
@@ -127,7 +127,7 @@ struct Nrm2w<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "RMV is not rank 0.");
     static_assert (XMV::rank == 1, "KokkosBlas::Impl::Nrm2w<1-D>: "
                    "XMV is not rank 1.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::nrm2w[ETI]":"KokkosBlas::nrm2w[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::nrm2w<> ETI specialization for < %s , %s >\n",typeid(RMV).name(),typeid(XMV).name());
@@ -144,6 +144,7 @@ struct Nrm2w<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
       typedef std::int64_t index_type;
       V_Nrm2w_Invoke<RMV, XMV, index_type> (R, X, W, take_sqrt);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 
@@ -162,7 +163,7 @@ struct Nrm2w<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
                    "RV is not rank 1.");
     static_assert (XMV::rank == 2, "KokkosBlas::Impl::Nrm2w<2-D>: "
                    "XMV is not rank 2.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::nrm2w[ETI]":"KokkosBlas::nrm2w[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::nrm2w<> ETI specialization for < %s , %s >\n",typeid(RV).name(),typeid(XMV).name());
@@ -181,6 +182,7 @@ struct Nrm2w<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
       typedef std::int64_t index_type;
       MV_Nrm2w_Invoke<RV, XMV, index_type> (R, X, W, take_sqrt);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 #endif

--- a/src/blas/impl/KokkosBlas1_nrm2w_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm2w_spec.hpp
@@ -127,7 +127,7 @@ struct Nrm2w<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "RMV is not rank 0.");
     static_assert (XMV::rank == 1, "KokkosBlas::Impl::Nrm2w<1-D>: "
                    "XMV is not rank 1.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::nrm2w[ETI]":"KokkosBlas::nrm2w[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::nrm2w[ETI]":"KokkosBlas::nrm2w[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::nrm2w<> ETI specialization for < %s , %s >\n",typeid(RMV).name(),typeid(XMV).name());
@@ -163,7 +163,7 @@ struct Nrm2w<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
                    "RV is not rank 1.");
     static_assert (XMV::rank == 2, "KokkosBlas::Impl::Nrm2w<2-D>: "
                    "XMV is not rank 2.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::nrm2w[ETI]":"KokkosBlas::nrm2w[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::nrm2w[ETI]":"KokkosBlas::nrm2w[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::nrm2w<> ETI specialization for < %s , %s >\n",typeid(RV).name(),typeid(XMV).name());

--- a/src/blas/impl/KokkosBlas1_nrminf_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_nrminf_impl.hpp
@@ -224,7 +224,7 @@ V_NrmInf_Invoke (const RV& r, const XV& X)
 
   typedef V_NrmInf_Functor<RV, XV, SizeType> functor_type;
   functor_type op (X);
-  Kokkos::parallel_reduce (policy, op, Kokkos::Max<typename RV::non_const_value_type>(r()));
+  Kokkos::parallel_reduce ("KokkosBlas::NrmInf::S0", policy, op, Kokkos::Max<typename RV::non_const_value_type>(r()));
 }
 
 
@@ -262,7 +262,7 @@ MV_NrmInf_Invoke (const RV& r, const XMV& X)
   else {
     typedef MV_NrmInf_Right_FunctorVector<RV, XMV, SizeType> functor_type;
     functor_type op (X);
-    Kokkos::parallel_reduce (policy, op, r);
+    Kokkos::parallel_reduce ("KokkosBlas::NrmInf::S1", policy, op, r);
   }
 }
 

--- a/src/blas/impl/KokkosBlas1_nrminf_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_nrminf_spec.hpp
@@ -131,7 +131,7 @@ struct NrmInf<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "RMV is not rank 0.");
     static_assert (XMV::rank == 1, "KokkosBlas::Impl::NrmInf<1-D>: "
                    "XMV is not rank 1.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::nrminf[ETI]":"KokkosBlas::nrminf[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::nrminf[ETI]":"KokkosBlas::nrminf[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::nrminf<> ETI specialization for < %s , %s >\n",typeid(RMV).name(),typeid(XMV).name());
@@ -167,7 +167,7 @@ struct NrmInf<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
                    "RV is not rank 1.");
     static_assert (XMV::rank == 2, "KokkosBlas::Impl::NrmInf<2-D>: "
                    "XMV is not rank 2.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::nrminf[ETI]":"KokkosBlas::nrminf[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::nrminf[ETI]":"KokkosBlas::nrminf[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::nrminf<> ETI specialization for < %s , %s >\n",typeid(RV).name(),typeid(XMV).name());

--- a/src/blas/impl/KokkosBlas1_nrminf_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_nrminf_spec.hpp
@@ -131,7 +131,7 @@ struct NrmInf<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "RMV is not rank 0.");
     static_assert (XMV::rank == 1, "KokkosBlas::Impl::NrmInf<1-D>: "
                    "XMV is not rank 1.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::nrminf[ETI]":"KokkosBlas::nrminf[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::nrminf<> ETI specialization for < %s , %s >\n",typeid(RMV).name(),typeid(XMV).name());
@@ -148,6 +148,7 @@ struct NrmInf<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
       typedef std::int64_t index_type;
       V_NrmInf_Invoke<RMV, XMV, index_type> (R, X);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 
@@ -166,7 +167,7 @@ struct NrmInf<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
                    "RV is not rank 1.");
     static_assert (XMV::rank == 2, "KokkosBlas::Impl::NrmInf<2-D>: "
                    "XMV is not rank 2.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::nrminf[ETI]":"KokkosBlas::nrminf[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::nrminf<> ETI specialization for < %s , %s >\n",typeid(RV).name(),typeid(XMV).name());
@@ -185,6 +186,7 @@ struct NrmInf<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
       typedef std::int64_t index_type;
       MV_NrmInf_Invoke<RV, XMV, index_type> (R, X);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 #endif

--- a/src/blas/impl/KokkosBlas1_reciprocal_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_reciprocal_impl.hpp
@@ -199,11 +199,11 @@ MV_Reciprocal_Generic (const RMV& R, const XMV& X)
 
   if (R == X) { // if R and X are the same (alias one another)
     MV_ReciprocalSelf_Functor<RMV, SizeType> op (R);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Reciprocal::S0", policy, op);
   }
   else {
     MV_Reciprocal_Functor<RMV, XMV, SizeType> op (R, X);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Reciprocal::S1", policy, op);
   }
 }
 
@@ -227,11 +227,11 @@ V_Reciprocal_Generic (const RV& R, const XV& X)
 
   if (R == X) { // if R and X are the same (alias one another)
     V_ReciprocalSelf_Functor<RV, SizeType> op (R);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Reciprocal::S2", policy, op);
   }
   else {
     V_Reciprocal_Functor<RV, XV, SizeType> op (R, X);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Reciprocal::S3", policy, op);
   }
 }
 

--- a/src/blas/impl/KokkosBlas1_reciprocal_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_reciprocal_spec.hpp
@@ -127,7 +127,7 @@ struct Reciprocal<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "RMV is not rank 1.");
     static_assert (XMV::rank == 1, "KokkosBlas::Impl::Reciprocal<1-D>: "
                    "XMV is not rank 1.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::reciprocal[ETI]":"KokkosBlas::reciprocal[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::reciprocal[ETI]":"KokkosBlas::reciprocal[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::reciprocal<> ETI specialization for < %s , %s >\n",typeid(RMV).name(),typeid(XMV).name());
@@ -163,7 +163,7 @@ struct Reciprocal<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
                    "RMV is not rank 2.");
     static_assert (XMV::rank == 2, "KokkosBlas::Impl::Reciprocal<2-D>: "
                    "XMV is not rank 2.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::reciprocal[ETI]":"KokkosBlas::reciprocal[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::reciprocal[ETI]":"KokkosBlas::reciprocal[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::reciprocal<> ETI specialization for < %s , %s >\n",typeid(RMV).name(),typeid(XMV).name());

--- a/src/blas/impl/KokkosBlas1_reciprocal_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_reciprocal_spec.hpp
@@ -127,7 +127,7 @@ struct Reciprocal<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "RMV is not rank 1.");
     static_assert (XMV::rank == 1, "KokkosBlas::Impl::Reciprocal<1-D>: "
                    "XMV is not rank 1.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::reciprocal[ETI]":"KokkosBlas::reciprocal[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::reciprocal<> ETI specialization for < %s , %s >\n",typeid(RMV).name(),typeid(XMV).name());
@@ -145,6 +145,7 @@ struct Reciprocal<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
       typedef std::int64_t index_type;
       V_Reciprocal_Generic<RMV, XMV, index_type> (R, X);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 
@@ -162,7 +163,7 @@ struct Reciprocal<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
                    "RMV is not rank 2.");
     static_assert (XMV::rank == 2, "KokkosBlas::Impl::Reciprocal<2-D>: "
                    "XMV is not rank 2.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::reciprocal[ETI]":"KokkosBlas::reciprocal[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::reciprocal<> ETI specialization for < %s , %s >\n",typeid(RMV).name(),typeid(XMV).name());
@@ -182,6 +183,7 @@ struct Reciprocal<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
       typedef std::int64_t index_type;
       MV_Reciprocal_Generic<RMV, XMV, index_type> (R, X);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 #endif

--- a/src/blas/impl/KokkosBlas1_scal_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_scal_impl.hpp
@@ -188,23 +188,23 @@ V_Scal_Generic (const RV& r, const AV& av, const XV& x,
 
   if (a == 0) {
     V_Scal_Functor<RV, AV, XV, 0, SizeType> op (r, x, av, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Scal::S0", policy, op);
     return;
   }
   if (a == -1) {
     V_Scal_Functor<RV, AV, XV, -1, SizeType> op (r, x, av, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Scal::S1", policy, op);
     return;
   }
   if (a == 1) {
     V_Scal_Functor<RV, AV, XV, 1, SizeType> op (r, x, av, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Scal::S2", policy, op);
     return;
   }
 
   // a arbitrary (not -1, 0, or 1)
   V_Scal_Functor<RV, AV, XV, 2, SizeType> op (r, x, av, startingColumn);
-  Kokkos::parallel_for (policy, op);
+  Kokkos::parallel_for ("KokkosBlas::Scal::S3", policy, op);
 }
 
 

--- a/src/blas/impl/KokkosBlas1_scal_mv_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_scal_mv_impl.hpp
@@ -371,21 +371,21 @@ MV_Scal_Unrolled (const RMV& r, const aVector& av, const XMV& x,
     MV_Scal_Unroll_Functor<RMV, aVector, XMV, 0, UNROLL, SizeType> op (r, x, av, startingColumn);
     const SizeType numRows = x.extent(0);
     Kokkos::RangePolicy<execution_space, SizeType> policy (0, numRows);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Scal::MV::S0", policy, op);
     return;
   }
   if (a == -1) {
     MV_Scal_Unroll_Functor<RMV, aVector, XMV, -1, UNROLL, SizeType> op (r, x, av, startingColumn);
     const SizeType numRows = x.extent(0);
     Kokkos::RangePolicy<execution_space, SizeType> policy (0, numRows);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Scal::MV::S1", policy, op);
     return;
   }
   if (a == 1) {
     MV_Scal_Unroll_Functor<RMV, aVector, XMV, 1, UNROLL, SizeType> op (r, x, av, startingColumn);
     const SizeType numRows = x.extent(0);
     Kokkos::RangePolicy<execution_space, SizeType> policy (0, numRows);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Scal::MV::S2", policy, op);
     return;
   }
 
@@ -393,7 +393,7 @@ MV_Scal_Unrolled (const RMV& r, const aVector& av, const XMV& x,
   MV_Scal_Unroll_Functor<RMV, aVector, XMV, 2, UNROLL, SizeType> op (r, x, av, startingColumn);
   const SizeType numRows = x.extent(0);
   Kokkos::RangePolicy<execution_space, SizeType> policy (0, numRows);
-  Kokkos::parallel_for (policy, op);
+  Kokkos::parallel_for ("KokkosBlas::Scal::MV::S3", policy, op);
 }
 
 // Invoke the "generic" (not unrolled) multivector functor that
@@ -424,23 +424,23 @@ MV_Scal_Generic (const RVector& r,
 
   if (a == 0) {
     MV_Scal_Functor<RVector, aVector, XVector, 0, SizeType> op (r, x, av, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Scal::MV::S4", policy, op);
     return;
   }
   if (a == -1) {
     MV_Scal_Functor<RVector, aVector, XVector, -1, SizeType> op (r, x, av, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Scal::MV::S5", policy, op);
     return;
   }
   if (a == 1) {
     MV_Scal_Functor<RVector, aVector, XVector, 1, SizeType> op (r, x, av, startingColumn);
-    Kokkos::parallel_for (policy, op);
+    Kokkos::parallel_for ("KokkosBlas::Scal::MV::S6", policy, op);
     return;
   }
 
   // a arbitrary (not -1, 0, or 1)
   MV_Scal_Functor<RVector, aVector, XVector, 2, SizeType> op (r, x, av, startingColumn);
-  Kokkos::parallel_for (policy, op);
+  Kokkos::parallel_for ("KokkosBlas::Scal::MV::S7", policy, op);
 }
 
 

--- a/src/blas/impl/KokkosBlas1_scal_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_scal_spec.hpp
@@ -144,7 +144,7 @@ struct Scal<RV,  typename XV::non_const_value_type, XV, 1, false, KOKKOSKERNELS_
                    "RV is not rank 1.");
     static_assert (XV::rank == 1, "KokkosBlas::Impl::Scal<1-D>: "
                    "XV is not rank 1.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::scal[ETI]":"KokkosBlas::scal[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::scal[ETI]":"KokkosBlas::scal[noETI]");
 
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
@@ -203,7 +203,7 @@ struct Scal<RMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
                    "AV is not rank 1.");
     static_assert (XMV::rank == 2, "KokkosBlas::Impl::Scal<2-D>: "
                    "XMV is not rank 2.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::scal[ETI]":"KokkosBlas::scal[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::scal[ETI]":"KokkosBlas::scal[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::scal<2D> ETI specialization for < %s , %s , %s >\n",typeid(RMV).name(),typeid(AV).name(),typeid(XMV).name());
@@ -250,7 +250,7 @@ struct Scal<RMV, typename XMV::non_const_value_type, XMV, 2, false, KOKKOSKERNEL
                    "RMV is not rank 2.");
     static_assert (XMV::rank == 2, "KokkosBlas::Impl::Scal<2-D, AV=scalar>: "
                    "XMV is not rank 2.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::scal[ETI]":"KokkosBlas::scal[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::scal[ETI]":"KokkosBlas::scal[noETI]");
 
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)

--- a/src/blas/impl/KokkosBlas1_scal_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_scal_spec.hpp
@@ -144,7 +144,7 @@ struct Scal<RV,  typename XV::non_const_value_type, XV, 1, false, KOKKOSKERNELS_
                    "RV is not rank 1.");
     static_assert (XV::rank == 1, "KokkosBlas::Impl::Scal<1-D>: "
                    "XV is not rank 1.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::scal[ETI]":"KokkosBlas::scal[noETI]");
 
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
@@ -173,6 +173,7 @@ struct Scal<RV,  typename XV::non_const_value_type, XV, 1, false, KOKKOSKERNELS_
       typedef typename XV::size_type index_type;
       V_Scal_Generic<RV, AV, XV, index_type> (R, alpha, X, a);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 
@@ -202,7 +203,7 @@ struct Scal<RMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
                    "AV is not rank 1.");
     static_assert (XMV::rank == 2, "KokkosBlas::Impl::Scal<2-D>: "
                    "XMV is not rank 2.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::scal[ETI]":"KokkosBlas::scal[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::scal<2D> ETI specialization for < %s , %s , %s >\n",typeid(RMV).name(),typeid(AV).name(),typeid(XMV).name());
@@ -222,6 +223,7 @@ struct Scal<RMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
       typedef typename XMV::size_type index_type;
       MV_Scal_Invoke_Left<RMV, AV, XMV, index_type> (R, av, X, a);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 
@@ -248,7 +250,7 @@ struct Scal<RMV, typename XMV::non_const_value_type, XMV, 2, false, KOKKOSKERNEL
                    "RMV is not rank 2.");
     static_assert (XMV::rank == 2, "KokkosBlas::Impl::Scal<2-D, AV=scalar>: "
                    "XMV is not rank 2.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::scal[ETI]":"KokkosBlas::scal[noETI]");
 
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
@@ -281,6 +283,7 @@ struct Scal<RMV, typename XMV::non_const_value_type, XMV, 2, false, KOKKOSKERNEL
       MV_Scal_Invoke_Left<RMV, typename XMV::non_const_value_type, XMV,
         index_type> (R, alpha, X, a);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 #endif

--- a/src/blas/impl/KokkosBlas1_sum_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_sum_impl.hpp
@@ -212,7 +212,7 @@ V_Sum_Invoke (const RV& r, const XV& X)
 
   typedef V_Sum_Functor<RV, XV, SizeType> functor_type;
   functor_type op (X);
-  Kokkos::parallel_reduce (policy, op, r);
+  Kokkos::parallel_reduce ("KokkosBlas::Sum::S0", policy, op, r);
 }
 
 
@@ -238,7 +238,7 @@ MV_Sum_Invoke (const RV& r, const XMV& X)
   else {
     typedef MV_Sum_Right_FunctorVector<RV, XMV, SizeType> functor_type;
     functor_type op (X);
-    Kokkos::parallel_reduce (policy, op, r);
+    Kokkos::parallel_reduce ("KokkosBlas::Sum::S1", policy, op, r);
   }
 }
 

--- a/src/blas/impl/KokkosBlas1_sum_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_sum_spec.hpp
@@ -131,7 +131,7 @@ struct Sum<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "RMV is not rank 0.");
     static_assert (XMV::rank == 1, "KokkosBlas::Impl::Sum<1-D>: "
                    "XMV is not rank 1.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::sum[ETI]":"KokkosBlas::sum[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::sum[ETI]":"KokkosBlas::sum[noETI]");
 
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
@@ -168,7 +168,7 @@ struct Sum<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
                    "RV is not rank 1.");
     static_assert (XMV::rank == 2, "KokkosBlas::Impl::Sum<2-D>: "
                    "XMV is not rank 2.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::sum[ETI]":"KokkosBlas::sum[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::sum[ETI]":"KokkosBlas::sum[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::sum<> ETI specialization for < %s , %s >\n",typeid(RV).name(),typeid(XMV).name());

--- a/src/blas/impl/KokkosBlas1_sum_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_sum_spec.hpp
@@ -131,6 +131,7 @@ struct Sum<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "RMV is not rank 0.");
     static_assert (XMV::rank == 1, "KokkosBlas::Impl::Sum<1-D>: "
                    "XMV is not rank 1.");
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::sum[ETI]":"KokkosBlas::sum[noETI]");
 
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
@@ -148,6 +149,7 @@ struct Sum<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
       typedef std::int64_t index_type;
       V_Sum_Invoke<RMV, XMV, index_type> (R, X);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 
@@ -166,7 +168,7 @@ struct Sum<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
                    "RV is not rank 1.");
     static_assert (XMV::rank == 2, "KokkosBlas::Impl::Sum<2-D>: "
                    "XMV is not rank 2.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::sum[ETI]":"KokkosBlas::sum[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::sum<> ETI specialization for < %s , %s >\n",typeid(RV).name(),typeid(XMV).name());
@@ -185,6 +187,7 @@ struct Sum<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
       typedef std::int64_t index_type;
       MV_Sum_Invoke<RV, XMV, index_type> (R, X);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 #endif

--- a/src/blas/impl/KokkosBlas1_update_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_update_spec.hpp
@@ -162,7 +162,7 @@ struct Update<XMV, YMV, ZMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "X, Y, and Z must have the same rank.");
     static_assert (ZMV::rank == 2, "KokkosBlas::Impl::Update<rank 2>::update: "
                    "XMV, YMV, and ZMV must have rank 2.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::update[ETI]":"KokkosBlas::update[noETI]");
 
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
@@ -221,6 +221,7 @@ struct Update<XMV, YMV, ZMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
         MV_Update_Generic<XMV, YMV, ZMV, index_type> (alpha, X, beta, Y, gamma, Z, a, b, c);
       }
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 
@@ -256,7 +257,7 @@ struct Update<XV, YV, ZV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "X, Y, and Z must have the same rank.");
     static_assert (ZV::rank == 1, "KokkosBlas::Impl::Update<rank 1>::update: "
                    "XV, YV, and ZV must have rank 1.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::update[ETI]":"KokkosBlas::update[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::update<> ETI specialization for < %s , %s , %s >\n",typeid(XV).name(),typeid(YV).name(),typeid(ZV).name());
@@ -297,6 +298,7 @@ struct Update<XV, YV, ZV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
       typedef typename XV::size_type index_type;
       V_Update_Generic<XV, YV, ZV, index_type> (alpha, X, beta, Y, gamma, Z, a, b, c);
     }
+    Kokkos::Profiling::popRegion();
   }
 };
 #endif //!defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY

--- a/src/blas/impl/KokkosBlas1_update_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_update_spec.hpp
@@ -162,7 +162,7 @@ struct Update<XMV, YMV, ZMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "X, Y, and Z must have the same rank.");
     static_assert (ZMV::rank == 2, "KokkosBlas::Impl::Update<rank 2>::update: "
                    "XMV, YMV, and ZMV must have rank 2.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::update[ETI]":"KokkosBlas::update[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::update[ETI]":"KokkosBlas::update[noETI]");
 
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
@@ -257,7 +257,7 @@ struct Update<XV, YV, ZV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "X, Y, and Z must have the same rank.");
     static_assert (ZV::rank == 1, "KokkosBlas::Impl::Update<rank 1>::update: "
                    "XV, YV, and ZV must have rank 1.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::update[ETI]":"KokkosBlas::update[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::update[ETI]":"KokkosBlas::update[noETI]");
     #ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
     if(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
       printf("KokkosBlas1::update<> ETI specialization for < %s , %s , %s >\n",typeid(XV).name(),typeid(YV).name(),typeid(ZV).name());

--- a/src/blas/impl/KokkosBlas2_gemv_spec.hpp
+++ b/src/blas/impl/KokkosBlas2_gemv_spec.hpp
@@ -127,7 +127,7 @@ struct GEMV {
                    "XViewType must have rank 1.");
     static_assert (static_cast<int> (YViewType::rank) == 1,
                    "YViewType must have rank 1.");
-    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::gemv[ETI]":"KokkosBlas::gemv[noETI]");
+    Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::gemv[ETI]":"KokkosBlas::gemv[noETI]");
     typedef typename AViewType::size_type size_type;
     const size_type numRows = A.extent(0);
     const size_type numCols = A.extent(1);

--- a/src/blas/impl/KokkosBlas2_gemv_spec.hpp
+++ b/src/blas/impl/KokkosBlas2_gemv_spec.hpp
@@ -127,7 +127,7 @@ struct GEMV {
                    "XViewType must have rank 1.");
     static_assert (static_cast<int> (YViewType::rank) == 1,
                    "YViewType must have rank 1.");
-
+    Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::gemv[ETI]":"KokkosBlas::gemv[noETI]");
     typedef typename AViewType::size_type size_type;
     const size_type numRows = A.extent(0);
     const size_type numCols = A.extent(1);
@@ -142,6 +142,7 @@ struct GEMV {
       singleLevelGemv<AViewType, XViewType, YViewType, int64_t>
          (trans, alpha, A, x, beta, y);
     }
+    Kokkos::Profiling::popRegion();
   }
   #else
   ;

--- a/src/blas/impl/KokkosBlas3_gemm_spec.hpp
+++ b/src/blas/impl/KokkosBlas3_gemm_spec.hpp
@@ -128,7 +128,7 @@ struct GEMM {
   static_assert (static_cast<int> (CViewType::rank) == 2,
                  "CViewType must have rank 2.");
 
-  Kokkos::Profiling::pushRegion(eti_spec_avail?"KokkosBlas::gemm[ETI]":"KokkosBlas::gemm[noETI]");
+  Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY?"KokkosBlas::gemm[ETI]":"KokkosBlas::gemm[noETI]");
   // Figure out Scalar Types
   typedef typename AViewType::non_const_value_type ScalarA;
   typedef typename BViewType::non_const_value_type ScalarB;

--- a/src/common/KokkosKernels_PrintUtils.hpp
+++ b/src/common/KokkosKernels_PrintUtils.hpp
@@ -85,7 +85,7 @@ inline void kk_get_histogram(
     in_lno_view_t in_view,
     out_lno_view_t histogram /*must be initialized with 0s*/){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
-  Kokkos::parallel_for( my_exec_space(0, in_elements), Histogram<in_lno_view_t, out_lno_view_t>(in_view, histogram));
+  Kokkos::parallel_for( "KokkosKernels::Common::GetHistogram", my_exec_space(0, in_elements), Histogram<in_lno_view_t, out_lno_view_t>(in_view, histogram));
   MyExecSpace::fence();
 }
 

--- a/src/common/KokkosKernels_SimpleUtils.hpp
+++ b/src/common/KokkosKernels_SimpleUtils.hpp
@@ -115,7 +115,7 @@ struct InclusiveParallelPrefixSum{
 template <typename view_t, typename MyExecSpace>
 inline void kk_exclusive_parallel_prefix_sum(typename view_t::value_type num_elements, view_t arr){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
-  Kokkos::parallel_scan( "KokkosKernels::PrefixSum", my_exec_space(0, num_elements), ExclusiveParallelPrefixSum<view_t>(arr));
+  Kokkos::parallel_scan( "KokkosKernels::Common::PrefixSum", my_exec_space(0, num_elements), ExclusiveParallelPrefixSum<view_t>(arr));
 }
 
 
@@ -130,7 +130,7 @@ inline void kk_exclusive_parallel_prefix_sum(typename view_t::value_type num_ele
 template <typename forward_array_type, typename MyExecSpace>
 void kk_inclusive_parallel_prefix_sum(typename forward_array_type::value_type num_elements, forward_array_type arr){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
-  Kokkos::parallel_scan( "KokkosKernels::PrefixSum", my_exec_space(0, num_elements), InclusiveParallelPrefixSum<forward_array_type>(arr));
+  Kokkos::parallel_scan( "KokkosKernels::Common::PrefixSum", my_exec_space(0, num_elements), InclusiveParallelPrefixSum<forward_array_type>(arr));
 }
 
 template <typename view_t>
@@ -172,7 +172,7 @@ struct DiffReductionFunctor{
 template <typename view_t, typename view2_t, typename MyExecSpace>
 inline void kk_reduce_diff_view(size_t num_elements, view_t smaller, view2_t bigger, typename view_t::non_const_value_type & reduction){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
-  Kokkos::parallel_reduce( my_exec_space(0, num_elements), DiffReductionFunctor<view_t, view2_t>(smaller, bigger), reduction);
+  Kokkos::parallel_reduce( "KokkosKernels::Common::ReduceDiffView", my_exec_space(0, num_elements), DiffReductionFunctor<view_t, view2_t>(smaller, bigger), reduction);
 }
 
 template <typename it>
@@ -190,7 +190,7 @@ struct DiffReductionFunctorP{
 template <typename it,  typename MyExecSpace>
 inline void kkp_reduce_diff_view(const size_t num_elements, const it *smaller, const it *bigger, it & reduction){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
-  Kokkos::parallel_reduce( my_exec_space(0, num_elements), DiffReductionFunctorP<it>(smaller, bigger), reduction);
+  Kokkos::parallel_reduce( "KokkosKernels::Common::ReduceDiffView", my_exec_space(0, num_elements), DiffReductionFunctorP<it>(smaller, bigger), reduction);
 }
 
 
@@ -204,13 +204,13 @@ inline void kkp_reduce_diff_view(const size_t num_elements, const it *smaller, c
 template <typename view_t, typename MyExecSpace>
 inline void kk_reduce_view(size_t num_elements, view_t arr, typename view_t::value_type & reduction){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
-  Kokkos::parallel_reduce( my_exec_space(0, num_elements), ReductionFunctor<view_t>(arr), reduction);
+  Kokkos::parallel_reduce( "KokkosKernels::Common::ReduceView", my_exec_space(0, num_elements), ReductionFunctor<view_t>(arr), reduction);
 }
 
 template <typename view_t, typename MyExecSpace>
 inline void kk_reduce_view2(size_t num_elements, view_t arr, size_t & reduction){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
-  Kokkos::parallel_reduce( my_exec_space(0, num_elements), ReductionFunctor2<view_t>(arr), reduction);
+  Kokkos::parallel_reduce( "KokkosKernels::Common::ReduceView2", my_exec_space(0, num_elements), ReductionFunctor2<view_t>(arr), reduction);
 }
 
 template<typename view_type1, typename view_type2, typename eps_type = typename Kokkos::Details::ArithTraits<typename view_type2::non_const_value_type>::mag_type>
@@ -248,7 +248,7 @@ bool kk_is_identical_view(view_type1 view1, view_type2 view2, eps_type eps){
 
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
   size_t issame = 0;
-  Kokkos::parallel_reduce( my_exec_space(0,num_elements),
+  Kokkos::parallel_reduce( "KokkosKernels::Common::IsIdenticalView", my_exec_space(0,num_elements),
       IsIdenticalFunctor<view_type1, view_type2, eps_type>(view1, view2, eps), issame);
   MyExecSpace::fence();
   if (issame > 0){
@@ -296,7 +296,7 @@ struct ReduceMaxFunctor{
 template <typename view_type , typename MyExecSpace>
 void kk_view_reduce_max(size_t num_elements, view_type view_to_reduce, typename view_type::non_const_value_type &max_reduction){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
-  Kokkos::parallel_reduce( "KokkosKernels::FindMax", my_exec_space(0,num_elements), ReduceMaxFunctor<view_type>(view_to_reduce), max_reduction);
+  Kokkos::parallel_reduce( "KokkosKernels::Common::ReduceMax", my_exec_space(0,num_elements), ReduceMaxFunctor<view_type>(view_to_reduce), max_reduction);
 }
 
 

--- a/src/common/KokkosKernels_SparseUtils.hpp
+++ b/src/common/KokkosKernels_SparseUtils.hpp
@@ -491,10 +491,10 @@ inline void kk_transpose_graph(
 
 
   if (use_dynamic_scheduling){
-    Kokkos::parallel_for(  d_count_tp_t(num_rows  / team_work_chunk_size + 1 , suggested_team_size, vector_size), tm);
+    Kokkos::parallel_for(  "KokkosKernels::Common::TransposeGraph::DynamicSchedule::S0", d_count_tp_t(num_rows  / team_work_chunk_size + 1 , suggested_team_size, vector_size), tm);
   }
   else {
-    Kokkos::parallel_for(  count_tp_t(num_rows  / team_work_chunk_size + 1 , suggested_team_size, vector_size), tm);
+    Kokkos::parallel_for(  "KokkosKernels::Common::TransposeGraph::StaticSchedule::S0", count_tp_t(num_rows  / team_work_chunk_size + 1 , suggested_team_size, vector_size), tm);
   }
   MyExecSpace::fence();
 
@@ -506,10 +506,10 @@ inline void kk_transpose_graph(
 
 
   if (use_dynamic_scheduling){
-    Kokkos::parallel_for(  fill_tp_t(num_rows  / team_work_chunk_size + 1 , suggested_team_size, vector_size), tm);
+    Kokkos::parallel_for(  "KokkosKernels::Common::TransposeGraph::DynamicSchedule::S1", fill_tp_t(num_rows  / team_work_chunk_size + 1 , suggested_team_size, vector_size), tm);
   }
   else {
-    Kokkos::parallel_for(  d_fill_tp_t(num_rows  / team_work_chunk_size + 1 , suggested_team_size, vector_size), tm);
+    Kokkos::parallel_for(  "KokkosKernels::Common::TransposeGraph::StaticSchedule::S1", d_fill_tp_t(num_rows  / team_work_chunk_size + 1 , suggested_team_size, vector_size), tm);
   }
   MyExecSpace::fence();
 }
@@ -683,7 +683,7 @@ void kk_create_reverse_map(
     frsf frm (forward_map, tmp_color_xadj, reverse_map_adj,
             multiply_shift_for_scale, division_shift_for_bucket);
 
-    Kokkos::parallel_for (my_cnt_exec_space (0, num_forward_elements) , frm);
+    Kokkos::parallel_for ("KokkosKernels::Common::CreateReverseMap::NonAtomic::S0", my_cnt_exec_space (0, num_forward_elements) , frm);
     MyExecSpace::fence();
 
 
@@ -692,12 +692,12 @@ void kk_create_reverse_map(
       (tmp_reverse_size + 1, tmp_color_xadj);
     MyExecSpace::fence();
 
-    Kokkos::parallel_for (
+    Kokkos::parallel_for ("KokkosKernels::Common::CreateReverseMap::NonAtomic::S1",
         my_exec_space (0, num_reverse_elements + 1) ,
         StridedCopy1<reverse_array_type, reverse_array_type>
           (tmp_color_xadj, reverse_map_xadj, scale_size));
     MyExecSpace::fence();
-    Kokkos::parallel_for (my_fill_exec_space (0, num_forward_elements) , frm);
+    Kokkos::parallel_for ("KokkosKernels::Common::CreateReverseMap::NonAtomic::S2",my_fill_exec_space (0, num_forward_elements) , frm);
     MyExecSpace::fence();
   }
   else
@@ -713,7 +713,7 @@ void kk_create_reverse_map(
 
     rmp_functor_type frm (forward_map, tmp_color_xadj, reverse_map_adj);
 
-    Kokkos::parallel_for (my_cnt_exec_space (0, num_forward_elements) , frm);
+    Kokkos::parallel_for ("KokkosKernels::Common::CreateReverseMap::Atomic::S0", my_cnt_exec_space (0, num_forward_elements) , frm);
     MyExecSpace::fence();
 
     //kk_inclusive_parallel_prefix_sum<reverse_array_type, MyExecSpace>(num_reverse_elements + 1, reverse_map_xadj);
@@ -724,7 +724,7 @@ void kk_create_reverse_map(
     Kokkos::deep_copy (reverse_map_xadj, tmp_color_xadj);
     MyExecSpace::fence();
 
-    Kokkos::parallel_for (my_fill_exec_space (0, num_forward_elements) , frm);
+    Kokkos::parallel_for ("KokkosKernels::Common::CreateReverseMap::Atomic::S1", my_fill_exec_space (0, num_forward_elements) , frm);
     MyExecSpace::fence();
   }
 }
@@ -823,7 +823,7 @@ inline size_t kk_is_d1_coloring_valid(
 
   struct ColorChecker <in_row_view_t, in_nnz_view_t, in_color_view_t, team_member_t>  cc(num_rows, xadj, adj, v_colors, team_work_chunk_size);
   size_t num_conf = 0;
-  Kokkos::parallel_reduce( dynamic_team_policy(num_rows / team_work_chunk_size + 1 ,
+  Kokkos::parallel_reduce( "KokkosKernels::Common::IsD1ColoringValie", dynamic_team_policy(num_rows / team_work_chunk_size + 1 ,
       suggested_team_size, vector_size), cc, num_conf);
 
   MyExecSpace::fence();
@@ -1288,10 +1288,10 @@ void kk_get_lower_triangle_count_parallel(
 
 
   if (use_dynamic_scheduling){
-    Kokkos::parallel_for(  d_count_tp_t(nv  / team_work_chunk_size + 1 , suggested_team_size, vector_size), ltm);
+    Kokkos::parallel_for( "KokkosKernels::Common::GetLowerTriangleCount::DynamicSchedule",  d_count_tp_t(nv  / team_work_chunk_size + 1 , suggested_team_size, vector_size), ltm);
   }
   else {
-    Kokkos::parallel_for(  count_tp_t(nv  / team_work_chunk_size + 1 , suggested_team_size, vector_size), ltm);
+    Kokkos::parallel_for( "KokkosKernels::Common::GetLowerTriangleCount::StaticSchedule", count_tp_t(nv  / team_work_chunk_size + 1 , suggested_team_size, vector_size), ltm);
   }
   ExecutionSpace::fence();
 }
@@ -1387,7 +1387,7 @@ void kk_sort_by_row_size_parallel(
   SortItem * num_elements = &(vnum_elements[0]);
 
 
-  Kokkos::parallel_for( my_exec_space(0, nv),
+  Kokkos::parallel_for( "KokkosKernels::Common::SortByRowSize::S0", my_exec_space(0, nv),
       KOKKOS_LAMBDA(const lno_t& row) {
         lno_t row_size = in_xadj[row+1] - in_xadj[row];
         num_elements[row].size = row_size; 
@@ -1398,19 +1398,19 @@ void kk_sort_by_row_size_parallel(
       std::less<struct SortItem >());
 
       if (sort_decreasing_order == 1){
-        Kokkos::parallel_for( my_exec_space(0, nv),
+        Kokkos::parallel_for( "KokkosKernels::Common::SortByRowSize::S1", my_exec_space(0, nv),
         KOKKOS_LAMBDA(const lno_t& row) {
           new_indices[num_elements[row].id] = row;
         });
       }
       else if (sort_decreasing_order == 0){
-        Kokkos::parallel_for( my_exec_space(0, nv),
+        Kokkos::parallel_for( "KokkosKernels::Common::SortByRowSize::S2", my_exec_space(0, nv),
         KOKKOS_LAMBDA(const lno_t& row) {
           new_indices[num_elements[row].id] = nv - row - 1;
         });
       } 
       else {
-        Kokkos::parallel_for( my_exec_space(0, nv),
+        Kokkos::parallel_for( "KokkosKernels::Common::SortByRowSize::S3", my_exec_space(0, nv),
         KOKKOS_LAMBDA(const lno_t& row) {
           if (row   & 1){
           new_indices[num_elements[row].id] = nv - (row + 1) / 2;
@@ -1475,10 +1475,10 @@ void kk_get_lower_triangle_fill_parallel(
 
 
   if (use_dynamic_scheduling){
-    Kokkos::parallel_for(  d_fill_p_t(nv  / team_work_chunk_size + 1 , suggested_team_size, vector_size), ltm);
+    Kokkos::parallel_for( "KokkosKernels::Common::GetLowerTriangleFill::DynamicSchedule", d_fill_p_t(nv  / team_work_chunk_size + 1 , suggested_team_size, vector_size), ltm);
   }
   else {
-    Kokkos::parallel_for(  fill_p_t(nv  / team_work_chunk_size + 1 , suggested_team_size, vector_size), ltm);
+    Kokkos::parallel_for( "KokkosKernels::Common::GetLowerTriangleFill::StaticSchedule", fill_p_t(nv  / team_work_chunk_size + 1 , suggested_team_size, vector_size), ltm);
   }
   ExecutionSpace::fence();
 }
@@ -1848,7 +1848,7 @@ void kk_create_incidence_tranpose_matrix_from_lower_triangle(
   //const lno_t nr = in_rowmap.extent(0) - 1;
   typedef Kokkos::RangePolicy<exec_space> my_exec_space;
 
-  Kokkos::parallel_for(my_exec_space(0, ne + 1),
+  Kokkos::parallel_for("KokkosKernels::Common::CreateIncidenceTransposeMatrixFromLowerTriangle::S0", my_exec_space(0, ne + 1),
       KOKKOS_LAMBDA(const lno_t& i) {
     out_rowmap[i] = i * 2;
     });
@@ -1862,7 +1862,7 @@ void kk_create_incidence_tranpose_matrix_from_lower_triangle(
   out_entries = out_cols_view_t(Kokkos::ViewAllocateWithoutInitializing("LL"), 2 * ne);
 
   //TODO MAKE IT WITH TEAMS.
-  Kokkos::parallel_for(my_exec_space(0, nr),
+  Kokkos::parallel_for("KokkosKernels::Common::CreateIncidenceTransposeMatrixFromLowerTriangle::S1", my_exec_space(0, nr),
       KOKKOS_LAMBDA(const size_type& row) {
     size_type begin = in_rowmap(row);
     lno_t row_size = in_rowmap(row + 1) - begin;
@@ -1918,7 +1918,7 @@ void kk_create_incidence_matrix_from_lower_triangle(
   kk_exclusive_parallel_prefix_sum<out_row_map_view_t, exec_space>(nr+1, out_rowmap);
 
   exec_space::fence();
-  Kokkos::parallel_for(my_exec_space(0, nr + 1),
+  Kokkos::parallel_for("KokkosKernels::Common::CreateIncidenceTransposeMatrixFromLowerTriangle::S0", my_exec_space(0, nr + 1),
       KOKKOS_LAMBDA(const lno_t& i) {
     out_rowmap[i] += in_lower_rowmap[i];
   });
@@ -1928,7 +1928,7 @@ void kk_create_incidence_matrix_from_lower_triangle(
 
   out_entries = out_cols_view_t(Kokkos::ViewAllocateWithoutInitializing("LL"), 2*ne);
 
-  Kokkos::parallel_for(my_exec_space(0, nr),
+  Kokkos::parallel_for("KokkosKernels::Common::CreateIncidenceTransposeMatrixFromLowerTriangle::S1", my_exec_space(0, nr),
       KOKKOS_LAMBDA(const size_type& row) {
     size_type begin = in_lower_rowmap(row);
     lno_t row_size = in_lower_rowmap(row + 1) - begin;
@@ -1945,7 +1945,7 @@ void kk_create_incidence_matrix_from_lower_triangle(
     }
   });
   exec_space::fence();
-  Kokkos::parallel_for(my_exec_space(0, ne),
+  Kokkos::parallel_for("KokkosKernels::Common::CreateIncidenceTransposeMatrixFromLowerTriangle::S2", my_exec_space(0, ne),
       KOKKOS_LAMBDA(const size_type& edge_ind) {
     lno_t col = in_lower_entries[edge_ind];
     typedef typename std::remove_reference< decltype( out_rowmap_copy(0) ) >::type atomic_incr_type;
@@ -2017,13 +2017,13 @@ void kk_create_incidence_matrix_from_original_matrix(
 
   out_row_map_view_t out_rowmap_copy (Kokkos::ViewAllocateWithoutInitializing("tmp"), nr+1);
   //out_rowmap = out_row_map_view_t("LL", nr+1);
-  Kokkos::parallel_for(my_exec_space(0, nr+1),
+  Kokkos::parallel_for("KokkosKernels::Common::CreateIncidenceTransposeMatrixFromOriginalTriangle::S0", my_exec_space(0, nr+1),
       KOKKOS_LAMBDA(const lno_t& i) {
     out_rowmap_copy[i] = in_rowmap[i];
   });
 
   if (sort_decreasing_order){
-    Kokkos::parallel_for(my_exec_space(0, nr),
+    Kokkos::parallel_for("KokkosKernels::Common::CreateIncidenceTransposeMatrixFromOriginalTriangle::S1", my_exec_space(0, nr),
         KOKKOS_LAMBDA(const size_type& row) {
       size_type begin = in_rowmap(row);
       lno_t row_size = in_rowmap(row + 1) - begin;
@@ -2055,7 +2055,7 @@ void kk_create_incidence_matrix_from_original_matrix(
 
   }
   else {
-  Kokkos::parallel_for(my_exec_space(0, nr),
+    Kokkos::parallel_for("KokkosKernels::Common::CreateIncidenceTransposeMatrixFromOriginalTriangle::S2", my_exec_space(0, nr),
       KOKKOS_LAMBDA(const size_type& row) {
     size_type begin = in_rowmap(row);
     lno_t row_size = in_rowmap(row + 1) - begin;
@@ -2087,7 +2087,7 @@ void kk_create_incidence_matrix_from_original_matrix(
 
 
   //out_rowmap = out_row_map_view_t("LL", nr+1);
-  Kokkos::parallel_for(my_exec_space(0, nr+1),
+  Kokkos::parallel_for("KokkosKernels::Common::CreateIncidenceTransposeMatrixFromOriginalTriangle::S3", my_exec_space(0, nr+1),
       KOKKOS_LAMBDA(const lno_t& i) {
     out_rowmap[i] = in_rowmap[i];
   });
@@ -2130,7 +2130,7 @@ template <typename view_type , typename MyExecSpace>
 void kk_reduce_numrows_larger_than_threshold(size_t num_elements, view_type view_to_reduce,
 		typename view_type::const_value_type threshold, typename view_type::non_const_value_type &sum_reduction){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
-  Kokkos::parallel_reduce( my_exec_space(0,num_elements), ReduceLargerRowCount<view_type>(view_to_reduce, threshold), sum_reduction);
+  Kokkos::parallel_reduce( "KokkosKernels::Common::ReduceNumRowsLargerThanThreshold", my_exec_space(0,num_elements), ReduceLargerRowCount<view_type>(view_to_reduce, threshold), sum_reduction);
 }
 
 }

--- a/src/common/KokkosKernels_Utils.hpp
+++ b/src/common/KokkosKernels_Utils.hpp
@@ -708,14 +708,14 @@ struct LinearInitialization{
 template <typename array_type, typename MyExecSpace>
 void linear_init(typename array_type::value_type num_elements, array_type arr){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
-  Kokkos::parallel_for( my_exec_space(0, num_elements), LinearInitialization<array_type>(arr));
+  Kokkos::parallel_for( "KokkosKernels::Common::LinearInit", my_exec_space(0, num_elements), LinearInitialization<array_type>(arr));
 }
 
 
 template <typename forward_array_type, typename MyExecSpace>
 void remove_zeros_in_xadj_vector(typename forward_array_type::value_type num_elements, forward_array_type arr){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
-  Kokkos::parallel_scan( my_exec_space(0, num_elements), PropogataMaxValstoZeros<forward_array_type>(arr));
+  Kokkos::parallel_scan( "KokkosKernels::Common::RemoveZerosInXadjVector",my_exec_space(0, num_elements), PropogataMaxValstoZeros<forward_array_type>(arr));
 }
 
 
@@ -885,18 +885,18 @@ void create_reverse_map(
         tmp_color_xadj,
         multiply_shift_for_scale,
         division_shift_for_bucket);
-    Kokkos::parallel_for ("KokkosKernels::Impl::ReverseMapScaleInit",my_exec_space (0, num_forward_elements) , rmi);
+    Kokkos::parallel_for ("KokkosKernels::Common::ReverseMapScaleInit",my_exec_space (0, num_forward_elements) , rmi);
     MyExecSpace::fence();
 
 
     inclusive_parallel_prefix_sum<reverse_array_type, MyExecSpace>(tmp_reverse_size + 1, tmp_color_xadj);
     MyExecSpace::fence();
 
-    Kokkos::parallel_for ("KokkosKernels::Impl::StridedCopy",my_exec_space (0, num_reverse_elements + 1) , StridedCopy<reverse_array_type, reverse_array_type>(tmp_color_xadj, reverse_map_xadj, scale_size));
+    Kokkos::parallel_for ("KokkosKernels::Common::StridedCopy",my_exec_space (0, num_reverse_elements + 1) , StridedCopy<reverse_array_type, reverse_array_type>(tmp_color_xadj, reverse_map_xadj, scale_size));
     MyExecSpace::fence();
     Fill_Reverse_Scale_Map<forward_array_type, reverse_array_type> frm (forward_map, tmp_color_xadj, reverse_map_adj,
         multiply_shift_for_scale, division_shift_for_bucket);
-    Kokkos::parallel_for ("KokkosKernels::Impl::FillReverseMap",my_exec_space (0, num_forward_elements) , frm);
+    Kokkos::parallel_for ("KokkosKernels::Common::FillReverseMap",my_exec_space (0, num_forward_elements) , frm);
     MyExecSpace::fence();
   }
   else
@@ -906,7 +906,7 @@ void create_reverse_map(
 
     Reverse_Map_Init<forward_array_type, reverse_array_type> rmi(forward_map, reverse_map_xadj);
 
-    Kokkos::parallel_for ("KokkosKernels::Impl::ReverseMapInit",my_exec_space (0, num_forward_elements) , rmi);
+    Kokkos::parallel_for ("KokkosKernels::Common::ReverseMapInit",my_exec_space (0, num_forward_elements) , rmi);
     MyExecSpace::fence();
     //print_1Dview(reverse_map_xadj);
 
@@ -916,7 +916,7 @@ void create_reverse_map(
     Kokkos::deep_copy (tmp_color_xadj, reverse_map_xadj);
     MyExecSpace::fence();
     Fill_Reverse_Map<forward_array_type, reverse_array_type> frm (forward_map, tmp_color_xadj, reverse_map_adj);
-    Kokkos::parallel_for ("KokkosKernels::Impl::FillReverseMap",my_exec_space (0, num_forward_elements) , frm);
+    Kokkos::parallel_for ("KokkosKernels::Common::FillReverseMap",my_exec_space (0, num_forward_elements) , frm);
     MyExecSpace::fence();
   }
 }
@@ -953,7 +953,7 @@ void permute_vector(
     ){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
 
-  Kokkos::parallel_for("KokkosKernels::Impl::PermuteVector", my_exec_space(0,num_elements),
+  Kokkos::parallel_for("KokkosKernels::Common::PermuteVector", my_exec_space(0,num_elements),
       PermuteVector<value_array_type, out_value_array_type, idx_array_type>(old_vector, new_vector, old_to_new_index_map));
 
 }
@@ -997,7 +997,7 @@ void permute_block_vector(
     ){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
 
-  Kokkos::parallel_for("KokkosKernels::Impl::PermuteVector", my_exec_space(0,num_elements),
+  Kokkos::parallel_for("KokkosKernels::Common::PermuteVector", my_exec_space(0,num_elements),
 		  PermuteBlockVector<value_array_type, out_value_array_type, idx_array_type>(block_size, old_vector, new_vector, old_to_new_index_map));
 
 }
@@ -1152,7 +1152,7 @@ void symmetrize_and_get_lower_diagonal_edge_list(
 #endif
     //std::cout << "max_allowed_team_size:" << max_allowed_team_size << " vs:" << vector_size << " tsm:" << teamSizeMax<< std::endl;
 
-    Kokkos::parallel_for(
+    Kokkos::parallel_for("KokkosKernels::Common::SymmetrizeAndGetLowerDiagonalEdgeList::S0",
         team_policy(num_rows_to_symmetrize / teamSizeMax + 1 , teamSizeMax, vector_size),
         fse/*, num_symmetric_edges*/);
     MyExecSpace::fence();
@@ -1211,7 +1211,7 @@ void symmetrize_and_get_lower_diagonal_edge_list(
         teamSizeMax);
 #endif
 
-    Kokkos::parallel_for(
+    Kokkos::parallel_for("KokkosKernels::Common::SymmetrizeAndGetLowerDiagonalEdgeList::S1",
         team_policy(num_rows_to_symmetrize / teamSizeMax + 1 , teamSizeMax, vector_size),
         FSCH);
     MyExecSpace::fence();
@@ -1296,7 +1296,7 @@ void symmetrize_graph_symbolic_hashmap(
         teamSizeMax);
 #endif
 
-    Kokkos::parallel_for(
+    Kokkos::parallel_for("KokkosKernels::Common::SymmetrizeGraphSymbolicHashMap::S0",
         team_policy(num_rows_to_symmetrize / teamSizeMax + 1 , teamSizeMax, vector_size),
         fse/*, num_symmetric_edges*/);
     MyExecSpace::fence();
@@ -1352,7 +1352,7 @@ void symmetrize_graph_symbolic_hashmap(
         teamSizeMax);
 #endif
 
-    Kokkos::parallel_for(
+    Kokkos::parallel_for("KokkosKernels::Common::SymmetrizeGraphSymbolicHashMap::S1",
         team_policy(num_rows_to_symmetrize / teamSizeMax + 1 , teamSizeMax, vector_size),
         FSCH);
     MyExecSpace::fence();
@@ -1391,7 +1391,7 @@ void copy_view(
                 from_vector from, to_vector to){
 
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
-  Kokkos::parallel_for( my_exec_space(0,num_elements), CopyView<from_vector, to_vector>(from, to));
+  Kokkos::parallel_for( "KokkosKernels::Common::CopyView", my_exec_space(0,num_elements), CopyView<from_vector, to_vector>(from, to));
 
 }
 
@@ -1474,7 +1474,7 @@ struct ReduceSumFunctor{
 template <typename view_type , typename MyExecSpace>
 void view_reduce_sum(size_t num_elements, view_type view_to_reduce, typename view_type::non_const_value_type &sum_reduction){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
-  Kokkos::parallel_reduce( my_exec_space(0,num_elements), ReduceSumFunctor<view_type>(view_to_reduce), sum_reduction);
+  Kokkos::parallel_reduce( "KokkosKernels::Common::ViewReduceSum", my_exec_space(0,num_elements), ReduceSumFunctor<view_type>(view_to_reduce), sum_reduction);
 }
 
 
@@ -1525,7 +1525,7 @@ void kk_view_reduce_max_row_size(const size_t num_rows,
                 const size_type *rowmap_view_ends,
                 size_type &max_row_size){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
-  Kokkos::parallel_reduce( my_exec_space(0,num_rows),
+  Kokkos::parallel_reduce( "KokkosKernels::Common::ViewReduceMaxRowSize", my_exec_space(0,num_rows),
       ReduceRowSizeFunctor<size_type>(rowmap_view_begins, rowmap_view_ends), max_row_size);
 }
 
@@ -1567,7 +1567,7 @@ struct ReduceMaxRowFunctor{
 template <typename view_type , typename MyExecSpace>
 void view_reduce_maxsizerow(size_t num_rows, view_type rowmap_view, typename view_type::non_const_value_type &max_reduction){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
-  Kokkos::parallel_reduce( my_exec_space(0,num_rows), ReduceMaxRowFunctor<view_type>(rowmap_view), max_reduction);
+  Kokkos::parallel_reduce( "KokkosKernels::Common::ViewReduceMaxSizeRow", my_exec_space(0,num_rows), ReduceMaxRowFunctor<view_type>(rowmap_view), max_reduction);
 }
 
 
@@ -1604,7 +1604,7 @@ template <typename view_type1, typename view_type2, typename MyExecSpace>
 bool isSame(size_t num_elements, view_type1 view1, view_type2 view2){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
   int issame = 1;
-  Kokkos::parallel_reduce( my_exec_space(0,num_elements), IsEqualFunctor<view_type1, view_type2>(view1, view2), issame);
+  Kokkos::parallel_reduce( "KokkosKernels::Common::isSame", my_exec_space(0,num_elements), IsEqualFunctor<view_type1, view_type2>(view1, view2), issame);
   MyExecSpace::fence();
   return issame;
 }
@@ -1772,7 +1772,7 @@ void transpose_matrix(
   int vector_size = get_suggested_vector__size(num_rows, nnz, get_exec_space_type<MyExecSpace>());
 
   Kokkos::Impl::Timer timer1;
-  Kokkos::parallel_for(  tcp_t(num_rows / team_row_work_size + 1 , Kokkos::AUTO_t(), vector_size), tm);
+  Kokkos::parallel_for( "KokkosKernels::Common::TransposeMatrix::S0",  tcp_t(num_rows / team_row_work_size + 1 , Kokkos::AUTO_t(), vector_size), tm);
   MyExecSpace::fence();
 
   exclusive_parallel_prefix_sum<out_row_view_t, MyExecSpace>(num_cols+1, t_xadj);
@@ -1781,7 +1781,7 @@ void transpose_matrix(
   MyExecSpace::fence();
 
   timer1.reset();
-  Kokkos::parallel_for(  tfp_t(num_rows / team_row_work_size + 1 , Kokkos::AUTO_t(), vector_size), tm);
+  Kokkos::parallel_for( "KokkosKernels::Common::TransposeMatrix::S1",  tfp_t(num_rows / team_row_work_size + 1 , Kokkos::AUTO_t(), vector_size), tm);
   MyExecSpace::fence();
 }
 
@@ -1850,7 +1850,7 @@ void transpose_graph2(
   int vector_size = get_suggested_vector__size(num_rows, nnz, get_exec_space_type<MyExecSpace>());
 
   Kokkos::Impl::Timer timer1;
-  Kokkos::parallel_for(  tcp_t(num_rows  , Kokkos::AUTO_t(), vector_size), tm);
+  Kokkos::parallel_for( "KokkosKernels::Common::TransposeGraph2::S0",  tcp_t(num_rows  , Kokkos::AUTO_t(), vector_size), tm);
   MyExecSpace::fence();
 
   exclusive_parallel_prefix_sum<out_row_view_t, MyExecSpace>(num_cols+1, t_xadj);
@@ -1859,7 +1859,7 @@ void transpose_graph2(
   MyExecSpace::fence();
 
   timer1.reset();
-  Kokkos::parallel_for(  tfp_t(num_rows , Kokkos::AUTO_t(), vector_size), tm);
+  Kokkos::parallel_for( "KokkosKernels::Common::TransposeGraph::S1",  tfp_t(num_rows , Kokkos::AUTO_t(), vector_size), tm);
   MyExecSpace::fence();
 
 
@@ -1912,7 +1912,7 @@ void init_view_withscalar(typename in_row_view_t::size_type num_elements, in_row
   int vector_size = 1;
 
   Kokkos::Impl::Timer timer1;
-  Kokkos::parallel_for(  tcp_t(num_elements / chunk_size + 1 , team_size, vector_size), tm);
+  Kokkos::parallel_for( "KokkosKernels::Common::InitViewWithScalar",  tcp_t(num_elements / chunk_size + 1 , team_size, vector_size), tm);
   MyExecSpace::fence();
 }
 

--- a/src/common/KokkosKernels_VectorUtils.hpp
+++ b/src/common/KokkosKernels_VectorUtils.hpp
@@ -120,7 +120,7 @@ inline void kk_a_times_x_plus_b(
                   out_array_t out_arr, in_array_t in_arr,
                   scalar_1 a, scalar_2 b){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
-  Kokkos::parallel_for( my_exec_space(0, num_elements),
+  Kokkos::parallel_for( "KokkosKernels::Common::ATimesXPlusB", my_exec_space(0, num_elements),
       A_times_X_plus_B<out_array_t, in_array_t, scalar_1, scalar_2>(out_arr, in_arr, a, b));
 }
 
@@ -134,7 +134,7 @@ inline void kk_a_times_x_plus_b(
 template <typename out_array_type, typename in_array_type, typename MyExecSpace>
 inline void kk_modular_view(typename in_array_type::value_type num_elements, out_array_type out_arr, in_array_type in_arr, int mod_factor_){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
-  Kokkos::parallel_for( my_exec_space(0, num_elements), ModularView<out_array_type, in_array_type>(out_arr, in_arr, mod_factor_));
+  Kokkos::parallel_for( "KokkosKernels::Common::ModularView", my_exec_space(0, num_elements), ModularView<out_array_type, in_array_type>(out_arr, in_arr, mod_factor_));
 }
 
 
@@ -144,7 +144,7 @@ void kk_copy_vector(
     size_t num_elements,
     from_vector from, to_vector to){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
-  Kokkos::parallel_for( my_exec_space(0,num_elements), CopyVectorFunctor<from_vector, to_vector>(from, to));
+  Kokkos::parallel_for( "KokkosKernels::Common::CopyVector", my_exec_space(0,num_elements), CopyVectorFunctor<from_vector, to_vector>(from, to));
 
 }
 }

--- a/src/graph/impl/KokkosGraph_Distance2Color_impl.hpp
+++ b/src/graph/impl/KokkosGraph_Distance2Color_impl.hpp
@@ -360,7 +360,7 @@ public:
     nnz_lno_temp_work_view_t current_vertexList = nnz_lno_temp_work_view_t(Kokkos::ViewAllocateWithoutInitializing("vertexList"), this->nv);
 
     // init conflictlist sequentially.
-    Kokkos::parallel_for(my_exec_space(0, this->nv), functorInitList<nnz_lno_temp_work_view_t>(current_vertexList));
+    Kokkos::parallel_for("KokkosGraph::Distance2Color::ColorGraphD2", my_exec_space(0, this->nv), functorInitList<nnz_lno_temp_work_view_t>(current_vertexList));
 
     // Next iteratons's conflictList
     nnz_lno_temp_work_view_t next_iteration_recolorList;
@@ -513,7 +513,7 @@ private:
                           chunkSize_
                           );
 
-    Kokkos::parallel_for(my_exec_space(0, current_vertexListLength_ / chunkSize_ + 1), gc);
+    Kokkos::parallel_for("KokkosGraph::Distance2Color::ColorGraphGreedy", my_exec_space(0, current_vertexListLength_ / chunkSize_ + 1), gc);
 
   }  // colorGreedy (end)
 
@@ -573,7 +573,7 @@ private:
                                                      current_vertexList_,
                                                      next_iteration_recolorList_,
                                                      next_iteration_recolorListLength_);
-        Kokkos::parallel_reduce(my_exec_space(0, current_vertexListLength_), conf, output_numUncolored);
+        Kokkos::parallel_reduce("KokkosGraph::Distance2Color::FindConflicts", my_exec_space(0, current_vertexListLength_), conf, output_numUncolored);
       }
     }
     else

--- a/src/graph/impl/KokkosGraph_GraphColor_impl.hpp
+++ b/src/graph/impl/KokkosGraph_GraphColor_impl.hpp
@@ -1207,24 +1207,24 @@ private:
     if (this->_conflictlist == 0){
       if (this->_use_color_set == 0 || this->_use_color_set == 2){
         functorFindConflicts_No_Conflist<adj_view_t> conf( this->nv, xadj_, adj_, vertex_colors_);
-        Kokkos::parallel_reduce(my_exec_space(0, current_vertexListLength_), conf, numUncolored);
+        Kokkos::parallel_reduce("KokkosGraph::GraphColoring::FindConflicts::CaseA", my_exec_space(0, current_vertexListLength_), conf, numUncolored);
       }
       else {
         functorFindConflicts_No_Conflist_IMP<adj_view_t> conf(this->nv, xadj_, adj_,vertex_colors_, vertex_color_set_);
-        Kokkos::parallel_reduce(my_exec_space(0, current_vertexListLength_), conf, numUncolored);
+        Kokkos::parallel_reduce("KokkosGraph::GraphColoring::FindConflicts::CaseB", my_exec_space(0, current_vertexListLength_), conf, numUncolored);
       }
     }
     else if (this->_conflictlist == 2){ //IF PPS
       if (this->_use_color_set == 0 || this->_use_color_set == 2){
         // Check for conflicts. Compute numUncolored == numConflicts.
         functorFindConflicts_PPS<adj_view_t> conf(this->nv, xadj_, adj_,vertex_colors_,current_vertexList_,next_iteration_recolorList_);
-        Kokkos::parallel_reduce(my_exec_space(0, current_vertexListLength_), conf, numUncolored);
+        Kokkos::parallel_reduce("KokkosGraph::GraphColoring::FindConflicts::CaseC", my_exec_space(0, current_vertexListLength_), conf, numUncolored);
       }
       else {
         functorFindConflicts_PPS_IMP<adj_view_t> conf(this->nv,
             xadj_, adj_,vertex_colors_, vertex_color_set_,
             current_vertexList_,next_iteration_recolorList_);
-        Kokkos::parallel_reduce(my_exec_space(0, current_vertexListLength_), conf, numUncolored);
+        Kokkos::parallel_reduce("KokkosGraph::GraphColoring::FindConflicts::CaseD", my_exec_space(0, current_vertexListLength_), conf, numUncolored);
       }
 
 
@@ -2940,8 +2940,7 @@ public:
       //std::cout << "nv:" << this->nv << " i:" << i  << " num_work_edges:" << num_work_edges<< std::endl;
       //conflict detection mark conflicts as color 0.
       //update their bans
-      Kokkos::parallel_for(
-          "KokkosGraph::GraphColoring::HalfEdgeMarkConflicts",
+      Kokkos::parallel_for("KokkosGraph::GraphColoring::HalfEdgeMarkConflicts",
           my_exec_space(0,num_work_edges),
           halfedge_mark_conflicts (
               _kok_src, _kok_dst,
@@ -2966,8 +2965,7 @@ public:
 
 
       if (num_work_edges > 0)
-      Kokkos::parallel_reduce(
-          "KokkosGraph::GraphColoring::HalfEdgeConflictsCount",
+      Kokkos::parallel_reduce("KokkosGraph::GraphColoring::HalfEdgeConflictsCount",
           my_exec_space(0, num_work_edges),
           halfedge_conflict_count(
               _kok_src, _kok_dst,
@@ -3007,16 +3005,14 @@ public:
         //use_pps = false;
         if (use_pps){
           //calculate new positions of the edges in new worklist
-          Kokkos::parallel_scan (
-              "KokkosGraph::GraphColoring::CalcEdgePositions",
+          Kokkos::parallel_scan ("KokkosGraph::GraphColoring::CalcEdgePositions",
               my_exec_space(0, num_work_edges),
               parallel_prefix_sum(edge_conflict_indices, edge_conflict_marker, pps)
           );
           MyExecSpace::fence();
 
           //write the edge indices to new worklist.
-          Kokkos::parallel_for (
-              "KokkosGraph::GraphColoring::CreateNewWorkArray",
+          Kokkos::parallel_for ("KokkosGraph::GraphColoring::CreateNewWorkArray",
               my_exec_space(0, num_work_edges),
               create_new_work_array(edge_conflict_indices, edge_conflict_marker, pps, new_edge_conflict_indices));
           MyExecSpace::fence();
@@ -3024,8 +3020,7 @@ public:
         else {
           //create new worklist
           single_dim_index_view_type new_index = single_dim_index_view_type("recolorListLength");;
-          Kokkos::parallel_for (
-              "KokkosGraph::GraphColoring::CreateNewWorkArrayAtomic",
+          Kokkos::parallel_for ("KokkosGraph::GraphColoring::CreateNewWorkArrayAtomic",
               my_exec_space(0, num_work_edges),
               atomic_create_new_work_array(new_index, edge_conflict_indices, edge_conflict_marker, new_edge_conflict_indices));
           MyExecSpace::fence();
@@ -3045,8 +3040,7 @@ public:
       }
 
       //create ban colors using the colored neighbors
-      Kokkos::parallel_for (
-          "KokkosGraph::GraphColoring::HalfEdgeBancColors",
+      Kokkos::parallel_for ("KokkosGraph::GraphColoring::HalfEdgeBancColors",
           my_exec_space(0,num_work_edges),
           halfedge_ban_colors(
               _kok_src, _kok_dst,
@@ -3064,8 +3058,7 @@ public:
 
 
       //create tentative ban using the uncolored neighbors.
-      Kokkos::parallel_for (
-          "KokkosGraph::GraphColoring::HalfEdgeExpandBanForUnmatchedNeighbors",
+      Kokkos::parallel_for ("KokkosGraph::GraphColoring::HalfEdgeExpandBanForUnmatchedNeighbors",
           my_exec_space(0,num_work_edges),
           halfedge_expand_ban_for_unmatched_neighbors(
               _kok_src, _kok_dst,

--- a/src/impl/tpls/KokkosBlas1_axpby_tpl_spec_decl.hpp
+++ b/src/impl/tpls/KokkosBlas1_axpby_tpl_spec_decl.hpp
@@ -90,6 +90,7 @@ struct Axpby< \
 \
   static void \
   axpby (const AV& alpha, const XV& X, const BV& beta, const YV& Y) { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,double]"); \
     if((X.extent(0) < INT_MAX) && (beta == 1.0)) { \
       axpby_print_specialization<AV,XV,BV,YV>(); \
       int N = X.extent(0); \
@@ -97,6 +98,7 @@ struct Axpby< \
       daxpy_(&N,&alpha,X.data(),&one,Y.data(),&one); \
     } else \
       Axpby<AV,XV,BV,YV,YV::Rank,false,ETI_SPEC_AVAIL>::axpby(alpha,X,beta,Y); \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -120,6 +122,7 @@ struct Axpby< \
 \
   static void \
   axpby (const AV& alpha, const XV& X, const BV& beta, const YV& Y) { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,float]"); \
     if((X.extent(0) < INT_MAX) && (beta == 1.0f)) { \
       axpby_print_specialization<AV,XV,BV,YV>(); \
       int N = X.extent(0); \
@@ -127,6 +130,7 @@ struct Axpby< \
       saxpy_(&N,&alpha,X.data(),&one,Y.data(),&one); \
     } else \
       Axpby<AV,XV,BV,YV,YV::Rank,false,ETI_SPEC_AVAIL>::axpby(alpha,X,beta,Y); \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -149,6 +153,7 @@ struct Axpby< \
 \
   static void \
   axpby (const AV& alpha, const XV& X, const BV& beta, const YV& Y) { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,complex<double>]"); \
     if((X.extent(0) < INT_MAX) && (beta == 1.0f)) { \
       axpby_print_specialization<AV,XV,BV,YV>(); \
       int N = X.extent(0); \
@@ -158,6 +163,7 @@ struct Axpby< \
                 reinterpret_cast<std::complex<double>* >(Y.data()),&one); \
     } else \
       Axpby<AV,XV,BV,YV,YV::Rank,false,ETI_SPEC_AVAIL>::axpby(alpha,X,beta,Y); \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -180,6 +186,7 @@ struct Axpby< \
 \
   static void \
   axpby (const AV& alpha, const XV& X, const BV& beta, const YV& Y) { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,complex<float>]"); \
     if((X.extent(0) < INT_MAX) && (beta == 1.0f)) { \
       axpby_print_specialization<AV,XV,BV,YV>(); \
       int N = X.extent(0); \
@@ -189,6 +196,7 @@ struct Axpby< \
                 reinterpret_cast<std::complex<float>* >(Y.data()),&one); \
     } else \
       Axpby<AV,XV,BV,YV,YV::Rank,false,ETI_SPEC_AVAIL>::axpby(alpha,X,beta,Y); \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -240,6 +248,7 @@ struct Axpby< \
 \
   static void \
   axpby (const AV& alpha, const XV& X, const BV& beta, const YV& Y) { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,double]"); \
     const size_type numElems = X.extent(0); \
     if((numElems < static_cast<size_type> (INT_MAX)) && (beta == 1.0)) { \
       axpby_print_specialization<AV,XV,BV,YV>(); \
@@ -249,6 +258,7 @@ struct Axpby< \
       cublasDaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one); \
     } else \
       Axpby<AV,XV,BV,YV,YV::Rank,false,ETI_SPEC_AVAIL>::axpby(alpha,X,beta,Y); \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -273,6 +283,7 @@ struct Axpby< \
 \
   static void \
   axpby (const AV& alpha, const XV& X, const BV& beta, const YV& Y) { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,float]"); \
     const size_type numElems = X.extent(0); \
     if((numElems < static_cast<size_type> (INT_MAX)) && (beta == 1.0f)) { \
       axpby_print_specialization<AV,XV,BV,YV>(); \
@@ -282,6 +293,7 @@ struct Axpby< \
       cublasSaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one); \
     } else \
       Axpby<AV,XV,BV,YV,YV::Rank,false,ETI_SPEC_AVAIL>::axpby(alpha,X,beta,Y); \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -305,6 +317,7 @@ struct Axpby< \
 \
   static void \
   axpby (const AV& alpha, const XV& X, const BV& beta, const YV& Y) { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,complex<double>]"); \
     const size_type numElems = X.extent(0); \
     if((numElems < static_cast<size_type> (INT_MAX)) && (beta == 1.0f)) { \
       axpby_print_specialization<AV,XV,BV,YV>(); \
@@ -314,6 +327,7 @@ struct Axpby< \
       cublasZaxpy(s.handle, N, reinterpret_cast<const cuDoubleComplex*>(&alpha), reinterpret_cast<const cuDoubleComplex*>(X.data()), one, reinterpret_cast<cuDoubleComplex*>(Y.data()), one); \
     } else \
       Axpby<AV,XV,BV,YV,YV::Rank,false,ETI_SPEC_AVAIL>::axpby(alpha,X,beta,Y); \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -337,6 +351,7 @@ struct Axpby< \
 \
   static void \
   axpby (const AV& alpha, const XV& X, const BV& beta, const YV& Y) { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,complex<float>]"); \
     const size_type numElems = X.extent(0); \
     if((numElems < static_cast<size_type> (INT_MAX)) && (beta == 1.0f)) { \
       axpby_print_specialization<AV,XV,BV,YV>(); \
@@ -346,6 +361,7 @@ struct Axpby< \
       cublasCaxpy(s.handle, N, reinterpret_cast<const cuComplex*>(&alpha), reinterpret_cast<const cuComplex*>(X.data()), one, reinterpret_cast<cuComplex*>(Y.data()), one); \
     } else \
       Axpby<AV,XV,BV,YV,YV::Rank,false,ETI_SPEC_AVAIL>::axpby(alpha,X,beta,Y); \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 

--- a/src/impl/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
+++ b/src/impl/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
@@ -88,6 +88,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void dot (RV& R, const XV& X, const XV& Y) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::dot[TPL_BLAS,double]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       dot_print_specialization<RV,XV,XV>(); \
@@ -97,6 +98,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       Dot<RV,XV,XV,1,1,false,ETI_SPEC_AVAIL>::dot(R,X,Y); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -119,6 +121,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void dot (RV& R, const XV& X, const XV& Y) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::dot[TPL_BLAS,float]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       dot_print_specialization<RV,XV,XV>(); \
@@ -128,6 +131,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       Dot<RV,XV,XV,1,1,false,ETI_SPEC_AVAIL>::dot(R,X,Y); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -150,6 +154,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
   \
   static void dot (RV& R, const XV& X, const XV& Y) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::dot[TPL_BLAS,complex<double>]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       dot_print_specialization<RV,XV,XV>(); \
@@ -162,6 +167,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
     } else { \
       Dot<RV,XV,XV,1,1,false,ETI_SPEC_AVAIL>::dot(R,X,Y); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -184,6 +190,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
   \
   static void dot (RV& R, const XV& X, const XV& Y) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::dot[TPL_BLAS,complex<float>]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       dot_print_specialization<RV,XV,XV>(); \
@@ -196,6 +203,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
     } else { \
       Dot<RV,XV,XV,1,1,false,ETI_SPEC_AVAIL>::dot(R,X,Y); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -242,6 +250,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void dot (RV& R, const XV& X, const XV& Y) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::dot[TPL_CUBLAS,double]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       dot_print_specialization<RV,XV,XV>(); \
@@ -252,6 +261,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       Dot<RV,XV,XV,1,1,false,ETI_SPEC_AVAIL>::dot(R,X,Y); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -274,6 +284,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void dot (RV& R, const XV& X, const XV& Y) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::dot[TPL_CUBLAS,float]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       dot_print_specialization<RV,XV,XV>(); \
@@ -284,6 +295,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       Dot<RV,XV,XV,1,1,false,ETI_SPEC_AVAIL>::dot(R,X,Y); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -306,6 +318,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
   \
   static void dot (RV& R, const XV& X, const XV& Y) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::dot[TPL_CUBLAS,complex<double>]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       dot_print_specialization<RV,XV,XV>(); \
@@ -316,6 +329,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
     } else { \
       Dot<RV,XV,XV,1,1,false,ETI_SPEC_AVAIL>::dot(R,X,Y); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -338,6 +352,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
   \
   static void dot (RV& R, const XV& X, const XV& Y) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::dot[TPL_CUBLAS,complex<float>]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       dot_print_specialization<RV,XV,XV>(); \
@@ -348,6 +363,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
     } else { \
       Dot<RV,XV,XV,1,1,false,ETI_SPEC_AVAIL>::dot(R,X,Y); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 

--- a/src/impl/tpls/KokkosBlas1_nrm1_tpl_spec_decl.hpp
+++ b/src/impl/tpls/KokkosBlas1_nrm1_tpl_spec_decl.hpp
@@ -82,6 +82,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void nrm1 (RV& R, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm1[TPL_BLAS,double]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       nrm1_print_specialization<RV,XV>(); \
@@ -91,6 +92,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       Nrm1<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm1(R,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -111,6 +113,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void nrm1 (RV& R, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm1[TPL_BLAS,float]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       nrm1_print_specialization<RV,XV>(); \
@@ -120,6 +123,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       Nrm1<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm1(R,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -140,6 +144,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
   \
   static void nrm1 (RV& R, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm1[TPL_BLAS,complex<double>]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       nrm1_print_specialization<RV,XV>(); \
@@ -149,6 +154,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
     } else { \
       Nrm1<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm1(R,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -169,6 +175,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
   \
   static void nrm1 (RV& R, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm1[TPL_BLAS,complex<float>]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       nrm1_print_specialization<RV,XV>(); \
@@ -178,6 +185,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
     } else { \
       Nrm1<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm1(R,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -222,6 +230,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void nrm1 (RV& R, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm1[TPL_CUBLAS,double]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       nrm1_print_specialization<RV,XV>(); \
@@ -232,6 +241,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       Nrm1<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm1(R,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -252,6 +262,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void nrm1 (RV& R, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm1[TPL_CUBLAS,float]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       nrm1_print_specialization<RV,XV>(); \
@@ -262,6 +273,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       Nrm1<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm1(R,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -282,6 +294,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
   \
   static void nrm1 (RV& R, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm1[TPL_CUBLAS,complex<double>]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       nrm1_print_specialization<RV,XV>(); \
@@ -292,6 +305,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
     } else { \
       Nrm1<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm1(R,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -312,6 +326,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
   \
   static void nrm1 (RV& R, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm1[TPL_CUBLAS,complex<float>]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       nrm1_print_specialization<RV,XV>(); \
@@ -322,6 +337,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
     } else { \
       Nrm1<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm1(R,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 

--- a/src/impl/tpls/KokkosBlas1_nrm2_tpl_spec_decl.hpp
+++ b/src/impl/tpls/KokkosBlas1_nrm2_tpl_spec_decl.hpp
@@ -82,6 +82,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void nrm2 (RV& R, const XV& X, const bool& take_sqrt) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm2[TPL_BLAS,double]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       nrm2_print_specialization<RV,XV>(); \
@@ -92,6 +93,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       Nrm2<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm2(R,X,take_sqrt); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -112,6 +114,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void nrm2 (RV& R, const XV& X, const bool& take_sqrt) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm2[TPL_BLAS,float]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       nrm2_print_specialization<RV,XV>(); \
@@ -122,6 +125,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       Nrm2<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm2(R,X,take_sqrt); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -142,6 +146,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
   \
   static void nrm2 (RV& R, const XV& X, const bool& take_sqrt) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm2[TPL_BLAS,complex<double>]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       nrm2_print_specialization<RV,XV>(); \
@@ -152,6 +157,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
     } else { \
       Nrm2<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm2(R,X,take_sqrt); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -172,6 +178,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
   \
   static void nrm2 (RV& R, const XV& X, const bool& take_sqrt) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm2[TPL_BLAS,complex<float>]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       nrm2_print_specialization<RV,XV>(); \
@@ -182,6 +189,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
     } else { \
       Nrm2<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm2(R,X,take_sqrt); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -226,6 +234,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void nrm2 (RV& R, const XV& X, const bool& take_sqrt) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm2[TPL_CUBLAS,double]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       nrm2_print_specialization<RV,XV>(); \
@@ -237,6 +246,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       Nrm2<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm2(R,X,take_sqrt); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -257,6 +267,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void nrm2 (RV& R, const XV& X, const bool& take_sqrt) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm2[TPL_CUBLAS,float]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       nrm2_print_specialization<RV,XV>(); \
@@ -268,6 +279,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       Nrm2<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm2(R,X,take_sqrt); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -288,6 +300,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
   \
   static void nrm2 (RV& R, const XV& X, const bool& take_sqrt) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm2[TPL_CUBLAS,complex<double>]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       nrm2_print_specialization<RV,XV>(); \
@@ -299,6 +312,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
     } else { \
       Nrm2<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm2(R,X,take_sqrt); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -319,6 +333,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
   \
   static void nrm2 (RV& R, const XV& X, const bool& take_sqrt) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm2[TPL_CUBLAS,complex<float>]"); \
     const size_type numElems = X.extent(0); \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
       nrm2_print_specialization<RV,XV>(); \
@@ -330,6 +345,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
     } else { \
       Nrm2<RV,XV,1,false,ETI_SPEC_AVAIL>::nrm2(R,X,take_sqrt); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 

--- a/src/impl/tpls/KokkosBlas1_nrminf_tpl_spec_decl.hpp
+++ b/src/impl/tpls/KokkosBlas1_nrminf_tpl_spec_decl.hpp
@@ -82,6 +82,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void nrminf (RV& R, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_BLAS,double]"); \
     const size_type numElems = X.extent(0); \
     if (numElems == 0) { R() = 0.0; return; } \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
@@ -93,6 +94,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       NrmInf<RV,XV,1,false,ETI_SPEC_AVAIL>::nrminf(R,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -113,6 +115,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void nrminf (RV& R, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_BLAS,float]"); \
     const size_type numElems = X.extent(0); \
     if (numElems == 0) { R() = 0.0f; return; } \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
@@ -124,6 +127,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       NrmInf<RV,XV,1,false,ETI_SPEC_AVAIL>::nrminf(R,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -145,6 +149,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
   \
   static void nrminf (RV& R, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_BLAS,complex<double>]"); \
     const size_type numElems = X.extent(0); \
     if (numElems == 0) { R() = 0.0; return; } \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
@@ -156,6 +161,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
     } else { \
       NrmInf<RV,XV,1,false,ETI_SPEC_AVAIL>::nrminf(R,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -177,6 +183,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
   \
   static void nrminf (RV& R, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_BLAS,complex<float>]"); \
     const size_type numElems = X.extent(0); \
     if (numElems == 0) { R() = 0.0f; return; } \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
@@ -188,6 +195,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
     } else { \
       NrmInf<RV,XV,1,false,ETI_SPEC_AVAIL>::nrminf(R,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -232,6 +240,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void nrminf (RV& R, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_CUBLAS,double]"); \
     const size_type numElems = X.extent(0); \
     if (numElems == 0) { Kokkos::deep_copy (R, 0.0); return; } \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
@@ -245,6 +254,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       NrmInf<RV,XV,1,false,ETI_SPEC_AVAIL>::nrminf(R,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -265,6 +275,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void nrminf (RV& R, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_CUBLAS,float]"); \
     const size_type numElems = X.extent(0); \
     if (numElems == 0) { Kokkos::deep_copy (R, 0.0f);; return; } \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
@@ -278,6 +289,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       NrmInf<RV,XV,1,false,ETI_SPEC_AVAIL>::nrminf(R,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -299,6 +311,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
   \
   static void nrminf (RV& R, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_CUBLAS,complex<double>]"); \
     const size_type numElems = X.extent(0); \
     if (numElems == 0) { Kokkos::deep_copy (R, 0.0); return; } \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
@@ -315,6 +328,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
     } else { \
       NrmInf<RV,XV,1,false,ETI_SPEC_AVAIL>::nrminf(R,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -336,6 +350,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
   \
   static void nrminf (RV& R, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_CUBLAS,complex<float>]"); \
     const size_type numElems = X.extent(0); \
     if (numElems == 0) { Kokkos::deep_copy (R, 0.0f); return; } \
     if (numElems < static_cast<size_type> (INT_MAX)) { \
@@ -352,6 +367,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
     } else { \
       NrmInf<RV,XV,1,false,ETI_SPEC_AVAIL>::nrminf(R,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 

--- a/src/impl/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
+++ b/src/impl/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
@@ -88,6 +88,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void scal (const RV& R, const double& alpha, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::scal[TPL_BLAS,double]"); \
     const size_type numElems = X.extent(0); \
     if ((numElems < static_cast<size_type> (INT_MAX)) && (R.data() == X.data())) { \
       scal_print_specialization<RV,AV,XV>(); \
@@ -97,6 +98,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       Scal<RV,AV,XV,1,false,ETI_SPEC_AVAIL>::scal(R,alpha,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -119,6 +121,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void scal (const RV& R, const float& alpha, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::scal[TPL_BLAS,float]"); \
     const size_type numElems = X.extent(0); \
     if ((numElems < static_cast<size_type> (INT_MAX)) && (R.data() == X.data())) { \
       scal_print_specialization<RV,AV,XV>(); \
@@ -128,6 +131,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       Scal<RV,AV,XV,1,false,ETI_SPEC_AVAIL>::scal(R,alpha,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -150,6 +154,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
   \
   static void scal (const RV& R, const Kokkos::complex<double>& alpha, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::scal[TPL_BLAS,complex<double>]"); \
     const size_type numElems = X.extent(0); \
     if ((numElems < static_cast<size_type> (INT_MAX)) && (R.data() == X.data())) { \
       scal_print_specialization<RV,AV,XV>(); \
@@ -159,6 +164,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
     } else { \
       Scal<RV,AV,XV,1,false,ETI_SPEC_AVAIL>::scal(R,alpha,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -181,6 +187,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
   \
   static void scal (const RV& R, const Kokkos::complex<float>& alpha, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::scal[TPL_BLAS,complex<float>]"); \
     const size_type numElems = X.extent(0); \
     if ((numElems < static_cast<size_type> (INT_MAX)) && (R.data() == X.data())) { \
       scal_print_specialization<RV,AV,XV>(); \
@@ -190,6 +197,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
     } else { \
       Scal<RV,AV,XV,1,false,ETI_SPEC_AVAIL>::scal(R,alpha,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -236,6 +244,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void scal (const RV& R, const double& alpha, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::scal[TPL_CUBLAS,double]"); \
     const size_type numElems = X.extent(0); \
     if ((numElems < static_cast<size_type> (INT_MAX)) && (R.data() == X.data())) { \
       scal_print_specialization<RV,AV,XV>(); \
@@ -246,6 +255,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       Scal<RV,AV,XV,1,false,ETI_SPEC_AVAIL>::scal(R,alpha,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -268,6 +278,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   \
   static void scal (const RV& R, const float& alpha, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::scal[TPL_CUBLAS,float]"); \
     const size_type numElems = X.extent(0); \
     if ((numElems < static_cast<size_type> (INT_MAX)) && (R.data() == X.data())) { \
       scal_print_specialization<RV,AV,XV>(); \
@@ -278,6 +289,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
     } else { \
       Scal<RV,AV,XV,1,false,ETI_SPEC_AVAIL>::scal(R,alpha,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -300,6 +312,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
   \
   static void scal (const RV& R, const Kokkos::complex<double>& alpha, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::scal[TPL_CUBLAS,complex<double>]"); \
     const size_type numElems = X.extent(0); \
     if ((numElems < static_cast<size_type> (INT_MAX)) && (R.data() == X.data())) { \
       scal_print_specialization<RV,AV,XV>(); \
@@ -310,6 +323,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
     } else { \
       Scal<RV,AV,XV,1,false,ETI_SPEC_AVAIL>::scal(R,alpha,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 
@@ -332,6 +346,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
   \
   static void scal (const RV& R, const Kokkos::complex<float>& alpha, const XV& X) \
   { \
+    Kokkos::Profiling::pushRegion("KokkosBlas::scal[TPL_CUBLAS,complex<float>]"); \
     const size_type numElems = X.extent(0); \
     if ((numElems < static_cast<size_type> (INT_MAX)) && (R.data() == X.data())) { \
       scal_print_specialization<RV,AV,XV>(); \
@@ -342,6 +357,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
     } else { \
       Scal<RV,AV,XV,1,false,ETI_SPEC_AVAIL>::scal(R,alpha,X); \
     } \
+    Kokkos::Profiling::popRegion(); \
   } \
 };
 

--- a/test_common/KokkosBatched_Test_BlockCrs.hpp
+++ b/test_common/KokkosBatched_Test_BlockCrs.hpp
@@ -116,8 +116,7 @@ namespace KokkosBatched {
       KOKKOS_INLINE_FUNCTION 
       void operator()(const TeamTag &, const MemberType &member) const {
         const int ijbeg = member.league_rank()*VectorLength;
-        Kokkos::parallel_for
-          (Kokkos::ThreadVectorRange(member, VectorLength),
+        Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, VectorLength),
            [&](const int &idx) {
             const int ij = ijbeg + idx;
             if (ij < _ntridiag) {
@@ -211,8 +210,7 @@ namespace KokkosBatched {
         ScratchViewType<packed_view_type> sA(member.team_scratch(_shmemlvl), VectorLength, _blocksize, _blocksize);
 
         const int ijbeg = member.league_rank()*VectorLength;
-        Kokkos::parallel_for
-          (Kokkos::ThreadVectorRange(member, VectorLength),
+        Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, VectorLength),
            [&](const int &idx) {
             const int ij = ijbeg + idx;
             if (ij < _ntridiag) {
@@ -294,7 +292,7 @@ namespace KokkosBatched {
           case 0: {
             std::cout << "KokkosBatched::RangeTag::" << Gemm_AlgoTagType::name() << "\n";
             const Kokkos::RangePolicy<exec_space,RangeTag> policy(0, _ntridiag);
-            Kokkos::parallel_for(policy, *this);
+            Kokkos::parallel_for("KokkosBatched::Test::BlockCrs::FactorizeBlockTridiagMatrices::Op0", policy, *this);
             break;
           }
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__KOKKOSBATCHED_TEST_ENABLE_CUDA__)
@@ -322,7 +320,7 @@ namespace KokkosBatched {
             }
 
             const policy_type policy(_ntridiag, team_size, VectorLength);
-            Kokkos::parallel_for(policy, *this);
+            Kokkos::parallel_for("KokkosBatched::Test::BlockCrs::FactorizeBlockTridiagMatrices::Op1", policy, *this);
             break;
           }
           case 2: {
@@ -354,7 +352,7 @@ namespace KokkosBatched {
               }
               
               policy_type policy = policy_type(_ntridiag, team_size, VectorLength).set_scratch_size(_shmemlvl, Kokkos::PerTeam(per_team_scratch));
-              Kokkos::parallel_for(policy, *this);
+              Kokkos::parallel_for("KokkosBatched::Test::BlockCrs::FactorizeBlockTridiagMatrices::Op2", policy, *this);
             } 
             break;
           }
@@ -604,8 +602,7 @@ namespace KokkosBatched {
       KOKKOS_INLINE_FUNCTION 
       void operator()(const TeamTag &, const MemberType &member) const {
         const int ijbeg = member.league_rank()*VectorLength;
-        Kokkos::parallel_for
-          (Kokkos::ThreadVectorRange(member, VectorLength),
+        Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, VectorLength),
            [&](const int &idx) {
             const int ij = ijbeg + idx;
             if (ij < _ntridiag) {
@@ -704,8 +701,7 @@ namespace KokkosBatched {
         ScratchViewType<packed_view_type> s(member.team_scratch(_shmemlvl), VectorLength, _m, _blocksize);
 
         const int ijbeg = member.league_rank()*VectorLength;
-        Kokkos::parallel_for
-          (Kokkos::ThreadVectorRange(member, VectorLength),
+        Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, VectorLength),
            [&](const int &idx) {
             const int ij = ijbeg + idx;
             if (ij < _ntridiag) {
@@ -825,7 +821,7 @@ namespace KokkosBatched {
           switch (op) {
           case 0: {
             const Kokkos::RangePolicy<exec_space,RangeTag> policy(0, _ntridiag);
-            Kokkos::parallel_for(policy, *this);
+            Kokkos::parallel_for("KokkosBatched::Test::BlockCrs::SolveBlockTridiagMatrices::Op0", policy, *this);
             break;
           }
 #if defined(KOKKOS_ENABLE_CUDA) && defined(__KOKKOSBATCHED_TEST_ENABLE_CUDA__)
@@ -850,7 +846,7 @@ namespace KokkosBatched {
             }
             
             const policy_type policy(_ntridiag, team_size, VectorLength);
-            Kokkos::parallel_for(policy, *this);
+            Kokkos::parallel_for("KokkosBatched::Test::BlockCrs::SolveBlockTridiagMatrices::Op1", policy, *this);
             break;
           }
           case 2: {
@@ -879,7 +875,7 @@ namespace KokkosBatched {
               }
               
               policy_type policy = policy_type(_ntridiag, team_size, VectorLength).set_scratch_size(_shmemlvl, Kokkos::PerTeam(per_team_scratch));;
-              Kokkos::parallel_for(policy, *this);
+              Kokkos::parallel_for("KokkosBatched::Test::BlockCrs::SolveBlockTridiagMatrices::Op2", policy, *this);
             }
             break;
           }

--- a/test_common/Test_Common_ArithTraits.hpp
+++ b/test_common/Test_Common_ArithTraits.hpp
@@ -1447,7 +1447,7 @@ int testArithTraitsOnDevice (std::ostream& out, const int verbose)
   using std::endl;
   typedef ArithTraitsTester<ScalarType, DeviceType> functor_type;
   int success = 1; // output argument of parallel_reduce
-  Kokkos::parallel_reduce (1, functor_type (), success);
+  Kokkos::parallel_reduce ("KokkosKernels::Common::Test::ArithTraitsOnDevice", 1, functor_type (), success);
   if (success) {
     if (verbose)
       out << Kokkos::Details::ArithTraits<ScalarType>::name () << " passed" << endl;

--- a/test_common/Test_Common_set_bit_count.hpp
+++ b/test_common/Test_Common_set_bit_count.hpp
@@ -104,7 +104,7 @@ view_type get_array_bit_count(view_type view){
   typename view_type::non_const_type out_view ("out", view.extent(0));
 
   typedef Kokkos::RangePolicy<execution_space> my_exec_space;
-  Kokkos::parallel_for( my_exec_space(0, view.extent(0)),ppctest<view_type> (view, out_view));
+  Kokkos::parallel_for( "KokkosKernels::Common::Test::GetArrayBitCount", my_exec_space(0, view.extent(0)),ppctest<view_type> (view, out_view));
   Kokkos::fence();
   return out_view;
 }
@@ -116,7 +116,7 @@ view_type check_array_bit_count(view_type view){
   typename view_type::non_const_type  out_view ("out", view.extent(0));
 
   typedef Kokkos::RangePolicy<execution_space> my_exec_space;
-  Kokkos::parallel_for( my_exec_space(0, view.extent(0)), ppccheck<view_type> (view, out_view));
+  Kokkos::parallel_for( "KokkosKernels::Common::Test::CheckArrayBitCount", my_exec_space(0, view.extent(0)), ppccheck<view_type> (view, out_view));
   Kokkos::fence();
   return out_view;
 }
@@ -165,7 +165,7 @@ view_type get_ffs(view_type view){
   typename view_type::non_const_type out_view ("out", view.extent(0));
 
   typedef Kokkos::RangePolicy<execution_space> my_exec_space;
-  Kokkos::parallel_for( my_exec_space(0, view.extent(0)),  ffstest<view_type> (view, out_view));
+  Kokkos::parallel_for( "KokkosKernels::Common::Test::GetFFS", my_exec_space(0, view.extent(0)),  ffstest<view_type> (view, out_view));
   Kokkos::fence();
   return out_view;
 }
@@ -177,7 +177,7 @@ view_type check_ffs(view_type view){
   typename view_type::non_const_type  out_view ("out", view.extent(0));
 
   typedef Kokkos::RangePolicy<execution_space> my_exec_space;
-  Kokkos::parallel_for( my_exec_space(0, view.extent(0)),  ffscheck<view_type> (view, out_view));
+  Kokkos::parallel_for( "KokkosKernels::Common::Test::CheckFFS", my_exec_space(0, view.extent(0)),  ffscheck<view_type> (view, out_view));
   Kokkos::fence();
   return out_view;
 }

--- a/unit_test/batched/Test_Batched_SerialGemm.hpp
+++ b/unit_test/batched/Test_Batched_SerialGemm.hpp
@@ -53,8 +53,17 @@ namespace Test {
     
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::SerialGemm");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion( name.c_str() );
       Kokkos::RangePolicy<DeviceType,ParamTagType> policy(0, _c.extent(0));
-      Kokkos::parallel_for(policy, *this);            
+      Kokkos::parallel_for(name.c_str(), policy, *this);            
+      Kokkos::Profiling::popRegion();
     }
   };
     

--- a/unit_test/batched/Test_Batched_SerialGemv.hpp
+++ b/unit_test/batched/Test_Batched_SerialGemv.hpp
@@ -51,8 +51,17 @@ namespace Test {
     
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::SerialGemv");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion(name.c_str() );
       Kokkos::RangePolicy<DeviceType,ParamTagType> policy(0, _c.extent(0));
-      Kokkos::parallel_for(policy, *this);            
+      Kokkos::parallel_for(name.c_str(), policy, *this);
+      Kokkos::Profiling::popRegion();
     }
   };
     

--- a/unit_test/batched/Test_Batched_SerialInverseLU.hpp
+++ b/unit_test/batched/Test_Batched_SerialInverseLU.hpp
@@ -60,8 +60,17 @@ namespace Test {
     
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::SerialInverseLU");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion(name.c_str() );
       Kokkos::RangePolicy<DeviceType,ParamTagType> policy(0, _c.extent(0));
-      Kokkos::parallel_for(policy, *this);            
+      Kokkos::parallel_for((name+"::GemmFunctor").c_str(), policy, *this);            
+      Kokkos::Profiling::popRegion();
     }
   };
 
@@ -87,8 +96,17 @@ namespace Test {
 
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::SerialInverseLU");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion(name.c_str() );
       Kokkos::RangePolicy<DeviceType> policy(0, _a.extent(0));
-      Kokkos::parallel_for(policy, *this);
+      Kokkos::parallel_for((name+"::LUFunctor").c_str(), policy, *this);
+      Kokkos::Profiling::popRegion();
     }
   };
 
@@ -114,8 +132,18 @@ namespace Test {
 
     inline
     void run() {
+      typedef typename AViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::SerialInverseLU");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion(name.c_str() );
       Kokkos::RangePolicy<DeviceType> policy(0, _a.extent(0));
-      Kokkos::parallel_for(policy, *this);
+      Kokkos::parallel_for((name+"::InverseLUFunctor").c_str(), policy, *this);
+      Kokkos::Profiling::popRegion();
+
     }
   };
 

--- a/unit_test/batched/Test_Batched_SerialLU.hpp
+++ b/unit_test/batched/Test_Batched_SerialLU.hpp
@@ -37,8 +37,17 @@ namespace Test {
 
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::SerialLU");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion( name.c_str() );
       Kokkos::RangePolicy<DeviceType> policy(0, _a.extent(0));
-      Kokkos::parallel_for(policy, *this);
+      Kokkos::parallel_for(name.c_str(), policy, *this);
+      Kokkos::Profiling::popRegion();
     }
   };
 

--- a/unit_test/batched/Test_Batched_SerialMatUtil.hpp
+++ b/unit_test/batched/Test_Batched_SerialMatUtil.hpp
@@ -69,11 +69,22 @@ namespace Test {
 
     inline
     int run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::SerialMatUtil");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name_work_tag = ( std::is_same<AlgoTagType,KokkosKernelTag>::value ? "::KokkosBatched" :
+                                    std::is_same<AlgoTagType,NaiveTag>::value ? "::Naive" : "::UnknownWorkTag");
+      std::string name_test_id = ( TestID == BatchedSet ? "Set" : 
+                                   TestID == BatchedScale ? "Scale" : "UnknownTest");
+      std::string name = name_region + name_value_type + name_work_tag + name_test_id;
+      Kokkos::Profiling::pushRegion( name.c_str() );
       Kokkos::RangePolicy<DeviceType,AlgoTagType> policy(0, _a.extent(0));
-      Kokkos::parallel_for(policy, *this);
+      Kokkos::parallel_for(name.c_str(), policy, *this);
+      Kokkos::Profiling::popRegion();
       return 0; 
-      //MD 08/2017 NOTE: compilation was failing with werror.
-      //I added dummy return.
     }      
   };
 

--- a/unit_test/batched/Test_Batched_SerialSolveLU.hpp
+++ b/unit_test/batched/Test_Batched_SerialSolveLU.hpp
@@ -60,8 +60,17 @@ namespace Test {
     
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::SerialSolveLU");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion( name.c_str() );
       Kokkos::RangePolicy<DeviceType,ParamTagType> policy(0, _c.extent(0));
-      Kokkos::parallel_for(policy, *this);            
+      Kokkos::parallel_for((name+"::GemmFunctor").c_str(), policy, *this);          
+      Kokkos::Profiling::popRegion();
     }
   };
 
@@ -87,8 +96,17 @@ namespace Test {
 
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::SerialSolveLU");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion( name.c_str() );
       Kokkos::RangePolicy<DeviceType> policy(0, _a.extent(0));
-      Kokkos::parallel_for(policy, *this);
+      Kokkos::parallel_for((name+"::LUFunctor").c_str(), policy, *this);
+      Kokkos::Profiling::popRegion();
     }
   };
 
@@ -114,8 +132,17 @@ namespace Test {
 
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::SerialSolveLU");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion( name.c_str() );
       Kokkos::RangePolicy<DeviceType> policy(0, _a.extent(0));
-      Kokkos::parallel_for(policy, *this);
+      Kokkos::parallel_for((name+"::SolveLUFunctor").c_str(), policy, *this);
+      Kokkos::Profiling::popRegion();      
     }
   };
 

--- a/unit_test/batched/Test_Batched_SerialTrsm.hpp
+++ b/unit_test/batched/Test_Batched_SerialTrsm.hpp
@@ -54,8 +54,17 @@ namespace Test {
 
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::SerialTrsm");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion( name.c_str() );
       Kokkos::RangePolicy<DeviceType,ParamTagType> policy(0, _b.extent(0));
-      Kokkos::parallel_for(policy, *this);
+      Kokkos::parallel_for(name.c_str(), policy, *this);
+      Kokkos::Profiling::popRegion();
     }
   };
 

--- a/unit_test/batched/Test_Batched_SerialTrsv.hpp
+++ b/unit_test/batched/Test_Batched_SerialTrsv.hpp
@@ -52,8 +52,17 @@ namespace Test {
 
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::SerialTrsv");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion( name.c_str() );
       Kokkos::RangePolicy<DeviceType,ParamTagType> policy(0, _b.extent(0));
       Kokkos::parallel_for(policy, *this);
+      Kokkos::Profiling::popRegion();
     }
   };
 

--- a/unit_test/batched/Test_Batched_SerialTrsv.hpp
+++ b/unit_test/batched/Test_Batched_SerialTrsv.hpp
@@ -61,7 +61,7 @@ namespace Test {
       std::string name = name_region + name_value_type;
       Kokkos::Profiling::pushRegion( name.c_str() );
       Kokkos::RangePolicy<DeviceType,ParamTagType> policy(0, _b.extent(0));
-      Kokkos::parallel_for(policy, *this);
+      Kokkos::parallel_for(name.c_str(), policy, *this);
       Kokkos::Profiling::popRegion();
     }
   };

--- a/unit_test/batched/Test_Batched_TeamGemm.hpp
+++ b/unit_test/batched/Test_Batched_TeamGemm.hpp
@@ -58,9 +58,18 @@ namespace Test {
     
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::TeamGemm");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion( name.c_str() );
       const int league_size = _c.extent(0);
       Kokkos::TeamPolicy<DeviceType,ParamTagType> policy(league_size, Kokkos::AUTO);
-      Kokkos::parallel_for(policy, *this);            
+      Kokkos::parallel_for(name.c_str(), policy, *this);            
+      Kokkos::Profiling::popRegion(); 
     }
   };
     

--- a/unit_test/batched/Test_Batched_TeamGemv.hpp
+++ b/unit_test/batched/Test_Batched_TeamGemv.hpp
@@ -56,9 +56,18 @@ namespace Test {
     
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::SerialGemm");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion( name.c_str() );
       const int league_size = _c.extent(0);
       Kokkos::TeamPolicy<DeviceType,ParamTagType> policy(league_size, Kokkos::AUTO);
-      Kokkos::parallel_for(policy, *this);            
+      Kokkos::parallel_for(name.c_str(), policy, *this);          
+      Kokkos::Profiling::popRegion();   
     }
   };
     

--- a/unit_test/batched/Test_Batched_TeamInverseLU.hpp
+++ b/unit_test/batched/Test_Batched_TeamInverseLU.hpp
@@ -151,7 +151,7 @@ namespace Test {
 
     inline
     void run() {
-      typedef typename ViewType::value_type value_type;
+      typedef typename AViewType::value_type value_type;
       std::string name_region("KokkosBatched::Test::TeamInverseLU");
       std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
                                       std::is_same<value_type,double>::value ? "::Double" :

--- a/unit_test/batched/Test_Batched_TeamInverseLU.hpp
+++ b/unit_test/batched/Test_Batched_TeamInverseLU.hpp
@@ -67,9 +67,19 @@ namespace Test {
     
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::TeamInverseLU");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion( name.c_str() );
+
       const int league_size = _c.extent(0);
       Kokkos::TeamPolicy<DeviceType,ParamTagType> policy(league_size, Kokkos::AUTO);
-      Kokkos::parallel_for(policy, *this);            
+      Kokkos::parallel_for((name+"::GemmFunctor").c_str(), policy, *this);            
+      Kokkos::Profiling::popRegion(); 
     }
   };
 
@@ -100,9 +110,20 @@ namespace Test {
 
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::TeamInverseLU");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion( name.c_str() );
+
+
       const int league_size = _a.extent(0);
       Kokkos::TeamPolicy<DeviceType> policy(league_size, Kokkos::AUTO);
-      Kokkos::parallel_for(policy, *this);
+      Kokkos::parallel_for((name+"::LUFunctor").c_str(), policy, *this);
+      Kokkos::Profiling::popRegion(); 
     }
   };
 
@@ -130,9 +151,19 @@ namespace Test {
 
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::TeamInverseLU");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion( name.c_str() );
+
       const int league_size = _a.extent(0);
       Kokkos::TeamPolicy<DeviceType> policy(league_size, Kokkos::AUTO);
-      Kokkos::parallel_for(policy, *this);
+      Kokkos::parallel_for((name+"::InverseLUFunctor").c_str(), policy, *this);
+      Kokkos::Profiling::popRegion(); 
     }
   };
 

--- a/unit_test/batched/Test_Batched_TeamLU.hpp
+++ b/unit_test/batched/Test_Batched_TeamLU.hpp
@@ -43,9 +43,19 @@ namespace Test {
 
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::TeamLU");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion( name.c_str() );
+
       const int league_size = _a.extent(0);
       Kokkos::TeamPolicy<DeviceType> policy(league_size, Kokkos::AUTO);
-      Kokkos::parallel_for(policy, *this);
+      Kokkos::parallel_for(name.c_str(), policy, *this);
+      Kokkos::Profiling::popRegion(); 
     }
   };
 

--- a/unit_test/batched/Test_Batched_TeamMatUtil.hpp
+++ b/unit_test/batched/Test_Batched_TeamMatUtil.hpp
@@ -74,9 +74,23 @@ namespace Test {
 
     inline
     int run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::SerialMatUtil");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name_work_tag = ( std::is_same<AlgoTagType,KokkosKernelTag>::value ? "::KokkosBatched" :
+                                    std::is_same<AlgoTagType,NaiveTag>::value ? "::Naive" : "::UnknownWorkTag");
+      std::string name_test_id = ( TestID == BatchedSet ? "Set" : 
+                                   TestID == BatchedScale ? "Scale" : "UnknownTest");
+      std::string name = name_region + name_value_type + name_work_tag + name_test_id;
+      Kokkos::Profiling::pushRegion( name.c_str() );
+
       const int league_size = _a.extent(0);
       Kokkos::TeamPolicy<DeviceType,AlgoTagType> policy(league_size, Kokkos::AUTO);
-      Kokkos::parallel_for(policy, *this);
+      Kokkos::parallel_for(name.c_str(), policy, *this);
+      Kokkos::Profiling::popRegion(); 
 
       return 0; 
     }      

--- a/unit_test/batched/Test_Batched_TeamSolveLU.hpp
+++ b/unit_test/batched/Test_Batched_TeamSolveLU.hpp
@@ -67,9 +67,18 @@ namespace Test {
     
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::TeamSolveLU");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion( name.c_str() );
       const int league_size = _c.extent(0);
       Kokkos::TeamPolicy<DeviceType,ParamTagType> policy(league_size, Kokkos::AUTO);
-      Kokkos::parallel_for(policy, *this);            
+      Kokkos::parallel_for((name+"::GemmFunctor").c_str(), policy, *this);            
+      Kokkos::Profiling::popRegion(); 
     }
   };
 
@@ -100,9 +109,18 @@ namespace Test {
 
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::TeamSolveLU");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion( name.c_str() );
       const int league_size = _a.extent(0);
       Kokkos::TeamPolicy<DeviceType> policy(league_size, Kokkos::AUTO);
-      Kokkos::parallel_for(policy, *this);
+      Kokkos::parallel_for((name+"::LUFunctor").c_str(), policy, *this);
+      Kokkos::Profiling::popRegion(); 
     }
   };
 
@@ -130,9 +148,19 @@ namespace Test {
 
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::TeamSolveLU");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion( name.c_str() );
+
       const int league_size = _a.extent(0);
       Kokkos::TeamPolicy<DeviceType> policy(league_size, Kokkos::AUTO);
-      Kokkos::parallel_for(policy, *this);
+      Kokkos::parallel_for((name+"::SolveLU").c_str(), policy, *this);
+      Kokkos::Profiling::popRegion(); 
     }
   };
 

--- a/unit_test/batched/Test_Batched_TeamTrsm.hpp
+++ b/unit_test/batched/Test_Batched_TeamTrsm.hpp
@@ -59,9 +59,19 @@ namespace Test {
 
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::TeamTrsm");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion( name.c_str() );
+
       const int league_size = _b.extent(0);
       Kokkos::TeamPolicy<DeviceType,ParamTagType> policy(league_size, Kokkos::AUTO);
-      Kokkos::parallel_for(policy, *this);
+      Kokkos::parallel_for(name.c_str(), policy, *this);
+      Kokkos::Profiling::popRegion();
     }
   };
 

--- a/unit_test/batched/Test_Batched_TeamTrsv.hpp
+++ b/unit_test/batched/Test_Batched_TeamTrsv.hpp
@@ -57,9 +57,19 @@ namespace Test {
 
     inline
     void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::TeamTrsv");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion( name.c_str() );
+
       const int league_size = _b.extent(0);
       Kokkos::TeamPolicy<DeviceType,ParamTagType> policy(league_size, Kokkos::AUTO);
-      Kokkos::parallel_for(policy, *this);
+      Kokkos::parallel_for(name.c_str(), policy, *this);
+      Kokkos::Profiling::popRegion();
     }
   };
 

--- a/unit_test/blas/Test_Blas1_abs.hpp
+++ b/unit_test/blas/Test_Blas1_abs.hpp
@@ -222,37 +222,53 @@ int test_abs_mv() {
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, abs_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::abs_float");
     test_abs<float,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, abs_mv_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::abs_mv_float");
     test_abs_mv<float,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, abs_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::abs_double");
     test_abs<double,double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, abs_mv_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::abs_mv_double");
     test_abs_mv<double,double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, abs_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::abs_double");
     test_abs<Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, abs_mv_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::abs_mv_double");
     test_abs_mv<Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_INT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, abs_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::abs_int");
     test_abs<int,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, abs_mv_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::abs_mv_int");
     test_abs_mv<int,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 

--- a/unit_test/blas/Test_Blas1_asum.hpp
+++ b/unit_test/blas/Test_Blas1_asum.hpp
@@ -82,25 +82,33 @@ int test_asum() {
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, asum_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::asum_float");
     test_asum<float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, asum_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::asum_double");
     test_asum<double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, asum_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::asum_complex_double");
     test_asum<Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_INT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, asum_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::asum_int");
     test_asum<int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 

--- a/unit_test/blas/Test_Blas1_axpby.hpp
+++ b/unit_test/blas/Test_Blas1_axpby.hpp
@@ -218,45 +218,64 @@ int test_axpby_mv() {
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, axpby_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpby_float");
     test_axpby<float,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, axpby_mv_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpby_mv_float");
     test_axpby_mv<float,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, axpby_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpby_double");
     test_axpby<double,double,TestExecSpace> ();
 }
 TEST_F( TestCategory, axpby_mv_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpby_mv_double");
     test_axpby_mv<double,double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, axpby_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpby_complex_double");
     test_axpby<Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, axpby_mv_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpby_mv_complex_double");
     test_axpby_mv<Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_INT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, axpby_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpby_int");
     test_axpby<int,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, axpby_mv_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpby_mv_int");
     test_axpby_mv<int,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
 TEST_F( TestCategory, axpby_double_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpby_double_int");
     test_axpby<double,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, axpby_double_mv_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpby_mv_double_int");
     test_axpby_mv<double,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif

--- a/unit_test/blas/Test_Blas1_axpy.hpp
+++ b/unit_test/blas/Test_Blas1_axpy.hpp
@@ -213,45 +213,65 @@ int test_axpy_mv() {
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, axpy_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpy_float");
     test_axpy<float,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, axpy_mv_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpy_mv_float");
     test_axpy_mv<float,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, axpy_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpy_double");
     test_axpy<double,double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, axpy_mv_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpy_mv_double");
     test_axpy_mv<double,double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, axpy_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpy_complex_double");
     test_axpy<Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, axpy_mv_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpy_mv_complex_double");
     test_axpy_mv<Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_INT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, axpy_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpy_int");
     test_axpy<int,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, axpy_mv_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpy_mv_int");
     test_axpy_mv<int,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
 TEST_F( TestCategory, axpy_double_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpy_double_int");
     test_axpy<double,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, axpy_double_mv_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpy_mv_double_int");
     test_axpy_mv<double,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif

--- a/unit_test/blas/Test_Blas1_dot.hpp
+++ b/unit_test/blas/Test_Blas1_dot.hpp
@@ -217,37 +217,53 @@ int test_dot_mv() {
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, dot_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::dot_float");
     test_dot<float,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, dot_mv_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::dot_mv_float");
     test_dot_mv<float,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, dot_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::dot_double");
     test_dot<double,double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, dot_mv_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::dot_mv_double");
     test_dot_mv<double,double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, dot_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::dot_complex_double");
     test_dot<Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, dot_mv_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::dot_mv_complex_double");
     test_dot_mv<Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_INT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, dot_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::dot_int");
     test_dot<int,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, dot_mv_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::dot_mv_int");
     test_dot_mv<int,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 

--- a/unit_test/blas/Test_Blas1_mult.hpp
+++ b/unit_test/blas/Test_Blas1_mult.hpp
@@ -249,45 +249,65 @@ int test_mult_mv() {
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, mult_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::mult_float");
     test_mult<float,float,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, mult_mv_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::mult_float");
     test_mult_mv<float,float,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, mult_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::mult_double");
     test_mult<double,double,double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, mult_mv_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::mult_mv_double");
     test_mult_mv<double,double,double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, mult_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::mult_complex_double");
     test_mult<Kokkos::complex<double>,Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, mult_mv_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::mult_mv_complex_double");
     test_mult_mv<Kokkos::complex<double>,Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_INT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, mult_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::mult_int");
     test_mult<int,int,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, mult_mv_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::mult_mv_int");
     test_mult_mv<int,int,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
 TEST_F( TestCategory, mult_double_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::mult_double_int");
     test_mult<double,int,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
-TEST_F( TestCategory, mult_double_mv_int ) {
+TEST_F( TestCategory, mult_mv_double_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::mult_mv_double_int");
     test_mult_mv<double,int,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif

--- a/unit_test/blas/Test_Blas1_nrm1.hpp
+++ b/unit_test/blas/Test_Blas1_nrm1.hpp
@@ -165,37 +165,53 @@ int test_nrm1_mv() {
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, nrm1_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm1_float");
     test_nrm1<float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, nrm1_mv_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm1_mv_float");
     test_nrm1_mv<float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, nrm1_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm1_double");
     test_nrm1<double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, nrm1_mv_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm1_mv_double");
     test_nrm1_mv<double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, nrm1_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm1_complex_double");
     test_nrm1<Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, nrm1_mv_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm1_mv_complex_double");
     test_nrm1_mv<Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_INT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, nrm1_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm1_int");
     test_nrm1<int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, nrm1_mv_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm1_mv_int");
     test_nrm1_mv<int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 

--- a/unit_test/blas/Test_Blas1_nrm2.hpp
+++ b/unit_test/blas/Test_Blas1_nrm2.hpp
@@ -167,37 +167,53 @@ int test_nrm2_mv() {
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, nrm2_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_float");
     test_nrm2<float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, nrm2_mv_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_mv_float");
     test_nrm2_mv<float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, nrm2_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_double");
     test_nrm2<double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, nrm2_mv_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_mv_double");
     test_nrm2_mv<double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, nrm2_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_complex_double");
     test_nrm2<Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, nrm2_mv_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_mv_complex_double");
     test_nrm2_mv<Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_INT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, nrm2_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_int");
     test_nrm2<int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, nrm2_mv_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_mv_int");
     test_nrm2_mv<int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 

--- a/unit_test/blas/Test_Blas1_nrm2_squared.hpp
+++ b/unit_test/blas/Test_Blas1_nrm2_squared.hpp
@@ -171,37 +171,53 @@ int test_nrm2_squared_mv() {
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, nrm2_squared_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_squared_float");
     test_nrm2_squared<float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, nrm2_squared_mv_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_squared_mv_float");
     test_nrm2_squared_mv<float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, nrm2_squared_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_squared_double");
     test_nrm2_squared<double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, nrm2_squared_mv_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_squared_mv_double");
     test_nrm2_squared_mv<double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, nrm2_squared_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_squared_complex_double");
     test_nrm2_squared<Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, nrm2_squared_mv_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_squared_mv_complex_double");
     test_nrm2_squared_mv<Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_INT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, nrm2_squared_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_squared_int");
     test_nrm2_squared<int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, nrm2_squared_mv_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrm2_squared_mv_int");
     test_nrm2_squared_mv<int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 

--- a/unit_test/blas/Test_Blas1_nrminf.hpp
+++ b/unit_test/blas/Test_Blas1_nrminf.hpp
@@ -166,42 +166,57 @@ int test_nrminf_mv() {
   Test::impl_test_nrminf_mv<view_type_a_ls, Device>(132231,5);
 #endif
 
-  return 1;
-}
+  return 1;}
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, nrminf_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrminf_float");
     test_nrminf<float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, nrminf_mv_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrminf_mvfloat");
     test_nrminf_mv<float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, nrminf_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrminf_double");
     test_nrminf<double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, nrminf_mv_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrminf_mv_double");
     test_nrminf_mv<double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, nrminf_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrminf_complex_double");
     test_nrminf<Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, nrminf_mv_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrminf_mv_complex_double");
     test_nrminf_mv<Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_INT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, nrminf_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrminf_int");
     test_nrminf<int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, nrminf_mv_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::nrminf_mv_int");
     test_nrminf_mv<int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 

--- a/unit_test/blas/Test_Blas1_reciprocal.hpp
+++ b/unit_test/blas/Test_Blas1_reciprocal.hpp
@@ -227,37 +227,53 @@ int test_reciprocal_mv() {
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, reciprocal_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::reciprocal_float"); 
     test_reciprocal<float,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, reciprocal_mv_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::reciprocal_mv_float"); 
     test_reciprocal_mv<float,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, reciprocal_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::reciprocal_double"); 
     test_reciprocal<double,double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, reciprocal_mv_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::reciprocal_mv_double"); 
     test_reciprocal_mv<double,double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, reciprocal_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::reciprocal_complex_double"); 
     test_reciprocal<Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, reciprocal_mv_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::reciprocal_mv_complex_double"); 
     test_reciprocal_mv<Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_INT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, reciprocal_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::reciprocal_int"); 
     test_reciprocal<int,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, reciprocal_mv_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::reciprocal_mv_int"); 
     test_reciprocal_mv<int,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 

--- a/unit_test/blas/Test_Blas1_scal.hpp
+++ b/unit_test/blas/Test_Blas1_scal.hpp
@@ -268,45 +268,65 @@ int test_scal_mv() {
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, scal_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_float"); 
     test_scal<float,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, scal_mv_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_mv_float"); 
     test_scal_mv<float,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, scal_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_double"); 
     test_scal<double,double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, scal_mv_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_mv_double"); 
     test_scal_mv<double,double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, scal_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_complex_double"); 
     test_scal<Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, scal_mv_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_mv_complex_double"); 
     test_scal_mv<Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_INT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, scal_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_int"); 
     test_scal<int,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, scal_mv_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_mv_int"); 
     test_scal_mv<int,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
 TEST_F( TestCategory, scal_double_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_double_int"); 
     test_scal<double,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
-TEST_F( TestCategory, scal_double_mv_int ) {
+TEST_F( TestCategory, scal_mv_double_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_mv_double_int"); 
     test_scal_mv<double,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif

--- a/unit_test/blas/Test_Blas1_sum.hpp
+++ b/unit_test/blas/Test_Blas1_sum.hpp
@@ -164,37 +164,53 @@ int test_sum_mv() {
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, sum_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_float"); 
     test_sum<float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, sum_mv_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_mv_float"); 
     test_sum_mv<float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, sum_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_double"); 
     test_sum<double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, sum_mv_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_mv_double"); 
     test_sum_mv<double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, sum_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_complex_double"); 
     test_sum<Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, sum_mv_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_mv_complex_double"); 
     test_sum_mv<Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_INT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, sum_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_int"); 
     test_sum<int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, sum_mv_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_mv_int"); 
     test_sum_mv<int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 

--- a/unit_test/blas/Test_Blas1_team_abs.hpp
+++ b/unit_test/blas/Test_Blas1_team_abs.hpp
@@ -63,7 +63,7 @@ namespace Test {
       expected_result += AT::abs(h_x(i)) * AT::abs(h_x(i));
 
     //KokkosBlas::abs(y,x); 
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamAbs", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::abs(teamMember, Kokkos::subview(y,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), Kokkos::subview(x,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -74,7 +74,7 @@ namespace Test {
     Kokkos::deep_copy(b_y,b_org_y);
 
     //KokkosBlas::abs(y,c_x);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamAbs", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::abs(teamMember, Kokkos::subview(y,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), Kokkos::subview(c_x,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -142,7 +142,7 @@ namespace Test {
     Kokkos::View<ScalarB*,Kokkos::HostSpace> r("Dot::Result",K);
 
     //KokkosBlas::abs(y,x);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamAbs", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::abs(teamMember, Kokkos::subview(y,Kokkos::ALL(),teamId), Kokkos::subview(x,Kokkos::ALL(),teamId));
     } );
@@ -159,7 +159,7 @@ namespace Test {
     Kokkos::deep_copy(b_y,b_org_y);
 
     //KokkosBlas::abs(y,c_x);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamAbs", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::abs(teamMember, Kokkos::subview(y,Kokkos::ALL(),teamId), Kokkos::subview(c_x,Kokkos::ALL(),teamId));
     } );

--- a/unit_test/blas/Test_Blas1_team_axpby.hpp
+++ b/unit_test/blas/Test_Blas1_team_axpby.hpp
@@ -65,7 +65,7 @@ namespace Test {
       expected_result += ScalarB(a*h_x(i) + b*h_y(i)) * ScalarB(a*h_x(i) + b*h_y(i));
 
     //KokkosBlas::axpby(a,x,b,y);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamAxpby", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::axpby(teamMember, a, Kokkos::subview(x,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), b, Kokkos::subview(y,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -76,7 +76,7 @@ namespace Test {
     Kokkos::deep_copy(b_y,b_org_y);
     
     //KokkosBlas::axpby(a,c_x,b,y);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamAxpby", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::axpby(teamMember, a, Kokkos::subview(c_x,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), b, Kokkos::subview(y,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -145,7 +145,7 @@ namespace Test {
     typedef Kokkos::Details::ArithTraits<ScalarA> AT;
 
     //KokkosBlas::axpby(a,x,b,y);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamAxpby", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::axpby(teamMember, a, Kokkos::subview(x,Kokkos::ALL(),teamId), b, Kokkos::subview(y,Kokkos::ALL(),teamId));
     } );
@@ -159,7 +159,7 @@ namespace Test {
     Kokkos::deep_copy(b_y,b_org_y);
     
     //KokkosBlas::axpby(a,c_x,b,y);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamAxpby", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::axpby(teamMember, a, Kokkos::subview(c_x,Kokkos::ALL(),teamId), b, Kokkos::subview(y,Kokkos::ALL(),teamId));
     } );

--- a/unit_test/blas/Test_Blas1_team_axpy.hpp
+++ b/unit_test/blas/Test_Blas1_team_axpy.hpp
@@ -64,7 +64,7 @@ namespace Test {
       expected_result += ScalarB(a*h_x(i) + h_y(i)) * ScalarB(a*h_x(i) + h_y(i));
 
     //KokkosBlas::axpy(a,x,y);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamAxpy", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::axpy(teamMember, a, Kokkos::subview(x,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), Kokkos::subview(y,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -75,7 +75,7 @@ namespace Test {
     Kokkos::deep_copy(b_y,b_org_y);
 
     //KokkosBlas::axpy(a,c_x,y);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamAxpy", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::axpy(teamMember, a, Kokkos::subview(c_x,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), Kokkos::subview(y,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -140,7 +140,7 @@ namespace Test {
     Kokkos::View<ScalarB*,Kokkos::HostSpace> r("Dot::Result",K);
 
     //KokkosBlas::axpy(a,x,y);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamAxpy", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::axpy(teamMember, a, Kokkos::subview(x,Kokkos::ALL(),teamId), Kokkos::subview(y,Kokkos::ALL(),teamId));
     } );
@@ -154,7 +154,7 @@ namespace Test {
     Kokkos::deep_copy(b_y,b_org_y);
 
     //KokkosBlas::axpy(a,c_x,y);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamAxpy", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::axpy(teamMember, a, Kokkos::subview(c_x,Kokkos::ALL(),teamId), Kokkos::subview(y,Kokkos::ALL(),teamId));
     } );

--- a/unit_test/blas/Test_Blas1_team_dot.hpp
+++ b/unit_test/blas/Test_Blas1_team_dot.hpp
@@ -61,7 +61,7 @@ namespace Test {
     //ScalarA nonconst_nonconst_result = KokkosBlas::dot(a,b);
     ScalarA nonconst_nonconst_result = 0;
 
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamDot", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        d_r(teamId) = KokkosBlas::Experimental::dot(teamMember, Kokkos::subview(a,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), Kokkos::subview(b,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -78,7 +78,7 @@ namespace Test {
     //ScalarA const_const_result = KokkosBlas::dot(c_a,c_b);
     ScalarA const_const_result = 0;
 
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamDot", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        d_r(teamId) = KokkosBlas::Experimental::dot(teamMember, Kokkos::subview(c_a,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), Kokkos::subview(c_b,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -91,7 +91,7 @@ namespace Test {
     //ScalarA nonconst_const_result = KokkosBlas::dot(a,c_b);
     ScalarA nonconst_const_result = 0;
     
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamDot", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        d_r(teamId) = KokkosBlas::Experimental::dot(teamMember, Kokkos::subview(a,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), Kokkos::subview(c_b,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -104,7 +104,7 @@ namespace Test {
     //ScalarA const_nonconst_result = KokkosBlas::dot(c_a,b);
     ScalarA const_nonconst_result = 0;
     
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamDot", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        d_r(teamId) = KokkosBlas::Experimental::dot(teamMember, Kokkos::subview(c_a,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), Kokkos::subview(b,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -171,7 +171,7 @@ namespace Test {
     Kokkos::View<ScalarB*,Device> d_r("Dot::Result",K);
 
     //KokkosBlas::dot(r,a,b);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamDot", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        d_r(teamId) = KokkosBlas::Experimental::dot(teamMember, Kokkos::subview(a,Kokkos::ALL(),teamId), Kokkos::subview(b,Kokkos::ALL(),teamId));
     } );
@@ -182,7 +182,7 @@ namespace Test {
     }
 
     //KokkosBlas::dot(r,c_a,c_b);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamDot", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        d_r(teamId) = KokkosBlas::Experimental::dot(teamMember, Kokkos::subview(c_a,Kokkos::ALL(),teamId), Kokkos::subview(c_b,Kokkos::ALL(),teamId));
     } );
@@ -193,7 +193,7 @@ namespace Test {
     }
 
     //KokkosBlas::dot(r,a,c_b);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamDot", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        d_r(teamId) = KokkosBlas::Experimental::dot(teamMember, Kokkos::subview(a,Kokkos::ALL(),teamId), Kokkos::subview(c_b,Kokkos::ALL(),teamId));
     } );
@@ -204,7 +204,7 @@ namespace Test {
     }
 
     //KokkosBlas::dot(r,c_a,b);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamDot", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        d_r(teamId) = KokkosBlas::Experimental::dot(teamMember, Kokkos::subview(c_a,Kokkos::ALL(),teamId), Kokkos::subview(b,Kokkos::ALL(),teamId));
     } );

--- a/unit_test/blas/Test_Blas1_team_mult.hpp
+++ b/unit_test/blas/Test_Blas1_team_mult.hpp
@@ -76,7 +76,7 @@ namespace Test {
       expected_result += ScalarC(b*h_z(i) + a*h_x(i)*h_y(i)) * ScalarC(b*h_z(i) + a*h_x(i)*h_y(i));
 
     //KokkosBlas::mult(b,z,a,x,y);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamMult", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::mult(teamMember, b, Kokkos::subview(z,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), a, Kokkos::subview(x,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), Kokkos::subview(y,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -85,7 +85,7 @@ namespace Test {
  
     Kokkos::deep_copy(b_z,b_org_z);
     //KokkosBlas::mult(b,z,a,x,c_y);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamMult", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::mult(teamMember, b, Kokkos::subview(z,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), a, Kokkos::subview(x,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), Kokkos::subview(c_y,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -94,7 +94,7 @@ namespace Test {
 
     Kokkos::deep_copy(b_z,b_org_z);
     //KokkosBlas::mult(b,z,a,c_x,c_y);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamMult", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::mult(teamMember, b, Kokkos::subview(z,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), a, Kokkos::subview(c_x,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), Kokkos::subview(c_y,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -171,7 +171,7 @@ namespace Test {
     Kokkos::View<ScalarC*,Kokkos::HostSpace> r("Dot::Result",K);
 
     //KokkosBlas::mult(b,z,a,x,y);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamMult", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::mult(teamMember, b, Kokkos::subview(z,Kokkos::ALL(),teamId), a, x, Kokkos::subview(y,Kokkos::ALL(),teamId));
     } );
@@ -183,7 +183,7 @@ namespace Test {
 
     Kokkos::deep_copy(b_z,b_org_z);
     //KokkosBlas::mult(b,z,a,x,c_y);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamMult", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::mult(teamMember, b, Kokkos::subview(z,Kokkos::ALL(),teamId), a, x, Kokkos::subview(c_y,Kokkos::ALL(),teamId));
     } );

--- a/unit_test/blas/Test_Blas1_team_nrm2.hpp
+++ b/unit_test/blas/Test_Blas1_team_nrm2.hpp
@@ -53,7 +53,7 @@ namespace Test {
     Kokkos::View<typename AT::mag_type*,Device> d_r("Nrm2::Result",K);
 
     //KokkosBlas::nrm2(r,a);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamNrm2", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        d_r(teamId) = KokkosBlas::Experimental::nrm2(teamMember, Kokkos::subview(a,Kokkos::ALL(),teamId));
     } );
@@ -64,7 +64,7 @@ namespace Test {
     }
 
     //KokkosBlas::nrm2(r,c_a);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamNrm2", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        d_r(teamId) = KokkosBlas::Experimental::nrm2(teamMember, Kokkos::subview(c_a,Kokkos::ALL(),teamId));
     } );

--- a/unit_test/blas/Test_Blas1_team_scal.hpp
+++ b/unit_test/blas/Test_Blas1_team_scal.hpp
@@ -68,7 +68,7 @@ namespace Test {
     for(int i=0;i<N;i++)
     { expected_result += ScalarB(a*h_x(i)) * ScalarB(a*h_x(i)); }
 
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamScal", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::scal(teamMember, Kokkos::subview(y,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), a, Kokkos::subview(x,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -82,7 +82,7 @@ namespace Test {
  
     Kokkos::deep_copy(b_y,b_org_y);
     
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamScal", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::scal(teamMember, Kokkos::subview(y,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), a, Kokkos::subview(c_x,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -155,7 +155,7 @@ namespace Test {
 
     Kokkos::View<ScalarB*,Kokkos::HostSpace> r("Dot::Result",K);
 
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamScal", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::scal(teamMember, Kokkos::subview(y,Kokkos::ALL(),teamId), a, Kokkos::subview(x,Kokkos::ALL(),teamId));
     } );
@@ -170,7 +170,7 @@ namespace Test {
 
     Kokkos::deep_copy(b_y,b_org_y);
 
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamScal", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::scal(teamMember, Kokkos::subview(y,Kokkos::ALL(),teamId), a, Kokkos::subview(c_x,Kokkos::ALL(),teamId));
     } );
@@ -197,7 +197,7 @@ namespace Test {
       { expected_result[j] += ScalarB((3.0+j)*h_x(i,j)) * ScalarB((3.0+j)*h_x(i,j)); }
     }
 
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamScal", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::scal(teamMember, Kokkos::subview(y,Kokkos::ALL(),teamId), params(teamId), Kokkos::subview(x,Kokkos::ALL(),teamId));
     } );
@@ -212,7 +212,7 @@ namespace Test {
 
     Kokkos::deep_copy(b_y,b_org_y);
     
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamScal", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::scal(teamMember, Kokkos::subview(y,Kokkos::ALL(),teamId), params(teamId), Kokkos::subview(c_x,Kokkos::ALL(),teamId));
     } );

--- a/unit_test/blas/Test_Blas1_team_update.hpp
+++ b/unit_test/blas/Test_Blas1_team_update.hpp
@@ -79,7 +79,7 @@ namespace Test {
       expected_result += ScalarB(c*h_z(i) + a*h_x(i) + b*h_y(i)) * ScalarB(c*h_z(i) + a*h_x(i) + b*h_y(i));
 
     //KokkosBlas::update(a,x,b,y,c,z);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamUpdate", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::update(teamMember, a, Kokkos::subview(x,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), b, Kokkos::subview(y,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), c, Kokkos::subview(z,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -88,7 +88,7 @@ namespace Test {
  
     Kokkos::deep_copy(b_z,b_org_z);
     //KokkosBlas::update(a,c_x,b,y,c,z);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamUpdate", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::update(teamMember, a, Kokkos::subview(c_x,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), b, Kokkos::subview(y,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), c, Kokkos::subview(z,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -97,7 +97,7 @@ namespace Test {
 
     Kokkos::deep_copy(b_z,b_org_z);
     //KokkosBlas::update(a,c_x,b,c_y,c,z);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamUpdate", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::update(teamMember, a, Kokkos::subview(c_x,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), b, Kokkos::subview(c_y,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)), c, Kokkos::subview(z,Kokkos::make_pair(teamId*team_data_siz,(teamId < M-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -175,7 +175,7 @@ namespace Test {
     Kokkos::View<ScalarC*,Kokkos::HostSpace> r("Dot::Result",K);
 
     //KokkosBlas::update(a,x,b,y,c,z);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamUpdate", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::update(teamMember, a, Kokkos::subview(x,Kokkos::ALL(),teamId), b, Kokkos::subview(y,Kokkos::ALL(),teamId), c, Kokkos::subview(z,Kokkos::ALL(),teamId));
     } );
@@ -187,7 +187,7 @@ namespace Test {
 
     Kokkos::deep_copy(b_z,b_org_z);
     //KokkosBlas::update(a,c_x,b,y,c,z);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamUpdate", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::update(teamMember, a, Kokkos::subview(c_x,Kokkos::ALL(),teamId), b, Kokkos::subview(y,Kokkos::ALL(),teamId), c, Kokkos::subview(z,Kokkos::ALL(),teamId));
     } );

--- a/unit_test/blas/Test_Blas1_update.hpp
+++ b/unit_test/blas/Test_Blas1_update.hpp
@@ -253,45 +253,64 @@ int test_update_mv() {
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, update_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::update_float"); 
     test_update<float,float,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, update_mv_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::update_mv_float"); 
     test_update_mv<float,float,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, update_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::update_double"); 
     test_update<double,double,double,TestExecSpace> ();
 }
 TEST_F( TestCategory, update_mv_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::update_mv_double"); 
     test_update_mv<double,double,double,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, update_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::update_complex_double"); 
     test_update<Kokkos::complex<double>,Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, update_mv_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::update_mv_complex_double"); 
     test_update_mv<Kokkos::complex<double>,Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_INT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, update_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::update_int"); 
     test_update<int,int,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, update_mv_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::update_mv_int"); 
     test_update_mv<int,int,int,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
 TEST_F( TestCategory, update_double_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::update_double_int"); 
     test_update<double,int,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
-TEST_F( TestCategory, update_double_mv_int ) {
+TEST_F( TestCategory, update_mv_double_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::update_mv_double_int"); 
     test_update_mv<double,int,float,TestExecSpace> ();
+  Kokkos::Profiling::popRegion();
 }
 #endif

--- a/unit_test/blas/Test_Blas2_gemv.hpp
+++ b/unit_test/blas/Test_Blas2_gemv.hpp
@@ -137,30 +137,40 @@ int test_gemv(const char* mode) {
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, gemv_float ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::gemv_float");
     test_gemv<float,float,float,TestExecSpace> ("N");
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, gemv_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::gemv_double");
     test_gemv<double,double,double,TestExecSpace> ("N");
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, gemv_complex_double ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::gemv_complex_double");
     test_gemv<Kokkos::complex<double>,Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ("N");
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_INT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, gemv_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::gemv_int");
     test_gemv<int,int,int,TestExecSpace> ("N");
+  Kokkos::Profiling::popRegion();
 }
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
 TEST_F( TestCategory, gemv_double_int ) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::gemv_double_int");
     test_gemv<double,int,float,TestExecSpace> ("N");
+  Kokkos::Profiling::popRegion();
 }
 #endif

--- a/unit_test/blas/Test_Blas2_team_gemv.hpp
+++ b/unit_test/blas/Test_Blas2_team_gemv.hpp
@@ -87,7 +87,7 @@ namespace Test {
     char trans = mode[0];
 	
     //KokkosBlas::gemv(mode,a,A,x,b,y);
-    Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamGemm",  policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::gemv(teamMember, trans, a, Kokkos::subview(A,Kokkos::make_pair(teamId*team_data_siz,(teamId < K-1)?(teamId+1)*team_data_siz:N),Kokkos::ALL()), x, b, Kokkos::subview(y,Kokkos::make_pair(teamId*team_data_siz,(teamId < K-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -98,7 +98,7 @@ namespace Test {
     Kokkos::deep_copy(b_y,b_org_y);
 
     //KokkosBlas::gemv(mode,a,A,c_x,b,y);    
-   Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamGemm", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::gemv(teamMember, trans, a, Kokkos::subview(A,Kokkos::make_pair(teamId*team_data_siz,(teamId < K-1)?(teamId+1)*team_data_siz:N),Kokkos::ALL()), c_x, b, Kokkos::subview(y,Kokkos::make_pair(teamId*team_data_siz,(teamId < K-1)?(teamId+1)*team_data_siz:N)));
     } );
@@ -109,7 +109,7 @@ namespace Test {
     Kokkos::deep_copy(b_y,b_org_y);
 
     //KokkosBlas::gemv(mode,a,c_A,c_x,b,y);
-   Kokkos::parallel_for( policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
+    Kokkos::parallel_for( "KokkosBlas::Test::TeamGemm", policy, KOKKOS_LAMBDA ( const team_member &teamMember ) {
        const int teamId = teamMember.league_rank();
        KokkosBlas::Experimental::gemv(teamMember, trans, a, Kokkos::subview(c_A,Kokkos::make_pair(teamId*team_data_siz,(teamId < K-1)?(teamId+1)*team_data_siz:N),Kokkos::ALL()), c_x, b, Kokkos::subview(y,Kokkos::make_pair(teamId*team_data_siz,(teamId < K-1)?(teamId+1)*team_data_siz:N)));
     } );

--- a/unit_test/sparse/Test_Sparse_BlockCrsMatrix.hpp
+++ b/unit_test/sparse/Test_Sparse_BlockCrsMatrix.hpp
@@ -358,7 +358,7 @@ testBlockCrsMatrix ()
   result_view_type d_results("d_results");
   auto h_results = Kokkos::create_mirror_view( d_results );
 
-  Kokkos::parallel_for( Kokkos::RangePolicy<typename device::execution_space>(0, 1), Test::TestFunctor< block_crs_matrix_type, result_view_type>( A, d_results ) );
+  Kokkos::parallel_for( "KokkosSparse::Test::BlockCrsMatrix", Kokkos::RangePolicy<typename device::execution_space>(0, 1), Test::TestFunctor< block_crs_matrix_type, result_view_type>( A, d_results ) );
 
   Kokkos::deep_copy( h_results, d_results );
 

--- a/unit_test/sparse/Test_Sparse_replaceSumInto.hpp
+++ b/unit_test/sparse/Test_Sparse_replaceSumInto.hpp
@@ -113,7 +113,7 @@ namespace { // (anonymous)
     typedef Kokkos::RangePolicy<execution_space, typename CrsMatrixType::ordinal_type> policy_type;
 
     ::Test::ModifyEvenNumberedRows<CrsMatrixType> functor (A, replace, sorted, atomic);
-    Kokkos::parallel_for (policy_type (0, A.numRows ()), functor);
+    Kokkos::parallel_for ( "KokkosSparse::Test::ReplaceSumInto", policy_type (0, A.numRows ()), functor);
   }
 
   template<class CrsMatrixType>

--- a/unit_test/sparse/Test_Sparse_replaceSumIntoLonger.hpp
+++ b/unit_test/sparse/Test_Sparse_replaceSumIntoLonger.hpp
@@ -177,7 +177,7 @@ namespace { // (anonymous)
     functor_type functor (A, replace, sorted, atomic);
     ordinal_type numModified = 0;
     policy_type range (0, A.numRows ());
-    Kokkos::parallel_reduce (std::string ("ModifyEntries"), range, functor, numModified);
+    Kokkos::parallel_reduce ("KokkosSparse::Test::ModifyEntries", range, functor, numModified);
 
     const ordinal_type numEntShouldModify =
       static_cast<ordinal_type> (numEntToModify) <= A.numCols () ?

--- a/unit_test/sparse/Test_Sparse_spmv.hpp
+++ b/unit_test/sparse/Test_Sparse_spmv.hpp
@@ -108,11 +108,11 @@ void check_spmv(crsMat_t input_mat, x_vector_type x, y_vector_type y,
   //KokkosKernels::Impl::print_1Dview(y);
   typedef Kokkos::Details::ArithTraits<typename y_vector_type::non_const_value_type> AT;
   int num_errors = 0;
-  Kokkos::parallel_reduce("KokkosKernels::UnitTests::spmv"
+  Kokkos::parallel_reduce("KokkosSparse::Test::spmv"
                          ,my_exec_space(0, y.extent(0))
                          ,fSPMV<y_vector_type, y_vector_type, y_vector_type>(expected_y,y,eps)
                          ,num_errors);
-  if(num_errors>0) printf("KokkosKernels::UnitTests::spmv: %i errors of %i with params: %lf %lf\n",
+  if(num_errors>0) printf("KokkosSparse::Test::spmv: %i errors of %i with params: %lf %lf\n",
       num_errors,y.extent_int(0),AT::abs(alpha),AT::abs(beta));
   EXPECT_TRUE(num_errors==0);
 }
@@ -146,11 +146,11 @@ void check_spmv_mv(crsMat_t input_mat, x_vector_type x, y_vector_type y, y_vecto
 
     auto y_spmv = Kokkos::subview (y, Kokkos::ALL (), i);
     int num_errors = 0;
-    Kokkos::parallel_reduce("KokkosKernels::UnitTests::spmv_mv"
+    Kokkos::parallel_reduce("KokkosSparse::Test::spmv_mv"
                            ,my_exec_space(0,y_i.extent(0))
                            ,fSPMV<decltype(y_i), decltype(y_spmv), y_vector_type>(y_i, y_spmv, eps)
                            ,num_errors);
-    if(num_errors>0) printf("KokkosKernels::UnitTests::spmv_mv: %i errors of %i for mv %i\n",
+    if(num_errors>0) printf("KokkosSparse::Test::spmv_mv: %i errors of %i for mv %i\n",
         num_errors,y_i.extent_int(0),i);
     EXPECT_TRUE(num_errors==0);
   }


### PR DESCRIPTION
Kokkos needs to put a label for randomizer. Now simple timer reports as follows:
```
[----------] Global test environment tear-down
[==========] 272 tests from 1 test case ran. (206225 ms total)
[  PASSED  ] 272 tests.
KokkosP: Kernel timing written to /ascldap/users/kyukim/Work/lib/kokkoskernels/build/blake/tmp/unit_test/blake-lsm1.sandia.gov-43685.dat 
[kyukim @blake-lsm1] unit_test >  $HOME/Work/lib/kokkostools/src/tools/simple-kernel-timer/kp_reader blake-lsm1.sandia.gov-43685.dat  |& tee log 
Regions: 

                                                               KokkosBlas::Test::gemm_complex_double (Region)          55.68167            1        55.68167  36.153  27.000
                                                                       KokkosBlas::Test::gemm_double (Region)          30.98557            1        30.98557  20.118  15.025
                                                                               KokkosBlas::gemm[ETI] (Region)          17.40360          128         0.13597  11.300   8.439
                                                               KokkosBlas::Test::gemv_complex_double (Region)           6.14457            1         6.14457   3.990   2.980
                                                                       KokkosBlas::Test::gemv_double (Region)           4.24888            1         4.24888   2.759   2.060
                                                                               KokkosBlas::gemv[ETI] (Region)           1.64290           48         0.03423   1.067   0.797
                                                      KokkosBatched::Test::SerialGemm::ComplexDouble (Region)           1.26817         2688         0.00047   0.823   0.615
                                                                                KokkosBlas::dot[ETI] (Region)           1.16657         1220         0.00096   0.757   0.566
                                                      KokkosBatched::Test::SerialTrsm::ComplexDouble (Region)           1.05965         5376         0.00020   0.688   0.514
                                                             KokkosBatched::Test::SerialTrsm::Double (Region)           0.54380         3360         0.00016   0.353   0.264
                                                             KokkosBatched::Test::SerialGemm::Double (Region)           0.52332         1344         0.00039   0.340   0.254
                                                                     KokkosBlas::Test::abs_mv_double (Region)           0.27167            2         0.13584   0.176   0.132
                                                               KokkosBlas::Test::mult_complex_double (Region)           0.25018            1         0.25018   0.162   0.121
                                                            KokkosBlas::Test::axpy_mv_complex_double (Region)           0.21731            1         0.21731   0.141   0.105
                                                      KokkosBlas::Test::reciprocal_mv_complex_double (Region)           0.20795            1         0.20795   0.135   0.101
                                                            KokkosBlas::Test::mult_mv_complex_double (Region)           0.18344            1         0.18344   0.119   0.089
                                                           KokkosBlas::Test::axpby_mv_complex_double (Region)           0.17800            1         0.17800   0.116   0.086
                                                          KokkosBlas::Test::update_mv_complex_double (Region)           0.16343            1         0.16343   0.106   0.079
                                                            KokkosBlas::Test::scal_mv_complex_double (Region)           0.14306            1         0.14306   0.093   0.069
                                                                    KokkosBlas::Test::axpy_mv_double (Region)           0.14298            1         0.14298   0.093   0.069
                                                                              KokkosBlas::axpby[ETI] (Region)           0.13665          164         0.00083   0.089   0.066
                                                      KokkosBatched::Test::SerialGemv::ComplexDouble (Region)           0.13260          704         0.00019   0.086   0.064
                                                                    KokkosBlas::Test::mult_mv_double (Region)           0.12499            1         0.12499   0.081   0.061
                                                             KokkosBlas::Test::dot_mv_complex_double (Region)           0.12053            1         0.12053   0.078   0.058
                                                 KokkosBatched::Test::SerialInverseLU::ComplexDouble (Region)           0.11449          440         0.00026   0.074   0.056
                                                                   KokkosBlas::Test::axpby_mv_double (Region)           0.11408            1         0.11408   0.074   0.055
                                                                        KokkosBlas::Test::abs_double (Region)           0.10945            2         0.05472   0.071   0.053
                                                                  KokkosBlas::Test::update_mv_double (Region)           0.10767            1         0.10767   0.070   0.052
                                                                    KokkosBlas::Test::scal_mv_double (Region)           0.09483            1         0.09483   0.062   0.046
                                                        KokkosBatched::Test::SerialInverseLU::Double (Region)           0.09399          440         0.00021   0.061   0.046
                                                        KokkosBatched::Test::TeamTrsm::ComplexDouble (Region)           0.09257          672         0.00014   0.060   0.045
                                                             KokkosBatched::Test::SerialGemv::Double (Region)           0.09059          352         0.00026   0.059   0.044
                                                                     KokkosBlas::Test::dot_mv_double (Region)           0.07240            1         0.07240   0.047   0.035
                                                              KokkosBlas::Test::reciprocal_mv_double (Region)           0.07135            1         0.07135   0.046   0.035
                                                              KokkosBlas::Test::axpby_complex_double (Region)           0.07050            1         0.07050   0.046   0.034
                                                               KokkosBlas::Test::axpy_complex_double (Region)           0.06035            1         0.06035   0.039   0.029
                                                            KokkosBlas::Test::nrm2_mv_complex_double (Region)           0.05698            1         0.05698   0.037   0.028
                                                    KokkosBlas::Test::nrm2_squared_mv_complex_double (Region)           0.05683            1         0.05683   0.037   0.028
                                                             KokkosBlas::Test::update_complex_double (Region)           0.05448            1         0.05448   0.035   0.026
                                                          KokkosBatched::Test::SerialSolveLU::Double (Region)           0.04973          264         0.00019   0.032   0.024
                                                      KokkosBatched::Test::SerialTrsv::ComplexDouble (Region)           0.04818          704         0.00007   0.031   0.023
                                                            KokkosBlas::Test::nrm1_mv_complex_double (Region)           0.04749            1         0.04749   0.031   0.023
                                                         KokkosBlas::Test::reciprocal_complex_double (Region)           0.04712            1         0.04712   0.031   0.023
                                                                               KokkosBlas::mult[ETI] (Region)           0.04648           80         0.00058   0.030   0.023
                                                                       KokkosBlas::Test::axpy_double (Region)           0.04304            1         0.04304   0.028   0.021
                                                                                KokkosBlas::abs[ETI] (Region)           0.04267           64         0.00067   0.028   0.021
                                                             KokkosBlas::Test::sum_mv_complex_double (Region)           0.04238            1         0.04238   0.028   0.021
                                                             KokkosBatched::Test::SerialTrsv::Double (Region)           0.04196          352         0.00012   0.027   0.020
                                                                       KokkosBlas::Test::mult_double (Region)           0.04007            1         0.04007   0.026   0.019
                                                            KokkosBlas::Test::nrm2_squared_mv_double (Region)           0.03971            1         0.03971   0.026   0.019
                                                                    KokkosBlas::Test::nrm2_mv_double (Region)           0.03920            1         0.03920   0.025   0.019
                                                                               KokkosBlas::scal[ETI] (Region)           0.03864           96         0.00040   0.025   0.019
                                                          KokkosBlas::Test::nrminf_mv_complex_double (Region)           0.03808            1         0.03808   0.025   0.018
                                                                               KokkosBlas::nrm2[ETI] (Region)           0.03751          128         0.00029   0.024   0.018
                                         KokkosBatched::Test::SerialMatUtil::ComplexDouble::NaiveSet (Region)           0.03696           64         0.00058   0.024   0.018
                                                                         KokkosBlas::reciprocal[ETI] (Region)           0.03648           64         0.00057   0.024   0.018
                                                                               KokkosBlas::nrm1[ETI] (Region)           0.03501           96         0.00036   0.023   0.017
                                                   KokkosBatched::Test::SerialSolveLU::ComplexDouble (Region)           0.03032          264         0.00011   0.020   0.015
                                                               KokkosBatched::Test::SerialLU::Double (Region)           0.02960          176         0.00017   0.019   0.014
                                                                     KokkosBlas::Test::sum_mv_double (Region)           0.02772            1         0.02772   0.018   0.013
                                                                KokkosBlas::Test::dot_complex_double (Region)           0.02766            1         0.02766   0.018   0.013
                                                                    KokkosBlas::Test::nrm1_mv_double (Region)           0.02738            1         0.02738   0.018   0.013
                                                               KokkosBlas::Test::scal_complex_double (Region)           0.02678            1         0.02678   0.017   0.013
                                                        KokkosBatched::Test::SerialLU::ComplexDouble (Region)           0.02644          176         0.00015   0.017   0.013
                                       KokkosBatched::Test::SerialMatUtil::ComplexDouble::NaiveScale (Region)           0.02595           64         0.00041   0.017   0.013
                                                                             KokkosBlas::update[ETI] (Region)           0.02490           80         0.00031   0.016   0.012
                                                                  KokkosBlas::Test::nrminf_mv_double (Region)           0.02465            1         0.02465   0.016   0.012
                                                                 KokkosBlas::Test::reciprocal_double (Region)           0.02371            1         0.02371   0.015   0.011
                                                                        KokkosBlas::Test::dot_double (Region)           0.02351            1         0.02351   0.015   0.011
                                                               KokkosBlas::Test::asum_complex_double (Region)           0.01918            1         0.01918   0.012   0.009
                                                                       KokkosBlas::Test::scal_double (Region)           0.01853            1         0.01853   0.012   0.009
                                                       KokkosBlas::Test::nrm2_squared_complex_double (Region)           0.01699            1         0.01699   0.011   0.008
                                                                                KokkosBlas::sum[ETI] (Region)           0.01625           64         0.00025   0.011   0.008
                                                               KokkosBlas::Test::nrm2_complex_double (Region)           0.01606            1         0.01606   0.010   0.008
                               KokkosBatched::Test::SerialMatUtil::ComplexDouble::KokkosBatchedScale (Region)           0.01447           64         0.00023   0.009   0.007
                                                                             KokkosBlas::nrminf[ETI] (Region)           0.01414           48         0.00029   0.009   0.007
                                                                       KokkosBlas::Test::asum_double (Region)           0.01412            1         0.01412   0.009   0.007
                                                KokkosBatched::Test::SerialMatUtil::Double::NaiveSet (Region)           0.01388           32         0.00043   0.009   0.007
                                                             KokkosBlas::Test::nrminf_complex_double (Region)           0.01374            1         0.01374   0.009   0.007
                                                               KokkosBlas::Test::nrm1_complex_double (Region)           0.01369            1         0.01369   0.009   0.007
                                 KokkosBatched::Test::SerialMatUtil::ComplexDouble::KokkosBatchedSet (Region)           0.01348           64         0.00021   0.009   0.007
                                                                KokkosBlas::Test::sum_complex_double (Region)           0.01290            1         0.01290   0.008   0.006
                                                                       KokkosBlas::Test::nrm2_double (Region)           0.01246            1         0.01246   0.008   0.006
                                                               KokkosBlas::Test::nrm2_squared_double (Region)           0.01231            1         0.01231   0.008   0.006
                                                                       KokkosBlas::Test::nrm1_double (Region)           0.01144            1         0.01144   0.007   0.006
                                                                     KokkosBlas::Test::nrminf_double (Region)           0.01138            1         0.01138   0.007   0.006
                                                                        KokkosBlas::Test::sum_double (Region)           0.01124            1         0.01124   0.007   0.005
                                              KokkosBatched::Test::SerialMatUtil::Double::NaiveScale (Region)           0.01084           32         0.00034   0.007   0.005
                                      KokkosBatched::Test::SerialMatUtil::Double::KokkosBatchedScale (Region)           0.00729           32         0.00023   0.005   0.004
                                        KokkosBatched::Test::SerialMatUtil::Double::KokkosBatchedSet (Region)           0.00689           32         0.00022   0.004   0.003
                                                                     KokkosBlas::Test::update_double (Region)           0.00000            0            -nan   0.000   0.000
                                                                      KokkosBlas::Test::axpby_double (Region)           0.00000            0            -nan   0.000   0.000

-------------------------------------------------------------------------
Kernels: 

                                                                       KokkosBlas::Test::VanillaGEMM (ParFor)          64.78525          160         0.40491  42.063  31.415
                                                 KokkosSparse::GaussSeidel::BLOCK_Team_PSGS::forward (ParFor)          11.77266        33800         0.00035   7.644   5.709
                                                                        Kokkos::View::initialization (ParFor)          11.73584        33902         0.00035   7.620   5.691
                                                KokkosSparse::GaussSeidel::BLOCK_Team_PSGS::backward (ParFor)          11.35830        33800         0.00034   7.375   5.508
                                                                          KokkosBlas::Test::TeamGemm (ParFor)           9.28621           48         0.19346   6.029   4.503
                                                                                KokkosBlas::gemm[NN] (ParFor)           4.53830           32         0.14182   2.947   2.201
                                                                           Kokkos::View::destruction (ParFor)           4.38962        15113         0.00029   2.850   2.129
                                                           KokkosSparse::GaussSeidel::PSGS::backward (ParFor)           4.23784        29400         0.00014   2.752   2.055
                                                            KokkosSparse::GaussSeidel::PSGS::forward (ParFor)           4.06317        29400         0.00014   2.638   1.970
                                                                                KokkosBlas::gemm[CC] (ParFor)           2.32955           16         0.14560   1.513   1.130
                                                                                KokkosBlas::gemm[CN] (ParFor)           2.24695           16         0.14043   1.459   1.090
                                                                                KokkosBlas::gemm[NC] (ParFor)           2.22059           16         0.13879   1.442   1.077
                                                                                KokkosBlas::gemm[TN] (ParFor)           2.05385           16         0.12837   1.334   0.996
                                                                                KokkosBlas::gemm[TT] (ParFor)           2.00764           16         0.12548   1.304   0.974
                                                                                KokkosBlas::gemm[NT] (ParFor)           2.00616           16         0.12539   1.303   0.973
                                                                       KokkosBlas::gemv[SingleLevel] (ParFor)           1.64276           48         0.03422   1.067   0.797
                                                                          KokkosBlas::Test::DiffGEMM (ParRed)           1.08541          160         0.00678   0.705   0.526
N6Kokkos4Impl25fill_random_functor_rangeINS_4ViewIPPPNS_7complexIdEEJNS_10LayoutLeftENS_6OpenMPEEEENS_22Random_XorShift64_PoolIS9_EELi128ELi3ElEE (ParFor)           0.95760         2964         0.00032   0.622   0.464
                                                                     KokkosKernels::Common::CopyView (ParFor)           0.86971         1772         0.00049   0.565   0.422
N6Kokkos4Impl25fill_random_functor_rangeINS_4ViewIPPNS_7complexIdEEJNS_10LayoutLeftENS_6OpenMPEEEENS_22Random_XorShift64_PoolIS8_EELi128ELi2ElEE (ParFor)           0.81148          105         0.00773   0.527   0.393
N6Kokkos4Impl25fill_random_functor_rangeINS_4ViewIPPPNS_7complexIdEEJNS_11LayoutRightENS_6OpenMPEEEENS_22Random_XorShift64_PoolIS9_EELi128ELi3ElEE (ParFor)           0.72829         2964         0.00025   0.473   0.353
                                                                  KokkosSparse::spmv<MV,NoTranspose> (ParFor)           0.62234           40         0.01556   0.404   0.302
N6Kokkos4Impl25fill_random_functor_rangeINS_4ViewIPPPdJNS_10LayoutLeftENS_6OpenMPEEEENS_22Random_XorShift64_PoolIS7_EELi128ELi3ElEE (ParFor)           0.48458         1632         0.00030   0.315   0.235
                                                                                 KokkosBlas::dot<1D> (ParRed)           0.46645          676         0.00069   0.303   0.226
N6Kokkos4Impl25fill_random_functor_rangeINS_4ViewIPPNS_7complexIdEEJNS_10LayoutLeftENS_6DeviceINS_6OpenMPENS_9HostSpaceEEEEEENS_22Random_XorShift64_PoolIS9_EELi128ELi2ElEE (ParFor)           0.45895          120         0.00382   0.298   0.223
N6Kokkos4Impl25fill_random_functor_rangeINS_4ViewIPPdJNS_10LayoutLeftENS_6OpenMPEEEENS_22Random_XorShift64_PoolIS6_EELi128ELi2ElEE (ParFor)           0.44043          105         0.00419   0.286   0.214
                                                                             KokkosBlas::Dot::2_2::4 (ParRed)           0.38805          544         0.00071   0.252   0.188
N6Kokkos4Impl25fill_random_functor_rangeINS_4ViewIPPPdJNS_11LayoutRightENS_6OpenMPEEEENS_22Random_XorShift64_PoolIS7_EELi128ELi3ElEE (ParFor)           0.38620         1632         0.00024   0.251   0.187
N6Kokkos4Impl25fill_random_functor_rangeINS_4ViewIPPdJNS_10LayoutLeftENS_6DeviceINS_6OpenMPENS_9HostSpaceEEEEEENS_22Random_XorShift64_PoolIS7_EELi128ELi2ElEE (ParFor)           0.32151          120         0.00268   0.209   0.156
                                                       KokkosGraph::Distance2Color::ColorGraphGreedy (ParFor)           0.31095            3         0.10365   0.202   0.151
                                                                             KokkosBlas::Dot::2_2::1 (ParRed)           0.30716          544         0.00056   0.199   0.149
N6Kokkos4Impl25fill_random_functor_rangeINS_4ViewIPPNS_7complexIdEEJNS_11LayoutRightENS_6DeviceINS_6OpenMPENS_9HostSpaceEEEEEENS_22Random_XorShift64_PoolIS9_EELi128ELi2ElEE (ParFor)           0.28089          120         0.00234   0.182   0.136
N6Kokkos4Impl25fill_random_functor_rangeINS_4ViewIPPNS_7complexIdEEJNS_11LayoutRightENS_6OpenMPEEEENS_22Random_XorShift64_PoolIS8_EELi128ELi2ElEE (ParFor)           0.22367          105         0.00213   0.145   0.108
                                                                                 Kokkos::ViewFill-1D (ParFor)           0.20756          682         0.00030   0.135   0.101
                                                                   KokkosSparse::Test::ModifyEntries (ParRed)           0.19603          960         0.00020   0.127   0.095
                                                       KokkosSparse::NumericCMEM_CPU::DENSE::DYNAMIC (ParFor)           0.19578            6         0.03263   0.127   0.095
N6Kokkos4Impl25fill_random_functor_rangeINS_4ViewIPPdJNS_11LayoutRightENS_6DeviceINS_6OpenMPENS_9HostSpaceEEEEEENS_22Random_XorShift64_PoolIS7_EELi128ELi2ElEE (ParFor)           0.18249          120         0.00152   0.118   0.088
                                                     Deterministic Coloring: color nodes in frontier (ParFor)           0.16385          942         0.00017   0.106   0.079
                                           KokkosKernels::Common::SymmetrizeGraphSymbolicHashMap::S1 (ParFor)           0.15301           10         0.01530   0.099   0.074
N6Kokkos4Impl25fill_random_functor_rangeINS_4ViewIPPdJNS_11LayoutRightENS_6OpenMPEEEENS_22Random_XorShift64_PoolIS6_EELi128ELi2ElEE (ParFor)           0.14701          105         0.00140   0.095   0.071
                                                                         KokkosBlas::Test::TeamAxpby (ParFor)           0.13422           64         0.00210   0.087   0.065
                                                              KokkosKernels::Common::IsIdenticalView (ParRed)           0.13385           42         0.00319   0.087   0.065
                                                                                 Swap frontier sizes (ParFor)           0.12543          942         0.00013   0.081   0.061
                                                                          KokkosBlas::Test::TeamScal (ParFor)           0.12134           96         0.00126   0.079   0.059
                                                          KokkosGraph::Distance2Color::FindConflicts (ParRed)           0.11169            3         0.03723   0.073   0.054
                                                                          KokkosBlas::Test::TeamMult (ParFor)           0.10382           80         0.00130   0.067   0.050
                                           KokkosKernels::Common::SymmetrizeGraphSymbolicHashMap::S0 (ParFor)           0.09878           10         0.00988   0.064   0.048
                                                             KokkosSparse::spmv<NoTranspose,Dynamic> (ParFor)           0.09128            4         0.02282   0.059   0.044
                                                                              KokkosBlas::Axpby::S15 (ParFor)           0.08862          132         0.00067   0.058   0.043
                                                                          KokkosBlas::Test::TeamAxpy (ParFor)           0.08822           64         0.00138   0.057   0.043
N6Kokkos4Impl25fill_random_functor_rangeINS_4ViewIA2_PNS_7complexIdEEJNS_10LayoutLeftENS_6OpenMPEEEENS_22Random_XorShift64_PoolIS8_EELi128ELi2ElEE (ParFor)           0.08074          280         0.00029   0.052   0.039
                                                                 KOKKOSPARSE::SPGEMM::KKMEM::DYNAMIC (ParFor)           0.07843            4         0.01961   0.051   0.038
N6Kokkos4Impl25fill_random_functor_rangeINS_4ViewIA2_PdJNS_10LayoutLeftENS_6OpenMPEEEENS_22Random_XorShift64_PoolIS6_EELi128ELi2ElEE (ParFor)           0.07652          280         0.00027   0.050   0.037
                                                             KokkosGraph::GraphColoring::GreedyColor (ParFor)           0.07423          113         0.00066   0.048   0.036
                                                                    KokkosKernels::Common::PrefixSum (ParScan)          0.07350           96         0.00077   0.048   0.036
                                                                           KokkosBlas::Test::TeamDot (ParFor)           0.06921          128         0.00054   0.045   0.034
                                                                KokkosGraph::GraphColoring::InitList (ParFor)           0.06886           42         0.00164   0.045   0.033
                                                                        KokkosBlas::Test::TeamUpdate (ParFor)           0.06586           80         0.00082   0.043   0.032
                                                                 KokkosKernels::Common::Test::GetFFS (ParFor)           0.06135           12         0.00511   0.040   0.030
                                                       KokkosKernels::Common::Test::GetArrayBitCount (ParFor)           0.06131           12         0.00511   0.040   0.030
                                                                         KokkosSparse::Test::spmv_mv (ParRed)           0.05758          192         0.00030   0.037   0.028
                                                                           KokkosBlas::Test::TeamAbs (ParFor)           0.05019           64         0.00078   0.033   0.024
                                      KokkosBatched::Test::SerialInverseLU::ComplexDouble::LUFunctor (ParFor)           0.04584          176         0.00026   0.030   0.022
                                           KokkosBatched::Test::SerialInverseLU::Double::GemmFunctor (ParFor)           0.03971          176         0.00023   0.026   0.019
                               KokkosBatched::Test::SerialInverseLU::ComplexDouble::InverseLUFunctor (ParFor)           0.03510           88         0.00040   0.023   0.017
                                             KokkosBatched::Test::SerialInverseLU::Double::LUFunctor (ParFor)           0.03378          176         0.00019   0.022   0.016
                                          KokkosBatched::Test::SerialSolveLU::Double::SolveLUFunctor (ParFor)           0.03332          176         0.00019   0.022   0.016
                                    KokkosBatched::Test::SerialInverseLU::ComplexDouble::GemmFunctor (ParFor)           0.03307          176         0.00019   0.021   0.016
                                                     KokkosGraph::GraphColoring::FindConflictsAtomic (ParRed)           0.03256          116         0.00028   0.021   0.016
                                                                                KokkosBlas::Mult::S7 (ParFor)           0.02725           32         0.00085   0.018   0.013
                                                         KokkosGraph::GraphColoring::GreedyColor_IMP (ParFor)           0.02620            2         0.01310   0.017   0.013
                                                 KokkosGraph::GraphColoring::FindConflictsAtomic_IMP (ParRed)           0.02613            2         0.01306   0.017   0.013
                                                               KokkosKernels::Common::Test::CheckFFS (ParFor)           0.02561           12         0.00213   0.017   0.012
                                                                          KokkosBlas::Axpby::MV::S31 (ParFor)           0.02494           32         0.00078   0.016   0.012
                                                                          KokkosBlas::Axpby::MV::S15 (ParFor)           0.02268           32         0.00071   0.015   0.011
                                                                    KokkosKernels::Common::ReduceMax (ParRed)           0.02163           10         0.00216   0.014   0.010
                                                      KokkosSparse::GaussSeidel::fill_matrix_numeric (ParFor)           0.02121           32         0.00066   0.014   0.010
                                                                                KokkosBlas::Nrm2::S0 (ParRed)           0.02094           64         0.00033   0.014   0.010
                                                                          KokkosBlas::Reciprocal::S3 (ParFor)           0.02089           24         0.00087   0.014   0.010
                                                  KokkosSparse::StructureC::SPGEMM_KK_DENSE::DYNAMIC (ParFor)           0.02074            4         0.00518   0.013   0.010
                                      KokkosBatched::Test::SerialInverseLU::Double::InverseLUFunctor (ParFor)           0.02002           88         0.00023   0.013   0.010
                                   KokkosBatched::Test::SerialSolveLU::ComplexDouble::SolveLUFunctor (ParFor)           0.01986          176         0.00011   0.013   0.010
                                                                               KokkosBlas1::Nrm1::S0 (ParRed)           0.01971           64         0.00031   0.013   0.010
                                                                            KokkosBlas::Scal::MV::S3 (ParFor)           0.01954           64         0.00031   0.013   0.009
                                                            KokkosKernels::Common::IsD1ColoringValie (ParRed)           0.01933           18         0.00107   0.013   0.009
                                                    KokkosSparse::StructureC::SPGEMM_KK_MEM::DYNAMIC (ParFor)           0.01919            6         0.00320   0.012   0.009
                                                                                KokkosBlas::Mult::S3 (ParFor)           0.01913           48         0.00040   0.012   0.009
                                                                                KokkosBlas::Scal::S3 (ParFor)           0.01884           96         0.00020   0.012   0.009
                                                                          KokkosBlas::Test::TeamNrm2 (ParFor)           0.01857           32         0.00058   0.012   0.009
                                                                                 KokkosBlas::Abs::S3 (ParFor)           0.01846           24         0.00077   0.012   0.009
                                                                                 KokkosBlas::Abs::S1 (ParFor)           0.01740           24         0.00073   0.011   0.008
                                                                                KokkosBlas::Nrm2::S1 (ParRed)           0.01647           64         0.00026   0.011   0.008
                                             KokkosBatched::Test::SerialSolveLU::Double::GemmFunctor (ParFor)           0.01616           88         0.00018   0.010   0.008
                                                                               KokkosBlas1::Nrm1::S1 (ParRed)           0.01520           32         0.00047   0.010   0.007
                                                                        KokkosBlas::update<MV,a,b,c> (ParFor)           0.01456           32         0.00046   0.009   0.007
                                                               KokkosSparse::PredicMaxRowNNZ::STATIC (ParRed)           0.01405           20         0.00070   0.009   0.007
                                                              KokkosSparse::spmv<NoTranspose,Static> (ParFor)           0.01232           20         0.00062   0.008   0.006
                                                                          KokkosBlas::Reciprocal::S1 (ParFor)           0.01228           24         0.00051   0.008   0.006
                                                                KokkosKernels::Common::PermuteVector (ParFor)           0.01202           96         0.00013   0.008   0.006
                                                         KokkosKernels::Common::ViewReduceMaxSizeRow (ParRed)           0.01105           10         0.00111   0.007   0.005
                                                                           KokkosBlas::update<a,b,c> (ParFor)           0.01023           48         0.00021   0.007   0.005
                                      KokkosBatched::Test::SerialSolveLU::ComplexDouble::GemmFunctor (ParFor)           0.01017           88         0.00012   0.007   0.005
                                                     KokkosKernels::Common::Test::CheckArrayBitCount (ParFor)           0.00963           12         0.00080   0.006   0.005
                                        KokkosSparse::TwoStepZipMatrix::fill::use_unordered_compress (ParFor)           0.00948           10         0.00095   0.006   0.005
                                                                                 KokkosBlas::Sum::S0 (ParRed)           0.00817           32         0.00026   0.005   0.004
                                                                                 KokkosBlas::Sum::S1 (ParRed)           0.00802           32         0.00025   0.005   0.004
                                                                              KokkosBlas::NrmInf::S0 (ParRed)           0.00693           24         0.00029   0.004   0.003
                                                                              KokkosKernels::FindMax (ParRed)           0.00670           54         0.00012   0.004   0.003
                                              KokkosSparse::TwoStepZipMatrix::use_unordered_compress (ParFor)           0.00602           10         0.00060   0.004   0.003
                                                                  KokkosKernels::Common::ReduceView2 (ParRed)           0.00597           20         0.00030   0.004   0.003
                                                     KokkosSparse::GaussSeidel::fill_matrix_symbolic (ParFor)           0.00582           32         0.00018   0.004   0.003
                                                     Deterministic Coloring: compute dependency list (ParFor)           0.00556            6         0.00093   0.004   0.003
                                                  KokkosGraph::GraphColoring::HalfEdgeConflictsCount (ParRed)           0.00519            9         0.00058   0.003   0.003
                                                                              KokkosBlas::NrmInf::S1 (ParRed)           0.00478           12         0.00040   0.003   0.002
                                                KokkosSparse::GaussSeidel::team_get_matrix_diagonals (ParFor)           0.00476           16         0.00030   0.003   0.002
                                       KokkosSparse::SpAdd:Symbolic::InputNotSorted::PrefixSumSecond (ParScan)          0.00433            4         0.00108   0.003   0.002
                                             KokkosSparse::SpAdd:Symbolic::InputNotSorted::PrefixSum (ParScan)          0.00428            4         0.00107   0.003   0.002
                                                          KokkosKernels::Common::ReverseMapScaleInit (ParFor)           0.00428           32         0.00013   0.003   0.002
                                                   KokkosGraph::GraphColoring::HalfEdgeMarkConflicts (ParFor)           0.00421            9         0.00047   0.003   0.002
                                                KokkosSparse::SpAdd:Symbolic::InputSorted::PrefixSum (ParScan)          0.00413            4         0.00103   0.003   0.002
                                  KokkosGraph::GraphColoring::HalfEdgeExpandBanForUnmatchedNeighbors (ParFor)           0.00406            7         0.00058   0.003   0.002
                                                    KokkosKernels::Common::Test::ArithTraitsOnDevice (ParRed)           0.00394           23         0.00017   0.003   0.002
                                                               KokkosKernels::Common::FillReverseMap (ParFor)           0.00389           32         0.00012   0.003   0.002
                                                                                 KokkosBlas::Abs::S2 (ParFor)           0.00384            8         0.00048   0.002   0.002
                                                     KokkosSparse::GaussSeidel::create_permuted_xadj (ParFor)           0.00380           32         0.00012   0.002   0.002
                                                       KokkosGraph::GraphColoring::CalcEdgePositions (ParScan)          0.00374            4         0.00093   0.002   0.002
                                                                  KokkosKernels::Common::StridedCopy (ParFor)           0.00346           32         0.00011   0.002   0.002
                                                      KokkosGraph::GraphColoring::HalfEdgeBancColors (ParFor)           0.00317            7         0.00045   0.002   0.002
                                                                                 KokkosBlas::Abs::S0 (ParFor)           0.00288            8         0.00036   0.002   0.001
                                                                            KokkosSparse::Test::spmv (ParRed)           0.00285           18         0.00016   0.002   0.001
                                                     KokkosSparse::GaussSeidel::get_matrix_diagonals (ParFor)           0.00251           16         0.00016   0.002   0.001
                                                                  KokkosGraph::FillLowerTriangleTeam (ParFor)           0.00232            2         0.00116   0.002   0.001
                                                      KokkosGraph::GraphColoring::GreedyColor_IMPLOG (ParFor)           0.00231            3         0.00077   0.002   0.001
                                                                          KokkosBlas::Reciprocal::S2 (ParFor)           0.00170            8         0.00021   0.001   0.001
                                                                  KokkosSparse::Test::ReplaceSumInto (ParFor)           0.00162           16         0.00010   0.001   0.001
                                                         KokkosKernels::Common::ViewReduceMaxRowSize (ParRed)           0.00161           16         0.00010   0.001   0.001
                                                                          KokkosBlas::Reciprocal::S0 (ParFor)           0.00152            8         0.00019   0.001   0.001
                                                      KokkosGraph::GraphColoring::CreateNewWorkArray (ParFor)           0.00125            4         0.00031   0.001   0.001
                                          KokkosSparse::SpAdd:Symbolic::InputNotSorted::MergeEntries (ParFor)           0.00125            4         0.00031   0.001   0.001
                                                                 KokkosGraph::CountLowerTriangleTeam (ParRed)           0.00111            2         0.00055   0.001   0.001
                                                            KokkosGraph::GraphColoring::ChooseColors (ParFor)           0.00105            7         0.00015   0.001   0.001
                                          KokkosSparse::SpAdd:Symbolic::InputNotSorted::CountEntires (ParFor)           0.00095            4         0.00024   0.001   0.000
N6Kokkos4Impl25fill_random_functor_rangeINS_4ViewIPdJNS_11LayoutRightENS_6DeviceINS_6OpenMPENS_9HostSpaceEEENS_12MemoryTraitsILj0EEEEEENS_22Random_XorShift64_PoolIS6_EELi128ELi1ElEE (ParFor)           0.00094            6         0.00016   0.001   0.000
                                           KokkosSparse::SpAdd:Symbolic::InputNotSorted::UnmergedSum (ParFor)           0.00094            4         0.00024   0.001   0.000
                                            KokkosSparse::SpAdd::Symbolic::InputSorted::CountEntries (ParFor)           0.00089            4         0.00022   0.001   0.000
                                                      Deterministic Coloring: compute initial scores (ParRed)           0.00089            6         0.00015   0.001   0.000
                                                          KokkosGraph::GraphColoring::InitWorkArrays (ParFor)           0.00087            2         0.00043   0.001   0.000
                                                            KokkosSparse::SpAdd:Numeric::InputSorted (ParFor)           0.00086            4         0.00022   0.001   0.000
                                                         KokkosSparse::SpAdd:Numeric::InputNotSorted (ParFor)           0.00086            4         0.00022   0.001   0.000
N6Kokkos4Impl25fill_random_functor_rangeINS_4ViewIPNS_7complexIdEEJNS_11LayoutRightENS_6DeviceINS_6OpenMPENS_9HostSpaceEEENS_12MemoryTraitsILj0EEEEEENS_22Random_XorShift64_PoolIS8_EELi128ELi1ElEE (ParFor)           0.00080            6         0.00013   0.001   0.000
                                           KokkosSparse::SpAdd:Symbolic::InputNotSorted::SortEntries (ParFor)           0.00078            4         0.00020   0.001   0.000
                                                          KokkosGraph::GraphColoring::SetFinalColors (ParFor)           0.00072            4         0.00018   0.000   0.000
                                                           KokkosGraph::Distance2Color::ColorGraphD2 (ParFor)           0.00031            2         0.00015   0.000   0.000
                                                                  KokkosSparse::Test::BlockCrsMatrix (ParFor)           0.00030            2         0.00015   0.000   0.000
                                                              KokkosGraph::GraphColoring::initColors (ParFor)           0.00029            2         0.00014   0.000   0.000

-------------------------------------------------------------------------
Summary:

Total Execution Time (incl. Kokkos + Non-Kokkos:                  206.22480 seconds
Total Time in Kokkos kernels:                                     154.01778 seconds
   -> Time outside Kokkos kernels:                                 52.20702 seconds
   -> Percentage in Kokkos kernels:                                   74.68 %
Total Calls to Kokkos Kernels:                                       198095

-------------------------------------------------------------------------
```