### PR TITLE
tpl dot is wrong....

### DIFF
--- a/src/impl/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
+++ b/src/impl/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
@@ -51,9 +51,9 @@ extern "C" double ddot_ ( const int* N, const double* x, const int* x_inc,
                           const double* y, const int* y_inc);
 extern "C" float  sdot_ ( const int* N, const float* x, const int* x_inc,
                           const float* y, const int* y_inc);
-extern "C" void   zdotu_( std::complex<double> *res, const int* N, const std::complex<double>* x, const int* x_inc,
+extern "C" void   zdotc_( std::complex<double> *res, const int* N, const std::complex<double>* x, const int* x_inc,
                           const std::complex<double>* y, const int* y_inc);
-extern "C" void   cdotu_( std::complex<float> *res, const int* N, const std::complex<float>* x, const int* x_inc,
+extern "C" void   cdotc_( std::complex<float> *res, const int* N, const std::complex<float>* x, const int* x_inc,
                           const std::complex<float>* y, const int* y_inc);
 
 namespace KokkosBlas {
@@ -160,7 +160,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
       dot_print_specialization<RV,XV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      zdotu_(reinterpret_cast<std::complex<double>* >(R.data()),        \
+      zdotc_(reinterpret_cast<std::complex<double>* >(R.data()),        \
              &N,                                                        \
              reinterpret_cast<const std::complex<double>* >(X.data()),&one, \
              reinterpret_cast<const std::complex<double>* >(Y.data()),&one); \
@@ -196,7 +196,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
       dot_print_specialization<RV,XV,XV>(); \
       int N = numElems; \
       int one = 1; \
-      cdotu_(reinterpret_cast<std::complex<float>* >(R.data()), \
+      cdotc_(reinterpret_cast<std::complex<float>* >(R.data()), \
              &N,                                                        \
              reinterpret_cast<const std::complex<float>* >(X.data()),&one, \
              reinterpret_cast<const std::complex<float>* >(Y.data()),&one); \
@@ -325,7 +325,7 @@ Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, M
       const int N = static_cast<int> (numElems); \
       constexpr int one = 1; \
       KokkosBlas::Impl::CudaBlasSingleton & s = KokkosBlas::Impl::CudaBlasSingleton::singleton(); \
-      cublasZdotu(s.handle, N, reinterpret_cast<const cuDoubleComplex*>(X.data()), one, reinterpret_cast<const cuDoubleComplex*>(Y.data()), one, reinterpret_cast<cuDoubleComplex*>(&R())); \
+      cublasZdotc(s.handle, N, reinterpret_cast<const cuDoubleComplex*>(X.data()), one, reinterpret_cast<const cuDoubleComplex*>(Y.data()), one, reinterpret_cast<cuDoubleComplex*>(&R())); \
     } else { \
       Dot<RV,XV,XV,1,1,false,ETI_SPEC_AVAIL>::dot(R,X,Y); \
     } \
@@ -359,7 +359,7 @@ Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, ME
       const int N = static_cast<int> (numElems); \
       constexpr int one = 1; \
       KokkosBlas::Impl::CudaBlasSingleton & s = KokkosBlas::Impl::CudaBlasSingleton::singleton(); \
-      cublasCdotu(s.handle, N, reinterpret_cast<const cuComplex*>(X.data()), one, reinterpret_cast<const cuComplex*>(Y.data()), one, reinterpret_cast<cuComplex*>(&R())); \
+      cublasCdotc(s.handle, N, reinterpret_cast<const cuComplex*>(X.data()), one, reinterpret_cast<const cuComplex*>(Y.data()), one, reinterpret_cast<cuComplex*>(&R())); \
     } else { \
       Dot<RV,XV,XV,1,1,false,ETI_SPEC_AVAIL>::dot(R,X,Y); \
     } \

--- a/unit_test/blas/Test_Blas1_dot.hpp
+++ b/unit_test/blas/Test_Blas1_dot.hpp
@@ -1,6 +1,7 @@
 #include<gtest/gtest.h>
 #include<Kokkos_Core.hpp>
 #include<Kokkos_Random.hpp>
+#include<Kokkos_ArithTraits.hpp>
 #include<KokkosBlas1_dot.hpp>
 #include<KokkosKernels_TestUtils.hpp>
 
@@ -10,6 +11,7 @@ namespace Test {
 
     typedef typename ViewTypeA::value_type ScalarA;
     typedef typename ViewTypeB::value_type ScalarB;
+    typedef Kokkos::ArithTraits<ScalarA> ats;
 
     typedef Kokkos::View<ScalarA*[2],
        typename std::conditional<
@@ -45,7 +47,7 @@ namespace Test {
 
     ScalarA expected_result = 0;
     for(int i=0;i<N;i++)
-      expected_result += h_a(i)*h_b(i);
+      expected_result += ats::conj(h_a(i))*h_b(i);
 
     ScalarA nonconst_nonconst_result = KokkosBlas::dot(a,b);
     double eps = std::is_same<ScalarA,float>::value?2*1e-5:1e-7;
@@ -68,6 +70,7 @@ namespace Test {
 
     typedef typename ViewTypeA::value_type ScalarA;
     typedef typename ViewTypeB::value_type ScalarB;
+    typedef Kokkos::ArithTraits<ScalarA> ats;
 
     typedef multivector_layout_adapter<ViewTypeA> vfA_type;
     typedef multivector_layout_adapter<ViewTypeB> vfB_type;
@@ -104,7 +107,7 @@ namespace Test {
     for(int j=0;j<K;j++) {
       expected_result[j] = ScalarA();
       for(int i=0;i<N;i++)
-        expected_result[j] += h_a(i,j)*h_b(i,j);
+        expected_result[j] += ats::conj(h_a(i,j))*h_b(i,j);
     }
 
     double eps = std::is_same<ScalarA,float>::value?2*1e-5:1e-7;


### PR DESCRIPTION
It looks like that complex code is never well tested. Tpl complex dot uses zdotu which performs result += a(i)*b(i). However, it should use zdotc which does result += conj(a(i))*b(i). zdotc is consistent to what is implemented in Kokkos InnerProduct Traits. 