### PR TITLE
Shadowed declarations in SPGEMM

### DIFF
--- a/src/sparse/impl/KokkosSparse_spgemm_imp_outer.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_imp_outer.hpp
@@ -881,7 +881,7 @@ KokkosSPGEMM_numeric_outer(
     c_row_view_t &rowmapC_,
     c_lno_nnz_view_t &entriesC_,
     c_scalar_nnz_view_t &valuesC_,
-    KokkosKernels::Impl::ExecSpaceType my_exec_space){
+    KokkosKernels::Impl::ExecSpaceType my_exec_space_){
   throw std::runtime_error ("Cannot run outer product. ENABLE openmp and outer product to run\n");
 }
 #endif
@@ -898,7 +898,7 @@ void KokkosSPGEMM
     c_row_view_t &rowmapC_,
     c_lno_nnz_view_t &entriesC_,
     c_scalar_nnz_view_t &valuesC_,
-    KokkosKernels::Impl::ExecSpaceType my_exec_space){
+    KokkosKernels::Impl::ExecSpaceType my_exec_space_){
   throw std::runtime_error ("Cannot run outer product. ENABLE openmp and outer product to run\n");
 }
 #endif

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_def.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_def.hpp
@@ -62,7 +62,7 @@ void KokkosSPGEMM
 
     //get the algorithm and execution space.
     //SPGEMMAlgorithm spgemm_algorithm = this->handle->get_spgemm_handle()->get_algorithm_type();
-    KokkosKernels::Impl::ExecSpaceType my_exec_space = KokkosKernels::Impl::get_exec_space_type<MyExecSpace>();
+    KokkosKernels::Impl::ExecSpaceType my_exec_space_ = KokkosKernels::Impl::get_exec_space_type<MyExecSpace>();
 
     if (KOKKOSKERNELS_VERBOSE){
       std::cout << "Numeric PHASE" << std::endl;
@@ -70,10 +70,10 @@ void KokkosSPGEMM
 
     if (spgemm_algorithm == SPGEMM_KK_SPEED || spgemm_algorithm == SPGEMM_KK_DENSE)
     {
-      this->KokkosSPGEMM_numeric_speed(rowmapC_, entriesC_, valuesC_, my_exec_space);
+      this->KokkosSPGEMM_numeric_speed(rowmapC_, entriesC_, valuesC_, my_exec_space_);
     }
     else {
-      this->KokkosSPGEMM_numeric_hash(rowmapC_, entriesC_, valuesC_, my_exec_space);
+      this->KokkosSPGEMM_numeric_hash(rowmapC_, entriesC_, valuesC_, my_exec_space_);
     }
 
   }
@@ -120,11 +120,11 @@ void KokkosSPGEMM
     //number of rows and nnzs
     nnz_lno_t n = this->row_mapB.extent(0) - 1;
     size_type nnz = this->entriesB.extent(0);
-    KokkosKernels::Impl::ExecSpaceType my_exec_space = KokkosKernels::Impl::get_exec_space_type<MyExecSpace>();
+    KokkosKernels::Impl::ExecSpaceType my_exec_space_ = KokkosKernels::Impl::get_exec_space_type<MyExecSpace>();
 
     bool compress_in_single_step = this->handle->get_spgemm_handle()->get_compression_step();
     //compress in single step if it is cuda execution space.
-    if (my_exec_space == KokkosKernels::Impl::Exec_CUDA) {
+    if (my_exec_space_ == KokkosKernels::Impl::Exec_CUDA) {
     	compress_in_single_step = true;
     }
 

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
@@ -1122,7 +1122,7 @@ void
       c_row_view_t rowmapC_,
       c_lno_nnz_view_t entriesC_,
       c_scalar_nnz_view_t valuesC_,
-      KokkosKernels::Impl::ExecSpaceType my_exec_space){
+      KokkosKernels::Impl::ExecSpaceType lcl_my_exec_space){
 
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << "\tHASH MODE" << std::endl;
@@ -1183,7 +1183,7 @@ void
 
   //choose parameters
   if (this->spgemm_algorithm == SPGEMM_KK || SPGEMM_KK_LP == this->spgemm_algorithm){
-	  if (my_exec_space == KokkosKernels::Impl::Exec_CUDA){
+	  if (lcl_my_exec_space == KokkosKernels::Impl::Exec_CUDA){
 		  //then chose the best method and parameters.
 		  size_type average_row_nnz = overall_nnz / this->a_row_cnt;
 		  size_t average_row_flops = original_overall_flops / this->a_row_cnt;
@@ -1299,7 +1299,7 @@ void
 					  rowmapC_,
 					  entriesC_,
 					  valuesC_,
-					  my_exec_space);
+					  lcl_my_exec_space);
 			  return;
 		  }
 	  }
@@ -1313,7 +1313,7 @@ void
 
 
   //required memory for L2
-  if (my_exec_space == KokkosKernels::Impl::Exec_CUDA){
+  if (lcl_my_exec_space == KokkosKernels::Impl::Exec_CUDA){
 
 	  if (algorithm_to_run == SPGEMM_KK_MEMORY_SPREADTEAM){
 		  tmp_max_nnz = 1;
@@ -1356,7 +1356,7 @@ void
   int num_chunks = concurrency / suggested_vector_size;
 
 #if defined( KOKKOS_ENABLE_CUDA )
-  if (my_exec_space == KokkosKernels::Impl::Exec_CUDA) {
+  if (lcl_my_exec_space == KokkosKernels::Impl::Exec_CUDA) {
 
     size_t free_byte ;
     size_t total_byte ;
@@ -1390,7 +1390,7 @@ void
   KokkosKernels::Impl::PoolType my_pool_type =
       KokkosKernels::Impl::OneThread2OneChunk;
 
-  if (my_exec_space == KokkosKernels::Impl::Exec_CUDA){
+  if (lcl_my_exec_space == KokkosKernels::Impl::Exec_CUDA){
     my_pool_type = KokkosKernels::Impl::ManyThread2OneChunk;
   }
 
@@ -1428,7 +1428,7 @@ void
       min_hash_size, max_nnz,
       suggested_team_size,
 
-      my_exec_space,
+      lcl_my_exec_space,
       team_row_chunk_size,
 	  first_level_cut_off, flops_per_row,
 	  KOKKOSKERNELS_VERBOSE);
@@ -1439,7 +1439,7 @@ void
   }
   timer1.reset();
 
-  if (my_exec_space == KokkosKernels::Impl::Exec_CUDA){
+  if (lcl_my_exec_space == KokkosKernels::Impl::Exec_CUDA){
 	  if (algorithm_to_run == SPGEMM_KK_MEMORY_SPREADTEAM){
 		  Kokkos::parallel_for("KOKKOSPARSE::SPGEMM::SPGEMM_KK_MEMORY_SPREADTEAM", gpu_team_policy4_t(a_row_cnt / team_row_chunk_size + 1 , suggested_team_size, suggested_vector_size), sc);
 		    MyExecSpace::fence();
@@ -1498,7 +1498,7 @@ void
       c_row_view_t rowmapC_,
       c_lno_nnz_view_t entriesC_,
       c_scalar_nnz_view_t valuesC_,
-      KokkosKernels::Impl::ExecSpaceType my_exec_space){
+      KokkosKernels::Impl::ExecSpaceType my_exec_space_){
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << "\tHASH MODE" << std::endl;
   }
@@ -1534,7 +1534,7 @@ void
 
   KokkosKernels::Impl::PoolType my_pool_type =
       KokkosKernels::Impl::OneThread2OneChunk;
-  if (my_exec_space == KokkosKernels::Impl::Exec_CUDA){
+  if (my_exec_space_ == KokkosKernels::Impl::Exec_CUDA){
     my_pool_type = KokkosKernels::Impl::ManyThread2OneChunk;
   }
 
@@ -1573,7 +1573,7 @@ void
       min_hash_size, max_nnz,
       suggested_team_size,
 
-      my_exec_space,
+      my_exec_space_,
 	  team_row_chunk_size,
 	  first_level_cut_off,
        this->handle->get_spgemm_handle()->row_flops, KOKKOSKERNELS_VERBOSE);
@@ -1584,7 +1584,7 @@ void
   }
   timer1.reset();
 
-  if (my_exec_space == KokkosKernels::Impl::Exec_CUDA){
+  if (my_exec_space_ == KokkosKernels::Impl::Exec_CUDA){
     Kokkos::parallel_for("KOKKOSPARSE::SPGEMM::SPGEMM_KK_MEMORY2",  gpu_team_policy_t(a_row_cnt / team_row_chunk_size + 1 , suggested_team_size, suggested_vector_size), sc);
     MyExecSpace::fence();
   }

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
@@ -480,7 +480,7 @@ void
     c_row_view_t rowmapC_,
     c_lno_nnz_view_t entriesC_,
     c_scalar_nnz_view_t valuesC_,
-    KokkosKernels::Impl::ExecSpaceType my_exec_space){
+    KokkosKernels::Impl::ExecSpaceType my_exec_space_){
 
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << "\tSPEED MODE" << std::endl;
@@ -496,7 +496,7 @@ void
 
   Kokkos::Impl::Timer numeric_speed_timer_with_free;
 
-  if (my_exec_space == KokkosKernels::Impl::Exec_CUDA){
+  if (my_exec_space_ == KokkosKernels::Impl::Exec_CUDA){
     //allocate memory for begins and next to be used by the hashmap
     nnz_lno_temp_work_view_t beginsC
     (Kokkos::ViewAllocateWithoutInitializing("C keys"), valuesC_.extent(0));
@@ -599,7 +599,7 @@ void
         entriesC_,
         valuesC_,
         m_space,
-        my_exec_space,
+        my_exec_space_,
         team_row_chunk_size);
 
     MyExecSpace::fence();


### PR DESCRIPTION
I was getting a lot of compiler errors when I had -Werror=shadow enabled so I fixed them.

#### Example Error Message
```
/Users/wcmclen/dev/kk-dev/source/KokkosKernels/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp:1813:38: error: declaration of 'my_exec_space' shadows a previous local [-Werror=shadow]
   KokkosKernels::Impl::ExecSpaceType my_exec_space = this->handle->get_handle_exec_space();
                                      ^~~~~~~~~~~~~
In file included from /Users/wcmclen/dev/kk-dev/source/KokkosKernels/src/sparse/impl/KokkosSparse_spgemm_symbolic_spec.hpp:55,
                 from /Users/wcmclen/dev/kk-dev/source/KokkosKernels/src/impl/generated_specializations_cpp/spgemm_symbolic/KokkosSparse_spgemm_symbolic_eti_spec_inst_double_size_t_int_LayoutRight_Serial_HostSpace_HostSpace.cpp:55:
/Users/wcmclen/dev/kk-dev/source/KokkosKernels/src/sparse/impl/KokkosSparse_spgemm_impl.hpp:144:44: note: shadowed declaration is here
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
                                            ^~~~~~~~~~~~~
In file included from /Users/wcmclen/dev/kk-dev/source/KokkosKernels/src/sparse/impl/KokkosSparse_spgemm_impl.hpp:766,
                 from /Users/wcmclen/dev/kk-dev/source/KokkosKernels/src/sparse/impl/KokkosSparse_spgemm_symbolic_spec.hpp:55,
                 from /Users/wcmclen/dev/kk-dev/source/KokkosKernels/src/impl/generated_specializations_cpp/spgemm_symbolic/KokkosSparse_spgemm_symbolic_eti_spec_inst_double_size_t_int_LayoutRight_Serial_HostSpace_HostSpace.cpp:55:
/Users/wcmclen/dev/kk-dev/source/KokkosKernels/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp: In instantiation of 'void KokkosSparse::Impl::KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_view_t_, b_lno_ro<snip/>
```