### PR TITLE
Use homebrew's coreutils cp if available on osx

### DIFF
--- a/Makefile.kokkos-kernels
+++ b/Makefile.kokkos-kernels
@@ -456,6 +456,8 @@ endif
 
 DEPFLAGS = -M
 
+CP = cp
+
 ifeq ($(KOKKOS_OS),CYGWIN)
   COPY_FLAG = -u
 endif
@@ -463,7 +465,14 @@ ifeq ($(KOKKOS_OS),Linux)
   COPY_FLAG = -u
 endif
 ifeq ($(KOKKOS_OS),Darwin)
-  COPY_FLAG =
+  # If using Homebrew on OSX with the 'coreutils' package installed
+  # we have a gnu version of cp which has the -u option
+  ifeq (,$(wildcard "/usr/local/opt/coreutils/libexec/gnubin/cp"))
+    CP = /usr/local/opt/coreutils/libexec/gnubin/cp
+    COPY_FLAG = -u
+  else
+    COPY_FLAG =
+  endif
 endif
 
 KOKKOSKERNELS_INTERNAL_SRC_BLAS_NODIR = $(notdir $(KOKKOSKERNELS_INTERNAL_SRC_BLAS))

--- a/src/Makefile
+++ b/src/Makefile
@@ -74,20 +74,20 @@ kokkoskernels-install: kokkoskernels-build-lib
 	echo "KOKKOS_INTERNAL_USE_ROCM = ${KOKKOS_INTERNAL_USE_ROCM}" >> $(KOKKOSKERNELS_INSTALL_PATH)/Makefile.kokkos-kernels
 	echo "# Fake target" >> $(KOKKOSKERNELS_INSTALL_PATH)/Makefile.kokkos-kernels
 	echo "libkokkos_kernels.a:" >> $(KOKKOSKERNELS_INSTALL_PATH)/Makefile.kokkos-kernels
-	cp $(COPY_FLAG) KokkosKernels_config.h $(KOKKOSKERNELS_INSTALL_PATH)/include
-	cp $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
-	cp $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/impl/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
-	cp $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/blas/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
-	cp $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/blas/impl/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
-	cp $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/batched/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
-	cp $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/sparse/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
-	cp $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/sparse/impl/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
-	cp $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/graph/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
-	cp $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/graph/impl/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
-	cp $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/common/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
-	cp $(COPY_FLAG) -r ${KOKKOSKERNELS_PATH}/src/impl/generated_specializations_hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
-	cp $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/impl/tpls/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
-	cp $(COPY_FLAG) $(KOKKOSKERNELS_INTERNAL_LIBRARY) $(KOKKOSKERNELS_INSTALL_PATH)/lib
+	$(CP) $(COPY_FLAG) KokkosKernels_config.h $(KOKKOSKERNELS_INSTALL_PATH)/include
+	$(CP) $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
+	$(CP) $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/impl/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
+	$(CP) $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/blas/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
+	$(CP) $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/blas/impl/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
+	$(CP) $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/batched/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
+	$(CP) $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/sparse/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
+	$(CP) $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/sparse/impl/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
+	$(CP) $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/graph/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
+	$(CP) $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/graph/impl/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
+	$(CP) $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/common/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
+	$(CP) $(COPY_FLAG) -r ${KOKKOSKERNELS_PATH}/src/impl/generated_specializations_hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
+	$(CP) $(COPY_FLAG) ${KOKKOSKERNELS_PATH}/src/impl/tpls/*.hpp $(KOKKOSKERNELS_INSTALL_PATH)/include
+	$(CP) $(COPY_FLAG) $(KOKKOSKERNELS_INTERNAL_LIBRARY) $(KOKKOSKERNELS_INSTALL_PATH)/lib
 
 build: kokkoskernels-build-lib
 


### PR DESCRIPTION
If the `coreutils` package is installed on OSX via Homebrew, there will be a gnu version of cp installed which does respect the `-u` option.
This will reduce the time it takes to recompile KokkosKernels on OSX systems since we won't be updating the timestamp on all the sources every time we recompile.