### PR TITLE
KokkosBatched - add a more selective interface

### DIFF
--- a/src/batched/KokkosBatched_Gemm_Decl.hpp
+++ b/src/batched/KokkosBatched_Gemm_Decl.hpp
@@ -50,9 +50,38 @@ namespace KokkosBatched {
              const ScalarType beta,
              const CViewType &C);
     };
-  
-    // specialized for different m and n
-    // C(mxn) += alpha * A(mxk) B(kxn)
+
+
+    ///
+    /// Selective Interface
+    ///
+    template<typename MemberType,
+             typename ArgTransA,
+             typename ArgTransB,
+             typename ArgMode,
+             typename ArgAlgo>
+    struct Gemm {
+      template<typename ScalarType,
+               typename AViewType,
+               typename BViewType,
+               typename CViewType>
+      KOKKOS_FORCEINLINE_FUNCTION
+      static int
+      invoke(const MemberType &member,
+             const ScalarType alpha,
+             const AViewType &A,
+             const BViewType &B,
+             const ScalarType beta,
+             const CViewType &C) {
+        int r_val = 0;
+        if (std::is_same<ArgMode,Mode::Serial>::value) {
+          r_val = SerialGemm<ArgTransA,ArgTransB,ArgAlgo>::invoke(alpha, A, B, beta, C);
+        } else if (std::is_same<ArgMode,Mode::Team>::value) {
+          r_val = TeamGemm<MemberType,ArgTransA,ArgTransB,ArgAlgo>::invoke(member, alpha, A, B, beta, C);
+        } 
+        return r_val;
+      }
+    };      
 
   }
 }

--- a/src/batched/KokkosBatched_Gemv_Decl.hpp
+++ b/src/batched/KokkosBatched_Gemv_Decl.hpp
@@ -28,14 +28,6 @@ namespace KokkosBatched {
              const yViewType &y);
     };
     
-#define KOKKOSBATCHED_SERIAL_GEMV_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,M,N,ALPHA,A,AS0,AS1,X,XS,BETA,Y,YS) \
-    KokkosBatched::Experimental::SerialGemvInternal<ALGOTYPE>           \
-    ::invoke(M, N, ALPHA, A, AS0, AS1, X, XS, BETA, Y, YS)
-    
-#define KOKKOSBATCHED_SERIAL_GEMV_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,M,N,ALPHA,A,AS0,AS1,X,XS,BETA,Y,YS) \
-    KokkosBatched::Experimental::SerialGemvInternal<ALGOTYPE>           \
-    ::invoke(N, M, ALPHA, A, AS1, AS0, X, XS, BETA, Y, YS)
-    
     ///
     /// Team Gemv 
     ///
@@ -58,15 +50,66 @@ namespace KokkosBatched {
              const yViewType &y);
     };
 
-#define KOKKOSBATCHED_TEAM_GEMV_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,M,N,ALPHA,A,AS0,AS1,X,XS,BETA,Y,YS) \
-    KokkosBatched::Experimental::TeamGemvInternal<ALGOTYPE>           \
-    ::invoke(MEMBER, M, N, ALPHA, A, AS0, AS1, X, XS, BETA, Y, YS)
-    
-#define KOKKOSBATCHED_TEAM_GEMV_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,M,N,ALPHA,A,AS0,AS1,X,XS,BETA,Y,YS) \
-    KokkosBatched::Experimental::TeamGemvInternal<ALGOTYPE>           \
-    ::invoke(MEMBER, N, M, ALPHA, A, AS1, AS0, X, XS, BETA, Y, YS)
+    ///
+    /// Selective Interface
+    ///
+    template<typename MemberType,
+             typename ArgTrans,
+             typename ArgMode, typename ArgAlgo>
+    struct Gemv {
+      template<typename ScalarType,
+               typename AViewType,
+               typename xViewType,
+               typename yViewType>
+      KOKKOS_FORCEINLINE_FUNCTION
+      static int
+      invoke(const MemberType &member, 
+             const ScalarType alpha,
+             const AViewType &A,
+             const xViewType &x,
+             const ScalarType beta,
+             const yViewType &y) {
+        int r_val = 0;
+        if (std::is_same<ArgMode,Mode::Serial>::value) {
+          r_val = SerialGemv<ArgTrans,ArgAlgo>::invoke(alpha, A, x, beta, y);
+        } else if (std::is_same<ArgMode,Mode::Team>::value) {
+          r_val = TeamGemv<MemberType,ArgTrans,ArgAlgo>::invoke(member, alpha, A, x, beta, y);
+        } 
+        return r_val;
+      }      
+    };
 
-  }
 }
+}
+
+#define KOKKOSBATCHED_SERIAL_GEMV_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,M,N,ALPHA,A,AS0,AS1,X,XS,BETA,Y,YS) \
+  KokkosBatched::Experimental::SerialGemvInternal<ALGOTYPE>             \
+  ::invoke(M, N, ALPHA, A, AS0, AS1, X, XS, BETA, Y, YS)
+
+#define KOKKOSBATCHED_SERIAL_GEMV_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,M,N,ALPHA,A,AS0,AS1,X,XS,BETA,Y,YS) \
+  KokkosBatched::Experimental::SerialGemvInternal<ALGOTYPE>             \
+  ::invoke(N, M, ALPHA, A, AS1, AS0, X, XS, BETA, Y, YS)
+
+#define KOKKOSBATCHED_TEAM_GEMV_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,M,N,ALPHA,A,AS0,AS1,X,XS,BETA,Y,YS) \
+  KokkosBatched::Experimental::TeamGemvInternal<ALGOTYPE>               \
+  ::invoke(MEMBER, M, N, ALPHA, A, AS0, AS1, X, XS, BETA, Y, YS)
+
+#define KOKKOSBATCHED_TEAM_GEMV_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,M,N,ALPHA,A,AS0,AS1,X,XS,BETA,Y,YS) \
+  KokkosBatched::Experimental::TeamGemvInternal<ALGOTYPE>               \
+  ::invoke(MEMBER, N, M, ALPHA, A, AS1, AS0, X, XS, BETA, Y, YS)
+  
+#define KOKKOSBATCHED_GEMV_NO_TRANSPOSE_INTERNAL_INVOKE(MODETYPE,ALGOTYPE,MEMBER,M,N,ALPHA,A,AS0,AS1,X,XS,BETA,Y,YS) \
+  if (std::is_same<MODETYPE,KokkosBatched::Experimental::Mode::Serial>::value) { \
+    KOKKOSBATCHED_SERIAL_GEMV_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,M,N,ALPHA,A,AS0,AS1,X,XS,BETA,Y,YS); \
+  } else if (std::is_same<MODETYPE,KokkosBatched::Experimental::Mode::Team>::value) { \
+    KOKKOSBATCHED_TEAM_GEMV_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,M,N,ALPHA,A,AS0,AS1,X,XS,BETA,Y,YS); \
+  }                                                                   
+
+#define KOKKOSBATCHED_GEMV_TRANSPOSE_INTERNAL_INVOKE(MODETYPE,ALGOTYPE,MEMBER,M,N,ALPHA,A,AS0,AS1,X,XS,BETA,Y,YS) \
+  if (std::is_same<MODETYPE,KokkosBatched::Experimental::Mode::Serial>::value) { \
+    KOKKOSBATCHED_SERIAL_GEMV_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,M,N,ALPHA,A,AS0,AS1,X,XS,BETA,Y,YS); \
+  } else if (std::is_same<MODETYPE,KokkosBatched::Experimental::Mode::Team>::value) { \
+    KOKKOSBATCHED_TEAM_GEMV_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,M,N,ALPHA,A,AS0,AS1,X,XS,BETA,Y,YS); \
+  }
 
 #endif

--- a/src/batched/KokkosBatched_LU_Decl.hpp
+++ b/src/batched/KokkosBatched_LU_Decl.hpp
@@ -30,6 +30,29 @@ namespace KokkosBatched {
              const AViewType &A,
              const typename MagnitudeScalarType<typename AViewType::non_const_value_type>::type tiny = 0);
     };       
+
+    ///
+    /// Selective Interface
+    ///
+    template<typename MemberType,
+             typename ArgMode, typename ArgAlgo>
+    struct LU {
+      // no piv version
+      template<typename AViewType>
+      KOKKOS_FORCEINLINE_FUNCTION
+      static int
+      invoke(const MemberType &member, 
+             const AViewType &A,
+             const typename MagnitudeScalarType<typename AViewType::non_const_value_type>::type tiny = 0) {
+        int r_val = 0;
+        if (std::is_same<ArgMode,Mode::Serial>::value) {
+          r_val = SerialLU<ArgAlgo>::invoke(A, tiny);
+        } else if (std::is_same<ArgMode,Mode::Team>::value) {
+          r_val = TeamLU<MemberType,ArgAlgo>::invoke(member, A, tiny);
+        } 
+        return r_val;
+      }
+    };           
       
   }
 }

--- a/src/batched/KokkosBatched_Trsm_Decl.hpp
+++ b/src/batched/KokkosBatched_Trsm_Decl.hpp
@@ -42,6 +42,35 @@ namespace KokkosBatched {
              const BViewType &B);
     };
 
+    ///
+    /// Selective Interface
+    ///
+    template<typename MemberType,
+             typename ArgSide,
+             typename ArgUplo,
+             typename ArgTrans,
+             typename ArgDiag,
+             typename ArgMode, typename ArgAlgo>
+    struct Trsm {
+      template<typename ScalarType,
+               typename AViewType,
+               typename BViewType>
+      KOKKOS_FORCEINLINE_FUNCTION
+      static int
+      invoke(const MemberType &member,
+             const ScalarType alpha,
+             const AViewType &A,
+             const BViewType &B) {
+        int r_val = 0;
+        if (std::is_same<ArgMode,Mode::Serial>::value) {
+          r_val = SerialTrsm<ArgSide,ArgUplo,ArgTrans,ArgDiag,ArgAlgo>::invoke(alpha, A, B);
+        } else if (std::is_same<ArgMode,Mode::Team>::value) {
+          r_val = TeamTrsm<MemberType,ArgSide,ArgUplo,ArgTrans,ArgDiag,ArgAlgo>::invoke(member, alpha, A, B);
+        } 
+        return r_val;
+      }      
+    };
+
   }
 }
 

--- a/src/batched/KokkosBatched_Trsv_Decl.hpp
+++ b/src/batched/KokkosBatched_Trsv_Decl.hpp
@@ -27,17 +27,6 @@ namespace KokkosBatched {
              const bViewType &b);
     };
 
-#define KOKKOSBATCHED_SERIAL_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
-    KokkosBatched::Experimental::SerialTrsvInternalLower<ALGOTYPE>::invoke(DIAG::use_unit_diag, M, ALPHA, A, AS0, AS1, B, BS)
-    
-#define KOKKOSBATCHED_SERIAL_TRSV_LOWER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
-    KokkosBatched::Experimental::SerialTrsvInternalUpper<ALGOTYPE>::invoke(DIAG::use_unit_diag, N, ALPHA, A, AS1, AS0, B, BS)
-    
-#define KOKKOSBATCHED_SERIAL_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
-    KokkosBatched::Experimental::SerialTrsvInternalUpper<ALGOTYPE>::invoke(DIAG::use_unit_diag, M, ALPHA, A, AS0, AS1, B, BS)
-    
-#define KOKKOSBATCHED_SERIAL_TRSV_UPPER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
-    KokkosBatched::Experimental::SerialTrsvInternalLower<ALGOTYPE>::invoke(DIAG::use_unit_diag, N, ALPHA, A, AS1, AS0, B, BS) 
     
     ///
     /// Team Trsv
@@ -61,19 +50,88 @@ namespace KokkosBatched {
              const bViewType &b);
     };
 
-#define KOKKOSBATCHED_TEAM_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
-    KokkosBatched::Experimental::TeamTrsvInternalLower<ALGOTYPE>::invoke(MEMBER,DIAG::use_unit_diag, M, ALPHA, A, AS0, AS1, B, BS)
-    
-#define KOKKOSBATCHED_TEAM_TRSV_LOWER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
-    KokkosBatched::Experimental::TeamTrsvInternalUpper<ALGOTYPE>::invoke(MEMBER,DIAG::use_unit_diag, N, ALPHA, A, AS1, AS0, B, BS)
-    
-#define KOKKOSBATCHED_TEAM_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
-    KokkosBatched::Experimental::TeamTrsvInternalUpper<ALGOTYPE>::invoke(MEMBER,DIAG::use_unit_diag, M, ALPHA, A, AS0, AS1, B, BS)
-    
-#define KOKKOSBATCHED_TEAM_TRSV_UPPER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
-    KokkosBatched::Experimental::TeamTrsvInternalLower<ALGOTYPE>::invoke(MEMBER,DIAG::use_unit_diag, N, ALPHA, A, AS1, AS0, B, BS) 
+
+    ///
+    /// Selective Interface
+    ///
+    template<typename MemberType, 
+             typename ArgUplo,
+             typename ArgTrans,
+             typename ArgDiag,
+             typename ArgMode, typename ArgAlgo>
+    struct Trsv {      
+      template<typename ScalarType,
+               typename AViewType,
+               typename bViewType>
+      KOKKOS_INLINE_FUNCTION
+      static int
+      invoke(const MemberType &member,
+             const ScalarType alpha,
+             const AViewType &A,
+             const bViewType &b) {
+        int r_val = 0;
+        if (std::is_same<ArgMode,Mode::Serial>::value) {
+          r_val = SerialTrsv<ArgUplo,ArgTrans,ArgDiag,ArgAlgo>::invoke(alpha, A, b);
+        } else if (std::is_same<ArgMode,Mode::Team>::value) {
+          r_val = TeamTrsv<MemberType,ArgUplo,ArgTrans,ArgDiag,ArgAlgo>::invoke(member, alpha, A, b);
+        } 
+        return r_val;
+      }      
+    };
 
   }
 }
+
+#define KOKKOSBATCHED_SERIAL_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
+  KokkosBatched::Experimental::SerialTrsvInternalLower<ALGOTYPE>::invoke(DIAG::use_unit_diag, M, ALPHA, A, AS0, AS1, B, BS)
+
+#define KOKKOSBATCHED_SERIAL_TRSV_LOWER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
+  KokkosBatched::Experimental::SerialTrsvInternalUpper<ALGOTYPE>::invoke(DIAG::use_unit_diag, N, ALPHA, A, AS1, AS0, B, BS)
+
+#define KOKKOSBATCHED_SERIAL_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
+  KokkosBatched::Experimental::SerialTrsvInternalUpper<ALGOTYPE>::invoke(DIAG::use_unit_diag, M, ALPHA, A, AS0, AS1, B, BS)
+
+#define KOKKOSBATCHED_SERIAL_TRSV_UPPER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
+  KokkosBatched::Experimental::SerialTrsvInternalLower<ALGOTYPE>::invoke(DIAG::use_unit_diag, N, ALPHA, A, AS1, AS0, B, BS) 
+
+#define KOKKOSBATCHED_TEAM_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
+  KokkosBatched::Experimental::TeamTrsvInternalLower<ALGOTYPE>::invoke(MEMBER,DIAG::use_unit_diag, M, ALPHA, A, AS0, AS1, B, BS)
+
+#define KOKKOSBATCHED_TEAM_TRSV_LOWER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
+  KokkosBatched::Experimental::TeamTrsvInternalUpper<ALGOTYPE>::invoke(MEMBER,DIAG::use_unit_diag, N, ALPHA, A, AS1, AS0, B, BS)
+
+#define KOKKOSBATCHED_TEAM_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
+  KokkosBatched::Experimental::TeamTrsvInternalUpper<ALGOTYPE>::invoke(MEMBER,DIAG::use_unit_diag, M, ALPHA, A, AS0, AS1, B, BS)
+
+#define KOKKOSBATCHED_TEAM_TRSV_UPPER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
+  KokkosBatched::Experimental::TeamTrsvInternalLower<ALGOTYPE>::invoke(MEMBER,DIAG::use_unit_diag, N, ALPHA, A, AS1, AS0, B, BS) 
+
+#define KOKKOSBATCHED_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(MODETYPE,ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
+  if (std::is_same<MODETYPE,KokkosBatched::Experimental::Mode::Serial>::value) { \
+    KOKKOSBATCHED_SERIAL_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS); \
+  } else if (std::is_same<MODETYPE,KokkosBatched::Experimental::Mode::Team>::value) { \
+    KOKKOSBATCHED_TEAM_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS); \
+  }                                                                   
+
+#define KOKKOSBATCHED_TRSV_LOWER_TRANSPOSE_INTERNAL_INVOKE(MODETYPE,ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
+  if (std::is_same<MODETYPE,KokkosBatched::Experimental::Mode::Serial>::value) { \
+    KOKKOSBATCHED_SERIAL_TRSV_LOWER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS); \
+  } else if (std::is_same<MODETYPE,KokkosBatched::Experimental::Mode::Team>::value) { \
+    KOKKOSBATCHED_TEAM_TRSV_LOWER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS); \
+  }
+
+#define KOKKOSBATCHED_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE(MODETYPE,ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
+  if (std::is_same<MODETYPE,KokkosBatched::Experimental::Mode::Serial>::value) { \
+    KOKKOSBATCHED_SERIAL_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS); \
+  } else if (std::is_same<MODETYPE,KokkosBatched::Experimental::Mode::Team>::value) { \
+    KOKKOSBATCHED_TEAM_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS); \
+  }
+
+#define KOKKOSBATCHED_TRSV_UPPER_TRANSPOSE_INTERNAL_INVOKE(MODETYPE,ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
+  if (std::is_same<MODETYPE,KokkosBatched::Experimental::Mode::Serial>::value) { \
+    KOKKOSBATCHED_SERIAL_TRSV_UPPER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS); \
+  } else if (std::is_same<MODETYPE,KokkosBatched::Experimental::Mode::Team>::value) { \
+    KOKKOSBATCHED_TEAM_TRSV_UPPER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS); \
+  }
 
 #endif

--- a/src/batched/KokkosBatched_Util.hpp
+++ b/src/batched/KokkosBatched_Util.hpp
@@ -240,7 +240,16 @@ namespace KokkosBatched {
       struct NonUnit { static const bool use_unit_diag = false; };
     };
 
-    struct Algo {
+    struct Mode {
+      struct Serial {
+        static const char *name() { return "Serial"; }        
+      };
+      struct Team {
+        static const char *name() { return "Team"; }
+      };
+    };
+
+    struct Algo {      
       struct Level3 {
 	struct Unblocked {
 	  static const char* name() { return "Unblocked"; }


### PR DESCRIPTION
Add an interface to select between serial and team interfaces. This does not require a test as the modification is placed on decl.hpp. This modification however is required from Ifpack2.