### PR TITLE
D2GC: Fixing 'declaration hides member' error

### DIFF
--- a/src/graph/impl/KokkosGraph_Distance2Color_impl.hpp
+++ b/src/graph/impl/KokkosGraph_Distance2Color_impl.hpp
@@ -1163,19 +1163,19 @@ class GraphColorDistance2
         nnz_lno_temp_work_view_t  _vertexList;            //
         nnz_lno_type              _vertexListLength;      //
 
-        functorGreedyColorVB_BIT_EF(nnz_lno_type              nv,
-                                    const_lno_row_view_type   xadj,
-                                    nnz_lno_temp_work_view_t  adj,
-                                    const_clno_row_view_t     t_xadj,
-                                    non_const_clno_nnz_view_t t_adj,
+        functorGreedyColorVB_BIT_EF(nnz_lno_type              nv_,
+                                    const_lno_row_view_type   xadj_,
+                                    nnz_lno_temp_work_view_t  adj_,
+                                    const_clno_row_view_t     t_xadj_,
+                                    non_const_clno_nnz_view_t t_adj_,
                                     color_view_type           colors,
                                     nnz_lno_temp_work_view_t  vertexList,
                                     nnz_lno_type              vertexListLength)
-            : _nv(nv)
-            , _idx(xadj)
-            , _adj(adj)
-            , _t_idx(t_xadj)
-            , _t_adj(t_adj)
+            : _nv(nv_)
+            , _idx(xadj_)
+            , _adj(adj_)
+            , _t_idx(t_xadj_)
+            , _t_adj(t_adj_)
             , _colors(colors)
             , _vertexList(vertexList)
             , _vertexListLength(vertexListLength)


### PR DESCRIPTION
Bugfix for the KNL error from last night's tests.

@ndellingwood I looked at the other functors in `KokkosGraph_Distance2Color_impl.hpp` and they're all have the underscore appended to the end of the `nv`, `xadj`, `adj`, `t_xadj`, and `t_adj` paramters in the functor constructors so this one was just a cut-and-paste error I think.  Interesting that it got through the spot checks I was running.

My updated spot-check script for Bowman was able to replicate this error so I'm re-running it to make sure I got all the spots corrected.  I don't think it'll take too long to run so I'll post the spot check results here when it completes.