### PR TITLE
Add --help for distance-1 graph coloring

### DIFF
--- a/perf_test/graph/KokkosGraph_color.cpp
+++ b/perf_test/graph/KokkosGraph_color.cpp
@@ -97,6 +97,9 @@ void print_options(std::ostream &os, const char *app_name, unsigned int indent =
 
 int parse_inputs (KokkosKernels::Experiment::Parameters &params, int argc, char **argv)
 {
+  bool got_required_param_amtx      = false;
+  bool got_required_param_algorithm = false;
+
   for ( int i = 1 ; i < argc ; ++i ) {
     if ( 0 == strcasecmp( argv[i] , "--threads" ) ) {
       params.use_threads = atoi( argv[++i] );
@@ -123,6 +126,7 @@ int parse_inputs (KokkosKernels::Experiment::Parameters &params, int argc, char 
       params.vector_size  = atoi( argv[++i] ) ;
     }
     else if ( 0 == strcasecmp( argv[i] , "--amtx" ) ) {
+      got_required_param_amtx = true;
       params.a_mtx_bin_file = argv[++i];
     }
     else if ( 0 == strcasecmp( argv[i] , "--dynamic" ) ) {
@@ -132,6 +136,7 @@ int parse_inputs (KokkosKernels::Experiment::Parameters &params, int argc, char 
       params.verbose = 1;
     }
     else if ( 0 == strcasecmp( argv[i] , "--algorithm" ) ) {
+      got_required_param_algorithm = true;
       ++i;
       if ( 0 == strcasecmp( argv[i] , "COLORING_DEFAULT" ) ) {
         params.algorithm = 1;
@@ -174,6 +179,24 @@ int parse_inputs (KokkosKernels::Experiment::Parameters &params, int argc, char 
       return 1;
     }
   }
+  if(!got_required_param_amtx)
+  {
+    std::cout << "Missing required parameter amtx" << std::endl << std::endl;
+    print_options(std::cout, argv[0]);
+    return 1;
+  }
+  if(!got_required_param_algorithm)
+  {
+    std::cout << "Missing required parameter algorithm" << std::endl << std::endl;
+    print_options(std::cout, argv[0]);
+  return 1;
+  }
+  if(!params.use_serial && !params.use_threads && !params.use_openmp && !params.use_cuda)
+  {
+    print_options(std::cout, argv[0]);
+    return 1;
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
Added a --help option to the distance-1 graph coloring test, `perf_test/graph/KokkosGraph_color.exe`

### output
```
$ KokkosGraph_color.exe --help
Usage:
  KokkosGraph_color.exe [parameters]

Parameters:
  Parallelism (select one of the following):
      --serial <N>        Execute serially.
      --threads <N>       Use N posix threads.
      --openmp <N>        Use OpenMP with N threads.
      --cuda              Use CUDA

  Required Parameters:
      --amtx <filename>   Input file in Matrix Market format (.mtx).

      --algorithm <algorithm_name>   Set the algorithm to use.  Allowable values are:
                 COLORING_DEFAULT  - Use the default coloring method, architecture dependent.
                 COLORING_SERIAL   - Use the serial algorithm.
                 COLORING_VB       - Use the parallel vertex-based method.
                 COLORING_VBBIT    - Use the parallel vertex-based with bit vectors method.
                 COLORING_EB       - Use edge based method.
                 COLORING_VBD      - Use the vertex-based deterministic method.
                 COLORING_VBDBIT   - Use the vertex-based deterministic with bit vectors method.

  Optional Parameters:
      --repeat <N>        Set number of test repetitions (Default: 1)
      --verbose           Enable verbose mode (record and print timing + extra information)
      --chunksize <N>     Set the chunk size.
      --dynamic           Use dynamic scheduling.
      --teamsize  <N>     Set the team size.
      --vectorsize <N>    Set the vector size.
      --help              Print out command line help.

```

### Spot Checks
#### RHEL7 Linux
```
--------------------------------------------------------------------------------
-
-           K O K K O S   K E R N E L S   S P O T   C H E C K
-
--------------------------------------------------------------------------------

Kokkos
- URL...: git@github.com:william76/kokkos.git
- Branch: develop
- SHA1..: 660419121e8cd8fdf72db6299a8e69fc50efadc0

KokkosKernels
- URL...: git@github.com:william76/kokkos-kernels.git
- Branch: d1_gc_help_option
- SHA1..: a7b76a12b1c44173cbf3d4ab8d5a5b14a32257d9

Spot Check Command
/home/wcmclen/dev/kk-dev/source/KokkosKernels/scripts/test_all_sandia \
    --spot-check \
    --kokkoskernels-path=/home/wcmclen/dev/kk-dev/source/KokkosKernels \
    --kokkos-path=/home/wcmclen/dev/kk-dev/source/Kokkos \
    --arch="" \
    --skip-hwloc \
    gcc  \
    --num=2

ModuleCmd_Load.c(213):ERROR:105: Unable to locate a modulefile for 'sems-git'
Running on machine: sems
Going to test compilers:  gcc/5.3.0 gcc/7.2.0
Testing compiler gcc/5.3.0
Testing compiler gcc/7.2.0
  Starting job gcc-5.3.0-OpenMP-release
  Starting job gcc-7.2.0-Serial-release
  PASSED gcc-5.3.0-OpenMP-release
  PASSED gcc-7.2.0-Serial-release
#######################################################
PASSED TESTS
#######################################################
gcc-5.3.0-OpenMP-release build_time=165 run_time=285
gcc-7.2.0-Serial-release build_time=138 run_time=528
#######################################################
FAILED TESTS
#######################################################

--------------------------------------------------------------------------------
- Elapsed time: 668 seconds.
0m0.007s 0m0.009s
120m19.012s 7m54.066s
--------------------------------------------------------------------------------
```

#### Bowman (KNL)
```
--------------------------------------------------------------------------------
-
-           K O K K O S   K E R N E L S   S P O T   C H E C K
-
--------------------------------------------------------------------------------

Kokkos
- URL...: git@github.com:william76/kokkos.git
- Branch: develop
- SHA1..: 660419121e8cd8fdf72db6299a8e69fc50efadc0

KokkosKernels
- URL...: git@github.com:william76/kokkos-kernels.git
- Branch: d1_gc_help_option
- SHA1..: a7b76a12b1c44173cbf3d4ab8d5a5b14a32257d9

Spot Check Command
bsub -J wcmclen-KK-CUDA_OMP_Pascal \
    -W 6:00 \
    -Is \
    -q  \
    /home/wcmclen/dev/kk-dev/source/KokkosKernels/scripts/test_all_sandia \
        --spot-check \
        --kokkoskernels-path=/home/wcmclen/dev/kk-dev/source/KokkosKernels \
        --kokkos-path=/home/wcmclen/dev/kk-dev/source/Kokkos \
        --arch="KNL" \
        --skip-hwloc \
        intel \
        --num=2

Running on machine: bowman
Going to test compilers:  intel/17.2.174
Testing compiler intel/17.2.174
  Starting job intel-17.2.174-OpenMP-release
  PASSED intel-17.2.174-OpenMP-release
#######################################################
PASSED TESTS
#######################################################
intel-17.2.174-OpenMP-release build_time=1423 run_time=2084
#######################################################
FAILED TESTS
#######################################################

--------------------------------------------------------------------------------
- Elapsed time: 3511 seconds.
0m0.027s 0m0.043s
517m54.082s 32m24.000s
--------------------------------------------------------------------------------
```

#### White (CUDA)
```

--------------------------------------------------------------------------------
-
-           K O K K O S   K E R N E L S   S P O T   C H E C K
-
--------------------------------------------------------------------------------

Kokkos
- URL...: git@github.com:william76/kokkos.git
- Branch: develop
- SHA1..: 660419121e8cd8fdf72db6299a8e69fc50efadc0

KokkosKernels
- URL...: git@github.com:william76/kokkos-kernels.git
- Branch: d1_gc_help_option
- SHA1..: a7b76a12b1c44173cbf3d4ab8d5a5b14a32257d9

Spot Check Command
bsub -J wcmclen-KK-Test \
    -W 6:00 \
    -Is \
    -q rhel7F \
    /home/wcmclen/dev/kk-dev/source/KokkosKernels/scripts/test_all_sandia \
        --spot-check \
        --kokkoskernels-path=/home/wcmclen/dev/kk-dev/source/KokkosKernels \
        --kokkos-path=/home/wcmclen/dev/kk-dev/source/Kokkos \
        --arch="Power8,Kepler37" \
        --skip-hwloc \
        cuda \
        gcc \
        --num=2

***Forced exclusive execution
Job <46942> is submitted to queue <rhel7F>.
<<Waiting for dispatch ...>>
<<Starting on white23>>
Running on machine: white
Going to test compilers:  gcc/6.4.0 gcc/7.2.0 cuda/9.2.88 cuda/10.0.130
Testing compiler gcc/6.4.0
Testing compiler gcc/7.2.0
  Starting job gcc-6.4.0-OpenMP_Serial-release
  Starting job gcc-7.2.0-OpenMP-release
  PASSED gcc-7.2.0-OpenMP-release
  Starting job gcc-7.2.0-Serial-release
  PASSED gcc-6.4.0-OpenMP_Serial-release
Testing compiler cuda/9.2.88
  Starting job gcc-7.2.0-OpenMP_Serial-release
  PASSED gcc-7.2.0-Serial-release
  PASSED gcc-7.2.0-OpenMP_Serial-release
Testing compiler cuda/10.0.130
  Starting job cuda-9.2.88-Cuda_OpenMP-release
  PASSED cuda-9.2.88-Cuda_OpenMP-release
  Starting job cuda-10.0.130-Cuda_Serial-release
  PASSED cuda-10.0.130-Cuda_Serial-release
#######################################################
PASSED TESTS
#######################################################
cuda-10.0.130-Cuda_Serial-release build_time=1052 run_time=935
cuda-9.2.88-Cuda_OpenMP-release build_time=1085 run_time=524
gcc-6.4.0-OpenMP_Serial-release build_time=404 run_time=978
gcc-7.2.0-OpenMP-release build_time=291 run_time=263
gcc-7.2.0-OpenMP_Serial-release build_time=351 run_time=903
gcc-7.2.0-Serial-release build_time=199 run_time=651
#######################################################
FAILED TESTS
#######################################################

--------------------------------------------------------------------------------
- Elapsed time: 6241 seconds.
--------------------------------------------------------------------------------
```



