### PR TITLE
Fix putting ifdef guard for perf test

### DIFF
--- a/perf_test/batched/KokkosBatched_Test_BlockTridiagDirect.cpp
+++ b/perf_test/batched/KokkosBatched_Test_BlockTridiagDirect.cpp
@@ -5,6 +5,12 @@
 
 #if  defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 #if !defined(KOKKOS_ENABLE_CUDA) || (8000 <= CUDA_VERSION)
+#define KOKKOSBATCHED_TEST_BLOCKTRIDIAGDIRECT 
+#endif 
+#endif
+
+
+#if defined(KOKKOSBATCHED_TEST_BLOCKTRIDIAGDIRECT)
 
 /// KokkosKernels headers
 #include "KokkosBatched_Util.hpp"
@@ -618,5 +624,9 @@ int main(int argc, char* argv[]) {
   return 0;
 }
 
-#endif  // defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
-#endif  // !defined(KOKKOS_ENABLE_CUDA) || (8000 <= CUDA_VERSION)
+#else
+int main() {
+  return 0;
+}
+#endif
+

--- a/perf_test/batched/KokkosBatched_Test_BlockTridiagDirect.cpp
+++ b/perf_test/batched/KokkosBatched_Test_BlockTridiagDirect.cpp
@@ -3,6 +3,9 @@
 #include "impl/Kokkos_Timer.hpp"
 #include "Kokkos_Random.hpp"
 
+#if  defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
+#if !defined(KOKKOS_ENABLE_CUDA) || (8000 <= CUDA_VERSION)
+
 /// KokkosKernels headers
 #include "KokkosBatched_Util.hpp"
 #include "KokkosBatched_Vector.hpp"
@@ -615,4 +618,5 @@ int main(int argc, char* argv[]) {
   return 0;
 }
 
-
+#endif  // defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
+#endif  // !defined(KOKKOS_ENABLE_CUDA) || (8000 <= CUDA_VERSION)

--- a/perf_test/batched/KokkosBatched_Test_BlockTridiagJacobi.cpp
+++ b/perf_test/batched/KokkosBatched_Test_BlockTridiagJacobi.cpp
@@ -3,6 +3,9 @@
 #include "impl/Kokkos_Timer.hpp"
 #include "Kokkos_Random.hpp"
 
+#if  defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
+#if !defined(KOKKOS_ENABLE_CUDA) || (8000 <= CUDA_VERSION)
+
 /// KokkosKernels headers
 #include "KokkosBatched_Util.hpp"
 #include "KokkosBatched_Vector.hpp"
@@ -549,3 +552,5 @@ int main(int argc, char* argv[]) {
 }
 
 
+#endif  // defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
+#endif  // !defined(KOKKOS_ENABLE_CUDA) || (8000 <= CUDA_VERSION)

--- a/perf_test/batched/KokkosBatched_Test_BlockTridiagJacobi.cpp
+++ b/perf_test/batched/KokkosBatched_Test_BlockTridiagJacobi.cpp
@@ -5,6 +5,11 @@
 
 #if  defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
 #if !defined(KOKKOS_ENABLE_CUDA) || (8000 <= CUDA_VERSION)
+#define KOKKOSBATCHED_TEST_BLOCKTRIDIAGJACOBI
+#endif
+#endif
+
+#if defined( KOKKOSBATCHED_TEST_BLOCKTRIDIAGJACOBI )
 
 /// KokkosKernels headers
 #include "KokkosBatched_Util.hpp"
@@ -550,7 +555,8 @@ int main(int argc, char* argv[]) {
 
   return 0;
 }
-
-
-#endif  // defined(KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA)
-#endif  // !defined(KOKKOS_ENABLE_CUDA) || (8000 <= CUDA_VERSION)
+#else
+int main() {
+  return 0;
+}
+#endif


### PR DESCRIPTION
A simple fix for #407 . I tested without lambda and it compiles. 

