### PR TITLE
D2GC: Fix headers for Distance-1 use cases

### DIFF
--- a/perf_test/graph/KokkosGraph_color.cpp
+++ b/perf_test/graph/KokkosGraph_color.cpp
@@ -52,8 +52,7 @@
 #include "KokkosKernels_IOUtils.hpp"
 #include "KokkosKernels_MyCRSMatrix.hpp"
 #include "KokkosKernels_TestParameters.hpp"
-// #include "KokkosGraph_Distance1Color.hpp"
-#include "KokkosGraph_graph_color.hpp"
+#include "KokkosGraph_Distance1Color.hpp"
 
 
 

--- a/src/graph/impl/KokkosGraph_Distance1Color_impl.hpp
+++ b/src/graph/impl/KokkosGraph_Distance1Color_impl.hpp
@@ -46,7 +46,7 @@
 #include <impl/Kokkos_Timer.hpp>
 #include <Kokkos_MemoryTraits.hpp>
 #include <vector>
-#include "KokkosGraph_GraphColorHandle.hpp"
+#include "KokkosGraph_Distance1ColorHandle.hpp"
 
 #include <bitset>
 


### PR DESCRIPTION
Replaced a couple of places where we should be using `KokkosGraph_Distance1ColorHandle.hpp` instead of the older headers.  I probably should have done this in #375 but I just missed them.

Running spot-check now, I'll update results in comments.

FYI @ndellingwood 