### PR TITLE
Update fences in agreement with Kokkos deprecations

### DIFF
--- a/Makefile.kokkos-kernels
+++ b/Makefile.kokkos-kernels
@@ -464,16 +464,16 @@ endif
 ifeq ($(KOKKOS_OS),Linux)
   COPY_FLAG = -u
 endif
-ifeq ($(KOKKOS_OS),Darwin)
+#ifeq ($(KOKKOS_OS),Darwin)
   # If using Homebrew on OSX with the 'coreutils' package installed
   # we have a gnu version of cp which has the -u option
-  ifeq (,$(wildcard "/usr/local/opt/coreutils/libexec/gnubin/cp"))
-    CP = /usr/local/opt/coreutils/libexec/gnubin/cp
-    COPY_FLAG = -u
-  else
-    COPY_FLAG =
-  endif
-endif
+#  ifeq (,$(wildcard "/usr/local/opt/coreutils/libexec/gnubin/cp"))
+#    CP = /usr/local/opt/coreutils/libexec/gnubin/cp
+#    COPY_FLAG = -u
+#  else
+#    COPY_FLAG =
+#  endif
+#endif
 
 KOKKOSKERNELS_INTERNAL_SRC_BLAS_NODIR = $(notdir $(KOKKOSKERNELS_INTERNAL_SRC_BLAS))
 KOKKOSKERNELS_INTERNAL_SRC_SPARSE_NODIR = $(notdir $(KOKKOSKERNELS_INTERNAL_SRC_SPARSE))

--- a/example/fenl/CGSolve.hpp
+++ b/example/fenl/CGSolve.hpp
@@ -122,7 +122,7 @@ struct CGSolve< ImportType , SparseMatrixType , VectorType ,
       timer.reset();
       /* import p    */  import( pAll );
       /* Ap = A * p  */  KokkosSparse::spmv( "N", 1.0, A , pAll, 0.0, Ap);
-      execution_space::fence();
+      execution_space().fence();
       matvec_time += timer.seconds();
 
       const double pAp_dot = Kokkos::Example::all_reduce( KokkosBlas::dot( p , Ap ) , import.comm );
@@ -141,7 +141,7 @@ struct CGSolve< ImportType , SparseMatrixType , VectorType ,
       ++iteration ;
     }
 
-    execution_space::fence();
+    execution_space().fence();
     iter_time = wall_clock.seconds();
   }
 };

--- a/example/fenl/VectorImport.hpp
+++ b/example/fenl/VectorImport.hpp
@@ -153,7 +153,7 @@ public:
       , buffer( arg_buffer )
     {
       Kokkos::parallel_for( "kokkos-kernels/example/fenl: Pack", index.extent(0) , *this );
-      execution_space::fence();
+      execution_space().fence();
     }
   };
 

--- a/example/fenl/fenl_functors.hpp
+++ b/example/fenl/fenl_functors.hpp
@@ -151,7 +151,7 @@ public:
         Kokkos::parallel_for( "kokkos-kernels/example/fenl: NodeNodeGraph" , elem_node_id.extent(0) , *this );
       }
 
-      execution_space::fence();
+      execution_space().fence();
       results.ratio = (double)node_node_set.size() / (double)node_node_set.span();
       results.fill_node_set = wall_clock.seconds();
       //--------------------------------
@@ -178,14 +178,14 @@ public:
       //--------------------------------
       // Fill graph's entries from the (node,node) set.
 
-      execution_space::fence();
+      execution_space().fence();
       results.scan_node_count = wall_clock.seconds();
 
       wall_clock.reset();
       phase = FILL_GRAPH_ENTRIES ;
       Kokkos::parallel_for( node_node_set.span() , *this );
 
-      execution_space::fence();
+      execution_space().fence();
       results.fill_graph_entries = wall_clock.seconds();
 
       //--------------------------------
@@ -202,7 +202,7 @@ public:
 
       Kokkos::parallel_for( node_count , *this );
 
-      execution_space::fence();
+      execution_space().fence();
       results.sort_graph_entries = wall_clock.seconds();
 
       //--------------------------------
@@ -212,7 +212,7 @@ public:
       elem_graph = ElemGraphType("elem_graph", elem_node_id.extent(0) );
       Kokkos::parallel_for( elem_node_id.extent(0) , *this );
 
-      execution_space::fence();
+      execution_space().fence();
       results.fill_element_graph = wall_clock.seconds();
     }
 
@@ -502,7 +502,7 @@ public:
       Kokkos::deep_copy( row_count , 0u );
       Kokkos::parallel_for( elem_node_id.extent(0) , *this );
 
-      execution_space::fence();
+      execution_space().fence();
 
       //--------------------------------
       // Done with the temporary sets and arrays
@@ -516,7 +516,7 @@ public:
       phase = SORT_GRAPH_ENTRIES ;
       Kokkos::parallel_for( residual.extent(0) , *this );
 
-      execution_space::fence();
+      execution_space().fence();
 
       phase = GATHER_FILL ;
     }

--- a/example/fenl/fenl_impl.hpp
+++ b/example/fenl/fenl_impl.hpp
@@ -347,7 +347,7 @@ Perf fenl(
 
     SparseMatrixType jacobian( "jacobian" , mesh_to_graph.graph );
 
-    Device::fence();
+    Device().fence();
 
     perf.create_sparse_matrix = maximum( comm , wall_clock.seconds() );
 
@@ -444,7 +444,7 @@ Perf fenl(
         gatherfill.apply();
       }
 
-      Device::fence();
+      Device().fence();
       perf.fill_time = maximum( comm , wall_clock.seconds() );
 
       //--------------------------------
@@ -454,7 +454,7 @@ Perf fenl(
 
       dirichlet.apply();
 
-      Device::fence();
+      Device().fence();
       perf.bc_time = maximum( comm , wall_clock.seconds() );
 
       //--------------------------------

--- a/perf_test/batched/KokkosBatched_Test_Gemm_Host.hpp
+++ b/perf_test/batched/KokkosBatched_Test_Gemm_Host.hpp
@@ -124,7 +124,7 @@ namespace KokkosBatched {
             Kokkos::deep_copy(b, bmat);
             Kokkos::deep_copy(c, 0);
 
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             timer.reset();
 
             Kokkos::parallel_for("KokkosBatched::PerfTest::GemmHost::CblasOpenMP",
@@ -155,7 +155,7 @@ namespace KokkosBatched {
                   
                                  });
             
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             const double t = timer.seconds();
             tmin = std::min(tmin, t);
             tavg += (iter >= 0)*t;
@@ -215,7 +215,7 @@ namespace KokkosBatched {
             Kokkos::deep_copy(b, bmat);
             Kokkos::deep_copy(c, 0);
 
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             timer.reset();
             
             if (std::is_same<value_type,double>::value) {
@@ -242,7 +242,7 @@ namespace KokkosBatched {
                                 1, size_per_grp);                
             }
 
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             const double t = timer.seconds();
             tmin = std::min(tmin, t);
             tavg += (iter >= 0)*t;
@@ -297,7 +297,7 @@ namespace KokkosBatched {
               Kokkos::deep_copy(b, bmat_simd);
               Kokkos::deep_copy(c, 0);
                 
-              HostSpaceType::fence();
+              HostSpaceType().fence();
               timer.reset();
                 
               if (std::is_same<value_type,double>::value) {
@@ -322,7 +322,7 @@ namespace KokkosBatched {
                                   format, N*VectorLength);
               }
                 
-              HostSpaceType::fence();
+              HostSpaceType().fence();
               const double t = timer.seconds();
               tmin = std::min(tmin, t);
               tavg += (iter >= 0)*t;
@@ -381,7 +381,7 @@ namespace KokkosBatched {
             Kokkos::deep_copy(b, bmat);
             Kokkos::deep_copy(c, 0);
 
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             timer.reset();
 
             Kokkos::parallel_for("KokkosBatched::PerfTest::GemmHost::libxswmmOpenMP",
@@ -402,7 +402,7 @@ namespace KokkosBatched {
                                                 (double*)cc.data(), (const libxsmm_blasint*)&ldc);
                                  });
             
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             const double t = timer.seconds();
             tmin = std::min(tmin, t);
             tavg += (iter >= 0)*t;
@@ -451,7 +451,7 @@ namespace KokkosBatched {
       //       Kokkos::deep_copy(b, bmat);
       //       Kokkos::deep_copy(c, 0);
 
-      //       HostSpaceType::fence();
+      //       HostSpaceType().fence();
       //       timer.reset();
 
       //       Kokkos::parallel_for
@@ -465,7 +465,7 @@ namespace KokkosBatched {
       //             invoke(1.0, aa, bb, 1.0, cc);
       //         });
             
-      //       HostSpaceType::fence();
+      //       HostSpaceType().fence();
       //       const double t = timer.seconds();
       //       tmin = std::min(tmin, t);
       //       tavg += (iter >= 0)*t;
@@ -511,7 +511,7 @@ namespace KokkosBatched {
             Kokkos::deep_copy(b, bmat_simd);
             Kokkos::deep_copy(c, 0);
 
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             timer.reset();
 
             Kokkos::parallel_for("KokkosBatched::PerfTest::GemmHost::SIMDSerialOpenMP",
@@ -525,7 +525,7 @@ namespace KokkosBatched {
                                      invoke(1.0, aa, bb, 1.0, cc);
                                  });
             
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             const double t = timer.seconds();
             tmin = std::min(tmin, t);
             tavg += (iter >= 0)*t;

--- a/perf_test/batched/KokkosBatched_Test_Gemv_Host.hpp
+++ b/perf_test/batched/KokkosBatched_Test_Gemv_Host.hpp
@@ -110,7 +110,7 @@ namespace KokkosBatched {
             Kokkos::deep_copy(x, xvec);
             Kokkos::deep_copy(y, 0);
             
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             timer.reset();
             
             Kokkos::parallel_for("KokkosBatched::PerfTest::GemvHost::CblasOpenMP",
@@ -131,7 +131,7 @@ namespace KokkosBatched {
                                    }
                                  });
             
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             t += (iter >= 0)*timer.seconds();
           }
           t /= iter_end;
@@ -170,7 +170,7 @@ namespace KokkosBatched {
             Kokkos::deep_copy(x, xvec);
             Kokkos::deep_copy(y, 0);
 
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             timer.reset();
 
             Kokkos::parallel_for("KokkosBatched::PerfTest::GemvHost::SerialOpenMP",
@@ -187,7 +187,7 @@ namespace KokkosBatched {
                                    }
                                  });
             
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             t += (iter >= 0)*timer.seconds();
           }
           t /= iter_end;
@@ -245,7 +245,7 @@ namespace KokkosBatched {
             Kokkos::deep_copy(x, xvec_simd);
             Kokkos::deep_copy(y, 0);
 
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             timer.reset();
 
             Kokkos::parallel_for("KokkosBatched::PerfTest::GemvHost::SIMDSerialOpenMP",
@@ -262,7 +262,7 @@ namespace KokkosBatched {
                                    }
                                  });
             
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             t += (iter >= 0)*timer.seconds();
           }
           t /= iter_end;

--- a/perf_test/batched/KokkosBatched_Test_LU_Host.hpp
+++ b/perf_test/batched/KokkosBatched_Test_LU_Host.hpp
@@ -131,7 +131,7 @@ namespace KokkosBatched {
             // initialize matrix
             Kokkos::deep_copy(a, amat);
 
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             timer.reset();
 
             Kokkos::RangePolicy<HostSpaceType,ScheduleType> policy(0, N*VectorLength);
@@ -146,7 +146,7 @@ namespace KokkosBatched {
                                                   (int*)pp.data());
                                  });
 
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             const double t = timer.seconds();
             tmin = std::min(tmin, t);
             tavg += (iter >= 0)*t;
@@ -187,7 +187,7 @@ namespace KokkosBatched {
               // initialize matrix
               Kokkos::deep_copy(a, amat_simd);
                 
-              HostSpaceType::fence();
+              HostSpaceType().fence();
               timer.reset();
                 
               mkl_dgetrfnp_compact(MKL_ROW_MAJOR,
@@ -195,7 +195,7 @@ namespace KokkosBatched {
                                    (double*)a.data(), a.stride_1(),
                                    (MKL_INT*)&info, format, (MKL_INT)N*VectorLength);
                 
-              HostSpaceType::fence();
+              HostSpaceType().fence();
               const double t = timer.seconds();
               tmin = std::min(tmin, t);
               tavg += (iter >= 0)*t;
@@ -238,7 +238,7 @@ namespace KokkosBatched {
       //       // initialize matrix
       //       Kokkos::deep_copy(a, amat);
 
-      //       HostSpaceType::fence();
+      //       HostSpaceType().fence();
       //       timer.reset();
 
       //       Kokkos::RangePolicy<HostSpaceType,ScheduleType> policy(0, N*VectorLength);
@@ -250,7 +250,7 @@ namespace KokkosBatched {
       //           SerialLU<AlgoTagType>::invoke(aa);
       //         });
 
-      //       HostSpaceType::fence();
+      //       HostSpaceType().fence();
       //       const double t = timer.seconds();
       //       tmin = std::min(tmin, t);
       //       tavg += (iter >= 0)*t;
@@ -290,7 +290,7 @@ namespace KokkosBatched {
             // initialize matrix
             Kokkos::deep_copy(a, amat_simd);
 
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             timer.reset();
 
             Kokkos::RangePolicy<HostSpaceType,ScheduleType > policy(0, N);
@@ -302,7 +302,7 @@ namespace KokkosBatched {
                                    SerialLU<AlgoTagType>::invoke(aa);
                                  });
 
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             const double t = timer.seconds();
             tmin = std::min(tmin, t);
             tavg += (iter >= 0)*t;

--- a/perf_test/batched/KokkosBatched_Test_Trsm_Host.hpp
+++ b/perf_test/batched/KokkosBatched_Test_Trsm_Host.hpp
@@ -148,7 +148,7 @@ namespace KokkosBatched {
             Kokkos::deep_copy(a, amat);
             Kokkos::deep_copy(b, bmat);
 
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             timer.reset();
 
             Kokkos::RangePolicy<HostSpaceType,ScheduleType> policy(0, N*VectorLength);
@@ -201,7 +201,7 @@ namespace KokkosBatched {
                                    }
                                  });
 
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             const double t = timer.seconds();
             tmin = std::min(tmin, t);
             tavg += (iter >= 0)*t;
@@ -261,7 +261,7 @@ namespace KokkosBatched {
             Kokkos::deep_copy(a, amat);
             Kokkos::deep_copy(b, bmat);
 
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             timer.reset();
 
             switch (test) {
@@ -342,7 +342,7 @@ namespace KokkosBatched {
             }
             }
             
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             const double t = timer.seconds();
             tmin = std::min(tmin, t);
             tavg += (iter >= 0)*t;
@@ -391,7 +391,7 @@ namespace KokkosBatched {
               Kokkos::deep_copy(a, amat_simd);
               Kokkos::deep_copy(b, bmat_simd);
                 
-              HostSpaceType::fence();
+              HostSpaceType().fence();
               timer.reset();
                 
               switch (test) {
@@ -472,7 +472,7 @@ namespace KokkosBatched {
               }
               }
                 
-              HostSpaceType::fence();
+              HostSpaceType().fence();
               const double t = timer.seconds();
               tmin = std::min(tmin, t);
               tavg += (iter >= 0)*t;
@@ -518,7 +518,7 @@ namespace KokkosBatched {
       //       Kokkos::deep_copy(a, amat);
       //       Kokkos::deep_copy(b, bmat);
 
-      //       HostSpaceType::fence();
+      //       HostSpaceType().fence();
       //       timer.reset();
 
       //       Kokkos::RangePolicy<HostSpaceType,ScheduleType> policy(0, N*VectorLength);
@@ -552,7 +552,7 @@ namespace KokkosBatched {
       //           }
       //         });
 
-      //       HostSpaceType::fence();
+      //       HostSpaceType().fence();
       //       const double t = timer.seconds();
       //       tmin = std::min(tmin, t);
       //       tavg += (iter >= 0)*t;
@@ -594,7 +594,7 @@ namespace KokkosBatched {
             Kokkos::deep_copy(a, amat_simd);
             Kokkos::deep_copy(b, bmat_simd);
 
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             timer.reset();
 
             Kokkos::RangePolicy<HostSpaceType,ScheduleType> policy(0, N);
@@ -628,7 +628,7 @@ namespace KokkosBatched {
                                    }
                                  });
 
-            HostSpaceType::fence();
+            HostSpaceType().fence();
             const double t = timer.seconds();
             tmin = std::min(tmin, t);
             tavg += (iter >= 0)*t;

--- a/perf_test/graph/KokkosGraph_run_triangle.hpp
+++ b/perf_test/graph/KokkosGraph_run_triangle.hpp
@@ -152,7 +152,7 @@ struct Flush {
   void run() {
     double sum = 0;
     Kokkos::parallel_reduce("KokkosGraph::PerfTest::Flush", Kokkos::RangePolicy<SpaceType>(0,BufSize/sizeof(double)), *this, sum);
-    SpaceType::fence();
+    SpaceType().fence();
     std::cout << "Flush sum:" << sum << std::endl;
     FILE *fp = fopen("/dev/null", "w");
     fprintf(fp, "%f\n", sum);
@@ -341,7 +341,7 @@ void run_experiment(
 
       size_t num_triangles = 0;
       KokkosKernels::Impl::kk_reduce_view< Kokkos::View <size_t *,ExecSpace>, ExecSpace>(rowmap_size, row_mapC, num_triangles);
-      ExecSpace::fence();
+      ExecSpace().fence();
 
       symbolic_time = timer1.seconds();
       std::cout << "num_triangles:" << num_triangles << std::endl;

--- a/perf_test/sparse/KokkosSparse_pcg.hpp
+++ b/perf_test/sparse/KokkosSparse_pcg.hpp
@@ -151,7 +151,7 @@ void block_pcgsolve(
     gauss_seidel_numeric
       (&kh, count_total, count_total, point_crsMat.graph.row_map, point_crsMat.graph.entries, point_crsMat.values);
 
-    Space::fence();
+    Space().fence();
     timer.reset();
 */
 
@@ -162,7 +162,7 @@ void block_pcgsolve(
     precond_init_time += timer.seconds();
 
     z = y_vector_t( "pcg::z" , count_total );
-    Space::fence();
+    Space().fence();
     timer.reset();
     symmetric_block_gauss_seidel_apply
             (&block_kh, _block_crsMat.numRows(), _block_crsMat.numCols(),block_size,  _block_crsMat.graph.row_map, _block_crsMat.graph.entries, _block_crsMat.values,
@@ -171,7 +171,7 @@ void block_pcgsolve(
     symmetric_gauss_seidel_apply
         (&kh, count_total, count_total, point_crsMat.graph.row_map, point_crsMat.graph.entries, point_crsMat.values, z, r, true, true, apply_count);
 */
-    Space::fence();
+    Space().fence();
     precond_time += timer.seconds();
     precond_old_rdot = KokkosBlas::dot( r , z );
     Kokkos::deep_copy( p , z );
@@ -191,7 +191,7 @@ void block_pcgsolve(
     /* Ap = A * p   */  KokkosSparse::spmv("N", 1, point_crsMat, pAll, 0, Ap);
 
 
-    Space::fence();
+    Space().fence();
     matvec_time += timer.seconds();
 
     //const double pAp_dot = Kokkos::Example::all_reduce( dot( count_owned , p , Ap ) , import.comm );
@@ -218,7 +218,7 @@ void block_pcgsolve(
     double precond_r_dot = 1;
     double precond_beta = 1;
     if (use_sgs){
-      Space::fence();
+      Space().fence();
       timer.reset();
       symmetric_block_gauss_seidel_apply
                   (&block_kh, _block_crsMat.numRows(), _block_crsMat.numCols(),block_size, _block_crsMat.graph.row_map, _block_crsMat.graph.entries, _block_crsMat.values,
@@ -234,7 +234,7 @@ void block_pcgsolve(
           apply_count);
           */
 
-      Space::fence();
+      Space().fence();
       precond_time += timer.seconds();
       precond_r_dot = KokkosBlas::dot(r , z );
       precond_beta  = precond_r_dot / precond_old_rdot ;
@@ -267,7 +267,7 @@ void block_pcgsolve(
     ++iteration ;
   }
 
-  Space::fence();
+  Space().fence();
   iter_time = wall_clock.seconds();
 
   if ( 0 != result ) {
@@ -358,17 +358,17 @@ void pcgsolve(
     gauss_seidel_numeric
       (&kh, count_total, count_total, crsMat.graph.row_map, crsMat.graph.entries, crsMat.values);
 
-    Space::fence();
+    Space().fence();
 
     precond_init_time += timer.seconds();
     z = y_vector_t( "pcg::z" , count_total );
-    Space::fence();
+    Space().fence();
     timer.reset();
 
     symmetric_gauss_seidel_apply
         (&kh, count_total, count_total, crsMat.graph.row_map, crsMat.graph.entries, crsMat.values, z, r, true, true, apply_count);
 
-    Space::fence();
+    Space().fence();
     precond_time += timer.seconds();
     precond_old_rdot = KokkosBlas::dot( r , z );
     Kokkos::deep_copy( p , z );
@@ -388,7 +388,7 @@ void pcgsolve(
     /* Ap = A * p   */  KokkosSparse::spmv("N", 1, crsMat, pAll, 0, Ap);
 
 
-    Space::fence();
+    Space().fence();
     matvec_time += timer.seconds();
 
     //const double pAp_dot = Kokkos::Example::all_reduce( dot( count_owned , p , Ap ) , import.comm );
@@ -415,7 +415,7 @@ void pcgsolve(
     double precond_r_dot = 1;
     double precond_beta = 1;
     if (use_sgs){
-      Space::fence();
+      Space().fence();
       timer.reset();
       symmetric_gauss_seidel_apply(
           &kh,
@@ -425,7 +425,7 @@ void pcgsolve(
           crsMat.values, z, r, true,
           apply_count);
 
-      Space::fence();
+      Space().fence();
       precond_time += timer.seconds();
       precond_r_dot = KokkosBlas::dot(r , z );
       precond_beta  = precond_r_dot / precond_old_rdot ;
@@ -458,7 +458,7 @@ void pcgsolve(
     ++iteration ;
   }
 
-  Space::fence();
+  Space().fence();
   iter_time = wall_clock.seconds();
 
   if ( 0 != result ) {

--- a/perf_test/sparse/KokkosSparse_run_spgemm.hpp
+++ b/perf_test/sparse/KokkosSparse_run_spgemm.hpp
@@ -256,7 +256,7 @@ crsMat_t3 run_experiment(
         row_mapC_ref
     );
 
-    ExecSpace::fence();
+    ExecSpace().fence();
 
 
     size_type c_nnz_size = sequential_kh.get_spgemm_handle()->get_c_nnz();
@@ -283,7 +283,7 @@ crsMat_t3 run_experiment(
         entriesC_ref,
         valuesC_ref
     );
-    ExecSpace::fence();
+    ExecSpace().fence();
 
     typename crsMat_t3::HostMirror::StaticCrsGraphType static_graph (entriesC_ref, row_mapC_ref);
     typename crsMat_t3::HostMirror Ccrsmat("CrsMatrixC", k, valuesC_ref, static_graph);
@@ -337,7 +337,7 @@ crsMat_t3 run_experiment(
 			  row_mapC
 	  );
 
-	  ExecSpace::fence();
+	  ExecSpace().fence();
 	  double symbolic_time = timer1.seconds();
 
 	  Kokkos::Impl::Timer timer3;
@@ -366,7 +366,7 @@ crsMat_t3 run_experiment(
 			  entriesC,
 			  valuesC
 	  );
-	  ExecSpace::fence();
+	  ExecSpace().fence();
 	  double numeric_time = timer3.seconds();
 
 	  std::cout

--- a/src/batched/KokkosBatched_Util.hpp
+++ b/src/batched/KokkosBatched_Util.hpp
@@ -140,7 +140,7 @@ namespace KokkosBatched {
     void run() {
       double sum = 0;
       Kokkos::parallel_reduce(Kokkos::RangePolicy<SpaceType>(0,BufSize/sizeof(double)), *this, sum);
-      SpaceType::fence();
+      SpaceType().fence();
       FILE *fp = fopen("/dev/null", "w");
       fprintf(fp, "%f\n", sum);
       fclose(fp);

--- a/src/common/KokkosKernels_PrintUtils.hpp
+++ b/src/common/KokkosKernels_PrintUtils.hpp
@@ -86,7 +86,7 @@ inline void kk_get_histogram(
     out_lno_view_t histogram /*must be initialized with 0s*/){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
   Kokkos::parallel_for( "KokkosKernels::Common::GetHistogram", my_exec_space(0, in_elements), Histogram<in_lno_view_t, out_lno_view_t>(in_view, histogram));
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 }
 
 /**

--- a/src/common/KokkosKernels_SimpleUtils.hpp
+++ b/src/common/KokkosKernels_SimpleUtils.hpp
@@ -250,7 +250,7 @@ bool kk_is_identical_view(view_type1 view1, view_type2 view2, eps_type eps){
   size_t issame = 0;
   Kokkos::parallel_reduce( "KokkosKernels::Common::IsIdenticalView", my_exec_space(0,num_elements),
       IsIdenticalFunctor<view_type1, view_type2, eps_type>(view1, view2, eps), issame);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
   if (issame > 0){
     return false;
   }

--- a/src/common/KokkosKernels_SparseUtils.hpp
+++ b/src/common/KokkosKernels_SparseUtils.hpp
@@ -496,13 +496,13 @@ inline void kk_transpose_graph(
   else {
     Kokkos::parallel_for(  "KokkosKernels::Common::TransposeGraph::StaticSchedule::S0", count_tp_t(num_rows  / team_work_chunk_size + 1 , suggested_team_size, vector_size), tm);
   }
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
   kk_exclusive_parallel_prefix_sum<out_row_view_t, MyExecSpace>(num_cols+1, t_xadj);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
   Kokkos::deep_copy(tmp_row_view, t_xadj);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
 
   if (use_dynamic_scheduling){
@@ -511,7 +511,7 @@ inline void kk_transpose_graph(
   else {
     Kokkos::parallel_for(  "KokkosKernels::Common::TransposeGraph::StaticSchedule::S1", d_fill_tp_t(num_rows  / team_work_chunk_size + 1 , suggested_team_size, vector_size), tm);
   }
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 }
 
 template <typename forward_map_type, typename reverse_map_type>
@@ -684,21 +684,21 @@ void kk_create_reverse_map(
             multiply_shift_for_scale, division_shift_for_bucket);
 
     Kokkos::parallel_for ("KokkosKernels::Common::CreateReverseMap::NonAtomic::S0", my_cnt_exec_space (0, num_forward_elements) , frm);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
 
 
     //kk_inclusive_parallel_prefix_sum<reverse_array_type, MyExecSpace>(tmp_reverse_size + 1, tmp_color_xadj);
     kk_exclusive_parallel_prefix_sum<reverse_array_type, MyExecSpace>
       (tmp_reverse_size + 1, tmp_color_xadj);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
 
     Kokkos::parallel_for ("KokkosKernels::Common::CreateReverseMap::NonAtomic::S1",
         my_exec_space (0, num_reverse_elements + 1) ,
         StridedCopy1<reverse_array_type, reverse_array_type>
           (tmp_color_xadj, reverse_map_xadj, scale_size));
-    MyExecSpace::fence();
+    MyExecSpace().fence();
     Kokkos::parallel_for ("KokkosKernels::Common::CreateReverseMap::NonAtomic::S2",my_fill_exec_space (0, num_forward_elements) , frm);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
   }
   else
   //atomic implementation.
@@ -714,18 +714,18 @@ void kk_create_reverse_map(
     rmp_functor_type frm (forward_map, tmp_color_xadj, reverse_map_adj);
 
     Kokkos::parallel_for ("KokkosKernels::Common::CreateReverseMap::Atomic::S0", my_cnt_exec_space (0, num_forward_elements) , frm);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
 
     //kk_inclusive_parallel_prefix_sum<reverse_array_type, MyExecSpace>(num_reverse_elements + 1, reverse_map_xadj);
     kk_exclusive_parallel_prefix_sum<reverse_array_type, MyExecSpace>
       (num_reverse_elements + 1, tmp_color_xadj);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
 
     Kokkos::deep_copy (reverse_map_xadj, tmp_color_xadj);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
 
     Kokkos::parallel_for ("KokkosKernels::Common::CreateReverseMap::Atomic::S1", my_fill_exec_space (0, num_forward_elements) , frm);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
   }
 }
 
@@ -826,7 +826,7 @@ inline size_t kk_is_d1_coloring_valid(
   Kokkos::parallel_reduce( "KokkosKernels::Common::IsD1ColoringValie", dynamic_team_policy(num_rows / team_work_chunk_size + 1 ,
       suggested_team_size, vector_size), cc, num_conf);
 
-  MyExecSpace::fence();
+  MyExecSpace().fence();
   return num_conf;
 }
 
@@ -854,7 +854,7 @@ void kk_sort_graph(
     Kokkos::deep_copy (he, in_adj);
     typename scalar_view_t::HostMirror hv = Kokkos::create_mirror_view (in_vals);
     Kokkos::deep_copy (hv, in_vals);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
 
     typename lno_nnz_view_t::HostMirror heo = Kokkos::create_mirror_view (out_adj);
     typename scalar_view_t::HostMirror hvo = Kokkos::create_mirror_view (out_vals);
@@ -885,7 +885,7 @@ void kk_sort_graph(
 
     Kokkos::deep_copy (out_adj, heo);
     Kokkos::deep_copy (out_vals, hvo);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
   }
   else {
 
@@ -1058,7 +1058,7 @@ inline void kk_create_incidence_matrix(
   else {
     Kokkos::parallel_for(  d_fill_tp_t(num_rows  / team_work_chunk_size + 1 , suggested_team_size, vector_size), tm);
   }
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
 }
 */
@@ -1293,7 +1293,7 @@ void kk_get_lower_triangle_count_parallel(
   else {
     Kokkos::parallel_for( "KokkosKernels::Common::GetLowerTriangleCount::StaticSchedule", count_tp_t(nv  / team_work_chunk_size + 1 , suggested_team_size, vector_size), ltm);
   }
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 }
 
 
@@ -1480,7 +1480,7 @@ void kk_get_lower_triangle_fill_parallel(
   else {
     Kokkos::parallel_for( "KokkosKernels::Common::GetLowerTriangleFill::StaticSchedule", fill_p_t(nv  / team_work_chunk_size + 1 , suggested_team_size, vector_size), ltm);
   }
-  ExecutionSpace::fence();
+  ExecutionSpace().fence();
 }
 template <typename size_type, typename lno_t, typename scalar_t>
 void kk_get_lower_triangle_fill_sequential(
@@ -1618,7 +1618,7 @@ crstmat_t kk_get_lower_triangle(crstmat_t in_crs_matrix,
 
   kk_exclusive_parallel_prefix_sum
   <row_map_view_t, exec_space>(nr + 1, new_row_map);
-  exec_space::fence();
+  exec_space().fence();
 
   auto ll_size = Kokkos::subview(new_row_map, nr);
   auto h_ll_size = Kokkos::create_mirror_view (ll_size);
@@ -1675,7 +1675,7 @@ crstmat_t kk_get_lower_crs_matrix(crstmat_t in_crs_matrix,
 
   kk_exclusive_parallel_prefix_sum
   <row_map_view_t, exec_space>(nr + 1, new_row_map);
-  exec_space::fence();
+  exec_space().fence();
 
   auto ll_size = Kokkos::subview(new_row_map, nr);
   auto h_ll_size = Kokkos::create_mirror_view (ll_size);
@@ -1729,7 +1729,7 @@ graph_t kk_get_lower_crs_graph(graph_t in_crs_matrix,
 
   kk_exclusive_parallel_prefix_sum
   <row_map_view_t, exec_space>(nr + 1, new_row_map);
-  exec_space::fence();
+  exec_space().fence();
 
   auto ll_size = Kokkos::subview(new_row_map, nr);
   auto h_ll_size = Kokkos::create_mirror_view (ll_size);
@@ -1797,7 +1797,7 @@ void kk_get_lower_triangle(
 
   kk_exclusive_parallel_prefix_sum
   <out_row_map_view_t, exec_space>(nr + 1, out_rowmap);
-  exec_space::fence();
+  exec_space().fence();
 
   auto ll_size = Kokkos::subview(out_rowmap, nr);
   auto h_ll_size = Kokkos::create_mirror_view (ll_size);
@@ -1914,10 +1914,10 @@ void kk_create_incidence_matrix_from_lower_triangle(
     Kokkos::atomic_fetch_add(&(out_rowmap[in_lower_entries[i]]), atomic_incr_type(1));
   });
 
-  exec_space::fence();
+  exec_space().fence();
   kk_exclusive_parallel_prefix_sum<out_row_map_view_t, exec_space>(nr+1, out_rowmap);
 
-  exec_space::fence();
+  exec_space().fence();
   Kokkos::parallel_for("KokkosKernels::Common::CreateIncidenceTransposeMatrixFromLowerTriangle::S0", my_exec_space(0, nr + 1),
       KOKKOS_LAMBDA(const lno_t& i) {
     out_rowmap[i] += in_lower_rowmap[i];
@@ -1944,7 +1944,7 @@ void kk_create_incidence_matrix_from_lower_triangle(
       out_entries[out_begin + i] = edge_ind;
     }
   });
-  exec_space::fence();
+  exec_space().fence();
   Kokkos::parallel_for("KokkosKernels::Common::CreateIncidenceTransposeMatrixFromLowerTriangle::S2", my_exec_space(0, ne),
       KOKKOS_LAMBDA(const size_type& edge_ind) {
     lno_t col = in_lower_entries[edge_ind];
@@ -2010,7 +2010,7 @@ void kk_create_incidence_matrix_from_original_matrix(
       permutation.data(),
       use_dynamic_scheduling,
       chunksize, sort_decreasing_order);
-  exec_space::fence();
+  exec_space().fence();
   kk_exclusive_parallel_prefix_sum<out_row_map_view_t, exec_space>(nr+1, out_rowmap);
 
   //kk_print_1Dview(out_rowmap, false, 20);

--- a/src/common/KokkosKernels_Utils.hpp
+++ b/src/common/KokkosKernels_Utils.hpp
@@ -886,18 +886,18 @@ void create_reverse_map(
         multiply_shift_for_scale,
         division_shift_for_bucket);
     Kokkos::parallel_for ("KokkosKernels::Common::ReverseMapScaleInit",my_exec_space (0, num_forward_elements) , rmi);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
 
 
     inclusive_parallel_prefix_sum<reverse_array_type, MyExecSpace>(tmp_reverse_size + 1, tmp_color_xadj);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
 
     Kokkos::parallel_for ("KokkosKernels::Common::StridedCopy",my_exec_space (0, num_reverse_elements + 1) , StridedCopy<reverse_array_type, reverse_array_type>(tmp_color_xadj, reverse_map_xadj, scale_size));
-    MyExecSpace::fence();
+    MyExecSpace().fence();
     Fill_Reverse_Scale_Map<forward_array_type, reverse_array_type> frm (forward_map, tmp_color_xadj, reverse_map_adj,
         multiply_shift_for_scale, division_shift_for_bucket);
     Kokkos::parallel_for ("KokkosKernels::Common::FillReverseMap",my_exec_space (0, num_forward_elements) , frm);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
   }
   else
   //atomic implementation.
@@ -907,17 +907,17 @@ void create_reverse_map(
     Reverse_Map_Init<forward_array_type, reverse_array_type> rmi(forward_map, reverse_map_xadj);
 
     Kokkos::parallel_for ("KokkosKernels::Common::ReverseMapInit",my_exec_space (0, num_forward_elements) , rmi);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
     //print_1Dview(reverse_map_xadj);
 
 
     inclusive_parallel_prefix_sum<reverse_array_type, MyExecSpace>(num_reverse_elements + 1, reverse_map_xadj);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
     Kokkos::deep_copy (tmp_color_xadj, reverse_map_xadj);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
     Fill_Reverse_Map<forward_array_type, reverse_array_type> frm (forward_map, tmp_color_xadj, reverse_map_adj);
     Kokkos::parallel_for ("KokkosKernels::Common::FillReverseMap",my_exec_space (0, num_forward_elements) , frm);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
   }
 }
 
@@ -1155,7 +1155,7 @@ void symmetrize_and_get_lower_diagonal_edge_list(
     Kokkos::parallel_for("KokkosKernels::Common::SymmetrizeAndGetLowerDiagonalEdgeList::S0",
         team_policy(num_rows_to_symmetrize / teamSizeMax + 1 , teamSizeMax, vector_size),
         fse/*, num_symmetric_edges*/);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
 
   }
 
@@ -1163,7 +1163,7 @@ void symmetrize_and_get_lower_diagonal_edge_list(
   exclusive_parallel_prefix_sum<out_lno_nnz_view_t, MyExecSpace>(
       num_rows_to_symmetrize + 1,
       pre_pps_);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
   auto d_sym_edge_size = Kokkos::subview(pre_pps_, num_rows_to_symmetrize);
   auto h_sym_edge_size = Kokkos::create_mirror_view (d_sym_edge_size);
@@ -1179,7 +1179,7 @@ void symmetrize_and_get_lower_diagonal_edge_list(
 
   sym_srcs = out_lno_nnz_view_t(Kokkos::ViewAllocateWithoutInitializing("sym_srcs"), num_symmetric_edges);
   sym_dsts_ = out_lno_nnz_view_t(Kokkos::ViewAllocateWithoutInitializing("sym_dsts_"), num_symmetric_edges);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
   {
 
     hashmap_t umap (nnz);
@@ -1214,10 +1214,10 @@ void symmetrize_and_get_lower_diagonal_edge_list(
     Kokkos::parallel_for("KokkosKernels::Common::SymmetrizeAndGetLowerDiagonalEdgeList::S1",
         team_policy(num_rows_to_symmetrize / teamSizeMax + 1 , teamSizeMax, vector_size),
         FSCH);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
   }
 
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
 }
 
@@ -1299,7 +1299,7 @@ void symmetrize_graph_symbolic_hashmap(
     Kokkos::parallel_for("KokkosKernels::Common::SymmetrizeGraphSymbolicHashMap::S0",
         team_policy(num_rows_to_symmetrize / teamSizeMax + 1 , teamSizeMax, vector_size),
         fse/*, num_symmetric_edges*/);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
   }
 
 
@@ -1307,7 +1307,7 @@ void symmetrize_graph_symbolic_hashmap(
   exclusive_parallel_prefix_sum<out_lno_row_view_t, MyExecSpace>(
       num_rows_to_symmetrize + 1,
       pre_pps_);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
 
   //out_lno_row_view_t d_sym_edge_size = Kokkos::subview(pre_pps_, num_rows_to_symmetrize, num_rows_to_symmetrize );
@@ -1318,7 +1318,7 @@ void symmetrize_graph_symbolic_hashmap(
 
 
   sym_adj = out_lno_nnz_view_t(Kokkos::ViewAllocateWithoutInitializing("sym_adj"), num_symmetric_edges);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
   sym_xadj = out_lno_row_view_t(Kokkos::ViewAllocateWithoutInitializing("sym_xadj"), num_rows_to_symmetrize + 1);
   Kokkos::deep_copy(sym_xadj, pre_pps_);
   {
@@ -1355,10 +1355,10 @@ void symmetrize_graph_symbolic_hashmap(
     Kokkos::parallel_for("KokkosKernels::Common::SymmetrizeGraphSymbolicHashMap::S1",
         team_policy(num_rows_to_symmetrize / teamSizeMax + 1 , teamSizeMax, vector_size),
         FSCH);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
   }
 
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
 }
 
@@ -1605,7 +1605,7 @@ bool isSame(size_t num_elements, view_type1 view1, view_type2 view2){
   typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
   int issame = 1;
   Kokkos::parallel_reduce( "KokkosKernels::Common::isSame", my_exec_space(0,num_elements), IsEqualFunctor<view_type1, view_type2>(view1, view2), issame);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
   return issame;
 }
 
@@ -1773,16 +1773,16 @@ void transpose_matrix(
 
   Kokkos::Impl::Timer timer1;
   Kokkos::parallel_for( "KokkosKernels::Common::TransposeMatrix::S0",  tcp_t(num_rows / team_row_work_size + 1 , Kokkos::AUTO_t(), vector_size), tm);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
   exclusive_parallel_prefix_sum<out_row_view_t, MyExecSpace>(num_cols+1, t_xadj);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
   Kokkos::deep_copy(tmp_row_view, t_xadj);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
   timer1.reset();
   Kokkos::parallel_for( "KokkosKernels::Common::TransposeMatrix::S1",  tfp_t(num_rows / team_row_work_size + 1 , Kokkos::AUTO_t(), vector_size), tm);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 }
 
 template <typename in_row_view_t,
@@ -1851,16 +1851,16 @@ void transpose_graph2(
 
   Kokkos::Impl::Timer timer1;
   Kokkos::parallel_for( "KokkosKernels::Common::TransposeGraph2::S0",  tcp_t(num_rows  , Kokkos::AUTO_t(), vector_size), tm);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
   exclusive_parallel_prefix_sum<out_row_view_t, MyExecSpace>(num_cols+1, t_xadj);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
   Kokkos::deep_copy(tmp_row_view, t_xadj);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
   timer1.reset();
   Kokkos::parallel_for( "KokkosKernels::Common::TransposeGraph::S1",  tfp_t(num_rows , Kokkos::AUTO_t(), vector_size), tm);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
 
 }
@@ -1913,7 +1913,7 @@ void init_view_withscalar(typename in_row_view_t::size_type num_elements, in_row
 
   Kokkos::Impl::Timer timer1;
   Kokkos::parallel_for( "KokkosKernels::Common::InitViewWithScalar",  tcp_t(num_elements / chunk_size + 1 , team_size, vector_size), tm);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 }
 
 

--- a/src/graph/KokkosGraph_Distance1ColorHandle.hpp
+++ b/src/graph/KokkosGraph_Distance1ColorHandle.hpp
@@ -538,7 +538,7 @@ private:
         KokkosKernels::Impl::inclusive_parallel_prefix_sum<size_type_temp_work_view_t, HandleExecSpace>
         (nv+1, lower_count);
         //Kokkos::parallel_scan (my_exec_space(0, nv + 1), PPS<row_lno_temp_work_view_t>(lower_count));
-        HandleExecSpace::fence();
+        HandleExecSpace().fence();
         auto lower_total_count = Kokkos::subview(lower_count, nv);
         auto hlower = Kokkos::create_mirror_view (lower_total_count);
         Kokkos::deep_copy (hlower, lower_total_count);

--- a/src/graph/impl/KokkosGraph_Distance1Color_impl.hpp
+++ b/src/graph/impl/KokkosGraph_Distance1Color_impl.hpp
@@ -154,7 +154,7 @@ public:
     Kokkos::deep_copy (h_xadj, this->xadj);
     Kokkos::deep_copy (h_adj, this->adj);
 
-    MyExecSpace::fence();
+    MyExecSpace().fence();
 
 
 
@@ -219,7 +219,7 @@ public:
     typename const_lno_nnz_view_t::HostMirror h_adj = Kokkos::create_mirror_view (this->adj);
     Kokkos::deep_copy (h_xadj, this->xadj);
     Kokkos::deep_copy (h_adj, this->adj);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
 
 
     typedef typename col_view_t_::HostMirror col_host_view_t; //Host view type
@@ -228,7 +228,7 @@ public:
     col_nnz_view_t h_c_adj = Kokkos::create_mirror_view (col_entries);
     Kokkos::deep_copy (h_c_xadj, col_map);
     Kokkos::deep_copy (h_c_adj, col_entries);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
 
 
     Kokkos::Impl::Timer timer;
@@ -304,7 +304,7 @@ public:
     typename const_lno_nnz_view_t::HostMirror h_adj = Kokkos::create_mirror_view (this->adj);
     Kokkos::deep_copy (h_xadj, this->xadj);
     Kokkos::deep_copy (h_adj, this->adj);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
 
     //create a ban color array to keep track of
     //which colors have been taking by the neighbor vertices.
@@ -544,7 +544,7 @@ public:
     typename const_lno_nnz_view_t::HostMirror h_adj = Kokkos::create_mirror_view (this->adj);
     Kokkos::deep_copy (h_xadj, this->xadj);
     Kokkos::deep_copy (h_adj, this->adj);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
 
     typedef typename col_view_t_::HostMirror col_host_view_t; //Host view type
     typedef typename lno_colnnz_view_t_::HostMirror col_nnz_view_t; //Host view type
@@ -552,7 +552,7 @@ public:
     col_nnz_view_t h_c_adj = Kokkos::create_mirror_view (col_entries);
     Kokkos::deep_copy (h_c_xadj, col_map);
     Kokkos::deep_copy (h_c_adj, col_entries);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
 
 
     //create a ban color array to keep track of
@@ -969,7 +969,7 @@ public:
             current_vertexListLength);
       }
 
-      MyExecSpace::fence();
+      MyExecSpace().fence();
 
       if (this->_ticToc){
         t = timer.seconds();
@@ -1000,7 +1000,7 @@ public:
             pps_work_view);
       }
 
-      MyExecSpace::fence();
+      MyExecSpace().fence();
 
       if (_ticToc){
         t = timer.seconds();
@@ -1050,7 +1050,7 @@ public:
 
 
     	}
-    	MyExecSpace::fence();
+    	MyExecSpace().fence();
     	if (_ticToc){
     		t = timer.seconds();
     		total += t;
@@ -1249,13 +1249,13 @@ private:
         single_dim_index_host_view_type h_numUncolored(&numUncolored);
         Kokkos::deep_copy (next_iteration_recolorListLength_, h_numUncolored);
 
-        MyExecSpace::fence();
+        MyExecSpace().fence();
 
         Kokkos::parallel_scan ("KokkosGraph::GraphColoring::PrefixSum",
             my_exec_space(0, current_vertexListLength_),
             parallel_prefix_sum<nnz_lno_temp_work_view_t>(current_vertexList_, next_iteration_recolorList_, pps_work_view));
 
-        MyExecSpace::fence();
+        MyExecSpace().fence();
         Kokkos::parallel_for ("KokkosGraph::GraphColoring::CreateNewWorkArray",
             my_exec_space(0, current_vertexListLength_),
             create_new_work_array<nnz_lno_temp_work_view_t>(current_vertexList_, next_iteration_recolorList_, pps_work_view));
@@ -2925,7 +2925,7 @@ public:
         my_exec_space (0, num_work_edges),
         init_work_arrays(edge_conflict_indices, edge_conflict_marker)
     );
-    MyExecSpace::fence();
+    MyExecSpace().fence();
     //std::cout << "nv:" << this->nv << " init_work_arrays" << std::endl;
 
     double inittime = 0;
@@ -2961,7 +2961,7 @@ public:
           )
       );
 
-      MyExecSpace::fence();
+      MyExecSpace().fence();
       //std::cout << "nv:" << this->nv << " i:" << i <<  " halfedge_mark_conflicts" << std::endl;
 
       if (tictoc){
@@ -2985,7 +2985,7 @@ public:
               edge_conflict_marker
           ),num_conflict_reduction);
 
-      MyExecSpace::fence();
+      MyExecSpace().fence();
 
       /*
       std::cout << "nv:" << this->nv
@@ -3020,13 +3020,13 @@ public:
               my_exec_space(0, num_work_edges),
               parallel_prefix_sum(edge_conflict_indices, edge_conflict_marker, pps)
           );
-          MyExecSpace::fence();
+          MyExecSpace().fence();
 
           //write the edge indices to new worklist.
           Kokkos::parallel_for ("KokkosGraph::GraphColoring::CreateNewWorkArray",
               my_exec_space(0, num_work_edges),
               create_new_work_array(edge_conflict_indices, edge_conflict_marker, pps, new_edge_conflict_indices));
-          MyExecSpace::fence();
+          MyExecSpace().fence();
         }
         else {
           //create new worklist
@@ -3034,7 +3034,7 @@ public:
           Kokkos::parallel_for ("KokkosGraph::GraphColoring::CreateNewWorkArrayAtomic",
               my_exec_space(0, num_work_edges),
               atomic_create_new_work_array(new_index, edge_conflict_indices, edge_conflict_marker, new_edge_conflict_indices));
-          MyExecSpace::fence();
+          MyExecSpace().fence();
         }
 
         //swap old and new worklist
@@ -3060,7 +3060,7 @@ public:
           )
       );
 
-      MyExecSpace::fence();
+      MyExecSpace().fence();
 
       if (tictoc){
         ban_time += timer->seconds();

--- a/src/graph/impl/KokkosGraph_Distance2Color_impl.hpp
+++ b/src/graph/impl/KokkosGraph_Distance2Color_impl.hpp
@@ -312,7 +312,7 @@ class GraphColorDistance2
                   this->xadj, this->adj, this->t_xadj, this->t_adj, colors_out, current_vertexList, current_vertexListLength);
             }
 
-            my_exec_space::fence();
+            my_exec_space().fence();
 
             if(this->_ticToc)
             {
@@ -345,7 +345,7 @@ class GraphColorDistance2
                                                next_iteration_recolorList,
                                                next_iteration_recolorListLength);
 
-            my_exec_space::fence();
+            my_exec_space().fence();
 
             if(_ticToc)
             {
@@ -393,7 +393,7 @@ class GraphColorDistance2
                                          current_vertexListLength);
         }
 
-        my_exec_space::fence();
+        my_exec_space().fence();
 
         if(_ticToc)
         {
@@ -485,7 +485,7 @@ class GraphColorDistance2
         KokkosKernels::Impl::kk_get_histogram<typename HandleType::color_view_type, nnz_lno_temp_work_view_t, my_exec_space>(
           this->nv, this->gc_handle->get_vertex_colors(), histogram);
 
-        my_exec_space::fence();
+        my_exec_space().fence();
     }
 
 

--- a/src/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
@@ -663,7 +663,7 @@ namespace KokkosSparse{
           <typename HandleType::GraphColoringHandleType::color_view_t,
            nnz_lno_persistent_work_view_t, MyExecSpace>
           (num_rows, numColors, colors, color_xadj, color_adj);
-        MyExecSpace::fence();
+        MyExecSpace().fence();
 
 
 #ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
@@ -673,7 +673,7 @@ namespace KokkosSparse{
 
         nnz_lno_persistent_work_host_view_t  h_color_xadj = Kokkos::create_mirror_view (color_xadj);
         Kokkos::deep_copy (h_color_xadj , color_xadj);
-        MyExecSpace::fence();
+        MyExecSpace().fence();
 
 
 #ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
@@ -691,18 +691,18 @@ namespace KokkosSparse{
             if (color_index_begin + 1 >= color_index_end ) continue;
             auto colorsubset =
               subview(color_adj, Kokkos::pair<row_lno_t, row_lno_t> (color_index_begin, color_index_end));
-            MyExecSpace::fence();
+            MyExecSpace().fence();
             Kokkos::sort (colorsubset);
             //TODO: MD 08/2017: If I remove the below fence, code fails on cuda.
             //I do not see any reason yet it to fail.
-            MyExecSpace::fence();
+            MyExecSpace().fence();
           }
         }
 #endif
 
 
 
-        MyExecSpace::fence();
+        MyExecSpace().fence();
 #ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
         std::cout << "SORT_TIME:" << timer.seconds() << std::endl;
         timer.reset();
@@ -720,7 +720,7 @@ namespace KokkosSparse{
                                                    permuted_xadj,
                                                    old_to_new_map));
         //std::cout << "create_permuted_xadj" << std::endl;
-        MyExecSpace::fence();
+        MyExecSpace().fence();
 
 #ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
         std::cout << "CREATE_PERMUTED_XADJ:" << timer.seconds() << std::endl;
@@ -732,7 +732,7 @@ namespace KokkosSparse{
         KokkosKernels::Impl::inclusive_parallel_prefix_sum
           <row_lno_persistent_work_view_t, MyExecSpace>
           (num_rows + 1, permuted_xadj);
-        MyExecSpace::fence();
+        MyExecSpace().fence();
 
 #ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
         std::cout << "INCLUSIVE_PPS:" << timer.seconds() << std::endl;
@@ -751,7 +751,7 @@ namespace KokkosSparse{
                                                    permuted_adj,
                                                    //newvals_,
                                                    old_to_new_map));
-        MyExecSpace::fence();
+        MyExecSpace().fence();
 
 #ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
         std::cout << "SYMBOLIC_FILL:" << timer.seconds() << std::endl;
@@ -1163,7 +1163,7 @@ namespace KokkosSparse{
                                                       block_matrix_size
                                                       ));
           }
-          MyExecSpace::fence();
+          MyExecSpace().fence();
           gsHandler->set_new_adj_val(permuted_adj_vals);
 
           scalar_persistent_work_view_t permuted_inverse_diagonal (Kokkos::ViewAllocateWithoutInitializing("permuted_inverse_diagonal"), num_rows * block_size );
@@ -1210,7 +1210,7 @@ namespace KokkosSparse{
 
           }
 
-          MyExecSpace::fence();
+          MyExecSpace().fence();
           this->handle->get_gs_handle()->set_permuted_inverse_diagonal(permuted_inverse_diagonal);
 
           this->handle->get_gs_handle()->set_call_numeric(true);
@@ -1268,7 +1268,7 @@ namespace KokkosSparse{
                                                           Permuted_Yvector
                                                           );
         }
-        MyExecSpace::fence();
+        MyExecSpace().fence();
         if(init_zero_x_vector){
           KokkosKernels::Impl::zero_vector<scalar_persistent_work_view_t, MyExecSpace>(num_cols * block_size, Permuted_Xvector);
         }
@@ -1281,7 +1281,7 @@ namespace KokkosSparse{
                                                                                                              Permuted_Xvector
                                                                                                              );
         }
-        MyExecSpace::fence();
+        MyExecSpace().fence();
 
 
 
@@ -1358,7 +1358,7 @@ namespace KokkosSparse{
                                                                                                            Permuted_Xvector,
                                                                                                            x_lhs_output_vec
                                                                                                            );
-        MyExecSpace::fence();
+        MyExecSpace().fence();
 
 #if KOKKOSSPARSE_IMPL_PRINTDEBUG
         std::cout << "After X:";
@@ -1408,7 +1408,7 @@ namespace KokkosSparse{
                                                           Permuted_Yvector
                                                           );
         }
-        MyExecSpace::fence();
+        MyExecSpace().fence();
         if(init_zero_x_vector){
           KokkosKernels::Impl::zero_vector<scalar_persistent_work_view_t, MyExecSpace>(num_cols, Permuted_Xvector);
         }
@@ -1421,7 +1421,7 @@ namespace KokkosSparse{
                                                                                                              Permuted_Xvector
                                                                                                              );
         }
-        MyExecSpace::fence();
+        MyExecSpace().fence();
 
         row_lno_persistent_work_view_t permuted_xadj = gsHandler->get_new_xadj();
         nnz_lno_persistent_work_view_t permuted_adj = gsHandler->get_new_adj();
@@ -1476,7 +1476,7 @@ namespace KokkosSparse{
                                                                                                            Permuted_Xvector,
                                                                                                            x_lhs_output_vec
                                                                                                            );
-        MyExecSpace::fence();
+        MyExecSpace().fence();
 #if KOKKOSSPARSE_IMPL_PRINTDEBUG
         std::cout << "--point After X:";
         KokkosKernels::Impl::print_1Dview(Permuted_Xvector);
@@ -1576,7 +1576,7 @@ namespace KokkosSparse{
                                    gs );
             }
 
-            MyExecSpace::fence();
+            MyExecSpace().fence();
           }
         }
         if (apply_backward){
@@ -1608,7 +1608,7 @@ namespace KokkosSparse{
                                      bigblock_team_fill_policy_t(numberOfTeams / team_row_chunk_size + 1 , suggested_team_size, vector_size),
                                      gs );
               }
-              MyExecSpace::fence();
+              MyExecSpace().fence();
               if (i == 0){
                 break;
               }
@@ -1643,7 +1643,7 @@ namespace KokkosSparse{
             //std::cout <<  "i:" << i << " color_index_begin:" << color_index_begin << " color_index_end:" << color_index_end << std::endl;
             Kokkos::parallel_for ("KokkosSparse::GaussSeidel::PSGS::forward",
                                   my_exec_space (color_index_begin, color_index_end) , gs);
-            MyExecSpace::fence();
+            MyExecSpace().fence();
           }
         }
         if (apply_backward && numColors){
@@ -1652,7 +1652,7 @@ namespace KokkosSparse{
             nnz_lno_t color_index_end = h_color_xadj(i + 1);
             Kokkos::parallel_for ("KokkosSparse::GaussSeidel::PSGS::backward",
                                   my_exec_space (color_index_begin, color_index_end) , gs);
-            MyExecSpace::fence();
+            MyExecSpace().fence();
             if (i == 0){
               break;
             }

--- a/src/sparse/impl/KokkosSparse_spgemm_CUSP_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_CUSP_impl.hpp
@@ -182,7 +182,7 @@ void CUSP_apply(
 
   Kokkos::Impl::Timer timer1;
   cusp::multiply(A,B,C);
-  KernelHandle::HandleExecSpace::fence();
+  KernelHandle::HandleExecSpace().fence();
   std::cout << "Actual CUSP SPMM Time:" << timer1.seconds() << std::endl;
 
 

--- a/src/sparse/impl/KokkosSparse_spgemm_imp_outer.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_imp_outer.hpp
@@ -617,7 +617,7 @@ void KokkosSPGEMM
       row_mapA, entriesA, valsA,
       transpose_col_xadj,transpose_col_adj, tranpose_vals);
 
-  MyExecSpace::fence();
+  MyExecSpace().fence();
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << "\t\tTranspose FlopsPerRowOuterCal BlockPartition FastAllocation";
     std::cout << " Outer Sort Collapse CopyToSLOW MultiWayMerge FinalCollapse Overall"<<std::endl;
@@ -642,7 +642,7 @@ void KokkosSPGEMM
   const_b_lno_row_view_t,
   size_t_view_t> fpr(b_row_cnt, transpose_col_xadj, row_mapB, flop_per_row);
   Kokkos::parallel_for(Kokkos::RangePolicy<MyExecSpace> (0,b_row_cnt), fpr);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
   KokkosKernels::Impl::
   exclusive_parallel_prefix_sum<size_t_view_t, MyExecSpace>
@@ -651,7 +651,7 @@ void KokkosSPGEMM
   auto num_flops = Kokkos::subview(flop_per_row, b_row_cnt);
   auto h_num_flops = Kokkos::create_mirror_view (num_flops);
   Kokkos::deep_copy (h_num_flops, num_flops);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
   size_t num_required_flops = h_num_flops();
 
   if (KOKKOSKERNELS_VERBOSE){
@@ -708,7 +708,7 @@ void KokkosSPGEMM
       //    )
       , block_size);
 
-  MyExecSpace::fence();
+  MyExecSpace().fence();
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << timer1.seconds() << " ";
     //std::cout << "\t\tAllocation WITH FIRST TOUCH TIME:" << timer1.seconds() << std::endl<< std::endl;
@@ -746,7 +746,7 @@ void KokkosSPGEMM
 
 
 
-    MyExecSpace::fence();
+    MyExecSpace().fence();
     if (KOKKOSKERNELS_VERBOSE){
       outerproducttime += timer1.seconds();
       //std::cout << "\t\tOuter Product TIME:" << timer1.seconds() << std::endl;
@@ -777,7 +777,7 @@ void KokkosSPGEMM
 
     timer1.reset();
     this->sort_triplets(fast_memory_triplets, num_block_flops);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
     if (KOKKOSKERNELS_VERBOSE){
       sorttime += timer1.seconds();
       //std::cout << "\t\tTriplet Sort Time:" << timer1.seconds() << std::endl;
@@ -790,7 +790,7 @@ void KokkosSPGEMM
     size_type outsize = this->collapse_triplets_omp(
         fast_memory_triplets, num_block_flops, collapsed_fast_memory_triplets);
     overall_size += outsize;
-    MyExecSpace::fence();
+    MyExecSpace().fence();
     if (KOKKOSKERNELS_VERBOSE){
       //std::cout << "\t\toutsize:" << outsize << std::endl;
       collapse_time += timer1.seconds();
@@ -807,7 +807,7 @@ void KokkosSPGEMM
     KokkosKernels::Impl::kk_copy_vector
     <fast_triplet_view_t, slow_triplet_view_t, MyExecSpace>(
         outsize,collapsed_fast_memory_triplets, host_triplet_arrays[bi]);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
     if (KOKKOSKERNELS_VERBOSE){
       copy_to_slow_mem_time += timer1.seconds();
       //std::cout << "\t\tTriplet Copy To Slow Memory Time:" << timer1.seconds()  << std::endl << std::endl;

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_color.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_color.hpp
@@ -429,7 +429,7 @@ void
         break;
       }
     }
-    MyExecSpace::fence();
+    MyExecSpace().fence();
   }
 
   if (KOKKOSKERNELS_VERBOSE){
@@ -493,7 +493,7 @@ void
       team_row_chunk_size,
       use_dynamic_schedule);
 
-    MyExecSpace::fence();
+    MyExecSpace().fence();
   }
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << "\t\tTranspose Time:" << timer1.seconds() << std::endl;
@@ -537,7 +537,7 @@ void
         KokkosKernels::Impl::kk_read_1Dview_from_file(vertex_color_view, this->handle->get_spgemm_handle()->coloring_input_file.c_str());
         KokkosKernels::Impl::view_reduce_max<typename HandleType::GraphColoringHandleType::color_view_t, MyExecSpace>
               (a_row_cnt, vertex_color_view, original_num_colors);
-        MyExecSpace::fence();
+        MyExecSpace().fence();
 
         //KokkosKernels::Impl::kk_print_1Dview(vertex_color_view);
     }
@@ -551,7 +551,7 @@ void
     if (KOKKOSKERNELS_VERBOSE){
       //create histogram and print it.
       nnz_lno_temp_work_view_t histogram ("histogram", original_num_colors + 1);
-      MyExecSpace::fence();
+      MyExecSpace().fence();
       timer1.reset();
       KokkosKernels::Impl::kk_get_histogram
       <typename HandleType::GraphColoringHandleType::color_view_t, nnz_lno_temp_work_view_t, MyExecSpace>(a_row_cnt, vertex_color_view, histogram);
@@ -630,14 +630,14 @@ void
         <typename HandleType::GraphColoringHandleType::color_view_t //nnz_lno_temp_work_view_t
         ,nnz_lno_persistent_work_view_t, MyExecSpace>
             (a_row_cnt, num_multi_color_steps, tmp_color_view, color_xadj, color_adj);
-      MyExecSpace::fence();
+      MyExecSpace().fence();
 
       if (KOKKOSKERNELS_VERBOSE){
         std::cout << "\t\tReverse Map Create Time:" << timer1.seconds() << std::endl;
       }
       h_color_xadj = Kokkos::create_mirror_view (color_xadj);
       Kokkos::deep_copy (h_color_xadj, color_xadj);
-      MyExecSpace::fence();
+      MyExecSpace().fence();
     }
     this->handle->destroy_graph_coloring_handle();
   }

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
@@ -800,7 +800,7 @@ bool KokkosSPGEMM
     set_begins_ = out_nnz_view_t (Kokkos::ViewAllocateWithoutInitializing("set_begins_"), nnz);
     Kokkos::deep_copy (set_begins_, -1);
   }
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 #endif
 
   if (KOKKOSKERNELS_VERBOSE){
@@ -843,7 +843,7 @@ bool KokkosSPGEMM
 #ifndef KOKKOSKERNELSMOREMEM
     size_type max_row_nnz = 0;
     KokkosKernels::Impl::view_reduce_maxsizerow<in_row_view_t, MyExecSpace>(n, in_row_map, max_row_nnz);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
     KokkosKernels::Impl::PoolType my_pool_type = KokkosKernels::Impl::ManyThread2OneChunk;
 
     nnz_lno_t min_hash_size = 1;
@@ -890,7 +890,7 @@ bool KokkosSPGEMM
     }
     nnz_lno_t pool_init_val = -1;
     pool_memory_space m_space(num_chunks, chunksize, pool_init_val,  my_pool_type);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
     sszm_compressMatrix.memory_space = m_space;
 #endif
     Kokkos::parallel_for("KokkosSparse::SingleStepZipMatrix::GPUEXEC",  gpu_team_policy_t(n / suggested_team_size + 1 , suggested_team_size, suggested_vector_size), sszm_compressMatrix);
@@ -903,7 +903,7 @@ bool KokkosSPGEMM
       {
         size_type max_row_nnz = 0;
         KokkosKernels::Impl::view_reduce_maxsizerow<in_row_view_t, MyExecSpace>(n, in_row_map, max_row_nnz);
-        MyExecSpace::fence();
+        MyExecSpace().fence();
         KokkosKernels::Impl::PoolType my_pool_type = KokkosKernels::Impl::OneThread2OneChunk;
 
         nnz_lno_t min_hash_size = 1;
@@ -929,7 +929,7 @@ bool KokkosSPGEMM
         }
         nnz_lno_t pool_init_val = -1;
         pool_memory_space m_space(num_chunks, chunksize, pool_init_val,  my_pool_type);
-        MyExecSpace::fence();
+        MyExecSpace().fence();
         sszm_compressMatrix.memory_space = m_space;
       }
 
@@ -939,7 +939,7 @@ bool KokkosSPGEMM
       else
         Kokkos::parallel_for( "KokkosSparse::TwoStepZipMatrix::use_ordered_compress", team_count_policy_t(n / team_row_chunk_size + 1 , suggested_team_size, suggested_vector_size), sszm_compressMatrix);
 
-      MyExecSpace::fence();
+      MyExecSpace().fence();
       if (KOKKOSKERNELS_VERBOSE){
         std::cout << "\t\tCompression Count Kernel:" <<  timer_count.seconds() << std::endl;
       }
@@ -999,7 +999,7 @@ bool KokkosSPGEMM
 
     }
   }
-  MyExecSpace::fence();
+  MyExecSpace().fence();
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << "\t\tCompression Kernel time:" <<  timer1.seconds() << std::endl;
   }

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
@@ -1396,7 +1396,7 @@ void
 
   Kokkos::Impl::Timer timer1;
   pool_memory_space m_space(num_chunks, chunksize, -1,  my_pool_type);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << "\t\tPool Alloc Time:" << timer1.seconds() << std::endl;
@@ -1442,7 +1442,7 @@ void
   if (lcl_my_exec_space == KokkosKernels::Impl::Exec_CUDA){
 	  if (algorithm_to_run == SPGEMM_KK_MEMORY_SPREADTEAM){
 		  Kokkos::parallel_for("KOKKOSPARSE::SPGEMM::SPGEMM_KK_MEMORY_SPREADTEAM", gpu_team_policy4_t(a_row_cnt / team_row_chunk_size + 1 , suggested_team_size, suggested_vector_size), sc);
-		    MyExecSpace::fence();
+		    MyExecSpace().fence();
 
 	  }
 	  else if (algorithm_to_run == SPGEMM_KK_MEMORY_BIGSPREADTEAM){
@@ -1452,7 +1452,7 @@ void
 
 		  Kokkos::parallel_for("KOKKOSPARSE::SPGEMM::SPGEMM_KK_MEMORY", gpu_team_policy_t(a_row_cnt / team_row_chunk_size + 1 , suggested_team_size, suggested_vector_size), sc);
 	  }
-    MyExecSpace::fence();
+    MyExecSpace().fence();
   }
   else {
 	  if (algorithm_to_run == SPGEMM_KK_LP){
@@ -1474,7 +1474,7 @@ void
 			  Kokkos::parallel_for("KOKKOSPARSE::SPGEMM::KKMEM::STATIC",  multicore_team_policy_t(a_row_cnt / team_row_chunk_size + 1 , suggested_team_size, suggested_vector_size), sc);
 		  }
 	  }
-	  MyExecSpace::fence();
+	  MyExecSpace().fence();
   }
 
   if (KOKKOSKERNELS_VERBOSE){
@@ -1540,7 +1540,7 @@ void
 
   Kokkos::Impl::Timer timer1;
   pool_memory_space m_space(num_chunks, chunksize, -1,  my_pool_type);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << "\t\tPool Alloc Time:" << timer1.seconds() << std::endl;
@@ -1586,7 +1586,7 @@ void
 
   if (my_exec_space_ == KokkosKernels::Impl::Exec_CUDA){
     Kokkos::parallel_for("KOKKOSPARSE::SPGEMM::SPGEMM_KK_MEMORY2",  gpu_team_policy_t(a_row_cnt / team_row_chunk_size + 1 , suggested_team_size, suggested_vector_size), sc);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
   }
   else {
     if (use_dynamic_schedule){
@@ -1597,7 +1597,7 @@ void
 
       Kokkos::parallel_for( "KOKKOSPARSE::SPGEMM::SPGEMM_KK_MEMORY_STATIC", multicore_team_policy2_t(a_row_cnt / team_row_chunk_size + 1 , suggested_team_size, suggested_vector_size), sc);
     }
-    MyExecSpace::fence();
+    MyExecSpace().fence();
   }
 
   if (KOKKOSKERNELS_VERBOSE){

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_memaccess.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_memaccess.hpp
@@ -254,11 +254,11 @@ void KokkosSPGEMM
 
   //calculate how many flops per row is performed
   Kokkos::parallel_reduce( team_count_policy_t(a_row_cnt / team_row_chunk_size  + 1 , suggested_team_size, suggested_vector_size), pcnnnz, overall_flops);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
   //do a parallel prefix sum
   KokkosKernels::Impl::exclusive_parallel_prefix_sum<row_lno_temp_work_view_t, MyExecSpace>(a_row_cnt+1, c_flop_rowmap);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
   std::cout << "overall_flops:" << overall_flops << std::endl;
 
@@ -277,7 +277,7 @@ void KokkosSPGEMM
   //fill the hypergraph values.
   //indices of nnzs for a and b nets, for c nets, the row and column index.
   Kokkos::parallel_for( team_fill_policy_t(a_row_cnt / team_row_chunk_size  + 1 , suggested_team_size, suggested_vector_size), pcnnnz);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 }
 
 template <typename HandleType,

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
@@ -531,7 +531,7 @@ void
         KOKKOSKERNELS_VERBOSE);
 
     Kokkos::Impl::Timer timer1;
-    MyExecSpace::fence();
+    MyExecSpace().fence();
 
     if (KOKKOSKERNELS_VERBOSE){
       std::cout << "\t\tGPU vector_size:" << suggested_vector_size
@@ -549,7 +549,7 @@ void
             suggested_team_size ,
             suggested_vector_size),
             sc);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
 
     if (KOKKOSKERNELS_VERBOSE){
       std::cout << "\t\tNumeric TIME:" << timer1.seconds() << std::endl;
@@ -569,7 +569,7 @@ void
     Kokkos::Impl::Timer timer1;
     pool_memory_space m_space
     (num_chunks, this->b_col_cnt + (this->b_col_cnt) / sizeof(scalar_t) + 1, 0,  my_pool_type);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
 
     if (KOKKOSKERNELS_VERBOSE){
       std::cout << "\t\tPool Alloc Time:" << timer1.seconds() << std::endl;
@@ -602,7 +602,7 @@ void
         my_exec_space_,
         team_row_chunk_size);
 
-    MyExecSpace::fence();
+    MyExecSpace().fence();
     if (KOKKOSKERNELS_VERBOSE){
       std::cout << "\t\tCPU vector_size:" << suggested_vector_size
           <<  " team_size:" << suggested_team_size
@@ -618,7 +618,7 @@ void
       Kokkos::parallel_for( "KokkosSparse::NumericCMEM_CPU::DENSE::STATIC", multicore_team_policy_t(a_row_cnt / team_row_chunk_size + 1 , suggested_team_size, suggested_vector_size), sc);
     }
 
-    MyExecSpace::fence();
+    MyExecSpace().fence();
 
     if (KOKKOSKERNELS_VERBOSE){
       std::cout << "\t\tNumeric TIME:" << timer1.seconds() << std::endl;

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
@@ -1689,7 +1689,7 @@ void KokkosSPGEMM
 	}
 	Kokkos::Impl::Timer timer1;
 	pool_memory_space m_space(num_chunks, chunksize, pool_init_val,  my_pool_type);
-	MyExecSpace::fence();
+	MyExecSpace().fence();
 
 	if (KOKKOSKERNELS_VERBOSE){
 		std::cout << "\tPool Alloc Time:" << timer1.seconds() << std::endl;
@@ -1758,7 +1758,7 @@ void KokkosSPGEMM
 			}
 		}
 	}
-	MyExecSpace::fence();
+	MyExecSpace().fence();
 	if (KOKKOSKERNELS_VERBOSE){
 		std::cout << "\tStructureC Kernel time:" << timer1.seconds() << std::endl<< std::endl;
 	}
@@ -1767,7 +1767,7 @@ void KokkosSPGEMM
 		Kokkos::Impl::Timer timer1_;
 		size_type c_max_nnz = 0;
 		KokkosKernels::Impl::view_reduce_max<c_row_view_t, MyExecSpace>(m, rowmapC, c_max_nnz);
-		MyExecSpace::fence();
+		MyExecSpace().fence();
 		this->handle->get_spgemm_handle()->set_max_result_nnz(c_max_nnz);
 
 		if (KOKKOSKERNELS_VERBOSE){
@@ -1776,7 +1776,7 @@ void KokkosSPGEMM
 	}
 
 	KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<c_row_view_t, MyExecSpace>(m+1, rowmapC);
-	MyExecSpace::fence();
+	MyExecSpace().fence();
 	auto d_c_nnz_size = Kokkos::subview(rowmapC, m);
 	auto h_c_nnz_size = Kokkos::create_mirror_view (d_c_nnz_size);
 	Kokkos::deep_copy (h_c_nnz_size, d_c_nnz_size);
@@ -2017,7 +2017,7 @@ void KokkosSPGEMM
   }
   Kokkos::Impl::Timer timer1;
   pool_memory_space m_space(num_chunks, chunksize, pool_init_val,  my_pool_type);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << "\tPool Alloc Time:" << timer1.seconds() << std::endl;
@@ -2085,7 +2085,7 @@ void KokkosSPGEMM
 		  }
 	  }
   }
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << "\tStructureC Kernel time:" << timer1.seconds() << std::endl<< std::endl;
@@ -2123,7 +2123,7 @@ void KokkosSPGEMM
 	  typename c_row_view_t::HostMirror h_rowmapC = Kokkos::create_mirror_view (rowmapC);
 	  Kokkos::deep_copy(h_rowmapC, rowmapC);
 
-	  MyExecSpace::fence();
+	  MyExecSpace().fence();
 
 
 	  std::unordered_map <size_t, nnz_lno_t> flop_to_row_count;
@@ -2270,7 +2270,7 @@ void KokkosSPGEMM
     Kokkos::Impl::Timer timer1_;
     size_type c_max_nnz = 0;
     KokkosKernels::Impl::view_reduce_max<c_row_view_t, MyExecSpace>(m, rowmapC, c_max_nnz);
-    MyExecSpace::fence();
+    MyExecSpace().fence();
     this->handle->get_spgemm_handle()->set_max_result_nnz(c_max_nnz);
 
     if (KOKKOSKERNELS_VERBOSE){
@@ -2279,7 +2279,7 @@ void KokkosSPGEMM
   }
 
   KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<c_row_view_t, MyExecSpace>(m+1, rowmapC);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
   auto d_c_nnz_size = Kokkos::subview(rowmapC, m);
   auto h_c_nnz_size = Kokkos::create_mirror_view (d_c_nnz_size);
   Kokkos::deep_copy (h_c_nnz_size, d_c_nnz_size);
@@ -2324,7 +2324,7 @@ size_t KokkosSPGEMM
 
 	typename b_oldrow_view_t::non_const_value_type rough_size = 0;
 	Kokkos::parallel_reduce( "KokkosSparse::PredicMaxRowNNZ::STATIC", team_policy_t(m / team_row_chunk_size  + 1 , suggested_team_size, suggested_vector_size), pcnnnz, rough_size);
-	MyExecSpace::fence();
+	MyExecSpace().fence();
 
 	return rough_size;
 	}
@@ -2448,7 +2448,7 @@ size_t KokkosSPGEMM
 
   size_type rough_size = 0;
   Kokkos::parallel_reduce("KokkosSparse::PredicMaxRowNNZ_P::STATIC",  team_policy_t(m / team_row_chunk_size  + 1 , suggested_team_size, suggested_vector_size), pcnnnz, rough_size);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
   return rough_size;
 }
 
@@ -2490,7 +2490,7 @@ size_t KokkosSPGEMM
 
   nnz_lno_t rough_size = 0;
   Kokkos::parallel_reduce( "KokkosSparse::PredicMaxRowNNZIntersection::STATIC", team_policy_t(m / team_row_chunk_size  + 1 , suggested_team_size, suggested_vector_size), pcnnnz, rough_size);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
   return rough_size;
     }
 

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
@@ -1470,7 +1470,7 @@ void KokkosSPGEMM
 
   Kokkos::Impl::Timer timer1;
   pool_memory_space m_space(num_chunks, accumulator_chunksize, pool_init_val,  my_pool_type);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << "\tPool Alloc Time:" << timer1.seconds() << std::endl;
   }
@@ -1612,7 +1612,7 @@ void KokkosSPGEMM
 
     }
   }
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << "\tKernel time:" << timer1.seconds() << std::endl<< std::endl;
@@ -1914,7 +1914,7 @@ void KokkosSPGEMM
 
   KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum
                 <c_row_view_t, MyExecSpace>(this->a_row_cnt + 1, rowmapC_);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
   auto d_c_nnz_size = Kokkos::subview(rowmapC_, this->a_row_cnt);
   auto h_c_nnz_size = Kokkos::create_mirror_view (d_c_nnz_size);

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_triangle_no_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_triangle_no_compression.hpp
@@ -1008,7 +1008,7 @@ void KokkosSPGEMM
 
   Kokkos::Impl::Timer timer1;
   pool_memory_space m_space(num_chunks, accumulator_chunksize, pool_init_val,  my_pool_type);
-  MyExecSpace::fence();
+  MyExecSpace().fence();
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << "\tPool Alloc Time:" << timer1.seconds() << std::endl;
   }
@@ -1099,7 +1099,7 @@ void KokkosSPGEMM
 
     }
   }
-  MyExecSpace::fence();
+  MyExecSpace().fence();
 
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << "\tKernel time:" << timer1.seconds() << std::endl<< std::endl;

--- a/src/sparse/impl/KokkosSparse_spgemm_viennaCL_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_viennaCL_impl.hpp
@@ -160,7 +160,7 @@ namespace Impl{
 
       Kokkos::Impl::Timer timer1;
       viennacl::compressed_matrix<value_type> C = viennacl::linalg::prod(A, B);
-      MyExecSpace::fence();
+      MyExecSpace().fence();
 
       if (verbose)
       std::cout << "Actual VIENNACL SPMM Time:" << timer1.seconds() << std::endl;
@@ -187,11 +187,11 @@ namespace Impl{
           //row_mapC = typename cin_row_index_view_type::non_const_type(Kokkos::ViewAllocateWithoutInitializing("rowmapC"), c_rows + 1);
           entriesC = typename cin_nonzero_index_view_type::non_const_type (Kokkos::ViewAllocateWithoutInitializing("EntriesC") , cnnz);
           valuesC = typename cin_nonzero_value_view_type::non_const_type (Kokkos::ViewAllocateWithoutInitializing("valuesC") ,  cnnz);
-	  MyExecSpace::fence();
+	  MyExecSpace().fence();
           KokkosKernels::Impl::copy_vector<unsigned int const *, typename cin_row_index_view_type::non_const_type, MyExecSpace> (m + 1, rows_start, row_mapC);
           KokkosKernels::Impl::copy_vector<unsigned int const *, typename cin_nonzero_index_view_type::non_const_type, MyExecSpace> (cnnz, columns, entriesC);
           KokkosKernels::Impl::copy_vector<value_type   const *, typename cin_nonzero_value_view_type::non_const_type, MyExecSpace> (cnnz, values, valuesC);
-          MyExecSpace::fence();
+          MyExecSpace().fence();
 
 
           double copy_time_d = copy_time.seconds();


### PR DESCRIPTION
See kokkos/kokkos#2140
The fence as a static member function of execution spaces was
deprecated, made non-static.