### PR TITLE
KokkosBatched - reduce vector length from 16 to 8.

### DIFF
--- a/src/batched/KokkosBatched_Vector.hpp
+++ b/src/batched/KokkosBatched_Vector.hpp
@@ -64,35 +64,35 @@ namespace KokkosBatched {
 #if defined(KOKKOS_ENABLE_CUDA)
   template<>
   struct DefaultVectorLength<float,Kokkos::CudaSpace> {
-    enum : int { value = 16 };
+    enum : int { value = 8 };
   };
   template<>
   struct DefaultVectorLength<double,Kokkos::CudaSpace> {
-    enum : int { value = 16 };
+    enum : int { value = 8 };
   };
   template<>
   struct DefaultVectorLength<Kokkos::complex<float>,Kokkos::CudaSpace> {
-    enum : int { value = 16 };
+    enum : int { value = 8 };
   };
   template<>
   struct DefaultVectorLength<Kokkos::complex<double>,Kokkos::CudaSpace> {
-    enum : int { value = 16 };
+    enum : int { value = 8 };
   };
   template<>
   struct DefaultVectorLength<float,Kokkos::CudaUVMSpace> {
-    enum : int { value = 16 };
+    enum : int { value = 8 };
   };
   template<>
   struct DefaultVectorLength<double,Kokkos::CudaUVMSpace> {
-    enum : int { value = 16 };
+    enum : int { value = 8 };
   };
   template<>
   struct DefaultVectorLength<Kokkos::complex<float>,Kokkos::CudaUVMSpace> {
-    enum : int { value = 16 };
+    enum : int { value = 8 };
   };
   template<>
   struct DefaultVectorLength<Kokkos::complex<double>,Kokkos::CudaUVMSpace> {
-    enum : int { value = 16 };
+    enum : int { value = 8 };
   };
 #endif
 


### PR DESCRIPTION
Most important part in memory efficiency is keeping 32 byte cacheline.
By reducing the length, we can increase occupancy for smaller problems
and sparc is the case.