### PR TITLE
Fix dist-1 coloring crash

### DIFF
--- a/src/graph/impl/KokkosGraph_Distance1Color_impl.hpp
+++ b/src/graph/impl/KokkosGraph_Distance1Color_impl.hpp
@@ -1853,13 +1853,12 @@ public:
 
         // Do multiple passes if array is too small.
         color_t degree = _idx(i+1)-_idx(i); // My degree
-        color_t offset = 0;
+        color_t offset = 1;
         for (; (offset <= degree + VB_COLORING_FORBIDDEN_SIZE) && (!foundColor); offset += VB_COLORING_FORBIDDEN_SIZE){
           // initialize
           for (int j=0; j< VB_COLORING_FORBIDDEN_SIZE; j++){
             forbidden[j] = false;
           }
-          if (offset == 0) forbidden[0] = true; // by convention, start at 1
 
           // Check nbors, fill forbidden array.
           for (size_type j=_idx(i); j<_idx(i+1); j++){


### PR DESCRIPTION
Change the "forbidden" color offset to start at 1 instead of 0 in
VB coloring, to match VBBIT. Does not affect correctness but fixes
a crash (seemingly due to compiler bug) on Intel compilers 17/18,
running on KNL with OpenMP.

Spot check results on kokkos-dev:

#######################################################
PASSED TESTS
#######################################################
clang-4.0.1-Pthread_Serial-hwloc-release build_time=1540 run_time=671
clang-4.0.1-Pthread_Serial-release build_time=1473 run_time=907
cuda-8.0.44-Cuda_OpenMP-release build_time=2046 run_time=443
gcc-5.3.0-Serial-hwloc-release build_time=854 run_time=198
gcc-5.3.0-Serial-release build_time=847 run_time=195
gcc-7.2.0-Serial-hwloc-release build_time=762 run_time=177
gcc-7.2.0-Serial-release build_time=724 run_time=212
#######################################################
FAILED TESTS
#######################################################
intel-17.0.1-OpenMP-hwloc-release (test failed)
intel-17.0.1-OpenMP-release (test failed)

The two tests that fail under intel builds are unrelated to this change:
[  FAILED  ] openmp.sparse_spmv_struct_double_int64_t_int_TestExecSpace
[  FAILED  ] openmp.sparse_spmv_struct_double_int64_t_size_t_TestExecSpace