### PR TITLE
Fixed out-of-bounds read in read_mtx()

### DIFF
--- a/src/common/KokkosKernels_IOUtils.hpp
+++ b/src/common/KokkosKernels_IOUtils.hpp
@@ -995,7 +995,7 @@ int read_mtx (
   for (lno_t i = 0; i < nr; ++i){
     (*xadj)[i] = actual;
     bool is_first = true;
-    while (edges[eind].src == i){
+    while (eind < nE && edges[eind].src == i){
       if (is_first || !symmetrize || eind == 0 || (eind > 0 && edges[eind - 1].dst != edges[eind].dst)){
 
         (*adj)[actual] = edges[eind].dst;


### PR DESCRIPTION
read_mtx() loads a list of (row,col) pairs, sorts them, and then inserts
into the CRS structure one row at a time. The loop over entries in the
current row only checked if the next entry matches the current row, but NOT
that the end of the pair array has been reached. This caused an invalid
read just after inserting the last entry in the matrix.