### PR TITLE
Cuda: disable compression in SPGEMM symbolic

### DIFF
--- a/src/sparse/impl/KokkosSparse_spgemm_impl_def.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_def.hpp
@@ -158,7 +158,14 @@ void KokkosSPGEMM
     //first get the max flops for a row, which will be used for max row size.
     //If we did compression in single step, row_mapB[i] points the begining of row i,
     //and new_row_mapB[i] points to the end of row i.
-    if (compression_applied){
+
+#ifdef KOKKOS_ENABLE_CUDA
+    //BMK 8-19-19: emergency bug workaround on CUDA (#402): disable compression
+    if (compression_applied && !std::is_same<MyExecSpace, Kokkos::Cuda>::value) {
+#else
+    if (compression_applied) {
+#endif
+    
 		nnz_lno_t maxNumRoughZeros = this->handle->get_spgemm_handle()->compressed_max_row_flops;
 
     	if (compress_in_single_step){


### PR DESCRIPTION
For SPGEMM_KK algorithm on CUDA, entry compression has a bug
(for some inputs, the row map from symbolic has too few entries per
row). This commit disables compression on CUDA as a workaround (other
ExecSpaces are not affected)