### PR TITLE
SpMV struct: fixing bug with intel/17.0.1

### DIFF
--- a/test_common/KokkosKernels_Test_Structured_Matrix.hpp
+++ b/test_common/KokkosKernels_Test_Structured_Matrix.hpp
@@ -1794,7 +1794,7 @@ namespace Test {
       values(rowOffset - 15) =  0.0;
       values(rowOffset - 14) = 32.0;
       values(rowOffset - 13) =  0.0;
-      values(rowOffset - 12) =  2.0;
+      values(rowOffset - 12) = -2.0;
       values(rowOffset - 11) =  0.0;
       values(rowOffset - 10) = -2.0;
       values(rowOffset -  9) = -1.0;


### PR DESCRIPTION
This issue was originally reported in PR #452 
After extensive testing and code modification, this appears to be a compiler optimization bug.
Currently running the spot_check to verify that nothing else got disturbed by the fix.