### PR TITLE
SpMV Struct performance and clean-up

### DIFF
--- a/perf_test/sparse/CMakeLists.txt
+++ b/perf_test/sparse/CMakeLists.txt
@@ -29,6 +29,11 @@ KOKKOSKERNELS_ADD_EXECUTABLE(
   )
 
 KOKKOSKERNELS_ADD_EXECUTABLE(
+  sparse_spmv_struct_tunning
+  SOURCES KokkosSparse_spmv_struct_tunning.cpp
+  )
+
+TRIBITS_ADD_EXECUTABLE(
   sparse_spmv
   SOURCES KokkosSparse_spmv.cpp
   )

--- a/perf_test/sparse/CMakeLists.txt
+++ b/perf_test/sparse/CMakeLists.txt
@@ -33,7 +33,7 @@ KOKKOSKERNELS_ADD_EXECUTABLE(
   SOURCES KokkosSparse_spmv_struct_tuning.cpp
   )
 
-TRIBITS_ADD_EXECUTABLE(
+KOKKOSKERNELS_ADD_EXECUTABLE(
   sparse_spmv
   SOURCES KokkosSparse_spmv.cpp
   )

--- a/perf_test/sparse/CMakeLists.txt
+++ b/perf_test/sparse/CMakeLists.txt
@@ -29,8 +29,8 @@ KOKKOSKERNELS_ADD_EXECUTABLE(
   )
 
 KOKKOSKERNELS_ADD_EXECUTABLE(
-  sparse_spmv_struct_tunning
-  SOURCES KokkosSparse_spmv_struct_tunning.cpp
+  sparse_spmv_struct_tuning
+  SOURCES KokkosSparse_spmv_struct_tuning.cpp
   )
 
 TRIBITS_ADD_EXECUTABLE(
@@ -40,7 +40,7 @@ TRIBITS_ADD_EXECUTABLE(
 
 KOKKOSKERNELS_ADD_EXECUTABLE(
   sparse_sptrsv
-  SOURCES KokkosSparse_sptrsv.cpp 
+  SOURCES KokkosSparse_sptrsv.cpp
   )
 
 KOKKOSKERNELS_ADD_EXECUTABLE(

--- a/perf_test/sparse/KokkosSparse_spmv_struct.cpp
+++ b/perf_test/sparse/KokkosSparse_spmv_struct.cpp
@@ -51,6 +51,8 @@
 #include <cmath>
 #include <unordered_map>
 
+#include <sstream>
+
 #include <Kokkos_Core.hpp>
 #include <KokkosSparse_spmv.hpp>
 #include <KokkosKernels_Test_Structured_Matrix.hpp>
@@ -114,7 +116,7 @@ int main(int argc, char **argv)
     return 0;
   }
 
-  for(int i=0;i<argc;i++)
+  for(int i = 0; i < argc; i++)
     {
       if((strcmp(argv[i],"-nx" )==0)) {nx=atoi(argv[++i]); continue;}
       if((strcmp(argv[i],"-ny" )==0)) {ny=atoi(argv[++i]); continue;}
@@ -234,11 +236,12 @@ int main(int argc, char **argv)
         for(int vecIdx = 0; vecIdx < numVecs; ++vecIdx) {
           h_y_compare(rowIdx, vecIdx) = 0;
         }
+
         for(int entryIdx = start; entryIdx < end; ++entryIdx) {
           // Scalar tmp_val = h_graph.entries(entryIdx) + i;
-          int idx = h_graph.entries(entryIdx);
+          int colIdx = h_graph.entries(entryIdx);
           for(int vecIdx = 0; vecIdx < numVecs; ++vecIdx) {
-            h_y_compare(rowIdx, vecIdx) += h_values(entryIdx)*h_x(idx, vecIdx);
+            h_y_compare(rowIdx, vecIdx) += h_values(entryIdx)*h_x(colIdx, vecIdx);
           }
         }
       }
@@ -249,7 +252,6 @@ int main(int argc, char **argv)
     Kokkos::View<Scalar**, Kokkos::LayoutLeft, Kokkos::DefaultExecutionSpace> x1("X1", A.numCols(), numVecs);
     Kokkos::View<Scalar**, Kokkos::LayoutLeft, Kokkos::DefaultExecutionSpace> y1("Y1", A.numRows(), numVecs);
     Kokkos::deep_copy(x1, h_x);
-    // typename KokkosSparse::CrsMatrix<Scalar,int,Kokkos::DefaultExecutionSpace,void,int>::values_type y1("Y1", A.numRows(), numVecs);
 
     {
       Kokkos::Profiling::pushRegion("Structured spmv test");
@@ -257,7 +259,7 @@ int main(int argc, char **argv)
       double min_time = 1.0e32;
       double max_time = 0.0;
       double ave_time = 0.0;
-      for(int i=0;i<loop;i++) {
+      for(int i=0; i<loop; i++) {
 	Kokkos::Timer timer;
 	KokkosSparse::Experimental::spmv_struct("N", stencil_type, structure, 1.0, A, x1, 1.0, y1);
 	Kokkos::fence();
@@ -314,7 +316,13 @@ int main(int argc, char **argv)
 
     if(check_errors) {
       // Error Check
-      Kokkos::deep_copy(h_y, y1);
+      Kokkos::View<Scalar**, Kokkos::LayoutLeft, Kokkos::DefaultExecutionSpace> x_check("X_check", A.numCols(), numVecs);
+      Kokkos::View<Scalar**, Kokkos::LayoutLeft, Kokkos::DefaultExecutionSpace> y_check("Y_check", A.numRows(), numVecs);
+      Kokkos::deep_copy(x_check, h_x);
+      KokkosSparse::Experimental::spmv_struct("N", stencil_type, structure, 1.0, A, x_check, 1.0, y_check);
+      Kokkos::fence();
+
+      Kokkos::deep_copy(h_y, y_check);
       Scalar error = 0;
       Scalar sum = 0;
       for(int rowIdx = 0; rowIdx < A.numRows(); ++rowIdx) {

--- a/perf_test/sparse/KokkosSparse_spmv_struct_tuning.cpp
+++ b/perf_test/sparse/KokkosSparse_spmv_struct_tuning.cpp
@@ -163,19 +163,16 @@ void struct_matvec(const int stencil_type,
 
   int64_t worksets_ext = (numInteriorPts + rows_per_team_ext - 1) / rows_per_team_ext;
 
-  KokkosSparse::Impl::SPMV_Struct_Functor<AMatrix,XVector,YVector,1,false> func(structure,
-                                                                                stencil_type,
-                                                                                alpha,A,x,beta,y,
-                                                                                rows_per_team_int,
-										rows_per_team_ext);
+  KokkosSparse::Impl::SPMV_Struct_Functor<AMatrix,XVector,YVector,1,false>
+    spmv_struct(structure, stencil_type, alpha,A,x,beta,y, rows_per_team_int, rows_per_team_ext);
 
   if(print_lp) {
     std::cout << "worksets=" << worksets_ext << ", team_size=" << team_size_ext
               << ", vector_length=" << vector_length << std::endl;
   }
 
-  func.compute_interior(worksets_int, team_size_int, vector_length);
-  func.compute_exterior(worksets_ext, team_size_ext, vector_length);
+  spmv_struct.compute_interior(worksets_int, team_size_int, vector_length);
+  spmv_struct.compute_exterior(worksets_ext, team_size_ext, vector_length);
 
 } // struct_matvec
 

--- a/perf_test/sparse/KokkosSparse_spmv_struct_tunning.cpp
+++ b/perf_test/sparse/KokkosSparse_spmv_struct_tunning.cpp
@@ -1,0 +1,570 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//               KokkosKernels 0.9: Linear Algebra and Graph Kernels
+//                 Copyright 2017 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <cstdio>
+
+#include <ctime>
+#include <cstring>
+#include <cstdlib>
+#include <limits>
+#include <limits.h>
+#include <cmath>
+#include <unordered_map>
+
+#include <sstream>
+
+#include <Kokkos_Core.hpp>
+#include <KokkosSparse_spmv.hpp>
+#include <KokkosKernels_Test_Structured_Matrix.hpp>
+#include <KokkosSparse_spmv_struct_impl.hpp>
+#include <KokkosSparse_spmv_impl.hpp>
+
+#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+#include <cusparse.h>
+#endif
+
+enum {STRUCT, UNSTR};
+
+#ifdef INT64
+typedef long long int LocalOrdinalType;
+#else
+typedef int LocalOrdinalType;
+#endif
+
+void print_help() {
+  printf("SPMV_struct benchmark code written by Luc Berger-Vergiat.\n");
+  printf("Options:\n");
+  printf("  --check-errors     : Determine if the result of spmv_struct is compared to serial unstructured spmv.\n");
+  printf("  --compare          : Compare results efficiency of spmv_struct and spmv.\n");
+  printf("  --compare-cusparse : Compare results efficiency of spmv_struct and cusparseDcsrmv.\n");
+  printf("  -l [LOOP]          : How many spmv to run to aggregate average time. \n");
+  printf("  -nx                : How many nodes in x direction. \n");
+  printf("  -ny                : How many nodes in y direction. \n");
+  printf("  -nz                : How many nodes in z direction. \n");
+  printf("  -st                : The stencil type used for discretization: 1 -> FD, 2 -> FE.\n");
+  printf("  -dim               : Number of spacial dimensions used in the problem: 1, 2 or 3\n");
+  printf("  -ws                : Worksets. \n");
+  printf("  -ts                : Team Size. \n");
+  printf("  -vl                : Vector length. \n");
+  printf("  -wsu               : Worksets for unstructured spmv. \n");
+  printf("  -tsu               : Team Size for unstructured spmv. \n");
+  printf("  -vlu               : Vector length for unstructured spmv. \n");
+  printf("  --print-lp         : Print launch parameters to screen.\n");
+}
+
+template<class AMatrix,
+         class XVector,
+         class YVector>
+void struct_matvec(const int stencil_type,
+                   const Kokkos::View<typename AMatrix::non_const_ordinal_type*, Kokkos::HostSpace>& structure,
+                   typename YVector::const_value_type& alpha,
+                   const AMatrix& A,
+                   const XVector& x,
+                   typename YVector::const_value_type& beta,
+                   const YVector& y,
+                   int team_size_int,
+                   int vector_length,
+                   int64_t rows_per_thread_int,
+		   const bool print_lp)
+{
+  typedef typename AMatrix::ordinal_type ordinal_type;
+  typedef typename AMatrix::execution_space execution_space;
+  if (A.numRows () <= static_cast<ordinal_type> (0)) {
+    return;
+  }
+
+  int nnzPerRow = -1;
+  int64_t numInteriorPts = 0;
+  int64_t numExteriorPts = 0;
+  int vector_length_default = 0;
+
+  if(structure.extent(0) == 1) {
+    numInteriorPts = structure(0) - 2;
+    numExteriorPts = 2;
+    vector_length_default = 1;
+  } else if(structure.extent(0) == 2) {
+    numInteriorPts = (structure(1) - 2)*(structure(0) - 2);
+    numExteriorPts = 2*(structure(1) + structure(0) - 2);
+    if(stencil_type == 1) {
+      vector_length_default = 2;
+    } else if(stencil_type == 2) {
+      vector_length_default = 4;
+    }
+  } else if(structure.extent(0) == 3) {
+    numInteriorPts = (structure(2) - 2)*(structure(1) - 2)*(structure(0) - 2);
+    numExteriorPts = structure(2)*structure(1)*structure(0) - numInteriorPts;
+    if(stencil_type == 1) {
+      vector_length_default = 2;
+    } else if(stencil_type == 2) {
+      vector_length_default = 8;
+    }
+  }
+  vector_length = (vector_length == -1 ? vector_length_default : vector_length);
+
+  int64_t rows_per_team_int = KokkosSparse::Impl::
+    spmv_struct_launch_parameters<execution_space>(numInteriorPts,
+                                                   A.nnz(),
+                                                   nnzPerRow,
+                                                   rows_per_thread_int,
+                                                   team_size_int,
+                                                   vector_length);
+
+  int64_t worksets_int = (numInteriorPts + rows_per_team_int - 1) / rows_per_team_int;
+
+  int rows_per_thread_ext = -1;
+  int team_size_ext = -1;
+  int64_t rows_per_team_ext = KokkosSparse::Impl::
+    spmv_struct_launch_parameters<execution_space>(numExteriorPts,
+                                                   A.nnz(),
+                                                   nnzPerRow,
+                                                   rows_per_thread_ext,
+                                                   team_size_ext,
+                                                   vector_length);
+
+  int64_t worksets_ext = (numInteriorPts + rows_per_team_ext - 1) / rows_per_team_ext;
+
+  KokkosSparse::Impl::SPMV_Struct_Functor<AMatrix,XVector,YVector,1,false> func(structure,
+                                                                                stencil_type,
+                                                                                alpha,A,x,beta,y,
+                                                                                rows_per_team_int,
+										rows_per_team_ext);
+
+  if(print_lp) {
+    std::cout << "worksets=" << worksets_ext << ", team_size=" << team_size_ext
+              << ", vector_length=" << vector_length << std::endl;
+  }
+
+  func.compute_interior(worksets_int, team_size_int, vector_length);
+  func.compute_exterior(worksets_ext, team_size_ext, vector_length);
+
+} // struct_matvec
+
+template<class AMatrix,
+         class XVector,
+         class YVector>
+void matvec(typename YVector::const_value_type& alpha,
+            const AMatrix& A,
+            const XVector& x,
+            typename YVector::const_value_type& beta,
+            const YVector& y,
+            int team_size,
+            int vector_length,
+            int64_t rows_per_thread,
+            const bool print_lp) {
+  typedef typename AMatrix::ordinal_type ordinal_type;
+  typedef typename AMatrix::execution_space execution_space;
+
+  if (A.numRows () <= static_cast<ordinal_type> (0)) {
+    return;
+  }
+
+  int64_t rows_per_team = KokkosSparse::Impl::spmv_launch_parameters<execution_space>(A.numRows(),
+                                                                                      A.nnz(),
+                                                                                      rows_per_thread,
+                                                                                      team_size,
+                                                                                      vector_length);
+  int64_t worksets = (y.extent(0) + rows_per_team-1) / rows_per_team;
+
+  KokkosSparse::Impl::SPMV_Functor<AMatrix,XVector,YVector,1,false> func (alpha,A,x,beta,y,rows_per_team);
+
+  if(print_lp) {
+    std::cout << "worksets=" << worksets << ", team_size=" << team_size << ", vector_length=" << vector_length << std::endl;
+  }
+
+  Kokkos::TeamPolicy<execution_space, Kokkos::Schedule<Kokkos::Static> > policy(1,1);
+  if(team_size == -1) {
+    policy = Kokkos::TeamPolicy<execution_space, Kokkos::Schedule<Kokkos::Static> >(worksets,Kokkos::AUTO,vector_length);
+  } else {
+    policy = Kokkos::TeamPolicy<execution_space, Kokkos::Schedule<Kokkos::Static> >(worksets,team_size,vector_length);
+  }
+  Kokkos::parallel_for("KokkosSparse::spmv<NoTranspose,Static>", policy, func);
+
+} // matvec
+
+int main(int argc, char **argv)
+{
+  typedef double Scalar;
+
+  int  nx = 100;
+  int  ny = 100;
+  int  nz = 100;
+  int  stencil_type = 1;
+  int  numDimensions = 2;
+  int  numVecs = 1;
+  bool check_errors = false;
+  bool compare = false;
+  bool compare_cusparse = false;
+  bool print_lp = false;
+  int  loop = 100;
+  int  vl  = -1;
+  int  ts  = -1;
+  int  ws  = -1;
+  int  vlu = -1;
+  int  tsu = -1;
+  int  wsu = -1;
+
+  if(argc == 1) {
+    print_help();
+    return 0;
+  }
+
+  for(int i = 0; i < argc; i++)
+    {
+      if((strcmp(argv[i],"-nx" )==0)) {nx=atoi(argv[++i]); continue;}
+      if((strcmp(argv[i],"-ny" )==0)) {ny=atoi(argv[++i]); continue;}
+      if((strcmp(argv[i],"-nz" )==0)) {nz=atoi(argv[++i]); continue;}
+      if((strcmp(argv[i],"-st" )==0)) {stencil_type=atoi(argv[++i]); continue;}
+      if((strcmp(argv[i],"-dim")==0)) {numDimensions=atoi(argv[++i]); continue;}
+      // if((strcmp(argv[i],"-mv" )==0)) {numVecs=atoi(argv[++i]); continue;}
+      if((strcmp(argv[i],"-l"  )==0)) {loop=atoi(argv[++i]); continue;}
+      if((strcmp(argv[i],"-vl" )==0)) {vl=atoi(argv[++i]); continue;}
+      if((strcmp(argv[i],"-ts" )==0)) {ts=atoi(argv[++i]); continue;}
+      if((strcmp(argv[i],"-ws" )==0)) {ws=atoi(argv[++i]); continue;}
+      if((strcmp(argv[i],"-vlu" )==0)) {vlu=atoi(argv[++i]); continue;}
+      if((strcmp(argv[i],"-tsu" )==0)) {tsu=atoi(argv[++i]); continue;}
+      if((strcmp(argv[i],"-wsu" )==0)) {wsu=atoi(argv[++i]); continue;}
+      if((strcmp(argv[i],"--check-errors")==0)) {check_errors=true; continue;}
+      if((strcmp(argv[i],"--compare")==0)) {compare=true; continue;}
+      if((strcmp(argv[i],"--compare-cusparse")==0)) {compare_cusparse=true; continue;}
+      if((strcmp(argv[i],"--print-lp")==0)) {print_lp=true; continue;}
+      if((strcmp(argv[i],"--help")==0) || (strcmp(argv[i],"-h")==0)) {
+        print_help();
+        return 0;
+      }
+    }
+
+  Kokkos::initialize(argc,argv);
+
+  {
+
+    using matrix_type = KokkosSparse::CrsMatrix<Scalar,int,Kokkos::DefaultExecutionSpace,void,int>;
+    using mv_type     = typename Kokkos::View<Scalar*,Kokkos::LayoutLeft>;
+    using h_mv_type   = typename mv_type::HostMirror;
+
+    int leftBC = 1, rightBC = 1, frontBC = 1, backBC = 1, bottomBC = 1, topBC = 1;
+
+    Kokkos::View<int*, Kokkos::HostSpace> structure("Spmv Structure", numDimensions);
+    Kokkos::View<int*[3], Kokkos::HostSpace> mat_structure("Matrix Structure", numDimensions);
+    if(numDimensions == 1) {
+      structure(0) = nx;
+      mat_structure(0, 0) = nx;
+    } else if(numDimensions == 2) {
+      structure(0) = nx;
+      structure(1) = ny;
+      mat_structure(0, 0) = nx;
+      mat_structure(1, 0) = ny;
+      if(leftBC   == 1) { mat_structure(0, 1) = 1; }
+      if(rightBC  == 1) { mat_structure(0, 2) = 1; }
+      if(bottomBC == 1) { mat_structure(1, 1) = 1; }
+      if(topBC    == 1) { mat_structure(1, 2) = 1; }
+    } else if(numDimensions == 3) {
+      structure(0) = nx;
+      structure(1) = ny;
+      structure(2) = nz;
+      mat_structure(0, 0) = nx;
+      mat_structure(1, 0) = ny;
+      mat_structure(2, 0) = nz;
+      if(leftBC   == 1) { mat_structure(0, 1) = 1; }
+      if(rightBC  == 1) { mat_structure(0, 2) = 1; }
+      if(frontBC  == 1) { mat_structure(1, 1) = 1; }
+      if(backBC   == 1) { mat_structure(1, 2) = 1; }
+      if(bottomBC == 1) { mat_structure(2, 1) = 1; }
+      if(topBC    == 1) { mat_structure(2, 2) = 1; }
+    }
+
+    std::string discrectization_stencil;
+    if(stencil_type == 1) {
+      discrectization_stencil = "FD";
+    } else if(stencil_type == 2) {
+      discrectization_stencil = "FE";
+    }
+
+    matrix_type A;
+    if(numDimensions == 1) {
+      A = Test::generate_structured_matrix1D<matrix_type>(mat_structure);
+    } else if(numDimensions == 2) {
+      A = Test::generate_structured_matrix2D<matrix_type>(discrectization_stencil,
+							  mat_structure);
+    } else if(numDimensions == 3) {
+      A = Test::generate_structured_matrix3D<matrix_type>(discrectization_stencil,
+							  mat_structure);
+    }
+
+    mv_type x("X", A.numCols());
+    // mv_random_read_type t_x(x);
+    mv_type y("Y", A.numRows());
+    h_mv_type h_x = Kokkos::create_mirror_view(x);
+    h_mv_type h_y = Kokkos::create_mirror_view(y);
+    h_mv_type h_y_compare;
+
+    for(int rowIdx = 0; rowIdx < A.numCols(); ++rowIdx) {
+      for(int vecIdx = 0; vecIdx < numVecs; ++vecIdx) {
+        h_x(rowIdx) = static_cast<Scalar>(1.0*(rand()%40)-20.0);
+        h_y(rowIdx) = static_cast<Scalar>(1.0*(rand()%40)-20.0);
+      }
+    }
+
+    if(check_errors) {
+      h_y_compare = Kokkos::create_mirror(y);
+      typename matrix_type::StaticCrsGraphType::HostMirror h_graph = Kokkos::create_mirror(A.graph);
+      typename matrix_type::values_type::HostMirror h_values = Kokkos::create_mirror_view(A.values);
+
+      // Error Check Gold Values
+      for(int rowIdx = 0; rowIdx < A.numRows(); ++rowIdx) {
+        int start = h_graph.row_map(rowIdx);
+        int end = h_graph.row_map(rowIdx + 1);
+
+        for(int vecIdx = 0; vecIdx < numVecs; ++vecIdx) {
+          h_y_compare(rowIdx) = 0;
+        }
+
+        for(int entryIdx = start; entryIdx < end; ++entryIdx) {
+          // Scalar tmp_val = h_graph.entries(entryIdx) + i;
+          int colIdx = h_graph.entries(entryIdx);
+          for(int vecIdx = 0; vecIdx < numVecs; ++vecIdx) {
+            h_y_compare(rowIdx) += h_values(entryIdx)*h_x(colIdx);
+          }
+        }
+      }
+    }
+
+    Kokkos::deep_copy(x, h_x);
+    Kokkos::deep_copy(y, h_y);
+    Kokkos::View<Scalar*, Kokkos::LayoutLeft, Kokkos::DefaultExecutionSpace> x1("X1", A.numCols());
+    Kokkos::View<Scalar*, Kokkos::LayoutLeft, Kokkos::DefaultExecutionSpace> y1("Y1", A.numRows());
+    Kokkos::deep_copy(x1, h_x);
+
+    printf("Type NNZ NumRows NumCols ProblemSize(MB) AveBandwidth(GB/s) MinBandwidth(GB/s) MaxBandwidth(GB/s) AveGFlop MinGFlop MaxGFlop aveTime(ms) maxTime(ms) minTime(ms)\n");
+    {
+      Kokkos::Profiling::pushRegion("Structured spmv test");
+      // Benchmark
+      bool print_lp_struct = print_lp;
+      double min_time = 1.0e32;
+      double max_time = 0.0;
+      double ave_time = 0.0;
+      for(int i=0; i<loop; i++) {
+	Kokkos::Timer timer;
+	struct_matvec(stencil_type, structure, 1.0, A, x1, 1.0, y1, ts, vl, ws, print_lp_struct);
+	Kokkos::fence();
+	print_lp_struct = false;
+	double time = timer.seconds();
+	ave_time += time;
+	if(time>max_time) max_time = time;
+	if(time<min_time) min_time = time;
+      }
+
+      // Performance Output
+      double matrix_size = 1.0*((A.nnz()*(sizeof(Scalar) + sizeof(int)) + A.numRows()*sizeof(int)))/1024/1024;
+      double struct_matrix_size = 1.0*((A.nnz()*sizeof(Scalar) + A.numRows()*sizeof(int)))/1024/1024;
+      double vector_size = 2.0*A.numRows()*sizeof(Scalar)/1024/1024;
+      double vector_readwrite = (A.nnz() + A.numCols())*sizeof(Scalar)/1024/1024;
+
+      double problem_size = matrix_size+vector_size;
+      printf("Struct %i %i %i %6.2lf ( %6.2lf %6.2lf %6.2lf ) ( %6.3lf %6.3lf %6.3lf ) ( %8.5lf %8.5lf %8.5lf )\n",
+	     A.nnz(), A.numRows(), A.numCols(), problem_size,
+	     (struct_matrix_size+vector_readwrite)/ave_time*loop/1024, (struct_matrix_size+vector_readwrite)/max_time/1024, (struct_matrix_size+vector_readwrite)/min_time/1024,
+	     2.0*A.nnz()*loop/ave_time/1e9, 2.0*A.nnz()/max_time/1e9, 2.0*A.nnz()/min_time/1e9,
+	     ave_time/loop*1000, max_time*1000, min_time*1000);
+      Kokkos::Profiling::popRegion();
+    }
+
+    if(compare) {
+      Kokkos::Profiling::pushRegion("Unstructured spmv test");
+      // Benchmark
+      bool print_lp_unstruct = print_lp;
+      double min_time = 1.0e32;
+      double max_time = 0.0;
+      double ave_time = 0.0;
+      for(int i=0 ;i<loop; i++) {
+	Kokkos::Timer timer;
+	matvec(1.0, A, x1, 1.0, y1, tsu, vlu, wsu, print_lp_unstruct);
+	Kokkos::fence();
+        print_lp_unstruct = false;
+	double time = timer.seconds();
+	ave_time += time;
+	if(time>max_time) max_time = time;
+	if(time<min_time) min_time = time;
+      }
+
+      // Performance Output
+      double matrix_size = 1.0*((A.nnz()*(sizeof(Scalar)+sizeof(int)) + A.numRows()*sizeof(int)))/1024/1024;
+      double vector_size = 2.0*A.numRows()*sizeof(Scalar)/1024/1024;
+      double vector_readwrite = (A.nnz() + A.numCols())*sizeof(Scalar)/1024/1024;
+
+      double problem_size = matrix_size+vector_size;
+      printf("Unstr  %i %i %i %6.2lf ( %6.2lf %6.2lf %6.2lf ) ( %6.3lf %6.3lf %6.3lf ) ( %8.5lf %8.5lf %8.5lf )\n",
+	     A.nnz(), A.numRows(),A.numCols(), problem_size,
+	     (matrix_size+vector_readwrite)/ave_time*loop/1024, (matrix_size+vector_readwrite)/max_time/1024,(matrix_size+vector_readwrite)/min_time/1024,
+	     2.0*A.nnz()*loop/ave_time/1e9, 2.0*A.nnz()/max_time/1e9, 2.0*A.nnz()/min_time/1e9,
+	     ave_time/loop*1000, max_time*1000, min_time*1000);
+      Kokkos::Profiling::popRegion();
+    }
+
+    if(compare_cusparse) {
+#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+      // The data needs to be reformatted for cusparse before launching the kernel.
+      // Step one, extract raw data
+      using graph_type = typename matrix_type::StaticCrsGraphType;
+      using cusparse_int_type = typename Kokkos::View<int*,
+						      typename graph_type::entries_type::array_layout,
+						      typename matrix_type::device_type>;
+
+      typename graph_type::row_map_type::const_type     Arowptr = A.graph.row_map;
+      typename graph_type::entries_type::const_type     Acolind = A.graph.entries;
+      typename matrix_type::values_type::non_const_type Avals   = A.values;
+      cusparse_int_type Arowptr_cusparse, Acolind_cusparse;
+      Arowptr_cusparse = cusparse_int_type("Arowptr", Arowptr.extent(0));
+      Acolind_cusparse = cusparse_int_type("Acolind", Acolind.extent(0));
+      Kokkos::parallel_for(Arowptr.extent(0), KOKKOS_LAMBDA(const size_t idx) {
+      	  Arowptr_cusparse[idx] = Arowptr[idx];
+      	});
+      Kokkos::parallel_for(Acolind.extent(0), KOKKOS_LAMBDA(const size_t idx) {
+      	  Acolind_cusparse[idx] = Acolind[idx];
+      	});
+
+      int*    rows = reinterpret_cast<int*>(Arowptr_cusparse.data());
+      int*    cols = reinterpret_cast<int*>(Acolind_cusparse.data());
+      double* vals = reinterpret_cast<double*>(Avals.data());
+      double* x_cusparse = reinterpret_cast<double*>(x1.data());
+      double* y_cusparse = reinterpret_cast<double*>(y1.data());
+
+      /* Get handle to the CUSPARSE context */
+      cusparseHandle_t cusparseHandle;
+      cusparseStatus_t cusparseStatus;
+      cusparseStatus = cusparseCreate(&cusparseHandle);
+      if(cusparseStatus != CUSPARSE_STATUS_SUCCESS) {
+	printf("Error while initialize the cusparse handle!\n");
+      }
+
+      cusparseMatDescr_t descrA = 0;
+      cusparseStatus = cusparseCreateMatDescr(&descrA);
+      if(cusparseStatus != CUSPARSE_STATUS_SUCCESS) {
+	printf("Error while creating the matrix descriptor!\n");
+      }
+
+      cusparseSetMatType(descrA,CUSPARSE_MATRIX_TYPE_GENERAL);
+      cusparseSetMatIndexBase(descrA,CUSPARSE_INDEX_BASE_ZERO);
+
+      const double alpha = 1.0;
+      const double beta  = 1.0;
+      Kokkos::Profiling::pushRegion("cuSparse spmv test");
+      // Benchmark
+      double min_time = 1.0e32;
+      double max_time = 0.0;
+      double ave_time = 0.0;
+      for(int i=0;i<loop;i++) {
+	Kokkos::Timer timer;
+	cusparseStatus = cusparseDcsrmv(cusparseHandle,
+					CUSPARSE_OPERATION_NON_TRANSPOSE,
+					static_cast<int>(A.numRows()),
+					static_cast<int>(A.numCols()),
+					static_cast<int>(A.nnz()),
+					&alpha,
+					descrA, vals, rows, cols,
+					x_cusparse, &beta, y_cusparse);
+	Kokkos::fence();
+	double time = timer.seconds();
+	ave_time += time;
+	if(time>max_time) max_time = time;
+	if(time<min_time) min_time = time;
+      }
+      if(cusparseStatus != CUSPARSE_STATUS_SUCCESS) {
+	printf("Error during the cusparse SpMV!\n");
+      }
+
+      // Performance Output
+      double matrix_size = 1.0*((A.nnz()*(sizeof(Scalar)+sizeof(int)) + A.numRows()*sizeof(int)))/1024/1024;
+      double vector_size = 2.0*A.numRows()*sizeof(Scalar)/1024/1024;
+      double vector_readwrite = (A.nnz() + A.numCols())*sizeof(Scalar)/1024/1024;
+
+      double problem_size = matrix_size+vector_size;
+      printf("cusp   %i %i %i %6.2lf ( %6.2lf %6.2lf %6.2lf ) ( %6.3lf %6.3lf %6.3lf ) ( %8.5lf %8.5lf %8.5lf )\n",
+	     A.nnz(), A.numRows(),A.numCols(), problem_size,
+	     (matrix_size+vector_readwrite)/ave_time*loop/1024, (matrix_size+vector_readwrite)/max_time/1024,(matrix_size+vector_readwrite)/min_time/1024,
+	     2.0*A.nnz()*loop/ave_time/1e9, 2.0*A.nnz()/max_time/1e9, 2.0*A.nnz()/min_time/1e9,
+	     ave_time/loop*1000, max_time*1000, min_time*1000);
+      Kokkos::Profiling::popRegion();
+
+      // Clean-up cusparse and cublas contexts
+      cusparseDestroy(cusparseHandle);
+      // cublasDestroy(cublasHandle);
+#else
+      printf("Kokkos was not configure with cusparse, the comparison with cusparse_matvec is not perfromed!\n");
+#endif
+    }
+
+    if(check_errors) {
+      // Error Check
+      Kokkos::View<Scalar*, Kokkos::LayoutLeft, Kokkos::DefaultExecutionSpace> x_check("X_check", A.numCols());
+      Kokkos::View<Scalar*, Kokkos::LayoutLeft, Kokkos::DefaultExecutionSpace> y_check("Y_check", A.numRows());
+      Kokkos::deep_copy(x_check, h_x);
+      KokkosSparse::Experimental::spmv_struct("N", stencil_type, structure, 1.0, A, x_check, 1.0, y_check);
+      Kokkos::fence();
+
+      Kokkos::deep_copy(h_y, y_check);
+      Scalar error = 0;
+      Scalar sum = 0;
+      for(int rowIdx = 0; rowIdx < A.numRows(); ++rowIdx) {
+        for(int vecIdx = 0; vecIdx < numVecs; ++vecIdx) {
+          error += (h_y_compare(rowIdx) - h_y(rowIdx))*(h_y_compare(rowIdx) - h_y(rowIdx));
+          sum += h_y_compare(rowIdx)*h_y_compare(rowIdx);
+        }
+      }
+
+      int num_errors = 0;
+      double total_error = 0;
+      double total_sum = 0;
+      num_errors += (error/(sum==0?1:sum))>1e-5?1:0;
+      total_error += error;
+      total_sum += sum;
+
+      if(total_error == 0) {
+	printf("Kokkos::MultiVector Test: Passed\n");
+      } else {
+	printf("Kokkos::MultiVector Test: Failed\n");
+      }
+    }
+
+  }
+  Kokkos::finalize();
+}

--- a/src/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
@@ -562,7 +562,7 @@ struct SPMV_Struct_Functor {
 
     const size_type rowOffset = m_A.graph.row_map(rowIdx);
     const ordinal_type row_length = static_cast<ordinal_type> (m_A.graph.row_map(rowIdx + 1) - rowOffset);
-    y_value_type_ sum = 0;
+    y_value_type sum = 0.0;
     for(ordinal_type idx = 0; idx < row_length; ++idx) {
       sum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
               *m_x(m_A.graph.entries(rowOffset + idx));

--- a/src/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
@@ -140,7 +140,7 @@ struct SPMV_Struct_Functor {
   typedef typename team_policy::member_type                  team_member;
   typedef Kokkos::Details::ArithTraits<value_type>           ATV;
   typedef Kokkos::View<ordinal_type*, scratch_space,
-		       Kokkos::MemoryTraits<Kokkos::Unmanaged> > shared_ordinal_1d;
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged> > shared_ordinal_1d;
   using y_value_type = typename YVector::non_const_value_type;
 
   // Tags to perform SPMV on interior and boundaries
@@ -169,14 +169,14 @@ struct SPMV_Struct_Functor {
   const int64_t rows_per_team_ext;
 
   SPMV_Struct_Functor (const Kokkos::View<ordinal_type*, Kokkos::HostSpace> structure_,
-		       const int stencil_type_,
+                       const int stencil_type_,
                        const y_value_type alpha_,
                        const AMatrix m_A_,
                        const XVector m_x_,
                        const y_value_type beta_,
                        const YVector m_y_,
                        const int64_t rows_per_team_,
-		       const int64_t rows_per_team_ext_) :
+                       const int64_t rows_per_team_ext_) :
     alpha (alpha_), m_A (m_A_), m_x (m_x_),
     beta (beta_), m_y (m_y_),
     stencil_type(stencil_type_),
@@ -213,10 +213,10 @@ struct SPMV_Struct_Functor {
                            Kokkos::Schedule<Kokkos::Static> > policy(1,1);
         if(team_size < 0) {
           policy = Kokkos::TeamPolicy<interior3ptTag, execution_space, Kokkos::Schedule<Kokkos::Static> >(worksets,Kokkos::AUTO,vector_length).
-	      set_scratch_size(0, Kokkos::PerTeam( shared_size ));
+              set_scratch_size(0, Kokkos::PerTeam( shared_size ));
         } else {
           policy = Kokkos::TeamPolicy<interior3ptTag, execution_space, Kokkos::Schedule<Kokkos::Static> >(worksets,team_size,vector_length).
-	      set_scratch_size(0, Kokkos::PerTeam( shared_size ));
+              set_scratch_size(0, Kokkos::PerTeam( shared_size ));
         }
         Kokkos::parallel_for("KokkosSparse::spmv_struct<NoTranspose,Static>: interior", policy, *this);
       }
@@ -226,29 +226,29 @@ struct SPMV_Struct_Functor {
       numInterior = (ni - 2)*(nj - 2);
       if(numInterior > 0) {
         if(stencil_type == 1) {
-	  size_t shared_size = shared_ordinal_1d::shmem_size(5);
+          size_t shared_size = shared_ordinal_1d::shmem_size(5);
           Kokkos::TeamPolicy<interior5ptTag,
                              execution_space,
                              Kokkos::Schedule<Kokkos::Static> > policy(1,1);
           if(team_size < 0) {
             policy = Kokkos::TeamPolicy<interior5ptTag, execution_space, Kokkos::Schedule<Kokkos::Static> >(worksets,Kokkos::AUTO,vector_length).
-	      set_scratch_size(0, Kokkos::PerTeam( shared_size ));
+              set_scratch_size(0, Kokkos::PerTeam( shared_size ));
           } else {
             policy = Kokkos::TeamPolicy<interior5ptTag, execution_space, Kokkos::Schedule<Kokkos::Static> >(worksets,team_size,vector_length).
-	      set_scratch_size(0, Kokkos::PerTeam( shared_size ));
+              set_scratch_size(0, Kokkos::PerTeam( shared_size ));
           }
           Kokkos::parallel_for("KokkosSparse::spmv_struct<NoTranspose,Static>: interior", policy, *this);
         } else if(stencil_type == 2) {
-	  size_t shared_size = shared_ordinal_1d::shmem_size(9);
+          size_t shared_size = shared_ordinal_1d::shmem_size(9);
           Kokkos::TeamPolicy<interior9ptTag,
                              execution_space,
                              Kokkos::Schedule<Kokkos::Static> > policy(1,1);
           if(team_size < 0) {
             policy = Kokkos::TeamPolicy<interior9ptTag, execution_space, Kokkos::Schedule<Kokkos::Static> >(worksets,Kokkos::AUTO,vector_length).
-	      set_scratch_size(0, Kokkos::PerTeam( shared_size ));
+              set_scratch_size(0, Kokkos::PerTeam( shared_size ));
           } else {
             policy = Kokkos::TeamPolicy<interior9ptTag, execution_space, Kokkos::Schedule<Kokkos::Static> >(worksets,team_size,vector_length).
-	      set_scratch_size(0, Kokkos::PerTeam( shared_size ));
+              set_scratch_size(0, Kokkos::PerTeam( shared_size ));
           }
           Kokkos::parallel_for("KokkosSparse::spmv_struct<NoTranspose,Static>: interior", policy, *this);
         }
@@ -259,29 +259,29 @@ struct SPMV_Struct_Functor {
       numInterior = (ni - 2)*(nj - 2)*(nk - 2);
       if(numInterior > 0) {
         if(stencil_type == 1) {
-	  size_t shared_size = shared_ordinal_1d::shmem_size(7);
+          size_t shared_size = shared_ordinal_1d::shmem_size(7);
           Kokkos::TeamPolicy<interior7ptTag,
                              execution_space,
                              Kokkos::Schedule<Kokkos::Static> > policy(1,1);
           if(team_size < 0) {
             policy = Kokkos::TeamPolicy<interior7ptTag, execution_space, Kokkos::Schedule<Kokkos::Static> >(worksets,Kokkos::AUTO,vector_length).
-	      set_scratch_size(0, Kokkos::PerTeam( shared_size ));
+              set_scratch_size(0, Kokkos::PerTeam( shared_size ));
           } else {
             policy = Kokkos::TeamPolicy<interior7ptTag, execution_space, Kokkos::Schedule<Kokkos::Static> >(worksets,team_size,vector_length).
-	      set_scratch_size(0, Kokkos::PerTeam( shared_size ));
+              set_scratch_size(0, Kokkos::PerTeam( shared_size ));
           }
           Kokkos::parallel_for("KokkosSparse::spmv_struct<NoTranspose,Static>: interior", policy, *this);
         } else if(stencil_type == 2) {
-	  size_t shared_size = shared_ordinal_1d::shmem_size(27);
+          size_t shared_size = shared_ordinal_1d::shmem_size(27);
           Kokkos::TeamPolicy<interior27ptTag,
                              execution_space,
                              Kokkos::Schedule<Kokkos::Static> > policy(1,1);
           if(team_size < 0) {
             policy = Kokkos::TeamPolicy<interior27ptTag, execution_space, Kokkos::Schedule<Kokkos::Static> >(worksets,Kokkos::AUTO,vector_length).
-	      set_scratch_size(0, Kokkos::PerTeam(shared_size));
+              set_scratch_size(0, Kokkos::PerTeam(shared_size));
           } else {
             policy = Kokkos::TeamPolicy<interior27ptTag, execution_space, Kokkos::Schedule<Kokkos::Static> >(worksets,team_size,vector_length).
-	      set_scratch_size(0, Kokkos::PerTeam(shared_size));
+              set_scratch_size(0, Kokkos::PerTeam(shared_size));
           }
           Kokkos::parallel_for("KokkosSparse::spmv_struct<NoTranspose,Static>: interior", policy, *this);
         }
@@ -295,9 +295,9 @@ struct SPMV_Struct_Functor {
     // Allocate and initialize columnOffsets array for the team
     shared_ordinal_1d columnOffsets(dev.team_scratch(0), 3);
     Kokkos::single(Kokkos::PerTeam(dev), [&] () {
-    	columnOffsets(0) = -1;
-    	columnOffsets(1) = 0;
-    	columnOffsets(2) = 1;
+        columnOffsets(0) = -1;
+        columnOffsets(1) = 0;
+        columnOffsets(2) = 1;
       });
     dev.team_barrier();
 
@@ -309,15 +309,15 @@ struct SPMV_Struct_Functor {
         rowIdx = interiorIdx + 1;
 
         const size_type rowOffset = m_A.graph.row_map(rowIdx);
-	y_value_type sum = 0.0;
-	Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, 3), [&] (const ordinal_type& idx, y_value_type& lclSum) {
-	    lclSum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
-	      *m_x(rowIdx + columnOffsets(idx));
-	  }, sum);
+        y_value_type sum = 0.0;
+        Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, 3), [&] (const ordinal_type& idx, y_value_type& lclSum) {
+            lclSum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
+              *m_x(rowIdx + columnOffsets(idx));
+          }, sum);
 
-	Kokkos::single(Kokkos::PerThread(dev), [&] () {
-	    m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
-	  });
+        Kokkos::single(Kokkos::PerThread(dev), [&] () {
+            m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
+          });
       });
   }
 
@@ -327,11 +327,11 @@ struct SPMV_Struct_Functor {
     // Allocate and initialize columnOffsets array for the team
     shared_ordinal_1d columnOffsets(dev.team_scratch(0), 5);
     Kokkos::single(Kokkos::PerTeam(dev), [&] () {
-    	columnOffsets(0) = -ni;
-    	columnOffsets(1) = -1;
-    	columnOffsets(2) = 0;
-    	columnOffsets(3) = 1;
-    	columnOffsets(4) = ni;
+        columnOffsets(0) = -ni;
+        columnOffsets(1) = -1;
+        columnOffsets(2) = 0;
+        columnOffsets(3) = 1;
+        columnOffsets(4) = ni;
       });
     dev.team_barrier();
 
@@ -345,15 +345,15 @@ struct SPMV_Struct_Functor {
         rowIdx = (j + 1)*ni + i + 1;
 
         const size_type   rowOffset = m_A.graph.row_map(rowIdx);
-	y_value_type sum = 0.0;
-	Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, 5), [&] (const ordinal_type& idx, y_value_type& lclSum) {
-	    lclSum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
-	      *m_x(rowIdx + columnOffsets(idx));
-	  }, sum);
+        y_value_type sum = 0.0;
+        Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, 5), [&] (const ordinal_type& idx, y_value_type& lclSum) {
+            lclSum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
+              *m_x(rowIdx + columnOffsets(idx));
+          }, sum);
 
-	Kokkos::single(Kokkos::PerThread(dev), [&] () {
-	    m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
-	  });
+        Kokkos::single(Kokkos::PerThread(dev), [&] () {
+            m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
+          });
       });
   }
 
@@ -363,15 +363,15 @@ struct SPMV_Struct_Functor {
     // Allocate and initialize columnOffsets array for the team
     shared_ordinal_1d columnOffsets(dev.team_scratch(0), 9);
     Kokkos::single(Kokkos::PerTeam(dev), [&] () {
-    	columnOffsets(0) = -ni - 1;
-    	columnOffsets(1) = -ni;
-    	columnOffsets(2) = -ni + 1;
-    	columnOffsets(3) = -1;
-    	columnOffsets(4) = 0;
-    	columnOffsets(5) = 1;
-	columnOffsets(6) = ni - 1;
-	columnOffsets(7) = ni;
-	columnOffsets(8) = ni + 1;
+        columnOffsets(0) = -ni - 1;
+        columnOffsets(1) = -ni;
+        columnOffsets(2) = -ni + 1;
+        columnOffsets(3) = -1;
+        columnOffsets(4) = 0;
+        columnOffsets(5) = 1;
+        columnOffsets(6) = ni - 1;
+        columnOffsets(7) = ni;
+        columnOffsets(8) = ni + 1;
       });
     dev.team_barrier();
 
@@ -385,15 +385,15 @@ struct SPMV_Struct_Functor {
         rowIdx = (j + 1)*ni + i + 1;
 
         const size_type rowOffset = m_A.graph.row_map(rowIdx);
-	y_value_type sum = 0.0;
-	Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, 9), [&] (const ordinal_type& idx, y_value_type& lclSum) {
-	    lclSum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
-	      *m_x(rowIdx + columnOffsets(idx));
-	  }, sum);
+        y_value_type sum = 0.0;
+        Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, 9), [&] (const ordinal_type& idx, y_value_type& lclSum) {
+            lclSum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
+              *m_x(rowIdx + columnOffsets(idx));
+          }, sum);
 
-	Kokkos::single(Kokkos::PerThread(dev), [&] () {
-	    m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
-	  });
+        Kokkos::single(Kokkos::PerThread(dev), [&] () {
+            m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
+          });
       });
   }
 
@@ -403,13 +403,13 @@ struct SPMV_Struct_Functor {
     // Allocate and initialize columnOffsets array for the team
     shared_ordinal_1d columnOffsets(dev.team_scratch(0), 7);
     Kokkos::single(Kokkos::PerTeam(dev), [&] () {
-    	columnOffsets(0) = -ni*nj;
-    	columnOffsets(1) = -ni;
-    	columnOffsets(2) = -1;
-    	columnOffsets(3) = 0;
-    	columnOffsets(4) = 1;
-    	columnOffsets(5) = ni;
-	columnOffsets(6) = ni*nj;
+        columnOffsets(0) = -ni*nj;
+        columnOffsets(1) = -ni;
+        columnOffsets(2) = -1;
+        columnOffsets(3) = 0;
+        columnOffsets(4) = 1;
+        columnOffsets(5) = ni;
+        columnOffsets(6) = ni*nj;
       });
     dev.team_barrier();
 
@@ -425,15 +425,15 @@ struct SPMV_Struct_Functor {
         rowIdx = (k + 1)*nj*ni + (j + 1)*ni + (i + 1);
 
         const size_type rowOffset = m_A.graph.row_map(rowIdx);
-	y_value_type sum = 0.0;
-	Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, 7), [&] (const ordinal_type& idx, y_value_type& lclSum) {
-	    lclSum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
-	      *m_x(rowIdx + columnOffsets(idx));
-	  }, sum);
+        y_value_type sum = 0.0;
+        Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, 7), [&] (const ordinal_type& idx, y_value_type& lclSum) {
+            lclSum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
+              *m_x(rowIdx + columnOffsets(idx));
+          }, sum);
 
-	Kokkos::single(Kokkos::PerThread(dev), [&] () {
-	    m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
-	  });
+        Kokkos::single(Kokkos::PerThread(dev), [&] () {
+            m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
+          });
       });
   }
 
@@ -443,39 +443,39 @@ struct SPMV_Struct_Functor {
     // Allocate and initialize columnOffsets array for the team
     shared_ordinal_1d columnOffsets(dev.team_scratch(0), 27);
     Kokkos::single(Kokkos::PerTeam(dev), [&] () {
-    	columnOffsets(0)  = -ni*nj - ni - 1;
-    	columnOffsets(1)  = -ni*nj - ni;
-    	columnOffsets(2)  = -ni*nj - ni + 1;
-    	columnOffsets(3)  = -ni*nj - 1;
-    	columnOffsets(4)  = -ni*nj;
-    	columnOffsets(5)  = -ni*nj + 1;
-    	columnOffsets(6)  = -ni*nj + ni - 1;
-    	columnOffsets(7)  = -ni*nj + ni;
-    	columnOffsets(8)  = -ni*nj + ni + 1;
-    	columnOffsets(9)  = -ni - 1;
-    	columnOffsets(10) = -ni;
-    	columnOffsets(11) = -ni + 1;
-    	columnOffsets(12) = -1;
-    	columnOffsets(13) = 0;
-    	columnOffsets(14) = 1;
-    	columnOffsets(15) = ni - 1;
-    	columnOffsets(16) = ni;
-    	columnOffsets(17) = ni + 1;
-    	columnOffsets(18) = ni*nj - ni - 1;
-    	columnOffsets(19) = ni*nj - ni;
-    	columnOffsets(20) = ni*nj - ni + 1;
-    	columnOffsets(21) = ni*nj - 1;
-    	columnOffsets(22) = ni*nj;
-    	columnOffsets(23) = ni*nj + 1;
-    	columnOffsets(24) = ni*nj + ni - 1;
-    	columnOffsets(25) = ni*nj + ni;
-    	columnOffsets(26) = ni*nj + ni + 1;
+        columnOffsets(0)  = -ni*nj - ni - 1;
+        columnOffsets(1)  = -ni*nj - ni;
+        columnOffsets(2)  = -ni*nj - ni + 1;
+        columnOffsets(3)  = -ni*nj - 1;
+        columnOffsets(4)  = -ni*nj;
+        columnOffsets(5)  = -ni*nj + 1;
+        columnOffsets(6)  = -ni*nj + ni - 1;
+        columnOffsets(7)  = -ni*nj + ni;
+        columnOffsets(8)  = -ni*nj + ni + 1;
+        columnOffsets(9)  = -ni - 1;
+        columnOffsets(10) = -ni;
+        columnOffsets(11) = -ni + 1;
+        columnOffsets(12) = -1;
+        columnOffsets(13) = 0;
+        columnOffsets(14) = 1;
+        columnOffsets(15) = ni - 1;
+        columnOffsets(16) = ni;
+        columnOffsets(17) = ni + 1;
+        columnOffsets(18) = ni*nj - ni - 1;
+        columnOffsets(19) = ni*nj - ni;
+        columnOffsets(20) = ni*nj - ni + 1;
+        columnOffsets(21) = ni*nj - 1;
+        columnOffsets(22) = ni*nj;
+        columnOffsets(23) = ni*nj + 1;
+        columnOffsets(24) = ni*nj + ni - 1;
+        columnOffsets(25) = ni*nj + ni;
+        columnOffsets(26) = ni*nj + ni + 1;
       });
     dev.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(dev, 0, rows_per_team), [&] (const ordinal_type& loop) {
         const ordinal_type interiorIdx = static_cast<ordinal_type> ( dev.league_rank() ) * rows_per_team + loop;
-	if(interiorIdx >= numInterior) { return; }
+        if(interiorIdx >= numInterior) { return; }
 
         ordinal_type i, j, k, rowIdx, rem;
         k = interiorIdx / ((ni - 2)*(nj - 2));
@@ -486,21 +486,21 @@ struct SPMV_Struct_Functor {
 
         const size_type rowOffset = m_A.graph.row_map(rowIdx);
 
-	y_value_type sum(0.0);
+        y_value_type sum(0.0);
 #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
         for (ordinal_type idx = 0; idx < 27; ++idx) {
          sum += m_A.values(rowOffset + idx)*m_x(rowIdx + columnOffsets(idx));
         }
 #else
-	Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, 27), [&] (const ordinal_type& idx, y_value_type& lclSum) {
-	    lclSum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
-	      *m_x(rowIdx + columnOffsets(idx));
+        Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, 27), [&] (const ordinal_type& idx, y_value_type& lclSum) {
+            lclSum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
+              *m_x(rowIdx + columnOffsets(idx));
         }, sum);
 #endif
 
-	Kokkos::single(Kokkos::PerThread(dev), [&] () {
-	    m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
-	  });
+        Kokkos::single(Kokkos::PerThread(dev), [&] () {
+            m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
+          });
       });
   }
 
@@ -537,8 +537,8 @@ struct SPMV_Struct_Functor {
       numExterior = ni*nj*nk - (ni - 2)*(nj - 2)*(nk - 2);
       if(numExterior > 0) {
         Kokkos::TeamPolicy<exterior3DTag,
-			   execution_space,
-			   Kokkos::Schedule<Kokkos::Static> > policy(1, 1);
+                           execution_space,
+                           Kokkos::Schedule<Kokkos::Static> > policy(1, 1);
         if(team_size < 0) {
           policy = Kokkos::TeamPolicy<exterior3DTag,
                                       execution_space,
@@ -565,7 +565,7 @@ struct SPMV_Struct_Functor {
     y_value_type_ sum = 0;
     for(ordinal_type idx = 0; idx < row_length; ++idx) {
       sum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
-	      *m_x(m_A.graph.entries(rowOffset + idx));
+              *m_x(m_A.graph.entries(rowOffset + idx));
     }
     m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
   }
@@ -594,14 +594,14 @@ struct SPMV_Struct_Functor {
         const size_type rowOffset = m_A.graph.row_map(rowIdx);
         const ordinal_type row_length = static_cast<ordinal_type> (m_A.graph.row_map(rowIdx + 1) - rowOffset);
         y_value_type sum = 0;
-	Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, row_length),
+        Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, row_length),
                                 [&] (const ordinal_type& idx, y_value_type& lclSum) {
                                   lclSum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
-				    *m_x(m_A.graph.entries(rowOffset + idx));
+                                    *m_x(m_A.graph.entries(rowOffset + idx));
                                 }, sum);
-	Kokkos::single(Kokkos::PerThread(dev), [&] () {
-	    m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
-	  });
+        Kokkos::single(Kokkos::PerThread(dev), [&] () {
+            m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
+          });
       });
   }
 
@@ -611,46 +611,46 @@ struct SPMV_Struct_Functor {
     Kokkos::parallel_for(Kokkos::TeamThreadRange(dev, 0, rows_per_team_ext), [&] (const ordinal_type& loop){
         const ordinal_type exteriorIdx = static_cast<ordinal_type> ( dev.league_rank() ) * rows_per_team_ext + loop;
         if(exteriorIdx >= numExterior) { return; }
-	const ordinal_type topFlag = static_cast<ordinal_type>(numExterior - exteriorIdx - 1 < ni*nj);
-	const ordinal_type bottomFlag = static_cast<ordinal_type>(exteriorIdx / (ni*nj) == 0);
+        const ordinal_type topFlag = static_cast<ordinal_type>(numExterior - exteriorIdx - 1 < ni*nj);
+        const ordinal_type bottomFlag = static_cast<ordinal_type>(exteriorIdx / (ni*nj) == 0);
 
-	ordinal_type rowIdx = 0;
-	if(bottomFlag == 1) {
-	  rowIdx = exteriorIdx;
-	} else if(topFlag == 1) {
-	  rowIdx = exteriorIdx - ni*nj - 2*(nk - 2)*(nj + ni - 2) + (nk - 1)*ni*nj;
-	} else {
-	  ordinal_type k, rem;
-	  k = (exteriorIdx - ni*nj) / (2*(ni - 1 + nj - 1));
-	  rem = (exteriorIdx - ni*nj) % (2*(ni - 1 + nj - 1));
-	  // ordinal_type frontFlg = static_cast<ordinal_type>(rem < ni);
-	  // ordinal_type backFlg = static_cast<ordinal_type>(rem - ni - 2*(nj - 1) - 1 > 0);
-	  if(rem < ni) {
-	    rowIdx = (k + 1)*ni*nj + rem;
-	  } else if(rem < ni + 2*(nj - 2)) {
-	    ordinal_type edgeIdx = (rem - ni) / 2;
-	    ordinal_type edgeFlg = (rem - ni) % 2;
-	    if(edgeFlg == 0) {
-	      rowIdx = (k + 1)*ni*nj + (edgeIdx + 1)*ni;
-	    } else if(edgeFlg == 1) {
-	      rowIdx = (k + 1)*ni*nj + (edgeIdx + 2)*ni - 1;
-	    }
-	  } else {
-	    rowIdx = (k + 1)*ni*nj + rem - ni - 2*(nj - 2) + (nj - 1)*ni;
-	  }
-	}
+        ordinal_type rowIdx = 0;
+        if(bottomFlag == 1) {
+          rowIdx = exteriorIdx;
+        } else if(topFlag == 1) {
+          rowIdx = exteriorIdx - ni*nj - 2*(nk - 2)*(nj + ni - 2) + (nk - 1)*ni*nj;
+        } else {
+          ordinal_type k, rem;
+          k = (exteriorIdx - ni*nj) / (2*(ni - 1 + nj - 1));
+          rem = (exteriorIdx - ni*nj) % (2*(ni - 1 + nj - 1));
+          // ordinal_type frontFlg = static_cast<ordinal_type>(rem < ni);
+          // ordinal_type backFlg = static_cast<ordinal_type>(rem - ni - 2*(nj - 1) - 1 > 0);
+          if(rem < ni) {
+            rowIdx = (k + 1)*ni*nj + rem;
+          } else if(rem < ni + 2*(nj - 2)) {
+            ordinal_type edgeIdx = (rem - ni) / 2;
+            ordinal_type edgeFlg = (rem - ni) % 2;
+            if(edgeFlg == 0) {
+              rowIdx = (k + 1)*ni*nj + (edgeIdx + 1)*ni;
+            } else if(edgeFlg == 1) {
+              rowIdx = (k + 1)*ni*nj + (edgeIdx + 2)*ni - 1;
+            }
+          } else {
+            rowIdx = (k + 1)*ni*nj + rem - ni - 2*(nj - 2) + (nj - 1)*ni;
+          }
+        }
 
-	const size_type rowOffset = m_A.graph.row_map(rowIdx);
-	const ordinal_type row_length = static_cast<ordinal_type> (m_A.graph.row_map(rowIdx + 1) - rowOffset);
-	y_value_type sum = 0;
-	Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, row_length),
+        const size_type rowOffset = m_A.graph.row_map(rowIdx);
+        const ordinal_type row_length = static_cast<ordinal_type> (m_A.graph.row_map(rowIdx + 1) - rowOffset);
+        y_value_type sum = 0;
+        Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, row_length),
                                 [&] (const ordinal_type& idx, y_value_type& lclSum) {
                                   lclSum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
-				    *m_x(m_A.graph.entries(rowOffset + idx));
+                                    *m_x(m_A.graph.entries(rowOffset + idx));
                                 }, sum);
-	Kokkos::single(Kokkos::PerThread(dev), [&] () {
-	    m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
-	  });
+        Kokkos::single(Kokkos::PerThread(dev), [&] () {
+            m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
+          });
       });
   }
 }; // SPMV_Struct_Functor
@@ -766,19 +766,11 @@ spmv_struct_beta_no_transpose (const int stencil_type,
                                                                              vector_length);
   int64_t worksets_exterior = (numExteriorPts + rows_per_team_ext - 1) / rows_per_team_ext;
 
-  // std::cout << "worksets=" << worksets
-  //           << ", rows_per_team=" << rows_per_team
-  //           << ", team_size=" << team_size
-  //           << ",  vector_length=" << vector_length << std::endl;
+  SPMV_Struct_Functor<AMatrix,XVector,YVector,dobeta,conjugate>
+    spmv_struct(structure, stencil_type, alpha,A,x,beta,y, rows_per_team_int, rows_per_team_ext);
 
-  SPMV_Struct_Functor<AMatrix,XVector,YVector,dobeta,conjugate> func(structure,
-								     stencil_type,
-								     alpha,A,x,beta,y,
-								     rows_per_team_int,
-								     rows_per_team_ext);
-
-  func.compute_interior(worksets_interior, team_size_int, vector_length);
-  func.compute_exterior(worksets_exterior, team_size_ext, vector_length);
+  spmv_struct.compute_interior(worksets_interior, team_size_int, vector_length);
+  spmv_struct.compute_exterior(worksets_exterior, team_size_ext, vector_length);
 } // spmv_struct_beta_no_transpose
 
 template<class AMatrix,

--- a/src/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
@@ -154,10 +154,10 @@ struct SPMV_Struct_Functor {
   struct exterior3DTag{};
 
   // Classic spmv params
-  const value_type alpha;
+  const y_value_type alpha;
   AMatrix  m_A;
   XVector m_x;
-  const value_type beta;
+  const y_value_type beta;
   YVector m_y;
 
   // Additional structured spmv params
@@ -166,19 +166,22 @@ struct SPMV_Struct_Functor {
   const int stencil_type;
   ordinal_type numInterior, numExterior;
   const int64_t rows_per_team;
+  const int64_t rows_per_team_ext;
 
   SPMV_Struct_Functor (const Kokkos::View<ordinal_type*, Kokkos::HostSpace> structure_,
 		       const int stencil_type_,
-                       const value_type alpha_,
+                       const y_value_type alpha_,
                        const AMatrix m_A_,
                        const XVector m_x_,
-                       const value_type beta_,
+                       const y_value_type beta_,
                        const YVector m_y_,
-                       const int64_t rows_per_team_) :
+                       const int64_t rows_per_team_,
+		       const int64_t rows_per_team_ext_) :
     alpha (alpha_), m_A (m_A_), m_x (m_x_),
     beta (beta_), m_y (m_y_),
     stencil_type(stencil_type_),
-    rows_per_team (rows_per_team_)
+    rows_per_team (rows_per_team_),
+    rows_per_team_ext (rows_per_team_ext_)
   {
     static_assert (static_cast<int> (XVector::rank) == 1,
                    "XVector must be a rank 1 View.");
@@ -198,7 +201,7 @@ struct SPMV_Struct_Functor {
     }
   }
 
-  void compute(const int64_t worksets, const int team_size, const int vector_length) {
+  void compute_interior(const int64_t worksets, const int team_size, const int vector_length) {
 
     if(numDimensions == 1) {
       // Treat interior points using structured algorithm
@@ -216,15 +219,6 @@ struct SPMV_Struct_Functor {
 	      set_scratch_size(0, Kokkos::PerTeam( shared_size ));
         }
         Kokkos::parallel_for("KokkosSparse::spmv_struct<NoTranspose,Static>: interior", policy, *this);
-      }
-
-      // Treat exterior points using unstructured algorithm
-      numExterior = 2;
-      if(numExterior > 0) {
-        Kokkos::RangePolicy<exterior1DTag,
-                            execution_space,
-                            Kokkos::Schedule<Kokkos::Static> > policy(0, numExterior);
-        Kokkos::parallel_for("KokkosSparse::spmv_struct<NoTranspose,Static>: exterior", policy, *this);
       }
 
     } else if(numDimensions == 2) {
@@ -248,26 +242,18 @@ struct SPMV_Struct_Functor {
 	  size_t shared_size = shared_ordinal_1d::shmem_size(9);
           Kokkos::TeamPolicy<interior9ptTag,
                              execution_space,
-                             Kokkos::Schedule<Kokkos::Dynamic> > policy(1,1);
+                             Kokkos::Schedule<Kokkos::Static> > policy(1,1);
           if(team_size < 0) {
-            policy = Kokkos::TeamPolicy<interior9ptTag, execution_space, Kokkos::Schedule<Kokkos::Dynamic> >(worksets,Kokkos::AUTO,vector_length).
+            policy = Kokkos::TeamPolicy<interior9ptTag, execution_space, Kokkos::Schedule<Kokkos::Static> >(worksets,Kokkos::AUTO,vector_length).
 	      set_scratch_size(0, Kokkos::PerTeam( shared_size ));
           } else {
-            policy = Kokkos::TeamPolicy<interior9ptTag, execution_space, Kokkos::Schedule<Kokkos::Dynamic> >(worksets,team_size,vector_length).
+            policy = Kokkos::TeamPolicy<interior9ptTag, execution_space, Kokkos::Schedule<Kokkos::Static> >(worksets,team_size,vector_length).
 	      set_scratch_size(0, Kokkos::PerTeam( shared_size ));
           }
           Kokkos::parallel_for("KokkosSparse::spmv_struct<NoTranspose,Static>: interior", policy, *this);
         }
       }
 
-      // Treat exterior points using unstructured algorithm
-      numExterior = ni*nj - numInterior;
-      if(numExterior > 0) {
-        Kokkos::RangePolicy<exterior2DTag,
-                            execution_space,
-                            Kokkos::Schedule<Kokkos::Static> > policy(0, numExterior);
-        Kokkos::parallel_for("KokkosSparse::spmv_struct<NoTranspose,Static>: exterior", policy, *this);
-      }
     } else if(numDimensions == 3) {
       // Treat interior points using structured algorithm
       numInterior = (ni - 2)*(nj - 2)*(nk - 2);
@@ -289,28 +275,19 @@ struct SPMV_Struct_Functor {
 	  size_t shared_size = shared_ordinal_1d::shmem_size(27);
           Kokkos::TeamPolicy<interior27ptTag,
                              execution_space,
-                             Kokkos::Schedule<Kokkos::Dynamic> > policy(1,1);
+                             Kokkos::Schedule<Kokkos::Static> > policy(1,1);
           if(team_size < 0) {
-            policy = Kokkos::TeamPolicy<interior27ptTag, execution_space, Kokkos::Schedule<Kokkos::Dynamic> >(worksets,Kokkos::AUTO,vector_length).
+            policy = Kokkos::TeamPolicy<interior27ptTag, execution_space, Kokkos::Schedule<Kokkos::Static> >(worksets,Kokkos::AUTO,vector_length).
 	      set_scratch_size(0, Kokkos::PerTeam(shared_size));
           } else {
-            policy = Kokkos::TeamPolicy<interior27ptTag, execution_space, Kokkos::Schedule<Kokkos::Dynamic> >(worksets,team_size,vector_length).
+            policy = Kokkos::TeamPolicy<interior27ptTag, execution_space, Kokkos::Schedule<Kokkos::Static> >(worksets,team_size,vector_length).
 	      set_scratch_size(0, Kokkos::PerTeam(shared_size));
           }
           Kokkos::parallel_for("KokkosSparse::spmv_struct<NoTranspose,Static>: interior", policy, *this);
         }
       }
-
-      // Treat exterior points using unstructured algorithm
-      numExterior = ni*nj*nk - numInterior;
-      if(numExterior > 0) {
-        Kokkos::RangePolicy<exterior3DTag,
-                            execution_space,
-                            Kokkos::Schedule<Kokkos::Static> > policy(0, numExterior);
-        Kokkos::parallel_for("KokkosSparse::spmv_struct<NoTranspose,Static>: exterior", policy, *this);
-      }
     }
-  }
+  } // compute_interior
 
   KOKKOS_INLINE_FUNCTION
   void operator() (const interior3ptTag&, const team_member& dev) const
@@ -332,10 +309,10 @@ struct SPMV_Struct_Functor {
         rowIdx = interiorIdx + 1;
 
         const size_type rowOffset = m_A.graph.row_map(rowIdx);
-        const value_type* value_ptr = m_A.values.data() + rowOffset;
-	value_type sum = 0.0;
-	Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, 3), [&] (const ordinal_type& idx, value_type& lclSum) {
-	    lclSum += *(value_ptr + idx)*m_x(rowIdx + columnOffsets(idx));
+	y_value_type sum = 0.0;
+	Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, 3), [&] (const ordinal_type& idx, y_value_type& lclSum) {
+	    lclSum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
+	      *m_x(rowIdx + columnOffsets(idx));
 	  }, sum);
 
 	Kokkos::single(Kokkos::PerThread(dev), [&] () {
@@ -367,11 +344,11 @@ struct SPMV_Struct_Functor {
         i = interiorIdx % (ni - 2);
         rowIdx = (j + 1)*ni + i + 1;
 
-        const size_type rowOffset = m_A.graph.row_map(rowIdx);
-        const value_type* value_ptr = m_A.values.data() + rowOffset;
-	value_type sum = 0.0;
-	Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, 5), [&] (const ordinal_type& idx, value_type& lclSum) {
-	    lclSum += *(value_ptr + idx)*m_x(rowIdx + columnOffsets(idx));
+        const size_type   rowOffset = m_A.graph.row_map(rowIdx);
+	y_value_type sum = 0.0;
+	Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, 5), [&] (const ordinal_type& idx, y_value_type& lclSum) {
+	    lclSum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
+	      *m_x(rowIdx + columnOffsets(idx));
 	  }, sum);
 
 	Kokkos::single(Kokkos::PerThread(dev), [&] () {
@@ -408,10 +385,10 @@ struct SPMV_Struct_Functor {
         rowIdx = (j + 1)*ni + i + 1;
 
         const size_type rowOffset = m_A.graph.row_map(rowIdx);
-        const value_type* value_ptr = &(m_A.values(rowOffset));
-	value_type sum = 0.0;
-	Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, 9), [&] (const ordinal_type& idx, value_type& lclSum) {
-	    lclSum += *(value_ptr + idx)*m_x(rowIdx + columnOffsets(idx));
+	y_value_type sum = 0.0;
+	Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, 9), [&] (const ordinal_type& idx, y_value_type& lclSum) {
+	    lclSum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
+	      *m_x(rowIdx + columnOffsets(idx));
 	  }, sum);
 
 	Kokkos::single(Kokkos::PerThread(dev), [&] () {
@@ -448,10 +425,10 @@ struct SPMV_Struct_Functor {
         rowIdx = (k + 1)*nj*ni + (j + 1)*ni + (i + 1);
 
         const size_type rowOffset = m_A.graph.row_map(rowIdx);
-        const value_type* value_ptr = &(m_A.values(rowOffset));
-	value_type sum = 0.0;
-	Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, 7), [&] (const ordinal_type& idx, value_type& lclSum) {
-	    lclSum += *(value_ptr + idx)*m_x(rowIdx + columnOffsets(idx));
+	y_value_type sum = 0.0;
+	Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, 7), [&] (const ordinal_type& idx, y_value_type& lclSum) {
+	    lclSum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
+	      *m_x(rowIdx + columnOffsets(idx));
 	  }, sum);
 
 	Kokkos::single(Kokkos::PerThread(dev), [&] () {
@@ -498,7 +475,7 @@ struct SPMV_Struct_Functor {
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(dev, 0, rows_per_team), [&] (const ordinal_type& loop) {
         const ordinal_type interiorIdx = static_cast<ordinal_type> ( dev.league_rank() ) * rows_per_team + loop;
-        if(interiorIdx >= numInterior) { return; }
+	if(interiorIdx >= numInterior) { return; }
 
         ordinal_type i, j, k, rowIdx, rem;
         k = interiorIdx / ((ni - 2)*(nj - 2));
@@ -515,9 +492,9 @@ struct SPMV_Struct_Functor {
          sum += m_A.values(rowOffset + idx)*m_x(rowIdx + columnOffsets(idx));
         }
 #else
-        const value_type* value_ptr = &(m_A.values(rowOffset));
 	Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, 27), [&] (const ordinal_type& idx, y_value_type& lclSum) {
-          lclSum += *(value_ptr + idx)*m_x(rowIdx + columnOffsets(idx));
+	    lclSum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
+	      *m_x(rowIdx + columnOffsets(idx));
         }, sum);
 #endif
 
@@ -527,98 +504,156 @@ struct SPMV_Struct_Functor {
       });
   }
 
+  void compute_exterior(const int64_t worksets, const int team_size, const int vector_length) {
+    // Treat exterior points using unstructured algorithm
+    if(numDimensions == 1) {
+      numExterior = 2;
+      if(numExterior > 0) {
+        Kokkos::RangePolicy<exterior1DTag,
+                            execution_space,
+                            Kokkos::Schedule<Kokkos::Static> > policy(0, numExterior);
+        Kokkos::parallel_for("KokkosSparse::spmv_struct<NoTranspose,Static>: exterior", policy, *this);
+      }
+
+    } else if(numDimensions == 2) {
+      numExterior = 2*(nj + ni - 2);
+      if(numExterior > 0) {
+        Kokkos::TeamPolicy<exterior2DTag,
+                           execution_space,
+                           Kokkos::Schedule<Kokkos::Static> > policy(1, 1);
+        if(team_size < 0) {
+          policy = Kokkos::TeamPolicy<exterior2DTag,
+                                      execution_space,
+                                      Kokkos::Schedule<Kokkos::Static> >(worksets,Kokkos::AUTO,vector_length);
+        } else {
+          policy = Kokkos::TeamPolicy<exterior2DTag,
+                                      execution_space,
+                                      Kokkos::Schedule<Kokkos::Static> >(worksets,team_size,vector_length);
+        }
+        Kokkos::parallel_for("KokkosSparse::spmv_struct<NoTranspose,Static>: exterior", policy, *this);
+      }
+
+    } else if(numDimensions == 3) {
+      numExterior = ni*nj*nk - (ni - 2)*(nj - 2)*(nk - 2);
+      if(numExterior > 0) {
+        Kokkos::TeamPolicy<exterior3DTag,
+			   execution_space,
+			   Kokkos::Schedule<Kokkos::Static> > policy(1, 1);
+        if(team_size < 0) {
+          policy = Kokkos::TeamPolicy<exterior3DTag,
+                                      execution_space,
+                                      Kokkos::Schedule<Kokkos::Static> >(worksets,Kokkos::AUTO,vector_length);
+        } else {
+          policy = Kokkos::TeamPolicy<exterior3DTag,
+                                      execution_space,
+                                      Kokkos::Schedule<Kokkos::Static> >(worksets,team_size,vector_length);
+        }
+
+        Kokkos::parallel_for("KokkosSparse::spmv_struct<NoTranspose,Static>: exterior", policy, *this);
+      }
+    }
+  } // compute_exterior
+
   KOKKOS_INLINE_FUNCTION
   void operator() (const exterior1DTag&, const ordinal_type& exteriorIdx) const
   {
-    typedef typename YVector::non_const_value_type y_value_type_;
-
+    if(exteriorIdx >= numExterior) { return; }
     ordinal_type rowIdx = exteriorIdx*(ni - 1);
 
     const size_type rowOffset = m_A.graph.row_map(rowIdx);
     const ordinal_type row_length = static_cast<ordinal_type> (m_A.graph.row_map(rowIdx + 1) - rowOffset);
-    const value_type* value_ptr = &(m_A.values(rowOffset));
-    const ordinal_type* column_ptr = &(m_A.graph.entries(rowOffset));
     y_value_type_ sum = 0;
-    for(ordinal_type entryIdx = 0; entryIdx < row_length; ++entryIdx) {
-      sum += (*(value_ptr + entryIdx))*m_x(*(column_ptr + entryIdx));
+    for(ordinal_type idx = 0; idx < row_length; ++idx) {
+      sum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
+	      *m_x(m_A.graph.entries(rowOffset + idx));
     }
     m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator() (const exterior2DTag&, const ordinal_type& exteriorIdx) const
+  void operator() (const exterior2DTag&, const team_member& dev) const
   {
-    typedef typename YVector::non_const_value_type y_value_type_;
-    const ordinal_type topFlag = exteriorIdx / (ni + 2*nj - 4);
-    const ordinal_type bottomFlag = static_cast<ordinal_type>((exteriorIdx / ni) == 0);
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(dev, 0, rows_per_team_ext), [&] (const ordinal_type& loop){
+        const ordinal_type exteriorIdx = static_cast<ordinal_type> ( dev.league_rank() ) * rows_per_team_ext + loop;
+        if(exteriorIdx >= numExterior) { return; }
+        const ordinal_type topFlag = exteriorIdx / (ni + 2*nj - 4);
+        const ordinal_type bottomFlag = static_cast<ordinal_type>((exteriorIdx / ni) == 0);
 
-    ordinal_type rowIdx = 0;
-    if(bottomFlag == 1) {
-      rowIdx = exteriorIdx;
-    } else if(topFlag == 1) {
-      rowIdx = exteriorIdx - (ni + 2*nj - 4)
-        + ni*(nj - 1);
-    } else {
-      ordinal_type edgeIdx = (exteriorIdx - ni) / 2;
-      ordinal_type edgeFlg = (exteriorIdx - ni) % 2;
-      rowIdx = (edgeIdx + 1)*ni + edgeFlg*(ni - 1);
-    }
-
-    const size_type rowOffset = m_A.graph.row_map(rowIdx);
-    const ordinal_type row_length = static_cast<ordinal_type> (m_A.graph.row_map(rowIdx + 1) - rowOffset);
-    const value_type* value_ptr = &(m_A.values(rowOffset));
-    const ordinal_type* column_ptr = &(m_A.graph.entries(rowOffset));
-    y_value_type_ sum = 0;
-    for(ordinal_type entryIdx = 0; entryIdx < row_length; ++entryIdx) {
-      sum += (*(value_ptr + entryIdx))*m_x(*(column_ptr + entryIdx));
-    }
-    m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (const exterior3DTag&, const ordinal_type& exteriorIdx) const
-  {
-    typedef typename YVector::non_const_value_type y_value_type_;
-    const ordinal_type topFlag = static_cast<ordinal_type>(numExterior - exteriorIdx - 1 < ni*nj);
-    const ordinal_type bottomFlag = static_cast<ordinal_type>(exteriorIdx / (ni*nj) == 0);
-
-    ordinal_type rowIdx = 0;
-    if(bottomFlag == 1) {
-      rowIdx = exteriorIdx;
-    } else if(topFlag == 1) {
-      rowIdx = exteriorIdx - ni*nj - 2*(nk - 2)*(nj + ni - 2) + (nk - 1)*ni*nj;
-    } else {
-      ordinal_type k, rem;
-      k = (exteriorIdx - ni*nj) / (2*(ni - 1 + nj - 1));
-      rem = (exteriorIdx - ni*nj) % (2*(ni - 1 + nj - 1));
-      // ordinal_type frontFlg = static_cast<ordinal_type>(rem < ni);
-      // ordinal_type backFlg = static_cast<ordinal_type>(rem - ni - 2*(nj - 1) - 1 > 0);
-      if(rem < ni) {
-        rowIdx = (k + 1)*ni*nj + rem;
-      } else if(rem < ni + 2*(nj - 2)) {
-        ordinal_type edgeIdx = (rem - ni) / 2;
-        ordinal_type edgeFlg = (rem - ni) % 2;
-        if(edgeFlg == 0) {
-          rowIdx = (k + 1)*ni*nj + (edgeIdx + 1)*ni;
-        } else if(edgeFlg == 1) {
-          rowIdx = (k + 1)*ni*nj + (edgeIdx + 2)*ni - 1;
+        ordinal_type rowIdx = 0;
+        if(bottomFlag == 1) {
+          rowIdx = exteriorIdx;
+        } else if(topFlag == 1) {
+          rowIdx = exteriorIdx - (ni + 2*nj - 4)
+            + ni*(nj - 1);
+        } else {
+          ordinal_type edgeIdx = (exteriorIdx - ni) / 2;
+          ordinal_type edgeFlg = (exteriorIdx - ni) % 2;
+          rowIdx = (edgeIdx + 1)*ni + edgeFlg*(ni - 1);
         }
-      } else {
-        rowIdx = (k + 1)*ni*nj + rem - ni - 2*(nj - 2) + (nj - 1)*ni;
-      }
-    }
 
-    const size_type rowOffset = m_A.graph.row_map(rowIdx);
-    const ordinal_type row_length = static_cast<ordinal_type> (m_A.graph.row_map(rowIdx + 1) - rowOffset);
-    const value_type* value_ptr = &(m_A.values(rowOffset));
-    const ordinal_type* column_ptr = &(m_A.graph.entries(rowOffset));
-    y_value_type_ sum = 0;
-    for(ordinal_type entryIdx = 0; entryIdx < row_length; ++entryIdx) {
-      sum += (*(value_ptr + entryIdx))*m_x(*(column_ptr + entryIdx));
-    }
-    m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
+        const size_type rowOffset = m_A.graph.row_map(rowIdx);
+        const ordinal_type row_length = static_cast<ordinal_type> (m_A.graph.row_map(rowIdx + 1) - rowOffset);
+        y_value_type sum = 0;
+	Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, row_length),
+                                [&] (const ordinal_type& idx, y_value_type& lclSum) {
+                                  lclSum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
+				    *m_x(m_A.graph.entries(rowOffset + idx));
+                                }, sum);
+	Kokkos::single(Kokkos::PerThread(dev), [&] () {
+	    m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
+	  });
+      });
   }
-};
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (const exterior3DTag&, const team_member& dev) const
+  {
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(dev, 0, rows_per_team_ext), [&] (const ordinal_type& loop){
+        const ordinal_type exteriorIdx = static_cast<ordinal_type> ( dev.league_rank() ) * rows_per_team_ext + loop;
+        if(exteriorIdx >= numExterior) { return; }
+	const ordinal_type topFlag = static_cast<ordinal_type>(numExterior - exteriorIdx - 1 < ni*nj);
+	const ordinal_type bottomFlag = static_cast<ordinal_type>(exteriorIdx / (ni*nj) == 0);
+
+	ordinal_type rowIdx = 0;
+	if(bottomFlag == 1) {
+	  rowIdx = exteriorIdx;
+	} else if(topFlag == 1) {
+	  rowIdx = exteriorIdx - ni*nj - 2*(nk - 2)*(nj + ni - 2) + (nk - 1)*ni*nj;
+	} else {
+	  ordinal_type k, rem;
+	  k = (exteriorIdx - ni*nj) / (2*(ni - 1 + nj - 1));
+	  rem = (exteriorIdx - ni*nj) % (2*(ni - 1 + nj - 1));
+	  // ordinal_type frontFlg = static_cast<ordinal_type>(rem < ni);
+	  // ordinal_type backFlg = static_cast<ordinal_type>(rem - ni - 2*(nj - 1) - 1 > 0);
+	  if(rem < ni) {
+	    rowIdx = (k + 1)*ni*nj + rem;
+	  } else if(rem < ni + 2*(nj - 2)) {
+	    ordinal_type edgeIdx = (rem - ni) / 2;
+	    ordinal_type edgeFlg = (rem - ni) % 2;
+	    if(edgeFlg == 0) {
+	      rowIdx = (k + 1)*ni*nj + (edgeIdx + 1)*ni;
+	    } else if(edgeFlg == 1) {
+	      rowIdx = (k + 1)*ni*nj + (edgeIdx + 2)*ni - 1;
+	    }
+	  } else {
+	    rowIdx = (k + 1)*ni*nj + rem - ni - 2*(nj - 2) + (nj - 1)*ni;
+	  }
+	}
+
+	const size_type rowOffset = m_A.graph.row_map(rowIdx);
+	const ordinal_type row_length = static_cast<ordinal_type> (m_A.graph.row_map(rowIdx + 1) - rowOffset);
+	y_value_type sum = 0;
+	Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(dev, row_length),
+                                [&] (const ordinal_type& idx, y_value_type& lclSum) {
+                                  lclSum += (conjugate ? ATV::conj(m_A.values(rowOffset + idx)) : m_A.values(rowOffset + idx))
+				    *m_x(m_A.graph.entries(rowOffset + idx));
+                                }, sum);
+	Kokkos::single(Kokkos::PerThread(dev), [&] () {
+	    m_y(rowIdx) = beta*m_y(rowIdx) + alpha*sum;
+	  });
+      });
+  }
+}; // SPMV_Struct_Functor
 
 template<class execution_space>
 int64_t spmv_struct_launch_parameters(int64_t numInterior, int64_t nnz, int nnz_per_row,
@@ -645,7 +680,7 @@ int64_t spmv_struct_launch_parameters(int64_t numInterior, int64_t nnz, int nnz_
   #ifdef KOKKOS_ENABLE_CUDA
   if(team_size < 1) {
     if(std::is_same<Kokkos::Cuda,execution_space>::value)
-    { team_size = 256/vector_length; }
+    { team_size = 128 / vector_length; }
     else
     { team_size = 1; }
   }
@@ -662,7 +697,7 @@ int64_t spmv_struct_launch_parameters(int64_t numInterior, int64_t nnz, int nnz_
 
 
   return rows_per_team;
-}
+} // spmv_struct_launch_parameters
 
 template<class AMatrix,
          class XVector,
@@ -684,24 +719,30 @@ spmv_struct_beta_no_transpose (const int stencil_type,
     return;
   }
 
-  int team_size = -1;
   int vector_length = -1;
   int nnzPerRow = -1;
-  int64_t rows_per_thread = -1;
+  int team_size_int = -1;
+  int team_size_ext = -1;
+  int64_t rows_per_thread_int = -1;
+  int64_t rows_per_thread_ext = -1;
   int64_t numInteriorPts = 0;
+  int64_t numExteriorPts = 0;
 
   if(structure.extent(0) == 1) {
     numInteriorPts = structure(0) - 2;
+    numExteriorPts = 2;
     vector_length = 1;
   } else if(structure.extent(0) == 2) {
     numInteriorPts = (structure(1) - 2)*(structure(0) - 2);
+    numExteriorPts = 2*(structure(1) + structure(0) - 2);
     if(stencil_type == 1) {
       vector_length = 2;
     } else if(stencil_type == 2) {
-      vector_length = 4;
+      vector_length = 2;
     }
   } else if(structure.extent(0) == 3) {
     numInteriorPts = (structure(2) - 2)*(structure(1) - 2)*(structure(0) - 2);
+    numExteriorPts = structure(2)*structure(1)*structure(0) - numInteriorPts;
     if(stencil_type == 1) {
       vector_length = 2;
     } else if(stencil_type == 2) {
@@ -709,13 +750,21 @@ spmv_struct_beta_no_transpose (const int stencil_type,
     }
   }
 
-  int64_t rows_per_team = spmv_struct_launch_parameters<execution_space>(numInteriorPts,
-                                                                         A.nnz(),
-                                                                         nnzPerRow,
-                                                                         rows_per_thread,
-                                                                         team_size,
-                                                                         vector_length);
-  int64_t worksets = (numInteriorPts + rows_per_team - 1) / rows_per_team;
+  int64_t rows_per_team_int = spmv_struct_launch_parameters<execution_space>(numInteriorPts,
+                                                                             A.nnz(),
+                                                                             nnzPerRow,
+                                                                             rows_per_thread_int,
+                                                                             team_size_int,
+                                                                             vector_length);
+  int64_t worksets_interior = (numInteriorPts + rows_per_team_int - 1) / rows_per_team_int;
+
+  int64_t rows_per_team_ext = spmv_struct_launch_parameters<execution_space>(numExteriorPts,
+                                                                             A.nnz(),
+                                                                             nnzPerRow,
+                                                                             rows_per_thread_ext,
+                                                                             team_size_ext,
+                                                                             vector_length);
+  int64_t worksets_exterior = (numExteriorPts + rows_per_team_ext - 1) / rows_per_team_ext;
 
   // std::cout << "worksets=" << worksets
   //           << ", rows_per_team=" << rows_per_team
@@ -725,10 +774,12 @@ spmv_struct_beta_no_transpose (const int stencil_type,
   SPMV_Struct_Functor<AMatrix,XVector,YVector,dobeta,conjugate> func(structure,
 								     stencil_type,
 								     alpha,A,x,beta,y,
-								     rows_per_team);
+								     rows_per_team_int,
+								     rows_per_team_ext);
 
-  func.compute(worksets, team_size, vector_length);
-}
+  func.compute_interior(worksets_interior, team_size_int, vector_length);
+  func.compute_exterior(worksets_exterior, team_size_ext, vector_length);
+} // spmv_struct_beta_no_transpose
 
 template<class AMatrix,
          class XVector,

--- a/unit_test/sparse/Test_Sparse_spmv.hpp
+++ b/unit_test/sparse/Test_Sparse_spmv.hpp
@@ -15,7 +15,7 @@
 
 namespace Test {
 
-template < class VectorType0, class VectorType1 >
+  template < class VectorType0, class VectorType1 >
 struct fSPMV {
   using value_type = int;
   using AT         = Kokkos::ArithTraits<typename VectorType1::non_const_value_type>;
@@ -184,19 +184,17 @@ void check_spmv_struct(const crsMat_t input_mat,
                        y_vector_type y,
                        typename y_vector_type::non_const_value_type alpha,
                        typename y_vector_type::non_const_value_type beta) {
-  using ExecSpace     = typename crsMat_t::execution_space;
-  using scalar_view_t = typename crsMat_t::values_type::non_const_type;
-  using ScalarA       = typename scalar_view_t::value_type;
-  using my_exec_space = Kokkos::RangePolicy<ExecSpace>;
-    using y_value_type     = typename y_vector_type::non_const_value_type;
-    using y_value_trait    = Kokkos::ArithTraits<y_value_type>;
-    using y_value_mag_type = typename y_value_trait::mag_type;
+  using ExecSpace        = typename crsMat_t::execution_space;
+  using my_exec_space    = Kokkos::RangePolicy<ExecSpace>;
+  using y_value_type     = typename y_vector_type::non_const_value_type;
+  using y_value_trait    = Kokkos::ArithTraits<y_value_type>;
+  using y_value_mag_type = typename y_value_trait::mag_type;
 
-  double eps = std::is_same<ScalarA,float>::value ? 2*1e-3 : 1e-7;
-  size_t nr = input_mat.numRows();
-    // the appropriate tolerance precision.
-    const double eps = std::is_same<y_value_mag_type, float>::value ? 2*1e-3 : 1e-7;
-    const size_t nr = input_mat.numRows();
+  // y is the quantity being tested here,
+  // so let us use y_value_type to determine
+  // the appropriate tolerance precision.
+  const double eps = std::is_same<y_value_mag_type, float>::value ? 2*1e-3 : 1e-7;
+  const size_t nr = input_mat.numRows();
   y_vector_type expected_y("expected", nr);
   Kokkos::deep_copy(expected_y, y);
   Kokkos::fence();
@@ -208,12 +206,11 @@ void check_spmv_struct(const crsMat_t input_mat,
   int num_errors = 0;
   Kokkos::parallel_reduce("KokkosKernels::UnitTests::spmv_struct",
                           my_exec_space(0, y.extent(0)),
-                          fSPMV<y_vector_type, y_vector_type, y_vector_type>(expected_y,y,eps),
+                          fSPMV<y_vector_type, y_vector_type>(expected_y,y,eps),
                           num_errors);
-  typedef Kokkos::Details::ArithTraits<typename y_vector_type::non_const_value_type> AT;
   if(num_errors>0) printf("KokkosKernels::UnitTests::spmv_struct: %i errors of %i with params: %d %lf %lf\n",
-                          num_errors, y.extent_int(0), stencil_type, AT::abs(alpha), AT::abs(beta));
-                            y_value_trait::abs(alpha), y_value_trait::abs(beta));
+                          num_errors, y.extent_int(0), stencil_type,
+                          y_value_trait::abs(alpha), y_value_trait::abs(beta));
   EXPECT_TRUE(num_errors==0);
 } // check_spmv_struct
 
@@ -229,18 +226,16 @@ void check_spmv_mv_struct(const crsMat_t input_mat,
                           typename y_vector_type::non_const_value_type alpha,
                           typename y_vector_type::non_const_value_type beta,
                           int numMV) {
-  typedef typename crsMat_t::execution_space ExecSpace;
-  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
-  typedef typename scalar_view_t::value_type ScalarA;
-  typedef Kokkos::RangePolicy<ExecSpace> my_exec_space;
-    using y_value_type     = typename y_vector_type::non_const_value_type;
-    using y_value_trait    = Kokkos::ArithTraits<y_value_type>;
-    using y_value_mag_type = typename y_value_trait::mag_type;
+  using ExecSpace        = typename crsMat_t::execution_space;
+  using my_exec_space    = Kokkos::RangePolicy<ExecSpace>;
+  using y_value_type     = typename y_vector_type::non_const_value_type;
+  using y_value_trait    = Kokkos::ArithTraits<y_value_type>;
+  using y_value_mag_type = typename y_value_trait::mag_type;
 
-  double eps = std::is_same<ScalarA,float>::value?2*1e-3:1e-7;
-    // so let us use y_value_type to determine
-    // the appropriate tolerance precision.
-    const double eps = std::is_same<y_value_mag_type, float>::value ? 2*1e-3 : 1e-7;
+  // y is the quantity being tested here,
+  // so let us use y_value_type to determine
+  // the appropriate tolerance precision.
+  const double eps = std::is_same<y_value_mag_type, float>::value ? 2*1e-3 : 1e-7;
   Kokkos::deep_copy(expected_y, y);
   Kokkos::fence();
 
@@ -258,12 +253,11 @@ void check_spmv_mv_struct(const crsMat_t input_mat,
     int num_errors = 0;
     Kokkos::parallel_reduce("KokkosKernels::UnitTests::spmv_mv_struct",
                             my_exec_space(0, y.extent(0)),
-                            fSPMV<decltype(y_i), decltype(y_spmv), y_vector_type>(y_i,y_spmv,eps),
+                            fSPMV<decltype(y_i), decltype(y_spmv)>(y_i,y_spmv,eps),
                             num_errors);
-    typedef Kokkos::Details::ArithTraits<typename y_vector_type::non_const_value_type> AT;
     if(num_errors>0) printf("KokkosKernels::UnitTests::spmv_mv_struct: %i errors of %i with params: %d %lf %lf, in vector %i\n",
-                            num_errors, y.extent_int(0), stencil_type, AT::abs(alpha), AT::abs(beta), vectorIdx);
-                              y_value_trait::abs(alpha), y_value_trait::abs(beta), vectorIdx);
+                            num_errors, y.extent_int(0), stencil_type,
+                            y_value_trait::abs(alpha), y_value_trait::abs(beta), vectorIdx);
     EXPECT_TRUE(num_errors==0);
   }
 } // check_spmv_mv_struct

--- a/unit_test/sparse/Test_Sparse_spmv.hpp
+++ b/unit_test/sparse/Test_Sparse_spmv.hpp
@@ -667,9 +667,9 @@ TEST_F( TestCategory,sparse ## _ ## spmv_mv ## _ ## SCALAR ## _ ## ORDINAL ## _ 
 #define EXECUTE_TEST_STRUCT(SCALAR, ORDINAL, OFFSET, DEVICE) \
 TEST_F( TestCategory,sparse ## _ ## spmv_struct ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
   test_spmv_struct_1D<SCALAR,ORDINAL,OFFSET,DEVICE> (10, 1, 1);            \
-  test_spmv_struct_2D<SCALAR,ORDINAL,OFFSET,DEVICE> (250, 200, 3, 3);      \
+  test_spmv_struct_2D<SCALAR,ORDINAL,OFFSET,DEVICE> (250, 201, 3, 3);      \
   test_spmv_struct_2D<SCALAR,ORDINAL,OFFSET,DEVICE> (200, 250, 3, 3);      \
-  test_spmv_struct_2D<SCALAR,ORDINAL,OFFSET,DEVICE> (250, 250, 3, 3);      \
+  test_spmv_struct_2D<SCALAR,ORDINAL,OFFSET,DEVICE> (251, 251, 3, 3);      \
   test_spmv_struct_3D<SCALAR,ORDINAL,OFFSET,DEVICE> (30, 30, 30, 3, 3, 3); \
   test_spmv_struct_3D<SCALAR,ORDINAL,OFFSET,DEVICE> (40, 40, 40, 3, 3, 3); \
   test_spmv_struct_3D<SCALAR,ORDINAL,OFFSET,DEVICE> (25, 40, 50, 3, 3, 3); \


### PR DESCRIPTION
I'm adding a slightly modified heuristic that improves performance of the SpMV struct algorithm.
I also cleaned up the code, removing some pointer arithmetic where it does not help performance.
Finally I improved correctness by using appropriate types for temporary variables (should allow mix-arithmetic to work correctly).
Finally I also fixed an omission regarding the complex conjugate mode.

The spot_check is currently running on white, bowman and kokkos-dev, I'll post results when everything is clean.