### PR TITLE
Sorting utilities

### DIFF
--- a/src/common/KokkosKernels_Sorting.hpp
+++ b/src/common/KokkosKernels_Sorting.hpp
@@ -1,0 +1,232 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//               KokkosKernels 0.9: Linear Algebra and Graph Kernels
+//                 Copyright 2017 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+#ifndef _KOKKOSKERNELS_SORTING_HPP
+#define _KOKKOSKERNELS_SORTING_HPP
+#include "Kokkos_Core.hpp"
+#include "Kokkos_Atomic.hpp"
+#include "Kokkos_ArithTraits.hpp"
+#include "impl/Kokkos_Timer.hpp"
+#include <type_traits>
+
+namespace KokkosKernels {
+namespace Impl {
+
+//Radix sort for nonnegative integers, on a single thread within a team.
+//Pros: few diverging branches, so good for sorting on a single GPU thread/warp.
+//Con: requires auxiliary storage, this version only works for integers (although float/double is possible)
+template<typename Ordinal, typename ValueType, typename Thread>
+KOKKOS_INLINE_FUNCTION static void
+radixSortThread(ValueType* values, ValueType* valuesAux, Ordinal n, const Thread& thread)
+{
+  static_assert(std::is_integral<ValueType>::value, "radixSort can only be run on integers.");
+  if(n <= 1)
+    return;
+  //sort 4 bits at a time, into 16 buckets
+  ValueType mask = 0xF;
+  //Is the data currently held in values (false) or valuesAux (true)?
+  bool inAux = false;
+  //maskPos counts the low bit index of mask (0, 4, 8, ...)
+  Ordinal maskPos = 0;
+  Ordinal sortBits = 0;
+  ValueType minVal = Kokkos::ArithTraits<ValueType>::max();
+  ValueType maxVal = 0;
+  Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(thread, n),
+  [=](Ordinal i, ValueType& lminval)
+  {
+    if(values[i] < lminval)
+      lminval = values[i];
+  }, Kokkos::Min<ValueType>(minVal));
+  Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(thread, n),
+  [=](Ordinal i, ValueType& lmaxval)
+  {
+    if(values[i] > lmaxkey)
+      lmaxkey = values[i];
+  }, Kokkos::Max<ValueType>(maxVal));
+  //apply a bias so that key range always starts at 0
+  //also invert key values here for a descending sort
+  Kokkos::parallel_for(Kokkos::ThreadVectorRange(thread, n),
+  [=](Ordinal i)
+  {
+    values[i] -= minVal;
+  });
+  Kokkos::single(Kokkos::PerThread(thread),
+  [=]()
+  {
+    ValueType upperBound = maxVal - minVal;
+    while(upperBound)
+    {
+      upperBound >>= 1;
+      sortBits++;
+    }
+    for(Ordinal s = 0; s < (sortBits + 3) / 4; s++)
+    {
+      //Count the number of elements in each bucket
+      Ordinal count[16] = {0};
+      Ordinal offset[17];
+      if(!inAux)
+      {
+        for(Ordinal i = 0; i < n; i++)
+        {
+          count[(values[i] & mask) >> maskPos]++;
+        }
+      }
+      else
+      {
+        for(Ordinal i = 0; i < n; i++)
+        {
+          count[(valuesAux[i] & mask) >> maskPos]++;
+        }
+      }
+      offset[0] = 0;
+      //get offset as the prefix sum for count
+      for(Ordinal i = 0; i < 16; i++)
+      {
+        offset[i + 1] = offset[i] + count[i];
+      }
+      //now for each element in [lo, hi), move it to its offset in the other buffer
+      //this branch should be ok because whichBuf is the same on all threads
+      if(!inAux)
+      {
+        //copy from *Over to *Aux
+        for(Ordinal i = 0; i < n; i++)
+        {
+          Ordinal bucket = (values[i] & mask) >> maskPos;
+          valuesAux[offset[bucket + 1] - count[bucket]] = values[i];
+          count[bucket]--;
+        }
+      }
+      else
+      {
+        //copy from *Aux to *Over
+        for(Ordinal i = 0; i < n; i++)
+        {
+          Ordinal bucket = (valuesAux[i] & mask) >> maskPos;
+          values[offset[bucket + 1] - count[bucket]] = valuesAux[i];
+          count[bucket]--;
+        }
+      }
+      inAux = !inAux;
+      mask = mask << 4;
+      maskPos += 4;
+    }
+  });
+  //move values back into main array if they are currently in aux
+  if(inAux)
+  {
+    Kokkos::parallel_for(Kokkos::ThreadVectorRange(thread, n),
+    [=](Ordinal i)
+    {
+      values[i] = valuesAux[i];
+    });
+  }
+}
+
+//Bitonic merge sort (requires only comparison operators and trivially-copyable)
+//In-place, plenty of parallelism for GPUs, and memory references are coalesced
+//Good diagram of the algorithm at https://en.wikipedia.org/wiki/Bitonic_sorter
+template<typename Ordinal, typename ValueType, typename TeamMember>
+KOKKOS_INLINE_FUNCTION static void
+bitonicSortTeam(ValueType* values, Ordinal n, const TeamMember& mem)
+{
+  //Algorithm only works on power-of-two input size only.
+  //If n is not a power-of-two, will implicitly pretend
+  //that values[i] for i >= n is just the max for ValueType, so it never gets swapped
+  Ordinal npot = 1;
+  Ordinal levels = 0;
+  while(npot < n)
+  {
+    levels++;
+    npot <<= 1;
+  }
+  for(Ordinal i = 0; i < levels; i++)
+  {
+    for(Ordinal j = 0; j <= i; j++)
+    {
+      // n/2 pairs of items are compared in parallel
+      Kokkos::parallel_for(Kokkos::ThreadTeamRange(mem, npot / 2),
+        [=](const Ordinal t)
+        {
+          //How big are the brown/pink boxes?
+          Ordinal boxSize = Ordinal(2) << (i - j);
+          //Which box contains this thread?
+          Ordinal boxID = t >> (1 + i - j);         //t * 2 / boxSize;
+          Ordinal boxStart = boxID << (1 + i - j);  //boxID * boxSize
+          Ordinal boxOffset = t - (boxStart << 1);  //t - boxID * boxSize / 2;
+          Ordinal elem1 = boxStart + boxOffset;
+          if(j == 0)
+          {
+            //first phase (brown box): within a block, compare with the opposite value in the box
+            Ordinal elem2 = boxStart + boxSize - 1 - boxOffset;
+            if(elem2 < n)
+            {
+              //both elements in bounds, so compare them and swap if out of order
+              if(values[elem1] >= values[elem2])
+              {
+                ValueType temp = values[elem1];
+                values[elem1] = values[elem2];
+                values[elem2] = temp;
+              }
+            }
+          }
+          else
+          {
+            //later phases (pink box): within a block, compare with fixed distance (boxSize / 2) apart
+            Ordinal elem2 = elem1 + boxSize / 2;
+            if(elem2 < n)
+            {
+              if(values[elem1] >= values[elem2])
+              {
+                ValueType temp = values[elem1];
+                values[elem1] = values[elem2];
+                values[elem2] = temp;
+              }
+            }
+          }
+        });
+      mem.team_barrier();
+    }
+  }
+}
+
+#endif
+

--- a/src/common/KokkosKernels_Sorting.hpp
+++ b/src/common/KokkosKernels_Sorting.hpp
@@ -579,7 +579,6 @@ void bitonicSort(View v)
 {
   typedef Kokkos::TeamPolicy<ExecSpace> team_policy;
   typedef typename team_policy::member_type team_member;
-  typedef typename View::value_type Value;
   Ordinal n = v.extent(0);
   //If n is small, just sort on a single team
   if(n <= Ordinal(1) << 16)

--- a/src/sparse/KokkosSparse_spadd.hpp
+++ b/src/sparse/KokkosSparse_spadd.hpp
@@ -202,8 +202,8 @@ namespace Experimental {
       size_type rowStart = Crowptrs(i);
       size_type rowEnd = Crowptrs(i + 1);
       size_type rowNum = rowEnd - rowStart;
-      KokkosKernels::Impl::radixSort2<size_type, typename CcolindsT::non_const_value_type, typename CcolindsT::non_const_value_type, TeamMember>
-        (Ccolinds.data() + rowStart, CcolindsAux.data() + rowStart, ABperm.data() + rowStart, ABpermAux.data() + rowStart, rowNum, t);
+      KokkosKernels::Impl::SerialRadixSort2<size_type, typename CcolindsT::non_const_value_type, typename CcolindsT::non_const_value_type>
+        (Ccolinds.data() + rowStart, CcolindsAux.data() + rowStart, ABperm.data() + rowStart, ABpermAux.data() + rowStart, rowNum);
     }
     CrowptrsT Crowptrs;
     CcolindsT Ccolinds;
@@ -230,7 +230,7 @@ namespace Experimental {
       size_type rowStart = Crowptrs(i);
       size_type rowEnd = Crowptrs(i + 1);
       size_type rowNum = rowEnd - rowStart;
-      KokkosKernels::Impl::bitonicSortTeam2<size_type, typename CcolindsT::non_const_value_type, typename CcolindsT::non_const_value_type, TeamMember>
+      KokkosKernels::Impl::TeamBitonicSort2<size_type, typename CcolindsT::non_const_value_type, typename CcolindsT::non_const_value_type, TeamMember>
         (Ccolinds.data() + rowStart, ABperm.data() + rowStart, rowNum, t);
     }
     CrowptrsT Crowptrs;

--- a/src/sparse/KokkosSparse_spadd.hpp
+++ b/src/sparse/KokkosSparse_spadd.hpp
@@ -45,6 +45,7 @@
 #define _KOKKOS_SPADD_HPP
 
 #include "KokkosKernels_Handle.hpp"
+#include "KokkosKernels_Sorting.hpp"
 
 namespace KokkosSparse {
 namespace Experimental {
@@ -182,107 +183,7 @@ namespace Experimental {
     CcolindsT ABperm;
   };
 
-  template<typename size_type, typename KeyType, typename ValueType, typename IndexType>
-  KOKKOS_INLINE_FUNCTION void
-  radixSortKeysAndValues(KeyType* keys, KeyType* keysAux, ValueType* values, ValueType* valuesAux, IndexType n)
-  {
-    if(n <= 1)
-      return;
-    //sort 4 bits at a time
-    KeyType mask = 0xF;
-    bool inAux = false;
-    //maskPos counts the low bit index of mask (0, 4, 8, ...)
-    IndexType maskPos = 0;
-    IndexType sortBits = 0;
-    KeyType minKey = keys[0];
-    KeyType maxKey = keys[0];
-    for(size_type i = 0; i < n; i++)
-    {
-      if(keys[i] < minKey)
-        minKey = keys[i];
-      if(keys[i] > maxKey)
-        maxKey = keys[i];
-    }
-    //subtract a bias of minKey so that key range starts at 0
-    for(size_type i = 0; i < n; i++)
-    {
-      keys[i] -= minKey;
-    }
-    KeyType upperBound = maxKey - minKey;
-    while(upperBound)
-    {
-      upperBound >>= 1;
-      sortBits++;
-    }
-    for(size_type s = 0; s < (sortBits + 3) / 4; s++)
-    {
-      //Count the number of elements in each bucket
-      IndexType count[16] = {0};
-      IndexType offset[17] = {0};
-      if(!inAux)
-      {
-        for(IndexType i = 0; i < n; i++)
-        {
-          count[(keys[i] & mask) >> maskPos]++;
-        }
-      }
-      else
-      {
-        for(IndexType i = 0; i < n; i++)
-        {
-          count[(keysAux[i] & mask) >> maskPos]++;
-        }
-      }
-      //get offset as the prefix sum for count
-      for(IndexType i = 0; i < 16; i++)
-      {
-        offset[i + 1] = offset[i] + count[i];
-      }
-      //now for each element in [lo, hi), move it to its offset in the other buffer
-      //this branch should be ok because whichBuf is the same on all threads
-      if(!inAux)
-      {
-        //copy from *Over to *Aux
-        for(IndexType i = 0; i < n; i++)
-        {
-          IndexType bucket = (keys[i] & mask) >> maskPos;
-          keysAux[offset[bucket + 1] - count[bucket]] = keys[i];
-          valuesAux[offset[bucket + 1] - count[bucket]] = values[i];
-          count[bucket]--;
-        }
-      }
-      else
-      {
-        //copy from *Aux to *Over
-        for(IndexType i = 0; i < n; i++)
-        {
-          IndexType bucket = (keysAux[i] & mask) >> maskPos;
-          keys[offset[bucket + 1] - count[bucket]] = keysAux[i];
-          values[offset[bucket + 1] - count[bucket]] = valuesAux[i];
-          count[bucket]--;
-        }
-      }
-      inAux = !inAux;
-      mask = mask << 4;
-      maskPos += 4;
-    }
-    if(inAux)
-    {
-      //need to deep copy from aux arrays to main
-      for(IndexType i = 0; i < n; i++)
-      {
-        keys[i] = keysAux[i];
-        values[i] = valuesAux[i];
-      }
-    }
-    //remove the bias
-    for(size_type i = 0; i < n; i++)
-    {
-      keys[i] += minKey;
-    }
-  }
-
-  template<typename size_type, typename CrowptrsT, typename CcolindsT>
+  template<typename ExecSpace, typename size_type, typename CrowptrsT, typename CcolindsT>
   struct SortEntriesFunctor
   {
     SortEntriesFunctor(const CrowptrsT Crowptrs_, CcolindsT Ccolinds_, CcolindsT ABperm_) :
@@ -292,16 +193,17 @@ namespace Experimental {
       ABperm(ABperm_),
       ABpermAux("AB perm aux", ABperm_.extent(0))
     {}
-    KOKKOS_INLINE_FUNCTION void operator()(const size_type i) const
+    typedef typename Kokkos::TeamPolicy<ExecSpace>::member_type TeamMember;
+    KOKKOS_INLINE_FUNCTION void operator()(const TeamMember t) const
     {
       //3: Sort each row's colinds (permuting values at same time), then count unique colinds (write that to Crowptr(i))
       //CrowptrTemp tells how many entries in each oversized row
+      size_type i = t.league_rank();
       size_type rowStart = Crowptrs(i);
       size_type rowEnd = Crowptrs(i + 1);
       size_type rowNum = rowEnd - rowStart;
-      radixSortKeysAndValues<size_type, typename CcolindsT::non_const_value_type, typename CcolindsT::non_const_value_type>
-        (Ccolinds.data() + rowStart, CcolindsAux.data() + rowStart,
-         ABperm.data() + rowStart, ABpermAux.data() + rowStart, rowNum);
+      KokkosKernels::Impl::radixSort2<size_type, typename CcolindsT::non_const_value_type, typename CcolindsT::non_const_value_type, TeamMember>
+        (Ccolinds.data() + rowStart, CcolindsAux.data() + rowStart, ABperm.data() + rowStart, ABpermAux.data() + rowStart, rowNum, t);
     }
     CrowptrsT Crowptrs;
     CcolindsT Ccolinds;
@@ -309,6 +211,33 @@ namespace Experimental {
     CcolindsT ABperm;
     CcolindsT ABpermAux;
   };
+
+  #ifdef KOKKOS_ENABLE_CUDA
+  template<typename size_type, typename CrowptrsT, typename CcolindsT>
+  struct SortEntriesFunctor<Kokkos::Cuda, size_type, CrowptrsT, CcolindsT>
+  {
+    SortEntriesFunctor(const CrowptrsT Crowptrs_, CcolindsT Ccolinds_, CcolindsT ABperm_) :
+      Crowptrs(Crowptrs_),
+      Ccolinds(Ccolinds_),
+      ABperm(ABperm_)
+    {}
+    typedef typename Kokkos::TeamPolicy<Kokkos::Cuda>::member_type TeamMember;
+    KOKKOS_INLINE_FUNCTION void operator()(const TeamMember t) const
+    {
+      //3: Sort each row's colinds (permuting values at same time), then count unique colinds (write that to Crowptr(i))
+      //CrowptrTemp tells how many entries in each oversized row
+      size_type i = t.league_rank();
+      size_type rowStart = Crowptrs(i);
+      size_type rowEnd = Crowptrs(i + 1);
+      size_type rowNum = rowEnd - rowStart;
+      KokkosKernels::Impl::bitonicSort2<size_type, typename CcolindsT::non_const_value_type, typename CcolindsT::non_const_value_type, TeamMember>
+        (Ccolinds.data() + rowStart, ABperm.data() + rowStart, rowNum, t);
+    }
+    CrowptrsT Crowptrs;
+    CcolindsT Ccolinds;
+    CcolindsT ABperm;
+  };
+  #endif
 
   template<typename size_type, typename ordinal_type, typename ArowptrsT, typename BrowptrsT, typename CrowptrsT, typename CcolindsT>
   struct MergeEntriesFunctor
@@ -447,9 +376,10 @@ namespace Experimental {
       Kokkos::parallel_for("KokkosSparse::SpAdd:Symbolic::InputNotSorted::UnmergedSum", range_type(0, nrows), unmergedSum);
       execution_space().fence();
       //sort the unmerged sum
-      SortEntriesFunctor<size_type, clno_row_view_t_, clno_nnz_view_t_>
+      SortEntriesFunctor<execution_space, size_type, clno_row_view_t_, clno_nnz_view_t_>
         sortEntries(c_rowmap_upperbound, c_entries_uncompressed, ab_perm);
-      Kokkos::parallel_for("KokkosSparse::SpAdd:Symbolic::InputNotSorted::SortEntries", range_type(0, nrows), sortEntries);
+      Kokkos::parallel_for("KokkosSparse::SpAdd:Symbolic::InputNotSorted::SortEntries",
+          Kokkos::TeamPolicy<execution_space>(nrows, Kokkos::AUTO()), sortEntries);
       execution_space().fence();
       clno_nnz_view_t_ a_pos("A entry positions", a_entries.extent(0));
       clno_nnz_view_t_ b_pos("B entry positions", b_entries.extent(0));

--- a/src/sparse/KokkosSparse_spadd.hpp
+++ b/src/sparse/KokkosSparse_spadd.hpp
@@ -230,7 +230,7 @@ namespace Experimental {
       size_type rowStart = Crowptrs(i);
       size_type rowEnd = Crowptrs(i + 1);
       size_type rowNum = rowEnd - rowStart;
-      KokkosKernels::Impl::bitonicSort2<size_type, typename CcolindsT::non_const_value_type, typename CcolindsT::non_const_value_type, TeamMember>
+      KokkosKernels::Impl::bitonicSortTeam2<size_type, typename CcolindsT::non_const_value_type, typename CcolindsT::non_const_value_type, TeamMember>
         (Ccolinds.data() + rowStart, ABperm.data() + rowStart, rowNum, t);
     }
     CrowptrsT Crowptrs;

--- a/test_common/Test_Common_Sorting.hpp
+++ b/test_common/Test_Common_Sorting.hpp
@@ -1,0 +1,263 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//               KokkosKernels 0.9: Linear Algebra and Graph Kernels
+//                 Copyright 2017 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+/// \file Test_Common_Sorting.hpp
+/// \brief Tests for radixSortThread and bitonicSortTeam in KokkoKernels_Sorting.hpp
+
+#ifndef KOKKOSKERNELS_SORTINGTEST_HPP
+#define KOKKOSKERNELS_SORTINGTEST_HPP
+
+#include <Kokkos_Core.hpp>
+#include <KokkosKernels_SimpleUtils.hpp>
+#include <KokkosKernels_Utils.hpp>
+#include <KokkosKernels_Sorting.hpp>
+#include <Kokkos_ArithTraits.hpp>
+#include <cstdlib>
+
+//Generate n randomized counts with mean <avg>.
+//Then prefix-sum into randomOffsets.
+//This simulates a CRS rowmap or other batched sorting scenario
+template<typename OrdView, typename ExecSpace>
+size_t generateRandomOffsets(OrdView& randomCounts, OrdView& randomOffsets, size_t n, size_t avg)
+{
+  randomCounts = OrdView("Counts", n);
+  randomOffsets = OrdView("Offsets", n);
+  auto countsHost = Kokkos::create_mirror_view(randomCounts);
+  size_t total = 0;
+  for(size_t i = 0; i < n; i++)
+  {
+    countsHost(i) = 0.5 + rand() % (avg * 2);
+    total += countsHost(i);
+  }
+  Kokkos::deep_copy(randomCounts, countsHost);
+  Kokkos::deep_copy(randomOffsets, randomCounts);
+  KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<OrdView, ExecSpace>(n, randomOffsets);
+  return total;
+}
+
+//Generate random integer, up to RAND_MAX
+template<typename T>
+T getRandom()
+{
+  return rand() % Kokkos::ArithTraits<T>::max();
+}
+
+//Generate a uniform double between (-5, 5)
+template<>
+double getRandom<double>()
+{
+  return -5 + (10.0 * rand()) / RAND_MAX;
+}
+
+template<typename View>
+void fillRandom(View v)
+{
+  typedef typename View::value_type Value;
+  auto vhost = Kokkos::create_mirror_view(v);
+  for(size_t i = 0; i < v.extent(0); i++)
+    vhost(i) = getRandom<Value>();
+  Kokkos::deep_copy(v, vhost);
+}
+
+template<typename ValView, typename OrdView>
+struct RadixSortFunctor
+{
+  typedef typename ValView::value_type Value;
+  typedef typename ValView::memory_space Space;
+
+  RadixSortFunctor(ValView& values_, ValView& valuesAux_, OrdView& counts_, OrdView& offsets_)
+    : values(values_), valuesAux(valuesAux_), counts(counts_), offsets(offsets_)
+  {}
+  template<typename TeamMem>
+  KOKKOS_INLINE_FUNCTION void operator()(const TeamMem t) const
+  {
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(t, counts.extent(0)),
+      [=](const int i)
+      {
+        KokkosKernels::Impl::radixSortThread<int, Value, TeamMem, Space>(&values(offsets(i)), &valuesAux(offsets(i)), counts(i), t);
+      });
+  }
+  ValView values;
+  ValView valuesAux;
+  OrdView offsets;
+  OrdView counts;
+};
+
+template<typename ExecSpace, typename Scalar>
+void testRadixSort(bool perfTest)
+{
+  //Create a view of randomized data
+  typedef typename ExecSpace::memory_space mem_space;
+  typedef Kokkos::View<int*, mem_space> OrdView;
+  typedef Kokkos::View<int*, Kokkos::HostSpace> OrdViewHost;
+  typedef Kokkos::View<Scalar*, mem_space> ValView;
+  OrdView counts;
+  OrdView offsets;
+  //Generate k sub-array sizes, each with size about 20
+  size_t k = 100;
+  if(perfTest)
+    k = 100000;
+  size_t subSize = 20;
+  size_t n = generateRandomOffsets<OrdView, ExecSpace>(counts, offsets, k, subSize);
+  auto countsHost = Kokkos::create_mirror_view(counts);
+  auto offsetsHost = Kokkos::create_mirror_view(offsets);
+  Kokkos::deep_copy(countsHost, counts);
+  Kokkos::deep_copy(offsetsHost, offsets);
+  ValView data("Radix sort testing data", n);
+  fillRandom(data);
+  ValView dataAux("Radix sort aux data", n);
+  //Run the sorting on device in all sub-arrays in parallel, just using vector loops
+  Kokkos::Timer timer;
+  typedef Kokkos::TeamPolicy<ExecSpace> team_policy;
+  Kokkos::parallel_for(team_policy(1, Kokkos::AUTO(), 32),
+        RadixSortFunctor<ValView, OrdView>(data, dataAux, counts, offsets));
+  double time = timer.seconds();
+  if(perfTest)
+  {
+    std::cout << "Radix sort took " << time << " s to sort " << k * subSize << " total items.\n";
+  }
+  else
+  {
+    //Sort using std::sort on host to do correctness test
+    Kokkos::View<Scalar*, Kokkos::HostSpace> gold("Host sorted", n);
+    Kokkos::deep_copy(gold, data);
+    for(size_t i = 0; i < k; i++)
+    {
+      Scalar* begin = &gold(offsetsHost(i));
+      Scalar* end = begin + countsHost(i);
+      std::sort(begin, end);
+    }
+    //Copy result to host
+    auto dataHost = Kokkos::create_mirror_view(data);
+    Kokkos::deep_copy(dataHost, data);
+    for(size_t i = 0; i < n; i++)
+    {
+      ASSERT_EQ(dataHost(i), gold(i));
+    }
+  }
+}
+
+template<typename ValView, typename OrdView>
+struct BitonicSortFunctor
+{
+  typedef typename ValView::value_type Value;
+
+  BitonicSortFunctor(ValView& values_, OrdView& counts_, OrdView& offsets_)
+    : values(values_), counts(counts_), offsets(offsets_)
+  {}
+
+  template<typename TeamMem>
+  KOKKOS_INLINE_FUNCTION void operator()(const TeamMem t) const
+  {
+    int i = t.league_rank();
+    KokkosKernels::Impl::bitonicSortTeam<int, Value, TeamMem>(&values(offsets(i)), counts(i), t);
+  }
+  ValView values;
+  OrdView offsets;
+  OrdView counts;
+};
+
+template<typename ExecSpace, typename Scalar>
+void testBitonicSort(bool perfTest)
+{
+  //Create a view of randomized data
+  typedef typename ExecSpace::memory_space mem_space;
+  typedef Kokkos::View<int*, mem_space> OrdView;
+  typedef Kokkos::View<int*, Kokkos::HostSpace> OrdViewHost;
+  typedef Kokkos::View<Scalar*, mem_space> ValView;
+  OrdView counts;
+  OrdView offsets;
+  //Generate k sub-array sizes, each with size about 20
+  size_t k = 100;
+  size_t subSize = 100;
+  if(perfTest)
+  {
+    k = 500;
+    subSize = 1000000;
+  }
+  size_t n = generateRandomOffsets<OrdView, ExecSpace>(counts, offsets, k, subSize);
+  auto countsHost = Kokkos::create_mirror_view(counts);
+  auto offsetsHost = Kokkos::create_mirror_view(offsets);
+  Kokkos::deep_copy(countsHost, counts);
+  Kokkos::deep_copy(offsetsHost, offsets);
+  ValView data("Bitonic sort testing data", n);
+  fillRandom(data);
+  ValView dataAux("Bitonic sort aux data", n);
+  Kokkos::Timer timer;
+  //Run the sorting on device in all sub-arrays in parallel
+  Kokkos::parallel_for(Kokkos::TeamPolicy<ExecSpace>(k, Kokkos::AUTO()),
+      BitonicSortFunctor<ValView, OrdView>(data, counts, offsets));
+  double time = timer.seconds();
+  if(perfTest)
+  {
+    std::cout << "Bitonic sort took " << time << " s to sort " << k * subSize << " total items.\n";
+  }
+  else
+  {
+    //Copy result to host
+    auto dataHost = Kokkos::create_mirror_view(data);
+    Kokkos::deep_copy(dataHost, data);
+    //Sort using std::sort on host to do correctness test
+    Kokkos::View<Scalar*, Kokkos::HostSpace> gold("Host sorted", n);
+    Kokkos::deep_copy(gold, data);
+    for(size_t i = 0; i < k; i++)
+    {
+      Scalar* begin = &gold(offsetsHost(i));
+      Scalar* end = begin + countsHost(i);
+      std::sort(begin, end);
+    }
+    for(size_t i = 0; i < n; i++)
+    {
+      ASSERT_EQ(dataHost(i), gold(i));
+    }
+  }
+}
+
+TEST_F( TestCategory, common_Sorting) {
+  testRadixSort<TestExecSpace, char>(false);
+  testRadixSort<TestExecSpace, int>(true);
+  testBitonicSort<TestExecSpace, int>(true);
+  testBitonicSort<TestExecSpace, double>(false);
+}
+
+#endif

--- a/test_common/Test_Common_Sorting.hpp
+++ b/test_common/Test_Common_Sorting.hpp
@@ -42,12 +42,13 @@
 */
 
 /// \file Test_Common_Sorting.hpp
-/// \brief Tests for radixSortThread and bitonicSortTeam in KokkoKernels_Sorting.hpp
+/// \brief Tests for radixSort and bitonicSort in KokkoKernels_Sorting.hpp
 
 #ifndef KOKKOSKERNELS_SORTINGTEST_HPP
 #define KOKKOSKERNELS_SORTINGTEST_HPP
 
 #include <Kokkos_Core.hpp>
+#include <Kokkos_Sort.hpp>
 #include <KokkosKernels_SimpleUtils.hpp>
 #include <KokkosKernels_Utils.hpp>
 #include <KokkosKernels_Sorting.hpp>
@@ -92,6 +93,7 @@ double getRandom<double>()
 template<typename View>
 void fillRandom(View v)
 {
+  srand(12345);
   typedef typename View::value_type Value;
   auto vhost = Kokkos::create_mirror_view(v);
   for(size_t i = 0; i < v.extent(0); i++)
@@ -103,7 +105,6 @@ template<typename ValView, typename OrdView>
 struct RadixSortFunctor
 {
   typedef typename ValView::value_type Value;
-  typedef typename ValView::memory_space Space;
 
   RadixSortFunctor(ValView& values_, ValView& valuesAux_, OrdView& counts_, OrdView& offsets_)
     : values(values_), valuesAux(valuesAux_), counts(counts_), offsets(offsets_)
@@ -114,7 +115,7 @@ struct RadixSortFunctor
     Kokkos::parallel_for(Kokkos::TeamThreadRange(t, counts.extent(0)),
       [=](const int i)
       {
-        KokkosKernels::Impl::radixSortThread<int, Value, TeamMem, Space>(&values(offsets(i)), &valuesAux(offsets(i)), counts(i), t);
+        KokkosKernels::Impl::radixSort<int, Value, TeamMem>(&values(offsets(i)), &valuesAux(offsets(i)), counts(i), t);
       });
   }
   ValView values;
@@ -124,7 +125,7 @@ struct RadixSortFunctor
 };
 
 template<typename ExecSpace, typename Scalar>
-void testRadixSort(bool perfTest)
+void testBatchRadixSort()
 {
   //Create a view of randomized data
   typedef typename ExecSpace::memory_space mem_space;
@@ -135,8 +136,6 @@ void testRadixSort(bool perfTest)
   OrdView offsets;
   //Generate k sub-array sizes, each with size about 20
   size_t k = 100;
-  if(perfTest)
-    k = 100000;
   size_t subSize = 20;
   size_t n = generateRandomOffsets<OrdView, ExecSpace>(counts, offsets, k, subSize);
   auto countsHost = Kokkos::create_mirror_view(counts);
@@ -147,33 +146,24 @@ void testRadixSort(bool perfTest)
   fillRandom(data);
   ValView dataAux("Radix sort aux data", n);
   //Run the sorting on device in all sub-arrays in parallel, just using vector loops
-  Kokkos::Timer timer;
   typedef Kokkos::TeamPolicy<ExecSpace> team_policy;
   Kokkos::parallel_for(team_policy(1, Kokkos::AUTO(), 32),
         RadixSortFunctor<ValView, OrdView>(data, dataAux, counts, offsets));
-  double time = timer.seconds();
-  if(perfTest)
+  //Sort using std::sort on host to do correctness test
+  Kokkos::View<Scalar*, Kokkos::HostSpace> gold("Host sorted", n);
+  Kokkos::deep_copy(gold, data);
+  for(size_t i = 0; i < k; i++)
   {
-    std::cout << "Radix sort took " << time << " s to sort " << k * subSize << " total items.\n";
+    Scalar* begin = &gold(offsetsHost(i));
+    Scalar* end = begin + countsHost(i);
+    std::sort(begin, end);
   }
-  else
+  //Copy result to host
+  auto dataHost = Kokkos::create_mirror_view(data);
+  Kokkos::deep_copy(dataHost, data);
+  for(size_t i = 0; i < n; i++)
   {
-    //Sort using std::sort on host to do correctness test
-    Kokkos::View<Scalar*, Kokkos::HostSpace> gold("Host sorted", n);
-    Kokkos::deep_copy(gold, data);
-    for(size_t i = 0; i < k; i++)
-    {
-      Scalar* begin = &gold(offsetsHost(i));
-      Scalar* end = begin + countsHost(i);
-      std::sort(begin, end);
-    }
-    //Copy result to host
-    auto dataHost = Kokkos::create_mirror_view(data);
-    Kokkos::deep_copy(dataHost, data);
-    for(size_t i = 0; i < n; i++)
-    {
-      ASSERT_EQ(dataHost(i), gold(i));
-    }
+    ASSERT_EQ(dataHost(i), gold(i));
   }
 }
 
@@ -190,7 +180,7 @@ struct BitonicSortFunctor
   KOKKOS_INLINE_FUNCTION void operator()(const TeamMem t) const
   {
     int i = t.league_rank();
-    KokkosKernels::Impl::bitonicSortTeam<int, Value, TeamMem>(&values(offsets(i)), counts(i), t);
+    KokkosKernels::Impl::bitonicSort<int, Value, TeamMem>(&values(offsets(i)), counts(i), t);
   }
   ValView values;
   OrdView offsets;
@@ -198,7 +188,7 @@ struct BitonicSortFunctor
 };
 
 template<typename ExecSpace, typename Scalar>
-void testBitonicSort(bool perfTest)
+void testBatchBitonicSort()
 {
   //Create a view of randomized data
   typedef typename ExecSpace::memory_space mem_space;
@@ -210,11 +200,6 @@ void testBitonicSort(bool perfTest)
   //Generate k sub-array sizes, each with size about 20
   size_t k = 100;
   size_t subSize = 100;
-  if(perfTest)
-  {
-    k = 500;
-    subSize = 1000000;
-  }
   size_t n = generateRandomOffsets<OrdView, ExecSpace>(counts, offsets, k, subSize);
   auto countsHost = Kokkos::create_mirror_view(counts);
   auto offsetsHost = Kokkos::create_mirror_view(offsets);
@@ -222,42 +207,65 @@ void testBitonicSort(bool perfTest)
   Kokkos::deep_copy(offsetsHost, offsets);
   ValView data("Bitonic sort testing data", n);
   fillRandom(data);
-  ValView dataAux("Bitonic sort aux data", n);
-  Kokkos::Timer timer;
   //Run the sorting on device in all sub-arrays in parallel
   Kokkos::parallel_for(Kokkos::TeamPolicy<ExecSpace>(k, Kokkos::AUTO()),
       BitonicSortFunctor<ValView, OrdView>(data, counts, offsets));
-  double time = timer.seconds();
-  if(perfTest)
+  //Copy result to host
+  auto dataHost = Kokkos::create_mirror_view(data);
+  Kokkos::deep_copy(dataHost, data);
+  //Sort using std::sort on host to do correctness test
+  Kokkos::View<Scalar*, Kokkos::HostSpace> gold("Host sorted", n);
+  Kokkos::deep_copy(gold, data);
+  for(size_t i = 0; i < k; i++)
   {
-    std::cout << "Bitonic sort took " << time << " s to sort " << k * subSize << " total items.\n";
+    Scalar* begin = &gold(offsetsHost(i));
+    Scalar* end = begin + countsHost(i);
+    std::sort(begin, end);
   }
-  else
+  for(size_t i = 0; i < n; i++)
   {
-    //Copy result to host
-    auto dataHost = Kokkos::create_mirror_view(data);
-    Kokkos::deep_copy(dataHost, data);
-    //Sort using std::sort on host to do correctness test
-    Kokkos::View<Scalar*, Kokkos::HostSpace> gold("Host sorted", n);
-    Kokkos::deep_copy(gold, data);
-    for(size_t i = 0; i < k; i++)
-    {
-      Scalar* begin = &gold(offsetsHost(i));
-      Scalar* end = begin + countsHost(i);
-      std::sort(begin, end);
-    }
-    for(size_t i = 0; i < n; i++)
-    {
-      ASSERT_EQ(dataHost(i), gold(i));
-    }
+    ASSERT_EQ(dataHost(i), gold(i));
   }
+}
+
+template<typename View>
+struct CheckSortedFunctor
+{
+  CheckSortedFunctor(View& v_)
+    : v(v_) {}
+  KOKKOS_INLINE_FUNCTION void operator()(int i, int& lval) const
+  {
+    if(v(i) > v(i + 1))
+      lval = 0;
+  }
+  View v;
+};
+
+template<typename ExecSpace, typename Scalar>
+void testBitonicSort()
+{
+  //Create a view of randomized data
+  typedef typename ExecSpace::memory_space mem_space;
+  typedef Kokkos::View<Scalar*, mem_space> ValView;
+  size_t n = 100000;
+  ValView data("Bitonic sort testing data", n);
+  fillRandom(data);
+  KokkosKernels::Impl::bitonicSort<ValView, ExecSpace, int>(data);
+  int ordered = 1;
+  Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, n - 1),
+      CheckSortedFunctor<ValView>(data), Kokkos::Min<int>(ordered));
+  ASSERT_TRUE(ordered);
 }
 
 TEST_F( TestCategory, common_Sorting) {
-  testRadixSort<TestExecSpace, char>(false);
-  testRadixSort<TestExecSpace, int>(true);
-  testBitonicSort<TestExecSpace, int>(true);
-  testBitonicSort<TestExecSpace, double>(false);
+  testBatchRadixSort<TestExecSpace, char>();
+  testBatchRadixSort<TestExecSpace, int>();
+  testBatchBitonicSort<TestExecSpace, int>();
+  testBatchBitonicSort<TestExecSpace, double>();
+  testBitonicSort<TestExecSpace, char>();
+  testBitonicSort<TestExecSpace, int>();
+  testBitonicSort<TestExecSpace, double>();
 }
 
 #endif
+

--- a/test_common/Test_Common_Sorting.hpp
+++ b/test_common/Test_Common_Sorting.hpp
@@ -180,7 +180,7 @@ struct BitonicSortFunctor
   KOKKOS_INLINE_FUNCTION void operator()(const TeamMem t) const
   {
     int i = t.league_rank();
-    KokkosKernels::Impl::bitonicSort<int, Value, TeamMem>(&values(offsets(i)), counts(i), t);
+    KokkosKernels::Impl::bitonicSortTeam<int, Value, TeamMem>(&values(offsets(i)), counts(i), t);
   }
   ValView values;
   OrdView offsets;
@@ -247,7 +247,7 @@ void testBitonicSort()
   //Create a view of randomized data
   typedef typename ExecSpace::memory_space mem_space;
   typedef Kokkos::View<Scalar*, mem_space> ValView;
-  size_t n = 100000;
+  size_t n = 1599898;
   ValView data("Bitonic sort testing data", n);
   fillRandom(data);
   KokkosKernels::Impl::bitonicSort<ValView, ExecSpace, int>(data);

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -71,7 +71,7 @@ IF (Kokkos_ENABLE_Cuda)
   )
   
   #currently float 128 test is not working. So common tests are explicitly added.  
-  APPEND_GLOB(CUDA_COMMON_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/cuda/Test_Cuda_Common_ArithTraits.cpp)
+  APPEND_GLOB(CUDA_COMMON_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/cuda/Test_Cuda_Common*.cpp)
   
 
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
@@ -128,7 +128,7 @@ IF (Kokkos_ENABLE_OpenMP)
     TESTONLYLIBS kokkoskernels_gtest
   )
   
-  APPEND_GLOB(OPENMP_COMMON_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/openmp/Test_OpenMP_Common_ArithTraits.cpp)
+  APPEND_GLOB(OPENMP_COMMON_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/openmp/Test_OpenMP_Common*.cpp)
 
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     common_openmp
@@ -183,7 +183,7 @@ IF (Kokkos_ENABLE_Serial)
     TESTONLYLIBS kokkoskernels_gtest
   )
   
-  APPEND_GLOB(SERIAL_COMMON_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/serial/Test_Serial_Common_ArithTraits.cpp)
+  APPEND_GLOB(SERIAL_COMMON_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/serial/Test_Serial_Common*.cpp)
 
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     common_serial
@@ -234,7 +234,7 @@ IF (Kokkos_ENABLE_Pthread)
   )
   
   
-  APPEND_GLOB(THREADS_COMMON_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/threads/Test_Threads_Common_ArithTraits.cpp)
+  APPEND_GLOB(THREADS_COMMON_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/threads/Test_Threads_Common*.cpp)
 
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     common_threads

--- a/unit_test/cuda/Test_Cuda_Common_Sorting.cpp
+++ b/unit_test/cuda/Test_Cuda_Common_Sorting.cpp
@@ -1,0 +1,2 @@
+#include<Test_Cuda.hpp>
+#include<Test_Common_Sorting.hpp>

--- a/unit_test/openmp/Test_OpenMP_Common_Sorting.cpp
+++ b/unit_test/openmp/Test_OpenMP_Common_Sorting.cpp
@@ -1,0 +1,2 @@
+#include<Test_OpenMP.hpp>
+#include<Test_Common_Sorting.hpp>

--- a/unit_test/openmp/Test_OpenMP_Common_float128.cpp
+++ b/unit_test/openmp/Test_OpenMP_Common_float128.cpp
@@ -1,2 +1,4 @@
+/*
 #include<Test_OpenMP.hpp>
 #include<Test_Common_float128.hpp>
+*/

--- a/unit_test/serial/Test_Serial_Common_Sorting.cpp
+++ b/unit_test/serial/Test_Serial_Common_Sorting.cpp
@@ -1,0 +1,2 @@
+#include<Test_Serial.hpp>
+#include<Test_Common_Sorting.hpp>

--- a/unit_test/serial/Test_Serial_Common_float128.cpp
+++ b/unit_test/serial/Test_Serial_Common_float128.cpp
@@ -1,2 +1,4 @@
+/*
 #include<Test_Serial.hpp>
 #include<Test_Common_float128.hpp>
+*/

--- a/unit_test/threads/Test_Threads_Common_Sorting.cpp
+++ b/unit_test/threads/Test_Threads_Common_Sorting.cpp
@@ -1,0 +1,2 @@
+#include<Test_Threads.hpp>
+#include<Test_Common_Sorting.hpp>

--- a/unit_test/threads/Test_Threads_Common_float128.cpp
+++ b/unit_test/threads/Test_Threads_Common_float128.cpp
@@ -1,2 +1,4 @@
+/*
 #include<Test_Threads.hpp>
 #include<Test_Common_float128.hpp>
+*/


### PR DESCRIPTION
This commit adds a new utils file "KokkosKernels_Sorting.hpp". This adds some useful sorting routines for situations where Kokkos::sort can't be used (but may in the future, so these changes are in the Impl namespace).

- 16-bucket radix sort for integers (radixSort). The sorting can be called from inside a parallel region (RangePolicy, TeamPolicy or TeamThreadRange).
- Version of the above radix sort "radixSort2" that applies the same swaps to another array, of arbitrary type
- [Bitonic sort](https://en.wikipedia.org/wiki/Bitonic_sorter) implementation "bitonicSortTeam" that works within a TeamPolicy. This runs in parallel using a TeamThreadRange. This supports any data type that supports "operator<", "operator=", and copy constructor on device. A custom comparator can optionally be provided as a template argument. This makes it more general than Kokkos::sort. Bitonic is asymptotically slow at O(n log^2(n)). Generally it should only be used on GPUs where it is a very good fit for hardware, with high parallelism (>90% occupancy on CUDA) and coalesced memory references.
- bitonicSort2, which behaves like radixSort2
- bitonicSort, which is called from host and sorts a single view in parallel. Faster than Kokkos::sort for smallish arrays (< 10^7 elements) on GPUs.
- both algorithms are tested in test_common_***

For CUDA execution space, I replaced radix sort with bitonicSortTeam in unsorted sparse matrix addition (spadd). This gave a ~12% overall speedup for Tpetra::MatrixMatrix::add on CUDA. The CPU exec spaces still use radix sort.

kokkos-dev spot check:
#######################################################
PASSED TESTS
#######################################################
clang-4.0.1-Pthread_Serial-hwloc-release build_time=752 run_time=361
clang-4.0.1-Pthread_Serial-release build_time=772 run_time=567
cuda-8.0.44-Cuda_OpenMP-release build_time=1125 run_time=341
gcc-5.3.0-Serial-hwloc-release build_time=666 run_time=313
gcc-5.3.0-Serial-release build_time=671 run_time=309
gcc-7.2.0-Serial-hwloc-release build_time=496 run_time=171
gcc-7.2.0-Serial-release build_time=499 run_time=169
intel-17.0.1-OpenMP-hwloc-release build_time=924 run_time=111
intel-17.0.1-OpenMP-release build_time=919 run_time=115
#######################################################
FAILED TESTS
#######################################################


bowman spot check:
#######################################################
PASSED TESTS
#######################################################
intel-16.4.258-Pthread-release build_time=1503 run_time=572
intel-16.4.258-Pthread_Serial-release build_time=2442 run_time=1221
intel-16.4.258-Serial-release build_time=1459 run_time=609
intel-17.2.174-OpenMP-release build_time=1932 run_time=370
intel-17.2.174-OpenMP_Serial-release build_time=2876 run_time=1100
intel-17.2.174-Pthread-release build_time=1300 run_time=604
intel-17.2.174-Pthread_Serial-release build_time=2396 run_time=1253
intel-17.2.174-Serial-release build_time=1382 run_time=649
intel-18.2.199-OpenMP-release build_time=1584 run_time=402
intel-18.2.199-OpenMP_Serial-release build_time=2760 run_time=993
intel-18.2.199-Pthread-release build_time=1230 run_time=617
intel-18.2.199-Pthread_Serial-release build_time=2377 run_time=1199
intel-18.2.199-Serial-release build_time=1202 run_time=653
#######################################################
FAILED TESTS
#######################################################


white spot check:
#######################################################
PASSED TESTS
#######################################################
cuda-10.0.130-Cuda_Serial-release build_time=1096 run_time=364
cuda-9.2.88-Cuda_OpenMP-release build_time=1156 run_time=303
gcc-6.4.0-OpenMP_Serial-release build_time=568 run_time=321
gcc-7.2.0-OpenMP-release build_time=400 run_time=132
gcc-7.2.0-OpenMP_Serial-release build_time=638 run_time=363
gcc-7.2.0-Serial-release build_time=249 run_time=183
ibm-16.1.0-Serial-release build_time=1334 run_time=266
#######################################################
FAILED TESTS
#######################################################
