### PR TITLE
KokkosBatched - vector length adjustment for ARM

### DIFF
--- a/src/batched/KokkosBatched_Vector.hpp
+++ b/src/batched/KokkosBatched_Vector.hpp
@@ -26,8 +26,10 @@ namespace KokkosBatched {
     enum : int { value = 16 };
 #elif defined(__AVX__) || defined(__AVX2__)
     enum : int { value = 8 };
+#elif defined(__ARM_ARCH)
+    enum : int { value = 8 };    
 #else
-    enum : int { value = 16 };      
+    enum : int { value = 8 };      
 #endif
   };
   template<>
@@ -36,8 +38,10 @@ namespace KokkosBatched {
     enum : int { value = 8 };
 #elif defined(__AVX__) || defined(__AVX2__)
     enum : int { value = 4 };
+#elif defined(__ARM_ARCH)
+    enum : int { value = 4 };    
 #else
-    enum : int { value = 8 };      
+    enum : int { value = 4 };      
 #endif
   };
   template<>    
@@ -46,8 +50,10 @@ namespace KokkosBatched {
     enum : int { value = 8 };
 #elif defined(__AVX__) || defined(__AVX2__)
     enum : int { value = 4 };
+#elif defined(__ARM_ARCH)
+    enum : int { value = 4 };    
 #else
-    enum : int { value = 8 };      
+    enum : int { value = 4 };      
 #endif
   };
   template<>
@@ -56,8 +62,10 @@ namespace KokkosBatched {
     enum : int { value = 4 };
 #elif defined(__AVX__) || defined(__AVX2__)
     enum : int { value = 2 };
+#elif defined(__ARM_ARCH)
+    enum : int { value = 2 };    
 #else 
-    enum : int { value = 4 };      
+    enum : int { value = 2 };      
 #endif
   };
 


### PR DESCRIPTION
This set a vector length (4 doubles) for ARM architectures. For Ifpack2 block tridiagonal solver, using 256 bit length is better than 128 bit length. For quick test, I already submit a PR for Trilinos and this is a matching PR in KokkosKernels. 