### PR TITLE
With kokkos deprecated off, fix sugg teamsize = 0 (#468)

### DIFF
--- a/src/common/KokkosKernels_Utils.hpp
+++ b/src/common/KokkosKernels_Utils.hpp
@@ -242,6 +242,8 @@ void get_suggested_team_size(
 #if defined( KOKKOS_ENABLE_CUDA )
   if (Kokkos::Impl::is_same<Kokkos::Cuda, ExecutionSpace >::value){
     suggested_team_size_ = max_allowed_team_size / suggested_vector_size;
+    if(suggested_team_size_ == 0)
+      suggested_team_size_ = 1;
   }
 #endif
 


### PR DESCRIPTION
With Kokkos deprecated off, the KokkosKernels suggested team size was sometimes 0 (especially for small matrices, like in some unit tests). A team of size 0 obviously can't do any work, so this commit just makes sure the #teams is at least 1. This was caught because some of the symmetrize utility functions divide by the team size to divide up work, causing div-by-zero/floating point exceptions in the sparse and graph unittests.

This fixes #468.

Bowman spot check:
#######################################################
PASSED TESTS
#######################################################
intel-16.4.258-Pthread-release build_time=1521 run_time=587
intel-16.4.258-Pthread_Serial-release build_time=2472 run_time=1250
intel-16.4.258-Serial-release build_time=1470 run_time=622
intel-17.2.174-OpenMP-release build_time=1987 run_time=393
intel-17.2.174-OpenMP_Serial-release build_time=2841 run_time=1120
intel-17.2.174-Pthread-release build_time=1322 run_time=623
intel-17.2.174-Pthread_Serial-release build_time=2393 run_time=1268
intel-17.2.174-Serial-release build_time=1380 run_time=665
intel-18.2.199-OpenMP-release build_time=1590 run_time=436
intel-18.2.199-OpenMP_Serial-release build_time=2739 run_time=1049
intel-18.2.199-Pthread-release build_time=1230 run_time=635
intel-18.2.199-Pthread_Serial-release build_time=2357 run_time=1218
intel-18.2.199-Serial-release build_time=1210 run_time=671
#######################################################
FAILED TESTS
#######################################################

White spot check:
#######################################################
PASSED TESTS
#######################################################
cuda-10.0.130-Cuda_Serial-release build_time=1169 run_time=370
cuda-9.2.88-Cuda_OpenMP-release build_time=1351 run_time=305
gcc-6.4.0-OpenMP_Serial-release build_time=709 run_time=327
gcc-7.2.0-OpenMP-release build_time=466 run_time=145
gcc-7.2.0-OpenMP_Serial-release build_time=809 run_time=383
gcc-7.2.0-Serial-release build_time=277 run_time=165
ibm-16.1.0-Serial-release build_time=1514 run_time=272
#######################################################
FAILED TESTS
#######################################################

Kokkos-dev spot check:
#######################################################
PASSED TESTS
#######################################################
clang-4.0.1-Pthread_Serial-hwloc-release build_time=728 run_time=381
clang-4.0.1-Pthread_Serial-release build_time=757 run_time=598
cuda-8.0.44-Cuda_OpenMP-release build_time=1258 run_time=578
gcc-5.3.0-Serial-hwloc-release build_time=513 run_time=191
gcc-5.3.0-Serial-release build_time=510 run_time=214
gcc-7.2.0-Serial-hwloc-release build_time=438 run_time=172
gcc-7.2.0-Serial-release build_time=430 run_time=181
intel-17.0.1-OpenMP-hwloc-release build_time=1006 run_time=164
intel-17.0.1-OpenMP-release build_time=959 run_time=119
#######################################################
FAILED TESTS
#######################################################
