### PR TITLE
Use up-to-date Kokkos features to get team size

### DIFF
--- a/perf_test/sparse/KokkosSparse_run_spgemm.hpp
+++ b/perf_test/sparse/KokkosSparse_run_spgemm.hpp
@@ -319,8 +319,9 @@ crsMat_t3 run_experiment(
 	  row_mapC = lno_view_t
 			  ("non_const_lnow_row",
 					  m + 1);
-	  entriesC = lno_nnz_view_t ();
-	  valuesC = scalar_view_t ();
+	  entriesC = lno_nnz_view_t ("entriesC (empty)", 0);
+	  valuesC = scalar_view_t ("valuesC (empty)", 0);
+
 
 	  Kokkos::Impl::Timer timer1;
 	  spgemm_symbolic (

--- a/perf_test/sparse/KokkosSparse_run_spgemm.hpp
+++ b/perf_test/sparse/KokkosSparse_run_spgemm.hpp
@@ -319,8 +319,8 @@ crsMat_t3 run_experiment(
 	  row_mapC = lno_view_t
 			  ("non_const_lnow_row",
 					  m + 1);
-	  entriesC = lno_nnz_view_t ("");
-	  valuesC = scalar_view_t ("");
+	  entriesC = lno_nnz_view_t ();
+	  valuesC = scalar_view_t ();
 
 	  Kokkos::Impl::Timer timer1;
 	  spgemm_symbolic (

--- a/src/graph/KokkosGraph_Distance1ColorHandle.hpp
+++ b/src/graph/KokkosGraph_Distance1ColorHandle.hpp
@@ -521,17 +521,11 @@ private:
             vector_size,
             nv, ne);
 
-        team_policy_t tmp_policy(nv, Kokkos::AUTO, vector_size);
-        int max_allowed_team_size = tmp_policy.team_size_max( clt, Kokkos::ParallelForTag() );
-
-        KokkosKernels::Impl::get_suggested_team_size<HandleExecSpace>(
-            max_allowed_team_size,
-            vector_size,
-            teamSizeMax);
+        teamSizeMax = KokkosKernels::Impl::get_suggested_team_size<team_policy_t>(clt, vector_size);
 #endif
 
         Kokkos::parallel_for("KokkosGraph::CountLowerTriangleTeam",
-            team_policy_t(nv / teamSizeMax + 1 , teamSizeMax, vector_size),
+            team_policy_t((nv + teamSizeMax - 1) / teamSizeMax, teamSizeMax, vector_size),
             clt//, new_num_edge
         );
 


### PR DESCRIPTION
A permanent fix for #474, replacing the temporary one in #472. When Kokkos deprecated is off and the execution space is CUDA, ``KokkosKernels::Impl::get_suggested_team_size()`` uses ``TeamPolicy::team_size_recommmended()``, which calls ``cudaOccupancyMaxActiveBlocksPerMultiprocessor()``. This should be a good heuristic, and will definitely never produce a team size too high to launch, since the CUDA runtime knows exactly how many registers a kernel uses.

This change doesn't affect SPGEMM, SPMV or Blas. ``KokkosKernels::Impl::get_suggested_team_size()`` is only used in the utility functions ``symmetrize_and_get_lower_diagonal_edge_list()`` and ``symmetrize_graph_symbolic_hashmap()``, as well as ``get_lower_diagonal_edge_list()`` used during Dist1 coloring setup.

Bowman spot check:
#######################################################
PASSED TESTS
#######################################################
intel-16.4.258-Pthread-release build_time=1507 run_time=585
intel-16.4.258-Pthread_Serial-release build_time=2443 run_time=1248
intel-16.4.258-Serial-release build_time=1459 run_time=618
intel-17.2.174-OpenMP-release build_time=1951 run_time=371
intel-17.2.174-OpenMP_Serial-release build_time=2835 run_time=1136
intel-17.2.174-Pthread-release build_time=1305 run_time=630
intel-17.2.174-Pthread_Serial-release build_time=2381 run_time=1269
intel-17.2.174-Serial-release build_time=1388 run_time=660
intel-18.2.199-OpenMP-release build_time=1587 run_time=420
intel-18.2.199-OpenMP_Serial-release build_time=2761 run_time=1008
intel-18.2.199-Pthread-release build_time=1208 run_time=625
intel-18.2.199-Pthread_Serial-release build_time=2363 run_time=1226
intel-18.2.199-Serial-release build_time=1188 run_time=654
#######################################################
FAILED TESTS
#######################################################

White spot check:
#######################################################
PASSED TESTS
#######################################################
cuda-10.0.130-Cuda_Serial-release build_time=1245 run_time=369
cuda-9.2.88-Cuda_OpenMP-release build_time=1197 run_time=305
gcc-6.4.0-OpenMP_Serial-release build_time=635 run_time=366
gcc-7.2.0-OpenMP-release build_time=515 run_time=146
gcc-7.2.0-OpenMP_Serial-release build_time=665 run_time=448
gcc-7.2.0-Serial-release build_time=285 run_time=212
ibm-16.1.0-Serial-release build_time=1398 run_time=271
#######################################################
FAILED TESTS
#######################################################

kokkos-dev spot check:
#######################################################
PASSED TESTS
#######################################################
clang-4.0.1-Pthread_Serial-hwloc-release build_time=739 run_time=367
clang-4.0.1-Pthread_Serial-release build_time=769 run_time=606
cuda-8.0.44-Cuda_OpenMP-release build_time=1265 run_time=339
gcc-5.3.0-Serial-hwloc-release build_time=506 run_time=191
gcc-5.3.0-Serial-release build_time=504 run_time=214
gcc-7.2.0-Serial-hwloc-release build_time=437 run_time=188
gcc-7.2.0-Serial-release build_time=433 run_time=168
intel-17.0.1-OpenMP-hwloc-release build_time=980 run_time=165
intel-17.0.1-OpenMP-release build_time=950 run_time=123
#######################################################
FAILED TESTS
#######################################################