### PR TITLE
Fix unreachable warning in IOUtils (#481)

### DIFF
--- a/src/common/KokkosKernels_IOUtils.hpp
+++ b/src/common/KokkosKernels_IOUtils.hpp
@@ -1023,18 +1023,21 @@ int read_mtx (
   {
     if(!std::is_floating_point<scalar_t>::value)
       throw std::runtime_error("scalar_t in read_mtx() incompatible with float or double typed MatrixMarket file.");
-    mtx_field = REAL;
+    else
+      mtx_field = REAL;
   }
   else if (fline.find("complex") != std::string::npos){
     if(!(std::is_same<scalar_t, Kokkos::complex<float>>::value ||
           std::is_same<scalar_t, Kokkos::complex<double>>::value))
       throw std::runtime_error("scalar_t in read_mtx() incompatible with complex-typed MatrixMarket file.");
-    mtx_field = COMPLEX;
+    else
+      mtx_field = COMPLEX;
   }
   else if (fline.find("integer") != std::string::npos){
-    if(!std::is_integral<scalar_t>::value)
+    if(std::is_integral<scalar_t>::value)
+      mtx_field = INTEGER;
+    else
       throw std::runtime_error("scalar_t in read_mtx() incompatible with integer-typed MatrixMarket file.");
-    mtx_field = INTEGER;
   }
   else if (fline.find("pattern") != std::string::npos){
     mtx_field = PATTERN;


### PR DESCRIPTION
Bowman spot check:
#######################################################
PASSED TESTS
#######################################################
intel-16.4.258-Pthread-release build_time=1523 run_time=583
intel-16.4.258-Pthread_Serial-release build_time=2437 run_time=1261
intel-16.4.258-Serial-release build_time=1468 run_time=622
intel-17.2.174-OpenMP-release build_time=1967 run_time=385
intel-17.2.174-OpenMP_Serial-release build_time=2833 run_time=1156
intel-17.2.174-Pthread-release build_time=1313 run_time=620
intel-17.2.174-Pthread_Serial-release build_time=2371 run_time=1252
intel-17.2.174-Serial-release build_time=1370 run_time=662
intel-18.2.199-OpenMP-release build_time=1595 run_time=436
intel-18.2.199-OpenMP_Serial-release build_time=2735 run_time=1031
intel-18.2.199-Pthread-release build_time=1243 run_time=626
intel-18.2.199-Pthread_Serial-release build_time=2320 run_time=1217
intel-18.2.199-Serial-release build_time=1224 run_time=655
#######################################################
FAILED TESTS
#######################################################

White spot check:
#######################################################
PASSED TESTS
#######################################################
cuda-10.0.130-Cuda_Serial-release build_time=1113 run_time=365
cuda-9.2.88-Cuda_OpenMP-release build_time=1127 run_time=307
gcc-6.4.0-OpenMP_Serial-release build_time=574 run_time=330
gcc-7.2.0-OpenMP-release build_time=394 run_time=138
gcc-7.2.0-OpenMP_Serial-release build_time=596 run_time=421
gcc-7.2.0-Serial-release build_time=250 run_time=186
ibm-16.1.0-Serial-release build_time=1345 run_time=271
#######################################################
FAILED TESTS
#######################################################

kokkos-dev spot check:
#######################################################
PASSED TESTS
#######################################################
clang-4.0.1-Pthread_Serial-hwloc-release build_time=719 run_time=393
clang-4.0.1-Pthread_Serial-release build_time=727 run_time=616
cuda-8.0.44-Cuda_OpenMP-release build_time=1241 run_time=334
gcc-5.3.0-Serial-hwloc-release build_time=497 run_time=212
gcc-5.3.0-Serial-release build_time=496 run_time=207
gcc-7.2.0-Serial-hwloc-release build_time=447 run_time=194
gcc-7.2.0-Serial-release build_time=430 run_time=182
intel-17.0.1-OpenMP-hwloc-release build_time=978 run_time=170
intel-17.0.1-OpenMP-release build_time=946 run_time=120
#######################################################
FAILED TESTS
#######################################################
