### PR TITLE
Gauss-Seidel: rank-2 X/Y support

### DIFF
--- a/src/common/KokkosKernels_Handle.hpp
+++ b/src/common/KokkosKernels_Handle.hpp
@@ -195,6 +195,7 @@ public:
   typedef typename size_type_persistent_work_view_t::HostMirror size_type_persistent_work_host_view_t; //Host view type
   typedef typename Kokkos::View<nnz_scalar_t *, HandleTempMemorySpace> scalar_temp_work_view_t;
   typedef typename Kokkos::View<nnz_scalar_t *, HandlePersistentMemorySpace> scalar_persistent_work_view_t;
+  typedef typename Kokkos::View<nnz_scalar_t **, Kokkos::LayoutLeft, HandlePersistentMemorySpace> scalar_persistent_work_view2d_t;
   typedef typename Kokkos::View<nnz_lno_t *, HandleTempMemorySpace> nnz_lno_temp_work_view_t;
   typedef typename Kokkos::View<nnz_lno_t *, HandlePersistentMemorySpace> nnz_lno_persistent_work_view_t;
   typedef typename nnz_lno_persistent_work_view_t::HostMirror nnz_lno_persistent_work_host_view_t; //Host view type

--- a/src/common/KokkosKernels_Utils.hpp
+++ b/src/common/KokkosKernels_Utils.hpp
@@ -938,10 +938,12 @@ struct PermuteVector{
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const idx &ii) const {
-
     idx mapping = ii;
-    if (ii < mapping_size) mapping = old_to_new_mapping[ii];
-    new_vector[mapping] = old_vector[ii];
+    if (ii < mapping_size)
+      mapping = old_to_new_mapping[ii];
+    for (idx j = 0; j < (idx) new_vector.extent(1); j++) {
+      new_vector.access(mapping, j) = old_vector.access(ii, j);
+    }
   }
 };
 
@@ -980,10 +982,12 @@ struct PermuteBlockVector{
   void operator()(const idx &ii) const {
 
     idx mapping = ii;
-    if (ii < mapping_size) mapping = old_to_new_mapping[ii];
-
-    for (int i = 0; i < block_size; ++i){
-    	new_vector[mapping*block_size + i] = old_vector[ii * block_size + i];
+    if (ii < mapping_size)
+      mapping = old_to_new_mapping[ii];
+    for (idx j = 0; j < (idx) new_vector.extent(1); j++) {
+      for (int i = 0; i < block_size; ++i){
+        new_vector.access(mapping*block_size + i, j) = old_vector.access(ii * block_size + i, j);
+      }
     }
   }
 };

--- a/src/sparse/KokkosSparse_gauss_seidel.hpp
+++ b/src/sparse/KokkosSparse_gauss_seidel.hpp
@@ -334,8 +334,21 @@ namespace KokkosSparse{
                      typename x_scalar_view_t::value_type>::value,
                      "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the x-vector should be same as kernelHandle non-const scalar_t.");
 
+      static_assert (!std::is_same<typename lno_row_view_t_::array_layout, Kokkos::LayoutStride>::value,
+                     "KokkosSparse::symmetric_gauss_seidel_apply: row_map must have a contiguous layout (Left or Right, not Stride)");
+      static_assert (!std::is_same<typename lno_nnz_view_t_::array_layout, Kokkos::LayoutStride>::value,
+                     "KokkosSparse::symmetric_gauss_seidel_apply: entries must have a contiguous layout (Left or Right, not Stride)");
+      static_assert (!std::is_same<typename scalar_nnz_view_t_::array_layout, Kokkos::LayoutStride>::value,
+                     "KokkosSparse::symmetric_gauss_seidel_apply: values must have a contiguous layout (Left or Right, not Stride)");
 
-
+      // Check compatibility of #vectors
+      if(x_lhs_output_vec.extent(1) != y_rhs_input_vec.extent(1))
+      {
+        std::ostringstream os;
+        os << "KokkosSparse::symmetric_gauss_seidel_apply: " <<
+          "X has " << x_lhs_output_vec.extent(1) << "columns, Y has " << y_rhs_input_vec.extent(1) << " columns.";
+        Kokkos::Impl::throw_runtime_exception (os.str ());
+      }
 
       typedef typename KernelHandle::const_size_type c_size_t;
       typedef typename KernelHandle::const_nnz_lno_t c_lno_t;
@@ -346,7 +359,6 @@ namespace KokkosSparse{
       typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
 
       typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
-      //const_handle_type tmp_handle = *handle;
       const_handle_type tmp_handle (*handle);
 
       typedef Kokkos::View<
@@ -367,47 +379,37 @@ namespace KokkosSparse{
         typename scalar_nnz_view_t_::device_type,
         Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_ascalar_nnz_view_t_;
 
-
       typedef Kokkos::View<
-        typename y_scalar_view_t::const_value_type*,
+        typename y_scalar_view_t::const_value_type**,
         typename KokkosKernels::Impl::GetUnifiedLayout<y_scalar_view_t>::array_layout,
         typename y_scalar_view_t::device_type,
         Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_yscalar_nnz_view_t_;
 
       typedef Kokkos::View<
-        typename x_scalar_view_t::non_const_value_type*,
+        typename x_scalar_view_t::non_const_value_type**,
         typename KokkosKernels::Impl::GetUnifiedLayout<x_scalar_view_t>::array_layout,
         typename x_scalar_view_t::device_type,
         Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_xscalar_nnz_view_t_;
-
-      /*
-
-        Internal_alno_row_view_t_ const_a_r  = row_map;
-        Internal_alno_nnz_view_t_ const_a_l  = entries;
-        Internal_ascalar_nnz_view_t_ const_a_v  = values;
-        Internal_xscalar_nnz_view_t_ nonconst_x_v = x_lhs_output_vec;
-        Internal_yscalar_nnz_view_t_ const_y_v = y_rhs_input_vec;
-      */
 
       Internal_alno_row_view_t_ const_a_r (row_map.data(), row_map.extent(0));
       Internal_alno_nnz_view_t_ const_a_l (entries.data(), entries.extent(0));
       Internal_ascalar_nnz_view_t_ const_a_v (values.data(), values.extent(0));
 
-      Internal_xscalar_nnz_view_t_ nonconst_x_v (x_lhs_output_vec.data(), x_lhs_output_vec.extent(0));
-      Internal_yscalar_nnz_view_t_ const_y_v (y_rhs_input_vec.data(), y_rhs_input_vec.extent(0));
+      Internal_xscalar_nnz_view_t_ nonconst_x_v (x_lhs_output_vec.data(), x_lhs_output_vec.extent(0), x_lhs_output_vec.extent(1));
+      Internal_yscalar_nnz_view_t_ const_y_v (y_rhs_input_vec.data(), y_rhs_input_vec.extent(0), y_rhs_input_vec.extent(1));
 
       using namespace KokkosSparse::Impl;
 
       GAUSS_SEIDEL_APPLY<const_handle_type,
                          Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_,
                          Internal_xscalar_nnz_view_t_, Internal_yscalar_nnz_view_t_>::gauss_seidel_apply (
-                                                                                                          &tmp_handle, num_rows, num_cols,
-                                                                                                          const_a_r, const_a_l, const_a_v,
-                                                                                                          nonconst_x_v, const_y_v,
-                                                                                                          init_zero_x_vector,
-                                                                                                          update_y_vector,
-                                                                                                          omega,
-                                                                                                          numIter, true, true);
+                             &tmp_handle, num_rows, num_cols,
+                             const_a_r, const_a_l, const_a_v,
+                             nonconst_x_v, const_y_v,
+                             init_zero_x_vector,
+                             update_y_vector,
+                             omega,
+                             numIter, true, true);
 
 
     }
@@ -431,12 +433,22 @@ namespace KokkosSparse{
                                             bool init_zero_x_vector,
                                             bool update_y_vector,
                                             typename KernelHandle::nnz_scalar_t omega,
-                                            int numIter){
+                                            int numIter)
+    {
+      // Check compatibility of dimensions at run time.
+      if(x_lhs_output_vec.extent(1) != y_rhs_input_vec.extent(1))
+      {
+        std::ostringstream os;
+        os << "KokkosSparse::symmetric_block_gauss_seidel_apply: Dimensions of X and Y do not match: " <<
+          "X has " << x_lhs_output_vec.extent(1) << "columns, Y has " << y_rhs_input_vec.extent(1) << " columns.";
+        Kokkos::Impl::throw_runtime_exception (os.str ());
+      }
       auto gsHandle = handle->get_point_gs_handle();
       if(gsHandle->get_algorithm_type() == GS_CLUSTER)
       {
         throw std::runtime_error("Block versions of Gauss-Seidel are incompatible with algorithm GS_CLUSTER");
       }
+
       gsHandle->set_block_size(block_size);
       symmetric_gauss_seidel_apply(handle,num_rows,num_cols,
                                    row_map,
@@ -466,30 +478,43 @@ namespace KokkosSparse{
                                           bool init_zero_x_vector,
                                           bool update_y_vector,
                                           typename KernelHandle::nnz_scalar_t omega,
-                                          int numIter){
-
+                                          int numIter)
+    {
       static_assert (std::is_same<typename KernelHandle::const_size_type,
                      typename lno_row_view_t_::const_value_type>::value,
-                     "KokkosSparse::symmetric_gauss_seidel_apply: Size type of the matrix should be same as kernelHandle sizetype.");
+                     "KokkosSparse::forward_sweep_gauss_seidel_apply: Size type of the matrix should be same as kernelHandle sizetype.");
 
       static_assert (std::is_same<typename KernelHandle::const_nnz_lno_t,
                      typename lno_nnz_view_t_::const_value_type>::value,
-                     "KokkosSparse::symmetric_gauss_seidel_apply: lno type of the matrix should be same as kernelHandle lno_t.");
+                     "KokkosSparse::forward_sweep_gauss_seidel_apply: lno type of the matrix should be same as kernelHandle lno_t.");
 
       static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
                      typename scalar_nnz_view_t_::const_value_type>::value,
-                     "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the matrix should be same as kernelHandle scalar_t.");
+                     "KokkosSparse::forward_sweep_gauss_seidel_apply: scalar type of the matrix should be same as kernelHandle scalar_t.");
 
       static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
                      typename y_scalar_view_t::const_value_type>::value,
-                     "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the y-vector should be same as kernelHandle scalar_t.");
+                     "KokkosSparse::forward_sweep_gauss_seidel_apply: scalar type of the y-vector should be same as kernelHandle scalar_t.");
 
       static_assert (std::is_same<typename KernelHandle::nnz_scalar_t,
                      typename x_scalar_view_t::value_type>::value,
-                     "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the x-vector should be same as kernelHandle non-const scalar_t.");
+                     "KokkosSparse::forward_sweep_gauss_seidel_apply: scalar type of the x-vector should be same as kernelHandle non-const scalar_t.");
 
+      static_assert (!std::is_same<typename lno_row_view_t_::array_layout, Kokkos::LayoutStride>::value,
+                     "KokkosSparse::forward_sweep_gauss_seidel_apply: row_map must have a contiguous layout (Left or Right, not Stride)");
+      static_assert (!std::is_same<typename lno_nnz_view_t_::array_layout, Kokkos::LayoutStride>::value,
+                     "KokkosSparse::forward_sweep_gauss_seidel_apply: entries must have a contiguous layout (Left or Right, not Stride)");
+      static_assert (!std::is_same<typename scalar_nnz_view_t_::array_layout, Kokkos::LayoutStride>::value,
+                     "KokkosSparse::forward_sweep_gauss_seidel_apply: values must have a contiguous layout (Left or Right, not Stride)");
 
-
+      // Check compatibility of dimensions at run time.
+      if(x_lhs_output_vec.extent(1) != y_rhs_input_vec.extent(1))
+      {
+        std::ostringstream os;
+        os << "KokkosSparse::forward_sweep_gauss_seidel_apply: Dimensions of X and Y do not match: " <<
+          "X has " << x_lhs_output_vec.extent(1) << "columns, Y has " << y_rhs_input_vec.extent(1) << " columns.";
+        Kokkos::Impl::throw_runtime_exception (os.str ());
+      }
 
       typedef typename KernelHandle::const_size_type c_size_t;
       typedef typename KernelHandle::const_nnz_lno_t c_lno_t;
@@ -521,50 +546,37 @@ namespace KokkosSparse{
         typename scalar_nnz_view_t_::device_type,
         Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_ascalar_nnz_view_t_;
 
-
       typedef Kokkos::View<
-        typename y_scalar_view_t::const_value_type*,
+        typename y_scalar_view_t::const_value_type**,
         typename KokkosKernels::Impl::GetUnifiedLayout<y_scalar_view_t>::array_layout,
         typename y_scalar_view_t::device_type,
         Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_yscalar_nnz_view_t_;
 
       typedef Kokkos::View<
-        typename x_scalar_view_t::non_const_value_type*,
+        typename x_scalar_view_t::non_const_value_type**,
         typename KokkosKernels::Impl::GetUnifiedLayout<x_scalar_view_t>::array_layout,
         typename x_scalar_view_t::device_type,
         Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_xscalar_nnz_view_t_;
-
-      /*
-        Internal_alno_row_view_t_ const_a_r  = row_map;
-        Internal_alno_nnz_view_t_ const_a_l  = entries;
-        Internal_ascalar_nnz_view_t_ const_a_v  = values;
-        Internal_xscalar_nnz_view_t_ nonconst_x_v = x_lhs_output_vec;
-        Internal_yscalar_nnz_view_t_ const_y_v = y_rhs_input_vec;
-      */
 
       Internal_alno_row_view_t_ const_a_r (row_map.data(), row_map.extent(0));
       Internal_alno_nnz_view_t_ const_a_l (entries.data(), entries.extent(0));
       Internal_ascalar_nnz_view_t_ const_a_v (values.data(), values.extent(0));
 
-      Internal_xscalar_nnz_view_t_ nonconst_x_v (x_lhs_output_vec.data(), x_lhs_output_vec.extent(0));
-      Internal_yscalar_nnz_view_t_ const_y_v (y_rhs_input_vec.data(), y_rhs_input_vec.extent(0));
-
-
+      Internal_xscalar_nnz_view_t_ nonconst_x_v (x_lhs_output_vec.data(), x_lhs_output_vec.extent(0), x_lhs_output_vec.extent(1));
+      Internal_yscalar_nnz_view_t_ const_y_v (y_rhs_input_vec.data(), y_rhs_input_vec.extent(0), y_rhs_input_vec.extent(1));
 
       using namespace KokkosSparse::Impl;
 
       GAUSS_SEIDEL_APPLY<const_handle_type,
                          Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_,
-                         Internal_xscalar_nnz_view_t_, Internal_yscalar_nnz_view_t_>::gauss_seidel_apply(
-                                                                                                         &tmp_handle, num_rows, num_cols,
-                                                                                                         const_a_r, const_a_l, const_a_v,
-                                                                                                         nonconst_x_v, const_y_v,
-                                                                                                         init_zero_x_vector,
-                                                                                                         update_y_vector,
-                                                                                                         omega,
-                                                                                                         numIter, true, false);
-
-
+                         Internal_xscalar_nnz_view_t_, Internal_yscalar_nnz_view_t_>::gauss_seidel_apply (
+                             &tmp_handle, num_rows, num_cols,
+                             const_a_r, const_a_l, const_a_v,
+                             nonconst_x_v, const_y_v,
+                             init_zero_x_vector,
+                             update_y_vector,
+                             omega,
+                             numIter, true, false);
     }
 
 
@@ -587,7 +599,17 @@ namespace KokkosSparse{
                                                 bool init_zero_x_vector,
                                                 bool update_y_vector,
                                                 typename KernelHandle::nnz_scalar_t omega,
-                                                int numIter){
+                                                int numIter)
+    {
+      // Check compatibility of dimensions at run time.
+      if(x_lhs_output_vec.extent(1) != y_rhs_input_vec.extent(1))
+      {
+        std::ostringstream os;
+        os << "KokkosSparse::forward_sweep_block_gauss_seidel_apply: Dimensions of X and Y do not match: " <<
+          "X has " << x_lhs_output_vec.extent(1) << "columns, Y has " << y_rhs_input_vec.extent(1) << " columns.";
+        Kokkos::Impl::throw_runtime_exception (os.str ());
+      }
+
       auto gsHandle = handle->get_point_gs_handle();
       if(gsHandle->get_algorithm_type() == GS_CLUSTER)
       {
@@ -626,26 +648,39 @@ namespace KokkosSparse{
 
       static_assert (std::is_same<typename KernelHandle::const_size_type,
                      typename lno_row_view_t_::const_value_type>::value,
-                     "KokkosSparse::symmetric_gauss_seidel_apply: Size type of the matrix should be same as kernelHandle sizetype.");
+                     "KokkosSparse::backward_sweep_gauss_seidel_apply: Size type of the matrix should be same as kernelHandle sizetype.");
 
       static_assert (std::is_same<typename KernelHandle::const_nnz_lno_t,
                      typename lno_nnz_view_t_::const_value_type>::value,
-                     "KokkosSparse::symmetric_gauss_seidel_apply: lno type of the matrix should be same as kernelHandle lno_t.");
+                     "KokkosSparse::backward_sweep_gauss_seidel_apply: lno type of the matrix should be same as kernelHandle lno_t.");
 
       static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
                      typename scalar_nnz_view_t_::const_value_type>::value,
-                     "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the matrix should be same as kernelHandle scalar_t.");
+                     "KokkosSparse::backward_sweep_gauss_seidel_apply: scalar type of the matrix should be same as kernelHandle scalar_t.");
 
       static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
                      typename y_scalar_view_t::const_value_type>::value,
-                     "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the y-vector should be same as kernelHandle scalar_t.");
+                     "KokkosSparse::backward_sweep_gauss_seidel_apply: scalar type of the y-vector should be same as kernelHandle scalar_t.");
 
       static_assert (std::is_same<typename KernelHandle::nnz_scalar_t,
                      typename x_scalar_view_t::value_type>::value,
-                     "KokkosSparse::symmetric_gauss_seidel_apply: scalar type of the x-vector should be same as kernelHandle non-const scalar_t.");
+                     "KokkosSparse::backward_sweep_gauss_seidel_apply: scalar type of the x-vector should be same as kernelHandle non-const scalar_t.");
 
+      static_assert (!std::is_same<typename lno_row_view_t_::array_layout, Kokkos::LayoutStride>::value,
+                     "KokkosSparse::backward_sweep_gauss_seidel_apply: row_map must have a contiguous layout (Left or Right, not Stride)");
+      static_assert (!std::is_same<typename lno_nnz_view_t_::array_layout, Kokkos::LayoutStride>::value,
+                     "KokkosSparse::backward_sweep_gauss_seidel_apply: entries must have a contiguous layout (Left or Right, not Stride)");
+      static_assert (!std::is_same<typename scalar_nnz_view_t_::array_layout, Kokkos::LayoutStride>::value,
+                     "KokkosSparse::backward_sweep_gauss_seidel_apply: values must have a contiguous layout (Left or Right, not Stride)");
 
-
+      // Check compatibility of dimensions at run time.
+      if(x_lhs_output_vec.extent(1) != y_rhs_input_vec.extent(1))
+      {
+        std::ostringstream os;
+        os << "KokkosSparse::backward_sweep_gauss_seidel_apply: Dimensions of X and Y do not match: " <<
+          "X has " << x_lhs_output_vec.extent(1) << "columns, Y has " << y_rhs_input_vec.extent(1) << " columns.";
+        Kokkos::Impl::throw_runtime_exception (os.str ());
+      }
 
       typedef typename KernelHandle::const_size_type c_size_t;
       typedef typename KernelHandle::const_nnz_lno_t c_lno_t;
@@ -677,46 +712,37 @@ namespace KokkosSparse{
         typename scalar_nnz_view_t_::device_type,
         Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_ascalar_nnz_view_t_;
 
-
       typedef Kokkos::View<
-        typename y_scalar_view_t::const_value_type*,
+        typename y_scalar_view_t::const_value_type**,
         typename KokkosKernels::Impl::GetUnifiedLayout<y_scalar_view_t>::array_layout,
         typename y_scalar_view_t::device_type,
         Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_yscalar_nnz_view_t_;
 
       typedef Kokkos::View<
-        typename x_scalar_view_t::non_const_value_type*,
+        typename x_scalar_view_t::non_const_value_type**,
         typename KokkosKernels::Impl::GetUnifiedLayout<x_scalar_view_t>::array_layout,
         typename x_scalar_view_t::device_type,
         Kokkos::MemoryTraits<Kokkos::Unmanaged> > Internal_xscalar_nnz_view_t_;
 
-      /*
-        Internal_alno_row_view_t_ const_a_r  = row_map;
-        Internal_alno_nnz_view_t_ const_a_l  = entries;
-        Internal_ascalar_nnz_view_t_ const_a_v  = values;
-        Internal_xscalar_nnz_view_t_ nonconst_x_v = x_lhs_output_vec;
-        Internal_yscalar_nnz_view_t_ const_y_v = y_rhs_input_vec;
-      */
       Internal_alno_row_view_t_ const_a_r (row_map.data(), row_map.extent(0));
       Internal_alno_nnz_view_t_ const_a_l (entries.data(), entries.extent(0));
       Internal_ascalar_nnz_view_t_ const_a_v (values.data(), values.extent(0));
 
-      Internal_xscalar_nnz_view_t_ nonconst_x_v (x_lhs_output_vec.data(), x_lhs_output_vec.extent(0));
-      Internal_yscalar_nnz_view_t_ const_y_v (y_rhs_input_vec.data(), y_rhs_input_vec.extent(0));
-
+      Internal_xscalar_nnz_view_t_ nonconst_x_v (x_lhs_output_vec.data(), x_lhs_output_vec.extent(0), x_lhs_output_vec.extent(1));
+      Internal_yscalar_nnz_view_t_ const_y_v (y_rhs_input_vec.data(), y_rhs_input_vec.extent(0), y_rhs_input_vec.extent(1));
 
       using namespace KokkosSparse::Impl;
 
       GAUSS_SEIDEL_APPLY<const_handle_type,
                          Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_,
                          Internal_xscalar_nnz_view_t_, Internal_yscalar_nnz_view_t_>::gauss_seidel_apply (
-                                                                                                          &tmp_handle, num_rows, num_cols,
-                                                                                                          const_a_r, const_a_l, const_a_v,
-                                                                                                          nonconst_x_v, const_y_v,
-                                                                                                          init_zero_x_vector,
-                                                                                                          update_y_vector,
-                                                                                                          omega,
-                                                                                                          numIter, false, true);
+                             &tmp_handle, num_rows, num_cols,
+                             const_a_r, const_a_l, const_a_v,
+                             nonconst_x_v, const_y_v,
+                             init_zero_x_vector,
+                             update_y_vector,
+                             omega,
+                             numIter, false, true);
 
 
     }
@@ -740,7 +766,16 @@ namespace KokkosSparse{
                                                  bool init_zero_x_vector,
                                                  bool update_y_vector,
                                                  typename KernelHandle::nnz_scalar_t omega,
-                                                 int numIter){
+                                                 int numIter)
+    {
+      // Check compatibility of dimensions at run time.
+      if(x_lhs_output_vec.extent(1) != y_rhs_input_vec.extent(1))
+      {
+        std::ostringstream os;
+        os << "KokkosSparse::backward_sweep_block_gauss_seidel_apply: Dimensions of X and Y do not match: " <<
+          "X has " << x_lhs_output_vec.extent(1) << "columns, Y has " << y_rhs_input_vec.extent(1) << " columns.";
+        Kokkos::Impl::throw_runtime_exception (os.str ());
+      }
       auto gsHandle = handle->get_point_gs_handle();
       if(gsHandle->get_algorithm_type() == GS_CLUSTER)
       {

--- a/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
+++ b/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
@@ -228,6 +228,7 @@ namespace KokkosSparse{
 
     typedef typename Kokkos::View<nnz_scalar_t *, HandleTempMemorySpace> scalar_temp_work_view_t;
     typedef typename Kokkos::View<nnz_scalar_t *, HandlePersistentMemorySpace> scalar_persistent_work_view_t;
+    typedef typename Kokkos::View<nnz_scalar_t **, Kokkos::LayoutLeft, HandlePersistentMemorySpace> scalar_persistent_work_view2d_t;
     typedef typename scalar_persistent_work_view_t::HostMirror scalar_persistent_work_host_view_t; //Host view type
 
     typedef typename Kokkos::View<nnz_lno_t *, HandleTempMemorySpace> nnz_lno_temp_work_view_t;
@@ -240,8 +241,8 @@ namespace KokkosSparse{
     scalar_persistent_work_view_t permuted_adj_vals;
     nnz_lno_persistent_work_view_t old_to_new_map;
 
-    scalar_persistent_work_view_t permuted_y_vector;
-    scalar_persistent_work_view_t permuted_x_vector;
+    scalar_persistent_work_view2d_t permuted_y_vector;
+    scalar_persistent_work_view2d_t permuted_x_vector;
 
     scalar_persistent_work_view_t permuted_inverse_diagonal;
     nnz_lno_t block_size; //this is for block sgs
@@ -416,17 +417,18 @@ namespace KokkosSparse{
       this->max_nnz_input_row = num_result_nnz_;
     }
 
-    void allocate_x_y_vectors(nnz_lno_t num_rows, nnz_lno_t num_cols){
-      if(permuted_y_vector.extent(0) != size_t(num_rows)){
-        permuted_y_vector = scalar_persistent_work_view_t("PERMUTED Y VECTOR", num_rows);
+    void allocate_x_y_vectors(nnz_lno_t num_rows, nnz_lno_t num_cols, nnz_lno_t num_vecs){
+      if(permuted_y_vector.extent(0) != size_t(num_rows) || permuted_y_vector.extent(1) != size_t(num_vecs)){
+        permuted_y_vector = scalar_persistent_work_view2d_t("PERMUTED Y VECTOR", num_rows, num_vecs);
       }
-      if(permuted_x_vector.extent(0) != size_t(num_cols)){
-        permuted_x_vector = scalar_persistent_work_view_t("PERMUTED X VECTOR", num_cols);
+      if(permuted_x_vector.extent(0) != size_t(num_cols) || permuted_x_vector.extent(1) != size_t(num_vecs)){
+        permuted_x_vector = scalar_persistent_work_view2d_t("PERMUTED X VECTOR", num_cols, num_vecs);
       }
     }
 
-    scalar_persistent_work_view_t get_permuted_y_vector() const {return this->permuted_y_vector;}
-    scalar_persistent_work_view_t get_permuted_x_vector() const {return this->permuted_x_vector;}
+    scalar_persistent_work_view2d_t get_permuted_y_vector() const {return this->permuted_y_vector;}
+    scalar_persistent_work_view2d_t get_permuted_x_vector() const {return this->permuted_x_vector;}
+
     void vector_team_size(
                           int max_allowed_team_size,
                           int &suggested_vector_size_,

--- a/src/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
@@ -329,8 +329,6 @@ namespace KokkosSparse{
               for(nnz_lno_t j = _cluster_offsets(cluster); j < _cluster_offsets(cluster + 1); j++)
               {
                 nnz_lno_t row = _cluster_verts(j);
-                size_type row_begin = _xadj(row);
-                size_type row_end = _xadj(row + 1);
                 nnz_lno_t num_vecs = _Xvector.extent(1);
                 for(nnz_lno_t batch_start = 0; batch_start < num_vecs;)
                 {

--- a/src/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
@@ -135,7 +135,6 @@ namespace KokkosSparse{
       bool is_symmetric;
 
       static constexpr nnz_lno_t apply_batch_size = 16;
-      typedef typename KokkosKernels::Impl::array_sum_reduce<nnz_scalar_t, apply_batch_size> batch_sum;
 
     public:
 
@@ -186,11 +185,10 @@ namespace KokkosSparse{
         {}
 
         KOKKOS_FORCEINLINE_FUNCTION
-        void rowApply(const nnz_lno_t row) const
+        void rowApply(nnz_scalar_t* sum, const nnz_lno_t row) const
         {
           size_type row_begin = _xadj(row);
           size_type row_end = _xadj(row + 1);
-          nnz_scalar_t sum[apply_batch_size] = {0};
           nnz_lno_t num_vecs = _Xvector.extent(1);
           for(nnz_lno_t batch_start = 0; batch_start < num_vecs; batch_start += apply_batch_size)
           {
@@ -218,9 +216,10 @@ namespace KokkosSparse{
           //color_adj(ii) is a cluster in the current color set.
           nnz_lno_t clusterColorsetIndex = _color_set_begin + ii;
           nnz_lno_t cluster = _color_adj(clusterColorsetIndex);
+          nnz_scalar_t sum[apply_batch_size];
           for(nnz_lno_t j = _cluster_offsets(cluster); j < _cluster_offsets(cluster + 1); j++)
           {
-            rowApply(_cluster_verts(j));
+            rowApply(sum, _cluster_verts(j));
           }
         }
 
@@ -229,9 +228,10 @@ namespace KokkosSparse{
           //color_adj(ii) is a cluster in the current color set.
           nnz_lno_t clusterColorsetIndex =  _color_set_end - 1 - ii;
           nnz_lno_t cluster = _color_adj(clusterColorsetIndex);
+          nnz_scalar_t sum[apply_batch_size];
           for(nnz_lno_t j = _cluster_offsets(cluster + 1); j > _cluster_offsets(cluster); j--)
           {
-            rowApply(_cluster_verts(j - 1));
+            rowApply(sum, _cluster_verts(j - 1));
           }
         }
       };
@@ -288,6 +288,34 @@ namespace KokkosSparse{
           _omega(omega_)
         {}
 
+        template<int N>
+        KOKKOS_INLINE_FUNCTION void runColBatch(const team_member_t& teamMember, nnz_lno_t row, nnz_lno_t colStart) const
+        {
+          typedef KokkosKernels::Impl::array_sum_reduce<nnz_scalar_t, N> reducer; 
+          size_type row_begin = _xadj(row);
+          size_type row_end = _xadj(row + 1);
+          reducer sum;
+          Kokkos::parallel_reduce(
+            Kokkos::ThreadVectorRange(teamMember, row_end - row_begin),
+            [&] (size_type i, reducer& lsum)
+            {
+              size_type adjind = row_begin + i;
+              nnz_lno_t colIndex = _adj(adjind);
+              nnz_scalar_t val = _adj_vals(adjind);
+              for(int j = 0; j < N; j++)
+                lsum.data[j] += val * _Xvector(colIndex, colStart + j);
+            }, sum);
+          Kokkos::single(Kokkos::PerThread(teamMember),[=] ()
+          {
+            nnz_scalar_t invDiagonalVal = _inverse_diagonal(row);
+            for(int i = 0; i < N; i++)
+            {
+              _Xvector(row, colStart + i) +=
+                _omega * (_Yvector(row, colStart + i) - sum.data[i]) * invDiagonalVal;
+            }
+          });
+        }
+
         KOKKOS_INLINE_FUNCTION
         void operator()(const team_member_t& teamMember) const
         {
@@ -304,26 +332,27 @@ namespace KokkosSparse{
                 size_type row_begin = _xadj(row);
                 size_type row_end = _xadj(row + 1);
                 nnz_lno_t num_vecs = _Xvector.extent(1);
-                for(nnz_lno_t batch_start = 0; batch_start < num_vecs; batch_start += apply_batch_size)
+                for(nnz_lno_t batch_start = 0; batch_start < num_vecs;)
                 {
-                  nnz_lno_t this_batch_size = apply_batch_size;
-                  if(batch_start + this_batch_size >= num_vecs)
-                    this_batch_size = num_vecs - batch_start;
-                  batch_sum sum;
-                  Kokkos::parallel_reduce(
-                    Kokkos::ThreadVectorRange(teamMember, row_end - row_begin),
-                    [&] (size_type i, batch_sum& lsum)
-                    {
-                      size_type adjind = i + row_begin;
-                      nnz_lno_t colIndex = _adj(adjind);
-                      nnz_scalar_t val = _adj_vals(adjind);
-                      for(nnz_lno_t k = 0; k < this_batch_size; k++)
-                        lsum.data[k] += val * _Xvector(colIndex, batch_start + k);
-                    }, sum);
-                  Kokkos::single(Kokkos::PerThread(teamMember),[=] () {
-                    for(nnz_lno_t k = 0; k < this_batch_size; k++)
-                      _Xvector(row, batch_start + k) += _omega * (_Yvector(row, batch_start + k) - sum.data[k]) * _inverse_diagonal(row);
-                  });
+                  switch(num_vecs - batch_start)
+                  {
+                    #define COL_BATCH_CASE(n) \
+                    case n: \
+                            runColBatch<n>(teamMember, row, batch_start); \
+                            batch_start += n; \
+                            break;
+                    COL_BATCH_CASE(1)
+                    COL_BATCH_CASE(2)
+                    COL_BATCH_CASE(3)
+                    COL_BATCH_CASE(4)
+                    COL_BATCH_CASE(5)
+                    COL_BATCH_CASE(6)
+                    COL_BATCH_CASE(7)
+                    #undef COL_BATCH_CASE
+                    default:
+                      runColBatch<8>(teamMember, row, batch_start);
+                      batch_start += 8;
+                  }
                 }
               }
             });

--- a/src/sparse/impl/KokkosSparse_gauss_seidel_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_gauss_seidel_spec.hpp
@@ -110,19 +110,19 @@ namespace KokkosSparse {
                                             KokkosKernels::Experimental::KokkosKernelsHandle< \
                                                                                              const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
                                                                                              EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
-                                            Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE, \
+                                            Kokkos::View<const OFFSET_TYPE *, Kokkos::LayoutLeft, \
                                                          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-                                            Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE, \
+                                            Kokkos::View<const ORDINAL_TYPE *, Kokkos::LayoutLeft, \
                                                          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-                                            Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE, \
+                                            Kokkos::View<const SCALAR_TYPE *, Kokkos::LayoutLeft, \
                                                          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-                                            Kokkos::View< SCALAR_TYPE *, LAYOUT_TYPE, \
+                                            Kokkos::View< SCALAR_TYPE **, LAYOUT_TYPE, \
                                                           Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                                           Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-                                            Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE, \
+                                            Kokkos::View<const SCALAR_TYPE **, LAYOUT_TYPE, \
                                                          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                                          Kokkos::MemoryTraits<Kokkos::Unmanaged> > > \
   { enum : bool { value = true }; };
@@ -439,19 +439,19 @@ namespace KokkosSparse {
                       KokkosKernels::Experimental::KokkosKernelsHandle< \
                                                                        const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
                                                                        EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
-                      Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,    \
+                      Kokkos::View<const OFFSET_TYPE *, Kokkos::LayoutLeft,    \
                                    Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-                      Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,   \
+                      Kokkos::View<const ORDINAL_TYPE *, Kokkos::LayoutLeft,   \
                                    Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-                      Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,    \
+                      Kokkos::View<const SCALAR_TYPE *, Kokkos::LayoutLeft,    \
                                    Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-                      Kokkos::View<SCALAR_TYPE *, LAYOUT_TYPE,          \
+                      Kokkos::View<SCALAR_TYPE **, LAYOUT_TYPE, \
                                    Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-                      Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,    \
+                      Kokkos::View<const SCALAR_TYPE **, LAYOUT_TYPE, \
                                    Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> > , \
                       false, true >;
@@ -463,19 +463,19 @@ namespace KokkosSparse {
                       KokkosKernels::Experimental::KokkosKernelsHandle< \
                                                                        const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
                                                                        EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
-                      Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,    \
+                      Kokkos::View<const OFFSET_TYPE *, Kokkos::LayoutLeft,    \
                                    Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-                      Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,   \
+                      Kokkos::View<const ORDINAL_TYPE *, Kokkos::LayoutLeft,   \
                                    Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-                      Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,    \
+                      Kokkos::View<const SCALAR_TYPE *, Kokkos::LayoutLeft,    \
                                    Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-                      Kokkos::View<SCALAR_TYPE *, LAYOUT_TYPE,          \
+                      Kokkos::View<SCALAR_TYPE **, LAYOUT_TYPE, \
                                    Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-                      Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,    \
+                      Kokkos::View<const SCALAR_TYPE **, LAYOUT_TYPE, \
                                    Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> > , \
                       false, true > ;

--- a/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
@@ -328,7 +328,8 @@ void test_block_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth
     {
       sum += solution_host(j, i) * solution_host(j, i);
     }
-    initial_norms[i] = Kokkos::Details::ArithTraits<mag_t>::sqrt( sum );
+    initial_norms[i] = Kokkos::Details::ArithTraits<mag_t>::sqrt(
+        Kokkos::Details::ArithTraits<scalar_t>::abs(sum));
   }
 #ifdef gauss_seidel_testmore
   GSAlgorithm gs_algorithms[] ={GS_DEFAULT, GS_TEAM, GS_PERMUTED};
@@ -377,7 +378,8 @@ void test_block_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth
                 scalar_t diff = x_host(r, c) - solution_host(r, c);
                 sum += diff * diff;
               }
-              mag_t result_res = Kokkos::Details::ArithTraits<mag_t>::sqrt( sum );
+              mag_t result_res = Kokkos::Details::ArithTraits<mag_t>::sqrt(
+                  Kokkos::Details::ArithTraits<scalar_t>::abs(sum));
               EXPECT_TRUE( result_res < initial_norms[c] );
             }
           }

--- a/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
@@ -394,7 +394,7 @@ TEST_F( TestCategory, sparse ## _ ## block_gauss_seidel_rank1 ## _ ## SCALAR ## 
 	test_block_gauss_seidel_rank1<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 30, 200, 10); \
 } \
 TEST_F( TestCategory, sparse ## _ ## block_gauss_seidel_rank2 ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
-	test_block_gauss_seidel_rank2<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 30, 200, 10); \
+	test_block_gauss_seidel_rank2<SCALAR,ORDINAL,OFFSET,DEVICE>(5000, 5000 * 20, 200, 10); \
 }
 
 

--- a/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
@@ -66,6 +66,7 @@ using namespace KokkosKernels;
 using namespace KokkosKernels::Experimental;
 using namespace KokkosSparse;
 using namespace KokkosSparse::Experimental;
+
 namespace Test {
 
 template <typename crsMat_t, typename vector_t, typename const_vector_t, typename device>
@@ -161,7 +162,6 @@ vector_t create_y_vector(crsMat_t crsMat, vector_t x_vector){
   KokkosSparse::spmv("N", 1, crsMat, x_vector, 0, y_vector);
   return y_vector;
 }
-
 }
 
 template <typename scalar_t, typename lno_t, typename size_type, typename device>

--- a/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
@@ -51,6 +51,7 @@
 #include <KokkosSparse_spmv.hpp>
 #include <KokkosBlas1_dot.hpp>
 #include <KokkosBlas1_axpby.hpp>
+#include <KokkosBlas1_nrm2.hpp>
 #include <cstdlib>
 #include <iostream>
 #include <complex>
@@ -67,12 +68,12 @@ using namespace KokkosSparse;
 using namespace KokkosSparse::Experimental;
 namespace Test {
 
-template <typename crsMat_t, typename device>
+template <typename crsMat_t, typename vector_t, typename const_vector_t, typename device>
 int run_block_gauss_seidel_1(
     crsMat_t input_mat, int block_size,
     KokkosSparse::GSAlgorithm gs_algorithm,
-    typename crsMat_t::values_type::non_const_type x_vector,
-    typename crsMat_t::values_type::const_type y_vector,
+    vector_t x_vector,
+    const_vector_t y_vector,
     bool is_symmetric_graph,
     int apply_type = 0, // 0 for symmetric, 1 for forward, 2 for backward.
     bool skip_symbolic = false,
@@ -85,8 +86,6 @@ int run_block_gauss_seidel_1(
   typedef typename graph_t::entries_type   lno_nnz_view_t;
   typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
 
-
-
   typedef typename lno_view_t::value_type size_type;
   typedef typename lno_nnz_view_t::value_type lno_t;
   typedef typename scalar_view_t::value_type scalar_t;
@@ -95,18 +94,14 @@ int run_block_gauss_seidel_1(
       <size_type,lno_t, scalar_t,
       typename device::execution_space, typename device::memory_space,typename device::memory_space > KernelHandle;
 
-
-
   KernelHandle kh;
   kh.set_team_work_size(16);
   kh.set_shmem_size(shmem_size);
   kh.set_dynamic_scheduling(true);
   kh.create_gs_handle(gs_algorithm);
 
-
   const size_t num_rows_1 = input_mat.numRows();
   const size_t num_cols_1 = input_mat.numCols();
-  //std::cout << "num_rows_1:" << num_rows_1 << " num_cols_1:" << num_cols_1 << std::endl;
   const int apply_count = 100;
 
   if (!skip_symbolic){
@@ -143,37 +138,34 @@ int run_block_gauss_seidel_1(
   return 0;
 }
 
-template<typename scalar_view_t>
-scalar_view_t create_x_vector(size_t nv, double max_value = 10.0){
-  scalar_view_t kok_x ("X", nv);
-
-
-  typename scalar_view_t::HostMirror h_x =  Kokkos::create_mirror_view (kok_x);
-
-
-  for (size_t i = 0; i < nv; ++i){
-    typename scalar_view_t::value_type r =
-        static_cast <typename scalar_view_t::value_type> (rand()) /
-        static_cast <typename scalar_view_t::value_type> (RAND_MAX / max_value);
-    h_x(i) = r;
-    //h_x(i) = 1;
+template<typename vec_t>
+vec_t create_x_vector(vec_t& kok_x, double max_value = 10.0) {
+  typedef typename vec_t::value_type scalar_t;
+  auto h_x = Kokkos::create_mirror_view (kok_x);
+  for (size_t j = 0; j < h_x.extent(1); ++j){
+    for (size_t i = 0; i < h_x.extent(0); ++i){
+      scalar_t r =
+          static_cast <scalar_t> (rand()) /
+          static_cast <scalar_t> (RAND_MAX / max_value);
+      h_x.access(i, j) = r;
+    }
   }
   Kokkos::deep_copy (kok_x, h_x);
-
-
   return kok_x;
 }
+
 template <typename crsMat_t, typename vector_t>
 vector_t create_y_vector(crsMat_t crsMat, vector_t x_vector){
-  vector_t y_vector ("Y VECTOR", crsMat.numRows());
-  KokkosSparse::spmv("N", 1, crsMat, x_vector, 1, y_vector);
+  vector_t y_vector (Kokkos::ViewAllocateWithoutInitializing("Y VECTOR"),
+      crsMat.numRows(), x_vector.extent(1));
+  KokkosSparse::spmv("N", 1, crsMat, x_vector, 0, y_vector);
   return y_vector;
 }
 
 }
 
 template <typename scalar_t, typename lno_t, typename size_type, typename device>
-void test_block_gauss_seidel(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_variance) {
+void test_block_gauss_seidel_rank1(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_variance) {
 
   using namespace Test;
   srand(245);
@@ -183,11 +175,10 @@ void test_block_gauss_seidel(lno_t numRows, size_type nnz, lno_t bandwidth, lno_
   typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
   typedef typename crsMat_t::StaticCrsGraphType::row_map_type::non_const_type lno_view_t;
   typedef typename crsMat_t::StaticCrsGraphType::entries_type::non_const_type lno_nnz_view_t;
-
+  typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;
 
   lno_t numCols = numRows;
   crsMat_t crsmat = KokkosKernels::Impl::kk_generate_diagonally_dominant_sparse_matrix<crsMat_t>(numRows,numCols,nnz,row_size_variance, bandwidth);
-
 
   lno_view_t pf_rm;
   lno_nnz_view_t pf_e;
@@ -222,14 +213,10 @@ void test_block_gauss_seidel(lno_t numRows, size_type nnz, lno_t bandwidth, lno_
 
   lno_t nv = ((crsmat2.numRows() / block_size)+1) * block_size;
 
-
-  //scalar_view_t solution_x ("sol", nv);
-  //Kokkos::Random_XorShift64_Pool<ExecutionSpace> g(1931);
-  //Kokkos::fill_random(solution_x,g,Kokkos::Random_XorShift64_Pool<ExecutionSpace>::generator_type::MAX_URAND);
-  //values_view_t kok_x_original = create_x_vector<values_view_t>(((nv /5) + 1) * 5, MAXVAL);
-
-  const scalar_view_t solution_x = create_x_vector<scalar_view_t>(nv);
+  const scalar_view_t solution_x("X", nv);
+  create_x_vector(solution_x);
   scalar_view_t y_vector = create_y_vector(crsmat2, solution_x);
+  mag_t initial_norm_res = KokkosBlas::nrm2(solution_x);
 #ifdef gauss_seidel_testmore
   GSAlgorithm gs_algorithms[] ={GS_DEFAULT, GS_TEAM, GS_PERMUTED};
   int apply_count = 3;
@@ -240,21 +227,14 @@ void test_block_gauss_seidel(lno_t numRows, size_type nnz, lno_t bandwidth, lno_
   for (int ii = 0; ii < 1; ++ii){
 #endif
     GSAlgorithm gs_algorithm = gs_algorithms[ii];
-    scalar_view_t x_vector ("x vector", nv);
+    scalar_view_t x_vector("x vector", nv);
     const scalar_t alpha = 1.0;
-    KokkosBlas::axpby(alpha, solution_x, -alpha, x_vector);
-    scalar_t dot_product = KokkosBlas::dot( x_vector , x_vector );
-    typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;
-    mag_t initial_norm_res = Kokkos::Details::ArithTraits<scalar_t>::abs (dot_product);
-    initial_norm_res  = Kokkos::Details::ArithTraits<mag_t>::sqrt( initial_norm_res );
-    Kokkos::deep_copy (x_vector , 0);
 
     //bool is_symmetric_graph = false;
     //int apply_type = 0;
     //bool skip_symbolic = false;
     //bool skip_numeric = false;
     scalar_t omega = 0.9;
-
 
     bool is_symmetric_graph = true;
     size_t shmem_size = 32128;
@@ -268,17 +248,138 @@ void test_block_gauss_seidel(lno_t numRows, size_type nnz, lno_t bandwidth, lno_
 
             Kokkos::Impl::Timer timer1;
             //int res =
-            run_block_gauss_seidel_1<crsMat_t, device>(input_mat, block_size, gs_algorithm, x_vector, y_vector, is_symmetric_graph, apply_type, skip_symbolic, skip_numeric, shmem_size, omega);
+            run_block_gauss_seidel_1<crsMat_t, scalar_view_t, typename scalar_view_t::const_type, device>
+              (input_mat, block_size, gs_algorithm, x_vector, y_vector, is_symmetric_graph, apply_type, skip_symbolic, skip_numeric, shmem_size, omega);
             //double gs = timer1.seconds();
-
             //KokkosKernels::Impl::print_1Dview(x_vector);
             KokkosBlas::axpby(alpha, solution_x, -alpha, x_vector);
+            mag_t result_norm_res = KokkosBlas::nrm2(x_vector);
+            EXPECT_TRUE(( result_norm_res < initial_norm_res ));
+          }
+        }
+      }
+    }
+  }
+  //device::execution_space::finalize();
+}
+
+template <typename scalar_t, typename lno_t, typename size_type, typename device>
+void test_block_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_variance) {
+
+  using namespace Test;
+  srand(245);
+  typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type> crsMat_t;
+
+  typedef typename crsMat_t::StaticCrsGraphType graph_t;
+  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
+  typedef typename crsMat_t::StaticCrsGraphType::row_map_type::non_const_type lno_view_t;
+  typedef typename crsMat_t::StaticCrsGraphType::entries_type::non_const_type lno_nnz_view_t;
+  typedef Kokkos::View<scalar_t**, Kokkos::LayoutLeft, device> scalar_view2d_t;
+  typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;
+
+  lno_t numCols = numRows;
+  crsMat_t crsmat = KokkosKernels::Impl::kk_generate_diagonally_dominant_sparse_matrix<crsMat_t>(numRows,numCols,nnz,row_size_variance, bandwidth);
+
+  lno_view_t pf_rm;
+  lno_nnz_view_t pf_e;
+  scalar_view_t pf_v;
+  size_t out_r, out_c;
+  int block_size = 7;
+
+  //this makes consecutive 5 rows to have same columns.
+  //it will add scalar 0's for those entries that does not exists.
+  //the result is still a point crs matrix.
+  KokkosKernels::Impl::kk_create_blockcrs_formated_point_crsmatrix(
+		  block_size , crsmat.numRows(), crsmat.numCols(),
+		  crsmat.graph.row_map, crsmat.graph.entries, crsmat.values,
+		  out_r, out_c,
+		  pf_rm, pf_e, pf_v);
+  graph_t static_graph2 (pf_e, pf_rm);
+  crsMat_t crsmat2("CrsMatrix2", out_c, pf_v, static_graph2);
+
+  lno_view_t bf_rm;
+  lno_nnz_view_t bf_e;
+  scalar_view_t bf_v;
+  size_t but_r, but_c;
+
+  //this converts the previous generated matrix to block crs matrix.
+  KokkosKernels::Impl::kk_create_blockcrs_from_blockcrs_formatted_point_crs(
+		  block_size , out_r, out_c,
+		  pf_rm, pf_e, pf_v,
+		  but_r, but_c,
+		  bf_rm, bf_e, bf_v);
+  graph_t static_graph (bf_e, bf_rm);
+  crsMat_t input_mat("CrsMatrix", but_c, bf_v, static_graph);
+
+  lno_t nv = ((crsmat2.numRows() / block_size)+1) * block_size;
+
+  //how many columns X/Y have
+  constexpr lno_t numVecs = 2;
+
+  scalar_view2d_t solution_x("X", nv, numVecs);
+  create_x_vector(solution_x);
+  scalar_view2d_t y_vector = create_y_vector(crsmat2, solution_x);
+  auto solution_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), solution_x);
+  std::vector<mag_t> initial_norms(numVecs);
+  for(lno_t i = 0; i < numVecs; i++)
+  {
+    scalar_t sum = 0;
+    for(lno_t j = 0; j < nv; j++)
+    {
+      sum += solution_host(j, i) * solution_host(j, i);
+    }
+    initial_norms[i] = Kokkos::Details::ArithTraits<mag_t>::sqrt( sum );
+  }
+#ifdef gauss_seidel_testmore
+  GSAlgorithm gs_algorithms[] ={GS_DEFAULT, GS_TEAM, GS_PERMUTED};
+  int apply_count = 3;
+  for (int ii = 0; ii < 3; ++ii){
+#else
+  int apply_count = 1;
+  GSAlgorithm gs_algorithms[] ={GS_DEFAULT};
+  for (int ii = 0; ii < 1; ++ii){
+#endif
+    GSAlgorithm gs_algorithm = gs_algorithms[ii];
+    scalar_view2d_t x_vector("x vector", nv, numVecs);
+    auto x_host = Kokkos::create_mirror_view(x_vector);
+
+    //bool is_symmetric_graph = false;
+    //int apply_type = 0;
+    //bool skip_symbolic = false;
+    //bool skip_numeric = false;
+    scalar_t omega = 0.9;
+
+    bool is_symmetric_graph = true;
+    size_t shmem_size = 32128;
+
+    scalar_view_t res_norms("Residuals", numVecs);
+    auto h_res_norms = Kokkos::create_mirror_view(res_norms);
+    
+    for(int i = 0; i < 2; ++i)
+    {
+      if (i == 1) shmem_size = 2008; //make the shmem small on gpus so that it will test 2 level algorithm.
+      for (int apply_type = 0; apply_type < apply_count; ++apply_type){
+        for (int skip_symbolic = 0; skip_symbolic < 2; ++skip_symbolic){
+          for (int skip_numeric = 0; skip_numeric < 2; ++skip_numeric){
+
+            Kokkos::Impl::Timer timer1;
+            //int res =
+            run_block_gauss_seidel_1<crsMat_t, scalar_view2d_t, typename scalar_view2d_t::const_type, device>
+              (input_mat, block_size, gs_algorithm, x_vector, y_vector, is_symmetric_graph, apply_type, skip_symbolic, skip_numeric, shmem_size, omega);
+            //double gs = timer1.seconds();
             //KokkosKernels::Impl::print_1Dview(x_vector);
-            scalar_t result_dot_product = KokkosBlas::dot( x_vector , x_vector );
-            mag_t result_norm_res  = Kokkos::Details::ArithTraits<scalar_t>::abs( result_dot_product );
-            result_norm_res = Kokkos::Details::ArithTraits<mag_t>::sqrt(result_norm_res);
-            //std::cout << "result_norm_res:" << result_norm_res << " initial_norm_res:" << initial_norm_res << std::endl;
-            EXPECT_TRUE( (result_norm_res < initial_norm_res));
+            Kokkos::deep_copy(x_host, x_vector);
+            for(lno_t c = 0; c < numVecs; c++)
+            {
+              scalar_t sum = 0;
+              for(lno_t r = 0; r < nv; r++)
+              {
+                scalar_t diff = x_host(r, c) - solution_host(r, c);
+                sum += diff * diff;
+              }
+              mag_t result_res = Kokkos::Details::ArithTraits<mag_t>::sqrt( sum );
+              EXPECT_TRUE( result_res < initial_norms[c] );
+            }
           }
         }
       }
@@ -288,10 +389,12 @@ void test_block_gauss_seidel(lno_t numRows, size_type nnz, lno_t bandwidth, lno_
 }
 
 
-
 #define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE) \
-TEST_F( TestCategory, sparse ## _ ## block_gauss_seidel ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
-	test_block_gauss_seidel<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 30, 200, 10); \
+TEST_F( TestCategory, sparse ## _ ## block_gauss_seidel_rank1 ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
+	test_block_gauss_seidel_rank1<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 30, 200, 10); \
+} \
+TEST_F( TestCategory, sparse ## _ ## block_gauss_seidel_rank2 ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
+	test_block_gauss_seidel_rank2<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 30, 200, 10); \
 }
 
 

--- a/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
@@ -289,7 +289,6 @@ void test_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth, lno_
   using namespace Test;
   srand(245);
   typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type> crsMat_t;
-  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
   typedef Kokkos::View<scalar_t**, Kokkos::LayoutLeft, device> scalar_view2d_t;
   typedef Kokkos::View<scalar_t**, Kokkos::LayoutLeft, Kokkos::HostSpace> host_scalar_view2d_t;
   typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;

--- a/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
@@ -54,6 +54,8 @@
 #include <cstdlib>
 #include <iostream>
 #include <complex>
+#include <map>
+#include <vector>
 #include "KokkosSparse_gauss_seidel.hpp"
 #include "KokkosSparse_partitioning_impl.hpp"
 
@@ -68,18 +70,17 @@ using namespace KokkosSparse;
 using namespace KokkosSparse::Experimental;
 namespace Test {
 
-template <typename crsMat_t, typename device>
-int run_gauss_seidel_1(
+template <typename crsMat_t, typename vec_t, typename device>
+int run_gauss_seidel(
     crsMat_t input_mat,
-    KokkosSparse::GSAlgorithm gs_algorithm,
-    typename crsMat_t::values_type::non_const_type x_vector,
-    typename crsMat_t::values_type::const_type y_vector,
+    GSAlgorithm gs_algorithm,
+    vec_t x_vector,
+    vec_t y_vector,
     bool is_symmetric_graph,
     int apply_type = 0, // 0 for symmetric, 1 for forward, 2 for backward.
-    bool skip_symbolic = false,
-    bool skip_numeric = false,
-    typename crsMat_t::value_type omega = Kokkos::Details::ArithTraits<typename crsMat_t::value_type>::one()
-    ){
+    int cluster_size = 1,
+    ClusteringAlgorithm cluster_algorithm = CLUSTER_DEFAULT)
+{
   typedef typename crsMat_t::StaticCrsGraphType graph_t;
   typedef typename graph_t::row_map_type lno_view_t;
   typedef typename graph_t::entries_type lno_nnz_view_t;
@@ -96,311 +97,278 @@ int run_gauss_seidel_1(
   KernelHandle kh;
   kh.set_team_work_size(16);
   kh.set_dynamic_scheduling(true);
-  kh.create_gs_handle(gs_algorithm);
-
+  if(gs_algorithm == GS_CLUSTER)
+    kh.create_gs_handle(cluster_algorithm, cluster_size);
+  else
+    kh.create_gs_handle(GS_DEFAULT);
 
   const size_t num_rows_1 = input_mat.numRows();
   const size_t num_cols_1 = input_mat.numCols();
   const int apply_count = 100;
 
-  if (!skip_symbolic){
-    gauss_seidel_symbolic
-      (&kh, num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, is_symmetric_graph);
-  }
-
-  if (!skip_numeric){
-    gauss_seidel_numeric
+  gauss_seidel_symbolic
+    (&kh, num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, is_symmetric_graph);
+  gauss_seidel_numeric
     (&kh, num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, is_symmetric_graph);
-  }
+
+  scalar_t omega(0.9);
 
   switch (apply_type){
   case 0:
     symmetric_gauss_seidel_apply
-      (&kh, num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, omega, apply_count);
+      (&kh, num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector, false, true, omega, apply_count);
     break;
   case 1:
     forward_sweep_gauss_seidel_apply
-    (&kh, num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, omega, apply_count);
+    (&kh, num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector, false, true, omega, apply_count);
     break;
   case 2:
     backward_sweep_gauss_seidel_apply
-    (&kh, num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, omega, apply_count);
+    (&kh, num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector, false, true, omega, apply_count);
     break;
   default:
     symmetric_gauss_seidel_apply
-    (&kh, num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector,false, true, omega, apply_count);
+    (&kh, num_rows_1, num_cols_1, input_mat.graph.row_map, input_mat.graph.entries, input_mat.values, x_vector, y_vector, false, true, omega, apply_count);
     break;
   }
-
-
   kh.destroy_gs_handle();
   return 0;
 }
 
-template<typename scalar_view_t>
-scalar_view_t create_x_vector(size_t nv, double max_value = 10.0){
-  scalar_view_t kok_x ("X", nv);
-
-
-  typename scalar_view_t::HostMirror h_x =  Kokkos::create_mirror_view (kok_x);
-
-
-  for (size_t i = 0; i < nv; ++i){
-    typename scalar_view_t::value_type r =
-        static_cast <typename scalar_view_t::value_type> (rand()) /
-        static_cast <typename scalar_view_t::value_type> (RAND_MAX / max_value);
-    h_x(i) = r;
-    //h_x(i) = 1;
+template<typename vec_t>
+vec_t create_x_vector(vec_t& kok_x, double max_value = 10.0) {
+  typedef typename vec_t::value_type scalar_t;
+  auto h_x = Kokkos::create_mirror_view (kok_x);
+  for (size_t j = 0; j < h_x.extent(1); ++j){
+    for (size_t i = 0; i < h_x.extent(0); ++i){
+      scalar_t r =
+          static_cast <scalar_t> (rand()) /
+          static_cast <scalar_t> (RAND_MAX / max_value);
+      h_x.access(i, j) = r;
+    }
   }
   Kokkos::deep_copy (kok_x, h_x);
-
-
   return kok_x;
 }
+
 template <typename crsMat_t, typename vector_t>
 vector_t create_y_vector(crsMat_t crsMat, vector_t x_vector){
-  vector_t y_vector ("Y VECTOR", x_vector.extent(0), x_vector.extent(1));
+  vector_t y_vector (Kokkos::ViewAllocateWithoutInitializing("Y VECTOR"),
+      crsMat.numRows(), x_vector.extent(1));
   KokkosSparse::spmv("N", 1, crsMat, x_vector, 0, y_vector);
   return y_vector;
 }
+}
 
+template<typename scalar_t, typename lno_t, typename size_type, typename device, typename crsMat_t>
+crsMat_t symmetrize(crsMat_t A)
+{
+  typedef typename crsMat_t::StaticCrsGraphType graph_t;
+  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
+  typedef typename graph_t::row_map_type::non_const_type lno_view_t;
+  typedef typename graph_t::entries_type::non_const_type lno_nnz_view_t;
+  auto host_rowmap = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A.graph.row_map);
+  auto host_entries = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A.graph.entries);
+  auto host_values = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A.values);
+  lno_t numRows = A.numRows();
+  //symmetrize as input_mat + input_mat^T, to still have a diagonally dominant matrix
+  typedef std::map<lno_t, scalar_t> Row;
+  std::vector<Row> symRows(numRows);
+  for(lno_t r = 0; r < numRows; r++)
+  {
+    auto& row = symRows[r];
+    for(size_type i = host_rowmap(r); i < host_rowmap(r + 1); i++)
+    {
+      lno_t c = host_entries(i);
+      auto& col = symRows[c];
+      auto it = row.find(c);
+      if(it == row.end())
+        row[c] = host_values(i);
+      else
+        row[c] += host_values(i);
+      it = col.find(r);
+      if(it == col.end())
+        col[r] = host_values(i);
+      else
+        col[r] += host_values(i);
+    }
+  }
+  //Count entries
+  Kokkos::View<size_type*, Kokkos::LayoutLeft, Kokkos::HostSpace> new_host_rowmap("Rowmap", numRows + 1);
+  size_t accum = 0;
+  for(lno_t r = 0; r <= numRows; r++)
+  {
+    new_host_rowmap(r) = accum;
+    if(r < numRows)
+      accum += symRows[r].size();
+  }
+  //Allocate new entries/values
+  Kokkos::View<lno_t*, Kokkos::LayoutLeft, Kokkos::HostSpace> new_host_entries("Entries", accum);
+  Kokkos::View<scalar_t*, Kokkos::LayoutLeft, Kokkos::HostSpace> new_host_values("Values", accum);
+  for(lno_t r = 0; r < numRows; r++)
+  {
+    auto rowIt = symRows[r].begin();
+    for(size_type i = new_host_rowmap(r); i < new_host_rowmap(r + 1); i++)
+    {
+      new_host_entries(i) = rowIt->first;
+      new_host_values(i) = rowIt->second;
+      rowIt++;
+    }
+  }
+  lno_view_t new_rowmap("Rowmap", numRows + 1);
+  lno_nnz_view_t new_entries("Entries", accum);
+  scalar_view_t new_values("Values", accum);
+  Kokkos::deep_copy(new_rowmap, new_host_rowmap);
+  Kokkos::deep_copy(new_entries, new_host_entries);
+  Kokkos::deep_copy(new_values, new_host_values);
+  return crsMat_t("SymA", numRows, numRows, accum, new_values, new_rowmap, new_entries);
 }
 
 template <typename scalar_t, typename lno_t, typename size_type, typename device>
-void test_gauss_seidel(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_variance) {
+void test_gauss_seidel_rank1(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_variance, bool symmetric)
+{
+  using namespace Test;
+  typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type> crsMat_t;
+  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
+  typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;
+  srand(245);
+  lno_t numCols = numRows;
+  crsMat_t input_mat = KokkosKernels::Impl::kk_generate_diagonally_dominant_sparse_matrix<crsMat_t>(numRows, numCols, nnz, row_size_variance, bandwidth);
+  if(symmetric)
+  {
+    //Symmetrize on host, rather than relying on the parallel versions (those can be tested for symmetric=false)
+    input_mat = symmetrize<scalar_t, lno_t, size_type, device, crsMat_t>(input_mat);
+  }
+  lno_t nv = input_mat.numRows();
+  scalar_view_t solution_x(Kokkos::ViewAllocateWithoutInitializing("X (correct)"), nv);
+  create_x_vector(solution_x);
+  mag_t initial_norm_res = KokkosBlas::nrm2(solution_x);
+  scalar_view_t y_vector = create_y_vector(input_mat, solution_x);
+  //GS_DEFAULT is GS_TEAM on CUDA and GS_PERMUTED on other spaces, and the behavior
+  //of each algorithm _should be_ the same on every execution space, which is why
+  //we just test GS_DEFAULT.
+  int apply_count = 3;  //test symmetric, forward, backward
+  scalar_view_t x_vector(Kokkos::ViewAllocateWithoutInitializing("x vector"), nv);
+  const scalar_t alpha = 1.0;
+  //*** Point-coloring version ****
+  for (int apply_type = 0; apply_type < apply_count; ++apply_type)
+  {
+    Kokkos::Impl::Timer timer1;
+    Kokkos::deep_copy(x_vector, scalar_t(0.0));
+    run_gauss_seidel<crsMat_t, scalar_view_t, device>(input_mat, GS_DEFAULT, x_vector, y_vector, symmetric, apply_type);
+    //double gs = timer1.seconds();
+    //KokkosKernels::Impl::print_1Dview(x_vector);
+    KokkosBlas::axpby(alpha, solution_x, -alpha, x_vector);
+    mag_t result_norm_res = KokkosBlas::nrm2(x_vector);
+    EXPECT_LT(result_norm_res, initial_norm_res);
+  }
+  //*** Cluster-coloring version ****
+  int clusterSizes[3] = {2, 5, 34};
+  for(int csize = 0; csize < 3; csize++)
+  {
+    for(int algo = 0; algo < (int) NUM_CLUSTERING_ALGORITHMS; algo++)
+    {
+      for(int apply_type = 0; apply_type < apply_count; ++apply_type)
+      {
+        Kokkos::Impl::Timer timer1;
+        //Zero out X before solving
+        Kokkos::deep_copy(x_vector, scalar_t(0.0));
+        run_gauss_seidel<crsMat_t, scalar_view_t, device>(
+            input_mat, GS_CLUSTER, x_vector, y_vector, symmetric, apply_type, clusterSizes[csize], (ClusteringAlgorithm) algo);
+        KokkosBlas::axpby(alpha, solution_x, -alpha, x_vector);
+        mag_t result_norm_res = KokkosBlas::nrm2(x_vector);
+        EXPECT_LT(result_norm_res, initial_norm_res);
+      }
+    }
+  }
+}
 
+template <typename scalar_t, typename lno_t, typename size_type, typename device>
+void test_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_variance, lno_t numVecs, bool symmetric)
+{
   using namespace Test;
   srand(245);
   typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type> crsMat_t;
-  //typedef typename crsMat_t::StaticCrsGraphType graph_t;
-  //typedef typename graph_t::row_map_type lno_view_t;
-  //typedef typename graph_t::entries_type lno_nnz_view_t;
-  //typedef typename graph_t::entries_type::non_const_type   color_view_t;
   typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
+  typedef Kokkos::View<scalar_t**, Kokkos::LayoutLeft, device> scalar_view2d_t;
+  typedef Kokkos::View<scalar_t**, Kokkos::LayoutLeft, Kokkos::HostSpace> host_scalar_view2d_t;
+  typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;
 
   lno_t numCols = numRows;
   crsMat_t input_mat = KokkosKernels::Impl::kk_generate_diagonally_dominant_sparse_matrix<crsMat_t>(numRows,numCols,nnz,row_size_variance, bandwidth);
-
+  if(symmetric)
+  {
+    //Symmetrize on host, rather than relying on the parallel versions (those can be tested for symmetric=false)
+    input_mat = symmetrize<scalar_t, lno_t, size_type, device, crsMat_t>(input_mat);
+  }
   lno_t nv = input_mat.numRows();
-
-  //KokkosKernels::Impl::print_1Dview(input_mat.graph.row_map);
-  //KokkosKernels::Impl::print_1Dview(input_mat.graph.entries);
-  //KokkosKernels::Impl::print_1Dview(input_mat.values);
-
-  //scalar_view_t solution_x ("sol", nv);
-  //Kokkos::Random_XorShift64_Pool<ExecutionSpace> g(1931);
-  //Kokkos::fill_random(solution_x,g,Kokkos::Random_XorShift64_Pool<ExecutionSpace>::generator_type::MAX_URAND);
-
-  const scalar_view_t solution_x = create_x_vector<scalar_view_t>(nv);
-  scalar_view_t y_vector = create_y_vector(input_mat, solution_x);
-#ifdef gauss_seidel_testmore
-  GSAlgorithm gs_algorithms[] ={GS_DEFAULT, GS_TEAM, GS_PERMUTED};
-  int apply_count = 3;
-  for (int ii = 0; ii < 3; ++ii){
-#else
-  int apply_count = 1;
-  GSAlgorithm gs_algorithms[] ={GS_DEFAULT};
-  for (int ii = 0; ii < 1; ++ii){
-#endif
-    GSAlgorithm gs_algorithm = gs_algorithms[ii];
-    scalar_view_t x_vector ("x vector", nv);
-    const scalar_t alpha = 1.0;
-    KokkosBlas::axpby(alpha, solution_x, -alpha, x_vector);
-    scalar_t dot_product = KokkosBlas::dot( x_vector , x_vector );
-    typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;
-    mag_t initial_norm_res = Kokkos::Details::ArithTraits<scalar_t>::abs (dot_product);
-    initial_norm_res  = Kokkos::Details::ArithTraits<mag_t>::sqrt( initial_norm_res );
-    Kokkos::deep_copy (x_vector , 0);
-
-    //bool is_symmetric_graph = false;
-    //int apply_type = 0;
-    //bool skip_symbolic = false;
-    //bool skip_numeric = false;
-    scalar_t omega = 0.9;
-
-    for (int is_symmetric_graph = 0; is_symmetric_graph < 2; ++is_symmetric_graph){
-
-      for (int apply_type = 0; apply_type < apply_count; ++apply_type){
-        for (int skip_symbolic = 0; skip_symbolic < 2; ++skip_symbolic){
-          for (int skip_numeric = 0; skip_numeric < 2; ++skip_numeric){
-
-            Kokkos::Impl::Timer timer1;
-            run_gauss_seidel_1<crsMat_t, device>(input_mat, gs_algorithm, x_vector, y_vector, is_symmetric_graph, apply_type, skip_symbolic, skip_numeric, omega);
-            //double gs = timer1.seconds();
-
-            //KokkosKernels::Impl::print_1Dview(x_vector);
-            KokkosBlas::axpby(alpha, solution_x, -alpha, x_vector);
-            //KokkosKernels::Impl::print_1Dview(x_vector);
-            scalar_t result_dot_product = KokkosBlas::dot( x_vector , x_vector );
-            mag_t result_norm_res  = Kokkos::Details::ArithTraits<scalar_t>::abs( result_dot_product );
-            result_norm_res = Kokkos::Details::ArithTraits<mag_t>::sqrt(result_norm_res);
-            //std::cout << "result_norm_res:" << result_norm_res << " initial_norm_res:" << initial_norm_res << std::endl;
-            EXPECT_TRUE( (result_norm_res < initial_norm_res));
-          }
-        }
-      }
-    }
-  }
-  //device::execution_space::finalize();
-}
-
-template <typename scalar_t, typename lno_t, typename size_type, typename device>
-void test_cluster_sgs(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_variance)
-{
-  using namespace Test;
-  typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type> crsMat_t;
-  typedef typename crsMat_t::StaticCrsGraphType graph_t;
-  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
-  typedef typename graph_t::row_map_type lno_view_t;
-  typedef typename graph_t::entries_type::non_const_type lno_nnz_view_t;
-  typedef typename device::execution_space exec_space;
-  typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;
-  typedef KokkosKernelsHandle
-      <size_type, lno_t, scalar_t,
-      exec_space, typename device::memory_space,typename device::memory_space> KernelHandle;
-  crsMat_t A = KokkosKernels::Impl::kk_generate_diagonally_dominant_sparse_matrix<crsMat_t>(numRows,numRows,nnz,row_size_variance, bandwidth);
-  //create a randomized RHS vector (b)
-  scalar_view_t b("b", numRows);
+  host_scalar_view2d_t solution_x(Kokkos::ViewAllocateWithoutInitializing("X (correct)"), nv, numVecs);
+  create_x_vector(solution_x);
+  scalar_view2d_t x_vector(Kokkos::ViewAllocateWithoutInitializing("X"), nv, numVecs);
+  Kokkos::deep_copy(x_vector, solution_x);
+  scalar_view2d_t y_vector = create_y_vector(input_mat, x_vector);
+  host_scalar_view2d_t x_host = Kokkos::create_mirror_view(x_vector);
+  std::vector<mag_t> initial_norms(numVecs);
+  for(lno_t i = 0; i < numVecs; i++)
   {
-    Kokkos::View<scalar_t*, Kokkos::HostSpace> bHost("b (hosts)", numRows);
-    for(lno_t i = 0; i < numRows; i++)
+    scalar_t sum = 0;
+    for(lno_t j = 0; j < nv; j++)
     {
-      bHost(i) = scalar_t(10.0 * rand() / RAND_MAX);
+      sum += solution_x(j, i) * solution_x(j, i);
     }
-    Kokkos::deep_copy(b, bHost);
+    initial_norms[i] = Kokkos::Details::ArithTraits<mag_t>::sqrt(
+        Kokkos::Details::ArithTraits<scalar_t>::abs(sum));
   }
-  const mag_t bnorm = KokkosBlas::nrm2(b);
-  for(int algoCount = 0; algoCount < (int) KokkosSparse::NUM_CLUSTERING_ALGORITHMS; algoCount++)
+  int apply_count = 3;  //test symmetric, forward, backward
+  //*** Point-coloring version ****
+  for(int apply_type = 0; apply_type < apply_count; ++apply_type)
   {
-    ClusteringAlgorithm algo = (ClusteringAlgorithm) algoCount;
-    //create solution vector (x), zero initial guess
-    //try a bunch of powers of 2 for cluster sizes, up to about the
-    //point where there are very few clusters (8), even though this
-    //is not the intended use case.
-    std::vector<lno_t> clusterSizes;
-    for(lno_t i = 1; i <= numRows / 8; i <<= 1)
-      clusterSizes.push_back(i);
-    const int niters = 1;
-    for(size_t test = 0; test < clusterSizes.size(); test++)
+    Kokkos::Impl::Timer timer1;
+    //Zero out X before solving
+    Kokkos::deep_copy(x_vector, scalar_t(0.0));
+    run_gauss_seidel<crsMat_t, scalar_view2d_t, device>(
+        input_mat, GS_DEFAULT, x_vector, y_vector, symmetric, apply_type);
+    Kokkos::deep_copy(x_host, x_vector);
+    for(lno_t i = 0; i < numVecs; i++)
     {
-      auto clusterSize = clusterSizes[test];
-      KernelHandle kh;
-      if(clusterSize == 1)
-        kh.create_gs_handle(KokkosSparse::GS_DEFAULT);
-      else
-        kh.create_gs_handle((KokkosSparse::ClusteringAlgorithm) algo, clusterSize);
-      //only need to do G-S setup (symbolic/numeric) once
-      Kokkos::Impl::Timer timer;
-      KokkosSparse::Experimental::gauss_seidel_symbolic<KernelHandle, lno_view_t, lno_nnz_view_t>
-        (&kh, numRows, numRows, A.graph.row_map, A.graph.entries, false);
-      KokkosSparse::Experimental::gauss_seidel_numeric<KernelHandle, lno_view_t, lno_nnz_view_t, scalar_view_t>
-        (&kh, numRows, numRows, A.graph.row_map, A.graph.entries, A.values, false);
-  #ifdef CLUSTER_VERBOSE
-      output << "Cluster size " << clusterSize << " setup time: " << timer.seconds() << " s\n";
-  #endif
-      timer.reset();
-      typedef Kokkos::Details::ArithTraits<scalar_t> KAT;
-      scalar_t alpha = KAT::one();
-      scalar_t beta = -KAT::one();
-      //starting solution will be the zero vector, but make sure SGS can do that
-      scalar_view_t x(Kokkos::ViewAllocateWithoutInitializing("x"), numRows);
-      KokkosSparse::Experimental::symmetric_gauss_seidel_apply
-        <KernelHandle, lno_view_t, lno_nnz_view_t, scalar_view_t, scalar_view_t, scalar_view_t>
-        (&kh, numRows, numRows, A.graph.row_map, A.graph.entries, A.values, x, b, true, true, 1.0, niters);
-      scalar_view_t res("Ax-b", numRows);
-      Kokkos::deep_copy(res, b);
-      KokkosSparse::spmv("N", alpha, A, x, beta, res);
-      mag_t scaledNorm = KokkosBlas::nrm2(res) / bnorm;
-      //Sanity check the result. The input matrix is strictly diagonally dominant, so the scaled solution norm (after 1 iteration)
-      //should be nonnegative but also small.
-      EXPECT_TRUE(scaledNorm > 0);
-      EXPECT_TRUE(scaledNorm < 0.05);
-  #ifdef CLUSTER_VERBOSE
-      std::cout << "Scaled residual norm: " << (norm / bnorm) << " (algo = " << KokkosSparse::getClusterAlgoName(algo) << ", clustersize = " << clusterSize << ")\n";
-      output << "Cluster size " << clusterSize << " apply time: " << timer.seconds() << " s\n";
-      output << "Cluster size " << clusterSize << " norm after " << niters << " sweeps: " << norm << '\n';
-      output << "Cluster size " << clusterSize << " proportion of residual eliminated: " << 1.0 - (norm / bnorm) << std::endl;
-  #endif
-      kh.destroy_gs_handle();
-    }
-  }
-}
-
-template <typename scalar_t, typename lno_t, typename size_type, typename device>
-void test_sgs_multiple_rhs(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_variance, lno_t numVecs)
-{
-  using namespace Test;
-  typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type> crsMat_t;
-  typedef typename crsMat_t::StaticCrsGraphType graph_t;
-  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
-  typedef typename graph_t::row_map_type lno_view_t;
-  typedef typename graph_t::entries_type::non_const_type lno_nnz_view_t;
-  typedef typename device::execution_space exec_space;
-  typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;
-  typedef KokkosKernelsHandle
-      <size_type, lno_t, scalar_t,
-      exec_space, typename device::memory_space,typename device::memory_space> KernelHandle;
-  crsMat_t A = KokkosKernels::Impl::kk_generate_diagonally_dominant_sparse_matrix<crsMat_t>(numRows,numRows,nnz,row_size_variance, bandwidth);
-  typedef Kokkos::View<scalar_t**, Kokkos::LayoutLeft, device> MultiVec;
-  //create a randomized solution (LHS) vector first, and keep a read-only copy of it
-  //will compare the solution to this.
-  MultiVec x(Kokkos::ViewAllocateWithoutInitializing("X (actual)"), numRows, numVecs);
-  auto xHost = Kokkos::create_mirror_view(x);
-  for(lno_t v = 0; v < numVecs; v++) {
-    for(lno_t i = 0; i < numRows; i++) {
-      x(i, v) = scalar_t(10.0 * rand() / RAND_MAX);
-    }
-  }
-  Kokkos::deep_copy(x, xHost);
-  MultiVec b = Test::create_y_vector(A, x);
-  auto xgold = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), x);
-  for(int algoCount = 0; algoCount < (int) KokkosSparse::NUM_CLUSTERING_ALGORITHMS; algoCount++)
-  {
-    ClusteringAlgorithm algo = (ClusteringAlgorithm) algoCount;
-    //create solution vector (x), zero initial guess
-    //try a bunch of powers of 2 for cluster sizes, up to about the
-    //point where there are very few clusters (8), even though this
-    //is not the intended use case.
-    std::vector<lno_t> clusterSizes;
-    for(lno_t i = 1; i <= numRows / 8; i <<= 1)
-      clusterSizes.push_back(i);
-    const int niters = 1;
-    for(size_t test = 0; test < clusterSizes.size(); test++)
-    {
-      auto clusterSize = clusterSizes[test];
-      KernelHandle kh;
-      if(clusterSize == 1)
-        kh.create_gs_handle(KokkosSparse::GS_DEFAULT);
-      else
-        kh.create_gs_handle((KokkosSparse::ClusteringAlgorithm) algo, clusterSize);
-      //only need to do G-S setup (symbolic/numeric) once
-      KokkosSparse::Experimental::gauss_seidel_symbolic<KernelHandle, lno_view_t, lno_nnz_view_t>
-        (&kh, numRows, numRows, A.graph.row_map, A.graph.entries, false);
-      KokkosSparse::Experimental::gauss_seidel_numeric<KernelHandle, lno_view_t, lno_nnz_view_t, scalar_view_t>
-        (&kh, numRows, numRows, A.graph.row_map, A.graph.entries, A.values, false);
-      //starting solution will always be the zero vector (arg init_zero_x_vector = true)
-      KokkosSparse::Experimental::symmetric_gauss_seidel_apply
-        <KernelHandle, lno_view_t, lno_nnz_view_t, scalar_view_t, MultiVec, MultiVec>
-        (&kh, numRows, numRows, A.graph.row_map, A.graph.entries, A.values, x, b, true, true, 1.0, niters);
-      //compute <x, xgold> / <x, x> for each column - should each be very close to 1
-      Kokkos::deep_copy(xHost, x);
-      for(lno_t i = 0; i < numVecs; i++)
+      scalar_t diffDot = 0;
+      for(lno_t j = 0; j < numRows; j++)
       {
-        scalar_t diffDot = 0;
-        scalar_t xDot = 0;
-        for(lno_t j = 0; j < numRows; j++)
-        {
-          scalar_t diff = xHost(j, i) - xgold(j, i);
-          diffDot += diff * diff;
-          xDot += xHost(j, i) * xHost(j, i);
-        }
-        mag_t res = Kokkos::Details::ArithTraits<mag_t>::sqrt(
-            Kokkos::Details::ArithTraits<scalar_t>::abs(diffDot));
-        mag_t xnorm = Kokkos::Details::ArithTraits<mag_t>::sqrt(
-            Kokkos::Details::ArithTraits<scalar_t>::abs(xDot));
-        EXPECT_GT(xnorm * 0.001, res);
+        scalar_t diff = x_host(j, i) - solution_x(j, i);
+        diffDot += diff * diff;
       }
-      kh.destroy_gs_handle();
+      mag_t res = Kokkos::Details::ArithTraits<mag_t>::sqrt(
+          Kokkos::Details::ArithTraits<scalar_t>::abs(diffDot));
+      EXPECT_LT(res, initial_norms[i]);
+    }
+  }
+  //*** Cluster-coloring version ****
+  int clusterSizes[3] = {2, 5, 34};
+  for(int csize = 0; csize < 3; csize++)
+  {
+    for(int algo = 0; algo < (int) NUM_CLUSTERING_ALGORITHMS; algo++)
+    {
+      for(int apply_type = 0; apply_type < apply_count; ++apply_type)
+      {
+        Kokkos::Impl::Timer timer1;
+        //Zero out X before solving
+        Kokkos::deep_copy(x_vector, scalar_t(0.0));
+        run_gauss_seidel<crsMat_t, scalar_view2d_t, device>(
+            input_mat, GS_CLUSTER, x_vector, y_vector, symmetric, apply_type, clusterSizes[csize], (ClusteringAlgorithm) algo);
+        Kokkos::deep_copy(x_host, x_vector);
+        for(lno_t i = 0; i < numVecs; i++)
+        {
+          scalar_t diffDot = 0;
+          for(lno_t j = 0; j < numRows; j++)
+          {
+            scalar_t diff = x_host(j, i) - solution_x(j, i);
+            diffDot += diff * diff;
+          }
+          mag_t res = Kokkos::Details::ArithTraits<mag_t>::sqrt(
+              Kokkos::Details::ArithTraits<scalar_t>::abs(diffDot));
+          EXPECT_LT(res, initial_norms[i]);
+        }
+      }
     }
   }
 }
@@ -486,20 +454,23 @@ void test_balloon_clustering(lno_t numRows, size_type nnzPerRow, lno_t bandwidth
 }
 
 #define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE) \
-TEST_F( TestCategory, sparse ## _ ## gauss_seidel ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
-  test_gauss_seidel<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 30, 200, 10); \
+TEST_F( TestCategory, sparse ## _ ## gauss_seidel_asymmetric_rank1 ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
+  test_gauss_seidel_rank1<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 30, 200, 10, false); \
+} \
+TEST_F( TestCategory, sparse ## _ ## gauss_seidel_asymmetric_rank2 ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
+  test_gauss_seidel_rank2<SCALAR,ORDINAL,OFFSET,DEVICE>(5000, 5000 * 20, 200, 10, 3, false); \
+} \
+TEST_F( TestCategory, sparse ## _ ## gauss_seidel_symmetric_rank1 ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
+  test_gauss_seidel_rank1<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 30, 200, 10, true); \
+} \
+TEST_F( TestCategory, sparse ## _ ## gauss_seidel_symmetric_rank2 ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
+  test_gauss_seidel_rank2<SCALAR,ORDINAL,OFFSET,DEVICE>(5000, 5000 * 20, 200, 10, 3, true); \
 } \
 TEST_F( TestCategory, sparse ## _ ## rcm ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
   test_rcm<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 50, 2000); \
 } \
 TEST_F( TestCategory, sparse ## _ ## balloon_clustering ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
   test_balloon_clustering<SCALAR,ORDINAL,OFFSET,DEVICE>(5000, 100, 2000); \
-} \
-TEST_F( TestCategory, sparse ## _ ## cluster_sgs ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
-  test_cluster_sgs<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 30, 200, 10); \
-} \
-TEST_F( TestCategory, sparse ## _ ## sgs_multiple_rhs ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
-  test_sgs_multiple_rhs<SCALAR,ORDINAL,OFFSET,DEVICE>(5000, 5000 * 30, 200, 10, 3); \
 }
 
 #if (defined (KOKKOSKERNELS_INST_DOUBLE) \


### PR DESCRIPTION
This PR adds rank-2 vector support to all variants of parallel Gauss-Seidel (point-coloring, block, cluster-coloring). This should be a significant speedup for Ifpack2 MTSGS with multivectors. Rank-1 support is not affected from the user's perspective.

The ETI for Gauss-Seidel apply() has been changed to just instantiate for a rank-2 apply (both LayoutLeft and LayoutRight, in the normal ETI configuration). As before, the user's X and Y vectors are internally converted to unmanaged views with the appropriate scalar, space and layout. If a rank-1 view is provided, the apply is done internally on an Nx1 multivector.

Test coverage for Gauss-Seidel has been improved - both Rank-1 and Rank-2 X/Y, and all apply types (forward/backward/symmetric) are now tested. The versions with lazy setup (skipSymbolic/skipNumeric) are no longer tested since they meant 4x as many runs were done in testing, and the logic in apply to call symbolic and/or numeric is very simple.

For CGS (cluster), every clustering algorithm (balloon, RCM and no-op) and 3 different cluster sizes are tested. The RangePolicy, TeamPolicy, Block and BigBlock versions of point MTGS are still all tested (assuming CUDA and at least one other CPU exec space are tested), as are the Range/Team versions of CGS.

(CUDA still broken on kokkos-dev)

Bowman:
#######################################################
PASSED TESTS
#######################################################
intel-16.4.258-Pthread-release build_time=1629 run_time=1659
intel-16.4.258-Pthread_Serial-release build_time=2750 run_time=3317
intel-16.4.258-Serial-release build_time=1580 run_time=1643
intel-17.2.174-OpenMP-release build_time=2125 run_time=765
intel-17.2.174-OpenMP_Serial-release build_time=3158 run_time=2867
intel-17.2.174-Pthread-release build_time=1428 run_time=1663
intel-17.2.174-Pthread_Serial-release build_time=2553 run_time=3253
intel-17.2.174-Serial-release build_time=1655 run_time=1618
intel-18.2.199-OpenMP-release build_time=1693 run_time=744
intel-18.2.199-OpenMP_Serial-release build_time=3284 run_time=2347
intel-18.2.199-Pthread-release build_time=1419 run_time=1695
intel-18.2.199-Pthread_Serial-release build_time=2879 run_time=3138
intel-18.2.199-Serial-release build_time=1365 run_time=1636
#######################################################
FAILED TESTS
#######################################################

White:
#######################################################
PASSED TESTS
#######################################################
cuda-10.0.130-Cuda_Serial-release build_time=1171 run_time=1402
cuda-9.2.88-Cuda_OpenMP-release build_time=1159 run_time=1179
gcc-6.4.0-OpenMP_Serial-release build_time=602 run_time=913
gcc-7.2.0-OpenMP-release build_time=395 run_time=389
gcc-7.2.0-OpenMP_Serial-release build_time=594 run_time=1238
gcc-7.2.0-Serial-release build_time=265 run_time=443
gcc-7.4.0-OpenMP-release build_time=400 run_time=387
ibm-16.1.0-Serial-release build_time=1337 run_time=863
#######################################################
FAILED TESTS
#######################################################