### PR TITLE
Test sequential SOR (#494)

### DIFF
--- a/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
@@ -537,9 +537,6 @@ TEST_F( TestCategory, sparse ## _ ## rcm ## _ ## SCALAR ## _ ## ORDINAL ## _ ## 
 TEST_F( TestCategory, sparse ## _ ## balloon_clustering ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
   test_balloon_clustering<SCALAR,ORDINAL,OFFSET,DEVICE>(5000, 100, 2000); \
 } \
-TEST_F( TestCategory, sparse ## _ ## gauss_seidel ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
-  test_gauss_seidel<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 30, 200, 10); \
-} \
 TEST_F( TestCategory, sparse ## _ ## sequential_sor ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
   test_sequential_sor<SCALAR,ORDINAL,OFFSET,DEVICE>(1000, 1000 * 15, 50, 10); \
 }

--- a/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
@@ -435,7 +435,7 @@ void test_sequential_sor(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t ro
   vector_t xgold("X gold", numRows);
   Kokkos::deep_copy(xgold, x);
   vector_t y = Test::create_y_vector(input_mat, x);
-  vector_t y_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), y);
+  auto y_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), y);
   //initial solution is zero
   Kokkos::deep_copy(x_host, zero);
   //get the inverse diagonal (only needed on host)

--- a/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
@@ -425,7 +425,7 @@ void test_sequential_sor(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t ro
   using vector_t = typename crsMat_t::values_type::non_const_type;
   //Create random x
   vector_t x("X", numRows);
-  vector_t x_host = Kokkos::create_mirror_view(x);
+  auto x_host = Kokkos::create_mirror_view(x);
   for(lno_t i = 0; i < numRows; i++)
   {
     x_host(i) = one * (10.0 * rand() / RAND_MAX);

--- a/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
@@ -536,6 +536,7 @@ TEST_F( TestCategory, sparse ## _ ## rcm ## _ ## SCALAR ## _ ## ORDINAL ## _ ## 
 } \
 TEST_F( TestCategory, sparse ## _ ## balloon_clustering ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
   test_balloon_clustering<SCALAR,ORDINAL,OFFSET,DEVICE>(5000, 100, 2000); \
+} \
 TEST_F( TestCategory, sparse ## _ ## gauss_seidel ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
   test_gauss_seidel<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 30, 200, 10); \
 } \

--- a/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
@@ -58,6 +58,7 @@
 #include <vector>
 #include "KokkosSparse_gauss_seidel.hpp"
 #include "KokkosSparse_partitioning_impl.hpp"
+#include "impl/KokkosSparse_sor_sequential_impl.hpp"
 
 #ifndef kokkos_complex_double
 #define kokkos_complex_double Kokkos::complex<double>
@@ -407,7 +408,72 @@ void test_rcm(lno_t numRows, size_type nnzPerRow, lno_t bandwidth)
     std::cerr << "Only got back " << rowSet.size() << " unique row IDs!\n";
     return;
   }
-  //make a new CRS graph based on permuting the rows and columns of mat
+}
+
+template <typename scalar_t, typename lno_t, typename size_type, typename device>
+void test_sequential_sor(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_variance) {
+  const scalar_t zero = Kokkos::Details::ArithTraits<scalar_t>::zero();
+  const scalar_t one = Kokkos::Details::ArithTraits<scalar_t>::one();
+  srand(245);
+  typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type> crsMat_t;
+  lno_t numCols = numRows;
+  crsMat_t input_mat = KokkosKernels::Impl::kk_generate_diagonally_dominant_sparse_matrix<crsMat_t>(numRows,numCols,nnz,row_size_variance, bandwidth);
+  auto rowmap = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), input_mat.graph.row_map);
+  auto entries = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), input_mat.graph.entries);
+  auto values = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), input_mat.values);
+  //create raw x (unkown), y (rhs) vectors
+  using vector_t = typename crsMat_t::values_type::non_const_type;
+  //Create random x
+  vector_t x("X", numRows);
+  vector_t x_host = Kokkos::create_mirror_view(x);
+  for(lno_t i = 0; i < numRows; i++)
+  {
+    x_host(i) = one * (10.0 * rand() / RAND_MAX);
+  }
+  Kokkos::deep_copy(x, x_host);
+  //record the correct solution, to compare against at the end
+  vector_t xgold("X gold", numRows);
+  Kokkos::deep_copy(xgold, x);
+  vector_t y = Test::create_y_vector(input_mat, x);
+  vector_t y_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), y);
+  //initial solution is zero
+  Kokkos::deep_copy(x_host, zero);
+  //get the inverse diagonal (only needed on host)
+  Kokkos::View<scalar_t*, Kokkos::HostSpace> invDiag("diag^-1", numRows);
+  for(lno_t i = 0; i < numRows; i++)
+  {
+    for(size_type j = rowmap(i); j < rowmap(i + 1); j++)
+    {
+      if(entries(j) == i)
+        invDiag(i) = 1.0 / values(j);
+    }
+  }
+  for(int i = 0; i < 1; i++)
+  {
+    KokkosSparse::Impl::Sequential::gaussSeidel
+      <lno_t, size_type, scalar_t, scalar_t, scalar_t>
+      (numRows, 1, rowmap.data(), entries.data(), values.data(),
+       y_host.data(), numRows,
+       x_host.data(), numRows,
+       invDiag.data(),
+       one, //omega
+       "F");
+    KokkosSparse::Impl::Sequential::gaussSeidel
+      <lno_t, size_type, scalar_t, scalar_t, scalar_t>
+      (numRows, 1, rowmap.data(), entries.data(), values.data(),
+       y_host.data(), numRows,
+       x_host.data(), numRows,
+       invDiag.data(),
+       one, //omega
+       "B");
+  }
+  //Copy solution back
+  Kokkos::deep_copy(x, x_host);
+  //Check against gold solution
+  scalar_t xSq = KokkosBlas::dot(x, x);
+  scalar_t solnDot = KokkosBlas::dot(x, xgold);
+  double scaledSolutionDot = Kokkos::Details::ArithTraits<scalar_t>::abs(solnDot / xSq);
+  EXPECT_TRUE(0.99 < scaledSolutionDot);
 }
 
 template <typename scalar_t, typename lno_t, typename size_type, typename device>
@@ -470,6 +536,11 @@ TEST_F( TestCategory, sparse ## _ ## rcm ## _ ## SCALAR ## _ ## ORDINAL ## _ ## 
 } \
 TEST_F( TestCategory, sparse ## _ ## balloon_clustering ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
   test_balloon_clustering<SCALAR,ORDINAL,OFFSET,DEVICE>(5000, 100, 2000); \
+TEST_F( TestCategory, sparse ## _ ## gauss_seidel ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
+  test_gauss_seidel<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 30, 200, 10); \
+} \
+TEST_F( TestCategory, sparse ## _ ## sequential_sor ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
+  test_sequential_sor<SCALAR,ORDINAL,OFFSET,DEVICE>(1000, 1000 * 15, 50, 10); \
 }
 
 #if (defined (KOKKOSKERNELS_INST_DOUBLE) \


### PR DESCRIPTION
Add a simple test for sequential successive over-relaxation (aka Gauss-Seidel since omega=1).

White spot check:
#######################################################
PASSED TESTS
#######################################################
cuda-10.0.130-Cuda_Serial-release build_time=1119 run_time=1485
cuda-9.2.88-Cuda_OpenMP-release build_time=1216 run_time=1101
gcc-6.4.0-OpenMP_Serial-release build_time=577 run_time=1308
gcc-7.2.0-OpenMP-release build_time=390 run_time=488
gcc-7.2.0-OpenMP_Serial-release build_time=598 run_time=1551
gcc-7.2.0-Serial-release build_time=294 run_time=650
gcc-7.4.0-OpenMP-release build_time=405 run_time=527
ibm-16.1.0-Serial-release build_time=1305 run_time=1004
#######################################################
FAILED TESTS
#######################################################

Bowman spot check:
#######################################################
PASSED TESTS
#######################################################
intel-16.4.258-Pthread-release build_time=1670 run_time=3061
intel-16.4.258-Pthread_Serial-release build_time=2777 run_time=5955
intel-16.4.258-Serial-release build_time=1605 run_time=2831
intel-17.2.174-OpenMP-release build_time=2139 run_time=1059
intel-17.2.174-OpenMP_Serial-release build_time=2993 run_time=4458
intel-17.2.174-Pthread-release build_time=1428 run_time=2872
intel-17.2.174-Pthread_Serial-release build_time=2611 run_time=5593
intel-17.2.174-Serial-release build_time=1437 run_time=2874
intel-18.2.199-OpenMP-release build_time=1720 run_time=1100
intel-18.2.199-OpenMP_Serial-release build_time=3196 run_time=3916
intel-18.2.199-Pthread-release build_time=1353 run_time=3259
intel-18.2.199-Pthread_Serial-release build_time=2780 run_time=5768
intel-18.2.199-Serial-release build_time=1295 run_time=2808
#######################################################
FAILED TESTS
#######################################################
