### PR TITLE
block-sgs unit test: Fix case for rank-1 view accepting 2 args

### DIFF
--- a/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
@@ -158,6 +158,14 @@ vec_t create_x_vector(vec_t& kok_x, double max_value = 10.0) {
 template <typename crsMat_t, typename vector_t>
 vector_t create_y_vector(crsMat_t crsMat, vector_t x_vector){
   vector_t y_vector (Kokkos::ViewAllocateWithoutInitializing("Y VECTOR"),
+      crsMat.numRows());
+  KokkosSparse::spmv("N", 1, crsMat, x_vector, 0, y_vector);
+  return y_vector;
+}
+
+template <typename crsMat_t, typename vector_t>
+vector_t create_y_vector_mv(crsMat_t crsMat, vector_t x_vector){
+  vector_t y_vector (Kokkos::ViewAllocateWithoutInitializing("Y VECTOR"),
       crsMat.numRows(), x_vector.extent(1));
   KokkosSparse::spmv("N", 1, crsMat, x_vector, 0, y_vector);
   return y_vector;
@@ -318,7 +326,7 @@ void test_block_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth
 
   scalar_view2d_t solution_x("X", nv, numVecs);
   create_x_vector(solution_x);
-  scalar_view2d_t y_vector = create_y_vector(crsmat2, solution_x);
+  scalar_view2d_t y_vector = create_y_vector_mv(crsmat2, solution_x);
   auto solution_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), solution_x);
   std::vector<mag_t> initial_norms(numVecs);
   for(lno_t i = 0; i < numVecs; i++)


### PR DESCRIPTION
This resolves unit test failures like the following:

*sparse_block_gauss_seidel_rank1_double_int_int_TestExecSpace
Constructor for Kokkos View 'Y VECTOR' has mismatched number of arguments.
Number of arguments = 2 but dynamic rank = 1