### PR TITLE
Test_Sparse_gauss_seidel: UVM Fix

### DIFF
--- a/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
@@ -307,7 +307,7 @@ void test_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth, lno_
   scalar_view2d_t x_vector(Kokkos::ViewAllocateWithoutInitializing("X"), nv, numVecs);
   Kokkos::deep_copy(x_vector, solution_x);
   scalar_view2d_t y_vector = create_y_vector(input_mat, x_vector);
-  host_scalar_view2d_t x_host = Kokkos::create_mirror_view(x_vector);
+  auto x_host = Kokkos::create_mirror_view(x_vector);
   std::vector<mag_t> initial_norms(numVecs);
   for(lno_t i = 0; i < numVecs; i++)
   {


### PR DESCRIPTION
Use auto instead of explicity type when calling create_mirror_view
This fixes compilation errors of type
"Incompatible View copy construction" when UVM is enabled