### PR TITLE
Fix DotBasedGEMM bug encountered in Trilinos issue 6418

### DIFF
--- a/unit_test/blas/Test_Blas3_gemm.hpp
+++ b/unit_test/blas/Test_Blas3_gemm.hpp
@@ -105,9 +105,10 @@ namespace Test {
     uint64_t seed = Kokkos::Impl::clock_tic();
     Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(seed);
 
-    Kokkos::fill_random(A,rand_pool,ScalarA(10));
-    Kokkos::fill_random(B,rand_pool,ScalarB(10));
-    Kokkos::fill_random(C,rand_pool,ScalarC(10));
+    // (SA 11 Dec 2019) Max (previously: 10) increased to detect the bug in Trilinos issue #6418 
+    Kokkos::fill_random(A,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarA>::max());
+    Kokkos::fill_random(B,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarB>::max());
+    Kokkos::fill_random(C,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarC>::max());
     
     Kokkos::deep_copy(C2,C);
 


### PR DESCRIPTION
**Description:**
This PR matches the Trilinos PR https://github.com/trilinos/Trilinos/pull/6427.

**Testing:**
```
[sacer@kokkos-dev-2 unit_test]$ ./KokkosKernels_UnitTest_Cuda --gtest_filter=cuda.gemm_*
Kokkos::OpenMP::initialize WARNING: OMP_PROC_BIND environment variable not set
  In general, for best performance with OpenMP 4.0 or better set OMP_PROC_BIND=spread and OMP_PLACES=threads
  For best performance with OpenMP 3.1 set OMP_PROC_BIND=true
  For unit testing set OMP_PROC_BIND=false
Note: Google Test filter = cuda.gemm_*
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from cuda
[ RUN      ] cuda.gemm_double
[       OK ] cuda.gemm_double (3865 ms)
[ RUN      ] cuda.gemm_complex_double
[       OK ] cuda.gemm_complex_double (3729 ms)
[----------] 2 tests from cuda (7594 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (7594 ms total)
[  PASSED  ] 2 tests.
```