### PR TITLE
Test_Sparse_gauss_seidel: Fix for disabled deprecated code

### DIFF
--- a/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
@@ -155,6 +155,14 @@ vec_t create_x_vector(vec_t& kok_x, double max_value = 10.0) {
 template <typename crsMat_t, typename vector_t>
 vector_t create_y_vector(crsMat_t crsMat, vector_t x_vector){
   vector_t y_vector (Kokkos::ViewAllocateWithoutInitializing("Y VECTOR"),
+      crsMat.numRows());
+  KokkosSparse::spmv("N", 1, crsMat, x_vector, 0, y_vector);
+  return y_vector;
+}
+
+template <typename crsMat_t, typename vector_t>
+vector_t create_y_vector_mv(crsMat_t crsMat, vector_t x_vector){
+  vector_t y_vector (Kokkos::ViewAllocateWithoutInitializing("Y VECTOR"),
       crsMat.numRows(), x_vector.extent(1));
   KokkosSparse::spmv("N", 1, crsMat, x_vector, 0, y_vector);
   return y_vector;
@@ -306,7 +314,7 @@ void test_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth, lno_
   create_x_vector(solution_x);
   scalar_view2d_t x_vector(Kokkos::ViewAllocateWithoutInitializing("X"), nv, numVecs);
   Kokkos::deep_copy(x_vector, solution_x);
-  scalar_view2d_t y_vector = create_y_vector(input_mat, x_vector);
+  scalar_view2d_t y_vector = create_y_vector_mv(input_mat, x_vector);
   auto x_host = Kokkos::create_mirror_view(x_vector);
   std::vector<mag_t> initial_norms(numVecs);
   for(lno_t i = 0; i < numVecs; i++)


### PR DESCRIPTION
Fix to ensure View ctor called with number of args matching dynamic rank