### PR TITLE
KokkosBatched_Trsm: serial and team fixes

### DIFF
--- a/src/batched/KokkosBatched_Trsm_Serial_Impl.hpp
+++ b/src/batched/KokkosBatched_Trsm_Serial_Impl.hpp
@@ -365,7 +365,7 @@ namespace KokkosBatched {
     invoke(const ScalarType alpha,
            const AViewType &A,
            const BViewType &B) {
-      return SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(ArgDiag::use_unit_diag,
+      return SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(ArgDiag::use_unit_diag,
                                                                         B.extent(0), B.extent(1),
                                                                         alpha, 
                                                                         A.data(), A.stride_1(), A.stride_0(),
@@ -383,7 +383,7 @@ namespace KokkosBatched {
     invoke(const ScalarType alpha,
            const AViewType &A,
            const BViewType &B) {
-      return SerialTrsmInternalLeftLower<Algo::Trsm::Blocked>::invoke(ArgDiag::use_unit_diag,
+      return SerialTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(ArgDiag::use_unit_diag,
                                                                       B.extent(0), B.extent(1),
                                                                       alpha, 
                                                                       A.data(), A.stride_1(), A.stride_0(),
@@ -459,7 +459,7 @@ namespace KokkosBatched {
     invoke(const ScalarType alpha,
            const AViewType &A,
            const BViewType &B) {
-      return SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(ArgDiag::use_unit_diag,
+      return SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(ArgDiag::use_unit_diag,
                                                                         B.extent(0), B.extent(1),
                                                                         alpha, 
                                                                         A.data(), A.stride_1(), A.stride_0(),
@@ -477,7 +477,7 @@ namespace KokkosBatched {
     invoke(const ScalarType alpha,
            const AViewType &A,
            const BViewType &B) {
-      return SerialTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(ArgDiag::use_unit_diag,
+      return SerialTrsmInternalLeftLower<Algo::Trsm::Blocked>::invoke(ArgDiag::use_unit_diag,
                                                                       B.extent(0), B.extent(1),
                                                                       alpha, 
                                                                       A.data(), A.stride_1(), A.stride_0(),

--- a/src/batched/KokkosBatched_Trsm_Team_Impl.hpp
+++ b/src/batched/KokkosBatched_Trsm_Team_Impl.hpp
@@ -168,7 +168,7 @@ namespace KokkosBatched {
            const ScalarType alpha,
            const AViewType &A,
            const BViewType &B) {
-      return TeamTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(member,
+      return TeamTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(member,
                                                                       ArgDiag::use_unit_diag,
                                                                       B.extent(0), B.extent(1),
                                                                       alpha, 
@@ -188,7 +188,7 @@ namespace KokkosBatched {
            const ScalarType alpha,
            const AViewType &A,
            const BViewType &B) {
-      return TeamTrsmInternalLeftLower<Algo::Trsm::Blocked>::invoke(member,
+      return TeamTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(member,
                                                                     ArgDiag::use_unit_diag,
                                                                     B.extent(0), B.extent(1),
                                                                     alpha, 
@@ -214,7 +214,7 @@ namespace KokkosBatched {
            const ScalarType alpha,
            const AViewType &A,
            const BViewType &B) {
-      return TeamTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(member,
+      return TeamTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(member,
                                                                       ArgDiag::use_unit_diag,
                                                                       B.extent(0), B.extent(1),
                                                                       alpha, 
@@ -234,7 +234,7 @@ namespace KokkosBatched {
            const ScalarType alpha,
            const AViewType &A,
            const BViewType &B) {
-      return TeamTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(member, 
+      return TeamTrsmInternalLeftLower<Algo::Trsm::Blocked>::invoke(member, 
                                                                     ArgDiag::use_unit_diag,
                                                                     B.extent(0), B.extent(1),
                                                                     alpha, 


### PR DESCRIPTION
Upper vs Lower incorrectly marked in some routines.
Matches patch to Trilinos PR trilinos/Trilinos#6076