### PR TITLE
Fix #527

### DIFF
--- a/perf_test/sparse/KokkosSparse_gs.cpp
+++ b/perf_test/sparse/KokkosSparse_gs.cpp
@@ -57,6 +57,22 @@
 using std::cout;
 using std::string;
 
+#if defined(KOKKOSKERNELS_INST_ORDINAL_INT)
+  typedef int default_lno_t;
+#elif defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T)
+  typedef int64_t default_lno_t;
+#else
+  #error "Expect INT and/or INT64_T to be enabled as ORDINAL (lno_t) types"
+#endif
+  //Prefer int as the default offset type, because cuSPARSE doesn't support size_t for rowptrs.
+#if defined(KOKKOSKERNELS_INST_OFFSET_INT)
+  typedef int default_size_type;
+#elif defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)
+  typedef size_t default_size_type;
+#else
+  #error "Expect SIZE_T and/or INT to be enabled as OFFSET (size_type) types"
+#endif
+
 template<typename size_type, typename lno_t, typename device_t>
 void runGS(string matrixPath, string devName, bool symmetric)
 {
@@ -223,28 +239,28 @@ int main(int argc, char** argv)
   #ifdef KOKKOS_ENABLE_SERIAL
   if(device == "serial")
   {
-    runGS<size_t, int, Kokkos::Serial>(matrixPath, device, sym);
+    runGS<default_size_type, default_lno_t, Kokkos::Serial>(matrixPath, device, sym);
     run = true;
   }
   #endif
   #ifdef KOKKOS_ENABLE_OPENMP
   if(device == "openmp")
   {
-    runGS<size_t, int, Kokkos::OpenMP>(matrixPath, device, sym);
+    runGS<default_size_type, default_lno_t, Kokkos::OpenMP>(matrixPath, device, sym);
     run = true;
   }
   #endif
   #ifdef KOKKOS_ENABLE_THREADS
   if(device == "threads")
   {
-    runGS<size_t, int, Kokkos::Threads>(matrixPath, device, sym);
+    runGS<default_size_type, default_lno_t, Kokkos::Threads>(matrixPath, device, sym);
     run = true;
   }
   #endif
   #ifdef KOKKOS_ENABLE_CUDA
   if(device == "cuda")
   {
-    runGS<size_t, int, Kokkos::Cuda>(matrixPath, device, sym);
+    runGS<default_size_type, default_lno_t, Kokkos::Cuda>(matrixPath, device, sym);
     run = true;
   }
   #endif

--- a/perf_test/sparse/KokkosSparse_gs.cpp
+++ b/perf_test/sparse/KokkosSparse_gs.cpp
@@ -62,7 +62,7 @@ using std::string;
 #elif defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T)
   typedef int64_t default_lno_t;
 #else
-  #error "Expect INT and/or INT64_T to be enabled as ORDINAL (lno_t) types"
+  #error "Expect int and/or int64_t to be enabled as ORDINAL (lno_t) types"
 #endif
   //Prefer int as the default offset type, because cuSPARSE doesn't support size_t for rowptrs.
 #if defined(KOKKOSKERNELS_INST_OFFSET_INT)
@@ -70,7 +70,7 @@ using std::string;
 #elif defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   typedef size_t default_size_type;
 #else
-  #error "Expect SIZE_T and/or INT to be enabled as OFFSET (size_type) types"
+  #error "Expect size_t and/or int to be enabled as OFFSET (size_type) types"
 #endif
 
 template<typename size_type, typename lno_t, typename device_t>

--- a/perf_test/sparse/KokkosSparse_spiluk.cpp
+++ b/perf_test/sparse/KokkosSparse_spiluk.cpp
@@ -70,7 +70,7 @@
 #elif defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T)
   typedef int64_t default_lno_t;
 #else
-  #error "Expect INT and/or INT64_T to be enabled as ORDINAL (lno_t) types"
+  #error "Expect int and/or int64_t to be enabled as ORDINAL (lno_t) types"
 #endif
   //Prefer int as the default offset type, because cuSPARSE doesn't support size_t for rowptrs.
 #if defined(KOKKOSKERNELS_INST_OFFSET_INT)
@@ -78,7 +78,7 @@
 #elif defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   typedef size_t default_size_type;
 #else
-  #error "Expect SIZE_T and/or INT to be enabled as OFFSET (size_type) types"
+  #error "Expect size_t and/or int to be enabled as OFFSET (size_type) types"
 #endif
 
 #if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA ) && (!defined(KOKKOS_ENABLE_CUDA) || ( 8000 <= CUDA_VERSION ))

--- a/perf_test/sparse/KokkosSparse_spiluk.cpp
+++ b/perf_test/sparse/KokkosSparse_spiluk.cpp
@@ -65,6 +65,22 @@
 #include "KokkosSparse_CrsMatrix.hpp"
 #include <KokkosKernels_IOUtils.hpp>
 
+#if defined(KOKKOSKERNELS_INST_ORDINAL_INT)
+  typedef int default_lno_t;
+#elif defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T)
+  typedef int64_t default_lno_t;
+#else
+  #error "Expect INT and/or INT64_T to be enabled as ORDINAL (lno_t) types"
+#endif
+  //Prefer int as the default offset type, because cuSPARSE doesn't support size_t for rowptrs.
+#if defined(KOKKOSKERNELS_INST_OFFSET_INT)
+  typedef int default_size_type;
+#elif defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)
+  typedef size_t default_size_type;
+#else
+  #error "Expect SIZE_T and/or INT to be enabled as OFFSET (size_type) types"
+#endif
+
 #if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA ) && (!defined(KOKKOS_ENABLE_CUDA) || ( 8000 <= CUDA_VERSION ))
 using namespace KokkosSparse;
 using namespace KokkosSparse::Experimental;
@@ -77,8 +93,8 @@ template<typename Scalar>
 int test_spiluk_perf(std::vector<int> tests, std::string afilename, int k, int team_size, int vector_length, /*int idx_offset,*/ int loop) {
 
   typedef Scalar scalar_t;
-  typedef int lno_t;
-  typedef int size_type;
+  typedef default_lno_t lno_t;
+  typedef default_size_type size_type;
   typedef Kokkos::DefaultExecutionSpace execution_space;
   typedef typename execution_space::memory_space memory_space;
 
@@ -111,6 +127,8 @@ int test_spiluk_perf(std::vector<int> tests, std::string afilename, int k, int t
     const typename KernelHandle::const_nnz_lno_t fill_lev = lno_t(k) ;
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+    //cuSPARSE requires lno_t = size_type = int. For both, int is always used (if enabled)
+#if defined(KOKKOSKERNELS_INST_ORDINAL_INT) && defined(KOKKOSKERNELS_INST_OFFSET_INT)
     //std::cout << "  cusparse: create handle" << std::endl;
     cusparseStatus_t status;
     cusparseHandle_t handle = 0;
@@ -143,6 +161,9 @@ int test_spiluk_perf(std::vector<int> tests, std::string afilename, int k, int t
               descr, A.values.data(), A.graph.row_map.data(), A.graph.entries.data(), info, &pBufferSize);
     // pBuffer returned by cudaMalloc is automatically aligned to 128 bytes.
     cudaMalloc((void**)&pBuffer, pBufferSize);
+#else
+    std::cout << "Note: the cuSPARSE TPL is enabled, but either offset=int or ordinal=int is disabled, so it can't be used.\n";
+#endif
 #endif
 
     for ( auto test : tests ) {
@@ -496,6 +517,7 @@ int main(int argc, char **argv)
 }
 #else
 int main() {
+  std::cout << "The SPILUK perf_test requires CUDA >= 8.0\n";
   return 0;
 }
 #endif

--- a/perf_test/sparse/KokkosSparse_spmv_struct.cpp
+++ b/perf_test/sparse/KokkosSparse_spmv_struct.cpp
@@ -65,7 +65,7 @@ enum {AUTO, DYNAMIC, STATIC};
 #elif defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T)
   typedef int64_t default_lno_t;
 #else
-  #error "Expect INT and/or INT64_T to be enabled as ORDINAL (lno_t) types"
+  #error "Expect int and/or int64_t to be enabled as ORDINAL (lno_t) types"
 #endif
   //Prefer int as the default offset type, because cuSPARSE doesn't support size_t for rowptrs.
 #if defined(KOKKOSKERNELS_INST_OFFSET_INT)
@@ -73,7 +73,7 @@ enum {AUTO, DYNAMIC, STATIC};
 #elif defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   typedef size_t default_size_type;
 #else
-  #error "Expect SIZE_T and/or INT to be enabled as OFFSET (size_type) types"
+  #error "Expect size_t and/or int to be enabled as OFFSET (size_type) types"
 #endif
 
 void print_help() {

--- a/perf_test/sparse/KokkosSparse_sptrsv.cpp
+++ b/perf_test/sparse/KokkosSparse_sptrsv.cpp
@@ -69,7 +69,7 @@
 #elif defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T)
   typedef int64_t default_lno_t;
 #else
-  #error "Expect INT and/or INT64_T to be enabled as ORDINAL (lno_t) types"
+  #error "Expect int and/or int64_t to be enabled as ORDINAL (lno_t) types"
 #endif
   //Prefer int as the default offset type, because cuSPARSE doesn't support size_t for rowptrs.
 #if defined(KOKKOSKERNELS_INST_OFFSET_INT)
@@ -77,7 +77,7 @@
 #elif defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   typedef size_t default_size_type;
 #else
-  #error "Expect SIZE_T and/or INT to be enabled as OFFSET (size_type) types"
+  #error "Expect size_t and/or int to be enabled as OFFSET (size_type) types"
 #endif
 
 #if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA ) && (!defined(KOKKOS_ENABLE_CUDA) || ( 8000 <= CUDA_VERSION ))

--- a/perf_test/sparse/KokkosSparse_sptrsv.cpp
+++ b/perf_test/sparse/KokkosSparse_sptrsv.cpp
@@ -64,6 +64,22 @@
 #include "KokkosSparse_CrsMatrix.hpp"
 #include <KokkosKernels_IOUtils.hpp>
 
+#if defined(KOKKOSKERNELS_INST_ORDINAL_INT)
+  typedef int default_lno_t;
+#elif defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T)
+  typedef int64_t default_lno_t;
+#else
+  #error "Expect INT and/or INT64_T to be enabled as ORDINAL (lno_t) types"
+#endif
+  //Prefer int as the default offset type, because cuSPARSE doesn't support size_t for rowptrs.
+#if defined(KOKKOSKERNELS_INST_OFFSET_INT)
+  typedef int default_size_type;
+#elif defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)
+  typedef size_t default_size_type;
+#else
+  #error "Expect SIZE_T and/or INT to be enabled as OFFSET (size_type) types"
+#endif
+
 #if defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA ) && (!defined(KOKKOS_ENABLE_CUDA) || ( 8000 <= CUDA_VERSION ))
 using namespace KokkosSparse;
 using namespace KokkosSparse::Experimental;
@@ -78,8 +94,8 @@ template<typename Scalar>
 int test_sptrsv_perf(std::vector<int> tests, std::string& lfilename, std::string& ufilename, int team_size, int vector_length, int idx_offset, int loop) {
 
   typedef Scalar scalar_t;
-  typedef int lno_t;
-  typedef int size_type;
+  typedef default_lno_t lno_t;
+  typedef default_size_type size_type;
   typedef Kokkos::DefaultExecutionSpace execution_space;
   typedef typename execution_space::memory_space memory_space;
 


### PR DESCRIPTION
In GS, spiluk, sptrsv, and spmv_struct perf tests, use offset/ordinal ETI macros to determine what types to use.

@vqd8a I made 2 minor changes to spiluk, which are
- print a message if CUDA is not enabled
- don't run cuSPARSE if ordinal/offset is not int/int. If the TPL is enabled, print a message saying why it's not being run.

@ndellingwood, I built this successfully using generate_makefile in 3 OpenMP configurations: int/int, int/size_t and int64/size_t. The original issue was just for int/int and GS, but I thought we might as well allow the other combinations. I'm running the usual spot-checks now but you might just want to merge it now.