### PR TITLE
Fix major bug in TeamBitonicSort2.

### DIFF
--- a/src/blas/impl/KokkosBlas3_gemm_impl.hpp
+++ b/src/blas/impl/KokkosBlas3_gemm_impl.hpp
@@ -99,11 +99,11 @@ struct impl_deep_copy_matrix_block<TeamHandle,ViewTypeScratch,ViewType,Layout,bl
     } else {
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team,blockDim_j), [&] (const int j) {
 #ifndef KOKKOS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-        const int idx_j = offset_j+j;
+        int idx_j = offset_j+j;
 #endif
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(team,blockDim_i), [&] (const int i) {
 #ifdef KOKKOS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-          const int idx_j = offset_j+j;
+          int idx_j = offset_j+j;
 #endif
           const int idx_i = offset_i+i;
           A_scr(i,j) = idx_i<A.extent_int(0) && idx_j<A.extent_int(1) ? A(idx_i,idx_j) : ATV::zero();
@@ -131,11 +131,11 @@ struct impl_deep_copy_matrix_block<TeamHandle,ViewTypeScratch,ViewType,Kokkos::L
     } else {
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team,blockDim_i), [&] (const int i) {
 #ifndef KOKKOS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-        const int idx_i = offset_i+i;
+        int idx_i = offset_i+i;
 #endif
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(team,blockDim_j), [&] (const int j) {
 #ifdef KOKKOS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-          const int idx_i = offset_i+i;
+          int idx_i = offset_i+i;
 #endif
           const int idx_j = offset_j+j;
           A_scr(i,j) = idx_i<A.extent_int(0) && idx_j<A.extent_int(1) ? A(idx_i,idx_j) : ATV::zero();
@@ -168,11 +168,11 @@ struct impl_deep_copy_matrix_block<TeamHandle,ViewTypeScratch,ViewType,Layout,bl
     } else {
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team,blockDim_j), [&] (const int j) {
 #ifndef KOKKOS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-        const int idx_j = offset_j+j;
+        int idx_j = offset_j+j;
 #endif
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(team,blockDim_i), [&] (const int i) {
 #ifdef KOKKOS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-          const int idx_j = offset_j+j;
+          int idx_j = offset_j+j;
 #endif
           const int idx_i = offset_i+i;
           A_scr(i,j) = idx_i<A.extent_int(1) && idx_j<A.extent_int(0) ? A(idx_j,idx_i) : ATV::zero();
@@ -205,11 +205,11 @@ struct impl_deep_copy_matrix_block<TeamHandle,ViewTypeScratch,ViewType,Kokkos::L
     } else {
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team,blockDim_i), [&] (const int i) {
 #ifndef KOKKOS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-        const int idx_i = offset_i+i;
+        int idx_i = offset_i+i;
 #endif
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(team,blockDim_j), [&] (const int j) {
 #ifdef KOKKOS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-          const int idx_i = offset_i+i;
+          int idx_i = offset_i+i;
 #endif
           const int idx_j = offset_j+j;
           A_scr(i,j) = idx_i<A.extent_int(1) && idx_j<A.extent_int(0) ? A(idx_j,idx_i) : ATV::zero();
@@ -242,11 +242,11 @@ struct impl_deep_copy_matrix_block<TeamHandle,ViewTypeScratch,ViewType,Layout,bl
     } else {
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team,blockDim_j), [&] (const int j) {
 #ifndef KOKKOS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-        const int idx_j = offset_j+j;
+        int idx_j = offset_j+j;
 #endif
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(team,blockDim_i), [&] (const int i) {
 #ifdef KOKKOS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-          const int idx_j = offset_j+j;
+          int idx_j = offset_j+j;
 #endif
           const int idx_i = offset_i+i;
           A_scr(i,j) = idx_i<A.extent_int(1) && idx_j<A.extent_int(0) ? ATV::conj(A(idx_j,idx_i)) : ATV::zero();
@@ -279,11 +279,11 @@ struct impl_deep_copy_matrix_block<TeamHandle,ViewTypeScratch,ViewType,Kokkos::L
     } else {
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team,blockDim_i), [&] (const int i) {
 #ifndef KOKKOS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-        const int idx_i = offset_i+i;
+        int idx_i = offset_i+i;
 #endif
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(team,blockDim_j), [&] (const int j) {
 #ifdef KOKKOS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-          const int idx_i = offset_i+i;
+          int idx_i = offset_i+i;
 #endif
           const int idx_j = offset_j+j;
           A_scr(i,j) = idx_i<A.extent_int(1) && idx_j<A.extent_int(0) ? ATV::conj(A(idx_j,idx_i)) : ATV::zero();

--- a/src/common/KokkosKernels_Sorting.hpp
+++ b/src/common/KokkosKernels_Sorting.hpp
@@ -395,11 +395,11 @@ TeamBitonicSort2(ValueType* values, PermType* perm, Ordinal n, const TeamMember 
             if(elem2 < n)
             {
               //both elements in bounds, so compare them and swap if out of order
-              if(comp(values[elem2], values[elem2]))
+              if(comp(values[elem2], values[elem1]))
               {
-                ValueType temp = values[elem1];
+                ValueType temp1 = values[elem1];
                 values[elem1] = values[elem2];
-                values[elem2] = temp;
+                values[elem2] = temp1;
                 PermType temp2 = perm[elem1];
                 perm[elem1] = perm[elem2];
                 perm[elem2] = temp2;
@@ -414,9 +414,9 @@ TeamBitonicSort2(ValueType* values, PermType* perm, Ordinal n, const TeamMember 
             {
               if(comp(values[elem2], values[elem1]))
               {
-                ValueType temp = values[elem1];
+                ValueType temp1 = values[elem1];
                 values[elem1] = values[elem2];
-                values[elem2] = temp;
+                values[elem2] = temp1;
                 PermType temp2 = perm[elem1];
                 perm[elem1] = perm[elem2];
                 perm[elem2] = temp2;

--- a/src/common/KokkosKernels_Sorting.hpp
+++ b/src/common/KokkosKernels_Sorting.hpp
@@ -52,7 +52,7 @@ namespace KokkosKernels {
 namespace Impl {
 
 //Radix sort for integers, on a single thread within a team.
-//Pros: few diverging branches, so OK for sorting on a single GPU thread/warp. Better on CPU cores.
+//Pros: few diverging branches, so OK for sorting on a single GPU vector lane. Better on CPU cores.
 //Con: requires auxiliary storage, and this version only works for integers
 template<typename Ordinal, typename ValueType>
 KOKKOS_INLINE_FUNCTION void
@@ -166,7 +166,7 @@ SerialRadixSort(ValueType* values, ValueType* valuesAux, Ordinal n)
 
 //Radix sort for integers (no internal parallelism).
 //While sorting, also permute "perm" array along with the values.
-//Pros: few diverging branches, so good for sorting on a single GPU thread/warp.
+//Pros: few diverging branches, so good for sorting on a single GPU vector lane.
 //Con: requires auxiliary storage, this version only works for integers (although float/double is possible)
 template<typename Ordinal, typename ValueType, typename PermType>
 KOKKOS_INLINE_FUNCTION void

--- a/test_common/Test_Common_Sorting.hpp
+++ b/test_common/Test_Common_Sorting.hpp
@@ -538,7 +538,6 @@ TEST_F(TestCategory, common_serial_radix) {
 }
 
 TEST_F(TestCategory, common_serial_radix2) {
-  typedef TestExecSpace es;
   //Test serial radix over some contiguous small arrays
   //1st arg is #arrays, 2nd arg is max subarray size
   size_t numArrays = 100;

--- a/test_common/Test_Common_Sorting.hpp
+++ b/test_common/Test_Common_Sorting.hpp
@@ -53,6 +53,7 @@
 #include <KokkosKernels_Utils.hpp>
 #include <KokkosKernels_Sorting.hpp>
 #include <Kokkos_ArithTraits.hpp>
+#include <Kokkos_Complex.hpp>
 #include <cstdlib>
 
 //Generate n randomized counts with mean <avg>.
@@ -61,13 +62,17 @@
 template<typename OrdView, typename ExecSpace>
 size_t generateRandomOffsets(OrdView& randomCounts, OrdView& randomOffsets, size_t n, size_t avg)
 {
+  srand(54321);
   randomCounts = OrdView("Counts", n);
   randomOffsets = OrdView("Offsets", n);
   auto countsHost = Kokkos::create_mirror_view(randomCounts);
   size_t total = 0;
   for(size_t i = 0; i < n; i++)
   {
-    countsHost(i) = 0.5 + rand() % (avg * 2);
+    if(avg == 0)
+      countsHost(i) = 0;
+    else
+      countsHost(i) = 0.5 + rand() % (avg * 2);
     total += countsHost(i);
   }
   Kokkos::deep_copy(randomCounts, countsHost);
@@ -115,6 +120,25 @@ Coordinates getRandom<Coordinates>()
   return Coordinates(getRandom<double>(), getRandom<double>(), getRandom<double>());
 }
 
+//Specialize for Kokkos::complex, with the real and imaginary parts different
+template<typename Key, typename Value>
+struct kvHash
+{
+  Value operator()(const Key& k)
+  {
+    return (Value) (3 * k + 4);
+  }
+};
+
+template<typename Key>
+struct kvHash<Key, Kokkos::complex<double>>
+{
+  Kokkos::complex<double> operator()(const Key& k)
+  {
+    return Kokkos::complex<double>(3 * k + 4, k - 10.4);
+  }
+};
+
 template<typename View>
 void fillRandom(View v)
 {
@@ -123,6 +147,23 @@ void fillRandom(View v)
   auto vhost = Kokkos::create_mirror_view(v);
   for(size_t i = 0; i < v.extent(0); i++)
     vhost(i) = getRandom<Value>();
+  Kokkos::deep_copy(v, vhost);
+}
+
+template<typename KeyView, typename ValView>
+void fillRandom(KeyView k, ValView v)
+{
+  srand(23456);
+  typedef typename KeyView::value_type Key;
+  typedef typename ValView::value_type Value;
+  auto khost = Kokkos::create_mirror_view(k);
+  auto vhost = Kokkos::create_mirror_view(v);
+  for(size_t i = 0; i < v.extent(0); i++)
+  {
+    khost(i) = getRandom<Key>();
+    vhost(i) = kvHash<Key, Value>()(khost(i));
+  }
+  Kokkos::deep_copy(k, khost);
   Kokkos::deep_copy(v, vhost);
 }
 
@@ -149,46 +190,119 @@ struct TestSerialRadixFunctor
   OrdView offsets;
 };
 
-template<typename ExecSpace, typename Scalar>
-void testSerialRadixSort()
+template<typename KeyView, typename ValView, typename OrdView>
+struct TestSerialRadix2Functor
+{
+  //Sort by keys, while permuting values
+  typedef typename KeyView::value_type Key;
+  typedef typename ValView::value_type Value;
+
+  TestSerialRadix2Functor(KeyView& keys_, KeyView& keysAux_, ValView& values_, ValView& valuesAux_, OrdView& counts_, OrdView& offsets_)
+    : keys(keys_), keysAux(keysAux_), values(values_), valuesAux(valuesAux_), counts(counts_), offsets(offsets_)
+  {}
+  template<typename TeamMem>
+  KOKKOS_INLINE_FUNCTION void operator()(const TeamMem t) const
+  {
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(t, counts.extent(0)),
+      [=](const int i)
+      {
+        KokkosKernels::Impl::SerialRadixSort2<int, Key, Value>(&keys(offsets(i)), &keysAux(offsets(i)), &values(offsets(i)), &valuesAux(offsets(i)), counts(i));
+      });
+  }
+  KeyView keys;
+  KeyView keysAux;
+  ValView values;
+  ValView valuesAux;
+  OrdView counts;
+  OrdView offsets;
+};
+
+template<typename ExecSpace, typename Key>
+void testSerialRadixSort(size_t k, size_t subArraySize)
 {
   //Create a view of randomized data
   typedef typename ExecSpace::memory_space mem_space;
   typedef Kokkos::View<int*, mem_space> OrdView;
-  //typedef Kokkos::View<int*, Kokkos::HostSpace> OrdViewHost;
-  typedef Kokkos::View<Scalar*, mem_space> ValView;
+  typedef Kokkos::View<Key*, mem_space> KeyView;
   OrdView counts;
   OrdView offsets;
   //Generate k sub-array sizes, each with size about 20
-  size_t k = 100;
-  size_t subSize = 20;
-  size_t n = generateRandomOffsets<OrdView, ExecSpace>(counts, offsets, k, subSize);
+  size_t n = generateRandomOffsets<OrdView, ExecSpace>(counts, offsets, k, subArraySize);
   auto countsHost = Kokkos::create_mirror_view(counts);
   auto offsetsHost = Kokkos::create_mirror_view(offsets);
   Kokkos::deep_copy(countsHost, counts);
   Kokkos::deep_copy(offsetsHost, offsets);
-  ValView data("Radix sort testing data", n);
-  fillRandom(data);
-  ValView dataAux("Radix sort aux data", n);
+  KeyView keys("Radix sort testing data", n);
+  fillRandom(keys);
+  //Sort using std::sort on host to do correctness test
+  Kokkos::View<Key*, Kokkos::HostSpace> gold("Host sorted", n);
+  Kokkos::deep_copy(gold, keys);
+  for(size_t i = 0; i < k; i++)
+  {
+    Key* begin = gold.data() + offsetsHost(i);
+    Key* end = begin + countsHost(i);
+    std::sort(begin, end);
+  }
+  KeyView keysAux("Radix sort aux data", n);
   //Run the sorting on device in all sub-arrays in parallel, just using vector loops
   typedef Kokkos::TeamPolicy<ExecSpace> team_policy;
   Kokkos::parallel_for(team_policy(1, Kokkos::AUTO(), 32),
-        TestSerialRadixFunctor<ValView, OrdView>(data, dataAux, counts, offsets));
-  //Sort using std::sort on host to do correctness test
-  Kokkos::View<Scalar*, Kokkos::HostSpace> gold("Host sorted", n);
-  Kokkos::deep_copy(gold, data);
-  for(size_t i = 0; i < k; i++)
-  {
-    Scalar* begin = &gold(offsetsHost(i));
-    Scalar* end = begin + countsHost(i);
-    std::sort(begin, end);
-  }
+        TestSerialRadixFunctor<KeyView, OrdView>(keys, keysAux, counts, offsets));
   //Copy result to host
-  auto dataHost = Kokkos::create_mirror_view(data);
-  Kokkos::deep_copy(dataHost, data);
+  auto keysHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), keys);
   for(size_t i = 0; i < n; i++)
   {
-    ASSERT_EQ(dataHost(i), gold(i));
+    ASSERT_EQ(keysHost(i), gold(i));
+  }
+}
+
+template<typename ExecSpace, typename Key, typename Value>
+void testSerialRadixSort2(size_t k, size_t subArraySize)
+{
+  //Create a view of randomized data
+  typedef typename ExecSpace::memory_space mem_space;
+  typedef Kokkos::View<int*, mem_space> OrdView;
+  typedef Kokkos::View<Key*, mem_space> KeyView;
+  typedef Kokkos::View<Value*, mem_space> ValView;
+  OrdView counts;
+  OrdView offsets;
+  //Generate k sub-array sizes, each with size about 20
+  size_t n = generateRandomOffsets<OrdView, ExecSpace>(counts, offsets, k, subArraySize);
+  auto countsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), counts);
+  auto offsetsHost = Kokkos::create_mirror_view(Kokkos::HostSpace(), offsets);
+  KeyView keys("Radix test keys", n);
+  ValView data("Radix test data", n);
+  //The keys are randomized
+  fillRandom(keys, data);
+  KeyView keysAux("Radix sort aux keys", n);
+  ValView dataAux("Radix sort aux data", n);
+  //Run the sorting on device in all sub-arrays in parallel, just using vector loops
+  typedef Kokkos::TeamPolicy<ExecSpace> team_policy;
+  //Deliberately using a weird number for vector length
+  Kokkos::parallel_for(team_policy(1, Kokkos::AUTO(), 19),
+        TestSerialRadix2Functor<KeyView, ValView, OrdView>(keys, keysAux, data, dataAux, counts, offsets));
+  //Sort using std::sort on host to do correctness test
+  Kokkos::View<Key*, Kokkos::HostSpace> gold("Host sorted", n);
+  Kokkos::deep_copy(gold, keys);
+  for(size_t i = 0; i < k; i++)
+  {
+    Key* begin = &gold(offsetsHost(i));
+    Key* end = begin + countsHost(i);
+    std::sort(begin, end);
+  }
+  //Copy results to host
+  auto keysHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), keys);
+  auto dataHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), data);
+  //Make sure keys are sorted exactly (stability of sort doesn't matter)
+  for(size_t i = 0; i < n; i++)
+  {
+    ASSERT_EQ(keysHost(i), gold(i));
+  }
+  //Make sure the hashes of each key still matches the corresponding value
+  for(size_t i = 0; i < n; i++)
+  {
+    auto correctHash = kvHash<Key, Value>()(keysHost(i));
+    ASSERT_EQ(dataHost(i), correctHash);
   }
 }
 
@@ -213,20 +327,40 @@ struct TestTeamBitonicFunctor
   OrdView offsets;
 };
 
+template<typename KeyView, typename ValView, typename OrdView>
+struct TestTeamBitonic2Functor
+{
+  typedef typename KeyView::value_type Key;
+  typedef typename ValView::value_type Value;
+
+  TestTeamBitonic2Functor(KeyView& keys_, ValView& values_, OrdView& counts_, OrdView& offsets_)
+    : keys(keys_), values(values_), counts(counts_), offsets(offsets_)
+  {}
+
+  template<typename TeamMem>
+  KOKKOS_INLINE_FUNCTION void operator()(const TeamMem t) const
+  {
+    int i = t.league_rank();
+    KokkosKernels::Impl::TeamBitonicSort2<int, Key, Value, TeamMem>(&keys(offsets(i)), &values(offsets(i)), counts(i), t);
+  }
+
+  KeyView keys;
+  ValView values;
+  OrdView counts;
+  OrdView offsets;
+};
+
 template<typename ExecSpace, typename Scalar>
-void testTeamBitonicSort()
+void testTeamBitonicSort(size_t k, size_t subArraySize)
 {
   //Create a view of randomized data
   typedef typename ExecSpace::memory_space mem_space;
   typedef Kokkos::View<int*, mem_space> OrdView;
-  //typedef Kokkos::View<int*, Kokkos::HostSpace> OrdViewHost;
   typedef Kokkos::View<Scalar*, mem_space> ValView;
   OrdView counts;
   OrdView offsets;
   //Generate k sub-array sizes, each with size about 20
-  size_t k = 100;
-  size_t subSize = 100;
-  size_t n = generateRandomOffsets<OrdView, ExecSpace>(counts, offsets, k, subSize);
+  size_t n = generateRandomOffsets<OrdView, ExecSpace>(counts, offsets, k, subArraySize);
   auto countsHost = Kokkos::create_mirror_view(counts);
   auto offsetsHost = Kokkos::create_mirror_view(offsets);
   Kokkos::deep_copy(countsHost, counts);
@@ -251,6 +385,55 @@ void testTeamBitonicSort()
   for(size_t i = 0; i < n; i++)
   {
     ASSERT_EQ(dataHost(i), gold(i));
+  }
+}
+
+template<typename ExecSpace, typename Key, typename Value>
+void testTeamBitonicSort2(size_t k, size_t subArraySize)
+{
+  //Create a view of randomized data
+  typedef typename ExecSpace::memory_space mem_space;
+  typedef Kokkos::View<int*, mem_space> OrdView;
+  typedef Kokkos::View<Key*, mem_space> KeyView;
+  typedef Kokkos::View<Value*, mem_space> ValView;
+  OrdView counts;
+  OrdView offsets;
+  //Generate k sub-array sizes, each with size about 20
+  size_t n = generateRandomOffsets<OrdView, ExecSpace>(counts, offsets, k, subArraySize);
+  auto countsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), counts);
+  auto offsetsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), offsets);
+  Kokkos::deep_copy(countsHost, counts);
+  Kokkos::deep_copy(offsetsHost, offsets);
+  KeyView keys("Bitonic test keys", n);
+  ValView data("Bitonic test data", n);
+  //The keys are randomized
+  fillRandom(keys, data);
+  //Run the sorting on device in all sub-arrays in parallel, just using vector loops
+  //Deliberately using a weird number for vector length
+  Kokkos::parallel_for(Kokkos::TeamPolicy<ExecSpace>(k, Kokkos::AUTO()),
+      TestTeamBitonic2Functor<KeyView, ValView, OrdView>(keys, data, counts, offsets));
+  //Sort using std::sort on host to do correctness test
+  Kokkos::View<Key*, Kokkos::HostSpace> gold("Host sorted", n);
+  Kokkos::deep_copy(gold, keys);
+  for(size_t i = 0; i < k; i++)
+  {
+    Key* begin = gold.data() + offsetsHost(i);
+    Key* end = begin + countsHost(i);
+    std::sort(begin, end);
+  }
+  //Copy results to host
+  auto keysHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), keys);
+  auto dataHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), data);
+  //Make sure keys are sorted exactly (stability of sort doesn't matter)
+  for(size_t i = 0; i < n; i++)
+  {
+    ASSERT_EQ(keysHost(i), gold(i));
+  }
+  //Make sure the hashes of each key still matches the corresponding value
+  for(size_t i = 0; i < n; i++)
+  {
+    auto correctHash = kvHash<Key, Value>()(keysHost(i));
+    ASSERT_EQ(dataHost(i), correctHash);
   }
 }
 
@@ -360,18 +543,47 @@ void testBitonicSortLexicographic()
   ASSERT_TRUE(ordered);
 }
 
-TEST_F( TestCategory, common_Sorting) {
-  testSerialRadixSort<TestExecSpace, char>();
-  testSerialRadixSort<TestExecSpace, int>();
-  testTeamBitonicSort<TestExecSpace, int>();
-  testTeamBitonicSort<TestExecSpace, double>();
-  testBitonicSort<TestExecSpace, char>(215673);
-  testBitonicSort<TestExecSpace, int>(92314);
-  testBitonicSort<TestExecSpace, double>(60234);
+TEST_F(TestCategory, serial_radix) {
+  //Test serial radix over some contiguous small arrays
+  //1st arg is #arrays, 2nd arg is max subarray size
+  size_t numArrays = 100;
+  for(size_t arrayMax = 0; arrayMax < 1000; arrayMax = 1 + 4 * arrayMax)
+  {
+    testSerialRadixSort<TestExecSpace, char>(numArrays, arrayMax);
+    testSerialRadixSort<TestExecSpace, int>(numArrays, arrayMax);
+    testSerialRadixSort2<TestExecSpace, char, int>(numArrays, arrayMax);
+    testSerialRadixSort2<TestExecSpace, int, double>(numArrays, arrayMax);
+    testSerialRadixSort2<TestExecSpace, int, Kokkos::complex<double>>(numArrays, arrayMax);
+  }
+}
+
+TEST_F(TestCategory, test_bitonic) {
+  //Test team-level bitonic over some contiguous medium arrays
+  //1st arg is #arrays, 2nd arg is max subarray size
+  size_t numArrays = 20;
+  for(size_t arrayMax = 0; arrayMax < 10000; arrayMax = 1 + 4 * arrayMax)
+  {
+    testTeamBitonicSort<TestExecSpace, char>(numArrays, arrayMax);
+    testTeamBitonicSort<TestExecSpace, int>(numArrays, arrayMax);
+    testTeamBitonicSort2<TestExecSpace, char, int>(numArrays, arrayMax);
+    testTeamBitonicSort2<TestExecSpace, int, double>(numArrays, arrayMax);
+    testTeamBitonicSort2<TestExecSpace, int, Kokkos::complex<double>>(numArrays, arrayMax);
+  }
+}
+
+TEST_F( TestCategory, device_level_bitonic) {
+  //Test device-level bitonic with some larger arrays
+  testBitonicSort<TestExecSpace, char>(243743);
+  testBitonicSort<TestExecSpace, char>(2157);
   testBitonicSort<TestExecSpace, char>(424);
+  testBitonicSort<TestExecSpace, char>(5);
+  testBitonicSort<TestExecSpace, int>(92314);
   testBitonicSort<TestExecSpace, int>(123);
+  testBitonicSort<TestExecSpace, double>(60234);
   testBitonicSort<TestExecSpace, double>(53);
+  //Test custom comparator: ">" instead of "<" to sort descending
   testBitonicSortDescending<TestExecSpace>();
+  //Test custom comparator: lexicographic comparison of 3-element struct
   testBitonicSortLexicographic<TestExecSpace>();
 }
 

--- a/test_common/Test_Common_Sorting.hpp
+++ b/test_common/Test_Common_Sorting.hpp
@@ -83,13 +83,13 @@ size_t generateRandomOffsets(OrdView& randomCounts, OrdView& randomOffsets, size
 
 struct Coordinates
 {
-  Coordinates()
+  KOKKOS_INLINE_FUNCTION Coordinates()
   {
      x = 0;
      y = 0;
      z = 0;
   }
-  Coordinates(double x_, double y_, double z_)
+  KOKKOS_INLINE_FUNCTION Coordinates(double x_, double y_, double z_)
   {
      x = x_;
      y = y_;

--- a/unit_test/Makefile
+++ b/unit_test/Makefile
@@ -131,6 +131,7 @@ ifeq ($(KOKKOSKERNELS_INTERNAL_TEST_OPENMP), 1)
   OBJ_OPENMP += Test_OpenMP_Graph_graph_color_d2.o
   OBJ_OPENMP += Test_OpenMP_Common_ArithTraits.o
   OBJ_OPENMP += Test_OpenMP_Common_set_bit_count.o
+  OBJ_OPENMP += Test_OpenMP_Common_Sorting.o
 #  OBJ_OPENMP += Test_OpenMP_Common_float128.o
  # Real 
   OBJ_OPENMP += Test_OpenMP_Batched_SerialMatUtil_Real.o
@@ -247,6 +248,7 @@ ifeq ($(KOKKOSKERNELS_INTERNAL_TEST_CUDA), 1)
   OBJ_CUDA += Test_Cuda_Graph_graph_color_d2.o
   OBJ_CUDA += Test_Cuda_Common_ArithTraits.o
   OBJ_CUDA += Test_Cuda_Common_set_bit_count.o
+  OBJ_CUDA += Test_Cuda_Common_Sorting.o
   # Real
   OBJ_CUDA += Test_Cuda_Batched_SerialMatUtil_Real.o
   OBJ_CUDA += Test_Cuda_Batched_SerialGemm_Real.o
@@ -357,6 +359,7 @@ ifeq ($(KOKKOSKERNELS_INTERNAL_TEST_SERIAL), 1)
   OBJ_SERIAL += Test_Serial_Common_ArithTraits.o
   OBJ_SERIAL += Test_Serial_Common_set_bit_count.o
 #  OBJ_SERIAL += Test_Serial_Common_float128.o
+  OBJ_SERIAL += Test_Serial_Common_Sorting.o
   # Real
   OBJ_SERIAL += Test_Serial_Batched_SerialMatUtil_Real.o
   OBJ_SERIAL += Test_Serial_Batched_SerialGemm_Real.o
@@ -472,6 +475,7 @@ ifeq ($(KOKKOSKERNELS_INTERNAL_TEST_THREADS), 1)
   OBJ_THREADS += Test_Threads_Graph_graph_color_d2.o
   OBJ_THREADS += Test_Threads_Common_ArithTraits.o
   OBJ_THREADS += Test_Threads_Common_set_bit_count.o
+  OBJ_THREADS += Test_Threads_Common_Sorting.o
 #  OBJ_THREADS += Test_Threads_Common_float128.o
   TARGETS += KokkosKernels_UnitTest_Threads
   TEST_TARGETS += test-threads

--- a/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
@@ -528,13 +528,13 @@ void test_balloon_clustering(lno_t numRows, size_type nnzPerRow, lno_t bandwidth
 
 #define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE) \
 TEST_F( TestCategory, sparse ## _ ## gauss_seidel_asymmetric_rank1 ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
-  test_gauss_seidel_rank1<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 30, 200, 10, false); \
+  test_gauss_seidel_rank1<SCALAR,ORDINAL,OFFSET,DEVICE>(5000, 5000 * 20, 200, 10, false); \
 } \
 TEST_F( TestCategory, sparse ## _ ## gauss_seidel_asymmetric_rank2 ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
   test_gauss_seidel_rank2<SCALAR,ORDINAL,OFFSET,DEVICE>(5000, 5000 * 20, 200, 10, 3, false); \
 } \
 TEST_F( TestCategory, sparse ## _ ## gauss_seidel_symmetric_rank1 ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
-  test_gauss_seidel_rank1<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 30, 200, 10, true); \
+  test_gauss_seidel_rank1<SCALAR,ORDINAL,OFFSET,DEVICE>(5000, 5000 * 20, 200, 10, true); \
 } \
 TEST_F( TestCategory, sparse ## _ ## gauss_seidel_symmetric_rank2 ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
   test_gauss_seidel_rank2<SCALAR,ORDINAL,OFFSET,DEVICE>(5000, 5000 * 20, 200, 10, 3, true); \

--- a/unit_test/sparse/Test_Sparse_spadd.hpp
+++ b/unit_test/sparse/Test_Sparse_spadd.hpp
@@ -1,6 +1,7 @@
 #include<gtest/gtest.h>   
 #include<Kokkos_Core.hpp>
 #include<Kokkos_Random.hpp>
+#include<Kokkos_ArithTraits.hpp>
 
 #include<KokkosSparse_CrsMatrix.hpp>
 #include<KokkosSparse_spadd.hpp>
@@ -15,8 +16,6 @@
 
 typedef Kokkos::complex<double> kokkos_complex_double;
 typedef Kokkos::complex<float> kokkos_complex_float;
-
-namespace Test {
 
 //Create a random square matrix for testing mat-mat addition kernels
 template <typename crsMat_t, typename ordinal_type>
@@ -77,59 +76,6 @@ crsMat_t randomMatrix(ordinal_type nrows, ordinal_type minNNZ, ordinal_type maxN
   return crsMat_t("test matrix", nrows, nrows, nnz, values, rowmap, entries);
 }
 
-template <typename crsMat_t, typename ordinal_type>
-void checkSumRowCorrect(ordinal_type row, crsMat_t A, crsMat_t B, crsMat_t C)
-{
-  typedef typename crsMat_t::StaticCrsGraphType graph_t;
-  typedef typename graph_t::row_map_type size_type_view_t;
-  typedef typename graph_t::entries_type lno_view_t;
-  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
-  typedef typename size_type_view_t::non_const_value_type size_type;  //rowptr type
-  typedef typename lno_view_t::non_const_value_type lno_t;            //colind type
-  static_assert(std::is_same<ordinal_type, lno_t>::value, "ordinal_type should be same as lno_t from crsMat_t");
-  typedef typename scalar_view_t::non_const_value_type scalar_t;      //value type
-  auto Avalues = Kokkos::create_mirror_view(A.values);
-  auto Arowmap = Kokkos::create_mirror_view(A.graph.row_map);
-  auto Aentries = Kokkos::create_mirror_view(A.graph.entries);
-  auto Bvalues = Kokkos::create_mirror_view(B.values);
-  auto Browmap = Kokkos::create_mirror_view(B.graph.row_map);
-  auto Bentries = Kokkos::create_mirror_view(B.graph.entries);
-  auto Cvalues = Kokkos::create_mirror_view(C.values);
-  auto Crowmap = Kokkos::create_mirror_view(C.graph.row_map);
-  auto Centries = Kokkos::create_mirror_view(C.graph.entries);
-  lno_t nrows = Arowmap.extent(0) - 1;
-  //compute the correct row as a dense vector
-  std::vector<scalar_t> correct(nrows, 0);
-  std::vector<bool> nonzeros(nrows, false);
-  for(size_type i = Arowmap(row); i < Arowmap(row + 1); i++)
-  {
-    correct[Aentries(i)] += Avalues(i);
-    nonzeros[Aentries(i)] = true;
-  }
-  for(size_type i = Browmap(row); i < Browmap(row + 1); i++)
-  {
-    correct[Bentries(i)] += Bvalues(i);
-    nonzeros[Bentries(i)] = true;
-  }
-  size_type nz = 0;
-  for(lno_t i = 0; i < nrows; i++)
-  {
-    if(nonzeros[i])
-      nz++;
-  }
-  //make sure C has the right number of entries
-  auto actualNZ = Crowmap(row + 1) - Crowmap(row);
-  ASSERT_EQ(actualNZ, nz) << "A+B row " << row << " has " << actualNZ << " entries but should have " << nz;
-  //make sure C has the correct values
-  for(size_type i = Crowmap(row); i < Crowmap(row + 1); i++)
-  {
-    scalar_t Cval = Cvalues(i);
-    lno_t Ccol = Centries(i);
-    EXPECT_EQ(correct[Ccol], Cval) << "A+B row " << row << ", column " << Ccol << " has value " << Cval << " but should be " << correct[Ccol];
-  }
-}
-}
-
 template <typename scalar_t, typename lno_t, typename size_type, class Device>
 void test_spadd(lno_t numRows, size_type minNNZ, size_type maxNNZ, bool sortRows)
 {
@@ -144,8 +90,10 @@ void test_spadd(lno_t numRows, size_type minNNZ, size_type maxNNZ, bool sortRows
 
   KernelHandle handle;
   handle.create_spadd_handle(sortRows);
-  crsMat_t A = Test::randomMatrix<crsMat_t, lno_t>(numRows, minNNZ, maxNNZ, sortRows);
-  crsMat_t B = Test::randomMatrix<crsMat_t, lno_t>(numRows, minNNZ, maxNNZ, sortRows);
+  crsMat_t A = randomMatrix<crsMat_t, lno_t>(numRows, minNNZ, maxNNZ, sortRows);
+  crsMat_t B = randomMatrix<crsMat_t, lno_t>(numRows, minNNZ, maxNNZ, sortRows);
+  //Matrices from randomMatrix are always square
+  lno_t numCols = numRows;
   row_map_type c_row_map("C row map", numRows + 1);
   auto addHandle = handle.get_spadd_handle();
   KokkosSparse::Experimental::spadd_symbolic<
@@ -175,11 +123,55 @@ void test_spadd(lno_t numRows, size_type minNNZ, size_type maxNNZ, bool sortRows
   //create C using CRS arrays
   crsMat_t C("C", numRows, numRows, addHandle->get_max_result_nnz(), c_values, c_row_map, c_entries);
   handle.destroy_spadd_handle();
-
-  //check that C is correct
-  for(lno_t i = 0; i < numRows; i++)
+  auto Avalues = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A.values);
+  auto Arowmap = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A.graph.row_map);
+  auto Aentries = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A.graph.entries);
+  auto Bvalues = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), B.values);
+  auto Browmap = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), B.graph.row_map);
+  auto Bentries = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), B.graph.entries);
+  auto Cvalues = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), C.values);
+  auto Crowmap = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), C.graph.row_map);
+  auto Centries = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), C.graph.entries);
+  using KAT = Kokkos::ArithTraits<scalar_t>;
+  auto zero = KAT::zero();
+  auto eps = KAT::epsilon();
+  //check that C is correct and sorted, row-by-row
+  for(lno_t row = 0; row < numRows; row++)
   {
-    Test::checkSumRowCorrect<crsMat_t, lno_t>(i, A, B, C);
+    std::vector<scalar_t> correct(numCols, zero);
+    std::vector<bool> nonzeros(numCols, false);
+    for(size_type i = Arowmap(row); i < Arowmap(row + 1); i++)
+    {
+      correct[Aentries(i)] += Avalues(i);
+      nonzeros[Aentries(i)] = true;
+    }
+    for(size_type i = Browmap(row); i < Browmap(row + 1); i++)
+    {
+      correct[Bentries(i)] += Bvalues(i);
+      nonzeros[Bentries(i)] = true;
+    }
+    size_type nz = 0;
+    for(lno_t i = 0; i < numCols; i++)
+    {
+      if(nonzeros[i])
+        nz++;
+    }
+    //make sure C has the right number of entries
+    auto actualNZ = Crowmap(row + 1) - Crowmap(row);
+    ASSERT_EQ(actualNZ, nz) << "A+B row " << row << " has " << actualNZ << " entries but should have " << nz;
+    //make sure C's indices are sorted
+    for(size_type i = Crowmap(row) + 1; i < Crowmap(row + 1); i++)
+    {
+      ASSERT_LE(Centries(i - 1), Centries(i)) << "C row " << row << " is not sorted";
+    }
+    //make sure C has the correct values
+    for(size_type i = Crowmap(row); i < Crowmap(row + 1); i++)
+    {
+      scalar_t Cval = Cvalues(i);
+      lno_t Ccol = Centries(i);
+      //Check that result is correct to 1 ULP
+      ASSERT_LE(KAT::abs(correct[Ccol] - Cval), KAT::abs(correct[Ccol] * eps)) << "A+B row " << row << ", column " << Ccol << " has value " << Cval << " but should be " << correct[Ccol];
+    }
   }
 }
 

--- a/unit_test/sparse/Test_Sparse_spadd.hpp
+++ b/unit_test/sparse/Test_Sparse_spadd.hpp
@@ -13,10 +13,8 @@
 #include<cstdlib>     //for rand
 #include<type_traits> //for std::is_same
 
-#ifndef kokkos_complex_double
-#define kokkos_complex_double Kokkos::complex<double>
-#define kokkos_complex_float Kokkos::complex<float>
-#endif
+typedef Kokkos::complex<double> kokkos_complex_double;
+typedef Kokkos::complex<float> kokkos_complex_float;
 
 namespace Test {
 


### PR DESCRIPTION
Fix major bug/typo in BitonicSort2 where a key was compared with itself, so the swap was never happening.

Add Test_DEVICE_Common_Sorting.o to unit test executables in
Makefile-based build.

Improve test coverage in sorting tests that would have caught this, rather than relying on spadd tests to catch it indirectly. Fixed spadd tests to actually verify result indices are sorted.