### PR TITLE
Fix spgemm memory pool leaks, minor memory bugs

### DIFF
--- a/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
@@ -302,6 +302,7 @@ struct KokkosSPGEMM
       hm2.hash_begins[globally_used_hash_indices[i]] = -1;
     }
     });
+    memory_space.release_chunk(globally_used_hash_indices);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -388,6 +389,7 @@ struct KokkosSPGEMM
     //++used_size;
     }
     });
+    memory_space.release_chunk(globally_used_hash_indices);
   }
   KOKKOS_INLINE_FUNCTION
   void operator()(const FillTag&, const team_member_t & teamMember) const {

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
@@ -199,7 +199,7 @@ struct KokkosSPGEMM
         marker [ind] = 0;
       }
     });
-
+    memory_space.release_chunk(dense_accum);
   }
 
 };

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
@@ -364,7 +364,7 @@ struct KokkosSPGEMM
     }
     );
 
-    m_space.release_chunk(indices);
+    m_space.release_chunk(sets);
   }
   //this one will be LP on CPUs
   KOKKOS_INLINE_FUNCTION
@@ -620,7 +620,9 @@ struct KokkosSPGEMM
         m_space.release_chunk(globally_used_hash_indices);
       });
     }
-    rowmapC(row_index) = num_elements;
+    Kokkos::single(Kokkos::PerThread(teamMember),[&] () {
+      rowmapC(row_index) = num_elements;
+    });
   }
 
   ////
@@ -880,7 +882,7 @@ struct KokkosSPGEMM
     }
     );
 
-    m_space.release_chunk(indices);
+    m_space.release_chunk(sets);
   }
 
 
@@ -1296,8 +1298,11 @@ struct KokkosSPGEMM
       });
       num_elements += num_global_elements;
     }
-
-    rowmapC(row_index) = num_elements;
+    Kokkos::single(Kokkos::PerThread(teamMember),
+      [&]()
+      {
+        rowmapC(row_index) = num_elements;
+      });
   }
 
   size_t team_shmem_size (int /* team_size */) const {

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
@@ -297,7 +297,7 @@ struct KokkosSPGEMM
     }
     );
 
-    m_space.release_chunk(indices);
+    m_space.release_chunk(sets);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -389,7 +389,7 @@ struct KokkosSPGEMM
     }
     );
 
-    m_space.release_chunk(indices);
+    m_space.release_chunk(sets2);
   }
 
 
@@ -469,7 +469,7 @@ struct KokkosSPGEMM
     }
     );
 
-    m_space.release_chunk(indices);
+    m_space.release_chunk(sets);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -555,7 +555,7 @@ struct KokkosSPGEMM
     }
     );
 
-    m_space.release_chunk(indices);
+    m_space.release_chunk(sets);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -715,7 +715,7 @@ struct KokkosSPGEMM
     }
     );
 
-    m_space.release_chunk(indices);
+    m_space.release_chunk(sets);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -859,7 +859,7 @@ struct KokkosSPGEMM
     }
     );
 
-    m_space.release_chunk(indices);
+    m_space.release_chunk(sets);
   }
 
 


### PR DESCRIPTION
- For UniformMemoryPools, sure there is a release_chunk()
  corresponding to every allocate_chunk()
- Assign global values inside a single(PerThread), in a GPU kernel
  where vector_size > 1
- Pass back to release_chunk the same pointer returned by
  allocate_chunk - not strictly necessary but makes things clearer