### PR TITLE
Fix fallback gemm for complex scalar types

### DIFF
--- a/src/blas/impl/KokkosBlas3_gemm_impl.hpp
+++ b/src/blas/impl/KokkosBlas3_gemm_impl.hpp
@@ -273,7 +273,7 @@ struct impl_deep_copy_matrix_block<TeamHandle,ViewTypeScratch,ViewType,Kokkos::L
           const int idx_i = offset_i+i;
 #endif
           const int idx_j = offset_j+j;
-          A_scr(i,j) = A(idx_j,idx_i);
+          A_scr(i,j) = ATV::conj(A(idx_j,idx_i)); 
         });
       });
     } else {

--- a/unit_test/blas/Test_Blas3_gemm.hpp
+++ b/unit_test/blas/Test_Blas3_gemm.hpp
@@ -106,24 +106,12 @@ namespace Test {
     Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(seed);
 
     // (SA 11 Dec 2019) Max (previously: 10) increased to detect the bug in Trilinos issue #6418 
-    // Revisit this to address issues with complex types
-/*
-#ifdef KOKKOS_ENABLE_CUDABBBBBBBBB
-    if (std::is_same<execution_space,Kokkos::Cuda>::value) 
-    {
-      std::cout << "Cuda exec space" << std::endl;
-      Kokkos::fill_random(A,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarA>::max());
-      Kokkos::fill_random(B,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarB>::max());
-      Kokkos::fill_random(C,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarC>::max());
-    }
-    else
-#endif
-*/
-    {
-      Kokkos::fill_random(A,rand_pool,ScalarA(10));
-      Kokkos::fill_random(B,rand_pool,ScalarB(10));
-      Kokkos::fill_random(C,rand_pool,ScalarC(10));
-    }
+    Kokkos::fill_random(A,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarA>::max());
+    Kokkos::fill_random(B,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarB>::max());
+    Kokkos::fill_random(C,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarC>::max());
+    // Kokkos::fill_random(A,rand_pool,ScalarA(10));
+    // Kokkos::fill_random(B,rand_pool,ScalarB(10));
+    // Kokkos::fill_random(C,rand_pool,ScalarC(10));
     
     Kokkos::deep_copy(C2,C);
 


### PR DESCRIPTION
**Description:**
This PR fixes the fallback gemm resulting in large diffs with complex scalar type when input random matrices have reasonably large values.

This defect was exposed when the upper bound of the random number generator (for A, B, and C matrices) in KokkosKernels gemm unit test was increased from `10` to `Kokkos::Random_XorShift64_Pool<...>::max()`. This PR includes this change too.

**Testing:**
`[sacer@white29 testing]$ ../scripts/test_all_sandia --spot-check --arch=Power8,Pascal60`
```
Running on machine: white
Going to test compilers:  gcc/6.4.0 gcc/7.2.0 gcc/7.4.0 ibm/16.1.0 cuda/9.2.88 cuda/10.0.130
Testing compiler gcc/6.4.0
Testing compiler gcc/7.2.0
  Starting job gcc-6.4.0-OpenMP_Serial-release
  Starting job gcc-7.2.0-OpenMP-release
  PASSED gcc-7.2.0-OpenMP-release
  Starting job gcc-7.2.0-Serial-release
  PASSED gcc-6.4.0-OpenMP_Serial-release
Testing compiler gcc/7.4.0
  Starting job gcc-7.2.0-OpenMP_Serial-release
  PASSED gcc-7.2.0-Serial-release
Testing compiler ibm/16.1.0
  Starting job gcc-7.4.0-OpenMP-release
  PASSED gcc-7.4.0-OpenMP-release
Testing compiler cuda/9.2.88
  Starting job ibm-16.1.0-Serial-release
  PASSED gcc-7.2.0-OpenMP_Serial-release
  PASSED ibm-16.1.0-Serial-release
Testing compiler cuda/10.0.130
  Starting job cuda-9.2.88-Cuda_OpenMP-release
  PASSED cuda-9.2.88-Cuda_OpenMP-release
  Starting job cuda-10.0.130-Cuda_Serial-release
  PASSED cuda-10.0.130-Cuda_Serial-release
#######################################################
PASSED TESTS
#######################################################
cuda-10.0.130-Cuda_Serial-release build_time=1203 run_time=1057
cuda-9.2.88-Cuda_OpenMP-release build_time=1269 run_time=685
gcc-6.4.0-OpenMP_Serial-release build_time=587 run_time=1048
gcc-7.2.0-OpenMP-release build_time=444 run_time=299
gcc-7.2.0-OpenMP_Serial-release build_time=605 run_time=1359
gcc-7.2.0-Serial-release build_time=276 run_time=638
gcc-7.4.0-OpenMP-release build_time=385 run_time=300
ibm-16.1.0-Serial-release build_time=1439 run_time=968
#######################################################
FAILED TESTS
#######################################################

```