### PR TITLE
Fix radix test failure involving integer sign

### DIFF
--- a/src/sparse/KokkosSparse_spadd.hpp
+++ b/src/sparse/KokkosSparse_spadd.hpp
@@ -202,8 +202,11 @@ namespace Experimental {
       size_type rowStart = Crowptrs(i);
       size_type rowEnd = Crowptrs(i + 1);
       size_type rowNum = rowEnd - rowStart;
-      KokkosKernels::Impl::SerialRadixSort2<size_type, typename CcolindsT::non_const_value_type, typename CcolindsT::non_const_value_type>
-        (Ccolinds.data() + rowStart, CcolindsAux.data() + rowStart, ABperm.data() + rowStart, ABpermAux.data() + rowStart, rowNum);
+      using lno_t = typename CcolindsT::non_const_value_type;
+      using unsigned_lno_t = typename std::make_unsigned<lno_t>::type;
+      KokkosKernels::Impl::SerialRadixSort2<size_type, unsigned_lno_t, lno_t>
+        ((unsigned_lno_t*) Ccolinds.data() + rowStart, (unsigned_lno_t*) CcolindsAux.data() + rowStart,
+         ABperm.data() + rowStart, ABpermAux.data() + rowStart, rowNum);
     }
     CrowptrsT Crowptrs;
     CcolindsT Ccolinds;


### PR DESCRIPTION
Now, the serial radix sorts enforce at compile time that the key is an unsigned integer.
This was really the assumption all along (that values were always
nonnegative). No longer adding a bias to the keys while sorting, since all the keys are at least 0.

This was causing the char radix sort unit test to fail in an OpenMP debug configuration - I think because of undefined overflow behavior when the chars were normalized from range (min, max) to range (0, max-min). This PR sorts only nonnegative chars and reinterprets as ``unsigned char``, which is safe.