### PR TITLE
Fix #574 (improve KokkosBlas::dot accuracy for float & complex<float>)

### DIFF
--- a/src/blas/impl/KokkosBlas1_dot_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_dot_impl.hpp
@@ -81,7 +81,7 @@ struct DotFunctor
   KOKKOS_FORCEINLINE_FUNCTION void
   operator() (const size_type &i, value_type& sum) const
   {
-    sum += IPT::dot (m_x(i), m_y(i));  // m_x(i) * m_y(i)
+    Kokkos::Details::updateDot(sum, m_x(i), m_y(i)); // sum += m_x(i) * m_y(i)
   }
 
   KOKKOS_INLINE_FUNCTION void


### PR DESCRIPTION
For vectors of `float`, the two-argument overload of `KokkosBlas::dot` (that takes two vectors (rank-1 Views) as input, and returns the dot product result as a scalar value on host) gets inaccurate results on Mac Clang.  This commit fixes that overload of `KokkosBlas::dot` so that if the dot product result type is `float` resp. `complex<float>`, the function uses `double` resp. `complex<double>` as the type for intermediate sums.

This change, when applied to Trilinos in Pull Request https://github.com/trilinos/Trilinos/pull/6634, fixes Trilinos issue https://github.com/trilinos/Trilinos/issues/6633.

Closes #574 