### PR TITLE
Balanced coloring

### DIFF
--- a/src/common/KokkosKernels_SparseUtils.hpp
+++ b/src/common/KokkosKernels_SparseUtils.hpp
@@ -765,7 +765,6 @@ struct ColorChecker{
     size_t nf = 0;
     Kokkos::parallel_reduce(Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end), [&] (const lno_t& row_index, size_t &team_num_conf)
     {
-
       color_t my_color = color_view(row_index);
       const size_type col_begin = xadj[row_index];
       const size_type col_end = xadj[row_index + 1];
@@ -823,7 +822,7 @@ inline size_t kk_is_d1_coloring_valid(
 
   struct ColorChecker <in_row_view_t, in_nnz_view_t, in_color_view_t, team_member_t>  cc(num_rows, xadj, adj, v_colors, team_work_chunk_size);
   size_t num_conf = 0;
-  Kokkos::parallel_reduce( "KokkosKernels::Common::IsD1ColoringValie", dynamic_team_policy(num_rows / team_work_chunk_size + 1 ,
+  Kokkos::parallel_reduce( "KokkosKernels::Common::IsD1ColoringValid", dynamic_team_policy((num_rows + team_work_chunk_size - 1) / team_work_chunk_size,
       suggested_team_size, vector_size), cc, num_conf);
 
   MyExecSpace().fence();

--- a/src/graph/KokkosGraph_Distance1Color.hpp
+++ b/src/graph/KokkosGraph_Distance1Color.hpp
@@ -80,6 +80,9 @@ void graph_color_symbolic(
   typedef typename Impl::GraphColor
       <typename KernelHandle::GraphColoringHandleType, lno_row_view_t_, lno_nnz_view_t_> BaseGraphColoring;
   BaseGraphColoring *gc = NULL;
+  typedef typename Impl::GraphColor_VB <typename KernelHandle::GraphColoringHandleType, lno_row_view_t_, lno_nnz_view_t_> VBGraphColoring;
+  typedef typename Impl::GraphColor_VBD <typename KernelHandle::GraphColoringHandleType, lno_row_view_t_, lno_nnz_view_t_> VBDGraphColoring;
+  typedef typename Impl::GraphColor_EB <typename KernelHandle::GraphColoringHandleType, lno_row_view_t_, lno_nnz_view_t_> EBGraphColoring;
 
   switch (algorithm){
   case COLORING_SERIAL:
@@ -87,20 +90,18 @@ void graph_color_symbolic(
     break;
 
   case COLORING_VB:
+  case COLORING_BALANCED:
   case COLORING_VBBIT:
   case COLORING_VBCS:
-    typedef typename Impl::GraphColor_VB <typename KernelHandle::GraphColoringHandleType, lno_row_view_t_, lno_nnz_view_t_> VBGraphColoring;
     gc = new VBGraphColoring(num_rows, entries.extent(0), row_map, entries, gch);
     break;
 
   case COLORING_VBD:
   case COLORING_VBDBIT:
-    typedef typename Impl::GraphColor_VBD <typename KernelHandle::GraphColoringHandleType, lno_row_view_t_, lno_nnz_view_t_> VBDGraphColoring;
     gc = new VBDGraphColoring(num_rows, entries.extent(0), row_map, entries, gch);
     break;
 
   case COLORING_EB:
-    typedef typename Impl::GraphColor_EB <typename KernelHandle::GraphColoringHandleType, lno_row_view_t_, lno_nnz_view_t_> EBGraphColoring;
     gc = new EBGraphColoring(num_rows, entries.extent(0),row_map, entries, gch);
     break;
 

--- a/src/graph/KokkosGraph_Distance1ColorHandle.hpp
+++ b/src/graph/KokkosGraph_Distance1ColorHandle.hpp
@@ -62,6 +62,7 @@ enum ColoringAlgorithm { COLORING_DEFAULT,
                          COLORING_VBDBIT,                     // Vertex Based Deterministic Coloring with bit array
                          COLORING_EB,                         // Edge Based Coloring
                          COLORING_SERIAL2,                    // Serial Distance-2 Graph Coloring (kept here for backwards compatibility for SPGEMM and other use cases)
+                         COLORING_BALANCED
                        };
 
 enum ConflictList{COLORING_NOCONFLICT, COLORING_ATOMIC, COLORING_PPS};
@@ -620,6 +621,7 @@ private:
     case COLORING_VBD:
     case COLORING_VBDBIT:
     case COLORING_SERIAL:
+    case COLORING_BALANCED:
       this->conflict_list_type = COLORING_ATOMIC;
       this->min_reduction_for_conflictlist = 0.35;
       this->min_elements_for_conflictlist = 1000;

--- a/src/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
@@ -899,7 +899,7 @@ namespace KokkosSparse{
 #else
         //Create a handle that uses nnz_lno_t as the size_type, since the cluster graph should never be larger than 2^31 entries.
         KokkosKernels::Experimental::KokkosKernelsHandle<nnz_lno_t, nnz_lno_t, double, MyExecSpace, MyPersistentMemorySpace, MyPersistentMemorySpace> kh;
-        kh.create_graph_coloring_handle(KokkosGraph::COLORING_DEFAULT);
+        kh.create_graph_coloring_handle(KokkosGraph::COLORING_BALANCED);
         KokkosGraph::Experimental::graph_color_symbolic(&kh, numClusters, numClusters, clusterRowmap, clusterEntries);
         //retrieve colors
         auto coloringHandle = kh.get_graph_coloring_handle();

--- a/unit_test/graph/Test_Graph_graph_color.hpp
+++ b/unit_test/graph/Test_Graph_graph_color.hpp
@@ -78,7 +78,6 @@ int run_graphcolor(
   using KernelHandle = KokkosKernelsHandle
       <size_type,lno_t, scalar_t,
       exec_space, typename device::memory_space,typename device::memory_space >;
-  using color_view_t = typename KernelHandle::GraphColoringHandleType::color_view_t;
 
 
   KernelHandle kh;


### PR DESCRIPTION
(Enhancement request #495)

Added new distance-1 coloring algorithm COLORING_BALANCED. This algorithm starts with VB_BIT, and then recolors vertices to less common colors. During this last phase no conflicts are created and the number of colors doesn't change.

Example color histograms from some graphs, all run on GPU (balance is much better on openmp):
```
af_shell7:
VB_BIT (0.0472827 s):
22758 22881 22925 22895 23002 22879 22935 22811 22935 22889 22938 23158 23198 23076 22819 22592 22258 21875 21308 20384 18784 15814 10872 5211 1421 218 19

BALANCED (0.065916 s):
18660 18701 18807 18831 18699 18757 18801 18851 18714 18792 18708 18700 18876 18733 18736 18715 18790 18757 18731 18654 18602 18563 18376 18476 18554 18625 18646
```
```
Sample MomentumEQS from ExaWind:
VB_BIT (0.0252704 s):
994082 928685 537787 311998 196042 63749 51604 47366 40679 20515 11942 6410 2649 711 130 17
BALANCED (0.0478676 s):
191427 190428 190636 189190 188602 188716 188597 188624 188632 188658 188637 188629 188645 188677 188763 188755 188750
```

I use VBBIT as the initial coloring on all execution spaces, but any coloring could be used. In most experiments on CUDA, VBBIT+balancing was faster than EB by itself. In the future it might make sense to use a heuristic based on average degree or degree variance, but for now VBBIT works.

COLORING_BALANCED is now used for coloring in MTSGS and Cluster Gauss-Seidel, since parallelism is proportional to color set size. The number of kernel launches in apply is the same as it was, but now every color set has lots of parallelism, rather than just the first half or so.

RIDE:
#######################################################
PASSED TESTS
#######################################################
cuda-9.2.88-Cuda_OpenMP-release build_time=592 run_time=419
cuda-9.2.88-Cuda_Serial-release build_time=580 run_time=530
gcc-6.4.0-OpenMP_Serial-release build_time=184 run_time=397
gcc-7.2.0-OpenMP-release build_time=132 run_time=124
gcc-7.2.0-OpenMP_Serial-release build_time=209 run_time=356
gcc-7.2.0-Serial-release build_time=119 run_time=227

Bowman:
#######################################################
PASSED TESTS
#######################################################
intel-16.4.258-Pthread-release build_time=720 run_time=1025
intel-16.4.258-Pthread_Serial-release build_time=1055 run_time=2029
intel-16.4.258-Serial-release build_time=699 run_time=945
intel-17.2.174-OpenMP-release build_time=877 run_time=563
intel-17.2.174-OpenMP_Serial-release build_time=1286 run_time=1462
intel-17.2.174-Pthread-release build_time=812 run_time=894
intel-17.2.174-Pthread_Serial-release build_time=1131 run_time=1806
intel-17.2.174-Serial-release build_time=785 run_time=870