### PR TITLE
Update cm_test_all_sandia on white/ride (#576)

### DIFF
--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -393,8 +393,9 @@ elif [ "$MACHINE" = "white" ]; then
     # Format: (compiler module-list build-list exe-name warning-flag)
     COMPILERS=("gcc/6.4.0 $BASE_MODULE_LIST "OpenMP_Serial" g++ $GCC_WARNING_FLAGS"
                "gcc/7.2.0 $BASE_MODULE_LIST $IBM_BUILD_LIST g++ $GCC_WARNING_FLAGS"
-               "ibm/16.1.0 $IBM_MODULE_LIST $IBM_BUILD_LIST xlC $IBM_WARNING_FLAGS"
+               "ibm/16.1.0 $IBM_MODULE_LIST "Serial" xlC $IBM_WARNING_FLAGS"
                "cuda/9.2.88 $CUDA_MODULE_LIST $CUDA_IBM_BUILD_LIST ${KOKKOS_PATH}/bin/nvcc_wrapper $CUDA_WARNING_FLAGS"
+               "cuda/10.1.105 $CUDA_MODULE_LIST $CUDA_IBM_BUILD_LIST ${KOKKOS_PATH}/bin/nvcc_wrapper $CUDA_WARNING_FLAGS"
     )
   else
     # Format: (compiler module-list build-list exe-name warning-flag)
@@ -404,6 +405,7 @@ elif [ "$MACHINE" = "white" ]; then
                "ibm/16.1.1 $IBM_MODULE_LIST $IBM_BUILD_LIST xlC $IBM_WARNING_FLAGS"
                "cuda/9.2.88 $CUDA_MODULE_LIST $CUDA_IBM_BUILD_LIST ${KOKKOS_PATH}/bin/nvcc_wrapper $CUDA_WARNING_FLAGS"
                "cuda/10.0.130 $CUDA10_MODULE_LIST $CUDA_IBM_BUILD_LIST ${KOKKOS_PATH}/bin/nvcc_wrapper $CUDA_WARNING_FLAGS"
+               "cuda/10.1.105 $CUDA_MODULE_LIST $CUDA_IBM_BUILD_LIST ${KOKKOS_PATH}/bin/nvcc_wrapper $CUDA_WARNING_FLAGS"
     )
   fi
 


### PR DESCRIPTION
Requested in #576 

- Spot check only does "Serial" on IBM as OpenMP takes way too long (about 30x longer than a CUDA build)
- Add CUDA 10.1.105 as a build in both spot-check and full-check
  - CUDA 10.1 has CUDA graph support which we'll be using soon
  - CUDA 9.2 and 10.1 now done in spot check
  - CUDA 9.2, 10.0 and 10.1 now done in full check
  - All IBM builds (Serial, Serial_OpenMP, and OpenMP) on two compiler versions are still done in full checks

I thought I should test this on both RIDE and white since their software environments aren't exactly identical (for example, RIDE has CUDA 10.1.105 and 10.1.243, while white only has 10.1.105.

Bowman spot check, just to make sure testing on other machines didn't change:
```
#######################################################
PASSED TESTS
#######################################################
intel-16.4.258-Pthread-release build_time=513 run_time=376
intel-16.4.258-Pthread_Serial-release build_time=662 run_time=809
intel-16.4.258-Serial-release build_time=487 run_time=373
intel-17.2.174-OpenMP-release build_time=590 run_time=214
intel-17.2.174-OpenMP_Serial-release build_time=741 run_time=567
intel-17.2.174-Pthread-release build_time=520 run_time=346
intel-17.2.174-Pthread_Serial-release build_time=705 run_time=725
intel-17.2.174-Serial-release build_time=522 run_time=345
```

White, full check:
```
#######################################################
PASSED TESTS
#######################################################
cuda-10.0.130-Cuda_OpenMP-release build_time=311 run_time=258
cuda-10.0.130-Cuda_Serial-release build_time=327 run_time=306
cuda-10.1.105-Cuda_OpenMP-release build_time=272 run_time=255
cuda-10.1.105-Cuda_Serial-release build_time=294 run_time=303
cuda-9.2.88-Cuda_OpenMP-release build_time=299 run_time=258
cuda-9.2.88-Cuda_Serial-release build_time=300 run_time=307
gcc-6.4.0-OpenMP-release build_time=85 run_time=59
gcc-6.4.0-OpenMP_Serial-release build_time=119 run_time=167
gcc-6.4.0-Serial-release build_time=78 run_time=103
gcc-7.2.0-OpenMP-release build_time=83 run_time=58
gcc-7.2.0-OpenMP_Serial-release build_time=124 run_time=164
gcc-7.2.0-Serial-release build_time=79 run_time=102
ibm-16.1.0-OpenMP-release build_time=9249 run_time=52
ibm-16.1.0-OpenMP_Serial-release build_time=9355 run_time=164
ibm-16.1.0-Serial-release build_time=369 run_time=114
ibm-16.1.1-OpenMP-release build_time=10019 run_time=52
ibm-16.1.1-OpenMP_Serial-release build_time=10140 run_time=161
ibm-16.1.1-Serial-release build_time=371 run_time=114
```

White, spot check:
```
#######################################################
PASSED TESTS
#######################################################
cuda-10.1.105-Cuda_OpenMP-release build_time=284 run_time=256
cuda-10.1.105-Cuda_Serial-release build_time=290 run_time=303
cuda-9.2.88-Cuda_OpenMP-release build_time=320 run_time=258
cuda-9.2.88-Cuda_Serial-release build_time=311 run_time=308
gcc-6.4.0-OpenMP_Serial-release build_time=119 run_time=166
gcc-7.2.0-OpenMP-release build_time=84 run_time=57
gcc-7.2.0-OpenMP_Serial-release build_time=128 run_time=164
gcc-7.2.0-Serial-release build_time=79 run_time=103
ibm-16.1.0-Serial-release build_time=379 run_time=114
```

RIDE, full check:
```
#######################################################
PASSED TESTS
#######################################################
cuda-10.0.130-Cuda_OpenMP-release build_time=321 run_time=202
cuda-10.0.130-Cuda_Serial-release build_time=334 run_time=249
cuda-10.1.105-Cuda_OpenMP-release build_time=334 run_time=198
cuda-10.1.105-Cuda_Serial-release build_time=317 run_time=247
cuda-9.2.88-Cuda_OpenMP-release build_time=347 run_time=202
cuda-9.2.88-Cuda_Serial-release build_time=320 run_time=250
gcc-6.4.0-OpenMP-release build_time=82 run_time=57
gcc-6.4.0-OpenMP_Serial-release build_time=131 run_time=164
gcc-6.4.0-Serial-release build_time=78 run_time=103
gcc-7.2.0-OpenMP-release build_time=86 run_time=56
gcc-7.2.0-OpenMP_Serial-release build_time=128 run_time=162
gcc-7.2.0-Serial-release build_time=79 run_time=103
ibm-16.1.0-OpenMP-release build_time=9274 run_time=53
ibm-16.1.0-OpenMP_Serial-release build_time=9397 run_time=164
ibm-16.1.0-Serial-release build_time=376 run_time=115
ibm-16.1.1-OpenMP-release build_time=10030 run_time=52
ibm-16.1.1-OpenMP_Serial-release build_time=10159 run_time=160
ibm-16.1.1-Serial-release build_time=387 run_time=114
```

RIDE, spot check:
```
#######################################################
PASSED TESTS
#######################################################
cuda-10.1.105-Cuda_OpenMP-release build_time=328 run_time=196
cuda-10.1.105-Cuda_Serial-release build_time=318 run_time=243
cuda-9.2.88-Cuda_OpenMP-release build_time=275 run_time=200
cuda-9.2.88-Cuda_Serial-release build_time=287 run_time=248
gcc-6.4.0-OpenMP_Serial-release build_time=128 run_time=164
gcc-7.2.0-OpenMP-release build_time=81 run_time=56
gcc-7.2.0-OpenMP_Serial-release build_time=115 run_time=162
gcc-7.2.0-Serial-release build_time=78 run_time=103
ibm-16.1.0-Serial-release build_time=383 run_time=113
```