### PR TITLE
CUDA graph wrapper, using in Gauss-Seidel apply

### DIFF
--- a/src/common/KokkosKernels_ExecSpaceUtils.hpp
+++ b/src/common/KokkosKernels_ExecSpaceUtils.hpp
@@ -222,7 +222,7 @@ struct CudaGraphWrapper
   bool recording = false;
 };
 
-#if defined(KOKKOS_ENABLE_CUDA) && 10000 <= CUDA_VERSION
+#if defined(KOKKOS_ENABLE_CUDA) && 10010 <= CUDA_VERSION
 #define HAVE_CUDAGRAPHS
 
 //Dummy parallel call that makes compiler generate some declarations/initializations

--- a/src/common/KokkosKernels_ExecSpaceUtils.hpp
+++ b/src/common/KokkosKernels_ExecSpaceUtils.hpp
@@ -43,6 +43,7 @@
 
 #include "Kokkos_Core.hpp"
 #include "Kokkos_Atomic.hpp"
+#include "Kokkos_Concepts.hpp"
 
 #ifndef _KOKKOSKERNELSUTILSEXECSPACEUTILS_HPP
 #define _KOKKOSKERNELSUTILSEXECSPACEUTILS_HPP
@@ -136,7 +137,271 @@ inline int kk_get_suggested_team_size(const int vector_size, const ExecSpaceType
   }
 }
 
+/*
+ * CUDA 10.1 graph support. Currently, only supports a linear sequence of kernels.
+ * The first definition below is actually a fake wrapper with an identical interface,
+ * so that user code for launching kernels only needs to be written once.
+ *
+ * The second definition is used if the CUDA version supports graphs and the ExecSpace is Cuda.
+ *
+ * TODO: provide full CUDA graph support, with arbitrary dependencies involing multiple streams, kernels and memcpys.
+*/
+
+template<typename ExecSpace, typename LaunchParams>
+struct CudaGraphWrapper
+{
+  //No actual members, so nothing to construct
+  CudaGraphWrapper() {}
+
+  //Not allowing copy-ctor because the actual
+  //CUDA graph specialization below can't support it
+  CudaGraphWrapper(const CudaGraphWrapper&) = delete;
+
+  //Overload that constructs the params
+  template<class... Args>
+  bool begin_recording(Args&&... args)
+  {
+    return begin_recording_impl(LaunchParams(std::forward<Args>(args)...));
+  }
+
+  bool begin_recording_impl(const LaunchParams&)
+  {
+    //The fake wrapper always re-records, since recording here actually launches the kernels.
+    //Even though it's not strictly necessary, keep track of "recording" to catch
+    //some simple errors without needing to test with CUDA 10.1.
+    if(recording)
+      throw std::runtime_error("CudaGraphWrapper: already recording; can't call begin_recording() again");
+    recording = true;
+    return true;
+  }
+
+  void end_recording()
+  {
+    if(!recording)
+      throw std::runtime_error("CudaGraphWrapper: not currently recording, so can't call end_recording()");
+    recording = false;
+  }
+
+  template<typename Tag = void>
+  Kokkos::TeamPolicy<ExecSpace, Tag> team_policy(size_t num_teams, size_t team_size)
+  {
+    if(!recording)
+      throw std::runtime_error("CudaGraphWrapper: Can't create TeamPolicy because begin_recording() has not been called");
+    return Kokkos::TeamPolicy<ExecSpace, Tag>(num_teams, team_size);
+  }
+
+  template<typename Tag = void>
+  Kokkos::TeamPolicy<ExecSpace, Tag> team_policy(size_t num_teams, size_t team_size, size_t vector_size)
+  {
+    if(!recording)
+      throw std::runtime_error("CudaGraphWrapper: Can't create TeamPolicy because begin_recording() has not been called");
+    return Kokkos::TeamPolicy<ExecSpace, Tag>(num_teams, team_size, vector_size);
+  }
+
+  template<typename Tag = void>
+  Kokkos::TeamPolicy<ExecSpace, Tag> team_policy(size_t num_teams, size_t team_size, size_t vector_size, size_t sharedPerTeam, size_t sharedPerThread)
+  {
+    if(!recording)
+      throw std::runtime_error("CudaGraphWrapper: Can't create TeamPolicy because begin_recording() has not been called");
+    return Kokkos::TeamPolicy<ExecSpace, Tag>(num_teams, team_size).set_scratch_size(0, Kokkos::PerTeam(sharedPerTeam), Kokkos::PerThread(sharedPerThread));
+  }
+
+  template<typename Tag = void>
+  Kokkos::RangePolicy<ExecSpace, Tag> range_policy(size_t begin, size_t end)
+  {
+    if(!recording)
+      throw std::runtime_error("CudaGraphWrapper: Can't create RangePolicy because begin_recording() has not been called");
+    return Kokkos::RangePolicy<ExecSpace, Tag>(begin, end);
+  }
+
+  void launch() {
+    // The kernels were executed during recording, but fence now
+    ExecSpace().fence();
+  }
+
+  bool recording = false;
+};
+
+#if defined(KOKKOS_ENABLE_CUDA) && 10000 < CUDA_VERSION
+#define HAVE_CUDAGRAPHS
+
+//Dummy parallel call that makes compiler generate some declarations/initializations
+//necessary for CUDA graph stream capture to work (see Kokkos issue #2606)
+namespace Dummy
+{
+  struct F
+  {
+    KOKKOS_INLINE_FUNCTION void operator()(const int) const {}
+  };
+  inline void f()
+  {
+    Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::Cuda>(0,1), F());
+  }
+}
+
+//Specialize the wrapper for Cuda, to actually use the graph features.
+template<typename LaunchParams>
+struct CudaGraphWrapper<Kokkos::Cuda, LaunchParams>
+{
+  //The class assumes these are 
+  cudaGraph_t graph;
+  cudaGraphExec_t instance;
+  cudaStream_t stream;
+  Kokkos::Cuda kokkosStream;
+
+  using P_t = typename Kokkos::Experimental::WorkItemProperty::HintLightWeight_t;
+  static constexpr P_t P = Kokkos::Experimental::WorkItemProperty::HintLightWeight;
+  
+  using WrappedTeamPolicy =
+    typename Kokkos::Experimental::Impl::PolicyPropertyAdaptor<
+    P_t, Kokkos::TeamPolicy<Kokkos::Cuda>>::policy_out_t;
+  using WrappedRangePolicy =
+    typename Kokkos::Experimental::Impl::PolicyPropertyAdaptor<
+    P_t, Kokkos::RangePolicy<Kokkos::Cuda>>::policy_out_t;
+
+  #define CUDA_CALL(x) \
+  { \
+    cudaError_t err = x; \
+    if(err != cudaSuccess) \
+    { \
+      std::cout << "CUDA call at " << __FILE__ << ':' << __LINE__ << \
+      " encountered error:\n" << cudaGetErrorString(err) << '\n'; \
+      throw std::runtime_error("CUDA call failed"); \
+    } \
+  }
+
+  CudaGraphWrapper()
+  {
+    CUDA_CALL(cudaStreamCreate(&stream));
+    kokkosStream = Kokkos::Cuda(stream);
+    graphReady = false;
+    recording = false;
+  }
+
+  //Don't want to be able to copy this wrapper, because then ownership of the stream gets tricky.
+  //Just have one owner and pass around a pointer.
+  CudaGraphWrapper(const CudaGraphWrapper&) = delete;
+
+  ~CudaGraphWrapper()
+  {
+    //destructors are noexcept, so we have to catch any exceptions from CUDA calls
+    if(graphReady)
+    {
+      try
+      {
+        CUDA_CALL(cudaGraphExecDestroy(instance));
+        CUDA_CALL(cudaGraphDestroy(graph));
+      }
+      catch(...)
+      {
+        std::cout << "Encountered error while destroying CUDA graph.\n";
+        return;
+      }
+    }
+    try
+    {
+      CUDA_CALL(cudaStreamDestroy(stream));
+    }
+    catch(...)
+    {
+      std::cout << "Encountered error while destroying CUDA stream.\n";
+      return;
+    }
+  }
+
+  //Overload that constructs the params
+  template<class... Args>
+  bool begin_recording(Args&&... args)
+  {
+    return begin_recording_impl(LaunchParams(std::forward<Args>(args)...));
+  }
+
+  bool begin_recording_impl(const LaunchParams& params)
+  {
+    if(graphReady && params == currentParams)
+      return false;
+    //Otherwise, need to re-record (or record for the first time)
+    currentParams = params;
+    graphReady = false;
+    recording = true;
+    kokkosStream.fence();
+    CUDA_CALL(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal));
+    return true;
+  }
+
+  void end_recording()
+  {
+    //Make sure no errors happened during the kernel launches
+    CUDA_CALL(cudaGetLastError());
+    CUDA_CALL(cudaStreamEndCapture(stream, &graph));
+    CUDA_CALL(cudaGraphInstantiate(&instance, graph, NULL, NULL, 0));
+    graphReady = true;
+    recording = false;
+  }
+
+  template<typename Tag = void>
+  typename Kokkos::Experimental::Impl::PolicyPropertyAdaptor<
+  P_t, Kokkos::TeamPolicy<Kokkos::Cuda, Tag>>::policy_out_t
+  team_policy(size_t num_teams, size_t team_size)
+  {
+    if(!recording)
+      throw std::runtime_error("CudaGraphWrapper: Can't create TeamPolicy because begin_recording() has not been called");
+    return Kokkos::Experimental::require(Kokkos::TeamPolicy<Kokkos::Cuda, Tag>(kokkosStream, num_teams, team_size), P);
+  }
+
+  template<typename Tag = void>
+  typename Kokkos::Experimental::Impl::PolicyPropertyAdaptor<
+  P_t, Kokkos::TeamPolicy<Kokkos::Cuda, Tag>>::policy_out_t
+  team_policy(size_t num_teams, size_t team_size, size_t vector_size)
+  {
+    if(!recording)
+      throw std::runtime_error("CudaGraphWrapper: Can't create TeamPolicy because begin_recording() has not been called");
+    return Kokkos::Experimental::require(Kokkos::TeamPolicy<Kokkos::Cuda, Tag>(kokkosStream, num_teams, team_size, vector_size), P);
+  }
+
+  template<typename Tag = void>
+  typename Kokkos::Experimental::Impl::PolicyPropertyAdaptor<
+  P_t, Kokkos::TeamPolicy<Kokkos::Cuda, Tag>>::policy_out_t
+  team_policy(size_t num_teams, size_t team_size, size_t vector_size, size_t sharedPerTeam, size_t sharedPerThread)
+  {
+    if(!recording)
+      throw std::runtime_error("CudaGraphWrapper: Can't create TeamPolicy because begin_recording() has not been called");
+    return Kokkos::Experimental::require(Kokkos::TeamPolicy<Kokkos::Cuda, Tag>(kokkosStream, num_teams, team_size, vector_size).set_scratch_size(0, Kokkos::PerTeam(sharedPerTeam), Kokkos::PerThread(sharedPerThread)), P);
+  }
+
+  template<typename Tag = void>
+  typename Kokkos::Experimental::Impl::PolicyPropertyAdaptor<
+  P_t, Kokkos::RangePolicy<Kokkos::Cuda, Tag>>::policy_out_t
+  range_policy(size_t begin, size_t end)
+  {
+    if(!recording)
+      throw std::runtime_error("CudaGraphWrapper: Can't create RangePolicy because begin_recording() has not been called");
+    return Kokkos::Experimental::require(Kokkos::RangePolicy<Kokkos::Cuda, Tag>(kokkosStream, begin, end), P);
+  }
+
+  //Actually execute all the kernels in the graph
+  void launch()
+  {
+    if(recording)
+      throw std::runtime_error("Can't launch CUDA graph while recording kernel launches - call end_recording() first");
+    else if(!graphReady)
+      throw std::runtime_error("Can't launch CUDA graph: kernels have not been recorded yet.");
+    kokkosStream.fence();
+    CUDA_CALL(cudaGraphLaunch(instance, stream));
+    CUDA_CALL(cudaStreamSynchronize(stream));
+  }
+
+  bool recording;
+  bool graphReady;
+  LaunchParams currentParams;
+
+  #undef CUDA_CALL
+};
+
+#endif  //HAVE_CUDAGRAPHS
+
 }
 }
 
 #endif
+

--- a/src/common/KokkosKernels_ExecSpaceUtils.hpp
+++ b/src/common/KokkosKernels_ExecSpaceUtils.hpp
@@ -222,7 +222,7 @@ struct CudaGraphWrapper
   bool recording = false;
 };
 
-#if defined(KOKKOS_ENABLE_CUDA) && 10000 < CUDA_VERSION
+#if defined(KOKKOS_ENABLE_CUDA) && 10000 <= CUDA_VERSION
 #define HAVE_CUDAGRAPHS
 
 //Dummy parallel call that makes compiler generate some declarations/initializations

--- a/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
+++ b/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
@@ -649,32 +649,11 @@ namespace KokkosSparse{
     
     bool use_teams() const
     {
-#if defined( KOKKOS_ENABLE_SERIAL )
-      if (Kokkos::Impl::is_same< Kokkos::Serial , ExecutionSpace >::value) {
-        return false;
-      }
-#endif
-#if defined( KOKKOS_ENABLE_THREADS )
-      if (Kokkos::Impl::is_same< Kokkos::Threads , ExecutionSpace >::value){
-        return false;
-      }
-#endif
-#if defined( KOKKOS_ENABLE_OPENMP )
-      if (Kokkos::Impl::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
-        return false;
-      }
-#endif
 #if defined( KOKKOS_ENABLE_CUDA )
-      if (Kokkos::Impl::is_same<Kokkos::Cuda, ExecutionSpace >::value){
-        return true;
-      }
-#endif
-#if defined( KOKKOS_ENABLE_QTHREAD)
-      if (Kokkos::Impl::is_same< Kokkos::Qthread, ExecutionSpace >::value){
-        return false;
-      }
-#endif
+      return Kokkos::Impl::is_same<Kokkos::Cuda, ExecutionSpace >::value;
+#else
       return false;
+#endif
     }
 
     ~ClusterGaussSeidelHandle() = default;

--- a/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
+++ b/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
@@ -44,6 +44,7 @@
 #include <Kokkos_MemoryTraits.hpp>
 #include <Kokkos_Core.hpp>
 #include <KokkosKernels_Utils.hpp>
+#include <KokkosKernels_ExecSpaceUtils.hpp>
 #ifndef _GAUSSSEIDELHANDLE_HPP
 #define _GAUSSSEIDELHANDLE_HPP
 //#define VERBOSE
@@ -69,6 +70,72 @@ namespace KokkosSparse{
     }
     return "INVALID CLUSTERING ALGORITHM";
   }
+
+  //To re-use a CudaGraph between apply() calls, must be able to compare the X and Y
+  //views to see if they match the one that was used when recording the CudaGraph. 
+  //ViewInfo2D provides a type-generic way to store and compare rank-2 views.
+  struct ViewInfo2D
+  {
+    enum ViewLayout
+    {
+      LEFT,
+      RIGHT
+    };
+    ViewInfo2D()
+      : ptr(nullptr), extent0(0), extent1(0), layout(LEFT)
+    {}
+    template<typename View>
+    ViewInfo2D(const View& v)
+    {
+      static_assert(View::rank == 2, "ViewInfo2D passed a view with dimension other than 2");
+      static_assert(
+          std::is_same<typename View::array_layout, Kokkos::LayoutLeft>::value ||
+          std::is_same<typename View::array_layout, Kokkos::LayoutRight>::value,
+          "ViewInfo2D and Gauss-Seidel only support vector layouts Left and Right");
+      ptr = (const void*) v.data();
+      extent0 = v.extent(0);
+      extent1 = v.extent(1);
+      if(std::is_same<typename View::array_layout, Kokkos::LayoutLeft>::value)
+        layout = LEFT;
+      else
+        layout = RIGHT;
+    }
+    bool operator==(const ViewInfo2D& other) const
+    {
+      return ptr == other.ptr &&
+        extent0 == other.extent0 &&
+        extent1 == other.extent1 &&
+        layout == other.layout;
+    }
+    const void* ptr;
+    size_t extent0;
+    size_t extent1;
+    int layout;
+  };
+
+  struct ApplyLaunchParams
+  {
+    ApplyLaunchParams()
+    {}
+
+    template<typename XView, typename YView>
+    ApplyLaunchParams(const XView& x_, const YView& y_, bool forward_, bool backward_, int iters_)
+      : x(x_), y(y_), forward(forward_), backward(backward_), iters(iters_)
+    {}
+    bool operator==(const ApplyLaunchParams& other) const
+    {
+      return x == other.x &&
+        y == other.y &&
+        forward == other.forward &&
+        backward == other.backward &&
+        iters == other.iters;
+    }
+    ViewInfo2D x;
+    ViewInfo2D y;
+    bool forward;
+    bool backward;
+    int iters;
+  };
 
   template <class size_type_, class lno_t_, class scalar_t_,
             class ExecutionSpace,
@@ -102,7 +169,6 @@ namespace KokkosSparse{
     typedef typename Kokkos::View<nnz_lno_t *, HandlePersistentMemorySpace> nnz_lno_persistent_work_view_t;
     typedef typename nnz_lno_persistent_work_view_t::HostMirror nnz_lno_persistent_work_host_view_t; //Host view type
 
-
   protected:
     GSAlgorithm algorithm_type;
 
@@ -116,6 +182,19 @@ namespace KokkosSparse{
     int suggested_vector_size;
     int suggested_team_size;
 
+  private:
+    //CUDA graph that batches the entire apply(), removing most of the
+    //kernel launch overhead. Requires CUDA >= 10.1 (HAVE_CUDAGRAPH implies this).
+    //
+    //Will be reused on subsequent apply() calls, if the ApplyLaunchParameters are the same.
+    // * symbolic/numeric aren't called again
+    // * X/Y are the same views (pointer, layout, extent).
+    //   cudaGraphX and cudaGraphY are used to check this.
+    // * the direction (forward/backward/symmetric) is the same.
+    // * the iteration count is the same.
+    using CudaGraphType = KokkosKernels::Impl::CudaGraphWrapper<ExecutionSpace, ApplyLaunchParams>;
+    CudaGraphType applyCudaGraph;
+
   public:
 
     /**
@@ -128,7 +207,7 @@ namespace KokkosSparse{
       suggested_vector_size(0), suggested_team_size(0)
     {}
 
-    virtual ~GaussSeidelHandle() = default;
+    virtual ~GaussSeidelHandle() {}
 
     //getters
     GSAlgorithm get_algorithm_type() const {return this->algorithm_type;}
@@ -173,6 +252,10 @@ namespace KokkosSparse{
     }
     void set_num_colors(const nnz_lno_t &numColors_) {
       this->numColors = numColors_;
+    }
+
+    CudaGraphType& get_apply_cuda_graph() {
+      return applyCudaGraph;
     }
 
     void vector_team_size(
@@ -566,33 +649,32 @@ namespace KokkosSparse{
     
     bool use_teams() const
     {
-      bool return_value = false;
 #if defined( KOKKOS_ENABLE_SERIAL )
       if (Kokkos::Impl::is_same< Kokkos::Serial , ExecutionSpace >::value) {
-        return_value = false;
+        return false;
       }
 #endif
 #if defined( KOKKOS_ENABLE_THREADS )
       if (Kokkos::Impl::is_same< Kokkos::Threads , ExecutionSpace >::value){
-        return_value = false;
+        return false;
       }
 #endif
 #if defined( KOKKOS_ENABLE_OPENMP )
       if (Kokkos::Impl::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
-        return_value = false;
+        return false;
       }
 #endif
 #if defined( KOKKOS_ENABLE_CUDA )
       if (Kokkos::Impl::is_same<Kokkos::Cuda, ExecutionSpace >::value){
-        return_value = true;
+        return true;
       }
 #endif
 #if defined( KOKKOS_ENABLE_QTHREAD)
       if (Kokkos::Impl::is_same< Kokkos::Qthread, ExecutionSpace >::value){
-        return_value = false;
+        return false;
       }
 #endif
-      return return_value;
+      return false;
     }
 
     ~ClusterGaussSeidelHandle() = default;


### PR DESCRIPTION
(sorry for the wall of text, but some of this can become permanent documentation)

CUDA graphs (CUDA 10.1+) can eliminate most of the launch overhead in a repeated sequence of kernel launches, where during each repeat the kernel inputs are the same. For Kokkos, a graph is constructed by recording a sequence of kernel launches during a dry run (the kernel inputs are known, but the kernels aren't actually executed during recording).

This adds a user-friendly CUDA graph wrapper in ExecSpaceUtils. Currently, only a linear sequence of kernels are supported. Eventually it might be worth it to support multiple streams and an arbitrary dependency graph.

Depending on the complexity of the kernel inputs, using the wrapper for a set of kernels can involve as few as 5 new lines of code.

The wrapper has an arbitrary ``LaunchParams`` type that represents the input to kernels in the graph. If these inputs don't match those that were used to record the graph, the graph must be re-recorded. ``LaunchParams`` requires default constructor, ``operator==``, and a constructor that takes whatever values might change from launch to launch. E.g. if a sparse kernel is called with different X and Y vectors, the graph must be re-recorded if those vectors change.

- The call ``cugraph.begin_recording(args...)`` returns true if the graph needs to be re-recorded (or recorded for the first time), and false if the params match the existing graph. args... are used to construct the current LaunchParams instance.
  - If ``begin_recording(...)`` returned true, run kernels like normal, except policies are constructed by the wrapper, e.g. ``cugraph.range_policy<Tag>(begin, end)`` or ``cugraph.team_policy(nteams, nthreads)``.
  - After all kernels have been "executed" in a dry run, call ``cugraph.end_recording()`` to finalize the graph.
- Finally, call ``cugraph.launch()`` to actually execute the stored graph. This has about the same overhead as a single normal kernel launch, but runs all the kernels as they were recorded. It is also done on a separate stream and is not affected by CUDA_LAUNCH_BLOCKING, although a stream synchronize is done after the launch.

If CUDA is not enabled or is < 10.1, a dummy version of the graph wrapper is enabled with an identical interface, but begin_recording() always returns false (always re-record) and the policies returned are the real policies (so recording is not a dry run). This means that user code doesn't have to be duplicated depending on whether this is available.

CUDA graphs rely on Kokkos changes that are only in develop, so after the 3.0 release a small hotfix will be needed in the Trilinos snapshot to kokkos/core/src/impl/Kokkos_AnalyzePolicy.hpp.

Right now, this wrapper is just used in the apply of Gauss-Seidel and Cluster Gauss-Seidel. Multiple sweeps and iterations over the color sets (which used to involve many kernels) are collapsed into one graph. Whenever Ifpack2 calls apply() with the same vectors (as in multiple solver iterations) the graph is completely reused.

The spot checks on white/RIDE now have Cuda 10.1, so this feature is tested.

RIDE:
#######################################################
PASSED TESTS
#######################################################
cuda-10.1.105-Cuda_OpenMP-release build_time=597 run_time=401
cuda-10.1.105-Cuda_Serial-release build_time=599 run_time=503
cuda-9.2.88-Cuda_OpenMP-release build_time=525 run_time=396
cuda-9.2.88-Cuda_Serial-release build_time=525 run_time=498
gcc-6.4.0-OpenMP_Serial-release build_time=198 run_time=393
gcc-7.2.0-OpenMP-release build_time=129 run_time=129
gcc-7.2.0-OpenMP_Serial-release build_time=255 run_time=360
gcc-7.2.0-Serial-release build_time=148 run_time=227

Bowman:
#######################################################
PASSED TESTS
#######################################################
intel-16.4.258-Pthread-release build_time=743 run_time=1033
intel-16.4.258-Pthread_Serial-release build_time=1069 run_time=2009
intel-16.4.258-Serial-release build_time=708 run_time=934
intel-17.2.174-OpenMP-release build_time=875 run_time=581
intel-17.2.174-OpenMP_Serial-release build_time=1249 run_time=1465
intel-17.2.174-Pthread-release build_time=817 run_time=915
intel-17.2.174-Pthread_Serial-release build_time=1152 run_time=1789
intel-17.2.174-Serial-release build_time=788 run_time=891
