### PR TITLE
spgemm: more shmem alignment related fixes

### DIFF
--- a/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
@@ -56,7 +56,8 @@ template <typename a_row_view_t, typename a_nnz_view_t, typename a_scalar_view_t
 struct KokkosSPGEMM
   <HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_view_t_,
     b_lno_row_view_t_, b_lno_nnz_view_t_, b_scalar_nnz_view_t_>::
-    PortableNumericCHASH{
+  PortableNumericCHASH
+{
 
   nnz_lno_t numrows;
 
@@ -102,6 +103,7 @@ struct KokkosSPGEMM
 
   nnz_lno_t max_first_level_hash_size;
   row_lno_persistent_work_view_t flops_per_row;
+
   PortableNumericCHASH(
       nnz_lno_t m_,
       a_row_view_t row_mapA_,
@@ -149,27 +151,29 @@ struct KokkosSPGEMM
 
         unit_memory(sizeof(nnz_lno_t) * 2 + sizeof(nnz_lno_t) + sizeof (scalar_t)),
         suggested_team_size(suggested_team_size_),
-        thread_memory((shared_memory_size /sizeof(scalar_t) / suggested_team_size_) * sizeof(scalar_t)),
+        thread_memory((shared_memory_size /8 / suggested_team_size_) * 8),
         thread_shmem_key_size(),
-		thread_shared_memory_hash_func(),
-		thread_shmem_hash_size(1),
-		team_shmem_key_size(),
-		team_shared_memory_hash_func(),
-		team_shmem_hash_size(1),
-		team_cuckoo_key_size (1),
-		team_cuckoo_hash_func(1), max_first_level_hash_size( 1), flops_per_row(flops_per_row_)
-
+        thread_shared_memory_hash_func(),
+        thread_shmem_hash_size(1),
+        team_shmem_key_size(),
+        team_shared_memory_hash_func(),
+        team_shmem_hash_size(1),
+        team_cuckoo_key_size (1),
+        team_cuckoo_hash_func(1),
+        max_first_level_hash_size(1),
+        flops_per_row(flops_per_row_)
 
   {
-	nnz_lno_t tmp_team_cuckoo_key_size = ((shared_memory_size - sizeof(nnz_lno_t) * 2) / (sizeof(nnz_lno_t) + sizeof(scalar_t )));
+    nnz_lno_t tmp_team_cuckoo_key_size = ((shared_memory_size - sizeof(nnz_lno_t) * 2) / (sizeof(nnz_lno_t) + sizeof(scalar_t )));
 
-	while (team_cuckoo_key_size * 2 < tmp_team_cuckoo_key_size) team_cuckoo_key_size = team_cuckoo_key_size * 2;
-	team_cuckoo_hash_func = team_cuckoo_key_size - 1;
-	team_shmem_key_size = ((shared_memory_size - sizeof(nnz_lno_t) * 4) / unit_memory);
+    while (team_cuckoo_key_size * 2 < tmp_team_cuckoo_key_size) team_cuckoo_key_size = team_cuckoo_key_size * 2;
+    team_cuckoo_hash_func = team_cuckoo_key_size - 1;
+    team_shmem_key_size = ((shared_memory_size - sizeof(nnz_lno_t) * 4) / unit_memory);
     thread_shmem_key_size = ((thread_memory - sizeof(nnz_lno_t) * 4) / unit_memory);
-    if (KOKKOSKERNELS_VERBOSE_& 0 ){
+    if (KOKKOSKERNELS_VERBOSE_){
+      std::cout << "\t\tPortableNumericCHASH -- sizeof(scalar_t): " << sizeof(scalar_t) << "  sizeof(nnz_lno_t): " << sizeof(nnz_lno_t) << "  suggested_team_size: " << suggested_team_size << std::endl;
       std::cout << "\t\tPortableNumericCHASH -- thread_memory:" << thread_memory  << " unit_memory:" << unit_memory <<" initial key size:" << thread_shmem_key_size << std::endl;
-      std::cout << "\t\tPortableNumericCHASH -- team_memory:" << shared_memory_size  << " unit_memory:" << unit_memory <<" initial team key size:" << team_shmem_key_size << std::endl;
+      std::cout << "\t\tPortableNumericCHASH -- team shared_memory:" << shared_memory_size  << " unit_memory:" << unit_memory <<" initial team key size:" << team_shmem_key_size << std::endl;
     }
     while (thread_shmem_hash_size * 2 <=  thread_shmem_key_size){
       thread_shmem_hash_size = thread_shmem_hash_size * 2;
@@ -185,15 +189,23 @@ struct KokkosSPGEMM
     thread_shmem_key_size = thread_shmem_key_size + ((thread_shmem_key_size - thread_shmem_hash_size) * sizeof(nnz_lno_t)) / (sizeof (nnz_lno_t) * 2 + sizeof(scalar_t));
     thread_shmem_key_size = (thread_shmem_key_size >> 1) << 1;
 
-    // GPUTag
-    // thread_memory == 2*sizeof(nnz_lno_t)+2*sizeof(nnz_lno_t) + thread_shmem_hash_size*sizeof(nnz_lno_t) + 2*thread_shmem_key_size*sizeof(nnz_lno_t) + rem_size*sizeof(scalar_t)
+    if (KOKKOSKERNELS_VERBOSE_){
+      std::cout << "\t\tPortableNumericCHASH -- thread_memory:" << thread_memory  << " unit_memory:" << unit_memory <<" resized key size:" << thread_shmem_key_size << std::endl;
+      std::cout << "\t\tPortableNumericCHASH -- team shared_memory:" << shared_memory_size  << " unit_memory:" << unit_memory <<" resized team key size:" << team_shmem_key_size << std::endl;
+    }
 
+// This guard will help ensure behavior is consistent within Trilinos
+#ifdef KOKKOS_ENABLE_COMPLEX_ALIGN
+    {
+    // GPUTag
+    // shmem allocation will be partitioned as below for hash map accumulator
+    // thread_memory == 2*sizeof(nnz_lno_t)+2*sizeof(nnz_lno_t) + thread_shmem_hash_size*sizeof(nnz_lno_t) + 2*thread_shmem_key_size*sizeof(nnz_lno_t) + rem_size*sizeof(scalar_t)
     // if memory for vals is unaligned, adjust thread_shmem_key_size until alignment is achieved
     nnz_lno_t remainder_memory = thread_memory - sizeof(nnz_lno_t)*4 - thread_shmem_hash_size*sizeof(nnz_lno_t);
     // val_memory must be aligned into sizeof(scalar_t) chunks, and there must be at least as many entries as keys
     nnz_lno_t val_memory = remainder_memory - 2*thread_shmem_key_size*sizeof(nnz_lno_t);
 
-    nnz_lno_t val_unalign_mem = val_memory % sizeof(scalar_t);
+    nnz_lno_t val_unalign_mem = val_memory % alignof(scalar_t);
     if (val_unalign_mem > 0) {
       // Redistributing between thread_shmem_key_size and vals involves exchange of 2 "keys" (key+next) per val
       nnz_lno_t realign_chunk_mem = 2 * sizeof(nnz_lno_t);
@@ -201,20 +213,29 @@ struct KokkosSPGEMM
       bool is_align_possible = (val_unalign_mem % realign_chunk_mem) == 0;
       if(!is_align_possible)
       {
-        throw std::runtime_error("PortableNumericCHASH Ctor Error: unable to align memory for shared memory allocations. Modify your shared memory request");
+        std::cout << "PortableNumericCHASH: GPUTag shmem align impossible." << std::endl;
+        if (KOKKOSKERNELS_VERBOSE_){
+          std::cout << "    remainder_memory: " << remainder_memory << "  val_memory: " << val_memory << "  val_unalign_mem: " << val_unalign_mem << "  realign_chunk_mem: " << realign_chunk_mem << std::endl;
+        }
       }
 
       nnz_lno_t realign_chunks = val_unalign_mem / realign_chunk_mem;
 
       thread_shmem_key_size -= realign_chunks;
       val_memory = remainder_memory - 2*thread_shmem_key_size*sizeof(nnz_lno_t);
-      val_unalign_mem = val_memory%sizeof(scalar_t);
+      val_unalign_mem = val_memory%alignof(scalar_t);
     }
+
     if (val_unalign_mem > 0 || thread_shmem_key_size <= 0) {
-      throw std::runtime_error("PortableNumericCHASH Ctor Error: shared memory realignment failed. Modify your shared memory request");
+      std::cout << "PortableNumericCHASH Ctor Warning: shared memory realignment failed. Modify your shared memory request" << std::endl;
+      if (KOKKOSKERNELS_VERBOSE_){
+        std::cout << "GPUTag   alignment fail.  remainder_memory: " << remainder_memory << "  val_memory: " << val_memory << "  val_unalign_mem: " << val_unalign_mem << std::endl;
+        std::cout << "GPUTag   alignment fail.  thread_shmem_key_size: " << thread_shmem_key_size << std::endl;
+      }
     }
 
     // GPUTag4, GPUTag6
+    // shmem allocation will be partitioned as below for hash map accumulator
     // shmem == sizeof(nnz_lno_t)*2 + sizeof(nnz_lno_t)*team_cuckoo_key_size + sizeof(scalar_t)*rem_size
 
     // if memory for vals is unaligned, adjust team_cuckoo_key_size until alignment is achieved
@@ -222,7 +243,7 @@ struct KokkosSPGEMM
     // val_memory must be aligned into sizeof(scalar_t) chunks, and there must be at least as many entries as keys
     val_memory = remainder_memory - team_cuckoo_key_size*sizeof(nnz_lno_t);
 
-    val_unalign_mem = val_memory % sizeof(scalar_t);
+    val_unalign_mem = val_memory % alignof(scalar_t);
     if (val_unalign_mem > 0) {
       // Redistributing between team_cuckoo_key_size and vals involves exchange of 1 key per val
       nnz_lno_t realign_chunk_mem = sizeof(nnz_lno_t);
@@ -230,18 +251,29 @@ struct KokkosSPGEMM
       bool is_align_possible = (val_unalign_mem % realign_chunk_mem) == 0;
       if(!is_align_possible)
       {
-        throw std::runtime_error("PortableNumericCHASH Ctor Error: GPUTag4,6 unable to align memory for shared memory allocations. Modify your shared memory request");
+        std::cout << "PortableNumericCHASH GPUTag4,6 shmem alignment impossible." << std::endl;
+        if (KOKKOSKERNELS_VERBOSE_){
+          std::cout << "    remainder_memory: " << remainder_memory << "  val_memory: " << val_memory << "  val_unalign_mem: " << val_unalign_mem << "  realign_chunk_mem: " << realign_chunk_mem << std::endl;
+        }
       }
 
       nnz_lno_t realign_chunks = val_unalign_mem / realign_chunk_mem;
 
       team_cuckoo_key_size -= realign_chunks;
       val_memory = remainder_memory - team_cuckoo_key_size*sizeof(nnz_lno_t);
-      val_unalign_mem = val_memory%sizeof(scalar_t);
+      val_unalign_mem = val_memory%alignof(scalar_t);
     }
+
     if (val_unalign_mem > 0 || team_cuckoo_key_size <= 0) {
-      throw std::runtime_error("PortableNumericCHASH Ctor Error: GPUTag4,6 shared memory realignment failed. Modify your shared memory request");
+      std::cout << "PortableNumericCHASH Ctor Warning: GPUTag4,6 shared memory realignment failed. Modify your shared memory request" << std::endl;
+      if (KOKKOSKERNELS_VERBOSE_){
+        std::cout << "PortableNumericCHASH GPUTag4,6  alignment fail.  remainder_memory: " << remainder_memory << "  val_memory: " << val_memory << "  val_unalign_mem: " << val_unalign_mem << std::endl;
+        std::cout << "GPUTag4,6  alignment fail.  team_cuckoo_key_size: " << team_cuckoo_key_size << std::endl;
+      }
     }
+
+    }
+#endif
 
     max_first_level_hash_size = first_level_cut_off * team_cuckoo_key_size;
     if (KOKKOSKERNELS_VERBOSE_){
@@ -249,10 +281,11 @@ struct KokkosSPGEMM
       std::cout << "\t\tPortableNumericCHASH -- team_memory:" << shared_memory_size  << " unit_memory:" << unit_memory <<" initial team key size:" << team_shmem_key_size << std::endl;
       std::cout << "\t\tPortableNumericCHASH -- adjusted hashsize:" << thread_shmem_hash_size  << " thread_shmem_key_size:" << thread_shmem_key_size << std::endl;
       std::cout << "\t\tPortableNumericCHASH -- adjusted team hashsize:" << team_shmem_hash_size  << " team_shmem_key_size:" << team_shmem_key_size << std::endl;
-      std::cout << "\t\tteam_cuckoo_key_size:" << team_cuckoo_key_size << " team_cuckoo_hash_func:" << team_cuckoo_hash_func << " max_first_level_hash_size:" << max_first_level_hash_size << std::endl;
-      std::cout << "\t\tpow2_hash_size:" << pow2_hash_size << " pow2_hash_func:" << pow2_hash_func << std::endl;
+      std::cout << "\t\t  team_cuckoo_key_size:" << team_cuckoo_key_size << " team_cuckoo_hash_func:" << team_cuckoo_hash_func << " max_first_level_hash_size:" << max_first_level_hash_size << std::endl;
+      std::cout << "\t\t  pow2_hash_size:" << pow2_hash_size << " pow2_hash_func:" << pow2_hash_func << std::endl;
     }
   }
+
   KOKKOS_INLINE_FUNCTION
   size_t get_thread_id(const size_t row_index) const{
     switch (my_exec_space){
@@ -1175,6 +1208,60 @@ struct KokkosSPGEMM
 };
 
 
+//
+// * Notes on KokkosSPGEMM_numeric_hash *
+//
+// Prior to this routine, KokkosSPGEMM_numeric(...) was called
+//
+//   KokkosSPGEMM_numeric(...) :
+//     if (this->spgemm_algorithm == SPGEMM_KK || SPGEMM_KK_LP == this->spgemm_algorithm) :
+//       call KokkosSPGEMM_numeric_speed(...)
+//     else:
+//       call  KokkosSPGEMM_numeric_hash(...)  (this code!)
+//
+//     * NOTE: KokkosSPGEMM_numeric_hash2(...) is not called
+//
+//
+// KokkosSPGEMM_numeric_hash:
+//
+// Algorithm selection may be modified as follows
+//
+//   algorithm_to_run: initialized to spgemm_algorithm input to KokkosSPGEMM_numeric_hash
+//     * spgemm_algorithm CANNOT be SPGEMM_KK_SPEED or SPGEMM_KK_DENSE
+//
+//  if (this->spgemm_algorithm == SPGEMM_KK || SPGEMM_KK_LP == this->spgemm_algorithm) :
+//     if Cuda enabled :
+//       1. perform shmem-size + partition computations (used by HashMapAccumulator) and flop estimate
+//       2. from results of 1. select from SPGEMM_KK_MEMORY_SPREADTEAM, SPGEMM_KK_MEMORY_BIGSPREADTEAM, SPGEMM_KK_MEMORY
+//          * Note: These shmem calculations are not passed along to the PortableNumericCHASH functor used by kernels
+//            TODO check the pre-shmem calculations and functor shmem calculations consistent - pass shmem values to functor
+//     else :
+//       1. determine if problem is "dense"
+//       2. if dense: call "this->KokkosSPGEMM_numeric_speed"
+//          else : no change from algorithm_to_run; that is algorithm_to_run == SPGEMM_KK || SPGEMM_KK_LP
+//
+//  else :
+//     skip modification of input algorithm
+//
+//
+//
+// Algorithm type matching to kernel Tag:
+//
+//   Policy typedefs with tags found in: KokkosSparse_spgemm_impl.hpp
+//
+//  Cuda algorithm options:
+//   (algorithm_to_run == SPGEMM_KK_MEMORY_SPREADTEAM) : gpu_team_policy4_t,  i.e. GPUTag4
+//   (algorithm_to_run == SPGEMM_KK_MEMORY_BIGSPREADTEAM) : gpu_team_policy6_t,  i.e. GPUTag6
+//   (default == SPGEMM_KK_MEMORY) : gpu_team_policy_t,  i.e. GPUTag
+//
+//  Non-Cuda host algorithm options:
+//   SPGEMM_KK_LP:
+//     (algorithm_to_run == SPGEMM_KK_LP + Dynamic) : dynamic_multicore_team_policy4_t,  i.e. MultiCoreTag4
+//     (algorithm_to_run == SPGEMM_KK_LP + Static) :  dynamic_multicore_team_policy4_t // typo/bug, should be multicore_team_policy4_t?
+//   else SPGEMM::KKMEM
+//     kernel label: "KOKKOSPARSE::SPGEMM::KKMEM::DYNAMIC" : dynamic_multicore_team_policy_t,  i.e. MultiCoreTag
+//     kernel label: "KOKKOSPARSE::SPGEMM::KKMEM::STATIC"  : multicore_team_policy_t,  i.e. MultiCoreTag
+
 template <typename HandleType,
 typename a_row_view_t_, typename a_lno_nnz_view_t_, typename a_scalar_nnz_view_t_,
 typename b_lno_row_view_t_, typename b_lno_nnz_view_t_, typename b_scalar_nnz_view_t_  >
@@ -1183,11 +1270,12 @@ void
   KokkosSPGEMM
   <HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_view_t_,
     b_lno_row_view_t_, b_lno_nnz_view_t_, b_scalar_nnz_view_t_>::
-    KokkosSPGEMM_numeric_hash(
+  KokkosSPGEMM_numeric_hash(
       c_row_view_t rowmapC_,
       c_lno_nnz_view_t entriesC_,
       c_scalar_nnz_view_t valuesC_,
-      KokkosKernels::Impl::ExecSpaceType lcl_my_exec_space){
+      KokkosKernels::Impl::ExecSpaceType lcl_my_exec_space)
+{
 
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << "\tHASH MODE" << std::endl;
@@ -1219,7 +1307,10 @@ void
 	  tmp_max_nnz *= hash_scaler;
   }
 
+
   //START OF SHARED MEMORY SIZE CALCULATIONS
+  // NOTE: the values computed here are not actually passed to functors requiring shmem,
+  // the calculations here are used for algorithm selection
   nnz_lno_t unit_memory = sizeof(nnz_lno_t) * 2 + sizeof(nnz_lno_t) + sizeof(scalar_t);
   nnz_lno_t team_shmem_key_size = ((shmem_size_to_use - sizeof(nnz_lno_t) * 4) / unit_memory);
   nnz_lno_t thread_memory = (shmem_size_to_use /8 / suggested_team_size) * 8;
@@ -1256,7 +1347,7 @@ void
 		  //then we do row-base algorithm.
 		  if (SPGEMM_KK_LP != this->spgemm_algorithm && (average_row_nnz < 32 || average_row_flops < 256)){
 			  algorithm_to_run = SPGEMM_KK_MEMORY;
-			  //if (average_row_nnz / double (thread_shmem_key_size) > 1.5){
+			  //if (average_row_nnz / double (thread_shmem_key_size) > 1.5)
 				  while (average_row_nnz > size_type (thread_shmem_key_size) && suggested_vector_size < 32){
 					  suggested_vector_size  = suggested_vector_size * 2;
 					  suggested_vector_size = KOKKOSKERNELS_MACRO_MIN(32, suggested_vector_size);
@@ -1394,6 +1485,7 @@ void
 	  }
   }
 
+  // START SIZE CALCULATIONS FOR MEMORYPOOL
   if (algorithm_to_run == SPGEMM_KK_LP ){
 
 	  while (tmp_max_nnz > min_hash_size){
@@ -1442,6 +1534,7 @@ void
   }
 #endif
 
+  // END SIZE CALCULATIONS FOR MEMORYPOOL
 
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << "\t\t max_nnz: " << max_nnz
@@ -1496,9 +1589,9 @@ void
 
       lcl_my_exec_space,
       team_row_chunk_size,
-	  first_level_cut_off, flops_per_row,
-	  KOKKOSKERNELS_VERBOSE);
-
+      first_level_cut_off,
+      flops_per_row,
+      KOKKOSKERNELS_VERBOSE);
 
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << "\t\tvector_size:" << suggested_vector_size  << " chunk_size:" << team_row_chunk_size << " suggested_team_size:" << suggested_team_size<< std::endl;
@@ -1507,15 +1600,29 @@ void
 
   if (lcl_my_exec_space == KokkosKernels::Impl::Exec_CUDA){
 	  if (algorithm_to_run == SPGEMM_KK_MEMORY_SPREADTEAM){
+                  if (thread_shmem_key_size <= 0) {
+                    std::cout << "KokkosSPGEMM_numeric_hash SPGEMM_KK_MEMORY_SPREADTEAM: Insufficient shmem available for key for hash map accumulator - Terminating" << std::endl;
+                    std::cout << "    thread_shmem_key_size = " << thread_shmem_key_size << std::endl;
+                    throw std::runtime_error(" KokkosSPGEMM_numeric_hash SPGEMM_KK_MEMORY_SPREADTEAM: Insufficient shmem available for key for hash map accumulator ");
+                  }
 		  Kokkos::parallel_for("KOKKOSPARSE::SPGEMM::SPGEMM_KK_MEMORY_SPREADTEAM", gpu_team_policy4_t(a_row_cnt / team_row_chunk_size + 1 , suggested_team_size, suggested_vector_size), sc);
 		    MyExecSpace().fence();
 
 	  }
 	  else if (algorithm_to_run == SPGEMM_KK_MEMORY_BIGSPREADTEAM){
+                  if (thread_shmem_key_size <= 0) {
+                    std::cout << "KokkosSPGEMM_numeric_hash SPGEMM_KK_MEMORY_BIGSPREADTEAM: Insufficient shmem available for key for hash map accumulator - Terminating" << std::endl;
+                    std::cout << "    thread_shmem_key_size = " << thread_shmem_key_size << std::endl;
+                    throw std::runtime_error(" KokkosSPGEMM_numeric_hash SPGEMM_KK_MEMORY_BIGSPREADTEAM: Insufficient shmem available for key for hash map accumulator ");
+                  }
 		  Kokkos::parallel_for("KOKKOSPARSE::SPGEMM::SPGEMM_KK_MEMORY_BIGSPREADTEAM", gpu_team_policy6_t(a_row_cnt / team_row_chunk_size + 1 , suggested_team_size, suggested_vector_size), sc);
 	  }
 	  else {
-
+                  if (team_shmem_key_size <= 0) {
+                    std::cout << "KokkosSPGEMM_numeric_hash SPGEMM_KK_MEMORY: Insufficient shmem available for key for hash map accumulator - Terminating" << std::endl;
+                    std::cout << "    team_shmem_key_size = " << team_shmem_key_size << std::endl;
+                    throw std::runtime_error(" KokkosSPGEMM_numeric_hash SPGEMM_KK_MEMORY: Insufficient shmem available for key for hash map accumulator ");
+                  }
 		  Kokkos::parallel_for("KOKKOSPARSE::SPGEMM::SPGEMM_KK_MEMORY", gpu_team_policy_t(a_row_cnt / team_row_chunk_size + 1 , suggested_team_size, suggested_vector_size), sc);
 	  }
     MyExecSpace().fence();
@@ -1527,7 +1634,7 @@ void
 		  }
 		  else {
 
-			  Kokkos::parallel_for( "KOKKOSPARSE::SPGEMM::SPGEMM_KK_LP::STATIC", dynamic_multicore_team_policy4_t(a_row_cnt / team_row_chunk_size + 1 , suggested_team_size, suggested_vector_size), sc);
+			  Kokkos::parallel_for( "KOKKOSPARSE::SPGEMM::SPGEMM_KK_LP::STATIC", multicore_team_policy4_t(a_row_cnt / team_row_chunk_size + 1 , suggested_team_size, suggested_vector_size), sc);
 		  }
 	  }
 	  else {
@@ -1550,6 +1657,8 @@ void
 }
 
 
+// 01/30/2020: this code seems to be unused within any of the kokkos-kernels spgemm numeric phase algorithms
+// TODO determine if this code should be revived for use or removed
 //this is to isolate the memory use of accumulators and A,B,C.
 //normally accumulators can use memory of C directly, but in this one we separate it for experimenting.
 template <typename HandleType,
@@ -1560,11 +1669,12 @@ void
   KokkosSPGEMM
   <HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_view_t_,
     b_lno_row_view_t_, b_lno_nnz_view_t_, b_scalar_nnz_view_t_>::
-    KokkosSPGEMM_numeric_hash2(
+  KokkosSPGEMM_numeric_hash2(
       c_row_view_t rowmapC_,
       c_lno_nnz_view_t entriesC_,
       c_scalar_nnz_view_t valuesC_,
-      KokkosKernels::Impl::ExecSpaceType my_exec_space_){
+      KokkosKernels::Impl::ExecSpaceType my_exec_space_)
+{
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << "\tHASH MODE" << std::endl;
   }

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
@@ -55,7 +55,8 @@ template <typename a_row_view_t, typename a_nnz_view_t, typename a_scalar_view_t
 struct KokkosSPGEMM
   <HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_view_t_,
     b_lno_row_view_t_, b_lno_nnz_view_t_, b_scalar_nnz_view_t_>::
-  NumericCMEM_CPU{
+  NumericCMEM_CPU
+{
   nnz_lno_t numrows;
   nnz_lno_t numcols;
 
@@ -217,7 +218,8 @@ template <typename a_row_view_t__, typename a_nnz_view_t__, typename a_scalar_vi
 struct KokkosSPGEMM
   <HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_view_t_,
     b_lno_row_view_t_, b_lno_nnz_view_t_, b_scalar_nnz_view_t_>::
-  NumericCMEM{
+  NumericCMEM
+{
   nnz_lno_t numrows;
 
   a_row_view_t__ row_mapA;
@@ -297,7 +299,7 @@ struct KokkosSPGEMM
 
         unit_memory(sizeof(nnz_lno_t) * 2 + sizeof(nnz_lno_t) + sizeof (scalar_t)),
         suggested_team_size(suggested_team_size_),
-        thread_memory((shared_memory_size /sizeof(scalar_t) / suggested_team_size_) * sizeof(scalar_t)),
+        thread_memory((shared_memory_size /8 / suggested_team_size_) * 8),
         shmem_key_size(), shared_memory_hash_func(), shmem_hash_size(1)
         {
           shmem_key_size = ((thread_memory - sizeof(nnz_lno_t) * 2) / unit_memory);
@@ -313,14 +315,20 @@ struct KokkosSPGEMM
           shmem_key_size = shmem_key_size + ((shmem_key_size - shmem_hash_size) * sizeof(nnz_lno_t)) / (sizeof (nnz_lno_t) * 2 + sizeof(scalar_t));
           shmem_key_size = (shmem_key_size >> 1) << 1;
 
+// This guard will help ensure behavior is consistent within Trilinos
+#ifdef KOKKOS_ENABLE_COMPLEX_ALIGN
+          {
+          // GPUTag
+          // shmem allocation will be partitioned as below for hash map accumulator
           // thread_memory == 2*sizeof(nnz_lno_t) + shmem_hash_size*sizeof(nnz_lno_t) + 2*shmem_key_size*sizeof(nnz_lno_t) + rem_size*sizeof(scalar_t)
+
           // check that memory is partitioned into aligned chunks
           nnz_lno_t remainder_memory = thread_memory - sizeof(nnz_lno_t)*2 - shmem_hash_size*sizeof(nnz_lno_t);
 
           // The remainder of memory for vals must be aligned into sizeof(scalar_t) chunks, and there must be at least as many entries as keys
           nnz_lno_t val_memory = remainder_memory - 2*shmem_key_size*sizeof(nnz_lno_t);
 
-          nnz_lno_t val_unalign_mem = val_memory % sizeof(scalar_t);
+          nnz_lno_t val_unalign_mem = val_memory % alignof(scalar_t);
           if (val_unalign_mem > 0) {
             // Redistributing between shmem_key_size and vals involves exchange of 2 "keys" (key+next) per val
             nnz_lno_t realign_chunk_mem = 2 * sizeof(nnz_lno_t);
@@ -328,19 +336,24 @@ struct KokkosSPGEMM
             bool is_align_possible = (val_unalign_mem % realign_chunk_mem) == 0;
             if(!is_align_possible)
             {
-              throw std::runtime_error("NumericCMEM Ctor Error: unable to align memory for shared memory allocations. Modify your shared memory request");
+              //throw std::runtime_error("NumericCMEM Ctor Error: unable to align memory for shared memory allocations. Modify your shared memory request");
+              std::cout << "NumericCMEM Ctor WARNING: unable to align memory for shared memory allocations. Modify your shared memory request" << std::endl;
             }
 
             nnz_lno_t realign_chunks = val_unalign_mem / realign_chunk_mem; 
 
             shmem_key_size -= realign_chunks;
             val_memory = remainder_memory - 2*shmem_key_size*sizeof(nnz_lno_t);
-            val_unalign_mem = val_memory%sizeof(scalar_t);
+            val_unalign_mem = val_memory%alignof(scalar_t);
           }
 
           if (val_unalign_mem > 0) {
-            throw std::runtime_error("NumericCMEM Ctor Error: shared memory realignment failed. Modify your shared memory request");
+            //throw std::runtime_error("NumericCMEM Ctor Error: shared memory realignment failed. Modify your shared memory request");
+            std::cout << "NumericCMEM Ctor WARNING: shared memory realignment failed. Modify your shared memory request" << std::endl;
           }
+
+          }
+#endif
 
           if (KOKKOSKERNELS_VERBOSE_){
             std::cout << "\t\tNumericCMEM -- adjusted hashsize:" << shmem_hash_size  << " shmem_key_size:" << shmem_key_size << std::endl;
@@ -496,6 +509,34 @@ struct KokkosSPGEMM
   }
 };
 
+
+//
+// * Notes on KokkosSPGEMM_numeric_speed *
+//
+// Prior to this routine, KokkosSPGEMM_numeric(...) was called
+//
+//   KokkosSPGEMM_numeric(...) :
+//     if (this->spgemm_algorithm == SPGEMM_KK || SPGEMM_KK_LP == this->spgemm_algorithm) :
+//       call KokkosSPGEMM_numeric_speed(...)
+//     else:
+//       call  KokkosSPGEMM_numeric_hash(...)
+//
+//
+// KokkosSPGEMM_numeric_speed:
+//
+// Algorithm selection as follows and matching to kernel Tag:
+//
+//  Policy typedefs with tags found in: KokkosSparse_spgemm_impl.hpp
+//
+//  if Cuda enabled :
+//    "KokkosSparse::NumericCMEM::KKSPEED::GPU" : gpu_team_policy_t,  i.e. GPUTag
+//
+//  else :
+//    "KokkosSparse::NumericCMEM_CPU::DENSE::DYNAMIC" : dynamic_multicore_team_policy_t,  i.e. MultiCoreTag
+//    "KokkosSparse::NumericCMEM_CPU::DENSE::STATIC" :  multicore_team_policy_t,  i.e. MultiCoreTag
+//
+
+
 template <typename HandleType,
 typename a_row_view_t_, typename a_lno_nnz_view_t_, typename a_scalar_nnz_view_t_,
 typename b_lno_row_view_t_, typename b_lno_nnz_view_t_, typename b_scalar_nnz_view_t_  >
@@ -504,11 +545,12 @@ void
   KokkosSPGEMM
   <HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_view_t_,
     b_lno_row_view_t_, b_lno_nnz_view_t_, b_scalar_nnz_view_t_>::
-    KokkosSPGEMM_numeric_speed(
+  KokkosSPGEMM_numeric_speed(
     c_row_view_t rowmapC_,
     c_lno_nnz_view_t entriesC_,
     c_scalar_nnz_view_t valuesC_,
-    KokkosKernels::Impl::ExecSpaceType my_exec_space_){
+    KokkosKernels::Impl::ExecSpaceType my_exec_space_)
+{
 
   if (KOKKOSKERNELS_VERBOSE){
     std::cout << "\tSPEED MODE" << std::endl;


### PR DESCRIPTION
Address issue #587
Integration testing with Trilinos exposed issues with handling of
shmem alignment with ensemble types.

This PR:
1. reverts how thread_memory is computed during functor construction
2. removes throws within functors when shmem unaligned
3. adds warning message and throws prior to kernel launch for cases
   with inappropriate shmem sizes
4. guards shmem realignment with KOKKOS_ENABLE_COMPLEX_ALIGN
     this keeps behavior consistent with Trilinos, but will
     need to be further addressed
5. some formatting cleanup and comments added