### PR TITLE
Fixed SPGEMM for zero rows in several places

### DIFF
--- a/src/common/KokkosKernels_IOUtils.hpp
+++ b/src/common/KokkosKernels_IOUtils.hpp
@@ -78,7 +78,7 @@ void kk_sparseMatrix_generate(
 {
   rowPtr = new SizeType[nrows+1];
 
-  OrdinalType elements_per_row = nnz/nrows;
+  OrdinalType elements_per_row = nrows ? nnz/nrows : 0;
   srand(13721);
   rowPtr[0] = 0;
   for(int row=0;row<nrows;row++)

--- a/src/common/KokkosKernels_Utils.hpp
+++ b/src/common/KokkosKernels_Utils.hpp
@@ -1477,8 +1477,8 @@ struct ReduceRowSizeFunctor{
   const size_type min_val;
   ReduceRowSizeFunctor(
       const size_type *rb,const  size_type *re): rowmap_view_begins(rb), rowmap_view_ends(re),
-          min_val((std::numeric_limits<size_type>::lowest())){
-  }
+          min_val(0)
+  {}
   KOKKOS_INLINE_FUNCTION
   void operator()(const size_t &i, size_type &max_reduction) const {
     size_type val = rowmap_view_ends[i] - rowmap_view_begins[i] ;
@@ -1521,8 +1521,9 @@ struct ReduceMaxRowFunctor{
   const value_type min_val;
   ReduceMaxRowFunctor(
       view_type rowmap_view_): rowmap_view(rowmap_view_),
-          min_val((std::numeric_limits<value_type>::lowest())){
-  }
+          min_val(0)
+  {}
+
   KOKKOS_INLINE_FUNCTION
   void operator()(const size_t &i, value_type &max_reduction) const {
     value_type val = rowmap_view(i+1) - rowmap_view(i) ;

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
@@ -764,7 +764,8 @@ bool KokkosSPGEMM
     out_rowmap_view_t out_row_map,
     out_nnz_view_t &out_nnz_indices,
     out_nnz_view_t &out_nnz_sets,
-    bool compress_in_single_step){
+    bool compress_in_single_step)
+{
   //get the execution space type.
   KokkosKernels::Impl::ExecSpaceType lcl_my_exec_space = this->handle->get_handle_exec_space();
   //get the suggested vectorlane size based on the execution space, and average number of nnzs per row.
@@ -904,7 +905,8 @@ bool KokkosSPGEMM
       if(use_unordered_compress)
       {
         size_type max_row_nnz = 0;
-        KokkosKernels::Impl::view_reduce_maxsizerow<in_row_view_t, MyExecSpace>(n, in_row_map, max_row_nnz);
+        if(n)
+          KokkosKernels::Impl::view_reduce_maxsizerow<in_row_view_t, MyExecSpace>(n, in_row_map, max_row_nnz);
         MyExecSpace().fence();
         KokkosKernels::Impl::PoolType my_pool_type = KokkosKernels::Impl::OneThread2OneChunk;
 

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
@@ -1771,8 +1771,11 @@ void KokkosSPGEMM
 	{
 		Kokkos::Impl::Timer timer1_;
 		size_type c_max_nnz = 0;
-		KokkosKernels::Impl::view_reduce_max<c_row_view_t, MyExecSpace>(m, rowmapC, c_max_nnz);
-		MyExecSpace().fence();
+                if(m > 0)
+                {
+                  KokkosKernels::Impl::view_reduce_max<c_row_view_t, MyExecSpace>(m, rowmapC, c_max_nnz);
+                  MyExecSpace().fence();
+                }
 		this->handle->get_spgemm_handle()->set_max_result_nnz(c_max_nnz);
 
 		if (KOKKOSKERNELS_VERBOSE){
@@ -2274,8 +2277,11 @@ void KokkosSPGEMM
   {
     Kokkos::Impl::Timer timer1_;
     size_type c_max_nnz = 0;
-    KokkosKernels::Impl::view_reduce_max<c_row_view_t, MyExecSpace>(m, rowmapC, c_max_nnz);
-    MyExecSpace().fence();
+    if(m > 0)
+    {
+      KokkosKernels::Impl::view_reduce_max<c_row_view_t, MyExecSpace>(m, rowmapC, c_max_nnz);
+      MyExecSpace().fence();
+    }
     this->handle->get_spgemm_handle()->set_max_result_nnz(c_max_nnz);
 
     if (KOKKOSKERNELS_VERBOSE){

--- a/unit_test/sparse/Test_Sparse_spgemm.hpp
+++ b/unit_test/sparse/Test_Sparse_spgemm.hpp
@@ -111,8 +111,6 @@ int run_spgemm(crsMat_t input_mat, crsMat_t input_mat2, KokkosSparse::SPGEMMAlgo
   bool equal = num_rows_2 == num_cols_1;
   if (!equal) return 1;
 
-
-
   lno_view_t row_mapC ("non_const_lnow_row", num_rows_1 + 1);
   lno_nnz_view_t  entriesC;
   scalar_view_t valuesC;
@@ -133,10 +131,8 @@ int run_spgemm(crsMat_t input_mat, crsMat_t input_mat2, KokkosSparse::SPGEMMAlgo
   );
 
   size_t c_nnz_size = kh.get_spgemm_handle()->get_c_nnz();
-  if (c_nnz_size){
-    entriesC = lno_nnz_view_t (Kokkos::ViewAllocateWithoutInitializing("entriesC"), c_nnz_size);
-    valuesC = scalar_view_t (Kokkos::ViewAllocateWithoutInitializing("valuesC"), c_nnz_size);
-  }
+  entriesC = lno_nnz_view_t (Kokkos::ViewAllocateWithoutInitializing("entriesC"), c_nnz_size);
+  valuesC = scalar_view_t (Kokkos::ViewAllocateWithoutInitializing("valuesC"), c_nnz_size);
   spgemm_numeric(
       &kh,
       num_rows_1,
@@ -156,10 +152,8 @@ int run_spgemm(crsMat_t input_mat, crsMat_t input_mat2, KokkosSparse::SPGEMMAlgo
       valuesC
   );
 
-
   graph_t static_graph (entriesC, row_mapC);
-  crsMat_t crsmat("CrsMatrix", num_cols_2, valuesC, static_graph);
-  result = crsmat;
+  result = crsMat_t("CrsMatrix", num_cols_2, valuesC, static_graph);
   kh.destroy_spgemm_handle();
 
   return 0;
@@ -172,11 +166,11 @@ bool is_same_matrix(crsMat_t output_mat1, crsMat_t output_mat2){
   typedef typename graph_t::entries_type::non_const_type   lno_nnz_view_t;
   typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
 
-  size_t nrows1 = output_mat1.graph.row_map.extent(0);
+  size_t nrows1 = output_mat1.numRows();
   size_t nentries1 = output_mat1.graph.entries.extent(0) ;
   size_t nvals1 = output_mat1.values.extent(0);
 
-  size_t nrows2 = output_mat2.graph.row_map.extent(0);
+  size_t nrows2 = output_mat2.numRows();
   size_t nentries2 = output_mat2.graph.entries.extent(0) ;
   size_t nvals2 = output_mat2.values.extent(0);
 
@@ -228,11 +222,12 @@ bool is_same_matrix(crsMat_t output_mat1, crsMat_t output_mat2){
   is_identical = KokkosKernels::Impl::kk_is_identical_view
       <typename graph_t::row_map_type, typename graph_t::row_map_type, typename lno_view_t::value_type,
       typename device::execution_space>(output_mat1.graph.row_map, output_mat2.graph.row_map, 0);
-  //KokkosKernels::Impl::kk_print_1Dview(output_mat2.graph.row_map);
 
   if (!is_identical) {
     std::cout << "rowmaps are different." << std::endl;
+    std::cout << "Actual rowmap:\n";
     KokkosKernels::Impl::kk_print_1Dview(output_mat1.graph.row_map);
+    std::cout << "Correct rowmap (SPGEMM_DEBUG):\n";
     KokkosKernels::Impl::kk_print_1Dview(output_mat2.graph.row_map);
     return false;
   }
@@ -285,16 +280,17 @@ void test_spgemm(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_v
   lno_t numCols = numRows;
   crsMat_t input_mat = KokkosKernels::Impl::kk_generate_sparse_matrix<crsMat_t>(numRows,numCols,nnz,row_size_variance, bandwidth);
 
-
   crsMat_t output_mat2;
   run_spgemm<crsMat_t, device>(input_mat, input_mat, SPGEMM_DEBUG, output_mat2);
 
-  SPGEMMAlgorithm algorithms [] = {SPGEMM_KK_MEMORY, SPGEMM_KK_SPEED, SPGEMM_KK_MEMSPEED, /*SPGEMM_CUSPARSE, */SPGEMM_MKL};
+  std::vector<SPGEMMAlgorithm> algorithms = {SPGEMM_KK_MEMORY, SPGEMM_KK_SPEED, SPGEMM_KK_MEMSPEED};
 
-  for (int ii = 0; ii < 4; ++ii){
+#ifdef HAVE_KOKKOSKERNELS_MKL
+  algorithms.push_back(SPGEMM_MKL);
+#endif
 
-    SPGEMMAlgorithm spgemm_algorithm = algorithms[ii];
-
+  for (auto spgemm_algorithm : algorithms)
+  {
     const uint64_t max_integer = 2147483647;
     std::string algo = "UNKNOWN";
     bool is_expected_to_fail = false;
@@ -310,9 +306,6 @@ void test_spgemm(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_v
 
     case SPGEMM_MKL:
       algo = "SPGEMM_MKL";
-#if !defined(HAVE_KOKKOSKERNELS_MKL) && !defined(KOKKOSKERNELS_ENABLE_TPL_MKL)
-      is_expected_to_fail = true;
-#endif
       //MKL requires scalar to be either float or double
       if (!(std::is_same<float,scalar_t>::value || std::is_same<double,scalar_t>::value)){
         is_expected_to_fail = true;
@@ -342,7 +335,7 @@ void test_spgemm(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_v
       algo = "SPGEMM_KK_MEMORY";
       break;
     default:
-      break;
+      algo = "!!! UNKNOWN ALGO !!!";
     }
 
     Kokkos::Impl::Timer timer1;
@@ -456,6 +449,7 @@ void test_issue402()
 #define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE) \
 TEST_F( TestCategory, sparse ## _ ## spgemm ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
   test_spgemm<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 30, 500, 10); \
+  test_spgemm<SCALAR,ORDINAL,OFFSET,DEVICE>(0, 0, 10, 10); \
   test_issue402<SCALAR,ORDINAL,OFFSET,DEVICE>(); \
 }
 


### PR DESCRIPTION
The behavior fixes were to define the the average and maximum nonzeros per row for a zero-row matrix to be zero, not INT_MIN.

Added SPGEMM unit test for zero row case that would have caught this.

This is a high priority issue affecting EMPIRE.

Bowman spot checks passed. RIDE spot checks failed due to #598 - this affects develop branch and isn't related to these changes.

However, #598 won't affect Trilinos because shared memory alignment logic goes through a different path in order to work with ensemble scalar types. @ndellingwood and I are working on a permanent fix for that.