### PR TITLE
Fixed divide-by-zero with compression flops

### DIFF
--- a/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
@@ -960,16 +960,19 @@ bool KokkosSPGEMM
 
   		compressed_maxNumRoughZeros = this->getMaxRoughRowNNZ(a_row_cnt, row_mapA, entriesA, new_row_mapB_begin, new_row_mapB_end, compressed_flops_per_row.data());
   		KokkosKernels::Impl::kk_reduce_view2<row_lno_persistent_work_view_t, MyExecSpace>(a_row_cnt, compressed_flops_per_row, compressedoverall_flops);
+                double ratio = 0;
+                if(OriginaltotalFlops)
+                  ratio = compressedoverall_flops / ((double) OriginaltotalFlops);
   		if (KOKKOSKERNELS_VERBOSE){
   			std::cout << "\t\tCompressed Max Row Flops:" << compressed_maxNumRoughZeros  << std::endl;
   			std::cout << "\t\tCompressed Overall Row Flops:" << compressedoverall_flops  << std::endl;
-			std::cout << "\t\tCompressed Flops ratio:" << compressedoverall_flops / ((double) (OriginaltotalFlops)) <<  " min_reduction:" << min_reduction  << std::endl;
+			std::cout << "\t\tCompressed Flops ratio:" << ratio <<  " min_reduction:" << min_reduction  << std::endl;
   			std::cout << "\t\tCompressed Max Row Flop Calc Time:" << timer1_t.seconds()  << std::endl;
   		}
 
 		this->handle->get_spgemm_handle()->compressed_max_row_flops = compressed_maxNumRoughZeros;
 		this->handle->get_spgemm_handle()->compressed_overall_flops = compressedoverall_flops;
-    	if (compressedoverall_flops / ((double) (OriginaltotalFlops)) > min_reduction) {
+    	if (ratio > min_reduction) {
     		return false;
     	}
       }
@@ -1017,10 +1020,13 @@ bool KokkosSPGEMM
 
 	  compressed_maxNumRoughZeros = this->getMaxRoughRowNNZ(a_row_cnt, row_mapA, entriesA, new_row_mapB_begin, new_row_mapB_end, compressed_flops_per_row.data());
 	  KokkosKernels::Impl::kk_reduce_view2<row_lno_persistent_work_view_t, MyExecSpace>(a_row_cnt, compressed_flops_per_row, compressedoverall_flops);
+          double ratio = 0;
+          if(OriginaltotalFlops)
+            ratio = compressedoverall_flops / ((double) OriginaltotalFlops);
 	  if (KOKKOSKERNELS_VERBOSE){
 		  std::cout << "\t\tCompressed Max Row Flops:" << compressed_maxNumRoughZeros  << std::endl;
 		  std::cout << "\t\tCompressed Overall Row Flops:" << compressedoverall_flops  << std::endl;
-		  std::cout << "\t\tCompressed Flops ratio:" << compressedoverall_flops / ((double) (OriginaltotalFlops)) <<  " min_reduction:" << min_reduction  << std::endl;
+		  std::cout << "\t\tCompressed Flops ratio:" << ratio <<  " min_reduction:" << min_reduction  << std::endl;
 
 
 		  std::cout << "\t\tCompressed Max Row Flop Calc Time:" << timer1_t.seconds()  << std::endl;
@@ -1028,7 +1034,7 @@ bool KokkosSPGEMM
 
 	  this->handle->get_spgemm_handle()->compressed_max_row_flops = compressed_maxNumRoughZeros;
 	  this->handle->get_spgemm_handle()->compressed_overall_flops = compressedoverall_flops;
-	  if (compressedoverall_flops / ((double) (OriginaltotalFlops)) > min_reduction) {
+	  if (ratio > min_reduction) {
 		  return false;
 	  }
   }


### PR DESCRIPTION
Mirror of https://github.com/trilinos/Trilinos/pull/6780

Bowman
#######################################################
PASSED TESTS
#######################################################
intel-16.4.258-Pthread-release build_time=738 run_time=1060
intel-16.4.258-Pthread_Serial-release build_time=1065 run_time=1982
intel-16.4.258-Serial-release build_time=716 run_time=937
intel-17.2.174-OpenMP-release build_time=889 run_time=563
intel-17.2.174-OpenMP_Serial-release build_time=1236 run_time=1468
intel-17.2.174-Pthread-release build_time=820 run_time=885
intel-17.2.174-Pthread_Serial-release build_time=1126 run_time=1810
intel-17.2.174-Serial-release build_time=783 run_time=895

RIDE
#######################################################
PASSED TESTS
#######################################################
cuda-10.1.105-Cuda_OpenMP-release build_time=286 run_time=193
cuda-10.1.105-Cuda_Serial-release build_time=305 run_time=243
cuda-9.2.88-Cuda_OpenMP-release build_time=319 run_time=197
cuda-9.2.88-Cuda_Serial-release build_time=295 run_time=248
gcc-6.4.0-OpenMP_Serial-release build_time=112 run_time=164
gcc-7.2.0-OpenMP-release build_time=84 run_time=56
gcc-7.2.0-OpenMP_Serial-release build_time=123 run_time=162
gcc-7.2.0-Serial-release build_time=78 run_time=103
ibm-16.1.0-Serial-release build_time=372 run_time=115