### PR TITLE
Permanent fix for scalar memory alignment for hashmaps

### DIFF
--- a/src/common/KokkosKernels_Utils.hpp
+++ b/src/common/KokkosKernels_Utils.hpp
@@ -1935,6 +1935,16 @@ struct array_sum_reduce
   }
 };
 
+template<typename InPtr, typename T>
+KOKKOS_INLINE_FUNCTION T* alignPtr(InPtr p)
+{
+  //ugly but computationally free and the "right" way to do this in C++
+  std::uintptr_t ptrVal = reinterpret_cast<std::uintptr_t>(p);
+  //ptrVal + (align - 1) lands inside the next valid aligned scalar_t,
+  //and the mask produces the start of that scalar_t.
+  return reinterpret_cast<T*>((ptrVal + alignof(T) - 1) & (~(alignof(T) - 1)));
+}
+
 }
 }
 

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
@@ -168,8 +168,10 @@ struct KokkosSPGEMM
 
     while (team_cuckoo_key_size * 2 < tmp_team_cuckoo_key_size) team_cuckoo_key_size = team_cuckoo_key_size * 2;
     team_cuckoo_hash_func = team_cuckoo_key_size - 1;
-    team_shmem_key_size = ((shared_memory_size - sizeof(nnz_lno_t) * 4) / unit_memory);
-    thread_shmem_key_size = ((thread_memory - sizeof(nnz_lno_t) * 4) / unit_memory);
+    //How many extra bytes are needed to align a scalar_t after an array of nnz_lno_t, in the worst case?
+    constexpr size_t scalarAlignPad = (alignof(scalar_t) > alignof(nnz_lno_t)) ? (alignof(scalar_t) - alignof(nnz_lno_t)) : 0;
+    team_shmem_key_size = ((shared_memory_size - sizeof(nnz_lno_t) * 4 - scalarAlignPad) / unit_memory);
+    thread_shmem_key_size = ((thread_memory - sizeof(nnz_lno_t) * 4 - scalarAlignPad) / unit_memory);
     if (KOKKOSKERNELS_VERBOSE_){
       std::cout << "\t\tPortableNumericCHASH -- sizeof(scalar_t): " << sizeof(scalar_t) << "  sizeof(nnz_lno_t): " << sizeof(nnz_lno_t) << "  suggested_team_size: " << suggested_team_size << std::endl;
       std::cout << "\t\tPortableNumericCHASH -- thread_memory:" << thread_memory  << " unit_memory:" << unit_memory <<" initial key size:" << thread_shmem_key_size << std::endl;
@@ -194,87 +196,6 @@ struct KokkosSPGEMM
       std::cout << "\t\tPortableNumericCHASH -- team shared_memory:" << shared_memory_size  << " unit_memory:" << unit_memory <<" resized team key size:" << team_shmem_key_size << std::endl;
     }
 
-// This guard will help ensure behavior is consistent within Trilinos
-#ifdef KOKKOS_ENABLE_COMPLEX_ALIGN
-    {
-    // GPUTag
-    // shmem allocation will be partitioned as below for hash map accumulator
-    // thread_memory == 2*sizeof(nnz_lno_t)+2*sizeof(nnz_lno_t) + thread_shmem_hash_size*sizeof(nnz_lno_t) + 2*thread_shmem_key_size*sizeof(nnz_lno_t) + rem_size*sizeof(scalar_t)
-    // if memory for vals is unaligned, adjust thread_shmem_key_size until alignment is achieved
-    nnz_lno_t remainder_memory = thread_memory - sizeof(nnz_lno_t)*4 - thread_shmem_hash_size*sizeof(nnz_lno_t);
-    // val_memory must be aligned into sizeof(scalar_t) chunks, and there must be at least as many entries as keys
-    nnz_lno_t val_memory = remainder_memory - 2*thread_shmem_key_size*sizeof(nnz_lno_t);
-
-    nnz_lno_t val_unalign_mem = val_memory % alignof(scalar_t);
-    if (val_unalign_mem > 0) {
-      // Redistributing between thread_shmem_key_size and vals involves exchange of 2 "keys" (key+next) per val
-      nnz_lno_t realign_chunk_mem = 2 * sizeof(nnz_lno_t);
-
-      bool is_align_possible = (val_unalign_mem % realign_chunk_mem) == 0;
-      if(!is_align_possible)
-      {
-        std::cout << "PortableNumericCHASH: GPUTag shmem align impossible." << std::endl;
-        if (KOKKOSKERNELS_VERBOSE_){
-          std::cout << "    remainder_memory: " << remainder_memory << "  val_memory: " << val_memory << "  val_unalign_mem: " << val_unalign_mem << "  realign_chunk_mem: " << realign_chunk_mem << std::endl;
-        }
-      }
-
-      nnz_lno_t realign_chunks = val_unalign_mem / realign_chunk_mem;
-
-      thread_shmem_key_size -= realign_chunks;
-      val_memory = remainder_memory - 2*thread_shmem_key_size*sizeof(nnz_lno_t);
-      val_unalign_mem = val_memory%alignof(scalar_t);
-    }
-
-    if (val_unalign_mem > 0 || thread_shmem_key_size <= 0) {
-      std::cout << "PortableNumericCHASH Ctor Warning: shared memory realignment failed. Modify your shared memory request" << std::endl;
-      if (KOKKOSKERNELS_VERBOSE_){
-        std::cout << "GPUTag   alignment fail.  remainder_memory: " << remainder_memory << "  val_memory: " << val_memory << "  val_unalign_mem: " << val_unalign_mem << std::endl;
-        std::cout << "GPUTag   alignment fail.  thread_shmem_key_size: " << thread_shmem_key_size << std::endl;
-      }
-    }
-
-    // GPUTag4, GPUTag6
-    // shmem allocation will be partitioned as below for hash map accumulator
-    // shmem == sizeof(nnz_lno_t)*2 + sizeof(nnz_lno_t)*team_cuckoo_key_size + sizeof(scalar_t)*rem_size
-
-    // if memory for vals is unaligned, adjust team_cuckoo_key_size until alignment is achieved
-    remainder_memory = shared_memory_size - sizeof(nnz_lno_t)*2;
-    // val_memory must be aligned into sizeof(scalar_t) chunks, and there must be at least as many entries as keys
-    val_memory = remainder_memory - team_cuckoo_key_size*sizeof(nnz_lno_t);
-
-    val_unalign_mem = val_memory % alignof(scalar_t);
-    if (val_unalign_mem > 0) {
-      // Redistributing between team_cuckoo_key_size and vals involves exchange of 1 key per val
-      nnz_lno_t realign_chunk_mem = sizeof(nnz_lno_t);
-
-      bool is_align_possible = (val_unalign_mem % realign_chunk_mem) == 0;
-      if(!is_align_possible)
-      {
-        std::cout << "PortableNumericCHASH GPUTag4,6 shmem alignment impossible." << std::endl;
-        if (KOKKOSKERNELS_VERBOSE_){
-          std::cout << "    remainder_memory: " << remainder_memory << "  val_memory: " << val_memory << "  val_unalign_mem: " << val_unalign_mem << "  realign_chunk_mem: " << realign_chunk_mem << std::endl;
-        }
-      }
-
-      nnz_lno_t realign_chunks = val_unalign_mem / realign_chunk_mem;
-
-      team_cuckoo_key_size -= realign_chunks;
-      val_memory = remainder_memory - team_cuckoo_key_size*sizeof(nnz_lno_t);
-      val_unalign_mem = val_memory%alignof(scalar_t);
-    }
-
-    if (val_unalign_mem > 0 || team_cuckoo_key_size <= 0) {
-      std::cout << "PortableNumericCHASH Ctor Warning: GPUTag4,6 shared memory realignment failed. Modify your shared memory request" << std::endl;
-      if (KOKKOSKERNELS_VERBOSE_){
-        std::cout << "PortableNumericCHASH GPUTag4,6  alignment fail.  remainder_memory: " << remainder_memory << "  val_memory: " << val_memory << "  val_unalign_mem: " << val_unalign_mem << std::endl;
-        std::cout << "GPUTag4,6  alignment fail.  team_cuckoo_key_size: " << team_cuckoo_key_size << std::endl;
-      }
-    }
-
-    }
-#endif
-
     max_first_level_hash_size = first_level_cut_off * team_cuckoo_key_size;
     if (KOKKOSKERNELS_VERBOSE_){
       std::cout << "\t\tPortableNumericCHASH -- thread_memory:" << thread_memory  << " unit_memory:" << unit_memory <<" initial key size:" << thread_shmem_key_size << std::endl;
@@ -284,6 +205,16 @@ struct KokkosSPGEMM
       std::cout << "\t\t  team_cuckoo_key_size:" << team_cuckoo_key_size << " team_cuckoo_hash_func:" << team_cuckoo_hash_func << " max_first_level_hash_size:" << max_first_level_hash_size << std::endl;
       std::cout << "\t\t  pow2_hash_size:" << pow2_hash_size << " pow2_hash_func:" << pow2_hash_func << std::endl;
     }
+  }
+
+  template<typename InPtr, typename T>
+  KOKKOS_FORCEINLINE_FUNCTION static T* alignPtr(InPtr p)
+  {
+    //ugly but computationally free and the "right" way to do this in C++
+    std::uintptr_t ptrVal = reinterpret_cast<std::uintptr_t>(p);
+    //ptrVal + (align - 1) lands inside the next valid aligned scalar_t,
+    //and the mask produces the start of that scalar_t.
+    return (T*) ((ptrVal + alignof(T) - 1) & (~(alignof(T) - 1)));
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -340,7 +271,7 @@ struct KokkosSPGEMM
     tmp += max_nnz;
     nnz_lno_t *hash_ids = (nnz_lno_t *) (tmp);
     tmp += pow2_hash_size;
-    scalar_t *hash_values = (scalar_t *) (tmp);
+    scalar_t *hash_values = alignPtr<volatile nnz_lno_t*, scalar_t>(tmp);
 
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end), [&] (const nnz_lno_t& row_index) {
@@ -426,10 +357,6 @@ struct KokkosSPGEMM
       hm2.keys = pEntriesC + c_row_begin;
       hm2.values = pvaluesC + c_row_begin;
 
-
-
-
-
       const size_type col_begin = row_mapA[row_index];
       const nnz_lno_t left_work = row_mapA[row_index + 1] - col_begin;
 
@@ -492,7 +419,7 @@ struct KokkosSPGEMM
 
     hm2.keys = (nnz_lno_t *) (tmp);
     tmp += max_nnz;
-    hm2.values = (scalar_t *) (tmp);
+    hm2.values = alignPtr<volatile nnz_lno_t*, scalar_t>(tmp);
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end), [&] (const nnz_lno_t& row_index) {
       nnz_lno_t globally_used_hash_count = 0;
@@ -578,7 +505,7 @@ struct KokkosSPGEMM
     nnz_lno_t * keys = (nnz_lno_t *) (all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * thread_shmem_key_size;
     // remainder of shmem allocation for vals
-    scalar_t * vals = (scalar_t *) (all_shared_memory);
+    scalar_t * vals = alignPtr<char*, scalar_t>(all_shared_memory);
 
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t>
     hm(thread_shmem_hash_size, thread_shmem_key_size, begins, nexts, keys, vals);
@@ -719,7 +646,7 @@ struct KokkosSPGEMM
     //holds the keys
     nnz_lno_t * keys = (nnz_lno_t *) (all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * team_cuckoo_key_size;
-    scalar_t * vals = (scalar_t *) (all_shared_memory);
+    scalar_t * vals = alignPtr<char*, scalar_t>(all_shared_memory);
 
     int thread_rank =  teamMember.team_rank();
 
@@ -758,7 +685,7 @@ struct KokkosSPGEMM
     			  }, tmp);
     		  }
     		  global_acc_row_keys = (nnz_lno_t *) (tmp);
-    		  global_acc_row_vals = (scalar_t *) (tmp + pow2_hash_size);
+    		  global_acc_row_vals = alignPtr<volatile nnz_lno_t*, scalar_t>(tmp + pow2_hash_size);
     	  }
           //initialize begins.
           {
@@ -1025,7 +952,7 @@ struct KokkosSPGEMM
     //holds the keys
     nnz_lno_t * keys = (nnz_lno_t *) (all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * team_cuckoo_key_size;
-    scalar_t * vals = (scalar_t *) (all_shared_memory);
+    scalar_t * vals = alignPtr<char*, scalar_t>(all_shared_memory);
 
     int thread_rank =  teamMember.team_rank();
 
@@ -1307,13 +1234,17 @@ void
 	  tmp_max_nnz *= hash_scaler;
   }
 
+  //How many extra bytes are needed to align a scalar_t after an array of nnz_lno_t, in the worst case?
+  //Incurred once per hashmap, which may be per team or per thread depending on algorithm
+  constexpr size_t scalarAlignPad = (alignof(scalar_t) > alignof(nnz_lno_t)) ? (alignof(scalar_t) - alignof(nnz_lno_t)) : 0;
 
   //START OF SHARED MEMORY SIZE CALCULATIONS
   // NOTE: the values computed here are not actually passed to functors requiring shmem,
   // the calculations here are used for algorithm selection
   nnz_lno_t unit_memory = sizeof(nnz_lno_t) * 2 + sizeof(nnz_lno_t) + sizeof(scalar_t);
-  nnz_lno_t team_shmem_key_size = ((shmem_size_to_use - sizeof(nnz_lno_t) * 4) / unit_memory);
-  nnz_lno_t thread_memory = (shmem_size_to_use /8 / suggested_team_size) * 8;
+  nnz_lno_t team_shmem_key_size = ((shmem_size_to_use - sizeof(nnz_lno_t) * 4 - scalarAlignPad) / unit_memory);
+  // alignment padding is per-thread for algorithms with per-thread hashmap
+  nnz_lno_t thread_memory = ((shmem_size_to_use / suggested_team_size - scalarAlignPad) / 8) * 8;
 
 
   nnz_lno_t thread_shmem_key_size = ((thread_memory - sizeof(nnz_lno_t) * 4) / unit_memory);
@@ -1358,7 +1289,7 @@ void
 					  while (thread_shmem_hash_size * 2 <=  thread_shmem_key_size){
 						  thread_shmem_hash_size = thread_shmem_hash_size * 2;
 					  }
-					  thread_shmem_key_size = thread_shmem_key_size + ((thread_shmem_key_size - thread_shmem_hash_size) * sizeof(nnz_lno_t)) / (sizeof (nnz_lno_t) * 2 + sizeof(scalar_t));
+					  thread_shmem_key_size = thread_shmem_key_size + ((thread_shmem_key_size - thread_shmem_hash_size) * sizeof(nnz_lno_t) - scalarAlignPad) / (sizeof (nnz_lno_t) * 2 + sizeof(scalar_t));
 					  thread_shmem_key_size = (thread_shmem_key_size >> 1) << 1;
 				  }
 
@@ -1367,7 +1298,7 @@ void
 			  }
 		  }
 		  else {
-			  nnz_lno_t tmp_team_cuckoo_key_size = ((shmem_size_to_use - sizeof(nnz_lno_t) * 2) / (sizeof(nnz_lno_t) + sizeof(scalar_t )));
+			  nnz_lno_t tmp_team_cuckoo_key_size = ((shmem_size_to_use - sizeof(nnz_lno_t) * 2 - scalarAlignPad) / (sizeof(nnz_lno_t) + sizeof(scalar_t )));
 			  int team_cuckoo_key_size = 1;
 			  while (team_cuckoo_key_size * 2 < tmp_team_cuckoo_key_size) team_cuckoo_key_size = team_cuckoo_key_size * 2;
 			  suggested_vector_size = 32;
@@ -1375,7 +1306,7 @@ void
 			  algorithm_to_run = SPGEMM_KK_MEMORY_BIGSPREADTEAM;
 			  while (average_row_nnz < team_cuckoo_key_size / 2 * (KOKKOSKERNELS_MACRO_MIN (first_level_cut_off + 0.05, 1))){
 				  shmem_size_to_use = shmem_size_to_use / 2;
-				  tmp_team_cuckoo_key_size = ((shmem_size_to_use - sizeof(nnz_lno_t) * 2) / (sizeof(nnz_lno_t) + sizeof(scalar_t )));
+				  tmp_team_cuckoo_key_size = ((shmem_size_to_use - sizeof(nnz_lno_t) * 2 - scalarAlignPad) / (sizeof(nnz_lno_t) + sizeof(scalar_t )));
 				  team_cuckoo_key_size = 1;
 				  while (team_cuckoo_key_size * 2 < tmp_team_cuckoo_key_size) team_cuckoo_key_size = team_cuckoo_key_size * 2;
 
@@ -1384,7 +1315,7 @@ void
 			  if (average_row_flops > size_t(2) * suggested_team_size * suggested_vector_size &&
 					  average_row_nnz > size_type (team_cuckoo_key_size) * (KOKKOSKERNELS_MACRO_MIN (first_level_cut_off + 0.05, 1))){
 				  shmem_size_to_use = shmem_size_to_use * 2;
-				  tmp_team_cuckoo_key_size = ((shmem_size_to_use - sizeof(nnz_lno_t) * 2) / (sizeof(nnz_lno_t) + sizeof(scalar_t )));
+				  tmp_team_cuckoo_key_size = ((shmem_size_to_use - sizeof(nnz_lno_t) * 2 - scalarAlignPad) / (sizeof(nnz_lno_t) + sizeof(scalar_t )));
 				  team_cuckoo_key_size = 1;
 				  while (team_cuckoo_key_size * 2 < tmp_team_cuckoo_key_size) team_cuckoo_key_size = team_cuckoo_key_size * 2;
 				  suggested_team_size = suggested_team_size *2;
@@ -1432,7 +1363,7 @@ void
 			  size_t kkmem_chunksize = tmp_min_hash_size ; //this is for used hash indices
 			  kkmem_chunksize += tmp_min_hash_size ; //this is for the hash begins
 			  kkmem_chunksize += max_nnz ; //this is for hash nexts
-			  kkmem_chunksize = kkmem_chunksize * sizeof (nnz_lno_t);
+			  kkmem_chunksize = kkmem_chunksize * sizeof (nnz_lno_t) + scalarAlignPad;
 			  size_t dense_chunksize = (col_size + col_size / sizeof(scalar_t) + 1) * sizeof(scalar_t);
 
 
@@ -1493,6 +1424,7 @@ void
 	  }
 	  chunksize = min_hash_size; //this is for used hash keys
 	  chunksize += max_nnz; //this is for used hash keys
+	  chunksize += scalarAlignPad;  //for padding betwen keys and values
 	  chunksize += min_hash_size * sizeof(scalar_t) / sizeof(nnz_lno_t) ; //this is for the hash values
   }
   else if (algorithm_to_run == SPGEMM_KK_MEMORY_BIGSPREADTEAM){
@@ -1500,6 +1432,7 @@ void
 	      min_hash_size *= 2;  //try to keep it as low as possible because hashes are not tracked.
  	  }
 	  chunksize = min_hash_size; //this is for used hash keys
+          chunksize += scalarAlignPad;  //for padding between keys and values
 	  chunksize += min_hash_size * sizeof(scalar_t) / sizeof(nnz_lno_t) ; //this is for the hash values
   }
   else{

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
@@ -41,6 +41,8 @@
 //@HEADER
 */
 
+#include "KokkosKernels_Utils.hpp"
+
 namespace KokkosSparse{
 
 namespace Impl{
@@ -302,7 +304,8 @@ struct KokkosSPGEMM
         thread_memory((shared_memory_size /8 / suggested_team_size_) * 8),
         shmem_key_size(), shared_memory_hash_func(), shmem_hash_size(1)
         {
-          shmem_key_size = ((thread_memory - sizeof(nnz_lno_t) * 2) / unit_memory);
+          constexpr size_t scalarAlignPad = (alignof(scalar_t) > alignof(nnz_lno_t)) ? (alignof(scalar_t) - alignof(nnz_lno_t)) : 0;
+          shmem_key_size = ((thread_memory - sizeof(nnz_lno_t) * 2 - scalarAlignPad) / unit_memory);
           if (KOKKOSKERNELS_VERBOSE_){
             std::cout << "\t\tNumericCMEM -- thread_memory:" << thread_memory  << " unit_memory:" << unit_memory <<
                 " initial key size:" << shmem_key_size << std::endl;
@@ -314,46 +317,6 @@ struct KokkosSPGEMM
 
           shmem_key_size = shmem_key_size + ((shmem_key_size - shmem_hash_size) * sizeof(nnz_lno_t)) / (sizeof (nnz_lno_t) * 2 + sizeof(scalar_t));
           shmem_key_size = (shmem_key_size >> 1) << 1;
-
-// This guard will help ensure behavior is consistent within Trilinos
-#ifdef KOKKOS_ENABLE_COMPLEX_ALIGN
-          {
-          // GPUTag
-          // shmem allocation will be partitioned as below for hash map accumulator
-          // thread_memory == 2*sizeof(nnz_lno_t) + shmem_hash_size*sizeof(nnz_lno_t) + 2*shmem_key_size*sizeof(nnz_lno_t) + rem_size*sizeof(scalar_t)
-
-          // check that memory is partitioned into aligned chunks
-          nnz_lno_t remainder_memory = thread_memory - sizeof(nnz_lno_t)*2 - shmem_hash_size*sizeof(nnz_lno_t);
-
-          // The remainder of memory for vals must be aligned into sizeof(scalar_t) chunks, and there must be at least as many entries as keys
-          nnz_lno_t val_memory = remainder_memory - 2*shmem_key_size*sizeof(nnz_lno_t);
-
-          nnz_lno_t val_unalign_mem = val_memory % alignof(scalar_t);
-          if (val_unalign_mem > 0) {
-            // Redistributing between shmem_key_size and vals involves exchange of 2 "keys" (key+next) per val
-            nnz_lno_t realign_chunk_mem = 2 * sizeof(nnz_lno_t);
-
-            bool is_align_possible = (val_unalign_mem % realign_chunk_mem) == 0;
-            if(!is_align_possible)
-            {
-              //throw std::runtime_error("NumericCMEM Ctor Error: unable to align memory for shared memory allocations. Modify your shared memory request");
-              std::cout << "NumericCMEM Ctor WARNING: unable to align memory for shared memory allocations. Modify your shared memory request" << std::endl;
-            }
-
-            nnz_lno_t realign_chunks = val_unalign_mem / realign_chunk_mem; 
-
-            shmem_key_size -= realign_chunks;
-            val_memory = remainder_memory - 2*shmem_key_size*sizeof(nnz_lno_t);
-            val_unalign_mem = val_memory%alignof(scalar_t);
-          }
-
-          if (val_unalign_mem > 0) {
-            //throw std::runtime_error("NumericCMEM Ctor Error: shared memory realignment failed. Modify your shared memory request");
-            std::cout << "NumericCMEM Ctor WARNING: shared memory realignment failed. Modify your shared memory request" << std::endl;
-          }
-
-          }
-#endif
 
           if (KOKKOSKERNELS_VERBOSE_){
             std::cout << "\t\tNumericCMEM -- adjusted hashsize:" << shmem_hash_size  << " shmem_key_size:" << shmem_key_size << std::endl;
@@ -388,8 +351,7 @@ struct KokkosSPGEMM
     //holds the keys
     nnz_lno_t * keys = (nnz_lno_t *) (all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * shmem_key_size;
-    scalar_t * vals = (scalar_t *) (all_shared_memory);
-
+    scalar_t* vals = KokkosKernels::Impl::alignPtr<char*, scalar_t>(all_shared_memory);
 
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t>
     hm(shmem_hash_size, shmem_key_size, begins, nexts, keys, vals);


### PR DESCRIPTION
Explicitly align scalar_t pointers in hashmaps.
Account for the few extra bytes of padding (in practice, up to 4)
in every calculation of shared memory and pool chunk size.

@ndellingwood If you're OK with the changes I'll build and run Stokhos unit tests to make sure ensemble types work. Complex had 16-byte alignment for these tests (``KOKKOS_ENABLE_COMPLEX_ALIGN`` is on) so alignPtr is doing the correct thing here.

RIDE spot checks (double,complex_double)
#######################################################
PASSED TESTS
#######################################################
cuda-10.1.105-Cuda_OpenMP-release build_time=507 run_time=414
cuda-10.1.105-Cuda_Serial-release build_time=543 run_time=521
cuda-9.2.88-Cuda_OpenMP-release build_time=556 run_time=422
cuda-9.2.88-Cuda_Serial-release build_time=472 run_time=525
gcc-6.4.0-OpenMP_Serial-release build_time=227 run_time=386
gcc-7.2.0-OpenMP-release build_time=120 run_time=129
gcc-7.2.0-OpenMP_Serial-release build_time=191 run_time=362
gcc-7.2.0-Serial-release build_time=116 run_time=228
ibm-16.1.0-Serial-release build_time=490 run_time=395

Bowman spot checks (double, complex_double)
#######################################################
PASSED TESTS
#######################################################
intel-16.4.258-Pthread-release build_time=737 run_time=1030
intel-16.4.258-Pthread_Serial-release build_time=1092 run_time=2022
intel-16.4.258-Serial-release build_time=717 run_time=941
intel-17.2.174-OpenMP-release build_time=883 run_time=566
intel-17.2.174-OpenMP_Serial-release build_time=1261 run_time=1466
intel-17.2.174-Pthread-release build_time=805 run_time=928
intel-17.2.174-Pthread_Serial-release build_time=1142 run_time=1806
intel-17.2.174-Serial-release build_time=785 run_time=911