### PR TITLE
Small clean-up in spgemm and sptrsv for clang 7 cuda build with tpls

### DIFF
--- a/src/sparse/KokkosSparse_spgemm_handle.hpp
+++ b/src/sparse/KokkosSparse_spgemm_handle.hpp
@@ -243,9 +243,6 @@ private:
   int mkl_sort_option;
   bool calculate_read_write_cost;
 
-#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
-  SPGEMMcuSparseHandleType *cuSPARSEHandle;
-#endif
   public:
 
   std::string coloring_input_file;
@@ -299,6 +296,14 @@ private:
   int get_mkl_sort_option(){
     return this->mkl_sort_option;
   }
+
+#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+  private:
+  SPGEMMcuSparseHandleType *cuSPARSEHandle;
+
+  public:
+#endif
+
   void set_c_column_indices(nnz_lno_temp_work_view_t c_col_indices_){
     this->c_column_indices = c_col_indices_;
   }

--- a/src/sparse/impl/KokkosSparse_spgemm_cuSPARSE_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_cuSPARSE_impl.hpp
@@ -81,7 +81,6 @@ namespace Impl{
     typedef typename ain_nonzero_index_view_type::device_type device2;
 
     typedef typename KernelHandle::nnz_lno_t idx;
-    typedef typename ain_row_index_view_type::non_const_type idx_array_type;
 
 
     //TODO this is not correct, check memory space.
@@ -187,7 +186,6 @@ namespace Impl{
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
     typedef typename KernelHandle::nnz_lno_t idx;
-    typedef ain_row_index_view_type idx_array_type;
 
     typedef typename KernelHandle::nnz_scalar_t value_type;
 

--- a/src/sparse/impl/KokkosSparse_sptrsv_cuSPARSE_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_sptrsv_cuSPARSE_impl.hpp
@@ -213,7 +213,6 @@ namespace Impl{
   typedef typename KernelHandle::scalar_t  scalar_type;
 
   if (std::is_same<idx_type, int>::value) {
-    bool is_lower = sptrsv_handle->is_lower_tri();
 
     cusparseStatus_t status;
 


### PR DESCRIPTION
This allows us to update the `cm_sandia_test_all` script to test tpls on kokkos-dev with the cuda-clang build.