### PR TITLE
Fixed D2 resolveConflictsSerial() memory safety (#634)

### DIFF
--- a/src/graph/impl/KokkosGraph_Distance2Color_impl.hpp
+++ b/src/graph/impl/KokkosGraph_Distance2Color_impl.hpp
@@ -1286,33 +1286,21 @@ class GraphColorDistance2
                                 nnz_lno_temp_work_view_t current_vertexList_,
                                 size_type                current_vertexListLength_)
     {
-        color_type*  forbidden = new color_type[ _nv ];
+        //At any given time, forbidden[c] = the most recent vertex seen for which color c is forbidden.
+        nnz_lno_type* forbidden = new nnz_lno_type[_nv];
+        for(nnz_lno_type i = 0; i < _nv; i++)
+          forbidden[i] = _nv;
         nnz_lno_type vid       = 0;
-        nnz_lno_type end       = _nv;
 
-        typename nnz_lno_temp_work_view_t::HostMirror h_recolor_list;
+        auto h_recolor_list = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), current_vertexList_);
+        auto h_colors = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), vertex_colors_);
 
-        end            = current_vertexListLength_;
-        h_recolor_list = Kokkos::create_mirror_view(current_vertexList_);
-        Kokkos::deep_copy(h_recolor_list, current_vertexList_);
+        auto h_idx = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), xadj_);
+        auto h_adj = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), adj_);
+        auto h_t_idx = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), t_xadj_);
+        auto h_t_adj = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), t_adj_);
 
-        auto h_colors = Kokkos::create_mirror_view(vertex_colors_);
-
-        auto h_idx = Kokkos::create_mirror_view(xadj_);
-        auto h_adj = Kokkos::create_mirror_view(adj_);
-
-        auto h_t_idx = Kokkos::create_mirror_view(t_xadj_);
-        auto h_t_adj = Kokkos::create_mirror_view(t_adj_);
-
-        Kokkos::deep_copy(h_colors, vertex_colors_);
-
-        Kokkos::deep_copy(h_idx, xadj_);
-        Kokkos::deep_copy(h_adj, adj_);
-
-        Kokkos::deep_copy(h_t_idx, t_xadj_);
-        Kokkos::deep_copy(h_t_adj, t_adj_);
-
-        for(nnz_lno_type k = 0; k < end; k++)
+        for(nnz_lno_type k = 0; k < nnz_lno_type(current_vertexListLength_); k++)
         {
             vid = h_recolor_list(k);
 


### PR DESCRIPTION
Raw malloc'd buffer "forbidden" was read in this loop:
``while(forbidden[c] == v) c++;``

but forbidden was not initialized. If it happened to be filled with 0,
then when coloring the first vertex this loop would read past the end
of the array. This caused random crashes (#634 is an example).

kokkos-dev2:
#######################################################
PASSED TESTS
#######################################################
clang-8.0-Pthread_Serial-release build_time=89 run_time=371
cuda-10.1-Cuda_OpenMP-release build_time=274 run_time=525
gcc-7.3.0-OpenMP-release build_time=83 run_time=119
gcc-7.3.0-Pthread-release build_time=65 run_time=239
gcc-8.3.0-Serial-release build_time=64 run_time=182
gcc-9.1-OpenMP-release build_time=72 run_time=114
gcc-9.1-Serial-release build_time=65 run_time=178
intel-18.0.5-OpenMP-release build_time=168 run_time=123
#######################################################
FAILED TESTS
#######################################################
clang-8.0-Cuda_OpenMP-release (test failed)

The clang test failed because of this, which is definitely not related to changes in distance-2 coloring.
I can also look into why this failed.
```
1: [ RUN      ] cuda.team_dot_complex_double
1: terminate called after throwing an instance of 'std::runtime_error'
1:   what():  cudaFuncGetAttributes( &attr, cuda_parallel_launch_local_memory<DriverType>) error( cudaErrorMisalignedAddress): misaligned address /home/bmkelle/Fix634-testing-1583347507/Testing/TestAll_2020-03-04_10.45.18/clang/8.0/Cuda_OpenMP-release/kokkos-install/include/Cuda/Kokkos_Cuda_KernelLaunch.hpp:440
1: Traceback functionality not available
1:
1/8 Test #1: blas_cuda ........................***Exception: Child aborted  3.48 sec
```

RIDE:
#######################################################
PASSED TESTS
#######################################################
cuda-10.1.105-Cuda_OpenMP-release build_time=553 run_time=416
cuda-10.1.105-Cuda_Serial-release build_time=568 run_time=516
cuda-9.2.88-Cuda_OpenMP-release build_time=521 run_time=421
cuda-9.2.88-Cuda_Serial-release build_time=505 run_time=519
gcc-6.4.0-OpenMP_Serial-release build_time=197 run_time=395
gcc-7.2.0-OpenMP-release build_time=126 run_time=129
gcc-7.2.0-OpenMP_Serial-release build_time=196 run_time=362
gcc-7.2.0-Serial-release build_time=117 run_time=226
ibm-16.1.0-Serial-release build_time=496 run_time=396
