### PR TITLE
KokkosSparse_spmv_struct_tuning: add lambda guard

### DIFF
--- a/perf_test/sparse/KokkosSparse_spmv_struct_tuning.cpp
+++ b/perf_test/sparse/KokkosSparse_spmv_struct_tuning.cpp
@@ -438,7 +438,7 @@ int main(int argc, char **argv)
     }
 
     if(compare_cusparse) {
-#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+#if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) && defined(KOKKOS_ENABLE_CUDA_LAMBDA)
       // The data needs to be reformatted for cusparse before launching the kernel.
       // Step one, extract raw data
       using graph_type = typename matrix_type::StaticCrsGraphType;


### PR DESCRIPTION
Kokkos does not enable lambdas by default when Cuda is enabled.
This test was using lambdas without proper guards, this PR adds guard.
Detected during tpl spot-check nightly testing.