### PR TITLE
Fix UVM errors (generally, missing fences) in several places

### DIFF
--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -900,8 +900,6 @@ setup_env() {
     else
       export KOKKOS_CUDA_OPTIONS="${KOKKOS_CUDA_OPTIONS},force_uvm"
     fi
-    export CUDA_LAUNCH_BLOCKING=1
-    export CUDA_MANAGED_FORCE_DEVICE_ALLOC=1
     echo "cuda/9.2 + UVM Check KOKKOS_CUDA_OPTIONS: $KOKKOS_CUDA_OPTIONS"
   fi
 

--- a/src/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
@@ -374,7 +374,6 @@ void iluk_numeric ( IlukHandle& thandle,
   using size_type       = typename IlukHandle::size_type;
   using nnz_lno_t       = typename IlukHandle::nnz_lno_t;
   using HandleDeviceEntriesType = typename IlukHandle::nnz_lno_view_t;
-  using HandleHostEntriesType   = typename IlukHandle::nnz_lno_view_t::HostMirror;
 
   size_type nlevels = thandle.get_num_levels();
   size_type nrows   = thandle.get_nrows();

--- a/src/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
@@ -2548,6 +2548,7 @@ cudaProfilerStop();
   auto nodes_per_level = thandle.get_nodes_per_level();
   auto hnodes_per_level = thandle.get_host_nodes_per_level();
   auto nodes_grouped_by_level = thandle.get_nodes_grouped_by_level();
+  auto nodes_grouped_by_level_host = thandle.get_host_nodes_grouped_by_level();
 
 #if defined(KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV)
   using namespace KokkosSparse::Experimental;
@@ -2559,11 +2560,10 @@ cudaProfilerStop();
 
   const scalar_t zero (0.0);
   const scalar_t one (1.0);
-
-  auto nodes_grouped_by_level_host = Kokkos::create_mirror_view (nodes_grouped_by_level);
   Kokkos::deep_copy (nodes_grouped_by_level_host, nodes_grouped_by_level);
 
-  auto row_map_host = Kokkos::create_mirror_view (row_map);
+  Kokkos::View<size_type*, Kokkos::HostSpace> row_map_host(
+      Kokkos::ViewAllocateWithoutInitializing("host rowmap"), row_map.extent(0));
   Kokkos::deep_copy (row_map_host, row_map);
 
   // inversion options
@@ -2827,10 +2827,11 @@ cudaProfilerStop();
   const scalar_t zero (0.0);
   const scalar_t one (1.0);
 
-  auto nodes_grouped_by_level_host = Kokkos::create_mirror_view (nodes_grouped_by_level);
+  auto nodes_grouped_by_level_host = thandle.get_host_nodes_grouped_by_level();
   Kokkos::deep_copy (nodes_grouped_by_level_host, nodes_grouped_by_level);
 
-  auto row_map_host = Kokkos::create_mirror_view (row_map);
+  Kokkos::View<size_type*, Kokkos::HostSpace> row_map_host(
+      Kokkos::ViewAllocateWithoutInitializing("host rowmap"), row_map.extent(0));
   Kokkos::deep_copy (row_map_host, row_map);
 
   // supernode sizes
@@ -2928,7 +2929,6 @@ cudaProfilerStart();
             scalar_t *dataU = const_cast<scalar_t*> (values.data ());
 
             for (int league_rank = 0; league_rank < lvl_nodes; league_rank++) {
-
               auto s = nodes_grouped_by_level_host (node_count + league_rank);
 
               // supernodal column size
@@ -3007,7 +3007,6 @@ cudaProfilerStart();
             scalar_t *dataU = const_cast<scalar_t*> (values.data ());
 
             for (int league_rank = 0; league_rank < lvl_nodes; league_rank++) {
-
               auto s = nodes_grouped_by_level_host (node_count + league_rank);
 
               // supernodal column size

--- a/src/sparse/impl/KokkosSparse_sptrsv_symbolic_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_sptrsv_symbolic_impl.hpp
@@ -143,7 +143,7 @@ void symbolic_chain_phase(TriSolveHandle &thandle, const NPLViewType &nodes_per_
     // Two updates required - should only occur if chainlinks_length > 0
     // We have found two things: a non-one length chain, and a subsequent one length chain
     if (chain_state == 2) {
-      if (chainlinks_length == 0) { std::runtime_error("MAJOR LOGIC ERROR! TERMINATE!"); }
+      if (chainlinks_length == 0) { throw(std::runtime_error("MAJOR LOGIC ERROR! TERMINATE!")); }
 
       num_chain_entries += 1;
       h_chain_ptr(num_chain_entries) = h_chain_ptr(num_chain_entries-1) + chainlinks_length;
@@ -253,7 +253,7 @@ void lower_tri_symbolic (TriSolveHandle &thandle, const RowMapType drow_map, con
           }
           else if ( col > row ) {
             std::cout << "\nrow = " << row << "  col = " << col << "  offset = " << offset << std::endl;
-            std::runtime_error("SYMB ERROR: Lower tri with colid > rowid - SHOULD NOT HAPPEN!!!");
+            throw(std::runtime_error("SYMB ERROR: Lower tri with colid > rowid - SHOULD NOT HAPPEN!!!"));
           }
         } // end for offset , i.e. cols of this row
 

--- a/test_common/Test_Common_Sorting.hpp
+++ b/test_common/Test_Common_Sorting.hpp
@@ -228,25 +228,26 @@ void testSerialRadixSort(size_t k, size_t subArraySize)
   OrdView offsets("Subarray Offsets", k);
   //Generate k sub-array sizes, each with size about 20
   size_t n = generateRandomOffsets<OrdView, ExecSpace>(counts, offsets, k, subArraySize);
-  auto countsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), counts);
-  auto offsetsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), offsets);
   KeyView keys("Radix sort testing data", n);
   fillRandom(keys);
   //Sort using std::sort on host to do correctness test
   Kokkos::View<Key*, Kokkos::HostSpace> gold("Host sorted", n);
   Kokkos::deep_copy(gold, keys);
+  KeyView keysAux("Radix sort aux data", n);
+  //Run the sorting on device in all sub-arrays in parallel
+  typedef Kokkos::RangePolicy<ExecSpace> range_policy;
+  Kokkos::parallel_for(range_policy(0, k),
+        TestSerialRadixFunctor<KeyView, OrdView>(keys, keysAux, counts, offsets));
+  ExecSpace().fence();
+  auto countsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), counts);
+  auto offsetsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), offsets);
   for(size_t i = 0; i < k; i++)
   {
     Key* begin = gold.data() + offsetsHost(i);
     Key* end = begin + countsHost(i);
     std::sort(begin, end);
   }
-  KeyView keysAux("Radix sort aux data", n);
-  //Run the sorting on device in all sub-arrays in parallel
-  typedef Kokkos::RangePolicy<ExecSpace> range_policy;
-  Kokkos::parallel_for(range_policy(0, k),
-        TestSerialRadixFunctor<KeyView, OrdView>(keys, keysAux, counts, offsets));
-  //Copy result to host
+  //Copy actual result to host and compare
   auto keysHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), keys);
   for(size_t i = 0; i < n; i++)
   {
@@ -266,12 +267,12 @@ void testSerialRadixSort2(size_t k, size_t subArraySize)
   OrdView offsets("Subarray Offsets", k);
   //Generate k sub-array sizes, each with size about 20
   size_t n = generateRandomOffsets<OrdView, ExecSpace>(counts, offsets, k, subArraySize);
-  auto countsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), counts);
-  auto offsetsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), offsets);
   KeyView keys("Radix test keys", n);
   ValView data("Radix test data", n);
   //The keys are randomized
   fillRandom(keys, data);
+  Kokkos::View<Key*, Kokkos::HostSpace> gold("Host sorted", n);
+  Kokkos::deep_copy(gold, keys);
   KeyView keysAux("Radix sort aux keys", n);
   ValView dataAux("Radix sort aux data", n);
   //Run the sorting on device in all sub-arrays in parallel
@@ -279,9 +280,10 @@ void testSerialRadixSort2(size_t k, size_t subArraySize)
   //Deliberately using a weird number for vector length
   Kokkos::parallel_for(range_policy(0, k),
         TestSerialRadix2Functor<KeyView, ValView, OrdView>(keys, keysAux, data, dataAux, counts, offsets));
+  ExecSpace().fence();
   //Sort using std::sort on host to do correctness test
-  Kokkos::View<Key*, Kokkos::HostSpace> gold("Host sorted", n);
-  Kokkos::deep_copy(gold, keys);
+  auto countsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), counts);
+  auto offsetsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), offsets);
   for(size_t i = 0; i < k; i++)
   {
     Key* begin = gold.data() + offsetsHost(i);
@@ -359,10 +361,10 @@ void testTeamBitonicSort(size_t k, size_t subArraySize)
   OrdView offsets("Subarray Offsets", k);
   //Generate k sub-array sizes, each with size about 20
   size_t n = generateRandomOffsets<OrdView, ExecSpace>(counts, offsets, k, subArraySize);
-  auto countsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), counts);
-  auto offsetsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), offsets);
   ValView data("Bitonic sort testing data", n);
   fillRandom(data);
+  Kokkos::View<Scalar*, Kokkos::HostSpace> gold("Host sorted", n);
+  Kokkos::deep_copy(gold, data);
   //Run the sorting on device in all sub-arrays in parallel
   Kokkos::parallel_for(Kokkos::TeamPolicy<ExecSpace>(k, Kokkos::AUTO()),
       TestTeamBitonicFunctor<ValView, OrdView>(data, counts, offsets));
@@ -370,8 +372,9 @@ void testTeamBitonicSort(size_t k, size_t subArraySize)
   auto dataHost = Kokkos::create_mirror_view(data);
   Kokkos::deep_copy(dataHost, data);
   //Sort using std::sort on host to do correctness test
-  Kokkos::View<Scalar*, Kokkos::HostSpace> gold("Host sorted", n);
-  Kokkos::deep_copy(gold, data);
+  ExecSpace().fence();
+  auto countsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), counts);
+  auto offsetsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), offsets);
   for(size_t i = 0; i < k; i++)
   {
     Scalar* begin = gold.data() + offsetsHost(i);
@@ -396,19 +399,20 @@ void testTeamBitonicSort2(size_t k, size_t subArraySize)
   OrdView offsets("Subarray Offsets", k);
   //Generate k sub-array sizes, each with size about 20
   size_t n = generateRandomOffsets<OrdView, ExecSpace>(counts, offsets, k, subArraySize);
-  auto countsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), counts);
-  auto offsetsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), offsets);
   KeyView keys("Bitonic test keys", n);
   ValView data("Bitonic test data", n);
   //The keys are randomized
   fillRandom(keys, data);
+  Kokkos::View<Key*, Kokkos::HostSpace> gold("Host sorted", n);
+  Kokkos::deep_copy(gold, keys);
   //Run the sorting on device in all sub-arrays in parallel, just using vector loops
   //Deliberately using a weird number for vector length
   Kokkos::parallel_for(Kokkos::TeamPolicy<ExecSpace>(k, Kokkos::AUTO()),
       TestTeamBitonic2Functor<KeyView, ValView, OrdView>(keys, data, counts, offsets));
+  ExecSpace().fence();
+  auto countsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), counts);
+  auto offsetsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), offsets);
   //Sort using std::sort on host to do correctness test
-  Kokkos::View<Key*, Kokkos::HostSpace> gold("Host sorted", n);
-  Kokkos::deep_copy(gold, keys);
   for(size_t i = 0; i < k; i++)
   {
     Key* begin = gold.data() + offsetsHost(i);

--- a/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
@@ -423,6 +423,7 @@ void test_sequential_sor(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t ro
   const scalar_t zero = Kokkos::Details::ArithTraits<scalar_t>::zero();
   const scalar_t one = Kokkos::Details::ArithTraits<scalar_t>::one();
   srand(245);
+  typedef typename device::execution_space exec_space;
   typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type> crsMat_t;
   lno_t numCols = numRows;
   crsMat_t input_mat = KokkosKernels::Impl::kk_generate_diagonally_dominant_sparse_matrix<crsMat_t>(numRows,numCols,nnz,row_size_variance, bandwidth);
@@ -443,6 +444,7 @@ void test_sequential_sor(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t ro
   vector_t xgold("X gold", numRows);
   Kokkos::deep_copy(xgold, x);
   vector_t y = Test::create_y_vector(input_mat, x);
+  exec_space().fence();
   auto y_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), y);
   //initial solution is zero
   Kokkos::deep_copy(x_host, zero);


### PR DESCRIPTION
Also removing CUDA_LAUNCH_BLOCKING and CUDA_MANAGED_FORCE_DEVICE_ALLOC environment variables from the cm_test_all_sandia builds where UVM is enabled as the default space for Cuda device.

This fixes #636.

To avoid fencing inside a loop, in SPTRSV and SPILUK I replaced some host mirrors with HostSpace views. The weird thing about this case was, I believe that some small UVM views were placed on the same page, so when one view was accessed on device, the other view also became inaccessible on host without a fence. This is why a fence would have been required each iteration.

kokkos-dev2 spot check (the one failure is due to #645):
#######################################################
PASSED TESTS
#######################################################
clang-8.0-Pthread_Serial-release build_time=83 run_time=378
cuda-10.1-Cuda_OpenMP-release build_time=322 run_time=354
cuda-9.2-Cuda_Serial-release build_time=279 run_time=481
gcc-7.3.0-OpenMP-release build_time=70 run_time=123
gcc-7.3.0-Pthread-release build_time=56 run_time=192
gcc-8.3.0-Serial-release build_time=59 run_time=180
gcc-9.1-OpenMP-release build_time=72 run_time=127
gcc-9.1-Serial-release build_time=76 run_time=178
intel-18.0.5-OpenMP-release build_time=171 run_time=121
#######################################################
FAILED TESTS
#######################################################
clang-8.0-Cuda_OpenMP-release (test failed)

RIDE spot check (the CUDA 9.2 builds have force_uvm, and are testing without CUDA_LAUNCH_BLOCKING=1)
PASSED TESTS
#######################################################
cuda-10.1.105-Cuda_OpenMP-release build_time=578 run_time=415
cuda-10.1.105-Cuda_Serial-release build_time=549 run_time=516
cuda-9.2.88-Cuda_OpenMP-release build_time=492 run_time=556
cuda-9.2.88-Cuda_Serial-release build_time=547 run_time=648
gcc-6.4.0-OpenMP_Serial-release build_time=201 run_time=393
gcc-7.2.0-OpenMP-release build_time=123 run_time=129
gcc-7.2.0-OpenMP_Serial-release build_time=204 run_time=360
gcc-7.2.0-Serial-release build_time=110 run_time=226
ibm-16.1.0-Serial-release build_time=495 run_time=387
