### PR TITLE
Fixed block row formula in block GS test (Fix #648)

### DIFF
--- a/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
@@ -95,7 +95,6 @@ int run_block_gauss_seidel_1(
   typedef KokkosKernelsHandle
       <size_type,lno_t, scalar_t,
       typename device::execution_space, typename device::memory_space,typename device::memory_space > KernelHandle;
-
   KernelHandle kh;
   kh.set_team_work_size(16);
   kh.set_shmem_size(shmem_size);
@@ -188,13 +187,16 @@ void test_block_gauss_seidel_rank1(lno_t numRows, size_type nnz, lno_t bandwidth
   typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;
 
   lno_t numCols = numRows;
+
+  //Intentionally testing block_size that's not a multiple of #rows.
+  lno_t block_size = 7;
+
   crsMat_t crsmat = KokkosKernels::Impl::kk_generate_diagonally_dominant_sparse_matrix<crsMat_t>(numRows,numCols,nnz,row_size_variance, bandwidth);
 
   lno_view_t pf_rm;
   lno_nnz_view_t pf_e;
   scalar_view_t pf_v;
   size_t out_r, out_c;
-  int block_size = 7;
 
   //this makes consecutive 5 rows to have same columns.
   //it will add scalar 0's for those entries that does not exists.
@@ -221,7 +223,7 @@ void test_block_gauss_seidel_rank1(lno_t numRows, size_type nnz, lno_t bandwidth
   graph_t static_graph (bf_e, bf_rm);
   crsMat_t input_mat("CrsMatrix", but_c, bf_v, static_graph);
 
-  lno_t nv = ((crsmat2.numRows() / block_size)+1) * block_size;
+  lno_t nv = ((crsmat2.numRows() + block_size - 1) / block_size) * block_size;
 
   const scalar_view_t solution_x(Kokkos::ViewAllocateWithoutInitializing("X"), nv);
   //create_x_vector operates on host mirror, then copies to device. But create_y does everything on device.
@@ -291,13 +293,16 @@ void test_block_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth
   typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;
 
   lno_t numCols = numRows;
+
+  //Intentionally testing block_size that's not a multiple of #rows.
+  lno_t block_size = 7;
+
   crsMat_t crsmat = KokkosKernels::Impl::kk_generate_diagonally_dominant_sparse_matrix<crsMat_t>(numRows,numCols,nnz,row_size_variance, bandwidth);
 
   lno_view_t pf_rm;
   lno_nnz_view_t pf_e;
   scalar_view_t pf_v;
   size_t out_r, out_c;
-  int block_size = 7;
 
   //this makes consecutive 5 rows to have same columns.
   //it will add scalar 0's for those entries that does not exists.
@@ -324,7 +329,7 @@ void test_block_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth
   graph_t static_graph (bf_e, bf_rm);
   crsMat_t input_mat("CrsMatrix", but_c, bf_v, static_graph);
 
-  lno_t nv = ((crsmat2.numRows() / block_size)+1) * block_size;
+  lno_t nv = ((crsmat2.numRows() + block_size - 1) / block_size) * block_size;
 
   //how many columns X/Y have
   constexpr lno_t numVecs = 2;


### PR DESCRIPTION
(an example of #478, which is incorrect integer division with rounding up)

This caused the X vector to have the wrong length. I replicated #648 locally and checked that this fixed it.

RIDE:
#######################################################
PASSED TESTS
#######################################################
cuda-10.1.105-Cuda_OpenMP-release build_time=541 run_time=398
cuda-10.1.105-Cuda_Serial-release build_time=551 run_time=508
cuda-9.2.88-Cuda_OpenMP-release build_time=531 run_time=545
cuda-9.2.88-Cuda_Serial-release build_time=571 run_time=647
gcc-6.4.0-OpenMP_Serial-release build_time=207 run_time=382
gcc-7.2.0-OpenMP-release build_time=130 run_time=126
gcc-7.2.0-OpenMP_Serial-release build_time=183 run_time=356
gcc-7.2.0-Serial-release build_time=122 run_time=226
ibm-16.1.0-Serial-release build_time=504 run_time=392

Kokkos-dev2 (only failure is due to #645 )
#######################################################
PASSED TESTS
#######################################################
clang-8.0-Pthread_Serial-release build_time=86 run_time=370
cuda-10.1-Cuda_OpenMP-release build_time=272 run_time=318
cuda-9.2-Cuda_Serial-release build_time=264 run_time=428
gcc-7.3.0-OpenMP-release build_time=60 run_time=117
gcc-7.3.0-Pthread-release build_time=58 run_time=186
gcc-8.3.0-Serial-release build_time=59 run_time=177
gcc-9.1-OpenMP-release build_time=72 run_time=109
gcc-9.1-Serial-release build_time=65 run_time=175
intel-18.0.5-OpenMP-release build_time=169 run_time=121
#######################################################
FAILED TESTS
#######################################################
clang-8.0-Cuda_OpenMP-release (test failed)