### PR TITLE
trtri patch

### DIFF
--- a/src/impl/tpls/KokkosBlas_trtri_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosBlas_trtri_tpl_spec_avail.hpp
@@ -61,7 +61,7 @@ struct trtri_tpl_spec_avail< \
      Kokkos::View<int, LAYOUTA, Kokkos::HostSpace, \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      Kokkos::View<const SCALAR**, LAYOUTA, Kokkos::Device<ExecSpace, MEMSPACE>, \
-                  Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+                  Kokkos::MemoryTraits<Kokkos::Unmanaged> > \
      >  { enum : bool { value = true }; };
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_BLAS


### PR DESCRIPTION
@ndellingwood: Thank you for the detailed bug report!

This patch fixes the `gcc/5.3 OpenMP Build`. Would you check that it fixes the `clang/7+cuda/9.2 Cuda_OpenMP Build` as well?