### PR TITLE
Kokkos-Kernels: Add fence for dot

### DIFF
--- a/src/blas/KokkosBlas1_dot.hpp
+++ b/src/blas/KokkosBlas1_dot.hpp
@@ -244,6 +244,7 @@ dot (const RV& R, const XMV& X, const YMV& Y,
   YMV_Internal Y_internal = Y;
 
   Impl::Dot<RV_Internal, XMV_Internal, YMV_Internal>::dot(R_internal, X_internal, Y_internal);
+  Kokkos::fence();
 }
 }
 


### PR DESCRIPTION
@ndellingwood @brian-kelley We have a similar fence in this file for the other Impl::Dot so I think we want this one too. This will resolve the Tpetra test TpetraCore_idot to work with CUDA_LAUNCH_BLOCKING off.