### PR TITLE
Fix #665 (Graph's device type inside CrsMatrix)

### DIFF
--- a/src/sparse/KokkosSparse_CrsMatrix.hpp
+++ b/src/sparse/KokkosSparse_CrsMatrix.hpp
@@ -408,14 +408,14 @@ public:
   typedef CrsMatrix<ScalarType, OrdinalType, host_mirror_space, MemoryTraits> HostMirror;
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   //! Type of the graph structure of the sparse matrix.
-  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, execution_space, size_type, memory_traits> StaticCrsGraphType;
+  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, device_type, size_type, memory_traits> StaticCrsGraphType;
   //! Type of the graph structure of the sparse matrix - consistent with Kokkos.
-  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, execution_space, size_type, memory_traits> staticcrsgraph_type;
+  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, device_type, size_type, memory_traits> staticcrsgraph_type;
 #else
   //! Type of the graph structure of the sparse matrix.
-  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, execution_space, memory_traits, size_type> StaticCrsGraphType;
+  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, device_type, memory_traits, size_type> StaticCrsGraphType;
   //! Type of the graph structure of the sparse matrix - consistent with Kokkos.
-  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, execution_space, memory_traits, size_type> staticcrsgraph_type;
+  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, device_type, memory_traits, size_type> staticcrsgraph_type;
 #endif
   //! Type of column indices in the sparse matrix.
   typedef typename staticcrsgraph_type::entries_type index_type;


### PR DESCRIPTION
Replace "execution_space" with "device_t" for the StaticCrsGraph typedef inside CrsMatrix. This is important for when the device type uses a different memory space than the default for the exec space (which Tpetra will want to do with CudaSpace soon).

kokkos-dev2:
#######################################################
PASSED TESTS
#######################################################
clang-8.0-Pthread_Serial-release build_time=68 run_time=373
cuda-10.1-Cuda_OpenMP-release build_time=246 run_time=325
cuda-9.2-Cuda_Serial-release build_time=309 run_time=435
gcc-7.3.0-OpenMP-release build_time=54 run_time=374
gcc-7.3.0-Pthread-release build_time=58 run_time=203
gcc-8.3.0-Serial-release build_time=54 run_time=193
gcc-9.1-OpenMP-release build_time=78 run_time=195
gcc-9.1-Serial-release build_time=74 run_time=193
intel-18.0.5-OpenMP-release build_time=164 run_time=209
#######################################################
FAILED TESTS
#######################################################
clang-8.0-Cuda_OpenMP-release (test failed) (#645)
#######################################################

RIDE:
#######################################################
PASSED TESTS
#######################################################
cuda-10.1.105-Cuda_OpenMP-release build_time=474 run_time=413
cuda-10.1.105-Cuda_Serial-release build_time=475 run_time=517
cuda-9.2.88-Cuda_OpenMP-release build_time=465 run_time=547
cuda-9.2.88-Cuda_Serial-release build_time=448 run_time=662
gcc-6.4.0-OpenMP_Serial-release build_time=156 run_time=387
gcc-7.2.0-OpenMP-release build_time=96 run_time=129
gcc-7.2.0-OpenMP_Serial-release build_time=162 run_time=361
gcc-7.2.0-Serial-release build_time=100 run_time=226
ibm-16.1.0-Serial-release build_time=496 run_time=397
