### PR TITLE
Initial testing infrastructure for Spack

### DIFF
--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -15,6 +15,10 @@ print_help() {
   echo "--kokkos-path=/Path/To/Kokkos: Path to the Kokkos root directory"
   echo "    Defaults to KokkosKernelsPath/../kokkos"
   echo ""
+  echo "--kokkoskernels-branch=<Branch>: Branch to test. Only relevant for Spack builds."
+  echo "    No default. Spack otherwise does dev-build from source."
+  echo "--spack: Run spack builds rather than direct CMake tests"
+  echo ""
   echo "--debug: Run tests in debug. Defaults to False"
   echo "--test-script: Test this script, not Kokkos"
   echo "--skip-hwloc: Do not do hwloc tests"
@@ -172,6 +176,7 @@ DRYRUN=False
 BUILD_ONLY=False
 declare -i NUM_JOBS_TO_RUN_IN_PARALLEL=1
 TEST_SCRIPT=False
+TEST_SPACK=False
 SKIP_HWLOC=False
 SPOT_CHECK=False
 
@@ -183,6 +188,41 @@ KOKKOS_OPTIONS=""
 
 CXX_STANDARD="11"
 
+GCC_VARIANTS="+blas+lapack +openmp+serial<SPACK_HOST_ARCH>"
+CLANG_VARIANTS="+blas+lapack +openmp+serial<SPACK_HOST_ARCH>"
+CUDA_VARIANTS="+cusparse+cublas +cuda+cuda_lambda+wrapper<SPACK_CUDA_ARCH>+cuda_uvm"
+INTEL_VARIANTS="$GCC_VARIANTS"
+PGI_VARIANTS="$GCC_VARIANTS"
+SPACK_VARIANTS=("cuda 10.0 $CUDA_VARIANTS std=14"
+          "cuda 10.1  $CUDA_VARIANTS"
+          "cuda 9.2   $CUDA_VARIANTS"
+          "gcc 4.8.4  $GCC_VARIANTS"
+          "gcc 4.9.3  $GCC_VARIANTS"
+          "gcc 5.3.0  $GCC_VARIANTS"
+          "gcc 6.1.0  $GCC_VARIANTS"
+          "gcc 7.2.0  $GCC_VARIANTS std=14"
+          "gcc 7.3.0  $GCC_VARIANTS std=14"
+          "gcc 8.3.0  $GCC_VARIANTS std=14"
+          "gcc 9.1    $GCC_VARIANTS std=17"
+          "gcc 9.2.0  $GCC_VARIANTS std=17"
+          "intel 15.0.2 $INTEL_VARIANTS"
+          "intel 16.0.1 $INTEL_VARIANTS"
+          "intel 17.0.1 $INTEL_VARIANTS"
+          "intel 18.0.5 $INTEL_VARIANTS"
+          "intel 19.0.5 $INTEL_VARIANTS std=14"
+          "clang 3.6.1 $CLANG_VARIANTS"
+          "clang 3.7.1 $CLANG_VARIANTS"
+          "clang 3.8.1 $CLANG_VARIANTS"
+          "clang 3.9.0 $CLANG_VARIANTS"
+          "clang 5.0.1 $CLANG_VARIANTS"
+          "clang 7.0.1 $CLANG_VARIANTS"
+          "clang 8.0   $CLANG_VARIANTS std=14"
+          "clang 9.0.0 $CLANG_VARIANTS std=17"
+          "pgi 19.4    $PGI_VARIANTS"
+      )
+SPACK_HOST_ARCH=""
+SPACK_CUDA_ARCH=""
+SPACK_CUDA_HOST_COMPILER=""
 
 SPOT_CHECK_TPLS=False
 KOKKOSKERNELS_ENABLE_TPL_CMD=
@@ -216,6 +256,12 @@ do
       ;;
     --test-script*)
       TEST_SCRIPT=True
+      ;;
+    --spack*)
+      TEST_SPACK=True
+      ;;
+    --kokkoskernels-branch*)
+      KOKKOSKERNELS_BRANCH="${key#*=}"
       ;;
     --skip-hwloc*)
       SKIP_HWLOC=True
@@ -308,6 +354,7 @@ if [ -z "$KOKKOS_PATH" ]; then
 else
   # Ensure KOKKOS_PATH is abs path.
   KOKKOS_PATH=$( cd $KOKKOS_PATH && pwd )
+  SPACK_DEV_BUILD_KOKKOS=$KOKKOS_PATH
 fi
 
 
@@ -365,6 +412,8 @@ if [ "$MACHINE" = "sems" ]; then
                "cuda/9.2 $CUDA9_MODULE_LIST $CUDA_BUILD_LIST $KOKKOS_PATH/bin/nvcc_wrapper $CUDA_WARNING_FLAGS"
     )
   fi
+  SPACK_CUDA_ARCH="+maxwell50" #use an old one
+  SPACK_CUDA_HOST_COMPILER="%gcc@7.2.0"
 elif [ "$MACHINE" = "kokkos-dev" ]; then
   source /projects/sems/modulefiles/utils/sems-modules-init.sh
 
@@ -414,7 +463,8 @@ elif [ "$MACHINE" = "kokkos-dev" ]; then
                "cuda/9.2 $CUDA9_MODULE_LIST $CUDA_BUILD_LIST $KOKKOS_PATH/bin/nvcc_wrapper $CUDA_WARNING_FLAGS"
     )
   fi
-
+  SPACK_CUDA_ARCH="+kepler35"
+  SPACK_CUDA_HOST_COMPILER="%gcc@7.3.0"
 elif [ "$MACHINE" = "white" ]; then
   source /etc/profile.d/modules.sh
   SKIP_HWLOC=True
@@ -464,7 +514,9 @@ elif [ "$MACHINE" = "white" ]; then
   if [ -z "$ARCH_FLAG" ]; then
     ARCH_FLAG="--arch=Power8,Kepler37"
   fi
-
+  SPACK_HOST_ARCH="+power8"
+  SPACK_CUDA_ARCH="+kepler37"
+  SPACK_CUDA_HOST_COMPILER="%gcc@7.2.0"
 elif [ "$MACHINE" = "waterman" ]; then
   source /etc/profile.d/modules.sh
   SKIP_HWLOC=True
@@ -517,7 +569,8 @@ elif [ "$MACHINE" = "waterman" ]; then
     ARCH_FLAG="--arch=Power9,Volta70"
   fi
 
-
+  SPACK_HOST_ARCH="+power9"
+  SPACK_CUDA_ARCH="+volta70"
 elif [ "$MACHINE" = "bowman" ]; then
   source /etc/profile.d/modules.sh
   SKIP_HWLOC=True
@@ -535,7 +588,8 @@ elif [ "$MACHINE" = "bowman" ]; then
   if [ -z "$ARCH_FLAG" ]; then
     ARCH_FLAG="--arch=KNL"
   fi
-
+  SPACK_HOST_ARCH="+knl"
+  SPACK_CUDA_HOST_COMPILER="%gcc@7.2.0"
 elif [ "$MACHINE" = "mayer" ]; then
   SKIP_HWLOC=True
   export SLURM_TASKS_PER_NODE=96
@@ -553,6 +607,7 @@ elif [ "$MACHINE" = "mayer" ]; then
     ARCH_FLAG="--arch=ARMv8-TX2"
   fi
 
+  SPACK_HOST_ARCH="+armv8_tx2" 
 elif [ "$MACHINE" = "blake" ]; then
   source /etc/profile.d/modules.sh
   SKIP_HWLOC=True
@@ -595,7 +650,7 @@ elif [ "$MACHINE" = "blake" ]; then
   if [ -z "$ARCH_FLAG" ]; then
     ARCH_FLAG="--arch=SKX"
   fi
-
+  SPACK_HOST_ARCH="+skx"
 elif [ "$MACHINE" = "apollo" ]; then
   source /projects/sems/modulefiles/utils/sems-modules-init.sh
   module use /home/projects/modulefiles/local/x86-64
@@ -663,7 +718,9 @@ elif [ "$MACHINE" = "apollo" ]; then
   if [ -z "$ARCH_FLAG" ]; then
     ARCH_FLAG="--arch=SNB,Volta70"
   fi
-
+  SPACK_HOST_ARCH="+snb"
+  SPACK_CUDA_ARCH="+volta70" 
+  SPACK_CUDA_HOST_COMPILER="%gcc@6.1.0"
 elif [ "$MACHINE" = "kokkos-dev-2" ]; then
   source /projects/sems/modulefiles/utils/sems-modules-init.sh
   module use /home/projects/x86-64/modulefiles/local
@@ -746,7 +803,9 @@ elif [ "$MACHINE" = "kokkos-dev-2" ]; then
   if [ -z "$ARCH_FLAG" ]; then
     ARCH_FLAG="--arch=SNB,Volta70"
   fi
-
+  SPACK_HOST_ARCH="+snb"
+  SPACK_CUDA_ARCH="+volta70" 
+  SPACK_CUDA_HOST_COMPILER="%gcc@7.2.0"
 else
   echo "Unhandled machine $MACHINE" >&2
   exit 1
@@ -842,7 +901,6 @@ get_compiler_data() {
   local compiler_data
   for compiler_data in "${COMPILERS[@]}" ; do
     local arr=($compiler_data)
-
     if [ "$compiler" = "${arr[0]}" ]; then
       echo "${arr[$item]}" | tr , ' ' | sed -e "s/<COMPILER_NAME>/$compiler_name/g" -e "s/<COMPILER_VERSION>/$compiler_vers/g"
       return 0
@@ -850,7 +908,30 @@ get_compiler_data() {
   done
 
   # Not found.
-  echo "Unreconized compiler $compiler" >&2
+  echo "Unrecognized compiler $compiler" >&2
+  exit 1
+}
+
+get_variants_data() {
+  local compiler=$1
+  local item=$2
+
+  local variants_data
+  for variants_data in "${SPACK_VARIANTS[@]}" ; do
+    local arr=($variants_data)
+    matcher="${arr[0]}/${arr[1]}"
+    if [ "$compiler" = "$matcher" ]; then
+      if [ "$item" = 4 ]; then
+         echo "%${arr[0]}@${arr[1]}"
+      else
+         echo "${arr[$item]}"| tr , ' ' | sed -e "s/<SPACK_HOST_ARCH>/$SPACK_HOST_ARCH/g" -e "s/<SPACK_CUDA_ARCH>/$SPACK_CUDA_ARCH/g"
+      fi
+      return 0
+    fi
+  done
+
+  # Not found.
+  echo "Unrecognized compiler $compiler when looking for Spack variants" >&2
   exit 1
 }
 
@@ -872,6 +953,18 @@ get_compiler_exe_name() {
 
 get_compiler_warning_flags() {
   get_compiler_data $1 4
+}
+
+get_kernels_variants() {
+  get_variants_data $1 2
+}
+
+get_kokkos_variants() {
+  get_variants_data $1 3
+}
+
+get_compiler_variant() {
+  get_variants_data $1 4
 }
 
 run_cmd() {
@@ -998,6 +1091,33 @@ single_build_and_test() {
   mkdir -p $ROOT_DIR/$compiler/"${build}-$build_type"
   cd $ROOT_DIR/$compiler/"${build}-$build_type"
 
+  local kokkos_variants=$(get_kokkos_variants $compiler)
+  local kernels_variants=$(get_kernels_variants $compiler)
+  wrapper_spec=""
+  if [[ $kokkos_variants == *"wrapper"* ]]; then
+    #Don't build nvcc_wrapper to depend on MPI with Spack
+    wrapper_spec="^kokkos-nvcc-wrapper ~mpi"
+  fi
+  local compiler_variant=$(get_compiler_variant $compiler)
+  if [[ $compiler_variant == *"cuda"* ]]; then
+    #even though using nvcc, I need to tell spack
+    #to use a particular underlying host compiler
+    compiler_variant=$SPACK_CUDA_HOST_COMPILER
+  fi
+  if [ ! -z "$KOKKOSKERNELS_SCALARS" ]; then
+    kernels_variants="$kernels_variants scalars=$KOKKOSKERNELS_SCALARS"
+  fi
+  if [ ! -z "$KOKKOSKERNELS_LAYOUTS" ]; then
+    kernels_variants="$kernels_variants layouts=$KOKKOSKERNELS_LAYOUTS"
+  fi
+  if [ ! -z "$KOKKOSKERNELS_OFFSETS" ]; then
+    kernels_variants="$kernels_variants offsets=$KOKKOSKERNELS_OFFSETS"
+  fi
+  if [ ! -z "$KOKKOSKERNELS_ORDINALS" ]; then
+    kernels_variants="$kernels_variants ordinals=$KOKKOSKERNELS_ORDINALS"
+  fi
+
+
   echo "  #   Load modules:" &> reload_modules.sh
   echo "        module load $compiler_modules_list" &>> reload_modules.sh
   echo "" &>> reload_modules.sh
@@ -1051,6 +1171,17 @@ single_build_and_test() {
 
     if [ $rand -gt 5 ]; then
       run_cmd ls fake_problem >& ${desc}.configure.log || { report_and_log_test_result 1 $desc configure && return 0; }
+    fi
+  elif [ "$TEST_SPACK" = "True" ]; then
+    spack compiler find
+    if [ ! -z "$SPACK_DEV_BUILD_KOKKOS" ]; then
+      run_cmd spack dev-build -d $SPACK_DEV_BUILD_KOKKOS kokkos@develop $kokkos_variants $wrapper_spec $compiler_variant >& ${desc}.spack.log || { report_and_log_test_result 1 ${desc} spack && return 0; }
+    fi
+
+    if [ -z "$KOKKOSKERNELS_BRANCH" ]; then
+      run_cmd spack dev-build -d $KOKKOSKERNELS_PATH kokkos-kernels@develop $kernels_variants ^kokkos@develop $kokkos_variants $wrapper_spec $compiler_variant >& ${desc}.spack.log || { report_and_log_test_result 1 ${desc} spack && return 0; }
+    else
+      run_cmd spack install kokkos-kernels@$KOKKOSKERNELS_BRANCH $kernels_variants ^kokkos@develop $kokkos_variants $wrapper_spec $compiler_variant  >& ${desc}.spack.log|| { report_and_log_test_result 1 ${desc} spack && return 0; }
     fi
   else
     LOCAL_KOKKOS_DEVICES=${build//_/,}
@@ -1186,23 +1317,25 @@ wait_summarize_and_exit() {
       #local filename=reproducer_instructions-$comp-$vers-$lbuild
       local faildir=$ROOT_DIR/$comp/$vers/$lbuild
       # Output reproducer instructions
-      echo "#######################################################"
-      echo "  # Reproducer instructions:"
-      cat $faildir/reload_modules.sh
-      cat $faildir/call_generate_makefile.sh
-      echo ""
-      echo "  #  To reload modules, reconfigure, rebuild, and retest directly from this failing build do the following:"
-      echo "      # Move to the build directory"
-      echo "        cd $faildir"
-      echo "      # To reload modules"
-      echo "        source ./reload_modules.sh"
-      echo "      # To reconfigure"
-      echo "        ./call_generate_makefile.sh"
-      echo "      # To rebuild"
-      echo "        make -j"
-      echo "      # To retest"
-      echo "        ctest -V"
-      echo "#######################################################"
+      if [ $TEST_SPACK = "False" ]; then
+        echo "#######################################################"
+        echo "  # Reproducer instructions:"
+        cat $faildir/reload_modules.sh
+        cat $faildir/call_generate_makefile.sh
+        echo ""
+        echo "  #  To reload modules, reconfigure, rebuild, and retest directly from this failing build do the following:"
+        echo "      # Move to the build directory"
+        echo "        cd $faildir"
+        echo "      # To reload modules"
+        echo "        source ./reload_modules.sh"
+        echo "      # To reconfigure"
+        echo "        ./call_generate_makefile.sh"
+        echo "      # To rebuild"
+        echo "        make -j"
+        echo "      # To retest"
+        echo "        ctest -V"
+        echo "#######################################################"
+      fi
     done
   fi
 

--- a/scripts/spack/kokkos-dev-2.packages.yaml
+++ b/scripts/spack/kokkos-dev-2.packages.yaml
@@ -1,0 +1,18 @@
+packages:
+ cmake:
+  paths:
+   cmake: /projects/sems/install/rhel7-x86_64/sems/utility/cmake/3.12.2/bin/cmake 
+ cuda:
+  modules:
+   cuda@10.1: sems-cuda/10.1
+   cuda@9.2: sems-cuda/9.2
+ kokkos:
+  variants: +cuda +openmp +volta70 +cuda_lambda +wrapper std=14 ^cuda@10.1
+  compiler: [gcc@7.2.0]
+ openmpi:
+  paths:
+   openmpi@4.0.2: /projects/sems/install/rhel7-x86_64/sems/compiler/gcc/7.2.0/openmpi/4.0.2
+  modules:
+   openmpi@4.0.2: sems-openmpi/4.0.2
+
+   


### PR DESCRIPTION
This allows spack builds to be invoked instead of the usual tests.  Tests are invoked in exactly the same way except that the `--spack` option is given invokes Spack.