### PR TITLE
Fix Issue #678: kk_generate_diagonally_dominant_sparse_matrix

### DIFF
--- a/src/common/KokkosKernels_IOUtils.hpp
+++ b/src/common/KokkosKernels_IOUtils.hpp
@@ -180,8 +180,8 @@ void kk_diagonally_dominant_sparseMatrix_generate(
   {
     int varianz = (1.0*rand()/RAND_MAX-0.5)*row_size_variance;
     rowPtr[row+1] = rowPtr[row] + elements_per_row+varianz;
-    if(rowPtr[row+1] == rowPtr[row])   // This makes sure that
-      rowPtr[row+1]++;                 // there are no empty rows
+    if(rowPtr[row+1] <= rowPtr[row])   // This makes sure that there is
+      rowPtr[row+1] = rowPtr[row] + 1; // at least one nonzero in the row
   }
   nnz = rowPtr[nrows];
   values = new ScalarType[nnz];

--- a/src/common/KokkosKernels_IOUtils.hpp
+++ b/src/common/KokkosKernels_IOUtils.hpp
@@ -180,26 +180,45 @@ void kk_diagonally_dominant_sparseMatrix_generate(
   {
     int varianz = (1.0*rand()/RAND_MAX-0.5)*row_size_variance;
     rowPtr[row+1] = rowPtr[row] + elements_per_row+varianz;
+    if(rowPtr[row+1] == rowPtr[row])   // This makes sure that
+      rowPtr[row+1]++;                 // there are no empty rows
   }
   nnz = rowPtr[nrows];
   values = new ScalarType[nnz];
   colInd = new OrdinalType[nnz];
   const ScalarType temp = 10;
-  for(OrdinalType row=0;row<nrows;row++)
+  for(OrdinalType row=0; row<nrows; row++)
   {
     ScalarType total_values = 0;
-    for(SizeType k=rowPtr[row] ;k<rowPtr[row+1] - 1;k++)
+    for(SizeType k=rowPtr[row]; k<rowPtr[row+1]-1; k++)
     {
-      OrdinalType pos = row;
-      while (pos == row){
-        pos = ((1.0*rand())/RAND_MAX-0.5)*bandwidth+row;
-      }
-      if(pos<0) pos+=ncols;
+      while (true){
+        OrdinalType pos = (1.0*rand()/RAND_MAX-0.5)*bandwidth+row;
+        while(pos < 0)
+	  pos += ncols;
+        while(pos >= ncols)
+	  pos -= ncols;
 
-      if(pos>=ncols) pos-=ncols;
-      colInd[k]= pos;
-      values[k] = 100.0*rand()/RAND_MAX-50.0;
-      total_values += Kokkos::Details::ArithTraits<ScalarType>::abs(values[k]);
+        bool is_already_in_the_row = false;
+	if(pos == row)
+	  is_already_in_the_row = true;
+	else
+	{
+	  for(SizeType j = rowPtr[row] ; j<k ;j++){
+	    if (colInd[j] == pos){
+	      is_already_in_the_row = true;
+	      break;
+	    }
+	  }
+	}
+        if (!is_already_in_the_row) {
+
+          colInd[k]= pos;
+          values[k] = 100.0*rand()/RAND_MAX-50.0;
+	  total_values += Kokkos::Details::ArithTraits<ScalarType>::abs(values[k]);
+          break;
+        }
+      }
     }
 
     colInd[rowPtr[row+1] - 1]= row;


### PR DESCRIPTION
**Description:**

This PR fixes two problems with the diagonally-dominant matrices generated by the kk_generate_diagonally_dominant_sparse_matrix function. So the new function makes sure the following:

1. Each row has at least one nonzero entry. In the case there is exactly one nonzero entry, it is the diagonal entry. This makes sure all diagonal entries have nonzero values.

2. The entries in each row are unique, i.e., there are no duplicate entries.

**The respective issue:** 

https://github.com/kokkos/kokkos-kernels/issues/678

**Testing results:**

```
[sacer@white30 kokkos-kernels]$ scripts/cm_test_all_sandia --spot-check --arch=Power8,Pascal60
Running on machine: white
WARNING!! THE FOLLOWING CHANGES ARE UNCOMMITTED!! :
 M src/common/KokkosKernels_IOUtils.hpp

KokkosKernels Repository Status:  1be37e8aee0ddfee5ad5076f3a049c4c473f5665 Merge pull request #675 from iyamazaki/twostage-sgs

Kokkos Repository Status:  b5b7660af56d883ffc8892fa8a253ee257f38e26 Merge pull request #2800 from crtrott/fix-update-copyright-master


Going to test compilers:  gcc/6.4.0 gcc/7.2.0 ibm/16.1.0 cuda/9.2.88 cuda/10.1.105
Testing compiler gcc/6.4.0
Testing compiler gcc/7.2.0
Unrecognized compiler gcc/6.4.0 when looking for Spack variants
Unrecognized compiler gcc/6.4.0 when looking for Spack variants
Unrecognized compiler gcc/6.4.0 when looking for Spack variants
  Starting job gcc-6.4.0-OpenMP_Serial-release
kokkos options:
kokkos devices: OpenMP,Serial
kokkos cxx: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wignored-qualifiers -Wempty-body -Wclobbered -Wuninitialized
  PASSED gcc-6.4.0-OpenMP_Serial-release
  Starting job gcc-7.2.0-OpenMP-release
kokkos options:
kokkos devices: OpenMP
kokkos cxx: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wignored-qualifiers -Wempty-body -Wclobbered -Wuninitialized
  PASSED gcc-7.2.0-OpenMP-release
  Starting job gcc-7.2.0-Serial-release
kokkos options:
kokkos devices: Serial
kokkos cxx: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wignored-qualifiers -Wempty-body -Wclobbered -Wuninitialized
  PASSED gcc-7.2.0-Serial-release
Testing compiler ibm/16.1.0
  Starting job gcc-7.2.0-OpenMP_Serial-release
kokkos options:
kokkos devices: OpenMP,Serial
kokkos cxx: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wignored-qualifiers -Wempty-body -Wclobbered -Wuninitialized
  PASSED gcc-7.2.0-OpenMP_Serial-release
Testing compiler cuda/9.2.88
Unrecognized compiler ibm/16.1.0 when looking for Spack variants
Unrecognized compiler ibm/16.1.0 when looking for Spack variants
Unrecognized compiler ibm/16.1.0 when looking for Spack variants
  Starting job ibm-16.1.0-Serial-release
kokkos options:
kokkos devices: Serial
kokkos cxx: -O3 -Wall -Wshadow -pedantic -Wsign-compare -Wtype-limits -Wuninitialized
  PASSED ibm-16.1.0-Serial-release
Unrecognized compiler cuda/9.2.88 when looking for Spack variants
Unrecognized compiler cuda/9.2.88 when looking for Spack variants
Unrecognized compiler cuda/9.2.88 when looking for Spack variants
  Starting job cuda-9.2.88-Cuda_OpenMP-release
kokkos options:
kokkos devices: Cuda,OpenMP
kokkos cxx: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wuninitialized
  PASSED cuda-9.2.88-Cuda_OpenMP-release
Testing compiler cuda/10.1.105
Unrecognized compiler cuda/9.2.88 when looking for Spack variants
Unrecognized compiler cuda/9.2.88 when looking for Spack variants
Unrecognized compiler cuda/9.2.88 when looking for Spack variants
  Starting job cuda-9.2.88-Cuda_Serial-release
kokkos options:
kokkos devices: Cuda,Serial
kokkos cxx: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wuninitialized
  PASSED cuda-9.2.88-Cuda_Serial-release
Unrecognized compiler cuda/10.1.105 when looking for Spack variants
Unrecognized compiler cuda/10.1.105 when looking for Spack variants
Unrecognized compiler cuda/10.1.105 when looking for Spack variants
  Starting job cuda-10.1.105-Cuda_OpenMP-release
kokkos options:
kokkos devices: Cuda,OpenMP
kokkos cxx: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wuninitialized
  PASSED cuda-10.1.105-Cuda_OpenMP-release
Unrecognized compiler cuda/10.1.105 when looking for Spack variants
Unrecognized compiler cuda/10.1.105 when looking for Spack variants
Unrecognized compiler cuda/10.1.105 when looking for Spack variants
  Starting job cuda-10.1.105-Cuda_Serial-release
kokkos options:
kokkos devices: Cuda,Serial
kokkos cxx: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wuninitialized
  PASSED cuda-10.1.105-Cuda_Serial-release
#######################################################
PASSED TESTS
#######################################################
cuda-10.1.105-Cuda_OpenMP-release build_time=376 run_time=106
cuda-10.1.105-Cuda_Serial-release build_time=334 run_time=147
cuda-9.2.88-Cuda_OpenMP-release build_time=352 run_time=119
cuda-9.2.88-Cuda_Serial-release build_time=348 run_time=158
gcc-6.4.0-OpenMP_Serial-release build_time=120 run_time=129
gcc-7.2.0-OpenMP-release build_time=97 run_time=44
gcc-7.2.0-OpenMP_Serial-release build_time=128 run_time=127
gcc-7.2.0-Serial-release build_time=86 run_time=80
ibm-16.1.0-Serial-release build_time=611 run_time=88
```