### PR TITLE
Fix the problem in QR.

### DIFF
--- a/src/batched/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
+++ b/src/batched/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
@@ -86,8 +86,8 @@ namespace KokkosBatched {
         if (as0 == 1 || as1 == 1) { /// if mkl can be interfaced, use it 
           const auto matrix_layout = ( as1 == 1 ? LAPACK_ROW_MAJOR : LAPACK_COL_MAJOR );            
           LAPACKE_dgehrd(matrix_layout, m, 1, m, A, m, t);
-            
-          SerialCopyInternal::invoke(m, m, QZ, qzs0, qzs1);          
+
+          SerialSetIdentityInternal::invoke(m, QZ, qzs0, qzs1);          
           LAPACKE_dorghr(matrix_layout, m, 1, m, QZ, m, t);
         } else { /// for arbitrary strides, there is no choice to use tpls
           real_type *ww = w_now; w_now += m; wlen_now -= m;

--- a/src/batched/KokkosBatched_Vector_SIMD_Arith.hpp
+++ b/src/batched/KokkosBatched_Vector_SIMD_Arith.hpp
@@ -57,6 +57,7 @@ namespace KokkosBatched {
   KOKKOSKERNELS_SIMD_ARITH_RETURN_TYPE(T,l)
     operator + (const Vector<SIMD<T>,l> &a,  const Vector<SIMD<T>,l> &b) {
     Vector<SIMD<T>,l> r_val;
+    if (std::is_fundamental<T>::value) {
 #if defined( KOKKOS_ENABLE_PRAGMA_IVDEP )
 #pragma ivdep
 #endif
@@ -66,8 +67,12 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__) 
 #pragma omp simd
 #endif
-    for (int i=0;i<l;++i)
-      r_val[i] = a[i] + b[i];
+      for (int i=0;i<l;++i)
+        r_val[i] = a[i] + b[i];
+    } else {
+      for (int i=0;i<l;++i)
+        r_val[i] = a[i] + b[i];
+    }
     return r_val;
   }
     
@@ -273,6 +278,7 @@ namespace KokkosBatched {
   KOKKOSKERNELS_SIMD_ARITH_RETURN_TYPE(T,l)
     operator - (const Vector<SIMD<T>,l> &a, const Vector<SIMD<T>,l> &b) {
     Vector<SIMD<T>,l> r_val;
+    if (std::is_fundamental<T>::value) {
 #if defined( KOKKOS_ENABLE_PRAGMA_IVDEP )
 #pragma ivdep
 #endif
@@ -282,8 +288,12 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__) 
 #pragma omp simd
 #endif
-    for (int i=0;i<l;++i)
-      r_val[i] = a[i] - b[i];
+      for (int i=0;i<l;++i)
+        r_val[i] = a[i] - b[i];
+    } else {
+      for (int i=0;i<l;++i)
+        r_val[i] = a[i] - b[i];
+    }
     return r_val;
   }
 
@@ -336,6 +346,7 @@ namespace KokkosBatched {
   KOKKOSKERNELS_SIMD_ARITH_RETURN_TYPE(T,l)
     operator - (const Vector<SIMD<T>,l> &a) {
     Vector<SIMD<T>,l> r_val;
+    if (std::is_fundamental<T>::value) {
 #if defined( KOKKOS_ENABLE_PRAGMA_IVDEP )
 #pragma ivdep
 #endif
@@ -345,8 +356,12 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__) 
 #pragma omp simd
 #endif
-    for (int i=0;i<l;++i)
-      r_val[i] = -a[i];
+      for (int i=0;i<l;++i)
+        r_val[i] = -a[i];
+    } else {
+      for (int i=0;i<l;++i)
+        r_val[i] = -a[i];
+    }
     return r_val;
   }
 
@@ -533,6 +548,7 @@ namespace KokkosBatched {
   KOKKOSKERNELS_SIMD_ARITH_RETURN_TYPE(T,l)
     operator * (const Vector<SIMD<T>,l> &a, const Vector<SIMD<T>,l> &b) {
     Vector<SIMD<T>,l> r_val;
+    if (std::is_fundamental<T>::value) {
 #if defined( KOKKOS_ENABLE_PRAGMA_IVDEP )
 #pragma ivdep
 #endif
@@ -542,8 +558,12 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__) 
 #pragma omp simd
 #endif
-    for (int i=0;i<l;++i)
-      r_val[i] = a[i] * b[i];
+      for (int i=0;i<l;++i)
+        r_val[i] = a[i] * b[i];
+    } else {
+      for (int i=0;i<l;++i)
+        r_val[i] = a[i] * b[i];
+    }
     return r_val;
   }
 
@@ -818,6 +838,7 @@ namespace KokkosBatched {
   KOKKOSKERNELS_SIMD_ARITH_RETURN_TYPE(T,l)
     operator / (const Vector<SIMD<T>,l> &a, const Vector<SIMD<T>,l> &b) {
     Vector<SIMD<T>,l> r_val;
+    if (std::is_fundamental<T>::value) {
 #if defined( KOKKOS_ENABLE_PRAGMA_IVDEP )
 #pragma ivdep
 #endif
@@ -827,8 +848,12 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__) 
 #pragma omp simd
 #endif
-    for (int i=0;i<l;++i)
-      r_val[i] = a[i] / b[i];
+      for (int i=0;i<l;++i)
+        r_val[i] = a[i] / b[i];
+    } else {
+      for (int i=0;i<l;++i)
+        r_val[i] = a[i] / b[i];
+    }
     return r_val;
   }
 


### PR DESCRIPTION
As seen in #691 , it reports three failure cases. 

1) With TPL, the code goes into my test code. This part is work-in-progress and it is better not to be included in the test. Anyway, I fixed it. 

2) QR is failed. This turns out that some random matrices are badly conditioned and it exceed the error threshold. I made the random matrices diagonal dominant and evaluate the correctness element-wisely so that the error does not proportionally increase with the problem size.

3) Vectorization on kokkos complex. When testing odd number of vector size (e.g., 3), the aggressive vectorization with complex is failed. This is supposed to be failed as the vectorization does not care about the correctness but it issued a vector instruction. Somehow this passes the test so far and it pops up now. I remove the aggressive vectorization for non-built-in types i.e., complex. 

@ndellingwood This fix all the problems.