### PR TITLE
Intel 17 bug workaround, fix team QR random failure, fix several warnings

### DIFF
--- a/perf_test/sparse/KokkosSparse_spgemm.cpp
+++ b/perf_test/sparse/KokkosSparse_spgemm.cpp
@@ -50,12 +50,11 @@
 void print_options(){
   std::cerr << "Options\n" << std::endl;
 
-  std::cerr << "\t[Required] BACKEND: '--threads[numThreads]' | '--openmp [numThreads]' | '--cuda [cudaDeviceIndex]'" << std::endl;
-
   std::cerr << "\t[Required] INPUT MATRIX: '--amtx [left_hand_side.mtx]' -- for C=AxA" << std::endl;
 
+  std::cerr << "\t[Optional] BACKEND: '--threads [numThreads]' | '--openmp [numThreads]' | '--cuda [cudaDeviceIndex]' --> if none are specified, Serial is used (if enabled)" << std::endl
   std::cerr << "\t[Optional] '--algorithm [DEFAULT=KKDEFAULT=KKSPGEMM|KKMEM|KKDENSE|MKL|CUSPARSE|CUSP|VIENNA|MKL2]' --> to choose algorithm. KKMEM is outdated, use KKSPGEMM instead." << std::endl;
-  std::cerr << "\t[Optional] --bmtx [righ_hand_side.mtx]' for C= AxB" << std::endl;
+  std::cerr << "\t[Optional] --bmtx [righ_hand_side.mtx]' for C = AxB" << std::endl;
   std::cerr << "\t[Optional] OUTPUT MATRICES: '--cmtx [output_matrix.mtx]' --> to write output C=AxB"  << std::endl;
   std::cerr << "\t[Optional] --DENSEACCMAX: on CPUs default algorithm may choose to use dense accumulators. This parameter defaults to 250k, which is max k value to choose dense accumulators. This can be increased with more memory bandwidth." << std::endl;
   std::cerr << "\tThe memory space used for each matrix: '--memspaces [0|1|....15]' --> Bits representing the use of HBM for Work, C, B, and A respectively. For example 12 = 1100, will store work arrays and C on HBM. A and B will be stored DDR. To use this enable multilevel memory in Kokkos, check generate_makefile.sh" << std::endl;
@@ -297,7 +296,7 @@ int main (int argc, char ** argv){
     std::cout << "B is not provided. Multiplying AxA." << std::endl;
   }
 
-  const int num_threads = params.use_openmp; // Assumption is that use_openmp variable is provided as number of threads
+  const int num_threads = std::max(params.use_openmp, params.use_threads);
   const int device_id = params.use_cuda - 1;
 
   Kokkos::initialize( Kokkos::InitArguments( num_threads, -1, device_id ) );
@@ -337,9 +336,18 @@ int main (int argc, char ** argv){
   }
 #endif
 
+#if defined( KOKKOS_ENABLE_THREADS )
+  //If only serial is enabled (or no other device was specified), run with serial
+  if (params.use_threads)
+  {
+    KokkosKernels::Experiment::run_multi_mem_spgemm
+    <size_type, lno_t, scalar_t, Kokkos::Threads, Kokkos::HostSpace, Kokkos::HostSpace>(params);
+  }
+#endif
+
 #if defined( KOKKOS_ENABLE_SERIAL )
   //If only serial is enabled (or no other device was specified), run with serial
-  if (!params.use_openmp && !params.use_cuda)
+  if (!params.use_openmp && !params.use_cuda && !params.use_threads)
   {
     KokkosKernels::Experiment::run_multi_mem_spgemm
     <size_type, lno_t, scalar_t, Kokkos::Serial, Kokkos::HostSpace, Kokkos::HostSpace>(params);

--- a/perf_test/sparse/KokkosSparse_spgemm.cpp
+++ b/perf_test/sparse/KokkosSparse_spgemm.cpp
@@ -52,7 +52,7 @@ void print_options(){
 
   std::cerr << "\t[Required] INPUT MATRIX: '--amtx [left_hand_side.mtx]' -- for C=AxA" << std::endl;
 
-  std::cerr << "\t[Optional] BACKEND: '--threads [numThreads]' | '--openmp [numThreads]' | '--cuda [cudaDeviceIndex]' --> if none are specified, Serial is used (if enabled)" << std::endl
+  std::cerr << "\t[Optional] BACKEND: '--threads [numThreads]' | '--openmp [numThreads]' | '--cuda [cudaDeviceIndex]' --> if none are specified, Serial is used (if enabled)" << std::endl;
   std::cerr << "\t[Optional] '--algorithm [DEFAULT=KKDEFAULT=KKSPGEMM|KKMEM|KKDENSE|MKL|CUSPARSE|CUSP|VIENNA|MKL2]' --> to choose algorithm. KKMEM is outdated, use KKSPGEMM instead." << std::endl;
   std::cerr << "\t[Optional] --bmtx [righ_hand_side.mtx]' for C = AxB" << std::endl;
   std::cerr << "\t[Optional] OUTPUT MATRICES: '--cmtx [output_matrix.mtx]' --> to write output C=AxB"  << std::endl;

--- a/perf_test/sparse/KokkosSparse_spgemm.cpp
+++ b/perf_test/sparse/KokkosSparse_spgemm.cpp
@@ -47,10 +47,6 @@
 #include "KokkosKernels_IOUtils.hpp"
 #include "KokkosSparse_multimem_spgemm.hpp"
 
-typedef default_size_type size_type;
-typedef default_lno_t lno_t;
-typedef default_scalar scalar_t;
-
 void print_options(){
   std::cerr << "Options\n" << std::endl;
 
@@ -283,6 +279,9 @@ int parse_inputs (KokkosKernels::Experiment::Parameters &params, int argc, char 
 }
 
 int main (int argc, char ** argv){
+  using size_type = default_size_type;
+  using lno_t = default_lno_t;
+  using scalar_t = default_scalar;
 
   KokkosKernels::Experiment::Parameters params;
 

--- a/perf_test/sparse/KokkosSparse_spgemm_jacobi.cpp
+++ b/perf_test/sparse/KokkosSparse_spgemm_jacobi.cpp
@@ -50,7 +50,7 @@
 void print_options(){
   std::cerr << "Options\n" << std::endl;
   std::cerr << "\t[Required] INPUT MATRIX: '--amtx [left_hand_side.mtx]' -- for C=AxA" << std::endl;
-  std::cerr << "\t[Optional] BACKEND: '--threads [numThreads]' | '--openmp [numThreads]' | '--cuda [cudaDeviceIndex]' --> if none are specified, Serial is used (if enabled)" << std::endl
+  std::cerr << "\t[Optional] BACKEND: '--threads [numThreads]' | '--openmp [numThreads]' | '--cuda [cudaDeviceIndex]' --> if none are specified, Serial is used (if enabled)" << std::endl;
   std::cerr << "\t[Optional] --bmtx [righ_hand_side.mtx]' for C = AxB" << std::endl;
   std::cerr << "\t[Optional] OUTPUT MATRICES: '--cmtx [output_matrix.mtx]' --> to write output C=AxB"  << std::endl;
   std::cerr << "\t[Optional] --DENSEACCMAX: on CPUs default algorithm may choose to use dense accumulators. This parameter defaults to 250k, which is max k value to choose dense accumulators. This can be increased with more memory bandwidth." << std::endl;

--- a/perf_test/sparse/KokkosSparse_spgemm_jacobi.cpp
+++ b/perf_test/sparse/KokkosSparse_spgemm_jacobi.cpp
@@ -47,10 +47,6 @@
 #include "KokkosKernels_IOUtils.hpp"
 #include "KokkosSparse_run_spgemm_jacobi.hpp"
 
-using size_type = default_size_type;
-using lno_t =  default_lno_t;
-using scalar_t = default_scalar;
-
 void print_options(){
   std::cerr << "Options\n" << std::endl;
   std::cerr << "\t[Required] BACKEND: '--threads[numThreads]' | '--openmp [numThreads]' | '--cuda [cudaDeviceIndex]'" << std::endl;
@@ -250,6 +246,9 @@ int parse_inputs (KokkosKernels::Experiment::Parameters &params, int argc, char 
 }
 
 int main (int argc, char ** argv){
+  using size_type = default_size_type;
+  using lno_t =  default_lno_t;
+  using scalar_t = default_scalar;
 
   KokkosKernels::Experiment::Parameters params;
 

--- a/perf_test/sparse/KokkosSparse_spgemm_jacobi.cpp
+++ b/perf_test/sparse/KokkosSparse_spgemm_jacobi.cpp
@@ -49,9 +49,9 @@
 
 void print_options(){
   std::cerr << "Options\n" << std::endl;
-  std::cerr << "\t[Required] BACKEND: '--threads[numThreads]' | '--openmp [numThreads]' | '--cuda [cudaDeviceIndex]'" << std::endl;
   std::cerr << "\t[Required] INPUT MATRIX: '--amtx [left_hand_side.mtx]' -- for C=AxA" << std::endl;
-  std::cerr << "\t[Optional] --bmtx [righ_hand_side.mtx]' for C= AxB" << std::endl;
+  std::cerr << "\t[Optional] BACKEND: '--threads [numThreads]' | '--openmp [numThreads]' | '--cuda [cudaDeviceIndex]' --> if none are specified, Serial is used (if enabled)" << std::endl
+  std::cerr << "\t[Optional] --bmtx [righ_hand_side.mtx]' for C = AxB" << std::endl;
   std::cerr << "\t[Optional] OUTPUT MATRICES: '--cmtx [output_matrix.mtx]' --> to write output C=AxB"  << std::endl;
   std::cerr << "\t[Optional] --DENSEACCMAX: on CPUs default algorithm may choose to use dense accumulators. This parameter defaults to 250k, which is max k value to choose dense accumulators. This can be increased with more memory bandwidth." << std::endl;
   std::cerr << "\t[Optional] The memory space used for each matrix: '--memspaces [0|1|....15]' --> Bits representing the use of HBM for Work, C, B, and A respectively. For example 12 = 1100, will store work arrays and C on HBM. A and B will be stored DDR. To use this enable multilevel memory in Kokkos, check generate_makefile.sh" << std::endl;
@@ -264,7 +264,7 @@ int main (int argc, char ** argv){
     std::cout << "B is not provided. Multiplying AxA." << std::endl;
   }
 
-  const int num_threads = params.use_openmp; // Assumption is that use_openmp variable is provided as number of threads
+  const int num_threads = std::max(params.use_openmp, params.use_threads);
   const int device_id = params.use_cuda - 1;
 
   Kokkos::initialize( Kokkos::InitArguments( num_threads, -1, device_id ) );
@@ -295,13 +295,22 @@ int main (int argc, char ** argv){
   }
 #endif
 
+#if defined( KOKKOS_ENABLE_THREADS )
+  //If only serial is enabled (or no other device was specified), run with serial
+  if (params.use_threads)
+  {
+    KokkosKernels::Experiment::run_spgemm_jacobi
+      <size_type, lno_t, scalar_t, Kokkos::Threads, Kokkos::HostSpace, Kokkos::HostSpace>(params);
+  }
+#endif
+
 #if defined( KOKKOS_ENABLE_SERIAL )
   //If only serial is enabled (or no other device was specified), run with serial
-  if (!params.use_openmp && !params.use_cuda)
-    {
-      KokkosKernels::Experiment::run_spgemm_jacobi
-	<size_type, lno_t, scalar_t, Kokkos::Serial, Kokkos::HostSpace, Kokkos::HostSpace>(params);
-    }
+  if (!params.use_openmp && !params.use_cuda && !params.use_threads)
+  {
+    KokkosKernels::Experiment::run_spgemm_jacobi
+      <size_type, lno_t, scalar_t, Kokkos::Serial, Kokkos::HostSpace, Kokkos::HostSpace>(params);
+  }
 #endif
 
   Kokkos::finalize(); 

--- a/perf_test/sparse/KokkosSparse_spmv_struct.cpp
+++ b/perf_test/sparse/KokkosSparse_spmv_struct.cpp
@@ -64,10 +64,6 @@
 enum {STRUCT, UNSTR};
 enum {AUTO, DYNAMIC, STATIC};
 
-typedef default_scalar Scalar;
-typedef default_lno_t lno_t;
-typedef default_size_type size_type;
-
 void print_help() {
   printf("SPMV_struct benchmark code written by Luc Berger-Vergiat.\n");
   printf("Options:\n");
@@ -141,6 +137,9 @@ int main(int argc, char **argv)
 
   Kokkos::initialize(argc,argv);
   {
+    typedef default_size_type size_type;
+    typedef default_lno_t lno_t;
+    typedef default_scalar Scalar;
     typedef KokkosSparse::CrsMatrix<Scalar,lno_t,Kokkos::DefaultExecutionSpace,void,size_type> matrix_type;
     typedef typename Kokkos::View<Scalar**,Kokkos::LayoutLeft> mv_type;
     // typedef typename Kokkos::View<Scalar*,Kokkos::LayoutLeft,Kokkos::MemoryRandomAccess > mv_random_read_type;

--- a/perf_test/sparse/KokkosSparse_sptrsv_superlu.cpp
+++ b/perf_test/sparse/KokkosSparse_sptrsv_superlu.cpp
@@ -702,7 +702,7 @@ int main(int argc, char **argv) {
       using scalar_t = double;
       scalarTypeString = "(scalar_t = double)";
     #else
-      #error "Invalid type specified in KOKKOSKERNELS_SCALARS, supported types are "double,complex<double>""
+      #error "Invalid type specified in KOKKOSKERNELS_SCALARS, supported types are \"double,complex<double>\""
     #endif
   #endif
   int total_errors = test_sptrsv_perf<scalar_t> (tests, verbose, filename, symm_mode, metis, merge,

--- a/src/batched/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
+++ b/src/batched/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
@@ -68,7 +68,7 @@ namespace KokkosBatched {
 
       const bool is_UL = UL != NULL, is_UR = UR != NULL;
       const bool is_U  = is_UL || is_UR;
-      assert( is_U && "Eigendecomposition: eigenvectors are not requested; consider to use SerialEigenvalueInternal");
+      assert((is_UL || is_UR) && "Eigendecomposition: neither left nor right eigenvectors were requested. Use SerialEigenvalueInternal instead.");
         
       real_type *QZ = w_now; w_now += (m*m); wlen_now -= (m*m);
       assert( (wlen_now >= 0) && "Eigendecomposition: QZ allocation fails");

--- a/src/batched/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
+++ b/src/batched/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
@@ -67,7 +67,6 @@ namespace KokkosBatched {
       assert( (wlen_now >= 0) && "Eigendecomposition: workspace size is negative");
 
       const bool is_UL = UL != NULL, is_UR = UR != NULL;
-      const bool is_U  = is_UL || is_UR;
       assert((is_UL || is_UR) && "Eigendecomposition: neither left nor right eigenvectors were requested. Use SerialEigenvalueInternal instead.");
         
       real_type *QZ = w_now; w_now += (m*m); wlen_now -= (m*m);

--- a/src/batched/KokkosBatched_Householder_TeamVector_Internal.hpp
+++ b/src/batched/KokkosBatched_Householder_TeamVector_Internal.hpp
@@ -43,9 +43,11 @@ namespace KokkosBatched {
         
       /// if norm_x2 is zero, return with trivial values
       if (norm_x2_square == zero) {
-        *chi1 = -(*chi1);
-        *tau = half;
-          
+        Kokkos::single(Kokkos::PerTeam(member), [&]() { 
+            *chi1 = -(*chi1);
+            *tau = half;
+          });
+        member.team_barrier();
         return 0;
       }
 

--- a/src/batched/KokkosBatched_Vector_SIMD.hpp
+++ b/src/batched/KokkosBatched_Vector_SIMD.hpp
@@ -45,7 +45,7 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_PRAGMA_VECTOR )
 #pragma vector always
 #endif
-#if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__)
+#ifdef KOKKOSKERNELS_ENABLE_OMP_SIMD
 #pragma omp simd
 #endif
       for (int i=0;i<vector_length;++i)
@@ -59,7 +59,7 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_PRAGMA_VECTOR )
 #pragma vector always
 #endif
-#if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__)
+#ifdef KOKKOSKERNELS_ENABLE_OMP_SIMD
 #pragma omp simd
 #endif
       for (int i=0;i<vector_length;++i)
@@ -73,7 +73,7 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_PRAGMA_VECTOR )
 #pragma vector always
 #endif
-#if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__)
+#ifdef KOKKOSKERNELS_ENABLE_OMP_SIMD
 #pragma omp simd
 #endif
       for (int i=0;i<vector_length;++i)
@@ -88,7 +88,7 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_PRAGMA_VECTOR )
 #pragma vector always
 #endif
-#if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__)
+#ifdef KOKKOSKERNELS_ENABLE_OMP_SIMD
 #pragma omp simd
 #endif
       for (int i=0;i<vector_length;++i)
@@ -109,7 +109,7 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_PRAGMA_VECTOR )
 #pragma vector always
 #endif
-#if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__)
+#ifdef KOKKOSKERNELS_ENABLE_OMP_SIMD
 #pragma omp simd
 #endif
       for (int i=0;i<vector_length;++i)
@@ -529,7 +529,7 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_PRAGMA_VECTOR )
 #pragma vector always
 #endif
-#if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__)
+#ifdef KOKKOSKERNELS_ENABLE_OMP_SIMD
 #pragma omp simd
 #endif
       for (int i=0;i<vector_length;++i)
@@ -546,7 +546,7 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_PRAGMA_VECTOR )
 #pragma vector always
 #endif
-#if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__)
+#ifdef KOKKOSKERNELS_ENABLE_OMP_SIMD
 #pragma omp simd
 #endif
       for (int i=0;i<vector_length;++i)
@@ -639,7 +639,7 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_PRAGMA_VECTOR )
 #pragma vector always
 #endif
-#if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__)
+#ifdef KOKKOSKERNELS_ENABLE_OMP_SIMD
 #pragma omp simd
 #endif
       for (int i=0;i<vector_length;++i)
@@ -723,7 +723,7 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_PRAGMA_VECTOR )
 #pragma vector always
 #endif
-#if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__)
+#ifdef KOKKOSKERNELS_ENABLE_OMP_SIMD
 #pragma omp simd
 #endif
       for (int i=0;i<vector_length;++i)
@@ -739,7 +739,7 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_PRAGMA_VECTOR )
 #pragma vector always
 #endif
-#if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__)
+#ifdef KOKKOSKERNELS_ENABLE_OMP_SIMD
 #pragma omp simd
 #endif
       for (int i=0;i<vector_length;++i)
@@ -824,7 +824,7 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_PRAGMA_VECTOR )
 #pragma vector always
 #endif
-#if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__)
+#ifdef KOKKOSKERNELS_ENABLE_OMP_SIMD
 #pragma omp simd
 #endif
       for (int i=0;i<vector_length;++i)
@@ -840,7 +840,7 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_PRAGMA_VECTOR )
 #pragma vector always
 #endif
-#if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__)
+#ifdef KOKKOSKERNELS_ENABLE_OMP_SIMD
 #pragma omp simd
 #endif
       for (int i=0;i<vector_length;++i)

--- a/src/batched/KokkosBatched_Vector_SIMD_Arith.hpp
+++ b/src/batched/KokkosBatched_Vector_SIMD_Arith.hpp
@@ -4,6 +4,7 @@
 /// \author Kyungjoo Kim (kyukim@sandia.gov)
 
 #include "Kokkos_Complex.hpp"
+#include "KokkosKernels_Macros.hpp"
 
 namespace KokkosBatched {
 
@@ -64,7 +65,7 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_PRAGMA_VECTOR )
 #pragma vector always
 #endif
-#if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__) 
+#ifdef KOKKOSKERNELS_ENABLE_OMP_SIMD
 #pragma omp simd
 #endif
       for (int i=0;i<l;++i)
@@ -285,7 +286,7 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_PRAGMA_VECTOR )
 #pragma vector always
 #endif
-#if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__) 
+#ifdef KOKKOSKERNELS_ENABLE_OMP_SIMD
 #pragma omp simd
 #endif
       for (int i=0;i<l;++i)
@@ -353,7 +354,7 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_PRAGMA_VECTOR )
 #pragma vector always
 #endif
-#if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__) 
+#ifdef KOKKOSKERNELS_ENABLE_OMP_SIMD
 #pragma omp simd
 #endif
       for (int i=0;i<l;++i)
@@ -555,7 +556,7 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_PRAGMA_VECTOR )
 #pragma vector always
 #endif
-#if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__) 
+#ifdef KOKKOSKERNELS_ENABLE_OMP_SIMD
 #pragma omp simd
 #endif
       for (int i=0;i<l;++i)
@@ -845,7 +846,7 @@ namespace KokkosBatched {
 #if defined( KOKKOS_ENABLE_PRAGMA_VECTOR )
 #pragma vector always
 #endif
-#if defined( KOKKOS_ENABLE_OPENMP ) && !defined(__CUDA_ARCH__) 
+#ifdef KOKKOSKERNELS_ENABLE_OMP_SIMD
 #pragma omp simd
 #endif
       for (int i=0;i<l;++i)

--- a/src/blas/impl/KokkosBlas3_gemm_impl.hpp
+++ b/src/blas/impl/KokkosBlas3_gemm_impl.hpp
@@ -45,7 +45,8 @@
 #ifndef KOKKOS_BLAS3_GEMM_IMPL_HPP_
 #define KOKKOS_BLAS3_GEMM_IMPL_HPP_
 
-#include<Kokkos_Core.hpp>
+#include <Kokkos_Core.hpp>
+#include "KokkosKernels_Macros.hpp"
 
 #ifdef KOKKOS_ENABLE_CXX14
 #ifdef KOKKOS_COMPILER_GNU
@@ -401,16 +402,10 @@ void impl_team_gemm_block(const TeamHandle& team, const ViewTypeC& C, const View
   const int blockB1 = B.extent_int(1);
 #endif
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team,blockA0), [&] (const int i) {
-#if defined(__CUDA_ARCH__) || !defined(KOKKOS_ENABLE_OPENMP)
+#ifndef KOKKOSKERNELS_ENABLE_OMP_SIMD
     Kokkos::parallel_for(Kokkos::ThreadVectorRange(team,blockB1/4), [&] (const int B_j) {
 #else
-  #if defined(KOKKOS_COMPILER_GNU)
-    #if (KOKKOS_COMPILER_GNU > 485 )
     #pragma omp simd
-    #endif
-  #else
-    #pragma omp simd
-  #endif
     for(int B_j=0; B_j<blockB1/4; B_j++) {
 #endif
       ScalarC C_ij0 = 0;
@@ -428,7 +423,7 @@ void impl_team_gemm_block(const TeamHandle& team, const ViewTypeC& C, const View
       C(i,B_j+blockB1/4) += C_ij1;
       C(i,B_j+2*blockB1/4) += C_ij2;
       C(i,B_j+3*blockB1/4) += C_ij3;
-#if defined(__CUDA_ARCH__) || !defined(KOKKOS_ENABLE_OPENMP)
+#ifndef KOKKOSKERNELS_ENABLE_OMP_SIMD
     });
 #else
     }

--- a/src/common/KokkosKernels_Macros.hpp
+++ b/src/common/KokkosKernels_Macros.hpp
@@ -1,0 +1,65 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef _KOKKOSKERNELS_MACROUTILS_HPP_
+#define _KOKKOSKERNELS_MACROUTILS_HPP_
+
+// If KOKKOSKERNELS_ENABLE_OMP_SIMD is defined, it's legal to place
+// "#pragma omp simd" before a for loop. It's never defined if CUDA is enabled,
+// since in that case, Kokkos::ThreadVectorRange should be used instead for SIMD parallel loops.
+
+#if !defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_ENABLE_OPENMP)
+  #if defined(KOKKOS_COMPILER_GNU)
+    // GCC 4.8.5 and older do not support #pragma omp simd
+    #if (KOKKOS_COMPILER_GNU > 485 )
+      #define KOKKOSKERNELS_ENABLE_OMP_SIMD
+    #endif
+  #else
+    // All other Kokkos-supported compilers support it.
+    #define KOKKOSKERNELS_ENABLE_OMP_SIMD
+  #endif
+#endif
+
+#endif //_KOKKOSKERNELS_MACROUTILS_HPP_
+

--- a/test_common/Test_Common_Sorting.hpp
+++ b/test_common/Test_Common_Sorting.hpp
@@ -569,24 +569,34 @@ void testSortCRS(default_lno_t numRows, default_size_type nnz, bool doValues)
   Kokkos::deep_copy(rowmapHost, rowmap);
   Kokkos::deep_copy(entriesHost, entries);
   Kokkos::deep_copy(valuesHost, values);
+  struct ColValue
+  {
+    ColValue() {}
+    ColValue(lno_t c, scalar_t v) : col(c), val(v) {}
+    bool operator<(const ColValue& rhs)
+    {
+      return col < rhs.col;
+    }
+    bool operator==(const ColValue& rhs)
+    {
+      return col == rhs.col && val == rhs.val;
+    }
+    lno_t col;
+    scalar_t val;
+  };
   //sort one row at a time on host using STL.
   {
-    using ColValue = std::pair<lno_t, scalar_t>;
     for(lno_t i = 0; i < numRows; i++)
     {
       std::vector<ColValue> rowCopy;
       for(size_type j = rowmapHost(i); j < rowmapHost(i + 1); j++)
         rowCopy.emplace_back(entriesHost(j), valuesHost(j));
-      std::sort(rowCopy.begin(), rowCopy.end(),
-          [](const ColValue& lhs, const ColValue& rhs)
-          {
-            return lhs.first < rhs.first;
-          });
+      std::sort(rowCopy.begin(), rowCopy.end());
       //write sorted row back
       for(size_t j = 0; j < rowCopy.size(); j++)
       {
-        entriesHost(rowmapHost(i) + j) = rowCopy[j].first;
-        valuesHost(rowmapHost(i) + j) = rowCopy[j].second;
+        entriesHost(rowmapHost(i) + j) = rowCopy[j].col;
+        valuesHost(rowmapHost(i) + j) = rowCopy[j].val;
       }
     }
   }

--- a/test_common/Test_Common_Sorting.hpp
+++ b/test_common/Test_Common_Sorting.hpp
@@ -573,11 +573,11 @@ void testSortCRS(default_lno_t numRows, default_size_type nnz, bool doValues)
   {
     ColValue() {}
     ColValue(lno_t c, scalar_t v) : col(c), val(v) {}
-    bool operator<(const ColValue& rhs)
+    bool operator<(const ColValue& rhs) const
     {
       return col < rhs.col;
     }
-    bool operator==(const ColValue& rhs)
+    bool operator==(const ColValue& rhs) const
     {
       return col == rhs.col && val == rhs.val;
     }

--- a/unit_test/batched/Test_Batched_TeamVectorQR.hpp
+++ b/unit_test/batched/Test_Batched_TeamVectorQR.hpp
@@ -92,6 +92,7 @@ namespace Test {
 
       const int league_size = _a.extent(0);
       Kokkos::TeamPolicy<DeviceType> policy(league_size, Kokkos::AUTO);
+
       Kokkos::parallel_for(name.c_str(), policy, *this);
       Kokkos::Profiling::popRegion(); 
     }
@@ -112,6 +113,8 @@ namespace Test {
     VectorViewType b("b", N, BlkSize);
     VectorViewType t("t", N, BlkSize);
     WorkViewType   w("w", N, BlkSize);
+
+    Kokkos::fence();
 
     Kokkos::Random_XorShift64_Pool<typename DeviceType::execution_space> random(13718);
     Kokkos::fill_random(a, random, value_type(1.0));


### PR DESCRIPTION
See #696 for discussion. Fixes all Intel 17 builds on kokkos-dev2 (which only run in a full check, not spot check).

Fix warning on GCC <= 4.8.5 due to "pragma omp simd" being unrecognized. Made a generalized macro ``KOKKOSKERNELS_ENABLE_OMP_SIMD`` in a new file src/common/KokkosKernels_Macros.hpp. This is defined iff the pragma can be used (OpenMP enabled, CUDA not enabled, and compiler version is new enough if GCC).

Fix several  typedef shadow warnings in the spgemm, spgemm_jacobi, and spmv_struct perf tests. Also fix a weird unused variable warning in the serial eigendecomposition impl (is_U) which was used inside an assert (a macro) condition, but I guess that doesn't count as referencing it.

Add pthread support to spgemm and spgemm_jacobi perf tests. It was always enabled in the command line interface to do ``--threads N``, but there was no code to actually run with Threads backend.