### PR TITLE
Fix705: load module environment in reproducer script

### DIFF
--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -96,6 +96,10 @@ MACHINE=""
 HOSTNAME=$(hostname)
 PROCESSOR=`uname -p`
 CUDA_ENABLE_CMD=
+#Command(s) for accessing local modules on the current machine,
+#e.g. "module use ..."
+#This will be added to reproducer instructions/script.
+MODULE_ENVIRONMENT=
 
 if [[ "$HOSTNAME" =~ (white|ride).* ]]; then
   MACHINE=white
@@ -364,7 +368,8 @@ fi
 #
 
 if [ "$MACHINE" = "sems" ]; then
-  source /projects/sems/modulefiles/utils/sems-modules-init.sh
+  MODULE_ENVIRONMENT="source /projects/sems/modulefiles/utils/sems-modules-init.sh"
+  $MODULE_ENVIRONMENT
 
   # On unnamed sems machines, assume more restricted rhel7 environment
   # On rhel7 sems machines gcc/7.3.0, clang/4.0.1, and intel/16.0.3 are missing
@@ -415,7 +420,8 @@ if [ "$MACHINE" = "sems" ]; then
   SPACK_CUDA_ARCH="+maxwell50" #use an old one
   SPACK_CUDA_HOST_COMPILER="%gcc@7.2.0"
 elif [ "$MACHINE" = "kokkos-dev" ]; then
-  source /projects/sems/modulefiles/utils/sems-modules-init.sh
+  MODULE_ENVIRONMENT="source /projects/sems/modulefiles/utils/sems-modules-init.sh"
+  $MODULE_ENVIRONMENT
 
   module load sems-cmake/3.12.2
   BASE_MODULE_LIST="sems-env,sems-cmake/3.12.2,kokkos-env,kokkos-hwloc/1.10.1/base,sems-<COMPILER_NAME>/<COMPILER_VERSION>"
@@ -468,7 +474,8 @@ elif [ "$MACHINE" = "kokkos-dev" ]; then
   SPACK_CUDA_ARCH="+kepler35"
   SPACK_CUDA_HOST_COMPILER="%gcc@7.3.0"
 elif [ "$MACHINE" = "white" ]; then
-  source /etc/profile.d/modules.sh
+  MODULE_ENVIRONMENT="source /etc/profile.d/modules.sh"
+  $MODULE_ENVIRONMENT
   SKIP_HWLOC=True
   export SLURM_TASKS_PER_NODE=32
 
@@ -520,7 +527,8 @@ elif [ "$MACHINE" = "white" ]; then
   SPACK_CUDA_ARCH="+kepler37"
   SPACK_CUDA_HOST_COMPILER="%gcc@7.2.0"
 elif [ "$MACHINE" = "waterman" ]; then
-  source /etc/profile.d/modules.sh
+  MODULE_ENVIRONMENT="source /etc/profile.d/modules.sh"
+  $MODULE_ENVIRONMENT
   SKIP_HWLOC=True
 
   BASE_MODULE_LIST="cmake/3.12.3,<COMPILER_NAME>/<COMPILER_VERSION>"
@@ -574,7 +582,8 @@ elif [ "$MACHINE" = "waterman" ]; then
   SPACK_HOST_ARCH="+power9"
   SPACK_CUDA_ARCH="+volta70"
 elif [ "$MACHINE" = "bowman" ]; then
-  source /etc/profile.d/modules.sh
+  MODULE_ENVIRONMENT="source /etc/profile.d/modules.sh"
+  $MODULE_ENVIRONMENT
   SKIP_HWLOC=True
   export SLURM_TASKS_PER_NODE=32
 
@@ -611,7 +620,8 @@ elif [ "$MACHINE" = "mayer" ]; then
 
   SPACK_HOST_ARCH="+armv8_tx2" 
 elif [ "$MACHINE" = "blake" ]; then
-  source /etc/profile.d/modules.sh
+  MODULE_ENVIRONMENT="source /etc/profile.d/modules.sh"
+  $MODULE_ENVIRONMENT
   SKIP_HWLOC=True
   export SLURM_TASKS_PER_NODE=32
 
@@ -654,8 +664,8 @@ elif [ "$MACHINE" = "blake" ]; then
   fi
   SPACK_HOST_ARCH="+skx"
 elif [ "$MACHINE" = "apollo" ]; then
-  source /projects/sems/modulefiles/utils/sems-modules-init.sh
-  module use /home/projects/modulefiles/local/x86-64
+  MODULE_ENVIRONMENT="source /projects/sems/modulefiles/utils/sems-modules-init.sh ; module use /home/projects/modulefiles/local/x86-64"
+  $MODULE_ENVIRONMENT
   module load kokkos-env
 
   module load sems-git
@@ -724,9 +734,8 @@ elif [ "$MACHINE" = "apollo" ]; then
   SPACK_CUDA_ARCH="+volta70" 
   SPACK_CUDA_HOST_COMPILER="%gcc@6.1.0"
 elif [ "$MACHINE" = "kokkos-dev-2" ]; then
-  source /projects/sems/modulefiles/utils/sems-modules-init.sh
-  module use /home/projects/x86-64/modulefiles/local
-  module purge
+  MODULE_ENVIRONMENT="source /projects/sems/modulefiles/utils/sems-modules-init.sh ; module use /home/projects/x86-64/modulefiles/local ; module purge"
+  $MODULE_ENVIRONMENT
   module load sems-env
   module load kokkos-env
 
@@ -1129,6 +1138,10 @@ single_build_and_test() {
 
 
   echo "  #   Load modules:" &> reload_modules.sh
+  if [[ ! -z "$MODULE_ENVIRONMENT" ]]
+  then
+    echo "        $MODULE_ENVIRONMENT" &>> reload_modules.sh
+  fi
   echo "        module load $compiler_modules_list" &>> reload_modules.sh
   echo "" &>> reload_modules.sh
   chmod +x reload_modules.sh

--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -734,7 +734,7 @@ elif [ "$MACHINE" = "apollo" ]; then
   SPACK_CUDA_ARCH="+volta70" 
   SPACK_CUDA_HOST_COMPILER="%gcc@6.1.0"
 elif [ "$MACHINE" = "kokkos-dev-2" ]; then
-  MODULE_ENVIRONMENT="source /projects/sems/modulefiles/utils/sems-modules-init.sh ; module use /home/projects/x86-64/modulefiles/local ; module purge"
+  MODULE_ENVIRONMENT="source /projects/sems/modulefiles/utils/sems-modules-init.sh ; module use /home/projects/x86-64/modulefiles/local"
   $MODULE_ENVIRONMENT
   module load sems-env
   module load kokkos-env


### PR DESCRIPTION
On each machine, add the command(s) to load the full module environment (e.g. loading the local modulefile, running SEMS scripts) to the ``reload_modules.sh`` script for reproducing. This way, the reproducer instructions should work no matter what state the environment is in.