### PR TITLE
Initial tuning implementation for SPMV

### DIFF
--- a/perf_test/sparse/KokkosSparse_spmv.cpp
+++ b/perf_test/sparse/KokkosSparse_spmv.cpp
@@ -352,13 +352,14 @@ int main(int argc, char **argv)
  }
 
  Kokkos::initialize(argc,argv);
-
- int total_errors = test_crs_matrix_singlevec(size,size,test,filename,rows_per_thread,team_size,vector_length,schedule,loop);
-
+ for(int z = 6; z < 9; ++z){
+	 size = pow(10,z);
+   int total_errors = test_crs_matrix_singlevec(size,size,test,filename,rows_per_thread,team_size,vector_length,schedule,loop);
  if(total_errors == 0)
    printf("Kokkos::MultiVector Test: Passed\n");
  else
    printf("Kokkos::MultiVector Test: Failed\n");
+ }
 
 
   Kokkos::finalize();

--- a/src/sparse/KokkosSparse_spmv.hpp
+++ b/src/sparse/KokkosSparse_spmv.hpp
@@ -84,7 +84,7 @@ spmv (const char mode[],
   static_assert (std::is_same<typename YVector::value_type,
                    typename YVector::non_const_value_type>::value,
     "KokkosSparse::spmv: Output Vector must be non-const.");
-
+ //int x = "testing"; 
   // Check compatibility of dimensions at run time.
   if ((mode[0] == NoTranspose[0]) || (mode[0] == Conjugate[0])) {
     if ((x.extent(1) != y.extent(1)) ||


### PR DESCRIPTION
This is a draft PR to show how the proposed autotuning system in Kokkos might work inside Kokkos-Kernels. In this, I simply tune the `rows_per_thread` of one SPMV function based on `nnz` and `num_rows` (I forgot to do `num_cols`, I might add that later).

References the Kokkos Tuning PR kokkos/kokkos#2422 , uses the tool presented in kokkos/kokkos-tools#71 .

Note that I don't intend to merge this, my hope is that when it comes time to merge this functionality into Kokkos Kernels we'll have a much cleaner interface that sits on top of the highly mechanical and brittle one I expose here.