### PR TITLE
Fix Serial TRMM build

### DIFF
--- a/unit_test/batched/Test_Batched_SerialTrmm_Complex.hpp
+++ b/unit_test/batched/Test_Batched_SerialTrmm_Complex.hpp
@@ -109,7 +109,7 @@ TEST_F( TestCategory, batched_scalar_serial_trmm_r_u_ct_n_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Side::Right,Uplo::Upper,Trans::ConjTranspose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,_scomplex_scomplexKokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
 }
 #endif
 

--- a/unit_test/openmp/Test_OpenMP_Batched_SerialTrmm_Real.cpp
+++ b/unit_test/openmp/Test_OpenMP_Batched_SerialTrmm_Real.cpp
@@ -1,3 +1,3 @@
 #include "Test_OpenMP.hpp"
 #include "Test_Batched_SerialTrmm.hpp"
-#include "Test_Batched_SerialTrmm_Complex.hpp"
+#include "Test_Batched_SerialTrmm_Real.hpp"


### PR DESCRIPTION
Fix typos in the complex and OpenMP+real test headers for SerialTRMM.
Running kokkos-dev2 spot check with double+complex_float, so that the code with the first issue is enabled.