### PR TITLE
Add "module purge" to reproducer reload_modules.sh

### DIFF
--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -1142,6 +1142,7 @@ single_build_and_test() {
   then
     echo "        $MODULE_ENVIRONMENT" &>> reload_modules.sh
   fi
+  echo "        module purge" &>> reload_modules.sh
   echo "        module load $compiler_modules_list" &>> reload_modules.sh
   echo "" &>> reload_modules.sh
   chmod +x reload_modules.sh


### PR DESCRIPTION
This is just a one-line change to cm_test_all_sandia. It fixes the reproducer instructions for bowman, which was saying "module intel/18... conflicts with loaded module...". This matches the actual behavior of the testing script, which purges module before each build.