### PR TITLE
Fix compile error for CUDA in TRMM and TRTRI perf tests

### DIFF
--- a/perf_test/blas/blas/KokkosBlas_perf_test.cpp
+++ b/perf_test/blas/blas/KokkosBlas_perf_test.cpp
@@ -247,7 +247,9 @@ int main(int argc, char **argv) {
         out_file         = optarg;
         options.out_file = std::string(out_file);
         break;
-      case 'r': options.blas_routines = std::string(optarg);
+      case 'r': 
+        options.blas_routines = std::string(optarg);
+        break;
       case '?':
       default: __blas_perf_test_input_error(argv, option_idx);
     }

--- a/perf_test/blas/blas/KokkosBlas_trtri_perf_test.hpp
+++ b/perf_test/blas/blas/KokkosBlas_trtri_perf_test.hpp
@@ -201,6 +201,7 @@ void __do_trtri_serial_batched(options_t options, trtri_args_t trtri_args) {
   return;
 }
 
+#if !defined(KOKKOS_ENABLE_CUDA)
 template <class ExecutionSpace>
 struct parallel_blas_trtri {
   trtri_args_t trtri_args_;
@@ -214,9 +215,11 @@ struct parallel_blas_trtri {
     KokkosBlas::trtri(&trtri_args_.uplo, &trtri_args_.diag, svA);
   }
 };
+#endif // !KOKKOS_ENABLE_CUDA
 
 template <class scalar_type, class vta, class device_type>
 void __do_trtri_parallel_blas(options_t options, trtri_args_t trtri_args) {
+  #if !defined(KOKKOS_ENABLE_CUDA)
   uint32_t warm_up_n = options.warm_up_n;
   uint32_t n         = options.n;
   Kokkos::Timer timer;
@@ -237,6 +240,12 @@ void __do_trtri_parallel_blas(options_t options, trtri_args_t trtri_args) {
                        parallel_blas_trtri_functor);
   Kokkos::fence();
   __trtri_output_csv_row(options, trtri_args, timer.seconds());
+  #else
+  std::cerr << std::string(__func__) << 
+    " disabled since KOKKOS_ENABLE_CUDA is defined." << 
+    std::endl;
+  __trtri_output_csv_row(options, trtri_args, -1);
+  #endif // !KOKKOS_ENABLE_CUDA
   return;
 }
 

--- a/perf_test/blas/blas3/KokkosBlas3_perf_test.cpp
+++ b/perf_test/blas/blas3/KokkosBlas3_perf_test.cpp
@@ -259,7 +259,9 @@ int main(int argc, char **argv) {
         out_file         = optarg;
         options.out_file = std::string(out_file);
         break;
-      case 'r': options.blas_routines = std::string(optarg);
+      case 'r': 
+        options.blas_routines = std::string(optarg);
+        break;
       case '?':
       default: __blas3_perf_test_input_error(argv, option_idx);
     }

--- a/perf_test/blas/blas3/KokkosBlas3_trmm_perf_test.hpp
+++ b/perf_test/blas/blas3/KokkosBlas3_trmm_perf_test.hpp
@@ -289,6 +289,7 @@ void __do_trmm_serial_batched(options_t options, trmm_args_t trmm_args) {
   return;
 }
 
+#if !defined(KOKKOS_ENABLE_CUDA)
 template <class ExecutionSpace>
 struct parallel_blas_trmm {
   trmm_args_t trmm_args_;
@@ -304,9 +305,11 @@ struct parallel_blas_trmm {
                      &trmm_args_.diag, trmm_args_.alpha, svA, svB);
   }
 };
+#endif // !KOKKOS_ENABLE_CUDA
 
 template <class scalar_type, class vta, class vtb, class device_type>
 void __do_trmm_parallel_blas(options_t options, trmm_args_t trmm_args) {
+  #if !defined(KOKKOS_ENABLE_CUDA)
   uint32_t warm_up_n = options.warm_up_n;
   uint32_t n         = options.n;
   Kokkos::Timer timer;
@@ -315,6 +318,7 @@ void __do_trmm_parallel_blas(options_t options, trmm_args_t trmm_args) {
   functor_type parallel_blas_trmm_functor(trmm_args);
 
   STATUS;
+
 
   Kokkos::parallel_for("parallelBlasWarmUpLoopTrmm",
                        Kokkos::RangePolicy<execution_space>(0, warm_up_n),
@@ -327,6 +331,12 @@ void __do_trmm_parallel_blas(options_t options, trmm_args_t trmm_args) {
                        parallel_blas_trmm_functor);
   Kokkos::fence();
   __trmm_output_csv_row(options, trmm_args, timer.seconds());
+  #else
+  std::cerr << std::string(__func__) << 
+    " disabled since KOKKOS_ENABLE_CUDA is defined." << 
+    std::endl;
+  __trmm_output_csv_row(options, trmm_args, -1);
+  #endif // !KOKKOS_ENABLE_CUDA
   return;
 }
 

--- a/perf_test/blas/blas3/KokkosBlas3_trmm_perf_test.hpp
+++ b/perf_test/blas/blas3/KokkosBlas3_trmm_perf_test.hpp
@@ -494,6 +494,7 @@ trmm_args_t __do_setup(options_t options, matrix_dims_t dim) {
   uint64_t seed = Kokkos::Impl::clock_tic();
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(seed);
   decltype(dim.a.m) min_dim = dim.a.m < dim.a.n ? dim.a.m : dim.a.n;
+  typename vta::HostMirror host_A;
   STATUS;
 
   trmm_args.side  = options.blas_args.trmm.trmm_args.c_str()[0];
@@ -502,14 +503,17 @@ trmm_args_t __do_setup(options_t options, matrix_dims_t dim) {
   trmm_args.diag  = options.blas_args.trmm.trmm_args.c_str()[3];
   trmm_args.A     = vta("trmm_args.A", options.n, dim.a.m, dim.a.n);
   trmm_args.B     = vtb("trmm_args.B", options.n, dim.b.m, dim.b.n);
+  host_A = Kokkos::create_mirror_view(trmm_args.A);
 
   Kokkos::fill_random(trmm_args.A, rand_pool,
                       Kokkos::rand<Kokkos::Random_XorShift64<execution_space>,
                                    scalar_type>::max());
-  if (trmm_args.uplo == 'U' || trmm_args.uplo == 'u') {
+  Kokkos::deep_copy(host_A, trmm_args.A);
+
+  if (trmm_args.uplo == 'U' || trmm_args.uplo == 'u') {  
     // Make A upper triangular
     for (uint32_t k = 0; k < options.n; ++k) {
-      auto A = Kokkos::subview(trmm_args.A, k, Kokkos::ALL(), Kokkos::ALL());
+      auto A = Kokkos::subview(host_A, k, Kokkos::ALL(), Kokkos::ALL());
       for (int i = 1; i < dim.a.m; i++) {
         for (int j = 0; j < i; j++) {
           A(i, j) = scalar_type(0);
@@ -521,7 +525,7 @@ trmm_args_t __do_setup(options_t options, matrix_dims_t dim) {
     // Kokkos::parallel_for("toLowerLoop", options.n, KOKKOS_LAMBDA (const int&
     // i) {
     for (uint32_t k = 0; k < options.n; ++k) {
-      auto A = Kokkos::subview(trmm_args.A, k, Kokkos::ALL(), Kokkos::ALL());
+      auto A = Kokkos::subview(host_A, k, Kokkos::ALL(), Kokkos::ALL());
       for (int i = 0; i < dim.a.m - 1; i++) {
         for (int j = i + 1; j < dim.a.n; j++) {
           A(i, j) = scalar_type(0);
@@ -532,12 +536,13 @@ trmm_args_t __do_setup(options_t options, matrix_dims_t dim) {
 
   if (trmm_args.diag == 'U' || trmm_args.diag == 'u') {
     for (uint32_t k = 0; k < options.n; ++k) {
-      auto A = Kokkos::subview(trmm_args.A, k, Kokkos::ALL(), Kokkos::ALL());
+      auto A = Kokkos::subview(host_A, k, Kokkos::ALL(), Kokkos::ALL());
       for (int i = 0; i < min_dim; i++) {
         A(i, i) = scalar_type(1);
       }
     }
   }
+  Kokkos::deep_copy(trmm_args.A, host_A);
 
   Kokkos::fill_random(trmm_args.B, rand_pool,
                       Kokkos::rand<Kokkos::Random_XorShift64<execution_space>,


### PR DESCRIPTION
- Also fixes:
  - `-r` command line options
  - `__do_setup` for CUDA.

Fixes #727.

Running spot checks now.