### PR TITLE
Possible interface fix for batched macros

### DIFF
--- a/src/batched/KokkosBatched_Trsv_Decl.hpp
+++ b/src/batched/KokkosBatched_Trsv_Decl.hpp
@@ -110,7 +110,6 @@ namespace KokkosBatched {
 #include "KokkosBatched_Trsv_Serial_Impl.hpp"
 #include "KokkosBatched_Trsv_Team_Impl.hpp"
 #include "KokkosBatched_Trsv_TeamVector_Impl.hpp"
-
 #define KOKKOSBATCHED_SERIAL_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
   KokkosBatched::SerialTrsvInternalLower<ALGOTYPE>::invoke(DIAG::use_unit_diag, M, ALPHA, A, AS0, AS1, B, BS)
 
@@ -136,16 +135,16 @@ namespace KokkosBatched {
   KokkosBatched::TeamTrsvInternalLower<ALGOTYPE>::invoke(MEMBER,DIAG::use_unit_diag, N, ALPHA, A, AS1, AS0, B, BS) 
 
 #define KOKKOSBATCHED_TEAMVECTOR_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
-  KokkosBatched::TeamVectorTrsvInternalLower<ALGOTYPE>::invoke(MEMBER,DIAG::use_unit_diag, M, ALPHA, A, AS0, AS1, B, BS)
+  KokkosBatched::TeamVectorTrsvInternalLower::invoke(MEMBER,DIAG::use_unit_diag, M, ALPHA, A, AS0, AS1, B, BS)
 
 #define KOKKOSBATCHED_TEAMVECTOR_TRSV_LOWER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
-  KokkosBatched::TeamVectorTrsvInternalUpper<ALGOTYPE>::invoke(MEMBER,DIAG::use_unit_diag, N, ALPHA, A, AS1, AS0, B, BS)
+  KokkosBatched::TeamVectorTrsvInternalUpper::invoke(MEMBER,DIAG::use_unit_diag, N, ALPHA, A, AS1, AS0, B, BS)
 
 #define KOKKOSBATCHED_TEAMVECTOR_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
-  KokkosBatched::TeamVectorTrsvInternalUpper<ALGOTYPE>::invoke(MEMBER,DIAG::use_unit_diag, M, ALPHA, A, AS0, AS1, B, BS)
+  KokkosBatched::TeamVectorTrsvInternalUpper::invoke(MEMBER,DIAG::use_unit_diag, M, ALPHA, A, AS0, AS1, B, BS)
 
 #define KOKKOSBATCHED_TEAMVECTOR_TRSV_UPPER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
-  KokkosBatched::TeamVectorTrsvInternalLower<ALGOTYPE>::invoke(MEMBER,DIAG::use_unit_diag, N, ALPHA, A, AS1, AS0, B, BS) 
+  KokkosBatched::TeamVectorTrsvInternalLower::invoke(MEMBER,DIAG::use_unit_diag, N, ALPHA, A, AS1, AS0, B, BS) 
 
 #define KOKKOSBATCHED_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(MODETYPE,ALGOTYPE,MEMBER,DIAG,M,N,ALPHA,A,AS0,AS1,B,BS) \
   if (std::is_same<MODETYPE,KokkosBatched::Mode::Serial>::value) {      \


### PR DESCRIPTION
Hey folks, I was building Trilinos when I ran into a compilation error centered around `KokkosBatched::TeamVectorTrsvInternalLower` being given template arguments, when it needed to have no template arguments. The following patch fixed it.

I don't really know what I'm doing in Kokkos Kernels, so this should be read really carefully to make sure I'm not missing anything