### PR TITLE
First iteration of HashmapAccumulator cleanup

### DIFF
--- a/perf_test/sparse/KokkosSparse_run_spgemm.hpp
+++ b/perf_test/sparse/KokkosSparse_run_spgemm.hpp
@@ -241,7 +241,6 @@ crsMat_t3 run_experiment(crsMat_t crsMat, crsMat_t2 crsMat2, Parameters params)
       sequential_kh.set_dynamic_scheduling(true);
     }
 
-
     spgemm_symbolic (
         &sequential_kh,
         m,
@@ -341,7 +340,6 @@ crsMat_t3 run_experiment(crsMat_t crsMat, crsMat_t2 crsMat2, Parameters params)
       entriesC = lno_nnz_view_t (Kokkos::ViewAllocateWithoutInitializing("entriesC"), c_nnz_size);
       valuesC = scalar_view_t (Kokkos::ViewAllocateWithoutInitializing("valuesC"), c_nnz_size);
     }
-
     spgemm_numeric(
         &kh,
         m,

--- a/src/common/KokkosKernels_HashmapAccumulator.hpp
+++ b/src/common/KokkosKernels_HashmapAccumulator.hpp
@@ -174,14 +174,13 @@ struct HashmapAccumulator
   //Insertion is sequential, no race condition for the insertion.
   KOKKOS_INLINE_FUNCTION
   int sequential_insert_into_hash_mergeOr_TrackHashes (
-      size_type hash,
       key_type key,
       value_type value,
       size_type *used_size_,
       size_type *used_hash_size,
       size_type *used_hashes)
   {
-    hash = __compute_hash(key, __hashOpRHS);
+    size_type hash = __compute_hash(key, __hashOpRHS);
 
     size_type i = hash_begins[hash];
     for (; i != -1; i = hash_nexts[i]) {
@@ -212,7 +211,6 @@ struct HashmapAccumulator
   //Assume that there are 2 values for triangle count.
   KOKKOS_INLINE_FUNCTION
   int sequential_insert_into_hash_mergeOr_TriangleCount_TrackHashes (
-      size_type hash,
       key_type key,
       value_type value,
       value_type *values2,
@@ -220,7 +218,7 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
-    hash = __compute_hash(key, __hashOpRHS);
+    size_type hash = __compute_hash(key, __hashOpRHS);
 
     size_type i = hash_begins[hash];
     for (; i != -1; i = hash_nexts[i]) {
@@ -251,7 +249,6 @@ struct HashmapAccumulator
   //L x Incidence
   KOKKOS_INLINE_FUNCTION
   int sequential_insert_into_hash_mergeAnd_TriangleCount_TrackHashes (
-      size_type hash,
       key_type key,
       value_type value,
       value_type *values2,
@@ -259,7 +256,7 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
-    hash = __compute_hash(key, __hashOpRHS);
+    size_type hash = __compute_hash(key, __hashOpRHS);
 
     //this function will only try to do an AND operation with
     //existing keys. If the key is not there, returns __insert_full.
@@ -279,11 +276,10 @@ struct HashmapAccumulator
   //this is used in LxL or Incidence^T x L
   KOKKOS_INLINE_FUNCTION
   value_type sequential_insert_into_hash_mergeAnd_TriangleCount_TrackHashes (
-      size_type hash,
       key_type key,
       value_type value)
   {
-    hash = __compute_hash(key, __hashOpRHS);
+    size_type hash = __compute_hash(key, __hashOpRHS);
 
     //this function will only try to do an AND operation with
     //existing keys. If the key is not there, returns __insert_full.
@@ -302,7 +298,6 @@ struct HashmapAccumulator
   //L x Incidence
   KOKKOS_INLINE_FUNCTION
   int sequential_insert_into_hash_TriangleCount_TrackHashes (
-      size_type hash,
       key_type key,
       value_type value,
       value_type *values2,
@@ -310,7 +305,7 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
-    hash = __compute_hash(key, __hashOpRHS);
+    size_type hash = __compute_hash(key, __hashOpRHS);
 
     //this function will directly insert, won't check if it exists already.
     if (*used_size_ >= __max_value_size) return __insert_full;
@@ -334,14 +329,13 @@ struct HashmapAccumulator
   //this is used in LxL or Incidence^T x L
   KOKKOS_INLINE_FUNCTION
   int sequential_insert_into_hash_TriangleCount_TrackHashes (
-      size_type hash,
       key_type key,
       value_type value,
       size_type *used_size_,
       size_type *used_hash_size,
       size_type *used_hashes) // TODO figure out what this "used_hashes" is for
   {
-    hash = __compute_hash(key, __hashOpRHS);
+    size_type hash = __compute_hash(key, __hashOpRHS);
 
     //this function will directly insert, won't check if it exists already.
     if (*used_size_ >= __max_value_size) return __insert_full;
@@ -366,14 +360,13 @@ struct HashmapAccumulator
   //the mergeadd used in the numeric of KKMEM.
   KOKKOS_INLINE_FUNCTION
   int sequential_insert_into_hash_mergeAdd_TrackHashes (
-      size_type hash,
       key_type key,
       value_type value,
       size_type *used_size_,
       size_type *used_hash_size,
       size_type *used_hashes)
   {
-    hash = __compute_hash(key, __hashOpRHS);
+    size_type hash = __compute_hash(key, __hashOpRHS);
 
     // issue-508, TODO: ensure that i < __max_value_size, but
     // need information about length of keys, values, and hash_nexts first!
@@ -404,13 +397,12 @@ struct HashmapAccumulator
   //also used in the symbolic of spgemm if no compression is applied.
   KOKKOS_INLINE_FUNCTION
   int sequential_insert_into_hash_TrackHashes (
-      size_type hash,
       key_type key,
       size_type *used_size_,
       size_type *used_hash_size,
       size_type *used_hashes)
   {
-    hash = __compute_hash(key, __hashOpRHS);
+    size_type hash = __compute_hash(key, __hashOpRHS);
 
     size_type i = hash_begins[hash];
     for (; i != -1; i = hash_nexts[i]) {
@@ -439,13 +431,8 @@ struct HashmapAccumulator
   //insertions will have the same key.
   //Insertion is simulteanous for the vector lanes of a thread.
   //used_size should be a shared pointer among the thread vectors
-  template <typename team_member_t>
   KOKKOS_INLINE_FUNCTION
   int vector_atomic_insert_into_hash_mergeAdd_TrackHashes (
-      const team_member_t & /* teamMember */,
-      const int /* vector_size */,
-
-      size_type hash,
       const key_type key,
       const value_type value,
       volatile size_type *used_size_,
@@ -453,7 +440,7 @@ struct HashmapAccumulator
       size_type *used_hashes
       )
   {
-    hash = __compute_hash(key, __hashOpRHS);
+    size_type hash = __compute_hash(key, __hashOpRHS);
 
     if (hash != -1) {
       size_type i = hash_begins[hash];
@@ -513,7 +500,8 @@ struct HashmapAccumulator
       volatile size_type *used_size_,
       const size_type max_value_size_)
   {
-    hash = __compute_hash(key, __hashOpRHS);
+    // Cannot compute hash here due to impl_speed use-case
+    //hash = __compute_hash(key, __hashOpRHS);
 
     if (hash != -1) {
       size_type i = hash_begins[hash];
@@ -568,19 +556,15 @@ struct HashmapAccumulator
   //insertions will have the same key.
   //Insertion is simulteanous for the vector lanes of a thread.
   //used_size should be a shared pointer among the thread vectors
-  template <typename team_member_t>
   KOKKOS_INLINE_FUNCTION
   int vector_atomic_insert_into_hash_mergeAdd (
-      const team_member_t & /* teamMember */,
-      const int /* vector_size */,
-      size_type &hash,
       const key_type key,
       const value_type value,
       volatile size_type *used_size_)
   {
     return vector_atomic_insert_into_hash_mergeAdd_with_team_level_list_length(nullptr,
                                                                                0,
-                                                                               hash,
+                                                                               __compute_hash(key, __hashOpRHS),
                                                                                key,
                                                                                value,
                                                                                used_size_,
@@ -588,27 +572,19 @@ struct HashmapAccumulator
   }
 
   //used in symbolic of kkmem if the compression is not applied.
-  template <typename team_member_t>
   KOKKOS_INLINE_FUNCTION
   int vector_atomic_insert_into_hash (
-      const team_member_t & /* teamMember */,
-      const int &/* vector_size */,
-      size_type hash,
       const key_type &key,
       volatile size_type *used_size_
       )
   {
-    hash = __compute_hash(key, __hashOpRHS);
+    size_type hash = __compute_hash(key, __hashOpRHS);
 
-    if (hash != -1) {
-      size_type i = hash_begins[hash];
-      for (; i != -1; i = hash_nexts[i]) {
-        if (keys[i] == key) {
-          return __insert_success;
-        }
-      }
-    } else {
+    size_type i = hash_begins[hash];
+    for (; i != -1; i = hash_nexts[i]) {
+      if (keys[i] == key) {
         return __insert_success;
+      }
     }
 
     size_type my_write_index = Kokkos::atomic_fetch_add(used_size_, size_type(1));

--- a/src/common/KokkosKernels_HashmapAccumulator.hpp
+++ b/src/common/KokkosKernels_HashmapAccumulator.hpp
@@ -791,6 +791,8 @@ struct HashmapAccumulator
       #ifdef HASHMAPACCUMULATOR_ASSERT_ENABLED
         if (hash == -1)
           Kokkos::abort("__compute_hash: hash = -1");
+        if (key == -1)
+          Kokkos::abort("__compute_hash: key = -1");
       #endif // HASHMAPACCUMULATOR_ASSERT_ENABLED
       return hash;
     }
@@ -803,6 +805,8 @@ struct HashmapAccumulator
       #ifdef HASHMAPACCUMULATOR_ASSERT_ENABLED
         if (hash == -1)
           Kokkos::abort("__compute_hash: hash = -1");
+        if (key == -1)
+          Kokkos::abort("__compute_hash: key = -1");
       #endif // HASHMAPACCUMULATOR_ASSERT_ENABLED
       return hash;
     }
@@ -815,6 +819,8 @@ struct HashmapAccumulator
       #ifdef HASHMAPACCUMULATOR_ASSERT_ENABLED
         if (hash == -1)
           Kokkos::abort("__compute_hash: hash = -1");
+        if (key == -1)
+          Kokkos::abort("__compute_hash: key = -1");
       #endif // HASHMAPACCUMULATOR_ASSERT_ENABLED
       return hash;
     }

--- a/src/common/KokkosKernels_HashmapAccumulator.hpp
+++ b/src/common/KokkosKernels_HashmapAccumulator.hpp
@@ -77,8 +77,8 @@ template <typename size_type, typename key_type, typename value_type, typename h
  *                   corresponding to hash values [Begins]
  * \var hash_nexts:  Holds the indicies of the next elements
  *                   within the linked list [Nexts]
- * \var keys:        This stores the column indices of (??) [Ids]
- * \var values:      This store the (matrix element?) numerical value of (??) [Values]
+ * \var keys:        This stores the column indices of the crs matrix [Ids]
+ * \var values:      This store the numerical values (matrix elements) [Values]
  * 
  * Private members:
  * \var __max_value_size: The length of the two arrays (keys and hash_nexts)
@@ -349,7 +349,7 @@ struct HashmapAccumulator
       value_type value,
       size_type *used_size_,
       size_type *used_hash_size,
-      size_type *used_hashes) // TODO figure out what this "used_hashes" is for
+      size_type *used_hashes) // issue-508, TODO figure out what this "used_hashes" is for
   {
     size_type hash, my_index;
 
@@ -549,7 +549,7 @@ struct HashmapAccumulator
 
     // This appears to be redundant to the thread-safe atomic_fetch_add
     // conditional check below.
-    // TODO: Remove this check?
+    // issue-508, TODO: Remove this check?
     if (used_size_[0] >= max_value_size_) {
       return __insert_full;
     }

--- a/src/common/KokkosKernels_HashmapAccumulator.hpp
+++ b/src/common/KokkosKernels_HashmapAccumulator.hpp
@@ -186,8 +186,7 @@ struct HashmapAccumulator
       return __insert_success;
 
     hash = __compute_hash(key, __hashOpRHS);
-    i = hash_begins[hash];
-    for (; i != -1; i = hash_nexts[i]) {
+    for (i = hash_begins[hash]; i != -1; i = hash_nexts[i]) {
       if (keys[i] == key) {
         values[i] = values[i] | value;
         return __insert_success;
@@ -228,8 +227,7 @@ struct HashmapAccumulator
       return __insert_success;
 
     hash = __compute_hash(key, __hashOpRHS);
-    i = hash_begins[hash];
-    for (; i != -1; i = hash_nexts[i]) {
+    for (i = hash_begins[hash]; i != -1; i = hash_nexts[i]) {
       if (keys[i] == key) {
         values2[i] = values2[i] | (values[i] & value);
         values[i] = values[i] | value;
@@ -272,8 +270,7 @@ struct HashmapAccumulator
     //this function will only try to do an AND operation with
     //existing keys. If the key is not there, returns __insert_full.
     hash = __compute_hash(key, __hashOpRHS);
-    i = hash_begins[hash];
-    for (; i != -1; i = hash_nexts[i]) {
+    for (i = hash_begins[hash]; i != -1; i = hash_nexts[i]) {
       if (keys[i] == key) {
         //values2[i] = values2[i] | (values[i] & value);
         values[i] = values[i] & value;
@@ -299,8 +296,7 @@ struct HashmapAccumulator
     //this function will only try to do an AND operation with
     //existing keys. If the key is not there, returns __insert_full.
     hash = __compute_hash(key, __hashOpRHS);
-    i = hash_begins[hash];
-    for (; i != -1; i = hash_nexts[i])
+    for (i = hash_begins[hash]; i != -1; i = hash_nexts[i])
     {
       if (keys[i] == key) {
         return values[i] & value;
@@ -327,7 +323,6 @@ struct HashmapAccumulator
       return __insert_success;
 
     //this function will directly insert, won't check if it exists already.
-    hash = __compute_hash(key, __hashOpRHS);
     if (*used_size_ >= __max_value_size) return __insert_full;
     my_index = (*used_size_)++;
 
@@ -335,6 +330,7 @@ struct HashmapAccumulator
     values[my_index] = value;
     values2[my_index] = 1;
 
+    hash = __compute_hash(key, __hashOpRHS);
     if (hash_begins[hash] == -1) {
       hash_begins[hash] = my_index;
       used_hashes[used_hash_size[0]++] = hash;
@@ -361,13 +357,13 @@ struct HashmapAccumulator
       return __insert_success;
 
     //this function will directly insert, won't check if it exists already.
-    hash = __compute_hash(key, __hashOpRHS);
     if (*used_size_ >= __max_value_size) return __insert_full;
     my_index = (*used_size_)++;
 
     keys[my_index] = key;
     values[my_index] = value;
 
+    hash = __compute_hash(key, __hashOpRHS);
     if (hash_begins[hash] == -1) {
       hash_begins[hash] = my_index;
       used_hashes[used_hash_size[0]++] = hash;
@@ -398,8 +394,7 @@ struct HashmapAccumulator
     // issue-508, TODO: ensure that i < __max_value_size, but
     // need information about length of keys, values, and hash_nexts first!
     hash = __compute_hash(key, __hashOpRHS);
-    i = hash_begins[hash];
-    for (; i != -1; i = hash_nexts[i]) {
+    for (i = hash_begins[hash]; i != -1; i = hash_nexts[i]) {
       if (keys[i] == key) {
         values[i] = values[i] + value;
         return __insert_success;
@@ -436,8 +431,7 @@ struct HashmapAccumulator
       return __insert_success;
 
     hash = __compute_hash(key, __hashOpRHS);
-    i = hash_begins[hash];
-    for (; i != -1; i = hash_nexts[i]) {
+    for (i = hash_begins[hash]; i != -1; i = hash_nexts[i]) {
       if (keys[i] == key) {
         return __insert_success;
       }
@@ -625,8 +619,7 @@ struct HashmapAccumulator
       return __insert_success;
 
     hash = __compute_hash(key, __hashOpRHS);
-    i = hash_begins[hash];
-    for (; i != -1; i = hash_nexts[i]) {
+    for (i = hash_begins[hash]; i != -1; i = hash_nexts[i]) {
       if (keys[i] == key) {
         return __insert_success;
       }
@@ -679,8 +672,7 @@ struct HashmapAccumulator
       return __insert_success;
 
     hash = __compute_hash(key, __hashOpRHS);
-    i = hash_begins[hash];
-    for (; i != -1; i = hash_nexts[i]){
+    for (i = hash_begins[hash]; i != -1; i = hash_nexts[i]){
       if (keys[i] == key){
         values[i] = (key_type)values[i] | (key_type)value;
         return __insert_success;
@@ -737,7 +729,6 @@ struct HashmapAccumulator
       return __insert_success;
 
     hash = __compute_hash(key, __hashOpRHS);
-
     for (i = hash_begins[hash]; i != -1; i = hash_nexts[i]) {
       if (keys[i] == key) {
         values[i] = (key_type)values[i] | (key_type)value;
@@ -791,7 +782,6 @@ struct HashmapAccumulator
       return __insert_success;
 
     hash = __compute_hash(key, __hashOpRHS);
-
     for (i = hash_begins[hash]; i != -1; i = hash_nexts[i]) {
       if (keys[i] == key) {
         //values[i] = (key_type)values[i] | (key_type)value;

--- a/src/common/KokkosKernels_HashmapAccumulator.hpp
+++ b/src/common/KokkosKernels_HashmapAccumulator.hpp
@@ -764,30 +764,21 @@ struct HashmapAccumulator
   }
 
 
-  template <typename team_member_t>
   KOKKOS_INLINE_FUNCTION
   int vector_atomic_insert_into_hash_TrackHashes (
-      const team_member_t & /* teamMember */,
-      const int &/* vector_size */,
-
-      size_type hash,
       const key_type &key,
       volatile size_type *used_size_,
       size_type *used_hash_size,
       size_type *used_hashes)
   {
-   hash = __compute_hash(key, __hashOpRHS);
+   size_type hash = __compute_hash(key, __hashOpRHS);
 
-    if (hash != -1) {
-      size_type i = hash_begins[hash];
-      for (; i != -1; i = hash_nexts[i]) {
-        if (keys[i] == key) {
-          //values[i] = (key_type)values[i] | (key_type)value;
-          return __insert_success;
-        }
+    size_type i = hash_begins[hash];
+    for (; i != -1; i = hash_nexts[i]) {
+      if (keys[i] == key) {
+        //values[i] = (key_type)values[i] | (key_type)value;
+        return __insert_success;
       }
-    } else {
-      return __insert_success;
     }
 
     size_type my_write_index = Kokkos::atomic_fetch_add(used_size_, size_type(1));

--- a/src/common/KokkosKernels_HashmapAccumulator.hpp
+++ b/src/common/KokkosKernels_HashmapAccumulator.hpp
@@ -179,6 +179,8 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    hash = __compute_hash(key, __hashOpRHS);
+
     size_type i = hash_begins[hash];
     for (; i != -1; i = hash_nexts[i]) {
       if (keys[i] == key) {
@@ -216,6 +218,8 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    hash = __compute_hash(key, __hashOpRHS);
+
     size_type i = hash_begins[hash];
     for (; i != -1; i = hash_nexts[i]) {
       if (keys[i] == key) {
@@ -253,6 +257,8 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    hash = __compute_hash(key, __hashOpRHS);
+
     //this function will only try to do an AND operation with
     //existing keys. If the key is not there, returns __insert_full.
     size_type i = hash_begins[hash];
@@ -275,6 +281,8 @@ struct HashmapAccumulator
       key_type key,
       value_type value)
   {
+    hash = __compute_hash(key, __hashOpRHS);
+
     //this function will only try to do an AND operation with
     //existing keys. If the key is not there, returns __insert_full.
     size_type i = hash_begins[hash];
@@ -300,6 +308,8 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    hash = __compute_hash(key, __hashOpRHS);
+
     //this function will directly insert, won't check if it exists already.
     if (*used_size_ >= __max_value_size) return __insert_full;
     size_type my_index = (*used_size_)++;
@@ -329,6 +339,8 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes) // TODO figure out what this "used_hashes" is for
   {
+    hash = __compute_hash(key, __hashOpRHS);
+
     //this function will directly insert, won't check if it exists already.
     if (*used_size_ >= __max_value_size) return __insert_full;
     size_type my_index = (*used_size_)++;
@@ -359,6 +371,8 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    hash = __compute_hash(key, __hashOpRHS);
+
     // issue-508, TODO: ensure that i < __max_value_size, but
     // need information about length of keys, values, and hash_nexts first!
     size_type i = hash_begins[hash];
@@ -394,6 +408,8 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    hash = __compute_hash(key, __hashOpRHS);
+
     size_type i = hash_begins[hash];
     for (; i != -1; i = hash_nexts[i]) {
       if (keys[i] == key) {
@@ -427,7 +443,7 @@ struct HashmapAccumulator
       const team_member_t & /* teamMember */,
       const int /* vector_size */,
 
-      size_type &hash,
+      size_type hash,
       const key_type key,
       const value_type value,
       volatile size_type *used_size_,
@@ -435,6 +451,8 @@ struct HashmapAccumulator
       size_type *used_hashes
       )
   {
+    hash = __compute_hash(key, __hashOpRHS);
+
     if (hash != -1) {
       size_type i = hash_begins[hash];
 
@@ -487,12 +505,14 @@ struct HashmapAccumulator
   int vector_atomic_insert_into_hash_mergeAdd_with_team_level_list_length (
       const team_member_t & /* teamMember */,
       const int /* vector_size */,
-      size_type &hash,
+      size_type hash,
       const key_type key,
       const value_type value,
       volatile size_type *used_size_,
       const size_type max_value_size_)
   {
+    hash = __compute_hash(key, __hashOpRHS);
+
     if (hash != -1) {
       size_type i = hash_begins[hash];
       for (; i != -1; i = hash_nexts[i]) {
@@ -571,11 +591,13 @@ struct HashmapAccumulator
   int vector_atomic_insert_into_hash (
       const team_member_t & /* teamMember */,
       const int &/* vector_size */,
-      const size_type &hash,
+      size_type hash,
       const key_type &key,
       volatile size_type *used_size_
       )
   {
+    hash = __compute_hash(key, __hashOpRHS);
+
     if (hash != -1) {
       size_type i = hash_begins[hash];
       for (; i != -1; i = hash_nexts[i]) {
@@ -627,11 +649,13 @@ struct HashmapAccumulator
   int vector_atomic_insert_into_hash_mergeOr (
       const team_member_t & /* teamMember */,
       const int &/* vector_size */,
-      const size_type &hash,
+      size_type hash,
       const key_type &key,
       const value_type &value,
       volatile size_type *used_size_)
   {
+    hash = __compute_hash(key, __hashOpRHS);
+
     if (hash != -1){
       size_type i = hash_begins[hash];
       for (; i != -1; i = hash_nexts[i]){
@@ -685,13 +709,15 @@ struct HashmapAccumulator
   int vector_atomic_insert_into_hash_mergeOr_TrackHashes (
       const team_member_t & /* teamMember */,
       const int &/* vector_size */,
-      const size_type &hash,
+      size_type hash,
       const key_type &key,
       const value_type &value,
       volatile size_type *used_size_,
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    hash = __compute_hash(key, __hashOpRHS);
+
     if (hash != -1){
       size_type i = hash_begins[hash];
       for (; i != -1; i = hash_nexts[i]) {
@@ -744,12 +770,14 @@ struct HashmapAccumulator
       const team_member_t & /* teamMember */,
       const int &/* vector_size */,
 
-      const size_type &hash,
+      size_type hash,
       const key_type &key,
       volatile size_type *used_size_,
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+   hash = __compute_hash(key, __hashOpRHS);
+
     if (hash != -1) {
       size_type i = hash_begins[hash];
       for (; i != -1; i = hash_nexts[i]) {

--- a/src/common/KokkosKernels_HashmapAccumulator.hpp
+++ b/src/common/KokkosKernels_HashmapAccumulator.hpp
@@ -78,8 +78,24 @@ struct HashmapAccumulator
 {
   // begin public members
   size_type hash_key_size;
-  size_type used_size;
+  // issue-508, TODO: It's best for used_size to be an internal member of this
+  // class but the current use-cases rely on used_size to be a parameter to the
+  // below insertion routines. One way to remove used_size as a parameter to the
+  // insertion routines is to instantiate multiple HashmapAccumulator objects
+  // (one hashmap for each team of threads) instead of using a single 
+  // HashmapAccumulator object for multiple teams of threads; this entails 
+  // major refactoring throughout the kokkos-kernels code base.
+  // Making used_size a pointer and private member of this
+  // class still exposes access to this member outside of the class and is
+  // not a good option.
+  // size_type used_size;
 
+  // issue-508, TODO: The hash_begins, hash_nexts, keys, values, INSERT_SUCCESS,
+  // and INSERT_FULL members should all be private as well. They should be managed
+  // solely by this HashmapAccumulator class: initialized in the constructor(s)
+  // and only managed by HashmapAccumulator insertion routines. Making these
+  // members private requires major refactoring throughout the kokkos-kernels
+  // code base.
   size_type*  hash_begins;
   size_type*  hash_nexts;
   key_type*   keys;
@@ -98,7 +114,6 @@ struct HashmapAccumulator
   KOKKOS_INLINE_FUNCTION
   HashmapAccumulator ():
         hash_key_size(),
-        used_size(0),
         hash_begins(),
         hash_nexts(),
         keys(),
@@ -131,7 +146,6 @@ struct HashmapAccumulator
       value_type *values_):
 
         hash_key_size(hash_key_size_),
-        used_size(0),
         hash_begins(hash_begins_),
         hash_nexts(hash_nexts_),
         keys(keys_),

--- a/src/common/KokkosKernels_HashmapAccumulator.hpp
+++ b/src/common/KokkosKernels_HashmapAccumulator.hpp
@@ -180,6 +180,8 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    if (key == -1)
+      return __insert_success;
     size_type hash = __compute_hash(key, __hashOpRHS);
 
     size_type i = hash_begins[hash];
@@ -218,6 +220,8 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    if (key == -1)
+      return __insert_success;
     size_type hash = __compute_hash(key, __hashOpRHS);
 
     size_type i = hash_begins[hash];
@@ -256,6 +260,8 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    if (key == -1)
+      return __insert_success;
     size_type hash = __compute_hash(key, __hashOpRHS);
 
     //this function will only try to do an AND operation with
@@ -279,6 +285,8 @@ struct HashmapAccumulator
       key_type key,
       value_type value)
   {
+    if (key == -1)
+      return __insert_success;
     size_type hash = __compute_hash(key, __hashOpRHS);
 
     //this function will only try to do an AND operation with
@@ -305,6 +313,8 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    if (key == -1)
+      return __insert_success;
     size_type hash = __compute_hash(key, __hashOpRHS);
 
     //this function will directly insert, won't check if it exists already.
@@ -335,6 +345,8 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes) // TODO figure out what this "used_hashes" is for
   {
+    if (key == -1)
+      return __insert_success;
     size_type hash = __compute_hash(key, __hashOpRHS);
 
     //this function will directly insert, won't check if it exists already.
@@ -366,6 +378,8 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    if (key == -1)
+      return __insert_success;
     size_type hash = __compute_hash(key, __hashOpRHS);
 
     // issue-508, TODO: ensure that i < __max_value_size, but
@@ -402,6 +416,8 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    if (key == -1)
+      return __insert_success;
     size_type hash = __compute_hash(key, __hashOpRHS);
 
     size_type i = hash_begins[hash];
@@ -440,6 +456,8 @@ struct HashmapAccumulator
       size_type *used_hashes
       )
   {
+    if (key == -1)
+      return __insert_success;
     size_type hash = __compute_hash(key, __hashOpRHS);
 
     if (hash != -1) {
@@ -500,6 +518,8 @@ struct HashmapAccumulator
       volatile size_type *used_size_,
       const size_type max_value_size_)
   {
+    if (key == -1)
+      return __insert_success;
     // Cannot compute hash here due to impl_speed use-case
     //hash = __compute_hash(key, __hashOpRHS);
 
@@ -562,6 +582,8 @@ struct HashmapAccumulator
       const value_type value,
       volatile size_type *used_size_)
   {
+    if (key == -1)
+      return __insert_success;
     return vector_atomic_insert_into_hash_mergeAdd_with_team_level_list_length(nullptr,
                                                                                0,
                                                                                __compute_hash(key, __hashOpRHS),
@@ -578,6 +600,8 @@ struct HashmapAccumulator
       volatile size_type *used_size_
       )
   {
+    if (key == -1)
+      return __insert_success;
     size_type hash = __compute_hash(key, __hashOpRHS);
 
     size_type i = hash_begins[hash];
@@ -628,6 +652,8 @@ struct HashmapAccumulator
       const value_type &value,
       volatile size_type *used_size_)
   {
+    if (key == -1)
+      return __insert_success;
     size_type hash = __compute_hash(key, __hashOpRHS);
 
     size_type i = hash_begins[hash];
@@ -682,6 +708,8 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    if (key == -1)
+      return __insert_success;
     size_type hash = __compute_hash(key, __hashOpRHS);
     size_type i = hash_begins[hash];
     size_type my_write_index;
@@ -734,9 +762,14 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
-   size_type hash = __compute_hash(key, __hashOpRHS);
-   size_type my_write_index;
-   size_type hashbeginning;
+    size_type hash;
+    size_type my_write_index;
+    size_type hashbeginning;
+
+    if (key == -1)
+      return __insert_success;
+
+    hash = __compute_hash(key, __hashOpRHS);
 
     size_type i = hash_begins[hash];
     for (; i != -1; i = hash_nexts[i]) {

--- a/src/common/KokkosKernels_HashmapAccumulator.hpp
+++ b/src/common/KokkosKernels_HashmapAccumulator.hpp
@@ -506,6 +506,17 @@ struct HashmapAccumulator
       //hash_nexts is updated second time as below.
       //but this is okay for spgemm,
       //because no two keys will be inserted into hashmap at the same time, as rows have unique columns.
+      
+      // Neither the compiler nor the execution unit can re-order the line
+      // directly below with the next line performing the atomic_exchange as the
+      // atomic exchange writes to hash_begins[hash] and this line reads from
+      // hash_begins[hash].
+      // This line is needed such that threads of execution can still access the
+      // old linked list, after hash_begins+hash has been atomically overwritten
+      // with my_write_index but before hash_nexts[my_write_index] is
+      // overwritten with hashbeginning. If this line was not here, threads may
+      // not be able to access the dangling linked list since
+      // hash_nexts[my_write_index] would still be -1.
       hash_nexts[my_write_index] = hash_begins[hash];
       #endif
 
@@ -573,6 +584,16 @@ struct HashmapAccumulator
       //but this is okay for spgemm,
       //because no two keys will be inserted into hashmap at the same time, as rows have unique columns.
       
+      // Neither the compiler nor the execution unit can re-order the line
+      // directly below with the next line performing the atomic_exchange as the
+      // atomic exchange writes to hash_begins[hash] and this line reads from
+      // hash_begins[hash].
+      // This line is needed such that threads of execution can still access the
+      // old linked list, after hash_begins+hash has been atomically overwritten
+      // with my_write_index but before hash_nexts[my_write_index] is
+      // overwritten with hashbeginning. If this line was not here, threads may
+      // not be able to access the dangling linked list since
+      // hash_nexts[my_write_index] would still be -1.
       hash_nexts[my_write_index] = hash_begins[hash];
       #endif
 

--- a/src/common/KokkosKernels_HashmapAccumulator.hpp
+++ b/src/common/KokkosKernels_HashmapAccumulator.hpp
@@ -58,9 +58,6 @@ template <typename size_type, typename key_type, typename value_type>
  *   ( https://ieeexplore.ieee.org/abstract/document/7965111/ ) in section III.D
  * 
  * Public members:
- * \var hash_key_size: 
- * \var used_size:   Atomic counter to measure how full the hashmap is.
- * 
  * \var hash_begins: Holds the beginning indices of the linked lists
  *                   corresponding to hash values [Begins]
  * \var hash_nexts:  Holds the indicies of the next elements
@@ -68,8 +65,8 @@ template <typename size_type, typename key_type, typename value_type>
  * \var keys:        This stores the column indices of (??) [Ids]
  * \var values:      This store the (matrix element?) numerical value of (??) [Values]
  * 
- * \var INSERT_SUCCESS:
- * \var INSERT_FULL:
+ * \var INSERT_SUCCESS: Value to return upon insertion success.
+ * \var INSERT_FULL:    Value to return upon insertion failure.
  * 
  * Private members:
  * \var __max_value_size: The length of the two arrays (keys and hash_nexts)
@@ -77,7 +74,6 @@ template <typename size_type, typename key_type, typename value_type>
 struct HashmapAccumulator
 {
   // begin public members
-  size_type hash_key_size;
   // issue-508, TODO: It's best for used_size to be an internal member of this
   // class but the current use-cases rely on used_size to be a parameter to the
   // below insertion routines. One way to remove used_size as a parameter to the
@@ -113,7 +109,6 @@ struct HashmapAccumulator
    */
   KOKKOS_INLINE_FUNCTION
   HashmapAccumulator ():
-        hash_key_size(),
         hash_begins(),
         hash_nexts(),
         keys(),
@@ -127,32 +122,31 @@ struct HashmapAccumulator
    * \brief parameterized constructor HashmapAccumulator
    * Sets used_size to 0, INSERT_SUCCESS to 0, and INSERT_FULL to 1.
    * 
-   * /param hash_key_size_: 
-   * /param value_size_:
-   * /param hash_begins_:
-   * /param hash_nexts_:
-   * /param keys_:
-   * /param values_:
+   * /param max_value_size_: The length of the two arrays (keys and hash_nexts)
+   * /param hash_begins_:    Holds the beginning indices of the linked lists
+   *                         corresponding to hash values [Begins]
+   * /param hash_nexts_:     Holds the indicies of the next elements
+   *                         within the linked list [Nexts]
+   * /param keys_:           This stores the column indices of (??) [Ids]
+   * /param values_:         This store the (matrix element?) numerical value of (??) [Values]
    * 
    * Assumption: hash_begins_ are all initialized to -1.
    */
   KOKKOS_INLINE_FUNCTION
   HashmapAccumulator (
-      const size_type hash_key_size_,
-      const size_type value_size_,
+      const size_type max_value_size_,
       size_type *hash_begins_,
       size_type *hash_nexts_,
       key_type *keys_,
       value_type *values_):
 
-        hash_key_size(hash_key_size_),
         hash_begins(hash_begins_),
         hash_nexts(hash_nexts_),
         keys(keys_),
         values(values_), 
         INSERT_SUCCESS(0), 
         INSERT_FULL(1),
-        __max_value_size(value_size_)
+        __max_value_size(max_value_size_)
         {}
 
 

--- a/src/common/KokkosKernels_HashmapAccumulator.hpp
+++ b/src/common/KokkosKernels_HashmapAccumulator.hpp
@@ -46,7 +46,7 @@
 #include <Kokkos_Atomic.hpp>
 #include <atomic>
 
-#define HASHMAPACCUMULATOR_ASSERT_ENABLED
+//#define HASHMAPACCUMULATOR_ASSERT_ENABLED
 
 namespace KokkosKernels {
 

--- a/src/common/KokkosKernels_HashmapAccumulator.hpp
+++ b/src/common/KokkosKernels_HashmapAccumulator.hpp
@@ -180,11 +180,13 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    size_type hash, i, my_index;
+
     if (key == -1)
       return __insert_success;
-    size_type hash = __compute_hash(key, __hashOpRHS);
 
-    size_type i = hash_begins[hash];
+    hash = __compute_hash(key, __hashOpRHS);
+    i = hash_begins[hash];
     for (; i != -1; i = hash_nexts[i]) {
       if (keys[i] == key) {
         values[i] = values[i] | value;
@@ -193,7 +195,7 @@ struct HashmapAccumulator
     }
 
     if (*used_size_ >= __max_value_size) return __insert_full;
-    size_type my_index = (*used_size_)++;
+    my_index = (*used_size_)++;
 
     if (hash_begins[hash] == -1) {
       used_hashes[used_hash_size[0]++] = hash;
@@ -220,11 +222,13 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    size_type hash, i, my_index;
+
     if (key == -1)
       return __insert_success;
-    size_type hash = __compute_hash(key, __hashOpRHS);
 
-    size_type i = hash_begins[hash];
+    hash = __compute_hash(key, __hashOpRHS);
+    i = hash_begins[hash];
     for (; i != -1; i = hash_nexts[i]) {
       if (keys[i] == key) {
         values2[i] = values2[i] | (values[i] & value);
@@ -234,7 +238,7 @@ struct HashmapAccumulator
     }
 
     if (*used_size_ >= __max_value_size) return __insert_full;
-    size_type my_index = (*used_size_)++;
+    my_index = (*used_size_)++;
 
     if (hash_begins[hash] == -1) {
       used_hashes[used_hash_size[0]++] = hash;
@@ -260,13 +264,15 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    size_type hash, i;
+
     if (key == -1)
       return __insert_success;
-    size_type hash = __compute_hash(key, __hashOpRHS);
 
     //this function will only try to do an AND operation with
     //existing keys. If the key is not there, returns __insert_full.
-    size_type i = hash_begins[hash];
+    hash = __compute_hash(key, __hashOpRHS);
+    i = hash_begins[hash];
     for (; i != -1; i = hash_nexts[i]) {
       if (keys[i] == key) {
         //values2[i] = values2[i] | (values[i] & value);
@@ -285,13 +291,15 @@ struct HashmapAccumulator
       key_type key,
       value_type value)
   {
+    size_type hash, i;
+
     if (key == -1)
       return __insert_success;
-    size_type hash = __compute_hash(key, __hashOpRHS);
 
     //this function will only try to do an AND operation with
     //existing keys. If the key is not there, returns __insert_full.
-    size_type i = hash_begins[hash];
+    hash = __compute_hash(key, __hashOpRHS);
+    i = hash_begins[hash];
     for (; i != -1; i = hash_nexts[i])
     {
       if (keys[i] == key) {
@@ -313,13 +321,15 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    size_type hash, my_index;
+
     if (key == -1)
       return __insert_success;
-    size_type hash = __compute_hash(key, __hashOpRHS);
 
     //this function will directly insert, won't check if it exists already.
+    hash = __compute_hash(key, __hashOpRHS);
     if (*used_size_ >= __max_value_size) return __insert_full;
-    size_type my_index = (*used_size_)++;
+    my_index = (*used_size_)++;
 
     keys[my_index] = key;
     values[my_index] = value;
@@ -345,13 +355,15 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes) // TODO figure out what this "used_hashes" is for
   {
+    size_type hash, my_index;
+
     if (key == -1)
       return __insert_success;
-    size_type hash = __compute_hash(key, __hashOpRHS);
 
     //this function will directly insert, won't check if it exists already.
+    hash = __compute_hash(key, __hashOpRHS);
     if (*used_size_ >= __max_value_size) return __insert_full;
-    size_type my_index = (*used_size_)++;
+    my_index = (*used_size_)++;
 
     keys[my_index] = key;
     values[my_index] = value;
@@ -378,13 +390,15 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    size_type hash, i, my_index;
+
     if (key == -1)
       return __insert_success;
-    size_type hash = __compute_hash(key, __hashOpRHS);
 
     // issue-508, TODO: ensure that i < __max_value_size, but
     // need information about length of keys, values, and hash_nexts first!
-    size_type i = hash_begins[hash];
+    hash = __compute_hash(key, __hashOpRHS);
+    i = hash_begins[hash];
     for (; i != -1; i = hash_nexts[i]) {
       if (keys[i] == key) {
         values[i] = values[i] + value;
@@ -392,7 +406,7 @@ struct HashmapAccumulator
       }
     }
 
-    size_type my_index = (*used_size_)++;
+    my_index = (*used_size_)++;
 
     if (hash_begins[hash] == -1) {
       used_hashes[used_hash_size[0]++] = hash;
@@ -416,18 +430,20 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    size_type hash, i, my_index;
+
     if (key == -1)
       return __insert_success;
-    size_type hash = __compute_hash(key, __hashOpRHS);
 
-    size_type i = hash_begins[hash];
+    hash = __compute_hash(key, __hashOpRHS);
+    i = hash_begins[hash];
     for (; i != -1; i = hash_nexts[i]) {
       if (keys[i] == key) {
         return __insert_success;
       }
     }
 
-    size_type my_index = (*used_size_)++;
+    my_index = (*used_size_)++;
 
     if (hash_begins[hash] == -1) {
       used_hashes[used_hash_size[0]++] = hash;
@@ -456,12 +472,14 @@ struct HashmapAccumulator
       size_type *used_hashes
       )
   {
+    size_type hash, i, my_write_index, hashbeginning;
+
     if (key == -1)
       return __insert_success;
-    size_type hash = __compute_hash(key, __hashOpRHS);
 
+    hash = __compute_hash(key, __hashOpRHS);
     if (hash != -1) {
-      size_type i = hash_begins[hash];
+      i = hash_begins[hash];
 
       for (; i != -1; i = hash_nexts[i]) {
         if (keys[i] == key) {
@@ -473,7 +491,7 @@ struct HashmapAccumulator
       return __insert_success;
     }
 
-    size_type my_write_index = Kokkos::atomic_fetch_add(used_size_, size_type(1));
+    my_write_index = Kokkos::atomic_fetch_add(used_size_, size_type(1));
 
     if (my_write_index >= __max_value_size) {
       return __insert_full;
@@ -496,7 +514,7 @@ struct HashmapAccumulator
       hash_nexts[my_write_index] = hash_begins[hash];
       #endif
 
-      size_type hashbeginning = Kokkos::atomic_exchange(hash_begins+hash, my_write_index);
+      hashbeginning = Kokkos::atomic_exchange(hash_begins+hash, my_write_index);
       if (hashbeginning == -1) {
         used_hashes[Kokkos::atomic_fetch_add(used_hash_size, size_type(1))] = hash;
       }
@@ -518,10 +536,10 @@ struct HashmapAccumulator
       volatile size_type *used_size_,
       const size_type max_value_size_)
   {
-    if (key == -1)
-      return __insert_success;
     // Cannot compute hash here due to impl_speed use-case
     //hash = __compute_hash(key, __hashOpRHS);
+    if (key == -1)
+      return __insert_success;
 
     if (hash != -1) {
       size_type i = hash_begins[hash];
@@ -584,6 +602,7 @@ struct HashmapAccumulator
   {
     if (key == -1)
       return __insert_success;
+
     return vector_atomic_insert_into_hash_mergeAdd_with_team_level_list_length(nullptr,
                                                                                0,
                                                                                __compute_hash(key, __hashOpRHS),
@@ -600,18 +619,20 @@ struct HashmapAccumulator
       volatile size_type *used_size_
       )
   {
+    size_type hash, i, my_write_index, hashbeginning;
+
     if (key == -1)
       return __insert_success;
-    size_type hash = __compute_hash(key, __hashOpRHS);
 
-    size_type i = hash_begins[hash];
+    hash = __compute_hash(key, __hashOpRHS);
+    i = hash_begins[hash];
     for (; i != -1; i = hash_nexts[i]) {
       if (keys[i] == key) {
         return __insert_success;
       }
     }
 
-    size_type my_write_index = Kokkos::atomic_fetch_add(used_size_, size_type(1));
+    my_write_index = Kokkos::atomic_fetch_add(used_size_, size_type(1));
 
     if (my_write_index >= __max_value_size) {
       return __insert_full;
@@ -633,7 +654,7 @@ struct HashmapAccumulator
       hash_nexts[my_write_index] = hash_begins[hash];
       #endif
 
-      size_type hashbeginning = Kokkos::atomic_exchange(hash_begins+hash, my_write_index);
+      hashbeginning = Kokkos::atomic_exchange(hash_begins+hash, my_write_index);
       hash_nexts[my_write_index] = hashbeginning;
       return __insert_success;
     }
@@ -652,11 +673,13 @@ struct HashmapAccumulator
       const value_type &value,
       volatile size_type *used_size_)
   {
+    size_type hash, i, my_write_index, hashbeginning;
+
     if (key == -1)
       return __insert_success;
-    size_type hash = __compute_hash(key, __hashOpRHS);
 
-    size_type i = hash_begins[hash];
+    hash = __compute_hash(key, __hashOpRHS);
+    i = hash_begins[hash];
     for (; i != -1; i = hash_nexts[i]){
       if (keys[i] == key){
         values[i] = (key_type)values[i] | (key_type)value;
@@ -664,7 +687,7 @@ struct HashmapAccumulator
       }
     }
 
-    size_type my_write_index = Kokkos::atomic_fetch_add(used_size_, size_type(1));
+    my_write_index = Kokkos::atomic_fetch_add(used_size_, size_type(1));
 
     if (my_write_index >= __max_value_size) {
       return __insert_full;
@@ -687,7 +710,7 @@ struct HashmapAccumulator
       hash_nexts[my_write_index] = hash_begins[hash];
       #endif
 
-      size_type hashbeginning = Kokkos::atomic_exchange(hash_begins+hash, my_write_index);
+      hashbeginning = Kokkos::atomic_exchange(hash_begins+hash, my_write_index);
       hash_nexts[my_write_index] = hashbeginning;
       return __insert_success;
     }
@@ -708,14 +731,14 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
+    size_type hash, i, my_write_index, hashbeginning;
+
     if (key == -1)
       return __insert_success;
-    size_type hash = __compute_hash(key, __hashOpRHS);
-    size_type i = hash_begins[hash];
-    size_type my_write_index;
-    size_type hashbeginning;
 
-    for (; i != -1; i = hash_nexts[i]) {
+    hash = __compute_hash(key, __hashOpRHS);
+
+    for (i = hash_begins[hash]; i != -1; i = hash_nexts[i]) {
       if (keys[i] == key) {
         values[i] = (key_type)values[i] | (key_type)value;
         return __insert_success;
@@ -762,17 +785,14 @@ struct HashmapAccumulator
       size_type *used_hash_size,
       size_type *used_hashes)
   {
-    size_type hash;
-    size_type my_write_index;
-    size_type hashbeginning;
+    size_type hash, i, my_write_index, hashbeginning;
 
     if (key == -1)
       return __insert_success;
 
     hash = __compute_hash(key, __hashOpRHS);
 
-    size_type i = hash_begins[hash];
-    for (; i != -1; i = hash_nexts[i]) {
+    for (i = hash_begins[hash]; i != -1; i = hash_nexts[i]) {
       if (keys[i] == key) {
         //values[i] = (key_type)values[i] | (key_type)value;
         return __insert_success;

--- a/src/common/KokkosKernels_Utils.hpp
+++ b/src/common/KokkosKernels_Utils.hpp
@@ -60,6 +60,7 @@
 #define _KOKKOSKERNELSUTILS_HPP
 
 
+
 namespace KokkosKernels{
 
 

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
@@ -278,10 +278,10 @@ struct KokkosSPGEMM
           //std::cout << " pow2_hash_func:" << pow2_hash_func << " prev_nset_ind:" << prev_nset_ind << std::endl;
           //insert prev_nset_ind to hashmap
           hm2.sequential_insert_into_hash_TrackHashes(
-              prev_nset_ind & pow2_hash_func, prev_nset_ind,
-              &used_size,
-              &globally_used_hash_count,
-              globally_used_hash_indices
+            prev_nset_ind,
+            &used_size,
+            &globally_used_hash_count,
+            globally_used_hash_indices
           );
           //++used_size;
           prev_nset_ind = n_set_index;
@@ -289,10 +289,10 @@ struct KokkosSPGEMM
       }
       //insert prev_nset_ind to hashmap
       hm2.sequential_insert_into_hash_TrackHashes(
-          prev_nset_ind & pow2_hash_func, prev_nset_ind,
-          &used_size,
-          &globally_used_hash_count,
-          globally_used_hash_indices
+        prev_nset_ind,
+        &used_size,
+        &globally_used_hash_count,
+        globally_used_hash_indices
       );
       //++used_size;
     }
@@ -363,10 +363,10 @@ struct KokkosSPGEMM
         prev_nset = prev_nset | n_set;
       } else {
         hm2.sequential_insert_into_hash_mergeOr_TrackHashes(
-            prev_nset_ind & pow2_hash_func, prev_nset_ind, prev_nset,
-            &used_size,
-            &globally_used_hash_count,
-            globally_used_hash_indices
+          prev_nset_ind, prev_nset,
+          &used_size,
+          &globally_used_hash_count,
+          globally_used_hash_indices
         );
 
         //pset_index_entries[used_size + outrowBegin] = prev_nset_ind ;
@@ -377,10 +377,10 @@ struct KokkosSPGEMM
       }
     }
     hm2.sequential_insert_into_hash_mergeOr_TrackHashes(
-        prev_nset_ind & pow2_hash_func, prev_nset_ind, prev_nset,
-        &used_size,
-        &globally_used_hash_count,
-        globally_used_hash_indices
+      prev_nset_ind, prev_nset,
+      &used_size,
+      &globally_used_hash_count,
+      globally_used_hash_indices
     );
     for (nnz_lno_t i = 0; i < globally_used_hash_count ; ++i){
       hm2.hash_begins[globally_used_hash_indices[i]] = -1;
@@ -666,10 +666,10 @@ struct KokkosSPGEMM
 #ifdef KOKKOSKERNELSMOREMEM
       //if one of the inserts was successfull, which means we run out shared memory
       if (overall_num_unsuccess){
-        nnz_lno_t hash_ = -1;
-        if (num_unsuccess) hash_ = n_set_index % left_work;
-        hm2.vector_atomic_insert_into_hash_mergeOr(
-            teamMember, vector_size, hash_,n_set_index,n_set, used_hash_sizes + 1);
+        if (num_unsuccess) {
+          hm2.vector_atomic_insert_into_hash_mergeOr(
+            n_set_index,n_set, used_hash_sizes + 1);
+        }
       }
 #else
       //if one of the inserts was successfull, which means we run out shared memory

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
@@ -655,11 +655,11 @@ struct KokkosSPGEMM
           [&] (const int i, int &overall_num_unsuccess_) {
           n_set_index = result_keys[i];
           n_set = result_vals[i];
-          nnz_lno_t hash = n_set_index & shared_memory_hash_func;//% shmem_hash_size;
-          if (n_set_index == -1) hash = -1;
-          num_unsuccess = hm.vector_atomic_insert_into_hash_mergeOr(
-                            teamMember, vector_size, hash, n_set_index,
-                            n_set, used_hash_sizes);
+          if (n_set_index != -1) {
+            num_unsuccess = hm.vector_atomic_insert_into_hash_mergeOr(
+                              n_set_index,
+                              n_set, used_hash_sizes);
+          }
           overall_num_unsuccess_ += num_unsuccess;
       }, overall_num_unsuccess);
 
@@ -939,6 +939,7 @@ bool KokkosSPGEMM
       }
 
       Kokkos::Impl::Timer timer_count;
+      // HashmapAccumulator is populated here
       if(use_unordered_compress)
         Kokkos::parallel_for( "KokkosSparse::TwoStepZipMatrix::use_unordered_compress", team_count2_policy_t(n / team_row_chunk_size + 1 , suggested_team_size, suggested_vector_size), sszm_compressMatrix);
       else

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
@@ -687,10 +687,7 @@ struct KokkosSPGEMM
 		      hm2.hash_nexts = (nnz_lno_t *) (globally_used_hash_indices + pow2_hash_size * 2);
 		      l2_allocated = true;
 	      }
-	      //then for those who failed we insert it again to L2-accumulator.
-	      nnz_lno_t hash = -1;
-	      if (num_unsuccess) hash = n_set_index & (pow2_hash_func);
-
+	      
 	      //this parallel_for is not really needed.
 	      //we just need a sync threads at the end of the insertion.
 	      //Basically, we do not want
@@ -702,9 +699,12 @@ struct KokkosSPGEMM
                  Kokkos::ThreadVectorRange(teamMember, vector_size),
 	          [&] (nnz_lno_t i) {
 #endif
+        //then for those who failed we insert it again to L2-accumulator.
+	      if (num_unsuccess) {
 		      hm2.vector_atomic_insert_into_hash_mergeOr_TrackHashes(
-			      teamMember, vector_size, hash,n_set_index,n_set, used_hash_sizes + 1,
+			      n_set_index,n_set, used_hash_sizes + 1,
 			      globally_used_hash_count, globally_used_hash_indices);
+        }
 #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
 		});
 #endif

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
@@ -279,7 +279,7 @@ struct KokkosSPGEMM
           //insert prev_nset_ind to hashmap
           hm2.sequential_insert_into_hash_TrackHashes(
               prev_nset_ind & pow2_hash_func, prev_nset_ind,
-              &used_size, hm2.max_value_size,
+              &used_size,
               &globally_used_hash_count,
               globally_used_hash_indices
           );
@@ -290,7 +290,7 @@ struct KokkosSPGEMM
       //insert prev_nset_ind to hashmap
       hm2.sequential_insert_into_hash_TrackHashes(
           prev_nset_ind & pow2_hash_func, prev_nset_ind,
-          &used_size, hm2.max_value_size,
+          &used_size,
           &globally_used_hash_count,
           globally_used_hash_indices
       );
@@ -364,7 +364,7 @@ struct KokkosSPGEMM
       } else {
         hm2.sequential_insert_into_hash_mergeOr_TrackHashes(
             prev_nset_ind & pow2_hash_func, prev_nset_ind, prev_nset,
-            &used_size, hm2.max_value_size,
+            &used_size,
             &globally_used_hash_count,
             globally_used_hash_indices
         );
@@ -378,7 +378,7 @@ struct KokkosSPGEMM
     }
     hm2.sequential_insert_into_hash_mergeOr_TrackHashes(
         prev_nset_ind & pow2_hash_func, prev_nset_ind, prev_nset,
-        &used_size, hm2.max_value_size,
+        &used_size,
         &globally_used_hash_count,
         globally_used_hash_indices
     );
@@ -658,8 +658,8 @@ struct KokkosSPGEMM
           nnz_lno_t hash = n_set_index & shared_memory_hash_func;//% shmem_hash_size;
           if (n_set_index == -1) hash = -1;
           num_unsuccess = hm.vector_atomic_insert_into_hash_mergeOr(
-                              teamMember, vector_size, hash,n_set_index,
-			      n_set, used_hash_sizes, shmem_hash_size);
+                            teamMember, vector_size, hash, n_set_index,
+                            n_set, used_hash_sizes);
           overall_num_unsuccess_ += num_unsuccess;
       }, overall_num_unsuccess);
 
@@ -669,7 +669,7 @@ struct KokkosSPGEMM
         nnz_lno_t hash_ = -1;
         if (num_unsuccess) hash_ = n_set_index % hm2.hash_key_size;
         hm2.vector_atomic_insert_into_hash_mergeOr(
-            teamMember, vector_size, hash_,n_set_index,n_set, used_hash_sizes + 1, hm2.max_value_size);
+            teamMember, vector_size, hash_,n_set_index,n_set, used_hash_sizes + 1);
       }
 #else
       //if one of the inserts was successfull, which means we run out shared memory
@@ -703,8 +703,8 @@ struct KokkosSPGEMM
 	          [&] (nnz_lno_t i) {
 #endif
 		      hm2.vector_atomic_insert_into_hash_mergeOr_TrackHashes(
-			      teamMember, vector_size, hash,n_set_index,n_set, used_hash_sizes + 1, hm2.max_value_size
-			      ,globally_used_hash_count, globally_used_hash_indices);
+			      teamMember, vector_size, hash,n_set_index,n_set, used_hash_sizes + 1,
+			      globally_used_hash_count, globally_used_hash_indices);
 #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
 		});
 #endif

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
@@ -239,7 +239,7 @@ struct KokkosSPGEMM
     const nnz_lno_t team_row_end = KOKKOSKERNELS_MACRO_MIN(team_row_begin + team_row_chunk_size, numrows);
 
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t>
-    hm2(pow2_hash_size, max_row_size,NULL, NULL, NULL, NULL);
+    hm2(max_row_size,NULL, NULL, NULL, NULL);
 
     volatile nnz_lno_t * tmp = NULL;
     size_t tid = get_thread_id(team_row_begin + teamMember.team_rank());
@@ -312,7 +312,7 @@ struct KokkosSPGEMM
     const nnz_lno_t team_row_begin = teamMember.league_rank() * team_row_chunk_size;
     const nnz_lno_t team_row_end = KOKKOSKERNELS_MACRO_MIN(team_row_begin + team_row_chunk_size, numrows);
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t>
-    hm2(pow2_hash_size, max_row_size,NULL, NULL, NULL, NULL);
+    hm2(max_row_size,NULL, NULL, NULL, NULL);
 
     volatile nnz_lno_t * tmp = NULL;
     size_t tid = get_thread_id(team_row_begin + teamMember.team_rank());
@@ -547,7 +547,7 @@ struct KokkosSPGEMM
 
     //first level hashmap
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t>
-      hm(shmem_hash_size, shmem_hash_size, begins, nexts, keys, vals);
+      hm(shmem_hash_size, begins, nexts, keys, vals);
 
     size_type rowBegin = row_map(row_ind);
     size_type rowBeginP = rowBegin;
@@ -561,7 +561,7 @@ struct KokkosSPGEMM
       hm2(left_work, left_work, pset_index_begins + rowBegin, pset_index_nexts+ rowBegin, pset_index_entries+ rowBegin, pset_entries+ rowBegin);
 #else
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t>
-      hm2(left_work, left_work, /*pset_index_begins + rowBegin*/ NULL,
+      hm2(left_work, /*pset_index_begins + rowBegin*/ NULL,
           NULL, //pset_index_nexts+ rowBegin,
           pset_index_entries+ rowBegin,
           pset_entries+ rowBegin);

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
@@ -659,8 +659,8 @@ struct KokkosSPGEMM
             num_unsuccess = hm.vector_atomic_insert_into_hash_mergeOr(
                               n_set_index,
                               n_set, used_hash_sizes);
+            overall_num_unsuccess_ += num_unsuccess;
           }
-          overall_num_unsuccess_ += num_unsuccess;
       }, overall_num_unsuccess);
 
 #ifdef KOKKOSKERNELSMOREMEM

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
@@ -346,8 +346,6 @@ struct KokkosSPGEMM
       const size_type c_row_begin = rowmapC[row_index];
       const size_type c_row_end = rowmapC[row_index + 1];
 
-      const nnz_lno_t global_memory_hash_size = nnz_lno_t(c_row_end - c_row_begin);
-      hm2.max_value_size = global_memory_hash_size;
       hm2.keys = pEntriesC + c_row_begin;
       hm2.values = pvaluesC + c_row_begin;
 
@@ -373,8 +371,8 @@ struct KokkosSPGEMM
           //int insertion =
           hm2.sequential_insert_into_hash_mergeAdd_TrackHashes(
               hash, b_col_ind, b_val,
-              &used_hash_sizes, hm2.max_value_size
-              ,&globally_used_hash_count,
+              &used_hash_sizes,
+              &globally_used_hash_count,
               globally_used_hash_indices
           );
         }
@@ -423,7 +421,6 @@ struct KokkosSPGEMM
       const size_type c_row_end = rowmapC[row_index + 1];
 
       const nnz_lno_t global_memory_hash_size = nnz_lno_t(c_row_end - c_row_begin);
-      hm2.max_value_size = global_memory_hash_size;
 
       const size_type col_begin = row_mapA[row_index];
       const nnz_lno_t left_work = row_mapA[row_index + 1] - col_begin;
@@ -445,8 +442,8 @@ struct KokkosSPGEMM
           //int insertion =
           hm2.sequential_insert_into_hash_mergeAdd_TrackHashes(
               hash, b_col_ind, b_val,
-              &used_hash_sizes, hm2.max_value_size
-              ,&globally_used_hash_count,
+              &used_hash_sizes,
+              &globally_used_hash_count,
               globally_used_hash_indices
           );
         }
@@ -538,7 +535,6 @@ struct KokkosSPGEMM
 		  tmp += pow2_hash_size ;
 		  hm2.hash_nexts = (nnz_lno_t *) (tmp);
 	  }
-      hm2.max_value_size = global_memory_hash_size;
       hm2.keys = pEntriesC + c_row_begin;
       hm2.values = pvaluesC + c_row_begin;
 
@@ -574,23 +570,17 @@ struct KokkosSPGEMM
           //hash = b_col_ind % shmem_key_size;
           nnz_lno_t hash = b_col_ind & thread_shared_memory_hash_func;
           volatile int num_unsuccess = hm.vector_atomic_insert_into_hash_mergeAdd(
-              teamMember, vector_size,
-              hash, b_col_ind, b_val,
-              used_hash_sizes,
-              thread_shmem_key_size);
-          if (num_unsuccess){
-
+                                         teamMember, vector_size,
+                                         hash, b_col_ind, b_val,
+                                         used_hash_sizes);
+          if (num_unsuccess) {
         	  hash = b_col_ind & pow2_hash_func;
         	  hm2.vector_atomic_insert_into_hash_mergeAdd_TrackHashes(
-        			  teamMember, vector_size,
-					  hash,b_col_ind,b_val,
-					  used_hash_sizes + 1, hm2.max_value_size
-					  ,globally_used_hash_count, globally_used_hash_indices
-        	  );
-
-
+              teamMember, vector_size,
+              hash,b_col_ind,b_val,
+              used_hash_sizes + 1,
+              globally_used_hash_count, globally_used_hash_indices);
           }
-
         });
       }
 

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
@@ -364,15 +364,14 @@ struct KokkosSPGEMM
           nnz_lno_t b_col_ind = entriesB[adjind];
           scalar_t b_val = valuesB[adjind] * valA;
           //nnz_lno_t hash = (b_col_ind * 107) & pow2_hash_func;
-          nnz_lno_t hash = b_col_ind & pow2_hash_func;
 
           //this has to be a success, we do not need to check for the success.
           //int insertion =
           hm2.sequential_insert_into_hash_mergeAdd_TrackHashes(
-              hash, b_col_ind, b_val,
-              &used_hash_sizes,
-              &globally_used_hash_count,
-              globally_used_hash_indices
+            b_col_ind, b_val,
+            &used_hash_sizes,
+            &globally_used_hash_count,
+            globally_used_hash_indices
           );
         }
       }
@@ -443,10 +442,10 @@ struct KokkosSPGEMM
           //this has to be a success, we do not need to check for the success.
           //int insertion =
           hm2.sequential_insert_into_hash_mergeAdd_TrackHashes(
-              hash, b_col_ind, b_val,
-              &used_hash_sizes,
-              &globally_used_hash_count,
-              globally_used_hash_indices
+            b_col_ind, b_val,
+            &used_hash_sizes,
+            &globally_used_hash_count,
+            globally_used_hash_indices
           );
         }
       }
@@ -569,19 +568,16 @@ struct KokkosSPGEMM
           const size_type adjind = i + rowBegin;
           nnz_lno_t b_col_ind = entriesB[adjind];
           scalar_t b_val = valuesB[adjind] * valA;
-          //hash = b_col_ind % shmem_key_size;
-          nnz_lno_t hash = b_col_ind & thread_shared_memory_hash_func;
           volatile int num_unsuccess = hm.vector_atomic_insert_into_hash_mergeAdd(
-                                         teamMember, vector_size,
-                                         hash, b_col_ind, b_val,
-                                         used_hash_sizes);
+                                         b_col_ind, b_val,
+                                         used_hash_sizes
+                                       );
           if (num_unsuccess) {
-        	  hash = b_col_ind & pow2_hash_func;
         	  hm2.vector_atomic_insert_into_hash_mergeAdd_TrackHashes(
-              teamMember, vector_size,
-              hash,b_col_ind,b_val,
+              b_col_ind,b_val,
               used_hash_sizes + 1,
-              globally_used_hash_count, globally_used_hash_indices);
+              globally_used_hash_count, globally_used_hash_indices
+            );
           }
         });
       }

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
@@ -344,7 +344,6 @@ struct KokkosSPGEMM
       nnz_lno_t used_hash_sizes = 0;
 
       const size_type c_row_begin = rowmapC[row_index];
-      const size_type c_row_end = rowmapC[row_index + 1];
 
       hm2.keys = pEntriesC + c_row_begin;
       hm2.values = pvaluesC + c_row_begin;

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
@@ -325,7 +325,7 @@ struct KokkosSPGEMM
     const nnz_lno_t team_row_end = KOKKOSKERNELS_MACRO_MIN(team_row_begin + team_work_size, numrows);
 
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t>
-    hm2(pow2_hash_size, pow2_hash_size,NULL, NULL, NULL, NULL);
+    hm2(pow2_hash_size,NULL, NULL, NULL, NULL);
 
     volatile nnz_lno_t * tmp = NULL;
     size_t tid = get_thread_id(team_row_begin + teamMember.team_rank());
@@ -394,7 +394,7 @@ struct KokkosSPGEMM
     const nnz_lno_t team_row_end = KOKKOSKERNELS_MACRO_MIN(team_row_begin + team_work_size, numrows);
 
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t>
-    hm2(pow2_hash_size, pow2_hash_size,NULL, NULL, NULL, NULL);
+    hm2(pow2_hash_size,NULL, NULL, NULL, NULL);
 
     volatile nnz_lno_t * tmp = NULL;
     size_t tid = get_thread_id(team_row_begin + teamMember.team_rank());
@@ -499,10 +499,10 @@ struct KokkosSPGEMM
     scalar_t * vals = KokkosKernels::Impl::alignPtr<char*, scalar_t>(all_shared_memory);
 
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t>
-    hm(thread_shmem_hash_size, thread_shmem_key_size, begins, nexts, keys, vals);
+    hm(thread_shmem_key_size, begins, nexts, keys, vals);
 
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t>
-    hm2(pow2_hash_size, pow2_hash_size,
+    hm2(pow2_hash_size,
         NULL, NULL, NULL, NULL);
     Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end), [&] (const nnz_lno_t& row_index) {
       const size_type c_row_begin = rowmapC[row_index];

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_seq.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_seq.hpp
@@ -93,7 +93,6 @@ void spgemm_debug_symbolic(
 
   size_type result_index = 0;
 
-
   h_rmc(0) = 0;
   for (lno_t i = 0; i < m; ++i){
     const size_type a_row_begin = h_rma(i);

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
@@ -355,13 +355,13 @@ struct KokkosSPGEMM
     scalar_t* vals = KokkosKernels::Impl::alignPtr<char*, scalar_t>(all_shared_memory);
 
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t>
-    hm(shmem_hash_size, shmem_key_size, begins, nexts, keys, vals);
+    hm(shmem_key_size, begins, nexts, keys, vals);
 
     // TODO: understand below parallel_for loop.
     // GOAL: Inialize hm2 with correct __max_value_size.
 
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t>
-    hm2(0, 0,
+    hm2(0,
         NULL, NULL, NULL, NULL);
     /*
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t>
@@ -373,7 +373,6 @@ struct KokkosSPGEMM
       const size_type c_row_begin = rowmapC[row_index];
       const nnz_lno_t global_memory_hash_size = nnz_lno_t(rowmapC[row_index + 1] - c_row_begin);
 
-      hm2.hash_key_size = global_memory_hash_size;
       hm2.keys = pEntriesC + c_row_begin;
       hm2.values = pvaluesC + c_row_begin;
       hm2.hash_begins = pbeginsC + c_row_begin;

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
@@ -407,21 +407,18 @@ struct KokkosSPGEMM
           nnz_lno_t work_to_handle = KOKKOSKERNELS_MACRO_MIN(vector_size, left_work_);
           nnz_lno_t b_col_ind = -1;
           scalar_t b_val = -1;
-          nnz_lno_t hash = -1;
           Kokkos::parallel_for(
               Kokkos::ThreadVectorRange(teamMember, work_to_handle),
               [&] (nnz_lno_t i) {
             const size_type adjind = i + rowBegin;
             b_col_ind = entriesB[adjind];
             b_val = valuesB[adjind] * valA;
-            //hash = b_col_ind % shmem_key_size;
-            hash = b_col_ind & shared_memory_hash_func;
           });
 
           int num_unsuccess = hm.vector_atomic_insert_into_hash_mergeAdd(
-              teamMember, vector_size,
-              hash, b_col_ind, b_val,
-              used_hash_sizes);
+                                b_col_ind, b_val,
+                                used_hash_sizes
+                              );
 
           int overall_num_unsuccess = 0;
 

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
@@ -354,14 +354,15 @@ struct KokkosSPGEMM
     all_shared_memory += sizeof(nnz_lno_t) * shmem_key_size;
     scalar_t* vals = KokkosKernels::Impl::alignPtr<char*, scalar_t>(all_shared_memory);
 
-    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t>
-    hm(shmem_key_size, begins, nexts, keys, vals);
+    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t,KokkosKernels::Experimental::HashOpType::bitwiseAnd>
+    hm(shmem_key_size, shared_memory_hash_func, begins, nexts, keys, vals);
 
-    // TODO: understand below parallel_for loop.
-    // GOAL: Inialize hm2 with correct __max_value_size.
+    // issue-508, TODO: understand and re-work below parallel_for loop.
+    // Inialize hm2 with correct max_value_size and hashOpRHS
+    // global_memory_hash_size is computed, per team of threads -- this is hashOpRHS.
 
-    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t>
-    hm2(0,
+    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t,KokkosKernels::Experimental::HashOpType::modulo>
+    hm2(0, 0,
         NULL, NULL, NULL, NULL);
     /*
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t>

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
@@ -580,16 +580,14 @@ struct KokkosSPGEMM
             //hm2.values = (nnz_lno_t *) (tmp);
           }
 
-          nnz_lno_t hash_ = -1;
-          if (num_unsuccess) hash_ = b_set_ind & pow2_hash_func;
-
-          //int insertion =
-          hm2.vector_atomic_insert_into_hash_TrackHashes(
-              teamMember, vector_size,
-              hash_,b_set_ind,
-              used_hash_sizes + 1,
-              globally_used_hash_count, globally_used_hash_indices
-              );
+          if (num_unsuccess) {
+            //int insertion =
+            hm2.vector_atomic_insert_into_hash_TrackHashes(
+                b_set_ind,
+                used_hash_sizes + 1,
+                globally_used_hash_count, globally_used_hash_indices
+                );
+          }
 
         }
         left_work -= work_to_handle;

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
@@ -229,14 +229,12 @@ struct KokkosSPGEMM
 
     const nnz_lno_t team_row_begin = teamMember.league_rank() * team_row_chunk_size;
     const nnz_lno_t team_row_end = KOKKOSKERNELS_MACRO_MIN(team_row_begin + team_row_chunk_size, numrows);
-    nnz_lno_t chunk_size = 0;
 
     //get memory from memory pool.
     volatile nnz_lno_t * tmp = NULL;
     size_t tid = get_thread_id(team_row_begin + teamMember.team_rank());
     while (tmp == NULL){
       tmp = (volatile nnz_lno_t * )( m_space.allocate_chunk(tid));
-      // issue-508, TODO: chunk_size = ??
     }
 
     //set first to globally used hash indices.
@@ -245,7 +243,7 @@ struct KokkosSPGEMM
 
     //create hashmap accumulator.
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t,KokkosKernels::Experimental::HashOpType::bitwiseAnd> 
-    hm2(chunk_size, pow2_hash_func, nullptr, nullptr, nullptr, nullptr);
+    hm2(MaxRoughNonZero, pow2_hash_func, nullptr, nullptr, nullptr, nullptr);
 
     //set memory for hash begins.
     hm2.hash_begins = (nnz_lno_t *) (tmp);

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
@@ -1167,22 +1167,18 @@ struct KokkosSPGEMM
         nnz_lno_t work_to_handle = KOKKOSKERNELS_MACRO_MIN(vector_size, left_work);
 
         nnz_lno_t b_set_ind = -1, b_set = -1;
-        nnz_lno_t hash = -1;
         Kokkos::parallel_for(
             Kokkos::ThreadVectorRange(teamMember, work_to_handle),
             [&] (nnz_lno_t i) {
           const size_type adjind = i + rowBegin;
           b_set_ind = entriesSetIndicesB[adjind];
           b_set = entriesSetsB[adjind];
-          //hash = b_set_ind % shmem_key_size;
-          hash = b_set_ind & shared_memory_hash_func;
         });
 
 
         int num_unsuccess = hm.vector_atomic_insert_into_hash_mergeOr(
-            teamMember, vector_size,
-            hash, b_set_ind, b_set,
-            used_hash_sizes);
+                              b_set_ind, b_set, used_hash_sizes
+                            );
 
 
         int overall_num_unsuccess = 0;
@@ -2815,15 +2811,14 @@ struct KokkosSPGEMM
           const size_type adjind = i + rowBegin;
           b_set_ind = entriesSetIndicesB[adjind];
           b_set = entriesSetsB[adjind];
-          hash = b_set_ind % shared_memory_hash_size;
         });
 
 
         int num_unsuccess = hm.vector_atomic_insert_into_hash_mergeOr(
-            teamMember, vector_size,
-            hash, b_set_ind, b_set,
-            used_hash_sizes,
-            shared_memory_hash_size);
+                              b_set_ind, b_set,
+                              used_hash_sizes,
+                              shared_memory_hash_size
+                            );
 
 
         int overall_num_unsuccess = 0;

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
@@ -1222,17 +1222,14 @@ struct KokkosSPGEMM
             hm2.values = (nnz_lno_t *) (tmp);
           }
 
-          nnz_lno_t hash_ = -1;
-          if (num_unsuccess) hash_ = b_set_ind & pow2_hash_func;
-
-          //int insertion =
-          hm2.vector_atomic_insert_into_hash_mergeOr_TrackHashes(
-              teamMember, vector_size,
-              hash_,b_set_ind,b_set,
-              used_hash_sizes + 1,
-              globally_used_hash_count, globally_used_hash_indices
-              );
-
+          if (num_unsuccess) {
+            //int insertion =
+            hm2.vector_atomic_insert_into_hash_mergeOr_TrackHashes(
+                b_set_ind,b_set,
+                used_hash_sizes + 1,
+                globally_used_hash_count, globally_used_hash_indices
+                );
+          }
         }
         left_work -= work_to_handle;
         rowBegin += work_to_handle;
@@ -2866,17 +2863,14 @@ struct KokkosSPGEMM
             hm2.values = (nnz_lno_t *) (tmp);
           }
 
-          nnz_lno_t hash_ = -1;
-          if (num_unsuccess) hash_ = b_set_ind & pow2_hash_func;
-
-          //int insertion =
-          hm2.vector_atomic_insert_into_hash_mergeOr_TrackHashes(
-              teamMember, vector_size,
-              hash_,b_set_ind,b_set,
-              used_hash_sizes + 1,
-              globally_used_hash_count, globally_used_hash_indices
-              );
-
+          if (num_unsuccess) {
+            //int insertion =
+            hm2.vector_atomic_insert_into_hash_mergeOr_TrackHashes(
+                b_set_ind,b_set,
+                used_hash_sizes + 1,
+                globally_used_hash_count, globally_used_hash_indices
+                );
+          }
         }
         left_work -= work_to_handle;
         rowBegin += work_to_handle;

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
@@ -278,11 +278,9 @@ struct KokkosSPGEMM
 
           nnz_lno_t b_set_ind = b_entries[adjind];
           //nnz_lno_t b_set = entriesSetsB[adjind];
-          nnz_lno_t hash = b_set_ind & pow2_hash_func;
 
           //insert it to first hash.
           hm2.sequential_insert_into_hash_TrackHashes(
-              hash,
               b_set_ind,
               &used_hash_size,
               &globally_used_hash_count,
@@ -525,22 +523,19 @@ struct KokkosSPGEMM
         nnz_lno_t work_to_handle = KOKKOSKERNELS_MACRO_MIN(vector_size, left_work);
 
         nnz_lno_t b_set_ind = -1;// , b_set = -1;
-        nnz_lno_t hash = -1;
         Kokkos::parallel_for(
             Kokkos::ThreadVectorRange(teamMember, work_to_handle),
             [&] (nnz_lno_t i) {
           const size_type adjind = i + rowBegin;
           b_set_ind = b_entries[adjind];
           //b_set = entriesSetsB[adjind];
-          //hash = b_set_ind % shmem_key_size;
-          hash = b_set_ind & shared_memory_hash_func;
         });
 
 
         int num_unsuccess = hm.vector_atomic_insert_into_hash(
-            teamMember, vector_size,
-            hash, b_set_ind,
-            used_hash_sizes);
+                              b_set_ind,
+                              used_hash_sizes
+                            );
 
 
         int overall_num_unsuccess = 0;
@@ -1039,15 +1034,13 @@ struct KokkosSPGEMM
 
           nnz_lno_t b_set_ind = entriesSetIndicesB[adjind];
           nnz_lno_t b_set = entriesSetsB[adjind];
-          nnz_lno_t hash = b_set_ind & pow2_hash_func;
 
           //insert it to first hash.
           hm2.sequential_insert_into_hash_mergeOr_TrackHashes(
-              hash,
-              b_set_ind, b_set,
-              &used_hash_size,
-              &globally_used_hash_count,
-              globally_used_hash_indices
+            b_set_ind, b_set,
+            &used_hash_size,
+            &globally_used_hash_count,
+            globally_used_hash_indices
           );
         }
       }
@@ -2681,9 +2674,10 @@ struct KokkosSPGEMM
           nnz_lno_t hash = b_set_ind & pow2_hash_func;
 
           hm2.sequential_insert_into_hash_mergeOr_TrackHashes(
-              hash,b_set_ind,b_set,
-              &used_hash_size,
-              &globally_used_hash_count, globally_used_hash_indices
+            b_set_ind,b_set,
+            &used_hash_size,
+            &globally_used_hash_count,
+            globally_used_hash_indices
           );
         }
       }

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
@@ -257,8 +257,6 @@ struct KokkosSPGEMM
     //tmp += MaxRoughNonZero;
     //hm2.values = (nnz_lno_t *) (tmp);
 
-    hm2.hash_key_size = pow2_hash_size;
-
     Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end), [&] (const nnz_lno_t& row_index){
       nnz_lno_t globally_used_hash_count = 0;
       nnz_lno_t used_hash_size = 0;
@@ -486,9 +484,9 @@ struct KokkosSPGEMM
     //return;
     //first level hashmap
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t>
-      hm(shmem_hash_size, shmem_key_size, begins, nexts, keys, vals);
+      hm(shmem_key_size, begins, nexts, keys, vals);
 
-    hashmapType hm2(pow2_hash_size, MaxRoughNonZero,
+    hashmapType hm2(MaxRoughNonZero,
                     nullptr, nullptr,
                     nullptr, nullptr);
 
@@ -577,8 +575,6 @@ struct KokkosSPGEMM
             hm2.keys = (nnz_lno_t *) (tmp);
             //tmp += MaxRoughNonZero;
             //hm2.values = (nnz_lno_t *) (tmp);
-
-            hm2.hash_key_size = pow2_hash_size;
           }
 
           nnz_lno_t hash_ = -1;
@@ -1006,7 +1002,7 @@ struct KokkosSPGEMM
     tmp += pow2_hash_size;
 
     //create hashmap accumulator.
-    hashmapType hm2(pow2_hash_size, MaxRoughNonZero, 
+    hashmapType hm2(MaxRoughNonZero, 
                     nullptr, nullptr, 
                     nullptr, nullptr);
 
@@ -1130,9 +1126,9 @@ struct KokkosSPGEMM
     //return;
     //first level hashmap
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t>
-      hm(shmem_hash_size, shmem_key_size, begins, nexts, keys, vals);
+      hm(shmem_key_size, begins, nexts, keys, vals);
 
-    hashmapType hm2(pow2_hash_size, MaxRoughNonZero,
+    hashmapType hm2(MaxRoughNonZero,
                     nullptr, nullptr,
                     nullptr, nullptr);
 
@@ -1221,8 +1217,6 @@ struct KokkosSPGEMM
             hm2.keys = (nnz_lno_t *) (tmp);
             tmp += MaxRoughNonZero;
             hm2.values = (nnz_lno_t *) (tmp);
-
-            hm2.hash_key_size = pow2_hash_size;
           }
 
           nnz_lno_t hash_ = -1;
@@ -2644,7 +2638,7 @@ struct KokkosSPGEMM
     nnz_lno_t *globally_used_hash_indices = NULL;
     nnz_lno_t globally_used_hash_count = 0;
     nnz_lno_t used_hash_size = 0;
-    hashmapType hm2(pow2_hash_size, MaxRoughNonZero,
+    hashmapType hm2(MaxRoughNonZero,
                     nullptr, nullptr,
                     nullptr, nullptr);
 
@@ -2668,8 +2662,6 @@ struct KokkosSPGEMM
     hm2.keys = (nnz_lno_t *) (tmp);
     tmp += MaxRoughNonZero;
     hm2.values = (nnz_lno_t *) (tmp);
-
-    hm2.hash_key_size = pow2_hash_size;
 
 
     {
@@ -2778,7 +2770,7 @@ struct KokkosSPGEMM
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t>
       hm(shared_memory_hash_size, shared_memory_hash_size, begins, nexts, keys, vals);
 
-    hashmapType hm2(pow2_hash_size, MaxRoughNonZero,
+    hashmapType hm2(MaxRoughNonZero,
                     nullptr, nullptr,
                     nullptr, nullptr);
 
@@ -2867,8 +2859,6 @@ struct KokkosSPGEMM
             hm2.keys = (nnz_lno_t *) (tmp);
             tmp += MaxRoughNonZero;
             hm2.values = (nnz_lno_t *) (tmp);
-
-            hm2.hash_key_size = pow2_hash_size;
           }
 
           nnz_lno_t hash_ = -1;

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
@@ -883,7 +883,7 @@ struct KokkosSPGEMM
     tmp += pow2_hash_size;
 
     //create hashmap accumulator.
-    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t> hm2(pow2_hash_size, MaxRoughNonZero, nullptr, nullptr, nullptr, nullptr);
+    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t> hm2(MaxRoughNonZero, nullptr, nullptr, nullptr, nullptr);
 
     //set memory for hash begins.
     hm2.hash_begins = (nnz_lno_t *) (tmp);
@@ -1033,7 +1033,7 @@ struct KokkosSPGEMM
     tmp += pow2_hash_size;
 
     //create hashmap accumulator.
-    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t> hm2(pow2_hash_size, MaxRoughNonZero, nullptr, nullptr, nullptr, nullptr);
+    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t> hm2(MaxRoughNonZero, nullptr, nullptr, nullptr, nullptr);
 
     //set memory for hash begins.
     hm2.hash_begins = (nnz_lno_t *) (tmp);

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
@@ -883,7 +883,7 @@ struct KokkosSPGEMM
     tmp += pow2_hash_size;
 
     //create hashmap accumulator.
-    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t> hm2;
+    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t> hm2(pow2_hash_size, MaxRoughNonZero, nullptr, nullptr, nullptr, nullptr);
 
     //set memory for hash begins.
     hm2.hash_begins = (nnz_lno_t *) (tmp);
@@ -901,9 +901,6 @@ struct KokkosSPGEMM
     //currently hashmap accumulator wont use it.
     tmp += MaxRoughNonZero;
     nnz_lno_t *values2 = (nnz_lno_t *) (tmp);
-
-    hm2.hash_key_size = pow2_hash_size;
-    hm2.max_value_size = MaxRoughNonZero;
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end), [&] (const nnz_lno_t& row_index){
       nnz_lno_t globally_used_hash_count = 0;
@@ -932,7 +929,7 @@ struct KokkosSPGEMM
               hash,
               b_set_ind, b_set, values2,
               &used_hash_size,
-              hm2.max_value_size,&globally_used_hash_count,
+              &globally_used_hash_count,
               globally_used_hash_indices
           );
         }
@@ -1036,7 +1033,7 @@ struct KokkosSPGEMM
     tmp += pow2_hash_size;
 
     //create hashmap accumulator.
-    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t> hm2;
+    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t> hm2(pow2_hash_size, MaxRoughNonZero, nullptr, nullptr, nullptr, nullptr);
 
     //set memory for hash begins.
     hm2.hash_begins = (nnz_lno_t *) (tmp);
@@ -1049,9 +1046,6 @@ struct KokkosSPGEMM
     hm2.keys = (nnz_lno_t *) (tmp);
     tmp += MaxRoughNonZero;
     hm2.values = (nnz_lno_t *) (tmp);
-
-    hm2.hash_key_size = pow2_hash_size;
-    hm2.max_value_size = MaxRoughNonZero;
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end), [&] (const nnz_lno_t& row_index){
       nnz_lno_t globally_used_hash_count = 0;
@@ -1075,7 +1069,6 @@ struct KokkosSPGEMM
               hash,
               b_set_ind, b_set,
               &used_hash_size,
-              hm2.max_value_size,
               &globally_used_hash_count,
               globally_used_hash_indices
           );
@@ -1157,7 +1150,6 @@ struct KokkosSPGEMM
     nnz_lno_t *values2 = (nnz_lno_t *) (tmp);
 
     hm2.hash_key_size = pow2_hash_size;
-    hm2.max_value_size = MaxRoughNonZero;
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end), [&] (const nnz_lno_t& row_index){
       nnz_lno_t globally_used_hash_count = 0;
@@ -1186,7 +1178,6 @@ struct KokkosSPGEMM
               hash,
               b_set_ind, b_set, values2,
               &used_hash_size,
-              hm2.max_value_size,
               &globally_used_hash_count,
               globally_used_hash_indices
           );
@@ -1217,7 +1208,7 @@ struct KokkosSPGEMM
                 hash,
                 b_set_ind, b_set, values2,
                 &used_hash_size,
-                hm2.max_value_size,&globally_used_hash_count,
+                &globally_used_hash_count,
                 globally_used_hash_indices
             );
           }

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
@@ -883,7 +883,8 @@ struct KokkosSPGEMM
     tmp += pow2_hash_size;
 
     //create hashmap accumulator.
-    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t> hm2(MaxRoughNonZero, nullptr, nullptr, nullptr, nullptr);
+    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t,KokkosKernels::Experimental::HashOpType::bitwiseAnd> 
+    hm2(MaxRoughNonZero, pow2_hash_func, nullptr, nullptr, nullptr, nullptr);
 
     //set memory for hash begins.
     hm2.hash_begins = (nnz_lno_t *) (tmp);
@@ -1033,7 +1034,8 @@ struct KokkosSPGEMM
     tmp += pow2_hash_size;
 
     //create hashmap accumulator.
-    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t> hm2(MaxRoughNonZero, nullptr, nullptr, nullptr, nullptr);
+    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t,KokkosKernels::Experimental::HashOpType::bitwiseAnd>
+    hm2(MaxRoughNonZero, pow2_hash_func, nullptr, nullptr, nullptr, nullptr);
 
     //set memory for hash begins.
     hm2.hash_begins = (nnz_lno_t *) (tmp);
@@ -1116,13 +1118,14 @@ struct KokkosSPGEMM
   void operator()(const MultiCoreTag2&, const team_member_t & teamMember) const {
     const nnz_lno_t team_row_begin = teamMember.league_rank() * team_row_chunk_size;
     const nnz_lno_t team_row_end = KOKKOSKERNELS_MACRO_MIN(team_row_begin + team_row_chunk_size, numrows);
-
+    const nnz_lno_t chunk_size = 0;
 
     //get memory from memory pool.
     volatile nnz_lno_t * tmp = NULL;
     nnz_lno_t tid = get_thread_id(team_row_begin + teamMember.team_rank());
     while (tmp == NULL){
       tmp = (volatile nnz_lno_t * )( m_space.allocate_chunk(tid));
+      // issue-508, TODO: chunk_size = ??
     }
 
     //set first to globally used hash indices.
@@ -1130,7 +1133,8 @@ struct KokkosSPGEMM
     tmp += pow2_hash_size;
 
     //create hashmap accumulator.
-    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t> hm2;
+    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t,KokkosKernels::Experimental::HashOpType::bitwiseAnd> 
+    hm2(chunk_size, pow2_hash_func, nullptr, nullptr, nullptr, nullptr);
 
     //set memory for hash begins.
     hm2.hash_begins = (nnz_lno_t *) (tmp);

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
@@ -1111,14 +1111,12 @@ struct KokkosSPGEMM
   void operator()(const MultiCoreTag2&, const team_member_t & teamMember) const {
     const nnz_lno_t team_row_begin = teamMember.league_rank() * team_row_chunk_size;
     const nnz_lno_t team_row_end = KOKKOSKERNELS_MACRO_MIN(team_row_begin + team_row_chunk_size, numrows);
-    const nnz_lno_t chunk_size = 0;
 
     //get memory from memory pool.
     volatile nnz_lno_t * tmp = NULL;
     nnz_lno_t tid = get_thread_id(team_row_begin + teamMember.team_rank());
     while (tmp == NULL){
       tmp = (volatile nnz_lno_t * )( m_space.allocate_chunk(tid));
-      // issue-508, TODO: chunk_size = ??
     }
 
     //set first to globally used hash indices.
@@ -1127,7 +1125,7 @@ struct KokkosSPGEMM
 
     //create hashmap accumulator.
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t,KokkosKernels::Experimental::HashOpType::bitwiseAnd> 
-    hm2(chunk_size, pow2_hash_func, nullptr, nullptr, nullptr, nullptr);
+    hm2(MaxRoughNonZero, pow2_hash_func, nullptr, nullptr, nullptr, nullptr);
 
     //set memory for hash begins.
     hm2.hash_begins = (nnz_lno_t *) (tmp);

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
@@ -923,15 +923,13 @@ struct KokkosSPGEMM
 
           nnz_lno_t b_set_ind = entriesSetIndicesB[adjind];
           nnz_lno_t b_set = entriesSetsB[adjind];
-          nnz_lno_t hash = b_set_ind & pow2_hash_func;
 
           //insert it to first hash.
           hm2.sequential_insert_into_hash_mergeOr_TriangleCount_TrackHashes(
-              hash,
-              b_set_ind, b_set, values2,
-              &used_hash_size,
-              &globally_used_hash_count,
-              globally_used_hash_indices
+            b_set_ind, b_set, values2,
+            &used_hash_size,
+            &globally_used_hash_count,
+            globally_used_hash_indices
           );
         }
       }
@@ -1064,15 +1062,13 @@ struct KokkosSPGEMM
           const size_type adjind = i + mask_row_begin;
           nnz_lno_t b_set_ind = entriesSetIndicesB[adjind];
           nnz_lno_t b_set = entriesSetsB[adjind];
-          nnz_lno_t hash = b_set_ind & pow2_hash_func;
 
           //insert it to first hash.
           hm2.sequential_insert_into_hash_TriangleCount_TrackHashes(
-              hash,
-              b_set_ind, b_set,
-              &used_hash_size,
-              &globally_used_hash_count,
-              globally_used_hash_indices
+            b_set_ind, b_set,
+            &used_hash_size,
+            &globally_used_hash_count,
+            globally_used_hash_indices
           );
         }
 
@@ -1092,13 +1088,10 @@ struct KokkosSPGEMM
 
             nnz_lno_t b_set_ind = entriesSetIndicesB[adjind];
             nnz_lno_t b_set = entriesSetsB[adjind];
-            nnz_lno_t hash = b_set_ind & pow2_hash_func;
 
             //std::cout << "\t and hash:" << hash << " bset:" << b_set << " b_set_ind:" << b_set_ind << std::endl;
             //insert it to first hash.
-            nnz_lno_t intersection = hm2.sequential_insert_into_hash_mergeAnd_TriangleCount_TrackHashes(
-                hash,
-                b_set_ind, b_set);
+            nnz_lno_t intersection = hm2.sequential_insert_into_hash_mergeAnd_TriangleCount_TrackHashes(b_set_ind, b_set);
             if(intersection)
               visit_applier(row_index, b_set_ind, intersection, tid);
           }
@@ -1172,14 +1165,12 @@ struct KokkosSPGEMM
           const size_type adjind = i + min_row_begin;
           nnz_lno_t b_set_ind = entriesSetIndicesB[adjind];
           nnz_lno_t b_set = entriesSetsB[adjind];
-          nnz_lno_t hash = b_set_ind & pow2_hash_func;
 
 
           //std::cout << "\t union hash:" << hash << " bset:" << b_set << " b_set_ind:" << b_set_ind << std::endl;
 
           //insert it to first hash.
           hm2.sequential_insert_into_hash_TriangleCount_TrackHashes(
-              hash,
               b_set_ind, b_set, values2,
               &used_hash_size,
               &globally_used_hash_count,
@@ -1204,16 +1195,14 @@ struct KokkosSPGEMM
 
             nnz_lno_t b_set_ind = entriesSetIndicesB[adjind];
             nnz_lno_t b_set = entriesSetsB[adjind];
-            nnz_lno_t hash = b_set_ind & pow2_hash_func;
 
             //std::cout << "\t and hash:" << hash << " bset:" << b_set << " b_set_ind:" << b_set_ind << std::endl;
             //insert it to first hash.
             hm2.sequential_insert_into_hash_mergeAnd_TriangleCount_TrackHashes(
-                hash,
-                b_set_ind, b_set, values2,
-                &used_hash_size,
-                &globally_used_hash_count,
-                globally_used_hash_indices
+              b_set_ind, b_set, values2,
+              &used_hash_size,
+              &globally_used_hash_count,
+              globally_used_hash_indices
             );
           }
         }

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_triangle_no_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_triangle_no_compression.hpp
@@ -534,7 +534,6 @@ struct KokkosSPGEMM
     const nnz_lno_t team_row_begin = teamMember.league_rank() * team_row_chunk_size;
     const nnz_lno_t team_row_end = KOKKOSKERNELS_MACRO_MIN(team_row_begin + team_row_chunk_size, numrows);
 
-
     //get memory from memory pool.
     volatile nnz_lno_t * tmp = NULL;
     nnz_lno_t tid = get_thread_id(team_row_begin + teamMember.team_rank());
@@ -547,7 +546,8 @@ struct KokkosSPGEMM
     tmp += pow2_hash_size;
 
     //create hashmap accumulator.
-    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t> hm2;
+    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t,KokkosKernels::Experimental::HashOpType::bitwiseAnd> 
+    hm2(MaxRoughNonZero, pow2_hash_func, nullptr, nullptr, nullptr, nullptr);
 
     //set memory for hash begins.
     hm2.hash_begins = (nnz_lno_t *) (tmp);
@@ -565,9 +565,6 @@ struct KokkosSPGEMM
     //currently hashmap accumulator wont use it.
     tmp += MaxRoughNonZero;
     nnz_lno_t *values2 = (nnz_lno_t *) (tmp);
-
-    hm2.hash_key_size = pow2_hash_size;
-    hm2.max_value_size = MaxRoughNonZero;
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end), [&] (const nnz_lno_t& row_index){
       nnz_lno_t globally_used_hash_count = 0;
@@ -596,7 +593,7 @@ struct KokkosSPGEMM
               hash,
               b_set_ind, b_set, values2,
               &used_hash_size,
-              hm2.max_value_size,&globally_used_hash_count,
+              &globally_used_hash_count,
               globally_used_hash_indices
           );
         }
@@ -701,7 +698,8 @@ struct KokkosSPGEMM
     tmp += pow2_hash_size;
 
     //create hashmap accumulator.
-    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t> hm2;
+    KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,nnz_lno_t,KokkosKernels::Experimental::HashOpType::bitwiseAnd> 
+    hm2(MaxRoughNonZero, pow2_hash_func, nullptr, nullptr, nullptr, nullptr);
 
     //set memory for hash begins.
     hm2.hash_begins = (nnz_lno_t *) (tmp);
@@ -719,9 +717,6 @@ struct KokkosSPGEMM
     //currently hashmap accumulator wont use it.
     tmp += MaxRoughNonZero;
     nnz_lno_t *values2 = (nnz_lno_t *) (tmp);
-
-    hm2.hash_key_size = pow2_hash_size;
-    hm2.max_value_size = MaxRoughNonZero;
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end), [&] (const nnz_lno_t& row_index){
       nnz_lno_t globally_used_hash_count = 0;
@@ -746,11 +741,11 @@ struct KokkosSPGEMM
           //std::cout << "\t union hash:" << hash << " bset:" << b_set << " b_set_ind:" << b_set_ind << std::endl;
 
           //insert it to first hash.
+          // issue-508, TODO: this invocation is not correct.
           hm2.sequential_insert_into_hash_TriangleCount_TrackHashes(
               hash,
               b_set_ind, b_set, values2,
               &used_hash_size,
-              hm2.max_value_size,
               &globally_used_hash_count,
               globally_used_hash_indices
           );

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_triangle_no_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_triangle_no_compression.hpp
@@ -586,15 +586,13 @@ struct KokkosSPGEMM
 
           nnz_lno_t b_set_ind = entriesB[adjind];
           nnz_lno_t b_set = entriesSetsB[adjind];
-          nnz_lno_t hash = b_set_ind & pow2_hash_func;
 
           //insert it to first hash.
           hm2.sequential_insert_into_hash_mergeOr_TriangleCount_TrackHashes(
-              hash,
-              b_set_ind, b_set, values2,
-              &used_hash_size,
-              &globally_used_hash_count,
-              globally_used_hash_indices
+            b_set_ind, b_set, values2,
+            &used_hash_size,
+            &globally_used_hash_count,
+            globally_used_hash_indices
           );
         }
       }
@@ -735,19 +733,18 @@ struct KokkosSPGEMM
           const size_type adjind = i + min_row_begin;
           nnz_lno_t b_set_ind = entriesB[adjind];
           nnz_lno_t b_set = entriesSetsB[adjind];
-          nnz_lno_t hash = b_set_ind & pow2_hash_func;
 
 
           //std::cout << "\t union hash:" << hash << " bset:" << b_set << " b_set_ind:" << b_set_ind << std::endl;
 
           //insert it to first hash.
           // issue-508, TODO: this invocation is not correct.
+          
           hm2.sequential_insert_into_hash_TriangleCount_TrackHashes(
-              hash,
-              b_set_ind, b_set, values2,
-              &used_hash_size,
-              &globally_used_hash_count,
-              globally_used_hash_indices
+            b_set_ind, b_set, values2,
+            &used_hash_size,
+            &globally_used_hash_count,
+            globally_used_hash_indices
           );
         }
 
@@ -768,16 +765,14 @@ struct KokkosSPGEMM
 
             nnz_lno_t b_set_ind = entriesB[adjind];
             nnz_lno_t b_set = entriesSetsB[adjind];
-            nnz_lno_t hash = b_set_ind & pow2_hash_func;
 
             //std::cout << "\t and hash:" << hash << " bset:" << b_set << " b_set_ind:" << b_set_ind << std::endl;
             //insert it to first hash.
             hm2.sequential_insert_into_hash_mergeAnd_TriangleCount_TrackHashes(
-                hash,
-                b_set_ind, b_set, values2,
-                &used_hash_size,
-                hm2.max_value_size,&globally_used_hash_count,
-                globally_used_hash_indices
+              b_set_ind, b_set, values2,
+              &used_hash_size,
+              &globally_used_hash_count,
+              globally_used_hash_indices
             );
           }
         }

--- a/src/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
@@ -388,7 +388,6 @@ namespace KokkosSparse{
 			const size_type adjind = i + rowBegin;
 			nnz_lno_t b_col_ind = entriesB[adjind];
 			scalar_t b_val = valuesB[adjind] * valA;
-			nnz_lno_t hash = b_col_ind & pow2_hash_func;
 
 			hm2.sequential_insert_into_hash_mergeAdd_TrackHashes(
 			  b_col_ind, b_val,

--- a/src/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
@@ -348,7 +348,6 @@ namespace KokkosSparse{
 	    nnz_lno_t used_hash_sizes = 0;
 
 	    const size_type c_row_begin = row_mapC[row_index];
-	    const size_type c_row_end = row_mapC[row_index + 1];
 
 	    hm2.keys = pEntriesC + c_row_begin;
 	    hm2.values = pvaluesC + c_row_begin;

--- a/src/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
@@ -357,16 +357,17 @@ namespace KokkosSparse{
 	    size_type rowBegin = row_mapB(row_index);
 	    nnz_lno_t left_workB = row_mapB(row_index + 1) - rowBegin;
 
-	    for ( nnz_lno_t i = 0; i < left_workB; ++i){
+	    for (nnz_lno_t i = 0; i < left_workB; ++i) {
 	      const size_type adjind = i + rowBegin;
 	      nnz_lno_t b_col_ind = entriesB[adjind];
 	      scalar_t b_val = valuesB[adjind];
-	      nnz_lno_t hash = b_col_ind & pow2_hash_func;
 
-	      hm2.sequential_insert_into_hash_mergeAdd_TrackHashes(hash, b_col_ind, b_val,
-								   &used_hash_sizes,
-								   &globally_used_hash_count,
-								   globally_used_hash_indices);
+	      hm2.sequential_insert_into_hash_mergeAdd_TrackHashes(
+			b_col_ind, b_val,
+			&used_hash_sizes,
+			&globally_used_hash_count,
+			globally_used_hash_indices
+		  );
 	    }
 
 
@@ -383,16 +384,18 @@ namespace KokkosSparse{
 	      rowBegin = row_mapB(rowB);
 	      left_workB = row_mapB(rowB + 1) - rowBegin;
 
-	      for ( nnz_lno_t i = 0; i < left_workB; ++i){
-		const size_type adjind = i + rowBegin;
-		nnz_lno_t b_col_ind = entriesB[adjind];
-		scalar_t b_val = valuesB[adjind] * valA;
-		nnz_lno_t hash = b_col_ind & pow2_hash_func;
+	      for (nnz_lno_t i = 0; i < left_workB; ++i) {
+			const size_type adjind = i + rowBegin;
+			nnz_lno_t b_col_ind = entriesB[adjind];
+			scalar_t b_val = valuesB[adjind] * valA;
+			nnz_lno_t hash = b_col_ind & pow2_hash_func;
 
-		hm2.sequential_insert_into_hash_mergeAdd_TrackHashes(hash, b_col_ind, b_val,
-								     &used_hash_sizes,
-								     &globally_used_hash_count,
-								     globally_used_hash_indices);
+			hm2.sequential_insert_into_hash_mergeAdd_TrackHashes(
+			  b_col_ind, b_val,
+			  &used_hash_sizes,
+			  &globally_used_hash_count,
+			  globally_used_hash_indices
+			);
 	      }
 	    }
 
@@ -494,16 +497,16 @@ namespace KokkosSparse{
 		const size_type adjind = i + rowBegin;
 		nnz_lno_t b_col_ind = entriesB[adjind];
 		scalar_t b_val = valuesB[adjind]; 
-		nnz_lno_t hash = b_col_ind & thread_shmem_hash_func;
-		volatile int num_unsuccess = hm.vector_atomic_insert_into_hash_mergeAdd(teamMember, vector_size,
-											hash, b_col_ind, b_val,
-											used_hash_sizes);
+		volatile int num_unsuccess = hm.vector_atomic_insert_into_hash_mergeAdd(
+									   b_col_ind, b_val,
+									   used_hash_sizes
+									 );
 		if (num_unsuccess){
-		  hash = b_col_ind & pow2_hash_func;
-		  hm2.vector_atomic_insert_into_hash_mergeAdd_TrackHashes(teamMember, vector_size,
-									  hash,b_col_ind,b_val,
-									  used_hash_sizes + 1,
-									  globally_used_hash_count, globally_used_hash_indices);
+		  hm2.vector_atomic_insert_into_hash_mergeAdd_TrackHashes(
+			b_col_ind,b_val,
+			used_hash_sizes + 1,
+			globally_used_hash_count, globally_used_hash_indices
+		  );
 		}
 	      });
 	    
@@ -523,16 +526,16 @@ namespace KokkosSparse{
 		  const size_type adjind = i + rowBegin;
 		  nnz_lno_t b_col_ind = entriesB[adjind];
 		  scalar_t b_val = valuesB[adjind] * valA;
-		  nnz_lno_t hash = b_col_ind & thread_shmem_hash_func;
-		  volatile int num_unsuccess = hm.vector_atomic_insert_into_hash_mergeAdd(teamMember, vector_size,
-											  hash, b_col_ind, b_val,
-											  used_hash_sizes);
+		  volatile int num_unsuccess = hm.vector_atomic_insert_into_hash_mergeAdd(
+										 b_col_ind, b_val,
+										 used_hash_sizes
+									   );
 		  if (num_unsuccess){
-		    hash = b_col_ind & pow2_hash_func;
-		    hm2.vector_atomic_insert_into_hash_mergeAdd_TrackHashes(teamMember, vector_size,
-									    hash,b_col_ind,b_val,
-									    used_hash_sizes + 1,
-									    globally_used_hash_count, globally_used_hash_indices);
+		    hm2.vector_atomic_insert_into_hash_mergeAdd_TrackHashes(
+			  b_col_ind,b_val,
+			  used_hash_sizes + 1,
+			  globally_used_hash_count, globally_used_hash_indices
+			);
 		  }
 		});
 	    }

--- a/src/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
@@ -328,8 +328,8 @@ namespace KokkosSparse{
 	const nnz_lno_t team_row_begin = teamMember.league_rank() * team_work_size;
 	const nnz_lno_t team_row_end = KOKKOSKERNELS_MACRO_MIN(team_row_begin + team_work_size, numrows);
 
-	KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t>
-	  hm2(pow2_hash_size,NULL, NULL, NULL, NULL);
+	KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t,KokkosKernels::Experimental::HashOpType::bitwiseAnd>
+	  hm2(pow2_hash_size, pow2_hash_func, NULL, NULL, NULL, NULL);
 
 	volatile nnz_lno_t * tmp = NULL;
 	size_t tid = get_thread_id(team_row_begin + teamMember.team_rank());
@@ -439,11 +439,11 @@ namespace KokkosSparse{
 	scalar_t * vals = KokkosKernels::Impl::alignPtr<char*, scalar_t>(all_shared_memory);
 
 	// Create the hashmaps
-	KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t>
-	  hm(thread_shmem_key_size, begins, nexts, keys, vals);
+	KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t,KokkosKernels::Experimental::HashOpType::bitwiseAnd>
+	  hm(thread_shmem_key_size, thread_shmem_hash_func, begins, nexts, keys, vals);
 
-	KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t>
-	  hm2(pow2_hash_size,
+	KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t,KokkosKernels::Experimental::HashOpType::bitwiseAnd>
+	  hm2(pow2_hash_size, pow2_hash_func,
 	      NULL, NULL, NULL, NULL);
 
 	Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end), [&] (const nnz_lno_t& row_index) {

--- a/src/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
@@ -329,7 +329,7 @@ namespace KokkosSparse{
 	const nnz_lno_t team_row_end = KOKKOSKERNELS_MACRO_MIN(team_row_begin + team_work_size, numrows);
 
 	KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t>
-	  hm2(pow2_hash_size, pow2_hash_size,NULL, NULL, NULL, NULL);
+	  hm2(pow2_hash_size,NULL, NULL, NULL, NULL);
 
 	volatile nnz_lno_t * tmp = NULL;
 	size_t tid = get_thread_id(team_row_begin + teamMember.team_rank());
@@ -440,10 +440,10 @@ namespace KokkosSparse{
 
 	// Create the hashmaps
 	KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t>
-	  hm(thread_shmem_hash_size, thread_shmem_key_size, begins, nexts, keys, vals);
+	  hm(thread_shmem_key_size, begins, nexts, keys, vals);
 
 	KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t>
-	  hm2(pow2_hash_size, pow2_hash_size,
+	  hm2(pow2_hash_size,
 	      NULL, NULL, NULL, NULL);
 
 	Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end), [&] (const nnz_lno_t& row_index) {

--- a/src/sparse/impl/KokkosSparse_spgemm_symbolic_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_symbolic_spec.hpp
@@ -191,7 +191,6 @@ struct SPGEMM_SYMBOLIC < KernelHandle,
       break;
     case SPGEMM_CUSP:
     case SPGEMM_VIENNA:
-
       break;
 
     case SPGEMM_MKL2PHASE:

--- a/unit_test/sparse/Test_Sparse_spgemm.hpp
+++ b/unit_test/sparse/Test_Sparse_spgemm.hpp
@@ -226,7 +226,7 @@ bool is_same_matrix(crsMat_t output_mat_actual, crsMat_t output_mat_reference){
   bool is_identical = true;
   is_identical = KokkosKernels::Impl::kk_is_identical_view
       <typename graph_t::row_map_type, typename graph_t::row_map_type, typename lno_view_t::value_type,
-      typename device::execution_space>(output_mat1.graph.row_map, output_mat_reference.graph.row_map, 0);
+      typename device::execution_space>(output_mat_actual.graph.row_map, output_mat_reference.graph.row_map, 0);
 
   if (!is_identical) {
     std::cout << "rowmaps are different." << std::endl;
@@ -283,6 +283,8 @@ void test_spgemm(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_v
 
 
   lno_t numCols = numRows;
+  // Generate random compressed sparse row matrix. Randomly generated (non-zero) values are
+  // stored in a 1-D (1 rank) array.
   crsMat_t input_mat = KokkosKernels::Impl::kk_generate_sparse_matrix<crsMat_t>(numRows,numCols,nnz,row_size_variance, bandwidth);
 
   crsMat_t output_mat2;


### PR DESCRIPTION
The following changes were made to the HashmapAccumulator class:
1. `max_value_size` changed to `private` member `__max_value_size`.
2. `hash_key_size` was removed.
3. `used_size` was removed.
4. Hashes are now computed within the `HashmapAccumulator` insertion routines:
    - `__hashOpRHS` was added as a `private` member. 
    - `__compute_hash` was added as a `private` member. This function is selected at compile time via a templated argument to the `HashmapAccumulator` constructor.
    - `vector_atomic_insert_into_hash_mergeAdd_with_team_level_list_length` does not compute hashes internally due to the special use-case in `KokkosSparse_spgemm_impl_speed.hpp:operator GPUTag`.

Fixes #508.

## spot-checks
# 1
```
<snip>
WARNING!! THE FOLLOWING CHANGES ARE UNCOMMITTED!! :
?? build/
?? testing/

KokkosKernels Repository Status:  7ff59541f124a9756cabd2c6949758500db58afe common/HashmapAccumulator: cleanup insert fn declarations more

Kokkos Repository Status:  33f730c475802bc226fc17e42e58fe7612d86b41 Merge pull request #3073 from masterleinad/enable_travis_compiler_warnings


Going to test compilers:  gcc/6.4.0 gcc/7.2.0 ibm/16.1.1 cuda/9.2.88 cuda/10.1.105
<snip>
#######################################################
PASSED TESTS
#######################################################
cuda-10.1.105-Cuda_OpenMP-release build_time=647 run_time=170
cuda-10.1.105-Cuda_Serial-release build_time=587 run_time=186
cuda-9.2.88-Cuda_OpenMP-release build_time=664 run_time=185
cuda-9.2.88-Cuda_Serial-release build_time=650 run_time=201
gcc-6.4.0-OpenMP_Serial-release build_time=228 run_time=139
gcc-7.2.0-OpenMP-release build_time=158 run_time=61
gcc-7.2.0-OpenMP_Serial-release build_time=220 run_time=138
gcc-7.2.0-Serial-release build_time=141 run_time=71
ibm-16.1.1-Serial-release build_time=1012 run_time=74
```
# 2
```
KokkosKernels Repository Status:  7ff59541f124a9756cabd2c6949758500db58afe common/HashmapAccumulator: cleanup insert fn declarations more

Kokkos Repository Status:  33f730c475802bc226fc17e42e58fe7612d86b41 Merge pull request #3073 from masterleinad/enable_travis_compiler_warnings


Going to test compilers:  cuda/9.2
Testing compiler cuda/9.2
  Starting job cuda-9.2-Cuda_OpenMP-release
kokkos devices: Cuda,OpenMP
kokkos arch: Kepler35
kokkos options: 
kokkos cuda options: force_uvm
kokkos cxxflags: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wuninitialized 
extra_args: 
kokkoskernels scalars: 'double,complex_double'
kokkoskernels ordinals: int
kokkoskernels offsets: int,size_t
kokkoskernels layouts: LayoutLeft
[eharvey@kokkos-dev testing]$ tail -f do-test-issue-508-05-29-2020.out 
kokkos devices: Cuda,OpenMP
kokkos arch: Kepler35
kokkos options: 
kokkos cuda options: force_uvm
kokkos cxxflags: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wuninitialized 
extra_args: 
kokkoskernels scalars: 'double,complex_double'
kokkoskernels ordinals: int
kokkoskernels offsets: int,size_t
kokkoskernels layouts: LayoutLeft
  PASSED cuda-9.2-Cuda_OpenMP-release
#######################################################
PASSED TESTS
#######################################################
cuda-9.2-Cuda_OpenMP-release build_time=1095 run_time=264
```
# 3
```
<snip>
WARNING!! THE FOLLOWING CHANGES ARE UNCOMMITTED!! :
?? build-issue-508/
?? build.750fe245/
?? build/
?? do-cmake.sh
?? do-test.sh
?? issue-727/
?? testing/

KokkosKernels Repository Status:  7ff59541f124a9756cabd2c6949758500db58afe common/HashmapAccumulator: cleanup insert fn declarations more

Kokkos Repository Status:  cb9727fae308ce7ae2248dbb8168c430d958bc32 core/src/impl: Conditionally define get_gpu in Kokkos_Core
<snip>
#######################################################
PASSED TESTS
#######################################################
clang-8.0-Cuda_OpenMP-release build_time=687 run_time=159
clang-8.0-Pthread_Serial-release build_time=207 run_time=110
clang-9.0.0-Pthread-release build_time=126 run_time=61
clang-9.0.0-Serial-release build_time=207 run_time=56
cuda-10.1-Cuda_OpenMP-release build_time=806 run_time=149
cuda-9.2-Cuda_Serial-release build_time=753 run_time=180
gcc-4.8.4-OpenMP-release build_time=126 run_time=58
gcc-7.3.0-OpenMP-release build_time=136 run_time=57
gcc-7.3.0-Pthread-release build_time=111 run_time=52
gcc-8.3.0-Serial-release build_time=135 run_time=58
gcc-9.1-OpenMP-release build_time=170 run_time=58
gcc-9.1-Serial-release build_time=155 run_time=62
intel-17.0.1-Serial-release build_time=262 run_time=65
intel-18.0.5-OpenMP-release build_time=338 run_time=53
intel-19.0.5-Pthread-release build_time=469 run_time=56
<snip>
WARNING!! THE FOLLOWING CHANGES ARE UNCOMMITTED!! :
?? build-issue-508/
?? build.750fe245/
?? build/
?? do-cmake.sh
?? do-test.sh
?? issue-727/
?? testing/

KokkosKernels Repository Status:  7ff59541f124a9756cabd2c6949758500db58afe common/HashmapAccumulator: cleanup insert fn declarations more

Kokkos Repository Status:  33f730c475802bc226fc17e42e58fe7612d86b41 Merge pull request #3073 from masterleinad/enable_travis_compiler_warnings


Going to test compilers:  gcc/7.3.0 gcc/8.3.0 gcc/9.1 gcc/4.8.4 intel/17.0.1 intel/18.0.5 intel/19.0.5 clang/8.0 clang/9.0.0 cuda/10.1
<snip>
#######################################################
PASSED TESTS
#######################################################
clang-8.0-Cuda_OpenMP-release build_time=606 run_time=153
clang-8.0-Pthread_Serial-release build_time=197 run_time=111
clang-9.0.0-Pthread-release build_time=115 run_time=53
clang-9.0.0-Serial-release build_time=126 run_time=57
cuda-10.1-Cuda_OpenMP-release build_time=837 run_time=151
gcc-4.8.4-OpenMP-release build_time=116 run_time=60
gcc-7.3.0-OpenMP-release build_time=138 run_time=59
gcc-7.3.0-Pthread-release build_time=110 run_time=53
gcc-8.3.0-Serial-release build_time=136 run_time=59
gcc-9.1-OpenMP-release build_time=169 run_time=60
gcc-9.1-Serial-release build_time=153 run_time=59
intel-17.0.1-Serial-release build_time=245 run_time=56
intel-18.0.5-OpenMP-release build_time=363 run_time=53
intel-19.0.5-Pthread-release build_time=442 run_time=47
```

## When enabling all scalars
`$ ./KokkosKernels_sparse_cuda --gtest_filter=cuda.sparse_spmv_*` still results in:
```
[==========] 32 tests from 1 test case ran. (233294 ms total)
[  PASSED  ] 20 tests.
[  FAILED  ] 12 tests, listed below:
[  FAILED  ] cuda.sparse_spmv_float_int_int_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_struct_float_int_int_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_float_int_size_t_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_struct_float_int_size_t_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_kokkos_complex_float_int_int_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_struct_kokkos_complex_float_int_int_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_kokkos_complex_float_int_size_t_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_struct_kokkos_complex_float_int_size_t_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_mv_float_int_int_LayoutLeft_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_mv_float_int_size_t_LayoutLeft_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_mv_kokkos_complex_float_int_int_LayoutLeft_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_mv_kokkos_complex_float_int_size_t_LayoutLeft_TestExecSpace

12 FAILED TESTS
```
and `$ ./KokkosKernels_sparse_cuda --gtest_filter=cuda.sparse_spgemm_*` still results in:
```
[==========] 16 tests from 1 test case ran. (127993 ms total)
[  PASSED  ] 12 tests.
[  FAILED  ] 4 tests, listed below:
[  FAILED  ] cuda.sparse_spgemm_jacobi_float_int_int_TestExecSpace
[  FAILED  ] cuda.sparse_spgemm_jacobi_float_int_size_t_TestExecSpace
[  FAILED  ] cuda.sparse_spgemm_jacobi_kokkos_complex_float_int_int_TestExecSpace
[  FAILED  ] cuda.sparse_spgemm_jacobi_kokkos_complex_float_int_size_t_TestExecSpace

 4 FAILED TESTS
```
