### PR TITLE
Fix divide by zero in sort_crs_matrix, for 0 rows

### DIFF
--- a/src/common/KokkosKernels_SparseUtils.hpp
+++ b/src/common/KokkosKernels_SparseUtils.hpp
@@ -989,7 +989,9 @@ void sort_crs_matrix(const rowmap_t& rowmap, const entries_t& entries, const val
     //TODO (probably important for performnce): add thread-level sort also, and use that
     //for small avg degree. But this works for now.
     int teamSize = 1;
-    lno_t avgDeg = (entries.extent(0) + numRows - 1) / numRows;
+    lno_t avgDeg = 0;
+    if(numRows)
+      avgDeg = (entries.extent(0) + numRows - 1) / numRows;
     while(teamSize * 2 * 2 <= avgDeg)
     {
       teamSize *= 2;
@@ -1041,7 +1043,9 @@ void sort_crs_graph(const rowmap_t& rowmap, const entries_t& entries)
     //TODO (probably important for performnce): add thread-level sort also, and use that
     //for small avg degree. But this works for now.
     int teamSize = 1;
-    lno_t avgDeg = (entries.extent(0) + numRows - 1) / numRows;
+    lno_t avgDeg = 0;
+    if(numRows)
+      avgDeg = (entries.extent(0) + numRows - 1) / numRows;
     while(teamSize * 2 * 2 <= avgDeg)
     {
       teamSize *= 2;


### PR DESCRIPTION
``sort_crs_matrix`` uses avg degree, but there was no check that ``numRows != 0`` before dividing by it. This adds those checks.

This is a fix copied over from https://github.com/trilinos/Trilinos/pull/7464 .

Running kokkos-dev2 spot checks now.