### PR TITLE
TRMM and TRTRI perf test bug fixes and improvements

### DIFF
--- a/perf_test/blas/blas/KokkosBlas_perf_test.cpp
+++ b/perf_test/blas/blas/KokkosBlas_perf_test.cpp
@@ -159,7 +159,7 @@ static void __blas_perf_test_input_error(char **argv, int option_idx) {
 int main(int argc, char **argv) {
   options_t options;
   int option_idx = 0, ret;
-  char *n_str    = nullptr;
+  char *n_str = nullptr, *adim = nullptr, *bdim = nullptr;
   std::filebuf fb;
   char *out_file = nullptr;
 
@@ -213,31 +213,43 @@ int main(int argc, char **argv) {
         }
         break;
       case 'b':
-        n_str = strcasestr(optarg, "x");
+        adim    = optarg;
+        bdim    = strcasestr(optarg, ",");
+        bdim[0] = '\0';
+        bdim    = &bdim[1];
+
+        n_str = strcasestr(adim, "x");
         if (n_str == NULL) __blas_perf_test_input_error(argv, option_idx);
 
         n_str[0]          = '\0';
-        options.start.a.m = atoi(optarg);
+        options.start.a.m = atoi(adim);
         options.start.a.n = atoi(&n_str[1]);
 
-        n_str = strcasestr(&n_str[1], "x");
+        n_str = strcasestr(bdim, "x");
         if (n_str == NULL) __blas_perf_test_input_error(argv, option_idx);
+
         n_str[0]          = '\0';
-        options.start.b.m = atoi(optarg);
+        options.start.b.m = atoi(bdim);
         options.start.b.n = atoi(&n_str[1]);
         break;
       case 'e':
-        n_str = strcasestr(optarg, "x");
+        adim    = optarg;
+        bdim    = strcasestr(optarg, ",");
+        bdim[0] = '\0';
+        bdim    = &bdim[1];
+
+        n_str = strcasestr(adim, "x");
         if (n_str == NULL) __blas_perf_test_input_error(argv, option_idx);
 
         n_str[0]         = '\0';
-        options.stop.a.m = atoi(optarg);
+        options.stop.a.m = atoi(adim);
         options.stop.a.n = atoi(&n_str[1]);
 
-        n_str = strcasestr(&n_str[1], "x");
+        n_str = strcasestr(bdim, "x");
         if (n_str == NULL) __blas_perf_test_input_error(argv, option_idx);
+
         n_str[0]         = '\0';
-        options.stop.b.m = atoi(optarg);
+        options.stop.b.m = atoi(bdim);
         options.stop.b.n = atoi(&n_str[1]);
         break;
       case 's': options.step = atoi(optarg); break;
@@ -247,9 +259,7 @@ int main(int argc, char **argv) {
         out_file         = optarg;
         options.out_file = std::string(out_file);
         break;
-      case 'r': 
-        options.blas_routines = std::string(optarg);
-        break;
+      case 'r': options.blas_routines = std::string(optarg); break;
       case '?':
       default: __blas_perf_test_input_error(argv, option_idx);
     }

--- a/perf_test/blas/blas3/KokkosBlas3_perf_test.cpp
+++ b/perf_test/blas/blas3/KokkosBlas3_perf_test.cpp
@@ -166,7 +166,7 @@ static void __blas3_perf_test_input_error(char **argv, int option_idx) {
 int main(int argc, char **argv) {
   options_t options;
   int option_idx = 0, ret;
-  char *n_str    = nullptr;
+  char *n_str = nullptr, *adim = nullptr, *bdim = nullptr;
   std::filebuf fb;
   char *out_file = nullptr;
 
@@ -225,31 +225,43 @@ int main(int argc, char **argv) {
         }
         break;
       case 'b':
-        n_str = strcasestr(optarg, "x");
+        adim    = optarg;
+        bdim    = strcasestr(optarg, ",");
+        bdim[0] = '\0';
+        bdim    = &bdim[1];
+
+        n_str = strcasestr(adim, "x");
         if (n_str == NULL) __blas3_perf_test_input_error(argv, option_idx);
 
         n_str[0]          = '\0';
-        options.start.a.m = atoi(optarg);
+        options.start.a.m = atoi(adim);
         options.start.a.n = atoi(&n_str[1]);
 
-        n_str = strcasestr(&n_str[1], "x");
+        n_str = strcasestr(bdim, "x");
         if (n_str == NULL) __blas3_perf_test_input_error(argv, option_idx);
+
         n_str[0]          = '\0';
-        options.start.b.m = atoi(optarg);
+        options.start.b.m = atoi(bdim);
         options.start.b.n = atoi(&n_str[1]);
         break;
       case 'e':
-        n_str = strcasestr(optarg, "x");
+        adim    = optarg;
+        bdim    = strcasestr(optarg, ",");
+        bdim[0] = '\0';
+        bdim    = &bdim[1];
+
+        n_str = strcasestr(adim, "x");
         if (n_str == NULL) __blas3_perf_test_input_error(argv, option_idx);
 
         n_str[0]         = '\0';
-        options.stop.a.m = atoi(optarg);
+        options.stop.a.m = atoi(adim);
         options.stop.a.n = atoi(&n_str[1]);
 
-        n_str = strcasestr(&n_str[1], "x");
+        n_str = strcasestr(bdim, "x");
         if (n_str == NULL) __blas3_perf_test_input_error(argv, option_idx);
+
         n_str[0]         = '\0';
-        options.stop.b.m = atoi(optarg);
+        options.stop.b.m = atoi(bdim);
         options.stop.b.n = atoi(&n_str[1]);
         break;
       case 's': options.step = atoi(optarg); break;
@@ -259,9 +271,7 @@ int main(int argc, char **argv) {
         out_file         = optarg;
         options.out_file = std::string(out_file);
         break;
-      case 'r': 
-        options.blas_routines = std::string(optarg);
-        break;
+      case 'r': options.blas_routines = std::string(optarg); break;
       case '?':
       default: __blas3_perf_test_input_error(argv, option_idx);
     }


### PR DESCRIPTION
perf_test/blas:
  - Fix -b and -e options.
  - Always print device.
  - Ifdef serial routines to only run on host.
  - Initialize trmm_args.alpha.

# Spot-check
```
<snip>
WARNING!! THE FOLLOWING CHANGES ARE UNCOMMITTED!! :
?? build/
?? testing/

KokkosKernels Repository Status:  d9819c39cbdd163583397ee5a964e65ca5f0acdf perf_test/blas:

Kokkos Repository Status:  794c6df49008102b3237ad4f11e05f0aba89e021 Merge pull request #2997 from jjwilke/amd-zen-flags


Going to test compilers:  gcc/6.4.0 gcc/7.2.0 ibm/16.1.1 cuda/9.2.88 cuda/10.1.105
<snip>
#######################################################
PASSED TESTS
#######################################################
cuda-10.1.105-Cuda_OpenMP-release build_time=639 run_time=172
cuda-10.1.105-Cuda_Serial-release build_time=587 run_time=187
cuda-9.2.88-Cuda_OpenMP-release build_time=577 run_time=187
cuda-9.2.88-Cuda_Serial-release build_time=582 run_time=202
gcc-6.4.0-OpenMP_Serial-release build_time=240 run_time=141
gcc-7.2.0-OpenMP-release build_time=144 run_time=62
gcc-7.2.0-OpenMP_Serial-release build_time=239 run_time=138
gcc-7.2.0-Serial-release build_time=149 run_time=70
ibm-16.1.1-Serial-release build_time=986 run_time=75
```