### PR TITLE
Allow const-valued C rowmap in spgemm/add numeric (Fix #744)

### DIFF
--- a/src/sparse/KokkosSparse_spadd.hpp
+++ b/src/sparse/KokkosSparse_spadd.hpp
@@ -615,10 +615,8 @@ namespace Experimental {
         "add_symbolic: A size_type must match KernelHandle size_type (const doesn't matter)");
     static_assert(SAME_TYPE(typename blno_row_view_t_::value_type, size_type),
         "add_symbolic: B size_type must match KernelHandle size_type (const doesn't matter)");
-    static_assert(SAME_TYPE(typename clno_row_view_t_::value_type, size_type),
+    static_assert(SAME_TYPE(typename clno_row_view_t_::non_const_value_type, size_type),
         "add_symbolic: C size_type must match KernelHandle size_type)");
-    static_assert(std::is_same<typename clno_row_view_t_::value_type, typename clno_row_view_t_::value_type>::value,
-        "add_symbolic: C size_type must not be const");
     static_assert(SAME_TYPE(typename alno_nnz_view_t_::value_type, ordinal_type),
         "add_symbolic: A entry type must match KernelHandle entry type (aka nnz_lno_t, and const doesn't matter)");
     static_assert(SAME_TYPE(typename blno_nnz_view_t_::value_type, ordinal_type),

--- a/src/sparse/KokkosSparse_spgemm_numeric.hpp
+++ b/src/sparse/KokkosSparse_spgemm_numeric.hpp
@@ -84,54 +84,50 @@ void spgemm_numeric(
 
 
 
-  static_assert (std::is_same<typename clno_row_view_t_::value_type,
-      typename clno_row_view_t_::non_const_value_type>::value,
-      "KokkosSparse::spgemm_symbolic: Output matrix rowmap must be non-const.");
-
   static_assert (std::is_same<typename clno_nnz_view_t_::value_type,
       typename clno_nnz_view_t_::non_const_value_type>::value,
-      "KokkosSparse::spgemm_symbolic: Output matrix entriesView must be non-const.");
+      "KokkosSparse::spgemm_numeric: Output matrix entriesView must be non-const.");
 
   static_assert (std::is_same<typename cscalar_nnz_view_t_::value_type,
       typename cscalar_nnz_view_t_::non_const_value_type>::value,
-      "KokkosSparse::spgemm_symbolic: Output matrix scalar view must be non-const.");
+      "KokkosSparse::spgemm_numeric: Output matrix scalar view must be non-const.");
 
   static_assert (std::is_same<typename KernelHandle::const_size_type,
       typename alno_row_view_t_::const_value_type>::value,
-      "KokkosSparse::spgemm_symbolic: Size type of left handside matrix should be same as kernelHandle sizetype.");
+      "KokkosSparse::spgemm_numeric: Size type of left handside matrix should be same as kernelHandle sizetype.");
 
   static_assert (std::is_same<typename KernelHandle::const_size_type,
       typename blno_row_view_t_::const_value_type>::value,
-      "KokkosSparse::spgemm_symbolic: Size type of right handside matrix should be same as kernelHandle sizetype.");
+      "KokkosSparse::spgemm_numeric: Size type of right handside matrix should be same as kernelHandle sizetype.");
 
   static_assert (std::is_same<typename KernelHandle::const_size_type,
       typename clno_row_view_t_::const_value_type>::value,
-      "KokkosSparse::spgemm_symbolic: Size type of output matrix should be same as kernelHandle sizetype.");
+      "KokkosSparse::spgemm_numeric: Size type of output matrix should be same as kernelHandle sizetype.");
 
 
   static_assert (std::is_same<typename KernelHandle::const_nnz_lno_t,
       typename alno_nnz_view_t_::const_value_type>::value,
-      "KokkosSparse::spgemm_symbolic: lno type of left handside matrix should be same as kernelHandle lno_t.");
+      "KokkosSparse::spgemm_numeric: lno type of left handside matrix should be same as kernelHandle lno_t.");
 
   static_assert (std::is_same<typename KernelHandle::const_nnz_lno_t,
       typename blno_nnz_view_t_::const_value_type>::value,
-      "KokkosSparse::spgemm_symbolic: lno type of right handside matrix should be same as kernelHandle lno_t.");
+      "KokkosSparse::spgemm_numeric: lno type of right handside matrix should be same as kernelHandle lno_t.");
 
   static_assert (std::is_same<typename KernelHandle::const_nnz_lno_t,
       typename clno_nnz_view_t_::const_value_type>::value,
-      "KokkosSparse::spgemm_symbolic: lno type of output matrix should be same as kernelHandle lno_t.");
+      "KokkosSparse::spgemm_numeric: lno type of output matrix should be same as kernelHandle lno_t.");
 
   static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
       typename ascalar_nnz_view_t_::const_value_type>::value,
-      "KokkosSparse::spgemm_symbolic: scalar type of left handside matrix should be same as kernelHandle scalar.");
+      "KokkosSparse::spgemm_numeric: scalar type of left handside matrix should be same as kernelHandle scalar.");
 
   static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
       typename bscalar_nnz_view_t_::const_value_type>::value,
-      "KokkosSparse::spgemm_symbolic: scalar type of right handside matrix should be same as kernelHandle scalar.");
+      "KokkosSparse::spgemm_numeric: scalar type of right handside matrix should be same as kernelHandle scalar.");
 
   static_assert (std::is_same<typename KernelHandle::const_nnz_scalar_t,
       typename cscalar_nnz_view_t_::const_value_type>::value,
-      "KokkosSparse::spgemm_symbolic: scalar type of output matrix should be same as kernelHandle scalar.");
+      "KokkosSparse::spgemm_numeric: scalar type of output matrix should be same as kernelHandle scalar.");
 
 
   if (transposeA || transposeB){


### PR DESCRIPTION
Also fix the static_assert messages in spgemm_numeric to say they're in numeric, not symbolic.

kokkos-dev2:
#######################################################
PASSED TESTS
#######################################################
clang-8.0-Cuda_OpenMP-release build_time=353 run_time=85
clang-8.0-Pthread_Serial-release build_time=127 run_time=49
clang-9.0.0-Pthread-release build_time=83 run_time=24
clang-9.0.0-Serial-release build_time=89 run_time=24
cuda-10.1-Cuda_OpenMP-release build_time=445 run_time=84
cuda-9.2-Cuda_Serial-release build_time=438 run_time=97
gcc-4.8.4-OpenMP-release build_time=76 run_time=27
gcc-7.3.0-OpenMP-release build_time=95 run_time=26
gcc-7.3.0-Pthread-release build_time=79 run_time=24
gcc-8.3.0-Serial-release build_time=89 run_time=25
gcc-9.1-OpenMP-release build_time=109 run_time=26
gcc-9.1-Serial-release build_time=96 run_time=25
intel-17.0.1-Serial-release build_time=151 run_time=22
intel-18.0.5-OpenMP-release build_time=247 run_time=24
intel-19.0.5-Pthread-release build_time=256 run_time=22
