### PR TITLE
Develop: ignore invalid reads in MatrixMarket file reader

### DIFF
--- a/src/common/KokkosKernels_IOUtils.hpp
+++ b/src/common/KokkosKernels_IOUtils.hpp
@@ -1157,7 +1157,8 @@ int read_mtx (
   size_type nE = 0;
   lno_t numDiagonal = 0;
   for (size_type i = 0; i < nnz; ++i){
-    getline(mmf, fline);
+    bool isValid = getline(mmf, fline);
+    if(!isValid) continue;
     std::stringstream ss2 (fline);
     struct Edge<lno_t, scalar_t> tmp;
     //read source, dest (edge) and weight (value)

--- a/src/common/KokkosKernels_IOUtils.hpp
+++ b/src/common/KokkosKernels_IOUtils.hpp
@@ -1157,8 +1157,7 @@ int read_mtx (
   size_type nE = 0;
   lno_t numDiagonal = 0;
   for (size_type i = 0; i < nnz; ++i){
-    bool isValid = getline(mmf, fline);
-    if(!isValid) continue;
+    if(!getline(mmf, fline)) continue;
     std::stringstream ss2 (fline);
     struct Edge<lno_t, scalar_t> tmp;
     //read source, dest (edge) and weight (value)


### PR DESCRIPTION
I stumbled across an instance where a call to std::getline failed, and figured I'd issue a PR with the fix I used.

Output from running cm_test_all_sandia --spot-check: (note: I committed/pushed the current change after this test)

Running on machine: blake
WARNING!! THE FOLLOWING CHANGES ARE UNCOMMITTED!! :
 M src/common/KokkosKernels_IOUtils.hpp

KokkosKernels Repository Status:  0e4a5b3734487640b263ce51dba39f559a358acc Added check for std::getline's return value in MatrixMarket file reading, to ignore invalid reads.

Kokkos Repository Status:  120425747ea3ca217a00c6ec7243a5905def9dab Merge pull request #3172 from ndellingwood/fix-dangling-else


Going to test compilers:  intel/19.1.144 gcc/7.2.0
Testing compiler intel/19.1.144
Testing compiler gcc/7.2.0
  Starting job intel-19.1.144-OpenMP_Serial-release
kokkos devices: OpenMP,Serial
kokkos arch: SKX
kokkos options:
kokkos cuda options:
kokkos cxxflags: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wuninitialized

extra_args: 
kokkoskernels scalars: 'double,complex_double'
kokkoskernels ordinals: int
kokkoskernels offsets: int,size_t
kokkoskernels layouts: LayoutLeft
  PASSED intel-19.1.144-OpenMP_Serial-release
  Starting job gcc-7.2.0-OpenMP-release
kokkos devices: OpenMP
kokkos arch: SKX
kokkos options: 
kokkos cuda options: 
kokkos cxxflags: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wignored-qualifiers -Wempty-body -Wclobbered -Wuninitialized 
extra_args: 
kokkoskernels scalars: 'double,complex_double'
kokkoskernels ordinals: int
kokkoskernels offsets: int,size_t
kokkoskernels layouts: LayoutLeft
  PASSED gcc-7.2.0-OpenMP-release
  Starting job gcc-7.2.0-Pthread-release
kokkos devices: Pthread
kokkos arch: SKX
kokkos options: 
kokkos cuda options: 
kokkos cxxflags: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wignored-qualifiers -Wempty-body -Wclobbered -Wuninitialized 
extra_args: 
kokkoskernels scalars: 'double,complex_double'
kokkoskernels ordinals: int
kokkoskernels offsets: int,size_t
kokkoskernels layouts: LayoutLeft
  PASSED gcc-7.2.0-Pthread-release
  Starting job gcc-7.2.0-Serial-release
kokkos devices: Serial
kokkos arch: SKX
kokkos options: 
kokkos cuda options: 
kokkos cxxflags: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wignored-qualifiers -Wempty-body -Wclobbered -Wuninitialized 
extra_args: 
kokkoskernels scalars: 'double,complex_double'
kokkoskernels ordinals: int
kokkoskernels offsets: int,size_t
kokkoskernels layouts: LayoutLeft
  PASSED gcc-7.2.0-Serial-release
  Starting job gcc-7.2.0-OpenMP_Serial-release
kokkos devices: OpenMP,Serial
kokkos arch: SKX
kokkos options: 
kokkos cuda options: 
kokkos cxxflags: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wignored-qualifiers -Wempty-body -Wclobbered -Wuninitialized 
extra_args: 
kokkoskernels scalars: 'double,complex_double'
kokkoskernels ordinals: int
kokkoskernels offsets: int,size_t
kokkoskernels layouts: LayoutLeft
  PASSED gcc-7.2.0-OpenMP_Serial-release
  Starting job gcc-7.2.0-Pthread_Serial-release
kokkos devices: Pthread,Serial
kokkos arch: SKX
kokkos options: 
kokkos cuda options: 
kokkos cxxflags: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wignored-qualifiers -Wempty-body -Wclobbered -Wuninitialized
extra_args:
kokkoskernels scalars: 'double,complex_double'
kokkoskernels ordinals: int
kokkoskernels offsets: int,size_t
kokkoskernels layouts: LayoutLeft
  PASSED gcc-7.2.0-Pthread_Serial-release
#######################################################
PASSED TESTS
#######################################################
gcc-7.2.0-OpenMP-release build_time=206 run_time=56
gcc-7.2.0-OpenMP_Serial-release build_time=322 run_time=118
gcc-7.2.0-Pthread-release build_time=168 run_time=51
gcc-7.2.0-Pthread_Serial-release build_time=280 run_time=108
gcc-7.2.0-Serial-release build_time=183 run_time=56
intel-19.1.144-OpenMP_Serial-release build_time=758 run_time=103
