### PR TITLE
Use relative errors in the spgemm and jacobi tests 

### DIFF
--- a/src/common/KokkosKernels_SimpleUtils.hpp
+++ b/src/common/KokkosKernels_SimpleUtils.hpp
@@ -260,6 +260,59 @@ bool kk_is_identical_view(view_type1 view1, view_type2 view2, eps_type eps){
   }
 }
 
+template<typename view_type1, typename view_type2, typename eps_type = typename Kokkos::Details::ArithTraits<typename view_type2::non_const_value_type>::mag_type>
+struct IsRelativelyIdenticalFunctor{
+  view_type1 view1;
+  view_type2 view2;
+  eps_type eps;
+
+
+  IsRelativelyIdenticalFunctor(view_type1 view1_, view_type2 view2_, eps_type eps_):
+    view1(view1_), view2(view2_), eps(eps_){}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const size_t &i, size_t &is_equal) const {
+    typedef typename view_type2::non_const_value_type val_type;
+    typedef Kokkos::Details::ArithTraits<val_type> KAT;
+    typedef typename KAT::mag_type mag_type;
+    typedef Kokkos::Details::ArithTraits<mag_type> KATM;
+ 
+    mag_type val_diff = KAT::abs (view1(i) - view2(i));
+    mag_type denominator = KAT::abs(view1(i));
+    if(KAT::abs(view2(i)) > denominator)
+      denominator = KAT::abs(view2(i));
+    
+    if(denominator > KATM::zero() )
+      val_diff = val_diff / denominator;
+
+    if (val_diff > eps ) {
+      is_equal+=1;
+    }
+  }
+};
+
+template <typename view_type1, typename view_type2, typename eps_type, typename MyExecSpace>
+bool kk_is_relatively_identical_view(view_type1 view1, view_type2 view2, eps_type eps){
+
+  if (view1.extent(0) != view2.extent(0)){
+    return false;
+  }
+
+  size_t num_elements = view1.extent(0);
+
+  typedef Kokkos::RangePolicy<MyExecSpace> my_exec_space;
+  size_t issame = 0;
+  Kokkos::parallel_reduce( "KokkosKernels::Common::IsRelativelyIdenticalView", my_exec_space(0,num_elements),
+      IsRelativelyIdenticalFunctor<view_type1, view_type2, eps_type>(view1, view2, eps), issame);
+  MyExecSpace().fence();
+  if (issame > 0){
+    return false;
+  }
+  else {
+    return true;
+  }
+}
+
 template<typename view_type>
 struct ReduceMaxFunctor{
 

--- a/unit_test/sparse/Test_Sparse_spgemm.hpp
+++ b/unit_test/sparse/Test_Sparse_spgemm.hpp
@@ -253,7 +253,7 @@ bool is_same_matrix(crsMat_t output_mat_actual, crsMat_t output_mat_reference){
   eps_type eps = std::is_same<eps_type,float>::value?2*1e-3:1e-7;
 
 
-  is_identical = KokkosKernels::Impl::kk_is_identical_view
+  is_identical = KokkosKernels::Impl::kk_is_relatively_identical_view
       <scalar_view_t, scalar_view_t, eps_type,
       typename device::execution_space>(h_vals_actual, h_vals_reference, eps);
 
@@ -455,7 +455,7 @@ void test_issue402()
 
 #define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE) \
 TEST_F( TestCategory, sparse ## _ ## spgemm ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
-  test_spgemm<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 30, 500, 10); \
+  test_spgemm<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 20, 500, 10); \
   test_spgemm<SCALAR,ORDINAL,OFFSET,DEVICE>(0, 0, 10, 10); \
   test_issue402<SCALAR,ORDINAL,OFFSET,DEVICE>(); \
 }

--- a/unit_test/sparse/Test_Sparse_spgemm_jacobi.hpp
+++ b/unit_test/sparse/Test_Sparse_spgemm_jacobi.hpp
@@ -245,7 +245,7 @@ bool is_same_mat(crsMat_t output_mat1, crsMat_t output_mat2){
   typedef typename Kokkos::Details::ArithTraits<typename scalar_view_t::non_const_value_type>::mag_type eps_type;
   eps_type eps = std::is_same<eps_type,float>::value?2*1e-3:1e-7;
 
-  is_identical = KokkosKernels::Impl::kk_is_identical_view
+  is_identical = KokkosKernels::Impl::kk_is_relatively_identical_view
       <scalar_view_t, scalar_view_t, eps_type,
       typename device::execution_space>(h_vals1, h_vals2, eps);
 


### PR DESCRIPTION
This PR replaces the absolute error with the relative error computed during the spgemm and jacobi tests. This need was arisen when the tests of the new jacobi kernel failed on float types. This was more of an issue for jacobi because the values of the input matrix entries are much larger for the jacobi tests due to using diagonally dominant matrices as input. 

Testing:
kokkos-kernels/scripts/cm_test_all_sandia --spot-check
```
#######################################################
PASSED TESTS
#######################################################
clang-8.0-Cuda_OpenMP-release build_time=623 run_time=152
clang-8.0-Pthread_Serial-release build_time=206 run_time=97
clang-9.0.0-Pthread-release build_time=121 run_time=44
clang-9.0.0-Serial-release build_time=128 run_time=51
cuda-10.1-Cuda_OpenMP-release build_time=805 run_time=151
cuda-9.2-Cuda_Serial-release build_time=776 run_time=177
gcc-4.8.4-OpenMP-release build_time=114 run_time=54
gcc-7.3.0-OpenMP-release build_time=144 run_time=53
gcc-7.3.0-Pthread-release build_time=123 run_time=46
gcc-8.3.0-Serial-release build_time=142 run_time=51
gcc-9.1-OpenMP-release build_time=180 run_time=52
gcc-9.1-Serial-release build_time=160 run_time=51
intel-17.0.1-Serial-release build_time=254 run_time=50
intel-18.0.5-OpenMP-release build_time=368 run_time=47
intel-19.0.5-Pthread-release build_time=404 run_time=42
```



kokkos-kernels/scripts/cm_test_all_sandia --spot-check --with-scalars='float,complex_float'
```
#######################################################
PASSED TESTS
#######################################################
clang-8.0-Pthread_Serial-release build_time=269 run_time=117
clang-9.0.0-Pthread-release build_time=172 run_time=56
clang-9.0.0-Serial-release build_time=172 run_time=58
gcc-4.8.4-OpenMP-release build_time=143 run_time=67
gcc-7.3.0-OpenMP-release build_time=177 run_time=68
gcc-7.3.0-Pthread-release build_time=169 run_time=56
gcc-8.3.0-Serial-release build_time=176 run_time=59
gcc-9.1-OpenMP-release build_time=228 run_time=66
gcc-9.1-Serial-release build_time=194 run_time=58
#######################################################
```

Cuda builds are failing due to the following spmv tests:
```
[----------] Global test environment tear-down
[==========] 134 tests from 1 test case ran. (59637 ms total)
[  PASSED  ] 122 tests.
[  FAILED  ] 12 tests, listed below:
[  FAILED  ] cuda.sparse_spmv_float_int_int_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_struct_float_int_int_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_float_int_size_t_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_struct_float_int_size_t_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_kokkos_complex_float_int_int_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_struct_kokkos_complex_float_int_int_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_kokkos_complex_float_int_size_t_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_struct_kokkos_complex_float_int_size_t_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_mv_float_int_int_LayoutLeft_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_mv_float_int_size_t_LayoutLeft_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_mv_kokkos_complex_float_int_int_LayoutLeft_TestExecSpace
[  FAILED  ] cuda.sparse_spmv_mv_kokkos_complex_float_int_size_t_LayoutLeft_TestExecSpace
```
