### PR TITLE
KokkosBatched - copy and set identity

### DIFF
--- a/src/batched/KokkosBatched_Copy_Internal.hpp
+++ b/src/batched/KokkosBatched_Copy_Internal.hpp
@@ -71,7 +71,7 @@ namespace KokkosBatched {
            const int m, const int n, 
            const ValueType *__restrict__ A, const int as0, const int as1,
            /* */ ValueType *__restrict__ B, const int bs0, const int bs1) {
-      if (m > n) { 
+      if (m >= n) { 
         Kokkos::parallel_for
           (Kokkos::TeamThreadRange(member,m),[&](const int &i) {
             SerialCopyInternal::invoke(n, A+i*as0, as1, B+i*bs0, bs1);


### PR DESCRIPTION
Some utility functions can have the same thread distributions. To match the distribution, this change is required and it can remove team barrier when copy and set identity is used in a sequence. This is matching PR with https://github.com/trilinos/Trilinos/pull/7738.