### PR TITLE
Cleanup spadd (#685, #694)

### DIFF
--- a/perf_test/sparse/KokkosSparse_run_spadd.hpp
+++ b/perf_test/sparse/KokkosSparse_run_spadd.hpp
@@ -119,7 +119,7 @@ void run_experiment(Parameters params)
   exec_space().fence();
   double symbolic_time = timer1.seconds();
 
-  size_type c_nnz = addHandle->get_max_result_nnz();
+  size_type c_nnz = addHandle->get_c_nnz();
   std::cout << "Result matrix will have " << c_nnz << " entries.\n";
 
   entriesC = lno_nnz_view_t("entriesC (empty)", c_nnz);

--- a/src/sparse/KokkosSparse_spadd.hpp
+++ b/src/sparse/KokkosSparse_spadd.hpp
@@ -47,6 +47,7 @@
 
 #include "KokkosKernels_Handle.hpp"
 #include "KokkosKernels_Sorting.hpp"
+#include <limits>
 
 namespace KokkosSparse {
 namespace Experimental {
@@ -84,7 +85,11 @@ struct SortedCountEntries {
         Browptrs(Browptrs_),
         Bcolinds(Bcolinds_),
         Crowcounts(Crowcounts_) {}
-  KOKKOS_INLINE_FUNCTION void operator()(const ordinal_type i) const {
+
+  static constexpr ordinal_type ORDINAL_MAX = std::numeric_limits<ordinal_type>::max();
+
+  KOKKOS_INLINE_FUNCTION void operator()(const ordinal_type i) const
+  {
     // count the union of nonzeros in Arow and Brow
     size_type numEntries = 0;
     size_type ai         = 0;
@@ -93,24 +98,19 @@ struct SortedCountEntries {
     size_type Arowlen    = Arowptrs(i + 1) - Arowstart;
     size_type Browstart  = Browptrs(i);
     size_type Browlen    = Browptrs(i + 1) - Browstart;
-    while (ai < Arowlen && bi < Browlen) {
-      // have an entry in C's row
+    ordinal_type Acol = (Arowlen == 0) ? ORDINAL_MAX : Acolinds(Arowstart);
+    ordinal_type Bcol = (Browlen == 0) ? ORDINAL_MAX : Bcolinds(Browstart);
+    while (Acol != ORDINAL_MAX || Bcol != ORDINAL_MAX) {
+      ordinal_type Ccol = (Acol < Bcol) ? Acol : Bcol;
       numEntries++;
-      ordinal_type Acol = Acolinds(Arowstart + ai);
-      ordinal_type Bcol = Bcolinds(Browstart + bi);
-      if (Acol <= Bcol) ai++;
-      if (Acol >= Bcol) bi++;
+      //Eat all entries in both A and B which have this column
+      //This also results in Acol/Bcol being updated to following entries for next loop iter
+      while(Acol == Ccol)
+        Acol = (ai == Arowlen) ? ORDINAL_MAX : Acolinds(Arowstart + ai++);
+      while(Bcol == Ccol)
+        Bcol = (bi == Browlen) ? ORDINAL_MAX : Bcolinds(Browstart + bi++);
     }
-    // if a and b have different numbers of entries in row i,
-    // the next two lines will account for remaining entries in the longer one
-    numEntries += Arowlen - ai;
-    numEntries += Browlen - bi;
     Crowcounts(i) = numEntries;
-    if (i == nrows - 1) {
-      // last workitem also zeros the one-past-end entry of row counts, so
-      // that prefix sum is correct
-      Crowcounts(nrows) = 0;
-    }
   }
   ordinal_type nrows;
   const typename ARowPtrsT::const_type Arowptrs;
@@ -283,11 +283,22 @@ struct MergeEntriesFunctor {
   KOKKOS_INLINE_FUNCTION void operator()(const ordinal_type i) const {
     size_type CrowStart = Crowptrs(i);
     size_type CrowEnd   = Crowptrs(i + 1);
+    if(CrowEnd == CrowStart)
+    {
+      Crowcounts(i) = 0;
+      return;
+    }
     size_type ArowStart = Arowptrs(i);
     size_type ArowNum   = Arowptrs(i + 1) - ArowStart;
     size_type BrowStart = Browptrs(i);
     ordinal_type CFit   = 0;  // counting through merged C indices (within row)
     for (size_type Cit = CrowStart; Cit < CrowEnd; Cit++) {
+      if((Cit > CrowStart) && (Ccolinds(Cit) != Ccolinds(Cit - 1)))
+      {
+        //This is a different column than the previous entry, and is not the first entry.
+        //This means that this is the first occurence of a unique column.
+        CFit++;
+      }
       size_type permVal = ABperm(Cit);
       if (permVal < ArowNum) {
         // Entry belongs to A
@@ -302,15 +313,11 @@ struct MergeEntriesFunctor {
         // entry in C
         Bpos(BrowStart + Bindex) = CFit;
       }
-      // if NOT merging uncompressed entries Cit and Cit + 1, increment
-      // compressed index CFit
-      bool mergingWithNext =
-          Cit < CrowEnd - 1 && Ccolinds(Cit) == Ccolinds(Cit + 1);
-      if (!mergingWithNext) CFit++;
     }
-    // at end of the row, know how many entries are in merged C
-    Crowcounts(i) = CFit;
-    if (i == nrows - 1) Crowcounts(nrows) = 0;
+    // At end of the row, know how many entries are in merged C.
+    // Right now, CFit is the index of the last Apos/Bpos,
+    // so adding one gives the total number of entries.
+    Crowcounts(i) = CFit + 1;
   }
   ordinal_type nrows;
   const ArowptrsT Arowptrs;
@@ -376,7 +383,7 @@ void spadd_symbolic(
   auto addHandle = handle->get_spadd_handle();
   if (a_rowmap.extent(0) == 0 || a_rowmap.extent(0) == 1) {
     // Have 0 rows, so nothing to do except set #nnz to 0
-    addHandle->set_max_result_nnz(0);
+    addHandle->set_c_nnz(0);
     // If c_rowmap has a single entry, it must be 0
     if (c_rowmap.extent(0)) Kokkos::deep_copy(c_rowmap, (size_type)0);
     addHandle->set_call_symbolic();
@@ -457,7 +464,7 @@ void spadd_symbolic(
   // provide the number of NNZ in C to user through handle
   size_type cmax;
   Kokkos::deep_copy(cmax, Kokkos::subview(c_rowmap, nrows));
-  addHandle->set_max_result_nnz(cmax);
+  addHandle->set_c_nnz(cmax);
   addHandle->set_call_symbolic();
   addHandle->set_call_numeric(false);
   // this fence is for accurate timing from host
@@ -470,6 +477,9 @@ template <typename size_type, typename ordinal_type, typename ArowptrsT,
           typename BvaluesT, typename CvaluesT, typename AscalarT,
           typename BscalarT>
 struct SortedNumericSumFunctor {
+  using CscalarT = typename CvaluesT::non_const_value_type;
+  static constexpr ordinal_type ORDINAL_MAX = std::numeric_limits<ordinal_type>::max();
+
   SortedNumericSumFunctor(const ArowptrsT& Arowptrs_,
                           const BrowptrsT& Browptrs_,
                           const CrowptrsT& Crowptrs_,
@@ -489,48 +499,49 @@ struct SortedNumericSumFunctor {
         Cvalues(Cvalues_),
         alpha(alpha_),
         beta(beta_) {}
-  KOKKOS_INLINE_FUNCTION void operator()(const ordinal_type i) const {
-    size_type CrowStart = Crowptrs(i);
-    size_type ArowStart = Arowptrs(i);
-    size_type ArowEnd   = Arowptrs(i + 1);
-    size_type Arowlen   = ArowEnd - ArowStart;
-    size_type BrowStart = Browptrs(i);
-    size_type BrowEnd   = Browptrs(i + 1);
-    size_type Browlen   = BrowEnd - BrowStart;
-    size_type ai        = 0;
-    size_type bi        = 0;
-    size_type ci        = 0;
-    // add in A entries, while setting C colinds
-    while (ai < Arowlen && bi < Browlen) {
-      ordinal_type Acol = Acolinds(ArowStart + ai);
-      ordinal_type Bcol = Bcolinds(BrowStart + bi);
-      if (Acol <= Bcol) {
-        Ccolinds(CrowStart + ci) = Acol;
-        Cvalues(CrowStart + ci) += alpha * Avalues(ArowStart + ai);
+
+  KOKKOS_INLINE_FUNCTION void operator()(const ordinal_type i) const
+  {
+    // count the union of nonzeros in Arow and Brow
+    size_type ai         = 0;
+    size_type bi         = 0;
+    size_type Arowstart  = Arowptrs(i);
+    size_type Arowlen    = Arowptrs(i + 1) - Arowstart;
+    size_type Browstart  = Browptrs(i);
+    size_type Browlen    = Browptrs(i + 1) - Browstart;
+    ordinal_type Acol = (Arowlen == 0) ? ORDINAL_MAX : Acolinds(Arowstart);
+    ordinal_type Bcol = (Browlen == 0) ? ORDINAL_MAX : Bcolinds(Browstart);
+    size_type Coffset = Crowptrs(i);
+    while (Acol != ORDINAL_MAX || Bcol != ORDINAL_MAX)
+    {
+      ordinal_type Ccol = (Acol < Bcol) ? Acol : Bcol;
+      //Eat all entries in both A and B which have this column
+      //This also results in Acol/Bcol being updated to following entries for next loop iter
+      CscalarT accum = {0};
+      while(Acol == Ccol)
+      {
+        accum += static_cast<CscalarT>(alpha * Avalues(Arowstart + ai));
         ai++;
+        if(ai == Arowlen)
+          Acol = ORDINAL_MAX;
+        else
+          Acol = Acolinds(Arowstart + ai);
       }
-      if (Acol >= Bcol) {
-        Ccolinds(CrowStart + ci) = Bcol;
-        Cvalues(CrowStart + ci) += beta * Bvalues(BrowStart + bi);
+      while(Bcol == Ccol)
+      {
+        accum += static_cast<CscalarT>(beta * Bvalues(Browstart + bi));
         bi++;
+        if(bi == Browlen)
+          Bcol = ORDINAL_MAX;
+        else
+          Bcol = Bcolinds(Browstart + bi);
       }
-      ci++;
-    }
-    // append remaining A entries (if any)
-    while (ai < Arowlen) {
-      Ccolinds(CrowStart + ci) = Acolinds(ArowStart + ai);
-      Cvalues(CrowStart + ci)  = alpha * Avalues(ArowStart + ai);
-      ai++;
-      ci++;
-    }
-    // append remaining B entries (if any)
-    while (bi < Browlen) {
-      Ccolinds(CrowStart + ci) = Bcolinds(BrowStart + bi);
-      Cvalues(CrowStart + ci)  = beta * Bvalues(BrowStart + bi);
-      bi++;
-      ci++;
+      Ccolinds(Coffset) = Ccol;
+      Cvalues(Coffset) = accum;
+      Coffset++;
     }
   }
+
   const ArowptrsT Arowptrs;
   const BrowptrsT Browptrs;
   const CrowptrsT Crowptrs;
@@ -550,6 +561,8 @@ template <typename size_type, typename ordinal_type, typename ArowptrsT,
           typename BvaluesT, typename CvaluesT, typename AscalarT,
           typename BscalarT>
 struct UnsortedNumericSumFunctor {
+  using CscalarT = typename CvaluesT::non_const_value_type;
+
   UnsortedNumericSumFunctor(
       const ArowptrsT Arowptrs_, const BrowptrsT Browptrs_,
       const CrowptrsT Crowptrs_, const AcolindsT Acolinds_,
@@ -572,10 +585,13 @@ struct UnsortedNumericSumFunctor {
 
   KOKKOS_INLINE_FUNCTION void operator()(const ordinal_type i) const {
     size_type CrowStart = Crowptrs(i);
+    size_type CrowEnd   = Crowptrs(i + 1);
     size_type ArowStart = Arowptrs(i);
     size_type ArowEnd   = Arowptrs(i + 1);
     size_type BrowStart = Browptrs(i);
     size_type BrowEnd   = Browptrs(i + 1);
+    for (size_type j = CrowStart; j < CrowEnd; j++)
+      Cvalues(j) = Kokkos::ArithTraits<CscalarT>::zero();
     // add in A entries, while setting C colinds
     for (size_type j = ArowStart; j < ArowEnd; j++) {
       Cvalues(CrowStart + Apos(j)) += alpha * Avalues(j);
@@ -729,14 +745,14 @@ void spadd_symbolic(KernelHandle* handle, const AMatrix& A, const BMatrix& B,
   // and subsequently construct C.
   auto addHandle = handle->get_spadd_handle();
   entries_type entriesC(Kokkos::ViewAllocateWithoutInitializing("entries"),
-                        addHandle->get_max_result_nnz());
+                        addHandle->get_c_nnz());
   graph_type graphC(entriesC, row_mapC);
   C = CMatrix("matrix", graphC);
 
   // Finally since we already have the number of nnz handy
   // we can go ahead and allocate C's values and set them.
   values_type valuesC(Kokkos::ViewAllocateWithoutInitializing("values"),
-                      addHandle->get_max_result_nnz());
+                      addHandle->get_c_nnz());
 
   C.values = valuesC;
 }

--- a/src/sparse/KokkosSparse_spadd.hpp
+++ b/src/sparse/KokkosSparse_spadd.hpp
@@ -517,7 +517,7 @@ struct SortedNumericSumFunctor {
       ordinal_type Ccol = (Acol < Bcol) ? Acol : Bcol;
       //Eat all entries in both A and B which have this column
       //This also results in Acol/Bcol being updated to following entries for next loop iter
-      CscalarT accum = {0};
+      CscalarT accum = Kokkos::ArithTraits<CscalarT>::zero();
       while(Acol == Ccol)
       {
         accum += static_cast<CscalarT>(alpha * Avalues(Arowstart + ai));

--- a/unit_test/sparse/Test_Sparse_spadd.hpp
+++ b/unit_test/sparse/Test_Sparse_spadd.hpp
@@ -85,6 +85,7 @@ void test_spadd(lno_t numRows, lno_t numCols, size_type minNNZ, size_type maxNNZ
   typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, Device, void, size_type> crsMat_t;
 
   typedef Kokkos::ArithTraits<scalar_t> KAT;
+  typedef typename KAT::mag_type magnitude_t;
   typedef typename crsMat_t::row_map_type::non_const_type row_map_type;
   typedef typename crsMat_t::index_type::non_const_type entries_type;
   typedef typename crsMat_t::values_type::non_const_type values_type;
@@ -185,7 +186,7 @@ void test_spadd(lno_t numRows, lno_t numCols, size_type minNNZ, size_type maxNNZ
       scalar_t Cval = Cvalues(i);
       lno_t Ccol = Centries(i);
       //Check that result is correct to 1 ULP
-      scalar_t maxError = (correct[Ccol] == KAT::zero()) ? eps : KAT::abs(correct[Ccol] * eps);
+      magnitude_t maxError = (correct[Ccol] == KAT::zero()) ? KAT::abs(eps) : KAT::abs(correct[Ccol] * eps);
       ASSERT_LE(KAT::abs(correct[Ccol] - Cval), maxError) << "A+B row " << row << ", column " << Ccol << " has value " << Cval << " but should be " << correct[Ccol];
     }
   }

--- a/unit_test/sparse/Test_Sparse_spadd.hpp
+++ b/unit_test/sparse/Test_Sparse_spadd.hpp
@@ -19,7 +19,7 @@ typedef Kokkos::complex<float> kokkos_complex_float;
 
 //Create a random square matrix for testing mat-mat addition kernels
 template <typename crsMat_t, typename ordinal_type>
-crsMat_t randomMatrix(ordinal_type nrows, ordinal_type minNNZ, ordinal_type maxNNZ, bool sortRows)
+crsMat_t randomMatrix(ordinal_type nrows, ordinal_type ncols, ordinal_type minNNZ, ordinal_type maxNNZ, bool sortRows)
 {
   typedef typename crsMat_t::StaticCrsGraphType graph_t;
   typedef typename graph_t::row_map_type::non_const_type size_type_view_t;
@@ -27,16 +27,20 @@ crsMat_t randomMatrix(ordinal_type nrows, ordinal_type minNNZ, ordinal_type maxN
   typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
   typedef typename size_type_view_t::non_const_value_type size_type;  //rowptr type
   typedef typename lno_view_t::non_const_value_type lno_t;            //colind type
+  typedef typename scalar_view_t::non_const_value_type scalar_t;
+  typedef Kokkos::ArithTraits<scalar_t> KAT;
   static_assert(std::is_same<ordinal_type, lno_t>::value, "ordinal_type should be same as lno_t from crsMat_t");
   //first, populate rowmap
   size_type_view_t rowmap("rowmap", nrows + 1);
   typename size_type_view_t::HostMirror h_rowmap = Kokkos::create_mirror_view(rowmap);
   size_type nnz = 0;
+  size_type maxRowEntries = 0;
   for(lno_t i = 0; i < nrows; i++)
   {
     size_type rowEntries = rand() % (maxNNZ - minNNZ + 1) + minNNZ;
     h_rowmap(i) = nnz;
     nnz += rowEntries;
+    maxRowEntries = std::max(rowEntries, maxRowEntries);
   }
   h_rowmap(nrows) = nnz;
   Kokkos::deep_copy(rowmap, h_rowmap);
@@ -46,20 +50,19 @@ crsMat_t randomMatrix(ordinal_type nrows, ordinal_type minNNZ, ordinal_type maxN
   typename scalar_view_t::HostMirror h_values = Kokkos::create_mirror_view(values);
   for(size_type i = 0; i < nnz; i++)
   {
-    h_values(i) = rand() / RAND_MAX;
+    h_values(i) = KAT::one() * (((typename KAT::mag_type) rand()) / RAND_MAX);
   }
   Kokkos::deep_copy(values, h_values);
   //populate entries (make sure no entry is repeated within a row)
   lno_view_t entries("entries", nnz);
   typename lno_view_t::HostMirror h_entries = Kokkos::create_mirror_view(entries);
-  std::vector<lno_t> indices(nrows);
-  auto re = std::default_random_engine(0);
+  std::vector<lno_t> indices(std::max((size_type) ncols, maxRowEntries));
+  auto re = std::mt19937(rand());
   for(lno_t i = 0; i < nrows; i++)
   {
-    for(lno_t j = 0; j < nrows; j++)
-    {
-      indices[j] = j;
-    }
+    //this formula guarantees no duplicates if maxNNZ <= ncols, and duplicates if minNNZ > ncols
+    for(size_t j = 0; j < indices.size(); j++)
+      indices[j] = j % ncols;
     std::shuffle(indices.begin(), indices.end(), re);
     size_type rowStart = h_rowmap(i);
     size_type rowCount = h_rowmap(i + 1) - rowStart;
@@ -73,14 +76,15 @@ crsMat_t randomMatrix(ordinal_type nrows, ordinal_type minNNZ, ordinal_type maxN
     }
   }
   Kokkos::deep_copy(entries, h_entries);
-  return crsMat_t("test matrix", nrows, nrows, nnz, values, rowmap, entries);
+  return crsMat_t("test matrix", nrows, ncols, nnz, values, rowmap, entries);
 }
 
 template <typename scalar_t, typename lno_t, typename size_type, class Device>
-void test_spadd(lno_t numRows, size_type minNNZ, size_type maxNNZ, bool sortRows)
+void test_spadd(lno_t numRows, lno_t numCols, size_type minNNZ, size_type maxNNZ, bool sortRows)
 {
   typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, Device, void, size_type> crsMat_t;
 
+  typedef Kokkos::ArithTraits<scalar_t> KAT;
   typedef typename crsMat_t::row_map_type::non_const_type row_map_type;
   typedef typename crsMat_t::index_type::non_const_type entries_type;
   typedef typename crsMat_t::values_type::non_const_type values_type;
@@ -88,13 +92,16 @@ void test_spadd(lno_t numRows, size_type minNNZ, size_type maxNNZ, bool sortRows
   typedef typename KokkosKernels::Experimental::KokkosKernelsHandle<size_type, lno_t, scalar_t,
   typename Device::execution_space, typename Device::memory_space, typename Device::memory_space> KernelHandle;
 
+  //Make the test deterministic on a given machine+compiler
+  srand((numRows << 1) ^ numCols);
+
   KernelHandle handle;
   handle.create_spadd_handle(sortRows);
-  crsMat_t A = randomMatrix<crsMat_t, lno_t>(numRows, minNNZ, maxNNZ, sortRows);
-  crsMat_t B = randomMatrix<crsMat_t, lno_t>(numRows, minNNZ, maxNNZ, sortRows);
-  //Matrices from randomMatrix are always square
-  lno_t numCols = numRows;
-  row_map_type c_row_map("C row map", numRows + 1);
+  crsMat_t A = randomMatrix<crsMat_t, lno_t>(numRows, numCols, minNNZ, maxNNZ, sortRows);
+  crsMat_t B = randomMatrix<crsMat_t, lno_t>(numRows, numCols, minNNZ, maxNNZ, sortRows);
+  row_map_type c_row_map(Kokkos::ViewAllocateWithoutInitializing("C row map"), numRows + 1);
+  //Make sure that nothing relies on any specific entry of c_row_map being zero initialized
+  Kokkos::deep_copy(c_row_map, (size_type) 5);
   auto addHandle = handle.get_spadd_handle();
   KokkosSparse::Experimental::spadd_symbolic<
     KernelHandle,
@@ -105,8 +112,12 @@ void test_spadd(lno_t numRows, size_type minNNZ, size_type maxNNZ, bool sortRows
     row_map_type,
     entries_type>
   (&handle, A.graph.row_map, A.graph.entries, B.graph.row_map, B.graph.entries, c_row_map);
-  values_type c_values("C values", addHandle->get_max_result_nnz());
-  entries_type c_entries("C entries", addHandle->get_max_result_nnz());
+  size_type c_nnz = addHandle->get_c_nnz();
+  //Fill values, entries with incorrect incorret
+  values_type c_values(Kokkos::ViewAllocateWithoutInitializing("C values"), c_nnz);
+  Kokkos::deep_copy(c_values, ((typename KAT::mag_type) 5) * KAT::one());
+  entries_type c_entries("C entries", c_nnz);
+  Kokkos::deep_copy(c_entries, (lno_t) 5);
   KokkosSparse::Experimental::spadd_numeric<
     KernelHandle,
     typename row_map_type::const_type,
@@ -116,12 +127,12 @@ void test_spadd(lno_t numRows, size_type minNNZ, size_type maxNNZ, bool sortRows
     typename entries_type::const_type,
     scalar_t, typename values_type::const_type,
     row_map_type, entries_type, values_type>
-    (&handle, A.graph.row_map, A.graph.entries, A.values, 1,
-     B.graph.row_map, B.graph.entries, B.values, 1,
+    (&handle, A.graph.row_map, A.graph.entries, A.values, KAT::one(),
+     B.graph.row_map, B.graph.entries, B.values, KAT::one(),
      c_row_map, c_entries, c_values);
   //done with handle
   //create C using CRS arrays
-  crsMat_t C("C", numRows, numRows, addHandle->get_max_result_nnz(), c_values, c_row_map, c_entries);
+  crsMat_t C("C", numRows, numCols, c_nnz, c_values, c_row_map, c_entries);
   handle.destroy_spadd_handle();
   auto Avalues = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A.values);
   auto Arowmap = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A.graph.row_map);
@@ -132,7 +143,6 @@ void test_spadd(lno_t numRows, size_type minNNZ, size_type maxNNZ, bool sortRows
   auto Cvalues = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), C.values);
   auto Crowmap = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), C.graph.row_map);
   auto Centries = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), C.graph.entries);
-  using KAT = Kokkos::ArithTraits<scalar_t>;
   auto zero = KAT::zero();
   auto eps = KAT::epsilon();
   //check that C is correct and sorted, row-by-row
@@ -159,10 +169,15 @@ void test_spadd(lno_t numRows, size_type minNNZ, size_type maxNNZ, bool sortRows
     //make sure C has the right number of entries
     auto actualNZ = Crowmap(row + 1) - Crowmap(row);
     ASSERT_EQ(actualNZ, nz) << "A+B row " << row << " has " << actualNZ << " entries but should have " << nz;
-    //make sure C's indices are sorted
+    //make sure C's indices are sorted and unique
     for(size_type i = Crowmap(row) + 1; i < Crowmap(row + 1); i++)
     {
-      ASSERT_LE(Centries(i - 1), Centries(i)) << "C row " << row << " is not sorted";
+      ASSERT_LT(Centries(i - 1), Centries(i)) << "C row " << row << " is not sorted";
+    }
+    //make sure C's indices are exactly the same as "nonzeros"
+    for(size_type i = Crowmap(row); i < Crowmap(row + 1); i++)
+    {
+      ASSERT_EQ(true, nonzeros[Centries(i)]);
     }
     //make sure C has the correct values
     for(size_type i = Crowmap(row); i < Crowmap(row + 1); i++)
@@ -170,17 +185,24 @@ void test_spadd(lno_t numRows, size_type minNNZ, size_type maxNNZ, bool sortRows
       scalar_t Cval = Cvalues(i);
       lno_t Ccol = Centries(i);
       //Check that result is correct to 1 ULP
-      ASSERT_LE(KAT::abs(correct[Ccol] - Cval), KAT::abs(correct[Ccol] * eps)) << "A+B row " << row << ", column " << Ccol << " has value " << Cval << " but should be " << correct[Ccol];
+      scalar_t maxError = (correct[Ccol] == KAT::zero()) ? eps : KAT::abs(correct[Ccol] * eps);
+      ASSERT_LE(KAT::abs(correct[Ccol] - Cval), maxError) << "A+B row " << row << ", column " << Ccol << " has value " << Cval << " but should be " << correct[Ccol];
     }
   }
 }
 
 #define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE) \
-TEST_F( TestCategory,sparse ## _ ## spadd ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
-  test_spadd<SCALAR,ORDINAL,OFFSET,DEVICE> (10, 0, 3, true); \
-  test_spadd<SCALAR,ORDINAL,OFFSET,DEVICE> (10, 0, 3, false); \
-  test_spadd<SCALAR,ORDINAL,OFFSET,DEVICE> (100, 50, 100, true); \
-  test_spadd<SCALAR,ORDINAL,OFFSET,DEVICE> (100, 50, 100, false); \
+TEST_F( TestCategory,sparse ## _ ## spadd_sorted_input ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
+  test_spadd<SCALAR,ORDINAL,OFFSET,DEVICE> (10, 10, 0, 0, true); \
+  test_spadd<SCALAR,ORDINAL,OFFSET,DEVICE> (10, 10, 0, 2, true); \
+  test_spadd<SCALAR,ORDINAL,OFFSET,DEVICE> (100, 100, 50, 100, true); \
+  test_spadd<SCALAR,ORDINAL,OFFSET,DEVICE> (50, 50, 75, 100, true); \
+} \
+TEST_F( TestCategory,sparse ## _ ## spadd_unsorted_input ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
+  test_spadd<SCALAR,ORDINAL,OFFSET,DEVICE> (10, 10, 0, 0, false); \
+  test_spadd<SCALAR,ORDINAL,OFFSET,DEVICE> (10, 10, 0, 2, false); \
+  test_spadd<SCALAR,ORDINAL,OFFSET,DEVICE> (100, 100, 50, 100, false); \
+  test_spadd<SCALAR,ORDINAL,OFFSET,DEVICE> (50, 50, 75, 100, false); \
 }
 
 #if (defined (KOKKOSKERNELS_INST_DOUBLE) \


### PR DESCRIPTION
- Remove "max_nnz_in_result" and its getter/setter from SpADD handle. It was really a duplicate of "c_nnz". Max is a bad name for this since it is not an upper bound, it is always exact. This will need to be propagated to Tpetra_MatrixMatrix_def.hpp when we do promotion.
- Remove team size/vector length stuff from SpADD handle, since SpADD only uses range policy. This was just copied from SpGEMM handle without needing it
- No longer require C's scalar values to be zero-initialized when they are passed in (#694)
- If A and/or B have unmerged rows (aka repeated column in a row), the resulting C is now always merged. Before, it would produce the correct sum but could only merge one entry from A and one entry from B. Now, it can merge an arbitrary number of entries from A and B (#685)
- Improve test coverage: test with unmerged inputs (both sorted and unsorted). The test now checks that the result is sorted and merged. Also add a test for a matrix with nonzero dimensions but zero entries.

Note that these are all just enhancements, not bugfixes. I noticed these while trying to track down an EMPIRE issue, where add's MergeEntriesFunctor is crashing after my recent cuSPARSE TPL changes. I think the underlying cause of the bug is somewhere else since cuSPARSE SpMV is completely unrelated to add.

Testing:
#######################################################
PASSED TESTS
#######################################################
clang-8.0-Pthread_Serial-release build_time=336 run_time=173
clang-9.0.0-Pthread-release build_time=136 run_time=77
clang-9.0.0-Serial-release build_time=174 run_time=64
cuda-10.1-Cuda_OpenMP-release build_time=848 run_time=167
cuda-9.2-Cuda_Serial-release build_time=794 run_time=210
gcc-4.8.4-OpenMP-release build_time=117 run_time=64
gcc-7.3.0-OpenMP-release build_time=179 run_time=2532
gcc-7.3.0-Pthread-release build_time=132 run_time=80
gcc-8.3.0-Serial-release build_time=206 run_time=66
gcc-9.1-OpenMP-release build_time=190 run_time=392
gcc-9.1-Serial-release build_time=175 run_time=67
intel-17.0.1-Serial-release build_time=263 run_time=59
intel-18.0.5-OpenMP-release build_time=425 run_time=67
intel-19.0.5-Pthread-release build_time=467 run_time=72
clang-8.0-Cuda_OpenMP-release (test failed) <== sparse_openmp timed out due to machine congestion, but I re-ran it today from the same build and it passed
#######################################################