### PR TITLE
Shrink size of block GS test matrix

### DIFF
--- a/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
@@ -414,10 +414,10 @@ void test_block_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth
 
 #define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE) \
 TEST_F( TestCategory, sparse ## _ ## block_gauss_seidel_rank1 ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
-	test_block_gauss_seidel_rank1<SCALAR,ORDINAL,OFFSET,DEVICE>(2000, 2000 * 15, 200, 10); \
+	test_block_gauss_seidel_rank1<SCALAR,ORDINAL,OFFSET,DEVICE>(500, 500 * 10, 70, 3); \
 } \
 TEST_F( TestCategory, sparse ## _ ## block_gauss_seidel_rank2 ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
-	test_block_gauss_seidel_rank2<SCALAR,ORDINAL,OFFSET,DEVICE>(2000, 2000 * 15, 200, 10); \
+	test_block_gauss_seidel_rank2<SCALAR,ORDINAL,OFFSET,DEVICE>(500, 500 * 10, 70, 3); \
 }
 
 


### PR DESCRIPTION
so that tests don't time out. Decreased number of rows by 4x, and entries per row by a third.
In a build with -g, non optimized, and Kokkos
debug, this reduced the time to run all block GS tests from 43s to 3.2s.
I don't think the test coverage is any worse, and anyway block GS is not used anywhere currently.

#######################################################
PASSED TESTS
#######################################################
clang-8.0-Cuda_OpenMP-release build_time=712 run_time=438
clang-8.0-Pthread_Serial-release build_time=223 run_time=128
clang-9.0.0-Pthread-release build_time=131 run_time=58
clang-9.0.0-Serial-release build_time=136 run_time=51
cuda-10.1-Cuda_OpenMP-release build_time=976 run_time=149
cuda-9.2-Cuda_Serial-release build_time=899 run_time=165
gcc-4.8.4-OpenMP-release build_time=144 run_time=52
gcc-7.3.0-OpenMP-release build_time=149 run_time=51
gcc-7.3.0-Pthread-release build_time=118 run_time=57
gcc-8.3.0-Serial-release build_time=184 run_time=54
gcc-9.1-OpenMP-release build_time=230 run_time=132
gcc-9.1-Serial-release build_time=208 run_time=53
intel-17.0.1-Serial-release build_time=339 run_time=63
intel-18.0.5-OpenMP-release build_time=405 run_time=1819
intel-19.0.5-Pthread-release build_time=398 run_time=60
