### PR TITLE
Reduce batched trmm and trtri unit test sizes

### DIFF
--- a/unit_test/batched/Test_Batched_SerialTrmm.hpp
+++ b/unit_test/batched/Test_Batched_SerialTrmm.hpp
@@ -275,7 +275,7 @@ template<typename DeviceType,
          typename ScalarType,
          typename ParamTagType,
          typename AlgoTagType>
-int test_batched_trmm() {
+int test_batched_trmm(int batchSize = 512) {
   char trans = std::is_same<typename ParamTagType::trans,Trans::NoTranspose>::value ? 'N' :
                 std::is_same<typename ParamTagType::trans,Trans::Transpose>::value ? 'T' :
                 std::is_same<typename ParamTagType::trans,Trans::ConjTranspose>::value ? 'C' : 'E';
@@ -285,8 +285,8 @@ int test_batched_trmm() {
     Test::impl_test_batched_trmm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(     0, 10, 4, &trans);
     for (int i=0;i<10;++i) {
       //printf("Testing: LayoutLeft,  Blksize %d\n", i);  
-      Test::impl_test_batched_trmm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024,  i, 4, &trans);
-      Test::impl_test_batched_trmm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024,  i, 1, &trans);
+      Test::impl_test_batched_trmm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(batchSize,  i, 4, &trans);
+      Test::impl_test_batched_trmm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(batchSize,  i, 1, &trans);
     }
   }
 #endif
@@ -296,8 +296,8 @@ int test_batched_trmm() {
     Test::impl_test_batched_trmm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(     0, 10, 4, &trans);
     for (int i=0;i<10;++i) {
       //printf("Testing: LayoutRight, Blksize %d\n", i);  
-      Test::impl_test_batched_trmm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024,  i, 4, &trans);
-      Test::impl_test_batched_trmm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024,  i, 1, &trans);
+      Test::impl_test_batched_trmm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(batchSize,  i, 4, &trans);
+      Test::impl_test_batched_trmm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(batchSize,  i, 1, &trans);
     }
   }
 #endif

--- a/unit_test/batched/Test_Batched_SerialTrmm_Complex.hpp
+++ b/unit_test/batched/Test_Batched_SerialTrmm_Complex.hpp
@@ -5,111 +5,111 @@ TEST_F( TestCategory, batched_scalar_serial_trmm_l_l_nt_u_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::NoTranspose,Diag::Unit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_l_nt_n_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::NoTranspose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_u_nt_u_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::NoTranspose,Diag::Unit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_u_nt_n_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::NoTranspose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_r_u_nt_u_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Side::Right,Uplo::Upper,Trans::NoTranspose,Diag::Unit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_r_u_nt_n_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Side::Right,Uplo::Upper,Trans::NoTranspose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 // TRANSPOSE
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_l_t_u_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::Unit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_l_t_n_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_u_t_u_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::Unit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_u_t_n_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_r_u_t_u_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Side::Right,Uplo::Upper,Trans::Transpose,Diag::Unit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_r_u_t_n_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Side::Right,Uplo::Upper,Trans::Transpose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 // CONJUGATE TRANSPOSE
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_l_ct_u_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::ConjTranspose,Diag::Unit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_l_ct_n_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::ConjTranspose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_u_ct_u_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::ConjTranspose,Diag::Unit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_u_ct_n_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::ConjTranspose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_r_u_ct_u_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Side::Right,Uplo::Upper,Trans::ConjTranspose,Diag::Unit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_r_u_ct_n_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Side::Right,Uplo::Upper,Trans::ConjTranspose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 #endif
 
@@ -120,111 +120,111 @@ TEST_F( TestCategory, batched_scalar_serial_trmm_l_l_nt_u_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::NoTranspose,Diag::Unit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_l_nt_n_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::NoTranspose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_u_nt_u_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::NoTranspose,Diag::Unit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_u_nt_n_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::NoTranspose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_r_u_nt_u_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Side::Right,Uplo::Upper,Trans::NoTranspose,Diag::Unit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_r_u_nt_n_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Side::Right,Uplo::Upper,Trans::NoTranspose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 // TRANSPOSE
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_l_t_u_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::Unit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_l_t_n_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::Transpose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_u_t_u_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::Unit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_u_t_n_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::Transpose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_r_u_t_u_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Side::Right,Uplo::Upper,Trans::Transpose,Diag::Unit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_r_u_t_n_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Side::Right,Uplo::Upper,Trans::Transpose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 // CONJUGATE TRANSPOSE
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_l_ct_u_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::ConjTranspose,Diag::Unit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_l_ct_n_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Lower,Trans::ConjTranspose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_u_ct_u_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::ConjTranspose,Diag::Unit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_l_u_ct_n_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Side::Left,Uplo::Upper,Trans::ConjTranspose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_r_u_ct_u_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Side::Right,Uplo::Upper,Trans::ConjTranspose,Diag::Unit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trmm_r_u_ct_n_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Side::Right,Uplo::Upper,Trans::ConjTranspose,Diag::NonUnit> param_tag_type;
   typedef Algo::Trmm::Unblocked algo_tag_type;
   
-  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trmm<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 #endif
 

--- a/unit_test/batched/Test_Batched_SerialTrtri.hpp
+++ b/unit_test/batched/Test_Batched_SerialTrtri.hpp
@@ -304,7 +304,7 @@ template<typename DeviceType,
          typename ScalarType,
          typename ParamTagType,
          typename AlgoTagType>
-int test_batched_trtri() {
+int test_batched_trtri(int batchSize = 512) {
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
   {
     typedef Kokkos::View<ValueType***,Kokkos::LayoutLeft,DeviceType> ViewType;
@@ -312,8 +312,8 @@ int test_batched_trtri() {
     //Test::impl_test_batched_trtri<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(     1, 2);
     for (int i=0;i<10;++i) {
       //printf("Testing: LayoutLeft,  Blksize %d\n", i);  
-      Test::impl_test_batched_trtri<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024,  i);
-      Test::impl_test_batched_trtri<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024,  i);
+      Test::impl_test_batched_trtri<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(batchSize,  i);
+      Test::impl_test_batched_trtri<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(batchSize,  i);
     }
   }
 #endif
@@ -323,8 +323,8 @@ int test_batched_trtri() {
     Test::impl_test_batched_trtri<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(     0, 10);
     for (int i=0;i<10;++i) {
       //printf("Testing: LayoutRight, Blksize %d\n", i);  
-      Test::impl_test_batched_trtri<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024,  i);
-      Test::impl_test_batched_trtri<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024,  i);
+      Test::impl_test_batched_trtri<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(batchSize,  i);
+      Test::impl_test_batched_trtri<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(batchSize,  i);
     }
   }
 #endif

--- a/unit_test/batched/Test_Batched_SerialTrtri_Complex.hpp
+++ b/unit_test/batched/Test_Batched_SerialTrtri_Complex.hpp
@@ -5,25 +5,25 @@ TEST_F( TestCategory, batched_scalar_serial_trtri_u_n_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Uplo::Upper,Diag::NonUnit> param_tag_type;
   typedef Algo::Trtri::Unblocked algo_tag_type;
   
-  test_batched_trtri<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trtri<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trtri_u_u_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Uplo::Upper,Diag::Unit> param_tag_type;
   typedef Algo::Trtri::Unblocked algo_tag_type;
   
-  test_batched_trtri<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trtri<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trtri_l_n_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Uplo::Lower,Diag::NonUnit> param_tag_type;
   typedef Algo::Trtri::Unblocked algo_tag_type;
   
-  test_batched_trtri<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trtri<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trtri_l_u_scomplex_scomplex ) {
   typedef ::Test::ParamTag<Uplo::Lower,Diag::Unit> param_tag_type;
   typedef Algo::Trtri::Unblocked algo_tag_type;
   
-  test_batched_trtri<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>();
+  test_batched_trtri<TestExecSpace,Kokkos::complex<float>,Kokkos::complex<float>,param_tag_type,algo_tag_type>(128);
 }
 #endif
 
@@ -34,25 +34,25 @@ TEST_F( TestCategory, batched_scalar_serial_trtri_u_n_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Uplo::Upper,Diag::NonUnit> param_tag_type;
   typedef Algo::Trtri::Unblocked algo_tag_type;
   
-  test_batched_trtri<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trtri<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trtri_u_u_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Uplo::Upper,Diag::Unit> param_tag_type;
   typedef Algo::Trtri::Unblocked algo_tag_type;
   
-  test_batched_trtri<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trtri<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trtri_l_n_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Uplo::Lower,Diag::NonUnit> param_tag_type;
   typedef Algo::Trtri::Unblocked algo_tag_type;
   
-  test_batched_trtri<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trtri<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 TEST_F( TestCategory, batched_scalar_serial_trtri_l_u_dcomplex_dcomplex ) {
   typedef ::Test::ParamTag<Uplo::Lower,Diag::Unit> param_tag_type;
   typedef Algo::Trtri::Unblocked algo_tag_type;
   
-  test_batched_trtri<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+  test_batched_trtri<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>(128);
 }
 #endif
 


### PR DESCRIPTION
## Summary of changes
* Reduce the default batch size from 1024 to 512.
* For complex scalars, use a batch size of 128.

## How was this tested?
```
WARNING!! THE FOLLOWING CHANGES ARE UNCOMMITTED!! :
?? build-develop/
?? build-issue-508/
?? build-issue-757/
?? build.750fe245/
?? build/
?? do-cmake.sh
?? do-test.sh
?? install-develop/
?? install-issue-757/
?? issue-727/
?? testing/

KokkosKernels Repository Status:  c7f7f483e36b14bb255d14dc1b95e51b81060daa unit_test/batched: Reduce batch size for trmm and trtri

Kokkos Repository Status:  b973b126183f6ea756c7b02591cecaa445e85a8f Merge pull request #3158 from masterleinad/fIx_hip_abort_warning


Going to test compilers:  gcc/7.3.0
Testing compiler gcc/7.3.0
  Starting job gcc-7.3.0-OpenMP-release
kokkos devices: OpenMP
kokkos arch: SNB,Volta70
kokkos options: disable_deprecated_code
kokkos cuda options: 
kokkos cxxflags: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wignored-qualifiers -Wempty-body -Wclobbered -Wuninitialized 
extra_args: 
kokkoskernels scalars: 'double,complex_double'
kokkoskernels ordinals: int
kokkoskernels offsets: int,size_t
kokkoskernels layouts: LayoutLeft
  PASSED gcc-7.3.0-OpenMP-release
  Starting job gcc-7.3.0-OpenMP_Serial-release
kokkos devices: OpenMP,Serial
kokkos arch: SNB,Volta70
kokkos options: disable_deprecated_code
kokkos cuda options: 
kokkos cxxflags: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wignored-qualifiers -Wempty-body -Wclobbered -Wuninitialized 
extra_args: 
kokkoskernels scalars: 'double,complex_double'
kokkoskernels ordinals: int
kokkoskernels offsets: int,size_t
kokkoskernels layouts: LayoutLeft
  PASSED gcc-7.3.0-OpenMP_Serial-release
#######################################################
PASSED TESTS
#######################################################
gcc-7.3.0-OpenMP-release build_time=142 run_time=41
gcc-7.3.0-OpenMP_Serial-release build_time=244 run_time=99
```