### PR TITLE
Remove bash error from cm_generate_makefile

### DIFF
--- a/cm_generate_makefile.bash
+++ b/cm_generate_makefile.bash
@@ -580,7 +580,6 @@ if [ "${KOKKOS_PATH}" == "" ]; then
   KOKKOS_PATH=`dirname $CM_SCRIPT`
   KOKKOS_PATH="${KOKKOS_PATH}/../kokkos"
   echo "CHECKING: $KOKKOS_PATH"
-  $(ls $KOKKOS_PATH)
   if [ ! -e ${KOKKOS_PATH}/CMakeLists.txt ]; then
      echo "Either kokkos repository is not in the same base directory as kokkos-kernels or ${KOKKOS_PATH} repository appears to not be complete.  Please verify or provide the path to kokkos and try again"
      exit 0

--- a/cm_generate_makefile.bash
+++ b/cm_generate_makefile.bash
@@ -579,7 +579,6 @@ if [ "${KOKKOS_PATH}" == "" ]; then
   CM_SCRIPT=$0
   KOKKOS_PATH=`dirname $CM_SCRIPT`
   KOKKOS_PATH="${KOKKOS_PATH}/../kokkos"
-  echo "CHECKING: $KOKKOS_PATH"
   if [ ! -e ${KOKKOS_PATH}/CMakeLists.txt ]; then
      echo "Either kokkos repository is not in the same base directory as kokkos-kernels or ${KOKKOS_PATH} repository appears to not be complete.  Please verify or provide the path to kokkos and try again"
      exit 0


### PR DESCRIPTION
Line 583 was doing ``$(ls $KOKKOS_PATH)``, which was trying to interpret
the results of the ls as a command. Since kokkos always contains ``algorithms, bin, ...``,
it said something like ``error: command "algorithms" not found``.
Since the command is run in a subshell, this wasn't a fatal error, but the output makes it look like one.
This line can just be removed since
the check for existence of ``$KOKKOS_PATH/CMakeLists.txt`` also implies that
``$KOKKOS_PATH`` exists.

@ndellingwood If I misunderstood the intent of this line, I'm sure I could come up
with a way to do the same thing but avoid the bash error.

#######################################################
PASSED TESTS
#######################################################
clang-8.0-Cuda_OpenMP-release build_time=659 run_time=133
clang-8.0-Pthread_Serial-release build_time=207 run_time=115
clang-9.0.0-Pthread-release build_time=118 run_time=54
clang-9.0.0-Serial-release build_time=130 run_time=44
cuda-10.1-Cuda_OpenMP-release build_time=815 run_time=133
cuda-9.2-Cuda_Serial-release build_time=791 run_time=184
gcc-4.8.4-OpenMP-release build_time=116 run_time=46
gcc-7.3.0-OpenMP-release build_time=165 run_time=47
gcc-7.3.0-Pthread-release build_time=119 run_time=55
gcc-8.3.0-Serial-release build_time=141 run_time=47
gcc-9.1-OpenMP-release build_time=180 run_time=44
gcc-9.1-Serial-release build_time=170 run_time=46
intel-17.0.1-Serial-release build_time=255 run_time=49
intel-18.0.5-OpenMP-release build_time=350 run_time=46
intel-19.0.5-Pthread-release build_time=405 run_time=55
