### PR TITLE
Fix the relative error computation (used in SpGEMM and Jacobi-fused SpGEMM tests)

### DIFF
--- a/src/common/KokkosKernels_SimpleUtils.hpp
+++ b/src/common/KokkosKernels_SimpleUtils.hpp
@@ -278,12 +278,9 @@ struct IsRelativelyIdenticalFunctor{
     typedef Kokkos::Details::ArithTraits<mag_type> KATM;
  
     mag_type val_diff = KAT::abs (view1(i) - view2(i));
-    mag_type denominator = KAT::abs(view1(i));
-    if(KAT::abs(view2(i)) > denominator)
-      denominator = KAT::abs(view2(i));
-    
-    if(denominator > KATM::zero() )
-      val_diff = val_diff / denominator;
+    if(KAT::abs(view1(i)) > KATM::zero() && KAT::abs(view2(i)) > KATM::zero()) {
+      val_diff = val_diff / KAT::abs(view2(i));
+    }
 
     if (val_diff > eps ) {
       is_equal+=1;


### PR DESCRIPTION
This PR fixes a minor bug in the relative error computation. With this change, the normalization is performed only when both of the entries have nonzero values.

This PR is expected to get rid of the failures in https://github.com/kokkos/kokkos-kernels/issues/780. 

**Spot check on white:**
```
#######################################################
PASSED TESTS
#######################################################
cuda-10.1.105-Cuda_OpenMP-release build_time=639 run_time=137
cuda-10.1.105-Cuda_Serial-release build_time=613 run_time=183
cuda-9.2.88-Cuda_OpenMP-release build_time=673 run_time=157
cuda-9.2.88-Cuda_Serial-release build_time=649 run_time=203
gcc-6.4.0-OpenMP_Serial-release build_time=221 run_time=138
gcc-7.2.0-OpenMP-release build_time=151 run_time=45
gcc-7.2.0-OpenMP_Serial-release build_time=216 run_time=138
gcc-7.2.0-Serial-release build_time=139 run_time=54
#######################################################
FAILED TESTS
#######################################################
ibm-16.1.1-Serial-release (build failed)
#######################################################
```
This ibm failure is a configuration error, which is not relevant to my changes.

**Spot check on kokkos-dev-2:**
```
#######################################################
PASSED TESTS
#######################################################
clang-8.0-Cuda_OpenMP-release build_time=633 run_time=121
clang-8.0-Pthread_Serial-release build_time=204 run_time=104
clang-9.0.0-Pthread-release build_time=121 run_time=48
clang-9.0.0-Serial-release build_time=129 run_time=38
cuda-10.1-Cuda_OpenMP-release build_time=811 run_time=121
cuda-9.2-Cuda_Serial-release build_time=781 run_time=173
gcc-4.8.4-OpenMP-release build_time=115 run_time=40
gcc-7.3.0-OpenMP-release build_time=228 run_time=39
gcc-7.3.0-Pthread-release build_time=132 run_time=49
gcc-8.3.0-Serial-release build_time=142 run_time=40
gcc-9.1-OpenMP-release build_time=181 run_time=38
gcc-9.1-Serial-release build_time=166 run_time=40
intel-17.0.1-Serial-release build_time=252 run_time=42
intel-18.0.5-OpenMP-release build_time=356 run_time=40
intel-19.0.5-Pthread-release build_time=425 run_time=50


```