### PR TITLE
Add new SpGEMM interfaces to the unit tests

### DIFF
--- a/src/sparse/impl/KokkosSparse_spgemm_numeric_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_numeric_spec.hpp
@@ -101,6 +101,40 @@ struct spgemm_numeric_eti_spec_avail {
         Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,  \
           Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
           Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+        Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
+          Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+        Kokkos::View<ORDINAL_TYPE *, LAYOUT_TYPE,  \
+          Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+        Kokkos::View<SCALAR_TYPE *, LAYOUT_TYPE,  \
+          Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged> > > \
+    { enum : bool { value = true }; }; \
+    \
+    template<> \
+    struct spgemm_numeric_eti_spec_avail< \
+        KokkosKernels::Experimental::KokkosKernelsHandle<\
+        const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
+          EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE> , \
+        Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
+          Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+        Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,  \
+          Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+        Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,  \
+          Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+        Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
+          Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+        Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,  \
+          Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+        Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,  \
+          Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<OFFSET_TYPE *, LAYOUT_TYPE,  \
           Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
           Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
@@ -343,6 +377,39 @@ struct SPGEMM_NUMERIC<KernelHandle,
           Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,  \
             Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
             Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+          Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
+            Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+            Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+          Kokkos::View<ORDINAL_TYPE *, LAYOUT_TYPE,  \
+            Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+            Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+          Kokkos::View<SCALAR_TYPE *, LAYOUT_TYPE,  \
+            Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+            Kokkos::MemoryTraits<Kokkos::Unmanaged> >, false, true >; \
+    \
+    extern template struct  \
+    SPGEMM_NUMERIC< \
+          typename KokkosKernels::Experimental::KokkosKernelsHandle<\
+          	const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
+            EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE> , \
+          Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
+            Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+            Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+          Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,  \
+            Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+            Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+          Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,  \
+            Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+            Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+          Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
+            Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+            Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+          Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,  \
+            Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+            Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+          Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,  \
+            Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+            Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
           Kokkos::View<OFFSET_TYPE *, LAYOUT_TYPE,  \
             Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
             Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
@@ -353,8 +420,40 @@ struct SPGEMM_NUMERIC<KernelHandle,
             Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
             Kokkos::MemoryTraits<Kokkos::Unmanaged> >, false, true >;
 
-
 #define KOKKOSSPARSE_SPGEMM_NUMERIC_ETI_SPEC_INST( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE) \
+    template struct  \
+    SPGEMM_NUMERIC< \
+          KokkosKernels::Experimental::KokkosKernelsHandle<\
+          const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
+            EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE> , \
+          Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
+            Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+            Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+          Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,  \
+            Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+            Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+          Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,  \
+            Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+            Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+          Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
+            Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+            Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+          Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,  \
+            Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+            Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+          Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,  \
+            Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+            Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+          Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
+            Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+            Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+          Kokkos::View<ORDINAL_TYPE *, LAYOUT_TYPE,  \
+            Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+            Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+          Kokkos::View<SCALAR_TYPE *, LAYOUT_TYPE,  \
+            Kokkos::Device<EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE>, \
+            Kokkos::MemoryTraits<Kokkos::Unmanaged> >, false, true > ; \
+\
     template struct  \
     SPGEMM_NUMERIC< \
           KokkosKernels::Experimental::KokkosKernelsHandle<\

--- a/unit_test/sparse/Test_Sparse_spgemm.hpp
+++ b/unit_test/sparse/Test_Sparse_spgemm.hpp
@@ -80,7 +80,31 @@ using namespace KokkosKernels::Experimental;
 namespace Test {
 
 template <typename crsMat_t, typename device>
-int run_spgemm(crsMat_t input_mat, crsMat_t input_mat2, KokkosSparse::SPGEMMAlgorithm spgemm_algorithm, crsMat_t &result) {
+int run_spgemm(crsMat_t A, crsMat_t B, KokkosSparse::SPGEMMAlgorithm spgemm_algorithm, crsMat_t &C) {
+
+  typedef typename crsMat_t::size_type size_type;
+  typedef typename crsMat_t::ordinal_type lno_t;
+  typedef typename crsMat_t::value_type scalar_t;
+
+  typedef KokkosKernels::Experimental::KokkosKernelsHandle
+      <size_type, lno_t, scalar_t,
+      typename device::execution_space, typename device::memory_space,typename device::memory_space > KernelHandle;
+
+  KernelHandle kh;
+  kh.set_team_work_size(16);
+  kh.set_dynamic_scheduling(true);
+
+  kh.create_spgemm_handle(spgemm_algorithm);
+
+  KokkosSparse::spgemm_symbolic(kh, A, false, B, false, C);
+  KokkosSparse::spgemm_numeric(kh, A, false, B, false, C);
+  kh.destroy_spgemm_handle();
+
+  return 0;
+}
+
+template <typename crsMat_t, typename device>
+int run_spgemm_old_interface(crsMat_t input_mat, crsMat_t input_mat2, KokkosSparse::SPGEMMAlgorithm spgemm_algorithm, crsMat_t &result) {
   typedef typename crsMat_t::StaticCrsGraphType graph_t;
   typedef typename graph_t::row_map_type::non_const_type lno_view_t;
   typedef typename graph_t::entries_type::non_const_type   lno_nnz_view_t;
@@ -269,7 +293,7 @@ bool is_same_matrix(crsMat_t output_mat_actual, crsMat_t output_mat_reference){
 }
 
 template <typename scalar_t, typename lno_t, typename size_type, typename device>
-void test_spgemm(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_variance) {
+void test_spgemm(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_variance, bool oldInterface=false) {
 
   using namespace Test;
   //device::execution_space::initialize();
@@ -288,7 +312,10 @@ void test_spgemm(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_v
   crsMat_t input_mat = KokkosKernels::Impl::kk_generate_sparse_matrix<crsMat_t>(numRows,numCols,nnz,row_size_variance, bandwidth);
 
   crsMat_t output_mat2;
-  run_spgemm<crsMat_t, device>(input_mat, input_mat, SPGEMM_DEBUG, output_mat2);
+  if(oldInterface)
+    run_spgemm_old_interface<crsMat_t, device>(input_mat, input_mat, SPGEMM_DEBUG, output_mat2);
+  else
+    run_spgemm<crsMat_t, device>(input_mat, input_mat, SPGEMM_DEBUG, output_mat2);
 
   std::vector<SPGEMMAlgorithm> algorithms = {SPGEMM_KK_MEMORY, SPGEMM_KK_SPEED, SPGEMM_KK_MEMSPEED};
 
@@ -351,7 +378,10 @@ void test_spgemm(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size_v
     bool failed = false;
     int res = 0;
     try{
-      res = run_spgemm<crsMat_t, device>(input_mat, input_mat, spgemm_algorithm, output_mat);
+      if(oldInterface)
+	res = run_spgemm_old_interface<crsMat_t, device>(input_mat, input_mat, spgemm_algorithm, output_mat);
+      else
+	res = run_spgemm<crsMat_t, device>(input_mat, input_mat, spgemm_algorithm, output_mat);
     }
     catch (const char *message){
       EXPECT_TRUE(is_expected_to_fail) << algo;
@@ -458,6 +488,7 @@ TEST_F( TestCategory, sparse ## _ ## spgemm ## _ ## SCALAR ## _ ## ORDINAL ## _ 
   test_spgemm<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 20, 500, 10); \
   test_spgemm<SCALAR,ORDINAL,OFFSET,DEVICE>(0, 0, 10, 10); \
   test_issue402<SCALAR,ORDINAL,OFFSET,DEVICE>(); \
+  test_spgemm<SCALAR,ORDINAL,OFFSET,DEVICE>(10000, 10000 * 20, 500, 10, true); \
 }
 
 //test_spgemm<SCALAR,ORDINAL,OFFSET,DEVICE>(50000, 50000 * 30, 100, 10);


### PR DESCRIPTION
This PR adds the new SpGEMM interfaces to the unit tests in addition to the old interfaces. The new interfaces take three CrsMatrix objects as input while the old ones take up to nine Kokkos Views instead.

This integration required adding new ETI stuff for numeric, because the old numeric interface requires a **non-const** row_mapC, whereas the new interface requires a **const** row_mapC.

SpGEMM tests are passing on kokkos-dev-2 and white.