### PR TITLE
Moving KokkosKernelsHandle, SpADD and SpGEMM out of experimental

### DIFF
--- a/example/graph/KokkosKernels_Example_Distance2GraphColor.cpp
+++ b/example/graph/KokkosKernels_Example_Distance2GraphColor.cpp
@@ -319,7 +319,7 @@ run_example(CrsGraph_type crsGraph, DataType num_cols, Parameters params)
     using lno_nnz_view_type = typename CrsGraph_type::entries_type::non_const_type;
     using size_type         = typename lno_view_type::non_const_value_type;
     using lno_type          = typename lno_nnz_view_type::non_const_value_type;
-    using KernelHandle_type = KokkosKernels::Experimental::KokkosKernelsHandle<size_type, lno_type, kk_scalar_type, ExecSpace, TempMemSpace, PersistentMemSpace>;
+    using KernelHandle_type = KokkosKernels::KokkosKernelsHandle<size_type, lno_type, kk_scalar_type, ExecSpace, TempMemSpace, PersistentMemSpace>;
 
 
     // Create a kernel handle

--- a/example/wiki/graph/KokkosGraph_wiki_coloring.cpp
+++ b/example/wiki/graph/KokkosGraph_wiki_coloring.cpp
@@ -25,7 +25,7 @@ using DeviceSpace = typename ExecSpace::memory_space;
 using Kokkos::HostSpace;
 using RowmapType = Kokkos::View<Offset*, DeviceSpace>;
 using ColindsType = Kokkos::View<Ordinal*, DeviceSpace>;
-using Handle  = KokkosKernels::Experimental::
+using Handle  = KokkosKernels::
   KokkosKernelsHandle<Offset, Ordinal, default_scalar, ExecSpace, DeviceSpace, DeviceSpace>;
 
 namespace ColoringDemo

--- a/example/wiki/sparse/KokkosSparse_wiki_gauss_seidel.cpp
+++ b/example/wiki/sparse/KokkosSparse_wiki_gauss_seidel.cpp
@@ -22,7 +22,7 @@ int main(int argc, char* argv[])
   using ExecSpace = Kokkos::DefaultExecutionSpace;
   using MemSpace = typename ExecSpace::memory_space;
   using Device  = Kokkos::Device<ExecSpace, MemSpace>;
-  using Handle  = KokkosKernels::Experimental::
+  using Handle  = KokkosKernels::
     KokkosKernelsHandle<Offset, Ordinal, default_scalar, ExecSpace, MemSpace, MemSpace>;
   using Matrix  = KokkosSparse::CrsMatrix<Scalar, Ordinal, Device, void, Offset>;
   using Vector  = typename Matrix::values_type;

--- a/example/wiki/sparse/KokkosSparse_wiki_spadd.cpp
+++ b/example/wiki/sparse/KokkosSparse_wiki_spadd.cpp
@@ -48,7 +48,7 @@ int main(int argc, char* argv[]) {
     matrix_type C;
 
     // Create KokkosKernelHandle
-    using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<
+    using KernelHandle = KokkosKernels::KokkosKernelsHandle<
         Offset, Ordinal, Scalar, execution_space, memory_space, memory_space>;
     KernelHandle kh;
     kh.create_spadd_handle(false);

--- a/example/wiki/sparse/KokkosSparse_wiki_spgemm.cpp
+++ b/example/wiki/sparse/KokkosSparse_wiki_spgemm.cpp
@@ -48,7 +48,7 @@ int main(int argc, char* argv[]) {
     matrix_type C;
 
     // Create KokkosKernelHandle
-    using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<
+    using KernelHandle = KokkosKernels::KokkosKernelsHandle<
         Offset, Ordinal, Scalar, execution_space, memory_space, memory_space>;
     KernelHandle kh;
     kh.set_team_work_size(16);

--- a/perf_test/graph/KokkosGraph_color.cpp
+++ b/perf_test/graph/KokkosGraph_color.cpp
@@ -252,7 +252,7 @@ void run_experiment(
   typedef typename lno_view_t::non_const_value_type size_type;
   typedef typename lno_nnz_view_t::non_const_value_type lno_t;
 
-  typedef KokkosKernels::Experimental::KokkosKernelsHandle
+  typedef KokkosKernels::KokkosKernelsHandle
       <size_type,lno_t, lno_t,
       ExecSpace, TempMemSpace,PersistentMemSpace > KernelHandle;
 

--- a/perf_test/graph/KokkosGraph_color_d2.cpp
+++ b/perf_test/graph/KokkosGraph_color_d2.cpp
@@ -315,7 +315,7 @@ void run_experiment(crsGraph_t crsGraph, int num_cols, const D2Parameters& param
 
     int verbose = params.verbose;
 
-    typedef KokkosKernels::Experimental::KokkosKernelsHandle<size_type, lno_t, kk_scalar_t, exec_space, mem_space, mem_space> KernelHandle;
+    typedef KokkosKernels::KokkosKernelsHandle<size_type, lno_t, kk_scalar_t, exec_space, mem_space, mem_space> KernelHandle;
 
     std::cout << "Num verts: " << crsGraph.numRows()         << std::endl
               << "Num edges: " << crsGraph.entries.extent(0) << std::endl;

--- a/perf_test/graph/KokkosGraph_run_triangle.hpp
+++ b/perf_test/graph/KokkosGraph_run_triangle.hpp
@@ -217,7 +217,7 @@ void run_experiment(
   typedef typename lno_nnz_view_t::value_type lno_t;
   typedef typename lno_view_t::value_type size_type;
 
-  typedef KokkosKernels::Experimental::KokkosKernelsHandle
+  typedef KokkosKernels::KokkosKernelsHandle
       <size_type,lno_t, lno_t,
       ExecSpace, TempMemSpace,PersistentMemSpace > KernelHandle;
 

--- a/perf_test/sparse/KokkosSparse_block_pcg.cpp
+++ b/perf_test/sparse/KokkosSparse_block_pcg.cpp
@@ -117,7 +117,7 @@ void run_point_experiment(
 
 
 
-	  typedef KokkosKernels::Experimental::KokkosKernelsHandle
+	  typedef KokkosKernels::KokkosKernelsHandle
 	        < size_type,
 			  lno_t,
 			  scalar_t,
@@ -223,7 +223,7 @@ void run_block_experiment(
 
 
 
-	  typedef KokkosKernels::Experimental::KokkosKernelsHandle
+	  typedef KokkosKernels::KokkosKernelsHandle
 	        < size_type,
 			  lno_t,
 			  scalar_t,

--- a/perf_test/sparse/KokkosSparse_gs.cpp
+++ b/perf_test/sparse/KokkosSparse_gs.cpp
@@ -67,7 +67,7 @@ void runGS(string matrixPath, string devName, bool symmetric, bool twostage, boo
   typedef default_size_type size_type;
   typedef typename device_t::execution_space exec_space;
   typedef typename device_t::memory_space mem_space;
-  typedef KokkosKernels::Experimental::KokkosKernelsHandle<size_type, lno_t, scalar_t, exec_space, mem_space, mem_space> KernelHandle;
+  typedef KokkosKernels::KokkosKernelsHandle<size_type, lno_t, scalar_t, exec_space, mem_space, mem_space> KernelHandle;
   typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device_t, void, size_type> crsmat_t;
   //typedef typename crsmat_t::StaticCrsGraphType graph_t;
   typedef typename crsmat_t::values_type::non_const_type scalar_view_t;

--- a/perf_test/sparse/KokkosSparse_pcg.cpp
+++ b/perf_test/sparse/KokkosSparse_pcg.cpp
@@ -111,7 +111,7 @@ void run_experiment(
 
   KokkosKernels::Experimental::Example::CGSolveResult cg_result ;
 
-  typedef KokkosKernels::Experimental::KokkosKernelsHandle
+  typedef KokkosKernels::KokkosKernelsHandle
         < size_type,
 		  lno_t,
 		  scalar_t,

--- a/perf_test/sparse/KokkosSparse_run_spadd.hpp
+++ b/perf_test/sparse/KokkosSparse_run_spadd.hpp
@@ -54,7 +54,6 @@ template <typename crsMat_t>
 void run_experiment(Parameters params)
 {
   using namespace KokkosSparse;
-  using namespace KokkosSparse::Experimental;
 
   using size_type = typename crsMat_t::size_type;
   using lno_t = typename crsMat_t::ordinal_type;

--- a/perf_test/sparse/KokkosSparse_run_spadd.hpp
+++ b/perf_test/sparse/KokkosSparse_run_spadd.hpp
@@ -62,7 +62,7 @@ void run_experiment(Parameters params)
   using exec_space = typename device_t::execution_space;
   using mem_space = typename device_t::memory_space;
 
-  using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle
+  using KernelHandle = KokkosKernels::KokkosKernelsHandle
       <size_type, lno_t, scalar_t, exec_space, mem_space, mem_space>;
 
   std::cout << "************************************* \n";

--- a/perf_test/sparse/KokkosSparse_run_spgemm.hpp
+++ b/perf_test/sparse/KokkosSparse_run_spgemm.hpp
@@ -161,7 +161,7 @@ template <typename ExecSpace, typename crsMat_t, typename crsMat_t2 , typename c
 crsMat_t3 run_experiment(crsMat_t crsMat, crsMat_t2 crsMat2, Parameters params)
 {
   using namespace KokkosSparse;
-  using namespace KokkosSparse::Experimental;
+  // using namespace KokkosSparse::Experimental;
   using device_t = Kokkos::Device<ExecSpace, PersistentMemSpace>;
   int algorithm = params.algorithm;
   int repeat = params.repeat;

--- a/perf_test/sparse/KokkosSparse_run_spgemm.hpp
+++ b/perf_test/sparse/KokkosSparse_run_spgemm.hpp
@@ -188,7 +188,7 @@ crsMat_t3 run_experiment(crsMat_t crsMat, crsMat_t2 crsMat2, Parameters params)
   lno_nnz_view_t entriesC;
   scalar_view_t valuesC;
 
-  typedef KokkosKernels::Experimental::KokkosKernelsHandle
+  typedef KokkosKernels::KokkosKernelsHandle
       <size_type,lno_t, scalar_t,
       ExecSpace, TempMemSpace,PersistentMemSpace > KernelHandle;
 

--- a/perf_test/sparse/KokkosSparse_run_spgemm_jacobi.hpp
+++ b/perf_test/sparse/KokkosSparse_run_spgemm_jacobi.hpp
@@ -137,7 +137,7 @@ namespace KokkosKernels{
       using lno_t = typename lno_nnz_view_t::value_type;
       using size_type = typename lno_view_t::value_type;
       using scalar_t = typename scalar_view_t::value_type;
-      using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<size_type, lno_t, scalar_t,
+      using KernelHandle = KokkosKernels::KokkosKernelsHandle<size_type, lno_t, scalar_t,
 									    ExecSpace, TempMemSpace, PersistentMemSpace>;
 
       int algorithm = params.algorithm;

--- a/perf_test/sparse/KokkosSparse_run_spgemm_jacobi.hpp
+++ b/perf_test/sparse/KokkosSparse_run_spgemm_jacobi.hpp
@@ -129,7 +129,7 @@ namespace KokkosKernels{
     crsMat_t3 run_experiment(crsMat_t crsMat, crsMat_t2 crsMat2, Parameters params)
     {
       using namespace KokkosSparse;
-      using namespace KokkosSparse::Experimental;
+      // using namespace KokkosSparse::Experimental;
       using device_t = Kokkos::Device<ExecSpace, PersistentMemSpace>;
       using scalar_view_t = typename crsMat_t3::values_type::non_const_type;
       using lno_view_t = typename crsMat_t3::row_map_type::non_const_type;
@@ -172,7 +172,7 @@ namespace KokkosKernels{
       const lno_t n = crsMat2.numRows();
       const lno_t k = crsMat2.numCols();
 
-      if (verbose) 
+      if (verbose)
 	std::cout << "m:" << m << " n:" << n << " k:" << k << std::endl;
       if (m != n){
 	std::cerr << "left.numCols():" << n << " left.numRows():" << m << std::endl;
@@ -227,12 +227,12 @@ namespace KokkosKernels{
       	entriesC_ref = lno_nnz_view_t(Kokkos::ViewAllocateWithoutInitializing("entriesC"), c_nnz_size);
       	valuesC_ref = scalar_view_t(Kokkos::ViewAllocateWithoutInitializing("valuesC"), c_nnz_size);
 
-      	spgemm_jacobi(&sequential_kh, m, n, k,
-		      crsMat.graph.row_map, crsMat.graph.entries, crsMat.values, TRANSPOSEFIRST,
-		      crsMat2.graph.row_map, crsMat2.graph.entries, crsMat2.values, TRANSPOSESECOND,
-		      row_mapC_ref, entriesC_ref, valuesC_ref,
-		      omega, dinv);
-	
+        KokkosSparse::Experimental::spgemm_jacobi(&sequential_kh, m, n, k,
+                                                  crsMat.graph.row_map, crsMat.graph.entries, crsMat.values, TRANSPOSEFIRST,
+                                                  crsMat2.graph.row_map, crsMat2.graph.entries, crsMat2.values, TRANSPOSESECOND,
+                                                  row_mapC_ref, entriesC_ref, valuesC_ref,
+                                                  omega, dinv);
+
       	ExecSpace().fence();
 
       	Ccrsmat_ref = crsMat_t3("CorrectC", m, k, valuesC_ref.extent(0), valuesC_ref, row_mapC_ref, entriesC_ref);
@@ -271,18 +271,18 @@ namespace KokkosKernels{
 
 	Kokkos::Impl::Timer timer2;
 	size_type c_nnz_size = kh.get_spgemm_handle()->get_c_nnz();
-	if (verbose)  
+	if (verbose)
 	  std::cout << "C SIZE:" << c_nnz_size << std::endl;
 	if (c_nnz_size){
 	  entriesC = lno_nnz_view_t (Kokkos::ViewAllocateWithoutInitializing("entriesC"), c_nnz_size);
 	  valuesC = scalar_view_t (Kokkos::ViewAllocateWithoutInitializing("valuesC"), c_nnz_size);
 	}
 
-	spgemm_jacobi(&kh, m, n, k,
-		      crsMat.graph.row_map, crsMat.graph.entries, crsMat.values, TRANSPOSEFIRST,
-		      crsMat2.graph.row_map, crsMat2.graph.entries, crsMat2.values, TRANSPOSESECOND,
-		      row_mapC, entriesC, valuesC,
-		      omega, dinv);
+	KokkosSparse::Experimental::spgemm_jacobi(&kh, m, n, k,
+                                                  crsMat.graph.row_map, crsMat.graph.entries, crsMat.values, TRANSPOSEFIRST,
+                                                  crsMat2.graph.row_map, crsMat2.graph.entries, crsMat2.values, TRANSPOSESECOND,
+                                                  row_mapC, entriesC, valuesC,
+                                                  omega, dinv);
 
 	ExecSpace().fence();
 	double numeric_time = timer2.seconds();
@@ -509,7 +509,7 @@ namespace KokkosKernels{
 	  fast_values_view_t sorted_vals("sorted vals", c_fast_crsmat.graph.entries.extent(0));
 
 	  KokkosKernels::Impl::kk_sort_graph
-	    <const_fast_row_map_view_t, const_fast_cols_view_t, const_fast_values_view_t, 
+	    <const_fast_row_map_view_t, const_fast_cols_view_t, const_fast_values_view_t,
 	     fast_cols_view_t, fast_values_view_t, myExecSpace>(c_fast_crsmat.graph.row_map,
 								c_fast_crsmat.graph.entries,
 								c_fast_crsmat.values, sorted_adj, sorted_vals);
@@ -526,7 +526,7 @@ namespace KokkosKernels{
 	  slow_values_view_t sorted_vals("sorted vals", c_fast_crsmat.graph.entries.extent(0));
 
 	  KokkosKernels::Impl::kk_sort_graph
-	    <const_slow_row_map_view_t, const_slow_cols_view_t, const_slow_values_view_t, 
+	    <const_slow_row_map_view_t, const_slow_cols_view_t, const_slow_values_view_t,
 	     slow_cols_view_t, slow_values_view_t, myExecSpace>(c_slow_crsmat.graph.row_map,
 								c_slow_crsmat.graph.entries,
 								c_slow_crsmat.values, sorted_adj, sorted_vals);

--- a/perf_test/sparse/KokkosSparse_spiluk.cpp
+++ b/perf_test/sparse/KokkosSparse_spiluk.cpp
@@ -89,7 +89,7 @@ int test_spiluk_perf(std::vector<int> tests, std::string afilename, int kin, int
 
   typedef Kokkos::View< scalar_t*, memory_space >  ValuesType;
 
-  typedef KokkosKernels::Experimental::KokkosKernelsHandle <size_type, lno_t, scalar_t,
+  typedef KokkosKernels::KokkosKernelsHandle <size_type, lno_t, scalar_t,
                               execution_space, memory_space, memory_space > KernelHandle;
   printf("Execution space: %s, Memory space: %s\n", typeid(execution_space).name(), typeid(memory_space).name());
   scalar_t ZERO = scalar_t(0);

--- a/perf_test/sparse/KokkosSparse_sptrsv.cpp
+++ b/perf_test/sparse/KokkosSparse_sptrsv.cpp
@@ -128,7 +128,7 @@ int test_sptrsv_perf(std::vector<int> tests, const std::string& lfilename, const
 
   typedef Kokkos::View< scalar_t*, memory_space >     ValuesType;
 
-  typedef KokkosKernels::Experimental::KokkosKernelsHandle <size_type, lno_t, scalar_t,
+  typedef KokkosKernels::KokkosKernelsHandle <size_type, lno_t, scalar_t,
     execution_space, memory_space, memory_space > KernelHandle;
 
   const scalar_t ZERO = scalar_t(0);

--- a/perf_test/sparse/KokkosSparse_sptrsv_cholmod.cpp
+++ b/perf_test/sparse/KokkosSparse_sptrsv_cholmod.cpp
@@ -195,7 +195,7 @@ int test_sptrsv_perf(std::vector<int> tests, std::string& filename, bool u_in_cs
   using      scalar_view_t = Kokkos::View<scalar_type*,      memory_space>;
 
   //
-  using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle <size_type, ordinal_type, scalar_type,
+  using KernelHandle = KokkosKernels::KokkosKernelsHandle <size_type, ordinal_type, scalar_type,
     execution_space, memory_space, memory_space >;
 
   const scalar_type ZERO (0.0);

--- a/perf_test/sparse/KokkosSparse_sptrsv_superlu.cpp
+++ b/perf_test/sparse/KokkosSparse_sptrsv_superlu.cpp
@@ -298,7 +298,7 @@ int test_sptrsv_perf (std::vector<int> tests, bool verbose, std::string &filenam
   using host_memory_space = typename host_execution_space::memory_space;
 
   //
-  using KernelHandle =  KokkosKernels::Experimental::KokkosKernelsHandle
+  using KernelHandle =  KokkosKernels::KokkosKernelsHandle
                         <size_type, ordinal_type, scalar_type, execution_space, memory_space, memory_space >;
 
   //

--- a/perf_test/sparse/KokkosSparse_sptrsv_supernode.cpp
+++ b/perf_test/sparse/KokkosSparse_sptrsv_supernode.cpp
@@ -89,7 +89,7 @@ int test_sptrsv_perf (std::vector<int> tests, bool verbose, std::string& lower_f
   using host_memory_space = typename host_execution_space::memory_space;
 
   //
-  using KernelHandle =  KokkosKernels::Experimental::KokkosKernelsHandle
+  using KernelHandle =  KokkosKernels::KokkosKernelsHandle
                         <size_type, ordinal_type, scalar_type, execution_space, memory_space, memory_space >;
 
   //

--- a/src/common/KokkosKernels_Handle.hpp
+++ b/src/common/KokkosKernels_Handle.hpp
@@ -55,8 +55,6 @@
 
 namespace KokkosKernels{
 
-namespace Experimental{
-
 template <class size_type_, class lno_t_, class scalar_t_,
           class ExecutionSpace, class TemporaryMemorySpace, class PersistentMemorySpace>
 class KokkosKernelsHandle
@@ -791,10 +789,54 @@ public:
       this->spilukHandle = nullptr;
     }
   }
-  
+
 };    // end class KokkosKernelsHandle
 
-}
-}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+namespace Experimental{
+
+KOKKOS_DEPRECATED
+template <class size_type_, class lno_t_, class scalar_t_,
+          class ExecutionSpace, class TemporaryMemorySpace, class PersistentMemorySpace>
+class KokkosKernelsHandle : public KokkosKernels::KokkosKernelsHandle<size_type_,
+                                                                      lno_t_,
+                                                                      scalar_t_,
+                                                                      ExecutionSpace,
+                                                                      TemporaryMemorySpace,
+                                                                      PersistentMemorySpace> {
+
+public:
+
+  KokkosKernelsHandle() : KokkosKernels::KokkosKernelsHandle<size_type_, lno_t_, scalar_t_,
+                                                             ExecutionSpace, TemporaryMemorySpace,
+                                                             PersistentMemorySpace>() {}
+
+  template <typename right_size_type_, typename right_lno_t_, typename right_scalar_t_,
+            typename right_ExecutionSpace, typename right_TemporaryMemorySpace,
+            typename right_PersistentMemorySpace>
+  KokkosKernelsHandle(KokkosKernelsHandle<right_size_type_, right_lno_t_, right_scalar_t_,
+                      right_ExecutionSpace, right_TemporaryMemorySpace,
+                      right_PersistentMemorySpace> & right_side_handle)
+    : KokkosKernels::KokkosKernelsHandle<size_type_, lno_t_, scalar_t_,
+      ExecutionSpace, TemporaryMemorySpace,
+      PersistentMemorySpace> (right_side_handle) {}
+
+  template <typename right_size_type_, typename right_lno_t_, typename right_scalar_t_,
+            typename right_ExecutionSpace, typename right_TemporaryMemorySpace,
+            typename right_PersistentMemorySpace>
+  KokkosKernelsHandle(KokkosKernels::KokkosKernelsHandle<right_size_type_, right_lno_t_,
+                      right_scalar_t_, right_ExecutionSpace, right_TemporaryMemorySpace,
+                      right_PersistentMemorySpace> & right_side_handle)
+    : KokkosKernels::KokkosKernelsHandle<size_type_, lno_t_, scalar_t_,
+      ExecutionSpace, TemporaryMemorySpace,
+      PersistentMemorySpace> (right_side_handle) {}
+
+}; // KokkosKernelsHandle
+
+} // namespace Experimental
+#endif
+
+} // namespace KokkosKernels
 
 #endif //_KOKKOSKERNELHANDLE_HPP

--- a/src/sparse/KokkosSparse_gauss_seidel.hpp
+++ b/src/sparse/KokkosSparse_gauss_seidel.hpp
@@ -80,7 +80,7 @@ namespace KokkosSparse{
       typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
       typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
 
-      typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+      typedef typename  KokkosKernels::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
       //const_handle_type tmp_handle = *handle;
       const_handle_type tmp_handle (*handle);
 
@@ -167,7 +167,7 @@ namespace KokkosSparse{
       typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
       typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
 
-      typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+      typedef typename  KokkosKernels::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
       //const_handle_type tmp_handle = *handle;
       const_handle_type tmp_handle (*handle);
 
@@ -235,7 +235,7 @@ namespace KokkosSparse{
       typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
       typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
 
-      typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+      typedef typename  KokkosKernels::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
       //const_handle_type tmp_handle = *handle;
       const_handle_type tmp_handle (*handle);
 
@@ -359,7 +359,7 @@ namespace KokkosSparse{
       typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
       typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
 
-      typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+      typedef typename  KokkosKernels::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
       const_handle_type tmp_handle (*handle);
 
       typedef Kokkos::View<
@@ -525,7 +525,7 @@ namespace KokkosSparse{
       typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
       typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
 
-      typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+      typedef typename  KokkosKernels::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
       //const_handle_type tmp_handle = *handle;
       const_handle_type tmp_handle (*handle);
 
@@ -691,7 +691,7 @@ namespace KokkosSparse{
       typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
       typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
 
-      typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+      typedef typename  KokkosKernels::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
       //const_handle_type tmp_handle = *handle;
       const_handle_type tmp_handle (*handle);
 

--- a/src/sparse/KokkosSparse_spadd.hpp
+++ b/src/sparse/KokkosSparse_spadd.hpp
@@ -50,7 +50,6 @@
 #include <limits>
 
 namespace KokkosSparse {
-namespace Experimental {
 
 /*
 Unsorted symbolic algorithm notes:
@@ -716,7 +715,6 @@ void spadd_numeric(KernelHandle* kernel_handle, const alno_row_view_t_ a_rowmap,
   // this fence is for accurate timing from host
   execution_space().fence();
 }
-}  // namespace Experimental
 
 // Symbolic: count entries in each row in C to produce rowmap
 // kernel handle has information about whether it is sorted add or not.
@@ -732,7 +730,7 @@ void spadd_symbolic(KernelHandle* handle, const AMatrix& A, const BMatrix& B,
   // Create the row_map of C, no need to initialize it
   row_map_type row_mapC(Kokkos::ViewAllocateWithoutInitializing("row map"),
                         A.numRows() + 1);
-  KokkosSparse::Experimental::spadd_symbolic<
+  KokkosSparse::spadd_symbolic<
       KernelHandle, typename AMatrix::row_map_type::const_type,
       typename AMatrix::index_type::const_type,
       typename BMatrix::row_map_type::const_type,
@@ -763,11 +761,77 @@ template <typename KernelHandle, typename AScalar, typename AMatrix,
           typename BScalar, typename BMatrix, typename CMatrix>
 void spadd_numeric(KernelHandle* handle, const AScalar alpha, const AMatrix& A,
                    const BScalar beta, const BMatrix& B, CMatrix& C) {
-  KokkosSparse::Experimental::spadd_numeric(
+  KokkosSparse::spadd_numeric(
       handle, A.graph.row_map, A.graph.entries, A.values, alpha,
       B.graph.row_map, B.graph.entries, B.values, beta, C.graph.row_map,
       C.graph.entries, C.values);
 }
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+namespace Experimental {
+
+KOKKOS_DEPRECATED
+template <typename KernelHandle, typename alno_row_view_t_,
+          typename alno_nnz_view_t_, typename blno_row_view_t_,
+          typename blno_nnz_view_t_, typename clno_row_view_t_,
+          typename clno_nnz_view_t_>
+void spadd_symbolic(
+    KernelHandle* handle, const alno_row_view_t_ a_rowmap,
+    const alno_nnz_view_t_ a_entries, const blno_row_view_t_ b_rowmap,
+    const blno_nnz_view_t_ b_entries,
+    clno_row_view_t_ c_rowmap) {
+  ::KokkosSparse::spadd_symbolic<KernelHandle,
+                                 alno_row_view_t_,
+                                 alno_nnz_view_t_,
+                                 blno_row_view_t_,
+                                 blno_nnz_view_t_,
+                                 clno_row_view_t_,
+                                 clno_nnz_view_t_>(handle, a_rowmap, a_entries,
+                                                   b_rowmap, b_entries, c_rowmap);
+}
+
+KOKKOS_DEPRECATED
+template <typename KernelHandle, typename alno_row_view_t_,
+          typename alno_nnz_view_t_, typename ascalar_t_,
+          typename ascalar_nnz_view_t_, typename blno_row_view_t_,
+          typename blno_nnz_view_t_, typename bscalar_t_,
+          typename bscalar_nnz_view_t_, typename clno_row_view_t_,
+          typename clno_nnz_view_t_, typename cscalar_nnz_view_t_>
+void spadd_numeric(KernelHandle* kernel_handle, const alno_row_view_t_ a_rowmap,
+                   const alno_nnz_view_t_ a_entries,
+                   const ascalar_nnz_view_t_ a_values, const ascalar_t_ alpha,
+                   const blno_row_view_t_ b_rowmap,
+                   const blno_nnz_view_t_ b_entries,
+                   const bscalar_nnz_view_t_ b_values, const bscalar_t_ beta,
+                   const clno_row_view_t_ c_rowmap, clno_nnz_view_t_ c_entries,
+                   cscalar_nnz_view_t_ c_values) {
+  ::KokkosSparse::spadd_numeric<KernelHandle,
+                                alno_row_view_t_,
+                                alno_nnz_view_t_,
+                                ascalar_t_,
+                                ascalar_nnz_view_t_,
+                                blno_row_view_t_,
+                                blno_nnz_view_t_,
+                                bscalar_t_,
+                                bscalar_nnz_view_t_,
+                                clno_row_view_t_,
+                                clno_nnz_view_t_,
+                                cscalar_nnz_view_t_>(kernel_handle,
+                                                     a_rowmap,
+                                                     a_entries,
+                                                     a_values,
+                                                     alpha,
+                                                     b_rowmap,
+                                                     b_entries,
+                                                     b_values,
+                                                     beta,
+                                                     c_rowmap,
+                                                     c_entries,
+                                                     c_values);
+}
+
+}  // namespace Experimental
+#endif
 
 }  // namespace KokkosSparse
 

--- a/src/sparse/KokkosSparse_spgemm.hpp
+++ b/src/sparse/KokkosSparse_spgemm.hpp
@@ -64,7 +64,7 @@ void spgemm_symbolic(KernelHandle& kh, const AMatrix& A, const bool Amode,
   entries_type entriesC;
   values_type valuesC;
 
-  KokkosSparse::Experimental::spgemm_symbolic(
+  KokkosSparse::spgemm_symbolic(
       &kh, A.numRows(), B.numRows(), B.numCols(), A.graph.row_map,
       A.graph.entries, Amode, B.graph.row_map, B.graph.entries, Bmode,
       row_mapC);
@@ -88,7 +88,7 @@ void spgemm_numeric(KernelHandle& kh, const AMatrix& A, const bool Amode,
   // using entries_type = typename CMatrix::row_map_type::non_const_type;
   // using values_type  = typename CMatrix::values_type::non_const_type;
 
-  KokkosSparse::Experimental::spgemm_numeric(
+  KokkosSparse::spgemm_numeric(
       &kh, A.numRows(), B.numRows(), B.numCols(), A.graph.row_map,
       A.graph.entries, A.values, Amode, B.graph.row_map, B.graph.entries,
       B.values, Bmode, C.graph.row_map, C.graph.entries, C.values);

--- a/src/sparse/KokkosSparse_spgemm_jacobi.hpp
+++ b/src/sparse/KokkosSparse_spgemm_jacobi.hpp
@@ -150,7 +150,7 @@ namespace KokkosSparse{
       typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
       typedef typename Kokkos::Device<c_exec_t, c_temp_t> UniformDevice_t;
 
-      typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+      typedef typename  KokkosKernels::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
 
 
 

--- a/src/sparse/KokkosSparse_spgemm_numeric.hpp
+++ b/src/sparse/KokkosSparse_spgemm_numeric.hpp
@@ -50,8 +50,6 @@
 
 namespace KokkosSparse{
 
-namespace Experimental{
-
 
 template <typename KernelHandle,
 typename alno_row_view_t_,
@@ -241,7 +239,55 @@ void spgemm_numeric(
       nonconst_c_s);
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+namespace Experimental{
 
+KOKKOS_DEPRECATED
+template <typename KernelHandle,
+typename alno_row_view_t_,
+typename alno_nnz_view_t_,
+typename ascalar_nnz_view_t_,
+typename blno_row_view_t_,
+typename blno_nnz_view_t_,
+typename bscalar_nnz_view_t_,
+typename clno_row_view_t_,
+typename clno_nnz_view_t_,
+typename cscalar_nnz_view_t_>
+void spgemm_numeric(KernelHandle *handle,
+                    typename KernelHandle::const_nnz_lno_t m,
+                    typename KernelHandle::const_nnz_lno_t n,
+                    typename KernelHandle::const_nnz_lno_t k,
+                    alno_row_view_t_ row_mapA,
+                    alno_nnz_view_t_ entriesA,
+                    ascalar_nnz_view_t_ valuesA,
+                    bool transposeA,
+                    blno_row_view_t_ row_mapB,
+                    blno_nnz_view_t_ entriesB,
+                    bscalar_nnz_view_t_ valuesB,
+                    bool transposeB,
+                    clno_row_view_t_ row_mapC,
+                    clno_nnz_view_t_ &entriesC,
+                    cscalar_nnz_view_t_ &valuesC) {
+
+  ::KokkosSparse::spgemm_numeric<KernelHandle,
+                                 alno_row_view_t_,
+                                 alno_nnz_view_t_,
+                                 ascalar_nnz_view_t_,
+                                 blno_row_view_t_,
+                                 blno_nnz_view_t_,
+                                 bscalar_nnz_view_t_,
+                                 clno_row_view_t_,
+                                 clno_nnz_view_t_,
+                                 cscalar_nnz_view_t_>(handle, m, n, k,
+                                                      row_mapA, entriesA, valuesA,
+                                                      transposeA,
+                                                      row_mapB, entriesB, valuesB,
+                                                      transposeB,
+                                                      row_mapC, entriesC, valuesC);
 }
-}
+
+} // namespace Experimental
+#endif
+
+} // namespace KokkosSparse
 #endif

--- a/src/sparse/KokkosSparse_spgemm_numeric.hpp
+++ b/src/sparse/KokkosSparse_spgemm_numeric.hpp
@@ -143,7 +143,7 @@ void spgemm_numeric(
     typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
     typedef typename Kokkos::Device<c_exec_t, c_temp_t> UniformDevice_t;
 
-    typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+    typedef typename  KokkosKernels::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
 
   const_handle_type tmp_handle (*handle);
 

--- a/src/sparse/KokkosSparse_spgemm_symbolic.hpp
+++ b/src/sparse/KokkosSparse_spgemm_symbolic.hpp
@@ -111,7 +111,7 @@ void spgemm_symbolic(
   typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
   typedef typename Kokkos::Device<c_exec_t, c_temp_t> UniformDevice_t;
 
-  typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+  typedef typename  KokkosKernels::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
   const_handle_type tmp_handle (*handle);
 
 

--- a/src/sparse/KokkosSparse_spgemm_symbolic.hpp
+++ b/src/sparse/KokkosSparse_spgemm_symbolic.hpp
@@ -51,8 +51,6 @@
 
 namespace KokkosSparse{
 
-namespace Experimental{
-
 template <typename KernelHandle,
 typename alno_row_view_t_,
 typename alno_nnz_view_t_,
@@ -178,6 +176,45 @@ void spgemm_symbolic(
 
 }
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+namespace Experimental{
+
+KOKKOS_DEPRECATED
+template <typename KernelHandle,
+typename alno_row_view_t_,
+typename alno_nnz_view_t_,
+typename blno_row_view_t_,
+typename blno_nnz_view_t_,
+typename clno_row_view_t_>
+void spgemm_symbolic(
+    KernelHandle *handle,
+    typename KernelHandle::const_nnz_lno_t m,
+    typename KernelHandle::const_nnz_lno_t n,
+    typename KernelHandle::const_nnz_lno_t k,
+    alno_row_view_t_ row_mapA,
+    alno_nnz_view_t_ entriesA,
+    bool transposeA,
+    blno_row_view_t_ row_mapB,
+    blno_nnz_view_t_ entriesB,
+    bool transposeB,
+    clno_row_view_t_ row_mapC){
+
+  ::KokkosSparse::spgemm_symbolic<KernelHandle,
+                                  alno_row_view_t_,
+                                  alno_nnz_view_t_,
+                                  blno_row_view_t_,
+                                  blno_nnz_view_t_,
+                                  clno_row_view_t_>(handle, m, n, k,
+                                                    row_mapA, entriesA,
+                                                    transposeA,
+                                                    row_mapB, entriesB,
+                                                    transposeB,
+                                                    row_mapC);
+
 }
-}
+
+} // namespace Experimental
+#endif
+
+} // namespace KokkosSparse
 #endif

--- a/src/sparse/KokkosSparse_spiluk.hpp
+++ b/src/sparse/KokkosSparse_spiluk.hpp
@@ -173,7 +173,7 @@ namespace Experimental {
     typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
     typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
 
-    typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+    typedef typename  KokkosKernels::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
     const_handle_type tmp_handle (*handle);
 
     typedef Kokkos::View<
@@ -377,7 +377,7 @@ namespace Experimental {
     typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
     typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
 
-    typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+    typedef typename  KokkosKernels::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
     const_handle_type tmp_handle (*handle);
 
     typedef Kokkos::View<

--- a/src/sparse/KokkosSparse_sptrsv.hpp
+++ b/src/sparse/KokkosSparse_sptrsv.hpp
@@ -92,7 +92,7 @@ namespace Experimental {
     typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
     typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
 
-    typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+    typedef typename  KokkosKernels::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
     const_handle_type tmp_handle (*handle);
 
     typedef Kokkos::View<
@@ -146,7 +146,7 @@ namespace Experimental {
     typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
     typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
 
-    typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+    typedef typename  KokkosKernels::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
     const_handle_type tmp_handle (*handle);
 
     typedef Kokkos::View<
@@ -246,7 +246,7 @@ namespace Experimental {
     typedef typename KernelHandle::HandleTempMemorySpace c_temp_t;
     typedef typename KernelHandle::HandlePersistentMemorySpace c_persist_t;
 
-    typedef typename  KokkosKernels::Experimental::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
+    typedef typename  KokkosKernels::KokkosKernelsHandle<c_size_t, c_lno_t, c_scalar_t, c_exec_t, c_temp_t, c_persist_t> const_handle_type;
     const_handle_type tmp_handle (*handle);
 
     typedef Kokkos::View<

--- a/src/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
@@ -892,7 +892,7 @@ namespace KokkosSparse{
         Kokkos::deep_copy(colors, h_colors);
 #else
         //Create a handle that uses nnz_lno_t as the size_type, since the cluster graph should never be larger than 2^31 entries.
-        KokkosKernels::Experimental::KokkosKernelsHandle<nnz_lno_t, nnz_lno_t, double, MyExecSpace, MyPersistentMemorySpace, MyPersistentMemorySpace> kh;
+        KokkosKernels::KokkosKernelsHandle<nnz_lno_t, nnz_lno_t, double, MyExecSpace, MyPersistentMemorySpace, MyPersistentMemorySpace> kh;
         kh.create_graph_coloring_handle(KokkosGraph::COLORING_DEFAULT);
         KokkosGraph::Experimental::graph_color_symbolic(&kh, numClusters, numClusters, clusterRowmap, clusterEntries);
         //retrieve colors

--- a/src/sparse/impl/KokkosSparse_gauss_seidel_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_gauss_seidel_spec.hpp
@@ -78,7 +78,7 @@ namespace KokkosSparse {
 #define KOKKOSSPARSE_GAUSS_SEIDEL_SYMBOLIC_ETI_SPEC_AVAIL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE ) \
   template<>                                                            \
   struct gauss_seidel_symbolic_eti_spec_avail<                          \
-                                               KokkosKernels::Experimental::KokkosKernelsHandle< \
+                                               KokkosKernels::KokkosKernelsHandle< \
                                                                                                 const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
                                                                                                 EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
                                                Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE, \
@@ -92,7 +92,7 @@ namespace KokkosSparse {
 #define KOKKOSSPARSE_GAUSS_SEIDEL_NUMERIC_ETI_SPEC_AVAIL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE ) \
   template<>                                                            \
   struct gauss_seidel_numeric_eti_spec_avail<                           \
-                                              KokkosKernels::Experimental::KokkosKernelsHandle< \
+                                              KokkosKernels::KokkosKernelsHandle< \
                                                                                                const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
                                                                                                EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
                                               Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE, \
@@ -109,7 +109,7 @@ namespace KokkosSparse {
 #define KOKKOSSPARSE_GAUSS_SEIDEL_APPLY_ETI_SPEC_AVAIL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE ) \
   template<>                                                            \
   struct gauss_seidel_apply_eti_spec_avail<                             \
-                                            KokkosKernels::Experimental::KokkosKernelsHandle< \
+                                            KokkosKernels::KokkosKernelsHandle< \
                                                                                              const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
                                                                                              EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
                                             Kokkos::View<const OFFSET_TYPE *, Kokkos::LayoutLeft, \
@@ -416,7 +416,7 @@ namespace KokkosSparse {
 #define KOKKOSSPARSE_GAUSS_SEIDEL_SYMBOLIC_ETI_SPEC_DECL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE ) \
   extern template struct                                                \
   GAUSS_SEIDEL_SYMBOLIC<                                                \
-                         KokkosKernels::Experimental::KokkosKernelsHandle< \
+                         KokkosKernels::KokkosKernelsHandle< \
                                                                           const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
                                                                           EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
                          Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE, \
@@ -431,7 +431,7 @@ namespace KokkosSparse {
 #define KOKKOSSPARSE_GAUSS_SEIDEL_SYMBOLIC_ETI_SPEC_INST( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE) \
   template struct                                                       \
   GAUSS_SEIDEL_SYMBOLIC<                                                \
-                         KokkosKernels::Experimental::KokkosKernelsHandle< \
+                         KokkosKernels::KokkosKernelsHandle< \
                                                                           const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
                                                                           EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
                          Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE, \
@@ -445,7 +445,7 @@ namespace KokkosSparse {
 #define KOKKOSSPARSE_GAUSS_SEIDEL_NUMERIC_ETI_SPEC_DECL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE,SLOW_MEM_SPACE ) \
   extern template struct                                                \
   GAUSS_SEIDEL_NUMERIC<                                                 \
-                        KokkosKernels::Experimental::KokkosKernelsHandle< \
+                        KokkosKernels::KokkosKernelsHandle< \
                                                                          const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
                                                                          EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
                         Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
@@ -463,7 +463,7 @@ namespace KokkosSparse {
 #define KOKKOSSPARSE_GAUSS_SEIDEL_NUMERIC_ETI_SPEC_INST( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE) \
   template struct                                                       \
   GAUSS_SEIDEL_NUMERIC<                                                 \
-                        KokkosKernels::Experimental::KokkosKernelsHandle< \
+                        KokkosKernels::KokkosKernelsHandle< \
                                                                          const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
                                                                          EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
                         Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
@@ -480,7 +480,7 @@ namespace KokkosSparse {
 #define KOKKOSSPARSE_GAUSS_SEIDEL_APPLY_ETI_SPEC_DECL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE) \
   extern template struct                                                \
   GAUSS_SEIDEL_APPLY<                                                   \
-                      KokkosKernels::Experimental::KokkosKernelsHandle< \
+                      KokkosKernels::KokkosKernelsHandle< \
                                                                        const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
                                                                        EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
                       Kokkos::View<const OFFSET_TYPE *, Kokkos::LayoutLeft,    \
@@ -504,7 +504,7 @@ namespace KokkosSparse {
 #define KOKKOSSPARSE_GAUSS_SEIDEL_APPLY_ETI_SPEC_INST( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE) \
   template struct                                                       \
   GAUSS_SEIDEL_APPLY<                                                   \
-                      KokkosKernels::Experimental::KokkosKernelsHandle< \
+                      KokkosKernels::KokkosKernelsHandle< \
                                                                        const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
                                                                        EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
                       Kokkos::View<const OFFSET_TYPE *, Kokkos::LayoutLeft,    \

--- a/src/sparse/impl/KokkosSparse_spgemm_jacobi_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_jacobi_spec.hpp
@@ -77,7 +77,7 @@ namespace KokkosSparse {
 #define KOKKOSSPARSE_SPGEMM_JACOBI_ETI_SPEC_AVAIL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,FAST_MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE ) \
     template<> \
     struct spgemm_jacobi_eti_spec_avail< \
-        KokkosKernels::Experimental::KokkosKernelsHandle<\
+        KokkosKernels::KokkosKernelsHandle<\
         const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
           EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE> , \
         Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
@@ -249,7 +249,7 @@ namespace KokkosSparse {
 #define KOKKOSSPARSE_SPGEMM_JACOBI_ETI_SPEC_DECL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE ) \
   extern template struct						\
   SPGEMM_JACOBI<							\
-		 typename KokkosKernels::Experimental::KokkosKernelsHandle< \
+		 typename KokkosKernels::KokkosKernelsHandle< \
 									   const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
 									   EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE> , \
 		 Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,		\
@@ -287,7 +287,7 @@ namespace KokkosSparse {
 #define KOKKOSSPARSE_SPGEMM_JACOBI_ETI_SPEC_INST( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE) \
   template struct							\
   SPGEMM_JACOBI<							\
-		 KokkosKernels::Experimental::KokkosKernelsHandle<	\
+		 KokkosKernels::KokkosKernelsHandle<	\
 								  const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
 								  EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE> , \
 		 Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,		\

--- a/src/sparse/impl/KokkosSparse_spgemm_numeric_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_numeric_spec.hpp
@@ -80,7 +80,7 @@ struct spgemm_numeric_eti_spec_avail {
 #define KOKKOSSPARSE_SPGEMM_NUMERIC_ETI_SPEC_AVAIL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,FAST_MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE ) \
     template<> \
     struct spgemm_numeric_eti_spec_avail< \
-        KokkosKernels::Experimental::KokkosKernelsHandle<\
+        KokkosKernels::KokkosKernelsHandle<\
         const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
           EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE> , \
         Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
@@ -114,7 +114,7 @@ struct spgemm_numeric_eti_spec_avail {
     \
     template<> \
     struct spgemm_numeric_eti_spec_avail< \
-        KokkosKernels::Experimental::KokkosKernelsHandle<\
+        KokkosKernels::KokkosKernelsHandle<\
         const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
           EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE> , \
         Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
@@ -356,7 +356,7 @@ struct SPGEMM_NUMERIC<KernelHandle,
 #define KOKKOSSPARSE_SPGEMM_NUMERIC_ETI_SPEC_DECL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE ) \
     extern template struct  \
     SPGEMM_NUMERIC< \
-          typename KokkosKernels::Experimental::KokkosKernelsHandle<\
+          typename KokkosKernels::KokkosKernelsHandle<\
           	const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
             EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE> , \
           Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
@@ -389,7 +389,7 @@ struct SPGEMM_NUMERIC<KernelHandle,
     \
     extern template struct  \
     SPGEMM_NUMERIC< \
-          typename KokkosKernels::Experimental::KokkosKernelsHandle<\
+          typename KokkosKernels::KokkosKernelsHandle<\
           	const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
             EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE> , \
           Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
@@ -423,7 +423,7 @@ struct SPGEMM_NUMERIC<KernelHandle,
 #define KOKKOSSPARSE_SPGEMM_NUMERIC_ETI_SPEC_INST( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE) \
     template struct  \
     SPGEMM_NUMERIC< \
-          KokkosKernels::Experimental::KokkosKernelsHandle<\
+          KokkosKernels::KokkosKernelsHandle<\
           const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
             EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE> , \
           Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
@@ -456,7 +456,7 @@ struct SPGEMM_NUMERIC<KernelHandle,
 \
     template struct  \
     SPGEMM_NUMERIC< \
-          KokkosKernels::Experimental::KokkosKernelsHandle<\
+          KokkosKernels::KokkosKernelsHandle<\
           const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
             EXEC_SPACE_TYPE, FAST_MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE> , \
           Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \

--- a/src/sparse/impl/KokkosSparse_spgemm_symbolic_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_symbolic_spec.hpp
@@ -79,7 +79,7 @@ struct spgemm_symbolic_eti_spec_avail {
 #define KOKKOSSPARSE_SPGEMM_SYMBOLIC_ETI_SPEC_AVAIL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE,SLOW_MEM_SPACE_TYPE) \
     template<> \
     struct spgemm_symbolic_eti_spec_avail< \
-        KokkosKernels::Experimental::KokkosKernelsHandle<\
+        KokkosKernels::KokkosKernelsHandle<\
           const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
           EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE> , \
         Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
@@ -261,7 +261,7 @@ struct SPGEMM_SYMBOLIC < KernelHandle,
 #define KOKKOSSPARSE_SPGEMM_SYMBOLIC_ETI_SPEC_DECL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE,SLOW_MEM_SPACE_TYPE ) \
     extern template struct  \
     SPGEMM_SYMBOLIC< \
-        KokkosKernels::Experimental::KokkosKernelsHandle< \
+        KokkosKernels::KokkosKernelsHandle< \
         const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
           EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE> , \
         Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
@@ -284,7 +284,7 @@ struct SPGEMM_SYMBOLIC < KernelHandle,
 #define KOKKOSSPARSE_SPGEMM_SYMBOLIC_ETI_SPEC_INST( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE) \
     template struct  \
     SPGEMM_SYMBOLIC< \
-        KokkosKernels::Experimental::KokkosKernelsHandle<\
+        KokkosKernels::KokkosKernelsHandle<\
         const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
           EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE_TYPE> , \
         Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \

--- a/src/sparse/impl/KokkosSparse_spiluk_numeric_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_spiluk_numeric_spec.hpp
@@ -80,7 +80,7 @@ struct spiluk_numeric_eti_spec_avail {
 #define KOKKOSSPARSE_SPILUK_NUMERIC_ETI_SPEC_AVAIL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE) \
     template<> \
     struct spiluk_numeric_eti_spec_avail< \
-                  KokkosKernels::Experimental::KokkosKernelsHandle<\
+                  KokkosKernels::KokkosKernelsHandle<\
                                const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
                                EXEC_SPACE_TYPE, MEM_SPACE_TYPE, MEM_SPACE_TYPE> , \
                   Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
@@ -222,7 +222,7 @@ struct SPILUK_NUMERIC<KernelHandle, ARowMapType, AEntriesType, AValuesType, LRow
 #define KOKKOSSPARSE_SPILUK_NUMERIC_ETI_SPEC_DECL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE ) \
     extern template struct  \
     SPILUK_NUMERIC<\
-                  KokkosKernels::Experimental::KokkosKernelsHandle<\
+                  KokkosKernels::KokkosKernelsHandle<\
                                const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
                                EXEC_SPACE_TYPE, MEM_SPACE_TYPE, MEM_SPACE_TYPE> , \
                   Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
@@ -256,7 +256,7 @@ struct SPILUK_NUMERIC<KernelHandle, ARowMapType, AEntriesType, AValuesType, LRow
 #define KOKKOSSPARSE_SPILUK_NUMERIC_ETI_SPEC_INST( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE) \
     template struct  \
     SPILUK_NUMERIC<\
-                  KokkosKernels::Experimental::KokkosKernelsHandle<\
+                  KokkosKernels::KokkosKernelsHandle<\
                                const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
                                EXEC_SPACE_TYPE, MEM_SPACE_TYPE, MEM_SPACE_TYPE> , \
                   Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \

--- a/src/sparse/impl/KokkosSparse_spiluk_symbolic_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_spiluk_symbolic_spec.hpp
@@ -76,7 +76,7 @@ struct spiluk_symbolic_eti_spec_avail {
 #define KOKKOSSPARSE_SPILUK_SYMBOLIC_ETI_SPEC_AVAIL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE) \
     template<> \
     struct spiluk_symbolic_eti_spec_avail< \
-                  KokkosKernels::Experimental::KokkosKernelsHandle<\
+                  KokkosKernels::KokkosKernelsHandle<\
                                const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
                                EXEC_SPACE_TYPE, MEM_SPACE_TYPE, MEM_SPACE_TYPE> , \
                   Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
@@ -187,7 +187,7 @@ struct SPILUK_SYMBOLIC<KernelHandle, ARowMapType, AEntriesType, LRowMapType, LEn
 #define KOKKOSSPARSE_SPILUK_SYMBOLIC_ETI_SPEC_DECL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE ) \
     extern template struct  \
     SPILUK_SYMBOLIC<\
-                  KokkosKernels::Experimental::KokkosKernelsHandle<\
+                  KokkosKernels::KokkosKernelsHandle<\
                                const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
                                EXEC_SPACE_TYPE, MEM_SPACE_TYPE, MEM_SPACE_TYPE> , \
                   Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
@@ -213,7 +213,7 @@ struct SPILUK_SYMBOLIC<KernelHandle, ARowMapType, AEntriesType, LRowMapType, LEn
 #define KOKKOSSPARSE_SPILUK_SYMBOLIC_ETI_SPEC_INST( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE) \
     template struct  \
     SPILUK_SYMBOLIC<\
-                  KokkosKernels::Experimental::KokkosKernelsHandle<\
+                  KokkosKernels::KokkosKernelsHandle<\
                                const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
                                EXEC_SPACE_TYPE, MEM_SPACE_TYPE, MEM_SPACE_TYPE> , \
                   Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \

--- a/src/sparse/impl/KokkosSparse_sptrsv_solve_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_sptrsv_solve_spec.hpp
@@ -76,7 +76,7 @@ struct sptrsv_solve_eti_spec_avail {
 #define KOKKOSSPARSE_SPTRSV_SOLVE_ETI_SPEC_AVAIL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE) \
     template<> \
     struct sptrsv_solve_eti_spec_avail< \
-                  KokkosKernels::Experimental::KokkosKernelsHandle<\
+                  KokkosKernels::KokkosKernelsHandle<\
                                const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
                                EXEC_SPACE_TYPE, MEM_SPACE_TYPE, MEM_SPACE_TYPE> , \
                   Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
@@ -216,7 +216,7 @@ struct SPTRSV_SOLVE<KernelHandle, RowMapType, EntriesType, ValuesType, BType, XT
 #define KOKKOSSPARSE_SPTRSV_SOLVE_ETI_SPEC_DECL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE ) \
     extern template struct  \
     SPTRSV_SOLVE<\
-                  KokkosKernels::Experimental::KokkosKernelsHandle<\
+                  KokkosKernels::KokkosKernelsHandle<\
                                const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
                                EXEC_SPACE_TYPE, MEM_SPACE_TYPE, MEM_SPACE_TYPE> , \
                   Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
@@ -238,7 +238,7 @@ struct SPTRSV_SOLVE<KernelHandle, RowMapType, EntriesType, ValuesType, BType, XT
 #define KOKKOSSPARSE_SPTRSV_SOLVE_ETI_SPEC_INST( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE) \
     template struct  \
     SPTRSV_SOLVE<\
-                  KokkosKernels::Experimental::KokkosKernelsHandle<\
+                  KokkosKernels::KokkosKernelsHandle<\
                                const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
                                EXEC_SPACE_TYPE, MEM_SPACE_TYPE, MEM_SPACE_TYPE> , \
                   Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \

--- a/src/sparse/impl/KokkosSparse_sptrsv_symbolic_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_sptrsv_symbolic_spec.hpp
@@ -72,7 +72,7 @@ struct sptrsv_symbolic_eti_spec_avail {
 #define KOKKOSSPARSE_SPTRSV_SYMBOLIC_ETI_SPEC_AVAIL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE) \
     template<> \
     struct sptrsv_symbolic_eti_spec_avail< \
-                  KokkosKernels::Experimental::KokkosKernelsHandle<\
+                  KokkosKernels::KokkosKernelsHandle<\
                                const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
                                EXEC_SPACE_TYPE, MEM_SPACE_TYPE, MEM_SPACE_TYPE> , \
                   Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
@@ -153,7 +153,7 @@ struct SPTRSV_SYMBOLIC<KernelHandle, RowMapType, EntriesType, false, KOKKOSKERNE
 #define KOKKOSSPARSE_SPTRSV_SYMBOLIC_ETI_SPEC_DECL( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE ) \
     extern template struct  \
     SPTRSV_SYMBOLIC<\
-                  KokkosKernels::Experimental::KokkosKernelsHandle<\
+                  KokkosKernels::KokkosKernelsHandle<\
                                const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
                                EXEC_SPACE_TYPE, MEM_SPACE_TYPE, MEM_SPACE_TYPE> , \
                   Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \
@@ -167,7 +167,7 @@ struct SPTRSV_SYMBOLIC<KernelHandle, RowMapType, EntriesType, false, KOKKOSKERNE
 #define KOKKOSSPARSE_SPTRSV_SYMBOLIC_ETI_SPEC_INST( SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE) \
     template struct  \
     SPTRSV_SYMBOLIC<\
-                  KokkosKernels::Experimental::KokkosKernelsHandle<\
+                  KokkosKernels::KokkosKernelsHandle<\
                                const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,  \
                                EXEC_SPACE_TYPE, MEM_SPACE_TYPE, MEM_SPACE_TYPE> , \
                   Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,  \

--- a/unit_test/graph/Test_Graph_graph_color.hpp
+++ b/unit_test/graph/Test_Graph_graph_color.hpp
@@ -52,7 +52,7 @@
 #include "KokkosKernels_Handle.hpp"
 
 using namespace KokkosKernels;
-using namespace KokkosKernels::Experimental;
+// using namespace KokkosKernels::Experimental;
 
 using namespace KokkosGraph;
 using namespace KokkosGraph::Experimental;
@@ -64,19 +64,19 @@ int run_graphcolor(
     ColoringAlgorithm coloring_algorithm,
     size_t &num_colors,
     typename crsMat_t::StaticCrsGraphType::entries_type::non_const_type & vertex_colors){
-  typedef typename crsMat_t::StaticCrsGraphType graph_t;
-  typedef typename graph_t::row_map_type lno_view_t;
-  typedef typename graph_t::entries_type   lno_nnz_view_t;
-  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
+  using graph_t        = typename crsMat_t::StaticCrsGraphType;
+  using lno_view_t     = typename graph_t::row_map_type;
+  using lno_nnz_view_t = typename graph_t::entries_type;
+  using scalar_view_t  = typename crsMat_t::values_type::non_const_type;
 
-  typedef typename lno_view_t::value_type size_type;
-  typedef typename lno_nnz_view_t::value_type lno_t;
-  typedef typename scalar_view_t::value_type scalar_t;
+  using size_type = typename lno_view_t::value_type;
+  using lno_t     = typename lno_nnz_view_t::value_type;
+  using scalar_t  = typename scalar_view_t::value_type;
 
 
-  typedef KokkosKernelsHandle
+  using KernelHandle = KokkosKernels::KokkosKernelsHandle
       <size_type,lno_t, scalar_t,
-      typename device::execution_space, typename device::memory_space,typename device::memory_space > KernelHandle;
+      typename device::execution_space, typename device::memory_space,typename device::memory_space >;
 
   KernelHandle kh;
   kh.set_team_work_size(16);

--- a/unit_test/graph/Test_Graph_graph_color_deterministic.hpp
+++ b/unit_test/graph/Test_Graph_graph_color_deterministic.hpp
@@ -52,7 +52,7 @@
 #include "KokkosKernels_Handle.hpp"
 
 using namespace KokkosKernels;
-using namespace KokkosKernels::Experimental;
+// using namespace KokkosKernels::Experimental;
 
 using namespace KokkosGraph;
 using namespace KokkosGraph::Experimental;
@@ -64,19 +64,19 @@ int run_graphcolor_deter(
     ColoringAlgorithm coloring_algorithm,
     size_t &num_colors,
     typename crsMat_t::StaticCrsGraphType::entries_type::non_const_type & vertex_colors) {
-  typedef typename crsMat_t::StaticCrsGraphType graph_t;
-  typedef typename graph_t::row_map_type lno_view_t;
-  typedef typename graph_t::entries_type   lno_nnz_view_t;
-  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
+  using graph_t        = typename crsMat_t::StaticCrsGraphType;
+  using lno_view_t     = typename graph_t::row_map_type;
+  using lno_nnz_view_t = typename graph_t::entries_type;
+  using scalar_view_t  = typename crsMat_t::values_type::non_const_type;
 
-  typedef typename lno_view_t::value_type size_type;
-  typedef typename lno_nnz_view_t::value_type lno_t;
-  typedef typename scalar_view_t::value_type scalar_t;
+  using size_type = typename lno_view_t::value_type;
+  using lno_t     = typename lno_nnz_view_t::value_type;
+  using scalar_t  = typename scalar_view_t::value_type;
 
 
-  typedef KokkosKernelsHandle
+  using KernelHandle = KokkosKernels::KokkosKernelsHandle
       <size_type,lno_t, scalar_t,
-      typename device::execution_space, typename device::memory_space,typename device::memory_space > KernelHandle;
+      typename device::execution_space, typename device::memory_space,typename device::memory_space >;
 
   KernelHandle kh;
   kh.set_team_work_size(16);

--- a/unit_test/graph/Test_Graph_graph_color_distance2.hpp
+++ b/unit_test/graph/Test_Graph_graph_color_distance2.hpp
@@ -165,7 +165,7 @@ void test_dist2_coloring(lno_t numVerts, size_type nnz, lno_t bandwidth, lno_t r
     using c_entries_t = typename graph_type::entries_type;
     using rowmap_t = typename c_rowmap_t::non_const_type;
     using entries_t = typename c_entries_t::non_const_type;
-    using KernelHandle = KokkosKernelsHandle<
+    using KernelHandle = KokkosKernels::KokkosKernelsHandle<
       size_type, lno_t, double,
       execution_space, memory_space, memory_space>;
     //Generate graph, and add some out-of-bounds columns
@@ -207,14 +207,14 @@ template<typename scalar_unused, typename lno_t, typename size_type, typename de
 void test_bipartite_symmetric(lno_t numVerts, size_type nnz, lno_t bandwidth, lno_t row_size_variance)
 {
     using execution_space = typename device::execution_space;
-    using memory_space = typename device::memory_space;
-    using crsMat = KokkosSparse::CrsMatrix<double, lno_t, device, void, size_type>;
-    using graph_type = typename crsMat::StaticCrsGraphType;
-    using c_rowmap_t = typename graph_type::row_map_type;
-    using c_entries_t = typename graph_type::entries_type;
-    using rowmap_t = typename c_rowmap_t::non_const_type;
-    using entries_t = typename c_entries_t::non_const_type;
-    using KernelHandle = KokkosKernelsHandle<
+    using memory_space    = typename device::memory_space;
+    using crsMat          = KokkosSparse::CrsMatrix<double, lno_t, device, void, size_type>;
+    using graph_type      = typename crsMat::StaticCrsGraphType;
+    using c_rowmap_t      = typename graph_type::row_map_type;
+    using c_entries_t     = typename graph_type::entries_type;
+    using rowmap_t        = typename c_rowmap_t::non_const_type;
+    using entries_t       = typename c_entries_t::non_const_type;
+    using KernelHandle    = KokkosKernels::KokkosKernelsHandle<
       size_type, lno_t, double,
       execution_space, memory_space, memory_space>;
     //Generate graph, and add some out-of-bounds columns
@@ -263,7 +263,7 @@ void test_bipartite(lno_t numRows, lno_t numCols, size_type nnz, lno_t bandwidth
     using entries_t = typename graph_type::entries_type::non_const_type;
     using c_rowmap_t = typename graph_type::row_map_type;
     using c_entries_t = typename graph_type::entries_type;
-    using KernelHandle = KokkosKernelsHandle<
+    using KernelHandle = KokkosKernels::KokkosKernelsHandle<
       size_type, lno_t, double,
       execution_space, memory_space, memory_space>;
     //Generate graph
@@ -327,14 +327,14 @@ template<typename scalar_unused, typename lno_t, typename size_type, typename de
 void test_old_d2(lno_t numRows, lno_t numCols, size_type nnz, lno_t bandwidth, lno_t row_size_variance)
 {
     using execution_space = typename device::execution_space;
-    using memory_space = typename device::memory_space;
-    using crsMat = KokkosSparse::CrsMatrix<double, lno_t, device, void, size_type>;
-    using graph_type = typename crsMat::StaticCrsGraphType;
-    using c_rowmap_t = typename graph_type::row_map_type;
-    using c_entries_t = typename graph_type::entries_type;
-    using rowmap_t = typename graph_type::row_map_type::non_const_type;
-    using entries_t = typename graph_type::entries_type::non_const_type;
-    using KernelHandle = KokkosKernelsHandle<
+    using memory_space    = typename device::memory_space;
+    using crsMat          = KokkosSparse::CrsMatrix<double, lno_t, device, void, size_type>;
+    using graph_type      = typename crsMat::StaticCrsGraphType;
+    using c_rowmap_t      = typename graph_type::row_map_type;
+    using c_entries_t     = typename graph_type::entries_type;
+    using rowmap_t        = typename graph_type::row_map_type::non_const_type;
+    using entries_t       = typename graph_type::entries_type::non_const_type;
+    using KernelHandle    = KokkosKernels::KokkosKernelsHandle<
       size_type, lno_t, double,
       execution_space, memory_space, memory_space>;
     //Generate graph

--- a/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
@@ -92,9 +92,9 @@ int run_block_gauss_seidel_1(
   typedef typename lno_nnz_view_t::value_type lno_t;
   typedef typename scalar_view_t::value_type scalar_t;
 
-  typedef KokkosKernelsHandle
+  using  KernelHandle = KokkosKernels::KokkosKernelsHandle
       <size_type,lno_t, scalar_t,
-      typename device::execution_space, typename device::memory_space,typename device::memory_space > KernelHandle;
+      typename device::execution_space, typename device::memory_space,typename device::memory_space >;
   KernelHandle kh;
   kh.set_team_work_size(16);
   kh.set_shmem_size(shmem_size);

--- a/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
@@ -84,18 +84,18 @@ int run_gauss_seidel(
     ClusteringAlgorithm cluster_algorithm = CLUSTER_DEFAULT,
     bool classic = false) // only with two-stage, true for sptrsv instead of richardson
 {
-  typedef typename crsMat_t::StaticCrsGraphType graph_t;
-  typedef typename graph_t::row_map_type lno_view_t;
-  typedef typename graph_t::entries_type lno_nnz_view_t;
-  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
+  using graph_t        = typename crsMat_t::StaticCrsGraphType;
+  using lno_view_t     = typename graph_t::row_map_type;
+  using lno_nnz_view_t = typename graph_t::entries_type;
+  using scalar_view_t  = typename crsMat_t::values_type::non_const_type;
 
-  typedef typename lno_view_t::value_type size_type;
-  typedef typename lno_nnz_view_t::value_type lno_t;
-  typedef typename scalar_view_t::value_type scalar_t;
+  using size_type = typename lno_view_t::value_type;
+  using lno_t     = typename lno_nnz_view_t::value_type;
+  using scalar_t  = typename scalar_view_t::value_type;
 
-  typedef KokkosKernelsHandle
+  using KernelHandle = KokkosKernels::KokkosKernelsHandle
       <size_type,lno_t, scalar_t,
-      typename device::execution_space, typename device::memory_space,typename device::memory_space > KernelHandle;
+      typename device::execution_space, typename device::memory_space,typename device::memory_space >;
 
   KernelHandle kh;
   kh.set_team_work_size(16);
@@ -459,13 +459,13 @@ template <typename scalar_t, typename lno_t, typename size_type, typename device
 void test_rcm(lno_t numRows, size_type nnzPerRow, lno_t bandwidth)
 {
   using namespace Test;
-  typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type> crsMat_t;
-  typedef typename crsMat_t::StaticCrsGraphType graph_t;
-  typedef typename graph_t::row_map_type::non_const_type lno_row_view_t;
-  typedef typename graph_t::entries_type::non_const_type lno_nnz_view_t;
-  typedef KokkosKernelsHandle
+  using crsMat_t       = typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>;
+  using graph_t        = typename crsMat_t::StaticCrsGraphType;
+  using lno_row_view_t = typename graph_t::row_map_type::non_const_type;
+  using lno_nnz_view_t = typename graph_t::entries_type::non_const_type;
+  using KernelHandle   = KokkosKernels::KokkosKernelsHandle
       <size_type, lno_t, scalar_t,
-      typename device::execution_space, typename device::memory_space,typename device::memory_space> KernelHandle;
+      typename device::execution_space, typename device::memory_space,typename device::memory_space>;
   srand(245);
   size_type nnzTotal = nnzPerRow * numRows;
   lno_t nnzVariance = nnzPerRow / 4;
@@ -564,15 +564,15 @@ template <typename scalar_t, typename lno_t, typename size_type, typename device
 void test_balloon_clustering(lno_t numRows, size_type nnzPerRow, lno_t bandwidth)
 {
   using namespace Test;
-  typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type> crsMat_t;
-  typedef typename crsMat_t::StaticCrsGraphType graph_t;
-  typedef typename graph_t::row_map_type const_lno_row_view_t;
-  typedef typename graph_t::entries_type const_lno_nnz_view_t;
-  typedef typename graph_t::row_map_type::non_const_type lno_row_view_t;
-  typedef typename graph_t::entries_type::non_const_type lno_nnz_view_t;
-  typedef KokkosKernelsHandle
+  using crsMat_t             = typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>;
+  using graph_t              = typename crsMat_t::StaticCrsGraphType;
+  using const_lno_row_view_t = typename graph_t::row_map_type;
+  using const_lno_nnz_view_t = typename graph_t::entries_type;
+  using lno_row_view_t       = typename graph_t::row_map_type::non_const_type;
+  using lno_nnz_view_t       = typename graph_t::entries_type::non_const_type;
+  using KernelHandle         = KokkosKernels::KokkosKernelsHandle
       <size_type, lno_t, scalar_t,
-      typename device::execution_space, typename device::memory_space,typename device::memory_space> KernelHandle;
+      typename device::execution_space, typename device::memory_space,typename device::memory_space>;
   srand(245);
   size_type nnzTotal = nnzPerRow * numRows;
   lno_t nnzVariance = nnzPerRow / 4;
@@ -606,14 +606,14 @@ template <typename scalar_t, typename lno_t, typename size_type, typename device
 void test_sgs_zero_rows()
 {
   using namespace Test;
-  typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type> crsMat_t;
-  typedef typename crsMat_t::StaticCrsGraphType graph_t;
-  typedef typename graph_t::row_map_type::non_const_type row_map_type;
-  typedef typename graph_t::entries_type::non_const_type entries_type;
-  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
-  typedef KokkosKernelsHandle
+  using crsMat_t      = typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>;
+  using graph_t       = typename crsMat_t::StaticCrsGraphType;
+  using row_map_type  = typename graph_t::row_map_type::non_const_type;
+  using entries_type  = typename graph_t::entries_type::non_const_type;
+  using scalar_view_t = typename crsMat_t::values_type::non_const_type;
+  using KernelHandle  = KokkosKernels::KokkosKernelsHandle
       <size_type, lno_t, scalar_t,
-      typename device::execution_space, typename device::memory_space,typename device::memory_space> KernelHandle;
+      typename device::execution_space, typename device::memory_space,typename device::memory_space>;
   //The rowmap of a zero-row matrix can be length 0 or 1, so Gauss-Seidel should work with both
   //(the setup and apply are essentially no-ops but they shouldn't crash or throw exceptions)
   //For this test, create size-0 and size-1 rowmaps separately, and make sure each work with both point and cluster

--- a/unit_test/sparse/Test_Sparse_spadd.hpp
+++ b/unit_test/sparse/Test_Sparse_spadd.hpp
@@ -104,7 +104,7 @@ void test_spadd(lno_t numRows, lno_t numCols, size_type minNNZ, size_type maxNNZ
   //Make sure that nothing relies on any specific entry of c_row_map being zero initialized
   Kokkos::deep_copy(c_row_map, (size_type) 5);
   auto addHandle = handle.get_spadd_handle();
-  KokkosSparse::Experimental::spadd_symbolic<
+  KokkosSparse::spadd_symbolic<
     KernelHandle,
     typename row_map_type::const_type,
     typename entries_type::const_type,
@@ -119,7 +119,7 @@ void test_spadd(lno_t numRows, lno_t numCols, size_type minNNZ, size_type maxNNZ
   Kokkos::deep_copy(c_values, ((typename KAT::mag_type) 5) * KAT::one());
   entries_type c_entries("C entries", c_nnz);
   Kokkos::deep_copy(c_entries, (lno_t) 5);
-  KokkosSparse::Experimental::spadd_numeric<
+  KokkosSparse::spadd_numeric<
     KernelHandle,
     typename row_map_type::const_type,
     typename entries_type::const_type,

--- a/unit_test/sparse/Test_Sparse_spadd.hpp
+++ b/unit_test/sparse/Test_Sparse_spadd.hpp
@@ -90,7 +90,7 @@ void test_spadd(lno_t numRows, lno_t numCols, size_type minNNZ, size_type maxNNZ
   typedef typename crsMat_t::index_type::non_const_type entries_type;
   typedef typename crsMat_t::values_type::non_const_type values_type;
 
-  typedef typename KokkosKernels::Experimental::KokkosKernelsHandle<size_type, lno_t, scalar_t,
+  typedef typename KokkosKernels::KokkosKernelsHandle<size_type, lno_t, scalar_t,
   typename Device::execution_space, typename Device::memory_space, typename Device::memory_space> KernelHandle;
 
   //Make the test deterministic on a given machine+compiler

--- a/unit_test/sparse/Test_Sparse_spgemm.hpp
+++ b/unit_test/sparse/Test_Sparse_spgemm.hpp
@@ -68,7 +68,7 @@
 //const char *input_filename = "wathen_30_30.mtx";
 //const size_t expected_num_cols = 9906;
 using namespace KokkosSparse;
-using namespace KokkosSparse::Experimental;
+// using namespace KokkosSparse::Experimental;
 using namespace KokkosKernels;
 using namespace KokkosKernels::Experimental;
 

--- a/unit_test/sparse/Test_Sparse_spgemm.hpp
+++ b/unit_test/sparse/Test_Sparse_spgemm.hpp
@@ -70,7 +70,7 @@
 using namespace KokkosSparse;
 // using namespace KokkosSparse::Experimental;
 using namespace KokkosKernels;
-using namespace KokkosKernels::Experimental;
+// using namespace KokkosKernels::Experimental;
 
 #ifndef kokkos_complex_double
 #define kokkos_complex_double Kokkos::complex<double>
@@ -86,7 +86,7 @@ int run_spgemm(crsMat_t A, crsMat_t B, KokkosSparse::SPGEMMAlgorithm spgemm_algo
   typedef typename crsMat_t::ordinal_type lno_t;
   typedef typename crsMat_t::value_type scalar_t;
 
-  typedef KokkosKernels::Experimental::KokkosKernelsHandle
+  typedef KokkosKernels::KokkosKernelsHandle
       <size_type, lno_t, scalar_t,
       typename device::execution_space, typename device::memory_space,typename device::memory_space > KernelHandle;
 
@@ -116,7 +116,7 @@ int run_spgemm_old_interface(crsMat_t input_mat, crsMat_t input_mat2, KokkosSpar
   typedef typename lno_nnz_view_t::value_type lno_t;
   typedef typename scalar_view_t::value_type scalar_t;
 
-  typedef KokkosKernels::Experimental::KokkosKernelsHandle
+  typedef KokkosKernels::KokkosKernelsHandle
       <size_type,lno_t, scalar_t,
       typename device::execution_space, typename device::memory_space,typename device::memory_space > KernelHandle;
 

--- a/unit_test/sparse/Test_Sparse_spgemm_jacobi.hpp
+++ b/unit_test/sparse/Test_Sparse_spgemm_jacobi.hpp
@@ -62,7 +62,7 @@
 
 
 using namespace KokkosSparse;
-using namespace KokkosSparse::Experimental;
+// using namespace KokkosSparse::Experimental;
 using namespace KokkosKernels;
 using namespace KokkosKernels::Experimental;
 
@@ -129,25 +129,25 @@ namespace Test {
     entriesC = lno_nnz_view_t (Kokkos::ViewAllocateWithoutInitializing("entriesC"), c_nnz_size);
     valuesC = scalar_view_t (Kokkos::ViewAllocateWithoutInitializing("valuesC"), c_nnz_size);
   }
-  spgemm_jacobi(
-      &kh,
-      num_rows_1,
-      num_rows_2,
-      num_cols_2,
-      input_mat.graph.row_map,
-      input_mat.graph.entries,
-      input_mat.values,
-      false,
-      input_mat2.graph.row_map,
-      input_mat2.graph.entries,
-      input_mat2.values,
-      false,
-      row_mapC,
-      entriesC,
-      valuesC,
-      omega,
-      dinv
-  );
+  KokkosSparse::Experimental::spgemm_jacobi(
+                                            &kh,
+                                            num_rows_1,
+                                            num_rows_2,
+                                            num_cols_2,
+                                            input_mat.graph.row_map,
+                                            input_mat.graph.entries,
+                                            input_mat.values,
+                                            false,
+                                            input_mat2.graph.row_map,
+                                            input_mat2.graph.entries,
+                                            input_mat2.values,
+                                            false,
+                                            row_mapC,
+                                            entriesC,
+                                            valuesC,
+                                            omega,
+                                            dinv
+                                            );
 
 
   graph_t static_graph (entriesC, row_mapC);

--- a/unit_test/sparse/Test_Sparse_spgemm_jacobi.hpp
+++ b/unit_test/sparse/Test_Sparse_spgemm_jacobi.hpp
@@ -64,7 +64,7 @@
 using namespace KokkosSparse;
 // using namespace KokkosSparse::Experimental;
 using namespace KokkosKernels;
-using namespace KokkosKernels::Experimental;
+// using namespace KokkosKernels::Experimental;
 
 #ifndef kokkos_complex_double
 #define kokkos_complex_double Kokkos::complex<double>
@@ -84,7 +84,7 @@ namespace Test {
   typedef typename lno_nnz_view_t::value_type lno_t;
   typedef typename scalar_view_t::value_type scalar_t;
 
-  typedef KokkosKernels::Experimental::KokkosKernelsHandle
+  typedef KokkosKernels::KokkosKernelsHandle
       <size_type,lno_t, scalar_t,
       typename device::execution_space, typename device::memory_space,typename device::memory_space > KernelHandle;
 

--- a/unit_test/sparse/Test_Sparse_spiluk.hpp
+++ b/unit_test/sparse/Test_Sparse_spiluk.hpp
@@ -154,7 +154,7 @@ void run_test_spiluk() {
   Kokkos::deep_copy(entries, hentries);
   Kokkos::deep_copy(values,  hvalues);
 
-  typedef KokkosKernels::Experimental::KokkosKernelsHandle <size_type, lno_t, scalar_t,
+  typedef KokkosKernels::KokkosKernelsHandle <size_type, lno_t, scalar_t,
                                   typename device::execution_space, typename device::memory_space,typename device::memory_space > KernelHandle;
 
   KernelHandle kh;
@@ -162,32 +162,32 @@ void run_test_spiluk() {
   //SPILUKAlgorithm::SEQLVLSCHD_RP
   {
     kh.create_spiluk_handle(SPILUKAlgorithm::SEQLVLSCHD_RP, nrows, 4*nrows, 4*nrows);
-    
+
     auto spiluk_handle = kh.get_spiluk_handle();
-    
+
     // Allocate L and U as outputs
-    RowMapType  L_row_map("L_row_map", nrows + 1);                
+    RowMapType  L_row_map("L_row_map", nrows + 1);
     EntriesType L_entries("L_entries", spiluk_handle->get_nnzL());
     ValuesType  L_values ("L_values",  spiluk_handle->get_nnzL());
-    RowMapType  U_row_map("U_row_map", nrows + 1);                    
+    RowMapType  U_row_map("U_row_map", nrows + 1);
     EntriesType U_entries("U_entries", spiluk_handle->get_nnzU());
     ValuesType  U_values ("U_values",  spiluk_handle->get_nnzU());
-	  
+
     typename KernelHandle::const_nnz_lno_t fill_lev = 2;
-    
+
     spiluk_symbolic( &kh, fill_lev, row_map, entries, L_row_map, L_entries, U_row_map, U_entries );
 
     Kokkos::fence();
-    
+
     Kokkos::resize(L_entries, spiluk_handle->get_nnzL());
     Kokkos::resize(L_values,  spiluk_handle->get_nnzL());
     Kokkos::resize(U_entries, spiluk_handle->get_nnzU());
     Kokkos::resize(U_values,  spiluk_handle->get_nnzU());
-    
+
     spiluk_handle->print_algorithm();
-    spiluk_numeric( &kh, fill_lev, row_map, entries, values, 
+    spiluk_numeric( &kh, fill_lev, row_map, entries, values,
                                    L_row_map, L_entries, L_values, U_row_map, U_entries, U_values );
-	  				 
+
     Kokkos::fence();
 
     // Checking
@@ -195,56 +195,56 @@ void run_test_spiluk() {
     crsMat_t A("A_Mtx", nrows, nrows, nnz, values, row_map, entries);
     crsMat_t L("L_Mtx", nrows, nrows, spiluk_handle->get_nnzL(), L_values, L_row_map, L_entries);
     crsMat_t U("U_Mtx", nrows, nrows, spiluk_handle->get_nnzU(), U_values, U_row_map, U_entries);
-    
+
     // Create a reference view e set to all 1's
     ValuesType e_one  ( "e_one",  nrows ); Kokkos::deep_copy( e_one, 1.0 );
-    
+
     // Create two views for spmv results
     ValuesType bb     ( "bb",     nrows );
     ValuesType bb_tmp ( "bb_tmp", nrows );
-    
+
     // Compute norm2(L*U*e_one - A*e_one)/norm2(A*e_one)
-    KokkosSparse::spmv( "N", ONE, A, e_one, ZERO, bb); 
+    KokkosSparse::spmv( "N", ONE, A, e_one, ZERO, bb);
 
     typename AT::mag_type bb_nrm = KokkosBlas::nrm2(bb);
-    
+
     KokkosSparse::spmv( "N", ONE, U, e_one,  ZERO, bb_tmp);
     KokkosSparse::spmv( "N", ONE, L, bb_tmp, MONE, bb);
 
     typename AT::mag_type diff_nrm = KokkosBlas::nrm2(bb);
-	     
+
     EXPECT_TRUE( (diff_nrm/bb_nrm) < 1e-4 );
-    
+
     kh.destroy_spiluk_handle();
   }
 
   //SPILUKAlgorithm::SEQLVLSCHD_TP1
   {
     kh.create_spiluk_handle(SPILUKAlgorithm::SEQLVLSCHD_TP1, nrows, 4*nrows, 4*nrows);
-    
+
     auto spiluk_handle = kh.get_spiluk_handle();
-    
+
     // Allocate L and U as outputs
-    RowMapType  L_row_map("L_row_map", nrows + 1);                
+    RowMapType  L_row_map("L_row_map", nrows + 1);
     EntriesType L_entries("L_entries", spiluk_handle->get_nnzL());
     ValuesType  L_values ("L_values",  spiluk_handle->get_nnzL());
-    RowMapType  U_row_map("U_row_map", nrows + 1);                    
+    RowMapType  U_row_map("U_row_map", nrows + 1);
     EntriesType U_entries("U_entries", spiluk_handle->get_nnzU());
     ValuesType  U_values ("U_values",  spiluk_handle->get_nnzU());
-	  
+
     typename KernelHandle::const_nnz_lno_t fill_lev = 2;
-    
+
     spiluk_symbolic( &kh, fill_lev, row_map, entries, L_row_map, L_entries, U_row_map, U_entries );
 
     Kokkos::fence();
-    
+
     Kokkos::resize(L_entries, spiluk_handle->get_nnzL());
     Kokkos::resize(L_values,  spiluk_handle->get_nnzL());
     Kokkos::resize(U_entries, spiluk_handle->get_nnzU());
     Kokkos::resize(U_values,  spiluk_handle->get_nnzU());
-    
+
     spiluk_handle->print_algorithm();
-    spiluk_numeric( &kh, fill_lev, row_map, entries, values, 
+    spiluk_numeric( &kh, fill_lev, row_map, entries, values,
                                    L_row_map, L_entries, L_values, U_row_map, U_entries, U_values );
 
     Kokkos::fence();
@@ -254,26 +254,26 @@ void run_test_spiluk() {
     crsMat_t A("A_Mtx", nrows, nrows, nnz, values, row_map, entries);
     crsMat_t L("L_Mtx", nrows, nrows, spiluk_handle->get_nnzL(), L_values, L_row_map, L_entries);
     crsMat_t U("U_Mtx", nrows, nrows, spiluk_handle->get_nnzU(), U_values, U_row_map, U_entries);
-    
+
     // Create a reference view e set to all 1's
     ValuesType e_one  ( "e_one",  nrows ); Kokkos::deep_copy( e_one, 1.0 );
-    
-    // Create two views for spmv results     
+
+    // Create two views for spmv results
     ValuesType bb     ( "bb",     nrows );
     ValuesType bb_tmp ( "bb_tmp", nrows );
-    
+
     // Compute norm2(L*U*e_one - A*e_one)/norm2(A*e_one)
     KokkosSparse::spmv( "N", ONE, A, e_one, ZERO, bb);
-	
+
     typename AT::mag_type bb_nrm = KokkosBlas::nrm2(bb);
-    
+
     KokkosSparse::spmv( "N", ONE, U, e_one,  ZERO, bb_tmp);
     KokkosSparse::spmv( "N", ONE, L, bb_tmp, MONE, bb);
-	  
+
     typename AT::mag_type diff_nrm = KokkosBlas::nrm2(bb);
-	     
+
     EXPECT_TRUE( (diff_nrm/bb_nrm) < 1e-4 );
-    
+
     kh.destroy_spiluk_handle();
   }
 

--- a/unit_test/sparse/Test_Sparse_sptrsv.hpp
+++ b/unit_test/sparse/Test_Sparse_sptrsv.hpp
@@ -112,7 +112,7 @@ void run_test_sptrsv_mtx() {
     scalar_t ZERO = scalar_t(0);
     scalar_t ONE = scalar_t(1);
 
-    typedef KokkosKernels::Experimental::KokkosKernelsHandle <size_type, lno_t, scalar_t,
+    typedef KokkosKernels::KokkosKernelsHandle <size_type, lno_t, scalar_t,
       typename device::execution_space, typename device::memory_space,typename device::memory_space > KernelHandle;
 
     std::cout << "UnitTest nrows = " << nrows << std::endl;
@@ -229,7 +229,7 @@ void run_test_sptrsv_mtx() {
     scalar_t ZERO = scalar_t(0);
     scalar_t ONE = scalar_t(1);
 
-    typedef KokkosKernels::Experimental::KokkosKernelsHandle <size_type, lno_t, scalar_t,
+    typedef KokkosKernels::KokkosKernelsHandle <size_type, lno_t, scalar_t,
       typename device::execution_space, typename device::memory_space,typename device::memory_space > KernelHandle;
 
     std::cout << "UnitTest nrows = " << nrows << std::endl;
@@ -361,7 +361,7 @@ void run_test_sptrsv() {
   const size_type nrows = 5;
   const size_type nnz   = 10;
 
-  using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle <size_type, lno_t, scalar_t,
+  using KernelHandle = KokkosKernels::KokkosKernelsHandle <size_type, lno_t, scalar_t,
       typename device::execution_space, typename device::memory_space, typename device::memory_space>;
 
 #if defined(KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV)


### PR DESCRIPTION
See issue #741 for more background information

This does not change any kernel code but simply
rearrange the namespaces so that SpADD and SpGEMM
kernels are not implemented in experimental anymore.
Added macro and pre-processor guards to allow down
stream packages to turn on and off warnings/code.