### PR TITLE
Adding Changelog for Release 3.2.00

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Change Log
 
+## [3.2.00](https://github.com/kokkos/kokkos-kernels/tree/3.2.00) (2020-08-19)
+[Full Changelog](https://github.com/kokkos/kokkos-kernels/compare/3.1.01...3.2.00)
+
+**Implemented enhancements:**
+
+- Add CudaUVMSpace specializations for cuBLAS IAMAX and SCAL [\#758](https://github.com/kokkos/kokkos-kernels/issues/758)
+- Add wiki examples [\#735](https://github.com/kokkos/kokkos-kernels/issues/735)
+- Support complex\_float, complex\_double in cuSPARSE SPMV wrapper [\#726](https://github.com/kokkos/kokkos-kernels/issues/726)
+- Add performance tests for trmm and trtri [\#711](https://github.com/kokkos/kokkos-kernels/issues/711)
+- SpAdd requires output values to be zero-initialized, but this shouldnt be needed [\#694](https://github.com/kokkos/kokkos-kernels/issues/694)
+- SpAdd doesnt merge entries correctly [\#685](https://github.com/kokkos/kokkos-kernels/issues/685)
+- cusparse SpMV merge algorithm [\#670](https://github.com/kokkos/kokkos-kernels/issues/670)
+- TPL support for SpMV [\#614](https://github.com/kokkos/kokkos-kernels/issues/614)
+- Add two BLAS/LAPACK calls needed by: Sptrsv supernode \#552 [\#589](https://github.com/kokkos/kokkos-kernels/issues/589)
+- HashmapAccumulator has several unused members, misnamed parameters [\#508](https://github.com/kokkos/kokkos-kernels/issues/508)
+
+**Fixed bugs:**
+
+- Nightly test failure: spgemm unit tests failing on White \(Power8\) [\#780](https://github.com/kokkos/kokkos-kernels/issues/780)
+- supernodal does not build with UVM enabled [\#633](https://github.com/kokkos/kokkos-kernels/issues/633)
 
 ## [3.1.00](https://github.com/kokkos/kokkos-kernels/tree/3.1.00) (2020-04-14)
 [Full Changelog](https://github.com/kokkos/kokkos-kernels/compare/3.0.00...3.1.00)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ IF(NOT KOKKOSKERNELS_HAS_TRILINOS)
     PROJECT(KokkosKernels CXX)
   ENDIF()
   SET(KokkosKernels_VERSION_MAJOR 3)
-  SET(KokkosKernels_VERSION_MINOR 1)
+  SET(KokkosKernels_VERSION_MINOR 2)
   SET(KokkosKernels_VERSION_PATCH 0)
 ENDIF()
 


### PR DESCRIPTION
Part of Kokkos C++ Performance Portability Programming EcoSystem 3.2
Update Kokkos version macros to 3.2.0