### PR TITLE
HIP: fix ArithTraits to support HIP backend, see issue #807

### DIFF
--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -691,13 +691,13 @@ public:
   static KOKKOS_FORCEINLINE_FUNCTION float infinity() { return HUGE_VALF; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const float x) {
-    #ifndef __CUDA_ARCH__
+    #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
     using std::isinf;
     #endif
     return isinf (x);
   }
   static KOKKOS_FORCEINLINE_FUNCTION bool isNan (const float x) {
-    #ifndef __CUDA_ARCH__
+    #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
     using std::isnan;
     #endif
     return isnan (x);
@@ -801,9 +801,11 @@ public:
     return sqrt (x);
   }
   static KOKKOS_FORCEINLINE_FUNCTION float nan () {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__)
     return CUDART_NAN_F;
     //return nan (); //this returns 0???
+#elif defined(__HIP_DEVICE_COMPILE__)
+    return nanf("");
 #else
     return std::numeric_limits<float>::quiet_NaN();
 #endif // __CUDA_ARCH__
@@ -865,13 +867,13 @@ public:
   }
 
   static bool isInf (const std::complex<RealFloatType>& x) {
-    #ifndef __CUDA_ARCH__
+    #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
     using std::isinf;
     #endif
     return isinf (real (x)) || isinf (imag (x));
   }
   static bool isNan (const std::complex<RealFloatType>& x) {
-    #ifndef __CUDA_ARCH__
+    #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
     using std::isnan;
     #endif
     return isnan (real (x)) || isnan (imag (x));
@@ -1045,13 +1047,13 @@ public:
   static KOKKOS_FORCEINLINE_FUNCTION double infinity() { return HUGE_VAL; }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type x) {
-    #ifndef __CUDA_ARCH__
+    #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
     using std::isinf;
     #endif
     return isinf (x);
   }
   static KOKKOS_FORCEINLINE_FUNCTION bool isNan (const val_type x) {
-    #ifndef __CUDA_ARCH__
+    #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
     using std::isnan;
     #endif
     return isnan (x);
@@ -1126,9 +1128,11 @@ public:
     return ::atan (x);
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type nan () {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__)
     return CUDART_NAN;
     //return nan (); // this returns 0 ???
+#elif defined(__HIP_DEVICE_COMPILE__)
+    return nan("");
 #else
     return std::numeric_limits<val_type>::quiet_NaN();
 #endif // __CUDA_ARCH__
@@ -1140,8 +1144,10 @@ public:
   // Backwards compatibility with Teuchos::ScalarTraits.
   typedef mag_type magnitudeType;
   typedef float halfPrecision;
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__)
   typedef double doublePrecision; // CUDA doesn't support long double, unfortunately
+#elif defined(__HIP_DEVICE_COMPILE__)
+  typedef double doublePrecision; // HIP does not support long double unfortunately
 #else
   typedef long double doublePrecision;
 #endif // __CUDA_ARCH__
@@ -1216,13 +1222,13 @@ public:
   static KOKKOS_FORCEINLINE_FUNCTION long double infinity() { return HUGE_VALL; }
 
   static bool isInf (const val_type& x) {
-    #ifndef __CUDA_ARCH__
+    #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
     using std::isinf;
     #endif
     return isinf (x);
   }
   static bool isNan (const val_type& x) {
-    #ifndef __CUDA_ARCH__
+    #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
     using std::isnan;
     #endif
     return isnan (x);
@@ -2923,11 +2929,13 @@ public:
     return intPowSigned<val_type> (x, y);
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type sqrt (const val_type x) {
-#ifdef __CUDA_ARCH__
-    return static_cast<val_type> ( ::sqrt (static_cast<double> (abs (x))));
+    using std::sqrt;
+    using std::abs;
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+    return static_cast<val_type> ( sqrt (static_cast<long double> (abs (x))));
 #else
-    return static_cast<val_type> ( ::sqrt (static_cast<long double> (abs (x))));
-#endif // __CUDA_ARCH__
+    return static_cast<val_type> ( sqrt (static_cast<double> (abs (x))));
+#endif
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type log (const val_type x) {
     return static_cast<val_type> ( ::log (static_cast<double> (abs (x))));
@@ -3048,18 +3056,20 @@ public:
     return intPowUnsigned<val_type> (x, y);
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type sqrt (const val_type x) {
-#ifdef __CUDA_ARCH__
-    return static_cast<val_type> ( ::sqrt (static_cast<double> (x)));
+    using std::sqrt;
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+    return static_cast<val_type> ( sqrt (static_cast<long double> (x)));
 #else
-    return static_cast<val_type> ( ::sqrt (static_cast<long double> (x)));
-#endif // __CUDA_ARCH__
+    return static_cast<val_type> ( sqrt (static_cast<double> (x)));
+#endif
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type cbrt (const val_type x) {
-#ifdef __CUDA_ARCH__
-    return static_cast<val_type> ( ::cbrt (static_cast<double> (x)));
-#else
+    using std::cbrtl;
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
     return static_cast<val_type> ( ::cbrtl (static_cast<long double> (x)));
-#endif // __CUDA_ARCH__
+#else
+    return static_cast<val_type> ( ::cbrt (static_cast<double> (x)));
+#endif
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type exp (const val_type x) {
     return static_cast<val_type> ( ::exp (static_cast<double> (x)));
@@ -3184,7 +3194,15 @@ public:
     return intPowSigned<val_type> (x, y);
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type sqrt (const val_type x) {
-#ifdef __CUDA_ARCH__
+    using std::sqrt;
+    using std::abs;
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+    // IEEE 754 promises that long double has at least 64 significand
+    // bits, so we can use it to represent any signed or unsigned
+    // 64-bit integer type exactly.  However, CUDA does not implement
+    // long double for device functions.
+    return static_cast<val_type> ( sqrt (static_cast<long double> (abs (x))));
+#else
     // Casting from a 64-bit integer type to double does result in a
     // loss of accuracy.  However, it gives us a good first
     // approximation.  For very large numbers, we may lose some
@@ -3195,21 +3213,17 @@ public:
     // which it has to be, so we don't have to check) to ensure
     // correctness.  It actually should suffice to check numbers
     // within 1 of the result.
-    return static_cast<val_type> ( ::sqrt (static_cast<double> (abs (x))));
-#else
-    // IEEE 754 promises that long double has at least 64 significand
-    // bits, so we can use it to represent any signed or unsigned
-    // 64-bit integer type exactly.  However, CUDA does not implement
-    // long double for device functions.
-    return static_cast<val_type> ( ::sqrt (static_cast<long double> (abs (x))));
-#endif // __CUDA_ARCH__
+    return static_cast<val_type> ( sqrt (static_cast<double> (abs (x))));
+#endif
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type cbrt (const val_type x) {
-#ifdef __CUDA_ARCH__
-    return static_cast<val_type> ( ::cbrt (static_cast<double> (abs (x))));
+    using std::cbrtl;
+    using std::abs;
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+    return static_cast<val_type> ( cbrtl (static_cast<long double> (abs (x))));
 #else
-    return static_cast<val_type> ( ::cbrtl (static_cast<long double> (abs (x))));
-#endif // __CUDA_ARCH__
+    return static_cast<val_type> ( cbrt (static_cast<double> (abs (x))));
+#endif
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type exp (const val_type x) {
     return static_cast<val_type> ( ::exp (static_cast<double> (abs (x))));
@@ -3334,18 +3348,20 @@ public:
     return intPowUnsigned<val_type> (x, y);
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type sqrt (const val_type x) {
-#ifdef __CUDA_ARCH__
-    return static_cast<val_type> ( ::sqrt (static_cast<double> (x)));
-#else
+    using std::sqrt;
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
     return static_cast<val_type> ( ::sqrt (static_cast<long double> (x)));
-#endif // __CUDA_ARCH__
+#else
+    return static_cast<val_type> ( ::sqrt (static_cast<double> (x)));
+#endif
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type cbrt (const val_type x) {
-#ifdef __CUDA_ARCH__
-    return static_cast<val_type> ( ::cbrt (static_cast<double> (x)));
+    using std::cbrtl;
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+    return static_cast<val_type> ( cbrtl (static_cast<long double> (x)));
 #else
-    return static_cast<val_type> ( ::cbrtl (static_cast<long double> (x)));
-#endif // __CUDA_ARCH__
+    return static_cast<val_type> ( cbrt (static_cast<double> (x)));
+#endif
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type exp (const val_type x) {
     return static_cast<val_type> ( ::exp (static_cast<double> (x)));

--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -805,7 +805,7 @@ public:
     return CUDART_NAN_F;
     //return nan (); //this returns 0???
 #elif defined(__HIP_DEVICE_COMPILE__)
-    return nanf("");
+    return ::nanf("");
 #else
     return std::numeric_limits<float>::quiet_NaN();
 #endif // __CUDA_ARCH__
@@ -1132,7 +1132,7 @@ public:
     return CUDART_NAN;
     //return nan (); // this returns 0 ???
 #elif defined(__HIP_DEVICE_COMPILE__)
-    return nan("");
+    return ::nan("");
 #else
     return std::numeric_limits<val_type>::quiet_NaN();
 #endif // __CUDA_ARCH__

--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -3064,8 +3064,8 @@ public:
 #endif
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type cbrt (const val_type x) {
-    using std::cbrtl;
 #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+    using std::cbrtl;
     return static_cast<val_type> ( ::cbrtl (static_cast<long double> (x)));
 #else
     return static_cast<val_type> ( ::cbrt (static_cast<double> (x)));
@@ -3194,9 +3194,9 @@ public:
     return intPowSigned<val_type> (x, y);
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type sqrt (const val_type x) {
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
     using std::sqrt;
     using std::abs;
-#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
     // IEEE 754 promises that long double has at least 64 significand
     // bits, so we can use it to represent any signed or unsigned
     // 64-bit integer type exactly.  However, CUDA does not implement
@@ -3213,16 +3213,16 @@ public:
     // which it has to be, so we don't have to check) to ensure
     // correctness.  It actually should suffice to check numbers
     // within 1 of the result.
-    return static_cast<val_type> ( sqrt (static_cast<double> (abs (x))));
+    return static_cast<val_type> ( ::sqrt (static_cast<double> (abs (x))));
 #endif
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type cbrt (const val_type x) {
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
     using std::cbrtl;
     using std::abs;
-#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
     return static_cast<val_type> ( cbrtl (static_cast<long double> (abs (x))));
 #else
-    return static_cast<val_type> ( cbrt (static_cast<double> (abs (x))));
+    return static_cast<val_type> ( ::cbrt (static_cast<double> (abs (x))));
 #endif
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type exp (const val_type x) {
@@ -3348,19 +3348,19 @@ public:
     return intPowUnsigned<val_type> (x, y);
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type sqrt (const val_type x) {
-    using std::sqrt;
 #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
-    return static_cast<val_type> ( ::sqrt (static_cast<long double> (x)));
+    using std::sqrt;
+    return static_cast<val_type> ( sqrt (static_cast<long double> (x)));
 #else
     return static_cast<val_type> ( ::sqrt (static_cast<double> (x)));
 #endif
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type cbrt (const val_type x) {
-    using std::cbrtl;
 #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+    using std::cbrtl;
     return static_cast<val_type> ( cbrtl (static_cast<long double> (x)));
 #else
-    return static_cast<val_type> ( cbrt (static_cast<double> (x)));
+    return static_cast<val_type> ( ::cbrt (static_cast<double> (x)));
 #endif
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type exp (const val_type x) {


### PR DESCRIPTION
The goal is to replace undefined calls to math functions with the HIP backend.
Hopefully the pre-processor logic makes sense?