### PR TITLE
example/cmake/in-tree: Point to Kokkos_DIR

### DIFF
--- a/example/cmake/in-tree/CMakeLists.txt
+++ b/example/cmake/in-tree/CMakeLists.txt
@@ -9,6 +9,7 @@ project (MyProgram)
 # This assumes you have copied the source, sym-linked to source,
 # or have kokkos available as a git submodule
 add_subdirectory(kokkos)
+set(Kokkos_DIR ${CMAKE_BINARY_DIR}/kokkos)
 
 # This assumes you have copied the source, sym-linked to source,
 # or have kokkos-kernels available as a git submodule


### PR DESCRIPTION
Update the cmake in-tree example to point to the in-tree `Kokkos_DIR`.

Related to #802 