### PR TITLE
KokkosBatched - hip specialization

### DIFF
--- a/src/batched/KokkosBatched_Util.hpp
+++ b/src/batched/KokkosBatched_Util.hpp
@@ -277,6 +277,11 @@ namespace KokkosBatched {
         typename std::enable_if<std::is_same<ActiveMemorySpaceType,Kokkos::CudaSpace>::value,int>
         ::type mb() { return 2; }
 #endif
+#if defined(KOKKOS_ENABLE_HIP)
+        template<typename ActiveMemorySpaceType> KOKKOS_INLINE_FUNCTION static constexpr
+        typename std::enable_if<std::is_same<ActiveMemorySpaceType,Kokkos::Experimental::HIPSpace>::value,int>
+        ::type mb() { return 2; }
+#endif
         template<typename ActiveMemorySpaceType> KOKKOS_INLINE_FUNCTION static constexpr
         typename std::enable_if<std::is_same<ActiveMemorySpaceType,Kokkos::HostSpace>::value,int>
         ::type mb() { return 4; }
@@ -319,6 +324,11 @@ namespace KokkosBatched {
 #if defined(KOKKOS_ENABLE_CUDA)
         template<typename ActiveMemorySpaceType> KOKKOS_INLINE_FUNCTION static constexpr
         typename std::enable_if<std::is_same<ActiveMemorySpaceType,Kokkos::CudaSpace>::value,int>
+        ::type mb() { return 1; }
+#endif
+#if defined(KOKKOS_ENABLE_HIP)
+        template<typename ActiveMemorySpaceType> KOKKOS_INLINE_FUNCTION static constexpr
+        typename std::enable_if<std::is_same<ActiveMemorySpaceType,Kokkos::Experimental::HIPSpace>::value,int>
         ::type mb() { return 1; }
 #endif
         template<typename ActiveMemorySpaceType> KOKKOS_INLINE_FUNCTION static constexpr

--- a/test_common/Test_Common_ArithTraits.hpp
+++ b/test_common/Test_Common_ArithTraits.hpp
@@ -1598,7 +1598,7 @@ int runAllArithTraitsHostTests (std::ostream& out, const int verbose)
 
   success = success && curSuccess; curSuccess = testArithTraitsOnHost<float, DeviceType> (out, verbose);
   success = success && curSuccess; curSuccess = testArithTraitsOnHost<double, DeviceType> (out, verbose);
-#ifndef KOKKOS_ENABLE_CUDA
+#if !defined( KOKKOS_ENABLE_CUDA ) && !defined( KOKKOS_ENABLE_HIP )
   // This would spill tons of warnings about host device stuff otherwise
   success = success && curSuccess; curSuccess = testArithTraitsOnHost<long double, DeviceType> (out, verbose);
   success = success && curSuccess; curSuccess = testArithTraitsOnHost<std::complex<float>, DeviceType> (out, verbose);


### PR DESCRIPTION
I checked the compiling failure owing to the absence of hip space specialization and this PR fix the issue. 

One compile failure is due to complex abs which should be excluded from hip compiling as like cuda.

To compile KokkosKernels, I temporarily modified Kokkos as described in

https://github.com/kokkos/kokkos/issues/3386#issuecomment-693007713

This does not test with spotcheck as the spotcheck does not include an amd machine.
 