### PR TITLE
cm_test_all_sandia: fix determination of CM_ALL_SCRIPT_PATH var

### DIFF
--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -1099,7 +1099,7 @@ setup_env() {
   fi
 
   if [ -e ${CM_ALL_SCRIPT_PATH}/update_lib.sh ]; then
-     echo calling ${CM_ALL_SCRIPT_PATH}/update_lib.sh $MACHINE
+     echo "calling ${CM_ALL_SCRIPT_PATH}/update_lib.sh $MACHINE"
      source ${CM_ALL_SCRIPT_PATH}/update_lib.sh $MACHINE
   fi
 
@@ -1388,8 +1388,7 @@ wait_summarize_and_exit() {
 #
 
 CM_ALL_SCRIPT=$0
-CM_ALL_SCRIPT_PATH=`pwd`
-CM_ALL_SCRIPT_PATH=${CM_ALL_SCRIPT_PATH}/`dirname $CM_ALL_SCRIPT`
+CM_ALL_SCRIPT_PATH=$(cd `dirname $CM_ALL_SCRIPT` && pwd)
 
 ROOT_DIR=$(get_test_root_dir)
 mkdir -p $ROOT_DIR


### PR DESCRIPTION
Broken for absolute paths, causing update_libs.sh to not be called on some systems