### PR TITLE
Factor out coarsening

### DIFF
--- a/src/common/KokkosKernels_SparseUtils.hpp
+++ b/src/common/KokkosKernels_SparseUtils.hpp
@@ -1168,14 +1168,14 @@ struct MergedRowmapFunctor
 };
 
 template<typename rowmap_t, typename entries_t, typename values_t>
-struct MergedEntriesFunctor
+struct MatrixMergedEntriesFunctor
 {
   using size_type = typename rowmap_t::non_const_value_type;
   using lno_t = typename entries_t::non_const_value_type;
   using scalar_t = typename values_t::non_const_value_type;
 
   //Precondition: entries are sorted within each row
-  MergedEntriesFunctor(
+  MatrixMergedEntriesFunctor(
       const rowmap_t& rowmap_, const entries_t& entries_, const values_t& values_,
       const rowmap_t& mergedRowmap_, const entries_t& mergedEntries_, const values_t& mergedValues_)
     : rowmap(rowmap_), entries(entries_), values(values_),
@@ -1225,6 +1225,52 @@ struct MergedEntriesFunctor
   values_t mergedValues;
 };
 
+template<typename rowmap_t, typename entries_t>
+struct GraphMergedEntriesFunctor
+{
+  using size_type = typename rowmap_t::non_const_value_type;
+  using lno_t = typename entries_t::non_const_value_type;
+
+  //Precondition: entries are sorted within each row
+  GraphMergedEntriesFunctor(
+      const rowmap_t& rowmap_, const entries_t& entries_,
+      const rowmap_t& mergedRowmap_, const entries_t& mergedEntries_)
+    : rowmap(rowmap_), entries(entries_),
+    mergedRowmap(mergedRowmap_), mergedEntries(mergedEntries_)
+  {}
+
+  KOKKOS_INLINE_FUNCTION void operator()(lno_t row) const
+  {
+    size_type rowBegin = rowmap(row);
+    size_type rowEnd = rowmap(row + 1);
+    if(rowEnd == rowBegin)
+    {
+      //Row was empty to begin with, nothing to do
+      return;
+    }
+    //Otherwise, accumulate the value for each column
+    lno_t accumCol = entries(rowBegin);
+    size_type insertPos = mergedRowmap(row);
+    for(size_type j = rowBegin + 1; j < rowEnd; j++)
+    {
+      if(accumCol != entries(j))
+      {
+        //write out and reset
+        mergedEntries(insertPos) = accumCol;
+        insertPos++;
+        accumCol = entries(j);
+      }
+    }
+    //always left with the last unique entry
+    mergedEntries(insertPos) = accumCol;
+  }
+
+  rowmap_t rowmap;
+  entries_t entries;
+  rowmap_t mergedRowmap;
+  entries_t mergedEntries;
+};
+
 //Sort the rows of matrix, and merge duplicate entries.
 template<typename crsMat_t>
 crsMat_t sort_and_merge_matrix(const crsMat_t& A)
@@ -1248,12 +1294,47 @@ crsMat_t sort_and_merge_matrix(const crsMat_t& A)
   values_t mergedValues("SortedMerged values", numCompressedEntries);
   //Compute merged entries and values
   Kokkos::parallel_for(range_t(0, A.numRows()),
-      MergedEntriesFunctor<c_rowmap_t, entries_t, values_t>
+      MatrixMergedEntriesFunctor<c_rowmap_t, entries_t, values_t>
       (A.graph.row_map, A.graph.entries, A.values,
        mergedRowmap, mergedEntries, mergedValues));
   //Finally, construct the new compressed matrix
   return crsMat_t("SortedMerged", A.numRows(), A.numCols(), numCompressedEntries,
       mergedValues, mergedRowmap, mergedEntries);
+}
+
+template<typename exec_space, typename rowmap_t, typename entries_t>
+void sort_and_merge_graph(
+    const typename rowmap_t::const_type& rowmap_in, const entries_t& entries_in,
+    rowmap_t& rowmap_out, entries_t& entries_out)
+{
+  using size_type = typename rowmap_t::non_const_value_type;
+  using lno_t = typename entries_t::non_const_value_type;
+  using range_t = Kokkos::RangePolicy<exec_space>;
+  using const_rowmap_t = typename rowmap_t::const_type;
+  lno_t numRows = rowmap_in.extent(0);
+  if(numRows <= 1)
+  {
+    //Matrix has zero rows
+    rowmap_out = rowmap_t();
+    entries_out = entries_t();
+    return;
+  }
+  numRows--;
+  //Sort in place
+  sort_crs_graph<exec_space, const_rowmap_t, entries_t>(rowmap_in, entries_in);
+  //Count entries per row into a new rowmap, in terms of merges that can be done
+  rowmap_out = rowmap_t(Kokkos::ViewAllocateWithoutInitializing("SortedMerged rowmap"), numRows + 1);
+  size_type numCompressedEntries = 0;
+  Kokkos::parallel_reduce(range_t(0, numRows),
+      MergedRowmapFunctor<rowmap_t, entries_t>(rowmap_out, rowmap_in, entries_in), numCompressedEntries);
+  //Prefix sum to get rowmap
+  kk_exclusive_parallel_prefix_sum<rowmap_t, exec_space>(numRows + 1, rowmap_out);
+  entries_out = entries_t("SortedMerged entries", numCompressedEntries);
+  //Compute merged entries and values
+  Kokkos::parallel_for(range_t(0, numRows),
+      GraphMergedEntriesFunctor<const_rowmap_t, entries_t>
+      (rowmap_in, entries_in,
+       rowmap_out, entries_out));
 }
 
 template <typename lno_view_t,

--- a/src/graph/KokkosGraph_ExplicitCoarsening.hpp
+++ b/src/graph/KokkosGraph_ExplicitCoarsening.hpp
@@ -1,0 +1,117 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOSGRAPH_EXPLICIT_COARSEN_HPP
+#define KOKKOSGRAPH_EXPLICIT_COARSEN_HPP
+
+#include "KokkosGraph_ExplicitCoarsening_impl.hpp"
+#include "KokkosKernels_SparseUtils.hpp"
+
+namespace KokkosGraph {
+namespace Experimental {
+
+//Given a CRS graph and coarse labels, produce a new CRS graph representing the coarsened graph.
+//If A is nonsquare, entries in columns >= numVerts are discarded.
+//The labels should be in the range [0, numCoarseVerts), and the output graph wil have numCoarseVerts.
+//
+//If compress, sort and merge entries in each row.
+//An uncompressed graph will still work as input to some things like D1 graph coloring.
+
+template <typename device_t, typename fine_rowmap_t, typename fine_entries_t, typename labels_t, typename coarse_rowmap_t, typename coarse_entries_t>
+void graph_explicit_coarsen(
+    const fine_rowmap_t& fineRowmap, const fine_entries_t& fineEntries,
+    const labels_t& labels, typename fine_entries_t::non_const_value_type numCoarseVerts,
+    coarse_rowmap_t& coarseRowmap, coarse_entries_t& coarseEntries,
+    bool compress = true)
+{
+  using size_type = typename fine_rowmap_t::non_const_value_type;
+  using lno_t = typename fine_entries_t::non_const_value_type;
+  using exec_space = typename device_t::execution_space;
+  static_assert(std::is_same<lno_t, typename coarse_entries_t::non_const_value_type>::value,
+      "graph_explicit_coarsen: The coarse and fine entry Views have different value types.");
+  KokkosGraph::Impl::ExplicitGraphCoarsening<lno_t, size_type, device_t, fine_rowmap_t, fine_entries_t, labels_t, coarse_rowmap_t, coarse_entries_t, coarse_entries_t>
+    egc(fineRowmap, fineEntries, labels, numCoarseVerts);
+  coarseRowmap = egc.coarseRowmap;
+  coarseEntries = egc.coarseEntries;
+  if(compress)
+  {
+    coarse_rowmap_t mergedRowmap;
+    coarse_entries_t mergedEntries;
+    KokkosKernels::Impl::sort_and_merge_graph<exec_space, coarse_rowmap_t, coarse_entries_t>
+      (coarseRowmap, coarseEntries, mergedRowmap, mergedEntries);
+  }
+}
+
+//Same as above, but also produce the map from coarse vertices to fine vertices (inverse map of labels)
+template <typename device_t, typename fine_rowmap_t, typename fine_entries_t, typename labels_t, typename coarse_rowmap_t, typename coarse_entries_t, typename ordinal_view_t>
+void graph_explicit_coarsen_with_inverse_map(
+    const fine_rowmap_t& fineRowmap, const fine_entries_t& fineEntries,
+    const labels_t& labels, typename fine_entries_t::non_const_value_type numCoarseVerts,
+    coarse_rowmap_t& coarseRowmap, coarse_entries_t& coarseEntries,
+    ordinal_view_t& inverseOffsets, ordinal_view_t& inverseLabels,
+    bool compress = true)
+{
+  using size_type = typename fine_rowmap_t::non_const_value_type;
+  using lno_t = typename fine_entries_t::non_const_value_type;
+  using exec_space = typename device_t::execution_space;
+  static_assert(std::is_same<lno_t, typename coarse_entries_t::non_const_value_type>::value,
+      "graph_explicit_coarsen: The coarse and fine entry Views have different value types.");
+  KokkosGraph::Impl::ExplicitGraphCoarsening<lno_t, size_type, device_t, fine_rowmap_t, fine_entries_t, labels_t, coarse_rowmap_t, coarse_entries_t, ordinal_view_t>
+    egc(fineRowmap, fineEntries, labels, numCoarseVerts);
+  coarseRowmap = egc.coarseRowmap;
+  coarseEntries = egc.coarseEntries;
+  inverseOffsets = egc.clusterOffsets;
+  inverseLabels = egc.clusterVerts;
+  if(compress)
+  {
+    coarse_rowmap_t mergedRowmap;
+    coarse_entries_t mergedEntries;
+    KokkosKernels::Impl::sort_and_merge_graph<exec_space, coarse_rowmap_t, coarse_entries_t>
+      (coarseRowmap, coarseEntries, mergedRowmap, mergedEntries);
+  }
+}
+  
+}}
+
+#endif

--- a/src/graph/impl/KokkosGraph_Distance1Color_impl.hpp
+++ b/src/graph/impl/KokkosGraph_Distance1Color_impl.hpp
@@ -124,7 +124,13 @@ public:
       const_lno_nnz_view_t entries,
       HandleType *coloring_handle):
         nv (nv_), ne(ne_),xadj(row_map), adj (entries),
-        kok_src(), kok_dst(), cp(coloring_handle){}
+        kok_src(), kok_dst(), cp(coloring_handle)
+  {
+    static_assert(std::is_same<size_type, typename const_lno_row_view_t::non_const_value_type>::value,
+        "Row map element type does not match handle's size_type.");
+    static_assert(std::is_same<nnz_lno_t, typename const_lno_nnz_view_t::non_const_value_type>::value,
+        "Entries element type does not match handle's nnz_lno_t.");
+  }
 
   /** \brief GraphColor destructor.
    */

--- a/src/graph/impl/KokkosGraph_ExplicitCoarsening_impl.hpp
+++ b/src/graph/impl/KokkosGraph_ExplicitCoarsening_impl.hpp
@@ -1,0 +1,303 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOSGRAPH_EXPLICIT_COARSEN_IMPL_HPP
+#define KOKKOSGRAPH_EXPLICIT_COARSEN_IMPL_HPP
+
+namespace KokkosGraph {
+namespace Impl {
+
+template<typename lno_t, typename size_type, typename device_t, typename fine_rowmap_t, typename fine_entries_t, typename labels_t, typename coarse_rowmap_t, typename coarse_entries_t, typename ordinal_view_t>
+struct ExplicitGraphCoarsening
+{
+  using exec_space = typename device_t::execution_space;
+  using range_pol = Kokkos::RangePolicy<exec_space>;
+  using team_pol = Kokkos::TeamPolicy<exec_space>;
+  using team_member_t = typename team_pol::member_type;
+  using bitset_t = Kokkos::Bitset<device_t>;
+  using const_bitset_t = Kokkos::ConstBitset<device_t>;
+
+  struct ClusterSizeFunctor
+  {
+    ClusterSizeFunctor(const ordinal_view_t& counts_, const labels_t& vertClusters_)
+      : counts(counts_), vertClusters(vertClusters_)
+    {}
+    KOKKOS_INLINE_FUNCTION void operator()(const lno_t i) const
+    {
+      Kokkos::atomic_increment(&counts(vertClusters(i)));
+    }
+    ordinal_view_t counts;
+    labels_t vertClusters;
+  };
+
+  struct FillClusterVertsFunctor
+  {
+    FillClusterVertsFunctor(const ordinal_view_t& clusterOffsets_, const ordinal_view_t& clusterVerts_, const labels_t& vertClusters_, const ordinal_view_t& insertCounts_)
+      : clusterOffsets(clusterOffsets_), clusterVerts(clusterVerts_), vertClusters(vertClusters_), insertCounts(insertCounts_)
+    {}
+    KOKKOS_INLINE_FUNCTION void operator()(const lno_t i) const
+    {
+      lno_t cluster = vertClusters(i);
+      lno_t offset = clusterOffsets(cluster) + Kokkos::atomic_fetch_add(&insertCounts(cluster), 1);
+      clusterVerts(offset) = i;
+    }
+    ordinal_view_t clusterOffsets;
+    ordinal_view_t clusterVerts;
+    labels_t vertClusters;
+    ordinal_view_t insertCounts;
+  };
+
+  struct BuildCrossClusterMaskFunctor
+  {
+    BuildCrossClusterMaskFunctor(const fine_rowmap_t& rowmap_, const fine_entries_t& colinds_, const ordinal_view_t& clusterOffsets_, const ordinal_view_t& clusterVerts_, const labels_t& vertClusters_, const bitset_t& mask_)
+      : numRows(rowmap_.extent(0) - 1), rowmap(rowmap_), colinds(colinds_), clusterOffsets(clusterOffsets_), clusterVerts(clusterVerts_), vertClusters(vertClusters_), mask(mask_)
+    {}
+
+    //Used a fixed-size hash set in shared memory
+    KOKKOS_INLINE_FUNCTION constexpr int tableSize() const
+    {
+      //Should always be a power-of-two, so that X % tableSize() reduces to a bitwise and.
+      return 512;
+    }
+
+    //Given a cluster index, get the hash table index.
+    //This is the 32-bit xorshift RNG, but it works as a hash function.
+    KOKKOS_INLINE_FUNCTION unsigned xorshiftHash(lno_t cluster) const
+    {
+      unsigned x = cluster;
+      x ^= x << 13;
+      x ^= x >> 17;
+      x ^= x << 5;
+      return x;
+    }
+
+    KOKKOS_INLINE_FUNCTION bool lookup(lno_t cluster, int* table) const
+    {
+      unsigned h = xorshiftHash(cluster);
+      for(unsigned i = h; i < h + 2; i++)
+      {
+        if(table[i % tableSize()] == cluster)
+          return true;
+      }
+      return false;
+    }
+
+    //Try to insert the edge between cluster (team's cluster) and neighbor (neighboring cluster)
+    //by inserting nei into the table.
+    KOKKOS_INLINE_FUNCTION bool insert(lno_t cluster, lno_t nei, int* table) const
+    {
+      unsigned h = xorshiftHash(nei);
+      for(unsigned i = h; i < h + 2; i++)
+      {
+        if(Kokkos::atomic_compare_exchange_strong<int>(&table[i % tableSize()], cluster, nei))
+          return true;
+      }
+      return false;
+    }
+
+    KOKKOS_INLINE_FUNCTION void operator()(const team_member_t t) const
+    {
+      lno_t cluster = t.league_rank();
+      lno_t clusterSize = clusterOffsets(cluster + 1) - clusterOffsets(cluster);
+      //Use a fixed-size hash table per thread to accumulate neighbor of the cluster.
+      //If it fills up (very unlikely) then just count every remaining edge going to another cluster
+      //not already in the table; this provides a reasonable upper bound for overallocating the cluster graph.
+      //each thread handles a cluster
+      int* table = (int*) t.team_shmem().get_shmem(tableSize() * sizeof(int));
+      //mark every entry as cluster (self-loop) to represent free/empty
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(t, tableSize()),
+        [&](const lno_t i)
+        {
+          table[i] = cluster;
+        });
+      t.team_barrier();
+      //now, for each row belonging to the cluster, iterate through the neighbors
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(t, clusterSize),
+        [&] (const lno_t i)
+        {
+          lno_t row = clusterVerts(clusterOffsets(cluster) + i);
+          lno_t rowDeg = rowmap(row + 1) - rowmap(row);
+          Kokkos::parallel_for(Kokkos::ThreadVectorRange(t, rowDeg),
+            [&] (const lno_t j)
+            {
+              lno_t nei = colinds(rowmap(row) + j);
+              //Remote neighbors are not included
+              if(nei >= numRows)
+                return;
+              lno_t neiCluster = vertClusters(nei);
+              if(neiCluster != cluster)
+              {
+                //Have a neighbor. Try to find it in the table.
+                if(!lookup(neiCluster, table))
+                {
+                  //Not in the table. Try to insert it.
+                  insert(cluster, neiCluster, table);
+                  //Whether or not insertion succeeded,
+                  //this is a cross-cluster edge possibly not seen before
+                  mask.set(rowmap(row) + j);
+                }
+              }
+            });
+        });
+    }
+
+    size_t team_shmem_size(int teamSize) const
+    {
+      return tableSize() * sizeof(int);
+    }
+
+    lno_t numRows;
+    fine_rowmap_t rowmap;
+    fine_entries_t colinds;
+    ordinal_view_t clusterOffsets;
+    ordinal_view_t clusterVerts;
+    labels_t vertClusters;
+    bitset_t mask;
+  };
+
+  struct FillClusterEntriesFunctor
+  {
+    FillClusterEntriesFunctor(
+        const fine_rowmap_t& rowmap_, const fine_entries_t& colinds_, const coarse_rowmap_t& clusterRowmap_, const coarse_entries_t& clusterEntries_, const ordinal_view_t& clusterOffsets_, const ordinal_view_t& clusterVerts_, const labels_t& vertClusters_, const bitset_t& edgeMask_)
+      : rowmap(rowmap_), colinds(colinds_), clusterRowmap(clusterRowmap_), clusterEntries(clusterEntries_), clusterOffsets(clusterOffsets_), clusterVerts(clusterVerts_), vertClusters(vertClusters_), edgeMask(edgeMask_)
+    {}
+    //Run this scan over entries in clusterVerts (reordered point rows)
+    KOKKOS_INLINE_FUNCTION void operator()(const lno_t i, lno_t& lcount, const bool& finalPass) const
+    {
+      lno_t numRows = rowmap.extent(0) - 1;
+      lno_t row = clusterVerts(i);
+      size_type rowStart = rowmap(row);
+      size_type rowEnd = rowmap(row + 1);
+      lno_t cluster = vertClusters(row);
+      lno_t clusterStart = clusterOffsets(cluster);
+      //Count the number of entries in this row.
+      //This is how much lcount will be increased by,
+      //yielding the offset corresponding to
+      //these point entries in the cluster entries.
+      lno_t rowEntries = 0;
+      for(size_type j = rowStart; j < rowEnd; j++)
+      {
+        if(edgeMask.test(j))
+          rowEntries++;
+      }
+      if(finalPass)
+      {
+        //if this is the last row in the cluster, update the upper bound in clusterRowmap
+        if(i == clusterStart)
+        {
+          clusterRowmap(cluster) = lcount;
+        }
+        lno_t clusterEdge = lcount;
+        //populate clusterEntries for these edges
+        for(size_type j = rowStart; j < rowEnd; j++)
+        {
+          if(edgeMask.test(j))
+          {
+            clusterEntries(clusterEdge++) = vertClusters(colinds(j));
+          }
+        }
+      }
+      //update the scan result at the end (exclusive)
+      lcount += rowEntries;
+      if(i == numRows - 1 && finalPass)
+      {
+        //on the very last row, set the last entry of the cluster rowmap
+        clusterRowmap(clusterRowmap.extent(0) - 1) = lcount;
+      }
+    }
+    fine_rowmap_t rowmap;
+    fine_entries_t colinds;
+    coarse_rowmap_t clusterRowmap;
+    coarse_entries_t clusterEntries;
+    ordinal_view_t clusterOffsets;
+    ordinal_view_t clusterVerts;
+    labels_t vertClusters;
+    const_bitset_t edgeMask;
+  };
+
+  //Constructor just does the computation and outputs to coarseRowmap, coarseEntries.
+  ExplicitGraphCoarsening(const fine_rowmap_t& fineRowmap, const fine_entries_t& fineEntries, const labels_t& labels, lno_t numCoarseVerts)
+  {
+    lno_t numFineVerts = fineRowmap.extent(0);
+    if(numFineVerts <= 1)
+    {
+      coarseRowmap = coarse_rowmap_t();
+      coarseEntries = coarse_entries_t();
+      return;
+    }
+    numFineVerts--;
+    clusterOffsets = ordinal_view_t("Cluster offsets", numCoarseVerts + 1);
+    clusterVerts = ordinal_view_t(Kokkos::ViewAllocateWithoutInitializing("Cluster verts"), numFineVerts);
+    Kokkos::parallel_for(range_pol(0, numFineVerts), ClusterSizeFunctor(clusterOffsets, labels));
+    KokkosKernels::Impl::exclusive_parallel_prefix_sum<ordinal_view_t, exec_space>(numCoarseVerts + 1, clusterOffsets);
+    {
+      coarse_entries_t tempInsertCounts("Temporary cluster insert counts", numCoarseVerts);
+      Kokkos::parallel_for(range_pol(0, numFineVerts), FillClusterVertsFunctor(clusterOffsets, clusterVerts, labels, tempInsertCounts));
+    }
+    //Determine the set of edges (in the point graph) that cross between two distinct clusters
+    int vectorSize = KokkosKernels::Impl::kk_get_suggested_vector_size(numFineVerts, fineEntries.extent(0), KokkosKernels::Impl::kk_get_exec_space_type<exec_space>());
+    bitset_t crossClusterEdgeMask(fineEntries.extent(0));
+    size_type numClusterEdges;
+    {
+      BuildCrossClusterMaskFunctor buildEdgeMask(fineRowmap, fineEntries, clusterOffsets, clusterVerts, labels, crossClusterEdgeMask);
+      int sharedPerTeam = buildEdgeMask.team_shmem_size(0); //using team-size = 0 for since no per-thread shared is used.
+      int teamSize = KokkosKernels::Impl::get_suggested_team_size<team_pol>(buildEdgeMask, vectorSize, sharedPerTeam, 0);
+      Kokkos::parallel_for(team_pol(numCoarseVerts, teamSize, vectorSize).set_scratch_size(0, Kokkos::PerTeam(sharedPerTeam)), buildEdgeMask);
+      numClusterEdges = crossClusterEdgeMask.count();
+    }
+    coarseRowmap = coarse_rowmap_t(Kokkos::ViewAllocateWithoutInitializing("Cluster graph rowmap"), numCoarseVerts + 1);
+    coarseEntries = coarse_entries_t(Kokkos::ViewAllocateWithoutInitializing("Cluster graph colinds"), numClusterEdges);
+    Kokkos::parallel_scan(range_pol(0, numFineVerts), FillClusterEntriesFunctor
+        (fineRowmap, fineEntries, coarseRowmap, coarseEntries, clusterOffsets, clusterVerts, labels, crossClusterEdgeMask));
+  }
+
+  coarse_rowmap_t coarseRowmap;
+  coarse_entries_t coarseEntries;
+  ordinal_view_t clusterOffsets;
+  ordinal_view_t clusterVerts;
+};
+
+}}
+
+#endif

--- a/src/graph/impl/KokkosGraph_ExplicitCoarsening_impl.hpp
+++ b/src/graph/impl/KokkosGraph_ExplicitCoarsening_impl.hpp
@@ -272,7 +272,7 @@ struct ExplicitGraphCoarsening
     Kokkos::parallel_for(range_pol(0, numFineVerts), ClusterSizeFunctor(clusterOffsets, labels));
     KokkosKernels::Impl::exclusive_parallel_prefix_sum<ordinal_view_t, exec_space>(numCoarseVerts + 1, clusterOffsets);
     {
-      coarse_entries_t tempInsertCounts("Temporary cluster insert counts", numCoarseVerts);
+      ordinal_view_t tempInsertCounts("Temporary cluster insert counts", numCoarseVerts);
       Kokkos::parallel_for(range_pol(0, numFineVerts), FillClusterVertsFunctor(clusterOffsets, clusterVerts, labels, tempInsertCounts));
     }
     //Determine the set of edges (in the point graph) that cross between two distinct clusters

--- a/src/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
@@ -82,6 +82,10 @@ namespace KokkosSparse{
       typedef typename HandleType::nnz_lno_t nnz_lno_t;
       typedef typename HandleType::nnz_scalar_t nnz_scalar_t;
 
+      static_assert(std::is_same<size_type, typename in_lno_row_view_t::non_const_value_type>::value,
+          "ClusterGaussSeidel: Handle's size_type does not match input rowmap's element type.");
+      static_assert(std::is_same<nnz_lno_t, typename in_lno_nnz_view_t::non_const_value_type>::value,
+          "ClusterGaussSeidel: Handle's nnz_lno_t does not match input entries's element type.");
 
       typedef typename in_lno_row_view_t::const_type const_lno_row_view_t;
       typedef typename in_lno_row_view_t::non_const_type non_const_lno_row_view_t;
@@ -540,9 +544,9 @@ namespace KokkosSparse{
         using nnz_view_t   = nnz_lno_persistent_work_view_t;
         using in_rowmap_t  = const_lno_row_view_t;
         using in_colinds_t = const_lno_nnz_view_t;
-        using rowmap_t     = Kokkos::View<row_lno_t*, MyTempMemorySpace>;
+        using rowmap_t     = Kokkos::View<size_type*, MyTempMemorySpace>;
         using colinds_t    = Kokkos::View<nnz_lno_t*, MyTempMemorySpace>;
-        using raw_rowmap_t = Kokkos::View<const row_lno_t*, MyTempMemorySpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+        using raw_rowmap_t = Kokkos::View<const size_type*, MyTempMemorySpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
         using raw_colinds_t = Kokkos::View<const nnz_lno_t*, MyTempMemorySpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
         auto gsHandle = get_gs_handle();
 #ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
@@ -648,7 +652,7 @@ namespace KokkosSparse{
         Kokkos::deep_copy(colors, h_colors);
 #else
         //Create a handle that uses nnz_lno_t as the size_type, since the cluster graph should never be larger than 2^31 entries.
-        KokkosKernels::Experimental::KokkosKernelsHandle<nnz_lno_t, nnz_lno_t, double, MyExecSpace, MyPersistentMemorySpace, MyPersistentMemorySpace> kh;
+        HandleType kh;
         kh.create_graph_coloring_handle(KokkosGraph::COLORING_DEFAULT);
         KokkosGraph::Experimental::graph_color_symbolic(&kh, numClusters, numClusters, clusterRowmap, clusterEntries);
         //retrieve colors

--- a/src/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
@@ -57,6 +57,7 @@
 #include "KokkosKernels_SimpleUtils.hpp"
 #include "KokkosSparse_partitioning_impl.hpp"
 #include "KokkosGraph_MIS2.hpp"
+#include "KokkosGraph_ExplicitCoarsening.hpp"
 
 namespace KokkosSparse{
   namespace Impl{
@@ -495,208 +496,6 @@ namespace KokkosSparse{
         nnz_lno_t clusterSize;
       };
 
-      template<typename nnz_view_t>
-      struct ClusterSizeFunctor
-      {
-        ClusterSizeFunctor(nnz_view_t& counts_, nnz_view_t& vertClusters_)
-          : counts(counts_), vertClusters(vertClusters_)
-        {}
-        KOKKOS_INLINE_FUNCTION void operator()(const nnz_lno_t i) const
-        {
-          Kokkos::atomic_increment(&counts(vertClusters(i)));
-        }
-        nnz_view_t counts;
-        nnz_view_t vertClusters;
-      };
-
-      template<typename nnz_view_t>
-      struct FillClusterVertsFunctor
-      {
-        FillClusterVertsFunctor(nnz_view_t& clusterOffsets_, nnz_view_t& clusterVerts_, nnz_view_t& vertClusters_, nnz_view_t& insertCounts_)
-          : clusterOffsets(clusterOffsets_), clusterVerts(clusterVerts_), vertClusters(vertClusters_), insertCounts(insertCounts_)
-        {}
-        KOKKOS_INLINE_FUNCTION void operator()(const nnz_lno_t i) const
-        {
-          nnz_lno_t cluster = vertClusters(i);
-          nnz_lno_t offset = clusterOffsets(cluster) + Kokkos::atomic_fetch_add(&insertCounts(cluster), 1);
-          clusterVerts(offset) = i;
-        }
-        nnz_view_t clusterOffsets;
-        nnz_view_t clusterVerts;
-        nnz_view_t vertClusters;
-        nnz_view_t insertCounts;
-      };
-
-      template<typename Rowmap, typename Colinds, typename nnz_view_t>
-      struct BuildCrossClusterMaskFunctor
-      {
-        BuildCrossClusterMaskFunctor(Rowmap& rowmap_, Colinds& colinds_, nnz_view_t& clusterOffsets_, nnz_view_t& clusterVerts_, nnz_view_t& vertClusters_, bitset_t& mask_)
-          : numRows(rowmap_.extent(0) - 1), rowmap(rowmap_), colinds(colinds_), clusterOffsets(clusterOffsets_), clusterVerts(clusterVerts_), vertClusters(vertClusters_), mask(mask_)
-        {}
-
-        //Used a fixed-size hash set in shared memory
-        KOKKOS_INLINE_FUNCTION constexpr int tableSize() const
-        {
-          //Should always be a power-of-two, so that X % tableSize() reduces to a bitwise and.
-          return 512;
-        }
-
-        //Given a cluster index, get the hash table index.
-        //This is the 32-bit xorshift RNG, but it works as a hash function.
-        KOKKOS_INLINE_FUNCTION unsigned xorshiftHash(nnz_lno_t cluster) const
-        {
-          unsigned x = cluster;
-          x ^= x << 13;
-          x ^= x >> 17;
-          x ^= x << 5;
-          return x;
-        }
-
-        KOKKOS_INLINE_FUNCTION bool lookup(nnz_lno_t cluster, int* table) const
-        {
-          unsigned h = xorshiftHash(cluster);
-          for(unsigned i = h; i < h + 2; i++)
-          {
-            if(table[i % tableSize()] == cluster)
-              return true;
-          }
-          return false;
-        }
-
-        //Try to insert the edge between cluster (team's cluster) and neighbor (neighboring cluster)
-        //by inserting nei into the table.
-        KOKKOS_INLINE_FUNCTION bool insert(nnz_lno_t cluster, nnz_lno_t nei, int* table) const
-        {
-          unsigned h = xorshiftHash(nei);
-          for(unsigned i = h; i < h + 2; i++)
-          {
-            if(Kokkos::atomic_compare_exchange_strong<int>(&table[i % tableSize()], cluster, nei))
-              return true;
-          }
-          return false;
-        }
-
-        KOKKOS_INLINE_FUNCTION void operator()(const team_member_t t) const
-        {
-          nnz_lno_t cluster = t.league_rank();
-          nnz_lno_t clusterSize = clusterOffsets(cluster + 1) - clusterOffsets(cluster);
-          //Use a fixed-size hash table per thread to accumulate neighbor of the cluster.
-          //If it fills up (very unlikely) then just count every remaining edge going to another cluster
-          //not already in the table; this provides a reasonable upper bound for overallocating the cluster graph.
-          //each thread handles a cluster
-          int* table = (int*) t.team_shmem().get_shmem(tableSize() * sizeof(int));
-          //mark every entry as cluster (self-loop) to represent free/empty
-          Kokkos::parallel_for(Kokkos::TeamVectorRange(t, tableSize()),
-            [&](const nnz_lno_t i)
-            {
-              table[i] = cluster;
-            });
-          t.team_barrier();
-          //now, for each row belonging to the cluster, iterate through the neighbors
-          Kokkos::parallel_for(Kokkos::TeamThreadRange(t, clusterSize),
-            [&] (const nnz_lno_t i)
-            {
-              nnz_lno_t row = clusterVerts(clusterOffsets(cluster) + i);
-              nnz_lno_t rowDeg = rowmap(row + 1) - rowmap(row);
-              Kokkos::parallel_for(Kokkos::ThreadVectorRange(t, rowDeg),
-                [&] (const nnz_lno_t j)
-                {
-                  nnz_lno_t nei = colinds(rowmap(row) + j);
-                  //Remote neighbors are not included
-                  if(nei >= numRows)
-                    return;
-                  nnz_lno_t neiCluster = vertClusters(nei);
-                  if(neiCluster != cluster)
-                  {
-                    //Have a neighbor. Try to find it in the table.
-                    if(!lookup(neiCluster, table))
-                    {
-                      //Not in the table. Try to insert it.
-                      insert(cluster, neiCluster, table);
-                      //Whether or not insertion succeeded,
-                      //this is a cross-cluster edge possibly not seen before
-                      mask.set(rowmap(row) + j);
-                    }
-                  }
-                });
-            });
-        }
-
-        size_t team_shmem_size(int teamSize) const
-        {
-          return tableSize() * sizeof(int);
-        }
-
-        nnz_lno_t numRows;
-        Rowmap rowmap;
-        Colinds colinds;
-        nnz_view_t clusterOffsets;
-        nnz_view_t clusterVerts;
-        nnz_view_t vertClusters;
-        bitset_t mask;
-      };
-
-      template<typename Rowmap, typename Colinds, typename nnz_view_t>
-      struct FillClusterEntriesFunctor
-      {
-        FillClusterEntriesFunctor(
-            Rowmap& rowmap_, Colinds& colinds_, nnz_view_t& clusterRowmap_, nnz_view_t& clusterEntries_, nnz_view_t& clusterOffsets_, nnz_view_t& clusterVerts_, nnz_view_t& vertClusters_, bitset_t& edgeMask_)
-          : rowmap(rowmap_), colinds(colinds_), clusterRowmap(clusterRowmap_), clusterEntries(clusterEntries_), clusterOffsets(clusterOffsets_), clusterVerts(clusterVerts_), vertClusters(vertClusters_), edgeMask(edgeMask_)
-        {}
-        //Run this scan over entries in clusterVerts (reordered point rows)
-        KOKKOS_INLINE_FUNCTION void operator()(const nnz_lno_t i, nnz_lno_t& lcount, const bool& finalPass) const
-        {
-          nnz_lno_t numRows = rowmap.extent(0) - 1;
-          nnz_lno_t row = clusterVerts(i);
-          size_type rowStart = rowmap(row);
-          size_type rowEnd = rowmap(row + 1);
-          nnz_lno_t cluster = vertClusters(row);
-          nnz_lno_t clusterStart = clusterOffsets(cluster);
-          //Count the number of entries in this row.
-          //This is how much lcount will be increased by,
-          //yielding the offset corresponding to
-          //these point entries in the cluster entries.
-          nnz_lno_t rowEntries = 0;
-          for(size_type j = rowStart; j < rowEnd; j++)
-          {
-            if(edgeMask.test(j))
-              rowEntries++;
-          }
-          if(finalPass)
-          {
-            //if this is the last row in the cluster, update the upper bound in clusterRowmap
-            if(i == clusterStart)
-            {
-              clusterRowmap(cluster) = lcount;
-            }
-            nnz_lno_t clusterEdge = lcount;
-            //populate clusterEntries for these edges
-            for(size_type j = rowStart; j < rowEnd; j++)
-            {
-              if(edgeMask.test(j))
-              {
-                clusterEntries(clusterEdge++) = vertClusters(colinds(j));
-              }
-            }
-          }
-          //update the scan result at the end (exclusive)
-          lcount += rowEntries;
-          if(i == numRows - 1 && finalPass)
-          {
-            //on the very last row, set the last entry of the cluster rowmap
-            clusterRowmap(clusterRowmap.extent(0) - 1) = lcount;
-          }
-        }
-        Rowmap rowmap;
-        Colinds colinds;
-        nnz_view_t clusterRowmap;
-        nnz_view_t clusterEntries;
-        nnz_view_t clusterOffsets;
-        nnz_view_t clusterVerts;
-        nnz_view_t vertClusters;
-        const_bitset_t edgeMask;
-      };
-
       //Assign cluster labels to vertices, given that the vertices are naturally
       //ordered so that contiguous groups of vertices form decent clusters.
       template<typename View>
@@ -768,8 +567,6 @@ namespace KokkosSparse{
         //Now that a symmetric graph is available, build the cluster graph (also symmetric)
         nnz_lno_t clusterSize = gsHandle->get_cluster_size();
         nnz_lno_t numClusters = (num_rows + clusterSize - 1) / clusterSize;
-        nnz_view_t clusterOffsets("Cluster offsets", numClusters + 1);
-        nnz_view_t clusterVerts("Cluster -> vertices", num_rows);
         raw_rowmap_t raw_sym_xadj;
         raw_colinds_t raw_sym_adj;
         if(this->is_symmetric)
@@ -811,46 +608,12 @@ namespace KokkosSparse{
         std::cout << "Graph clustering: " << timer.seconds() << '\n';
         timer.reset();
 #endif
-        //Construct the cluster offset and vertex array. These allow fast iteration over all vertices in a given cluster.
-        Kokkos::parallel_for(my_exec_space(0, num_rows), ClusterSizeFunctor<nnz_view_t>(clusterOffsets, vertClusters));
-        KokkosKernels::Impl::exclusive_parallel_prefix_sum<nnz_view_t, MyExecSpace>(numClusters + 1, clusterOffsets);
-        {
-          nnz_view_t tempInsertCounts("Temporary cluster insert counts", numClusters);
-          Kokkos::parallel_for(my_exec_space(0, num_rows), FillClusterVertsFunctor<nnz_view_t>(clusterOffsets, clusterVerts, vertClusters, tempInsertCounts));
-        }
-#if KOKKOSSPARSE_IMPL_PRINTDEBUG
-        {
-          auto clusterOffsetsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), clusterOffsets);
-          auto clusterVertsHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), clusterVerts);
-          puts("Clusters (cluster #, and vertex #s):");
-          for(nnz_lno_t i = 0; i < numClusters; i++)
-          {
-            printf("%d: ", (int) i);
-            for(nnz_lno_t j = clusterOffsetsHost(i); j < clusterOffsetsHost(i + 1); j++)
-            {
-              printf("%d ", (int) clusterVerts(j));
-            }
-            putchar('\n');
-          }
-          printf("\n\n\n");
-        }
-#endif
-        //Determine the set of edges (in the point graph) that cross between two distinct clusters
-        int vectorSize = this->handle->get_suggested_vector_size(num_rows, raw_sym_adj.extent(0));
-        bitset_t crossClusterEdgeMask(raw_sym_adj.extent(0));
-        size_type numClusterEdges;
-        {
-          BuildCrossClusterMaskFunctor<raw_rowmap_t, raw_colinds_t, nnz_view_t>
-            buildEdgeMask(raw_sym_xadj, raw_sym_adj, clusterOffsets, clusterVerts, vertClusters, crossClusterEdgeMask);
-          int sharedPerTeam = buildEdgeMask.team_shmem_size(0); //using team-size = 0 for since no per-thread shared is used.
-          int teamSize = KokkosKernels::Impl::get_suggested_team_size<team_policy_t>(buildEdgeMask, vectorSize, sharedPerTeam, 0);
-          Kokkos::parallel_for(team_policy_t(numClusters, teamSize, vectorSize).set_scratch_size(0, Kokkos::PerTeam(sharedPerTeam)), buildEdgeMask);
-          numClusterEdges = crossClusterEdgeMask.count();
-        }
-        nnz_view_t clusterRowmap = nnz_view_t("Cluster graph rowmap", numClusters + 1);
-        nnz_view_t clusterEntries = nnz_view_t("Cluster graph colinds", numClusterEdges);
-        Kokkos::parallel_scan(my_exec_space(0, num_rows), FillClusterEntriesFunctor<raw_rowmap_t, raw_colinds_t, nnz_view_t>
-            (raw_sym_xadj, raw_sym_adj, clusterRowmap, clusterEntries, clusterOffsets, clusterVerts, vertClusters, crossClusterEdgeMask));
+        rowmap_t clusterRowmap;
+        colinds_t clusterEntries;
+        nnz_view_t clusterOffsets;
+        nnz_view_t clusterVerts;
+        KokkosGraph::Experimental::graph_explicit_coarsen_with_inverse_map<Kokkos::Device<MyExecSpace, MyTempMemorySpace>, raw_rowmap_t, raw_colinds_t, nnz_view_t, rowmap_t, colinds_t, nnz_view_t>
+          (raw_sym_xadj, raw_sym_adj, vertClusters, numClusters, clusterRowmap, clusterEntries, clusterOffsets, clusterVerts, false);
 #ifdef KOKKOSSPARSE_IMPL_TIME_REVERSE
         std::cout << "Building explicit cluster graph: " << timer.seconds() << '\n';
         timer.reset();


### PR DESCRIPTION
This adds explicit graph coarsening as a standalone feature (given a graph and coarse labels, construct a new graph were all vertices of a given label are collapsed). This has been buried in Cluster Gauss-Seidel for a while but Gordon Moon would like to use it, so this provides a clean interface for it. There isn't a unit test for this but it's tested through cluster Gauss-Seidel.

I also added sort_and_merge_crs_graph() to SparseUtils, since the coarsened graph can optionally be merged. This shares most code with sort_and_merge_crs_matrix(), but doesn't process values, and it takes rowmap/colinds views as input (using StaticCrsGraph would have been too messy since it forces the rowmap to be const-valued).

#######################################################
PASSED TESTS
#######################################################
clang-8.0-Cuda_OpenMP-release build_time=649 run_time=126
clang-8.0-Pthread_Serial-release build_time=211 run_time=115
clang-9.0.0-Pthread-release build_time=132 run_time=53
clang-9.0.0-Serial-release build_time=133 run_time=44
cuda-10.1-Cuda_OpenMP-release build_time=896 run_time=130
cuda-11.0-Cuda_OpenMP-release build_time=973 run_time=124
cuda-9.2-Cuda_Serial-release build_time=887 run_time=191
gcc-7.3.0-OpenMP-release build_time=150 run_time=43
gcc-7.3.0-Pthread-release build_time=122 run_time=60
gcc-8.3.0-Serial-release build_time=148 run_time=52
gcc-9.1-OpenMP-release build_time=188 run_time=44
gcc-9.1-Serial-release build_time=166 run_time=46
intel-17.0.1-Serial-release build_time=286 run_time=50
intel-18.0.5-OpenMP-release build_time=380 run_time=46
intel-19.0.5-Pthread-release build_time=402 run_time=56