### PR TITLE
Test spmv transpose (Fix #829)

### DIFF
--- a/unit_test/sparse/Test_Sparse_spmv.hpp
+++ b/unit_test/sparse/Test_Sparse_spmv.hpp
@@ -51,7 +51,8 @@ struct fSPMV {
 template <typename crsMat_t, typename x_vector_type, typename y_vector_type>
 void sequential_spmv(crsMat_t input_mat, x_vector_type x, y_vector_type y,
                      typename y_vector_type::non_const_value_type alpha,
-                     typename y_vector_type::non_const_value_type beta){
+                     typename y_vector_type::non_const_value_type beta,
+                     char mode = 'N'){
 
   using graph_t          = typename crsMat_t::StaticCrsGraphType;
   using size_type_view_t = typename graph_t::row_map_type;
@@ -61,7 +62,9 @@ void sequential_spmv(crsMat_t input_mat, x_vector_type x, y_vector_type y,
   using size_type = typename size_type_view_t::non_const_value_type;
   using lno_t     = typename lno_view_t::non_const_value_type;
   using scalar_t  = typename scalar_view_t::non_const_value_type;
+  using KAT       = Kokkos::ArithTraits<scalar_t>;
 
+  mode = toupper(mode);
 
   typename scalar_view_t::HostMirror h_values = Kokkos::create_mirror_view(input_mat.values);
   Kokkos::deep_copy(h_values,input_mat.values);
@@ -84,15 +87,24 @@ void sequential_spmv(crsMat_t input_mat, x_vector_type x, y_vector_type y,
 
   lno_t nr = input_mat.numRows();
 
-  for (lno_t i = 0; i < nr; ++i){
-    scalar_t result = 0;
-    for (size_type j = h_rowmap(i); j < h_rowmap(i+1); ++j){
+  //first, scale y by beta
+  for(size_t i = 0; i < h_y.extent(0); i++)
+    h_y(i) *= beta;
+
+  //then go through the matrix and accumulate the matrix-vector product
+  for (lno_t row = 0; row < nr; ++row) {
+    for (size_type j = h_rowmap(row); j < h_rowmap(row+1); ++j) {
       lno_t col = h_entries(j);
       scalar_t val = h_values(j);
-      scalar_t vector_val = h_x(col);
-      result += val * vector_val;
+      if(mode == 'N')
+        h_y(row) += alpha * val * h_x(col);
+      else if(mode == 'C')
+        h_y(row) += alpha * KAT::conj(val) * h_x(col);
+      else if(mode == 'T')
+        h_y(col) += alpha * val * h_x(row);
+      else if(mode == 'H')
+        h_y(col) += alpha * KAT::conj(val) * h_x(row);
     }
-    h_y(i) = beta * h_y(i) + alpha * result;
   }
   KokkosKernels::Impl::safe_host_to_device_deep_copy (y.extent(0),  h_y, y);
   Kokkos::fence();
@@ -102,7 +114,7 @@ void sequential_spmv(crsMat_t input_mat, x_vector_type x, y_vector_type y,
 template <typename crsMat_t, typename x_vector_type, typename y_vector_type>
 void check_spmv(crsMat_t input_mat, x_vector_type x, y_vector_type y,
                 typename y_vector_type::non_const_value_type alpha,
-                typename y_vector_type::non_const_value_type beta) {
+                typename y_vector_type::non_const_value_type beta, char mode) {
   //typedef typename crsMat_t::StaticCrsGraphType graph_t;
   using ExecSpace = typename crsMat_t::execution_space;
   using my_exec_space    = Kokkos::RangePolicy<ExecSpace>;
@@ -115,13 +127,14 @@ void check_spmv(crsMat_t input_mat, x_vector_type x, y_vector_type y,
   // the appropriate tolerance precision.
   const y_value_mag_type eps = std::is_same<y_value_mag_type, float>::value ? 2*1e-3 : 1e-7;
   const size_t nr = input_mat.numRows();
-  y_vector_type expected_y("expected", nr);
+  bool transposed = (mode == 'T') || (mode == 'H');
+  y_vector_type expected_y("expected", transposed ? input_mat.numCols() : input_mat.numRows());
   Kokkos::deep_copy(expected_y, y);
   Kokkos::fence();
 
-  sequential_spmv(input_mat, x, expected_y, alpha, beta);
+  sequential_spmv(input_mat, x, expected_y, alpha, beta, mode);
   //KokkosKernels::Impl::print_1Dview(expected_y);
-  KokkosSparse::spmv("N", alpha, input_mat, x, beta, y);
+  KokkosSparse::spmv(&mode, alpha, input_mat, x, beta, y);
   //KokkosKernels::Impl::print_1Dview(y);
   int num_errors = 0;
   Kokkos::parallel_reduce("KokkosSparse::Test::spmv",
@@ -137,7 +150,7 @@ void check_spmv(crsMat_t input_mat, x_vector_type x, y_vector_type y,
 template <typename crsMat_t, typename x_vector_type, typename y_vector_type>
 void check_spmv_mv(crsMat_t input_mat, x_vector_type x, y_vector_type y, y_vector_type expected_y,
                    typename y_vector_type::non_const_value_type alpha,
-                   typename y_vector_type::non_const_value_type beta, int numMV) {
+                   typename y_vector_type::non_const_value_type beta, int numMV, char mode) {
   using ExecSpace = typename crsMat_t::execution_space;
   using my_exec_space = Kokkos::RangePolicy<ExecSpace>;
   using y_value_type     = typename y_vector_type::non_const_value_type;
@@ -153,7 +166,7 @@ void check_spmv_mv(crsMat_t input_mat, x_vector_type x, y_vector_type y, y_vecto
 
   Kokkos::fence();
 
-  KokkosSparse::spmv("N", alpha, input_mat, x, beta, y);
+  KokkosSparse::spmv(&mode, alpha, input_mat, x, beta, y);
 
 
   for (int i = 0; i < numMV; ++i){
@@ -162,7 +175,7 @@ void check_spmv_mv(crsMat_t input_mat, x_vector_type x, y_vector_type y, y_vecto
     auto y_i = Kokkos::subview (expected_y, Kokkos::ALL (), i);
     Kokkos::fence();
 
-    sequential_spmv(input_mat, x_i, y_i, alpha, beta);
+    sequential_spmv(input_mat, x_i, y_i, alpha, beta, mode);
 
     auto y_spmv = Kokkos::subview (y, Kokkos::ALL (), i);
     int num_errors = 0;
@@ -326,6 +339,8 @@ void test_spmv(lno_t numRows,size_type nnz, lno_t bandwidth, lno_t row_size_vari
 
   x_vector_type input_x ("x", nc);
   y_vector_type output_y ("y", nr);
+  x_vector_type input_xt ("x", nr);
+  y_vector_type output_yt ("y", nc);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
@@ -334,10 +349,23 @@ void test_spmv(lno_t numRows,size_type nnz, lno_t bandwidth, lno_t row_size_vari
 
   Kokkos::fill_random(input_x,rand_pool,ScalarX(10));
   Kokkos::fill_random(output_y,rand_pool,ScalarY(10));
+  Kokkos::fill_random(input_xt,rand_pool,ScalarX(10));
+  Kokkos::fill_random(output_yt,rand_pool,ScalarY(10));
 
-  Test::check_spmv(input_mat, input_x, output_y, 1.0, 0.0);
-  Test::check_spmv(input_mat, input_x, output_y, 0.0, 1.0);
-  Test::check_spmv(input_mat, input_x, output_y, 1.0, 1.0);
+  std::vector<char> nonTransModes = {'N', 'C'};
+  std::vector<char> transModes = {'T', 'H'};
+  for(auto mode : nonTransModes)
+  {
+    Test::check_spmv(input_mat, input_x, output_y, 1.0, 0.0, mode);
+    Test::check_spmv(input_mat, input_x, output_y, 0.0, 1.0, mode);
+    Test::check_spmv(input_mat, input_x, output_y, 1.0, 1.0, mode);
+  }
+  for(auto mode : transModes)
+  {
+    Test::check_spmv(input_mat, input_xt, output_yt, 1.0, 0.0, mode);
+    Test::check_spmv(input_mat, input_xt, output_yt, 0.0, 1.0, mode);
+    Test::check_spmv(input_mat, input_xt, output_yt, 1.0, 1.0, mode);
+  }
 }
 
 template <typename scalar_t, typename lno_t, typename size_type, typename layout, class Device>
@@ -353,21 +381,36 @@ void test_spmv_mv(lno_t numRows,size_type nnz, lno_t bandwidth, lno_t row_size_v
   ViewTypeY b_y("B",numCols,numMV);
   ViewTypeY b_y_copy("B",numCols,numMV);
 
+  ViewTypeX b_xt("A",numCols,numMV);
+  ViewTypeY b_yt("B",numRows,numMV);
+  ViewTypeY b_yt_copy("B",numRows,numMV);
+
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
   Kokkos::fill_random(b_x,rand_pool,scalar_t(10));
   Kokkos::fill_random(b_y,rand_pool,scalar_t(10));
+  Kokkos::fill_random(b_xt,rand_pool,scalar_t(10));
+  Kokkos::fill_random(b_yt,rand_pool,scalar_t(10));
 
 
   crsMat_t input_mat = KokkosKernels::Impl::kk_generate_sparse_matrix<crsMat_t>(numRows,numCols,nnz,row_size_variance, bandwidth);
 
   Kokkos::deep_copy(b_y_copy, b_y);
+  Kokkos::deep_copy(b_yt_copy, b_yt);
 
-
-  Test::check_spmv_mv(input_mat, b_x, b_y, b_y_copy, 1.0, 0.0, numMV);
-  Test::check_spmv_mv(input_mat, b_x, b_y, b_y_copy, 0.0, 1.0, numMV);
-  Test::check_spmv_mv(input_mat, b_x, b_y, b_y_copy, 1.0, 1.0, numMV);
-
-
+  std::vector<char> nonTransModes = {'N', 'C'};
+  std::vector<char> transModes = {'T', 'H'};
+  for(auto mode : nonTransModes)
+  {
+    Test::check_spmv_mv(input_mat, b_x, b_y, b_y_copy, 1.0, 0.0, numMV, mode);
+    Test::check_spmv_mv(input_mat, b_x, b_y, b_y_copy, 0.0, 1.0, numMV, mode);
+    Test::check_spmv_mv(input_mat, b_x, b_y, b_y_copy, 1.0, 1.0, numMV, mode);
+  }
+  for(auto mode : transModes)
+  {
+    Test::check_spmv_mv(input_mat, b_xt, b_yt, b_yt_copy, 1.0, 0.0, numMV, mode);
+    Test::check_spmv_mv(input_mat, b_xt, b_yt, b_yt_copy, 0.0, 1.0, numMV, mode);
+    Test::check_spmv_mv(input_mat, b_xt, b_yt, b_yt_copy, 1.0, 1.0, numMV, mode);
+  }
 }
 
 template <typename scalar_t, typename lno_t, typename size_type, class Device>

--- a/unit_test/sparse/Test_Sparse_spmv.hpp
+++ b/unit_test/sparse/Test_Sparse_spmv.hpp
@@ -126,7 +126,6 @@ void check_spmv(crsMat_t input_mat, x_vector_type x, y_vector_type y,
   // so let us use y_value_type to determine
   // the appropriate tolerance precision.
   const y_value_mag_type eps = std::is_same<y_value_mag_type, float>::value ? 2*1e-3 : 1e-7;
-  const size_t nr = input_mat.numRows();
   bool transposed = (mode == 'T') || (mode == 'H');
   y_vector_type expected_y("expected", transposed ? input_mat.numCols() : input_mat.numRows());
   Kokkos::deep_copy(expected_y, y);


### PR DESCRIPTION
Add tests for SpMV modes conjugate (C), transpose (T) and conjugate transpose (H). The new tests use the same matrix as the existing normal (N) mode test. Added 1D and 2D vector versions but didn't touch the structured spmv tests, they may still need more tests.

#######################################################
PASSED TESTS
#######################################################
clang-8.0-Cuda_OpenMP-release build_time=812 run_time=108
clang-8.0-Pthread_Serial-release build_time=223 run_time=154
clang-9.0.0-Pthread-release build_time=133 run_time=67
clang-9.0.0-Serial-release build_time=141 run_time=52
cuda-10.1-Cuda_OpenMP-release build_time=918 run_time=130
cuda-11.0-Cuda_OpenMP-release build_time=1157 run_time=1177
cuda-9.2-Cuda_Serial-release build_time=943 run_time=196
gcc-7.3.0-OpenMP-release build_time=156 run_time=257
gcc-7.3.0-Pthread-release build_time=129 run_time=63
gcc-8.3.0-Serial-release build_time=153 run_time=49
gcc-9.1-OpenMP-release build_time=193 run_time=101
gcc-9.1-Serial-release build_time=171 run_time=51
intel-17.0.1-Serial-release build_time=307 run_time=59
intel-18.0.5-OpenMP-release build_time=392 run_time=50
intel-19.0.5-Pthread-release build_time=446 run_time=71
