### PR TITLE
Add fallback condition to use spmv_native when cuSPARSE won't work

### DIFF
--- a/src/sparse/KokkosSparse_spmv.hpp
+++ b/src/sparse/KokkosSparse_spmv.hpp
@@ -151,7 +151,7 @@ spmv (KokkosKernels::Experimental::Controls controls,
       KokkosBlas::scal(y_i, beta, y_i);
     return;
   }
-  return Impl::SPMV<
+  Impl::SPMV<
     typename AMatrix_Internal::value_type,
     typename AMatrix_Internal::ordinal_type,
     typename AMatrix_Internal::device_type,

--- a/src/sparse/impl/KokkosSparse_spgemm_cuSPARSE_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_cuSPARSE_impl.hpp
@@ -79,9 +79,10 @@ namespace Impl{
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 
-    using device1 = typename ain_row_index_view_type::device_type;
-    using device2 = typename ain_nonzero_index_view_type::device_type;
-    using idx     = typename KernelHandle::nnz_lno_t;
+    using device1   = typename ain_row_index_view_type::device_type;
+    using device2   = typename ain_nonzero_index_view_type::device_type;
+    using idx       = typename KernelHandle::nnz_lno_t;
+    using size_type = typename KernelHandle::size_type;
 
 
     //TODO this is not correct, check memory space.
@@ -98,11 +99,10 @@ namespace Impl{
       throw std::runtime_error ("SpGEMM cuSPARSE backend is not yet supported for this CUDA version\n");
 #else
 
-    if (std::is_same<idx, int>::value){
-
-      const idx *a_xadj = (int *)row_mapA.data();
-      const idx *b_xadj = (int *)row_mapB.data();
-      idx *c_xadj = (int *)row_mapC.data();
+    if (std::is_same<idx, int>::value && std::is_same<size_type, int>::value){
+      const idx *a_xadj = (const idx*) row_mapA.data();
+      const idx *b_xadj = (const idx*) row_mapB.data();
+      idx *c_xadj = (idx*) row_mapC.data();
 
       const idx *a_adj = entriesA.data();
       const idx *b_adj = entriesB.data();

--- a/src/sparse/impl/KokkosSparse_spmv_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_spec.hpp
@@ -257,8 +257,6 @@ struct SPMV < AT, AO, AD, AM, AS,
   {
     typedef Kokkos::Details::ArithTraits<coefficient_type> KAT;
 
-    typedef Kokkos::Details::ArithTraits<coefficient_type> KAT;
-
     if (alpha == KAT::zero ()) {
       if (beta != KAT::one ()) {
         KokkosBlas::scal (y, beta, y);

--- a/src/sparse/impl/KokkosSparse_sptrsv_cuSPARSE_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_sptrsv_cuSPARSE_impl.hpp
@@ -95,7 +95,7 @@ namespace Impl{
     if (!std::is_same<size_type, int>::value)
       sptrsv_handle->allocate_tmp_int_rowmap(row_map.extent(0));
     const int* rm  = !std::is_same<size_type, int>::value ? sptrsv_handle->get_int_rowmap_ptr_copy(row_map) : (const int*)row_map.data();
-    const int* ent =  entries.data();
+    const int* ent = (const int*) entries.data();
     const scalar_type* vals = values.data();
 
     if (std::is_same<scalar_type,double>::value) {
@@ -297,7 +297,7 @@ namespace Impl{
     int nnz = entries.extent_int(0);
 
     const int* rm  = !std::is_same<size_type, int>::value ? sptrsv_handle->get_int_rowmap_ptr() : (const int*)row_map.data();
-    const int* ent =  entries.data(); 
+    const int* ent = (const int*) entries.data();
     const scalar_type* vals = values.data();
     const scalar_type* bv = rhs.data();
     scalar_type* xv = lhs.data();


### PR DESCRIPTION
- Improve SpMV unit test:
  - generate random complex values with nonzero imaginary component
  - catch exceptions in spmv
- Add "spmv_native" support to the cusparse spmv file (this calls KokkosKernels spmv)
- Fall back to native for mode 'C' (which cusparse doesn't have), or modes 'T'/'H' for CUDA 9 (fixing #833)
- Fix some minor type casts/checks in spgemm/sptrsv cusparse wrappers - now those builds and tests succeed with all 4 possible combinations of offset/ordinal width