### PR TITLE
Fixes -Werror for gcc with c++20

### DIFF
--- a/src/common/KokkosKernels_Sorting.hpp
+++ b/src/common/KokkosKernels_Sorting.hpp
@@ -431,7 +431,7 @@ struct BitonicPhase1Functor
     Ordinal workStart = work * (t.league_rank() % teamsPerBox);
     Ordinal workReflect = boxSize - workStart - 1;
     Kokkos::parallel_for(Kokkos::TeamThreadRange(t, work),
-      [=](const Ordinal i)
+      [&](const Ordinal i)
       {
         Ordinal elem1 = boxStart + workStart + i;
         Ordinal elem2 = boxStart + workReflect - i;
@@ -471,7 +471,7 @@ struct BitonicPhase2Functor
     Ordinal workStart = boxStart + work * (t.league_rank() % teamsPerBox);
     Ordinal jump = boxSize / 2;
     Kokkos::parallel_for(Kokkos::TeamThreadRange(t, work),
-      [=](const Ordinal i)
+      [&](const Ordinal i)
       {
         Ordinal elem1 = workStart + i;
         Ordinal elem2 = workStart + jump + i;
@@ -495,7 +495,7 @@ struct BitonicPhase2Functor
         Ordinal logSubBoxSize = logBoxSize - subLevel;
         Ordinal subBoxSize = Ordinal(1) << logSubBoxSize;
         Kokkos::parallel_for(Kokkos::TeamThreadRange(t, work),
-          [=](const Ordinal i)
+          [&](const Ordinal i)
           {
             Ordinal globalThread = i + t.league_rank() * work;
             Ordinal subBox = globalThread >> (logSubBoxSize - 1);

--- a/src/graph/KokkosGraph_Distance1ColorHandle.hpp
+++ b/src/graph/KokkosGraph_Distance1ColorHandle.hpp
@@ -357,7 +357,7 @@ private:
         }
       }, new_edge_count);
 
-      Kokkos::single(Kokkos::PerThread(teamMember),[=] () {
+      Kokkos::single(Kokkos::PerThread(teamMember),[&] () {
         lower_xadj_counts(ii + 1) = new_edge_count;
       });
     }

--- a/src/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
@@ -312,7 +312,7 @@ namespace KokkosSparse{
               for(int j = 0; j < N; j++)
                 lsum.data[j] += val * _Xvector(colIndex, colStart + j);
             }, sum);
-          Kokkos::single(Kokkos::PerThread(teamMember),[=] ()
+          Kokkos::single(Kokkos::PerThread(teamMember),[&] ()
           {
             nnz_scalar_t invDiagonalVal = _inverse_diagonal(row);
             for(int i = 0; i < N; i++)

--- a/src/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
@@ -276,7 +276,7 @@ namespace KokkosSparse{
               for(int j = 0; j < N; j++)
                 lsum.data[j] += val * _Xvector(colIndex, colStart + j);
             }, sum);
-          Kokkos::single(Kokkos::PerThread(teamMember),[=] ()
+          Kokkos::single(Kokkos::PerThread(teamMember),[&] ()
           {
             nnz_scalar_t invDiagonalVal = _permuted_inverse_diagonal(row);
             for(int i = 0; i < N; i++)
@@ -420,7 +420,7 @@ namespace KokkosSparse{
 
                   product += product2;
                   //update the new vector entries.
-                  Kokkos::single(Kokkos::PerThread(teamMember),[=] () {
+                  Kokkos::single(Kokkos::PerThread(teamMember),[&] () {
                       nnz_lno_t block_row_index = ii * block_size + i;
                       nnz_scalar_t invDiagonalVal = _permuted_inverse_diagonal(block_row_index);
                       _Xvector(block_row_index, vec) += omega * (_Yvector(block_row_index, vec) - product) * invDiagonalVal;
@@ -484,7 +484,7 @@ namespace KokkosSparse{
 
           Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end), [&] (const nnz_lno_t& ii) {
 #if KOKKOSSPARSE_IMPL_PRINTDEBUG
-              Kokkos::single(Kokkos::PerThread(teamMember),[=] () {
+              Kokkos::single(Kokkos::PerThread(teamMember),[&] () {
                   for(nnz_lno_t i = 0; i < block_size; diagonal_positions[i++] = -1);
                 });
 #endif
@@ -542,7 +542,7 @@ namespace KokkosSparse{
                       valueToUpdate += all_shared_memory[colind] * _adj_vals(current_row_begin + colind);
                     }, product);
 
-                  Kokkos::single(Kokkos::PerThread(teamMember),[=] ()
+                  Kokkos::single(Kokkos::PerThread(teamMember),[&] ()
                   {
                     nnz_lno_t block_row_index = ii * block_size + i;
                     nnz_scalar_t invDiagonalVal = _permuted_inverse_diagonal(block_row_index);

--- a/src/sparse/impl/KokkosSparse_partitioning_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_partitioning_impl.hpp
@@ -253,7 +253,7 @@ struct RCM
       int next = 1;
       nnz_lno_t visitCounter = 0;
       Kokkos::single(Kokkos::PerTeam(mem),
-      [=]()
+      [&]()
       {
         workQueue(active, 0) = start;
         visit(start) = QUEUED;
@@ -337,7 +337,7 @@ struct RCM
         if(visitCounter < numRows && activeQSize == 0)
         {
           Kokkos::single(Kokkos::PerTeam(mem),
-          [=]()
+          [&]()
           {
             //Some nodes are unreachable from start (graph not connected)
             //Find an unvisited node to resume BFS
@@ -356,7 +356,7 @@ struct RCM
         level++;
       }
       Kokkos::single(Kokkos::PerTeam(mem),
-      [=]
+      [&]
       {
         numLevels() = level - 1;
       });
@@ -447,7 +447,7 @@ struct RCM
         }
         mem.team_barrier();
         Kokkos::single(Kokkos::PerTeam(mem),
-        [=]()
+        [&]()
         {
           radixSortKeysAndValues<size_type, offset_t, nnz_lno_t, nnz_lno_t, team_member_t>
             (scores.data(), scoresAux.data(), adj.data() + levelOffset, adjAux.data(), levelSize, mem);

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
@@ -654,7 +654,7 @@ struct KokkosSPGEMM
       if (c_row_size > max_first_level_hash_size){
     	  {
     		  while (tmp == NULL){
-    			  Kokkos::single(Kokkos::PerTeam(teamMember),[=] (volatile nnz_lno_t * &memptr) {
+    			  Kokkos::single(Kokkos::PerTeam(teamMember),[&] (volatile nnz_lno_t * &memptr) {
     				  memptr = (volatile nnz_lno_t * )( memory_space.allocate_chunk(row_index));
     			  }, tmp);
     		  }

--- a/src/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
@@ -816,7 +816,7 @@ namespace KokkosSparse{
 	  // Initialize hashmaps
 	  if (c_row_size > max_first_level_hash_size){
 	    while (tmp == NULL){
-	      Kokkos::single(Kokkos::PerTeam(teamMember),[=] (volatile nnz_lno_t * &memptr) {
+	      Kokkos::single(Kokkos::PerTeam(teamMember),[&] (volatile nnz_lno_t * &memptr) {
 		  memptr = (volatile nnz_lno_t * )( memory_space.allocate_chunk(row_index));
 		}, tmp);
 	    }


### PR DESCRIPTION
Resolves messages of form:
error: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20
[-Werror=deprecated]