### PR TITLE
HIP: fixing a couple of issues on AMD

### DIFF
--- a/src/common/KokkosKernels_BitUtils.hpp
+++ b/src/common/KokkosKernels_BitUtils.hpp
@@ -189,7 +189,11 @@ int least_set_bit( unsigned i ){
 
 KOKKOS_FORCEINLINE_FUNCTION
 int least_set_bit( unsigned long i ){
+#if defined(__HIP_DEVICE_COMPILE__)
+  return __ffsll(static_cast<unsigned long long>(i));
+#else
   return __ffsll(i);
+#endif
 }
 
 
@@ -207,7 +211,11 @@ int least_set_bit( int i ){
 
 KOKKOS_FORCEINLINE_FUNCTION
 int least_set_bit( long i ){
+#if defined(__HIP_DEVICE_COMPILE__)
+  return __ffsll(static_cast<long long>(i));
+#else
   return __ffsll(i);
+#endif
 }
 
 KOKKOS_FORCEINLINE_FUNCTION

--- a/src/sparse/KokkosSparse_CrsMatrix.hpp
+++ b/src/sparse/KokkosSparse_CrsMatrix.hpp
@@ -106,7 +106,7 @@ inline int RowsPerThread<Kokkos::Cuda>(const int NNZPerRow) {
 #endif
 #ifdef KOKKOS_ENABLE_HIP
 template<>
-inline int RowsPerThread<Kokkos::HIP>(const int NNZPerRow) {
+inline int RowsPerThread<Kokkos::Experimental::HIP>(const int NNZPerRow) {
   return 1;
 }
 #endif


### PR DESCRIPTION
A couple of issues have appeared in the HIP build using rocm/3.8.0, nothing bit though

1. typo: Kokkos::HIP instead of Kokkos::Experimental::HIP
2. __ffsll is not overloaded in HIP so need to cast the input correctly