### PR TITLE
New issue with HIP and Kokkos_ArithTraits

### DIFF
--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -1385,17 +1385,25 @@ public:
   static constexpr bool has_infinity = true;
   static KOKKOS_FORCEINLINE_FUNCTION long double infinity() { return HUGE_VALL; }
 
-  static bool isInf (const val_type& x) {
+  static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type& x) {
     #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
     using std::isinf;
     #endif
+#if defined(KOKKOS_ENABLE_HIP)
+    return isinf (static_cast<double>(x));
+#else
     return isinf (x);
+#endif
   }
-  static bool isNan (const val_type& x) {
+  static KOKKOS_FORCEINLINE_FUNCTION bool isNan (const val_type& x) {
     #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
     using std::isnan;
     #endif
+#if defined(KOKKOS_ENABLE_HIP)
+    return isnan (static_cast<double>(x));
+#else
     return isnan (x);
+#endif
   }
   static mag_type abs (const val_type& x) {
     return ::fabsl (x);

--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -1370,6 +1370,7 @@ public:
 // CUDA does not support long double in device functions, so none of
 // the class methods in this specialization are marked as device
 // functions.
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
 template<>
 class ArithTraits<long double> {
 public:
@@ -1383,27 +1384,15 @@ public:
   static const bool is_complex = false;
 
   static constexpr bool has_infinity = true;
-  static KOKKOS_FORCEINLINE_FUNCTION long double infinity() { return HUGE_VALL; }
+  static long double infinity() { return HUGE_VALL; }
 
-  static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type& x) {
-    #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+  static bool isInf (const val_type& x) {
     using std::isinf;
-    #endif
-#if defined(KOKKOS_ENABLE_HIP)
-    return isinf (static_cast<double>(x));
-#else
     return isinf (x);
-#endif
   }
-  static KOKKOS_FORCEINLINE_FUNCTION bool isNan (const val_type& x) {
-    #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+  static bool isNan (const val_type& x) {
     using std::isnan;
-    #endif
-#if defined(KOKKOS_ENABLE_HIP)
-    return isnan (static_cast<double>(x));
-#else
     return isnan (x);
-#endif
   }
   static mag_type abs (const val_type& x) {
     return ::fabsl (x);
@@ -1537,7 +1526,8 @@ public:
   static mag_type rmax () {
     return LDBL_MAX;
   }
-};
+}; // long double specialization
+#endif // KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
 
 #ifdef HAVE_KOKKOSKERNELS_QUADMATH
 

--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -1367,9 +1367,9 @@ public:
 };
 
 
-// CUDA does not support long double in device functions, so none of
-// the class methods in this specialization are marked as device
-// functions.
+// CUDA and HIP do not support long double in device functions,
+// so none of the class methods in this specialization are marked
+// as device functions.
 #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
 template<>
 class ArithTraits<long double> {

--- a/src/Kokkos_InnerProductSpaceTraits.hpp
+++ b/src/Kokkos_InnerProductSpaceTraits.hpp
@@ -170,6 +170,7 @@ public:
 /// \brief Partial specialization for long double.
 ///
 /// \warning CUDA does not support long double in device functions.
+#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
 template<>
 struct InnerProductSpaceTraits<long double>
 {
@@ -184,6 +185,7 @@ struct InnerProductSpaceTraits<long double>
     return x * y;
   }
 };
+#endif
 
 //! Partial specialization for Kokkos::complex<T>.
 template<class T>


### PR DESCRIPTION
`isinf` and `isnan` are not defined for long double with HIP.
The input parameter is casted to avoid ambiguous function call.
The function is also defined as __device __ so it needs to be decorated with KOKKOS_FORCE_INLINE_FUNCTION.

@crtrott @brian-kelley any idea why this issue would only appear on Tulip?
It is using rocm-3.8.0 so I am not sure why this would not be an issue on caraway?
Maybe because of the gcc toolchain?