### PR TITLE
Half_t explicit conversions

### DIFF
--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -683,7 +683,7 @@ public:
   static const bool is_complex = false;
 
   static constexpr bool has_infinity = true;
-  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return HUGE_VALF; }
+  static KOKKOS_FORCEINLINE_FUNCTION val_type infinity() { return Kokkos::Experimental::cast_to_half(HUGE_VALF); }
 
   static KOKKOS_FORCEINLINE_FUNCTION bool isInf (const val_type x) {
     #ifndef __CUDA_ARCH__
@@ -698,78 +698,78 @@ public:
     return isnan(Kokkos::Experimental::cast_from_half<float>(x));
   }
   static KOKKOS_FORCEINLINE_FUNCTION mag_type abs (const val_type x) {
-    return fabs(Kokkos::Experimental::cast_from_half<float>(x));
+    return Kokkos::Experimental::cast_to_half(fabs(Kokkos::Experimental::cast_from_half<float>(x)));
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type zero () {
-    return 0.0F;
+    return Kokkos::Experimental::cast_to_half(0.0F);
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type one () {
-    return 1.0F;
+    return Kokkos::Experimental::cast_to_half(1.0F);
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type min () {
-    return -KOKKOSKERNELS_IMPL_FP16_MAX;
+    return Kokkos::Experimental::cast_to_half(-KOKKOSKERNELS_IMPL_FP16_MAX);
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type max () {
-    return KOKKOSKERNELS_IMPL_FP16_MAX;
+    return Kokkos::Experimental::cast_to_half(KOKKOSKERNELS_IMPL_FP16_MAX);
   }
   static KOKKOS_FORCEINLINE_FUNCTION mag_type real (const val_type x) {
     return x;
   }
   static KOKKOS_FORCEINLINE_FUNCTION mag_type imag (const val_type) {
-    return 0.0F;
+    return Kokkos::Experimental::cast_to_half(0.0F);
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type conj (const val_type x) {
     return x;
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type pow (const val_type x, const val_type y) {
-    return ::pow(Kokkos::Experimental::cast_from_half<float>(x),
-                 Kokkos::Experimental::cast_from_half<float>(y));
+    return Kokkos::Experimental::cast_to_half(::pow(Kokkos::Experimental::cast_from_half<float>(x),
+                 Kokkos::Experimental::cast_from_half<float>(y)));
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type sqrt (const val_type x) {
-    return ::sqrt (Kokkos::Experimental::cast_from_half<float>(x));
+    return Kokkos::Experimental::cast_to_half(::sqrt (Kokkos::Experimental::cast_from_half<float>(x)));
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type cbrt (const val_type x) {
-    return ::cbrt (Kokkos::Experimental::cast_from_half<float>(x));
+    return Kokkos::Experimental::cast_to_half(::cbrt (Kokkos::Experimental::cast_from_half<float>(x)));
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type exp (const val_type x) {
-    return ::exp (Kokkos::Experimental::cast_from_half<float>(x));
+    return Kokkos::Experimental::cast_to_half(::exp (Kokkos::Experimental::cast_from_half<float>(x)));
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type log (const val_type x) {
-    return ::log (Kokkos::Experimental::cast_from_half<float>(x));
+    return Kokkos::Experimental::cast_to_half(::log (Kokkos::Experimental::cast_from_half<float>(x)));
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type log10 (const val_type x) {
-    return ::log10 (Kokkos::Experimental::cast_from_half<float>(x));
+    return Kokkos::Experimental::cast_to_half(::log10 (Kokkos::Experimental::cast_from_half<float>(x)));
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type sin (const val_type x) {
-    return ::sin (Kokkos::Experimental::cast_from_half<float>(x));
+    return Kokkos::Experimental::cast_to_half(::sin (Kokkos::Experimental::cast_from_half<float>(x)));
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type cos (const val_type x) {
-    return ::cos (Kokkos::Experimental::cast_from_half<float>(x));
+    return Kokkos::Experimental::cast_to_half(::cos (Kokkos::Experimental::cast_from_half<float>(x)));
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type tan (const val_type x) {
-    return ::tan (Kokkos::Experimental::cast_from_half<float>(x));
+    return Kokkos::Experimental::cast_to_half(::tan (Kokkos::Experimental::cast_from_half<float>(x)));
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type sinh (const val_type x) {
-    return ::sinh (Kokkos::Experimental::cast_from_half<float>(x));
+    return Kokkos::Experimental::cast_to_half(::sinh (Kokkos::Experimental::cast_from_half<float>(x)));
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type cosh (const val_type x) {
-    return ::cosh (Kokkos::Experimental::cast_from_half<float>(x));
+    return Kokkos::Experimental::cast_to_half(::cosh (Kokkos::Experimental::cast_from_half<float>(x)));
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type tanh (const val_type x) {
-    return ::tanh (Kokkos::Experimental::cast_from_half<float>(x));
+    return Kokkos::Experimental::cast_to_half(::tanh (Kokkos::Experimental::cast_from_half<float>(x)));
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type asin (const val_type x) {
-    return ::asin (Kokkos::Experimental::cast_from_half<float>(x));
+    return Kokkos::Experimental::cast_to_half(::asin (Kokkos::Experimental::cast_from_half<float>(x)));
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type acos (const val_type x) {
-    return ::acos (Kokkos::Experimental::cast_from_half<float>(x));
+    return Kokkos::Experimental::cast_to_half(::acos (Kokkos::Experimental::cast_from_half<float>(x)));
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type atan (const val_type x) {
-    return ::atan (Kokkos::Experimental::cast_from_half<float>(x));
+    return Kokkos::Experimental::cast_to_half(::atan (Kokkos::Experimental::cast_from_half<float>(x)));
   }
   static KOKKOS_FORCEINLINE_FUNCTION mag_type epsilon () {
     //return ::pow(2, -KOKKOSKERNELS_IMPL_FP16_SIGNIFICAND_BITS);
-    return KOKKOSKERNELS_IMPL_FP16_EPSILON;
+    return Kokkos::Experimental::cast_to_half(KOKKOSKERNELS_IMPL_FP16_EPSILON);
   }
   // Backwards compatibility with Teuchos::ScalarTraits.
   typedef mag_type magnitudeType;
@@ -785,29 +785,29 @@ public:
     return isNan (x) || isInf (x);
   }
   static KOKKOS_FORCEINLINE_FUNCTION magnitudeType magnitude (const val_type x) {
-    return abs (Kokkos::Experimental::cast_from_half<float>(x));
+    return abs(x);
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type conjugate (const val_type x) {
-    return conj (Kokkos::Experimental::cast_from_half<float>(x));
+    return conj(x);
   }
   static std::string name () {
     return "half";
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type squareroot (const val_type x) {
-    return sqrt (Kokkos::Experimental::cast_from_half<float>(x));
+    return sqrt(x);
   }
   static KOKKOS_FORCEINLINE_FUNCTION val_type nan () {
 #ifdef __CUDA_ARCH__
-    return CUDART_NAN_F;
+    return Kokkos::Experimental::cast_to_half(CUDART_NAN_F);
 #else
-    return std::numeric_limits<float>::quiet_NaN();
+    return Kokkos::Experimental::cast_to_half(std::numeric_limits<float>::quiet_NaN());
 #endif // __CUDA_ARCH__
   }
   static KOKKOS_FORCEINLINE_FUNCTION mag_type eps () {
     return epsilon ();
   }
   static KOKKOS_FORCEINLINE_FUNCTION mag_type sfmin () {
-    return KOKKOSKERNELS_IMPL_FP16_MIN;
+    return Kokkos::Experimental::cast_to_half(KOKKOSKERNELS_IMPL_FP16_MIN);
   }
   static KOKKOS_FORCEINLINE_FUNCTION int base () {
     return KOKKOSKERNELS_IMPL_FP16_RADIX;
@@ -823,19 +823,19 @@ public:
     return KOKKOSKERNELS_IMPL_FP16_MANT_DIG;
   }
   static KOKKOS_FORCEINLINE_FUNCTION mag_type rnd () {
-    return 1.0;
+    return Kokkos::Experimental::cast_to_half(1.0);
   }
   static KOKKOS_FORCEINLINE_FUNCTION int emin () {
     return KOKKOSKERNELS_IMPL_FP16_MIN_EXP;
   }
   static KOKKOS_FORCEINLINE_FUNCTION mag_type rmin () {
-    return KOKKOSKERNELS_IMPL_FP16_MIN;
+    return Kokkos::Experimental::cast_to_half(KOKKOSKERNELS_IMPL_FP16_MIN);
   }
   static KOKKOS_FORCEINLINE_FUNCTION int emax () {
     return KOKKOSKERNELS_IMPL_FP16_MAX_EXP;
   }
   static KOKKOS_FORCEINLINE_FUNCTION mag_type rmax () {
-    return KOKKOSKERNELS_IMPL_FP16_MAX;
+    return Kokkos::Experimental::cast_to_half(KOKKOSKERNELS_IMPL_FP16_MAX);
   }
 };
 #endif // KOKKOS_HALF_T_IS_FLOAT && KOKKOS_ENABLE_CUDA_HALF

--- a/src/batched/KokkosBatched_Gemm_TeamVector_Internal.hpp
+++ b/src/batched/KokkosBatched_Gemm_TeamVector_Internal.hpp
@@ -70,7 +70,7 @@ namespace KokkosBatched {
 		const ValueType
 		  *__restrict__ pB = B+j*bs1;
 		
-		ValueType c = 0;
+		ValueType c = ValueType(0);
 		for (int p=0;p<k;++p) 
 		  c += pA[p*as1]*pB[p*bs0];
 		C[i*cs0+j*cs1] += alpha*c;

--- a/src/batched/KokkosBatched_Gemm_Team_Internal.hpp
+++ b/src/batched/KokkosBatched_Gemm_Team_Internal.hpp
@@ -69,7 +69,7 @@ namespace KokkosBatched {
             *__restrict__ pA = A+i*as0,
             *__restrict__ pB = B+j*bs1;
             
-          ValueType c = 0;
+          ValueType c = ValueType(0);
           for (int p=0;p<k;++p) 
             c += pA[p*as1]*pB[p*bs0];
           C[i*cs0+j*cs1] += alpha*c;

--- a/src/batched/KokkosBatched_InnerGemmFixC_Serial_Impl.hpp
+++ b/src/batched/KokkosBatched_InnerGemmFixC_Serial_Impl.hpp
@@ -469,10 +469,10 @@ namespace KokkosBatched {
     if (k <= 0) return 0;
 
     ValueType
-      a_0p, b_p0, c_00 = 0, c_01 = 0, c_02 = 0, c_03 = 0,
-      a_1p, b_p1, c_10 = 0, c_11 = 0, c_12 = 0, c_13 = 0,
-      a_2p, b_p2, c_20 = 0, c_21 = 0, c_22 = 0, c_23 = 0,
-      a_3p, b_p3, c_30 = 0, c_31 = 0, c_32 = 0, c_33 = 0;
+      a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0), c_02 = ValueType(0), c_03 = ValueType(0),
+      a_1p, b_p1, c_10 = ValueType(0), c_11 = ValueType(0), c_12 = ValueType(0), c_13 = ValueType(0),
+      a_2p, b_p2, c_20 = ValueType(0), c_21 = ValueType(0), c_22 = ValueType(0), c_23 = ValueType(0),
+      a_3p, b_p3, c_30 = ValueType(0), c_31 = ValueType(0), c_32 = ValueType(0), c_33 = ValueType(0);
 
     const int
       i0 = 0*_as0, i1 = 1*_as0, i2 = 2*_as0, i3 = 3*_as0,
@@ -516,10 +516,10 @@ namespace KokkosBatched {
     if (k <= 0) return 0;
 
     ValueType
-      a_0p, b_p0, c_00 = 0, c_01 = 0, c_02 = 0,
-      a_1p, b_p1, c_10 = 0, c_11 = 0, c_12 = 0,
-      a_2p, b_p2, c_20 = 0, c_21 = 0, c_22 = 0,
-      a_3p,       c_30 = 0, c_31 = 0, c_32 = 0;
+      a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0), c_02 = ValueType(0),
+      a_1p, b_p1, c_10 = ValueType(0), c_11 = ValueType(0), c_12 = ValueType(0),
+      a_2p, b_p2, c_20 = ValueType(0), c_21 = ValueType(0), c_22 = ValueType(0),
+      a_3p,       c_30 = ValueType(0), c_31 = ValueType(0), c_32 = ValueType(0);
 
     const int
       i0 = 0*_as0, i1 = 1*_as0, i2 = 2*_as0, i3 = 3*_as0,
@@ -563,10 +563,10 @@ namespace KokkosBatched {
     if (k <= 0) return 0;
 
     ValueType
-      a_0p, b_p0, c_00 = 0, c_01 = 0, 
-      a_1p, b_p1, c_10 = 0, c_11 = 0, 
-      a_2p,       c_20 = 0, c_21 = 0, 
-      a_3p,       c_30 = 0, c_31 = 0;
+      a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0), 
+      a_1p, b_p1, c_10 = ValueType(0), c_11 = ValueType(0), 
+      a_2p,       c_20 = ValueType(0), c_21 = ValueType(0), 
+      a_3p,       c_30 = ValueType(0), c_31 = ValueType(0);
 
     const int
       i0 = 0*_as0, i1 = 1*_as0, i2 = 2*_as0, i3 = 3*_as0,
@@ -610,10 +610,10 @@ namespace KokkosBatched {
     if (k <= 0) return 0;
 
     ValueType
-      a_0p, b_p0, c_00 = 0,
-      a_1p,       c_10 = 0,
-      a_2p,       c_20 = 0,
-      a_3p,       c_30 = 0;
+      a_0p, b_p0, c_00 = ValueType(0),
+      a_1p,       c_10 = ValueType(0),
+      a_2p,       c_20 = ValueType(0),
+      a_3p,       c_30 = ValueType(0);
 
     const int
       i0 = 0*_as0, i1 = 1*_as0, i2 = 2*_as0, i3 = 3*_as0,
@@ -657,9 +657,9 @@ namespace KokkosBatched {
     if (k <= 0) return 0;
 
     ValueType
-      a_0p, b_p0, c_00 = 0, c_01 = 0, c_02 = 0, c_03 = 0,
-      a_1p, b_p1, c_10 = 0, c_11 = 0, c_12 = 0, c_13 = 0,
-      a_2p, b_p2, c_20 = 0, c_21 = 0, c_22 = 0, c_23 = 0,
+      a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0), c_02 = ValueType(0), c_03 = ValueType(0),
+      a_1p, b_p1, c_10 = ValueType(0), c_11 = ValueType(0), c_12 = ValueType(0), c_13 = ValueType(0),
+      a_2p, b_p2, c_20 = ValueType(0), c_21 = ValueType(0), c_22 = ValueType(0), c_23 = ValueType(0),
       /**/  b_p3;
 
     const int
@@ -702,8 +702,8 @@ namespace KokkosBatched {
     if (k <= 0) return 0;
 
     ValueType
-      a_0p, b_p0, c_00 = 0, c_01 = 0, c_02 = 0, c_03 = 0,
-      a_1p, b_p1, c_10 = 0, c_11 = 0, c_12 = 0, c_13 = 0,
+      a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0), c_02 = ValueType(0), c_03 = ValueType(0),
+      a_1p, b_p1, c_10 = ValueType(0), c_11 = ValueType(0), c_12 = ValueType(0), c_13 = ValueType(0),
       /**/  b_p2, 
       /**/  b_p3;
 
@@ -745,7 +745,7 @@ namespace KokkosBatched {
     if (k <= 0) return 0;
 
     ValueType
-      a_0p, b_p0, c_00 = 0, c_01 = 0, c_02 = 0, c_03 = 0,
+      a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0), c_02 = ValueType(0), c_03 = ValueType(0),
       /**/  b_p1, 
       /**/  b_p2, 
       /**/  b_p3; 
@@ -790,9 +790,9 @@ namespace KokkosBatched {
     if (k <= 0) return 0;
 
     ValueType
-      a_0p, b_p0, c_00 = 0, c_01 = 0, c_02 = 0,
-      a_1p, b_p1, c_10 = 0, c_11 = 0, c_12 = 0,
-      a_2p, b_p2, c_20 = 0, c_21 = 0, c_22 = 0;
+      a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0), c_02 = ValueType(0),
+      a_1p, b_p1, c_10 = ValueType(0), c_11 = ValueType(0), c_12 = ValueType(0),
+      a_2p, b_p2, c_20 = ValueType(0), c_21 = ValueType(0), c_22 = ValueType(0);
 
     const int
       i0 = 0*_as0, i1 = 1*_as0, i2 = 2*_as0,
@@ -833,9 +833,9 @@ namespace KokkosBatched {
     if (k <= 0) return 0;
 
     ValueType
-      a_0p, b_p0, c_00 = 0, c_01 = 0, 
-      a_1p, b_p1, c_10 = 0, c_11 = 0, 
-      a_2p,       c_20 = 0, c_21 = 0;
+      a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0), 
+      a_1p, b_p1, c_10 = ValueType(0), c_11 = ValueType(0), 
+      a_2p,       c_20 = ValueType(0), c_21 = ValueType(0);
 
     const int
       i0 = 0*_as0, i1 = 1*_as0, i2 = 2*_as0,
@@ -876,9 +876,9 @@ namespace KokkosBatched {
     if (k <= 0) return 0;
 
     ValueType
-      a_0p, b_p0, c_00 = 0, 
-      a_1p,       c_10 = 0, 
-      a_2p,       c_20 = 0;
+      a_0p, b_p0, c_00 = ValueType(0), 
+      a_1p,       c_10 = ValueType(0), 
+      a_2p,       c_20 = ValueType(0);
 
     const int
       i0 = 0*_as0, i1 = 1*_as0, i2 = 2*_as0,
@@ -919,8 +919,8 @@ namespace KokkosBatched {
     if (k <= 0) return 0;
 
     ValueType
-      a_0p, b_p0, c_00 = 0, c_01 = 0, c_02 = 0,
-      a_1p, b_p1, c_10 = 0, c_11 = 0, c_12 = 0,
+      a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0), c_02 = ValueType(0),
+      a_1p, b_p1, c_10 = ValueType(0), c_11 = ValueType(0), c_12 = ValueType(0),
       /**/  b_p2;
 
     const int
@@ -959,7 +959,7 @@ namespace KokkosBatched {
     if (k <= 0) return 0;
 
     ValueType
-      a_0p, b_p0, c_00 = 0, c_01 = 0, c_02 = 0,
+      a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0), c_02 = ValueType(0),
       /**/  b_p1, 
       /**/  b_p2; 
 
@@ -1002,8 +1002,8 @@ namespace KokkosBatched {
     if (k <= 0) return 0;
 
     ValueType
-      a_0p, b_p0, c_00 = 0, c_01 = 0,
-      a_1p, b_p1, c_10 = 0, c_11 = 0;
+      a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0),
+      a_1p, b_p1, c_10 = ValueType(0), c_11 = ValueType(0);
 
     const int
       i0 = 0*_as0, i1 = 1*_as0,
@@ -1041,8 +1041,8 @@ namespace KokkosBatched {
     if (k <= 0) return 0;
 
     ValueType
-      a_0p, b_p0, c_00 = 0,
-      a_1p,       c_10 = 0;
+      a_0p, b_p0, c_00 = ValueType(0),
+      a_1p,       c_10 = ValueType(0);
 
     const int
       i0 = 0*_as0, i1 = 1*_as0,
@@ -1080,7 +1080,7 @@ namespace KokkosBatched {
     if (k <= 0) return 0;
 
     ValueType
-      a_0p, b_p0, c_00 = 0, c_01 = 0,
+      a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0),
       /**/  b_p1;
     const int
       i0 = 0*_as0, 
@@ -1120,7 +1120,7 @@ namespace KokkosBatched {
     if (k <= 0) return 0;
 
     ValueType
-      a_0p, b_p0, c_00 = 0;
+      a_0p, b_p0, c_00 = ValueType(0);
 
     const int
       i0 = 0*_as0,

--- a/unit_test/batched/Test_Batched_SerialGemm.hpp
+++ b/unit_test/batched/Test_Batched_SerialGemm.hpp
@@ -83,7 +83,8 @@ template<typename DeviceType,
     using ats = Kokkos::Details::ArithTraits<host_value_type>;
 
     /// randomized input testing views
-    ScalarType alpha = 1.5, beta = 3.0;
+    ScalarType alpha = ScalarType(1.5);
+    ScalarType beta = ScalarType(3.0);
 
     ViewType
       a_expected("a_expected", N, matAdim1, matAdim2), a1("a1", N, matAdim1, matAdim2),

--- a/unit_test/batched/Test_Batched_TeamGemm.hpp
+++ b/unit_test/batched/Test_Batched_TeamGemm.hpp
@@ -147,7 +147,7 @@ namespace Test {
     using ats = Kokkos::Details::ArithTraits<host_value_type>;
 
     /// randomized input testing views
-    ScalarType alpha = 1.5, beta = 3.0;
+    ScalarType alpha = ScalarType(1.5), beta = ScalarType(3.0);
 
     ViewType
       a_expected("a_expected", N, matAdim1, matAdim2), a1("a1", N, matAdim1, matAdim2),

--- a/unit_test/batched/Test_Batched_TeamVectorGemm.hpp
+++ b/unit_test/batched/Test_Batched_TeamVectorGemm.hpp
@@ -142,7 +142,7 @@ namespace Test {
     using ats = Kokkos::Details::ArithTraits<host_value_type>;
 
     /// randomized input testing views
-    ScalarType alpha = 1.5, beta = 3.0;
+    ScalarType alpha = ScalarType(1.5), beta = ScalarType(3.0);
 
     ViewType
       a_expected("a_expected", N, matAdim1, matAdim2), a1("a1", N, matAdim1, matAdim2),


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos/pull/3593

It was decided to remove implicit conversions from half_t -> T to prevent implicit downcasting to `half_t` in mixed precision expressions.