### PR TITLE
Add permanent RCM reordering interface, and a basic serial implementation

### DIFF
--- a/example/wiki/graph/CMakeLists.txt
+++ b/example/wiki/graph/CMakeLists.txt
@@ -18,3 +18,8 @@ KOKKOSKERNELS_ADD_EXECUTABLE_AND_TEST(
   SOURCES KokkosGraph_wiki_coarsening.cpp
   )
 
+KOKKOSKERNELS_ADD_EXECUTABLE_AND_TEST(
+  wiki_rcm
+  SOURCES KokkosGraph_wiki_rcm.cpp
+  )
+

--- a/example/wiki/graph/KokkosGraph_wiki_9pt_stencil.hpp
+++ b/example/wiki/graph/KokkosGraph_wiki_9pt_stencil.hpp
@@ -23,9 +23,16 @@ using Handle  = KokkosKernels::Experimental::
 
 namespace GraphDemo
 {
-  constexpr Ordinal gridX = 15;
-  constexpr Ordinal gridY = 25;
-  constexpr Ordinal numVertices = gridX * gridY;
+  Ordinal gridX = 15;
+  Ordinal gridY = 25;
+  Ordinal numVertices = gridX * gridY;
+
+  void setGridDimensions(Ordinal newX, Ordinal newY)
+  {
+    gridX = newX;
+    gridY = newY;
+    numVertices = gridX * gridY;
+  }
 
   //Helper to get the vertex ID given grid coordinates
   Ordinal getVertexID(Ordinal x, Ordinal y)

--- a/example/wiki/graph/KokkosGraph_wiki_rcm.cpp
+++ b/example/wiki/graph/KokkosGraph_wiki_rcm.cpp
@@ -25,7 +25,7 @@ void printReorderedMatrix(const rowmap_t& rowmapIn, const entries_t& entriesIn, 
       neighbors.push_back(nei);
     }
     std::sort(neighbors.begin(), neighbors.end());
-    lno_t it = 0;
+    size_t it = 0;
     for(lno_t j = 0; j < numVerts; j++)
     {
       if(it < neighbors.size() && j == neighbors[it])

--- a/example/wiki/graph/KokkosGraph_wiki_rcm.cpp
+++ b/example/wiki/graph/KokkosGraph_wiki_rcm.cpp
@@ -1,0 +1,68 @@
+#include "KokkosGraph_wiki_9pt_stencil.hpp"
+#include "KokkosGraph_RCM.hpp"
+
+template<typename rowmap_t, typename entries_t, typename labels_t>
+void printReorderedMatrix(const rowmap_t& rowmapIn, const entries_t& entriesIn, const labels_t& invPermIn)
+{
+  using size_type = typename rowmap_t::non_const_value_type;
+  using lno_t = typename entries_t::non_const_value_type;
+  auto rowmap = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), rowmapIn);
+  auto entries = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), entriesIn);
+  auto invPerm = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), invPermIn);
+  lno_t numVerts = rowmap.extent(0) - 1;
+  decltype(invPerm) perm(Kokkos::ViewAllocateWithoutInitializing("Perm"), numVerts);
+  for(lno_t i = 0; i < numVerts; i++)
+    perm(invPerm(i)) = i;
+  std::vector<lno_t> neighbors;
+  for(lno_t i = 0; i < numVerts; i++)
+  {
+    lno_t origRow = perm(i);
+    neighbors.clear();
+    for(size_type j = rowmap(origRow); j < rowmap(origRow + 1); j++)
+    {
+      lno_t origNei = entries(j);
+      lno_t nei = invPerm(origNei);
+      neighbors.push_back(nei);
+    }
+    std::sort(neighbors.begin(), neighbors.end());
+    lno_t it = 0;
+    for(lno_t j = 0; j < numVerts; j++)
+    {
+      if(it < neighbors.size() && j == neighbors[it])
+      {
+        std::cout << '*';
+        it++;
+      }
+      else
+        std::cout << ' ';
+    }
+    std::cout << '\n';
+  }
+  std::cout << '\n';
+}
+
+
+int main(int argc, char* argv[])
+{
+  Kokkos::initialize();
+  {
+    using GraphDemo::numVertices;
+    GraphDemo::setGridDimensions(6, 6);
+    RowmapType rowmapDevice;
+    ColindsType colindsDevice;
+    //Make the graph smaller so the matrix can be printed easily
+    //Step 1: Generate the graph on host, allocate space on device, and copy.
+    //See function "generate9pt" below.
+    GraphDemo::generate9pt(rowmapDevice, colindsDevice);
+    //Step 2: Run RCM and print the reordered matrix
+    {
+      auto rcmDevice = KokkosGraph::Experimental::graph_rcm<ExecSpace, RowmapType, ColindsType>(
+          rowmapDevice, colindsDevice);
+      std::cout << "Graph reordered by reverse Cuthill-McKee:\n";
+      printReorderedMatrix(rowmapDevice, colindsDevice, rcmDevice);
+    }
+  }
+  Kokkos::finalize();
+  return 0;
+}
+

--- a/src/graph/KokkosGraph_RCM.hpp
+++ b/src/graph/KokkosGraph_RCM.hpp
@@ -69,8 +69,8 @@ graph_rcm(const rowmap_t& rowmap, const colinds_t& colinds)
       numVerts--;
     return labels_t("RCM Labels", numVerts);
   }
-  Impl::SerialBFS<rowmap_t, colinds_t, labels_t> bfs(rowmap, colinds);
-  return bfs.rcm();
+  Impl::SerialRCM<rowmap_t, colinds_t, labels_t> algo(rowmap, colinds);
+  return algo.rcm();
 }
 
 }}  //namespace KokkosGraph::Experimental

--- a/src/graph/KokkosGraph_RCM.hpp
+++ b/src/graph/KokkosGraph_RCM.hpp
@@ -1,0 +1,78 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Brian Kelley (bmkelle@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef _KOKKOSGRAPH_RCM_HPP
+#define _KOKKOSGRAPH_RCM_HPP
+
+#include "KokkosGraph_BFS_impl.hpp"
+
+namespace KokkosGraph
+{
+namespace Experimental
+{
+
+//Compute the reverse Cuthill-McKee ordering of a graph.
+//The graph must be symmetric, but it may have any number of connected components.
+//This function returns a list of vertices in RCM order.
+
+template <typename device_t, typename rowmap_t, typename colinds_t, typename labels_t = typename colinds_t::non_const_type>
+labels_t
+graph_rcm(const rowmap_t& rowmap, const colinds_t& colinds)
+{
+  using lno_t = typename colinds_t::non_const_value_type;
+  if(rowmap.extent(0) <= 2)
+  {
+    //there are 0 or 1 vertices - return trivial ordering
+    lno_t numVerts = rowmap.extent(0);
+    if(numVerts)
+      numVerts--;
+    return labels_t("RCM Labels", numVerts);
+  }
+  Impl::SerialBFS<rowmap_t, colinds_t, labels_t> bfs(rowmap, colinds);
+  return bfs.rcm();
+}
+
+}}  //namespace KokkosGraph::Experimental
+
+#endif

--- a/src/graph/impl/KokkosGraph_BFS_impl.hpp
+++ b/src/graph/impl/KokkosGraph_BFS_impl.hpp
@@ -55,7 +55,7 @@ namespace Experimental {
 namespace Impl {
 
 template<typename rowmap_t, typename entries_t, typename lno_view_t>
-struct SerialBFS
+struct SerialRCM
 {
   using size_type = typename rowmap_t::non_const_value_type;
   using lno_t = typename entries_t::non_const_value_type;
@@ -67,7 +67,7 @@ struct SerialBFS
   host_rowmap_t rowmap;
   host_lno_view_t entries;
 
-  SerialBFS(const rowmap_t& rowmap_, const entries_t& entries_) :
+  SerialRCM(const rowmap_t& rowmap_, const entries_t& entries_) :
     numVerts(rowmap_.extent(0) - 1),
     rowmap(Kokkos::ViewAllocateWithoutInitializing("HostRowmap"), rowmap_.extent(0)),
     entries(Kokkos::ViewAllocateWithoutInitializing("HostEntries"), entries_.extent(0))

--- a/src/graph/impl/KokkosGraph_BFS_impl.hpp
+++ b/src/graph/impl/KokkosGraph_BFS_impl.hpp
@@ -1,0 +1,159 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Brian Kelley (bmkelle@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef _KOKKOSGRAPH_BFS_IMPL_HPP
+#define _KOKKOSGRAPH_BFS_IMPL_HPP
+
+#include "Kokkos_Core.hpp"
+#include "KokkosKernels_Utils.hpp"
+#include <vector>
+#include <algorithm>
+
+namespace KokkosGraph {
+namespace Experimental {
+namespace Impl {
+
+template<typename rowmap_t, typename entries_t, typename lno_view_t>
+struct SerialBFS
+{
+  using size_type = typename rowmap_t::non_const_value_type;
+  using lno_t = typename entries_t::non_const_value_type;
+  using host_rowmap_t = Kokkos::View<size_type*, Kokkos::HostSpace>;
+  using host_lno_view_t = Kokkos::View<lno_t*, Kokkos::HostSpace>;
+  using host_lno_2D_view_t = Kokkos::View<lno_t**, Kokkos::LayoutLeft, Kokkos::HostSpace>;
+
+  lno_t numVerts;
+  host_rowmap_t rowmap;
+  host_lno_view_t entries;
+
+  SerialBFS(const rowmap_t& rowmap_, const entries_t& entries_) :
+    numVerts(rowmap_.extent(0) - 1),
+    rowmap(Kokkos::ViewAllocateWithoutInitializing("HostRowmap"), rowmap_.extent(0)),
+    entries(Kokkos::ViewAllocateWithoutInitializing("HostEntries"), entries_.extent(0))
+  {
+    Kokkos::deep_copy(rowmap, rowmap_);
+    Kokkos::deep_copy(entries, entries_);
+  }
+
+  lno_t findPseudoPeripheral()
+  {
+    //Choose vertex with smallest degree
+    lno_t periph = -1;
+    lno_t periphDeg = numVerts;
+    for(lno_t i = 0; i < numVerts; i++)
+    {
+      lno_t deg = rowmap(i + 1) - rowmap(i);
+      if(deg < periphDeg)
+      {
+        periph = i;
+        periphDeg = deg;
+      }
+    }
+    return periph;
+  }
+
+  lno_view_t rcm()
+  {
+    lno_t start = findPseudoPeripheral();
+    host_lno_view_t q(Kokkos::ViewAllocateWithoutInitializing("Queue"), numVerts);
+    host_lno_view_t label(Kokkos::ViewAllocateWithoutInitializing("Permutation"), numVerts);
+    for(lno_t i = 0; i < numVerts; i++)
+      label(i) = -1;
+    lno_t qhead = 0;
+    lno_t qtail = 0;
+    label(start) = qtail;
+    q(qtail++) = start;
+    std::vector<lno_t> neighbors;
+    lno_t outerQueue = 0;
+    while(true)
+    {
+      lno_t v = q(qhead++);
+      neighbors.clear();
+      for(size_type j = rowmap(v); j < rowmap(v + 1); j++)
+      {
+        lno_t nei = entries(j);
+        if(nei == v || nei >= numVerts)
+          continue;
+        if(label(nei) == -1)
+        {
+          neighbors.push_back(nei);
+        }
+      }
+      std::sort(neighbors.begin(), neighbors.end(),
+      [&](lno_t n1, lno_t n2) -> bool
+      {
+        //return true of n1 has a lower degree than n2
+        return (rowmap(n1 + 1) - rowmap(n1)) < (rowmap(n2 + 1) - rowmap(n2));
+      });
+      //label and enqueue all unlabeled neighbors
+      for(lno_t nei : neighbors)
+      {
+        label(nei) = qtail;
+        q(qtail++) = nei;
+      }
+      if(qtail == numVerts)
+      {
+        //have labeled all vertices
+        break;
+      }
+      else if(qhead == qtail)
+      {
+        //have exhausted this connected component, but others remain unlabeled
+        while(label(outerQueue) != -1)
+          outerQueue++;
+        label(outerQueue) = qtail;
+        q(qtail++) = outerQueue;
+      }
+    }
+    lno_view_t labelOut(Kokkos::ViewAllocateWithoutInitializing("RCM Permutation"), numVerts);
+    //reverse the labels
+    for(lno_t i = 0; i < numVerts; i++)
+      label(i) = numVerts - label(i) - 1;
+    Kokkos::deep_copy(labelOut, label);
+    return labelOut;
+  }
+};
+
+}}} //namespace KokkosGraph::Experimental::Impl
+#endif

--- a/src/graph/impl/KokkosGraph_BFS_impl.hpp
+++ b/src/graph/impl/KokkosGraph_BFS_impl.hpp
@@ -87,6 +87,8 @@ struct SerialRCM
       {
         periph = i;
         periphDeg = deg;
+        if(deg == 0)
+          break;
       }
     }
     return periph;

--- a/src/graph/impl/KokkosGraph_BFS_impl.hpp
+++ b/src/graph/impl/KokkosGraph_BFS_impl.hpp
@@ -61,7 +61,6 @@ struct SerialRCM
   using lno_t = typename entries_t::non_const_value_type;
   using host_rowmap_t = Kokkos::View<size_type*, Kokkos::HostSpace>;
   using host_lno_view_t = Kokkos::View<lno_t*, Kokkos::HostSpace>;
-  using host_lno_2D_view_t = Kokkos::View<lno_t**, Kokkos::LayoutLeft, Kokkos::HostSpace>;
 
   lno_t numVerts;
   host_rowmap_t rowmap;
@@ -123,7 +122,7 @@ struct SerialRCM
       std::sort(neighbors.begin(), neighbors.end(),
       [&](lno_t n1, lno_t n2) -> bool
       {
-        //return true of n1 has a lower degree than n2
+        //return true if n1 has a lower degree than n2
         return (rowmap(n1 + 1) - rowmap(n1)) < (rowmap(n2 + 1) - rowmap(n2));
       });
       //label and enqueue all unlabeled neighbors

--- a/unit_test/cuda/Test_Cuda_Graph_rcm.cpp
+++ b/unit_test/cuda/Test_Cuda_Graph_rcm.cpp
@@ -1,0 +1,2 @@
+#include<Test_Cuda.hpp>
+#include<Test_Graph_rcm.hpp>

--- a/unit_test/graph/Test_Graph_rcm.hpp
+++ b/unit_test/graph/Test_Graph_rcm.hpp
@@ -1,0 +1,197 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+
+#include "KokkosGraph_RCM.hpp"
+#include "KokkosKernels_IOUtils.hpp"
+#include "KokkosSparse_CrsMatrix.hpp"
+
+#include <vector>
+
+//Generates a graph from 3D 7-pt stencil. Slices grid into 2 connected components near the middle of X dimension.
+template<typename rowmap_t, typename entries_t>
+void generate7pt(rowmap_t& rowmapView, entries_t& entriesView, int gridX, int gridY, int gridZ)
+{
+  using size_type = typename rowmap_t::non_const_value_type;
+  using lno_t = typename entries_t::non_const_value_type;
+  auto getVertexID =
+  [=](lno_t x, lno_t y, lno_t z) -> lno_t
+  {
+    return x + y * gridX + z * gridX * gridY;
+  };
+  lno_t numVertices = gridX * gridY * gridZ;
+  //Generate the graph on host (use std::vector to not need to know
+  //how many entries ahead of time)
+  std::vector<size_type> rowmap(numVertices + 1);
+  std::vector<lno_t> entries;
+  rowmap[0] = 0;
+  lno_t xslice = gridX / 2;
+  for(lno_t k = 0; k < gridZ; k++)
+  {
+    for(lno_t j = 0; j < gridY; j++)
+    {
+      for(lno_t i = 0; i < gridX; i++)
+      {
+        lno_t v = getVertexID(i, j, k);
+        if(i != 0 && i != xslice + 1)
+          entries.push_back(getVertexID(i - 1, j, k));
+        if(i != gridX - 1 && i != xslice)
+          entries.push_back(getVertexID(i + 1, j, k));
+        if(j != 0)
+          entries.push_back(getVertexID(i, j - 1, k));
+        if(j != gridY - 1)
+          entries.push_back(getVertexID(i, j + 1, k));
+        if(k != 0)
+          entries.push_back(getVertexID(i, j, k - 1));
+        if(k != gridZ - 1)
+          entries.push_back(getVertexID(i, j, k + 1));
+        rowmap[v + 1] = entries.size();
+      }
+    }
+  }
+  size_type numEdges = entries.size();
+  //Now that the graph is formed, copy rowmap and entries to Kokkos::Views in device memory
+  //The nonowning host views just alias the std::vectors.
+  Kokkos::View<size_type*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> rowmapHost(rowmap.data(), numVertices + 1);
+  Kokkos::View<lno_t*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> entriesHost(entries.data(), numEdges);
+  //Allocate owning views on device with the correct size.
+  rowmapView = rowmap_t(Kokkos::ViewAllocateWithoutInitializing("Rowmap"), numVertices + 1);
+  entriesView = entries_t(Kokkos::ViewAllocateWithoutInitializing("Colinds"), numEdges);
+  //Copy the graph from host to device
+  Kokkos::deep_copy(rowmapView, rowmapHost);
+  Kokkos::deep_copy(entriesView, entriesHost);
+}
+
+template<typename rowmap_t, typename entries_t, typename labels_t>
+int maxBandwidth(const rowmap_t& rowmap, const entries_t& entries, const labels_t& invPerm, const labels_t& perm)
+{
+  using size_type = typename rowmap_t::non_const_value_type;
+  using lno_t = typename entries_t::non_const_value_type;
+  lno_t numVerts = rowmap.extent(0) - 1;
+  int bw = 0;
+  for(lno_t i = 0; i < numVerts; i++)
+  {
+    lno_t origRow = perm(i);
+    for(size_type j = rowmap(origRow); j < rowmap(origRow + 1); j++)
+    {
+      lno_t origNei = entries(j);
+      lno_t nei = invPerm(origNei);
+      if(nei > i)
+      {
+        lno_t thisBW = nei - i;
+        if(thisBW > bw)
+          bw = thisBW;
+      }
+    }
+  }
+  return bw;
+}
+
+template <typename lno_t, typename size_type, typename device>
+void test_rcm(lno_t gridX, lno_t gridY, lno_t gridZ)
+{
+  typedef typename KokkosSparse::CrsMatrix<double, lno_t, device, void, size_type> crsMat_t;
+  typedef typename crsMat_t::StaticCrsGraphType graph_t;
+  typedef typename graph_t::row_map_type rowmap_t;
+  typedef typename graph_t::entries_type entries_t; 
+  lno_t numVerts = gridX * gridY * gridZ;
+  typename rowmap_t::non_const_type rowmap;
+  typename entries_t::non_const_type entries;
+  generate7pt(rowmap, entries, gridX, gridY, gridZ);
+  auto rcm = KokkosGraph::Experimental::graph_rcm<device, rowmap_t, entries_t>(rowmap, entries);
+  auto rowmapHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), rowmap);
+  auto entriesHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), entries);
+  auto rcmHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), rcm);
+  decltype(rcmHost) rcmPermHost(Kokkos::ViewAllocateWithoutInitializing("RCMPerm"), numVerts);
+  for(lno_t i = 0; i < numVerts; i++)
+    rcmPermHost(rcmHost(i)) = i;
+  //make sure each row index shows up exactly once
+  {
+    std::vector<int> counts(numVerts);
+    for(lno_t i = 0; i < numVerts; i++)
+    {
+      lno_t orig = rcmHost(i);
+      ASSERT_GE(orig, 0);
+      ASSERT_LT(orig, numVerts);
+      counts[orig]++;
+    }
+    for(lno_t i = 0; i < numVerts; i++)
+      ASSERT_EQ(counts[i], 1);
+  }
+  Kokkos::View<lno_t*, Kokkos::HostSpace> identityOrder(Kokkos::ViewAllocateWithoutInitializing("Identity"), numVerts);
+  for(lno_t i = 0; i < numVerts; i++)
+    identityOrder(i) = i;
+  size_t origBW = maxBandwidth(rowmapHost, entriesHost, identityOrder, identityOrder);
+  size_t rcmBW = maxBandwidth(rowmapHost, entriesHost, rcmHost, rcmPermHost);
+  EXPECT_LE(rcmBW, origBW);
+}
+
+#define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE) \
+TEST_F( TestCategory, graph ## _ ## rcm ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
+  test_rcm<ORDINAL,OFFSET,DEVICE>(6, 3, 3); \
+  test_rcm<ORDINAL,OFFSET,DEVICE>(20, 20, 20); \
+  test_rcm<ORDINAL,OFFSET,DEVICE>(100, 100, 1); \
+}
+
+#if (defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_INT) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(double, int, int, TestExecSpace)
+#endif
+
+#if (defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_INT) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(double, int64_t, int, TestExecSpace)
+#endif
+
+#if (defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(double, int, size_t, TestExecSpace)
+#endif
+
+#if (defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
+ && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T) ) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+ EXECUTE_TEST(double, int64_t, size_t, TestExecSpace)
+#endif

--- a/unit_test/hip/Test_HIP_Graph_rcm.cpp
+++ b/unit_test/hip/Test_HIP_Graph_rcm.cpp
@@ -1,0 +1,2 @@
+#include<Test_HIP.hpp>
+#include<Test_Graph_rcm.hpp>

--- a/unit_test/openmp/Test_OpenMP_Graph_rcm.cpp
+++ b/unit_test/openmp/Test_OpenMP_Graph_rcm.cpp
@@ -1,0 +1,2 @@
+#include<Test_OpenMP.hpp>
+#include<Test_Graph_rcm.hpp>

--- a/unit_test/serial/Test_Serial_Graph_rcm.cpp
+++ b/unit_test/serial/Test_Serial_Graph_rcm.cpp
@@ -1,0 +1,2 @@
+#include<Test_Serial.hpp>
+#include<Test_Graph_rcm.hpp>

--- a/unit_test/threads/Test_Threads_Graph_rcm.cpp
+++ b/unit_test/threads/Test_Threads_Graph_rcm.cpp
@@ -1,0 +1,3 @@
+#include<Test_Threads.hpp>
+#include<Test_Graph_rcm.hpp>
+


### PR DESCRIPTION
Add reverse Cuthill-McKee reordering to replace the broken one that I took out of cluster Gauss-Seidel impl. Needed by MueLu.

Has unit test and wiki example.

#######################################################
PASSED TESTS
#######################################################
clang-8.0-Cuda_OpenMP-release build_time=751 run_time=141
clang-8.0-Pthread_Serial-release build_time=241 run_time=133
clang-9.0.0-Pthread-release build_time=153 run_time=62
clang-9.0.0-Serial-release build_time=166 run_time=50
cuda-10.1-Cuda_OpenMP-release build_time=912 run_time=144
cuda-11.0-Cuda_OpenMP-release build_time=930 run_time=143
cuda-9.2-Cuda_Serial-release build_time=881 run_time=229
gcc-7.3.0-OpenMP-release build_time=166 run_time=48
gcc-7.3.0-Pthread-release build_time=135 run_time=62
gcc-8.3.0-Serial-release build_time=166 run_time=53
gcc-9.1-OpenMP-release build_time=212 run_time=48
gcc-9.1-Serial-release build_time=194 run_time=52
intel-17.0.1-Serial-release build_time=396 run_time=54
intel-18.0.5-OpenMP-release build_time=693 run_time=49
intel-19.0.5-Pthread-release build_time=350 run_time=64
