### PR TITLE
Restore distance-1 default algos from 3.2.0

### DIFF
--- a/src/graph/KokkosGraph_Distance1ColorHandle.hpp
+++ b/src/graph/KokkosGraph_Distance1ColorHandle.hpp
@@ -239,15 +239,22 @@ private:
     if(exec == KokkosKernels::Impl::Exec_SERIAL)
     {
       this->coloring_algorithm_type = COLORING_SERIAL;
-#ifdef VERBOSE 
+#ifdef VERBOSE
       std:cout << "Serial Execution Space, Default Algorithm: COLORING_SERIAL\n";
+#endif
+    }
+    else if(KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>())
+    {
+      this->coloring_algorithm_type = COLORING_EB;
+#ifdef VERBOSE
+      std::cout << ExecutionSpace::name() << " Execution Space, Default Algorithm: COLORING_EB\n";
 #endif
     }
     else
     {
-      this->coloring_algorithm_type = COLORING_VBBIT;
-#ifdef VERBOSE 
-      std:cout << ExecutionSpace::name() << " Execution Space, Default Algorithm: COLORING_VBBIT\n";
+      this->coloring_algorithm_type = COLORING_VB;
+#ifdef VERBOSE
+      std::cout << ExecutionSpace::name() << " Execution Space, Default Algorithm: COLORING_VB\n";
 #endif
     }
   }


### PR DESCRIPTION
In PR #828, I changed the default D1 coloring algorithm for CUDA
from EB to VBBIT. Although VBBIT is usually faster for balanced/regular
problems, it is causing an increase in MTGS + GMRES iterations
in some Ifpack2 tests compared to EB. This causes random failures
since the tests expect convergence within a certain number of iters.

This PR puts back the old defaults (SERIAL for Serial, VB for parallel CPU, and EB for GPU).
This fixes the Ifpack2 tests on CUDA. A long term solution could be to let
Ifpack2 Relaxation's parameter list select a coloring algorithm, then EB could be
selected for these tests and VBBIT could be the general default for coloring.