### PR TITLE
Make tpl avail type combinations match tpl decl

### DIFF
--- a/src/impl/tpls/KokkosBlas1_axpby_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosBlas1_axpby_tpl_spec_avail.hpp
@@ -72,18 +72,10 @@ struct axpby_tpl_spec_avail< \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      1>  { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE)
 KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS( double,                  Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT)
 KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS( float,                   Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_)
 KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_)
 KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
 
 #endif
 
@@ -101,18 +93,10 @@ struct axpby_tpl_spec_avail< \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      1>  { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE)
 KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT)
 KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_)
 KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_)
 KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
 
 #endif
 }

--- a/src/impl/tpls/KokkosBlas1_dot_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosBlas1_dot_tpl_spec_avail.hpp
@@ -72,18 +72,10 @@ Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
              Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
 1,1> { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE)
 KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL_BLAS( double,                  Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT)
 KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL_BLAS( float,                   Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_)
 KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_)
 KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
 
 #endif
 
@@ -101,18 +93,10 @@ Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
              Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
 1,1> { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE)
 KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT)
 KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_)
 KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_)
 KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
 
 #endif
 

--- a/src/impl/tpls/KokkosBlas1_iamax_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosBlas1_iamax_tpl_spec_avail.hpp
@@ -70,18 +70,10 @@ Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
              Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
 1> { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_BLAS( unsigned long, double,                  Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_BLAS( unsigned long, float,                   Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_BLAS( unsigned long, Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_BLAS( unsigned long, Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
 
 #endif
 
@@ -104,41 +96,23 @@ Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
              Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
 1> { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_CUBLAS( unsigned long, double,                 Kokkos::LayoutLeft, Kokkos::CudaSpace)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_CUBLAS( unsigned int, double,                  Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_CUBLAS( unsigned long, float,                  Kokkos::LayoutLeft, Kokkos::CudaSpace)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_CUBLAS( unsigned int, float,                   Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_CUBLAS( unsigned long, Kokkos::complex<double>,Kokkos::LayoutLeft, Kokkos::CudaSpace)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_CUBLAS( unsigned int, Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_CUBLAS( unsigned long, Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_CUBLAS( unsigned int, Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
 
-#if defined (KOKKOS_ENABLE_CUDA_UVM)
-#if defined (KOKKOSKERNELS_INST_DOUBLE)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_CUBLAS( unsigned long, double,                 Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_CUBLAS( unsigned int, double,                  Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_CUBLAS( unsigned long, float,                  Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_CUBLAS( unsigned int, float,                   Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_CUBLAS( unsigned long, Kokkos::complex<double>,Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_CUBLAS( unsigned int, Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_CUBLAS( unsigned long, Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
 KOKKOSBLAS1_IAMAX_TPL_SPEC_AVAIL_CUBLAS( unsigned int, Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#endif
 
 #endif
 

--- a/src/impl/tpls/KokkosBlas1_nrm1_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosBlas1_nrm1_tpl_spec_avail.hpp
@@ -70,18 +70,10 @@ Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
              Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
 1> { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE)
 KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_BLAS( double,                  Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT)
 KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_BLAS( float,                   Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_)
 KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_)
 KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
 
 #endif
 
@@ -97,18 +89,10 @@ Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
              Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
 1> { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE)
 KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT)
 KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_)
 KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_)
 KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
 
 #endif
 

--- a/src/impl/tpls/KokkosBlas1_nrm2_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosBlas1_nrm2_tpl_spec_avail.hpp
@@ -57,7 +57,6 @@ struct nrm2_tpl_spec_avail {
 
 namespace KokkosBlas {
 namespace Impl {
-
 // Generic Host side BLAS (could be MKL or whatever)
 #ifdef KOKKOSKERNELS_ENABLE_TPL_BLAS
 // double
@@ -70,18 +69,10 @@ Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
              Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
 1> { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE)
 KOKKOSBLAS1_NRM2_TPL_SPEC_AVAIL_BLAS( double,                  Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT)
 KOKKOSBLAS1_NRM2_TPL_SPEC_AVAIL_BLAS( float,                   Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_)
 KOKKOSBLAS1_NRM2_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_)
 KOKKOSBLAS1_NRM2_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
 
 #endif
 
@@ -97,18 +88,10 @@ Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
              Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
 1> { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE)
 KOKKOSBLAS1_NRM2_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT)
 KOKKOSBLAS1_NRM2_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_)
 KOKKOSBLAS1_NRM2_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_)
 KOKKOSBLAS1_NRM2_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
 
 #endif
 

--- a/src/impl/tpls/KokkosBlas1_nrminf_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosBlas1_nrminf_tpl_spec_avail.hpp
@@ -70,18 +70,10 @@ Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
              Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
 1> { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE)
 KOKKOSBLAS1_NRMINF_TPL_SPEC_AVAIL_BLAS( double,                  Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT)
 KOKKOSBLAS1_NRMINF_TPL_SPEC_AVAIL_BLAS( float,                   Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_)
 KOKKOSBLAS1_NRMINF_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_)
 KOKKOSBLAS1_NRMINF_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
 
 #endif
 
@@ -97,18 +89,10 @@ Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
              Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
 1> { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE)
 KOKKOSBLAS1_NRMINF_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT)
 KOKKOSBLAS1_NRMINF_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_)
 KOKKOSBLAS1_NRMINF_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_)
 KOKKOSBLAS1_NRMINF_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
 
 #endif
 

--- a/src/impl/tpls/KokkosBlas1_scal_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosBlas1_scal_tpl_spec_avail.hpp
@@ -71,18 +71,10 @@ Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
              Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
 1> { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_BLAS( double,                  Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_BLAS( float,                   Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
 
 #endif
 
@@ -99,33 +91,15 @@ Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
              Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
 1> { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
 
-#if defined (KOKKOS_ENABLE_CUDA_UVM)
-#if defined (KOKKOSKERNELS_INST_DOUBLE)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#endif
 
 #endif
 

--- a/src/impl/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
+++ b/src/impl/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
@@ -376,7 +376,6 @@ KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_CUBLAS( Kokkos::LayoutLeft, Kokkos::CudaSpace, f
 KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_CUBLAS( Kokkos::LayoutLeft, Kokkos::CudaSpace, true)
 KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_CUBLAS( Kokkos::LayoutLeft, Kokkos::CudaSpace, false)
 
-#if defined (KOKKOS_ENABLE_CUDA_UVM)
 KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_CUBLAS( Kokkos::LayoutLeft, Kokkos::CudaUVMSpace, true)
 KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_CUBLAS( Kokkos::LayoutLeft, Kokkos::CudaUVMSpace, false)
 
@@ -388,7 +387,6 @@ KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_CUBLAS( Kokkos::LayoutLeft, Kokkos::CudaUVMSpace
 
 KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_CUBLAS( Kokkos::LayoutLeft, Kokkos::CudaUVMSpace, true)
 KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_CUBLAS( Kokkos::LayoutLeft, Kokkos::CudaUVMSpace, false)
-#endif
 
 }
 }

--- a/src/impl/tpls/KokkosBlas2_gemv_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosBlas2_gemv_tpl_spec_avail.hpp
@@ -67,39 +67,15 @@ struct gemv_tpl_spec_avail< \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > \
      >  { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_BLAS( double,                  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_BLAS( float,                   Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_BLAS( double,                  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_BLAS( float,                   Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<double>, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::HostSpace)
-#endif
 
 #endif
 
@@ -117,39 +93,15 @@ struct gemv_tpl_spec_avail< \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > \
      >  { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
-#endif
 
 #endif
 }

--- a/src/impl/tpls/KokkosBlas3_gemm_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosBlas3_gemm_tpl_spec_avail.hpp
@@ -67,39 +67,15 @@ struct gemm_tpl_spec_avail< \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > \
      >  { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_BLAS( double,                  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_BLAS( float,                   Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_BLAS( double,                  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_BLAS( float,                   Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<double>, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::HostSpace)
-#endif
 
 #endif
 
@@ -117,47 +93,23 @@ struct gemm_tpl_spec_avail< \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > \
      >  { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
  KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
 
 #endif
 }

--- a/src/impl/tpls/KokkosBlas3_trmm_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosBlas3_trmm_tpl_spec_avail.hpp
@@ -66,39 +66,15 @@ struct trmm_tpl_spec_avail< \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > \
      >  { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_BLAS( double,                  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_BLAS( float,                   Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_BLAS( double,                  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_BLAS( float,                   Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<double>, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::HostSpace)
-#endif
 
 #endif // KOKKOSKERNELS_ENABLE_TPL_BLAS
 
@@ -114,47 +90,23 @@ struct trmm_tpl_spec_avail< \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > \
      >  { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
  KOKKOSBLAS3_TRMM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
 
 #endif // KOKKOSKERNELS_ENABLE_TPL_CUBLAS
 } // namespace Impl

--- a/src/impl/tpls/KokkosBlas3_trsm_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosBlas3_trsm_tpl_spec_avail.hpp
@@ -66,39 +66,15 @@ struct trsm_tpl_spec_avail< \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > \
      >  { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_BLAS( double,                  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_BLAS( float,                   Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_BLAS( double,                  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_BLAS( float,                   Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<double>, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::HostSpace)
-#endif
 
 #endif
 
@@ -114,47 +90,23 @@ struct trsm_tpl_spec_avail< \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > \
      >  { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
  KOKKOSBLAS3_TRSM_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
 
 #endif
 }

--- a/src/impl/tpls/KokkosBlas_gesv_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosBlas_gesv_tpl_spec_avail.hpp
@@ -66,22 +66,10 @@ struct gesv_tpl_spec_avail< \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > \
      >  { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS_GESV_TPL_SPEC_AVAIL_BLAS( double,                  Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS_GESV_TPL_SPEC_AVAIL_BLAS( float,                   Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS_GESV_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS_GESV_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::HostSpace)
-#endif
 /*
 #if defined (KOKKOSKERNELS_INST_DOUBLE) \
  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
@@ -114,22 +102,10 @@ struct gesv_tpl_spec_avail< \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > \
      >  { enum : bool { value = true }; };
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS_GESV_TPL_SPEC_AVAIL_MAGMA( double,                  Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS_GESV_TPL_SPEC_AVAIL_MAGMA( float,                   Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS_GESV_TPL_SPEC_AVAIL_MAGMA( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS_GESV_TPL_SPEC_AVAIL_MAGMA( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
 
 /*
 #if defined (KOKKOSKERNELS_INST_DOUBLE) \

--- a/src/impl/tpls/KokkosBlas_trtri_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosBlas_trtri_tpl_spec_avail.hpp
@@ -78,55 +78,31 @@ KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL(SCALAR, LAYOUTA, MEMSPACE)
 #define KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_MAGMA( SCALAR , LAYOUTA, MEMSPACE )
 #endif // KOKKOSKERNELS_ENABLE_TPL_MAGMA
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_BLAS( double,                  Kokkos::LayoutLeft, Kokkos::HostSpace) 
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_MAGMA( double,                  Kokkos::LayoutLeft, Kokkos::CudaSpace)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_MAGMA( double,                  Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_BLAS( float,                   Kokkos::LayoutLeft, Kokkos::HostSpace)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_MAGMA( float,                   Kokkos::LayoutLeft, Kokkos::CudaSpace)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_MAGMA( float,                   Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HostSpace)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_MAGMA( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_MAGMA( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTLEFT)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::HostSpace)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_MAGMA( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::CudaSpace)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_MAGMA( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
 
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_BLAS( double,                  Kokkos::LayoutRight, Kokkos::HostSpace)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_MAGMA( double,                  Kokkos::LayoutRight, Kokkos::CudaSpace)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_MAGMA( double,                  Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_BLAS( float,                   Kokkos::LayoutRight, Kokkos::HostSpace)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_MAGMA( float,                   Kokkos::LayoutRight, Kokkos::CudaSpace)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_MAGMA( float,                   Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<double>, Kokkos::LayoutRight, Kokkos::HostSpace)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_MAGMA( Kokkos::complex<double>, Kokkos::LayoutRight, Kokkos::CudaSpace)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_MAGMA( Kokkos::complex<double>, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
- && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutRight, Kokkos::HostSpace)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_MAGMA( Kokkos::complex<float>,  Kokkos::LayoutRight, Kokkos::CudaSpace)
  KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL_MAGMA( Kokkos::complex<float>,  Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
 
 } // namespace Impl
 } // namespace KokkosBlas

--- a/src/impl/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
@@ -71,117 +71,22 @@ struct spmv_tpl_spec_avail<const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::C
 
 #if (9000 <= CUDA_VERSION)
 
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int, int, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int, int, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int, int, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int, int, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
 
 //CUDA_VERSION by itself cannot determine whether the generic cuSPARSE API is available:
 //cuSPARSE version 10.1.105 does not have the generic API, but it comes with the same CUDA_VERSION (10010) as 10.1.243 which does.
@@ -190,117 +95,22 @@ struct spmv_tpl_spec_avail<const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::C
 //Can enable int64/size_t.
 //TODO: if Nvidia ever supports int/size_t, add that too.
 
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int64_t, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int64_t, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int64_t, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int64_t, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int64_t, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int64_t, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_FLOAT) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int64_t, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_DOUBLE) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int64_t, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int64_t, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int64_t, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int64_t, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int64_t, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int64_t, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int64_t, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int64_t, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
-
-#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
-  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
-  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int64_t, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif
 
 #endif  // CUSPARSE >= 10.3 (nested, implies >= 9.0)
 #endif  // CUDA/CUSPARSE >= 9.0?


### PR DESCRIPTION
``*_tpl_spec_decl.hpp`` files instantiate all type combinations allowed by the TPL, even those which are not enabled in KokkosKernels ETI type. ``*_tpl_spec_avail.hpp`` was restricting to ETI type combinations, but they should match what is actually getting instantiated in *_spec__decl.

If a user called with non-ETI types, they would silently get the Kokkos implementation instantiated for them on-demand, even though the TPL wrapper was actually compiled into libkokkoskernels.

Regular checks:
#######################################################
PASSED TESTS
#######################################################
clang-8.0-Cuda_OpenMP-release build_time=736 run_time=113
clang-8.0-Pthread_Serial-release build_time=245 run_time=134
clang-9.0.0-Pthread-release build_time=155 run_time=63
clang-9.0.0-Serial-release build_time=175 run_time=60
cuda-10.1-Cuda_OpenMP-release build_time=919 run_time=113
cuda-11.0-Cuda_OpenMP-release build_time=931 run_time=113
cuda-9.2-Cuda_Serial-release build_time=883 run_time=199
gcc-7.3.0-OpenMP-release build_time=170 run_time=48
gcc-7.3.0-Pthread-release build_time=138 run_time=63
gcc-8.3.0-Serial-release build_time=167 run_time=53
gcc-9.1-OpenMP-release build_time=215 run_time=47
gcc-9.1-Serial-release build_time=204 run_time=62
intel-17.0.1-Serial-release build_time=412 run_time=64
intel-18.0.5-OpenMP-release build_time=706 run_time=50
intel-19.0.5-Pthread-release build_time=371 run_time=64

TPL checks:
#######################################################
PASSED TESTS
#######################################################
clang-8.0-Cuda_OpenMP-release build_time=734 run_time=131
clang-8.0-Pthread_Serial-release build_time=243 run_time=136
clang-9.0.0-Pthread-release build_time=154 run_time=63
clang-9.0.0-Serial-release build_time=170 run_time=51
cuda-10.1-Cuda_OpenMP-release build_time=1977 run_time=120
cuda-11.0-Cuda_OpenMP-release build_time=1973 run_time=119
gcc-7.3.0-OpenMP-release build_time=188 run_time=53
gcc-7.3.0-Pthread-release build_time=143 run_time=64
gcc-8.3.0-Serial-release build_time=167 run_time=53
gcc-9.1-OpenMP-release build_time=213 run_time=49
gcc-9.1-Serial-release build_time=194 run_time=53
intel-17.0.1-Serial-release build_time=404 run_time=54
intel-18.0.5-OpenMP-release build_time=702 run_time=50
intel-19.0.5-Pthread-release build_time=359 run_time=64
