### PR TITLE
Fix >1024 team size error in sort_crs_*

### DIFF
--- a/test_common/Test_Common_Sorting.hpp
+++ b/test_common/Test_Common_Sorting.hpp
@@ -544,7 +544,7 @@ void testBitonicSortLexicographic()
 }
 
 template<typename exec_space>
-void testSortCRS(default_lno_t numRows, default_size_type nnz, bool doValues)
+void testSortCRS(default_lno_t numRows, default_lno_t numCols, default_size_type nnz, bool doValues)
 {
   using scalar_t = default_scalar;
   using lno_t = default_lno_t;
@@ -559,7 +559,7 @@ void testSortCRS(default_lno_t numRows, default_size_type nnz, bool doValues)
   //IMPORTANT: kk_generate_sparse_matrix does not sort the rows, if it did this
   //wouldn't test anything
   crsMat_t A = KokkosKernels::Impl::kk_generate_sparse_matrix<crsMat_t>
-    (numRows, numRows, nnz, 2, numRows / 2);
+    (numRows, numCols, nnz, 2, numCols / 2);
   auto rowmap = A.graph.row_map;
   auto entries = A.graph.entries;
   auto values = A.values;
@@ -774,15 +774,20 @@ TEST_F( TestCategory, common_device_bitonic) {
 }
 
 TEST_F( TestCategory, common_sort_crsgraph) {
-  testSortCRS<TestExecSpace>(10, 20, false);
-  testSortCRS<TestExecSpace>(100, 2000, false);
-  testSortCRS<TestExecSpace>(1000, 30000, false);
+  testSortCRS<TestExecSpace>(10, 10, 20, false);
+  testSortCRS<TestExecSpace>(100, 100, 2000, false);
+  testSortCRS<TestExecSpace>(1000, 1000, 30000, false);
 }
 
 TEST_F( TestCategory, common_sort_crsmatrix) {
-  testSortCRS<TestExecSpace>(10, 20, true);
-  testSortCRS<TestExecSpace>(100, 2000, true);
-  testSortCRS<TestExecSpace>(1000, 30000, true);
+  testSortCRS<TestExecSpace>(10, 10, 20, true);
+  testSortCRS<TestExecSpace>(100, 100, 2000, true);
+  testSortCRS<TestExecSpace>(1000, 1000, 30000, true);
+}
+
+TEST_F( TestCategory, common_sort_crs_longrows) {
+  testSortCRS<TestExecSpace>(1, 50000, 10000, false);
+  testSortCRS<TestExecSpace>(1, 50000, 10000, true);
 }
 
 TEST_F( TestCategory, common_sort_merge_crsmatrix) {


### PR DESCRIPTION
Fixes a bug found by Mike Gilbert on slack.
Also add a test that replicated the issue.

#######################################################
PASSED TESTS
#######################################################
clang-8.0-Cuda_OpenMP-release build_time=730 run_time=142
clang-8.0-Pthread_Serial-release build_time=242 run_time=132
clang-9.0.0-Pthread-release build_time=156 run_time=61
clang-9.0.0-Serial-release build_time=164 run_time=50
cuda-10.1-Cuda_OpenMP-release build_time=911 run_time=144
cuda-11.0-Cuda_OpenMP-release build_time=924 run_time=142
cuda-9.2-Cuda_Serial-release build_time=878 run_time=226
gcc-7.3.0-OpenMP-release build_time=166 run_time=47
gcc-7.3.0-Pthread-release build_time=144 run_time=62
gcc-8.3.0-Serial-release build_time=164 run_time=52
gcc-9.1-OpenMP-release build_time=214 run_time=47
gcc-9.1-Serial-release build_time=193 run_time=51
intel-18.0.5-OpenMP-release build_time=689 run_time=49
intel-19.0.5-Pthread-release build_time=333 run_time=64
#######################################################
FAILED TESTS
#######################################################
intel-17.0.1-Serial-release (build failed)
#######################################################

(The only reason intel 17 failed is it couldn't load the license)