### PR TITLE
Move spmv fallback branch out of TPL layer

### DIFF
--- a/src/sparse/KokkosSparse_spmv.hpp
+++ b/src/sparse/KokkosSparse_spmv.hpp
@@ -151,23 +151,63 @@ spmv (KokkosKernels::Experimental::Controls controls,
       KokkosBlas::scal(y_i, beta, y_i);
     return;
   }
-  Impl::SPMV<
-    typename AMatrix_Internal::value_type,
-    typename AMatrix_Internal::ordinal_type,
-    typename AMatrix_Internal::device_type,
-    typename AMatrix_Internal::memory_traits,
-    typename AMatrix_Internal::size_type,
-    typename XVector_Internal::value_type*,
-    typename XVector_Internal::array_layout,
-    typename XVector_Internal::device_type,
-    typename XVector_Internal::memory_traits,
-    typename YVector_Internal::value_type*,
-    typename YVector_Internal::array_layout,
-    typename YVector_Internal::device_type,
-    typename YVector_Internal::memory_traits>
-      ::spmv (controls, mode, alpha, A_i, x_i, beta, y_i);
-}
 
+  //Whether to call KokkosKernel's native implementation, even if a TPL impl is available
+  bool useFallback = controls.isParameter("algorithm") && controls.getParameter("algorithm") == "native";
+
+#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+  //cuSPARSE does not support the conjugate mode (C), and cuSPARSE 9 only supports the normal (N) mode.
+#if (9000 <= CUDA_VERSION)
+  useFallback = useFallback || (mode[0] != NoTranspose[0]);
+#endif
+#if defined(CUSPARSE_VERSION) && (10300 <= CUSPARSE_VERSION)
+  useFallback = useFallback || (mode[0] == Conjugate[0]);
+#endif
+#endif
+
+  if(useFallback)
+  {
+    //Explicitly call the non-TPL SPMV implementation
+    std::string label = "KokkosSparse::spmv[NATIVE," + Kokkos::ArithTraits<typename AMatrix_Internal::non_const_value_type>::name() + "]";
+    Kokkos::Profiling::pushRegion(label);
+    Impl::SPMV<
+      typename AMatrix_Internal::value_type,
+      typename AMatrix_Internal::ordinal_type,
+      typename AMatrix_Internal::device_type,
+      typename AMatrix_Internal::memory_traits,
+      typename AMatrix_Internal::size_type,
+      typename XVector_Internal::value_type*,
+      typename XVector_Internal::array_layout,
+      typename XVector_Internal::device_type,
+      typename XVector_Internal::memory_traits,
+      typename YVector_Internal::value_type*,
+      typename YVector_Internal::array_layout,
+      typename YVector_Internal::device_type,
+      typename YVector_Internal::memory_traits,
+      false>
+        ::spmv (controls, mode, alpha, A_i, x_i, beta, y_i);
+    Kokkos::Profiling::popRegion();
+  }
+  else
+  {
+    //note: the cuSPARSE spmv wrapper defines a profiling region, so one is not needed here.
+    Impl::SPMV<
+      typename AMatrix_Internal::value_type,
+      typename AMatrix_Internal::ordinal_type,
+      typename AMatrix_Internal::device_type,
+      typename AMatrix_Internal::memory_traits,
+      typename AMatrix_Internal::size_type,
+      typename XVector_Internal::value_type*,
+      typename XVector_Internal::array_layout,
+      typename XVector_Internal::device_type,
+      typename XVector_Internal::memory_traits,
+      typename YVector_Internal::value_type*,
+      typename YVector_Internal::array_layout,
+      typename YVector_Internal::device_type,
+      typename YVector_Internal::memory_traits>
+        ::spmv (controls, mode, alpha, A_i, x_i, beta, y_i);
+  }
+}
 
 template<class AlphaType, class AMatrix, class XVector, class BetaType, class YVector ,
          class XLayout = typename XVector::array_layout>


### PR DESCRIPTION
This was causing the entire native impl to get instantiated once
every time KokkosSparse_spmv.hpp was included.

This fix is also getting patched into the 3.3.1 Kokkos promotion since the code
size was causing a TrilinosCouplings test to run out of device memory.

Intel 17 only failed because it couldn't validate the license. This is with ``--spot-check-tpls --with-scalars=double,complex_double``.

#######################################################
PASSED TESTS
#######################################################
clang-8.0-Cuda_OpenMP-release build_time=736 run_time=144
clang-8.0-Pthread_Serial-release build_time=248 run_time=135
clang-9.0.0-Pthread-release build_time=152 run_time=64
clang-9.0.0-Serial-release build_time=169 run_time=51
cuda-10.1-Cuda_OpenMP-release build_time=969 run_time=153
cuda-11.0-Cuda_OpenMP-release build_time=986 run_time=134
gcc-7.3.0-OpenMP-release build_time=169 run_time=50
gcc-7.3.0-Pthread-release build_time=138 run_time=64
gcc-8.3.0-Serial-release build_time=166 run_time=54
gcc-9.1-OpenMP-release build_time=223 run_time=50
gcc-9.1-Serial-release build_time=195 run_time=53
intel-18.0.5-OpenMP-release build_time=712 run_time=49
intel-19.0.5-Pthread-release build_time=343 run_time=63
#######################################################
FAILED TESTS
#######################################################
intel-17.0.1-Serial-release (build failed)
#######################################################