### PR TITLE
IntelClang guarding __assume_aligned with !defined(__clang__)

### DIFF
--- a/perf_test/sparse/spmv/OpenMPSmartStatic_SPMV.hpp
+++ b/perf_test/sparse/spmv/OpenMPSmartStatic_SPMV.hpp
@@ -138,7 +138,7 @@ void openmp_smart_static_matvec(AType A, XType x, YType y) {
 
   #pragma omp parallel
   {
-#ifdef KOKKOS_COMPILER_INTEL
+#if defined(KOKKOS_COMPILER_INTEL) && !defined(__clang__)
     __assume_aligned(x_ptr, 64);
     __assume_aligned(y_ptr, 64);
 #endif

--- a/src/sparse/impl/KokkosSparse_spmv_impl_omp.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_impl_omp.hpp
@@ -69,7 +69,7 @@ void spmv_raw_openmp_no_transpose(typename YVector::const_value_type& s_a, AMatr
   typename YVector::const_value_type zero = 0;
   #pragma omp parallel
   {
-#ifdef KOKKOS_COMPILER_INTEL
+#if defined(KOKKOS_COMPILER_INTEL) && !defined(__clang__)
     __assume_aligned(x_ptr, 64);
     __assume_aligned(y_ptr, 64);
 #endif


### PR DESCRIPTION
With the new check we are making sure that the IntelClang compilers that do not define this function (icpx/dpc++) are not generating build errors in the OpenMP backend (would likely be a problem for OpenMP Target too since it uses the same compilers).
This fixes an issue in Kokkos Kernels on the iris/yarrow platforms see issue #877 , a more permanent solution will be available with the c++20 standard which defines: `std::assume_aligned<>()`.
This was tested on iris/yarrow, will now run checks on kokkos-dev2.