### PR TITLE
Construct SpGEMM C with correct #cols

### DIFF
--- a/src/sparse/KokkosSparse_spgemm.hpp
+++ b/src/sparse/KokkosSparse_spgemm.hpp
@@ -53,7 +53,6 @@ namespace KokkosSparse {
 template <class KernelHandle, class AMatrix, class BMatrix, class CMatrix>
 void spgemm_symbolic(KernelHandle& kh, const AMatrix& A, const bool Amode,
                      const BMatrix& B, const bool Bmode, CMatrix& C) {
-  using graph_type   = typename CMatrix::staticcrsgraph_type;
   using row_map_type = typename CMatrix::row_map_type::non_const_type;
   using entries_type = typename CMatrix::index_type::non_const_type;
   using values_type  = typename CMatrix::values_type::non_const_type;
@@ -77,8 +76,7 @@ void spgemm_symbolic(KernelHandle& kh, const AMatrix& A, const bool Amode,
                           c_nnz_size);
   }
 
-  graph_type graphC(entriesC, row_mapC);
-  C = CMatrix("matrix", graphC);
+  C = CMatrix("C=AB", A.numRows(), B.numCols(), c_nnz_size, valuesC, row_mapC, entriesC);
 }
 
 template <class KernelHandle, class AMatrix, class BMatrix, class CMatrix>


### PR DESCRIPTION
Fix the number of columns of C in the simplified SpGEMM interface.

```
#######################################################
PASSED TESTS
#######################################################
clang-8.0-Cuda_OpenMP-release build_time=731 run_time=142
clang-8.0-Pthread_Serial-release build_time=246 run_time=132
clang-9.0.0-Pthread-release build_time=157 run_time=61
clang-9.0.0-Serial-release build_time=167 run_time=49
cuda-10.1-Cuda_OpenMP-release build_time=927 run_time=144
cuda-11.0-Cuda_OpenMP-release build_time=938 run_time=144
cuda-9.2-Cuda_Serial-release build_time=896 run_time=225
gcc-7.3.0-OpenMP-release build_time=173 run_time=47
gcc-7.3.0-Pthread-release build_time=144 run_time=62
gcc-8.3.0-Serial-release build_time=172 run_time=53
gcc-9.1-OpenMP-release build_time=222 run_time=48
gcc-9.1-Serial-release build_time=206 run_time=51
intel-17.0.1-Serial-release build_time=411 run_time=55
intel-18.0.5-OpenMP-release build_time=712 run_time=50
intel-19.0.5-Pthread-release build_time=358 run_time=64
```