### PR TITLE
Fixed supernodal SpTRSV build with serial+openmp+cuda

### DIFF
--- a/src/sparse/KokkosSparse_sptrsv_handle.hpp
+++ b/src/sparse/KokkosSparse_sptrsv_handle.hpp
@@ -222,11 +222,11 @@ public:
   using integer_view_t = Kokkos::View<int*, supercols_memory_space>;
   using integer_view_host_t = Kokkos::View<int*, supercols_host_memory_space>;
 
-  using workspace_t = typename Kokkos::View<scalar_t*, supercols_memory_space>;
+  using workspace_t = typename Kokkos::View<scalar_t*, Kokkos::Device<execution_space, supercols_memory_space>>;
 
   //
   using host_crsmat_t = KokkosSparse::CrsMatrix<scalar_t, nnz_lno_t, supercols_host_execution_space, void, size_type>;
-  using crsmat_t      = KokkosSparse::CrsMatrix<scalar_t, nnz_lno_t,                execution_space, void, size_type>;
+  using crsmat_t      = KokkosSparse::CrsMatrix<scalar_t, nnz_lno_t, Kokkos::Device<execution_space, PersistentMemorySpace>, void, size_type>;
 
   //
   using host_graph_t = typename host_crsmat_t::StaticCrsGraphType;

--- a/src/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
@@ -617,7 +617,7 @@ struct SparseTriSupernodalSpMVFunctor
 
   using scalar_t = typename LHSType::non_const_value_type;
 
-  using work_view_t = typename Kokkos::View<scalar_t*, memory_space>;
+  using work_view_t = typename Kokkos::View<scalar_t*, Kokkos::Device<execution_space, memory_space>>;
 
   int flag;
   long node_count;
@@ -698,7 +698,7 @@ struct LowerTriSupernodalFunctor
   using scalar_t = typename ValuesType::non_const_value_type;
 
   using integer_view_t = Kokkos::View<int*, memory_space>;
-  using work_view_t = typename Kokkos::View<scalar_t*, memory_space>;
+  using work_view_t = typename Kokkos::View<scalar_t*, Kokkos::Device<execution_space, memory_space>>;
 
   using range_type = Kokkos::pair<int, int>;
 
@@ -875,7 +875,7 @@ struct UpperTriSupernodalFunctor
   using scalar_t = typename ValuesType::non_const_value_type;
 
   using integer_view_t = Kokkos::View<int*, memory_space>;
-  using work_view_t = typename Kokkos::View<scalar_t*, memory_space>;
+  using work_view_t = typename Kokkos::View<scalar_t*, Kokkos::Device<execution_space, memory_space>>;
 
   using SupernodeView = typename Kokkos::View<scalar_t**, Kokkos::LayoutLeft,
                                               memory_space, Kokkos::MemoryUnmanaged>;


### PR DESCRIPTION
Fix SpMV link errors in a build with supernodal SpTRSV by using ``Device<exec, mem>`` as the device type for matrices and vectors, so that ETI type combinations are used. This configuration now builds and passes all tests:
```
cmake \
  -DKokkos_DIR=... \
  -DCMAKE_CXX_FLAGS=-Wall \
  -DKokkosKernels_ENABLE_TESTS=ON \
  -DKokkosKernels_ENABLE_EXAMPLES:BOOL=ON \
  -DKokkosKernels_ENABLE_TPL_CUSPARSE=OFF \
  -DKokkosKernels_ENABLE_TPL_CUBLAS=OFF \
  -DKokkosKernels_ENABLE_TPL_BLAS=ON \
  -DKokkosKernels_ENABLE_TPL_CHOLMOD=ON \
  -DKokkosKernels_ENABLE_TPL_SUPERLU=ON \
  -DKokkosKernels_ENABLE_SUPERNODAL_SPTRSV=ON \
  -DCMAKE_BUILD_TYPE=RELEASE \
  ../kokkos-kernels
```