### PR TITLE
Make work_view_t typedef consistent

### DIFF
--- a/src/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
@@ -1028,7 +1028,7 @@ struct UpperTriTranSupernodalFunctor
   using scalar_t = typename ValuesType::non_const_value_type;
 
   using integer_view_t = Kokkos::View<int*, memory_space>;
-  using work_view_t = typename Kokkos::View<scalar_t*, memory_space>;
+  using work_view_t = typename Kokkos::View<scalar_t*, Kokkos::Device<execution_space, memory_space>>;
 
   using range_type =  Kokkos::pair<int, int>;
 


### PR DESCRIPTION
One line follow up to #884 that makes the functor work_view_t typedefs all consistent. This change doesn't affect whether supernodal sptrsv build/tests succeed.