### PR TITLE
KokkosSparse - fix for nightly test failure

### DIFF
--- a/src/sparse/impl/KokkosSparse_spmv_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_impl.hpp
@@ -341,7 +341,10 @@ spmv_beta_no_transpose (const KokkosKernels::Experimental::Controls& controls,
     const ordinal_type nrow = A.numRows();
     if (alpha == zero) {
       if (dobeta == 0) {
-        memset(y_ptr, 0, sizeof(typename YVector::value_type)*nrow);
+        /// not working with kkosDev2_CUDA110_GCC92_cpp17/
+        ///memset(y_ptr, 0, sizeof(typename YVector::value_type)*nrow);
+        for (int i=0;i<nrow;++i) 
+          y_ptr[i] = zero;
       } else if (dobeta == 1) {
         /// so nothing
       } else {


### PR DESCRIPTION
As reported in #896, the complex build somehow does not understand the memset and sizeof function in the nightly test. This replace the memset function with a for loop. I personally prefer memset as the function is simply vectorized but it turns out that some compilers are picky and it does not work with the kokkos complex. This PR is the fix for the problem but it may indicate that the compiler or kokkos complex has an inssue with sizeof function. The sizeof function should be able to figure out the data object size though.   