### PR TITLE
Supernodal SpTRSV, improve symbolic performance

### DIFF
--- a/src/sparse/KokkosSparse_sptrsv.hpp
+++ b/src/sparse/KokkosSparse_sptrsv.hpp
@@ -108,11 +108,17 @@ namespace Experimental {
           Kokkos::MemoryTraits<Kokkos::Unmanaged|Kokkos::RandomAccess> > Entries_Internal;
 
 
+    #ifdef  KK_TRISOLVE_TIMERS
+    Kokkos::Timer timer_sptrsv;
+    #endif
     RowMap_Internal rowmap_i = rowmap;
     Entries_Internal entries_i = entries;
 
     KokkosSparse::Impl::SPTRSV_SYMBOLIC<const_handle_type, RowMap_Internal, Entries_Internal>::sptrsv_symbolic (&tmp_handle, rowmap_i, entries_i);
 
+    #ifdef KK_TRISOLVE_TIMERS
+    std::cout << "     > sptrsv_symbolic time = " << timer_sptrsv.seconds() << std::endl;
+    #endif
   } // sptrsv_symbolic
 
   template <typename KernelHandle,
@@ -167,6 +173,9 @@ namespace Experimental {
           typename scalar_nnz_view_t_::device_type,
           Kokkos::MemoryTraits<Kokkos::Unmanaged|Kokkos::RandomAccess> > Values_Internal;
 
+    #ifdef KK_TRISOLVE_TIMERS
+    Kokkos::Timer timer_sptrsv;
+    #endif
     auto sptrsv_handle = handle->get_sptrsv_handle();
     if (sptrsv_handle->get_algorithm() == KokkosSparse::Experimental::SPTRSVAlgorithm::SPTRSV_CUSPARSE) {
       RowMap_Internal rowmap_i = rowmap;
@@ -189,7 +198,9 @@ namespace Experimental {
     else {
       KokkosSparse::Experimental::sptrsv_symbolic (handle, rowmap, entries);
     }
-
+    #ifdef KK_TRISOLVE_TIMERS
+    std::cout << "     + sptrsv_symbolic time = " << timer_sptrsv.seconds() << std::endl;
+    #endif
   } // sptrsv_symbolic
 
   template <typename KernelHandle,

--- a/src/sparse/KokkosSparse_sptrsv_superlu.hpp
+++ b/src/sparse/KokkosSparse_sptrsv_superlu.hpp
@@ -296,6 +296,7 @@ void sptrsv_symbolic(
   #ifdef KOKKOS_SPTRSV_SUPERNODE_PROFILE
   double time_seconds = tic.seconds ();
   std::cout << "   Conversion Time (from SuperLU to CSR): " << time_seconds << std::endl;
+  tic.reset();
   #endif
 
   // ===================================================================
@@ -313,6 +314,10 @@ void sptrsv_symbolic(
   sptrsv_supernodal_symbolic (nsuper, supercols, etree,
                               graphL_host, kernelHandleL,
                               graphU_host, kernelHandleU);
+  #ifdef KOKKOS_SPTRSV_SUPERNODE_PROFILE
+  time_seconds = tic.seconds ();
+  std::cout << "   SpTRSV Supernodal Symbolic Time      : " << time_seconds << std::endl;
+  #endif
 }
 
 

--- a/src/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
@@ -2656,6 +2656,10 @@ cudaProfilerStop();
 
   size_type node_count = 0;
 
+  #ifdef profile_supernodal_etree
+  Kokkos::Timer sptrsv_timer;
+  sptrsv_timer.reset();
+  #endif
   for ( size_type lvl = 0; lvl < nlevels; ++lvl ) {
    {
     size_type lvl_nodes = hnodes_per_level(lvl);
@@ -2716,7 +2720,6 @@ cudaProfilerStart();
                thandle.get_algorithm () == SPTRSVAlgorithm::SUPERNODAL_ETREE ||
                thandle.get_algorithm () == SPTRSVAlgorithm::SUPERNODAL_DAG) {
 
-        //#define profile_supernodal_etree
         #ifdef profile_supernodal_etree
         size_t flops = 0;
         Kokkos::Timer timer;
@@ -2884,6 +2887,13 @@ cudaProfilerStop();
    } // scope for if-block
 
   } // end for lvl
+  #ifdef profile_supernodal_etree
+  Kokkos::fence();
+  double sptrsv_time_seconds = sptrsv_timer.seconds ();
+  std::cout << " + Execution space   : " << execution_space::name () << std::endl;
+  std::cout << " + Memory space      : " << memory_space::name () << std::endl;
+  std::cout << " + SpTrsv(lower) time: " << sptrsv_time_seconds << std::endl << std::endl;
+  #endif
 
 } // end lower_tri_solve
 
@@ -2954,6 +2964,10 @@ cudaProfilerStop();
   size_type node_count = 0;
 
   // This must stay serial; would be nice to try out Cuda's graph stuff to reduce kernel launch overhead
+  #ifdef profile_supernodal_etree
+  Kokkos::Timer sptrsv_timer;
+  sptrsv_timer.reset();
+  #endif
   for ( size_type lvl = 0; lvl < nlevels; ++lvl ) {
     size_type lvl_nodes = hnodes_per_level(lvl);
 
@@ -3279,6 +3293,13 @@ cudaProfilerStop();
 #endif
     } // end if
   } // end for lvl
+  #ifdef profile_supernodal_etree
+  Kokkos::fence();
+  double sptrsv_time_seconds = sptrsv_timer.seconds ();
+  std::cout << " + SpTrsv(uppper) time: " << sptrsv_time_seconds << std::endl << std::endl;
+  std::cout <<"  + Execution space    : " << execution_space::name () << std::endl;
+  std::cout << " + Memory space       : " << memory_space::name () << std::endl;
+  #endif
 
 } // end upper_tri_solve
 


### PR DESCRIPTION

This PR aims to reduce the SpTRSV symbolic time by keep track of nonzero entries in generate_supernodal_graph (using deep-copy of the whole vector can be expensive for a large matrix).

Spot-checks on White:
-  ../scripts/cm_test_all_sandia --spot-check --arch=Power8,Pascal60 --num=1

> #######################################################
PASSED TESTS
#######################################################
cuda-10.1.105-Cuda_OpenMP-release build_time=701 run_time=165
cuda-10.1.105-Cuda_Serial-release build_time=742 run_time=233
cuda-9.2.88-Cuda_OpenMP-release build_time=690 run_time=192
cuda-9.2.88-Cuda_Serial-release build_time=712 run_time=260
gcc-6.4.0-OpenMP_Serial-release build_time=243 run_time=171
gcc-7.2.0-OpenMP-release build_time=189 run_time=59
gcc-7.2.0-OpenMP_Serial-release build_time=246 run_time=169
gcc-7.2.0-Serial-release build_time=167 run_time=72

-   ../scripts/cm_test_all_sandia --spot-check-tpls --arch=Power8,Pascal60 --num=1 --cxxflags-extra='-DKOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV=ON'

> #######################################################
PASSED TESTS
#######################################################
cuda-10.1.105-Cuda_Serial-release build_time=827 run_time=231
cuda-9.2.88-Cuda_OpenMP-release build_time=758 run_time=196
gcc-7.2.0-OpenMP-release build_time=191 run_time=60
gcc-7.2.0-Serial-release build_time=161 run_time=74
gcc-7.4.0-OpenMP-release build_time=204 run_time=56

