### PR TITLE
Fixup HIP nightly builds

### DIFF
--- a/.jenkins/nightly.groovy
+++ b/.jenkins/nightly.groovy
@@ -18,6 +18,7 @@ pipeline {
                       mkdir build && cd build && \
                       cmake \
                         -DCMAKE_CXX_COMPILER=hipcc \
+                        -DCMAKE_CXX_EXTENSIONS=OFF \
                         -DKokkos_ENABLE_HIP=ON \
                         -DKokkos_ARCH_VEGA906=ON \
                         .. && \
@@ -27,6 +28,7 @@ pipeline {
                       cmake \
                         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                         -DCMAKE_CXX_COMPILER=hipcc \
+                        -DCMAKE_CXX_EXTENSIONS=OFF \
                         -DKokkosKernels_ENABLE_TESTS=ON \
                         -DKokkosKernels_ENABLE_EXAMPLES=ON \
                         -DKokkos_ENABLE_HIP=ON \


### PR DESCRIPTION
I just noticed that the merge of https://github.com/kokkos/kokkos/pull/3809 broke the [HIP nightly builds](https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/KokkosKernels/detail/KokkosKernels/84/pipeline/) on ORNL's Jenkins CI.