### PR TITLE
Small but important fixes and testing coverage (mainly in graph coarsening)

### DIFF
--- a/src/graph/KokkosGraph_Distance1ColorHandle.hpp
+++ b/src/graph/KokkosGraph_Distance1ColorHandle.hpp
@@ -240,7 +240,7 @@ private:
     {
       this->coloring_algorithm_type = COLORING_SERIAL;
 #ifdef VERBOSE
-      std:cout << "Serial Execution Space, Default Algorithm: COLORING_SERIAL\n";
+      std::cout << "Serial Execution Space, Default Algorithm: COLORING_SERIAL\n";
 #endif
     }
     else if(KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>())

--- a/src/graph/KokkosGraph_Distance2ColorHandle.hpp
+++ b/src/graph/KokkosGraph_Distance2ColorHandle.hpp
@@ -209,14 +209,14 @@ class GraphColorDistance2Handle
         {
             this->coloring_algorithm_type = COLORING_D2_SERIAL;
 #ifdef VERBOSE 
-            std:cout << "Serial Execution Space, Default Algorithm: COLORING_D2_SERIAL\n";
+            std::cout << "Serial Execution Space, Default Algorithm: COLORING_D2_SERIAL\n";
 #endif
         }
         else
         {
             this->coloring_algorithm_type = COLORING_D2_NB_BIT;
 #ifdef VERBOSE 
-            std:cout << ExecutionSpace::name() << " Execution Space, Default Algorithm: COLORING_D2_NB_BIT\n";
+            std::cout << ExecutionSpace::name() << " Execution Space, Default Algorithm: COLORING_D2_NB_BIT\n";
 #endif
         }
     }

--- a/src/graph/KokkosGraph_ExplicitCoarsening.hpp
+++ b/src/graph/KokkosGraph_ExplicitCoarsening.hpp
@@ -80,6 +80,8 @@ void graph_explicit_coarsen(
     coarse_entries_t mergedEntries;
     KokkosKernels::Impl::sort_and_merge_graph<exec_space, coarse_rowmap_t, coarse_entries_t>
       (coarseRowmap, coarseEntries, mergedRowmap, mergedEntries);
+    coarseRowmap = mergedRowmap;
+    coarseEntries = mergedEntries;
   }
 }
 
@@ -109,6 +111,8 @@ void graph_explicit_coarsen_with_inverse_map(
     coarse_entries_t mergedEntries;
     KokkosKernels::Impl::sort_and_merge_graph<exec_space, coarse_rowmap_t, coarse_entries_t>
       (coarseRowmap, coarseEntries, mergedRowmap, mergedEntries);
+    coarseRowmap = mergedRowmap;
+    coarseEntries = mergedEntries;
   }
 }
   

--- a/src/graph/KokkosGraph_MIS2.hpp
+++ b/src/graph/KokkosGraph_MIS2.hpp
@@ -94,6 +94,7 @@ graph_mis2_coarsen(const rowmap_t& rowmap, const colinds_t& colinds, typename co
   if(rowmap.extent(0) <= 1)
   {
     //there are no vertices to label
+    numClusters = 0;
     return labels_t();
   }
   labels_t mis2 = graph_d2_mis<device_t, rowmap_t, colinds_t, labels_t>(rowmap, colinds, algo);

--- a/unit_test/graph/Test_Graph_mis2.hpp
+++ b/unit_test/graph/Test_Graph_mis2.hpp
@@ -47,6 +47,7 @@
 #include <Kokkos_Core.hpp>
 
 #include "KokkosGraph_MIS2.hpp"
+#include "KokkosGraph_ExplicitCoarsening.hpp"
 #include "KokkosSparse_CrsMatrix.hpp"
 #include "KokkosKernels_IOUtils.hpp"
 #include "KokkosKernels_SparseUtils.hpp"
@@ -194,7 +195,71 @@ void test_mis2_coarsening(lno_t numVerts, size_type nnz, lno_t bandwidth, lno_t 
     //Check that every label is in the range [0, numClusters)
     for(lno_t i = 0; i < numVerts; i++)
       EXPECT_TRUE(0 <= labelsHost(i) && labelsHost(i) < numClusters);
+    //Test explicit coarsening given the labels, with and without compressing the result
+    rowmap_t coarseRowmapNC, coarseRowmapC;
+    entries_t coarseEntriesNC, coarseEntriesC;
+    KokkosGraph::Experimental::graph_explicit_coarsen<device, rowmap_t, entries_t, entries_t, rowmap_t, entries_t>
+      (symRowmap, symEntries, labels, numClusters, coarseRowmapNC, coarseEntriesNC, false);
+    KokkosGraph::Experimental::graph_explicit_coarsen<device, rowmap_t, entries_t, entries_t, rowmap_t, entries_t>
+      (symRowmap, symEntries, labels, numClusters, coarseRowmapC, coarseEntriesC, true);
+    EXPECT_EQ(coarseRowmapC.extent(0), numClusters + 1);
+    EXPECT_EQ(coarseRowmapNC.extent(0), numClusters + 1);
+    //Check that coarse graph doesn't have more edges than fine graph
+    EXPECT_LE(coarseEntriesC.extent(0), symEntries.extent(0));
+    EXPECT_LE(coarseEntriesNC.extent(0), symEntries.extent(0));
+    //Verify compression is working.
+    auto hostRowmapNC = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), coarseRowmapNC);
+    auto hostEntriesNC = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), coarseEntriesNC);
+    auto hostRowmapC = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), coarseRowmapC);
+    auto hostEntriesC = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), coarseEntriesC);
+    for(lno_t i = 0; i < numClusters; i++)
+    {
+      //std::set maintains uniqueness as well as ascending order of elements.
+      //So it should exactly match the entries in the compressed version.
+      std::set<lno_t> uniqueEntries;
+      for(size_type j = hostRowmapNC(i); j < hostRowmapNC(i + 1); j++)
+      {
+        uniqueEntries.insert(hostEntriesNC(j));
+      }
+      size_type compressedRowLen = hostRowmapC(i + 1) - hostRowmapC(i);
+      ASSERT_EQ(uniqueEntries.size(), compressedRowLen);
+      auto it = uniqueEntries.begin();
+      for(size_type j = hostRowmapC(i); j < hostRowmapC(i + 1); j++)
+      {
+        EXPECT_EQ(*it, hostEntriesC(j));
+        it++;
+      }
+    }
   }
+}
+
+template<typename scalar_unused, typename lno_t, typename size_type, typename device>
+void test_mis2_coarsening_zero_rows()
+{
+  using crsMat = KokkosSparse::CrsMatrix<double, lno_t, device, void, size_type>;
+  using graph_type = typename crsMat::StaticCrsGraphType;
+  using c_rowmap_t = typename graph_type::row_map_type;
+  using c_entries_t = typename graph_type::entries_type;
+  using rowmap_t = typename c_rowmap_t::non_const_type;
+  using entries_t = typename c_entries_t::non_const_type;
+  rowmap_t fineRowmap;
+  entries_t fineEntries;
+  //note: MIS2 coarsening first calls MIS2 on the fine graph, so this covers the zero-row case for MIS2 alone.
+  lno_t numClusters;
+  auto labels = graph_mis2_coarsen<device, rowmap_t, entries_t>(fineRowmap, fineEntries, numClusters, KokkosGraph::MIS2_FAST);
+  EXPECT_EQ(numClusters, 0);
+  EXPECT_EQ(labels.extent(0), 0);
+  //coarsen, should also produce a graph with 0 rows/entries
+  rowmap_t coarseRowmap;
+  entries_t coarseEntries;
+  KokkosGraph::Experimental::graph_explicit_coarsen<device, rowmap_t, entries_t, entries_t, rowmap_t, entries_t>
+    (fineRowmap, fineEntries, labels, 0, coarseRowmap, coarseEntries, false);
+  EXPECT_LE(coarseRowmap.extent(0), 1);
+  EXPECT_EQ(coarseEntries.extent(0), 0);
+  KokkosGraph::Experimental::graph_explicit_coarsen<device, rowmap_t, entries_t, entries_t, rowmap_t, entries_t>
+    (fineRowmap, fineEntries, labels, 0, coarseRowmap, coarseEntries, true);
+  EXPECT_LE(coarseRowmap.extent(0), 1);
+  EXPECT_EQ(coarseEntries.extent(0), 0);
 }
 
 #define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE) \
@@ -206,9 +271,11 @@ void test_mis2_coarsening(lno_t numVerts, size_type nnz, lno_t bandwidth, lno_t 
     } \
     TEST_F(TestCategory, graph##_##graph_mis2_coarsening##_##SCALAR##_##ORDINAL##_##OFFSET##_##DEVICE) \
     { \
+      test_mis2_coarsening<SCALAR, ORDINAL, OFFSET, DEVICE>(5000, 5000 * 200, 2000, 10); \
       test_mis2_coarsening<SCALAR, ORDINAL, OFFSET, DEVICE>(5000, 5000 * 20, 1000, 10); \
       test_mis2_coarsening<SCALAR, ORDINAL, OFFSET, DEVICE>(50, 50 * 10, 40, 10); \
       test_mis2_coarsening<SCALAR, ORDINAL, OFFSET, DEVICE>(5, 5 * 3, 5, 0); \
+      test_mis2_coarsening_zero_rows<SCALAR, ORDINAL, OFFSET, DEVICE>(); \
     }
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE)


### PR DESCRIPTION
Fixes:
- When doing MIS2 coarsening with sort+merge, actually return the
  sorted+merged graph instead of the raw coarsened one.
- Fix typo: ``std:cout`` -> ``std::cout`` (in verbose path of D1/D2 coloring), same as https://github.com/trilinos/Trilinos/pull/8859
- Set numClusters to 0 in MIS2 coarsening when graph has 0 vertices

Test coverage improvements, which verify the above fixes:
- Test MIS-2 based coarsening (fine graph -> labels) for zero row case
- Test explicit coarsening (fine graph, labels -> coarse graph), was not tested before
  - Test with zero row case
  - Test with and without compression (this PR also fixes that)
    - The test graph actually does exercise compression e.g. the
      uncompressed graph actually has duplicate entries per row.