### PR TITLE
Fixed nrm1 (#914), removed cublas nrminf, improved blas tests

### DIFF
--- a/src/impl/tpls/KokkosBlas1_nrminf_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosBlas1_nrminf_tpl_spec_avail.hpp
@@ -77,25 +77,6 @@ KOKKOSBLAS1_NRMINF_TPL_SPEC_AVAIL_BLAS( Kokkos::complex<float>,  Kokkos::LayoutL
 
 #endif
 
-// cuBLAS
-#ifdef KOKKOSKERNELS_ENABLE_TPL_CUBLAS
-// double
-#define KOKKOSBLAS1_NRMINF_TPL_SPEC_AVAIL_CUBLAS( SCALAR, LAYOUT, MEMSPACE ) \
-template<class ExecSpace> \
-struct nrminf_tpl_spec_avail< \
-Kokkos::View<typename Kokkos::Details::InnerProductSpaceTraits<SCALAR>::mag_type, LAYOUT, Kokkos::HostSpace, \
-             Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
-             Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-1> { enum : bool { value = true }; };
-
-KOKKOSBLAS1_NRMINF_TPL_SPEC_AVAIL_CUBLAS( double,                  Kokkos::LayoutLeft, Kokkos::CudaSpace)
-KOKKOSBLAS1_NRMINF_TPL_SPEC_AVAIL_CUBLAS( float,                   Kokkos::LayoutLeft, Kokkos::CudaSpace)
-KOKKOSBLAS1_NRMINF_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-KOKKOSBLAS1_NRMINF_TPL_SPEC_AVAIL_CUBLAS( Kokkos::complex<float>,  Kokkos::LayoutLeft, Kokkos::CudaSpace)
-
-#endif
-
 }
 }
 #endif

--- a/src/impl/tpls/KokkosBlas1_nrminf_tpl_spec_decl.hpp
+++ b/src/impl/tpls/KokkosBlas1_nrminf_tpl_spec_decl.hpp
@@ -83,6 +83,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   typedef Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV; \
   typedef typename XV::size_type size_type; \
+  typedef Kokkos::Details::InnerProductSpaceTraits<double> IPT; \
   \
   static void nrminf (RV& R, const XV& X) \
   { \
@@ -94,7 +95,7 @@ Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
       int N = numElems; \
       int one = 1; \
       int idx = HostBlas<double>::iamax(N,X.data(),one)-1;  \
-      R() = X(idx); \
+      R() = IPT::norm(X(idx)); \
     } else { \
       NrmInf<RV,XV,1,false,ETI_SPEC_AVAIL>::nrminf(R,X); \
     } \
@@ -116,6 +117,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
   typedef Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV; \
   typedef typename XV::size_type size_type; \
+  typedef Kokkos::Details::InnerProductSpaceTraits<float> IPT; \
   \
   static void nrminf (RV& R, const XV& X) \
   { \
@@ -127,7 +129,7 @@ Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
       int N = numElems; \
       int one = 1; \
       int idx = HostBlas<float>::iamax(N,X.data(),one)-1;  \
-      R() = X(idx); \
+      R() = IPT::norm(X(idx)); \
     } else { \
       NrmInf<RV,XV,1,false,ETI_SPEC_AVAIL>::nrminf(R,X); \
     } \
@@ -214,178 +216,6 @@ KOKKOSBLAS1_ZNRMINF_TPL_SPEC_DECL_BLAS( Kokkos::LayoutLeft, Kokkos::HostSpace, f
 
 KOKKOSBLAS1_CNRMINF_TPL_SPEC_DECL_BLAS( Kokkos::LayoutLeft, Kokkos::HostSpace, true)
 KOKKOSBLAS1_CNRMINF_TPL_SPEC_DECL_BLAS( Kokkos::LayoutLeft, Kokkos::HostSpace, false)
-
-}
-}
-
-#endif
-
-// cuBLAS
-#ifdef KOKKOSKERNELS_ENABLE_TPL_CUBLAS
-#include<KokkosBlas_tpl_spec.hpp>
-
-namespace KokkosBlas {
-namespace Impl {
-
-#define KOKKOSBLAS1_DNRMINF_TPL_SPEC_DECL_CUBLAS( LAYOUT, MEMSPACE, ETI_SPEC_AVAIL ) \
-template<class ExecSpace> \
-struct NrmInf< \
-Kokkos::View<double, LAYOUT, Kokkos::HostSpace, \
-             Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
-             Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-1,true, ETI_SPEC_AVAIL > { \
-  \
-  typedef Kokkos::View<double, LAYOUT, Kokkos::HostSpace, \
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV; \
-  typedef Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV; \
-  typedef typename XV::size_type size_type; \
-  \
-  static void nrminf (RV& R, const XV& X) \
-  { \
-    Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_CUBLAS,double]"); \
-    const size_type numElems = X.extent(0); \
-    if (numElems == 0) { Kokkos::deep_copy (R, 0.0); return; } \
-    if (numElems < static_cast<size_type> (INT_MAX)) { \
-      nrminf_print_specialization<RV,XV>(); \
-      const int N = static_cast<int> (numElems); \
-      constexpr int one = 1; \
-      int idx; \
-      KokkosBlas::Impl::CudaBlasSingleton & s = KokkosBlas::Impl::CudaBlasSingleton::singleton(); \
-      cublasIdamax(s.handle, N, X.data(), one, &idx); \
-      Kokkos::deep_copy(R, subview(X,idx-1)); \
-    } else { \
-      NrmInf<RV,XV,1,false,ETI_SPEC_AVAIL>::nrminf(R,X); \
-    } \
-    Kokkos::Profiling::popRegion(); \
-  } \
-};
-
-#define KOKKOSBLAS1_SNRMINF_TPL_SPEC_DECL_CUBLAS( LAYOUT, MEMSPACE, ETI_SPEC_AVAIL ) \
-template<class ExecSpace> \
-struct NrmInf< \
-Kokkos::View<float, LAYOUT, Kokkos::HostSpace, \
-             Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
-             Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-1,true, ETI_SPEC_AVAIL > { \
-  \
-  typedef Kokkos::View<float, LAYOUT, Kokkos::HostSpace, \
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV; \
-  typedef Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV; \
-  typedef typename XV::size_type size_type; \
-  \
-  static void nrminf (RV& R, const XV& X) \
-  { \
-    Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_CUBLAS,float]"); \
-    const size_type numElems = X.extent(0); \
-    if (numElems == 0) { Kokkos::deep_copy (R, 0.0f);; return; } \
-    if (numElems < static_cast<size_type> (INT_MAX)) { \
-      nrminf_print_specialization<RV,XV>(); \
-      const int N = static_cast<int> (numElems); \
-      constexpr int one = 1; \
-      int idx; \
-      KokkosBlas::Impl::CudaBlasSingleton & s = KokkosBlas::Impl::CudaBlasSingleton::singleton(); \
-      cublasIsamax(s.handle, N, X.data(), one, &idx); \
-      Kokkos::deep_copy(R, subview(X,idx-1)); \
-    } else { \
-      NrmInf<RV,XV,1,false,ETI_SPEC_AVAIL>::nrminf(R,X); \
-    } \
-    Kokkos::Profiling::popRegion(); \
-  } \
-};
-
-#define KOKKOSBLAS1_ZNRMINF_TPL_SPEC_DECL_CUBLAS( LAYOUT, MEMSPACE, ETI_SPEC_AVAIL ) \
-template<class ExecSpace> \
-struct NrmInf< \
-Kokkos::View<double, LAYOUT, Kokkos::HostSpace, \
-             Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
-             Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-1,true, ETI_SPEC_AVAIL > { \
-  \
-  typedef Kokkos::View<double, LAYOUT, Kokkos::HostSpace, \
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV; \
-  typedef Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV; \
-  typedef typename XV::size_type size_type; \
-  typedef Kokkos::Details::InnerProductSpaceTraits<Kokkos::complex<double>> IPT; \
-  \
-  static void nrminf (RV& R, const XV& X) \
-  { \
-    Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_CUBLAS,complex<double>]"); \
-    const size_type numElems = X.extent(0); \
-    if (numElems == 0) { Kokkos::deep_copy (R, 0.0); return; } \
-    if (numElems < static_cast<size_type> (INT_MAX)) { \
-      nrminf_print_specialization<RV,XV>(); \
-      const int N = static_cast<int> (numElems); \
-      constexpr int one = 1; \
-      int idx; \
-      KokkosBlas::Impl::CudaBlasSingleton & s = KokkosBlas::Impl::CudaBlasSingleton::singleton(); \
-      cublasIzamax(s.handle, N, reinterpret_cast<const cuDoubleComplex*>(X.data()), one, &idx); \
-      Kokkos::complex<double> R_cplx_val {0.0, 0.0}; \
-      Kokkos::View<Kokkos::complex<double>, LAYOUT, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > R_cplx (&R_cplx_val); \
-      Kokkos::deep_copy(R_cplx, subview(X,idx-1)); \
-      R() = IPT::norm(R_cplx()); \
-    } else { \
-      NrmInf<RV,XV,1,false,ETI_SPEC_AVAIL>::nrminf(R,X); \
-    } \
-    Kokkos::Profiling::popRegion(); \
-  } \
-};
-
-#define KOKKOSBLAS1_CNRMINF_TPL_SPEC_DECL_CUBLAS( LAYOUT, MEMSPACE, ETI_SPEC_AVAIL ) \
-template<class ExecSpace> \
-struct NrmInf< \
-Kokkos::View<float, LAYOUT, Kokkos::HostSpace, \
-             Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
-             Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-1,true, ETI_SPEC_AVAIL > { \
-  \
-  typedef Kokkos::View<float, LAYOUT, Kokkos::HostSpace, \
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV; \
-  typedef Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV; \
-  typedef typename XV::size_type size_type; \
-  typedef Kokkos::Details::InnerProductSpaceTraits<Kokkos::complex<float>> IPT; \
-  \
-  static void nrminf (RV& R, const XV& X) \
-  { \
-    Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_CUBLAS,complex<float>]"); \
-    const size_type numElems = X.extent(0); \
-    if (numElems == 0) { Kokkos::deep_copy (R, 0.0f); return; } \
-    if (numElems < static_cast<size_type> (INT_MAX)) { \
-      nrminf_print_specialization<RV,XV>(); \
-      const int N = static_cast<int> (numElems); \
-      constexpr int one = 1; \
-      int idx; \
-      KokkosBlas::Impl::CudaBlasSingleton & s = KokkosBlas::Impl::CudaBlasSingleton::singleton(); \
-      cublasIcamax(s.handle, N, reinterpret_cast<const cuComplex*>(X.data()), one, &idx); \
-      Kokkos::complex<float> R_cplx_val {0.0f, 0.0f}; \
-      Kokkos::View<Kokkos::complex<float>, LAYOUT, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > R_cplx (&R_cplx_val); \
-      Kokkos::deep_copy(R_cplx, subview(X,idx-1)); \
-      R() = IPT::norm(R_cplx()); \
-    } else { \
-      NrmInf<RV,XV,1,false,ETI_SPEC_AVAIL>::nrminf(R,X); \
-    } \
-    Kokkos::Profiling::popRegion(); \
-  } \
-};
-
-KOKKOSBLAS1_DNRMINF_TPL_SPEC_DECL_CUBLAS( Kokkos::LayoutLeft, Kokkos::CudaSpace, true)
-KOKKOSBLAS1_DNRMINF_TPL_SPEC_DECL_CUBLAS( Kokkos::LayoutLeft, Kokkos::CudaSpace, false)
-
-KOKKOSBLAS1_SNRMINF_TPL_SPEC_DECL_CUBLAS( Kokkos::LayoutLeft, Kokkos::CudaSpace, true)
-KOKKOSBLAS1_SNRMINF_TPL_SPEC_DECL_CUBLAS( Kokkos::LayoutLeft, Kokkos::CudaSpace, false)
-
-KOKKOSBLAS1_ZNRMINF_TPL_SPEC_DECL_CUBLAS( Kokkos::LayoutLeft, Kokkos::CudaSpace, true)
-KOKKOSBLAS1_ZNRMINF_TPL_SPEC_DECL_CUBLAS( Kokkos::LayoutLeft, Kokkos::CudaSpace, false)
-
-KOKKOSBLAS1_CNRMINF_TPL_SPEC_DECL_CUBLAS( Kokkos::LayoutLeft, Kokkos::CudaSpace, true)
-KOKKOSBLAS1_CNRMINF_TPL_SPEC_DECL_CUBLAS( Kokkos::LayoutLeft, Kokkos::CudaSpace, false)
 
 }
 }

--- a/unit_test/blas/Test_Blas1_dot.hpp
+++ b/unit_test/blas/Test_Blas1_dot.hpp
@@ -37,10 +37,16 @@ namespace Test {
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
-    Kokkos::fill_random(b_a,rand_pool,ScalarA(10));
-    Kokkos::fill_random(b_b,rand_pool,ScalarB(10));
-
-    Kokkos::fence();
+    {
+      ScalarA randStart, randEnd;
+      Test::getRandomBounds(10.0, randStart, randEnd);
+      Kokkos::fill_random(b_a,rand_pool,randStart,randEnd);
+    }
+    {
+      ScalarB randStart, randEnd;
+      Test::getRandomBounds(10.0, randStart, randEnd);
+      Kokkos::fill_random(b_b,rand_pool,randStart,randEnd);
+    }
 
     Kokkos::deep_copy(h_b_a,b_a);
     Kokkos::deep_copy(h_b_b,b_b);
@@ -92,10 +98,16 @@ namespace Test {
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
-    Kokkos::fill_random(b_a,rand_pool,ScalarA(10));
-    Kokkos::fill_random(b_b,rand_pool,ScalarB(10));
-
-    Kokkos::fence();
+    {
+      ScalarA randStart, randEnd;
+      Test::getRandomBounds(10.0, randStart, randEnd);
+      Kokkos::fill_random(b_a,rand_pool,randStart,randEnd);
+    }
+    {
+      ScalarB randStart, randEnd;
+      Test::getRandomBounds(10.0, randStart, randEnd);
+      Kokkos::fill_random(b_b,rand_pool,randStart,randEnd);
+    }
 
     Kokkos::deep_copy(h_b_a,b_a);
     Kokkos::deep_copy(h_b_b,b_b);

--- a/unit_test/blas/Test_Blas1_iamax.hpp
+++ b/unit_test/blas/Test_Blas1_iamax.hpp
@@ -29,9 +29,9 @@ namespace Test {
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
-    Kokkos::fill_random(b_a,rand_pool,ScalarA(10));
-
-    Kokkos::fence();
+    ScalarA randStart, randEnd;
+    Test::getRandomBounds(10.0, randStart, randEnd);
+    Kokkos::fill_random(b_a,rand_pool,randStart,randEnd);
 
     Kokkos::deep_copy(h_b_a,b_a);
 
@@ -115,9 +115,9 @@ namespace Test {
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
-    Kokkos::fill_random(b_a,rand_pool,ScalarA(10));
-
-    Kokkos::fence();
+    ScalarA randStart, randEnd;
+    Test::getRandomBounds(10.0, randStart, randEnd);
+    Kokkos::fill_random(b_a,rand_pool,randStart,randEnd);
 
     Kokkos::deep_copy(h_b_a,b_a);
 

--- a/unit_test/blas/Test_Blas1_mult.hpp
+++ b/unit_test/blas/Test_Blas1_mult.hpp
@@ -29,7 +29,7 @@ namespace Test {
 
     ScalarA a = 3;
     ScalarB b = 5;
-    double eps = std::is_same<ScalarC,float>::value?2*1e-5:1e-7;
+    double eps = std::is_same<ScalarC,float>::value?1e-4:1e-7;
 
     BaseTypeA b_x("X",N);
     BaseTypeB b_y("Y",N);
@@ -53,33 +53,52 @@ namespace Test {
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
-    Kokkos::fill_random(b_x,rand_pool,ScalarA(10));
-    Kokkos::fill_random(b_y,rand_pool,ScalarB(10));
-    Kokkos::fill_random(b_z,rand_pool,ScalarC(10));
+    {
+      ScalarA randStart, randEnd;
+      Test::getRandomBounds(10.0, randStart, randEnd);
+      Kokkos::fill_random(b_x,rand_pool,randStart,randEnd);
+    }
+    {
+      ScalarB randStart, randEnd;
+      Test::getRandomBounds(10.0, randStart, randEnd);
+      Kokkos::fill_random(b_y,rand_pool,randStart,randEnd);
+    }
+    {
+      ScalarC randStart, randEnd;
+      Test::getRandomBounds(10.0, randStart, randEnd);
+      Kokkos::fill_random(b_z,rand_pool,randStart,randEnd);
+    }
 
     Kokkos::deep_copy(b_org_z,b_z);
+    auto h_b_org_z = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_org_z);
 
     Kokkos::deep_copy(h_b_x,b_x);
     Kokkos::deep_copy(h_b_y,b_y);
-    Kokkos::deep_copy(h_b_z,b_z);
 
-    ScalarA expected_result = 0;
-    for(int i=0;i<N;i++)
-      expected_result += ScalarC(b*h_z(i) + a*h_x(i)*h_y(i)) * ScalarC(b*h_z(i) + a*h_x(i)*h_y(i));
+    //expected_result = ScalarC(b*h_z(i) + a*h_x(i)*h_y(i))
 
     KokkosBlas::mult(b,z,a,x,y);
-    ScalarC nonconst_nonconst_result = KokkosBlas::dot(z,z);
-    EXPECT_NEAR_KK( nonconst_nonconst_result, expected_result, eps*expected_result);
- 
+    Kokkos::deep_copy(h_b_z, b_z);
+    for(int i = 0; i < N; i++)
+    {
+      EXPECT_NEAR_KK(a * h_x(i) * h_y(i) + b * h_b_org_z(i, 0), h_z(i), eps);
+    }
+
     Kokkos::deep_copy(b_z,b_org_z);
     KokkosBlas::mult(b,z,a,x,c_y);
-    ScalarC const_nonconst_result = KokkosBlas::dot(z,z);
-    EXPECT_NEAR_KK( const_nonconst_result, expected_result, eps*expected_result);
+    Kokkos::deep_copy(h_b_z, b_z);
+    for(int i = 0; i < N; i++)
+    {
+      EXPECT_NEAR_KK(a * h_x(i) * h_y(i) + b * h_b_org_z(i, 0), h_z(i), eps);
+    }
 
     Kokkos::deep_copy(b_z,b_org_z);
     KokkosBlas::mult(b,z,a,c_x,c_y);
-    ScalarC const_const_result = KokkosBlas::dot(z,z);
-    EXPECT_NEAR_KK( const_const_result, expected_result, eps*expected_result);
+    Kokkos::deep_copy(h_b_z, b_z);
+    for(int i = 0; i < N; i++)
+    {
+      EXPECT_NEAR_KK(a * h_x(i) * h_y(i) + b * h_b_org_z(i, 0), h_z(i), eps);
+    }
   }
 
   template<class ViewTypeA, class ViewTypeB, class ViewTypeC, class Device>
@@ -118,11 +137,24 @@ namespace Test {
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
-    Kokkos::fill_random(b_x,rand_pool,ScalarA(10));
-    Kokkos::fill_random(b_y,rand_pool,ScalarB(10));
-    Kokkos::fill_random(b_z,rand_pool,ScalarC(10));
+    {
+      ScalarA randStart, randEnd;
+      Test::getRandomBounds(10.0, randStart, randEnd);
+      Kokkos::fill_random(b_x,rand_pool,randStart,randEnd);
+    }
+    {
+      ScalarB randStart, randEnd;
+      Test::getRandomBounds(10.0, randStart, randEnd);
+      Kokkos::fill_random(b_y,rand_pool,randStart,randEnd);
+    }
+    {
+      ScalarC randStart, randEnd;
+      Test::getRandomBounds(10.0, randStart, randEnd);
+      Kokkos::fill_random(b_z,rand_pool,randStart,randEnd);
+    }
 
     Kokkos::deep_copy(b_org_z,b_z);
+    auto h_b_org_z = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_org_z);
 
     Kokkos::deep_copy(h_b_x,b_x);
     Kokkos::deep_copy(h_b_y,b_y);
@@ -133,33 +165,28 @@ namespace Test {
     typename ViewTypeA::const_type c_x = x;
     typename ViewTypeB::const_type c_y = y;
 
-    ScalarC* expected_result = new ScalarC[K];
-    for(int j=0;j<K;j++) {
-      expected_result[j] = ScalarC();
-      for(int i=0;i<N;i++)
-        expected_result[j] += ScalarC(b*h_z(i,j) + a*h_x(i)*h_y(i,j)) * ScalarC(b*h_z(i,j) + a*h_x(i)*h_y(i,j));
-    }
-
-    double eps = std::is_same<ScalarA,float>::value?2*1e-5:1e-7;
-
-    Kokkos::View<ScalarC*,Kokkos::HostSpace> r("Dot::Result",K);
+    double eps = std::is_same<ScalarA,float>::value?1e-4:1e-7;
 
     KokkosBlas::mult(b,z,a,x,y);
-    KokkosBlas::dot(r,z,z);
-    for(int k=0;k<K;k++) {
-      ScalarA nonconst_nonconst_result = r(k);
-      EXPECT_NEAR_KK( nonconst_nonconst_result, expected_result[k], eps*expected_result[k]);
+    Kokkos::deep_copy(h_b_z, b_z);
+    for(int i = 0; i < N; i++)
+    {
+      for(int j = 0; j < K; j++)
+      {
+        EXPECT_NEAR_KK(a * h_x(i) * h_y(i, j) + b * h_b_org_z(i, j), h_z(i, j), eps);
+      }
     }
 
     Kokkos::deep_copy(b_z,b_org_z);
     KokkosBlas::mult(b,z,a,x,c_y);
-    KokkosBlas::dot(r,z,z);
-    for(int k=0;k<K;k++) {
-      ScalarA const_non_const_result = r(k);
-      EXPECT_NEAR_KK( const_non_const_result, expected_result[k], eps*expected_result[k]);
+    Kokkos::deep_copy(h_b_z, b_z);
+    for(int i = 0; i < N; i++)
+    {
+      for(int j = 0; j < K; j++)
+      {
+        EXPECT_NEAR_KK(a * h_x(i) * h_y(i, j) + b * h_b_org_z(i, j), h_z(i, j), eps);
+      }
     }
-
-    delete [] expected_result;
   }
 }
 

--- a/unit_test/blas/Test_Blas1_nrm2.hpp
+++ b/unit_test/blas/Test_Blas1_nrm2.hpp
@@ -27,9 +27,9 @@ namespace Test {
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
-    Kokkos::fill_random(b_a,rand_pool,ScalarA(1));
-
-    Kokkos::fence();
+    ScalarA randStart, randEnd;
+    Test::getRandomBounds(1.0, randStart, randEnd);
+    Kokkos::fill_random(b_a,rand_pool,randStart,randEnd);
 
     Kokkos::deep_copy(h_b_a,b_a);
 
@@ -69,9 +69,9 @@ namespace Test {
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
-    Kokkos::fill_random(b_a,rand_pool,ScalarA(1));
-
-    Kokkos::fence();
+    ScalarA randStart, randEnd;
+    Test::getRandomBounds(1.0, randStart, randEnd);
+    Kokkos::fill_random(b_a,rand_pool,randStart,randEnd);
 
     Kokkos::deep_copy(h_b_a,b_a);
 

--- a/unit_test/blas/Test_Blas1_nrm2_squared.hpp
+++ b/unit_test/blas/Test_Blas1_nrm2_squared.hpp
@@ -27,9 +27,9 @@ namespace Test {
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
-    Kokkos::fill_random(b_a,rand_pool,ScalarA(1));
-
-    Kokkos::fence();
+    ScalarA randStart, randEnd;
+    Test::getRandomBounds(1.0, randStart, randEnd);
+    Kokkos::fill_random(b_a,rand_pool,randStart,randEnd);
 
     Kokkos::deep_copy(h_b_a,b_a);
 
@@ -68,9 +68,9 @@ namespace Test {
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
-    Kokkos::fill_random(b_a,rand_pool,ScalarA(1));
-
-    Kokkos::fence();
+    ScalarA randStart, randEnd;
+    Test::getRandomBounds(1.0, randStart, randEnd);
+    Kokkos::fill_random(b_a,rand_pool,randStart,randEnd);
 
     Kokkos::deep_copy(h_b_a,b_a);
 

--- a/unit_test/blas/Test_Blas1_nrminf.hpp
+++ b/unit_test/blas/Test_Blas1_nrminf.hpp
@@ -27,9 +27,9 @@ namespace Test {
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
-    Kokkos::fill_random(b_a,rand_pool,ScalarA(10));
-
-    Kokkos::fence();
+    ScalarA randStart, randEnd;
+    Test::getRandomBounds(10.0, randStart, randEnd);
+    Kokkos::fill_random(b_a,rand_pool,randStart,randEnd);
 
     Kokkos::deep_copy(h_b_a,b_a);
 
@@ -70,9 +70,9 @@ namespace Test {
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
-    Kokkos::fill_random(b_a,rand_pool,ScalarA(10));
-
-    Kokkos::fence();
+    ScalarA randStart, randEnd;
+    Test::getRandomBounds(10.0, randStart, randEnd);
+    Kokkos::fill_random(b_a,rand_pool,randStart,randEnd);
 
     Kokkos::deep_copy(h_b_a,b_a);
 
@@ -98,13 +98,12 @@ namespace Test {
       EXPECT_NEAR_KK( nonconst_result, exp_result, eps*exp_result);
     }
 
-   /* KokkosBlas::nrminf(r,c_a);
+    KokkosBlas::nrminf(r,c_a);
     for(int k=0;k<K;k++) {
       typename AT::mag_type const_result = r(k);
       typename AT::mag_type exp_result = expected_result[k];
       EXPECT_NEAR_KK( const_result, exp_result, eps*exp_result);
     }
-*/
     delete [] expected_result;
   }
 }

--- a/unit_test/blas/Test_Blas1_reciprocal.hpp
+++ b/unit_test/blas/Test_Blas1_reciprocal.hpp
@@ -44,10 +44,16 @@ namespace Test {
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
-    Kokkos::fill_random(b_x,rand_pool,ScalarA(1));
-    Kokkos::fill_random(b_y,rand_pool,ScalarB(1));
-
-    Kokkos::fence();
+    {
+      ScalarA randStart, randEnd;
+      Test::getRandomBounds(1.0, randStart, randEnd);
+      Kokkos::fill_random(b_x,rand_pool,randStart,randEnd);
+    }
+    {
+      ScalarB randStart, randEnd;
+      Test::getRandomBounds(1.0, randStart, randEnd);
+      Kokkos::fill_random(b_y,rand_pool,randStart,randEnd);
+    }
 
     Kokkos::deep_copy(b_org_y,b_y);
 
@@ -99,10 +105,16 @@ namespace Test {
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
-    Kokkos::fill_random(b_x,rand_pool,ScalarA(1));
-    Kokkos::fill_random(b_y,rand_pool,ScalarB(1));
-
-    Kokkos::fence();
+    {
+      ScalarA randStart, randEnd;
+      Test::getRandomBounds(1.0, randStart, randEnd);
+      Kokkos::fill_random(b_x,rand_pool,randStart,randEnd);
+    }
+    {
+      ScalarB randStart, randEnd;
+      Test::getRandomBounds(1.0, randStart, randEnd);
+      Kokkos::fill_random(b_y,rand_pool,randStart,randEnd);
+    }
 
     Kokkos::deep_copy(b_org_y,b_y);
 

--- a/unit_test/blas/Test_Blas1_scal.hpp
+++ b/unit_test/blas/Test_Blas1_scal.hpp
@@ -25,13 +25,10 @@ namespace Test {
 
     ScalarA a(3);
     typename AT::mag_type eps = AT::epsilon()*1000;
-    typename AT::mag_type zero = AT::abs( AT::zero() );
-    typename AT::mag_type one = AT::abs( AT::one() );
 
     BaseTypeA b_x("X",N);
     BaseTypeB b_y("Y",N);
     BaseTypeB b_org_y("Org_Y",N);
-    
 
     ViewTypeA x = Kokkos::subview(b_x,Kokkos::ALL(),0);
     ViewTypeB y = Kokkos::subview(b_y,Kokkos::ALL(),0);
@@ -46,35 +43,35 @@ namespace Test {
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
-    Kokkos::fill_random(b_x,rand_pool,ScalarA(1));
-    Kokkos::fill_random(b_y,rand_pool,ScalarB(1));
-
-    Kokkos::fence();
+    {
+      ScalarA randStart, randEnd;
+      Test::getRandomBounds(1.0, randStart, randEnd);
+      Kokkos::fill_random(b_x,rand_pool,randStart,randEnd);
+    }
+    {
+      ScalarB randStart, randEnd;
+      Test::getRandomBounds(1.0, randStart, randEnd);
+      Kokkos::fill_random(b_y,rand_pool,randStart,randEnd);
+    }
 
     Kokkos::deep_copy(b_org_y,b_y);
 
     Kokkos::deep_copy(h_b_x,b_x);
     Kokkos::deep_copy(h_b_y,b_y);
 
-    ScalarA expected_result(0);
-    for(int i=0;i<N;i++)
-    { expected_result += ScalarB(a*h_x(i)) * ScalarB(a*h_x(i)); }
-
     KokkosBlas::scal(y,a,x);
+    Kokkos::deep_copy(h_b_y, b_y);
+    for(int i = 0; i < N; i++)
     {
-      ScalarB nonconst_nonconst_result = KokkosBlas::dot(y,y);
-      typename AT::mag_type divisor = AT::abs(expected_result) == zero ? one : AT::abs(expected_result);
-      typename AT::mag_type diff = AT::abs( nonconst_nonconst_result - expected_result )/divisor;
-      EXPECT_NEAR_KK( diff, zero, eps );
+      EXPECT_NEAR_KK(a * h_x(i), h_y(i), eps);
     }
  
     Kokkos::deep_copy(b_y,b_org_y);
     KokkosBlas::scal(y,a,c_x);
+    Kokkos::deep_copy(h_b_y, b_y);
+    for(int i = 0; i < N; i++)
     {
-      ScalarB const_nonconst_result = KokkosBlas::dot(y,y);
-      typename AT::mag_type divisor = AT::abs(expected_result) == zero ? one : AT::abs(expected_result);
-      typename AT::mag_type diff = AT::abs( const_nonconst_result - expected_result )/divisor;
-      EXPECT_NEAR_KK( diff, zero, eps );
+      EXPECT_NEAR_KK(a * h_x(i), h_y(i), eps);
     }
   }
 
@@ -106,50 +103,51 @@ namespace Test {
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
-    Kokkos::fill_random(b_x,rand_pool,ScalarA(1));
-    Kokkos::fill_random(b_y,rand_pool,ScalarB(1));
+    {
+      ScalarA randStart, randEnd;
+      Test::getRandomBounds(1.0, randStart, randEnd);
+      Kokkos::fill_random(b_x,rand_pool,randStart,randEnd);
+    }
+    {
+      ScalarB randStart, randEnd;
+      Test::getRandomBounds(1.0, randStart, randEnd);
+      Kokkos::fill_random(b_y,rand_pool,randStart,randEnd);
+    }
 
     Kokkos::fence();
 
     Kokkos::deep_copy(b_org_y,b_y);
 
     Kokkos::deep_copy(h_b_x,b_x);
-    Kokkos::deep_copy(h_b_y,b_y);
 
     ScalarA a(3.0);
     typename ViewTypeA::const_type c_x = x;
 
-    ScalarA* expected_result = new ScalarA[K];
-    for(int j=0;j<K;j++) {
-      expected_result[j] = ScalarA();
-      for(int i=0;i<N;i++)
-      { expected_result[j] += ScalarB(a*h_x(i,j)) * ScalarB(a*h_x(i,j)); }
-    }
-
     typename AT::mag_type eps = AT::epsilon()*1000;
-    typename AT::mag_type zero = AT::abs( AT::zero() );
-    typename AT::mag_type one = AT::abs( AT::one() );
 
     Kokkos::View<ScalarB*,Kokkos::HostSpace> r("Dot::Result",K);
 
     KokkosBlas::scal(y,a,x);
-    KokkosBlas::dot(r,y,y);
-    for(int k=0;k<K;k++) {
-      ScalarA nonconst_scalar_result = r(k);
-      typename AT::mag_type divisor = AT::abs(expected_result[k]) == zero ? one : AT::abs(expected_result[k]);
-      typename AT::mag_type diff = AT::abs( nonconst_scalar_result - expected_result[k] )/divisor;
-      EXPECT_NEAR_KK( diff, zero, eps );
+    Kokkos::deep_copy(h_b_y, b_y);
+    for(int i = 0; i < N; i++)
+    {
+      for(int j = 0; j < K; j++)
+      {
+        EXPECT_NEAR_KK(a * h_x(i, j), h_y(i, j), eps);
+      }
     }
 
     Kokkos::deep_copy(b_y,b_org_y);
     KokkosBlas::scal(y,a,c_x);
-    KokkosBlas::dot(r,y,y);
-    for(int k=0;k<K;k++) {
-      ScalarA const_scalar_result = r(k);
-      typename AT::mag_type divisor = AT::abs(expected_result[k]) == zero ? one : AT::abs(expected_result[k]);
-      typename AT::mag_type diff = AT::abs( const_scalar_result - expected_result[k] )/divisor;
-      EXPECT_NEAR_KK( diff, zero, eps );
+    Kokkos::deep_copy(h_b_y, b_y);
+    for(int i = 0; i < N; i++)
+    {
+      for(int j = 0; j < K; j++)
+      {
+        EXPECT_NEAR_KK(a * h_x(i, j), h_y(i, j), eps);
+      }
     }
+
 
     // Generate 'params' view with dimension == number of multivectors; each entry will be different scalar to scale y
     Kokkos::View<ScalarA*,Device> params("Params",K);
@@ -158,33 +156,28 @@ namespace Test {
       Kokkos::deep_copy(param_j,ScalarA(3+j));
     }
 
-    // Update expected_result for next 3 vector tests
-    for(int j=0;j<K;j++) {
-      expected_result[j] = ScalarA();
-      for(int i=0;i<N;i++)
-        expected_result[j] += ScalarB((3.0+j)*h_x(i,j)) * ScalarB((3.0+j)*h_x(i,j));
-    }
+    auto h_params = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), params);
 
     KokkosBlas::scal(y,params,x);
-    KokkosBlas::dot(r,y,y);
-    for(int k=0;k<K;k++) {
-      ScalarA nonconst_vector_result = r(k);
-      typename AT::mag_type divisor = AT::abs(expected_result[k]) == zero ? one : AT::abs(expected_result[k]);
-      typename AT::mag_type diff = AT::abs( nonconst_vector_result - expected_result[k] )/divisor;
-      EXPECT_NEAR_KK( diff, zero, eps );
+    Kokkos::deep_copy(h_b_y, b_y);
+    for(int i = 0; i < N; i++)
+    {
+      for(int j = 0; j < K; j++)
+      {
+        EXPECT_NEAR_KK(h_params(j) * h_x(i, j), h_y(i, j), eps);
+      }
     }
 
     Kokkos::deep_copy(b_y,b_org_y);
     KokkosBlas::scal(y,params,c_x);
-    KokkosBlas::dot(r,y,y);
-    for(int k=0;k<K;k++) {
-      ScalarA const_vector_result = r(k);
-      typename AT::mag_type divisor = AT::abs(expected_result[k]) == zero ? one : AT::abs(expected_result[k]);
-      typename AT::mag_type diff = AT::abs( const_vector_result - expected_result[k] )/divisor;
-      EXPECT_NEAR_KK( diff, zero, eps );
+    Kokkos::deep_copy(h_b_y, b_y);
+    for(int i = 0; i < N; i++)
+    {
+      for(int j = 0; j < K; j++)
+      {
+        EXPECT_NEAR_KK(h_params(j) * h_x(i, j), h_y(i, j), eps);
+      }
     }
-
-    delete [] expected_result;
   }
 }
 

--- a/unit_test/blas/Test_Blas1_sum.hpp
+++ b/unit_test/blas/Test_Blas1_sum.hpp
@@ -26,9 +26,9 @@ namespace Test {
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
-    Kokkos::fill_random(b_a,rand_pool,ScalarA(10));
-
-    Kokkos::fence();
+    ScalarA randStart, randEnd;
+    Test::getRandomBounds(10.0, randStart, randEnd);
+    Kokkos::fill_random(b_a,rand_pool,randStart,randEnd);
 
     Kokkos::deep_copy(h_b_a,b_a);
 
@@ -51,7 +51,6 @@ namespace Test {
   void impl_test_sum_mv(int N, int K) {
 
     typedef typename ViewTypeA::value_type ScalarA;
-    typedef Kokkos::Details::ArithTraits<ScalarA> AT;
 
     typedef multivector_layout_adapter<ViewTypeA> vfA_type;
 
@@ -67,9 +66,9 @@ namespace Test {
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
-    Kokkos::fill_random(b_a,rand_pool,ScalarA(10));
-
-    Kokkos::fence();
+    ScalarA randStart, randEnd;
+    Test::getRandomBounds(10.0, randStart, randEnd);
+    Kokkos::fill_random(b_a,rand_pool,randStart,randEnd);
 
     Kokkos::deep_copy(h_b_a,b_a);
 
@@ -79,7 +78,7 @@ namespace Test {
     for(int j=0;j<K;j++) {
       expected_result[j] = ScalarA();
       for(int i=0;i<N;i++)
-        expected_result[j] += AT::abs(h_a(i,j));
+        expected_result[j] += h_a(i,j);
     }
 
     double eps = std::is_same<ScalarA,float>::value?2*1e-5:1e-7;

--- a/unit_test/blas/Test_Blas1_team_dot.hpp
+++ b/unit_test/blas/Test_Blas1_team_dot.hpp
@@ -46,8 +46,6 @@ namespace Test {
     Kokkos::fill_random(b_a,rand_pool,ScalarA(10));
     Kokkos::fill_random(b_b,rand_pool,ScalarB(10));
 
-    Kokkos::fence();
-
     Kokkos::deep_copy(h_b_a,b_a);
     Kokkos::deep_copy(h_b_b,b_b);
 
@@ -149,8 +147,6 @@ namespace Test {
 
     Kokkos::fill_random(b_a,rand_pool,ScalarA(10));
     Kokkos::fill_random(b_b,rand_pool,ScalarB(10));
-
-    Kokkos::fence();
 
     Kokkos::deep_copy(h_b_a,b_a);
     Kokkos::deep_copy(h_b_b,b_b);

--- a/unit_test/blas/Test_Blas1_team_nrm2.hpp
+++ b/unit_test/blas/Test_Blas1_team_nrm2.hpp
@@ -33,8 +33,6 @@ namespace Test {
 
     Kokkos::fill_random(b_a,rand_pool,ScalarA(10));
 
-    Kokkos::fence();
-
     Kokkos::deep_copy(h_b_a,b_a);
 
     typename ViewTypeA::const_type c_a = a;

--- a/unit_test/blas/Test_Blas1_team_scal.hpp
+++ b/unit_test/blas/Test_Blas1_team_scal.hpp
@@ -57,8 +57,6 @@ namespace Test {
     Kokkos::fill_random(b_x,rand_pool,ScalarA(1));
     Kokkos::fill_random(b_y,rand_pool,ScalarB(1));
 
-    Kokkos::fence();
-
     Kokkos::deep_copy(b_org_y,b_y);
 
     Kokkos::deep_copy(h_b_x,b_x);
@@ -131,8 +129,6 @@ namespace Test {
 
     Kokkos::fill_random(b_x,rand_pool,ScalarA(1));
     Kokkos::fill_random(b_y,rand_pool,ScalarB(1));
-
-    Kokkos::fence();
 
     Kokkos::deep_copy(b_org_y,b_y);
 

--- a/unit_test/blas/Test_Blas1_team_update.hpp
+++ b/unit_test/blas/Test_Blas1_team_update.hpp
@@ -66,8 +66,6 @@ namespace Test {
     Kokkos::fill_random(b_y,rand_pool,ScalarB(10));
     Kokkos::fill_random(b_z,rand_pool,ScalarC(10));
 
-    Kokkos::fence();
-
     Kokkos::deep_copy(b_org_z,b_z);
 
     Kokkos::deep_copy(h_b_x,b_x);
@@ -148,8 +146,6 @@ namespace Test {
     Kokkos::fill_random(b_x,rand_pool,ScalarA(10));
     Kokkos::fill_random(b_y,rand_pool,ScalarB(10));
     Kokkos::fill_random(b_z,rand_pool,ScalarC(10));
-
-    Kokkos::fence();
 
     Kokkos::deep_copy(b_org_z,b_z);
 

--- a/unit_test/blas/Test_Blas2_team_gemv.hpp
+++ b/unit_test/blas/Test_Blas2_team_gemv.hpp
@@ -64,8 +64,6 @@ namespace Test {
     Kokkos::fill_random(b_y,rand_pool,ScalarY(10));
     Kokkos::fill_random(b_A,rand_pool,ScalarA(10));
 
-    Kokkos::fence();
-
     Kokkos::deep_copy(b_org_y,b_y);
 
     Kokkos::deep_copy(h_b_x,b_x);

--- a/unit_test/blas/Test_Blas3_gemm.hpp
+++ b/unit_test/blas/Test_Blas3_gemm.hpp
@@ -115,8 +115,6 @@ namespace Test {
     
     Kokkos::deep_copy(C2,C);
 
-    Kokkos::fence();
- 
     struct VanillaGEMM<ViewTypeA,ViewTypeB,ViewTypeC,execution_space> vgemm;
     vgemm.A_t = A_t; vgemm.B_t = B_t;
     vgemm.A_c = A_c; vgemm.B_c = B_c;
@@ -129,8 +127,6 @@ namespace Test {
     Kokkos::parallel_for("KokkosBlas::Test::VanillaGEMM", Kokkos::TeamPolicy<execution_space>(M,Kokkos::AUTO,16), vgemm);
 
     KokkosBlas::gemm(TA,TB,alpha,A,B,beta,C);
-
-    Kokkos::fence();
 
     mag_type diff_C = 0;
     struct DiffGEMM<ViewTypeC,execution_space> diffgemm;

--- a/unit_test/blas/Test_Blas3_trmm.hpp
+++ b/unit_test/blas/Test_Blas3_trmm.hpp
@@ -121,7 +121,6 @@ namespace Test {
       Kokkos::parallel_for("KokkosBlas::Test::NonUnitDiagTRMM", Kokkos::RangePolicy<execution_space>(0,K), nudtrmm);
     }
     Kokkos::fill_random(B, rand_pool, Kokkos::rand<Kokkos::Random_XorShift64<execution_space>, ScalarA>::max());
-    Kokkos::fence();
     
     Kokkos::deep_copy(host_A,  A);
     // Make host_A a lower triangle
@@ -162,11 +161,9 @@ namespace Test {
       vgemm.beta = beta;
       Kokkos::parallel_for("KokkosBlas::Test::VanillaGEMM", Kokkos::TeamPolicy<execution_space>(M,Kokkos::AUTO,16), vgemm);
     }
-    Kokkos::fence();
     Kokkos::deep_copy(host_B_expected, B_expected);
 
     KokkosBlas::trmm(side, uplo, trans, diag, alpha, A, B);
-    Kokkos::fence();
     Kokkos::deep_copy(host_B_actual, B);
 
     bool test_flag = true;

--- a/unit_test/blas/Test_Blas3_trsm.hpp
+++ b/unit_test/blas/Test_Blas3_trsm.hpp
@@ -127,8 +127,6 @@ namespace Test {
     ScalarA alpha_trmm = ScalarA(1)/alpha;
     ScalarA beta       = ScalarA(0);
 
-    Kokkos::fence();
- 
     if ((uplo[0]=='L')||(uplo[0]=='l')) {
       for (int i = 0; i < K-1; i++)
         for (int j = i+1; j < K; j++)


### PR DESCRIPTION
- (#914) Made nrm1 compute the sum of all absolute real and imaginary parts
  to match BLAS/MKL/CUBLAS behavior, rather than sum of magnitudes. Change its test to verify that - passes with both TPL and KokkosKernels impls now.
- Removed CUBLAS impl of nrminf (maximum magnitude). This was implemented in terms of i*amax (since cublas doesn't have nrminf), and was just returning the maximal element without applying abs to it. Rather than do the abs on host or in a 1-element RangePolicy, we might as well just use the KokkosKernels impl which computes the correct nrminf in a single parallel_reduce. Someone on the slack channel ran into this bug a while back.
- Improved blas unit tests
  - verify each output element is correct, not just dotprod of output with itself
  - for complex, create randomized inputs with nonzero imaginary parts
    - sample values between (-10 - 10i) and  (10 + 10i), not between (-10 + 0i and 10 + 0i)
  - enable conj-trans mode testing for gemv

All blas tests pass for serial, openmp, cuda with and without host BLAS and CUBLAS enabled, over the four main scalar types.