### PR TITLE
Fix #917: ctor CrsMat mirror with CrsGraph mirror

### DIFF
--- a/src/sparse/KokkosSparse_CrsMatrix.hpp
+++ b/src/sparse/KokkosSparse_CrsMatrix.hpp
@@ -411,7 +411,7 @@ public:
   typedef SizeType size_type;
 
   //! Type of a host-memory mirror of the sparse matrix.
-  typedef CrsMatrix<ScalarType, OrdinalType, host_mirror_space, MemoryTraits> HostMirror;
+  typedef CrsMatrix<ScalarType, OrdinalType, host_mirror_space, MemoryTraits, SizeType> HostMirror;
   //! Type of the graph structure of the sparse matrix.
   typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, device_type, memory_traits, size_type> StaticCrsGraphType;
   //! Type of the graph structure of the sparse matrix - consistent with Kokkos.
@@ -494,14 +494,36 @@ public:
     //as the constructor of StaticCrsGraph does not allow copy from non const version.
   }
 
+  //! Deep copy constructor (can cross spaces)
+  template<typename S, typename O, typename D, typename M, typename ST>
+  CrsMatrix (const std::string& label,
+      const CrsMatrix<S, O, D, M, ST>& mat_)
+  {
+    typename row_map_type::non_const_type rowmap(Kokkos::ViewAllocateWithoutInitializing("rowmap"), mat_.graph.row_map.extent(0));
+    index_type cols(Kokkos::ViewAllocateWithoutInitializing("cols"), mat_.nnz());
+    values = values_type(Kokkos::ViewAllocateWithoutInitializing("values"), mat_.nnz());
+    Kokkos::deep_copy(rowmap, mat_.graph.row_map);
+    Kokkos::deep_copy(cols, mat_.graph.entries);
+    Kokkos::deep_copy(values, mat_.values);
+
+    numCols_ = mat_.numCols();
+    graph = StaticCrsGraphType(cols, rowmap);
+
+#ifdef KOKKOS_USE_CUSPARSE
+    cusparseCreate (&cusparse_handle);
+    cusparseCreateMatDescr (&cusparse_descr);
+#endif // KOKKOS_USE_CUSPARSE
+  }
+
   /// \brief Construct with a graph that will be shared.
   ///
   /// Allocate the values array for subsquent fill.
-  CrsMatrix (const std::string& arg_label,
-             const staticcrsgraph_type& arg_graph) :
-    graph (arg_graph),
-    values (arg_label, arg_graph.entries.extent(0)),
-    numCols_ (maximum_entry (arg_graph) + 1)
+  template<typename DT, typename A1, typename A2, typename A3, typename ST>
+  CrsMatrix (const std::string& label,
+             const Kokkos::StaticCrsGraph<DT, A1, A2, A3, ST>& graph_) :
+    graph (graph_.entries, graph_.row_map),
+    values (label, graph_.entries.extent(0)),
+    numCols_ (maximum_entry (graph_) + 1)
   {}
 
   /// \brief Constructor that copies raw arrays of host data in
@@ -609,11 +631,12 @@ public:
   /// \param rows [in/out] The row map (containing the offsets to the
   ///   data in each row).
   /// \param cols [in/out] The column indices.
-  CrsMatrix (const std::string& /* label */,
+  template<typename DT, typename A1, typename A2, typename A3, typename ST>
+  CrsMatrix (const std::string&,
              const OrdinalType& ncols,
              const values_type& vals,
-             const staticcrsgraph_type& graph_) :
-    graph (graph_),
+             const Kokkos::StaticCrsGraph<DT, A1, A2, A3, ST>& graph_) :
+    graph (graph_.entries, graph_.row_map),
     values (vals),
     numCols_ (ncols)
   {
@@ -888,7 +911,6 @@ ctor_impl (const std::string &label,
     row_lengths[i] = rows[i + 1] - rows[i];
   }
 
-  str = label;
   graph = Kokkos::create_staticcrsgraph<staticcrsgraph_type> (str.append (".graph"), row_lengths);
   typename values_type::HostMirror h_values = Kokkos::create_mirror_view (values);
   typename index_type::HostMirror h_entries = Kokkos::create_mirror_view (graph.entries);

--- a/src/sparse/KokkosSparse_CrsMatrix.hpp
+++ b/src/sparse/KokkosSparse_CrsMatrix.hpp
@@ -473,13 +473,13 @@ public:
   {}
 
   //! Copy constructor (shallow copy).
-  template<typename SType,
-           typename OType,
-           class DType,
-           class MTType,
-           typename IType>
+  template<typename InScalar,
+           typename InOrdinal,
+           class InDevice,
+           class InMemTraits,
+           typename InSizeType>
   KOKKOS_INLINE_FUNCTION
-  CrsMatrix (const CrsMatrix<SType,OType,DType,MTType,IType> & B) :
+  CrsMatrix (const CrsMatrix<InScalar,InOrdinal,InDevice,InMemTraits,InSizeType> & B) :
     graph (B.graph.entries, B.graph.row_map),
     values (B.values),
     dev_config (B.dev_config),
@@ -495,9 +495,9 @@ public:
   }
 
   //! Deep copy constructor (can cross spaces)
-  template<typename S, typename O, typename D, typename M, typename ST>
-  CrsMatrix (const std::string& label,
-      const CrsMatrix<S, O, D, M, ST>& mat_)
+  template<typename InScalar, typename InOrdinal, typename InDevice, typename InMemTraits, typename InSizeType>
+  CrsMatrix (const std::string&,
+      const CrsMatrix<InScalar, InOrdinal, InDevice, InMemTraits, InSizeType>& mat_)
   {
     typename row_map_type::non_const_type rowmap(Kokkos::ViewAllocateWithoutInitializing("rowmap"), mat_.graph.row_map.extent(0));
     index_type cols(Kokkos::ViewAllocateWithoutInitializing("cols"), mat_.nnz());
@@ -518,9 +518,9 @@ public:
   /// \brief Construct with a graph that will be shared.
   ///
   /// Allocate the values array for subsquent fill.
-  template<typename DT, typename A1, typename A2, typename A3, typename ST>
+  template<typename InOrdinal, typename InLayout, typename InDevice, typename InMemTraits, typename InSizeType>
   CrsMatrix (const std::string& label,
-             const Kokkos::StaticCrsGraph<DT, A1, A2, A3, ST>& graph_) :
+             const Kokkos::StaticCrsGraph<InOrdinal, InLayout, InDevice, InMemTraits, InSizeType>& graph_) :
     graph (graph_.entries, graph_.row_map),
     values (label, graph_.entries.extent(0)),
     numCols_ (maximum_entry (graph_) + 1)
@@ -631,11 +631,11 @@ public:
   /// \param rows [in/out] The row map (containing the offsets to the
   ///   data in each row).
   /// \param cols [in/out] The column indices.
-  template<typename DT, typename A1, typename A2, typename A3, typename ST>
+  template<typename InOrdinal, typename InLayout, typename InDevice, typename InMemTraits, typename InSizeType>
   CrsMatrix (const std::string&,
              const OrdinalType& ncols,
              const values_type& vals,
-             const Kokkos::StaticCrsGraph<DT, A1, A2, A3, ST>& graph_) :
+             const Kokkos::StaticCrsGraph<InOrdinal, InLayout, InDevice, InMemTraits, InSizeType>& graph_) :
     graph (graph_.entries, graph_.row_map),
     values (vals),
     numCols_ (ncols)

--- a/unit_test/sparse/Test_Sparse_CrsMatrix.hpp
+++ b/unit_test/sparse/Test_Sparse_CrsMatrix.hpp
@@ -189,9 +189,36 @@ testCrsMatrix ()
   //printf ("A is %d by %d\n", A.numRows (), A.numCols ());
 }
 
+template <typename scalar_t, typename lno_t, typename size_type, typename device>
+void
+testCrsMatrixHostMirror ()
+{
+  using namespace Test;
+  using crs_matrix = KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>;
+  using crs_matrix_host = typename crs_matrix::HostMirror;
+  using crs_graph = typename crs_matrix::StaticCrsGraphType;
+  using crs_graph_host = typename crs_graph::HostMirror;
+  crs_matrix A = makeCrsMatrix<crs_matrix>();
+  typename crs_matrix::values_type::HostMirror valuesHost("values host", A.nnz());
+  typename crs_matrix::row_map_type::HostMirror rowmapHost("rowmap host", A.numRows() + 1);
+  typename crs_matrix::index_type::HostMirror entriesHost("entries host", A.nnz());
+  crs_graph_host graphHost(entriesHost, rowmapHost);
+  //Test the two CrsMatrix constructors that take the StaticCrsGraph
+  crs_matrix_host Ahost1("Ahost1", graphHost);
+  crs_matrix_host Ahost2("Ahost2", A.numCols(), valuesHost, graphHost);
+  //Test deep copy constructor (can copy between any two spaces)
+  {
+    crs_matrix Bdev("B device", Ahost1);
+    crs_matrix_host Bhost("B host", A);
+  }
+}
+
 #define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE) \
 TEST_F( TestCategory, sparse ## _ ## crsmatrix ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
   testCrsMatrix<SCALAR, ORDINAL, OFFSET, DEVICE> (); \
+} \
+TEST_F( TestCategory, sparse ## _ ## crsmatrix_host_mirror ## _ ## SCALAR ## _ ## ORDINAL ## _ ## OFFSET ## _ ## DEVICE ) { \
+  testCrsMatrixHostMirror<SCALAR, ORDINAL, OFFSET, DEVICE> (); \
 }
 
 

--- a/unit_test/sparse/Test_Sparse_CrsMatrix.hpp
+++ b/unit_test/sparse/Test_Sparse_CrsMatrix.hpp
@@ -211,6 +211,16 @@ testCrsMatrixHostMirror ()
     crs_matrix Bdev("B device", Ahost1);
     crs_matrix_host Bhost("B host", A);
   }
+  //Test the empty (0x0, 0 entries) case - zero-length rowmap.
+  typename crs_graph::row_map_type::non_const_type zeroRowmap;
+  typename crs_graph::entries_type zeroEntries;
+  typename crs_matrix::values_type zeroValues;
+  crs_matrix zero("ZeroRow", 0, 0, 0, zeroValues, zeroRowmap, zeroEntries);
+  crs_matrix_host zeroHost("zero1Host", zero);
+  EXPECT_EQ(zeroHost.numRows(), 0);
+  EXPECT_EQ(zeroHost.numCols(), 0);
+  EXPECT_EQ(zeroHost.nnz(), 0);
+  EXPECT_EQ(zeroHost.graph.row_map.extent(0), 0);
 }
 
 #define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE) \


### PR DESCRIPTION
Make CrsMatrix constructors taking StaticCrsGraph more permissive on the graph type (if the entries and rowmap views can be shallow copied, it will work). This allows CrsMatrix::HostMirror to be constructed using a CrsMatrix::StaticCrsGraphType::HostMirror (#917), which is needed by Tpetra.

Also add deep copy constructor for CrsMatrix at @lucbv suggestion. Takes a label and
any other CrsMatrix<...>, and will work as long as it has same scalar/index/offset types.