### PR TITLE
Workaround using new/delete in kernel code

### DIFF
--- a/src/graph/impl/KokkosGraph_Distance1Color_impl.hpp
+++ b/src/graph/impl/KokkosGraph_Distance1Color_impl.hpp
@@ -2058,7 +2058,7 @@ public:
     Kokkos::View<size_type, MyTempMemorySpace> newFrontierSize_;
     size_type maxColors_;
     color_view_type colors_;
-    Kokkos::View<int *, MyTempMemorySpace> bannedColors_;
+    Kokkos::View<int **, MyTempMemorySpace> bannedColors_;
 
     functorDeterministicColoring(
         const_lno_row_view_t rowPtr, const_lno_nnz_view_t colInd,
@@ -2077,21 +2077,20 @@ public:
           newFrontierSize_(newFrontierSize),
           maxColors_(maxColors),
           colors_(colors),
-          bannedColors_("KokkosKernels::bannedColors",
-                        maxColors_ * frontier.size()) {}
+          bannedColors_("KokkosKernels::bannedColors", frontier.size(),
+                        maxColors_) {}
 
     KOKKOS_INLINE_FUNCTION
     void operator() (const size_type frontierIdx) const {
       typedef typename std::remove_reference< decltype( newFrontierSize_() ) >::type atomic_incr_type;
       size_type frontierNode = frontier_(frontierIdx);
-      int *bannedColors      = bannedColors_.data() + maxColors_ * frontierIdx;
       for(size_type colorIdx= 0; colorIdx < maxColors_; ++colorIdx) {
-        bannedColors[colorIdx] = 0;
+        bannedColors_(frontierIdx, colorIdx) = 0;
       }
 
       // Loop over neighbors, find banned colors, decrement dependency and update newFrontier
       for(size_type neigh = xadj_(frontierNode); neigh < xadj_(frontierNode + 1); ++neigh) {
-        bannedColors[colors_(adj_(neigh))] = 1;
+        bannedColors_(frontierIdx, colors_(adj_(neigh))) = 1;
 
         // We want to avoid the cost of atomic operations when not needed
         // so let's check that the node is not already colored, i.e.
@@ -2108,7 +2107,7 @@ public:
       } // Loop over neighbors
 
       for(size_type color = 1; color < maxColors_; ++color) {
-        if(bannedColors[color] == 0) {
+        if (bannedColors_(frontierIdx, color) == 0) {
           colors_(frontierNode) = color;
           break;
         }


### PR DESCRIPTION
Using `new` and `delete` is not supported by all backends. Hence, this pull request allocates global memory instead. Scratch memory would potentially be more in line with the previous implementation but we can't use that for `RangePolicy`.