### PR TITLE
Add static_assert/throw in batched eigendecomp

### DIFF
--- a/src/batched/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
+++ b/src/batched/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
@@ -57,6 +57,7 @@ namespace KokkosBatched {
 		  RealType * w,  const int wlen) {
       /// until debugging is done, comment out the code
       /// testing happens only for TPLs on host.
+      static_assert(false, "Serial eigendecomposition on device and/or without LAPACK is not implemented yet");
 //       typedef RealType real_type;
 //       typedef Kokkos::Details::ArithTraits<real_type> ats;
 
@@ -356,9 +357,12 @@ namespace KokkosBatched {
 	   RealType * UR, const int urs0, const int urs1,
 	   RealType * w,  const int wlen) {
 #if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
-      if (as0 == 1 || as1 == 1) {
+      //if (as0 == 1 || as1 == 1) {
 	/// column major or row major and it runs on host
 	/// potentially it can run tpls internally 
+        // NOTE BMK: If LAPACK not enabled, this will static_assert.
+        //           If neither stride is unit, will runtime assert.
+        //           Otherwise will succeed using LAPACK.
 	host_invoke(m,
 		    A, as0, as1,
 		    er, ers,
@@ -366,6 +370,7 @@ namespace KokkosBatched {
 		    UL, uls0, uls1,
 		    UR, urs0, urs1,
 		    w, wlen);
+        /*
       } else {
 	/// arbitrary strides should be handled by native implementation
 	device_invoke(m,
@@ -375,7 +380,9 @@ namespace KokkosBatched {
 		      UL, uls0, uls1,
 		      UR, urs0, urs1,
 		      w, wlen);
+        throw std::runtime_error("Serial eigendecomposition without unit stride  implemented yet.");
       }
+      */
 #else
       /// device code runs 
       device_invoke(m,

--- a/src/batched/KokkosBatched_Eigendecomposition_TeamVector_Internal.hpp
+++ b/src/batched/KokkosBatched_Eigendecomposition_TeamVector_Internal.hpp
@@ -76,6 +76,8 @@ namespace KokkosBatched {
            RealType * UL, const int uls0, const int uls1,
            RealType * UR, const int urs0, const int urs1,
            RealType * w,  const int wlen) {
+      static_assert(false, "TeamVector eigendecomposition is not implemented yet.");
+      /*
 #if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
       if (as0 == 1 || as1 == 1) {
 	/// column major or row major and it runs on host
@@ -100,6 +102,7 @@ namespace KokkosBatched {
 		      UL, uls0, uls1,
 		      UR, urs0, urs1,
 		      w, wlen);
+        throw std::runtime_error("TeamVector eigendecomposition is not implemented yet.");
       }
 #else
       /// device code runs 
@@ -111,6 +114,7 @@ namespace KokkosBatched {
 		    UR, urs0, urs1,
 		    w, wlen);
 #endif
+*/
       return 0;
     }
   };

--- a/unit_test/batched/Test_Batched_SerialEigendecomposition.hpp
+++ b/unit_test/batched/Test_Batched_SerialEigendecomposition.hpp
@@ -1,5 +1,6 @@
 /// \author Kyungjoo Kim (kyukim@sandia.gov)
 
+/*
 #include "gtest/gtest.h"
 #include "Kokkos_Core.hpp"
 #include "Kokkos_Random.hpp"
@@ -111,3 +112,4 @@ int test_batched_serial_eigendecomposition() {
   
   return 0;
 }
+*/

--- a/unit_test/batched/Test_Batched_SerialEigendecomposition_Real.hpp
+++ b/unit_test/batched/Test_Batched_SerialEigendecomposition_Real.hpp
@@ -1,3 +1,4 @@
+/*
 #if defined(KOKKOSKERNELS_INST_FLOAT)
 TEST_F( TestCategory, batched_scalar_serial_eigendecomposition_float ) {
   test_batched_serial_eigendecomposition<TestExecSpace,float>();
@@ -9,5 +10,5 @@ TEST_F( TestCategory, batched_scalar_serial_eigendecomposition_double ) {
   test_batched_serial_eigendecomposition<TestExecSpace,double>();
 }
 #endif
-
+*/
 

--- a/unit_test/batched/Test_Batched_TeamVectorEigendecomposition.hpp
+++ b/unit_test/batched/Test_Batched_TeamVectorEigendecomposition.hpp
@@ -1,5 +1,6 @@
 /// \author Kyungjoo Kim (kyukim@sandia.gov)
 
+/*
 #include "gtest/gtest.h"
 #include "Kokkos_Core.hpp"
 #include "Kokkos_Random.hpp"
@@ -114,3 +115,4 @@ int test_batched_teamvector_eigendecomposition() {
   
   return 0;
 }
+*/

--- a/unit_test/batched/Test_Batched_TeamVectorEigendecomposition_Real.hpp
+++ b/unit_test/batched/Test_Batched_TeamVectorEigendecomposition_Real.hpp
@@ -1,3 +1,4 @@
+/*
 #if defined(KOKKOSKERNELS_INST_FLOAT)
 TEST_F( TestCategory, batched_scalar_teamvector_eigendecomposition_float ) {
   test_batched_teamvector_eigendecomposition<TestExecSpace,float>();
@@ -9,5 +10,4 @@ TEST_F( TestCategory, batched_scalar_teamvector_eigendecomposition_double ) {
   test_batched_teamvector_eigendecomposition<TestExecSpace,double>();
 }
 #endif
-
-
+*/


### PR DESCRIPTION
so that users know it's not supported yet. Disable the unit tests for it.
Serial eigendecomposition on host with LAPACK enabled will still work.
This would at least tell users right away (like in #873) that they can't use it yet.