### PR TITLE
Added code to allow KokkosKernels coloring to accept partial colorings

### DIFF
--- a/src/graph/KokkosGraph_Distance1Color.hpp
+++ b/src/graph/KokkosGraph_Distance1Color.hpp
@@ -73,8 +73,12 @@ void graph_color_symbolic(
 
   gch->set_tictoc(handle->get_verbose());
 
-  color_view_type colors_out = color_view_type("Graph Colors", num_rows);
-
+  color_view_type colors_out;
+  if(gch->get_vertex_colors().use_count() > 0){
+    colors_out = gch->get_vertex_colors();
+  } else {
+    colors_out = color_view_type("Graph Colors", num_rows);
+  }
 
   typedef typename Impl::GraphColor
       <typename KernelHandle::GraphColoringHandleType, lno_row_view_t_, lno_nnz_view_t_> BaseGraphColoring;

--- a/src/graph/KokkosGraph_Distance1ColorHandle.hpp
+++ b/src/graph/KokkosGraph_Distance1ColorHandle.hpp
@@ -158,6 +158,10 @@ private:
   nnz_lno_persistent_work_view_t lower_triangle_src;
   nnz_lno_persistent_work_view_t lower_triangle_dst;
 
+  bool use_vtx_list;
+  nnz_lno_temp_work_view_t vertex_list;
+  size_type vertex_list_size;
+
   color_view_t vertex_colors;
   bool is_coloring_called_before;
   nnz_lno_t num_colors;
@@ -189,7 +193,7 @@ private:
     overall_coloring_time_phase5(0),
     coloring_time(0),
     num_phases(0), size_of_edge_list(0), lower_triangle_src(), lower_triangle_dst(),
-    vertex_colors(), is_coloring_called_before(false), num_colors(0)
+    use_vtx_list(false), vertex_colors(), is_coloring_called_before(false), num_colors(0)
   {
     this->choose_default_algorithm();
     this->set_defaults(this->coloring_algorithm_type);
@@ -640,7 +644,15 @@ private:
   int get_num_phases() const { return this->num_phases;}
   color_view_t get_vertex_colors() const {return this->vertex_colors;}
   bool is_coloring_called() const {return this->is_coloring_called_before;}
+  bool get_use_vtx_list() const {return this->use_vtx_list;}
+  nnz_lno_temp_work_view_t get_vertex_list() const {return this->vertex_list;}
+  size_type get_vertex_list_size() const {return this->vertex_list_size;}
   //setters
+  void set_vertex_list(nnz_lno_temp_work_view_t vertex_list_, size_type vertex_list_size_){
+    this->vertex_list = vertex_list_;
+    this->vertex_list_size = vertex_list_size_;
+    this->use_vtx_list = true;
+  }
   void set_coloring_algo_type(const ColoringAlgorithm &col_algo){this->coloring_algorithm_type = col_algo;}
   void set_conflict_list_type(const ConflictList &cl){this->conflict_list_type = cl;}
   void set_min_reduction_for_conflictlist(const double &min_reduction){this->min_reduction_for_conflictlist = min_reduction;}

--- a/src/graph/KokkosGraph_Distance2ColorHandle.hpp
+++ b/src/graph/KokkosGraph_Distance2ColorHandle.hpp
@@ -120,6 +120,10 @@ class GraphColorDistance2Handle
     double overall_coloring_time_phase5;      //
     double coloring_time;                     // the time that it took to color the graph
 
+    bool use_vtx_list;
+    nnz_lno_temp_work_view_type vertex_list;
+    size_type vertex_list_size;    
+
     int num_phases;      // Number of phases used by the coloring algorithm
 
     color_view_type vertex_colors;
@@ -144,6 +148,7 @@ class GraphColorDistance2Handle
         , overall_coloring_time_phase4(0)
         , overall_coloring_time_phase5(0)
         , coloring_time(0)
+        , use_vtx_list(false)
         , num_phases(0)
         , vertex_colors()
         , is_coloring_called_before(false)
@@ -282,7 +287,16 @@ class GraphColorDistance2Handle
 
     bool is_coloring_called() const { return this->is_coloring_called_before; }
 
+    bool get_use_vtx_list() const { return this->use_vtx_list; }
+    nnz_lno_temp_work_view_type get_vertex_list() const { return this->vertex_list; }
+    size_type get_vertex_list_size() const { return this->vertex_list_size; }
+
     // setters
+    void set_vertex_list(nnz_lno_temp_work_view_type vertex_list_, size_type vertex_list_size_){
+      this->vertex_list = vertex_list_;
+      this->vertex_list_size = vertex_list_size_;
+      this->use_vtx_list = true;
+    }
     void set_coloring_called() { this->is_coloring_called_before = true; }
 
     void set_coloring_algo_type(const GraphColoringAlgorithmDistance2& col_algo) { this->coloring_algorithm_type = col_algo; }

--- a/src/graph/impl/KokkosGraph_Distance1Color_impl.hpp
+++ b/src/graph/impl/KokkosGraph_Distance1Color_impl.hpp
@@ -367,11 +367,17 @@ public:
     //the conflictlist
     nnz_lno_temp_work_view_t current_vertexList =
         nnz_lno_temp_work_view_t(Kokkos::ViewAllocateWithoutInitializing("vertexList"), this->nv);
-
-    //init vertexList sequentially.
-    Kokkos::parallel_for("KokkosGraph::GraphColoring::InitList",
-        my_exec_space(0, this->nv), functorInitList<nnz_lno_temp_work_view_t> (current_vertexList));
-
+    nnz_lno_t current_vertexListLength = this->nv;
+    
+    if(this->cp->get_use_vtx_list()){
+      //get the vertexList from the color handle, if it exists.
+      current_vertexList = this->cp->get_vertex_list();
+      current_vertexListLength = this->cp->get_vertex_list_size();
+    } else {
+      //init vertexList sequentially.
+      Kokkos::parallel_for("KokkosGraph::GraphColoring::InitList",
+          my_exec_space(0, this->nv), functorInitList<nnz_lno_temp_work_view_t> (current_vertexList));
+    }
 
     // the next iteration's conflict list
     nnz_lno_temp_work_view_t next_iteration_recolorList;
@@ -388,7 +394,6 @@ public:
     }
 
     nnz_lno_t numUncolored = this->nv;
-    nnz_lno_t current_vertexListLength = this->nv;
 
 
     double t, total=0.0;
@@ -2310,7 +2315,7 @@ public:
     nnz_lno_temp_work_view_t color_set ("color_set", this->nv); //initialized with zero.
     //initialize colors, color bans
     Kokkos::parallel_for ("KokkosGraph::GraphColoring::initColors",
-        my_exec_space (0, this->nv) , init_colors (kok_colors, color_ban, numInitialColors));
+        my_exec_space (0, this->nv) , init_colors (kok_colors, color_ban, numInitialColors, color_set));
     //std::cout << "nv:" << this->nv << " init_colors" << std::endl;
 
     //worklist
@@ -2521,23 +2526,27 @@ public:
     color_view_type kokcolors;
     color_temp_work_view_type color_ban; //colors
     color_t hash; //the number of colors to be assigned initially.
+    nnz_lno_temp_work_view_t color_set;
 
     //the value to initialize the color_ban_. We avoid using the first bit representing the sign.
     //Therefore if idx is int, it can represent 32-1 colors. Use color_set to represent more.
     color_t color_ban_init_val;
 
 
-    init_colors (color_view_type colors,color_temp_work_view_type color_ban_,color_t hash_):
-      kokcolors(colors), color_ban(color_ban_), hash(hash_){
+    init_colors (color_view_type colors,color_temp_work_view_type color_ban_,color_t hash_, nnz_lno_temp_work_view_t color_set_):
+      kokcolors(colors), color_ban(color_ban_), hash(hash_), color_set(color_set_){
       color_t tmp = 1;
       color_ban_init_val = tmp <<( sizeof(color_t) * 8 -1);
     }
 
     KOKKOS_INLINE_FUNCTION
     void operator()(const size_type &ii) const {
-      //set colors based on their indices.
-      color_t tmp1 = 1;
-      kokcolors(ii) = tmp1 << (ii % hash);
+      //set colors based on their input colors.
+      if(kokcolors(ii) > 0){
+        color_t colorsize = sizeof(color_t) * 8 - 1;
+        color_set(ii) = (kokcolors(ii) - 1) / colorsize;
+        kokcolors(ii) = 1 << ((kokcolors(ii) - 1) % colorsize);
+      }
       color_ban(ii) = color_ban_init_val;
     }
   };

--- a/src/graph/impl/KokkosGraph_Distance2Color_impl.hpp
+++ b/src/graph/impl/KokkosGraph_Distance2Color_impl.hpp
@@ -191,7 +191,12 @@ class GraphColorDistance2
     {
         //Delegate to different coloring functions, depending on algorithm
         using_edge_filtering = false;
-        color_view_type colors_out("Graph Colors", this->nr);
+        color_view_type colors_out;
+        if(gc_handle->get_vertex_colors().use_count() > 0){
+          colors_out = gc_handle->get_vertex_colors();
+        } else {
+          colors_out = color_view_type("Graph Colors", this->nr);
+        }
         switch(this->gc_handle->get_coloring_algo_type())
         {
           case COLORING_D2_VB_BIT_EF:
@@ -244,9 +249,16 @@ class GraphColorDistance2
         lno_view_t current_vertexList(
             Kokkos::ViewAllocateWithoutInitializing("vertexList"), this->nr);
 
-        // init conflictlist sequentially.
-        Kokkos::parallel_for("InitList", range_policy_type(0, this->nr), functorInitList<lno_view_t>(current_vertexList));
-
+        lno_t current_vertexListLength = this->nr;
+        
+        if(this->gc_handle->get_use_vtx_list()){
+          //init conflict list from coloring handle
+          current_vertexList = this->gc_handle->get_vertex_list();
+          current_vertexListLength = this->gc_handle->get_vertex_list_size();
+        } else {
+          // init conflictlist sequentially.
+          Kokkos::parallel_for("InitList", range_policy_type(0, this->nr), functorInitList<lno_view_t>(current_vertexList));
+        }
         // Next iteratons's conflictList
         lno_view_t next_iteration_recolorList(Kokkos::ViewAllocateWithoutInitializing("recolorList"), this->nr);
 
@@ -255,7 +267,6 @@ class GraphColorDistance2
 
         lno_t numUncolored             = this->nr;
         lno_t numUncoloredPreviousIter = this->nr + 1;
-        lno_t current_vertexListLength = this->nr;
 
         double              time;
         double              total_time = 0.0;
@@ -445,7 +456,7 @@ class GraphColorDistance2
               break;
             }
           }
-          if(color)
+          if(color && (colors(v) == 0 || colors(v) == CONFLICTED || colors(v) == UNCOLORABLE))
           {
             //Color v
             colors(v) = color;
@@ -466,7 +477,7 @@ class GraphColorDistance2
               }
             }
           }
-          else
+          else if (colors(v) == 0 || colors(v) == CONFLICTED || colors(v) == UNCOLORABLE)
           {
             colors(v) = UNCOLORABLE;
           }
@@ -737,6 +748,31 @@ class GraphColorDistance2
           lno_t vertsPerThread = 1;
           lno_t workBatches = (currentWork + vertsPerThread - 1) / vertsPerThread;
           timer.reset();
+          //if still using this color set, refresh forbidden.
+          //This avoids using too many colors, by relying on forbidden from before previous conflict resolution (which is now stale).
+          //Refreshing forbidden before conflict resolution ensures that previously-colored vertices do not get recolored.
+          switch(batch)
+          {
+            case 1:
+              Kokkos::parallel_for("NB D2 Forbidden", range_policy_type(0, numCols),
+                  NB_RefreshForbidden<1>(colorBase, forbidden, colors_out, this->t_xadj, this->t_adj, numVerts));
+              break;
+            case 2:
+              Kokkos::parallel_for("NB D2 Forbidden", range_policy_type(0, numCols),
+                  NB_RefreshForbidden<2>(colorBase, forbidden, colors_out, this->t_xadj, this->t_adj, numVerts));
+              break;
+            case 4:
+              Kokkos::parallel_for("NB D2 Forbidden", range_policy_type(0, numCols),
+                  NB_RefreshForbidden<4>(colorBase, forbidden, colors_out, this->t_xadj, this->t_adj, numVerts));
+              break;
+            case 8:
+              Kokkos::parallel_for("NB D2 Forbidden", range_policy_type(0, numCols),
+                  NB_RefreshForbidden<8>(colorBase, forbidden, colors_out, this->t_xadj, this->t_adj, numVerts));
+              break;
+            default:;
+          }
+          forbiddenTime += timer.seconds();
+          timer.reset();
           switch(batch)
           {
             case 1:
@@ -788,33 +824,6 @@ class GraphColorDistance2
               NB_Worklist(colors_out, worklist, worklen, numVerts), currentWork);
           worklistTime += timer.seconds();
           timer.reset();
-          //if still using this color set, refresh forbidden.
-          //This avoids using too many colors, by relying on forbidden from before conflict resolution (which is now stale).
-          if(currentWork)
-          {
-            switch(batch)
-            {
-              case 1:
-                Kokkos::parallel_for("NB D2 Forbidden", range_policy_type(0, numCols),
-                    NB_RefreshForbidden<1>(colorBase, forbidden, colors_out, this->t_xadj, this->t_adj, numVerts));
-                break;
-              case 2:
-                Kokkos::parallel_for("NB D2 Forbidden", range_policy_type(0, numCols),
-                    NB_RefreshForbidden<2>(colorBase, forbidden, colors_out, this->t_xadj, this->t_adj, numVerts));
-                break;
-              case 4:
-                Kokkos::parallel_for("NB D2 Forbidden", range_policy_type(0, numCols),
-                    NB_RefreshForbidden<4>(colorBase, forbidden, colors_out, this->t_xadj, this->t_adj, numVerts));
-                break;
-              case 8:
-                Kokkos::parallel_for("NB D2 Forbidden", range_policy_type(0, numCols),
-                    NB_RefreshForbidden<8>(colorBase, forbidden, colors_out, this->t_xadj, this->t_adj, numVerts));
-                break;
-              default:;
-            }
-            forbiddenTime += timer.seconds();
-            timer.reset();
-          }
           iter++;
         }
         //Will need to run with a different color base, so rebuild the work list


### PR DESCRIPTION
These code changes allow KokkosKernels' coloring routines to accept partial colorings and prevent any previously-colored vertex from being recolored. These changes do not significantly impact the existing interface or performance of the coloring code, to my knowledge. Zoltan2's distributed coloring depends on these changes.

~/fork.kokkos-kernels-coloring/scripts/cm_test_all_sandia --kokkoskernels-path=/ascldap/users/ibogle/fork.kokkos-kernels-coloring/ --kokkos-path=/ascldap/users/ibogle/kokkos --arch=Power8,Kepler80 cuda/10.1.105 --spot-check
Running on machine: white
WARNING!! THE FOLLOWING CHANGES ARE UNCOMMITTED!! :
 M src/graph/KokkosGraph_Distance1Color.hpp
 M src/graph/KokkosGraph_Distance1ColorHandle.hpp
 M src/graph/KokkosGraph_Distance2ColorHandle.hpp
 M src/graph/impl/KokkosGraph_Distance1Color_impl.hpp
 M src/graph/impl/KokkosGraph_Distance2Color_impl.hpp
?? testing/

KokkosKernels Repository Status:  5016b18de5b7f93e7a36be720c0e9ede00fb8cd0 Merge pull request #936 from ndellingwood/fix-cplx-arithtraits

Kokkos Repository Status:  f654c0c5da3dc40f568394f50f9a87893d333691 Merge pull request #3928 from masterleinad/sycl_fix_profiling_deallocate_data


Going to test compilers:  cuda/10.1.105
Testing compiler cuda/10.1.105
Unrecognized compiler cuda/10.1.105 when looking for Spack variants
Unrecognized compiler cuda/10.1.105 when looking for Spack variants
Unrecognized compiler cuda/10.1.105 when looking for Spack variants
  Starting job cuda-10.1.105-Cuda_OpenMP-release
kokkos devices: Cuda,OpenMP
kokkos arch: Power8,Kepler80
kokkos options: 
kokkos cuda options: 
kokkos cxxflags: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wuninitialized 
extra_args: 
kokkoskernels scalars: 'double,complex_double'
kokkoskernels ordinals: int
kokkoskernels offsets: int,size_t
kokkoskernels layouts: LayoutLeft
  PASSED cuda-10.1.105-Cuda_OpenMP-release
Unrecognized compiler cuda/10.1.105 when looking for Spack variants
Unrecognized compiler cuda/10.1.105 when looking for Spack variants
Unrecognized compiler cuda/10.1.105 when looking for Spack variants
  Starting job cuda-10.1.105-Cuda_Serial-release
kokkos devices: Cuda,Serial
kokkos arch: Power8,Kepler80
kokkos options: 
kokkos cuda options: 
kokkos cxxflags: -O3 -Wall -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wuninitialized 
extra_args: 
kokkoskernels scalars: 'double,complex_double'
kokkoskernels ordinals: int
kokkoskernels offsets: int,size_t
kokkoskernels layouts: LayoutLeft
  PASSED cuda-10.1.105-Cuda_Serial-release
#######################################################
PASSED TESTS
#######################################################
cuda-10.1.105-Cuda_OpenMP-release build_time=723 run_time=166
cuda-10.1.105-Cuda_Serial-release build_time=688 run_time=216


