### PR TITLE
host only macro: adding macro to checks for any device backend

### DIFF
--- a/cmake/KokkosKernels_config.h.in
+++ b/cmake/KokkosKernels_config.h.in
@@ -119,6 +119,13 @@
 #endif
 #endif
 
+#if !defined(KOKKOS_ENABLE_CUDA) \
+  && !defined(KOKKOS_ENABLE_HIP)/* \
+  && !defined(KOKKOS_ENABLE_SYCL) \
+  && !defined(KOKKOS_ENABLE_OPENMPTARGET) */
+#define KOKKOSKERNELS_ENABLE_HOST_ONLY
+#endif
+
 
 /*
  * "Optimization level" for computational kernels in this subpackage.

--- a/cmake/KokkosKernels_config.h.in
+++ b/cmake/KokkosKernels_config.h.in
@@ -120,9 +120,9 @@
 #endif
 
 #if !defined(KOKKOS_ENABLE_CUDA) \
-  && !defined(KOKKOS_ENABLE_HIP)/* \
+  && !defined(KOKKOS_ENABLE_HIP) \
   && !defined(KOKKOS_ENABLE_SYCL) \
-  && !defined(KOKKOS_ENABLE_OPENMPTARGET) */
+  && !defined(KOKKOS_ENABLE_OPENMPTARGET)
 #define KOKKOSKERNELS_ENABLE_HOST_ONLY
 #endif
 

--- a/unit_test/cuda/Test_Cuda_Batched.cpp
+++ b/unit_test/cuda/Test_Cuda_Batched.cpp
@@ -1,9 +1,7 @@
 #ifndef TEST_CUDA_BATCHED_CPP
 #define TEST_CUDA_BATCHED_CPP
-#define KOKKOSKERNELS_CUDA_BATCHED_TESTS
 
 #include<Test_Cuda.hpp>
 #include<Test_Batched.hpp>
 
-#undef KOKKOSKERNELS_CUDA_BATCHED_TESTS
 #endif // TEST_CUDA_BATCHED_CPP


### PR DESCRIPTION
This is becoming increasingly necessary to check if code can be compiled on device or only on host.
This macro provides a simpler version to express that.
Also cleaning up an unused macro.

Next step will be to clean-up some code so that we start using it instead of the current
```c++
#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP)
 host code
#endif
```