### PR TITLE
unit_test/batched: Remove *_half fns from gemm unit tests

### DIFF
--- a/unit_test/batched/Test_Batched_SerialGemm.hpp
+++ b/unit_test/batched/Test_Batched_SerialGemm.hpp
@@ -16,235 +16,178 @@ using namespace KokkosBatched;
 namespace Test {
 namespace Gemm {
 
-  template<typename TA, typename TB>
-  struct ParamTag { 
-    typedef TA transA;
-    typedef TB transB;
-  };
- 
-  template<typename DeviceType,
-           typename ViewType,
-           typename ScalarType,
-           typename ParamTagType, 
-           typename AlgoTagType>
-  struct Functor_TestBatchedSerialGemm {
-    ViewType _a, _b, _c;
-    
-    ScalarType _alpha, _beta;
-    
-    KOKKOS_INLINE_FUNCTION
-    Functor_TestBatchedSerialGemm(const ScalarType alpha, 
-            const ViewType &a,
-            const ViewType &b,
-            const ScalarType beta,
-            const ViewType &c)
+template <typename TA, typename TB>
+struct ParamTag {
+  typedef TA transA;
+  typedef TB transB;
+};
+
+template <typename DeviceType, typename ViewType, typename ScalarType,
+          typename ParamTagType, typename AlgoTagType>
+struct Functor_TestBatchedSerialGemm {
+  ViewType _a, _b, _c;
+
+  ScalarType _alpha, _beta;
+
+  KOKKOS_INLINE_FUNCTION
+  Functor_TestBatchedSerialGemm(const ScalarType alpha, const ViewType &a,
+                                const ViewType &b, const ScalarType beta,
+                                const ViewType &c)
       : _a(a), _b(b), _c(c), _alpha(alpha), _beta(beta) {}
-    
-    KOKKOS_INLINE_FUNCTION
-    void operator()(const ParamTagType &, const int k) const {
-      auto aa = Kokkos::subview(_a, k, Kokkos::ALL(), Kokkos::ALL());
-      auto bb = Kokkos::subview(_b, k, Kokkos::ALL(), Kokkos::ALL());
-      auto cc = Kokkos::subview(_c, k, Kokkos::ALL(), Kokkos::ALL());
-      
-      SerialGemm<typename ParamTagType::transA,
-        typename ParamTagType::transB,
-        AlgoTagType>::
-        invoke(_alpha, aa, bb, _beta, cc);
-    }
-    
-    inline
-    void run() {
-      typedef typename ViewType::value_type value_type;
-      std::string name_region("KokkosBatched::Test::SerialGemm");
-      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
-                                      std::is_same<value_type,double>::value ? "::Double" :
-                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
-                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
-      std::string name = name_region + name_value_type;
-      Kokkos::Profiling::pushRegion( name.c_str() );
-      Kokkos::RangePolicy<DeviceType,ParamTagType> policy(0, _c.extent(0));
-      Kokkos::parallel_for(name.c_str(), policy, *this);            
-      Kokkos::Profiling::popRegion();
-    }
-  };
 
-template<typename DeviceType,
-        typename ViewType,
-        typename ScalarType,
-        typename ParamTagType, 
-        typename AlgoTagType>
-  void impl_test_batched_gemm_half(const int N, const int matAdim1, const int matAdim2, const int matBdim1, const int matBdim2,
-      const int matCdim1, const int matCdim2) {
-    using layout_type = typename ViewType::array_layout;
-    using execution_space = typename DeviceType::execution_space;
-    using host_value_type = float;
-    using transA = typename ParamTagType::transA;
-    using transB = typename ParamTagType::transB;
-    using ViewType_host_value_type = Kokkos::View<host_value_type***,layout_type,DeviceType>;
-    using ats = Kokkos::Details::ArithTraits<host_value_type>;
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const ParamTagType &, const int k) const {
+    auto aa = Kokkos::subview(_a, k, Kokkos::ALL(), Kokkos::ALL());
+    auto bb = Kokkos::subview(_b, k, Kokkos::ALL(), Kokkos::ALL());
+    auto cc = Kokkos::subview(_c, k, Kokkos::ALL(), Kokkos::ALL());
 
-    /// randomized input testing views
-    ScalarType alpha = ScalarType(1.5);
-    ScalarType beta = ScalarType(3.0);
-
-    ViewType
-      a_expected("a_expected", N, matAdim1, matAdim2), a1("a1", N, matAdim1, matAdim2),
-      b_expected("b_expected", N, matBdim1, matBdim2), b1("b1", N, matBdim1, matBdim2),
-      c_expected("c_expected", N, matCdim1, matCdim2), c1("c1", N, matCdim1, matCdim2);
-
-    // fill_random does not support half precision, so use float to
-    // generate random numbers and copy to half views with deep_copy
-    Kokkos::Random_XorShift64_Pool<execution_space> random(13718);
-    ViewType_host_value_type
-      a_expected_host_value_type("a_expected_host_value_type", N, matAdim1, matAdim2),
-      b_expected_host_value_type("b_expected_host_value_type", N, matBdim1, matBdim2),
-      c_expected_host_value_type("c_expected_host_value_type", N, matCdim1, matCdim2),
-      c1_host_value_type("c1_host_value_type", N, matCdim1, matCdim2);
-
-    Kokkos::fill_random(a_expected_host_value_type, random, host_value_type(1.0));
-    Kokkos::fill_random(b_expected_host_value_type, random, host_value_type(1.0));
-    Kokkos::fill_random(c_expected_host_value_type, random, host_value_type(1.0));
-
-    Kokkos::fence();
-
-    Kokkos::deep_copy(a_expected, a_expected_host_value_type);
-    Kokkos::deep_copy(b_expected, b_expected_host_value_type);
-    Kokkos::deep_copy(c_expected, c_expected_host_value_type);
-
-    Kokkos::deep_copy(a1, a_expected);
-    Kokkos::deep_copy(b1, b_expected);
-    Kokkos::deep_copy(c1, c_expected);
-
-    Functor_BatchedVanillaGEMM<ViewType, ViewType, ViewType, execution_space> vgemm;
-    vgemm.A_t = std::is_same<transA, Trans::Transpose>::value;
-    vgemm.B_t = std::is_same<transB, Trans::Transpose>::value;
-    vgemm.A_c = vgemm.B_c = false;
-    vgemm.A = a_expected;
-    vgemm.B = b_expected;
-    vgemm.C = c_expected;
-    vgemm.alpha = alpha;
-    vgemm.beta = beta;
-    vgemm.run(); // Compute c_expected
-    Functor_TestBatchedSerialGemm<DeviceType,ViewType,ScalarType,
-      ParamTagType,AlgoTagType>(alpha, a1, b1, beta, c1).run();
-
-    // Convert and copy half to host_value_type, on device
-    Kokkos::deep_copy(c_expected_host_value_type, c_expected);
-    Kokkos::deep_copy(c1_host_value_type, c1);
-
-    // We may not have half precision on the host, use single precision here.
-    // For comparison send it to host, in host compatible type
-    typename ViewType_host_value_type::HostMirror c_expected_host_value_type_host = Kokkos::create_mirror_view(c_expected_host_value_type);
-    typename ViewType_host_value_type::HostMirror c1_host_value_type_host = Kokkos::create_mirror_view(c1_host_value_type);
-
-    // Copy host_value_type on device to host_value_type on host
-    Kokkos::deep_copy(c_expected_host_value_type_host, c_expected_host_value_type);
-    Kokkos::deep_copy(c1_host_value_type_host, c1_host_value_type);
-
-    Kokkos::fence();
-
-    // check c_expected = c1 ; this eps is about 2^-9
-    // Set mag_type to host_value_type, we may not have half precision on host
-    using mag_type = host_value_type;
-    mag_type sum(1), diff(0);
-
-    mag_type eps = (mag_type) (1 << 1) * KOKKOSKERNELS_IMPL_FP16_EPSILON;
-
-    for (int k=0;k<N;++k)
-      for (int i=0;i<matCdim1;++i) 
-        for (int j=0;j<matCdim2;++j) {
-          sum  += ats::abs(c_expected_host_value_type_host(k,i,j));
-          diff += ats::abs(c_expected_host_value_type_host(k,i,j)-c1_host_value_type_host(k,i,j));
-        }
-    EXPECT_NEAR_KK( diff/sum, 0, eps);
+    SerialGemm<typename ParamTagType::transA, typename ParamTagType::transB,
+               AlgoTagType>::invoke(_alpha, aa, bb, _beta, cc);
   }
-    
-  template<typename DeviceType,
-           typename ViewType,
-           typename ScalarType,
-           typename ParamTagType, 
-           typename AlgoTagType>
-  void impl_test_batched_gemm(const int N, const int matAdim1, const int matAdim2, const int matBdim1, const int matBdim2,
-      const int matCdim1, const int matCdim2) {
+
+  inline void run() {
     typedef typename ViewType::value_type value_type;
-    typedef Kokkos::Details::ArithTraits<value_type> ats;
-
-    /// randomized input testing views
-    ScalarType alpha = 1.5, beta = 3.0;
-
-    ViewType
-      a0("a0", N, matAdim1, matAdim2), a1("a1", N, matAdim1, matAdim2),
-      b0("b0", N, matBdim1, matBdim2), b1("b1", N, matBdim1, matBdim2),
-      c0("c0", N, matCdim1, matCdim2), c1("c1", N, matCdim1, matCdim2);
-
-    Kokkos::Random_XorShift64_Pool<typename DeviceType::execution_space> random(13718);
-    Kokkos::fill_random(a0, random, value_type(1.0));
-    Kokkos::fill_random(b0, random, value_type(1.0));
-    Kokkos::fill_random(c0, random, value_type(1.0));
-
-    Kokkos::fence();
-
-    Kokkos::deep_copy(a1, a0);
-    Kokkos::deep_copy(b1, b0);
-    Kokkos::deep_copy(c1, c0);
-
-    /// test body
-    Functor_TestBatchedSerialGemm<DeviceType,ViewType,ScalarType,
-      ParamTagType,Algo::Gemm::Unblocked>(alpha, a0, b0, beta, c0).run();
-    Functor_TestBatchedSerialGemm<DeviceType,ViewType,ScalarType,
-      ParamTagType,AlgoTagType>(alpha, a1, b1, beta, c1).run();
-
-    Kokkos::fence();
-
-    /// for comparison send it to host
-    typename ViewType::HostMirror c0_host = Kokkos::create_mirror_view(c0);
-    typename ViewType::HostMirror c1_host = Kokkos::create_mirror_view(c1);
-
-    Kokkos::deep_copy(c0_host, c0);
-    Kokkos::deep_copy(c1_host, c1);
-
-    /// check c0 = c1 ; this eps is about 10^-14
-    typedef typename ats::mag_type mag_type;
-    mag_type sum(1), diff(0);
-    const mag_type eps = 1.0e3 * ats::epsilon();
-
-    for (int k=0;k<N;++k)
-      for (int i=0;i<matCdim1;++i) 
-        for (int j=0;j<matCdim2;++j) {
-          sum  += ats::abs(c0_host(k,i,j));
-          diff += ats::abs(c0_host(k,i,j)-c1_host(k,i,j));
-        }
-    EXPECT_NEAR_KK( diff/sum, 0, eps);
+    std::string name_region("KokkosBatched::Test::SerialGemm");
+    std::string name_value_type =
+        (std::is_same<value_type, float>::value    ? "::Float"
+         : std::is_same<value_type, double>::value ? "::Double"
+         : std::is_same<value_type, Kokkos::complex<float> >::value
+             ? "::ComplexFloat"
+         : std::is_same<value_type, Kokkos::complex<double> >::value
+             ? "::ComplexDouble"
+             : "::UnknownValueType");
+    std::string name = name_region + name_value_type;
+    Kokkos::Profiling::pushRegion(name.c_str());
+    Kokkos::RangePolicy<DeviceType, ParamTagType> policy(0, _c.extent(0));
+    Kokkos::parallel_for(name.c_str(), policy, *this);
+    Kokkos::Profiling::popRegion();
   }
-}
-}
+};
 
-template<typename DeviceType, 
-         typename ValueType, 
-         typename ScalarType,
-         typename ParamTagType,
-         typename AlgoTagType>
+template <typename DeviceType, typename ViewType, typename ScalarType,
+          typename ParamTagType, typename AlgoTagType>
+void impl_test_batched_gemm(const int N, const int matAdim1, const int matAdim2,
+                            const int matBdim1, const int matBdim2,
+                            const int matCdim1, const int matCdim2) {
+  using execution_space = typename DeviceType::execution_space;
+  using transA          = typename ParamTagType::transA;
+  using transB          = typename ParamTagType::transB;
+  using value_type      = typename ViewType::value_type;
+  using ats             = Kokkos::Details::ArithTraits<value_type>;
+
+  /// randomized input testing views
+  ScalarType alpha = ScalarType(1.5);
+  ScalarType beta  = ScalarType(3.0);
+
+  ViewType a_expected("a_expected", N, matAdim1, matAdim2),
+      a_actual("a_actual", N, matAdim1, matAdim2),
+      b_expected("b_expected", N, matBdim1, matBdim2),
+      b_actual("b_actual", N, matBdim1, matBdim2),
+      c_expected("c_expected", N, matCdim1, matCdim2),
+      c_actual("c_actual", N, matCdim1, matCdim2);
+
+  Kokkos::Random_XorShift64_Pool<execution_space> random(13718);
+
+  Kokkos::fill_random(a_expected, random, value_type(1.0));
+  Kokkos::fill_random(b_expected, random, value_type(1.0));
+  Kokkos::fill_random(c_expected, random, value_type(1.0));
+
+  Kokkos::fence();
+
+  Kokkos::deep_copy(a_actual, a_expected);
+  Kokkos::deep_copy(b_actual, b_expected);
+  Kokkos::deep_copy(c_actual, c_expected);
+
+  Functor_BatchedVanillaGEMM<ViewType, ViewType, ViewType, execution_space>
+      vgemm;
+  vgemm.A_t = std::is_same<transA, Trans::Transpose>::value;
+  vgemm.B_t = std::is_same<transB, Trans::Transpose>::value;
+  vgemm.A_c = vgemm.B_c = false;
+  vgemm.A               = a_expected;
+  vgemm.B               = b_expected;
+  vgemm.C               = c_expected;
+  vgemm.alpha           = alpha;
+  vgemm.beta            = beta;
+  vgemm.run();  // Compute c_expected
+  Functor_TestBatchedSerialGemm<DeviceType, ViewType, ScalarType, ParamTagType,
+                                AlgoTagType>(alpha, a_actual, b_actual, beta,
+                                             c_actual)
+      .run();
+
+  typename ViewType::HostMirror c_expected_host =
+      Kokkos::create_mirror_view(c_expected);
+  typename ViewType::HostMirror c_actual_host =
+      Kokkos::create_mirror_view(c_actual);
+
+  // Copy to host for comparison
+  Kokkos::deep_copy(c_expected_host, c_expected);
+  Kokkos::deep_copy(c_actual_host, c_actual);
+
+  Kokkos::fence();
+
+  // check c_expected = c_actual
+  // std::conditional<, float,
+  using mag_type = typename ats::mag_type;
+  mag_type sum(1), diff(0);
+
+  mag_type eps = ats::epsilon();
+
+  eps *=
+      std::is_same<value_type, Kokkos::Experimental::half_t>::value ? 4 : 1e3;
+
+  for (int k = 0; k < N; ++k)
+    for (int i = 0; i < matCdim1; ++i)
+      for (int j = 0; j < matCdim2; ++j) {
+        sum += ats::abs(c_expected_host(k, i, j));
+        diff += ats::abs(c_expected_host(k, i, j) - c_actual_host(k, i, j));
+      }
+  EXPECT_NEAR_KK(diff / sum, 0, eps);
+}
+}
+}  // namespace Test
+
+template <typename DeviceType, typename ValueType, typename ScalarType,
+          typename ParamTagType, typename AlgoTagType>
 int test_batched_gemm() {
-#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) 
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
   {
-    typedef Kokkos::View<ValueType***,Kokkos::LayoutLeft,DeviceType> ViewType;
-    Test::Gemm::impl_test_batched_gemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(0, 10, 10, 10, 10, 10, 10);
-    for (int i=0;i<10;++i) {                                                                                        
-      //printf("Testing: LayoutLeft,  Blksize %d\n", i);
-      Test::Gemm::impl_test_batched_gemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, i, i, i, i, i, i);
+    typedef Kokkos::View<ValueType ***, Kokkos::LayoutLeft, DeviceType>
+        ViewType;
+    Test::Gemm::impl_test_batched_gemm<DeviceType, ViewType, ScalarType,
+                                       ParamTagType, AlgoTagType>(0, 10, 10, 10,
+                                                                  10, 10, 10);
+    for (int i = 0; i < 10; ++i) {
+      // printf("Testing: LayoutLeft,  Blksize %d\n", i);
+      Test::Gemm::impl_test_batched_gemm<DeviceType, ViewType, ScalarType,
+                                         ParamTagType, AlgoTagType>(1024, i, i,
+                                                                    i, i, i, i);
     }
-    for (int i=0;i<10;++i) {                                                                                        
-      //printf("Testing: LayoutLeft,  Blksize %d\n", i);
-      int dimM=i; int dimN=2*i; int dimK=3*i;
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::Gemm::impl_test_batched_gemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::Gemm::impl_test_batched_gemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimN, dimK, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::Gemm::impl_test_batched_gemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimK, dimN, dimM, dimN); }
+    for (int i = 0; i < 10; ++i) {
+      // printf("Testing: LayoutLeft,  Blksize %d\n", i);
+      int dimM = i;
+      int dimN = 2 * i;
+      int dimK = 3 * i;
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::NoTranspose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::NoTranspose>::value)) {
+        Test::Gemm::impl_test_batched_gemm<DeviceType, ViewType, ScalarType,
+                                           ParamTagType, AlgoTagType>(
+            1024, dimM, dimK, dimK, dimN, dimM, dimN);
+      }
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::NoTranspose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::Transpose>::value)) {
+        Test::Gemm::impl_test_batched_gemm<DeviceType, ViewType, ScalarType,
+                                           ParamTagType, AlgoTagType>(
+            1024, dimM, dimK, dimN, dimK, dimM, dimN);
+      }
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::Transpose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::NoTranspose>::value)) {
+        Test::Gemm::impl_test_batched_gemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimK, dimN, dimM, dimN); }
       if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
         (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
           Test::Gemm::impl_test_batched_gemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimN, dimK, dimM, dimN); }
@@ -253,92 +196,57 @@ int test_batched_gemm() {
 #endif
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
   {
-    typedef Kokkos::View<ValueType***,Kokkos::LayoutRight,DeviceType> ViewType;
-    Test::Gemm::impl_test_batched_gemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(0, 10, 10, 10, 10, 10, 10);
-    for (int i=0;i<10;++i) {                                                                                        
-      //printf("Testing: LayoutRight, Blksize %d\n", i);
-      Test::Gemm::impl_test_batched_gemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, i, i, i, i, i, i);
+    typedef Kokkos::View<ValueType ***, Kokkos::LayoutRight, DeviceType>
+        ViewType;
+    Test::Gemm::impl_test_batched_gemm<DeviceType, ViewType, ScalarType,
+                                       ParamTagType, AlgoTagType>(0, 10, 10, 10,
+                                                                  10, 10, 10);
+    for (int i = 0; i < 10; ++i) {
+      // printf("Testing: LayoutRight, Blksize %d\n", i);
+      Test::Gemm::impl_test_batched_gemm<DeviceType, ViewType, ScalarType,
+                                         ParamTagType, AlgoTagType>(1024, i, i,
+                                                                    i, i, i, i);
     }
-    for (int i=0;i<10;++i) {                                                                                        
-      //printf("Testing: LayoutLeft,  Blksize %d\n", i);
-      int dimM=i; int dimN=2*i; int dimK=3*i;
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::Gemm::impl_test_batched_gemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::Gemm::impl_test_batched_gemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimN, dimK, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::Gemm::impl_test_batched_gemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::Gemm::impl_test_batched_gemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimN, dimK, dimM, dimN); }
+    for (int i = 0; i < 10; ++i) {
+      // printf("Testing: LayoutLeft,  Blksize %d\n", i);
+      int dimM = i;
+      int dimN = 2 * i;
+      int dimK = 3 * i;
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::NoTranspose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::NoTranspose>::value)) {
+        Test::Gemm::impl_test_batched_gemm<DeviceType, ViewType, ScalarType,
+                                           ParamTagType, AlgoTagType>(
+            1024, dimM, dimK, dimK, dimN, dimM, dimN);
+      }
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::NoTranspose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::Transpose>::value)) {
+        Test::Gemm::impl_test_batched_gemm<DeviceType, ViewType, ScalarType,
+                                           ParamTagType, AlgoTagType>(
+            1024, dimM, dimK, dimN, dimK, dimM, dimN);
+      }
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::Transpose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::NoTranspose>::value)) {
+        Test::Gemm::impl_test_batched_gemm<DeviceType, ViewType, ScalarType,
+                                           ParamTagType, AlgoTagType>(
+            1024, dimK, dimM, dimK, dimN, dimM, dimN);
+      }
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::Transpose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::Transpose>::value)) {
+        Test::Gemm::impl_test_batched_gemm<DeviceType, ViewType, ScalarType,
+                                           ParamTagType, AlgoTagType>(
+            1024, dimK, dimM, dimN, dimK, dimM, dimN);
+      }
     }
   }
 #endif
-  
-  return 0;
-}
 
-template<typename DeviceType, 
-         typename ValueType, 
-         typename ScalarType,
-         typename ParamTagType,
-         typename AlgoTagType>
-int test_batched_gemm_half() {
-#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) 
-  {
-    typedef Kokkos::View<ValueType***,Kokkos::LayoutLeft,DeviceType> ViewType;
-    Test::Gemm::impl_test_batched_gemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(0, 10, 10, 10, 10, 10, 10);
-    for (int i=0;i<10;++i) {                                                                                        
-      //printf("Testing: LayoutLeft,  Blksize %d\n", i);
-      Test::Gemm::impl_test_batched_gemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, i, i, i, i, i, i);
-    }
-    for (int i=1;i<10;++i) {                                                                                        
-      //printf("Testing: LayoutLeft,  Blksize %d\n", i);
-      int dimM=i; int dimN=2*i; int dimK=3*i;
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::Gemm::impl_test_batched_gemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::Gemm::impl_test_batched_gemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimN, dimK, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::Gemm::impl_test_batched_gemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::Gemm::impl_test_batched_gemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimN, dimK, dimM, dimN); }
-    }
-  }
-#endif
-#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
-  {
-    typedef Kokkos::View<ValueType***,Kokkos::LayoutRight,DeviceType> ViewType;
-    Test::Gemm::impl_test_batched_gemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(0, 10, 10, 10, 10, 10, 10);
-    for (int i=0;i<10;++i) {                                                                                        
-      //printf("Testing: LayoutRight, Blksize %d\n", i);
-      Test::Gemm::impl_test_batched_gemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, i, i, i, i, i, i);
-    }
-    for (int i=0;i<10;++i) {                                                                                        
-      //printf("Testing: LayoutLeft,  Blksize %d\n", i);
-      int dimM=i; int dimN=2*i; int dimK=3*i;
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::Gemm::impl_test_batched_gemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::Gemm::impl_test_batched_gemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimN, dimK, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::Gemm::impl_test_batched_gemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::Gemm::impl_test_batched_gemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimN, dimK, dimM, dimN); }
-    }
-  }
-#endif
-  
   return 0;
 }

--- a/unit_test/batched/Test_Batched_SerialGemm_Real.hpp
+++ b/unit_test/batched/Test_Batched_SerialGemm_Real.hpp
@@ -1,27 +1,47 @@
 #if defined(KOKKOS_HALF_T_IS_FLOAT)
 TEST_F( TestCategory, batched_scalar_serial_gemm_nt_nt_half_half ) {
-  typedef ::Test::Gemm::ParamTag<Trans::NoTranspose,Trans::NoTranspose> param_tag_type;
+  typedef ::Test::Gemm::ParamTag<Trans::NoTranspose, Trans::NoTranspose>
+      param_tag_type;
 
-  test_batched_gemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Blocked>();
-  test_batched_gemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Unblocked>();
+  test_batched_gemm<TestExecSpace, ::Test::halfScalarType,
+                    ::Test::halfScalarType, param_tag_type,
+                    Algo::Gemm::Blocked>();
+  test_batched_gemm<TestExecSpace, ::Test::halfScalarType,
+                    ::Test::halfScalarType, param_tag_type,
+                    Algo::Gemm::Unblocked>();
 }
 TEST_F( TestCategory, batched_scalar_serial_gemm_t_nt_half_half ) {
-  typedef ::Test::Gemm::ParamTag<Trans::Transpose,Trans::NoTranspose> param_tag_type;
+  typedef ::Test::Gemm::ParamTag<Trans::Transpose, Trans::NoTranspose>
+      param_tag_type;
 
-  test_batched_gemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Blocked>();
-  test_batched_gemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Unblocked>();
+  test_batched_gemm<TestExecSpace, ::Test::halfScalarType,
+                    ::Test::halfScalarType, param_tag_type,
+                    Algo::Gemm::Blocked>();
+  test_batched_gemm<TestExecSpace, ::Test::halfScalarType,
+                    ::Test::halfScalarType, param_tag_type,
+                    Algo::Gemm::Unblocked>();
 }
 TEST_F( TestCategory, batched_scalar_serial_gemm_nt_t_half_half ) {
-  typedef ::Test::Gemm::ParamTag<Trans::NoTranspose,Trans::Transpose> param_tag_type;
+  typedef ::Test::Gemm::ParamTag<Trans::NoTranspose, Trans::Transpose>
+      param_tag_type;
 
-  test_batched_gemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Blocked>();
-  test_batched_gemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Unblocked>();
+  test_batched_gemm<TestExecSpace, ::Test::halfScalarType,
+                    ::Test::halfScalarType, param_tag_type,
+                    Algo::Gemm::Blocked>();
+  test_batched_gemm<TestExecSpace, ::Test::halfScalarType,
+                    ::Test::halfScalarType, param_tag_type,
+                    Algo::Gemm::Unblocked>();
 }
 TEST_F( TestCategory, batched_scalar_serial_gemm_t_t_half_half ) {
-  typedef ::Test::Gemm::ParamTag<Trans::Transpose,Trans::Transpose> param_tag_type;
+  typedef ::Test::Gemm::ParamTag<Trans::Transpose, Trans::Transpose>
+      param_tag_type;
 
-  test_batched_gemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Blocked>();
-  test_batched_gemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Unblocked>();
+  test_batched_gemm<TestExecSpace, ::Test::halfScalarType,
+                    ::Test::halfScalarType, param_tag_type,
+                    Algo::Gemm::Blocked>();
+  test_batched_gemm<TestExecSpace, ::Test::halfScalarType,
+                    ::Test::halfScalarType, param_tag_type,
+                    Algo::Gemm::Unblocked>();
 }
 #endif // KOKKOS_HALF_T_IS_FLOAT
 

--- a/unit_test/batched/Test_Batched_TeamGemm.hpp
+++ b/unit_test/batched/Test_Batched_TeamGemm.hpp
@@ -18,28 +18,23 @@ namespace Test {
 namespace TeamGemm {
 
   template<typename TA, typename TB>
-  struct ParamTag { 
-    typedef TA transA;
-    typedef TB transB;
-  };
- 
-  template<typename DeviceType,
-           typename ViewType,
-           typename ScalarType,
-           typename ParamTagType, 
-           typename AlgoTagType>
-  struct Functor_TestBatchedTeamGemm {
+struct ParamTag {
+  typedef TA transA;
+  typedef TB transB;
+};
+
+  template <typename DeviceType, typename ViewType, typename ScalarType,
+          typename ParamTagType, typename AlgoTagType>
+struct Functor_TestBatchedTeamGemm {
     ViewType _a, _b, _c;
-    
+
     ScalarType _alpha, _beta;
-    
+
     KOKKOS_INLINE_FUNCTION
-    Functor_TestBatchedTeamGemm(const ScalarType alpha, 
-            const ViewType &a,
-            const ViewType &b,
-            const ScalarType beta,
-            const ViewType &c)
-      : _a(a), _b(b), _c(c), _alpha(alpha), _beta(beta) {}
+    Functor_TestBatchedTeamGemm(const ScalarType alpha, const ViewType &a,
+                                const ViewType &b, const ScalarType beta,
+                                const ViewType &c)
+        : _a(a), _b(b), _c(c), _alpha(alpha), _beta(beta) {}
 
     template<typename MemberType>
     KOKKOS_INLINE_FUNCTION
@@ -49,303 +44,218 @@ namespace TeamGemm {
       auto aa = Kokkos::subview(_a, k, Kokkos::ALL(), Kokkos::ALL());
       auto bb = Kokkos::subview(_b, k, Kokkos::ALL(), Kokkos::ALL());
       auto cc = Kokkos::subview(_c, k, Kokkos::ALL(), Kokkos::ALL());
-      
+
       KokkosBatched::TeamGemm<MemberType,
         typename ParamTagType::transA,
         typename ParamTagType::transB,
         AlgoTagType>::
         invoke(member, _alpha, aa, bb, _beta, cc);
     }
-    
+
     inline
     void run() {
       typedef typename ViewType::value_type value_type;
       std::string name_region("KokkosBatched::Test::TeamGemm");
-      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
-                                      std::is_same<value_type,double>::value ? "::Double" :
-                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
-                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name_value_type =
+          (std::is_same<value_type, float>::value    ? "::Float"
+           : std::is_same<value_type, double>::value ? "::Double"
+           : std::is_same<value_type, Kokkos::complex<float> >::value
+               ? "::ComplexFloat"
+           : std::is_same<value_type, Kokkos::complex<double> >::value
+               ? "::ComplexDouble"
+               : "::UnknownValueType");
       std::string name = name_region + name_value_type;
-      Kokkos::Profiling::pushRegion( name.c_str() );
+      Kokkos::Profiling::pushRegion(name.c_str());
       const int league_size = _c.extent(0);
-      Kokkos::TeamPolicy<DeviceType,ParamTagType> policy(league_size, Kokkos::AUTO);
-      Kokkos::parallel_for(name.c_str(), policy, *this);            
-      Kokkos::Profiling::popRegion(); 
+      Kokkos::TeamPolicy<DeviceType, ParamTagType> policy(league_size,
+                                                          Kokkos::AUTO);
+      Kokkos::parallel_for(name.c_str(), policy, *this);
+      Kokkos::Profiling::popRegion();
     }
   };
-    
-  template<typename DeviceType,
-           typename ViewType,
-           typename ScalarType,
-           typename ParamTagType, 
-           typename AlgoTagType>
+
+  template <typename DeviceType, typename ViewType, typename ScalarType,
+            typename ParamTagType, typename AlgoTagType>
   void impl_test_batched_teamgemm(const int N, const int matAdim1, const int matAdim2, const int matBdim1, const int matBdim2,
       const int matCdim1, const int matCdim2) {
-    typedef typename ViewType::value_type value_type;
-    typedef Kokkos::Details::ArithTraits<value_type> ats;
-
-    /// randomized input testing views
-    ScalarType alpha = 1.5, beta = 3.0;
-
-    ViewType
-      a0("a0", N, matAdim1,matAdim2), a1("a1", N, matAdim1,matAdim2),
-      b0("b0", N, matBdim1,matBdim2), b1("b1", N, matBdim1,matBdim2),
-      c0("c0", N, matCdim1,matCdim2), c1("c1", N, matCdim1,matCdim2);
-
-    Kokkos::Random_XorShift64_Pool<typename DeviceType::execution_space> random(13718);
-    Kokkos::fill_random(a0, random, value_type(1.0));
-    Kokkos::fill_random(b0, random, value_type(1.0));
-    Kokkos::fill_random(c0, random, value_type(1.0));
-
-    Kokkos::fence();
-
-    Kokkos::deep_copy(a1, a0);
-    Kokkos::deep_copy(b1, b0);
-    Kokkos::deep_copy(c1, c0);
-
-    /// test body
-    Functor_TestBatchedTeamGemm<DeviceType,ViewType,ScalarType,
-      ParamTagType,Algo::Gemm::Unblocked>(alpha, a0, b0, beta, c0).run();
-    Functor_TestBatchedTeamGemm<DeviceType,ViewType,ScalarType,
-      ParamTagType,AlgoTagType>(alpha, a1, b1, beta, c1).run();
-
-    Kokkos::fence();
-
-    /// for comparison send it to host
-    typename ViewType::HostMirror c0_host = Kokkos::create_mirror_view(c0);
-    typename ViewType::HostMirror c1_host = Kokkos::create_mirror_view(c1);
-
-    Kokkos::deep_copy(c0_host, c0);
-    Kokkos::deep_copy(c1_host, c1);
-
-    /// check c0 = c1 ; this eps is about 10^-14
-    typedef typename ats::mag_type mag_type;
-    mag_type sum(1), diff(0);
-    const mag_type eps = 1.0e3 * ats::epsilon();
-
-    for (int k=0;k<N;++k) 
-      for (int i=0;i<matCdim1;++i) 
-        for (int j=0;j<matCdim2;++j) {
-          sum  += ats::abs(c0_host(k,i,j));
-          diff += ats::abs(c0_host(k,i,j)-c1_host(k,i,j));
-        }
-    EXPECT_NEAR_KK( diff/sum, 0, eps);
-  }
-
-  template<typename DeviceType,
-           typename ViewType,
-           typename ScalarType,
-           typename ParamTagType, 
-           typename AlgoTagType>
-  void impl_test_batched_teamgemm_half(const int N, const int matAdim1, const int matAdim2, const int matBdim1, const int matBdim2,
-      const int matCdim1, const int matCdim2) {
-    using layout_type = typename ViewType::array_layout;
-    using transA = typename ParamTagType::transA;
-    using transB = typename ParamTagType::transB;
+    using transA          = typename ParamTagType::transA;
+    using transB          = typename ParamTagType::transB;
     using execution_space = typename DeviceType::execution_space;
-    using host_value_type = float;
-    using ViewType_host_value_type = Kokkos::View<host_value_type***,layout_type,DeviceType>;
-    using ats = Kokkos::Details::ArithTraits<host_value_type>;
+    using value_type      = typename ViewType::value_type;
+    using ats             = Kokkos::Details::ArithTraits<value_type>;
 
     /// randomized input testing views
     ScalarType alpha = ScalarType(1.5), beta = ScalarType(3.0);
 
-    ViewType
-      a_expected("a_expected", N, matAdim1, matAdim2), a1("a1", N, matAdim1, matAdim2),
-      b_expected("b_expected", N, matBdim1, matBdim2), b1("b1", N, matBdim1, matBdim2),
-      c_expected("c_expected", N, matCdim1, matCdim2), c1("c1", N, matCdim1, matCdim2);
+    ViewType a_expected("a_expected", N, matAdim1, matAdim2),
+        a_actual("a_actual", N, matAdim1, matAdim2),
+        b_expected("b_expected", N, matBdim1, matBdim2),
+        b_actual("b_actual", N, matBdim1, matBdim2),
+        c_expected("c_expected", N, matCdim1, matCdim2),
+        c_actual("c_actual", N, matCdim1, matCdim2);
 
-    // fill_random does not support half precision, so use float to
-    // generate random numbers and copy to half views with deep_copy
-    Kokkos::Random_XorShift64_Pool<typename DeviceType::execution_space> random(13718);
-    ViewType_host_value_type
-      a_expected_host_value_type("a_expected_host_value_type", N, matAdim1, matAdim2),
-      b_expected_host_value_type("b_expected_host_value_type", N, matBdim1, matBdim2),
-      c_expected_host_value_type("c_expected_host_value_type", N, matCdim1, matCdim2),
-      c1_host_value_type("c1_host_value_type", N, matCdim1, matCdim2);
+    Kokkos::Random_XorShift64_Pool<typename DeviceType::execution_space> random(
+        13718);
 
-    Kokkos::fill_random(a_expected_host_value_type, random, host_value_type(1.0));
-    Kokkos::fill_random(b_expected_host_value_type, random, host_value_type(1.0));
-    Kokkos::fill_random(c_expected_host_value_type, random, host_value_type(1.0));
+    Kokkos::fill_random(a_expected, random, value_type(1.0));
+    Kokkos::fill_random(b_expected, random, value_type(1.0));
+    Kokkos::fill_random(c_expected, random, value_type(1.0));
 
     Kokkos::fence();
 
-    Kokkos::deep_copy(a_expected, a_expected_host_value_type);
-    Kokkos::deep_copy(b_expected, b_expected_host_value_type);
-    Kokkos::deep_copy(c_expected, c_expected_host_value_type);
+    Kokkos::deep_copy(a_actual, a_expected);
+    Kokkos::deep_copy(b_actual, b_expected);
+    Kokkos::deep_copy(c_actual, c_expected);
 
-    Kokkos::deep_copy(a1, a_expected);
-    Kokkos::deep_copy(b1, b_expected);
-    Kokkos::deep_copy(c1, c_expected);
-
-    Functor_BatchedVanillaGEMM<ViewType, ViewType, ViewType, execution_space> vgemm;
+    Functor_BatchedVanillaGEMM<ViewType, ViewType, ViewType, execution_space>
+        vgemm;
     vgemm.A_t = std::is_same<transA, Trans::Transpose>::value;
     vgemm.B_t = std::is_same<transB, Trans::Transpose>::value;
     vgemm.A_c = vgemm.B_c = false;
-    vgemm.A = a_expected;
-    vgemm.B = b_expected;
-    vgemm.C = c_expected;
-    vgemm.alpha = alpha;
-    vgemm.beta = beta;
-    vgemm.run(); // Compute c_expected
+    vgemm.A               = a_expected;
+    vgemm.B               = b_expected;
+    vgemm.C               = c_expected;
+    vgemm.alpha           = alpha;
+    vgemm.beta            = beta;
+    vgemm.run();  // Compute c_expected
 
-    Functor_TestBatchedTeamGemm<DeviceType,ViewType,ScalarType,
-      ParamTagType,AlgoTagType>(alpha, a1, b1, beta, c1).run();
+    Functor_TestBatchedTeamGemm<DeviceType, ViewType, ScalarType, ParamTagType,
+                                AlgoTagType>(alpha, a_actual, b_actual, beta,
+                                             c_actual)
+        .run();
 
     Kokkos::fence();
 
-    // Convert and copy half to host_value_type, on device
-    Kokkos::deep_copy(c_expected_host_value_type, c_expected);
-    Kokkos::deep_copy(c1_host_value_type, c1);    
+    typename ViewType::HostMirror c_expected_host =
+        Kokkos::create_mirror_view(c_expected);
+    typename ViewType::HostMirror c_actual_host =
+        Kokkos::create_mirror_view(c_actual);
 
-    // We may not have half precision on the host, use single precision here.
-    // For comparison send it to host, in host compatible type
-    typename ViewType_host_value_type::HostMirror c_expected_host_value_type_host = Kokkos::create_mirror_view(c_expected_host_value_type);
-    typename ViewType_host_value_type::HostMirror c1_host_value_type_host = Kokkos::create_mirror_view(c1_host_value_type);
+    // Copy to host for comparision
+    Kokkos::deep_copy(c_expected_host, c_expected);
+    Kokkos::deep_copy(c_actual_host, c_actual);
 
-    // Copy host_value_type on device to host_value_type on host
-    Kokkos::deep_copy(c_expected_host_value_type_host, c_expected_host_value_type);
-    Kokkos::deep_copy(c1_host_value_type_host, c1_host_value_type);
-
-    // check c_expected = c1 ; this eps is about 2^-9
-    // Set mag_type to host_value_type, we may not have half precision on host
-    using mag_type = host_value_type;
+    using mag_type = typename ats::mag_type;
     mag_type sum(1), diff(0);
+    mag_type eps = ats::epsilon();
 
-    mag_type eps = (mag_type) (1 << 1) * KOKKOSKERNELS_IMPL_FP16_EPSILON;
+    eps *=
+        std::is_same<value_type, Kokkos::Experimental::half_t>::value ? 4 : 1e3;
 
-    for (int k=0;k<N;++k)
-      for (int i=0;i<matCdim1;++i) 
-        for (int j=0;j<matCdim2;++j) {
-          sum  += ats::abs(c_expected_host_value_type_host(k,i,j));
-          diff += ats::abs(c_expected_host_value_type_host(k,i,j)-c1_host_value_type_host(k,i,j));
+    for (int k = 0; k < N; ++k)
+      for (int i = 0; i < matCdim1; ++i)
+        for (int j = 0; j < matCdim2; ++j) {
+          sum += ats::abs(c_expected_host(k, i, j));
+          diff += ats::abs(c_expected_host(k, i, j) - c_actual_host(k, i, j));
         }
     EXPECT_NEAR_KK( diff/sum, 0, eps);
   }
 }
 }
 
-// void (*impl_test)(const int, const int, const int, const int, const int, const int, const int)
-template<typename DeviceType, 
-         typename ValueType, 
-         typename ScalarType,
-         typename ParamTagType,
-         typename AlgoTagType>
+// void (*impl_test)(const int, const int, const int, const int, const int,
+// const int, const int)
+template <typename DeviceType, typename ValueType, typename ScalarType,
+          typename ParamTagType, typename AlgoTagType>
 int test_batched_teamgemm() {
-#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) 
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
   {
-    typedef Kokkos::View<ValueType***,Kokkos::LayoutLeft,DeviceType> ViewType;
-    Test::TeamGemm::impl_test_batched_teamgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(0, 10, 10, 10, 10, 10, 10);
-    for (int i=0;i<10;++i) {
-      //printf("Testing: LayoutLeft,  Blksize %d\n", i);
-      Test::TeamGemm::impl_test_batched_teamgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, i, i, i, i, i, i);
+    typedef Kokkos::View<ValueType ***, Kokkos::LayoutLeft, DeviceType>
+        ViewType;
+    Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ViewType, ScalarType,
+                                               ParamTagType, AlgoTagType>(
+        0, 10, 10, 10, 10, 10, 10);
+    for (int i = 0; i < 10; ++i) {
+      // printf("Testing: LayoutLeft,  Blksize %d\n", i);
+      Test::TeamGemm::impl_test_batched_teamgemm<
+          DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
+          1024, i, i, i, i, i, i);
     }
-    for (int i=0;i<10;++i) {                                                                                        
-      //printf("Testing: LayoutLeft,  Blksize %d\n", i);
-      int dimM=i; int dimN=2*i; int dimK=3*i;
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::TeamGemm::impl_test_batched_teamgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::TeamGemm::impl_test_batched_teamgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimN, dimK, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::TeamGemm::impl_test_batched_teamgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimK, dimN, dimM, dimN); }
+    for (int i = 0; i < 10; ++i) {
+      // printf("Testing: LayoutLeft,  Blksize %d\n", i);
+      int dimM = i;
+      int dimN = 2 * i;
+      int dimK = 3 * i;
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::NoTranspose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::NoTranspose>::value)) {
+        Test::TeamGemm::impl_test_batched_teamgemm<
+            DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
+            1024, dimM, dimK, dimK, dimN, dimM, dimN);
+      }
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::NoTranspose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::Transpose>::value)) {
+        Test::TeamGemm::impl_test_batched_teamgemm<
+            DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
+            1024, dimM, dimK, dimN, dimK, dimM, dimN);
+      }
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::Transpose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::NoTranspose>::value)) {
+        Test::TeamGemm::impl_test_batched_teamgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimK, dimN, dimM, dimN); }
       if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
         (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
           Test::TeamGemm::impl_test_batched_teamgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimN, dimK, dimM, dimN); }
     }
   }
 #endif
-#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) 
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
   {
-    typedef Kokkos::View<ValueType***,Kokkos::LayoutRight,DeviceType> ViewType;
-    Test::TeamGemm::impl_test_batched_teamgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(0, 10, 10, 10, 10, 10, 10);
-    for (int i=0;i<10;++i) {
-      //printf("Testing: LayoutRight, Blksize %d\n", i);
-      Test::TeamGemm::impl_test_batched_teamgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, i, i, i, i, i, i);
+    typedef Kokkos::View<ValueType ***, Kokkos::LayoutRight, DeviceType>
+        ViewType;
+    Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ViewType, ScalarType,
+                                               ParamTagType, AlgoTagType>(
+        0, 10, 10, 10, 10, 10, 10);
+    for (int i = 0; i < 10; ++i) {
+      // printf("Testing: LayoutRight, Blksize %d\n", i);
+      Test::TeamGemm::impl_test_batched_teamgemm<
+          DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
+          1024, i, i, i, i, i, i);
     }
-    for (int i=0;i<10;++i) {                                                                                        
-      //printf("Testing: LayoutLeft,  Blksize %d\n", i);
-      int dimM=i; int dimN=2*i; int dimK=3*i;
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::TeamGemm::impl_test_batched_teamgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::TeamGemm::impl_test_batched_teamgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimN, dimK, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::TeamGemm::impl_test_batched_teamgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::TeamGemm::impl_test_batched_teamgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimN, dimK, dimM, dimN); }
+    for (int i = 0; i < 10; ++i) {
+      // printf("Testing: LayoutLeft,  Blksize %d\n", i);
+      int dimM = i;
+      int dimN = 2 * i;
+      int dimK = 3 * i;
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::NoTranspose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::NoTranspose>::value)) {
+        Test::TeamGemm::impl_test_batched_teamgemm<
+            DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
+            1024, dimM, dimK, dimK, dimN, dimM, dimN);
+      }
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::NoTranspose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::Transpose>::value)) {
+        Test::TeamGemm::impl_test_batched_teamgemm<
+            DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
+            1024, dimM, dimK, dimN, dimK, dimM, dimN);
+      }
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::Transpose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::NoTranspose>::value)) {
+        Test::TeamGemm::impl_test_batched_teamgemm<
+            DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
+            1024, dimK, dimM, dimK, dimN, dimM, dimN);
+      }
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::Transpose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::Transpose>::value)) {
+        Test::TeamGemm::impl_test_batched_teamgemm<
+            DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
+            1024, dimK, dimM, dimN, dimK, dimM, dimN);
+      }
     }
   }
 #endif
-  
-  return 0;
-}
 
-template<typename DeviceType, 
-         typename ValueType, 
-         typename ScalarType,
-         typename ParamTagType,
-         typename AlgoTagType>
-int test_batched_teamgemm_half() {
-#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) 
-  {
-    typedef Kokkos::View<ValueType***,Kokkos::LayoutLeft,DeviceType> ViewType;
-    Test::TeamGemm::impl_test_batched_teamgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(0, 10, 10, 10, 10, 10, 10);
-    for (int i=0;i<10;++i) {
-      //printf("Testing: LayoutLeft,  Blksize %d\n", i);
-      Test::TeamGemm::impl_test_batched_teamgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, i, i, i, i, i, i);
-    }
-    for (int i=0;i<10;++i) {                                                                                        
-      //printf("Testing: LayoutLeft,  Blksize %d\n", i);
-      int dimM=i; int dimN=2*i; int dimK=3*i;
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::TeamGemm::impl_test_batched_teamgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::TeamGemm::impl_test_batched_teamgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimN, dimK, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::TeamGemm::impl_test_batched_teamgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::TeamGemm::impl_test_batched_teamgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimN, dimK, dimM, dimN); }
-    }
-  }
-#endif
-#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) 
-  {
-    typedef Kokkos::View<ValueType***,Kokkos::LayoutRight,DeviceType> ViewType;
-    Test::TeamGemm::impl_test_batched_teamgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(0, 10, 10, 10, 10, 10, 10);
-    for (int i=0;i<10;++i) {
-      //printf("Testing: LayoutRight, Blksize %d\n", i);
-      Test::TeamGemm::impl_test_batched_teamgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, i, i, i, i, i, i);
-    }
-    for (int i=0;i<10;++i) {                                                                                        
-      //printf("Testing: LayoutLeft,  Blksize %d\n", i);
-      int dimM=i; int dimN=2*i; int dimK=3*i;
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::TeamGemm::impl_test_batched_teamgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::TeamGemm::impl_test_batched_teamgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimN, dimK, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::TeamGemm::impl_test_batched_teamgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::TeamGemm::impl_test_batched_teamgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimN, dimK, dimM, dimN); }
-    }
-  }
-#endif
-  
   return 0;
 }

--- a/unit_test/batched/Test_Batched_TeamGemm_Real.hpp
+++ b/unit_test/batched/Test_Batched_TeamGemm_Real.hpp
@@ -1,27 +1,47 @@
 #if defined(KOKKOS_HALF_T_IS_FLOAT)
 TEST_F( TestCategory, batched_scalar_team_gemm_nt_nt_half_half ) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::NoTranspose,Trans::NoTranspose> param_tag_type;
+  typedef ::Test::TeamGemm::ParamTag<Trans::NoTranspose, Trans::NoTranspose>
+      param_tag_type;
 
-  test_batched_teamgemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Blocked>();
-  test_batched_teamgemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Unblocked>();
+  test_batched_teamgemm<TestExecSpace, ::Test::halfScalarType,
+                        ::Test::halfScalarType, param_tag_type,
+                        Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestExecSpace, ::Test::halfScalarType,
+                        ::Test::halfScalarType, param_tag_type,
+                        Algo::Gemm::Unblocked>();
 }
 TEST_F( TestCategory, batched_scalar_team_gemm_t_nt_half_half ) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::Transpose,Trans::NoTranspose> param_tag_type;
+  typedef ::Test::TeamGemm::ParamTag<Trans::Transpose, Trans::NoTranspose>
+      param_tag_type;
 
-  test_batched_teamgemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Blocked>();
-  test_batched_teamgemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Unblocked>();
+  test_batched_teamgemm<TestExecSpace, ::Test::halfScalarType,
+                        ::Test::halfScalarType, param_tag_type,
+                        Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestExecSpace, ::Test::halfScalarType,
+                        ::Test::halfScalarType, param_tag_type,
+                        Algo::Gemm::Unblocked>();
 }
 TEST_F( TestCategory, batched_scalar_team_gemm_nt_t_half_half ) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::NoTranspose,Trans::Transpose> param_tag_type;
+  typedef ::Test::TeamGemm::ParamTag<Trans::NoTranspose, Trans::Transpose>
+      param_tag_type;
 
-  test_batched_teamgemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Blocked>();
-  test_batched_teamgemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Unblocked>();
+  test_batched_teamgemm<TestExecSpace, ::Test::halfScalarType,
+                        ::Test::halfScalarType, param_tag_type,
+                        Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestExecSpace, ::Test::halfScalarType,
+                        ::Test::halfScalarType, param_tag_type,
+                        Algo::Gemm::Unblocked>();
 }
 TEST_F( TestCategory, batched_scalar_team_gemm_t_t_half_half ) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::Transpose,Trans::Transpose> param_tag_type;
+  typedef ::Test::TeamGemm::ParamTag<Trans::Transpose, Trans::Transpose>
+      param_tag_type;
 
-  test_batched_teamgemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Blocked>();
-  test_batched_teamgemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Unblocked>();
+  test_batched_teamgemm<TestExecSpace, ::Test::halfScalarType,
+                        ::Test::halfScalarType, param_tag_type,
+                        Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestExecSpace, ::Test::halfScalarType,
+                        ::Test::halfScalarType, param_tag_type,
+                        Algo::Gemm::Unblocked>();
 }
 #endif // KOKKOS_HALF_T_IS_FLOAT
 

--- a/unit_test/batched/Test_Batched_TeamVectorGemm.hpp
+++ b/unit_test/batched/Test_Batched_TeamVectorGemm.hpp
@@ -13,28 +13,23 @@ namespace Test {
 namespace TeamVectorGemm {
 
   template<typename TA, typename TB>
-  struct ParamTag { 
-    typedef TA transA;
-    typedef TB transB;
-  };
- 
-  template<typename DeviceType,
-           typename ViewType,
-           typename ScalarType,
-           typename ParamTagType, 
-           typename AlgoTagType>
-  struct Functor_TestBatchedTeamVector {
+struct ParamTag {
+  typedef TA transA;
+  typedef TB transB;
+};
+
+  template <typename DeviceType, typename ViewType, typename ScalarType,
+          typename ParamTagType, typename AlgoTagType>
+struct Functor_TestBatchedTeamVector {
     ViewType _a, _b, _c;
-    
+
     ScalarType _alpha, _beta;
-    
+
     KOKKOS_INLINE_FUNCTION
-    Functor_TestBatchedTeamVector(const ScalarType alpha, 
-            const ViewType &a,
-            const ViewType &b,
-            const ScalarType beta,
-            const ViewType &c)
-      : _a(a), _b(b), _c(c), _alpha(alpha), _beta(beta) {}
+    Functor_TestBatchedTeamVector(const ScalarType alpha, const ViewType &a,
+                                  const ViewType &b, const ScalarType beta,
+                                  const ViewType &c)
+        : _a(a), _b(b), _c(c), _alpha(alpha), _beta(beta) {}
 
     template<typename MemberType>
     KOKKOS_INLINE_FUNCTION
@@ -44,305 +39,222 @@ namespace TeamVectorGemm {
       auto aa = Kokkos::subview(_a, k, Kokkos::ALL(), Kokkos::ALL());
       auto bb = Kokkos::subview(_b, k, Kokkos::ALL(), Kokkos::ALL());
       auto cc = Kokkos::subview(_c, k, Kokkos::ALL(), Kokkos::ALL());
-      
+
       KokkosBatched::TeamVectorGemm<MemberType,
         typename ParamTagType::transA,
         typename ParamTagType::transB,
         AlgoTagType>::
         invoke(member, _alpha, aa, bb, _beta, cc);
     }
-    
+
     inline
     void run() {
       typedef typename ViewType::value_type value_type;
       std::string name_region("KokkosBatched::Test::TeamVector");
-      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
-                                      std::is_same<value_type,double>::value ? "::Double" :
-                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
-                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name_value_type =
+          (std::is_same<value_type, float>::value    ? "::Float"
+           : std::is_same<value_type, double>::value ? "::Double"
+           : std::is_same<value_type, Kokkos::complex<float> >::value
+               ? "::ComplexFloat"
+           : std::is_same<value_type, Kokkos::complex<double> >::value
+               ? "::ComplexDouble"
+               : "::UnknownValueType");
       std::string name = name_region + name_value_type;
-      Kokkos::Profiling::pushRegion( name.c_str() );
+      Kokkos::Profiling::pushRegion(name.c_str());
       const int league_size = _c.extent(0);
-      Kokkos::TeamPolicy<DeviceType,ParamTagType> policy(league_size, Kokkos::AUTO);
-      Kokkos::parallel_for(name.c_str(), policy, *this);            
-      Kokkos::Profiling::popRegion(); 
+      Kokkos::TeamPolicy<DeviceType, ParamTagType> policy(league_size,
+                                                          Kokkos::AUTO);
+      Kokkos::parallel_for(name.c_str(), policy, *this);
+      Kokkos::Profiling::popRegion();
     }
   };
-    
-  template<typename DeviceType,
-           typename ViewType,
-           typename ScalarType,
-           typename ParamTagType, 
-           typename AlgoTagType>
+
+  template <typename DeviceType, typename ViewType, typename ScalarType,
+            typename ParamTagType, typename AlgoTagType>
   void impl_test_batched_teamvectorgemm(const int N, const int matAdim1, const int matAdim2, const int matBdim1, const int matBdim2,
       const int matCdim1, const int matCdim2) {
-    typedef typename ViewType::value_type value_type;
-    typedef Kokkos::Details::ArithTraits<value_type> ats;
-
-    /// randomized input testing views
-    ScalarType alpha = 1.5, beta = 3.0;
-
-    ViewType
-      a0("a0", N, matAdim1,matAdim2), a1("a1", N, matAdim1,matAdim2),
-      b0("b0", N, matBdim1,matBdim2), b1("b1", N, matBdim1,matBdim2),
-      c0("c0", N, matCdim1,matCdim2), c1("c1", N, matCdim1,matCdim2);
-
-    Kokkos::Random_XorShift64_Pool<typename DeviceType::execution_space> random(13718);
-    Kokkos::fill_random(a0, random, value_type(1.0));
-    Kokkos::fill_random(b0, random, value_type(1.0));
-    Kokkos::fill_random(c0, random, value_type(1.0));
-
-    Kokkos::fence();
-
-    Kokkos::deep_copy(a1, a0);
-    Kokkos::deep_copy(b1, b0);
-    Kokkos::deep_copy(c1, c0);
-
-    /// test body
-    Functor_TestBatchedTeamVector<DeviceType,ViewType,ScalarType,
-      ParamTagType,Algo::Gemm::Unblocked>(alpha, a0, b0, beta, c0).run();
-    Functor_TestBatchedTeamVector<DeviceType,ViewType,ScalarType,
-      ParamTagType,AlgoTagType>(alpha, a1, b1, beta, c1).run();
-
-    Kokkos::fence();
-
-    /// for comparison send it to host
-    typename ViewType::HostMirror c0_host = Kokkos::create_mirror_view(c0);
-    typename ViewType::HostMirror c1_host = Kokkos::create_mirror_view(c1);
-
-    Kokkos::deep_copy(c0_host, c0);
-    Kokkos::deep_copy(c1_host, c1);
-
-    /// check c0 = c1 ; this eps is about 10^-14
-    typedef typename ats::mag_type mag_type;
-    mag_type sum(1), diff(0);
-    const mag_type eps = 1.0e3 * ats::epsilon();
-
-    for (int k=0;k<N;++k) 
-      for (int i=0;i<matCdim1;++i) 
-        for (int j=0;j<matCdim2;++j) {
-          sum  += ats::abs(c0_host(k,i,j));
-          diff += ats::abs(c0_host(k,i,j)-c1_host(k,i,j));
-        }
-    EXPECT_NEAR_KK( diff/sum, 0, eps);
-  }
-
-  template<typename DeviceType,
-           typename ViewType,
-           typename ScalarType,
-           typename ParamTagType, 
-           typename AlgoTagType>
-  void impl_test_batched_teamvectorgemm_half(const int N, const int matAdim1, const int matAdim2, const int matBdim1, const int matBdim2,
-      const int matCdim1, const int matCdim2) {
-    using layout_type = typename ViewType::array_layout;
-    using transA = typename ParamTagType::transA;
-    using transB = typename ParamTagType::transB;
+    using transA          = typename ParamTagType::transA;
+    using transB          = typename ParamTagType::transB;
     using execution_space = typename DeviceType::execution_space;
-    using host_value_type = float;
-    using ViewType_host_value_type = Kokkos::View<host_value_type***,layout_type,DeviceType>;
-    using ats = Kokkos::Details::ArithTraits<host_value_type>;
+    using value_type      = typename ViewType::value_type;
+    using ats             = Kokkos::Details::ArithTraits<value_type>;
 
     /// randomized input testing views
     ScalarType alpha = ScalarType(1.5), beta = ScalarType(3.0);
 
-    ViewType
-      a_expected("a_expected", N, matAdim1, matAdim2), a1("a1", N, matAdim1, matAdim2),
-      b_expected("b_expected", N, matBdim1, matBdim2), b1("b1", N, matBdim1, matBdim2),
-      c_expected("c_expected", N, matCdim1, matCdim2), c1("c1", N, matCdim1, matCdim2);
+    ViewType a_expected("a_expected", N, matAdim1, matAdim2),
+        a_actual("a_actual", N, matAdim1, matAdim2),
+        b_expected("b_expected", N, matBdim1, matBdim2),
+        b_actual("b_actual", N, matBdim1, matBdim2),
+        c_expected("c_expected", N, matCdim1, matCdim2),
+        c_actual("c_actual", N, matCdim1, matCdim2);
 
-    // fill_random does not support half precision, so use float to
-    // generate random numbers and copy to half views with deep_copy
-    Kokkos::Random_XorShift64_Pool<typename DeviceType::execution_space> random(13718);
-    ViewType_host_value_type
-      a_expected_host_value_type("a_expected_host_value_type", N, matAdim1, matAdim2),
-      b_expected_host_value_type("b_expected_host_value_type", N, matBdim1, matBdim2),
-      c_expected_host_value_type("c_expected_host_value_type", N, matCdim1, matCdim2),
-      c1_host_value_type("c1_host_value_type", N, matCdim1, matCdim2);
+    Kokkos::Random_XorShift64_Pool<typename DeviceType::execution_space> random(
+        13718);
 
-    Kokkos::fill_random(a_expected_host_value_type, random, host_value_type(1.0));
-    Kokkos::fill_random(b_expected_host_value_type, random, host_value_type(1.0));
-    Kokkos::fill_random(c_expected_host_value_type, random, host_value_type(1.0));
+    Kokkos::fill_random(a_expected, random, value_type(1.0));
+    Kokkos::fill_random(b_expected, random, value_type(1.0));
+    Kokkos::fill_random(c_expected, random, value_type(1.0));
 
     Kokkos::fence();
 
-    Kokkos::deep_copy(a_expected, a_expected_host_value_type);
-    Kokkos::deep_copy(b_expected, b_expected_host_value_type);
-    Kokkos::deep_copy(c_expected, c_expected_host_value_type);
+    Kokkos::deep_copy(a_actual, a_expected);
+    Kokkos::deep_copy(b_actual, b_expected);
+    Kokkos::deep_copy(c_actual, c_expected);
 
-    Kokkos::deep_copy(a1, a_expected);
-    Kokkos::deep_copy(b1, b_expected);
-    Kokkos::deep_copy(c1, c_expected);
-
-    //Functor_TestBatchedTeamVector<DeviceType,ViewType,ScalarType,
-    //  ParamTagType,Algo::Gemm::Unblocked>(alpha, a_expected, b_expected, beta, c_expected).run();
-    Functor_BatchedVanillaGEMM<ViewType, ViewType, ViewType, execution_space> vgemm;
+    // Functor_TestBatchedTeamVector<DeviceType,ViewType,ScalarType,
+    //   ParamTagType,Algo::Gemm::Unblocked>(alpha, a_expected, b_expected,
+    //   beta, c_expected).run();
+    Functor_BatchedVanillaGEMM<ViewType, ViewType, ViewType, execution_space>
+        vgemm;
     vgemm.A_t = std::is_same<transA, Trans::Transpose>::value;
     vgemm.B_t = std::is_same<transB, Trans::Transpose>::value;
     vgemm.A_c = vgemm.B_c = false;
-    vgemm.A = a_expected;
-    vgemm.B = b_expected;
-    vgemm.C = c_expected;
-    vgemm.alpha = alpha;
-    vgemm.beta = beta;
-    vgemm.run(); // Compute c_expected
+    vgemm.A               = a_expected;
+    vgemm.B               = b_expected;
+    vgemm.C               = c_expected;
+    vgemm.alpha           = alpha;
+    vgemm.beta            = beta;
+    vgemm.run();  // Compute c_expected
 
-    Functor_TestBatchedTeamVector<DeviceType,ViewType,ScalarType,
-      ParamTagType,AlgoTagType>(alpha, a1, b1, beta, c1).run();
+    Functor_TestBatchedTeamVector<DeviceType, ViewType, ScalarType,
+                                  ParamTagType, AlgoTagType>(
+        alpha, a_actual, b_actual, beta, c_actual)
+        .run();
 
     Kokkos::fence();
 
-    // Convert and copy half to host_value_type, on device
-    Kokkos::deep_copy(c_expected_host_value_type, c_expected);
-    Kokkos::deep_copy(c1_host_value_type, c1);    
+    typename ViewType::HostMirror c_expected_host =
+        Kokkos::create_mirror_view(c_expected);
+    typename ViewType::HostMirror c_actual_host =
+        Kokkos::create_mirror_view(c_actual);
 
-    // We may not have half precision on the host, use single precision here.
-    // For comparison send it to host, in host compatible type
-    typename ViewType_host_value_type::HostMirror c_expected_host_value_type_host = Kokkos::create_mirror_view(c_expected_host_value_type);
-    typename ViewType_host_value_type::HostMirror c1_host_value_type_host = Kokkos::create_mirror_view(c1_host_value_type);
+    // Copy to host for comparison
+    Kokkos::deep_copy(c_expected_host, c_expected);
+    Kokkos::deep_copy(c_actual_host, c_actual);
 
-    // Copy host_value_type on device to host_value_type on host
-    Kokkos::deep_copy(c_expected_host_value_type_host, c_expected_host_value_type);
-    Kokkos::deep_copy(c1_host_value_type_host, c1_host_value_type);
-
-    // check c_expected = c1 ; this eps is about 2^-9
-    // Set mag_type to host_value_type, we may not have half precision on host
-    using mag_type = host_value_type;
+    using mag_type = typename ats::mag_type;
     mag_type sum(1), diff(0);
 
-    mag_type eps = (mag_type) (1 << 1) * KOKKOSKERNELS_IMPL_FP16_EPSILON;
+    mag_type eps = ats::epsilon();
 
-    for (int k=0;k<N;++k)
-      for (int i=0;i<matCdim1;++i) 
-        for (int j=0;j<matCdim2;++j) {
-          sum  += ats::abs(c_expected_host_value_type_host(k,i,j));
-          diff += ats::abs(c_expected_host_value_type_host(k,i,j)-c1_host_value_type_host(k,i,j));
+    eps *=
+        std::is_same<value_type, Kokkos::Experimental::half_t>::value ? 4 : 1e3;
+
+    for (int k = 0; k < N; ++k)
+      for (int i = 0; i < matCdim1; ++i)
+        for (int j = 0; j < matCdim2; ++j) {
+          sum += ats::abs(c_expected_host(k, i, j));
+          diff += ats::abs(c_expected_host(k, i, j) - c_actual_host(k, i, j));
         }
-    EXPECT_NEAR_KK( diff/sum, 0, eps);
+    EXPECT_NEAR_KK(diff / sum, 0, eps);
+  }
   }
 }
-}
 
-// void (*impl_test)(const int, const int, const int, const int, const int, const int, const int)
-template<typename DeviceType, 
-         typename ValueType, 
-         typename ScalarType,
-         typename ParamTagType,
-         typename AlgoTagType>
+// void (*impl_test)(const int, const int, const int, const int, const int,
+// const int, const int)
+template <typename DeviceType, typename ValueType, typename ScalarType,
+          typename ParamTagType, typename AlgoTagType>
 int test_batched_teamvectorgemm() {
-#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) 
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
   {
-    typedef Kokkos::View<ValueType***,Kokkos::LayoutLeft,DeviceType> ViewType;
-    Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(0, 10, 10, 10, 10, 10, 10);
-    for (int i=0;i<10;++i) {
-      //printf("Testing: LayoutLeft,  Blksize %d\n", i);
-      Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, i, i, i, i, i, i);
+    typedef Kokkos::View<ValueType ***, Kokkos::LayoutLeft, DeviceType>
+        ViewType;
+    Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<
+        DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
+        0, 10, 10, 10, 10, 10, 10);
+    for (int i = 0; i < 10; ++i) {
+      // printf("Testing: LayoutLeft,  Blksize %d\n", i);
+      Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<
+          DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
+          1024, i, i, i, i, i, i);
     }
-    for (int i=0;i<10;++i) {                                                                                        
-      //printf("Testing: LayoutLeft,  Blksize %d\n", i);
-      int dimM=i; int dimN=2*i; int dimK=3*i;
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimN, dimK, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimK, dimN, dimM, dimN); }
+    for (int i = 0; i < 10; ++i) {
+      // printf("Testing: LayoutLeft,  Blksize %d\n", i);
+      int dimM = i;
+      int dimN = 2 * i;
+      int dimK = 3 * i;
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::NoTranspose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::NoTranspose>::value)) {
+        Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<
+            DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
+            1024, dimM, dimK, dimK, dimN, dimM, dimN);
+      }
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::NoTranspose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::Transpose>::value)) {
+        Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<
+            DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
+            1024, dimM, dimK, dimN, dimK, dimM, dimN);
+      }
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::Transpose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::NoTranspose>::value)) {
+        Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimK, dimN, dimM, dimN); }
       if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
         (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
           Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimN, dimK, dimM, dimN); }
     }
   }
 #endif
-#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) 
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
   {
-    typedef Kokkos::View<ValueType***,Kokkos::LayoutRight,DeviceType> ViewType;
-    Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(0, 10, 10, 10, 10, 10, 10);
-    for (int i=0;i<10;++i) {
-      //printf("Testing: LayoutRight, Blksize %d\n", i);
-      Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, i, i, i, i, i, i);
+    typedef Kokkos::View<ValueType ***, Kokkos::LayoutRight, DeviceType>
+        ViewType;
+    Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<
+        DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
+        0, 10, 10, 10, 10, 10, 10);
+    for (int i = 0; i < 10; ++i) {
+      // printf("Testing: LayoutRight, Blksize %d\n", i);
+      Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<
+          DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
+          1024, i, i, i, i, i, i);
     }
-    for (int i=0;i<10;++i) {                                                                                        
-      //printf("Testing: LayoutLeft,  Blksize %d\n", i);
-      int dimM=i; int dimN=2*i; int dimK=3*i;
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimN, dimK, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimN, dimK, dimM, dimN); }
+    for (int i = 0; i < 10; ++i) {
+      // printf("Testing: LayoutLeft,  Blksize %d\n", i);
+      int dimM = i;
+      int dimN = 2 * i;
+      int dimK = 3 * i;
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::NoTranspose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::NoTranspose>::value)) {
+        Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<
+            DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
+            1024, dimM, dimK, dimK, dimN, dimM, dimN);
+      }
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::NoTranspose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::Transpose>::value)) {
+        Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<
+            DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
+            1024, dimM, dimK, dimN, dimK, dimM, dimN);
+      }
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::Transpose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::NoTranspose>::value)) {
+        Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<
+            DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
+            1024, dimK, dimM, dimK, dimN, dimM, dimN);
+      }
+      if ((std::is_same<typename ParamTagType::transA,
+                        KokkosBatched::Trans::Transpose>::value) &&
+          (std::is_same<typename ParamTagType::transB,
+                        KokkosBatched::Trans::Transpose>::value)) {
+        Test::TeamVectorGemm::impl_test_batched_teamvectorgemm<
+            DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
+            1024, dimK, dimM, dimN, dimK, dimM, dimN);
+      }
     }
   }
 #endif
-  
-  return 0;
-}
 
-template<typename DeviceType, 
-         typename ValueType, 
-         typename ScalarType,
-         typename ParamTagType,
-         typename AlgoTagType>
-int test_batched_teamvectorgemm_half() {
-#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) 
-  {
-    typedef Kokkos::View<ValueType***,Kokkos::LayoutLeft,DeviceType> ViewType;
-    Test::TeamVectorGemm::impl_test_batched_teamvectorgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(0, 10, 10, 10, 10, 10, 10);
-    for (int i=0;i<10;++i) {
-      //printf("Testing: LayoutLeft,  Blksize %d\n", i);
-      Test::TeamVectorGemm::impl_test_batched_teamvectorgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, i, i, i, i, i, i);
-    }
-    for (int i=0;i<10;++i) {                                                                                        
-      //printf("Testing: LayoutLeft,  Blksize %d\n", i);
-      int dimM=i; int dimN=2*i; int dimK=3*i;
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::TeamVectorGemm::impl_test_batched_teamvectorgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::TeamVectorGemm::impl_test_batched_teamvectorgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimN, dimK, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::TeamVectorGemm::impl_test_batched_teamvectorgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::TeamVectorGemm::impl_test_batched_teamvectorgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimN, dimK, dimM, dimN); }
-    }
-  }
-#endif
-#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) 
-  {
-    typedef Kokkos::View<ValueType***,Kokkos::LayoutRight,DeviceType> ViewType;
-    Test::TeamVectorGemm::impl_test_batched_teamvectorgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(0, 10, 10, 10, 10, 10, 10);
-    for (int i=0;i<10;++i) {
-      //printf("Testing: LayoutRight, Blksize %d\n", i);
-      Test::TeamVectorGemm::impl_test_batched_teamvectorgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, i, i, i, i, i, i);
-    }
-    for (int i=0;i<10;++i) {                                                                                        
-      //printf("Testing: LayoutLeft,  Blksize %d\n", i);
-      int dimM=i; int dimN=2*i; int dimK=3*i;
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::TeamVectorGemm::impl_test_batched_teamvectorgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::NoTranspose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::TeamVectorGemm::impl_test_batched_teamvectorgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimM, dimK, dimN, dimK, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::NoTranspose>::value)) {
-          Test::TeamVectorGemm::impl_test_batched_teamvectorgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimK, dimN, dimM, dimN); }
-      if ((std::is_same<typename ParamTagType::transA,KokkosBatched::Trans::Transpose>::value) &&
-        (std::is_same<typename ParamTagType::transB,KokkosBatched::Trans::Transpose>::value)) {
-          Test::TeamVectorGemm::impl_test_batched_teamvectorgemm_half<DeviceType,ViewType,ScalarType,ParamTagType,AlgoTagType>(1024, dimK, dimM, dimN, dimK, dimM, dimN); }
-    }
-  }
-#endif
-  
   return 0;
 }

--- a/unit_test/batched/Test_Batched_TeamVectorGemm_Real.hpp
+++ b/unit_test/batched/Test_Batched_TeamVectorGemm_Real.hpp
@@ -1,27 +1,40 @@
 #if defined(KOKKOS_HALF_T_IS_FLOAT)
 TEST_F( TestCategory, batched_scalar_team_vector_gemm_nt_nt_half_half ) {
-  typedef ::Test::TeamVectorGemm::ParamTag<Trans::NoTranspose,Trans::NoTranspose> param_tag_type;
+  typedef ::Test::TeamVectorGemm::ParamTag<Trans::NoTranspose,
+                                           Trans::NoTranspose>
+      param_tag_type;
 
-  //test_batched_teamvectorgemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Blocked>();
-  test_batched_teamvectorgemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Unblocked>();
+  // test_batched_teamvectorgemm<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Blocked>();
+  test_batched_teamvectorgemm<TestExecSpace, ::Test::halfScalarType,
+                              ::Test::halfScalarType, param_tag_type,
+                              Algo::Gemm::Unblocked>();
 }
 TEST_F( TestCategory, batched_scalar_team_vector_gemm_t_nt_half_half ) {
-  typedef ::Test::TeamVectorGemm::ParamTag<Trans::Transpose,Trans::NoTranspose> param_tag_type;
+  typedef ::Test::TeamVectorGemm::ParamTag<Trans::Transpose, Trans::NoTranspose>
+      param_tag_type;
 
-  //test_batched_teamvectorgemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Blocked>();
-  test_batched_teamvectorgemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Unblocked>();
+  // test_batched_teamvectorgemm<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Blocked>();
+  test_batched_teamvectorgemm<TestExecSpace, ::Test::halfScalarType,
+                              ::Test::halfScalarType, param_tag_type,
+                              Algo::Gemm::Unblocked>();
 }
 TEST_F( TestCategory, batched_scalar_team_vector_gemm_nt_t_half_half ) {
-  typedef ::Test::TeamVectorGemm::ParamTag<Trans::NoTranspose,Trans::Transpose> param_tag_type;
+  typedef ::Test::TeamVectorGemm::ParamTag<Trans::NoTranspose, Trans::Transpose>
+      param_tag_type;
 
-  //test_batched_teamvectorgemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Blocked>();
-  test_batched_teamvectorgemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Unblocked>();
+  // test_batched_teamvectorgemm<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Blocked>();
+  test_batched_teamvectorgemm<TestExecSpace, ::Test::halfScalarType,
+                              ::Test::halfScalarType, param_tag_type,
+                              Algo::Gemm::Unblocked>();
 }
 TEST_F( TestCategory, batched_scalar_team_vector_gemm_t_t_half_half ) {
-  typedef ::Test::TeamVectorGemm::ParamTag<Trans::Transpose,Trans::Transpose> param_tag_type;
+  typedef ::Test::TeamVectorGemm::ParamTag<Trans::Transpose, Trans::Transpose>
+      param_tag_type;
 
-  //test_batched_teamvectorgemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Blocked>();
-  test_batched_teamvectorgemm_half<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Unblocked>();
+  // test_batched_teamvectorgemm<TestExecSpace,::Test::halfScalarType,::Test::halfScalarType,param_tag_type,Algo::Gemm::Blocked>();
+  test_batched_teamvectorgemm<TestExecSpace, ::Test::halfScalarType,
+                              ::Test::halfScalarType, param_tag_type,
+                              Algo::Gemm::Unblocked>();
 }
 #endif // KOKKOS_HALF_T_IS_FLOAT
 


### PR DESCRIPTION
With the merge of https://github.com/kokkos/kokkos/pull/3922, the _half functions can be removed from the batched gemm unit tests. 

These changes also update the gemm unit tests to compare against the vanilla gemm reference implementation in our test utils, rather than comparing results against the KokkosBatched implementations themselves.

All the formatting changes are from a pre-commit hook that applies clang-format using https://github.com/kokkos/kokkos-kernels/blob/master/.clang-format.

Fixes #846.