### PR TITLE
Add sort and make sure using host mirror on host memory in kspiluk_symbolic

### DIFF
--- a/src/sparse/impl/KokkosSparse_spiluk_symbolic_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spiluk_symbolic_impl.hpp
@@ -51,6 +51,7 @@
 #include <KokkosKernels_config.h>
 #include <Kokkos_ArithTraits.hpp>
 #include <KokkosSparse_spiluk_handle.hpp>
+#include <Kokkos_Sort.hpp>
 
 //#define SYMBOLIC_OUTPUT_INFO
 
@@ -171,49 +172,32 @@ void iluk_symbolic ( IlukHandle& thandle,
  {
   // Scheduling and symbolic phase currently compute on host - need host copy of all views
 
-  typedef typename ARowMapType::HostMirror  AHostRowMapType;
-  typedef typename AEntriesType::HostMirror AHostEntriesType;
-  typedef typename LRowMapType::HostMirror  LHostRowMapType;
-  typedef typename LEntriesType::HostMirror LHostEntriesType;
-  typedef typename URowMapType::HostMirror  UHostRowMapType;
-  typedef typename UEntriesType::HostMirror UHostEntriesType;
-
   typedef typename IlukHandle::size_type size_type;
   typedef typename IlukHandle::nnz_lno_t nnz_lno_t;
 
   typedef typename IlukHandle::nnz_lno_view_t             HandleDeviceEntriesType;
-  typedef typename IlukHandle::nnz_lno_view_t::HostMirror HandleHostEntriesType;
-
   typedef typename IlukHandle::nnz_row_view_t             HandleDeviceRowMapType;
-  typedef typename IlukHandle::nnz_row_view_t::HostMirror HandleHostRowMapType;
 
   //typedef typename IlukHandle::signed_integral_t signed_integral_t;
 
   size_type nrows = thandle.get_nrows();
 
-  AHostRowMapType A_row_map = Kokkos::create_mirror_view(A_row_map_d);
-  Kokkos::deep_copy(A_row_map, A_row_map_d);
+  auto A_row_map = Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), A_row_map_d );
+  auto A_entries = Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), A_entries_d );
+  auto L_row_map = Kokkos::create_mirror_view(Kokkos::HostSpace(), L_row_map_d);
+  auto L_entries = Kokkos::create_mirror_view(Kokkos::HostSpace(), L_entries_d);
+  auto U_row_map = Kokkos::create_mirror_view(Kokkos::HostSpace(), U_row_map_d);
+  auto U_entries = Kokkos::create_mirror_view(Kokkos::HostSpace(), U_entries_d);
 
-  AHostEntriesType A_entries = Kokkos::create_mirror_view(A_entries_d);
-  Kokkos::deep_copy(A_entries, A_entries_d);
-
-  LHostRowMapType  L_row_map = Kokkos::create_mirror_view(L_row_map_d);
-  LHostEntriesType L_entries = Kokkos::create_mirror_view(L_entries_d);
-  UHostRowMapType  U_row_map = Kokkos::create_mirror_view(U_row_map_d);
-  UHostEntriesType U_entries = Kokkos::create_mirror_view(U_entries_d);
-  
   HandleDeviceRowMapType dlevel_list = thandle.get_level_list();
-  HandleHostRowMapType level_list    = Kokkos::create_mirror_view(dlevel_list);
-  Kokkos::deep_copy(level_list, dlevel_list);
-  
+  auto level_list = Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), dlevel_list );
+
   HandleDeviceEntriesType dlevel_ptr = thandle.get_level_ptr();
-  HandleHostEntriesType level_ptr    = Kokkos::create_mirror_view(dlevel_ptr);
-  Kokkos::deep_copy(level_ptr, dlevel_ptr);
+  auto level_ptr = Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), dlevel_ptr );
 
   HandleDeviceEntriesType dlevel_idx = thandle.get_level_idx();
-  HandleHostEntriesType level_idx    = Kokkos::create_mirror_view(dlevel_idx);
-  Kokkos::deep_copy(level_idx, dlevel_idx);
- 
+  auto level_idx = Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), dlevel_idx );
+
   size_type nlev = 0;
 
   //Level scheduling on A???
@@ -357,6 +341,18 @@ void iluk_symbolic ( IlukHandle& thandle,
 
   thandle.set_nnzL(cntL);
   thandle.set_nnzU(cntU);
+
+  // Sort
+  for (size_type row_id = 0; row_id < L_row_map.extent(0)-1; row_id++) {
+    size_type row_start = L_row_map(row_id);
+    size_type row_end   = L_row_map(row_id + 1);
+    Kokkos::sort(subview(L_entries, Kokkos::make_pair(row_start, row_end)));
+  }
+  for (size_type row_id = 0; row_id < U_row_map.extent(0)-1; row_id++) {
+    size_type row_start = U_row_map(row_id);
+    size_type row_end   = U_row_map(row_id + 1);
+    Kokkos::sort(subview(U_entries, Kokkos::make_pair(row_start, row_end)));
+  }
 
   //Level scheduling on L
   level_sched (thandle, L_row_map, L_entries, nrows, level_list, level_ptr, level_idx, nlev);  

--- a/src/sparse/impl/KokkosSparse_spiluk_symbolic_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spiluk_symbolic_impl.hpp
@@ -343,12 +343,12 @@ void iluk_symbolic ( IlukHandle& thandle,
   thandle.set_nnzU(cntU);
 
   // Sort
-  for (size_type row_id = 0; row_id < L_row_map.extent(0)-1; row_id++) {
+  for (size_type row_id = 0; row_id < static_cast<size_type>(L_row_map.extent(0))-1; row_id++) {
     size_type row_start = L_row_map(row_id);
     size_type row_end   = L_row_map(row_id + 1);
     Kokkos::sort(subview(L_entries, Kokkos::make_pair(row_start, row_end)));
   }
-  for (size_type row_id = 0; row_id < U_row_map.extent(0)-1; row_id++) {
+  for (size_type row_id = 0; row_id < static_cast<size_type>(U_row_map.extent(0))-1; row_id++) {
     size_type row_start = U_row_map(row_id);
     size_type row_end   = U_row_map(row_id + 1);
     Kokkos::sort(subview(U_entries, Kokkos::make_pair(row_start, row_end)));


### PR DESCRIPTION
This PR matches changes to kokkos-kernels needed for trilinos/Trilinos#9088:
- move sort operations in Ifpack2's RILUK compute phase to Kokkos Kernels spiluk_symbolic,
- explicitly create host mirror on host memory in Kokkos Kernels spiluk_symbolic to make sure it is running on host.
