### PR TITLE
Deprecation: a deprecated function is called in the SpADD perf_test

### DIFF
--- a/perf_test/sparse/KokkosSparse_spadd.cpp
+++ b/perf_test/sparse/KokkosSparse_spadd.cpp
@@ -197,8 +197,8 @@ void run_experiment(const Params& params)
   if(params.sorted)
   {
     std::cout << "Assuming input matrices are sorted (explicitly sorting just in case)\n";
-    KokkosKernels::Impl::sort_crs_matrix(A);
-    KokkosKernels::Impl::sort_crs_matrix(B);
+    KokkosKernels::sort_crs_matrix(A);
+    KokkosKernels::sort_crs_matrix(B);
   }
   else
     std::cout << "Assuming input matrices are not sorted.\n";


### PR DESCRIPTION
Replacing the call to the offending function with the new function call that is not from the Impl namespace.
See issue #953 