### PR TITLE
Fix invalid mem accesses in new GEMV kernel

### DIFF
--- a/src/blas/impl/KokkosBlas2_gemv_impl.hpp
+++ b/src/blas/impl/KokkosBlas2_gemv_impl.hpp
@@ -566,12 +566,10 @@ public:
       IndexType yrow = team.league_rank() * 32 + i;
       if(yrow < (IndexType) A_.extent(0))
       {
-        Scalar betaTerm;
         if(beta_ == KAT::zero())
-          betaTerm = KAT::zero();
+          y_(yrow) = alpha_ * blockResult[i];
         else
-          betaTerm = beta_ * y_(yrow);
-        y_(yrow) = betaTerm + alpha_ * blockResult[i];
+          y_(yrow) = beta_ * y_(yrow) + alpha_ * blockResult[i];
       }
     });
   }

--- a/src/blas/impl/KokkosBlas2_gemv_impl.hpp
+++ b/src/blas/impl/KokkosBlas2_gemv_impl.hpp
@@ -550,11 +550,9 @@ public:
     IndexType blockColStart = columnsPerThread * block;
     Scalar localSum = KAT::zero();
     //compute local sum
-    for(IndexType col = blockColStart; col < blockColStart + columnsPerThread; col++)
+    if(row < (IndexType) A_.extent(0))
     {
-      if(col == (IndexType) A_.extent(1))
-        break;
-      if(row < (IndexType) A_.extent(0))
+      for(IndexType col = blockColStart; col < blockColStart + columnsPerThread && col < A_.extent(1); col++)
       {
         //A access is coalesced, x access is a broadcast
         localSum += A_(row, col) * x_(col);

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -214,6 +214,46 @@ namespace Test {
     }
   };
 
+  template<class ViewTypeA, class ViewTypeX, class ViewTypeY>
+  void vanillaGEMV(char mode,
+      typename ViewTypeA::non_const_value_type alpha, const ViewTypeA& A, const ViewTypeX& x, 
+      typename ViewTypeY::non_const_value_type beta, const ViewTypeY& y)
+  {
+    using ScalarY = typename ViewTypeY::non_const_value_type;
+    using KAT_A = Kokkos::ArithTraits<typename ViewTypeA::non_const_value_type>;
+    using KAT_Y = Kokkos::ArithTraits<ScalarY>;
+    int M = A.extent(0);
+    int N = A.extent(1);
+    if(beta == KAT_Y::zero())
+      Kokkos::deep_copy(y, KAT_Y::zero());
+    if(mode == 'N') {
+      for(int i = 0; i < M; i++) {
+        ScalarY y_i = beta * y(i);
+        for(int j = 0; j < N; j++) {
+           y_i += alpha * A(i,j) * x(j);
+        }
+        y(i) = y_i;
+      }
+    } else if(mode == 'T') {
+      for(int j = 0; j < N; j++) {
+        ScalarY y_j = beta * y(j);
+        for(int i = 0; i < M; i++) {
+           y_j += alpha * A(i,j) * x(i);
+        }
+        y(j) = y_j;
+      }
+    } else if(mode == 'C') {
+      for(int j = 0; j < N; j++) {
+        ScalarY y_j = beta * y(j);
+        for(int i = 0; i < M; i++) {
+           y_j += alpha * KAT_A::conj (A(i,j)) * x(i);
+        }
+        y(j) = y_j;
+      }
+    }
+  }
+
+
   template<class T>
   class epsilon {
     public:

--- a/unit_test/blas/Test_Blas2_gemv.hpp
+++ b/unit_test/blas/Test_Blas2_gemv.hpp
@@ -168,6 +168,7 @@ int test_gemv(const char* mode) {
   Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,1024,0);
   Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,13,13);
   Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,13,1024);
+  Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,50,40);
   Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,1024,1024);
   Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,4321,4321);
   //Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,132231,1024);
@@ -181,6 +182,7 @@ int test_gemv(const char* mode) {
   Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,1024,0);
   Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,13,13);
   Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,13,1024);
+  Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,50,40);
   Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,1024,1024);
   Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,4321,4321);
   //Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,132231,1024);
@@ -194,6 +196,7 @@ int test_gemv(const char* mode) {
   Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,1024,0);
   Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,13,13);
   Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,13,1024);
+  Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,50,40);
   Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,1024,1024);
   Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,4321,4321);
   //Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,132231,1024);


### PR DESCRIPTION
This was silently succeeding on Volta but failed on Pascal. Running
under cuda-memcheck, or kokkos view bounds checking, on Volta showed the issue.