### PR TITLE
Warnings: remove -Wunused-parameter warnings in Kokkos Kernels

### DIFF
--- a/example/wiki/graph/KokkosGraph_wiki_coarsening.cpp
+++ b/example/wiki/graph/KokkosGraph_wiki_coarsening.cpp
@@ -1,7 +1,7 @@
 #include "KokkosGraph_wiki_9pt_stencil.hpp"
 #include "KokkosGraph_MIS2.hpp"
 
-int main(int argc, char* argv[])
+int main(int /*argc*/, char* /*argv*/[])
 {
   Kokkos::initialize();
   {

--- a/example/wiki/graph/KokkosGraph_wiki_coloring.cpp
+++ b/example/wiki/graph/KokkosGraph_wiki_coloring.cpp
@@ -11,7 +11,7 @@
 //    -Different constraint: two vertices separated by a path of length 1 OR 2
 //     must have different colors)
 
-int main(int argc, char* argv[])
+int main(int /*argc*/, char* /*argv*/[])
 {
   Kokkos::initialize();
   {

--- a/example/wiki/graph/KokkosGraph_wiki_mis2.cpp
+++ b/example/wiki/graph/KokkosGraph_wiki_mis2.cpp
@@ -1,7 +1,7 @@
 #include "KokkosGraph_wiki_9pt_stencil.hpp"
 #include "KokkosGraph_MIS2.hpp"
 
-int main(int argc, char* argv[])
+int main(int /*argc*/, char* /*argv*/[])
 {
   Kokkos::initialize();
   {

--- a/example/wiki/graph/KokkosGraph_wiki_rcm.cpp
+++ b/example/wiki/graph/KokkosGraph_wiki_rcm.cpp
@@ -42,7 +42,7 @@ void printReorderedMatrix(const rowmap_t& rowmapIn, const entries_t& entriesIn, 
 }
 
 
-int main(int argc, char* argv[])
+int main(int /*argc*/, char* /*argv*/[])
 {
   Kokkos::initialize();
   {

--- a/example/wiki/sparse/KokkosSparse_wiki_crsmatrix.cpp
+++ b/example/wiki/sparse/KokkosSparse_wiki_crsmatrix.cpp
@@ -11,7 +11,7 @@ using Ordinal = default_lno_t;
 using Offset  = default_size_type;
 using Layout  = default_layout;
 
-int main(int argc, char* argv[]) {
+int main(int /*argc*/, char* /*argv*/[]) {
   Kokkos::initialize();
 
   using device_type = typename Kokkos::Device<

--- a/example/wiki/sparse/KokkosSparse_wiki_gauss_seidel.cpp
+++ b/example/wiki/sparse/KokkosSparse_wiki_gauss_seidel.cpp
@@ -13,7 +13,7 @@
 //  -Here, use to solve a diagonally dominant linear system directly.
 
 //Helper to print out colors in the shape of the grid
-int main(int argc, char* argv[])
+int main(int /*argc*/, char* /*argv*/[])
 {
   using Scalar  = default_scalar;
   using Mag     = Kokkos::ArithTraits<Scalar>::mag_type;

--- a/example/wiki/sparse/KokkosSparse_wiki_spadd.cpp
+++ b/example/wiki/sparse/KokkosSparse_wiki_spadd.cpp
@@ -10,7 +10,7 @@ using Ordinal = default_lno_t;
 using Offset  = default_size_type;
 using Layout  = default_layout;
 
-int main(int argc, char* argv[]) {
+int main(int /*argc*/, char* /*argv*/[]) {
   Kokkos::initialize();
 
   using device_type = typename Kokkos::Device<

--- a/example/wiki/sparse/KokkosSparse_wiki_spgemm.cpp
+++ b/example/wiki/sparse/KokkosSparse_wiki_spgemm.cpp
@@ -10,7 +10,7 @@ using Ordinal = default_lno_t;
 using Offset  = default_size_type;
 using Layout  = default_layout;
 
-int main(int argc, char* argv[]) {
+int main(int /*argc*/, char* /*argv*/[]) {
   Kokkos::initialize();
 
   using device_type = typename Kokkos::Device<

--- a/example/wiki/sparse/KokkosSparse_wiki_spmv.cpp
+++ b/example/wiki/sparse/KokkosSparse_wiki_spmv.cpp
@@ -26,7 +26,7 @@ struct check_spmv_functor {
   }
 };
 
-int main(int argc, char* argv[]) {
+int main(int /*argc*/, char** /*argv*/) {
   Kokkos::initialize();
 
   using device_type = typename Kokkos::Device<

--- a/perf_test/blas/blas3/KokkosBlas3_perf_test.cpp
+++ b/perf_test/blas/blas3/KokkosBlas3_perf_test.cpp
@@ -220,7 +220,7 @@ static void __print_help_blas3_perf_test() {
       DEFAULT_VERIFY);
 }
 
-static void __blas3_perf_test_input_error(char **argv, char short_opt,
+static void __blas3_perf_test_input_error(char **/*argv*/, char short_opt,
                                           char *getopt_optarg) {
   fprintf(stderr, "ERROR: invalid option \"-%c %s\". Try --help.\n", short_opt,
           getopt_optarg);

--- a/perf_test/blas/blas3/KokkosBlas3_trmm_perf_test.hpp
+++ b/perf_test/blas/blas3/KokkosBlas3_trmm_perf_test.hpp
@@ -82,8 +82,8 @@ void (*do_trmm_invoke[LOOP_N][TEST_N])(options_t) = {
  * LHS giving us this flop count: flops = columns_LHS * (columns_LHS + 1) flops
  * = (flops / 2) * 2 flops = flops * rows_LHS
  */
-static inline int __trmm_impl_flop_count(char side, int b_m, int b_n, int a_m,
-                                         int a_n) {
+static inline int __trmm_impl_flop_count(char side, int b_m, int b_n, int /*a_m*/,
+                                         int /*a_n*/) {
   int flops;
 
   if (side == 'L' || side == 'l') {
@@ -107,7 +107,7 @@ static inline int __trmm_impl_flop_count(char side, int b_m, int b_n, int a_m,
 // Flop count formula from lapack working note 41:
 // http://www.icl.utk.edu/~mgates3/docs/lawn41.pdf
 static inline double __trmm_flop_count(char side, double b_m, double b_n,
-                                       double a_m, double a_n) {
+                                       double /*a_m*/, double /*a_n*/) {
   double flops;
 
   if (side == 'L' || side == 'l') {
@@ -189,8 +189,8 @@ static void __trmm_output_csv_row(options_t options, trmm_args_t trmm_args,
                  << std::endl;
 }
 
-static void __print_trmm_perf_test_options(options_t options) {
 #ifdef PERF_TEST_DEBUG
+static void __print_trmm_perf_test_options(options_t options) {
   printf("options.test      = %s\n", test_e_str[options.test].c_str());
   printf("options.loop      = %s\n", loop_e_str[options.loop].c_str());
   printf("options.start     = %dx%d,%dx%d\n", options.start.a.m,
@@ -207,17 +207,21 @@ static void __print_trmm_perf_test_options(options_t options) {
     printf("options.alpha     = %lf\n", options.blas_args.trmm.alpha);
   else if (std::is_same<float, default_scalar>::value)
     printf("options.alpha     = %f\n", options.blas_args.trmm.alpha);
-#endif  // PERF_TEST_DEBUG
   return;
 }
+#else
+static void __print_trmm_perf_test_options(options_t /*options*/) {
+  return;
+}
+#endif  // PERF_TEST_DEBUG
 
 /*************************** Internal templated fns **************************/
-template <class scalar_type, class vta, class vtb, class device_type>
-void __do_trmm_serial_blas(options_t options, trmm_args_t trmm_args) {
 // Need to take subviews on the device
 #if !defined(KOKKOS_ENABLE_CUDA) \
   && !defined(KOKKOS_ENABLE_HIP) \
   && !defined(KOKKOS_ENABLE_OPENMPTARGET)
+template <class scalar_type, class vta, class vtb, class device_type>
+void __do_trmm_serial_blas(options_t options, trmm_args_t trmm_args) {
   uint32_t warm_up_n = options.warm_up_n;
   uint32_t n         = options.n;
   Kokkos::Timer timer;
@@ -249,20 +253,24 @@ void __do_trmm_serial_blas(options_t options, trmm_args_t trmm_args) {
     Kokkos::fence();
   }
   __trmm_output_csv_row(options, trmm_args, timer.seconds());
-#else
-  std::cerr << std::string(__func__)
-            << " disabled since KOKKOS_ENABLE_CUDA or KOKKOS_ENABLE_OPENMPTARGET is defined." << std::endl;
-#endif  // !KOKKOS_ENABLE_CUDA && !KOKKOS_ENABLE_OPENMPTARGET
   return;
 }
+#else
+template <class scalar_type, class vta, class vtb, class device_type>
+void __do_trmm_serial_blas(options_t /*options*/, trmm_args_t /*trmm_args*/) {
+  std::cerr << std::string(__func__)
+            << " disabled since KOKKOS_ENABLE_CUDA or KOKKOS_ENABLE_OPENMPTARGET is defined." << std::endl;
+  return;
+}
+#endif  // !KOKKOS_ENABLE_CUDA && !KOKKOS_ENABLE_OPENMPTARGET
 
-template <class side, class uplo, class trans, class diag>
-void __do_trmm_serial_batched_template(options_t options,
-                                       trmm_args_t trmm_args) {
 // Need to take subviews on the device
 #if !defined(KOKKOS_ENABLE_CUDA) \
   && !defined(KOKKOS_ENABLE_HIP) \
   && !defined(KOKKOS_ENABLE_OPENMPTARGET)
+template <class side, class uplo, class trans, class diag>
+void __do_trmm_serial_batched_template(options_t options,
+                                       trmm_args_t trmm_args) {
   uint32_t warm_up_n = options.warm_up_n;
   uint32_t n         = options.n;
   Kokkos::Timer timer;
@@ -291,11 +299,15 @@ void __do_trmm_serial_batched_template(options_t options,
     Kokkos::fence();
   }
   __trmm_output_csv_row(options, trmm_args, timer.seconds());
+}
 #else
+template <class side, class uplo, class trans, class diag>
+void __do_trmm_serial_batched_template(options_t /*options*/,
+                                       trmm_args_t /*trmm_args*/) {
   std::cerr << std::string(__func__)
             << " disabled since KOKKOS_ENABLE_CUDA or KOKKOS_ENABLE_OPENMPTARGET is defined." << std::endl;
-#endif  // !KOKKOS_ENABLE_CUDA && !KOKKOS_ENABLE_OPENMPTARGET
 }
+#endif  // !KOKKOS_ENABLE_CUDA && !KOKKOS_ENABLE_OPENMPTARGET
 
 template <class scalar_type, class vta, class vtb, class device_type>
 void __do_trmm_serial_batched(options_t options, trmm_args_t trmm_args) {

--- a/perf_test/sparse/KokkosSparse_pcg.hpp
+++ b/perf_test/sparse/KokkosSparse_pcg.hpp
@@ -307,7 +307,7 @@ void pcgsolve(
             ,  const double tolerance = std::numeric_limits<double>::epsilon()
             ,  CGSolveResult * result = 0
             ,  bool use_sgs = true
-            ,  int clusterSize = 1
+            ,  int /*clusterSize*/ = 1
             ,  bool use_sequential_sgs = false)
 {
   using namespace KokkosSparse;

--- a/perf_test/sparse/KokkosSparse_spiluk.cpp
+++ b/perf_test/sparse/KokkosSparse_spiluk.cpp
@@ -74,7 +74,7 @@ using namespace KokkosKernels::Experimental;
 
 enum {DEFAULT, CUSPARSE, LVLSCHED_RP, LVLSCHED_TP1/*, LVLSCHED_TP2*/};
 
-int test_spiluk_perf(std::vector<int> tests, std::string afilename, int kin, int team_size, int vector_length, /*int idx_offset,*/ int loop) {
+int test_spiluk_perf(std::vector<int> tests, std::string afilename, int kin, int team_size, int /*vector_length*/, /*int idx_offset,*/ int loop) {
   typedef default_scalar scalar_t;
   typedef default_lno_t lno_t;
   typedef default_size_type size_type;

--- a/perf_test/sparse/KokkosSparse_sptrsv.cpp
+++ b/perf_test/sparse/KokkosSparse_sptrsv.cpp
@@ -116,7 +116,7 @@ void check_entries_sorted(const RowMapType drow_map, const EntriesType dentries)
 
 }
 
-int test_sptrsv_perf(std::vector<int> tests, const std::string& lfilename, const std::string& ufilename, const int team_size, const int vector_length, const int idx_offset, const int loop, const int chain_threshold = 0, const float dense_row_percent = -1.0) {
+int test_sptrsv_perf(std::vector<int> tests, const std::string& lfilename, const std::string& ufilename, const int team_size, const int vector_length, const int /*idx_offset*/, const int loop, const int chain_threshold = 0, const float /*dense_row_percent*/ = -1.0) {
   typedef default_scalar scalar_t;
   typedef default_lno_t lno_t;
   typedef default_size_type size_type;

--- a/perf_test/sparse/KokkosSparse_sptrsv_cholmod.cpp
+++ b/perf_test/sparse/KokkosSparse_sptrsv_cholmod.cpp
@@ -595,7 +595,7 @@ int main(int argc, char **argv)
   return 0;
 }
 #else // defined(KOKKOSKERNELS_ENABLE_TPL_CHOLMOD)
-int main(int argc, char **argv)
+int main(int /*argc*/, char **/*argv*/)
 {
   std::cout << std::endl << "** CHOLMOD NOT ENABLED **" << std::endl << std::endl;
   return 0;

--- a/perf_test/sparse/KokkosSparse_sptrsv_superlu.cpp
+++ b/perf_test/sparse/KokkosSparse_sptrsv_superlu.cpp
@@ -811,7 +811,7 @@ int main(int argc, char **argv) {
   return 0;
 }
 #else // defined(KOKKOSKERNELS_ENABLE_TPL_SUPERLU)
-int main(int argc, char **argv) {
+int main(int /*argc*/, char **/*argv*/) {
   std::cout << std::endl << " ** SUPERLU NOT ENABLED **" << std::endl << std::endl;
   exit(0);
   return 0;
@@ -820,7 +820,7 @@ int main(int argc, char **argv) {
 
 #else // defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA ) && (!defined(KOKKOS_ENABLE_CUDA) || ( 8000 <= CUDA_VERSION ))
 
-int main(int argc, char **argv) {
+int main(int /*argc*/, char **/*argv*/) {
 #if !defined(KOKKOSKERNELS_INST_DOUBLE)
   std::cout << " Only supported with double precision" << std::endl;
 #endif

--- a/perf_test/sparse/KokkosSparse_sptrsv_supernode.cpp
+++ b/perf_test/sparse/KokkosSparse_sptrsv_supernode.cpp
@@ -412,7 +412,7 @@ int main(int argc, char **argv) {
   return 0;
 }
 #else // defined(KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV)
-int main(int argc, char **argv) {
+int main(int /*argc*/, char **/*argv*/) {
   std::cout << std::endl << " ** SUPERNODAL NOT ENABLED **" << std::endl << std::endl;
   exit(0);
   return 0;
@@ -421,7 +421,7 @@ int main(int argc, char **argv) {
 
 #else // defined( KOKKOS_ENABLE_CXX11_DISPATCH_LAMBDA ) && (!defined(KOKKOS_ENABLE_CUDA) || ( 8000 <= CUDA_VERSION ))
 
-int main(int argc, char **argv) {
+int main(int /*argc*/, char **/*argv*/) {
 #if !defined(KOKKOSKERNELS_INST_DOUBLE)
   std::cout << " Only supported with double precision" << std::endl;
 #endif

--- a/src/batched/KokkosBatched_Gemv_Decl.hpp
+++ b/src/batched/KokkosBatched_Gemv_Decl.hpp
@@ -22,11 +22,11 @@ namespace KokkosBatched {
              typename yViewType>
     KOKKOS_INLINE_FUNCTION
     static int
-    invoke(const ScalarType alpha,
-           const AViewType &A,
-           const xViewType &x,
-           const ScalarType beta,
-           const yViewType &y) {
+    invoke(const ScalarType /*alpha*/,
+           const AViewType &/*A*/,
+           const xViewType &/*x*/,
+           const ScalarType /*beta*/,
+           const yViewType &/*y*/) {
       assert(false && "Error: encounter dummy impl");
       return 0;
     }
@@ -46,12 +46,12 @@ namespace KokkosBatched {
              typename yViewType>
     KOKKOS_INLINE_FUNCTION
     static int
-    invoke(const MemberType &member, 
-           const ScalarType alpha,
-           const AViewType &A,
-           const xViewType &x,
-           const ScalarType beta,
-           const yViewType &y) {
+    invoke(const MemberType &/*member*/, 
+           const ScalarType /*alpha*/,
+           const AViewType &/*A*/,
+           const xViewType &/*x*/,
+           const ScalarType /*beta*/,
+           const yViewType &/*y*/) {
       assert(false && "Error: encounter dummy impl");
       return 0;
     }
@@ -71,12 +71,12 @@ namespace KokkosBatched {
              typename yViewType>
     KOKKOS_INLINE_FUNCTION
     static int
-    invoke(const MemberType &member, 
-           const ScalarType alpha,
-           const AViewType &A,
-           const xViewType &x,
-           const ScalarType beta,
-           const yViewType &y) {
+    invoke(const MemberType &/*member*/, 
+           const ScalarType /*alpha*/,
+           const AViewType &/*A*/,
+           const xViewType &/*x*/,
+           const ScalarType /*beta*/,
+           const yViewType &/*y*/) {
       assert(false && "Error: encounter dummy impl");
       return 0;
     }

--- a/src/batched/KokkosBatched_Gemv_TeamVector_Internal.hpp
+++ b/src/batched/KokkosBatched_Gemv_TeamVector_Internal.hpp
@@ -23,13 +23,13 @@ namespace KokkosBatched {
              typename ValueType>
     KOKKOS_INLINE_FUNCTION
     static int
-    invoke(const MemberType &member,
-           const int m, const int n, 
-           const ScalarType alpha,
-           const ValueType *__restrict__ A, const int as0, const int as1,
-           const ValueType *__restrict__ x, const int xs0, 
-           const ScalarType beta,
-           /**/  ValueType *__restrict__ y, const int ys0) {
+    invoke(const MemberType &/*member*/,
+           const int /*m*/, const int /*n*/, 
+           const ScalarType /*alpha*/,
+           const ValueType *__restrict__ /*A*/, const int /*as0*/, const int /*as1*/,
+           const ValueType *__restrict__ /*x*/, const int /*xs0*/, 
+           const ScalarType /*beta*/,
+           /**/  ValueType *__restrict__ /*y*/, const int /*ys0*/) {
       assert(false && "Error: encounter dummy impl");
       return 0;
     }

--- a/src/batched/KokkosBatched_LU_Serial_Internal.hpp
+++ b/src/batched/KokkosBatched_LU_Serial_Internal.hpp
@@ -82,7 +82,7 @@ namespace KokkosBatched {
   SerialLU_Internal<Algo::LU::Blocked>::
   invoke(const int m, const int n,
          ValueType *__restrict__ A, const int as0, const int as1,
-         const typename MagnitudeScalarType<ValueType>::type tiny) {
+         const typename MagnitudeScalarType<ValueType>::type /*tiny*/) {
     enum : int {
       mbAlgo = Algo::LU::Blocked::mb<Kokkos::Impl::ActiveExecutionMemorySpace>()
     };

--- a/src/batched/KokkosBatched_LU_Team_Internal.hpp
+++ b/src/batched/KokkosBatched_LU_Team_Internal.hpp
@@ -92,7 +92,7 @@ namespace KokkosBatched {
   invoke(const MemberType &member, 
          const int m, const int n,
          ValueType *__restrict__ A, const int as0, const int as1,
-         const typename MagnitudeScalarType<ValueType>::type tiny) {
+         const typename MagnitudeScalarType<ValueType>::type /*tiny*/) {
 
     enum : int {
       mbAlgo = Algo::LU::Blocked::mb<Kokkos::Impl::ActiveExecutionMemorySpace>()

--- a/src/batched/KokkosBatched_QR_Decl.hpp
+++ b/src/batched/KokkosBatched_QR_Decl.hpp
@@ -36,10 +36,10 @@ namespace KokkosBatched {
              typename wViewType>
     KOKKOS_INLINE_FUNCTION
     static int
-    invoke(const MemberType &member,
-           const AViewType &A,
-           const tViewType &t,
-           const wViewType &w) {
+    invoke(const MemberType &/*member*/,
+           const AViewType &/*A*/,
+           const tViewType &/*t*/,
+           const wViewType &/*w*/) {
       /// not implemented
       return -1;
     }

--- a/src/batched/KokkosBatched_SolveUTV_TeamVector_Internal.hpp
+++ b/src/batched/KokkosBatched_SolveUTV_TeamVector_Internal.hpp
@@ -25,7 +25,7 @@ namespace KokkosBatched {
     static int
     invoke(const MemberType &member, 
 	   const int matrix_rank,
-           const int m, const int n,
+           const int m, const int /*n*/,
            const ValueType * U, const int us0, const int us1,
 	   const ValueType * T, const int ts0, const int ts1,
 	   const ValueType * V, const int vs0, const int vs1,

--- a/src/batched/KokkosBatched_Trmm_Serial_Internal.hpp
+++ b/src/batched/KokkosBatched_Trmm_Serial_Internal.hpp
@@ -121,7 +121,7 @@ namespace KokkosBatched {
   KOKKOS_INLINE_FUNCTION
   int
   SerialTrmmInternalLeftLower<Algo::Trmm::Unblocked>::
-  invoke(const bool use_unit_diag,
+  invoke(const bool /*use_unit_diag*/,
          const bool do_conj,
          const int am, const int an,
          const int bm, const int bn,
@@ -203,7 +203,7 @@ namespace KokkosBatched {
   KOKKOS_INLINE_FUNCTION
   int
   SerialTrmmInternalRightLower<Algo::Trmm::Unblocked>::
-  invoke(const bool use_unit_diag,
+  invoke(const bool /*use_unit_diag*/,
          const bool do_conj,
          const int am, const int an,
          const int bm, const int bn,
@@ -284,7 +284,7 @@ namespace KokkosBatched {
   KOKKOS_INLINE_FUNCTION
   int
   SerialTrmmInternalLeftUpper<Algo::Trmm::Unblocked>::
-  invoke(const bool use_unit_diag,
+  invoke(const bool /*use_unit_diag*/,
          const bool do_conj,
          const int am, const int an,
          const int bm, const int bn,
@@ -362,7 +362,7 @@ namespace KokkosBatched {
   KOKKOS_INLINE_FUNCTION
   int
   SerialTrmmInternalRightUpper<Algo::Trmm::Unblocked>::
-  invoke(const bool use_unit_diag,
+  invoke(const bool /*use_unit_diag*/,
          const bool do_conj,
          const int am, const int an,
          const int bm, const int bn,

--- a/src/batched/KokkosBatched_Trsv_Decl.hpp
+++ b/src/batched/KokkosBatched_Trsv_Decl.hpp
@@ -24,9 +24,9 @@ namespace KokkosBatched {
              typename bViewType>
     KOKKOS_INLINE_FUNCTION
     static int
-    invoke(const ScalarType alpha,
-           const AViewType &A,
-           const bViewType &b) {
+    invoke(const ScalarType /*alpha*/,
+           const AViewType &/*A*/,
+           const bViewType &/*b*/) {
       assert(false && "Error: encounter dummy impl");
       return 0;
     }
@@ -49,10 +49,10 @@ namespace KokkosBatched {
              typename bViewType>
     KOKKOS_INLINE_FUNCTION
     static int
-    invoke(const MemberType &member,
-           const ScalarType alpha,
-           const AViewType &A,
-           const bViewType &b) {
+    invoke(const MemberType &/*member*/,
+           const ScalarType /*alpha*/,
+           const AViewType &/*A*/,
+           const bViewType &/*b*/) {
       assert(false && "Error: encounter dummy impl");
       return 0;
     }
@@ -74,10 +74,10 @@ namespace KokkosBatched {
              typename bViewType>
     KOKKOS_INLINE_FUNCTION
     static int
-    invoke(const MemberType &member,
-           const ScalarType alpha,
-           const AViewType &A,
-           const bViewType &b) {
+    invoke(const MemberType &/*member*/,
+           const ScalarType /*alpha*/,
+           const AViewType &/*A*/,
+           const bViewType &/*b*/) {
       assert(false && "Error: encounter dummy impl");
       return 0;
     }

--- a/src/batched/KokkosBatched_Trsv_TeamVector_Internal.hpp
+++ b/src/batched/KokkosBatched_Trsv_TeamVector_Internal.hpp
@@ -26,12 +26,12 @@ namespace KokkosBatched {
              typename ValueType>
     KOKKOS_INLINE_FUNCTION
     static int
-    invoke(const MemberType &member,
-           const bool use_unit_diag,
-           const int m,
-           const ScalarType alpha,
-           const ValueType *__restrict__ A, const int as0, const int as1,
-           /**/  ValueType *__restrict__ b, const int bs0) {
+    invoke(const MemberType &/*member*/,
+           const bool /*use_unit_diag*/,
+           const int /*m*/,
+           const ScalarType /*alpha*/,
+           const ValueType *__restrict__ /*A*/, const int /*as0*/, const int /*as1*/,
+           /**/  ValueType *__restrict__ /*b*/, const int /*bs0*/) {
       assert(false && "Error: encounter dummy impl");
       return 0;
     }
@@ -97,12 +97,12 @@ namespace KokkosBatched {
              typename ValueType>
     KOKKOS_INLINE_FUNCTION
     static int
-    invoke(const MemberType &member,
-           const bool use_unit_diag,
-           const int m,
-           const ScalarType alpha,
-           const ValueType *__restrict__ A, const int as0, const int as1,
-           /**/  ValueType *__restrict__ b, const int bs0) {
+    invoke(const MemberType &/*member*/,
+           const bool /*use_unit_diag*/,
+           const int /*m*/,
+           const ScalarType /*alpha*/,
+           const ValueType *__restrict__ /*A*/, const int /*as0*/, const int /*as1*/,
+           /**/  ValueType *__restrict__ /*b*/, const int /*bs0*/) {
       assert(false && "Error: encounter dummy impl");
       return 0;
     }

--- a/src/batched/KokkosBatched_Trsv_Team_Impl.hpp
+++ b/src/batched/KokkosBatched_Trsv_Team_Impl.hpp
@@ -97,7 +97,7 @@ namespace KokkosBatched {
              typename bViewType>
     KOKKOS_INLINE_FUNCTION
     static int
-    invoke(const MemberType &member,
+    invoke(const MemberType &/*member*/,
            const ScalarType alpha,
            const AViewType &A,
            const bViewType &b) {

--- a/src/batched/KokkosBatched_Trsv_Team_Internal.hpp
+++ b/src/batched/KokkosBatched_Trsv_Team_Internal.hpp
@@ -29,12 +29,12 @@ namespace KokkosBatched {
              typename ValueType>
     KOKKOS_INLINE_FUNCTION
     static int
-    invoke(const MemberType &member,
-           const bool use_unit_diag,
-           const int m,
-           const ScalarType alpha,
-           const ValueType *__restrict__ A, const int as0, const int as1,
-           /**/  ValueType *__restrict__ b, const int bs0) {
+    invoke(const MemberType &/*member*/,
+           const bool /*use_unit_diag*/,
+           const int /*m*/,
+           const ScalarType /*alpha*/,
+           const ValueType *__restrict__ /*A*/, const int /*as0*/, const int /*as1*/,
+           /**/  ValueType *__restrict__ /*b*/, const int /*bs0*/) {
       assert(false && "Error: encounter dummy impl");
       return 0;
     }
@@ -160,12 +160,12 @@ namespace KokkosBatched {
              typename ValueType>
     KOKKOS_INLINE_FUNCTION
     static int
-    invoke(const MemberType &member,
-           const bool use_unit_diag,
-           const int m,
-           const ScalarType alpha,
-           const ValueType *__restrict__ A, const int as0, const int as1,
-           /**/  ValueType *__restrict__ b, const int bs0) {
+    invoke(const MemberType &/*member*/,
+           const bool /*use_unit_diag*/,
+           const int /*m*/,
+           const ScalarType /*alpha*/,
+           const ValueType *__restrict__ /*A*/, const int /*as0*/, const int /*as1*/,
+           /**/  ValueType *__restrict__ /*b*/, const int /*bs0*/) {
       assert(false && "Error: encounter dummy impl");
       return 0;
     }

--- a/src/batched/KokkosBatched_Trtri_Serial_Internal.hpp
+++ b/src/batched/KokkosBatched_Trtri_Serial_Internal.hpp
@@ -76,7 +76,7 @@ namespace KokkosBatched {
   int
   SerialTrtriInternalLower<Algo::Trtri::Unblocked>::
   invoke(const bool use_unit_diag,
-         const int am, const int an,
+         const int am, const int /*an*/,
          ValueType *__restrict__ A, const int as0, const int as1) {
     ValueType one(1.0), zero(0.0), A_ii;
     if (!use_unit_diag) {
@@ -131,7 +131,7 @@ namespace KokkosBatched {
   int
   SerialTrtriInternalUpper<Algo::Trtri::Unblocked>::
   invoke(const bool use_unit_diag,
-         const int am, const int an,
+         const int am, const int /*an*/,
          ValueType *__restrict__ A, const int as0, const int as1) {
     ValueType one(1.0), zero(0.0), A_ii;
 

--- a/src/batched/KokkosBatched_Util.hpp
+++ b/src/batched/KokkosBatched_Util.hpp
@@ -441,7 +441,7 @@ namespace KokkosBatched {
       : as1(arg_as1), AL(NULL), AR(NULL) {}
 
     KOKKOS_INLINE_FUNCTION
-    void partWithAL(ValueType *A, const int nA, const int nAL) {
+    void partWithAL(ValueType *A, const int /* nA */, const int nAL) {
       AL = A; AR = AL+nAL*as1;
     }
 
@@ -496,7 +496,7 @@ namespace KokkosBatched {
       : as0(arg_as0), AT(NULL), AB(NULL) {}
 
     KOKKOS_INLINE_FUNCTION
-    void partWithAT(ValueType *A, const int mA, const int mAT) {
+    void partWithAT(ValueType *A, const int /* mA */, const int mAT) {
       AT = A;
       AB = AT+mAT*as0;
     }
@@ -564,7 +564,7 @@ namespace KokkosBatched {
 
     KOKKOS_INLINE_FUNCTION
     void partWithATL(ValueType *A, 
-                     const int mA, const int nA, 
+                     const int /* mA */, const int /* nA */, 
                      const int mATL, const int nATL) {
       ATL = A;            ATR = ATL+nATL*as1; 
       ABL = ATL+mATL*as0; ABR = ABL+nATL*as1;

--- a/src/batched/KokkosBatched_Vector_SIMD_View.hpp
+++ b/src/batched/KokkosBatched_Vector_SIMD_View.hpp
@@ -72,7 +72,7 @@ namespace KokkosBatched {
     template< typename I0 , class ... Args >
     KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<Kokkos::Impl::are_integral<I0,Args...>::value && 1 == ViewType::rank, reference_type >::type
-      operator()( const I0 & i0 , Args ... args ) const {
+    operator()( const I0 & i0 , Args ... /*args*/ ) const {
       return _a(i0/vector_length)[i0%vector_length];
     }
       
@@ -80,7 +80,7 @@ namespace KokkosBatched {
     template< typename I0 , typename I1 , class ... Args >
     KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<Kokkos::Impl::are_integral<I0,I1,Args...>::value && 2 == ViewType::rank, reference_type >::type
-      operator()( const I0 & i0 , const I1 & i1 , Args ... args ) const {
+    operator()( const I0 & i0 , const I1 & i1 , Args ... /*args*/ ) const {
       switch (PackDim::value) {
       case 0: return _a(i0/vector_length,i1)[i0%vector_length];
       case 1: break;
@@ -93,7 +93,7 @@ namespace KokkosBatched {
     template< typename I0 , typename I1 , typename I2 , class ... Args >
     KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<Kokkos::Impl::are_integral<I0,I1,I2,Args...>::value && 3 == ViewType::rank, reference_type >::type
-      operator()( const I0 & i0 , const I1 & i1 , const I2 & i2 , Args ... args ) const {
+    operator()( const I0 & i0 , const I1 & i1 , const I2 & i2 , Args ... /*args*/ ) const {
       switch (PackDim::value) {
       case 0: return _a(i0/vector_length,i1,i2)[i0%vector_length];
       case 1: return _a(i0,i1/vector_length,i2)[i1%vector_length];
@@ -107,7 +107,7 @@ namespace KokkosBatched {
     template< typename I0 , typename I1 , typename I2 , typename I3 , class ... Args >
     KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<Kokkos::Impl::are_integral<I0,I1,I2,I3,Args...>::value && 4 == ViewType::rank, reference_type >::type
-      operator()( const I0 & i0 , const I1 & i1 , const I2 & i2 , const I3 & i3 , Args ... args ) const {
+    operator()( const I0 & i0 , const I1 & i1 , const I2 & i2 , const I3 & i3 , Args ... /*args*/ ) const {
       switch (PackDim::value) {
       case 0: return _a(i0/vector_length,i1,i2,i3)[i0%vector_length];
       case 1: return _a(i0,i1/vector_length,i2,i3)[i1%vector_length];
@@ -122,7 +122,7 @@ namespace KokkosBatched {
     template< typename I0 , typename I1 , typename I2 , typename I3 , typename I4 , class ... Args >
     KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<Kokkos::Impl::are_integral<I0,I1,I2,I3,I4,Args...>::value && 5 == ViewType::rank, reference_type >::type
-      operator()( const I0 & i0 , const I1 & i1 , const I2 & i2 , const I3 & i3 , const I4 & i4 , Args ... args ) const {
+    operator()( const I0 & i0 , const I1 & i1 , const I2 & i2 , const I3 & i3 , const I4 & i4 , Args ... /*args*/ ) const {
       switch (PackDim::value) {
       case 0: return _a(i0/vector_length,i1,i2,i3,i4)[i0%vector_length];
       case 1: return _a(i0,i1/vector_length,i2,i3,i4)[i1%vector_length];
@@ -138,7 +138,7 @@ namespace KokkosBatched {
     template< typename I0 , typename I1 , typename I2 , typename I3 , typename I4 , typename I5 , class ... Args >
     KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<Kokkos::Impl::are_integral<I0,I1,I2,I3,I4,I5,Args...>::value && 6 == ViewType::rank, reference_type >::type
-      operator()( const I0 & i0 , const I1 & i1 , const I2 & i2 , const I3 & i3 , const I4 & i4 , const I5 & i5 , Args ... args ) const {
+    operator()( const I0 & i0 , const I1 & i1 , const I2 & i2 , const I3 & i3 , const I4 & i4 , const I5 & i5 , Args ... /*args*/ ) const {
       switch (PackDim::value) {
       case 0: return _a(i0/vector_length,i1,i2,i3,i4,i5)[i0%vector_length];
       case 1: return _a(i0,i1/vector_length,i2,i3,i4,i5)[i1%vector_length];
@@ -155,7 +155,7 @@ namespace KokkosBatched {
     template< typename I0 , typename I1 , typename I2 , typename I3 , typename I4 , typename I5 , typename I6 , class ... Args >
     KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<Kokkos::Impl::are_integral<I0,I1,I2,I3,I4,I5,I6,Args...>::value && 7 == ViewType::rank, reference_type >::type
-      operator()( const I0 & i0 , const I1 & i1 , const I2 & i2 , const I3 & i3 , const I4 & i4 , const I5 & i5 , const I6 & i6 , Args ... args ) const {
+    operator()( const I0 & i0 , const I1 & i1 , const I2 & i2 , const I3 & i3 , const I4 & i4 , const I5 & i5 , const I6 & i6 , Args ... /*args*/ ) const {
       switch (PackDim::value) {
       case 0: return _a(i0/vector_length,i1,i2,i3,i4,i5,i6)[i0%vector_length];
       case 1: return _a(i0,i1/vector_length,i2,i3,i4,i5,i6)[i1%vector_length];
@@ -173,7 +173,7 @@ namespace KokkosBatched {
     template< typename I0 , typename I1 , typename I2 , typename I3 , typename I4 , typename I5 , typename I6 , typename I7 , class ... Args >
     KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<Kokkos::Impl::are_integral<I0,I1,I2,I3,I4,I5,I6,I7,Args...>::value && 8 == ViewType::rank, reference_type >::type
-      operator()( const I0 & i0 , const I1 & i1 , const I2 & i2 , const I3 & i3 , const I4 & i4 , const I5 & i5 , const I6 & i6 , const I7 & i7 , Args ... args ) const {
+    operator()( const I0 & i0 , const I1 & i1 , const I2 & i2 , const I3 & i3 , const I4 & i4 , const I5 & i5 , const I6 & i6 , const I7 & i7 , Args ... /*args*/ ) const {
       switch (PackDim::value) {
       case 0: return _a(i0/vector_length,i1,i2,i3,i4,i5,i6,i7)[i0%vector_length];
       case 1: return _a(i0,i1/vector_length,i2,i3,i4,i5,i6,i7)[i1%vector_length];

--- a/src/blas/KokkosBlas3_gemm.hpp
+++ b/src/blas/KokkosBlas3_gemm.hpp
@@ -100,13 +100,13 @@ namespace Impl {
            class CViewType>
   bool
   gemv_based_gemm
-       (const char transA[],
-        const char transB[],
-        typename AViewType::const_value_type& alpha,
-        const AViewType& A,
-        const BViewType& B,
-        typename CViewType::const_value_type& beta,
-        const CViewType& C,
+       (const char /*transA*/[],
+        const char /*transB*/[],
+        typename AViewType::const_value_type& /*alpha*/,
+        const AViewType& /*A*/,
+        const BViewType& /*B*/,
+        typename CViewType::const_value_type& /*beta*/,
+        const CViewType& /*C*/,
         typename std::enable_if<
           std::is_same<typename BViewType::array_layout, Kokkos::LayoutStride>::value ||
           std::is_same<typename CViewType::array_layout, Kokkos::LayoutStride>::value>::type* = nullptr)

--- a/src/blas/impl/KokkosBlas1_axpby_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_axpby_spec.hpp
@@ -151,7 +151,7 @@ struct Axpby {
 
 template<class AV, class XMV, class BV, class YMV>
 struct Axpby<AV,XMV,BV,YMV,0,true,true> {
-  static void axpby (const AV& av, const XMV& X, const BV& bv, const YMV& Y) {
+  static void axpby (const AV& /* av */, const XMV& /* X */, const BV& /* bv */, const YMV& /* Y */) {
     static_assert(YMV::Rank==0,"Oh My God");
   }
 };

--- a/src/blas/impl/KokkosBlas3_trmm_impl.hpp
+++ b/src/blas/impl/KokkosBlas3_trmm_impl.hpp
@@ -68,7 +68,7 @@ namespace KokkosBlas {
     void SerialTrmm_Invoke (const char side[],
                       const char uplo[],
                       const char trans[],
-                      const char diag[],
+		      const char /*diag*/[],
                       typename BViewType::const_value_type& alpha,
                       const AViewType& A,
                       const BViewType& B)

--- a/src/blas/impl/KokkosBlas_gesv_spec.hpp
+++ b/src/blas/impl/KokkosBlas_gesv_spec.hpp
@@ -113,9 +113,9 @@ template<class AMatrix,
          class IPIVV>
 struct GESV<AMatrix, BXMV, IPIVV, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>{
   static void
-  gesv (const AMatrix& A,
-        const BXMV& B,
-        const IPIVV& IPIV)
+  gesv (const AMatrix& /* A */,
+        const BXMV& /* B */,
+        const IPIVV& /* IPIV */)
   {
    //NOTE: Might add the implementation of KokkosBlas::gesv later
    throw std::runtime_error("No fallback implementation of GESV (general LU factorization & solve) exists. Enable BLAS and/or MAGMA TPL.");

--- a/src/common/KokkosKernels_ExecSpaceUtils.hpp
+++ b/src/common/KokkosKernels_ExecSpaceUtils.hpp
@@ -140,7 +140,7 @@ kk_is_gpu_exec_space<Kokkos::Experimental::SYCL>() {
 //Host function to determine free and total device memory.
 //Will throw if execution space doesn't support this.
 template <typename MemorySpace>
-inline void kk_get_free_total_memory(size_t& free_mem, size_t& total_mem)
+inline void kk_get_free_total_memory(size_t& /* free_mem */, size_t& /* total_mem */)
 {
   std::ostringstream oss;
   oss << "Error: memory space " << MemorySpace::name() << " does not support querying free/total memory.";

--- a/src/common/KokkosKernels_HashmapAccumulator.hpp
+++ b/src/common/KokkosKernels_HashmapAccumulator.hpp
@@ -259,9 +259,9 @@ struct HashmapAccumulator
       key_type key,
       value_type value,
       value_type *values2,
-      size_type *used_size_,
-      size_type *used_hash_size,
-      size_type *used_hashes)
+      size_type */*used_size_*/,
+      size_type */*used_hash_size*/,
+      size_type */*used_hashes*/)
   {
     size_type hash, i;
 

--- a/src/common/KokkosKernels_IOUtils.hpp
+++ b/src/common/KokkosKernels_IOUtils.hpp
@@ -126,8 +126,8 @@ void kk_sparseMatrix_generate_lower_upper_triangle(
     OrdinalType nrows,
     OrdinalType ncols,
     SizeType &nnz,
-    OrdinalType row_size_variance,
-    OrdinalType bandwidth,
+    OrdinalType /*row_size_variance*/,
+    OrdinalType /*bandwidth*/,
     ScalarType* &values,
     SizeType* &rowPtr,
     OrdinalType* &colInd)
@@ -396,7 +396,7 @@ crsMat_t kk_generate_sparse_matrix(
 //TODO: need to fix the size_type. All over the reading inputs are lno_t.
 
 template <typename stype>
-void md_malloc(stype **arr, size_t n, std::string alloc_str = ""){
+void md_malloc(stype **arr, size_t n, std::string /*alloc_str*/ = ""){
   *arr = new stype[n];
   if (*arr == NULL){
     throw std::runtime_error ("Memory Allocation Problem\n");
@@ -718,7 +718,7 @@ void write_graph_crs(lno_t nv, size_type ne,const size_type *xadj,const  lno_t *
 }
 
 template <typename lno_t, typename size_type, typename scalar_t>
-void write_graph_ligra(lno_t nv, size_type ne,const size_type *xadj,const  lno_t *adj,const  scalar_t *ew,const  char *filename){
+void write_graph_ligra(lno_t nv, size_type ne,const size_type *xadj,const  lno_t *adj,const  scalar_t */*ew*/,const  char *filename){
 
   std::ofstream ff (filename);
   ff << "AdjacencyGraph" << std::endl;

--- a/src/common/KokkosKernels_SparseUtils.hpp
+++ b/src/common/KokkosKernels_SparseUtils.hpp
@@ -843,7 +843,7 @@ template <typename in_row_view_t,
           typename MyExecSpace>
 inline size_t kk_is_d1_coloring_valid(
     typename in_nnz_view_t::non_const_value_type num_rows,
-    typename in_nnz_view_t::non_const_value_type num_cols,
+    typename in_nnz_view_t::non_const_value_type /*num_cols*/,
     in_row_view_t xadj,
     in_nnz_view_t adj,
     in_color_view_t v_colors
@@ -1438,21 +1438,29 @@ void kk_sort_by_row_size_parallel(
         });
       }
 }
-#endif 
+#endif
+
+#ifdef KOKKOSKERNELS_HAVE_PARALLEL_GNUSORT
 template <typename size_type, typename lno_t, typename ExecutionSpace>
 void kk_sort_by_row_size(
     const lno_t nv,
     const size_type *in_xadj,
     lno_t *new_indices, int sort_decreasing_order = 1, int num_threads=64){
 
-#ifdef KOKKOSKERNELS_HAVE_PARALLEL_GNUSORT
   std::cout << "Parallel Sort" << std::endl;
   kk_sort_by_row_size_parallel<size_type, lno_t, ExecutionSpace>(nv, in_xadj, new_indices, sort_decreasing_order, num_threads); 
+}
 #else
+template <typename size_type, typename lno_t, typename ExecutionSpace>
+void kk_sort_by_row_size(
+    const lno_t nv,
+    const size_type *in_xadj,
+    lno_t *new_indices, int sort_decreasing_order = 1, int /*num_threads*/=64){
+
   std::cout << "Sequential Sort" << std::endl;
   kk_sort_by_row_size_sequential(nv, in_xadj, new_indices, sort_decreasing_order);
-#endif
 }
+#endif
 
 template <typename size_type, typename lno_t, typename ExecutionSpace, typename scalar_t = double>
 void kk_get_lower_triangle_fill_parallel(
@@ -1717,8 +1725,8 @@ crstmat_t kk_get_lower_crs_matrix(crstmat_t in_crs_matrix,
 template <typename graph_t>
 graph_t kk_get_lower_crs_graph(graph_t in_crs_matrix,
     typename graph_t::data_type *new_indices = NULL,
-    bool use_dynamic_scheduling = false,
-    bool chunksize = 4){
+    bool /*use_dynamic_scheduling*/ = false,
+    bool /*chunksize*/ = 4){
 
   typedef typename graph_t::execution_space exec_space;
 
@@ -1848,8 +1856,8 @@ void kk_create_incidence_tranpose_matrix_from_lower_triangle(
     cols_view_t in_entries,
     out_row_map_view_t &out_rowmap,
     out_cols_view_t &out_entries,
-    bool use_dynamic_scheduling = false,
-    bool chunksize = 4){
+    bool /*use_dynamic_scheduling */ = false,
+    bool /*chunksize*/ = 4){
 
   //typedef typename row_map_view_t::const_type const_row_map_view_t;
   //typedef typename cols_view_t::const_type   const_cols_view_t;

--- a/src/graph/impl/KokkosGraph_ExplicitCoarsening_impl.hpp
+++ b/src/graph/impl/KokkosGraph_ExplicitCoarsening_impl.hpp
@@ -182,7 +182,7 @@ struct ExplicitGraphCoarsening
         });
     }
 
-    size_t team_shmem_size(int teamSize) const
+    size_t team_shmem_size(int /*teamSize*/) const
     {
       return tableSize() * sizeof(int);
     }

--- a/src/sparse/KokkosSparse_BlockCrsMatrix.hpp
+++ b/src/sparse/KokkosSparse_BlockCrsMatrix.hpp
@@ -208,7 +208,7 @@ public:
   /// \param idx_to_match [in] local block idx within block-row
   /// \param is_sorted [in] defaulted to false; no usage at this time
   KOKKOS_INLINE_FUNCTION
-  ordinal_type findRelBlockOffset ( const ordinal_type idx_to_match, bool is_sorted = false ) const {
+  ordinal_type findRelBlockOffset ( const ordinal_type idx_to_match, bool /*is_sorted*/ = false ) const {
     ordinal_type offset = Kokkos::Details::ArithTraits< ordinal_type >::max();
     for ( ordinal_type blk_offset = 0; blk_offset < length; ++blk_offset ) {
       ordinal_type idx = colidx_[blk_offset];
@@ -358,7 +358,7 @@ public:
   /// \param idx_to_match [in] local block idx within block-row
   /// \param is_sorted [in] defaulted to false; no usage at this time
   KOKKOS_INLINE_FUNCTION
-  ordinal_type findRelBlockOffset ( const ordinal_type &idx_to_match, bool is_sorted = false ) const {
+  ordinal_type findRelBlockOffset ( const ordinal_type &idx_to_match, bool /*is_sorted*/ = false ) const {
     typedef typename std::remove_cv<ordinal_type>::type non_const_ordinal_type;
     non_const_ordinal_type offset = Kokkos::Details::ArithTraits< non_const_ordinal_type >::max();
     for ( non_const_ordinal_type blk_offset = 0; blk_offset < length; ++blk_offset ) {
@@ -549,10 +549,10 @@ public:
   /// \param rows [in/out] The row map (containing the offsets to the
   ///   data in each row).
   /// \param cols [in/out] The column indices.
-  BlockCrsMatrix (const std::string& label,
+  BlockCrsMatrix (const std::string& /*label*/,
                   const OrdinalType nrows,
                   const OrdinalType ncols,
-                  const size_type annz,
+                  const size_type /*annz*/,
                   const values_type& vals,
                   const row_map_type& rows,
                   const index_type& cols,
@@ -595,7 +595,7 @@ public:
   /// \param rows [in/out] The row map (containing the offsets to the
   ///   data in each row).
   /// \param cols [in/out] The column indices.
-  BlockCrsMatrix (const std::string& label,
+  BlockCrsMatrix (const std::string& /*label*/,
                   const OrdinalType& ncols,
                   const values_type& vals,
                   const staticcrsgraph_type& graph_,
@@ -905,7 +905,7 @@ private:
 template< typename ScalarType , typename OrdinalType, class Device, class MemoryTraits, typename SizeType >
 void
 BlockCrsMatrix<ScalarType , OrdinalType, Device, MemoryTraits, SizeType >::
-ctor_impl (const std::string &label,
+ctor_impl (const std::string &/*label*/,
            const OrdinalType nrows,
            const OrdinalType ncols,
            const size_type annz,

--- a/src/sparse/KokkosSparse_CrsMatrix.hpp
+++ b/src/sparse/KokkosSparse_CrsMatrix.hpp
@@ -106,7 +106,7 @@ inline int RowsPerThread<Kokkos::Cuda>(const int NNZPerRow) {
 #endif
 #ifdef KOKKOS_ENABLE_HIP
 template<>
-inline int RowsPerThread<Kokkos::Experimental::HIP>(const int NNZPerRow) {
+inline int RowsPerThread<Kokkos::Experimental::HIP>(const int /*NNZPerRow*/) {
   return 1;
 }
 #endif
@@ -546,7 +546,7 @@ public:
   ///   must have length \c nrows+1.
   /// \param cols [in] The column indices. \c cols[k] is the column
   ///   index of entry k, with a corresponding value of \c val[k] .
-  CrsMatrix (const std::string &label,
+  CrsMatrix (const std::string &/*label*/,
              OrdinalType nrows,
              OrdinalType ncols,
              size_type annz,

--- a/src/sparse/KokkosSparse_spmv.hpp
+++ b/src/sparse/KokkosSparse_spmv.hpp
@@ -232,6 +232,7 @@ struct SPMV2D1D {
 };
 
 
+#if defined (KOKKOSKERNELS_INST_LAYOUTSTRIDE) || !defined(KOKKOSKERNELS_ETI_ONLY)
 template<class AlphaType, class AMatrix, class XVector, class BetaType, class YVector>
 struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector, Kokkos::LayoutStride>{
   static bool spmv2d1d (const char mode[],
@@ -241,15 +242,25 @@ struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector, Kokkos::LayoutSt
         const BetaType& beta,
         const YVector& y)
   {
-#if defined (KOKKOSKERNELS_INST_LAYOUTSTRIDE) || !defined(KOKKOSKERNELS_ETI_ONLY)
     spmv (mode, alpha, A, x, beta, y);
     return true;
-#else
-    return false;
-#endif
   }
+#else
+template<class AlphaType, class AMatrix, class XVector, class BetaType, class YVector>
+struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector, Kokkos::LayoutStride>{
+  static bool spmv2d1d (const char /*mode*/[],
+	const AlphaType& /*alpha*/,
+	const AMatrix& /*A*/,
+        const XVector& /*x*/,
+        const BetaType& /*beta*/,
+        const YVector& /*y*/)
+  {
+    return false;
+  }
+#endif
 };
 
+#if defined (KOKKOSKERNELS_INST_LAYOUTLEFT) || !defined(KOKKOSKERNELS_ETI_ONLY)
 template<class AlphaType, class AMatrix, class XVector, class BetaType, class YVector>
 struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector, Kokkos::LayoutLeft>{
   static bool spmv2d1d (const char mode[],
@@ -259,16 +270,26 @@ struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector, Kokkos::LayoutLe
         const BetaType& beta,
         const YVector& y)
   {
-#if defined (KOKKOSKERNELS_INST_LAYOUTLEFT) || !defined(KOKKOSKERNELS_ETI_ONLY)
     spmv (mode, alpha, A, x, beta, y);
     return true;
-#else
-    return false;
-#endif
   }
+#else
+template<class AlphaType, class AMatrix, class XVector, class BetaType, class YVector>
+struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector, Kokkos::LayoutLeft>{
+  static bool spmv2d1d (const char /*mode*/[],
+        const AlphaType& /*alpha*/,
+        const AMatrix& /*A*/,
+        const XVector& /*x*/,
+        const BetaType& /*beta*/,
+        const YVector& /*y*/)
+  {
+    return false;
+  }
+#endif
 };
 
 
+#if defined (KOKKOSKERNELS_INST_LAYOUTLEFT) || !defined(KOKKOSKERNELS_ETI_ONLY)
 template<class AlphaType, class AMatrix, class XVector, class BetaType, class YVector>
 struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector, Kokkos::LayoutRight>{
   static bool spmv2d1d (const char mode[],
@@ -278,18 +299,27 @@ struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector, Kokkos::LayoutRi
         const BetaType& beta,
         const YVector& y)
   {
-#if defined (KOKKOSKERNELS_INST_LAYOUTLEFT) || !defined(KOKKOSKERNELS_ETI_ONLY)
     spmv (mode, alpha, A, x, beta, y);
     return true;
-#else
-    return false;
-#endif
   }
+#else
+template<class AlphaType, class AMatrix, class XVector, class BetaType, class YVector>
+struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector, Kokkos::LayoutRight>{
+  static bool spmv2d1d (const char /*mode*/[],
+        const AlphaType& /*alpha*/,
+        const AMatrix& /*A*/,
+        const XVector& /*x*/,
+        const BetaType& /*beta*/,
+        const YVector& /*y*/)
+  {
+    return false;
+  }
+#endif
 };
 
 template<class AlphaType, class AMatrix, class XVector, class BetaType, class YVector>
 void
-spmv (KokkosKernels::Experimental::Controls controls,
+spmv (KokkosKernels::Experimental::Controls /*controls*/,
       const char mode[],
       const AlphaType& alpha,
       const AMatrix& A,
@@ -557,6 +587,7 @@ void spmv(const char mode[],
     };
 
 
+#if defined (KOKKOSKERNELS_INST_LAYOUTSTRIDE) || !defined(KOKKOSKERNELS_ETI_ONLY)
     template<class AlphaType, class AMatrix, class XVector, class BetaType, class YVector>
     struct SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector, Kokkos::LayoutStride>{
       static bool spmv2d1d_struct (const char mode[],
@@ -567,15 +598,26 @@ void spmv(const char mode[],
                                    const XVector& x,
                                    const BetaType& beta,
                                    const YVector& y){
-#if defined (KOKKOSKERNELS_INST_LAYOUTSTRIDE) || !defined(KOKKOSKERNELS_ETI_ONLY)
         spmv_struct (mode, stencil_type, structure, alpha, A, x, beta, y, RANK_ONE());
         return true;
-#else
-        return false;
-#endif
       }
+#else
+    template<class AlphaType, class AMatrix, class XVector, class BetaType, class YVector>
+    struct SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector, Kokkos::LayoutStride>{
+      static bool spmv2d1d_struct (const char /*mode*/[],
+                                   const int /*stencil_type*/,
+                                   const Kokkos::View<typename AMatrix::non_const_ordinal_type*, Kokkos::HostSpace>& /*structure*/,
+                                   const AlphaType& /*alpha*/,
+                                   const AMatrix& /*A*/,
+                                   const XVector& /*x*/,
+                                   const BetaType& /*beta*/,
+                                   const YVector& /*y*/){
+        return false;
+      }
+#endif
     };
 
+#if defined (KOKKOSKERNELS_INST_LAYOUTLEFT) || !defined(KOKKOSKERNELS_ETI_ONLY)
     template<class AlphaType, class AMatrix, class XVector, class BetaType, class YVector>
     struct SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector, Kokkos::LayoutLeft>{
       static bool spmv2d1d_struct (const char mode[],
@@ -586,16 +628,27 @@ void spmv(const char mode[],
                                    const XVector& x,
                                    const BetaType& beta,
                                    const YVector& y){
-#if defined (KOKKOSKERNELS_INST_LAYOUTLEFT) || !defined(KOKKOSKERNELS_ETI_ONLY)
         spmv_struct (mode, stencil_type, structure, alpha, A, x, beta, y, RANK_ONE());
         return true;
-#else
-        return false;
-#endif
       }
+#else
+    template<class AlphaType, class AMatrix, class XVector, class BetaType, class YVector>
+    struct SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector, Kokkos::LayoutLeft>{
+      static bool spmv2d1d_struct (const char /*mode*/[],
+                                   const int /*stencil_type*/,
+                                   const Kokkos::View<typename AMatrix::non_const_ordinal_type*, Kokkos::HostSpace>& /*structure*/,
+                                   const AlphaType& /*alpha*/,
+                                   const AMatrix& /*A*/,
+                                   const XVector& /*x*/,
+                                   const BetaType& /*beta*/,
+                                   const YVector& /*y*/){
+        return false;
+      }
+#endif
     };
 
 
+#if defined (KOKKOSKERNELS_INST_LAYOUTLEFT) || !defined(KOKKOSKERNELS_ETI_ONLY)
     template<class AlphaType, class AMatrix, class XVector, class BetaType, class YVector>
     struct SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector, Kokkos::LayoutRight>{
       static bool spmv2d1d_struct (const char mode[],
@@ -606,13 +659,23 @@ void spmv(const char mode[],
                                    const XVector& x,
                                    const BetaType& beta,
                                    const YVector& y){
-#if defined (KOKKOSKERNELS_INST_LAYOUTLEFT) || !defined(KOKKOSKERNELS_ETI_ONLY)
         spmv_struct (mode, stencil_type, structure, alpha, A, x, beta, y, RANK_ONE());
         return true;
-#else
-        return false;
-#endif
       }
+#else
+    template<class AlphaType, class AMatrix, class XVector, class BetaType, class YVector>
+    struct SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector, Kokkos::LayoutRight>{
+      static bool spmv2d1d_struct (const char /*mode*/[],
+                                   const int /*stencil_type*/,
+                                   const Kokkos::View<typename AMatrix::non_const_ordinal_type*, Kokkos::HostSpace>& /*structure*/,
+                                   const AlphaType& /*alpha*/,
+                                   const AMatrix& /*A*/,
+                                   const XVector& /*x*/,
+                                   const BetaType& /*beta*/,
+				   const YVector& /*y*/){
+        return false;
+      }
+#endif
     };
 
     template<class AlphaType, class AMatrix, class XVector, class BetaType, class YVector>

--- a/src/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
@@ -811,7 +811,7 @@ namespace KokkosSparse{
           nnz_scalar_t omega = Kokkos::Details::ArithTraits<nnz_scalar_t>::one(),
           bool apply_forward = true,
           bool apply_backward = true,
-          bool update_y_vector = true)
+          bool /*update_y_vector*/ = true)
       {
         auto gsHandle = get_gs_handle();
 

--- a/src/sparse/impl/KokkosSparse_spgemm_imp_outer.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_imp_outer.hpp
@@ -896,10 +896,10 @@ void KokkosSPGEMM
   <HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_view_t_,
     b_lno_row_view_t_, b_lno_nnz_view_t_, b_scalar_nnz_view_t_>::
     KokkosSPGEMM_numeric_outer(
-    c_row_view_t &rowmapC_,
-    c_lno_nnz_view_t &entriesC_,
-    c_scalar_nnz_view_t &valuesC_,
-    KokkosKernels::Impl::ExecSpaceType my_exec_space_){
+    c_row_view_t &/*rowmapC_*/,
+    c_lno_nnz_view_t &/*entriesC_*/,
+    c_scalar_nnz_view_t &/*valuesC_*/,
+    KokkosKernels::Impl::ExecSpaceType /*my_exec_space_*/){
   throw std::runtime_error ("Cannot run outer product. ENABLE openmp and outer product to run\n");
 }
 #endif

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
@@ -2765,7 +2765,7 @@ struct KokkosSPGEMM
         int overall_num_unsuccess = 0;
 
         Kokkos::parallel_reduce( Kokkos::ThreadVectorRange(teamMember, vector_size),
-            [&] (const int threadid, int &overall_num_unsuccess_) {
+            [&] (const int /*threadid*/, int &overall_num_unsuccess_) {
           overall_num_unsuccess_ += num_unsuccess;
         }, overall_num_unsuccess);
 
@@ -2882,7 +2882,7 @@ struct KokkosSPGEMM
 
   }
 
-  size_t team_shmem_size (int team_size) const {
+  size_t team_shmem_size (int /*team_size*/) const {
     return shared_memory_size;
   }
 

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
@@ -1291,10 +1291,10 @@ struct KokkosSPGEMM
 
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const GPUTag&, const team_member_t & teamMember) const {
+  void operator()(const GPUTag&, const team_member_t & /*teamMember*/) const {
   }
 
-  size_t team_shmem_size (int team_size) const {
+  size_t team_shmem_size (int /*team_size*/) const {
     return shared_memory_size;
   }
 
@@ -1591,7 +1591,7 @@ void
     KokkosSPGEMM_numeric_triangle(
       c_row_view_t rowmapC_,
       c_lno_nnz_view_t entriesC_,
-      c_scalar_nnz_view_t valuesC_){
+      c_scalar_nnz_view_t /*valuesC_*/){
   this->KokkosSPGEMM_numeric_triangle_ai(rowmapC_, entriesC_);
 
 }
@@ -1644,7 +1644,7 @@ void
   struct dummy{
 
     KOKKOS_INLINE_FUNCTION
-    void operator ()(const nnz_lno_t &row, const nnz_lno_t &col_set_ind, const nnz_lno_t & col_set, const nnz_lno_t &threadid) const{
+    void operator ()(const nnz_lno_t &/*row*/, const nnz_lno_t &/*col_set_ind*/, const nnz_lno_t & /*col_set*/, const nnz_lno_t &/*threadid*/) const{
     }
   } dummy;
   this->triangle_count_ai(
@@ -1858,7 +1858,7 @@ void KokkosSPGEMM
 
   struct dummy{
     KOKKOS_INLINE_FUNCTION
-    void operator ()(const nnz_lno_t &row, const nnz_lno_t &col_set_ind, const nnz_lno_t & col_set, const nnz_lno_t &threadid) const{
+    void operator ()(const nnz_lno_t &/*row*/, const nnz_lno_t &/*col_set_ind*/, const nnz_lno_t & /*col_set*/, const nnz_lno_t &/*threadid*/) const{
     }
 
   } dummy;

--- a/src/sparse/impl/KokkosSparse_spiluk_numeric_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_spiluk_numeric_spec.hpp
@@ -186,7 +186,7 @@ template<class KernelHandle,
 struct SPILUK_NUMERIC<KernelHandle, ARowMapType, AEntriesType, AValuesType, LRowMapType, LEntriesType, LValuesType, URowMapType, UEntriesType, UValuesType, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>{
   static void
   spiluk_numeric (KernelHandle *handle,
-                  const typename KernelHandle::const_nnz_lno_t &fill_lev,
+                  const typename KernelHandle::const_nnz_lno_t &/*fill_lev*/,
                   const ARowMapType&  A_row_map,
                   const AEntriesType& A_entries,
                   const AValuesType&  A_values,

--- a/src/sparse/impl/KokkosSparse_spmv_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_impl.hpp
@@ -71,7 +71,7 @@ struct GetCoeffView {
 template<class IT, class IL, class ID, class IM, class IS, class DeviceType>
 struct GetCoeffView<Kokkos::View<IT*,IL,ID,IM,IS>,DeviceType> {
   typedef Kokkos::View<IT*,IL,ID,IM,IS> view_type;
-  static Kokkos::View<IT*,IL,ID,IM,IS> get_view(const Kokkos::View<IT*,IL,ID,IM,IS>& in, int size) {
+  static Kokkos::View<IT*,IL,ID,IM,IS> get_view(const Kokkos::View<IT*,IL,ID,IM,IS>& in, int /*size*/) {
     return in;
   }
 };

--- a/src/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
@@ -771,8 +771,8 @@ template<class AMatrix,
          int dobeta,
          bool conjugate>
 static void
-spmv_struct_beta_transpose (const int stencil_type,
-                            const Kokkos::View<typename AMatrix::non_const_ordinal_type*, Kokkos::HostSpace>& structure,
+spmv_struct_beta_transpose (const int /*stencil_type*/,
+                            const Kokkos::View<typename AMatrix::non_const_ordinal_type*, Kokkos::HostSpace>& /*structure*/,
                             typename YVector::const_value_type& alpha,
                             const AMatrix& A,
                             const XVector& x,

--- a/src/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
@@ -3305,7 +3305,7 @@ cudaProfilerStop();
 
 
 template < class TriSolveHandle, class RowMapType, class EntriesType, class ValuesType, class RHSType, class LHSType >
-void tri_solve_chain(TriSolveHandle & thandle, const RowMapType row_map, const EntriesType entries, const ValuesType values, const RHSType & rhs, LHSType &lhs, const bool is_lowertri_) {
+void tri_solve_chain(TriSolveHandle & thandle, const RowMapType row_map, const EntriesType entries, const ValuesType values, const RHSType & rhs, LHSType &lhs, const bool /*is_lowertri_*/) {
 
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOSPSTRSV_SOLVE_IMPL_PROFILE)
 cudaProfilerStop();

--- a/src/sparse/impl/KokkosSparse_twostage_gauss_seidel_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_twostage_gauss_seidel_impl.hpp
@@ -869,7 +869,7 @@ namespace KokkosSparse{
                   scalar_t omega = ST::one(),
                   bool apply_forward = true,
                   bool apply_backward = true,
-                  bool update_y_vector = true)
+                  bool /*update_y_vector*/ = true)
       {
         const_scalar_t one = Kokkos::Details::ArithTraits<scalar_t>::one ();
         const_scalar_t zero = Kokkos::Details::ArithTraits<scalar_t>::zero ();

--- a/test_common/KokkosKernels_Test_Structured_Matrix.hpp
+++ b/test_common/KokkosKernels_Test_Structured_Matrix.hpp
@@ -128,7 +128,7 @@ namespace Test {
     }
 
     KOKKOS_INLINE_FUNCTION
-    void operator() (const exteriorTag&, const size_type idx) const {
+    void operator() (const exteriorTag&, const size_type /*idx*/) const {
       // LeftBC
       rowmap(1) = 2;
 
@@ -476,7 +476,7 @@ namespace Test {
     }
 
     KOKKOS_INLINE_FUNCTION
-    void operator() (const cornerFDTag&, const size_type idx) const {
+    void operator() (const cornerFDTag&, const size_type /*idx*/) const {
       // Bottom-left corner
       ordinal_type rowIdx = 0;
       size_type rowOffset = cornerStencilLength;
@@ -727,7 +727,7 @@ namespace Test {
     }
 
     KOKKOS_INLINE_FUNCTION
-    void operator() (const cornerFETag&, const size_type idx) const {
+    void operator() (const cornerFETag&, const size_type /*idx*/) const {
       // Bottom-left corner
       ordinal_type rowIdx = 0;
       size_type rowOffset = cornerStencilLength;
@@ -1775,7 +1775,7 @@ namespace Test {
     }
 
     KOKKOS_INLINE_FUNCTION
-    void operator() (const cornerFDTag&, const size_type idx) const {
+    void operator() (const cornerFDTag&, const size_type /*idx*/) const {
       // Bottom corners
       ordinal_type rowIdx = 0;
       size_type rowOffset = cornerStencilLength;
@@ -3151,7 +3151,7 @@ namespace Test {
     }
 
     KOKKOS_INLINE_FUNCTION
-    void operator() (const cornerFETag&, const size_type idx) const {
+    void operator() (const cornerFETag&, const size_type /*idx*/) const {
       // Bottom corners
       ordinal_type rowIdx = 0;
       size_type rowOffset = cornerStencilLength;

--- a/unit_test/common/Test_Common_ArithTraits.hpp
+++ b/unit_test/common/Test_Common_ArithTraits.hpp
@@ -294,7 +294,7 @@ protected:
   /// this a "hook.")
   ///
   /// \return \c 1 if all tests succeeded, else \c 0.
-  int testHostImpl (std::ostream& out) const {
+  int testHostImpl (std::ostream& /*out*/) const {
     return 1; // there are no tests, so trivially, all the tests pass
   }
 

--- a/unit_test/sparse/Test_Sparse_BlockCrsMatrix.hpp
+++ b/unit_test/sparse/Test_Sparse_BlockCrsMatrix.hpp
@@ -226,7 +226,7 @@ namespace Test{ // anonymous
   {}
 
   KOKKOS_INLINE_FUNCTION
-  void operator()( const int rid ) const
+  void operator()( const int /*rid*/ ) const
   {
     // Test 1: Check member functions behave as expected
     bool check0 = true;

--- a/unit_test/sparse/Test_Sparse_findRelOffset.hpp
+++ b/unit_test/sparse/Test_Sparse_findRelOffset.hpp
@@ -70,7 +70,7 @@ namespace Test{ // (anonymous)
   // This takes the same arguments as if it were declared via the
   // TEUCHOS_UNIT_TEST macro.
   template <typename lno_t, typename DT>
-  void generalTest (bool& success, std::ostream &out)
+  void generalTest (bool& /*success*/, std::ostream &out)
   {
     using KokkosSparse::findRelOffset;
     //typedef int lno_t;
@@ -357,7 +357,7 @@ namespace Test{ // (anonymous)
   // This takes the same arguments as if it were declared via the
   // TEUCHOS_UNIT_TEST macro.
   template <typename lno_t, typename device_t>
-  void testLongArray (bool& success, std::ostream &out)
+  void testLongArray (bool& /*success*/, std::ostream &out)
   {
     using KokkosSparse::findRelOffset;
     //typedef long lno_t; // just for a change

--- a/unit_test/sparse/Test_Sparse_replaceSumInto.hpp
+++ b/unit_test/sparse/Test_Sparse_replaceSumInto.hpp
@@ -58,6 +58,9 @@ typedef Kokkos::complex<float> kokkos_complex_float;
 // mfh 21 Jun 2016: CUDA 7.5 with GCC 4.8.4 gives me funny build
 // errors if I put this functor in an anonymous namespace.  If I name
 // the namespace, it builds just fine.
+// lbv 06 May 2021: Commenting out atomic
+// it seems wrong that the atomic_ attribute is not
+// initialized using the constructor input atomic!
 namespace Test {
   template<class CrsMatrixType>
   class ModifyEvenNumberedRows {
@@ -68,7 +71,7 @@ namespace Test {
     ModifyEvenNumberedRows (const CrsMatrixType& A,
                             const bool replace,
                             const bool sorted,
-                            const bool atomic) :
+                            const bool /*atomic*/) :
       A_ (A), replace_ (replace), sorted_ (sorted)
     {}
 
@@ -159,11 +162,16 @@ namespace { // (anonymous)
     return success;
   }
 
+  // lbv 06 May 2021: it seems success it not set anywhere
+  // this feels like a problem especially since lclSuccess
+  // defined in the functor could be reduced on to generate
+  // a reasonable value for success. Or we should just get
+  // rid of success altogether.
   template<class CrsMatrixType>
   void
-  testOneCase (bool& success,
+  testOneCase (bool& /*success*/,
                //Teuchos::FancyOStream& out,
-          	   std::ostream &out,
+	       std::ostream &out,
                const CrsMatrixType& A,
                const bool replace,
                const bool sorted,

--- a/unit_test/sparse/Test_Sparse_replaceSumIntoLonger.hpp
+++ b/unit_test/sparse/Test_Sparse_replaceSumIntoLonger.hpp
@@ -73,7 +73,7 @@ namespace Test {
     ModifyEntries (const CrsMatrixType& A,
                    const bool replace,
                    const bool sorted,
-                   const bool atomic) :
+                   const bool /*atomic*/) :
       A_ (A), replace_ (replace), sorted_ (sorted)
     {}
 
@@ -204,7 +204,7 @@ namespace { // (anonymous)
 		  	  	  	  	  	  	   std::ostream &outRef,
 								   //Teuchos::FancyOStream& outRef, // see notes
                                    const CrsMatrixType& A,
-                                   const bool replace,
+                                   const bool /*replace*/,
                                    const bool /* sorted */,
                                    const bool /* atomic */,
                                    const bool debug = false)
@@ -304,9 +304,9 @@ namespace { // (anonymous)
 
   template<class CrsMatrixType, const int numEntriesToModify>
   void
-  testOneCaseImpl (bool& success,
-		  	  	   std::ostream &out,
-				   //Teuchos::FancyOStream& out,
+  testOneCaseImpl (bool& /*success*/,
+		   std::ostream &out,
+		   //Teuchos::FancyOStream& out,
                    const CrsMatrixType& A,
                    const bool replace,
                    const bool sorted,
@@ -386,8 +386,8 @@ namespace { // (anonymous)
   struct TestOneCase<CrsMatrixType, 0> {
     static void
     test (bool& /* success */,
-    	  std::ostream &out,
-		  //Teuchos::FancyOStream& /* out */,
+    	  std::ostream &/*out*/,
+	  //Teuchos::FancyOStream& /* out */,
           const CrsMatrixType& /* A */,
           const bool /* replace */,
           const bool /* sorted */,


### PR DESCRIPTION
To have Kokkos Kernels in line with Kokkos flags we should be able to build without unused-parameter warnings.
I am somewhat surprised that these flags from Kokkos are not picked up by our builds?
This PR is fairly large but actually has very minor impact on the code base as it primarily comments unused function parameters... but it also reveals a few strange and worrisome patterns like not setting/checking test results.
Also I spotted a bug where an `int` is declared as a `bool`, see below:
```c++
void kk_get_lower_triangle_fill_parallel(
     const lno_t nv,
     const size_type ne,
     const size_type *in_xadj,
     const lno_t *in_adj,
     const scalar_t *in_vals,
     size_type *out_xadj,
     lno_t *out_adj,
     scalar_t *out_vals,
     const lno_t *new_indices = NULL,
     bool use_dynamic_scheduling = false,
     bool chunksize = 4,
     bool is_lower = true
     )
```

Maybe more testing on other platform should be performed with this warning turned on.
If you have any comments as to how things should be done let me know.
With these changes I can build with `-Werror -Wunused-parameter` on tulip with clang-12, I will setup a build that reproduces the auto-tester config using these flags to see if we could set these on in CI testing.