### PR TITLE
Fix -Werror=deprecated errors with c++20 standard

### DIFF
--- a/src/blas/impl/KokkosBlas2_gemv_impl.hpp
+++ b/src/blas/impl/KokkosBlas2_gemv_impl.hpp
@@ -592,7 +592,7 @@ public:
 
     // compute yj = beta*yj + alpha*val
     Kokkos::single(Kokkos::PerTeam(team),
-    [=]()
+    [&]()
     {
       y_(i) = beta_ * y_(i) + alpha_ * val;
     });

--- a/src/sparse/KokkosSparse_spadd.hpp
+++ b/src/sparse/KokkosSparse_spadd.hpp
@@ -183,7 +183,7 @@ struct SortedCountEntriesTeam {
     {
       //fall back to slow serial method
       Kokkos::single(Kokkos::PerThread(t),
-      [=]()
+      [&]()
       {
         longRowFallback(i);
       });
@@ -192,7 +192,7 @@ struct SortedCountEntriesTeam {
     if(n == 0)
     {
       Kokkos::single(Kokkos::PerThread(t),
-      [=]()
+      [&]()
       {
         Crowcounts(i) = 0;
       });
@@ -259,7 +259,7 @@ struct SortedCountEntriesTeam {
           lcount++;
       }, risingEdges);
     Kokkos::single(Kokkos::PerThread(t),
-    [=]()
+    [&]()
     {
       Crowcounts(i) = risingEdges + 1;
     });


### PR DESCRIPTION
Removes "error: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20"