### PR TITLE
Fix build and add CI coverage for LayoutLeft=OFF

### DIFF
--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -361,7 +361,7 @@ do
     --no-default-eti*)
       NO_DEFAULT_ETI=True
       ;;
-    --with-layouts*)
+    --with-spaces*)
       KOKKOSKERNELS_SPACES="${key#*=}"
       ;;
     --with-tpls*)

--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -76,6 +76,9 @@ print_help() {
   echo ""
   echo "--no-default-eti:  Do not include default ETI types for Kokkos Kernels"
   echo ""
+  echo "--with-spaces=SPACES:       Set spaces to be instantiated."
+  echo "                                Options: hostspace, cudaspace, cudauvmspace"
+  echo ""
 
   echo "ARGS: list of expressions matching compilers to test"
   echo "  supported compilers sems"
@@ -357,6 +360,9 @@ do
       ;;
     --no-default-eti*)
       NO_DEFAULT_ETI=True
+      ;;
+    --with-layouts*)
+      KOKKOSKERNELS_SPACES="${key#*=}"
       ;;
     --with-tpls*)
       KOKKOSKERNELS_ENABLE_TPLS="${key#*=}"
@@ -1158,6 +1164,10 @@ single_build_and_test() {
   if [ ! -z "$KOKKOSKERNELS_ORDINALS" ]; then
     kernels_variants="$kernels_variants ordinals=$KOKKOSKERNELS_ORDINALS"
   fi
+  if [ ! -z "$KOKKOSKERNELS_SPACES" ]; then
+      kernels_variants="$kernels_variants spaces=$KOKKOSKERNELS_SPACES"
+      KOKKOSKERNELS_SPACES="--with-spaces=$KOKKOSKERNELS_SPACES"
+  fi
 
 
   echo "  #   Load modules:" &> reload_modules.sh
@@ -1251,13 +1261,13 @@ single_build_and_test() {
 
     # KOKKOS_OPTIONS and KOKKOS_CUDA_OPTIONS are exported and detected by kokkos' generate_makefile.sh during install of kokkos; we pass them to the reproducer script instructions
     echo "  #   Use generate_makefile line below to call cmake which generates makefile for this build:" &> call_generate_makefile.sh
-    echo "        ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --with-devices=$LOCAL_KOKKOS_DEVICES $ARCH_FLAG --compiler=$(which $compiler_exe) --cxxflags=\"$cxxflags\" --cxxstandard=\"$cxx_standard\" --ldflags=\"$ldflags\" $CUDA_ENABLE_CMD $HIP_ENABLE_CMD --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --with-scalars=$kk_scalars --with-ordinals=${KOKKOSKERNELS_ORDINALS} --with-offsets=${KOKKOSKERNELS_OFFSETS} --with-layouts=${KOKKOSKERNELS_LAYOUTS} ${KOKKOSKERNELS_ENABLE_TPL_CMD} ${KOKKOSKERNELS_TPL_PATH_CMD} ${KOKKOSKERNELS_TPL_LIBS_CMD} ${KOKKOSKERNELS_EXTRA_LINKER_FLAGS_CMD} --with-options=${KOKKOS_OPTIONS} --with-cuda-options=${KOKKOS_CUDA_OPTIONS} ${KOKKOS_BOUNDS_CHECK} --no-examples $extra_args" &>> call_generate_makefile.sh
+    echo "        ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --with-devices=$LOCAL_KOKKOS_DEVICES $ARCH_FLAG --compiler=$(which $compiler_exe) --cxxflags=\"$cxxflags\" --cxxstandard=\"$cxx_standard\" --ldflags=\"$ldflags\" $CUDA_ENABLE_CMD $HIP_ENABLE_CMD --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --with-scalars=$kk_scalars --with-ordinals=${KOKKOSKERNELS_ORDINALS} --with-offsets=${KOKKOSKERNELS_OFFSETS} --with-layouts=${KOKKOSKERNELS_LAYOUTS} ${KOKKOSKERNELS_ENABLE_TPL_CMD} ${KOKKOSKERNELS_TPL_PATH_CMD} ${KOKKOSKERNELS_TPL_LIBS_CMD} ${KOKKOSKERNELS_EXTRA_LINKER_FLAGS_CMD} --with-options=${KOKKOS_OPTIONS} --with-cuda-options=${KOKKOS_CUDA_OPTIONS} ${KOKKOS_BOUNDS_CHECK} ${KOKKOSKERNELS_SPACES} --no-examples $extra_args" &>> call_generate_makefile.sh
     chmod +x call_generate_makefile.sh
 
     # script command with generic path for faster copy/paste of reproducer into issues
-    echo "  #     \$KOKKOSKERNELS_PATH/cm_generate_makefile.bash --with-devices=$LOCAL_KOKKOS_DEVICES $ARCH_FLAG --compiler=$(which $compiler_exe) --cxxflags=\"$cxxflags\" --cxxstandard=\"$cxx_standard\" --ldflags=\"$ldflags\" $CUDA_ENABLE_CMD $HIP_ENABLE_CMD --kokkos-path=\$KOKKOS_PATH --kokkoskernels-path=\$KOKKOSKERNELS_PATH --with-scalars=$kk_scalars --with-ordinals=${KOKKOSKERNELS_ORDINALS} --with-offsets=${KOKKOSKERNELS_OFFSETS} --with-layouts=${KOKKOSKERNELS_LAYOUTS} ${KOKKOSKERNELS_ENABLE_TPL_CMD} ${KOKKOSKERNELS_TPL_PATH_CMD} ${KOKKOSKERNELS_TPL_LIBS_CMD} ${KOKKOSKERNELS_EXTRA_LINKER_FLAGS_CMD} --with-options=${KOKKOS_OPTIONS} --with-cuda-options=${KOKKOS_CUDA_OPTIONS} ${KOKKOS_BOUNDS_CHECK} --no-examples $extra_args" &> call_generate_makefile_genericpath.sh
+    echo "  #     \$KOKKOSKERNELS_PATH/cm_generate_makefile.bash --with-devices=$LOCAL_KOKKOS_DEVICES $ARCH_FLAG --compiler=$(which $compiler_exe) --cxxflags=\"$cxxflags\" --cxxstandard=\"$cxx_standard\" --ldflags=\"$ldflags\" $CUDA_ENABLE_CMD $HIP_ENABLE_CMD --kokkos-path=\$KOKKOS_PATH --kokkoskernels-path=\$KOKKOSKERNELS_PATH --with-scalars=$kk_scalars --with-ordinals=${KOKKOSKERNELS_ORDINALS} --with-offsets=${KOKKOSKERNELS_OFFSETS} --with-layouts=${KOKKOSKERNELS_LAYOUTS} ${KOKKOSKERNELS_ENABLE_TPL_CMD} ${KOKKOSKERNELS_TPL_PATH_CMD} ${KOKKOSKERNELS_TPL_LIBS_CMD} ${KOKKOSKERNELS_EXTRA_LINKER_FLAGS_CMD} --with-options=${KOKKOS_OPTIONS} --with-cuda-options=${KOKKOS_CUDA_OPTIONS} ${KOKKOS_BOUNDS_CHECK} ${KOKKOSKERNELS_SPACES} --no-examples $extra_args" &> call_generate_makefile_genericpath.sh
 
-    run_cmd ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --with-devices=$LOCAL_KOKKOS_DEVICES $ARCH_FLAG --compiler=$(which $compiler_exe) --cxxflags=\"$cxxflags\" --cxxstandard=\"$cxx_standard\" --ldflags=\"$ldflags\" $CUDA_ENABLE_CMD $HIP_ENABLE_CMD --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --with-scalars=$kk_scalars --with-ordinals=${KOKKOSKERNELS_ORDINALS} --with-offsets=${KOKKOSKERNELS_OFFSETS} --with-layouts=${KOKKOSKERNELS_LAYOUTS} ${KOKKOSKERNELS_ENABLE_TPL_CMD} ${KOKKOSKERNELS_TPL_PATH_CMD} ${KOKKOSKERNELS_TPL_LIBS_CMD} ${KOKKOSKERNELS_EXTRA_LINKER_FLAGS_CMD} ${KOKKOS_BOUNDS_CHECK} --no-examples $extra_args &>> ${desc}.configure.log || { report_and_log_test_result 1 ${desc} configure && return 0; }
+    run_cmd ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --with-devices=$LOCAL_KOKKOS_DEVICES $ARCH_FLAG --compiler=$(which $compiler_exe) --cxxflags=\"$cxxflags\" --cxxstandard=\"$cxx_standard\" --ldflags=\"$ldflags\" $CUDA_ENABLE_CMD $HIP_ENABLE_CMD --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --with-scalars=$kk_scalars --with-ordinals=${KOKKOSKERNELS_ORDINALS} --with-offsets=${KOKKOSKERNELS_OFFSETS} --with-layouts=${KOKKOSKERNELS_LAYOUTS} ${KOKKOSKERNELS_ENABLE_TPL_CMD} ${KOKKOSKERNELS_TPL_PATH_CMD} ${KOKKOSKERNELS_TPL_LIBS_CMD} ${KOKKOSKERNELS_EXTRA_LINKER_FLAGS_CMD} ${KOKKOS_BOUNDS_CHECK} ${KOKKOSKERNELS_SPACES} --no-examples $extra_args &>> ${desc}.configure.log || { report_and_log_test_result 1 ${desc} configure && return 0; }
 
     local make_par_lvl=12
     if [[ "$MACHINE" = white* ]]; then

--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -74,6 +74,8 @@ print_help() {
   echo "    Valid items:"
   echo "      LayoutLeft,LayoutRight"
   echo ""
+  echo "--no-default-eti:  Do not include default ETI types for Kokkos Kernels"
+  echo ""
 
   echo "ARGS: list of expressions matching compilers to test"
   echo "  supported compilers sems"
@@ -202,6 +204,7 @@ TEST_SCRIPT=False
 TEST_SPACK=False
 SKIP_HWLOC=False
 SPOT_CHECK=False
+NO_DEFAULT_ETI=False
 
 PRINT_HELP=False
 OPT_FLAG=""
@@ -351,6 +354,9 @@ do
       ;;
     --with-layouts*)
       KOKKOSKERNELS_LAYOUTS="${key#*=}"
+      ;;
+    --no-default-eti*)
+      NO_DEFAULT_ETI=True
       ;;
     --with-tpls*)
       KOKKOSKERNELS_ENABLE_TPLS="${key#*=}"
@@ -1190,6 +1196,10 @@ single_build_and_test() {
   local ldflags="${LD_FLAGS_EXTRA}"
 
   local cxx_standard="${CXX_STANDARD}"
+
+  if [ "${NO_DEFAULT_ETI}" = "True" ]; then
+    local extra_args="$extra_args --no-default-eti"
+  fi
 
 
   echo "  Starting job $desc"

--- a/src/blas/KokkosBlas1_dot.hpp
+++ b/src/blas/KokkosBlas1_dot.hpp
@@ -213,13 +213,17 @@ dot (const RV& R, const XMV& X, const YMV& Y,
   }
 
   // Create unmanaged versions of the input Views.
+  using UnifiedXLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout;
+  using UnifiedRVLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayoutPreferring<RV, UnifiedXLayout>::array_layout;
 
   typedef Kokkos::View<
     typename Kokkos::Impl::if_c<
       RV::rank == 0,
       typename RV::non_const_value_type,
       typename RV::non_const_value_type* >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<RV>::array_layout,
+    UnifiedRVLayout,
     typename RV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV_Internal;
   typedef Kokkos::View<
@@ -227,7 +231,7 @@ dot (const RV& R, const XMV& X, const YMV& Y,
       XMV::rank == 1,
       typename XMV::const_value_type*,
       typename XMV::const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
+    UnifiedXLayout,
     typename XMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XMV_Internal;
   typedef Kokkos::View<

--- a/src/blas/KokkosBlas1_dot.hpp
+++ b/src/blas/KokkosBlas1_dot.hpp
@@ -101,11 +101,11 @@ dot (const XVector& x, const YVector& y)
   using result_type =
     typename KokkosBlas::Impl::DotAccumulatingScalar<dot_type>::type;
   using RVector_Internal = Kokkos::View<dot_type,
-    Kokkos::LayoutLeft,
+    typename XVector_Internal::array_layout,
     Kokkos::HostSpace,
     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
   using RVector_Result = Kokkos::View<result_type,
-    Kokkos::LayoutLeft,
+    typename XVector_Internal::array_layout,
     Kokkos::HostSpace,
     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 

--- a/src/blas/KokkosBlas1_iamax.hpp
+++ b/src/blas/KokkosBlas1_iamax.hpp
@@ -130,14 +130,19 @@ iamax (const RV& R, const XMV& X,
     Kokkos::Impl::throw_runtime_exception (os.str ());
   }
 
-  // Create unmanaged versions of the input Views.  RV may be rank 0 or rank 2.
+  using UnifiedXLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout;
+  using UnifiedRVLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayoutPreferring<RV, UnifiedXLayout>::array_layout;
+
+  // Create unmanaged versions of the input Views.  RV may be rank 0 or rank 1.
   // XMV may be rank 1 or rank 2.
   typedef Kokkos::View<
     typename std::conditional<
       RV::rank == 0,
       typename RV::non_const_value_type,
       typename RV::non_const_value_type* >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<RV>::array_layout,
+    UnifiedRVLayout,
     typename std::conditional<
       std::is_same<typename RV::device_type::memory_space, Kokkos::HostSpace>::value,
       Kokkos::HostSpace,
@@ -148,7 +153,7 @@ iamax (const RV& R, const XMV& X,
       XMV::rank == 1,
       typename XMV::const_value_type*,
       typename XMV::const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
+    UnifiedXLayout,
     typename XMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XMV_Internal;
 

--- a/src/blas/KokkosBlas1_iamax.hpp
+++ b/src/blas/KokkosBlas1_iamax.hpp
@@ -50,14 +50,14 @@
 
 namespace KokkosBlas {
 
-/// \brief Return the (smallest) index of the element of the maximum magnitude of the vector x. 
+/// \brief Return the (smallest) index of the element of the maximum magnitude of the vector x.
 ///
 /// \tparam XVector Type of the first vector x; a 1-D Kokkos::View.
 ///
 /// \param x [in] Input 1-D View.
 ///
 /// \return The (smallest) index of the element of the maximum magnitude; a single value.
-///         Note: Returned index is 1-based for compatibility with Fortran.    
+///         Note: Returned index is 1-based for compatibility with Fortran.
 template<class XVector>
 typename XVector::size_type iamax (const XVector& x)
 {
@@ -74,7 +74,7 @@ typename XVector::size_type iamax (const XVector& x)
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XVector_Internal;
 
   typedef Kokkos::View<index_type,
-    Kokkos::LayoutLeft,
+    typename XVector_Internal::array_layout,
     Kokkos::HostSpace,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RVector_Internal;
 
@@ -130,12 +130,12 @@ iamax (const RV& R, const XMV& X,
     Kokkos::Impl::throw_runtime_exception (os.str ());
   }
 
-  // Create unmanaged versions of the input Views.  RV may be rank 0 or rank 2. 
+  // Create unmanaged versions of the input Views.  RV may be rank 0 or rank 2.
   // XMV may be rank 1 or rank 2.
   typedef Kokkos::View<
     typename std::conditional<
-      RV::rank == 0, 
-      typename RV::non_const_value_type, 
+      RV::rank == 0,
+      typename RV::non_const_value_type,
       typename RV::non_const_value_type* >::type,
     typename KokkosKernels::Impl::GetUnifiedLayout<RV>::array_layout,
     typename std::conditional<

--- a/src/blas/KokkosBlas1_mult.hpp
+++ b/src/blas/KokkosBlas1_mult.hpp
@@ -85,26 +85,24 @@ mult (typename YMV::const_value_type& gamma,
     Kokkos::Impl::throw_runtime_exception (os.str ());
   }
 
+  using YUnifiedLayout = typename KokkosKernels::Impl::GetUnifiedLayout<YMV>::array_layout;
+  using AUnifiedLayout = typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<AV, YUnifiedLayout>::array_layout;
+  using XUnifiedLayout = typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<XMV, YUnifiedLayout>::array_layout;
+
   // Create unmanaged versions of the input Views.
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      YMV::rank == 1,
-      typename YMV::non_const_value_type*,
-      typename YMV::non_const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<YMV>::array_layout,
+    typename YMV::non_const_data_type,
+    YUnifiedLayout,
     typename YMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > YMV_Internal;
   typedef Kokkos::View<
     typename AV::const_value_type*,
-    typename KokkosKernels::Impl::GetUnifiedLayout<AV>::array_layout,
+    AUnifiedLayout,
     typename AV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > AV_Internal;
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      XMV::rank == 1,
-      typename XMV::const_value_type*,
-      typename XMV::const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
+    typename XMV::const_data_type,
+    XUnifiedLayout,
     typename XMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XMV_Internal;
 

--- a/src/blas/KokkosBlas1_nrm1.hpp
+++ b/src/blas/KokkosBlas1_nrm1.hpp
@@ -73,7 +73,7 @@ nrm1 (const XVector& x)
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XVector_Internal;
 
   typedef Kokkos::View<mag_type,
-    Kokkos::LayoutLeft,
+    typename XVector_Internal::array_layout,
     Kokkos::HostSpace,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RVector_Internal;
 

--- a/src/blas/KokkosBlas1_nrm1.hpp
+++ b/src/blas/KokkosBlas1_nrm1.hpp
@@ -129,6 +129,11 @@ nrm1 (const RV& R, const XMV& X,
     Kokkos::Impl::throw_runtime_exception (os.str ());
   }
 
+  using UnifiedXLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout;
+  using UnifiedRVLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayoutPreferring<RV, UnifiedXLayout>::array_layout;
+
   // Create unmanaged versions of the input Views.  RV and XMV may be
   // rank 1 or rank 2.
   typedef Kokkos::View<
@@ -136,7 +141,7 @@ nrm1 (const RV& R, const XMV& X,
       RV::rank == 0,
       typename RV::non_const_value_type,
       typename RV::non_const_value_type* >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<RV>::array_layout,
+    UnifiedRVLayout,
     typename RV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV_Internal;
   typedef Kokkos::View<
@@ -144,7 +149,7 @@ nrm1 (const RV& R, const XMV& X,
       XMV::rank == 1,
       typename XMV::const_value_type*,
       typename XMV::const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
+    UnifiedXLayout,
     typename XMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XMV_Internal;
 

--- a/src/blas/KokkosBlas1_nrm2.hpp
+++ b/src/blas/KokkosBlas1_nrm2.hpp
@@ -73,7 +73,7 @@ nrm2 (const XVector& x)
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XVector_Internal;
 
   typedef Kokkos::View<mag_type,
-    Kokkos::LayoutLeft,
+    typename XVector_Internal::array_layout,
     Kokkos::HostSpace,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RVector_Internal;
 

--- a/src/blas/KokkosBlas1_nrm2.hpp
+++ b/src/blas/KokkosBlas1_nrm2.hpp
@@ -64,7 +64,7 @@ nrm2 (const XVector& x)
   static_assert (Kokkos::Impl::is_view<XVector>::value,
                  "KokkosBlas::nrm2: XVector must be a Kokkos::View.");
   static_assert (XVector::rank == 1, "KokkosBlas::nrm2: "
-                 "Both Vector inputs must have rank 1.");
+                 "XVector must have rank 1.");
   typedef typename Kokkos::Details::InnerProductSpaceTraits<typename XVector::non_const_value_type>::mag_type mag_type;
 
   typedef Kokkos::View<typename XVector::const_value_type*,
@@ -129,22 +129,21 @@ nrm2 (const RV& R, const XMV& X,
     Kokkos::Impl::throw_runtime_exception (os.str ());
   }
 
+  using UnifiedXLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout;
+  using UnifiedRVLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayoutPreferring<RV, UnifiedXLayout>::array_layout;
+
   // Create unmanaged versions of the input Views.  RV and XMV may be
   // rank 1 or rank 2.
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      RV::rank == 0,
-      typename RV::non_const_value_type,
-      typename RV::non_const_value_type* >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<RV>::array_layout,
+    typename RV::non_const_data_type,
+    UnifiedRVLayout,
     typename RV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV_Internal;
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      XMV::rank == 1,
-      typename XMV::const_value_type*,
-      typename XMV::const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
+    typename XMV::const_data_type,
+    UnifiedXLayout,
     typename XMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XMV_Internal;
 

--- a/src/blas/KokkosBlas1_nrm2_squared.hpp
+++ b/src/blas/KokkosBlas1_nrm2_squared.hpp
@@ -74,7 +74,7 @@ nrm2_squared (const XVector& x)
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XVector_Internal;
 
   typedef Kokkos::View<mag_type,
-    typename XVector::array_layout,
+    typename XVector_Internal::array_layout,
     Kokkos::HostSpace,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RVector_Internal;
 
@@ -129,22 +129,21 @@ nrm2_squared (const RV& R, const XMV& X,
     Kokkos::Impl::throw_runtime_exception (os.str ());
   }
 
+  using UnifiedXLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout;
+  using UnifiedRVLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayoutPreferring<RV, UnifiedXLayout>::array_layout;
+
   // Create unmanaged versions of the input Views.  RV and XMV may be
   // rank 1 or rank 2.
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      RV::rank == 0,
-      typename RV::non_const_value_type,
-      typename RV::non_const_value_type* >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<RV>::array_layout,
+    typename RV::non_const_data_type,
+    UnifiedRVLayout,
     typename RV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV_Internal;
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      XMV::rank == 1,
-      typename XMV::const_value_type*,
-      typename XMV::const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
+    typename XMV::const_data_type,
+    UnifiedXLayout,
     typename XMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XMV_Internal;
 

--- a/src/blas/KokkosBlas1_nrm2_squared.hpp
+++ b/src/blas/KokkosBlas1_nrm2_squared.hpp
@@ -74,7 +74,7 @@ nrm2_squared (const XVector& x)
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XVector_Internal;
 
   typedef Kokkos::View<mag_type,
-    Kokkos::LayoutLeft,
+    typename XVector::array_layout,
     Kokkos::HostSpace,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RVector_Internal;
 

--- a/src/blas/KokkosBlas1_nrminf.hpp
+++ b/src/blas/KokkosBlas1_nrminf.hpp
@@ -129,6 +129,11 @@ nrminf (const RV& R, const XMV& X,
     Kokkos::Impl::throw_runtime_exception (os.str ());
   }
 
+  using UnifiedXLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout;
+  using UnifiedRVLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayoutPreferring<RV, UnifiedXLayout>::array_layout;
+
   // Create unmanaged versions of the input Views.  RV and XMV may be
   // rank 1 or rank 2.
   typedef Kokkos::View<
@@ -136,7 +141,7 @@ nrminf (const RV& R, const XMV& X,
       RV::rank == 0,
       typename RV::non_const_value_type,
       typename RV::non_const_value_type* >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<RV>::array_layout,
+    UnifiedRVLayout,
     typename RV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV_Internal;
   typedef Kokkos::View<
@@ -144,7 +149,7 @@ nrminf (const RV& R, const XMV& X,
       XMV::rank == 1,
       typename XMV::const_value_type*,
       typename XMV::const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
+    UnifiedXLayout,
     typename XMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XMV_Internal;
 

--- a/src/blas/KokkosBlas1_nrminf.hpp
+++ b/src/blas/KokkosBlas1_nrminf.hpp
@@ -73,7 +73,7 @@ nrminf (const XVector& x)
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XVector_Internal;
 
   typedef Kokkos::View<mag_type,
-    Kokkos::LayoutLeft,
+    typename XVector_Internal::array_layout,
     Kokkos::HostSpace,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RVector_Internal;
 

--- a/src/blas/KokkosBlas1_scal.hpp
+++ b/src/blas/KokkosBlas1_scal.hpp
@@ -78,27 +78,26 @@ scal (const RMV& R, const AV& a, const XMV& X)
     Kokkos::Impl::throw_runtime_exception (os.str ());
   }
 
+  using UnifiedRLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayout<RMV>::array_layout;
+  using UnifiedXLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayoutPreferring<XMV, UnifiedRLayout>::array_layout;
+
   // Create unmanaged versions of the input Views.  RMV and XMV may be
   // rank 1 or rank 2.  AV may be either a rank-1 View, or a scalar
   // value.
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      RMV::rank == 1,
-      typename RMV::non_const_value_type*,
-      typename RMV::non_const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<RMV>::array_layout,
+    typename RMV::non_const_data_type,
+    UnifiedRLayout,
     typename RMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RMV_Internal;
-  typedef typename KokkosKernels::Impl::GetUnifiedScalarViewType<
-    AV, XMV, true>::type AV_Internal;
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      XMV::rank == 1,
-      typename XMV::const_value_type*,
-      typename XMV::const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
+    typename XMV::const_data_type,
+    UnifiedXLayout,
     typename XMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XMV_Internal;
+  typedef typename KokkosKernels::Impl::GetUnifiedScalarViewType<
+    AV, XMV_Internal, true>::type AV_Internal;
 
   RMV_Internal R_internal = R;
   AV_Internal  a_internal = a;

--- a/src/blas/KokkosBlas1_sum.hpp
+++ b/src/blas/KokkosBlas1_sum.hpp
@@ -122,22 +122,21 @@ sum (const RV& R, const XMV& X,
     Kokkos::Impl::throw_runtime_exception (os.str ());
   }
 
+  using UnifiedXLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout;
+  using UnifiedRVLayout = typename
+    KokkosKernels::Impl::GetUnifiedLayoutPreferring<RV, UnifiedXLayout>::array_layout;
+
   // Create unmanaged versions of the input Views.  RV and XMV may be
   // rank 1 or rank 2.
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      RV::rank == 0,
-      typename RV::non_const_value_type,
-      typename RV::non_const_value_type* >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<RV>::array_layout,
+    typename RV::non_const_data_type,
+    UnifiedRVLayout,
     typename RV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV_Internal;
   typedef Kokkos::View<
-    typename Kokkos::Impl::if_c<
-      XMV::rank == 1,
-      typename XMV::const_value_type*,
-      typename XMV::const_value_type** >::type,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
+    typename XMV::const_data_type,
+    UnifiedXLayout,
     typename XMV::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XMV_Internal;
 

--- a/src/blas/KokkosBlas1_sum.hpp
+++ b/src/blas/KokkosBlas1_sum.hpp
@@ -73,7 +73,7 @@ sum (const XVector& x)
 
   typedef Kokkos::View<
     typename XVector::non_const_value_type,
-    Kokkos::LayoutLeft,
+    typename XVector_Internal::array_layout,
     Kokkos::HostSpace,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > RVector_Internal;
 

--- a/src/blas/KokkosBlas2_gemv.hpp
+++ b/src/blas/KokkosBlas2_gemv.hpp
@@ -124,19 +124,21 @@ gemv (const char trans[],
     Kokkos::Impl::throw_runtime_exception (os.str ());
   }
 
+  using ALayout = typename AViewType::array_layout;
+
   // Minimize the number of Impl::GEMV instantiations, by
   // standardizing on particular View specializations for its template
   // parameters.
   typedef Kokkos::View<typename AViewType::const_value_type**,
-    typename AViewType::array_layout,
+    ALayout,
     typename AViewType::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > AVT;
   typedef Kokkos::View<typename XViewType::const_value_type*,
-    typename KokkosKernels::Impl::GetUnifiedLayout<XViewType>::array_layout,
+    typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<XViewType, ALayout>::array_layout,
     typename XViewType::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > XVT;
   typedef Kokkos::View<typename YViewType::non_const_value_type*,
-    typename KokkosKernels::Impl::GetUnifiedLayout<YViewType>::array_layout,
+    typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<YViewType, ALayout>::array_layout,
     typename YViewType::device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged> > YVT;
 

--- a/src/blas/impl/KokkosBlas1_axpby_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_axpby_spec.hpp
@@ -446,11 +446,11 @@ extern template struct Axpby< \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      2, false, true>; \
 extern template struct Axpby< \
-     Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,\
+     Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,\
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-     Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,\
+     Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,\
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
@@ -466,11 +466,11 @@ template struct Axpby< \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      2, false, true>; \
 template struct Axpby< \
-     Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,\
+     Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,\
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-     Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,\
+     Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,\
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \

--- a/src/blas/impl/KokkosBlas1_dot_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_dot_spec.hpp
@@ -134,8 +134,7 @@ struct dot_eti_spec_avail {
 #define KOKKOSBLAS1_DOT_MV_ETI_SPEC_AVAIL( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
     template<> \
     struct dot_eti_spec_avail< \
-        Kokkos::View<SCALAR*, typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                        Kokkos::LayoutLeft, LAYOUT>::type, \
+        Kokkos::View<SCALAR*, LAYOUT, \
                      Kokkos::Device<Kokkos::DefaultHostExecutionSpace,Kokkos::HostSpace>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -145,8 +144,7 @@ struct dot_eti_spec_avail {
         2,2> { enum : bool { value = true }; }; \
     template<> \
     struct dot_eti_spec_avail< \
-        Kokkos::View<SCALAR*, typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                        Kokkos::LayoutLeft, LAYOUT>::type, \
+        Kokkos::View<SCALAR*, LAYOUT, \
                      Kokkos::Device<Kokkos::DefaultHostExecutionSpace,Kokkos::HostSpace>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -157,8 +155,7 @@ struct dot_eti_spec_avail {
     template<> \
     struct dot_eti_spec_avail< \
         Kokkos::View<SCALAR*, \
-                     typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                            Kokkos::LayoutLeft, LAYOUT>::type, \
+                     LAYOUT, \
                      Kokkos::Device<Kokkos::DefaultHostExecutionSpace,Kokkos::HostSpace>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -441,8 +438,7 @@ template struct DotSpecialAccumulator< \
 //
 #define KOKKOSBLAS1_DOT_MV_ETI_SPEC_DECL( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
 extern template struct Dot< \
-        Kokkos::View<SCALAR*, typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                        Kokkos::LayoutLeft, LAYOUT>::type, \
+        Kokkos::View<SCALAR*, LAYOUT, \
                      Kokkos::Device<Kokkos::DefaultHostExecutionSpace,Kokkos::HostSpace>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -451,8 +447,7 @@ extern template struct Dot< \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         2,2,false,true>; \
 extern template struct Dot< \
-        Kokkos::View<SCALAR*, typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                        Kokkos::LayoutLeft, LAYOUT>::type, \
+        Kokkos::View<SCALAR*, LAYOUT, \
                      Kokkos::Device<Kokkos::DefaultHostExecutionSpace,Kokkos::HostSpace>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -461,8 +456,7 @@ extern template struct Dot< \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         2,1,false,true>; \
 extern template struct Dot< \
-        Kokkos::View<SCALAR*, typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                        Kokkos::LayoutLeft, LAYOUT>::type, \
+        Kokkos::View<SCALAR*, LAYOUT, \
                      Kokkos::Device<Kokkos::DefaultHostExecutionSpace,Kokkos::HostSpace>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -473,8 +467,7 @@ extern template struct Dot< \
 
 #define KOKKOSBLAS1_DOT_MV_ETI_SPEC_INST( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
 template struct Dot< \
-        Kokkos::View<SCALAR*, typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                        Kokkos::LayoutLeft, LAYOUT>::type, \
+        Kokkos::View<SCALAR*, LAYOUT, \
                      Kokkos::Device<Kokkos::DefaultHostExecutionSpace,Kokkos::HostSpace>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -483,8 +476,7 @@ template struct Dot< \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         2,2,false,true>; \
 template struct Dot< \
-        Kokkos::View<SCALAR*, typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                        Kokkos::LayoutLeft, LAYOUT>::type, \
+        Kokkos::View<SCALAR*, LAYOUT, \
                      Kokkos::Device<Kokkos::DefaultHostExecutionSpace,Kokkos::HostSpace>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -493,8 +485,7 @@ template struct Dot< \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         2,1,false,true>; \
 template struct Dot< \
-        Kokkos::View<SCALAR*, typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                         Kokkos::LayoutLeft, LAYOUT>::type, \
+        Kokkos::View<SCALAR*, LAYOUT, \
                      Kokkos::Device<Kokkos::DefaultHostExecutionSpace,Kokkos::HostSpace>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \

--- a/src/blas/impl/KokkosBlas1_iamax_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_iamax_spec.hpp
@@ -50,7 +50,7 @@
 #include <Kokkos_InnerProductSpaceTraits.hpp>
 
 // Include the actual functors
-#if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY 
+#if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 #include <KokkosBlas1_iamax_impl.hpp>
 #endif
 
@@ -103,8 +103,7 @@ struct iamax_eti_spec_avail {
     template<> \
     struct iamax_eti_spec_avail< \
         Kokkos::View<INDEX_TYPE*, \
-                     typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                               Kokkos::LayoutLeft, LAYOUT>::type, \
+                     LAYOUT, \
                      Kokkos::HostSpace, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -113,8 +112,7 @@ struct iamax_eti_spec_avail {
     template<> \
     struct iamax_eti_spec_avail< \
         Kokkos::View<INDEX_TYPE*, \
-                     typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                               Kokkos::LayoutLeft, LAYOUT>::type, \
+                     LAYOUT, \
                      Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -203,7 +201,7 @@ struct Iamax<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
       printf("KokkosBlas1::iamax<> non-ETI specialization for < %s , %s >\n",typeid(RV).name(),typeid(XMV).name());
     }
     #endif
-    
+
     const size_type numRows = X.extent(0);
     const size_type numCols = X.extent(1);
     if (numRows < static_cast<size_type> (INT_MAX) &&
@@ -282,8 +280,7 @@ template struct Iamax< \
 #define KOKKOSBLAS1_IAMAX_MV_ETI_SPEC_DECL_INDEX( INDEX_TYPE, SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
 extern template struct Iamax< \
          Kokkos::View<INDEX_TYPE*, \
-                      typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                Kokkos::LayoutLeft, LAYOUT>::type, \
+                      LAYOUT, \
                       Kokkos::HostSpace, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
          Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -291,8 +288,7 @@ extern template struct Iamax< \
          2, false, true>; \
 extern template struct Iamax< \
          Kokkos::View<INDEX_TYPE*, \
-                      typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                Kokkos::LayoutLeft, LAYOUT>::type, \
+                      LAYOUT, \
                       Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
          Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -312,8 +308,7 @@ extern template struct Iamax< \
 #define KOKKOSBLAS1_IAMAX_MV_ETI_SPEC_INST_INDEX( INDEX_TYPE, SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
 template struct Iamax< \
          Kokkos::View<INDEX_TYPE*, \
-                      typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                Kokkos::LayoutLeft, LAYOUT>::type, \
+                      LAYOUT, \
                       Kokkos::HostSpace, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
          Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -321,8 +316,7 @@ template struct Iamax< \
          2, false, true>; \
 template struct Iamax< \
          Kokkos::View<INDEX_TYPE*, \
-                      typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                Kokkos::LayoutLeft, LAYOUT>::type, \
+                      LAYOUT, \
                       Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
          Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \

--- a/src/blas/impl/KokkosBlas1_mult_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_mult_spec.hpp
@@ -99,8 +99,7 @@ struct mult_eti_spec_avail {
          Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
          Kokkos::View<const SCALAR*, \
-                      std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                               Kokkos::LayoutLeft, LAYOUT>::type, \
+                      LAYOUT, \
                       Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
          Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -228,7 +227,7 @@ struct Mult<YV, AV, XV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
       printf("KokkosBlas1::mult<> non-ETI specialization for < %s , %s , %s >\n",typeid(YV).name(),typeid(AV).name(),typeid(XV).name());
     }
     #endif
- 
+
     const size_type numRows = Y.extent(0);
     if (numRows < static_cast<int> (INT_MAX)) {
       V_Mult_Generic<YV, AV, XV, int> (gamma, Y, alpha, A, X);
@@ -265,8 +264,7 @@ extern template struct Mult< \
                       Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
          Kokkos::View<const SCALAR*, \
-                      std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                               Kokkos::LayoutLeft, LAYOUT>::type, \
+                      LAYOUT, \
                       Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         1, false, true>;
@@ -300,8 +298,7 @@ extern template struct Mult< \
      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      Kokkos::View<const SCALAR*, \
-                  std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                            Kokkos::LayoutLeft, LAYOUT>::type, \
+                  LAYOUT, \
                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -313,8 +310,7 @@ template struct Mult< \
      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      Kokkos::View<const SCALAR*, \
-                  std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                            Kokkos::LayoutLeft, LAYOUT>::type, \
+                  LAYOUT, \
                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \

--- a/src/blas/impl/KokkosBlas1_nrm1_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm1_spec.hpp
@@ -50,7 +50,7 @@
 #include <Kokkos_InnerProductSpaceTraits.hpp>
 
 // Include the actual functors
-#if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY 
+#if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 #include <KokkosBlas1_nrm1_impl.hpp>
 #endif
 
@@ -91,8 +91,7 @@ struct nrm1_eti_spec_avail {
     template<> \
     struct nrm1_eti_spec_avail< \
         Kokkos::View<typename Kokkos::Details::InnerProductSpaceTraits<SCALAR>::mag_type*, \
-                     typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                               Kokkos::LayoutLeft, LAYOUT>::type, \
+                     LAYOUT, \
                      Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -235,8 +234,7 @@ template struct Nrm1< \
 #define KOKKOSBLAS1_NRM1_MV_ETI_SPEC_DECL( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
 extern template struct Nrm1< \
          Kokkos::View<typename Kokkos::Details::InnerProductSpaceTraits<SCALAR>::mag_type*, \
-                      typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                Kokkos::LayoutLeft, LAYOUT>::type, \
+                      LAYOUT, \
                       Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
          Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -251,8 +249,7 @@ extern template struct Nrm1< \
 #define KOKKOSBLAS1_NRM1_MV_ETI_SPEC_INST( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
 template struct Nrm1< \
          Kokkos::View<typename Kokkos::Details::InnerProductSpaceTraits<SCALAR>::mag_type*, \
-                      typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                Kokkos::LayoutLeft, LAYOUT>::type, \
+                      LAYOUT, \
                       Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
          Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \

--- a/src/blas/impl/KokkosBlas1_nrm2_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm2_spec.hpp
@@ -50,7 +50,7 @@
 #include <Kokkos_InnerProductSpaceTraits.hpp>
 
 // Include the actual functors
-#if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY 
+#if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 #include <KokkosBlas1_nrm2_impl.hpp>
 #endif
 
@@ -91,8 +91,7 @@ struct nrm2_eti_spec_avail {
     template<> \
     struct nrm2_eti_spec_avail< \
         Kokkos::View<typename Kokkos::Details::InnerProductSpaceTraits<SCALAR>::mag_type*, \
-                     typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                               Kokkos::LayoutLeft, LAYOUT>::type, \
+                     LAYOUT, \
                      Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -235,8 +234,7 @@ template struct Nrm2< \
 #define KOKKOSBLAS1_NRM2_MV_ETI_SPEC_DECL( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
 extern template struct Nrm2< \
          Kokkos::View<typename Kokkos::Details::InnerProductSpaceTraits<SCALAR>::mag_type*, \
-                      typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                Kokkos::LayoutLeft, LAYOUT>::type, \
+                      LAYOUT, \
                       Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
          Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -251,8 +249,7 @@ extern template struct Nrm2< \
 #define KOKKOSBLAS1_NRM2_MV_ETI_SPEC_INST( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
 template struct Nrm2< \
          Kokkos::View<typename Kokkos::Details::InnerProductSpaceTraits<SCALAR>::mag_type*, \
-                      typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                Kokkos::LayoutLeft, LAYOUT>::type, \
+                      LAYOUT, \
                       Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
          Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \

--- a/src/blas/impl/KokkosBlas1_nrminf_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_nrminf_spec.hpp
@@ -50,7 +50,7 @@
 #include <Kokkos_InnerProductSpaceTraits.hpp>
 
 // Include the actual functors
-#if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY 
+#if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 #include <KokkosBlas1_nrminf_impl.hpp>
 #endif
 
@@ -91,8 +91,7 @@ struct nrminf_eti_spec_avail {
     template<> \
     struct nrminf_eti_spec_avail< \
         Kokkos::View<typename Kokkos::Details::InnerProductSpaceTraits<SCALAR>::mag_type*, \
-                     typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                               Kokkos::LayoutLeft, LAYOUT>::type, \
+                     LAYOUT, \
                      Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -235,8 +234,7 @@ template struct NrmInf< \
 #define KOKKOSBLAS1_NRMINF_MV_ETI_SPEC_DECL( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
 extern template struct NrmInf< \
          Kokkos::View<typename Kokkos::Details::InnerProductSpaceTraits<SCALAR>::mag_type*, \
-                      typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                Kokkos::LayoutLeft, LAYOUT>::type, \
+                      LAYOUT, \
                       Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
          Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -251,8 +249,7 @@ extern template struct NrmInf< \
 #define KOKKOSBLAS1_NRMINF_MV_ETI_SPEC_INST( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
 template struct NrmInf< \
          Kokkos::View<typename Kokkos::Details::InnerProductSpaceTraits<SCALAR>::mag_type*, \
-                      typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                Kokkos::LayoutLeft, LAYOUT>::type, \
+                      LAYOUT, \
                       Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
          Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \

--- a/src/blas/impl/KokkosBlas1_scal_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_scal_spec.hpp
@@ -49,7 +49,7 @@
 #include <Kokkos_ArithTraits.hpp>
 
 // Include the actual functors
-#if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY 
+#if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 #include <KokkosBlas1_scal_impl.hpp>
 #include <KokkosBlas1_scal_mv_impl.hpp>
 #endif
@@ -93,7 +93,7 @@ struct scal_eti_spec_avail {
     struct scal_eti_spec_avail< \
         Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
+        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
@@ -327,7 +327,7 @@ template struct Scal< \
 extern template struct Scal< \
         Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
+        Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
@@ -344,7 +344,7 @@ extern template struct Scal< \
 template struct Scal< \
         Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-        Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, \
+        Kokkos::View<const SCALAR*, LAYOUT, \
                      Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \

--- a/src/blas/impl/KokkosBlas1_sum_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_sum_spec.hpp
@@ -50,7 +50,7 @@
 #include <Kokkos_InnerProductSpaceTraits.hpp>
 
 // Include the actual functors
-#if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY 
+#if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 #include <KokkosBlas1_sum_impl.hpp>
 #endif
 
@@ -74,7 +74,7 @@ struct sum_eti_spec_avail {
 #define KOKKOSBLAS1_SUM_ETI_SPEC_AVAIL( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
     template<> \
     struct sum_eti_spec_avail< \
-        Kokkos::View<SCALAR, Kokkos::LayoutLeft, Kokkos::HostSpace, \
+        Kokkos::View<SCALAR, LAYOUT, Kokkos::HostSpace, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
@@ -91,8 +91,7 @@ struct sum_eti_spec_avail {
     template<> \
     struct sum_eti_spec_avail< \
         Kokkos::View<SCALAR*, \
-                     typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                               Kokkos::LayoutLeft, LAYOUT>::type, \
+                     LAYOUT, \
                      Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>, \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
         Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -205,7 +204,7 @@ struct Sum<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 //
 #define KOKKOSBLAS1_SUM_ETI_SPEC_DECL( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
 extern template struct Sum< \
-         Kokkos::View<SCALAR, Kokkos::LayoutLeft, Kokkos::HostSpace, \
+         Kokkos::View<SCALAR, LAYOUT, Kokkos::HostSpace, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
          Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
@@ -218,7 +217,7 @@ extern template struct Sum< \
 //
 #define KOKKOSBLAS1_SUM_ETI_SPEC_INST( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
 template struct Sum< \
-         Kokkos::View<SCALAR, Kokkos::LayoutLeft, Kokkos::HostSpace, \
+         Kokkos::View<SCALAR, LAYOUT, Kokkos::HostSpace, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
          Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
@@ -234,8 +233,7 @@ template struct Sum< \
 #define KOKKOSBLAS1_SUM_MV_ETI_SPEC_DECL( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
 extern template struct Sum< \
          Kokkos::View<SCALAR*, \
-                      typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                Kokkos::LayoutLeft, LAYOUT>::type, \
+                      LAYOUT, \
                       Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
          Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
@@ -250,8 +248,7 @@ extern template struct Sum< \
 #define KOKKOSBLAS1_SUM_MV_ETI_SPEC_INST( SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE ) \
 template struct Sum< \
          Kokkos::View<SCALAR*, \
-                      typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                Kokkos::LayoutLeft, LAYOUT>::type, \
+                      LAYOUT, \
                       Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
          Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \

--- a/src/blas/impl/KokkosBlas2_gemv_spec.hpp
+++ b/src/blas/impl/KokkosBlas2_gemv_spec.hpp
@@ -76,13 +76,11 @@ struct gemv_eti_spec_avail {
          Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
          Kokkos::View<const SCALAR*, \
-                      typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                             Kokkos::LayoutLeft, LAYOUT>::type, \
+                      LAYOUT, \
                       Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
          Kokkos::View<SCALAR*, \
-                      typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                             Kokkos::LayoutLeft, LAYOUT>::type, \
+                      LAYOUT, \
                       Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                       Kokkos::MemoryTraits<Kokkos::Unmanaged> > \
          > { enum : bool { value = true }; };
@@ -170,13 +168,11 @@ extern template struct GEMV< \
      Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      Kokkos::View<const SCALAR*, \
-                  typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                         Kokkos::LayoutLeft, LAYOUT>::type, \
+                  LAYOUT, \
                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      Kokkos::View<SCALAR*, \
-                  typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                         Kokkos::LayoutLeft, LAYOUT>::type, \
+                  LAYOUT, \
                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      false, true>;
@@ -186,13 +182,11 @@ template struct GEMV< \
      Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      Kokkos::View<const SCALAR*, \
-                  typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                         Kokkos::LayoutLeft, LAYOUT>::type, \
+                  LAYOUT, \
                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
      Kokkos::View<SCALAR*, \
-                  typename std::conditional<std::is_same<LAYOUT,Kokkos::LayoutRight>::value, \
-                                                         Kokkos::LayoutLeft, LAYOUT>::type, \
+                  LAYOUT, \
                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,  \
      false, true>;

--- a/src/common/KokkosKernels_Handle.hpp
+++ b/src/common/KokkosKernels_Handle.hpp
@@ -49,6 +49,7 @@
 #include "KokkosSparse_spadd_handle.hpp"
 #include "KokkosSparse_sptrsv_handle.hpp"
 #include "KokkosSparse_spiluk_handle.hpp"
+#include "KokkosKernels_default_types.hpp"
 
 #ifndef _KOKKOSKERNELHANDLE_HPP
 #define _KOKKOSKERNELHANDLE_HPP

--- a/src/common/KokkosKernels_Handle.hpp
+++ b/src/common/KokkosKernels_Handle.hpp
@@ -216,7 +216,7 @@ public:
   typedef typename size_type_persistent_work_view_t::HostMirror size_type_persistent_work_host_view_t; //Host view type
   typedef typename Kokkos::View<nnz_scalar_t *, HandleTempMemorySpace> scalar_temp_work_view_t;
   typedef typename Kokkos::View<nnz_scalar_t *, HandlePersistentMemorySpace> scalar_persistent_work_view_t;
-  typedef typename Kokkos::View<nnz_scalar_t **, Kokkos::LayoutLeft, HandlePersistentMemorySpace> scalar_persistent_work_view2d_t;
+  typedef typename Kokkos::View<nnz_scalar_t **, default_layout, HandlePersistentMemorySpace> scalar_persistent_work_view2d_t;
   typedef typename Kokkos::View<nnz_lno_t *, HandleTempMemorySpace> nnz_lno_temp_work_view_t;
   typedef typename Kokkos::View<nnz_lno_t *, HandlePersistentMemorySpace> nnz_lno_persistent_work_view_t;
   typedef typename nnz_lno_persistent_work_view_t::HostMirror nnz_lno_persistent_work_host_view_t; //Host view type
@@ -810,7 +810,7 @@ public:
       this->spilukHandle = nullptr;
     }
   }
-  
+
 };    // end class KokkosKernelsHandle
 
 }

--- a/src/impl/KokkosKernels_helpers.hpp
+++ b/src/impl/KokkosKernels_helpers.hpp
@@ -44,31 +44,55 @@
 #ifndef KOKKOSKERNELS_HELPERS_HPP_
 #define KOKKOSKERNELS_HELPERS_HPP_
 
+#include "KokkosKernels_config.h"  // KOKKOSKERNELS_INST_LAYOUTLEFT, KOKKOSKERNELS_INST_LAYOUTRIGHT
+
 namespace KokkosKernels {
 namespace Impl {
 
 // Unify Layout of a View to LayoutLeft if possible.
 // Used to reduce number of code instantiations
-
-template<class ViewType>
-struct GetUnifiedLayout {
+template <class ViewType, class UnifiedLayoutType>
+struct GetUnifiedLayoutInternal {
   typedef typename std::conditional<
-        ( (ViewType::rank == 1) &&
-          (!std::is_same<typename ViewType::array_layout,Kokkos::LayoutStride>::value) ) ||
-        ( (ViewType::rank == 0) )
-       ,Kokkos::LayoutLeft,typename ViewType::array_layout>::type array_layout;
+      ((ViewType::rank == 1) && (!std::is_same<typename ViewType::array_layout,
+                                               Kokkos::LayoutStride>::value)) ||
+          ((ViewType::rank == 0)),
+      UnifiedLayoutType, typename ViewType::array_layout>::type array_layout;
 };
 
-template<class T, class TX, bool do_const, bool isView = Kokkos::is_view<T>::value>
+// If LayoutLeft kernels are pre instantiated, try to unify layout to LayoutLeft
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
+template <class ViewType>
+struct GetUnifiedLayout {
+  using array_layout =
+      typename GetUnifiedLayoutInternal<ViewType,
+                                        Kokkos::LayoutLeft>::array_layout;
+};
+#else
+// If LayoutLeft kernels are not pre instantiated, try to unify layout to
+// LayoutRight
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
+template <class ViewType>
+struct GetUnifiedLayout {
+  using array_layout =
+      typename GetUnifiedLayoutInternal<ViewType,
+                                        Kokkos::LayoutRight>::array_layout;
+};
+#endif
+#endif
+
+template <class T, class TX, bool do_const,
+          bool isView = Kokkos::is_view<T>::value>
 struct GetUnifiedScalarViewType {
   typedef typename TX::non_const_value_type type;
 };
 
-template<class T, class TX>
-struct GetUnifiedScalarViewType<T,TX,false,true> {
-  typedef Kokkos::View<typename T::non_const_value_type*,
-                       typename KokkosKernels::Impl::GetUnifiedLayout<T>::array_layout,
-                       typename T::device_type,
+template <class T, class TX>
+struct GetUnifiedScalarViewType<T, TX, false, true> {
+  typedef Kokkos::View<
+      typename T::non_const_value_type*,
+      typename KokkosKernels::Impl::GetUnifiedLayout<T>::array_layout,
+      typename T::device_type,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> > type;
 };
 

--- a/src/sparse/KokkosSparse_CrsMatrix.hpp
+++ b/src/sparse/KokkosSparse_CrsMatrix.hpp
@@ -58,6 +58,7 @@
 #include <stdexcept>
 #include <type_traits>
 #include "KokkosSparse_findRelOffset.hpp"
+#include "KokkosKernels_default_types.hpp"
 
 namespace KokkosSparse {
 
@@ -413,9 +414,9 @@ public:
   //! Type of a host-memory mirror of the sparse matrix.
   typedef CrsMatrix<ScalarType, OrdinalType, host_mirror_space, MemoryTraits, SizeType> HostMirror;
   //! Type of the graph structure of the sparse matrix.
-  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, device_type, memory_traits, size_type> StaticCrsGraphType;
+  typedef Kokkos::StaticCrsGraph<ordinal_type, default_layout, device_type, memory_traits, size_type> StaticCrsGraphType;
   //! Type of the graph structure of the sparse matrix - consistent with Kokkos.
-  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, device_type, memory_traits, size_type> staticcrsgraph_type;
+  typedef Kokkos::StaticCrsGraph<ordinal_type, default_layout, device_type, memory_traits, size_type> staticcrsgraph_type;
   //! Type of column indices in the sparse matrix.
   typedef typename staticcrsgraph_type::entries_type index_type;
   //! Const version of the type of column indices in the sparse matrix.

--- a/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
+++ b/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
@@ -226,7 +226,7 @@ namespace KokkosSparse{
 
     typedef typename Kokkos::View<nnz_scalar_t *, HandleTempMemorySpace> scalar_temp_work_view_t;
     typedef typename Kokkos::View<nnz_scalar_t *, HandlePersistentMemorySpace> scalar_persistent_work_view_t;
-    typedef typename Kokkos::View<nnz_scalar_t **, Kokkos::LayoutLeft, HandlePersistentMemorySpace> scalar_persistent_work_view2d_t;
+    typedef typename Kokkos::View<nnz_scalar_t **, default_layout, HandlePersistentMemorySpace> scalar_persistent_work_view2d_t;
     typedef typename scalar_persistent_work_view_t::HostMirror scalar_persistent_work_host_view_t; //Host view type
 
     typedef typename Kokkos::View<nnz_lno_t *, HandleTempMemorySpace> nnz_lno_temp_work_view_t;
@@ -514,7 +514,7 @@ namespace KokkosSparse{
         throw std::runtime_error("inverse diagonal does not exist until after numeric setup.");
       return inverse_diagonal;
     }
-    
+
     bool use_teams() const
     {
       return KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>();
@@ -562,7 +562,7 @@ namespace KokkosSparse{
     using const_ordinal_t = typename const_entries_view_t::value_type;
     using const_scalar_t  = typename const_values_view_t::value_type;
 
-    using vector_view_t = Kokkos::View<scalar_t**, Kokkos::LayoutLeft, device_t>;
+    using vector_view_t = Kokkos::View<scalar_t**, default_layout, device_t>;
 
     using GSHandle = GaussSeidelHandle<input_size_t, input_ordinal_t, input_scalar_t,
                                        ExecutionSpace, TemporaryMemorySpace, PersistentMemorySpace>;

--- a/src/sparse/KokkosSparse_spmv.hpp
+++ b/src/sparse/KokkosSparse_spmv.hpp
@@ -374,13 +374,11 @@ spmv (KokkosKernels::Experimental::Controls /*controls*/,
   // Call single-vector version if appropriate
   if (x.extent(1) == 1) {
     typedef Kokkos::View<typename XVector::const_value_type*,
-      typename Kokkos::Impl::if_c<std::is_same<typename YVector::array_layout, Kokkos::LayoutLeft>::value,
-                                  Kokkos::LayoutLeft, Kokkos::LayoutStride>::type,
+      typename YVector::array_layout,
       typename XVector::device_type,
       Kokkos::MemoryTraits<Kokkos::Unmanaged|Kokkos::RandomAccess> > XVector_SubInternal;
     typedef Kokkos::View<typename YVector::non_const_value_type*,
-      typename Kokkos::Impl::if_c<std::is_same<typename YVector::array_layout,Kokkos::LayoutLeft>::value,
-                                  Kokkos::LayoutLeft,Kokkos::LayoutStride>::type,
+      typename YVector::array_layout,
       typename YVector::device_type,
       Kokkos::MemoryTraits<Kokkos::Unmanaged> > YVector_SubInternal;
 
@@ -735,13 +733,11 @@ void spmv(const char mode[],
       // Call single-vector version if appropriate
       if (x.extent(1) == 1) {
         typedef Kokkos::View<typename XVector::const_value_type*,
-                             typename Kokkos::Impl::if_c<std::is_same<typename YVector::array_layout, Kokkos::LayoutLeft>::value,
-                                                         Kokkos::LayoutLeft, Kokkos::LayoutStride>::type,
+                             typename YVector::array_layout,
                              typename XVector::device_type,
                              Kokkos::MemoryTraits<Kokkos::Unmanaged|Kokkos::RandomAccess> > XVector_SubInternal;
         typedef Kokkos::View<typename YVector::non_const_value_type*,
-                             typename Kokkos::Impl::if_c<std::is_same<typename YVector::array_layout,Kokkos::LayoutLeft>::value,
-                                                         Kokkos::LayoutLeft,Kokkos::LayoutStride>::type,
+                             typename YVector::array_layout,
                              typename YVector::device_type,
                              Kokkos::MemoryTraits<Kokkos::Unmanaged> > YVector_SubInternal;
 

--- a/src/sparse/KokkosSparse_spmv.hpp
+++ b/src/sparse/KokkosSparse_spmv.hpp
@@ -374,11 +374,11 @@ spmv (KokkosKernels::Experimental::Controls /*controls*/,
   // Call single-vector version if appropriate
   if (x.extent(1) == 1) {
     typedef Kokkos::View<typename XVector::const_value_type*,
-      typename YVector::array_layout,
+      typename KokkosKernels::Impl::GetUnifiedLayout<XVector>::array_layout,
       typename XVector::device_type,
       Kokkos::MemoryTraits<Kokkos::Unmanaged|Kokkos::RandomAccess> > XVector_SubInternal;
     typedef Kokkos::View<typename YVector::non_const_value_type*,
-      typename YVector::array_layout,
+      typename KokkosKernels::Impl::GetUnifiedLayout<YVector>::array_layout,
       typename YVector::device_type,
       Kokkos::MemoryTraits<Kokkos::Unmanaged> > YVector_SubInternal;
 

--- a/src/sparse/impl/KokkosSparse_gauss_seidel_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_gauss_seidel_spec.hpp
@@ -112,13 +112,13 @@ namespace KokkosSparse {
                                             KokkosKernels::Experimental::KokkosKernelsHandle< \
                                                                                              const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
                                                                                              EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
-                                            Kokkos::View<const OFFSET_TYPE *, Kokkos::LayoutLeft, \
+                                            Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE, \
                                                          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-                                            Kokkos::View<const ORDINAL_TYPE *, Kokkos::LayoutLeft, \
+                                            Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE, \
                                                          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-                                            Kokkos::View<const SCALAR_TYPE *, Kokkos::LayoutLeft, \
+                                            Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE, \
                                                          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
                                             Kokkos::View< SCALAR_TYPE **, LAYOUT_TYPE, \
@@ -483,13 +483,13 @@ namespace KokkosSparse {
                       KokkosKernels::Experimental::KokkosKernelsHandle< \
                                                                        const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
                                                                        EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
-                      Kokkos::View<const OFFSET_TYPE *, Kokkos::LayoutLeft,    \
+                      Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,    \
                                    Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-                      Kokkos::View<const ORDINAL_TYPE *, Kokkos::LayoutLeft,   \
+                      Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,   \
                                    Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-                      Kokkos::View<const SCALAR_TYPE *, Kokkos::LayoutLeft,    \
+                      Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,    \
                                    Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
                       Kokkos::View<SCALAR_TYPE **, LAYOUT_TYPE, \
@@ -507,13 +507,13 @@ namespace KokkosSparse {
                       KokkosKernels::Experimental::KokkosKernelsHandle< \
                                                                        const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE, \
                                                                        EXEC_SPACE_TYPE, MEM_SPACE_TYPE, SLOW_MEM_SPACE> , \
-                      Kokkos::View<const OFFSET_TYPE *, Kokkos::LayoutLeft,    \
+                      Kokkos::View<const OFFSET_TYPE *, LAYOUT_TYPE,    \
                                    Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-                      Kokkos::View<const ORDINAL_TYPE *, Kokkos::LayoutLeft,   \
+                      Kokkos::View<const ORDINAL_TYPE *, LAYOUT_TYPE,   \
                                    Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-                      Kokkos::View<const SCALAR_TYPE *, Kokkos::LayoutLeft,    \
+                      Kokkos::View<const SCALAR_TYPE *, LAYOUT_TYPE,    \
                                    Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
                       Kokkos::View<SCALAR_TYPE **, LAYOUT_TYPE, \

--- a/src/sparse/impl/KokkosSparse_spgemm_mkl2phase_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_mkl2phase_impl.hpp
@@ -83,7 +83,7 @@ void mkl2phase_symbolic(
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
 
   typedef typename KernelHandle::nnz_lno_t idx;
-  
+
   typedef typename KernelHandle::HandlePersistentMemorySpace HandlePersistentMemorySpace;
 
   typedef typename Kokkos::View<int *, HandlePersistentMemorySpace> int_persistent_work_view_t;
@@ -156,8 +156,8 @@ void mkl2phase_symbolic(
         mynullptr, mynulladj, c_xadj,
         &nzmax, &info);
 
-    if (verbose){ 
-      std::cout << "Sort:" << sort << " Actual MKL2 Symbolic Time:" << timer1.seconds() << std::endl; 
+    if (verbose){
+      std::cout << "Sort:" << sort << " Actual MKL2 Symbolic Time:" << timer1.seconds() << std::endl;
     }
 
     if (handle->mkl_convert_to_1base){
@@ -183,7 +183,7 @@ void mkl2phase_symbolic(
       if (SPARSE_STATUS_SUCCESS != mkl_sparse_d_create_csr (&A, SPARSE_INDEX_BASE_ONE, mklm, mkln, a_xadj, a_xadj + 1, a_adj, mynullptr)){
         throw std::runtime_error ("CANNOT CREATE mkl_sparse_s_create_csr A matrix\n");
       }
-  
+
       if (SPARSE_STATUS_SUCCESS != mkl_sparse_d_create_csr (&B, SPARSE_INDEX_BASE_ONE, n, k, b_xadj, b_xadj + 1, b_adj, mynullptr)){
         throw std::runtime_error ("CANNOT CREATE mkl_sparse_s_create_csr B matrix\n");
       }
@@ -191,7 +191,7 @@ void mkl2phase_symbolic(
       if (SPARSE_STATUS_SUCCESS != mkl_sparse_d_create_csr (&A, SPARSE_INDEX_BASE_ZERO, mklm, mkln, a_xadj, a_xadj + 1, a_adj, mynullptr)){
         throw std::runtime_error ("CANNOT CREATE mkl_sparse_s_create_csr A matrix\n");
       }
-  
+
       if (SPARSE_STATUS_SUCCESS != mkl_sparse_d_create_csr (&B, SPARSE_INDEX_BASE_ZERO, n, k, b_xadj, b_xadj + 1, b_adj, mynullptr)){
         throw std::runtime_error ("CANNOT CREATE mkl_sparse_s_create_csr B matrix\n");
       }
@@ -217,13 +217,13 @@ void mkl2phase_symbolic(
     // options: SPARSE_STAGE_FULL_MULT vs SPARSE_STAGE_NNZ_COUNT then SPARSE_STAGE_FINALIZE_MULT
     bool success = SPARSE_STATUS_SUCCESS != mkl_sparse_sp2m (operation, common_mtx_props, A, operation, common_mtx_props, B, SPARSE_STAGE_NNZ_COUNT, &C); // success is "true" if mkl_sparse_spmm does not return success
 
-    if (verbose){ 
-      std::cout << "Actual DOUBLE MKL SPMM Time:" << timer1.seconds() << std::endl; 
+    if (verbose){
+      std::cout << "Actual DOUBLE MKL SPMM Time:" << timer1.seconds() << std::endl;
     }
 
     if (success) {
       throw std::runtime_error ("ERROR at SPGEMM multiplication in mkl_sparse_spmm\n");
-    } 
+    }
     else {
 
       // Copy sparse_matrix_t C results back to input data structure
@@ -232,8 +232,8 @@ void mkl2phase_symbolic(
       double *values; // should return null
 
       if (SPARSE_STATUS_SUCCESS !=
-          //mkl_sparse_s_export_csr (C, &c_indexing, &c_rows, &c_cols, &rows_start, &rows_end, &columns, &values)) 
-          mkl_sparse_d_export_csr (C, &c_indexing, &c_rows, &c_cols, &c_xadj, &rows_end, &columns, &values)) 
+          //mkl_sparse_s_export_csr (C, &c_indexing, &c_rows, &c_cols, &rows_start, &rows_end, &columns, &values))
+          mkl_sparse_d_export_csr (C, &c_indexing, &c_rows, &c_cols, &c_xadj, &rows_end, &columns, &values))
       {
         throw std::runtime_error ("ERROR at exporting result matrix in mkl_sparse_spmm\n");
       }
@@ -274,7 +274,7 @@ void mkl2phase_symbolic(
     throw std::runtime_error ("MKL requires local ordinals to be integer.\n");
     (void) k; (void) transposeA; (void) transposeB; (void) verbose;
   }
-#else // KOKKOSKERNELS_ENABLE_TPL_MKL
+#else
   (void)handle;
   (void)m;          (void)n;          (void)k;
   (void)row_mapA;   (void)row_mapB;   (void)row_mapC;
@@ -283,6 +283,10 @@ void mkl2phase_symbolic(
   (void)verbose;
   throw std::runtime_error ("MKL IS NOT DEFINED\n");
 #endif // KOKKOSKERNELS_ENABLE_TPL_MKL
+  // Supress -Wunused-param in intel-18
+  (void)k;
+  (void)transposeA; (void)transposeB;
+  (void)verbose;
 }
 
 
@@ -331,7 +335,7 @@ void mkl2phase_symbolic(
 
       int *a_adj = (int *)entriesA.data();
       int *b_adj = (int *)entriesB.data();
-      
+
 
       if (handle->mkl_convert_to_1base)
       {
@@ -436,7 +440,7 @@ void mkl2phase_symbolic(
             throw std::runtime_error ("CANNOT CREATE mkl_sparse_s_create_csr A matrix\n");
           }
         }
-    
+
         if (std::is_same<value_type, double>::value){
           if (SPARSE_STATUS_SUCCESS != mkl_sparse_d_create_csr (&B, SPARSE_INDEX_BASE_ONE, n, k, b_xadj, b_xadj + 1, b_adj, reinterpret_cast<double*>(b_ew))){
             throw std::runtime_error ("CANNOT CREATE mkl_sparse_s_create_csr B matrix\n");
@@ -458,7 +462,7 @@ void mkl2phase_symbolic(
             throw std::runtime_error ("CANNOT CREATE mkl_sparse_s_create_csr A matrix\n");
           }
         }
-    
+
         if (std::is_same<value_type, double>::value){
           if (SPARSE_STATUS_SUCCESS != mkl_sparse_d_create_csr (&B, SPARSE_INDEX_BASE_ZERO, n, k, b_xadj, b_xadj + 1, b_adj, reinterpret_cast<double*>(b_ew))){
             throw std::runtime_error ("CANNOT CREATE mkl_sparse_s_create_csr B matrix\n");
@@ -470,7 +474,7 @@ void mkl2phase_symbolic(
           }
         }
       }
-  
+
       sparse_operation_t operation;
       if (transposeA && transposeB){
         operation = SPARSE_OPERATION_TRANSPOSE;
@@ -481,7 +485,7 @@ void mkl2phase_symbolic(
       else {
         throw std::runtime_error ("MKL either transpose both matrices, or none for SPGEMM\n");
       }
-  
+
       matrix_descr common_mtx_props;
       common_mtx_props.type = SPARSE_MATRIX_TYPE_GENERAL;
       common_mtx_props.mode = SPARSE_FILL_MODE_FULL;
@@ -491,8 +495,8 @@ void mkl2phase_symbolic(
       // options: SPARSE_STAGE_FULL_MULT vs SPARSE_STAGE_NNZ_COUNT then SPARSE_STAGE_FINALIZE_MULT
       bool success = SPARSE_STATUS_SUCCESS != mkl_sparse_sp2m (operation, common_mtx_props, A, operation, common_mtx_props, B, SPARSE_STAGE_FINALIZE_MULT, &C); // success is "true" if mkl_sparse_spmm does not return success
 
-      if (verbose){ 
-        std::cout << "Actual MKL SPMM Time:" << timer1.seconds() << std::endl; 
+      if (verbose){
+        std::cout << "Actual MKL SPMM Time:" << timer1.seconds() << std::endl;
       }
 
       if (success) {
@@ -558,7 +562,6 @@ void mkl2phase_symbolic(
       (void)transposeA; (void)transposeB;
       (void)verbose;
 #endif // __INTEL_MKL__ == 2018 && __INTEL_MKL_UPDATE__ >= 2
-
     }
     else {
       (void) m;         (void) n;         (void) k;

--- a/src/sparse/impl/KokkosSparse_spgemm_mkl2phase_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_mkl2phase_impl.hpp
@@ -556,7 +556,10 @@ void mkl2phase_symbolic(
       (void)verbose;
 #else
       throw std::runtime_error ("Intel MKL versions > 18 are not yet tested/supported\n");
+      // Supress -Wunused-parameter on intel-18
       (void) m;         (void) n;         (void) k;
+#endif
+      // Supress -Wunused-parameter on intel-18
       (void)entriesC;
       (void)valuesA;    (void)valuesB;    (void)valuesC;
       (void)transposeA; (void)transposeB;

--- a/src/sparse/impl/KokkosSparse_spgemm_mkl2phase_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_mkl2phase_impl.hpp
@@ -274,7 +274,7 @@ void mkl2phase_symbolic(
     throw std::runtime_error ("MKL requires local ordinals to be integer.\n");
     (void) k; (void) transposeA; (void) transposeB; (void) verbose;
   }
-#else
+#else // KOKKOSKERNELS_ENABLE_TPL_MKL
   (void)handle;
   (void)m;          (void)n;          (void)k;
   (void)row_mapA;   (void)row_mapB;   (void)row_mapC;
@@ -283,10 +283,6 @@ void mkl2phase_symbolic(
   (void)verbose;
   throw std::runtime_error ("MKL IS NOT DEFINED\n");
 #endif // KOKKOSKERNELS_ENABLE_TPL_MKL
-  // Supress -Wunused-param in intel-18
-  (void)k;
-  (void)transposeA; (void)transposeB;
-  (void)verbose;
 }
 
 
@@ -558,8 +554,6 @@ void mkl2phase_symbolic(
       throw std::runtime_error ("Intel MKL versions > 18 are not yet tested/supported\n");
       // Supress -Wunused-parameter on intel-18
       (void) m;         (void) n;         (void) k;
-#endif
-      // Supress -Wunused-parameter on intel-18
       (void)entriesC;
       (void)valuesA;    (void)valuesB;    (void)valuesC;
       (void)transposeA; (void)transposeB;

--- a/unit_test/blas/Test_Blas1_dot.hpp
+++ b/unit_test/blas/Test_Blas1_dot.hpp
@@ -8,56 +8,44 @@
 namespace Test {
   template<class ViewTypeA, class ViewTypeB, class Device>
   void impl_test_dot(int N) {
+  typedef typename ViewTypeA::value_type ScalarA;
+  typedef typename ViewTypeB::value_type ScalarB;
+  typedef Kokkos::ArithTraits<ScalarA> ats;
 
-    typedef typename ViewTypeA::value_type ScalarA;
-    typedef typename ViewTypeB::value_type ScalarB;
-    typedef Kokkos::ArithTraits<ScalarA> ats;
+  ViewTypeA a("a", N);
+  ViewTypeB b("b", N);
 
-    typedef Kokkos::View<ScalarA*[2],
-       typename ViewTypeA::array_layout,Device> BaseTypeA;
-    typedef Kokkos::View<ScalarB*[2],
-       typename ViewTypeB::array_layout,Device> BaseTypeB;
+  typename ViewTypeA::HostMirror h_a = Kokkos::create_mirror_view(a);
+  typename ViewTypeB::HostMirror h_b = Kokkos::create_mirror_view(b);
 
+  Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
+      13718);
 
-    BaseTypeA b_a("A",N);
-    BaseTypeB b_b("B",N);
+  {
+    ScalarA randStart, randEnd;
+    Test::getRandomBounds(10.0, randStart, randEnd);
+    Kokkos::fill_random(a, rand_pool, randStart, randEnd);
+  }
+  {
+    ScalarB randStart, randEnd;
+    Test::getRandomBounds(10.0, randStart, randEnd);
+    Kokkos::fill_random(b, rand_pool, randStart, randEnd);
+  }
 
-    ViewTypeA a = Kokkos::subview(b_a,Kokkos::ALL(),0);
-    ViewTypeB b = Kokkos::subview(b_b,Kokkos::ALL(),0);
+  Kokkos::deep_copy(h_a, a);
+  Kokkos::deep_copy(h_b, b);
 
-    typename BaseTypeA::HostMirror h_b_a = Kokkos::create_mirror_view(b_a);
-    typename BaseTypeB::HostMirror h_b_b = Kokkos::create_mirror_view(b_b);
+  ScalarA expected_result = 0;
+  for (int i = 0; i < N; i++) expected_result += ats::conj(h_a(i)) * h_b(i);
 
-    typename ViewTypeA::HostMirror h_a = Kokkos::subview(h_b_a,Kokkos::ALL(),0);
-    typename ViewTypeB::HostMirror h_b = Kokkos::subview(h_b_b,Kokkos::ALL(),0);
+  ScalarA nonconst_nonconst_result = KokkosBlas::dot(a, b);
+  double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
+  EXPECT_NEAR_KK(nonconst_nonconst_result, expected_result,
+                 eps * expected_result);
+  typename ViewTypeA::const_type c_a = a;
+  typename ViewTypeB::const_type c_b = b;
 
-    Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
-
-    {
-      ScalarA randStart, randEnd;
-      Test::getRandomBounds(10.0, randStart, randEnd);
-      Kokkos::fill_random(b_a,rand_pool,randStart,randEnd);
-    }
-    {
-      ScalarB randStart, randEnd;
-      Test::getRandomBounds(10.0, randStart, randEnd);
-      Kokkos::fill_random(b_b,rand_pool,randStart,randEnd);
-    }
-
-    Kokkos::deep_copy(h_b_a,b_a);
-    Kokkos::deep_copy(h_b_b,b_b);
-
-    ScalarA expected_result = 0;
-    for(int i=0;i<N;i++)
-      expected_result += ats::conj(h_a(i))*h_b(i);
-
-    ScalarA nonconst_nonconst_result = KokkosBlas::dot(a,b);
-    double eps = std::is_same<ScalarA,float>::value?2*1e-5:1e-7;
-    EXPECT_NEAR_KK( nonconst_nonconst_result, expected_result, eps*expected_result);
-    typename ViewTypeA::const_type c_a = a;
-    typename ViewTypeB::const_type c_b = b;
-
-    ScalarA const_const_result = KokkosBlas::dot(c_a,c_b);
+  ScalarA const_const_result = KokkosBlas::dot(c_a,c_b);
     EXPECT_NEAR_KK( const_const_result, expected_result, eps*expected_result);
 
     ScalarA nonconst_const_result = KokkosBlas::dot(a,c_b);

--- a/unit_test/blas/Test_Blas1_dot.hpp
+++ b/unit_test/blas/Test_Blas1_dot.hpp
@@ -14,13 +14,9 @@ namespace Test {
     typedef Kokkos::ArithTraits<ScalarA> ats;
 
     typedef Kokkos::View<ScalarA*[2],
-       typename std::conditional<
-                std::is_same<typename ViewTypeA::array_layout,Kokkos::LayoutStride>::value,
-                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,Device> BaseTypeA;
+       typename ViewTypeA::array_layout,Device> BaseTypeA;
     typedef Kokkos::View<ScalarB*[2],
-       typename std::conditional<
-                std::is_same<typename ViewTypeB::array_layout,Kokkos::LayoutStride>::value,
-                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,Device> BaseTypeB;
+       typename ViewTypeB::array_layout,Device> BaseTypeB;
 
 
     BaseTypeA b_a("A",N);

--- a/unit_test/blas/Test_Blas1_iamax.hpp
+++ b/unit_test/blas/Test_Blas1_iamax.hpp
@@ -11,27 +11,19 @@ namespace Test {
     typedef typename ViewTypeA::non_const_value_type ScalarA;
     typedef Kokkos::Details::ArithTraits<ScalarA> AT;
     typedef typename AT::mag_type mag_type;
+    using size_type = typename ViewTypeA::size_type;
 
-    typedef Kokkos::View<ScalarA*[2],
-       typename ViewTypeA::array_layout,Device> BaseTypeA;
+    ViewTypeA a("a", N);
 
-    typedef typename BaseTypeA::size_type size_type;
-
-    BaseTypeA b_a("A",N);
-
-    ViewTypeA a = Kokkos::subview(b_a,Kokkos::ALL(),0);
-
-    typename BaseTypeA::HostMirror h_b_a = Kokkos::create_mirror_view(b_a);
-
-    typename ViewTypeA::HostMirror h_a = Kokkos::subview(h_b_a,Kokkos::ALL(),0);
+    typename ViewTypeA::HostMirror h_a = Kokkos::create_mirror_view(a);
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
     ScalarA randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(b_a,rand_pool,randStart,randEnd);
+    Kokkos::fill_random(a, rand_pool, randStart, randEnd);
 
-    Kokkos::deep_copy(h_b_a,b_a);
+    Kokkos::deep_copy(h_a, a);
 
     typename ViewTypeA::const_type c_a = a;
 

--- a/unit_test/blas/Test_Blas1_iamax.hpp
+++ b/unit_test/blas/Test_Blas1_iamax.hpp
@@ -13,9 +13,7 @@ namespace Test {
     typedef typename AT::mag_type mag_type;
 
     typedef Kokkos::View<ScalarA*[2],
-       typename std::conditional<
-                std::is_same<typename ViewTypeA::array_layout,Kokkos::LayoutStride>::value,
-                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,Device> BaseTypeA;
+       typename ViewTypeA::array_layout,Device> BaseTypeA;
 
     typedef typename BaseTypeA::size_type size_type;
 
@@ -39,31 +37,31 @@ namespace Test {
 
     mag_type expected_result = Kokkos::Details::ArithTraits<mag_type>::min();
     size_type expected_max_loc = 0;
-    for(int i=0;i<N;i++) {      
+    for(int i=0;i<N;i++) {
       mag_type val = AT::abs(h_a(i));
       if(val > expected_result) { expected_result = val; expected_max_loc = i+1;}
     }
-	
+
     if(N == 0) {expected_result = typename AT::mag_type(0); expected_max_loc = 0;}
 
     {
       //printf("impl_test_iamax -- return result as a scalar on host -- N %d\n", N);
       size_type nonconst_max_loc = KokkosBlas::iamax(a);
       ASSERT_EQ( nonconst_max_loc, expected_max_loc);
-      
+
       size_type const_max_loc = KokkosBlas::iamax(c_a);
       ASSERT_EQ( const_max_loc, expected_max_loc);
     }
 
 	{
       //printf("impl_test_iamax -- return result as a 0-D View on host -- N %d\n", N);
-      typedef Kokkos::View<size_type, Kokkos::LayoutLeft, Kokkos::HostSpace> ViewType0D;
-	  ViewType0D r("Iamax::Result 0-D View on host");
-      
+      typedef Kokkos::View<size_type, typename ViewTypeA::array_layout, Kokkos::HostSpace> ViewType0D;
+      ViewType0D r("Iamax::Result 0-D View on host");
+
       KokkosBlas::iamax(r,a);
       size_type nonconst_max_loc = r();
       ASSERT_EQ( nonconst_max_loc, expected_max_loc);
-      
+
       KokkosBlas::iamax(r,c_a);
       size_type const_max_loc = r();
       ASSERT_EQ( const_max_loc, expected_max_loc);
@@ -71,12 +69,12 @@ namespace Test {
 
 	{
       //printf("impl_test_iamax -- return result as a 0-D View on device -- N %d\n", N);
-      typedef Kokkos::View<size_type, Kokkos::LayoutLeft, Device> ViewType0D;
-	  ViewType0D r("Iamax::Result 0-D View on device");
+      typedef Kokkos::View<size_type, typename ViewTypeA::array_layout, Device> ViewType0D;
+      ViewType0D r("Iamax::Result 0-D View on device");
       typename ViewType0D::HostMirror h_r = Kokkos::create_mirror_view(r);
-      
+
       size_type nonconst_max_loc, const_max_loc;
-      
+
       KokkosBlas::iamax(r,a);
       Kokkos::deep_copy(h_r,r);
 
@@ -137,18 +135,18 @@ namespace Test {
 
     {
       //printf("impl_test_iamax_mv -- return results as a 1-D View on host -- N %d\n", N);
-      Kokkos::View<size_type*, Kokkos::LayoutLeft, Kokkos::HostSpace> r("Iamax::Result View on host",K);
-      
+      Kokkos::View<size_type*, typename ViewTypeA::array_layout, Kokkos::HostSpace> r("Iamax::Result View on host",K);
+
       KokkosBlas::iamax(r,a);
-      
+
       for(int k=0;k<K;k++) {
         size_type nonconst_result = r(k);
         size_type exp_result = expected_max_loc[k];
         ASSERT_EQ( nonconst_result, exp_result);
       }
-      
+
       KokkosBlas::iamax(r,c_a);
-      
+
       for(int k=0;k<K;k++) {
         size_type const_result = r(k);
         size_type exp_result = expected_max_loc[k];
@@ -158,21 +156,21 @@ namespace Test {
 
     {
       //printf("impl_test_iamax_mv -- return results as a 1-D View on device -- N %d\n", N);
-      Kokkos::View<size_type*, Kokkos::LayoutLeft, Device> r("Iamax::Result View on device",K);
-      typename Kokkos::View<size_type *, Kokkos::LayoutLeft, Device>::HostMirror h_r= Kokkos::create_mirror_view(r);
-      
+      Kokkos::View<size_type*, typename ViewTypeA::array_layout, Device> r("Iamax::Result View on device",K);
+      typename Kokkos::View<size_type *, typename ViewTypeA::array_layout, Device>::HostMirror h_r= Kokkos::create_mirror_view(r);
+
       KokkosBlas::iamax(r,a);
       Kokkos::deep_copy(h_r,r);
-      
+
       for(int k=0;k<K;k++) {
         size_type nonconst_result = h_r(k);
         size_type exp_result = expected_max_loc[k];
         ASSERT_EQ( nonconst_result, exp_result);
       }
-      
+
       KokkosBlas::iamax(r,c_a);
       Kokkos::deep_copy(h_r,r);
-      
+
       for(int k=0;k<K;k++) {
         size_type const_result = h_r(k);
         size_type exp_result = expected_max_loc[k];

--- a/unit_test/blas/Test_Blas1_mult.hpp
+++ b/unit_test/blas/Test_Blas1_mult.hpp
@@ -86,28 +86,24 @@ namespace Test {
     typedef typename ViewTypeB::value_type ScalarB;
     typedef typename ViewTypeC::value_type ScalarC;
 
-    typedef Kokkos::View<ScalarA*[2],
-       typename ViewTypeA::array_layout,Device> BaseTypeA;
     typedef multivector_layout_adapter<ViewTypeB> vfB_type;
     typedef multivector_layout_adapter<ViewTypeC> vfC_type;
 
-    BaseTypeA b_x("X",N);
-    typename vfB_type::BaseType b_y("Y",N,K);
+    ViewTypeA x("X", N);
+    typename vfB_type::BaseType b_y("Y", N, K);
     typename vfC_type::BaseType b_z("Z",N,K);
     typename vfC_type::BaseType b_org_z("Z",N,K);
 
-    ViewTypeA x = Kokkos::subview(b_x,Kokkos::ALL(),0);
     ViewTypeB y = vfB_type::view(b_y);
     ViewTypeC z = vfC_type::view(b_z);
 
     typedef multivector_layout_adapter<typename ViewTypeB::HostMirror> h_vfB_type;
     typedef multivector_layout_adapter<typename ViewTypeC::HostMirror> h_vfC_type;
 
-    typename BaseTypeA::HostMirror h_b_x = Kokkos::create_mirror_view(b_x);
     typename h_vfB_type::BaseType h_b_y = Kokkos::create_mirror_view(b_y);
     typename h_vfC_type::BaseType h_b_z = Kokkos::create_mirror_view(b_z);
 
-    typename ViewTypeA::HostMirror h_x = Kokkos::subview(h_b_x,Kokkos::ALL(),0);
+    typename ViewTypeA::HostMirror h_x = Kokkos::create_mirror_view(x);
     typename ViewTypeB::HostMirror h_y = h_vfB_type::view(h_b_y);
     typename ViewTypeC::HostMirror h_z = h_vfC_type::view(h_b_z);
 
@@ -116,7 +112,7 @@ namespace Test {
     {
       ScalarA randStart, randEnd;
       Test::getRandomBounds(10.0, randStart, randEnd);
-      Kokkos::fill_random(b_x,rand_pool,randStart,randEnd);
+      Kokkos::fill_random(x, rand_pool, randStart, randEnd);
     }
     {
       ScalarB randStart, randEnd;
@@ -132,8 +128,8 @@ namespace Test {
     Kokkos::deep_copy(b_org_z,b_z);
     auto h_b_org_z = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_org_z);
 
-    Kokkos::deep_copy(h_b_x,b_x);
-    Kokkos::deep_copy(h_b_y,b_y);
+    Kokkos::deep_copy(h_x, x);
+    Kokkos::deep_copy(h_b_y, b_y);
     Kokkos::deep_copy(h_b_z,b_z);
 
     ScalarA a = 3;

--- a/unit_test/blas/Test_Blas1_mult.hpp
+++ b/unit_test/blas/Test_Blas1_mult.hpp
@@ -14,17 +14,11 @@ namespace Test {
     typedef typename ViewTypeC::value_type ScalarC;
 
     typedef Kokkos::View<ScalarA*[2],
-       typename std::conditional<
-                std::is_same<typename ViewTypeA::array_layout,Kokkos::LayoutStride>::value,
-                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,Device> BaseTypeA;
+       typename ViewTypeA::array_layout,Device> BaseTypeA;
     typedef Kokkos::View<ScalarB*[2],
-       typename std::conditional<
-                std::is_same<typename ViewTypeB::array_layout,Kokkos::LayoutStride>::value,
-                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,Device> BaseTypeB;
+       typename ViewTypeB::array_layout,Device> BaseTypeB;
     typedef Kokkos::View<ScalarC*[2],
-       typename std::conditional<
-                std::is_same<typename ViewTypeC::array_layout,Kokkos::LayoutStride>::value,
-                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,Device> BaseTypeC;
+       typename ViewTypeC::array_layout,Device> BaseTypeC;
 
 
     ScalarA a = 3;
@@ -35,7 +29,7 @@ namespace Test {
     BaseTypeB b_y("Y",N);
     BaseTypeC b_z("Y",N);
     BaseTypeC b_org_z("Org_Z",N);
-    
+
 
     ViewTypeA x = Kokkos::subview(b_x,Kokkos::ALL(),0);
     ViewTypeB y = Kokkos::subview(b_y,Kokkos::ALL(),0);
@@ -109,9 +103,7 @@ namespace Test {
     typedef typename ViewTypeC::value_type ScalarC;
 
     typedef Kokkos::View<ScalarA*[2],
-       typename std::conditional<
-                std::is_same<typename ViewTypeA::array_layout,Kokkos::LayoutStride>::value,
-                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,Device> BaseTypeA;
+       typename ViewTypeA::array_layout,Device> BaseTypeA;
     typedef multivector_layout_adapter<ViewTypeB> vfB_type;
     typedef multivector_layout_adapter<ViewTypeC> vfC_type;
 

--- a/unit_test/blas/Test_Blas1_mult.hpp
+++ b/unit_test/blas/Test_Blas1_mult.hpp
@@ -8,91 +8,75 @@
 namespace Test {
   template<class ViewTypeA, class ViewTypeB, class ViewTypeC, class Device>
   void impl_test_mult(int N) {
+  typedef typename ViewTypeA::value_type ScalarA;
+  typedef typename ViewTypeB::value_type ScalarB;
+  typedef typename ViewTypeC::value_type ScalarC;
 
-    typedef typename ViewTypeA::value_type ScalarA;
-    typedef typename ViewTypeB::value_type ScalarB;
-    typedef typename ViewTypeC::value_type ScalarC;
+  ScalarA a  = 3;
+  ScalarB b  = 5;
+  double eps = std::is_same<ScalarC, float>::value ? 1e-4 : 1e-7;
 
-    typedef Kokkos::View<ScalarA*[2],
-       typename ViewTypeA::array_layout,Device> BaseTypeA;
-    typedef Kokkos::View<ScalarB*[2],
-       typename ViewTypeB::array_layout,Device> BaseTypeB;
-    typedef Kokkos::View<ScalarC*[2],
-       typename ViewTypeC::array_layout,Device> BaseTypeC;
+  ViewTypeA x("X", N);
+  ViewTypeB y("Y", N);
+  ViewTypeC z("Y", N);
+  ViewTypeC b_org_z("Org_Z", N);
 
+  typename ViewTypeA::const_type c_x = x;
+  typename ViewTypeB::const_type c_y = y;
 
-    ScalarA a = 3;
-    ScalarB b = 5;
-    double eps = std::is_same<ScalarC,float>::value?1e-4:1e-7;
+  typename ViewTypeA::HostMirror h_x = Kokkos::create_mirror_view(x);
+  typename ViewTypeB::HostMirror h_y = Kokkos::create_mirror_view(y);
+  typename ViewTypeC::HostMirror h_z = Kokkos::create_mirror_view(z);
 
-    BaseTypeA b_x("X",N);
-    BaseTypeB b_y("Y",N);
-    BaseTypeC b_z("Y",N);
-    BaseTypeC b_org_z("Org_Z",N);
+  Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
+      13718);
 
+  {
+    ScalarA randStart, randEnd;
+    Test::getRandomBounds(10.0, randStart, randEnd);
+    Kokkos::fill_random(x, rand_pool, randStart, randEnd);
+  }
+  {
+    ScalarB randStart, randEnd;
+    Test::getRandomBounds(10.0, randStart, randEnd);
+    Kokkos::fill_random(y, rand_pool, randStart, randEnd);
+  }
+  {
+    ScalarC randStart, randEnd;
+    Test::getRandomBounds(10.0, randStart, randEnd);
+    Kokkos::fill_random(z, rand_pool, randStart, randEnd);
+  }
 
-    ViewTypeA x = Kokkos::subview(b_x,Kokkos::ALL(),0);
-    ViewTypeB y = Kokkos::subview(b_y,Kokkos::ALL(),0);
-    ViewTypeC z = Kokkos::subview(b_z,Kokkos::ALL(),0);
-    typename ViewTypeA::const_type c_x = x;
-    typename ViewTypeB::const_type c_y = y;
+  Kokkos::deep_copy(b_org_z, z);
+  auto h_b_org_z =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_org_z);
 
-    typename BaseTypeA::HostMirror h_b_x = Kokkos::create_mirror_view(b_x);
-    typename BaseTypeB::HostMirror h_b_y = Kokkos::create_mirror_view(b_y);
-    typename BaseTypeC::HostMirror h_b_z = Kokkos::create_mirror_view(b_z);
+  Kokkos::deep_copy(h_x, x);
+  Kokkos::deep_copy(h_y, y);
 
-    typename ViewTypeA::HostMirror h_x = Kokkos::subview(h_b_x,Kokkos::ALL(),0);
-    typename ViewTypeB::HostMirror h_y = Kokkos::subview(h_b_y,Kokkos::ALL(),0);
-    typename ViewTypeC::HostMirror h_z = Kokkos::subview(h_b_z,Kokkos::ALL(),0);
+  // expected_result = ScalarC(b*h_z(i) + a*h_x(i)*h_y(i))
 
-    Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
+  KokkosBlas::mult(b, z, a, x, y);
+  Kokkos::deep_copy(h_z, z);
+  for (int i = 0; i < N; i++) {
+    EXPECT_NEAR_KK(a * h_x(i) * h_y(i) + b * h_b_org_z(i), h_z(i), eps);
+  }
 
+  Kokkos::deep_copy(z, b_org_z);
+  KokkosBlas::mult(b, z, a, x, c_y);
+  Kokkos::deep_copy(h_z, z);
+  for(int i = 0; i < N; i++)
     {
-      ScalarA randStart, randEnd;
-      Test::getRandomBounds(10.0, randStart, randEnd);
-      Kokkos::fill_random(b_x,rand_pool,randStart,randEnd);
-    }
+    EXPECT_NEAR_KK(a * h_x(i) * h_y(i) + b * h_b_org_z(i), h_z(i), eps);
+  }
+
+  Kokkos::deep_copy(z, b_org_z);
+  KokkosBlas::mult(b, z, a, c_x, c_y);
+  Kokkos::deep_copy(h_z, z);
+  for(int i = 0; i < N; i++)
     {
-      ScalarB randStart, randEnd;
-      Test::getRandomBounds(10.0, randStart, randEnd);
-      Kokkos::fill_random(b_y,rand_pool,randStart,randEnd);
-    }
-    {
-      ScalarC randStart, randEnd;
-      Test::getRandomBounds(10.0, randStart, randEnd);
-      Kokkos::fill_random(b_z,rand_pool,randStart,randEnd);
-    }
-
-    Kokkos::deep_copy(b_org_z,b_z);
-    auto h_b_org_z = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_org_z);
-
-    Kokkos::deep_copy(h_b_x,b_x);
-    Kokkos::deep_copy(h_b_y,b_y);
-
-    //expected_result = ScalarC(b*h_z(i) + a*h_x(i)*h_y(i))
-
-    KokkosBlas::mult(b,z,a,x,y);
-    Kokkos::deep_copy(h_b_z, b_z);
-    for(int i = 0; i < N; i++)
-    {
-      EXPECT_NEAR_KK(a * h_x(i) * h_y(i) + b * h_b_org_z(i, 0), h_z(i), eps);
-    }
-
-    Kokkos::deep_copy(b_z,b_org_z);
-    KokkosBlas::mult(b,z,a,x,c_y);
-    Kokkos::deep_copy(h_b_z, b_z);
-    for(int i = 0; i < N; i++)
-    {
-      EXPECT_NEAR_KK(a * h_x(i) * h_y(i) + b * h_b_org_z(i, 0), h_z(i), eps);
-    }
-
-    Kokkos::deep_copy(b_z,b_org_z);
-    KokkosBlas::mult(b,z,a,c_x,c_y);
-    Kokkos::deep_copy(h_b_z, b_z);
-    for(int i = 0; i < N; i++)
-    {
-      EXPECT_NEAR_KK(a * h_x(i) * h_y(i) + b * h_b_org_z(i, 0), h_z(i), eps);
-    }
+    EXPECT_NEAR_KK(a * h_x(i) * h_y(i) + b * h_b_org_z(i), h_z(i), eps);
+  }
   }
 
   template<class ViewTypeA, class ViewTypeB, class ViewTypeC, class Device>

--- a/unit_test/blas/Test_Blas1_nrm1.hpp
+++ b/unit_test/blas/Test_Blas1_nrm1.hpp
@@ -14,9 +14,7 @@ namespace Test {
     typedef Kokkos::ArithTraits<mag_type> MAT;
 
     typedef Kokkos::View<ScalarA*[2],
-       typename std::conditional<
-                std::is_same<typename ViewTypeA::array_layout,Kokkos::LayoutStride>::value,
-                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,Device> BaseTypeA;
+       typename ViewTypeA::array_layout,Device> BaseTypeA;
 
 
     BaseTypeA b_a("A",N);

--- a/unit_test/blas/Test_Blas1_nrm1.hpp
+++ b/unit_test/blas/Test_Blas1_nrm1.hpp
@@ -13,25 +13,17 @@ namespace Test {
     typedef typename AT::mag_type mag_type;
     typedef Kokkos::ArithTraits<mag_type> MAT;
 
-    typedef Kokkos::View<ScalarA*[2],
-       typename ViewTypeA::array_layout,Device> BaseTypeA;
+    ViewTypeA a("A", N);
 
-
-    BaseTypeA b_a("A",N);
-
-    ViewTypeA a = Kokkos::subview(b_a,Kokkos::ALL(),0);
-
-    typename BaseTypeA::HostMirror h_b_a = Kokkos::create_mirror_view(b_a);
-
-    typename ViewTypeA::HostMirror h_a = Kokkos::subview(h_b_a,Kokkos::ALL(),0);
+    typename ViewTypeA::HostMirror h_a = Kokkos::create_mirror_view(a);
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
     ScalarA randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(b_a,rand_pool,randStart,randEnd);
+    Kokkos::fill_random(a, rand_pool, randStart, randEnd);
 
-    Kokkos::deep_copy(h_b_a,b_a);
+    Kokkos::deep_copy(h_a, a);
 
     typename ViewTypeA::const_type c_a = a;
     double eps = (std::is_same<typename Kokkos::ArithTraits<ScalarA>::mag_type, float>::value ? 1e-4 : 1e-7);

--- a/unit_test/blas/Test_Blas1_nrm2.hpp
+++ b/unit_test/blas/Test_Blas1_nrm2.hpp
@@ -85,7 +85,7 @@ namespace Test {
 
     double eps = std::is_same<ScalarA,float>::value?2*1e-5:1e-7;
 
-    Kokkos::View<typename AT::mag_type*,typename ViewTypeA::array_layout,Kokkos::HostSpace> r("Dot::Result",K);
+    Kokkos::View<typename AT::mag_type*,Kokkos::HostSpace> r("Dot::Result",K);
 
     KokkosBlas::nrm2(r,a);
     for(int k=0;k<K;k++) {

--- a/unit_test/blas/Test_Blas1_nrm2.hpp
+++ b/unit_test/blas/Test_Blas1_nrm2.hpp
@@ -11,25 +11,17 @@ namespace Test {
     typedef typename ViewTypeA::value_type ScalarA;
     typedef Kokkos::Details::ArithTraits<ScalarA> AT;
 
-    typedef Kokkos::View<ScalarA*[2],
-       typename ViewTypeA::array_layout,Device> BaseTypeA;
+    ViewTypeA a("A", N);
 
-
-    BaseTypeA b_a("A",N);
-
-    ViewTypeA a = Kokkos::subview(b_a,Kokkos::ALL(),0);
-
-    typename BaseTypeA::HostMirror h_b_a = Kokkos::create_mirror_view(b_a);
-
-    typename ViewTypeA::HostMirror h_a = Kokkos::subview(h_b_a,Kokkos::ALL(),0);
+    typename ViewTypeA::HostMirror h_a = Kokkos::create_mirror_view(a);
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
     ScalarA randStart, randEnd;
     Test::getRandomBounds(1.0, randStart, randEnd);
-    Kokkos::fill_random(b_a,rand_pool,randStart,randEnd);
+    Kokkos::fill_random(a, rand_pool, randStart, randEnd);
 
-    Kokkos::deep_copy(h_b_a,b_a);
+    Kokkos::deep_copy(h_a, a);
 
     typename ViewTypeA::const_type c_a = a;
     double eps = std::is_same<ScalarA,float>::value?2*1e-5:1e-7;

--- a/unit_test/blas/Test_Blas1_nrm2.hpp
+++ b/unit_test/blas/Test_Blas1_nrm2.hpp
@@ -12,9 +12,7 @@ namespace Test {
     typedef Kokkos::Details::ArithTraits<ScalarA> AT;
 
     typedef Kokkos::View<ScalarA*[2],
-       typename std::conditional<
-                std::is_same<typename ViewTypeA::array_layout,Kokkos::LayoutStride>::value,
-                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,Device> BaseTypeA;
+       typename ViewTypeA::array_layout,Device> BaseTypeA;
 
 
     BaseTypeA b_a("A",N);
@@ -87,7 +85,7 @@ namespace Test {
 
     double eps = std::is_same<ScalarA,float>::value?2*1e-5:1e-7;
 
-    Kokkos::View<typename AT::mag_type*,Kokkos::HostSpace> r("Dot::Result",K);
+    Kokkos::View<typename AT::mag_type*,typename ViewTypeA::array_layout,Kokkos::HostSpace> r("Dot::Result",K);
 
     KokkosBlas::nrm2(r,a);
     for(int k=0;k<K;k++) {

--- a/unit_test/blas/Test_Blas1_nrminf.hpp
+++ b/unit_test/blas/Test_Blas1_nrminf.hpp
@@ -11,25 +11,17 @@ namespace Test {
     typedef typename ViewTypeA::non_const_value_type ScalarA;
     typedef Kokkos::Details::ArithTraits<ScalarA> AT;
 
-    typedef Kokkos::View<ScalarA*[2],
-       typename ViewTypeA::array_layout,Device> BaseTypeA;
+    ViewTypeA a("A", N);
 
-
-    BaseTypeA b_a("A",N);
-
-    ViewTypeA a = Kokkos::subview(b_a,Kokkos::ALL(),0);
-
-    typename BaseTypeA::HostMirror h_b_a = Kokkos::create_mirror_view(b_a);
-
-    typename ViewTypeA::HostMirror h_a = Kokkos::subview(h_b_a,Kokkos::ALL(),0);
+    typename ViewTypeA::HostMirror h_a = Kokkos::create_mirror_view(a);
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
     ScalarA randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(b_a,rand_pool,randStart,randEnd);
+    Kokkos::fill_random(a, rand_pool, randStart, randEnd);
 
-    Kokkos::deep_copy(h_b_a,b_a);
+    Kokkos::deep_copy(h_a, a);
 
     typename ViewTypeA::const_type c_a = a;
     double eps = std::is_same<ScalarA,float>::value?2*1e-5:1e-7;

--- a/unit_test/blas/Test_Blas1_nrminf.hpp
+++ b/unit_test/blas/Test_Blas1_nrminf.hpp
@@ -12,9 +12,7 @@ namespace Test {
     typedef Kokkos::Details::ArithTraits<ScalarA> AT;
 
     typedef Kokkos::View<ScalarA*[2],
-       typename std::conditional<
-                std::is_same<typename ViewTypeA::array_layout,Kokkos::LayoutStride>::value,
-                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,Device> BaseTypeA;
+       typename ViewTypeA::array_layout,Device> BaseTypeA;
 
 
     BaseTypeA b_a("A",N);

--- a/unit_test/blas/Test_Blas1_scal.hpp
+++ b/unit_test/blas/Test_Blas1_scal.hpp
@@ -8,63 +8,51 @@
 namespace Test {
   template<class ViewTypeA, class ViewTypeB, class Device>
   void impl_test_scal(int N) {
+  typedef typename ViewTypeA::value_type ScalarA;
+  typedef typename ViewTypeB::value_type ScalarB;
+  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
 
-    typedef typename ViewTypeA::value_type ScalarA;
-    typedef typename ViewTypeB::value_type ScalarB;
-    typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  ScalarA a(3);
+  typename AT::mag_type eps = AT::epsilon() * 1000;
 
-    typedef Kokkos::View<ScalarA*[2],
-       typename ViewTypeA::array_layout,Device> BaseTypeA;
-    typedef Kokkos::View<ScalarB*[2],
-       typename ViewTypeB::array_layout,Device> BaseTypeB;
+  ViewTypeA x("X", N);
+  ViewTypeB y("Y", N);
+  ViewTypeB org_y("Org_Y", N);
 
+  typename ViewTypeA::const_type c_x = x;
+  typename ViewTypeB::const_type c_y = y;
 
-    ScalarA a(3);
-    typename AT::mag_type eps = AT::epsilon()*1000;
+  typename ViewTypeA::HostMirror h_x = Kokkos::create_mirror_view(x);
+  typename ViewTypeB::HostMirror h_y = Kokkos::create_mirror_view(y);
 
-    BaseTypeA b_x("X",N);
-    BaseTypeB b_y("Y",N);
-    BaseTypeB b_org_y("Org_Y",N);
+  Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
+      13718);
 
-    ViewTypeA x = Kokkos::subview(b_x,Kokkos::ALL(),0);
-    ViewTypeB y = Kokkos::subview(b_y,Kokkos::ALL(),0);
-    typename ViewTypeA::const_type c_x = x;
-    typename ViewTypeB::const_type c_y = y;
+  {
+    ScalarA randStart, randEnd;
+    Test::getRandomBounds(1.0, randStart, randEnd);
+    Kokkos::fill_random(x, rand_pool, randStart, randEnd);
+  }
+  {
+    ScalarB randStart, randEnd;
+    Test::getRandomBounds(1.0, randStart, randEnd);
+    Kokkos::fill_random(y, rand_pool, randStart, randEnd);
+  }
 
-    typename BaseTypeA::HostMirror h_b_x = Kokkos::create_mirror_view(b_x);
-    typename BaseTypeB::HostMirror h_b_y = Kokkos::create_mirror_view(b_y);
+  Kokkos::deep_copy(org_y, y);
 
-    typename ViewTypeA::HostMirror h_x = Kokkos::subview(h_b_x,Kokkos::ALL(),0);
-    typename ViewTypeB::HostMirror h_y = Kokkos::subview(h_b_y,Kokkos::ALL(),0);
+  Kokkos::deep_copy(h_x, x);
 
-    Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
-
-    {
-      ScalarA randStart, randEnd;
-      Test::getRandomBounds(1.0, randStart, randEnd);
-      Kokkos::fill_random(b_x,rand_pool,randStart,randEnd);
-    }
-    {
-      ScalarB randStart, randEnd;
-      Test::getRandomBounds(1.0, randStart, randEnd);
-      Kokkos::fill_random(b_y,rand_pool,randStart,randEnd);
-    }
-
-    Kokkos::deep_copy(b_org_y,b_y);
-
-    Kokkos::deep_copy(h_b_x,b_x);
-    Kokkos::deep_copy(h_b_y,b_y);
-
-    KokkosBlas::scal(y,a,x);
-    Kokkos::deep_copy(h_b_y, b_y);
-    for(int i = 0; i < N; i++)
+  KokkosBlas::scal(y, a, x);
+  Kokkos::deep_copy(h_y, y);
+  for(int i = 0; i < N; i++)
     {
       EXPECT_NEAR_KK(a * h_x(i), h_y(i), eps);
     }
 
-    Kokkos::deep_copy(b_y,b_org_y);
-    KokkosBlas::scal(y,a,c_x);
-    Kokkos::deep_copy(h_b_y, b_y);
+    Kokkos::deep_copy(y, org_y);
+    KokkosBlas::scal(y, a, c_x);
+    Kokkos::deep_copy(h_y, y);
     for(int i = 0; i < N; i++)
     {
       EXPECT_NEAR_KK(a * h_x(i), h_y(i), eps);

--- a/unit_test/blas/Test_Blas1_scal.hpp
+++ b/unit_test/blas/Test_Blas1_scal.hpp
@@ -14,13 +14,9 @@ namespace Test {
     typedef Kokkos::Details::ArithTraits<ScalarA> AT;
 
     typedef Kokkos::View<ScalarA*[2],
-       typename std::conditional<
-                std::is_same<typename ViewTypeA::array_layout,Kokkos::LayoutStride>::value,
-                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,Device> BaseTypeA;
+       typename ViewTypeA::array_layout,Device> BaseTypeA;
     typedef Kokkos::View<ScalarB*[2],
-       typename std::conditional<
-                std::is_same<typename ViewTypeB::array_layout,Kokkos::LayoutStride>::value,
-                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,Device> BaseTypeB;
+       typename ViewTypeB::array_layout,Device> BaseTypeB;
 
 
     ScalarA a(3);
@@ -65,7 +61,7 @@ namespace Test {
     {
       EXPECT_NEAR_KK(a * h_x(i), h_y(i), eps);
     }
- 
+
     Kokkos::deep_copy(b_y,b_org_y);
     KokkosBlas::scal(y,a,c_x);
     Kokkos::deep_copy(h_b_y, b_y);
@@ -261,12 +257,12 @@ int test_scal_mv() {
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, scal_float ) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_float"); 
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_float");
     test_scal<float,float,TestExecSpace> ();
   Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, scal_mv_float ) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_mv_float"); 
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_mv_float");
     test_scal_mv<float,float,TestExecSpace> ();
   Kokkos::Profiling::popRegion();
 }
@@ -274,12 +270,12 @@ TEST_F( TestCategory, scal_mv_float ) {
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, scal_double ) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_double"); 
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_double");
     test_scal<double,double,TestExecSpace> ();
   Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, scal_mv_double ) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_mv_double"); 
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_mv_double");
     test_scal_mv<double,double,TestExecSpace> ();
   Kokkos::Profiling::popRegion();
 }
@@ -287,12 +283,12 @@ TEST_F( TestCategory, scal_mv_double ) {
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, scal_complex_double ) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_complex_double"); 
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_complex_double");
     test_scal<Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ();
   Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, scal_mv_complex_double ) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_mv_complex_double"); 
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_mv_complex_double");
     test_scal_mv<Kokkos::complex<double>,Kokkos::complex<double>,TestExecSpace> ();
   Kokkos::Profiling::popRegion();
 }
@@ -300,12 +296,12 @@ TEST_F( TestCategory, scal_mv_complex_double ) {
 
 #if defined(KOKKOSKERNELS_INST_INT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, scal_int ) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_int"); 
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_int");
     test_scal<int,int,TestExecSpace> ();
   Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, scal_mv_int ) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_mv_int"); 
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_mv_int");
     test_scal_mv<int,int,TestExecSpace> ();
   Kokkos::Profiling::popRegion();
 }
@@ -313,12 +309,12 @@ TEST_F( TestCategory, scal_mv_int ) {
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
 TEST_F( TestCategory, scal_double_int ) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_double_int"); 
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_double_int");
     test_scal<double,int,TestExecSpace> ();
   Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, scal_mv_double_int ) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_mv_double_int"); 
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::scal_mv_double_int");
     test_scal_mv<double,int,TestExecSpace> ();
   Kokkos::Profiling::popRegion();
 }

--- a/unit_test/blas/Test_Blas1_sum.hpp
+++ b/unit_test/blas/Test_Blas1_sum.hpp
@@ -10,25 +10,17 @@ namespace Test {
 
     typedef typename ViewTypeA::value_type ScalarA;
 
-    typedef Kokkos::View<ScalarA*[2],
-       typename ViewTypeA::array_layout,Device> BaseTypeA;
+    ViewTypeA a("A", N);
 
-
-    BaseTypeA b_a("A",N);
-
-    ViewTypeA a = Kokkos::subview(b_a,Kokkos::ALL(),0);
-
-    typename BaseTypeA::HostMirror h_b_a = Kokkos::create_mirror_view(b_a);
-
-    typename ViewTypeA::HostMirror h_a = Kokkos::subview(h_b_a,Kokkos::ALL(),0);
+    typename ViewTypeA::HostMirror h_a = Kokkos::create_mirror_view(a);
 
     Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
     ScalarA randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(b_a,rand_pool,randStart,randEnd);
+    Kokkos::fill_random(a, rand_pool, randStart, randEnd);
 
-    Kokkos::deep_copy(h_b_a,b_a);
+    Kokkos::deep_copy(h_a, a);
 
     typename ViewTypeA::const_type c_a = a;
     double eps = std::is_same<ScalarA,float>::value?2*1e-5:1e-7;

--- a/unit_test/blas/Test_Blas1_sum.hpp
+++ b/unit_test/blas/Test_Blas1_sum.hpp
@@ -11,9 +11,7 @@ namespace Test {
     typedef typename ViewTypeA::value_type ScalarA;
 
     typedef Kokkos::View<ScalarA*[2],
-       typename std::conditional<
-                std::is_same<typename ViewTypeA::array_layout,Kokkos::LayoutStride>::value,
-                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,Device> BaseTypeA;
+       typename ViewTypeA::array_layout,Device> BaseTypeA;
 
 
     BaseTypeA b_a("A",N);
@@ -163,12 +161,12 @@ int test_sum_mv() {
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, sum_float ) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_float"); 
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_float");
     test_sum<float,TestExecSpace> ();
   Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, sum_mv_float ) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_mv_float"); 
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_mv_float");
     test_sum_mv<float,TestExecSpace> ();
   Kokkos::Profiling::popRegion();
 }
@@ -176,12 +174,12 @@ TEST_F( TestCategory, sum_mv_float ) {
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, sum_double ) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_double"); 
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_double");
     test_sum<double,TestExecSpace> ();
   Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, sum_mv_double ) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_mv_double"); 
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_mv_double");
     test_sum_mv<double,TestExecSpace> ();
   Kokkos::Profiling::popRegion();
 }
@@ -189,12 +187,12 @@ TEST_F( TestCategory, sum_mv_double ) {
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, sum_complex_double ) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_complex_double"); 
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_complex_double");
     test_sum<Kokkos::complex<double>,TestExecSpace> ();
   Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, sum_mv_complex_double ) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_mv_complex_double"); 
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_mv_complex_double");
     test_sum_mv<Kokkos::complex<double>,TestExecSpace> ();
   Kokkos::Profiling::popRegion();
 }
@@ -202,12 +200,12 @@ TEST_F( TestCategory, sum_mv_complex_double ) {
 
 #if defined(KOKKOSKERNELS_INST_INT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F( TestCategory, sum_int ) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_int"); 
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_int");
     test_sum<int,TestExecSpace> ();
   Kokkos::Profiling::popRegion();
 }
 TEST_F( TestCategory, sum_mv_int ) {
-  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_mv_int"); 
+  Kokkos::Profiling::pushRegion("KokkosBlas::Test::sum_mv_int");
     test_sum_mv<int,TestExecSpace> ();
   Kokkos::Profiling::popRegion();
 }

--- a/unit_test/blas/Test_Blas2_gemv.hpp
+++ b/unit_test/blas/Test_Blas2_gemv.hpp
@@ -15,15 +15,6 @@ namespace Test {
     typedef Kokkos::ArithTraits<ScalarY> KAT_Y;
 
     typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-    typedef Kokkos::View<ScalarX*[2],
-       typename std::conditional<
-                std::is_same<typename ViewTypeX::array_layout,Kokkos::LayoutStride>::value,
-                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,Device> BaseTypeX;
-    typedef Kokkos::View<ScalarY*[2],
-       typename std::conditional<
-                std::is_same<typename ViewTypeY::array_layout,Kokkos::LayoutStride>::value,
-                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,Device> BaseTypeY;
-
 
     ScalarA alpha = 3;
     ScalarY beta = 5;
@@ -31,7 +22,7 @@ namespace Test {
 
     int ldx;
     int ldy;
-    if(mode[0]=='N') {
+    if (mode[0] == 'N') {
       ldx = N;
       ldy = M;
     } else {
@@ -39,80 +30,80 @@ namespace Test {
       ldy = N;
     }
     typename vfA_type::BaseType b_A("A", M, N);
-    BaseTypeX b_x("X", ldx);
-    BaseTypeY b_y("Y", ldy);
-    BaseTypeY b_org_y("Org_Y", ldy);
-    
-    ViewTypeA A = vfA_type::view(b_A);
-    ViewTypeX x = Kokkos::subview(b_x,Kokkos::ALL(),0);
-    ViewTypeY y = Kokkos::subview(b_y,Kokkos::ALL(),0);
+    ViewTypeX x("X", ldx);
+    ViewTypeY y("Y", ldy);
+    ViewTypeY org_y("Org_Y", ldy);
+
+    ViewTypeA A                        = vfA_type::view(b_A);
     typename ViewTypeX::const_type c_x = x;
     typename ViewTypeA::const_type c_A = A;
 
-    typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
+    typedef multivector_layout_adapter<typename ViewTypeA::HostMirror>
+        h_vfA_type;
 
     typename h_vfA_type::BaseType h_b_A = Kokkos::create_mirror_view(b_A);
-    typename BaseTypeX::HostMirror h_b_x = Kokkos::create_mirror_view(b_x);
-    typename BaseTypeY::HostMirror h_b_y = Kokkos::create_mirror_view(b_y);
 
     typename ViewTypeA::HostMirror h_A = h_vfA_type::view(h_b_A);
-    typename ViewTypeX::HostMirror h_x = Kokkos::subview(h_b_x,Kokkos::ALL(),0);
-    typename ViewTypeY::HostMirror h_y = Kokkos::subview(h_b_y,Kokkos::ALL(),0);
+    typename ViewTypeX::HostMirror h_x = Kokkos::create_mirror_view(x);
+    typename ViewTypeY::HostMirror h_y = Kokkos::create_mirror_view(y);
 
-    Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
+    Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
+        13718);
 
     {
       ScalarX randStart, randEnd;
       Test::getRandomBounds(10.0, randStart, randEnd);
-      Kokkos::fill_random(b_x,rand_pool,randStart,randEnd);
+      Kokkos::fill_random(x, rand_pool, randStart, randEnd);
     }
     {
       ScalarY randStart, randEnd;
       Test::getRandomBounds(10.0, randStart, randEnd);
-      Kokkos::fill_random(b_y,rand_pool,randStart,randEnd);
+      Kokkos::fill_random(y, rand_pool, randStart, randEnd);
     }
     {
       ScalarA randStart, randEnd;
       Test::getRandomBounds(10.0, randStart, randEnd);
-      Kokkos::fill_random(b_A,rand_pool,randStart,randEnd);
+      Kokkos::fill_random(b_A, rand_pool, randStart, randEnd);
     }
 
-    Kokkos::deep_copy(b_org_y,b_y);
-    auto h_b_org_y = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_org_y);
-    auto h_org_y = Kokkos::subview(h_b_org_y, Kokkos::ALL(), 0);
+    Kokkos::deep_copy(org_y, y);
+    auto h_org_y =
+        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), org_y);
 
-    Kokkos::deep_copy(h_b_x,b_x);
-    Kokkos::deep_copy(h_b_y,b_y);
-    Kokkos::deep_copy(h_b_A,b_A);
+    Kokkos::deep_copy(h_x, x);
+    Kokkos::deep_copy(h_y, y);
+    Kokkos::deep_copy(h_b_A, b_A);
 
     Kokkos::View<ScalarY*, Kokkos::HostSpace> expected("expected aAx+by", ldy);
     Kokkos::deep_copy(expected, h_org_y);
     vanillaGEMV(mode[0], alpha, h_A, h_x, beta, expected);
 
     KokkosBlas::gemv(mode, alpha, A, x, beta, y);
-    Kokkos::deep_copy(h_b_y, b_y);
+    Kokkos::deep_copy(h_y, y);
     int numErrors = 0;
-    for(int i = 0; i < ldy; i++)
-    {
-      if(KAT_Y::abs(expected(i) - h_y(i)) > KAT_Y::abs(eps * expected(i)))
+    for (int i = 0; i < ldy; i++) {
+      if (KAT_Y::abs(expected(i) - h_y(i)) > KAT_Y::abs(eps * expected(i)))
         numErrors++;
     }
-    EXPECT_EQ(numErrors, 0) << "Nonconst input, " << M << 'x' << N << ", alpha = " << alpha << ", beta = " << beta << ", mode " << mode << ": gemv incorrect";
- 
-    Kokkos::deep_copy(b_y, b_org_y);
-    KokkosBlas::gemv(mode, alpha,A ,c_x, beta, y);
-    Kokkos::deep_copy(h_b_y, b_y);
-    numErrors = 0;
-    for(int i = 0; i < ldy; i++)
-    {
-      if(KAT_Y::abs(expected(i) - h_y(i)) > KAT_Y::abs(eps * expected(i)))
-        numErrors++;
-    }
-    EXPECT_EQ(numErrors, 0) << "Const vector input, " << M << 'x' << N << ", alpha = " << alpha << ", beta = " << beta << ", mode " << mode << ": gemv incorrect";
+    EXPECT_EQ(numErrors, 0)
+        << "Nonconst input, " << M << 'x' << N << ", alpha = " << alpha
+        << ", beta = " << beta << ", mode " << mode << ": gemv incorrect";
 
-    Kokkos::deep_copy(b_y, b_org_y);
+    Kokkos::deep_copy(y, org_y);
+    KokkosBlas::gemv(mode, alpha, A, c_x, beta, y);
+    Kokkos::deep_copy(h_y, y);
+    numErrors = 0;
+    for (int i = 0; i < ldy; i++) {
+      if (KAT_Y::abs(expected(i) - h_y(i)) > KAT_Y::abs(eps * expected(i)))
+        numErrors++;
+    }
+    EXPECT_EQ(numErrors, 0)
+        << "Const vector input, " << M << 'x' << N << ", alpha = " << alpha
+        << ", beta = " << beta << ", mode " << mode << ": gemv incorrect";
+
+    Kokkos::deep_copy(y, org_y);
     KokkosBlas::gemv(mode, alpha, c_A, c_x, beta, y);
-    Kokkos::deep_copy(h_b_y, b_y);
+    Kokkos::deep_copy(h_y, y);
     numErrors = 0;
     for(int i = 0; i < ldy; i++)
     {
@@ -125,9 +116,9 @@ namespace Test {
     beta = KAT_Y::zero();
     //beta changed, so update the correct answer
     vanillaGEMV(mode[0], alpha, h_A, h_x, beta, expected);
-    Kokkos::deep_copy(b_y, KAT_Y::nan());
+    Kokkos::deep_copy(y, KAT_Y::nan());
     KokkosBlas::gemv(mode, alpha, A, x, beta, y);
-    Kokkos::deep_copy(h_b_y, b_y);
+    Kokkos::deep_copy(h_y, y);
     numErrors = 0;
     for(int i = 0; i < ldy; i++)
     {

--- a/unit_test/blas/Test_Blas_gesv.hpp
+++ b/unit_test/blas/Test_Blas_gesv.hpp
@@ -44,7 +44,7 @@ void impl_test_gesv(const char* mode, const char* padding, int N) {
     // Create host mirrors of device views.
     typename ViewTypeB::HostMirror h_X0 = Kokkos::create_mirror_view(X0);
     typename ViewTypeB::HostMirror h_B  = Kokkos::create_mirror(B);
-    
+
     // Initialize data.
     Kokkos::fill_random(A, rand_pool,Kokkos::rand<Kokkos::Random_XorShift64<execution_space>,ScalarA >::max());
     Kokkos::fill_random(X0,rand_pool,Kokkos::rand<Kokkos::Random_XorShift64<execution_space>,ScalarA >::max());
@@ -69,14 +69,14 @@ void impl_test_gesv(const char* mode, const char* padding, int N) {
         magma_imalloc_cpu( &ipiv_raw, Nt );
       }
       ViewTypeP ipiv(ipiv_raw, Nt);
-	  
+
       // Solve.
       KokkosBlas::gesv(A,B,ipiv);
       Kokkos::fence();
-      
+
       // Get the solution vector.
       Kokkos::deep_copy( h_B, B );
-      
+
       // Checking vs ref on CPU, this eps is about 10^-9
       typedef typename ats::mag_type mag_type;
       const mag_type eps = 1.0e7 * ats::epsilon();
@@ -84,10 +84,10 @@ void impl_test_gesv(const char* mode, const char* padding, int N) {
       for (int i=0; i<N; i++) {
         if ( ats::abs(h_B(i) - h_X0(i)) > eps ) {
           test_flag = false;
-          //printf( "    Error %d, pivot %c, padding %c: result( %.15lf ) != solution( %.15lf ) at (%ld)\n", N, mode[0], padding[0], ats::abs(h_B(i)), ats::abs(h_X0(i)), i );		
+          //printf( "    Error %d, pivot %c, padding %c: result( %.15lf ) != solution( %.15lf ) at (%ld)\n", N, mode[0], padding[0], ats::abs(h_B(i)), ats::abs(h_X0(i)), i );
           break;
         }
-      }	
+      }
       ASSERT_EQ( test_flag, true );
 
       if(mode[0]=='Y') {
@@ -100,7 +100,7 @@ void impl_test_gesv(const char* mode, const char* padding, int N) {
     int Nt = 0;
     if(mode[0]=='Y') Nt = N;
     ViewTypeP ipiv("IPIV", Nt);
-	
+
     // Solve.
     KokkosBlas::gesv(A,B,ipiv);
     Kokkos::fence();
@@ -115,10 +115,10 @@ void impl_test_gesv(const char* mode, const char* padding, int N) {
     for (int i=0; i<N; i++) {
       if ( ats::abs(h_B(i) - h_X0(i)) > eps ) {
         test_flag = false;
-        //printf( "    Error %d, pivot %c, padding %c: result( %.15lf ) != solution( %.15lf ) at (%ld)\n", N, mode[0], padding[0], ats::abs(h_B(i)), ats::abs(h_X0(i)), i );		
+        //printf( "    Error %d, pivot %c, padding %c: result( %.15lf ) != solution( %.15lf ) at (%ld)\n", N, mode[0], padding[0], ats::abs(h_B(i)), ats::abs(h_X0(i)), i );
         break;
       }
-    }	
+    }
     ASSERT_EQ( test_flag, true );
 #endif
 
@@ -133,7 +133,7 @@ void impl_test_gesv_mrhs(const char* mode, const char* padding, int N, int nrhs)
     Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
     int ldda, lddb;
-	
+
     if(padding[0]=='Y') {//rounded up to multiple of 32
       ldda = ((N+32-1)/32)*32;
       lddb = ldda;
@@ -151,7 +151,7 @@ void impl_test_gesv_mrhs(const char* mode, const char* padding, int N, int nrhs)
     // Create host mirrors of device views.
     typename ViewTypeB::HostMirror h_X0 = Kokkos::create_mirror_view( X0 );
     typename ViewTypeB::HostMirror h_B  = Kokkos::create_mirror( B );
-    
+
     // Initialize data.
     Kokkos::fill_random(A, rand_pool,Kokkos::rand<Kokkos::Random_XorShift64<execution_space>,ScalarA >::max());
     Kokkos::fill_random(X0,rand_pool,Kokkos::rand<Kokkos::Random_XorShift64<execution_space>,ScalarA >::max());
@@ -176,14 +176,14 @@ void impl_test_gesv_mrhs(const char* mode, const char* padding, int N, int nrhs)
         magma_imalloc_cpu( &ipiv_raw, Nt );
       }
       ViewTypeP ipiv(ipiv_raw, Nt);
-      
-      // Solve.	
+
+      // Solve.
       KokkosBlas::gesv(A,B,ipiv);
       Kokkos::fence();
-      
+
       // Get the solution vector.
       Kokkos::deep_copy( h_B, B );
-      
+
       // Checking vs ref on CPU, this eps is about 10^-9
       typedef typename ats::mag_type mag_type;
       const mag_type eps = 1.0e7 * ats::epsilon();
@@ -192,7 +192,7 @@ void impl_test_gesv_mrhs(const char* mode, const char* padding, int N, int nrhs)
         for (int i=0; i<N; i++) {
           if ( ats::abs(h_B(i,j) - h_X0(i,j)) > eps ) {
             test_flag = false;
-            //printf( "    Error %d, pivot %c, padding %c: result( %.15lf ) != solution( %.15lf ) at (%ld) at rhs %d\n", N, mode[0], padding[0], ats::abs(h_B(i,j)), ats::abs(h_X0(i,j)), i, j );		
+            //printf( "    Error %d, pivot %c, padding %c: result( %.15lf ) != solution( %.15lf ) at (%ld) at rhs %d\n", N, mode[0], padding[0], ats::abs(h_B(i,j)), ats::abs(h_X0(i,j)), i, j );
             break;
           }
         }
@@ -211,7 +211,7 @@ void impl_test_gesv_mrhs(const char* mode, const char* padding, int N, int nrhs)
     if(mode[0]=='Y') Nt = N;
     ViewTypeP ipiv("IPIV", Nt);
 
-    // Solve.	
+    // Solve.
     KokkosBlas::gesv(A,B,ipiv);
     Kokkos::fence();
 
@@ -226,7 +226,7 @@ void impl_test_gesv_mrhs(const char* mode, const char* padding, int N, int nrhs)
       for (int i=0; i<N; i++) {
         if ( ats::abs(h_B(i,j) - h_X0(i,j)) > eps ) {
           test_flag = false;
-          //printf( "    Error %d, pivot %c, padding %c: result( %.15lf ) != solution( %.15lf ) at (%ld) at rhs %d\n", N, mode[0], padding[0], ats::abs(h_B(i,j)), ats::abs(h_X0(i,j)), i, j );		
+          //printf( "    Error %d, pivot %c, padding %c: result( %.15lf ) != solution( %.15lf ) at (%ld) at rhs %d\n", N, mode[0], padding[0], ats::abs(h_B(i,j)), ats::abs(h_X0(i,j)), i, j );
           break;
         }
       }
@@ -267,7 +267,8 @@ int test_gesv(const char* mode) {
   Test::impl_test_gesv<view_type_a_lr, view_type_b_lr, Device>(&mode[0], "Y", 179); //padding
 #endif
 */
-
+  // Supress unused parameters on CUDA10
+  (void)mode;
   return 1;
 }
 
@@ -299,7 +300,8 @@ int test_gesv_mrhs(const char* mode) {
   Test::impl_test_gesv_mrhs<view_type_a_lr, view_type_b_lr, Device>(&mode[0], "Y", 179, 5);//padding
 #endif
 */
-
+  // Supress unused parameters on CUDA10
+  (void)mode;
   return 1;
 }
 

--- a/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
@@ -255,7 +255,7 @@ void test_block_gauss_seidel_rank1(lno_t numRows, size_type nnz, lno_t bandwidth
 
     bool is_symmetric_graph = true;
     size_t shmem_size = 32128;
-    
+
     for(int i = 0; i < 2; ++i)
     {
       if (i == 1) shmem_size = 2008; //make the shmem small on gpus so that it will test 2 level algorithm.
@@ -292,7 +292,7 @@ void test_block_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth
   typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
   typedef typename crsMat_t::StaticCrsGraphType::row_map_type::non_const_type lno_view_t;
   typedef typename crsMat_t::StaticCrsGraphType::entries_type::non_const_type lno_nnz_view_t;
-  typedef Kokkos::View<scalar_t**, Kokkos::LayoutLeft, device> scalar_view2d_t;
+  typedef Kokkos::View<scalar_t**, default_layout, device> scalar_view2d_t;
   typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;
 
   lno_t numCols = numRows;
@@ -378,7 +378,7 @@ void test_block_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth
 
     scalar_view_t res_norms("Residuals", numVecs);
     auto h_res_norms = Kokkos::create_mirror_view(res_norms);
-    
+
     for(int i = 0; i < 2; ++i)
     {
       if (i == 1) shmem_size = 2008; //make the shmem small on gpus so that it will test 2 level algorithm.

--- a/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
@@ -87,7 +87,7 @@ int run_gauss_seidel(
     int apply_type = 0, // 0 for symmetric, 1 for forward, 2 for backward.
     int cluster_size = 1,
     bool classic = false, // only with two-stage, true for sptrsv instead of richardson
-    ClusteringAlgorithm clusterAlgo = CLUSTER_DEFAULT) 
+    ClusteringAlgorithm clusterAlgo = CLUSTER_DEFAULT)
 {
   typedef typename crsMat_t::StaticCrsGraphType graph_t;
   typedef typename graph_t::row_map_type lno_view_t;
@@ -221,7 +221,7 @@ crsMat_t symmetrize(crsMat_t A)
     }
   }
   //Count entries
-  Kokkos::View<size_type*, Kokkos::LayoutLeft, Kokkos::HostSpace> new_host_rowmap("Rowmap", numRows + 1);
+  Kokkos::View<size_type*, default_layout, Kokkos::HostSpace> new_host_rowmap("Rowmap", numRows + 1);
   size_t accum = 0;
   for(lno_t r = 0; r <= numRows; r++)
   {
@@ -230,8 +230,8 @@ crsMat_t symmetrize(crsMat_t A)
       accum += symRows[r].size();
   }
   //Allocate new entries/values
-  Kokkos::View<lno_t*, Kokkos::LayoutLeft, Kokkos::HostSpace> new_host_entries("Entries", accum);
-  Kokkos::View<scalar_t*, Kokkos::LayoutLeft, Kokkos::HostSpace> new_host_values("Values", accum);
+  Kokkos::View<lno_t*, default_layout, Kokkos::HostSpace> new_host_entries("Entries", accum);
+  Kokkos::View<scalar_t*, default_layout, Kokkos::HostSpace> new_host_values("Values", accum);
   for(lno_t r = 0; r < numRows; r++)
   {
     auto rowIt = symRows[r].begin();
@@ -338,8 +338,8 @@ void test_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth, lno_
   using namespace Test;
   srand(245);
   typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type> crsMat_t;
-  typedef Kokkos::View<scalar_t**, Kokkos::LayoutLeft, device> scalar_view2d_t;
-  typedef Kokkos::View<scalar_t**, Kokkos::LayoutLeft, Kokkos::HostSpace> host_scalar_view2d_t;
+  typedef Kokkos::View<scalar_t**, default_layout, device> scalar_view2d_t;
+  typedef Kokkos::View<scalar_t**, default_layout, Kokkos::HostSpace> host_scalar_view2d_t;
   typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;
 
   lno_t numCols = numRows;

--- a/unit_test/sparse/Test_Sparse_spmv.hpp
+++ b/unit_test/sparse/Test_Sparse_spmv.hpp
@@ -9,6 +9,7 @@
 #include<KokkosKernels_Utils.hpp>
 
 #include "KokkosKernels_Controls.hpp"
+#include "KokkosKernels_default_types.hpp"
 
 // #ifndef kokkos_complex_double
 // #define kokkos_complex_double Kokkos::complex<double>
@@ -778,9 +779,9 @@ void test_github_issue_101 ()
   // vectors.  Include a little extra in case the implementers decide
   // to strip-mine that.
   constexpr int numVecs = 22;
-  Kokkos::View<double**, Kokkos::LayoutLeft, DeviceType> X ("X", numCols, numVecs);
+  Kokkos::View<double**, default_layout, DeviceType> X ("X", numCols, numVecs);
   Kokkos::deep_copy (X, static_cast<double> (1.0));
-  Kokkos::View<double**, Kokkos::LayoutLeft, DeviceType> Y ("Y", numRows, numVecs);
+  Kokkos::View<double**, default_layout, DeviceType> Y ("Y", numRows, numVecs);
   auto Y_h = Kokkos::create_mirror_view (Y); // we'll want this later
 
   // Start with the easy test case, where the matrix and the vectors
@@ -1043,7 +1044,7 @@ TEST_F( TestCategory,sparse ## _ ## spmv_mv_struct ## _ ## SCALAR ## _ ## ORDINA
 #endif
 
 
-
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
 #if (defined (KOKKOSKERNELS_INST_DOUBLE) \
  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) && defined(KOKKOSKERNELS_INST_LAYOUTLEFT) \
  && defined (KOKKOSKERNELS_INST_OFFSET_INT)) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -1156,7 +1157,7 @@ TEST_F( TestCategory,sparse ## _ ## spmv_mv_struct ## _ ## SCALAR ## _ ## ORDINA
  EXECUTE_TEST_MV(kokkos_complex_float, int64_t, size_t, LayoutLeft, TestExecSpace)
  EXECUTE_TEST_MV_STRUCT(kokkos_complex_float, int64_t, size_t, LayoutLeft, TestExecSpace)
 #endif
-
+#endif // defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
 
 
 


### PR DESCRIPTION
## Bug Fixes
- The C++ code changes are so that we can build without configuring with `KokkosKernels_INST_LAYOUTLEFT:BOOL=ON`. (Fixes #903)
- Blas and sparse unit tests. (Fixes #973)
- Cublas gemv bug. (Fixes #974)
- Hostblas gemv bug. (Fixes #975)

## New Features
- Two new LayoutRight projects in the auto-tester.
- The script changes allow us to run `cm_test_all` with `--no-default-eti` so that the build system does not default `KokkosKernels_INST_LAYOUTLEFT` to on. (Fixes #916)

The new LayoutRight projects will still enable LayoutLeft for other PRs until this PR is merged. This PR will be tested with LayoutLeft disabled.

