### PR TITLE
HIP: enabling all unit tests

### DIFF
--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -145,29 +145,29 @@ IF (KOKKOS_ENABLE_HIP)
     COMPONENTS blas
   )
 
-  # KOKKOSKERNELS_ADD_UNIT_TEST(
-  #   batched_dla_hip
-  #   SOURCES
-  #     Test_Main.cpp
-  #     hip/Test_HIP_Batched.cpp
-  #   COMPONENTS batched
-  # )
+  KOKKOSKERNELS_ADD_UNIT_TEST(
+    batched_dla_hip
+    SOURCES
+      Test_Main.cpp
+      hip/Test_HIP_Batched.cpp
+    COMPONENTS batched
+  )
 
-  # KOKKOSKERNELS_ADD_UNIT_TEST(
-  #   sparse_hip
-  #   SOURCES
-  #     Test_Main.cpp
-  #     hip/Test_HIP_Sparse.cpp
-  #   COMPONENTS sparse
-  # )
+  KOKKOSKERNELS_ADD_UNIT_TEST(
+    sparse_hip
+    SOURCES
+      Test_Main.cpp
+      hip/Test_HIP_Sparse.cpp
+    COMPONENTS sparse
+  )
 
-  # KOKKOSKERNELS_ADD_UNIT_TEST(
-  #   graph_hip
-  #   SOURCES
-  #     Test_Main.cpp
-  #     hip/Test_HIP_Graph.cpp
-  #   COMPONENTS graph
-  # )
+  KOKKOSKERNELS_ADD_UNIT_TEST(
+    graph_hip
+    SOURCES
+      Test_Main.cpp
+      hip/Test_HIP_Graph.cpp
+    COMPONENTS graph
+  )
   
   KOKKOSKERNELS_ADD_UNIT_TEST(
     common_hip


### PR DESCRIPTION
All unit-tests can now be enabled, compiled and run correctly on AMD platform using the latest compiler toolchain.
Turning this on will allow for more testing at integration and in Trilinos too.