### PR TITLE
Fix build for no-ETI build

### DIFF
--- a/perf_test/graph/KokkosGraph_color_d2.cpp
+++ b/perf_test/graph/KokkosGraph_color_d2.cpp
@@ -101,29 +101,9 @@ struct D2Parameters
   }
 };
 
-#ifdef KOKKOSKERNELS_INST_DOUBLE
-    typedef double kk_scalar_t;
-#else
-    #ifdef KOKKOSKERNELS_INST_FLOAT
-        typedef float kk_scalar_t;
-    #endif
-#endif
-
-#ifdef KOKKOSKERNELS_INST_OFFSET_INT
-    typedef int kk_size_type;
-#else
-    #ifdef KOKKOSKERNELS_INST_OFFSET_SIZE_T
-        typedef size_t kk_size_type;
-    #endif
-#endif
-
-#ifdef KOKKOSKERNELS_INST_ORDINAL_INT
-    typedef int kk_lno_t;
-#else
-    #ifdef KOKKOSKERNELS_INST_ORDINAL_INT64_T
-        typedef int64_t kk_lno_t;
-    #endif
-#endif
+typedef default_scalar kk_scalar_t;
+typedef default_size_type kk_size_type;
+typedef default_lno_t kk_lno_t;
 
 using namespace KokkosGraph;
 

--- a/perf_test/graph/KokkosGraph_color_d2.cpp
+++ b/perf_test/graph/KokkosGraph_color_d2.cpp
@@ -63,6 +63,7 @@
 #include "KokkosSparse_CrsMatrix.hpp"
 #include <KokkosKernels_TestParameters.hpp>
 #include <KokkosGraph_Distance2Color.hpp>
+#include "KokkosKernels_default_types.hpp"
 
 using namespace KokkosGraph;
 

--- a/src/common/KokkosKernels_default_types.hpp
+++ b/src/common/KokkosKernels_default_types.hpp
@@ -53,7 +53,7 @@
 #elif defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T)
   using default_lno_t = int64_t;
 #else
-  #error "Expect INT and/or INT64_T to be enabled as ORDINAL (lno_t) types"
+  using default_lno_t = int;
 #endif
   //Prefer int as the default offset type, because cuSPARSE doesn't support size_t for rowptrs.
 #if defined(KOKKOSKERNELS_INST_OFFSET_INT)
@@ -61,7 +61,7 @@
 #elif defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)
   using default_size_type = size_t;
 #else
-  #error "Expect SIZE_T and/or INT to be enabled as OFFSET (size_type) types"
+  using default_size_type = int;
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
@@ -69,7 +69,7 @@
 #elif defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
   using default_layout = Kokkos::LayoutRight;
 #else
-  #error "Expect LAYOUTLEFT and/or LAYOUTRIGHT to be enabled as layout types"
+  using default_layout = Kokkos::LayoutLeft;
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE)
@@ -77,7 +77,7 @@
 #elif defined(KOKKOSKERNELS_INST_FLOAT)
   using default_scalar = float;
 #else
-  #error "Expect at least one real-valued scalar type (double or float) to be enabled"
+  using default_scalar = double;
 #endif
 
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/src/impl/KokkosKernels_helpers.hpp
+++ b/src/impl/KokkosKernels_helpers.hpp
@@ -45,6 +45,7 @@
 #define KOKKOSKERNELS_HELPERS_HPP_
 
 #include "KokkosKernels_config.h"  // KOKKOSKERNELS_INST_LAYOUTLEFT, KOKKOSKERNELS_INST_LAYOUTRIGHT
+#include "KokkosKernels_default_types.hpp"  // default_layout
 
 namespace KokkosKernels {
 namespace Impl {
@@ -61,26 +62,11 @@ struct GetUnifiedLayoutPreferring {
       PreferredLayoutType, typename ViewType::array_layout>::type array_layout;
 };
 
-// If LayoutLeft kernels are pre instantiated, try to unify layout to LayoutLeft
-#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
 template <class ViewType>
 struct GetUnifiedLayout {
   using array_layout =
-      typename GetUnifiedLayoutPreferring<ViewType,
-               Kokkos::LayoutLeft>::array_layout;
+      typename GetUnifiedLayoutPreferring<ViewType, default_layout>::array_layout;
 };
-#else
-// If LayoutLeft kernels are not pre instantiated, try to unify layout to
-// LayoutRight
-#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
-template <class ViewType>
-struct GetUnifiedLayout {
-  using array_layout =
-      typename GetUnifiedLayoutPreferring<ViewType,
-               Kokkos::LayoutRight>::array_layout;
-};
-#endif
-#endif
 
 template <class T, class TX, bool do_const,
           bool isView = Kokkos::is_view<T>::value>


### PR DESCRIPTION
Can build library, examples, perf tests and unit tests with ``--no-default-eti``. Unit tests are all empty since TEST_ETI_ONLY is ON by default, but the everything else is still completely functional. The default types used by examples and perf tests in this build are double/int/int/LayoutLeft.