### PR TITLE
this is a PR for 4005 vs2019build, which fixes a few things on Windows.

### DIFF
--- a/src/common/KokkosKernels_BitUtils.hpp
+++ b/src/common/KokkosKernels_BitUtils.hpp
@@ -46,6 +46,10 @@
 #define _KOKKOSKERNELS_BITUTILS_HPP
 #include "Kokkos_Core.hpp"
 
+#if defined (KOKKOS_COMPILER_MSVC)
+#include <intrin.h>
+#endif
+
 namespace KokkosKernels{
 
 namespace Impl{
@@ -203,6 +207,36 @@ int pop_count( long long i ){
   return __popcnt8(i);
 }
 
+#elif defined (KOKKOS_COMPILER_MSVC)
+KOKKOS_FORCEINLINE_FUNCTION
+int pop_count( unsigned i ){
+    return __popcnt(i);
+}
+KOKKOS_FORCEINLINE_FUNCTION
+int pop_count( unsigned long i ){
+    return __popcnt(i);
+}
+
+KOKKOS_FORCEINLINE_FUNCTION
+int pop_count( unsigned long long i ){
+    return __popcnt64(i);
+}
+
+KOKKOS_FORCEINLINE_FUNCTION
+int pop_count(int i ){
+    return __popcnt(i);
+}
+
+KOKKOS_FORCEINLINE_FUNCTION
+int pop_count( long i ){
+    return __popcnt(i);
+}
+
+KOKKOS_FORCEINLINE_FUNCTION
+int pop_count( long long i ){
+    return __popcnt64(i);
+}
+
 #else
   #error "Popcount function is not defined for this compiler. Please report this with the compiler you are using to KokkosKernels."
 #endif
@@ -326,6 +360,35 @@ int least_set_bit(  long i ){
 KOKKOS_FORCEINLINE_FUNCTION
 int least_set_bit(  long long i ){
   return __builtin_ffsll(i);
+}
+
+#elif defined (KOKKOS_COMPILER_MSVC)
+KOKKOS_FORCEINLINE_FUNCTION
+int least_set_bit( unsigned i ){
+    return __lzcnt(i);
+}
+KOKKOS_FORCEINLINE_FUNCTION
+int least_set_bit( unsigned long i ){
+    return __lzcnt(i);
+}
+
+KOKKOS_FORCEINLINE_FUNCTION
+int least_set_bit( unsigned long long i ){
+    return __lzcnt64(i);
+}
+
+KOKKOS_FORCEINLINE_FUNCTION
+int least_set_bit( int i ){
+    return __lzcnt(i);
+}
+KOKKOS_FORCEINLINE_FUNCTION
+int least_set_bit(  long i ){
+    return __lzcnt(i);
+}
+
+KOKKOS_FORCEINLINE_FUNCTION
+int least_set_bit(  long long i ){
+    return __lzcnt64(i);
 }
 
 #else

--- a/src/common/KokkosKernels_IOUtils.hpp
+++ b/src/common/KokkosKernels_IOUtils.hpp
@@ -421,11 +421,13 @@ struct Edge{
 ////////////////////////////////////////////////////////////////////////////////
 inline size_t kk_get_file_size(const char* file)
 {
-  struct stat stat_buf;
+  // struct stat stat_buf;
 
 #ifdef _WIN32
+  struct _stat stat_buf;
   int retval = _stat(file, &stat_buf);
 #else
+  struct stat stat_buf;
   int retval = stat(file, &stat_buf);
 #endif
 


### PR DESCRIPTION
This fixes #957

switching on KOKKOS_COMPILER_MSVC

src/common/KokkosKernels_IOUtils.hpp:

Change struct stat to struct _stat on Windows.

src/common/KokkosKernels_BitUtils.hpp:

Define pop_count and least_set_bit on for _MSC_VER.

These need intrin.h included.

Will remove old PR.