### PR TITLE
cmake/kokkoskernels_tpls: Remove trilinos check

### DIFF
--- a/cmake/kokkoskernels_tpls.cmake
+++ b/cmake/kokkoskernels_tpls.cmake
@@ -450,7 +450,6 @@ KOKKOSKERNELS_ADD_TPL_OPTION(CUSPARSE ${CUSPARSE_DEFAULT}   "Whether to enable C
   DEFAULT_DOCSTRING "ON if CUDA-enabled Kokkos, otherwise OFF")
 
 IF (KOKKOSKERNELS_ENABLE_TPL_MAGMA)
-  IF (KOKKOSKERNELS_HAS_TRILINOS)
     IF (F77_BLAS_MANGLE STREQUAL "(name,NAME) name ## _")
       SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DADD_ -fopenmp -lgfortran")
     ELSEIF (F77_BLAS_MANGLE STREQUAL "(name,NAME) NAME")
@@ -460,7 +459,6 @@ IF (KOKKOSKERNELS_ENABLE_TPL_MAGMA)
     ELSE ()
       MESSAGE(FATAL_ERROR "F77_BLAS_MANGLE ${F77_BLAS_MANGLE} detected while MAGMA only accepts Fortran mangling that is one of single underscore (-DADD_), uppercase (-DUPCASE), and no change (-DNOCHANGE)")
     ENDIF()
-  ENDIF()
   LIST(APPEND TPL_LIST "MAGMA")
 ENDIF()
 


### PR DESCRIPTION
## How was this tested?
- [X] Using Magma 2.5.4 configured via cmake:
```bash
cmake -DCMAKE_CXX_FLAGS=-O3 \
    -DCMAKE_INSTALL_PREFIX=$HOME/local/magma-2.5.4/install \
    -DGPU_TARGET=Volta \
    -DBLA_VENDOR=cuBLAS \
    -DLAPACK_LIBRARIES="$CUDA_ROOT/lib64/liblapack_static.a;$HOME/local/OpenBLAS-0.3.13/install/lib64/libopenblas.a" \
    $HOME/local/magma-2.5.4
```
And kokkos configured via cmake:
```bash
cmake -DCMAKE_CXX_COMPILER=$HOME/KOKKOS.base/kokkos/install-develop/bin/nvcc_wrapper -DCMAKE_INSTALL_PREFIX=$PWD/../install-issue991 -DCMAKE_BUILD_TYPE:STRING=RELEASE -DKokkos_DIR=$HOME/KOKKOS.base/kokkos/install-develop/lib64/cmake/Kokkos -DKokkosKernels_INST_COMPLEX_DOUBLE:BOOL=ON -DKokkosKernels_ENABLE_TPL_MAGMA:BOOL=ON -DKokkosKernels_MAGMA_ROOT:PATH=$HOME/local/magma-2.5.4/install ..
<snip>
make
<snip>
[100%] Built target kokkoskernels
```

- [X] Using Magma 2.5.4 configured via make.inc 

Fixes #991 