### PR TITLE
Fix nightly build errors in KokkosBlas3_Gemm_impl.hpp

### DIFF
--- a/src/KokkosKernels_Macros.hpp
+++ b/src/KokkosKernels_Macros.hpp
@@ -62,11 +62,14 @@
 
 #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && \
     defined(KOKKOS_ENABLE_OPENMP)
-#if defined(KOKKOS_COMPILER_GNU)
+// For clang OpenMP support, see
+// https://clang.llvm.org/docs/OpenMPSupport.html#id1
+#if defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
 // GCC 4.8.5 and older do not support #pragma omp simd
 #if (KOKKOS_COMPILER_GNU > 485)
 #define KOKKOSKERNELS_ENABLE_OMP_SIMD
 #endif
+// TODO: Check for a clang version that supports #pragma omp simd
 #else
 // All other Kokkos-supported compilers support it.
 #define KOKKOSKERNELS_ENABLE_OMP_SIMD

--- a/src/KokkosKernels_Macros.hpp
+++ b/src/KokkosKernels_Macros.hpp
@@ -66,7 +66,8 @@
 // https://clang.llvm.org/docs/OpenMPSupport.html#id1
 #if defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
 // GCC 4.8.5 and older do not support #pragma omp simd
-#if (KOKKOS_COMPILER_GNU > 485)
+// Do not enable when using GCC 7.2.0 + C++17 due to a bug in gcc
+#if (KOKKOS_COMPILER_GNU > 485) && !(KOKKOS_COMPILER_GNU == 720 && defined(KOKKOS_ENABLE_CXX17))
 #define KOKKOSKERNELS_ENABLE_OMP_SIMD
 #endif
 // TODO: Check for a clang version that supports #pragma omp simd


### PR DESCRIPTION
#1003 is due to moving the contents of `src/common/KokkosKernels_Macros.hpp` into `src/KokkosKernels_Macros.hpp`; before this change, `KOKKOSKERNELS_ENABLE_OMP_SIMD` was never defined since `src/KokkosKernels_Macros.hpp` was always included rather than `src/common/KokkosKernels_Macros.hpp`.

## Spot-checks
```bash
#######################################################
PASSED TESTS
#######################################################
clang-10.0.0-OpenMP-release build_time=181 run_time=47
clang-10.0.0-Pthread-release build_time=176 run_time=75
clang-10.0.0-Serial-release build_time=169 run_time=55
#######################################################
PASSED TESTS
#######################################################
gcc-7.2.0-OpenMP-release build_time=222 run_time=85
```

Fixes #1003