### PR TITLE
Blas/team policy dot test

### DIFF
--- a/perf_test/blas/blas/CMakeLists.txt
+++ b/perf_test/blas/blas/CMakeLists.txt
@@ -12,3 +12,8 @@ KOKKOSKERNELS_ADD_EXECUTABLE(
         KokkosBlas_dot_perf_test
         SOURCES KokkosBlas_dot_perf_test.cpp
         )
+
+KOKKOSKERNELS_ADD_EXECUTABLE(
+        KokkosBlas_team_dot_perf_test
+        SOURCES KokkosBlas_team_dot_perf_test.cpp
+        )

--- a/perf_test/blas/blas/CMakeLists.txt
+++ b/perf_test/blas/blas/CMakeLists.txt
@@ -5,3 +5,10 @@ KOKKOSKERNELS_ADD_EXECUTABLE(
     KokkosBlas_perf_test
     SOURCES KokkosBlas_perf_test.cpp
   )
+
+
+
+KOKKOSKERNELS_ADD_EXECUTABLE(
+        KokkosBlas_dot_perf_test
+        SOURCES KokkosBlas_dot_perf_test.cpp
+        )

--- a/perf_test/blas/blas/KokkosBlas_dot_perf_test.cpp
+++ b/perf_test/blas/blas/KokkosBlas_dot_perf_test.cpp
@@ -1,0 +1,262 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Core.hpp>
+#include <KokkosBlas1_dot.hpp>
+#include <Kokkos_Random.hpp>
+
+struct Params {
+  int use_cuda    = 0;
+  int use_openmp  = 0;
+  int use_threads = 0;
+  // m is vector length
+  int m           = 100000;
+  int repeat      = 1;
+  bool layoutLeft = true;
+};
+
+void print_options() {
+  std::cerr << "Options:\n" << std::endl;
+
+  std::cerr << "\tBACKEND: '--threads[numThreads]' | '--openmp [numThreads]' | "
+               "'--cuda [cudaDeviceIndex]'"
+            << std::endl;
+  std::cerr << "\tIf no BACKEND selected, serial is the default." << std::endl;
+  std::cerr << "\t[Optional] --repeat :: how many times to repeat overall "
+               "dot (symbolic + repeated numeric)"
+            << std::endl;
+  std::cerr << "\t[Optional] --layout :: matrix layout ('left' or 'right', "
+               "default 'left')"
+            << std::endl;
+  std::cerr << "\t[Optional] --m      :: desired length of test vectors; test "
+               "vectors will have the same length"
+            << std::endl;
+}
+
+int parse_inputs(Params& params, int argc, char** argv) {
+  for (int i = 1; i < argc; ++i) {
+    if (0 == strcasecmp(argv[i], "--help") || 0 == strcasecmp(argv[i], "-h")) {
+      print_options();
+      exit(0);  // note: this is before Kokkos::initialize
+    } else if (0 == strcasecmp(argv[i], "--threads")) {
+      params.use_threads = atoi(argv[++i]);
+    } else if (0 == strcasecmp(argv[i], "--openmp")) {
+      params.use_openmp = atoi(argv[++i]);
+    } else if (0 == strcasecmp(argv[i], "--cuda")) {
+      params.use_cuda = atoi(argv[++i]) + 1;
+    } else if (0 == strcasecmp(argv[i], "--layout")) {
+      i++;
+      if (0 == strcasecmp(argv[i], "left"))
+        params.layoutLeft = true;
+      else if (0 == strcasecmp(argv[i], "right"))
+        params.layoutLeft = false;
+      else {
+        std::cerr << "Invalid layout: must be 'left' or 'right'.\n";
+        exit(1);
+      }
+    } else if (0 == strcasecmp(argv[i], "--m")) {
+      params.m = atoi(argv[++i]);
+    } else if (0 == strcasecmp(argv[i], "--repeat")) {
+      // if provided, C will be written to given file.
+      // has to have ".bin", or ".crs" extension.
+      params.repeat = atoi(argv[++i]);
+    } else {
+      std::cerr << "Unrecognized command line argument #" << i << ": "
+                << argv[i] << std::endl;
+      print_options();
+      return 1;
+    }
+  }
+  return 0;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// The Level 1 BLAS perform scalar, vector and vector-vector operations;
+//
+// https://github.com/kokkos/kokkos-kernels/wiki/BLAS-1%3A%3Adot
+//
+// Usage: result = KokkosBlas::dot(x,y); KokkosBlas::dot(r,x,y);
+// Multiplies each value of x(i) [x(i,j)] with y(i) or [y(i,j)] and computes the
+// sum. (If x and y have scalar type Kokkos::complex, the complex conjugate of
+// x(i) or x(i,j) will be used.) VectorX: A rank-1 Kokkos::View VectorY: A
+// rank-1 Kokkos::View ReturnVector: A rank-0 or rank-1 Kokkos::View
+//
+// REQUIREMENTS:
+// Y.rank == 1 or X.rank == 1
+// Y.extent(0) == X.extent(0)
+
+// Dot Test design:
+// 1) create 1D View containing 1D matrix, aka a vector; this will be your X
+// input matrix; 2) create 1D View containing 1D matrix, aka a vector; this will
+// be your Y input matrix; 3) perform the dot operation on the two inputs, and
+// capture result in "result"
+
+// Here, m represents the desired length for each 1D matrix;
+// "m" is used here, because code from another test was adapted for this test.
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class ExecSpace, class Layout>
+void run(int m, int repeat) {
+  // Declare type aliases
+  using Scalar   = double;
+  using MemSpace = typename ExecSpace::memory_space;
+  using Device   = Kokkos::Device<ExecSpace, MemSpace>;
+
+  std::cout << "Running BLAS Level 1 DOT perfomrance experiment ("
+            << ExecSpace::name() << ")\n";
+
+  std::cout << "Each test input vector has a length of " << m << std::endl;
+
+  // Create 1D view w/ Device as the ExecSpace; this is an input vector
+  Kokkos::View<Scalar*, Device> x(Kokkos::ViewAllocateWithoutInitializing("x"),
+                                  m);
+
+  // Create 1D view w/ Device as the ExecSpace; this is the output vector
+  Kokkos::View<Scalar*, Device> y(Kokkos::ViewAllocateWithoutInitializing("y"),
+                                  m);
+
+  // Declaring variable pool w/ a seeded random number;
+  // a parallel random number generator, so you
+  // won't get the same number with a given seed each time
+  Kokkos::Random_XorShift64_Pool<ExecSpace> pool(123);
+
+  Kokkos::fill_random(x, pool, 10.0);
+  Kokkos::fill_random(y, pool, 10.0);
+
+  // do a warm up run of dot:
+  KokkosBlas::dot(x, y);
+
+  // The live test of dot:
+
+  Kokkos::fence();
+  Kokkos::Timer timer;
+
+  for (int i = 0; i < repeat; i++) {
+    double result = KokkosBlas::dot(x, y);
+    ExecSpace().fence();
+  }
+
+  // Kokkos Timer set up
+  double total = timer.seconds();
+  double avg   = total / repeat;
+  // Flops calculation for a 1D matrix dot product per test run;
+  size_t flopsPerRun = (size_t)2 * m;
+  printf("Avg DOT time: %f s.\n", avg);
+  printf("Avg DOT FLOP/s: %.3e\n", flopsPerRun / avg);
+}
+
+int main(int argc, char** argv) {
+  Params params;
+
+  if (parse_inputs(params, argc, argv)) {
+    return 1;
+  }
+  //const int num_threads =
+      //params.use_openmp;  // Assumption is that use_openmp variable is provided
+                          // as number of threads
+  const int device_id = params.use_cuda - 1;
+
+
+  const int num_threads = std::max(params.use_openmp, params.use_threads);
+
+  Kokkos::initialize(Kokkos::InitArguments(num_threads, -1, device_id));
+
+  // TODO from BMK:  Set up pthreads
+  bool useThreads = params.use_threads != 0;
+  bool useOMP     = params.use_openmp != 0;
+  bool useCUDA    = params.use_cuda != 0;
+
+  bool useSerial = !useOMP && !useCUDA;
+
+
+  if (useThreads)
+  {
+#if defined(KOKKOS_ENABLE_THREADS)
+    if (params.use_threads)
+      run<Kokkos::Threads, Kokkos::LayoutLeft>(params.m, params.repeat);
+    else
+      run<Kokkos::Threads, Kokkos::LayoutRight>(params.m, params.repeat);
+#else
+    std::cout << "ERROR:  PThreads requested, but not available.\n";
+  return 1;
+#endif
+}
+
+    if (useOMP) {
+#if defined(KOKKOS_ENABLE_OPENMP)
+      if (params.layoutLeft)
+        run<Kokkos::OpenMP, Kokkos::LayoutLeft>(params.m, params.repeat);
+      else
+        run<Kokkos::OpenMP, Kokkos::LayoutRight>(params.m, params.repeat);
+#else
+  std::cout << "ERROR: OpenMP requested, but not available.\n";
+  return 1;
+#endif
+    }
+
+    if (useCUDA) {
+#if defined(KOKKOS_ENABLE_CUDA)
+      if (params.layoutLeft)
+        run<Kokkos::Cuda, Kokkos::LayoutLeft>(params.m, params.repeat);
+      else
+        run<Kokkos::Cuda, Kokkos::LayoutRight>(params.m, params.repeat);
+#else
+  std::cout << "ERROR: CUDA requested, but not available.\n";
+  return 1;
+#endif
+    }
+    if (useSerial) {
+#if defined(KOKKOS_ENABLE_SERIAL)
+      if (params.layoutLeft)
+        run<Kokkos::Serial, Kokkos::LayoutLeft>(params.m, params.repeat);
+      else
+        run<Kokkos::Serial, Kokkos::LayoutRight>(params.m, params.repeat);
+#else
+  std::cout << "ERROR: Serial device requested, but not available.\n";
+  return 1;
+#endif
+    }
+    Kokkos::finalize();
+    return 0;
+  }

--- a/perf_test/blas/blas/KokkosBlas_team_dot_perf_test.cpp
+++ b/perf_test/blas/blas/KokkosBlas_team_dot_perf_test.cpp
@@ -1,0 +1,300 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Core.hpp>
+#include <KokkosBlas1_team_dot.hpp>
+#include <Kokkos_Random.hpp>
+
+struct Params {
+  int use_cuda    = 0;
+  int use_openmp  = 0;
+  int use_threads = 0;
+  // m is vector length, or number of rows
+  int m           = 100000;
+  int repeat      = 1;
+  bool layoutLeft = true;
+};
+
+void print_options() {
+  std::cerr << "Options:\n" << std::endl;
+
+  std::cerr << "\tBACKEND: '--threads[numThreads]' | '--openmp [numThreads]' | "
+               "'--cuda [cudaDeviceIndex]'"
+            << std::endl;
+  std::cerr << "\tIf no BACKEND selected, serial is the default." << std::endl;
+  std::cerr << "\t[Optional] --repeat :: how many times to repeat overall "
+               "dot (symbolic + repeated numeric)"
+            << std::endl;
+  std::cerr << "\t[Optional] --layout :: matrix layout ('left' or 'right', "
+               "default 'left')"
+            << std::endl;
+  std::cerr << "\t[Optional] --m      :: desired length of test vectors; test "
+               "vectors will have the same length"
+            << std::endl;
+}
+
+int parse_inputs(Params& params, int argc, char** argv) {
+  for (int i = 1; i < argc; ++i) {
+    if (0 == strcasecmp(argv[i], "--help") || 0 == strcasecmp(argv[i], "-h")) {
+      print_options();
+      exit(0);  // note: this is before Kokkos::initialize
+    } else if (0 == strcasecmp(argv[i], "--threads")) {
+      params.use_threads = atoi(argv[++i]);
+    } else if (0 == strcasecmp(argv[i], "--openmp")) {
+      params.use_openmp = atoi(argv[++i]);
+    } else if (0 == strcasecmp(argv[i], "--cuda")) {
+      params.use_cuda = atoi(argv[++i]) + 1;
+    } else if (0 == strcasecmp(argv[i], "--layout")) {
+      i++;
+      if (0 == strcasecmp(argv[i], "left"))
+        params.layoutLeft = true;
+      else if (0 == strcasecmp(argv[i], "right"))
+        params.layoutLeft = false;
+      else {
+        std::cerr << "Invalid layout: must be 'left' or 'right'.\n";
+        exit(1);
+      }
+    } else if (0 == strcasecmp(argv[i], "--m")) {
+      params.m = atoi(argv[++i]);
+    } else if (0 == strcasecmp(argv[i], "--repeat")) {
+      // if provided, C will be written to given file.
+      // has to have ".bin", or ".crs" extension.
+      params.repeat = atoi(argv[++i]);
+    } else {
+      std::cerr << "Unrecognized command line argument #" << i << ": "
+                << argv[i] << std::endl;
+      print_options();
+      return 1;
+    }
+  }
+  return 0;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// The Level 1 BLAS perform scalar, vector and vector-vector operations;
+
+// https://github.com/kokkos/kokkos-kernels/wiki/BLAS-1%3A%3Ateam-dot
+//
+// Usage: result = KokkosBlas::Experimental::dot(team,x,y);
+// 
+// Multiplies each value of x(i) with y(i), and computes the total within 
+// a parallel kernel using a TeamPolicy execution policy
+
+// Interface Single Vector only
+//
+// Parameters:
+/*
+    TeamType: A Kokkos::TeamPolicy<...>::member_type
+    VectorX: A rank-1 Kokkos::View
+    VectorY: A rank-1 Kokkos::View
+
+*/
+
+// REQUIREMENTS:
+// Y.rank == 1 or X.rank == 1
+// Y.extent(0) == X.extent(0)
+
+// Dot Test WITH TEAM POLICY design:
+// 1) create 1D View containing 1D matrix, aka a vector; this will be your X
+// input matrix; 2) create 1D View containing 1D matrix, aka a vector; this will
+// be your Y input matrix; 3) perform the dot operation on the two inputs, and
+// capture result in "result"
+
+// Here, m represents the desired length for each 1D matrix / vector;
+// "m" is used here, because code from another test was adapted for this test.
+//  
+//  Top Level Execution Policies:
+//  https://github.com/kokkos/kokkos/wiki/Execution-Policies
+//
+//  TeamPolicy
+//  https://github.com/kokkos/kokkos/wiki/Kokkos%3A%3ATeamPolicy
+//
+/*
+Policy 	        Description
+RangePolicy 	Each iterate is an integer in a contiguous range
+MDRangePolicy 	Each iterate for each rank is an integer in a contiguous range
+TeamPolicy      Assigns to each iterate in a contiguous range a team of threads
+*/
+
+/// Nested Execution Policies are used to dispatch parallel work inside of an already executing parallel region,
+//  either dispatched with a TeamPolicy or a task policy.
+/*
+ * Policy 	            Description
+TeamThreadRange 	Used inside of a TeamPolicy kernel to perform nested parallel loops split over threads of a team.
+TeamVectorRange 	Used inside of a TeamPolicy kernel to perform nested parallel loops split over threads of a team and their vector lanes.
+ThreadVectorRange 	Used inside of a TeamPolicy kernel to perform nested parallel loops with vector lanes of a thread.
+*/
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class ExecSpace, class Layout>
+void run(int m, int repeat) {
+  // Declare type aliases
+    using Scalar   = double;
+    using MemSpace = typename ExecSpace::memory_space;
+    using Device   = Kokkos::Device<ExecSpace, MemSpace>;
+
+     // For the Team implementation of dot; ExecSpace is implicit;
+     using policy = Kokkos::TeamPolicy<ExecSpace>;
+     using member_type = typename policy::member_type;
+
+  // Create 1D view w/ Device as the ExecSpace; this is an input vector
+  Kokkos::View<Scalar*, MemSpace> x("X", m);
+
+  // Create 1D view w/ Device as the ExecSpace; this is the output vector
+  Kokkos::View<Scalar*, MemSpace> y("Y", m);
+
+  //
+  // Here, deep_copy is filling / copying values into Host memory from Views X
+  // and Y
+  Kokkos::deep_copy(x, 3.0);
+  Kokkos::deep_copy(y, 2.0);
+
+  std::cout << "Running BLAS Level 1 Kokkos Teams-based implementation DOT performance experiment ("
+            << ExecSpace::name() << ")\n";
+
+  std::cout << "Each test input vector has a length of " << m << std::endl;
+
+  // Warm up run of dot:
+
+  Kokkos::parallel_for("TeamDotDemoUsage",
+                  policy(1, Kokkos::AUTO),
+                  KOKKOS_LAMBDA(const member_type& team){
+                       });
+
+  // To guarantee a kernel has finished, a developer should call the fence of the execution space on which the kernel is being executed. 
+  // Otherwise, it depends on the execution space where the loop executes, and whether this execution space implements a barrier.
+
+  Kokkos::fence();
+  Kokkos::Timer timer;
+
+  // Live test of dot:
+  Kokkos::parallel_for("TeamDotDemoUsage",
+                       policy(1, Kokkos::AUTO),
+                       KOKKOS_LAMBDA (const member_type& team)
+                       {
+                       double result = KokkosBlas::Experimental::dot(team, x, y);
+                       }
+                       );
+
+  ExecSpace().fence();
+
+  // Kokkos Timer set up and data capture
+  double total = timer.seconds();
+  double avg   = total / repeat;
+  // Flops calculation for a 1D matrix dot product per test run;
+  size_t flopsPerRun = (size_t)2 * m;
+  printf("Avg DOT time: %f s.\n", avg);
+  printf("Avg DOT FLOP/s: %.3e\n", flopsPerRun / avg);
+}
+
+int main(int argc, char** argv) {
+  Params params;
+
+  if (parse_inputs(params, argc, argv)) {
+    return 1;
+  }
+
+  const int device_id = params.use_cuda - 1;
+
+  const int num_threads = std::max(params.use_openmp, params.use_threads);
+
+  Kokkos::initialize(Kokkos::InitArguments(num_threads, -1, device_id));
+
+  bool useThreads = params.use_threads != 0;
+  bool useOMP     = params.use_openmp != 0;
+  bool useCUDA    = params.use_cuda != 0;
+
+  bool useSerial = !useOMP && !useCUDA;
+
+  if (useThreads)
+  {
+#if defined(KOKKOS_ENABLE_THREADS)
+    if (params.use_threads)
+      run<Kokkos::Threads, Kokkos::LayoutLeft>(params.m, params.repeat);
+    else
+      run<Kokkos::Threads, Kokkos::LayoutRight>(params.m, params.repeat);
+#else
+    std::cout << "ERROR:  PThreads requested, but not available.\n";
+  return 1;
+#endif
+}
+
+    if (useOMP) {
+#if defined(KOKKOS_ENABLE_OPENMP)
+      if (params.layoutLeft)
+        run<Kokkos::OpenMP, Kokkos::LayoutLeft>(params.m, params.repeat);
+      else
+        run<Kokkos::OpenMP, Kokkos::LayoutRight>(params.m, params.repeat);
+#else
+  std::cout << "ERROR: OpenMP requested, but not available.\n";
+  return 1;
+#endif
+    }
+
+    if (useCUDA) {
+#if defined(KOKKOS_ENABLE_CUDA)
+      if (params.layoutLeft)
+        run<Kokkos::Cuda, Kokkos::LayoutLeft>(params.m, params.repeat);
+      else
+        run<Kokkos::Cuda, Kokkos::LayoutRight>(params.m, params.repeat);
+#else
+  std::cout << "ERROR: CUDA requested, but not available.\n";
+  return 1;
+#endif
+    }
+    if (useSerial) {
+#if defined(KOKKOS_ENABLE_SERIAL)
+      if (params.layoutLeft)
+        run<Kokkos::Serial, Kokkos::LayoutLeft>(params.m, params.repeat);
+      else
+        run<Kokkos::Serial, Kokkos::LayoutRight>(params.m, params.repeat);
+#else
+  std::cout << "ERROR: Serial device requested, but not available; here, implementation of dot is explicitly parallel.\n";
+  return 1;
+#endif
+    }
+    Kokkos::finalize();
+    return 0;
+  }

--- a/perf_test/blas/blas2/KokkosBlas2_gemv_perf_test.cpp
+++ b/perf_test/blas/blas2/KokkosBlas2_gemv_perf_test.cpp
@@ -210,7 +210,7 @@ int main (int argc, char ** argv){
   // Create boolean to handle serial setting if not using open and cuda
   bool useSerial = !useOMP && !useCUDA;
 
-  // Logic for runtime with PThreads; AJP inserted at BMK's mention
+  // Logic for runtime with PThreads 
     if (useThreads)
   {
 #if defined(KOKKOS_ENABLE_THREADS)

--- a/perf_test/blas/blas2/KokkosBlas2_gemv_perf_test.cpp
+++ b/perf_test/blas/blas2/KokkosBlas2_gemv_perf_test.cpp
@@ -116,22 +116,57 @@ int parse_inputs (Params& params, int argc, char **argv){
   return 0;
 }
 
+/* Templated function on ExecSpace and Layout
+ * The run function takes three arguments:
+ * m = number of rows in a matrix
+ * n = number of columns
+ * repeat = number of replicates in a run
+ *
+ */
+
+
+// These types 
+//
 template<typename ExecSpace, typename Layout>
 void run(int m, int n, int repeat)
 {
+  // Declare type aliases      
   using Scalar = double;
   using MemSpace = typename ExecSpace::memory_space;
   using Device = Kokkos::Device<ExecSpace, MemSpace>;
+
   std::cout << "Running GEMV experiment (" << ExecSpace::name() << ")\n";
+  
+  // Create a View containing a 2D matrix; allocate KokkosView with template args of Scalar**, a layout, and
+  // device, and create the "A" matrix with m rows, n columns as an
+  // uninitialized view   
   Kokkos::View<Scalar**, Layout, Device> A(Kokkos::ViewAllocateWithoutInitializing("A"), m, n);
+  // Create Views containing 1D matrix; allocate (without) matrix "x" of size n
   Kokkos::View<Scalar*, Device> x(Kokkos::ViewAllocateWithoutInitializing("x"), n);
+  // Create Views containing 1D matrix; allocate (without) matrix "y" of size m   
   Kokkos::View<Scalar*, Device> y(Kokkos::ViewAllocateWithoutInitializing("y"), m);
+  
+  // Declaring variable pool w/ a number seed; 
+  // a parallel random number generator, so you
+  // won't get the same number with a given seed each time
   Kokkos::Random_XorShift64_Pool<ExecSpace> pool(123);
+
+  // Fill 2D Matrix "A" and 1D matrix (i.e., a vector) "x" with random values;
+  // Here, 10 is the max value of the random generator between 1 and 10
+  // (uniform )
   Kokkos::fill_random(A, pool, 10.0);
   Kokkos::fill_random(x, pool, 10.0);
-  //Do a warm-up run
+  
+
+  // https://github.com/kokkos/kokkos-kernels/wiki/BLAS-2%3A%3Agemv
+  // Header File: KokkosBlas2_gemv.hpp
+  // Usage: KokkosBlas::gemv (mode, alpha, A, x, beta, y);
+  // Matrix Vector Multiplication y[i] = beta * y[i] + alpha * SUM_j(A[i,j] * x[j])
+ 
+  // Do a warm-up run
   KokkosBlas::gemv("N", 1.0, A, x, 0.0, y);
-  //Now, start timing
+
+  //Start timing
   Kokkos::fence();
   Kokkos::Timer timer;
   for(int i = 0; i < repeat; i++)
@@ -139,29 +174,57 @@ void run(int m, int n, int repeat)
     KokkosBlas::gemv("N", 1.0, A, x, 0.0, y);
     ExecSpace().fence();
   }
+  // Kokkos Timer set up
   double total = timer.seconds();
   double avg = total / repeat;
+  // Flops calculation   
   size_t flopsPerRun = (size_t) 2 * m * n;
   printf("Avg GEMV time: %f s.\n", avg);
   printf("Avg GEMV FLOP/s: %.3e\n", flopsPerRun / avg);
 }
 
+
 int main (int argc, char ** argv){
+  
+  // Create an instance of Params
   Params params;
 
+  // Argument parsing:
   if (parse_inputs (params, argc, argv) ){
     return 1;
   }
-  const int num_threads = params.use_openmp; // Assumption is that use_openmp variable is provided as number of threads
+  //const int num_threads = params.use_openmp;
+  const int num_threads = std::max(params.use_openmp, params.use_threads);
+
   const int device_id = params.use_cuda - 1;
 
-  Kokkos::initialize( Kokkos::InitArguments( num_threads, -1, device_id ) );
 
+
+  Kokkos::initialize( Kokkos::InitArguments( num_threads, -1, device_id ) );
+  
+  // Create booleans to handle pthreads, openmp and cuda params and initialize to true;
+  bool useThreads = params.use_threads != 0;
   bool useOMP = params.use_openmp != 0;
   bool useCUDA = params.use_cuda != 0;
 
+  // Create boolean to handle serial setting if not using open and cuda
   bool useSerial = !useOMP && !useCUDA;
 
+  // Logic for runtime with PThreads; AJP inserted at BMK's mention
+    if (useThreads)
+  {
+#if defined(KOKKOS_ENABLE_THREADS)
+    if (params.use_threads)
+      run<Kokkos::Threads, Kokkos::LayoutLeft>(params.m, params.n, params.repeat);
+    else
+      run<Kokkos::Threads, Kokkos::LayoutRight>(params.m, params.n, params.repeat);
+#else
+    std::cout << "ERROR:  PThreads requested, but not available.\n";
+  return 1;
+#endif
+}
+
+  // Logic for runtime with OpenMP
   if(useOMP)
   {
 #if defined( KOKKOS_ENABLE_OPENMP )
@@ -174,6 +237,8 @@ int main (int argc, char ** argv){
     return 1;
 #endif
   }
+
+  // Logic for runtime with Cuda
   if(useCUDA)
   {
 #if defined( KOKKOS_ENABLE_CUDA )
@@ -186,6 +251,7 @@ int main (int argc, char ** argv){
     return 1;
 #endif
   }
+  // Logic for serial runtime
   if(useSerial)
   {
 #if defined( KOKKOS_ENABLE_SERIAL )


### PR DESCRIPTION
The proposed code represents a TeamPolicy-based dot performance test (https://github.com/kokkos/kokkos-kernels/wiki/BLAS-1%3A%3Ateam-dot).  In the near future, this test will also be implemented with RAJAPerf Suite infrastructure for nightly builds, performance testing and reporting.  


(SAMPLE RESULTS WITH OPENMP IMPLEMENTATION; OTHER CASES SHOWN TO DEMO EXPECTED ERRORS) 

 ./KokkosBlas_team_dot_perf_test 
Kokkos::OpenMP::initialize WARNING: OMP_PROC_BIND environment variable not set
  In general, for best performance with OpenMP 4.0 or better set OMP_PROC_BIND=spread and OMP_PLACES=threads
  For best performance with OpenMP 3.1 set OMP_PROC_BIND=true
  For unit testing set OMP_PROC_BIND=false
ERROR: Serial device requested, but not available; here, implementation of dot is explicitly parallel.
[ajpowel@kokkos-dev-2 blas]$ 
[ajpowel@kokkos-dev-2 blas]$ 
[ajpowel@kokkos-dev-2 blas]$ ./KokkosBlas_team_dot_perf_test --openmp 20
Kokkos::OpenMP::initialize WARNING: OMP_PROC_BIND environment variable not set
  In general, for best performance with OpenMP 4.0 or better set OMP_PROC_BIND=spread and OMP_PLACES=threads
  For best performance with OpenMP 3.1 set OMP_PROC_BIND=true
  For unit testing set OMP_PROC_BIND=false
Running BLAS Level 1 Kokkos Teams-based implementation DOT performance experiment (OpenMP)
Each test input vector has a length of 100000
Avg DOT time: 0.000172 s.
Avg DOT FLOP/s: 1.164e+09
[ajpowel@kokkos-dev-2 blas]$ ./KokkosBlas_team_dot_perf_test --threads 20
Kokkos::OpenMP::initialize WARNING: OMP_PROC_BIND environment variable not set
  In general, for best performance with OpenMP 4.0 or better set OMP_PROC_BIND=spread and OMP_PLACES=threads
  For best performance with OpenMP 3.1 set OMP_PROC_BIND=true
  For unit testing set OMP_PROC_BIND=false
ERROR:  PThreads requested, but not available.
[ajpowel@kokkos-dev-2 blas]$ 
[ajpowel@kokkos-dev-2 blas]$ 
[ajpowel@kokkos-dev-2 blas]$ ./KokkosBlas_team_dot_perf_test --cuda 0
Kokkos::OpenMP::initialize WARNING: OMP_PROC_BIND environment variable not set
  In general, for best performance with OpenMP 4.0 or better set OMP_PROC_BIND=spread and OMP_PLACES=threads
  For best performance with OpenMP 3.1 set OMP_PROC_BIND=true
  For unit testing set OMP_PROC_BIND=false
ERROR: CUDA requested, but not available.
