### PR TITLE
Fix559: Intel 18 has trouble with pointer in ternary expr

### DIFF
--- a/src/blas/impl/KokkosBlas3_trsm_impl.hpp
+++ b/src/blas/impl/KokkosBlas3_trsm_impl.hpp
@@ -83,12 +83,11 @@ SerialTrsmInternalLeftLowerConj(const bool use_unit_diag,
     for (int p=0;p<m;++p) {
       const int iend = m-p-1, jend = n;
         
-      const ValueType
-        *KOKKOS_RESTRICT a21 = iend ? A+(p+1)*as0+p*as1 : NULL;
+      const ValueType *KOKKOS_RESTRICT a21 = A+(p+1)*as0+p*as1;
           
       ValueType
-        *KOKKOS_RESTRICT b1t =        B+p*bs0,
-        *KOKKOS_RESTRICT B2  = iend ? B+(p+1)*bs0 : NULL;
+        *KOKKOS_RESTRICT b1t = B+p*bs0,
+        *KOKKOS_RESTRICT B2  = B+(p+1)*bs0;
         
       if (!use_unit_diag) {
         const ValueType alpha11 = AT::conj(A[p*as0+p*as1]);


### PR DESCRIPTION
Fix #559 (trsm for conjugate transpose mode with Intel 18). I think this is a compiler bug after all, since one fix was just to replace two ternary expressions ``a = cond ? b : c;`` with ``a = c; if(cond) a = b;``. And evaluating b/c have no side effects. But the simpler fix was to just get rid of the ternaries, since whenever ``cond`` is false here, the pointer ``a`` is never dereferenced (if ``iend == 0``, the loop from 0...iend doesn't run).

BTW, In #559 I found that Intel 16/17 didn't have this issue, and I just tried 19 and GCC 9.2 and they didn't either. So it really seems to be a bug only in Intel18.