### PR TITLE
cm_test_all_sandia: Exit with non-zero on errors

### DIFF
--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -975,7 +975,7 @@ if [ "$COMPILERS_TO_TEST" == "" ]; then
    echo "   !!!! Invalid Compiler provided  '$ARGS' !!!!"
    echo "-----------------------------------------------"
    print_help
-   exit 0
+   exit 1
 fi
 
 #


### PR DESCRIPTION
Related to #908.