### PR TITLE
src/blas/impl: Explicitly cast to LHS type for axpby

### DIFF
--- a/src/blas/impl/KokkosBlas1_axpby_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_axpby_impl.hpp
@@ -253,16 +253,17 @@ struct Axpby_Functor<typename XV::non_const_value_type, XV,
 #if KOKKOSBLAS_OPTIMIZATION_LEVEL_AXPBY <= 2
 
     if (scalar_x == 0 && scalar_y == 0) {
-      m_y(i) = ATS::zero ();
+      m_y(i) = static_cast<typename YV::non_const_value_type>(ATS::zero());
     }
     if (scalar_x == 0 && scalar_y == 2) {
-      m_y(i) = m_b*m_y(i);
+      m_y(i) = static_cast<typename YV::non_const_value_type>(m_b * m_y(i));
     }
     if (scalar_x == 2 && scalar_y == 0) {
-      m_y(i) = m_a*m_x(i);
+      m_y(i) = static_cast<typename YV::non_const_value_type>(m_a * m_x(i));
     }
     if (scalar_x == 2 && scalar_y == 2) {
-      m_y(i) = m_a*m_x(i) + m_b*m_y(i);
+      m_y(i) = static_cast<typename YV::non_const_value_type>(m_a * m_x(i) +
+                                                              m_b * m_y(i));
     }
 
 #else // KOKKOSBLAS_OPTIMIZATION_LEVEL_AXPBY > 2


### PR DESCRIPTION
## Motivation
In order to support mixed precision with `Kokkos::Experimental::half_t` we must use explicit casts from `half_t` to other types in certain expressions. The reason we cannot support implicit conversion operators from `half_t` to `T` is that when selecting an operator overload, the toolchain encounters multiple valid operators and without a precedence. In this case, if we supported implicit conversions from `half_t` -> `T`, `T = half_t Op half_t` the toolchain would consider the following options:
- `T = half_t Op half_t`
- `T = T Op T`

and produce a compile time error.

What we can and DO support is upcasting for binary arithmetic involving float and double:
- `float_or_double` = `half_t Op float_or_double`
- `float_or_double` = `float_or_double Op half_t`

related to #1049.