### PR TITLE
Add batched axpy and batched spmv

### DIFF
--- a/src/batched/KokkosBatched_Axpy_Decl.hpp
+++ b/src/batched/KokkosBatched_Axpy_Decl.hpp
@@ -1,0 +1,66 @@
+#ifndef __KOKKOSBATCHED_AXPY_DECL_HPP__
+#define __KOKKOSBATCHED_AXPY_DECL_HPP__
+
+
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "KokkosBatched_Util.hpp"
+#include "KokkosBatched_Vector.hpp"
+
+namespace KokkosBatched {
+
+  ///
+  /// Serial AXPY
+  ///
+  ///
+  /// y <- alpha * x + y
+  ///
+  ///
+
+  struct SerialAxpy {
+    template<typename ViewType,
+             typename alphaViewType>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const alphaViewType &alpha,
+           const ViewType &X,
+           const ViewType &Y);
+  };
+
+  ///
+  /// Team AXPY
+  ///
+
+  template<typename MemberType>
+  struct TeamAxpy {
+    template<typename ViewType,
+             typename alphaViewType>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const MemberType &member, 
+           const alphaViewType &alpha,
+           const ViewType &X,
+           const ViewType &Y);
+  };
+
+  ///
+  /// TeamVector AXPY
+  ///
+
+  template<typename MemberType>
+  struct TeamVectorAxpy {
+    template<typename ViewType,
+             typename alphaViewType>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const MemberType &member, 
+           const alphaViewType &alpha,
+           const ViewType &X,
+           const ViewType &Y);
+  };
+
+}
+
+#include "KokkosBatched_Axpy_Impl.hpp"
+
+#endif

--- a/src/batched/KokkosBatched_Axpy_Impl.hpp
+++ b/src/batched/KokkosBatched_Axpy_Impl.hpp
@@ -1,0 +1,86 @@
+#ifndef __KOKKOSBATCHED_AXPY_IMPL_HPP__
+#define __KOKKOSBATCHED_AXPY_IMPL_HPP__
+
+
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "KokkosBatched_Util.hpp"
+#include "KokkosBatched_Axpy_Internal.hpp"
+
+namespace KokkosBatched {
+
+  ///
+  /// Serial Impl
+  /// ===========
+  template<typename ViewType,
+           typename alphaViewType>
+  KOKKOS_INLINE_FUNCTION
+  int
+  SerialAxpy::
+  invoke(const alphaViewType &alpha,
+         const ViewType &X,
+         const ViewType &Y) {
+    return SerialAxpyInternal::template
+      invoke<typename alphaViewType::non_const_value_type,
+             typename ViewType::non_const_value_type>
+             (X.extent(0), X.extent(1),
+              alpha.data(), alpha.stride_0(),
+              X.data(), X.stride_0(), X.stride_1(),
+              Y.data(), Y.stride_0(), Y.stride_1());
+  }
+
+  ///
+  /// Team Impl
+  /// =========
+    
+  template<typename MemberType>
+  template<typename ViewType,
+           typename alphaViewType>
+  KOKKOS_INLINE_FUNCTION
+  int
+  TeamAxpy<MemberType>::
+  invoke(const MemberType &member, 
+         const alphaViewType &alpha,
+         const ViewType &X,
+         const ViewType &Y) {
+    return TeamAxpyInternal::template
+      invoke<MemberType,
+             typename alphaViewType::non_const_value_type,
+             typename ViewType::non_const_value_type>
+             (member, 
+              X.extent(0), X.extent(1),
+              alpha.data(), alpha.stride_0(),
+              X.data(), X.stride_0(), X.stride_1(),
+              Y.data(), Y.stride_0(), Y.stride_1());
+  }
+
+  ///
+  /// TeamVector Impl
+  /// ===============
+    
+  template<typename MemberType>
+  template<typename ViewType,
+           typename alphaViewType>
+  KOKKOS_INLINE_FUNCTION
+  int
+  TeamVectorAxpy<MemberType>::
+  invoke(const MemberType &member, 
+         const alphaViewType &alpha,
+         const ViewType &X,
+         const ViewType &Y) {
+    return TeamVectorAxpyInternal::
+      invoke<MemberType,
+             typename alphaViewType::non_const_value_type,
+             typename ViewType::non_const_value_type,
+             typename ViewType::array_layout>
+             (member, 
+             X.extent(0), X.extent(1),
+             alpha.data(), alpha.stride_0(),
+             X.data(), X.stride_0(), X.stride_1(),
+             Y.data(), Y.stride_0(), Y.stride_1());
+  }
+  
+}
+
+
+#endif

--- a/src/batched/KokkosBatched_Axpy_Internal.hpp
+++ b/src/batched/KokkosBatched_Axpy_Internal.hpp
@@ -1,0 +1,231 @@
+#ifndef __KOKKOSBATCHED_AXPY_INTERNAL_HPP__
+#define __KOKKOSBATCHED_AXPY_INTERNAL_HPP__
+
+
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "KokkosBatched_Util.hpp"
+
+namespace KokkosBatched {
+
+  ///
+  /// Serial Internal Impl
+  /// ==================== 
+  struct SerialAxpyInternal {
+    template<typename ScalarType,
+             typename ValueType>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const int m, 
+           const ScalarType alpha, 
+           /* */ ValueType *__restrict__ X, const int xs0,
+           /* */ ValueType *__restrict__ Y, const int ys0) {
+
+#if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
+#pragma unroll
+#endif
+      for (int i=0;i<m;++i)
+        Y[i*ys0] += alpha*X[i*xs0];
+        
+      return 0;
+    }
+
+    template<typename ScalarType,
+             typename ValueType>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const int m, 
+           const ScalarType *__restrict__ alpha, const int alphas0,
+           /* */ ValueType *__restrict__ X, const int xs0,
+           /* */ ValueType *__restrict__ Y, const int ys0) {
+
+#if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
+#pragma unroll
+#endif
+      for (int i=0;i<m;++i)
+        Y[i*ys0] += alpha[i*alphas0]*X[i*xs0];
+        
+      return 0;
+    }
+      
+    template<typename ScalarType,
+             typename ValueType>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const int m, const int n, 
+           const ScalarType *__restrict__ alpha, const int alphas0,
+           /* */ ValueType *__restrict__ X, const int xs0, const int xs1,
+           /* */ ValueType *__restrict__ Y, const int ys0, const int ys1) {
+
+      if (xs0 > xs1)
+        for (int i=0;i<m;++i)
+          invoke(n, alpha[i*alphas0], X+i*xs0, xs1, Y+i*ys0, ys1);
+      else
+        for (int j=0;j<n;++j)
+          invoke(m, alpha, alphas0, X+j*xs1, xs0, Y+j*ys1, ys0);
+        
+      return 0;
+    }
+  };
+
+  ///
+  /// Team Internal Impl
+  /// ==================== 
+  struct TeamAxpyInternal {
+    template<typename MemberType,
+             typename ScalarType,
+             typename ValueType>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const MemberType &member, 
+           const int m, 
+           const ScalarType alpha, 
+           /* */ ValueType *__restrict__ X, const int xs0,
+           /* */ ValueType *__restrict__ Y, const int ys0) {
+
+      Kokkos::parallel_for
+        (Kokkos::TeamThreadRange(member,m),
+         [&](const int &i) {
+          Y[i*ys0] += alpha*X[i*xs0];
+        });
+      //member.team_barrier();
+      return 0;
+    }
+
+    template<typename MemberType,
+             typename ScalarType,
+             typename ValueType>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const MemberType &member, 
+           const int m, 
+           const ScalarType *__restrict__ alpha, const int alphas0, 
+           /* */ ValueType *__restrict__ X, const int xs0,
+           /* */ ValueType *__restrict__ Y, const int ys0) {
+
+      Kokkos::parallel_for
+        (Kokkos::TeamThreadRange(member,m),
+         [&](const int &i) {
+          Y[i*ys0] += alpha[i*alphas0]*X[i*xs0];
+        });
+      //member.team_barrier();
+      return 0;
+    }
+      
+    template<typename MemberType,
+             typename ScalarType,
+             typename ValueType>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const MemberType &member, 
+           const int m, const int n, 
+           const ScalarType *__restrict__ alpha, const int alphas0, 
+           /* */ ValueType *__restrict__ X, const int xs0, const int xs1,
+           /* */ ValueType *__restrict__ Y, const int ys0, const int ys1) {
+      if (m > n) {
+        Kokkos::parallel_for
+          (Kokkos::TeamThreadRange(member,m),
+           [&](const int &i) {
+            SerialAxpyInternal::invoke(n, alpha[i*alphas0], X+i*xs0, xs1, Y+i*ys0, ys1);
+          });
+      } else {
+        Kokkos::parallel_for
+          (Kokkos::TeamThreadRange(member,n),
+           [&](const int &j) {
+            SerialAxpyInternal::invoke(m, alpha, alphas0, X+j*xs1, xs0, Y+j*ys1, ys0);
+          });
+      }
+      //member.team_barrier();
+      return 0;
+    }
+  };
+
+  ///
+  /// TeamVector Internal Impl
+  /// ======================== 
+  struct TeamVectorAxpyInternal {
+    template<typename MemberType,
+             typename ScalarType,
+             typename ValueType>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const MemberType &member, 
+           const int m, 
+           const ScalarType alpha, 
+           /* */ ValueType *__restrict__ X, const int xs0,
+           /* */ ValueType *__restrict__ Y, const int ys0) {
+
+      Kokkos::parallel_for
+        (Kokkos::TeamVectorRange(member,m),
+         [&](const int &i) {
+          Y[i*ys0] += alpha*X[i*xs0];
+        });
+      //member.team_barrier();
+      return 0;
+    }
+
+    template<typename MemberType,
+             typename ScalarType,
+             typename ValueType>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const MemberType &member, 
+           const int m, 
+           const ScalarType *__restrict__ alpha, const int alphas0, 
+           /* */ ValueType *__restrict__ X, const int xs0,
+           /* */ ValueType *__restrict__ Y, const int ys0) {
+
+      Kokkos::parallel_for
+        (Kokkos::TeamVectorRange(member,m),
+         [&](const int &i) {
+          Y[i*ys0] += alpha[i*alphas0]*X[i*xs0];
+        });
+      //member.team_barrier();
+      return 0;
+    }
+
+    template<typename layout>
+    KOKKOS_INLINE_FUNCTION
+    static void
+    getIndices(const int iTemp,
+               const int n_rows,
+               const int n_matrices,
+               int &iRow,
+               int &iMatrix) {
+      if (std::is_same<layout, Kokkos::LayoutLeft>::value) {
+        iRow    = iTemp / n_matrices;
+        iMatrix = iTemp % n_matrices;
+      }
+      else {
+        iRow    = iTemp % n_rows;
+        iMatrix = iTemp / n_rows;
+      }
+    }
+
+    template<typename MemberType,
+             typename ScalarType,
+             typename ValueType,
+             typename layout>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const MemberType &member, 
+           const int m, const int n, 
+           const ScalarType *__restrict__ alpha, const int alphas0, 
+           /* */ ValueType *__restrict__ X, const int xs0, const int xs1,
+           /* */ ValueType *__restrict__ Y, const int ys0, const int ys1) {
+      Kokkos::parallel_for(
+          Kokkos::TeamVectorRange(member, 0, m * n),
+          [&](const int& iTemp) {
+            int i, j;
+            getIndices<layout>(iTemp, n, m, j, i);
+            Y[i*ys0+j*ys1] += alpha[i*alphas0] * X[i*xs0+j*xs1];
+          });
+      //member.team_barrier();
+      return 0;
+    }
+  };
+
+}
+
+
+#endif

--- a/src/batched/KokkosBatched_Spmv_Decl.hpp
+++ b/src/batched/KokkosBatched_Spmv_Decl.hpp
@@ -1,0 +1,136 @@
+#ifndef __KOKKOSBATCHED_SPMV_DECL_HPP__
+#define __KOKKOSBATCHED_SPMV_DECL_HPP__
+
+
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "KokkosBatched_Util.hpp"
+#include "KokkosBatched_Vector.hpp"
+
+namespace KokkosBatched {
+
+  ///
+  /// Serial SPMV
+  ///
+  ///
+  /// y <- alpha * A * x + beta * y
+  ///
+  ///
+
+  template<typename ArgTrans,
+           typename ArgAlgo>
+  struct SerialSpmv {
+    template<typename DViewType,
+             typename IntView,
+             typename xViewType,
+             typename yViewType,
+             typename alphaViewType,
+             typename betaViewType,
+             int dobeta>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const alphaViewType &alpha,
+           const DViewType &D,
+           const IntView &r,
+           const IntView &c,
+           const xViewType &x,
+           const betaViewType &beta,
+           const yViewType &y);
+  };
+
+  ///
+  /// Team SPMV
+  ///
+
+  template<typename MemberType,
+           typename ArgTrans,
+           typename ArgAlgo>
+  struct TeamSpmv {
+    template<typename DViewType,
+             typename IntView,
+             typename xViewType,
+             typename yViewType,
+             typename alphaViewType,
+             typename betaViewType,
+             int dobeta>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const MemberType &member, 
+           const alphaViewType &alpha,
+           const DViewType &D,
+           const IntView &r,
+           const IntView &c,
+           const xViewType &x,
+           const betaViewType &beta,
+           const yViewType &y);
+  };
+
+  ///
+  /// TeamVector SPMV
+  ///
+
+  template<typename MemberType,
+           typename ArgTrans,
+           typename ArgAlgo>
+  struct TeamVectorSpmv {
+    template<typename DViewType,
+             typename IntView,
+             typename xViewType,
+             typename yViewType,
+             typename alphaViewType,
+             typename betaViewType,
+             int dobeta>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const MemberType &member, 
+           const alphaViewType &alpha,
+           const DViewType &D,
+           const IntView &r,
+           const IntView &c,
+           const xViewType &x,
+           const betaViewType &beta,
+           const yViewType &y);
+  };
+
+  ///
+  /// Selective Interface
+  ///
+  template<typename MemberType,
+           typename ArgTrans,
+           typename ArgMode, typename ArgAlgo>
+  struct Spmv {
+    template<typename DViewType,
+             typename IntView,
+             typename xViewType,
+             typename yViewType,
+             typename alphaViewType,
+             typename betaViewType,
+             int dobeta>
+    KOKKOS_FORCEINLINE_FUNCTION
+    static int
+    invoke(const MemberType &member, 
+           const alphaViewType &alpha,
+           const DViewType &D,
+           const IntView &r,
+           const IntView &c,
+           const xViewType &x,
+           const betaViewType &beta,
+           const yViewType &y) {
+      int r_val = 0;
+      if (std::is_same<ArgMode,Mode::Serial>::value) {
+        r_val = SerialSpmv<ArgTrans,ArgAlgo>::template invoke<DViewType, IntView, xViewType, yViewType, alphaViewType, betaViewType, dobeta>(alpha, D, r, c, x, beta, y);
+      } else if (std::is_same<ArgMode,Mode::Team>::value) {
+        r_val = TeamSpmv<MemberType,ArgTrans,ArgAlgo>::template invoke<DViewType, IntView, xViewType, yViewType, alphaViewType, betaViewType, dobeta>(member, alpha, D, r, c, x, beta, y);
+      } else if (std::is_same<ArgMode,Mode::TeamVector>::value) {
+        r_val = TeamVectorSpmv<MemberType,ArgTrans,ArgAlgo>::template invoke<DViewType, IntView, xViewType, yViewType, alphaViewType, betaViewType, dobeta>(member, alpha, D, r, c, x, beta, y);
+      } 
+      return r_val;
+    }      
+  };
+
+}
+
+#include "KokkosBatched_Spmv_Serial_Impl.hpp"
+#include "KokkosBatched_Spmv_Team_Impl.hpp"
+#include "KokkosBatched_Spmv_TeamVector_Impl.hpp"
+#endif

--- a/src/batched/KokkosBatched_Spmv_Serial_Impl.hpp
+++ b/src/batched/KokkosBatched_Spmv_Serial_Impl.hpp
@@ -1,0 +1,51 @@
+#ifndef __KOKKOSBATCHED_SPMV_SERIAL_IMPL_HPP__
+#define __KOKKOSBATCHED_SPMV_SERIAL_IMPL_HPP__
+
+
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "KokkosBatched_Util.hpp"
+#include "KokkosBatched_Spmv_Serial_Internal.hpp"
+
+namespace KokkosBatched {
+
+  template<typename ArgAlgo>
+  struct SerialSpmv<Trans::NoTranspose,ArgAlgo> {
+          
+    template<typename DViewType,
+             typename IntView,
+             typename xViewType,
+             typename yViewType,
+             typename alphaViewType,
+             typename betaViewType,
+             int dobeta>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const alphaViewType &alpha,
+           const DViewType &D,
+           const IntView &r,
+           const IntView &c,
+           const xViewType &X,
+           const betaViewType &beta,
+           const yViewType &Y) {
+      return SerialSpmvInternal<ArgAlgo>::template
+        invoke<typename alphaViewType::non_const_value_type, 
+               typename DViewType::non_const_value_type, 
+               typename IntView::non_const_value_type, 
+               typename DViewType::array_layout, 
+               dobeta>
+               (X.extent(0), X.extent(1),
+                alpha.data(), alpha.stride_0(),
+                D.data(), D.stride_0(), D.stride_1(),
+                r.data(), r.stride_0(),
+                c.data(), c.stride_0(),
+                X.data(), X.stride_0(), X.stride_1(),
+                beta.data(), beta.stride_0(),
+                Y.data(), Y.stride_0(), Y.stride_1());
+    }
+  };
+
+}
+
+
+#endif

--- a/src/batched/KokkosBatched_Spmv_Serial_Internal.hpp
+++ b/src/batched/KokkosBatched_Spmv_Serial_Internal.hpp
@@ -1,0 +1,62 @@
+#ifndef __KOKKOSBATCHED_SPMV_SERIAL_INTERNAL_HPP__
+#define __KOKKOSBATCHED_SPMV_SERIAL_INTERNAL_HPP__
+
+
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "KokkosBatched_Util.hpp"
+
+namespace KokkosBatched {
+
+  ///
+  /// Serial Internal Impl
+  /// ==================== 
+  template<typename ArgAlgo>
+  struct SerialSpmvInternal {
+    template <typename ScalarType,
+              typename ValueType,
+              typename OrdinalType,
+              typename layout,
+              int dobeta>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const OrdinalType m, const OrdinalType nrows, 
+           const ScalarType *__restrict__ alpha, const OrdinalType alphas0,
+           const ValueType *__restrict__ D, const OrdinalType ds0, const OrdinalType ds1,
+           const OrdinalType *__restrict__ r, const OrdinalType rs0,
+           const OrdinalType *__restrict__ c, const OrdinalType cs0,
+           const ValueType *__restrict__ X, const OrdinalType xs0, const OrdinalType xs1, 
+           const ScalarType *__restrict__ beta, const OrdinalType betas0,
+           /**/  ValueType *__restrict__ Y, const OrdinalType ys0, const OrdinalType ys1) {
+
+      for (OrdinalType iMatrix = 0; iMatrix < m; ++iMatrix) {
+        for (OrdinalType iRow = 0; iRow < nrows; ++iRow) {
+            const OrdinalType row_length =
+                r[(iRow+1)*rs0] - r[iRow*rs0];
+            ValueType sum = 0;
+  #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
+  #pragma unroll
+  #endif
+            for (OrdinalType iEntry = 0; iEntry < row_length; ++iEntry) {
+              sum += D[iMatrix*ds0+(r[iRow*rs0]+iEntry)*ds1]
+                      * X[iMatrix*xs0+c[(r[iRow*rs0]+iEntry)*cs0]*xs1];
+            }
+
+            sum *= alpha[iMatrix*alphas0];
+
+            if (dobeta == 0) {
+              Y[iMatrix*ys0+iRow*ys1] = sum;
+            } else {
+              Y[iMatrix*ys0+iRow*ys1] = 
+                  beta[iMatrix*betas0] * Y[iMatrix*ys0+iRow*ys1] + sum;
+            }
+        }
+      }
+        
+      return 0;  
+    }
+  };
+
+}
+
+#endif

--- a/src/batched/KokkosBatched_Spmv_TeamVector_Impl.hpp
+++ b/src/batched/KokkosBatched_Spmv_TeamVector_Impl.hpp
@@ -1,0 +1,54 @@
+#ifndef __KOKKOSBATCHED_SPMV_TEAMVECTOR_IMPL_HPP__
+#define __KOKKOSBATCHED_SPMV_TEAMVECTOR_IMPL_HPP__
+
+
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "KokkosBatched_Util.hpp"
+#include "KokkosBatched_Spmv_TeamVector_Internal.hpp"
+
+namespace KokkosBatched {
+
+  template<typename MemberType, typename ArgAlgo>
+  struct TeamVectorSpmv<MemberType,Trans::NoTranspose,ArgAlgo> {
+          
+    template<typename DViewType,
+             typename IntView,
+             typename xViewType,
+             typename yViewType,
+             typename alphaViewType,
+             typename betaViewType,
+             int dobeta>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const MemberType &member, 
+           const alphaViewType &alpha,
+           const DViewType &D,
+           const IntView &r,
+           const IntView &c,
+           const xViewType &X,
+           const betaViewType &beta,
+           const yViewType &Y) {
+      return TeamVectorSpmvInternal<ArgAlgo>::template
+        invoke<MemberType, 
+               typename alphaViewType::non_const_value_type, 
+               typename DViewType::non_const_value_type, 
+               typename IntView::non_const_value_type, 
+               typename DViewType::array_layout, 
+               dobeta>
+               (member, 
+                X.extent(0), X.extent(1),
+                alpha.data(), alpha.stride_0(),
+                D.data(), D.stride_0(), D.stride_1(),
+                r.data(), r.stride_0(),
+                c.data(), c.stride_0(),
+                X.data(), X.stride_0(), X.stride_1(),
+                beta.data(), beta.stride_0(),
+                Y.data(), Y.stride_0(), Y.stride_1());
+    }
+  };
+
+}
+
+
+#endif

--- a/src/batched/KokkosBatched_Spmv_TeamVector_Internal.hpp
+++ b/src/batched/KokkosBatched_Spmv_TeamVector_Internal.hpp
@@ -1,0 +1,120 @@
+#ifndef __KOKKOSBATCHED_SPMV_TEAMVECTOR_INTERNAL_HPP__
+#define __KOKKOSBATCHED_SPMV_TEAMVECTOR_INTERNAL_HPP__
+
+
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "KokkosBatched_Util.hpp"
+
+namespace KokkosBatched {
+
+  ///
+  /// TeamVector Internal Impl
+  /// ==================== 
+  template<typename ArgAlgo>
+  struct TeamVectorSpmvInternal {
+    template <typename OrdinalType,
+              typename layout>
+    KOKKOS_INLINE_FUNCTION
+    static void getIndices(const OrdinalType iTemp,
+                    const OrdinalType n_rows,
+                    const OrdinalType n_matrices,
+                    OrdinalType &iRow,
+                    OrdinalType &iMatrix);
+
+    template <typename MemberType,
+              typename ScalarType,
+              typename ValueType,
+              typename OrdinalType,
+              typename layout,
+              int dobeta>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const MemberType &member,
+           const OrdinalType m, const OrdinalType nrows, 
+           const ScalarType *__restrict__ alpha, const OrdinalType alphas0,
+           const ValueType *__restrict__ D, const OrdinalType ds0, const OrdinalType ds1,
+           const OrdinalType *__restrict__ r, const OrdinalType rs0,
+           const OrdinalType *__restrict__ c, const OrdinalType cs0,
+           const ValueType *__restrict__ X, const OrdinalType xs0, const OrdinalType xs1, 
+           const ScalarType *__restrict__ beta, const OrdinalType betas0,
+           /**/  ValueType *__restrict__ Y, const OrdinalType ys0, const OrdinalType ys1);
+  };
+
+
+  template<>
+  template <typename OrdinalType,
+            typename layout>
+  KOKKOS_INLINE_FUNCTION
+  void
+  TeamVectorSpmvInternal<Algo::Spmv::Unblocked>:: 
+  getIndices(const OrdinalType iTemp,
+             const OrdinalType n_rows,
+             const OrdinalType n_matrices,
+             OrdinalType &iRow,
+             OrdinalType &iMatrix) {
+    if (std::is_same<layout, Kokkos::LayoutLeft>::value) {
+      iRow    = iTemp / n_matrices;
+      iMatrix = iTemp % n_matrices;
+    }
+    else {
+      iRow    = iTemp % n_rows;
+      iMatrix = iTemp / n_rows;
+    }
+  }
+
+  template<>
+  template <typename MemberType,
+            typename ScalarType,
+            typename ValueType,
+            typename OrdinalType,
+            typename layout,
+            int dobeta>
+  KOKKOS_INLINE_FUNCTION
+  int
+  TeamVectorSpmvInternal<Algo::Spmv::Unblocked>::
+  invoke(const MemberType &member,
+         const OrdinalType m, const OrdinalType nrows, 
+         const ScalarType *__restrict__ alpha, const OrdinalType alphas0,
+         const ValueType *__restrict__ D, const OrdinalType ds0, const OrdinalType ds1,
+         const OrdinalType *__restrict__ r, const OrdinalType rs0,
+         const OrdinalType *__restrict__ c, const OrdinalType cs0,
+         const ValueType *__restrict__ X, const OrdinalType xs0, const OrdinalType xs1,
+         const ScalarType *__restrict__ beta, const OrdinalType betas0,
+         /**/  ValueType *__restrict__ Y, const OrdinalType ys0, const OrdinalType ys1) {
+
+
+    Kokkos::parallel_for(
+        Kokkos::TeamVectorRange(member, 0, m * nrows),
+        [&](const OrdinalType& iTemp) {
+          OrdinalType iRow, iMatrix;
+          getIndices<OrdinalType,layout>(iTemp, nrows, m, iRow, iMatrix);
+
+          const OrdinalType row_length =
+              r[(iRow+1)*rs0] - r[iRow*rs0];
+          ValueType sum = 0;
+#if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
+#pragma unroll
+#endif
+          for (OrdinalType iEntry = 0; iEntry < row_length; ++iEntry) {
+            sum += D[iMatrix*ds0+(r[iRow*rs0]+iEntry)*ds1]
+                    * X[iMatrix*xs0+c[(r[iRow*rs0]+iEntry)*cs0]*xs1];
+          }
+
+          sum *= alpha[iMatrix*alphas0];
+
+          if (dobeta == 0) {
+            Y[iMatrix*ys0+iRow*ys1] = sum;
+          } else {
+            Y[iMatrix*ys0+iRow*ys1] = 
+                beta[iMatrix*betas0] * Y[iMatrix*ys0+iRow*ys1] + sum;
+          }
+      });
+      
+    return 0;  
+  }
+
+}
+
+
+#endif

--- a/src/batched/KokkosBatched_Spmv_Team_Impl.hpp
+++ b/src/batched/KokkosBatched_Spmv_Team_Impl.hpp
@@ -1,0 +1,54 @@
+#ifndef __KOKKOSBATCHED_SPMV_TEAM_IMPL_HPP__
+#define __KOKKOSBATCHED_SPMV_TEAM_IMPL_HPP__
+
+
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "KokkosBatched_Util.hpp"
+#include "KokkosBatched_Spmv_Team_Internal.hpp"
+
+namespace KokkosBatched {
+
+  template<typename MemberType, typename ArgAlgo>
+  struct TeamSpmv<MemberType,Trans::NoTranspose,ArgAlgo> {
+          
+    template<typename DViewType,
+             typename IntView,
+             typename xViewType,
+             typename yViewType,
+             typename alphaViewType,
+             typename betaViewType,
+             int dobeta>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const MemberType &member, 
+           const alphaViewType &alpha,
+           const DViewType &D,
+           const IntView &r,
+           const IntView &c,
+           const xViewType &X,
+           const betaViewType &beta,
+           const yViewType &Y) {
+      return TeamSpmvInternal<ArgAlgo>::template
+        invoke<MemberType,
+               typename alphaViewType::non_const_value_type, 
+               typename DViewType::non_const_value_type, 
+               typename IntView::non_const_value_type, 
+               typename DViewType::array_layout, 
+               dobeta>
+               (member, 
+                X.extent(0), X.extent(1),
+                alpha.data(), alpha.stride_0(),
+                D.data(), D.stride_0(), D.stride_1(),
+                r.data(), r.stride_0(),
+                c.data(), c.stride_0(),
+                X.data(), X.stride_0(), X.stride_1(),
+                beta.data(), beta.stride_0(),
+                Y.data(), Y.stride_0(), Y.stride_1());
+    }
+  };
+
+}
+
+
+#endif

--- a/src/batched/KokkosBatched_Spmv_Team_Internal.hpp
+++ b/src/batched/KokkosBatched_Spmv_Team_Internal.hpp
@@ -1,0 +1,120 @@
+#ifndef __KOKKOSBATCHED_SPMV_TEAM_INTERNAL_HPP__
+#define __KOKKOSBATCHED_SPMV_TEAM_INTERNAL_HPP__
+
+
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "KokkosBatched_Util.hpp"
+
+namespace KokkosBatched {
+
+  ///
+  /// Team Internal Impl
+  /// ==================== 
+  template<typename ArgAlgo>
+  struct TeamSpmvInternal {
+    template <typename OrdinalType,
+              typename layout>
+    KOKKOS_INLINE_FUNCTION
+    static void getIndices(const OrdinalType iTemp,
+                    const OrdinalType n_rows,
+                    const OrdinalType n_matrices,
+                    OrdinalType &iRow,
+                    OrdinalType &iMatrix);
+
+    template <typename MemberType,
+              typename ScalarType,
+              typename ValueType,
+              typename OrdinalType,
+              typename layout,
+              int dobeta>
+    KOKKOS_INLINE_FUNCTION
+    static int
+    invoke(const MemberType &member,
+           const OrdinalType m, const OrdinalType nrows, 
+           const ScalarType *__restrict__ alpha, const OrdinalType alphas0,
+           const ValueType *__restrict__ D, const OrdinalType ds0, const OrdinalType ds1,
+           const OrdinalType *__restrict__ r, const OrdinalType rs0,
+           const OrdinalType *__restrict__ c, const OrdinalType cs0,
+           const ValueType *__restrict__ X, const OrdinalType xs0, const OrdinalType xs1, 
+           const ScalarType *__restrict__ beta, const OrdinalType betas0,
+           /**/  ValueType *__restrict__ Y, const OrdinalType ys0, const OrdinalType ys1);
+  };
+
+
+  template<>
+  template <typename OrdinalType,
+            typename layout>
+  KOKKOS_INLINE_FUNCTION
+  void
+  TeamSpmvInternal<Algo::Spmv::Unblocked>:: 
+  getIndices(const OrdinalType iTemp,
+             const OrdinalType n_rows,
+             const OrdinalType n_matrices,
+             OrdinalType &iRow,
+             OrdinalType &iMatrix) {
+    if (std::is_same<layout, Kokkos::LayoutLeft>::value) {
+      iRow    = iTemp / n_matrices;
+      iMatrix = iTemp % n_matrices;
+    }
+    else {
+      iRow    = iTemp % n_rows;
+      iMatrix = iTemp / n_rows;
+    }
+  }
+
+  template<>
+  template <typename MemberType,
+            typename ScalarType,
+            typename ValueType,
+            typename OrdinalType,
+            typename layout,
+            int dobeta>
+  KOKKOS_INLINE_FUNCTION
+  int
+  TeamSpmvInternal<Algo::Spmv::Unblocked>::
+  invoke(const MemberType &member,
+         const OrdinalType m, const OrdinalType nrows, 
+         const ScalarType *__restrict__ alpha, const OrdinalType alphas0,
+         const ValueType *__restrict__ D, const OrdinalType ds0, const OrdinalType ds1,
+         const OrdinalType *__restrict__ r, const OrdinalType rs0,
+         const OrdinalType *__restrict__ c, const OrdinalType cs0,
+         const ValueType *__restrict__ X, const OrdinalType xs0, const OrdinalType xs1,
+         const ScalarType *__restrict__ beta, const OrdinalType betas0,
+         /**/  ValueType *__restrict__ Y, const OrdinalType ys0, const OrdinalType ys1) {
+
+
+    Kokkos::parallel_for(
+        Kokkos::TeamThreadRange(member, 0, m * nrows),
+        [&](const OrdinalType& iTemp) {
+          OrdinalType iRow, iMatrix;
+          getIndices<OrdinalType,layout>(iTemp, nrows, m, iRow, iMatrix);
+
+          const OrdinalType row_length =
+              r[(iRow+1)*rs0] - r[iRow*rs0];
+          ValueType sum = 0;
+#if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
+#pragma unroll
+#endif
+          for (OrdinalType iEntry = 0; iEntry < row_length; ++iEntry) {
+            sum += D[iMatrix*ds0+(r[iRow*rs0]+iEntry)*ds1]
+                    * X[iMatrix*xs0+c[(r[iRow*rs0]+iEntry)*cs0]*xs1];
+          }
+
+          sum *= alpha[iMatrix*alphas0];
+
+          if (dobeta == 0) {
+            Y[iMatrix*ys0+iRow*ys1] = sum;
+          } else {
+            Y[iMatrix*ys0+iRow*ys1] = 
+                beta[iMatrix*betas0] * Y[iMatrix*ys0+iRow*ys1] + sum;
+          }
+      });
+      
+    return 0;  
+  }
+
+}
+
+
+#endif

--- a/src/batched/KokkosBatched_Util.hpp
+++ b/src/batched/KokkosBatched_Util.hpp
@@ -390,6 +390,7 @@ namespace KokkosBatched {
     };
 
     using Gemv = Level2;
+    using Spmv = Level2;
     using Trsv = Level2;
     using ApplyQ = Level2;
 

--- a/unit_test/batched/Test_Batched.hpp
+++ b/unit_test/batched/Test_Batched.hpp
@@ -2,6 +2,9 @@
 #define TEST_BATCHED_HPP
 
 // Serial kernels
+#include "Test_Batched_SerialAxpy.hpp"
+#include "Test_Batched_SerialAxpy_Real.hpp"
+#include "Test_Batched_SerialAxpy_Complex.hpp"
 #include "Test_Batched_SerialEigendecomposition.hpp"
 #include "Test_Batched_SerialEigendecomposition_Real.hpp"
 #include "Test_Batched_SerialGemm.hpp"
@@ -25,6 +28,8 @@
 #include "Test_Batched_SerialSolveLU.hpp"
 #include "Test_Batched_SerialSolveLU_Real.hpp"
 #include "Test_Batched_SerialSolveLU_Complex.hpp"
+#include "Test_Batched_SerialSpmv.hpp"
+#include "Test_Batched_SerialSpmv_Real.hpp"
 #include "Test_Batched_SerialTrmm.hpp"
 #include "Test_Batched_SerialTrmm_Real.hpp"
 #include "Test_Batched_SerialTrmm_Complex.hpp"
@@ -39,6 +44,9 @@
 #include "Test_Batched_SerialTrtri_Complex.hpp"
 
 // Team Kernels
+#include "Test_Batched_TeamAxpy.hpp"
+#include "Test_Batched_TeamAxpy_Real.hpp"
+#include "Test_Batched_TeamAxpy_Complex.hpp"
 #include "Test_Batched_TeamGemm.hpp"
 #include "Test_Batched_TeamGemm_Real.hpp"
 #include "Test_Batched_TeamGemm_Complex.hpp"
@@ -57,6 +65,8 @@
 #include "Test_Batched_TeamSolveLU.hpp"
 #include "Test_Batched_TeamSolveLU_Real.hpp"
 #include "Test_Batched_TeamSolveLU_Complex.hpp"
+#include "Test_Batched_TeamSpmv.hpp"
+#include "Test_Batched_TeamSpmv_Real.hpp"
 #include "Test_Batched_TeamTrsm.hpp"
 #include "Test_Batched_TeamTrsm_Real.hpp"
 #include "Test_Batched_TeamTrsm_Complex.hpp"
@@ -65,6 +75,9 @@
 #include "Test_Batched_TeamTrsv_Complex.hpp"
 
 // TeamVector Kernels
+#include "Test_Batched_TeamVectorAxpy.hpp"
+#include "Test_Batched_TeamVectorAxpy_Real.hpp"
+#include "Test_Batched_TeamVectorAxpy_Complex.hpp"
 #include "Test_Batched_TeamVectorEigendecomposition.hpp"
 #include "Test_Batched_TeamVectorEigendecomposition_Real.hpp"
 #include "Test_Batched_TeamVectorGemm.hpp"
@@ -78,6 +91,8 @@
 #include "Test_Batched_TeamVectorSolveUTV_Real.hpp"
 #include "Test_Batched_TeamVectorSolveUTV2.hpp"
 #include "Test_Batched_TeamVectorSolveUTV2_Real.hpp"
+#include "Test_Batched_TeamVectorSpmv.hpp"
+#include "Test_Batched_TeamVectorSpmv_Real.hpp"
 #include "Test_Batched_TeamVectorUTV.hpp"
 #include "Test_Batched_TeamVectorUTV_Real.hpp"
 

--- a/unit_test/batched/Test_Batched_SerialAxpy.hpp
+++ b/unit_test/batched/Test_Batched_SerialAxpy.hpp
@@ -1,0 +1,147 @@
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "gtest/gtest.h"
+#include "Kokkos_Core.hpp"
+#include "Kokkos_Random.hpp"
+
+//#include "KokkosBatched_Vector.hpp"
+
+#include "KokkosBatched_Axpy_Decl.hpp"
+#include "KokkosBatched_Axpy_Impl.hpp"
+
+#include "KokkosKernels_TestUtils.hpp"
+
+using namespace KokkosBatched;
+
+namespace Test {
+namespace Axpy {
+ 
+  template<typename DeviceType,
+           typename ViewType,
+           typename alphaViewType>
+  struct Functor_TestBatchedSerialAxpy {
+    const alphaViewType _alpha;
+    const ViewType _X;
+    const ViewType _Y;
+    
+    KOKKOS_INLINE_FUNCTION
+    Functor_TestBatchedSerialAxpy(const alphaViewType &alpha,
+      const ViewType &X,
+      const ViewType &Y)
+    : _alpha(alpha), _X(X), _Y(Y) {}
+    
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const int k) const {
+      auto alpha = Kokkos::subview(_alpha,Kokkos::make_pair(k,k+1));
+      auto x = Kokkos::subview(_X,Kokkos::make_pair(k,k+1),Kokkos::ALL);
+      auto y = Kokkos::subview(_Y,Kokkos::make_pair(k,k+1),Kokkos::ALL);
+      
+      KokkosBatched::SerialAxpy::template invoke<ViewType, alphaViewType>
+          (alpha, x, y);
+    }
+    
+    inline
+    void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::SerialAxpy");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion(name.c_str() );
+      Kokkos::RangePolicy<DeviceType> policy(0, _X.extent(0));
+      Kokkos::parallel_for(name.c_str(), policy, *this);
+      Kokkos::Profiling::popRegion();
+    }
+  };
+    
+  template<typename DeviceType,
+           typename ViewType,
+           typename alphaViewType>
+  void impl_test_batched_axpy(const int N, const int BlkSize) {
+    typedef typename ViewType::value_type value_type;
+    typedef Kokkos::Details::ArithTraits<value_type> ats;
+
+    ViewType  X0("x0", N, BlkSize), X1("x1", N, BlkSize), Y0("y0", N, BlkSize), Y1("y1", N, BlkSize);
+
+    alphaViewType  alpha("alpha", N);
+
+    Kokkos::Random_XorShift64_Pool<typename DeviceType::execution_space> random(13718);
+    Kokkos::fill_random(X0, random, value_type(1.0));
+    Kokkos::fill_random(Y0, random, value_type(1.0));
+    Kokkos::fill_random(alpha, random, value_type(1.0));
+
+    Kokkos::fence();
+
+    Kokkos::deep_copy(X1, X0);
+    Kokkos::deep_copy(Y1, Y0);
+
+    /// test body
+    auto alpha_host = Kokkos::create_mirror_view(alpha);
+    auto X0_host = Kokkos::create_mirror_view(X0);
+    auto Y0_host = Kokkos::create_mirror_view(Y0);
+
+    Kokkos::deep_copy(alpha_host, alpha);
+    Kokkos::deep_copy(X0_host, X0);
+    Kokkos::deep_copy(Y0_host, Y0);
+
+    for (int l=0;l<N;++l) 
+      for (int i=0;i<BlkSize;++i)
+        Y0_host(l,i) += alpha_host(l)*X0_host(l,i);
+
+    Functor_TestBatchedSerialAxpy<DeviceType,ViewType,alphaViewType>
+    (alpha, X1, Y1).run();
+
+    Kokkos::fence();
+
+    /// for comparison send it to host
+    auto Y1_host = Kokkos::create_mirror_view(Y1);
+
+    Kokkos::deep_copy(Y1_host, Y1);
+
+    /// check c0 = c1 ; this eps is about 10^-14
+    typedef typename ats::mag_type mag_type;
+    mag_type sum(1), diff(0);
+    const mag_type eps = 1.0e3 * ats::epsilon();
+
+    for (int l=0;l<N;++l) 
+      for (int i=0;i<BlkSize;++i) {
+        sum  += ats::abs(Y0_host(l,i));
+        diff += ats::abs(Y0_host(l,i)-Y1_host(l,i));
+      }
+    EXPECT_NEAR_KK( diff/sum, 0, eps);
+  }
+}
+}
+
+template<typename DeviceType, 
+         typename ValueType, 
+         typename ScalarType>
+int test_batched_axpy() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) 
+  {
+    typedef Kokkos::View<ValueType**,Kokkos::LayoutLeft,DeviceType> ViewType;
+    typedef Kokkos::View<ValueType*,Kokkos::LayoutLeft,DeviceType> alphaViewType;
+    
+    Test::Axpy::impl_test_batched_axpy<DeviceType,ViewType,alphaViewType>( 0, 10);
+    for (int i=3;i<10;++i) {                                                                                        
+      Test::Axpy::impl_test_batched_axpy<DeviceType,ViewType,alphaViewType>(1024,  i);
+    }
+  }
+#endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) 
+  {
+    typedef Kokkos::View<ValueType**,Kokkos::LayoutRight,DeviceType> ViewType;
+    typedef Kokkos::View<ValueType*,Kokkos::LayoutRight,DeviceType> alphaViewType;
+
+    Test::Axpy::impl_test_batched_axpy<DeviceType,ViewType,alphaViewType>( 0, 10);
+    for (int i=3;i<10;++i) {                                                                                        
+      Test::Axpy::impl_test_batched_axpy<DeviceType,ViewType,alphaViewType>(1024,  i);
+    }
+  }
+#endif
+  
+  return 0;
+}
+

--- a/unit_test/batched/Test_Batched_SerialAxpy_Complex.hpp
+++ b/unit_test/batched/Test_Batched_SerialAxpy_Complex.hpp
@@ -1,0 +1,10 @@
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
+TEST_F( TestCategory, batched_scalar_serial_axpy_nt_dcomplex_dcomplex ) {
+  test_batched_axpy<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>>();
+}
+
+TEST_F( TestCategory, batched_scalar_serial_axpy_nt_dcomplex_double ) {
+  test_batched_axpy<TestExecSpace,Kokkos::complex<double>,double>();
+}
+#endif

--- a/unit_test/batched/Test_Batched_SerialAxpy_Real.hpp
+++ b/unit_test/batched/Test_Batched_SerialAxpy_Real.hpp
@@ -1,0 +1,12 @@
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+TEST_F( TestCategory, batched_scalar_serial_axpy_nt_float_float ) {
+  test_batched_axpy<TestExecSpace,float,float>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+TEST_F( TestCategory, batched_scalar_serial_axpy_nt_double_double ) {
+  test_batched_axpy<TestExecSpace,double,double>();
+}
+#endif

--- a/unit_test/batched/Test_Batched_SerialSpmv.hpp
+++ b/unit_test/batched/Test_Batched_SerialSpmv.hpp
@@ -1,0 +1,245 @@
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "gtest/gtest.h"
+#include "Kokkos_Core.hpp"
+#include "Kokkos_Random.hpp"
+
+//#include "KokkosBatched_Vector.hpp"
+
+#include "KokkosBatched_Spmv_Decl.hpp"
+#include "KokkosBatched_Spmv_Serial_Impl.hpp"
+
+#include "KokkosKernels_TestUtils.hpp"
+
+using namespace KokkosBatched;
+
+namespace Test {
+namespace Spmv {
+
+  template<typename T>
+  struct ParamTag { 
+    typedef T trans;
+  };
+ 
+  template<typename DeviceType,
+           typename ParamTagType, 
+           typename AlgoTagType,
+           typename DViewType,
+           typename IntView,
+           typename xViewType,
+           typename yViewType,
+           typename alphaViewType,
+           typename betaViewType,
+           int dobeta>
+  struct Functor_TestBatchedSerialSpmv {
+    const alphaViewType _alpha;
+    const DViewType _D;
+    const IntView _r;
+    const IntView _c;
+    const xViewType _X;
+    const betaViewType _beta;
+    const yViewType _Y;
+    
+    KOKKOS_INLINE_FUNCTION
+    Functor_TestBatchedSerialSpmv(const alphaViewType &alpha,
+      const DViewType &D,
+      const IntView &r,
+      const IntView &c,
+      const xViewType &X,
+      const betaViewType &beta,
+      const yViewType &Y)
+    : _alpha(alpha), _D(D), _r(r), _c(c), _X(X), _beta(beta), _Y(Y) {}
+    
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const ParamTagType &, const int k) const {
+      auto alpha = Kokkos::subview(_alpha,Kokkos::make_pair(k,k+1));
+      auto d = Kokkos::subview(_D,Kokkos::make_pair(k,k+1),Kokkos::ALL);
+      auto x = Kokkos::subview(_X,Kokkos::make_pair(k,k+1),Kokkos::ALL);
+      auto beta = Kokkos::subview(_beta,Kokkos::make_pair(k,k+1));
+      auto y = Kokkos::subview(_Y,Kokkos::make_pair(k,k+1),Kokkos::ALL);
+      
+      KokkosBatched::SerialSpmv<typename ParamTagType::trans, AlgoTagType>::template invoke<DViewType, IntView, xViewType, yViewType, alphaViewType, betaViewType, dobeta>
+          (alpha, d, _r, _c, x, beta, y);
+    }
+    
+    inline
+    void run() {
+      typedef typename DViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::SerialSpmv");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion(name.c_str() );
+      Kokkos::RangePolicy<DeviceType,ParamTagType> policy(0, _D.extent(0));
+      Kokkos::parallel_for(name.c_str(), policy, *this);
+      Kokkos::Profiling::popRegion();
+    }
+  };
+    
+  template<typename DeviceType,
+           typename ParamTagType, 
+           typename AlgoTagType,
+           typename DViewType,
+           typename IntView,
+           typename xViewType,
+           typename yViewType,
+           typename alphaViewType,
+           typename betaViewType,
+           int dobeta>
+  void impl_test_batched_spmv(const int N, const int BlkSize) {
+    typedef typename DViewType::value_type value_type;
+    typedef Kokkos::Details::ArithTraits<value_type> ats;
+
+    const int nnz = (BlkSize-2) * 3 + 2 * 2;
+
+    xViewType  X0("x0", N, BlkSize), X1("x1", N, BlkSize);
+    yViewType  Y0("y0", N, BlkSize), Y1("y1", N, BlkSize);
+    DViewType  D("D", N, nnz);
+    IntView    r("r", BlkSize+1);
+    IntView    c("c", nnz);
+
+    alphaViewType  alpha("alpha", N);
+    betaViewType   beta("beta", N);
+
+    Kokkos::deep_copy(alpha, value_type(1.0));
+    Kokkos::deep_copy(beta, value_type(1.0));
+
+    Kokkos::Random_XorShift64_Pool<typename DeviceType::execution_space> random(13718);
+    Kokkos::fill_random(X0, random, value_type(1.0));
+    Kokkos::fill_random(Y0, random, value_type(1.0));
+
+    auto D_host = Kokkos::create_mirror_view(D);
+    auto r_host = Kokkos::create_mirror_view(r);
+    auto c_host = Kokkos::create_mirror_view(c);
+
+    r_host(0) = 0;
+
+    int current_col = 0;
+
+    for (int i=0;i<BlkSize;++i) {
+      r_host(i+1) = r_host(i) + (i==0 || i==(BlkSize-1) ? 2 : 3);
+    }
+    for (int i=0;i<nnz;++i) {
+      if (i%3 == 0) {
+        for (int l=0;l<N;++l) {
+          D_host(l,i) = value_type(1.0);
+        }
+        c_host(i) = current_col;
+        ++current_col;
+      }
+      else {
+        for (int l=0;l<N;++l) {
+          D_host(l,i) = value_type(0.5);
+        }
+        c_host(i) = current_col;
+        if (i%3 == 1)
+          --current_col;
+        else
+          ++current_col;
+      }
+    }
+
+    Kokkos::fence();
+
+    Kokkos::deep_copy(D, D_host);
+    Kokkos::deep_copy(r, r_host);
+    Kokkos::deep_copy(c, c_host);
+
+    Kokkos::deep_copy(X1, X0);
+    Kokkos::deep_copy(Y1, Y0);
+
+    /// test body
+    auto alpha_host = Kokkos::create_mirror_view(alpha);
+    auto beta_host = Kokkos::create_mirror_view(beta);
+    auto X0_host = Kokkos::create_mirror_view(X0);
+    auto Y0_host = Kokkos::create_mirror_view(Y0);
+
+    Kokkos::deep_copy(alpha_host, alpha);
+    Kokkos::deep_copy(beta_host, beta);
+    Kokkos::deep_copy(X0_host, X0);
+    Kokkos::deep_copy(Y0_host, Y0);
+
+    for (int l=0;l<N;++l) 
+      for (int i=0;i<BlkSize;++i) {
+        if (dobeta == 0)
+          Y0_host(l,i) = value_type(0.0);
+        else
+          Y0_host(l,i) *= beta_host(l);
+        if (i != 0 && i != (BlkSize-1))
+          Y0_host(l,i) += alpha_host(l)*(X0_host(l,i) + 0.5*X0_host(l,i-1) + 0.5*X0_host(l,i+1));
+        else if (i == 0)
+          Y0_host(l,i) += alpha_host(l)*(X0_host(l,i) + 0.5*X0_host(l,i+1));
+        else
+          Y0_host(l,i) += alpha_host(l)*(X0_host(l,i) + 0.5*X0_host(l,i-1));
+      }
+
+    Functor_TestBatchedSerialSpmv<DeviceType,ParamTagType,AlgoTagType,DViewType,IntView,xViewType,yViewType,alphaViewType,betaViewType,dobeta>
+    (alpha, D, r, c, X1, beta, Y1).run();
+
+    Kokkos::fence();
+
+    /// for comparison send it to host
+    auto Y1_host = Kokkos::create_mirror_view(Y1);
+
+    Kokkos::deep_copy(Y1_host, Y1);
+
+    /// check c0 = c1 ; this eps is about 10^-14
+    typedef typename ats::mag_type mag_type;
+    mag_type sum(1), diff(0);
+    const mag_type eps = 1.0e3 * ats::epsilon();
+
+    for (int l=0;l<N;++l) 
+      for (int i=0;i<BlkSize;++i) {
+        sum  += ats::abs(Y0_host(l,i));
+        diff += ats::abs(Y0_host(l,i)-Y1_host(l,i));
+      }
+    EXPECT_NEAR_KK( diff/sum, 0, eps);
+  }
+}
+}
+
+template<typename DeviceType, 
+         typename ValueType, 
+         typename ScalarType,
+         typename ParamTagType,
+         typename AlgoTagType>
+int test_batched_spmv() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) 
+  {
+    typedef Kokkos::View<ValueType**,Kokkos::LayoutLeft,DeviceType> ViewType;
+    typedef Kokkos::View<int*,Kokkos::LayoutLeft,DeviceType> IntView;
+    typedef Kokkos::View<ValueType*,Kokkos::LayoutLeft,DeviceType> alphaViewType;
+    
+    Test::Spmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,0>( 0, 10);
+    for (int i=3;i<10;++i) {                                                                                        
+      Test::Spmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,0>(1024,  i);
+    }
+    Test::Spmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,1>( 0, 10);
+    for (int i=3;i<10;++i) {                                                                                        
+      Test::Spmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,1>(1024,  i);
+    }
+  }
+#endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) 
+  {
+    typedef Kokkos::View<ValueType**,Kokkos::LayoutRight,DeviceType> ViewType;
+    typedef Kokkos::View<int*,Kokkos::LayoutRight,DeviceType> IntView;
+    typedef Kokkos::View<ValueType*,Kokkos::LayoutRight,DeviceType> alphaViewType;
+
+    Test::Spmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,0>( 0, 10);
+    for (int i=3;i<10;++i) {                                                                                        
+      Test::Spmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,0>(1024,  i);
+    }
+
+    Test::Spmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,1>( 0, 10);
+    for (int i=3;i<10;++i) {                                                                                         
+      Test::Spmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,1>(1024,  i);
+    }
+  }
+#endif
+  
+  return 0;
+}
+

--- a/unit_test/batched/Test_Batched_SerialSpmv_Real.hpp
+++ b/unit_test/batched/Test_Batched_SerialSpmv_Real.hpp
@@ -1,0 +1,16 @@
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+TEST_F( TestCategory, batched_scalar_serial_spmv_nt_float_float ) {
+  typedef ::Test::Spmv::ParamTag<Trans::NoTranspose> param_tag_type;
+  typedef Algo::Spmv::Unblocked algo_tag_type;
+  test_batched_spmv<TestExecSpace,float,float,param_tag_type,algo_tag_type>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+TEST_F( TestCategory, batched_scalar_serial_spmv_nt_double_double ) {
+  typedef ::Test::Spmv::ParamTag<Trans::NoTranspose> param_tag_type;
+  typedef Algo::Spmv::Unblocked algo_tag_type;
+  test_batched_spmv<TestExecSpace,double,double,param_tag_type,algo_tag_type>();
+}
+#endif

--- a/unit_test/batched/Test_Batched_TeamAxpy.hpp
+++ b/unit_test/batched/Test_Batched_TeamAxpy.hpp
@@ -1,0 +1,155 @@
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "gtest/gtest.h"
+#include "Kokkos_Core.hpp"
+#include "Kokkos_Random.hpp"
+
+//#include "KokkosBatched_Vector.hpp"
+
+#include "KokkosBatched_Axpy_Decl.hpp"
+#include "KokkosBatched_Axpy_Impl.hpp"
+
+#include "KokkosKernels_TestUtils.hpp"
+
+using namespace KokkosBatched;
+
+namespace Test {
+namespace TeamAxpy {
+ 
+  template<typename DeviceType,
+           typename ViewType,
+           typename alphaViewType>
+  struct Functor_TestBatchedTeamAxpy {
+    const alphaViewType _alpha;
+    const ViewType _X;
+    const ViewType _Y;
+    const int _N_team;
+    
+    KOKKOS_INLINE_FUNCTION
+    Functor_TestBatchedTeamAxpy(const alphaViewType &alpha,
+      const ViewType &X,
+      const ViewType &Y,
+      const int N_team)
+    : _alpha(alpha), _X(X), _Y(Y), _N_team(N_team) {}
+    
+    template<typename MemberType>
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const MemberType &member) const {
+      const int first_matrix =
+          static_cast<int>(member.league_rank()) * _N_team;
+      const int N = _X.extent(0);
+      const int last_matrix = (static_cast<int>(member.league_rank() + 1) * _N_team < N ? static_cast<int>(member.league_rank() + 1) * _N_team : N );
+
+      auto alpha = Kokkos::subview(_alpha,Kokkos::make_pair(first_matrix,last_matrix));
+      auto x = Kokkos::subview(_X,Kokkos::make_pair(first_matrix,last_matrix),Kokkos::ALL);
+      auto y = Kokkos::subview(_Y,Kokkos::make_pair(first_matrix,last_matrix),Kokkos::ALL);
+      
+      KokkosBatched::TeamAxpy<MemberType>::template invoke<ViewType, alphaViewType>
+          (member, alpha, x, y);
+    }
+    
+    inline
+    void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::TeamAxpy");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion(name.c_str() );
+      Kokkos::TeamPolicy<DeviceType> policy(_X.extent(0)/_N_team, Kokkos::AUTO(), Kokkos::AUTO());
+      Kokkos::parallel_for(name.c_str(), policy, *this);
+      Kokkos::Profiling::popRegion();
+    }
+  };
+    
+  template<typename DeviceType,
+           typename ViewType,
+           typename alphaViewType>
+  void impl_test_batched_axpy(const int N, const int BlkSize, const int N_team) {
+    typedef typename ViewType::value_type value_type;
+    typedef Kokkos::Details::ArithTraits<value_type> ats;
+
+    ViewType  X0("x0", N, BlkSize), X1("x1", N, BlkSize), Y0("y0", N, BlkSize), Y1("y1", N, BlkSize);
+
+    alphaViewType  alpha("alpha", N);
+
+    Kokkos::Random_XorShift64_Pool<typename DeviceType::execution_space> random(13718);
+    Kokkos::fill_random(X0, random, value_type(1.0));
+    Kokkos::fill_random(Y0, random, value_type(1.0));
+    Kokkos::fill_random(alpha, random, value_type(1.0));
+
+    Kokkos::fence();
+
+    Kokkos::deep_copy(X1, X0);
+    Kokkos::deep_copy(Y1, Y0);
+
+    /// test body
+    auto alpha_host = Kokkos::create_mirror_view(alpha);
+    auto X0_host = Kokkos::create_mirror_view(X0);
+    auto Y0_host = Kokkos::create_mirror_view(Y0);
+
+    Kokkos::deep_copy(alpha_host, alpha);
+    Kokkos::deep_copy(X0_host, X0);
+    Kokkos::deep_copy(Y0_host, Y0);
+
+    for (int l=0;l<N;++l) 
+      for (int i=0;i<BlkSize;++i)
+        Y0_host(l,i) += alpha_host(l)*X0_host(l,i);
+
+    Functor_TestBatchedTeamAxpy<DeviceType,ViewType,alphaViewType>
+    (alpha, X1, Y1, N_team).run();
+
+    Kokkos::fence();
+
+    /// for comparison send it to host
+    auto Y1_host = Kokkos::create_mirror_view(Y1);
+
+    Kokkos::deep_copy(Y1_host, Y1);
+
+    /// check c0 = c1 ; this eps is about 10^-14
+    typedef typename ats::mag_type mag_type;
+    mag_type sum(1), diff(0);
+    const mag_type eps = 1.0e3 * ats::epsilon();
+
+    for (int l=0;l<N;++l) 
+      for (int i=0;i<BlkSize;++i) {
+        sum  += ats::abs(Y0_host(l,i));
+        diff += ats::abs(Y0_host(l,i)-Y1_host(l,i));
+      }
+    EXPECT_NEAR_KK( diff/sum, 0, eps);
+  }
+}
+}
+
+template<typename DeviceType, 
+         typename ValueType, 
+         typename ScalarType>
+int test_batched_team_axpy() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) 
+  {
+    typedef Kokkos::View<ValueType**,Kokkos::LayoutLeft,DeviceType> ViewType;
+    typedef Kokkos::View<ValueType*,Kokkos::LayoutLeft,DeviceType> alphaViewType;
+    
+    Test::TeamAxpy::impl_test_batched_axpy<DeviceType,ViewType,alphaViewType>( 0, 10, 2);
+    for (int i=3;i<10;++i) {                                                                                        
+      Test::TeamAxpy::impl_test_batched_axpy<DeviceType,ViewType,alphaViewType>(1024,  i, 2);
+    }
+  }
+#endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) 
+  {
+    typedef Kokkos::View<ValueType**,Kokkos::LayoutRight,DeviceType> ViewType;
+    typedef Kokkos::View<ValueType*,Kokkos::LayoutRight,DeviceType> alphaViewType;
+
+    Test::TeamAxpy::impl_test_batched_axpy<DeviceType,ViewType,alphaViewType>( 0, 10, 2);
+    for (int i=3;i<10;++i) {                                                                                        
+      Test::TeamAxpy::impl_test_batched_axpy<DeviceType,ViewType,alphaViewType>(1024,  i, 2);
+    }
+  }
+#endif
+  
+  return 0;
+}
+

--- a/unit_test/batched/Test_Batched_TeamAxpy_Complex.hpp
+++ b/unit_test/batched/Test_Batched_TeamAxpy_Complex.hpp
@@ -1,0 +1,10 @@
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
+TEST_F( TestCategory, batched_scalar_team_axpy_nt_dcomplex_dcomplex ) {
+  test_batched_team_axpy<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>>();
+}
+
+TEST_F( TestCategory, batched_scalar_team_axpy_nt_dcomplex_double ) {
+  test_batched_team_axpy<TestExecSpace,Kokkos::complex<double>,double>();
+}
+#endif

--- a/unit_test/batched/Test_Batched_TeamAxpy_Real.hpp
+++ b/unit_test/batched/Test_Batched_TeamAxpy_Real.hpp
@@ -1,0 +1,12 @@
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+TEST_F( TestCategory, batched_scalar_team_axpy_nt_float_float ) {
+  test_batched_team_axpy<TestExecSpace,float,float>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+TEST_F( TestCategory, batched_scalar_team_axpy_nt_double_double ) {
+  test_batched_team_axpy<TestExecSpace,double,double>();
+}
+#endif

--- a/unit_test/batched/Test_Batched_TeamSpmv.hpp
+++ b/unit_test/batched/Test_Batched_TeamSpmv.hpp
@@ -1,0 +1,252 @@
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "gtest/gtest.h"
+#include "Kokkos_Core.hpp"
+#include "Kokkos_Random.hpp"
+
+//#include "KokkosBatched_Vector.hpp"
+
+#include "KokkosBatched_Spmv_Decl.hpp"
+#include "KokkosBatched_Spmv_Team_Impl.hpp"
+
+#include "KokkosKernels_TestUtils.hpp"
+
+using namespace KokkosBatched;
+
+namespace Test {
+namespace TeamSpmv {
+
+  template<typename T>
+  struct ParamTag { 
+    typedef T trans;
+  };
+ 
+  template<typename DeviceType,
+           typename ParamTagType, 
+           typename AlgoTagType,
+           typename DViewType,
+           typename IntView,
+           typename xViewType,
+           typename yViewType,
+           typename alphaViewType,
+           typename betaViewType,
+           int dobeta>
+  struct Functor_TestBatchedTeamSpmv {
+    const alphaViewType _alpha;
+    const DViewType _D;
+    const IntView _r;
+    const IntView _c;
+    const xViewType _X;
+    const betaViewType _beta;
+    const yViewType _Y;
+    const int _N_team;
+    
+    KOKKOS_INLINE_FUNCTION
+    Functor_TestBatchedTeamSpmv(const alphaViewType &alpha,
+      const DViewType &D,
+      const IntView &r,
+      const IntView &c,
+      const xViewType &X,
+      const betaViewType &beta,
+      const yViewType &Y,
+      const int N_team)
+    : _alpha(alpha), _D(D), _r(r), _c(c), _X(X), _beta(beta), _Y(Y), _N_team(N_team) {}
+    
+    template<typename MemberType>
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const ParamTagType &, const MemberType &member) const {
+      const int first_matrix =
+          static_cast<int>(member.league_rank()) * _N_team;
+      const int N = _D.extent(0);
+      const int last_matrix = (static_cast<int>(member.league_rank() + 1) * _N_team < N ? static_cast<int>(member.league_rank() + 1) * _N_team : N );
+      
+      auto alpha = Kokkos::subview(_alpha,Kokkos::make_pair(first_matrix,last_matrix));
+      auto d = Kokkos::subview(_D,Kokkos::make_pair(first_matrix,last_matrix),Kokkos::ALL);
+      auto x = Kokkos::subview(_X,Kokkos::make_pair(first_matrix,last_matrix),Kokkos::ALL);
+      auto beta = Kokkos::subview(_beta,Kokkos::make_pair(first_matrix,last_matrix));
+      auto y = Kokkos::subview(_Y,Kokkos::make_pair(first_matrix,last_matrix),Kokkos::ALL);
+      
+      KokkosBatched::TeamSpmv<MemberType, typename ParamTagType::trans, AlgoTagType>::template invoke<DViewType, IntView, xViewType, yViewType, alphaViewType, betaViewType, dobeta> (member, alpha, d, _r, _c, x, beta, y);
+    }
+    
+    inline
+    void run() {
+      typedef typename DViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::TeamSpmv");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion(name.c_str() );
+      Kokkos::TeamPolicy<DeviceType,ParamTagType> policy(_D.extent(0)/_N_team, Kokkos::AUTO(), Kokkos::AUTO());
+      Kokkos::parallel_for(name.c_str(), policy, *this);
+      Kokkos::Profiling::popRegion();
+    }
+  };
+    
+  template<typename DeviceType,
+           typename ParamTagType, 
+           typename AlgoTagType,
+           typename DViewType,
+           typename IntView,
+           typename xViewType,
+           typename yViewType,
+           typename alphaViewType,
+           typename betaViewType,
+           int dobeta>
+  void impl_test_batched_spmv(const int N, const int BlkSize, const int N_team) {
+    typedef typename DViewType::value_type value_type;
+    typedef Kokkos::Details::ArithTraits<value_type> ats;
+
+    const int nnz = (BlkSize-2) * 3 + 2 * 2;
+
+    xViewType  X0("x0", N, BlkSize), X1("x1", N, BlkSize);
+    yViewType  Y0("y0", N, BlkSize), Y1("y1", N, BlkSize);
+    DViewType  D("D", N, nnz);
+    IntView    r("r", BlkSize+1);
+    IntView    c("c", nnz);
+
+    alphaViewType  alpha("alpha", N);
+    betaViewType   beta("beta", N);
+
+    Kokkos::deep_copy(alpha, value_type(1.0));
+    Kokkos::deep_copy(beta, value_type(1.0));
+
+    Kokkos::Random_XorShift64_Pool<typename DeviceType::execution_space> random(13718);
+    Kokkos::fill_random(X0, random, value_type(1.0));
+    Kokkos::fill_random(Y0, random, value_type(1.0));
+
+    auto D_host = Kokkos::create_mirror_view(D);
+    auto r_host = Kokkos::create_mirror_view(r);
+    auto c_host = Kokkos::create_mirror_view(c);
+
+    r_host(0) = 0;
+
+    int current_col = 0;
+
+    for (int i=0;i<BlkSize;++i) {
+      r_host(i+1) = r_host(i) + (i==0 || i==(BlkSize-1) ? 2 : 3);
+    }
+    for (int i=0;i<nnz;++i) {
+      if (i%3 == 0) {
+        for (int l=0;l<N;++l) {
+          D_host(l,i) = value_type(1.0);
+        }
+        c_host(i) = current_col;
+        ++current_col;
+      }
+      else {
+        for (int l=0;l<N;++l) {
+          D_host(l,i) = value_type(0.5);
+        }
+        c_host(i) = current_col;
+        if (i%3 == 1)
+          --current_col;
+        else
+          ++current_col;
+      }
+    }
+
+    Kokkos::fence();
+
+    Kokkos::deep_copy(D, D_host);
+    Kokkos::deep_copy(r, r_host);
+    Kokkos::deep_copy(c, c_host);
+
+    Kokkos::deep_copy(X1, X0);
+    Kokkos::deep_copy(Y1, Y0);
+
+    /// test body
+    auto alpha_host = Kokkos::create_mirror_view(alpha);
+    auto beta_host = Kokkos::create_mirror_view(beta);
+    auto X0_host = Kokkos::create_mirror_view(X0);
+    auto Y0_host = Kokkos::create_mirror_view(Y0);
+
+    Kokkos::deep_copy(alpha_host, alpha);
+    Kokkos::deep_copy(beta_host, beta);
+    Kokkos::deep_copy(X0_host, X0);
+    Kokkos::deep_copy(Y0_host, Y0);
+
+    for (int l=0;l<N;++l) 
+      for (int i=0;i<BlkSize;++i) {
+        if (dobeta == 0)
+          Y0_host(l,i) = value_type(0.0);
+        else
+          Y0_host(l,i) *= beta_host(l);
+        if (i != 0 && i != (BlkSize-1))
+          Y0_host(l,i) += alpha_host(l)*(X0_host(l,i) + 0.5*X0_host(l,i-1) + 0.5*X0_host(l,i+1));
+        else if (i == 0)
+          Y0_host(l,i) += alpha_host(l)*(X0_host(l,i) + 0.5*X0_host(l,i+1));
+        else
+          Y0_host(l,i) += alpha_host(l)*(X0_host(l,i) + 0.5*X0_host(l,i-1));
+      }
+
+    Functor_TestBatchedTeamSpmv<DeviceType,ParamTagType,AlgoTagType,DViewType,IntView,xViewType,yViewType,alphaViewType,betaViewType,dobeta>
+    (alpha, D, r, c, X1, beta, Y1, N_team).run();
+
+    Kokkos::fence();
+
+    /// for comparison send it to host
+    auto Y1_host = Kokkos::create_mirror_view(Y1);
+
+    Kokkos::deep_copy(Y1_host, Y1);
+
+    /// check c0 = c1 ; this eps is about 10^-14
+    typedef typename ats::mag_type mag_type;
+    mag_type sum(1), diff(0);
+    const mag_type eps = 1.0e3 * ats::epsilon();
+
+    for (int l=0;l<N;++l) 
+      for (int i=0;i<BlkSize;++i) {
+        sum  += ats::abs(Y0_host(l,i));
+        diff += ats::abs(Y0_host(l,i)-Y1_host(l,i));
+      }
+    EXPECT_NEAR_KK( diff/sum, 0, eps);
+  }
+}
+}
+
+template<typename DeviceType, 
+         typename ValueType, 
+         typename ScalarType,
+         typename ParamTagType,
+         typename AlgoTagType>
+int test_batched_team_spmv() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) 
+  {
+    typedef Kokkos::View<ValueType**,Kokkos::LayoutLeft,DeviceType> ViewType;
+    typedef Kokkos::View<int*,Kokkos::LayoutLeft,DeviceType> IntView;
+    typedef Kokkos::View<ValueType*,Kokkos::LayoutLeft,DeviceType> alphaViewType;
+    
+    Test::TeamSpmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,0>( 0, 10, 1);
+    for (int i=3;i<10;++i) {                                                                                        
+      Test::TeamSpmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,0>(1024,  i, 2);
+    }
+    Test::TeamSpmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,1>( 0, 10, 1);
+    for (int i=3;i<10;++i) {                                                                                        
+      Test::TeamSpmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,1>(1024,  i, 2);
+    }
+  }
+#endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) 
+  {
+    typedef Kokkos::View<ValueType**,Kokkos::LayoutRight,DeviceType> ViewType;
+    typedef Kokkos::View<int*,Kokkos::LayoutRight,DeviceType> IntView;
+    typedef Kokkos::View<ValueType*,Kokkos::LayoutRight,DeviceType> alphaViewType;
+
+    Test::TeamSpmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,0>( 0, 10, 1);
+    for (int i=3;i<10;++i) {                                                                                        
+      Test::TeamSpmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,0>(1024,  i, 2);
+    }
+
+    Test::TeamSpmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,1>( 0, 10, 1);
+    for (int i=3;i<10;++i) {                                                                                         
+      Test::TeamSpmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,1>(1024,  i, 2);
+    }
+  }
+#endif
+  
+  return 0;
+}
+

--- a/unit_test/batched/Test_Batched_TeamSpmv_Real.hpp
+++ b/unit_test/batched/Test_Batched_TeamSpmv_Real.hpp
@@ -1,0 +1,16 @@
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+TEST_F( TestCategory, batched_scalar_team_spmv_nt_float_float ) {
+  typedef ::Test::Spmv::ParamTag<Trans::NoTranspose> param_tag_type;
+  typedef Algo::Spmv::Unblocked algo_tag_type;
+  test_batched_team_spmv<TestExecSpace,float,float,param_tag_type,algo_tag_type>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+TEST_F( TestCategory, batched_scalar_team_spmv_nt_double_double ) {
+  typedef ::Test::Spmv::ParamTag<Trans::NoTranspose> param_tag_type;
+  typedef Algo::Spmv::Unblocked algo_tag_type;
+  test_batched_team_spmv<TestExecSpace,double,double,param_tag_type,algo_tag_type>();
+}
+#endif

--- a/unit_test/batched/Test_Batched_TeamVectorAxpy.hpp
+++ b/unit_test/batched/Test_Batched_TeamVectorAxpy.hpp
@@ -1,0 +1,155 @@
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "gtest/gtest.h"
+#include "Kokkos_Core.hpp"
+#include "Kokkos_Random.hpp"
+
+//#include "KokkosBatched_Vector.hpp"
+
+#include "KokkosBatched_Axpy_Decl.hpp"
+#include "KokkosBatched_Axpy_Impl.hpp"
+
+#include "KokkosKernels_TestUtils.hpp"
+
+using namespace KokkosBatched;
+
+namespace Test {
+namespace TeamVectorAxpy {
+ 
+  template<typename DeviceType,
+           typename ViewType,
+           typename alphaViewType>
+  struct Functor_TestBatchedTeamVectorAxpy {
+    const alphaViewType _alpha;
+    const ViewType _X;
+    const ViewType _Y;
+    const int _N_team;
+    
+    KOKKOS_INLINE_FUNCTION
+    Functor_TestBatchedTeamVectorAxpy(const alphaViewType &alpha,
+      const ViewType &X,
+      const ViewType &Y,
+      const int N_team)
+    : _alpha(alpha), _X(X), _Y(Y), _N_team(N_team) {}
+    
+    template<typename MemberType>
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const MemberType &member) const {
+      const int first_matrix =
+          static_cast<int>(member.league_rank()) * _N_team;
+      const int N = _X.extent(0);
+      const int last_matrix = (static_cast<int>(member.league_rank() + 1) * _N_team < N ? static_cast<int>(member.league_rank() + 1) * _N_team : N );
+
+      auto alpha = Kokkos::subview(_alpha,Kokkos::make_pair(first_matrix,last_matrix));
+      auto x = Kokkos::subview(_X,Kokkos::make_pair(first_matrix,last_matrix),Kokkos::ALL);
+      auto y = Kokkos::subview(_Y,Kokkos::make_pair(first_matrix,last_matrix),Kokkos::ALL);
+      
+      KokkosBatched::TeamVectorAxpy<MemberType>::template invoke<ViewType, alphaViewType>
+          (member, alpha, x, y);
+    }
+    
+    inline
+    void run() {
+      typedef typename ViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::TeamVectorAxpy");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion(name.c_str() );
+      Kokkos::TeamPolicy<DeviceType> policy(_X.extent(0)/_N_team, Kokkos::AUTO(), Kokkos::AUTO());
+      Kokkos::parallel_for(name.c_str(), policy, *this);
+      Kokkos::Profiling::popRegion();
+    }
+  };
+    
+  template<typename DeviceType,
+           typename ViewType,
+           typename alphaViewType>
+  void impl_test_batched_axpy(const int N, const int BlkSize, const int N_team) {
+    typedef typename ViewType::value_type value_type;
+    typedef Kokkos::Details::ArithTraits<value_type> ats;
+
+    ViewType  X0("x0", N, BlkSize), X1("x1", N, BlkSize), Y0("y0", N, BlkSize), Y1("y1", N, BlkSize);
+
+    alphaViewType  alpha("alpha", N);
+
+    Kokkos::Random_XorShift64_Pool<typename DeviceType::execution_space> random(13718);
+    Kokkos::fill_random(X0, random, value_type(1.0));
+    Kokkos::fill_random(Y0, random, value_type(1.0));
+    Kokkos::fill_random(alpha, random, value_type(1.0));
+
+    Kokkos::fence();
+
+    Kokkos::deep_copy(X1, X0);
+    Kokkos::deep_copy(Y1, Y0);
+
+    /// test body
+    auto alpha_host = Kokkos::create_mirror_view(alpha);
+    auto X0_host = Kokkos::create_mirror_view(X0);
+    auto Y0_host = Kokkos::create_mirror_view(Y0);
+
+    Kokkos::deep_copy(alpha_host, alpha);
+    Kokkos::deep_copy(X0_host, X0);
+    Kokkos::deep_copy(Y0_host, Y0);
+
+    for (int l=0;l<N;++l) 
+      for (int i=0;i<BlkSize;++i)
+        Y0_host(l,i) += alpha_host(l)*X0_host(l,i);
+
+    Functor_TestBatchedTeamVectorAxpy<DeviceType,ViewType,alphaViewType>
+    (alpha, X1, Y1, N_team).run();
+
+    Kokkos::fence();
+
+    /// for comparison send it to host
+    auto Y1_host = Kokkos::create_mirror_view(Y1);
+
+    Kokkos::deep_copy(Y1_host, Y1);
+
+    /// check c0 = c1 ; this eps is about 10^-14
+    typedef typename ats::mag_type mag_type;
+    mag_type sum(1), diff(0);
+    const mag_type eps = 1.0e3 * ats::epsilon();
+
+    for (int l=0;l<N;++l) 
+      for (int i=0;i<BlkSize;++i) {
+        sum  += ats::abs(Y0_host(l,i));
+        diff += ats::abs(Y0_host(l,i)-Y1_host(l,i));
+      }
+    EXPECT_NEAR_KK( diff/sum, 0, eps);
+  }
+}
+}
+
+template<typename DeviceType, 
+         typename ValueType, 
+         typename ScalarType>
+int test_batched_teamvector_axpy() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) 
+  {
+    typedef Kokkos::View<ValueType**,Kokkos::LayoutLeft,DeviceType> ViewType;
+    typedef Kokkos::View<ValueType*,Kokkos::LayoutLeft,DeviceType> alphaViewType;
+    
+    Test::TeamVectorAxpy::impl_test_batched_axpy<DeviceType,ViewType,alphaViewType>( 0, 10, 2);
+    for (int i=3;i<10;++i) {                                                                                        
+      Test::TeamVectorAxpy::impl_test_batched_axpy<DeviceType,ViewType,alphaViewType>(1024,  i, 2);
+    }
+  }
+#endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) 
+  {
+    typedef Kokkos::View<ValueType**,Kokkos::LayoutRight,DeviceType> ViewType;
+    typedef Kokkos::View<ValueType*,Kokkos::LayoutRight,DeviceType> alphaViewType;
+
+    Test::TeamVectorAxpy::impl_test_batched_axpy<DeviceType,ViewType,alphaViewType>( 0, 10, 2);
+    for (int i=3;i<10;++i) {                                                                                        
+      Test::TeamVectorAxpy::impl_test_batched_axpy<DeviceType,ViewType,alphaViewType>(1024,  i, 2);
+    }
+  }
+#endif
+  
+  return 0;
+}
+

--- a/unit_test/batched/Test_Batched_TeamVectorAxpy_Complex.hpp
+++ b/unit_test/batched/Test_Batched_TeamVectorAxpy_Complex.hpp
@@ -1,0 +1,10 @@
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
+TEST_F( TestCategory, batched_scalar_teamvector_axpy_nt_dcomplex_dcomplex ) {
+  test_batched_teamvector_axpy<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>>();
+}
+
+TEST_F( TestCategory, batched_scalar_teamvector_axpy_nt_dcomplex_double ) {
+  test_batched_teamvector_axpy<TestExecSpace,Kokkos::complex<double>,double>();
+}
+#endif

--- a/unit_test/batched/Test_Batched_TeamVectorAxpy_Real.hpp
+++ b/unit_test/batched/Test_Batched_TeamVectorAxpy_Real.hpp
@@ -1,0 +1,12 @@
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+TEST_F( TestCategory, batched_scalar_teamvector_axpy_nt_float_float ) {
+  test_batched_teamvector_axpy<TestExecSpace,float,float>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+TEST_F( TestCategory, batched_scalar_teamvector_axpy_nt_double_double ) {
+  test_batched_teamvector_axpy<TestExecSpace,double,double>();
+}
+#endif

--- a/unit_test/batched/Test_Batched_TeamVectorSpmv.hpp
+++ b/unit_test/batched/Test_Batched_TeamVectorSpmv.hpp
@@ -1,0 +1,252 @@
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "gtest/gtest.h"
+#include "Kokkos_Core.hpp"
+#include "Kokkos_Random.hpp"
+
+//#include "KokkosBatched_Vector.hpp"
+
+#include "KokkosBatched_Spmv_Decl.hpp"
+#include "KokkosBatched_Spmv_TeamVector_Impl.hpp"
+
+#include "KokkosKernels_TestUtils.hpp"
+
+using namespace KokkosBatched;
+
+namespace Test {
+namespace TeamVectorSpmv {
+
+  template<typename T>
+  struct ParamTag { 
+    typedef T trans;
+  };
+ 
+  template<typename DeviceType,
+           typename ParamTagType, 
+           typename AlgoTagType,
+           typename DViewType,
+           typename IntView,
+           typename xViewType,
+           typename yViewType,
+           typename alphaViewType,
+           typename betaViewType,
+           int dobeta>
+  struct Functor_TestBatchedTeamVectorSpmv {
+    const alphaViewType _alpha;
+    const DViewType _D;
+    const IntView _r;
+    const IntView _c;
+    const xViewType _X;
+    const betaViewType _beta;
+    const yViewType _Y;
+    const int _N_team;
+    
+    KOKKOS_INLINE_FUNCTION
+    Functor_TestBatchedTeamVectorSpmv(const alphaViewType &alpha,
+      const DViewType &D,
+      const IntView &r,
+      const IntView &c,
+      const xViewType &X,
+      const betaViewType &beta,
+      const yViewType &Y,
+      const int N_team)
+    : _alpha(alpha), _D(D), _r(r), _c(c), _X(X), _beta(beta), _Y(Y), _N_team(N_team) {}
+    
+    template<typename MemberType>
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const ParamTagType &, const MemberType &member) const {
+      const int first_matrix =
+          static_cast<int>(member.league_rank()) * _N_team;
+      const int N = _D.extent(0);
+      const int last_matrix = (static_cast<int>(member.league_rank() + 1) * _N_team < N ? static_cast<int>(member.league_rank() + 1) * _N_team : N );
+      
+      auto alpha = Kokkos::subview(_alpha,Kokkos::make_pair(first_matrix,last_matrix));
+      auto d = Kokkos::subview(_D,Kokkos::make_pair(first_matrix,last_matrix),Kokkos::ALL);
+      auto x = Kokkos::subview(_X,Kokkos::make_pair(first_matrix,last_matrix),Kokkos::ALL);
+      auto beta = Kokkos::subview(_beta,Kokkos::make_pair(first_matrix,last_matrix));
+      auto y = Kokkos::subview(_Y,Kokkos::make_pair(first_matrix,last_matrix),Kokkos::ALL);
+      
+      KokkosBatched::TeamVectorSpmv<MemberType, typename ParamTagType::trans, AlgoTagType>::template invoke<DViewType, IntView, xViewType, yViewType, alphaViewType, betaViewType, dobeta> (member, alpha, d, _r, _c, x, beta, y);
+    }
+    
+    inline
+    void run() {
+      typedef typename DViewType::value_type value_type;
+      std::string name_region("KokkosBatched::Test::TeamVectorSpmv");
+      std::string name_value_type = ( std::is_same<value_type,float>::value ? "::Float" : 
+                                      std::is_same<value_type,double>::value ? "::Double" :
+                                      std::is_same<value_type,Kokkos::complex<float> >::value ? "::ComplexFloat" :
+                                      std::is_same<value_type,Kokkos::complex<double> >::value ? "::ComplexDouble" : "::UnknownValueType" );                               
+      std::string name = name_region + name_value_type;
+      Kokkos::Profiling::pushRegion(name.c_str() );
+      Kokkos::TeamPolicy<DeviceType,ParamTagType> policy(_D.extent(0)/_N_team, Kokkos::AUTO(), Kokkos::AUTO());
+      Kokkos::parallel_for(name.c_str(), policy, *this);
+      Kokkos::Profiling::popRegion();
+    }
+  };
+    
+  template<typename DeviceType,
+           typename ParamTagType, 
+           typename AlgoTagType,
+           typename DViewType,
+           typename IntView,
+           typename xViewType,
+           typename yViewType,
+           typename alphaViewType,
+           typename betaViewType,
+           int dobeta>
+  void impl_test_batched_spmv(const int N, const int BlkSize, const int N_team) {
+    typedef typename DViewType::value_type value_type;
+    typedef Kokkos::Details::ArithTraits<value_type> ats;
+
+    const int nnz = (BlkSize-2) * 3 + 2 * 2;
+
+    xViewType  X0("x0", N, BlkSize), X1("x1", N, BlkSize);
+    yViewType  Y0("y0", N, BlkSize), Y1("y1", N, BlkSize);
+    DViewType  D("D", N, nnz);
+    IntView    r("r", BlkSize+1);
+    IntView    c("c", nnz);
+
+    alphaViewType  alpha("alpha", N);
+    betaViewType   beta("beta", N);
+
+    Kokkos::deep_copy(alpha, value_type(1.0));
+    Kokkos::deep_copy(beta, value_type(1.0));
+
+    Kokkos::Random_XorShift64_Pool<typename DeviceType::execution_space> random(13718);
+    Kokkos::fill_random(X0, random, value_type(1.0));
+    Kokkos::fill_random(Y0, random, value_type(1.0));
+
+    auto D_host = Kokkos::create_mirror_view(D);
+    auto r_host = Kokkos::create_mirror_view(r);
+    auto c_host = Kokkos::create_mirror_view(c);
+
+    r_host(0) = 0;
+
+    int current_col = 0;
+
+    for (int i=0;i<BlkSize;++i) {
+      r_host(i+1) = r_host(i) + (i==0 || i==(BlkSize-1) ? 2 : 3);
+    }
+    for (int i=0;i<nnz;++i) {
+      if (i%3 == 0) {
+        for (int l=0;l<N;++l) {
+          D_host(l,i) = value_type(1.0);
+        }
+        c_host(i) = current_col;
+        ++current_col;
+      }
+      else {
+        for (int l=0;l<N;++l) {
+          D_host(l,i) = value_type(0.5);
+        }
+        c_host(i) = current_col;
+        if (i%3 == 1)
+          --current_col;
+        else
+          ++current_col;
+      }
+    }
+
+    Kokkos::fence();
+
+    Kokkos::deep_copy(D, D_host);
+    Kokkos::deep_copy(r, r_host);
+    Kokkos::deep_copy(c, c_host);
+
+    Kokkos::deep_copy(X1, X0);
+    Kokkos::deep_copy(Y1, Y0);
+
+    /// test body
+    auto alpha_host = Kokkos::create_mirror_view(alpha);
+    auto beta_host = Kokkos::create_mirror_view(beta);
+    auto X0_host = Kokkos::create_mirror_view(X0);
+    auto Y0_host = Kokkos::create_mirror_view(Y0);
+
+    Kokkos::deep_copy(alpha_host, alpha);
+    Kokkos::deep_copy(beta_host, beta);
+    Kokkos::deep_copy(X0_host, X0);
+    Kokkos::deep_copy(Y0_host, Y0);
+
+    for (int l=0;l<N;++l) 
+      for (int i=0;i<BlkSize;++i) {
+        if (dobeta == 0)
+          Y0_host(l,i) = value_type(0.0);
+        else
+          Y0_host(l,i) *= beta_host(l);
+        if (i != 0 && i != (BlkSize-1))
+          Y0_host(l,i) += alpha_host(l)*(X0_host(l,i) + 0.5*X0_host(l,i-1) + 0.5*X0_host(l,i+1));
+        else if (i == 0)
+          Y0_host(l,i) += alpha_host(l)*(X0_host(l,i) + 0.5*X0_host(l,i+1));
+        else
+          Y0_host(l,i) += alpha_host(l)*(X0_host(l,i) + 0.5*X0_host(l,i-1));
+      }
+
+    Functor_TestBatchedTeamVectorSpmv<DeviceType,ParamTagType,AlgoTagType,DViewType,IntView,xViewType,yViewType,alphaViewType,betaViewType,dobeta>
+    (alpha, D, r, c, X1, beta, Y1, N_team).run();
+
+    Kokkos::fence();
+
+    /// for comparison send it to host
+    auto Y1_host = Kokkos::create_mirror_view(Y1);
+
+    Kokkos::deep_copy(Y1_host, Y1);
+
+    /// check c0 = c1 ; this eps is about 10^-14
+    typedef typename ats::mag_type mag_type;
+    mag_type sum(1), diff(0);
+    const mag_type eps = 1.0e3 * ats::epsilon();
+
+    for (int l=0;l<N;++l) 
+      for (int i=0;i<BlkSize;++i) {
+        sum  += ats::abs(Y0_host(l,i));
+        diff += ats::abs(Y0_host(l,i)-Y1_host(l,i));
+      }
+    EXPECT_NEAR_KK( diff/sum, 0, eps);
+  }
+}
+}
+
+template<typename DeviceType, 
+         typename ValueType, 
+         typename ScalarType,
+         typename ParamTagType,
+         typename AlgoTagType>
+int test_batched_teamvector_spmv() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) 
+  {
+    typedef Kokkos::View<ValueType**,Kokkos::LayoutLeft,DeviceType> ViewType;
+    typedef Kokkos::View<int*,Kokkos::LayoutLeft,DeviceType> IntView;
+    typedef Kokkos::View<ValueType*,Kokkos::LayoutLeft,DeviceType> alphaViewType;
+    
+    Test::TeamVectorSpmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,0>( 0, 10, 1);
+    for (int i=3;i<10;++i) {                                                                                        
+      Test::TeamVectorSpmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,0>(1024,  i, 2);
+    }
+    Test::TeamVectorSpmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,1>( 0, 10, 1);
+    for (int i=3;i<10;++i) {                                                                                        
+      Test::TeamVectorSpmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,1>(1024,  i, 2);
+    }
+  }
+#endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) 
+  {
+    typedef Kokkos::View<ValueType**,Kokkos::LayoutRight,DeviceType> ViewType;
+    typedef Kokkos::View<int*,Kokkos::LayoutRight,DeviceType> IntView;
+    typedef Kokkos::View<ValueType*,Kokkos::LayoutRight,DeviceType> alphaViewType;
+
+    Test::TeamVectorSpmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,0>( 0, 10, 1);
+    for (int i=3;i<10;++i) {                                                                                        
+      Test::TeamVectorSpmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,0>(1024,  i, 2);
+    }
+
+    Test::TeamVectorSpmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,1>( 0, 10, 1);
+    for (int i=3;i<10;++i) {                                                                                         
+      Test::TeamVectorSpmv::impl_test_batched_spmv<DeviceType,ParamTagType,AlgoTagType,ViewType,IntView,ViewType,ViewType,alphaViewType,alphaViewType,1>(1024,  i, 2);
+    }
+  }
+#endif
+  
+  return 0;
+}
+

--- a/unit_test/batched/Test_Batched_TeamVectorSpmv_Real.hpp
+++ b/unit_test/batched/Test_Batched_TeamVectorSpmv_Real.hpp
@@ -1,0 +1,16 @@
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+TEST_F( TestCategory, batched_scalar_teamvector_spmv_nt_float_float ) {
+  typedef ::Test::Spmv::ParamTag<Trans::NoTranspose> param_tag_type;
+  typedef Algo::Spmv::Unblocked algo_tag_type;
+  test_batched_teamvector_spmv<TestExecSpace,float,float,param_tag_type,algo_tag_type>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+TEST_F( TestCategory, batched_scalar_teamvector_spmv_nt_double_double ) {
+  typedef ::Test::Spmv::ParamTag<Trans::NoTranspose> param_tag_type;
+  typedef Algo::Spmv::Unblocked algo_tag_type;
+  test_batched_teamvector_spmv<TestExecSpace,double,double,param_tag_type,algo_tag_type>();
+}
+#endif


### PR DESCRIPTION
This PR adds two BLAS functions to the batched ones:
- `Axpy`,
- `Spmv`.

3 implementations are provided for the 2 of them, a `serial`, a `team`, and a `teamvector` one.

All the implementations are tested with the unit tests.

The tests passed on weaver with `cuda/10.1.243`.

@srajama1 @lucbv 