### PR TITLE
Allow reading integer mtx files into floating-point matrices

### DIFF
--- a/src/common/KokkosKernels_IOUtils.hpp
+++ b/src/common/KokkosKernels_IOUtils.hpp
@@ -1163,7 +1163,9 @@ int read_mtx (
       mtx_field = COMPLEX;
   }
   else if (fline.find("integer") != std::string::npos){
-    if(std::is_integral<scalar_t>::value)
+    if(std::is_integral<scalar_t>::value 
+       || std::is_floating_point<scalar_t>::value
+       || std::is_same<scalar_t,Kokkos::Experimental::half_t>::value)
       mtx_field = INTEGER;
     else
       throw std::runtime_error("scalar_t in read_mtx() incompatible with integer-typed MatrixMarket file.");


### PR DESCRIPTION
Allow reading "integer" values from matrix market files into floating-point type `T` (either `std::is_floating_point<T>::value == true` or `T` is `Kokkos__Experimental::half_t`.

Though it is possible that the integer value may not be accurately representable as a float (for example, `100,000` and `half_t`), that limitation is already implicitly accepted by the current code. For example, reading a mtx "real" matrix with a ascii entry of `0.1` into a `float` is accepted, despite how the value 0.1 cannot be represented as a `float`.
