### PR TITLE
Fix SpGEMM for Nvidia Turing/Ampere

### DIFF
--- a/src/common/KokkosKernels_HashmapAccumulator.hpp
+++ b/src/common/KokkosKernels_HashmapAccumulator.hpp
@@ -495,8 +495,8 @@ struct HashmapAccumulator
       keys[my_write_index] = key;
       values[my_write_index] = value;
 
-      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
-      //this is an issue on VOLTA because warps do not go in SIMD fashion anymore.
+      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
+      //this is an issue on VOLTA and up because warps do not go in SIMD fashion anymore.
       //while some thread might insert my_write_index into linked list, another
       //thread in the warp might be reading keys in above loop.
       //before inserting the new value in liked list -- which is done with atomic exchange below,
@@ -572,8 +572,8 @@ struct HashmapAccumulator
       keys[my_write_index] = key;
       values[my_write_index] = value;
 
-      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
-      //this is an issue on VOLTA because warps do not go in SIMD fashion anymore.
+      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
+      //this is an issue on VOLTA and up because warps do not go in SIMD fashion anymore.
       //while some thread might insert my_write_index into linked list, another
       //thread in the warp might be reading keys in above loop.
       //before inserting the new value in liked list -- which is done with atomic exchange below,
@@ -659,8 +659,8 @@ struct HashmapAccumulator
 
       keys[my_write_index] = key;
 
-      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
-      //this is an issue on VOLTA because warps do not go in SIMD fashion anymore.
+      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
+      //this is an issue on VOLTA and up because warps do not go in SIMD fashion anymore.
       //while some thread might insert my_write_index into linked list, another
       //thread in the warp might be reading keys in above loop.
       //before inserting the new value in liked list -- which is done with atomic exchange below,
@@ -714,8 +714,8 @@ struct HashmapAccumulator
       keys[my_write_index] = key;
       values[my_write_index] = value;
 
-      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
-      //this is an issue on VOLTA because warps do not go in SIMD fashion anymore.
+      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
+      //this is an issue on VOLTA and up because warps do not go in SIMD fashion anymore.
       //while some thread might insert my_write_index into linked list, another
       //thread in the warp might be reading keys in above loop.
       //before inserting the new value in liked list -- which is done with atomic exchange below,
@@ -771,8 +771,8 @@ struct HashmapAccumulator
       keys[my_write_index] = key;
       values[my_write_index] = value;
 
-      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
-      //this is an issue on VOLTA because warps do not go in SIMD fashion anymore.
+      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
+      //this is an issue on VOLTA and up because warps do not go in SIMD fashion anymore.
       //while some thread might insert my_write_index into linked list, another
       //thread in the warp might be reading keys in above loop.
       //before inserting the new value in liked list -- which is done with atomic exchange below,
@@ -822,8 +822,8 @@ struct HashmapAccumulator
 
       keys[my_write_index] = key;
 
-      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
-      //this is an issue on VOLTA because warps do not go in SIMD fashion anymore.
+      #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
+      //this is an issue on VOLTA and up because warps do not go in SIMD fashion anymore.
       //while some thread might insert my_write_index into linked list, another
       //thread in the warp might be reading keys in above loop.
       //before inserting the new value in liked list -- which is done with atomic exchange below,

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
@@ -596,7 +596,8 @@ struct KokkosSPGEMM
           Kokkos::ThreadVectorRange(teamMember, vector_size),
           [&] (nnz_lno_t i) {
         result_keys[i] = -1;
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
+        //This is required for Nvidia architectures with "independent thread scheduling"
+#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
         result_vals[i] = 0;
 #endif
       });
@@ -626,7 +627,7 @@ struct KokkosSPGEMM
 	    //once the keys are set, some other vector lane might be doing a
 	    //fetch_or before we set with n_set. Therefore it is necessary to do
 	    //atomic, and set it with zero as above.
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
+#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
             Kokkos::atomic_fetch_or(result_vals + new_hash, n_set);
 #else
             result_vals[new_hash] = n_set;
@@ -690,7 +691,7 @@ struct KokkosSPGEMM
 	      //new_row_map(row_ind) = rowBeginP + used_hash_sizes[0] + used_hash_sizes[1];
 	      //to execute before the below insertion finishes.
 	      //parallel_for will provide this mechanism.
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
+#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
               Kokkos::parallel_for(
                  Kokkos::ThreadVectorRange(teamMember, vector_size),
 	          [&] (nnz_lno_t /*i*/) {
@@ -701,7 +702,7 @@ struct KokkosSPGEMM
 			      n_set_index,n_set, used_hash_sizes + 1,
 			      globally_used_hash_count, globally_used_hash_indices);
         }
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_VOLTA70) || defined(KOKKOS_ARCH_VOLTA72)
+#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE)
 		});
 #endif
       }


### PR DESCRIPTION
by enabling the code paths required for "independent thread scheduling"
that was introduced with Volta. Tested on Perlmutter A100 - the spgemm unit tests went from failing to passing with this change.

Should fix https://github.com/trilinos/Trilinos/issues/9155 .

To keep the #if condition on one line, I removed ``KOKKOS_ARCH_VOLTA_70`` and ``KOKKOS_ARCH_VOLTA_72`` since these are redundant (``KOKKOS_ARCH_VOLTA`` covers both cases).