### PR TITLE
Revert "gmres: disable examples for builds with ibm/xl"

### DIFF
--- a/example/gmres/CMakeLists.txt
+++ b/example/gmres/CMakeLists.txt
@@ -1,8 +1,6 @@
 KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
 KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
-# Workaround https://github.com/kokkos/kokkos/issues/4376 for ibm/xl
-IF (NOT ${KOKKOS_COMPILER_IBM})
 KOKKOSKERNELS_ADD_EXECUTABLE(
   gmres_ex_real_A
   SOURCES ex_real_A.cpp
@@ -22,8 +20,4 @@ KOKKOSKERNELS_ADD_EXECUTABLE_AND_TEST(
   gmres_test_prec
   SOURCES test_prec.cpp
   )
-
-ELSE ()
-  MESSAGE (STATUS "SKIPPING gmres examples - Kokkos::complex<half_t> unsupported with ibm/xlC as host compiler")
-ENDIF ()
 


### PR DESCRIPTION
This reverts commit adaa5510f9db1c9fbac8fef8e13afa6f23f0d383.

This can be merged after https://github.com/kokkos/kokkos/pull/4399.