### PR TITLE
Fix https://github.com/kokkos/kokkos-kernels/issues/1133

### DIFF
--- a/src/sparse/KokkosSparse_BsrMatrix.hpp
+++ b/src/sparse/KokkosSparse_BsrMatrix.hpp
@@ -699,7 +699,7 @@ class BsrMatrix {
     // numBlocks in the final entry
     graph = Kokkos::create_staticcrsgraph<staticcrsgraph_type>("blockgraph",
                                                                block_rows);
-    typename index_type::HostMirror h_row_map =
+    typename row_map_type::HostMirror h_row_map =
         Kokkos::create_mirror_view(graph.row_map);
     Kokkos::deep_copy(h_row_map, graph.row_map);
 


### PR DESCRIPTION
This PR changes `index_type` to `row_map_type` when constructing a BsrMatrix from a graph and values. It would coincidentally work for certain template parameters, but not all of them.