### PR TITLE
Deprecation warning: SpaceAccessibility move out of impl, see #1140

### DIFF
--- a/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
@@ -84,13 +84,13 @@ void mkl_symbolic(KernelHandle *handle, typename KernelHandle::nnz_lno_t m,
   typedef typename KernelHandle::HandleExecSpace MyExecSpace;
   /*
     if (!(
-        (Kokkos::Impl::SpaceAccessibility<typename
+        (Kokkos::SpaceAccessibility<typename
     Kokkos::HostSpace::execution_space, typename
     device1::memory_space>::accessible) &&
-        (Kokkos::Impl::SpaceAccessibility<typename
+        (Kokkos::SpaceAccessibility<typename
     Kokkos::HostSpace::execution_space, typename
     device2::memory_space>::accessible) &&
-        (Kokkos::Impl::SpaceAccessibility<typename
+        (Kokkos::SpaceAccessibility<typename
     Kokkos::HostSpace::execution_space, typename
     device3::memory_space>::accessible) )
         ){
@@ -386,13 +386,13 @@ void mkl_apply(KernelHandle *handle, typename KernelHandle::nnz_lno_t m,
   typedef typename KernelHandle::HandleExecSpace MyExecSpace;
   /*
       if (!(
-          (Kokkos::Impl::SpaceAccessibility<typename
+          (Kokkos::SpaceAccessibility<typename
      Kokkos::HostSpace::execution_space, typename
      device1::memory_space>::accessible) &&
-          (Kokkos::Impl::SpaceAccessibility<typename
+          (Kokkos::SpaceAccessibility<typename
      Kokkos::HostSpace::execution_space, typename
      device2::memory_space>::accessible) &&
-          (Kokkos::Impl::SpaceAccessibility<typename
+          (Kokkos::SpaceAccessibility<typename
      Kokkos::HostSpace::execution_space, typename
      device3::memory_space>::accessible) )
           ){

--- a/unit_test/batched/dense/Test_Batched_VectorArithmatic.hpp
+++ b/unit_test/batched/dense/Test_Batched_VectorArithmatic.hpp
@@ -227,18 +227,18 @@ void impl_test_batched_vector_arithmatic() {
 
 template <typename DeviceType, typename VectorTagType, int VectorLength>
 int test_batched_vector_arithmatic() {
-  static_assert(Kokkos::Impl::SpaceAccessibility<DeviceType,
-                                                 Kokkos::HostSpace>::accessible,
-                "vector datatype is only tested on host space");
+  static_assert(
+      Kokkos::SpaceAccessibility<DeviceType, Kokkos::HostSpace>::accessible,
+      "vector datatype is only tested on host space");
   Test::impl_test_batched_vector_arithmatic<VectorTagType, VectorLength>();
 
   return 0;
 }
 template <typename DeviceType, typename VectorTagType, int VectorLength>
 int test_batched_complex_real_imag_value() {
-  static_assert(Kokkos::Impl::SpaceAccessibility<DeviceType,
-                                                 Kokkos::HostSpace>::accessible,
-                "vector datatype is only tested on host space");
+  static_assert(
+      Kokkos::SpaceAccessibility<DeviceType, Kokkos::HostSpace>::accessible,
+      "vector datatype is only tested on host space");
   Test::impl_test_complex_real_imag_value<VectorTagType, VectorLength>();
 
   return 0;

--- a/unit_test/batched/dense/Test_Batched_VectorLogical.hpp
+++ b/unit_test/batched/dense/Test_Batched_VectorLogical.hpp
@@ -85,9 +85,9 @@ void impl_test_batched_vector_logical() {
 
 template <typename DeviceType, typename ValueType, int VectorLength>
 int test_batched_vector_logical() {
-  static_assert(Kokkos::Impl::SpaceAccessibility<DeviceType,
-                                                 Kokkos::HostSpace>::accessible,
-                "vector datatype is only tested on host space");
+  static_assert(
+      Kokkos::SpaceAccessibility<DeviceType, Kokkos::HostSpace>::accessible,
+      "vector datatype is only tested on host space");
   Test::impl_test_batched_vector_logical<ValueType, VectorLength>();
 
   return 0;

--- a/unit_test/batched/dense/Test_Batched_VectorMath.hpp
+++ b/unit_test/batched/dense/Test_Batched_VectorMath.hpp
@@ -111,9 +111,9 @@ void impl_test_batched_vector_math() {
 
 template <typename DeviceType, typename VectorTagType, int VectorLength>
 int test_batched_vector_math() {
-  static_assert(Kokkos::Impl::SpaceAccessibility<DeviceType,
-                                                 Kokkos::HostSpace>::accessible,
-                "vector datatype is only tested on host space");
+  static_assert(
+      Kokkos::SpaceAccessibility<DeviceType, Kokkos::HostSpace>::accessible,
+      "vector datatype is only tested on host space");
   Test::impl_test_batched_vector_math<VectorTagType, VectorLength>();
 
   return 0;

--- a/unit_test/batched/dense/Test_Batched_VectorMisc.hpp
+++ b/unit_test/batched/dense/Test_Batched_VectorMisc.hpp
@@ -144,9 +144,9 @@ void impl_test_batched_vector_misc() {
 
 template <typename DeviceType, typename VectorTagType, int VectorLength>
 int test_batched_vector_misc() {
-  static_assert(Kokkos::Impl::SpaceAccessibility<DeviceType,
-                                                 Kokkos::HostSpace>::accessible,
-                "vector datatype is only tested on host space");
+  static_assert(
+      Kokkos::SpaceAccessibility<DeviceType, Kokkos::HostSpace>::accessible,
+      "vector datatype is only tested on host space");
   Test::impl_test_batched_vector_misc<VectorTagType, VectorLength>();
 
   return 0;

--- a/unit_test/batched/dense/Test_Batched_VectorRelation.hpp
+++ b/unit_test/batched/dense/Test_Batched_VectorRelation.hpp
@@ -98,9 +98,9 @@ void impl_test_batched_vector_relation() {
 
 template <typename DeviceType, typename VectorTagType, int VectorLength>
 int test_batched_vector_relation() {
-  static_assert(Kokkos::Impl::SpaceAccessibility<DeviceType,
-                                                 Kokkos::HostSpace>::accessible,
-                "vector datatype is only tested on host space");
+  static_assert(
+      Kokkos::SpaceAccessibility<DeviceType, Kokkos::HostSpace>::accessible,
+      "vector datatype is only tested on host space");
   Test::impl_test_batched_vector_relation<VectorTagType, VectorLength>();
 
   return 0;

--- a/unit_test/batched/dense/Test_Batched_VectorView.hpp
+++ b/unit_test/batched/dense/Test_Batched_VectorView.hpp
@@ -326,9 +326,9 @@ void impl_test_batched_vector_view() {
 
 template <typename DeviceType, typename VectorTagType, int VectorLength>
 int test_batched_vector_view() {
-  static_assert(Kokkos::Impl::SpaceAccessibility<DeviceType,
-                                                 Kokkos::HostSpace>::accessible,
-                "vector datatype is only tested on host space");
+  static_assert(
+      Kokkos::SpaceAccessibility<DeviceType, Kokkos::HostSpace>::accessible,
+      "vector datatype is only tested on host space");
   Test::impl_test_batched_vector_view<DeviceType, VectorTagType,
                                       VectorLength>();
 

--- a/unit_test/sparse/Test_Sparse_spgemm.hpp
+++ b/unit_test/sparse/Test_Sparse_spgemm.hpp
@@ -313,7 +313,7 @@ void test_spgemm(lno_t numRows, size_type nnz, lno_t bandwidth,
           is_expected_to_fail = true;
         }
 
-        if (!(Kokkos::Impl::SpaceAccessibility<
+        if (!(Kokkos::SpaceAccessibility<
                 typename Kokkos::HostSpace::execution_space,
                 typename device::memory_space>::accessible)) {
           is_expected_to_fail = true;


### PR DESCRIPTION
Kokkos::impl::SpaceAccessibility moved out of the impl namespace in kokkos/kokkos#1115 and was deprecated in favor of
Kokkos::SpaceAccessibility. This PR removes all calls to the deprecated version.