### PR TITLE
Merge pull request #1150 from ndellingwood/trilinos-disable-sluperftest

### DIFF
--- a/perf_test/sparse/CMakeLists.txt
+++ b/perf_test/sparse/CMakeLists.txt
@@ -73,10 +73,14 @@ KOKKOSKERNELS_ADD_EXECUTABLE(
   SOURCES KokkosSparse_sptrsv_cholmod.cpp 
   )
 
+IF(NOT KOKKOS_HAS_TRILINOS)
+# Disable this perf test with Trilinos builds to workaround
+# -Werror issues error: declaration of xyz with C language linkage
 KOKKOSKERNELS_ADD_EXECUTABLE(
   sparse_sptrsv_superlu
   SOURCES KokkosSparse_sptrsv_superlu.cpp 
   )
+ENDIF()
 
 KOKKOSKERNELS_ADD_EXECUTABLE(
   sparse_sptrsv_supernode


### PR DESCRIPTION
Temporarily disable perf test KokkosSparse_sptrsv_superlu w/ Trilinos

(cherry picked from commit fe881a5180ddb53b8302532dd205ba28d3a15c7d)