### PR TITLE
Use KOKKOS_IMPL_DO_NOT_USE_PRINTF instead of printf in kernels

### DIFF
--- a/unit_test/sparse/Test_Sparse_findRelOffset.hpp
+++ b/unit_test/sparse/Test_Sparse_findRelOffset.hpp
@@ -48,8 +48,9 @@
 //       by all backends so the following guard
 //       ensure that the test is not inclueded
 //       on these backends.
-#if !defined(TEST_HIP_SPARSE_CPP) &&   \
-    (!defined(TEST_CUDA_SPARSE_CPP) || \
+#if !defined(TEST_HIP_SPARSE_CPP) && !defined(TEST_SYCL_SPARSE_CPP) && \
+    !defined(TEST_OPENMPTARGET_SPARSE_CPP) &&                          \
+    (!defined(TEST_CUDA_SPARSE_CPP) ||                                 \
      (defined(TEST_CUDA_SPARSE_CPP) && defined(KOKKOS_ENABLE_CUDA_UVM)))
 
 #include "Kokkos_Core.hpp"

--- a/unit_test/sparse/Test_Sparse_trsv.hpp
+++ b/unit_test/sparse/Test_Sparse_trsv.hpp
@@ -1,5 +1,6 @@
-#if !defined(TEST_HIP_SPARSE_CPP) &&   \
-    (!defined(TEST_CUDA_SPARSE_CPP) || \
+#if !defined(TEST_HIP_SPARSE_CPP) && !defined(TEST_SYCL_SPARSE_CPP) && \
+    !defined(TEST_OPENMPTARGET_BATCHED_DENSE_CPP) &&                   \
+    (!defined(TEST_CUDA_SPARSE_CPP) ||                                 \
      (defined(TEST_CUDA_SPARSE_CPP) && defined(KOKKOS_ENABLE_CUDA_UVM)))
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
These tests have already been disabled for `HIP` and `CUDA`.