### PR TITLE
using namespace should be scoped to prevent name clashes, see issue #1170

### DIFF
--- a/perf_test/blas/blas3/KokkosBlas3_trmm_perf_test.hpp
+++ b/perf_test/blas/blas3/KokkosBlas3_trmm_perf_test.hpp
@@ -272,14 +272,15 @@ void __do_trmm_serial_batched_template(options_t options,
   uint32_t warm_up_n = options.warm_up_n;
   uint32_t n         = options.n;
   Kokkos::Timer timer;
-  using tag = Algo::Trmm::Unblocked;
+  using tag = KokkosBatched::Algo::Trmm::Unblocked;
 
   for (uint32_t j = 0; j < warm_up_n; ++j) {
     for (int i = 0; i < options.start.a.k; ++i) {
       auto A = Kokkos::subview(trmm_args.A, i, Kokkos::ALL(), Kokkos::ALL());
       auto B = Kokkos::subview(trmm_args.B, i, Kokkos::ALL(), Kokkos::ALL());
 
-      SerialTrmm<side, uplo, trans, diag, tag>::invoke(trmm_args.alpha, A, B);
+      KokkosBatched::SerialTrmm<side, uplo, trans, diag, tag>::invoke(
+          trmm_args.alpha, A, B);
     }
     // Fence after submitting each batch operation
     Kokkos::fence();
@@ -291,7 +292,8 @@ void __do_trmm_serial_batched_template(options_t options,
       auto A = Kokkos::subview(trmm_args.A, i, Kokkos::ALL(), Kokkos::ALL());
       auto B = Kokkos::subview(trmm_args.B, i, Kokkos::ALL(), Kokkos::ALL());
 
-      SerialTrmm<side, uplo, trans, diag, tag>::invoke(trmm_args.alpha, A, B);
+      KokkosBatched::SerialTrmm<side, uplo, trans, diag, tag>::invoke(
+          trmm_args.alpha, A, B);
     }
     // Fence after submitting each batch operation
     Kokkos::fence();
@@ -314,6 +316,11 @@ void __do_trmm_serial_batched(options_t options, trmm_args_t trmm_args) {
   char __side = tolower(trmm_args.side), __uplo = tolower(trmm_args.uplo),
        __trans = tolower(trmm_args.trans);
   //__diag = tolower(diag[0]);
+
+  using KokkosBatched::Diag;
+  using KokkosBatched::Side;
+  using KokkosBatched::Trans;
+  using KokkosBatched::Uplo;
 
   STATUS;
 
@@ -480,8 +487,8 @@ struct parallel_batched_trmm {
     auto svA = Kokkos::subview(trmm_args_.A, i, Kokkos::ALL(), Kokkos::ALL());
     auto svB = Kokkos::subview(trmm_args_.B, i, Kokkos::ALL(), Kokkos::ALL());
 
-    SerialTrmm<side, uplo, trans, diag, tag>::invoke(trmm_args_.alpha, svA,
-                                                     svB);
+    KokkosBatched::SerialTrmm<side, uplo, trans, diag, tag>::invoke(
+        trmm_args_.alpha, svA, svB);
   }
 };
 
@@ -491,7 +498,7 @@ void __do_trmm_parallel_batched_template(options_t options,
   uint32_t warm_up_n = options.warm_up_n;
   uint32_t n         = options.n;
   Kokkos::Timer timer;
-  using tag             = Algo::Trmm::Unblocked;
+  using tag             = KokkosBatched::Algo::Trmm::Unblocked;
   using execution_space = typename device_type::execution_space;
   using functor_type =
       parallel_batched_trmm<side, uplo, trans, diag, tag, execution_space>;
@@ -527,6 +534,11 @@ void __do_trmm_parallel_batched(options_t options, trmm_args_t trmm_args) {
   char __side = tolower(trmm_args.side), __uplo = tolower(trmm_args.uplo),
        __trans = tolower(trmm_args.trans);
   //__diag = tolower(diag[0]);
+
+  using KokkosBatched::Diag;
+  using KokkosBatched::Side;
+  using KokkosBatched::Trans;
+  using KokkosBatched::Uplo;
 
   STATUS;
 

--- a/perf_test/blas/blas3/KokkosBlas_trtri_perf_test.hpp
+++ b/perf_test/blas/blas3/KokkosBlas_trtri_perf_test.hpp
@@ -249,13 +249,13 @@ void __do_trtri_serial_batched_template(options_t options,
   uint32_t warm_up_n = options.warm_up_n;
   uint32_t n         = options.n;
   Kokkos::Timer timer;
-  using tag = Algo::Trtri::Unblocked;
+  using tag = KokkosBatched::Algo::Trtri::Unblocked;
 
   for (uint32_t j = 0; j < warm_up_n; ++j) {
     for (int i = 0; i < options.start.a.k; ++i) {
       auto A = Kokkos::subview(trtri_args.A, i, Kokkos::ALL(), Kokkos::ALL());
 
-      SerialTrtri<uplo, diag, tag>::invoke(A);
+      KokkosBatched::SerialTrtri<uplo, diag, tag>::invoke(A);
     }
     // Fence after each batch operation
     Kokkos::fence();
@@ -266,7 +266,7 @@ void __do_trtri_serial_batched_template(options_t options,
     for (int i = 0; i < options.start.a.k; ++i) {
       auto A = Kokkos::subview(trtri_args.A, i, Kokkos::ALL(), Kokkos::ALL());
 
-      SerialTrtri<uplo, diag, tag>::invoke(A);
+      KokkosBatched::SerialTrtri<uplo, diag, tag>::invoke(A);
     }
     // Fence after each batch operation
     Kokkos::fence();
@@ -284,6 +284,9 @@ void __do_trtri_serial_batched_template(options_t /*options*/,
 
 template <class scalar_type, class vta, class device_type>
 void __do_trtri_serial_batched(options_t options, trtri_args_t trtri_args) {
+  using KokkosBatched::Diag;
+  using KokkosBatched::Uplo;
+
   char __uplo = tolower(trtri_args.uplo), __diag = tolower(trtri_args.diag);
 
   STATUS;
@@ -382,7 +385,7 @@ struct parallel_batched_trtri {
   void operator()(const int& i) const {
     auto svA = Kokkos::subview(trtri_args_.A, i, Kokkos::ALL(), Kokkos::ALL());
 
-    SerialTrtri<uplo, diag, tag>::invoke(svA);
+    KokkosBatched::SerialTrtri<uplo, diag, tag>::invoke(svA);
   }
 };
 
@@ -392,7 +395,7 @@ void __do_trtri_parallel_batched_template(options_t options,
   uint32_t warm_up_n = options.warm_up_n;
   uint32_t n         = options.n;
   Kokkos::Timer timer;
-  using tag             = Algo::Trtri::Unblocked;
+  using tag             = KokkosBatched::Algo::Trtri::Unblocked;
   using execution_space = typename device_type::execution_space;
   using functor_type = parallel_batched_trtri<uplo, diag, tag, execution_space>;
   functor_type parallel_batched_trtri_functor(trtri_args);
@@ -425,6 +428,9 @@ void __do_trtri_parallel_batched_template(options_t options,
 
 template <class scalar_type, class vta, class device_type>
 void __do_trtri_parallel_batched(options_t options, trtri_args_t trtri_args) {
+  using KokkosBatched::Diag;
+  using KokkosBatched::Uplo;
+
   char __uplo = tolower(trtri_args.uplo), __diag = tolower(trtri_args.diag);
 
   STATUS;

--- a/src/blas/impl/KokkosBlas3_trmm_impl.hpp
+++ b/src/blas/impl/KokkosBlas3_trmm_impl.hpp
@@ -58,8 +58,6 @@
 #include "KokkosBatched_Trmm_Decl.hpp"
 #include "KokkosBatched_Trmm_Serial_Impl.hpp"
 
-using namespace KokkosBatched;
-
 namespace KokkosBlas {
 namespace Impl {
 
@@ -68,6 +66,13 @@ void SerialTrmm_Invoke(const char side[], const char uplo[], const char trans[],
                        const char /*diag*/[],
                        typename BViewType::const_value_type& alpha,
                        const AViewType& A, const BViewType& B) {
+  using KokkosBatched::Algo;
+  using KokkosBatched::Diag;
+  using KokkosBatched::SerialTrmmInternalLeftLower;
+  using KokkosBatched::SerialTrmmInternalLeftUpper;
+  using KokkosBatched::SerialTrmmInternalRightLower;
+  using KokkosBatched::SerialTrmmInternalRightUpper;
+
   char __side = tolower(side[0]), __uplo = tolower(uplo[0]),
        __trans = tolower(trans[0]);
   //__diag = tolower(diag[0]);

--- a/src/blas/impl/KokkosBlas3_trsm_impl.hpp
+++ b/src/blas/impl/KokkosBlas3_trsm_impl.hpp
@@ -57,8 +57,6 @@
 #include "KokkosBatched_Trsm_Decl.hpp"
 #include "KokkosBatched_Trsm_Serial_Impl.hpp"
 
-using namespace KokkosBatched;
-
 namespace KokkosBlas {
 namespace Impl {
 
@@ -74,9 +72,10 @@ int SerialTrsmInternalLeftLowerConj(const bool use_unit_diag, const int m,
   const ScalarType one(1.0), zero(0.0);
 
   if (alpha == zero)
-    SerialSetInternal ::invoke(m, n, zero, B, bs0, bs1);
+    KokkosBatched::SerialSetInternal ::invoke(m, n, zero, B, bs0, bs1);
   else {
-    if (alpha != one) SerialScaleInternal::invoke(m, n, alpha, B, bs0, bs1);
+    if (alpha != one)
+      KokkosBatched::SerialScaleInternal::invoke(m, n, alpha, B, bs0, bs1);
     if (m <= 0 || n <= 0) return 0;
 
     for (int p = 0; p < m; ++p) {
@@ -112,9 +111,10 @@ int SerialTrsmInternalLeftUpperConj(const bool use_unit_diag, const int m,
   const ScalarType one(1.0), zero(0.0);
 
   if (alpha == zero)
-    SerialSetInternal ::invoke(m, n, zero, B, bs0, bs1);
+    KokkosBatched::SerialSetInternal ::invoke(m, n, zero, B, bs0, bs1);
   else {
-    if (alpha != one) SerialScaleInternal::invoke(m, n, alpha, B, bs0, bs1);
+    if (alpha != one)
+      KokkosBatched::SerialScaleInternal::invoke(m, n, alpha, B, bs0, bs1);
     if (m <= 0 || n <= 0) return 0;
 
     ValueType* KOKKOS_RESTRICT B0 = B;
@@ -145,19 +145,22 @@ void SerialTrsm_Invoke(const char side[], const char uplo[], const char trans[],
                        const char diag[],
                        typename BViewType::const_value_type& alpha,
                        const AViewType& A, const BViewType& B) {
+  using KokkosBatched::Algo;
+  using KokkosBatched::Diag;
+
   // Side::Left, Uplo::Lower, Trans::NoTranspose
   if (((side[0] == 'L') || (side[0] == 'l')) &&
       ((uplo[0] == 'L') || (uplo[0] == 'l')) &&
       ((trans[0] == 'N') || (trans[0] == 'n')) &&
       ((diag[0] == 'U') || (diag[0] == 'u')))
-    SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
+    KokkosBatched::SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
         Diag::Unit::use_unit_diag, B.extent(0), B.extent(1), alpha, A.data(),
         A.stride(0), A.stride(1), B.data(), B.stride(0), B.stride(1));
   if (((side[0] == 'L') || (side[0] == 'l')) &&
       ((uplo[0] == 'L') || (uplo[0] == 'l')) &&
       ((trans[0] == 'N') || (trans[0] == 'n')) &&
       ((diag[0] == 'N') || (diag[0] == 'n')))
-    SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
+    KokkosBatched::SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
         Diag::NonUnit::use_unit_diag, B.extent(0), B.extent(1), alpha, A.data(),
         A.stride(0), A.stride(1), B.data(), B.stride(0), B.stride(1));
 
@@ -166,14 +169,14 @@ void SerialTrsm_Invoke(const char side[], const char uplo[], const char trans[],
       ((uplo[0] == 'L') || (uplo[0] == 'l')) &&
       ((trans[0] == 'T') || (trans[0] == 't')) &&
       ((diag[0] == 'U') || (diag[0] == 'u')))
-    SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
+    KokkosBatched::SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
         Diag::Unit::use_unit_diag, B.extent(0), B.extent(1), alpha, A.data(),
         A.stride(1), A.stride(0), B.data(), B.stride(0), B.stride(1));
   if (((side[0] == 'L') || (side[0] == 'l')) &&
       ((uplo[0] == 'L') || (uplo[0] == 'l')) &&
       ((trans[0] == 'T') || (trans[0] == 't')) &&
       ((diag[0] == 'N') || (diag[0] == 'n')))
-    SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
+    KokkosBatched::SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
         Diag::NonUnit::use_unit_diag, B.extent(0), B.extent(1), alpha, A.data(),
         A.stride(1), A.stride(0), B.data(), B.stride(0), B.stride(1));
 
@@ -198,14 +201,14 @@ void SerialTrsm_Invoke(const char side[], const char uplo[], const char trans[],
       ((uplo[0] == 'U') || (uplo[0] == 'u')) &&
       ((trans[0] == 'N') || (trans[0] == 'n')) &&
       ((diag[0] == 'U') || (diag[0] == 'u')))
-    SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
+    KokkosBatched::SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
         Diag::Unit::use_unit_diag, B.extent(0), B.extent(1), alpha, A.data(),
         A.stride(0), A.stride(1), B.data(), B.stride(0), B.stride(1));
   if (((side[0] == 'L') || (side[0] == 'l')) &&
       ((uplo[0] == 'U') || (uplo[0] == 'u')) &&
       ((trans[0] == 'N') || (trans[0] == 'n')) &&
       ((diag[0] == 'N') || (diag[0] == 'n')))
-    SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
+    KokkosBatched::SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
         Diag::NonUnit::use_unit_diag, B.extent(0), B.extent(1), alpha, A.data(),
         A.stride(0), A.stride(1), B.data(), B.stride(0), B.stride(1));
 
@@ -214,14 +217,14 @@ void SerialTrsm_Invoke(const char side[], const char uplo[], const char trans[],
       ((uplo[0] == 'U') || (uplo[0] == 'u')) &&
       ((trans[0] == 'T') || (trans[0] == 't')) &&
       ((diag[0] == 'U') || (diag[0] == 'u')))
-    SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
+    KokkosBatched::SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
         Diag::Unit::use_unit_diag, B.extent(0), B.extent(1), alpha, A.data(),
         A.stride(1), A.stride(0), B.data(), B.stride(0), B.stride(1));
   if (((side[0] == 'L') || (side[0] == 'l')) &&
       ((uplo[0] == 'U') || (uplo[0] == 'u')) &&
       ((trans[0] == 'T') || (trans[0] == 't')) &&
       ((diag[0] == 'N') || (diag[0] == 'n')))
-    SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
+    KokkosBatched::SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
         Diag::NonUnit::use_unit_diag, B.extent(0), B.extent(1), alpha, A.data(),
         A.stride(1), A.stride(0), B.data(), B.stride(0), B.stride(1));
 
@@ -246,14 +249,14 @@ void SerialTrsm_Invoke(const char side[], const char uplo[], const char trans[],
       ((uplo[0] == 'L') || (uplo[0] == 'l')) &&
       ((trans[0] == 'N') || (trans[0] == 'n')) &&
       ((diag[0] == 'U') || (diag[0] == 'u')))
-    SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
+    KokkosBatched::SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
         Diag::Unit::use_unit_diag, B.extent(1), B.extent(0), alpha, A.data(),
         A.stride(1), A.stride(0), B.data(), B.stride(1), B.stride(0));
   if (((side[0] == 'R') || (side[0] == 'r')) &&
       ((uplo[0] == 'L') || (uplo[0] == 'l')) &&
       ((trans[0] == 'N') || (trans[0] == 'n')) &&
       ((diag[0] == 'N') || (diag[0] == 'n')))
-    SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
+    KokkosBatched::SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
         Diag::NonUnit::use_unit_diag, B.extent(1), B.extent(0), alpha, A.data(),
         A.stride(1), A.stride(0), B.data(), B.stride(1), B.stride(0));
 
@@ -262,14 +265,14 @@ void SerialTrsm_Invoke(const char side[], const char uplo[], const char trans[],
       ((uplo[0] == 'L') || (uplo[0] == 'l')) &&
       ((trans[0] == 'T') || (trans[0] == 't')) &&
       ((diag[0] == 'U') || (diag[0] == 'u')))
-    SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
+    KokkosBatched::SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
         Diag::Unit::use_unit_diag, B.extent(1), B.extent(0), alpha, A.data(),
         A.stride(0), A.stride(1), B.data(), B.stride(1), B.stride(0));
   if (((side[0] == 'R') || (side[0] == 'r')) &&
       ((uplo[0] == 'L') || (uplo[0] == 'l')) &&
       ((trans[0] == 'T') || (trans[0] == 't')) &&
       ((diag[0] == 'N') || (diag[0] == 'n')))
-    SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
+    KokkosBatched::SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
         Diag::NonUnit::use_unit_diag, B.extent(1), B.extent(0), alpha, A.data(),
         A.stride(0), A.stride(1), B.data(), B.stride(1), B.stride(0));
 
@@ -294,14 +297,14 @@ void SerialTrsm_Invoke(const char side[], const char uplo[], const char trans[],
       ((uplo[0] == 'U') || (uplo[0] == 'u')) &&
       ((trans[0] == 'N') || (trans[0] == 'n')) &&
       ((diag[0] == 'U') || (diag[0] == 'u')))
-    SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
+    KokkosBatched::SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
         Diag::Unit::use_unit_diag, B.extent(1), B.extent(0), alpha, A.data(),
         A.stride(1), A.stride(0), B.data(), B.stride(1), B.stride(0));
   if (((side[0] == 'R') || (side[0] == 'r')) &&
       ((uplo[0] == 'U') || (uplo[0] == 'u')) &&
       ((trans[0] == 'N') || (trans[0] == 'n')) &&
       ((diag[0] == 'N') || (diag[0] == 'n')))
-    SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
+    KokkosBatched::SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
         Diag::NonUnit::use_unit_diag, B.extent(1), B.extent(0), alpha, A.data(),
         A.stride(1), A.stride(0), B.data(), B.stride(1), B.stride(0));
 
@@ -310,14 +313,14 @@ void SerialTrsm_Invoke(const char side[], const char uplo[], const char trans[],
       ((uplo[0] == 'U') || (uplo[0] == 'u')) &&
       ((trans[0] == 'T') || (trans[0] == 't')) &&
       ((diag[0] == 'U') || (diag[0] == 'u')))
-    SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
+    KokkosBatched::SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
         Diag::Unit::use_unit_diag, B.extent(1), B.extent(0), alpha, A.data(),
         A.stride(0), A.stride(1), B.data(), B.stride(1), B.stride(0));
   if (((side[0] == 'R') || (side[0] == 'r')) &&
       ((uplo[0] == 'U') || (uplo[0] == 'u')) &&
       ((trans[0] == 'T') || (trans[0] == 't')) &&
       ((diag[0] == 'N') || (diag[0] == 'n')))
-    SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
+    KokkosBatched::SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
         Diag::NonUnit::use_unit_diag, B.extent(1), B.extent(0), alpha, A.data(),
         A.stride(0), A.stride(1), B.data(), B.stride(1), B.stride(0));
 

--- a/src/blas/impl/KokkosBlas_trtri_impl.hpp
+++ b/src/blas/impl/KokkosBlas_trtri_impl.hpp
@@ -55,14 +55,17 @@
 #include "KokkosBatched_Trtri_Decl.hpp"
 #include "KokkosBatched_Trtri_Serial_Impl.hpp"
 
-using namespace KokkosBatched;
-
 namespace KokkosBlas {
 namespace Impl {
 
 template <class RViewType, class AViewType>
 void SerialTrtri_Invoke(const RViewType &R, const char uplo[],
                         const char diag[], const AViewType &A) {
+  using KokkosBatched::Algo;
+  using KokkosBatched::Diag;
+  using KokkosBatched::SerialTrtriInternalLower;
+  using KokkosBatched::SerialTrtriInternalUpper;
+
   char __uplo = tolower(uplo[0]), __diag = tolower(diag[0]);
 
   //// Lower ////


### PR DESCRIPTION
Introducing a whole namespace in a public is dangerous due to the potential for name clashes with other libraries.
Removing such usage from trmm, trsm and trtri resolves build issues observed by users in Trilinos, see issue #1170 