### PR TITLE
KokkosSparse_spmv_bsrmatrix_impl: remove unused typedef

### DIFF
--- a/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
@@ -239,8 +239,6 @@ struct BsrMatrixSpMVTensorCoreFunctor {
     using nvcuda::wmma::mma_sync;
     using nvcuda::wmma::store_matrix_sync;
 
-    typedef typename AMatrix::ordinal_type Ordinal;
-
     FragA fa;
     FragX fx;
     FragY fy;


### PR DESCRIPTION
Removed unused Ordinal typdef to prevent -Werror compile errors with
clang compilers