### PR TITLE
Fix #threads setting in pcg for OpenMP

### DIFF
--- a/perf_test/sparse/KokkosSparse_pcg.cpp
+++ b/perf_test/sparse/KokkosSparse_pcg.cpp
@@ -378,7 +378,8 @@ int main(int argc, char **argv) {
         std::max(cmdline[CMD_USE_THREADS], cmdline[CMD_USE_OPENMP]);
     init_args.num_numa = cmdline[CMD_USE_NUMA];
   } else {
-    init_args.num_threads = cmdline[CMD_USE_THREADS];
+    init_args.num_threads =
+        std::max(cmdline[CMD_USE_THREADS], cmdline[CMD_USE_OPENMP]);
   }
 
   Kokkos::initialize(init_args);


### PR DESCRIPTION
``./sparse_pcg --openmp N ...`` should set the number of threads to N,
but it was setting this to 0 no matter what argument was passed on command line.
It was using the thread count for Pthreads (``--threads N``) instead, and this defaulted to 0.
This caused a crash in parallel_scan halfway through Gauss-Seidel setup.

Fixes https://github.com/kokkos/kokkos-kernels/issues/1168 .

See https://github.com/kokkos/kokkos/issues/4512 for a request that Kokkos check that ``InitArguments::num_threads != 0``.