### PR TITLE
Check that ordinal types are signed

### DIFF
--- a/src/common/KokkosKernels_Handle.hpp
+++ b/src/common/KokkosKernels_Handle.hpp
@@ -61,6 +61,10 @@ namespace Experimental {
 template <class size_type_, class lno_t_, class scalar_t_, class ExecutionSpace,
           class TemporaryMemorySpace, class PersistentMemorySpace>
 class KokkosKernelsHandle {
+  static_assert(std::is_signed<lno_t_>::value,
+                "KokkosKernelsHandle requires that lno_t_ (ordinal) is a "
+                "signed integer type.");
+
  public:
   typedef typename ExecutionSpace::execution_space HandleExecSpace;
   typedef typename TemporaryMemorySpace::memory_space HandleTempMemorySpace;

--- a/src/sparse/KokkosSparse_BlockCrsMatrix.hpp
+++ b/src/sparse/KokkosSparse_BlockCrsMatrix.hpp
@@ -410,6 +410,10 @@ template <class ScalarType, class OrdinalType, class Device,
           class SizeType     = typename Kokkos::ViewTraits<OrdinalType*, Device,
                                                        void, void>::size_type>
 class BlockCrsMatrix {
+  static_assert(
+      std::is_signed<OrdinalType>::value,
+      "BlockCrsMatrix requires that OrdinalType is a signed integer type.");
+
  private:
   typedef
       typename Kokkos::ViewTraits<ScalarType*, Device, void,

--- a/src/sparse/KokkosSparse_BsrMatrix.hpp
+++ b/src/sparse/KokkosSparse_BsrMatrix.hpp
@@ -344,6 +344,10 @@ template <class ScalarType, class OrdinalType, class Device,
           class SizeType     = typename Kokkos::ViewTraits<OrdinalType*, Device,
                                                        void, void>::size_type>
 class BsrMatrix {
+  static_assert(
+      std::is_signed<OrdinalType>::value,
+      "BsrMatrix requires that OrdinalType is a signed integer type.");
+
  private:
   typedef
       typename Kokkos::ViewTraits<ScalarType*, Device, void,

--- a/src/sparse/KokkosSparse_CrsMatrix.hpp
+++ b/src/sparse/KokkosSparse_CrsMatrix.hpp
@@ -373,6 +373,10 @@ template <class ScalarType, class OrdinalType, class Device,
           class SizeType     = typename Kokkos::ViewTraits<OrdinalType*, Device,
                                                        void, void>::size_type>
 class CrsMatrix {
+  static_assert(
+      std::is_signed<OrdinalType>::value,
+      "CrsMatrix requires that OrdinalType is a signed integer type.");
+
  private:
   typedef typename Kokkos::ViewTraits<ScalarType*, Device, void,
                                       MemoryTraits>::host_mirror_space


### PR DESCRIPTION
At compile time, check that the ordinal type is signed, for Crs/Bsr/BlockCrs matrix and KokkosKernelHandle.

This is required by at least 2 algorithms (SpGEMM and MIS2).
Note that you can only ETI for ordinal being signed (int and int64_t).
Having an unsigned ordinal gives warnings now. It might take some work to make everything fully support unsigned.