### PR TITLE
bsr: add guards to prevent unused variable -Werror in Cuda builds

### DIFF
--- a/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
@@ -239,9 +239,11 @@ struct BsrMatrixSpMVTensorCoreFunctor {
     using nvcuda::wmma::mma_sync;
     using nvcuda::wmma::store_matrix_sync;
 
+#ifdef __CUDA_ARCH__
     FragA fa;
     FragX fx;
     FragY fy;
+#endif
 
     // override with template params if given
     const int ld_x = LEAGUE_DIM_X > 0 ? LEAGUE_DIM_X : params.leagueDim_x;


### PR DESCRIPTION
FragA,X,Y are only used when CUDA_ARCH is true; add guards to the
variables to prevent unused variable Werror