### PR TITLE
scripts/cm_test_all_sandia: add clang/10.0.1 spot check

### DIFF
--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -739,6 +739,7 @@ elif [ "$MACHINE" = "blake" ]; then
       #"pgi/18.7.0 $BASE_MODULE_LIST $GCC_BUILD_LIST pgc++ $PGI_WARNING_FLAGS"
     COMPILERS=("intel/19.1.144 $BASE_MODULE_LIST_INTEL "OpenMP_Serial" icpc $INTEL_WARNING_FLAGS"
                "gcc/7.2.0 $BASE_MODULE_LIST "Pthread_Serial,OpenMP" g++ $GCC_WARNING_FLAGS"
+               "clang/10.0.1 $BASE_MODULE_LIST "Pthread_Serial" clang++ $CLANG_WARNING_FLAGS"
     )
   elif [ "$SPOT_CHECK_TPLS" = "True" ]; then
       # Format: (compiler module-list build-list exe-name warning-flag)


### PR DESCRIPTION
Related to #956.