### PR TITLE
Allow choosing coloring algorithm in multicolor GS

### DIFF
--- a/src/common/KokkosKernels_Handle.hpp
+++ b/src/common/KokkosKernels_Handle.hpp
@@ -605,7 +605,9 @@ class KokkosKernelsHandle {
     return cgs;
   }
   void create_gs_handle(
-      KokkosSparse::GSAlgorithm gs_algorithm = KokkosSparse::GS_DEFAULT) {
+      KokkosSparse::GSAlgorithm gs_algorithm = KokkosSparse::GS_DEFAULT,
+      KokkosGraph::ColoringAlgorithm coloring_algorithm =
+          KokkosGraph::COLORING_DEFAULT) {
     this->destroy_gs_handle();
     this->is_owner_of_the_gs_handle = true;
     // ---------------------------------------- //
@@ -613,7 +615,8 @@ class KokkosKernelsHandle {
     if (gs_algorithm == KokkosSparse::GS_TWOSTAGE)
       this->gsHandle = new TwoStageGaussSeidelHandleType();
     else
-      this->gsHandle = new PointGaussSeidelHandleType(gs_algorithm);
+      this->gsHandle =
+          new PointGaussSeidelHandleType(gs_algorithm, coloring_algorithm);
   }
   // ---------------------------------------- //
   // Two-stage Gauss-Seidel handle
@@ -673,11 +676,13 @@ class KokkosKernelsHandle {
   }
 
   void create_gs_handle(KokkosSparse::ClusteringAlgorithm clusterAlgo,
-                        nnz_lno_t hint_verts_per_cluster) {
+                        nnz_lno_t hint_verts_per_cluster,
+                        KokkosGraph::ColoringAlgorithm coloring_algorithm =
+                            KokkosGraph::COLORING_DEFAULT) {
     this->destroy_gs_handle();
     this->is_owner_of_the_gs_handle = true;
-    this->gsHandle =
-        new ClusterGaussSeidelHandleType(clusterAlgo, hint_verts_per_cluster);
+    this->gsHandle                  = new ClusterGaussSeidelHandleType(
+        clusterAlgo, hint_verts_per_cluster, coloring_algorithm);
   }
   void destroy_gs_handle() {
     if (is_owner_of_the_gs_handle && this->gsHandle != NULL) {

--- a/src/common/KokkosKernels_IOUtils.hpp
+++ b/src/common/KokkosKernels_IOUtils.hpp
@@ -188,7 +188,7 @@ void kk_diagonally_dominant_sparseMatrix_generate(
   rowPtr[0] = 0;
   for (int row = 0; row < nrows; row++) {
     int varianz = (1.0 * rand() / RAND_MAX - 0.5) * row_size_variance;
-    if (varianz < 0) varianz = 0;
+    if (varianz < 1) varianz = 1;
     if (varianz > 0.75 * ncols) varianz = 0.75 * ncols;
     rowPtr[row + 1] = rowPtr[row] + elements_per_row + varianz;
     if (rowPtr[row + 1] <= rowPtr[row])   // This makes sure that there is

--- a/src/common/KokkosKernels_IOUtils.hpp
+++ b/src/common/KokkosKernels_IOUtils.hpp
@@ -49,6 +49,7 @@
 #include <sstream>
 #include <algorithm>
 #include <vector>
+#include <unordered_set>
 #include <stdexcept>
 #include <type_traits>
 #ifndef _KOKKOSKERNELSIOUTILS_HPP
@@ -186,7 +187,9 @@ void kk_diagonally_dominant_sparseMatrix_generate(
   srand(13721);
   rowPtr[0] = 0;
   for (int row = 0; row < nrows; row++) {
-    int varianz     = (1.0 * rand() / RAND_MAX - 0.5) * row_size_variance;
+    int varianz = (1.0 * rand() / RAND_MAX - 0.5) * row_size_variance;
+    if (varianz < 0) varianz = 0;
+    if (varianz > 0.75 * ncols) varianz = 0.75 * ncols;
     rowPtr[row + 1] = rowPtr[row] + elements_per_row + varianz;
     if (rowPtr[row + 1] <= rowPtr[row])   // This makes sure that there is
       rowPtr[row + 1] = rowPtr[row] + 1;  // at least one nonzero in the row
@@ -196,24 +199,17 @@ void kk_diagonally_dominant_sparseMatrix_generate(
   colInd = new OrdinalType[nnz];
   for (OrdinalType row = 0; row < nrows; row++) {
     ScalarType total_values = 0;
+    std::unordered_set<OrdinalType> entriesInRow;
+    // We always add the diagonal entry (after this loop)
+    entriesInRow.insert(row);
     for (SizeType k = rowPtr[row]; k < rowPtr[row + 1] - 1; k++) {
       while (true) {
         OrdinalType pos = (1.0 * rand() / RAND_MAX - 0.5) * bandwidth + row;
         while (pos < 0) pos += ncols;
         while (pos >= ncols) pos -= ncols;
 
-        bool is_already_in_the_row = false;
-        if (pos == row)
-          is_already_in_the_row = true;
-        else {
-          for (SizeType j = rowPtr[row]; j < k; j++) {
-            if (colInd[j] == pos) {
-              is_already_in_the_row = true;
-              break;
-            }
-          }
-        }
-        if (!is_already_in_the_row) {
+        if (entriesInRow.find(pos) == entriesInRow.end()) {
+          entriesInRow.insert(pos);
           colInd[k] = pos;
           values[k] = 100.0 * rand() / RAND_MAX - 50.0;
           total_values +=

--- a/src/common/KokkosKernels_Sorting.hpp
+++ b/src/common/KokkosKernels_Sorting.hpp
@@ -1063,7 +1063,7 @@ template <typename exec_space, typename rowmap_t, typename entries_t>
 
 template <typename crsMat_t>
 [[deprecated]] crsMat_t sort_and_merge_matrix(const crsMat_t& A) {
-  KokkosKernels::sort_and_merge_matrix(A);
+  return KokkosKernels::sort_and_merge_matrix(A);
 }
 
 template <

--- a/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
+++ b/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
@@ -47,6 +47,8 @@
 #include <KokkosKernels_Utils.hpp>
 // needed for two-stage/classical GS
 #include <KokkosSparse_CrsMatrix.hpp>
+// needed for the set of available coloring algorithms
+#include <KokkosGraph_Distance1ColorHandle.hpp>
 
 #ifndef _GAUSSSEIDELHANDLE_HPP
 #define _GAUSSSEIDELHANDLE_HPP
@@ -264,11 +266,16 @@ class PointGaussSeidelHandle
   // in a color.
   scalar_persistent_work_view_t long_row_x;
 
+  // Coloring algorithm to use
+  KokkosGraph::ColoringAlgorithm coloring_algo;
+
  public:
   /**
    * \brief Default constructor.
    */
-  PointGaussSeidelHandle(GSAlgorithm gs = GS_DEFAULT)
+  PointGaussSeidelHandle(GSAlgorithm gs = GS_DEFAULT,
+                         KokkosGraph::ColoringAlgorithm coloring_algo_ =
+                             KokkosGraph::COLORING_DEFAULT)
       : GSHandle(gs),
         permuted_xadj(),
         permuted_adj(),
@@ -283,7 +290,8 @@ class PointGaussSeidelHandle
         num_big_rows(0),
         level_1_mem(0),
         level_2_mem(0),
-        long_row_threshold(0) {
+        long_row_threshold(0),
+        coloring_algo(coloring_algo_) {
     if (gs == GS_DEFAULT) this->choose_default_algorithm();
   }
 
@@ -295,6 +303,13 @@ class PointGaussSeidelHandle
       this->algorithm_type = GS_TEAM;
     else
       this->algorithm_type = GS_PERMUTED;
+  }
+
+  KokkosGraph::ColoringAlgorithm get_coloring_algorithm() const {
+    return this->coloring_algo;
+  }
+  void set_coloring_algorithm(KokkosGraph::ColoringAlgorithm algo) {
+    this->coloring_algo = algo;
   }
 
   ~PointGaussSeidelHandle() = default;
@@ -491,6 +506,9 @@ class ClusterGaussSeidelHandle
   // but cluster_xadj always has the exact size of each.
   nnz_lno_t cluster_size;
 
+  // Coloring algorithm to use on the coarsened graph
+  KokkosGraph::ColoringAlgorithm coloring_algo;
+
   int suggested_vector_size;
   int suggested_team_size;
 
@@ -509,10 +527,12 @@ class ClusterGaussSeidelHandle
 
   // Constructor for cluster-coloring based GS and SGS
   ClusterGaussSeidelHandle(ClusteringAlgorithm cluster_algo_,
-                           nnz_lno_t cluster_size_)
+                           nnz_lno_t cluster_size_,
+                           KokkosGraph::ColoringAlgorithm coloring_algo_)
       : GSHandle(GS_CLUSTER),
         cluster_algo(cluster_algo_),
         cluster_size(cluster_size_),
+        coloring_algo(coloring_algo_),
         inverse_diagonal(),
         cluster_xadj(),
         cluster_adj(),
@@ -520,6 +540,13 @@ class ClusterGaussSeidelHandle
 
   void set_cluster_size(nnz_lno_t cs) { this->cluster_size = cs; }
   nnz_lno_t get_cluster_size() const { return this->cluster_size; }
+
+  KokkosGraph::ColoringAlgorithm get_coloring_algorithm() const {
+    return this->coloring_algo;
+  }
+  void set_coloring_algorithm(KokkosGraph::ColoringAlgorithm algo) {
+    this->coloring_algo = algo;
+  }
 
   void set_vert_clusters(nnz_lno_persistent_work_view_t &vert_clusters_) {
     this->vert_clusters = vert_clusters_;

--- a/src/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
@@ -660,7 +660,7 @@ class ClusterGaussSeidel {
     // Create a handle that uses nnz_lno_t as the size_type, since the cluster
     // graph should never be larger than 2^31 entries.
     HandleType kh;
-    kh.create_graph_coloring_handle(KokkosGraph::COLORING_DEFAULT);
+    kh.create_graph_coloring_handle(gsHandle->get_coloring_algorithm());
     KokkosGraph::Experimental::graph_color_symbolic(
         &kh, numClusters, numClusters, clusterRowmap, clusterEntries);
     // retrieve colors

--- a/src/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
@@ -873,7 +873,8 @@ class PointGaussSeidel {
     color_t numColors;
     {
       HandleType coloringHandle;
-      coloringHandle.create_graph_coloring_handle();
+      coloringHandle.create_graph_coloring_handle(
+          gsHandle->get_coloring_algorithm());
       auto gchandle = coloringHandle.get_graph_coloring_handle();
       if (!is_symmetric) {
         if (gchandle->get_coloring_algo_type() == KokkosGraph::COLORING_EB) {


### PR DESCRIPTION
(both point and cluster)

- Allow the two overloads of KokkosKernelsHandle::create_gs_handle to take a coloring algorithm (it's the last argument, and defaults to COLORING_DEFAULT, so it's backwards compatible)
- Add coloring algorithm as argument to Point/Cluster gauss seidel handle, and getter/setter
- Test for GS using a custom algorithm (existing tests still use default)

This is needed in order to do https://github.com/trilinos/Trilinos/issues/8441 (add coloring as an option to Ifpack2 MTGS). Then it will be possible to fix random failures in Ifpack2::Relaxation - right now, non-deterministic coloring can make the number of GS iterations change slightly from run to run.