### PR TITLE
Add rocBLAS GEMV wrapper

### DIFF
--- a/perf_test/blas/blas2/KokkosBlas2_gemv_perf_test.cpp
+++ b/perf_test/blas/blas2/KokkosBlas2_gemv_perf_test.cpp
@@ -188,12 +188,12 @@ int main(int argc, char** argv) {
   bool useHIP     = params.use_hip != 0;
 
   // Create boolean to handle serial setting if not using open and cuda
-  bool useSerial = !useOMP && !useCUDA;
+  bool useSerial = !useThreads && !useOMP && !useCUDA && !useHIP;
 
   // Logic for runtime with PThreads
   if (useThreads) {
 #if defined(KOKKOS_ENABLE_THREADS)
-    if (params.use_threads)
+    if (params.layoutLeft)
       run<Kokkos::Threads, Kokkos::LayoutLeft>(params.m, params.n,
                                                params.repeat);
     else

--- a/perf_test/blas/blas2/KokkosBlas2_gemv_perf_test.cpp
+++ b/perf_test/blas/blas2/KokkosBlas2_gemv_perf_test.cpp
@@ -47,6 +47,7 @@
 
 struct Params {
   int use_cuda    = 0;
+  int use_hip     = 0;
   int use_openmp  = 0;
   int use_threads = 0;
   int m           = 5000;
@@ -85,6 +86,8 @@ int parse_inputs(Params& params, int argc, char** argv) {
       params.use_openmp = atoi(argv[++i]);
     } else if (0 == strcasecmp(argv[i], "--cuda")) {
       params.use_cuda = atoi(argv[++i]) + 1;
+    } else if (0 == strcasecmp(argv[i], "--hip")) {
+      params.use_hip = atoi(argv[++i]) + 1;
     } else if (0 == strcasecmp(argv[i], "--layout")) {
       i++;
       if (0 == strcasecmp(argv[i], "left"))
@@ -174,8 +177,7 @@ int main(int argc, char** argv) {
   // const int num_threads = params.use_openmp;
   const int num_threads = std::max(params.use_openmp, params.use_threads);
 
-  const int device_id = params.use_cuda - 1;
-
+  const int device_id = std::max(params.use_cuda, params.use_hip) - 1;
   Kokkos::initialize(Kokkos::InitArguments(num_threads, -1, device_id));
 
   // Create booleans to handle pthreads, openmp and cuda params and initialize
@@ -183,6 +185,7 @@ int main(int argc, char** argv) {
   bool useThreads = params.use_threads != 0;
   bool useOMP     = params.use_openmp != 0;
   bool useCUDA    = params.use_cuda != 0;
+  bool useHIP     = params.use_hip != 0;
 
   // Create boolean to handle serial setting if not using open and cuda
   bool useSerial = !useOMP && !useCUDA;
@@ -226,6 +229,19 @@ int main(int argc, char** argv) {
       run<Kokkos::Cuda, Kokkos::LayoutRight>(params.m, params.n, params.repeat);
 #else
     std::cout << "ERROR: CUDA requested, but not available.\n";
+    return 1;
+#endif
+  }
+  if (useHIP) {
+#if defined(KOKKOS_ENABLE_HIP)
+    if (params.layoutLeft)
+      run<Kokkos::Experimental::HIP, Kokkos::LayoutLeft>(params.m, params.n,
+                                                         params.repeat);
+    else
+      run<Kokkos::Experimental::HIP, Kokkos::LayoutRight>(params.m, params.n,
+                                                          params.repeat);
+#else
+    std::cout << "ERROR: HIP requested, but not available.\n";
     return 1;
 #endif
   }

--- a/src/blas/KokkosBlas2_gemv.hpp
+++ b/src/blas/KokkosBlas2_gemv.hpp
@@ -145,8 +145,8 @@ void gemv(const typename AViewType::execution_space& space, const char trans[],
   // to avoid potential (unlikely?) circular dependence issues by including
   // other KokkosBlas headers
   bool useFallback = A.extent(0) == 0 || A.extent(1) == 0;
-  // If A is LayoutRight and we have the cuBLAS or rocBLAS TPL, use fallback
-  // because those only support LayoutLeft
+  // If A is LayoutRight and we have the BLAS, cuBLAS or rocBLAS TPL, use
+  // fallback because those only support LayoutLeft
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUBLAS
   useFallback = useFallback || (tolower(*trans) == 'c' &&
                                 std::is_same<typename AViewType::array_layout,
@@ -161,6 +161,13 @@ void gemv(const typename AViewType::execution_space& space, const char trans[],
                                    Kokkos::LayoutRight>::value &&
                       std::is_same<typename AViewType::memory_space,
                                    Kokkos::Experimental::HIPSpace>::value);
+#endif
+#ifdef KOKKOSKERNELS_ENABLE_TPL_BLAS
+  useFallback = useFallback || (tolower(*trans) == 'c' &&
+                                std::is_same<typename AViewType::array_layout,
+                                             Kokkos::LayoutRight>::value &&
+                                std::is_same<typename AViewType::memory_space,
+                                             Kokkos::HostSpace>::value);
 #endif
   if (useFallback) {
     const bool eti_spec_avail =

--- a/src/impl/tpls/KokkosBlas2_gemv_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosBlas2_gemv_tpl_spec_avail.hpp
@@ -117,6 +117,11 @@ KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_BLAS(Kokkos::complex<float>,
     enum : bool { value = true };                                         \
   };
 
+// Note BMK: We use the same layout for A, X and Y because the GEMV
+// interface will switch the layouts of X and Y to that of A.
+// So this TPL version will match any layout combination, as long
+// as none are LayoutStride.
+
 KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_CUBLAS(double, Kokkos::LayoutLeft,
                                        Kokkos::LayoutLeft, Kokkos::LayoutLeft,
                                        Kokkos::CudaSpace)
@@ -142,6 +147,43 @@ KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<double>,
 KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<float>,
                                        Kokkos::LayoutRight, Kokkos::LayoutRight,
                                        Kokkos::LayoutRight, Kokkos::CudaSpace)
+
+#endif
+
+// rocBLAS
+#ifdef KOKKOSKERNELS_ENABLE_TPL_ROCBLAS
+
+#define KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ROCBLAS(SCALAR, LAYOUT)    \
+  template <>                                                      \
+  struct gemv_tpl_spec_avail<                                      \
+      Kokkos::View<const SCALAR**, LAYOUT,                         \
+                   Kokkos::Device<Kokkos::Experimental::HIP,       \
+                                  Kokkos::Experimental::HIPSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
+      Kokkos::View<const SCALAR*, LAYOUT,                          \
+                   Kokkos::Device<Kokkos::Experimental::HIP,       \
+                                  Kokkos::Experimental::HIPSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
+      Kokkos::View<SCALAR*, LAYOUT,                                \
+                   Kokkos::Device<Kokkos::Experimental::HIP,       \
+                                  Kokkos::Experimental::HIPSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {   \
+    enum : bool { value = true };                                  \
+  };
+
+KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ROCBLAS(double, Kokkos::LayoutLeft)
+KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ROCBLAS(float, Kokkos::LayoutLeft)
+KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<double>,
+                                        Kokkos::LayoutLeft)
+KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<float>,
+                                        Kokkos::LayoutLeft)
+
+KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ROCBLAS(double, Kokkos::LayoutRight)
+KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ROCBLAS(float, Kokkos::LayoutRight)
+KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<double>,
+                                        Kokkos::LayoutRight)
+KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<float>,
+                                        Kokkos::LayoutRight)
 
 #endif
 }  // namespace Impl

--- a/unit_test/blas/Test_Blas2_gemv.hpp
+++ b/unit_test/blas/Test_Blas2_gemv.hpp
@@ -11,7 +11,6 @@ void impl_test_gemv(const char* mode, int M, int N) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeX::value_type ScalarX;
   typedef typename ViewTypeY::value_type ScalarY;
-  using LayoutAType = typename ViewTypeA::array_layout;
   typedef Kokkos::ArithTraits<ScalarY> KAT_Y;
 
   typedef multivector_layout_adapter<ViewTypeA> vfA_type;
@@ -78,17 +77,7 @@ void impl_test_gemv(const char* mode, int M, int N) {
   Kokkos::deep_copy(expected, h_org_y);
   vanillaGEMV(mode[0], alpha, h_A, h_x, beta, expected);
 
-  // Cublas does not support row-major (LayoutRight) + conjugate transpose
-  // We throw a runtime error in the wrapper for cublasGemv if the user attempts
-  // this, therefore we must test this code path via the try-catch below.
-  try {
-    KokkosBlas::gemv(mode, alpha, A, x, beta, y);
-  } catch (const std::runtime_error& error) {
-    if ((mode[0] == 'c' || mode[0] == 'C') &&
-        std::is_same<LayoutAType, Kokkos::LayoutRight>::value)
-      return;  // Pass since we caught the runtime error
-    FAIL();
-  }
+  KokkosBlas::gemv(mode, alpha, A, x, beta, y);
   Kokkos::deep_copy(h_y, y);
   int numErrors = 0;
   for (int i = 0; i < ldy; i++) {


### PR DESCRIPTION
Fix GEMV for complex/LayoutRight: this isn't supported by cuBLAS or rocBLAS, so call the fallback option instead of just throwing. To test this, change the unit test to not catch and ignore exceptions.

Add HIP support to GEMV perftest.

This basically takes care of #1083 . Here are some performance measurements for double, 10k x 10k matrix, based on 100 repetitions:

MI100 native impl: 1.74 e+11 flops
MI100 rocBLAS: 2.48 e+11 flops
V100 cuBLAS: 2.18 e+11 flops