### PR TITLE
Replace array reductions in BLAS-1 MV reductions

### DIFF
--- a/perf_test/blas/blas1/CMakeLists.txt
+++ b/perf_test/blas/blas1/CMakeLists.txt
@@ -8,4 +8,7 @@ KOKKOSKERNELS_ADD_EXECUTABLE(
     KokkosBlas_dot_perf_test SOURCES KokkosBlas_dot_perf_test.cpp)
 
 KOKKOSKERNELS_ADD_EXECUTABLE(
+    KokkosBlas_dot_mv_perf_test SOURCES KokkosBlas_dot_mv_perf_test.cpp)
+
+KOKKOSKERNELS_ADD_EXECUTABLE(
     KokkosBlas_team_dot_perf_test SOURCES KokkosBlas_team_dot_perf_test.cpp)

--- a/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test.cpp
@@ -1,0 +1,235 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Core.hpp>
+#include <blas/KokkosBlas1_dot.hpp>
+#include <Kokkos_Random.hpp>
+
+struct Params {
+  int use_cuda    = 0;
+  int use_openmp  = 0;
+  int use_threads = 0;
+  // m is vector length
+  int m = 100000;
+  // n is number of columns
+  int n      = 5;
+  int repeat = 20;
+};
+
+void print_options() {
+  std::cerr << "Options:\n" << std::endl;
+
+  std::cerr << "\tBACKEND: '--threads[numThreads]' | '--openmp [numThreads]' | "
+               "'--cuda [cudaDeviceIndex]'"
+            << std::endl;
+  std::cerr << "\tIf no BACKEND selected, serial is the default." << std::endl;
+  std::cerr << "\t[Optional] --repeat :: how many times to repeat overall "
+               "dot (symbolic + repeated numeric)"
+            << std::endl;
+  std::cerr << "\t[Optional] --m      :: desired length of test vectors; test "
+               "vectors will have the same length"
+            << std::endl;
+  std::cerr << "\t[Optional] --n      :: number of test vectors (columns)"
+            << std::endl;
+}
+
+int parse_inputs(Params& params, int argc, char** argv) {
+  for (int i = 1; i < argc; ++i) {
+    if (0 == strcasecmp(argv[i], "--help") || 0 == strcasecmp(argv[i], "-h")) {
+      print_options();
+      exit(0);  // note: this is before Kokkos::initialize
+    } else if (0 == strcasecmp(argv[i], "--threads")) {
+      params.use_threads = atoi(argv[++i]);
+    } else if (0 == strcasecmp(argv[i], "--openmp")) {
+      params.use_openmp = atoi(argv[++i]);
+    } else if (0 == strcasecmp(argv[i], "--cuda")) {
+      params.use_cuda = atoi(argv[++i]) + 1;
+    } else if (0 == strcasecmp(argv[i], "--m")) {
+      params.m = atoi(argv[++i]);
+    } else if (0 == strcasecmp(argv[i], "--n")) {
+      params.n = atoi(argv[++i]);
+    } else if (0 == strcasecmp(argv[i], "--repeat")) {
+      // if provided, C will be written to given file.
+      // has to have ".bin", or ".crs" extension.
+      params.repeat = atoi(argv[++i]);
+    } else {
+      std::cerr << "Unrecognized command line argument #" << i << ": "
+                << argv[i] << std::endl;
+      print_options();
+      return 1;
+    }
+  }
+  return 0;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// The Level 1 BLAS perform scalar, vector and vector-vector operations;
+//
+// https://github.com/kokkos/kokkos-kernels/wiki/BLAS-1%3A%3Adot
+//
+// Usage: result = KokkosBlas::dot(x,y); KokkosBlas::dot(r,x,y);
+// Multiplies each value of x(i) [x(i,j)] with y(i) or [y(i,j)] and computes the
+// sum. (If x and y have scalar type Kokkos::complex, the complex conjugate of
+// x(i) or x(i,j) will be used.) VectorX: A rank-1 Kokkos::View VectorY: A
+// rank-1 Kokkos::View ReturnVector: A rank-0 or rank-1 Kokkos::View
+//
+// REQUIREMENTS:
+// Y.rank == 1 or X.rank == 1
+// Y.extent(0) == X.extent(0)
+
+// Dot Test design:
+// 1) create 1D View containing 1D matrix, aka a vector; this will be your X
+// input matrix; 2) create 1D View containing 1D matrix, aka a vector; this will
+// be your Y input matrix; 3) perform the dot operation on the two inputs, and
+// capture result in "result"
+
+// Here, m represents the desired length for each 1D matrix;
+// "m" is used here, because code from another test was adapted for this test.
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class ExecSpace>
+void run(int m, int n, int repeat) {
+  // Declare type aliases
+  using Scalar   = double;
+  using MemSpace = typename ExecSpace::memory_space;
+  using Device   = Kokkos::Device<ExecSpace, MemSpace>;
+
+  std::cout << "Running BLAS Level 1 DOT perfomrance experiment ("
+            << ExecSpace::name() << ")\n";
+
+  std::cout << "Each test input vector has a length of " << m << std::endl;
+
+  Kokkos::View<Scalar**, Kokkos::LayoutLeft, Device> x(
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "x"), m, n);
+
+  Kokkos::View<Scalar**, Kokkos::LayoutLeft, Device> y(
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "y"), m, n);
+
+  Kokkos::View<Scalar*, Device> result(
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "x dot y"), n);
+
+  // Declaring variable pool w/ a seeded random number;
+  // a parallel random number generator, so you
+  // won't get the same number with a given seed each time
+  Kokkos::Random_XorShift64_Pool<ExecSpace> pool(123);
+
+  Kokkos::fill_random(x, pool, 10.0);
+  Kokkos::fill_random(y, pool, 10.0);
+
+  // do a warm up run of dot:
+  KokkosBlas::dot(result, x, y);
+
+  // The live test of dot:
+
+  Kokkos::fence();
+  Kokkos::Timer timer;
+
+  for (int i = 0; i < repeat; i++) {
+    KokkosBlas::dot(result, x, y);
+    ExecSpace().fence();
+  }
+
+  // Kokkos Timer set up
+  double total = timer.seconds();
+  double avg   = total / repeat;
+  // Flops calculation for a 1D matrix dot product per test run;
+  size_t flopsPerRun = (size_t)2 * m * n;
+  printf("Avg DOT time: %f s.\n", avg);
+  printf("Avg DOT FLOP/s: %.3e\n", flopsPerRun / avg);
+}
+
+int main(int argc, char** argv) {
+  Params params;
+
+  if (parse_inputs(params, argc, argv)) {
+    return 1;
+  }
+  const int device_id = params.use_cuda - 1;
+
+  const int num_threads = std::max(params.use_openmp, params.use_threads);
+
+  Kokkos::initialize(Kokkos::InitArguments(num_threads, -1, device_id));
+
+  bool useThreads = params.use_threads != 0;
+  bool useOMP     = params.use_openmp != 0;
+  bool useCUDA    = params.use_cuda != 0;
+  bool useSerial  = !useThreads && !useOMP && !useCUDA;
+
+  if (useThreads) {
+#if defined(KOKKOS_ENABLE_THREADS)
+    run<Kokkos::Threads>(params.m, params.n, params.repeat);
+#else
+    std::cout << "ERROR:  PThreads requested, but not available.\n";
+    return 1;
+#endif
+  }
+
+  if (useOMP) {
+#if defined(KOKKOS_ENABLE_OPENMP)
+    run<Kokkos::OpenMP>(params.m, params.n, params.repeat);
+#else
+    std::cout << "ERROR: OpenMP requested, but not available.\n";
+    return 1;
+#endif
+  }
+
+  if (useCUDA) {
+#if defined(KOKKOS_ENABLE_CUDA)
+    run<Kokkos::Cuda>(params.m, params.n, params.repeat);
+#else
+    std::cout << "ERROR: CUDA requested, but not available.\n";
+    return 1;
+#endif
+  }
+  if (useSerial) {
+#if defined(KOKKOS_ENABLE_SERIAL)
+    run<Kokkos::Serial>(params.m, params.n, params.repeat);
+#else
+    std::cout << "ERROR: Serial device requested, but not available.\n";
+    return 1;
+#endif
+  }
+  Kokkos::finalize();
+  return 0;
+}

--- a/src/blas/impl/KokkosBlas1_dot_mv_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_dot_mv_impl.hpp
@@ -44,616 +44,124 @@
 #ifndef KOKKOSBLAS1_IMPL_DOT_MV_IMPL_HPP_
 #define KOKKOSBLAS1_IMPL_DOT_MV_IMPL_HPP_
 
-#ifndef KOKKOSBLAS_OPTIMIZATION_LEVEL_DOT
-#define KOKKOSBLAS_OPTIMIZATION_LEVEL_DOT 2
-#endif  // KOKKOSBLAS_OPTIMIZATION_LEVEL_DOT
-
 #include <KokkosKernels_config.h>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_InnerProductSpaceTraits.hpp>
-#include <type_traits>
-#include <KokkosBlas1_dot_impl.hpp>
+#include <KokkosBlas_util.hpp>
+#include <sstream>
 
 namespace KokkosBlas {
 namespace Impl {
 
-/// \brief Dot product functor for a multivector times a single
-///   vector, or vice versa.
-///
-/// "Multivector dot a single vector" means that each column of the
-/// multivector gets dotted with the same vector, as if the latter
-/// vector were replicated.  "Single vector dot a multivector" means
-/// the (conjugate) transpose of that.  We combine both (multivector
-/// dot vector) and (vector dot multivector) cases into a single
-/// functor, to avoid code duplication.
-///
-/// \tparam RV 1-D output View
-/// \tparam XMV 2-D input View (the multivector)
-/// \tparam YV 1-D input View (the single vector)
-/// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template <class RV, class XMV, class YV,
-          class SizeType = typename XMV::size_type>
-struct MV_V_Dot_Functor {
-  typedef typename XMV::execution_space execution_space;
-  typedef SizeType size_type;
-  typedef typename XMV::non_const_value_type xvalue_type;
-  typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::dot_type> AT;
-  typedef typename IPT::dot_type value_type[];
+template <class ExecSpace, class RV, class XV, class YV, class size_type>
+struct Dot_MV_Functor {
+  using Scalar = typename RV::non_const_value_type;
+  using IPT    = Kokkos::Details::InnerProductSpaceTraits<
+      typename XV::non_const_value_type>;
+  using dot_type = typename IPT::dot_type;
+  using KAT      = Kokkos::ArithTraits<dot_type>;
 
-  size_type value_count;
-  RV m_r;
-  typename XMV::const_type m_x;
-  typename YV::const_type m_y;
-  //! If true, do y dot x instead of x dot y.
-  bool reverseOrder_;
+  using TeamMem = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
-  MV_V_Dot_Functor(const RV& r, const XMV& x, const YV& y,
-                   const bool reverseOrder)
-      : value_count(x.extent(1)),
-        m_r(r),
-        m_x(x),
-        m_y(y),
-        reverseOrder_(reverseOrder) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
-                  "KokkosBlas::Impl::"
-                  "MV_V_Dot_Functor: R is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
-                  "KokkosBlas::Impl::"
-                  "MV_V_Dot_Functor: X is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YV>::value,
-                  "KokkosBlas::Impl::"
-                  "MV_V_Dot_Functor: Y is not a Kokkos::View.");
-    static_assert(std::is_same<typename RV::value_type,
-                               typename RV::non_const_value_type>::value,
-                  "KokkosBlas::Impl::MV_V_Dot_Functor: R is const.  "
-                  "It must be nonconst, because it is an output argument "
-                  "(we have to be able to write to its entries).");
-    static_assert(static_cast<int>(XMV::rank) == 2,
-                  "KokkosBlas::Impl::MV_V_Dot_Functor: X must have rank 2.");
-    static_assert(static_cast<int>(YV::rank) == 1,
-                  "KokkosBlas::Impl::MV_V_Dot_Functor: Y must have rank 1.");
-    static_assert(static_cast<int>(RV::rank) == 1,
-                  "KokkosBlas::Impl::MV_V_Dot_Functor: RV must have rank 1.");
-  }
+  RV r;
+  XV x;
+  YV y;
+
+  size_type
+      teamsPerDot;  // number of teams collectively performing a dot product
+  size_type
+      chunkSize;  // the local length of each team's share on the dot product
+
+  Dot_MV_Functor(const RV& r_, const XV& x_, const YV& y_, int teamsPerDot_,
+                 int chunkSize_)
+      : r(r_), x(x_), y(y_), teamsPerDot(teamsPerDot_), chunkSize(chunkSize_) {}
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_type& i, value_type sum) const {
-    const size_type numVecs = value_count;
-    if (reverseOrder_) {
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-      for (size_type k = 0; k < numVecs; ++k) {
-        sum[k] += IPT::dot(m_y(i), m_x(i, k));  // m_x(i,k) * m_y(i)
-      }
-    } else {
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-      for (size_type k = 0; k < numVecs; ++k) {
-        sum[k] += IPT::dot(m_x(i, k), m_y(i));  // m_x(i,k) * m_y(i)
-      }
-    }
-  }
+  void operator()(const TeamMem& t) const {
+    size_type globalRank = t.league_rank();
+    size_type localRank  = globalRank % teamsPerDot;
+    size_type i          = globalRank / teamsPerDot;
+    size_type xcol       = x.extent(1) == 1 ? 0 : i;
+    size_type ycol       = y.extent(1) == 1 ? 0 : i;
+    size_type length     = x.extent(0);
 
-  KOKKOS_INLINE_FUNCTION void init(value_type update) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type k = 0; k < numVecs; ++k) {
-      update[k] = AT::zero();
-    }
-  }
+    dot_type localResult = KAT::zero();
+    size_type baseInd    = chunkSize * localRank;
+    Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(t, chunkSize),
+        [&](size_type k, dot_type& update) {
+          if (baseInd + k < length) {
+            Kokkos::Details::updateDot(update, x.access(baseInd + k, xcol),
+                                       y.access(baseInd + k, ycol));
+          }
+        },
+        localResult);
 
-  KOKKOS_INLINE_FUNCTION void join(volatile value_type update,
-                                   const volatile value_type source) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type k = 0; k < numVecs; ++k) {
-      update[k] += source[k];
-    }
-  }
-
-  // On device, write the reduction result to the output View.
-  /*KOKKOS_INLINE_FUNCTION void
-  final (const value_type dst) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type k = 0; k < numVecs; ++k) {
-      m_r(k) = dst[k];
-    }
-  }*/
-};
-
-/// \brief Column-wise dot product functor for multivectors; works for
-///   any layout, but best performance with LayoutRight.
-///
-/// \tparam RV 1-D output View
-/// \tparam XMV 2-D input View
-/// \tparam YMV 2-D input View
-/// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template <class RV, class XMV, class YMV,
-          class SizeType = typename XMV::size_type>
-struct MV_Dot_Right_FunctorVector {
-  typedef typename XMV::execution_space execution_space;
-  typedef SizeType size_type;
-  typedef typename XMV::non_const_value_type xvalue_type;
-  typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::dot_type> AT;
-  typedef typename IPT::dot_type value_type[];
-
-  size_type value_count;
-  RV m_r;
-  typename XMV::const_type m_x;
-  typename YMV::const_type m_y;
-
-  MV_Dot_Right_FunctorVector(const RV& r, const XMV& x, const YMV& y)
-      : value_count(x.extent(1)), m_r(r), m_x(x), m_y(y) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
-                  "KokkosBlas::Impl::"
-                  "MV_Dot_Right_FunctorVector: R is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
-                  "KokkosBlas::Impl::"
-                  "MV_Dot_Right_FunctorVector: X is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YMV>::value,
-                  "KokkosBlas::Impl::"
-                  "MV_Dot_Right_FunctorVector: Y is not a Kokkos::View.");
-    static_assert(std::is_same<typename RV::value_type,
-                               typename RV::non_const_value_type>::value,
-                  "KokkosBlas::Impl::MV_Dot_Right_FunctorVector: R is const.  "
-                  "It must be nonconst, because it is an output argument "
-                  "(we have to be able to write to its entries).");
-    static_assert(XMV::rank == YMV::rank,
-                  "KokkosBlas::Impl::MV_Dot_Right_FunctorVector: "
-                  "X and Y must have the same rank.");
-    static_assert(RV::rank == 1 && XMV::rank == 2,
-                  "KokkosBlas::Impl::MV_Dot_Right_FunctorVector: "
-                  "RV must have rank 1 and XMV and YMV must have rank 2.");
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const size_type& i, value_type sum) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type k = 0; k < numVecs; ++k) {
-      sum[k] += IPT::dot(m_x(i, k), m_y(i, k));  // m_x(i,k) * m_y(i,k)
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION void init(value_type update) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type k = 0; k < numVecs; ++k) {
-      update[k] = AT::zero();
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION void join(volatile value_type update,
-                                   const volatile value_type source) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type k = 0; k < numVecs; ++k) {
-      update[k] += source[k];
-    }
-  }
-
-  // On device, write the reduction result to the output View.
-  /*KOKKOS_INLINE_FUNCTION void
-  final (const value_type dst) const
-  {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type k = 0; k < numVecs; ++k) {
-      m_r(k) = dst[k];
-    }
-  }*/
-};
-
-/// \brief Column-wise dot product functor for multivectors with
-///   number of columns known at compile time; works for any layout,
-///   but best performance with LayoutRight.
-///
-/// \tparam RV 1-D output View
-/// \tparam XMV 2-D input View
-/// \tparam YMV 2-D input View
-/// \tparam UNROLL Number of columns (vectors)
-/// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template <class RV, class XMV, class YMV, int UNROLL,
-          class SizeType = typename XMV::size_type>
-struct MV_Dot_Right_FunctorUnroll {
-  typedef typename XMV::execution_space execution_space;
-  typedef SizeType size_type;
-  typedef typename XMV::non_const_value_type xvalue_type;
-  typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::dot_type> AT;
-  typedef typename IPT::dot_type value_type[];
-
-  size_type value_count;
-  RV m_r;
-  typename XMV::const_type m_x;
-  typename YMV::const_type m_y;
-
-  MV_Dot_Right_FunctorUnroll(const RV& r, const XMV& x, const YMV& y)
-      : value_count(x.extent(1)), m_r(r), m_x(x), m_y(y) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
-                  "KokkosBlas::Impl::"
-                  "MV_Dot_Right_FunctorUnroll: R is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
-                  "KokkosBlas::Impl::"
-                  "MV_Dot_Right_FunctorUnroll: X is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YMV>::value,
-                  "KokkosBlas::Impl::"
-                  "MV_Dot_Right_FunctorUnroll: Y is not a Kokkos::View.");
-    static_assert(std::is_same<typename RV::value_type,
-                               typename RV::non_const_value_type>::value,
-                  "KokkosBlas::Impl::MV_Dot_Right_FunctorUnroll: R is const.  "
-                  "It must be nonconst, because it is an output argument "
-                  "(we have to be able to write to its entries).");
-    static_assert(int(XMV::rank) == int(YMV::rank),
-                  "KokkosBlas::Impl::MV_Dot_Right_FunctorUnroll: "
-                  "X and Y must have the same rank.");
-    static_assert(RV::rank == 1 && XMV::rank == 2,
-                  "KokkosBlas::Impl::MV_Dot_Right_FunctorUnroll: "
-                  "RV must have rank 1 and XMV and YMV must have rank 2.");
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const size_type& i, value_type sum) const {
-#ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
-#pragma unroll
-#endif
-    for (int k = 0; k < UNROLL; ++k) {
-      sum[k] += IPT::dot(m_x(i, k), m_y(i, k));  // m_x(i,k) * m_y(i,k)
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION void init(volatile value_type update) const {
-#ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
-#pragma unroll
-#endif
-    for (int k = 0; k < UNROLL; ++k) {
-      update[k] = AT::zero();
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION void join(volatile value_type update,
-                                   const volatile value_type source) const {
-#ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
-#pragma unroll
-#endif
-    for (int k = 0; k < UNROLL; ++k) {
-      update[k] += source[k];
-    }
-  }
-
-  // On device, write the reduction result to the output View.
-  /*KOKKOS_INLINE_FUNCTION void
-  final (const value_type dst) const
-  {
-#ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
-#pragma unroll
-#endif
-    for (int k = 0; k < UNROLL; ++k) {
-      m_r(k) = dst[k];
-    }
-  }*/
-};
-
-//! Implementation detail of MV_V_Dot_Invoke (see below).
-template <class RV, class XMV, class YMV, class SizeType,
-          const int XMV_rank = XMV::rank, const int YMV_rank = YMV::rank>
-struct MV_V_Dot_Invoke_Impl {
-  static void run(const RV& r, const XMV& X, const YMV& Y,
-                  const SizeType numRows);
-};
-
-template <class RV, class XMV, class YMV, class SizeType>
-struct MV_V_Dot_Invoke_Impl<RV, XMV, YMV, SizeType, 2, 1> {
-  static void run(const RV& r, const XMV& X, const YMV& Y,
-                  const SizeType numRows) {
-    static_assert(
-        static_cast<int>(XMV::rank) == 2 && static_cast<int>(YMV::rank) == 1,
-        "XMV must have rank 2, and YMV must have rank 1.");
-    static_assert(static_cast<int>(RV::rank) == 1, "Rank of r must be 1.");
-    static_assert(std::is_integral<SizeType>::value,
-                  "SizeType must be a built-in integer type.");
-
-    typedef typename XMV::execution_space execution_space;
-    typedef SizeType size_type;
-    typedef Kokkos::RangePolicy<execution_space, size_type> range_type;
-
-    typedef MV_V_Dot_Functor<RV, XMV, YMV, size_type> op_type;
-    constexpr bool reverseOrder = false;
-    op_type op(r, X, Y, reverseOrder);
-    Kokkos::parallel_reduce("KokkosBlas::Dot::2_1", range_type(0, numRows), op,
-                            r);
+    Kokkos::single(Kokkos::PerTeam(t),
+                   [&]() { Kokkos::atomic_add(&r(i), Scalar(localResult)); });
   }
 };
 
-template <class RV, class XMV, class YMV, class SizeType>
-struct MV_V_Dot_Invoke_Impl<RV, XMV, YMV, SizeType, 1, 2> {
-  static void run(const RV& r, const XMV& X, const YMV& Y,
-                  const SizeType numRows) {
-    static_assert(
-        static_cast<int>(XMV::rank) == 1 && static_cast<int>(YMV::rank) == 2,
-        "XMV must have rank 1, and YMV must have rank 2.");
-    static_assert(static_cast<int>(RV::rank) == 1, "Rank of r must be 1.");
-    static_assert(std::is_integral<SizeType>::value,
-                  "SizeType must be a built-in integer type.");
-
-    typedef typename XMV::execution_space execution_space;
-    typedef SizeType size_type;
-    typedef Kokkos::RangePolicy<execution_space, size_type> range_type;
-
-    // Use the "reverse arguments" mode of the functor.
-    typedef MV_V_Dot_Functor<RV, YMV, XMV, size_type> op_type;
-    constexpr bool reverseOrder = true;
-    op_type op(r, Y, X, reverseOrder);
-    Kokkos::parallel_reduce("KokkosBlas::Dot::1_2", range_type(0, numRows), op,
-                            r);
+// Main version: the result view is accessible from execution space, so it can
+// be computed in-place
+template <class RV, class XV, class YV, class size_type>
+void MV_Dot_Invoke(
+    const RV& r, const XV& x, const YV& y,
+    typename std::enable_if<Kokkos::SpaceAccessibility<
+        typename XV::execution_space,
+        typename RV::memory_space>::accessible>::type* = nullptr) {
+  using execution_space = typename XV::execution_space;
+  size_type numDots     = std::max(x.extent(1), y.extent(1));
+  if (x.extent(0) != y.extent(0)) {
+    std::ostringstream oss;
+    oss << "KokkosBlas::dot (rank-2): x and y have different lengths ("
+        << x.extent(0) << " and " << y.extent(0) << ")";
+    throw std::runtime_error(oss.str());
   }
-};
-
-//! Special case where XMV has rank 2 and YMV has rank 1, or vice versa.
-template <class RV, class XMV, class YMV, class SizeType>
-void MV_V_Dot_Invoke(const RV& r, const XMV& X, const YMV& Y,
-                     const SizeType numRows) {
-  MV_V_Dot_Invoke_Impl<RV, XMV, YMV, SizeType>::run(r, X, Y, numRows);
+  if ((x.extent(1) != size_t(1) && x.extent(1) != size_t(numDots)) ||
+      (y.extent(1) != size_t(1) && y.extent(1) != size_t(numDots))) {
+    std::ostringstream oss;
+    oss << "KokkosBlas::dot (rank-2): x and y have incompatible numbers of "
+           "columns ("
+        << x.extent(1) << " and " << y.extent(1) << ")";
+    throw std::runtime_error(oss.str());
+  }
+  if (r.extent(0) != size_t(numDots)) {
+    std::ostringstream oss;
+    oss << "KokkosBlas::dot (rank-2): result vector has wrong length ("
+        << r.extent(0) << ", but " << numDots
+        << " dot products will be computed)";
+    throw std::runtime_error(oss.str());
+  }
+  // Zero out the result vector
+  Kokkos::deep_copy(
+      r, Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
+  size_type teamsPerDot, chunkSize;
+  KokkosBlas::Impl::multipleReductionWorkDistribution<execution_space,
+                                                      size_type>(
+      x.extent(0), numDots, teamsPerDot, chunkSize);
+  size_type numTeams = numDots * teamsPerDot;
+  Kokkos::TeamPolicy<execution_space> pol(numTeams, Kokkos::AUTO);
+  Kokkos::parallel_for("Dot_MV", pol,
+                       Dot_MV_Functor<execution_space, RV, XV, YV, size_type>(
+                           r, x, y, teamsPerDot, chunkSize));
 }
 
-//! Special case where XMV and YMV both have rank 2.
-template <class RV, class XMV, class YMV, class SizeType>
-void MV_Dot_Invoke(const RV& r, const XMV& X, const YMV& Y) {
-  const SizeType numRows = static_cast<SizeType>(X.extent(0));
-  const SizeType numCols = static_cast<SizeType>(X.extent(1));
-  Kokkos::RangePolicy<typename XMV::execution_space, SizeType> policy(0,
-                                                                      numRows);
-
-  if (static_cast<int>(X.extent(1)) != 1 &&
-      static_cast<int>(Y.extent(1)) == 1) {
-    // X has > 1 columns, and Y has 1 column.
-    auto Y_0 = Kokkos::subview(Y, Kokkos::ALL(), 0);
-    typedef typename decltype(Y_0)::const_type YV;
-    MV_V_Dot_Invoke<RV, XMV, YV, SizeType>(r, X, Y_0, numRows);
-    return;
-  } else if (static_cast<int>(X.extent(1)) == 1 &&
-             static_cast<int>(Y.extent(1)) != 1) {
-    // X has 1 column, and Y has > 1 columns.
-    auto X_0 = Kokkos::subview(X, Kokkos::ALL(), 0);
-    typedef typename decltype(X_0)::const_type XV;
-    MV_V_Dot_Invoke<RV, XV, YMV, SizeType>(r, X_0, Y, numRows);
-    return;
-  }
-
-#if KOKKOSBLAS_OPTIMIZATION_LEVEL_DOT <= 2
-
-  // Strip-mine by 8, then 4.  After that, do one column at a time.
-  // We limit the number of strip-mine values in order to keep down
-  // the amount of code to compile.
-
-  SizeType j = 0;  // the current column of X and Y
-  for (; j + 8 <= numCols; j += 8) {
-    auto X_cur = Kokkos::subview(X, Kokkos::ALL(), std::make_pair(j, j + 8));
-    auto Y_cur = Kokkos::subview(Y, Kokkos::ALL(), std::make_pair(j, j + 8));
-    auto r_cur = Kokkos::subview(r, std::make_pair(j, j + 8));
-
-    MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 8, SizeType> op(r_cur, X_cur,
-                                                             Y_cur);
-    Kokkos::parallel_reduce("KokkosBlas::Dot::2_2::8", policy, op, r_cur);
-  }
-  for (; j + 4 <= numCols; j += 4) {
-    auto X_cur = Kokkos::subview(X, Kokkos::ALL(), std::make_pair(j, j + 4));
-    auto Y_cur = Kokkos::subview(Y, Kokkos::ALL(), std::make_pair(j, j + 4));
-    auto r_cur = Kokkos::subview(r, std::make_pair(j, j + 4));
-
-    MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 4, SizeType> op(r_cur, X_cur,
-                                                             Y_cur);
-    Kokkos::parallel_reduce("KokkosBlas::Dot::2_2::4", policy, op, r_cur);
-  }
-  for (; j < numCols; ++j) {
-    // RV needs to turn 0-D, and XMV and YMV need to turn 1-D.
-    auto x_cur = Kokkos::subview(X, Kokkos::ALL(), j);
-    auto y_cur = Kokkos::subview(Y, Kokkos::ALL(), j);
-    auto r_cur = Kokkos::subview(r, j);
-    typedef decltype(r_cur) RV0D;
-    typedef decltype(x_cur) XMV1D;
-    typedef decltype(y_cur) YMV1D;
-
-    DotFunctor<RV0D, XMV1D, YMV1D, SizeType> op(x_cur, y_cur);
-    Kokkos::parallel_reduce("KokkosBlas::Dot::2_2::1", policy, op, r_cur);
-  }
-
-#else  // KOKKOSBLAS_OPTIMIZATION_LEVEL_DOT > 2
-
-  if (numCols > 16) {
-    MV_Dot_Right_FunctorVector<RV, XMV, YMV, SizeType> op(r, X, Y);
-    Kokkos::parallel_reduce("KokkosBlas::Dot::NumCols::16Above", policy, op, r);
-  } else {
-    switch (numCols) {
-      case 16: {
-        MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 16, SizeType> op(r, X, Y);
-        Kokkos::parallel_reduce("KokkosBlas::Dot::NumCols::16", policy, op, r);
-        break;
-      }
-      case 15: {
-        MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 15, SizeType> op(r, X, Y);
-        Kokkos::parallel_reduce("KokkosBlas::Dot::NumCols::15", policy, op, r);
-        break;
-      }
-      case 14: {
-        MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 14, SizeType> op(r, X, Y);
-        Kokkos::parallel_reduce("KokkosBlas::Dot::NumCols::14", policy, op, r);
-        break;
-      }
-      case 13: {
-        MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 13, SizeType> op(r, X, Y);
-        Kokkos::parallel_reduce("KokkosBlas::Dot::NumCols::13", policy, op, r);
-        break;
-      }
-      case 12: {
-        MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 12, SizeType> op(r, X, Y);
-        Kokkos::parallel_reduce("KokkosBlas::Dot::NumCols::12", policy, op, r);
-        break;
-      }
-      case 11: {
-        MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 11, SizeType> op(r, X, Y);
-        Kokkos::parallel_reduce("KokkosBlas::Dot::NumCols::11", policy, op, r);
-        break;
-      }
-      case 10: {
-        MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 10, SizeType> op(r, X, Y);
-        Kokkos::parallel_reduce("KokkosBlas::Dot::NumCols::10", policy, op, r);
-        break;
-      }
-      case 9: {
-        MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 9, SizeType> op(r, X, Y);
-        Kokkos::parallel_reduce("KokkosBlas::Dot::NumCols::9", policy, op, r);
-        break;
-      }
-      case 8: {
-        MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 8, SizeType> op(r, X, Y);
-        Kokkos::parallel_reduce("KokkosBlas::Dot::NumCols::8", policy, op, r);
-        break;
-      }
-      case 7: {
-        MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 7, SizeType> op(r, X, Y);
-        Kokkos::parallel_reduce("KokkosBlas::Dot::NumCols::7", policy, op, r);
-        break;
-      }
-      case 6: {
-        MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 6, SizeType> op(r, X, Y);
-        Kokkos::parallel_reduce("KokkosBlas::Dot::NumCols::6", policy, op, r);
-        break;
-      }
-      case 5: {
-        MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 5, SizeType> op(r, X, Y);
-        Kokkos::parallel_reduce("KokkosBlas::Dot::NumCols::5", policy, op, r);
-        break;
-      }
-      case 4: {
-        MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 4, SizeType> op(r, X, Y);
-        Kokkos::parallel_reduce("KokkosBlas::Dot::NumCols::4", policy, op, r);
-        break;
-      }
-      case 3: {
-        MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 3, SizeType> op(r, X, Y);
-        Kokkos::parallel_reduce("KokkosBlas::Dot::NumCols::3", policy, op, r);
-        break;
-      }
-      case 2: {
-        MV_Dot_Right_FunctorUnroll<RV, XMV, YMV, 2, SizeType> op(r, X, Y);
-        Kokkos::parallel_reduce("KokkosBlas::Dot::NumCols::2", policy, op, r);
-        break;
-      }
-      case 1: {
-        // RV needs to turn 0-D, and XMV and YMV need to turn 1-D.
-        auto r_0 = Kokkos::subview(r, 0);
-        auto X_0 = Kokkos::subview(X, Kokkos::ALL(), 0);
-        auto Y_0 = Kokkos::subview(Y, Kokkos::ALL(), 0);
-        typedef decltype(r_0) RV0D;
-        typedef decltype(X_0) XMV1D;
-        typedef decltype(Y_0) YMV1D;
-
-        typedef V_Dot_Functor<RV0D, XMV1D, YMV1D, SizeType> op_type;
-        op_type op(r_0, X_0, Y_0);
-        Kokkos::parallel_reduce("KokkosBlas::Dot::NumCols::1", policy, op, r_0);
-        break;
-      }
-    }  // switch
-  }    // if-else
-
-#endif  // KOKKOSBLAS_OPTIMIZATION_LEVEL_DOT
+// Version for when a temporary result view is needed (implemented in terms of
+// the other version)
+template <class RV, class XV, class YV, class size_type>
+void MV_Dot_Invoke(
+    const RV& r, const XV& x, const YV& y,
+    typename std::enable_if<!Kokkos::SpaceAccessibility<
+        typename XV::execution_space,
+        typename RV::memory_space>::accessible>::type* = nullptr) {
+  Kokkos::View<typename RV::non_const_value_type*, typename XV::memory_space>
+      tempResult(
+          Kokkos::view_alloc(Kokkos::WithoutInitializing, "Dot_MV temp result"),
+          r.extent(0));
+  MV_Dot_Invoke<decltype(tempResult), XV, YV, size_type>(tempResult, x, y);
+  Kokkos::deep_copy(r, tempResult);
 }
-
-/// \brief Implementation of KokkosBlas::dot for multivectors or
-///   single vectors.
-///
-/// \tparam RV Type of return View of dot product results.
-/// \tparam XMV Type of first input (multi)vector X View.
-/// \tparam YMV Type of second input (multi)vector Y View.
-/// \tparam XMV_rank The rank of XMY.  If 2, it is a multivector; if
-///   1, it is a single vector.
-/// \tparam YMV_rank The rank of YMV.  If 2, it is a multivector; if
-///   1, it is a single vector.
-template <class RV, class XMV, class YMV, class SizeType,
-          const int XMV_rank = XMV::rank, const int YMV_rnak = YMV::rank>
-struct Dot_MV;
-
-template <class RV, class XMV, class YMV, class SizeType>
-struct Dot_MV<RV, XMV, YMV, SizeType, 2, 2> {
-  /// \brief Compute the dot product(s) of the column(s) of the
-  ///   multivectors (2-D views) X and Y, and store result(s) in the
-  ///   1-D View r.
-  static void dot(const RV& r, const XMV& X, const YMV& Y) {
-    MV_Dot_Invoke<RV, XMV, YMV, SizeType>(r, X, Y);
-  }
-};
-
-/// \brief Partial specialization for XMV_rank == 2 and YMV_rank == 1
-///   (X is a multivector, and Y is a single column).
-template <class RV, class XMV, class YV, class SizeType>
-struct Dot_MV<RV, XMV, YV, SizeType, 2, 1> {
-  /// \brief Compute the dot product(s) of each column of X with the
-  ///   single vector Y, and store result(s) in the 1-D View r.
-  static void dot(const RV& r, const XMV& X, const YV& Y) {
-    MV_V_Dot_Invoke<RV, XMV, YV, SizeType>(r, X, Y,
-                                           static_cast<int>(X.extent(0)));
-  }
-};
-
-/// \brief Partial specialization for XMV_rank == 1 and YMV_rank == 2
-///   (X is a single column, and Y is a multivector).
-template <class RV, class XV, class YMV, class SizeType>
-struct Dot_MV<RV, XV, YMV, SizeType, 1, 2> {
-  /// \brief Compute the dot product(s) of the single vector X with
-  ///   each column of Y, and store result(s) in the 1-D View r.
-  static void dot(const RV& r, const XV& X, const YMV& Y) {
-    const SizeType numRows = X.extent(0);
-    MV_V_Dot_Invoke<RV, XV, YMV, SizeType>(r, X, Y, numRows);
-  }
-};
 
 }  // namespace Impl
 }  // namespace KokkosBlas

--- a/src/blas/impl/KokkosBlas1_dot_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_dot_spec.hpp
@@ -396,10 +396,10 @@ struct Dot<RV, XV, YV, X_Rank, Y_Rank, false,
     if (numRows < static_cast<size_type>(INT_MAX) &&
         numRows * numCols < static_cast<size_type>(INT_MAX)) {
       typedef int index_type;
-      Dot_MV<RV, XV, YV, index_type>::dot(R, X, Y);
+      MV_Dot_Invoke<RV, XV, YV, index_type>(R, X, Y);
     } else {
       typedef std::int64_t index_type;
-      Dot_MV<RV, XV, YV, index_type>::dot(R, X, Y);
+      MV_Dot_Invoke<RV, XV, YV, index_type>(R, X, Y);
     }
     Kokkos::Profiling::popRegion();
   }

--- a/src/blas/impl/KokkosBlas1_iamax_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_iamax_impl.hpp
@@ -111,106 +111,6 @@ struct V_Iamax_Functor {
   }
 };
 
-/// \brief Column-wise Iamax functor for multivectors.
-///
-/// \tparam RV 1-D output View
-/// \tparam XMV 2-D input View
-/// \tparam MagType Magnitude type
-/// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template <class RV, class XMV, class MagType,
-          class SizeType = typename XMV::size_type>
-struct MV_Iamax_FunctorVector {
-  using execution_space = typename XMV::execution_space;
-  using memory_space    = typename XMV::memory_space;
-  using size_type       = SizeType;
-  using mag_type        = MagType;
-  using xvalue_type     = typename XMV::non_const_value_type;
-  using IPT             = Kokkos::Details::InnerProductSpaceTraits<xvalue_type>;
-  using value_type      = typename RV::value_type[];
-
-  size_type value_count;
-  typename XMV::const_type m_x;
-
-  MV_Iamax_FunctorVector(const XMV& x) : value_count(x.extent(1)), m_x(x) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
-                  "KokkosBlas::Impl::MV_Iamax_FunctorVector: "
-                  "R is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
-                  "KokkosBlas::Impl::MV_Iamax_FunctorVector: "
-                  "X is not a Kokkos::View.");
-    static_assert(std::is_same<typename RV::value_type,
-                               typename RV::non_const_value_type>::value,
-                  "KokkosBlas::Impl::MV_Iamax_FunctorVector: "
-                  "R is const.  It must be nonconst, because it is an output "
-                  "argument (we must be able to write to its entries).");
-    static_assert(RV::rank == 1 && XMV::rank == 2,
-                  "KokkosBlas::Impl::MV_Iamax_FunctorVector: "
-                  "RV must have rank 1 and XMV must have rank 2.");
-  }
-
-  KOKKOS_INLINE_FUNCTION void operator()(const size_type i,
-                                         value_type lmaxloc) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      mag_type val    = IPT::norm(m_x(i - 1, j));
-      mag_type maxval = IPT::norm(m_x(lmaxloc[j] - 1, j));
-      if (val > maxval) lmaxloc[j] = i;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION void init(value_type update) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] =
-          Kokkos::reduction_identity<typename RV::value_type>::max() + 1;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION void join(volatile value_type update,
-                                   const volatile value_type source) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      mag_type source_val = IPT::norm(m_x(source[j] - 1, j));
-      mag_type update_val = IPT::norm(m_x(update[j] - 1, j));
-      if (update_val < source_val) update[j] = source[j];
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION void join(value_type update,
-                                   const value_type source) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      mag_type source_val = IPT::norm(m_x(source[j] - 1, j));
-      mag_type update_val = IPT::norm(m_x(update[j] - 1, j));
-      if (update_val < source_val) update[j] = source[j];
-    }
-  }
-};
-
 /// \brief Find the index of the element with the maximum magnitude of the
 /// single vector (1-D
 ///   View) X, and store the result in the 0-D View r.
@@ -240,35 +140,10 @@ void V_Iamax_Invoke(const RV& r, const XV& X) {
 ///   multivector (2-D View) X, and store result(s) in the 1-D View r.
 template <class RV, class XMV, class SizeType>
 void MV_Iamax_Invoke(const RV& r, const XMV& X) {
-  using execution_space = typename XMV::execution_space;
-  using AT = Kokkos::Details::ArithTraits<typename XMV::non_const_value_type>;
-  using mag_type = typename AT::mag_type;
-
-  const SizeType numRows = static_cast<SizeType>(X.extent(0));
-
-  // Avoid MaxLoc Reduction if this is a zero length view
-  if (numRows == 0) {
-    Kokkos::deep_copy(r, 0);
-    return;
-  }
-
-  Kokkos::RangePolicy<execution_space, SizeType> policy(1, numRows + 1);
-
-  // If the input multivector (2-D View) has only one column, invoke
-  // the single-vector version of the kernel.
-  if (X.extent(1) == 1) {
-    using RV0D =
-        Kokkos::View<typename RV::non_const_value_type,
-                     typename RV::array_layout, typename RV::device_type,
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-    RV0D r_0(r, 0);
-    auto X_0   = Kokkos::subview(X, Kokkos::ALL(), 0);
-    using XV1D = decltype(X_0);
-    V_Iamax_Invoke<RV0D, XV1D, SizeType>(r_0, X_0);
-  } else {
-    using functor_type = MV_Iamax_FunctorVector<RV, XMV, mag_type, SizeType>;
-    functor_type op(X);
-    Kokkos::parallel_reduce("KokkosBlas::Iamax::S1", policy, op, r);
+  for (size_t i = 0; i < X.extent(1); i++) {
+    auto ri = Kokkos::subview(r, i);
+    auto Xi = Kokkos::subview(X, Kokkos::ALL(), i);
+    V_Iamax_Invoke<decltype(ri), decltype(Xi), SizeType>(ri, Xi);
   }
 }
 

--- a/src/blas/impl/KokkosBlas1_nrm1_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm1_impl.hpp
@@ -111,27 +111,24 @@ struct Nrm1_MV_Functor {
 
   size_type
       teamsPerVec;  // number of teams collectively performing a dot product
-  size_type
-      chunkSize;  // the local length of each team's share on the dot product
 
-  Nrm1_MV_Functor(const RV& r_, const XV& x_, int teamsPerVec_, int chunkSize_)
-      : r(r_), x(x_), teamsPerVec(teamsPerVec_), chunkSize(chunkSize_) {}
+  Nrm1_MV_Functor(const RV& r_, const XV& x_, int teamsPerVec_)
+      : r(r_), x(x_), teamsPerVec(teamsPerVec_) {}
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const TeamMem& t) const {
     size_type globalRank = t.league_rank();
     size_type localRank  = globalRank % teamsPerVec;
     size_type i          = globalRank / teamsPerVec;
-
+    size_type begin      = localRank * (x.extent(0) / teamsPerVec);
+    size_type end        = (localRank + 1) * (x.extent(0) / teamsPerVec);
+    if (localRank == teamsPerVec - 1) end = x.extent(0);
     value_type localResult = MAT::zero();
-    size_type baseInd      = chunkSize * localRank;
     Kokkos::parallel_reduce(
-        Kokkos::TeamThreadRange(t, chunkSize),
+        Kokkos::TeamThreadRange(t, begin, end),
         [&](size_type k, value_type& update) {
-          if (baseInd + k < size_type(x.extent(0))) {
-            auto val = x(baseInd + k, i);
-            update += MAT::abs(XAT::real(val)) + MAT::abs(XAT::imag(val));
-          }
+          auto val = x(k, i);
+          update += MAT::abs(XAT::real(val)) + MAT::abs(XAT::imag(val));
         },
         localResult);
 
@@ -174,15 +171,15 @@ void MV_Nrm1_Invoke(
   // Zero out the result vector
   Kokkos::deep_copy(
       r, Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
-  size_type teamsPerVec, chunkSize;
+  size_type teamsPerVec;
   KokkosBlas::Impl::multipleReductionWorkDistribution<execution_space,
                                                       size_type>(
-      x.extent(0), x.extent(1), teamsPerVec, chunkSize);
+      x.extent(0), x.extent(1), teamsPerVec);
   size_type numTeams = x.extent(1) * teamsPerVec;
   Kokkos::TeamPolicy<execution_space> pol(numTeams, Kokkos::AUTO);
-  Kokkos::parallel_for("KokkosBlas1::Nrm1::S1", pol,
-                       Nrm1_MV_Functor<execution_space, RV, XV, size_type>(
-                           r, x, teamsPerVec, chunkSize));
+  Kokkos::parallel_for(
+      "KokkosBlas1::Nrm1::S1", pol,
+      Nrm1_MV_Functor<execution_space, RV, XV, size_type>(r, x, teamsPerVec));
 }
 
 // Version for when a temporary result view is needed (implemented in terms of

--- a/src/blas/impl/KokkosBlas1_nrm1_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm1_impl.hpp
@@ -47,6 +47,7 @@
 #include <KokkosKernels_config.h>
 #include <Kokkos_Core.hpp>
 #include <KokkosBlas1_nrm1_spec.hpp>
+#include <KokkosBlas_util.hpp>
 
 namespace KokkosBlas {
 namespace Impl {
@@ -93,111 +94,50 @@ struct V_Nrm1_Functor {
     xvalue_type val = m_x(i);
     sum += MAT::abs(XAT::real(val)) + MAT::abs(XAT::imag(val));
   }
-
-  KOKKOS_INLINE_FUNCTION void init(value_type& update) const {
-    update = MAT::zero();
-  }
-
-  KOKKOS_INLINE_FUNCTION void join(value_type& update,
-                                   const value_type& source) const {
-    update += source;
-  }
-
-  KOKKOS_INLINE_FUNCTION void join(volatile value_type& update,
-                                   const volatile value_type& source) const {
-    update += source;
-  }
 };
 
-/// \brief Column-wise 1-norm functor for multivectors; works for
-///   any layout, but best performance with LayoutRight.
-///
-/// \tparam RV 1-D output View
-/// \tparam XMV 2-D input View
-/// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template <class RV, class XMV, class SizeType = typename XMV::size_type>
-struct MV_Nrm1_Right_FunctorVector {
-  typedef typename XMV::execution_space execution_space;
-  typedef SizeType size_type;
-  typedef typename XMV::non_const_value_type xvalue_type;
+template <class ExecSpace, class RV, class XV, class size_type>
+struct Nrm1_MV_Functor {
+  typedef typename RV::non_const_value_type rvalue_type;
+  typedef typename XV::non_const_value_type xvalue_type;
   typedef Kokkos::ArithTraits<xvalue_type> XAT;
-  typedef Kokkos::ArithTraits<typename XAT::mag_type> MAT;
-  typedef typename XAT::mag_type value_type[];
+  typedef typename XAT::mag_type value_type;
+  typedef Kokkos::ArithTraits<value_type> MAT;
 
-  size_type value_count;
-  typename XMV::const_type m_x;
+  using TeamMem = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
-  MV_Nrm1_Right_FunctorVector(const XMV& x) : value_count(x.extent(1)), m_x(x) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
-                  "KokkosBlas::Impl::MV_Nrm1_Right_FunctorVector: "
-                  "R is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
-                  "KokkosBlas::Impl::MV_Nrm1_Right_FunctorVector: "
-                  "X is not a Kokkos::View.");
-    static_assert(std::is_same<typename RV::value_type,
-                               typename RV::non_const_value_type>::value,
-                  "KokkosBlas::Impl::MV_Nrm1_Right_FunctorVector: "
-                  "R is const.  It must be nonconst, because it is an output "
-                  "argument (we must be able to write to its entries).");
-    static_assert(RV::rank == 1 && XMV::rank == 2,
-                  "KokkosBlas::Impl::MV_Nrm1_Right_FunctorVector: "
-                  "RV must have rank 1 and XMV must have rank 2.");
-  }
+  RV r;
+  XV x;
 
-  KOKKOS_INLINE_FUNCTION void operator()(const size_type i,
-                                         value_type sum) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      xvalue_type val = m_x(i, j);
-      sum[j] += MAT::abs(XAT::real(val)) + MAT::abs(XAT::imag(val));
-    }
-  }
+  size_type
+      teamsPerVec;  // number of teams collectively performing a dot product
+  size_type
+      chunkSize;  // the local length of each team's share on the dot product
 
-  KOKKOS_INLINE_FUNCTION void init(value_type update) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] = MAT::zero();
-    }
-  }
+  Nrm1_MV_Functor(const RV& r_, const XV& x_, int teamsPerVec_, int chunkSize_)
+      : r(r_), x(x_), teamsPerVec(teamsPerVec_), chunkSize(chunkSize_) {}
 
-  KOKKOS_INLINE_FUNCTION void join(volatile value_type update,
-                                   const volatile value_type source) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] += source[j];
-    }
-  }
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const TeamMem& t) const {
+    size_type globalRank = t.league_rank();
+    size_type localRank  = globalRank % teamsPerVec;
+    size_type i          = globalRank / teamsPerVec;
 
-  KOKKOS_INLINE_FUNCTION void join(value_type update,
-                                   const value_type source) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] += source[j];
-    }
+    value_type localResult = MAT::zero();
+    size_type baseInd      = chunkSize * localRank;
+    Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(t, chunkSize),
+        [&](size_type k, value_type& update) {
+          if (baseInd + k < size_type(x.extent(0))) {
+            auto val = x(baseInd + k, i);
+            update += MAT::abs(XAT::real(val)) + MAT::abs(XAT::imag(val));
+          }
+        },
+        localResult);
+
+    Kokkos::single(Kokkos::PerTeam(t), [&]() {
+      Kokkos::atomic_add(&r(i), rvalue_type(localResult));
+    });
   }
 };
 
@@ -216,25 +156,49 @@ void V_Nrm1_Invoke(const RV& r, const XV& X) {
 
 /// \brief Compute the 2-norms (or their square) of the columns of the
 ///   multivector (2-D View) X, and store result(s) in the 1-D View r.
-template <class RV, class XMV, class SizeType>
-void MV_Nrm1_Invoke(const RV& r, const XMV& X) {
-  typedef typename XMV::execution_space execution_space;
-  const SizeType numRows = static_cast<SizeType>(X.extent(0));
-  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
-
-  // If the input multivector (2-D View) has only one column, invoke
-  // the single-vector version of the kernel.
-  if (X.extent(1) == 1) {
-    auto r_0 = Kokkos::subview(r, 0);
-    auto X_0 = Kokkos::subview(X, Kokkos::ALL(), 0);
-    typedef decltype(r_0) RV0D;
-    typedef decltype(X_0) XV1D;
-    V_Nrm1_Invoke<RV0D, XV1D, SizeType>(r_0, X_0);
-  } else {
-    typedef MV_Nrm1_Right_FunctorVector<RV, XMV, SizeType> functor_type;
-    functor_type op(X);
-    Kokkos::parallel_reduce("KokkosBlas1::Nrm1::S1", policy, op, r);
+// Main version: the result view is accessible from execution space, so it can
+// be computed in-place
+template <class RV, class XV, class size_type>
+void MV_Nrm1_Invoke(
+    const RV& r, const XV& x,
+    typename std::enable_if<Kokkos::SpaceAccessibility<
+        typename XV::execution_space,
+        typename RV::memory_space>::accessible>::type* = nullptr) {
+  using execution_space = typename XV::execution_space;
+  if (r.extent(0) != x.extent(1)) {
+    std::ostringstream oss;
+    oss << "KokkosBlas::nrm1 (rank-2): result vector has wrong length ("
+        << r.extent(0) << ", but x has " << x.extent(1) << " columns)";
+    throw std::runtime_error(oss.str());
   }
+  // Zero out the result vector
+  Kokkos::deep_copy(
+      r, Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
+  size_type teamsPerVec, chunkSize;
+  KokkosBlas::Impl::multipleReductionWorkDistribution<execution_space,
+                                                      size_type>(
+      x.extent(0), x.extent(1), teamsPerVec, chunkSize);
+  size_type numTeams = x.extent(1) * teamsPerVec;
+  Kokkos::TeamPolicy<execution_space> pol(numTeams, Kokkos::AUTO);
+  Kokkos::parallel_for("KokkosBlas1::Nrm1::S1", pol,
+                       Nrm1_MV_Functor<execution_space, RV, XV, size_type>(
+                           r, x, teamsPerVec, chunkSize));
+}
+
+// Version for when a temporary result view is needed (implemented in terms of
+// the other version)
+template <class RV, class XV, class size_type>
+void MV_Nrm1_Invoke(
+    const RV& r, const XV& x,
+    typename std::enable_if<!Kokkos::SpaceAccessibility<
+        typename XV::execution_space,
+        typename RV::memory_space>::accessible>::type* = nullptr) {
+  Kokkos::View<typename RV::non_const_value_type*, typename XV::memory_space>
+      tempResult(
+          Kokkos::view_alloc(Kokkos::WithoutInitializing, "Nrm1 temp result"),
+          r.extent(0));
+  MV_Nrm1_Invoke<decltype(tempResult), XV, size_type>(tempResult, x);
+  Kokkos::deep_copy(r, tempResult);
 }
 
 }  // namespace Impl

--- a/src/blas/impl/KokkosBlas1_nrm2_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm2_impl.hpp
@@ -139,11 +139,9 @@ struct Nrm2_MV_Functor {
 
   size_type
       teamsPerVec;  // number of teams collectively performing a dot product
-  size_type
-      chunkSize;  // the local length of each team's share on the dot product
 
-  Nrm2_MV_Functor(const RV& r_, const XV& x_, int teamsPerVec_, int chunkSize_)
-      : r(r_), x(x_), teamsPerVec(teamsPerVec_), chunkSize(chunkSize_) {}
+  Nrm2_MV_Functor(const RV& r_, const XV& x_, int teamsPerVec_)
+      : r(r_), x(x_), teamsPerVec(teamsPerVec_) {}
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const TeamMem& t) const {
@@ -152,14 +150,15 @@ struct Nrm2_MV_Functor {
     size_type i          = globalRank / teamsPerVec;
 
     value_type localResult = AT::zero();
-    size_type baseInd      = chunkSize * localRank;
+    size_type begin        = localRank * (x.extent(0) / teamsPerVec);
+    size_type end          = (localRank + 1) * (x.extent(0) / teamsPerVec);
+    if (localRank == teamsPerVec - 1) end = x.extent(0);
+
     Kokkos::parallel_reduce(
-        Kokkos::TeamThreadRange(t, chunkSize),
+        Kokkos::TeamThreadRange(t, begin, end),
         [&](size_type k, value_type& update) {
-          if (baseInd + k < size_type(x.extent(0))) {
-            value_type tmp = IPT::norm(x(baseInd + k, i));
-            update += tmp * tmp;
-          }
+          value_type tmp = IPT::norm(x(k, i));
+          update += tmp * tmp;
         },
         localResult);
 
@@ -202,15 +201,15 @@ void MV_Nrm2_Invoke(
   // Zero out the result vector
   Kokkos::deep_copy(
       r, Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
-  size_type teamsPerVec, chunkSize;
+  size_type teamsPerVec;
   KokkosBlas::Impl::multipleReductionWorkDistribution<execution_space,
                                                       size_type>(
-      x.extent(0), x.extent(1), teamsPerVec, chunkSize);
+      x.extent(0), x.extent(1), teamsPerVec);
   size_type numTeams = x.extent(1) * teamsPerVec;
   Kokkos::TeamPolicy<execution_space> pol(numTeams, Kokkos::AUTO);
-  Kokkos::parallel_for("KokkosBlas1::Nrm2::S1", pol,
-                       Nrm2_MV_Functor<execution_space, RV, XV, size_type>(
-                           r, x, teamsPerVec, chunkSize));
+  Kokkos::parallel_for(
+      "KokkosBlas1::Nrm2::S1", pol,
+      Nrm2_MV_Functor<execution_space, RV, XV, size_type>(r, x, teamsPerVec));
   if (take_sqrt) {
     Kokkos::parallel_for("KokkosBlas1::Nrm2::Sqrt",
                          Kokkos::RangePolicy<execution_space>(0, r.extent(0)),

--- a/src/blas/impl/KokkosBlas1_nrm2_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm2_impl.hpp
@@ -47,6 +47,7 @@
 #include <KokkosKernels_config.h>
 #include <Kokkos_Core.hpp>
 #include <KokkosBlas1_nrm2_spec.hpp>
+#include <KokkosBlas_util.hpp>
 
 namespace KokkosBlas {
 namespace Impl {
@@ -118,112 +119,53 @@ struct V_Nrm2_Functor {
 };
 
 /// \brief Column-wise 2-norm functor for multivectors; works for
-///   any layout, but best performance with LayoutRight.
+///   any layout, but best performance with LayoutLeft.
 ///
 /// \tparam RV 1-D output View
 /// \tparam XMV 2-D input View
 /// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template <class RV, class XMV, class SizeType = typename XMV::size_type>
-struct MV_Nrm2_Right_FunctorVector {
-  typedef typename XMV::execution_space execution_space;
-  typedef SizeType size_type;
-  typedef typename XMV::non_const_value_type xvalue_type;
+template <class ExecSpace, class RV, class XV, class size_type>
+struct Nrm2_MV_Functor {
+  typedef typename RV::non_const_value_type rvalue_type;
+  typedef typename XV::non_const_value_type xvalue_type;
   typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
   typedef Kokkos::Details::ArithTraits<typename IPT::mag_type> AT;
-  typedef typename IPT::mag_type value_type[];
+  typedef typename IPT::mag_type value_type;
 
-  size_type value_count;
-  typename XMV::const_type m_x;
-  bool m_take_sqrt;
+  using TeamMem = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
-  MV_Nrm2_Right_FunctorVector(const XMV& x, const bool& take_sqrt)
-      : value_count(x.extent(1)), m_x(x), m_take_sqrt(take_sqrt) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
-                  "KokkosBlas::Impl::MV_Nrm2_Right_FunctorVector: "
-                  "R is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
-                  "KokkosBlas::Impl::MV_Nrm2_Right_FunctorVector: "
-                  "X is not a Kokkos::View.");
-    static_assert(std::is_same<typename RV::value_type,
-                               typename RV::non_const_value_type>::value,
-                  "KokkosBlas::Impl::MV_Nrm2_Right_FunctorVector: "
-                  "R is const.  It must be nonconst, because it is an output "
-                  "argument (we must be able to write to its entries).");
-    static_assert(RV::rank == 1 && XMV::rank == 2,
-                  "KokkosBlas::Impl::MV_Nrm2_Right_FunctorVector: "
-                  "RV must have rank 1 and XMV must have rank 2.");
-  }
+  RV r;
+  XV x;
 
-  KOKKOS_INLINE_FUNCTION void operator()(const size_type i,
-                                         value_type sum) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      const typename IPT::mag_type tmp = IPT::norm(m_x(i, j));
-      sum[j] += tmp * tmp;
-    }
-  }
+  size_type
+      teamsPerVec;  // number of teams collectively performing a dot product
+  size_type
+      chunkSize;  // the local length of each team's share on the dot product
 
-  KOKKOS_INLINE_FUNCTION void init(value_type update) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] = AT::zero();
-    }
-  }
+  Nrm2_MV_Functor(const RV& r_, const XV& x_, int teamsPerVec_, int chunkSize_)
+      : r(r_), x(x_), teamsPerVec(teamsPerVec_), chunkSize(chunkSize_) {}
 
-  KOKKOS_INLINE_FUNCTION void join(volatile value_type update,
-                                   const volatile value_type source) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] += source[j];
-    }
-  }
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const TeamMem& t) const {
+    size_type globalRank = t.league_rank();
+    size_type localRank  = globalRank % teamsPerVec;
+    size_type i          = globalRank / teamsPerVec;
 
-  KOKKOS_INLINE_FUNCTION void join(value_type update,
-                                   const value_type source) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] += source[j];
-    }
-  }
+    value_type localResult = AT::zero();
+    size_type baseInd      = chunkSize * localRank;
+    Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(t, chunkSize),
+        [&](size_type k, value_type& update) {
+          if (baseInd + k < size_type(x.extent(0))) {
+            value_type tmp = IPT::norm(x(baseInd + k, i));
+            update += tmp * tmp;
+          }
+        },
+        localResult);
 
-  KOKKOS_INLINE_FUNCTION void final(value_type update) const {
-    if (m_take_sqrt) {
-      const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-      for (size_type j = 0; j < numVecs; ++j) {
-        update[j] = Kokkos::Details::ArithTraits<
-            typename RV::non_const_value_type>::sqrt(update[j]);
-      }
-    }
+    Kokkos::single(Kokkos::PerTeam(t), [&]() {
+      Kokkos::atomic_add(&r(i), rvalue_type(localResult));
+    });
   }
 };
 
@@ -242,25 +184,54 @@ void V_Nrm2_Invoke(const RV& r, const XV& X, const bool& take_sqrt) {
 
 /// \brief Compute the 2-norms (or their square) of the columns of the
 ///   multivector (2-D View) X, and store result(s) in the 1-D View r.
-template <class RV, class XMV, class SizeType>
-void MV_Nrm2_Invoke(const RV& r, const XMV& X, const bool& take_sqrt) {
-  typedef typename XMV::execution_space execution_space;
-  const SizeType numRows = static_cast<SizeType>(X.extent(0));
-  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
-
-  // If the input multivector (2-D View) has only one column, invoke
-  // the single-vector version of the kernel.
-  if (X.extent(1) == 1) {
-    auto r_0 = Kokkos::subview(r, 0);
-    auto X_0 = Kokkos::subview(X, Kokkos::ALL(), 0);
-    typedef decltype(r_0) RV0D;
-    typedef decltype(X_0) XV1D;
-    V_Nrm2_Invoke<RV0D, XV1D, SizeType>(r_0, X_0, take_sqrt);
-  } else {
-    typedef MV_Nrm2_Right_FunctorVector<RV, XMV, SizeType> functor_type;
-    functor_type op(X, take_sqrt);
-    Kokkos::parallel_reduce("KokkosBlas::Nrm2::S1", policy, op, r);
+// Main version: the result view is accessible from execution space, so it can
+// be computed in-place
+template <class RV, class XV, class size_type>
+void MV_Nrm2_Invoke(
+    const RV& r, const XV& x, bool take_sqrt,
+    typename std::enable_if<Kokkos::SpaceAccessibility<
+        typename XV::execution_space,
+        typename RV::memory_space>::accessible>::type* = nullptr) {
+  using execution_space = typename XV::execution_space;
+  if (r.extent(0) != x.extent(1)) {
+    std::ostringstream oss;
+    oss << "KokkosBlas::nrm2 (rank-2): result vector has wrong length ("
+        << r.extent(0) << ", but x has " << x.extent(1) << " columns)";
+    throw std::runtime_error(oss.str());
   }
+  // Zero out the result vector
+  Kokkos::deep_copy(
+      r, Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
+  size_type teamsPerVec, chunkSize;
+  KokkosBlas::Impl::multipleReductionWorkDistribution<execution_space,
+                                                      size_type>(
+      x.extent(0), x.extent(1), teamsPerVec, chunkSize);
+  size_type numTeams = x.extent(1) * teamsPerVec;
+  Kokkos::TeamPolicy<execution_space> pol(numTeams, Kokkos::AUTO);
+  Kokkos::parallel_for("KokkosBlas1::Nrm2::S1", pol,
+                       Nrm2_MV_Functor<execution_space, RV, XV, size_type>(
+                           r, x, teamsPerVec, chunkSize));
+  if (take_sqrt) {
+    Kokkos::parallel_for("KokkosBlas1::Nrm2::Sqrt",
+                         Kokkos::RangePolicy<execution_space>(0, r.extent(0)),
+                         TakeSqrtFunctor<RV>(r));
+  }
+}
+
+// Version for when a temporary result view is needed (implemented in terms of
+// the other version)
+template <class RV, class XV, class size_type>
+void MV_Nrm2_Invoke(
+    const RV& r, const XV& x, bool take_sqrt,
+    typename std::enable_if<!Kokkos::SpaceAccessibility<
+        typename XV::execution_space,
+        typename RV::memory_space>::accessible>::type* = nullptr) {
+  Kokkos::View<typename RV::non_const_value_type*, typename XV::memory_space>
+      tempResult(
+          Kokkos::view_alloc(Kokkos::WithoutInitializing, "Nrm2 temp result"),
+          r.extent(0));
+  MV_Nrm2_Invoke<decltype(tempResult), XV, size_type>(tempResult, x, take_sqrt);
+  Kokkos::deep_copy(r, tempResult);
 }
 
 }  // namespace Impl

--- a/src/blas/impl/KokkosBlas1_nrm2w_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm2w_impl.hpp
@@ -48,6 +48,7 @@
 #include <Kokkos_Core.hpp>
 #include <Kokkos_InnerProductSpaceTraits.hpp>
 #include <KokkosBlas1_nrm2w_spec.hpp>
+#include <KokkosBlas_util.hpp>
 
 namespace KokkosBlas {
 namespace Impl {
@@ -120,116 +121,51 @@ struct V_Nrm2w_Functor {
   }
 };
 
-/// \brief Column-wise 2-norm functor for multivectors; works for
-///   any layout, but best performance with LayoutRight.
-///
-/// \tparam RV 1-D output View
-/// \tparam XMV 2-D input View
-/// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template <class RV, class XMV, class SizeType = typename XMV::size_type>
-struct MV_Nrm2w_Right_FunctorVector {
-  typedef typename XMV::execution_space execution_space;
-  typedef SizeType size_type;
-  typedef typename XMV::non_const_value_type xvalue_type;
+template <class ExecSpace, class RV, class XV, class size_type>
+struct Nrm2w_MV_Functor {
+  typedef typename RV::non_const_value_type rvalue_type;
+  typedef typename XV::non_const_value_type xvalue_type;
   typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
   typedef Kokkos::Details::ArithTraits<typename IPT::mag_type> AT;
-  typedef typename IPT::mag_type value_type[];
+  typedef typename IPT::mag_type value_type;
 
-  size_type value_count;
-  typename XMV::const_type m_x, m_w;
-  bool m_take_sqrt;
+  using TeamMem = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
-  MV_Nrm2w_Right_FunctorVector(const XMV& x, const XMV& /* w */,
-                               const bool& take_sqrt)
-      : value_count(x.extent(1)), m_x(x), m_w(x), m_take_sqrt(take_sqrt) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
-                  "KokkosBlas::Impl::MV_Nrm2w_Right_FunctorVector: "
-                  "R is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
-                  "KokkosBlas::Impl::MV_Nrm2w_Right_FunctorVector: "
-                  "X is not a Kokkos::View.");
-    static_assert(std::is_same<typename RV::value_type,
-                               typename RV::non_const_value_type>::value,
-                  "KokkosBlas::Impl::MV_Nrm2w_Right_FunctorVector: "
-                  "R is const.  It must be nonconst, because it is an output "
-                  "argument (we must be able to write to its entries).");
-    static_assert(RV::rank == 1 && XMV::rank == 2,
-                  "KokkosBlas::Impl::MV_Nrm2w_Right_FunctorVector: "
-                  "RV must have rank 1 and XMV must have rank 2.");
-  }
+  RV r;
+  XV x;
+  XV w;
 
-  KOKKOS_INLINE_FUNCTION void operator()(const size_type i,
-                                         value_type sum) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      const typename IPT::mag_type tmp =
-          IPT::norm(m_x(i, j)) / IPT::norm(m_w(i, j));
-      sum[j] += tmp * tmp;
-      ;
-    }
-  }
+  size_type
+      teamsPerVec;  // number of teams collectively performing a dot product
+  size_type
+      chunkSize;  // the local length of each team's share on the dot product
 
-  KOKKOS_INLINE_FUNCTION void init(value_type update) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] = AT::zero();
-    }
-  }
+  Nrm2w_MV_Functor(const RV& r_, const XV& x_, const XV& w_, int teamsPerVec_,
+                   int chunkSize_)
+      : r(r_), x(x_), w(w_), teamsPerVec(teamsPerVec_), chunkSize(chunkSize_) {}
 
-  KOKKOS_INLINE_FUNCTION void join(volatile value_type update,
-                                   const volatile value_type source) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] += source[j];
-    }
-  }
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const TeamMem& t) const {
+    size_type globalRank = t.league_rank();
+    size_type localRank  = globalRank % teamsPerVec;
+    size_type i          = globalRank / teamsPerVec;
 
-  KOKKOS_INLINE_FUNCTION void join(value_type update,
-                                   const value_type source) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      update[j] += source[j];
-    }
-  }
+    value_type localResult = AT::zero();
+    size_type baseInd      = chunkSize * localRank;
+    Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(t, chunkSize),
+        [&](size_type k, value_type& update) {
+          if (baseInd + k < size_type(x.extent(0))) {
+            const typename IPT::mag_type tmp =
+                IPT::norm(x(baseInd + k, i)) / IPT::norm(w(baseInd + k, i));
+            update += tmp * tmp;
+          }
+        },
+        localResult);
 
-  KOKKOS_INLINE_FUNCTION void final(value_type update) const {
-    if (m_take_sqrt) {
-      const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-      for (size_type j = 0; j < numVecs; ++j) {
-        update[j] = Kokkos::Details::ArithTraits<
-            typename RV::non_const_value_type>::sqrt(update[j]);
-      }
-    }
+    Kokkos::single(Kokkos::PerTeam(t), [&]() {
+      Kokkos::atomic_add(&r(i), rvalue_type(localResult));
+    });
   }
 };
 
@@ -247,29 +183,57 @@ void V_Nrm2w_Invoke(const RV& r, const XV& X, const XV& W,
   Kokkos::parallel_reduce("KokkosBlas::Nrm2w::S0", policy, op, r);
 }
 
-/// \brief Compute the 2-norms (or their square) of the columns of the
+/// \brief Compute the weighted 2-norms (or their square) of the columns of the
 ///   multivector (2-D View) X, and store result(s) in the 1-D View r.
-template <class RV, class XMV, class SizeType>
-void MV_Nrm2w_Invoke(const RV& r, const XMV& X, const XMV& W,
-                     const bool& take_sqrt) {
-  typedef typename XMV::execution_space execution_space;
-  const SizeType numRows = static_cast<SizeType>(X.extent(0));
-  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
-
-  // If the input multivector (2-D View) has only one column, invoke
-  // the single-vector version of the kernel.
-  if (X.extent(1) == 1) {
-    auto r_0 = Kokkos::subview(r, 0);
-    auto X_0 = Kokkos::subview(X, Kokkos::ALL(), 0);
-    auto W_0 = Kokkos::subview(W, Kokkos::ALL(), 0);
-    typedef decltype(r_0) RV0D;
-    typedef decltype(X_0) XV1D;
-    V_Nrm2w_Invoke<RV0D, XV1D, SizeType>(r_0, X_0, W_0, take_sqrt);
-  } else {
-    typedef MV_Nrm2w_Right_FunctorVector<RV, XMV, SizeType> functor_type;
-    functor_type op(X, W, take_sqrt);
-    Kokkos::parallel_reduce("KokkosBlas::Nrm2w::S1", policy, op, r);
+// Main version: the result view is accessible from execution space, so it can
+// be computed in-place
+template <class RV, class XV, class size_type>
+void MV_Nrm2w_Invoke(
+    const RV& r, const XV& x, const XV& w, bool take_sqrt,
+    typename std::enable_if<Kokkos::SpaceAccessibility<
+        typename XV::execution_space,
+        typename RV::memory_space>::accessible>::type* = nullptr) {
+  using execution_space = typename XV::execution_space;
+  if (r.extent(0) != x.extent(1)) {
+    std::ostringstream oss;
+    oss << "KokkosBlas::nrm2w (rank-2): result vector has wrong length ("
+        << r.extent(0) << ", but x has " << x.extent(1) << " columns)";
+    throw std::runtime_error(oss.str());
   }
+  // Zero out the result vector
+  Kokkos::deep_copy(
+      r, Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
+  size_type teamsPerVec, chunkSize;
+  KokkosBlas::Impl::multipleReductionWorkDistribution<execution_space,
+                                                      size_type>(
+      x.extent(0), x.extent(1), teamsPerVec, chunkSize);
+  size_type numTeams = x.extent(1) * teamsPerVec;
+  Kokkos::TeamPolicy<execution_space> pol(numTeams, Kokkos::AUTO);
+  Kokkos::parallel_for("KokkosBlas1::Nrm2w::S1", pol,
+                       Nrm2w_MV_Functor<execution_space, RV, XV, size_type>(
+                           r, x, w, teamsPerVec, chunkSize));
+  if (take_sqrt) {
+    Kokkos::parallel_for("KokkosBlas1::Nrm2w::Sqrt",
+                         Kokkos::RangePolicy<execution_space>(0, r.extent(0)),
+                         TakeSqrtFunctor<RV>(r));
+  }
+}
+
+// Version for when a temporary result view is needed (implemented in terms of
+// the other version)
+template <class RV, class XV, class size_type>
+void MV_Nrm2w_Invoke(
+    const RV& r, const XV& x, const XV& w, bool take_sqrt,
+    typename std::enable_if<!Kokkos::SpaceAccessibility<
+        typename XV::execution_space,
+        typename RV::memory_space>::accessible>::type* = nullptr) {
+  Kokkos::View<typename RV::non_const_value_type*, typename XV::memory_space>
+      tempResult(
+          Kokkos::view_alloc(Kokkos::WithoutInitializing, "Nrm2w temp result"),
+          r.extent(0));
+  MV_Nrm2w_Invoke<decltype(tempResult), XV, size_type>(tempResult, x, w,
+                                                       take_sqrt);
+  Kokkos::deep_copy(r, tempResult);
 }
 
 }  // namespace Impl

--- a/src/blas/impl/KokkosBlas1_sum_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_sum_impl.hpp
@@ -48,6 +48,7 @@
 #include <Kokkos_Core.hpp>
 #include <Kokkos_InnerProductSpaceTraits.hpp>
 #include <KokkosBlas1_sum_spec.hpp>
+#include <KokkosBlas_util.hpp>
 
 namespace KokkosBlas {
 namespace Impl {
@@ -93,101 +94,44 @@ struct V_Sum_Functor {
   void operator()(const size_type& i, value_type& sum) const { sum += m_x(i); }
 };
 
-/// \brief Column-wise 2-norm functor for multivectors; works for
-///   any layout, but best performance with LayoutRight.
-///
-/// \tparam RV 1-D output View
-/// \tparam XMV 2-D input View
-/// \tparam SizeType Index type.  Use int (32 bits) if possible.
-template <class RV, class XMV, class SizeType = typename XMV::size_type>
-struct MV_Sum_Right_FunctorVector {
-  typedef typename XMV::execution_space execution_space;
-  typedef SizeType size_type;
-  typedef typename XMV::non_const_value_type xvalue_type;
-  typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type> AT;
-  typedef typename RV::non_const_value_type value_type[];
+template <class ExecSpace, class RV, class XV, class size_type>
+struct Sum_MV_Functor {
+  typedef typename RV::non_const_value_type value_type;
+  typedef Kokkos::ArithTraits<value_type> AT;
 
-  size_type value_count;
-  typename XMV::const_type m_x;
+  using TeamMem = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
 
-  MV_Sum_Right_FunctorVector(const XMV& x) : value_count(x.extent(1)), m_x(x) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
-                  "KokkosBlas::Impl::MV_Sum_Right_FunctorVector: "
-                  "R is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
-                  "KokkosBlas::Impl::MV_Sum_Right_FunctorVector: "
-                  "X is not a Kokkos::View.");
-    static_assert(std::is_same<typename RV::value_type,
-                               typename RV::non_const_value_type>::value,
-                  "KokkosBlas::Impl::MV_Sum_Right_FunctorVector: "
-                  "R is const.  It must be nonconst, because it is an output "
-                  "argument (we must be able to write to its entries).");
-    static_assert(RV::rank == 1 && XMV::rank == 2,
-                  "KokkosBlas::Impl::MV_Sum_Right_FunctorVector: "
-                  "RV must have rank 1 and XMV must have rank 2.");
+  RV r;
+  XV x;
+
+  size_type
+      teamsPerVec;  // number of teams collectively performing a dot product
+  size_type
+      chunkSize;  // the local length of each team's share on the dot product
+
+  Sum_MV_Functor(const RV& r_, const XV& x_, int teamsPerVec_, int chunkSize_)
+      : r(r_), x(x_), teamsPerVec(teamsPerVec_), chunkSize(chunkSize_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const TeamMem& t) const {
+    size_type globalRank = t.league_rank();
+    size_type localRank  = globalRank % teamsPerVec;
+    size_type i          = globalRank / teamsPerVec;
+
+    value_type localResult = AT::zero();
+    size_type baseInd      = chunkSize * localRank;
+    Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(t, chunkSize),
+        [&](size_type k, value_type& update) {
+          if (baseInd + k < size_type(x.extent(0))) {
+            update += x(baseInd + k, i);
+          }
+        },
+        localResult);
+
+    Kokkos::single(Kokkos::PerTeam(t),
+                   [&]() { Kokkos::atomic_add(&r(i), localResult); });
   }
-
-  KOKKOS_INLINE_FUNCTION void operator()(const size_type i,
-                                         value_type sum) const {
-    const size_type numVecs = value_count;
-#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
-#pragma ivdep
-#endif
-#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
-#pragma vector always
-#endif
-    for (size_type j = 0; j < numVecs; ++j) {
-      sum[j] += m_x(i, j);
-    }
-  }
-
-  /* KOKKOS_INLINE_FUNCTION void
-   init (value_type update) const
-   {
-     const size_type numVecs = value_count;
- #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
- #pragma ivdep
- #endif
- #ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
- #pragma vector always
- #endif
-     for (size_type j = 0; j < numVecs; ++j) {
-       update[j] = AT::zero ();
-     }
-   }
-
-   KOKKOS_INLINE_FUNCTION void
-   join (volatile value_type update,
-         const volatile value_type source) const
-   {
-     const size_type numVecs = value_count;
- #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
- #pragma ivdep
- #endif
- #ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
- #pragma vector always
- #endif
-     for (size_type j = 0; j < numVecs; ++j) {
-       update[j] += source[j];
-     }
-   }
-
-   KOKKOS_INLINE_FUNCTION void
-   join (value_type update,
-         const value_type source) const
-   {
-     const size_type numVecs = value_count;
- #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
- #pragma ivdep
- #endif
- #ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
- #pragma vector always
- #endif
-     for (size_type j = 0; j < numVecs; ++j) {
-       update[j] += source[j];
-     }
-   }*/
 };
 
 /// \brief Compute the 2-norm (or its square) of the single vector (1-D
@@ -205,25 +149,49 @@ void V_Sum_Invoke(const RV& r, const XV& X) {
 
 /// \brief Compute the 2-norms (or their square) of the columns of the
 ///   multivector (2-D View) X, and store result(s) in the 1-D View r.
-template <class RV, class XMV, class SizeType>
-void MV_Sum_Invoke(const RV& r, const XMV& X) {
-  typedef typename XMV::execution_space execution_space;
-  const SizeType numRows = static_cast<SizeType>(X.extent(0));
-  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
-
-  // If the input multivector (2-D View) has only one column, invoke
-  // the single-vector version of the kernel.
-  if (X.extent(1) == 1) {
-    auto r_0 = Kokkos::subview(r, 0);
-    auto X_0 = Kokkos::subview(X, Kokkos::ALL(), 0);
-    typedef decltype(r_0) RV0D;
-    typedef decltype(X_0) XV1D;
-    V_Sum_Invoke<RV0D, XV1D, SizeType>(r_0, X_0);
-  } else {
-    typedef MV_Sum_Right_FunctorVector<RV, XMV, SizeType> functor_type;
-    functor_type op(X);
-    Kokkos::parallel_reduce("KokkosBlas::Sum::S1", policy, op, r);
+// Main version: the result view is accessible from execution space, so it can
+// be computed in-place
+template <class RV, class XV, class size_type>
+void MV_Sum_Invoke(
+    const RV& r, const XV& x,
+    typename std::enable_if<Kokkos::SpaceAccessibility<
+        typename XV::execution_space,
+        typename RV::memory_space>::accessible>::type* = nullptr) {
+  using execution_space = typename XV::execution_space;
+  if (r.extent(0) != x.extent(1)) {
+    std::ostringstream oss;
+    oss << "KokkosBlas::Sum (rank-2): result vector has wrong length ("
+        << r.extent(0) << ", but x has " << x.extent(1) << " columns)";
+    throw std::runtime_error(oss.str());
   }
+  // Zero out the result vector
+  Kokkos::deep_copy(
+      r, Kokkos::ArithTraits<typename RV::non_const_value_type>::zero());
+  size_type teamsPerVec, chunkSize;
+  KokkosBlas::Impl::multipleReductionWorkDistribution<execution_space,
+                                                      size_type>(
+      x.extent(0), x.extent(1), teamsPerVec, chunkSize);
+  size_type numTeams = x.extent(1) * teamsPerVec;
+  Kokkos::TeamPolicy<execution_space> pol(numTeams, Kokkos::AUTO);
+  Kokkos::parallel_for("KokkosBlas1::Sum::S1", pol,
+                       Sum_MV_Functor<execution_space, RV, XV, size_type>(
+                           r, x, teamsPerVec, chunkSize));
+}
+
+// Version for when a temporary result view is needed (implemented in terms of
+// the other version)
+template <class RV, class XV, class size_type>
+void MV_Sum_Invoke(
+    const RV& r, const XV& x,
+    typename std::enable_if<!Kokkos::SpaceAccessibility<
+        typename XV::execution_space,
+        typename RV::memory_space>::accessible>::type* = nullptr) {
+  Kokkos::View<typename RV::non_const_value_type*, typename XV::memory_space>
+      tempResult(
+          Kokkos::view_alloc(Kokkos::WithoutInitializing, "Sum temp result"),
+          r.extent(0));
+  MV_Sum_Invoke<decltype(tempResult), XV, size_type>(tempResult, x);
+  Kokkos::deep_copy(r, tempResult);
 }
 
 }  // namespace Impl

--- a/src/blas/impl/KokkosBlas3_gemm_dotbased_impl.hpp
+++ b/src/blas/impl/KokkosBlas3_gemm_dotbased_impl.hpp
@@ -45,6 +45,8 @@
 #ifndef KOKKOS_BLAS3_GEMM_DOTBASED_IMPL_HPP_
 #define KOKKOS_BLAS3_GEMM_DOTBASED_IMPL_HPP_
 
+#include "KokkosBlas_util.hpp"
+
 namespace KokkosBlas {
 namespace Impl {
 
@@ -82,7 +84,7 @@ struct DotBasedGEMM {
   size_C numTeams;      // total number of teams
 
   const size_A dotSize;  // the length of the vectors in the dot products
-  size_A chunkSize;  // the local length of each team's share on the dot product
+  size_C chunkSize;  // the local length of each team's share on the dot product
 
   DotBasedGEMM(const scalar_A& alpha_, const AV& A_, const BV& B_,
                const scalar_C& beta_, const CV& C_)
@@ -96,37 +98,10 @@ struct DotBasedGEMM {
         dotSize(A.extent(0)) {}
 
   void run(const typename CV::execution_space& space, bool conjugateTranspose) {
-    // NOTE: these workPerTeam and approxNumTeams were used for TPL CUBLAS,
-    //       and may need to be retuned for other architectures
-    constexpr size_C workPerTeam = 4096;       // Amount of work per team
+    multipleReductionWorkDistribution<ExecSpace, size_C>(
+        dotSize, numCrows * numCcols, numDivPerDot, chunkSize);
     const size_C ndots = numCrows * numCcols;  // Number of dot products
-    size_C appxNumTeams =
-        (dotSize * ndots) / workPerTeam;  // Estimation for appxNumTeams
-
-    // Adjust appxNumTeams in case it is too small or too large
-    if (appxNumTeams < 1) appxNumTeams = 1;
-    if (appxNumTeams > 1024) appxNumTeams = 1024;
-
-    // If there are more dot products than the number of teams,
-    // then set the number of teams to be number of dot products
-    // and each team will perform only one dot product.
-    // We don't want a team to perform more than one dot product.
-    if (ndots >= appxNumTeams) {
-      numTeams     = ndots;
-      numDivPerDot = 1;
-    }
-    // If there are more teams than dot products, each dot product can
-    // potentially be performed by multiple teams. First, compute
-    // numDivPerDot as an integer (take the floor, not ceiling), then,
-    // compute actual number of teams by using this factor.
-    else {
-      numDivPerDot = appxNumTeams / ndots;
-      numTeams     = ndots * numDivPerDot;
-    }
-
-    // Determine the local length for the dot product
-    chunkSize = dotSize / numDivPerDot;
-    if (numDivPerDot > 1) chunkSize++;
+    numTeams           = ndots * numDivPerDot;
 
     // Initialize C matrix if beta != 1
     if (beta == CVT::zero()) {

--- a/src/blas/impl/KokkosBlas_util.hpp
+++ b/src/blas/impl/KokkosBlas_util.hpp
@@ -60,12 +60,10 @@ namespace Impl {
 //  * numReductions: number of reductions to compute
 // Output params:
 //  * teamsPerReduction: number of teams to use for each reduction
-//  * chunkSize: length of each team's local reduction
 template <typename ExecSpace, typename size_type>
 void multipleReductionWorkDistribution(size_type length,
                                        size_type numReductions,
-                                       size_type& teamsPerDot,
-                                       size_type& chunkSize) {
+                                       size_type& teamsPerDot) {
   constexpr size_type workPerTeam = 4096;  // Amount of work per team
   size_type appxNumTeams =
       (length * numReductions) / workPerTeam;  // Estimation for appxNumTeams
@@ -87,10 +85,6 @@ void multipleReductionWorkDistribution(size_type length,
   else {
     teamsPerDot = appxNumTeams / numReductions;
   }
-
-  // Determine the local length for the dot product
-  chunkSize = length / teamsPerDot;
-  if (teamsPerDot > 1) chunkSize++;
 }
 
 // Functor to apply sqrt() to each element of a 1D view.

--- a/src/blas/impl/KokkosBlas_util.hpp
+++ b/src/blas/impl/KokkosBlas_util.hpp
@@ -1,0 +1,112 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Brian Kelley (bmkelle@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_BLAS_UTIL_HPP
+#define KOKKOS_BLAS_UTIL_HPP
+
+namespace KokkosBlas {
+namespace Impl {
+
+// Helper to choose the work distribution for a TeamPolicy computing multiple
+// reductions. Each team computes a partial reduction and atomically contributes
+// to the final result.
+//
+// This was originally written for dot-based GEMM, but can also be applied to
+// multivector dots/norms.
+
+// Input params:
+//  * length: size of each vector to reduce
+//  * numReductions: number of reductions to compute
+// Output params:
+//  * teamsPerReduction: number of teams to use for each reduction
+//  * chunkSize: length of each team's local reduction
+template <typename ExecSpace, typename size_type>
+void multipleReductionWorkDistribution(size_type length,
+                                       size_type numReductions,
+                                       size_type& teamsPerDot,
+                                       size_type& chunkSize) {
+  constexpr size_type workPerTeam = 4096;  // Amount of work per team
+  size_type appxNumTeams =
+      (length * numReductions) / workPerTeam;  // Estimation for appxNumTeams
+
+  // Adjust appxNumTeams in case it is too small or too large
+  if (appxNumTeams < 1) appxNumTeams = 1;
+  if (appxNumTeams > 1024) appxNumTeams = 1024;
+
+  // If there are more reductions than the number of teams,
+  // then set the number of teams to be number of reductions.
+  // We don't want a team to contribute to more than one reduction.
+  if (numReductions >= appxNumTeams) {
+    teamsPerDot = 1;
+  }
+  // If there are more teams than reductions, each reduction can
+  // potentially be performed by multiple teams. First, compute
+  // teamsPerDot as an integer (take the floor, not ceiling), then,
+  // compute actual number of teams by using this factor.
+  else {
+    teamsPerDot = appxNumTeams / numReductions;
+  }
+
+  // Determine the local length for the dot product
+  chunkSize = length / teamsPerDot;
+  if (teamsPerDot > 1) chunkSize++;
+}
+
+// Functor to apply sqrt() to each element of a 1D view.
+
+template <class RV>
+struct TakeSqrtFunctor {
+  TakeSqrtFunctor(const RV& r_) : r(r_) {}
+
+  KOKKOS_INLINE_FUNCTION void operator()(int i) const {
+    r(i) = Kokkos::ArithTraits<typename RV::non_const_value_type>::sqrt(r(i));
+  }
+
+  RV r;
+};
+
+}  // namespace Impl
+}  // namespace KokkosBlas
+
+#endif


### PR DESCRIPTION
Where possible, have multiple teams contribute to each reduction using
atomics, just like dot-based GEMM (~3x speedup on Cuda).
Otherwise, process each column in the multivector using a single reduction
(this is still faster on GPU)

Works around https://github.com/trilinos/Trilinos/issues/9856 (original Trilinos issue) and https://github.com/kokkos/kokkos/issues/4461. Also, Kokkos doesn't support array reductions in OpenMPTarget so this is one step closer to running with that backend.