### PR TITLE
Replace `Kokkos::Impl::if_c -> std::conditional`

### DIFF
--- a/src/blas/KokkosBlas1_abs.hpp
+++ b/src/blas/KokkosBlas1_abs.hpp
@@ -91,16 +91,16 @@ void abs(const RMV& R, const XMV& X) {
   // Create unmanaged versions of the input Views.  RMV and XMV may be
   // rank 1 or rank 2.
   typedef Kokkos::View<
-      typename Kokkos::Impl::if_c<RMV::rank == 1,
-                                  typename RMV::non_const_value_type*,
-                                  typename RMV::non_const_value_type**>::type,
+      typename std::conditional<RMV::rank == 1,
+                                typename RMV::non_const_value_type*,
+                                typename RMV::non_const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<RMV>::array_layout,
       typename RMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RMV_Internal;
   typedef Kokkos::View<
-      typename Kokkos::Impl::if_c<XMV::rank == 1,
-                                  typename XMV::const_value_type*,
-                                  typename XMV::const_value_type**>::type,
+      typename std::conditional<XMV::rank == 1,
+                                typename XMV::const_value_type*,
+                                typename XMV::const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
       typename XMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       XMV_Internal;

--- a/src/blas/KokkosBlas1_abs.hpp
+++ b/src/blas/KokkosBlas1_abs.hpp
@@ -98,8 +98,7 @@ void abs(const RMV& R, const XMV& X) {
       typename RMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RMV_Internal;
   typedef Kokkos::View<
-      typename std::conditional<XMV::rank == 1,
-                                typename XMV::const_value_type*,
+      typename std::conditional<XMV::rank == 1, typename XMV::const_value_type*,
                                 typename XMV::const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
       typename XMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >

--- a/src/blas/KokkosBlas1_dot.hpp
+++ b/src/blas/KokkosBlas1_dot.hpp
@@ -226,15 +226,14 @@ void dot(
                        UnifiedRVLayout, typename RV::device_type,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>
       RV_Internal;
-  typedef Kokkos::View<typename std::conditional<
-                           XMV::rank == 1, typename XMV::const_value_type*,
-                           typename XMV::const_value_type**>::type,
-                       UnifiedXLayout, typename XMV::device_type,
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+  typedef Kokkos::View<
+      typename std::conditional<XMV::rank == 1, typename XMV::const_value_type*,
+                                typename XMV::const_value_type**>::type,
+      UnifiedXLayout, typename XMV::device_type,
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>>
       XMV_Internal;
   typedef Kokkos::View<
-      typename std::conditional<YMV::rank == 1,
-                                typename YMV::const_value_type*,
+      typename std::conditional<YMV::rank == 1, typename YMV::const_value_type*,
                                 typename YMV::const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<YMV>::array_layout,
       typename YMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>

--- a/src/blas/KokkosBlas1_dot.hpp
+++ b/src/blas/KokkosBlas1_dot.hpp
@@ -220,22 +220,22 @@ void dot(
       typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<
           RV, UnifiedXLayout>::array_layout;
 
-  typedef Kokkos::View<typename Kokkos::Impl::if_c<
+  typedef Kokkos::View<typename std::conditional<
                            RV::rank == 0, typename RV::non_const_value_type,
                            typename RV::non_const_value_type*>::type,
                        UnifiedRVLayout, typename RV::device_type,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>
       RV_Internal;
-  typedef Kokkos::View<typename Kokkos::Impl::if_c<
+  typedef Kokkos::View<typename std::conditional<
                            XMV::rank == 1, typename XMV::const_value_type*,
                            typename XMV::const_value_type**>::type,
                        UnifiedXLayout, typename XMV::device_type,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>
       XMV_Internal;
   typedef Kokkos::View<
-      typename Kokkos::Impl::if_c<YMV::rank == 1,
-                                  typename YMV::const_value_type*,
-                                  typename YMV::const_value_type**>::type,
+      typename std::conditional<YMV::rank == 1,
+                                typename YMV::const_value_type*,
+                                typename YMV::const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<YMV>::array_layout,
       typename YMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>
       YMV_Internal;

--- a/src/blas/KokkosBlas1_nrm1.hpp
+++ b/src/blas/KokkosBlas1_nrm1.hpp
@@ -148,11 +148,11 @@ void nrm1(
                        UnifiedRVLayout, typename RV::device_type,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RV_Internal;
-  typedef Kokkos::View<typename std::conditional<
-                           XMV::rank == 1, typename XMV::const_value_type*,
-                           typename XMV::const_value_type**>::type,
-                       UnifiedXLayout, typename XMV::device_type,
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+  typedef Kokkos::View<
+      typename std::conditional<XMV::rank == 1, typename XMV::const_value_type*,
+                                typename XMV::const_value_type**>::type,
+      UnifiedXLayout, typename XMV::device_type,
+      Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       XMV_Internal;
 
   RV_Internal R_internal  = R;

--- a/src/blas/KokkosBlas1_nrm1.hpp
+++ b/src/blas/KokkosBlas1_nrm1.hpp
@@ -142,13 +142,13 @@ void nrm1(
 
   // Create unmanaged versions of the input Views.  RV and XMV may be
   // rank 1 or rank 2.
-  typedef Kokkos::View<typename Kokkos::Impl::if_c<
+  typedef Kokkos::View<typename std::conditional<
                            RV::rank == 0, typename RV::non_const_value_type,
                            typename RV::non_const_value_type*>::type,
                        UnifiedRVLayout, typename RV::device_type,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RV_Internal;
-  typedef Kokkos::View<typename Kokkos::Impl::if_c<
+  typedef Kokkos::View<typename std::conditional<
                            XMV::rank == 1, typename XMV::const_value_type*,
                            typename XMV::const_value_type**>::type,
                        UnifiedXLayout, typename XMV::device_type,

--- a/src/blas/KokkosBlas1_nrm2w.hpp
+++ b/src/blas/KokkosBlas1_nrm2w.hpp
@@ -137,16 +137,16 @@ void nrm2w(
   // Create unmanaged versions of the input Views.  RV and XMV may be
   // rank 1 or rank 2.
   typedef Kokkos::View<
-      typename Kokkos::Impl::if_c<RV::rank == 0,
-                                  typename RV::non_const_value_type,
-                                  typename RV::non_const_value_type*>::type,
+      typename std::conditional<RV::rank == 0,
+                                typename RV::non_const_value_type,
+                                typename RV::non_const_value_type*>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<RV>::array_layout,
       typename RV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RV_Internal;
   typedef Kokkos::View<
-      typename Kokkos::Impl::if_c<XMV::rank == 1,
-                                  typename XMV::const_value_type*,
-                                  typename XMV::const_value_type**>::type,
+      typename std::conditional<XMV::rank == 1,
+                                typename XMV::const_value_type*,
+                                typename XMV::const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
       typename XMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       XMV_Internal;

--- a/src/blas/KokkosBlas1_nrm2w.hpp
+++ b/src/blas/KokkosBlas1_nrm2w.hpp
@@ -144,8 +144,7 @@ void nrm2w(
       typename RV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RV_Internal;
   typedef Kokkos::View<
-      typename std::conditional<XMV::rank == 1,
-                                typename XMV::const_value_type*,
+      typename std::conditional<XMV::rank == 1, typename XMV::const_value_type*,
                                 typename XMV::const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
       typename XMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >

--- a/src/blas/KokkosBlas1_nrm2w_squared.hpp
+++ b/src/blas/KokkosBlas1_nrm2w_squared.hpp
@@ -144,8 +144,7 @@ void nrm2w_squared(
       typename RV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RV_Internal;
   typedef Kokkos::View<
-      typename std::conditional<XMV::rank == 1,
-                                typename XMV::const_value_type*,
+      typename std::conditional<XMV::rank == 1, typename XMV::const_value_type*,
                                 typename XMV::const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
       typename XMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >

--- a/src/blas/KokkosBlas1_nrm2w_squared.hpp
+++ b/src/blas/KokkosBlas1_nrm2w_squared.hpp
@@ -137,16 +137,16 @@ void nrm2w_squared(
   // Create unmanaged versions of the input Views.  RV and XMV may be
   // rank 1 or rank 2.
   typedef Kokkos::View<
-      typename Kokkos::Impl::if_c<RV::rank == 0,
-                                  typename RV::non_const_value_type,
-                                  typename RV::non_const_value_type*>::type,
+      typename std::conditional<RV::rank == 0,
+                                typename RV::non_const_value_type,
+                                typename RV::non_const_value_type*>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<RV>::array_layout,
       typename RV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RV_Internal;
   typedef Kokkos::View<
-      typename Kokkos::Impl::if_c<XMV::rank == 1,
-                                  typename XMV::const_value_type*,
-                                  typename XMV::const_value_type**>::type,
+      typename std::conditional<XMV::rank == 1,
+                                typename XMV::const_value_type*,
+                                typename XMV::const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
       typename XMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       XMV_Internal;

--- a/src/blas/KokkosBlas1_nrminf.hpp
+++ b/src/blas/KokkosBlas1_nrminf.hpp
@@ -148,11 +148,11 @@ void nrminf(
                        UnifiedRVLayout, typename RV::device_type,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RV_Internal;
-  typedef Kokkos::View<typename std::conditional<
-                           XMV::rank == 1, typename XMV::const_value_type*,
-                           typename XMV::const_value_type**>::type,
-                       UnifiedXLayout, typename XMV::device_type,
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+  typedef Kokkos::View<
+      typename std::conditional<XMV::rank == 1, typename XMV::const_value_type*,
+                                typename XMV::const_value_type**>::type,
+      UnifiedXLayout, typename XMV::device_type,
+      Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       XMV_Internal;
 
   RV_Internal R_internal  = R;

--- a/src/blas/KokkosBlas1_nrminf.hpp
+++ b/src/blas/KokkosBlas1_nrminf.hpp
@@ -142,13 +142,13 @@ void nrminf(
 
   // Create unmanaged versions of the input Views.  RV and XMV may be
   // rank 1 or rank 2.
-  typedef Kokkos::View<typename Kokkos::Impl::if_c<
+  typedef Kokkos::View<typename std::conditional<
                            RV::rank == 0, typename RV::non_const_value_type,
                            typename RV::non_const_value_type*>::type,
                        UnifiedRVLayout, typename RV::device_type,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RV_Internal;
-  typedef Kokkos::View<typename Kokkos::Impl::if_c<
+  typedef Kokkos::View<typename std::conditional<
                            XMV::rank == 1, typename XMV::const_value_type*,
                            typename XMV::const_value_type**>::type,
                        UnifiedXLayout, typename XMV::device_type,

--- a/src/blas/KokkosBlas1_reciprocal.hpp
+++ b/src/blas/KokkosBlas1_reciprocal.hpp
@@ -98,8 +98,7 @@ void reciprocal(const RMV& R, const XMV& X) {
       typename RMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RMV_Internal;
   typedef Kokkos::View<
-      typename std::conditional<XMV::rank == 1,
-                                typename XMV::const_value_type*,
+      typename std::conditional<XMV::rank == 1, typename XMV::const_value_type*,
                                 typename XMV::const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
       typename XMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >

--- a/src/blas/KokkosBlas1_reciprocal.hpp
+++ b/src/blas/KokkosBlas1_reciprocal.hpp
@@ -91,16 +91,16 @@ void reciprocal(const RMV& R, const XMV& X) {
   // Create unmanaged versions of the input Views.  RMV and XMV may be
   // rank 1 or rank 2.
   typedef Kokkos::View<
-      typename Kokkos::Impl::if_c<RMV::rank == 1,
-                                  typename RMV::non_const_value_type*,
-                                  typename RMV::non_const_value_type**>::type,
+      typename std::conditional<RMV::rank == 1,
+                                typename RMV::non_const_value_type*,
+                                typename RMV::non_const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<RMV>::array_layout,
       typename RMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RMV_Internal;
   typedef Kokkos::View<
-      typename Kokkos::Impl::if_c<XMV::rank == 1,
-                                  typename XMV::const_value_type*,
-                                  typename XMV::const_value_type**>::type,
+      typename std::conditional<XMV::rank == 1,
+                                typename XMV::const_value_type*,
+                                typename XMV::const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
       typename XMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       XMV_Internal;

--- a/src/blas/KokkosBlas1_update.hpp
+++ b/src/blas/KokkosBlas1_update.hpp
@@ -102,25 +102,25 @@ void update(const typename XMV::non_const_value_type& alpha, const XMV& X,
   // may be rank 1 or rank 2, but they must all have the same rank.
 
   typedef Kokkos::View<
-      typename Kokkos::Impl::if_c<XMV::rank == 1,
-                                  typename XMV::const_value_type*,
-                                  typename XMV::const_value_type**>::type,
+      typename std::conditional<XMV::rank == 1,
+                                typename XMV::const_value_type*,
+                                typename XMV::const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
       typename XMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       XMV_Internal;
 
   typedef Kokkos::View<
-      typename Kokkos::Impl::if_c<YMV::rank == 1,
-                                  typename YMV::const_value_type*,
-                                  typename YMV::const_value_type**>::type,
+      typename std::conditional<YMV::rank == 1,
+                                typename YMV::const_value_type*,
+                                typename YMV::const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<YMV>::array_layout,
       typename YMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       YMV_Internal;
 
   typedef Kokkos::View<
-      typename Kokkos::Impl::if_c<ZMV::rank == 1,
-                                  typename ZMV::non_const_value_type*,
-                                  typename ZMV::non_const_value_type**>::type,
+      typename std::conditional<ZMV::rank == 1,
+                                typename ZMV::non_const_value_type*,
+                                typename ZMV::non_const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<ZMV>::array_layout,
       typename ZMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       ZMV_Internal;

--- a/src/blas/KokkosBlas1_update.hpp
+++ b/src/blas/KokkosBlas1_update.hpp
@@ -102,16 +102,14 @@ void update(const typename XMV::non_const_value_type& alpha, const XMV& X,
   // may be rank 1 or rank 2, but they must all have the same rank.
 
   typedef Kokkos::View<
-      typename std::conditional<XMV::rank == 1,
-                                typename XMV::const_value_type*,
+      typename std::conditional<XMV::rank == 1, typename XMV::const_value_type*,
                                 typename XMV::const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
       typename XMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       XMV_Internal;
 
   typedef Kokkos::View<
-      typename std::conditional<YMV::rank == 1,
-                                typename YMV::const_value_type*,
+      typename std::conditional<YMV::rank == 1, typename YMV::const_value_type*,
                                 typename YMV::const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<YMV>::array_layout,
       typename YMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >

--- a/src/sparse/KokkosSparse_spmv.hpp
+++ b/src/sparse/KokkosSparse_spmv.hpp
@@ -894,7 +894,7 @@ void spmv_struct(const char mode[], const int stencil_type,
                  const AlphaType& alpha, const AMatrix& A, const XVector& x,
                  const BetaType& beta, const YVector& y) {
   typedef
-      typename Kokkos::Impl::if_c<XVector::rank == 2, RANK_TWO, RANK_ONE>::type
+      typename std::conditional<XVector::rank == 2, RANK_TWO, RANK_ONE>::type
           RANK_SPECIALISE;
   spmv_struct(mode, stencil_type, structure, alpha, A, x, beta, y,
               RANK_SPECIALISE());

--- a/src/stage/blas3/Kokkos_Blas3.hpp
+++ b/src/stage/blas3/Kokkos_Blas3.hpp
@@ -217,7 +217,7 @@ void gemm(const char transA, const char transB, AMat::const_value_type alpha,
     Kokkos::Impl::throw_runtime_exception(os.str());
   }
 
-  typedef Kokkos::View<typename Kokkos::Impl::if_c<
+  typedef Kokkos::View<typename std::conditional<
                            AMat::rank == 2, typename AMat::const_value_type**,
                            typename AMat::const_value_type***>::type,
                        typename AMat::array_layout, typename AMat::device_type,
@@ -225,7 +225,7 @@ void gemm(const char transA, const char transB, AMat::const_value_type alpha,
                        typename AMat::specialize>
       AMat_Internal;
 
-  typedef Kokkos::View<typename Kokkos::Impl::if_c<
+  typedef Kokkos::View<typename std::conditional<
                            BMat::rank == 2, typename BMat::const_value_type**,
                            typename BMat::const_value_type***>::type,
                        typename BMat::array_layout, typename BMat::device_type,
@@ -233,7 +233,7 @@ void gemm(const char transA, const char transB, AMat::const_value_type alpha,
                        typename BMat::specialize>
       BMat_Internal;
 
-  typedef Kokkos::View<typename Kokkos::Impl::if_c<
+  typedef Kokkos::View<typename std::conditional<
                            CMat::rank == 2, typename CMat::const_value_type**,
                            typename CMat::const_value_type***>::type,
                        typename CMat::array_layout, typename CMat::device_type,


### PR DESCRIPTION
Rational: It is not "legal" to reach into the `Kokkos::Impl::` namespace and the same functionality is provided by `<type_traits>` standard library header since C++11