### PR TITLE
Do not use `Kokkos::Impl::is_view`

### DIFF
--- a/example/fenl/CGSolve.hpp
+++ b/example/fenl/CGSolve.hpp
@@ -60,83 +60,80 @@
 namespace Kokkos {
 namespace Example {
 
-template< class ImportType , class SparseMatrixType , class VectorType , class TagType = void >
-struct CGSolve ;
+template <class ImportType, class SparseMatrixType, class VectorType,
+          class TagType = void>
+struct CGSolve;
 
 template <class ImportType, class SparseMatrixType, class VectorType>
 struct CGSolve<ImportType, SparseMatrixType, VectorType,
                typename std::enable_if<(Kokkos::is_view<VectorType>::value &&
-                                        VectorType::rank == 1)>::type>
-{
-  typedef typename VectorType::value_type scalar_type ;
+                                        VectorType::rank == 1)>::type> {
+  typedef typename VectorType::value_type scalar_type;
   typedef typename VectorType::execution_space execution_space;
 
-  size_t iteration ;
-  double iter_time ;
-  double matvec_time ;
-  double norm_res ;
+  size_t iteration;
+  double iter_time;
+  double matvec_time;
+  double norm_res;
 
-  CGSolve( const ImportType       & import ,
-           const SparseMatrixType & A ,
-           const VectorType       & b ,
-           const VectorType       & x ,
-           const size_t             maximum_iteration = 200 ,
-           const double             tolerance = std::numeric_limits<double>::epsilon() )
-    : iteration(0)
-    , iter_time(0)
-    , matvec_time(0)
-    , norm_res(0)
-  {
-    const size_t count_owned = import.count_owned ;
+  CGSolve(const ImportType& import, const SparseMatrixType& A,
+          const VectorType& b, const VectorType& x,
+          const size_t maximum_iteration = 200,
+          const double tolerance = std::numeric_limits<double>::epsilon())
+      : iteration(0), iter_time(0), matvec_time(0), norm_res(0) {
+    const size_t count_owned = import.count_owned;
     const size_t count_total = import.count_owned + import.count_receive;
 
     // Need input vector to matvec to be owned + received
-    VectorType pAll ( "cg::p" , count_total );
+    VectorType pAll("cg::p", count_total);
 
-    VectorType p = Kokkos::subview( pAll , std::pair<size_t,size_t>(0,count_owned) );
-    VectorType r ( "cg::r" , count_owned );
-    VectorType Ap( "cg::Ap", count_owned );
+    VectorType p =
+        Kokkos::subview(pAll, std::pair<size_t, size_t>(0, count_owned));
+    VectorType r("cg::r", count_owned);
+    VectorType Ap("cg::Ap", count_owned);
 
     /* r = b - A * x ; */
 
-    /* p  = x       */  Kokkos::deep_copy( p , x );
-    /* import p     */  import( pAll );
-    /* Ap = A * p   */  KokkosSparse::spmv( "N" , 1.0 , A , pAll , 0.0 , Ap);
-    /* b - Ap => r  */  KokkosBlas::update( 1.0 , b , -1.0 , Ap , 0.0 , r);
-    /* p  = r       */  Kokkos::deep_copy( p , r );
+    /* p  = x       */ Kokkos::deep_copy(p, x);
+    /* import p     */ import(pAll);
+    /* Ap = A * p   */ KokkosSparse::spmv("N", 1.0, A, pAll, 0.0, Ap);
+    /* b - Ap => r  */ KokkosBlas::update(1.0, b, -1.0, Ap, 0.0, r);
+    /* p  = r       */ Kokkos::deep_copy(p, r);
 
-    double old_rdot = Kokkos::Example::all_reduce( KokkosBlas::dot( r , r ) , import.comm );
+    double old_rdot =
+        Kokkos::Example::all_reduce(KokkosBlas::dot(r, r), import.comm);
 
-    norm_res  = sqrt( old_rdot );
-    iteration = 0 ;
+    norm_res  = sqrt(old_rdot);
+    iteration = 0;
 
-    Kokkos::Timer wall_clock ;
+    Kokkos::Timer wall_clock;
     Kokkos::Timer timer;
 
-    while ( tolerance < norm_res && iteration < maximum_iteration ) {
-
+    while (tolerance < norm_res && iteration < maximum_iteration) {
       /* pAp_dot = dot( p , Ap = A * p ) */
 
       timer.reset();
-      /* import p    */  import( pAll );
-      /* Ap = A * p  */  KokkosSparse::spmv( "N", 1.0, A , pAll, 0.0, Ap);
+      /* import p    */ import(pAll);
+      /* Ap = A * p  */ KokkosSparse::spmv("N", 1.0, A, pAll, 0.0, Ap);
       execution_space().fence();
       matvec_time += timer.seconds();
 
-      const double pAp_dot = Kokkos::Example::all_reduce( KokkosBlas::dot( p , Ap ) , import.comm );
-      const double alpha   = old_rdot / pAp_dot ;
+      const double pAp_dot =
+          Kokkos::Example::all_reduce(KokkosBlas::dot(p, Ap), import.comm);
+      const double alpha = old_rdot / pAp_dot;
 
-      /* x +=  alpha * p ;  */ KokkosBlas::axpby( alpha, p  , 1.0 , x );
-      /* r += -alpha * Ap ; */ KokkosBlas::axpby(-alpha, Ap , 1.0 , r );
+      /* x +=  alpha * p ;  */ KokkosBlas::axpby(alpha, p, 1.0, x);
+      /* r += -alpha * Ap ; */ KokkosBlas::axpby(-alpha, Ap, 1.0, r);
 
-      const double r_dot = Kokkos::Example::all_reduce( KokkosBlas::dot( r , r ) , import.comm );
-      const double beta  = r_dot / old_rdot ;
+      const double r_dot =
+          Kokkos::Example::all_reduce(KokkosBlas::dot(r, r), import.comm);
+      const double beta = r_dot / old_rdot;
 
-      /* p = r + beta * p ; */ KokkosBlas::axpby( 1.0 , r , beta , p );
+      /* p = r + beta * p ; */ KokkosBlas::axpby(1.0, r, beta, p);
 
-      norm_res = std::sqrt( old_rdot = r_dot );
+      norm_res = std::sqrt(old_rdot = r_dot);
 
-      ++iteration ;
+      ++iteration;
     }
 
     execution_space().fence();
@@ -144,12 +141,11 @@ struct CGSolve<ImportType, SparseMatrixType, VectorType,
   }
 };
 
-} // namespace Example
-} // namespace Kokkos
+}  // namespace Example
+}  // namespace Kokkos
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
 #endif /* #ifndef KOKKOS_EXAMPLE_CG_SOLVE */
-
 

--- a/example/fenl/CGSolve.hpp
+++ b/example/fenl/CGSolve.hpp
@@ -63,13 +63,10 @@ namespace Example {
 template< class ImportType , class SparseMatrixType , class VectorType , class TagType = void >
 struct CGSolve ;
 
-
-template< class ImportType , class SparseMatrixType , class VectorType >
-struct CGSolve< ImportType , SparseMatrixType , VectorType ,
-  typename std::enable_if<(
-    Kokkos::is_view< VectorType >::value &&
-    VectorType::rank == 1
-  )>::type >
+template <class ImportType, class SparseMatrixType, class VectorType>
+struct CGSolve<ImportType, SparseMatrixType, VectorType,
+               typename std::enable_if<(Kokkos::is_view<VectorType>::value &&
+                                        VectorType::rank == 1)>::type>
 {
   typedef typename VectorType::value_type scalar_type ;
   typedef typename VectorType::execution_space execution_space;

--- a/example/fenl/CGSolve.hpp
+++ b/example/fenl/CGSolve.hpp
@@ -148,4 +148,3 @@ struct CGSolve<ImportType, SparseMatrixType, VectorType,
 //----------------------------------------------------------------------------
 
 #endif /* #ifndef KOKKOS_EXAMPLE_CG_SOLVE */
-

--- a/example/fenl/CGSolve.hpp
+++ b/example/fenl/CGSolve.hpp
@@ -67,7 +67,7 @@ struct CGSolve ;
 template< class ImportType , class SparseMatrixType , class VectorType >
 struct CGSolve< ImportType , SparseMatrixType , VectorType ,
   typename std::enable_if<(
-    Kokkos::Impl::is_view< VectorType >::value &&
+    Kokkos::is_view< VectorType >::value &&
     VectorType::rank == 1
   )>::type >
 {

--- a/perf_test/blas/blas1/KokkosBlas_team_dot_perf_test.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_team_dot_perf_test.cpp
@@ -97,9 +97,8 @@ int parse_inputs(Params& params, int argc, char** argv) {
 template <class Vector, class ExecSpace>
 struct teamDotFunctor {
   // Compile - time check to see if your data type is a Kokkos::View:
-  static_assert(Kokkos::Impl::is_view<Vector>::value,
-                "Vector is not a "
-                "Kokkos::View.");
+  static_assert(Kokkos::is_view<Vector>::value,
+                "Vector is not a Kokkos::View.");
 
   using Scalar = typename Vector::non_const_value_type;
   // Vector is templated on memory space

--- a/src/batched/dense/KokkosBatched_Gemm_Decl.hpp
+++ b/src/batched/dense/KokkosBatched_Gemm_Decl.hpp
@@ -319,11 +319,11 @@ int BatchedGemm(BatchedGemmHandleType *const handle, const ScalarType alpha,
   size_t c_m, c_n;
   using ViewValueType = typename CViewType::value_type;
   // Check for valid input views
-  static_assert(Kokkos::Impl::is_view<AViewType>::value,
+  static_assert(Kokkos::is_view<AViewType>::value,
                 "AViewType must be a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<BViewType>::value,
+  static_assert(Kokkos::is_view<BViewType>::value,
                 "BViewType must be a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<CViewType>::value,
+  static_assert(Kokkos::is_view<CViewType>::value,
                 "CViewType must be a Kokkos::View.");
   if (is_vector<ViewValueType>::value) {
     // Check ranks of view with underlying SIMD value types

--- a/src/batched/dense/impl/KokkosBatched_Axpy_Impl.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Axpy_Impl.hpp
@@ -208,11 +208,11 @@ KOKKOS_INLINE_FUNCTION int SerialAxpy::invoke(const alphaViewType& alpha,
                                               const XViewType& X,
                                               const YViewType& Y) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-  static_assert(Kokkos::Impl::is_view<XViewType>::value,
+  static_assert(Kokkos::is_view<XViewType>::value,
                 "KokkosBatched::axpy: XViewType is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<YViewType>::value,
+  static_assert(Kokkos::is_view<YViewType>::value,
                 "KokkosBatched::axpy: YViewType is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<alphaViewType>::value,
+  static_assert(Kokkos::is_view<alphaViewType>::value,
                 "KokkosBatched::axpy: alphaViewType is not a Kokkos::View.");
   static_assert(XViewType::Rank == 2,
                 "KokkosBatched::axpy: XViewType must have rank 2.");
@@ -255,11 +255,11 @@ KOKKOS_INLINE_FUNCTION int TeamAxpy<MemberType>::invoke(
     const MemberType& member, const alphaViewType& alpha, const XViewType& X,
     const YViewType& Y) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-  static_assert(Kokkos::Impl::is_view<XViewType>::value,
+  static_assert(Kokkos::is_view<XViewType>::value,
                 "KokkosBatched::axpy: XViewType is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<YViewType>::value,
+  static_assert(Kokkos::is_view<YViewType>::value,
                 "KokkosBatched::axpy: YViewType is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<alphaViewType>::value,
+  static_assert(Kokkos::is_view<alphaViewType>::value,
                 "KokkosBatched::axpy: alphaViewType is not a Kokkos::View.");
   static_assert(XViewType::Rank == 2,
                 "KokkosBatched::axpy: XViewType must have rank 2.");
@@ -303,11 +303,11 @@ KOKKOS_INLINE_FUNCTION int TeamVectorAxpy<MemberType>::invoke(
     const MemberType& member, const alphaViewType& alpha, const XViewType& X,
     const YViewType& Y) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-  static_assert(Kokkos::Impl::is_view<XViewType>::value,
+  static_assert(Kokkos::is_view<XViewType>::value,
                 "KokkosBatched::axpy: XViewType is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<YViewType>::value,
+  static_assert(Kokkos::is_view<YViewType>::value,
                 "KokkosBatched::axpy: YViewType is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<alphaViewType>::value,
+  static_assert(Kokkos::is_view<alphaViewType>::value,
                 "KokkosBatched::axpy: alphaViewType is not a Kokkos::View.");
   static_assert(XViewType::Rank == 2,
                 "KokkosBatched::axpy: XViewType must have rank 2.");

--- a/src/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
@@ -156,11 +156,11 @@ struct SerialDot<Trans::Transpose> {
                                            const YViewType &Y,
                                            const NormViewType &dot) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-    static_assert(Kokkos::Impl::is_view<XViewType>::value,
+    static_assert(Kokkos::is_view<XViewType>::value,
                   "KokkosBatched::dot: XViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YViewType>::value,
+    static_assert(Kokkos::is_view<YViewType>::value,
                   "KokkosBatched::dot: YViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<NormViewType>::value,
+    static_assert(Kokkos::is_view<NormViewType>::value,
                   "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
     static_assert(XViewType::Rank == 2,
                   "KokkosBatched::dot: XViewType must have rank 2.");
@@ -202,11 +202,11 @@ struct SerialDot<Trans::NoTranspose> {
                                            const YViewType &Y,
                                            const NormViewType &dot) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-    static_assert(Kokkos::Impl::is_view<XViewType>::value,
+    static_assert(Kokkos::is_view<XViewType>::value,
                   "KokkosBatched::dot: XViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YViewType>::value,
+    static_assert(Kokkos::is_view<YViewType>::value,
                   "KokkosBatched::dot: YViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<NormViewType>::value,
+    static_assert(Kokkos::is_view<NormViewType>::value,
                   "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
     static_assert(XViewType::Rank == 2,
                   "KokkosBatched::dot: XViewType must have rank 2.");
@@ -251,11 +251,11 @@ struct TeamDot<MemberType, Trans::Transpose> {
                                            const YViewType &Y,
                                            const NormViewType &dot) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-    static_assert(Kokkos::Impl::is_view<XViewType>::value,
+    static_assert(Kokkos::is_view<XViewType>::value,
                   "KokkosBatched::dot: XViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YViewType>::value,
+    static_assert(Kokkos::is_view<YViewType>::value,
                   "KokkosBatched::dot: YViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<NormViewType>::value,
+    static_assert(Kokkos::is_view<NormViewType>::value,
                   "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
     static_assert(XViewType::Rank == 2,
                   "KokkosBatched::dot: XViewType must have rank 2.");
@@ -298,11 +298,11 @@ struct TeamDot<MemberType, Trans::NoTranspose> {
                                            const YViewType &Y,
                                            const NormViewType &dot) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-    static_assert(Kokkos::Impl::is_view<XViewType>::value,
+    static_assert(Kokkos::is_view<XViewType>::value,
                   "KokkosBatched::dot: XViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YViewType>::value,
+    static_assert(Kokkos::is_view<YViewType>::value,
                   "KokkosBatched::dot: YViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<NormViewType>::value,
+    static_assert(Kokkos::is_view<NormViewType>::value,
                   "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
     static_assert(XViewType::Rank == 2,
                   "KokkosBatched::dot: XViewType must have rank 2.");
@@ -347,11 +347,11 @@ struct TeamVectorDot<MemberType, Trans::Transpose> {
                                            const YViewType &Y,
                                            const NormViewType &dot) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-    static_assert(Kokkos::Impl::is_view<XViewType>::value,
+    static_assert(Kokkos::is_view<XViewType>::value,
                   "KokkosBatched::dot: XViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YViewType>::value,
+    static_assert(Kokkos::is_view<YViewType>::value,
                   "KokkosBatched::dot: YViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<NormViewType>::value,
+    static_assert(Kokkos::is_view<NormViewType>::value,
                   "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
     static_assert(XViewType::Rank == 2,
                   "KokkosBatched::dot: XViewType must have rank 2.");
@@ -394,11 +394,11 @@ struct TeamVectorDot<MemberType, Trans::NoTranspose> {
                                            const YViewType &Y,
                                            const NormViewType &dot) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-    static_assert(Kokkos::Impl::is_view<XViewType>::value,
+    static_assert(Kokkos::is_view<XViewType>::value,
                   "KokkosBatched::dot: XViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YViewType>::value,
+    static_assert(Kokkos::is_view<YViewType>::value,
                   "KokkosBatched::dot: YViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<NormViewType>::value,
+    static_assert(Kokkos::is_view<NormViewType>::value,
                   "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
     static_assert(XViewType::Rank == 2,
                   "KokkosBatched::dot: XViewType must have rank 2.");

--- a/src/batched/dense/impl/KokkosBatched_Xpay_Impl.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Xpay_Impl.hpp
@@ -219,9 +219,9 @@ KOKKOS_INLINE_FUNCTION int SerialXpay::invoke(const alphaViewType& alpha,
                                               const ViewType& X,
                                               const ViewType& Y) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-  static_assert(Kokkos::Impl::is_view<ViewType>::value,
+  static_assert(Kokkos::is_view<ViewType>::value,
                 "KokkosBatched::xpay: ViewType is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<alphaViewType>::value,
+  static_assert(Kokkos::is_view<alphaViewType>::value,
                 "KokkosBatched::xpay: alphaViewType is not a Kokkos::View.");
   static_assert(ViewType::Rank == 2,
                 "KokkosBatched::xpay: ViewType must have rank 2.");
@@ -262,9 +262,9 @@ KOKKOS_INLINE_FUNCTION int TeamXpay<MemberType>::invoke(
     const MemberType& member, const alphaViewType& alpha, const ViewType& X,
     const ViewType& Y) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-  static_assert(Kokkos::Impl::is_view<ViewType>::value,
+  static_assert(Kokkos::is_view<ViewType>::value,
                 "KokkosBatched::xpay: ViewType is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<alphaViewType>::value,
+  static_assert(Kokkos::is_view<alphaViewType>::value,
                 "KokkosBatched::xpay: alphaViewType is not a Kokkos::View.");
   static_assert(ViewType::Rank == 2,
                 "KokkosBatched::xpay: ViewType must have rank 2.");
@@ -306,9 +306,9 @@ KOKKOS_INLINE_FUNCTION int TeamVectorXpay<MemberType>::invoke(
     const MemberType& member, const alphaViewType& alpha, const ViewType& X,
     const ViewType& Y) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-  static_assert(Kokkos::Impl::is_view<ViewType>::value,
+  static_assert(Kokkos::is_view<ViewType>::value,
                 "KokkosBatched::xpay: ViewType is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<alphaViewType>::value,
+  static_assert(Kokkos::is_view<alphaViewType>::value,
                 "KokkosBatched::xpay: alphaViewType is not a Kokkos::View.");
   static_assert(ViewType::Rank == 2,
                 "KokkosBatched::xpay: ViewType must have rank 2.");

--- a/src/batched/sparse/impl/KokkosBatched_Spmv_Serial_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_Spmv_Serial_Impl.hpp
@@ -151,17 +151,17 @@ struct SerialSpmv<Trans::NoTranspose> {
       const IntView& row_ptr, const IntView& colIndices, const xViewType& X,
       const betaViewType& beta, const yViewType& Y) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-    static_assert(Kokkos::Impl::is_view<ValuesViewType>::value,
+    static_assert(Kokkos::is_view<ValuesViewType>::value,
                   "KokkosBatched::spmv: ValuesViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<IntView>::value,
+    static_assert(Kokkos::is_view<IntView>::value,
                   "KokkosBatched::spmv: IntView is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<xViewType>::value,
+    static_assert(Kokkos::is_view<xViewType>::value,
                   "KokkosBatched::spmv: xViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<yViewType>::value,
+    static_assert(Kokkos::is_view<yViewType>::value,
                   "KokkosBatched::spmv: yViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<alphaViewType>::value,
+    static_assert(Kokkos::is_view<alphaViewType>::value,
                   "KokkosBatched::spmv: alphaViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<betaViewType>::value,
+    static_assert(Kokkos::is_view<betaViewType>::value,
                   "KokkosBatched::spmv: betaViewType is not a Kokkos::View.");
 
     static_assert(ValuesViewType::Rank == 2,
@@ -249,13 +249,13 @@ struct SerialSpmv<Trans::NoTranspose> {
           typename ValuesViewType::non_const_value_type>::mag_type& beta,
       const yViewType& Y) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-    static_assert(Kokkos::Impl::is_view<ValuesViewType>::value,
+    static_assert(Kokkos::is_view<ValuesViewType>::value,
                   "KokkosBatched::spmv: ValuesViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<IntView>::value,
+    static_assert(Kokkos::is_view<IntView>::value,
                   "KokkosBatched::spmv: IntView is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<xViewType>::value,
+    static_assert(Kokkos::is_view<xViewType>::value,
                   "KokkosBatched::spmv: xViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<yViewType>::value,
+    static_assert(Kokkos::is_view<yViewType>::value,
                   "KokkosBatched::spmv: yViewType is not a Kokkos::View.");
 
     static_assert(ValuesViewType::Rank == 2,

--- a/src/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
@@ -189,17 +189,17 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose> {
       const IntView& colIndices, const xViewType& X, const betaViewType& beta,
       const yViewType& Y) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-    static_assert(Kokkos::Impl::is_view<ValuesViewType>::value,
+    static_assert(Kokkos::is_view<ValuesViewType>::value,
                   "KokkosBatched::spmv: ValuesViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<IntView>::value,
+    static_assert(Kokkos::is_view<IntView>::value,
                   "KokkosBatched::spmv: IntView is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<xViewType>::value,
+    static_assert(Kokkos::is_view<xViewType>::value,
                   "KokkosBatched::spmv: xViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<yViewType>::value,
+    static_assert(Kokkos::is_view<yViewType>::value,
                   "KokkosBatched::spmv: yViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<alphaViewType>::value,
+    static_assert(Kokkos::is_view<alphaViewType>::value,
                   "KokkosBatched::spmv: alphaViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<betaViewType>::value,
+    static_assert(Kokkos::is_view<betaViewType>::value,
                   "KokkosBatched::spmv: betaViewType is not a Kokkos::View.");
 
     static_assert(ValuesViewType::Rank == 2,
@@ -292,13 +292,13 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose> {
           typename ValuesViewType::non_const_value_type>::mag_type& beta,
       const yViewType& Y) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-    static_assert(Kokkos::Impl::is_view<ValuesViewType>::value,
+    static_assert(Kokkos::is_view<ValuesViewType>::value,
                   "KokkosBatched::spmv: ValuesViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<IntView>::value,
+    static_assert(Kokkos::is_view<IntView>::value,
                   "KokkosBatched::spmv: IntView is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<xViewType>::value,
+    static_assert(Kokkos::is_view<xViewType>::value,
                   "KokkosBatched::spmv: xViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<yViewType>::value,
+    static_assert(Kokkos::is_view<yViewType>::value,
                   "KokkosBatched::spmv: yViewType is not a Kokkos::View.");
 
     static_assert(ValuesViewType::Rank == 2,

--- a/src/batched/sparse/impl/KokkosBatched_Spmv_Team_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_Spmv_Team_Impl.hpp
@@ -189,17 +189,17 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
       const IntView& colIndices, const xViewType& X, const betaViewType& beta,
       const yViewType& Y) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-    static_assert(Kokkos::Impl::is_view<ValuesViewType>::value,
+    static_assert(Kokkos::is_view<ValuesViewType>::value,
                   "KokkosBatched::spmv: ValuesViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<IntView>::value,
+    static_assert(Kokkos::is_view<IntView>::value,
                   "KokkosBatched::spmv: IntView is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<xViewType>::value,
+    static_assert(Kokkos::is_view<xViewType>::value,
                   "KokkosBatched::spmv: xViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<yViewType>::value,
+    static_assert(Kokkos::is_view<yViewType>::value,
                   "KokkosBatched::spmv: yViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<alphaViewType>::value,
+    static_assert(Kokkos::is_view<alphaViewType>::value,
                   "KokkosBatched::spmv: alphaViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<betaViewType>::value,
+    static_assert(Kokkos::is_view<betaViewType>::value,
                   "KokkosBatched::spmv: betaViewType is not a Kokkos::View.");
 
     static_assert(ValuesViewType::Rank == 2,
@@ -288,13 +288,13 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
           typename ValuesViewType::non_const_value_type>::mag_type& beta,
       const yViewType& Y) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-    static_assert(Kokkos::Impl::is_view<ValuesViewType>::value,
+    static_assert(Kokkos::is_view<ValuesViewType>::value,
                   "KokkosBatched::spmv: ValuesViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<IntView>::value,
+    static_assert(Kokkos::is_view<IntView>::value,
                   "KokkosBatched::spmv: IntView is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<xViewType>::value,
+    static_assert(Kokkos::is_view<xViewType>::value,
                   "KokkosBatched::spmv: xViewType is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<yViewType>::value,
+    static_assert(Kokkos::is_view<yViewType>::value,
                   "KokkosBatched::spmv: yViewType is not a Kokkos::View.");
 
     static_assert(ValuesViewType::Rank == 2,

--- a/src/blas/KokkosBlas1_abs.hpp
+++ b/src/blas/KokkosBlas1_abs.hpp
@@ -61,10 +61,10 @@ namespace KokkosBlas {
 ///   those of RMV.
 template <class RMV, class XMV>
 void abs(const RMV& R, const XMV& X) {
-  static_assert(Kokkos::Impl::is_view<RMV>::value,
+  static_assert(Kokkos::is_view<RMV>::value,
                 "KokkosBlas::abs: "
                 "R is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::abs: "
                 "X is not a Kokkos::View.");
   static_assert(std::is_same<typename RMV::value_type,

--- a/src/blas/KokkosBlas1_axpby.hpp
+++ b/src/blas/KokkosBlas1_axpby.hpp
@@ -58,10 +58,10 @@ namespace KokkosBlas {
 
 template <class AV, class XMV, class BV, class YMV>
 void axpby(const AV& a, const XMV& X, const BV& b, const YMV& Y) {
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::axpby: "
                 "X is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<YMV>::value,
+  static_assert(Kokkos::is_view<YMV>::value,
                 "KokkosBlas::axpby: "
                 "Y is not a Kokkos::View.");
   static_assert(std::is_same<typename YMV::value_type,

--- a/src/blas/KokkosBlas1_dot.hpp
+++ b/src/blas/KokkosBlas1_dot.hpp
@@ -63,9 +63,9 @@ template <class XVector, class YVector>
 typename Kokkos::Details::InnerProductSpaceTraits<
     typename XVector::non_const_value_type>::dot_type
 dot(const XVector& x, const YVector& y) {
-  static_assert(Kokkos::Impl::is_view<XVector>::value,
+  static_assert(Kokkos::is_view<XVector>::value,
                 "KokkosBlas::dot: XVector must be a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<YVector>::value,
+  static_assert(Kokkos::is_view<YVector>::value,
                 "KokkosBlas::dot: YVector must be a Kokkos::View.");
   static_assert((int)XVector::rank == (int)YVector::rank,
                 "KokkosBlas::dot: Vector ranks do not match.");
@@ -155,16 +155,15 @@ dot(const XVector& x, const YVector& y) {
 ///   doesn't confuse this version of dot() with the three-argument
 ///   version of dot() in Kokkos_Blas1.hpp.
 template <class RV, class XMV, class YMV>
-void dot(
-    const RV& R, const XMV& X, const YMV& Y,
-    typename std::enable_if<Kokkos::Impl::is_view<RV>::value, int>::type = 0) {
-  static_assert(Kokkos::Impl::is_view<RV>::value,
+void dot(const RV& R, const XMV& X, const YMV& Y,
+         typename std::enable_if<Kokkos::is_view<RV>::value, int>::type = 0) {
+  static_assert(Kokkos::is_view<RV>::value,
                 "KokkosBlas::dot: "
                 "R is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::dot: "
                 "X is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<YMV>::value,
+  static_assert(Kokkos::is_view<YMV>::value,
                 "KokkosBlas::dot: "
                 "Y is not a Kokkos::View.");
   static_assert(std::is_same<typename RV::value_type,

--- a/src/blas/KokkosBlas1_iamax.hpp
+++ b/src/blas/KokkosBlas1_iamax.hpp
@@ -62,7 +62,7 @@ namespace KokkosBlas {
 ///         Note: Returned index is 1-based for compatibility with Fortran.
 template <class XVector>
 typename XVector::size_type iamax(const XVector& x) {
-  static_assert(Kokkos::Impl::is_view<XVector>::value,
+  static_assert(Kokkos::is_view<XVector>::value,
                 "KokkosBlas::iamax: XVector must be a Kokkos::View.");
   static_assert(XVector::rank == 1,
                 "KokkosBlas::iamax: "
@@ -101,13 +101,12 @@ typename XVector::size_type iamax(const XVector& x) {
 /// Note for TPL cuBLAS: When TPL cuBLAS iamax is used and returns result to a
 /// view, RMV must be 0-D view and XMV must be 1-D view.
 template <class RV, class XMV>
-void iamax(
-    const RV& R, const XMV& X,
-    typename std::enable_if<Kokkos::Impl::is_view<RV>::value, int>::type = 0) {
-  static_assert(Kokkos::Impl::is_view<RV>::value,
+void iamax(const RV& R, const XMV& X,
+           typename std::enable_if<Kokkos::is_view<RV>::value, int>::type = 0) {
+  static_assert(Kokkos::is_view<RV>::value,
                 "KokkosBlas::iamax: "
                 "R is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::iamax: "
                 "X is not a Kokkos::View.");
   static_assert(std::is_same<typename RV::value_type,

--- a/src/blas/KokkosBlas1_mult.hpp
+++ b/src/blas/KokkosBlas1_mult.hpp
@@ -53,10 +53,10 @@ namespace KokkosBlas {
 template <class YMV, class AV, class XMV>
 void mult(typename YMV::const_value_type& gamma, const YMV& Y,
           typename AV::const_value_type& alpha, const AV& A, const XMV& X) {
-  static_assert(Kokkos::Impl::is_view<YMV>::value,
+  static_assert(Kokkos::is_view<YMV>::value,
                 "KokkosBlas::mult: "
                 "Y is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<AV>::value,
+  static_assert(Kokkos::is_view<AV>::value,
                 "KokkosBlas::mult: "
                 "A is not a Kokkos::View.");
   static_assert(std::is_same<typename YMV::value_type,

--- a/src/blas/KokkosBlas1_nrm1.hpp
+++ b/src/blas/KokkosBlas1_nrm1.hpp
@@ -61,7 +61,7 @@ template <class XVector>
 typename Kokkos::Details::InnerProductSpaceTraits<
     typename XVector::non_const_value_type>::mag_type
 nrm1(const XVector& x) {
-  static_assert(Kokkos::Impl::is_view<XVector>::value,
+  static_assert(Kokkos::is_view<XVector>::value,
                 "KokkosBlas::nrm1: XVector must be a Kokkos::View.");
   static_assert(XVector::rank == 1,
                 "KokkosBlas::nrm1: "
@@ -99,13 +99,12 @@ nrm1(const XVector& x) {
 ///   the same rank as RMV, and its entries must be assignable to
 ///   those of RMV.
 template <class RV, class XMV>
-void nrm1(
-    const RV& R, const XMV& X,
-    typename std::enable_if<Kokkos::Impl::is_view<RV>::value, int>::type = 0) {
-  static_assert(Kokkos::Impl::is_view<RV>::value,
+void nrm1(const RV& R, const XMV& X,
+          typename std::enable_if<Kokkos::is_view<RV>::value, int>::type = 0) {
+  static_assert(Kokkos::is_view<RV>::value,
                 "KokkosBlas::nrm1: "
                 "R is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::nrm1: "
                 "X is not a Kokkos::View.");
   static_assert(std::is_same<typename RV::value_type,

--- a/src/blas/KokkosBlas1_nrm2.hpp
+++ b/src/blas/KokkosBlas1_nrm2.hpp
@@ -61,7 +61,7 @@ template <class XVector>
 typename Kokkos::Details::InnerProductSpaceTraits<
     typename XVector::non_const_value_type>::mag_type
 nrm2(const XVector& x) {
-  static_assert(Kokkos::Impl::is_view<XVector>::value,
+  static_assert(Kokkos::is_view<XVector>::value,
                 "KokkosBlas::nrm2: XVector must be a Kokkos::View.");
   static_assert(XVector::rank == 1,
                 "KokkosBlas::nrm2: "
@@ -99,13 +99,12 @@ nrm2(const XVector& x) {
 ///   the same rank as RMV, and its entries must be assignable to
 ///   those of RMV.
 template <class RV, class XMV>
-void nrm2(
-    const RV& R, const XMV& X,
-    typename std::enable_if<Kokkos::Impl::is_view<RV>::value, int>::type = 0) {
-  static_assert(Kokkos::Impl::is_view<RV>::value,
+void nrm2(const RV& R, const XMV& X,
+          typename std::enable_if<Kokkos::is_view<RV>::value, int>::type = 0) {
+  static_assert(Kokkos::is_view<RV>::value,
                 "KokkosBlas::nrm2: "
                 "R is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::nrm2: "
                 "X is not a Kokkos::View.");
   static_assert(std::is_same<typename RV::value_type,

--- a/src/blas/KokkosBlas1_nrm2_squared.hpp
+++ b/src/blas/KokkosBlas1_nrm2_squared.hpp
@@ -61,7 +61,7 @@ template <class XVector>
 typename Kokkos::Details::InnerProductSpaceTraits<
     typename XVector::non_const_value_type>::mag_type
 nrm2_squared(const XVector& x) {
-  static_assert(Kokkos::Impl::is_view<XVector>::value,
+  static_assert(Kokkos::is_view<XVector>::value,
                 "KokkosBlas::nrm2_squared: XVector must be a Kokkos::View.");
   static_assert(XVector::rank == 1,
                 "KokkosBlas::nrm2_squared: "
@@ -102,11 +102,11 @@ nrm2_squared(const XVector& x) {
 template <class RV, class XMV>
 void nrm2_squared(
     const RV& R, const XMV& X,
-    typename std::enable_if<Kokkos::Impl::is_view<RV>::value, int>::type = 0) {
-  static_assert(Kokkos::Impl::is_view<RV>::value,
+    typename std::enable_if<Kokkos::is_view<RV>::value, int>::type = 0) {
+  static_assert(Kokkos::is_view<RV>::value,
                 "KokkosBlas::nrm2_squared: "
                 "R is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::nrm2_squared: "
                 "X is not a Kokkos::View.");
   static_assert(std::is_same<typename RV::value_type,

--- a/src/blas/KokkosBlas1_nrm2w.hpp
+++ b/src/blas/KokkosBlas1_nrm2w.hpp
@@ -61,7 +61,7 @@ template <class XVector>
 typename Kokkos::Details::InnerProductSpaceTraits<
     typename XVector::non_const_value_type>::mag_type
 nrm2w(const XVector& x, const XVector& w) {
-  static_assert(Kokkos::Impl::is_view<XVector>::value,
+  static_assert(Kokkos::is_view<XVector>::value,
                 "KokkosBlas::nrm2w: XVector must be a Kokkos::View.");
   static_assert(XVector::rank == 1,
                 "KokkosBlas::nrm2w: "
@@ -99,13 +99,12 @@ nrm2w(const XVector& x, const XVector& w) {
 ///   the same rank as RMV, and its entries must be assignable to
 ///   those of RMV.
 template <class RV, class XMV>
-void nrm2w(
-    const RV& R, const XMV& X, const XMV& W,
-    typename std::enable_if<Kokkos::Impl::is_view<RV>::value, int>::type = 0) {
-  static_assert(Kokkos::Impl::is_view<RV>::value,
+void nrm2w(const RV& R, const XMV& X, const XMV& W,
+           typename std::enable_if<Kokkos::is_view<RV>::value, int>::type = 0) {
+  static_assert(Kokkos::is_view<RV>::value,
                 "KokkosBlas::nrm2w: "
                 "R is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::nrm2w: "
                 "X is not a Kokkos::View.");
   static_assert(std::is_same<typename RV::value_type,

--- a/src/blas/KokkosBlas1_nrm2w_squared.hpp
+++ b/src/blas/KokkosBlas1_nrm2w_squared.hpp
@@ -61,7 +61,7 @@ template <class XVector>
 typename Kokkos::Details::InnerProductSpaceTraits<
     typename XVector::non_const_value_type>::mag_type
 nrm2w_squared(const XVector& x, const XVector& w) {
-  static_assert(Kokkos::Impl::is_view<XVector>::value,
+  static_assert(Kokkos::is_view<XVector>::value,
                 "KokkosBlas::nrm2w_squared: XVector must be a Kokkos::View.");
   static_assert(XVector::rank == 1,
                 "KokkosBlas::nrm2w_squared: "
@@ -102,11 +102,11 @@ nrm2w_squared(const XVector& x, const XVector& w) {
 template <class RV, class XMV>
 void nrm2w_squared(
     const RV& R, const XMV& X, const XMV& W,
-    typename std::enable_if<Kokkos::Impl::is_view<RV>::value, int>::type = 0) {
-  static_assert(Kokkos::Impl::is_view<RV>::value,
+    typename std::enable_if<Kokkos::is_view<RV>::value, int>::type = 0) {
+  static_assert(Kokkos::is_view<RV>::value,
                 "KokkosBlas::nrm2w_squared: "
                 "R is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::nrm2w_squared: "
                 "X is not a Kokkos::View.");
   static_assert(std::is_same<typename RV::value_type,

--- a/src/blas/KokkosBlas1_nrminf.hpp
+++ b/src/blas/KokkosBlas1_nrminf.hpp
@@ -61,7 +61,7 @@ template <class XVector>
 typename Kokkos::Details::InnerProductSpaceTraits<
     typename XVector::non_const_value_type>::mag_type
 nrminf(const XVector& x) {
-  static_assert(Kokkos::Impl::is_view<XVector>::value,
+  static_assert(Kokkos::is_view<XVector>::value,
                 "KokkosBlas::nrminf: XVector must be a Kokkos::View.");
   static_assert(XVector::rank == 1,
                 "KokkosBlas::nrminf: "
@@ -101,11 +101,11 @@ nrminf(const XVector& x) {
 template <class RV, class XMV>
 void nrminf(
     const RV& R, const XMV& X,
-    typename std::enable_if<Kokkos::Impl::is_view<RV>::value, int>::type = 0) {
-  static_assert(Kokkos::Impl::is_view<RV>::value,
+    typename std::enable_if<Kokkos::is_view<RV>::value, int>::type = 0) {
+  static_assert(Kokkos::is_view<RV>::value,
                 "KokkosBlas::nrminf: "
                 "R is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::nrminf: "
                 "X is not a Kokkos::View.");
   static_assert(std::is_same<typename RV::value_type,

--- a/src/blas/KokkosBlas1_reciprocal.hpp
+++ b/src/blas/KokkosBlas1_reciprocal.hpp
@@ -61,10 +61,10 @@ namespace KokkosBlas {
 ///   those of RMV.
 template <class RMV, class XMV>
 void reciprocal(const RMV& R, const XMV& X) {
-  static_assert(Kokkos::Impl::is_view<RMV>::value,
+  static_assert(Kokkos::is_view<RMV>::value,
                 "KokkosBlas::reciprocal: "
                 "R is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::reciprocal: "
                 "X is not a Kokkos::View.");
   static_assert(std::is_same<typename RMV::value_type,

--- a/src/blas/KokkosBlas1_scal.hpp
+++ b/src/blas/KokkosBlas1_scal.hpp
@@ -52,10 +52,10 @@ namespace KokkosBlas {
 
 template <class RMV, class AV, class XMV>
 void scal(const RMV& R, const AV& a, const XMV& X) {
-  static_assert(Kokkos::Impl::is_view<RMV>::value,
+  static_assert(Kokkos::is_view<RMV>::value,
                 "KokkosBlas::scal: "
                 "R is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::scal: "
                 "X is not a Kokkos::View.");
   static_assert(std::is_same<typename RMV::value_type,

--- a/src/blas/KokkosBlas1_sum.hpp
+++ b/src/blas/KokkosBlas1_sum.hpp
@@ -59,7 +59,7 @@ namespace KokkosBlas {
 /// \return The sum product result; a single value.
 template <class XVector>
 typename XVector::non_const_value_type sum(const XVector& x) {
-  static_assert(Kokkos::Impl::is_view<XVector>::value,
+  static_assert(Kokkos::is_view<XVector>::value,
                 "KokkosBlas::sum: XVector must be a Kokkos::View.");
   static_assert(XVector::rank == 1,
                 "KokkosBlas::sum: "
@@ -96,13 +96,12 @@ typename XVector::non_const_value_type sum(const XVector& x) {
 ///   the same rank as RMV, and its entries must be assignable to
 ///   those of RMV.
 template <class RV, class XMV>
-void sum(
-    const RV& R, const XMV& X,
-    typename std::enable_if<Kokkos::Impl::is_view<RV>::value, int>::type = 0) {
-  static_assert(Kokkos::Impl::is_view<RV>::value,
+void sum(const RV& R, const XMV& X,
+         typename std::enable_if<Kokkos::is_view<RV>::value, int>::type = 0) {
+  static_assert(Kokkos::is_view<RV>::value,
                 "KokkosBlas::sum: "
                 "R is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::sum: "
                 "X is not a Kokkos::View.");
   static_assert(std::is_same<typename RV::value_type,

--- a/src/blas/KokkosBlas1_update.hpp
+++ b/src/blas/KokkosBlas1_update.hpp
@@ -63,13 +63,13 @@ template <class XMV, class YMV, class ZMV>
 void update(const typename XMV::non_const_value_type& alpha, const XMV& X,
             const typename YMV::non_const_value_type& beta, const YMV& Y,
             const typename ZMV::non_const_value_type& gamma, const ZMV& Z) {
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::update: "
                 "X is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<YMV>::value,
+  static_assert(Kokkos::is_view<YMV>::value,
                 "KokkosBlas::update: "
                 "Y is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<ZMV>::value,
+  static_assert(Kokkos::is_view<ZMV>::value,
                 "KokkosBlas::update: "
                 "Z is not a Kokkos::View.");
   static_assert(std::is_same<typename ZMV::value_type,

--- a/src/blas/KokkosBlas2_gemv.hpp
+++ b/src/blas/KokkosBlas2_gemv.hpp
@@ -79,11 +79,11 @@ void gemv(const typename AViewType::execution_space& space, const char trans[],
           typename AViewType::const_value_type& alpha, const AViewType& A,
           const XViewType& x, typename YViewType::const_value_type& beta,
           const YViewType& y) {
-  static_assert(Kokkos::Impl::is_view<AViewType>::value,
+  static_assert(Kokkos::is_view<AViewType>::value,
                 "AViewType must be a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XViewType>::value,
+  static_assert(Kokkos::is_view<XViewType>::value,
                 "XViewType must be a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<YViewType>::value,
+  static_assert(Kokkos::is_view<YViewType>::value,
                 "YViewType must be a Kokkos::View.");
   static_assert(static_cast<int>(AViewType::rank) == 2,
                 "AViewType must have rank 2.");

--- a/src/blas/KokkosBlas3_gemm.hpp
+++ b/src/blas/KokkosBlas3_gemm.hpp
@@ -140,11 +140,11 @@ void gemm(const typename CViewType::execution_space& space, const char transA[],
           const AViewType& A, const BViewType& B,
           typename CViewType::const_value_type& beta, const CViewType& C) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-  static_assert(Kokkos::Impl::is_view<AViewType>::value,
+  static_assert(Kokkos::is_view<AViewType>::value,
                 "AViewType must be a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<BViewType>::value,
+  static_assert(Kokkos::is_view<BViewType>::value,
                 "BViewType must be a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<CViewType>::value,
+  static_assert(Kokkos::is_view<CViewType>::value,
                 "CViewType must be a Kokkos::View.");
   static_assert(static_cast<int>(AViewType::rank) == 2,
                 "AViewType must have rank 2.");

--- a/src/blas/KokkosBlas3_trmm.hpp
+++ b/src/blas/KokkosBlas3_trmm.hpp
@@ -87,9 +87,9 @@ template <class AViewType, class BViewType>
 void trmm(const char side[], const char uplo[], const char trans[],
           const char diag[], typename BViewType::const_value_type& alpha,
           const AViewType& A, const BViewType& B) {
-  static_assert(Kokkos::Impl::is_view<AViewType>::value,
+  static_assert(Kokkos::is_view<AViewType>::value,
                 "AViewType must be a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<BViewType>::value,
+  static_assert(Kokkos::is_view<BViewType>::value,
                 "BViewType must be a Kokkos::View.");
   static_assert(static_cast<int>(AViewType::rank) == 2,
                 "AViewType must have rank 2.");

--- a/src/blas/KokkosBlas3_trsm.hpp
+++ b/src/blas/KokkosBlas3_trsm.hpp
@@ -84,9 +84,9 @@ template <class AViewType, class BViewType>
 void trsm(const char side[], const char uplo[], const char trans[],
           const char diag[], typename BViewType::const_value_type& alpha,
           const AViewType& A, const BViewType& B) {
-  static_assert(Kokkos::Impl::is_view<AViewType>::value,
+  static_assert(Kokkos::is_view<AViewType>::value,
                 "AViewType must be a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<BViewType>::value,
+  static_assert(Kokkos::is_view<BViewType>::value,
                 "BViewType must be a Kokkos::View.");
   static_assert(static_cast<int>(AViewType::rank) == 2,
                 "AViewType must have rank 2.");

--- a/src/blas/KokkosBlas_gesv.hpp
+++ b/src/blas/KokkosBlas_gesv.hpp
@@ -82,11 +82,11 @@ void gesv(const AMatrix& A, const BXMV& B, const IPIVV& IPIV) {
   //       device views BLAS TPL should be enabled to call the BLAS interface
   //       for host views
 
-  static_assert(Kokkos::Impl::is_view<AMatrix>::value,
+  static_assert(Kokkos::is_view<AMatrix>::value,
                 "KokkosBlas::gesv: A must be a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<BXMV>::value,
+  static_assert(Kokkos::is_view<BXMV>::value,
                 "KokkosBlas::gesv: B must be a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<IPIVV>::value,
+  static_assert(Kokkos::is_view<IPIVV>::value,
                 "KokkosBlas::gesv: IPIV must be a Kokkos::View.");
   static_assert(static_cast<int>(AMatrix::rank) == 2,
                 "KokkosBlas::gesv: A must have rank 2.");

--- a/src/blas/KokkosBlas_trtri.hpp
+++ b/src/blas/KokkosBlas_trtri.hpp
@@ -75,7 +75,7 @@ namespace KokkosBlas {
 // source: https://software.intel.com/en-us/mkl-developer-reference-c-trtri
 template <class AViewType>
 int trtri(const char uplo[], const char diag[], const AViewType& A) {
-  static_assert(Kokkos::Impl::is_view<AViewType>::value,
+  static_assert(Kokkos::is_view<AViewType>::value,
                 "AViewType must be a Kokkos::View.");
   static_assert(static_cast<int>(AViewType::rank) == 2,
                 "AViewType must have rank 2.");

--- a/src/blas/impl/KokkosBlas1_abs_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_abs_impl.hpp
@@ -68,10 +68,10 @@ struct MV_Abs_Functor {
 
   MV_Abs_Functor(const RMV& R, const XMV& X)
       : numCols(X.extent(1)), R_(R), X_(X) {
-    static_assert(Kokkos::Impl::is_view<RMV>::value,
+    static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "MV_Abs_Functor: RMV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "MV_Abs_Functor: XMV is not a Kokkos::View.");
     static_assert(RMV::rank == 2,
@@ -104,7 +104,7 @@ struct MV_AbsSelf_Functor {
   RMV R_;
 
   MV_AbsSelf_Functor(const RMV& R) : numCols(R.extent(1)), R_(R) {
-    static_assert(Kokkos::Impl::is_view<RMV>::value,
+    static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "MV_Abs_Functor: RMV is not a Kokkos::View.");
     static_assert(RMV::rank == 2,
@@ -134,10 +134,10 @@ struct V_Abs_Functor {
   XV X_;
 
   V_Abs_Functor(const RV& R, const XV& X) : R_(R), X_(X) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
+    static_assert(Kokkos::is_view<RV>::value,
                   "KokkosBlas::Impl::"
                   "V_Abs_Functor: RV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XV>::value,
+    static_assert(Kokkos::is_view<XV>::value,
                   "KokkosBlas::Impl::"
                   "V_Abs_Functor: XV is not a Kokkos::View.");
     static_assert(RV::rank == 1,
@@ -163,7 +163,7 @@ struct V_AbsSelf_Functor {
   RV R_;
 
   V_AbsSelf_Functor(const RV& R) : R_(R) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
+    static_assert(Kokkos::is_view<RV>::value,
                   "KokkosBlas::Impl::"
                   "V_Abs_Functor: RV is not a Kokkos::View.");
     static_assert(RV::rank == 1,
@@ -179,10 +179,10 @@ struct V_AbsSelf_Functor {
 // computes entry-wise absolute value.
 template <class RMV, class XMV, class SizeType>
 void MV_Abs_Generic(const RMV& R, const XMV& X) {
-  static_assert(Kokkos::Impl::is_view<RMV>::value,
+  static_assert(Kokkos::is_view<RMV>::value,
                 "KokkosBlas::Impl::"
                 "MV_Abs_Generic: RMV is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::Impl::"
                 "MV_Abs_Generic: XMV is not a Kokkos::View.");
   static_assert(RMV::rank == 2,
@@ -209,10 +209,10 @@ void MV_Abs_Generic(const RMV& R, const XMV& X) {
 // Variant of MV_Abs_Generic for single vectors (1-D Views) R and X.
 template <class RV, class XV, class SizeType>
 void V_Abs_Generic(const RV& R, const XV& X) {
-  static_assert(Kokkos::Impl::is_view<RV>::value,
+  static_assert(Kokkos::is_view<RV>::value,
                 "KokkosBlas::Impl::"
                 "V_Abs_Generic: RV is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XV>::value,
+  static_assert(Kokkos::is_view<XV>::value,
                 "KokkosBlas::Impl::"
                 "V_Abs_Generic: XV is not a Kokkos::View.");
   static_assert(RV::rank == 1,

--- a/src/blas/impl/KokkosBlas1_abs_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_abs_spec.hpp
@@ -125,10 +125,10 @@ struct Abs<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
 
   static void abs(const RMV& R, const XMV& X) {
-    static_assert(Kokkos::Impl::is_view<RMV>::value,
+    static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Abs<1-D>: RMV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Abs<1-D>: XMV is not a Kokkos::View.");
     static_assert(RMV::rank == 1,
@@ -167,10 +167,10 @@ struct Abs<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
 
   static void abs(const RMV& R, const XMV& X) {
-    static_assert(Kokkos::Impl::is_view<RMV>::value,
+    static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Abs<2-D>: RMV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Abs<2-D>: XMV is not a Kokkos::View.");
     static_assert(RMV::rank == 2,

--- a/src/blas/impl/KokkosBlas1_axpby_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_axpby_impl.hpp
@@ -92,10 +92,10 @@ struct Axpby_Functor {
   Axpby_Functor(const XV& x, const YV& y, const AV& a, const BV& b,
                 const SizeType startingColumn)
       : m_x(x), m_y(y), m_a(a), m_b(b) {
-    static_assert(Kokkos::Impl::is_view<XV>::value,
+    static_assert(Kokkos::is_view<XV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_Functor: X is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YV>::value,
+    static_assert(Kokkos::is_view<YV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_Functor: Y is not a Kokkos::View.");
     static_assert(std::is_same<typename YV::value_type,
@@ -228,10 +228,10 @@ struct Axpby_Functor<typename XV::non_const_value_type, XV,
                 const typename YV::non_const_value_type& b,
                 const SizeType /* startingColumn */)
       : m_x(x), m_y(y), m_a(a), m_b(b) {
-    static_assert(Kokkos::Impl::is_view<XV>::value,
+    static_assert(Kokkos::is_view<XV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_Functor: X is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YV>::value,
+    static_assert(Kokkos::is_view<YV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_Functor: Y is not a Kokkos::View.");
     static_assert(std::is_same<typename YV::value_type,
@@ -333,10 +333,10 @@ struct Axpby_Functor<typename XV::non_const_value_type, XV,
 template <class AV, class XV, class BV, class YV, class SizeType>
 void Axpby_Generic(const AV& av, const XV& x, const BV& bv, const YV& y,
                    const SizeType startingColumn, int a = 2, int b = 2) {
-  static_assert(Kokkos::Impl::is_view<XV>::value,
+  static_assert(Kokkos::is_view<XV>::value,
                 "KokkosBlas::Impl::"
                 "Axpby_Generic: X is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<YV>::value,
+  static_assert(Kokkos::is_view<YV>::value,
                 "KokkosBlas::Impl::"
                 "Axpby_Generic: Y is not a Kokkos::View.");
   static_assert(std::is_same<typename YV::value_type,

--- a/src/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
@@ -84,16 +84,16 @@ struct Axpby_MV_Functor {
   Axpby_MV_Functor(const XMV& X, const YMV& Y, const AV& a, const BV& b)
       : numCols(X.extent(1)), m_x(X), m_y(Y), m_a(a), m_b(b) {
     // XMV and YMV must be Kokkos::View specializations.
-    static_assert(Kokkos::Impl::is_view<AV>::value,
+    static_assert(Kokkos::is_view<AV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Functor: a is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Functor: X is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<BV>::value,
+    static_assert(Kokkos::is_view<BV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Functor: b is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YMV>::value,
+    static_assert(Kokkos::is_view<YMV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Functor: Y is not a Kokkos::View.");
     // YMV must be nonconst (else it can't be an output argument).
@@ -328,10 +328,10 @@ struct Axpby_MV_Functor<typename XMV::non_const_value_type, XMV,
                    const typename XMV::non_const_value_type& a,
                    const typename YMV::non_const_value_type& b)
       : numCols(X.extent(1)), m_x(X), m_y(Y), m_a(a), m_b(b) {
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Functor: X is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YMV>::value,
+    static_assert(Kokkos::is_view<YMV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Functor: Y is not a Kokkos::View.");
     static_assert(std::is_same<typename YMV::value_type,
@@ -540,16 +540,16 @@ struct Axpby_MV_Unroll_Functor {
   Axpby_MV_Unroll_Functor(const XMV& x, const YMV& y, const AV& a, const BV& b,
                           const SizeType startingColumn)
       : m_x(x), m_y(y), m_a(a), m_b(b) {
-    static_assert(Kokkos::Impl::is_view<AV>::value,
+    static_assert(Kokkos::is_view<AV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Unroll_Functor: a is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Unroll_Functor: X is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<BV>::value,
+    static_assert(Kokkos::is_view<BV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Unroll_Functor: b is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YMV>::value,
+    static_assert(Kokkos::is_view<YMV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Unroll_Functor: Y is not a Kokkos::View.");
     static_assert(std::is_same<typename YMV::value_type,
@@ -770,10 +770,10 @@ struct Axpby_MV_Unroll_Functor<typename XMV::non_const_value_type, XMV,
                           const typename YMV::non_const_value_type& b,
                           const SizeType /* startingColumn */)
       : m_x(X), m_y(Y), m_a(a), m_b(b) {
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Unroll_Functor: X is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YMV>::value,
+    static_assert(Kokkos::is_view<YMV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Unroll_Functor: Y is not a Kokkos::View.");
     static_assert(std::is_same<typename YMV::value_type,
@@ -982,10 +982,10 @@ struct Axpby_MV_Unroll_Functor<typename XMV::non_const_value_type, XMV,
 template <class AV, class XMV, class BV, class YMV, int UNROLL, class SizeType>
 void Axpby_MV_Unrolled(const AV& av, const XMV& x, const BV& bv, const YMV& y,
                        const SizeType startingColumn, int a = 2, int b = 2) {
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::Impl::"
                 "Axpby_MV_Unrolled: X is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<YMV>::value,
+  static_assert(Kokkos::is_view<YMV>::value,
                 "KokkosBlas::Impl::"
                 "Axpby_MV_Unrolled: Y is not a Kokkos::View.");
   static_assert(std::is_same<typename YMV::value_type,
@@ -1137,10 +1137,10 @@ void Axpby_MV_Unrolled(const AV& av, const XMV& x, const BV& bv, const YMV& y,
 template <class AV, class XMV, class BV, class YMV, class SizeType>
 void Axpby_MV_Generic(const AV& av, const XMV& x, const BV& bv, const YMV& y,
                       int a = 2, int b = 2) {
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::Impl::"
                 "Axpby_MV_Generic: X is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<YMV>::value,
+  static_assert(Kokkos::is_view<YMV>::value,
                 "KokkosBlas::Impl::"
                 "Axpby_MV_Generic: Y is not a Kokkos::View.");
   static_assert(std::is_same<typename YMV::value_type,
@@ -1277,10 +1277,10 @@ template <class AV, class XMV, class BV, class YMV, class SizeType>
 struct Axpby_MV_Invoke_Left {
   static void run(const AV& av, const XMV& x, const BV& bv, const YMV& y,
                   int a = 2, int b = 2) {
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Invoke_Left: X is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YMV>::value,
+    static_assert(Kokkos::is_view<YMV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Invoke_Left: Y is not a Kokkos::View.");
     static_assert(std::is_same<typename YMV::value_type,
@@ -1358,10 +1358,10 @@ template <class AV, class XMV, class BV, class YMV, class SizeType>
 struct Axpby_MV_Invoke_Right {
   static void run(const AV& av, const XMV& x, const BV& bv, const YMV& y,
                   int a = 2, int b = 2) {
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Invoke_Right: X is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YMV>::value,
+    static_assert(Kokkos::is_view<YMV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Invoke_Right: Y is not a Kokkos::View.");
     static_assert(std::is_same<typename YMV::value_type,

--- a/src/blas/impl/KokkosBlas1_axpby_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_axpby_spec.hpp
@@ -177,10 +177,10 @@ struct Axpby<AV, XMV, BV, YMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename YMV::size_type size_type;
 
   static void axpby(const AV& av, const XMV& X, const BV& bv, const YMV& Y) {
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby<rank-2>::axpby: X is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YMV>::value,
+    static_assert(Kokkos::is_view<YMV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby<rank-2>::axpby: Y is not a Kokkos::View.");
     static_assert(std::is_same<typename YMV::value_type,
@@ -258,10 +258,10 @@ struct Axpby<typename XMV::non_const_value_type, XMV,
 
   static void axpby(const AV& alpha, const XMV& X, const BV& beta,
                     const YMV& Y) {
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::Axpby::axpby (MV): "
                   "X is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YMV>::value,
+    static_assert(Kokkos::is_view<YMV>::value,
                   "KokkosBlas::Impl::Axpby::axpby (MV): "
                   "Y is not a Kokkos::View.");
     static_assert(std::is_same<typename YMV::value_type,
@@ -359,10 +359,10 @@ struct Axpby<typename XV::non_const_value_type, XV,
   typedef Kokkos::Details::ArithTraits<typename YV::non_const_value_type> ATB;
 
   static void axpby(const AV& alpha, const XV& X, const BV& beta, const YV& Y) {
-    static_assert(Kokkos::Impl::is_view<XV>::value,
+    static_assert(Kokkos::is_view<XV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby<rank-1>::axpby: X is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YV>::value,
+    static_assert(Kokkos::is_view<YV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby<rank-1>::axpby: Y is not a Kokkos::View.");
     static_assert(std::is_same<typename YV::value_type,

--- a/src/blas/impl/KokkosBlas1_dot_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_dot_spec.hpp
@@ -230,13 +230,13 @@ template <class RV, class XV, class YV>
 struct Dot<RV, XV, YV, 1, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   // Check some things about the template parameters at compile time to get nice
   // error messages, before using them under the assumption they are valid.
-  static_assert(Kokkos::Impl::is_view<XV>::value,
+  static_assert(Kokkos::is_view<XV>::value,
                 "KokkosBlas::Impl::"
                 "Dot<1-D>: XV is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<YV>::value,
+  static_assert(Kokkos::is_view<YV>::value,
                 "KokkosBlas::Impl::"
                 "Dot<1-D>: YV is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<RV>::value,
+  static_assert(Kokkos::is_view<RV>::value,
                 "KokkosBlas::Impl::"
                 "Dot<1-D>: RV is not a Kokkos::View.");
   static_assert(RV::rank == 0,
@@ -299,10 +299,10 @@ struct Dot<RV, XV, YV, 1, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 // Is never supported by TPLs, but uses the same dot_eti_spec_avail::value.
 template <class RV, class XV, class YV>
 struct DotSpecialAccumulator<RV, XV, YV, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
-  static_assert(Kokkos::Impl::is_view<XV>::value,
+  static_assert(Kokkos::is_view<XV>::value,
                 "KokkosBlas::Impl::"
                 "DotSpecialAccumulator: XV is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<YV>::value,
+  static_assert(Kokkos::is_view<YV>::value,
                 "KokkosBlas::Impl::"
                 "DotSpecialAccumulator: YV is not a Kokkos::View.");
   static_assert(XV::rank == YV::rank,
@@ -311,7 +311,7 @@ struct DotSpecialAccumulator<RV, XV, YV, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   static_assert(XV::rank == 1,
                 "KokkosBlas::Impl::"
                 "DotSpecialAccumulator: X and Y are not rank-1 Views.");
-  static_assert(Kokkos::Impl::is_view<RV>::value,
+  static_assert(Kokkos::is_view<RV>::value,
                 "KokkosBlas::Impl::"
                 "DotSpecialAccumulator: RV is not a Kokkos::View.");
   static_assert(std::is_same<typename XV::non_const_value_type,
@@ -365,10 +365,10 @@ struct DotSpecialAccumulator<RV, XV, YV, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 template <class RV, class XV, class YV, int X_Rank, int Y_Rank>
 struct Dot<RV, XV, YV, X_Rank, Y_Rank, false,
            KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
-  static_assert(Kokkos::Impl::is_view<XV>::value,
+  static_assert(Kokkos::is_view<XV>::value,
                 "KokkosBlas::Impl::"
                 "Dot<2-D>: XV is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<YV>::value,
+  static_assert(Kokkos::is_view<YV>::value,
                 "KokkosBlas::Impl::"
                 "Dot<2-D>: YV is not a Kokkos::View.");
   static_assert(RV::rank == 1,

--- a/src/blas/impl/KokkosBlas1_iamax_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_iamax_impl.hpp
@@ -69,10 +69,10 @@ struct V_Iamax_Functor {
   typename XV::const_type m_x;
 
   V_Iamax_Functor(const XV& x) : m_x(x) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
+    static_assert(Kokkos::is_view<RV>::value,
                   "KokkosBlas::Impl::V_Iamax_Functor: "
                   "R is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XV>::value,
+    static_assert(Kokkos::is_view<XV>::value,
                   "KokkosBlas::Impl::V_Iamax_Functor: "
                   "X is not a Kokkos::View.");
     static_assert(std::is_same<typename RV::value_type,

--- a/src/blas/impl/KokkosBlas1_iamax_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_iamax_spec.hpp
@@ -165,10 +165,10 @@ struct Iamax<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
 
   static void iamax(const RMV& R, const XMV& X) {
-    static_assert(Kokkos::Impl::is_view<RMV>::value,
+    static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Iamax<1-D>: RMV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Iamax<1-D>: XMV is not a Kokkos::View.");
     static_assert(RMV::rank == 0,
@@ -206,10 +206,10 @@ struct Iamax<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
 
   static void iamax(const RV& R, const XMV& X) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
+    static_assert(Kokkos::is_view<RV>::value,
                   "KokkosBlas::Impl::"
                   "Iamax<2-D>: RV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Iamax<2-D>: XMV is not a Kokkos::View.");
     static_assert(RV::rank == 1,

--- a/src/blas/impl/KokkosBlas1_mult_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_mult_spec.hpp
@@ -146,13 +146,13 @@ struct Mult<YMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 
   static void mult(const YMV_scalar& gamma, const YMV& Y,
                    const XMV_scalar& alpha, const AV& A, const XMV& X) {
-    static_assert(Kokkos::Impl::is_view<YMV>::value,
+    static_assert(Kokkos::is_view<YMV>::value,
                   "KokkosBlas::Impl::"
                   "Mult<rank 2>::mult: Y is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<AV>::value,
+    static_assert(Kokkos::is_view<AV>::value,
                   "KokkosBlas::Impl::"
                   "Mult<rank 2>::mult: A is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Mult<rank 2>::mult: X is not a Kokkos::View.");
     static_assert(std::is_same<typename YMV::value_type,
@@ -206,13 +206,13 @@ struct Mult<YV, AV, XV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   static void mult(const YV_scalar& gamma, const YV& Y, const XV_scalar& alpha,
                    const AV& A, const XV& X) {
     // YV, AV, and XV must be Kokkos::View specializations.
-    static_assert(Kokkos::Impl::is_view<YV>::value,
+    static_assert(Kokkos::is_view<YV>::value,
                   "KokkosBlas::Impl::"
                   "Mult<rank 1>::mult: Y is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<AV>::value,
+    static_assert(Kokkos::is_view<AV>::value,
                   "KokkosBlas::Impl::"
                   "Mult<rank 1>::mult: A is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XV>::value,
+    static_assert(Kokkos::is_view<XV>::value,
                   "KokkosBlas::Impl::"
                   "Mult<rank 1>::mult: X is not a Kokkos::View.");
     // XV must be nonconst (else it can't be an output argument).

--- a/src/blas/impl/KokkosBlas1_nrm1_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm1_impl.hpp
@@ -73,10 +73,10 @@ struct V_Nrm1_Functor {
   typename XV::const_type m_x;
 
   V_Nrm1_Functor(const XV& x) : m_x(x) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
+    static_assert(Kokkos::is_view<RV>::value,
                   "KokkosBlas::Impl::V_Nrm1_Functor: "
                   "R is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XV>::value,
+    static_assert(Kokkos::is_view<XV>::value,
                   "KokkosBlas::Impl::V_Nrm1_Functor: "
                   "X is not a Kokkos::View.");
     static_assert(std::is_same<typename RV::value_type,

--- a/src/blas/impl/KokkosBlas1_nrm1_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm1_spec.hpp
@@ -132,10 +132,10 @@ struct Nrm1<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
 
   static void nrm1(const RMV& R, const XMV& X) {
-    static_assert(Kokkos::Impl::is_view<RMV>::value,
+    static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Nrm1<1-D>: RMV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Nrm1<1-D>: XMV is not a Kokkos::View.");
     static_assert(RMV::rank == 0,
@@ -173,10 +173,10 @@ struct Nrm1<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
 
   static void nrm1(const RV& R, const XMV& X) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
+    static_assert(Kokkos::is_view<RV>::value,
                   "KokkosBlas::Impl::"
                   "Nrm1<2-D>: RV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Nrm1<2-D>: XMV is not a Kokkos::View.");
     static_assert(RV::rank == 1,

--- a/src/blas/impl/KokkosBlas1_nrm2_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm2_impl.hpp
@@ -74,10 +74,10 @@ struct V_Nrm2_Functor {
   bool m_take_sqrt;
 
   V_Nrm2_Functor(const XV& x, bool take_sqrt) : m_x(x), m_take_sqrt(take_sqrt) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
+    static_assert(Kokkos::is_view<RV>::value,
                   "KokkosBlas::Impl::V_Nrm2_Functor: "
                   "R is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XV>::value,
+    static_assert(Kokkos::is_view<XV>::value,
                   "KokkosBlas::Impl::V_Nrm2_Functor: "
                   "X is not a Kokkos::View.");
     static_assert(std::is_same<typename RV::value_type,

--- a/src/blas/impl/KokkosBlas1_nrm2_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm2_spec.hpp
@@ -132,10 +132,10 @@ struct Nrm2<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
 
   static void nrm2(const RMV& R, const XMV& X, const bool& take_sqrt) {
-    static_assert(Kokkos::Impl::is_view<RMV>::value,
+    static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Nrm2<1-D>: RMV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Nrm2<1-D>: XMV is not a Kokkos::View.");
     static_assert(RMV::rank == 0,
@@ -173,10 +173,10 @@ struct Nrm2<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
 
   static void nrm2(const RV& R, const XMV& X, const bool& take_sqrt) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
+    static_assert(Kokkos::is_view<RV>::value,
                   "KokkosBlas::Impl::"
                   "Nrm2<2-D>: RV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Nrm2<2-D>: XMV is not a Kokkos::View.");
     static_assert(RV::rank == 1,

--- a/src/blas/impl/KokkosBlas1_nrm2w_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm2w_impl.hpp
@@ -76,10 +76,10 @@ struct V_Nrm2w_Functor {
 
   V_Nrm2w_Functor(const XV& x, const XV& w, bool take_sqrt)
       : m_x(x), m_w(w), m_take_sqrt(take_sqrt) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
+    static_assert(Kokkos::is_view<RV>::value,
                   "KokkosBlas::Impl::V_Nrm2w_Functor: "
                   "R is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XV>::value,
+    static_assert(Kokkos::is_view<XV>::value,
                   "KokkosBlas::Impl::V_Nrm2w_Functor: "
                   "X is not a Kokkos::View.");
     static_assert(std::is_same<typename RV::value_type,

--- a/src/blas/impl/KokkosBlas1_nrm2w_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_nrm2w_spec.hpp
@@ -132,10 +132,10 @@ struct Nrm2w<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 
   static void nrm2w(const RMV& R, const XMV& X, const XMV& W,
                     const bool& take_sqrt) {
-    static_assert(Kokkos::Impl::is_view<RMV>::value,
+    static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Nrm2w<1-D>: RMV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Nrm2w<1-D>: XMV is not a Kokkos::View.");
     static_assert(RMV::rank == 0,
@@ -174,10 +174,10 @@ struct Nrm2w<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 
   static void nrm2w(const RV& R, const XMV& X, const XMV& W,
                     const bool& take_sqrt) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
+    static_assert(Kokkos::is_view<RV>::value,
                   "KokkosBlas::Impl::"
                   "Nrm2w<2-D>: RV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Nrm2w<2-D>: XMV is not a Kokkos::View.");
     static_assert(RV::rank == 1,

--- a/src/blas/impl/KokkosBlas1_nrminf_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_nrminf_impl.hpp
@@ -72,10 +72,10 @@ struct V_NrmInf_Functor {
   typename XV::const_type m_x;
 
   V_NrmInf_Functor(const XV& x) : m_x(x) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
+    static_assert(Kokkos::is_view<RV>::value,
                   "KokkosBlas::Impl::V_NrmInf_Functor: "
                   "R is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XV>::value,
+    static_assert(Kokkos::is_view<XV>::value,
                   "KokkosBlas::Impl::V_NrmInf_Functor: "
                   "X is not a Kokkos::View.");
     static_assert(std::is_same<typename RV::value_type,

--- a/src/blas/impl/KokkosBlas1_nrminf_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_nrminf_spec.hpp
@@ -133,10 +133,10 @@ struct NrmInf<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
 
   static void nrminf(const RMV& R, const XMV& X) {
-    static_assert(Kokkos::Impl::is_view<RMV>::value,
+    static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "NrmInf<1-D>: RMV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "NrmInf<1-D>: XMV is not a Kokkos::View.");
     static_assert(RMV::rank == 0,
@@ -174,10 +174,10 @@ struct NrmInf<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
 
   static void nrminf(const RV& R, const XMV& X) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
+    static_assert(Kokkos::is_view<RV>::value,
                   "KokkosBlas::Impl::"
                   "NrmInf<2-D>: RV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "NrmInf<2-D>: XMV is not a Kokkos::View.");
     static_assert(RV::rank == 1,

--- a/src/blas/impl/KokkosBlas1_reciprocal_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_reciprocal_impl.hpp
@@ -68,10 +68,10 @@ struct MV_Reciprocal_Functor {
 
   MV_Reciprocal_Functor(const RMV& R, const XMV& X)
       : numCols(X.extent(1)), R_(R), X_(X) {
-    static_assert(Kokkos::Impl::is_view<RMV>::value,
+    static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "MV_Reciprocal_Functor: RMV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "MV_Reciprocal_Functor: XMV is not a Kokkos::View.");
     static_assert(RMV::rank == 2,
@@ -105,7 +105,7 @@ struct MV_ReciprocalSelf_Functor {
   RMV R_;
 
   MV_ReciprocalSelf_Functor(const RMV& R) : numCols(R.extent(1)), R_(R) {
-    static_assert(Kokkos::Impl::is_view<RMV>::value,
+    static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "MV_Reciprocal_Functor: RMV is not a Kokkos::View.");
     static_assert(RMV::rank == 2,
@@ -136,10 +136,10 @@ struct V_Reciprocal_Functor {
   XV X_;
 
   V_Reciprocal_Functor(const RV& R, const XV& X) : R_(R), X_(X) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
+    static_assert(Kokkos::is_view<RV>::value,
                   "KokkosBlas::Impl::"
                   "V_Reciprocal_Functor: RV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XV>::value,
+    static_assert(Kokkos::is_view<XV>::value,
                   "KokkosBlas::Impl::"
                   "V_Reciprocal_Functor: XV is not a Kokkos::View.");
     static_assert(RV::rank == 1,
@@ -165,7 +165,7 @@ struct V_ReciprocalSelf_Functor {
   RV R_;
 
   V_ReciprocalSelf_Functor(const RV& R) : R_(R) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
+    static_assert(Kokkos::is_view<RV>::value,
                   "KokkosBlas::Impl::"
                   "V_Reciprocal_Functor: RV is not a Kokkos::View.");
     static_assert(RV::rank == 1,
@@ -181,10 +181,10 @@ struct V_ReciprocalSelf_Functor {
 // computes entry-wise reciprocalolute value.
 template <class RMV, class XMV, class SizeType>
 void MV_Reciprocal_Generic(const RMV& R, const XMV& X) {
-  static_assert(Kokkos::Impl::is_view<RMV>::value,
+  static_assert(Kokkos::is_view<RMV>::value,
                 "KokkosBlas::Impl::"
                 "MV_Reciprocal_Generic: RMV is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::Impl::"
                 "MV_Reciprocal_Generic: XMV is not a Kokkos::View.");
   static_assert(RMV::rank == 2,
@@ -210,10 +210,10 @@ void MV_Reciprocal_Generic(const RMV& R, const XMV& X) {
 // Variant of MV_Reciprocal_Generic for single vectors (1-D Views) R and X.
 template <class RV, class XV, class SizeType>
 void V_Reciprocal_Generic(const RV& R, const XV& X) {
-  static_assert(Kokkos::Impl::is_view<RV>::value,
+  static_assert(Kokkos::is_view<RV>::value,
                 "KokkosBlas::Impl::"
                 "V_Reciprocal_Generic: RV is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XV>::value,
+  static_assert(Kokkos::is_view<XV>::value,
                 "KokkosBlas::Impl::"
                 "V_Reciprocal_Generic: XV is not a Kokkos::View.");
   static_assert(RV::rank == 1,

--- a/src/blas/impl/KokkosBlas1_reciprocal_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_reciprocal_spec.hpp
@@ -126,10 +126,10 @@ struct Reciprocal<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
 
   static void reciprocal(const RMV& R, const XMV& X) {
-    static_assert(Kokkos::Impl::is_view<RMV>::value,
+    static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Reciprocal<1-D>: RMV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Reciprocal<1-D>: XMV is not a Kokkos::View.");
     static_assert(RMV::rank == 1,
@@ -169,10 +169,10 @@ struct Reciprocal<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
 
   static void reciprocal(const RMV& R, const XMV& X) {
-    static_assert(Kokkos::Impl::is_view<RMV>::value,
+    static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Reciprocal<2-D>: RMV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Reciprocal<2-D>: XMV is not a Kokkos::View.");
     static_assert(RMV::rank == 2,

--- a/src/blas/impl/KokkosBlas1_scal_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_scal_impl.hpp
@@ -83,11 +83,11 @@ struct V_Scal_Functor {
   V_Scal_Functor(const RV& r, const XV& x, const AV& a,
                  const SizeType startingColumn)
       : m_r(r), m_x(x), m_a(a) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
+    static_assert(Kokkos::is_view<RV>::value,
                   "V_Scal_Functor: RV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<AV>::value,
+    static_assert(Kokkos::is_view<AV>::value,
                   "V_Scal_Functor: AV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XV>::value,
+    static_assert(Kokkos::is_view<XV>::value,
                   "V_Scal_Functor: XV is not a Kokkos::View.");
     static_assert(RV::rank == 1, "V_Scal_Functor: RV is not rank 1.");
     static_assert(AV::rank == 1, "V_Scal_Functor: AV is not rank 1.");
@@ -165,9 +165,9 @@ struct V_Scal_Functor<RV, typename XV::non_const_value_type, XV, scalar_x,
 template <class RV, class AV, class XV, class SizeType>
 void V_Scal_Generic(const RV& r, const AV& av, const XV& x,
                     const SizeType startingColumn, int a = 2) {
-  static_assert(Kokkos::Impl::is_view<RV>::value,
+  static_assert(Kokkos::is_view<RV>::value,
                 "V_Scal_Generic: RV is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XV>::value,
+  static_assert(Kokkos::is_view<XV>::value,
                 "V_Scal_Generic: XV is not a Kokkos::View.");
   static_assert(RV::rank == 1, "V_Scal_Generic: RV is not rank 1.");
   static_assert(XV::rank == 1, "V_Scal_Generic: XV is not rank 1.");

--- a/src/blas/impl/KokkosBlas1_scal_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_scal_spec.hpp
@@ -144,10 +144,10 @@ struct Scal<RV, typename XV::non_const_value_type, XV, 1, false,
   typedef Kokkos::Details::ArithTraits<typename XV::non_const_value_type> ATA;
 
   static void scal(const RV& R, const AV& alpha, const XV& X) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
+    static_assert(Kokkos::is_view<RV>::value,
                   "KokkosBlas::Impl::"
                   "Scal<1-D>: RV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XV>::value,
+    static_assert(Kokkos::is_view<XV>::value,
                   "KokkosBlas::Impl::"
                   "Scal<1-D>: XV is not a Kokkos::View.");
     static_assert(RV::rank == 1,
@@ -203,13 +203,13 @@ struct Scal<RMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef Kokkos::Details::ArithTraits<typename XMV::non_const_value_type> ATA;
 
   static void scal(const RMV& R, const AV& av, const XMV& X) {
-    static_assert(Kokkos::Impl::is_view<RMV>::value,
+    static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Scal<2-D>: RMV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<AV>::value,
+    static_assert(Kokkos::is_view<AV>::value,
                   "KokkosBlas::Impl::"
                   "Scal<2-D>: AV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Scal<2-D>: XMV is not a Kokkos::View.");
     static_assert(RMV::rank == 2,
@@ -263,10 +263,10 @@ struct Scal<RMV, typename XMV::non_const_value_type, XMV, 2, false,
   typedef Kokkos::Details::ArithTraits<typename XMV::non_const_value_type> ATA;
 
   static void scal(const RMV& R, const AV& alpha, const XMV& X) {
-    static_assert(Kokkos::Impl::is_view<RMV>::value,
+    static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Scal<2-D, AV=scalar>: RMV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Scal<2-D, AV=scalar>: XMV is not a Kokkos::View.");
     static_assert(RMV::rank == 2,

--- a/src/blas/impl/KokkosBlas1_sum_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_sum_impl.hpp
@@ -74,10 +74,10 @@ struct V_Sum_Functor {
   typename XV::const_type m_x;
 
   V_Sum_Functor(const XV& x) : m_x(x) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
+    static_assert(Kokkos::is_view<RV>::value,
                   "KokkosBlas::Impl::V_Sum_Functor: "
                   "R is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XV>::value,
+    static_assert(Kokkos::is_view<XV>::value,
                   "KokkosBlas::Impl::V_Sum_Functor: "
                   "X is not a Kokkos::View.");
     static_assert(std::is_same<typename RV::value_type,

--- a/src/blas/impl/KokkosBlas1_sum_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_sum_spec.hpp
@@ -128,10 +128,10 @@ struct Sum<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
 
   static void sum(const RMV& R, const XMV& X) {
-    static_assert(Kokkos::Impl::is_view<RMV>::value,
+    static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Sum<1-D>: RMV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Sum<1-D>: XMV is not a Kokkos::View.");
     static_assert(RMV::rank == 0,
@@ -170,10 +170,10 @@ struct Sum<RV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
 
   static void sum(const RV& R, const XMV& X) {
-    static_assert(Kokkos::Impl::is_view<RV>::value,
+    static_assert(Kokkos::is_view<RV>::value,
                   "KokkosBlas::Impl::"
                   "Sum<2-D>: RV is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Sum<2-D>: XMV is not a Kokkos::View.");
     static_assert(RV::rank == 1,

--- a/src/blas/impl/KokkosBlas1_update_impl.hpp
+++ b/src/blas/impl/KokkosBlas1_update_impl.hpp
@@ -96,13 +96,13 @@ struct MV_Update_Functor {
         Y_(Y),
         gamma_(gamma),
         Z_(Z) {
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "MV_Update_Functor: X is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YMV>::value,
+    static_assert(Kokkos::is_view<YMV>::value,
                   "KokkosBlas::Impl::"
                   "MV_Update_Functor: Y is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<ZMV>::value,
+    static_assert(Kokkos::is_view<ZMV>::value,
                   "KokkosBlas::Impl::"
                   "MV_Update_Functor: Z is not a Kokkos::View.");
     static_assert(std::is_same<typename ZMV::value_type,
@@ -263,13 +263,13 @@ struct V_Update_Functor {
         Y_(Y),
         gamma_(gamma),
         Z_(Z) {
-    static_assert(Kokkos::Impl::is_view<XV>::value,
+    static_assert(Kokkos::is_view<XV>::value,
                   "KokkosBlas::Impl::"
                   "V_Update_Functor: X is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YV>::value,
+    static_assert(Kokkos::is_view<YV>::value,
                   "KokkosBlas::Impl::"
                   "V_Update_Functor: Y is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<ZV>::value,
+    static_assert(Kokkos::is_view<ZV>::value,
                   "KokkosBlas::Impl::"
                   "V_Update_Functor: Z is not a Kokkos::View.");
     static_assert(std::is_same<typename ZV::value_type,
@@ -351,13 +351,13 @@ void MV_Update_Generic(const typename XMV::non_const_value_type& alpha,
                        const YMV& Y,
                        const typename ZMV::non_const_value_type& gamma,
                        const ZMV& Z, int a = 2, int b = 2, int c = 2) {
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::Impl::"
                 "MV_Update_Generic: X is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<YMV>::value,
+  static_assert(Kokkos::is_view<YMV>::value,
                 "KokkosBlas::Impl::"
                 "MV_Update_Generic: Y is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<ZMV>::value,
+  static_assert(Kokkos::is_view<ZMV>::value,
                 "KokkosBlas::Impl::"
                 "MV_Update_Generic: Z is not a Kokkos::View.");
   static_assert(std::is_same<typename ZMV::value_type,
@@ -452,13 +452,13 @@ void V_Update_Generic(const typename XV::non_const_value_type& alpha,
                       const YV& Y,
                       const typename ZV::non_const_value_type& gamma,
                       const ZV& Z, int a = 2, int b = 2, int c = 2) {
-  static_assert(Kokkos::Impl::is_view<XV>::value,
+  static_assert(Kokkos::is_view<XV>::value,
                 "KokkosBlas::Impl::"
                 "V_Update_Generic: X is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<YV>::value,
+  static_assert(Kokkos::is_view<YV>::value,
                 "KokkosBlas::Impl::"
                 "V_Update_Generic: Y is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<ZV>::value,
+  static_assert(Kokkos::is_view<ZV>::value,
                 "KokkosBlas::Impl::"
                 "V_Update_Generic: Z is not a Kokkos::View.");
   static_assert(std::is_same<typename ZV::value_type,

--- a/src/blas/impl/KokkosBlas1_update_spec.hpp
+++ b/src/blas/impl/KokkosBlas1_update_spec.hpp
@@ -155,13 +155,13 @@ struct Update<XMV, YMV, ZMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
                      const YMV& Y,
                      const typename ZMV::non_const_value_type& gamma,
                      const ZMV& Z) {
-    static_assert(Kokkos::Impl::is_view<XMV>::value,
+    static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Update<rank 2>::update: X is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YMV>::value,
+    static_assert(Kokkos::is_view<YMV>::value,
                   "KokkosBlas::Impl::"
                   "Update<rank 2>::update: Y is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<ZMV>::value,
+    static_assert(Kokkos::is_view<ZMV>::value,
                   "KokkosBlas::Impl::"
                   "Update<rank 2>::update: Z is not a Kokkos::View.");
     static_assert(std::is_same<typename ZMV::value_type,
@@ -260,13 +260,13 @@ struct Update<XV, YV, ZV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
                      const typename ZV::non_const_value_type& gamma,
                      const ZV& Z) {
     // XV, YV, and ZV must be Kokkos::View specializations.
-    static_assert(Kokkos::Impl::is_view<XV>::value,
+    static_assert(Kokkos::is_view<XV>::value,
                   "KokkosBlas::Impl::"
                   "Update<rank 1>::update: X is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YV>::value,
+    static_assert(Kokkos::is_view<YV>::value,
                   "KokkosBlas::Impl::"
                   "Update<rank 1>::update: Y is not a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<ZV>::value,
+    static_assert(Kokkos::is_view<ZV>::value,
                   "KokkosBlas::Impl::"
                   "Update<rank 1>::update: Z is not a Kokkos::View.");
     // ZV must be nonconst (else it can't be an output argument).

--- a/src/blas/impl/KokkosBlas2_gemv_impl.hpp
+++ b/src/blas/impl/KokkosBlas2_gemv_impl.hpp
@@ -71,11 +71,11 @@ struct SingleLevelNontransposeGEMV {
                               const XViewType& x, const BetaCoeffType& beta,
                               const YViewType& y)
       : alpha_(alpha), A_(A), x_(x), beta_(beta), y_(y) {
-    static_assert(Kokkos::Impl::is_view<AViewType>::value,
+    static_assert(Kokkos::is_view<AViewType>::value,
                   "AViewType must be a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XViewType>::value,
+    static_assert(Kokkos::is_view<XViewType>::value,
                   "XViewType must be a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YViewType>::value,
+    static_assert(Kokkos::is_view<YViewType>::value,
                   "YViewType must be a Kokkos::View.");
     static_assert(static_cast<int>(AViewType::rank) == 2,
                   "AViewType must have rank 2.");
@@ -161,11 +161,11 @@ struct SingleLevelTransposeGEMV {
         x_(x),
         beta_(beta),
         y_(y) {
-    static_assert(Kokkos::Impl::is_view<AViewType>::value,
+    static_assert(Kokkos::is_view<AViewType>::value,
                   "AViewType must be a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XViewType>::value,
+    static_assert(Kokkos::is_view<XViewType>::value,
                   "XViewType must be a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YViewType>::value,
+    static_assert(Kokkos::is_view<YViewType>::value,
                   "YViewType must be a Kokkos::View.");
     static_assert(static_cast<int>(AViewType::rank) == 2,
                   "AViewType must have rank 2.");
@@ -234,11 +234,11 @@ void singleLevelGemv(const typename AViewType::execution_space& space,
                      const AViewType& A, const XViewType& x,
                      typename YViewType::const_value_type& beta,
                      const YViewType& y) {
-  static_assert(Kokkos::Impl::is_view<AViewType>::value,
+  static_assert(Kokkos::is_view<AViewType>::value,
                 "AViewType must be a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XViewType>::value,
+  static_assert(Kokkos::is_view<XViewType>::value,
                 "XViewType must be a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<YViewType>::value,
+  static_assert(Kokkos::is_view<YViewType>::value,
                 "YViewType must be a Kokkos::View.");
   static_assert(static_cast<int>(AViewType::rank) == 2,
                 "AViewType must have rank 2.");
@@ -490,11 +490,11 @@ struct TwoLevelGEMV {
                const XViewType& x, const BetaCoeffType& beta,
                const YViewType& y)
       : alpha_(alpha), A_(A), x_(x), beta_(beta), y_(y) {
-    static_assert(Kokkos::Impl::is_view<AViewType>::value,
+    static_assert(Kokkos::is_view<AViewType>::value,
                   "AViewType must be a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XViewType>::value,
+    static_assert(Kokkos::is_view<XViewType>::value,
                   "XViewType must be a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YViewType>::value,
+    static_assert(Kokkos::is_view<YViewType>::value,
                   "YViewType must be a Kokkos::View.");
     static_assert(static_cast<int>(AViewType::rank) == 2,
                   "AViewType must have rank 2.");
@@ -611,11 +611,11 @@ struct TwoLevelTransposeGEMV {
                         const XViewType& x, const BetaCoeffType& beta,
                         const YViewType& y)
       : alpha_(alpha), A_(A), x_(x), beta_(beta), y_(y) {
-    static_assert(Kokkos::Impl::is_view<AViewType>::value,
+    static_assert(Kokkos::is_view<AViewType>::value,
                   "AViewType must be a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XViewType>::value,
+    static_assert(Kokkos::is_view<XViewType>::value,
                   "XViewType must be a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YViewType>::value,
+    static_assert(Kokkos::is_view<YViewType>::value,
                   "YViewType must be a Kokkos::View.");
     static_assert(static_cast<int>(AViewType::rank) == 2,
                   "AViewType must have rank 2.");
@@ -673,11 +673,11 @@ void twoLevelGemv(const typename AViewType::execution_space& space,
                   const AViewType& A, const XViewType& x,
                   typename YViewType::const_value_type& beta,
                   const YViewType& y) {
-  static_assert(Kokkos::Impl::is_view<AViewType>::value,
+  static_assert(Kokkos::is_view<AViewType>::value,
                 "AViewType must be a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XViewType>::value,
+  static_assert(Kokkos::is_view<XViewType>::value,
                 "XViewType must be a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<YViewType>::value,
+  static_assert(Kokkos::is_view<YViewType>::value,
                 "YViewType must be a Kokkos::View.");
   static_assert(static_cast<int>(AViewType::rank) == 2,
                 "AViewType must have rank 2.");

--- a/src/blas/impl/KokkosBlas2_gemv_spec.hpp
+++ b/src/blas/impl/KokkosBlas2_gemv_spec.hpp
@@ -109,11 +109,11 @@ struct GEMV {
                    const YViewType& y)
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
   {
-    static_assert(Kokkos::Impl::is_view<AViewType>::value,
+    static_assert(Kokkos::is_view<AViewType>::value,
                   "AViewType must be a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<XViewType>::value,
+    static_assert(Kokkos::is_view<XViewType>::value,
                   "XViewType must be a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<YViewType>::value,
+    static_assert(Kokkos::is_view<YViewType>::value,
                   "YViewType must be a Kokkos::View.");
     static_assert(static_cast<int>(AViewType::rank) == 2,
                   "AViewType must have rank 2.");

--- a/src/blas/impl/KokkosBlas3_gemm_spec.hpp
+++ b/src/blas/impl/KokkosBlas3_gemm_spec.hpp
@@ -126,11 +126,11 @@ struct GEMM {
                    const CViewType& C)
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
   {
-    static_assert(Kokkos::Impl::is_view<AViewType>::value,
+    static_assert(Kokkos::is_view<AViewType>::value,
                   "AViewType must be a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<BViewType>::value,
+    static_assert(Kokkos::is_view<BViewType>::value,
                   "BViewType must be a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<CViewType>::value,
+    static_assert(Kokkos::is_view<CViewType>::value,
                   "CViewType must be a Kokkos::View.");
     static_assert(static_cast<int>(AViewType::rank) == 2,
                   "AViewType must have rank 2.");

--- a/src/blas/impl/KokkosBlas3_trmm_spec.hpp
+++ b/src/blas/impl/KokkosBlas3_trmm_spec.hpp
@@ -110,10 +110,8 @@ struct TRMM<AVIT, BVIT, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   static void trmm(const char side[], const char uplo[], const char trans[],
                    const char diag[], typename BVIT::const_value_type& alpha,
                    const AVIT& A, const BVIT& B) {
-    static_assert(Kokkos::Impl::is_view<AVIT>::value,
-                  "AVIT must be a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<BVIT>::value,
-                  "BVIT must be a Kokkos::View.");
+    static_assert(Kokkos::is_view<AVIT>::value, "AVIT must be a Kokkos::View.");
+    static_assert(Kokkos::is_view<BVIT>::value, "BVIT must be a Kokkos::View.");
     static_assert(static_cast<int>(AVIT::rank) == 2, "AVIT must have rank 2.");
     static_assert(static_cast<int>(BVIT::rank) == 2, "BVIT must have rank 2.");
 

--- a/src/blas/impl/KokkosBlas3_trsm_spec.hpp
+++ b/src/blas/impl/KokkosBlas3_trsm_spec.hpp
@@ -117,9 +117,9 @@ struct TRSM<AViewType, BViewType, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
                    const char diag[],
                    typename BViewType::const_value_type& alpha,
                    const AViewType& A, const BViewType& B) {
-    static_assert(Kokkos::Impl::is_view<AViewType>::value,
+    static_assert(Kokkos::is_view<AViewType>::value,
                   "AViewType must be a Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<BViewType>::value,
+    static_assert(Kokkos::is_view<BViewType>::value,
                   "BViewType must be a Kokkos::View.");
     static_assert(static_cast<int>(AViewType::rank) == 2,
                   "AViewType must have rank 2.");

--- a/src/blas/impl/KokkosBlas_trtri_spec.hpp
+++ b/src/blas/impl/KokkosBlas_trtri_spec.hpp
@@ -101,8 +101,7 @@ template <class RVIT, class AVIT>
 struct TRTRI<RVIT, AVIT, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   static void trtri(const RVIT& R, const char uplo[], const char diag[],
                     const AVIT& A) {
-    static_assert(Kokkos::Impl::is_view<AVIT>::value,
-                  "AVIT must be a Kokkos::View.");
+    static_assert(Kokkos::is_view<AVIT>::value, "AVIT must be a Kokkos::View.");
     static_assert(static_cast<int>(AVIT::rank) == 2, "AVIT must have rank 2.");
 
     Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY

--- a/src/sparse/KokkosSparse_getDiagCopy.hpp
+++ b/src/sparse/KokkosSparse_getDiagCopy.hpp
@@ -56,14 +56,14 @@ namespace KokkosSparse {
 template <class DiagType, class OffsetsType, class CrsMatrixType>
 void getDiagCopy(const DiagType& D, const OffsetsType& offsets,
                  const CrsMatrixType& A) {
-  static_assert(Kokkos::Impl::is_view<DiagType>::value,
+  static_assert(Kokkos::is_view<DiagType>::value,
                 "The DiagType template parameter must be a Kokkos::View.");
   static_assert(static_cast<int>(DiagType::rank) == 1,
                 "The DiagType template parameter must be a 1-D Kokkos::View.");
   static_assert(
       std::is_same<DiagType, typename DiagType::non_const_type>::value,
       "The DiagType template parameter must be a nonconst Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<OffsetsType>::value,
+  static_assert(Kokkos::is_view<OffsetsType>::value,
                 "The OffsetsType template parameter must be a Kokkos::View.");
   static_assert(
       static_cast<int>(OffsetsType::rank) == 1,

--- a/src/sparse/KokkosSparse_spiluk.hpp
+++ b/src/sparse/KokkosSparse_spiluk.hpp
@@ -104,17 +104,17 @@ void spiluk_symbolic(KernelHandle* handle,
                 "spiluk_symbolic: U entry type must match KernelHandle entry "
                 "type (aka nnz_lno_t, and const doesn't matter)");
 
-  static_assert(Kokkos::Impl::is_view<ARowMapType>::value,
+  static_assert(Kokkos::is_view<ARowMapType>::value,
                 "spiluk_symbolic: A_rowmap is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<AEntriesType>::value,
+  static_assert(Kokkos::is_view<AEntriesType>::value,
                 "spiluk_symbolic: A_entries is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<LRowMapType>::value,
+  static_assert(Kokkos::is_view<LRowMapType>::value,
                 "spiluk_symbolic: L_rowmap is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<LEntriesType>::value,
+  static_assert(Kokkos::is_view<LEntriesType>::value,
                 "spiluk_symbolic: L_entries is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<URowMapType>::value,
+  static_assert(Kokkos::is_view<URowMapType>::value,
                 "spiluk_symbolic: U_rowmap is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<UEntriesType>::value,
+  static_assert(Kokkos::is_view<UEntriesType>::value,
                 "spiluk_symbolic: U_entries is not a Kokkos::View.");
 
   static_assert(
@@ -325,23 +325,23 @@ void spiluk_numeric(KernelHandle* handle,
                 "spiluk_numeric: U scalar type must match KernelHandle entry "
                 "type (aka nnz_lno_t, and const doesn't matter)");
 
-  static_assert(Kokkos::Impl::is_view<ARowMapType>::value,
+  static_assert(Kokkos::is_view<ARowMapType>::value,
                 "spiluk_numeric: A_rowmap is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<AEntriesType>::value,
+  static_assert(Kokkos::is_view<AEntriesType>::value,
                 "spiluk_numeric: A_entries is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<AValuesType>::value,
+  static_assert(Kokkos::is_view<AValuesType>::value,
                 "spiluk_numeric: A_values is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<LRowMapType>::value,
+  static_assert(Kokkos::is_view<LRowMapType>::value,
                 "spiluk_numeric: L_rowmap is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<LEntriesType>::value,
+  static_assert(Kokkos::is_view<LEntriesType>::value,
                 "spiluk_numeric: L_entries is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<LValuesType>::value,
+  static_assert(Kokkos::is_view<LValuesType>::value,
                 "spiluk_numeric: L_values is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<URowMapType>::value,
+  static_assert(Kokkos::is_view<URowMapType>::value,
                 "spiluk_numeric: U_rowmap is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<UEntriesType>::value,
+  static_assert(Kokkos::is_view<UEntriesType>::value,
                 "spiluk_numeric: U_entries is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<UValuesType>::value,
+  static_assert(Kokkos::is_view<UValuesType>::value,
                 "spiluk_numeric: U_values is not a Kokkos::View.");
 
   static_assert(

--- a/src/sparse/KokkosSparse_sptrsv.hpp
+++ b/src/sparse/KokkosSparse_sptrsv.hpp
@@ -243,9 +243,9 @@ void sptrsv_solve(KernelHandle *handle, lno_row_view_t_ rowmap,
                 "sptrsv_solve: A scalar type must match KernelHandle entry "
                 "type (aka nnz_lno_t, and const doesn't matter)");
 
-  static_assert(Kokkos::Impl::is_view<BType>::value,
+  static_assert(Kokkos::is_view<BType>::value,
                 "sptrsv: b is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XType>::value,
+  static_assert(Kokkos::is_view<XType>::value,
                 "sptrsv: x is not a Kokkos::View.");
   static_assert((int)BType::rank == (int)XType::rank,
                 "sptrsv: The ranks of b and x do not match.");

--- a/src/sparse/KokkosSparse_trsv.hpp
+++ b/src/sparse/KokkosSparse_trsv.hpp
@@ -82,9 +82,9 @@ void trsv(const char uplo[], const char trans[], const char diag[],
                 "KokkosBlas::trsv: Rank-1 version of this "
                 "function has not yet been implemented.");
 
-  static_assert(Kokkos::Impl::is_view<BMV>::value,
+  static_assert(Kokkos::is_view<BMV>::value,
                 "KokkosBlas::trsv: b is not a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<XMV>::value,
+  static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::trsv: x is not a Kokkos::View.");
   static_assert((int)BMV::rank == (int)XMV::rank,
                 "KokkosBlas::trsv: The ranks of b and x do not match.");

--- a/src/sparse/impl/KokkosSparse_getDiagCopyWithOffsets_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_getDiagCopyWithOffsets_impl.hpp
@@ -82,7 +82,7 @@ struct CrsMatrixGetDiagCopyWithOffsetsFunctor {
                                          const OffsetsType& offsets,
                                          const CrsMatrixType& A)
       : D_(D), offsets_(offsets), A_(A) {
-    static_assert(Kokkos::Impl::is_view<DiagType>::value,
+    static_assert(Kokkos::is_view<DiagType>::value,
                   "The DiagType template parameter must be a Kokkos::View.");
     static_assert(
         static_cast<int>(DiagType::rank) == 1,
@@ -90,7 +90,7 @@ struct CrsMatrixGetDiagCopyWithOffsetsFunctor {
     static_assert(
         std::is_same<DiagType, typename DiagType::non_const_type>::value,
         "The DiagType template parameter must be a nonconst Kokkos::View.");
-    static_assert(Kokkos::Impl::is_view<OffsetsType>::value,
+    static_assert(Kokkos::is_view<OffsetsType>::value,
                   "The OffsetsType template parameter must be a Kokkos::View.");
     static_assert(
         static_cast<int>(OffsetsType::rank) == 1,

--- a/src/stage/blas3/Kokkos_Blas3.hpp
+++ b/src/stage/blas3/Kokkos_Blas3.hpp
@@ -55,11 +55,11 @@ template <class AMat, class BMat, class CMat>
 void gemm(const char transA, const char transB, AMat::const_value_type alpha,
           const AMat& a, const BMat& b, CMat::const_value_type beta,
           const CMat& c) {
-  static_assert(Kokkos::Impl::is_view<AMat>::value,
+  static_assert(Kokkos::is_view<AMat>::value,
                 "KokkosBlas::gemm: AMat must be a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<BMat>::value,
+  static_assert(Kokkos::is_view<BMat>::value,
                 "KokkosBlas::gemm: BMat must be a Kokkos::View.");
-  static_assert(Kokkos::Impl::is_view<CMat>::value,
+  static_assert(Kokkos::is_view<CMat>::value,
                 "KokkosBlas::gemm: CMat must be a Kokkos::View.");
   static_assert(AMat::rank != BMat::rank && CMat::rank != BMat::rank,
                 "KokkosBlas::gemm: Matrix ranks do not match.");


### PR DESCRIPTION
Prefer `Kokkos::is_view`.  It is not legal to reach into `Kokkos::Impl::` namespace.
See kokkos/kokkos#4592