### PR TITLE
Add Jacobi Batched preconditioner

### DIFF
--- a/src/batched/dense/KokkosBatched_HadamardProduct.hpp
+++ b/src/batched/dense/KokkosBatched_HadamardProduct.hpp
@@ -1,0 +1,158 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.4
+//       Copyright (2021) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+#ifndef __KOKKOSBATCHED_HADAMARDPRODUCT_HPP__
+#define __KOKKOSBATCHED_HADAMARDPRODUCT_HPP__
+
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "KokkosBatched_Util.hpp"
+#include "KokkosBatched_Vector.hpp"
+
+namespace KokkosBatched {
+
+/// \brief Serial Batched Hadamard Product:
+///   v_ij <- x_ij * y_ij for all i = 1, ..., n and j = 1, ..., N
+/// where:
+///   * n is the number of rows,
+///   * N is the number of vectors.
+///
+/// \tparam XViewType: Input type for X, needs to be a 2D view
+/// \tparam YViewType: Input type for Y, needs to be a 2D view
+/// \tparam VViewType: Input type for V, needs to be a 2D view
+///
+/// \param X [in]: Input vector X, a rank 2 view
+/// \param Y [in]: Input vector Y, a rank 2 view
+/// \param V [out]: Output vector V, a rank 2 view
+///
+/// No nested parallel_for is used inside of the function.
+///
+
+struct SerialHadamardProduct {
+  template <typename XViewType, typename YViewType, typename VViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const XViewType &X,
+                                           const YViewType &Y,
+                                           const VViewType &V);
+};
+
+/// \brief Team Batched Hadamard Product:
+///   v_ij <- x_ij * y_ij for all i = 1, ..., n and j = 1, ..., N
+/// where:
+///   * n is the number of rows,
+///   * N is the number of vectors.
+///
+/// \tparam XViewType: Input type for X, needs to be a 2D view
+/// \tparam YViewType: Input type for Y, needs to be a 2D view
+/// \tparam VViewType: Input type for V, needs to be a 2D view
+///
+/// \param member [in]: TeamPolicy member
+/// \param X [in]: Input vector X, a rank 2 view
+/// \param Y [in]: Input vector Y, a rank 2 view
+/// \param V [out]: Output vector V, a rank 2 view
+///
+/// A nested parallel_for with TeamThreadRange is used.
+///
+
+template <typename MemberType>
+struct TeamHadamardProduct {
+  template <typename XViewType, typename YViewType, typename VViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
+                                           const XViewType &X,
+                                           const YViewType &Y,
+                                           const VViewType &V);
+};
+
+/// \brief TeamVector Batched Hadamard Product:
+///   v_ij <- x_ij * y_ij for all i = 1, ..., n and j = 1, ..., N
+/// where:
+///   * n is the number of rows,
+///   * N is the number of vectors.
+///
+/// \tparam XViewType: Input type for X, needs to be a 2D view
+/// \tparam YViewType: Input type for Y, needs to be a 2D view
+/// \tparam VViewType: Input type for V, needs to be a 2D view
+///
+/// \param member [in]: TeamPolicy member
+/// \param X [in]: Input vector X, a rank 2 view
+/// \param Y [in]: Input vector Y, a rank 2 view
+/// \param V [out]: Output vector V, a rank 2 view
+///
+/// Two nested parallel_for with both TeamThreadRange and ThreadVectorRange
+/// (or one with TeamVectorRange) are used inside.
+///
+
+template <typename MemberType>
+struct TeamVectorHadamardProduct {
+  template <typename XViewType, typename YViewType, typename VViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
+                                           const XViewType &X,
+                                           const YViewType &Y,
+                                           const VViewType &V);
+};
+
+template <typename MemberType, typename ArgMode>
+struct HadamardProduct {
+  template <typename XViewType, typename YViewType, typename VViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
+                                           const XViewType &X,
+                                           const YViewType &Y,
+                                           const VViewType &V) {
+    int r_val = 0;
+    if (std::is_same<ArgMode, Mode::Serial>::value) {
+      r_val = SerialHadamardProduct::template invoke<XViewType, YViewType,
+                                                     VViewType>(X, Y, V);
+    } else if (std::is_same<ArgMode, Mode::Team>::value) {
+      r_val =
+          TeamHadamardProduct<MemberType>::template invoke<XViewType, YViewType,
+                                                           VViewType>(member, X,
+                                                                      Y, V);
+    } else if (std::is_same<ArgMode, Mode::TeamVector>::value) {
+      r_val = TeamVectorHadamardProduct<MemberType>::template invoke<
+          XViewType, YViewType, VViewType>(member, X, Y, V);
+    }
+    return r_val;
+  }
+};
+}  // namespace KokkosBatched
+
+#include "KokkosBatched_HadamardProduct_Impl.hpp"
+
+#endif

--- a/src/batched/dense/impl/KokkosBatched_HadamardProduct_Impl.hpp
+++ b/src/batched/dense/impl/KokkosBatched_HadamardProduct_Impl.hpp
@@ -1,0 +1,270 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.4
+//       Copyright (2021) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+#ifndef __KOKKOSBATCHED_HADAMARDPRODUCT_IMPL_HPP__
+#define __KOKKOSBATCHED_HADAMARDPRODUCT_IMPL_HPP__
+
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "KokkosBatched_Util.hpp"
+
+namespace KokkosBatched {
+
+///
+/// Serial Internal Impl
+/// ====================
+struct SerialHadamardProductInternal {
+  template <typename ScalarType, typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const int m, const int n,
+                                           const ValueType* KOKKOS_RESTRICT X,
+                                           const int xs0, const int xs1,
+                                           const ValueType* KOKKOS_RESTRICT Y,
+                                           const int ys0, const int ys1,
+                                           /* */ ValueType* KOKKOS_RESTRICT V,
+                                           const int vs0, const int vs1) {
+    for (int i = 0; i < m; ++i)
+      for (int j = 0; j < n; ++j)
+        V[i * vs0 + j * vs1] = X[i * xs0 + j * xs1] * Y[i * ys0 + j * ys1];
+
+    return 0;
+  }
+};
+
+///
+/// Team Internal Impl
+/// ====================
+struct TeamHadamardProductInternal {
+  template <typename MemberType, typename ValueType, typename layout>
+  KOKKOS_INLINE_FUNCTION static int invoke(
+      const MemberType& member, const int m, const int n,
+      const ValueType* KOKKOS_RESTRICT X, const int xs0, const int xs1,
+      const ValueType* KOKKOS_RESTRICT Y, const int ys0, const int ys1,
+      /* */ ValueType* KOKKOS_RESTRICT V, const int vs0, const int vs1) {
+    Kokkos::parallel_for(
+        Kokkos::TeamThreadRange(member, 0, m * n), [&](const int& iTemp) {
+          int i, j;
+          getIndices<int, layout>(iTemp, n, m, j, i);
+          V[i * vs0 + j * vs1] = X[i * xs0 + j * xs1] * Y[i * ys0 + j * ys1];
+        });
+    // member.team_barrier();
+    return 0;
+  }
+};
+
+///
+/// TeamVector Internal Impl
+/// ========================
+struct TeamVectorHadamardProductInternal {
+  template <typename MemberType, typename ValueType, typename layout>
+  KOKKOS_INLINE_FUNCTION static int invoke(
+      const MemberType& member, const int m, const int n,
+      const ValueType* KOKKOS_RESTRICT X, const int xs0, const int xs1,
+      const ValueType* KOKKOS_RESTRICT Y, const int ys0, const int ys1,
+      /* */ ValueType* KOKKOS_RESTRICT V, const int vs0, const int vs1) {
+    Kokkos::parallel_for(
+        Kokkos::TeamVectorRange(member, 0, m * n), [&](const int& iTemp) {
+          int i, j;
+          getIndices<int, layout>(iTemp, n, m, j, i);
+          V[i * vs0 + j * vs1] = X[i * xs0 + j * xs1] * Y[i * ys0 + j * ys1];
+        });
+    // member.team_barrier();
+    return 0;
+  }
+};
+
+///
+/// Serial Impl
+/// ===========
+template <typename XViewType, typename YViewType, typename VViewType>
+KOKKOS_INLINE_FUNCTION int SerialHadamardProduct::invoke(const XViewType& X,
+                                                         const YViewType& Y,
+                                                         const VViewType& V) {
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+  static_assert(
+      Kokkos::Impl::is_view<XViewType>::value,
+      "KokkosBatched::HadamardProduct: XViewType is not a Kokkos::View.");
+  static_assert(
+      Kokkos::Impl::is_view<YViewType>::value,
+      "KokkosBatched::HadamardProduct: YViewType is not a Kokkos::View.");
+  static_assert(
+      Kokkos::Impl::is_view<VViewType>::value,
+      "KokkosBatched::HadamardProduct: VViewType is not a Kokkos::View.");
+  static_assert(XViewType::Rank == 2,
+                "KokkosBatched::HadamardProduct: XViewType must have rank 2.");
+  static_assert(YViewType::Rank == 2,
+                "KokkosBatched::HadamardProduct: YViewType must have rank 2.");
+  static_assert(VViewType::Rank == 2,
+                "KokkosBatched::HadamardProduct: VViewType must have rank 2.");
+
+  // Check compatibility of dimensions at run time.
+  if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+    printf(
+        "KokkosBatched::HadamardProduct: Dimensions of X and Y do not match: "
+        "X: %d x %d, "
+        "Y: %d x %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+    return 1;
+  }
+  if (X.extent(0) != V.extent(0) || X.extent(1) != V.extent(1)) {
+    printf(
+        "KokkosBatched::HadamardProduct: Dimensions of X and V do not match: "
+        "X: %d x %d, "
+        "V: %d x %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)V.extent(0), (int)V.extent(1));
+    return 1;
+  }
+#endif
+
+  return SerialHadamardProductInternal::template invoke<
+      typename XViewType::non_const_value_type>(
+      X.extent(0), X.extent(1), X.data(), X.stride_0(), X.stride_1(), Y.data(),
+      Y.stride_0(), Y.stride_1(), V.data(), V.stride_0(), V.stride_1());
+}
+
+///
+/// Team Impl
+/// =========
+
+template <typename MemberType>
+template <typename XViewType, typename YViewType, typename VViewType>
+KOKKOS_INLINE_FUNCTION int TeamHadamardProduct<MemberType>::invoke(
+    const MemberType& member, const XViewType& X, const YViewType& Y,
+    const VViewType& V) {
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+  static_assert(
+      Kokkos::Impl::is_view<XViewType>::value,
+      "KokkosBatched::HadamardProduct: XViewType is not a Kokkos::View.");
+  static_assert(
+      Kokkos::Impl::is_view<YViewType>::value,
+      "KokkosBatched::HadamardProduct: YViewType is not a Kokkos::View.");
+  static_assert(
+      Kokkos::Impl::is_view<VViewType>::value,
+      "KokkosBatched::HadamardProduct: VViewType is not a Kokkos::View.");
+  static_assert(XViewType::Rank == 2,
+                "KokkosBatched::HadamardProduct: XViewType must have rank 2.");
+  static_assert(YViewType::Rank == 2,
+                "KokkosBatched::HadamardProduct: YViewType must have rank 2.");
+  static_assert(VViewType::Rank == 2,
+                "KokkosBatched::HadamardProduct: VViewType must have rank 2.");
+
+  // Check compatibility of dimensions at run time.
+  if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+    printf(
+        "KokkosBatched::HadamardProduct: Dimensions of X and Y do not match: "
+        "X: %d x %d, "
+        "Y: %d x %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+    return 1;
+  }
+  if (X.extent(0) != V.extent(0) || X.extent(1) != V.extent(1)) {
+    printf(
+        "KokkosBatched::HadamardProduct: Dimensions of X and V do not match: "
+        "X: %d x %d, "
+        "V: %d x %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)V.extent(0), (int)V.extent(1));
+    return 1;
+  }
+#endif
+
+  return TeamHadamardProductInternal::template invoke<
+      MemberType, typename XViewType::non_const_value_type,
+      typename XViewType::array_layout>(member, X.extent(0), X.extent(1),
+                                        X.data(), X.stride_0(), X.stride_1(),
+                                        Y.data(), Y.stride_0(), Y.stride_1(),
+                                        V.data(), V.stride_0(), V.stride_1());
+}
+
+///
+/// TeamVector Impl
+/// ===============
+
+template <typename MemberType>
+template <typename XViewType, typename YViewType, typename VViewType>
+KOKKOS_INLINE_FUNCTION int TeamVectorHadamardProduct<MemberType>::invoke(
+    const MemberType& member, const XViewType& X, const YViewType& Y,
+    const VViewType& V) {
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+  static_assert(
+      Kokkos::Impl::is_view<XViewType>::value,
+      "KokkosBatched::HadamardProduct: XViewType is not a Kokkos::View.");
+  static_assert(
+      Kokkos::Impl::is_view<YViewType>::value,
+      "KokkosBatched::HadamardProduct: YViewType is not a Kokkos::View.");
+  static_assert(
+      Kokkos::Impl::is_view<VViewType>::value,
+      "KokkosBatched::HadamardProduct: VViewType is not a Kokkos::View.");
+  static_assert(XViewType::Rank == 2,
+                "KokkosBatched::HadamardProduct: XViewType must have rank 2.");
+  static_assert(YViewType::Rank == 2,
+                "KokkosBatched::HadamardProduct: YViewType must have rank 2.");
+  static_assert(VViewType::Rank == 2,
+                "KokkosBatched::HadamardProduct: VViewType must have rank 2.");
+
+  // Check compatibility of dimensions at run time.
+  if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+    printf(
+        "KokkosBatched::HadamardProduct: Dimensions of X and Y do not match: "
+        "X: %d x %d, "
+        "Y: %d x %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+    return 1;
+  }
+  if (X.extent(0) != V.extent(0) || X.extent(1) != V.extent(1)) {
+    printf(
+        "KokkosBatched::HadamardProduct: Dimensions of X and V do not match: "
+        "X: %d x %d, "
+        "V: %d x %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)V.extent(0), (int)V.extent(1));
+    return 1;
+  }
+#endif
+
+  return TeamVectorHadamardProductInternal::invoke<
+      MemberType, typename XViewType::non_const_value_type,
+      typename XViewType::array_layout>(member, X.extent(0), X.extent(1),
+                                        X.data(), X.stride_0(), X.stride_1(),
+                                        Y.data(), Y.stride_0(), Y.stride_1(),
+                                        V.data(), V.stride_0(), V.stride_1());
+}
+
+}  // namespace KokkosBatched
+
+#endif

--- a/src/batched/sparse/KokkosBatched_Identity.hpp
+++ b/src/batched/sparse/KokkosBatched_Identity.hpp
@@ -1,0 +1,80 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.4
+//       Copyright (2021) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+#ifndef __KOKKOSBATCHED_IDENTITY_HPP__
+#define __KOKKOSBATCHED_IDENTITY_HPP__
+
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "KokkosBatched_Util.hpp"
+
+#include "KokkosBatched_Copy_Decl.hpp"
+
+namespace KokkosBatched {
+
+/// \brief Batched Identity Operator:
+
+class Identity {
+ public:
+  KOKKOS_INLINE_FUNCTION
+  Identity() {}
+
+  KOKKOS_INLINE_FUNCTION
+  ~Identity() {}
+
+  template <typename MemberType, typename XViewType, typename YViewType,
+            typename ArgTrans, typename ArgMode>
+  KOKKOS_INLINE_FUNCTION void apply(const MemberType &member,
+                                    const XViewType &X,
+                                    const YViewType &Y) const {
+    if (std::is_same<ArgMode, KokkosBatched::Mode::Serial>::value) {
+      SerialCopy<Trans::NoTranspose>::invoke(X, Y);
+    } else if (std::is_same<ArgMode, KokkosBatched::Mode::Team>::value) {
+      TeamCopy<MemberType>::invoke(member, X, Y);
+    } else if (std::is_same<ArgMode, KokkosBatched::Mode::TeamVector>::value) {
+      TeamVectorCopy<MemberType>::invoke(member, X, Y);
+    }
+  }
+};
+
+}  // namespace KokkosBatched
+
+#endif

--- a/src/batched/sparse/KokkosBatched_JacobiPrec.hpp
+++ b/src/batched/sparse/KokkosBatched_JacobiPrec.hpp
@@ -1,0 +1,134 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.4
+//       Copyright (2021) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+#ifndef __KOKKOSBATCHED_JACOBIPREC_HPP__
+#define __KOKKOSBATCHED_JACOBIPREC_HPP__
+
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "KokkosBatched_HadamardProduct.hpp"
+
+namespace KokkosBatched {
+
+/// \brief Batched Jacobi Preconditioner:
+///
+/// \tparam ValuesViewType: Input type for the values of the diagonal
+
+template <class ValuesViewType>
+class JacobiPrec {
+ public:
+  using ScalarType = typename ValuesViewType::non_const_value_type;
+  using MagnitudeType =
+      typename Kokkos::Details::ArithTraits<ScalarType>::mag_type;
+
+ private:
+  mutable ValuesViewType diag_values;
+  int n_operators;
+  int n_rows;
+  int n_colums;
+  mutable bool computed_inverse = false;
+
+ public:
+  KOKKOS_INLINE_FUNCTION
+  JacobiPrec(const ValuesViewType &_diag_values) : diag_values(_diag_values) {
+    n_operators = _diag_values.extent(0);
+    n_rows      = _diag_values.extent(1);
+    n_colums    = n_rows;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  ~JacobiPrec() {}
+
+  template <typename MemberType, typename ArgMode>
+  KOKKOS_INLINE_FUNCTION void computeInverse(const MemberType &member) const {
+    auto one = Kokkos::Details::ArithTraits<MagnitudeType>::one();
+    if (std::is_same<ArgMode, Mode::Serial>::value) {
+      for (int i = 0; i < n_operators; ++i)
+        for (int j = 0; j < n_colums; ++j)
+          diag_values(i, j) = one / diag_values(i, j);
+    } else if (std::is_same<ArgMode, Mode::Team>::value) {
+      auto diag_values_array = diag_values.data();
+      auto vs0               = diag_values.stride_0();
+      auto vs1               = diag_values.stride_1();
+
+      Kokkos::parallel_for(
+          Kokkos::TeamThreadRange(member, 0, n_operators * n_rows),
+          [&](const int &iTemp) {
+            int i, j;
+            getIndices<int, typename ValuesViewType::array_layout>(
+                iTemp, n_rows, n_operators, j, i);
+            diag_values_array[i * vs0 + j * vs1] =
+                one / diag_values_array[i * vs0 + j * vs1];
+          });
+    } else if (std::is_same<ArgMode, Mode::TeamVector>::value) {
+      auto diag_values_array = diag_values.data();
+      auto vs0               = diag_values.stride_0();
+      auto vs1               = diag_values.stride_1();
+
+      Kokkos::parallel_for(
+          Kokkos::TeamVectorRange(member, 0, n_operators * n_rows),
+          [&](const int &iTemp) {
+            int i, j;
+            getIndices<int, typename ValuesViewType::array_layout>(
+                iTemp, n_rows, n_operators, j, i);
+            diag_values_array[i * vs0 + j * vs1] =
+                one / diag_values_array[i * vs0 + j * vs1];
+          });
+    }
+
+    computed_inverse = true;
+  }
+
+  template <typename MemberType, typename XViewType, typename YViewType,
+            typename ArgTrans, typename ArgMode>
+  KOKKOS_INLINE_FUNCTION void apply(const MemberType &member,
+                                    const XViewType &X,
+                                    const YViewType &Y) const {
+    if (!computed_inverse) this->computeInverse<MemberType, ArgMode>(member);
+
+    KokkosBatched::HadamardProduct<MemberType, ArgTrans>::template invoke<
+        ValuesViewType, XViewType, YViewType>(member, diag_values, X, Y);
+  }
+};
+
+}  // namespace KokkosBatched
+
+#endif

--- a/src/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
@@ -53,6 +53,7 @@
 #include "KokkosBatched_Xpay.hpp"
 #include "KokkosBatched_Givens_Serial_Internal.hpp"
 #include "KokkosBatched_Trsm_Decl.hpp"
+#include "KokkosBatched_Identity.hpp"
 
 namespace KokkosBatched {
 
@@ -64,12 +65,13 @@ namespace KokkosBatched {
 
 template <typename MemberType>
 struct TeamVectorGMRES {
-  template <typename OperatorType, typename VectorViewType>
+  template <typename OperatorType, typename VectorViewType,
+            typename PrecOperatorType>
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType& member, const OperatorType& A, const VectorViewType& _B,
       const VectorViewType& _X,
-      const KrylovHandle<typename VectorViewType::non_const_value_type>&
-          handle) {
+      const KrylovHandle<typename VectorViewType::non_const_value_type>& handle,
+      const PrecOperatorType& P) {
     typedef int OrdinalType;
     typedef typename Kokkos::Details::ArithTraits<
         typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
@@ -129,6 +131,11 @@ struct TeamVectorGMRES {
                      Mode::TeamVector>(member, X, R, -1, 1);
     member.team_barrier();
 
+    P.template apply<MemberType, ScratchPadVectorViewType,
+                     ScratchPadVectorViewType, Trans::NoTranspose, Mode::Team>(
+        member, R, R);
+    member.team_barrier();
+
     TeamVectorDot<MemberType>::invoke(member, R, R, beta);
     member.team_barrier();
 
@@ -158,6 +165,9 @@ struct TeamVectorGMRES {
       A.template apply<MemberType, ScratchPadVectorViewType,
                        ScratchPadVectorViewType, Trans::NoTranspose,
                        Mode::TeamVector>(member, V_j, W);
+      P.template apply<MemberType, ScratchPadVectorViewType,
+                       ScratchPadVectorViewType, Trans::NoTranspose,
+                       Mode::TeamVector>(member, W, W);
       member.team_barrier();
 
       for (size_t i = 0; i < j + 1; ++i) {
@@ -261,6 +271,17 @@ struct TeamVectorGMRES {
 
     TeamVectorCopy<MemberType>::invoke(member, X, _X);
     return status;
+  }
+
+  template <typename OperatorType, typename VectorViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(
+      const MemberType& member, const OperatorType& A, const VectorViewType& _B,
+      const VectorViewType& _X,
+      const KrylovHandle<typename VectorViewType::non_const_value_type>&
+          handle) {
+    Identity P;
+    return invoke<OperatorType, VectorViewType, Identity>(member, A, _B, _X,
+                                                          handle, P);
   }
 };
 }  // namespace KokkosBatched

--- a/unit_test/batched/sparse/Test_Batched_TeamGMRES.hpp
+++ b/unit_test/batched/sparse/Test_Batched_TeamGMRES.hpp
@@ -7,6 +7,7 @@
 #include "KokkosKernels_TestUtils.hpp"
 #include "KokkosBatched_CrsMatrix.hpp"
 #include "Test_Batched_SparseUtils.hpp"
+#include "KokkosBatched_JacobiPrec.hpp"
 
 using namespace KokkosBatched;
 

--- a/unit_test/batched/sparse/Test_Batched_TeamVectorGMRES.hpp
+++ b/unit_test/batched/sparse/Test_Batched_TeamVectorGMRES.hpp
@@ -7,6 +7,7 @@
 #include "KokkosKernels_TestUtils.hpp"
 #include "KokkosBatched_CrsMatrix.hpp"
 #include "Test_Batched_SparseUtils.hpp"
+#include "KokkosBatched_JacobiPrec.hpp"
 
 using namespace KokkosBatched;
 
@@ -17,6 +18,7 @@ template <typename DeviceType, typename ValuesViewType, typename IntView,
           typename VectorViewType>
 struct Functor_TestBatchedTeamVectorGMRES {
   const ValuesViewType _D;
+  const ValuesViewType _Diag;
   const IntView _r;
   const IntView _c;
   const VectorViewType _X;
@@ -27,8 +29,10 @@ struct Functor_TestBatchedTeamVectorGMRES {
   KOKKOS_INLINE_FUNCTION
   Functor_TestBatchedTeamVectorGMRES(const ValuesViewType &D, const IntView &r,
                                      const IntView &c, const VectorViewType &X,
-                                     const VectorViewType &B, const int N_team)
-      : _D(D), _r(r), _c(c), _X(X), _B(B), _N_team(N_team) {}
+                                     const VectorViewType &B,
+                                     const VectorViewType &diag,
+                                     const int N_team)
+      : _D(D), _r(r), _c(c), _X(X), _B(B), _N_team(N_team), _Diag(diag) {}
 
   template <typename MemberType>
   KOKKOS_INLINE_FUNCTION void operator()(const MemberType &member) const {
@@ -41,18 +45,22 @@ struct Functor_TestBatchedTeamVectorGMRES {
 
     auto d = Kokkos::subview(_D, Kokkos::make_pair(first_matrix, last_matrix),
                              Kokkos::ALL);
+    auto diag = Kokkos::subview(
+        _Diag, Kokkos::make_pair(first_matrix, last_matrix), Kokkos::ALL);
     auto x = Kokkos::subview(_X, Kokkos::make_pair(first_matrix, last_matrix),
                              Kokkos::ALL);
     auto b = Kokkos::subview(_B, Kokkos::make_pair(first_matrix, last_matrix),
                              Kokkos::ALL);
 
-    using Operator = KokkosBatched::CrsMatrix<ValuesViewType, IntView>;
+    using Operator     = KokkosBatched::CrsMatrix<ValuesViewType, IntView>;
+    using PrecOperator = KokkosBatched::JacobiPrec<ValuesViewType>;
 
     Operator A(d, _r, _c);
+    PrecOperator P(diag);
 
     KokkosBatched::TeamVectorGMRES<MemberType>::template invoke<Operator,
                                                                 VectorViewType>(
-        member, A, b, x, handle);
+        member, A, b, x, handle, P);
   }
 
   inline void run() {
@@ -94,6 +102,7 @@ void impl_test_batched_GMRES(const int N, const int BlkSize, const int N_team) {
   VectorViewType R("r0", N, BlkSize);
   VectorViewType B("b", N, BlkSize);
   ValuesViewType D("D", N, nnz);
+  ValuesViewType Diag("Diag", N, BlkSize);
   IntView r("r", BlkSize + 1);
   IntView c("c", nnz);
 
@@ -109,6 +118,29 @@ void impl_test_batched_GMRES(const int N, const int BlkSize, const int N_team) {
   NormViewType sqr_norm_j("sqr_norm_j", N);
 
   create_tridiagonal_batched_matrices(nnz, BlkSize, N, r, c, D, X, B);
+
+  {
+    auto diag_values_host = Kokkos::create_mirror_view(Diag);
+    auto values_host      = Kokkos::create_mirror_view(D);
+    auto row_ptr_host     = Kokkos::create_mirror_view(r);
+    auto colIndices_host  = Kokkos::create_mirror_view(c);
+
+    Kokkos::deep_copy(values_host, D);
+    Kokkos::deep_copy(row_ptr_host, r);
+    Kokkos::deep_copy(colIndices_host, c);
+
+    int current_index;
+    for (int i = 0; i < BlkSize; ++i) {
+      for (current_index = row_ptr_host(i); current_index < row_ptr_host(i + 1);
+           ++current_index) {
+        if (colIndices_host(current_index) == i) break;
+      }
+      for (int j = 0; j < N; ++j)
+        diag_values_host(j, i) = values_host(j, current_index);
+    }
+
+    Kokkos::deep_copy(Diag, diag_values_host);
+  }
 
   // Compute initial norm
 
@@ -137,7 +169,8 @@ void impl_test_batched_GMRES(const int N, const int BlkSize, const int N_team) {
   KokkosBatched::SerialDot<Trans::NoTranspose>::invoke(R_host, R_host,
                                                        sqr_norm_0_host);
   Functor_TestBatchedTeamVectorGMRES<DeviceType, ValuesViewType, IntView,
-                                     VectorViewType>(D, r, c, X, B, N_team)
+                                     VectorViewType>(D, r, c, X, B, Diag,
+                                                     N_team)
       .run();
 
   Kokkos::fence();


### PR DESCRIPTION
This PR adds the batched Jacobi preconditioner for the batched GMRES.

The preconditioner relies on the Hadamard product and on the precomputation of the inverse of the diagonal.
By default, an identity preconditioner is passed to the GMRES and its apply function does nothing.