### PR TITLE
Fix 1216: remove 'impl/' from #include path

### DIFF
--- a/src/sparse/KokkosSparse_BsrMatrix.hpp
+++ b/src/sparse/KokkosSparse_BsrMatrix.hpp
@@ -52,7 +52,7 @@
 #ifndef KOKKOS_SPARSE_BSRMATRIX_HPP_
 #define KOKKOS_SPARSE_BSRMATRIX_HPP_
 
-#include "impl/KokkosSparse_BsrMatrix_impl.hpp"
+#include "KokkosSparse_BsrMatrix_impl.hpp"
 
 namespace KokkosSparse {
 


### PR DESCRIPTION
We add 'src/sparse/impl' to the include path for the library, so doing ``#include "impl/foo.hpp"`` isn't necessary. We install impl/ files directly to the include dir, so in an installed KokkosKernels the impl/foo.hpp include doesn't work.