### PR TITLE
Replace __restrict__ with KOKKOS_RESTRICT

### DIFF
--- a/src/batched/KokkosBatched_Util.hpp
+++ b/src/batched/KokkosBatched_Util.hpp
@@ -462,16 +462,16 @@ struct Algo {
 struct Util {
   template <typename ValueType>
   KOKKOS_INLINE_FUNCTION static void packColMajor(
-      ValueType *__restrict__ A, const int m, const int n,
-      const ValueType *__restrict__ B, const int bs0, const int bs1) {
+      ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+      const ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
     for (int j = 0; j < n; ++j)
       for (int i = 0; i < m; ++i) A[i + j * m] = B[i * bs0 + j * bs1];
   }
 
   template <typename ValueType>
   KOKKOS_INLINE_FUNCTION static void packRowMajor(
-      ValueType *__restrict__ A, const int m, const int n,
-      const ValueType *__restrict__ B, const int bs0, const int bs1) {
+      ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+      const ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
     for (int i = 0; i < m; ++i)
       for (int j = 0; j < n; ++j) A[i * n + j] = B[i * bs0 + j * bs1];
   }

--- a/src/batched/dense/KokkosBatched_InnerGemmFixA_Decl.hpp
+++ b/src/batched/dense/KokkosBatched_InnerGemmFixA_Decl.hpp
@@ -17,19 +17,19 @@ struct InnerGemmFixA {
   // serial rank update
   template <typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION int serial_invoke(const ScalarType alpha,
-                                           const ValueType *__restrict__ A,
-                                           const ValueType *__restrict__ B,
+                                           const ValueType *KOKKOS_RESTRICT A,
+                                           const ValueType *KOKKOS_RESTRICT B,
                                            const int n,
-                                           /**/ ValueType *__restrict__ C);
+                                           /**/ ValueType *KOKKOS_RESTRICT C);
 
   // serial rank update for remainder
   template <typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION int serial_invoke(const ScalarType alpha,
-                                           const ValueType *__restrict__ A,
-                                           const ValueType *__restrict__ B,
+                                           const ValueType *KOKKOS_RESTRICT A,
+                                           const ValueType *KOKKOS_RESTRICT B,
                                            const int m, const int n,
                                            const int k,
-                                           /**/ ValueType *__restrict__ C);
+                                           /**/ ValueType *KOKKOS_RESTRICT C);
 };
 }  // namespace KokkosBatched
 

--- a/src/batched/dense/KokkosBatched_InnerGemmFixB_Decl.hpp
+++ b/src/batched/dense/KokkosBatched_InnerGemmFixB_Decl.hpp
@@ -17,19 +17,19 @@ struct InnerGemmFixB {
   // serial rank update
   template <typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION int serial_invoke(const ScalarType alpha,
-                                           const ValueType *__restrict__ A,
-                                           const ValueType *__restrict__ B,
+                                           const ValueType *KOKKOS_RESTRICT A,
+                                           const ValueType *KOKKOS_RESTRICT B,
                                            const int n,
-                                           /**/ ValueType *__restrict__ C);
+                                           /**/ ValueType *KOKKOS_RESTRICT C);
 
   // serial rank update for remainder
   template <typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION int serial_invoke(const ScalarType alpha,
-                                           const ValueType *__restrict__ A,
-                                           const ValueType *__restrict__ B,
+                                           const ValueType *KOKKOS_RESTRICT A,
+                                           const ValueType *KOKKOS_RESTRICT B,
                                            const int m, const int n,
                                            const int k,
-                                           /**/ ValueType *__restrict__ C);
+                                           /**/ ValueType *KOKKOS_RESTRICT C);
 };
 }  // namespace KokkosBatched
 

--- a/src/batched/dense/KokkosBatched_InnerGemmFixC_Decl.hpp
+++ b/src/batched/dense/KokkosBatched_InnerGemmFixC_Decl.hpp
@@ -17,44 +17,44 @@ struct InnerGemmFixC {
   // serial rank update
   template <typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION int serial_invoke(const ScalarType alpha,
-                                           const ValueType *__restrict__ A,
-                                           const ValueType *__restrict__ B,
+                                           const ValueType *KOKKOS_RESTRICT A,
+                                           const ValueType *KOKKOS_RESTRICT B,
                                            const int k,
-                                           /**/ ValueType *__restrict__ C);
+                                           /**/ ValueType *KOKKOS_RESTRICT C);
 
   // serial rank update for remainder
   template <typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION int serial_invoke(const ScalarType alpha,
-                                           const ValueType *__restrict__ A,
-                                           const ValueType *__restrict__ B,
+                                           const ValueType *KOKKOS_RESTRICT A,
+                                           const ValueType *KOKKOS_RESTRICT B,
                                            const int m, const int k,
-                                           /**/ ValueType *__restrict__ C);
+                                           /**/ ValueType *KOKKOS_RESTRICT C);
 
   // serial rank update for remainder
   template <typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION int serial_invoke(const ScalarType alpha,
-                                           const ValueType *__restrict__ A,
-                                           const ValueType *__restrict__ B,
+                                           const ValueType *KOKKOS_RESTRICT A,
+                                           const ValueType *KOKKOS_RESTRICT B,
                                            const int m, const int n,
                                            const int k,
-                                           /**/ ValueType *__restrict__ C);
+                                           /**/ ValueType *KOKKOS_RESTRICT C);
 
   template <typename MemberType, typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION int team_invoke(const MemberType &member,
                                          const ScalarType alpha,
-                                         const ValueType *__restrict__ A,
-                                         const ValueType *__restrict__ B,
+                                         const ValueType *KOKKOS_RESTRICT A,
+                                         const ValueType *KOKKOS_RESTRICT B,
                                          const int k,
-                                         /**/ ValueType *__restrict__ C);
+                                         /**/ ValueType *KOKKOS_RESTRICT C);
 
   // team rank update for remainder
   template <typename MemberType, typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION int team_invoke(const MemberType &member,
                                          const ScalarType alpha,
-                                         const ValueType *__restrict__ A,
-                                         const ValueType *__restrict__ B,
+                                         const ValueType *KOKKOS_RESTRICT A,
+                                         const ValueType *KOKKOS_RESTRICT B,
                                          const int m, const int n, const int k,
-                                         /**/ ValueType *__restrict__ C);
+                                         /**/ ValueType *KOKKOS_RESTRICT C);
 };
 }  // namespace KokkosBatched
 

--- a/src/batched/dense/KokkosBatched_InnerLU_Decl.hpp
+++ b/src/batched/dense/KokkosBatched_InnerLU_Decl.hpp
@@ -14,17 +14,17 @@ struct InnerLU {
 
   // lu
   template <typename ValueType>
-  KOKKOS_INLINE_FUNCTION int serial_invoke(ValueType *__restrict__ A);
+  KOKKOS_INLINE_FUNCTION int serial_invoke(ValueType *KOKKOS_RESTRICT A);
 
   // for remainder square
   template <typename ValueType>
   KOKKOS_INLINE_FUNCTION int serial_invoke(const int m,
-                                           ValueType *__restrict__ A);
+                                           ValueType *KOKKOS_RESTRICT A);
 
   // for remainder
   template <typename ValueType>
   KOKKOS_INLINE_FUNCTION int serial_invoke(const int m, const int n,
-                                           ValueType *__restrict__ A);
+                                           ValueType *KOKKOS_RESTRICT A);
 };
 }  // namespace KokkosBatched
 

--- a/src/batched/dense/KokkosBatched_InnerMultipleDotProduct_Decl.hpp
+++ b/src/batched/dense/KokkosBatched_InnerMultipleDotProduct_Decl.hpp
@@ -16,17 +16,17 @@ struct InnerMultipleDotProduct {
 
   template <typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION int serial_invoke(const ScalarType alpha,
-                                           const ValueType *__restrict__ A,
-                                           const ValueType *__restrict__ x,
+                                           const ValueType *KOKKOS_RESTRICT A,
+                                           const ValueType *KOKKOS_RESTRICT x,
                                            const int n,
-                                           /**/ ValueType *__restrict__ y);
+                                           /**/ ValueType *KOKKOS_RESTRICT y);
 
   template <typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION int serial_invoke(const ScalarType alpha,
-                                           const ValueType *__restrict__ A,
-                                           const ValueType *__restrict__ x,
+                                           const ValueType *KOKKOS_RESTRICT A,
+                                           const ValueType *KOKKOS_RESTRICT x,
                                            const int m, const int n,
-                                           /**/ ValueType *__restrict__ y);
+                                           /**/ ValueType *KOKKOS_RESTRICT y);
 };
 }  // namespace KokkosBatched
 

--- a/src/batched/dense/KokkosBatched_InnerTrsm_Decl.hpp
+++ b/src/batched/dense/KokkosBatched_InnerTrsm_Decl.hpp
@@ -18,15 +18,15 @@ struct InnerTrsmLeftLowerUnitDiag {
 
   // trisolve
   template <typename ValueType>
-  KOKKOS_INLINE_FUNCTION int serial_invoke(const ValueType *__restrict__ A,
+  KOKKOS_INLINE_FUNCTION int serial_invoke(const ValueType *KOKKOS_RESTRICT A,
                                            const int n,
-                                           /**/ ValueType *__restrict__ B);
+                                           /**/ ValueType *KOKKOS_RESTRICT B);
 
   // for remainder
   template <typename ValueType>
-  KOKKOS_INLINE_FUNCTION int serial_invoke(const ValueType *__restrict__ A,
+  KOKKOS_INLINE_FUNCTION int serial_invoke(const ValueType *KOKKOS_RESTRICT A,
                                            const int m, const int n,
-                                           /**/ ValueType *__restrict__ B);
+                                           /**/ ValueType *KOKKOS_RESTRICT B);
 };
 
 // specialized for different m and n
@@ -42,15 +42,15 @@ struct InnerTrsmLeftLowerNonUnitDiag {
 
   // trisolve
   template <typename ValueType>
-  KOKKOS_INLINE_FUNCTION int serial_invoke(const ValueType *__restrict__ A,
+  KOKKOS_INLINE_FUNCTION int serial_invoke(const ValueType *KOKKOS_RESTRICT A,
                                            const int n,
-                                           /**/ ValueType *__restrict__ B);
+                                           /**/ ValueType *KOKKOS_RESTRICT B);
 
   // for remainder
   template <typename ValueType>
-  KOKKOS_INLINE_FUNCTION int serial_invoke(const ValueType *__restrict__ A,
+  KOKKOS_INLINE_FUNCTION int serial_invoke(const ValueType *KOKKOS_RESTRICT A,
                                            const int m, const int n,
-                                           /**/ ValueType *__restrict__ B);
+                                           /**/ ValueType *KOKKOS_RESTRICT B);
 };
 
 // specialized for different m and n
@@ -66,15 +66,15 @@ struct InnerTrsmLeftUpperUnitDiag {
 
   // trisolve
   template <typename ValueType>
-  KOKKOS_INLINE_FUNCTION int serial_invoke(const ValueType *__restrict__ A,
+  KOKKOS_INLINE_FUNCTION int serial_invoke(const ValueType *KOKKOS_RESTRICT A,
                                            const int n,
-                                           /**/ ValueType *__restrict__ B);
+                                           /**/ ValueType *KOKKOS_RESTRICT B);
 
   // for remainder
   template <typename ValueType>
-  KOKKOS_INLINE_FUNCTION int serial_invoke(const ValueType *__restrict__ A,
+  KOKKOS_INLINE_FUNCTION int serial_invoke(const ValueType *KOKKOS_RESTRICT A,
                                            const int m, const int n,
-                                           /**/ ValueType *__restrict__ B);
+                                           /**/ ValueType *KOKKOS_RESTRICT B);
 };
 
 // specialized for different m and n
@@ -90,15 +90,15 @@ struct InnerTrsmLeftUpperNonUnitDiag {
 
   // trisolve
   template <typename ValueType>
-  KOKKOS_INLINE_FUNCTION int serial_invoke(const ValueType *__restrict__ A,
+  KOKKOS_INLINE_FUNCTION int serial_invoke(const ValueType *KOKKOS_RESTRICT A,
                                            const int n,
-                                           /**/ ValueType *__restrict__ B);
+                                           /**/ ValueType *KOKKOS_RESTRICT B);
 
   // for remainder
   template <typename ValueType>
-  KOKKOS_INLINE_FUNCTION int serial_invoke(const ValueType *__restrict__ A,
+  KOKKOS_INLINE_FUNCTION int serial_invoke(const ValueType *KOKKOS_RESTRICT A,
                                            const int m, const int n,
-                                           /**/ ValueType *__restrict__ B);
+                                           /**/ ValueType *KOKKOS_RESTRICT B);
 };
 
 }  // namespace KokkosBatched

--- a/src/batched/dense/impl/KokkosBatched_AddRadial_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_AddRadial_Internal.hpp
@@ -13,7 +13,7 @@ namespace KokkosBatched {
 struct SerialAddRadialInternal {
   template <typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const int m, const ScalarType tiny,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as) {
     const auto abs_tiny       = tiny > 0 ? tiny : -tiny;
     const auto minus_abs_tiny = -abs_tiny;
@@ -40,7 +40,7 @@ struct TeamAddRadialInternal {
   template <typename MemberType, typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int m, const ScalarType tiny,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as) {
     const auto abs_tiny       = tiny > 0 ? tiny : -tiny;
     const auto minus_abs_tiny = -abs_tiny;

--- a/src/batched/dense/impl/KokkosBatched_ApplyGivens_Serial_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_ApplyGivens_Serial_Internal.hpp
@@ -75,10 +75,10 @@ struct SerialApplyLeftRightGivensInternal {
   template <typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(
       const Kokkos::pair<ValueType, ValueType> &G12, const int &m, const int &n,
-      /* */ ValueType *__restrict__ a1t,
-      /* */ ValueType *__restrict__ a2t,
-      /* */ ValueType *__restrict__ a1,
-      /* */ ValueType *__restrict__ a2, const int &as0, const int &as1) {
+      /* */ ValueType *KOKKOS_RESTRICT a1t,
+      /* */ ValueType *KOKKOS_RESTRICT a2t,
+      /* */ ValueType *KOKKOS_RESTRICT a1,
+      /* */ ValueType *KOKKOS_RESTRICT a2, const int &as0, const int &as1) {
     typedef ValueType value_type;
     if (G12.first == value_type(1) && G12.second == value_type(0)) return 0;
     if (m == 0 && n == 0) return 0;  // quick return
@@ -112,12 +112,12 @@ struct SerialApplyLeftRightGivensInternal {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const Kokkos::pair<ValueType, ValueType> &G12,
       const Kokkos::pair<ValueType, ValueType> &G13, const int &m, const int &n,
-      /* */ ValueType *__restrict__ a1t,
-      /* */ ValueType *__restrict__ a2t,
-      /* */ ValueType *__restrict__ a3t,
-      /* */ ValueType *__restrict__ a1,
-      /* */ ValueType *__restrict__ a2,
-      /* */ ValueType *__restrict__ a3, const int &as0, const int &as1) {
+      /* */ ValueType *KOKKOS_RESTRICT a1t,
+      /* */ ValueType *KOKKOS_RESTRICT a2t,
+      /* */ ValueType *KOKKOS_RESTRICT a3t,
+      /* */ ValueType *KOKKOS_RESTRICT a1,
+      /* */ ValueType *KOKKOS_RESTRICT a2,
+      /* */ ValueType *KOKKOS_RESTRICT a3, const int &as0, const int &as1) {
     typedef ValueType value_type;
     if (m == 0 && n == 0) return 0;  // quick return
 

--- a/src/batched/dense/impl/KokkosBatched_ApplyPivot_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_ApplyPivot_Internal.hpp
@@ -18,7 +18,7 @@ struct TeamVectorApplyPivotVectorForwardInternal {
   template <typename MemberType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int piv,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0) {
     if (piv != 0) {
       Kokkos::single(Kokkos::PerTeam(member), [&]() {
@@ -34,9 +34,9 @@ struct TeamVectorApplyPivotVectorForwardInternal {
   template <typename MemberType, typename IntType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int plen,
-                                           const IntType *__restrict__ p,
+                                           const IntType *KOKKOS_RESTRICT p,
                                            const int ps0,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0) {
     Kokkos::single(Kokkos::PerTeam(member), [&]() {
       for (int i = 0; i < plen; ++i) {
@@ -58,16 +58,16 @@ struct TeamVectorApplyPivotMatrixForwardInternal {
   template <typename MemberType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int n, const int piv,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1) {
     if (piv != 0) {
       Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n),
                            [&](const int &j) {
-                             ValueType *__restrict__ A_at_j = A + j * as1;
-                             const int idx_p                = piv * as0;
-                             const ValueType tmp            = A_at_j[0];
-                             A_at_j[0]                      = A_at_j[idx_p];
-                             A_at_j[idx_p]                  = tmp;
+                             ValueType *KOKKOS_RESTRICT A_at_j = A + j * as1;
+                             const int idx_p                   = piv * as0;
+                             const ValueType tmp               = A_at_j[0];
+                             A_at_j[0]                         = A_at_j[idx_p];
+                             A_at_j[idx_p]                     = tmp;
                            });
     }
     return 0;
@@ -76,12 +76,12 @@ struct TeamVectorApplyPivotMatrixForwardInternal {
   template <typename MemberType, typename IntType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int n, const int plen,
-                                           const IntType *__restrict__ p,
+                                           const IntType *KOKKOS_RESTRICT p,
                                            const int ps0,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1) {
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n), [&](const int &j) {
-      ValueType *__restrict__ A_at_j = A + j * as1;
+      ValueType *KOKKOS_RESTRICT A_at_j = A + j * as1;
       for (int i = 0; i < plen; ++i) {
         const int piv = p[i * ps0];
         if (piv != 0) {
@@ -103,7 +103,7 @@ struct TeamVectorApplyPivotVectorBackwardInternal {
   template <typename MemberType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int piv,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0) {
     if (piv != 0) {
       Kokkos::single(Kokkos::PerTeam(member), [&]() {
@@ -119,9 +119,9 @@ struct TeamVectorApplyPivotVectorBackwardInternal {
   template <typename MemberType, typename IntType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int plen,
-                                           const IntType *__restrict__ p,
+                                           const IntType *KOKKOS_RESTRICT p,
                                            const int ps0,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0) {
     Kokkos::single(Kokkos::PerTeam(member), [&]() {
       for (int i = (plen - 1); i >= 0; --i) {
@@ -143,16 +143,16 @@ struct TeamVectorApplyPivotMatrixBackwardInternal {
   template <typename MemberType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int n, const int piv,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1) {
     if (piv != 0) {
       Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n),
                            [&](const int &j) {
-                             ValueType *__restrict__ A_at_j = A + j * as1;
-                             const int idx_p                = piv * as0;
-                             const ValueType tmp            = A_at_j[0];
-                             A_at_j[0]                      = A_at_j[idx_p];
-                             A_at_j[idx_p]                  = tmp;
+                             ValueType *KOKKOS_RESTRICT A_at_j = A + j * as1;
+                             const int idx_p                   = piv * as0;
+                             const ValueType tmp               = A_at_j[0];
+                             A_at_j[0]                         = A_at_j[idx_p];
+                             A_at_j[idx_p]                     = tmp;
                            });
     }
     return 0;
@@ -161,12 +161,12 @@ struct TeamVectorApplyPivotMatrixBackwardInternal {
   template <typename MemberType, typename IntType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int n, const int plen,
-                                           const IntType *__restrict__ p,
+                                           const IntType *KOKKOS_RESTRICT p,
                                            const int ps0,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1) {
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n), [&](const int &j) {
-      ValueType *__restrict__ A_at_j = A + j * as1;
+      ValueType *KOKKOS_RESTRICT A_at_j = A + j * as1;
       for (int i = (plen - 1); i >= 0; --i) {
         const int piv = p[i * ps0];
         if (piv != 0) {

--- a/src/batched/dense/impl/KokkosBatched_Copy_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Copy_Internal.hpp
@@ -13,11 +13,9 @@ namespace KokkosBatched {
 
 struct SerialCopyInternal {
   template <typename ValueType>
-  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const int m,
-                                                const ValueType *__restrict__ A,
-                                                const int as0,
-                                                /* */ ValueType *__restrict__ B,
-                                                const int bs0) {
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(
+      const int m, const ValueType *KOKKOS_RESTRICT A, const int as0,
+      /* */ ValueType *KOKKOS_RESTRICT B, const int bs0) {
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
 #endif
@@ -26,11 +24,10 @@ struct SerialCopyInternal {
     return 0;
   }
   template <typename ValueType>
-  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const int m, const int n,
-                                                const ValueType *__restrict__ A,
-                                                const int as0, const int as1,
-                                                /* */ ValueType *__restrict__ B,
-                                                const int bs0, const int bs1) {
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(
+      const int m, const int n, const ValueType *KOKKOS_RESTRICT A,
+      const int as0, const int as1,
+      /* */ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
     if (as1 < as0)
       for (int i = 0; i < m; ++i) invoke(n, A + i * as0, as1, B + i * bs0, bs1);
     else
@@ -44,24 +41,20 @@ struct SerialCopyInternal {
 /// ==================
 struct TeamCopyInternal {
   template <typename MemberType, typename ValueType>
-  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member,
-                                                const int m,
-                                                const ValueType *__restrict__ A,
-                                                const int as0,
-                                                /* */ ValueType *__restrict__ B,
-                                                const int bs0) {
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(
+      const MemberType &member, const int m, const ValueType *KOKKOS_RESTRICT A,
+      const int as0,
+      /* */ ValueType *KOKKOS_RESTRICT B, const int bs0) {
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, m),
                          [&](const int &i) { B[i * bs0] = A[i * as0]; });
     // member.team_barrier();
     return 0;
   }
   template <typename MemberType, typename ValueType>
-  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member,
-                                                const int m, const int n,
-                                                const ValueType *__restrict__ A,
-                                                const int as0, const int as1,
-                                                /* */ ValueType *__restrict__ B,
-                                                const int bs0, const int bs1) {
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(
+      const MemberType &member, const int m, const int n,
+      const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+      /* */ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
     if (m >= n) {
       Kokkos::parallel_for(
           Kokkos::TeamThreadRange(member, m), [&](const int &i) {
@@ -83,24 +76,20 @@ struct TeamCopyInternal {
 /// ========================
 struct TeamVectorCopyInternal {
   template <typename MemberType, typename ValueType>
-  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member,
-                                                const int m,
-                                                const ValueType *__restrict__ A,
-                                                const int as0,
-                                                /* */ ValueType *__restrict__ B,
-                                                const int bs0) {
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(
+      const MemberType &member, const int m, const ValueType *KOKKOS_RESTRICT A,
+      const int as0,
+      /* */ ValueType *KOKKOS_RESTRICT B, const int bs0) {
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, m),
                          [&](const int &i) { B[i * bs0] = A[i * as0]; });
     // member.team_barrier();
     return 0;
   }
   template <typename MemberType, typename ValueType>
-  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member,
-                                                const int m, const int n,
-                                                const ValueType *__restrict__ A,
-                                                const int as0, const int as1,
-                                                /* */ ValueType *__restrict__ B,
-                                                const int bs0, const int bs1) {
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(
+      const MemberType &member, const int m, const int n,
+      const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+      /* */ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
     if (as0 > as1) {
       Kokkos::parallel_for(
           Kokkos::TeamThreadRange(member, m), [&](const int &i) {

--- a/src/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
@@ -16,9 +16,9 @@ struct SerialDotInternal {
   // C = conj(A(:))*B(:)
   template <typename ValueType, typename MagnitudeType>
   KOKKOS_FORCEINLINE_FUNCTION static int invoke(
-      const int m, const ValueType *__restrict__ A, const int as0,
-      const ValueType *__restrict__ B, const int bs0,
-      /* */ MagnitudeType *__restrict__ C) {
+      const int m, const ValueType *KOKKOS_RESTRICT A, const int as0,
+      const ValueType *KOKKOS_RESTRICT B, const int bs0,
+      /* */ MagnitudeType *KOKKOS_RESTRICT C) {
     using ats = Kokkos::ArithTraits<ValueType>;
     C[0]      = ValueType(0);
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
@@ -34,13 +34,11 @@ struct SerialDotInternal {
   // j \in [0,n), i \in [0,m)
   // C(j) = conj(A(:,j))*B(:,j)
   template <typename ValueType, typename MagnitudeType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const int m, const int n,
-                                           const ValueType *__restrict__ A,
-                                           const int as0, const int as1,
-                                           const ValueType *__restrict__ B,
-                                           const int bs0, const int bs1,
-                                           /* */ MagnitudeType *__restrict__ C,
-                                           const int cs) {
+  KOKKOS_INLINE_FUNCTION static int invoke(
+      const int m, const int n, const ValueType *KOKKOS_RESTRICT A,
+      const int as0, const int as1, const ValueType *KOKKOS_RESTRICT B,
+      const int bs0, const int bs1,
+      /* */ MagnitudeType *KOKKOS_RESTRICT C, const int cs) {
     for (int j = 0; j < n; ++j)
       invoke(m, A + j * as1, as0, B + j * bs1, bs0, C + j * cs);
     return 0;
@@ -56,9 +54,9 @@ struct SerialDotInternal {
 struct TeamDotInternal {
   template <typename MemberType, typename ValueType, typename MagnitudeType>
   KOKKOS_FORCEINLINE_FUNCTION static int invoke(
-      const MemberType &member, const int m, const ValueType *__restrict__ A,
-      const int as0, const ValueType *__restrict__ B, const int bs0,
-      /* */ MagnitudeType *__restrict__ C) {
+      const MemberType &member, const int m, const ValueType *KOKKOS_RESTRICT A,
+      const int as0, const ValueType *KOKKOS_RESTRICT B, const int bs0,
+      /* */ MagnitudeType *KOKKOS_RESTRICT C) {
     using ats = Kokkos::ArithTraits<ValueType>;
     ValueType t(0);
     Kokkos::parallel_reduce(
@@ -77,14 +75,14 @@ struct TeamDotInternal {
   template <typename MemberType, typename ValueType, typename MagnitudeType>
   KOKKOS_FORCEINLINE_FUNCTION static int invoke(
       const MemberType &member, const int m, const int n,
-      const ValueType *__restrict__ A, const int as0, const int as1,
-      const ValueType *__restrict__ B, const int bs0, const int bs1,
-      /* */ MagnitudeType *__restrict__ C, const int cs) {
+      const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+      const ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1,
+      /* */ MagnitudeType *KOKKOS_RESTRICT C, const int cs) {
     using ats = Kokkos::ArithTraits<ValueType>;
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int &j) {
       ValueType t(0);
-      const ValueType *__restrict__ A_at_j = A + j * as1;
-      const ValueType *__restrict__ B_at_j = B + j * bs1;
+      const ValueType *KOKKOS_RESTRICT A_at_j = A + j * as1;
+      const ValueType *KOKKOS_RESTRICT B_at_j = B + j * bs1;
       for (int i = 0; i < m; ++i) {
         const int idx_a = i * as0, idx_b = i * bs0;
         t += ats::conj(A_at_j[idx_a]) * B_at_j[idx_b];
@@ -104,9 +102,9 @@ struct TeamDotInternal {
 struct TeamVectorDotInternal {
   template <typename MemberType, typename ValueType, typename MagnitudeType>
   KOKKOS_FORCEINLINE_FUNCTION static int invoke(
-      const MemberType &member, const int m, const ValueType *__restrict__ A,
-      const int as0, const ValueType *__restrict__ B, const int bs0,
-      /* */ MagnitudeType *__restrict__ C) {
+      const MemberType &member, const int m, const ValueType *KOKKOS_RESTRICT A,
+      const int as0, const ValueType *KOKKOS_RESTRICT B, const int bs0,
+      /* */ MagnitudeType *KOKKOS_RESTRICT C) {
     using ats = Kokkos::ArithTraits<ValueType>;
     ValueType t(0);
     Kokkos::parallel_reduce(
@@ -125,14 +123,14 @@ struct TeamVectorDotInternal {
   template <typename MemberType, typename ValueType, typename MagnitudeType>
   KOKKOS_FORCEINLINE_FUNCTION static int invoke(
       const MemberType &member, const int m, const int n,
-      const ValueType *__restrict__ A, const int as0, const int as1,
-      const ValueType *__restrict__ B, const int bs0, const int bs1,
-      /* */ MagnitudeType *__restrict__ C, const int cs) {
+      const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+      const ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1,
+      /* */ MagnitudeType *KOKKOS_RESTRICT C, const int cs) {
     using ats = Kokkos::ArithTraits<ValueType>;
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int &j) {
       ValueType t(0);
-      const ValueType *__restrict__ A_at_j = A + j * as1;
-      const ValueType *__restrict__ B_at_j = B + j * bs1;
+      const ValueType *KOKKOS_RESTRICT A_at_j = A + j * as1;
+      const ValueType *KOKKOS_RESTRICT B_at_j = B + j * bs1;
       Kokkos::parallel_reduce(
           Kokkos::ThreadVectorRange(member, m),
           [&](const int &i, ValueType &update) {

--- a/src/batched/dense/impl/KokkosBatched_FindAmax_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_FindAmax_Internal.hpp
@@ -13,9 +13,9 @@ namespace KokkosBatched {
 struct SerialFindAmaxInternal {
   template <typename ValueType, typename IntType>
   KOKKOS_INLINE_FUNCTION static int invoke(const int m,
-                                           const ValueType *__restrict__ A,
+                                           const ValueType *KOKKOS_RESTRICT A,
                                            const int as0,
-                                           /**/ IntType *__restrict__ idx) {
+                                           /**/ IntType *KOKKOS_RESTRICT idx) {
     ValueType max_val(A[0]);
     IntType val_loc(0);
     for (int i = 1; i < m; ++i) {
@@ -37,9 +37,9 @@ struct TeamVectorFindAmaxInternal {
   template <typename MemberType, typename ValueType, typename IntType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int m,
-                                           const ValueType *__restrict__ A,
+                                           const ValueType *KOKKOS_RESTRICT A,
                                            const int as0,
-                                           /**/ IntType *__restrict__ idx) {
+                                           /**/ IntType *KOKKOS_RESTRICT idx) {
     if (m > 0) {
       using reducer_value_type =
           typename Kokkos::MaxLoc<ValueType, IntType>::value_type;

--- a/src/batched/dense/impl/KokkosBatched_Gemm_Serial_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Gemm_Serial_Internal.hpp
@@ -21,20 +21,20 @@ struct SerialGemmInternal {
   template <typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(
       const int m, const int n, const int k, const ScalarType alpha,
-      const ValueType *__restrict__ A, const int as0, const int as1,
-      const ValueType *__restrict__ B, const int bs0, const int bs1,
+      const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+      const ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1,
       const ScalarType beta,
-      /**/ ValueType *__restrict__ C, const int cs0, const int cs1);
+      /**/ ValueType *KOKKOS_RESTRICT C, const int cs0, const int cs1);
 };
 
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialGemmInternal<Algo::Gemm::Unblocked>::invoke(
     const int m, const int n, const int k, const ScalarType alpha,
-    const ValueType *__restrict__ A, const int as0, const int as1,
-    const ValueType *__restrict__ B, const int bs0, const int bs1,
+    const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+    const ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1,
     const ScalarType beta,
-    /**/ ValueType *__restrict__ C, const int cs0, const int cs1) {
+    /**/ ValueType *KOKKOS_RESTRICT C, const int cs0, const int cs1) {
   // C = beta C + alpha A B
   // C (m x n), A(m x k), B(k x n)
 
@@ -48,10 +48,10 @@ KOKKOS_INLINE_FUNCTION int SerialGemmInternal<Algo::Gemm::Unblocked>::invoke(
   if (alpha != zero) {
     if (m <= 0 || n <= 0 || k <= 0) return 0;
 
-    ValueType *__restrict__ pC = C;
+    ValueType *KOKKOS_RESTRICT pC = C;
     for (int p = 0; p < k; ++p) {
-      const ValueType *__restrict__ pA               = A + p * as1,
-                                    *__restrict__ pB = B + p * bs0;
+      const ValueType *KOKKOS_RESTRICT pA                  = A + p * as1,
+                                       *KOKKOS_RESTRICT pB = B + p * bs0;
       for (int i = 0; i < m; ++i) {
         const ValueType tA(alpha * pA[i * as0]);
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
@@ -68,10 +68,10 @@ template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialGemmInternal<Algo::Gemm::Blocked>::invoke(
     const int m, const int n, const int k, const ScalarType alpha,
-    const ValueType *__restrict__ A, const int as0, const int as1,
-    const ValueType *__restrict__ B, const int bs0, const int bs1,
+    const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+    const ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1,
     const ScalarType beta,
-    /**/ ValueType *__restrict__ C, const int cs0, const int cs1) {
+    /**/ ValueType *KOKKOS_RESTRICT C, const int cs0, const int cs1) {
   // C = beta C + alpha A B
   // C (m x n), A(m x k), B(k x n)
 
@@ -94,9 +94,9 @@ KOKKOS_INLINE_FUNCTION int SerialGemmInternal<Algo::Gemm::Blocked>::invoke(
 
     InnerGemmFixC<mbAlgo, nbAlgo> inner(as0, as1, bs0, bs1, cs0, cs1);
     auto gemm = [&](const int ib, const int jb, const int pb,
-                    const ValueType *__restrict__ AA,
-                    const ValueType *__restrict__ BB,
-                    /**/ ValueType *__restrict__ CC) {
+                    const ValueType *KOKKOS_RESTRICT AA,
+                    const ValueType *KOKKOS_RESTRICT BB,
+                    /**/ ValueType *KOKKOS_RESTRICT CC) {
       const int mb = mbAlgo, nb = nbAlgo;
       for (int i = 0; i < ib; i += mb)
         for (int j = 0; j < jb; j += nb)
@@ -122,9 +122,9 @@ KOKKOS_INLINE_FUNCTION int SerialGemmInternal<Algo::Gemm::Blocked>::invoke(
       //     for (int ii=0;ii<m;ii+=mc) {
       //       const int ti = m-ii, ib = (ti < mc ? ti : mc);
 
-      //       const ValueType *__restrict__ AA = A+ii*as0+pp*as1;
-      //       const ValueType *__restrict__ BB = B+pp*bs0+jj*bs1;
-      //       /**/  ValueType *__restrict__ CC = C+ii*cs0+jj*cs1;
+      //       const ValueType *KOKKOS_RESTRICT AA = A+ii*as0+pp*as1;
+      //       const ValueType *KOKKOS_RESTRICT BB = B+pp*bs0+jj*bs1;
+      //       /**/  ValueType *KOKKOS_RESTRICT CC = C+ii*cs0+jj*cs1;
 
       //       gemm(ib, jb, pb, AA, BB, CC);
       //     } // for ii

--- a/src/batched/dense/impl/KokkosBatched_Gemm_TeamVector_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Gemm_TeamVector_Internal.hpp
@@ -18,10 +18,10 @@ struct TeamVectorGemmInternal {
   template <typename MemberType, typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType &member, const int m, const int n, const int k,
-      const ScalarType alpha, const ValueType *__restrict__ A, const int as0,
-      const int as1, const ValueType *__restrict__ B, const int bs0,
+      const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A, const int as0,
+      const int as1, const ValueType *KOKKOS_RESTRICT B, const int bs0,
       const int bs1, const ScalarType beta,
-      /**/ ValueType *__restrict__ C, const int cs0, const int cs1);
+      /**/ ValueType *KOKKOS_RESTRICT C, const int cs0, const int cs1);
 };
 
 template <>
@@ -29,10 +29,10 @@ template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int
 TeamVectorGemmInternal<Algo::Gemm::Unblocked>::invoke(
     const MemberType &member, const int m, const int n, const int k,
-    const ScalarType alpha, const ValueType *__restrict__ A, const int as0,
-    const int as1, const ValueType *__restrict__ B, const int bs0,
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A, const int as0,
+    const int as1, const ValueType *KOKKOS_RESTRICT B, const int bs0,
     const int bs1, const ScalarType beta,
-    /**/ ValueType *__restrict__ C, const int cs0, const int cs1) {
+    /**/ ValueType *KOKKOS_RESTRICT C, const int cs0, const int cs1) {
   // C = beta C + alpha A B
   // C (m x n), A(m x k), B(k x n)
 
@@ -49,10 +49,10 @@ TeamVectorGemmInternal<Algo::Gemm::Unblocked>::invoke(
     if (beta != one) member.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, m), [&](const int &i) {
-      const ValueType *__restrict__ pA = A + i * as0;
+      const ValueType *KOKKOS_RESTRICT pA = A + i * as0;
       Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, n),
                            [&](const int &j) {
-                             const ValueType *__restrict__ pB = B + j * bs1;
+                             const ValueType *KOKKOS_RESTRICT pB = B + j * bs1;
 
                              ValueType c = ValueType(0);
                              for (int p = 0; p < k; ++p)

--- a/src/batched/dense/impl/KokkosBatched_Gemm_Team_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Gemm_Team_Internal.hpp
@@ -21,20 +21,20 @@ struct TeamGemmInternal {
   template <typename MemberType, typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType &member, const int m, const int n, const int k,
-      const ScalarType alpha, const ValueType *__restrict__ A, const int as0,
-      const int as1, const ValueType *__restrict__ B, const int bs0,
+      const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A, const int as0,
+      const int as1, const ValueType *KOKKOS_RESTRICT B, const int bs0,
       const int bs1, const ScalarType beta,
-      /**/ ValueType *__restrict__ C, const int cs0, const int cs1);
+      /**/ ValueType *KOKKOS_RESTRICT C, const int cs0, const int cs1);
 };
 
 template <>
 template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
     const MemberType &member, const int m, const int n, const int k,
-    const ScalarType alpha, const ValueType *__restrict__ A, const int as0,
-    const int as1, const ValueType *__restrict__ B, const int bs0,
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A, const int as0,
+    const int as1, const ValueType *KOKKOS_RESTRICT B, const int bs0,
     const int bs1, const ScalarType beta,
-    /**/ ValueType *__restrict__ C, const int cs0, const int cs1) {
+    /**/ ValueType *KOKKOS_RESTRICT C, const int cs0, const int cs1) {
   // C = beta C + alpha A B
   // C (m x n), A(m x k), B(k x n)
 
@@ -54,8 +54,8 @@ KOKKOS_INLINE_FUNCTION int TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
         Kokkos::TeamThreadRange(member, 0, m * n), [&](const int &ij) {
           // assume layout right for batched computation
           const int i = ij / n, j = ij % n;
-          const ValueType *__restrict__ pA               = A + i * as0,
-                                        *__restrict__ pB = B + j * bs1;
+          const ValueType *KOKKOS_RESTRICT pA                  = A + i * as0,
+                                           *KOKKOS_RESTRICT pB = B + j * bs1;
 
           ValueType c = ValueType(0);
           for (int p = 0; p < k; ++p) c += pA[p * as1] * pB[p * bs0];
@@ -69,10 +69,10 @@ template <>
 template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
     const MemberType &member, const int m, const int n, const int k,
-    const ScalarType alpha, const ValueType *__restrict__ A, const int as0,
-    const int as1, const ValueType *__restrict__ B, const int bs0,
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A, const int as0,
+    const int as1, const ValueType *KOKKOS_RESTRICT B, const int bs0,
     const int bs1, const ScalarType beta,
-    /**/ ValueType *__restrict__ C, const int cs0, const int cs1) {
+    /**/ ValueType *KOKKOS_RESTRICT C, const int cs0, const int cs1) {
   // C = beta C + alpha A B
   // C (m x n), A(m x k), B(k x n)
 
@@ -98,9 +98,9 @@ KOKKOS_INLINE_FUNCTION int TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
     /// GPU case: team size is large and blocksize (mb,nb) is small
     InnerGemmFixC<mbAlgo, nbAlgo> inner(as0, as1, bs0, bs1, cs0, cs1);
     auto gemm = [&](const int ib, const int jb, const int pb,
-                    const ValueType *__restrict__ AA,
-                    const ValueType *__restrict__ BB,
-                    /**/ ValueType *__restrict__ CC) {
+                    const ValueType *KOKKOS_RESTRICT AA,
+                    const ValueType *KOKKOS_RESTRICT BB,
+                    /**/ ValueType *KOKKOS_RESTRICT CC) {
       // Made this non-const in order to WORKAROUND issue #349
       int mb = mbAlgo, mp = (ib % mb), mq = (ib / mb) + (mp > 0), nb = nbAlgo,
           np = (jb % nb), nq = (jb / nb) + (np > 0);
@@ -140,9 +140,9 @@ KOKKOS_INLINE_FUNCTION int TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
       //     for (int ii=0;ii<m;ii+=mc) {
       //       const int ti = m-ii, ib = (ti < mc ? ti : mc);
 
-      //       const ValueType *__restrict__ AA = A+ii*as0+pp*as1;
-      //       const ValueType *__restrict__ BB = B+pp*bs0+jj*bs1;
-      //       /**/  ValueType *__restrict__ CC = C+ii*cs0+jj*cs1;
+      //       const ValueType *KOKKOS_RESTRICT AA = A+ii*as0+pp*as1;
+      //       const ValueType *KOKKOS_RESTRICT BB = B+pp*bs0+jj*bs1;
+      //       /**/  ValueType *KOKKOS_RESTRICT CC = C+ii*cs0+jj*cs1;
 
       //       gemm(ib, jb, pb, AA, BB, CC);
       //     } // for ii

--- a/src/batched/dense/impl/KokkosBatched_Gemv_Serial_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Gemv_Serial_Internal.hpp
@@ -21,18 +21,18 @@ struct SerialGemvInternal {
   template <typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(
       const int m, const int n, const ScalarType alpha,
-      const ValueType *__restrict__ A, const int as0, const int as1,
-      const ValueType *__restrict__ x, const int xs0, const ScalarType beta,
-      /**/ ValueType *__restrict__ y, const int ys0);
+      const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+      const ValueType *KOKKOS_RESTRICT x, const int xs0, const ScalarType beta,
+      /**/ ValueType *KOKKOS_RESTRICT y, const int ys0);
 };
 
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialGemvInternal<Algo::Gemv::Unblocked>::invoke(
     const int m, const int n, const ScalarType alpha,
-    const ValueType *__restrict__ A, const int as0, const int as1,
-    const ValueType *__restrict__ x, const int xs0, const ScalarType beta,
-    /**/ ValueType *__restrict__ y, const int ys0) {
+    const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+    const ValueType *KOKKOS_RESTRICT x, const int xs0, const ScalarType beta,
+    /**/ ValueType *KOKKOS_RESTRICT y, const int ys0) {
   const ScalarType one(1.0), zero(0.0);
 
   // y = beta y + alpha A x
@@ -48,7 +48,7 @@ KOKKOS_INLINE_FUNCTION int SerialGemvInternal<Algo::Gemv::Unblocked>::invoke(
 
     for (int i = 0; i < m; ++i) {
       ValueType t(0);
-      const ValueType *__restrict__ tA = (A + i * as0);
+      const ValueType *KOKKOS_RESTRICT tA = (A + i * as0);
 
 #if defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
 #pragma ivdep
@@ -67,9 +67,9 @@ template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialGemvInternal<Algo::Gemv::Blocked>::invoke(
     const int m, const int n, const ScalarType alpha,
-    const ValueType *__restrict__ A, const int as0, const int as1,
-    const ValueType *__restrict__ x, const int xs0, const ScalarType beta,
-    /**/ ValueType *__restrict__ y, const int ys0) {
+    const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+    const ValueType *KOKKOS_RESTRICT x, const int xs0, const ScalarType beta,
+    /**/ ValueType *KOKKOS_RESTRICT y, const int ys0) {
   const ScalarType one(1.0), zero(0.0);
 
   // y = beta y + alpha A x

--- a/src/batched/dense/impl/KokkosBatched_Gemv_TeamVector_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Gemv_TeamVector_Internal.hpp
@@ -20,10 +20,11 @@ struct TeamVectorGemvInternal {
   template <typename MemberType, typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType & /*member*/, const int /*m*/, const int /*n*/,
-      const ScalarType /*alpha*/, const ValueType *__restrict__ /*A*/,
-      const int /*as0*/, const int /*as1*/, const ValueType *__restrict__ /*x*/,
-      const int /*xs0*/, const ScalarType /*beta*/,
-      /**/ ValueType *__restrict__ /*y*/, const int /*ys0*/) {
+      const ScalarType /*alpha*/, const ValueType *KOKKOS_RESTRICT /*A*/,
+      const int /*as0*/, const int /*as1*/,
+      const ValueType *KOKKOS_RESTRICT /*x*/, const int /*xs0*/,
+      const ScalarType /*beta*/,
+      /**/ ValueType *KOKKOS_RESTRICT /*y*/, const int /*ys0*/) {
     assert(false && "Error: encounter dummy impl");
     return 0;
   }
@@ -34,9 +35,9 @@ template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int
 TeamVectorGemvInternal<Algo::Gemv::Unblocked>::invoke(
     const MemberType &member, const int m, const int n, const ScalarType alpha,
-    const ValueType *__restrict__ A, const int as0, const int as1,
-    const ValueType *__restrict__ x, const int xs0, const ScalarType beta,
-    /**/ ValueType *__restrict__ y, const int ys0) {
+    const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+    const ValueType *KOKKOS_RESTRICT x, const int xs0, const ScalarType beta,
+    /**/ ValueType *KOKKOS_RESTRICT y, const int ys0) {
   const ScalarType one(1.0), zero(0.0);
 
   // y = beta y + alpha A x
@@ -54,7 +55,7 @@ TeamVectorGemvInternal<Algo::Gemv::Unblocked>::invoke(
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, m), [&](const int &i) {
       ValueType t(0);
-      const ValueType *__restrict__ tA = (A + i * as0);
+      const ValueType *KOKKOS_RESTRICT tA = (A + i * as0);
       Kokkos::parallel_reduce(
           Kokkos::ThreadVectorRange(member, n),
           [&](const int &j, ValueType &update) {

--- a/src/batched/dense/impl/KokkosBatched_Gemv_Team_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Gemv_Team_Internal.hpp
@@ -20,19 +20,19 @@ struct TeamGemvInternal {
   template <typename MemberType, typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType &member, const int m, const int n,
-      const ScalarType alpha, const ValueType *__restrict__ A, const int as0,
-      const int as1, const ValueType *__restrict__ x, const int xs0,
+      const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A, const int as0,
+      const int as1, const ValueType *KOKKOS_RESTRICT x, const int xs0,
       const ScalarType beta,
-      /**/ ValueType *__restrict__ y, const int ys0);
+      /**/ ValueType *KOKKOS_RESTRICT y, const int ys0);
 };
 
 template <>
 template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int TeamGemvInternal<Algo::Gemv::Unblocked>::invoke(
     const MemberType &member, const int m, const int n, const ScalarType alpha,
-    const ValueType *__restrict__ A, const int as0, const int as1,
-    const ValueType *__restrict__ x, const int xs0, const ScalarType beta,
-    /**/ ValueType *__restrict__ y, const int ys0) {
+    const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+    const ValueType *KOKKOS_RESTRICT x, const int xs0, const ScalarType beta,
+    /**/ ValueType *KOKKOS_RESTRICT y, const int ys0) {
   const ScalarType one(1.0), zero(0.0);
 
   // y = beta y + alpha A x
@@ -51,7 +51,7 @@ KOKKOS_INLINE_FUNCTION int TeamGemvInternal<Algo::Gemv::Unblocked>::invoke(
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, m),
                          [&](const int &i) {
                            ValueType t(0);
-                           const ValueType *__restrict__ tA = (A + i * as0);
+                           const ValueType *KOKKOS_RESTRICT tA = (A + i * as0);
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
 #endif
@@ -67,9 +67,9 @@ template <>
 template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int TeamGemvInternal<Algo::Gemv::Blocked>::invoke(
     const MemberType &member, const int m, const int n, const ScalarType alpha,
-    const ValueType *__restrict__ A, const int as0, const int as1,
-    const ValueType *__restrict__ x, const int xs0, const ScalarType beta,
-    /**/ ValueType *__restrict__ y, const int ys0) {
+    const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+    const ValueType *KOKKOS_RESTRICT x, const int xs0, const ScalarType beta,
+    /**/ ValueType *KOKKOS_RESTRICT y, const int ys0) {
   const ScalarType one(1.0), zero(0.0);
 
   // y = beta y + alpha A x

--- a/src/batched/dense/impl/KokkosBatched_InnerGemmFixA_Serial_Impl.hpp
+++ b/src/batched/dense/impl/KokkosBatched_InnerGemmFixA_Serial_Impl.hpp
@@ -15,9 +15,9 @@ namespace KokkosBatched {
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<5, 5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
@@ -86,9 +86,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<5, 5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<5, 4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
@@ -149,9 +149,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<5, 4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<5, 3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
@@ -203,9 +203,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<5, 3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<5, 2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
@@ -249,9 +249,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<5, 2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<5, 1>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_10 = A[1 * _as0 + 0 * _as1],
@@ -289,9 +289,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<5, 1>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<4, 5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
@@ -351,9 +351,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<4, 5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<3, 5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
@@ -403,9 +403,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<3, 5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<2, 5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
@@ -446,9 +446,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<2, 5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<1, 5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
@@ -482,9 +482,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<1, 5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<5, 5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m, const int n, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m, const int n, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0 || n <= 0 || k <= 0) return 0;
 
   switch (m * 10 + k) {
@@ -554,9 +554,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<5, 5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<4, 4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
@@ -608,9 +608,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<4, 4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<4, 3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
@@ -656,9 +656,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<4, 3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<4, 2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
@@ -698,9 +698,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<4, 2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<4, 1>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_10 = A[1 * _as0 + 0 * _as1],
@@ -734,9 +734,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<4, 1>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<3, 4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
@@ -781,9 +781,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<3, 4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<2, 4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
@@ -821,9 +821,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<2, 4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<1, 4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
@@ -854,9 +854,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<1, 4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<4, 4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m, const int n, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m, const int n, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0 || n <= 0 || k <= 0) return 0;
 
   switch (m * 10 + k) {
@@ -921,9 +921,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<4, 4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<3, 3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
@@ -963,9 +963,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<3, 3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<3, 2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
@@ -1000,9 +1000,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<3, 2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<3, 1>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_10 = A[1 * _as0 + 0 * _as1],
@@ -1032,9 +1032,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<3, 1>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<2, 3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
@@ -1067,9 +1067,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<2, 3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<1, 3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
@@ -1097,9 +1097,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<1, 3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<3, 3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m, const int n, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m, const int n, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0 || n <= 0 || k <= 0) return 0;
 
   switch (m * 10 + k) {
@@ -1154,9 +1154,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<3, 3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<2, 2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
@@ -1185,9 +1185,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<2, 2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<2, 1>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_10 = A[1 * _as0 + 0 * _as1];
@@ -1213,9 +1213,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<2, 1>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<1, 2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1];
@@ -1240,9 +1240,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<1, 2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<2, 2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m, const int n, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m, const int n, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0 || n <= 0 || k <= 0) return 0;
 
   switch (m * 10 + k) {
@@ -1283,9 +1283,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixA<2, 2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixA<1, 1>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int n,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (n <= 0) return 0;
 
   const ValueType a_00 = A[0 * _as0 + 0 * _as1];

--- a/src/batched/dense/impl/KokkosBatched_InnerGemmFixB_Serial_Impl.hpp
+++ b/src/batched/dense/impl/KokkosBatched_InnerGemmFixB_Serial_Impl.hpp
@@ -15,9 +15,9 @@ namespace KokkosBatched {
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<5, 5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1],
@@ -86,9 +86,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<5, 5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<5, 4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1],
@@ -148,9 +148,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<5, 4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<5, 3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1],
@@ -200,9 +200,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<5, 3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<5, 2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1],
@@ -243,9 +243,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<5, 2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<5, 1>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_10 = B[1 * _bs0 + 0 * _bs1],
@@ -279,9 +279,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<5, 1>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<4, 5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1],
@@ -341,9 +341,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<4, 5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<3, 5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1],
@@ -393,9 +393,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<3, 5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<2, 5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1],
@@ -436,9 +436,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<2, 5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<1, 5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1],
@@ -472,9 +472,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<1, 5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<5, 5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m, const int n, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m, const int n, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0 || n <= 0 || k <= 0) return 0;
 
   switch (k * 10 + n) {
@@ -530,9 +530,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<5, 5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<4, 4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1],
@@ -584,9 +584,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<4, 4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<4, 3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1],
@@ -631,9 +631,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<4, 3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<4, 2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1],
@@ -671,9 +671,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<4, 2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<4, 1>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_10 = B[1 * _bs0 + 0 * _bs1],
@@ -704,9 +704,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<4, 1>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<3, 4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1],
@@ -751,9 +751,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<3, 4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<2, 4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1],
@@ -791,9 +791,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<2, 4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<1, 4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1],
@@ -824,9 +824,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<1, 4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<4, 4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m, const int n, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m, const int n, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0 || n <= 0 || k <= 0) return 0;
 
   switch (k * 10 + n) {
@@ -872,9 +872,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<4, 4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<3, 3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1],
@@ -914,9 +914,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<3, 3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<3, 2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1],
@@ -950,9 +950,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<3, 2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<3, 1>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_10 = B[1 * _bs0 + 0 * _bs1],
@@ -980,9 +980,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<3, 1>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<2, 3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1],
@@ -1015,9 +1015,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<2, 3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<1, 3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1],
@@ -1045,9 +1045,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<1, 3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<3, 3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m, const int n, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m, const int n, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0 || n <= 0 || k <= 0) return 0;
 
   switch (k * 10 + n) {
@@ -1083,9 +1083,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<3, 3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<2, 2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1],
@@ -1114,9 +1114,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<2, 2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<2, 1>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_10 = B[1 * _bs0 + 0 * _bs1];
@@ -1141,9 +1141,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<2, 1>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<1, 2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1], b_01 = B[0 * _bs0 + 1 * _bs1];
@@ -1168,9 +1168,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<1, 2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<2, 2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m, const int n, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m, const int n, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0 || n <= 0 || k <= 0) return 0;
 
   switch (k * 10 + n) {
@@ -1196,9 +1196,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<2, 2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<1, 1>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0) return 0;
 
   const ValueType b_00 = B[0 * _bs0 + 0 * _bs1];
@@ -1225,9 +1225,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<1, 1>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixB<0, 0>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m, const int n, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m, const int n, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0 || n <= 0 || k <= 0) return 0;
 
   if (k == n) {
@@ -1260,11 +1260,11 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixB<0, 0>::serial_invoke(
     }
   } else {
     for (int i = 0; i < m; ++i) {
-      const ValueType *__restrict__ iA = A + i * _as0;
-      /**/ ValueType *__restrict__ iC    = C + i * _cs0;
+      const ValueType *KOKKOS_RESTRICT iA = A + i * _as0;
+      /**/ ValueType *KOKKOS_RESTRICT iC    = C + i * _cs0;
       for (int j = 0; j < n; ++j) {
-        const ValueType *__restrict__ jB = B + j * _bs1;
-        /**/ ValueType tC                  = 0;
+        const ValueType *KOKKOS_RESTRICT jB = B + j * _bs1;
+        /**/ ValueType tC                     = 0;
         for (int p = 0; p < k; ++p) tC += iA[p * _as1] * jB[p * _bs0];
         pC[i * _cs0] += alpha * tC;
       }

--- a/src/batched/dense/impl/KokkosBatched_InnerGemmFixC_Serial_Impl.hpp
+++ b/src/batched/dense/impl/KokkosBatched_InnerGemmFixC_Serial_Impl.hpp
@@ -15,9 +15,9 @@ namespace KokkosBatched {
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<5, 5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0,
@@ -105,9 +105,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<5, 5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<5, 4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = 0, c_01 = 0, c_02 = 0, c_03 = 0, a_1p, b_p1,
@@ -183,9 +183,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<5, 4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<5, 3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = 0, c_01 = 0, c_02 = 0, a_1p, b_p1, c_10 = 0,
@@ -248,9 +248,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<5, 3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<5, 2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = 0, c_01 = 0, a_1p, b_p1, c_10 = 0, c_11 = 0,
@@ -301,9 +301,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<5, 2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<5, 1>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = 0, a_1p, c_10 = 0, a_2p, c_20 = 0, a_3p,
@@ -342,9 +342,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<5, 1>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<4, 5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = 0, c_01 = 0, c_02 = 0, c_03 = 0, c_04 = 0, a_1p,
@@ -421,9 +421,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<4, 5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<3, 5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = 0, c_01 = 0, c_02 = 0, c_03 = 0, c_04 = 0, a_1p,
@@ -488,9 +488,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<3, 5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<2, 5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = 0, c_01 = 0, c_02 = 0, c_03 = 0, c_04 = 0, a_1p,
@@ -543,9 +543,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<2, 5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<1, 5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = 0, c_01 = 0, c_02 = 0, c_03 = 0, c_04 = 0,
@@ -590,9 +590,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<1, 5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<4, 4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0,
@@ -660,9 +660,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<4, 4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<4, 3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0,
@@ -719,9 +719,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<4, 3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<4, 2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0), a_1p, b_p1,
@@ -768,9 +768,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<4, 2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<4, 1>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = ValueType(0), a_1p, c_10 = ValueType(0), a_2p,
@@ -806,9 +806,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<4, 1>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<3, 4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0,
@@ -866,9 +866,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<3, 4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<2, 4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0),
@@ -917,9 +917,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<2, 4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<1, 4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0),
@@ -962,9 +962,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<1, 4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<3, 3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0,
@@ -1013,9 +1013,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<3, 3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<3, 2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0), a_1p, b_p1,
@@ -1056,9 +1056,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<3, 2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<3, 1>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = ValueType(0), a_1p, c_10 = ValueType(0), a_2p,
@@ -1090,9 +1090,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<3, 1>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<2, 3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0),
@@ -1133,9 +1133,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<2, 3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<1, 3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0),
@@ -1173,9 +1173,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<1, 3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<2, 2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0), a_1p, b_p1,
@@ -1209,9 +1209,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<2, 2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<2, 1>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = ValueType(0), a_1p, c_10 = ValueType(0);
@@ -1239,9 +1239,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<2, 1>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<1, 2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = ValueType(0), c_01 = ValueType(0),
@@ -1272,9 +1272,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<1, 2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<1, 1>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (k <= 0) return 0;
 
   ValueType a_0p, b_p0, c_00 = ValueType(0);
@@ -1297,9 +1297,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<1, 1>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<0, 1>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0 || k <= 0) return 0;
 
   switch (m) {
@@ -1339,9 +1339,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<0, 1>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<5, 5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m, const int n, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m, const int n, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0 || n <= 0 || k <= 0) return 0;
   if (!(m <= 5 && n <= 5))
     Kokkos::abort(
@@ -1405,9 +1405,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<5, 5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<4, 4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m, const int n, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m, const int n, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0 || n <= 0 || k <= 0) return 0;
   if (!(m <= 4 && n <= 4))
     Kokkos::abort(
@@ -1461,9 +1461,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<4, 4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<3, 3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m, const int n, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m, const int n, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0 || n <= 0 || k <= 0) return 0;
   if (!(m <= 3 && n <= 3))
     Kokkos::abort(
@@ -1507,9 +1507,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<3, 3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<2, 2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m, const int n, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m, const int n, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0 || n <= 0 || k <= 0) return 0;
   if (!(m <= 2 && n <= 2))
     Kokkos::abort(
@@ -1543,9 +1543,9 @@ KOKKOS_INLINE_FUNCTION int InnerGemmFixC<2, 2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<1, 1>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ B, const int m, const int n, const int k,
-    /**/ ValueType *__restrict__ C) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT B, const int m, const int n, const int k,
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   if (m <= 0 || n <= 0 || k <= 0) return 0;
   if (!(m <= 1 && n <= 1))
     Kokkos::abort(

--- a/src/batched/dense/impl/KokkosBatched_InnerGemmFixC_Team_Impl.hpp
+++ b/src/batched/dense/impl/KokkosBatched_InnerGemmFixC_Team_Impl.hpp
@@ -12,15 +12,15 @@ template <int mb, int nb>
 template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<mb, nb>::team_invoke(
     const MemberType &member, const ScalarType alpha,
-    const ValueType *__restrict__ A, const ValueType *__restrict__ B,
+    const ValueType *KOKKOS_RESTRICT A, const ValueType *KOKKOS_RESTRICT B,
     const int k,
-    /**/ ValueType *__restrict__ C) {
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   Kokkos::parallel_for(
       Kokkos::TeamThreadRange(member, 0, mb * nb), [&](const int &ij) {
         const int i = ij / nb, j = ij % nb;
 
-        const ValueType *__restrict__ pA               = A + i * _as0,
-                                      *__restrict__ pB = B + j * _bs1;
+        const ValueType *KOKKOS_RESTRICT pA                  = A + i * _as0,
+                                         *KOKKOS_RESTRICT pB = B + j * _bs1;
 
         ValueType c = 0;
         for (int p = 0; p < k; ++p) c += pA[p * _as1] * pB[p * _bs0];
@@ -33,15 +33,15 @@ template <int mb, int nb>
 template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerGemmFixC<mb, nb>::team_invoke(
     const MemberType &member, const ScalarType alpha,
-    const ValueType *__restrict__ A, const ValueType *__restrict__ B,
+    const ValueType *KOKKOS_RESTRICT A, const ValueType *KOKKOS_RESTRICT B,
     const int m, const int n, const int k,
-    /**/ ValueType *__restrict__ C) {
+    /**/ ValueType *KOKKOS_RESTRICT C) {
   Kokkos::parallel_for(
       Kokkos::TeamThreadRange(member, 0, m * n), [&](const int &ij) {
         const int i = ij / n, j = ij % n;
 
-        const ValueType *__restrict__ pA               = A + i * _as0,
-                                      *__restrict__ pB = B + j * _bs1;
+        const ValueType *KOKKOS_RESTRICT pA                  = A + i * _as0,
+                                         *KOKKOS_RESTRICT pB = B + j * _bs1;
 
         ValueType c = 0;
         for (int p = 0; p < k; ++p) c += pA[p * _as1] * pB[p * _bs0];

--- a/src/batched/dense/impl/KokkosBatched_InnerLU_Serial_Impl.hpp
+++ b/src/batched/dense/impl/KokkosBatched_InnerLU_Serial_Impl.hpp
@@ -15,7 +15,7 @@ namespace KokkosBatched {
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerLU<5>::serial_invoke(
-    ValueType *__restrict__ A) {
+    ValueType *KOKKOS_RESTRICT A) {
   // load
   ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
             a_02 = A[0 * _as0 + 2 * _as1], a_03 = A[0 * _as0 + 3 * _as1],
@@ -107,7 +107,7 @@ KOKKOS_INLINE_FUNCTION int InnerLU<5>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerLU<4>::serial_invoke(
-    ValueType *__restrict__ A) {
+    ValueType *KOKKOS_RESTRICT A) {
   // load
   ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
             a_02 = A[0 * _as0 + 2 * _as1], a_03 = A[0 * _as0 + 3 * _as1],
@@ -164,7 +164,7 @@ KOKKOS_INLINE_FUNCTION int InnerLU<4>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerLU<3>::serial_invoke(
-    ValueType *__restrict__ A) {
+    ValueType *KOKKOS_RESTRICT A) {
   // load
   ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
             a_02 = A[0 * _as0 + 2 * _as1], a_10 = A[1 * _as0 + 0 * _as1],
@@ -198,7 +198,7 @@ KOKKOS_INLINE_FUNCTION int InnerLU<3>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerLU<2>::serial_invoke(
-    ValueType *__restrict__ A) {
+    ValueType *KOKKOS_RESTRICT A) {
   // load
   ValueType a_00 = A[0 * _as0 + 0 * _as1], a_01 = A[0 * _as0 + 1 * _as1],
             a_10 = A[1 * _as0 + 0 * _as1], a_11 = A[1 * _as0 + 1 * _as1];
@@ -217,14 +217,14 @@ KOKKOS_INLINE_FUNCTION int InnerLU<2>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerLU<1>::serial_invoke(
-    ValueType *__restrict__ /* A */) {
+    ValueType *KOKKOS_RESTRICT /* A */) {
   return 0;
 }
 
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerLU<5>::serial_invoke(
-    const int m, ValueType *__restrict__ A) {
+    const int m, ValueType *KOKKOS_RESTRICT A) {
   if (m > 5) Kokkos::abort("InnerLU<5>::serial_invoke, assert failure (m<=5)");
   if (m <= 0) return 0;
 
@@ -261,7 +261,7 @@ KOKKOS_INLINE_FUNCTION int InnerLU<5>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerLU<4>::serial_invoke(
-    const int m, ValueType *__restrict__ A) {
+    const int m, ValueType *KOKKOS_RESTRICT A) {
   if (m > 4) Kokkos::abort("InnerLU<4>::serial_invoke, assert failure (m<=4)");
   if (m <= 0) return 0;
 
@@ -293,7 +293,7 @@ KOKKOS_INLINE_FUNCTION int InnerLU<4>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerLU<3>::serial_invoke(
-    const int m, ValueType *__restrict__ A) {
+    const int m, ValueType *KOKKOS_RESTRICT A) {
   if (m > 3) Kokkos::abort("InnerLU<3>::serial_invoke, assert failure (m<=3)");
   if (m <= 0) return 0;
 
@@ -320,7 +320,7 @@ KOKKOS_INLINE_FUNCTION int InnerLU<3>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerLU<2>::serial_invoke(
-    const int m, ValueType *__restrict__ A) {
+    const int m, ValueType *KOKKOS_RESTRICT A) {
   if (m > 2) Kokkos::abort("InnerLU<2>::serial_invoke, assert failure (m<=2)");
   if (m <= 0) return 0;
 
@@ -342,7 +342,7 @@ KOKKOS_INLINE_FUNCTION int InnerLU<2>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerLU<1>::serial_invoke(
-    const int m, ValueType *__restrict__ A) {
+    const int m, ValueType *KOKKOS_RESTRICT A) {
   if (m > 1) Kokkos::abort("InnerLU<1>::serial_invoke, assert failure (m<=1)");
   if (m <= 0) return 0;
 
@@ -362,18 +362,18 @@ KOKKOS_INLINE_FUNCTION int InnerLU<1>::serial_invoke(
 // int
 // InnerLU<bmn>::
 // serial_invoke(const int m, const int n,
-//               ValueType *__restrict__ A) {
+//               ValueType *KOKKOS_RESTRICT A) {
 //   if (m <= 0 || n <= 0) return 0;
 //   const int k = m < n ? m : n;
 //   for (int p=0;p<k;++p) {
 //     const ValueType
 //       // inv_alpha11 = 1.0/A[p*_as0+p*_as1],
 //       alpha11 = A[p*_as0+p*_as1],
-//       *__restrict__ a12t = A + (p  )*_as0 + (p+1)*_as1;
+//       *KOKKOS_RESTRICT a12t = A + (p  )*_as0 + (p+1)*_as1;
 
 //     ValueType
-//       *__restrict__ a21  = A + (p+1)*_as0 + (p  )*_as1,
-//       *__restrict__ A22  = A + (p+1)*_as0 + (p+1)*_as1;
+//       *KOKKOS_RESTRICT a21  = A + (p+1)*_as0 + (p  )*_as1,
+//       *KOKKOS_RESTRICT A22  = A + (p+1)*_as0 + (p+1)*_as1;
 
 //     const int
 //       iend = m-p-1,

--- a/src/batched/dense/impl/KokkosBatched_InnerMultipleDotProduct_Serial_Impl.hpp
+++ b/src/batched/dense/impl/KokkosBatched_InnerMultipleDotProduct_Serial_Impl.hpp
@@ -15,9 +15,9 @@ namespace KokkosBatched {
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerMultipleDotProduct<5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ x, const int n,
-    /**/ ValueType *__restrict__ y) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT x, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT y) {
   if (n <= 0) return 0;
 
   const int i0 = 0 * _as0, i1 = 1 * _as0, i2 = 2 * _as0, i3 = 3 * _as0,
@@ -52,9 +52,9 @@ KOKKOS_INLINE_FUNCTION int InnerMultipleDotProduct<5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerMultipleDotProduct<4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ x, const int n,
-    /**/ ValueType *__restrict__ y) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT x, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT y) {
   if (!n) return 0;
 
   const int i0 = 0 * _as0, i1 = 1 * _as0, i2 = 2 * _as0, i3 = 3 * _as0;
@@ -86,9 +86,9 @@ KOKKOS_INLINE_FUNCTION int InnerMultipleDotProduct<4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerMultipleDotProduct<3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ x, const int n,
-    /**/ ValueType *__restrict__ y) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT x, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT y) {
   if (n <= 0) return 0;
 
   const int i0 = 0 * _as0, i1 = 1 * _as0, i2 = 2 * _as0;
@@ -118,9 +118,9 @@ KOKKOS_INLINE_FUNCTION int InnerMultipleDotProduct<3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerMultipleDotProduct<2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ x, const int n,
-    /**/ ValueType *__restrict__ y) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT x, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT y) {
   if (n <= 0) return 0;
 
   const int i0 = 0 * _as0, i1 = 1 * _as0;
@@ -148,9 +148,9 @@ KOKKOS_INLINE_FUNCTION int InnerMultipleDotProduct<2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerMultipleDotProduct<1>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ x, const int n,
-    /**/ ValueType *__restrict__ y) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT x, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT y) {
   if (n <= 0) return 0;
 
   // unroll by rows
@@ -169,9 +169,9 @@ KOKKOS_INLINE_FUNCTION int InnerMultipleDotProduct<1>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerMultipleDotProduct<5>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ x, const int m, const int n,
-    /**/ ValueType *__restrict__ y) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT x, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT y) {
   if (m <= 0 || n <= 0) return 0;
   switch (m) {
     case 5: {
@@ -206,9 +206,9 @@ KOKKOS_INLINE_FUNCTION int InnerMultipleDotProduct<5>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerMultipleDotProduct<4>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ x, const int m, const int n,
-    /**/ ValueType *__restrict__ y) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT x, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT y) {
   if (m <= 0 || n <= 0) return 0;
   switch (m) {
     case 4: {
@@ -238,9 +238,9 @@ KOKKOS_INLINE_FUNCTION int InnerMultipleDotProduct<4>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerMultipleDotProduct<3>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ x, const int m, const int n,
-    /**/ ValueType *__restrict__ y) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT x, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT y) {
   if (m <= 0 || n <= 0) return 0;
   switch (m) {
     case 3: {
@@ -265,9 +265,9 @@ KOKKOS_INLINE_FUNCTION int InnerMultipleDotProduct<3>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerMultipleDotProduct<2>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ x, const int m, const int n,
-    /**/ ValueType *__restrict__ y) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT x, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT y) {
   if (m <= 0 || n <= 0) return 0;
   switch (m) {
     case 2: {
@@ -287,9 +287,9 @@ KOKKOS_INLINE_FUNCTION int InnerMultipleDotProduct<2>::serial_invoke(
 template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerMultipleDotProduct<1>::serial_invoke(
-    const ScalarType alpha, const ValueType *__restrict__ A,
-    const ValueType *__restrict__ x, const int m, const int n,
-    /**/ ValueType *__restrict__ y) {
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
+    const ValueType *KOKKOS_RESTRICT x, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT y) {
   if (m <= 0 || n <= 0) return 0;
   switch (m) {
     case 1: {

--- a/src/batched/dense/impl/KokkosBatched_InnerTrsm_Serial_Impl.hpp
+++ b/src/batched/dense/impl/KokkosBatched_InnerTrsm_Serial_Impl.hpp
@@ -16,8 +16,8 @@ namespace KokkosBatched {
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<5>::serial_invoke(
-    const ValueType *__restrict__ A, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (n <= 0) return 0;
 
   const ValueType a_10 = A[1 * _as0 + 0 * _as1], a_20 = A[2 * _as0 + 0 * _as1],
@@ -73,8 +73,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<5>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<4>::serial_invoke(
-    const ValueType *__restrict__ A, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (n <= 0) return 0;
 
   const ValueType a_10 = A[1 * _as0 + 0 * _as1], a_20 = A[2 * _as0 + 0 * _as1],
@@ -120,8 +120,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<4>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<3>::serial_invoke(
-    const ValueType *__restrict__ A, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (n <= 0) return 0;
 
   const ValueType a_10 = A[1 * _as0 + 0 * _as1], a_20 = A[2 * _as0 + 0 * _as1],
@@ -159,8 +159,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<3>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<2>::serial_invoke(
-    const ValueType *__restrict__ A, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (n <= 0) return 0;
 
   const ValueType a_10 = A[1 * _as0 + 0 * _as1];
@@ -191,8 +191,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<2>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<1>::serial_invoke(
-    const ValueType *__restrict__ /* A */, const int /* n */,
-    /**/ ValueType *__restrict__ /* B */) {
+    const ValueType *KOKKOS_RESTRICT /* A */, const int /* n */,
+    /**/ ValueType *KOKKOS_RESTRICT /* B */) {
   return 0;
 }
 
@@ -204,8 +204,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<1>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<5>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 5)
     Kokkos::abort(
         "InnerTrsmLeftLowerUnitDiag<5>::serial_invoke, assert failure (m<=5)");
@@ -242,8 +242,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<5>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<4>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 4)
     Kokkos::abort(
         "InnerTrsmLeftLowerUnitDiag<4>::serial_invoke, assert failure (m<=4)");
@@ -275,8 +275,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<4>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<3>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 3)
     Kokkos::abort(
         "InnerTrsmLeftLowerUnitDiag<3>::serial_invoke, assert failure (m<=3)");
@@ -303,8 +303,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<3>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<2>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 2)
     Kokkos::abort(
         "InnerTrsmLeftLowerUnitDiag<2>::serial_invoke, assert failure (m<=2)");
@@ -326,8 +326,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<2>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<1>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 1)
     Kokkos::abort(
         "InnerTrsmLeftLowerUnitDiag<1>::serial_invoke, assert failure (m<=1)");
@@ -350,8 +350,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<1>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<5>::serial_invoke(
-    const ValueType *__restrict__ A, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (n <= 0) return 0;
 
   const ValueType a_10 = A[1 * _as0 + 0 * _as1], a_20 = A[2 * _as0 + 0 * _as1],
@@ -434,8 +434,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<5>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<4>::serial_invoke(
-    const ValueType *__restrict__ A, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (n <= 0) return 0;
 
   const ValueType a_10 = A[1 * _as0 + 0 * _as1], a_20 = A[2 * _as0 + 0 * _as1],
@@ -504,8 +504,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<4>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<3>::serial_invoke(
-    const ValueType *__restrict__ A, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (n <= 0) return 0;
 
   const ValueType a_10 = A[1 * _as0 + 0 * _as1], a_20 = A[2 * _as0 + 0 * _as1],
@@ -562,8 +562,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<3>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<2>::serial_invoke(
-    const ValueType *__restrict__ A, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (n <= 0) return 0;
 
   const ValueType a_10 = A[1 * _as0 + 0 * _as1];
@@ -608,8 +608,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<2>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<1>::serial_invoke(
-    const ValueType *__restrict__ A, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (n <= 0) return 0;
 
   // const ValueType
@@ -641,8 +641,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<1>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<5>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 5)
     Kokkos::abort(
         "InnerTrsmLeftLowerNonUnitDiag<5>::serial_invoke, assert failure "
@@ -680,8 +680,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<5>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<4>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 4)
     Kokkos::abort(
         "InnerTrsmLeftLowerNonUnitDiag<4>::serial_invoke, assert failure "
@@ -714,8 +714,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<4>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<3>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 3)
     Kokkos::abort(
         "InnerTrsmLeftLowerNonUnitDiag<3>::serial_invoke, assert failure "
@@ -743,8 +743,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<3>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<2>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 2)
     Kokkos::abort(
         "InnerTrsmLeftLowerNonUnitDiag<2>::serial_invoke, assert failure "
@@ -767,8 +767,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<2>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<1>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 1)
     Kokkos::abort(
         "InnerTrsmLeftLowerNonUnitDiag<1>::serial_invoke, assert failure "
@@ -792,8 +792,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<1>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<5>::serial_invoke(
-    const ValueType *__restrict__ A, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (n <= 0) return 0;
 
   const ValueType a_01 = A[0 * _as0 + 1 * _as1], a_02 = A[0 * _as0 + 2 * _as1],
@@ -852,8 +852,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<5>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<4>::serial_invoke(
-    const ValueType *__restrict__ A, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (n <= 0) return 0;
 
   const ValueType a_01 = A[0 * _as0 + 1 * _as1], a_02 = A[0 * _as0 + 2 * _as1],
@@ -902,8 +902,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<4>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<3>::serial_invoke(
-    const ValueType *__restrict__ A, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (n <= 0) return 0;
 
   const ValueType a_01 = A[0 * _as0 + 1 * _as1], a_02 = A[0 * _as0 + 2 * _as1],
@@ -942,8 +942,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<3>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<2>::serial_invoke(
-    const ValueType *__restrict__ A, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (n <= 0) return 0;
 
   const ValueType a_01 = A[0 * _as0 + 1 * _as1];
@@ -974,8 +974,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<2>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<1>::serial_invoke(
-    const ValueType *__restrict__ /* A */, const int /* n */,
-    /**/ ValueType *__restrict__ /* B */) {
+    const ValueType *KOKKOS_RESTRICT /* A */, const int /* n */,
+    /**/ ValueType *KOKKOS_RESTRICT /* B */) {
   return 0;
 }
 
@@ -987,8 +987,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<1>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<5>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 5)
     Kokkos::abort(
         "InnerTrsmLeftUpperUnitDiag<5>::serial_invoke, assert failure (m<=5)");
@@ -1025,8 +1025,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<5>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<4>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 4)
     Kokkos::abort(
         "InnerTrsmLeftUpperUnitDiag<4>::serial_invoke, assert failure (m<=4)");
@@ -1058,8 +1058,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<4>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<3>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 3)
     Kokkos::abort(
         "InnerTrsmLeftUpperUnitDiag<3>::serial_invoke, assert failure (m<=3)");
@@ -1086,8 +1086,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<3>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<2>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 2)
     Kokkos::abort(
         "InnerTrsmLeftUpperUnitDiag<2>::serial_invoke, assert failure (m<=2)");
@@ -1109,8 +1109,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<2>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<1>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 1)
     Kokkos::abort(
         "InnerTrsmLeftUpperUnitDiag<1>::serial_invoke, assert failure (m<=1)");
@@ -1133,8 +1133,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<1>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<5>::serial_invoke(
-    const ValueType *__restrict__ A, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (n <= 0) return 0;
 
   const ValueType a_01 = A[0 * _as0 + 1 * _as1], a_02 = A[0 * _as0 + 2 * _as1],
@@ -1219,8 +1219,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<5>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<4>::serial_invoke(
-    const ValueType *__restrict__ A, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (n <= 0) return 0;
 
   const ValueType a_01 = A[0 * _as0 + 1 * _as1], a_02 = A[0 * _as0 + 2 * _as1],
@@ -1291,8 +1291,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<4>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<3>::serial_invoke(
-    const ValueType *__restrict__ A, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (n <= 0) return 0;
 
   const ValueType a_01 = A[0 * _as0 + 1 * _as1], a_02 = A[0 * _as0 + 2 * _as1],
@@ -1349,8 +1349,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<3>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<2>::serial_invoke(
-    const ValueType *__restrict__ A, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (n <= 0) return 0;
 
   const ValueType a_01 = A[0 * _as0 + 1 * _as1];
@@ -1395,8 +1395,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<2>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<1>::serial_invoke(
-    const ValueType *__restrict__ A, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (n <= 0) return 0;
 
   // const ValueType
@@ -1429,8 +1429,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<1>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<5>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 5)
     Kokkos::abort(
         "InnerTrsmLeftUpperNonUnitDiag<5>::serial_invoke, assert failure "
@@ -1468,8 +1468,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<5>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<4>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 4)
     Kokkos::abort(
         "InnerTrsmLeftUpperNonUnitDiag<4>::serial_invoke, assert failure "
@@ -1502,8 +1502,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<4>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<3>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 3)
     Kokkos::abort(
         "InnerTrsmLeftUpperNonUnitDiag<3>::serial_invoke, assert failure "
@@ -1531,8 +1531,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<3>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<2>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 2)
     Kokkos::abort(
         "InnerTrsmLeftUpperNonUnitDiag<2>::serial_invoke, assert failure "
@@ -1555,8 +1555,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<2>::serial_invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<1>::serial_invoke(
-    const ValueType *__restrict__ A, const int m, const int n,
-    /**/ ValueType *__restrict__ B) {
+    const ValueType *KOKKOS_RESTRICT A, const int m, const int n,
+    /**/ ValueType *KOKKOS_RESTRICT B) {
   if (m > 1)
     Kokkos::abort(
         "InnerTrsmLeftUpperNonUnitDiag<1>::serial_invoke, assert failure "

--- a/src/batched/dense/impl/KokkosBatched_LU_Serial_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_LU_Serial_Internal.hpp
@@ -19,14 +19,14 @@ template <typename AlgoType>
 struct SerialLU_Internal {
   template <typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(
-      const int m, const int n, ValueType *__restrict__ A, const int as0,
+      const int m, const int n, ValueType *KOKKOS_RESTRICT A, const int as0,
       const int as1, const typename MagnitudeScalarType<ValueType>::type tiny);
 };
 
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialLU_Internal<Algo::LU::Unblocked>::invoke(
-    const int m, const int n, ValueType *__restrict__ A, const int as0,
+    const int m, const int n, ValueType *KOKKOS_RESTRICT A, const int as0,
     const int as1, const typename MagnitudeScalarType<ValueType>::type tiny) {
   const int k = (m < n ? m : n);
   if (k <= 0) return 0;
@@ -38,11 +38,11 @@ KOKKOS_INLINE_FUNCTION int SerialLU_Internal<Algo::LU::Unblocked>::invoke(
   for (int p = 0; p < k; ++p) {
     const int iend = m - p - 1, jend = n - p - 1;
 
-    const ValueType *__restrict__ a12t = A + (p)*as0 + (p + 1) * as1;
+    const ValueType *KOKKOS_RESTRICT a12t = A + (p)*as0 + (p + 1) * as1;
 
-    ValueType *__restrict__ a21 = A + (p + 1) * as0 + (p)*as1,
-                            *__restrict__ A22 =
-                                A + (p + 1) * as0 + (p + 1) * as1;
+    ValueType *KOKKOS_RESTRICT a21 = A + (p + 1) * as0 + (p)*as1,
+                               *KOKKOS_RESTRICT A22 =
+                                   A + (p + 1) * as0 + (p + 1) * as1;
 
     if (tiny != 0) {
       ValueType &alpha11_reference = A[p * as0 + p * as1];
@@ -71,7 +71,7 @@ KOKKOS_INLINE_FUNCTION int SerialLU_Internal<Algo::LU::Unblocked>::invoke(
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialLU_Internal<Algo::LU::Blocked>::invoke(
-    const int m, const int n, ValueType *__restrict__ A, const int as0,
+    const int m, const int n, ValueType *KOKKOS_RESTRICT A, const int as0,
     const int as1,
     const typename MagnitudeScalarType<ValueType>::type /*tiny*/) {
   enum : int {
@@ -88,14 +88,14 @@ KOKKOS_INLINE_FUNCTION int SerialLU_Internal<Algo::LU::Blocked>::invoke(
   InnerTrsmLeftLowerNonUnitDiag<mbAlgo> trsm_run(as1, as0, as1, as0);
 
   auto lu_factorize = [&](const int ib, const int jb,
-                          ValueType *__restrict__ AA) {
+                          ValueType *KOKKOS_RESTRICT AA) {
     const int mb = mbAlgo;
     const int kb = ib < jb ? ib : jb;
     for (int p = 0; p < kb; p += mb) {
       const int pb = (p + mb) > kb ? (kb - p) : mb;
 
       // diagonal block
-      ValueType *__restrict__ Ap = AA + p * as0 + p * as1;
+      ValueType *KOKKOS_RESTRICT Ap = AA + p * as0 + p * as1;
 
       // lu on a block
       lu.serial_invoke(pb, Ap);

--- a/src/batched/dense/impl/KokkosBatched_LU_Team_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_LU_Team_Internal.hpp
@@ -22,7 +22,7 @@ struct TeamLU_Internal {
   template <typename MemberType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType &member, const int m, const int n,
-      ValueType *__restrict__ A, const int as0, const int as1,
+      ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
       const typename MagnitudeScalarType<ValueType>::type tiny);
 };
 
@@ -30,7 +30,7 @@ template <>
 template <typename MemberType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int TeamLU_Internal<Algo::LU::Unblocked>::invoke(
     const MemberType &member, const int m, const int n,
-    ValueType *__restrict__ A, const int as0, const int as1,
+    ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
     const typename MagnitudeScalarType<ValueType>::type tiny) {
   const int k = (m < n ? m : n);
   if (k <= 0) return 0;
@@ -43,11 +43,11 @@ KOKKOS_INLINE_FUNCTION int TeamLU_Internal<Algo::LU::Unblocked>::invoke(
     int iend = m - p - 1;
     int jend = n - p - 1;
 
-    const ValueType *__restrict__ a12t = A + (p)*as0 + (p + 1) * as1;
+    const ValueType *KOKKOS_RESTRICT a12t = A + (p)*as0 + (p + 1) * as1;
 
-    ValueType *__restrict__ a21 = A + (p + 1) * as0 + (p)*as1,
-                            *__restrict__ A22 =
-                                A + (p + 1) * as0 + (p + 1) * as1;
+    ValueType *KOKKOS_RESTRICT a21 = A + (p + 1) * as0 + (p)*as1,
+                               *KOKKOS_RESTRICT A22 =
+                                   A + (p + 1) * as0 + (p + 1) * as1;
 
     if (tiny != 0) {
       if (member.team_rank() == 0) {
@@ -82,7 +82,7 @@ template <>
 template <typename MemberType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int TeamLU_Internal<Algo::LU::Blocked>::invoke(
     const MemberType &member, const int m, const int n,
-    ValueType *__restrict__ A, const int as0, const int as1,
+    ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
     const typename MagnitudeScalarType<ValueType>::type /*tiny*/) {
   enum : int {
     mbAlgo = Algo::LU::Blocked::mb<Kokkos::Impl::ActiveExecutionMemorySpace>()
@@ -98,7 +98,7 @@ KOKKOS_INLINE_FUNCTION int TeamLU_Internal<Algo::LU::Blocked>::invoke(
   InnerTrsmLeftLowerUnitDiag<mbAlgo> trsm_llu(as0, as1, as0, as1);
   InnerTrsmLeftLowerNonUnitDiag<mbAlgo> trsm_run(as1, as0, as1, as0);
   auto lu_factorize = [&](const int ib, const int jb,
-                          ValueType *__restrict__ AA) {
+                          ValueType *KOKKOS_RESTRICT AA) {
     const int tsize = member.team_size();
     // Made this non-const in order to WORKAROUND issue #349
     int mb = mbAlgo;
@@ -112,7 +112,7 @@ KOKKOS_INLINE_FUNCTION int TeamLU_Internal<Algo::LU::Blocked>::invoke(
       const int pb = (p + mb) > kb ? (kb - p) : mb;
 
       // diagonal block
-      ValueType *__restrict__ Ap = AA + p * as0 + p * as1;
+      ValueType *KOKKOS_RESTRICT Ap = AA + p * as0 + p * as1;
 
       // lu on a block
       member.team_barrier();

--- a/src/batched/dense/impl/KokkosBatched_Normalize_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Normalize_Internal.hpp
@@ -13,7 +13,7 @@ namespace KokkosBatched {
 struct SerialNormalizeInternal {
   template <typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const int m,
-                                           /* */ ValueType *__restrict__ v,
+                                           /* */ ValueType *KOKKOS_RESTRICT v,
                                            const int vs) {
     typedef ValueType value_type;
     typedef Kokkos::Details::ArithTraits<value_type> ats;
@@ -38,9 +38,9 @@ struct SerialNormalizeInternal {
 
   template <typename RealType>
   KOKKOS_INLINE_FUNCTION static int invoke(const int m,
-                                           /* */ RealType *__restrict__ vr,
+                                           /* */ RealType *KOKKOS_RESTRICT vr,
                                            const int vrs,
-                                           /* */ RealType *__restrict__ vi,
+                                           /* */ RealType *KOKKOS_RESTRICT vi,
                                            const int vis) {
     typedef RealType real_type;
     typedef Kokkos::Details::ArithTraits<real_type> ats;

--- a/src/batched/dense/impl/KokkosBatched_QR_WithColumnPivoting_TeamVector_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_QR_WithColumnPivoting_TeamVector_Internal.hpp
@@ -22,12 +22,10 @@ namespace KokkosBatched {
 ///
 struct TeamVectorUpdateColumnNormsInternal {
   template <typename MemberType, typename ValueType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
-                                           const int n,
-                                           const ValueType *__restrict__ a,
-                                           const int as0,
-                                           /* */ ValueType *__restrict__ norm,
-                                           const int ns0) {
+  KOKKOS_INLINE_FUNCTION static int invoke(
+      const MemberType &member, const int n, const ValueType *KOKKOS_RESTRICT a,
+      const int as0,
+      /* */ ValueType *KOKKOS_RESTRICT norm, const int ns0) {
     using ats = Kokkos::ArithTraits<ValueType>;
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n), [&](const int &j) {
       const int idx_a = j * as0, idx_n = j * ns0;

--- a/src/batched/dense/impl/KokkosBatched_Scale_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Scale_Internal.hpp
@@ -13,7 +13,7 @@ namespace KokkosBatched {
 struct SerialScaleInternal {
   template <typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const int m, const ScalarType alpha,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0) {
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
@@ -26,7 +26,7 @@ struct SerialScaleInternal {
   template <typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const int m, const int n,
                                            const ScalarType alpha,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1) {
     if (as0 > as1)
       for (int i = 0; i < m; ++i) invoke(n, alpha, A + i * as0, as1);
@@ -44,7 +44,7 @@ struct TeamScaleInternal {
   template <typename MemberType, typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int m, const ScalarType alpha,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0) {
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, m),
                          [&](const int &i) { A[i * as0] *= alpha; });
@@ -56,7 +56,7 @@ struct TeamScaleInternal {
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int m, const int n,
                                            const ScalarType alpha,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1) {
     if (m > n) {
       Kokkos::parallel_for(
@@ -81,7 +81,7 @@ struct TeamVectorScaleInternal {
   template <typename MemberType, typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int m, const ScalarType alpha,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0) {
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, m),
                          [&](const int &i) { A[i * as0] *= alpha; });
@@ -93,7 +93,7 @@ struct TeamVectorScaleInternal {
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int m, const int n,
                                            const ScalarType alpha,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1) {
     if (as0 > as1) {
       Kokkos::parallel_for(

--- a/src/batched/dense/impl/KokkosBatched_SetIdentity_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_SetIdentity_Internal.hpp
@@ -13,7 +13,7 @@ namespace KokkosBatched {
 struct SerialSetIdentityInternal {
   template <typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const int m, const int n,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1) {
     const ValueType one(1), zero(0);
     for (int j = 0; j < n; ++j) {
@@ -36,7 +36,7 @@ struct TeamSetIdentityInternal {
   template <typename MemberType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int m, const int n,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1) {
     const ValueType one(1), zero(0);
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, m), [&](const int &i) {
@@ -57,7 +57,7 @@ struct TeamVectorSetIdentityInternal {
   template <typename MemberType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int m, const int n,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1) {
     const ValueType one(1), zero(0);
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, m), [&](const int &i) {

--- a/src/batched/dense/impl/KokkosBatched_SetTriangular_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_SetTriangular_Internal.hpp
@@ -15,7 +15,7 @@ struct SerialSetLowerTriangularInternal {
   KOKKOS_INLINE_FUNCTION static int invoke(const int m, const int n,
                                            const int dist,
                                            const ScalarType alpha,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1) {
     for (int j = 0; j < n; ++j) {
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
@@ -36,7 +36,7 @@ struct TeamVectorSetLowerTriangularInternal {
                                            const int m, const int n,
                                            const int dist,
                                            const ScalarType alpha,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1) {
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int &j) {
       const int jdist = j + dist;

--- a/src/batched/dense/impl/KokkosBatched_Set_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Set_Internal.hpp
@@ -13,7 +13,7 @@ namespace KokkosBatched {
 struct SerialSetInternal {
   template <typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const int m, const ScalarType alpha,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0) {
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
@@ -26,7 +26,7 @@ struct SerialSetInternal {
   template <typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const int m, const int n,
                                            const ScalarType alpha,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1) {
     if (as0 > as1)
       for (int i = 0; i < m; ++i) invoke(n, alpha, A + i * as0, as1);
@@ -44,7 +44,7 @@ struct TeamSetInternal {
   template <typename MemberType, typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int m, const ScalarType alpha,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0) {
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, m),
                          [&](const int &i) { A[i * as0] = alpha; });
@@ -56,7 +56,7 @@ struct TeamSetInternal {
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int m, const int n,
                                            const ScalarType alpha,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1) {
     if (m > n) {
       Kokkos::parallel_for(
@@ -81,7 +81,7 @@ struct TeamVectorSetInternal {
   template <typename MemberType, typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int m, const ScalarType alpha,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0) {
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, m),
                          [&](const int &i) { A[i * as0] = alpha; });
@@ -93,7 +93,7 @@ struct TeamVectorSetInternal {
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const int m, const int n,
                                            const ScalarType alpha,
-                                           /* */ ValueType *__restrict__ A,
+                                           /* */ ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1) {
     if (m > n) {
       Kokkos::parallel_for(

--- a/src/batched/dense/impl/KokkosBatched_ShiftedTrsv_Serial_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_ShiftedTrsv_Serial_Internal.hpp
@@ -24,11 +24,11 @@ namespace KokkosBatched {
 struct SerialShiftedTrsvInternalLower {
   template <typename ScalarType, typename ValueTypeA, typename ValueTypeB>
   KOKKOS_INLINE_FUNCTION static int invoke(const int m, const ScalarType lambda,
-                                           const ValueTypeA *__restrict__ A,
+                                           const ValueTypeA *KOKKOS_RESTRICT A,
                                            const int as0, const int as1,
-                                           /* */ ValueTypeB *__restrict__ b,
+                                           /* */ ValueTypeB *KOKKOS_RESTRICT b,
                                            const int bs0,
-                                           const int *__restrict__ blks) {
+                                           const int *KOKKOS_RESTRICT blks) {
     const int as = as0 + as1;
 
     int p = 0;
@@ -37,17 +37,17 @@ struct SerialShiftedTrsvInternalLower {
       assert(((blk == 1) || (blk == 2)) &&
              "ShiftedTrsvLower: blocks are not 1x1 or 2x2");
       if (blk == 1) {
-        const auto alpha11             = A[p * as] - lambda;
-        ValueTypeB *__restrict__ beta1 = b + p * bs0;
+        const auto alpha11                = A[p * as] - lambda;
+        ValueTypeB *KOKKOS_RESTRICT beta1 = b + p * bs0;
 
-        // with __restrict__ a compiler assumes that the pointer is not accessed
-        // by others op(/=) uses this pointer and changes the associated values,
-        // which brings a compiler problem
+        // with KOKKOS_RESTRICT a compiler assumes that the pointer is not
+        // accessed by others op(/=) uses this pointer and changes the
+        // associated values, which brings a compiler problem
         *beta1 = *beta1 / alpha11;
 
         if (iend) {
-          const ValueTypeA *__restrict__ a21 = A + p * as + as0;
-          ValueTypeB *__restrict__ b2        = beta1 + bs0;
+          const ValueTypeA *KOKKOS_RESTRICT a21 = A + p * as + as0;
+          ValueTypeB *KOKKOS_RESTRICT b2        = beta1 + bs0;
           for (int i = 0; i < iend; ++i) b2[i * bs0] -= a21[i * as0] * (*beta1);
         }
       } else {
@@ -58,8 +58,8 @@ struct SerialShiftedTrsvInternalLower {
         const auto alpha22   = A[p_plus_one * as] - lambda;
         const auto det       = alpha11 * alpha22 - alpha12 * alpha21;
 
-        ValueTypeB *__restrict__ beta1 = b + p * bs0;
-        ValueTypeB *__restrict__ beta2 = b + p_plus_one * bs0;
+        ValueTypeB *KOKKOS_RESTRICT beta1 = b + p * bs0;
+        ValueTypeB *KOKKOS_RESTRICT beta2 = b + p_plus_one * bs0;
 
         const ValueTypeB beta_one = *beta1;
         const ValueTypeB beta_two = *beta2;
@@ -68,8 +68,8 @@ struct SerialShiftedTrsvInternalLower {
         *beta2 = (-alpha21 * (beta_one) + alpha11 * (beta_two)) / det;
 
         if (iend) {
-          const ValueTypeA *__restrict__ A21 = A + p * as + 2 * as0;
-          ValueTypeB *__restrict__ b2        = beta1 + 2 * bs0;
+          const ValueTypeA *KOKKOS_RESTRICT A21 = A + p * as + 2 * as0;
+          ValueTypeB *KOKKOS_RESTRICT b2        = beta1 + 2 * bs0;
 
           for (int i = 0; i < iend; ++i)
             b2[i * bs0] -=
@@ -89,14 +89,14 @@ struct SerialShiftedTrsvInternalLower {
 struct SerialShiftedTrsvInternalUpper {
   template <typename ScalarType, typename ValueTypeA, typename ValueTypeB>
   KOKKOS_INLINE_FUNCTION static int invoke(const int m, const ScalarType lambda,
-                                           const ValueTypeA *__restrict__ A,
+                                           const ValueTypeA *KOKKOS_RESTRICT A,
                                            const int as0, const int as1,
-                                           /**/ ValueTypeB *__restrict__ b,
+                                           /**/ ValueTypeB *KOKKOS_RESTRICT b,
                                            const int bs0,
-                                           const int *__restrict__ blks) {
+                                           const int *KOKKOS_RESTRICT blks) {
     const int as = as0 + as1;
 
-    ValueTypeB *__restrict__ b0 = b;
+    ValueTypeB *KOKKOS_RESTRICT b0 = b;
 
     int p = m - 1;
     for (; p >= 0;) {
@@ -104,16 +104,16 @@ struct SerialShiftedTrsvInternalUpper {
       assert(((blk == 1) || (blk == 2)) &&
              "ShiftedTrsvUpper: blocks are not 1x1 or 2x2");
       if (blk == 1) {
-        const auto alpha11                = A[p * as] - lambda;
-        /**/ ValueTypeB *__restrict__ beta1 = b + p * bs0;
+        const auto alpha11                   = A[p * as] - lambda;
+        /**/ ValueTypeB *KOKKOS_RESTRICT beta1 = b + p * bs0;
 
-        // with __restrict__ a compiler assumes that the pointer is not accessed
-        // by others op(/=) uses this pointer and changes the associated values,
-        // which brings a compiler problem
+        // with KOKKOS_RESTRICT a compiler assumes that the pointer is not
+        // accessed by others op(/=) uses this pointer and changes the
+        // associated values, which brings a compiler problem
         *beta1 = *beta1 / alpha11;
 
         if (iend) {
-          const ValueTypeA *__restrict__ a01 = A + p * as1;
+          const ValueTypeA *KOKKOS_RESTRICT a01 = A + p * as1;
           for (int i = 0; i < iend; ++i) b0[i * bs0] -= a01[i * as0] * (*beta1);
         }
       } else {
@@ -124,8 +124,8 @@ struct SerialShiftedTrsvInternalUpper {
         const auto alpha22    = A[p * as] - lambda;
         const auto det        = alpha11 * alpha22 - alpha12 * alpha21;
 
-        ValueTypeB *__restrict__ beta1 = b + p_minus_one * bs0;
-        ValueTypeB *__restrict__ beta2 = b + p * bs0;
+        ValueTypeB *KOKKOS_RESTRICT beta1 = b + p_minus_one * bs0;
+        ValueTypeB *KOKKOS_RESTRICT beta2 = b + p * bs0;
 
         const ValueTypeB beta_one = *beta1;
         const ValueTypeB beta_two = *beta2;
@@ -134,7 +134,7 @@ struct SerialShiftedTrsvInternalUpper {
         *beta2 = (-alpha21 * (beta_one) + alpha11 * (beta_two)) / det;
 
         if (iend) {
-          const ValueTypeA *__restrict__ A01 = A + p_minus_one * as1;
+          const ValueTypeA *KOKKOS_RESTRICT A01 = A + p_minus_one * as1;
           for (int i = 0; i < iend; ++i)
             b0[i * bs0] -=
                 (A01[i * as0] * (*beta1) + A01[i * as0 + as1] * (*beta2));

--- a/src/batched/dense/impl/KokkosBatched_Trmm_Serial_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Trmm_Serial_Internal.hpp
@@ -58,8 +58,8 @@ struct SerialTrmmInternalLeftLower {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const bool use_unit_diag, const bool do_conj, const int am, const int an,
       const int bm, const int bn, const ScalarType alpha,
-      const ValueType *__restrict__ A, const int as0, const int as1,
-      /**/ ValueType *__restrict__ B, const int bs0, const int bs1);
+      const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+      /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1);
 };
 
 template <typename AlgoType>
@@ -68,8 +68,8 @@ struct SerialTrmmInternalLeftUpper {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const bool use_unit_diag, const bool do_conj, const int am, const int an,
       const int bm, const int bn, const ScalarType alpha,
-      const ValueType *__restrict__ A, const int as0, const int as1,
-      /**/ ValueType *__restrict__ B, const int bs0, const int bs1);
+      const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+      /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1);
 };
 
 template <typename AlgoType>
@@ -78,8 +78,8 @@ struct SerialTrmmInternalRightLower {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const bool use_unit_diag, const bool do_conj, const int am, const int an,
       const int bm, const int bn, const ScalarType alpha,
-      const ValueType *__restrict__ A, const int as0, const int as1,
-      /**/ ValueType *__restrict__ B, const int bs0, const int bs1);
+      const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+      /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1);
 };
 
 template <typename AlgoType>
@@ -88,8 +88,8 @@ struct SerialTrmmInternalRightUpper {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const bool use_unit_diag, const bool do_conj, const int am, const int an,
       const int bm, const int bn, const ScalarType alpha,
-      const ValueType *__restrict__ A, const int as0, const int as1,
-      /**/ ValueType *__restrict__ B, const int bs0, const int bs1);
+      const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+      /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1);
 };
 
 // ech-note: use_unit_diag intentionally ignored for now. Compiler can optimize
@@ -102,8 +102,8 @@ KOKKOS_INLINE_FUNCTION int
 SerialTrmmInternalLeftLower<Algo::Trmm::Unblocked>::invoke(
     const bool /*use_unit_diag*/, const bool do_conj, const int am,
     const int an, const int bm, const int bn, const ScalarType alpha,
-    const ValueType *__restrict__ A, const int as0, const int as1,
-    /**/ ValueType *__restrict__ B, const int bs0, const int bs1) {
+    const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+    /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   const ScalarType one(1.0), zero(0.0);
   typedef Kokkos::Details::ArithTraits<ValueType> AT;
   int left_m  = am;
@@ -116,9 +116,9 @@ SerialTrmmInternalLeftLower<Algo::Trmm::Unblocked>::invoke(
   // printf("SerialTrmmInternalLeftLower\n");
 
   auto dotLowerLeftConj =
-      [&](const ValueType *__restrict__ __A, const int __as0, const int __as1,
-          const int __left_row, ValueType *__restrict__ __B, const int __bs0,
-          const int __bs1, const int __right_col) {
+      [&](const ValueType *KOKKOS_RESTRICT __A, const int __as0,
+          const int __as1, const int __left_row, ValueType *KOKKOS_RESTRICT __B,
+          const int __bs0, const int __bs1, const int __right_col) {
         auto B_elems   = __left_row;
         ScalarType sum = 0;
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
@@ -132,9 +132,9 @@ SerialTrmmInternalLeftLower<Algo::Trmm::Unblocked>::invoke(
         return sum;
       };
 
-  auto dotLowerLeft = [&](const ValueType *__restrict__ __A, const int __as0,
+  auto dotLowerLeft = [&](const ValueType *KOKKOS_RESTRICT __A, const int __as0,
                           const int __as1, const int __left_row,
-                          ValueType *__restrict__ __B, const int __bs0,
+                          ValueType *KOKKOS_RESTRICT __B, const int __bs0,
                           const int __bs1, const int __right_col) {
     auto B_elems   = __left_row;
     ScalarType sum = 0;
@@ -186,8 +186,8 @@ KOKKOS_INLINE_FUNCTION int
 SerialTrmmInternalRightLower<Algo::Trmm::Unblocked>::invoke(
     const bool /*use_unit_diag*/, const bool do_conj, const int am,
     const int an, const int bm, const int bn, const ScalarType alpha,
-    const ValueType *__restrict__ A, const int as0, const int as1,
-    /**/ ValueType *__restrict__ B, const int bs0, const int bs1) {
+    const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+    /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   const ScalarType one(1.0), zero(0.0);
   typedef Kokkos::Details::ArithTraits<ValueType> AT;
   int left_m  = bm;
@@ -201,39 +201,41 @@ SerialTrmmInternalRightLower<Algo::Trmm::Unblocked>::invoke(
   // Lower triangular matrix is on RHS with the base facing down.
   // Everytime we compute a new output row of B, we must shift over to the
   // right by one in A's column to ensure we skip the 0's.
-  auto dotLowerRightConj =
-      [&](const ValueType *__restrict__ __A, const int __as0, const int __as1,
-          const int __am, const int __left_row, ValueType *__restrict__ __B,
-          const int __bs0, const int __bs1, const int __right_col) {
-        auto B_elems   = __am - 1;
-        ScalarType sum = 0;
+  auto dotLowerRightConj = [&](const ValueType *KOKKOS_RESTRICT __A,
+                               const int __as0, const int __as1, const int __am,
+                               const int __left_row,
+                               ValueType *KOKKOS_RESTRICT __B, const int __bs0,
+                               const int __bs1, const int __right_col) {
+    auto B_elems   = __am - 1;
+    ScalarType sum = 0;
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
 #endif
-        for (int i = __right_col; i <= B_elems; i++) {
-          // sum += B[left_row, i] * A[i, right_col]
-          sum += __B[__bs0 * __left_row + i * __bs1] *
-                 AT::conj(__A[i * __as0 + __right_col * __as1]);
-        }
-        return sum;
-      };
+    for (int i = __right_col; i <= B_elems; i++) {
+      // sum += B[left_row, i] * A[i, right_col]
+      sum += __B[__bs0 * __left_row + i * __bs1] *
+             AT::conj(__A[i * __as0 + __right_col * __as1]);
+    }
+    return sum;
+  };
 
-  auto dotLowerRight =
-      [&](const ValueType *__restrict__ __A, const int __as0, const int __as1,
-          const int __am, const int __left_row, ValueType *__restrict__ __B,
-          const int __bs0, const int __bs1, const int __right_col) {
-        auto B_elems   = __am - 1;
-        ScalarType sum = 0;
+  auto dotLowerRight = [&](const ValueType *KOKKOS_RESTRICT __A,
+                           const int __as0, const int __as1, const int __am,
+                           const int __left_row, ValueType *KOKKOS_RESTRICT __B,
+                           const int __bs0, const int __bs1,
+                           const int __right_col) {
+    auto B_elems   = __am - 1;
+    ScalarType sum = 0;
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
 #endif
-        for (int i = __right_col; i <= B_elems; i++) {
-          // sum += B[left_row, i] * A[i, right_col]
-          sum += __B[__bs0 * __left_row + i * __bs1] *
-                 __A[i * __as0 + __right_col * __as1];
-        }
-        return sum;
-      };
+    for (int i = __right_col; i <= B_elems; i++) {
+      // sum += B[left_row, i] * A[i, right_col]
+      sum += __B[__bs0 * __left_row + i * __bs1] *
+             __A[i * __as0 + __right_col * __as1];
+    }
+    return sum;
+  };
 
   if (bm <= 0 || bn <= 0 || am <= 0 || an <= 0) return 0;
 
@@ -269,8 +271,8 @@ KOKKOS_INLINE_FUNCTION int
 SerialTrmmInternalLeftUpper<Algo::Trmm::Unblocked>::invoke(
     const bool /*use_unit_diag*/, const bool do_conj, const int am,
     const int an, const int bm, const int bn, const ScalarType alpha,
-    const ValueType *__restrict__ A, const int as0, const int as1,
-    /**/ ValueType *__restrict__ B, const int bs0, const int bs1) {
+    const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+    /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   const ScalarType one(1.0), zero(0.0);
   typedef Kokkos::Details::ArithTraits<ValueType> AT;
   int left_m  = am;
@@ -281,26 +283,27 @@ SerialTrmmInternalLeftUpper<Algo::Trmm::Unblocked>::invoke(
   //  conjOp = AT::conj;
   //}
 
-  auto dotUpperLeftConj =
-      [&](const ValueType *__restrict__ __A, const int __as0, const int __as1,
-          const int __an, const int __left_row, ValueType *__restrict__ __B,
-          const int __bs0, const int __bs1, const int __right_col) {
-        auto B_elems   = __an - __left_row - 1;
-        ScalarType sum = 0;
+  auto dotUpperLeftConj = [&](const ValueType *KOKKOS_RESTRICT __A,
+                              const int __as0, const int __as1, const int __an,
+                              const int __left_row,
+                              ValueType *KOKKOS_RESTRICT __B, const int __bs0,
+                              const int __bs1, const int __right_col) {
+    auto B_elems   = __an - __left_row - 1;
+    ScalarType sum = 0;
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
 #endif
-        for (int i = 0; i <= B_elems; i++) {
-          // sum += A[left_row, i+left_row] * B[i+left_row, right_col]
-          sum += AT::conj(__A[__left_row * __as0 + (i + __left_row) * __as1]) *
-                 __B[(i + __left_row) * __bs0 + __bs1 * __right_col];
-        }
-        return sum;
-      };
+    for (int i = 0; i <= B_elems; i++) {
+      // sum += A[left_row, i+left_row] * B[i+left_row, right_col]
+      sum += AT::conj(__A[__left_row * __as0 + (i + __left_row) * __as1]) *
+             __B[(i + __left_row) * __bs0 + __bs1 * __right_col];
+    }
+    return sum;
+  };
 
-  auto dotUpperLeft = [&](const ValueType *__restrict__ __A, const int __as0,
+  auto dotUpperLeft = [&](const ValueType *KOKKOS_RESTRICT __A, const int __as0,
                           const int __as1, const int __an, const int __left_row,
-                          ValueType *__restrict__ __B, const int __bs0,
+                          ValueType *KOKKOS_RESTRICT __B, const int __bs0,
                           const int __bs1, const int __right_col) {
     auto B_elems   = __an - __left_row - 1;
     ScalarType sum = 0;
@@ -349,8 +352,8 @@ KOKKOS_INLINE_FUNCTION int
 SerialTrmmInternalRightUpper<Algo::Trmm::Unblocked>::invoke(
     const bool /*use_unit_diag*/, const bool do_conj, const int am,
     const int an, const int bm, const int bn, const ScalarType alpha,
-    const ValueType *__restrict__ A, const int as0, const int as1,
-    /**/ ValueType *__restrict__ B, const int bs0, const int bs1) {
+    const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+    /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   const ScalarType one(1.0), zero(0.0);
   typedef Kokkos::Details::ArithTraits<ValueType> AT;
   int left_m  = bm;
@@ -362,9 +365,9 @@ SerialTrmmInternalRightUpper<Algo::Trmm::Unblocked>::invoke(
   //}
 
   auto dotUpperRightConj =
-      [&](const ValueType *__restrict__ __A, const int __as0, const int __as1,
-          const int __left_row, ValueType *__restrict__ __B, const int __bs0,
-          const int __bs1, const int __right_col) {
+      [&](const ValueType *KOKKOS_RESTRICT __A, const int __as0,
+          const int __as1, const int __left_row, ValueType *KOKKOS_RESTRICT __B,
+          const int __bs0, const int __bs1, const int __right_col) {
         auto B_elems   = __right_col;
         ScalarType sum = 0;
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
@@ -378,22 +381,22 @@ SerialTrmmInternalRightUpper<Algo::Trmm::Unblocked>::invoke(
         return sum;
       };
 
-  auto dotUpperRight = [&](const ValueType *__restrict__ __A, const int __as0,
-                           const int __as1, const int __left_row,
-                           ValueType *__restrict__ __B, const int __bs0,
-                           const int __bs1, const int __right_col) {
-    auto B_elems   = __right_col;
-    ScalarType sum = 0;
+  auto dotUpperRight =
+      [&](const ValueType *KOKKOS_RESTRICT __A, const int __as0,
+          const int __as1, const int __left_row, ValueType *KOKKOS_RESTRICT __B,
+          const int __bs0, const int __bs1, const int __right_col) {
+        auto B_elems   = __right_col;
+        ScalarType sum = 0;
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
 #endif
-    for (int i = 0; i <= B_elems; i++) {
-      // sum += B[left_row, i] * A[i, right_col]
-      sum += __B[__left_row * __bs0 + i * __bs1] *
-             __A[i * __as0 + __right_col * __as1];
-    }
-    return sum;
-  };
+        for (int i = 0; i <= B_elems; i++) {
+          // sum += B[left_row, i] * A[i, right_col]
+          sum += __B[__left_row * __bs0 + i * __bs1] *
+                 __A[i * __as0 + __right_col * __as1];
+        }
+        return sum;
+      };
 
   if (bm <= 0 || bn <= 0 || am <= 0 || an <= 0) return 0;
 

--- a/src/batched/dense/impl/KokkosBatched_Trsm_Serial_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Trsm_Serial_Internal.hpp
@@ -23,9 +23,9 @@ struct SerialTrsmInternalLeftLower {
   KOKKOS_INLINE_FUNCTION static int invoke(const bool use_unit_diag,
                                            const int m, const int n,
                                            const ScalarType alpha,
-                                           const ValueType *__restrict__ A,
+                                           const ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1,
-                                           /**/ ValueType *__restrict__ B,
+                                           /**/ ValueType *KOKKOS_RESTRICT B,
                                            const int bs0, const int bs1);
 };
 
@@ -34,8 +34,8 @@ template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int
 SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
     const bool use_unit_diag, const int m, const int n, const ScalarType alpha,
-    const ValueType *__restrict__ A, const int as0, const int as1,
-    /**/ ValueType *__restrict__ B, const int bs0, const int bs1) {
+    const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+    /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   const ScalarType one(1.0), zero(0.0);
 
   if (alpha == zero)
@@ -47,12 +47,12 @@ SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
     for (int p = 0; p < m; ++p) {
       const int iend = m - p - 1, jend = n;
 
-      const ValueType *__restrict__ a21 =
+      const ValueType *KOKKOS_RESTRICT a21 =
           iend ? A + (p + 1) * as0 + p * as1 : NULL;
 
-      ValueType *__restrict__ b1t = B + p * bs0,
-                              *__restrict__ B2 =
-                                  iend ? B + (p + 1) * bs0 : NULL;
+      ValueType *KOKKOS_RESTRICT b1t = B + p * bs0,
+                                 *KOKKOS_RESTRICT B2 =
+                                     iend ? B + (p + 1) * bs0 : NULL;
 
       if (!use_unit_diag) {
         const ValueType alpha11 = A[p * as0 + p * as1];
@@ -80,8 +80,8 @@ template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int
 SerialTrsmInternalLeftLower<Algo::Trsm::Blocked>::invoke(
     const bool use_unit_diag, const int m, const int n, const ScalarType alpha,
-    const ValueType *__restrict__ A, const int as0, const int as1,
-    /**/ ValueType *__restrict__ B, const int bs0, const int bs1) {
+    const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+    /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   enum : int {
     mbAlgo = Algo::Trsm::Blocked::mb<Kokkos::Impl::ActiveExecutionMemorySpace>()
   };
@@ -99,15 +99,15 @@ SerialTrsmInternalLeftLower<Algo::Trsm::Blocked>::invoke(
 
     InnerGemmFixA<mbAlgo, mbAlgo> gemm(as0, as1, bs0, bs1, bs0, bs1);
     auto trsm = [&](const int ib, const int jb,
-                    const ValueType *__restrict__ AA,
-                    /**/ ValueType *__restrict__ BB) {
+                    const ValueType *KOKKOS_RESTRICT AA,
+                    /**/ ValueType *KOKKOS_RESTRICT BB) {
       const int mb = mbAlgo;
       for (int p = 0; p < ib; p += mb) {
         const int pb = (p + mb) > ib ? (ib - p) : mb;
 
         // trsm update
-        const ValueType *__restrict__ Ap = AA + p * as0 + p * as1;
-        /**/ ValueType *__restrict__ Bp    = BB + p * bs0;
+        const ValueType *KOKKOS_RESTRICT Ap = AA + p * as0 + p * as1;
+        /**/ ValueType *KOKKOS_RESTRICT Bp    = BB + p * bs0;
 
         if (use_unit_diag)
           trsm_u.serial_invoke(Ap, pb, jb, Bp);
@@ -140,9 +140,9 @@ struct SerialTrsmInternalLeftUpper {
   KOKKOS_INLINE_FUNCTION static int invoke(const bool use_unit_diag,
                                            const int m, const int n,
                                            const ScalarType alpha,
-                                           const ValueType *__restrict__ A,
+                                           const ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1,
-                                           /**/ ValueType *__restrict__ B,
+                                           /**/ ValueType *KOKKOS_RESTRICT B,
                                            const int bs0, const int bs1);
 };
 
@@ -151,8 +151,8 @@ template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int
 SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
     const bool use_unit_diag, const int m, const int n, const ScalarType alpha,
-    const ValueType *__restrict__ A, const int as0, const int as1,
-    /**/ ValueType *__restrict__ B, const int bs0, const int bs1) {
+    const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+    /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   const ScalarType one(1.0), zero(0.0);
 
   if (alpha == zero)
@@ -161,12 +161,12 @@ SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
     if (alpha != one) SerialScaleInternal::invoke(m, n, alpha, B, bs0, bs1);
     if (m <= 0 || n <= 0) return 0;
 
-    ValueType *__restrict__ B0 = B;
+    ValueType *KOKKOS_RESTRICT B0 = B;
     for (int p = (m - 1); p >= 0; --p) {
       const int iend = p, jend = n;
 
-      const ValueType *__restrict__ a01 = A + p * as1;
-      ValueType *__restrict__ b1t       = B + p * bs0;
+      const ValueType *KOKKOS_RESTRICT a01 = A + p * as1;
+      ValueType *KOKKOS_RESTRICT b1t       = B + p * bs0;
 
       if (!use_unit_diag) {
         const ValueType alpha11 = A[p * as0 + p * as1];
@@ -197,8 +197,8 @@ template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int
 SerialTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(
     const bool use_unit_diag, const int m, const int n, const ScalarType alpha,
-    const ValueType *__restrict__ A, const int as0, const int as1,
-    /**/ ValueType *__restrict__ B, const int bs0, const int bs1) {
+    const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+    /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
   enum : int {
@@ -217,16 +217,16 @@ SerialTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(
     InnerGemmFixA<mbAlgo, mbAlgo> gemm(as0, as1, bs0, bs1, bs0, bs1);
 
     auto trsm = [&](const int ib, const int jb,
-                    const ValueType *__restrict__ AA,
-                    /**/ ValueType *__restrict__ BB) {
+                    const ValueType *KOKKOS_RESTRICT AA,
+                    /**/ ValueType *KOKKOS_RESTRICT BB) {
       const int mb = mbAlgo;
       for (int pp = 0; pp < ib; pp += mb) {
         const int ptmp = ib - pp - mb, p = ptmp < 0 ? 0 : ptmp,
                   pb = mb + (ptmp < 0) * ptmp;
 
         // trsm update
-        const ValueType *__restrict__ Ap = AA + p * as0 + p * as1;
-        /**/ ValueType *__restrict__ Bp    = BB + p * bs0;
+        const ValueType *KOKKOS_RESTRICT Ap = AA + p * as0 + p * as1;
+        /**/ ValueType *KOKKOS_RESTRICT Bp    = BB + p * bs0;
 
         if (use_unit_diag)
           trsm_u.serial_invoke(Ap, pb, jb, Bp);

--- a/src/batched/dense/impl/KokkosBatched_Trsm_TeamVector_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Trsm_TeamVector_Internal.hpp
@@ -19,9 +19,9 @@ struct TeamVectorTrsmInternalLeftLower {
   template <typename MemberType, typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType &member, const bool use_unit_diag, const int m,
-      const int n, const ScalarType alpha, const ValueType *__restrict__ A,
+      const int n, const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
       const int as0, const int as1,
-      /**/ ValueType *__restrict__ B, const int bs0, const int bs1);
+      /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1);
 };
 
 template <>
@@ -29,9 +29,9 @@ template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int
 TeamVectorTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
     const MemberType &member, const bool use_unit_diag, const int m,
-    const int n, const ScalarType alpha, const ValueType *__restrict__ A,
+    const int n, const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
     const int as0, const int as1,
-    /**/ ValueType *__restrict__ B, const int bs0, const int bs1) {
+    /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   const ScalarType one(1.0), zero(0.0);
 
   if (alpha == zero)
@@ -46,12 +46,12 @@ TeamVectorTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
       int iend = m - p - 1;
       int jend = n;
 
-      const ValueType *__restrict__ a21 =
+      const ValueType *KOKKOS_RESTRICT a21 =
           iend ? A + (p + 1) * as0 + p * as1 : NULL;
 
-      ValueType *__restrict__ b1t = B + p * bs0,
-                              *__restrict__ B2 =
-                                  iend ? B + (p + 1) * bs0 : NULL;
+      ValueType *KOKKOS_RESTRICT b1t = B + p * bs0,
+                                 *KOKKOS_RESTRICT B2 =
+                                     iend ? B + (p + 1) * bs0 : NULL;
 
       member.team_barrier();
       if (!use_unit_diag) {
@@ -79,9 +79,9 @@ struct TeamVectorTrsmInternalLeftUpper {
   template <typename MemberType, typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType &member, const bool use_unit_diag, const int m,
-      const int n, const ScalarType alpha, const ValueType *__restrict__ A,
+      const int n, const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
       const int as0, const int as1,
-      /**/ ValueType *__restrict__ B, const int bs0, const int bs1);
+      /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1);
 };
 
 template <>
@@ -89,9 +89,9 @@ template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int
 TeamVectorTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
     const MemberType &member, const bool use_unit_diag, const int m,
-    const int n, const ScalarType alpha, const ValueType *__restrict__ A,
+    const int n, const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
     const int as0, const int as1,
-    /**/ ValueType *__restrict__ B, const int bs0, const int bs1) {
+    /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   const ScalarType one(1.0), zero(0.0);
 
   // note that parallel range is different ( m*n vs m-1*n);
@@ -102,14 +102,14 @@ TeamVectorTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
       TeamVectorScaleInternal::invoke(member, m, n, alpha, B, bs0, bs1);
     if (m <= 0 || n <= 0) return 0;
 
-    ValueType *__restrict__ B0 = B;
+    ValueType *KOKKOS_RESTRICT B0 = B;
     for (int p = (m - 1); p >= 0; --p) {
       // Made this non-const in order to WORKAROUND issue #349
       int iend = p;
       int jend = n;
 
-      const ValueType *__restrict__ a01 = A + p * as1;
-      /**/ ValueType *__restrict__ b1t    = B + p * bs0;
+      const ValueType *KOKKOS_RESTRICT a01 = A + p * as1;
+      /**/ ValueType *KOKKOS_RESTRICT b1t    = B + p * bs0;
 
       member.team_barrier();
       if (!use_unit_diag) {

--- a/src/batched/dense/impl/KokkosBatched_Trsm_Team_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Trsm_Team_Internal.hpp
@@ -23,9 +23,9 @@ struct TeamTrsmInternalLeftLower {
   template <typename MemberType, typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType &member, const bool use_unit_diag, const int m,
-      const int n, const ScalarType alpha, const ValueType *__restrict__ A,
+      const int n, const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
       const int as0, const int as1,
-      /**/ ValueType *__restrict__ B, const int bs0, const int bs1);
+      /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1);
 };
 
 template <>
@@ -33,9 +33,9 @@ template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int
 TeamTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
     const MemberType &member, const bool use_unit_diag, const int m,
-    const int n, const ScalarType alpha, const ValueType *__restrict__ A,
+    const int n, const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
     const int as0, const int as1,
-    /**/ ValueType *__restrict__ B, const int bs0, const int bs1) {
+    /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   const ScalarType one(1.0), zero(0.0);
 
   if (alpha == zero)
@@ -50,12 +50,12 @@ TeamTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
       int iend = m - p - 1;
       int jend = n;
 
-      const ValueType *__restrict__ a21 =
+      const ValueType *KOKKOS_RESTRICT a21 =
           iend ? A + (p + 1) * as0 + p * as1 : NULL;
 
-      ValueType *__restrict__ b1t = B + p * bs0,
-                              *__restrict__ B2 =
-                                  iend ? B + (p + 1) * bs0 : NULL;
+      ValueType *KOKKOS_RESTRICT b1t = B + p * bs0,
+                                 *KOKKOS_RESTRICT B2 =
+                                     iend ? B + (p + 1) * bs0 : NULL;
 
       member.team_barrier();
       if (!use_unit_diag) {
@@ -81,9 +81,9 @@ template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int
 TeamTrsmInternalLeftLower<Algo::Trsm::Blocked>::invoke(
     const MemberType &member, const bool use_unit_diag, const int m,
-    const int n, const ScalarType alpha, const ValueType *__restrict__ A,
+    const int n, const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
     const int as0, const int as1,
-    /**/ ValueType *__restrict__ B, const int bs0, const int bs1) {
+    /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   enum : int {
     mbAlgo = Algo::Trsm::Blocked::mb<Kokkos::Impl::ActiveExecutionMemorySpace>()
   };
@@ -107,8 +107,8 @@ TeamTrsmInternalLeftLower<Algo::Trsm::Blocked>::invoke(
     InnerTrsmLeftLowerNonUnitDiag<mbAlgo> trsm_n(as0, as1, bs0, bs1);
 
     auto trsm = [&](const int ib, const int jb,
-                    const ValueType *__restrict__ AA,
-                    /**/ ValueType *__restrict__ BB) {
+                    const ValueType *KOKKOS_RESTRICT AA,
+                    /**/ ValueType *KOKKOS_RESTRICT BB) {
       const int mb    = mbAlgo;
       const int tsize = member.team_size();
       // Made this non-const in order to WORKAROUND issue #349
@@ -119,8 +119,8 @@ TeamTrsmInternalLeftLower<Algo::Trsm::Blocked>::invoke(
         int pb = ((p + mb) > ib ? (ib - p) : mb);
 
         // trsm update
-        const ValueType *__restrict__ Ap = AA + p * as0 + p * as1;
-        /**/ ValueType *__restrict__ Bp    = BB + p * bs0;
+        const ValueType *KOKKOS_RESTRICT Ap = AA + p * as0 + p * as1;
+        /**/ ValueType *KOKKOS_RESTRICT Bp    = BB + p * bs0;
 
         member.team_barrier();
         Kokkos::parallel_for(
@@ -158,9 +158,9 @@ struct TeamTrsmInternalLeftUpper {
   template <typename MemberType, typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType &member, const bool use_unit_diag, const int m,
-      const int n, const ScalarType alpha, const ValueType *__restrict__ A,
+      const int n, const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
       const int as0, const int as1,
-      /**/ ValueType *__restrict__ B, const int bs0, const int bs1);
+      /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1);
 };
 
 template <>
@@ -168,9 +168,9 @@ template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int
 TeamTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
     const MemberType &member, const bool use_unit_diag, const int m,
-    const int n, const ScalarType alpha, const ValueType *__restrict__ A,
+    const int n, const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
     const int as0, const int as1,
-    /**/ ValueType *__restrict__ B, const int bs0, const int bs1) {
+    /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   const ScalarType one(1.0), zero(0.0);
 
   // note that parallel range is different ( m*n vs m-1*n);
@@ -181,14 +181,14 @@ TeamTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
       TeamScaleInternal::invoke(member, m, n, alpha, B, bs0, bs1);
     if (m <= 0 || n <= 0) return 0;
 
-    ValueType *__restrict__ B0 = B;
+    ValueType *KOKKOS_RESTRICT B0 = B;
     for (int p = (m - 1); p >= 0; --p) {
       // Made this non-const in order to WORKAROUND issue #349
       int iend = p;
       int jend = n;
 
-      const ValueType *__restrict__ a01 = A + p * as1;
-      /**/ ValueType *__restrict__ b1t    = B + p * bs0;
+      const ValueType *KOKKOS_RESTRICT a01 = A + p * as1;
+      /**/ ValueType *KOKKOS_RESTRICT b1t    = B + p * bs0;
 
       member.team_barrier();
       if (!use_unit_diag) {
@@ -222,9 +222,9 @@ template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int
 TeamTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(
     const MemberType &member, const bool use_unit_diag, const int m,
-    const int n, const ScalarType alpha, const ValueType *__restrict__ A,
+    const int n, const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A,
     const int as0, const int as1,
-    /**/ ValueType *__restrict__ B, const int bs0, const int bs1) {
+    /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   enum : int {
     mbAlgo = Algo::Trsm::Blocked::mb<Kokkos::Impl::ActiveExecutionMemorySpace>()
   };
@@ -243,8 +243,8 @@ TeamTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(
     InnerTrsmLeftUpperNonUnitDiag<mbAlgo> trsm_n(as0, as1, bs0, bs1);
 
     auto trsm = [&](const int ib, const int jb,
-                    const ValueType *__restrict__ AA,
-                    /**/ ValueType *__restrict__ BB) {
+                    const ValueType *KOKKOS_RESTRICT AA,
+                    /**/ ValueType *KOKKOS_RESTRICT BB) {
       const int mb    = mbAlgo;  //(ib <=5 ? ib : mbAlgo);
       const int tsize = member.team_size();
       // Made this non-const in order to WORKAROUND issue #349
@@ -255,8 +255,8 @@ TeamTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(
                   pb = (mb + (ptmp < 0) * ptmp);
 
         // trsm update
-        const ValueType *__restrict__ Ap = AA + p * as0 + p * as1;
-        /**/ ValueType *__restrict__ Bp    = BB + p * bs0;
+        const ValueType *KOKKOS_RESTRICT Ap = AA + p * as0 + p * as1;
+        /**/ ValueType *KOKKOS_RESTRICT Bp    = BB + p * bs0;
 
         member.team_barrier();
         Kokkos::parallel_for(

--- a/src/batched/dense/impl/KokkosBatched_Trsv_Serial_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Trsv_Serial_Internal.hpp
@@ -26,9 +26,9 @@ struct SerialTrsvInternalLower {
   template <typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const bool use_unit_diag,
                                            const int m, const ScalarType alpha,
-                                           const ValueType *__restrict__ A,
+                                           const ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1,
-                                           /**/ ValueType *__restrict__ b,
+                                           /**/ ValueType *KOKKOS_RESTRICT b,
                                            const int bs0);
 };
 
@@ -37,8 +37,8 @@ template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int
 SerialTrsvInternalLower<Algo::Trsv::Unblocked>::invoke(
     const bool use_unit_diag, const int m, const ScalarType alpha,
-    const ValueType *__restrict__ A, const int as0, const int as1,
-    /**/ ValueType *__restrict__ b, const int bs0) {
+    const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+    /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
   const ScalarType one(1.0), zero(0.0);
 
   if (alpha == zero)
@@ -50,15 +50,16 @@ SerialTrsvInternalLower<Algo::Trsv::Unblocked>::invoke(
     for (int p = 0; p < m; ++p) {
       const int iend = m - p - 1;
 
-      const ValueType *__restrict__ a21 =
+      const ValueType *KOKKOS_RESTRICT a21 =
           iend ? A + (p + 1) * as0 + p * as1 : NULL;
 
-      ValueType *__restrict__ beta1            = b + p * bs0,
-                              *__restrict__ b2 = iend ? beta1 + bs0 : NULL;
+      ValueType *KOKKOS_RESTRICT beta1 = b + p * bs0,
+                                 *KOKKOS_RESTRICT b2 =
+                                     iend ? beta1 + bs0 : NULL;
 
-      // with __restrict__ a compiler assumes that the pointer is not accessed
-      // by others op(/=) uses this pointer and changes the associated values,
-      // which brings a compiler problem
+      // with KOKKOS_RESTRICT a compiler assumes that the pointer is not
+      // accessed by others op(/=) uses this pointer and changes the associated
+      // values, which brings a compiler problem
       if (!use_unit_diag) *beta1 = *beta1 / A[p * as0 + p * as1];
 
       for (int i = 0; i < iend; ++i) b2[i * bs0] -= a21[i * as0] * (*beta1);
@@ -71,8 +72,8 @@ template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialTrsvInternalLower<Algo::Trsv::Blocked>::invoke(
     const bool use_unit_diag, const int m, const ScalarType alpha,
-    const ValueType *__restrict__ A, const int as0, const int as1,
-    /**/ ValueType *__restrict__ b, const int bs0) {
+    const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+    /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
   enum : int {
@@ -94,8 +95,8 @@ KOKKOS_INLINE_FUNCTION int SerialTrsvInternalLower<Algo::Trsv::Blocked>::invoke(
       const int pb = ((p + mb) > m ? (m - p) : mb);
 
       // trsm update
-      const ValueType *__restrict__ Ap = A + p * as0 + p * as1;
-      /**/ ValueType *__restrict__ bp    = b + p * bs0;
+      const ValueType *KOKKOS_RESTRICT Ap = A + p * as0 + p * as1;
+      /**/ ValueType *KOKKOS_RESTRICT bp    = b + p * bs0;
 
       if (use_unit_diag)
         trsm_u.serial_invoke(Ap, pb, 1, bp);
@@ -120,9 +121,9 @@ struct SerialTrsvInternalUpper {
   template <typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const bool use_unit_diag,
                                            const int m, const ScalarType alpha,
-                                           const ValueType *__restrict__ A,
+                                           const ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1,
-                                           /**/ ValueType *__restrict__ b,
+                                           /**/ ValueType *KOKKOS_RESTRICT b,
                                            const int bs0);
 };
 
@@ -131,8 +132,8 @@ template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int
 SerialTrsvInternalUpper<Algo::Trsv::Unblocked>::invoke(
     const bool use_unit_diag, const int m, const ScalarType alpha,
-    const ValueType *__restrict__ A, const int as0, const int as1,
-    /**/ ValueType *__restrict__ b, const int bs0) {
+    const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+    /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
   const ScalarType one(1.0), zero(0.0);
 
   if (alpha == zero)
@@ -141,16 +142,16 @@ SerialTrsvInternalUpper<Algo::Trsv::Unblocked>::invoke(
     if (alpha != one) SerialScaleInternal::invoke(m, alpha, b, bs0);
     if (m <= 0) return 0;
 
-    ValueType *__restrict__ b0 = b;
+    ValueType *KOKKOS_RESTRICT b0 = b;
     for (int p = (m - 1); p >= 0; --p) {
       const int iend = p;
 
-      const ValueType *__restrict__ a01 = A + p * as1;
-      /**/ ValueType *__restrict__ beta1  = b + p * bs0;
+      const ValueType *KOKKOS_RESTRICT a01 = A + p * as1;
+      /**/ ValueType *KOKKOS_RESTRICT beta1  = b + p * bs0;
 
-      // with __restrict__ a compiler assumes that the pointer is not accessed
-      // by others op(/=) uses this pointer and changes the associated values,
-      // which brings a compiler problem
+      // with KOKKOS_RESTRICT a compiler assumes that the pointer is not
+      // accessed by others op(/=) uses this pointer and changes the associated
+      // values, which brings a compiler problem
       if (!use_unit_diag) *beta1 = *beta1 / A[p * as0 + p * as1];
 
       for (int i = 0; i < iend; ++i) b0[i * bs0] -= a01[i * as0] * (*beta1);
@@ -163,8 +164,8 @@ template <>
 template <typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialTrsvInternalUpper<Algo::Trsv::Blocked>::invoke(
     const bool use_unit_diag, const int m, const ScalarType alpha,
-    const ValueType *__restrict__ A, const int as0, const int as1,
-    /**/ ValueType *__restrict__ b, const int bs0) {
+    const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+    /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
   enum : int {
@@ -187,8 +188,8 @@ KOKKOS_INLINE_FUNCTION int SerialTrsvInternalUpper<Algo::Trsv::Blocked>::invoke(
                 pb = (mb + (ptmp < 0) * ptmp);
 
       // trsm update
-      const ValueType *__restrict__ Ap = A + p * as0 + p * as1;
-      /**/ ValueType *__restrict__ bp    = b + p * bs0;
+      const ValueType *KOKKOS_RESTRICT Ap = A + p * as0 + p * as1;
+      /**/ ValueType *KOKKOS_RESTRICT bp    = b + p * bs0;
 
       if (use_unit_diag)
         trsm_u.serial_invoke(Ap, pb, 1, bp);

--- a/src/batched/dense/impl/KokkosBatched_Trsv_TeamVector_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Trsv_TeamVector_Internal.hpp
@@ -24,8 +24,9 @@ struct TeamVectorTrsvInternalLower {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType & /*member*/, const bool /*use_unit_diag*/,
       const int /*m*/, const ScalarType /*alpha*/,
-      const ValueType *__restrict__ /*A*/, const int /*as0*/, const int /*as1*/,
-      /**/ ValueType *__restrict__ /*b*/, const int /*bs0*/) {
+      const ValueType *KOKKOS_RESTRICT /*A*/, const int /*as0*/,
+      const int /*as1*/,
+      /**/ ValueType *KOKKOS_RESTRICT /*b*/, const int /*bs0*/) {
     assert(false && "Error: encounter dummy impl");
     return 0;
   }
@@ -36,9 +37,9 @@ template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int
 TeamVectorTrsvInternalLower<Algo::Trsv::Unblocked>::invoke(
     const MemberType &member, const bool use_unit_diag, const int m,
-    const ScalarType alpha, const ValueType *__restrict__ A, const int as0,
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A, const int as0,
     const int as1,
-    /**/ ValueType *__restrict__ b, const int bs0) {
+    /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
   const ScalarType one(1.0), zero(0.0);
 
   if (alpha == zero)
@@ -50,11 +51,12 @@ TeamVectorTrsvInternalLower<Algo::Trsv::Unblocked>::invoke(
     for (int p = 0; p < m; ++p) {
       const int iend = m - p - 1;
 
-      const ValueType *__restrict__ a21 =
+      const ValueType *KOKKOS_RESTRICT a21 =
           iend ? A + (p + 1) * as0 + p * as1 : NULL;
 
-      ValueType *__restrict__ beta1            = b + p * bs0,
-                              *__restrict__ b2 = iend ? beta1 + bs0 : NULL;
+      ValueType *KOKKOS_RESTRICT beta1 = b + p * bs0,
+                                 *KOKKOS_RESTRICT b2 =
+                                     iend ? beta1 + bs0 : NULL;
 
       member.team_barrier();
       ValueType local_beta1 = *beta1;
@@ -84,8 +86,9 @@ struct TeamVectorTrsvInternalUpper {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType & /*member*/, const bool /*use_unit_diag*/,
       const int /*m*/, const ScalarType /*alpha*/,
-      const ValueType *__restrict__ /*A*/, const int /*as0*/, const int /*as1*/,
-      /**/ ValueType *__restrict__ /*b*/, const int /*bs0*/) {
+      const ValueType *KOKKOS_RESTRICT /*A*/, const int /*as0*/,
+      const int /*as1*/,
+      /**/ ValueType *KOKKOS_RESTRICT /*b*/, const int /*bs0*/) {
     assert(false && "Error: encounter dummy impl");
     return 0;
   }
@@ -96,9 +99,9 @@ template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int
 TeamVectorTrsvInternalUpper<Algo::Trsv::Unblocked>::invoke(
     const MemberType &member, const bool use_unit_diag, const int m,
-    const ScalarType alpha, const ValueType *__restrict__ A, const int as0,
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A, const int as0,
     const int as1,
-    /**/ ValueType *__restrict__ b, const int bs0) {
+    /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
   const ScalarType one(1.0), zero(0.0);
 
   if (alpha == zero)
@@ -107,12 +110,12 @@ TeamVectorTrsvInternalUpper<Algo::Trsv::Unblocked>::invoke(
     if (alpha != one) TeamVectorScaleInternal::invoke(member, m, alpha, b, bs0);
     if (m <= 0) return 0;
 
-    ValueType *__restrict__ b0 = b;
+    ValueType *KOKKOS_RESTRICT b0 = b;
     for (int p = (m - 1); p >= 0; --p) {
       const int iend = p;
 
-      const ValueType *__restrict__ a01 = A + p * as1;
-      /**/ ValueType *__restrict__ beta1  = b + p * bs0;
+      const ValueType *KOKKOS_RESTRICT a01 = A + p * as1;
+      /**/ ValueType *KOKKOS_RESTRICT beta1  = b + p * bs0;
 
       member.team_barrier();
       ValueType local_beta1 = *beta1;

--- a/src/batched/dense/impl/KokkosBatched_Trsv_Team_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Trsv_Team_Internal.hpp
@@ -27,8 +27,9 @@ struct TeamTrsvInternalLower {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType & /*member*/, const bool /*use_unit_diag*/,
       const int /*m*/, const ScalarType /*alpha*/,
-      const ValueType *__restrict__ /*A*/, const int /*as0*/, const int /*as1*/,
-      /**/ ValueType *__restrict__ /*b*/, const int /*bs0*/) {
+      const ValueType *KOKKOS_RESTRICT /*A*/, const int /*as0*/,
+      const int /*as1*/,
+      /**/ ValueType *KOKKOS_RESTRICT /*b*/, const int /*bs0*/) {
     assert(false && "Error: encounter dummy impl");
     return 0;
   }
@@ -38,9 +39,9 @@ template <>
 template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int TeamTrsvInternalLower<Algo::Trsv::Unblocked>::invoke(
     const MemberType &member, const bool use_unit_diag, const int m,
-    const ScalarType alpha, const ValueType *__restrict__ A, const int as0,
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A, const int as0,
     const int as1,
-    /**/ ValueType *__restrict__ b, const int bs0) {
+    /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
   const ScalarType one(1.0), zero(0.0);
 
   if (alpha == zero)
@@ -52,11 +53,12 @@ KOKKOS_INLINE_FUNCTION int TeamTrsvInternalLower<Algo::Trsv::Unblocked>::invoke(
     for (int p = 0; p < m; ++p) {
       const int iend = m - p - 1;
 
-      const ValueType *__restrict__ a21 =
+      const ValueType *KOKKOS_RESTRICT a21 =
           iend ? A + (p + 1) * as0 + p * as1 : NULL;
 
-      ValueType *__restrict__ beta1            = b + p * bs0,
-                              *__restrict__ b2 = iend ? beta1 + bs0 : NULL;
+      ValueType *KOKKOS_RESTRICT beta1 = b + p * bs0,
+                                 *KOKKOS_RESTRICT b2 =
+                                     iend ? beta1 + bs0 : NULL;
 
       member.team_barrier();
       ValueType local_beta1 = *beta1;
@@ -80,9 +82,9 @@ template <>
 template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int TeamTrsvInternalLower<Algo::Trsv::Blocked>::invoke(
     const MemberType &member, const bool use_unit_diag, const int m,
-    const ScalarType alpha, const ValueType *__restrict__ A, const int as0,
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A, const int as0,
     const int as1,
-    /**/ ValueType *__restrict__ b, const int bs0) {
+    /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
   enum : int {
@@ -105,8 +107,8 @@ KOKKOS_INLINE_FUNCTION int TeamTrsvInternalLower<Algo::Trsv::Blocked>::invoke(
       const int pb = ((p + mb) > m ? (m - p) : mb);
 
       // trsm update
-      const ValueType *__restrict__ Ap = A + p * as0 + p * as1;
-      /**/ ValueType *__restrict__ bp    = b + p * bs0;
+      const ValueType *KOKKOS_RESTRICT Ap = A + p * as0 + p * as1;
+      /**/ ValueType *KOKKOS_RESTRICT bp    = b + p * bs0;
 
       member.team_barrier();
       if (member.team_rank() == 0) {
@@ -136,8 +138,9 @@ struct TeamTrsvInternalUpper {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType & /*member*/, const bool /*use_unit_diag*/,
       const int /*m*/, const ScalarType /*alpha*/,
-      const ValueType *__restrict__ /*A*/, const int /*as0*/, const int /*as1*/,
-      /**/ ValueType *__restrict__ /*b*/, const int /*bs0*/) {
+      const ValueType *KOKKOS_RESTRICT /*A*/, const int /*as0*/,
+      const int /*as1*/,
+      /**/ ValueType *KOKKOS_RESTRICT /*b*/, const int /*bs0*/) {
     assert(false && "Error: encounter dummy impl");
     return 0;
   }
@@ -147,9 +150,9 @@ template <>
 template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int TeamTrsvInternalUpper<Algo::Trsv::Unblocked>::invoke(
     const MemberType &member, const bool use_unit_diag, const int m,
-    const ScalarType alpha, const ValueType *__restrict__ A, const int as0,
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A, const int as0,
     const int as1,
-    /**/ ValueType *__restrict__ b, const int bs0) {
+    /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
   const ScalarType one(1.0), zero(0.0);
 
   if (alpha == zero)
@@ -158,12 +161,12 @@ KOKKOS_INLINE_FUNCTION int TeamTrsvInternalUpper<Algo::Trsv::Unblocked>::invoke(
     if (alpha != one) TeamScaleInternal::invoke(member, m, alpha, b, bs0);
     if (m <= 0) return 0;
 
-    ValueType *__restrict__ b0 = b;
+    ValueType *KOKKOS_RESTRICT b0 = b;
     for (int p = (m - 1); p >= 0; --p) {
       const int iend = p;
 
-      const ValueType *__restrict__ a01 = A + p * as1;
-      /**/ ValueType *__restrict__ beta1  = b + p * bs0;
+      const ValueType *KOKKOS_RESTRICT a01 = A + p * as1;
+      /**/ ValueType *KOKKOS_RESTRICT beta1  = b + p * bs0;
 
       member.team_barrier();
       ValueType local_beta1 = *beta1;
@@ -187,9 +190,9 @@ template <>
 template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int TeamTrsvInternalUpper<Algo::Trsv::Blocked>::invoke(
     const MemberType &member, const bool use_unit_diag, const int m,
-    const ScalarType alpha, const ValueType *__restrict__ A, const int as0,
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A, const int as0,
     const int as1,
-    /**/ ValueType *__restrict__ b, const int bs0) {
+    /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
   enum : int {
@@ -212,8 +215,8 @@ KOKKOS_INLINE_FUNCTION int TeamTrsvInternalUpper<Algo::Trsv::Blocked>::invoke(
                 pb = (mb + (ptmp < 0) * ptmp);
 
       // trsm update
-      const ValueType *__restrict__ Ap = A + p * as0 + p * as1;
-      /**/ ValueType *__restrict__ bp    = b + p * bs0;
+      const ValueType *KOKKOS_RESTRICT Ap = A + p * as0 + p * as1;
+      /**/ ValueType *KOKKOS_RESTRICT bp    = b + p * bs0;
 
       member.team_barrier();
       if (member.team_rank() == 0) {

--- a/src/batched/dense/impl/KokkosBatched_Trtri_Serial_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Trtri_Serial_Internal.hpp
@@ -55,7 +55,7 @@ struct SerialTrtriInternalLower {
   template <typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const bool use_unit_diag,
                                            const int am, const int an,
-                                           ValueType *__restrict__ A,
+                                           ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1);
 };
 
@@ -64,7 +64,7 @@ struct SerialTrtriInternalUpper {
   template <typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(const bool use_unit_diag,
                                            const int am, const int an,
-                                           ValueType *__restrict__ A,
+                                           ValueType *KOKKOS_RESTRICT A,
                                            const int as0, const int as1);
 };
 
@@ -73,7 +73,7 @@ template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int
 SerialTrtriInternalLower<Algo::Trtri::Unblocked>::invoke(
     const bool use_unit_diag, const int am, const int /*an*/,
-    ValueType *__restrict__ A, const int as0, const int as1) {
+    ValueType *KOKKOS_RESTRICT A, const int as0, const int as1) {
   ValueType one(1.0), zero(0.0), A_ii;
   if (!use_unit_diag) {
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
@@ -96,9 +96,9 @@ SerialTrtriInternalLower<Algo::Trtri::Unblocked>::invoke(
       else
         A_ii = -A[i * as0 + i * as1];
 
-      ValueType *__restrict__ A_subblock = &A[(i + 1) * as0 + (i + 1) * as1];
+      ValueType *KOKKOS_RESTRICT A_subblock = &A[(i + 1) * as0 + (i + 1) * as1];
       int A_subblock_m = am - i - 1, A_subblock_n = am - i - 1;
-      ValueType *__restrict__ A_col_vec = &A[(i + 1) * as0 + i * as1];
+      ValueType *KOKKOS_RESTRICT A_col_vec = &A[(i + 1) * as0 + i * as1];
       int A_col_vec_m = am - i - 1, A_col_vec_n = 1;
       // TRMV/TRMM −− x=Ax
       // A((j+1):n,j) = A((j+1):n,(j+1):n) ∗ A((j+1):n,j) ;
@@ -120,7 +120,7 @@ template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int
 SerialTrtriInternalUpper<Algo::Trtri::Unblocked>::invoke(
     const bool use_unit_diag, const int am, const int /*an*/,
-    ValueType *__restrict__ A, const int as0, const int as1) {
+    ValueType *KOKKOS_RESTRICT A, const int as0, const int as1) {
   ValueType one(1.0), zero(0.0), A_ii;
 
   if (!use_unit_diag) {
@@ -144,9 +144,9 @@ SerialTrtriInternalUpper<Algo::Trtri::Unblocked>::invoke(
       else
         A_ii = -A[i * as0 + i * as1];
 
-      ValueType *__restrict__ A_subblock = &A[0 * as0 + 0 * as1];
+      ValueType *KOKKOS_RESTRICT A_subblock = &A[0 * as0 + 0 * as1];
       int A_subblock_m = i, A_subblock_n = i;
-      ValueType *__restrict__ A_col_vec = &A[0 * as0 + i * as1];
+      ValueType *KOKKOS_RESTRICT A_col_vec = &A[0 * as0 + i * as1];
       int A_col_vec_m = i, A_col_vec_n = 1;
       // TRMV/TRMM −− x=Ax
       // A(1:(j-1),j) = A(1:(j-1),1:(j-1)) ∗ A(1:(j-1),j) ;

--- a/src/sparse/impl/KokkosSparse_spmv_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_impl.hpp
@@ -317,12 +317,12 @@ static void spmv_beta_no_transpose(
     typedef typename AMatrix::non_const_size_type size_type;
     typedef Kokkos::ArithTraits<value_type> ATV;
 
-    const size_type* __restrict__ row_map_ptr    = A.graph.row_map.data();
-    const ordinal_type* __restrict__ col_idx_ptr = A.graph.entries.data();
-    const value_type* __restrict__ values_ptr    = A.values.data();
+    const size_type* KOKKOS_RESTRICT row_map_ptr    = A.graph.row_map.data();
+    const ordinal_type* KOKKOS_RESTRICT col_idx_ptr = A.graph.entries.data();
+    const value_type* KOKKOS_RESTRICT values_ptr    = A.values.data();
 
-    typename YVector::non_const_value_type* __restrict__ y_ptr = y.data();
-    typename XVector::const_value_type* __restrict__ x_ptr     = x.data();
+    typename YVector::non_const_value_type* KOKKOS_RESTRICT y_ptr = y.data();
+    typename XVector::const_value_type* KOKKOS_RESTRICT x_ptr     = x.data();
 
     const typename YVector::non_const_value_type zero(0);
     const ordinal_type nrow = A.numRows();
@@ -557,12 +557,12 @@ static void spmv_beta_transpose(typename YVector::const_value_type& alpha,
       /// serial impl
       typedef typename AMatrix::non_const_value_type value_type;
       typedef Kokkos::Details::ArithTraits<value_type> ATV;
-      const size_type* __restrict__ row_map_ptr    = A.graph.row_map.data();
-      const ordinal_type* __restrict__ col_idx_ptr = A.graph.entries.data();
-      const value_type* __restrict__ values_ptr    = A.values.data();
+      const size_type* KOKKOS_RESTRICT row_map_ptr    = A.graph.row_map.data();
+      const ordinal_type* KOKKOS_RESTRICT col_idx_ptr = A.graph.entries.data();
+      const value_type* KOKKOS_RESTRICT values_ptr    = A.values.data();
 
-      typename YVector::value_type* __restrict__ y_ptr = y.data();
-      typename XVector::value_type* __restrict__ x_ptr = x.data();
+      typename YVector::value_type* KOKKOS_RESTRICT y_ptr = y.data();
+      typename XVector::value_type* KOKKOS_RESTRICT x_ptr = x.data();
 
       const typename YVector::non_const_value_type zero(0);
       const ordinal_type nrow = A.numRows();


### PR DESCRIPTION
Preparation for MSVC usability. Kokkos defines this macro based on
compiler.