### PR TITLE
Add custom implementation for strcasecmp

### DIFF
--- a/example/fenl/main.cpp
+++ b/example/fenl/main.cpp
@@ -278,51 +278,51 @@ int main( int argc , char ** argv )
 
   if ( 0 == comm_rank ) {
     for ( int i = 1 ; i < argc ; ++i ) {
-      if ( 0 == strcasecmp( argv[i] , "threads" ) ) {
+      if ( 0 == Test::string_compare_no_case( argv[i] , "threads" ) ) {
         cmdline[ CMD_USE_THREADS ] = atoi( argv[++i] );
       }
-      else if ( 0 == strcasecmp( argv[i] , "openmp" ) ) {
+      else if ( 0 == Test::string_compare_no_case( argv[i] , "openmp" ) ) {
         cmdline[ CMD_USE_OPENMP ] = atoi( argv[++i] );
       }
-      else if ( 0 == strcasecmp( argv[i] , "cores" ) ) {
+      else if ( 0 == Test::string_compare_no_case( argv[i] , "cores" ) ) {
         sscanf( argv[++i] , "%dx%d" ,
                 cmdline + CMD_USE_NUMA ,
                 cmdline + CMD_USE_CORE_PER_NUMA );
       }
-      else if ( 0 == strcasecmp( argv[i] , "cuda" ) ) {
+      else if ( 0 == Test::string_compare_no_case( argv[i] , "cuda" ) ) {
         cmdline[ CMD_USE_CUDA ] = 1 ;
       }
-      else if ( 0 == strcasecmp( argv[i] , "cuda-dev" ) ) {
+      else if ( 0 == Test::string_compare_no_case( argv[i] , "cuda-dev" ) ) {
         cmdline[ CMD_USE_CUDA ] = 1 ;
         cmdline[ CMD_USE_CUDA_DEV ] = atoi( argv[++i] ) ;
       }
-      else if ( 0 == strcasecmp( argv[i] , "fixture" ) ) {
+      else if ( 0 == Test::string_compare_no_case( argv[i] , "fixture" ) ) {
         sscanf( argv[++i] , "%dx%dx%d" ,
                 cmdline + CMD_USE_FIXTURE_X ,
                 cmdline + CMD_USE_FIXTURE_Y ,
                 cmdline + CMD_USE_FIXTURE_Z );
       }
-      else if ( 0 == strcasecmp( argv[i] , "fixture-range" ) ) {
+      else if ( 0 == Test::string_compare_no_case( argv[i] , "fixture-range" ) ) {
         sscanf( argv[++i] , "%d..%d" ,
                 cmdline + CMD_USE_FIXTURE_BEGIN ,
                 cmdline + CMD_USE_FIXTURE_END );
       }
-      else if ( 0 == strcasecmp( argv[i] , "fixture-quadratic" ) ) {
+      else if ( 0 == Test::string_compare_no_case( argv[i] , "fixture-quadratic" ) ) {
         cmdline[ CMD_USE_FIXTURE_QUADRATIC ] = 1 ;
       }
-      else if ( 0 == strcasecmp( argv[i] , "atomic" ) ) {
+      else if ( 0 == Test::string_compare_no_case( argv[i] , "atomic" ) ) {
         cmdline[ CMD_USE_ATOMIC ] = 1 ;
       }
-      else if ( 0 == strcasecmp( argv[i] , "trials" ) ) {
+      else if ( 0 == Test::string_compare_no_case( argv[i] , "trials" ) ) {
         cmdline[ CMD_USE_TRIALS ] = atoi( argv[++i] ) ;
       }
-      else if ( 0 == strcasecmp( argv[i] , "vtune" ) ) {
+      else if ( 0 == Test::string_compare_no_case( argv[i] , "vtune" ) ) {
         cmdline[ CMD_VTUNE ] = 1 ;
       }
-      else if ( 0 == strcasecmp( argv[i] , "print" ) ) {
+      else if ( 0 == Test::string_compare_no_case( argv[i] , "print" ) ) {
         cmdline[ CMD_PRINT ] = 1 ;
       }
-      else if ( 0 == strcasecmp( argv[i] , "echo" ) ) {
+      else if ( 0 == Test::string_compare_no_case( argv[i] , "echo" ) ) {
         cmdline[ CMD_ECHO ] = 1 ;
       }
       else {

--- a/example/graph/KokkosKernels_Example_Distance2GraphColor.cpp
+++ b/example/graph/KokkosKernels_Example_Distance2GraphColor.cpp
@@ -184,77 +184,77 @@ parse_inputs(KokkosKernels::Example::Parameters& params, int argc, char** argv)
 
     for(int i = 1; i < argc; ++i)
     {
-        if(0 == strcasecmp(argv[ i ], "--threads"))
+        if(0 == Test::string_compare_no_case(argv[ i ], "--threads"))
         {
             params.use_threads = atoi(argv[ ++i ]);
             //std::cout << "use_threads = " << params.use_threads << std::endl;
         }
-        else if(0 == strcasecmp(argv[ i ], "--serial"))
+        else if(0 == Test::string_compare_no_case(argv[ i ], "--serial"))
         {
             params.use_serial = atoi(argv[ ++i ]);
             //std::cout << "use_serial = " << params.use_serial << std::endl;
         }
-        else if(0 == strcasecmp(argv[ i ], "--openmp"))
+        else if(0 == Test::string_compare_no_case(argv[ i ], "--openmp"))
         {
             params.use_openmp = atoi(argv[ ++i ]);
             //std::cout << "use_openmp = " << params.use_openmp << std::endl;
         }
-        else if(0 == strcasecmp(argv[ i ], "--cuda"))
+        else if(0 == Test::string_compare_no_case(argv[ i ], "--cuda"))
         {
             params.use_cuda = 1;
             //std::cout << "use_cuda = " << params.use_cuda << std::endl;
         }
-        else if(0 == strcasecmp(argv[ i ], "--amtx"))
+        else if(0 == Test::string_compare_no_case(argv[ i ], "--amtx"))
         {
             got_required_param_amtx = true;
             params.mtx_bin_file     = argv[ ++i ];
         }
-        else if(0 == strcasecmp(argv[ i ], "--validate"))
+        else if(0 == Test::string_compare_no_case(argv[ i ], "--validate"))
         {
             params.validate = 1;
         }
-        else if(0 == strcasecmp(argv[ i ], "--verbose-level"))
+        else if(0 == Test::string_compare_no_case(argv[ i ], "--verbose-level"))
         {
             params.verbose_level = atoi( argv[++i] );
             params.verbose_level = std::min(5, params.verbose_level);
             params.verbose_level = std::max(0, params.verbose_level);
         }
-        else if(0 == strcasecmp(argv[ i ], "--output-histogram"))
+        else if(0 == Test::string_compare_no_case(argv[ i ], "--output-histogram"))
         {
             params.output_histogram = 1;
         }
-        else if(0 == strcasecmp(argv[ i ], "--output-graphviz"))
+        else if(0 == Test::string_compare_no_case(argv[ i ], "--output-graphviz"))
         {
             params.output_graphviz = 1;
         }
-        else if(0 == strcasecmp(argv[ i ], "--output-graphviz-vert-max"))
+        else if(0 == Test::string_compare_no_case(argv[ i ], "--output-graphviz-vert-max"))
         {
             params.output_graphviz_vert_max = atoi( argv[++i] );
         }
-        else if(0 == strcasecmp(argv[ i ], "--algorithm"))
+        else if(0 == Test::string_compare_no_case(argv[ i ], "--algorithm"))
         {
             ++i;
-            if(0 == strcasecmp(argv[ i ], "COLORING_D2_MATRIX_SQUARED"))
+            if(0 == Test::string_compare_no_case(argv[ i ], "COLORING_D2_MATRIX_SQUARED"))
             {
                 params.algorithm             = 1;
                 got_required_param_algorithm = true;
             }
-            else if(0 == strcasecmp(argv[ i ], "COLORING_D2_SERIAL"))
+            else if(0 == Test::string_compare_no_case(argv[ i ], "COLORING_D2_SERIAL"))
             {
                 params.algorithm             = 2;
                 got_required_param_algorithm = true;
             }
-            else if(0 == strcasecmp(argv[ i ], "COLORING_D2_VB") || 0 == strcasecmp(argv[ i ], "COLORING_D2"))
+            else if(0 == Test::string_compare_no_case(argv[ i ], "COLORING_D2_VB") || 0 == Test::string_compare_no_case(argv[ i ], "COLORING_D2"))
             {
                 params.algorithm             = 3;
                 got_required_param_algorithm = true;
             }
-            else if(0 == strcasecmp(argv[ i ], "COLORING_D2_VB_BIT"))
+            else if(0 == Test::string_compare_no_case(argv[ i ], "COLORING_D2_VB_BIT"))
             {
                 params.algorithm             = 4;
                 got_required_param_algorithm = true;
             }
-            else if(0 == strcasecmp(argv[ i ], "COLORING_D2_VB_BIT_EF"))
+            else if(0 == Test::string_compare_no_case(argv[ i ], "COLORING_D2_VB_BIT_EF"))
             {
                 params.algorithm             = 5;
                 got_required_param_algorithm = true;
@@ -266,7 +266,7 @@ parse_inputs(KokkosKernels::Example::Parameters& params, int argc, char** argv)
                 return 1;
             }
         }
-        else if(0 == strcasecmp(argv[ i ], "--help") || 0 == strcasecmp(argv[ i ], "-h"))
+        else if(0 == Test::string_compare_no_case(argv[ i ], "--help") || 0 == Test::string_compare_no_case(argv[ i ], "-h"))
         {
             print_options(std::cout, argv[ 0 ]);
             return 1;

--- a/example/hashmap_accumulator/KokkosKernels_Example_HashmapAccumulator.cpp
+++ b/example/hashmap_accumulator/KokkosKernels_Example_HashmapAccumulator.cpp
@@ -341,35 +341,35 @@ int parse_inputs(parameters_t &params, int argc, char **argv)
 
     for(int i = 1; i < argc; ++i)
     {
-        if(0 == strcasecmp(argv[i], "--threads"))
+        if(0 == Test::string_compare_no_case(argv[i], "--threads"))
         {
             params.use_threads = atoi(argv[++i]);
         }
-        else if(0 == strcasecmp(argv[i], "--serial"))
+        else if(0 == Test::string_compare_no_case(argv[i], "--serial"))
         {
             params.use_serial = atoi(argv[++i]);
         }
-        else if(0 == strcasecmp(argv[i], "--openmp"))
+        else if(0 == Test::string_compare_no_case(argv[i], "--openmp"))
         {
             params.use_openmp = atoi(argv[++i]);
         }
-        else if(0 == strcasecmp(argv[i], "--cuda"))
+        else if(0 == Test::string_compare_no_case(argv[i], "--cuda"))
         {
             params.use_cuda = 1;
         }
-        else if (0 == strcasecmp(argv[i], "--repeat"))
+        else if (0 == Test::string_compare_no_case(argv[i], "--repeat"))
         {
             params.repeat = atoi(argv[++i]);
         }
-        else if (0 == strcasecmp(argv[i], "--problem-size"))
+        else if (0 == Test::string_compare_no_case(argv[i], "--problem-size"))
         {
             params.problem_size = atoi(argv[++i]);
         }
-        else if(0 == strcasecmp(argv[i], "--verbose") || 0 == strcasecmp(argv[i], "-V") )
+        else if(0 == Test::string_compare_no_case(argv[i], "--verbose") || 0 == Test::string_compare_no_case(argv[i], "-V") )
         {
             params.verbose = true;
         }
-        else if(0 == strcasecmp(argv[i], "help") || 0 == strcasecmp(argv[i], "-h"))
+        else if(0 == Test::string_compare_no_case(argv[i], "help") || 0 == Test::string_compare_no_case(argv[i], "-h"))
         {
             print_options(std::cout, argv[0]);
             return 1;

--- a/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test.cpp
@@ -45,6 +45,7 @@
 #include <Kokkos_Core.hpp>
 #include <blas/KokkosBlas1_dot.hpp>
 #include <Kokkos_Random.hpp>
+#include "KokkosKernels_TestUtils.hpp"
 
 struct Params {
   int use_cuda    = 0;
@@ -77,22 +78,23 @@ void print_options() {
 
 int parse_inputs(Params& params, int argc, char** argv) {
   for (int i = 1; i < argc; ++i) {
-    if (0 == strcasecmp(argv[i], "--help") || 0 == strcasecmp(argv[i], "-h")) {
+    if (0 == Test::string_compare_no_case(argv[i], "--help") ||
+        0 == Test::string_compare_no_case(argv[i], "-h")) {
       print_options();
       exit(0);  // note: this is before Kokkos::initialize
-    } else if (0 == strcasecmp(argv[i], "--threads")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--threads")) {
       params.use_threads = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--openmp")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--openmp")) {
       params.use_openmp = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--cuda")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cuda")) {
       params.use_cuda = atoi(argv[++i]) + 1;
-    } else if (0 == strcasecmp(argv[i], "--hip")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--hip")) {
       params.use_hip = atoi(argv[++i]) + 1;
-    } else if (0 == strcasecmp(argv[i], "--m")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--m")) {
       params.m = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--n")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--n")) {
       params.n = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--repeat")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--repeat")) {
       // if provided, C will be written to given file.
       // has to have ".bin", or ".crs" extension.
       params.repeat = atoi(argv[++i]);

--- a/perf_test/blas/blas1/KokkosBlas_dot_perf_test.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_perf_test.cpp
@@ -48,6 +48,7 @@
 
 // For RPS implementation
 #include "KokkosBlas_dot_perf_test.hpp"
+#include "KokkosKernels_TestUtils.hpp"
 
 struct Params {
   int use_cuda    = 0;
@@ -75,18 +76,19 @@ void print_options() {
 
 int parse_inputs(Params& params, int argc, char** argv) {
   for (int i = 1; i < argc; ++i) {
-    if (0 == strcasecmp(argv[i], "--help") || 0 == strcasecmp(argv[i], "-h")) {
+    if (0 == Test::string_compare_no_case(argv[i], "--help") ||
+        0 == Test::string_compare_no_case(argv[i], "-h")) {
       print_options();
       exit(0);  // note: this is before Kokkos::initialize
-    } else if (0 == strcasecmp(argv[i], "--threads")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--threads")) {
       params.use_threads = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--openmp")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--openmp")) {
       params.use_openmp = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--cuda")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cuda")) {
       params.use_cuda = atoi(argv[++i]) + 1;
-    } else if (0 == strcasecmp(argv[i], "--m")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--m")) {
       params.m = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--repeat")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--repeat")) {
       // if provided, C will be written to given file.
       // has to have ".bin", or ".crs" extension.
       params.repeat = atoi(argv[++i]);

--- a/perf_test/blas/blas1/KokkosBlas_team_dot_perf_test.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_team_dot_perf_test.cpp
@@ -45,6 +45,7 @@
 #include <Kokkos_Core.hpp>
 #include <KokkosBlas1_team_dot.hpp>
 #include <Kokkos_Random.hpp>
+#include "KokkosKernels_TestUtils.hpp"
 
 struct Params {
   int use_cuda    = 0;
@@ -69,18 +70,19 @@ void print_options() {
 
 int parse_inputs(Params& params, int argc, char** argv) {
   for (int i = 1; i < argc; ++i) {
-    if (0 == strcasecmp(argv[i], "--help") || 0 == strcasecmp(argv[i], "-h")) {
+    if (0 == Test::string_compare_no_case(argv[i], "--help") ||
+        0 == Test::string_compare_no_case(argv[i], "-h")) {
       print_options();
       exit(0);  // note: this is before Kokkos::initialize
-    } else if (0 == strcasecmp(argv[i], "--threads")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--threads")) {
       params.use_threads = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--openmp")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--openmp")) {
       params.use_openmp = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--cuda")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cuda")) {
       params.use_cuda = atoi(argv[++i]) + 1;
-    } else if (0 == strcasecmp(argv[i], "--m")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--m")) {
       params.m = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--repeat")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--repeat")) {
       // if provided, C will be written to given file.
       // has to have ".bin", or ".crs" extension.
       params.repeat = atoi(argv[++i]);

--- a/perf_test/blas/blas2/KokkosBlas2_gemv_perf_test.cpp
+++ b/perf_test/blas/blas2/KokkosBlas2_gemv_perf_test.cpp
@@ -44,6 +44,7 @@
 
 #include "KokkosBlas2_gemv.hpp"
 #include <Kokkos_Random.hpp>
+#include "KokkosKernels_TestUtils.hpp"
 
 struct Params {
   int use_cuda    = 0;
@@ -77,32 +78,33 @@ void print_options() {
 
 int parse_inputs(Params& params, int argc, char** argv) {
   for (int i = 1; i < argc; ++i) {
-    if (0 == strcasecmp(argv[i], "--help") || 0 == strcasecmp(argv[i], "-h")) {
+    if (0 == Test::string_compare_no_case(argv[i], "--help") ||
+        0 == Test::string_compare_no_case(argv[i], "-h")) {
       print_options();
       exit(0);  // note: this is before Kokkos::initialize
-    } else if (0 == strcasecmp(argv[i], "--threads")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--threads")) {
       params.use_threads = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--openmp")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--openmp")) {
       params.use_openmp = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--cuda")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cuda")) {
       params.use_cuda = atoi(argv[++i]) + 1;
-    } else if (0 == strcasecmp(argv[i], "--hip")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--hip")) {
       params.use_hip = atoi(argv[++i]) + 1;
-    } else if (0 == strcasecmp(argv[i], "--layout")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--layout")) {
       i++;
-      if (0 == strcasecmp(argv[i], "left"))
+      if (0 == Test::string_compare_no_case(argv[i], "left"))
         params.layoutLeft = true;
-      else if (0 == strcasecmp(argv[i], "right"))
+      else if (0 == Test::string_compare_no_case(argv[i], "right"))
         params.layoutLeft = false;
       else {
         std::cerr << "Invalid layout: must be 'left' or 'right'.\n";
         exit(1);
       }
-    } else if (0 == strcasecmp(argv[i], "--m")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--m")) {
       params.m = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--n")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--n")) {
       params.n = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--repeat")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--repeat")) {
       // if provided, C will be written to given file.
       // has to have ".bin", or ".crs" extension.
       params.repeat = atoi(argv[++i]);

--- a/perf_test/blas/blas3/KokkosBlas3_gemm_standalone_perf_test.cpp
+++ b/perf_test/blas/blas3/KokkosBlas3_gemm_standalone_perf_test.cpp
@@ -44,6 +44,7 @@
 
 #include "KokkosBlas3_gemm.hpp"
 #include <Kokkos_Random.hpp>
+#include "KokkosKernels_TestUtils.hpp"
 
 struct Params {
   int use_cuda    = 0;
@@ -72,22 +73,23 @@ void print_options() {
 
 int parse_inputs(Params& params, int argc, char** argv) {
   for (int i = 1; i < argc; ++i) {
-    if (0 == strcasecmp(argv[i], "--help") || 0 == strcasecmp(argv[i], "-h")) {
+    if (0 == Test::string_compare_no_case(argv[i], "--help") ||
+        0 == Test::string_compare_no_case(argv[i], "-h")) {
       print_options();
       exit(0);  // note: this is before Kokkos::initialize
-    } else if (0 == strcasecmp(argv[i], "--threads")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--threads")) {
       params.use_threads = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--openmp")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--openmp")) {
       params.use_openmp = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--cuda")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cuda")) {
       params.use_cuda = atoi(argv[++i]) + 1;
-    } else if (0 == strcasecmp(argv[i], "--m")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--m")) {
       params.m = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--n")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--n")) {
       params.n = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--k")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--k")) {
       params.k = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--repeat")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--repeat")) {
       // if provided, C will be written to given file.
       // has to have ".bin", or ".crs" extension.
       params.repeat = atoi(argv[++i]);

--- a/perf_test/graph/KokkosGraph_color.cpp
+++ b/perf_test/graph/KokkosGraph_color.cpp
@@ -54,6 +54,7 @@
 #include "KokkosSparse_CrsMatrix.hpp"
 #include "KokkosKernels_TestParameters.hpp"
 #include "KokkosGraph_Distance1Color.hpp"
+#include "KokkosKernels_TestUtils.hpp"
 
 void print_options(std::ostream &os, const char *app_name,
                    unsigned int indent = 0) {
@@ -151,55 +152,57 @@ int parse_inputs(KokkosKernels::Experiment::Parameters &params, int argc,
   bool got_required_param_algorithm = false;
 
   for (int i = 1; i < argc; ++i) {
-    if (0 == strcasecmp(argv[i], "--threads")) {
+    if (0 == Test::string_compare_no_case(argv[i], "--threads")) {
       params.use_threads = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--serial")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--serial")) {
       params.use_serial = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--openmp")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--openmp")) {
       params.use_openmp = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--cuda")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cuda")) {
       params.use_cuda = 1 + atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--hip")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--hip")) {
       params.use_hip = 1 + atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--repeat")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--repeat")) {
       params.repeat = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--chunksize")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--chunksize")) {
       params.chunk_size = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--teamsize")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--teamsize")) {
       params.team_size = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--vectorsize")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--vectorsize")) {
       params.vector_size = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--amtx")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--amtx")) {
       got_required_param_amtx = true;
       params.a_mtx_bin_file   = getNextArg(i, argc, argv);
-    } else if (0 == strcasecmp(argv[i], "--dynamic")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--dynamic")) {
       params.use_dynamic_scheduling = 1;
-    } else if (0 == strcasecmp(argv[i], "--verbose")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--verbose")) {
       params.verbose = 1;
-    } else if (0 == strcasecmp(argv[i], "--outputfile") ||
-               0 == strcasecmp(argv[i], "-o")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--outputfile") ||
+               0 == Test::string_compare_no_case(argv[i], "-o")) {
       params.coloring_output_file = getNextArg(i, argc, argv);
-    } else if (0 == strcasecmp(argv[i], "--algorithm")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--algorithm")) {
       got_required_param_algorithm = true;
       ++i;
-      if (0 == strcasecmp(argv[i], "COLORING_DEFAULT")) {
+      if (0 == Test::string_compare_no_case(argv[i], "COLORING_DEFAULT")) {
         params.algorithm = 1;
-      } else if (0 == strcasecmp(argv[i], "COLORING_SERIAL")) {
+      } else if (0 ==
+                 Test::string_compare_no_case(argv[i], "COLORING_SERIAL")) {
         params.algorithm = 2;
-      } else if (0 == strcasecmp(argv[i], "COLORING_VB")) {
+      } else if (0 == Test::string_compare_no_case(argv[i], "COLORING_VB")) {
         params.algorithm = 3;
-      } else if (0 == strcasecmp(argv[i], "COLORING_VBBIT")) {
+      } else if (0 == Test::string_compare_no_case(argv[i], "COLORING_VBBIT")) {
         params.algorithm = 4;
-      } else if (0 == strcasecmp(argv[i], "COLORING_VBCS")) {
+      } else if (0 == Test::string_compare_no_case(argv[i], "COLORING_VBCS")) {
         params.algorithm = 5;
-      } else if (0 == strcasecmp(argv[i], "COLORING_EB")) {
+      } else if (0 == Test::string_compare_no_case(argv[i], "COLORING_EB")) {
         params.algorithm = 6;
-      } else if (0 == strcasecmp(argv[i], "COLORING_VBD")) {
+      } else if (0 == Test::string_compare_no_case(argv[i], "COLORING_VBD")) {
         params.algorithm = 7;
-      } else if (0 == strcasecmp(argv[i], "COLORING_VBDBIT")) {
+      } else if (0 ==
+                 Test::string_compare_no_case(argv[i], "COLORING_VBDBIT")) {
         params.algorithm = 8;
-      } else if (0 == strcasecmp(argv[i], "--help") ||
-                 0 == strcasecmp(argv[i], "-h")) {
+      } else if (0 == Test::string_compare_no_case(argv[i], "--help") ||
+                 0 == Test::string_compare_no_case(argv[i], "-h")) {
         print_options(std::cout, argv[0]);
         return 1;
       } else {

--- a/perf_test/graph/KokkosGraph_color_d2.cpp
+++ b/perf_test/graph/KokkosGraph_color_d2.cpp
@@ -64,6 +64,7 @@
 #include <KokkosKernels_TestParameters.hpp>
 #include <KokkosGraph_Distance2Color.hpp>
 #include "KokkosKernels_default_types.hpp"
+#include "KokkosKernels_TestUtils.hpp"
 
 using namespace KokkosGraph;
 
@@ -198,34 +199,37 @@ static char* getNextArg(int& i, int argc, char** argv) {
 int parse_inputs(D2Parameters& params, int argc, char** argv) {
   bool got_required_param_amtx = false;
   for (int i = 1; i < argc; ++i) {
-    if (0 == strcasecmp(argv[i], "--threads")) {
+    if (0 == Test::string_compare_no_case(argv[i], "--threads")) {
       params.use_threads = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--serial")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--serial")) {
       params.use_serial = 1;
-    } else if (0 == strcasecmp(argv[i], "--openmp")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--openmp")) {
       params.use_openmp = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--cuda")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cuda")) {
       params.use_cuda = 1 + atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--hip")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--hip")) {
       params.use_hip = 1 + atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--repeat")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--repeat")) {
       params.repeat = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--amtx")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--amtx")) {
       got_required_param_amtx = true;
       params.mtx_file         = getNextArg(i, argc, argv);
-    } else if (0 == strcasecmp(argv[i], "--verbose")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--verbose")) {
       params.verbose = 1;
-    } else if (0 == strcasecmp(argv[i], "--algorithm")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--algorithm")) {
       ++i;
-      if (0 == strcasecmp(argv[i], "COLORING_D2_SERIAL")) {
+      if (0 == Test::string_compare_no_case(argv[i], "COLORING_D2_SERIAL")) {
         params.algorithm = COLORING_D2_SERIAL;
-      } else if (0 == strcasecmp(argv[i], "COLORING_D2_VB")) {
+      } else if (0 == Test::string_compare_no_case(argv[i], "COLORING_D2_VB")) {
         params.algorithm = COLORING_D2_VB;
-      } else if (0 == strcasecmp(argv[i], "COLORING_D2_VB_BIT")) {
+      } else if (0 ==
+                 Test::string_compare_no_case(argv[i], "COLORING_D2_VB_BIT")) {
         params.algorithm = COLORING_D2_VB_BIT;
-      } else if (0 == strcasecmp(argv[i], "COLORING_D2_VB_BIT_EF")) {
+      } else if (0 == Test::string_compare_no_case(argv[i],
+                                                   "COLORING_D2_VB_BIT_EF")) {
         params.algorithm = COLORING_D2_VB_BIT_EF;
-      } else if (0 == strcasecmp(argv[i], "COLORING_D2_NB_BIT")) {
+      } else if (0 ==
+                 Test::string_compare_no_case(argv[i], "COLORING_D2_NB_BIT")) {
         params.algorithm = COLORING_D2_NB_BIT;
       } else {
         std::cerr << "2-Unrecognized command line argument #" << i << ": "
@@ -233,14 +237,14 @@ int parse_inputs(D2Parameters& params, int argc, char** argv) {
         print_options(std::cout, argv[0]);
         return 1;
       }
-    } else if (0 == strcasecmp(argv[i], "--symmetric_d2")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--symmetric_d2")) {
       params.d2_color_type = MODE_D2_SYMMETRIC;
-    } else if (0 == strcasecmp(argv[i], "--bipartite_rows")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--bipartite_rows")) {
       params.d2_color_type = MODE_BIPARTITE_ROWS;
-    } else if (0 == strcasecmp(argv[i], "--bipartite_cols")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--bipartite_cols")) {
       params.d2_color_type = MODE_BIPARTITE_COLS;
-    } else if (0 == strcasecmp(argv[i], "--help") ||
-               0 == strcasecmp(argv[i], "-h")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--help") ||
+               0 == Test::string_compare_no_case(argv[i], "-h")) {
       print_options(std::cout, argv[0]);
       return 1;
     } else {

--- a/perf_test/graph/KokkosGraph_mis_d2.cpp
+++ b/perf_test/graph/KokkosGraph_mis_d2.cpp
@@ -65,6 +65,7 @@
 #include "KokkosSparse_spadd.hpp"
 #include "KokkosGraph_MIS2.hpp"
 #include "KokkosKernels_default_types.hpp"
+#include "KokkosKernels_TestUtils.hpp"
 
 using namespace KokkosGraph;
 
@@ -183,38 +184,38 @@ static char* getNextArg(int& i, int argc, char** argv) {
 int parse_inputs(MIS2Parameters& params, int argc, char** argv) {
   bool got_required_param_amtx = false;
   for (int i = 1; i < argc; ++i) {
-    if (0 == strcasecmp(argv[i], "--threads")) {
+    if (0 == Test::string_compare_no_case(argv[i], "--threads")) {
       params.use_threads = 1;
-    } else if (0 == strcasecmp(argv[i], "--serial")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--serial")) {
       params.use_serial = 1;
-    } else if (0 == strcasecmp(argv[i], "--openmp")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--openmp")) {
       params.use_openmp = 1;
-    } else if (0 == strcasecmp(argv[i], "--cuda")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cuda")) {
       params.use_cuda = 1;
-    } else if (0 == strcasecmp(argv[i], "--hip")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--hip")) {
       params.use_hip = 1;
-    } else if (0 == strcasecmp(argv[i], "--repeat")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--repeat")) {
       params.repeat = atoi(getNextArg(i, argc, argv));
       if (params.repeat <= 0) {
         std::cout << "*** Repeat count must be positive, defaulting to 1.\n";
         params.repeat = 1;
       }
-    } else if (0 == strcasecmp(argv[i], "--amtx")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--amtx")) {
       got_required_param_amtx = true;
       params.mtx_file         = getNextArg(i, argc, argv);
-    } else if (0 == strcasecmp(argv[i], "--algo")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--algo")) {
       const char* algName = getNextArg(i, argc, argv);
-      if (!strcasecmp(algName, "fast"))
+      if (!Test::string_compare_no_case(algName, "fast"))
         params.algo = MIS2_FAST;
-      else if (!strcasecmp(algName, "quality"))
+      else if (!Test::string_compare_no_case(algName, "quality"))
         params.algo = MIS2_QUALITY;
       else
         throw std::invalid_argument(
             "Algorithm not valid: must be 'fast' or 'quality'");
-    } else if (0 == strcasecmp(argv[i], "--verbose")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--verbose")) {
       params.verbose = true;
-    } else if (0 == strcasecmp(argv[i], "--help") ||
-               0 == strcasecmp(argv[i], "-h")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--help") ||
+               0 == Test::string_compare_no_case(argv[i], "-h")) {
       print_options(std::cout, argv[0]);
       return 1;
     } else {

--- a/perf_test/graph/KokkosGraph_triangle.cpp
+++ b/perf_test/graph/KokkosGraph_triangle.cpp
@@ -124,29 +124,30 @@ void print_options() {
 int parse_inputs(KokkosKernels::Experiment::Parameters &params, int argc,
                  char **argv) {
   for (int i = 1; i < argc; ++i) {
-    if (0 == strcasecmp(argv[i], "--threads")) {
+    if (0 == Test::string_compare_no_case(argv[i], "--threads")) {
       params.use_threads = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--openmp")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--openmp")) {
       params.use_openmp = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--cuda")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cuda")) {
       params.use_cuda = 1;
-    } else if (0 == strcasecmp(argv[i], "--hip")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--hip")) {
       params.use_hip = 1;
-    } else if (0 == strcasecmp(argv[i], "--repeat")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--repeat")) {
       params.repeat = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--triangle_operation")) {
+    } else if (0 ==
+               Test::string_compare_no_case(argv[i], "--triangle_operation")) {
       params.triangle_options = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--chunksize")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--chunksize")) {
       params.chunk_size = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--teamsize")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--teamsize")) {
       params.team_size = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--vectorsize")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--vectorsize")) {
       params.vector_size = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--compression")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--compression")) {
       params.apply_compression = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--sort_option")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--sort_option")) {
       params.sort_option = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--memspaces")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--memspaces")) {
       int memspaces    = atoi(argv[++i]);
       int memspaceinfo = memspaces;
       std::cout << "memspaceinfo:" << memspaceinfo << std::endl;
@@ -182,60 +183,61 @@ int parse_inputs(KokkosKernels::Experiment::Parameters &params, int argc,
         std::cout << "Using DDR4 for work memory space" << std::endl;
       }
       memspaceinfo = memspaceinfo >> 1;
-    } else if (0 == strcasecmp(argv[i], "--flop")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--flop")) {
       params.calculate_read_write_cost = 1;
-    } else if (0 == strcasecmp(argv[i], "--CIF")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--CIF")) {
       params.coloring_input_file = argv[++i];
-    } else if (0 == strcasecmp(argv[i], "--COF")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--COF")) {
       params.coloring_output_file = argv[++i];
-    } else if (0 == strcasecmp(argv[i], "--mhscale")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--mhscale")) {
       params.minhashscale = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--mcscale")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--mcscale")) {
       params.multi_color_scale = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--shmem")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--shmem")) {
       params.shmemsize = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--compression2step")) {
+    } else if (0 ==
+               Test::string_compare_no_case(argv[i], "--compression2step")) {
       params.compression2step = true;
-    } else if (0 == strcasecmp(argv[i], "--mklsort")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--mklsort")) {
       params.mkl_sort_option = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--mklkeepout")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--mklkeepout")) {
       params.mkl_keep_output = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--checkoutput")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--checkoutput")) {
       params.check_output = 1;
-    } else if (0 == strcasecmp(argv[i], "--amtx")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--amtx")) {
       params.a_mtx_bin_file = argv[++i];
     }
     /*
-    else if ( 0 == strcasecmp( argv[i] , "cmtx" ) ) {
+    else if ( 0 == Test::string_compare_no_case( argv[i] , "cmtx" ) ) {
       params.c_mtx_bin_file = argv[++i];
     }
-    else if ( 0 == strcasecmp( argv[i] , "bmtx" ) ) {
+    else if ( 0 == Test::string_compare_no_case( argv[i] , "bmtx" ) ) {
       params.b_mtx_bin_file = argv[++i];
     }
     */
-    else if (0 == strcasecmp(argv[i], "--dynamic")) {
+    else if (0 == Test::string_compare_no_case(argv[i], "--dynamic")) {
       params.use_dynamic_scheduling = 1;
-    } else if (0 == strcasecmp(argv[i], "--cache_flush")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cache_flush")) {
       params.cache_flush = atoi(argv[++i]);
     }
 
-    else if (0 == strcasecmp(argv[i], "--RLT")) {
+    else if (0 == Test::string_compare_no_case(argv[i], "--RLT")) {
       params.right_lower_triangle = 1;
-    } else if (0 == strcasecmp(argv[i], "--RS")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--RS")) {
       params.right_sort = atoi(argv[++i]);
     }
 
-    else if (0 == strcasecmp(argv[i], "--verbose")) {
+    else if (0 == Test::string_compare_no_case(argv[i], "--verbose")) {
       params.verbose = 1;
     }
 
-    else if (0 == strcasecmp(argv[i], "--accumulator")) {
+    else if (0 == Test::string_compare_no_case(argv[i], "--accumulator")) {
       ++i;
-      if (0 == strcasecmp(argv[i], "default")) {
+      if (0 == Test::string_compare_no_case(argv[i], "default")) {
         params.accumulator = 0;
-      } else if (0 == strcasecmp(argv[i], "dense")) {
+      } else if (0 == Test::string_compare_no_case(argv[i], "dense")) {
         params.accumulator = 1;
-      } else if (0 == strcasecmp(argv[i], "sparse")) {
+      } else if (0 == Test::string_compare_no_case(argv[i], "sparse")) {
         params.accumulator = 2;
       } else {
         std::cerr << "1-Unrecognized command line argument #" << i << ": "
@@ -243,17 +245,18 @@ int parse_inputs(KokkosKernels::Experiment::Parameters &params, int argc,
         print_options();
         return 1;
       }
-    } else if (0 == strcasecmp(argv[i], "--algorithm")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--algorithm")) {
       ++i;
-      if (0 == strcasecmp(argv[i], "TRIANGLEAI")) {
+      if (0 == Test::string_compare_no_case(argv[i], "TRIANGLEAI")) {
         params.algorithm = 16;
-      } else if (0 == strcasecmp(argv[i], "TRIANGLEIA")) {
+      } else if (0 == Test::string_compare_no_case(argv[i], "TRIANGLEIA")) {
         params.algorithm = 17;
-      } else if (0 == strcasecmp(argv[i], "TRIANGLEIAUNION")) {
+      } else if (0 ==
+                 Test::string_compare_no_case(argv[i], "TRIANGLEIAUNION")) {
         params.algorithm = 18;
-      } else if (0 == strcasecmp(argv[i], "TRIANGLELL")) {
+      } else if (0 == Test::string_compare_no_case(argv[i], "TRIANGLELL")) {
         params.algorithm = 19;
-      } else if (0 == strcasecmp(argv[i], "TRIANGLELU")) {
+      } else if (0 == Test::string_compare_no_case(argv[i], "TRIANGLELU")) {
         params.algorithm = 20;
       } else {
         std::cerr << "2-Unrecognized command line argument #" << i << ": "

--- a/perf_test/sparse/KokkosSparse_block_pcg.cpp
+++ b/perf_test/sparse/KokkosSparse_block_pcg.cpp
@@ -52,6 +52,8 @@
 #include "KokkosKernels_Utils.hpp"
 #include "KokkosKernels_IOUtils.hpp"
 
+#include "KokkosKernels_TestUtils.hpp"
+
 #define MAXVAL 1
 
 #define SIZE_TYPE int
@@ -384,23 +386,23 @@ int main(int argc, char **argv) {
   for (int i = 0; i < CMD_COUNT; ++i) cmdline[i] = 0;
 
   for (int i = 1; i < argc; ++i) {
-    if (0 == strcasecmp(argv[i], "--serial")) {
+    if (0 == Test::string_compare_no_case(argv[i], "--serial")) {
       cmdline[CMD_USE_SERIAL] = 1;
-    } else if (0 == strcasecmp(argv[i], "--threads")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--threads")) {
       kargs.num_threads = cmdline[CMD_USE_THREADS] = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--openmp")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--openmp")) {
       kargs.num_threads = cmdline[CMD_USE_OPENMP] = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--cuda")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cuda")) {
       cmdline[CMD_USE_CUDA] = 1;
-    } else if (0 == strcasecmp(argv[i], "--mtx")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--mtx")) {
       mtx_bin_file = argv[++i];
     }
 
-    else if (0 == strcasecmp(argv[i], "--block_size")) {
+    else if (0 == Test::string_compare_no_case(argv[i], "--block_size")) {
       block_size = atoi(argv[++i]);
     }
 
-    else if (0 == strcasecmp(argv[i], "--iteration")) {
+    else if (0 == Test::string_compare_no_case(argv[i], "--iteration")) {
       cg_iteration_limit = atoi(argv[++i]);
     } else {
       cmdline[CMD_ERROR] = 1;

--- a/perf_test/sparse/KokkosSparse_pcg.cpp
+++ b/perf_test/sparse/KokkosSparse_pcg.cpp
@@ -48,6 +48,7 @@
 #include "KokkosKernels_Utils.hpp"
 #include "KokkosKernels_IOUtils.hpp"
 #include "KokkosKernels_default_types.hpp"
+#include "KokkosKernels_TestUtils.hpp"
 #include <iostream>
 
 #define MAXVAL 1
@@ -317,32 +318,32 @@ int main(int argc, char **argv) {
   for (int i = 0; i < CMD_COUNT; ++i) cmdline[i] = 0;
 
   for (int i = 1; i < argc; ++i) {
-    if (0 == strcasecmp(argv[i], "--threads")) {
+    if (0 == Test::string_compare_no_case(argv[i], "--threads")) {
       cmdline[CMD_USE_THREADS] = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--openmp")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--openmp")) {
       cmdline[CMD_USE_OPENMP] = atoi(argv[++i]);
     }
     /*
-    else if ( 0 == strcasecmp( argv[i] , "--cores" ) ) {
+    else if ( 0 == Test::string_compare_no_case( argv[i] , "--cores" ) ) {
       //Note BMK: specifying #NUMA regions isn't supported by initialize
       sscanf( argv[++i] , "%dx%d" ,
               cmdline + CMD_USE_NUMA ,
               cmdline + CMD_USE_CORE_PER_NUMA );
     }
     */
-    else if (0 == strcasecmp(argv[i], "--cuda")) {
+    else if (0 == Test::string_compare_no_case(argv[i], "--cuda")) {
       cmdline[CMD_USE_CUDA] = 1;
-    } else if (0 == strcasecmp(argv[i], "--hip")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--hip")) {
       cmdline[CMD_USE_HIP] = 1;
-    } else if (0 == strcasecmp(argv[i], "--device-id")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--device-id")) {
       cmdline[CMD_DEVICE] = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--cluster-size")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cluster-size")) {
       cmdline[CMD_CLUSTER_SIZE] = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--seq-gs")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--seq-gs")) {
       cmdline[CMD_USE_SEQUENTIAL_SGS] = 1;
     }
 
-    else if (0 == strcasecmp(argv[i], "--mtx")) {
+    else if (0 == Test::string_compare_no_case(argv[i], "--mtx")) {
       mtx_file = argv[++i];
     } else {
       cmdline[CMD_ERROR] = 1;

--- a/perf_test/sparse/KokkosSparse_spadd.cpp
+++ b/perf_test/sparse/KokkosSparse_spadd.cpp
@@ -48,6 +48,7 @@
 #include "KokkosKernels_IOUtils.hpp"
 #include "KokkosKernels_SparseUtils_cusparse.hpp"
 #include "KokkosSparse_spadd.hpp"
+#include "KokkosKernels_TestUtils.hpp"
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 #include <cusparse.h>
@@ -426,47 +427,47 @@ void print_options() {
 
 int parse_inputs(Params& params, int argc, char** argv) {
   for (int i = 1; i < argc; ++i) {
-    if (0 == strcasecmp(argv[i], "--threads")) {
+    if (0 == Test::string_compare_no_case(argv[i], "--threads")) {
       params.use_threads = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--openmp")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--openmp")) {
       params.use_openmp = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--cuda")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cuda")) {
       params.use_cuda = atoi(argv[++i]) + 1;
-    } else if (0 == strcasecmp(argv[i], "--mkl")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--mkl")) {
       params.use_mkl = 1;
-    } else if (0 == strcasecmp(argv[i], "--cusparse")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cusparse")) {
       params.use_cusparse = 1;
-    } else if (0 == strcasecmp(argv[i], "--sorted")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--sorted")) {
       params.sorted = true;
-    } else if (0 == strcasecmp(argv[i], "--unsorted")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--unsorted")) {
       params.sorted = false;
-    } else if (0 == strcasecmp(argv[i], "--amtx")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--amtx")) {
       // A at C=AxB
       params.amtx = argv[++i];
-    } else if (0 == strcasecmp(argv[i], "--bmtx")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--bmtx")) {
       // B at C=AxB.
       // if not provided, C = AxA will be performed.
       params.bmtx = argv[++i];
-    } else if (0 == strcasecmp(argv[i], "--cmtx")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cmtx")) {
       // if provided, C will be written to given file.
       // has to have ".bin", or ".crs" extension.
       params.cmtx = argv[++i];
-    } else if (0 == strcasecmp(argv[i], "--m")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--m")) {
       params.m = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--n")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--n")) {
       params.n = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--nnz")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--nnz")) {
       params.nnzPerRow = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--bdiag")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--bdiag")) {
       params.bDiag = true;
-    } else if (0 == strcasecmp(argv[i], "--repeat")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--repeat")) {
       // if provided, C will be written to given file.
       // has to have ".bin", or ".crs" extension.
       params.repeat = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--numeric-repeat")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--numeric-repeat")) {
       // Reuse the symbolic step this many times.
       params.numericRepeat = atoi(argv[++i]);
-    } else if (0 == strcasecmp(argv[i], "--verbose")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--verbose")) {
       params.verbose = true;
     } else {
       std::cerr << "Unrecognized command line argument #" << i << ": "

--- a/perf_test/sparse/KokkosSparse_spgemm.cpp
+++ b/perf_test/sparse/KokkosSparse_spgemm.cpp
@@ -46,6 +46,7 @@
 #include "KokkosKernels_default_types.hpp"
 #include "KokkosKernels_IOUtils.hpp"
 #include "KokkosSparse_multimem_spgemm.hpp"
+#include "KokkosKernels_TestUtils.hpp"
 
 void print_options() {
   std::cerr << "Options\n" << std::endl;
@@ -99,31 +100,31 @@ static char* getNextArg(int& i, int argc, char** argv) {
 int parse_inputs(KokkosKernels::Experiment::Parameters& params, int argc,
                  char** argv) {
   for (int i = 1; i < argc; ++i) {
-    if (0 == strcasecmp(argv[i], "--threads")) {
+    if (0 == Test::string_compare_no_case(argv[i], "--threads")) {
       params.use_threads = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--openmp")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--openmp")) {
       params.use_openmp = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--cuda")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cuda")) {
       params.use_cuda = atoi(getNextArg(i, argc, argv)) + 1;
-    } else if (0 == strcasecmp(argv[i], "--hip")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--hip")) {
       params.use_hip = atoi(getNextArg(i, argc, argv)) + 1;
-    } else if (0 == strcasecmp(argv[i], "--repeat")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--repeat")) {
       params.repeat = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--hashscale")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--hashscale")) {
       params.minhashscale = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--chunksize")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--chunksize")) {
       params.chunk_size = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--teamsize")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--teamsize")) {
       params.team_size = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--vectorsize")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--vectorsize")) {
       params.vector_size = atoi(getNextArg(i, argc, argv));
     }
 
-    else if (0 == strcasecmp(argv[i], "--compression2step")) {
+    else if (0 == Test::string_compare_no_case(argv[i], "--compression2step")) {
       params.compression2step = true;
-    } else if (0 == strcasecmp(argv[i], "--shmem")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--shmem")) {
       params.shmemsize = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--memspaces")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--memspaces")) {
       int memspaces    = atoi(getNextArg(i, argc, argv));
       int memspaceinfo = memspaces;
       std::cout << "memspaceinfo:" << memspaceinfo << std::endl;
@@ -159,58 +160,58 @@ int parse_inputs(KokkosKernels::Experiment::Parameters& params, int argc,
         std::cout << "Using DDR4 for work memory space" << std::endl;
       }
       memspaceinfo = memspaceinfo >> 1;
-    } else if (0 == strcasecmp(argv[i], "--CRWC")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--CRWC")) {
       params.calculate_read_write_cost = 1;
-    } else if (0 == strcasecmp(argv[i], "--CIF")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--CIF")) {
       params.coloring_input_file = getNextArg(i, argc, argv);
-    } else if (0 == strcasecmp(argv[i], "--COF")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--COF")) {
       params.coloring_output_file = getNextArg(i, argc, argv);
-    } else if (0 == strcasecmp(argv[i], "--CCO")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--CCO")) {
       // if 0.85 set, if compression does not reduce flops by at least 15%
       // symbolic will run on original matrix. otherwise, it will compress the
       // graph and run symbolic on compressed one.
       params.compression_cut_off = atof(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--FLHCO")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--FLHCO")) {
       // if linear probing is used as hash, what is the max occupancy percantage
       // we allow in the hash.
       params.first_level_hash_cut_off = atof(getNextArg(i, argc, argv));
     }
 
-    else if (0 == strcasecmp(argv[i], "--flop")) {
+    else if (0 == Test::string_compare_no_case(argv[i], "--flop")) {
       // print flop statistics. only for the first repeat.
       params.calculate_read_write_cost = 1;
     }
 
-    else if (0 == strcasecmp(argv[i], "--mklsort")) {
+    else if (0 == Test::string_compare_no_case(argv[i], "--mklsort")) {
       // when mkl2 is run, the sort option to use.
       // 7:not to sort the output
       // 8:to sort the output
       params.mkl_sort_option = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--mklkeepout")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--mklkeepout")) {
       // mkl output is not kept.
       params.mkl_keep_output = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--checkoutput")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--checkoutput")) {
       // check correctness
       params.check_output = 1;
-    } else if (0 == strcasecmp(argv[i], "--amtx")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--amtx")) {
       // A at C=AxB
       params.a_mtx_bin_file = getNextArg(i, argc, argv);
     }
 
-    else if (0 == strcasecmp(argv[i], "--bmtx")) {
+    else if (0 == Test::string_compare_no_case(argv[i], "--bmtx")) {
       // B at C=AxB.
       // if not provided, C = AxA will be performed.
       params.b_mtx_bin_file = getNextArg(i, argc, argv);
-    } else if (0 == strcasecmp(argv[i], "--cmtx")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cmtx")) {
       // if provided, C will be written to given file.
       // has to have ".bin", or ".crs" extension.
       params.c_mtx_bin_file = getNextArg(i, argc, argv);
-    } else if (0 == strcasecmp(argv[i], "--dynamic")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--dynamic")) {
       // dynamic scheduling will be used for loops.
       // currently it is default already.
       // so has to use the dynamic schedulin.
       params.use_dynamic_scheduling = 1;
-    } else if (0 == strcasecmp(argv[i], "--DENSEACCMAX")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--DENSEACCMAX")) {
       // on CPUs and KNLs if DEFAULT algorithm or KKSPGEMM is chosen,
       // it uses dense accumulators for smaller matrices based on the size of
       // column (k) in B. Max column size is 250,000 for k to use dense
@@ -218,39 +219,39 @@ int parse_inputs(KokkosKernels::Experiment::Parameters& params, int argc,
       // with smaller thread count, where memory bandwidth is not an issue, this
       // cut-off can be increased to be more than 250,000
       params.MaxColDenseAcc = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--verbose")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--verbose")) {
       // print the timing and information about the inner steps.
       // if you are timing TPL libraries, for correct timing use verbose option,
       // because there are pre- post processing in these TPL kernel wraps.
       params.verbose = 1;
-    } else if (0 == strcasecmp(argv[i], "--algorithm")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--algorithm")) {
       char* algoStr = getNextArg(i, argc, argv);
 
-      if (0 == strcasecmp(algoStr, "DEFAULT")) {
+      if (0 == Test::string_compare_no_case(algoStr, "DEFAULT")) {
         params.algorithm = KokkosSparse::SPGEMM_KK;
-      } else if (0 == strcasecmp(algoStr, "KKDEFAULT")) {
+      } else if (0 == Test::string_compare_no_case(algoStr, "KKDEFAULT")) {
         params.algorithm = KokkosSparse::SPGEMM_KK;
-      } else if (0 == strcasecmp(algoStr, "KKSPGEMM")) {
+      } else if (0 == Test::string_compare_no_case(algoStr, "KKSPGEMM")) {
         params.algorithm = KokkosSparse::SPGEMM_KK;
       }
 
-      else if (0 == strcasecmp(algoStr, "KKMEM")) {
+      else if (0 == Test::string_compare_no_case(algoStr, "KKMEM")) {
         params.algorithm = KokkosSparse::SPGEMM_KK_MEMORY;
-      } else if (0 == strcasecmp(algoStr, "KKDENSE")) {
+      } else if (0 == Test::string_compare_no_case(algoStr, "KKDENSE")) {
         params.algorithm = KokkosSparse::SPGEMM_KK_DENSE;
-      } else if (0 == strcasecmp(algoStr, "KKLP")) {
+      } else if (0 == Test::string_compare_no_case(algoStr, "KKLP")) {
         params.algorithm = KokkosSparse::SPGEMM_KK_LP;
-      } else if (0 == strcasecmp(algoStr, "MKL")) {
+      } else if (0 == Test::string_compare_no_case(algoStr, "MKL")) {
         params.algorithm = KokkosSparse::SPGEMM_MKL;
-      } else if (0 == strcasecmp(algoStr, "CUSPARSE")) {
+      } else if (0 == Test::string_compare_no_case(algoStr, "CUSPARSE")) {
         params.algorithm = KokkosSparse::SPGEMM_CUSPARSE;
-      } else if (0 == strcasecmp(algoStr, "CUSP")) {
+      } else if (0 == Test::string_compare_no_case(algoStr, "CUSP")) {
         params.algorithm = KokkosSparse::SPGEMM_CUSP;
-      } else if (0 == strcasecmp(algoStr, "KKDEBUG")) {
+      } else if (0 == Test::string_compare_no_case(algoStr, "KKDEBUG")) {
         params.algorithm = KokkosSparse::SPGEMM_KK_LP;
-      } else if (0 == strcasecmp(algoStr, "MKL2")) {
+      } else if (0 == Test::string_compare_no_case(algoStr, "MKL2")) {
         params.algorithm = KokkosSparse::SPGEMM_MKL2PHASE;
-      } else if (0 == strcasecmp(algoStr, "VIENNA")) {
+      } else if (0 == Test::string_compare_no_case(algoStr, "VIENNA")) {
         params.algorithm = KokkosSparse::SPGEMM_VIENNA;
       }
 

--- a/perf_test/sparse/KokkosSparse_spgemm_jacobi.cpp
+++ b/perf_test/sparse/KokkosSparse_spgemm_jacobi.cpp
@@ -46,6 +46,7 @@
 #include "KokkosKernels_default_types.hpp"
 #include "KokkosKernels_IOUtils.hpp"
 #include "KokkosSparse_run_spgemm_jacobi.hpp"
+#include "KokkosKernels_TestUtils.hpp"
 
 void print_options() {
   std::cerr << "Options\n" << std::endl;
@@ -92,27 +93,28 @@ static char* getNextArg(int& i, int argc, char** argv) {
 int parse_inputs(KokkosKernels::Experiment::Parameters& params, int argc,
                  char** argv) {
   for (int i = 1; i < argc; ++i) {
-    if (0 == strcasecmp(argv[i], "--threads")) {
+    if (0 == Test::string_compare_no_case(argv[i], "--threads")) {
       params.use_threads = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--openmp")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--openmp")) {
       params.use_openmp = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--cuda")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cuda")) {
       params.use_cuda = atoi(getNextArg(i, argc, argv)) + 1;
-    } else if (0 == strcasecmp(argv[i], "--repeat")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--repeat")) {
       params.repeat = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--hashscale")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--hashscale")) {
       params.minhashscale = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--chunksize")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--chunksize")) {
       params.chunk_size = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--teamsize")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--teamsize")) {
       params.team_size = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--vectorsize")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--vectorsize")) {
       params.vector_size = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--compression2step")) {
+    } else if (0 ==
+               Test::string_compare_no_case(argv[i], "--compression2step")) {
       params.compression2step = true;
-    } else if (0 == strcasecmp(argv[i], "--shmem")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--shmem")) {
       params.shmemsize = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--memspaces")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--memspaces")) {
       int memspaces    = atoi(getNextArg(i, argc, argv));
       int memspaceinfo = memspaces;
       std::cout << "memspaceinfo:" << memspaceinfo << std::endl;
@@ -148,50 +150,50 @@ int parse_inputs(KokkosKernels::Experiment::Parameters& params, int argc,
         std::cout << "Using DDR4 for work memory space" << std::endl;
       }
       memspaceinfo = memspaceinfo >> 1;
-    } else if (0 == strcasecmp(argv[i], "--CRWC")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--CRWC")) {
       params.calculate_read_write_cost = 1;
-    } else if (0 == strcasecmp(argv[i], "--CIF")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--CIF")) {
       params.coloring_input_file = getNextArg(i, argc, argv);
-    } else if (0 == strcasecmp(argv[i], "--COF")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--COF")) {
       params.coloring_output_file = getNextArg(i, argc, argv);
-    } else if (0 == strcasecmp(argv[i], "--CCO")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--CCO")) {
       // if 0.85 set, if compression does not reduce flops by at least 15%
       // symbolic will run on original matrix. otherwise, it will compress the
       // graph and run symbolic on compressed one.
       params.compression_cut_off = atof(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--FLHCO")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--FLHCO")) {
       // if linear probing is used as hash, what is the max occupancy percantage
       // we allow in the hash.
       params.first_level_hash_cut_off = atof(getNextArg(i, argc, argv));
     }
 
-    else if (0 == strcasecmp(argv[i], "--flop")) {
+    else if (0 == Test::string_compare_no_case(argv[i], "--flop")) {
       // print flop statistics. only for the first repeat.
       params.calculate_read_write_cost = 1;
     }
 
-    else if (0 == strcasecmp(argv[i], "--checkoutput")) {
+    else if (0 == Test::string_compare_no_case(argv[i], "--checkoutput")) {
       // check correctness
       params.check_output = 1;
-    } else if (0 == strcasecmp(argv[i], "--amtx")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--amtx")) {
       // A at C=AxB
       params.a_mtx_bin_file = getNextArg(i, argc, argv);
     }
 
-    else if (0 == strcasecmp(argv[i], "--bmtx")) {
+    else if (0 == Test::string_compare_no_case(argv[i], "--bmtx")) {
       // B at C=AxB.
       // if not provided, C = AxA will be performed.
       params.b_mtx_bin_file = getNextArg(i, argc, argv);
-    } else if (0 == strcasecmp(argv[i], "--cmtx")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cmtx")) {
       // if provided, C will be written to given file.
       // has to have ".bin", or ".crs" extension.
       params.c_mtx_bin_file = getNextArg(i, argc, argv);
-    } else if (0 == strcasecmp(argv[i], "--dynamic")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--dynamic")) {
       // dynamic scheduling will be used for loops.
       // currently it is default already.
       // so has to use the dynamic schedulin.
       params.use_dynamic_scheduling = 1;
-    } else if (0 == strcasecmp(argv[i], "--DENSEACCMAX")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--DENSEACCMAX")) {
       // on CPUs and KNLs if DEFAULT algorithm or KKSPGEMM is chosen,
       // it uses dense accumulators for smaller matrices based on the size of
       // column (k) in B. Max column size is 250,000 for k to use dense
@@ -199,25 +201,25 @@ int parse_inputs(KokkosKernels::Experiment::Parameters& params, int argc,
       // with smaller thread count, where memory bandwidth is not an issue, this
       // cut-off can be increased to be more than 250,000
       params.MaxColDenseAcc = atoi(getNextArg(i, argc, argv));
-    } else if (0 == strcasecmp(argv[i], "--verbose")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--verbose")) {
       // print the timing and information about the inner steps.
       params.verbose = 1;
-    } else if (0 == strcasecmp(argv[i], "--algorithm")) {
+    } else if (0 == Test::string_compare_no_case(argv[i], "--algorithm")) {
       char* algoStr = getNextArg(i, argc, argv);
 
-      if (0 == strcasecmp(algoStr, "DEFAULT")) {
+      if (0 == Test::string_compare_no_case(algoStr, "DEFAULT")) {
         params.algorithm = KokkosSparse::SPGEMM_KK;
-      } else if (0 == strcasecmp(algoStr, "KKDEFAULT")) {
+      } else if (0 == Test::string_compare_no_case(algoStr, "KKDEFAULT")) {
         params.algorithm = KokkosSparse::SPGEMM_KK;
-      } else if (0 == strcasecmp(algoStr, "KKSPGEMM")) {
+      } else if (0 == Test::string_compare_no_case(algoStr, "KKSPGEMM")) {
         params.algorithm = KokkosSparse::SPGEMM_KK;
-      } else if (0 == strcasecmp(algoStr, "KKMEM")) {
+      } else if (0 == Test::string_compare_no_case(algoStr, "KKMEM")) {
         params.algorithm = KokkosSparse::SPGEMM_KK_MEMORY;
-      } else if (0 == strcasecmp(algoStr, "KKDENSE")) {
+      } else if (0 == Test::string_compare_no_case(algoStr, "KKDENSE")) {
         params.algorithm = KokkosSparse::SPGEMM_KK_DENSE;
-      } else if (0 == strcasecmp(algoStr, "KKLP")) {
+      } else if (0 == Test::string_compare_no_case(algoStr, "KKLP")) {
         params.algorithm = KokkosSparse::SPGEMM_KK_LP;
-      } else if (0 == strcasecmp(algoStr, "KKDEBUG")) {
+      } else if (0 == Test::string_compare_no_case(algoStr, "KKDEBUG")) {
         params.algorithm = KokkosSparse::SPGEMM_KK_LP;
       } else {
         std::cerr << "Unrecognized command line argument #" << i << ": "

--- a/test_common/KokkosKernels_MatrixConverter.cpp
+++ b/test_common/KokkosKernels_MatrixConverter.cpp
@@ -59,19 +59,19 @@ int main (int argc, char* argv[]){
   char *in_mtx = NULL, *out_bin = NULL;
   //bool create_incidence = false;
   for ( int i = 1 ; i < argc ; ++i ) {
-    if ( 0 == strcasecmp( argv[i] , "--symmetrize" ) ) {
+    if ( 0 == Test::string_compare_no_case( argv[i] , "--symmetrize" ) ) {
       symmetrize = true;
     }
-    else if ( 0 == strcasecmp( argv[i] , "--remove_diagonal" ) ) {
+    else if ( 0 == Test::string_compare_no_case( argv[i] , "--remove_diagonal" ) ) {
       remove_diagonal = true;
     }
-    else if ( 0 == strcasecmp( argv[i] , "--transpose" ) ) {
+    else if ( 0 == Test::string_compare_no_case( argv[i] , "--transpose" ) ) {
       transpose = true;
     }
-    else if ( 0 == strcasecmp( argv[i] , "--in_mtx" ) ) {
+    else if ( 0 == Test::string_compare_no_case( argv[i] , "--in_mtx" ) ) {
       in_mtx = argv[++i];
     }
-    else if ( 0 == strcasecmp( argv[i] , "--out_mtx" ) ) {
+    else if ( 0 == Test::string_compare_no_case( argv[i] , "--out_mtx" ) ) {
       out_bin = argv[++i];
     }
     else {

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -48,7 +48,8 @@
 #include "KokkosKernels_Utils.hpp"
 #include "Kokkos_ArithTraits.hpp"
 #include "KokkosSparse_spmv.hpp"
-#include "gtest/gtest.h"  //for EXPECT_**
+// Make this include-able from all subdirectories
+#include "../tpls/gtest/gtest/gtest.h"  //for EXPECT_**
 
 namespace Test {
 template <class ViewType,
@@ -457,5 +458,14 @@ template <>
 KOKKOS_INLINE_FUNCTION std::string value_type_name<Kokkos::complex<double>>() {
   return "::ComplexDouble";
 }
+
+int string_compare_no_case(const char* str1, const char* str2) {
+  std::string str1_s(str1);
+  std::string str2_s(str2);
+  for(int i=0; i<str1_s.size(); i++) str1_s[i] = std::tolower(str1_s[i]);
+  for(int i=0; i<str2_s.size(); i++) str2_s[i] = std::tolower(str2_s[i]);
+  return strcmp(str1_s.c_str(),str2_s.c_str());
+}
+
 }  // namespace Test
 #endif

--- a/test_common/KokkosKernels_WriteBinaryFromBinSrcDst.cpp
+++ b/test_common/KokkosKernels_WriteBinaryFromBinSrcDst.cpp
@@ -61,10 +61,10 @@ int main (int argc, char ** argv){
 
   char *in_src = NULL, *in_dst = NULL;
   for ( int i = 1 ; i < argc ; ++i ) {
-    if ( 0 == strcasecmp( argv[i] , "in_src" ) ) {
+    if ( 0 == Test::string_compare_no_case( argv[i] , "in_src" ) ) {
       in_src = argv[++i];
     }
-    else if ( 0 == strcasecmp( argv[i] , "in_dst" ) ) {
+    else if ( 0 == Test::string_compare_no_case( argv[i] , "in_dst" ) ) {
       in_dst = argv[++i];
     }
     else {


### PR DESCRIPTION
Lets not use linux system level functions in KokkosKernels.

Note there is one somewhat awkward thing I did. Since I added the function to test_common/KokkosKernels_TestUtils.hpp I had to include that thing in all kinds of files. However that thing includes gtest which is not found by the perf_tests since its not used there. I change the include path of gtest/gtest.h in the file to go upstream a bit. We could also add gtest directory to the include directories of the examples and perf_test or put the new function into something which doesn't use gtest. I mean there are a lot of util headers in KokkosKernels to choose from ...