### PR TITLE
Fix compilation errors for multi-vectors in kk_print_1Dview()

### DIFF
--- a/src/common/KokkosKernels_PrintUtils.hpp
+++ b/src/common/KokkosKernels_PrintUtils.hpp
@@ -140,9 +140,14 @@ template <typename idx_array_type>
 inline std::enable_if_t<idx_array_type::rank != 1> kk_print_1Dview(
     std::ostream& os, idx_array_type view, bool print_all = false,
     const char* sep = " ", size_t print_size = 40) {
-  if (idx_array_type::rank == 2 && view.extent(1) == 1) {
-    kk_print_1Dview(os, subview(view, Kokkos::ALL, 0), print_all, sep,
-                    print_size);
+  if ((idx_array_type::rank == 2 && view.extent(1) == 1) ||
+      idx_array_type::rank == 0) {
+    const auto n     = idx_array_type::rank == 0 ? 1 : view.extent(0);
+    using rank1_view = Kokkos::View<decltype(view.data()),
+                                    typename idx_array_type::array_layout,
+                                    typename idx_array_type::memory_space,
+                                    typename idx_array_type::memory_traits>;
+    kk_print_1Dview(os, rank1_view(view.data(), n), print_all, sep, print_size);
     return;
   }
   os << "[" << view.extent(0);

--- a/src/common/KokkosKernels_PrintUtils.hpp
+++ b/src/common/KokkosKernels_PrintUtils.hpp
@@ -98,9 +98,9 @@ inline void kk_get_histogram(
  * pritned. This parameter is not used if print_all is set to true.
  */
 template <typename idx_array_type>
-inline void kk_print_1Dview(std::ostream& os, idx_array_type view,
-                            bool print_all = false, const char* sep = " ",
-                            size_t print_size = 40) {
+inline std::enable_if_t<idx_array_type::rank == 1> kk_print_1Dview(
+    std::ostream& os, idx_array_type view, bool print_all = false,
+    const char* sep = " ", size_t print_size = 40) {
   typedef typename idx_array_type::HostMirror host_type;
   typedef typename idx_array_type::size_type idx;
   host_type host_view = Kokkos::create_mirror_view(view);
@@ -130,6 +130,26 @@ inline void kk_print_1Dview(std::ostream& os, idx_array_type view,
     }
     os << std::endl;
   }
+}
+
+/**
+ * \brief Multi-vector variant (see rank-1 for param description). Prints Nx1
+ * rank-2 vectors same like rank-1 vectors and prints multi-vector dimensions.
+ */
+template <typename idx_array_type>
+inline std::enable_if_t<idx_array_type::rank != 1> kk_print_1Dview(
+    std::ostream& os, idx_array_type view, bool print_all = false,
+    const char* sep = " ", size_t print_size = 40) {
+  if (idx_array_type::rank == 2 && view.extent(1) == 1) {
+    kk_print_1Dview(os, subview(view, Kokkos::ALL, 0), print_all, sep,
+                    print_size);
+    return;
+  }
+  os << "[" << view.extent(0);
+  for (int i = 1; i < idx_array_type::rank; ++i) {
+    os << "x" << view.extent(i);
+  }
+  os << " multi-vector]" << std::endl;
 }
 
 /**

--- a/unit_test/common/Test_Common.hpp
+++ b/unit_test/common/Test_Common.hpp
@@ -9,5 +9,6 @@
 #include <Test_Common_set_bit_count.hpp>
 #include <Test_Common_Sorting.hpp>
 #include <Test_Common_Transpose.hpp>
+#include <Test_Common_IOUtils.hpp>
 
 #endif  // TEST_COMMON_HPP

--- a/unit_test/common/Test_Common_IOUtils.hpp
+++ b/unit_test/common/Test_Common_IOUtils.hpp
@@ -1,0 +1,91 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+/// \file Test_Common_IOUtils.hpp
+/// \brief Tests for IO and print routines
+
+#ifndef KOKKOSKERNELS_IOTEST_HPP
+#define KOKKOSKERNELS_IOTEST_HPP
+
+#include <Kokkos_Core.hpp>
+#include <KokkosKernels_PrintUtils.hpp>
+
+template <typename exec_space>
+void testPrintView() {
+  using scalar_t   = default_scalar;
+  using Unmanaged  = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
+  using rank0_view = Kokkos::View<scalar_t, Kokkos::HostSpace, Unmanaged>;
+  using rank1_view = Kokkos::View<scalar_t*, Kokkos::HostSpace, Unmanaged>;
+  using rank2_view = Kokkos::View<scalar_t**, Kokkos::HostSpace, Unmanaged>;
+
+  constexpr auto sep = "|";  // test something else than space
+
+  std::stringstream out;
+
+  const auto test = [&](auto hv, int limit = 0) {
+    const auto v = Kokkos::create_mirror_view_and_copy(exec_space(), hv);
+    kk_print_1Dview(out, v, limit < 1, sep, limit);
+  };
+
+  std::vector<scalar_t> vals = {4, 5, 6, 7};
+  const rank1_view hv1(vals.data(), vals.size());
+  test(hv1);
+  test(hv1, 4);
+  test(hv1, 3);
+  test(rank0_view(vals.data()));
+  test(rank2_view(vals.data(), vals.size(), 1));
+  test(rank2_view(vals.data(), vals.size() / 2, 2));
+
+  EXPECT_EQ(out.str(),
+            "4|5|6|7|\n"
+            "4|5|6|7|\n"
+            "4|... ... ...|7|\n"
+            "4|\n"
+            "4|5|6|7|\n"
+            "[2x2 multi-vector]\n");
+}
+
+TEST_F(TestCategory, common_print_view) { testPrintView<TestExecSpace>(); }
+
+#endif  // KOKKOSKERNELS_IOTEST_HPP


### PR DESCRIPTION
Let's make `kk_print_1Dview()` useful also where displayed view can be either single- or multi-vector.

### Proposed behavior

* Print Nx1 rank-2 vectors same like rank-1 vectors;
* Display multi-vector dimensions like: `[504x2 multi-vector]`.

### Current behavior

GCC compilation error which is not very helpful if ones single vector gets turned somewhere into Nx1 rank-2 vector to be dispatched through generic multi-vector interface. The message looks like:
```shell
/kokkos-kernels/src/common/KokkosKernels_PrintUtils.hpp:113:24: error: no match for call to ‘(host_type {aka
Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Serial, Kokkos::HostSpace> >}) (idx&)’
  113 |         os << host_view(i) << sep;
      |               ~~~~~~~~~^~~
In file included from /install/kokkos/include/Kokkos_Parallel.hpp:54,
                 from /install/kokkos/include/Kokkos_Serial.hpp:59,
                 from /install/kokkos/include/decl/Kokkos_Declare_SERIAL.hpp:49,
                 from /install/kokkos/include/KokkosCore_Config_DeclareBackend.hpp:47,
                 from /install/kokkos/include/Kokkos_Core.hpp:56,
                 from /kokkos-kernels/unit_test/serial/Test_Serial.hpp:5,
                 from /kokkos-kernels/unit_test/serial/Test_Serial_Sparse.cpp:4:
/install/kokkos/include/Kokkos_View.hpp:815:18: note: candidate: ‘Kokkos::View<DataType,
Properties>::reference_type Kokkos::View<DataType, Properties>::operator()() const [with DataType = double**;
Properties = {Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Serial, Kokkos::HostSpace>}; Kokkos::View<DataType,
Properties>::reference_type = double&]’
  815 |   reference_type operator()() const { return m_map.reference(); }
      |                  ^~~~~~~~
/install/kokkos/include/Kokkos_View.hpp:815:18: note:   candidate expects 0 arguments, 1 provided
/install/kokkos/include/Kokkos_View.hpp:824:7: note: candidate: ‘template<class I0> typename
std::enable_if<((Kokkos::Impl::are_integral<I0>::value && (1 == Kokkos::View<DataType, Properties>::Rank)) &&
(! Kokkos::View<DataType, Properties>::is_default_map)), typename Kokkos::Impl::ViewMapping<Kokkos::ViewTraits<DataType,
Properties ...>, typename Kokkos::ViewTraits<DataType, Properties ...>::specialize>::reference_type>::type
Kokkos::View<DataType, Properties>::operator()(const I0&) const [with I0 = I0; DataType = double**;
Properties = {Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Serial, Kokkos::HostSpace>}]’
  824 |       operator()(const I0& i0) const {
      |       ^~~~~~~~
/install/kokkos/include/Kokkos_View.hpp:824:7: note:   template argument deduction/substitution failed:
/install/kokkos/include/Kokkos_View.hpp: In substitution of ‘template<class I0> typename
std::enable_if<((Kokkos::Impl::are_integral<I0>::value && (1 == Kokkos::View<double**, Kokkos::LayoutLeft, 
Kokkos::Device<Kokkos::Serial, Kokkos::HostSpace> >::Rank)) && (! Kokkos::View<double**, Kokkos::LayoutLeft, 
Kokkos::Device<Kokkos::Serial, Kokkos::HostSpace> >::is_default_map)), double&>::type Kokkos::View<double**, 
Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Serial, Kokkos::HostSpace> >::operator()<I0>(const I0&) const
[with I0 = long unsigned int]’:
```

