### PR TITLE
BSR format support in block Gauss-Seidel

### DIFF
--- a/src/common/KokkosKernels_SparseUtils.hpp
+++ b/src/common/KokkosKernels_SparseUtils.hpp
@@ -2097,7 +2097,7 @@ struct MatrixConverter<BlockCRS> {
           KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>,
       typename blockCrsMat_t = KokkosSparse::Experimental::BlockCrsMatrix<
           scalar_t, lno_t, device, void, size_type>>
-  static blockCrsMat_t from_crs(
+  static blockCrsMat_t from_blockcrs_formated_point_crsmatrix(
       const KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>
           &mtx,
       lno_t block_size) {
@@ -2111,7 +2111,7 @@ struct MatrixConverter<BSR> {
             typename device,
             typename bsrMtx_t = KokkosSparse::Experimental::BsrMatrix<
                 scalar_t, lno_t, device, void, size_type>>
-  static bsrMtx_t from_crs(
+  static bsrMtx_t from_blockcrs_formated_point_crsmatrix(
       const KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>
           &mtx,
       lno_t block_size) {

--- a/src/common/KokkosKernels_SparseUtils.hpp
+++ b/src/common/KokkosKernels_SparseUtils.hpp
@@ -49,6 +49,8 @@
 #include "KokkosKernels_ExecSpaceUtils.hpp"
 #include <vector>
 #include "KokkosKernels_PrintUtils.hpp"
+#include "KokkosSparse_CrsMatrix.hpp"
+#include "KokkosSparse_BsrMatrix.hpp"
 
 #ifdef KOKKOSKERNELS_HAVE_PARALLEL_GNUSORT
 #include <parallel/algorithm>
@@ -2054,6 +2056,69 @@ class MatrixRowIndex<BSR, lno_t, size_type>
   size_type value(const lno_t col_idx, const lno_t block_row,
                   const lno_t block_col) {
     return block(col_idx) + block_row * block_stride() + block_col;
+  }
+};
+
+template <typename mtx_t>
+struct MatrixTraits;
+
+template <typename scalar_t, typename lno_t, typename device,
+          typename mem_traits, typename size_type>
+struct MatrixTraits<
+    KokkosSparse::CrsMatrix<scalar_t, lno_t, device, mem_traits, size_type>> {
+  static constexpr auto format = KokkosKernels::BlockCRS;
+};
+
+template <typename scalar_t, typename lno_t, typename device,
+          typename mem_traits, typename size_type>
+struct MatrixTraits<KokkosSparse::Experimental::BsrMatrix<
+    scalar_t, lno_t, device, mem_traits, size_type>> {
+  static constexpr auto format = KokkosKernels::BSR;
+};
+
+template <SparseMatrixFormat /* outFormat */>
+struct MatrixConverter;
+
+template <>
+struct MatrixConverter<BlockCRS> {
+  template <
+      typename scalar_t, typename lno_t, typename device, typename size_type,
+      typename crsMat_t =
+          KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>>
+  static crsMat_t from_crs(
+      const std::string &label,
+      const KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>
+          &mtx,
+      lno_t block_size) {
+    using graph_t        = typename crsMat_t::StaticCrsGraphType;
+    using lno_view_t     = typename graph_t::row_map_type::non_const_type;
+    using lno_nnz_view_t = typename graph_t::entries_type::non_const_type;
+    using scalar_view_t  = typename crsMat_t::values_type::non_const_type;
+    lno_view_t rows;
+    lno_nnz_view_t entries;
+    scalar_view_t vals;
+    size_t num_rows, num_cols;
+
+    KokkosKernels::Impl::kk_create_blockcrs_from_blockcrs_formatted_point_crs(
+        block_size, mtx.numRows(), mtx.numCols(), mtx.graph.row_map,
+        mtx.graph.entries, mtx.values, num_rows, num_cols, rows, entries, vals);
+
+    return crsMat_t(label, num_cols, vals, graph_t(entries, rows));
+  }
+};
+
+template <>
+struct MatrixConverter<BSR> {
+  template <typename scalar_t, typename lno_t, typename size_type,
+            typename device,
+            typename bsrMtx_t = KokkosSparse::Experimental::BsrMatrix<
+                scalar_t, lno_t, device, void, size_type>>
+  static bsrMtx_t from_crs(
+      const std::string & /* label */,
+      const KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>
+          &mtx,
+      lno_t block_size) {
+    return bsrMtx_t(mtx, block_size);
   }
 };
 

--- a/src/common/KokkosKernels_SparseUtils.hpp
+++ b/src/common/KokkosKernels_SparseUtils.hpp
@@ -846,7 +846,7 @@ inline size_t kk_is_d1_coloring_valid(
   ;
   typename in_nnz_view_t::non_const_value_type team_work_chunk_size =
       suggested_team_size;
-  typedef Kokkos::TeamPolicy<MyExecSpace, Kokkos::Schedule<Kokkos::Dynamic> >
+  typedef Kokkos::TeamPolicy<MyExecSpace, Kokkos::Schedule<Kokkos::Dynamic>>
       dynamic_team_policy;
   typedef typename dynamic_team_policy::member_type team_member_t;
 
@@ -1115,10 +1115,10 @@ struct LowerTriangularMatrix {
   typedef Kokkos::TeamPolicy<FillTag, ExecutionSpace> team_fill_policy_t;
 
   typedef Kokkos::TeamPolicy<CountTag, ExecutionSpace,
-                             Kokkos::Schedule<Kokkos::Dynamic> >
+                             Kokkos::Schedule<Kokkos::Dynamic>>
       dynamic_team_count_policy_t;
   typedef Kokkos::TeamPolicy<FillTag, ExecutionSpace,
-                             Kokkos::Schedule<Kokkos::Dynamic> >
+                             Kokkos::Schedule<Kokkos::Dynamic>>
       dynamic_team_fill_policy_t;
 
   typedef typename team_count_policy_t::member_type team_count_member_t;

--- a/src/common/KokkosKernels_SparseUtils.hpp
+++ b/src/common/KokkosKernels_SparseUtils.hpp
@@ -59,9 +59,11 @@
 namespace KokkosKernels {
 
 enum SparseMatrixFormat {
-  /* CRS, */
   BlockCRS,
   BSR,
+  CRS = BlockCRS,  // convenience alias: for block_size=1 or no-blocks there is
+                   // no difference in value ordering (so the format tag becomes
+                   // irrelevant)
 };
 
 namespace Impl {
@@ -2066,7 +2068,7 @@ template <typename scalar_t, typename lno_t, typename device,
           typename mem_traits, typename size_type>
 struct MatrixTraits<
     KokkosSparse::CrsMatrix<scalar_t, lno_t, device, mem_traits, size_type>> {
-  static constexpr auto format = KokkosKernels::BlockCRS;
+  static constexpr auto format = KokkosKernels::CRS;
 };
 
 template <typename scalar_t, typename lno_t, typename device,

--- a/src/graph/impl/KokkosGraph_Distance2MIS_impl.hpp
+++ b/src/graph/impl/KokkosGraph_Distance2MIS_impl.hpp
@@ -1079,7 +1079,7 @@ struct D2_MIS_Aggregation {
     // Now, filter out the candidate aggs which are big enough, and create those
     // aggregates. Using a scan for this assigns IDs deterministically (unlike
     // an atomic counter).
-    lno_t numNewAggs;
+    lno_t numNewAggs = 0;
     Kokkos::parallel_scan(
         range_pol(0, numCandRoots),
         ChoosePhase2AggsFunctor(numVerts, numAggs, m2, rowmap, entries, labels,

--- a/src/sparse/KokkosSparse_gauss_seidel.hpp
+++ b/src/sparse/KokkosSparse_gauss_seidel.hpp
@@ -132,7 +132,8 @@ void block_gauss_seidel_symbolic(
                         is_graph_symmetric);
 }
 
-template <typename KernelHandle, typename lno_row_view_t_,
+template <KokkosKernels::SparseMatrixFormat format = KokkosKernels::BlockCRS,
+          typename KernelHandle, typename lno_row_view_t_,
           typename lno_nnz_view_t_, typename scalar_nnz_view_t_>
 void gauss_seidel_numeric(KernelHandle *handle,
                           typename KernelHandle::const_nnz_lno_t num_rows,
@@ -198,14 +199,16 @@ void gauss_seidel_numeric(KernelHandle *handle,
   using namespace KokkosSparse::Impl;
 
   GAUSS_SEIDEL_NUMERIC<
-      const_handle_type, Internal_alno_row_view_t_, Internal_alno_nnz_view_t_,
+      const_handle_type, format, Internal_alno_row_view_t_,
+      Internal_alno_nnz_view_t_,
       Internal_ascalar_nnz_view_t_>::gauss_seidel_numeric(&tmp_handle, num_rows,
                                                           num_cols, const_a_r,
                                                           const_a_l, const_a_v,
                                                           is_graph_symmetric);
 }
 
-template <typename KernelHandle, typename lno_row_view_t_,
+template <KokkosKernels::SparseMatrixFormat format = KokkosKernels::BlockCRS,
+          typename KernelHandle, typename lno_row_view_t_,
           typename lno_nnz_view_t_, typename scalar_nnz_view_t_>
 void gauss_seidel_numeric(KernelHandle *handle,
                           typename KernelHandle::const_nnz_lno_t num_rows,
@@ -274,7 +277,8 @@ void gauss_seidel_numeric(KernelHandle *handle,
   using namespace KokkosSparse::Impl;
 
   GAUSS_SEIDEL_NUMERIC<
-      const_handle_type, Internal_alno_row_view_t_, Internal_alno_nnz_view_t_,
+      const_handle_type, format, Internal_alno_row_view_t_,
+      Internal_alno_nnz_view_t_,
       Internal_ascalar_nnz_view_t_>::gauss_seidel_numeric(&tmp_handle, num_rows,
                                                           num_cols, const_a_r,
                                                           const_a_l, const_a_v,
@@ -282,7 +286,8 @@ void gauss_seidel_numeric(KernelHandle *handle,
                                                           is_graph_symmetric);
 }
 
-template <typename KernelHandle, typename lno_row_view_t_,
+template <KokkosKernels::SparseMatrixFormat format = KokkosKernels::BlockCRS,
+          typename KernelHandle, typename lno_row_view_t_,
           typename lno_nnz_view_t_, typename scalar_nnz_view_t_>
 void block_gauss_seidel_numeric(
     KernelHandle *handle, typename KernelHandle::const_nnz_lno_t num_rows,
@@ -298,11 +303,12 @@ void block_gauss_seidel_numeric(
   }
   gsHandle->set_block_size(block_size);
 
-  gauss_seidel_numeric(handle, num_rows, num_cols, row_map, entries, values,
-                       is_graph_symmetric);
+  gauss_seidel_numeric<format>(handle, num_rows, num_cols, row_map, entries,
+                               values, is_graph_symmetric);
 }
 
-template <typename KernelHandle, typename lno_row_view_t_,
+template <KokkosKernels::SparseMatrixFormat format = KokkosKernels::BlockCRS,
+          typename KernelHandle, typename lno_row_view_t_,
           typename lno_nnz_view_t_, typename scalar_nnz_view_t_,
           typename x_scalar_view_t, typename y_scalar_view_t>
 void symmetric_gauss_seidel_apply(
@@ -422,19 +428,17 @@ void symmetric_gauss_seidel_apply(
 
   using namespace KokkosSparse::Impl;
 
-  GAUSS_SEIDEL_APPLY<
-      const_handle_type, Internal_alno_row_view_t_, Internal_alno_nnz_view_t_,
-      Internal_ascalar_nnz_view_t_, Internal_xscalar_nnz_view_t_,
-      Internal_yscalar_nnz_view_t_>::gauss_seidel_apply(&tmp_handle, num_rows,
-                                                        num_cols, const_a_r,
-                                                        const_a_l, const_a_v,
-                                                        nonconst_x_v, const_y_v,
-                                                        init_zero_x_vector,
-                                                        update_y_vector, omega,
-                                                        numIter, true, true);
+  GAUSS_SEIDEL_APPLY<const_handle_type, format, Internal_alno_row_view_t_,
+                     Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_,
+                     Internal_xscalar_nnz_view_t_,
+                     Internal_yscalar_nnz_view_t_>::
+      gauss_seidel_apply(&tmp_handle, num_rows, num_cols, const_a_r, const_a_l,
+                         const_a_v, nonconst_x_v, const_y_v, init_zero_x_vector,
+                         update_y_vector, omega, numIter, true, true);
 }
 
-template <typename KernelHandle, typename lno_row_view_t_,
+template <KokkosKernels::SparseMatrixFormat format = KokkosKernels::BlockCRS,
+          typename KernelHandle, typename lno_row_view_t_,
           typename lno_nnz_view_t_, typename scalar_nnz_view_t_,
           typename x_scalar_view_t, typename y_scalar_view_t>
 void symmetric_block_gauss_seidel_apply(
@@ -463,11 +467,12 @@ void symmetric_block_gauss_seidel_apply(
   }
 
   gsHandle->set_block_size(block_size);
-  symmetric_gauss_seidel_apply(
+  symmetric_gauss_seidel_apply<format>(
       handle, num_rows, num_cols, row_map, entries, values, x_lhs_output_vec,
       y_rhs_input_vec, init_zero_x_vector, update_y_vector, omega, numIter);
 }
-template <class KernelHandle, typename lno_row_view_t_,
+template <KokkosKernels::SparseMatrixFormat format = KokkosKernels::BlockCRS,
+          class KernelHandle, typename lno_row_view_t_,
           typename lno_nnz_view_t_, typename scalar_nnz_view_t_,
           typename x_scalar_view_t, typename y_scalar_view_t>
 void forward_sweep_gauss_seidel_apply(
@@ -589,19 +594,17 @@ void forward_sweep_gauss_seidel_apply(
 
   using namespace KokkosSparse::Impl;
 
-  GAUSS_SEIDEL_APPLY<
-      const_handle_type, Internal_alno_row_view_t_, Internal_alno_nnz_view_t_,
-      Internal_ascalar_nnz_view_t_, Internal_xscalar_nnz_view_t_,
-      Internal_yscalar_nnz_view_t_>::gauss_seidel_apply(&tmp_handle, num_rows,
-                                                        num_cols, const_a_r,
-                                                        const_a_l, const_a_v,
-                                                        nonconst_x_v, const_y_v,
-                                                        init_zero_x_vector,
-                                                        update_y_vector, omega,
-                                                        numIter, true, false);
+  GAUSS_SEIDEL_APPLY<const_handle_type, format, Internal_alno_row_view_t_,
+                     Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_,
+                     Internal_xscalar_nnz_view_t_,
+                     Internal_yscalar_nnz_view_t_>::
+      gauss_seidel_apply(&tmp_handle, num_rows, num_cols, const_a_r, const_a_l,
+                         const_a_v, nonconst_x_v, const_y_v, init_zero_x_vector,
+                         update_y_vector, omega, numIter, true, false);
 }
 
-template <typename KernelHandle, typename lno_row_view_t_,
+template <KokkosKernels::SparseMatrixFormat format = KokkosKernels::BlockCRS,
+          typename KernelHandle, typename lno_row_view_t_,
           typename lno_nnz_view_t_, typename scalar_nnz_view_t_,
           typename x_scalar_view_t, typename y_scalar_view_t>
 void forward_sweep_block_gauss_seidel_apply(
@@ -630,11 +633,12 @@ void forward_sweep_block_gauss_seidel_apply(
         "GS_CLUSTER");
   }
   gsHandle->set_block_size(block_size);
-  forward_sweep_gauss_seidel_apply(
+  forward_sweep_gauss_seidel_apply<format>(
       handle, num_rows, num_cols, row_map, entries, values, x_lhs_output_vec,
       y_rhs_input_vec, init_zero_x_vector, update_y_vector, omega, numIter);
 }
-template <class KernelHandle, typename lno_row_view_t_,
+template <KokkosKernels::SparseMatrixFormat format = KokkosKernels::BlockCRS,
+          class KernelHandle, typename lno_row_view_t_,
           typename lno_nnz_view_t_, typename scalar_nnz_view_t_,
           typename x_scalar_view_t, typename y_scalar_view_t>
 void backward_sweep_gauss_seidel_apply(
@@ -756,19 +760,17 @@ void backward_sweep_gauss_seidel_apply(
 
   using namespace KokkosSparse::Impl;
 
-  GAUSS_SEIDEL_APPLY<
-      const_handle_type, Internal_alno_row_view_t_, Internal_alno_nnz_view_t_,
-      Internal_ascalar_nnz_view_t_, Internal_xscalar_nnz_view_t_,
-      Internal_yscalar_nnz_view_t_>::gauss_seidel_apply(&tmp_handle, num_rows,
-                                                        num_cols, const_a_r,
-                                                        const_a_l, const_a_v,
-                                                        nonconst_x_v, const_y_v,
-                                                        init_zero_x_vector,
-                                                        update_y_vector, omega,
-                                                        numIter, false, true);
+  GAUSS_SEIDEL_APPLY<const_handle_type, format, Internal_alno_row_view_t_,
+                     Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_,
+                     Internal_xscalar_nnz_view_t_,
+                     Internal_yscalar_nnz_view_t_>::
+      gauss_seidel_apply(&tmp_handle, num_rows, num_cols, const_a_r, const_a_l,
+                         const_a_v, nonconst_x_v, const_y_v, init_zero_x_vector,
+                         update_y_vector, omega, numIter, false, true);
 }
 
-template <typename KernelHandle, typename lno_row_view_t_,
+template <KokkosKernels::SparseMatrixFormat format = KokkosKernels::BlockCRS,
+          typename KernelHandle, typename lno_row_view_t_,
           typename lno_nnz_view_t_, typename scalar_nnz_view_t_,
           typename x_scalar_view_t, typename y_scalar_view_t>
 void backward_sweep_block_gauss_seidel_apply(
@@ -796,7 +798,7 @@ void backward_sweep_block_gauss_seidel_apply(
         "GS_CLUSTER");
   }
   gsHandle->set_block_size(block_size);
-  backward_sweep_gauss_seidel_apply(
+  backward_sweep_gauss_seidel_apply<format>(
       handle, num_rows, num_cols, row_map, entries, values, x_lhs_output_vec,
       y_rhs_input_vec, init_zero_x_vector, update_y_vector, omega, numIter);
 }

--- a/src/sparse/KokkosSparse_gauss_seidel.hpp
+++ b/src/sparse/KokkosSparse_gauss_seidel.hpp
@@ -132,7 +132,7 @@ void block_gauss_seidel_symbolic(
                         is_graph_symmetric);
 }
 
-template <KokkosKernels::SparseMatrixFormat format = KokkosKernels::BlockCRS,
+template <KokkosKernels::SparseMatrixFormat format = KokkosKernels::CRS,
           typename KernelHandle, typename lno_row_view_t_,
           typename lno_nnz_view_t_, typename scalar_nnz_view_t_>
 void gauss_seidel_numeric(KernelHandle *handle,
@@ -207,7 +207,7 @@ void gauss_seidel_numeric(KernelHandle *handle,
                                                           is_graph_symmetric);
 }
 
-template <KokkosKernels::SparseMatrixFormat format = KokkosKernels::BlockCRS,
+template <KokkosKernels::SparseMatrixFormat format = KokkosKernels::CRS,
           typename KernelHandle, typename lno_row_view_t_,
           typename lno_nnz_view_t_, typename scalar_nnz_view_t_>
 void gauss_seidel_numeric(KernelHandle *handle,
@@ -307,7 +307,7 @@ void block_gauss_seidel_numeric(
                                values, is_graph_symmetric);
 }
 
-template <KokkosKernels::SparseMatrixFormat format = KokkosKernels::BlockCRS,
+template <KokkosKernels::SparseMatrixFormat format = KokkosKernels::CRS,
           typename KernelHandle, typename lno_row_view_t_,
           typename lno_nnz_view_t_, typename scalar_nnz_view_t_,
           typename x_scalar_view_t, typename y_scalar_view_t>
@@ -471,7 +471,7 @@ void symmetric_block_gauss_seidel_apply(
       handle, num_rows, num_cols, row_map, entries, values, x_lhs_output_vec,
       y_rhs_input_vec, init_zero_x_vector, update_y_vector, omega, numIter);
 }
-template <KokkosKernels::SparseMatrixFormat format = KokkosKernels::BlockCRS,
+template <KokkosKernels::SparseMatrixFormat format = KokkosKernels::CRS,
           class KernelHandle, typename lno_row_view_t_,
           typename lno_nnz_view_t_, typename scalar_nnz_view_t_,
           typename x_scalar_view_t, typename y_scalar_view_t>
@@ -637,7 +637,7 @@ void forward_sweep_block_gauss_seidel_apply(
       handle, num_rows, num_cols, row_map, entries, values, x_lhs_output_vec,
       y_rhs_input_vec, init_zero_x_vector, update_y_vector, omega, numIter);
 }
-template <KokkosKernels::SparseMatrixFormat format = KokkosKernels::BlockCRS,
+template <KokkosKernels::SparseMatrixFormat format = KokkosKernels::CRS,
           class KernelHandle, typename lno_row_view_t_,
           typename lno_nnz_view_t_, typename scalar_nnz_view_t_,
           typename x_scalar_view_t, typename y_scalar_view_t>

--- a/src/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
@@ -62,7 +62,7 @@ namespace Impl {
 
 template <typename HandleType, typename lno_row_view_t_,
           typename lno_nnz_view_t_, typename scalar_nnz_view_t_,
-          KokkosKernels::SparseMatrixFormat format = KokkosKernels::BlockCRS>
+          KokkosKernels::SparseMatrixFormat format = KokkosKernels::CRS>
 class PointGaussSeidel {
  public:
   typedef lno_row_view_t_ in_lno_row_view_t;

--- a/src/sparse/impl/KokkosSparse_gauss_seidel_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_gauss_seidel_spec.hpp
@@ -44,8 +44,6 @@
 #ifndef KOKKOSSPARSE_IMPL_GAUSS_SEIDEL_SPEC_HPP_
 #define KOKKOSSPARSE_IMPL_GAUSS_SEIDEL_SPEC_HPP_
 
-// #define KOKKOSSPARSE_IMPL_PRINTDEBUG true
-
 #include <KokkosKernels_config.h>
 
 #include <Kokkos_Core.hpp>

--- a/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
@@ -86,7 +86,7 @@ struct GSTestParams {
   lno_t block_size = 7;
   lno_t numVecs    = 2;  // how many columns X/Y have
   scalar_t omega   = 0.9;
-  mag_t tolerance  = 1e-15;  // relative error for solution x vector
+  mag_t tolerance  = 1e-7;  // relative error for solution x vector
 
   // variants to cover
   std::vector<GSAlgorithm> gs_algorithms = {

--- a/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
@@ -218,7 +218,9 @@ void test_block_gauss_seidel_rank1(lno_t numRows, size_type nnz,
   crsMat_t crsmat2("CrsMatrix2", out_c, pf_v, static_graph2);
 
   // this converts the previous generated matrix to block matrix.
-  auto input_mat = MatrixConverter<mtx_format>::from_crs(crsmat2, block_size);
+  auto input_mat =
+      MatrixConverter<mtx_format>::from_blockcrs_formated_point_crsmatrix(
+          crsmat2, block_size);
 
   lno_t nv = ((crsmat2.numRows() + block_size - 1) / block_size) * block_size;
 
@@ -303,7 +305,9 @@ void test_block_gauss_seidel_rank2(lno_t numRows, size_type nnz,
   graph_t static_graph2(pf_e, pf_rm);
   crsMat_t crsmat2("CrsMatrix2", out_c, pf_v, static_graph2);
 
-  auto input_mat = MatrixConverter<mtx_format>::from_crs(crsmat2, block_size);
+  auto input_mat =
+      MatrixConverter<mtx_format>::from_blockcrs_formated_point_crsmatrix(
+          crsmat2, block_size);
 
   lno_t nv = ((crsmat2.numRows() + block_size - 1) / block_size) * block_size;
 

--- a/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
@@ -102,8 +102,8 @@ struct GSTestParams {
       2008  // make the shmem small on gpus so that it will test 2 level
             // algorithm.
   };
-  std::vector<GSApplyType> apply_types = {
-      symmetric /* , forward_sweep, backward_sweep */};
+  std::vector<GSApplyType> apply_types = {symmetric, forward_sweep,
+                                          backward_sweep};
 };
 
 template <typename mtx_t, typename vector_t, typename const_vector_t>

--- a/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
@@ -88,16 +88,10 @@ struct GSTestParams {
   scalar_t omega   = 0.9;
   mag_t tolerance  = 1e-7;  // relative error for solution x vector
 
-  // variants to cover
-  std::vector<GSAlgorithm> gs_algorithms = {
-      GS_DEFAULT,  // == GS_TEAM
-#if 0
-      GS_PERMUTED, // == GS_DEFAULT for blocks
-      GS_TWOSTAGE, // blocks not supported (yet?)
-      GS_CLUSTER,  // not compatible with blocks
-#endif
-  };
-  std::vector<size_t> shmem_sizes = {
+  // Note: GS_DEFAULT is same as GS_TEAM and - for blocks - as GS_PERMUTED
+  // Note: GS_TWOSTAGE and GS_CLUSTER are not supported for blocks
+  std::vector<GSAlgorithm> gs_algorithms = {GS_DEFAULT};
+  std::vector<size_t> shmem_sizes        = {
       32128,
       2008  // make the shmem small on gpus so that it will test 2 level
             // algorithm.

--- a/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
@@ -86,7 +86,7 @@ struct GSTestParams {
   lno_t block_size   = 7;
   lno_t numVecs      = 2;  // how many columns X/Y have
   scalar_t omega     = 0.9;
-  scalar_t tolerance = 1.0;  // relative error for solution x vector
+  scalar_t tolerance = 1e-15;  // relative error for solution x vector
 
   // variants to cover
   std::vector<GSAlgorithm> gs_algorithms = {

--- a/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
@@ -218,8 +218,7 @@ void test_block_gauss_seidel_rank1(lno_t numRows, size_type nnz,
   crsMat_t crsmat2("CrsMatrix2", out_c, pf_v, static_graph2);
 
   // this converts the previous generated matrix to block matrix.
-  auto input_mat =
-      MatrixConverter<mtx_format>::from_crs("BlockMatrix", crsmat2, block_size);
+  auto input_mat = MatrixConverter<mtx_format>::from_crs(crsmat2, block_size);
 
   lno_t nv = ((crsmat2.numRows() + block_size - 1) / block_size) * block_size;
 
@@ -304,8 +303,7 @@ void test_block_gauss_seidel_rank2(lno_t numRows, size_type nnz,
   graph_t static_graph2(pf_e, pf_rm);
   crsMat_t crsmat2("CrsMatrix2", out_c, pf_v, static_graph2);
 
-  auto input_mat =
-      MatrixConverter<mtx_format>::from_crs("BlockMatrix", crsmat2, block_size);
+  auto input_mat = MatrixConverter<mtx_format>::from_crs(crsmat2, block_size);
 
   lno_t nv = ((crsmat2.numRows() + block_size - 1) / block_size) * block_size;
 

--- a/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
@@ -98,6 +98,8 @@ struct GSTestParams {
   };
   std::vector<GSApplyType> apply_types = {symmetric, forward_sweep,
                                           backward_sweep};
+
+  GSTestParams() = default;
 };
 
 template <typename mtx_t, typename vector_t, typename const_vector_t>

--- a/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_block_gauss_seidel.hpp
@@ -80,13 +80,13 @@ enum GSApplyType {
   backward_sweep,
 };
 
-template <typename lno_t, typename scalar_t>
+template <typename lno_t, typename scalar_t, typename mag_t>
 struct GSTestParams {
   // Intentionally testing block_size that's not a multiple of #rows.
-  lno_t block_size   = 7;
-  lno_t numVecs      = 2;  // how many columns X/Y have
-  scalar_t omega     = 0.9;
-  scalar_t tolerance = 1e-15;  // relative error for solution x vector
+  lno_t block_size = 7;
+  lno_t numVecs    = 2;  // how many columns X/Y have
+  scalar_t omega   = 0.9;
+  mag_t tolerance  = 1e-15;  // relative error for solution x vector
 
   // variants to cover
   std::vector<GSAlgorithm> gs_algorithms = {
@@ -200,7 +200,7 @@ void test_block_gauss_seidel_rank1(lno_t numRows, size_type nnz,
 
   lno_t numCols = numRows;
 
-  const GSTestParams<lno_t, scalar_t> params;
+  const GSTestParams<lno_t, scalar_t, mag_t> params;
   lno_t block_size = params.block_size;
 
   crsMat_t crsmat =
@@ -287,7 +287,7 @@ void test_block_gauss_seidel_rank2(lno_t numRows, size_type nnz,
 
   lno_t numCols = numRows;
 
-  const GSTestParams<lno_t, scalar_t> params;
+  const GSTestParams<lno_t, scalar_t, mag_t> params;
   lno_t block_size = params.block_size;
 
   crsMat_t crsmat =

--- a/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
@@ -504,7 +504,7 @@ void test_balloon_clustering(lno_t numRows, size_type nnzPerRow,
 
 template <typename scalar_t, typename lno_t, typename size_type,
           typename device>
-void test_sgs_zero_rows() {
+void test_gauss_seidel_empty() {
   using namespace Test;
   typedef
       typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>
@@ -520,27 +520,29 @@ void test_sgs_zero_rows() {
   // The rowmap of a zero-row matrix can be length 0 or 1, so Gauss-Seidel
   // should work with both (the setup and apply are essentially no-ops but they
   // shouldn't crash or throw exceptions) For this test, create size-0 and
-  // size-1
-  // rowmaps separately, and make sure each work with both point and cluster
+  // size-1 rowmaps separately, and make sure each work with both point and
+  // cluster. Check also 5x5 matrix with empty rows (0-nnz), which can trigger
+  // different bugs.
   for (int doingCluster = 0; doingCluster < 2; doingCluster++) {
-    for (int rowmapLen = 0; rowmapLen < 2; rowmapLen++) {
+    for (const int rowmapLen : {0, 1, 5}) {
       KernelHandle kh;
       if (doingCluster)
         kh.create_gs_handle(CLUSTER_DEFAULT, 10);
       else
         kh.create_gs_handle(GS_DEFAULT);
+      const auto nRows = KOKKOSKERNELS_MACRO_MAX(0, rowmapLen - 1);
       // initialized to 0
       row_map_type rowmap("Rowmap", rowmapLen);
       entries_type entries("Entries", 0);
       scalar_view_t values("Values", 0);
       // also, make sure graph symmetrization doesn't crash on zero rows
-      gauss_seidel_symbolic(&kh, 0, 0, rowmap, entries, false);
-      gauss_seidel_numeric(&kh, 0, 0, rowmap, entries, values, false);
-      scalar_view_t x("X", 0);
-      scalar_view_t y("Y", 0);
+      gauss_seidel_symbolic(&kh, nRows, nRows, rowmap, entries, false);
+      gauss_seidel_numeric(&kh, nRows, nRows, rowmap, entries, values, false);
+      scalar_view_t x("X", nRows);
+      scalar_view_t y("Y", nRows);
       scalar_t omega(0.9);
-      symmetric_gauss_seidel_apply(&kh, 0, 0, rowmap, entries, values, x, y,
-                                   false, true, omega, 3);
+      symmetric_gauss_seidel_apply(&kh, nRows, nRows, rowmap, entries, values,
+                                   x, y, false, true, omega, 3);
       kh.destroy_gs_handle();
     }
   }
@@ -714,8 +716,8 @@ void test_gauss_seidel_custom_coloring(lno_t numRows, lno_t nnzPerRow) {
   }                                                                                            \
   TEST_F(                                                                                      \
       TestCategory,                                                                            \
-      sparse##_##gauss_seidel_zero_rows##_##SCALAR##_##ORDINAL##_##OFFSET##_##DEVICE) {        \
-    test_sgs_zero_rows<SCALAR, ORDINAL, OFFSET, DEVICE>();                                     \
+      sparse##_##gauss_seidel_empty##_##SCALAR##_##ORDINAL##_##OFFSET##_##DEVICE) {            \
+    test_gauss_seidel_empty<SCALAR, ORDINAL, OFFSET, DEVICE>();                                \
   }                                                                                            \
   TEST_F(                                                                                      \
       TestCategory,                                                                            \


### PR DESCRIPTION
### Contents

* [x] Gauss-Seidel variant coverage:
  - [x] `PointGaussSeidel` - numeric and apply;
    - [x] `Get_Matrix_Diagonals`;
    - [x] `Team_PSGS`: `BlockTag` and `BigBlockTag` operators;
* [x] Unit test:
  - [x] run both formats (`BlockCRS` and `BSR`) through the tests;
  - [x] expand test coverage to all GS aplly types;
  - [x] replace implicit 𝜀=1 relative error with 𝜀=1e-15;

> **Note:** Assumed `TwostageGaussSeidel` (`GS_TWOSTAGE`) and `ClusterGaussSeidel` (`GS_CLUSTER`) to be out of scope: two-stage doesn't support blocks (yet?) and cluster seems not to be compatible with blocks at all.

> **Note:** `PSGS` is not executed in block scenario (only in non-block one, with `GS_PERMUTED` algorithm, see `point_apply(...)`). No-tag operator in `Team_PSGS` is only called in non-block scenario and `LongRowTag` operator(s) are not allowed for blocks (symbolic phase fails if long rows are enabled with block).

### Implementation

Gauss-Seidel kernel already supports sparse block computation based on block CRS format, which differs from BSR only in the value ordering in `values` view (`rows` and `entries` views are identical for both formats as they index whole blocks in the same way):
<p align="center">
<img src="https://user-images.githubusercontent.com/29018159/146382644-ac307b4b-4a11-48a4-a331-a02d397da69b.png"
</p>

Because the difference lays only in the indexing method applied to values vector, it's sufficient to make that indexing method a plugin to GS kernel to have it support both formats. The implementation approach proposed on this PR has  `SparseMatrixFormat` tag (`BlockCRS` or `BSR`) provided to GS functions together with `rows`, `entries` and `values` sparse vectors. Based on that tag, GS internally creates and uses `MatrixRowIndex<Format>` to access sparse values. Format tag can be easily deduced from actual matrix type with `MatrixTraits<MatrixType>::format` as in the unit test.

### Alternatives

* Instead of passing sparse `rows`, `entries` and `values` vectors accompanied with matrix format (as `BlockCRS` or `BSR` tag), we could consider passing through Gauss-Seidel interfaces a `CrsMatrix` (`BlockCrsMatrix` ?) or `BsrMatrix` handle, which binds all that necessary information together.
* `MatrixRowIndex<Format>` could be defined in respective matrix headers instead of _KokkosKernels_SparseUtils.hpp_, like row views and `row()` methods in `CrsMatrix` and `BsrMatrix`.
* Row indexing (`MatrixRowIndex<...>`) could be provided to GS kernel directly instead of `SparseMatrixFormat` tag.