### PR TITLE
Do not set Kokkos variables when exporting CMake configuration

### DIFF
--- a/cmake/KokkosKernelsConfig.cmake.in
+++ b/cmake/KokkosKernelsConfig.cmake.in
@@ -9,13 +9,5 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(Kokkos HINTS @Kokkos_DIR@)
 
-SET(Kokkos_ENABLE_OPENMP       @Kokkos_ENABLE_OPENMP@)
-SET(Kokkos_ENABLE_OPENMPTARGET @Kokkos_ENABLE_OPENMPTARGET@)
-SET(Kokkos_ENABLE_CUDA         @Kokkos_ENABLE_CUDA@)
-SET(Kokkos_ENABLE_HIP          @Kokkos_ENABLE_HIP@)
-SET(Kokkos_ENABLE_SYCL         @Kokkos_ENABLE_SYCL@)
-SET(Kokkos_ENABLE_PTHREAD      @Kokkos_ENABLE_PTHREAD@) 
-SET(Kokkos_ENABLE_SERIAL       @Kokkos_ENABLE_SERIAL@)
-
 INCLUDE("${KokkosKernels_CMAKE_DIR}/KokkosKernelsTargets.cmake")
 


### PR DESCRIPTION
It is not legal to define Kokkos variables from KokkosKernels.  These are properly defined from the Kokkos side https://github.com/kokkos/kokkos/blob/ae5fc649ef4b62b48a01123759ed066bff227b43/cmake/KokkosConfigCommon.cmake.in#L9-L11