### PR TITLE
Remove all references to the Kokkos QThreads backend

### DIFF
--- a/src/common/KokkosKernels_ExecSpaceUtils.hpp
+++ b/src/common/KokkosKernels_ExecSpaceUtils.hpp
@@ -56,7 +56,6 @@ enum ExecSpaceType {
   Exec_SERIAL,
   Exec_OMP,
   Exec_PTHREADS,
-  Exec_QTHREADS,
   Exec_CUDA,
   Exec_HIP,
   Exec_SYCL
@@ -100,11 +99,6 @@ KOKKOS_FORCEINLINE_FUNCTION ExecSpaceType kk_get_exec_space_type() {
   }
 #endif
 
-#if defined(KOKKOS_ENABLE_QTHREAD)
-  if (std::is_same<Kokkos::Qthread, ExecutionSpace>::value) {
-    exec_space = Exec_QTHREADS;
-  }
-#endif
   return exec_space;
 }
 
@@ -218,8 +212,7 @@ inline int kk_get_suggested_vector_size(const size_t nr, const size_t nnz,
     default: break;
     case Exec_SERIAL:
     case Exec_OMP:
-    case Exec_PTHREADS:
-    case Exec_QTHREADS: break;
+    case Exec_PTHREADS: break;
     case Exec_CUDA:
     case Exec_HIP:
       if (nr > 0) suggested_vector_size_ = nnz / double(nr) + 0.5;

--- a/src/sparse/KokkosSparse_spgemm_handle.hpp
+++ b/src/sparse/KokkosSparse_spgemm_handle.hpp
@@ -568,16 +568,6 @@ class SPGEMMHandle {
 #endif
     }
 #endif
-
-#if defined(KOKKOS_ENABLE_QTHREAD)
-    if (std::is_same<Kokkos::Qthread, ExecutionSpace>::value) {
-      this->algorithm_type = SPGEMM_SERIAL;
-#ifdef VERBOSE
-      std::cout << "Qthread Execution Space, Default Algorithm: SPGEMM_SERIAL"
-                << std::endl;
-#endif
-    }
-#endif
   }
 
   void set_compression(bool compress_second_matrix_) {

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
@@ -210,10 +210,6 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
       case KokkosKernels::Impl::Exec_PTHREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
 #endif
-#if defined(KOKKOS_ENABLE_QTHREAD)
-      case KokkosKernels::Impl::Exec_QTHREADS:
-        return 0;  // Kokkos does not have a thread_id API for Qthreads
-#endif
 #if defined(KOKKOS_ENABLE_CUDA)
       case KokkosKernels::Impl::Exec_CUDA: return row_index;
 #endif

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
@@ -261,10 +261,6 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
       case KokkosKernels::Impl::Exec_PTHREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
 #endif
-#if defined(KOKKOS_ENABLE_QTHREAD)
-      case KokkosKernels::Impl::Exec_QTHREADS:
-        return 0;  // Kokkos does not have a thread_id API for Qthreads
-#endif
 #if defined(KOKKOS_ENABLE_CUDA)
       case KokkosKernels::Impl::Exec_CUDA: return row_index;
 #endif

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
@@ -125,10 +125,6 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
       case KokkosKernels::Impl::Exec_PTHREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
 #endif
-#if defined(KOKKOS_ENABLE_QTHREAD)
-      case KokkosKernels::Impl::Exec_QTHREADS:
-        return 0;  // Kokkos does not have a thread_id API for Qthreads
-#endif
 #if defined(KOKKOS_ENABLE_CUDA)
       case KokkosKernels::Impl::Exec_CUDA: return row_index;
 #endif

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
@@ -189,10 +189,6 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
       case KokkosKernels::Impl::Exec_PTHREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
 #endif
-#if defined(KOKKOS_ENABLE_QTHREAD)
-      case KokkosKernels::Impl::Exec_QTHREADS:
-        return 0;  // Kokkos does not have a thread_id API for Qthreads
-#endif
 #if defined(KOKKOS_ENABLE_CUDA)
       case KokkosKernels::Impl::Exec_CUDA: return row_index;
 #endif
@@ -745,10 +741,6 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
 #if defined(KOKKOS_ENABLE_THREADS)
       case KokkosKernels::Impl::Exec_PTHREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
-#endif
-#if defined(KOKKOS_ENABLE_QTHREAD)
-      case KokkosKernels::Impl::Exec_QTHREADS:
-        return 0;  // Kokkos does not have a thread_id API for Qthreads
 #endif
 #if defined(KOKKOS_ENABLE_CUDA)
       case KokkosKernels::Impl::Exec_CUDA: return row_index;
@@ -2547,10 +2539,6 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
 #if defined(KOKKOS_ENABLE_THREADS)
       case KokkosKernels::Impl::Exec_PTHREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
-#endif
-#if defined(KOKKOS_ENABLE_QTHREAD)
-      case KokkosKernels::Impl::Exec_QTHREADS:
-        return 0;  // Kokkos does not have a thread_id API for Qthreads
 #endif
 #if defined(KOKKOS_ENABLE_CUDA)
       case KokkosKernels::Impl::Exec_CUDA: return row_index;

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
@@ -200,10 +200,6 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
       case KokkosKernels::Impl::Exec_PTHREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
 #endif
-#if defined(KOKKOS_ENABLE_QTHREAD)
-      case KokkosKernels::Impl::Exec_QTHREADS:
-        return 0;  // Kokkos does not have a thread_id API for Qthreads
-#endif
 #if defined(KOKKOS_ENABLE_CUDA)
       case KokkosKernels::Impl::Exec_CUDA: return row_index;
 #endif

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_triangle_no_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_triangle_no_compression.hpp
@@ -195,10 +195,6 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
       case KokkosKernels::Impl::Exec_PTHREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
 #endif
-#if defined(KOKKOS_ENABLE_QTHREAD)
-      case KokkosKernels::Impl::Exec_QTHREADS:
-        return 0;  // Kokkos does not have a thread_id API for Qthreads
-#endif
 #if defined(KOKKOS_ENABLE_CUDA)
       case KokkosKernels::Impl::Exec_CUDA: return row_index;
 #endif

--- a/src/sparse/impl/KokkosSparse_spgemm_jacobi_denseacc_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_jacobi_denseacc_impl.hpp
@@ -128,10 +128,6 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
       case KokkosKernels::Impl::Exec_PTHREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
 #endif
-#if defined(KOKKOS_ENABLE_QTHREAD)
-      case KokkosKernels::Impl::Exec_QTHREADS:
-        return 0;  // Kokkos does not have a thread_id API for Qthreads
-#endif
     }
   }
 

--- a/src/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
@@ -261,10 +261,6 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
       case KokkosKernels::Impl::Exec_PTHREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
 #endif
-#if defined(KOKKOS_ENABLE_QTHREAD)
-      case KokkosKernels::Impl::Exec_QTHREADS:
-        return 0;  // Kokkos does not have a thread_id API for Qthreads
-#endif
 #if defined(KOKKOS_ENABLE_CUDA)
       case KokkosKernels::Impl::Exec_CUDA: return row_index;
 #endif


### PR DESCRIPTION
The backend was removed in Kokkos 3.1 (see kokkos/kokkos#2738)