### PR TITLE
Improve double buffering batched gemm for matrix sizes >64

### DIFF
--- a/src/batched/KokkosBatched_Util.hpp
+++ b/src/batched/KokkosBatched_Util.hpp
@@ -840,8 +840,7 @@ access_view_bounds_check(ViewType v, int m, int n, const BoundsCheck::No &) {
 template <class ViewType, class SizeType, class ViewValueType, class ScalarType>
 KOKKOS_INLINE_FUNCTION void fma_bounds_check(ViewType v, SizeType m, SizeType n,
                                              ViewValueType reg_c,
-                                             ScalarType alpha,
-                                             ScalarType beta,
+                                             ScalarType alpha, ScalarType beta,
                                              const BoundsCheck::Yes &) {
   if (m < v.extent_int(0) && n < v.extent_int(1))
     v(m, n) = reg_c * alpha + v(m, n) * beta;
@@ -850,24 +849,21 @@ KOKKOS_INLINE_FUNCTION void fma_bounds_check(ViewType v, SizeType m, SizeType n,
 template <class ViewType, class SizeType, class ViewValueType, class ScalarType>
 KOKKOS_INLINE_FUNCTION void fma_bounds_check(ViewType v, SizeType m, SizeType n,
                                              ViewValueType reg_c,
-                                             ScalarType alpha,
-                                             ScalarType beta,
+                                             ScalarType alpha, ScalarType beta,
                                              const BoundsCheck::No &) {
   v(m, n) = reg_c * alpha + v(m, n) * beta;
 }
 
 template <class ViewType, class SizeType, class ScalarType>
 KOKKOS_INLINE_FUNCTION void fma_bounds_check(ViewType v, SizeType m, SizeType n,
-                                             ScalarType reg_c,
-                                             ScalarType alpha,
+                                             ScalarType reg_c, ScalarType alpha,
                                              const BoundsCheck::Yes &) {
   if (m < v.extent_int(0) && n < v.extent_int(1)) v(m, n) = reg_c * alpha;
 }
 
 template <class ViewType, class SizeType, class ScalarType>
 KOKKOS_INLINE_FUNCTION void fma_bounds_check(ViewType v, SizeType m, SizeType n,
-                                             ScalarType reg_c,
-                                             ScalarType alpha,
+                                             ScalarType reg_c, ScalarType alpha,
                                              const BoundsCheck::No &) {
   v(m, n) = reg_c * alpha;
 }

--- a/src/batched/KokkosBatched_Util.hpp
+++ b/src/batched/KokkosBatched_Util.hpp
@@ -840,32 +840,36 @@ access_view_bounds_check(ViewType v, int m, int n, const BoundsCheck::No &) {
 template <class ViewType, class SizeType, class ViewValueType, class ScalarType>
 KOKKOS_INLINE_FUNCTION void fma_bounds_check(ViewType v, SizeType m, SizeType n,
                                              ViewValueType reg_c,
+                                             ScalarType alpha,
                                              ScalarType beta,
                                              const BoundsCheck::Yes &) {
   if (m < v.extent_int(0) && n < v.extent_int(1))
-    v(m, n) = reg_c + v(m, n) * beta;
+    v(m, n) = reg_c * alpha + v(m, n) * beta;
 }
 
 template <class ViewType, class SizeType, class ViewValueType, class ScalarType>
 KOKKOS_INLINE_FUNCTION void fma_bounds_check(ViewType v, SizeType m, SizeType n,
                                              ViewValueType reg_c,
+                                             ScalarType alpha,
                                              ScalarType beta,
                                              const BoundsCheck::No &) {
-  v(m, n) = reg_c + v(m, n) * beta;
+  v(m, n) = reg_c * alpha + v(m, n) * beta;
 }
 
 template <class ViewType, class SizeType, class ScalarType>
 KOKKOS_INLINE_FUNCTION void fma_bounds_check(ViewType v, SizeType m, SizeType n,
                                              ScalarType reg_c,
+                                             ScalarType alpha,
                                              const BoundsCheck::Yes &) {
-  if (m < v.extent_int(0) && n < v.extent_int(1)) v(m, n) = reg_c;
+  if (m < v.extent_int(0) && n < v.extent_int(1)) v(m, n) = reg_c * alpha;
 }
 
 template <class ViewType, class SizeType, class ScalarType>
 KOKKOS_INLINE_FUNCTION void fma_bounds_check(ViewType v, SizeType m, SizeType n,
                                              ScalarType reg_c,
+                                             ScalarType alpha,
                                              const BoundsCheck::No &) {
-  v(m, n) = reg_c;
+  v(m, n) = reg_c * alpha;
 }
 
 }  // namespace KokkosBatched

--- a/src/batched/dense/impl/KokkosBatched_Gemm_DblBuf_Impl.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Gemm_DblBuf_Impl.hpp
@@ -756,8 +756,8 @@ class BatchedDblBufGemm {
 #endif  // KOKKOS_ENABLE_PRAGMA_UNROLL
                       for (int n = 0; n < REG_N; ++n) {
                         int cn = vlane_offset + n * STRIDE_N;
-                        fma_bounds_check(svC, cm, cn, reg_c[m][n], __alpha, __beta,
-                                         __ei.__bounds_check_tag);
+                        fma_bounds_check(svC, cm, cn, reg_c[m][n], __alpha,
+                                         __beta, __ei.__bounds_check_tag);
                       }
                     }
                   }

--- a/src/batched/dense/impl/KokkosBatched_Gemm_DblBuf_Impl.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Gemm_DblBuf_Impl.hpp
@@ -667,7 +667,7 @@ class BatchedDblBufGemm {
 #pragma unroll
 #endif  // KOKKOS_ENABLE_PRAGMA_UNROLL
                         for (int n = 0; n < REG_N; ++n)
-                          reg_c[m][n] += reg_a[m] * reg_b[n] * __alpha;
+                          reg_c[m][n] += reg_a[m] * reg_b[n];
                       }
                     }
 
@@ -725,7 +725,7 @@ class BatchedDblBufGemm {
 #pragma unroll
 #endif  // KOKKOS_ENABLE_PRAGMA_UNROLL
                       for (int n = 0; n < REG_N; ++n)
-                        reg_c[m][n] += reg_a[m] * reg_b[n] * __alpha;
+                        reg_c[m][n] += reg_a[m] * reg_b[n];
                     }
                   }
 
@@ -741,7 +741,7 @@ class BatchedDblBufGemm {
 #endif  // KOKKOS_ENABLE_PRAGMA_UNROLL
                       for (int n = 0; n < REG_N; ++n) {
                         int cn = vlane_offset + n * STRIDE_N;
-                        fma_bounds_check(svC, cm, cn, reg_c[m][n],
+                        fma_bounds_check(svC, cm, cn, reg_c[m][n], __alpha,
                                          __ei.__bounds_check_tag);
                       }
                     }
@@ -756,7 +756,7 @@ class BatchedDblBufGemm {
 #endif  // KOKKOS_ENABLE_PRAGMA_UNROLL
                       for (int n = 0; n < REG_N; ++n) {
                         int cn = vlane_offset + n * STRIDE_N;
-                        fma_bounds_check(svC, cm, cn, reg_c[m][n], __beta,
+                        fma_bounds_check(svC, cm, cn, reg_c[m][n], __alpha, __beta,
                                          __ei.__bounds_check_tag);
                       }
                     }


### PR DESCRIPTION
Not multiplying with alpha in matrix multiplication, but when storing results back to global memory instead.