### PR TITLE
Prune extra dependencies

### DIFF
--- a/src/batched/KokkosBatched_Util.hpp
+++ b/src/batched/KokkosBatched_Util.hpp
@@ -17,13 +17,10 @@
 
 #include <complex>
 
-#include "Kokkos_Core.hpp"
 #include "Kokkos_Complex.hpp"
-#include "Kokkos_ArithTraits.hpp"
-#include "Kokkos_Timer.hpp"
 
 #include "KokkosKernels_config.h"
-#include "KokkosKernels_Utils.hpp"
+#include "KokkosKernels_SimpleUtils.hpp"
 
 // TPL macros
 #if defined(KOKKOSKERNELS_ENABLE_TPL_MKL)


### PR DESCRIPTION
@lucbv @vqd8a

Can we replace _KokkosKernels_Utils.hpp_ include in _KokkosBatched_Util.hpp_ (introduced with 81d7f94f7dd04bfae43a5103cc46a79ee36bc5ef, for `KOKKOSKERNELS_MACRO_MIN()` I assume) with _KokkosKernels_SimpleUtils.hpp_ ?

Pulling in whole set of utilities with _KokkosKernels_Utils.hpp_ blocks other utilities from including _KokkosBatched_Util.hpp_ and can easily lead to circular dependencies issues (e.g. on #1099 I've just hit conflict with: _KokkosKernels_Utils_ → _KokkosKernels_SparseUtils_ → _KokkosKernels_BlockUtils_ (new) → _KokkosBatched_Gemm_Serial_Internal_ → _KokkosBatched_Util.hpp_)

![utils_headers](https://user-images.githubusercontent.com/29018159/147006086-c98e5a5a-0fbc-47a2-a950-a32b7918b559.png)


