### PR TITLE
Restrict BsrMatrix specialization for AMPERE and VOLTA to CUDA

### DIFF
--- a/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -224,7 +224,7 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
     }
 #endif
 
-#if defined(KOKKOS_ARCH_AMPERE)
+#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_ARCH_AMPERE)
     typedef typename XVector::non_const_value_type XScalar;
     typedef typename AMatrix::non_const_value_type AScalar;
     typedef Kokkos::Experimental::half_t Half;
@@ -266,7 +266,7 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
         return;
       }
     }
-#elif defined(KOKKOS_ARCH_VOLTA)
+#elif defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_ARCH_VOLTA)
     /* Volta has float += half * half
        use it for all matrices
     */


### PR DESCRIPTION
This should fix the other nightly build failure, see https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/KokkosKernels/detail/KokkosKernels/366/pipeline.
We also define `CUDA` architectures for `SYCL`, in particular in the SYCL CI that we are running on `NVidia` devices. The class in question, `BsrMatrixSpMVTensorCoreDispatcher`, is only defined for `CUDA+VOLTA` or `CUDA+AMPERE`, see https://github.com/kokkos/kokkos-kernels/blob/6c786cd6900b977e7b3b19a1f88c0c433a49cbcc/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp#L48-L49 but we are missing the check for `CUDA` in the lines changed in this pull request.