### PR TITLE
Refactoring of MKL SpGEMM implementation

### DIFF
--- a/perf_test/sparse/KokkosSparse_spadd.cpp
+++ b/perf_test/sparse/KokkosSparse_spadd.cpp
@@ -47,6 +47,7 @@
 #include "KokkosKernels_Handle.hpp"
 #include "KokkosKernels_IOUtils.hpp"
 #include "KokkosKernels_SparseUtils_cusparse.hpp"
+#include "KokkosKernels_SparseUtils_mkl.hpp"
 #include "KokkosSparse_spadd.hpp"
 #include "KokkosKernels_TestUtils.hpp"
 
@@ -57,21 +58,6 @@
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
 #include <mkl.h>
 #include <mkl_spblas.h>
-
-inline void spadd_mkl_internal_safe_call(sparse_status_t mklStatus,
-                                         const char* name,
-                                         const char* file = nullptr,
-                                         const int line   = 0) {
-  if (SPARSE_STATUS_SUCCESS != mklStatus) {
-    std::ostringstream oss;
-    oss << "MKL call \"" << name << "\" encountered error at " << file << ":"
-        << line << '\n';
-    Kokkos::abort(oss.str().c_str());
-  }
-}
-
-#define SPADD_MKL_SAFE_CALL(call) \
-  spadd_mkl_internal_safe_call(call, #call, __FILE__, __LINE__)
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) &&     \
@@ -259,11 +245,11 @@ void run_experiment(const Params& params) {
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
   sparse_matrix_t Amkl, Bmkl, Cmkl;
   if (params.use_mkl) {
-    SPADD_MKL_SAFE_CALL(mkl_sparse_d_create_csr(
+    MKL_SAFE_CALL(mkl_sparse_d_create_csr(
         &Amkl, SPARSE_INDEX_BASE_ZERO, m, n, (int*)A.graph.row_map.data(),
         (int*)A.graph.row_map.data() + 1, A.graph.entries.data(),
         A.values.data()));
-    SPADD_MKL_SAFE_CALL(mkl_sparse_d_create_csr(
+    MKL_SAFE_CALL(mkl_sparse_d_create_csr(
         &Bmkl, SPARSE_INDEX_BASE_ZERO, m, n, (int*)B.graph.row_map.data(),
         (int*)B.graph.row_map.data() + 1, B.graph.entries.data(),
         B.values.data()));
@@ -326,9 +312,9 @@ void run_experiment(const Params& params) {
 #endif
       } else if (params.use_mkl) {
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
-        SPADD_MKL_SAFE_CALL(mkl_sparse_d_add(SPARSE_OPERATION_NON_TRANSPOSE,
-                                             Amkl, 1.0, Bmkl, &Cmkl));
-        SPADD_MKL_SAFE_CALL(mkl_sparse_destroy(Cmkl));
+        MKL_SAFE_CALL(mkl_sparse_d_add(SPARSE_OPERATION_NON_TRANSPOSE, Amkl,
+                                       1.0, Bmkl, &Cmkl));
+        MKL_SAFE_CALL(mkl_sparse_destroy(Cmkl));
 #endif
       } else {
         spadd_numeric(
@@ -351,8 +337,8 @@ void run_experiment(const Params& params) {
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
   if (params.use_mkl) {
-    SPADD_MKL_SAFE_CALL(mkl_sparse_destroy(Amkl));
-    SPADD_MKL_SAFE_CALL(mkl_sparse_destroy(Bmkl));
+    MKL_SAFE_CALL(mkl_sparse_destroy(Amkl));
+    MKL_SAFE_CALL(mkl_sparse_destroy(Bmkl));
   }
 #endif
 

--- a/src/common/KokkosKernels_SparseUtils_mkl.hpp
+++ b/src/common/KokkosKernels_SparseUtils_mkl.hpp
@@ -1,0 +1,87 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef _KOKKOSKERNELS_SPARSEUTILS_MKL_HPP
+#define _KOKKOSKERNELS_SPARSEUTILS_MKL_HPP
+
+#include "KokkosKernels_config.h"
+
+#ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
+
+#include <mkl.h>
+
+namespace KokkosSparse {
+namespace Impl {
+
+inline void mkl_internal_safe_call(sparse_status_t mkl_status, const char *name,
+                                   const char *file = nullptr,
+                                   const int line   = 0) {
+  if (SPARSE_STATUS_SUCCESS != mkl_status) {
+    std::ostringstream oss;
+    oss << "MKL call \"" << name << "\" encountered error at " << file << ":"
+        << line << '\n';
+    Kokkos::abort(oss.str().c_str());
+  }
+}
+
+#define MKL_SAFE_CALL(call) \
+  KokkosSparse::Impl::mkl_internal_safe_call(call, #call, __FILE__, __LINE__)
+
+inline sparse_operation_t mode_kk_to_mkl(char mode_kk) {
+  switch (toupper(mode_kk)) {
+    case 'N': return SPARSE_OPERATION_NON_TRANSPOSE;
+    case 'T': return SPARSE_OPERATION_TRANSPOSE;
+    case 'H': return SPARSE_OPERATION_CONJUGATE_TRANSPOSE;
+    default:;
+  }
+  throw std::invalid_argument(
+      "Invalid mode for MKL (should be one of N, T, H)");
+}
+
+}  // namespace Impl
+}  // namespace KokkosSparse
+
+#endif  // KOKKOSKERNELS_ENABLE_TPL_MKL
+
+#endif  // _KOKKOSKERNELS_SPARSEUTILS_MKL_HPP

--- a/src/common/KokkosKernels_SparseUtils_mkl.hpp
+++ b/src/common/KokkosKernels_SparseUtils_mkl.hpp
@@ -79,6 +79,85 @@ inline sparse_operation_t mode_kk_to_mkl(char mode_kk) {
       "Invalid mode for MKL (should be one of N, T, H)");
 }
 
+// MKLSparseMatrix provides thin wrapper around MKL matrix handle
+// (sparse_matrix_t) and encapsulates MKL call dispatches related to details
+// like value_type, allowing simple client code in kernels.
+template <typename value_type>
+class MKLSparseMatrix {
+  sparse_matrix_t mtx;
+
+ public:
+  inline MKLSparseMatrix(sparse_matrix_t mtx_) : mtx(mtx_) {}
+
+  // Constructs MKL sparse matrix from KK sparse views (m rows x n cols)
+  inline MKLSparseMatrix(const MKL_INT num_rows, const MKL_INT num_cols,
+                         MKL_INT *xadj, MKL_INT *adj, value_type *values);
+
+  // Allows using MKLSparseMatrix directly in MKL calls
+  inline operator sparse_matrix_t() const { return mtx; }
+
+  // Exports MKL sparse matrix contents into KK views
+  inline void export_data(MKL_INT &num_rows, MKL_INT &num_cols,
+                          MKL_INT *&rows_start, MKL_INT *&columns,
+                          value_type *&values);
+
+  inline void destroy() { MKL_SAFE_CALL(mkl_sparse_destroy(mtx)); }
+};
+
+template <>
+inline MKLSparseMatrix<float>::MKLSparseMatrix(const MKL_INT rows,
+                                               const MKL_INT cols,
+                                               MKL_INT *xadj, MKL_INT *adj,
+                                               float *values) {
+  MKL_SAFE_CALL(mkl_sparse_s_create_csr(&mtx, SPARSE_INDEX_BASE_ZERO, rows,
+                                        cols, xadj, xadj + 1, adj, values));
+}
+
+template <>
+inline MKLSparseMatrix<double>::MKLSparseMatrix(const MKL_INT rows,
+                                                const MKL_INT cols,
+                                                MKL_INT *xadj, MKL_INT *adj,
+                                                double *values) {
+  MKL_SAFE_CALL(mkl_sparse_d_create_csr(&mtx, SPARSE_INDEX_BASE_ZERO, rows,
+                                        cols, xadj, xadj + 1, adj, values));
+}
+
+template <>
+inline void MKLSparseMatrix<float>::export_data(MKL_INT &num_rows,
+                                                MKL_INT &num_cols,
+                                                MKL_INT *&rows_start,
+                                                MKL_INT *&columns,
+                                                float *&values) {
+  sparse_index_base_t indexing;
+  MKL_INT *rows_end;
+  MKL_SAFE_CALL(mkl_sparse_s_export_csr(mtx, &indexing, &num_rows, &num_cols,
+                                        &rows_start, &rows_end, &columns,
+                                        &values));
+  if (SPARSE_INDEX_BASE_ZERO != indexing) {
+    throw std::runtime_error(
+        "Expected zero based indexing in exported MKL sparse matrix\n");
+    return;
+  }
+}
+
+template <>
+inline void MKLSparseMatrix<double>::export_data(MKL_INT &num_rows,
+                                                 MKL_INT &num_cols,
+                                                 MKL_INT *&rows_start,
+                                                 MKL_INT *&columns,
+                                                 double *&values) {
+  sparse_index_base_t indexing;
+  MKL_INT *rows_end;
+  MKL_SAFE_CALL(mkl_sparse_d_export_csr(mtx, &indexing, &num_rows, &num_cols,
+                                        &rows_start, &rows_end, &columns,
+                                        &values));
+  if (SPARSE_INDEX_BASE_ZERO != indexing) {
+    throw std::runtime_error(
+        "Expected zero based indexing in exported MKL sparse matrix\n");
+    return;
+  }
+}
+
 }  // namespace Impl
 }  // namespace KokkosSparse
 

--- a/src/common/KokkosKernels_SparseUtils_mkl.hpp
+++ b/src/common/KokkosKernels_SparseUtils_mkl.hpp
@@ -79,12 +79,24 @@ inline sparse_operation_t mode_kk_to_mkl(char mode_kk) {
       "Invalid mode for MKL (should be one of N, T, H)");
 }
 
+template <typename value_type>
+struct mkl_is_supported_value_type : std::false_type {};
+
+template <>
+struct mkl_is_supported_value_type<float> : std::true_type {};
+template <>
+struct mkl_is_supported_value_type<double> : std::true_type {};
+
 // MKLSparseMatrix provides thin wrapper around MKL matrix handle
 // (sparse_matrix_t) and encapsulates MKL call dispatches related to details
 // like value_type, allowing simple client code in kernels.
 template <typename value_type>
 class MKLSparseMatrix {
   sparse_matrix_t mtx;
+
+  static_assert(mkl_is_supported_value_type<value_type>::value,
+                "Scalar type used in MKLSparseMatrix<value_type> is NOT "
+                "supported by MKL");
 
  public:
   inline MKLSparseMatrix(sparse_matrix_t mtx_) : mtx(mtx_) {}

--- a/src/impl/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/src/impl/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -530,33 +530,13 @@ KOKKOSSPARSE_SPMV_ROCSPARSE(Kokkos::complex<float>, Kokkos::LayoutRight,
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
 #include <mkl.h>
+#include "KokkosKernels_SparseUtils_mkl.hpp"
 
 namespace KokkosSparse {
 namespace Impl {
 
 #if (__INTEL_MKL__ > 2017)
 // MKL 2018 and above: use new interface: sparse_matrix_t and mkl_sparse_?_mv()
-
-// Note 12/03/21 - lbv:
-// mkl_safe_call and mode_kk_to_mkl should
-// be moved to some sparse or mkl utility
-// header. It is likely that these will be
-// reused for other kernels.
-inline void mkl_safe_call(int errcode) {
-  if (errcode != SPARSE_STATUS_SUCCESS)
-    throw std::runtime_error("MKL returned non-success error code");
-}
-
-inline sparse_operation_t mode_kk_to_mkl(char mode_kk) {
-  switch (toupper(mode_kk)) {
-    case 'N': return SPARSE_OPERATION_NON_TRANSPOSE;
-    case 'T': return SPARSE_OPERATION_TRANSPOSE;
-    case 'H': return SPARSE_OPERATION_CONJUGATE_TRANSPOSE;
-    default:;
-  }
-  throw std::invalid_argument(
-      "Invalid mode for MKL (should be one of N, T, H)");
-}
 
 inline void spmv_mkl(sparse_operation_t op, float alpha, float beta, int m,
                      int n, const int* Arowptrs, const int* Aentries,
@@ -566,11 +546,11 @@ inline void spmv_mkl(sparse_operation_t op, float alpha, float beta, int m,
   A_descr.type = SPARSE_MATRIX_TYPE_GENERAL;
   A_descr.mode = SPARSE_FILL_MODE_FULL;
   A_descr.diag = SPARSE_DIAG_NON_UNIT;
-  mkl_safe_call(mkl_sparse_s_create_csr(
+  MKL_SAFE_CALL(mkl_sparse_s_create_csr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, m, n, const_cast<int*>(Arowptrs),
       const_cast<int*>(Arowptrs + 1), const_cast<int*>(Aentries),
       const_cast<float*>(Avalues)));
-  mkl_safe_call(mkl_sparse_s_mv(op, alpha, A_mkl, A_descr, x, beta, y));
+  MKL_SAFE_CALL(mkl_sparse_s_mv(op, alpha, A_mkl, A_descr, x, beta, y));
 }
 
 inline void spmv_mkl(sparse_operation_t op, double alpha, double beta, int m,
@@ -581,11 +561,11 @@ inline void spmv_mkl(sparse_operation_t op, double alpha, double beta, int m,
   A_descr.type = SPARSE_MATRIX_TYPE_GENERAL;
   A_descr.mode = SPARSE_FILL_MODE_FULL;
   A_descr.diag = SPARSE_DIAG_NON_UNIT;
-  mkl_safe_call(mkl_sparse_d_create_csr(
+  MKL_SAFE_CALL(mkl_sparse_d_create_csr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, m, n, const_cast<int*>(Arowptrs),
       const_cast<int*>(Arowptrs + 1), const_cast<int*>(Aentries),
       const_cast<double*>(Avalues)));
-  mkl_safe_call(mkl_sparse_d_mv(op, alpha, A_mkl, A_descr, x, beta, y));
+  MKL_SAFE_CALL(mkl_sparse_d_mv(op, alpha, A_mkl, A_descr, x, beta, y));
 }
 
 inline void spmv_mkl(sparse_operation_t op, Kokkos::complex<float> alpha,
@@ -599,13 +579,13 @@ inline void spmv_mkl(sparse_operation_t op, Kokkos::complex<float> alpha,
   A_descr.type = SPARSE_MATRIX_TYPE_GENERAL;
   A_descr.mode = SPARSE_FILL_MODE_FULL;
   A_descr.diag = SPARSE_DIAG_NON_UNIT;
-  mkl_safe_call(mkl_sparse_c_create_csr(
+  MKL_SAFE_CALL(mkl_sparse_c_create_csr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, m, n, const_cast<int*>(Arowptrs),
       const_cast<int*>(Arowptrs + 1), const_cast<int*>(Aentries),
       (MKL_Complex8*)Avalues));
   MKL_Complex8& alpha_mkl = reinterpret_cast<MKL_Complex8&>(alpha);
   MKL_Complex8& beta_mkl  = reinterpret_cast<MKL_Complex8&>(beta);
-  mkl_safe_call(mkl_sparse_c_mv(op, alpha_mkl, A_mkl, A_descr,
+  MKL_SAFE_CALL(mkl_sparse_c_mv(op, alpha_mkl, A_mkl, A_descr,
                                 reinterpret_cast<const MKL_Complex8*>(x),
                                 beta_mkl, reinterpret_cast<MKL_Complex8*>(y)));
 }
@@ -621,13 +601,13 @@ inline void spmv_mkl(sparse_operation_t op, Kokkos::complex<double> alpha,
   A_descr.type = SPARSE_MATRIX_TYPE_GENERAL;
   A_descr.mode = SPARSE_FILL_MODE_FULL;
   A_descr.diag = SPARSE_DIAG_NON_UNIT;
-  mkl_safe_call(mkl_sparse_z_create_csr(
+  MKL_SAFE_CALL(mkl_sparse_z_create_csr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, m, n, const_cast<int*>(Arowptrs),
       const_cast<int*>(Arowptrs + 1), const_cast<int*>(Aentries),
       (MKL_Complex16*)Avalues));
   MKL_Complex16& alpha_mkl = reinterpret_cast<MKL_Complex16&>(alpha);
   MKL_Complex16& beta_mkl  = reinterpret_cast<MKL_Complex16&>(beta);
-  mkl_safe_call(mkl_sparse_z_mv(op, alpha_mkl, A_mkl, A_descr,
+  MKL_SAFE_CALL(mkl_sparse_z_mv(op, alpha_mkl, A_mkl, A_descr,
                                 reinterpret_cast<const MKL_Complex16*>(x),
                                 beta_mkl, reinterpret_cast<MKL_Complex16*>(y)));
 }

--- a/src/sparse/KokkosSparse_spgemm_numeric.hpp
+++ b/src/sparse/KokkosSparse_spgemm_numeric.hpp
@@ -139,7 +139,9 @@ void spgemm_numeric(KernelHandle *handle,
         "If you need this case please let kokkos-kernels developers know.\n");
   }
 
-  if (m < 1 || n < 1 || k < 1) return;
+  if (m < 1 || n < 1 || k < 1 || entriesA.extent(0) < 1 ||
+      entriesB.extent(0) < 1)
+    return;
 
   typedef typename KernelHandle::const_size_type c_size_t;
   typedef typename KernelHandle::const_nnz_lno_t c_lno_t;

--- a/src/sparse/impl/KokkosSparse_spgemm_mkl2phase_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_mkl2phase_impl.hpp
@@ -302,6 +302,11 @@ void mkl2phase_symbolic(
     (void)transposeA;
     (void)transposeB;
     (void)verbose;
+    (void)a_xadj;
+    (void)b_xadj;
+    (void)c_xadj;
+    (void)a_adj;
+    (void)b_adj;
 #endif
 
   } else {
@@ -351,9 +356,7 @@ void mkl2phase_apply(
       typename KernelHandle::HandlePersistentMemorySpace;
   using int_persistent_work_view_t =
       typename Kokkos::View<int *, HandlePersistentMemorySpace>;
-  using MyExecSpace = typename KernelHandle::HandleExecSpace;
-  using value_type  = typename KernelHandle::nnz_scalar_t;
-  using idx         = typename KernelHandle::nnz_lno_t;
+  using idx = typename KernelHandle::nnz_lno_t;
 
   if (std::is_same<idx, int>::value) {
     int *a_xadj = (int *)row_mapA.data();
@@ -639,6 +642,11 @@ void mkl2phase_apply(
     (void)transposeA;
     (void)transposeB;
     (void)verbose;
+    (void)a_xadj;
+    (void)b_xadj;
+    (void)c_xadj;
+    (void)a_adj;
+    (void)b_adj;
 #endif  // __INTEL_MKL__ == 2018 && __INTEL_MKL_UPDATE__ >= 2
   } else {
     (void)m;

--- a/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
@@ -172,7 +172,8 @@ class MKLApply {
     using scalar_t = typename KernelHandle::nnz_scalar_t;
 
     const auto export_rowmap = [&](MKL_INT m, MKL_INT *rows_start,
-                                   MKL_INT *columns, scalar_t *values) {
+                                   MKL_INT * /*columns*/,
+                                   scalar_t * /*values*/) {
       if (handle->mkl_keep_output) {
         Kokkos::Timer copy_time;
         const nnz_lno_t nnz = rows_start[m];
@@ -204,7 +205,7 @@ class MKLApply {
       a_rowmap_view_type row_mapA, a_index_view_type entriesA,
       a_values_view_type valuesA, bool transposeA, b_rowmap_view_type row_mapB,
       b_index_view_type entriesB, b_values_view_type valuesB, bool transposeB,
-      c_rowmap_view_type row_mapC, c_index_view_type entriesC,
+      c_rowmap_view_type /* row_mapC */, c_index_view_type entriesC,
       c_values_view_type valuesC, bool verbose = false) {
     Kokkos::Timer timer;
 
@@ -234,9 +235,9 @@ class MKLApply {
 
  private:
   template <typename CB>
-  static void apply(KernelHandle *handle, nnz_lno_t m, nnz_lno_t n, nnz_lno_t k,
-                    a_rowmap_view_type row_mapA, a_index_view_type entriesA,
-                    a_values_view_type valuesA,
+  static void apply(KernelHandle * /* handle */, nnz_lno_t m, nnz_lno_t n,
+                    nnz_lno_t k, a_rowmap_view_type row_mapA,
+                    a_index_view_type entriesA, a_values_view_type valuesA,
 
                     bool transposeA, b_rowmap_view_type row_mapB,
                     b_index_view_type entriesB, b_values_view_type valuesB,
@@ -362,6 +363,18 @@ void mkl_symbolic(KernelHandle *handle, nnz_lno_t m, nnz_lno_t n, nnz_lno_t k,
                   c_rowmap_type row_mapC, bool verbose = false) {
 #ifndef KOKKOSKERNELS_ENABLE_TPL_MKL
   throw std::runtime_error("MKL was not enabled in this build!");
+  (void)handle;
+  (void)m;
+  (void)n;
+  (void)k;
+  (void)row_mapA;
+  (void)entriesA;
+  (void)transposeA;
+  (void)row_mapB;
+  (void)entriesB;
+  (void)transposeB;
+  (void)row_mapC;
+  (void)verbose;
 #else
   using values_type  = typename KernelHandle::scalar_temp_work_view_t;
   using c_index_type = b_index_type;
@@ -386,6 +399,22 @@ void mkl_apply(KernelHandle *handle, nnz_lno_t m, nnz_lno_t n, nnz_lno_t k,
                c_values_type valuesC, bool verbose = false) {
 #ifndef KOKKOSKERNELS_ENABLE_TPL_MKL
   throw std::runtime_error("MKL was not enabled in this build!");
+  (void)handle;
+  (void)m;
+  (void)n;
+  (void)k;
+  (void)row_mapA;
+  (void)entriesA;
+  (void)valuesA;
+  (void)transposeA;
+  (void)row_mapB;
+  (void)entriesB;
+  (void)valuesB;
+  (void)transposeB;
+  (void)row_mapC;
+  (void)entriesC;
+  (void)valuesC;
+  (void)verbose;
 #else
   using mkl = MKLApply<KernelHandle, a_rowmap_type, a_index_type, a_values_type,
                        b_rowmap_type, b_index_type, b_values_type,

--- a/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
@@ -341,7 +341,6 @@ class MKLApply {
     auto h_to = Kokkos::create_mirror_view(Kokkos::HostSpace(), to);
     Kokkos::deep_copy(h_to, h_from);  // view copy (for different element types)
     Kokkos::deep_copy(to, h_to);
-    Kokkos::fence();
   }
 
   template <typename T>

--- a/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
@@ -343,11 +343,10 @@ class MKLApply {
     Kokkos::deep_copy(to, h_to);
   }
 
-  template <typename T>
-  inline static decltype(auto) make_host_view(const T *data, size_t num_elems) {
-    using device_type =
-        Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>;
-    return Kokkos::View<const T *, Kokkos::HostSpace>(data, num_elems);
+  template <typename T,
+            typename view_type = Kokkos::View<const T *, Kokkos::HostSpace>>
+  inline static view_type make_host_view(const T *data, size_t num_elems) {
+    return view_type(data, num_elems);
   }
 };
 #endif  // KOKKOSKERNELS_ENABLE_TPL_MKL

--- a/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
@@ -50,12 +50,9 @@
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
 #include "mkl_spblas.h"
-#endif
 
 namespace KokkosSparse {
 namespace Impl {
-
-#ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
 
 // multiplies two sparse MKL matrices and returns sparse MKL matrix
 template <typename value_type>
@@ -276,7 +273,6 @@ class MKL_SPMM {
     return view_type(data, num_elems);
   }
 };
-#endif  // KOKKOSKERNELS_ENABLE_TPL_MKL
 
 template <typename KernelHandle, typename a_rowmap_type, typename a_index_type,
           typename b_rowmap_type, typename b_index_type, typename c_rowmap_type,
@@ -286,21 +282,6 @@ void mkl_symbolic(KernelHandle *handle, nnz_lno_t m, nnz_lno_t n, nnz_lno_t k,
                   bool transposeA, b_rowmap_type row_mapB,
                   b_index_type entriesB, bool transposeB,
                   c_rowmap_type row_mapC, bool verbose = false) {
-#ifndef KOKKOSKERNELS_ENABLE_TPL_MKL
-  throw std::runtime_error("MKL was not enabled in this build!");
-  (void)handle;
-  (void)m;
-  (void)n;
-  (void)k;
-  (void)row_mapA;
-  (void)entriesA;
-  (void)transposeA;
-  (void)row_mapB;
-  (void)entriesB;
-  (void)transposeB;
-  (void)row_mapC;
-  (void)verbose;
-#else
   using values_type  = typename KernelHandle::scalar_temp_work_view_t;
   using c_index_type = b_index_type;
   using mkl = MKL_SPMM<KernelHandle, a_rowmap_type, a_index_type, values_type,
@@ -308,7 +289,6 @@ void mkl_symbolic(KernelHandle *handle, nnz_lno_t m, nnz_lno_t n, nnz_lno_t k,
                        c_index_type, values_type>;
   mkl::mkl_symbolic(handle, m, n, k, row_mapA, entriesA, transposeA, row_mapB,
                     entriesB, transposeB, row_mapC, verbose);
-#endif
 }
 
 template <typename KernelHandle, typename a_rowmap_type, typename a_index_type,
@@ -322,35 +302,16 @@ void mkl_apply(KernelHandle *handle, nnz_lno_t m, nnz_lno_t n, nnz_lno_t k,
                b_index_type entriesB, b_values_type valuesB, bool transposeB,
                c_rowmap_type row_mapC, c_index_type entriesC,
                c_values_type valuesC, bool verbose = false) {
-#ifndef KOKKOSKERNELS_ENABLE_TPL_MKL
-  throw std::runtime_error("MKL was not enabled in this build!");
-  (void)handle;
-  (void)m;
-  (void)n;
-  (void)k;
-  (void)row_mapA;
-  (void)entriesA;
-  (void)valuesA;
-  (void)transposeA;
-  (void)row_mapB;
-  (void)entriesB;
-  (void)valuesB;
-  (void)transposeB;
-  (void)row_mapC;
-  (void)entriesC;
-  (void)valuesC;
-  (void)verbose;
-#else
   using mkl = MKL_SPMM<KernelHandle, a_rowmap_type, a_index_type, a_values_type,
                        b_rowmap_type, b_index_type, b_values_type,
                        c_rowmap_type, c_index_type, c_values_type>;
   mkl::mkl_numeric(handle, m, n, k, row_mapA, entriesA, valuesA, transposeA,
                    row_mapB, entriesB, valuesB, transposeB, row_mapC, entriesC,
                    valuesC, verbose);
-#endif
 }
 
 }  // namespace Impl
 }  // namespace KokkosSparse
 
-#endif
+#endif  // KOKKOSKERNELS_ENABLE_TPL_MKL
+#endif  // _KOKKOSSPGEMMMKL_HPP

--- a/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
@@ -214,8 +214,8 @@ class MKL_SPMM {
     auto h_valsB           = create_mirror(valuesB);
     auto h_entriesA        = create_mirror(entriesA);
     auto h_entriesB        = create_mirror(entriesB);
-    const int *a_adj       = h_entriesA.data();
-    const int *b_adj       = h_entriesB.data();
+    const int *a_adj       = reinterpret_cast<const int *>(h_entriesA.data());
+    const int *b_adj       = reinterpret_cast<const int *>(h_entriesB.data());
     const value_type *a_ew = h_valsA.data();
     const value_type *b_ew = h_valsB.data();
 

--- a/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
@@ -54,8 +54,7 @@ namespace Impl {
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
 
-KOKKOS_INLINE_FUNCTION
-void mkl_call(sparse_status_t result, const char *err_msg) {
+inline void mkl_call(sparse_status_t result, const char *err_msg) {
   if (SPARSE_STATUS_SUCCESS != result) {
     throw std::runtime_error(err_msg);
   }
@@ -66,12 +65,10 @@ class MKLSparseMatrix {
   sparse_matrix_t mtx;
 
  public:
-  KOKKOS_INLINE_FUNCTION
-  MKLSparseMatrix(const MKL_INT m, const MKL_INT n, MKL_INT *xadj, MKL_INT *adj,
-                  value_type *values);
+  inline MKLSparseMatrix(const MKL_INT m, const MKL_INT n, MKL_INT *xadj,
+                         MKL_INT *adj, value_type *values);
 
-  KOKKOS_INLINE_FUNCTION
-  static MKLSparseMatrix<value_type> spmm(
+  inline static MKLSparseMatrix<value_type> spmm(
       sparse_operation_t operation, const MKLSparseMatrix<value_type> &A,
       const MKLSparseMatrix<value_type> &B) {
     sparse_matrix_t c;
@@ -80,44 +77,41 @@ class MKLSparseMatrix {
     return MKLSparseMatrix<value_type>(c);
   }
 
-  KOKKOS_INLINE_FUNCTION
-  void get(MKL_INT &rows, MKL_INT &cols, MKL_INT *&rows_start,
-           MKL_INT *&columns, value_type *&values);
+  inline void get(MKL_INT &rows, MKL_INT &cols, MKL_INT *&rows_start,
+                  MKL_INT *&columns, value_type *&values);
 
-  KOKKOS_INLINE_FUNCTION
-  void destroy() {
+  inline void destroy() {
     mkl_call(mkl_sparse_destroy(mtx), "mkl_sparse_destroy() failed!");
   }
 
  private:
-  KOKKOS_INLINE_FUNCTION
-  MKLSparseMatrix(sparse_matrix_t mtx_) : mtx(mtx_) {}
+  inline MKLSparseMatrix(sparse_matrix_t mtx_) : mtx(mtx_) {}
 };
 
 template <>
-KOKKOS_INLINE_FUNCTION MKLSparseMatrix<float>::MKLSparseMatrix(
-    const MKL_INT rows, const MKL_INT cols, MKL_INT *xadj, MKL_INT *adj,
-    float *values) {
+inline MKLSparseMatrix<float>::MKLSparseMatrix(const MKL_INT rows,
+                                               const MKL_INT cols,
+                                               MKL_INT *xadj, MKL_INT *adj,
+                                               float *values) {
   mkl_call(mkl_sparse_s_create_csr(&mtx, SPARSE_INDEX_BASE_ZERO, rows, cols,
                                    xadj, xadj + 1, adj, values),
            "mkl_sparse_s_create_csr() failed!");
 }
 
 template <>
-KOKKOS_INLINE_FUNCTION MKLSparseMatrix<double>::MKLSparseMatrix(
-    const MKL_INT rows, const MKL_INT cols, MKL_INT *xadj, MKL_INT *adj,
-    double *values) {
+inline MKLSparseMatrix<double>::MKLSparseMatrix(const MKL_INT rows,
+                                                const MKL_INT cols,
+                                                MKL_INT *xadj, MKL_INT *adj,
+                                                double *values) {
   mkl_call(mkl_sparse_d_create_csr(&mtx, SPARSE_INDEX_BASE_ZERO, rows, cols,
                                    xadj, xadj + 1, adj, values),
            "mkl_sparse_d_create_csr() failed!");
 }
 
 template <>
-KOKKOS_INLINE_FUNCTION void MKLSparseMatrix<float>::get(MKL_INT &rows,
-                                                        MKL_INT &cols,
-                                                        MKL_INT *&rows_start,
-                                                        MKL_INT *&columns,
-                                                        float *&values) {
+inline void MKLSparseMatrix<float>::get(MKL_INT &rows, MKL_INT &cols,
+                                        MKL_INT *&rows_start, MKL_INT *&columns,
+                                        float *&values) {
   sparse_index_base_t indexing;
   MKL_INT *rows_end;
   mkl_call(mkl_sparse_s_export_csr(mtx, &indexing, &rows, &cols, &rows_start,
@@ -131,11 +125,9 @@ KOKKOS_INLINE_FUNCTION void MKLSparseMatrix<float>::get(MKL_INT &rows,
 }
 
 template <>
-KOKKOS_INLINE_FUNCTION void MKLSparseMatrix<double>::get(MKL_INT &rows,
-                                                         MKL_INT &cols,
-                                                         MKL_INT *&rows_start,
-                                                         MKL_INT *&columns,
-                                                         double *&values) {
+inline void MKLSparseMatrix<double>::get(MKL_INT &rows, MKL_INT &cols,
+                                         MKL_INT *&rows_start,
+                                         MKL_INT *&columns, double *&values) {
   sparse_index_base_t indexing;
   MKL_INT *rows_end;
   mkl_call(mkl_sparse_d_export_csr(mtx, &indexing, &rows, &cols, &rows_start,
@@ -326,8 +318,7 @@ class MKLApply {
   }
 
   template <typename from_type, typename to_type>
-  KOKKOS_INLINE_FUNCTION static void copy(size_t num_elems, from_type from,
-                                          to_type to) {
+  inline static void copy(size_t num_elems, from_type from, to_type to) {
     KokkosKernels::Impl::copy_vector<from_type, to_type, MyExecSpace>(num_elems,
                                                                       from, to);
   }

--- a/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
@@ -171,14 +171,14 @@ class MKLApply {
     Kokkos::Timer timer;
     using scalar_t = typename KernelHandle::nnz_scalar_t;
 
-    const auto export_rowmap = [&](MKL_INT m, MKL_INT *rows_start,
+    const auto export_rowmap = [&](MKL_INT num_rows, MKL_INT *rows_start,
                                    MKL_INT * /*columns*/,
                                    scalar_t * /*values*/) {
       if (handle->mkl_keep_output) {
         Kokkos::Timer copy_time;
-        const nnz_lno_t nnz = rows_start[m];
+        const nnz_lno_t nnz = rows_start[num_rows];
         handle->set_c_nnz(nnz);
-        copy(make_host_view(rows_start, m + 1), row_mapC);
+        copy(make_host_view(rows_start, num_rows + 1), row_mapC);
         if (verbose)
           std::cout << "\tMKL rowmap export time:" << copy_time.seconds()
                     << std::endl;
@@ -210,11 +210,11 @@ class MKLApply {
     Kokkos::Timer timer;
 
     const auto export_values =
-        [&](MKL_INT m, MKL_INT *rows_start, MKL_INT *columns,
+        [&](MKL_INT num_rows, MKL_INT *rows_start, MKL_INT *columns,
             typename KernelHandle::nnz_scalar_t *values) {
           if (handle->mkl_keep_output) {
             Kokkos::Timer copy_time;
-            const nnz_lno_t nnz = rows_start[m];
+            const nnz_lno_t nnz = rows_start[num_rows];
             copy(make_host_view(columns, nnz), entriesC);
             copy(make_host_view(values, nnz), valuesC);
             if (verbose)

--- a/src/sparse/impl/KokkosSparse_spgemm_numeric_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_numeric_spec.hpp
@@ -245,9 +245,13 @@ struct SPGEMM_NUMERIC<
                                     transposeB, row_mapC, entriesC, valuesC);
         break;
       case SPGEMM_MKL:
+#ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
         mkl_apply(sh, m, n, k, row_mapA, entriesA, valuesA, transposeA,
                   row_mapB, entriesB, valuesB, transposeB, row_mapC, entriesC,
                   valuesC, handle->get_verbose());
+#else
+        throw std::runtime_error("MKL was not enabled in this build!");
+#endif
         break;
       case SPGEMM_MKL2PHASE:
         mkl2phase_apply(sh, m, n, k, row_mapA, entriesA, valuesA, transposeA,

--- a/src/sparse/impl/KokkosSparse_spgemm_symbolic_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_symbolic_spec.hpp
@@ -179,9 +179,13 @@ struct SPGEMM_SYMBOLIC<KernelHandle, a_size_view_t_, a_lno_view_t,
                               row_mapC);
         break;
       case SPGEMM_MKL:
+#ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
         mkl_symbolic(sh, m, n, k, row_mapA, entriesA, transposeA, row_mapB,
                      entriesB, transposeB, row_mapC, handle->get_verbose());
         break;
+#else
+        throw std::runtime_error("MKL was not enabled in this build!");
+#endif
     }
     sh->set_call_symbolic();
   }

--- a/unit_test/sparse/Test_Sparse_spgemm.hpp
+++ b/unit_test/sparse/Test_Sparse_spgemm.hpp
@@ -299,13 +299,12 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth,
 #endif
         break;
 
-      case SPGEMM_MKL:
-        algo = "SPGEMM_MKL";
-        // MKL requires scalar to be either float or double
-        if (!(std::is_same<float, scalar_t>::value ||
-              std::is_same<double, scalar_t>::value)) {
+      case SPGEMM_MKL: algo = "SPGEMM_MKL";
+#ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
+        if (!KokkosSparse::Impl::mkl_is_supported_value_type<scalar_t>::value) {
           is_expected_to_fail = true;
         }
+#endif
         // mkl requires local ordinals to be int.
         if (!(std::is_same<int, lno_t>::value)) {
           is_expected_to_fail = true;

--- a/unit_test/sparse/Test_Sparse_spgemm.hpp
+++ b/unit_test/sparse/Test_Sparse_spgemm.hpp
@@ -315,12 +315,6 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth,
         if (A.values.extent(0) > max_integer) {
           is_expected_to_fail = true;
         }
-
-        if (!(Kokkos::SpaceAccessibility<
-                typename Kokkos::HostSpace::execution_space,
-                typename device::memory_space>::accessible)) {
-          is_expected_to_fail = true;
-        }
         break;
 
       case SPGEMM_KK: algo = "SPGEMM_KK"; break;

--- a/unit_test/sparse/Test_Sparse_spgemm.hpp
+++ b/unit_test/sparse/Test_Sparse_spgemm.hpp
@@ -229,7 +229,7 @@ bool is_same_matrix(crsMat_t output_mat_actual, crsMat_t output_mat_reference) {
 
   typedef typename Kokkos::Details::ArithTraits<
       typename scalar_view_t::non_const_value_type>::mag_type eps_type;
-  eps_type eps = std::is_same<eps_type, float>::value ? 2 * 1e-3 : 1e-7;
+  eps_type eps = std::is_same<eps_type, float>::value ? 3.7e-3 : 1e-7;
 
   is_identical = KokkosKernels::Impl::kk_is_relatively_identical_view<
       scalar_view_t, scalar_view_t, eps_type, typename device::execution_space>(

--- a/unit_test/sparse/Test_Sparse_spgemm.hpp
+++ b/unit_test/sparse/Test_Sparse_spgemm.hpp
@@ -280,7 +280,7 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth,
       SPGEMM_KK_SPEED /* alias SPGEMM_KK_DENSE */
   };
 
-#ifdef HAVE_KOKKOSKERNELS_MKL
+#ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
   algorithms.push_back(SPGEMM_MKL);
 #endif
 


### PR DESCRIPTION
@lucbv @brian-kelley 

While adding BSR matrix support to MKL implementation of SpGEMM on #1215, I decided to employ some preliminary refactoring to avoid [further] code duplication. The refactoring proposed here is based on `MKLSparseMatrix<value_type>` wrapper specialized over scalar type (we support `float` and `double`) to manage MKL calls for different matrix types internally.

### Contents

- [x] General refactoring: spmm code duplication replaced with single entry accompanied with templated utils;
- [x] GPU memory spaces support (can run MKL with CUDA);
- [x] Minor fixes;
- [x] Dedicated MKL utilities header introduced (`src/common/KokkosKernels_SparseUtils_mkl.hpp`);