### PR TITLE
Update SYCL compiler version in CI

### DIFF
--- a/scripts/docker/Dockerfile.sycl
+++ b/scripts/docker/Dockerfile.sycl
@@ -36,8 +36,8 @@ RUN CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSIO
 ENV PATH=${CMAKE_DIR}/bin:$PATH
 
 ENV SYCL_DIR=/opt/sycl
-RUN SYCL_VERSION=20210903 && \
-    SYCL_URL=https://github.com/intel/llvm/archive/sycl-nightly && \
+RUN SYCL_VERSION=2021-09 && \
+    SYCL_URL=https://github.com/intel/llvm/archive && \
     SYCL_ARCHIVE=${SYCL_VERSION}.tar.gz && \
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     wget --quiet ${SYCL_URL}/${SYCL_ARCHIVE} && \


### PR DESCRIPTION
Corresponds to https://github.com/kokkos/kokkos/pull/4631. Just to be able to run the CI again, this also currently includes the changes in #1234.