### PR TITLE
Rename enumerator `Impl::Exec_{PTHREADS -> THREADS}`

### DIFF
--- a/src/common/KokkosKernels_ExecSpaceUtils.hpp
+++ b/src/common/KokkosKernels_ExecSpaceUtils.hpp
@@ -55,7 +55,7 @@ namespace Impl {
 enum ExecSpaceType {
   Exec_SERIAL,
   Exec_OMP,
-  Exec_PTHREADS,
+  Exec_THREADS,
   Exec_CUDA,
   Exec_HIP,
   Exec_SYCL
@@ -71,7 +71,7 @@ KOKKOS_FORCEINLINE_FUNCTION ExecSpaceType kk_get_exec_space_type() {
 
 #if defined(KOKKOS_ENABLE_THREADS)
   if (std::is_same<Kokkos::Threads, ExecutionSpace>::value) {
-    exec_space = Exec_PTHREADS;
+    exec_space = Exec_THREADS;
   }
 #endif
 
@@ -212,7 +212,7 @@ inline int kk_get_suggested_vector_size(const size_t nr, const size_t nnz,
     default: break;
     case Exec_SERIAL:
     case Exec_OMP:
-    case Exec_PTHREADS: break;
+    case Exec_THREADS: break;
     case Exec_CUDA:
     case Exec_HIP:
       if (nr > 0) suggested_vector_size_ = nnz / double(nr) + 0.5;

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
@@ -207,7 +207,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
         return Kokkos::OpenMP::impl_hardware_thread_id();
 #endif
 #if defined(KOKKOS_ENABLE_THREADS)
-      case KokkosKernels::Impl::Exec_PTHREADS:
+      case KokkosKernels::Impl::Exec_THREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
 #endif
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
@@ -258,7 +258,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
         return Kokkos::OpenMP::impl_hardware_thread_id();
 #endif
 #if defined(KOKKOS_ENABLE_THREADS)
-      case KokkosKernels::Impl::Exec_PTHREADS:
+      case KokkosKernels::Impl::Exec_THREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
 #endif
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
@@ -122,7 +122,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
         return Kokkos::OpenMP::impl_hardware_thread_id();
 #endif
 #if defined(KOKKOS_ENABLE_THREADS)
-      case KokkosKernels::Impl::Exec_PTHREADS:
+      case KokkosKernels::Impl::Exec_THREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
 #endif
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
@@ -186,7 +186,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
         return Kokkos::OpenMP::impl_hardware_thread_id();
 #endif
 #if defined(KOKKOS_ENABLE_THREADS)
-      case KokkosKernels::Impl::Exec_PTHREADS:
+      case KokkosKernels::Impl::Exec_THREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
 #endif
 #if defined(KOKKOS_ENABLE_CUDA)
@@ -739,7 +739,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
         return Kokkos::OpenMP::impl_hardware_thread_id();
 #endif
 #if defined(KOKKOS_ENABLE_THREADS)
-      case KokkosKernels::Impl::Exec_PTHREADS:
+      case KokkosKernels::Impl::Exec_THREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
 #endif
 #if defined(KOKKOS_ENABLE_CUDA)
@@ -2537,7 +2537,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
         return Kokkos::OpenMP::impl_hardware_thread_id();
 #endif
 #if defined(KOKKOS_ENABLE_THREADS)
-      case KokkosKernels::Impl::Exec_PTHREADS:
+      case KokkosKernels::Impl::Exec_THREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
 #endif
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
@@ -197,7 +197,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
         return Kokkos::OpenMP::impl_hardware_thread_id();
 #endif
 #if defined(KOKKOS_ENABLE_THREADS)
-      case KokkosKernels::Impl::Exec_PTHREADS:
+      case KokkosKernels::Impl::Exec_THREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
 #endif
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/src/sparse/impl/KokkosSparse_spgemm_impl_triangle_no_compression.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_impl_triangle_no_compression.hpp
@@ -192,7 +192,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
         return Kokkos::OpenMP::impl_hardware_thread_id();
 #endif
 #if defined(KOKKOS_ENABLE_THREADS)
-      case KokkosKernels::Impl::Exec_PTHREADS:
+      case KokkosKernels::Impl::Exec_THREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
 #endif
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/src/sparse/impl/KokkosSparse_spgemm_jacobi_denseacc_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_jacobi_denseacc_impl.hpp
@@ -125,7 +125,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
         return Kokkos::OpenMP::impl_hardware_thread_id();
 #endif
 #if defined(KOKKOS_ENABLE_THREADS)
-      case KokkosKernels::Impl::Exec_PTHREADS:
+      case KokkosKernels::Impl::Exec_THREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
 #endif
     }

--- a/src/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
@@ -258,7 +258,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
         return Kokkos::OpenMP::impl_hardware_thread_id();
 #endif
 #if defined(KOKKOS_ENABLE_THREADS)
-      case KokkosKernels::Impl::Exec_PTHREADS:
+      case KokkosKernels::Impl::Exec_THREADS:
         return Kokkos::Threads::impl_hardware_thread_id();
 #endif
 #if defined(KOKKOS_ENABLE_CUDA)


### PR DESCRIPTION
With that change, `git grep -n -i pthread src/` prints
```
src/common/KokkosKernels_default_types.hpp:94:#elif defined(KOKKOS_ENABLE_PTHREAD) || defined(KOKKOS_ENABLE_THREADS
```
so this finishes cleaning up the change pthread -> threads initiated by Kokkos