### PR TITLE
Fix some typos related to the sparse batched linear solvers

### DIFF
--- a/src/batched/sparse/KokkosBatched_JacobiPrec.hpp
+++ b/src/batched/sparse/KokkosBatched_JacobiPrec.hpp
@@ -146,7 +146,7 @@ class JacobiPrec {
                                     const YViewType &Y) const {
     if (!computed_inverse) this->computeInverse<MemberType, ArgMode>(member);
 
-    KokkosBatched::HadamardProduct<MemberType, ArgTrans>::template invoke<
+    KokkosBatched::HadamardProduct<MemberType, ArgMode>::template invoke<
         ValuesViewType, XViewType, YViewType>(member, diag_values, X, Y);
   }
 };

--- a/src/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
@@ -132,8 +132,8 @@ struct TeamVectorGMRES {
     member.team_barrier();
 
     P.template apply<MemberType, ScratchPadVectorViewType,
-                     ScratchPadVectorViewType, Trans::NoTranspose, Mode::Team,
-                     1>(member, R, R);
+                     ScratchPadVectorViewType, Trans::NoTranspose,
+                     Mode::TeamVector, 1>(member, R, R);
     member.team_barrier();
 
     TeamVectorDot<MemberType>::invoke(member, R, R, beta);

--- a/unit_test/batched/sparse/Test_Batched_TeamCG.hpp
+++ b/unit_test/batched/sparse/Test_Batched_TeamCG.hpp
@@ -64,7 +64,7 @@ struct Functor_TestBatchedTeamCG {
     Kokkos::TeamPolicy<DeviceType> policy(_D.extent(0) / _N_team,
                                           Kokkos::AUTO(), Kokkos::AUTO());
 
-    size_t bytes_0 = ValuesViewType::shmem_size(_N_team, _D.extent(1));
+    size_t bytes_0 = ValuesViewType::shmem_size(_N_team, _X.extent(1));
     size_t bytes_1 = ValuesViewType::shmem_size(_N_team, 1);
     policy.set_scratch_size(0, Kokkos::PerTeam(4 * bytes_0 + 5 * bytes_1));
 

--- a/unit_test/batched/sparse/Test_Batched_TeamGMRES.hpp
+++ b/unit_test/batched/sparse/Test_Batched_TeamGMRES.hpp
@@ -65,7 +65,7 @@ struct Functor_TestBatchedTeamGMRES {
     Kokkos::TeamPolicy<DeviceType> policy(_D.extent(0) / _N_team,
                                           Kokkos::AUTO(), Kokkos::AUTO());
 
-    size_t bytes_0 = ValuesViewType::shmem_size(_N_team, _D.extent(1));
+    size_t bytes_0 = ValuesViewType::shmem_size(_N_team, _X.extent(1));
     size_t bytes_1 = ValuesViewType::shmem_size(_N_team, 1);
 
     handle.set_max_iteration(10);

--- a/unit_test/batched/sparse/Test_Batched_TeamVectorCG.hpp
+++ b/unit_test/batched/sparse/Test_Batched_TeamVectorCG.hpp
@@ -64,7 +64,7 @@ struct Functor_TestBatchedTeamVectorCG {
     Kokkos::TeamPolicy<DeviceType> policy(_D.extent(0) / _N_team,
                                           Kokkos::AUTO(), Kokkos::AUTO());
 
-    size_t bytes_0 = ValuesViewType::shmem_size(_N_team, _D.extent(1));
+    size_t bytes_0 = ValuesViewType::shmem_size(_N_team, _X.extent(1));
     size_t bytes_1 = ValuesViewType::shmem_size(_N_team, 1);
     policy.set_scratch_size(0, Kokkos::PerTeam(4 * bytes_0 + 5 * bytes_1));
 

--- a/unit_test/batched/sparse/Test_Batched_TeamVectorGMRES.hpp
+++ b/unit_test/batched/sparse/Test_Batched_TeamVectorGMRES.hpp
@@ -22,7 +22,7 @@ struct Functor_TestBatchedTeamVectorGMRES {
   const IntView _c;
   const VectorViewType _X;
   const VectorViewType _B;
-  const ValuesViewType _Diag;
+  const VectorViewType _Diag;
   const int _N_team;
   KrylovHandle<typename ValuesViewType::value_type> handle;
 
@@ -72,7 +72,7 @@ struct Functor_TestBatchedTeamVectorGMRES {
     Kokkos::TeamPolicy<DeviceType> policy(_D.extent(0) / _N_team,
                                           Kokkos::AUTO(), Kokkos::AUTO());
 
-    size_t bytes_0 = ValuesViewType::shmem_size(_N_team, _D.extent(1));
+    size_t bytes_0 = ValuesViewType::shmem_size(_N_team, _X.extent(1));
     size_t bytes_1 = ValuesViewType::shmem_size(_N_team, 1);
 
     handle.set_max_iteration(10);


### PR DESCRIPTION
This commit fixes some typos in the TeamVector GMRES, in the preconditioner, and in the unit tests.

@srajama1 @lucbv 