### PR TITLE
src/batched: Use SerialOpt2 for 33 to 39 square matrices

### DIFF
--- a/src/batched/dense/KokkosBatched_Gemm_Decl.hpp
+++ b/src/batched/dense/KokkosBatched_Gemm_Decl.hpp
@@ -468,8 +468,7 @@ int BatchedGemm(BatchedGemmHandleType *const handle, const ScalarType alpha,
       // } else
       if (on_gpu && ((std::is_same<layout_type, Kokkos::LayoutLeft>::value)
                          ? (c_m >= 16)
-                         : (c_m >= 24))) {  // Vinh's note: use this condition
-                                            // for now, might need to revisit
+                         : (c_m >= 24 && c_m <= 32) || c_m >= 40)) {
         handle->teamSz = handle->vecLen = 8;
         constexpr int tile_m = 32, tile_n = 32, tile_k = 8;
 #ifdef __CUDACC_RDC__


### PR DESCRIPTION
Based on the data collection done yesterday, this condition update gives produces the best performance.
## Before this change

square matrix dims|KokkosLL|KokkosLR
| ----------- | ----------- | ----------- |
30|1058.316667|1271.95
32|1468.17|1577.553333
34|611.2006667|738.5043333
36|684.4183333|839.801
38|762.6296667|933.2223333
40|850.706|1046.363333

## After this change

square matrix dims|KokkosLL|KokkosLR
| ----------- | ----------- | ----------- |
30|1055.953333|1276.933333
32|1467.28|1578.036667
34|610.9443333|924.128
36|687.4673333|998.7813333
38|760.513|949.824
40|848.4526667|1049.49
