### PR TITLE
Do not use deprecated algorithm `std::random_shuffle`

### DIFF
--- a/perf_test/sparse/KokkosSparse_gs.cpp
+++ b/perf_test/sparse/KokkosSparse_gs.cpp
@@ -119,7 +119,8 @@ crsMat_t generateLongRowMatrix(const GS_Parameters& params) {
     } else
       rowLengths.push_back(params.nnzPerRow);
   }
-  std::random_shuffle(rowLengths.begin(), rowLengths.end());
+  std::default_random_engine generator;
+  std::shuffle(rowLengths.begin(), rowLengths.end(), generator);
   size_type totalEntries = 0;
   int randSteps          = 1000000;
   // Set of columns inserted so far into current short row
@@ -133,7 +134,7 @@ crsMat_t generateLongRowMatrix(const GS_Parameters& params) {
     shortRowEntries.clear();
     bool rowIsLong = rowLengths[i] > params.nnzPerRow;
     if (rowIsLong)
-      std::random_shuffle(longRowEntries.begin(), longRowEntries.end());
+      std::shuffle(longRowEntries.begin(), longRowEntries.end(), generator);
     for (lno_t ent = 0; ent < rowLengths[i]; ent++) {
       if (ent == 0) {
         entries.push_back(i);

--- a/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
+++ b/unit_test/sparse/Test_Sparse_gauss_seidel.hpp
@@ -57,6 +57,7 @@
 #include <complex>
 #include <map>
 #include <vector>
+#include <random>
 #include "KokkosSparse_gauss_seidel.hpp"
 #include "KokkosSparse_partitioning_impl.hpp"
 #include "KokkosSparse_sor_sequential_impl.hpp"
@@ -569,7 +570,8 @@ void test_gauss_seidel_long_rows(lno_t numRows, lno_t numLongRows,
     else
       rowLengths.push_back(nnzPerShortRow);
   }
-  std::random_shuffle(rowLengths.begin(), rowLengths.end());
+  std::default_random_engine generator;
+  std::shuffle(rowLengths.begin(), rowLengths.end(), generator);
   size_type totalEntries = 0;
   int randSteps          = 1000000;
   scalar_t offDiagBase;

--- a/unit_test/sparse/Test_Sparse_spadd.hpp
+++ b/unit_test/sparse/Test_Sparse_spadd.hpp
@@ -9,7 +9,7 @@
 #include <KokkosKernels_IOUtils.hpp>
 #include <KokkosKernels_Utils.hpp>
 
-#include <algorithm>    //for std::random_shuffle
+#include <algorithm>    //for std::shuffle
 #include <random>       // for std::default_random_engine
 #include <cstdlib>      //for rand
 #include <type_traits>  //for std::is_same


### PR DESCRIPTION
`std::random_shuffle` is deprecated since `C++14` and removed in `C++17`