### PR TITLE
Avoid using `#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_*` macro guards

### DIFF
--- a/src/Kokkos_InnerProductSpaceTraits.hpp
+++ b/src/Kokkos_InnerProductSpaceTraits.hpp
@@ -171,7 +171,6 @@ class InnerProductSpaceTraits {
 /// \brief Partial specialization for long double.
 ///
 /// \warning CUDA does not support long double in device functions.
-#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
 template <>
 struct InnerProductSpaceTraits<long double> {
   typedef long double val_type;
@@ -183,7 +182,6 @@ struct InnerProductSpaceTraits<long double> {
   }
   static dot_type dot(const val_type& x, const val_type& y) { return x * y; }
 };
-#endif
 
 //! Partial specialization for Kokkos::complex<T>.
 template <class T>

--- a/src/batched/dense/impl/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
@@ -82,6 +82,22 @@ struct SerialEigendecompositionInternal {
 
     //       /// step 1: Hessenberg reduction A = Q H Q^H
     //       ///         Q is stored in QZ
+    //
+    ////////////////////////////////////////////////////////////////////////////
+    // DO NOT USE
+    //
+    //     #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+    //     <host code>
+    //     #else
+    //     <device code>
+    //     #endif
+    //
+    // DO THIS INSTEAD
+    //
+    //     KOKKOS_IF_HOST((<host code>))
+    //     KOKKOS_IF_DEVICE((<device code>))
+    //
+    ////////////////////////////////////////////////////////////////////////////
     // #if (defined(KOKKOSKERNELS_ENABLE_TPL_MKL) && (__INTEL_MKL__ >= 2018)) &&
     // defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
     //       {

--- a/src/batched/dense/impl/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
@@ -357,7 +357,15 @@ struct SerialEigendecompositionInternal {
       const int ers, RealType* ei, const int eis, RealType* UL, const int uls0,
       const int uls1, RealType* UR, const int urs0, const int urs1, RealType* w,
       const int wlen) {
-#if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
+#if defined(KOKKOS_IF_HOST)
+    KOKKOS_IF_HOST((host_invoke(m, A, as0, as1, er, ers, ei, eis, UL, uls0,
+                                uls1, UR, urs0, urs1, w, wlen);))
+    KOKKOS_IF_DEVICE((device_invoke(m, A, as0, as1, er, ers, ei, eis, UL, uls0,
+                                    uls1, UR, urs0, urs1, w, wlen);))
+#elif defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)  // FIXME remove when
+                                                          // requiring minimum
+                                                          // version of
+                                                          // Kokkos 3.6
     // if (as0 == 1 || as1 == 1) {
     /// column major or row major and it runs on host
     /// potentially it can run tpls internally

--- a/src/batched/dense/impl/KokkosBatched_Eigendecomposition_TeamVector_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Eigendecomposition_TeamVector_Internal.hpp
@@ -67,6 +67,19 @@ struct TeamVectorEigendecompositionInternal {
     static_assert(false,
                   "TeamVector eigendecomposition is not implemented yet.");
     /*
+    // DO NOT USE
+    //
+    //     #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+    //     <host code>
+    //     #else
+    //     <device code>
+    //     #endif
+    //
+    // DO THIS INSTEAD
+    //
+    //     KOKKOS_IF_HOST((<host code>))
+    //     KOKKOS_IF_DEVICE((<device code>))
+    //
 #if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
     if (as0 == 1 || as1 == 1) {
       /// column major or row major and it runs on host


### PR DESCRIPTION
See kokkos/kokkos#4668

Replace uses of `#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_*` macro guards that are not in `<Kokkos_ArithTraits.hpp>`

I do not intend to change `Kokkos::[Details::]ArithTraits` as part of this pull request.  I expect this will be fixed as part of its refactoring (see #870)