### PR TITLE
Changes to make graph run on SYCL

### DIFF
--- a/src/graph/KokkosGraph_Distance1ColorHandle.hpp
+++ b/src/graph/KokkosGraph_Distance1ColorHandle.hpp
@@ -260,6 +260,13 @@ class GraphColoringHandle {
       std::cout
           << "Serial Execution Space, Default Algorithm: COLORING_SERIAL\n";
 #endif
+    } else if (exec == KokkosKernels::Impl::Exec_SYCL) {
+      // FIXME SYCL: Do not use EB
+      this->coloring_algorithm_type = COLORING_VBBIT;
+#ifdef VERBOSE
+      std::cout << ExecutionSpace::name()
+                << " Execution Space, Default Algorithm: COLORING_VBBIT\n";
+#endif
     } else if (KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>()) {
       this->coloring_algorithm_type = COLORING_EB;
 #ifdef VERBOSE
@@ -267,10 +274,10 @@ class GraphColoringHandle {
                 << " Execution Space, Default Algorithm: COLORING_EB\n";
 #endif
     } else {
-      this->coloring_algorithm_type = COLORING_VB;
+      this->coloring_algorithm_type = COLORING_VBBIT;
 #ifdef VERBOSE
       std::cout << ExecutionSpace::name()
-                << " Execution Space, Default Algorithm: COLORING_VB\n";
+                << " Execution Space, Default Algorithm: COLORING_VBBIT\n";
 #endif
     }
   }
@@ -499,7 +506,8 @@ class GraphColoringHandle {
             new_num_edge);
         Kokkos::parallel_for(
             "KokkosGraph::FillLowerTriangleTeam",
-            team_policy_t(nv / teamSizeMax + 1, teamSizeMax, vector_size),
+            team_policy_t((nv + teamSizeMax - 1) / teamSizeMax, teamSizeMax,
+                          vector_size),
             FillLowerTriangleTeam<row_index_view_type, nonzero_view_type,
                                   size_type_temp_work_view_t,
                                   nnz_lno_persistent_work_view_t>(

--- a/src/graph/impl/KokkosGraph_Distance1Color_impl.hpp
+++ b/src/graph/impl/KokkosGraph_Distance1Color_impl.hpp
@@ -2198,6 +2198,7 @@ template <typename HandleType, typename in_row_index_view_type_,
           typename in_nonzero_index_view_type_>
 class GraphColor_EB : public GraphColor<HandleType, in_row_index_view_type_,
                                         in_nonzero_index_view_type_> {
+  // FIXME SYCL: This does not work, returns colors with conflicts.
  public:
   typedef long long int ban_type;
 

--- a/unit_test/graph/Test_Graph_graph_color.hpp
+++ b/unit_test/graph/Test_Graph_graph_color.hpp
@@ -144,6 +144,7 @@ void test_coloring(lno_t numRows, size_type nnz, lno_t bandwidth,
   coloring_algorithms.push_back(COLORING_VBD);
 #endif
 
+  // FIXME SYCL: re-enable this when EB is working
 #ifdef KOKKOS_ENABLE_SYCL
   if (!std::is_same<typename device::execution_space,
                     Kokkos::Experimental::SYCL>::value) {

--- a/unit_test/graph/Test_Graph_graph_color.hpp
+++ b/unit_test/graph/Test_Graph_graph_color.hpp
@@ -133,8 +133,8 @@ void test_coloring(lno_t numRows, size_type nnz, lno_t bandwidth,
   input_mat = crsMat_t("CrsMatrix", numCols, newValues, static_graph);
 
   std::vector<ColoringAlgorithm> coloring_algorithms = {
-      COLORING_DEFAULT, COLORING_SERIAL, COLORING_VB,
-      COLORING_VBBIT,   COLORING_VBCS,   COLORING_EB};
+      COLORING_DEFAULT, COLORING_SERIAL, COLORING_VB, COLORING_VBBIT,
+      COLORING_VBCS};
 
 #ifdef KOKKOS_ENABLE_CUDA
   if (!std::is_same<typename device::execution_space, Kokkos::Cuda>::value) {
@@ -142,6 +142,15 @@ void test_coloring(lno_t numRows, size_type nnz, lno_t bandwidth,
   }
 #else
   coloring_algorithms.push_back(COLORING_VBD);
+#endif
+
+#ifdef KOKKOS_ENABLE_SYCL
+  if (!std::is_same<typename device::execution_space,
+                    Kokkos::Experimental::SYCL>::value) {
+    coloring_algorithms.push_back(COLORING_EB);
+  }
+#else
+  coloring_algorithms.push_back(COLORING_EB);
 #endif
 
   for (size_t ii = 0; ii < coloring_algorithms.size(); ++ii) {

--- a/unit_test/graph/Test_Graph_graph_color_distance2.hpp
+++ b/unit_test/graph/Test_Graph_graph_color_distance2.hpp
@@ -381,14 +381,11 @@ EXECUTE_TEST(double, int, int, TestExecSpace)
 EXECUTE_TEST(double, int64_t, int, TestExecSpace)
 #endif
 
-// FIXME_SYCL
-#ifndef KOKKOS_ENABLE_SYCL
 #if (defined(KOKKOSKERNELS_INST_ORDINAL_INT) &&    \
      defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&           \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 EXECUTE_TEST(double, int, size_t, TestExecSpace)
-#endif
 #endif
 
 #if (defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T) && \

--- a/unit_test/graph/Test_Graph_mis2.hpp
+++ b/unit_test/graph/Test_Graph_mis2.hpp
@@ -296,8 +296,6 @@ void test_mis2_coarsening_zero_rows() {
     test_mis2_coarsening_zero_rows<SCALAR, ORDINAL, OFFSET, DEVICE>();                \
   }
 
-// FIXME_SYCL
-#ifndef KOKKOS_ENABLE_SYCL
 #if defined(KOKKOSKERNELS_INST_DOUBLE)
 #if (defined(KOKKOSKERNELS_INST_ORDINAL_INT) && \
      defined(KOKKOSKERNELS_INST_OFFSET_INT)) || \
@@ -326,7 +324,6 @@ EXECUTE_TEST(double, int, size_t, TestExecSpace)
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&            \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 EXECUTE_TEST(double, int64_t, size_t, TestExecSpace)
-#endif
 #endif
 
 #undef EXECUTE_TEST


### PR DESCRIPTION
(except EB coloring - VBBIT is used as the default algo
instead and EB is disabled in the test for now)