### PR TITLE
Full Blas support on SYCL

### DIFF
--- a/src/blas/impl/KokkosBlas3_gemm_spec.hpp
+++ b/src/blas/impl/KokkosBlas3_gemm_spec.hpp
@@ -196,7 +196,10 @@ struct GEMM {
                        24000)
                           ? 4
                           : 16;
-      static constexpr int vector_length = blockB1 / 4;
+      int vector_length     = blockB1 / 4;
+      int max_vector_length = KokkosKernels::Impl::kk_get_max_vector_size<
+          typename CViewType::execution_space>();
+      if (vector_length > max_vector_length) vector_length = max_vector_length;
 
       // Compute scratch space size
       typedef KokkosBlas::Impl::GEMMImpl<typename CViewType::execution_space,
@@ -224,6 +227,11 @@ struct GEMM {
 #if defined(KOKKOS_ENABLE_ROCM)
       if (std::is_same<typename CViewType::execution_space,
                        Kokkos::ROCm>::value)
+        team_size = blockA0;
+#endif
+#if defined(KOKKOS_ENABLE_SYCL)
+      if (std::is_same<typename CViewType::execution_space,
+                       Kokkos::Experimental::SYCL>::value)
         team_size = blockA0;
 #endif
 

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -238,7 +238,8 @@ struct Functor_BatchedVanillaGEMM {
     Kokkos::parallel_for(
         "Test::VanillaGEMM",
         Kokkos::TeamPolicy<ExecutionSpace>(
-            batch_size_last_dim ? C.extent(2) : C.extent(0), Kokkos::AUTO, 16),
+            batch_size_last_dim ? C.extent(2) : C.extent(0), Kokkos::AUTO,
+            KokkosKernels::Impl::kk_get_max_vector_size<ExecutionSpace>()),
         *this);
   }
 };

--- a/unit_test/blas/Test_Blas1_iamax.hpp
+++ b/unit_test/blas/Test_Blas1_iamax.hpp
@@ -288,8 +288,6 @@ TEST_F(TestCategory, iamax_mv_float) {
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&  \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-// FIXME_SYCL
-#ifndef KOKKOS_ENABLE_SYCL
 TEST_F(TestCategory, iamax_double) {
   Kokkos::Profiling::pushRegion("KokkosBlas::Test::iamax_double");
   test_iamax<double, TestExecSpace>();
@@ -300,7 +298,6 @@ TEST_F(TestCategory, iamax_mv_double) {
   test_iamax_mv<double, TestExecSpace>();
   Kokkos::Profiling::popRegion();
 }
-#endif
 #endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || \

--- a/unit_test/blas/Test_Blas2_gemv.hpp
+++ b/unit_test/blas/Test_Blas2_gemv.hpp
@@ -237,8 +237,6 @@ TEST_F(TestCategory, gemv_float) {
 }
 #endif
 
-// FIXME_SYCL Warp Invalid Address Space.
-#ifndef KOKKOS_ENABLE_SYCL
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&  \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -251,7 +249,6 @@ TEST_F(TestCategory, gemv_double) {
   test_gemv<double, double, double, TestExecSpace>("T");
   Kokkos::Profiling::popRegion();
 }
-#endif
 #endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || \

--- a/unit_test/blas/Test_Blas3_trmm.hpp
+++ b/unit_test/blas/Test_Blas3_trmm.hpp
@@ -170,9 +170,12 @@ void impl_test_trmm(const char* side, const char* uplo, const char* trans,
   vgemm.C     = B_expected;  // out
   vgemm.alpha = alpha;
   vgemm.beta  = beta;
-  Kokkos::parallel_for("KokkosBlas::Test::trmm_VanillaGEMM",
-                       Kokkos::TeamPolicy<execution_space>(M, Kokkos::AUTO, 16),
-                       vgemm);
+  Kokkos::parallel_for(
+      "KokkosBlas::Test::trmm_VanillaGEMM",
+      Kokkos::TeamPolicy<execution_space>(
+          M, Kokkos::AUTO,
+          KokkosKernels::Impl::kk_get_max_vector_size<execution_space>()),
+      vgemm);
   Kokkos::fence();
   Kokkos::deep_copy(host_B_expected, B_expected);
 

--- a/unit_test/blas/Test_Blas3_trsm.hpp
+++ b/unit_test/blas/Test_Blas3_trsm.hpp
@@ -169,9 +169,12 @@ void impl_test_trsm(const char* side, const char* uplo, const char* trans,
   vgemm.C     = B;
   vgemm.alpha = alpha_trmm;
   vgemm.beta  = beta;
-  Kokkos::parallel_for("KokkosBlas::Test::trsm_VanillaGEMM",
-                       Kokkos::TeamPolicy<execution_space>(M, Kokkos::AUTO, 16),
-                       vgemm);
+  Kokkos::parallel_for(
+      "KokkosBlas::Test::trsm_VanillaGEMM",
+      Kokkos::TeamPolicy<execution_space>(
+          M, Kokkos::AUTO,
+          KokkosKernels::Impl::kk_get_max_vector_size<execution_space>()),
+      vgemm);
   Kokkos::fence();
 
   KokkosBlas::trsm(side, uplo, trans, diag, alpha, A, B);

--- a/unit_test/blas/Test_Blas_trtri.hpp
+++ b/unit_test/blas/Test_Blas_trtri.hpp
@@ -210,9 +210,12 @@ int impl_test_trtri(int bad_diag_idx, const char* uplo, const char* diag,
   vgemm.C     = A_I;  // out
   vgemm.alpha = ScalarA(1);
   vgemm.beta  = beta;
-  Kokkos::parallel_for("KokkosBlas::Test::VanillaGEMM",
-                       Kokkos::TeamPolicy<execution_space>(M, Kokkos::AUTO, 16),
-                       vgemm);
+  Kokkos::parallel_for(
+      "KokkosBlas::Test::VanillaGEMM",
+      Kokkos::TeamPolicy<execution_space>(
+          M, Kokkos::AUTO,
+          KokkosKernels::Impl::kk_get_max_vector_size<execution_space>()),
+      vgemm);
   Kokkos::fence();
   Kokkos::deep_copy(host_I, A_I);
 


### PR DESCRIPTION
Enable all Blas tests for SYCL and get them working

This just involves 2 workarounds: GEMV to deal with
team_size_recommended coming back with a number that's too large for
the LayoutLeft kernel, and using a maximum vector length of 8 for SYCL.

Note: this PR has the same changes to ExecSpaceUtils as https://github.com/kokkos/kokkos-kernels/pull/1269