### PR TITLE
Fix some warnings

### DIFF
--- a/perf_test/blas/blas3/KokkosBlas3_gemm_perf_test.hpp
+++ b/perf_test/blas/blas3/KokkosBlas3_gemm_perf_test.hpp
@@ -2353,9 +2353,8 @@ void do_gemm_serial_batched_compact_mkl_parallel(options_t options) {
   return;
 }
 #else
-void do_gemm_serial_batched_compact_mkl_parallel(options_t options) {
+void do_gemm_serial_batched_compact_mkl_parallel(options_t) {
   STATUS;
-  options.use_simd = true;
 #if !defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL__)
   std::cerr
       << std::string(__func__)

--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -1450,7 +1450,6 @@ class ArithTraits<double> {
 // CUDA and HIP do not support long double in device functions,
 // so none of the class methods in this specialization are marked
 // as device functions.
-#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
 template <>
 class ArithTraits<long double> {
  public:
@@ -1532,8 +1531,7 @@ class ArithTraits<long double> {
   static mag_type rmin() { return LDBL_MIN; }
   static int emax() { return LDBL_MAX_EXP; }
   static mag_type rmax() { return LDBL_MAX; }
-};      // long double specialization
-#endif  // KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+};  // long double specialization
 
 #ifdef HAVE_KOKKOSKERNELS_QUADMATH
 

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -434,27 +434,27 @@ struct SharedParamTag {
 
 /// \brief value_type_name returns a string with the value type name
 template <typename T>
-KOKKOS_INLINE_FUNCTION std::string value_type_name() {
+std::string value_type_name() {
   return "::UnknownValueType";
 }
 
 template <>
-KOKKOS_INLINE_FUNCTION std::string value_type_name<float>() {
+std::string value_type_name<float>() {
   return "::Float";
 }
 
 template <>
-KOKKOS_INLINE_FUNCTION std::string value_type_name<double>() {
+std::string value_type_name<double>() {
   return "::Double";
 }
 
 template <>
-KOKKOS_INLINE_FUNCTION std::string value_type_name<Kokkos::complex<float>>() {
+std::string value_type_name<Kokkos::complex<float>>() {
   return "::ComplexFloat";
 }
 
 template <>
-KOKKOS_INLINE_FUNCTION std::string value_type_name<Kokkos::complex<double>>() {
+std::string value_type_name<Kokkos::complex<double>>() {
   return "::ComplexDouble";
 }
 }  // namespace Test


### PR DESCRIPTION
- Fix ``ArithTraits<long double>::abs`` was referenced but not defined
- Fix ``cannot call __host__ function from __host__ __device__ function``.
  ``value_type_name<T>`` uses ``std::string`` and should only be used on host.
- Fix unused named parameter in gemm perf test