### PR TITLE
Rename `KOKKOS_IF_{HOST,DEVICE} -> KOKKOS_IF_ON_{HOST,DEVICE}`

### DIFF
--- a/src/batched/KokkosBatched_Util.hpp
+++ b/src/batched/KokkosBatched_Util.hpp
@@ -368,7 +368,7 @@ struct Algo {
       // - space (gpu vs host)
       // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
 #if defined(KOKKOS_IF_ON_HOST)
-      static constexpr KOKKKOS_FUNCTION int mb() {
+      static constexpr KOKKOS_FUNCTION int mb() {
         KOKKOS_IF_ON_HOST((return 4;))
         KOKKOS_IF_ON_DEVICE((return 2;))
       }
@@ -418,7 +418,7 @@ struct Algo {
       // - space (cuda vs host)
       // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
 #if defined(KOKKOS_IF_ON_HOST)
-      static constexpr KOKKKOS_FUNCTION int mb() {
+      static constexpr KOKKOS_FUNCTION int mb() {
         KOKKOS_IF_ON_HOST((return 4;))
         KOKKOS_IF_ON_DEVICE((return 1;))
       }

--- a/src/batched/KokkosBatched_Util.hpp
+++ b/src/batched/KokkosBatched_Util.hpp
@@ -300,7 +300,7 @@ struct Mode {
   };
 };
 
-#if !defined(KOKKOS_IF_HOST)
+#if !defined(KOKKOS_IF_ON_HOST)
 
 template <class>
 struct algo_level3_blocked_mb_impl;
@@ -367,10 +367,10 @@ struct Algo {
       // - team policy (smaller) or range policy (bigger)
       // - space (gpu vs host)
       // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
-#if defined(KOKKOS_IF_HOST)
+#if defined(KOKKOS_IF_ON_HOST)
       static constexpr KOKKKOS_FUNCTION int mb() {
-        KOKKOS_IF_HOST((return 4;))
-        KOKKOS_IF_DEVICE((return 2;))
+        KOKKOS_IF_ON_HOST((return 4;))
+        KOKKOS_IF_ON_DEVICE((return 2;))
       }
 
 #else  // FIXME remove when requiring minimum version of Kokkos 3.6
@@ -417,10 +417,10 @@ struct Algo {
       // - team policy (smaller) or range policy (bigger)
       // - space (cuda vs host)
       // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
-#if defined(KOKKOS_IF_HOST)
+#if defined(KOKKOS_IF_ON_HOST)
       static constexpr KOKKKOS_FUNCTION int mb() {
-        KOKKOS_IF_HOST((return 4;))
-        KOKKOS_IF_DEVICE((return 1;))
+        KOKKOS_IF_ON_HOST((return 4;))
+        KOKKOS_IF_ON_DEVICE((return 1;))
       }
 
 #else  // FIXME remove when requiring minimum version of Kokkos 3.6

--- a/src/batched/dense/impl/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
@@ -94,8 +94,8 @@ struct SerialEigendecompositionInternal {
     //
     // DO THIS INSTEAD
     //
-    //     KOKKOS_IF_HOST((<host code>))
-    //     KOKKOS_IF_DEVICE((<device code>))
+    //     KOKKOS_IF_ON_HOST((<host code>))
+    //     KOKKOS_IF_ON_DEVICE((<device code>))
     //
     ////////////////////////////////////////////////////////////////////////////
     // #if (defined(KOKKOSKERNELS_ENABLE_TPL_MKL) && (__INTEL_MKL__ >= 2018)) &&
@@ -373,11 +373,11 @@ struct SerialEigendecompositionInternal {
       const int ers, RealType* ei, const int eis, RealType* UL, const int uls0,
       const int uls1, RealType* UR, const int urs0, const int urs1, RealType* w,
       const int wlen) {
-#if defined(KOKKOS_IF_HOST)
-    KOKKOS_IF_HOST((host_invoke(m, A, as0, as1, er, ers, ei, eis, UL, uls0,
-                                uls1, UR, urs0, urs1, w, wlen);))
-    KOKKOS_IF_DEVICE((device_invoke(m, A, as0, as1, er, ers, ei, eis, UL, uls0,
-                                    uls1, UR, urs0, urs1, w, wlen);))
+#if defined(KOKKOS_IF_ON_HOST)
+    KOKKOS_IF_ON_HOST((host_invoke(m, A, as0, as1, er, ers, ei, eis, UL, uls0,
+                                   uls1, UR, urs0, urs1, w, wlen);))
+    KOKKOS_IF_ON_DEVICE((device_invoke(m, A, as0, as1, er, ers, ei, eis, UL,
+                                       uls0, uls1, UR, urs0, urs1, w, wlen);))
 #elif defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)  // FIXME remove when
                                                           // requiring minimum
                                                           // version of

--- a/src/batched/dense/impl/KokkosBatched_Eigendecomposition_TeamVector_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Eigendecomposition_TeamVector_Internal.hpp
@@ -77,8 +77,8 @@ struct TeamVectorEigendecompositionInternal {
     //
     // DO THIS INSTEAD
     //
-    //     KOKKOS_IF_HOST((<host code>))
-    //     KOKKOS_IF_DEVICE((<device code>))
+    //     KOKKOS_IF_ON_HOST((<host code>))
+    //     KOKKOS_IF_ON_DEVICE((<device code>))
     //
 #if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
     if (as0 == 1 || as1 == 1) {

--- a/src/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
@@ -548,16 +548,16 @@ struct SPMV_Struct_Functor {
           const size_type rowOffset = m_A.graph.row_map(rowIdx);
 
           y_value_type sum(0.0);
-#if defined(KOKKOS_IF_HOST)
+#if defined(KOKKOS_IF_ON_HOST)
           // clang-format off
-          KOKKOS_IF_HOST((
+          KOKKOS_IF_ON_HOST((
           for (ordinal_type idx = 0; idx < 27; ++idx) {
             sum +=
                 m_A.values(rowOffset + idx) * m_x(rowIdx + columnOffsets(idx));
           }
           ))
 
-          KOKKOS_IF_DEVICE((
+          KOKKOS_IF_ON_DEVICE((
           Kokkos::parallel_reduce(
               Kokkos::ThreadVectorRange(dev, 27),
               [&](const ordinal_type& idx, y_value_type& lclSum) {


### PR DESCRIPTION
We decided to rename the macro at the last Kokkos developer meeting
kokkos/kokkos#4660 has been merged so make sure you get this in ASAP so you don't get deprecation warnings in your nightly testing