### PR TITLE
Bump ROCm version 4.2 -> 4.5 in nightly Jenkins CI build

### DIFF
--- a/.jenkins/nightly.groovy
+++ b/.jenkins/nightly.groovy
@@ -46,12 +46,12 @@ pipeline {
                     }
                 }
 
-                stage('HIP-ROCm-4.2-C++14') {
+                stage('HIP-ROCm-4.5-C++14') {
                     agent {
                         dockerfile {
                             filename 'Dockerfile.hip'
                             dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:4.2'
+                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-20.04:4.5'
                             label 'rocm-docker && vega'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
                         }


### PR DESCRIPTION
Kokkos now requires ROCm minimum version of 4.5 kokkos/kokkos#4689