### PR TITLE
Remove private Kokkos header include (`Cuda/Kokkos_Cuda_Half.hpp`)

### DIFF
--- a/unit_test/sparse/Test_Sparse_spmv.hpp
+++ b/unit_test/sparse/Test_Sparse_spmv.hpp
@@ -10,7 +10,6 @@
 
 #include "KokkosKernels_Controls.hpp"
 #include "KokkosKernels_default_types.hpp"
-#include "Cuda/Kokkos_Cuda_Half.hpp"
 
 // #ifndef kokkos_complex_double
 // #define kokkos_complex_double Kokkos::complex<double>


### PR DESCRIPTION
Fix #1280

Support for half types is there when including `<Kokkos_Core.hpp>`
https://github.com/kokkos/kokkos/blob/39a54435ecabca16d73bd6f9d1648d8831f6b730/core/src/Kokkos_Core.hpp#L55