### PR TITLE
Add missing barriers to TeamGMRES, fix vector len

### DIFF
--- a/src/batched/sparse/KokkosBatched_JacobiPrec.hpp
+++ b/src/batched/sparse/KokkosBatched_JacobiPrec.hpp
@@ -60,7 +60,7 @@ class JacobiPrec {
       typename Kokkos::Details::ArithTraits<ScalarType>::mag_type;
 
  private:
-  mutable ValuesViewType diag_values;
+  ValuesViewType diag_values;
   int n_operators;
   int n_rows;
   int n_colums;
@@ -96,39 +96,41 @@ class JacobiPrec {
       auto vs0               = diag_values.stride_0();
       auto vs1               = diag_values.stride_1();
 
-      Kokkos::parallel_for(
+      Kokkos::parallel_reduce(
           Kokkos::TeamThreadRange(member, 0, n_operators * n_rows),
-          [&](const int &iTemp) {
+          [&](const int &iTemp, int &ltooSmall) {
             int i, j;
             getIndices<int, typename ValuesViewType::array_layout>(
                 iTemp, n_rows, n_operators, j, i);
             if (Kokkos::abs<ScalarType>(diag_values_array[i * vs0 + j * vs1]) <=
                 epsilon) {
-              Kokkos::atomic_fetch_add(&tooSmall, 1);
+              ltooSmall++;
               diag_values_array[i * vs0 + j * vs1] = one;
             } else
               diag_values_array[i * vs0 + j * vs1] =
                   one / diag_values_array[i * vs0 + j * vs1];
-          });
+          },
+          tooSmall);
     } else if (std::is_same<ArgMode, Mode::TeamVector>::value) {
       auto diag_values_array = diag_values.data();
       auto vs0               = diag_values.stride_0();
       auto vs1               = diag_values.stride_1();
 
-      Kokkos::parallel_for(
+      Kokkos::parallel_reduce(
           Kokkos::TeamVectorRange(member, 0, n_operators * n_rows),
-          [&](const int &iTemp) {
+          [&](const int &iTemp, int &ltooSmall) {
             int i, j;
             getIndices<int, typename ValuesViewType::array_layout>(
                 iTemp, n_rows, n_operators, j, i);
             if (Kokkos::abs<ScalarType>(diag_values_array[i * vs0 + j * vs1]) <=
                 epsilon) {
-              Kokkos::atomic_fetch_add(&tooSmall, 1);
+              ltooSmall++;
               diag_values_array[i * vs0 + j * vs1] = one;
             } else
               diag_values_array[i * vs0 + j * vs1] =
                   one / diag_values_array[i * vs0 + j * vs1];
-          });
+          },
+          tooSmall);
     }
 
     if (tooSmall > 0)

--- a/src/batched/sparse/KokkosBatched_JacobiPrec.hpp
+++ b/src/batched/sparse/KokkosBatched_JacobiPrec.hpp
@@ -146,7 +146,10 @@ class JacobiPrec {
   KOKKOS_INLINE_FUNCTION void apply(const MemberType &member,
                                     const XViewType &X,
                                     const YViewType &Y) const {
-    if (!computed_inverse) this->computeInverse<MemberType, ArgMode>(member);
+    if (!computed_inverse) {
+      this->computeInverse<MemberType, ArgMode>(member);
+      member.team_barrier();  // Finish writing to this->diag_values
+    }
 
     KokkosBatched::HadamardProduct<MemberType, ArgMode>::template invoke<
         ValuesViewType, XViewType, YViewType>(member, diag_values, X, Y);

--- a/unit_test/batched/sparse/Test_Batched_TeamGMRES.hpp
+++ b/unit_test/batched/sparse/Test_Batched_TeamGMRES.hpp
@@ -63,7 +63,7 @@ struct Functor_TestBatchedTeamGMRES {
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::TeamPolicy<DeviceType> policy(_D.extent(0) / _N_team,
-                                          Kokkos::AUTO(), Kokkos::AUTO());
+                                          Kokkos::AUTO());
 
     size_t bytes_0 = ValuesViewType::shmem_size(_N_team, _X.extent(1));
     size_t bytes_1 = ValuesViewType::shmem_size(_N_team, 1);


### PR DESCRIPTION
- Add missing team barriers
- Don't try to do atomics on local/register values in batched Jacobi
  (those are private to each thread/vector lane). Instead use parallel_reduce
  to sum results over all threads.
- Make the TeamGMRES test use vector length 1 in the TeamPolicy, since
  it doesn't use thread-level parallelism
- With this all batched sparse tests pass on SYCL+Intel.