### PR TITLE
Remove unneeded Cuda Half include

### DIFF
--- a/unit_test/sparse/Test_Sparse_spmv.hpp
+++ b/unit_test/sparse/Test_Sparse_spmv.hpp
@@ -10,7 +10,6 @@
 
 #include "KokkosKernels_Controls.hpp"
 #include "KokkosKernels_default_types.hpp"
-#include "Cuda/Kokkos_Cuda_Half.hpp"
 
 // #ifndef kokkos_complex_double
 // #define kokkos_complex_double Kokkos::complex<double>


### PR DESCRIPTION
Kokkos recently reorganized half precision related headers, breaking
this include. It wasn't necessary anyway.