### PR TITLE
Fix out-of-sync Kokkos items

### DIFF
--- a/src/batched/KokkosBatched_Util.hpp
+++ b/src/batched/KokkosBatched_Util.hpp
@@ -300,7 +300,7 @@ struct Mode {
   };
 };
 
-#if !defined(KOKKOS_IF_HOST)
+#if !defined(KOKKOS_IF_ON_HOST)
 
 template <class>
 struct algo_level3_blocked_mb_impl;
@@ -367,14 +367,14 @@ struct Algo {
       // - team policy (smaller) or range policy (bigger)
       // - space (gpu vs host)
       // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
-#if defined(KOKKOS_IF_HOST)
-      static constexpr KOKKKOS_FUNCTION int mb() {
-        KOKKOS_IF_HOST((return 4;))
-        KOKKOS_IF_DEVICE((return 2;))
+#if defined(KOKKOS_IF_ON_HOST)
+      static constexpr KOKKOS_INLINE_FUNCTION int mb() {
+        KOKKOS_IF_ON_HOST((return 4;))
+        KOKKOS_IF_ON_DEVICE((return 2;))
       }
 
 #else  // FIXME remove when requiring minimum version of Kokkos 3.6
-      static constexpr KOKKOS_FUNCTION int mb() {
+      static constexpr KOKKOS_INLINE_FUNCTION int mb() {
         return algo_level3_blocked_mb_impl<
             Kokkos::Impl::ActiveExecutionMemorySpace>::value;
       }
@@ -417,14 +417,14 @@ struct Algo {
       // - team policy (smaller) or range policy (bigger)
       // - space (cuda vs host)
       // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
-#if defined(KOKKOS_IF_HOST)
-      static constexpr KOKKKOS_FUNCTION int mb() {
-        KOKKOS_IF_HOST((return 4;))
-        KOKKOS_IF_DEVICE((return 1;))
+#if defined(KOKKOS_IF_ON_HOST)
+      static constexpr KOKKOS_INLINE_FUNCTION int mb() {
+        KOKKOS_IF_ON_HOST((return 4;))
+        KOKKOS_IF_ON_DEVICE((return 1;))
       }
 
 #else  // FIXME remove when requiring minimum version of Kokkos 3.6
-      static constexpr KOKKOS_FUNCTION int mb() {
+      static constexpr KOKKOS_INLINE_FUNCTION int mb() {
         return algo_level2_blocked_mb_impl<
             Kokkos::Impl::ActiveExecutionMemorySpace>::value;
       }

--- a/src/batched/dense/impl/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
@@ -94,8 +94,8 @@ struct SerialEigendecompositionInternal {
     //
     // DO THIS INSTEAD
     //
-    //     KOKKOS_IF_HOST((<host code>))
-    //     KOKKOS_IF_DEVICE((<device code>))
+    //     KOKKOS_IF_ON_HOST((<host code>))
+    //     KOKKOS_IF_ON_DEVICE((<device code>))
     //
     ////////////////////////////////////////////////////////////////////////////
     // #if (defined(KOKKOSKERNELS_ENABLE_TPL_MKL) && (__INTEL_MKL__ >= 2018)) &&
@@ -373,11 +373,11 @@ struct SerialEigendecompositionInternal {
       const int ers, RealType* ei, const int eis, RealType* UL, const int uls0,
       const int uls1, RealType* UR, const int urs0, const int urs1, RealType* w,
       const int wlen) {
-#if defined(KOKKOS_IF_HOST)
-    KOKKOS_IF_HOST((host_invoke(m, A, as0, as1, er, ers, ei, eis, UL, uls0,
-                                uls1, UR, urs0, urs1, w, wlen);))
-    KOKKOS_IF_DEVICE((device_invoke(m, A, as0, as1, er, ers, ei, eis, UL, uls0,
-                                    uls1, UR, urs0, urs1, w, wlen);))
+#if defined(KOKKOS_IF_ON_HOST)
+    KOKKOS_IF_ON_HOST((host_invoke(m, A, as0, as1, er, ers, ei, eis, UL, uls0,
+                                   uls1, UR, urs0, urs1, w, wlen);))
+    KOKKOS_IF_ON_DEVICE((device_invoke(m, A, as0, as1, er, ers, ei, eis, UL,
+                                       uls0, uls1, UR, urs0, urs1, w, wlen);))
 #elif defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)  // FIXME remove when
                                                           // requiring minimum
                                                           // version of

--- a/src/batched/dense/impl/KokkosBatched_Eigendecomposition_TeamVector_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Eigendecomposition_TeamVector_Internal.hpp
@@ -77,8 +77,8 @@ struct TeamVectorEigendecompositionInternal {
     //
     // DO THIS INSTEAD
     //
-    //     KOKKOS_IF_HOST((<host code>))
-    //     KOKKOS_IF_DEVICE((<device code>))
+    //     KOKKOS_IF_ON_HOST((<host code>))
+    //     KOKKOS_IF_ON_DEVICE((<device code>))
     //
 #if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
     if (as0 == 1 || as1 == 1) {

--- a/src/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
@@ -548,16 +548,16 @@ struct SPMV_Struct_Functor {
           const size_type rowOffset = m_A.graph.row_map(rowIdx);
 
           y_value_type sum(0.0);
-#if defined(KOKKOS_IF_HOST)
+#if defined(KOKKOS_IF_ON_HOST)
           // clang-format off
-          KOKKOS_IF_HOST((
+          KOKKOS_IF_ON_HOST((
           for (ordinal_type idx = 0; idx < 27; ++idx) {
             sum +=
                 m_A.values(rowOffset + idx) * m_x(rowIdx + columnOffsets(idx));
           }
           ))
 
-          KOKKOS_IF_DEVICE((
+          KOKKOS_IF_ON_DEVICE((
           Kokkos::parallel_reduce(
               Kokkos::ThreadVectorRange(dev, 27),
               [&](const ordinal_type& idx, y_value_type& lclSum) {


### PR DESCRIPTION
@dalg24 @lucbv 

I got https://github.com/kokkos/kokkos-kernels/pull/1232 blocked by [unrelated] [CI errors](https://github.com/kokkos/kokkos-kernels/runs/4930646227?check_suite_focus=true#step:7:248): it seems like KokkosKernels `develop` is no longer compiling with Kokkos `develop` ?

The commit here is aimed to resolve the errors, but essentially it's just a discussion starter - please feel free to take over and replace it with whatever you find appropriate.

Related Kokkos PRs: https://github.com/kokkos/kokkos/pull/4660