### PR TITLE
Add calls to BLAS routines for SpMV with BsrMatrix

### DIFF
--- a/src/batched/KokkosBatched_Util.hpp
+++ b/src/batched/KokkosBatched_Util.hpp
@@ -300,7 +300,7 @@ struct Mode {
   };
 };
 
-#if !defined(KOKKOS_IF_HOST)
+#if !defined(KOKKOS_IF_ON_HOST)
 
 template <class>
 struct algo_level3_blocked_mb_impl;
@@ -367,10 +367,10 @@ struct Algo {
       // - team policy (smaller) or range policy (bigger)
       // - space (gpu vs host)
       // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
-#if defined(KOKKOS_IF_HOST)
-      static constexpr KOKKKOS_FUNCTION int mb() {
-        KOKKOS_IF_HOST((return 4;))
-        KOKKOS_IF_DEVICE((return 2;))
+#if defined(KOKKOS_IF_ON_HOST)
+      static constexpr KOKKOS_FUNCTION int mb() {
+        KOKKOS_IF_ON_HOST((return 4;))
+        KOKKOS_IF_ON_DEVICE((return 2;))
       }
 
 #else  // FIXME remove when requiring minimum version of Kokkos 3.6
@@ -417,10 +417,10 @@ struct Algo {
       // - team policy (smaller) or range policy (bigger)
       // - space (cuda vs host)
       // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
-#if defined(KOKKOS_IF_HOST)
-      static constexpr KOKKKOS_FUNCTION int mb() {
-        KOKKOS_IF_HOST((return 4;))
-        KOKKOS_IF_DEVICE((return 1;))
+#if defined(KOKKOS_IF_ON_HOST)
+      static constexpr KOKKOS_FUNCTION int mb() {
+        KOKKOS_IF_ON_HOST((return 4;))
+        KOKKOS_IF_ON_DEVICE((return 1;))
       }
 
 #else  // FIXME remove when requiring minimum version of Kokkos 3.6

--- a/src/batched/dense/impl/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
@@ -94,8 +94,8 @@ struct SerialEigendecompositionInternal {
     //
     // DO THIS INSTEAD
     //
-    //     KOKKOS_IF_HOST((<host code>))
-    //     KOKKOS_IF_DEVICE((<device code>))
+    //     KOKKOS_IF_ON_HOST((<host code>))
+    //     KOKKOS_IF_ON_DEVICE((<device code>))
     //
     ////////////////////////////////////////////////////////////////////////////
     // #if (defined(KOKKOSKERNELS_ENABLE_TPL_MKL) && (__INTEL_MKL__ >= 2018)) &&
@@ -373,11 +373,11 @@ struct SerialEigendecompositionInternal {
       const int ers, RealType* ei, const int eis, RealType* UL, const int uls0,
       const int uls1, RealType* UR, const int urs0, const int urs1, RealType* w,
       const int wlen) {
-#if defined(KOKKOS_IF_HOST)
-    KOKKOS_IF_HOST((host_invoke(m, A, as0, as1, er, ers, ei, eis, UL, uls0,
-                                uls1, UR, urs0, urs1, w, wlen);))
-    KOKKOS_IF_DEVICE((device_invoke(m, A, as0, as1, er, ers, ei, eis, UL, uls0,
-                                    uls1, UR, urs0, urs1, w, wlen);))
+#if defined(KOKKOS_IF_ON_HOST)
+    KOKKOS_IF_ON_HOST((host_invoke(m, A, as0, as1, er, ers, ei, eis, UL, uls0,
+                                   uls1, UR, urs0, urs1, w, wlen);))
+    KOKKOS_IF_ON_DEVICE((device_invoke(m, A, as0, as1, er, ers, ei, eis, UL,
+                                       uls0, uls1, UR, urs0, urs1, w, wlen);))
 #elif defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)  // FIXME remove when
                                                           // requiring minimum
                                                           // version of

--- a/src/batched/dense/impl/KokkosBatched_Eigendecomposition_TeamVector_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Eigendecomposition_TeamVector_Internal.hpp
@@ -77,8 +77,8 @@ struct TeamVectorEigendecompositionInternal {
     //
     // DO THIS INSTEAD
     //
-    //     KOKKOS_IF_HOST((<host code>))
-    //     KOKKOS_IF_DEVICE((<device code>))
+    //     KOKKOS_IF_ON_HOST((<host code>))
+    //     KOKKOS_IF_ON_DEVICE((<device code>))
     //
 #if defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST)
     if (as0 == 1 || as1 == 1) {

--- a/src/batched/dense/impl/KokkosBatched_Gemm_TeamVector_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Gemm_TeamVector_Internal.hpp
@@ -13,7 +13,7 @@ namespace KokkosBatched {
 ///
 /// TeamVector Internal Impl
 /// ====================
-template <typename ArgAlgo>
+template <typename ArgAlgo, bool useConjA = false>
 struct TeamVectorGemmInternal {
   template <typename MemberType, typename ScalarType, typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(
@@ -27,7 +27,7 @@ struct TeamVectorGemmInternal {
 template <>
 template <typename MemberType, typename ScalarType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int
-TeamVectorGemmInternal<Algo::Gemm::Unblocked>::invoke(
+TeamVectorGemmInternal<Algo::Gemm::Unblocked, false>::invoke(
     const MemberType &member, const int m, const int n, const int k,
     const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A, const int as0,
     const int as1, const ValueType *KOKKOS_RESTRICT B, const int bs0,
@@ -59,6 +59,47 @@ TeamVectorGemmInternal<Algo::Gemm::Unblocked>::invoke(
                                c += pA[p * as1] * pB[p * bs0];
                              C[i * cs0 + j * cs1] += alpha * c;
                            });
+    });
+  }
+  return 0;
+}
+
+template <>
+template <typename MemberType, typename ScalarType, typename ValueType>
+KOKKOS_INLINE_FUNCTION int
+TeamVectorGemmInternal<Algo::Gemm::Unblocked, true>::invoke(
+    const MemberType &member, const int m, const int n, const int k,
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A, const int as0,
+    const int as1, const ValueType *KOKKOS_RESTRICT B, const int bs0,
+    const int bs1, const ScalarType beta,
+    /**/ ValueType *KOKKOS_RESTRICT C, const int cs0, const int cs1) {
+  // C = beta C + alpha A B
+  // C (m x n), A(m x k), B(k x n)
+
+  const ScalarType one(1.0), zero(0.0);
+
+  if (beta == zero)
+    TeamVectorSetInternal ::invoke(member, m, n, zero, C, cs0, cs1);
+  else if (beta != one)
+    TeamVectorScaleInternal::invoke(member, m, n, beta, C, cs0, cs1);
+
+  if (alpha != ScalarType(0.0)) {
+    if (m <= 0 || n <= 0 || k <= 0) return 0;
+
+    if (beta != one) member.team_barrier();
+
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(member, m), [&](const int &i) {
+      const ValueType *KOKKOS_RESTRICT pA = A + i * as0;
+      Kokkos::parallel_for(
+          Kokkos::ThreadVectorRange(member, n), [&](const int &j) {
+            const ValueType *KOKKOS_RESTRICT pB = B + j * bs1;
+
+            ValueType c = ValueType(0);
+            for (int p = 0; p < k; ++p)
+              c += Kokkos::ArithTraits<ValueType>::conj(pA[p * as1]) *
+                   pB[p * bs0];
+            C[i * cs0 + j * cs1] += alpha * c;
+          });
     });
   }
   return 0;

--- a/src/blas/impl/KokkosBlas2_team_gemv_spec.hpp
+++ b/src/blas/impl/KokkosBlas2_team_gemv_spec.hpp
@@ -42,8 +42,8 @@
 //@HEADER
 */
 
-#ifndef KOKKOSBLAS1_TEAM_GEMV_SPEC_HPP_
-#define KOKKOSBLAS1_TEAM_GEMV_SPEC_HPP_
+#ifndef KOKKOSBLAS2_TEAM_GEMV_SPEC_HPP_
+#define KOKKOSBLAS2_TEAM_GEMV_SPEC_HPP_
 
 #include <KokkosKernels_config.h>
 #include <Kokkos_Core.hpp>
@@ -74,7 +74,6 @@ template <class TeamType, class MatrixType, class XVector, class YVector>
 struct TeamGEMV<TeamType, MatrixType, XVector, YVector, 0, false> {
   typedef typename Kokkos::Details::InnerProductSpaceTraits<
       typename MatrixType::non_const_value_type>::dot_type dot_type;
-  typedef typename XVector::non_const_value_type x_value_type;
   static KOKKOS_INLINE_FUNCTION void team_gemv(
       const TeamType& team, const typename XVector::non_const_value_type& alpha,
       const MatrixType& A, const XVector& x,
@@ -87,6 +86,31 @@ struct TeamGEMV<TeamType, MatrixType, XVector, YVector, 0, false> {
       Kokkos::parallel_reduce(
           Kokkos::ThreadVectorRange(team, M),
           [&](const int& j, dot_type& val) { val += A(i, j) * x(j); }, Ax_i);
+      y(i) = beta * y(i) + alpha * Ax_i;
+    });
+  }
+};
+
+template <class TeamType, class MatrixType, class XVector, class YVector>
+struct TeamGEMV<TeamType, MatrixType, XVector, YVector, -1, false> {
+  typedef typename MatrixType::non_const_value_type value_type;
+  typedef typename Kokkos::Details::InnerProductSpaceTraits<
+      typename MatrixType::non_const_value_type>::dot_type dot_type;
+  static KOKKOS_INLINE_FUNCTION void team_gemv(
+      const TeamType& team, const typename XVector::non_const_value_type& alpha,
+      const MatrixType& A, const XVector& x,
+      const typename YVector::non_const_value_type& beta, const YVector& y) {
+    const int N = A.extent(0);
+    const int M = A.extent(1);
+
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, N), [&](const int& i) {
+      dot_type Ax_i;
+      Kokkos::parallel_reduce(
+          Kokkos::ThreadVectorRange(team, M),
+          [&](const int& j, dot_type& val) {
+            val += Kokkos::ArithTraits<value_type>::conj(A(i, j)) * x(j);
+          },
+          Ax_i);
       y(i) = beta * y(i) + alpha * Ax_i;
     });
   }

--- a/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
@@ -532,9 +532,13 @@ struct BsrMatrixSpMVTensorCoreDispatcher {
 
 #include "KokkosBlas.hpp"
 #include "KokkosBatched_Gemv_Serial_Internal.hpp"
+#include "KokkosBatched_Gemv_TeamVector_Internal.hpp"
 #include "KokkosBatched_Gemm_Serial_Internal.hpp"
+#include "KokkosBatched_Gemm_TeamVector_Internal.hpp"
+#include "KokkosBatched_Scale_Internal.hpp"
 #include "KokkosKernels_ExecSpaceUtils.hpp"
-#include "KokkosSparse_spmv_impl.hpp"
+
+#include "KokkosBlas2_team_gemv_spec.hpp"
 
 namespace KokkosSparse {
 namespace Experimental {
@@ -555,24 +559,25 @@ struct BSR_GEMV_Functor {
   typedef typename AMatrix::non_const_size_type size_type;
 
   const value_type alpha;
+  const value_type beta;
+
   AMatrix m_A;
   XVector m_x;
   YVector m_y;
 
   const ordinal_type block_dim;
-  const ordinal_type blocks_per_team;
 
   bool conjugate = false;
 
-  BSR_GEMV_Functor(const value_type alpha_, const AMatrix m_A_,
-                   const XVector m_x_, const YVector m_y_,
-                   const int blocks_per_team_, bool conj_)
+  BSR_GEMV_Functor(const value_type alpha_, const AMatrix &m_A_,
+                   const XVector &m_x_, value_type beta_, YVector &m_y_,
+                   const int block_dim_, bool conj_)
       : alpha(alpha_),
+        beta(beta_),
         m_A(m_A_),
         m_x(m_x_),
         m_y(m_y_),
-        block_dim(m_A_.blockDim()),
-        blocks_per_team(blocks_per_team_),
+        block_dim(block_dim_),
         conjugate(conj_) {
     static_assert(static_cast<int>(XVector::rank) == 1,
                   "XVector must be a rank 1 View.");
@@ -608,58 +613,74 @@ struct BSR_GEMV_Functor {
         const auto Aview  = row.block(ic);
         const auto xstart = row.block_colidx(ic) * block_dim;
         KokkosBatched::SerialGemvInternal<KokkosBatched::Algo::Gemv::Blocked>::
-            invoke<value_type, value_type>(block_dim, block_dim, alpha,
-                                           Aview.data(), block_dim, 1,
-                                           &m_x(xstart), m_x.stride_0(), beta1,
-                                           &m_y(ystart), m_y.stride_0());
+            invoke<value_type, value_type>(
+                static_cast<int>(block_dim), static_cast<int>(block_dim), alpha,
+                Aview.data(), static_cast<int>(block_dim), 1, &m_x(xstart),
+                static_cast<int>(m_x.stride_0()), beta1, &m_y(ystart),
+                static_cast<int>(m_y.stride_0()));
       }
     }
   }
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const team_member &dev) const {
-    using y_value_type = typename YVector::non_const_value_type;
-    Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(dev, 0, blocks_per_team),
-        [&](const ordinal_type &loop) {
-          const ordinal_type iBlock =
-              static_cast<ordinal_type>(dev.league_rank()) * blocks_per_team +
-              loop;
-          if (iBlock >= m_A.numRows()) {
-            return;
-          }
-          const auto start = m_A.graph.row_map(iBlock);
-          const ordinal_type count =
-              static_cast<ordinal_type>(m_A.graph.row_map(iBlock + 1) - start);
-          const auto row = m_A.block_row_Const(iBlock);
-          //
-          auto yview = Kokkos::subview(
-              m_y, Kokkos::make_pair(iBlock * block_dim,
-                                     iBlock * block_dim + block_dim));
-          //
-          for (ordinal_type ir = 0; ir < block_dim; ++ir) {
-            y_value_type sum = 0;
+    using y_value_type        = typename YVector::non_const_value_type;
+    const ordinal_type iBlock = static_cast<ordinal_type>(dev.league_rank());
 
-            Kokkos::parallel_reduce(
-                Kokkos::ThreadVectorRange(dev, count),
-                [&](const ordinal_type &iEntry, y_value_type &lsum) {
-                  const auto start_col = row.block_colidx(iEntry) * block_dim;
-                  for (ordinal_type jr = 0; jr < block_dim; ++jr) {
-                    const value_type val =
-                        conjugate
-                            ? ATV::conj(row.local_block_value(iEntry, ir, jr))
-                            : row.local_block_value(iEntry, ir, jr);
-                    lsum += val * m_x(start_col + jr);
-                  }
-                },
-                sum);
+    const size_type Y_ptBeg = iBlock * block_dim;
+    const size_type Y_ptEnd = Y_ptBeg + block_dim;
+    auto Y_cur = Kokkos::subview(m_y, ::Kokkos::make_pair(Y_ptBeg, Y_ptEnd));
 
-            Kokkos::single(Kokkos::PerThread(dev), [&]() {
-              sum *= alpha;
-              yview(ir) += sum;
-            });
-          }
-        });
+    const y_value_type val_one = 1;
+    if (beta != val_one) {
+      KokkosBatched::TeamVectorScaleInternal::invoke(
+          dev, block_dim, beta, Y_cur.data(),
+          static_cast<int>(Y_cur.stride_0()));
+    }
+
+    dev.team_barrier();
+
+    const auto myRow = m_A.block_row_Const(iBlock);
+    const auto count = myRow.length;
+
+    if (conjugate) {
+      typedef Kokkos::View<const y_value_type **, Kokkos::LayoutRight,
+                           typename AMatrix::device_type,
+                           Kokkos::MemoryUnmanaged>
+          block_values_type;
+
+      for (ordinal_type jBlock = 0; jBlock < count; ++jBlock) {
+        const auto A_cur    = myRow.block(jBlock);
+        const auto X_blkCol = myRow.block_colidx(jBlock);
+        const auto X_ptBeg  = X_blkCol * block_dim;
+        const auto X_cur    = Kokkos::subview(
+            m_x, ::Kokkos::make_pair(X_ptBeg, X_ptBeg + block_dim));
+        KokkosBlas::Experimental::Impl::TeamGEMV<
+            team_member, block_values_type, XVector, YVector, -1,
+            false>::team_gemv(dev, alpha, A_cur, X_cur, val_one, Y_cur);
+      }
+    } else {
+      typedef Kokkos::View<const y_value_type **, Kokkos::LayoutRight,
+                           typename AMatrix::device_type,
+                           Kokkos::MemoryUnmanaged>
+          block_values_type;
+
+      for (ordinal_type jBlock = 0; jBlock < count; ++jBlock) {
+        const auto A_cur    = myRow.block(jBlock);
+        const auto X_blkCol = myRow.block_colidx(jBlock);
+        const auto X_ptBeg  = X_blkCol * block_dim;
+        const auto X_cur    = Kokkos::subview(
+            m_x, ::Kokkos::make_pair(X_ptBeg, X_ptBeg + block_dim));
+        KokkosBatched::TeamVectorGemvInternal<
+            KokkosBatched::Algo::Gemv::Unblocked>::
+            invoke(dev, static_cast<int>(block_dim),
+                   static_cast<int>(block_dim), alpha, A_cur.data(),
+                   static_cast<int>(A_cur.stride_0()),
+                   static_cast<int>(A_cur.stride_1()), X_cur.data(),
+                   static_cast<int>(X_cur.stride_0()), val_one, Y_cur.data(),
+                   static_cast<int>(Y_cur.stride_0()));
+      }
+    }
   }
 };
 
@@ -705,8 +726,8 @@ void spMatVec_no_transpose(
     }
   }
 
-  BSR_GEMV_Functor<AMatrix_Internal, XVector, YVector> func(alpha, A, x, y, 1,
-                                                            useConjugate);
+  BSR_GEMV_Functor<AMatrix_Internal, XVector, YVector> func(
+      alpha, A, x, beta, y, A.blockDim(), useConjugate);
   if (((A.nnz() > 10000000) || use_dynamic_schedule) && !use_static_schedule) {
     Kokkos::parallel_for(
         "KokkosSparse::bspmv<NoTranspose,Dynamic>",
@@ -743,10 +764,6 @@ void spMatVec_no_transpose(
     return;
   }
 
-  // We need to scale y first ("scaling" by zero just means filling
-  // with zeros), since the functor updates y (by adding alpha Op(A) x).
-  KokkosBlas::scal(y, beta, y);
-
   typedef KokkosSparse::Experimental::BsrMatrix<
       AT, AO, AD, Kokkos::MemoryTraits<Kokkos::Unmanaged>, AS>
       AMatrix_Internal;
@@ -761,9 +778,25 @@ void spMatVec_no_transpose(
       use_static_schedule = true;
     }
   }
-  int team_size           = -1;
-  int vector_length       = -1;
-  int64_t rows_per_thread = -1;
+  int team_size        = -1;
+  int vector_length    = -1;
+  const auto block_dim = A.blockDim();
+
+  team_size = 8;
+  if (block_dim <= 4) {
+    vector_length = 4;
+    team_size     = 64;
+  } else if (block_dim <= 8) {
+    vector_length = 8;
+    team_size     = 32;
+  } else if (block_dim <= 16) {
+    vector_length = 16;
+    team_size     = 16;
+  } else {
+    vector_length = 32;
+    team_size     = 8;
+  }
+  int64_t worksets = A.numRows();
 
   //
   // Use the controls to allow the user to pass in some tuning parameters.
@@ -774,26 +807,9 @@ void spMatVec_no_transpose(
   if (controls.isParameter("vector length")) {
     vector_length = std::stoi(controls.getParameter("vector length"));
   }
-  if (controls.isParameter("rows per thread")) {
-    rows_per_thread = std::stoll(controls.getParameter("rows per thread"));
-  }
-
-  //
-  // Use the existing launch parameters routine from SPMV
-  //
-  const auto block_dim = A.blockDim();
-  int64_t rows_per_team =
-      KokkosSparse::Impl::spmv_launch_parameters<execution_space>(
-          A.numRows() * block_dim, A.nnz() * block_dim * block_dim,
-          rows_per_thread, team_size, vector_length);
-  int64_t blocks_per_team = (rows_per_team + block_dim - 1) / block_dim;
-  blocks_per_team         = (blocks_per_team < 1) ? 1 : blocks_per_team;
-  int64_t worksets = (A.numRows() + blocks_per_team - 1) / blocks_per_team;
-
-  AMatrix_Internal A_internal = A;
 
   BSR_GEMV_Functor<AMatrix_Internal, XVector, YVector> func(
-      alpha, A_internal, x, y, blocks_per_team, useConjugate);
+      alpha, A, x, beta, y, block_dim, useConjugate);
 
   if (((A.nnz() > 10000000) || use_dynamic_schedule) && !use_static_schedule) {
     Kokkos::TeamPolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>
@@ -846,19 +862,17 @@ struct BSR_GEMV_Transpose_Functor {
   YVector m_y;
 
   const ordinal_type block_dim;
-  const ordinal_type blocks_per_team;
 
   bool conjugate = false;
 
-  BSR_GEMV_Transpose_Functor(const value_type alpha_, const AMatrix m_A_,
-                             const XVector m_x_, const YVector m_y_,
-                             const int blocks_per_team_, bool conj_)
+  BSR_GEMV_Transpose_Functor(const value_type alpha_, const AMatrix &m_A_,
+                             const XVector &m_x_, const YVector &m_y_,
+                             bool conj_)
       : alpha(alpha_),
         m_A(m_A_),
         m_x(m_x_),
         m_y(m_y_),
         block_dim(m_A_.blockDim()),
-        blocks_per_team(blocks_per_team_),
         conjugate(conj_) {
     static_assert(static_cast<int>(XVector::rank) == 1,
                   "XVector must be a rank 1 View.");
@@ -915,39 +929,78 @@ struct BSR_GEMV_Transpose_Functor {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const team_member &dev) const {
-    using y_value_type = typename YVector::non_const_value_type;
-    Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(dev, 0, blocks_per_team),
-        [&](const ordinal_type &loop) {
-          const ordinal_type iBlock =
-              static_cast<ordinal_type>(dev.league_rank()) * blocks_per_team +
-              loop;
-          if (iBlock >= m_A.numRows()) {
-            return;
-          }
-          const auto start = m_A.graph.row_map(iBlock);
-          const ordinal_type count =
-              static_cast<ordinal_type>(m_A.graph.row_map(iBlock + 1) - start);
-          const auto row = m_A.block_row_Const(iBlock);
-          //
-          for (ordinal_type ir = 0; ir < block_dim; ++ir) {
-            Kokkos::parallel_for(
-                Kokkos::ThreadVectorRange(dev, count),
-                [&](const ordinal_type &iEntry) {
-                  for (ordinal_type jr = 0; jr < block_dim; ++jr) {
-                    const value_type val =
-                        conjugate
-                            ? ATV::conj(row.local_block_value(iEntry, jr, ir))
-                            : row.local_block_value(iEntry, jr, ir);
-                    const ordinal_type ind = row.block_colidx(iEntry);
-                    Kokkos::atomic_add(
-                        &m_y(block_dim * ind + ir),
-                        static_cast<y_value_type>(
-                            alpha * val * m_x(block_dim * iBlock + jr)));
-                  }
-                });
-          }
-        });
+    using y_value_type        = typename YVector::non_const_value_type;
+    const ordinal_type iBlock = static_cast<ordinal_type>(dev.league_rank());
+
+    const size_type X_ptBeg = iBlock * block_dim;
+    const size_type X_ptEnd = X_ptBeg + block_dim;
+    const auto X_cur =
+        Kokkos::subview(m_x, ::Kokkos::make_pair(X_ptBeg, X_ptEnd));
+
+    const auto myRow = m_A.block_row_Const(iBlock);
+    const auto count = myRow.length;
+
+    const y_value_type val_zero = 0;
+    y_value_type *shared_y      = (y_value_type *)dev.team_shmem().get_shmem(
+        block_dim * sizeof(y_value_type));
+
+    if (conjugate) {
+      typedef Kokkos::View<const y_value_type **, Kokkos::LayoutRight,
+                           typename AMatrix::device_type,
+                           Kokkos::MemoryUnmanaged>
+          block_values_type;
+      Kokkos::View<y_value_type *, typename AMatrix::device_type,
+                   Kokkos::MemoryUnmanaged>
+          shared_view(shared_y, block_dim);
+      for (ordinal_type jBlock = 0; jBlock < count; ++jBlock) {
+        const auto A_cur = myRow.block(jBlock);
+        //
+        KokkosBlas::Experimental::Impl::TeamGEMV<
+            team_member, block_values_type, XVector, YVector, 2,
+            false>::team_gemv(dev, alpha, A_cur, X_cur, val_zero, shared_view);
+        //
+        dev.team_barrier();
+        //
+        const auto Y_blkCol = myRow.block_colidx(jBlock);
+        const auto Y_ptBeg  = Y_blkCol * block_dim;
+        auto Y_cur          = Kokkos::subview(
+            m_y, ::Kokkos::make_pair(Y_ptBeg, Y_ptBeg + block_dim));
+        Kokkos::parallel_for(Kokkos::TeamVectorRange(dev, 0, block_dim),
+                             [&](const ordinal_type &ijk) {
+                               Kokkos::atomic_add(&Y_cur(ijk),
+                                                  shared_view(ijk));
+                             });
+      }
+    } else {
+      for (ordinal_type jBlock = 0; jBlock < count; ++jBlock) {
+        const auto A_cur = myRow.block(jBlock);
+        //
+        KokkosBatched::TeamVectorGemvInternal<
+            KokkosBatched::Algo::Gemv::Unblocked>::invoke(dev, block_dim,
+                                                          block_dim, alpha,
+                                                          A_cur.data(),
+                                                          static_cast<int>(
+                                                              A_cur.stride_1()),
+                                                          static_cast<int>(
+                                                              A_cur.stride_0()),
+                                                          X_cur.data(),
+                                                          static_cast<int>(
+                                                              X_cur.stride_0()),
+                                                          val_zero, shared_y,
+                                                          1);
+        //
+        dev.team_barrier();
+        //
+        const auto Y_blkCol = myRow.block_colidx(jBlock);
+        const auto Y_ptBeg  = Y_blkCol * block_dim;
+        auto Y_cur          = Kokkos::subview(
+            m_y, ::Kokkos::make_pair(Y_ptBeg, Y_ptBeg + block_dim));
+        Kokkos::parallel_for(Kokkos::TeamVectorRange(dev, 0, block_dim),
+                             [&](const ordinal_type &ijk) {
+                               Kokkos::atomic_add(&Y_cur(ijk), shared_y[ijk]);
+                             });
+      }
+    }
   }
 };
 
@@ -983,8 +1036,6 @@ void spMatVec_transpose(
       AT, AO, AD, Kokkos::MemoryTraits<Kokkos::Unmanaged>, AS>
       AMatrix_Internal;
 
-  AMatrix_Internal A_internal = A;
-
   bool use_dynamic_schedule = false;  // Forces the use of a dynamic schedule
   bool use_static_schedule  = false;  // Forces the use of a static schedule
   if (controls.isParameter("schedule")) {
@@ -996,7 +1047,7 @@ void spMatVec_transpose(
   }
 
   BSR_GEMV_Transpose_Functor<AMatrix_Internal, XVector, YVector> func(
-      alpha, A_internal, x, y, 1, useConjugate);
+      alpha, A, x, y, useConjugate);
   if (((A.nnz() > 10000000) || use_dynamic_schedule) && !use_static_schedule) {
     Kokkos::parallel_for(
         "KokkosSparse::bspmv<Transpose,Dynamic>",
@@ -1029,11 +1080,11 @@ void spMatVec_transpose(const KokkosKernels::Experimental::Controls &controls,
     return;
   }
 
-  // We need to scale y first ("scaling" by zero just means filling
-  // with zeros), since the functor works by atomic-adding into y.
-  KokkosBlas::scal(y, beta, y);
-
   typedef typename AMatrix::execution_space execution_space;
+
+  const auto block_dim = A.blockDim();
+
+  KokkosBlas::scal(y, beta, y);
 
   bool use_dynamic_schedule = false;  // Forces the use of a dynamic schedule
   bool use_static_schedule  = false;  // Forces the use of a static schedule
@@ -1044,9 +1095,26 @@ void spMatVec_transpose(const KokkosKernels::Experimental::Controls &controls,
       use_static_schedule = true;
     }
   }
-  int team_size           = -1;
-  int vector_length       = -1;
-  int64_t rows_per_thread = -1;
+  int team_size     = -1;
+  int vector_length = -1;
+
+  int64_t worksets = A.numRows();
+
+  if (block_dim <= 4) {
+    vector_length = 4;
+    team_size     = 64;
+  }
+  if (block_dim <= 8) {
+    vector_length = 8;
+    team_size     = 32;
+  }
+  if (block_dim <= 16) {
+    vector_length = 16;
+    team_size     = 16;
+  } else {
+    vector_length = 32;
+    team_size     = 8;
+  }
 
   //
   // Use the controls to allow the user to pass in some tuning parameters.
@@ -1057,24 +1125,9 @@ void spMatVec_transpose(const KokkosKernels::Experimental::Controls &controls,
   if (controls.isParameter("vector length")) {
     vector_length = std::stoi(controls.getParameter("vector length"));
   }
-  if (controls.isParameter("rows per thread")) {
-    rows_per_thread = std::stoll(controls.getParameter("rows per thread"));
-  }
 
-  //
-  // Use the existing launch parameters routine from SPMV
-  //
-  const auto block_dim = A.blockDim();
-  int64_t rows_per_team =
-      KokkosSparse::Impl::spmv_launch_parameters<execution_space>(
-          A.numRows() * block_dim, A.nnz() * block_dim * block_dim,
-          rows_per_thread, team_size, vector_length);
-  int64_t blocks_per_team = (rows_per_team + block_dim - 1) / block_dim;
-  blocks_per_team         = (blocks_per_team < 1) ? 1 : blocks_per_team;
-  int64_t worksets = (A.numRows() + blocks_per_team - 1) / blocks_per_team;
-
-  BSR_GEMV_Transpose_Functor<AMatrix, XVector, YVector> func(
-      alpha, A, x, y, blocks_per_team, useConjugate);
+  BSR_GEMV_Transpose_Functor<AMatrix, XVector, YVector> func(alpha, A, x, y,
+                                                             useConjugate);
 
   if (((A.nnz() > 10000000) || use_dynamic_schedule) && !use_static_schedule) {
     Kokkos::TeamPolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>
@@ -1082,11 +1135,19 @@ void spMatVec_transpose(const KokkosKernels::Experimental::Controls &controls,
     if (team_size < 0)
       policy = Kokkos::TeamPolicy<execution_space,
                                   Kokkos::Schedule<Kokkos::Dynamic>>(
-          worksets, Kokkos::AUTO, vector_length);
+                   worksets, Kokkos::AUTO, vector_length)
+                   .set_scratch_size(
+                       0, Kokkos::PerTeam(
+                              block_dim *
+                              sizeof(typename YVector::non_const_value_type)));
     else
       policy = Kokkos::TeamPolicy<execution_space,
                                   Kokkos::Schedule<Kokkos::Dynamic>>(
-          worksets, team_size, vector_length);
+                   worksets, team_size, vector_length)
+                   .set_scratch_size(
+                       0, Kokkos::PerTeam(
+                              block_dim *
+                              sizeof(typename YVector::non_const_value_type)));
     Kokkos::parallel_for("KokkosSparse::bspmv<Transpose,Dynamic>", policy,
                          func);
   } else {
@@ -1095,11 +1156,19 @@ void spMatVec_transpose(const KokkosKernels::Experimental::Controls &controls,
     if (team_size < 0)
       policy =
           Kokkos::TeamPolicy<execution_space, Kokkos::Schedule<Kokkos::Static>>(
-              worksets, Kokkos::AUTO, vector_length);
+              worksets, Kokkos::AUTO, vector_length)
+              .set_scratch_size(
+                  0, Kokkos::PerTeam(
+                         block_dim *
+                         sizeof(typename YVector::non_const_value_type)));
     else
       policy =
           Kokkos::TeamPolicy<execution_space, Kokkos::Schedule<Kokkos::Static>>(
-              worksets, team_size, vector_length);
+              worksets, team_size, vector_length)
+              .set_scratch_size(
+                  0, Kokkos::PerTeam(
+                         block_dim *
+                         sizeof(typename YVector::non_const_value_type)));
     Kokkos::parallel_for("KokkosSparse::bspmv<Transpose, Static>", policy,
                          func);
   }
@@ -1121,26 +1190,26 @@ struct BSR_GEMM_Functor {
   typedef typename AMatrix::non_const_size_type size_type;
 
   const value_type alpha;
+  const value_type beta;
+
   AMatrix m_A;
   XVector m_x;
   YVector m_y;
   const ordinal_type block_dim;
   const ordinal_type num_rhs;
 
-  const ordinal_type blocks_per_team;
-
   bool conjugate = false;
 
   BSR_GEMM_Functor(const value_type alpha_, const AMatrix m_A_,
-                   const XVector m_x_, const YVector m_y_,
-                   const int blocks_per_team_, bool conj_)
+                   const XVector m_x_, value_type beta_, const YVector m_y_,
+                   bool conj_)
       : alpha(alpha_),
+        beta(beta_),
         m_A(m_A_),
         m_x(m_x_),
         m_y(m_y_),
         block_dim(m_A_.blockDim()),
         num_rhs(m_x_.extent(1)),
-        blocks_per_team(blocks_per_team_),
         conjugate(conj_) {
     static_assert(static_cast<int>(XVector::rank) == 2,
                   "XVector must be a rank 2 View.");
@@ -1182,59 +1251,78 @@ struct BSR_GEMM_Functor {
         const auto xstart = row.block_colidx(ic) * block_dim;
         KokkosBatched::SerialGemmInternal<KokkosBatched::Algo::Gemm::Blocked>::
             invoke<value_type, value_type>(
-                block_dim, num_rhs, block_dim, alpha, Aview.data(), block_dim,
-                1, &m_x(xstart, 0), m_x.stride_0(), ldx, beta1, &m_y(ystart, 0),
-                m_y.stride_0(), ldy);
+                block_dim, num_rhs, block_dim, alpha, Aview.data(),
+                Aview.stride_0(), Aview.stride_1(), &m_x(xstart, 0),
+                m_x.stride_0(), ldx, beta1, &m_y(ystart, 0), m_y.stride_0(),
+                ldy);
       }
     }
   }
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const team_member &dev) const {
-    using y_value_type = typename YVector::non_const_value_type;
-    Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(dev, 0, blocks_per_team),
-        [&](const ordinal_type &loop) {
-          const ordinal_type iBlock =
-              static_cast<ordinal_type>(dev.league_rank()) * blocks_per_team +
-              loop;
-          if (iBlock >= m_A.numRows()) {
-            return;
-          }
-          //
-          const auto start = m_A.graph.row_map(iBlock);
-          const ordinal_type count =
-              static_cast<ordinal_type>(m_A.graph.row_map(iBlock + 1) - start);
-          const KokkosSparse::Experimental::BsrRowViewConst<AMatrix> row(
-              m_A.values, m_A.graph.entries, block_dim, count, start);
-          const auto nrhs = num_rhs;
-          //
-          for (ordinal_type ic = 0; ic < nrhs; ++ic) {
-            for (ordinal_type ir = 0; ir < block_dim; ++ir) {
-              y_value_type sum = 0;
+    using y_value_type        = typename YVector::non_const_value_type;
+    const ordinal_type iBlock = static_cast<ordinal_type>(dev.league_rank());
 
-              Kokkos::parallel_reduce(
-                  Kokkos::ThreadVectorRange(dev, count),
-                  [&](const ordinal_type &iEntry, y_value_type &lsum) {
-                    const auto start_col = row.block_colidx(iEntry) * block_dim;
-                    for (ordinal_type jr = 0; jr < block_dim; ++jr) {
-                      const value_type val =
-                          conjugate
-                              ? ATV::conj(row.local_block_value(iEntry, ir, jr))
-                              : row.local_block_value(iEntry, ir, jr);
-                      lsum += val * m_x(start_col + jr, ic);
-                    }
-                  },
-                  sum);
+    const size_type Y_ptBeg = iBlock * block_dim;
+    const size_type Y_ptEnd = Y_ptBeg + block_dim;
+    auto Y_cur = Kokkos::subview(m_y, ::Kokkos::make_pair(Y_ptBeg, Y_ptEnd),
+                                 Kokkos::ALL());
 
-              Kokkos::single(Kokkos::PerThread(dev), [&]() {
-                sum *= alpha;
-                m_y(iBlock * block_dim + ir, ic) += sum;
-              });
-            }
-          }
-          //
-        });
+    const y_value_type val_one = 1;
+    if (beta != val_one) {
+      KokkosBatched::TeamVectorScaleInternal::invoke(
+          dev, block_dim, num_rhs, beta, Y_cur.data(),
+          static_cast<int>(Y_cur.stride_0()),
+          static_cast<int>(Y_cur.stride_1()));
+    }
+
+    dev.team_barrier();
+
+    const auto myRow = m_A.block_row_Const(iBlock);
+    const auto count = myRow.length;
+
+    if (conjugate) {
+      for (ordinal_type jBlock = 0; jBlock < count; ++jBlock) {
+        const auto A_cur    = myRow.block(jBlock);
+        const auto X_blkCol = myRow.block_colidx(jBlock);
+        const auto X_ptBeg  = X_blkCol * block_dim;
+        const auto X_cur    = Kokkos::subview(
+            m_x, ::Kokkos::make_pair(X_ptBeg, X_ptBeg + block_dim),
+            Kokkos::ALL());
+        KokkosBatched::TeamVectorGemmInternal<
+            KokkosBatched::Algo::Gemm::Unblocked,
+            true>::invoke(dev, static_cast<int>(block_dim),
+                          static_cast<int>(num_rhs),
+                          static_cast<int>(block_dim), alpha, A_cur.data(),
+                          static_cast<int>(A_cur.stride_0()),
+                          static_cast<int>(A_cur.stride_1()), X_cur.data(),
+                          static_cast<int>(X_cur.stride_0()),
+                          static_cast<int>(X_cur.stride_1()), val_one,
+                          Y_cur.data(), static_cast<int>(Y_cur.stride_0()),
+                          static_cast<int>(Y_cur.stride_1()));
+      }
+    } else {
+      for (ordinal_type jBlock = 0; jBlock < count; ++jBlock) {
+        const auto A_cur    = myRow.block(jBlock);
+        const auto X_blkCol = myRow.block_colidx(jBlock);
+        const auto X_ptBeg  = X_blkCol * block_dim;
+        const auto X_cur    = Kokkos::subview(
+            m_x, ::Kokkos::make_pair(X_ptBeg, X_ptBeg + block_dim),
+            Kokkos::ALL());
+        KokkosBatched::TeamVectorGemmInternal<
+            KokkosBatched::Algo::Gemm::Unblocked,
+            false>::invoke(dev, static_cast<int>(block_dim),
+                           static_cast<int>(num_rhs),
+                           static_cast<int>(block_dim), alpha, A_cur.data(),
+                           static_cast<int>(A_cur.stride_0()),
+                           static_cast<int>(A_cur.stride_1()), X_cur.data(),
+                           static_cast<int>(X_cur.stride_0()),
+                           static_cast<int>(X_cur.stride_1()), val_one,
+                           Y_cur.data(), static_cast<int>(Y_cur.stride_0()),
+                           static_cast<int>(Y_cur.stride_1()));
+      }
+    }
   }
 };
 
@@ -1278,8 +1366,8 @@ void spMatMultiVec_no_transpose(
     }
   }
 
-  BSR_GEMM_Functor<AMatrix_Internal, XVector, YVector> func(alpha, A, x, y, 1,
-                                                            useConjugate);
+  BSR_GEMM_Functor<AMatrix_Internal, XVector, YVector> func(alpha, A, x, beta,
+                                                            y, useConjugate);
   if (((A.nnz() > 10000000) || use_dynamic_schedule) && !use_static_schedule) {
     Kokkos::parallel_for(
         "KokkosSparse::bsr_spm_mv<NoTranspose,Dynamic>",
@@ -1317,8 +1405,6 @@ void spMatMultiVec_no_transpose(
     return;
   }
 
-  KokkosBlas::scal(y, beta, y);
-
   typedef KokkosSparse::Experimental::BsrMatrix<
       AT, AO, AD, Kokkos::MemoryTraits<Kokkos::Unmanaged>, AS>
       AMatrix_Internal;
@@ -1333,9 +1419,25 @@ void spMatMultiVec_no_transpose(
       use_static_schedule = true;
     }
   }
-  int team_size           = -1;
-  int vector_length       = -1;
-  int64_t rows_per_thread = -1;
+
+  int team_size     = -1;
+  int vector_length = -1;
+  int64_t worksets  = A.numRows();
+
+  const auto block_dim = A.blockDim();
+  if (block_dim <= 4) {
+    vector_length = 4;
+    team_size     = 64;
+  } else if (block_dim <= 8) {
+    vector_length = 8;
+    team_size     = 32;
+  } else if (block_dim <= 16) {
+    vector_length = 16;
+    team_size     = 16;
+  } else {
+    vector_length = 32;
+    team_size     = 8;
+  }
 
   //
   // Use the controls to allow the user to pass in some tuning parameters.
@@ -1346,26 +1448,9 @@ void spMatMultiVec_no_transpose(
   if (controls.isParameter("vector length")) {
     vector_length = std::stoi(controls.getParameter("vector length"));
   }
-  if (controls.isParameter("rows per thread")) {
-    rows_per_thread = std::stoll(controls.getParameter("rows per thread"));
-  }
 
-  //
-  // Use the existing launch parameters routine from SPMV
-  //
-  const auto block_dim = A.blockDim();
-  int64_t rows_per_team =
-      KokkosSparse::Impl::spmv_launch_parameters<execution_space>(
-          A.numRows() * block_dim, A.nnz() * block_dim * block_dim,
-          rows_per_thread, team_size, vector_length);
-  int64_t blocks_per_team = (rows_per_team + block_dim - 1) / block_dim;
-  blocks_per_team         = (blocks_per_team < 1) ? 1 : blocks_per_team;
-  int64_t worksets = (A.numRows() + blocks_per_team - 1) / blocks_per_team;
-
-  AMatrix_Internal A_internal = A;
-
-  BSR_GEMM_Functor<AMatrix_Internal, XVector, YVector> func(
-      alpha, A_internal, x, y, blocks_per_team, useConjugate);
+  BSR_GEMM_Functor<AMatrix_Internal, XVector, YVector> func(alpha, A, x, beta,
+                                                            y, useConjugate);
 
   if (((A.nnz() > 10000000) || use_dynamic_schedule) && !use_static_schedule) {
     Kokkos::TeamPolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>
@@ -1417,20 +1502,16 @@ struct BSR_GEMM_Transpose_Functor {
   const ordinal_type block_dim;
   const ordinal_type num_rhs;
 
-  const ordinal_type blocks_per_team;
-
   bool conjugate = false;
 
-  BSR_GEMM_Transpose_Functor(const value_type alpha_, const AMatrix m_A_,
-                             const XVector m_x_, const YVector m_y_,
-                             const int blocks_per_team_, bool conj_)
+  BSR_GEMM_Transpose_Functor(const value_type alpha_, const AMatrix &m_A_,
+                             const XVector &m_x_, YVector &m_y_, bool conj_)
       : alpha(alpha_),
         m_A(m_A_),
         m_x(m_x_),
         m_y(m_y_),
         block_dim(m_A_.blockDim()),
         num_rhs(m_x_.extent(1)),
-        blocks_per_team(blocks_per_team_),
         conjugate(conj_) {
     static_assert(static_cast<int>(XVector::rank) == 2,
                   "XVector must be a rank 2 View.");
@@ -1492,45 +1573,86 @@ struct BSR_GEMM_Transpose_Functor {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const team_member &dev) const {
-    using y_value_type = typename YVector::non_const_value_type;
-    Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(dev, 0, blocks_per_team),
-        [&](const ordinal_type &loop) {
-          const ordinal_type iBlock =
-              static_cast<ordinal_type>(dev.league_rank()) * blocks_per_team +
-              loop;
-          if (iBlock >= m_A.numRows()) {
-            return;
-          }
-          //
-          const auto start = m_A.graph.row_map(iBlock);
-          const ordinal_type count =
-              static_cast<ordinal_type>(m_A.graph.row_map(iBlock + 1) - start);
-          const KokkosSparse::Experimental::BsrRowViewConst<AMatrix> row(
-              m_A.values, m_A.graph.entries, block_dim, count, start);
-          const auto nrhs = m_x.extent(1);
-          //
-          for (ordinal_type ic = 0; ic < nrhs; ++ic) {
-            for (ordinal_type ir = 0; ir < block_dim; ++ir) {
-              Kokkos::parallel_for(
-                  Kokkos::ThreadVectorRange(dev, count),
-                  [&](const ordinal_type &iEntry) {
-                    for (ordinal_type jr = 0; jr < block_dim; ++jr) {
-                      const value_type val =
-                          conjugate
-                              ? ATV::conj(row.local_block_value(iEntry, jr, ir))
-                              : row.local_block_value(iEntry, jr, ir);
-                      const ordinal_type ind = row.block_colidx(iEntry);
-                      Kokkos::atomic_add(
-                          &m_y(block_dim * ind + ir, ic),
-                          static_cast<y_value_type>(
-                              alpha * val * m_x(block_dim * iBlock + jr, ic)));
-                    }
-                  });
-            }
-          }
-          //
-        });
+    using y_value_type        = typename YVector::non_const_value_type;
+    const ordinal_type iBlock = static_cast<ordinal_type>(dev.league_rank());
+
+    const size_type X_ptBeg = iBlock * block_dim;
+    const size_type X_ptEnd = X_ptBeg + block_dim;
+    const auto X_cur        = Kokkos::subview(
+        m_x, ::Kokkos::make_pair(X_ptBeg, X_ptEnd), Kokkos::ALL());
+
+    const auto myRow = m_A.block_row_Const(iBlock);
+    const auto count = myRow.length;
+
+    const y_value_type val_zero = 0;
+    y_value_type *shared_y      = (y_value_type *)dev.team_shmem().get_shmem(
+        block_dim * num_rhs * sizeof(y_value_type));
+
+    if (conjugate) {
+      for (ordinal_type jBlock = 0; jBlock < count; ++jBlock) {
+        const auto A_cur = myRow.block(jBlock);
+        //
+        KokkosBatched::TeamVectorGemmInternal<
+            KokkosBatched::Algo::Gemm::Unblocked,
+            true>::invoke(dev, block_dim, num_rhs, block_dim, alpha,
+                          A_cur.data(), static_cast<int>(A_cur.stride_1()),
+                          static_cast<int>(A_cur.stride_0()), X_cur.data(),
+                          static_cast<int>(X_cur.stride_0()),
+                          static_cast<int>(X_cur.stride_1()), val_zero,
+                          shared_y, 1, block_dim);
+        //
+        dev.team_barrier();
+        //
+        const auto Y_blkCol = myRow.block_colidx(jBlock);
+        const auto Y_ptBeg  = Y_blkCol * block_dim;
+        auto Y_cur          = Kokkos::subview(
+            m_y, ::Kokkos::make_pair(Y_ptBeg, Y_ptBeg + block_dim),
+            Kokkos::ALL());
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(dev, 0, num_rhs),
+                             [&](const ordinal_type &kc) {
+                               Kokkos::parallel_for(
+                                   Kokkos::ThreadVectorRange(dev, 0, block_dim),
+                                   [&](const ordinal_type &kr) {
+                                     Kokkos::atomic_add(
+                                         &Y_cur(kr, kc),
+                                         shared_y[kr + kc * block_dim]);
+                                   });
+                             });
+        dev.team_barrier();
+      }
+    } else {
+      for (ordinal_type jBlock = 0; jBlock < count; ++jBlock) {
+        const auto A_cur = myRow.block(jBlock);
+        //
+        KokkosBatched::TeamVectorGemmInternal<
+            KokkosBatched::Algo::Gemm::Unblocked,
+            false>::invoke(dev, block_dim, num_rhs, block_dim, alpha,
+                           A_cur.data(), static_cast<int>(A_cur.stride_1()),
+                           static_cast<int>(A_cur.stride_0()), X_cur.data(),
+                           static_cast<int>(X_cur.stride_0()),
+                           static_cast<int>(X_cur.stride_1()), val_zero,
+                           shared_y, 1, block_dim);
+        //
+        dev.team_barrier();
+        //
+        const auto Y_blkCol = myRow.block_colidx(jBlock);
+        const auto Y_ptBeg  = Y_blkCol * block_dim;
+        auto Y_cur          = Kokkos::subview(
+            m_y, ::Kokkos::make_pair(Y_ptBeg, Y_ptBeg + block_dim),
+            Kokkos::ALL());
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(dev, 0, num_rhs),
+                             [&](const ordinal_type &kc) {
+                               Kokkos::parallel_for(
+                                   Kokkos::ThreadVectorRange(dev, 0, block_dim),
+                                   [&](const ordinal_type &kr) {
+                                     Kokkos::atomic_add(
+                                         &Y_cur(kr, kc),
+                                         shared_y[kr + kc * block_dim]);
+                                   });
+                             });
+        dev.team_barrier();
+      }
+    }
   }
 };
 
@@ -1563,8 +1685,6 @@ void spMatMultiVec_transpose(
       AMatrix_Internal;
   typedef typename AMatrix_Internal::execution_space execution_space;
 
-  AMatrix_Internal A_internal = A;
-
   bool use_dynamic_schedule = false;  // Forces the use of a dynamic schedule
   bool use_static_schedule  = false;  // Forces the use of a static schedule
   if (controls.isParameter("schedule")) {
@@ -1576,7 +1696,7 @@ void spMatMultiVec_transpose(
   }
 
   BSR_GEMM_Transpose_Functor<AMatrix_Internal, XVector, YVector> func(
-      alpha, A_internal, x, y, 1, useConjugate);
+      alpha, A, x, y, useConjugate);
   if (((A.nnz() > 10000000) || use_dynamic_schedule) && !use_static_schedule) {
     Kokkos::parallel_for(
         "KokkosSparse::bsr_spm_mv<Transpose,Dynamic>",
@@ -1620,9 +1740,24 @@ void spMatMultiVec_transpose(
       use_static_schedule = true;
     }
   }
-  int team_size           = -1;
-  int vector_length       = -1;
-  int64_t rows_per_thread = -1;
+  int team_size     = -1;
+  int vector_length = -1;
+  int64_t worksets  = A.numRows();
+
+  const auto block_dim = A.blockDim();
+  if (block_dim <= 4) {
+    vector_length = 4;
+    team_size     = 64;
+  } else if (block_dim <= 8) {
+    vector_length = 8;
+    team_size     = 32;
+  } else if (block_dim <= 8) {
+    vector_length = 16;
+    team_size     = 16;
+  } else {
+    vector_length = 32;
+    team_size     = 8;
+  }
 
   //
   // Use the controls to allow the user to pass in some tuning
@@ -1634,24 +1769,9 @@ void spMatMultiVec_transpose(
   if (controls.isParameter("vector length")) {
     vector_length = std::stoi(controls.getParameter("vector length"));
   }
-  if (controls.isParameter("rows per thread")) {
-    rows_per_thread = std::stoll(controls.getParameter("rows per thread"));
-  }
 
-  //
-  // Use the existing launch parameters routine from SPMV
-  //
-  const auto block_dim = A.blockDim();
-  int64_t rows_per_team =
-      KokkosSparse::Impl::spmv_launch_parameters<execution_space>(
-          A.numRows() * block_dim, A.nnz() * block_dim * block_dim,
-          rows_per_thread, team_size, vector_length);
-  int64_t blocks_per_team = (rows_per_team + block_dim - 1) / block_dim;
-  blocks_per_team         = (blocks_per_team < 1) ? 1 : blocks_per_team;
-  int64_t worksets = (A.numRows() + blocks_per_team - 1) / blocks_per_team;
-
-  BSR_GEMM_Transpose_Functor<AMatrix, XVector, YVector> func(
-      alpha, A, x, y, blocks_per_team, useConjugate);
+  BSR_GEMM_Transpose_Functor<AMatrix, XVector, YVector> func(alpha, A, x, y,
+                                                             useConjugate);
 
   if (((A.nnz() > 10000000) || use_dynamic_schedule) && !use_static_schedule) {
     Kokkos::TeamPolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>
@@ -1659,11 +1779,19 @@ void spMatMultiVec_transpose(
     if (team_size < 0)
       policy = Kokkos::TeamPolicy<execution_space,
                                   Kokkos::Schedule<Kokkos::Dynamic>>(
-          worksets, Kokkos::AUTO, vector_length);
+                   worksets, Kokkos::AUTO, vector_length)
+                   .set_scratch_size(
+                       0, Kokkos::PerTeam(
+                              block_dim * x.extent(1) *
+                              sizeof(typename YVector::non_const_value_type)));
     else
       policy = Kokkos::TeamPolicy<execution_space,
                                   Kokkos::Schedule<Kokkos::Dynamic>>(
-          worksets, team_size, vector_length);
+                   worksets, team_size, vector_length)
+                   .set_scratch_size(
+                       0, Kokkos::PerTeam(
+                              block_dim * x.extent(1) *
+                              sizeof(typename YVector::non_const_value_type)));
     Kokkos::parallel_for("KokkosSparse::bsr_spm_mv<Transpose,Dynamic>", policy,
                          func);
   } else {
@@ -1672,11 +1800,19 @@ void spMatMultiVec_transpose(
     if (team_size < 0)
       policy =
           Kokkos::TeamPolicy<execution_space, Kokkos::Schedule<Kokkos::Static>>(
-              worksets, Kokkos::AUTO, vector_length);
+              worksets, Kokkos::AUTO, vector_length)
+              .set_scratch_size(
+                  0, Kokkos::PerTeam(
+                         block_dim * x.extent(1) *
+                         sizeof(typename YVector::non_const_value_type)));
     else
       policy =
           Kokkos::TeamPolicy<execution_space, Kokkos::Schedule<Kokkos::Static>>(
-              worksets, team_size, vector_length);
+              worksets, team_size, vector_length)
+              .set_scratch_size(
+                  0, Kokkos::PerTeam(
+                         block_dim * x.extent(1) *
+                         sizeof(typename YVector::non_const_value_type)));
     Kokkos::parallel_for("KokkosSparse::bsr_spm_mv<Transpose, Static>", policy,
                          func);
   }

--- a/src/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
@@ -548,16 +548,16 @@ struct SPMV_Struct_Functor {
           const size_type rowOffset = m_A.graph.row_map(rowIdx);
 
           y_value_type sum(0.0);
-#if defined(KOKKOS_IF_HOST)
+#if defined(KOKKOS_IF_ON_HOST)
           // clang-format off
-          KOKKOS_IF_HOST((
+          KOKKOS_IF_ON_HOST((
           for (ordinal_type idx = 0; idx < 27; ++idx) {
             sum +=
                 m_A.values(rowOffset + idx) * m_x(rowIdx + columnOffsets(idx));
           }
           ))
 
-          KOKKOS_IF_DEVICE((
+          KOKKOS_IF_ON_DEVICE((
           Kokkos::parallel_reduce(
               Kokkos::ThreadVectorRange(dev, 27),
               [&](const ordinal_type& idx, y_value_type& lclSum) {


### PR DESCRIPTION
- Call a KokkosKernels BLAS routine for each operation of Y <- alpha OP(A) X + beta Y
- Add the conjugate option for two BLAS routines (GEMV and GEMM).