### PR TITLE
Add dimension checking to generic spmv interface

### DIFF
--- a/src/sparse/KokkosSparse_BlockCrsMatrix.hpp
+++ b/src/sparse/KokkosSparse_BlockCrsMatrix.hpp
@@ -848,6 +848,18 @@ class BlockCrsMatrix {
   //! The block dimension in the sparse block matrix.
   KOKKOS_INLINE_FUNCTION ordinal_type blockDim() const { return blockDim_; }
 
+  //! The number of "point" (non-block) rows in the matrix.
+  //  This is the dimension of the range of this matrix as a linear operator.
+  KOKKOS_INLINE_FUNCTION ordinal_type numPointRows() const {
+    return numRows() * blockDim();
+  }
+
+  //! The number of "point" (non-block) columns in the matrix.
+  //  This is the dimension of the domain of this matrix as a linear operator.
+  KOKKOS_INLINE_FUNCTION ordinal_type numPointCols() const {
+    return numCols() * blockDim();
+  }
+
   //! The number of stored entries in the sparse matrix.
   KOKKOS_INLINE_FUNCTION size_type nnz() const {
     return graph.entries.extent(0);

--- a/src/sparse/KokkosSparse_BsrMatrix.hpp
+++ b/src/sparse/KokkosSparse_BsrMatrix.hpp
@@ -870,6 +870,18 @@ class BsrMatrix {
   //! The block dimension in the sparse block matrix.
   KOKKOS_INLINE_FUNCTION ordinal_type blockDim() const { return blockDim_; }
 
+  //! The number of "point" (non-block) rows in the matrix.
+  //  This is the dimension of the range of this matrix as a linear operator.
+  KOKKOS_INLINE_FUNCTION ordinal_type numPointRows() const {
+    return numRows() * blockDim();
+  }
+
+  //! The number of "point" (non-block) columns in the matrix.
+  //  This is the dimension of the domain of this matrix as a linear operator.
+  KOKKOS_INLINE_FUNCTION ordinal_type numPointCols() const {
+    return numCols() * blockDim();
+  }
+
   //! The number of stored entries in the sparse matrix.
   KOKKOS_INLINE_FUNCTION size_type nnz() const {
     return graph.entries.extent(0);

--- a/src/sparse/KokkosSparse_CrsMatrix.hpp
+++ b/src/sparse/KokkosSparse_CrsMatrix.hpp
@@ -803,6 +803,14 @@ class CrsMatrix {
   //! The number of columns in the sparse matrix.
   KOKKOS_INLINE_FUNCTION ordinal_type numCols() const { return numCols_; }
 
+  //! The number of "point" (non-block) rows in the matrix. Since Crs is not
+  //! blocked, this is just the number of regular rows.
+  KOKKOS_INLINE_FUNCTION ordinal_type numPointRows() const { return numRows(); }
+
+  //! The number of "point" (non-block) columns in the matrix. Since Crs is not
+  //! blocked, this is just the number of regular columns.
+  KOKKOS_INLINE_FUNCTION ordinal_type numPointCols() const { return numCols(); }
+
   //! The number of stored entries in the sparse matrix.
   KOKKOS_INLINE_FUNCTION size_type nnz() const {
     return graph.entries.extent(0);


### PR DESCRIPTION
Generic KokkosSparse::spmv (where AMatrix can be Crs, Bsr or BlockCrs)
didn't check that the dimensions of A, x and y were compatible. If it
takes the alpha=0 shortcut, this would never get checked. A Tpetra test
relied on this throwing (see #1291), so this adds that check in.