### PR TITLE
Revert "Kokkos synch up: remove macro usage"

### DIFF
--- a/src/batched/dense/impl/KokkosBatched_Axpy_Impl.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Axpy_Impl.hpp
@@ -223,14 +223,14 @@ KOKKOS_INLINE_FUNCTION int SerialAxpy::invoke(const alphaViewType& alpha,
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-    printf(
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::axpy: Dimensions of X and Y do not match: X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
     return 1;
   }
   if (X.extent(0) != alpha.extent(0)) {
-    printf(
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::axpy: First dimension of X and alpha do not match: X: "
         "%d x %d, alpha: %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
@@ -270,14 +270,14 @@ KOKKOS_INLINE_FUNCTION int TeamAxpy<MemberType>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-    printf(
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::axpy: Dimensions of X and Y do not match: X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
     return 1;
   }
   if (X.extent(0) != alpha.extent(0)) {
-    printf(
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::axpy: First dimension of X and alpha do not match: X: "
         "%d x %d, alpha: %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
@@ -318,14 +318,14 @@ KOKKOS_INLINE_FUNCTION int TeamVectorAxpy<MemberType>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-    printf(
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::axpy: Dimensions of X and Y do not match: X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
     return 1;
   }
   if (X.extent(0) != alpha.extent(0)) {
-    printf(
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::axpy: First dimension of X and alpha do not match: X: "
         "%d x %d, alpha: %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));

--- a/src/batched/sparse/KokkosBatched_JacobiPrec.hpp
+++ b/src/batched/sparse/KokkosBatched_JacobiPrec.hpp
@@ -132,7 +132,7 @@ class JacobiPrec {
     }
 
     if (tooSmall > 0)
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::JacobiPrec: %d entrie(s) has/have a too small "
           "magnitude and have been replaced by one, \n",
           (int)tooSmall);

--- a/src/batched/sparse/impl/KokkosBatched_Spmv_Serial_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_Spmv_Serial_Impl.hpp
@@ -179,7 +179,7 @@ struct SerialSpmv<Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
           "%d, Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -187,21 +187,21 @@ struct SerialSpmv<Trans::NoTranspose> {
       return 1;
     }
     if (X.extent(0) != alpha.extent(0)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and alpha do not match: "
           "X: %d x %d, alpha: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
       return 1;
     }
     if (X.extent(0) != beta.extent(0)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and beta do not match: X: "
           "%d x %d, beta: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)beta.extent(0));
       return 1;
     }
     if (X.extent(0) != values.extent(0)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and the first dimension "
           "of values do not match: X: %d x %d, values: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
@@ -209,7 +209,7 @@ struct SerialSpmv<Trans::NoTranspose> {
       return 1;
     }
     if (colIndices.extent(0) != values.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of colIndices and the second "
           "dimension of values do not match: colIndices: %d , values: %d x "
           "%d\n",
@@ -218,7 +218,7 @@ struct SerialSpmv<Trans::NoTranspose> {
       return 1;
     }
     if (row_ptr.extent(0) - 1 != X.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
           "of X do not match: colIndices (-1): %d , values: %d x %d\n",
           (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));

--- a/src/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
@@ -221,7 +221,7 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
           "%d, Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -229,21 +229,21 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (X.extent(0) != alpha.extent(0)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and alpha do not match: "
           "X: %d x %d, alpha: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
       return 1;
     }
     if (X.extent(0) != beta.extent(0)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and beta do not match: X: "
           "%d x %d, beta: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)beta.extent(0));
       return 1;
     }
     if (X.extent(0) != values.extent(0)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and the first dimension "
           "of values do not match: X: %d x %d, values: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
@@ -251,7 +251,7 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (colIndices.extent(0) != values.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of colIndices and the second "
           "dimension of values do not match: colIndices: %d , values: %d x "
           "%d\n",
@@ -260,7 +260,7 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (row_ptr.extent(0) - 1 != X.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
           "of X do not match: colIndices (-1): %d , values: %d x %d\n",
           (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));

--- a/src/batched/sparse/impl/KokkosBatched_Spmv_Team_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_Spmv_Team_Impl.hpp
@@ -217,7 +217,7 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
           "%d, Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -225,21 +225,21 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (X.extent(0) != alpha.extent(0)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and alpha do not match: "
           "X: %d x %d, alpha: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
       return 1;
     }
     if (X.extent(0) != beta.extent(0)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and beta do not match: X: "
           "%d x %d, beta: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)beta.extent(0));
       return 1;
     }
     if (X.extent(0) != values.extent(0)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and the first dimension "
           "of values do not match: X: %d x %d, values: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
@@ -247,7 +247,7 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (colIndices.extent(0) != values.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of colIndices and the second "
           "dimension of values do not match: colIndices: %d , values: %d x "
           "%d\n",
@@ -256,7 +256,7 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (row_ptr.extent(0) - 1 != X.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
           "of X do not match: colIndices (-1): %d , values: %d x %d\n",
           (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));

--- a/unit_test/common/Test_Common_ArithTraits.hpp
+++ b/unit_test/common/Test_Common_ArithTraits.hpp
@@ -63,14 +63,17 @@
 #include <typeinfo>  // typeid (T)
 #include <cstdio>
 
-#define FAILURE()                                                \
-  {                                                              \
-    printf("%s:%s:%d: Failure\n", __FILE__, __func__, __LINE__); \
-    success = 0;                                                 \
+#define FAILURE()                                                            \
+  {                                                                          \
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF("%s:%s:%d: Failure\n", __FILE__, __func__, \
+                                  __LINE__);                                 \
+    success = 0;                                                             \
   }
 
 #if 0
-#define TRACE() printf("%s:%s:%d: Trace\n", __FILE__, __func__, __LINE__);
+#define TRACE()                                                          \
+  KOKKOS_IMPL_DO_NOT_USE_PRINTF("%s:%s:%d: Trace\n", __FILE__, __func__, \
+                                __LINE__);
 #else
 #define TRACE()
 #endif
@@ -206,7 +209,7 @@ class ArithTraitsTesterBase {
     // T, but we check for this int constant for compatibility with
     // std::numeric_limits.
     if (!AT::is_specialized) {
-      printf("! AT::is_specialized\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("! AT::is_specialized\n");
       FAILURE();
     }
 
@@ -214,11 +217,13 @@ class ArithTraitsTesterBase {
     // function, just not to its class methods (which are not marked
     // as device functions).
     if (AT::is_integer != std::numeric_limits<ScalarType>::is_integer) {
-      printf("AT::is_integer not same as numeric_limits\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "AT::is_integer not same as numeric_limits\n");
       FAILURE();
     }
     if (AT::is_exact != std::numeric_limits<ScalarType>::is_exact) {
-      printf("AT::is_exact not same as numeric_limits\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "AT::is_exact not same as numeric_limits\n");
       FAILURE();
     }
 
@@ -227,34 +232,34 @@ class ArithTraitsTesterBase {
 
     // Test properties of the arithmetic and multiplicative identities.
     if (zero + zero != zero) {
-      printf("0 + 0 != 0\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("0 + 0 != 0\n");
       FAILURE();
     }
     if (zero + one != one) {
-      printf("0 + 1 != 1\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("0 + 1 != 1\n");
       FAILURE();
     }
     if (one - one != zero) {
-      printf("1 - 1 != 0\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("1 - 1 != 0\n");
       FAILURE();
     }
     // This is technically 1 even of Z_2, since in that field, one
     // is its own inverse (so -one == one).
     if ((one + one) - one != one) {
-      printf("(1 + 1) - 1 != 1\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("(1 + 1) - 1 != 1\n");
       FAILURE();
     }
 
     if (AT::abs(zero) != zero) {
-      printf("AT::abs(0) != 0\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::abs(0) != 0\n");
       FAILURE();
     }
     if (AT::abs(one) != one) {
-      printf("AT::abs(1) != 1\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::abs(1) != 1\n");
       FAILURE();
     }
     if (AT::is_signed && AT::abs(-one) != one) {
-      printf("AT::is_signed and AT::abs(-1) != 1\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::is_signed and AT::abs(-1) != 1\n");
       FAILURE();
     }
     // Need enable_if to test whether T can be compared using <=.
@@ -263,7 +268,7 @@ class ArithTraitsTesterBase {
     // These are very mild ordering properties.
     // They should work even for a set only containing zero.
     if (AT::abs(zero) > AT::abs(AT::max())) {
-      printf("AT::abs(0) > AT::abs (AT::max ())\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::abs(0) > AT::abs (AT::max ())\n");
       FAILURE();
     }
 
@@ -580,20 +585,20 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
     if (!AT::is_complex) {
       result = AT::pow(two, three);
       if (!equal(result, eight)) {
-        printf("AT::pow(2,3) != 8\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(2,3) != 8\n");
         FAILURE();
       }
     }
     if (!equal(AT::pow(three, zero), one)) {
-      printf("AT::pow(3,0) != 1\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(3,0) != 1\n");
       FAILURE();
     }
     if (!equal(AT::pow(three, one), three)) {
-      printf("AT::pow(3,1) != 3\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(3,1) != 3\n");
       FAILURE();
     }
     if (!equal(AT::pow(three, two), nine)) {
-      printf("AT::pow(3,2) != 9\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(3,2) != 9\n");
       FAILURE();
     }
 
@@ -601,7 +606,7 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
     if (!AT::is_complex) {
       result = AT::pow(three, three);
       if (!equal(result, twentySeven)) {
-        printf("AT::pow(3,3) != 27\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(3,3) != 27\n");
         FAILURE();
       }
     }
@@ -610,92 +615,93 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
     if (AT::is_signed && !AT::is_complex) {
       result = AT::pow(-three, one);
       if (!equal(result, -three)) {
-        printf("AT::pow(-3,1) != -3\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(-3,1) != -3\n");
         FAILURE();
       }
       result = AT::pow(-three, two);
       if (!equal(result, nine)) {
-        printf("AT::pow(-3,2) != 9\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(-3,2) != 9\n");
         FAILURE();
       }
       result = AT::pow(-three, three);
       if (!equal(result, -twentySeven)) {
-        printf("AT::pow(-3,3) != 27\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(-3,3) != 27\n");
         FAILURE();
       }
     }
 
     if (!equal(AT::sqrt(zero), zero)) {
-      printf("AT::sqrt(0) != 0\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::sqrt(0) != 0\n");
       FAILURE();
     }
     if (!equal(AT::sqrt(one), one)) {
-      printf("AT::sqrt(1) != 1\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::sqrt(1) != 1\n");
       FAILURE();
     }
     if (!equal(AT::sqrt(thirtySix), six)) {
-      printf("AT::sqrt(36) != 6\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::sqrt(36) != 6\n");
       FAILURE();
     }
     if (!equal(AT::sqrt(sixtyFour), eight)) {
-      printf("AT::sqrt(64) != 8\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::sqrt(64) != 8\n");
       FAILURE();
     }
     if (AT::is_integer) {
       if (!equal(AT::sqrt(fortyTwo), six)) {
-        printf("AT:sqrt(42) != 6\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT:sqrt(42) != 6\n");
         FAILURE();
       }
       if (!equal(AT::sqrt(oneTwentySeven), eleven)) {
-        printf("AT::sqrt(127) != 11\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::sqrt(127) != 11\n");
         FAILURE();
       }
     }
 
     if (!equal(AT::cbrt(zero), zero)) {
-      printf("AT::cbrt(0) != 0\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(0) != 0\n");
       FAILURE();
     }
     if (!equal(AT::cbrt(one), one)) {
-      printf("AT::cbrt(1) != 1\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(1) != 1\n");
       FAILURE();
     }
     if (!equal(AT::cbrt(twentySeven), three)) {
-      printf("AT::cbrt(27) != 3\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(27) != 3\n");
       FAILURE();
     }
     if (!equal(AT::cbrt(sixtyFour), four)) {
-      printf("AT::cbrt(64) != 4\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(64) != 4\n");
       FAILURE();
     }
     if (AT::is_integer) {
       if (!equal(AT::cbrt(fortyTwo), three)) {
-        printf("AT:cbrt(42) != 3\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT:cbrt(42) != 3\n");
         FAILURE();
       }
       if (!equal(AT::cbrt(oneTwentySeven), five)) {
-        printf("AT::cbrt(127) != 5\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(127) != 5\n");
         FAILURE();
       }
     }
 
     if (!equal(AT::exp(zero), one)) {
-      printf("AT::cbrt(0) != 1\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(0) != 1\n");
       FAILURE();
     }
     if (AT::is_complex) {
       const ScalarType val = two;  //(two.real(), two.real());
       if (!equal(AT::conj(AT::exp(val)), AT::exp(AT::conj(val)))) {
-        printf("AT::conj(exp(complex(2,2))) != AT::exp(conj(complex(2,2)))\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+            "AT::conj(exp(complex(2,2))) != AT::exp(conj(complex(2,2)))\n");
         FAILURE();
       }
     }
     if (!equal(AT::log(one), zero)) {
-      printf("AT::log(1) != 0\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::log(1) != 0\n");
       FAILURE();
     }
     if (!equal(AT::log10(one), zero)) {
-      printf("AT::log10(1) != 0\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::log10(1) != 0\n");
       FAILURE();
     }
 
@@ -704,11 +710,13 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
       const auto val_sin = AT::sin(val);
       const auto val_cos = AT::cos(val);
       if (!equal(val_sin * val_sin + val_cos * val_cos, one)) {
-        printf("AT(complex):: sin(val)*sin(val) + cos(val)*cos(val) != 1\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+            "AT(complex):: sin(val)*sin(val) + cos(val)*cos(val) != 1\n");
         FAILURE();
       }
       if (!equal(val_sin / val_cos, AT::tan(val))) {
-        printf("AT(complex):: sin(val)/cos(val) != AT(real)::tan(val)\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+            "AT(complex):: sin(val)/cos(val) != AT(real)::tan(val)\n");
         FAILURE();
       }
     } else {
@@ -716,25 +724,27 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
       const auto val_sin = AT::sin(val);
       const auto val_cos = AT::cos(val);
       if (!equal(val_sin * val_sin + val_cos * val_cos, one)) {
-        printf("AT(real):: sin(val)*sin(val) + cos(a)*cos(a) != 1\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+            "AT(real):: sin(val)*sin(val) + cos(a)*cos(a) != 1\n");
         FAILURE();
       }
       if (!equal(val_sin / val_cos, AT::tan(val))) {
-        printf("AT(real):: sin(val)/cos(val) != AT(real)::tan(val)\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+            "AT(real):: sin(val)/cos(val) != AT(real)::tan(val)\n");
         FAILURE();
       }
     }
 
     if (!equal(AT::asin(AT::sin(one)), one)) {
-      printf("AT::asin(sin(1)) != 1\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::asin(sin(1)) != 1\n");
       FAILURE();
     }
     if (!equal(AT::acos(AT::cos(one)), one)) {
-      printf("AT::acos(cos(1)) != 1\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::acos(cos(1)) != 1\n");
       FAILURE();
     }
     if (!equal(AT::atan(AT::tan(one)), one)) {
-      printf("AT::atan(tan(1)) != 1\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::atan(tan(1)) != 1\n");
       FAILURE();
     }
 
@@ -861,40 +871,41 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
     }
 
     if (!equal(AT::cbrt(zero), zero)) {
-      printf("AT::cbrt(0) != 0\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(0) != 0\n");
       FAILURE();
     }
     if (!equal(AT::cbrt(one), one)) {
-      printf("AT::cbrt(1) != 1\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(1) != 1\n");
       FAILURE();
     }
     if (!equal(AT::cbrt(twentySeven), three)) {
-      printf("AT::cbrt(27) != 3\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(27) != 3\n");
       FAILURE();
     }
     if (!equal(AT::cbrt(sixtyFour), four)) {
-      printf("AT::cbrt(64) != 4\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(64) != 4\n");
       FAILURE();
     }
     if (AT::is_integer) {
       if (!equal(AT::cbrt(fortyTwo), three)) {
-        printf("AT:cbrt(42) != 3\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT:cbrt(42) != 3\n");
         FAILURE();
       }
       if (!equal(AT::cbrt(oneTwentySeven), five)) {
-        printf("AT::cbrt(127) != 5\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(127) != 5\n");
         FAILURE();
       }
     }
 
     if (!equal(AT::exp(zero), one)) {
-      printf("AT::cbrt(0) != 1\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(0) != 1\n");
       FAILURE();
     }
     if (AT::is_complex) {
       const ScalarType val = two;  //(two.real(), two.real());
       if (!equal(AT::conj(AT::exp(val)), AT::exp(AT::conj(val)))) {
-        printf("AT::conj(exp(complex(2,0))) != AT::exp(conj(complex(2,0)))\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+            "AT::conj(exp(complex(2,0))) != AT::exp(conj(complex(2,0)))\n");
         FAILURE();
       }
     }
@@ -912,11 +923,13 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
       const auto val_sin   = AT::sin(val);
       const auto val_cos   = AT::cos(val);
       if (!equal(val_sin * val_sin + val_cos * val_cos, one)) {
-        printf("AT(complex):: sin(val)*sin(val) + cos(val)*cos(val) != 1\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+            "AT(complex):: sin(val)*sin(val) + cos(val)*cos(val) != 1\n");
         FAILURE();
       }
       if (!equal(val_sin / val_cos, AT::tan(val))) {
-        printf("AT(complex):: sin(val)/cos(val) != AT(real)::tan(val)\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+            "AT(complex):: sin(val)/cos(val) != AT(real)::tan(val)\n");
         FAILURE();
       }
     } else {
@@ -924,25 +937,27 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
       const auto val_sin   = AT::sin(val);
       const auto val_cos   = AT::cos(val);
       if (!equal(val_sin * val_sin + val_cos * val_cos, one)) {
-        printf("AT(real):: sin(val)*sin(val) + cos(a)*cos(a) != 1\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+            "AT(real):: sin(val)*sin(val) + cos(a)*cos(a) != 1\n");
         FAILURE();
       }
       if (!equal(val_sin / val_cos, AT::tan(val))) {
-        printf("AT(real):: sin(val)/cos(val) != AT(real)::tan(val)\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+            "AT(real):: sin(val)/cos(val) != AT(real)::tan(val)\n");
         FAILURE();
       }
     }
 
     if (!equal(AT::asin(AT::sin(three)), three)) {
-      printf("AT::asin(sin(3)) != 3\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::asin(sin(3)) != 3\n");
       FAILURE();
     }
     if (!equal(AT::acos(AT::cos(three)), three)) {
-      printf("AT::acos(cos(3)) != 3\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::acos(cos(3)) != 3\n");
       FAILURE();
     }
     if (!equal(AT::atan(AT::tan(three)), three)) {
-      printf("AT::atan(tan(3)) != 3\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::atan(tan(3)) != 3\n");
       FAILURE();
     }
 
@@ -1035,7 +1050,7 @@ class ArithTraitsTesterComplexBase<ScalarType, DeviceType, 0>
 #else
     {
       if (AT::is_signed != std::numeric_limits<ScalarType>::is_signed) {
-        printf(
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
             "AT::is_signed = 0x%x, std::numeric_limits<ScalarType>::is_signed "
             "= 0x%x\n",
             AT::is_signed, std::numeric_limits<ScalarType>::is_signed);
@@ -1256,12 +1271,12 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 0>
     int success = 1;
 
     if (AT::is_exact) {
-      printf("AT::is_exact is 1\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::is_exact is 1\n");
       FAILURE();
     }
 
     if (!AT::isNan(AT::nan())) {
-      printf("NaN is not NaN\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("NaN is not NaN\n");
       FAILURE();
     }
 
@@ -1269,19 +1284,19 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 0>
     const ScalarType one  = AT::one();
 
     if (AT::isInf(zero)) {
-      printf("0 is Inf\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("0 is Inf\n");
       FAILURE();
     }
     if (AT::isInf(one)) {
-      printf("1 is Inf\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("1 is Inf\n");
       FAILURE();
     }
     if (AT::isNan(zero)) {
-      printf("0 is NaN\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("0 is NaN\n");
       FAILURE();
     }
     if (AT::isNan(one)) {
-      printf("1 is NaN\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("1 is NaN\n");
       FAILURE();
     }
 
@@ -1377,7 +1392,7 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 1>
     int success = 1;
 
     if (!AT::is_exact) {
-      printf("! AT:is_exact\n");
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("! AT:is_exact\n");
       FAILURE();
     }
 


### PR DESCRIPTION
Partly reverts eda2cc45ccc829528e3c9d84ce489f7a787025de in accordance with https://github.com/kokkos/kokkos/pull/4732.

Apparently, the `printf` in the global namespace only worked by accident for a few releases but is broken again in recent releases...