### PR TITLE
Fix 1303: maintain correct #cols on A in twostage

### DIFF
--- a/src/sparse/impl/KokkosSparse_twostage_gauss_seidel_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_twostage_gauss_seidel_impl.hpp
@@ -916,8 +916,8 @@ class TwostageGaussSeidel {
         gsHandle->getUa();  // complement of U+D (used only for compact form)
 
     // wratp A into crsmat
-    input_graph_t graphA(column_view, rowmap_view);
-    input_crsmat_t crsmatA("A", num_rows, values_view, graphA);
+    input_crsmat_t crsmatA("A", num_rows, num_cols, values_view.extent(0),
+                           values_view, rowmap_view, column_view);
 #ifdef KOKKOSSPARSE_IMPL_TIME_TWOSTAGE_GS
     Kokkos::fence();
     tic = timer.seconds();


### PR DESCRIPTION
#1303 

Tested by building Trilinos with serial backend, kokkos-promotion branch, with kokkos version 72efefa. Ifpack2_SGSMT_compare_with_Jacobi_MPI_4 now passes.