### PR TITLE
Fix std::abs calls for rocBLAS/rocSparse

### DIFF
--- a/perf_test/sparse/KokkosSparse_spmv_blockcrs.cpp
+++ b/perf_test/sparse/KokkosSparse_spmv_blockcrs.cpp
@@ -223,11 +223,9 @@ int test_blockcrs_matrix_single_vec(
     Kokkos::deep_copy(h_yblockcrs, yblockcrs);
     double error = 0.0, maxNorm = 0.0;
     for (size_t ir = 0; ir < h_ycrs.extent(0); ++ir) {
-      maxNorm = std::max<double>(
-          maxNorm, std::abs<double>(static_cast<double>(h_ycrs(ir))));
-      error = std::max<double>(
-          error,
-          std::abs<double>(static_cast<double>(h_ycrs(ir) - h_yblockcrs(ir))));
+      maxNorm = std::max(maxNorm, std::abs(static_cast<double>(h_ycrs(ir))));
+      error   = std::max(
+          error, std::abs(static_cast<double>(h_ycrs(ir) - h_yblockcrs(ir))));
     }
 
     double tol =
@@ -357,11 +355,10 @@ int test_blockcrs_matrix_vec(
     for (int jc = 0; jc < nvec; ++jc) {
       double error = 0.0, maxNorm = 0.0;
       for (size_t ir = 0; ir < h_ycrs.extent(0); ++ir) {
-        maxNorm = std::max<double>(
-            maxNorm, std::abs<double>(static_cast<double>(h_ycrs(ir, jc))));
-        error =
-            std::max<double>(error, std::abs<double>(static_cast<double>(
-                                        h_ycrs(ir, jc) - h_yblockcrs(ir, jc))));
+        maxNorm =
+            std::max(maxNorm, std::abs(static_cast<double>(h_ycrs(ir, jc))));
+        error = std::max(error, std::abs(static_cast<double>(
+                                    h_ycrs(ir, jc) - h_yblockcrs(ir, jc))));
       }
       if (error > tol * maxNorm) {
         num_errors += 1;

--- a/perf_test/sparse/KokkosSparse_spmv_bsr.cpp
+++ b/perf_test/sparse/KokkosSparse_spmv_bsr.cpp
@@ -241,11 +241,9 @@ int test_bsr_matrix_single_vec(
     Kokkos::deep_copy(h_ybsr, ybsr);
     double error = 0.0, maxNorm = 0.0;
     for (size_t ir = 0; ir < h_ycrs.extent(0); ++ir) {
-      maxNorm = std::max<double>(
-          maxNorm, std::abs<double>(static_cast<double>(h_ycrs(ir))));
-      error = std::max<double>(
-          error,
-          std::abs<double>(static_cast<double>(h_ycrs(ir) - h_ybsr(ir))));
+      maxNorm = std::max(maxNorm, std::abs(static_cast<double>(h_ycrs(ir))));
+      error   = std::max(error,
+                       std::abs(static_cast<double>(h_ycrs(ir) - h_ybsr(ir))));
     }
 
     double tol =
@@ -406,10 +404,10 @@ int test_bsr_matrix_vec(
     for (int jc = 0; jc < nvec; ++jc) {
       double error = 0.0, maxNorm = 0.0;
       for (size_t ir = 0; ir < h_ycrs.extent(0); ++ir) {
-        maxNorm = std::max<double>(
-            maxNorm, std::abs<double>(static_cast<double>(h_ycrs(ir, jc))));
-        error = std::max<double>(error, std::abs<double>(static_cast<double>(
-                                            h_ycrs(ir, jc) - h_ybsr(ir, jc))));
+        maxNorm =
+            std::max(maxNorm, std::abs(static_cast<double>(h_ycrs(ir, jc))));
+        error = std::max(error, std::abs(static_cast<double>(h_ycrs(ir, jc) -
+                                                             h_ybsr(ir, jc))));
       }
       if (error > tol * maxNorm) {
         num_errors += 1;

--- a/unit_test/sparse/Test_Sparse_spmv_blockcrs.hpp
+++ b/unit_test/sparse/Test_Sparse_spmv_blockcrs.hpp
@@ -197,10 +197,10 @@ void check_blockcrs_times_v(const char fOp[], scalar_t alpha, scalar_t beta,
     Kokkos::deep_copy(h_ycrs, ycrs);
     Kokkos::deep_copy(h_ybcrs, ybcrs);
     for (lno_t ir = 0; ir < nRow; ++ir) {
-      error = std::max<double>(
+      error = std::max(
           error, Kokkos::ArithTraits<scalar_t>::abs(h_ycrs(ir) - h_ybcrs(ir)));
-      maxNorm = std::max<double>(
-          maxNorm, Kokkos::ArithTraits<scalar_t>::abs(h_ycrs(ir)));
+      maxNorm =
+          std::max(maxNorm, Kokkos::ArithTraits<scalar_t>::abs(h_ycrs(ir)));
     }
 
     double tmps =
@@ -350,10 +350,10 @@ void check_blockcrs_times_mv(const char fOp[], scalar_t alpha, scalar_t beta,
     double error = 0.0, maxNorm = 0.0;
     for (int jc = 0; jc < nrhs; ++jc) {
       for (int ir = 0; ir < nRow; ++ir) {
-        error   = std::max<double>(error, Kokkos::ArithTraits<scalar_t>::abs(
-                                            h_ycrs(ir, jc) - h_ybcrs(ir, jc)));
-        maxNorm = std::max<double>(
-            maxNorm, Kokkos::ArithTraits<scalar_t>::abs(h_ycrs(ir, jc)));
+        error   = std::max(error, Kokkos::ArithTraits<scalar_t>::abs(
+                                    h_ycrs(ir, jc) - h_ybcrs(ir, jc)));
+        maxNorm = std::max(maxNorm,
+                           Kokkos::ArithTraits<scalar_t>::abs(h_ycrs(ir, jc)));
       }
     }
     auto tol = ((nnz / nRow) + 1) *

--- a/unit_test/sparse/Test_Sparse_spmv_bsr.hpp
+++ b/unit_test/sparse/Test_Sparse_spmv_bsr.hpp
@@ -233,10 +233,10 @@ void check_bsrm_times_v(const char fOp[], scalar_t alpha, scalar_t beta,
     Kokkos::deep_copy(h_ycrs, ycrs);
     Kokkos::deep_copy(h_ybsr, ybsr);
     for (lno_t ir = 0; ir < nRow; ++ir) {
-      error = std::max<double>(
+      error = std::max(
           error, Kokkos::ArithTraits<scalar_t>::abs(h_ycrs(ir) - h_ybsr(ir)));
-      maxNorm = std::max<double>(
-          maxNorm, Kokkos::ArithTraits<scalar_t>::abs(h_ycrs(ir)));
+      maxNorm =
+          std::max(maxNorm, Kokkos::ArithTraits<scalar_t>::abs(h_ycrs(ir)));
     }
 
     double tmps =
@@ -369,10 +369,10 @@ void check_bsrm_times_mv(const char fOp[], scalar_t alpha, scalar_t beta,
     double error = 0.0, maxNorm = 0.0;
     for (int jc = 0; jc < nrhs; ++jc) {
       for (int ir = 0; ir < nRow; ++ir) {
-        error   = std::max<double>(error, Kokkos::ArithTraits<scalar_t>::abs(
-                                            h_ycrs(ir, jc) - h_ybsr(ir, jc)));
-        maxNorm = std::max<double>(
-            maxNorm, Kokkos::ArithTraits<scalar_t>::abs(h_ycrs(ir, jc)));
+        error   = std::max(error, Kokkos::ArithTraits<scalar_t>::abs(
+                                    h_ycrs(ir, jc) - h_ybsr(ir, jc)));
+        maxNorm = std::max(maxNorm,
+                           Kokkos::ArithTraits<scalar_t>::abs(h_ycrs(ir, jc)));
       }
     }
 


### PR DESCRIPTION
rocBLAS and rocSparse both overload the template std::abs<T>
instead of creating specializations for each type, e.g. ``rocblas_complex_num<double>``.
This breaks calls like ``std::abs<double>(x)`` because it's now ambiguous, even if x is
double. Fix by just letting the compiler deduce which type and overload to use.

With this, 100% building and passing on Crusher :)