### PR TITLE
Use the SYCL workaround for printf in a couple more places

### DIFF
--- a/src/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
@@ -169,7 +169,7 @@ struct SerialDot<Trans::Transpose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
           "Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -177,7 +177,7 @@ struct SerialDot<Trans::Transpose> {
       return 1;
     }
     if (X.extent(1) != dot.extent(0)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: Second dimension of X and alpha do not match: "
           "X: "
           "%d x %d, dot: %d\n",
@@ -215,7 +215,7 @@ struct SerialDot<Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
           "Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -223,7 +223,7 @@ struct SerialDot<Trans::NoTranspose> {
       return 1;
     }
     if (X.extent(0) != dot.extent(0)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: First dimension of X and alpha do not match: X: "
           "%d x %d, dot: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
@@ -264,7 +264,7 @@ struct TeamDot<MemberType, Trans::Transpose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
           "Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -272,7 +272,7 @@ struct TeamDot<MemberType, Trans::Transpose> {
       return 1;
     }
     if (X.extent(1) != dot.extent(0)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: Second dimension of X and alpha do not match: "
           "X: "
           "%d x %d, dot: %d\n",
@@ -311,7 +311,7 @@ struct TeamDot<MemberType, Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
           "Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -319,7 +319,7 @@ struct TeamDot<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (X.extent(0) != dot.extent(0)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: First dimension of X and alpha do not match: X: "
           "%d x %d, dot: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
@@ -360,7 +360,7 @@ struct TeamVectorDot<MemberType, Trans::Transpose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
           "Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -368,7 +368,7 @@ struct TeamVectorDot<MemberType, Trans::Transpose> {
       return 1;
     }
     if (X.extent(1) != dot.extent(0)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: Second dimension of X and alpha do not match: "
           "X: "
           "%d x %d, dot: %d\n",
@@ -407,7 +407,7 @@ struct TeamVectorDot<MemberType, Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
           "Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -415,7 +415,7 @@ struct TeamVectorDot<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (X.extent(0) != dot.extent(0)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: First dimension of X and alpha do not match: X: "
           "%d x %d, dot: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));

--- a/src/batched/dense/impl/KokkosBatched_HadamardProduct_Impl.hpp
+++ b/src/batched/dense/impl/KokkosBatched_HadamardProduct_Impl.hpp
@@ -136,7 +136,7 @@ KOKKOS_INLINE_FUNCTION int SerialHadamardProduct::invoke(const XViewType& X,
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-    printf(
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::HadamardProduct: Dimensions of X and Y do not match: "
         "X: %d x %d, "
         "Y: %d x %d\n",
@@ -144,7 +144,7 @@ KOKKOS_INLINE_FUNCTION int SerialHadamardProduct::invoke(const XViewType& X,
     return 1;
   }
   if (X.extent(0) != V.extent(0) || X.extent(1) != V.extent(1)) {
-    printf(
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::HadamardProduct: Dimensions of X and V do not match: "
         "X: %d x %d, "
         "V: %d x %d\n",
@@ -187,7 +187,7 @@ KOKKOS_INLINE_FUNCTION int TeamHadamardProduct<MemberType>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-    printf(
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::HadamardProduct: Dimensions of X and Y do not match: "
         "X: %d x %d, "
         "Y: %d x %d\n",
@@ -195,7 +195,7 @@ KOKKOS_INLINE_FUNCTION int TeamHadamardProduct<MemberType>::invoke(
     return 1;
   }
   if (X.extent(0) != V.extent(0) || X.extent(1) != V.extent(1)) {
-    printf(
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::HadamardProduct: Dimensions of X and V do not match: "
         "X: %d x %d, "
         "V: %d x %d\n",
@@ -240,7 +240,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorHadamardProduct<MemberType>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-    printf(
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::HadamardProduct: Dimensions of X and Y do not match: "
         "X: %d x %d, "
         "Y: %d x %d\n",
@@ -248,7 +248,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorHadamardProduct<MemberType>::invoke(
     return 1;
   }
   if (X.extent(0) != V.extent(0) || X.extent(1) != V.extent(1)) {
-    printf(
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::HadamardProduct: Dimensions of X and V do not match: "
         "X: %d x %d, "
         "V: %d x %d\n",

--- a/src/batched/dense/impl/KokkosBatched_Xpay_Impl.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Xpay_Impl.hpp
@@ -230,14 +230,14 @@ KOKKOS_INLINE_FUNCTION int SerialXpay::invoke(const alphaViewType& alpha,
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-    printf(
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::xpay: Dimensions of X and Y do not match: X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
     return 1;
   }
   if (X.extent(0) != alpha.extent(0)) {
-    printf(
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::xpay: First dimension of X and alpha do not match: X: "
         "%d x %d, alpha: %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
@@ -273,14 +273,14 @@ KOKKOS_INLINE_FUNCTION int TeamXpay<MemberType>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-    printf(
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::xpay: Dimensions of X and Y do not match: X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
     return 1;
   }
   if (X.extent(0) != alpha.extent(0)) {
-    printf(
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::xpay: First dimension of X and alpha do not match: X: "
         "%d x %d, alpha: %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
@@ -317,14 +317,14 @@ KOKKOS_INLINE_FUNCTION int TeamVectorXpay<MemberType>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-    printf(
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::xpay: Dimensions of X and Y do not match: X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
     return 1;
   }
   if (X.extent(0) != alpha.extent(0)) {
-    printf(
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::xpay: First dimension of X and alpha do not match: X: "
         "%d x %d, alpha: %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));

--- a/src/batched/sparse/impl/KokkosBatched_Spmv_Serial_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_Spmv_Serial_Impl.hpp
@@ -269,7 +269,7 @@ struct SerialSpmv<Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
           "%d, Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -277,7 +277,7 @@ struct SerialSpmv<Trans::NoTranspose> {
       return 1;
     }
     if (X.extent(0) != values.extent(0)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and the first dimension "
           "of values do not match: X: %d x %d, values: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
@@ -285,7 +285,7 @@ struct SerialSpmv<Trans::NoTranspose> {
       return 1;
     }
     if (colIndices.extent(0) != values.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of colIndices and the second "
           "dimension of values do not match: colIndices: %d , values: %d x "
           "%d\n",
@@ -294,7 +294,7 @@ struct SerialSpmv<Trans::NoTranspose> {
       return 1;
     }
     if (row_ptr.extent(0) - 1 != X.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
           "of X do not match: colIndices (-1): %d , values: %d x %d\n",
           (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));

--- a/src/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
@@ -312,7 +312,7 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
           "%d, Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -320,7 +320,7 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (X.extent(0) != values.extent(0)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and the first dimension "
           "of values do not match: X: %d x %d, values: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
@@ -328,7 +328,7 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (colIndices.extent(0) != values.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of colIndices and the second "
           "dimension of values do not match: colIndices: %d , values: %d x "
           "%d\n",
@@ -337,7 +337,7 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (row_ptr.extent(0) - 1 != X.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
           "of X do not match: colIndices (-1): %d , values: %d x %d\n",
           (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));

--- a/src/batched/sparse/impl/KokkosBatched_Spmv_Team_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_Spmv_Team_Impl.hpp
@@ -308,7 +308,7 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
           "%d, Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -316,7 +316,7 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (X.extent(0) != values.extent(0)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and the first dimension "
           "of values do not match: X: %d x %d, values: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
@@ -324,7 +324,7 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (colIndices.extent(0) != values.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of colIndices and the second "
           "dimension of values do not match: colIndices: %d , values: %d x "
           "%d\n",
@@ -333,7 +333,7 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (row_ptr.extent(0) - 1 != X.extent(1)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
           "of X do not match: colIndices (-1): %d , values: %d x %d\n",
           (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));


### PR DESCRIPTION
We didn't catch these when we were reverting the removal of the `printf` workaround for SYCL, likely because they were introduced in the meantime.