### PR TITLE
Replace std::abs with ArithTraits::abs

### DIFF
--- a/perf_test/batched/do-not-use/KokkosBatched_Test_Gemm_Cuda.cpp
+++ b/perf_test/batched/do-not-use/KokkosBatched_Test_Gemm_Cuda.cpp
@@ -328,7 +328,8 @@ void Gemm(const int NN, const int BlkSize) {
       for (int i = 0, iend = cref.extent(0); i < iend; ++i)
         for (int j = 0, jend = cref.extent(1); j < jend; ++j)
           for (int k = 0, kend = cref.extent(2); k < kend; ++k)
-            diff += std::abs(cref(i, j, k) - csol(i, j, k));
+            diff += Kokkos::ArithTraits<value_type>::abs(cref(i, j, k) -
+                                                         csol(i, j, k));
 
       std::cout << std::setw(8) << "Kokkos" << std::setw(8) << "Range"
                 << " BlkSize = " << std::setw(3) << BlkSize << " TeamSize = N/A"
@@ -396,7 +397,8 @@ void Gemm(const int NN, const int BlkSize) {
       for (int i = 0, iend = cref.extent(0); i < iend; ++i)
         for (int j = 0, jend = cref.extent(1); j < jend; ++j)
           for (int k = 0, kend = cref.extent(2); k < kend; ++k)
-            diff += std::abs(cref(i, j, k) - csol(i, j, k));
+            diff += Kokkos::ArithTraits<value_type>::abs(cref(i, j, k) -
+                                                         csol(i, j, k));
 
       std::cout << std::setw(8) << "Kokkos" << std::setw(8) << "Team V1"
                 << " BlkSize = " << std::setw(3) << BlkSize
@@ -470,7 +472,8 @@ void Gemm(const int NN, const int BlkSize) {
       for (int i = 0, iend = cref.extent(0); i < iend; ++i)
         for (int j = 0, jend = cref.extent(1); j < jend; ++j)
           for (int k = 0, kend = cref.extent(2); k < kend; ++k)
-            diff += std::abs(cref(i, j, k) - csol(i, j, k));
+            diff += Kokkos::ArithTraits<value_type>::abs(cref(i, j, k) -
+                                                         csol(i, j, k));
 
       std::cout << std::setw(8) << "Kokkos" << std::setw(8) << "Team V2"
                 << " BlkSize = " << std::setw(3) << BlkSize
@@ -553,7 +556,8 @@ void Gemm(const int NN, const int BlkSize) {
         for (int i = 0, iend = cref.extent(0); i < iend; ++i)
           for (int j = 0, jend = cref.extent(1); j < jend; ++j)
             for (int k = 0, kend = cref.extent(2); k < kend; ++k)
-              diff += std::abs(cref(i, j, k) - csol(i, j, k));
+              diff += Kokkos::ArithTraits<value_type>::abs(cref(i, j, k) -
+                                                           csol(i, j, k));
 
         std::cout << std::setw(8) << "Kokkos" << std::setw(8) << "Team V3"
                   << " BlkSize = " << std::setw(3) << BlkSize
@@ -627,7 +631,8 @@ void Gemm(const int NN, const int BlkSize) {
       for (int i = 0, iend = cref.extent(0); i < iend; ++i)
         for (int j = 0, jend = cref.extent(1); j < jend; ++j)
           for (int k = 0, kend = cref.extent(2); k < kend; ++k)
-            diff += std::abs(cref(i, j, k) - csol(i, j, k));
+            diff += Kokkos::ArithTraits<value_type>::abs(cref(i, j, k) -
+                                                         csol(i, j, k));
 
       std::cout << std::setw(8) << "Kokkos" << std::setw(8) << "Team HM"
                 << " BlkSize = " << std::setw(3) << BlkSize

--- a/perf_test/batched/do-not-use/KokkosBatched_Test_Gemv_Host.hpp
+++ b/perf_test/batched/do-not-use/KokkosBatched_Test_Gemv_Host.hpp
@@ -202,7 +202,8 @@ void Gemv(const int NN) {
       for (int i = 0, iend = yref.extent(0); i < iend; ++i)
         for (int j = 0, jend = yref.extent(1); j < jend; ++j)
           for (int k = 0, kend = yref.extent(2); k < kend; ++k)
-            diff += std::abs(yref(i, j, k) - y(i, j, k));
+            diff += Kokkos::ArithTraits<value_type>::abs(yref(i, j, k) -
+                                                         y(i, j, k));
 
       std::cout << std::setw(12) << "Plain"
                 << " BlkSize = " << std::setw(3) << BlkSize
@@ -274,8 +275,8 @@ void Gemv(const int NN) {
       for (int i = 0, iend = yref.extent(0); i < iend; ++i)
         for (int j = 0, jend = yref.extent(1); j < jend; ++j)
           for (int k = 0, kend = yref.extent(2); k < kend; ++k)
-            diff += std::abs(yref(i, j, k) -
-                             y(i / VectorLength, j, k)[i % VectorLength]);
+            diff += Kokkos::ArithTraits<value_type>::abs(
+                yref(i, j, k) - y(i / VectorLength, j, k)[i % VectorLength]);
 
       std::cout << std::setw(12) << "Serial SIMD"
                 << " BlkSize = " << std::setw(3) << BlkSize

--- a/perf_test/batched/do-not-use/KokkosBatched_Test_LU_Cuda.cpp
+++ b/perf_test/batched/do-not-use/KokkosBatched_Test_LU_Cuda.cpp
@@ -307,7 +307,8 @@ void LU(const int NN, const int BlkSize) {
       for (int i = 0, iend = aref.extent(0); i < iend; ++i)
         for (int j = 0, jend = aref.extent(1); j < jend; ++j)
           for (int k = 0, kend = aref.extent(2); k < kend; ++k)
-            diff += std::abs(aref(i, j, k) - asol(i, j, k));
+            diff += Kokkos::ArithTraits<value_type>::abs(aref(i, j, k) -
+                                                         asol(i, j, k));
 
       std::cout << std::setw(8) << "Kokkos" << std::setw(8) << "Range"
                 << " BlkSize = " << std::setw(3) << BlkSize << " TeamSize = N/A"
@@ -367,7 +368,8 @@ void LU(const int NN, const int BlkSize) {
       for (int i = 0, iend = aref.extent(0); i < iend; ++i)
         for (int j = 0, jend = aref.extent(1); j < jend; ++j)
           for (int k = 0, kend = aref.extent(2); k < kend; ++k)
-            diff += std::abs(aref(i, j, k) - asol(i, j, k));
+            diff += Kokkos::ArithTraits<value_type>::abs(aref(i, j, k) -
+                                                         asol(i, j, k));
 
       std::cout << std::setw(8) << "Kokkos" << std::setw(8) << "Team V1"
                 << " BlkSize = " << std::setw(3) << BlkSize
@@ -438,7 +440,8 @@ void LU(const int NN, const int BlkSize) {
       for (int i = 0, iend = aref.extent(0); i < iend; ++i)
         for (int j = 0, jend = aref.extent(1); j < jend; ++j)
           for (int k = 0, kend = aref.extent(2); k < kend; ++k)
-            diff += std::abs(aref(i, j, k) - asol(i, j, k));
+            diff += Kokkos::ArithTraits<value_type>::abs(aref(i, j, k) -
+                                                         asol(i, j, k));
 
       std::cout << std::setw(8) << "Kokkos" << std::setw(8) << "Team V2"
                 << " BlkSize = " << std::setw(3) << BlkSize
@@ -516,7 +519,8 @@ void LU(const int NN, const int BlkSize) {
         for (int i = 0, iend = aref.extent(0); i < iend; ++i)
           for (int j = 0, jend = aref.extent(1); j < jend; ++j)
             for (int k = 0, kend = aref.extent(2); k < kend; ++k)
-              diff += std::abs(aref(i, j, k) - asol(i, j, k));
+              diff += Kokkos::ArithTraits<value_type>::abs(aref(i, j, k) -
+                                                           asol(i, j, k));
 
         std::cout << std::setw(8) << "Kokkos" << std::setw(8) << "Team V3"
                   << " BlkSize = " << std::setw(3) << BlkSize

--- a/perf_test/batched/do-not-use/KokkosBatched_Test_Trsm_Cuda.cpp
+++ b/perf_test/batched/do-not-use/KokkosBatched_Test_Trsm_Cuda.cpp
@@ -476,7 +476,8 @@ void Trsm(const int NN, const int BlkSize, const int NumCols) {
       for (int i = 0, iend = bref.extent(0); i < iend; ++i)
         for (int j = 0, jend = bref.extent(1); j < jend; ++j)
           for (int k = 0, kend = bref.extent(2); k < kend; ++k)
-            diff += std::abs(bref(i, j, k) - bsol(i, j, k));
+            diff += Kokkos::ArithTraits<value_type>::abs(bref(i, j, k) -
+                                                         bsol(i, j, k));
 
       std::cout << std::setw(8) << "Kokkos" << std::setw(8) << "Range"
                 << " BlkSize = " << std::setw(3) << BlkSize
@@ -540,7 +541,8 @@ void Trsm(const int NN, const int BlkSize, const int NumCols) {
       for (int i = 0, iend = bref.extent(0); i < iend; ++i)
         for (int j = 0, jend = bref.extent(1); j < jend; ++j)
           for (int k = 0, kend = bref.extent(2); k < kend; ++k)
-            diff += std::abs(bref(i, j, k) - bsol(i, j, k));
+            diff += Kokkos::ArithTraits<value_type>::abs(bref(i, j, k) -
+                                                         bsol(i, j, k));
 
       std::cout << std::setw(8) << "Kokkos" << std::setw(8) << "Team V1"
                 << " BlkSize = " << std::setw(3) << BlkSize
@@ -614,7 +616,8 @@ void Trsm(const int NN, const int BlkSize, const int NumCols) {
       for (int i = 0, iend = bref.extent(0); i < iend; ++i)
         for (int j = 0, jend = bref.extent(1); j < jend; ++j)
           for (int k = 0, kend = bref.extent(2); k < kend; ++k)
-            diff += std::abs(bref(i, j, k) - bsol(i, j, k));
+            diff += Kokkos::ArithTraits<value_type>::abs(bref(i, j, k) -
+                                                         bsol(i, j, k));
 
       std::cout << std::setw(8) << "Kokkos" << std::setw(8) << "Team V2"
                 << " BlkSize = " << std::setw(3) << BlkSize
@@ -694,7 +697,8 @@ void Trsm(const int NN, const int BlkSize, const int NumCols) {
         for (int i = 0, iend = bref.extent(0); i < iend; ++i)
           for (int j = 0, jend = bref.extent(1); j < jend; ++j)
             for (int k = 0, kend = bref.extent(2); k < kend; ++k)
-              diff += std::abs(bref(i, j, k) - bsol(i, j, k));
+              diff += Kokkos::ArithTraits<value_type>::abs(bref(i, j, k) -
+                                                           bsol(i, j, k));
 
         std::cout << std::setw(8) << "Kokkos" << std::setw(8) << "Team V3"
                   << " BlkSize = " << std::setw(3) << BlkSize

--- a/perf_test/batched/do-not-use/KokkosBatched_Test_Trsm_Host.hpp
+++ b/perf_test/batched/do-not-use/KokkosBatched_Test_Trsm_Host.hpp
@@ -209,7 +209,7 @@ void Trsm(const int NN) {
       for (int i = 0, iend = b.extent(0); i < iend; ++i)
         for (int j = 0, jend = b.extent(1); j < jend; ++j)
           for (int k = 0, kend = b.extent(2); k < kend; ++k)
-            sum += std::abs(bmat(i, j, k));
+            sum += Kokkos::ArithTraits<value_type>::abs(bmat(i, j, k));
 
       std::cout << std::setw(10) << "MKL TRSM"
                 << " BlkSize = " << std::setw(3) << BlkSize
@@ -327,7 +327,8 @@ void Trsm(const int NN) {
       for (int i = 0, iend = bref.extent(0); i < iend; ++i)
         for (int j = 0, jend = bref.extent(1); j < jend; ++j)
           for (int k = 0, kend = bref.extent(2); k < kend; ++k)
-            diff += std::abs(bref(i, j, k) - b(i, j, k));
+            diff += Kokkos::ArithTraits<value_type>::abs(bref(i, j, k) -
+                                                         b(i, j, k));
 
       std::cout << std::setw(10) << "MKL Batch"
                 << " BlkSize = " << std::setw(3) << BlkSize
@@ -443,8 +444,8 @@ void Trsm(const int NN) {
         for (int i = 0, iend = bref.extent(0); i < iend; ++i)
           for (int j = 0, jend = bref.extent(1); j < jend; ++j)
             for (int k = 0, kend = bref.extent(2); k < kend; ++k)
-              diff += std::abs(bref(i, j, k) -
-                               b(i / VectorLength, j, k)[i % VectorLength]);
+              diff += Kokkos::ArithTraits<value_type>::abs(
+                  bref(i, j, k) - b(i / VectorLength, j, k)[i % VectorLength]);
 
         std::cout << std::setw(10) << "MKL Cmpt"
                   << " BlkSize = " << std::setw(3) << BlkSize
@@ -523,7 +524,8 @@ void Trsm(const int NN) {
   //     for (int i=0,iend=bref.extent(0);i<iend;++i)
   //       for (int j=0,jend=bref.extent(1);j<jend;++j)
   //         for (int k=0,kend=bref.extent(2);k<kend;++k)
-  //           diff += std::abs(bref(i,j,k) - b(i,j,k));
+  //           diff += Kokkos::ArithTraits<value_type>::abs(bref(i,j,k) -
+  //           b(i,j,k));
 
   //     std::cout << std::setw(10) << "KK Scalar"
   //               << " BlkSize = " << std::setw(3) << BlkSize
@@ -599,8 +601,8 @@ void Trsm(const int NN) {
       for (int i = 0, iend = bref.extent(0); i < iend; ++i)
         for (int j = 0, jend = bref.extent(1); j < jend; ++j)
           for (int k = 0, kend = bref.extent(2); k < kend; ++k)
-            diff += std::abs(bref(i, j, k) -
-                             b(i / VectorLength, j, k)[i % VectorLength]);
+            diff += Kokkos::ArithTraits<value_type>::abs(
+                bref(i, j, k) - b(i / VectorLength, j, k)[i % VectorLength]);
 
       std::cout << std::setw(10) << "KK Vector"
                 << " BlkSize = " << std::setw(3) << BlkSize

--- a/perf_test/sparse/KokkosSparse_spmv_blockcrs.cpp
+++ b/perf_test/sparse/KokkosSparse_spmv_blockcrs.cpp
@@ -223,9 +223,9 @@ int test_blockcrs_matrix_single_vec(
     Kokkos::deep_copy(h_yblockcrs, yblockcrs);
     double error = 0.0, maxNorm = 0.0;
     for (size_t ir = 0; ir < h_ycrs.extent(0); ++ir) {
-      maxNorm = std::max(maxNorm, std::abs(static_cast<double>(h_ycrs(ir))));
-      error   = std::max(
-          error, std::abs(static_cast<double>(h_ycrs(ir) - h_yblockcrs(ir))));
+      maxNorm = std::max(maxNorm, Kokkos::ArithTraits<Scalar>::abs(h_ycrs(ir)));
+      error   = std::max(error, Kokkos::ArithTraits<Scalar>::abs(
+                                  h_ycrs(ir) - h_yblockcrs(ir)));
     }
 
     double tol =
@@ -356,9 +356,9 @@ int test_blockcrs_matrix_vec(
       double error = 0.0, maxNorm = 0.0;
       for (size_t ir = 0; ir < h_ycrs.extent(0); ++ir) {
         maxNorm =
-            std::max(maxNorm, std::abs(static_cast<double>(h_ycrs(ir, jc))));
-        error = std::max(error, std::abs(static_cast<double>(
-                                    h_ycrs(ir, jc) - h_yblockcrs(ir, jc))));
+            std::max(maxNorm, Kokkos::ArithTraits<Scalar>::abs(h_ycrs(ir, jc)));
+        error = std::max(error, Kokkos::ArithTraits<Scalar>::abs(
+                                    h_ycrs(ir, jc) - h_yblockcrs(ir, jc)));
       }
       if (error > tol * maxNorm) {
         num_errors += 1;

--- a/perf_test/sparse/KokkosSparse_spmv_bsr.cpp
+++ b/perf_test/sparse/KokkosSparse_spmv_bsr.cpp
@@ -241,9 +241,9 @@ int test_bsr_matrix_single_vec(
     Kokkos::deep_copy(h_ybsr, ybsr);
     double error = 0.0, maxNorm = 0.0;
     for (size_t ir = 0; ir < h_ycrs.extent(0); ++ir) {
-      maxNorm = std::max(maxNorm, std::abs(static_cast<double>(h_ycrs(ir))));
-      error   = std::max(error,
-                       std::abs(static_cast<double>(h_ycrs(ir) - h_ybsr(ir))));
+      maxNorm = std::max(maxNorm, Kokkos::ArithTraits<Scalar>::abs(h_ycrs(ir)));
+      error   = std::max(
+          error, Kokkos::ArithTraits<Scalar>::abs(h_ycrs(ir) - h_ybsr(ir)));
     }
 
     double tol =
@@ -405,9 +405,9 @@ int test_bsr_matrix_vec(
       double error = 0.0, maxNorm = 0.0;
       for (size_t ir = 0; ir < h_ycrs.extent(0); ++ir) {
         maxNorm =
-            std::max(maxNorm, std::abs(static_cast<double>(h_ycrs(ir, jc))));
-        error = std::max(error, std::abs(static_cast<double>(h_ycrs(ir, jc) -
-                                                             h_ybsr(ir, jc))));
+            std::max(maxNorm, Kokkos::ArithTraits<Scalar>::abs(h_ycrs(ir, jc)));
+        error = std::max(error, Kokkos::ArithTraits<Scalar>::abs(
+                                    h_ycrs(ir, jc) - h_ybsr(ir, jc)));
       }
       if (error > tol * maxNorm) {
         num_errors += 1;

--- a/src/batched/KokkosBatched_Util.hpp
+++ b/src/batched/KokkosBatched_Util.hpp
@@ -65,7 +65,6 @@ struct is_same_mag_type {
 };
 
 // to use double, std::complex<double>, Kokkos::complex<double>
-using std::abs;
 using std::max;
 using std::min;
 

--- a/src/batched/dense/KokkosBatched_Test_BlockCrs_Util.hpp
+++ b/src/batched/dense/KokkosBatched_Test_BlockCrs_Util.hpp
@@ -805,7 +805,8 @@ class ExtractBlockTridiagMatrices {
     const auto eps = 1e2 * std::numeric_limits<scalar_type>::epsilon();
     for (ordinal_type ii = 0; ii < blocksize; ++ii)
       for (ordinal_type jj = 0; jj < blocksize; ++jj)
-        if (std::abs(tdiag_val(T, ij, k, ii, jj) - A(c, ii, jj)) >= eps)
+        if (Kokkos::ArithTraits<scalar_type>::abs(tdiag_val(T, ij, k, ii, jj) -
+                                                  A(c, ii, jj)) >= eps)
           return false;
     return true;
   }

--- a/src/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
@@ -252,7 +252,9 @@ struct TeamVectorGMRES {
               G(l, j + 1) = 0.;
             }
 
-            if (mask(l) == 1. && std::abs(G(l, j + 1)) / beta(l) < tolerance) {
+            if (mask(l) == 1. &&
+                Kokkos::ArithTraits<double>::abs(G(l, j + 1)) / beta(l) <
+                    tolerance) {
               mask(l)     = 0.;
               G(l, j + 1) = 0.;
             }

--- a/src/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
@@ -249,7 +249,9 @@ struct TeamGMRES {
               G(l, j + 1) = 0.;
             }
 
-            if (mask(l) == 1. && std::abs(G(l, j + 1)) / beta(l) < tolerance) {
+            if (mask(l) == 1. &&
+                Kokkos::ArithTraits<double>::abs(G(l, j + 1)) / beta(l) <
+                    tolerance) {
               mask(l)     = 0.;
               G(l, j + 1) = 0.;
             }

--- a/test_common/KokkosBatched_Test_BlockCrs.hpp
+++ b/test_common/KokkosBatched_Test_BlockCrs.hpp
@@ -497,18 +497,26 @@ class FactorizeBlockTridiagMatrices {
     for (ordinal_type t = 0; t < _ntridiag; ++t) {
       for (ordinal_type ii = 0; ii < _blocksize; ++ii)
         for (ordinal_type jj = 0; jj < _blocksize; ++jj) {
-          norm += std::abs(tdiag_val(A, t, 0, ii, jj));
-          diff += std::abs(tdiag_val(AA, t, 0, ii, jj));
+          norm +=
+              Kokkos::ArithTraits<value_type>::abs(tdiag_val(A, t, 0, ii, jj));
+          diff +=
+              Kokkos::ArithTraits<value_type>::abs(tdiag_val(AA, t, 0, ii, jj));
         }
       for (ordinal_type i = 1; i < _m; ++i)
         for (ordinal_type ii = 0; ii < _blocksize; ++ii)
           for (ordinal_type jj = 0; jj < _blocksize; ++jj) {
-            norm += std::abs(tdiag_val(A, t, i, ii, jj));
-            diff += std::abs(tdiag_val(AA, t, i, ii, jj));
-            norm += std::abs(tdiag_val(B, t, i - 1, ii, jj));
-            diff += std::abs(tdiag_val(BB, t, i - 1, ii, jj));
-            norm += std::abs(tdiag_val(C, t, i - 1, ii, jj));
-            diff += std::abs(tdiag_val(CC, t, i - 1, ii, jj));
+            norm += Kokkos::ArithTraits<value_type>::abs(
+                tdiag_val(A, t, i, ii, jj));
+            diff += Kokkos::ArithTraits<value_type>::abs(
+                tdiag_val(AA, t, i, ii, jj));
+            norm += Kokkos::ArithTraits<value_type>::abs(
+                tdiag_val(B, t, i - 1, ii, jj));
+            diff += Kokkos::ArithTraits<value_type>::abs(
+                tdiag_val(BB, t, i - 1, ii, jj));
+            norm += Kokkos::ArithTraits<value_type>::abs(
+                tdiag_val(C, t, i - 1, ii, jj));
+            diff += Kokkos::ArithTraits<value_type>::abs(
+                tdiag_val(CC, t, i - 1, ii, jj));
           }
     }
     // std::cout << "tridiag factor check  norm = " << norm << "  diff = " <<
@@ -1046,8 +1054,10 @@ class SolveBlockTridiagMatrices {
       for (ordinal_type jvec = 0; jvec < _nvectors; ++jvec)
         for (ordinal_type i = 0; i < _m; ++i)
           for (ordinal_type ii = 0; ii < _blocksize; ++ii) {
-            norm += std::abs(tdiag_val(bb, t, jvec, i, ii));
-            diff += std::abs(tdiag_val(rr, t, jvec, i, ii));
+            norm += Kokkos::ArithTraits<value_type>::abs(
+                tdiag_val(bb, t, jvec, i, ii));
+            diff += Kokkos::ArithTraits<value_type>::abs(
+                tdiag_val(rr, t, jvec, i, ii));
           }
 
     // std::cout << "tridiag solve check  norm = " << norm << "  diff = " <<


### PR DESCRIPTION
Mainly just making things consistent. In a few perf tests, also allows using scalar=complex.