### PR TITLE
Fix bug in `spmv_mv_bsrmatrix()` for Ampere GPU arch

### DIFF
--- a/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -263,7 +263,7 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
       } else {
         BsrMatrixSpMVTensorCoreDispatcher<AMatrix, double, XVector, double,
                                           YVector, double, 8, 8,
-                                          4>::dispatch(alpha, A, x, beta, y);
+                                          4>::dispatch(alpha, A, X, beta, Y);
         return;
       }
     }


### PR DESCRIPTION
Reported on Slack