### PR TITLE
Guard __device__ functions in KOKKOS_INLINE_FUNCTION for tensor core SpMV

### DIFF
--- a/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
@@ -420,6 +420,7 @@ struct BsrMatrixSpMVTensorCoreFunctor {
 #endif
       }
       (void)j;
+      (void)ap;
     }  // loop through blocks in row of A
 
 #ifdef __CUDA_ARCH__


### PR DESCRIPTION
This code relies on `__device__` intrinsics, which do not work in KOKKOS_INLINE_FUNCTION functions (`__host__ __device__`). 