### PR TITLE
default for Controls::getParameter and unit tests

### DIFF
--- a/src/common/KokkosKernels_Controls.hpp
+++ b/src/common/KokkosKernels_Controls.hpp
@@ -81,28 +81,23 @@ class Controls {
 
   // check if a parameter is already set
   bool isParameter(const std::string& name) const {
-    bool return_value = false;
-
-    auto search = kernel_parameters.find(name);
-    if (search != kernel_parameters.end()) {
-      return_value = true;
-    }
-
-    return return_value;
+    return kernel_parameters.end() != kernel_parameters.find(name);
   }
 
-  // retrieve the value associated with a parameter if it is already set
-  std::string getParameter(const std::string& name) const {
+  /// \brief get the value associated with \c name, or \c default if not present
+  ///
+  /// \param name the name of the parameter to retrieve
+  /// \param orUnset (default \c "" ) the value to return if \c name is not set
+  std::string getParameter(const std::string& name,
+                           const std::string& orUnset = "") const {
     auto search = kernel_parameters.find(name);
-    std::string value;
-    if (search == kernel_parameters.end()) {
+    if (kernel_parameters.end() == search) {
       std::cout << "Parameter " << name
                 << " was not found in the list of parameters!" << std::endl;
-      value = "";
+      return orUnset;
     } else {
-      value = search->second;
+      return search->second;
     }
-    return value;
   }
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUBLAS

--- a/unit_test/common/Test_Common.hpp
+++ b/unit_test/common/Test_Common.hpp
@@ -11,5 +11,6 @@
 #include <Test_Common_Transpose.hpp>
 #include <Test_Common_IOUtils.hpp>
 #include <Test_Common_Error.hpp>
+#include <Test_Common_Controls.hpp>
 
 #endif  // TEST_COMMON_HPP

--- a/unit_test/common/Test_Common_Controls.hpp
+++ b/unit_test/common/Test_Common_Controls.hpp
@@ -1,0 +1,72 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef TEST_COMMON_CONTROLS_HPP
+#define TEST_COMMON_CONTROLS_HPP
+
+#include "KokkosKernels_Controls.hpp"
+
+void test_controls_empty() {
+  KokkosKernels::Experimental::Controls c;
+  EXPECT_EQ(c.isParameter(""), false);
+  EXPECT_EQ(c.getParameter(""), "");
+  EXPECT_EQ(c.getParameter("", "default"), "default");
+}
+
+void test_controls_set() {
+  KokkosKernels::Experimental::Controls c;
+  c.setParameter("key", "value");
+  EXPECT_EQ(c.isParameter("key"), true);
+  EXPECT_EQ(c.getParameter("key"), "value");
+  EXPECT_EQ(c.getParameter("key", "default"), "value");
+
+  EXPECT_EQ(c.isParameter(""), false);
+  EXPECT_EQ(c.getParameter(""), "");
+  EXPECT_EQ(c.getParameter("", "default"), "default");
+}
+
+TEST_F(TestCategory, controls_empty) { test_controls_empty(); }
+TEST_F(TestCategory, controls_set) { test_controls_set(); }
+
+#endif  // TEST_COMMON_CONTROLS_HPP


### PR DESCRIPTION
Add an optional `onUnset` argument for a value to return if the key is not present.
Add supporting unit tests