### PR TITLE
Refactor tensor core SpMV to disallow certain executions and avoid non-GPU instantiation

### DIFF
--- a/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
@@ -494,7 +494,9 @@ struct BsrMatrixSpMVTensorCoreDispatcher {
   // to be used to avoid instantiating on unsupported types
   static void tag_dispatch(std::false_type, YScalar, AMatrix, XMatrix, YScalar,
                            YMatrix) {
-    KokkosKernels::Impl::throw_runtime_exception("unsupported for arguments");
+    KokkosKernels::Impl::throw_runtime_exception(
+        "Tensor core SpMV is only supported for non-complex types in GPU "
+        "execution spaces");
   }
 
   /*true if none of T1, T2, or T3 are complex*/

--- a/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
@@ -46,6 +46,7 @@
 #define KOKKOSSPARSE_IMPL_SPMV_BSRMATRIX_IMPL_HPP_
 
 #include "KokkosKernels_Error.hpp"
+#include "KokkosKernels_ExecSpaceUtils.hpp"
 
 #if defined(KOKKOS_ENABLE_CUDA) && \
     (defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_AMPERE))
@@ -320,10 +321,8 @@ struct BsrMatrixSpMVTensorCoreFunctor {
     // no barrier - each warp uses independent shared memory
 
     // load from the shared memory
-#ifdef __CUDA_ARCH__
     load_matrix_sync(fy, &sy(warpIdx_y, warpIdx_x, 0, 0), FRAG_N,
                      nvcuda::wmma::mem_row_major);
-#endif
 
     auto rowView = a.block_row_Const(blockIdx_i);
 
@@ -363,17 +362,12 @@ struct BsrMatrixSpMVTensorCoreFunctor {
           const AOrdinal bj = bk + tj;
 
           // fill shmem with 0 outside of the block boundary
-#ifdef __CUDA_ARCH__
           if (bi < a.blockDim() && bj < a.blockDim()) {
             sa(ti / FRAG_M, ti % FRAG_M, tj) =
                 AFragScalar(alpha * ap[bi * a.blockDim() + bj]);
           } else {
             sa(ti / FRAG_M, ti % FRAG_M, tj) = AFragScalar(0);
           }
-#else
-          (void)bi;
-          (void)bj;
-#endif
         }
 
         // collaborative load of X fragments into shared memory
@@ -391,7 +385,6 @@ struct BsrMatrixSpMVTensorCoreFunctor {
           // load 0 outside of the block boundary
           // x is not necessarily a multiple of block size, so make sure access
           // is in bounds
-#ifdef __CUDA_ARCH__
           if (bi < a.blockDim() && bj < a.blockDim() &&
               unsigned(blockIdx_j * a.blockDim() + bj) < x.extent(1)) {
             // tile is some fragments in the j/n direction that are frag_n wide
@@ -400,15 +393,10 @@ struct BsrMatrixSpMVTensorCoreFunctor {
           } else {
             sx(tj / FRAG_N, ti, tj % FRAG_N) = XFragScalar(0);
           }
-#else
-          (void)bi;
-          (void)bj;
-#endif
         }
         mbr.team_barrier();
 
         // load correct fragment from shared memory and accumulate
-#ifdef __CUDA_ARCH__
         // only need to do any math if our fragment will write a result back to
         // Y
         if (ay_i < static_cast<AOrdinal>(y.extent(0)) &&
@@ -417,17 +405,12 @@ struct BsrMatrixSpMVTensorCoreFunctor {
           load_matrix_sync(fx, &sx(warpIdx_x, 0, 0), FRAG_N);
           mma_sync(fy, fa, fx, fy);
         }
-#endif
       }
-      (void)j;
-      (void)ap;
     }  // loop through blocks in row of A
 
-#ifdef __CUDA_ARCH__
     // store Y fragments into shared memory
     store_matrix_sync(&sy(warpIdx_y, warpIdx_x, 0, 0), fy, FRAG_N,
                       nvcuda::wmma::mem_row_major);
-#endif
     // team loads its fragments of Y that make up part or all of the block of Y
     // it's responsible for. each warp loads the part corresponding to its y
     // fragment
@@ -447,21 +430,16 @@ struct BsrMatrixSpMVTensorCoreFunctor {
       }
     }
     mbr.team_barrier();
-
-    // Suppress unused var warnings
-    // TODO (@cwpearson): Should this functor only compile on device?
-    (void)fx;
-    (void)fa;
-    (void)fy;
   }
 };
 
-/* Instantiate some common template parameter values
-   for BsrMatrixSpMVTensorCoreFunctor.
-   This is a struct instead of a function for template...using shorthand
-   Discriminates between complex (supported) and non-complex (unsupported)
-   scalar types, and throws a runtime error for unsupported types
-*/
+/// \brief Avoid instantiating tensor core functor for unsupported types
+///
+/// Instantiate some common template parameter values
+/// for BsrMatrixSpMVTensorCoreFunctor.
+/// This is a struct instead of a function for template...using shorthand
+/// Discriminates between non-complex/on-GPU (supported) and otherwise
+/// (unsupported) scalar types, and throws a runtime error for unsupported types
 template <typename AMatrix,
           typename AFragScalar,  // input matrix type and fragment scalar type
           typename XMatrix, typename XFragScalar, typename YMatrix,
@@ -516,11 +494,10 @@ struct BsrMatrixSpMVTensorCoreDispatcher {
   // to be used to avoid instantiating on unsupported types
   static void tag_dispatch(std::false_type, YScalar, AMatrix, XMatrix, YScalar,
                            YMatrix) {
-    KokkosKernels::Impl::throw_runtime_exception(
-        "unsupported for complex types");
+    KokkosKernels::Impl::throw_runtime_exception("unsupported for arguments");
   }
 
-  /*true if T1, T2, or T3 are complex*/
+  /*true if none of T1, T2, or T3 are complex*/
   template <typename T1, typename T2, typename T3>
   struct none_complex {
     const static bool value = !Kokkos::ArithTraits<T1>::is_complex &&
@@ -528,11 +505,22 @@ struct BsrMatrixSpMVTensorCoreDispatcher {
                               !Kokkos::ArithTraits<T3>::is_complex;
   };
 
+  /*true if T1::execution_space, T2, or T3 are all GPU exec space*/
+  template <typename T1, typename T2, typename T3>
+  struct all_gpu {
+    const static bool value = KokkosKernels::Impl::kk_is_gpu_exec_space<T1>() &&
+                              KokkosKernels::Impl::kk_is_gpu_exec_space<T2>() &&
+                              KokkosKernels::Impl::kk_is_gpu_exec_space<T3>();
+  };
+
   static void dispatch(YScalar alpha, AMatrix a, XMatrix x, YScalar beta,
                        YMatrix y) {
-    using tag =
-        std::integral_constant<bool,
-                               none_complex<AScalar, XScalar, YScalar>::value>;
+    // tag will be false unless all conditions are met
+    using tag = std::integral_constant<
+        bool, none_complex<AScalar, XScalar, YScalar>::value &&
+                  all_gpu<typename AMatrix::execution_space,
+                          typename XMatrix::execution_space,
+                          typename YMatrix::execution_space>::value>;
     tag_dispatch(tag{}, alpha, a, x, beta, y);
   }
 };

--- a/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -201,88 +201,126 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
   typedef Kokkos::View<YT, YL, YD, YM> YVector;
   typedef typename YVector::non_const_value_type YScalar;
 
+  enum class Method {
+    Fallback,    ///< Don't use tensor cores
+    TensorCores  ///< use tensor cores
+  };
+
+  /// Precision to use in the tensor core implementation
+  enum class Precision {
+    Automatic,  ///< Use Double, unless operations match mixed precision
+    Double,     ///< fp64 += fp64 * fp64
+    Mixed       ///< fp32 += fp16 * fp16
+  };
+
   static void spmv_mv_bsrmatrix(
       const KokkosKernels::Experimental::Controls &controls, const char mode[],
       const YScalar &alpha, const AMatrix &A, const XVector &X,
       const YScalar &beta, const YVector &Y) {
+    Method method = Method::Fallback;
+
 #if defined(KOKKOS_ARCH_AMPERE) || defined(KOKKOS_ARCH_VOLTA)
-    // user explicitly requests a particular precision
-    bool requestMixed  = false;
-    bool requestDouble = false;
-    if (controls.isParameter("tc_precision")) {
-      if (controls.getParameter("tc_precision") == "mixed") {
-        requestMixed = true;
-      } else if (controls.getParameter("tc_precision") == "double") {
-        requestDouble = true;
-      }
-    }
-    //
-    bool use_tc = false;
-    if ((controls.isParameter("algorithm")) &&
-        (controls.getParameter("algorithm") == "experimental_bsr_tc")) {
-      if (Kokkos::Details::ArithTraits<YScalar>::is_complex == false)
-        use_tc = true;
+    {
+      typedef typename AMatrix::non_const_value_type AScalar;
+      typedef typename XVector::non_const_value_type XScalar;
+      // try to use tensor cores if requested
+      if (controls.getParameter("algorithm") == "experimental_bsr_tc")
+        method = Method::TensorCores;
+      // can't use tensor cores for complex
+      if (Kokkos::Details::ArithTraits<YScalar>::is_complex)
+        method = Method::Fallback;
+      if (Kokkos::Details::ArithTraits<XScalar>::is_complex)
+        method = Method::Fallback;
+      if (Kokkos::Details::ArithTraits<AScalar>::is_complex)
+        method = Method::Fallback;
+      // can't use tensor cores outside GPU
+      if (!KokkosKernels::Impl::kk_is_gpu_exec_space<
+              typename AMatrix::execution_space>())
+        method = Method::Fallback;
+      if (!KokkosKernels::Impl::kk_is_gpu_exec_space<
+              typename XVector::execution_space>())
+        method = Method::Fallback;
+      if (!KokkosKernels::Impl::kk_is_gpu_exec_space<
+              typename YVector::execution_space>())
+        method = Method::Fallback;
+      // can't use tensor cores unless mode is no-transpose
+      if (mode[0] != KokkosSparse::NoTranspose[0]) method = Method::Fallback;
+#if KOKKOS_HALF_T_IS_FLOAT
+      // disable tensor cores when Kokkos half is actually a float
+      method = Method::Fallback;
+#endif
     }
 #endif
 
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_ARCH_AMPERE)
-    typedef typename XVector::non_const_value_type XScalar;
-    typedef typename AMatrix::non_const_value_type AScalar;
-    typedef Kokkos::Experimental::half_t Half;
+    {
+      typedef Kokkos::Experimental::half_t Half;
+      typedef typename AMatrix::non_const_value_type AScalar;
+      typedef typename XVector::non_const_value_type XScalar;
 
-    /* Ampere has double += double * double and float += half * half
+      /* Ampere has double += double * double and float += half * half
 
-    use whichever is requested.
-    If none requested, used mixed precision if the inputs are mixed, otherwise
-    use double
-    */
+      use whichever is requested.
+      If none requested, used mixed precision if the inputs are mixed, otherwise
+      use double
+      */
+      if (Method::TensorCores == method) {
+        Precision precision = Precision::Automatic;
+        if (controls.getParameter("tc_precision") == "mixed")
+          precision = Precision::Mixed;
+        else if (controls.getParameter("tc_precision") == "double")
+          precision = Precision::Double;
 
-    // input precision matches a tensor core fragment type
-    constexpr bool operandsHalfHalfFloat = std::is_same<AScalar, Half>::value &&
-                                           std::is_same<XScalar, Half>::value &&
-                                           std::is_same<YScalar, float>::value;
-
-    if (use_tc) {
-      if (requestMixed) {
-        BsrMatrixSpMVTensorCoreDispatcher<AMatrix, half, XVector, half, YVector,
-                                          float, 16, 16, 16>::dispatch(alpha, A,
-                                                                       X, beta,
-                                                                       Y);
-        return;
-      } else if (requestDouble) {
-        BsrMatrixSpMVTensorCoreDispatcher<AMatrix, double, XVector, double,
-                                          YVector, double, 8, 8,
-                                          4>::dispatch(alpha, A, X, beta, Y);
-        return;
-      } else if (operandsHalfHalfFloat) {
-        BsrMatrixSpMVTensorCoreDispatcher<AMatrix, half, XVector, half, YVector,
-                                          float, 16, 16, 16>::dispatch(alpha, A,
-                                                                       X, beta,
-                                                                       Y);
-        return;
-      } else {
-        BsrMatrixSpMVTensorCoreDispatcher<AMatrix, double, XVector, double,
-                                          YVector, double, 8, 8,
-                                          4>::dispatch(alpha, A, X, beta, Y);
-        return;
+        switch (precision) {
+          case Precision::Mixed: {
+            BsrMatrixSpMVTensorCoreDispatcher<AMatrix, half, XVector, half,
+                                              YVector, float, 16, 16,
+                                              16>::dispatch(alpha, A, X, beta,
+                                                            Y);
+            return;
+          }
+          case Precision::Double: {
+            BsrMatrixSpMVTensorCoreDispatcher<AMatrix, double, XVector, double,
+                                              YVector, double, 8, 8,
+                                              4>::dispatch(alpha, A, X, beta,
+                                                           Y);
+            return;
+          }
+          case Precision::Automatic:  // fallthrough
+          default: {
+            constexpr bool operandsHalfHalfFloat =
+                std::is_same<AScalar, Half>::value &&
+                std::is_same<XScalar, Half>::value &&
+                std::is_same<YScalar, float>::value;
+            if (operandsHalfHalfFloat) {
+              BsrMatrixSpMVTensorCoreDispatcher<AMatrix, half, XVector, half,
+                                                YVector, float, 16, 16,
+                                                16>::dispatch(alpha, A, X, beta,
+                                                              Y);
+              return;
+            } else {
+              BsrMatrixSpMVTensorCoreDispatcher<AMatrix, double, XVector,
+                                                double, YVector, double, 8, 8,
+                                                4>::dispatch(alpha, A, X, beta,
+                                                             Y);
+              return;
+            }
+          }
+        }
       }
     }
 #elif defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_ARCH_VOLTA)
-    /* Volta has float += half * half
-       use it for all matrices
-    */
-    if (use_tc) {
-      if (requestDouble) {
-        KokkosKernels::Impl::throw_runtime_exception(
-            "KokkosSparse::spmv[algorithm=experimental_bsr_tc] "
-            "tc_precision=double unsupported KOKKOS_ARCH_VOLTA");
+    {
+      /* Volta has float += half * half
+         use it for all matrices
+      */
+      if (Method::TensorCores == method) {
+        BsrMatrixSpMVTensorCoreDispatcher<AMatrix, half, XVector, half, YVector,
+                                          float, 16, 16, 16>::dispatch(alpha, A,
+                                                                       X, beta,
+                                                                       Y);
+        return;
       }
-      BsrMatrixSpMVTensorCoreDispatcher<AMatrix, half, XVector, half, YVector,
-                                        float, 16, 16, 16>::dispatch(alpha, A,
-                                                                     X, beta,
-                                                                     Y);
-      (void)requestMixed;  // unused
-      return;
     }
 #endif  // KOKKOS_ARCH
 

--- a/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -217,9 +217,8 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
       const KokkosKernels::Experimental::Controls &controls, const char mode[],
       const YScalar &alpha, const AMatrix &A, const XVector &X,
       const YScalar &beta, const YVector &Y) {
-    Method method = Method::Fallback;
-
 #if defined(KOKKOS_ARCH_AMPERE) || defined(KOKKOS_ARCH_VOLTA)
+    Method method = Method::Fallback;
     {
       typedef typename AMatrix::non_const_value_type AScalar;
       typedef typename XVector::non_const_value_type XScalar;
@@ -248,9 +247,9 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
 #if KOKKOS_HALF_T_IS_FLOAT
       // disable tensor cores when Kokkos half is actually a float
       method = Method::Fallback;
-#endif
+#endif  // KOKKOS_HALF_T_IS_FLOAT
     }
-#endif
+#endif  // AMPERE || VOLTA
 
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_ARCH_AMPERE)
     {


### PR DESCRIPTION
* src/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp: remove compile-time guards for GPU intrinsics. Add GPU execution space to tag-dispatch scheme to avoid host instantiation.
* src/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp: refactor to reduce unused variables. Skip tensor cores for all except non-transpose.