### PR TITLE
ROCmCC compiler error with Kokkos_ArithTraits.hpp: wrong-side rule

### DIFF
--- a/src/Kokkos_ArithTraits.hpp
+++ b/src/Kokkos_ArithTraits.hpp
@@ -1098,6 +1098,8 @@ class ArithTraits<float> {
     using std::isinf;
 #elif defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_SYCL)
     using sycl::isinf;
+#elif __HIP_DEVICE_COMPILE__
+    using std::isinf;
 #endif
     return isinf(x);
   }
@@ -1106,6 +1108,8 @@ class ArithTraits<float> {
     using std::isnan;
 #elif defined(KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_SYCL)
     using sycl::isnan;
+#elif __HIP_DEVICE_COMPILE__
+    using std::isnan;
 #endif
     return isnan(x);
   }


### PR DESCRIPTION
Working with Trilinos (using the HIP backend) I ran into a wrong-side rule violation error:

```
/home/users/lroskop/Trilinos/packages/kokkos-kernels/src/Kokkos_ArithTraits.hpp:1112:12: error: no matching function for call to 'isnan'
    return isnan (real (x)) || isnan (imag (x));
...
...
...                                               \
      ^
/opt/rocm-5.0.0/llvm/lib/clang/14.0.0/include/__clang_hip_cmath.h:97:31: note: candidate function not viable: call to __device__ function from __host__ function
__DEVICE__ __CONSTEXPR__ bool isnan(float __x) { return ::__isnanf(__x); }
                              ^
/opt/rocm-5.0.0/llvm/lib/clang/14.0.0/include/__clang_hip_cmath.h:98:31: note: candidate function not viable: call to __device__ function from __host__ function
__DEVICE__ __CONSTEXPR__ bool isnan(double __x) { return ::__isnan(__x); }
```

From: https://github.com/kokkos/kokkos/blob/2834f94af9b01debf67c1aaa3f0eb0c903d72c8d/core/src/Kokkos_Macros.hpp#L493
```
#if defined(__CUDACC__) && defined(__CUDA_ARCH__) && defined(KOKKOS_ENABLE_CUDA)
#define KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_CUDA
#elif defined(__SYCL_DEVICE_ONLY__) && defined(KOKKOS_ENABLE_SYCL)
#define KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_SYCL
#elif defined(__HIPCC__) && defined(__HIP_DEVICE_COMPILE__) && \
    defined(KOKKOS_ENABLE_HIP)
#define KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HIP_GPU
#else
#define KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
#endif
```

Neither `KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HIP_GPU` nor `KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST` are defined. It could be I'm doing something incorrectly, still I would think setting `__HIPCC__`, `__HIP_DEVICE_COMPILE__`, and `KOKKOS_ENABLE_HIP` would result in setting `KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HIP_GPU` and still lead to the wrong-side rule violation.
There are a few ways around this. But since the `__HIP_DEVICE_COMPILE__` macro is used in other places in `src/Kokkos_ArithTraits.hpp`, maybe just use that?

If I am doing something wrong, please advise how I can fix my compiler error.
Thanks!