### PR TITLE
Only instantiate Kokkos's default Cuda mem space

### DIFF
--- a/cmake/kokkoskernels_eti_devices.cmake
+++ b/cmake/kokkoskernels_eti_devices.cmake
@@ -41,19 +41,29 @@ SET(MEMSPACE_HBWSPACE_CPP_TYPE          Kokkos::HBWSpace)
 IF(KOKKOS_ENABLE_CUDA)
  KOKKOSKERNELS_ADD_OPTION(
    INST_EXECSPACE_CUDA
-   ${KOKKOSKERNELS_INST_EXECSPACE_CUDA_DEFAULT}
+   ON
    BOOL
    "Whether to pre instantiate kernels for the execution space Kokkos::Cuda. Disabling this when Kokkos_ENABLE_CUDA is enabled may increase build times. Default: ON if Kokkos is CUDA-enabled, OFF otherwise."
    )
+
+ # By default, instantiate only for Cuda's default memory space (either CudaSpace, or CudaUVMSpace).
+ IF(KOKKOS_ENABLE_CUDA_UVM)
+   SET(CUDA_CUDAUVMSPACE_DEFAULT ON)
+   SET(CUDA_CUDASPACE_DEFAULT OFF)
+ ELSE()
+   SET(CUDA_CUDAUVMSPACE_DEFAULT OFF)
+   SET(CUDA_CUDASPACE_DEFAULT ON)
+ ENDIF()
+
  KOKKOSKERNELS_ADD_OPTION(
    INST_MEMSPACE_CUDAUVMSPACE
-   ${KOKKOSKERNELS_INST_EXECSPACE_CUDA_DEFAULT}
+   ${CUDA_CUDAUVMSPACE_DEFAULT}
    BOOL
    "Whether to pre instantiate kernels for the memory space Kokkos::CudaUVMSpace.  Disabling this when Kokkos_ENABLE_CUDA is enabled may increase build times. Default: ON if Kokkos is CUDA-enabled, OFF otherwise."
    )
  KOKKOSKERNELS_ADD_OPTION(
    INST_MEMSPACE_CUDASPACE
-   ${KOKKOSKERNELS_INST_EXECSPACE_CUDA_DEFAULT}
+   ${CUDA_CUDASPACE_DEFAULT}
    BOOL
    "Whether to pre instantiate kernels for the memory space Kokkos::CudaSpace.  Disabling this when Kokkos_ENABLE_CUDA is enabled may increase build times. Default: ON if Kokkos is CUDA-enabled, OFF otherwise."
    )


### PR DESCRIPTION
Instead of instantiating for both ``<Cuda,CudaSpace>`` and ``<Cuda,CudaUVMSpace>``
by default, just instantiate for the Kokkos's default mem space
(``Cuda::memory_space``), which is controlled by the option ``Kokkos_ENABLE_CUDA_UVM``.

This is a 5 year old suggestion from Trilinos but still, I think better late than never :)
See https://github.com/trilinos/Trilinos/issues/1729

This will roughly cut the library build time in half for Cuda builds, with no downsides that I can think of. The Tpetra stack is either all-UVM or all-CudaSpace. Meanwhile our unit tests, perf tests and examples all use the default mem space for the given exec space, so we're not losing coverage with this change.