### PR TITLE
Fix sign-compare warning in SPMV perf test

### DIFF
--- a/perf_test/sparse/spmv/Kokkos_SPMV_Inspector.hpp
+++ b/perf_test/sparse/spmv/Kokkos_SPMV_Inspector.hpp
@@ -143,7 +143,7 @@ void kk_inspector_matvec(AType A, XType x, YType y, int team_size,
     workset_offsets(0)    = 0;
     lno_t ws              = 1;
     for (lno_t row = 0; row < A.numRows(); row++) {
-      if (A.graph.row_map(row) > ws * nnz_per_workset) {
+      if (A.graph.row_map(row) > size_type(ws) * nnz_per_workset) {
         workset_offsets(ws) = row;
         ws++;
       }


### PR DESCRIPTION
size_t was recently changed to be the default offset enabled in a build, and this exposed this signed/unsigned comparison warning in the SPMV perf test.