### PR TITLE
Fix unused parameter warnings in GEMM test.

### DIFF
--- a/perf_test/blas/blas3/KokkosBlas3_gemm_perf_test.hpp
+++ b/perf_test/blas/blas3/KokkosBlas3_gemm_perf_test.hpp
@@ -1775,6 +1775,11 @@ out:
   Kokkos::deep_copy(dst, h_dst);
   Kokkos::fence();
 #else
+  // Avoid unused parameter warnings:
+  (void)src;
+  (void)dst;
+  (void)options;
+
   Kokkos::abort(
       "Cannot perform simd verification with cuda/10.2.2, rerun with -v 0");
 #endif  // #if (CUDA_VERSION != 10020)


### PR DESCRIPTION
This fixes the following unused parameter warnings that were blocking my build:
``` 
/ascldap/users/jloe/Kokkos/kokkos-kernels/perf_test/blas/blas3/KokkosBlas3_gemm_perf_test.hpp: In instantiation of ‘void __gemm_copy_simd_view_to_3d_view(gemm_simd_args_t, dstViewType, options_t) 
[with dstViewType = Kokkos::View<double***, Kokkos::LayoutLeft, Kokkos::Cuda>; gemm_simd_args_t = gemm_simd_args; options_t = perf_test_options]’:
/ascldap/users/jloe/Kokkos/kokkos-kernels/perf_test/blas/blas3/KokkosBlas3_gemm_perf_test.hpp:1845:97:   required from ‘void __gemm_do_verify(options_t, gemm_args_t, void (*)(options_t, gemm_args_t)) 
[with ScalarType = double; LayoutType = Kokkos::LayoutLeft; DeviceType = Kokkos::Cuda; options_t = perf_test_options; gemm_args_t = gemm_args]’
/ascldap/users/jloe/Kokkos/kokkos-kernels/perf_test/blas/blas3/KokkosBlas3_gemm_perf_test.hpp:2209:84:   required from here
/ascldap/users/jloe/Kokkos/kokkos-kernels/perf_test/blas/blas3/KokkosBlas3_gemm_perf_test.hpp:1641:51: error: unused parameter ‘src’ [-Werror=unused-parameter]
 static inline void __gemm_copy_simd_view_to_3d_view(gemm_simd_args_t src,
                                                   ^~~
/ascldap/users/jloe/Kokkos/kokkos-kernels/perf_test/blas/blas3/KokkosBlas3_gemm_perf_test.hpp:1642:1: error: unused parameter ‘dst’ [-Werror=unused-parameter]
                                                     dstViewType dst,
 ^
/ascldap/users/jloe/Kokkos/kokkos-kernels/perf_test/blas/blas3/KokkosBlas3_gemm_perf_test.hpp:1643:1: error: unused parameter ‘options’ [-Werror=unused-parameter]
                                                     options_t options) {
```
That said, I am not 100% sure that this is the correct fix.  I am building with CUDA 10.2.89.  
The test error message only indicates a problem with CUDA 10.2.2.  Should my build really be skipping this test per the ifdef in this code?