### PR TITLE
Value-initialize result of `MaxLoc` reduction to avoid maybe uninitialized warning

### DIFF
--- a/src/batched/dense/impl/KokkosBatched_FindAmax_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_FindAmax_Internal.hpp
@@ -43,7 +43,7 @@ struct TeamVectorFindAmaxInternal {
     if (m > 0) {
       using reducer_value_type =
           typename Kokkos::MaxLoc<ValueType, IntType>::value_type;
-      reducer_value_type value;
+      reducer_value_type value{};
       Kokkos::MaxLoc<ValueType, IntType> reducer_value(value);
       Kokkos::parallel_reduce(
           Kokkos::TeamVectorRange(member, m),


### PR DESCRIPTION
Tentative fix for kokkos/kokkos#4959
Value-initialization will zero-initialize the `ValLocScalar` data members.

To be honest I don't quite see how the warning was not there before and how it is related to the "volatile" changes in Kokkos.

cc @PhilMiller