### PR TITLE
Add verbosity parameter to GMRES example. Turn off for testing.

### DIFF
--- a/example/gmres/ex_real_A.cpp
+++ b/example/gmres/ex_real_A.cpp
@@ -64,7 +64,7 @@ int main(int argc, char* argv[]) {
   int m          = 50;                   // Max subspace size before restarting.
   double convTol = 1e-10;  // Relative residual convergence tolerance.
   int cycLim     = 50;     // Maximum number of times to restart the solver.
-  bool rand_rhs = false;   // Generate random right-hand side.
+  bool rand_rhs  = false;  // Generate random right-hand side.
 
   for (int i = 1; i < argc; ++i) {
     const std::string& token = argv[i];

--- a/example/gmres/ex_real_A.cpp
+++ b/example/gmres/ex_real_A.cpp
@@ -42,31 +42,31 @@
 //@HEADER
 */
 
-#include<math.h>
-#include"KokkosKernels_IOUtils.hpp"
-#include<Kokkos_Core.hpp>
-#include<Kokkos_Random.hpp>
-#include<KokkosBlas.hpp>
-#include<KokkosBlas3_trsm.hpp>
-#include<KokkosSparse_spmv.hpp>
+#include <math.h>
+#include "KokkosKernels_IOUtils.hpp"
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
+#include <KokkosBlas.hpp>
+#include <KokkosBlas3_trsm.hpp>
+#include <KokkosSparse_spmv.hpp>
 
-#include"gmres.hpp"
+#include "gmres.hpp"
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   typedef double ST;
   typedef int OT;
-  typedef Kokkos::DefaultExecutionSpace     EXSP;
+  typedef Kokkos::DefaultExecutionSpace EXSP;
 
-  using ViewVectorType = Kokkos::View<ST*,Kokkos::LayoutLeft, EXSP>;
+  using ViewVectorType = Kokkos::View<ST*, Kokkos::LayoutLeft, EXSP>;
 
-  std::string filename("bcsstk09.mtx"); // example matrix
-  std::string ortho("CGS2"); //orthog type
-  int m = 50; //Max subspace size before restarting.
-  double convTol = 1e-10; //Relative residual convergence tolerance.
-  int cycLim = 50; //Maximum number of times to restart the solver. 
-  bool rand_rhs = false; //Generate random right-hand side. 
+  std::string filename("bcsstk09.mtx");  // example matrix
+  std::string ortho("CGS2");             // orthog type
+  int m          = 50;                   // Max subspace size before restarting.
+  double convTol = 1e-10;  // Relative residual convergence tolerance.
+  int cycLim     = 50;     // Maximum number of times to restart the solver.
+  bool rand_rhs = false;   // Generate random right-hand side.
 
-  for (int i=1;i<argc;++i) {
+  for (int i = 1; i < argc; ++i) {
     const std::string& token = argv[i];
     if (token == std::string("--filename")) filename = argv[++i];
     if (token == std::string("--max-subsp")) m = std::atoi(argv[++i]);
@@ -74,68 +74,84 @@ int main(int argc, char *argv[]) {
     if (token == std::string("--tol")) convTol = std::stod(argv[++i]);
     if (token == std::string("--ortho")) ortho = argv[++i];
     if (token == std::string("--rand_rhs")) rand_rhs = true;
-    if (token == std::string("--help") || token == std::string("-h")){
-      std::cout << "Kokkos GMRES solver options:" << std::endl
-        << "--filename    :  The name of a matrix market (.mtx) file for matrix A (Default bcsstk09.mtx)." << std::endl
-        << "--max-subsp   :  The maximum size of the Kyrlov subspace before restarting (Default 50)." << std::endl
-        << "--max-restarts:  Maximum number of GMRES restarts (Default 50)." << std::endl
-        << "--tol         :  Convergence tolerance.  (Default 1e-10)." << std::endl
-        << "--ortho       :  Type of orthogonalization. Use 'CGS2' or 'MGS'. (Default 'CGS2')" << std::endl
-        << "--rand_rhs    :  Generate a random right-hand side b.  (Else, default uses b = vector of ones.)" << std::endl
-        << "--help  -h    :  Display this help message." << std::endl 
-        << "Example Call  :  ./Gmres.exe --filename Laplace3D100.mtx --tol 1e-5 --max-subsp 100 " << std::endl << std::endl;
-      return 0; }
+    if (token == std::string("--help") || token == std::string("-h")) {
+      std::cout
+          << "Kokkos GMRES solver options:" << std::endl
+          << "--filename    :  The name of a matrix market (.mtx) file for "
+             "matrix A (Default bcsstk09.mtx)."
+          << std::endl
+          << "--max-subsp   :  The maximum size of the Kyrlov subspace before "
+             "restarting (Default 50)."
+          << std::endl
+          << "--max-restarts:  Maximum number of GMRES restarts (Default 50)."
+          << std::endl
+          << "--tol         :  Convergence tolerance.  (Default 1e-10)."
+          << std::endl
+          << "--ortho       :  Type of orthogonalization. Use 'CGS2' or 'MGS'. "
+             "(Default 'CGS2')"
+          << std::endl
+          << "--rand_rhs    :  Generate a random right-hand side b.  (Else, "
+             "default uses b = vector of ones.)"
+          << std::endl
+          << "--help  -h    :  Display this help message." << std::endl
+          << "Example Call  :  ./Gmres.exe --filename Laplace3D100.mtx --tol "
+             "1e-5 --max-subsp 100 "
+          << std::endl
+          << std::endl;
+      return 0;
+    }
   }
   std::cout << "File to process is: " << filename << std::endl;
   std::cout << "Convergence tolerance is: " << convTol << std::endl;
 
   // Set GMRES options:
   GmresOpts<ST> solverOpts;
-  solverOpts.tol = convTol;
-  solverOpts.m = m;
+  solverOpts.tol        = convTol;
+  solverOpts.m          = m;
   solverOpts.maxRestart = cycLim;
-  solverOpts.ortho = ortho;
+  solverOpts.ortho      = ortho;
+  solverOpts.verbose    = false;  // No verbosity needed for most testing
 
-  //Initialize Kokkos AFTER parsing parameters:
+  // Initialize Kokkos AFTER parsing parameters:
   Kokkos::initialize();
   {
+    // Read in a matrix Market file and use it to test the Kokkos Operator.
+    KokkosSparse::CrsMatrix<ST, OT, EXSP> A =
+        KokkosKernels::Impl::read_kokkos_crst_matrix<
+            KokkosSparse::CrsMatrix<ST, OT, EXSP>>(filename.c_str());
 
-  // Read in a matrix Market file and use it to test the Kokkos Operator.
-  KokkosSparse::CrsMatrix<ST, OT, EXSP> A = 
-    KokkosKernels::Impl::read_kokkos_crst_matrix<KokkosSparse::CrsMatrix<ST, OT, EXSP>>(filename.c_str()); 
+    int n = A.numRows();
+    ViewVectorType X("X", n);    // Solution and initial guess
+    ViewVectorType Wj("Wj", n);  // For checking residuals at end.
+    ViewVectorType B(Kokkos::view_alloc(Kokkos::WithoutInitializing, "B"),
+                     n);  // right-hand side vec
 
-  int n = A.numRows();
-  ViewVectorType X("X",n); //Solution and initial guess
-  ViewVectorType Wj("Wj",n); //For checking residuals at end.
-  ViewVectorType B(Kokkos::view_alloc(Kokkos::WithoutInitializing, "B"),n);//right-hand side vec
+    if (rand_rhs) {
+      // Make rhs random.
+      int rand_seed = 123;
+      Kokkos::Random_XorShift64_Pool<> pool(rand_seed);
+      Kokkos::fill_random(B, pool, -1, 1);
+    } else {
+      // Make rhs ones so that results are repeatable:
+      Kokkos::deep_copy(B, 1.0);
+    }
 
-  if(rand_rhs){
-    // Make rhs random.
-    int rand_seed = 123;
-    Kokkos::Random_XorShift64_Pool<> pool(rand_seed); 
-    Kokkos::fill_random(B, pool, -1,1);
-  }
-  else{
-    // Make rhs ones so that results are repeatable:
-    Kokkos::deep_copy(B,1.0);
-  }
+    // Run GMRS solve:
+    GmresStats solveStats =
+        gmres<ST, Kokkos::LayoutLeft, EXSP>(A, B, X, solverOpts);
 
-  // Run GMRS solve:
-  GmresStats solveStats = gmres<ST, Kokkos::LayoutLeft, EXSP>(A, B, X, solverOpts);
-
-  // Double check residuals at end of solve:
-  ST nrmB = KokkosBlas::nrm2(B);
-  KokkosSparse::spmv("N", 1.0, A, X, 0.0, Wj); // wj = Ax
-  KokkosBlas::axpy(-1.0, Wj, B); // b = b-Ax. 
-  ST endRes = KokkosBlas::nrm2(B)/nrmB;
-  std::cout << "=========================================" << std::endl;
-  std::cout << "Verify from main: Ending residual is " << endRes << std::endl;
-  std::cout << "Number of iterations is: " << solveStats.numIters << std::endl;
-  std::cout << "Diff of residual from main - residual from solver: " << solveStats.endRelRes - endRes << std::endl;
-  std::cout << "Convergence flag is : " << solveStats.convFlag() << std::endl;
-
+    // Double check residuals at end of solve:
+    ST nrmB = KokkosBlas::nrm2(B);
+    KokkosSparse::spmv("N", 1.0, A, X, 0.0, Wj);  // wj = Ax
+    KokkosBlas::axpy(-1.0, Wj, B);                // b = b-Ax.
+    ST endRes = KokkosBlas::nrm2(B) / nrmB;
+    std::cout << "=========================================" << std::endl;
+    std::cout << "Verify from main: Ending residual is " << endRes << std::endl;
+    std::cout << "Number of iterations is: " << solveStats.numIters
+              << std::endl;
+    std::cout << "Diff of residual from main - residual from solver: "
+              << solveStats.endRelRes - endRes << std::endl;
+    std::cout << "Convergence flag is : " << solveStats.convFlag() << std::endl;
   }
   Kokkos::finalize();
-
 }
-

--- a/example/gmres/test_cmplx_A.cpp
+++ b/example/gmres/test_cmplx_A.cpp
@@ -65,6 +65,7 @@ int main(int /*argc*/, char** /*argv[]*/) {
   solverOpts.tol        = 1e-05;  // Relative residual convergence tolerance.
   solverOpts.maxRestart = 60;
   solverOpts.ortho      = "CGS2";  // orthog type
+  solverOpts.verbose    = false;   // No verbosity needed for most testing
   bool pass1            = false;
   bool pass2            = false;
 

--- a/example/gmres/test_prec.cpp
+++ b/example/gmres/test_prec.cpp
@@ -61,8 +61,8 @@ int main(int argc, char* argv[]) {
   int m          = 50;        // Max subspace size before restarting.
   double convTol = 1e-10;     // Relative residual convergence tolerance.
   int cycLim     = 50;        // Maximum number of times to restart the solver.
-  bool rand_rhs = false;      // Generate random right-hand side.
-  bool pass = false;
+  bool rand_rhs  = false;     // Generate random right-hand side.
+  bool pass      = false;
 
   for (int i = 1; i < argc; ++i) {
     const std::string& token = argv[i];

--- a/example/gmres/test_prec.cpp
+++ b/example/gmres/test_prec.cpp
@@ -42,30 +42,29 @@
 //@HEADER
 */
 
-#include<KokkosSparse_MatrixPrec.hpp>
-#include<Kokkos_Core.hpp>
-#include<gmres.hpp>
-#include<Kokkos_Random.hpp>
-#include<KokkosBlas.hpp>
-#include<KokkosSparse_spmv.hpp>
+#include <KokkosSparse_MatrixPrec.hpp>
+#include <Kokkos_Core.hpp>
+#include <gmres.hpp>
+#include <Kokkos_Random.hpp>
+#include <KokkosBlas.hpp>
+#include <KokkosSparse_spmv.hpp>
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
+  typedef double ST;
+  typedef int OT;
+  typedef Kokkos::DefaultExecutionSpace EXSP;
 
-  typedef double                            ST;
-  typedef int                               OT;
-  typedef Kokkos::DefaultExecutionSpace     EXSP;
+  using ViewVectorType = Kokkos::View<ST*, Kokkos::LayoutLeft, EXSP>;
 
-  using ViewVectorType = Kokkos::View<ST*,Kokkos::LayoutLeft, EXSP>;
-
-  std::string ortho("CGS2"); //orthog type
-  int n = 1000; //Matrix size
-  int m = 50; //Max subspace size before restarting.
-  double convTol = 1e-10; //Relative residual convergence tolerance.
-  int cycLim = 50; //Maximum number of times to restart the solver. 
-  bool rand_rhs = false; //Generate random right-hand side. 
+  std::string ortho("CGS2");  // orthog type
+  int n          = 1000;      // Matrix size
+  int m          = 50;        // Max subspace size before restarting.
+  double convTol = 1e-10;     // Relative residual convergence tolerance.
+  int cycLim     = 50;        // Maximum number of times to restart the solver.
+  bool rand_rhs = false;      // Generate random right-hand side.
   bool pass = false;
 
-  for (int i=1;i<argc;++i) {
+  for (int i = 1; i < argc; ++i) {
     const std::string& token = argv[i];
     if (token == std::string("--mat-size")) n = std::atoi(argv[++i]);
     if (token == std::string("--max-subsp")) m = std::atoi(argv[++i]);
@@ -74,75 +73,98 @@ int main(int argc, char *argv[]) {
     if (token == std::string("--ortho")) ortho = argv[++i];
     if (token == std::string("--rand_rhs")) rand_rhs = true;
     if (token == std::string("--help") || token == std::string("-h")) {
-      std::cout << "Kokkos GMRES solver options:" << std::endl
-        << "--mat-size    :  The size of the nxn test matrix. (Default: n=1000.)" << std::endl
-        << "--max-subsp   :  The maximum size of the Kyrlov subspace before restarting (Default 50)." << std::endl
-        << "--max-restarts:  Maximum number of GMRES restarts (Default 50)." << std::endl
-        << "--tol         :  Convergence tolerance.  (Default 1e-10)." << std::endl
-        << "--ortho       :  Type of orthogonalization. Use 'CGS2' or 'MGS'. (Default 'CGS2')" << std::endl
-        << "--rand_rhs    :  Generate a random right-hand side b.  (Else, default uses b = vector of ones.)" << std::endl
-        << "--help  -h    :  Display this help message." << std::endl 
-        << "Example Call  :  ./Gmres.exe --filename Laplace3D100.mtx --tol 1e-5 --max-subsp 100 " << std::endl << std::endl;
-      return 0; }
+      std::cout
+          << "Kokkos GMRES solver options:" << std::endl
+          << "--mat-size    :  The size of the nxn test matrix. (Default: "
+             "n=1000.)"
+          << std::endl
+          << "--max-subsp   :  The maximum size of the Kyrlov subspace before "
+             "restarting (Default 50)."
+          << std::endl
+          << "--max-restarts:  Maximum number of GMRES restarts (Default 50)."
+          << std::endl
+          << "--tol         :  Convergence tolerance.  (Default 1e-10)."
+          << std::endl
+          << "--ortho       :  Type of orthogonalization. Use 'CGS2' or 'MGS'. "
+             "(Default 'CGS2')"
+          << std::endl
+          << "--rand_rhs    :  Generate a random right-hand side b.  (Else, "
+             "default uses b = vector of ones.)"
+          << std::endl
+          << "--help  -h    :  Display this help message." << std::endl
+          << "Example Call  :  ./Gmres.exe --filename Laplace3D100.mtx --tol "
+             "1e-5 --max-subsp 100 "
+          << std::endl
+          << std::endl;
+      return 0;
+    }
   }
   std::cout << "Convergence tolerance is: " << convTol << std::endl;
 
   // Set GMRES options:
   GmresOpts<ST> solverOpts;
-  solverOpts.tol = convTol;
-  solverOpts.m = m;
+  solverOpts.tol        = convTol;
+  solverOpts.m          = m;
   solverOpts.maxRestart = cycLim;
-  solverOpts.ortho = ortho;
+  solverOpts.ortho      = ortho;
+  solverOpts.verbose    = false;  // No verbosity needed for most testing
 
-  //Initialize Kokkos AFTER parsing parameters:
+  // Initialize Kokkos AFTER parsing parameters:
   Kokkos::initialize();
   {
-  // Generate a diagonal matrix with entries 1, 2, ...., 1000 and its inverse.
-  KokkosSparse::CrsMatrix<ST, OT, EXSP> A = 
-                        KokkosKernels::Impl::kk_generate_diag_matrix<KokkosSparse::CrsMatrix<ST, OT, EXSP>>(n);
-  KokkosSparse::Experimental::MatrixPrec<ST, Kokkos::LayoutLeft, EXSP, OT>  * myPrec = 
-                    new KokkosSparse::Experimental::MatrixPrec<ST, Kokkos::LayoutLeft, EXSP, OT>(
-                    KokkosKernels::Impl::kk_generate_diag_matrix<KokkosSparse::CrsMatrix<ST, OT, EXSP>>(n, true));
+    // Generate a diagonal matrix with entries 1, 2, ...., 1000 and its inverse.
+    KokkosSparse::CrsMatrix<ST, OT, EXSP> A =
+        KokkosKernels::Impl::kk_generate_diag_matrix<
+            KokkosSparse::CrsMatrix<ST, OT, EXSP>>(n);
+    KokkosSparse::Experimental::MatrixPrec<ST, Kokkos::LayoutLeft, EXSP, OT>*
+        myPrec =
+            new KokkosSparse::Experimental::MatrixPrec<ST, Kokkos::LayoutLeft,
+                                                       EXSP, OT>(
+                KokkosKernels::Impl::kk_generate_diag_matrix<
+                    KokkosSparse::CrsMatrix<ST, OT, EXSP>>(n, true));
 
-  ViewVectorType X(Kokkos::view_alloc(Kokkos::WithoutInitializing, "X"),n); //Solution and initial guess
-  ViewVectorType Wj("Wj",n); //For checking residuals at end.
-  ViewVectorType B(Kokkos::view_alloc(Kokkos::WithoutInitializing, "B"),n);//right-hand side vec
-  int rand_seed = 123;
-  Kokkos::Random_XorShift64_Pool<> pool(rand_seed); 
-  Kokkos::fill_random(X, pool, -1,1); //Use non-zero initial guess to test GMRES properties. 
-  if(rand_rhs){
-    Kokkos::fill_random(B, pool, -1,1);
-  }
-  else{
-    // Make rhs ones so that results are repeatable:
-    Kokkos::deep_copy(B,1.0);
-  }
+    ViewVectorType X(Kokkos::view_alloc(Kokkos::WithoutInitializing, "X"),
+                     n);         // Solution and initial guess
+    ViewVectorType Wj("Wj", n);  // For checking residuals at end.
+    ViewVectorType B(Kokkos::view_alloc(Kokkos::WithoutInitializing, "B"),
+                     n);  // right-hand side vec
+    int rand_seed = 123;
+    Kokkos::Random_XorShift64_Pool<> pool(rand_seed);
+    Kokkos::fill_random(
+        X, pool, -1,
+        1);  // Use non-zero initial guess to test GMRES properties.
+    if (rand_rhs) {
+      Kokkos::fill_random(B, pool, -1, 1);
+    } else {
+      // Make rhs ones so that results are repeatable:
+      Kokkos::deep_copy(B, 1.0);
+    }
 
-  GmresStats solveStats = gmres<ST, Kokkos::LayoutLeft, EXSP>(A, B, X, solverOpts, myPrec);
+    GmresStats solveStats =
+        gmres<ST, Kokkos::LayoutLeft, EXSP>(A, B, X, solverOpts, myPrec);
 
-  // Double check residuals at end of solve:
-  ST nrmB = KokkosBlas::nrm2(B);
-  KokkosSparse::spmv("N", 1.0, A, X, 0.0, Wj); // wj = Ax
-  KokkosBlas::axpy(-1.0, Wj, B); // b = b-Ax. 
-  ST endRes = KokkosBlas::nrm2(B)/nrmB;
-  std::cout << "=========================================" << std::endl;
-  std::cout << "Verify from main: Ending residual is " << endRes << std::endl;
-  std::cout << "Number of iterations is: " << solveStats.numIters << std::endl;
-  std::cout << "Diff of residual from main - residual from solver: " << solveStats.endRelRes - endRes << std::endl;
-  std::cout << "Convergence flag is : " << solveStats.convFlag() << std::endl;
-  if( endRes < convTol && solveStats.numIters == 1){
-    pass = true;
-  }
-
+    // Double check residuals at end of solve:
+    ST nrmB = KokkosBlas::nrm2(B);
+    KokkosSparse::spmv("N", 1.0, A, X, 0.0, Wj);  // wj = Ax
+    KokkosBlas::axpy(-1.0, Wj, B);                // b = b-Ax.
+    ST endRes = KokkosBlas::nrm2(B) / nrmB;
+    std::cout << "=========================================" << std::endl;
+    std::cout << "Verify from main: Ending residual is " << endRes << std::endl;
+    std::cout << "Number of iterations is: " << solveStats.numIters
+              << std::endl;
+    std::cout << "Diff of residual from main - residual from solver: "
+              << solveStats.endRelRes - endRes << std::endl;
+    std::cout << "Convergence flag is : " << solveStats.convFlag() << std::endl;
+    if (endRes < convTol && solveStats.numIters == 1) {
+      pass = true;
+    }
   }
   Kokkos::finalize();
 
-  if( pass ){
+  if (pass) {
     std::cout << "Test passed!" << std::endl;
-  }
-  else{
+  } else {
     std::cout << "Test Failed!" << std::endl;
   }
-  return ( pass ? EXIT_SUCCESS : EXIT_FAILURE );
+  return (pass ? EXIT_SUCCESS : EXIT_FAILURE);
 }
-

--- a/example/gmres/test_real_A.cpp
+++ b/example/gmres/test_real_A.cpp
@@ -72,6 +72,7 @@ int main(int /*argc*/, char** /*argv[]*/) {
   solverOpts.m          = 15;      // Max subspace size before restarting.
   solverOpts.tol        = 1e-10;   // Relative residual convergence tolerance.
   solverOpts.maxRestart = 50;
+  solverOpts.verbose    = false;  // No verbosity needed for most testing
   bool pass1            = false;
   bool pass2            = false;
 


### PR DESCRIPTION
Adds verbosity parameter to the GMRES examples and turns it off during testing.  The output was taking over all of the other PR test output, so it may be helpful to silence it. 

Also, it seems that several files were adjusted by CLANG formatting. 