### PR TITLE
Reformat PR test reproducer instructions for clarity.

### DIFF
--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -1457,19 +1457,19 @@ wait_summarize_and_exit() {
         echo "#######################################################"
         echo "  # Reproducer instructions:"
                   modulefile=$faildir/reload_modules.sh
-                  head -1 $modulefile | cut -c 2-
+        echo "   "\#"$(cat modulefile)"
         echo ""
-        echo “   Then run the following bash script:" 
+        echo "   Then run the following bash script:" 
         echo ""
-        echo \"$(cat $faildir/call_generate_makefile_genericpath.sh)\"
+        echo "   \\$(cat $faildir/call_generate_makefile_genericpath.sh)"
         echo ""
         echo "   where KOKKOSKERNELS_PATH is the top-level KokkosKernels
         echo "   code directory. This will generate a makefile. 
         echo ""
-        echo "  #  If you have webcars Jenkins job creation access: "
+        echo "   # If you have webcars Jenkins job creation access: "
         echo ""
-        echo "  ##  To reload modules, reconfigure, rebuild, and retest 
-        echo "  ##  directly from this failing build, do the following:
+        echo "  ##  To reload modules, reconfigure, rebuild, and retest "
+        echo "  ##  directly from this failing build, do the following: "
         echo "      # Move to the build directory"
         echo "        cd $faildir"
         echo "      # To reload modules"

--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -1456,13 +1456,18 @@ wait_summarize_and_exit() {
       if [ $TEST_SPACK = "False" ]; then
         echo "#######################################################"
         echo "  # Reproducer instructions:"
-        echo "   1. \\$(cat $faildir/reload_modules.sh)
-        echo “   2. Then run the following bash script:" 
+                  modulefile=$faildir/reload_modules.sh
+                  head -1 $modulefile | cut -c 2-
+        echo ""
+        echo “   Then run the following bash script:" 
+        echo ""
         echo \"$(cat $faildir/call_generate_makefile_genericpath.sh)\"
+        echo ""
         echo "   where KOKKOSKERNELS_PATH is the top-level KokkosKernels
         echo "   code directory. This will generate a makefile. 
         echo ""
-        echo "  #  If (and only if) you have webcars Jenkins job creation access:
+        echo "  #  If you have webcars Jenkins job creation access: "
+        echo ""
         echo "  ##  To reload modules, reconfigure, rebuild, and retest 
         echo "  ##  directly from this failing build, do the following:
         echo "      # Move to the build directory"

--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -1456,10 +1456,15 @@ wait_summarize_and_exit() {
       if [ $TEST_SPACK = "False" ]; then
         echo "#######################################################"
         echo "  # Reproducer instructions:"
-        cat $faildir/reload_modules.sh
-        cat $faildir/call_generate_makefile_genericpath.sh
+        echo "   1. \\$(cat $faildir/reload_modules.sh)
+        echo “   2. Then run the following bash script:" 
+        echo \"$(cat $faildir/call_generate_makefile_genericpath.sh)\"
+        echo "   where KOKKOSKERNELS_PATH is the top-level KokkosKernels
+        echo "   code directory. This will generate a makefile. 
         echo ""
-        echo "  #  To reload modules, reconfigure, rebuild, and retest directly from this failing build do the following:"
+        echo "  #  If (and only if) you have webcars Jenkins job creation access:
+        echo "  ##  To reload modules, reconfigure, rebuild, and retest 
+        echo "  ##  directly from this failing build, do the following:
         echo "      # Move to the build directory"
         echo "        cd $faildir"
         echo "      # To reload modules"


### PR DESCRIPTION
This is an attempt to reformat the PR test build reproducer instructions so that they will be clearer for new developers. 