### PR TITLE
Improve spiluk numeric phase to avoid race conditions and processing in chunks

### DIFF
--- a/src/sparse/KokkosSparse_spiluk_handle.hpp
+++ b/src/sparse/KokkosSparse_spiluk_handle.hpp
@@ -100,12 +100,17 @@ class SPILUKHandle {
   nnz_lno_view_t level_idx;   // the list of rows in each level
   nnz_lno_view_t
       level_ptr;  // the starting index (into the view level_idx) of each level
+  nnz_lno_view_t level_nchunks; //number of chunks of rows at each level
+  nnz_lno_view_t 
+      level_nrowsperchunk; //maximum number of rows among chunks at each level
 
   size_type nrows;
-  size_type nlevel;
+  size_type nlevels;
   size_type nnzL;
   size_type nnzU;
-  size_type level_maxrows;  // maximum number of rows of levels
+  size_type level_maxrows;  // max. number of rows among levels
+  size_type 
+      level_maxrowsperchunk;//max.number of rows among chunks among levels
 
   bool symbolic_complete;
 
@@ -121,11 +126,14 @@ class SPILUKHandle {
       : level_list(),
         level_idx(),
         level_ptr(),
+        level_nchunks(),
+        level_nrowsperchunk(),
         nrows(nrows_),
-        nlevel(0),
+        nlevels(0),
         nnzL(nnzL_),
         nnzU(nnzU_),
         level_maxrows(0),
+        level_maxrowsperchunk(0),
         symbolic_complete(symbolic_complete_),
         algm(choice),
         team_size(-1),
@@ -138,9 +146,12 @@ class SPILUKHandle {
     set_nnzL(nnzL_);
     set_nnzU(nnzU_);
     set_level_maxrows(0);
+    set_level_maxrowsperchunk(0);
     level_list = nnz_row_view_t("level_list", nrows_),
     level_idx  = nnz_lno_view_t("level_idx", nrows_),
     level_ptr  = nnz_lno_view_t("level_ptr", nrows_ + 1),
+    level_nchunks = nnz_lno_view_t(),
+    level_nrowsperchunk = nnz_lno_view_t(),
     reset_symbolic_complete();
   }
 
@@ -158,6 +169,22 @@ class SPILUKHandle {
 
   KOKKOS_INLINE_FUNCTION
   nnz_lno_view_t get_level_ptr() const { return level_ptr; }
+
+  KOKKOS_INLINE_FUNCTION
+  nnz_lno_view_t get_level_nchunks() const { return level_nchunks; }
+
+  void alloc_level_nchunks(const size_type nlevels_) {
+    level_nchunks = nnz_lno_view_t("level_nchunks", nlevels_);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  nnz_lno_view_t get_level_nrowsperchunk() const { 
+    return level_nrowsperchunk; 
+  }
+
+  void alloc_level_nrowsperchunk(const size_type nlevels_) {
+    level_nrowsperchunk = nnz_lno_view_t("level_nrowsperchunk", nlevels_);
+  }
 
   KOKKOS_INLINE_FUNCTION
   size_type get_nrows() const { return nrows; }
@@ -185,10 +212,18 @@ class SPILUKHandle {
     this->level_maxrows = level_maxrows_;
   }
 
+  KOKKOS_INLINE_FUNCTION
+  size_type get_level_maxrowsperchunk() const { return level_maxrowsperchunk; }
+
+  KOKKOS_INLINE_FUNCTION
+  void set_level_maxrowsperchunk(const size_type level_maxrowsperchunk_) { 
+    this->level_maxrowsperchunk = level_maxrowsperchunk_; 
+  }
+
   bool is_symbolic_complete() const { return symbolic_complete; }
 
-  size_type get_num_levels() const { return nlevel; }
-  void set_num_levels(size_type nlevels_) { this->nlevel = nlevels_; }
+  size_type get_num_levels() const { return nlevels; }
+  void set_num_levels(size_type nlevels_) { this->nlevels = nlevels_; }
 
   void set_symbolic_complete() { this->symbolic_complete = true; }
   void reset_symbolic_complete() { this->symbolic_complete = false; }
@@ -202,11 +237,9 @@ class SPILUKHandle {
   void print_algorithm() {
     if (algm == SPILUKAlgorithm::SEQLVLSCHD_RP)
       std::cout << "SEQLVLSCHD_RP" << std::endl;
-    ;
 
     if (algm == SPILUKAlgorithm::SEQLVLSCHD_TP1)
       std::cout << "SEQLVLSCHD_TP1" << std::endl;
-    ;
 
     /*
     if ( algm == SPILUKAlgorithm::SEQLVLSCHED_TP2 ) {

--- a/src/sparse/KokkosSparse_spiluk_handle.hpp
+++ b/src/sparse/KokkosSparse_spiluk_handle.hpp
@@ -100,17 +100,17 @@ class SPILUKHandle {
   nnz_lno_view_t level_idx;   // the list of rows in each level
   nnz_lno_view_t
       level_ptr;  // the starting index (into the view level_idx) of each level
-  nnz_lno_view_t level_nchunks; //number of chunks of rows at each level
-  nnz_lno_view_t 
-      level_nrowsperchunk; //maximum number of rows among chunks at each level
+  nnz_lno_view_t level_nchunks;  // number of chunks of rows at each level
+  nnz_lno_view_t
+      level_nrowsperchunk;  // maximum number of rows among chunks at each level
 
   size_type nrows;
   size_type nlevels;
   size_type nnzL;
   size_type nnzU;
   size_type level_maxrows;  // max. number of rows among levels
-  size_type 
-      level_maxrowsperchunk;//max.number of rows among chunks among levels
+  size_type
+      level_maxrowsperchunk;  // max.number of rows among chunks among levels
 
   bool symbolic_complete;
 
@@ -147,11 +147,10 @@ class SPILUKHandle {
     set_nnzU(nnzU_);
     set_level_maxrows(0);
     set_level_maxrowsperchunk(0);
-    level_list = nnz_row_view_t("level_list", nrows_),
-    level_idx  = nnz_lno_view_t("level_idx", nrows_),
-    level_ptr  = nnz_lno_view_t("level_ptr", nrows_ + 1),
-    level_nchunks = nnz_lno_view_t(),
-    level_nrowsperchunk = nnz_lno_view_t(),
+    level_list    = nnz_row_view_t("level_list", nrows_),
+    level_idx     = nnz_lno_view_t("level_idx", nrows_),
+    level_ptr     = nnz_lno_view_t("level_ptr", nrows_ + 1),
+    level_nchunks = nnz_lno_view_t(), level_nrowsperchunk = nnz_lno_view_t(),
     reset_symbolic_complete();
   }
 
@@ -178,9 +177,7 @@ class SPILUKHandle {
   }
 
   KOKKOS_INLINE_FUNCTION
-  nnz_lno_view_t get_level_nrowsperchunk() const { 
-    return level_nrowsperchunk; 
-  }
+  nnz_lno_view_t get_level_nrowsperchunk() const { return level_nrowsperchunk; }
 
   void alloc_level_nrowsperchunk(const size_type nlevels_) {
     level_nrowsperchunk = nnz_lno_view_t("level_nrowsperchunk", nlevels_);
@@ -216,8 +213,8 @@ class SPILUKHandle {
   size_type get_level_maxrowsperchunk() const { return level_maxrowsperchunk; }
 
   KOKKOS_INLINE_FUNCTION
-  void set_level_maxrowsperchunk(const size_type level_maxrowsperchunk_) { 
-    this->level_maxrowsperchunk = level_maxrowsperchunk_; 
+  void set_level_maxrowsperchunk(const size_type level_maxrowsperchunk_) {
+    this->level_maxrowsperchunk = level_maxrowsperchunk_;
   }
 
   bool is_symbolic_complete() const { return symbolic_complete; }

--- a/src/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
@@ -323,9 +323,9 @@ struct ILUKLvlSchedTP1NumericFunctor {
             if (ipos != -1) {
               auto lxu = -U_values(kk) * fact;
               if (col < rowid)
-                L_values(ipos) += lxu;
+                Kokkos::atomic_add (&L_values(ipos), lxu);
               else
-                U_values(ipos) += lxu;
+                Kokkos::atomic_add (&U_values(ipos), lxu);
             }
           });  // end for kk
 
@@ -383,28 +383,46 @@ void iluk_numeric(IlukHandle &thandle, const ARowMapType &A_row_map,
   using size_type               = typename IlukHandle::size_type;
   using nnz_lno_t               = typename IlukHandle::nnz_lno_t;
   using HandleDeviceEntriesType = typename IlukHandle::nnz_lno_view_t;
+  using WorkViewType            = 
+      Kokkos::View<nnz_lno_t**, Kokkos::Device<execution_space,memory_space>>;
+  using LevelHostViewType       = Kokkos::View<nnz_lno_t*, Kokkos::HostSpace>;
 
   size_type nlevels = thandle.get_num_levels();
   size_type nrows   = thandle.get_nrows();
 
-  // Keep this as host View, create device version and copy to back to host
+  // Keep these as host View, create device version and copy back to host
   HandleDeviceEntriesType level_ptr = thandle.get_level_ptr();
+  HandleDeviceEntriesType level_idx = thandle.get_level_idx();
+  HandleDeviceEntriesType level_nchunks = thandle.get_level_nchunks();
+  HandleDeviceEntriesType level_nrowsperchunk = 
+                                    thandle.get_level_nrowsperchunk();
+
   // Make level_ptr_h a separate allocation, since it will be accessed on host
   // between kernel launches. If a mirror were used and level_ptr is in UVM
   // space, a fence would be required before each access since UVM views can
   // share pages.
-  Kokkos::View<nnz_lno_t *, Kokkos::HostSpace> level_ptr_h(
-      Kokkos::view_alloc(Kokkos::WithoutInitializing, "Host level pointers"),
-      level_ptr.extent(0));
+  LevelHostViewType level_ptr_h, level_nchunks_h, level_nrowsperchunk_h;
+  WorkViewType iw;
+
+  level_ptr_h = LevelHostViewType(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Host level pointers"),
+                                  level_ptr.extent(0));
   Kokkos::deep_copy(level_ptr_h, level_ptr);
 
-  HandleDeviceEntriesType level_idx = thandle.get_level_idx();
-
-  using WorkViewType =
-      Kokkos::View<nnz_lno_t **, Kokkos::Device<execution_space, memory_space>>;
-
-  WorkViewType iw("iw", thandle.get_level_maxrows(), nrows);
-  Kokkos::deep_copy(iw, nnz_lno_t(-1));
+  if ( thandle.get_algorithm() == 
+       KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_TP1 ) {
+    level_nchunks_h       = LevelHostViewType(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Host level nchunks"),
+                                              level_nchunks.extent(0));
+    level_nrowsperchunk_h = LevelHostViewType(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Host level nrowsperchunk"),
+                                              level_nrowsperchunk.extent(0));
+    Kokkos::deep_copy(level_nchunks_h,       level_nchunks);
+    Kokkos::deep_copy(level_nrowsperchunk_h, level_nrowsperchunk);
+    iw = WorkViewType( Kokkos::view_alloc(Kokkos::WithoutInitializing, "iw"), thandle.get_level_maxrowsperchunk(), nrows );
+    Kokkos::deep_copy(iw, nnz_lno_t(-1));
+    }
+  else {
+    iw = WorkViewType( Kokkos::view_alloc(Kokkos::WithoutInitializing, "iw"), thandle.get_level_maxrows(), nrows );
+    Kokkos::deep_copy(iw, nnz_lno_t(-1));
+  }
 
   // Main loop must be performed sequential. Question: Try out Cuda's graph
   // stuff to reduce kernel launch overhead
@@ -424,25 +442,41 @@ void iluk_numeric(IlukHandle &thandle, const ARowMapType &A_row_map,
                 UValuesType, HandleDeviceEntriesType, WorkViewType, nnz_lno_t>(
                 A_row_map, A_entries, A_values, L_row_map, L_entries, L_values,
                 U_row_map, U_entries, U_values, level_idx, iw, lev_start));
-      } else if (thandle.get_algorithm() ==
-                 KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_TP1) {
+      } else if ( thandle.get_algorithm() ==
+                KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_TP1 ) {
         using policy_type = Kokkos::TeamPolicy<execution_space>;
-        int team_size     = thandle.get_team_size();
-
-        ILUKLvlSchedTP1NumericFunctor<
-            ARowMapType, AEntriesType, AValuesType, LRowMapType, LEntriesType,
-            LValuesType, URowMapType, UEntriesType, UValuesType,
-            HandleDeviceEntriesType, WorkViewType, nnz_lno_t>
-            tstf(A_row_map, A_entries, A_values, L_row_map, L_entries, L_values,
-                 U_row_map, U_entries, U_values, level_idx, iw, lev_start);
-        if (team_size == -1)
-          Kokkos::parallel_for("parfor_l_team",
-                               policy_type(lev_end - lev_start, Kokkos::AUTO),
-                               tstf);
-        else
-          Kokkos::parallel_for("parfor_l_team",
-                               policy_type(lev_end - lev_start, team_size),
-                               tstf);
+        int team_size = thandle.get_team_size();
+    
+        nnz_lno_t lvl_rowid_start = 0;
+        nnz_lno_t lvl_nrows_chunk;
+        for(int chunkid=0; chunkid<level_nchunks_h(lvl); chunkid++) {
+          if ((lvl_rowid_start + level_nrowsperchunk_h(lvl)) > 
+              (lev_end - lev_start))
+             lvl_nrows_chunk = (lev_end - lev_start)-lvl_rowid_start;
+          else         
+             lvl_nrows_chunk = level_nrowsperchunk_h(lvl);
+    
+          ILUKLvlSchedTP1NumericFunctor<
+              ARowMapType, AEntriesType, AValuesType,
+              LRowMapType, LEntriesType, LValuesType,
+              URowMapType, UEntriesType, UValuesType,
+              HandleDeviceEntriesType, WorkViewType, nnz_lno_t> 
+              tstf(A_row_map, A_entries, A_values,
+                   L_row_map, L_entries, L_values,
+                   U_row_map, U_entries, U_values,
+                   level_idx, iw, lev_start+lvl_rowid_start);
+    
+          if ( team_size == -1 )
+            Kokkos::parallel_for("parfor_l_team",
+                                 policy_type( lvl_nrows_chunk , Kokkos::AUTO ),
+                                 tstf);
+          else
+            Kokkos::parallel_for("parfor_l_team",
+                                 policy_type( lvl_nrows_chunk , team_size ),
+                                 tstf);
+    
+          lvl_rowid_start += lvl_nrows_chunk;
+        }
       }
       //      /*
       //      // TP2 algorithm has issues with some offset-ordinal combo to be

--- a/src/sparse/impl/KokkosSparse_spiluk_symbolic_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spiluk_symbolic_impl.hpp
@@ -63,12 +63,14 @@ namespace Experimental {
 template <class IlukHandle, class RowMapType, class EntriesType,
           class LevelType1, class LevelType2, class size_type>
 void level_sched(IlukHandle& thandle, const RowMapType row_map,
-                 const EntriesType entries, const size_type nrows,
-                 LevelType1& level_list, LevelType2& level_ptr,
-                 LevelType2& level_idx, size_type& nlevels) {
+                 const EntriesType entries, LevelType1& level_list,
+                 LevelType2& level_ptr, LevelType2& level_idx,
+                 size_type& nlevels) {
   // Scheduling currently compute on host
 
-  typedef typename IlukHandle::nnz_lno_t nnz_lno_t;
+  using  nnz_lno_t = typename IlukHandle::nnz_lno_t;
+
+  size_type nrows = thandle.get_nrows();
 
   nlevels      = 0;
   level_ptr(0) = 0;
@@ -115,6 +117,111 @@ void level_sched(IlukHandle& thandle, const RowMapType row_map,
 
   thandle.set_num_levels(nlevels);
   thandle.set_level_maxrows(maxrows);
+}
+
+//SEQLVLSCHD_TP1 algorithm (chunks)
+template <class IlukHandle,
+          class RowMapType, 
+          class EntriesType,
+          class LevelType1,
+          class LevelType2,
+          class LevelType3,
+          class size_type>
+void level_sched ( IlukHandle& thandle, const RowMapType row_map, 
+                   const EntriesType entries, LevelType1& level_list, 
+                   LevelType2& level_ptr, LevelType2& level_idx, 
+                   LevelType3& level_nchunks, LevelType3& level_nrowsperchunk,
+                   size_type &nlevels ) {
+  // Scheduling currently compute on host
+
+  using nnz_lno_t    = typename IlukHandle::nnz_lno_t;
+  using memory_space = typename IlukHandle::memory_space;
+
+  size_type nrows = thandle.get_nrows();
+
+  nlevels      = 0;
+  level_ptr(0) = 0;
+
+  for ( size_type i = 0; i < nrows; ++i ) {
+    size_type l = 0;
+    size_type rowstart= row_map(i);
+    size_type rowend  = row_map(i+1);
+    for ( size_type j = rowstart; j < rowend; ++j ) {
+      nnz_lno_t col = entries(j);
+      l = std::max(l, level_list(col));
+    }
+    level_list(i)   = l+1;
+    level_ptr(l+1) += 1;
+    nlevels         = std::max(nlevels, l+1);
+  }
+
+  for ( size_type i = 1; i <= nlevels; ++i ) {
+    level_ptr(i) += level_ptr(i-1);
+  }
+
+  for ( size_type i = 0; i < nrows; i++ ) {
+    level_idx(level_ptr(level_list(i)-1)) = i;
+    level_ptr(level_list(i)-1) += 1;
+  }
+
+  if (nlevels>0) {// note: to avoid wrapping around to the max of size_t 
+                  // when nlevels = 0.
+    for ( size_type i = nlevels-1; i > 0; --i ) {
+      level_ptr(i) = level_ptr(i-1);
+    }
+  }
+
+  level_ptr(0) = 0;
+
+  // Find max rows, number of chunks, max rows of chunks across levels
+  using HostViewType = Kokkos::View<nnz_lno_t*, Kokkos::LayoutLeft, 
+                                                Kokkos::HostSpace>;
+
+  HostViewType lnchunks( "lnchunks", nlevels );
+  HostViewType lnrowsperchunk( "lnrowsperchunk", nlevels );
+
+  size_t avail_byte = 0;
+#ifdef KOKKOS_ENABLE_CUDA
+  if ( std::is_same< memory_space, Kokkos::CudaSpace >::value )	{
+    size_t free_byte, total_byte;
+    KokkosKernels::Impl::kk_get_free_total_memory<memory_space>(free_byte, total_byte);
+    avail_byte = static_cast<size_t>(0.85*free_byte);
+  }
+#endif
+
+  size_type maxrows = 0;
+  size_type maxrowsperchunk = 0;
+  for ( size_type i = 0; i < nlevels; ++i ) {
+    size_type lnrows = level_ptr(i+1) - level_ptr(i);    
+    if( maxrows < lnrows ) {
+      maxrows = lnrows;
+    }
+#ifdef KOKKOS_ENABLE_CUDA
+    size_t required_size = static_cast<size_t>(lnrows)*nrows*sizeof(nnz_lno_t);
+    if ( std::is_same< memory_space, Kokkos::CudaSpace >::value ) 
+    {
+      lnchunks(i) = required_size/avail_byte+1;
+      lnrowsperchunk(i) = (lnrows%lnchunks(i)==0)?(lnrows/lnchunks(i)):
+                                                  (lnrows/lnchunks(i)+1);
+    }
+    else
+#endif
+    {
+      lnchunks(i) = 1;
+      lnrowsperchunk(i) = lnrows;
+    }
+    if( maxrowsperchunk < lnrowsperchunk(i) ) {
+      maxrowsperchunk = lnrowsperchunk(i);
+    }
+  }
+
+  thandle.set_num_levels(nlevels);
+  thandle.set_level_maxrows(maxrows);
+  thandle.set_level_maxrowsperchunk(maxrowsperchunk);
+
+  level_nchunks = lnchunks;
+  level_nrowsperchunk = lnrowsperchunk;
+
 }
 
 // Linear Search for the smallest row index
@@ -166,11 +273,11 @@ void iluk_symbolic(IlukHandle& thandle,
     // Scheduling and symbolic phase currently compute on host - need host copy
     // of all views
 
-    typedef typename IlukHandle::size_type size_type;
-    typedef typename IlukHandle::nnz_lno_t nnz_lno_t;
+    using size_type = typename IlukHandle::size_type;
+    using nnz_lno_t = typename IlukHandle::nnz_lno_t;
 
-    typedef typename IlukHandle::nnz_lno_view_t HandleDeviceEntriesType;
-    typedef typename IlukHandle::nnz_row_view_t HandleDeviceRowMapType;
+    using HandleDeviceEntriesType = typename IlukHandle::nnz_lno_view_t;
+    using HandleDeviceRowMapType  = typename IlukHandle::nnz_row_view_t;
 
     // typedef typename IlukHandle::signed_integral_t signed_integral_t;
 
@@ -217,13 +324,14 @@ void iluk_symbolic(IlukHandle& thandle,
     // Can only resize managed views Kokkos::resize(L_entries_d,
     // L_entries_d.extent(0)-3); thandle.set_nnzL(L_entries_d.extent(0)+5);
 
-    typedef Kokkos::View<nnz_lno_t*, Kokkos::LayoutLeft, Kokkos::HostSpace>
-        HostTmpViewType;
+    using HostTmpViewType = 
+          Kokkos::View<nnz_lno_t*, Kokkos::LayoutLeft, Kokkos::HostSpace>;
 
     HostTmpViewType h_lev("h_lev", thandle.get_nnzU());
     HostTmpViewType h_iw("h_iw", nrows);
     HostTmpViewType h_iL("h_iL", nrows);
     HostTmpViewType h_llev("h_llev", nrows);
+    HostTmpViewType level_nchunks, level_nrowsperchunk;
 
     size_type cntL = 0;
     size_type cntU = 0;
@@ -367,8 +475,32 @@ void iluk_symbolic(IlukHandle& thandle,
     }
 
     // Level scheduling on L
-    level_sched(thandle, L_row_map, L_entries, nrows, level_list, level_ptr,
-                level_idx, nlev);
+    if ( thandle.get_algorithm() ==
+             KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_TP1 ) {
+      level_sched (thandle, L_row_map, L_entries, level_list, level_ptr, 
+                   level_idx, level_nchunks, level_nrowsperchunk, nlev);
+
+      thandle.alloc_level_nchunks(nlev);
+      thandle.alloc_level_nrowsperchunk(nlev);
+      HandleDeviceEntriesType dlevel_nchunks = thandle.get_level_nchunks();
+      HandleDeviceEntriesType dlevel_nrowsperchunk = 
+                                        thandle.get_level_nrowsperchunk();
+      Kokkos::deep_copy(dlevel_nchunks, level_nchunks);
+      Kokkos::deep_copy(dlevel_nrowsperchunk, level_nrowsperchunk);
+    }
+    else {
+      level_sched (thandle, L_row_map, L_entries, level_list, level_ptr,
+                   level_idx, nlev);
+    }
+
+    Kokkos::deep_copy(dlevel_ptr, level_ptr);
+    Kokkos::deep_copy(dlevel_idx, level_idx);
+    Kokkos::deep_copy(dlevel_list, level_list);
+
+    Kokkos::deep_copy(L_row_map_d, L_row_map);
+    Kokkos::deep_copy(L_entries_d, L_entries);
+    Kokkos::deep_copy(U_row_map_d, U_row_map);
+    Kokkos::deep_copy(U_entries_d, U_entries);
 
     thandle.set_symbolic_complete();
 
@@ -378,9 +510,11 @@ void iluk_symbolic(IlukHandle& thandle,
     std::cout << "  symbolic complete: " << thandle.is_symbolic_complete()
               << std::endl;
     std::cout << "  num levels: " << thandle.get_num_levels() << std::endl;
-    std::cout << "  max num rows levels: " << thandle.get_level_maxrows()
+    std::cout << "  max num rows among levels: " << thandle.get_level_maxrows()
               << std::endl;
-
+    std::cout << "  max num rows among chunks among levels: "
+              << thandle.get_level_maxrowsperchunk() << std::endl;
+  
     std::cout << "  iluk_symbolic result: " << std::endl;
 
     std::cout << "  level_list = ";
@@ -427,15 +561,6 @@ void iluk_symbolic(IlukHandle& thandle,
     }
     std::cout << std::endl;
 #endif
-
-    Kokkos::deep_copy(dlevel_ptr, level_ptr);
-    Kokkos::deep_copy(dlevel_idx, level_idx);
-    Kokkos::deep_copy(dlevel_list, level_list);
-
-    Kokkos::deep_copy(L_row_map_d, L_row_map);
-    Kokkos::deep_copy(L_entries_d, L_entries);
-    Kokkos::deep_copy(U_row_map_d, U_row_map);
-    Kokkos::deep_copy(U_entries_d, U_entries);
   }
 }  // end iluk_symbolic
 

--- a/src/sparse/impl/KokkosSparse_spiluk_symbolic_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spiluk_symbolic_impl.hpp
@@ -129,7 +129,7 @@ void level_sched(IlukHandle& thandle, const RowMapType row_map,
                  size_type& nlevels) {
   // Scheduling currently compute on host
 
-  using nnz_lno_t    = typename IlukHandle::nnz_lno_t;
+  using nnz_lno_t = typename IlukHandle::nnz_lno_t;
 
   size_type nrows = thandle.get_nrows();
 
@@ -176,7 +176,7 @@ void level_sched(IlukHandle& thandle, const RowMapType row_map,
 
 #ifdef KOKKOS_ENABLE_CUDA
   using memory_space = typename IlukHandle::memory_space;
-  size_t avail_byte = 0;
+  size_t avail_byte  = 0;
   if (std::is_same<memory_space, Kokkos::CudaSpace>::value) {
     size_t free_byte, total_byte;
     KokkosKernels::Impl::kk_get_free_total_memory<memory_space>(free_byte,

--- a/src/sparse/impl/KokkosSparse_spiluk_symbolic_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spiluk_symbolic_impl.hpp
@@ -130,7 +130,6 @@ void level_sched(IlukHandle& thandle, const RowMapType row_map,
   // Scheduling currently compute on host
 
   using nnz_lno_t    = typename IlukHandle::nnz_lno_t;
-  using memory_space = typename IlukHandle::memory_space;
 
   size_type nrows = thandle.get_nrows();
 
@@ -175,8 +174,9 @@ void level_sched(IlukHandle& thandle, const RowMapType row_map,
   HostViewType lnchunks("lnchunks", nlevels);
   HostViewType lnrowsperchunk("lnrowsperchunk", nlevels);
 
-  size_t avail_byte = 0;
 #ifdef KOKKOS_ENABLE_CUDA
+  using memory_space = typename IlukHandle::memory_space;
+  size_t avail_byte = 0;
   if (std::is_same<memory_space, Kokkos::CudaSpace>::value) {
     size_t free_byte, total_byte;
     KokkosKernels::Impl::kk_get_free_total_memory<memory_space>(free_byte,
@@ -206,7 +206,7 @@ void level_sched(IlukHandle& thandle, const RowMapType row_map,
       lnchunks(i)       = 1;
       lnrowsperchunk(i) = lnrows;
     }
-    if (maxrowsperchunk < lnrowsperchunk(i)) {
+    if (maxrowsperchunk < static_cast<size_type>(lnrowsperchunk(i))) {
       maxrowsperchunk = lnrowsperchunk(i);
     }
   }


### PR DESCRIPTION
This PR makes two changes in the numeric phase of SPILUK:
1. Use ```Kokkos::atomic_add``` to avoid race conditions when updating L and U values --> This helps resolve the issue of inconsistent convergence in Belos solver (tested with Aria matrices)
2. Allow computing rows in chunks at each level when dealing with large dense array used for tracking indices of CRS big matrices. Note: another implementation using shared memory hash map will be added in another PR.