### PR TITLE
Update Batched GMRES

### DIFF
--- a/example/batched_solve/CMakeLists.txt
+++ b/example/batched_solve/CMakeLists.txt
@@ -5,3 +5,8 @@ KOKKOSKERNELS_ADD_EXECUTABLE(
   static_pivoting
   SOURCES static_pivoting.cpp
   )
+
+KOKKOSKERNELS_ADD_EXECUTABLE(
+  team_GMRES
+  SOURCES team_GMRES.cpp
+  )

--- a/example/batched_solve/team_GMRES.cpp
+++ b/example/batched_solve/team_GMRES.cpp
@@ -232,11 +232,6 @@ struct Functor_TestBatchedTeamVectorGMRES {
     size_t bytes_col_idc = IntView::shmem_size(_c.extent(0));
     size_t bytes_2D_1    = ViewType2D::shmem_size(_N_team, _X.extent(1));
     size_t bytes_2D_2 = ViewType2D::shmem_size(_N_team, maximum_iteration + 1);
-    size_t bytes_3D_1 =
-        ViewType3D::shmem_size(_N_team, _X.extent(1), maximum_iteration);
-    size_t bytes_3D_2 = ViewType3D::shmem_size(_N_team, maximum_iteration + 1,
-                                               maximum_iteration);
-    size_t bytes_3D_3 = ViewType3D::shmem_size(_N_team, 2, maximum_iteration);
 
     size_t bytes_int  = bytes_row_ptr + bytes_col_idc;
     size_t bytes_diag = bytes_2D_1;
@@ -267,7 +262,7 @@ int main(int /*argc*/, char ** /*argv*/) {
     std::string name_A = "mat.mm";
     std::string name_B = "rhs.mm";
 
-    int N, Blk, nnz, ncols;
+    int N, Blk, nnz;
 
     Blk = 10;
     N   = 100;

--- a/example/batched_solve/team_GMRES.cpp
+++ b/example/batched_solve/team_GMRES.cpp
@@ -1,0 +1,358 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.4
+//       Copyright (2021) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+
+#include <fstream>
+
+#define KOKKOSKERNELS_DEBUG_LEVEL 0
+
+#include "Kokkos_Core.hpp"
+#include "Kokkos_Timer.hpp"
+#include "Kokkos_Random.hpp"
+#include "Kokkos_UnorderedMap.hpp"
+#include "Kokkos_Sort.hpp"
+
+/// KokkosKernels headers
+#include "KokkosBatched_Util.hpp"
+#include "KokkosBatched_Vector.hpp"
+#include "KokkosKernels_IOUtils.hpp"
+
+#include <Kokkos_ArithTraits.hpp>
+#include <KokkosBatched_Util.hpp>
+#include "examples_helper.hpp"
+#include <KokkosBatched_Spmv.hpp>
+#include <KokkosBatched_GMRES.hpp>
+#include <KokkosBatched_CrsMatrix.hpp>
+#include <KokkosBatched_Krylov_Handle.hpp>
+#include <KokkosBatched_JacobiPrec.hpp>
+
+typedef Kokkos::DefaultExecutionSpace exec_space;
+
+template <typename DeviceType, typename ValuesViewType, typename IntView,
+          typename VectorViewType, typename KrylovHandleType, bool UsePrec>
+struct Functor_TestBatchedTeamVectorGMRES {
+  const ValuesViewType _D;
+  const ValuesViewType _diag;
+  const IntView _r;
+  const IntView _c;
+  const VectorViewType _X;
+  const VectorViewType _B;
+  const int _N_team, _team_size, _vector_length;
+  const int _N_iteration;
+  const double _tol;
+  const int _ortho_strategy;
+  const int _scratch_pad_level;
+  KrylovHandleType _handle;
+
+  KOKKOS_INLINE_FUNCTION
+  Functor_TestBatchedTeamVectorGMRES(
+      const ValuesViewType &D, const IntView &r, const IntView &c,
+      const VectorViewType &X, const VectorViewType &B, const int N_team,
+      const int team_size, const int vector_length, const int N_iteration,
+      const double tol, const int ortho_strategy, const int scratch_pad_level,
+      KrylovHandleType &handle)
+      : _D(D),
+        _r(r),
+        _c(c),
+        _X(X),
+        _B(B),
+        _N_team(N_team),
+        _team_size(team_size),
+        _vector_length(vector_length),
+        _N_iteration(N_iteration),
+        _tol(tol),
+        _ortho_strategy(ortho_strategy),
+        _scratch_pad_level(scratch_pad_level),
+        _handle(handle) {}
+
+  KOKKOS_INLINE_FUNCTION
+  Functor_TestBatchedTeamVectorGMRES(
+      const ValuesViewType &D, const ValuesViewType &diag, const IntView &r,
+      const IntView &c, const VectorViewType &X, const VectorViewType &B,
+      const int N_team, const int team_size, const int vector_length,
+      const int N_iteration, const double tol, int ortho_strategy,
+      const int scratch_pad_level, KrylovHandleType &handle)
+      : _D(D),
+        _diag(diag),
+        _r(r),
+        _c(c),
+        _X(X),
+        _B(B),
+        _N_team(N_team),
+        _team_size(team_size),
+        _vector_length(vector_length),
+        _N_iteration(N_iteration),
+        _tol(tol),
+        _ortho_strategy(ortho_strategy),
+        _scratch_pad_level(scratch_pad_level),
+        _handle(handle) {}
+
+  template <typename MemberType>
+  KOKKOS_INLINE_FUNCTION void operator()(const MemberType &member) const {
+    const int first_matrix = static_cast<int>(member.league_rank()) * _N_team;
+    const int N            = _D.extent(0);
+    const int last_matrix =
+        (static_cast<int>(member.league_rank() + 1) * _N_team < N
+             ? static_cast<int>(member.league_rank() + 1) * _N_team
+             : N);
+    using TeamVectorCopy1D =
+        KokkosBatched::TeamVectorCopy<MemberType,
+                                      KokkosBatched::Trans::NoTranspose, 1>;
+
+    auto d = Kokkos::subview(_D, Kokkos::make_pair(first_matrix, last_matrix),
+                             Kokkos::ALL);
+    auto x = Kokkos::subview(_X, Kokkos::make_pair(first_matrix, last_matrix),
+                             Kokkos::ALL);
+    auto b = Kokkos::subview(_B, Kokkos::make_pair(first_matrix, last_matrix),
+                             Kokkos::ALL);
+
+    using ScratchPadIntViewType =
+        Kokkos::View<typename IntView::non_const_value_type *,
+                     typename IntView::array_layout,
+                     typename IntView::execution_space::scratch_memory_space>;
+    using ScratchPadValuesViewType = Kokkos::View<
+        typename ValuesViewType::non_const_value_type **,
+        typename ValuesViewType::array_layout,
+        typename ValuesViewType::execution_space::scratch_memory_space>;
+
+    using Operator =
+        KokkosBatched::CrsMatrix<ValuesViewType, ScratchPadIntViewType>;
+
+    ScratchPadIntViewType tmp_1D_int(member.team_scratch(0),
+                                     _r.extent(0) + _c.extent(0));
+
+    auto r =
+        Kokkos::subview(tmp_1D_int, Kokkos::make_pair(0, (int)_r.extent(0)));
+    auto c = Kokkos::subview(
+        tmp_1D_int,
+        Kokkos::make_pair((int)_r.extent(0), (int)tmp_1D_int.extent(0)));
+
+    TeamVectorCopy1D::invoke(member, _r, r);
+    TeamVectorCopy1D::invoke(member, _c, c);
+    Operator A(d, r, c);
+
+    if (UsePrec) {
+      ScratchPadValuesViewType diag(
+          member.team_scratch(0), last_matrix - first_matrix, _diag.extent(1));
+      using PrecOperator = KokkosBatched::JacobiPrec<ScratchPadValuesViewType>;
+
+      KokkosBatched::TeamVectorCopy<MemberType>::invoke(
+          member,
+          Kokkos::subview(_diag, Kokkos::make_pair(first_matrix, last_matrix),
+                          Kokkos::ALL),
+          diag);
+      PrecOperator P(diag);
+      P.setComputedInverse();
+
+      KokkosBatched::TeamVectorGMRES<MemberType>::template invoke<
+          Operator, VectorViewType, PrecOperator, KrylovHandleType>(
+          member, A, b, x, P, _handle);
+    } else {
+      KokkosBatched::TeamVectorGMRES<MemberType>::template invoke<
+          Operator, VectorViewType>(member, A, b, x, _handle);
+    }
+  }
+
+  inline double run() {
+    typedef typename ValuesViewType::value_type value_type;
+    std::string name("KokkosBatched::Test::TeamVectorGMRES");
+    Kokkos::Timer timer;
+    Kokkos::Profiling::pushRegion(name.c_str());
+
+    Kokkos::TeamPolicy<DeviceType> auto_policy(
+        ceil(1. * _D.extent(0) / _N_team), Kokkos::AUTO(), Kokkos::AUTO());
+    Kokkos::TeamPolicy<DeviceType> tuned_policy(
+        ceil(1. * _D.extent(0) / _N_team), _team_size, _vector_length);
+    Kokkos::TeamPolicy<DeviceType> policy;
+
+    if (_team_size < 1)
+      policy = auto_policy;
+    else
+      policy = tuned_policy;
+
+    _handle.set_max_iteration(_N_iteration);
+    _handle.set_tolerance(_tol);
+    _handle.set_ortho_strategy(_ortho_strategy);
+    _handle.set_scratch_pad_level(_scratch_pad_level);
+    _handle.set_compute_last_residual(true);
+
+    int maximum_iteration = _handle.get_max_iteration();
+
+    using ScalarType = typename ValuesViewType::non_const_value_type;
+    using Layout     = typename ValuesViewType::array_layout;
+    using EXSP       = typename ValuesViewType::execution_space;
+
+    using MagnitudeType =
+        typename Kokkos::Details::ArithTraits<ScalarType>::mag_type;
+
+    using ViewType1D = Kokkos::View<MagnitudeType *, Layout, EXSP>;
+    using ViewType2D = Kokkos::View<ScalarType **, Layout, EXSP>;
+    using ViewType3D = Kokkos::View<ScalarType ***, Layout, EXSP>;
+
+    size_t bytes_1D      = ViewType2D::shmem_size(_N_team, 1);
+    size_t bytes_row_ptr = IntView::shmem_size(_r.extent(0));
+    size_t bytes_col_idc = IntView::shmem_size(_c.extent(0));
+    size_t bytes_2D_1    = ViewType2D::shmem_size(_N_team, _X.extent(1));
+    size_t bytes_2D_2 = ViewType2D::shmem_size(_N_team, maximum_iteration + 1);
+    size_t bytes_3D_1 =
+        ViewType3D::shmem_size(_N_team, _X.extent(1), maximum_iteration);
+    size_t bytes_3D_2 = ViewType3D::shmem_size(_N_team, maximum_iteration + 1,
+                                               maximum_iteration);
+    size_t bytes_3D_3 = ViewType3D::shmem_size(_N_team, 2, maximum_iteration);
+
+    size_t bytes_int  = bytes_row_ptr + bytes_col_idc;
+    size_t bytes_diag = bytes_2D_1;
+    size_t bytes_tmp  = 2 * bytes_2D_1 + 2 * bytes_1D + bytes_2D_2;
+
+    policy.set_scratch_size(
+        0, Kokkos::PerTeam(bytes_tmp + bytes_diag + bytes_int));
+
+    exec_space().fence();
+    timer.reset();
+    Kokkos::parallel_for(name.c_str(), policy, *this);
+    exec_space().fence();
+    double sec = timer.seconds();
+
+    return sec;
+  }
+};
+
+int main(int /*argc*/, char ** /*argv*/) {
+  Kokkos::initialize();
+  {
+    using layout = Kokkos::LayoutLeft;
+
+    using IntView          = Kokkos::View<int *, layout, exec_space>;
+    using AMatrixValueView = Kokkos::View<double **, layout, exec_space>;
+    using XYType           = Kokkos::View<double **, layout, exec_space>;
+
+    std::string name_A = "mat.mm";
+    std::string name_B = "rhs.mm";
+
+    int N, Blk, nnz, ncols;
+
+    Blk = 10;
+    N   = 100;
+    nnz = (Blk - 2) * 3 + 2 * 2;
+
+    IntView rowOffsets("rowOffsets", Blk + 1);
+    IntView colIndices("colIndices", nnz);
+    AMatrixValueView values("values", N, nnz);
+    AMatrixValueView diag("diag", N, Blk);
+    XYType x("x", N, Blk);
+    XYType y("y", N, Blk);
+
+    printf("N = %d, Blk = %d, nnz = %d\n", N, Blk, nnz);
+
+    create_tridiagonal_batched_matrices(nnz, Blk, N, rowOffsets, colIndices,
+                                        values, x, y);
+
+    // Replace y by ones:
+    Kokkos::deep_copy(y, 1.);
+
+    // Replace x by zeros:
+    // Kokkos::deep_copy(x, 0.);
+
+    getInvDiagFromCRS(values, rowOffsets, colIndices, diag);
+
+    using ScalarType = typename AMatrixValueView::non_const_value_type;
+    using Layout     = typename AMatrixValueView::array_layout;
+    using EXSP       = typename AMatrixValueView::execution_space;
+
+    using MagnitudeType =
+        typename Kokkos::Details::ArithTraits<ScalarType>::mag_type;
+    using NormViewType = Kokkos::View<MagnitudeType *, Layout, EXSP>;
+
+    using Norm2DViewType   = Kokkos::View<MagnitudeType **, Layout, EXSP>;
+    using Scalar3DViewType = Kokkos::View<ScalarType ***, Layout, EXSP>;
+    using IntViewType      = Kokkos::View<int *, Layout, EXSP>;
+
+    using KrylovHandleType =
+        KokkosBatched::KrylovHandle<Norm2DViewType, IntViewType,
+                                    Scalar3DViewType>;
+
+    const int N_team       = 2;
+    const int n_iterations = 150;
+
+    const int team_size      = -1;
+    const int vector_length  = -1;
+    const double tol         = 1e-8;
+    const int ortho_strategy = 0;
+
+    KrylovHandleType handle(N, N_team, n_iterations, true);
+    handle.Arnoldi_view =
+        Scalar3DViewType("", N, n_iterations, Blk + n_iterations + 3);
+
+    double time =
+        Functor_TestBatchedTeamVectorGMRES<exec_space, AMatrixValueView,
+                                           IntView, XYType, KrylovHandleType,
+                                           true>(
+            values, diag, rowOffsets, colIndices, x, y, N_team, team_size,
+            vector_length, n_iterations, tol, ortho_strategy, 0, handle)
+            .run();
+
+    printf("times = %f secondes\n", time);
+
+    for (int i = 0; i < N; ++i) {
+      if (handle.is_converged_host(i)) {
+        std::cout
+            << "System " << i << " converged in "
+            << handle.get_iteration_host(i)
+            << " iterations, the initial absolute norm of the residual was "
+            << handle.get_norm_host(i, 0) << " and is now "
+            << handle.get_last_norm_host(i) << std::endl;
+      } else {
+        std::cout
+            << "System " << i << " did not converge in "
+            << handle.get_max_iteration()
+            << " iterations, the initial absolute norm of the residual was "
+            << handle.get_norm_host(i, 0) << " and is now "
+            << handle.get_last_norm_host(i) << std::endl;
+      }
+    }
+    if (handle.is_converged_host())
+      std::cout << "All the systems have converged." << std::endl;
+    else
+      std::cout << "There is at least one system that did not converge."
+                << std::endl;
+  }
+  Kokkos::finalize();
+}

--- a/example/batched_solve/team_GMRES.cpp
+++ b/example/batched_solve/team_GMRES.cpp
@@ -192,7 +192,6 @@ struct Functor_TestBatchedTeamVectorGMRES {
   }
 
   inline double run() {
-    typedef typename ValuesViewType::value_type value_type;
     std::string name("KokkosBatched::Test::TeamVectorGMRES");
     Kokkos::Timer timer;
     Kokkos::Profiling::pushRegion(name.c_str());
@@ -220,12 +219,7 @@ struct Functor_TestBatchedTeamVectorGMRES {
     using Layout     = typename ValuesViewType::array_layout;
     using EXSP       = typename ValuesViewType::execution_space;
 
-    using MagnitudeType =
-        typename Kokkos::Details::ArithTraits<ScalarType>::mag_type;
-
-    using ViewType1D = Kokkos::View<MagnitudeType *, Layout, EXSP>;
     using ViewType2D = Kokkos::View<ScalarType **, Layout, EXSP>;
-    using ViewType3D = Kokkos::View<ScalarType ***, Layout, EXSP>;
 
     size_t bytes_1D      = ViewType2D::shmem_size(_N_team, 1);
     size_t bytes_row_ptr = IntView::shmem_size(_r.extent(0));
@@ -294,7 +288,6 @@ int main(int /*argc*/, char ** /*argv*/) {
 
     using MagnitudeType =
         typename Kokkos::Details::ArithTraits<ScalarType>::mag_type;
-    using NormViewType = Kokkos::View<MagnitudeType *, Layout, EXSP>;
 
     using Norm2DViewType   = Kokkos::View<MagnitudeType **, Layout, EXSP>;
     using Scalar3DViewType = Kokkos::View<ScalarType ***, Layout, EXSP>;

--- a/src/batched/KokkosBatched_Util.hpp
+++ b/src/batched/KokkosBatched_Util.hpp
@@ -718,6 +718,17 @@ KOKKOS_INLINE_FUNCTION
   iMatrix = iTemp / numRows;
 }
 
+template <typename OrdinalType, typename layout>
+KOKKOS_INLINE_FUNCTION
+    typename std::enable_if<std::is_same<layout, Kokkos::LayoutStride>::value,
+                            void>::type
+    getIndices(const OrdinalType iTemp, const OrdinalType /*numRows*/,
+               const OrdinalType numMatrices, OrdinalType &iRow,
+               OrdinalType &iMatrix) {
+  iRow    = iTemp / numMatrices;
+  iMatrix = iTemp % numMatrices;
+}
+
 template <class ViewType>
 KOKKOS_INLINE_FUNCTION auto transpose_2d_view(ViewType v, const int *order) {
   constexpr int rank         = 2;

--- a/src/batched/dense/KokkosBatched_Copy_Decl.hpp
+++ b/src/batched/dense/KokkosBatched_Copy_Decl.hpp
@@ -11,7 +11,7 @@ namespace KokkosBatched {
 /// Serial Copy
 ///
 
-template <typename ArgTrans, int rank = 2>
+template <typename ArgTrans = Trans::NoTranspose, int rank = 2>
 struct SerialCopy {
   template <typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A,

--- a/src/batched/dense/impl/KokkosBatched_Gemv_TeamVector_Impl.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Gemv_TeamVector_Impl.hpp
@@ -30,9 +30,17 @@ struct TeamVectorGemv<MemberType, Trans::NoTranspose, Algo::Gemv::Unblocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType &member, const ScalarType alpha, const AViewType &A,
       const xViewType &x, const ScalarType beta, const yViewType &y) {
-    return TeamVectorGemvInternal<Algo::Gemv::Unblocked>::invoke(
-        member, A.extent(0), A.extent(1), alpha, A.data(), A.stride_0(),
-        A.stride_1(), x.data(), x.stride_0(), beta, y.data(), y.stride_0());
+    if (AViewType::Rank == 2)
+      return TeamVectorGemvInternal<Algo::Gemv::Unblocked>::invoke(
+          member, A.extent(0), A.extent(1), alpha, A.data(), A.stride_0(),
+          A.stride_1(), x.data(), x.stride_0(), beta, y.data(), y.stride_0());
+    else
+      return TeamVectorGemvInternal<Algo::Gemv::Unblocked>::template invoke<
+          MemberType, ScalarType, typename AViewType::array_layout,
+          typename AViewType::non_const_value_type>(
+          member, A.extent(0), A.extent(1), A.extent(2), alpha, A.data(),
+          A.stride_0(), A.stride_1(), A.stride_2(), x.data(), x.stride_0(),
+          x.stride_1(), beta, y.data(), y.stride_0(), y.stride_1());
   }
 };
 
@@ -60,9 +68,17 @@ struct TeamVectorGemv<MemberType, Trans::Transpose, Algo::Gemv::Unblocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType &member, const ScalarType alpha, const AViewType &A,
       const xViewType &x, const ScalarType beta, const yViewType &y) {
-    return TeamVectorGemvInternal<Algo::Gemv::Unblocked>::invoke(
-        member, A.extent(1), A.extent(0), alpha, A.data(), A.stride_1(),
-        A.stride_0(), x.data(), x.stride_0(), beta, y.data(), y.stride_0());
+    if (AViewType::Rank == 2)
+      return TeamVectorGemvInternal<Algo::Gemv::Unblocked>::invoke(
+          member, A.extent(1), A.extent(0), alpha, A.data(), A.stride_1(),
+          A.stride_0(), x.data(), x.stride_0(), beta, y.data(), y.stride_0());
+    else
+      return TeamVectorGemvInternal<Algo::Gemv::Unblocked>::template invoke<
+          MemberType, ScalarType, typename AViewType::array_layout,
+          typename AViewType::non_const_value_type>(
+          member, A.extent(0), A.extent(2), A.extent(1), alpha, A.data(),
+          A.stride_0(), A.stride_2(), A.stride_1(), x.data(), x.stride_0(),
+          x.stride_1(), beta, y.data(), y.stride_0(), y.stride_1());
   }
 };
 

--- a/src/batched/dense/impl/KokkosBatched_Gemv_TeamVector_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Gemv_TeamVector_Internal.hpp
@@ -28,6 +28,20 @@ struct TeamVectorGemvInternal {
     assert(false && "Error: encounter dummy impl");
     return 0;
   }
+  template <typename MemberType, typename ScalarType, typename layout,
+            typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(
+      const MemberType & /*member*/, const int /*N*/, const int /*m*/,
+      const int /*n*/, const ScalarType /*alpha*/,
+      const ValueType *KOKKOS_RESTRICT /*A*/, const int /*as0*/,
+      const int /*as1*/, const int /*as2*/,
+      const ValueType *KOKKOS_RESTRICT /*x*/, const int /*xs0*/,
+      const int /*xs1*/, const ScalarType /*beta*/,
+      /**/ ValueType *KOKKOS_RESTRICT /*y*/, const int /*ys0*/,
+      const int /*ys1*/) {
+    assert(false && "Error: encounter dummy impl");
+    return 0;
+  }
 };
 
 template <>
@@ -65,6 +79,55 @@ TeamVectorGemvInternal<Algo::Gemv::Unblocked>::invoke(
       Kokkos::single(Kokkos::PerThread(member),
                      [&]() { y[i * ys0] += alpha * t; });
     });
+  }
+  return 0;
+}
+
+template <>
+template <typename MemberType, typename ScalarType, typename layout,
+          typename ValueType>
+KOKKOS_INLINE_FUNCTION int
+TeamVectorGemvInternal<Algo::Gemv::Unblocked>::invoke(
+    const MemberType &member, const int N, const int m, const int n,
+    const ScalarType alpha, const ValueType *KOKKOS_RESTRICT A, const int as0,
+    const int as1, const int as2, const ValueType *KOKKOS_RESTRICT X,
+    const int xs0, const int xs1, const ScalarType beta,
+    /**/ ValueType *KOKKOS_RESTRICT Y, const int ys0, const int ys1) {
+  const ScalarType one(1.0), zero(0.0);
+
+  // y_l = beta y_l + alpha A_l x_l for l in range(0, N)
+  // y_l (m), A_l(m x n), B_l(n)
+
+  if (beta == zero)
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, N * m),
+                         [&](const int &iTemp) {
+                           int iRow, iMatrix;
+                           getIndices<int, layout>(iTemp, m, N, iRow, iMatrix);
+                           Y[ys0 * iMatrix + ys1 * iRow] = zero;
+                         });
+  else if (beta != one)
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, N * m),
+                         [&](const int &iTemp) {
+                           int iRow, iMatrix;
+                           getIndices<int, layout>(iTemp, m, N, iRow, iMatrix);
+                           Y[ys0 * iMatrix + ys1 * iRow] *= beta;
+                         });
+
+  if (alpha != zero) {
+    if (m <= 0 || n <= 0) return 0;
+
+    if (beta != one) member.team_barrier();
+
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, N * m),
+                         [&](const int &iTemp) {
+                           int iRow, iMatrix;
+                           ValueType t(0);
+                           getIndices<int, layout>(iTemp, m, N, iRow, iMatrix);
+                           for (int i = 0; i < n; ++i)
+                             t += A[as0 * iMatrix + as1 * iRow + as2 * i] *
+                                  X[xs0 * iMatrix + xs1 * i];
+                           Y[ys0 * iMatrix + ys1 * iRow] += alpha * t;
+                         });
   }
   return 0;
 }

--- a/src/batched/dense/impl/KokkosBatched_Gemv_Team_Impl.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Gemv_Team_Impl.hpp
@@ -30,9 +30,17 @@ struct TeamGemv<MemberType, Trans::NoTranspose, Algo::Gemv::Unblocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType &member, const ScalarType alpha, const AViewType &A,
       const xViewType &x, const ScalarType beta, const yViewType &y) {
-    return TeamGemvInternal<Algo::Gemv::Unblocked>::invoke(
-        member, A.extent(0), A.extent(1), alpha, A.data(), A.stride_0(),
-        A.stride_1(), x.data(), x.stride_0(), beta, y.data(), y.stride_0());
+    if (AViewType::Rank == 2)
+      return TeamGemvInternal<Algo::Gemv::Unblocked>::invoke(
+          member, A.extent(0), A.extent(1), alpha, A.data(), A.stride_0(),
+          A.stride_1(), x.data(), x.stride_0(), beta, y.data(), y.stride_0());
+    else
+      return TeamGemvInternal<Algo::Gemv::Unblocked>::template invoke<
+          MemberType, ScalarType, typename AViewType::array_layout,
+          typename AViewType::non_const_value_type>(
+          member, A.extent(0), A.extent(1), A.extent(2), alpha, A.data(),
+          A.stride_0(), A.stride_1(), A.stride_2(), x.data(), x.stride_0(),
+          x.stride_1(), beta, y.data(), y.stride_0(), y.stride_1());
   }
 };
 
@@ -60,9 +68,17 @@ struct TeamGemv<MemberType, Trans::Transpose, Algo::Gemv::Unblocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType &member, const ScalarType alpha, const AViewType &A,
       const xViewType &x, const ScalarType beta, const yViewType &y) {
-    return TeamGemvInternal<Algo::Gemv::Unblocked>::invoke(
-        member, A.extent(1), A.extent(0), alpha, A.data(), A.stride_1(),
-        A.stride_0(), x.data(), x.stride_0(), beta, y.data(), y.stride_0());
+    if (AViewType::Rank == 2)
+      return TeamGemvInternal<Algo::Gemv::Unblocked>::invoke(
+          member, A.extent(1), A.extent(0), alpha, A.data(), A.stride_1(),
+          A.stride_0(), x.data(), x.stride_0(), beta, y.data(), y.stride_0());
+    else
+      return TeamGemvInternal<Algo::Gemv::Unblocked>::template invoke<
+          MemberType, ScalarType, typename AViewType::array_layout,
+          typename AViewType::non_const_value_type>(
+          member, A.extent(0), A.extent(2), A.extent(1), alpha, A.data(),
+          A.stride_0(), A.stride_2(), A.stride_1(), x.data(), x.stride_0(),
+          x.stride_1(), beta, y.data(), y.stride_0(), y.stride_1());
   }
 };
 

--- a/src/batched/dense/impl/KokkosBatched_Gemv_Team_Internal.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Gemv_Team_Internal.hpp
@@ -24,6 +24,7 @@ struct TeamGemvInternal {
       const int as1, const ValueType *KOKKOS_RESTRICT x, const int xs0,
       const ScalarType beta,
       /**/ ValueType *KOKKOS_RESTRICT y, const int ys0);
+
   template <typename MemberType, typename ScalarType, typename layout,
             typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(

--- a/src/batched/sparse/KokkosBatched_CG.hpp
+++ b/src/batched/sparse/KokkosBatched_CG.hpp
@@ -68,12 +68,13 @@ namespace KokkosBatched {
 
 template <typename MemberType, typename ArgMode>
 struct CG {
-  template <typename OperatorType, typename VectorViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(
-      const MemberType &member, const OperatorType &A, const VectorViewType &B,
-      const VectorViewType &X,
-      const KrylovHandle<typename VectorViewType::non_const_value_type>
-          &handle) {
+  template <typename OperatorType, typename VectorViewType,
+            typename KrylovHandleType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
+                                           const OperatorType &A,
+                                           const VectorViewType &B,
+                                           const VectorViewType &X,
+                                           const KrylovHandleType &handle) {
     int status = 0;
     if (std::is_same<ArgMode, Mode::Team>::value) {
       status =

--- a/src/batched/sparse/KokkosBatched_CrsMatrix.hpp
+++ b/src/batched/sparse/KokkosBatched_CrsMatrix.hpp
@@ -111,7 +111,7 @@ class CrsMatrix {
       MagnitudeType alpha = Kokkos::Details::ArithTraits<MagnitudeType>::one(),
       MagnitudeType beta =
           Kokkos::Details::ArithTraits<MagnitudeType>::zero()) const {
-    if (beta == 0)
+    if (beta == Kokkos::Details::ArithTraits<MagnitudeType>::zero())
       KokkosBatched::TeamVectorSpmv<MemberType, ArgTrans>::template invoke<
           ValuesViewType, IntViewType, XViewType, YViewType, 0>(
           member, alpha, values, row_ptr, colIndices, X, beta, Y);
@@ -127,7 +127,7 @@ class CrsMatrix {
       MagnitudeType alpha = Kokkos::Details::ArithTraits<MagnitudeType>::one(),
       MagnitudeType beta =
           Kokkos::Details::ArithTraits<MagnitudeType>::zero()) const {
-    if (beta == 0)
+    if (beta == Kokkos::Details::ArithTraits<MagnitudeType>::zero())
       KokkosBatched::SerialSpmv<ArgTrans>::template invoke<
           ValuesViewType, IntViewType, XViewType, YViewType, 0>(
           alpha, values, row_ptr, colIndices, X, beta, Y);

--- a/src/batched/sparse/KokkosBatched_CrsMatrix.hpp
+++ b/src/batched/sparse/KokkosBatched_CrsMatrix.hpp
@@ -104,89 +104,37 @@ class CrsMatrix {
   /// \param beta [in]: input coefficient for Y (default value 0.)
   /// \param Y [in/out]: Output vector Y, a rank 2 view
 
-  template <typename MemberType, typename XViewType, typename YViewType,
-            typename ArgTrans, typename ArgMode>
+  template <typename ArgTrans, typename ArgMode, typename MemberType,
+            typename XViewType, typename YViewType>
   KOKKOS_INLINE_FUNCTION void apply(
       const MemberType &member, const XViewType &X, const YViewType &Y,
       MagnitudeType alpha = Kokkos::Details::ArithTraits<MagnitudeType>::one(),
       MagnitudeType beta =
           Kokkos::Details::ArithTraits<MagnitudeType>::zero()) const {
     if (beta == 0)
-      KokkosBatched::Spmv<MemberType, ArgTrans, ArgMode>::template invoke<
+      KokkosBatched::TeamVectorSpmv<MemberType, ArgTrans>::template invoke<
           ValuesViewType, IntViewType, XViewType, YViewType, 0>(
           member, alpha, values, row_ptr, colIndices, X, beta, Y);
     else
-      KokkosBatched::Spmv<MemberType, ArgTrans, ArgMode>::template invoke<
+      KokkosBatched::TeamVectorSpmv<MemberType, ArgTrans>::template invoke<
           ValuesViewType, IntViewType, XViewType, YViewType, 1>(
           member, alpha, values, row_ptr, colIndices, X, beta, Y);
   }
 
-  /// \brief apply version that uses variable coefficient alpha and no beta
-  ///   y_l <- alpha_l * A_l * x_l  for all l = 1, ..., N
-  /// where:
-  ///   * N is the number of matrices,
-  ///   * A_1, ..., A_N are N sparse matrices which share the same sparsity
-  ///   pattern,
-  ///   * x_1, ..., x_N are the N input vectors,
-  ///   * y_1, ..., y_N are the N output vectors,
-  ///   * alpha_1, ..., alpha_N are N scaling factors for x_1, ..., x_N.
-  ///
-  /// \tparam MemberType: Input type for the TeamPolicy member
-  /// \tparam XViewType: Input type for X, needs to be a 2D view
-  /// \tparam YViewType: Input type for Y, needs to be a 2D view
-  /// \tparam ArgTrans: Argument for transpose or notranspose
-  /// \tparam ArgMode: Argument for the parallelism used in the apply
-  ///
-  /// \param member [in]: TeamPolicy member
-  /// \param alpha [in]: input coefficient for X, a rank 1 view
-  /// \param X [in]: Input vector X, a rank 2 view
-  /// \param Y [out]: Output vector Y, a rank 2 view
-
-  template <typename MemberType, typename XViewType, typename YViewType,
-            typename NormViewType, typename ArgTrans, typename ArgMode>
-  KOKKOS_INLINE_FUNCTION void apply(const MemberType &member,
-                                    const XViewType &X, const YViewType &Y,
-                                    NormViewType alpha) const {
-    KokkosBatched::Spmv<MemberType, ArgTrans, ArgMode>::template invoke<
-        ValuesViewType, IntViewType, XViewType, YViewType, NormViewType,
-        NormViewType, 0>(member, alpha, values, row_ptr, colIndices, X, alpha,
-                         Y);
-  }
-
-  /// \brief apply version that uses variable coefficients alpha and beta
-  ///   y_l <- alpha_l * A_l * x_l + beta_l * y_l for all l = 1, ..., N
-  /// where:
-  ///   * N is the number of matrices,
-  ///   * A_1, ..., A_N are N sparse matrices which share the same sparsity
-  ///   pattern,
-  ///   * x_1, ..., x_N are the N input vectors,
-  ///   * y_1, ..., y_N are the N output vectors,
-  ///   * alpha_1, ..., alpha_N are N scaling factors for x_1, ..., x_N,
-  ///   * beta_1, ..., beta_N are N scaling factors for y_1, ..., y_N.
-  ///
-  /// \tparam MemberType: Input type for the TeamPolicy member
-  /// \tparam XViewType: Input type for X, needs to be a 2D view
-  /// \tparam YViewType: Input type for Y, needs to be a 2D view
-  /// \tparam NormViewType: Input type for alpha and beta, needs to be a 1D view
-  /// \tparam ArgTrans: Argument for transpose or notranspose
-  /// \tparam ArgMode: Argument for the parallelism used in the apply
-  ///
-  /// \param member [in]: TeamPolicy member
-  /// \param alpha [in]: input coefficient for X, a rank 1 view
-  /// \param X [in]: Input vector X, a rank 2 view
-  /// \param beta [in]: input coefficient for Y, a rank 1 view
-  /// \param Y [in/out]: Output vector Y, a rank 2 view
-
-  template <typename MemberType, typename XViewType, typename YViewType,
-            typename NormViewType, typename ArgTrans, typename ArgMode>
-  KOKKOS_INLINE_FUNCTION void apply(const MemberType &member,
-                                    const XViewType &X, const YViewType &Y,
-                                    const NormViewType &alpha,
-                                    const NormViewType &beta) const {
-    KokkosBatched::Spmv<MemberType, ArgTrans, ArgMode>::template invoke<
-        ValuesViewType, IntViewType, XViewType, YViewType, NormViewType,
-        NormViewType, 1>(member, alpha, values, row_ptr, colIndices, X, beta,
-                         Y);
+  template <typename ArgTrans, typename XViewType, typename YViewType>
+  KOKKOS_INLINE_FUNCTION void apply(
+      const XViewType &X, const YViewType &Y,
+      MagnitudeType alpha = Kokkos::Details::ArithTraits<MagnitudeType>::one(),
+      MagnitudeType beta =
+          Kokkos::Details::ArithTraits<MagnitudeType>::zero()) const {
+    if (beta == 0)
+      KokkosBatched::SerialSpmv<ArgTrans>::template invoke<
+          ValuesViewType, IntViewType, XViewType, YViewType, 0>(
+          alpha, values, row_ptr, colIndices, X, beta, Y);
+    else
+      KokkosBatched::SerialSpmv<ArgTrans>::template invoke<
+          ValuesViewType, IntViewType, XViewType, YViewType, 1>(
+          alpha, values, row_ptr, colIndices, X, beta, Y);
   }
 };
 

--- a/src/batched/sparse/KokkosBatched_GMRES.hpp
+++ b/src/batched/sparse/KokkosBatched_GMRES.hpp
@@ -60,6 +60,7 @@
 /// \param handle [in]: a handle which provides different information such as
 /// the tolerance or the maximal number of iterations of the solver.
 
+#include <KokkosBatched_Krylov_Solvers.hpp>
 #include "KokkosBatched_Krylov_Handle.hpp"
 #include "KokkosBatched_GMRES_Serial_Impl.hpp"
 #include "KokkosBatched_GMRES_Team_Impl.hpp"

--- a/src/batched/sparse/KokkosBatched_GMRES.hpp
+++ b/src/batched/sparse/KokkosBatched_GMRES.hpp
@@ -61,6 +61,7 @@
 /// the tolerance or the maximal number of iterations of the solver.
 
 #include "KokkosBatched_Krylov_Handle.hpp"
+#include "KokkosBatched_GMRES_Serial_Impl.hpp"
 #include "KokkosBatched_GMRES_Team_Impl.hpp"
 #include "KokkosBatched_GMRES_TeamVector_Impl.hpp"
 
@@ -68,14 +69,18 @@ namespace KokkosBatched {
 
 template <typename MemberType, typename ArgMode>
 struct GMRES {
-  template <typename OperatorType, typename VectorViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(
-      const MemberType &member, const OperatorType &A, const VectorViewType &B,
-      const VectorViewType &X,
-      const KrylovHandle<typename VectorViewType::non_const_value_type>
-          &handle) {
+  template <typename OperatorType, typename VectorViewType,
+            typename KrylovHandleType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
+                                           const OperatorType &A,
+                                           const VectorViewType &B,
+                                           const VectorViewType &X,
+                                           const KrylovHandleType &handle) {
     int status = 0;
-    if (std::is_same<ArgMode, Mode::Team>::value) {
+    if (std::is_same<ArgMode, Mode::Serial>::value) {
+      status = SerialGMRES::template invoke<OperatorType, VectorViewType>(
+          A, B, X, handle);
+    } else if (std::is_same<ArgMode, Mode::Team>::value) {
       status =
           TeamGMRES<MemberType>::template invoke<OperatorType, VectorViewType>(
               member, A, B, X, handle);

--- a/src/batched/sparse/KokkosBatched_Identity.hpp
+++ b/src/batched/sparse/KokkosBatched_Identity.hpp
@@ -60,8 +60,8 @@ class Identity {
   KOKKOS_INLINE_FUNCTION
   ~Identity() {}
 
-  template <typename MemberType, typename XViewType, typename YViewType,
-            typename ArgTrans, typename ArgMode, int sameXY>
+  template <typename ArgTrans, typename ArgMode, int sameXY,
+            typename MemberType, typename XViewType, typename YViewType>
   KOKKOS_INLINE_FUNCTION void apply(const MemberType &member,
                                     const XViewType &X,
                                     const YViewType &Y) const {
@@ -74,6 +74,14 @@ class Identity {
                               KokkosBatched::Mode::TeamVector>::value) {
         TeamVectorCopy<MemberType>::invoke(member, X, Y);
       }
+    }
+  }
+  template <typename ArgTrans, int sameXY, typename XViewType,
+            typename YViewType>
+  KOKKOS_INLINE_FUNCTION void apply(const XViewType &X,
+                                    const YViewType &Y) const {
+    if (sameXY == 0) {
+      SerialCopy<Trans::NoTranspose>::invoke(X, Y);
     }
   }
 };

--- a/src/batched/sparse/KokkosBatched_Krylov_Handle.hpp
+++ b/src/batched/sparse/KokkosBatched_Krylov_Handle.hpp
@@ -56,21 +56,154 @@ namespace KokkosBatched {
 ///
 /// \tparam scalar_type: Scalar type of the linear solver
 
-template <class scalar_type>
+template <class NormViewType, class IntViewType, class ViewType3D>
 class KrylovHandle {
  public:
-  using norm_type =
-      typename Kokkos::Details::ArithTraits<scalar_type>::mag_type;
+  using norm_type = typename NormViewType::non_const_value_type;
+
+  typedef ViewType3D ArnoldiViewType;
+  typedef Kokkos::View<typename ViewType3D::non_const_value_type **,
+                       typename ViewType3D::array_layout,
+                       typename ViewType3D::execution_space>
+      TemporaryViewType;
+
+ public:
+  NormViewType residual_norms;
+  IntViewType iteration_numbers;
+  typename NormViewType::HostMirror residual_norms_host;
+  typename IntViewType::HostMirror iteration_numbers_host;
+  IntViewType first_index;
+  IntViewType last_index;
+  ArnoldiViewType Arnoldi_view;
+  TemporaryViewType tmp_view;
 
  private:
   norm_type tolerance;
+  norm_type max_tolerance;
   int max_iteration;
+  int batched_size;
+  int N_team;
+  int ortho_strategy;
+  int scratch_pad_level;
+  bool compute_last_residual;
+  bool monitor_residual;
+  bool host_synchronised;
 
  public:
-  KOKKOS_INLINE_FUNCTION
-  KrylovHandle() {
+  KrylovHandle(int _batched_size, int _N_team, int _max_iteration = 200,
+               bool _monitor_residual = false)
+      : max_iteration(_max_iteration),
+        batched_size(_batched_size),
+        N_team(_N_team),
+        monitor_residual(_monitor_residual) {
     tolerance     = Kokkos::Details::ArithTraits<norm_type>::epsilon();
-    max_iteration = 200;
+    max_tolerance = 1e-30;
+    if (std::is_same<norm_type, double>::value) max_tolerance = 1e-50;
+    if (monitor_residual) {
+      residual_norms = NormViewType("", batched_size, max_iteration + 2);
+    }
+    iteration_numbers = IntViewType("", batched_size);
+    Kokkos::deep_copy(iteration_numbers, -1);
+
+    int n_teams = ceil(1. * batched_size / N_team);
+    first_index = IntViewType("", n_teams);
+    last_index  = IntViewType("", n_teams);
+
+    auto first_index_host = Kokkos::create_mirror_view(first_index);
+    auto last_index_host  = Kokkos::create_mirror_view(last_index);
+
+    first_index_host(0) = 0;
+    last_index_host(0)  = N_team;
+    for (int i = 1; i < n_teams; ++i) {
+      first_index_host(i) = last_index_host(i - 1);
+      last_index_host(i)  = first_index_host(i) + N_team;
+    }
+    last_index_host(n_teams - 1) = batched_size;
+
+    Kokkos::deep_copy(first_index, first_index_host);
+    Kokkos::deep_copy(last_index, last_index_host);
+
+    // Default Classical GS
+    ortho_strategy        = 1;
+    scratch_pad_level     = 0;
+    compute_last_residual = true;
+    host_synchronised     = false;
+  }
+
+  /// \brief reset
+  ///   Reset the iteration numbers to the default value of -1
+  ///   and the residual norms if monitored.
+  ///   (Usefull when mulitple consecutive solvers use the same handle)
+  ///
+
+  void reset() {
+    Kokkos::deep_copy(iteration_numbers, -1);
+    if (monitor_residual) {
+      Kokkos::deep_copy(residual_norms, 0.);
+    }
+    host_synchronised = false;
+  }
+
+  ///
+
+  void synchronise_host() {
+    iteration_numbers_host = Kokkos::create_mirror_view(iteration_numbers);
+    Kokkos::deep_copy(iteration_numbers_host, iteration_numbers);
+    if (monitor_residual) {
+      residual_norms_host = Kokkos::create_mirror_view(residual_norms);
+      Kokkos::deep_copy(residual_norms_host, residual_norms);
+    }
+    host_synchronised = true;
+  }
+
+  /// \brief is_converged
+  ///   Test if all the systems have converged.
+  ///
+
+  KOKKOS_INLINE_FUNCTION
+  bool is_converged() const {
+    bool all_converged = true;
+    for (size_t i = 0; i < batched_size; ++i)
+      if (iteration_numbers(i) == -1) {
+        all_converged = false;
+        break;
+      }
+    return all_converged;
+  }
+
+  /// \brief is_converged_host
+  ///   Test if all the systems have converged (host).
+  ///
+
+  bool is_converged_host() {
+    if (!host_synchronised) this->synchronise_host();
+    bool all_converged = true;
+    for (int i = 0; i < batched_size; ++i)
+      if (iteration_numbers_host(i) == -1) {
+        all_converged = false;
+        break;
+      }
+    return all_converged;
+  }
+
+  /// \brief is_converged
+  ///   Test if one particular system has converged.
+  ///
+  /// \param batched_id [in]: Global batched ID
+
+  KOKKOS_INLINE_FUNCTION
+  bool is_converged(int batched_id) const {
+    return (iteration_numbers(batched_id) != -1);
+  }
+
+  /// \brief is_converged
+  ///   Test if one particular system has converged (host).
+  ///
+  /// \param batched_id [in]: Global batched ID
+
+  bool is_converged_host(int batched_id) {
+    if (!host_synchronised) this->synchronise_host();
+    return (iteration_numbers_host(batched_id) != -1);
   }
 
   /// \brief set_tolerance
@@ -87,21 +220,246 @@ class KrylovHandle {
   KOKKOS_INLINE_FUNCTION
   norm_type get_tolerance() const { return tolerance; }
 
+  /// \brief set_max_tolerance
+  ///   Set the maximal tolerance of the batched Krylov solver
+  ///
+  /// \param _max_tolerance [in]: New tolerance
+
+  KOKKOS_INLINE_FUNCTION
+  void set_max_tolerance(norm_type _max_tolerance) {
+    max_tolerance = _max_tolerance;
+  }
+
+  /// \brief get_max_tolerance
+  ///   Get the maximal tolerance of the batched Krylov solver
+
+  KOKKOS_INLINE_FUNCTION
+  norm_type get_max_tolerance() const { return max_tolerance; }
+
   /// \brief set_max_iteration
   ///   Set the maximum number of iterations of the batched Krylov solver
   ///
   /// \param _max_iteration [in]: New maximum number of iterations
 
   KOKKOS_INLINE_FUNCTION
-  void set_max_iteration(norm_type _max_iteration) {
-    max_iteration = _max_iteration;
-  }
+  void set_max_iteration(int _max_iteration) { max_iteration = _max_iteration; }
 
   /// \brief get_max_iteration
   ///   Get the maximum number of iterations of the batched Krylov solver
 
   KOKKOS_INLINE_FUNCTION
   int get_max_iteration() const { return max_iteration; }
+
+  /// \brief set_norm
+  ///   Store the norm of one of the system at one of the iteration
+  ///
+  /// \param batched_id [in]: Global batched ID
+  /// \param iteration_id [in]: Iteration ID
+  /// \param norm_i [in]: Norm to store
+
+  KOKKOS_INLINE_FUNCTION
+  void set_norm(int batched_id, int iteration_id, norm_type norm_i) const {
+    if (monitor_residual) residual_norms(batched_id, iteration_id) = norm_i;
+  }
+
+  /// \brief set_norm
+  ///   Store the norm of one of the system at one of the iteration
+  ///
+  /// \param batchedteam_id [in]: Team ID
+  /// \param batched_id [in]: Local batched ID (local ID within the team)
+  /// \param iteration_id [in]: Iteration ID
+  /// \param norm_i [in]: Norm to store
+
+  KOKKOS_INLINE_FUNCTION
+  void set_norm(int team_id, int batched_id, int iteration_id,
+                norm_type norm_i) const {
+    if (monitor_residual)
+      residual_norms(team_id * N_team + batched_id, iteration_id) = norm_i;
+  }
+
+  /// \brief get_norm
+  ///   Get the norm of one system at a given iteration
+  ///
+  /// \param batched_id [in]: Global batched ID
+  /// \param iteration_id [in]: Iteration ID
+
+  KOKKOS_INLINE_FUNCTION
+  norm_type get_norm(int batched_id, int iteration_id) const {
+    if (monitor_residual) {
+      return residual_norms(batched_id, iteration_id);
+    } else
+      return 0;
+  }
+
+  /// \brief get_norm_host
+  ///   Get the norm of one system at a given iteration (host)
+  ///
+  /// \param batched_id [in]: Global batched ID
+  /// \param iteration_id [in]: Iteration ID
+
+  norm_type get_norm_host(int batched_id, int iteration_id) {
+    if (monitor_residual) {
+      if (!host_synchronised) this->synchronise_host();
+      return residual_norms_host(batched_id, iteration_id);
+    } else
+      return 0;
+  }
+
+  /// \brief set_last_norm
+  ///   Store the last norm of one system
+  ///
+  /// \param batched_id [in]: Global batched ID
+  /// \param norm_i [in]: Norm to store
+
+  KOKKOS_INLINE_FUNCTION
+  void set_last_norm(int batched_id, norm_type norm_i) const {
+    if (monitor_residual)
+      residual_norms(batched_id, max_iteration + 1) = norm_i;
+  }
+
+  /// \brief set_last_norm
+  ///   Store the last norm of one system
+  ///
+  /// \param batchedteam_id [in]: Team ID
+  /// \param batched_id [in]: Local batched ID (local ID within the team)
+  /// \param batched_id [in]: Global batched ID
+  /// \param norm_i [in]: Norm to store
+
+  KOKKOS_INLINE_FUNCTION
+  void set_last_norm(int team_id, int batched_id, norm_type norm_i) const {
+    if (monitor_residual)
+      residual_norms(team_id * N_team + batched_id, max_iteration + 1) = norm_i;
+  }
+
+  /// \brief get_last_norm
+  ///   Get the last norm of one system
+  ///
+  /// \param batched_id [in]: Global batched ID
+
+  KOKKOS_INLINE_FUNCTION
+  norm_type get_last_norm(int batched_id) const {
+    if (monitor_residual && compute_last_residual) {
+      return residual_norms(batched_id, max_iteration + 1);
+    } else
+      return 0;
+  }
+
+  /// \brief get_last_norm_host
+  ///   Get the last norm of one system (host)
+  ///
+  /// \param batched_id [in]: Global batched ID
+
+  norm_type get_last_norm_host(int batched_id) {
+    if (monitor_residual && compute_last_residual) {
+      if (!host_synchronised) this->synchronise_host();
+      return residual_norms_host(batched_id, max_iteration + 1);
+    } else
+      return 0;
+  }
+
+  /// \brief set_iteration
+  ///   Store the number of iteration after convergence for one system
+  ///
+  /// \param batched_id [in]: Global batched ID
+  /// \param iteration_id [in]: Iteration ID
+
+  KOKKOS_INLINE_FUNCTION
+  void set_iteration(int batched_id, int iteration_id) const {
+    iteration_numbers(batched_id) = iteration_id;
+  }
+
+  /// \brief set_iteration
+  ///   Store the number of iteration after convergence for one system
+  ///
+  /// \param batchedteam_id [in]: Team ID
+  /// \param batched_id [in]: Local batched ID (local ID within the team)
+  /// \param iteration_id [in]: Iteration ID
+
+  KOKKOS_INLINE_FUNCTION
+  void set_iteration(int team_id, int batched_id, int iteration_id) const {
+    iteration_numbers(team_id * N_team + batched_id) = iteration_id;
+  }
+
+  /// \brief get_iteration
+  ///   Get the number of iteration after convergence for one system
+  ///
+  /// \param batched_id [in]: Global batched ID
+
+  KOKKOS_INLINE_FUNCTION
+  int get_iteration(int batched_id) const {
+    return iteration_numbers(batched_id);
+  }
+
+  /// \brief get_iteration_host
+  ///   Get the number of iteration after convergence for one system (host)
+  ///
+  /// \param batched_id [in]: Global batched ID
+
+  int get_iteration_host(int batched_id) {
+    if (!host_synchronised) this->synchronise_host();
+    return iteration_numbers_host(batched_id);
+  }
+
+  /// \brief set_ortho_strategy
+  ///   Set the used orthogonalization strategy.
+  ///   Either classical GS (_ortho_strategy=0) or modified GS
+  ///   (_ortho_strategy=1)
+  ///
+  /// \param _ortho_strategy [in]: used orthogonalization strategy
+
+  KOKKOS_INLINE_FUNCTION
+  void set_ortho_strategy(int _ortho_strategy) {
+    ortho_strategy = _ortho_strategy;
+  }
+
+  /// \brief get_ortho_strategy
+  ///   Get the used orthogonalization strategy.
+  ///   Either classical GS (_ortho_strategy=0) or modified GS
+  ///   (_ortho_strategy=1)
+
+  KOKKOS_INLINE_FUNCTION
+  int get_ortho_strategy() const { return ortho_strategy; }
+
+  /// \brief set_scratch_pad_level
+  ///   Set the scratch pad level used to store temporary variables.
+  ///
+  /// \param _scratch_pad_level [in]: used level
+
+  KOKKOS_INLINE_FUNCTION
+  void set_scratch_pad_level(int _scratch_pad_level) {
+    scratch_pad_level = _scratch_pad_level;
+  }
+
+  /// \brief get_scratch_pad_level
+  ///   Get the scratch pad level used to store temporary variables.
+
+  KOKKOS_INLINE_FUNCTION
+  int get_scratch_pad_level() const { return scratch_pad_level; }
+
+  /// \brief set_compute_last_residual
+  ///   Select if the last residual is explicitly computed.
+  ///
+  /// \param _compute_last_residual [in]: boolean that specifies if we compute
+  /// the last residual explicitly
+
+  KOKKOS_INLINE_FUNCTION
+  void set_compute_last_residual(bool _compute_last_residual) {
+    if (monitor_residual)
+      compute_last_residual = _compute_last_residual;
+    else
+      compute_last_residual = false;
+  }
+
+  /// \brief get_compute_last_residual
+  ///   Specify if the last residual has to be computed explicitly.
+
+  KOKKOS_INLINE_FUNCTION
+  bool get_compute_last_residual() const {
+    if (monitor_residual)
+      return compute_last_residual;
+    else
+      return false;
+  }
 };
 
 }  // namespace KokkosBatched

--- a/src/batched/sparse/KokkosBatched_Krylov_Solvers.hpp
+++ b/src/batched/sparse/KokkosBatched_Krylov_Solvers.hpp
@@ -1,0 +1,129 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef __KOKKOSBATCHED_KRYLOV_SOLVERS_HPP__
+#define __KOKKOSBATCHED_KRYLOV_SOLVERS_HPP__
+
+namespace KokkosBatched {
+
+struct SerialGMRES {
+  template <typename OperatorType, typename VectorViewType,
+            typename PrecOperatorType, typename KrylovHandleType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const OperatorType& A,
+                                           const VectorViewType& _B,
+                                           const VectorViewType& _X,
+                                           const PrecOperatorType& P,
+                                           const KrylovHandleType& handle,
+                                           const int GMRES_id);
+  template <typename OperatorType, typename VectorViewType,
+            typename KrylovHandleType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const OperatorType& A,
+                                           const VectorViewType& _B,
+                                           const VectorViewType& _X,
+                                           const KrylovHandleType& handle);
+};
+
+template <typename MemberType>
+struct TeamGMRES {
+  template <typename OperatorType, typename VectorViewType,
+            typename PrecOperatorType, typename KrylovHandleType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
+                                           const OperatorType& A,
+                                           const VectorViewType& _B,
+                                           const VectorViewType& _X,
+                                           const PrecOperatorType& P,
+                                           const KrylovHandleType& handle);
+  template <typename OperatorType, typename VectorViewType,
+            typename KrylovHandleType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
+                                           const OperatorType& A,
+                                           const VectorViewType& _B,
+                                           const VectorViewType& _X,
+                                           const KrylovHandleType& handle);
+};
+
+template <typename MemberType>
+struct TeamVectorGMRES {
+  template <typename OperatorType, typename VectorViewType,
+            typename PrecOperatorType, typename KrylovHandleType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
+                                           const OperatorType& A,
+                                           const VectorViewType& _B,
+                                           const VectorViewType& _X,
+                                           const PrecOperatorType& P,
+                                           const KrylovHandleType& handle);
+  template <typename OperatorType, typename VectorViewType,
+            typename KrylovHandleType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
+                                           const OperatorType& A,
+                                           const VectorViewType& _B,
+                                           const VectorViewType& _X,
+                                           const KrylovHandleType& handle);
+};
+
+template <typename MemberType>
+struct TeamCG {
+  template <typename OperatorType, typename VectorViewType,
+            typename KrylovHandleType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
+                                           const OperatorType& A,
+                                           const VectorViewType& _B,
+                                           const VectorViewType& _X,
+                                           const KrylovHandleType& handle);
+};
+
+template <typename MemberType>
+struct TeamVectorCG {
+  template <typename OperatorType, typename VectorViewType,
+            typename KrylovHandleType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
+                                           const OperatorType& A,
+                                           const VectorViewType& _B,
+                                           const VectorViewType& _X,
+                                           const KrylovHandleType& handle);
+};
+
+}  // namespace KokkosBatched
+
+#endif

--- a/src/batched/sparse/impl/KokkosBatched_CG_TeamVector_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_CG_TeamVector_Impl.hpp
@@ -63,7 +63,7 @@ namespace KokkosBatched {
 template <typename MemberType>
 template <typename OperatorType, typename VectorViewType,
           typename KrylovHandleType>
-KOKKOS_INLINE_FUNCTION int TeamVectorCG<MemberType>::template invoke(
+KOKKOS_INLINE_FUNCTION int TeamVectorCG<MemberType>::invoke(
     const MemberType& member, const OperatorType& A, const VectorViewType& _B,
     const VectorViewType& _X, const KrylovHandleType& handle) {
   typedef int OrdinalType;

--- a/src/batched/sparse/impl/KokkosBatched_CG_TeamVector_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_CG_TeamVector_Impl.hpp
@@ -61,149 +61,145 @@ namespace KokkosBatched {
 ///
 
 template <typename MemberType>
-struct TeamVectorCG {
-  template <typename OperatorType, typename VectorViewType,
-            typename KrylovHandleType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
-                                           const OperatorType& A,
-                                           const VectorViewType& _B,
-                                           const VectorViewType& _X,
-                                           const KrylovHandleType& handle) {
-    typedef int OrdinalType;
-    typedef typename Kokkos::Details::ArithTraits<
-        typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
+template <typename OperatorType, typename VectorViewType,
+          typename KrylovHandleType>
+KOKKOS_INLINE_FUNCTION int TeamVectorCG<MemberType>::template invoke(
+    const MemberType& member, const OperatorType& A, const VectorViewType& _B,
+    const VectorViewType& _X, const KrylovHandleType& handle) {
+  typedef int OrdinalType;
+  typedef typename Kokkos::Details::ArithTraits<
+      typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
 
-    const size_t maximum_iteration = handle.get_max_iteration();
-    const MagnitudeType tolerance  = handle.get_tolerance();
+  const size_t maximum_iteration = handle.get_max_iteration();
+  const MagnitudeType tolerance  = handle.get_tolerance();
 
-    using ScratchPadNormViewType = Kokkos::View<
-        MagnitudeType*,
-        typename VectorViewType::execution_space::scratch_memory_space>;
-    using ScratchPadVectorViewType = Kokkos::View<
-        typename VectorViewType::non_const_value_type**,
-        typename VectorViewType::array_layout,
-        typename VectorViewType::execution_space::scratch_memory_space>;
-    using TeamVectorCopy1D = TeamVectorCopy<MemberType, Trans::NoTranspose, 1>;
+  using ScratchPadNormViewType = Kokkos::View<
+      MagnitudeType*,
+      typename VectorViewType::execution_space::scratch_memory_space>;
+  using ScratchPadVectorViewType = Kokkos::View<
+      typename VectorViewType::non_const_value_type**,
+      typename VectorViewType::array_layout,
+      typename VectorViewType::execution_space::scratch_memory_space>;
+  using TeamVectorCopy1D = TeamVectorCopy<MemberType, Trans::NoTranspose, 1>;
 
-    const OrdinalType numMatrices = _X.extent(0);
-    const OrdinalType numRows     = _X.extent(1);
+  const OrdinalType numMatrices = _X.extent(0);
+  const OrdinalType numRows     = _X.extent(1);
 
-    ScratchPadVectorViewType P(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-        numRows);
-    ScratchPadVectorViewType Q(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-        numRows);
-    ScratchPadVectorViewType R(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-        numRows);
-    ScratchPadVectorViewType X(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-        numRows);
+  ScratchPadVectorViewType P(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+      numRows);
+  ScratchPadVectorViewType Q(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+      numRows);
+  ScratchPadVectorViewType R(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+      numRows);
+  ScratchPadVectorViewType X(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+      numRows);
 
-    ScratchPadNormViewType sqr_norm_0(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
-    ScratchPadNormViewType sqr_norm_j(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
-    ScratchPadNormViewType alpha(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
-    ScratchPadNormViewType mask(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
-    ScratchPadNormViewType tmp(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
+  ScratchPadNormViewType sqr_norm_0(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
+  ScratchPadNormViewType sqr_norm_j(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
+  ScratchPadNormViewType alpha(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
+  ScratchPadNormViewType mask(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
+  ScratchPadNormViewType tmp(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
 
-    TeamVectorCopy<MemberType>::invoke(member, _X, X);
-    // Deep copy of b into r_0:
-    TeamVectorCopy<MemberType>::invoke(member, _B, R);
+  TeamVectorCopy<MemberType>::invoke(member, _X, X);
+  // Deep copy of b into r_0:
+  TeamVectorCopy<MemberType>::invoke(member, _B, R);
 
-    // r_0 := b - A x_0
+  // r_0 := b - A x_0
+  member.team_barrier();
+  A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, X, R, -1, 1);
+  member.team_barrier();
+
+  // Deep copy of r_0 into p_0:
+  TeamVectorCopy<MemberType>::invoke(member, R, P);
+
+  TeamVectorDot<MemberType>::invoke(member, R, R, sqr_norm_0);
+  member.team_barrier();
+
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
+                       [&](const OrdinalType& i) {
+                         mask(i) =
+                             sqr_norm_0(i) > tolerance * tolerance ? 1. : 0;
+                       });
+
+  TeamVectorCopy1D::invoke(member, sqr_norm_0, sqr_norm_j);
+
+  int status               = 1;
+  int number_not_converged = 0;
+
+  for (size_t j = 0; j < maximum_iteration; ++j) {
+    // q := A p_j
+    A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, P, Q);
     member.team_barrier();
-    A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, X, R, -1, 1);
-    member.team_barrier();
 
-    // Deep copy of r_0 into p_0:
-    TeamVectorCopy<MemberType>::invoke(member, R, P);
-
-    TeamVectorDot<MemberType>::invoke(member, R, R, sqr_norm_0);
+    TeamVectorDot<MemberType>::invoke(member, P, Q, tmp);
     member.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
                          [&](const OrdinalType& i) {
-                           mask(i) =
-                               sqr_norm_0(i) > tolerance * tolerance ? 1. : 0;
+                           alpha(i) =
+                               mask(i) != 0. ? sqr_norm_j(i) / tmp(i) : 0.;
+                         });
+    member.team_barrier();
+
+    // x_{j+1} := alpha p_j + x_j
+    TeamVectorAxpy<MemberType>::invoke(member, alpha, P, X);
+    member.team_barrier();
+
+    // r_{j+1} := - alpha q + r_j
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
+                         [&](const OrdinalType& i) { alpha(i) = -alpha(i); });
+    member.team_barrier();
+
+    TeamVectorAxpy<MemberType>::invoke(member, alpha, Q, R);
+    member.team_barrier();
+
+    TeamVectorDot<MemberType>::invoke(member, R, R, tmp);
+    member.team_barrier();
+
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
+                         [&](const OrdinalType& i) {
+                           alpha(i) =
+                               mask(i) != 0. ? tmp(i) / sqr_norm_j(i) : 0.;
                          });
 
-    TeamVectorCopy1D::invoke(member, sqr_norm_0, sqr_norm_j);
+    TeamVectorCopy1D::invoke(member, tmp, sqr_norm_j);
 
-    int status               = 1;
-    int number_not_converged = 0;
+    // Relative convergence check:
+    number_not_converged = 0;
+    Kokkos::parallel_reduce(
+        Kokkos::TeamVectorRange(member, 0, numMatrices),
+        [&](const OrdinalType& i, int& lnumber_not_converged) {
+          if (sqr_norm_j(i) / sqr_norm_0(i) > tolerance * tolerance)
+            ++lnumber_not_converged;
+          else
+            mask(i) = 0.;
+        },
+        number_not_converged);
 
-    for (size_t j = 0; j < maximum_iteration; ++j) {
-      // q := A p_j
-      A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, P, Q);
-      member.team_barrier();
+    member.team_barrier();
 
-      TeamVectorDot<MemberType>::invoke(member, P, Q, tmp);
-      member.team_barrier();
-
-      Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
-                           [&](const OrdinalType& i) {
-                             alpha(i) =
-                                 mask(i) != 0. ? sqr_norm_j(i) / tmp(i) : 0.;
-                           });
-      member.team_barrier();
-
-      // x_{j+1} := alpha p_j + x_j
-      TeamVectorAxpy<MemberType>::invoke(member, alpha, P, X);
-      member.team_barrier();
-
-      // r_{j+1} := - alpha q + r_j
-      Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
-                           [&](const OrdinalType& i) { alpha(i) = -alpha(i); });
-      member.team_barrier();
-
-      TeamVectorAxpy<MemberType>::invoke(member, alpha, Q, R);
-      member.team_barrier();
-
-      TeamVectorDot<MemberType>::invoke(member, R, R, tmp);
-      member.team_barrier();
-
-      Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
-                           [&](const OrdinalType& i) {
-                             alpha(i) =
-                                 mask(i) != 0. ? tmp(i) / sqr_norm_j(i) : 0.;
-                           });
-
-      TeamVectorCopy1D::invoke(member, tmp, sqr_norm_j);
-
-      // Relative convergence check:
-      number_not_converged = 0;
-      Kokkos::parallel_reduce(
-          Kokkos::TeamVectorRange(member, 0, numMatrices),
-          [&](const OrdinalType& i, int& lnumber_not_converged) {
-            if (sqr_norm_j(i) / sqr_norm_0(i) > tolerance * tolerance)
-              ++lnumber_not_converged;
-            else
-              mask(i) = 0.;
-          },
-          number_not_converged);
-
-      member.team_barrier();
-
-      if (number_not_converged == 0) {
-        status = 0;
-        break;
-      }
-
-      // p_{j+1} := alpha p_j + r_{j+1}
-      TeamVectorXpay<MemberType>::invoke(member, alpha, R, P);
-      member.team_barrier();
+    if (number_not_converged == 0) {
+      status = 0;
+      break;
     }
 
-    TeamVectorCopy<MemberType>::invoke(member, X, _X);
-    return status;
+    // p_{j+1} := alpha p_j + r_{j+1}
+    TeamVectorXpay<MemberType>::invoke(member, alpha, R, P);
+    member.team_barrier();
   }
-};
+
+  TeamVectorCopy<MemberType>::invoke(member, X, _X);
+  return status;
+}
 }  // namespace KokkosBatched
 
 #endif

--- a/src/batched/sparse/impl/KokkosBatched_CG_TeamVector_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_CG_TeamVector_Impl.hpp
@@ -62,12 +62,13 @@ namespace KokkosBatched {
 
 template <typename MemberType>
 struct TeamVectorCG {
-  template <typename OperatorType, typename VectorViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(
-      const MemberType& member, const OperatorType& A, const VectorViewType& _B,
-      const VectorViewType& _X,
-      const KrylovHandle<typename VectorViewType::non_const_value_type>&
-          handle) {
+  template <typename OperatorType, typename VectorViewType,
+            typename KrylovHandleType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
+                                           const OperatorType& A,
+                                           const VectorViewType& _B,
+                                           const VectorViewType& _X,
+                                           const KrylovHandleType& handle) {
     typedef int OrdinalType;
     typedef typename Kokkos::Details::ArithTraits<
         typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
@@ -87,16 +88,29 @@ struct TeamVectorCG {
     const OrdinalType numMatrices = _X.extent(0);
     const OrdinalType numRows     = _X.extent(1);
 
-    ScratchPadVectorViewType P(member.team_scratch(0), numMatrices, numRows);
-    ScratchPadVectorViewType Q(member.team_scratch(0), numMatrices, numRows);
-    ScratchPadVectorViewType R(member.team_scratch(0), numMatrices, numRows);
-    ScratchPadVectorViewType X(member.team_scratch(0), numMatrices, numRows);
+    ScratchPadVectorViewType P(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+        numRows);
+    ScratchPadVectorViewType Q(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+        numRows);
+    ScratchPadVectorViewType R(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+        numRows);
+    ScratchPadVectorViewType X(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+        numRows);
 
-    ScratchPadNormViewType sqr_norm_0(member.team_scratch(0), numMatrices);
-    ScratchPadNormViewType sqr_norm_j(member.team_scratch(0), numMatrices);
-    ScratchPadNormViewType alpha(member.team_scratch(0), numMatrices);
-    ScratchPadNormViewType mask(member.team_scratch(0), numMatrices);
-    ScratchPadNormViewType tmp(member.team_scratch(0), numMatrices);
+    ScratchPadNormViewType sqr_norm_0(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
+    ScratchPadNormViewType sqr_norm_j(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
+    ScratchPadNormViewType alpha(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
+    ScratchPadNormViewType mask(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
+    ScratchPadNormViewType tmp(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
 
     TeamVectorCopy<MemberType>::invoke(member, _X, X);
     // Deep copy of b into r_0:
@@ -104,9 +118,7 @@ struct TeamVectorCG {
 
     // r_0 := b - A x_0
     member.team_barrier();
-    A.template apply<MemberType, ScratchPadVectorViewType,
-                     ScratchPadVectorViewType, Trans::NoTranspose,
-                     Mode::TeamVector>(member, X, R, -1, 1);
+    A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, X, R, -1, 1);
     member.team_barrier();
 
     // Deep copy of r_0 into p_0:
@@ -128,9 +140,7 @@ struct TeamVectorCG {
 
     for (size_t j = 0; j < maximum_iteration; ++j) {
       // q := A p_j
-      A.template apply<MemberType, ScratchPadVectorViewType,
-                       ScratchPadVectorViewType, Trans::NoTranspose,
-                       Mode::TeamVector>(member, P, Q);
+      A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, P, Q);
       member.team_barrier();
 
       TeamVectorDot<MemberType>::invoke(member, P, Q, tmp);

--- a/src/batched/sparse/impl/KokkosBatched_CG_Team_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_CG_Team_Impl.hpp
@@ -60,149 +60,145 @@ namespace KokkosBatched {
 ///
 
 template <typename MemberType>
-struct TeamCG {
-  template <typename OperatorType, typename VectorViewType,
-            typename KrylovHandle>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
-                                           const OperatorType& A,
-                                           const VectorViewType& _B,
-                                           const VectorViewType& _X,
-                                           const KrylovHandle& handle) {
-    typedef int OrdinalType;
-    typedef typename Kokkos::Details::ArithTraits<
-        typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
+template <typename OperatorType, typename VectorViewType, typename KrylovHandle>
+KOKKOS_INLINE_FUNCTION int TeamCG<MemberType>::template invoke(
+    const MemberType& member, const OperatorType& A, const VectorViewType& _B,
+    const VectorViewType& _X, const KrylovHandle& handle) {
+  typedef int OrdinalType;
+  typedef typename Kokkos::Details::ArithTraits<
+      typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
 
-    size_t maximum_iteration      = handle.get_max_iteration();
-    const MagnitudeType tolerance = handle.get_tolerance();
+  size_t maximum_iteration      = handle.get_max_iteration();
+  const MagnitudeType tolerance = handle.get_tolerance();
 
-    using ScratchPadNormViewType = Kokkos::View<
-        MagnitudeType*,
-        typename VectorViewType::execution_space::scratch_memory_space>;
-    using ScratchPadVectorViewType = Kokkos::View<
-        typename VectorViewType::non_const_value_type**,
-        typename VectorViewType::array_layout,
-        typename VectorViewType::execution_space::scratch_memory_space>;
-    using TeamCopy1D = TeamCopy<MemberType, Trans::NoTranspose, 1>;
+  using ScratchPadNormViewType = Kokkos::View<
+      MagnitudeType*,
+      typename VectorViewType::execution_space::scratch_memory_space>;
+  using ScratchPadVectorViewType = Kokkos::View<
+      typename VectorViewType::non_const_value_type**,
+      typename VectorViewType::array_layout,
+      typename VectorViewType::execution_space::scratch_memory_space>;
+  using TeamCopy1D = TeamCopy<MemberType, Trans::NoTranspose, 1>;
 
-    const OrdinalType numMatrices = _X.extent(0);
-    const OrdinalType numRows     = _X.extent(1);
+  const OrdinalType numMatrices = _X.extent(0);
+  const OrdinalType numRows     = _X.extent(1);
 
-    ScratchPadVectorViewType P(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-        numRows);
-    ScratchPadVectorViewType Q(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-        numRows);
-    ScratchPadVectorViewType R(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-        numRows);
-    ScratchPadVectorViewType X(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-        numRows);
+  ScratchPadVectorViewType P(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+      numRows);
+  ScratchPadVectorViewType Q(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+      numRows);
+  ScratchPadVectorViewType R(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+      numRows);
+  ScratchPadVectorViewType X(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+      numRows);
 
-    ScratchPadNormViewType sqr_norm_0(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
-    ScratchPadNormViewType sqr_norm_j(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
-    ScratchPadNormViewType alpha(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
-    ScratchPadNormViewType mask(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
-    ScratchPadNormViewType tmp(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
+  ScratchPadNormViewType sqr_norm_0(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
+  ScratchPadNormViewType sqr_norm_j(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
+  ScratchPadNormViewType alpha(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
+  ScratchPadNormViewType mask(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
+  ScratchPadNormViewType tmp(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
 
-    TeamCopy<MemberType>::invoke(member, _X, X);
-    // Deep copy of b into r_0:
-    TeamCopy<MemberType>::invoke(member, _B, R);
+  TeamCopy<MemberType>::invoke(member, _X, X);
+  // Deep copy of b into r_0:
+  TeamCopy<MemberType>::invoke(member, _B, R);
 
-    // r_0 := b - A x_0
+  // r_0 := b - A x_0
+  member.team_barrier();
+  A.template apply<Trans::NoTranspose, Mode::Team>(member, X, R, -1, 1);
+  member.team_barrier();
+
+  // Deep copy of r_0 into p_0:
+  TeamCopy<MemberType>::invoke(member, R, P);
+
+  TeamDot<MemberType>::invoke(member, R, R, sqr_norm_0);
+  member.team_barrier();
+
+  Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
+                       [&](const OrdinalType& i) {
+                         mask(i) =
+                             sqr_norm_0(i) > tolerance * tolerance ? 1. : 0;
+                       });
+
+  TeamCopy1D::invoke(member, sqr_norm_0, sqr_norm_j);
+
+  int status               = 1;
+  int number_not_converged = 0;
+
+  for (size_t j = 0; j < maximum_iteration; ++j) {
+    // q := A p_j
+    A.template apply<Trans::NoTranspose, Mode::Team>(member, P, Q);
     member.team_barrier();
-    A.template apply<Trans::NoTranspose, Mode::Team>(member, X, R, -1, 1);
-    member.team_barrier();
 
-    // Deep copy of r_0 into p_0:
-    TeamCopy<MemberType>::invoke(member, R, P);
-
-    TeamDot<MemberType>::invoke(member, R, R, sqr_norm_0);
+    TeamDot<MemberType>::invoke(member, P, Q, tmp);
     member.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
                          [&](const OrdinalType& i) {
-                           mask(i) =
-                               sqr_norm_0(i) > tolerance * tolerance ? 1. : 0;
+                           alpha(i) =
+                               mask(i) != 0. ? sqr_norm_j(i) / tmp(i) : 0.;
+                         });
+    member.team_barrier();
+
+    // x_{j+1} := alpha p_j + x_j
+    TeamAxpy<MemberType>::invoke(member, alpha, P, X);
+    member.team_barrier();
+
+    // r_{j+1} := - alpha q + r_j
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
+                         [&](const OrdinalType& i) { alpha(i) = -alpha(i); });
+    member.team_barrier();
+
+    TeamAxpy<MemberType>::invoke(member, alpha, Q, R);
+    member.team_barrier();
+
+    TeamDot<MemberType>::invoke(member, R, R, tmp);
+    member.team_barrier();
+
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
+                         [&](const OrdinalType& i) {
+                           alpha(i) =
+                               mask(i) != 0. ? tmp(i) / sqr_norm_j(i) : 0.;
                          });
 
-    TeamCopy1D::invoke(member, sqr_norm_0, sqr_norm_j);
+    TeamCopy1D::invoke(member, tmp, sqr_norm_j);
 
-    int status               = 1;
-    int number_not_converged = 0;
+    // Relative convergence check:
+    number_not_converged = 0;
+    Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(member, 0, numMatrices),
+        [&](const OrdinalType& i, int& lnumber_not_converged) {
+          if (sqr_norm_j(i) / sqr_norm_0(i) > tolerance * tolerance)
+            ++lnumber_not_converged;
+          else
+            mask(i) = 0.;
+        },
+        number_not_converged);
 
-    for (size_t j = 0; j < maximum_iteration; ++j) {
-      // q := A p_j
-      A.template apply<Trans::NoTranspose, Mode::Team>(member, P, Q);
-      member.team_barrier();
+    member.team_barrier();
 
-      TeamDot<MemberType>::invoke(member, P, Q, tmp);
-      member.team_barrier();
-
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
-                           [&](const OrdinalType& i) {
-                             alpha(i) =
-                                 mask(i) != 0. ? sqr_norm_j(i) / tmp(i) : 0.;
-                           });
-      member.team_barrier();
-
-      // x_{j+1} := alpha p_j + x_j
-      TeamAxpy<MemberType>::invoke(member, alpha, P, X);
-      member.team_barrier();
-
-      // r_{j+1} := - alpha q + r_j
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
-                           [&](const OrdinalType& i) { alpha(i) = -alpha(i); });
-      member.team_barrier();
-
-      TeamAxpy<MemberType>::invoke(member, alpha, Q, R);
-      member.team_barrier();
-
-      TeamDot<MemberType>::invoke(member, R, R, tmp);
-      member.team_barrier();
-
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
-                           [&](const OrdinalType& i) {
-                             alpha(i) =
-                                 mask(i) != 0. ? tmp(i) / sqr_norm_j(i) : 0.;
-                           });
-
-      TeamCopy1D::invoke(member, tmp, sqr_norm_j);
-
-      // Relative convergence check:
-      number_not_converged = 0;
-      Kokkos::parallel_reduce(
-          Kokkos::TeamThreadRange(member, 0, numMatrices),
-          [&](const OrdinalType& i, int& lnumber_not_converged) {
-            if (sqr_norm_j(i) / sqr_norm_0(i) > tolerance * tolerance)
-              ++lnumber_not_converged;
-            else
-              mask(i) = 0.;
-          },
-          number_not_converged);
-
-      member.team_barrier();
-
-      if (number_not_converged == 0) {
-        status = 0;
-        break;
-      }
-
-      // p_{j+1} := alpha p_j + r_{j+1}
-      TeamXpay<MemberType>::invoke(member, alpha, R, P);
-      member.team_barrier();
+    if (number_not_converged == 0) {
+      status = 0;
+      break;
     }
 
-    TeamCopy<MemberType>::invoke(member, X, _X);
-    return status;
+    // p_{j+1} := alpha p_j + r_{j+1}
+    TeamXpay<MemberType>::invoke(member, alpha, R, P);
+    member.team_barrier();
   }
-};
+
+  TeamCopy<MemberType>::invoke(member, X, _X);
+  return status;
+}
+
 }  // namespace KokkosBatched
 
 #endif

--- a/src/batched/sparse/impl/KokkosBatched_CG_Team_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_CG_Team_Impl.hpp
@@ -61,7 +61,7 @@ namespace KokkosBatched {
 
 template <typename MemberType>
 template <typename OperatorType, typename VectorViewType, typename KrylovHandle>
-KOKKOS_INLINE_FUNCTION int TeamCG<MemberType>::template invoke(
+KOKKOS_INLINE_FUNCTION int TeamCG<MemberType>::invoke(
     const MemberType& member, const OperatorType& A, const VectorViewType& _B,
     const VectorViewType& _X, const KrylovHandle& handle) {
   typedef int OrdinalType;

--- a/src/batched/sparse/impl/KokkosBatched_GMRES_Serial_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_GMRES_Serial_Impl.hpp
@@ -281,7 +281,7 @@ KOKKOS_INLINE_FUNCTION int SerialGMRES::invoke(const OperatorType& A,
     auto B_l = Kokkos::subview(G, l, first_indices);
 
     SerialTrsm<Side::Left, Uplo::Lower, Trans::Transpose, Diag::NonUnit,
-               Algo::Trsm::Unblocked>::template invoke(1, A_l, B_l);
+               Algo::Trsm::Unblocked>::invoke(1, A_l, B_l);
   }
 
   if (handle.get_ortho_strategy() == 0) {

--- a/src/batched/sparse/impl/KokkosBatched_GMRES_Serial_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_GMRES_Serial_Impl.hpp
@@ -1,0 +1,333 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.4
+//       Copyright (2021) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+#ifndef __KOKKOSBATCHED_GMRES_SERIAL_IMPL_HPP__
+#define __KOKKOSBATCHED_GMRES_SERIAL_IMPL_HPP__
+
+/// \author Kim Liegeois (knliege@sandia.gov)
+
+#include "KokkosBatched_Util.hpp"
+
+#include "KokkosBatched_Axpy.hpp"
+#include "KokkosBatched_Copy_Decl.hpp"
+#include "KokkosBatched_Dot.hpp"
+#include "KokkosBatched_Spmv.hpp"
+#include "KokkosBatched_Xpay.hpp"
+#include "KokkosBatched_Givens_Serial_Internal.hpp"
+#include "KokkosBatched_Trsm_Decl.hpp"
+#include "KokkosBatched_Identity.hpp"
+#include "KokkosBatched_Gemv_Decl.hpp"
+
+namespace KokkosBatched {
+
+///
+/// Serial GMRES
+///
+
+struct SerialGMRES {
+  template <typename OperatorType, typename VectorViewType,
+            typename PrecOperatorType, typename KrylovHandleType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const OperatorType& A,
+                                           const VectorViewType& _B,
+                                           const VectorViewType& _X,
+                                           const PrecOperatorType& P,
+                                           const KrylovHandleType& handle,
+                                           const int GMRES_id) {
+    typedef int OrdinalType;
+    typedef typename Kokkos::Details::ArithTraits<
+        typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
+    typedef Kokkos::Details::ArithTraits<MagnitudeType> ATM;
+
+    using SerialCopy1D = SerialCopy<Trans::NoTranspose, 1>;
+    using SerialCopy2D = SerialCopy<Trans::NoTranspose, 2>;
+
+    const OrdinalType numMatrices = _X.extent(0);
+    const OrdinalType numRows     = _X.extent(1);
+
+    size_t maximum_iteration = handle.get_max_iteration() < numRows
+                                   ? handle.get_max_iteration()
+                                   : numRows;
+    const MagnitudeType tolerance     = handle.get_tolerance();
+    const MagnitudeType max_tolerance = handle.get_max_tolerance();
+
+    int n_V      = numRows;
+    int n_H      = maximum_iteration + 1;
+    int n_Givens = 2;
+
+    int offset_V      = 0;
+    int offset_H      = offset_V + n_V;
+    int offset_Givens = offset_H + n_H;
+
+    const int first_matrix = handle.first_index(GMRES_id);
+    const int last_matrix  = handle.last_index(GMRES_id);
+
+    auto V_view = Kokkos::subview(
+        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+        Kokkos::ALL, Kokkos::make_pair(offset_V, offset_V + n_V));
+    auto H_view = Kokkos::subview(
+        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+        Kokkos::ALL, Kokkos::make_pair(offset_H, offset_H + n_H));
+    auto Givens_view = Kokkos::subview(
+        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+        Kokkos::ALL,
+        Kokkos::make_pair(offset_Givens, offset_Givens + n_Givens));
+
+    int n_G    = maximum_iteration + 1;
+    int n_W    = numRows;
+    int n_mask = 1;
+
+    int offset_G    = 0;
+    int offset_W    = offset_G + n_G;
+    int offset_mask = offset_W + n_W;
+    int offset_tmp  = offset_mask + n_mask;
+
+    auto G    = Kokkos::subview(handle.tmp_view,
+                             Kokkos::make_pair(first_matrix, last_matrix),
+                             Kokkos::make_pair(offset_G, offset_G + n_G));
+    auto W    = Kokkos::subview(handle.tmp_view,
+                             Kokkos::make_pair(first_matrix, last_matrix),
+                             Kokkos::make_pair(offset_W, offset_W + n_W));
+    auto mask = Kokkos::subview(handle.tmp_view,
+                                Kokkos::make_pair(first_matrix, last_matrix),
+                                offset_mask);
+    auto tmp  = Kokkos::subview(handle.tmp_view,
+                               Kokkos::make_pair(first_matrix, last_matrix),
+                               offset_tmp);
+
+    // Deep copy of b into r_0:
+    SerialCopy2D::invoke(_B, W);
+
+    // r_0 := b - A x_0
+    A.template apply<Trans::NoTranspose>(_X, W, -1, 1);
+
+    P.template apply<Trans::NoTranspose, 1>(W, W);
+
+    SerialDot<Trans::NoTranspose>::invoke(W, W, tmp);
+
+    for (OrdinalType i = 0; i < numMatrices; ++i) {
+      tmp(i) = ATM::sqrt(tmp(i));
+      handle.set_norm(GMRES_id, i, 0, tmp(i));
+      if (tmp(i) > max_tolerance) {
+        mask(i) = 1;
+        G(i, 0) = tmp(i);
+        tmp(i)  = 1. / tmp(i);
+      } else {
+        handle.set_iteration(GMRES_id, i, 0);
+        mask(i) = 0;
+        G(i, 0) = 0.;
+        tmp(i)  = 0.;
+      }
+    }
+
+    auto V_0 = Kokkos::subview(V_view, Kokkos::ALL, 0, Kokkos::ALL);
+    for (OrdinalType iRow = 0; iRow < numRows; ++iRow) {
+      for (OrdinalType iMatrix = 0; iMatrix < numMatrices; ++iMatrix) {
+        V_0(iMatrix, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
+      }
+    }
+    int status = 1;
+    // int number_not_converged = 0;
+
+    for (size_t j = 0; j < maximum_iteration; ++j) {
+      // q := A p_j
+      auto V_j = Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL);
+
+      A.template apply<Trans::NoTranspose>(V_j, W);
+
+      P.template apply<Trans::NoTranspose, 1>(W, W);
+
+      if (handle.get_ortho_strategy() == 0) {
+        for (OrdinalType l = 0; l < numMatrices; ++l) {
+          auto W_l   = Kokkos::subview(W, l, Kokkos::ALL);
+          auto V_old = Kokkos::subview(
+              V_view, l, Kokkos::make_pair(0, (int)j + 1), Kokkos::ALL);
+          auto H_old =
+              Kokkos::subview(H_view, l, j, Kokkos::make_pair(0, (int)j + 1));
+
+          // Inner products
+          SerialGemv<Trans::NoTranspose, Algo::Gemv::Unblocked>::invoke(
+              1, V_old, W_l, 0, H_old);
+
+          // Update
+          SerialGemv<Trans::Transpose, Algo::Gemv::Unblocked>::invoke(
+              -1, V_old, H_old, 1, W_l);
+        }
+      }
+      if (handle.get_ortho_strategy() == 1) {
+        for (size_t i = 0; i < j + 1; ++i) {
+          auto V_i = Kokkos::subview(V_view, Kokkos::ALL, i, Kokkos::ALL);
+          SerialDot<Trans::NoTranspose>::invoke(W, V_i, tmp);
+          SerialCopy1D::invoke(tmp, Kokkos::subview(H_view, Kokkos::ALL, j, i));
+          for (OrdinalType ii = 0; ii < numMatrices; ++ii) tmp(ii) = -tmp(ii);
+
+          SerialAxpy::invoke(tmp, V_i, W);
+        }
+      }
+
+      SerialDot<Trans::NoTranspose>::invoke(W, W, tmp);
+
+      for (OrdinalType i = 0; i < numMatrices; ++i) {
+        H_view(i, j, j + 1) = ATM::sqrt(tmp(i));
+        tmp(i) =
+            H_view(i, j, j + 1) > max_tolerance ? 1. / H_view(i, j, j + 1) : 0.;
+      }
+
+      if (j + 1 < maximum_iteration) {
+        auto V_n = Kokkos::subview(V_view, Kokkos::ALL, j + 1, Kokkos::ALL);
+        for (OrdinalType iRow = 0; iRow < numRows; ++iRow) {
+          for (OrdinalType iMatrix = 0; iMatrix < numMatrices; ++iMatrix) {
+            V_n(iMatrix, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
+          }
+        }
+      }
+
+      for (OrdinalType l = 0; l < numMatrices; ++l) {
+        // Apply the previous Givens rotations:
+        auto H_j        = Kokkos::subview(H_view, l, j, Kokkos::ALL);
+        auto Givens_0_l = Kokkos::subview(Givens_view, l, Kokkos::ALL, 0);
+        auto Givens_1_l = Kokkos::subview(Givens_view, l, Kokkos::ALL, 1);
+
+        if (mask(l) == 1.) {
+          for (size_t i = 0; i < j; ++i) {
+            auto tmp1  = Givens_0_l(i) * H_j(i) + Givens_1_l(i) * H_j(i + 1);
+            auto tmp2  = -Givens_1_l(i) * H_j(i) + Givens_0_l(i) * H_j(i + 1);
+            H_j(i)     = tmp1;
+            H_j(i + 1) = tmp2;
+          }
+
+          // Compute the new Givens rotation:
+          Kokkos::pair<typename VectorViewType::non_const_value_type,
+                       typename VectorViewType::non_const_value_type>
+              G_new(1, 0);
+          typename VectorViewType::non_const_value_type alpha = 0;
+          SerialGivensInternal::invoke(H_j(j), H_j(j + 1), &G_new, &alpha);
+
+          Givens_0_l(j) = G_new.first;
+          Givens_1_l(j) = G_new.second;
+
+          // Apply the new Givens rotation:
+          auto tmp1  = Givens_0_l(j) * H_j(j) + Givens_1_l(j) * H_j(j + 1);
+          auto tmp2  = -Givens_1_l(j) * H_j(j) + Givens_0_l(j) * H_j(j + 1);
+          H_j(j)     = tmp1;
+          H_j(j + 1) = tmp2;
+
+          G(l, j + 1) = -Givens_1_l(j) * G(l, j);
+          G(l, j) *= Givens_0_l(j);
+        } else {
+          H_j(j)      = 1.;
+          G(l, j + 1) = 0.;
+        }
+
+        auto res_norm = Kokkos::ArithTraits<double>::abs(G(l, j + 1)) / G(l, 0);
+
+        handle.set_norm(GMRES_id, l, j + 1, res_norm);
+
+        if (mask(l) == 1. && res_norm < tolerance) {
+          mask(l)     = 0.;
+          G(l, j + 1) = 0.;
+          handle.set_iteration(GMRES_id, l, j + 1);
+        }
+      }
+
+      bool all_converged = true;
+      for (OrdinalType l = 0; l < numMatrices; ++l)
+        all_converged = (all_converged && mask(l) == 0.);
+      if (all_converged) {
+        maximum_iteration = j + 1;
+        break;
+      }
+    }
+
+    for (OrdinalType l = 0; l < numMatrices; ++l) {
+      for (size_t i = 0; i < maximum_iteration; ++i) {
+        size_t row_i = maximum_iteration - 1 - i;
+        for (size_t j = row_i + 1; j < maximum_iteration; ++j)
+          G(l, row_i) -= H_view(l, j, row_i) * G(l, j);
+        G(l, row_i) /= H_view(l, row_i, row_i);
+      }
+    }
+
+    if (handle.get_ortho_strategy() == 0) {
+      for (OrdinalType l = 0; l < numMatrices; ++l) {
+        SerialGemv<Trans::Transpose, Algo::Gemv::Unblocked>::invoke(
+            1,
+            Kokkos::subview(V_view, l,
+                            Kokkos::make_pair(0, (int)maximum_iteration),
+                            Kokkos::ALL),
+            Kokkos::subview(G, l, Kokkos::make_pair(0, (int)maximum_iteration)),
+            1, Kokkos::subview(_X, l, Kokkos::ALL));
+      }
+    }
+    if (handle.get_ortho_strategy() == 1) {
+      for (size_t j = 0; j < maximum_iteration; ++j) {
+        SerialAxpy::invoke(Kokkos::subview(G, Kokkos::ALL, j),
+                           Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL),
+                           _X);
+      }
+    }
+
+    if (handle.get_compute_last_residual()) {
+      SerialCopy2D::invoke(_B, W);
+      A.template apply<Trans::NoTranspose>(_X, W, -1, 1);
+      P.template apply<Trans::NoTranspose, 1>(W, W);
+      SerialDot<Trans::NoTranspose>::invoke(W, W, tmp);
+
+      for (OrdinalType i = 0; i < numMatrices; ++i) {
+        tmp(i) = ATM::sqrt(tmp(i));
+        handle.set_last_norm(GMRES_id, i, tmp(i));
+      }
+    }
+    return status;
+  }
+
+  template <typename OperatorType, typename VectorViewType,
+            typename KrylovHandleType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const OperatorType& A,
+                                           const VectorViewType& _B,
+                                           const VectorViewType& _X,
+                                           const KrylovHandleType& handle) {
+    Identity P;
+    return invoke<OperatorType, VectorViewType, Identity>(A, _B, _X, P, handle);
+  }
+};
+}  // namespace KokkosBatched
+
+#endif

--- a/src/batched/sparse/impl/KokkosBatched_GMRES_Serial_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_GMRES_Serial_Impl.hpp
@@ -62,272 +62,267 @@ namespace KokkosBatched {
 /// Serial GMRES
 ///
 
-struct SerialGMRES {
-  template <typename OperatorType, typename VectorViewType,
-            typename PrecOperatorType, typename KrylovHandleType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const OperatorType& A,
-                                           const VectorViewType& _B,
-                                           const VectorViewType& _X,
-                                           const PrecOperatorType& P,
-                                           const KrylovHandleType& handle,
-                                           const int GMRES_id) {
-    typedef int OrdinalType;
-    typedef typename Kokkos::Details::ArithTraits<
-        typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
-    typedef Kokkos::Details::ArithTraits<MagnitudeType> ATM;
+template <typename OperatorType, typename VectorViewType,
+          typename PrecOperatorType, typename KrylovHandleType>
+KOKKOS_INLINE_FUNCTION int SerialGMRES::invoke(const OperatorType& A,
+                                               const VectorViewType& _B,
+                                               const VectorViewType& _X,
+                                               const PrecOperatorType& P,
+                                               const KrylovHandleType& handle,
+                                               const int GMRES_id) {
+  typedef int OrdinalType;
+  typedef typename Kokkos::Details::ArithTraits<
+      typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
+  typedef Kokkos::Details::ArithTraits<MagnitudeType> ATM;
 
-    using SerialCopy1D = SerialCopy<Trans::NoTranspose, 1>;
-    using SerialCopy2D = SerialCopy<Trans::NoTranspose, 2>;
+  using SerialCopy1D = SerialCopy<Trans::NoTranspose, 1>;
+  using SerialCopy2D = SerialCopy<Trans::NoTranspose, 2>;
 
-    const OrdinalType numMatrices = _X.extent(0);
-    const OrdinalType numRows     = _X.extent(1);
+  const OrdinalType numMatrices = _X.extent(0);
+  const OrdinalType numRows     = _X.extent(1);
 
-    size_t maximum_iteration = handle.get_max_iteration() < numRows
-                                   ? handle.get_max_iteration()
-                                   : numRows;
-    const MagnitudeType tolerance     = handle.get_tolerance();
-    const MagnitudeType max_tolerance = handle.get_max_tolerance();
+  size_t maximum_iteration = handle.get_max_iteration() < numRows
+                                 ? handle.get_max_iteration()
+                                 : numRows;
+  const MagnitudeType tolerance     = handle.get_tolerance();
+  const MagnitudeType max_tolerance = handle.get_max_tolerance();
 
-    int n_V      = numRows;
-    int n_H      = maximum_iteration + 1;
-    int n_Givens = 2;
+  int n_V      = numRows;
+  int n_H      = maximum_iteration + 1;
+  int n_Givens = 2;
 
-    int offset_V      = 0;
-    int offset_H      = offset_V + n_V;
-    int offset_Givens = offset_H + n_H;
+  int offset_V      = 0;
+  int offset_H      = offset_V + n_V;
+  int offset_Givens = offset_H + n_H;
 
-    const int first_matrix = handle.first_index(GMRES_id);
-    const int last_matrix  = handle.last_index(GMRES_id);
+  const int first_matrix = handle.first_index(GMRES_id);
+  const int last_matrix  = handle.last_index(GMRES_id);
 
-    auto V_view = Kokkos::subview(
-        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
-        Kokkos::ALL, Kokkos::make_pair(offset_V, offset_V + n_V));
-    auto H_view = Kokkos::subview(
-        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
-        Kokkos::ALL, Kokkos::make_pair(offset_H, offset_H + n_H));
-    auto Givens_view = Kokkos::subview(
-        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
-        Kokkos::ALL,
-        Kokkos::make_pair(offset_Givens, offset_Givens + n_Givens));
+  auto V_view = Kokkos::subview(
+      handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+      Kokkos::ALL, Kokkos::make_pair(offset_V, offset_V + n_V));
+  auto H_view = Kokkos::subview(
+      handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+      Kokkos::ALL, Kokkos::make_pair(offset_H, offset_H + n_H));
+  auto Givens_view = Kokkos::subview(
+      handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+      Kokkos::ALL, Kokkos::make_pair(offset_Givens, offset_Givens + n_Givens));
 
-    int n_G    = maximum_iteration + 1;
-    int n_W    = numRows;
-    int n_mask = 1;
+  int n_G    = maximum_iteration + 1;
+  int n_W    = numRows;
+  int n_mask = 1;
 
-    int offset_G    = 0;
-    int offset_W    = offset_G + n_G;
-    int offset_mask = offset_W + n_W;
-    int offset_tmp  = offset_mask + n_mask;
+  int offset_G    = 0;
+  int offset_W    = offset_G + n_G;
+  int offset_mask = offset_W + n_W;
+  int offset_tmp  = offset_mask + n_mask;
 
-    auto G    = Kokkos::subview(handle.tmp_view,
-                             Kokkos::make_pair(first_matrix, last_matrix),
-                             Kokkos::make_pair(offset_G, offset_G + n_G));
-    auto W    = Kokkos::subview(handle.tmp_view,
-                             Kokkos::make_pair(first_matrix, last_matrix),
-                             Kokkos::make_pair(offset_W, offset_W + n_W));
-    auto mask = Kokkos::subview(handle.tmp_view,
-                                Kokkos::make_pair(first_matrix, last_matrix),
-                                offset_mask);
-    auto tmp  = Kokkos::subview(handle.tmp_view,
-                               Kokkos::make_pair(first_matrix, last_matrix),
-                               offset_tmp);
+  auto G    = Kokkos::subview(handle.tmp_view,
+                           Kokkos::make_pair(first_matrix, last_matrix),
+                           Kokkos::make_pair(offset_G, offset_G + n_G));
+  auto W    = Kokkos::subview(handle.tmp_view,
+                           Kokkos::make_pair(first_matrix, last_matrix),
+                           Kokkos::make_pair(offset_W, offset_W + n_W));
+  auto mask = Kokkos::subview(handle.tmp_view,
+                              Kokkos::make_pair(first_matrix, last_matrix),
+                              offset_mask);
+  auto tmp =
+      Kokkos::subview(handle.tmp_view,
+                      Kokkos::make_pair(first_matrix, last_matrix), offset_tmp);
 
-    // Deep copy of b into r_0:
-    SerialCopy2D::invoke(_B, W);
+  // Deep copy of b into r_0:
+  SerialCopy2D::invoke(_B, W);
 
-    // r_0 := b - A x_0
-    A.template apply<Trans::NoTranspose>(_X, W, -1, 1);
+  // r_0 := b - A x_0
+  A.template apply<Trans::NoTranspose>(_X, W, -1, 1);
+
+  P.template apply<Trans::NoTranspose, 1>(W, W);
+
+  SerialDot<Trans::NoTranspose>::invoke(W, W, tmp);
+
+  for (OrdinalType i = 0; i < numMatrices; ++i) {
+    tmp(i) = ATM::sqrt(tmp(i));
+    handle.set_norm(GMRES_id, i, 0, tmp(i));
+    if (tmp(i) > max_tolerance) {
+      mask(i) = 1;
+      G(i, 0) = tmp(i);
+      tmp(i)  = 1. / tmp(i);
+    } else {
+      handle.set_iteration(GMRES_id, i, 0);
+      mask(i) = 0;
+      G(i, 0) = 0.;
+      tmp(i)  = 0.;
+    }
+  }
+
+  auto V_0 = Kokkos::subview(V_view, Kokkos::ALL, 0, Kokkos::ALL);
+  for (OrdinalType iRow = 0; iRow < numRows; ++iRow) {
+    for (OrdinalType iMatrix = 0; iMatrix < numMatrices; ++iMatrix) {
+      V_0(iMatrix, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
+    }
+  }
+  int status = 1;
+  // int number_not_converged = 0;
+
+  for (size_t j = 0; j < maximum_iteration; ++j) {
+    // q := A p_j
+    auto V_j = Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL);
+
+    A.template apply<Trans::NoTranspose>(V_j, W);
 
     P.template apply<Trans::NoTranspose, 1>(W, W);
+
+    if (handle.get_ortho_strategy() == 0) {
+      for (OrdinalType l = 0; l < numMatrices; ++l) {
+        auto W_l   = Kokkos::subview(W, l, Kokkos::ALL);
+        auto V_old = Kokkos::subview(
+            V_view, l, Kokkos::make_pair(0, (int)j + 1), Kokkos::ALL);
+        auto H_old =
+            Kokkos::subview(H_view, l, j, Kokkos::make_pair(0, (int)j + 1));
+
+        // Inner products
+        SerialGemv<Trans::NoTranspose, Algo::Gemv::Unblocked>::invoke(
+            1, V_old, W_l, 0, H_old);
+
+        // Update
+        SerialGemv<Trans::Transpose, Algo::Gemv::Unblocked>::invoke(
+            -1, V_old, H_old, 1, W_l);
+      }
+    }
+    if (handle.get_ortho_strategy() == 1) {
+      for (size_t i = 0; i < j + 1; ++i) {
+        auto V_i = Kokkos::subview(V_view, Kokkos::ALL, i, Kokkos::ALL);
+        SerialDot<Trans::NoTranspose>::invoke(W, V_i, tmp);
+        SerialCopy1D::invoke(tmp, Kokkos::subview(H_view, Kokkos::ALL, j, i));
+        for (OrdinalType ii = 0; ii < numMatrices; ++ii) tmp(ii) = -tmp(ii);
+
+        SerialAxpy::invoke(tmp, V_i, W);
+      }
+    }
 
     SerialDot<Trans::NoTranspose>::invoke(W, W, tmp);
 
     for (OrdinalType i = 0; i < numMatrices; ++i) {
-      tmp(i) = ATM::sqrt(tmp(i));
-      handle.set_norm(GMRES_id, i, 0, tmp(i));
-      if (tmp(i) > max_tolerance) {
-        mask(i) = 1;
-        G(i, 0) = tmp(i);
-        tmp(i)  = 1. / tmp(i);
-      } else {
-        handle.set_iteration(GMRES_id, i, 0);
-        mask(i) = 0;
-        G(i, 0) = 0.;
-        tmp(i)  = 0.;
-      }
+      H_view(i, j, j + 1) = ATM::sqrt(tmp(i));
+      tmp(i) =
+          H_view(i, j, j + 1) > max_tolerance ? 1. / H_view(i, j, j + 1) : 0.;
     }
 
-    auto V_0 = Kokkos::subview(V_view, Kokkos::ALL, 0, Kokkos::ALL);
-    for (OrdinalType iRow = 0; iRow < numRows; ++iRow) {
-      for (OrdinalType iMatrix = 0; iMatrix < numMatrices; ++iMatrix) {
-        V_0(iMatrix, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
-      }
-    }
-    int status = 1;
-    // int number_not_converged = 0;
-
-    for (size_t j = 0; j < maximum_iteration; ++j) {
-      // q := A p_j
-      auto V_j = Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL);
-
-      A.template apply<Trans::NoTranspose>(V_j, W);
-
-      P.template apply<Trans::NoTranspose, 1>(W, W);
-
-      if (handle.get_ortho_strategy() == 0) {
-        for (OrdinalType l = 0; l < numMatrices; ++l) {
-          auto W_l   = Kokkos::subview(W, l, Kokkos::ALL);
-          auto V_old = Kokkos::subview(
-              V_view, l, Kokkos::make_pair(0, (int)j + 1), Kokkos::ALL);
-          auto H_old =
-              Kokkos::subview(H_view, l, j, Kokkos::make_pair(0, (int)j + 1));
-
-          // Inner products
-          SerialGemv<Trans::NoTranspose, Algo::Gemv::Unblocked>::invoke(
-              1, V_old, W_l, 0, H_old);
-
-          // Update
-          SerialGemv<Trans::Transpose, Algo::Gemv::Unblocked>::invoke(
-              -1, V_old, H_old, 1, W_l);
+    if (j + 1 < maximum_iteration) {
+      auto V_n = Kokkos::subview(V_view, Kokkos::ALL, j + 1, Kokkos::ALL);
+      for (OrdinalType iRow = 0; iRow < numRows; ++iRow) {
+        for (OrdinalType iMatrix = 0; iMatrix < numMatrices; ++iMatrix) {
+          V_n(iMatrix, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
         }
-      }
-      if (handle.get_ortho_strategy() == 1) {
-        for (size_t i = 0; i < j + 1; ++i) {
-          auto V_i = Kokkos::subview(V_view, Kokkos::ALL, i, Kokkos::ALL);
-          SerialDot<Trans::NoTranspose>::invoke(W, V_i, tmp);
-          SerialCopy1D::invoke(tmp, Kokkos::subview(H_view, Kokkos::ALL, j, i));
-          for (OrdinalType ii = 0; ii < numMatrices; ++ii) tmp(ii) = -tmp(ii);
-
-          SerialAxpy::invoke(tmp, V_i, W);
-        }
-      }
-
-      SerialDot<Trans::NoTranspose>::invoke(W, W, tmp);
-
-      for (OrdinalType i = 0; i < numMatrices; ++i) {
-        H_view(i, j, j + 1) = ATM::sqrt(tmp(i));
-        tmp(i) =
-            H_view(i, j, j + 1) > max_tolerance ? 1. / H_view(i, j, j + 1) : 0.;
-      }
-
-      if (j + 1 < maximum_iteration) {
-        auto V_n = Kokkos::subview(V_view, Kokkos::ALL, j + 1, Kokkos::ALL);
-        for (OrdinalType iRow = 0; iRow < numRows; ++iRow) {
-          for (OrdinalType iMatrix = 0; iMatrix < numMatrices; ++iMatrix) {
-            V_n(iMatrix, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
-          }
-        }
-      }
-
-      for (OrdinalType l = 0; l < numMatrices; ++l) {
-        // Apply the previous Givens rotations:
-        auto H_j        = Kokkos::subview(H_view, l, j, Kokkos::ALL);
-        auto Givens_0_l = Kokkos::subview(Givens_view, l, Kokkos::ALL, 0);
-        auto Givens_1_l = Kokkos::subview(Givens_view, l, Kokkos::ALL, 1);
-
-        if (mask(l) == 1.) {
-          for (size_t i = 0; i < j; ++i) {
-            auto tmp1  = Givens_0_l(i) * H_j(i) + Givens_1_l(i) * H_j(i + 1);
-            auto tmp2  = -Givens_1_l(i) * H_j(i) + Givens_0_l(i) * H_j(i + 1);
-            H_j(i)     = tmp1;
-            H_j(i + 1) = tmp2;
-          }
-
-          // Compute the new Givens rotation:
-          Kokkos::pair<typename VectorViewType::non_const_value_type,
-                       typename VectorViewType::non_const_value_type>
-              G_new(1, 0);
-          typename VectorViewType::non_const_value_type alpha = 0;
-          SerialGivensInternal::invoke(H_j(j), H_j(j + 1), &G_new, &alpha);
-
-          Givens_0_l(j) = G_new.first;
-          Givens_1_l(j) = G_new.second;
-
-          // Apply the new Givens rotation:
-          auto tmp1  = Givens_0_l(j) * H_j(j) + Givens_1_l(j) * H_j(j + 1);
-          auto tmp2  = -Givens_1_l(j) * H_j(j) + Givens_0_l(j) * H_j(j + 1);
-          H_j(j)     = tmp1;
-          H_j(j + 1) = tmp2;
-
-          G(l, j + 1) = -Givens_1_l(j) * G(l, j);
-          G(l, j) *= Givens_0_l(j);
-        } else {
-          H_j(j)      = 1.;
-          G(l, j + 1) = 0.;
-        }
-
-        auto res_norm = Kokkos::ArithTraits<double>::abs(G(l, j + 1)) / G(l, 0);
-
-        handle.set_norm(GMRES_id, l, j + 1, res_norm);
-
-        if (mask(l) == 1. && res_norm < tolerance) {
-          mask(l)     = 0.;
-          G(l, j + 1) = 0.;
-          handle.set_iteration(GMRES_id, l, j + 1);
-        }
-      }
-
-      bool all_converged = true;
-      for (OrdinalType l = 0; l < numMatrices; ++l)
-        all_converged = (all_converged && mask(l) == 0.);
-      if (all_converged) {
-        maximum_iteration = j + 1;
-        break;
       }
     }
 
     for (OrdinalType l = 0; l < numMatrices; ++l) {
-      for (size_t i = 0; i < maximum_iteration; ++i) {
-        size_t row_i = maximum_iteration - 1 - i;
-        for (size_t j = row_i + 1; j < maximum_iteration; ++j)
-          G(l, row_i) -= H_view(l, j, row_i) * G(l, j);
-        G(l, row_i) /= H_view(l, row_i, row_i);
+      // Apply the previous Givens rotations:
+      auto H_j        = Kokkos::subview(H_view, l, j, Kokkos::ALL);
+      auto Givens_0_l = Kokkos::subview(Givens_view, l, Kokkos::ALL, 0);
+      auto Givens_1_l = Kokkos::subview(Givens_view, l, Kokkos::ALL, 1);
+
+      if (mask(l) == 1.) {
+        for (size_t i = 0; i < j; ++i) {
+          auto tmp1  = Givens_0_l(i) * H_j(i) + Givens_1_l(i) * H_j(i + 1);
+          auto tmp2  = -Givens_1_l(i) * H_j(i) + Givens_0_l(i) * H_j(i + 1);
+          H_j(i)     = tmp1;
+          H_j(i + 1) = tmp2;
+        }
+
+        // Compute the new Givens rotation:
+        Kokkos::pair<typename VectorViewType::non_const_value_type,
+                     typename VectorViewType::non_const_value_type>
+            G_new(1, 0);
+        typename VectorViewType::non_const_value_type alpha = 0;
+        SerialGivensInternal::invoke(H_j(j), H_j(j + 1), &G_new, &alpha);
+
+        Givens_0_l(j) = G_new.first;
+        Givens_1_l(j) = G_new.second;
+
+        // Apply the new Givens rotation:
+        auto tmp1  = Givens_0_l(j) * H_j(j) + Givens_1_l(j) * H_j(j + 1);
+        auto tmp2  = -Givens_1_l(j) * H_j(j) + Givens_0_l(j) * H_j(j + 1);
+        H_j(j)     = tmp1;
+        H_j(j + 1) = tmp2;
+
+        G(l, j + 1) = -Givens_1_l(j) * G(l, j);
+        G(l, j) *= Givens_0_l(j);
+      } else {
+        H_j(j)      = 1.;
+        G(l, j + 1) = 0.;
+      }
+
+      auto res_norm = Kokkos::ArithTraits<double>::abs(G(l, j + 1)) / G(l, 0);
+
+      handle.set_norm(GMRES_id, l, j + 1, res_norm);
+
+      if (mask(l) == 1. && res_norm < tolerance) {
+        mask(l)     = 0.;
+        G(l, j + 1) = 0.;
+        handle.set_iteration(GMRES_id, l, j + 1);
       }
     }
 
-    if (handle.get_ortho_strategy() == 0) {
-      for (OrdinalType l = 0; l < numMatrices; ++l) {
-        SerialGemv<Trans::Transpose, Algo::Gemv::Unblocked>::invoke(
-            1,
-            Kokkos::subview(V_view, l,
-                            Kokkos::make_pair(0, (int)maximum_iteration),
-                            Kokkos::ALL),
-            Kokkos::subview(G, l, Kokkos::make_pair(0, (int)maximum_iteration)),
-            1, Kokkos::subview(_X, l, Kokkos::ALL));
-      }
+    bool all_converged = true;
+    for (OrdinalType l = 0; l < numMatrices; ++l)
+      all_converged = (all_converged && mask(l) == 0.);
+    if (all_converged) {
+      maximum_iteration = j + 1;
+      break;
     }
-    if (handle.get_ortho_strategy() == 1) {
-      for (size_t j = 0; j < maximum_iteration; ++j) {
-        SerialAxpy::invoke(Kokkos::subview(G, Kokkos::ALL, j),
-                           Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL),
-                           _X);
-      }
-    }
-
-    if (handle.get_compute_last_residual()) {
-      SerialCopy2D::invoke(_B, W);
-      A.template apply<Trans::NoTranspose>(_X, W, -1, 1);
-      P.template apply<Trans::NoTranspose, 1>(W, W);
-      SerialDot<Trans::NoTranspose>::invoke(W, W, tmp);
-
-      for (OrdinalType i = 0; i < numMatrices; ++i) {
-        tmp(i) = ATM::sqrt(tmp(i));
-        handle.set_last_norm(GMRES_id, i, tmp(i));
-      }
-    }
-    return status;
   }
 
-  template <typename OperatorType, typename VectorViewType,
-            typename KrylovHandleType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const OperatorType& A,
-                                           const VectorViewType& _B,
-                                           const VectorViewType& _X,
-                                           const KrylovHandleType& handle) {
-    Identity P;
-    return invoke<OperatorType, VectorViewType, Identity>(A, _B, _X, P, handle);
+  auto first_indices = Kokkos::make_pair(0, (int)maximum_iteration);
+
+  for (OrdinalType l = 0; l < numMatrices; ++l) {
+    auto A_l = Kokkos::subview(H_view, l, first_indices, first_indices);
+    auto B_l = Kokkos::subview(G, l, first_indices);
+
+    SerialTrsm<Side::Left, Uplo::Lower, Trans::Transpose, Diag::NonUnit,
+               Algo::Trsm::Unblocked>::template invoke(1, A_l, B_l);
   }
-};
+
+  if (handle.get_ortho_strategy() == 0) {
+    for (OrdinalType l = 0; l < numMatrices; ++l) {
+      SerialGemv<Trans::Transpose, Algo::Gemv::Unblocked>::invoke(
+          1, Kokkos::subview(V_view, l, first_indices, Kokkos::ALL),
+          Kokkos::subview(G, l, first_indices), 1,
+          Kokkos::subview(_X, l, Kokkos::ALL));
+    }
+  }
+  if (handle.get_ortho_strategy() == 1) {
+    for (size_t j = 0; j < maximum_iteration; ++j) {
+      SerialAxpy::invoke(Kokkos::subview(G, Kokkos::ALL, j),
+                         Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL),
+                         _X);
+    }
+  }
+
+  if (handle.get_compute_last_residual()) {
+    SerialCopy2D::invoke(_B, W);
+    A.template apply<Trans::NoTranspose>(_X, W, -1, 1);
+    P.template apply<Trans::NoTranspose, 1>(W, W);
+    SerialDot<Trans::NoTranspose>::invoke(W, W, tmp);
+
+    for (OrdinalType i = 0; i < numMatrices; ++i) {
+      tmp(i) = ATM::sqrt(tmp(i));
+      handle.set_last_norm(GMRES_id, i, tmp(i));
+    }
+  }
+  return status;
+}
+
+template <typename OperatorType, typename VectorViewType,
+          typename KrylovHandleType>
+KOKKOS_INLINE_FUNCTION int SerialGMRES::invoke(const OperatorType& A,
+                                               const VectorViewType& _B,
+                                               const VectorViewType& _X,
+                                               const KrylovHandleType& handle) {
+  Identity P;
+  return invoke<OperatorType, VectorViewType, Identity>(A, _B, _X, P, handle);
+}
 }  // namespace KokkosBatched
 
 #endif

--- a/src/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
@@ -54,6 +54,7 @@
 #include "KokkosBatched_Givens_Serial_Internal.hpp"
 #include "KokkosBatched_Trsm_Decl.hpp"
 #include "KokkosBatched_Identity.hpp"
+#include "KokkosBatched_Gemv_Decl.hpp"
 
 namespace KokkosBatched {
 
@@ -66,12 +67,13 @@ namespace KokkosBatched {
 template <typename MemberType>
 struct TeamVectorGMRES {
   template <typename OperatorType, typename VectorViewType,
-            typename PrecOperatorType>
-  KOKKOS_INLINE_FUNCTION static int invoke(
-      const MemberType& member, const OperatorType& A, const VectorViewType& _B,
-      const VectorViewType& _X, const PrecOperatorType& P,
-      const KrylovHandle<typename VectorViewType::non_const_value_type>&
-          handle) {
+            typename PrecOperatorType, typename KrylovHandleType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
+                                           const OperatorType& A,
+                                           const VectorViewType& _B,
+                                           const VectorViewType& _X,
+                                           const PrecOperatorType& P,
+                                           const KrylovHandleType& handle) {
     typedef int OrdinalType;
     typedef typename Kokkos::Details::ArithTraits<
         typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
@@ -97,132 +99,185 @@ struct TeamVectorGMRES {
                                    ? handle.get_max_iteration()
                                    : numRows;
     const MagnitudeType tolerance     = handle.get_tolerance();
-    const MagnitudeType max_tolerance = 0.;
+    const MagnitudeType max_tolerance = handle.get_max_tolerance();
 
-    ScratchPadMultiVectorViewType V(member.team_scratch(1), numMatrices,
-                                    maximum_iteration + 1, numRows);
-    ScratchPadMultiVectorViewType H(member.team_scratch(1), numMatrices,
-                                    maximum_iteration + 1, maximum_iteration);
-    ScratchPadMultiVectorViewType Givens(member.team_scratch(1), numMatrices,
-                                         maximum_iteration, 2);
-    ScratchPadVectorViewType G(member.team_scratch(1), numMatrices,
-                               maximum_iteration + 1);
+    int n_V      = numRows;
+    int n_H      = maximum_iteration + 1;
+    int n_Givens = 2;
 
-    ScratchPadVectorViewType W(member.team_scratch(0), numMatrices, numRows);
-    ScratchPadVectorViewType Q(member.team_scratch(0), numMatrices, numRows);
-    ScratchPadVectorViewType R(member.team_scratch(0), numMatrices, numRows);
-    ScratchPadVectorViewType X(member.team_scratch(0), numMatrices, numRows);
+    int offset_V      = 0;
+    int offset_H      = offset_V + n_V;
+    int offset_Givens = offset_H + n_H;
 
-    ScratchPadNormViewType beta(member.team_scratch(0), numMatrices);
-    ScratchPadNormViewType mask(member.team_scratch(0), numMatrices);
-    ScratchPadNormViewType tmp(member.team_scratch(0), numMatrices);
+    const int first_matrix = handle.first_index(member.league_rank());
+    const int last_matrix  = handle.last_index(member.league_rank());
+
+    auto V_view = Kokkos::subview(
+        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+        Kokkos::ALL, Kokkos::make_pair(offset_V, offset_V + n_V));
+    auto H_view = Kokkos::subview(
+        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+        Kokkos::ALL, Kokkos::make_pair(offset_H, offset_H + n_H));
+    auto Givens_view = Kokkos::subview(
+        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+        Kokkos::ALL,
+        Kokkos::make_pair(offset_Givens, offset_Givens + n_Givens));
+
+    int n_G    = maximum_iteration + 1;
+    int n_W    = numRows;
+    int n_X    = numRows;
+    int n_mask = 1;
+    int n_tmp  = 1;
+
+    int offset_G    = 0;
+    int offset_W    = offset_G + n_G;
+    int offset_X    = offset_W + n_W;
+    int offset_mask = offset_X + n_X;
+    int offset_tmp  = offset_mask + n_mask;
+
+    ScratchPadVectorViewType tmp_2D(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+        n_G + n_W + n_X + n_mask + n_tmp);
+
+    auto G    = Kokkos::subview(tmp_2D, Kokkos::ALL,
+                             Kokkos::make_pair(offset_G, offset_G + n_G));
+    auto W    = Kokkos::subview(tmp_2D, Kokkos::ALL,
+                             Kokkos::make_pair(offset_W, offset_W + n_W));
+    auto X    = Kokkos::subview(tmp_2D, Kokkos::ALL,
+                             Kokkos::make_pair(offset_X, offset_X + n_X));
+    auto mask = Kokkos::subview(tmp_2D, Kokkos::ALL, offset_mask);
+    auto tmp  = Kokkos::subview(tmp_2D, Kokkos::ALL, offset_tmp);
 
     TeamVectorCopy<MemberType>::invoke(member, _X, X);
     // Deep copy of b into r_0:
-    TeamVectorCopy<MemberType>::invoke(member, _B, R);
-
-    Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
-                         [&](const OrdinalType& i) { mask(i) = 1.; });
+    TeamVectorCopy<MemberType>::invoke(member, _B, W);
 
     // r_0 := b - A x_0
     member.team_barrier();
-    A.template apply<MemberType, ScratchPadVectorViewType,
-                     ScratchPadVectorViewType, Trans::NoTranspose,
-                     Mode::TeamVector>(member, X, R, -1, 1);
+    A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, X, W, -1, 1);
     member.team_barrier();
 
-    P.template apply<MemberType, ScratchPadVectorViewType,
-                     ScratchPadVectorViewType, Trans::NoTranspose,
-                     Mode::TeamVector, 1>(member, R, R);
+    P.template apply<Trans::NoTranspose, Mode::TeamVector, 1>(member, W, W);
     member.team_barrier();
 
-    TeamVectorDot<MemberType>::invoke(member, R, R, beta);
+    TeamVectorDot<MemberType>::invoke(member, W, W, tmp);
     member.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
                          [&](const OrdinalType& i) {
-                           beta(i) = ATM::sqrt(beta(i));
-                           G(i, 0) = beta(i) > max_tolerance ? beta(i) : 0.;
-                           tmp(i) = beta(i) > max_tolerance ? 1. / beta(i) : 0.;
+                           tmp(i) = ATM::sqrt(tmp(i));
+                           handle.set_norm(member.league_rank(), i, 0, tmp(i));
+                           if (tmp(i) > max_tolerance) {
+                             mask(i) = 1;
+                             G(i, 0) = tmp(i);
+                             tmp(i)  = 1. / tmp(i);
+                           } else {
+                             handle.set_iteration(member.league_rank(), i, 0);
+                             mask(i) = 0;
+                             G(i, 0) = 0.;
+                             tmp(i)  = 0.;
+                           }
                          });
 
     member.team_barrier();  // Finish writing to tmp
 
+    auto V_0 = Kokkos::subview(V_view, Kokkos::ALL, 0, Kokkos::ALL);
     Kokkos::parallel_for(
         Kokkos::TeamVectorRange(member, 0, numMatrices * numRows),
         [&](const OrdinalType& iTemp) {
           OrdinalType iRow, iMatrix;
           getIndices<OrdinalType, typename VectorViewType::array_layout>(
               iTemp, numRows, numMatrices, iRow, iMatrix);
-          V(iMatrix, 0, iRow) = R(iMatrix, iRow) * tmp(iMatrix);
+          V_0(iMatrix, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
         });
-
     int status = 1;
     // int number_not_converged = 0;
 
     for (size_t j = 0; j < maximum_iteration; ++j) {
       member.team_barrier();  // Finish writing to V
       // q := A p_j
-      auto V_j = Kokkos::subview(V, Kokkos::ALL, j, Kokkos::ALL);
+      auto V_j = Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL);
 
-      A.template apply<MemberType, ScratchPadVectorViewType,
-                       ScratchPadVectorViewType, Trans::NoTranspose,
-                       Mode::TeamVector>(member, V_j, W);
+      A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, V_j, W);
       member.team_barrier();
-      P.template apply<MemberType, ScratchPadVectorViewType,
-                       ScratchPadVectorViewType, Trans::NoTranspose,
-                       Mode::TeamVector, 1>(member, W, W);
 
-      for (size_t i = 0; i < j + 1; ++i) {
-        member.team_barrier();  // Finish writing to W
-        auto V_i = Kokkos::subview(V, Kokkos::ALL, i, Kokkos::ALL);
-        TeamVectorDot<MemberType>::invoke(member, W, V_i, tmp);
+      P.template apply<Trans::NoTranspose, Mode::TeamVector, 1>(member, W, W);
+      member.team_barrier();
+
+      if (handle.get_ortho_strategy() == 0) {
+        auto V_old = Kokkos::subview(
+            V_view, Kokkos::ALL, Kokkos::make_pair(0, (int)j + 1), Kokkos::ALL);
+        auto H_old = Kokkos::subview(H_view, Kokkos::ALL, j,
+                                     Kokkos::make_pair(0, (int)j + 1));
         member.team_barrier();
-        TeamVectorCopy1D::invoke(member, tmp,
-                                 Kokkos::subview(H, Kokkos::ALL, i, j));
+        // Inner products
+        TeamVectorGemv<MemberType, Trans::NoTranspose,
+                       Algo::Gemv::Unblocked>::invoke(member, 1, V_old, W, 0,
+                                                      H_old);
+        member.team_barrier();
 
-        member.team_barrier();  // Don't start modifying tmp until copy above
-                                // finishes
-        Kokkos::parallel_for(
-            Kokkos::TeamVectorRange(member, 0, numMatrices),
-            [&](const OrdinalType& ii) { tmp(ii) = -tmp(ii); });
+        // Update
+        TeamVectorGemv<MemberType, Trans::Transpose,
+                       Algo::Gemv::Unblocked>::invoke(member, -1, V_old, H_old,
+                                                      1, W);
+        member.team_barrier();
+      }
+      if (handle.get_ortho_strategy() == 1) {
+        for (size_t i = 0; i < j + 1; ++i) {
+          auto V_i = Kokkos::subview(V_view, Kokkos::ALL, i, Kokkos::ALL);
+          TeamVectorDot<MemberType>::invoke(member, W, V_i, tmp);
+          member.team_barrier();
+          TeamVectorCopy1D::invoke(member, tmp,
+                                   Kokkos::subview(H_view, Kokkos::ALL, j, i));
+          member.team_barrier();
+          Kokkos::parallel_for(
+              Kokkos::TeamVectorRange(member, 0, numMatrices),
+              [&](const OrdinalType& ii) { tmp(ii) = -tmp(ii); });
 
-        member.team_barrier();  // Finish writing to tmp
+          member.team_barrier();  // Finish writing to tmp
 
-        TeamVectorAxpy<MemberType>::invoke(member, tmp, V_i, W);
+          TeamVectorAxpy<MemberType>::invoke(member, tmp, V_i, W);
+          member.team_barrier();  // Finish writing to W
+        }
       }
 
       member.team_barrier();  // Finish writing to W
       TeamVectorDot<MemberType>::invoke(member, W, W, tmp);
       member.team_barrier();
-      Kokkos::parallel_for(
-          Kokkos::TeamVectorRange(member, 0, numMatrices),
-          [&](const OrdinalType& i) {
-            H(i, j + 1, j) = ATM::sqrt(tmp(i));
-            tmp(i) = H(i, j + 1, j) > max_tolerance ? 1. / H(i, j + 1, j) : 0.;
-          });
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
+                           [&](const OrdinalType& i) {
+                             H_view(i, j, j + 1) = ATM::sqrt(tmp(i));
+                             tmp(i) = H_view(i, j, j + 1) > max_tolerance
+                                          ? 1. / H_view(i, j, j + 1)
+                                          : 0.;
+                           });
       member.team_barrier();
-      Kokkos::parallel_for(
-          Kokkos::TeamVectorRange(member, 0, numMatrices * numRows),
-          [&](const OrdinalType& iTemp) {
-            OrdinalType iRow, iMatrix;
-            getIndices<OrdinalType, typename VectorViewType::array_layout>(
-                iTemp, numRows, numMatrices, iRow, iMatrix);
-            V(iMatrix, j + 1, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
-          });
+      if (j + 1 < maximum_iteration) {
+        auto V_n = Kokkos::subview(V_view, Kokkos::ALL, j + 1, Kokkos::ALL);
+        Kokkos::parallel_for(
+            Kokkos::TeamVectorRange(member, 0, numMatrices * numRows),
+            [&](const OrdinalType& iTemp) {
+              OrdinalType iRow, iMatrix;
+              getIndices<OrdinalType, typename VectorViewType::array_layout>(
+                  iTemp, numRows, numMatrices, iRow, iMatrix);
+              V_n(iMatrix, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
+            });
+        member.team_barrier();
+      }
 
       Kokkos::parallel_for(
           Kokkos::TeamVectorRange(member, 0, numMatrices),
           [&](const OrdinalType& l) {
             // Apply the previous Givens rotations:
-            auto H_j = Kokkos::subview(H, l, Kokkos::ALL, j);
+            auto H_j        = Kokkos::subview(H_view, l, j, Kokkos::ALL);
+            auto Givens_0_l = Kokkos::subview(Givens_view, l, Kokkos::ALL, 0);
+            auto Givens_1_l = Kokkos::subview(Givens_view, l, Kokkos::ALL, 1);
 
             if (mask(l) == 1.) {
               for (size_t i = 0; i < j; ++i) {
-                auto tmp1 =
-                    Givens(l, i, 0) * H_j(i) + Givens(l, i, 1) * H_j(i + 1);
+                auto tmp1 = Givens_0_l(i) * H_j(i) + Givens_1_l(i) * H_j(i + 1);
                 auto tmp2 =
-                    -Givens(l, i, 1) * H_j(i) + Givens(l, i, 0) * H_j(i + 1);
+                    -Givens_1_l(i) * H_j(i) + Givens_0_l(i) * H_j(i + 1);
                 H_j(i)     = tmp1;
                 H_j(i + 1) = tmp2;
               }
@@ -234,68 +289,112 @@ struct TeamVectorGMRES {
               typename VectorViewType::non_const_value_type alpha = 0;
               SerialGivensInternal::invoke(H_j(j), H_j(j + 1), &G_new, &alpha);
 
-              Givens(l, j, 0) = G_new.first;
-              Givens(l, j, 1) = G_new.second;
+              Givens_0_l(j) = G_new.first;
+              Givens_1_l(j) = G_new.second;
 
               // Apply the new Givens rotation:
-              auto tmp1 =
-                  Givens(l, j, 0) * H_j(j) + Givens(l, j, 1) * H_j(j + 1);
-              auto tmp2 =
-                  -Givens(l, j, 1) * H_j(j) + Givens(l, j, 0) * H_j(j + 1);
+              auto tmp1  = Givens_0_l(j) * H_j(j) + Givens_1_l(j) * H_j(j + 1);
+              auto tmp2  = -Givens_1_l(j) * H_j(j) + Givens_0_l(j) * H_j(j + 1);
               H_j(j)     = tmp1;
               H_j(j + 1) = tmp2;
 
-              G(l, j + 1) = -Givens(l, j, 1) * G(l, j);
-              G(l, j) *= Givens(l, j, 0);
+              G(l, j + 1) = -Givens_1_l(j) * G(l, j);
+              G(l, j) *= Givens_0_l(j);
             } else {
               H_j(j)      = 1.;
               G(l, j + 1) = 0.;
             }
 
-            if (mask(l) == 1. &&
-                Kokkos::ArithTraits<double>::abs(G(l, j + 1)) / beta(l) <
-                    tolerance) {
+            auto res_norm =
+                Kokkos::ArithTraits<double>::abs(G(l, j + 1)) / G(l, 0);
+
+            handle.set_norm(member.league_rank(), l, j + 1, res_norm);
+
+            if (mask(l) == 1. && res_norm < tolerance) {
               mask(l)     = 0.;
               G(l, j + 1) = 0.;
+              handle.set_iteration(member.league_rank(), l, j + 1);
             }
           });
+      member.team_barrier();
+
+      bool all_converged = true;
+      for (OrdinalType l = 0; l < numMatrices; ++l)
+        all_converged = (all_converged && mask(l) == 0.);
+      if (all_converged) {
+        maximum_iteration = j + 1;
+        break;
+      }
     }
 
     member.team_barrier();  // Finish writing to G
 
-    Kokkos::parallel_for(
-        Kokkos::TeamVectorRange(member, 0, numMatrices),
-        [&](const OrdinalType& l) {
-          SerialTrsm<Side::Left, Uplo::Upper, Trans::NoTranspose, Diag::NonUnit,
-                     Algo::Trsm::Unblocked>::template invoke(1,
-                                                             Kokkos::subview(
-                                                                 H, l,
-                                                                 Kokkos::ALL,
-                                                                 Kokkos::ALL),
-                                                             Kokkos::subview(
-                                                                 G, l,
-                                                                 Kokkos::ALL));
-        });
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
+                         [&](const OrdinalType& l) {
+                           for (size_t i = 0; i < maximum_iteration; ++i) {
+                             size_t row_i = maximum_iteration - 1 - i;
+                             for (size_t j = row_i + 1; j < maximum_iteration;
+                                  ++j)
+                               G(l, row_i) -= H_view(l, j, row_i) * G(l, j);
+                             G(l, row_i) /= H_view(l, row_i, row_i);
+                           }
+                         });
 
     member.team_barrier();  // Finish writing to G
 
-    for (size_t j = 0; j < maximum_iteration; ++j) {
-      TeamVectorAxpy<MemberType>::invoke(
-          member, Kokkos::subview(G, Kokkos::ALL, j),
-          Kokkos::subview(V, Kokkos::ALL, j, Kokkos::ALL), X);
-      member.team_barrier();  // Finish writing to X
+    if (handle.get_ortho_strategy() == 0) {
+      TeamVectorGemv<MemberType, Trans::Transpose, Algo::Gemv::Unblocked>::
+          invoke(member, 1,
+                 Kokkos::subview(V_view, Kokkos::ALL,
+                                 Kokkos::make_pair(0, (int)maximum_iteration),
+                                 Kokkos::ALL),
+                 Kokkos::subview(G, Kokkos::ALL,
+                                 Kokkos::make_pair(0, (int)maximum_iteration)),
+                 1, X);
     }
+    if (handle.get_ortho_strategy() == 1) {
+      for (size_t j = 0; j < maximum_iteration; ++j) {
+        TeamVectorAxpy<MemberType>::invoke(
+            member, Kokkos::subview(G, Kokkos::ALL, j),
+            Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL), X);
+        member.team_barrier();  // Finish writing to X
+      }
+    }
+
+    member.team_barrier();  // Finish writing to X
 
     TeamVectorCopy<MemberType>::invoke(member, X, _X);
+
+    member.team_barrier();
+
+    if (handle.get_compute_last_residual()) {
+      TeamVectorCopy<MemberType>::invoke(member, _B, W);
+      member.team_barrier();
+      A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, X, W, -1,
+                                                             1);
+      member.team_barrier();
+      P.template apply<Trans::NoTranspose, Mode::TeamVector, 1>(member, W, W);
+      member.team_barrier();
+      TeamVectorDot<MemberType>::invoke(member, W, W, tmp);
+      member.team_barrier();
+
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
+                           [&](const OrdinalType& i) {
+                             tmp(i) = ATM::sqrt(tmp(i));
+                             handle.set_last_norm(member.league_rank(), i,
+                                                  tmp(i));
+                           });
+    }
     return status;
   }
 
-  template <typename OperatorType, typename VectorViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(
-      const MemberType& member, const OperatorType& A, const VectorViewType& _B,
-      const VectorViewType& _X,
-      const KrylovHandle<typename VectorViewType::non_const_value_type>&
-          handle) {
+  template <typename OperatorType, typename VectorViewType,
+            typename KrylovHandleType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
+                                           const OperatorType& A,
+                                           const VectorViewType& _B,
+                                           const VectorViewType& _X,
+                                           const KrylovHandleType& handle) {
     Identity P;
     return invoke<OperatorType, VectorViewType, Identity>(member, A, _B, _X, P,
                                                           handle);

--- a/src/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
@@ -67,7 +67,7 @@ namespace KokkosBatched {
 template <typename MemberType>
 template <typename OperatorType, typename VectorViewType,
           typename PrecOperatorType, typename KrylovHandleType>
-KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::template invoke(
+KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::invoke(
     const MemberType& member, const OperatorType& A, const VectorViewType& _B,
     const VectorViewType& _X, const PrecOperatorType& P,
     const KrylovHandleType& handle) {
@@ -326,7 +326,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::template invoke(
         auto B_l = Kokkos::subview(G, l, first_indices);
 
         SerialTrsm<Side::Left, Uplo::Lower, Trans::Transpose, Diag::NonUnit,
-                   Algo::Trsm::Unblocked>::template invoke(1, A_l, B_l);
+                   Algo::Trsm::Unblocked>::invoke(1, A_l, B_l);
       });
 
   member.team_barrier();  // Finish writing to G
@@ -375,7 +375,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::template invoke(
 template <typename MemberType>
 template <typename OperatorType, typename VectorViewType,
           typename KrylovHandleType>
-KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::template invoke(
+KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::invoke(
     const MemberType& member, const OperatorType& A, const VectorViewType& _B,
     const VectorViewType& _X, const KrylovHandleType& handle) {
   Identity P;

--- a/src/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
@@ -65,334 +65,324 @@ namespace KokkosBatched {
 ///
 
 template <typename MemberType>
-struct TeamVectorGMRES {
-  template <typename OperatorType, typename VectorViewType,
-            typename PrecOperatorType, typename KrylovHandleType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
-                                           const OperatorType& A,
-                                           const VectorViewType& _B,
-                                           const VectorViewType& _X,
-                                           const PrecOperatorType& P,
-                                           const KrylovHandleType& handle) {
-    typedef int OrdinalType;
-    typedef typename Kokkos::Details::ArithTraits<
-        typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
-    typedef Kokkos::Details::ArithTraits<MagnitudeType> ATM;
+template <typename OperatorType, typename VectorViewType,
+          typename PrecOperatorType, typename KrylovHandleType>
+KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::template invoke(
+    const MemberType& member, const OperatorType& A, const VectorViewType& _B,
+    const VectorViewType& _X, const PrecOperatorType& P,
+    const KrylovHandleType& handle) {
+  typedef int OrdinalType;
+  typedef typename Kokkos::Details::ArithTraits<
+      typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
+  typedef Kokkos::Details::ArithTraits<MagnitudeType> ATM;
 
-    using ScratchPadVectorViewType = Kokkos::View<
-        typename VectorViewType::non_const_value_type**,
-        typename VectorViewType::array_layout,
-        typename VectorViewType::execution_space::scratch_memory_space>;
-    using TeamVectorCopy1D = TeamVectorCopy<MemberType, Trans::NoTranspose, 1>;
+  using ScratchPadVectorViewType = Kokkos::View<
+      typename VectorViewType::non_const_value_type**,
+      typename VectorViewType::array_layout,
+      typename VectorViewType::execution_space::scratch_memory_space>;
+  using TeamVectorCopy1D = TeamVectorCopy<MemberType, Trans::NoTranspose, 1>;
 
-    const OrdinalType numMatrices = _X.extent(0);
-    const OrdinalType numRows     = _X.extent(1);
+  const OrdinalType numMatrices = _X.extent(0);
+  const OrdinalType numRows     = _X.extent(1);
 
-    size_t maximum_iteration = handle.get_max_iteration() < numRows
-                                   ? handle.get_max_iteration()
-                                   : numRows;
-    const MagnitudeType tolerance     = handle.get_tolerance();
-    const MagnitudeType max_tolerance = handle.get_max_tolerance();
+  size_t maximum_iteration = handle.get_max_iteration() < numRows
+                                 ? handle.get_max_iteration()
+                                 : numRows;
+  const MagnitudeType tolerance     = handle.get_tolerance();
+  const MagnitudeType max_tolerance = handle.get_max_tolerance();
 
-    int n_V      = numRows;
-    int n_H      = maximum_iteration + 1;
-    int n_Givens = 2;
+  int n_V      = numRows;
+  int n_H      = maximum_iteration + 1;
+  int n_Givens = 2;
 
-    int offset_V      = 0;
-    int offset_H      = offset_V + n_V;
-    int offset_Givens = offset_H + n_H;
+  int offset_V      = 0;
+  int offset_H      = offset_V + n_V;
+  int offset_Givens = offset_H + n_H;
 
-    const int first_matrix = handle.first_index(member.league_rank());
-    const int last_matrix  = handle.last_index(member.league_rank());
+  const int first_matrix = handle.first_index(member.league_rank());
+  const int last_matrix  = handle.last_index(member.league_rank());
 
-    auto V_view = Kokkos::subview(
-        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
-        Kokkos::ALL, Kokkos::make_pair(offset_V, offset_V + n_V));
-    auto H_view = Kokkos::subview(
-        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
-        Kokkos::ALL, Kokkos::make_pair(offset_H, offset_H + n_H));
-    auto Givens_view = Kokkos::subview(
-        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
-        Kokkos::ALL,
-        Kokkos::make_pair(offset_Givens, offset_Givens + n_Givens));
+  auto V_view = Kokkos::subview(
+      handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+      Kokkos::ALL, Kokkos::make_pair(offset_V, offset_V + n_V));
+  auto H_view = Kokkos::subview(
+      handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+      Kokkos::ALL, Kokkos::make_pair(offset_H, offset_H + n_H));
+  auto Givens_view = Kokkos::subview(
+      handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+      Kokkos::ALL, Kokkos::make_pair(offset_Givens, offset_Givens + n_Givens));
 
-    int n_G    = maximum_iteration + 1;
-    int n_W    = numRows;
-    int n_X    = numRows;
-    int n_mask = 1;
-    int n_tmp  = 1;
+  int n_G    = maximum_iteration + 1;
+  int n_W    = numRows;
+  int n_X    = numRows;
+  int n_mask = 1;
+  int n_tmp  = 1;
 
-    int offset_G    = 0;
-    int offset_W    = offset_G + n_G;
-    int offset_X    = offset_W + n_W;
-    int offset_mask = offset_X + n_X;
-    int offset_tmp  = offset_mask + n_mask;
+  int offset_G    = 0;
+  int offset_W    = offset_G + n_G;
+  int offset_X    = offset_W + n_W;
+  int offset_mask = offset_X + n_X;
+  int offset_tmp  = offset_mask + n_mask;
 
-    ScratchPadVectorViewType tmp_2D(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-        n_G + n_W + n_X + n_mask + n_tmp);
+  ScratchPadVectorViewType tmp_2D(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+      n_G + n_W + n_X + n_mask + n_tmp);
 
-    auto G    = Kokkos::subview(tmp_2D, Kokkos::ALL,
-                             Kokkos::make_pair(offset_G, offset_G + n_G));
-    auto W    = Kokkos::subview(tmp_2D, Kokkos::ALL,
-                             Kokkos::make_pair(offset_W, offset_W + n_W));
-    auto X    = Kokkos::subview(tmp_2D, Kokkos::ALL,
-                             Kokkos::make_pair(offset_X, offset_X + n_X));
-    auto mask = Kokkos::subview(tmp_2D, Kokkos::ALL, offset_mask);
-    auto tmp  = Kokkos::subview(tmp_2D, Kokkos::ALL, offset_tmp);
+  auto G    = Kokkos::subview(tmp_2D, Kokkos::ALL,
+                           Kokkos::make_pair(offset_G, offset_G + n_G));
+  auto W    = Kokkos::subview(tmp_2D, Kokkos::ALL,
+                           Kokkos::make_pair(offset_W, offset_W + n_W));
+  auto X    = Kokkos::subview(tmp_2D, Kokkos::ALL,
+                           Kokkos::make_pair(offset_X, offset_X + n_X));
+  auto mask = Kokkos::subview(tmp_2D, Kokkos::ALL, offset_mask);
+  auto tmp  = Kokkos::subview(tmp_2D, Kokkos::ALL, offset_tmp);
 
-    TeamVectorCopy<MemberType>::invoke(member, _X, X);
-    // Deep copy of b into r_0:
-    TeamVectorCopy<MemberType>::invoke(member, _B, W);
+  TeamVectorCopy<MemberType>::invoke(member, _X, X);
+  // Deep copy of b into r_0:
+  TeamVectorCopy<MemberType>::invoke(member, _B, W);
 
-    // r_0 := b - A x_0
-    member.team_barrier();
-    A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, X, W, -1, 1);
+  // r_0 := b - A x_0
+  member.team_barrier();
+  A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, X, W, -1, 1);
+  member.team_barrier();
+
+  P.template apply<Trans::NoTranspose, Mode::TeamVector, 1>(member, W, W);
+  member.team_barrier();
+
+  TeamVectorDot<MemberType>::invoke(member, W, W, tmp);
+  member.team_barrier();
+
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
+                       [&](const OrdinalType& i) {
+                         tmp(i) = ATM::sqrt(tmp(i));
+                         handle.set_norm(member.league_rank(), i, 0, tmp(i));
+                         if (tmp(i) > max_tolerance) {
+                           mask(i) = 1;
+                           G(i, 0) = tmp(i);
+                           tmp(i)  = 1. / tmp(i);
+                         } else {
+                           handle.set_iteration(member.league_rank(), i, 0);
+                           mask(i) = 0;
+                           G(i, 0) = 0.;
+                           tmp(i)  = 0.;
+                         }
+                       });
+
+  member.team_barrier();  // Finish writing to tmp
+
+  auto V_0 = Kokkos::subview(V_view, Kokkos::ALL, 0, Kokkos::ALL);
+  Kokkos::parallel_for(
+      Kokkos::TeamVectorRange(member, 0, numMatrices * numRows),
+      [&](const OrdinalType& iTemp) {
+        OrdinalType iRow, iMatrix;
+        getIndices<OrdinalType, typename VectorViewType::array_layout>(
+            iTemp, numRows, numMatrices, iRow, iMatrix);
+        V_0(iMatrix, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
+      });
+  int status = 1;
+  // int number_not_converged = 0;
+
+  for (size_t j = 0; j < maximum_iteration; ++j) {
+    member.team_barrier();  // Finish writing to V
+    // q := A p_j
+    auto V_j = Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL);
+
+    A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, V_j, W);
     member.team_barrier();
 
     P.template apply<Trans::NoTranspose, Mode::TeamVector, 1>(member, W, W);
     member.team_barrier();
 
+    if (handle.get_ortho_strategy() == 0) {
+      auto V_old = Kokkos::subview(
+          V_view, Kokkos::ALL, Kokkos::make_pair(0, (int)j + 1), Kokkos::ALL);
+      auto H_old = Kokkos::subview(H_view, Kokkos::ALL, j,
+                                   Kokkos::make_pair(0, (int)j + 1));
+      member.team_barrier();
+      // Inner products
+      TeamVectorGemv<MemberType, Trans::NoTranspose,
+                     Algo::Gemv::Unblocked>::invoke(member, 1, V_old, W, 0,
+                                                    H_old);
+      member.team_barrier();
+
+      // Update
+      TeamVectorGemv<MemberType, Trans::Transpose,
+                     Algo::Gemv::Unblocked>::invoke(member, -1, V_old, H_old, 1,
+                                                    W);
+      member.team_barrier();
+    }
+    if (handle.get_ortho_strategy() == 1) {
+      for (size_t i = 0; i < j + 1; ++i) {
+        auto V_i = Kokkos::subview(V_view, Kokkos::ALL, i, Kokkos::ALL);
+        TeamVectorDot<MemberType>::invoke(member, W, V_i, tmp);
+        member.team_barrier();
+        TeamVectorCopy1D::invoke(member, tmp,
+                                 Kokkos::subview(H_view, Kokkos::ALL, j, i));
+        member.team_barrier();
+        Kokkos::parallel_for(
+            Kokkos::TeamVectorRange(member, 0, numMatrices),
+            [&](const OrdinalType& ii) { tmp(ii) = -tmp(ii); });
+
+        member.team_barrier();  // Finish writing to tmp
+
+        TeamVectorAxpy<MemberType>::invoke(member, tmp, V_i, W);
+        member.team_barrier();  // Finish writing to W
+      }
+    }
+
+    member.team_barrier();  // Finish writing to W
+    TeamVectorDot<MemberType>::invoke(member, W, W, tmp);
+    member.team_barrier();
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
+                         [&](const OrdinalType& i) {
+                           H_view(i, j, j + 1) = ATM::sqrt(tmp(i));
+                           tmp(i) = H_view(i, j, j + 1) > max_tolerance
+                                        ? 1. / H_view(i, j, j + 1)
+                                        : 0.;
+                         });
+    member.team_barrier();
+    if (j + 1 < maximum_iteration) {
+      auto V_n = Kokkos::subview(V_view, Kokkos::ALL, j + 1, Kokkos::ALL);
+      Kokkos::parallel_for(
+          Kokkos::TeamVectorRange(member, 0, numMatrices * numRows),
+          [&](const OrdinalType& iTemp) {
+            OrdinalType iRow, iMatrix;
+            getIndices<OrdinalType, typename VectorViewType::array_layout>(
+                iTemp, numRows, numMatrices, iRow, iMatrix);
+            V_n(iMatrix, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
+          });
+      member.team_barrier();
+    }
+
+    Kokkos::parallel_for(
+        Kokkos::TeamVectorRange(member, 0, numMatrices),
+        [&](const OrdinalType& l) {
+          // Apply the previous Givens rotations:
+          auto H_j        = Kokkos::subview(H_view, l, j, Kokkos::ALL);
+          auto Givens_0_l = Kokkos::subview(Givens_view, l, Kokkos::ALL, 0);
+          auto Givens_1_l = Kokkos::subview(Givens_view, l, Kokkos::ALL, 1);
+
+          if (mask(l) == 1.) {
+            for (size_t i = 0; i < j; ++i) {
+              auto tmp1  = Givens_0_l(i) * H_j(i) + Givens_1_l(i) * H_j(i + 1);
+              auto tmp2  = -Givens_1_l(i) * H_j(i) + Givens_0_l(i) * H_j(i + 1);
+              H_j(i)     = tmp1;
+              H_j(i + 1) = tmp2;
+            }
+
+            // Compute the new Givens rotation:
+            Kokkos::pair<typename VectorViewType::non_const_value_type,
+                         typename VectorViewType::non_const_value_type>
+                G_new(1, 0);
+            typename VectorViewType::non_const_value_type alpha = 0;
+            SerialGivensInternal::invoke(H_j(j), H_j(j + 1), &G_new, &alpha);
+
+            Givens_0_l(j) = G_new.first;
+            Givens_1_l(j) = G_new.second;
+
+            // Apply the new Givens rotation:
+            auto tmp1  = Givens_0_l(j) * H_j(j) + Givens_1_l(j) * H_j(j + 1);
+            auto tmp2  = -Givens_1_l(j) * H_j(j) + Givens_0_l(j) * H_j(j + 1);
+            H_j(j)     = tmp1;
+            H_j(j + 1) = tmp2;
+
+            G(l, j + 1) = -Givens_1_l(j) * G(l, j);
+            G(l, j) *= Givens_0_l(j);
+          } else {
+            H_j(j)      = 1.;
+            G(l, j + 1) = 0.;
+          }
+
+          auto res_norm =
+              Kokkos::ArithTraits<double>::abs(G(l, j + 1)) / G(l, 0);
+
+          handle.set_norm(member.league_rank(), l, j + 1, res_norm);
+
+          if (mask(l) == 1. && res_norm < tolerance) {
+            mask(l)     = 0.;
+            G(l, j + 1) = 0.;
+            handle.set_iteration(member.league_rank(), l, j + 1);
+          }
+        });
+    member.team_barrier();
+
+    bool all_converged = true;
+    for (OrdinalType l = 0; l < numMatrices; ++l)
+      all_converged = (all_converged && mask(l) == 0.);
+    if (all_converged) {
+      maximum_iteration = j + 1;
+      break;
+    }
+  }
+
+  member.team_barrier();  // Finish writing to G
+
+  auto first_indices = Kokkos::make_pair(0, (int)maximum_iteration);
+
+  Kokkos::parallel_for(
+      Kokkos::TeamVectorRange(member, 0, numMatrices),
+      [&](const OrdinalType& l) {
+        auto A_l = Kokkos::subview(H_view, l, first_indices, first_indices);
+        auto B_l = Kokkos::subview(G, l, first_indices);
+
+        SerialTrsm<Side::Left, Uplo::Lower, Trans::Transpose, Diag::NonUnit,
+                   Algo::Trsm::Unblocked>::template invoke(1, A_l, B_l);
+      });
+
+  member.team_barrier();  // Finish writing to G
+
+  if (handle.get_ortho_strategy() == 0) {
+    TeamVectorGemv<MemberType, Trans::Transpose, Algo::Gemv::Unblocked>::invoke(
+        member, 1,
+        Kokkos::subview(V_view, Kokkos::ALL, first_indices, Kokkos::ALL),
+        Kokkos::subview(G, Kokkos::ALL, first_indices), 1, X);
+  }
+  if (handle.get_ortho_strategy() == 1) {
+    for (size_t j = 0; j < maximum_iteration; ++j) {
+      TeamVectorAxpy<MemberType>::invoke(
+          member, Kokkos::subview(G, Kokkos::ALL, j),
+          Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL), X);
+      member.team_barrier();  // Finish writing to X
+    }
+  }
+
+  member.team_barrier();  // Finish writing to X
+
+  TeamVectorCopy<MemberType>::invoke(member, X, _X);
+
+  member.team_barrier();
+
+  if (handle.get_compute_last_residual()) {
+    TeamVectorCopy<MemberType>::invoke(member, _B, W);
+    member.team_barrier();
+    A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, X, W, -1, 1);
+    member.team_barrier();
+    P.template apply<Trans::NoTranspose, Mode::TeamVector, 1>(member, W, W);
+    member.team_barrier();
     TeamVectorDot<MemberType>::invoke(member, W, W, tmp);
     member.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
                          [&](const OrdinalType& i) {
                            tmp(i) = ATM::sqrt(tmp(i));
-                           handle.set_norm(member.league_rank(), i, 0, tmp(i));
-                           if (tmp(i) > max_tolerance) {
-                             mask(i) = 1;
-                             G(i, 0) = tmp(i);
-                             tmp(i)  = 1. / tmp(i);
-                           } else {
-                             handle.set_iteration(member.league_rank(), i, 0);
-                             mask(i) = 0;
-                             G(i, 0) = 0.;
-                             tmp(i)  = 0.;
-                           }
+                           handle.set_last_norm(member.league_rank(), i,
+                                                tmp(i));
                          });
-
-    member.team_barrier();  // Finish writing to tmp
-
-    auto V_0 = Kokkos::subview(V_view, Kokkos::ALL, 0, Kokkos::ALL);
-    Kokkos::parallel_for(
-        Kokkos::TeamVectorRange(member, 0, numMatrices * numRows),
-        [&](const OrdinalType& iTemp) {
-          OrdinalType iRow, iMatrix;
-          getIndices<OrdinalType, typename VectorViewType::array_layout>(
-              iTemp, numRows, numMatrices, iRow, iMatrix);
-          V_0(iMatrix, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
-        });
-    int status = 1;
-    // int number_not_converged = 0;
-
-    for (size_t j = 0; j < maximum_iteration; ++j) {
-      member.team_barrier();  // Finish writing to V
-      // q := A p_j
-      auto V_j = Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL);
-
-      A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, V_j, W);
-      member.team_barrier();
-
-      P.template apply<Trans::NoTranspose, Mode::TeamVector, 1>(member, W, W);
-      member.team_barrier();
-
-      if (handle.get_ortho_strategy() == 0) {
-        auto V_old = Kokkos::subview(
-            V_view, Kokkos::ALL, Kokkos::make_pair(0, (int)j + 1), Kokkos::ALL);
-        auto H_old = Kokkos::subview(H_view, Kokkos::ALL, j,
-                                     Kokkos::make_pair(0, (int)j + 1));
-        member.team_barrier();
-        // Inner products
-        TeamVectorGemv<MemberType, Trans::NoTranspose,
-                       Algo::Gemv::Unblocked>::invoke(member, 1, V_old, W, 0,
-                                                      H_old);
-        member.team_barrier();
-
-        // Update
-        TeamVectorGemv<MemberType, Trans::Transpose,
-                       Algo::Gemv::Unblocked>::invoke(member, -1, V_old, H_old,
-                                                      1, W);
-        member.team_barrier();
-      }
-      if (handle.get_ortho_strategy() == 1) {
-        for (size_t i = 0; i < j + 1; ++i) {
-          auto V_i = Kokkos::subview(V_view, Kokkos::ALL, i, Kokkos::ALL);
-          TeamVectorDot<MemberType>::invoke(member, W, V_i, tmp);
-          member.team_barrier();
-          TeamVectorCopy1D::invoke(member, tmp,
-                                   Kokkos::subview(H_view, Kokkos::ALL, j, i));
-          member.team_barrier();
-          Kokkos::parallel_for(
-              Kokkos::TeamVectorRange(member, 0, numMatrices),
-              [&](const OrdinalType& ii) { tmp(ii) = -tmp(ii); });
-
-          member.team_barrier();  // Finish writing to tmp
-
-          TeamVectorAxpy<MemberType>::invoke(member, tmp, V_i, W);
-          member.team_barrier();  // Finish writing to W
-        }
-      }
-
-      member.team_barrier();  // Finish writing to W
-      TeamVectorDot<MemberType>::invoke(member, W, W, tmp);
-      member.team_barrier();
-      Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
-                           [&](const OrdinalType& i) {
-                             H_view(i, j, j + 1) = ATM::sqrt(tmp(i));
-                             tmp(i) = H_view(i, j, j + 1) > max_tolerance
-                                          ? 1. / H_view(i, j, j + 1)
-                                          : 0.;
-                           });
-      member.team_barrier();
-      if (j + 1 < maximum_iteration) {
-        auto V_n = Kokkos::subview(V_view, Kokkos::ALL, j + 1, Kokkos::ALL);
-        Kokkos::parallel_for(
-            Kokkos::TeamVectorRange(member, 0, numMatrices * numRows),
-            [&](const OrdinalType& iTemp) {
-              OrdinalType iRow, iMatrix;
-              getIndices<OrdinalType, typename VectorViewType::array_layout>(
-                  iTemp, numRows, numMatrices, iRow, iMatrix);
-              V_n(iMatrix, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
-            });
-        member.team_barrier();
-      }
-
-      Kokkos::parallel_for(
-          Kokkos::TeamVectorRange(member, 0, numMatrices),
-          [&](const OrdinalType& l) {
-            // Apply the previous Givens rotations:
-            auto H_j        = Kokkos::subview(H_view, l, j, Kokkos::ALL);
-            auto Givens_0_l = Kokkos::subview(Givens_view, l, Kokkos::ALL, 0);
-            auto Givens_1_l = Kokkos::subview(Givens_view, l, Kokkos::ALL, 1);
-
-            if (mask(l) == 1.) {
-              for (size_t i = 0; i < j; ++i) {
-                auto tmp1 = Givens_0_l(i) * H_j(i) + Givens_1_l(i) * H_j(i + 1);
-                auto tmp2 =
-                    -Givens_1_l(i) * H_j(i) + Givens_0_l(i) * H_j(i + 1);
-                H_j(i)     = tmp1;
-                H_j(i + 1) = tmp2;
-              }
-
-              // Compute the new Givens rotation:
-              Kokkos::pair<typename VectorViewType::non_const_value_type,
-                           typename VectorViewType::non_const_value_type>
-                  G_new(1, 0);
-              typename VectorViewType::non_const_value_type alpha = 0;
-              SerialGivensInternal::invoke(H_j(j), H_j(j + 1), &G_new, &alpha);
-
-              Givens_0_l(j) = G_new.first;
-              Givens_1_l(j) = G_new.second;
-
-              // Apply the new Givens rotation:
-              auto tmp1  = Givens_0_l(j) * H_j(j) + Givens_1_l(j) * H_j(j + 1);
-              auto tmp2  = -Givens_1_l(j) * H_j(j) + Givens_0_l(j) * H_j(j + 1);
-              H_j(j)     = tmp1;
-              H_j(j + 1) = tmp2;
-
-              G(l, j + 1) = -Givens_1_l(j) * G(l, j);
-              G(l, j) *= Givens_0_l(j);
-            } else {
-              H_j(j)      = 1.;
-              G(l, j + 1) = 0.;
-            }
-
-            auto res_norm =
-                Kokkos::ArithTraits<double>::abs(G(l, j + 1)) / G(l, 0);
-
-            handle.set_norm(member.league_rank(), l, j + 1, res_norm);
-
-            if (mask(l) == 1. && res_norm < tolerance) {
-              mask(l)     = 0.;
-              G(l, j + 1) = 0.;
-              handle.set_iteration(member.league_rank(), l, j + 1);
-            }
-          });
-      member.team_barrier();
-
-      bool all_converged = true;
-      for (OrdinalType l = 0; l < numMatrices; ++l)
-        all_converged = (all_converged && mask(l) == 0.);
-      if (all_converged) {
-        maximum_iteration = j + 1;
-        break;
-      }
-    }
-
-    member.team_barrier();  // Finish writing to G
-
-    Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
-                         [&](const OrdinalType& l) {
-                           for (size_t i = 0; i < maximum_iteration; ++i) {
-                             size_t row_i = maximum_iteration - 1 - i;
-                             for (size_t j = row_i + 1; j < maximum_iteration;
-                                  ++j)
-                               G(l, row_i) -= H_view(l, j, row_i) * G(l, j);
-                             G(l, row_i) /= H_view(l, row_i, row_i);
-                           }
-                         });
-
-    member.team_barrier();  // Finish writing to G
-
-    if (handle.get_ortho_strategy() == 0) {
-      TeamVectorGemv<MemberType, Trans::Transpose, Algo::Gemv::Unblocked>::
-          invoke(member, 1,
-                 Kokkos::subview(V_view, Kokkos::ALL,
-                                 Kokkos::make_pair(0, (int)maximum_iteration),
-                                 Kokkos::ALL),
-                 Kokkos::subview(G, Kokkos::ALL,
-                                 Kokkos::make_pair(0, (int)maximum_iteration)),
-                 1, X);
-    }
-    if (handle.get_ortho_strategy() == 1) {
-      for (size_t j = 0; j < maximum_iteration; ++j) {
-        TeamVectorAxpy<MemberType>::invoke(
-            member, Kokkos::subview(G, Kokkos::ALL, j),
-            Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL), X);
-        member.team_barrier();  // Finish writing to X
-      }
-    }
-
-    member.team_barrier();  // Finish writing to X
-
-    TeamVectorCopy<MemberType>::invoke(member, X, _X);
-
-    member.team_barrier();
-
-    if (handle.get_compute_last_residual()) {
-      TeamVectorCopy<MemberType>::invoke(member, _B, W);
-      member.team_barrier();
-      A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, X, W, -1,
-                                                             1);
-      member.team_barrier();
-      P.template apply<Trans::NoTranspose, Mode::TeamVector, 1>(member, W, W);
-      member.team_barrier();
-      TeamVectorDot<MemberType>::invoke(member, W, W, tmp);
-      member.team_barrier();
-
-      Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
-                           [&](const OrdinalType& i) {
-                             tmp(i) = ATM::sqrt(tmp(i));
-                             handle.set_last_norm(member.league_rank(), i,
-                                                  tmp(i));
-                           });
-    }
-    return status;
   }
+  return status;
+}
 
-  template <typename OperatorType, typename VectorViewType,
-            typename KrylovHandleType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
-                                           const OperatorType& A,
-                                           const VectorViewType& _B,
-                                           const VectorViewType& _X,
-                                           const KrylovHandleType& handle) {
-    Identity P;
-    return invoke<OperatorType, VectorViewType, Identity>(member, A, _B, _X, P,
-                                                          handle);
-  }
-};
+template <typename MemberType>
+template <typename OperatorType, typename VectorViewType,
+          typename KrylovHandleType>
+KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::template invoke(
+    const MemberType& member, const OperatorType& A, const VectorViewType& _B,
+    const VectorViewType& _X, const KrylovHandleType& handle) {
+  Identity P;
+  return invoke<OperatorType, VectorViewType, Identity>(member, A, _B, _X, P,
+                                                        handle);
+}
+
 }  // namespace KokkosBatched
 
 #endif

--- a/src/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
@@ -79,15 +79,8 @@ struct TeamVectorGMRES {
         typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
     typedef Kokkos::Details::ArithTraits<MagnitudeType> ATM;
 
-    using ScratchPadNormViewType = Kokkos::View<
-        MagnitudeType*,
-        typename VectorViewType::execution_space::scratch_memory_space>;
     using ScratchPadVectorViewType = Kokkos::View<
         typename VectorViewType::non_const_value_type**,
-        typename VectorViewType::array_layout,
-        typename VectorViewType::execution_space::scratch_memory_space>;
-    using ScratchPadMultiVectorViewType = Kokkos::View<
-        typename VectorViewType::non_const_value_type***,
         typename VectorViewType::array_layout,
         typename VectorViewType::execution_space::scratch_memory_space>;
     using TeamVectorCopy1D = TeamVectorCopy<MemberType, Trans::NoTranspose, 1>;

--- a/src/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
@@ -78,15 +78,8 @@ struct TeamGMRES {
         typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
     typedef Kokkos::Details::ArithTraits<MagnitudeType> ATM;
 
-    using ScratchPadNormViewType = Kokkos::View<
-        MagnitudeType*,
-        typename VectorViewType::execution_space::scratch_memory_space>;
     using ScratchPadVectorViewType = Kokkos::View<
         typename VectorViewType::non_const_value_type**,
-        typename VectorViewType::array_layout,
-        typename VectorViewType::execution_space::scratch_memory_space>;
-    using ScratchPadMultiVectorViewType = Kokkos::View<
-        typename VectorViewType::non_const_value_type***,
         typename VectorViewType::array_layout,
         typename VectorViewType::execution_space::scratch_memory_space>;
     using TeamCopy1D = TeamCopy<MemberType, Trans::NoTranspose, 1>;

--- a/src/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
@@ -66,7 +66,7 @@ namespace KokkosBatched {
 template <typename MemberType>
 template <typename OperatorType, typename VectorViewType,
           typename PrecOperatorType, typename KrylovHandleType>
-KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::template invoke(
+KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::invoke(
     const MemberType& member, const OperatorType& A, const VectorViewType& _B,
     const VectorViewType& _X, const PrecOperatorType& P,
     const KrylovHandleType& handle) {
@@ -323,7 +323,7 @@ KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::template invoke(
         auto B_l = Kokkos::subview(G, l, first_indices);
 
         SerialTrsm<Side::Left, Uplo::Lower, Trans::Transpose, Diag::NonUnit,
-                   Algo::Trsm::Unblocked>::template invoke(1, A_l, B_l);
+                   Algo::Trsm::Unblocked>::invoke(1, A_l, B_l);
       });
 
   member.team_barrier();  // Finish writing to G
@@ -372,7 +372,7 @@ KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::template invoke(
 template <typename MemberType>
 template <typename OperatorType, typename VectorViewType,
           typename KrylovHandleType>
-KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::template invoke(
+KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::invoke(
     const MemberType& member, const OperatorType& A, const VectorViewType& _B,
     const VectorViewType& _X, const KrylovHandleType& handle) {
   Identity P;

--- a/src/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
@@ -64,331 +64,322 @@ namespace KokkosBatched {
 ///
 
 template <typename MemberType>
-struct TeamGMRES {
-  template <typename OperatorType, typename VectorViewType,
-            typename PrecOperatorType, typename KrylovHandleType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
-                                           const OperatorType& A,
-                                           const VectorViewType& _B,
-                                           const VectorViewType& _X,
-                                           const PrecOperatorType& P,
-                                           const KrylovHandleType& handle) {
-    typedef int OrdinalType;
-    typedef typename Kokkos::Details::ArithTraits<
-        typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
-    typedef Kokkos::Details::ArithTraits<MagnitudeType> ATM;
+template <typename OperatorType, typename VectorViewType,
+          typename PrecOperatorType, typename KrylovHandleType>
+KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::template invoke(
+    const MemberType& member, const OperatorType& A, const VectorViewType& _B,
+    const VectorViewType& _X, const PrecOperatorType& P,
+    const KrylovHandleType& handle) {
+  typedef int OrdinalType;
+  typedef typename Kokkos::Details::ArithTraits<
+      typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
+  typedef Kokkos::Details::ArithTraits<MagnitudeType> ATM;
 
-    using ScratchPadVectorViewType = Kokkos::View<
-        typename VectorViewType::non_const_value_type**,
-        typename VectorViewType::array_layout,
-        typename VectorViewType::execution_space::scratch_memory_space>;
-    using TeamCopy1D = TeamCopy<MemberType, Trans::NoTranspose, 1>;
+  using ScratchPadVectorViewType = Kokkos::View<
+      typename VectorViewType::non_const_value_type**,
+      typename VectorViewType::array_layout,
+      typename VectorViewType::execution_space::scratch_memory_space>;
+  using TeamCopy1D = TeamCopy<MemberType, Trans::NoTranspose, 1>;
 
-    const OrdinalType numMatrices = _X.extent(0);
-    const OrdinalType numRows     = _X.extent(1);
+  const OrdinalType numMatrices = _X.extent(0);
+  const OrdinalType numRows     = _X.extent(1);
 
-    size_t maximum_iteration = handle.get_max_iteration() < numRows
-                                   ? handle.get_max_iteration()
-                                   : numRows;
-    const MagnitudeType tolerance     = handle.get_tolerance();
-    const MagnitudeType max_tolerance = handle.get_max_tolerance();
+  size_t maximum_iteration = handle.get_max_iteration() < numRows
+                                 ? handle.get_max_iteration()
+                                 : numRows;
+  const MagnitudeType tolerance     = handle.get_tolerance();
+  const MagnitudeType max_tolerance = handle.get_max_tolerance();
 
-    int n_V      = numRows;
-    int n_H      = maximum_iteration + 1;
-    int n_Givens = 2;
+  int n_V      = numRows;
+  int n_H      = maximum_iteration + 1;
+  int n_Givens = 2;
 
-    int offset_V      = 0;
-    int offset_H      = offset_V + n_V;
-    int offset_Givens = offset_H + n_H;
+  int offset_V      = 0;
+  int offset_H      = offset_V + n_V;
+  int offset_Givens = offset_H + n_H;
 
-    const int first_matrix = handle.first_index(member.league_rank());
-    const int last_matrix  = handle.last_index(member.league_rank());
+  const int first_matrix = handle.first_index(member.league_rank());
+  const int last_matrix  = handle.last_index(member.league_rank());
 
-    auto V_view = Kokkos::subview(
-        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
-        Kokkos::ALL, Kokkos::make_pair(offset_V, offset_V + n_V));
-    auto H_view = Kokkos::subview(
-        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
-        Kokkos::ALL, Kokkos::make_pair(offset_H, offset_H + n_H));
-    auto Givens_view = Kokkos::subview(
-        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
-        Kokkos::ALL,
-        Kokkos::make_pair(offset_Givens, offset_Givens + n_Givens));
+  auto V_view = Kokkos::subview(
+      handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+      Kokkos::ALL, Kokkos::make_pair(offset_V, offset_V + n_V));
+  auto H_view = Kokkos::subview(
+      handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+      Kokkos::ALL, Kokkos::make_pair(offset_H, offset_H + n_H));
+  auto Givens_view = Kokkos::subview(
+      handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+      Kokkos::ALL, Kokkos::make_pair(offset_Givens, offset_Givens + n_Givens));
 
-    int n_G    = maximum_iteration + 1;
-    int n_W    = numRows;
-    int n_X    = numRows;
-    int n_mask = 1;
-    int n_tmp  = 1;
+  int n_G    = maximum_iteration + 1;
+  int n_W    = numRows;
+  int n_X    = numRows;
+  int n_mask = 1;
+  int n_tmp  = 1;
 
-    int offset_G    = 0;
-    int offset_W    = offset_G + n_G;
-    int offset_X    = offset_W + n_W;
-    int offset_mask = offset_X + n_X;
-    int offset_tmp  = offset_mask + n_mask;
+  int offset_G    = 0;
+  int offset_W    = offset_G + n_G;
+  int offset_X    = offset_W + n_W;
+  int offset_mask = offset_X + n_X;
+  int offset_tmp  = offset_mask + n_mask;
 
-    ScratchPadVectorViewType tmp_2D(
-        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-        n_G + n_W + n_X + n_mask + n_tmp);
+  ScratchPadVectorViewType tmp_2D(
+      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+      n_G + n_W + n_X + n_mask + n_tmp);
 
-    auto G    = Kokkos::subview(tmp_2D, Kokkos::ALL,
-                             Kokkos::make_pair(offset_G, offset_G + n_G));
-    auto W    = Kokkos::subview(tmp_2D, Kokkos::ALL,
-                             Kokkos::make_pair(offset_W, offset_W + n_W));
-    auto X    = Kokkos::subview(tmp_2D, Kokkos::ALL,
-                             Kokkos::make_pair(offset_X, offset_X + n_X));
-    auto mask = Kokkos::subview(tmp_2D, Kokkos::ALL, offset_mask);
-    auto tmp  = Kokkos::subview(tmp_2D, Kokkos::ALL, offset_tmp);
+  auto G    = Kokkos::subview(tmp_2D, Kokkos::ALL,
+                           Kokkos::make_pair(offset_G, offset_G + n_G));
+  auto W    = Kokkos::subview(tmp_2D, Kokkos::ALL,
+                           Kokkos::make_pair(offset_W, offset_W + n_W));
+  auto X    = Kokkos::subview(tmp_2D, Kokkos::ALL,
+                           Kokkos::make_pair(offset_X, offset_X + n_X));
+  auto mask = Kokkos::subview(tmp_2D, Kokkos::ALL, offset_mask);
+  auto tmp  = Kokkos::subview(tmp_2D, Kokkos::ALL, offset_tmp);
 
-    TeamCopy<MemberType>::invoke(member, _X, X);
-    // Deep copy of b into r_0:
-    TeamCopy<MemberType>::invoke(member, _B, W);
+  TeamCopy<MemberType>::invoke(member, _X, X);
+  // Deep copy of b into r_0:
+  TeamCopy<MemberType>::invoke(member, _B, W);
 
-    // r_0 := b - A x_0
-    member.team_barrier();
-    A.template apply<Trans::NoTranspose, Mode::Team>(member, X, W, -1, 1);
+  // r_0 := b - A x_0
+  member.team_barrier();
+  A.template apply<Trans::NoTranspose, Mode::Team>(member, X, W, -1, 1);
+  member.team_barrier();
+
+  P.template apply<Trans::NoTranspose, Mode::Team, 1>(member, W, W);
+  member.team_barrier();
+
+  TeamDot<MemberType>::invoke(member, W, W, tmp);
+  member.team_barrier();
+
+  Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
+                       [&](const OrdinalType& i) {
+                         tmp(i) = ATM::sqrt(tmp(i));
+                         handle.set_norm(member.league_rank(), i, 0, tmp(i));
+                         if (tmp(i) > max_tolerance) {
+                           mask(i) = 1;
+                           G(i, 0) = tmp(i);
+                           tmp(i)  = 1. / tmp(i);
+                         } else {
+                           handle.set_iteration(member.league_rank(), i, 0);
+                           mask(i) = 0;
+                           G(i, 0) = 0.;
+                           tmp(i)  = 0.;
+                         }
+                       });
+
+  member.team_barrier();  // Finish writing to tmp
+
+  auto V_0 = Kokkos::subview(V_view, Kokkos::ALL, 0, Kokkos::ALL);
+  Kokkos::parallel_for(
+      Kokkos::TeamThreadRange(member, 0, numMatrices * numRows),
+      [&](const OrdinalType& iTemp) {
+        OrdinalType iRow, iMatrix;
+        getIndices<OrdinalType, typename VectorViewType::array_layout>(
+            iTemp, numRows, numMatrices, iRow, iMatrix);
+        V_0(iMatrix, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
+      });
+  int status = 1;
+  // int number_not_converged = 0;
+
+  for (size_t j = 0; j < maximum_iteration; ++j) {
+    member.team_barrier();  // Finish writing to V
+    // q := A p_j
+    auto V_j = Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL);
+
+    A.template apply<Trans::NoTranspose, Mode::Team>(member, V_j, W);
     member.team_barrier();
 
     P.template apply<Trans::NoTranspose, Mode::Team, 1>(member, W, W);
     member.team_barrier();
 
+    if (handle.get_ortho_strategy() == 0) {
+      auto V_old = Kokkos::subview(
+          V_view, Kokkos::ALL, Kokkos::make_pair(0, (int)j + 1), Kokkos::ALL);
+      auto H_old = Kokkos::subview(H_view, Kokkos::ALL, j,
+                                   Kokkos::make_pair(0, (int)j + 1));
+      member.team_barrier();
+      // Inner products
+      TeamGemv<MemberType, Trans::NoTranspose, Algo::Gemv::Unblocked>::invoke(
+          member, 1, V_old, W, 0, H_old);
+      member.team_barrier();
+
+      // Update
+      TeamGemv<MemberType, Trans::Transpose, Algo::Gemv::Unblocked>::invoke(
+          member, -1, V_old, H_old, 1, W);
+      member.team_barrier();
+    }
+    if (handle.get_ortho_strategy() == 1) {
+      for (size_t i = 0; i < j + 1; ++i) {
+        auto V_i = Kokkos::subview(V_view, Kokkos::ALL, i, Kokkos::ALL);
+        TeamDot<MemberType>::invoke(member, W, V_i, tmp);
+        member.team_barrier();
+        TeamCopy1D::invoke(member, tmp,
+                           Kokkos::subview(H_view, Kokkos::ALL, j, i));
+        member.team_barrier();
+        Kokkos::parallel_for(
+            Kokkos::TeamThreadRange(member, 0, numMatrices),
+            [&](const OrdinalType& ii) { tmp(ii) = -tmp(ii); });
+
+        member.team_barrier();  // Finish writing to tmp
+
+        TeamAxpy<MemberType>::invoke(member, tmp, V_i, W);
+        member.team_barrier();  // Finish writing to W
+      }
+    }
+
+    member.team_barrier();  // Finish writing to W
+    TeamDot<MemberType>::invoke(member, W, W, tmp);
+    member.team_barrier();
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
+                         [&](const OrdinalType& i) {
+                           H_view(i, j, j + 1) = ATM::sqrt(tmp(i));
+                           tmp(i) = H_view(i, j, j + 1) > max_tolerance
+                                        ? 1. / H_view(i, j, j + 1)
+                                        : 0.;
+                         });
+    member.team_barrier();
+    if (j + 1 < maximum_iteration) {
+      auto V_n = Kokkos::subview(V_view, Kokkos::ALL, j + 1, Kokkos::ALL);
+      Kokkos::parallel_for(
+          Kokkos::TeamThreadRange(member, 0, numMatrices * numRows),
+          [&](const OrdinalType& iTemp) {
+            OrdinalType iRow, iMatrix;
+            getIndices<OrdinalType, typename VectorViewType::array_layout>(
+                iTemp, numRows, numMatrices, iRow, iMatrix);
+            V_n(iMatrix, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
+          });
+      member.team_barrier();
+    }
+
+    Kokkos::parallel_for(
+        Kokkos::TeamThreadRange(member, 0, numMatrices),
+        [&](const OrdinalType& l) {
+          // Apply the previous Givens rotations:
+          auto H_j        = Kokkos::subview(H_view, l, j, Kokkos::ALL);
+          auto Givens_0_l = Kokkos::subview(Givens_view, l, Kokkos::ALL, 0);
+          auto Givens_1_l = Kokkos::subview(Givens_view, l, Kokkos::ALL, 1);
+
+          if (mask(l) == 1.) {
+            for (size_t i = 0; i < j; ++i) {
+              auto tmp1  = Givens_0_l(i) * H_j(i) + Givens_1_l(i) * H_j(i + 1);
+              auto tmp2  = -Givens_1_l(i) * H_j(i) + Givens_0_l(i) * H_j(i + 1);
+              H_j(i)     = tmp1;
+              H_j(i + 1) = tmp2;
+            }
+
+            // Compute the new Givens rotation:
+            Kokkos::pair<typename VectorViewType::non_const_value_type,
+                         typename VectorViewType::non_const_value_type>
+                G_new(1, 0);
+            typename VectorViewType::non_const_value_type alpha = 0;
+            SerialGivensInternal::invoke(H_j(j), H_j(j + 1), &G_new, &alpha);
+
+            Givens_0_l(j) = G_new.first;
+            Givens_1_l(j) = G_new.second;
+
+            // Apply the new Givens rotation:
+            auto tmp1  = Givens_0_l(j) * H_j(j) + Givens_1_l(j) * H_j(j + 1);
+            auto tmp2  = -Givens_1_l(j) * H_j(j) + Givens_0_l(j) * H_j(j + 1);
+            H_j(j)     = tmp1;
+            H_j(j + 1) = tmp2;
+
+            G(l, j + 1) = -Givens_1_l(j) * G(l, j);
+            G(l, j) *= Givens_0_l(j);
+          } else {
+            H_j(j)      = 1.;
+            G(l, j + 1) = 0.;
+          }
+
+          auto res_norm =
+              Kokkos::ArithTraits<double>::abs(G(l, j + 1)) / G(l, 0);
+
+          handle.set_norm(member.league_rank(), l, j + 1, res_norm);
+
+          if (mask(l) == 1. && res_norm < tolerance) {
+            mask(l)     = 0.;
+            G(l, j + 1) = 0.;
+            handle.set_iteration(member.league_rank(), l, j + 1);
+          }
+        });
+    member.team_barrier();
+
+    bool all_converged = true;
+    for (OrdinalType l = 0; l < numMatrices; ++l)
+      all_converged = (all_converged && mask(l) == 0.);
+    if (all_converged) {
+      maximum_iteration = j + 1;
+      break;
+    }
+  }
+
+  member.team_barrier();  // Finish writing to G
+
+  auto first_indices = Kokkos::make_pair(0, (int)maximum_iteration);
+
+  Kokkos::parallel_for(
+      Kokkos::TeamVectorRange(member, 0, numMatrices),
+      [&](const OrdinalType& l) {
+        auto A_l = Kokkos::subview(H_view, l, first_indices, first_indices);
+        auto B_l = Kokkos::subview(G, l, first_indices);
+
+        SerialTrsm<Side::Left, Uplo::Lower, Trans::Transpose, Diag::NonUnit,
+                   Algo::Trsm::Unblocked>::template invoke(1, A_l, B_l);
+      });
+
+  member.team_barrier();  // Finish writing to G
+
+  if (handle.get_ortho_strategy() == 0) {
+    TeamGemv<MemberType, Trans::Transpose, Algo::Gemv::Unblocked>::invoke(
+        member, 1,
+        Kokkos::subview(V_view, Kokkos::ALL, first_indices, Kokkos::ALL),
+        Kokkos::subview(G, Kokkos::ALL, first_indices), 1, X);
+  }
+  if (handle.get_ortho_strategy() == 1) {
+    for (size_t j = 0; j < maximum_iteration; ++j) {
+      TeamAxpy<MemberType>::invoke(
+          member, Kokkos::subview(G, Kokkos::ALL, j),
+          Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL), X);
+      member.team_barrier();  // Finish writing to X
+    }
+  }
+
+  member.team_barrier();  // Finish writing to X
+
+  TeamCopy<MemberType>::invoke(member, X, _X);
+
+  member.team_barrier();
+
+  if (handle.get_compute_last_residual()) {
+    TeamCopy<MemberType>::invoke(member, _B, W);
+    member.team_barrier();
+    A.template apply<Trans::NoTranspose, Mode::Team>(member, X, W, -1, 1);
+    member.team_barrier();
+    P.template apply<Trans::NoTranspose, Mode::Team, 1>(member, W, W);
+    member.team_barrier();
     TeamDot<MemberType>::invoke(member, W, W, tmp);
     member.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
                          [&](const OrdinalType& i) {
                            tmp(i) = ATM::sqrt(tmp(i));
-                           handle.set_norm(member.league_rank(), i, 0, tmp(i));
-                           if (tmp(i) > max_tolerance) {
-                             mask(i) = 1;
-                             G(i, 0) = tmp(i);
-                             tmp(i)  = 1. / tmp(i);
-                           } else {
-                             handle.set_iteration(member.league_rank(), i, 0);
-                             mask(i) = 0;
-                             G(i, 0) = 0.;
-                             tmp(i)  = 0.;
-                           }
+                           handle.set_last_norm(member.league_rank(), i,
+                                                tmp(i));
                          });
-
-    member.team_barrier();  // Finish writing to tmp
-
-    auto V_0 = Kokkos::subview(V_view, Kokkos::ALL, 0, Kokkos::ALL);
-    Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(member, 0, numMatrices * numRows),
-        [&](const OrdinalType& iTemp) {
-          OrdinalType iRow, iMatrix;
-          getIndices<OrdinalType, typename VectorViewType::array_layout>(
-              iTemp, numRows, numMatrices, iRow, iMatrix);
-          V_0(iMatrix, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
-        });
-    int status = 1;
-    // int number_not_converged = 0;
-
-    for (size_t j = 0; j < maximum_iteration; ++j) {
-      member.team_barrier();  // Finish writing to V
-      // q := A p_j
-      auto V_j = Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL);
-
-      A.template apply<Trans::NoTranspose, Mode::Team>(member, V_j, W);
-      member.team_barrier();
-
-      P.template apply<Trans::NoTranspose, Mode::Team, 1>(member, W, W);
-      member.team_barrier();
-
-      if (handle.get_ortho_strategy() == 0) {
-        auto V_old = Kokkos::subview(
-            V_view, Kokkos::ALL, Kokkos::make_pair(0, (int)j + 1), Kokkos::ALL);
-        auto H_old = Kokkos::subview(H_view, Kokkos::ALL, j,
-                                     Kokkos::make_pair(0, (int)j + 1));
-        member.team_barrier();
-        // Inner products
-        TeamGemv<MemberType, Trans::NoTranspose, Algo::Gemv::Unblocked>::invoke(
-            member, 1, V_old, W, 0, H_old);
-        member.team_barrier();
-
-        // Update
-        TeamGemv<MemberType, Trans::Transpose, Algo::Gemv::Unblocked>::invoke(
-            member, -1, V_old, H_old, 1, W);
-        member.team_barrier();
-      }
-      if (handle.get_ortho_strategy() == 1) {
-        for (size_t i = 0; i < j + 1; ++i) {
-          auto V_i = Kokkos::subview(V_view, Kokkos::ALL, i, Kokkos::ALL);
-          TeamDot<MemberType>::invoke(member, W, V_i, tmp);
-          member.team_barrier();
-          TeamCopy1D::invoke(member, tmp,
-                             Kokkos::subview(H_view, Kokkos::ALL, j, i));
-          member.team_barrier();
-          Kokkos::parallel_for(
-              Kokkos::TeamThreadRange(member, 0, numMatrices),
-              [&](const OrdinalType& ii) { tmp(ii) = -tmp(ii); });
-
-          member.team_barrier();  // Finish writing to tmp
-
-          TeamAxpy<MemberType>::invoke(member, tmp, V_i, W);
-          member.team_barrier();  // Finish writing to W
-        }
-      }
-
-      member.team_barrier();  // Finish writing to W
-      TeamDot<MemberType>::invoke(member, W, W, tmp);
-      member.team_barrier();
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
-                           [&](const OrdinalType& i) {
-                             H_view(i, j, j + 1) = ATM::sqrt(tmp(i));
-                             tmp(i) = H_view(i, j, j + 1) > max_tolerance
-                                          ? 1. / H_view(i, j, j + 1)
-                                          : 0.;
-                           });
-      member.team_barrier();
-      if (j + 1 < maximum_iteration) {
-        auto V_n = Kokkos::subview(V_view, Kokkos::ALL, j + 1, Kokkos::ALL);
-        Kokkos::parallel_for(
-            Kokkos::TeamThreadRange(member, 0, numMatrices * numRows),
-            [&](const OrdinalType& iTemp) {
-              OrdinalType iRow, iMatrix;
-              getIndices<OrdinalType, typename VectorViewType::array_layout>(
-                  iTemp, numRows, numMatrices, iRow, iMatrix);
-              V_n(iMatrix, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
-            });
-        member.team_barrier();
-      }
-
-      Kokkos::parallel_for(
-          Kokkos::TeamThreadRange(member, 0, numMatrices),
-          [&](const OrdinalType& l) {
-            // Apply the previous Givens rotations:
-            auto H_j        = Kokkos::subview(H_view, l, j, Kokkos::ALL);
-            auto Givens_0_l = Kokkos::subview(Givens_view, l, Kokkos::ALL, 0);
-            auto Givens_1_l = Kokkos::subview(Givens_view, l, Kokkos::ALL, 1);
-
-            if (mask(l) == 1.) {
-              for (size_t i = 0; i < j; ++i) {
-                auto tmp1 = Givens_0_l(i) * H_j(i) + Givens_1_l(i) * H_j(i + 1);
-                auto tmp2 =
-                    -Givens_1_l(i) * H_j(i) + Givens_0_l(i) * H_j(i + 1);
-                H_j(i)     = tmp1;
-                H_j(i + 1) = tmp2;
-              }
-
-              // Compute the new Givens rotation:
-              Kokkos::pair<typename VectorViewType::non_const_value_type,
-                           typename VectorViewType::non_const_value_type>
-                  G_new(1, 0);
-              typename VectorViewType::non_const_value_type alpha = 0;
-              SerialGivensInternal::invoke(H_j(j), H_j(j + 1), &G_new, &alpha);
-
-              Givens_0_l(j) = G_new.first;
-              Givens_1_l(j) = G_new.second;
-
-              // Apply the new Givens rotation:
-              auto tmp1  = Givens_0_l(j) * H_j(j) + Givens_1_l(j) * H_j(j + 1);
-              auto tmp2  = -Givens_1_l(j) * H_j(j) + Givens_0_l(j) * H_j(j + 1);
-              H_j(j)     = tmp1;
-              H_j(j + 1) = tmp2;
-
-              G(l, j + 1) = -Givens_1_l(j) * G(l, j);
-              G(l, j) *= Givens_0_l(j);
-            } else {
-              H_j(j)      = 1.;
-              G(l, j + 1) = 0.;
-            }
-
-            auto res_norm =
-                Kokkos::ArithTraits<double>::abs(G(l, j + 1)) / G(l, 0);
-
-            handle.set_norm(member.league_rank(), l, j + 1, res_norm);
-
-            if (mask(l) == 1. && res_norm < tolerance) {
-              mask(l)     = 0.;
-              G(l, j + 1) = 0.;
-              handle.set_iteration(member.league_rank(), l, j + 1);
-            }
-          });
-      member.team_barrier();
-
-      bool all_converged = true;
-      for (OrdinalType l = 0; l < numMatrices; ++l)
-        all_converged = (all_converged && mask(l) == 0.);
-      if (all_converged) {
-        maximum_iteration = j + 1;
-        break;
-      }
-    }
-
-    member.team_barrier();  // Finish writing to G
-
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
-                         [&](const OrdinalType& l) {
-                           for (size_t i = 0; i < maximum_iteration; ++i) {
-                             size_t row_i = maximum_iteration - 1 - i;
-                             for (size_t j = row_i + 1; j < maximum_iteration;
-                                  ++j)
-                               G(l, row_i) -= H_view(l, j, row_i) * G(l, j);
-                             G(l, row_i) /= H_view(l, row_i, row_i);
-                           }
-                         });
-
-    member.team_barrier();  // Finish writing to G
-
-    if (handle.get_ortho_strategy() == 0) {
-      TeamGemv<MemberType, Trans::Transpose, Algo::Gemv::Unblocked>::invoke(
-          member, 1,
-          Kokkos::subview(V_view, Kokkos::ALL,
-                          Kokkos::make_pair(0, (int)maximum_iteration),
-                          Kokkos::ALL),
-          Kokkos::subview(G, Kokkos::ALL,
-                          Kokkos::make_pair(0, (int)maximum_iteration)),
-          1, X);
-    }
-    if (handle.get_ortho_strategy() == 1) {
-      for (size_t j = 0; j < maximum_iteration; ++j) {
-        TeamAxpy<MemberType>::invoke(
-            member, Kokkos::subview(G, Kokkos::ALL, j),
-            Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL), X);
-        member.team_barrier();  // Finish writing to X
-      }
-    }
-
-    member.team_barrier();  // Finish writing to X
-
-    TeamCopy<MemberType>::invoke(member, X, _X);
-
-    member.team_barrier();
-
-    if (handle.get_compute_last_residual()) {
-      TeamCopy<MemberType>::invoke(member, _B, W);
-      member.team_barrier();
-      A.template apply<Trans::NoTranspose, Mode::Team>(member, X, W, -1, 1);
-      member.team_barrier();
-      P.template apply<Trans::NoTranspose, Mode::Team, 1>(member, W, W);
-      member.team_barrier();
-      TeamDot<MemberType>::invoke(member, W, W, tmp);
-      member.team_barrier();
-
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
-                           [&](const OrdinalType& i) {
-                             tmp(i) = ATM::sqrt(tmp(i));
-                             handle.set_last_norm(member.league_rank(), i,
-                                                  tmp(i));
-                           });
-    }
-    return status;
   }
+  return status;
+}
 
-  template <typename OperatorType, typename VectorViewType,
-            typename KrylovHandleType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
-                                           const OperatorType& A,
-                                           const VectorViewType& _B,
-                                           const VectorViewType& _X,
-                                           const KrylovHandleType& handle) {
-    Identity P;
-    return invoke<OperatorType, VectorViewType, Identity>(member, A, _B, _X, P,
-                                                          handle);
-  }
-};
+template <typename MemberType>
+template <typename OperatorType, typename VectorViewType,
+          typename KrylovHandleType>
+KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::template invoke(
+    const MemberType& member, const OperatorType& A, const VectorViewType& _B,
+    const VectorViewType& _X, const KrylovHandleType& handle) {
+  Identity P;
+  return invoke<OperatorType, VectorViewType, Identity>(member, A, _B, _X, P,
+                                                        handle);
+}
+
 }  // namespace KokkosBatched
 
 #endif

--- a/src/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
+++ b/src/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
@@ -54,6 +54,7 @@
 #include "KokkosBatched_Givens_Serial_Internal.hpp"
 #include "KokkosBatched_Trsm_Decl.hpp"
 #include "KokkosBatched_Identity.hpp"
+#include "KokkosBatched_Gemv_Decl.hpp"
 
 namespace KokkosBatched {
 
@@ -65,12 +66,13 @@ namespace KokkosBatched {
 template <typename MemberType>
 struct TeamGMRES {
   template <typename OperatorType, typename VectorViewType,
-            typename PrecOperatorType>
-  KOKKOS_INLINE_FUNCTION static int invoke(
-      const MemberType& member, const OperatorType& A, const VectorViewType& _B,
-      const VectorViewType& _X, const PrecOperatorType& P,
-      const KrylovHandle<typename VectorViewType::non_const_value_type>&
-          handle) {
+            typename PrecOperatorType, typename KrylovHandleType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
+                                           const OperatorType& A,
+                                           const VectorViewType& _B,
+                                           const VectorViewType& _X,
+                                           const PrecOperatorType& P,
+                                           const KrylovHandleType& handle) {
     typedef int OrdinalType;
     typedef typename Kokkos::Details::ArithTraits<
         typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
@@ -96,130 +98,183 @@ struct TeamGMRES {
                                    ? handle.get_max_iteration()
                                    : numRows;
     const MagnitudeType tolerance     = handle.get_tolerance();
-    const MagnitudeType max_tolerance = 0.;
+    const MagnitudeType max_tolerance = handle.get_max_tolerance();
 
-    ScratchPadMultiVectorViewType V(member.team_scratch(1), numMatrices,
-                                    maximum_iteration + 1, numRows);
-    ScratchPadMultiVectorViewType H(member.team_scratch(1), numMatrices,
-                                    maximum_iteration + 1, maximum_iteration);
-    ScratchPadMultiVectorViewType Givens(member.team_scratch(1), numMatrices,
-                                         maximum_iteration, 2);
-    ScratchPadVectorViewType G(member.team_scratch(1), numMatrices,
-                               maximum_iteration + 1);
+    int n_V      = numRows;
+    int n_H      = maximum_iteration + 1;
+    int n_Givens = 2;
 
-    ScratchPadVectorViewType W(member.team_scratch(0), numMatrices, numRows);
-    ScratchPadVectorViewType Q(member.team_scratch(0), numMatrices, numRows);
-    ScratchPadVectorViewType R(member.team_scratch(0), numMatrices, numRows);
-    ScratchPadVectorViewType X(member.team_scratch(0), numMatrices, numRows);
+    int offset_V      = 0;
+    int offset_H      = offset_V + n_V;
+    int offset_Givens = offset_H + n_H;
 
-    ScratchPadNormViewType beta(member.team_scratch(0), numMatrices);
-    ScratchPadNormViewType mask(member.team_scratch(0), numMatrices);
-    ScratchPadNormViewType tmp(member.team_scratch(0), numMatrices);
+    const int first_matrix = handle.first_index(member.league_rank());
+    const int last_matrix  = handle.last_index(member.league_rank());
+
+    auto V_view = Kokkos::subview(
+        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+        Kokkos::ALL, Kokkos::make_pair(offset_V, offset_V + n_V));
+    auto H_view = Kokkos::subview(
+        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+        Kokkos::ALL, Kokkos::make_pair(offset_H, offset_H + n_H));
+    auto Givens_view = Kokkos::subview(
+        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+        Kokkos::ALL,
+        Kokkos::make_pair(offset_Givens, offset_Givens + n_Givens));
+
+    int n_G    = maximum_iteration + 1;
+    int n_W    = numRows;
+    int n_X    = numRows;
+    int n_mask = 1;
+    int n_tmp  = 1;
+
+    int offset_G    = 0;
+    int offset_W    = offset_G + n_G;
+    int offset_X    = offset_W + n_W;
+    int offset_mask = offset_X + n_X;
+    int offset_tmp  = offset_mask + n_mask;
+
+    ScratchPadVectorViewType tmp_2D(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+        n_G + n_W + n_X + n_mask + n_tmp);
+
+    auto G    = Kokkos::subview(tmp_2D, Kokkos::ALL,
+                             Kokkos::make_pair(offset_G, offset_G + n_G));
+    auto W    = Kokkos::subview(tmp_2D, Kokkos::ALL,
+                             Kokkos::make_pair(offset_W, offset_W + n_W));
+    auto X    = Kokkos::subview(tmp_2D, Kokkos::ALL,
+                             Kokkos::make_pair(offset_X, offset_X + n_X));
+    auto mask = Kokkos::subview(tmp_2D, Kokkos::ALL, offset_mask);
+    auto tmp  = Kokkos::subview(tmp_2D, Kokkos::ALL, offset_tmp);
 
     TeamCopy<MemberType>::invoke(member, _X, X);
     // Deep copy of b into r_0:
-    TeamCopy<MemberType>::invoke(member, _B, R);
-
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
-                         [&](const OrdinalType& i) { mask(i) = 1.; });
+    TeamCopy<MemberType>::invoke(member, _B, W);
 
     // r_0 := b - A x_0
     member.team_barrier();
-    A.template apply<MemberType, ScratchPadVectorViewType,
-                     ScratchPadVectorViewType, Trans::NoTranspose, Mode::Team>(
-        member, X, R, -1, 1);
+    A.template apply<Trans::NoTranspose, Mode::Team>(member, X, W, -1, 1);
     member.team_barrier();
 
-    P.template apply<MemberType, ScratchPadVectorViewType,
-                     ScratchPadVectorViewType, Trans::NoTranspose, Mode::Team,
-                     1>(member, R, R);
+    P.template apply<Trans::NoTranspose, Mode::Team, 1>(member, W, W);
     member.team_barrier();
 
-    TeamDot<MemberType>::invoke(member, R, R, beta);
+    TeamDot<MemberType>::invoke(member, W, W, tmp);
     member.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
                          [&](const OrdinalType& i) {
-                           beta(i) = ATM::sqrt(beta(i));
-                           G(i, 0) = beta(i) > max_tolerance ? beta(i) : 0.;
-                           tmp(i) = beta(i) > max_tolerance ? 1. / beta(i) : 0.;
+                           tmp(i) = ATM::sqrt(tmp(i));
+                           handle.set_norm(member.league_rank(), i, 0, tmp(i));
+                           if (tmp(i) > max_tolerance) {
+                             mask(i) = 1;
+                             G(i, 0) = tmp(i);
+                             tmp(i)  = 1. / tmp(i);
+                           } else {
+                             handle.set_iteration(member.league_rank(), i, 0);
+                             mask(i) = 0;
+                             G(i, 0) = 0.;
+                             tmp(i)  = 0.;
+                           }
                          });
 
     member.team_barrier();  // Finish writing to tmp
 
+    auto V_0 = Kokkos::subview(V_view, Kokkos::ALL, 0, Kokkos::ALL);
     Kokkos::parallel_for(
         Kokkos::TeamThreadRange(member, 0, numMatrices * numRows),
         [&](const OrdinalType& iTemp) {
           OrdinalType iRow, iMatrix;
           getIndices<OrdinalType, typename VectorViewType::array_layout>(
               iTemp, numRows, numMatrices, iRow, iMatrix);
-          V(iMatrix, 0, iRow) = R(iMatrix, iRow) * tmp(iMatrix);
+          V_0(iMatrix, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
         });
-
     int status = 1;
     // int number_not_converged = 0;
 
     for (size_t j = 0; j < maximum_iteration; ++j) {
       member.team_barrier();  // Finish writing to V
       // q := A p_j
-      auto V_j = Kokkos::subview(V, Kokkos::ALL, j, Kokkos::ALL);
+      auto V_j = Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL);
 
-      A.template apply<MemberType, ScratchPadVectorViewType,
-                       ScratchPadVectorViewType, Trans::NoTranspose,
-                       Mode::Team>(member, V_j, W);
+      A.template apply<Trans::NoTranspose, Mode::Team>(member, V_j, W);
       member.team_barrier();
-      P.template apply<MemberType, ScratchPadVectorViewType,
-                       ScratchPadVectorViewType, Trans::NoTranspose, Mode::Team,
-                       1>(member, W, W);
 
-      for (size_t i = 0; i < j + 1; ++i) {
-        member.team_barrier();  // Finish writing to W
-        auto V_i = Kokkos::subview(V, Kokkos::ALL, i, Kokkos::ALL);
-        TeamDot<MemberType>::invoke(member, W, V_i, tmp);
+      P.template apply<Trans::NoTranspose, Mode::Team, 1>(member, W, W);
+      member.team_barrier();
+
+      if (handle.get_ortho_strategy() == 0) {
+        auto V_old = Kokkos::subview(
+            V_view, Kokkos::ALL, Kokkos::make_pair(0, (int)j + 1), Kokkos::ALL);
+        auto H_old = Kokkos::subview(H_view, Kokkos::ALL, j,
+                                     Kokkos::make_pair(0, (int)j + 1));
         member.team_barrier();
-        TeamCopy1D::invoke(member, tmp, Kokkos::subview(H, Kokkos::ALL, i, j));
-        member.team_barrier();  // Don't start modifying tmp until copy above
-                                // finishes
-        Kokkos::parallel_for(
-            Kokkos::TeamThreadRange(member, 0, numMatrices),
-            [&](const OrdinalType& ii) { tmp(ii) = -tmp(ii); });
+        // Inner products
+        TeamGemv<MemberType, Trans::NoTranspose, Algo::Gemv::Unblocked>::invoke(
+            member, 1, V_old, W, 0, H_old);
+        member.team_barrier();
 
-        member.team_barrier();  // Finish writing to tmp
+        // Update
+        TeamGemv<MemberType, Trans::Transpose, Algo::Gemv::Unblocked>::invoke(
+            member, -1, V_old, H_old, 1, W);
+        member.team_barrier();
+      }
+      if (handle.get_ortho_strategy() == 1) {
+        for (size_t i = 0; i < j + 1; ++i) {
+          auto V_i = Kokkos::subview(V_view, Kokkos::ALL, i, Kokkos::ALL);
+          TeamDot<MemberType>::invoke(member, W, V_i, tmp);
+          member.team_barrier();
+          TeamCopy1D::invoke(member, tmp,
+                             Kokkos::subview(H_view, Kokkos::ALL, j, i));
+          member.team_barrier();
+          Kokkos::parallel_for(
+              Kokkos::TeamThreadRange(member, 0, numMatrices),
+              [&](const OrdinalType& ii) { tmp(ii) = -tmp(ii); });
 
-        TeamAxpy<MemberType>::invoke(member, tmp, V_i, W);
+          member.team_barrier();  // Finish writing to tmp
+
+          TeamAxpy<MemberType>::invoke(member, tmp, V_i, W);
+          member.team_barrier();  // Finish writing to W
+        }
       }
 
       member.team_barrier();  // Finish writing to W
       TeamDot<MemberType>::invoke(member, W, W, tmp);
       member.team_barrier();
-      Kokkos::parallel_for(
-          Kokkos::TeamThreadRange(member, 0, numMatrices),
-          [&](const OrdinalType& i) {
-            H(i, j + 1, j) = ATM::sqrt(tmp(i));
-            tmp(i) = H(i, j + 1, j) > max_tolerance ? 1. / H(i, j + 1, j) : 0.;
-          });
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
+                           [&](const OrdinalType& i) {
+                             H_view(i, j, j + 1) = ATM::sqrt(tmp(i));
+                             tmp(i) = H_view(i, j, j + 1) > max_tolerance
+                                          ? 1. / H_view(i, j, j + 1)
+                                          : 0.;
+                           });
       member.team_barrier();
-      Kokkos::parallel_for(
-          Kokkos::TeamThreadRange(member, 0, numMatrices * numRows),
-          [&](const OrdinalType& iTemp) {
-            OrdinalType iRow, iMatrix;
-            getIndices<OrdinalType, typename VectorViewType::array_layout>(
-                iTemp, numRows, numMatrices, iRow, iMatrix);
-            V(iMatrix, j + 1, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
-          });
+      if (j + 1 < maximum_iteration) {
+        auto V_n = Kokkos::subview(V_view, Kokkos::ALL, j + 1, Kokkos::ALL);
+        Kokkos::parallel_for(
+            Kokkos::TeamThreadRange(member, 0, numMatrices * numRows),
+            [&](const OrdinalType& iTemp) {
+              OrdinalType iRow, iMatrix;
+              getIndices<OrdinalType, typename VectorViewType::array_layout>(
+                  iTemp, numRows, numMatrices, iRow, iMatrix);
+              V_n(iMatrix, iRow) = W(iMatrix, iRow) * tmp(iMatrix);
+            });
+        member.team_barrier();
+      }
 
       Kokkos::parallel_for(
           Kokkos::TeamThreadRange(member, 0, numMatrices),
           [&](const OrdinalType& l) {
             // Apply the previous Givens rotations:
-            auto H_j = Kokkos::subview(H, l, Kokkos::ALL, j);
+            auto H_j        = Kokkos::subview(H_view, l, j, Kokkos::ALL);
+            auto Givens_0_l = Kokkos::subview(Givens_view, l, Kokkos::ALL, 0);
+            auto Givens_1_l = Kokkos::subview(Givens_view, l, Kokkos::ALL, 1);
 
             if (mask(l) == 1.) {
               for (size_t i = 0; i < j; ++i) {
-                auto tmp1 =
-                    Givens(l, i, 0) * H_j(i) + Givens(l, i, 1) * H_j(i + 1);
+                auto tmp1 = Givens_0_l(i) * H_j(i) + Givens_1_l(i) * H_j(i + 1);
                 auto tmp2 =
-                    -Givens(l, i, 1) * H_j(i) + Givens(l, i, 0) * H_j(i + 1);
+                    -Givens_1_l(i) * H_j(i) + Givens_0_l(i) * H_j(i + 1);
                 H_j(i)     = tmp1;
                 H_j(i + 1) = tmp2;
               }
@@ -231,68 +286,111 @@ struct TeamGMRES {
               typename VectorViewType::non_const_value_type alpha = 0;
               SerialGivensInternal::invoke(H_j(j), H_j(j + 1), &G_new, &alpha);
 
-              Givens(l, j, 0) = G_new.first;
-              Givens(l, j, 1) = G_new.second;
+              Givens_0_l(j) = G_new.first;
+              Givens_1_l(j) = G_new.second;
 
               // Apply the new Givens rotation:
-              auto tmp1 =
-                  Givens(l, j, 0) * H_j(j) + Givens(l, j, 1) * H_j(j + 1);
-              auto tmp2 =
-                  -Givens(l, j, 1) * H_j(j) + Givens(l, j, 0) * H_j(j + 1);
+              auto tmp1  = Givens_0_l(j) * H_j(j) + Givens_1_l(j) * H_j(j + 1);
+              auto tmp2  = -Givens_1_l(j) * H_j(j) + Givens_0_l(j) * H_j(j + 1);
               H_j(j)     = tmp1;
               H_j(j + 1) = tmp2;
 
-              G(l, j + 1) = -Givens(l, j, 1) * G(l, j);
-              G(l, j) *= Givens(l, j, 0);
+              G(l, j + 1) = -Givens_1_l(j) * G(l, j);
+              G(l, j) *= Givens_0_l(j);
             } else {
               H_j(j)      = 1.;
               G(l, j + 1) = 0.;
             }
 
-            if (mask(l) == 1. &&
-                Kokkos::ArithTraits<double>::abs(G(l, j + 1)) / beta(l) <
-                    tolerance) {
+            auto res_norm =
+                Kokkos::ArithTraits<double>::abs(G(l, j + 1)) / G(l, 0);
+
+            handle.set_norm(member.league_rank(), l, j + 1, res_norm);
+
+            if (mask(l) == 1. && res_norm < tolerance) {
               mask(l)     = 0.;
               G(l, j + 1) = 0.;
+              handle.set_iteration(member.league_rank(), l, j + 1);
             }
           });
+      member.team_barrier();
+
+      bool all_converged = true;
+      for (OrdinalType l = 0; l < numMatrices; ++l)
+        all_converged = (all_converged && mask(l) == 0.);
+      if (all_converged) {
+        maximum_iteration = j + 1;
+        break;
+      }
     }
 
     member.team_barrier();  // Finish writing to G
 
-    Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(member, 0, numMatrices),
-        [&](const OrdinalType& l) {
-          SerialTrsm<Side::Left, Uplo::Upper, Trans::NoTranspose, Diag::NonUnit,
-                     Algo::Trsm::Unblocked>::template invoke(1,
-                                                             Kokkos::subview(
-                                                                 H, l,
-                                                                 Kokkos::ALL,
-                                                                 Kokkos::ALL),
-                                                             Kokkos::subview(
-                                                                 G, l,
-                                                                 Kokkos::ALL));
-        });
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
+                         [&](const OrdinalType& l) {
+                           for (size_t i = 0; i < maximum_iteration; ++i) {
+                             size_t row_i = maximum_iteration - 1 - i;
+                             for (size_t j = row_i + 1; j < maximum_iteration;
+                                  ++j)
+                               G(l, row_i) -= H_view(l, j, row_i) * G(l, j);
+                             G(l, row_i) /= H_view(l, row_i, row_i);
+                           }
+                         });
 
     member.team_barrier();  // Finish writing to G
 
-    for (size_t j = 0; j < maximum_iteration; ++j) {
-      TeamAxpy<MemberType>::invoke(
-          member, Kokkos::subview(G, Kokkos::ALL, j),
-          Kokkos::subview(V, Kokkos::ALL, j, Kokkos::ALL), X);
-      member.team_barrier();  // Finish writing to X
+    if (handle.get_ortho_strategy() == 0) {
+      TeamGemv<MemberType, Trans::Transpose, Algo::Gemv::Unblocked>::invoke(
+          member, 1,
+          Kokkos::subview(V_view, Kokkos::ALL,
+                          Kokkos::make_pair(0, (int)maximum_iteration),
+                          Kokkos::ALL),
+          Kokkos::subview(G, Kokkos::ALL,
+                          Kokkos::make_pair(0, (int)maximum_iteration)),
+          1, X);
     }
+    if (handle.get_ortho_strategy() == 1) {
+      for (size_t j = 0; j < maximum_iteration; ++j) {
+        TeamAxpy<MemberType>::invoke(
+            member, Kokkos::subview(G, Kokkos::ALL, j),
+            Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL), X);
+        member.team_barrier();  // Finish writing to X
+      }
+    }
+
+    member.team_barrier();  // Finish writing to X
 
     TeamCopy<MemberType>::invoke(member, X, _X);
+
+    member.team_barrier();
+
+    if (handle.get_compute_last_residual()) {
+      TeamCopy<MemberType>::invoke(member, _B, W);
+      member.team_barrier();
+      A.template apply<Trans::NoTranspose, Mode::Team>(member, X, W, -1, 1);
+      member.team_barrier();
+      P.template apply<Trans::NoTranspose, Mode::Team, 1>(member, W, W);
+      member.team_barrier();
+      TeamDot<MemberType>::invoke(member, W, W, tmp);
+      member.team_barrier();
+
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
+                           [&](const OrdinalType& i) {
+                             tmp(i) = ATM::sqrt(tmp(i));
+                             handle.set_last_norm(member.league_rank(), i,
+                                                  tmp(i));
+                           });
+    }
     return status;
   }
 
-  template <typename OperatorType, typename VectorViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(
-      const MemberType& member, const OperatorType& A, const VectorViewType& _B,
-      const VectorViewType& _X,
-      const KrylovHandle<typename VectorViewType::non_const_value_type>&
-          handle) {
+  template <typename OperatorType, typename VectorViewType,
+            typename KrylovHandleType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
+                                           const OperatorType& A,
+                                           const VectorViewType& _B,
+                                           const VectorViewType& _X,
+                                           const KrylovHandleType& handle) {
     Identity P;
     return invoke<OperatorType, VectorViewType, Identity>(member, A, _B, _X, P,
                                                           handle);

--- a/src/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
@@ -1141,8 +1141,7 @@ struct UpperTriSupernodalFunctor {
         KokkosBatched::TeamTrsm<
             member_type, KokkosBatched::Side::Left, KokkosBatched::Uplo::Lower,
             KokkosBatched::Trans::Transpose, KokkosBatched::Diag::NonUnit,
-            KokkosBatched::Algo::Trsm::Unblocked>::template invoke(team, one,
-                                                                   Ujj, Xjj);
+            KokkosBatched::Algo::Trsm::Unblocked>::invoke(team, one, Ujj, Xjj);
       }
       team.team_barrier();
     }

--- a/unit_test/batched/sparse/Test_Batched_SerialGMRES.hpp
+++ b/unit_test/batched/sparse/Test_Batched_SerialGMRES.hpp
@@ -36,8 +36,8 @@ struct Functor_TestBatchedSerialGMRES {
         _c(c),
         _X(X),
         _B(B),
-        _N_team(N_team),
         _Diag(diag),
+        _N_team(N_team),
         _handle(handle) {}
 
   KOKKOS_INLINE_FUNCTION void operator()(const int k) const {

--- a/unit_test/batched/sparse/Test_Batched_SerialGMRES_Real.hpp
+++ b/unit_test/batched/sparse/Test_Batched_SerialGMRES_Real.hpp
@@ -1,0 +1,12 @@
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+TEST_F(TestCategory, batched_scalar_serial_GMRES_float) {
+  test_batched_serial_GMRES<TestExecSpace, float>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+TEST_F(TestCategory, batched_scalar_serial_GMRES_double) {
+  test_batched_serial_GMRES<TestExecSpace, double>();
+}
+#endif

--- a/unit_test/batched/sparse/Test_Batched_Sparse.hpp
+++ b/unit_test/batched/sparse/Test_Batched_Sparse.hpp
@@ -2,6 +2,8 @@
 #define TEST_BATCHED_SPARSE_HPP
 
 // Serial kernels
+#include "Test_Batched_SerialGMRES.hpp"
+#include "Test_Batched_SerialGMRES_Real.hpp"
 #include "Test_Batched_SerialSpmv.hpp"
 #include "Test_Batched_SerialSpmv_Real.hpp"
 

--- a/unit_test/batched/sparse/Test_Batched_TeamCG.hpp
+++ b/unit_test/batched/sparse/Test_Batched_TeamCG.hpp
@@ -14,7 +14,7 @@ namespace Test {
 namespace TeamCG {
 
 template <typename DeviceType, typename ValuesViewType, typename IntView,
-          typename VectorViewType>
+          typename VectorViewType, typename KrylovHandleType>
 struct Functor_TestBatchedTeamCG {
   const ValuesViewType _D;
   const IntView _r;
@@ -22,13 +22,18 @@ struct Functor_TestBatchedTeamCG {
   const VectorViewType _X;
   const VectorViewType _B;
   const int _N_team;
-  KrylovHandle<typename ValuesViewType::value_type> handle;
+  KrylovHandleType handle;
 
-  KOKKOS_INLINE_FUNCTION
   Functor_TestBatchedTeamCG(const ValuesViewType &D, const IntView &r,
                             const IntView &c, const VectorViewType &X,
                             const VectorViewType &B, const int N_team)
-      : _D(D), _r(r), _c(c), _X(X), _B(B), _N_team(N_team) {}
+      : _D(D),
+        _r(r),
+        _c(c),
+        _X(X),
+        _B(B),
+        _N_team(N_team),
+        handle(KrylovHandleType(_D.extent(0), _N_team)) {}
 
   template <typename MemberType>
   KOKKOS_INLINE_FUNCTION void operator()(const MemberType &member) const {
@@ -50,9 +55,7 @@ struct Functor_TestBatchedTeamCG {
 
     Operator A(d, _r, _c);
 
-    KokkosBatched::TeamCG<MemberType>::template invoke<Operator,
-                                                       VectorViewType>(
-        member, A, b, x, handle);
+    KokkosBatched::TeamCG<MemberType>::invoke(member, A, b, x, handle);
   }
 
   inline void run() {
@@ -96,6 +99,13 @@ void impl_test_batched_CG(const int N, const int BlkSize, const int N_team) {
       typename Kokkos::Details::ArithTraits<ScalarType>::mag_type;
   using NormViewType = Kokkos::View<MagnitudeType *, Layout, EXSP>;
 
+  using Norm2DViewType   = Kokkos::View<MagnitudeType **, Layout, EXSP>;
+  using Scalar3DViewType = Kokkos::View<ScalarType ***, Layout, EXSP>;
+  using IntViewType      = Kokkos::View<int *, Layout, EXSP>;
+
+  using KrylovHandleType =
+      KrylovHandle<Norm2DViewType, IntViewType, Scalar3DViewType>;
+
   NormViewType sqr_norm_0("sqr_norm_0", N);
   NormViewType sqr_norm_j("sqr_norm_j", N);
 
@@ -127,8 +137,8 @@ void impl_test_batched_CG(const int N, const int BlkSize, const int N_team) {
       1>(-1, D_host, r_host, c_host, X_host, 1, R_host);
   KokkosBatched::SerialDot<Trans::NoTranspose>::invoke(R_host, R_host,
                                                        sqr_norm_0_host);
-  Functor_TestBatchedTeamCG<DeviceType, ValuesViewType, IntView,
-                            VectorViewType>(D, r, c, X, B, N_team)
+  Functor_TestBatchedTeamCG<DeviceType, ValuesViewType, IntView, VectorViewType,
+                            KrylovHandleType>(D, r, c, X, B, N_team)
       .run();
 
   Kokkos::fence();

--- a/unit_test/batched/sparse/Test_Batched_TeamGMRES.hpp
+++ b/unit_test/batched/sparse/Test_Batched_TeamGMRES.hpp
@@ -36,8 +36,8 @@ struct Functor_TestBatchedTeamGMRES {
         _c(c),
         _X(X),
         _B(B),
-        _N_team(N_team),
         _Diag(diag),
+        _N_team(N_team),
         _handle(handle) {}
 
   template <typename MemberType>
@@ -83,9 +83,6 @@ struct Functor_TestBatchedTeamGMRES {
     const int n                 = _X.extent(1);
     const int maximum_iteration = _handle.get_max_iteration();
 
-    size_t bytes_0 = ValuesViewType::shmem_size(_N_team, n);
-    size_t bytes_1 = ValuesViewType::shmem_size(_N_team, 1);
-
     _handle.set_ortho_strategy(0);
     _handle.set_compute_last_residual(false);
     _handle.set_tolerance(1e-8);
@@ -111,8 +108,6 @@ struct Functor_TestBatchedTeamGMRES {
     size_t bytes_tmp  = 2 * bytes_2D_1 + 2 * bytes_1D + bytes_2D_2;
     policy.set_scratch_size(
         0, Kokkos::PerTeam(bytes_tmp + bytes_diag + bytes_int));
-
-    // policy.set_scratch_size(0, Kokkos::PerTeam(5 * bytes_0 + 5 * bytes_1));
 
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();

--- a/unit_test/batched/sparse/Test_Batched_TeamVectorCG.hpp
+++ b/unit_test/batched/sparse/Test_Batched_TeamVectorCG.hpp
@@ -14,7 +14,7 @@ namespace Test {
 namespace TeamVectorCG {
 
 template <typename DeviceType, typename ValuesViewType, typename IntView,
-          typename VectorViewType>
+          typename VectorViewType, typename KrylovHandleType>
 struct Functor_TestBatchedTeamVectorCG {
   const ValuesViewType _D;
   const IntView _r;
@@ -22,13 +22,18 @@ struct Functor_TestBatchedTeamVectorCG {
   const VectorViewType _X;
   const VectorViewType _B;
   const int _N_team;
-  KrylovHandle<typename ValuesViewType::value_type> handle;
+  KrylovHandleType handle;
 
-  KOKKOS_INLINE_FUNCTION
   Functor_TestBatchedTeamVectorCG(const ValuesViewType &D, const IntView &r,
                                   const IntView &c, const VectorViewType &X,
                                   const VectorViewType &B, const int N_team)
-      : _D(D), _r(r), _c(c), _X(X), _B(B), _N_team(N_team) {}
+      : _D(D),
+        _r(r),
+        _c(c),
+        _X(X),
+        _B(B),
+        _N_team(N_team),
+        handle(KrylovHandleType(_D.extent(0), _N_team)) {}
 
   template <typename MemberType>
   KOKKOS_INLINE_FUNCTION void operator()(const MemberType &member) const {
@@ -96,6 +101,13 @@ void impl_test_batched_CG(const int N, const int BlkSize, const int N_team) {
       typename Kokkos::Details::ArithTraits<ScalarType>::mag_type;
   using NormViewType = Kokkos::View<MagnitudeType *, Layout, EXSP>;
 
+  using Norm2DViewType   = Kokkos::View<MagnitudeType **, Layout, EXSP>;
+  using Scalar3DViewType = Kokkos::View<ScalarType ***, Layout, EXSP>;
+  using IntViewType      = Kokkos::View<int *, Layout, EXSP>;
+
+  using KrylovHandleType =
+      KrylovHandle<Norm2DViewType, IntViewType, Scalar3DViewType>;
+
   NormViewType sqr_norm_0("sqr_norm_0", N);
   NormViewType sqr_norm_j("sqr_norm_j", N);
 
@@ -128,7 +140,8 @@ void impl_test_batched_CG(const int N, const int BlkSize, const int N_team) {
   KokkosBatched::SerialDot<Trans::NoTranspose>::invoke(R_host, R_host,
                                                        sqr_norm_0_host);
   Functor_TestBatchedTeamVectorCG<DeviceType, ValuesViewType, IntView,
-                                  VectorViewType>(D, r, c, X, B, N_team)
+                                  VectorViewType, KrylovHandleType>(D, r, c, X,
+                                                                    B, N_team)
       .run();
 
   Kokkos::fence();

--- a/unit_test/batched/sparse/Test_Batched_TeamVectorGMRES.hpp
+++ b/unit_test/batched/sparse/Test_Batched_TeamVectorGMRES.hpp
@@ -15,7 +15,7 @@ namespace Test {
 namespace TeamVectorGMRES {
 
 template <typename DeviceType, typename ValuesViewType, typename IntView,
-          typename VectorViewType>
+          typename VectorViewType, typename KrylovHandleType>
 struct Functor_TestBatchedTeamVectorGMRES {
   const ValuesViewType _D;
   const IntView _r;
@@ -24,15 +24,21 @@ struct Functor_TestBatchedTeamVectorGMRES {
   const VectorViewType _B;
   const VectorViewType _Diag;
   const int _N_team;
-  KrylovHandle<typename ValuesViewType::value_type> handle;
+  KrylovHandleType _handle;
 
-  KOKKOS_INLINE_FUNCTION
   Functor_TestBatchedTeamVectorGMRES(const ValuesViewType &D, const IntView &r,
                                      const IntView &c, const VectorViewType &X,
                                      const VectorViewType &B,
                                      const VectorViewType &diag,
-                                     const int N_team)
-      : _D(D), _r(r), _c(c), _X(X), _B(B), _Diag(diag), _N_team(N_team) {}
+                                     const int N_team, KrylovHandleType &handle)
+      : _D(D),
+        _r(r),
+        _c(c),
+        _X(X),
+        _B(B),
+        _N_team(N_team),
+        _Diag(diag),
+        _handle(handle) {}
 
   template <typename MemberType>
   KOKKOS_INLINE_FUNCTION void operator()(const MemberType &member) const {
@@ -57,10 +63,11 @@ struct Functor_TestBatchedTeamVectorGMRES {
 
     Operator A(d, _r, _c);
     PrecOperator P(diag);
+    P.setComputedInverse();
 
     KokkosBatched::TeamVectorGMRES<MemberType>::template invoke<Operator,
                                                                 VectorViewType>(
-        member, A, b, x, P, handle);
+        member, A, b, x, P, _handle);
   }
 
   inline void run() {
@@ -72,18 +79,40 @@ struct Functor_TestBatchedTeamVectorGMRES {
     Kokkos::TeamPolicy<DeviceType> policy(_D.extent(0) / _N_team,
                                           Kokkos::AUTO(), Kokkos::AUTO());
 
-    size_t bytes_0 = ValuesViewType::shmem_size(_N_team, _X.extent(1));
+    const int N                 = _D.extent(0);
+    const int n                 = _X.extent(1);
+    const int maximum_iteration = _handle.get_max_iteration();
+
+    size_t bytes_0 = ValuesViewType::shmem_size(_N_team, n);
     size_t bytes_1 = ValuesViewType::shmem_size(_N_team, 1);
 
-    handle.set_max_iteration(10);
+    _handle.set_ortho_strategy(0);
+    _handle.set_compute_last_residual(false);
+    _handle.set_tolerance(1e-8);
 
-    int maximum_iteration = handle.get_max_iteration();
+    _handle.Arnoldi_view = typename KrylovHandleType::ArnoldiViewType(
+        "", N, maximum_iteration, n + maximum_iteration + 3);
 
-    policy.set_scratch_size(0, Kokkos::PerTeam(5 * bytes_0 + 5 * bytes_1));
+    using ScalarType = typename ValuesViewType::non_const_value_type;
+    using Layout     = typename ValuesViewType::array_layout;
+    using EXSP       = typename ValuesViewType::execution_space;
+
+    using ViewType2D = Kokkos::View<ScalarType **, Layout, EXSP>;
+
+    size_t bytes_1D   = ViewType2D::shmem_size(_N_team, 1);
+    size_t bytes_2D_1 = ViewType2D::shmem_size(_N_team, _X.extent(1));
+    size_t bytes_2D_2 = ViewType2D::shmem_size(_N_team, maximum_iteration + 1);
+
+    size_t bytes_row_ptr = IntView::shmem_size(_r.extent(0));
+    size_t bytes_col_idc = IntView::shmem_size(_c.extent(0));
+
+    size_t bytes_int  = bytes_row_ptr + bytes_col_idc;
+    size_t bytes_diag = bytes_2D_1;
+    size_t bytes_tmp  = 2 * bytes_2D_1 + 2 * bytes_1D + bytes_2D_2;
     policy.set_scratch_size(
-        1, Kokkos::PerTeam(maximum_iteration * bytes_0 +
-                           ((maximum_iteration + 3) * maximum_iteration) *
-                               bytes_1));
+        0, Kokkos::PerTeam(bytes_tmp + bytes_diag + bytes_int));
+
+    // policy.set_scratch_size(0, Kokkos::PerTeam(5 * bytes_0 + 5 * bytes_1));
 
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
@@ -113,6 +142,13 @@ void impl_test_batched_GMRES(const int N, const int BlkSize, const int N_team) {
   using MagnitudeType =
       typename Kokkos::Details::ArithTraits<ScalarType>::mag_type;
   using NormViewType = Kokkos::View<MagnitudeType *, Layout, EXSP>;
+
+  using Norm2DViewType   = Kokkos::View<MagnitudeType **, Layout, EXSP>;
+  using Scalar3DViewType = Kokkos::View<ScalarType ***, Layout, EXSP>;
+  using IntViewType      = Kokkos::View<int *, Layout, EXSP>;
+
+  using KrylovHandleType =
+      KrylovHandle<Norm2DViewType, IntViewType, Scalar3DViewType>;
 
   NormViewType sqr_norm_0("sqr_norm_0", N);
   NormViewType sqr_norm_j("sqr_norm_j", N);
@@ -162,6 +198,9 @@ void impl_test_batched_GMRES(const int N, const int BlkSize, const int N_team) {
   Kokkos::deep_copy(r_host, r);
   Kokkos::deep_copy(D_host, D);
 
+  const int n_iterations = 10;
+  KrylovHandleType handle(N, N_team, n_iterations);
+
   KokkosBatched::SerialSpmv<Trans::NoTranspose>::template invoke<
       typename ValuesViewType::HostMirror, typename IntView::HostMirror,
       typename VectorViewType::HostMirror, typename VectorViewType::HostMirror,
@@ -169,8 +208,8 @@ void impl_test_batched_GMRES(const int N, const int BlkSize, const int N_team) {
   KokkosBatched::SerialDot<Trans::NoTranspose>::invoke(R_host, R_host,
                                                        sqr_norm_0_host);
   Functor_TestBatchedTeamVectorGMRES<DeviceType, ValuesViewType, IntView,
-                                     VectorViewType>(D, r, c, X, B, Diag,
-                                                     N_team)
+                                     VectorViewType, KrylovHandleType>(
+      D, r, c, X, B, Diag, N_team, handle)
       .run();
 
   Kokkos::fence();

--- a/unit_test/batched/sparse/Test_Batched_TeamVectorGMRES.hpp
+++ b/unit_test/batched/sparse/Test_Batched_TeamVectorGMRES.hpp
@@ -36,8 +36,8 @@ struct Functor_TestBatchedTeamVectorGMRES {
         _c(c),
         _X(X),
         _B(B),
-        _N_team(N_team),
         _Diag(diag),
+        _N_team(N_team),
         _handle(handle) {}
 
   template <typename MemberType>
@@ -83,9 +83,6 @@ struct Functor_TestBatchedTeamVectorGMRES {
     const int n                 = _X.extent(1);
     const int maximum_iteration = _handle.get_max_iteration();
 
-    size_t bytes_0 = ValuesViewType::shmem_size(_N_team, n);
-    size_t bytes_1 = ValuesViewType::shmem_size(_N_team, 1);
-
     _handle.set_ortho_strategy(0);
     _handle.set_compute_last_residual(false);
     _handle.set_tolerance(1e-8);
@@ -111,8 +108,6 @@ struct Functor_TestBatchedTeamVectorGMRES {
     size_t bytes_tmp  = 2 * bytes_2D_1 + 2 * bytes_1D + bytes_2D_2;
     policy.set_scratch_size(
         0, Kokkos::PerTeam(bytes_tmp + bytes_diag + bytes_int));
-
-    // policy.set_scratch_size(0, Kokkos::PerTeam(5 * bytes_0 + 5 * bytes_1));
 
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();


### PR DESCRIPTION
This PR updates the batched GMRES as follows:
- It adds a serial batched GMRES,
- It updates the Krylov handle to preallocate memory to store Arnoldi vectors,
- It adds an example,
- It adds the option to choose the orthogonalization process,
- It allows the user to track the convergence of the systems.