### PR TITLE
Sparse and CI updates

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -46,6 +46,7 @@ jobs:
           -DCMAKE_CXX_FLAGS="-Werror" \
           -DCMAKE_CXX_STANDARD=14 \
           -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
+          -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK:BOOL=ON \
           -DKokkos_ENABLE_DEPRECATED_CODE_3=OFF \
           -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
           -DCMAKE_INSTALL_PREFIX=$PWD/../install \

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -2,12 +2,19 @@ name: github-OSX
 
 on:
   pull_request:
-    branches:
-      - master
-      - develop
+    types: [ opened, labeled, unlabeled, reopened, synchronize ]
 
 jobs:
+  check-pr-labels:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          none_of: 'AT: WIP'
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
   osxci:
+    needs: check-pr-labels
+    # TODO: allow re-run via retest label if: ${{ github.event.label.name == 'AT: RETEST' }}
     name: osx-ci
     runs-on: [macos-latest]
 

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -16,12 +16,16 @@ jobs:
         include:
           - backend: "SERIAL"
             cmake_build_type: "RelWithDebInfo"
+            debug_bounds_check: "ON"
           - backend: "THREADS"
             cmake_build_type: "RelWithDebInfo"
+            debug_bounds_check: "ON"
           - backend: "SERIAL"
             cmake_build_type: "Debug"
+            debug_bounds_check: "OFF"
           - backend: "SERIAL"
             cmake_build_type: "Release"
+            debug_bounds_check: "ON"
 
     steps:
       - name: checkout_kokkos_kernels
@@ -46,7 +50,7 @@ jobs:
           -DCMAKE_CXX_FLAGS="-Werror" \
           -DCMAKE_CXX_STANDARD=14 \
           -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
-          -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK:BOOL=ON \
+          -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK:BOOL=${{ matrix.debug_bounds_check }} \
           -DKokkos_ENABLE_DEPRECATED_CODE_3=OFF \
           -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
           -DCMAKE_INSTALL_PREFIX=$PWD/../install \
@@ -86,4 +90,4 @@ jobs:
 
       - name: test
         working-directory: kokkos-kernels/build
-        run: ctest -j2 --output-on-failure --timeout 2500
+        run: ctest -j2 --output-on-failure --timeout 3600

--- a/src/sparse/KokkosSparse_csc2csr.hpp
+++ b/src/sparse/KokkosSparse_csc2csr.hpp
@@ -109,8 +109,7 @@ class Csc2Csr {
       // Use exclusive scan so we can allocate the row map uninitialized and
       // avoid accessing device views on the host.
       KE::exclusive_scan(crsET, KE::cbegin(__crs_row_cnt),
-                         KE::cend(__crs_row_cnt) + 1, KE::begin(__crs_row_map),
-                         0);
+                         KE::cend(__crs_row_cnt), KE::begin(__crs_row_map), 0);
       CrsET().fence();
       Kokkos::deep_copy(__crs_row_map_scratch, __crs_row_map);
       CrsET().fence();
@@ -203,7 +202,7 @@ class Csc2Csr {
     __crs_col_ids = CrsColIdViewType(
         Kokkos::view_alloc(Kokkos::WithoutInitializing, "__crs_col_ids"), nnz);
 
-    __crs_row_cnt = RowIdViewType("__crs_row_cnt", __nrows);
+    __crs_row_cnt = RowIdViewType("__crs_row_cnt", __nrows + 1);
 
     __Functor<typename TeamPolicyType::member_type> functor(
         __nrows, __ncols, __nnz, __vals, __crs_vals, __row_ids, __crs_row_map,


### PR DESCRIPTION
Replaces #1405.

Fixes #1404.

@lucbv: Adding the `AT: WIP` label for documentation changes will pause both the autotester and github action ci checks.