### PR TITLE
Change Controls::getParameter error message from stdout to stderr

### DIFF
--- a/src/common/KokkosKernels_Controls.hpp
+++ b/src/common/KokkosKernels_Controls.hpp
@@ -92,8 +92,6 @@ class Controls {
                            const std::string& orUnset = "") const {
     auto search = kernel_parameters.find(name);
     if (kernel_parameters.end() == search) {
-      std::cout << "Parameter " << name
-                << " was not found in the list of parameters!" << std::endl;
       return orUnset;
     } else {
       return search->second;

--- a/src/common/KokkosKernels_Controls.hpp
+++ b/src/common/KokkosKernels_Controls.hpp
@@ -92,6 +92,8 @@ class Controls {
                            const std::string& orUnset = "") const {
     auto search = kernel_parameters.find(name);
     if (kernel_parameters.end() == search) {
+      std::cerr << "WARNING: Controls::getParameter for name \"" << name
+                << "\" was unset" << std::endl;
       return orUnset;
     } else {
       return search->second;


### PR DESCRIPTION
Remove the diagnostic message printed to stdout in Controls::getParameter when the requested parameter is not set.

Fixes https://github.com/kokkos/kokkos-kernels/issues/1415