### PR TITLE
Fix SYCL nightly test

### DIFF
--- a/scripts/docker/Dockerfile.sycl
+++ b/scripts/docker/Dockerfile.sycl
@@ -1,6 +1,8 @@
 ARG BASE=nvidia/cuda:10.2-devel
 FROM $BASE
 
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+
 RUN apt-get update && apt-get install -y \
         bc \
         wget \

--- a/unit_test/sparse/Test_Sparse_spmv.hpp
+++ b/unit_test/sparse/Test_Sparse_spmv.hpp
@@ -73,8 +73,9 @@ struct fSPMV {
 
     if (error > eps * max_val) {
       err++;
-      printf("expected_y(%d)=%f, y(%d)=%f err=%f, max_error=%f\n", i,
-             AT::abs(expected_y(i)), i, AT::abs(y(i)), error, eps * max_val);
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "expected_y(%d)=%f, y(%d)=%f err=%f, max_error=%f\n", i,
+          AT::abs(expected_y(i)), i, AT::abs(y(i)), error, eps * max_val);
     }
   }
 };


### PR DESCRIPTION
This is supposed to fix the nightly tests for SYCL, see https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/KokkosKernels/detail/KokkosKernels/502/pipeline, that were failing since 05/07(!).