### PR TITLE
Update SYCL CI

### DIFF
--- a/scripts/docker/Dockerfile.sycl
+++ b/scripts/docker/Dockerfile.sycl
@@ -38,8 +38,8 @@ RUN CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSIO
 ENV PATH=${CMAKE_DIR}/bin:$PATH
 
 ENV SYCL_DIR=/opt/sycl
-RUN SYCL_VERSION=2021-09 && \
-    SYCL_URL=https://github.com/intel/llvm/archive && \
+RUN SYCL_VERSION=20220112 && \
+    SYCL_URL=https://github.com/intel/llvm/archive/sycl-nightly && \
     SYCL_ARCHIVE=${SYCL_VERSION}.tar.gz && \
     SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
     wget --quiet ${SYCL_URL}/${SYCL_ARCHIVE} && \


### PR DESCRIPTION
Even after #1419, the SYCL nightly CI still doesn't work since assume a newer compiler in `Kokkos`, see https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/KokkosKernels/detail/KokkosKernels/521/pipeline. This brings the the `Dockerfiles` for `Kokkos` and `KokkosKernels` in line again.