### PR TITLE
Add cuSparse TPL files for CrsMatrix-multivector product

### DIFF
--- a/src/batched/KokkosBatched_Util.hpp
+++ b/src/batched/KokkosBatched_Util.hpp
@@ -854,10 +854,9 @@ KOKKOS_INLINE_FUNCTION ViewValueType fma_alpha(ViewValueType reg_c,
 
 template <class ViewValueType, class ScalarType>
 KOKKOS_INLINE_FUNCTION ViewValueType fma_alpha(ViewValueType reg_c,
-                                               ScalarType alpha,
+                                               ScalarType /*alpha*/,
                                                const AlphaTag::No &) {
   return reg_c;
-  (void)alpha;
 }
 
 template <class ViewType, class SizeType, class ViewValueType, class ScalarType,

--- a/src/impl/tpls/KokkosSparse_spmv_mv_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosSparse_spmv_mv_tpl_spec_avail.hpp
@@ -1,0 +1,175 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOSPARSE_SPMV_MV_TPL_SPEC_AVAIL_HPP_
+#define KOKKOSPARSE_SPMV_MV_TPL_SPEC_AVAIL_HPP_
+
+namespace KokkosSparse {
+namespace Impl {
+
+// Specialization struct which defines whether a specialization exists
+template <class AT, class AO, class AD, class AM, class AS, class XT, class XL,
+          class XD, class XM, class YT, class YL, class YD, class YM,
+          const bool integerScalarType =
+              std::is_integral<typename std::decay<AT>::type>::value>
+struct spmv_mv_tpl_spec_avail {
+  enum : bool { value = false };
+};
+
+#define KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(SCALAR, ORDINAL, OFFSET, \
+                                                     XL, YL, MEMSPACE)        \
+  template <>                                                                 \
+  struct spmv_mv_tpl_spec_avail<                                              \
+      const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,    \
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET, const SCALAR**,  \
+      XL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                             \
+      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,         \
+      SCALAR**, YL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                   \
+      Kokkos::MemoryTraits<Kokkos::Unmanaged> > {                             \
+    enum : bool { value = true };                                             \
+  };
+
+/* CUSPARSE_VERSION 10300 and lower seem to have a bug in cusparseSpMM
+non-transpose that produces incorrect result. This is cusparse distributed with
+CUDA 10.1.243. The bug seems to be resolved by CUSPARSE 10301 (present by
+CUDA 10.2.89) */
+#if defined(CUSPARSE_VERSION) && (10301 <= CUSPARSE_VERSION)
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(double, int, int,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaSpace)
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(double, int, int,
+                                             Kokkos::LayoutRight,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaSpace)
+
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(float, int, int,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaSpace)
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(float, int, int,
+                                             Kokkos::LayoutRight,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaSpace)
+
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, int,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaSpace)
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, int,
+                                             Kokkos::LayoutRight,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaSpace)
+
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, int,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaSpace)
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, int,
+                                             Kokkos::LayoutRight,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaSpace)
+
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(double, int, int,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaUVMSpace)
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(double, int, int,
+                                             Kokkos::LayoutRight,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaUVMSpace)
+
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(float, int, int,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaUVMSpace)
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(float, int, int,
+                                             Kokkos::LayoutRight,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaUVMSpace)
+
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, int,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaUVMSpace)
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, int,
+                                             Kokkos::LayoutRight,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaUVMSpace)
+
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, int,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaUVMSpace)
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, int,
+                                             Kokkos::LayoutRight,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaUVMSpace)
+
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::Experimental::half_t, int,
+                                             int, Kokkos::LayoutLeft,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaSpace)
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::Experimental::half_t, int,
+                                             int, Kokkos::LayoutRight,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaSpace)
+
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::Experimental::half_t, int,
+                                             int, Kokkos::LayoutLeft,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaUVMSpace)
+KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::Experimental::half_t, int,
+                                             int, Kokkos::LayoutRight,
+                                             Kokkos::LayoutLeft,
+                                             Kokkos::CudaUVMSpace)
+
+#endif
+#endif  // defined(CUSPARSE_VERSION) && (10300 <= CUSPARSE_VERSION)
+
+}  // namespace Impl
+}  // namespace KokkosSparse
+
+#endif  // KOKKOSPARSE_SPMV_MV_TPL_SPEC_AVAIL_HPP_

--- a/src/impl/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
+++ b/src/impl/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
@@ -1,0 +1,336 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOSPARSE_SPMV_MV_TPL_SPEC_DECL_HPP_
+#define KOKKOSPARSE_SPMV_MV_TPL_SPEC_DECL_HPP_
+
+#include "KokkosKernels_Controls.hpp"
+
+#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+
+/* CUSPARSE_VERSION < 10301 either doesn't have cusparseSpMM
+   or the non-tranpose version produces incorrect results.
+*/
+#if defined(CUSPARSE_VERSION) && (10301 <= CUSPARSE_VERSION)
+#include "cusparse.h"
+#include "KokkosSparse_Utils_cusparse.hpp"
+
+namespace KokkosSparse {
+namespace Impl {
+
+/* Derive a compute type for various operand types.
+   cusparseSpMM does not always allow the same compute type as operand types
+   This should be consistent with the allowed operand types for cusparseSpMM,
+   as needed for TPL availability. Current definition does not comprehensively
+   cover all cusparseSpMM options.
+
+   cuSparse 11.5.1+ does not support uniform precision for FP16
+   Otherwise, uniform precision is supported
+*/
+template <typename AScalar, typename XScalar = AScalar,
+          typename YScalar = AScalar>
+cudaDataType compute_type() {
+  return cuda_data_type_from<AScalar>();
+}
+#if CUSPARSE_VERSION >= 11501
+template <>
+inline cudaDataType compute_type<Kokkos::Experimental::half_t>() {
+  return CUDA_R_32F;
+}
+#else
+template <>
+inline cudaDataType compute_type<Kokkos::Experimental::half_t>() {
+  return cuda_data_type_from<Kokkos::Experimental::half_t>();
+}
+#endif
+
+/*! \brief convert a 2D view to a cusparseDnMatDescr_t
+
+*/
+template <typename ViewType, std::enable_if_t<ViewType::rank == 2, bool> = true>
+cusparseDnMatDescr_t make_cusparse_dn_mat_descr_t(ViewType &view) {
+  const int64_t rows = view.extent(0);
+  const int64_t cols = view.extent(1);
+  const int64_t ld   = view.extent(0);
+
+  // cusparseCreateCsr notes it is safe to const_cast this away for input
+  // pointers to a descriptor as long as that descriptor is not an output
+  // parameter
+  void *values =
+      const_cast<typename ViewType::non_const_value_type *>(view.data());
+
+  cudaDataType valueType =
+      cuda_data_type_from<typename ViewType::non_const_value_type>();
+
+  // col-major is the only supported order in 10301
+  // ignore the layout of the provided view, and expect the caller to
+  // fix with a transpose operation, if possible.
+  // This should be revisited once cusparse supports row-major dense matrices
+  const cusparseOrder_t order = CUSPARSE_ORDER_COL;
+
+  cusparseDnMatDescr_t descr;
+  KOKKOS_CUSPARSE_SAFE_CALL(
+      cusparseCreateDnMat(&descr, rows, cols, ld, values, valueType, order));
+
+  return descr;
+}
+
+template <class AMatrix, class XVector, class YVector>
+void spmv_mv_cusparse(const KokkosKernels::Experimental::Controls &controls,
+                      const char mode[],
+                      typename YVector::non_const_value_type const &alpha,
+                      const AMatrix &A, const XVector &x,
+                      typename YVector::non_const_value_type const &beta,
+                      const YVector &y) {
+  static_assert(XVector::rank == 2,
+                "should only be instantiated for multivector");
+  static_assert(YVector::rank == 2,
+                "should only be instantiated for multivector");
+
+  using offset_type  = typename AMatrix::non_const_size_type;
+  using entry_type   = typename AMatrix::non_const_ordinal_type;
+  using value_type   = typename AMatrix::non_const_value_type;
+  using x_value_type = typename XVector::non_const_value_type;
+  using y_value_type = typename YVector::non_const_value_type;
+
+  /* initialize cusparse library */
+  cusparseHandle_t cusparseHandle = controls.getCusparseHandle();
+
+  /* Set the operation mode */
+  cusparseOperation_t opA;
+  switch (toupper(mode[0])) {
+    case 'N': opA = CUSPARSE_OPERATION_NON_TRANSPOSE; break;
+    case 'T': opA = CUSPARSE_OPERATION_TRANSPOSE; break;
+    case 'H': opA = CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE; break;
+    default: {
+      std::cerr << "Mode " << mode << " invalid for cuSPARSE SpMV MV.\n";
+      throw std::invalid_argument("Invalid mode");
+    }
+  }
+
+  /* Check that cusparse can handle the types of the input Kokkos::CrsMatrix */
+  const cusparseIndexType_t myCusparseOffsetType =
+      cusparse_index_type_t_from<offset_type>();
+  const cusparseIndexType_t myCusparseEntryType =
+      cusparse_index_type_t_from<entry_type>();
+  const cudaDataType aCusparseType = cuda_data_type_from<value_type>();
+
+  /* create matrix */
+  cusparseSpMatDescr_t A_cusparse;
+  KOKKOS_CUSPARSE_SAFE_CALL(cusparseCreateCsr(
+      &A_cusparse, A.numRows(), A.numCols(), A.nnz(),
+      (void *)A.graph.row_map.data(), (void *)A.graph.entries.data(),
+      (void *)A.values.data(), myCusparseOffsetType, myCusparseEntryType,
+      CUSPARSE_INDEX_BASE_ZERO, aCusparseType));
+
+  /* create lhs and rhs
+     NOTE: The descriptions always say vecX and vecY are column-major cusparse
+     order. For CUSPARSE_VERSION 10301 this is the only supported ordering. if X
+     is not LayoutLeft, we can fix with a transpose. If cusparseSpMM ever
+     supports row-major dense matrices, this logic will have to be reworked */
+  constexpr bool xIsLL =
+      std::is_same<typename XVector::array_layout, Kokkos::LayoutLeft>::value;
+  constexpr bool xIsLR =
+      std::is_same<typename XVector::array_layout, Kokkos::LayoutRight>::value;
+  static_assert(xIsLL || xIsLR, "X multivector was not LL or LR (TPL error)");
+  cusparseDnMatDescr_t vecX = make_cusparse_dn_mat_descr_t(x);
+  cusparseDnMatDescr_t vecY = make_cusparse_dn_mat_descr_t(y);
+  cusparseOperation_t opB =
+      xIsLL ? CUSPARSE_OPERATION_NON_TRANSPOSE : CUSPARSE_OPERATION_TRANSPOSE;
+
+  const cusparseSpMMAlg_t alg = CUSPARSE_MM_ALG_DEFAULT;
+
+  // the precision of the SpMV
+  const cudaDataType computeType =
+      compute_type<value_type, x_value_type, y_value_type>();
+
+  size_t bufferSize = 0;
+  KOKKOS_CUSPARSE_SAFE_CALL(cusparseSpMM_bufferSize(
+      cusparseHandle, opA, opB, &alpha, A_cusparse, vecX, &beta, vecY,
+      computeType, alg, &bufferSize));
+
+  void *dBuffer = nullptr;
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc(&dBuffer, bufferSize));
+  KOKKOS_CUSPARSE_SAFE_CALL(cusparseSpMM(cusparseHandle, opA, opB, &alpha,
+                                         A_cusparse, vecX, &beta, vecY,
+                                         computeType, alg, dBuffer));
+
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(dBuffer));
+  KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnMat(vecX));
+  KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnMat(vecY));
+  KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroySpMat(A_cusparse));
+}
+
+#define KOKKOSSPARSE_SPMV_MV_CUSPARSE(SCALAR, ORDINAL, OFFSET, XL, YL, SPACE,  \
+                                      COMPILE_LIBRARY)                         \
+  template <>                                                                  \
+  struct SPMV_MV<                                                              \
+      SCALAR const, ORDINAL const, Kokkos::Device<Kokkos::Cuda, SPACE>,        \
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>, OFFSET const, SCALAR const **,  \
+      XL, Kokkos::Device<Kokkos::Cuda, SPACE>,                                 \
+      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,          \
+      SCALAR **, YL, Kokkos::Device<Kokkos::Cuda, SPACE>,                      \
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>, false, true, COMPILE_LIBRARY> { \
+    using device_type       = Kokkos::Device<Kokkos::Cuda, SPACE>;             \
+    using memory_trait_type = Kokkos::MemoryTraits<Kokkos::Unmanaged>;         \
+    using AMatrix = CrsMatrix<SCALAR const, ORDINAL const, device_type,        \
+                              memory_trait_type, OFFSET const>;                \
+    using XVector = Kokkos::View<                                              \
+        SCALAR const **, XL, device_type,                                      \
+        Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;       \
+    using YVector =                                                            \
+        Kokkos::View<SCALAR **, YL, device_type, memory_trait_type>;           \
+                                                                               \
+    using coefficient_type = typename YVector::non_const_value_type;           \
+                                                                               \
+    using Controls = KokkosKernels::Experimental::Controls;                    \
+    static void spmv_mv(const Controls &controls, const char mode[],           \
+                        const coefficient_type &alpha, const AMatrix &A,       \
+                        const XVector &x, const coefficient_type &beta,        \
+                        const YVector &y) {                                    \
+      std::string label = "KokkosSparse::spmv[TPL_CUSPARSE," +                 \
+                          Kokkos::ArithTraits<SCALAR>::name() + "]";           \
+      Kokkos::Profiling::pushRegion(label);                                    \
+      spmv_mv_cusparse(controls, mode, alpha, A, x, beta, y);                  \
+      Kokkos::Profiling::popRegion();                                          \
+    }                                                                          \
+  };
+
+/* cusparseSpMM with following restrictions
+ column-major ordering for Y
+ col-major or row-major for X (see note below)
+ 32-bit indices for matrix A */
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(double, int, int, Kokkos::LayoutLeft,
+                              Kokkos::LayoutLeft, Kokkos::CudaSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(double, int, int, Kokkos::LayoutRight,
+                              Kokkos::LayoutLeft, Kokkos::CudaSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(float, int, int, Kokkos::LayoutLeft,
+                              Kokkos::LayoutLeft, Kokkos::CudaSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(float, int, int, Kokkos::LayoutRight,
+                              Kokkos::LayoutLeft, Kokkos::CudaSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<double>, int, int,
+                              Kokkos::LayoutLeft, Kokkos::LayoutLeft,
+                              Kokkos::CudaSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<double>, int, int,
+                              Kokkos::LayoutRight, Kokkos::LayoutLeft,
+                              Kokkos::CudaSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<float>, int, int,
+                              Kokkos::LayoutLeft, Kokkos::LayoutLeft,
+                              Kokkos::CudaSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<float>, int, int,
+                              Kokkos::LayoutRight, Kokkos::LayoutLeft,
+                              Kokkos::CudaSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(double, int, int, Kokkos::LayoutLeft,
+                              Kokkos::LayoutLeft, Kokkos::CudaUVMSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(double, int, int, Kokkos::LayoutRight,
+                              Kokkos::LayoutLeft, Kokkos::CudaUVMSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(float, int, int, Kokkos::LayoutLeft,
+                              Kokkos::LayoutLeft, Kokkos::CudaUVMSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(float, int, int, Kokkos::LayoutRight,
+                              Kokkos::LayoutLeft, Kokkos::CudaUVMSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<double>, int, int,
+                              Kokkos::LayoutLeft, Kokkos::LayoutLeft,
+                              Kokkos::CudaUVMSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<double>, int, int,
+                              Kokkos::LayoutRight, Kokkos::LayoutLeft,
+                              Kokkos::CudaUVMSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<float>, int, int,
+                              Kokkos::LayoutLeft, Kokkos::LayoutLeft,
+                              Kokkos::CudaUVMSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<float>, int, int,
+                              Kokkos::LayoutRight, Kokkos::LayoutLeft,
+                              Kokkos::CudaUVMSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::Experimental::half_t, int, int,
+                              Kokkos::LayoutLeft, Kokkos::LayoutLeft,
+                              Kokkos::CudaSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::Experimental::half_t, int, int,
+                              Kokkos::LayoutRight, Kokkos::LayoutLeft,
+                              Kokkos::CudaSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::Experimental::half_t, int, int,
+                              Kokkos::LayoutLeft, Kokkos::LayoutLeft,
+                              Kokkos::CudaUVMSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::Experimental::half_t, int, int,
+                              Kokkos::LayoutRight, Kokkos::LayoutLeft,
+                              Kokkos::CudaUVMSpace,
+                              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
+
+#endif
+
+#undef KOKKOSSPARSE_SPMV_MV_CUSPARSE
+
+}  // namespace Impl
+}  // namespace KokkosSparse
+#endif  // defined(CUSPARSE_VERSION) && (10301 <= CUSPARSE_VERSION)
+#endif  // KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+
+#endif  // KOKKOSPARSE_SPMV_MV_TPL_SPEC_DECL_HPP_

--- a/src/impl/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
@@ -201,6 +201,8 @@ KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int64_t,
 #endif  // CUDA/CUSPARSE >= 9.0?
 #endif  // KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 
+#undef KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE
+
 #if defined(KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE)
 
 #define KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ROCSPARSE(SCALAR, LAYOUT)             \
@@ -264,15 +266,6 @@ KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_MKL(Kokkos::complex<double>, Kokkos::OpenMP)
 #endif
 
 #endif  // KOKKOSKERNELS_ENABLE_TPL_MKL
-
-// Specialization struct which defines whether a specialization exists
-template <class AT, class AO, class AD, class AM, class AS, class XT, class XL,
-          class XD, class XM, class YT, class YL, class YD, class YM,
-          const bool integerScalarType =
-              std::is_integral<typename std::decay<AT>::type>::value>
-struct spmv_mv_tpl_spec_avail {
-  enum : bool { value = false };
-};
 
 }  // namespace Impl
 }  // namespace KokkosSparse

--- a/src/impl/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/src/impl/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -86,25 +86,11 @@ void spmv_cusparse(const KokkosKernels::Experimental::Controls& controls,
 #if defined(CUSPARSE_VERSION) && (10300 <= CUSPARSE_VERSION)
 
   /* Check that cusparse can handle the types of the input Kokkos::CrsMatrix */
-  cusparseIndexType_t myCusparseOffsetType;
-  if (std::is_same<offset_type, int>::value)
-    myCusparseOffsetType = CUSPARSE_INDEX_32I;
-  else if (std::is_same<offset_type, int64_t>::value ||
-           std::is_same<offset_type, size_t>::value)
-    myCusparseOffsetType = CUSPARSE_INDEX_64I;
-  else
-    throw std::logic_error(
-        "Offset type of CrsMatrix isn't supported by cuSPARSE, yet TPL layer "
-        "says it is");
-  cusparseIndexType_t myCusparseEntryType;
-  if (std::is_same<entry_type, int>::value)
-    myCusparseEntryType = CUSPARSE_INDEX_32I;
-  else if (std::is_same<entry_type, int64_t>::value)
-    myCusparseEntryType = CUSPARSE_INDEX_64I;
-  else
-    throw std::logic_error(
-        "Ordinal (entry) type of CrsMatrix isn't supported by cuSPARSE, yet "
-        "TPL layer says it is");
+  const cusparseIndexType_t myCusparseOffsetType =
+      cusparse_index_type_t_from<offset_type>();
+  const cusparseIndexType_t myCusparseEntryType =
+      cusparse_index_type_t_from<entry_type>();
+
   cudaDataType myCudaDataType;
   if (std::is_same<value_type, float>::value)
     myCudaDataType = CUDA_R_32F;
@@ -373,8 +359,8 @@ KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>, int64_t, size_t,
 KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>, int64_t, size_t,
                            Kokkos::LayoutRight, Kokkos::CudaUVMSpace,
                            KOKKOSKERNELS_IMPL_COMPILE_LIBRARY)
-#endif
-#endif
+#endif  // defined(CUSPARSE_VERSION) && (10300 <= CUSPARSE_VERSION)
+#endif  // 9000 <= CUDA_VERSION
 
 #undef KOKKOSSPARSE_SPMV_CUSPARSE
 

--- a/src/sparse/KokkosSparse_Utils_cusparse.hpp
+++ b/src/sparse/KokkosSparse_Utils_cusparse.hpp
@@ -114,6 +114,83 @@ inline void cusparse_internal_safe_call(cusparseStatus_t cusparseStatus,
   KokkosSparse::Impl::cusparse_internal_safe_call(call, #call, __FILE__, \
                                                   __LINE__)
 
+template <typename T>
+cudaDataType cuda_data_type_from() {
+  // compile-time failure with a nice message if called on an unsupported type
+  static_assert(!std::is_same<T, T>::value,
+                "cuSparse TPL does not support scalar type");
+  // static_assert(false, ...) is allowed to error even if the code is not
+  // instantiated. obfuscate the predicate Despite this function being
+  // uncompilable, the compiler may decide that a return statement is missing,
+  // so throw to silence that
+  throw std::logic_error("unreachable throw after static_assert");
+}
+
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+template <>
+inline cudaDataType cuda_data_type_from<Kokkos::Experimental::half_t>() {
+  return CUDA_R_16F;  // Kokkos half_t is a half
+}
+#else
+template <>
+inline cudaDataType cuda_data_type_from<Kokkos::Experimental::half_t>() {
+  return CUDA_R_32F;  // Kokkos half_t is a float
+}
+#endif
+template <>
+inline cudaDataType cuda_data_type_from<float>() {
+  return CUDA_R_32F;
+}
+template <>
+inline cudaDataType cuda_data_type_from<double>() {
+  return CUDA_R_64F;
+}
+template <>
+inline cudaDataType cuda_data_type_from<Kokkos::complex<float>>() {
+  return CUDA_C_32F;
+}
+template <>
+inline cudaDataType cuda_data_type_from<Kokkos::complex<double>>() {
+  return CUDA_C_32F;
+}
+
+#if defined(CUSPARSE_VERSION) && (10300 <= CUSPARSE_VERSION)
+
+template <typename T>
+cusparseIndexType_t cusparse_index_type_t_from() {
+#define AS_STR_LITERAL_IMPL_(x) #x
+#define AS_STR_LITERAL(x) AS_STR_LITERAL_IMPL_(x)
+  static_assert(!std::is_same<T, T>::value,
+                "cuSparse " AS_STR_LITERAL(
+                    CUSPARSE_VERSION) " TPL does not support index type");
+  // static_assert(false, ...) is allowed to error even if the code is not
+  // instantiated. obfuscate the predicate Despite this function being
+  // uncompilable, the compiler may decide that a return statement is missing,
+  // so throw to silence that
+  throw std::logic_error("unreachable throw after static_assert");
+#undef AS_STR_LITERAL_IMPL_
+#undef AS_STR_LITERAL
+}
+
+template <>
+inline cusparseIndexType_t cusparse_index_type_t_from<int>() {
+  return CUSPARSE_INDEX_32I;
+}
+template <>
+inline cusparseIndexType_t cusparse_index_type_t_from<int64_t>() {
+  return CUSPARSE_INDEX_64I;
+}
+// Currently no CUSPARSE_INDEX_64U but this will work most of the time
+template <>
+inline cusparseIndexType_t cusparse_index_type_t_from<size_t>() {
+  return CUSPARSE_INDEX_64I;
+}
+template <>
+inline cusparseIndexType_t cusparse_index_type_t_from<unsigned short>() {
+  return CUSPARSE_INDEX_16U;
+}
+#endif
+
 }  // namespace Impl
 
 }  // namespace KokkosSparse

--- a/src/sparse/impl/KokkosSparse_spmv_spec.hpp
+++ b/src/sparse/impl/KokkosSparse_spmv_spec.hpp
@@ -111,6 +111,8 @@ struct spmv_mv_eti_spec_avail {
 // Include the actual specialization declarations
 #include <KokkosSparse_spmv_tpl_spec_avail.hpp>
 #include <generated_specializations_hpp/KokkosSparse_spmv_eti_spec_avail.hpp>
+
+#include <KokkosSparse_spmv_mv_tpl_spec_avail.hpp>
 #include <generated_specializations_hpp/KokkosSparse_spmv_mv_eti_spec_avail.hpp>
 
 namespace KokkosSparse {
@@ -204,7 +206,8 @@ struct SPMV_MV {
   typedef Kokkos::View<YT, YL, YD, YM> YVector;
   typedef typename YVector::non_const_value_type coefficient_type;
 
-  static void spmv_mv(const char mode[], const coefficient_type& alpha,
+  static void spmv_mv(const KokkosKernels::Experimental::Controls& controls,
+                      const char mode[], const coefficient_type& alpha,
                       const AMatrix& A, const XVector& x,
                       const coefficient_type& beta, const YVector& y);
 };
@@ -261,7 +264,8 @@ struct SPMV_MV<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM, false, false,
   typedef Kokkos::View<YT, YL, YD, YM> YVector;
   typedef typename YVector::non_const_value_type coefficient_type;
 
-  static void spmv_mv(const char mode[], const coefficient_type& alpha,
+  static void spmv_mv(const KokkosKernels::Experimental::Controls& /*controls*/,
+                      const char mode[], const coefficient_type& alpha,
                       const AMatrix& A, const XVector& x,
                       const coefficient_type& beta, const YVector& y) {
     typedef Kokkos::Details::ArithTraits<coefficient_type> KAT;
@@ -287,7 +291,8 @@ struct SPMV_MV<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM, true, false,
   typedef Kokkos::View<YT, YL, YD, YM> YVector;
   typedef typename YVector::non_const_value_type coefficient_type;
 
-  static void spmv_mv(const char mode[], const coefficient_type& alpha,
+  static void spmv_mv(const KokkosKernels::Experimental::Controls& /*controls*/,
+                      const char mode[], const coefficient_type& alpha,
                       const AMatrix& A, const XVector& x,
                       const coefficient_type& beta, const YVector& y) {
     static_assert(std::is_integral<AT>::value,
@@ -377,6 +382,8 @@ struct SPMV_MV<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM, true, false,
 
 #include <KokkosSparse_spmv_tpl_spec_decl.hpp>
 #include <generated_specializations_hpp/KokkosSparse_spmv_eti_spec_decl.hpp>
+
+#include <KokkosSparse_spmv_mv_tpl_spec_decl.hpp>
 #include <generated_specializations_hpp/KokkosSparse_spmv_mv_eti_spec_decl.hpp>
 
 #endif  // KOKKOSSPARSE_IMPL_SPMV_SPEC_HPP_


### PR DESCRIPTION
* Add TPL files for CrsMatrix-multivector product Y += AX wherever cusparseSpMM is supported:
  * CUSPARSE_VERSION >= 10301
  * Y is `LayoutLeft`
  * X is `LayoutLeft` or `LayoutRight` (cuSparse dense matrices must be col-major, but we can sneak in a transpose operation when X is `layoutRight`)
  * Scalar type is all the usual suspects + `Kokkos::Experimental::half_t`
  * Index/Offset types are only `int`

This uses the generic `cusparseSpMM` interface, so in the general case it needs a `cudaMalloc`. Older cuSparse Csr functions have all been deprecated.