### PR TITLE
Workaround SYCL segmentation fault

### DIFF
--- a/unit_test/batched/dense/Test_Batched_SerialAxpy.hpp
+++ b/unit_test/batched/dense/Test_Batched_SerialAxpy.hpp
@@ -57,11 +57,18 @@ void impl_test_batched_axpy(const int N, const int BlkSize) {
 
   alphaViewType alpha("alpha", N);
 
+// FIXME_SYCL Using Random_XorShift64_Pool here gives a segmentation fault
+#ifdef KOKKOS_ENABLE_SYCL
+  Kokkos::deep_copy(X0, const_value_type(.5));
+  Kokkos::deep_copy(X0, const_value_type(.3));
+  Kokkos::deep_copy(alpha, alpha_const_value_type(.1));
+#else
   Kokkos::Random_XorShift64_Pool<typename DeviceType::execution_space> random(
       13718);
   Kokkos::fill_random(X0, random, const_value_type(1.0));
   Kokkos::fill_random(Y0, random, const_value_type(1.0));
   Kokkos::fill_random(alpha, random, alpha_const_value_type(1.0));
+#endif
 
   Kokkos::fence();
 

--- a/unit_test/batched/sparse/Test_Batched_SparseUtils.hpp
+++ b/unit_test/batched/sparse/Test_Batched_SparseUtils.hpp
@@ -9,6 +9,11 @@ void create_tridiagonal_batched_matrices(const int nnz, const int BlkSize,
                                          const VectorViewType &D,
                                          const VectorViewType &X,
                                          const VectorViewType &B) {
+// FIXME_SYCL Using Random_XorShift64_Pool here gives a segmentation fault
+#ifdef KOKKOS_ENABLE_SYCL
+  Kokkos::deep_copy(X, .5);
+  Kokkos::deep_copy(B, .3);
+#else
   Kokkos::Random_XorShift64_Pool<
       typename VectorViewType::device_type::execution_space>
       random(13718);
@@ -18,6 +23,7 @@ void create_tridiagonal_batched_matrices(const int nnz, const int BlkSize,
   Kokkos::fill_random(
       B, random,
       Kokkos::reduction_identity<typename VectorViewType::value_type>::prod());
+#endif
 
   auto D_host = Kokkos::create_mirror_view(D);
   auto r_host = Kokkos::create_mirror_view(r);


### PR DESCRIPTION
We are seeing some segmentation faults on Intel GPUs but using random values is not crucial for these tests. Using fixed values provides a workaround for the issue until it's fixed elsewhere.