### PR TITLE
Fix incorrect function call in KokkosBatched::TeamGEMV unit test

### DIFF
--- a/unit_test/batched/dense/Test_Batched_TeamGemv_Complex.hpp
+++ b/unit_test/batched/dense/Test_Batched_TeamGemv_Complex.hpp
@@ -5,19 +5,21 @@
 TEST_F(TestCategory, batched_scalar_team_gemv_nt_dcomplex_dcomplex) {
   typedef ::Test::TeamGemv::ParamTag<Trans::NoTranspose> param_tag_type;
   typedef Algo::Gemv::Blocked algo_tag_type;
-  test_batched_gemv<TestExecSpace, Kokkos::complex<double>,
-                    Kokkos::complex<double>, param_tag_type, algo_tag_type>();
+  test_batched_team_gemv<TestExecSpace, Kokkos::complex<double>,
+                         Kokkos::complex<double>, param_tag_type,
+                         algo_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemv_t_dcomplex_dcomplex) {
   typedef ::Test::TeamGemv::ParamTag<Trans::Transpose> param_tag_type;
   typedef Algo::Gemv::Blocked algo_tag_type;
-  test_batched_gemv<TestExecSpace, Kokkos::complex<double>,
-                    Kokkos::complex<double>, param_tag_type, algo_tag_type>();
+  test_batched_team_gemv<TestExecSpace, Kokkos::complex<double>,
+                         Kokkos::complex<double>, param_tag_type,
+                         algo_tag_type>();
 }
 // TEST_F( TestCategory, batched_scalar_team_gemv_ct_dcomplex_dcomplex ) {
 //   typedef ::Test::TeamGemv::ParamTag<Trans::ConjTranspose> param_tag_type;
 //   typedef Algo::Gemv::Blocked algo_tag_type;
-//   test_batched_gemv<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
+//   test_batched_team_gemv<TestExecSpace,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
 // }
 
 /// dcomplex, double
@@ -25,19 +27,19 @@ TEST_F(TestCategory, batched_scalar_team_gemv_t_dcomplex_dcomplex) {
 TEST_F(TestCategory, batched_scalar_team_gemv_nt_dcomplex_double) {
   typedef ::Test::TeamGemv::ParamTag<Trans::NoTranspose> param_tag_type;
   typedef Algo::Gemv::Blocked algo_tag_type;
-  test_batched_gemv<TestExecSpace, Kokkos::complex<double>, double,
-                    param_tag_type, algo_tag_type>();
+  test_batched_team_gemv<TestExecSpace, Kokkos::complex<double>, double,
+                         param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemv_t_dcomplex_double) {
   typedef ::Test::TeamGemv::ParamTag<Trans::Transpose> param_tag_type;
   typedef Algo::Gemv::Blocked algo_tag_type;
-  test_batched_gemv<TestExecSpace, Kokkos::complex<double>, double,
-                    param_tag_type, algo_tag_type>();
+  test_batched_team_gemv<TestExecSpace, Kokkos::complex<double>, double,
+                         param_tag_type, algo_tag_type>();
 }
 // TEST_F( TestCategory, batched_scalar_team_gemv_ct_dcomplex_double ) {
 //   typedef ::Test::TeamGemv::ParamTag<Trans::ConjTranspose> param_tag_type;
 //   typedef Algo::Gemv::Blocked algo_tag_type;
-//   test_batched_gemv<TestExecSpace,Kokkos::complex<double>,double,param_tag_type,algo_tag_type>();
+//   test_batched_team_gemv<TestExecSpace,Kokkos::complex<double>,double,param_tag_type,algo_tag_type>();
 // }
 
 #endif

--- a/unit_test/batched/dense/Test_Batched_TeamGemv_Real.hpp
+++ b/unit_test/batched/dense/Test_Batched_TeamGemv_Real.hpp
@@ -3,14 +3,14 @@
 TEST_F(TestCategory, batched_scalar_team_gemv_nt_float_float) {
   typedef ::Test::TeamGemv::ParamTag<Trans::NoTranspose> param_tag_type;
   typedef Algo::Gemv::Blocked algo_tag_type;
-  test_batched_gemv<TestExecSpace, float, float, param_tag_type,
-                    algo_tag_type>();
+  test_batched_team_gemv<TestExecSpace, float, float, param_tag_type,
+                         algo_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemv_t_float_float) {
   typedef ::Test::TeamGemv::ParamTag<Trans::Transpose> param_tag_type;
   typedef Algo::Gemv::Blocked algo_tag_type;
-  test_batched_gemv<TestExecSpace, float, float, param_tag_type,
-                    algo_tag_type>();
+  test_batched_team_gemv<TestExecSpace, float, float, param_tag_type,
+                         algo_tag_type>();
 }
 #endif
 
@@ -18,13 +18,13 @@ TEST_F(TestCategory, batched_scalar_team_gemv_t_float_float) {
 TEST_F(TestCategory, batched_scalar_team_gemv_nt_double_double) {
   typedef ::Test::TeamGemv::ParamTag<Trans::NoTranspose> param_tag_type;
   typedef Algo::Gemv::Blocked algo_tag_type;
-  test_batched_gemv<TestExecSpace, double, double, param_tag_type,
-                    algo_tag_type>();
+  test_batched_team_gemv<TestExecSpace, double, double, param_tag_type,
+                         algo_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemv_t_double_double) {
   typedef ::Test::TeamGemv::ParamTag<Trans::Transpose> param_tag_type;
   typedef Algo::Gemv::Blocked algo_tag_type;
-  test_batched_gemv<TestExecSpace, double, double, param_tag_type,
-                    algo_tag_type>();
+  test_batched_team_gemv<TestExecSpace, double, double, param_tag_type,
+                         algo_tag_type>();
 }
 #endif


### PR DESCRIPTION
@lucbv @fnrizzi

This fix makes `KokkosBatched::TeamGEMV` unit test call `test_batched_team_gemv()` instead of `test_batched_gemv()`, which runs `SerialGEMV`.