### PR TITLE
csc2csr: update Kokkos_Numeric.hpp header inclusion

### DIFF
--- a/src/sparse/KokkosSparse_csc2csr.hpp
+++ b/src/sparse/KokkosSparse_csc2csr.hpp
@@ -44,7 +44,13 @@
 
 #include "KokkosKernels_Utils.hpp"
 #include <std_algorithms/Kokkos_BeginEnd.hpp>
-#include <std_algorithms/Kokkos_Numeric.hpp>
+#include <std_algorithms/Kokkos_AdjacentDifference.hpp>
+#include <std_algorithms/Kokkos_Reduce.hpp>
+#include <std_algorithms/Kokkos_TransformReduce.hpp>
+#include <std_algorithms/Kokkos_ExclusiveScan.hpp>
+#include <std_algorithms/Kokkos_TransformExclusiveScan.hpp>
+#include <std_algorithms/Kokkos_InclusiveScan.hpp>
+#include <std_algorithms/Kokkos_TransformInclusiveScan.hpp>
 
 #ifndef _KOKKOSSPARSE_CSC2CSR_HPP
 #define _KOKKOSSPARSE_CSC2CSR_HPP


### PR DESCRIPTION
Update std_algorithms header include to match renaming/reorg of
numeric headers in kokkos/kokkos#5113