### PR TITLE
dot perf test: adding support for HIP and SYCL backend

### DIFF
--- a/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test.cpp
@@ -50,6 +50,7 @@
 struct Params {
   int use_cuda    = 0;
   int use_hip     = 0;
+  int use_sycl    = 0;
   int use_openmp  = 0;
   int use_threads = 0;
   // m is vector length
@@ -63,7 +64,8 @@ void print_options() {
   std::cerr << "Options:\n" << std::endl;
 
   std::cerr << "\tBACKEND: '--threads[numThreads]' | '--openmp [numThreads]' | "
-               "'--cuda [cudaDeviceIndex]' | '--hip [hipDeviceIndex]'"
+               "'--cuda [cudaDeviceIndex]' | '--hip [hipDeviceIndex]' | "
+               "'--sycl [syclDeviceIndex]'"
             << std::endl;
   std::cerr << "\tIf no BACKEND selected, serial is the default." << std::endl;
   std::cerr << "\t[Optional] --repeat :: how many times to repeat overall "
@@ -89,7 +91,9 @@ int parse_inputs(Params& params, int argc, char** argv) {
     } else if (0 == Test::string_compare_no_case(argv[i], "--cuda")) {
       params.use_cuda = atoi(argv[++i]) + 1;
     } else if (0 == Test::string_compare_no_case(argv[i], "--hip")) {
-      params.use_hip = atoi(argv[++i]) + 1;
+      params.use_hip = atoi(argv[++i]) + 1;;
+    } else if (0 == Test::string_compare_no_case(argv[i], "--sycl")) {
+      params.use_sycl = atoi(argv[++i]) + 1;
     } else if (0 == Test::string_compare_no_case(argv[i], "--m")) {
       params.m = atoi(argv[++i]);
     } else if (0 == Test::string_compare_no_case(argv[i], "--n")) {
@@ -190,7 +194,7 @@ int main(int argc, char** argv) {
   if (parse_inputs(params, argc, argv)) {
     return 1;
   }
-  const int device_id = std::max(params.use_cuda, params.use_hip) - 1;
+  const int device_id = std::max(std::max(params.use_cuda, params.use_hip), params.use_sycl) - 1;
 
   const int num_threads = std::max(params.use_openmp, params.use_threads);
 
@@ -200,7 +204,8 @@ int main(int argc, char** argv) {
   bool useOMP     = params.use_openmp != 0;
   bool useCUDA    = params.use_cuda != 0;
   bool useHIP     = params.use_hip != 0;
-  bool useSerial  = !useThreads && !useOMP && !useCUDA && !useHIP;
+  bool useSYCL    = params.use_sycl != 0;
+  bool useSerial  = !useThreads && !useOMP && !useCUDA && !useHIP && !useSYCL;
 
   if (useThreads) {
 #if defined(KOKKOS_ENABLE_THREADS)
@@ -233,6 +238,14 @@ int main(int argc, char** argv) {
     run<Kokkos::Experimental::HIP>(params.m, params.n, params.repeat);
 #else
     std::cout << "ERROR: HIP requested, but not available.\n";
+    return 1;
+#endif
+  }
+  if (useSYCL) {
+#if defined(KOKKOS_ENABLE_SYCL)
+    run<Kokkos::Experimental::SYCL>(params.m, params.n, params.repeat);
+#else
+    std::cout << "ERROR: SYCL requested, but not available.\n";
     return 1;
 #endif
   }

--- a/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test.cpp
@@ -91,7 +91,8 @@ int parse_inputs(Params& params, int argc, char** argv) {
     } else if (0 == Test::string_compare_no_case(argv[i], "--cuda")) {
       params.use_cuda = atoi(argv[++i]) + 1;
     } else if (0 == Test::string_compare_no_case(argv[i], "--hip")) {
-      params.use_hip = atoi(argv[++i]) + 1;;
+      params.use_hip = atoi(argv[++i]) + 1;
+      ;
     } else if (0 == Test::string_compare_no_case(argv[i], "--sycl")) {
       params.use_sycl = atoi(argv[++i]) + 1;
     } else if (0 == Test::string_compare_no_case(argv[i], "--m")) {
@@ -194,7 +195,8 @@ int main(int argc, char** argv) {
   if (parse_inputs(params, argc, argv)) {
     return 1;
   }
-  const int device_id = std::max(std::max(params.use_cuda, params.use_hip), params.use_sycl) - 1;
+  const int device_id =
+      std::max(std::max(params.use_cuda, params.use_hip), params.use_sycl) - 1;
 
   const int num_threads = std::max(params.use_openmp, params.use_threads);
 

--- a/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test.cpp
@@ -92,7 +92,6 @@ int parse_inputs(Params& params, int argc, char** argv) {
       params.use_cuda = atoi(argv[++i]) + 1;
     } else if (0 == Test::string_compare_no_case(argv[i], "--hip")) {
       params.use_hip = atoi(argv[++i]) + 1;
-      ;
     } else if (0 == Test::string_compare_no_case(argv[i], "--sycl")) {
       params.use_sycl = atoi(argv[++i]) + 1;
     } else if (0 == Test::string_compare_no_case(argv[i], "--m")) {

--- a/perf_test/blas/blas1/KokkosBlas_dot_perf_test.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_perf_test.cpp
@@ -191,7 +191,8 @@ int main(int argc, char** argv) {
   if (parse_inputs(params, argc, argv)) {
     return 1;
   }
-  const int device_id = std::max(std::max(params.use_cuda, params.use_hip), params.use_sycl) - 1;
+  const int device_id =
+      std::max(std::max(params.use_cuda, params.use_hip), params.use_sycl) - 1;
 
   const int num_threads = std::max(params.use_openmp, params.use_threads);
 

--- a/perf_test/blas/blas1/KokkosBlas_dot_perf_test.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_perf_test.cpp
@@ -236,7 +236,7 @@ int main(int argc, char** argv) {
 #if defined(KOKKOS_ENABLE_HIP)
     run<Kokkos::Experimental::HIP>(params.m, params.repeat);
 #else
-    std::cout << "ERROR: CUDA requested, but not available.\n";
+    std::cout << "ERROR: HIP requested, but not available.\n";
     return 1;
 #endif
   }
@@ -245,7 +245,7 @@ int main(int argc, char** argv) {
 #if defined(KOKKOS_ENABLE_SYCL)
     run<Kokkos::Experimental::SYCL>(params.m, params.repeat);
 #else
-    std::cout << "ERROR: CUDA requested, but not available.\n";
+    std::cout << "ERROR: SYCL requested, but not available.\n";
     return 1;
 #endif
   }

--- a/perf_test/blas/blas1/KokkosBlas_dot_perf_test.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_perf_test.cpp
@@ -191,7 +191,7 @@ int main(int argc, char** argv) {
   if (parse_inputs(params, argc, argv)) {
     return 1;
   }
-  const int device_id = params.use_cuda - 1;
+  const int device_id = std::max(std::max(params.use_cuda, params.use_hip), params.use_sycl) - 1;
 
   const int num_threads = std::max(params.use_openmp, params.use_threads);
 
@@ -202,7 +202,7 @@ int main(int argc, char** argv) {
   bool useCUDA    = params.use_cuda != 0;
   bool useHIP     = params.use_hip != 0;
   bool useSYCL    = params.use_sycl != 0;
-  bool useSerial  = !useThreads && !useOMP && !useCUDA;
+  bool useSerial  = !useThreads && !useOMP && !useCUDA && !useHIP && !useSYCL;
 
   if (useThreads) {
 #if defined(KOKKOS_ENABLE_THREADS)


### PR DESCRIPTION
@masterleinad 
Not much needed to change, the device argument is currently ignored.