### PR TITLE
Fix GitHub CI failing on broken `develop`

### DIFF
--- a/example/graph/KokkosKernels_Example_Distance2GraphColor.cpp
+++ b/example/graph/KokkosKernels_Example_Distance2GraphColor.cpp
@@ -526,7 +526,9 @@ int main(int argc, char* argv[]) {
       params.use_openmp;  // Assumption is that use_openmp variable is provided
                           // as number of threads
   const int device_id = 0;
-  Kokkos::initialize(Kokkos::InitArguments(num_threads, -1, device_id));
+  Kokkos::initialize(Kokkos::InitializationSettings()
+                         .set_num_threads(num_threads)
+                         .set_device_id(device_id));
 
   // Print out information about the configuration of the run if verbose_level
   // >= 5

--- a/example/hashmap_accumulator/KokkosKernels_Example_HashmapAccumulator.cpp
+++ b/example/hashmap_accumulator/KokkosKernels_Example_HashmapAccumulator.cpp
@@ -384,7 +384,9 @@ int main(int argc, char* argv[]) {
       params.use_openmp;  // Assumption is that use_openmp variable is provided
                           // as number of threads
 
-  Kokkos::initialize(Kokkos::InitArguments(num_threads, -1, device_id));
+  Kokkos::initialize(Kokkos::InitializationSettings()
+                         .set_num_threads(num_threads)
+                         .set_device_id(device_id));
 
   if (params.verbose) {
     Kokkos::print_configuration(std::cout);

--- a/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test.cpp
@@ -199,7 +199,9 @@ int main(int argc, char** argv) {
 
   const int num_threads = std::max(params.use_openmp, params.use_threads);
 
-  Kokkos::initialize(Kokkos::InitArguments(num_threads, -1, device_id));
+  Kokkos::initialize(Kokkos::InitializationSettings()
+                         .set_num_threads(num_threads)
+                         .set_device_id(device_id));
 
   bool useThreads = params.use_threads != 0;
   bool useOMP     = params.use_openmp != 0;

--- a/perf_test/blas/blas1/KokkosBlas_dot_perf_test.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_perf_test.cpp
@@ -196,7 +196,9 @@ int main(int argc, char** argv) {
 
   const int num_threads = std::max(params.use_openmp, params.use_threads);
 
-  Kokkos::initialize(Kokkos::InitArguments(num_threads, -1, device_id));
+  Kokkos::initialize(Kokkos::InitializationSettings()
+                         .set_num_threads(num_threads)
+                         .set_device_id(device_id));
 
   bool useThreads = params.use_threads != 0;
   bool useOMP     = params.use_openmp != 0;

--- a/perf_test/blas/blas1/KokkosBlas_team_dot_perf_test.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_team_dot_perf_test.cpp
@@ -188,7 +188,9 @@ int main(int argc, char** argv) {
 
   const int num_threads = std::max(params.use_openmp, params.use_threads);
 
-  Kokkos::initialize(Kokkos::InitArguments(num_threads, -1, device_id));
+  Kokkos::initialize(Kokkos::InitializationSettings()
+                         .set_num_threads(num_threads)
+                         .set_device_id(device_id));
 
   bool useThreads = params.use_threads != 0;
   bool useOMP     = params.use_openmp != 0;

--- a/perf_test/blas/blas2/KokkosBlas2_gemv_perf_test.cpp
+++ b/perf_test/blas/blas2/KokkosBlas2_gemv_perf_test.cpp
@@ -180,7 +180,9 @@ int main(int argc, char** argv) {
   const int num_threads = std::max(params.use_openmp, params.use_threads);
 
   const int device_id = std::max(params.use_cuda, params.use_hip) - 1;
-  Kokkos::initialize(Kokkos::InitArguments(num_threads, -1, device_id));
+  Kokkos::initialize(Kokkos::InitializationSettings()
+                         .set_num_threads(num_threads)
+                         .set_device_id(device_id));
 
   // Create booleans to handle pthreads, openmp and cuda params and initialize
   // to true;

--- a/perf_test/blas/blas3/KokkosBlas3_gemm_standalone_perf_test.cpp
+++ b/perf_test/blas/blas3/KokkosBlas3_gemm_standalone_perf_test.cpp
@@ -158,7 +158,9 @@ int main(int argc, char** argv) {
                           // as number of threads
   const int device_id = params.use_cuda - 1;
 
-  Kokkos::initialize(Kokkos::InitArguments(num_threads, -1, device_id));
+  Kokkos::initialize(Kokkos::InitializationSettings()
+                         .set_num_threads(num_threads)
+                         .set_device_id(device_id));
 
   bool useOMP  = params.use_openmp != 0;
   bool useCUDA = params.use_cuda != 0;

--- a/perf_test/graph/KokkosGraph_color.cpp
+++ b/perf_test/graph/KokkosGraph_color.cpp
@@ -536,7 +536,9 @@ int main(int argc, char **argv) {
       params.use_openmp;  // Assumption is that use_openmp variable is provided
                           // as number of threads
   const int device_id = std::max(params.use_cuda, params.use_hip) - 1;
-  Kokkos::initialize(Kokkos::InitArguments(num_threads, -1, device_id));
+  Kokkos::initialize(Kokkos::InitializationSettings()
+                         .set_num_threads(num_threads)
+                         .set_device_id(device_id));
   Kokkos::print_configuration(std::cout);
 
 #if defined(KOKKOS_ENABLE_OPENMP)

--- a/perf_test/graph/KokkosGraph_color_d2.cpp
+++ b/perf_test/graph/KokkosGraph_color_d2.cpp
@@ -632,7 +632,9 @@ int main(int argc, char* argv[]) {
     device_id = params.use_cuda - 1;
   else if (params.use_hip)
     device_id = params.use_hip - 1;
-  Kokkos::initialize(Kokkos::InitArguments(num_threads, -1, device_id));
+  Kokkos::initialize(Kokkos::InitializationSettings()
+                         .set_num_threads(num_threads)
+                         .set_device_id(device_id));
 
   // Print out verbose information about the configuration of the run.
   // Kokkos::print_configuration(std::cout);

--- a/perf_test/graph/KokkosGraph_triangle.cpp
+++ b/perf_test/graph/KokkosGraph_triangle.cpp
@@ -303,7 +303,7 @@ int main(int argc, char **argv) {
 #if defined(KOKKOS_ENABLE_OPENMP)
 
   if (params.use_openmp) {
-    Kokkos::OpenMP::print_configuration(std::cout);
+    Kokkos::OpenMP().print_configuration(std::cout);
 #ifdef KOKKOSKERNELS_MULTI_MEM
     KokkosKernels::Experiment::run_multi_mem_triangle<
         size_type, idx, Kokkos::OpenMP, Kokkos::OpenMP::memory_space,
@@ -319,7 +319,7 @@ int main(int argc, char **argv) {
 
 #if defined(KOKKOS_ENABLE_CUDA)
   if (params.use_cuda) {
-    Kokkos::Cuda::print_configuration(std::cout);
+    Kokkos::Cuda().print_configuration(std::cout);
 #ifdef KOKKOSKERNELS_MULTI_MEM
     KokkosKernels::Experiment::run_multi_mem_triangle<
         size_type, idx, Kokkos::Cuda, Kokkos::Cuda::memory_space,
@@ -335,7 +335,7 @@ int main(int argc, char **argv) {
 
 #if defined(KOKKOS_ENABLE_HIP)
   if (params.use_hip) {
-    Kokkos::Experimental::HIP::print_configuration(std::cout);
+    Kokkos::Experimental::HIP().print_configuration(std::cout);
     KokkosKernels::Experiment::run_multi_mem_triangle<
         size_type, idx, Kokkos::Experimental::HIP,
         Kokkos::Experimental::HIPSpace, Kokkos::Experimental::HIPSpace>(params);

--- a/perf_test/graph/KokkosGraph_triangle.cpp
+++ b/perf_test/graph/KokkosGraph_triangle.cpp
@@ -296,7 +296,9 @@ int main(int argc, char **argv) {
       params.use_openmp;  // Assumption is that use_openmp variable is provided
                           // as number of threads
   const int device_id = 0;
-  Kokkos::initialize(Kokkos::InitArguments(num_threads, -1, device_id));
+  Kokkos::initialize(Kokkos::InitializationSettings()
+                         .set_num_threads(num_threads)
+                         .set_device_id(device_id));
 
 #if defined(KOKKOS_ENABLE_OPENMP)
 

--- a/perf_test/sparse/KokkosSparse_block_pcg.cpp
+++ b/perf_test/sparse/KokkosSparse_block_pcg.cpp
@@ -437,7 +437,7 @@ int main(int argc, char **argv) {
 
   if (cmdline[CMD_USE_SERIAL]) {
     using myExecSpace = Kokkos::Serial;
-    Kokkos::Serial::print_configuration(std::cout);
+    myExecSpace().print_configuration(std::cout);
 
     using crsMat_t =
         typename KokkosSparse::CrsMatrix<SCALAR_TYPE, INDEX_TYPE, myExecSpace,
@@ -460,7 +460,7 @@ int main(int argc, char **argv) {
 
   if (cmdline[CMD_USE_THREADS]) {
     using myExecSpace = Kokkos::Threads;
-    Kokkos::Threads::print_configuration(std::cout);
+    myExecSpace().print_configuration(std::cout);
 
     using crsMat_t =
         typename KokkosSparse::CrsMatrix<SCALAR_TYPE, INDEX_TYPE, myExecSpace,
@@ -483,7 +483,7 @@ int main(int argc, char **argv) {
 
   if (cmdline[CMD_USE_OPENMP]) {
     using myExecSpace = Kokkos::OpenMP;
-    Kokkos::OpenMP::print_configuration(std::cout);
+    myExecSpace().print_configuration(std::cout);
 
     using crsMat_t =
         typename KokkosSparse::CrsMatrix<SCALAR_TYPE, INDEX_TYPE, myExecSpace,
@@ -506,7 +506,7 @@ int main(int argc, char **argv) {
   if (cmdline[CMD_USE_CUDA]) {
     // Use the last device:
     using myExecSpace = Kokkos::Cuda;
-    Kokkos::Cuda::print_configuration(std::cout);
+    myExecSpace().print_configuration(std::cout);
 
     using crsMat_t =
         typename KokkosSparse::CrsMatrix<SCALAR_TYPE, INDEX_TYPE, myExecSpace,

--- a/perf_test/sparse/KokkosSparse_block_pcg.cpp
+++ b/perf_test/sparse/KokkosSparse_block_pcg.cpp
@@ -381,7 +381,7 @@ int main(int argc, char **argv) {
   int cmdline[CMD_COUNT];
   char *mtx_bin_file = NULL;
   int block_size     = 5;
-  struct Kokkos::InitArguments kargs;
+  struct Kokkos::InitializationSettings kargs;
 
   for (int i = 0; i < CMD_COUNT; ++i) cmdline[i] = 0;
 
@@ -389,9 +389,11 @@ int main(int argc, char **argv) {
     if (0 == Test::string_compare_no_case(argv[i], "--serial")) {
       cmdline[CMD_USE_SERIAL] = 1;
     } else if (0 == Test::string_compare_no_case(argv[i], "--threads")) {
-      kargs.num_threads = cmdline[CMD_USE_THREADS] = atoi(argv[++i]);
+      cmdline[CMD_USE_THREADS] = atoi(argv[++i]);
+      kargs.set_num_threads(cmdline[CMD_USE_THREADS]);
     } else if (0 == Test::string_compare_no_case(argv[i], "--openmp")) {
-      kargs.num_threads = cmdline[CMD_USE_OPENMP] = atoi(argv[++i]);
+      cmdline[CMD_USE_OPENMP] = atoi(argv[++i]);
+      kargs.set_num_threads(cmdline[CMD_USE_OPENMP]);
     } else if (0 == Test::string_compare_no_case(argv[i], "--cuda")) {
       cmdline[CMD_USE_CUDA] = 1;
     } else if (0 == Test::string_compare_no_case(argv[i], "--mtx")) {

--- a/perf_test/sparse/KokkosSparse_pcg.cpp
+++ b/perf_test/sparse/KokkosSparse_pcg.cpp
@@ -370,17 +370,16 @@ int main(int argc, char **argv) {
     return 0;
   }
 
-  Kokkos::InitArguments init_args;  // Construct with default args, change
-                                    // members based on exec space
+  // Construct with default args, change members based on exec space
+  Kokkos::InitializationSettings init_args;
 
-  init_args.device_id = cmdline[CMD_DEVICE];
+  init_args.set_device_id(cmdline[CMD_DEVICE]);
+  init_args.set_num_threads(
+      std::max(cmdline[CMD_USE_THREADS], cmdline[CMD_USE_OPENMP]));
   if (cmdline[CMD_USE_NUMA] && cmdline[CMD_USE_CORE_PER_NUMA]) {
-    init_args.num_threads =
-        std::max(cmdline[CMD_USE_THREADS], cmdline[CMD_USE_OPENMP]);
-    init_args.num_numa = cmdline[CMD_USE_NUMA];
-  } else {
-    init_args.num_threads =
-        std::max(cmdline[CMD_USE_THREADS], cmdline[CMD_USE_OPENMP]);
+    KokkosKernels::Impl::throw_runtime_exception(
+        "NUMA init arg is no longer supported by Kokkos");
+    // init_args.num_numa = cmdline[CMD_USE_NUMA];
   }
 
   Kokkos::initialize(init_args);

--- a/perf_test/sparse/KokkosSparse_spadd.cpp
+++ b/perf_test/sparse/KokkosSparse_spadd.cpp
@@ -476,7 +476,9 @@ int main(int argc, char** argv) {
                           // as number of threads
   const int device_id = params.use_cuda - 1;
 
-  Kokkos::initialize(Kokkos::InitArguments(num_threads, -1, device_id));
+  Kokkos::initialize(Kokkos::InitializationSettings()
+                         .set_num_threads(num_threads)
+                         .set_device_id(device_id));
   // Kokkos::print_configuration(std::cout);
 
   // First, make sure that requested TPL (if any) is actually available

--- a/perf_test/sparse/KokkosSparse_spgemm.cpp
+++ b/perf_test/sparse/KokkosSparse_spgemm.cpp
@@ -294,7 +294,9 @@ int main(int argc, char** argv) {
   const int device_id =
       params.use_cuda ? params.use_cuda - 1 : params.use_hip - 1;
 
-  Kokkos::initialize(Kokkos::InitArguments(num_threads, -1, device_id));
+  Kokkos::initialize(Kokkos::InitializationSettings()
+                         .set_num_threads(num_threads)
+                         .set_device_id(device_id));
   Kokkos::print_configuration(std::cout);
 
 #if defined(KOKKOS_ENABLE_OPENMP)

--- a/perf_test/sparse/KokkosSparse_spgemm_jacobi.cpp
+++ b/perf_test/sparse/KokkosSparse_spgemm_jacobi.cpp
@@ -259,7 +259,9 @@ int main(int argc, char** argv) {
   const int num_threads = std::max(params.use_openmp, params.use_threads);
   const int device_id   = params.use_cuda - 1;
 
-  Kokkos::initialize(Kokkos::InitArguments(num_threads, -1, device_id));
+  Kokkos::initialize(Kokkos::InitializationSettings()
+                         .set_num_threads(num_threads)
+                         .set_device_id(device_id));
   Kokkos::print_configuration(std::cout);
 
 #if defined(KOKKOS_ENABLE_OPENMP)

--- a/src/batched/dense/impl/KokkosBatched_Gesv_Impl.hpp
+++ b/src/batched/dense/impl/KokkosBatched_Gesv_Impl.hpp
@@ -545,7 +545,6 @@ struct TeamGesv<MemberType, Gesv::StaticPivoting> {
 #endif
     using ScratchPadMatrixViewType = Kokkos::View<
         typename MatrixType::non_const_value_type **,
-        typename MatrixType::array_layout,
         typename MatrixType::execution_space::scratch_memory_space>;
 
     const int n = A.extent(0);
@@ -682,7 +681,6 @@ struct TeamVectorGesv<MemberType, Gesv::StaticPivoting> {
 #endif
     using ScratchPadMatrixViewType = Kokkos::View<
         typename MatrixType::non_const_value_type **,
-        typename MatrixType::array_layout,
         typename MatrixType::execution_space::scratch_memory_space>;
 
     const int n = A.extent(0);

--- a/src/graph/impl/KokkosGraph_Distance2Color_impl.hpp
+++ b/src/graph/impl/KokkosGraph_Distance2Color_impl.hpp
@@ -51,7 +51,6 @@
 #include <type_traits>
 
 #include <Kokkos_Core.hpp>
-#include <Kokkos_UniqueToken.hpp>
 
 #include <KokkosKernels_Uniform_Initialized_MemoryPool.hpp>
 #include <KokkosKernels_HashmapAccumulator.hpp>

--- a/src/sparse/KokkosSparse_csc2csr.hpp
+++ b/src/sparse/KokkosSparse_csc2csr.hpp
@@ -43,14 +43,7 @@
 */
 
 #include "KokkosKernels_Utils.hpp"
-#include <std_algorithms/Kokkos_BeginEnd.hpp>
-#include <std_algorithms/Kokkos_AdjacentDifference.hpp>
-#include <std_algorithms/Kokkos_Reduce.hpp>
-#include <std_algorithms/Kokkos_TransformReduce.hpp>
-#include <std_algorithms/Kokkos_ExclusiveScan.hpp>
-#include <std_algorithms/Kokkos_TransformExclusiveScan.hpp>
-#include <std_algorithms/Kokkos_InclusiveScan.hpp>
-#include <std_algorithms/Kokkos_TransformInclusiveScan.hpp>
+#include <Kokkos_StdAlgorithms.hpp>
 
 #ifndef _KOKKOSSPARSE_CSC2CSR_HPP
 #define _KOKKOSSPARSE_CSC2CSR_HPP

--- a/src/sparse/impl/KokkosSparse_spgemm_mkl2phase_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_mkl2phase_impl.hpp
@@ -50,7 +50,6 @@
 #endif
 
 #include "KokkosKernels_Utils.hpp"
-#include <Kokkos_Concepts.hpp>
 #include <vector>
 
 namespace KokkosSparse {

--- a/src/sparse/impl/KokkosSparse_spgemm_mkl2phase_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_mkl2phase_impl.hpp
@@ -50,7 +50,6 @@
 #endif
 
 #include "KokkosKernels_Utils.hpp"
-#include <vector>
 
 namespace KokkosSparse {
 namespace Impl {

--- a/unit_test/common/Test_Common_set_bit_count.hpp
+++ b/unit_test/common/Test_Common_set_bit_count.hpp
@@ -51,9 +51,6 @@
 #include <string>
 #include <stdexcept>
 
-#include <gtest/gtest.h>
-#include <Kokkos_Core.hpp>
-
 // const char *input_filename = "sherman1.mtx";
 // const char *input_filename = "Si2.mtx";
 // const char *input_filename = "wathen_30_30.mtx";

--- a/unit_test/common/Test_Common_set_bit_count.hpp
+++ b/unit_test/common/Test_Common_set_bit_count.hpp
@@ -48,7 +48,6 @@
 #include "KokkosKernels_BitUtils.hpp"
 #include "KokkosKernels_SimpleUtils.hpp"
 #include "KokkosKernels_PrintUtils.hpp"
-#include <Kokkos_Concepts.hpp>
 #include <string>
 #include <stdexcept>
 

--- a/unit_test/sparse/Test_Sparse_spgemm.hpp
+++ b/unit_test/sparse/Test_Sparse_spgemm.hpp
@@ -47,7 +47,6 @@
 
 #include "KokkosSparse_Utils.hpp"
 #include "KokkosSparse_SortCrs.hpp"
-#include <Kokkos_Concepts.hpp>
 #include <string>
 #include <stdexcept>
 

--- a/unit_test/sparse/Test_Sparse_spgemm_jacobi.hpp
+++ b/unit_test/sparse/Test_Sparse_spgemm_jacobi.hpp
@@ -47,7 +47,6 @@
 
 #include "KokkosSparse_Utils.hpp"
 #include "KokkosSparse_SortCrs.hpp"
-#include <Kokkos_Concepts.hpp>
 #include <string>
 #include <stdexcept>
 

--- a/unit_test/sparse/Test_Sparse_spiluk.hpp
+++ b/unit_test/sparse/Test_Sparse_spiluk.hpp
@@ -45,7 +45,6 @@
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
 
-#include <Kokkos_Concepts.hpp>
 #include <string>
 #include <stdexcept>
 

--- a/unit_test/sparse/Test_Sparse_sptrsv.hpp
+++ b/unit_test/sparse/Test_Sparse_sptrsv.hpp
@@ -45,7 +45,6 @@
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
 
-#include <Kokkos_Concepts.hpp>
 #include <string>
 #include <stdexcept>
 
@@ -122,7 +121,7 @@ void run_test_sptrsv_mtx() {
     bool is_lower_tri = true;
     std::cout << "Create handle" << std::endl;
     kh.create_sptrsv_handle(SPTRSVAlgorithm::SEQLVLSCHD_TP1, nrows, is_lower_tri);
-    
+
     std::cout << "Prepare linear system" << std::endl;
     // Create known_lhs, generate rhs, then solve for lhs to compare to known_lhs
     ValuesType known_lhs("known_lhs", nrows);
@@ -239,7 +238,7 @@ void run_test_sptrsv_mtx() {
     bool is_lower_tri = false;
     std::cout << "Create handle" << std::endl;
     kh.create_sptrsv_handle(SPTRSVAlgorithm::SEQLVLSCHD_TP1, nrows, is_lower_tri);
-    
+
     std::cout << "Prepare linear system" << std::endl;
     // Create known_lhs, generate rhs, then solve for lhs to compare to known_lhs
     ValuesType known_lhs("known_lhs", nrows);


### PR DESCRIPTION
@lucbv @crtrott @kliegeois 

This PR addresses couple of issues that cause GitHub CI to fail with _unrelated_ compilation errors (i.e. broken `develop`):
* Kokkos updates:
  - [x] [PR#5135](https://github.com/kokkos/kokkos/pull/5135) deprecates `Kokkos::InitArguments` replacing it with new `Kokkos::InitializationSettings`: here we update Kokkos initialization in performance tests accordingly;
    - **Note:** Deprecated `num_numa` was being set in [_perf_test/sparse/KokkosSparse_block_pcg.cpp_](https://github.com/kokkos/kokkos-kernels/pull/1461/files#diff-1d9913f65a6408f50d3d5bf03674cddfa41b08594efa5afd48baf7d6e2ea2146L380).
  - [x] [PR#5178](https://github.com/kokkos/kokkos/pull/5178) guards against private header inclusion: here we switch to _Kokkos_StdAlgorithms.hpp_ for std algorithms and just drop other private includes (like  _Kokkos_Concepts.hpp_);
  - [x] [PR#5144](https://github.com/kokkos/kokkos/pull/5144) removes `static` from execution space `print_configuration()`: we call it on instances now;
* Bugs:
  - [x] Bug in batched GESV (introduced by #1384) and detected with `Kokkos_ENABLE_DEBUG_BOUNDS_CHECK=ON` introduced by #1411 - see [the details below](https://github.com/kokkos/kokkos-kernels/pull/1461#issuecomment-1182232042);
