### PR TITLE
trsv: remove assumptions about entry order within rows

### DIFF
--- a/unit_test/sparse/Test_Sparse_trsv.hpp
+++ b/unit_test/sparse/Test_Sparse_trsv.hpp
@@ -104,16 +104,19 @@ void test_trsv_mv(lno_t numRows, size_type nnz, lno_t bandwidth,
   Test::check_trsv_mv(upper_part, b_x, b_y, b_x_copy, numMV, "U", "T");
 }
 
+// Note BMK 7-22: the matrix generator used by this test always
+// generates a dense triangle. It ignores bandwidth, nnz and row size variance.
+
 #define EXECUTE_TEST_MV(SCALAR, ORDINAL, OFFSET, LAYOUT, DEVICE)                    \
   TEST_F(                                                                           \
       TestCategory,                                                                 \
       sparse##_##trsv_mv##_##SCALAR##_##ORDINAL##_##OFFSET##_##LAYOUT##_##DEVICE) { \
     test_trsv_mv<SCALAR, ORDINAL, OFFSET, Kokkos::LAYOUT, DEVICE>(                  \
-        5000, 5000 * 30, 200, 10, 1);                                               \
+        1000, 1000 * 30, 200, 10, 1);                                               \
     test_trsv_mv<SCALAR, ORDINAL, OFFSET, Kokkos::LAYOUT, DEVICE>(                  \
-        5000, 5000 * 30, 100, 10, 5);                                               \
+        800, 800 * 30, 100, 10, 5);                                                 \
     test_trsv_mv<SCALAR, ORDINAL, OFFSET, Kokkos::LAYOUT, DEVICE>(                  \
-        1000, 1000 * 20, 100, 5, 10);                                               \
+        400, 400 * 20, 100, 5, 10);                                                 \
   }
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) || \

--- a/unit_test/sparse/Test_Sparse_trsv.hpp
+++ b/unit_test/sparse/Test_Sparse_trsv.hpp
@@ -79,6 +79,10 @@ void test_trsv_mv(lno_t numRows, size_type nnz, lno_t bandwidth,
   crsMat_t lower_part =
       KokkosSparse::Impl::kk_generate_triangular_sparse_matrix<crsMat_t>(
           'L', numRows, numCols, nnz, row_size_variance, bandwidth);
+
+  Test::shuffleMatrixEntries(lower_part.graph.row_map, lower_part.graph.entries,
+                             lower_part.values);
+
   KokkosSparse::spmv("N", alpha, lower_part, b_x_copy, beta, b_y);
   Test::check_trsv_mv(lower_part, b_x, b_y, b_x_copy, numMV, "L", "N");
 
@@ -89,6 +93,10 @@ void test_trsv_mv(lno_t numRows, size_type nnz, lno_t bandwidth,
   crsMat_t upper_part =
       KokkosSparse::Impl::kk_generate_triangular_sparse_matrix<crsMat_t>(
           'U', numRows, numCols, nnz, row_size_variance, bandwidth);
+
+  Test::shuffleMatrixEntries(upper_part.graph.row_map, upper_part.graph.entries,
+                             upper_part.values);
+
   KokkosSparse::spmv("N", alpha, upper_part, b_x_copy, beta, b_y);
   Test::check_trsv_mv(upper_part, b_x, b_y, b_x_copy, numMV, "U", "N");
 


### PR DESCRIPTION
In trsv, don't assume the diagonal entry is first in its row if the matrix is upper triangular. Test this by randomly shuffling each row of the matrix used for testing.

Must wait until #1461 is merged.