### PR TITLE
Fix -Werror

### DIFF
--- a/perf_test/sparse/KokkosSparse_block_pcg.cpp
+++ b/perf_test/sparse/KokkosSparse_block_pcg.cpp
@@ -381,7 +381,7 @@ int main(int argc, char **argv) {
   int cmdline[CMD_COUNT];
   char *mtx_bin_file = NULL;
   int block_size     = 5;
-  struct Kokkos::InitializationSettings kargs;
+  Kokkos::InitializationSettings kargs;
 
   for (int i = 0; i < CMD_COUNT; ++i) cmdline[i] = 0;
 


### PR DESCRIPTION
Drop struct from creation of Kokkos::InitializationSettings type

Small fix for `-Werror,-Wmismatched-tags` picked up in clang/7 nightly builds