### PR TITLE
Fix build when double not instantiated

### DIFF
--- a/unit_test/graph/Test_Graph_graph_color.hpp
+++ b/unit_test/graph/Test_Graph_graph_color.hpp
@@ -50,6 +50,7 @@
 #include "KokkosSparse_IOUtils.hpp"
 #include "KokkosSparse_Utils.hpp"
 #include "KokkosKernels_Handle.hpp"
+#include "KokkosKernels_default_types.hpp"
 
 using namespace KokkosKernels;
 using namespace KokkosKernels::Experimental;
@@ -220,14 +221,14 @@ void test_coloring(lno_t numRows, size_type nnz, lno_t bandwidth,
      defined(KOKKOSKERNELS_INST_OFFSET_INT)) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-EXECUTE_TEST(double, int, int, TestExecSpace)
+EXECUTE_TEST(default_scalar, int, int, TestExecSpace)
 #endif
 
 #if (defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T) && \
      defined(KOKKOSKERNELS_INST_OFFSET_INT)) ||     \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&            \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-EXECUTE_TEST(double, int64_t, int, TestExecSpace)
+EXECUTE_TEST(default_scalar, int64_t, int, TestExecSpace)
 #endif
 
 // FIXME_SYCL
@@ -236,7 +237,7 @@ EXECUTE_TEST(double, int64_t, int, TestExecSpace)
      defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&           \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-EXECUTE_TEST(double, int, size_t, TestExecSpace)
+EXECUTE_TEST(default_scalar, int, size_t, TestExecSpace)
 #endif
 #endif
 
@@ -244,7 +245,7 @@ EXECUTE_TEST(double, int, size_t, TestExecSpace)
      defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)) ||  \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&            \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-EXECUTE_TEST(double, int64_t, size_t, TestExecSpace)
+EXECUTE_TEST(default_scalar, int64_t, size_t, TestExecSpace)
 #endif
 
 #undef EXECUTE_TEST

--- a/unit_test/graph/Test_Graph_graph_color_deterministic.hpp
+++ b/unit_test/graph/Test_Graph_graph_color_deterministic.hpp
@@ -50,6 +50,7 @@
 #include "KokkosKernels_IOUtils.hpp"
 #include "KokkosSparse_Utils.hpp"
 #include "KokkosKernels_Handle.hpp"
+#include "KokkosKernels_default_types.hpp"
 
 using namespace KokkosKernels;
 using namespace KokkosKernels::Experimental;
@@ -274,28 +275,28 @@ void test_coloring_deterministic(lno_t numRows, size_type nnz) {
      defined(KOKKOSKERNELS_INST_OFFSET_INT)) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-EXECUTE_TEST(double, int, int, TestExecSpace)
+EXECUTE_TEST(default_scalar, int, int, TestExecSpace)
 #endif
 
 #if (defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T) && \
      defined(KOKKOSKERNELS_INST_OFFSET_INT)) ||     \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&            \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-EXECUTE_TEST(double, int64_t, int, TestExecSpace)
+EXECUTE_TEST(default_scalar, int64_t, int, TestExecSpace)
 #endif
 
 #if (defined(KOKKOSKERNELS_INST_ORDINAL_INT) &&    \
      defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&           \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-EXECUTE_TEST(double, int, size_t, TestExecSpace)
+EXECUTE_TEST(default_scalar, int, size_t, TestExecSpace)
 #endif
 
 #if (defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T) && \
      defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)) ||  \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&            \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-EXECUTE_TEST(double, int64_t, size_t, TestExecSpace)
+EXECUTE_TEST(default_scalar, int64_t, size_t, TestExecSpace)
 #endif
 
 #undef EXECUTE_TEST


### PR DESCRIPTION
Use default scalar (may be float or double) for the KernelHandle in graph coloring unit test. If double was not instantiated before,
hardcoding double here caused undefined reference errors.