### PR TITLE
Fix arithtraits warning

### DIFF
--- a/src/common/Kokkos_ArithTraits.hpp
+++ b/src/common/Kokkos_ArithTraits.hpp
@@ -413,25 +413,37 @@ namespace Details {
   static FUNC_QUAL val_type squareroot(const val_type x) { return sqrt(x); }   \
   static FUNC_QUAL mag_type eps() { return epsilon(); }
 
-template<typename val_type>
+template <typename val_type>
 static KOKKOS_FUNCTION
-typename std::enable_if<std::numeric_limits<val_type>::is_signed, val_type>::type
-KokkosKernelsAbs(const val_type x) { return Kokkos::abs(x); }
+    typename std::enable_if<std::numeric_limits<val_type>::is_signed,
+                            val_type>::type
+    KokkosKernelsAbs(const val_type x) {
+  return Kokkos::abs(x);
+}
 
-template<typename val_type>
+template <typename val_type>
 static KOKKOS_FUNCTION
-typename std::enable_if<!std::numeric_limits<val_type>::is_signed, val_type>::type
-KokkosKernelsAbs(const val_type x) { return x; }
+    typename std::enable_if<!std::numeric_limits<val_type>::is_signed,
+                            val_type>::type
+    KokkosKernelsAbs(const val_type x) {
+  return x;
+}
 
-template<typename val_type>
+template <typename val_type>
 static KOKKOS_FUNCTION
-typename std::enable_if<std::numeric_limits<val_type>::is_signed, val_type>::type
-KokkosKernelsNan() { return -1; }
+    typename std::enable_if<std::numeric_limits<val_type>::is_signed,
+                            val_type>::type
+    KokkosKernelsNan() {
+  return -1;
+}
 
-template<typename val_type>
+template <typename val_type>
 static KOKKOS_FUNCTION
-typename std::enable_if<!std::numeric_limits<val_type>::is_signed, val_type>::type
-KokkosKernelsNan() { return Kokkos::Experimental::finite_max<val_type>::value; }
+    typename std::enable_if<!std::numeric_limits<val_type>::is_signed,
+                            val_type>::type
+    KokkosKernelsNan() {
+  return Kokkos::Experimental::finite_max<val_type>::value;
+}
 
 #define KOKKOSKERNELS_ARITHTRAITS_INTEGRAL()                                  \
                                                                               \

--- a/src/common/Kokkos_ArithTraits.hpp
+++ b/src/common/Kokkos_ArithTraits.hpp
@@ -431,7 +431,7 @@ KokkosKernelsNan() { return -1; }
 template<typename val_type>
 static KOKKOS_FUNCTION
 typename std::enable_if<!std::numeric_limits<val_type>::is_signed, val_type>::type
-KokkosKernelsNan() { return max(); }
+KokkosKernelsNan() { return Kokkos::Experimental::finite_max<val_type>::value; }
 
 #define KOKKOSKERNELS_ARITHTRAITS_INTEGRAL()                                  \
                                                                               \

--- a/src/common/Kokkos_ArithTraits.hpp
+++ b/src/common/Kokkos_ArithTraits.hpp
@@ -413,22 +413,27 @@ namespace Details {
   static FUNC_QUAL val_type squareroot(const val_type x) { return sqrt(x); }   \
   static FUNC_QUAL mag_type eps() { return epsilon(); }
 
-#define KOKKOSKERNELS_SIGNED_ABS                          \
-  static KOKKOS_FUNCTION mag_type abs(const val_type x) { \
-    return Kokkos::abs(x);                                \
-  }
+template<typename val_type>
+static KOKKOS_FUNCTION
+typename std::enable_if<std::numeric_limits<val_type>::is_signed, val_type>::type
+KokkosKernelsAbs(const val_type x) { return Kokkos::abs(x); }
 
-#define KOKKOSKERNELS_UNSIGNED_ABS \
-  static KOKKOS_FUNCTION mag_type abs(const val_type x) { return x; }
+template<typename val_type>
+static KOKKOS_FUNCTION
+typename std::enable_if<!std::numeric_limits<val_type>::is_signed, val_type>::type
+KokkosKernelsAbs(const val_type x) { return x; }
 
-#define KOKKOSKERNELS_SIGNED_NAN \
-  static KOKKOS_FUNCTION val_type nan() { return -1; }
+template<typename val_type>
+static KOKKOS_FUNCTION
+typename std::enable_if<std::numeric_limits<val_type>::is_signed, val_type>::type
+KokkosKernelsNan() { return -1; }
 
-#define KOKKOSKERNELS_UNSIGNED_NAN \
-  static KOKKOS_FUNCTION val_type nan() { return max(); }
+template<typename val_type>
+static KOKKOS_FUNCTION
+typename std::enable_if<!std::numeric_limits<val_type>::is_signed, val_type>::type
+KokkosKernelsNan() { return max(); }
 
-#define KOKKOSKERNELS_ARITHTRAITS_INTEGRAL(KOKKOSKERNELS_ABS,                 \
-                                           KOKKOSKERNELS_NAN)                 \
+#define KOKKOSKERNELS_ARITHTRAITS_INTEGRAL()                                  \
                                                                               \
   static constexpr bool is_specialized = true;                                \
   static constexpr bool is_integer     = true;                                \
@@ -456,10 +461,14 @@ namespace Details {
   static KOKKOS_FUNCTION val_type infinity() {                                \
     return static_cast<val_type>(0);                                          \
   }                                                                           \
-  KOKKOSKERNELS_NAN                                                           \
+  static KOKKOS_FUNCTION val_type nan() {                                     \
+    return KokkosKernelsNan<val_type>();                                      \
+  }                                                                           \
   static KOKKOS_FUNCTION bool isInf(const val_type) { return false; }         \
   static KOKKOS_FUNCTION bool isNan(const val_type) { return false; }         \
-  KOKKOSKERNELS_ABS                                                           \
+  static KOKKOS_FUNCTION mag_type abs(const val_type x) {                     \
+    return KokkosKernelsAbs(x);                                               \
+  }                                                                           \
   static KOKKOS_FUNCTION mag_type real(const val_type x) {                    \
     return Kokkos::real(x);                                                   \
   }                                                                           \
@@ -1659,8 +1668,7 @@ class ArithTraits<char> {
 
   static std::string name() { return "char"; }
 
-  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL(KOKKOSKERNELS_SIGNED_ABS,
-                                     KOKKOSKERNELS_SIGNED_NAN)
+  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL()
 };
 
 template <>
@@ -1673,8 +1681,7 @@ class ArithTraits<signed char> {
 
   static std::string name() { return "signed char"; }
 
-  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL(KOKKOSKERNELS_SIGNED_ABS,
-                                     KOKKOSKERNELS_SIGNED_NAN)
+  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL()
 };
 
 template <>
@@ -1687,8 +1694,7 @@ class ArithTraits<unsigned char> {
 
   static std::string name() { return "unsigned char"; }
 
-  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL(KOKKOSKERNELS_UNSIGNED_ABS,
-                                     KOKKOSKERNELS_UNSIGNED_NAN)
+  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL()
 };
 
 template <>
@@ -1701,8 +1707,7 @@ class ArithTraits<short> {
 
   static std::string name() { return "short"; }
 
-  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL(KOKKOSKERNELS_SIGNED_ABS,
-                                     KOKKOSKERNELS_SIGNED_NAN)
+  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL()
 };
 
 template <>
@@ -1715,8 +1720,7 @@ class ArithTraits<unsigned short> {
 
   static std::string name() { return "unsigned short"; }
 
-  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL(KOKKOSKERNELS_UNSIGNED_ABS,
-                                     KOKKOSKERNELS_UNSIGNED_NAN)
+  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL()
 };
 
 template <>
@@ -1729,8 +1733,7 @@ class ArithTraits<int> {
 
   static std::string name() { return "int"; }
 
-  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL(KOKKOSKERNELS_SIGNED_ABS,
-                                     KOKKOSKERNELS_SIGNED_NAN)
+  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL()
 };
 
 template <>
@@ -1743,8 +1746,7 @@ class ArithTraits<unsigned int> {
 
   static std::string name() { return "unsigned int"; }
 
-  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL(KOKKOSKERNELS_UNSIGNED_ABS,
-                                     KOKKOSKERNELS_UNSIGNED_NAN)
+  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL()
 };
 
 template <>
@@ -1757,8 +1759,7 @@ class ArithTraits<long> {
 
   static std::string name() { return "long"; }
 
-  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL(KOKKOSKERNELS_SIGNED_ABS,
-                                     KOKKOSKERNELS_SIGNED_NAN)
+  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL()
 };
 
 template <>
@@ -1771,8 +1772,7 @@ class ArithTraits<unsigned long> {
 
   static std::string name() { return "unsigned long"; }
 
-  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL(KOKKOSKERNELS_UNSIGNED_ABS,
-                                     KOKKOSKERNELS_UNSIGNED_NAN)
+  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL()
 };
 
 template <>
@@ -1785,8 +1785,7 @@ class ArithTraits<long long> {
 
   static std::string name() { return "long long"; }
 
-  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL(KOKKOSKERNELS_SIGNED_ABS,
-                                     KOKKOSKERNELS_SIGNED_NAN)
+  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL()
 };
 
 template <>
@@ -1799,8 +1798,7 @@ class ArithTraits<unsigned long long> {
 
   static std::string name() { return "unsigned long long"; }
 
-  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL(KOKKOSKERNELS_UNSIGNED_ABS,
-                                     KOKKOSKERNELS_UNSIGNED_NAN)
+  KOKKOSKERNELS_ARITHTRAITS_INTEGRAL()
 };
 
 // dd_real and qd_real are floating-point types provided by the QD


### PR DESCRIPTION
Fixing warning being generated on IBM Power9
The warning comes from the current handling of char type that can be either signed or unsigned depending on the platform.
The new implementation uses enable_if to detect if numeric_limits<char>::is_signed is set to true or false and an appropriate implementation of abs() and nan() is selected.