### PR TITLE
Optimize TPL interface to rocsparse spmv by caching variables for repeated use

### DIFF
--- a/graph/src/KokkosGraph_CoarsenConstruct.hpp
+++ b/graph/src/KokkosGraph_CoarsenConstruct.hpp
@@ -1554,6 +1554,7 @@ class coarse_builder {
           ordinal_t u         = vcmap.graph.entries(outer_idx);
           edge_offset_t start = g.graph.row_map(outer_idx);
           edge_offset_t end   = g.graph.row_map(outer_idx + 1);
+          auto g_values       = g.values;
           Kokkos::parallel_for(
               Kokkos::TeamThreadRange(thread, start, end),
               [=](const edge_offset_t idx) {
@@ -1567,7 +1568,7 @@ class coarse_builder {
                   offset += source_bucket_offset(u);
 
                   dest_by_source(offset) = v;
-                  wgt_by_source(offset)  = g.values(idx);
+                  wgt_by_source(offset)  = g_values(idx);
                 }
               });
         });
@@ -1649,6 +1650,7 @@ class coarse_builder {
           ordinal_t u         = vcmap.graph.entries(outer_idx);
           edge_offset_t start = g.graph.row_map(outer_idx);
           edge_offset_t end   = g.graph.row_map(outer_idx + 1);
+          auto g_values       = g.values;
           Kokkos::parallel_for(
               Kokkos::TeamThreadRange(thread, start, end),
               [=](const edge_offset_t idx) {
@@ -1662,7 +1664,7 @@ class coarse_builder {
                   offset += row_map_copy(outer_idx);
 
                   dest_fine(offset) = v;
-                  wgt_fine(offset)  = g.values(idx);
+                  wgt_fine(offset)  = g_values(idx);
                 }
               });
         });

--- a/sparse/src/KokkosSparse_Utils_cusparse.hpp
+++ b/sparse/src/KokkosSparse_Utils_cusparse.hpp
@@ -19,7 +19,6 @@
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 #include "cuda.h"
-#include "cuda_runtime.h"
 #include "cusparse.h"
 
 namespace KokkosSparse {

--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -145,6 +145,22 @@ void spmv(const ExecutionSpace& space,
     }
   }
 
+#if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE)
+  // Allocate the spmv helper, which is passed to A_i below and gets populated
+  if (A.cuda_spmv_helper == nullptr) {
+    const_cast<AMatrix&>(A).cuda_spmv_helper =
+        std::make_shared<cuSparseSpMVHelper>();
+  }
+#endif
+
+#if defined(KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE)
+  // Allocate the spmv helper, which is passed to A_i below and gets populated
+  if (A.roc_spmv_helper == nullptr) {
+    const_cast<AMatrix&>(A).roc_spmv_helper =
+        std::make_shared<rocSparseSpMVHelper>();
+  }
+#endif
+
   typedef KokkosSparse::CrsMatrix<
       typename AMatrix::const_value_type, typename AMatrix::const_ordinal_type,
       typename AMatrix::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>,


### PR DESCRIPTION
Caching the temp variables is key to performance of repeated SpMV. I tested on one Crusher node with petsc microbenchmark (src/mat/tests/ex1k).

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-57f63c0c-7fff-468e-47c0-c6637abb2a4e">

 Average SpMV time (us) with matrix HV15R (of size 2M x 2M).
  | 1 rank | 8 ranks
-- | -- | --
TPL=OFF | 3743 | 636
TPL=ON | 14948 | 3713
TPL=ON + this PR | 2686 | 571

</b>

@lucbv  I hope to make `A.roc_spmv_helper` a private member, but I don't know how to access it in `spmv_rocsparse()` then.