### PR TITLE
BLAS: fixing test that access results before synching

### DIFF
--- a/unit_test/blas/Test_Blas1_dot.hpp
+++ b/unit_test/blas/Test_Blas1_dot.hpp
@@ -111,6 +111,7 @@ void impl_test_dot_mv(int N, int K) {
   Kokkos::View<ScalarB*, Kokkos::HostSpace> r("Dot::Result", K);
 
   KokkosBlas::dot(r, a, b);
+  Kokkos::fence();
   for (int k = 0; k < K; k++) {
     ScalarA nonconst_nonconst_result = r(k);
     EXPECT_NEAR_KK(nonconst_nonconst_result, expected_result[k],
@@ -118,6 +119,7 @@ void impl_test_dot_mv(int N, int K) {
   }
 
   KokkosBlas::dot(r, c_a, c_b);
+  Kokkos::fence();
   for (int k = 0; k < K; k++) {
     ScalarA const_const_result = r(k);
     EXPECT_NEAR_KK(const_const_result, expected_result[k],
@@ -125,6 +127,7 @@ void impl_test_dot_mv(int N, int K) {
   }
 
   KokkosBlas::dot(r, a, c_b);
+  Kokkos::fence();
   for (int k = 0; k < K; k++) {
     ScalarA non_const_const_result = r(k);
     EXPECT_NEAR_KK(non_const_const_result, expected_result[k],
@@ -132,6 +135,7 @@ void impl_test_dot_mv(int N, int K) {
   }
 
   KokkosBlas::dot(r, c_a, b);
+  Kokkos::fence();
   for (int k = 0; k < K; k++) {
     ScalarA const_non_const_result = r(k);
     EXPECT_NEAR_KK(const_non_const_result, expected_result[k],

--- a/unit_test/blas/Test_Blas1_iamax.hpp
+++ b/unit_test/blas/Test_Blas1_iamax.hpp
@@ -61,6 +61,7 @@ void impl_test_iamax(int N) {
     ViewType0D r("Iamax::Result 0-D View on host");
 
     KokkosBlas::iamax(r, a);
+    Kokkos::fence();
     size_type nonconst_max_loc = r();
     ASSERT_EQ(nonconst_max_loc, expected_max_loc);
 
@@ -151,6 +152,7 @@ void impl_test_iamax_mv(int N, int K) {
         r("Iamax::Result View on host", K);
 
     KokkosBlas::iamax(r, a);
+    Kokkos::fence();
 
     for (int k = 0; k < K; k++) {
       size_type nonconst_result = r(k);
@@ -159,6 +161,7 @@ void impl_test_iamax_mv(int N, int K) {
     }
 
     KokkosBlas::iamax(r, c_a);
+    Kokkos::fence();
 
     for (int k = 0; k < K; k++) {
       size_type const_result = r(k);

--- a/unit_test/blas/Test_Blas1_nrm1.hpp
+++ b/unit_test/blas/Test_Blas1_nrm1.hpp
@@ -98,6 +98,7 @@ void impl_test_nrm1_mv(int N, int K) {
 
   KokkosBlas::nrm1(r, a);
   KokkosBlas::nrm1(c_r, a);
+  Kokkos::fence();
   for (int k = 0; k < K; k++) {
     EXPECT_NEAR_KK(r(k), expected_result(k), eps * expected_result(k));
     EXPECT_NEAR_KK(c_r(k), expected_result(k), eps * expected_result(k));

--- a/unit_test/blas/Test_Blas1_nrm2.hpp
+++ b/unit_test/blas/Test_Blas1_nrm2.hpp
@@ -84,6 +84,7 @@ void impl_test_nrm2_mv(int N, int K) {
   Kokkos::View<typename AT::mag_type*, Kokkos::HostSpace> r("Dot::Result", K);
 
   KokkosBlas::nrm2(r, a);
+  Kokkos::fence();
   for (int k = 0; k < K; k++) {
     typename AT::mag_type nonconst_result = r(k);
     EXPECT_NEAR_KK(nonconst_result, expected_result[k],
@@ -91,6 +92,7 @@ void impl_test_nrm2_mv(int N, int K) {
   }
 
   KokkosBlas::nrm2(r, c_a);
+  Kokkos::fence();
   for (int k = 0; k < K; k++) {
     typename AT::mag_type const_result = r(k);
     EXPECT_NEAR_KK(const_result, expected_result[k], eps * expected_result[k]);

--- a/unit_test/blas/Test_Blas1_nrm2_squared.hpp
+++ b/unit_test/blas/Test_Blas1_nrm2_squared.hpp
@@ -93,6 +93,7 @@ void impl_test_nrm2_squared_mv(int N, int K) {
   Kokkos::View<typename AT::mag_type*, Kokkos::HostSpace> r("Dot::Result", K);
 
   KokkosBlas::nrm2_squared(r, a);
+  Kokkos::fence();
   for (int k = 0; k < K; k++) {
     typename AT::mag_type nonconst_result = r(k);
     typename AT::mag_type divisor =
@@ -103,6 +104,7 @@ void impl_test_nrm2_squared_mv(int N, int K) {
   }
 
   KokkosBlas::nrm2_squared(r, c_a);
+  Kokkos::fence();
   for (int k = 0; k < K; k++) {
     typename AT::mag_type const_result = r(k);
     typename AT::mag_type divisor =

--- a/unit_test/blas/Test_Blas1_sum.hpp
+++ b/unit_test/blas/Test_Blas1_sum.hpp
@@ -73,6 +73,7 @@ void impl_test_sum_mv(int N, int K) {
   Kokkos::View<ScalarA*, Kokkos::HostSpace> r("Sum::Result", K);
 
   KokkosBlas::sum(r, a);
+  Kokkos::fence();
   for (int k = 0; k < K; k++) {
     ScalarA nonconst_result = r(k);
     EXPECT_NEAR_KK(nonconst_result, expected_result[k],
@@ -80,6 +81,7 @@ void impl_test_sum_mv(int N, int K) {
   }
 
   KokkosBlas::sum(r, c_a);
+  Kokkos::fence();
   for (int k = 0; k < K; k++) {
     ScalarA const_result = r(k);
     EXPECT_NEAR_KK(const_result, expected_result[k], eps * expected_result[k]);


### PR DESCRIPTION
For some kernels that return results in host views the implementation is non-blocking and requires to do a Kokkos::fence() before checking the value against the reference value.