### PR TITLE
sycl: re-enabling test now that dpcpp has made progress

### DIFF
--- a/unit_test/common/Test_Common.hpp
+++ b/unit_test/common/Test_Common.hpp
@@ -1,10 +1,7 @@
 #ifndef TEST_COMMON_HPP
 #define TEST_COMMON_HPP
 
-// FIXME_SYCL still some uses of the wrong namespace
-#ifndef KOKKOS_ENABLE_SYCL
 #include <Test_Common_ArithTraits.hpp>
-#endif
 // #include<Test_Common_float128.hpp>
 #include <Test_Common_set_bit_count.hpp>
 #include <Test_Common_Sorting.hpp>

--- a/unit_test/graph/Test_Graph_graph_color.hpp
+++ b/unit_test/graph/Test_Graph_graph_color.hpp
@@ -231,14 +231,11 @@ EXECUTE_TEST(default_scalar, int, int, TestExecSpace)
 EXECUTE_TEST(default_scalar, int64_t, int, TestExecSpace)
 #endif
 
-// FIXME_SYCL
-#ifndef KOKKOS_ENABLE_SYCL
 #if (defined(KOKKOSKERNELS_INST_ORDINAL_INT) &&    \
      defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&           \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 EXECUTE_TEST(default_scalar, int, size_t, TestExecSpace)
-#endif
 #endif
 
 #if (defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T) && \


### PR DESCRIPTION
With the latest dpcpp compiler drop we can turn back on a couple of test.
The ArithTraits is also mostly using Kokkos implementation of math functions and numeric traits so we should be able to blame them for new issues :p