### PR TITLE
Fixup drop layout template param in rank-0 views

### DIFF
--- a/src/blas/KokkosBlas_trtri.hpp
+++ b/src/blas/KokkosBlas_trtri.hpp
@@ -129,7 +129,7 @@ int trtri(const char uplo[], const char diag[], const AViewType& A) {
 
   // This is the return value type and should always reside on host
   using RViewInternalType =
-      Kokkos::View<int, Kokkos::HostSpace,
+      Kokkos::View<int, Kokkos::LayoutRight, Kokkos::HostSpace,
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
 
   int result;

--- a/src/blas/KokkosBlas_trtri.hpp
+++ b/src/blas/KokkosBlas_trtri.hpp
@@ -129,7 +129,7 @@ int trtri(const char uplo[], const char diag[], const AViewType& A) {
 
   // This is the return value type and should always reside on host
   using RViewInternalType =
-      Kokkos::View<int, typename AViewType::array_layout, Kokkos::HostSpace,
+      Kokkos::View<int, Kokkos::HostSpace,
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
 
   int result;

--- a/src/blas/impl/KokkosBlas_trtri_spec.hpp
+++ b/src/blas/impl/KokkosBlas_trtri_spec.hpp
@@ -69,7 +69,7 @@ struct trtri_eti_spec_avail {
                                         MEM_SPACE)                           \
   template <>                                                                \
   struct trtri_eti_spec_avail<                                               \
-      Kokkos::View<int, LAYOUTA, Kokkos::HostSpace,                          \
+      Kokkos::View<int, Kokkos::HostSpace,                                   \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                \
       Kokkos::View<SCALAR**, LAYOUTA, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {             \
@@ -136,7 +136,7 @@ struct TRTRI<RVIT, AVIT, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 //
 #define KOKKOSBLAS_TRTRI_ETI_SPEC_DECL(SCALAR, LAYOUTA, EXEC_SPACE, MEM_SPACE) \
   extern template struct TRTRI<                                                \
-      Kokkos::View<int, LAYOUTA, Kokkos::HostSpace,                            \
+      Kokkos::View<int, Kokkos::HostSpace,                                     \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       Kokkos::View<SCALAR**, LAYOUTA, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,   \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
@@ -144,7 +144,7 @@ struct TRTRI<RVIT, AVIT, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 
 #define KOKKOSBLAS_TRTRI_ETI_SPEC_INST(SCALAR, LAYOUTA, EXEC_SPACE, MEM_SPACE) \
   template struct TRTRI<                                                       \
-      Kokkos::View<int, LAYOUTA, Kokkos::HostSpace,                            \
+      Kokkos::View<int, Kokkos::HostSpace,                                     \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       Kokkos::View<SCALAR**, LAYOUTA, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,   \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \

--- a/src/blas/impl/KokkosBlas_trtri_spec.hpp
+++ b/src/blas/impl/KokkosBlas_trtri_spec.hpp
@@ -69,7 +69,7 @@ struct trtri_eti_spec_avail {
                                         MEM_SPACE)                           \
   template <>                                                                \
   struct trtri_eti_spec_avail<                                               \
-      Kokkos::View<int, Kokkos::HostSpace,                                   \
+      Kokkos::View<int, Kokkos::LayoutRight, Kokkos::HostSpace,              \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                \
       Kokkos::View<SCALAR**, LAYOUTA, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {             \
@@ -136,7 +136,7 @@ struct TRTRI<RVIT, AVIT, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 //
 #define KOKKOSBLAS_TRTRI_ETI_SPEC_DECL(SCALAR, LAYOUTA, EXEC_SPACE, MEM_SPACE) \
   extern template struct TRTRI<                                                \
-      Kokkos::View<int, Kokkos::HostSpace,                                     \
+      Kokkos::View<int, Kokkos::LayoutRight, Kokkos::HostSpace,                \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       Kokkos::View<SCALAR**, LAYOUTA, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,   \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
@@ -144,7 +144,7 @@ struct TRTRI<RVIT, AVIT, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 
 #define KOKKOSBLAS_TRTRI_ETI_SPEC_INST(SCALAR, LAYOUTA, EXEC_SPACE, MEM_SPACE) \
   template struct TRTRI<                                                       \
-      Kokkos::View<int, Kokkos::HostSpace,                                     \
+      Kokkos::View<int, Kokkos::LayoutRight, Kokkos::HostSpace,                \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       Kokkos::View<SCALAR**, LAYOUTA, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,   \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \

--- a/src/impl/tpls/KokkosBlas_trtri_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosBlas_trtri_tpl_spec_avail.hpp
@@ -58,7 +58,7 @@ struct trtri_tpl_spec_avail {
 #define KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL(SCALAR, LAYOUTA, MEMSPACE)         \
   template <class ExecSpace>                                               \
   struct trtri_tpl_spec_avail<                                             \
-      Kokkos::View<int, LAYOUTA, Kokkos::HostSpace,                        \
+      Kokkos::View<int, Kokkos::HostSpace,                                 \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,              \
       Kokkos::View<SCALAR**, LAYOUTA, Kokkos::Device<ExecSpace, MEMSPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {           \

--- a/src/impl/tpls/KokkosBlas_trtri_tpl_spec_avail.hpp
+++ b/src/impl/tpls/KokkosBlas_trtri_tpl_spec_avail.hpp
@@ -58,7 +58,7 @@ struct trtri_tpl_spec_avail {
 #define KOKKOSBLAS_TRTRI_TPL_SPEC_AVAIL(SCALAR, LAYOUTA, MEMSPACE)         \
   template <class ExecSpace>                                               \
   struct trtri_tpl_spec_avail<                                             \
-      Kokkos::View<int, Kokkos::HostSpace,                                 \
+      Kokkos::View<int, Kokkos::LayoutRight, Kokkos::HostSpace,            \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,              \
       Kokkos::View<SCALAR**, LAYOUTA, Kokkos::Device<ExecSpace, MEMSPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {           \

--- a/src/impl/tpls/KokkosBlas_trtri_tpl_spec_decl.hpp
+++ b/src/impl/tpls/KokkosBlas_trtri_tpl_spec_decl.hpp
@@ -55,14 +55,14 @@ namespace Impl {
 #define KOKKOSBLAS_TRTRI_BLAS_HOST(SCALAR_TYPE, BASE_SCALAR_TYPE, LAYOUTA,     \
                                    MEM_SPACE, ETI_SPEC_AVAIL)                  \
   template <class ExecSpace>                                                   \
-  struct TRTRI<Kokkos::View<int, LAYOUTA, Kokkos::HostSpace,                   \
+  struct TRTRI<Kokkos::View<int, Kokkos::HostSpace,                            \
                             Kokkos::MemoryTraits<Kokkos::Unmanaged> >,         \
                Kokkos::View<SCALAR_TYPE**, LAYOUTA,                            \
                             Kokkos::Device<ExecSpace, MEM_SPACE>,              \
                             Kokkos::MemoryTraits<Kokkos::Unmanaged> >,         \
                true, ETI_SPEC_AVAIL> {                                         \
     typedef SCALAR_TYPE SCALAR;                                                \
-    typedef Kokkos::View<int, LAYOUTA, Kokkos::HostSpace,                      \
+    typedef Kokkos::View<int, Kokkos::HostSpace,                               \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         RViewType;                                                             \
     typedef Kokkos::View<const SCALAR_TYPE**, LAYOUTA,                         \
@@ -104,14 +104,14 @@ namespace Impl {
 #define KOKKOSBLAS_TRTRI_BLAS_MAGMA(SCALAR_TYPE, BASE_SCALAR_TYPE, MAGMA_FN,   \
                                     LAYOUTA, MEM_SPACE, ETI_SPEC_AVAIL)        \
   template <class ExecSpace>                                                   \
-  struct TRTRI<Kokkos::View<int, LAYOUTA, Kokkos::HostSpace,                   \
+  struct TRTRI<Kokkos::View<int, Kokkos::HostSpace,                            \
                             Kokkos::MemoryTraits<Kokkos::Unmanaged> >,         \
                Kokkos::View<SCALAR_TYPE**, LAYOUTA,                            \
                             Kokkos::Device<ExecSpace, MEM_SPACE>,              \
                             Kokkos::MemoryTraits<Kokkos::Unmanaged> >,         \
                true, ETI_SPEC_AVAIL> {                                         \
     typedef SCALAR_TYPE SCALAR;                                                \
-    typedef Kokkos::View<int, LAYOUTA, Kokkos::HostSpace,                      \
+    typedef Kokkos::View<int, Kokkos::HostSpace,                               \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         RViewType;                                                             \
     typedef Kokkos::View<const SCALAR_TYPE**, LAYOUTA,                         \

--- a/src/impl/tpls/KokkosBlas_trtri_tpl_spec_decl.hpp
+++ b/src/impl/tpls/KokkosBlas_trtri_tpl_spec_decl.hpp
@@ -55,14 +55,14 @@ namespace Impl {
 #define KOKKOSBLAS_TRTRI_BLAS_HOST(SCALAR_TYPE, BASE_SCALAR_TYPE, LAYOUTA,     \
                                    MEM_SPACE, ETI_SPEC_AVAIL)                  \
   template <class ExecSpace>                                                   \
-  struct TRTRI<Kokkos::View<int, Kokkos::HostSpace,                            \
+  struct TRTRI<Kokkos::View<int, Kokkos::LayoutRight, Kokkos::HostSpace,       \
                             Kokkos::MemoryTraits<Kokkos::Unmanaged> >,         \
                Kokkos::View<SCALAR_TYPE**, LAYOUTA,                            \
                             Kokkos::Device<ExecSpace, MEM_SPACE>,              \
                             Kokkos::MemoryTraits<Kokkos::Unmanaged> >,         \
                true, ETI_SPEC_AVAIL> {                                         \
     typedef SCALAR_TYPE SCALAR;                                                \
-    typedef Kokkos::View<int, Kokkos::HostSpace,                               \
+    typedef Kokkos::View<int, Kokkos::LayoutRight, Kokkos::HostSpace,          \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         RViewType;                                                             \
     typedef Kokkos::View<const SCALAR_TYPE**, LAYOUTA,                         \
@@ -104,14 +104,14 @@ namespace Impl {
 #define KOKKOSBLAS_TRTRI_BLAS_MAGMA(SCALAR_TYPE, BASE_SCALAR_TYPE, MAGMA_FN,   \
                                     LAYOUTA, MEM_SPACE, ETI_SPEC_AVAIL)        \
   template <class ExecSpace>                                                   \
-  struct TRTRI<Kokkos::View<int, Kokkos::HostSpace,                            \
+  struct TRTRI<Kokkos::View<int, Kokkos::LayoutRight, Kokkos::HostSpace,       \
                             Kokkos::MemoryTraits<Kokkos::Unmanaged> >,         \
                Kokkos::View<SCALAR_TYPE**, LAYOUTA,                            \
                             Kokkos::Device<ExecSpace, MEM_SPACE>,              \
                             Kokkos::MemoryTraits<Kokkos::Unmanaged> >,         \
                true, ETI_SPEC_AVAIL> {                                         \
     typedef SCALAR_TYPE SCALAR;                                                \
-    typedef Kokkos::View<int, Kokkos::HostSpace,                               \
+    typedef Kokkos::View<int, Kokkos::LayoutRight, Kokkos::HostSpace,          \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         RViewType;                                                             \
     typedef Kokkos::View<const SCALAR_TYPE**, LAYOUTA,                         \


### PR DESCRIPTION
Partial fix for #1474 following merge of kokkos/kokkos#5209
cc @crtrott 

There was no point on specifying the layout of a rank-0 view.  This seems to resolve the compiler error.
I changed occurrences I could find but not all were actually showing as errors on my local build which means I did not actually compile all the code paths.
I hope this helps resolving the nightly failures.  Feel free to push more changes as necessary.
