### PR TITLE
Add missing dependency on CUBLAS (#10807)

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -9,4 +9,3 @@ TRIBITS_PACKAGE_DEFINE_DEPENDENCIES(
 if (TPL_ENABLE_CUDA)
   tribits_tpl_tentatively_enable(CUBLAS)
 endif()
-


### PR DESCRIPTION
CC:  @vqd8a

@lucbv 

This should fix link errors on an ATS2 configuration missing cublas link symbols from KokkosKernels objecct files (see trilinos/Trilinos#10807).

The customer @vqd8a confirmed this fixes is build problem in https://github.com/trilinos/Trilinos/pull/10808#issuecomment-1199540031.

This is the identical commit to that in https://github.com/trilinos/Trilinos/pull/10808 made directly against Trilinos 'develop'.

I would recommend that the PR https://github.com/trilinos/Trilinos/pull/10808 gets merged right away and also merge this PR so that the next time kokkos-kernels gets snapshotted into Trilinos 'develop', then it will not overwrite the changes from  https://github.com/trilinos/Trilinos/pull/10808.
