### PR TITLE
Add gcc/7.3.0 to macro guard define for KOKKOSKERNELS_ENABLE_OMP_SIMD

### DIFF
--- a/src/KokkosKernels_Macros.hpp
+++ b/src/KokkosKernels_Macros.hpp
@@ -66,9 +66,10 @@
 // https://clang.llvm.org/docs/OpenMPSupport.html#id1
 #if defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
 // GCC 4.8.5 and older do not support #pragma omp simd
-// Do not enable when using GCC 7.2.0 + C++17 due to a bug in gcc
+// Do not enable when using GCC 7.2.0 or 7.3.0 + C++17 due to a bug in gcc
 #if (KOKKOS_COMPILER_GNU > 485) && \
-    !(KOKKOS_COMPILER_GNU == 720 && defined(KOKKOS_ENABLE_CXX17))
+    !(KOKKOS_COMPILER_GNU == 720 && defined(KOKKOS_ENABLE_CXX17)) && \
+    !(KOKKOS_COMPILER_GNU == 730 && defined(KOKKOS_ENABLE_CXX17))
 #define KOKKOSKERNELS_ENABLE_OMP_SIMD
 #endif
 // TODO: Check for a clang version that supports #pragma omp simd

--- a/src/KokkosKernels_Macros.hpp
+++ b/src/KokkosKernels_Macros.hpp
@@ -67,7 +67,7 @@
 #if defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
 // GCC 4.8.5 and older do not support #pragma omp simd
 // Do not enable when using GCC 7.2.0 or 7.3.0 + C++17 due to a bug in gcc
-#if (KOKKOS_COMPILER_GNU > 485) && \
+#if (KOKKOS_COMPILER_GNU > 485) &&                                   \
     !(KOKKOS_COMPILER_GNU == 720 && defined(KOKKOS_ENABLE_CXX17)) && \
     !(KOKKOS_COMPILER_GNU == 730 && defined(KOKKOS_ENABLE_CXX17))
 #define KOKKOSKERNELS_ENABLE_OMP_SIMD


### PR DESCRIPTION
Address issue #1487