### PR TITLE
c++17: add [[fallthrough]] attribute

### DIFF
--- a/graph/impl/KokkosGraph_Distance2Color_impl.hpp
+++ b/graph/impl/KokkosGraph_Distance2Color_impl.hpp
@@ -157,7 +157,7 @@ class GraphColorDistance2 {
       colors_out = color_view_type("Graph Colors", this->nr);
     }
     switch (this->gc_handle->get_coloring_algo_type()) {
-      case COLORING_D2_VB_BIT_EF: using_edge_filtering = true;
+      case COLORING_D2_VB_BIT_EF: using_edge_filtering = true; [[fallthrough]];
       case COLORING_D2_VB_BIT:
       case COLORING_D2_VB: compute_d2_coloring_vb(colors_out); break;
       case COLORING_D2_NB_BIT: compute_d2_coloring_nb(colors_out); break;

--- a/perf_test/sparse/KokkosSparse_sptrsv.cpp
+++ b/perf_test/sparse/KokkosSparse_sptrsv.cpp
@@ -279,6 +279,7 @@ int test_sptrsv_perf(std::vector<int> tests, const std::string &lfilename,
 #else
           std::cout << "CUSPARSE not enabled: Fall through to defaults"
                     << std::endl;
+          [[fallthrough]];
 #endif
         default:
           kh.create_sptrsv_handle(SPTRSVAlgorithm::SEQLVLSCHD_TP1, nrows,
@@ -681,6 +682,7 @@ int test_sptrsv_perf(std::vector<int> tests, const std::string &lfilename,
 #else
           std::cout << "CUSPARSE not enabled: Fall through to defaults"
                     << std::endl;
+          [[fallthrough]];
 #endif
         default:
           kh.create_sptrsv_handle(SPTRSVAlgorithm::SEQLVLSCHD_TP1, nrows,

--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -702,7 +702,7 @@ elif [ "$MACHINE" = "blake" ]; then
   ONEAPI_FLAGS_EXTRA="-fp-model=precise"
   LLVM_EXTRA_FLAGS="-fPIC ${CLANG_WARNING_FLAGS}"
   # Remove -Wuninitialized: compiler issues show up with Threads backend
-  GCC11_WARNING_FLAGS="-Wall,-Wunused-parameter,-Wshadow,-pedantic,-Werror,-Wsign-compare,-Wtype-limits,-Wignored-qualifiers,-Wempty-body,-Wclobbered"
+  GCC11_WARNING_FLAGS="-Wall,-Wunused-parameter,-Wshadow,-pedantic,-Werror,-Wsign-compare,-Wtype-limits,-Wignored-qualifiers,-Wempty-body,-Wclobbered,-Wimplicit-fallthrough"
   # update KOKKOS_PASSTHRU_CMAKE_FLAGS to disable onedpl on Blake
   KOKKOS_PASSTHRU_CMAKE_FLAGS="${KOKKOS_PASSTHRU_CMAKE_FLAGS} -DKokkos_ENABLE_ONEDPL=OFF"
 

--- a/sparse/impl/KokkosSparse_spgemm_impl_memaccess.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_memaccess.hpp
@@ -663,7 +663,7 @@ void KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
                               cache_1_line_count);
                     }
                   } break;
-                  case 2: hyper_thread_ind = 1;
+                  case 2: hyper_thread_ind = 1; [[fallthrough]];
                   case 1: {
                     nnz_lno_t result_col_ind =
                         result_col + (hyper_thread_ind - 1) * b_col_cnt;


### PR DESCRIPTION
Now that we require c++17 support, use [[fallthrough]] to suppress `-Wimplicit-fallthrough` and friends, and add it to `cm_test_all_sandia`