### PR TITLE
utils: implicit copy-assign deprecated in array_sum_reduce

### DIFF
--- a/src/common/KokkosKernels_Utils.hpp
+++ b/src/common/KokkosKernels_Utils.hpp
@@ -1454,10 +1454,7 @@ struct array_sum_reduce {
   array_sum_reduce() {
     for (int i = 0; i < N; i++) data[i] = scalar_t();
   }
-  KOKKOS_INLINE_FUNCTION
-  array_sum_reduce(const ValueType &rhs) {
-    for (int i = 0; i < N; i++) data[i] = rhs.data[i];
-  }
+
   KOKKOS_INLINE_FUNCTION  // add operator
       array_sum_reduce &
       operator+=(const ValueType &src) {


### PR DESCRIPTION
c++11 deprecated implicit copy-assign operators when a copy-constructor is defined.

array_sum_reduce is actually okay with implicit versions both copy-ctor and copy-assign, so don't define either one ourselves