### PR TITLE
Add INTEL19 and CUDA11 CI settings

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -149,6 +149,12 @@ endif()
 * KokkosKernels_ENABLE_TESTS: BOOL
   * Whether to build tests.
   * Default: OFF
+* KokkosKernels_ENABLE_PERFTESTS: BOOL
+  * Whether to build performance tests.
+  * Default: OFF
+* KokkosKernels_ENABLE_TESTS_AND_PERFSUITE: BOOL
+  * Whether to build performance tests and suite.
+  * Default: OFF
 * KokkosKernels_ENABLE_DOCS: BOOL
   * Whether to build docs.
   * Default: OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,10 +66,16 @@ IF (NOT KOKKOSKERNELS_HAS_TRILINOS)
           "Whether to build tests. Default: OFF"
   )
   KOKKOSKERNELS_ADD_OPTION(
+          "ENABLE_PERFTESTS"
+          OFF
+          BOOL
+          "Whether to build performance tests. Default: OFF"
+  )
+  KOKKOSKERNELS_ADD_OPTION(
           "ENABLE_TESTS_AND_PERFSUITE"
           OFF
           BOOL
-          "Whether to build tests including Perfsuite. Default: OFF"
+          "Whether to build performance tests and suite. Default: OFF"
   )
   IF(KokkosKernels_ENABLE_TESTS_AND_PERFSUITE)
     set(BLT_CODE_CHECK_TARGET_NAME "fix-for-blt" CACHE STRING "Docstring")
@@ -77,6 +83,7 @@ IF (NOT KOKKOSKERNELS_HAS_TRILINOS)
     add_definitions("-DRAJAPERF_INFRASTRUCTURE_ONLY")
     add_subdirectory(tpls/rajaperf)
     include_directories(tpls/rajaperf/src)
+    set(KokkosKernels_ENABLE_PERFTESTS ON CACHE BOOL "Whether to build tests including Perfsuite. Default: OFF" FORCE)
   ENDIF()
 ENDIF ()
 

--- a/perf_test/CMakeLists.txt
+++ b/perf_test/CMakeLists.txt
@@ -1,50 +1,54 @@
-KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
-KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
+if (KokkosKernels_ENABLE_PERFTESTS)
+    KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
+    KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
-KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/../test_common)
+    KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/../test_common)
 
-#At some point, we may wish to make this into real "performance
-#tests, " in the sense that they can pass or fail.  At that point, use
-#"CATEGORIES PERFORMANCE" to mark them as such.For now, we just
-#build the executables for manual use, but don't run the tests.  They
-#build correctly with or without MPI, but only run them with a single
-#MPI process.
+    #At some point, we may wish to make this into real "performance
+    #tests, " in the sense that they can pass or fail.  At that point, use
+    #"CATEGORIES PERFORMANCE" to mark them as such.For now, we just
+    #build the executables for manual use, but don't run the tests.  They
+    #build correctly with or without MPI, but only run them with a single
+    #MPI process.
 
-SET(GTEST_SOURCE_DIR ${PACKAGE_SOURCE_DIR}/tpls/gtest)
+    SET(GTEST_SOURCE_DIR ${PACKAGE_SOURCE_DIR}/tpls/gtest)
 
-KOKKOSKERNELS_ADD_TEST_LIBRARY(
-                               kokkoskernelsperf_gtest
-                               HEADERS ${GTEST_SOURCE_DIR}/gtest/gtest.h
-                               SOURCES ${GTEST_SOURCE_DIR}/gtest/gtest-all.cc
-                                )
-#Disables pthreads, this is a problem for serial builds in Trilinos & Sierra if it's enabled.
+    KOKKOSKERNELS_ADD_TEST_LIBRARY(
+                                kokkoskernelsperf_gtest
+                                HEADERS ${GTEST_SOURCE_DIR}/gtest/gtest.h
+                                SOURCES ${GTEST_SOURCE_DIR}/gtest/gtest-all.cc
+                                    )
+    #Disables pthreads, this is a problem for serial builds in Trilinos & Sierra if it's enabled.
 
-TARGET_COMPILE_DEFINITIONS(kokkoskernelsperf_gtest PUBLIC "-DGTEST_HAS_PTHREAD=0")
-TARGET_INCLUDE_DIRECTORIES(kokkoskernelsperf_gtest PUBLIC $<BUILD_INTERFACE:${GTEST_SOURCE_DIR}>)
+    TARGET_COMPILE_DEFINITIONS(kokkoskernelsperf_gtest PUBLIC "-DGTEST_HAS_PTHREAD=0")
+    TARGET_INCLUDE_DIRECTORIES(kokkoskernelsperf_gtest PUBLIC $<BUILD_INTERFACE:${GTEST_SOURCE_DIR}>)
 
-#Gtest minimally requires C++ 11
-TARGET_COMPILE_FEATURES(kokkoskernelsperf_gtest PUBLIC cxx_std_11)
-include_directories(sparse)
-if (KokkosKernels_ENABLE_TESTS_AND_PERFSUITE)
-#Add RPS implementations of KK perf tests here
+    #Gtest minimally requires C++ 11
+    TARGET_COMPILE_FEATURES(kokkoskernelsperf_gtest PUBLIC cxx_std_11)
 
-    KOKKOSKERNELS_ADD_EXECUTABLE(
-        tracked_testing
-        SOURCES KokkosKernelsTrackedTesting.cpp
-        sparse/KokkosSparse_spmv_test.cpp
-        blas/blas2/KokkosBlas2_gemv_tracked_perf_test.cpp
-        blas/blas1/KokkosBlas_dot_tracked_perf_test.cpp
-        blas/blas1/KokkosBlas_team_dot_tracked_perf_test.cpp
-        blas/blas3/KokkosBlas3_gemm_tracked_perf_test.cpp
-        PerfTestUtilities.cpp
-        sparse/spmv/OpenMPSmartStatic_SPMV.cpp
-        #sparse / KokkosSparse_spgemm_test.cpp
-        )
+    include_directories(sparse)
+    
+    if(Kokkos_ENABLE_TESTS_AND_PERFSUITE)
+        #Add RPS implementations of KK perf tests here
+        KOKKOSKERNELS_ADD_EXECUTABLE(
+            tracked_testing
+            SOURCES KokkosKernelsTrackedTesting.cpp
+            sparse/KokkosSparse_spmv_test.cpp
+            blas/blas2/KokkosBlas2_gemv_tracked_perf_test.cpp
+            blas/blas1/KokkosBlas_dot_tracked_perf_test.cpp
+            blas/blas1/KokkosBlas_team_dot_tracked_perf_test.cpp
+            blas/blas3/KokkosBlas3_gemm_tracked_perf_test.cpp
+            PerfTestUtilities.cpp
+            sparse/spmv/OpenMPSmartStatic_SPMV.cpp
+            #sparse / KokkosSparse_spgemm_test.cpp
+            )
+    endif()
+
+    ADD_COMPONENT_SUBDIRECTORY(batched)
+    ADD_COMPONENT_SUBDIRECTORY(graph)
+    ADD_COMPONENT_SUBDIRECTORY(sparse)
+    ADD_COMPONENT_SUBDIRECTORY(blas)
+    ADD_SUBDIRECTORY(performance)
+    #ADD_SUBDIRECTORY(common)
 endif()
-ADD_COMPONENT_SUBDIRECTORY(batched)
-ADD_COMPONENT_SUBDIRECTORY(graph)
-ADD_COMPONENT_SUBDIRECTORY(sparse)
-ADD_COMPONENT_SUBDIRECTORY(blas)
-ADD_SUBDIRECTORY(performance)
-#ADD_SUBDIRECTORY(common)
 

--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -133,6 +133,7 @@ fi
 
 if [[ "$HOSTNAME" =~ weaver.* ]]; then
   MACHINE=weaver
+  source /etc/profile.d/modules.sh
   module load git
 fi
 
@@ -169,6 +170,10 @@ fi
 
 if [[ "$HOSTNAME" == sogpu01* ]]; then
   MACHINE=sogpu
+fi
+
+if [[ "$HOSTNAME" == sorh7* ]]; then
+  MACHINE=sorh7
 fi
 
 if [ ! -z "$SEMS_MODULEFILES_ROOT" ]; then
@@ -483,7 +488,8 @@ elif [ "$MACHINE" = "sogpu" ]; then
   INTEL_BASE_MODULE_LIST="sems-archive-env,sems-archive-cmake/3.17.1,sems-archive-gcc/7.2.0,sems-archive-<COMPILER_NAME>/<COMPILER_VERSION>"
   CLANG_BASE_MODULE_LIST="sems-archive-env,sems-archive-cmake/3.17.1,sems-archive-gcc/9.2.0,sems-archive-<COMPILER_NAME>/<COMPILER_VERSION>"
   CUDA_MODULE_LIST="sems-archive-env,sems-archive-cmake/3.17.1,sems-archive-gcc/7.2.0,sems-archive-<COMPILER_NAME>/<COMPILER_VERSION>"
-  CUDA11_MODULE_LIST="sems-archive-env,sems-archive-cmake/3.17.1,sems-archive-gcc/8.3.0,sems-archive-<COMPILER_NAME>/<COMPILER_VERSION>"
+  CUDA11_MODULE_LIST="sems-cmake/3.23.1,sems-gcc/8.3.0,sems-<COMPILER_NAME>/<COMPILER_VERSION>"
+  CUDA11_MODULE_TPL_LIST="$CUDA11_MODULE_LIST,sems-openblas/0.3.10"
   SKIP_HWLOC=True
   # No sems hwloc module
 
@@ -491,6 +497,15 @@ elif [ "$MACHINE" = "sogpu" ]; then
     ARCH_FLAG="--arch=Volta70"
   fi
 
+  if [ "$SPOT_CHECK" = "True" ]; then
+    # Format: (compiler module-list build-list exe-name warning-flag)
+    COMPILERS=("cuda/11.1.0 $CUDA11_MODULE_LIST "Cuda_OpenMP" $KOKKOS_PATH/bin/nvcc_wrapper $CUDA_WARNING_FLAGS"
+              )
+  elif [ "$SPOT_CHECK_TPLS" = "True" ]; then
+    # Format: (compiler module-list build-list exe-name warning-flag)
+    COMPILERS=("cuda/11.1.0 $CUDA11_MODULE_TPL_LIST "Cuda_Serial" $KOKKOS_PATH/bin/nvcc_wrapper $CUDA_WARNING_FLAGS"
+              )
+  else
     # Format: (compiler module-list build-list exe-name warning-flag)
     COMPILERS=("gcc/5.3.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
                "gcc/6.1.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
@@ -509,6 +524,45 @@ elif [ "$MACHINE" = "sogpu" ]; then
                "cuda/10.1 $CUDA_MODULE_LIST $CUDA_BUILD_LIST $KOKKOS_PATH/bin/nvcc_wrapper $CUDA_WARNING_FLAGS"
                "cuda/11.1 $CUDA11_MODULE_LIST $CUDA_BUILD_LIST $KOKKOS_PATH/bin/nvcc_wrapper $CUDA_WARNING_FLAGS"
               )
+
+  fi
+elif [ "$MACHINE" = "sorh7" ]; then
+  module load sems-cmake/3.23.1 sems-git
+  BASE_MODULE_LIST="sems-cmake/3.23.1,sems-<COMPILER_NAME>/<COMPILER_VERSION>"
+  INTEL_BASE_MODULE_LIST="sems-cmake/3.23.1,sems-gcc/7.3.0,sems-<COMPILER_NAME>/<COMPILER_VERSION>"
+  CLANG_BASE_MODULE_LIST="sems-cmake/3.23.1,sems-gcc/10.1.0,sems-<COMPILER_NAME>/<COMPILER_VERSION>"
+  SKIP_HWLOC=True
+  # No sems hwloc module
+
+  if [ -z "$ARCH_FLAG" ]; then
+    ARCH_FLAG="--arch=SKX"
+  fi
+
+  if [ "$SPOT_CHECK" = "True" ]; then
+    # Format: (compiler module-list build-list exe-name warning-flag)
+    COMPILERS=("intel/19.0.5 $INTEL_BASE_MODULE_LIST "OpenMP,Threads" icpc $INTEL_WARNING_FLAGS"
+              )
+  elif [ "$SPOT_CHECK_TPLS" = "True" ]; then
+    # Format: (compiler module-list build-list exe-name warning-flag)
+    COMPILERS=("intel/19.0.5 $INTEL_BASE_MODULE_LIST "OpenMP,Threads" icpc $INTEL_WARNING_FLAGS"
+              )
+  else
+    # Format: (compiler module-list build-list exe-name warning-flag)
+    COMPILERS=("gcc/5.3.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
+                "gcc/6.1.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
+                "gcc/6.4.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
+                "gcc/7.2.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
+                "gcc/7.3.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
+                "gcc/8.3.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
+                "gcc/9.2.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
+                "clang/5.0.1 $CLANG_BASE_MODULE_LIST $CLANG_BUILD_LIST clang++ $CLANG_WARNING_FLAGS"
+                "clang/7.0.1 $CLANG_BASE_MODULE_LIST $CLANG_BUILD_LIST clang++ $CLANG_WARNING_FLAGS"
+                "clang/9.0.0 $CLANG_BASE_MODULE_LIST $CLANG_BUILD_LIST clang++ $CLANG_WARNING_FLAGS"
+                "clang/10.0.0 $CLANG_BASE_MODULE_LIST $CLANG_BUILD_LIST clang++ $CLANG_WARNING_FLAGS"
+                "intel/19.0.5 $INTEL_BASE_MODULE_LIST $INTEL_BUILD_LIST icpc $INTEL_WARNING_FLAGS"
+              )
+
+  fi
 elif [ "$MACHINE" = "kokkos-dev" ]; then
   MODULE_ENVIRONMENT="source /projects/sems/modulefiles/utils/sems-archive-modules-init.sh"
   eval "$MODULE_ENVIRONMENT"
@@ -696,6 +750,7 @@ elif [ "$MACHINE" = "weaver" ]; then
                "gcc/7.2.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
                "cuda/9.2.88 $CUDA_MODULE_LIST "Cuda_Serial" ${KOKKOS_PATH}/bin/nvcc_wrapper $CUDA_WARNING_FLAGS"
                "cuda/10.1.243 $CUDA10_MODULE_LIST "Cuda_OpenMP" ${KOKKOS_PATH}/bin/nvcc_wrapper $CUDA_WARNING_FLAGS"
+               "cuda/11.2.2 $CUDA11_MODULE_LIST "Cuda_OpenMP" ${KOKKOS_PATH}/bin/nvcc_wrapper $CUDA_WARNING_FLAGS"
     )
   elif [ "$SPOT_CHECK_TPLS" = "True" ]; then
     # Format: (compiler module-list build-list exe-name warning-flag)
@@ -810,6 +865,7 @@ elif [ "$MACHINE" = "blake" ]; then
     COMPILERS=("intel/19.1.144 $BASE_MODULE_LIST_INTEL "OpenMP_Serial" icpc $INTEL_WARNING_FLAGS"
                "gcc/7.2.0 $BASE_MODULE_LIST "Threads_Serial,OpenMP" g++ $GCC_WARNING_FLAGS"
                "clang/10.0.1 $BASE_MODULE_LIST "Threads_Serial" clang++ $CLANG_WARNING_FLAGS"
+               "intel/19.5.281 $BASE_MODULE_LIST_INTEL "OpenMP,Threads" icpc $INTEL_WARNING_FLAGS"
     )
   elif [ "$SPOT_CHECK_TPLS" = "True" ]; then
       # Format: (compiler module-list build-list exe-name warning-flag)
@@ -817,6 +873,7 @@ elif [ "$MACHINE" = "blake" ]; then
       #"pgi/18.7.0 $BASE_MODULE_LIST $GCC_BUILD_LIST pgc++ $PGI_WARNING_FLAGS"
     COMPILERS=("intel/18.1.163 $BASE_MODULE_LIST_INTEL "OpenMP,Threads" icpc $INTEL_WARNING_FLAGS"
                "gcc/7.2.0 $GCC72_MODULE_TPL_LIST "OpenMP_Serial" g++ $GCC_WARNING_FLAGS"
+               "intel/19.5.281 $BASE_MODULE_LIST_INTEL "OpenMP,Threads" icpc $INTEL_WARNING_FLAGS"
     )
   else
     COMPILERS=("intel/17.4.196 $BASE_MODULE_LIST_INTEL $INTEL_BUILD_LIST icpc $INTEL_WARNING_FLAGS"
@@ -1171,7 +1228,7 @@ setup_env() {
 
     if [[ "${SPOT_CHECK_TPLS}" = "True" ]]; then
       # Some machines will require explicitly setting include dirs and libs
-      if ([[ "$MACHINE" = white* ]] || [[ "$MACHINE" = weaver* ]] || [[ "$MACHINE" = blake* ]]) && [[ "$mod" = openblas* ]]; then
+      if ([[ "$MACHINE" = white* ]] || [[ "$MACHINE" = weaver* ]] || [[ "$MACHINE" = blake* ]] || [[ "$MACHINE" = sogpu* ]]) && [[ "$mod" = openblas* ]]; then
         BLAS_LIBRARY_DIRS="${OPENBLAS_ROOT}/lib"
         LAPACK_LIBRARY_DIRS="${OPENBLAS_ROOT}/lib"
   #      BLAS_LIBRARIES="openblas"

--- a/src/sparse/impl/KokkosSparse_spgemm_cuSPARSE_impl.hpp
+++ b/src/sparse/impl/KokkosSparse_spgemm_cuSPARSE_impl.hpp
@@ -88,6 +88,17 @@ void cuSPARSE_symbolic(KernelHandle *handle, typename KernelHandle::nnz_lno_t m,
   }
 
 #if defined(CUSPARSE_VERSION) && (11000 <= CUSPARSE_VERSION)
+  (void)handle;
+  (void)m;
+  (void)n;
+  (void)k;
+  (void)row_mapA;
+  (void)row_mapB;
+  (void)row_mapC;
+  (void)entriesA;
+  (void)entriesB;
+  (void)transposeA;
+  (void)transposeB;
   throw std::runtime_error(
       "SpGEMM cuSPARSE backend is not yet supported for this CUDA version\n");
 #else
@@ -166,6 +177,19 @@ void cuSPARSE_apply(
     cin_nonzero_index_view_type entriesC, cin_nonzero_value_view_type valuesC) {
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 #if defined(CUSPARSE_VERSION) && (11000 <= CUSPARSE_VERSION)
+  (void)handle;
+  (void)m;
+  (void)n;
+  (void)k;
+  (void)row_mapA;
+  (void)row_mapB;
+  (void)row_mapC;
+  (void)entriesA;
+  (void)entriesB;
+  (void)entriesC;
+  (void)valuesA;
+  (void)valuesB;
+  (void)valuesC;
   throw std::runtime_error(
       "SpGEMM cuSPARSE backend is not yet supported for this CUDA version\n");
 #else

--- a/unit_test/sparse/Test_Sparse_spmv.hpp
+++ b/unit_test/sparse/Test_Sparse_spmv.hpp
@@ -486,6 +486,13 @@ template <typename scalar_t, typename lno_t, typename size_type,
           typename layout, class Device>
 void test_spmv_mv(lno_t numRows, size_type nnz, lno_t bandwidth,
                   lno_t row_size_variance, bool heavy, int numMV) {
+  // The kokkos-kernels gtest does not have GTEST_SKIP defined. Suggest updating
+  // or using kokkos/tpls/gtest instead.
+  // if (std::is_same<typename Test::scalar_t, typename
+  // Kokkos::complex<double>>::value)
+  //  GTEST_SKIP(
+  //      "Skipped until https://github.com/kokkos/kokkos-kernels/issues/1331 is
+  //      " "resolved");
   using mag_t = typename Kokkos::ArithTraits<scalar_t>::mag_type;
 
   constexpr mag_t max_x   = static_cast<mag_t>(1);


### PR DESCRIPTION
-    scripts/cm_test_all_sandia:
      - Add spot check options for cuda11 and intel19 on 4 rhel7 machines
      - Switch cuda11 modules from sems-archive-env to sems-env
      - Added initial source of /etc/profile.d/modules.sh for the dev queue
    
-    cmake:
      - Added cmake option `KokkosKernels_ENABLE_PERFTESTS`
        - Note: This changes all our cmake configure to, by default, disable building `perf_test`. The default used to be to build `perf_test` but the binaries were never run in PR (or nightly?) testing. In the long run, this will save many cycles.
      - Document undocumented cmake option `KokkosKernels_ENABLE_TESTS_AND_PERFSUITE`
    
-    src/sparse:
      - Fix some warnings as errors in spmv when compiling with cuda11
      - Attempted to conditionally skip spmv_mv for ARMPL PR builds

Once this merges, we can replace the INTEL18 PR test with INTEL19.

I am leaving CUDA11 disabled due to low resource availability via the dev queue.