### PR TITLE
Graph coarsen: fix test by adding pre-processor guards, issue #1516

### DIFF
--- a/src/graph/KokkosGraph_CoarsenConstruct.hpp
+++ b/src/graph/KokkosGraph_CoarsenConstruct.hpp
@@ -1,3 +1,47 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Mike Gilbert (msg5334@psu.edu)
+//
+// ************************************************************************
+//@HEADER
+*/
+
 #pragma once
 // exclude from Cuda builds without lambdas enabled
 #if !defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)

--- a/unit_test/graph/Test_Graph.hpp
+++ b/unit_test/graph/Test_Graph.hpp
@@ -5,7 +5,9 @@
 #include "Test_Graph_graph_color_distance2.hpp"
 #include "Test_Graph_graph_color.hpp"
 #include "Test_Graph_mis2.hpp"
+#if !defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 #include "Test_Graph_coarsen.hpp"
+#endif
 #include "Test_Graph_rcm.hpp"
 
 #endif  // TEST_GRAPH_HPP

--- a/unit_test/graph/Test_Graph_coarsen.hpp
+++ b/unit_test/graph/Test_Graph_coarsen.hpp
@@ -272,6 +272,7 @@ crsMat gen_grid() {
   return A;
 }
 
+#if !defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 template <typename scalar, typename lno_t, typename size_type, typename device>
 void test_multilevel_coarsen_grid() {
   using crsMat =
@@ -304,7 +305,13 @@ void test_multilevel_coarsen_grid() {
     coarse++;
   }
 }
+#else
+template <typename scalar, typename lno_t, typename size_type, typename device>
+void test_multilevel_coarsen_grid() {}
+#endif
 
+
+#if !defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 template <typename scalar, typename lno_t, typename size_type, typename device>
 void test_coarsen_grid() {
   using crsMat =
@@ -355,7 +362,13 @@ void test_coarsen_grid() {
     }
   }
 }
+#else
+template <typename scalar, typename lno_t, typename size_type, typename device>
+void test_coarsen_grid() {}
+#endif
 
+
+#if !defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 template <typename scalar, typename lno_t, typename size_type, typename device>
 void test_coarsen_random(lno_t numVerts, size_type nnz, lno_t bandwidth,
                          lno_t row_size_variance) {
@@ -424,6 +437,11 @@ void test_coarsen_random(lno_t numVerts, size_type nnz, lno_t bandwidth,
     }
   }
 }
+#else
+template <typename scalar, typename lno_t, typename size_type, typename device>
+void test_coarsen_random(lno_t /*numVerts*/, size_type /*nnz*/, lno_t /*bandwidth*/,
+                         lno_t /*row_size_variance*/) {}
+#endif
 
 #define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE)                                         \
   TEST_F(                                                                                     \

--- a/unit_test/graph/Test_Graph_coarsen.hpp
+++ b/unit_test/graph/Test_Graph_coarsen.hpp
@@ -272,7 +272,6 @@ crsMat gen_grid() {
   return A;
 }
 
-#if !defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 template <typename scalar, typename lno_t, typename size_type, typename device>
 void test_multilevel_coarsen_grid() {
   using crsMat =
@@ -305,12 +304,7 @@ void test_multilevel_coarsen_grid() {
     coarse++;
   }
 }
-#else
-template <typename scalar, typename lno_t, typename size_type, typename device>
-void test_multilevel_coarsen_grid() {}
-#endif
 
-#if !defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 template <typename scalar, typename lno_t, typename size_type, typename device>
 void test_coarsen_grid() {
   using crsMat =
@@ -361,12 +355,7 @@ void test_coarsen_grid() {
     }
   }
 }
-#else
-template <typename scalar, typename lno_t, typename size_type, typename device>
-void test_coarsen_grid() {}
-#endif
 
-#if !defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 template <typename scalar, typename lno_t, typename size_type, typename device>
 void test_coarsen_random(lno_t numVerts, size_type nnz, lno_t bandwidth,
                          lno_t row_size_variance) {
@@ -435,11 +424,6 @@ void test_coarsen_random(lno_t numVerts, size_type nnz, lno_t bandwidth,
     }
   }
 }
-#else
-template <typename scalar, typename lno_t, typename size_type, typename device>
-void test_coarsen_random(lno_t /*numVerts*/, size_type /*nnz*/,
-                         lno_t /*bandwidth*/, lno_t /*row_size_variance*/) {}
-#endif
 
 #define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE)                                         \
   TEST_F(                                                                                     \

--- a/unit_test/graph/Test_Graph_coarsen.hpp
+++ b/unit_test/graph/Test_Graph_coarsen.hpp
@@ -310,7 +310,6 @@ template <typename scalar, typename lno_t, typename size_type, typename device>
 void test_multilevel_coarsen_grid() {}
 #endif
 
-
 #if !defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 template <typename scalar, typename lno_t, typename size_type, typename device>
 void test_coarsen_grid() {
@@ -366,7 +365,6 @@ void test_coarsen_grid() {
 template <typename scalar, typename lno_t, typename size_type, typename device>
 void test_coarsen_grid() {}
 #endif
-
 
 #if !defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 template <typename scalar, typename lno_t, typename size_type, typename device>
@@ -439,8 +437,8 @@ void test_coarsen_random(lno_t numVerts, size_type nnz, lno_t bandwidth,
 }
 #else
 template <typename scalar, typename lno_t, typename size_type, typename device>
-void test_coarsen_random(lno_t /*numVerts*/, size_type /*nnz*/, lno_t /*bandwidth*/,
-                         lno_t /*row_size_variance*/) {}
+void test_coarsen_random(lno_t /*numVerts*/, size_type /*nnz*/,
+                         lno_t /*bandwidth*/, lno_t /*row_size_variance*/) {}
 #endif
 
 #define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE)                                         \


### PR DESCRIPTION
New capabilities added to perform graph coarsening rely on LAMBDA expression that are only available in CUDA when specifically enabled in Kokkos Core. Adding guards for CUDA LAMBDAs fix a compilation issue in the unit-tests.