### PR TITLE
.githob/workflows: Fix redundant workflow triggers

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   clang-format-check:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -2,7 +2,18 @@ name: github-OSX
 
 on:
   pull_request:
-    types: [ opened, labeled, unlabeled, reopened, synchronize ]
+    paths-ignore:
+    - '**/*.rst'
+    - '**/*.md'
+    - '**/requirements.txt'
+    - '**/*.py'
+    - 'docs/**'
+    types: [ opened, reopened, synchronize ]
+
+# Cancels any in progress 'workflow' associated with this PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check-pr-labels:
@@ -49,7 +60,6 @@ jobs:
 
       - name: configure_kokkos
         run: |
-          ls -lat
           mkdir -p kokkos/{build,install}
           cd kokkos/build
           cmake \
@@ -69,7 +79,6 @@ jobs:
 
       - name: configure_kokkos_kernels
         run: |
-          ls -lat
           mkdir -p kokkos-kernels/{build,install}
           cd kokkos-kernels/build
           cmake \


### PR DESCRIPTION
The following changes were made:
 - Removed 'labeled' and 'unlabeled' triggers in favor of manually clicking 'Re-run all jobs' when `AT: WIP` is removed. We do not want to trigger workflow runs every time any label is added or removed and it is not clear how to only trigger when the `AT: WIP` label is removed. This fixes #1491.
 - Conditionally ignore triggers for certain documentation files
 - Previously running workflows are now canceled when when the PR is reopened or the source branch receives a new commit
 - Updated code style check to use ubuntu 20
