### PR TITLE
MIS2 aggregation: fix bug with uninitialized memory

### DIFF
--- a/src/graph/impl/KokkosGraph_Distance2MIS_impl.hpp
+++ b/src/graph/impl/KokkosGraph_Distance2MIS_impl.hpp
@@ -1117,7 +1117,8 @@ struct D2_MIS_Aggregation {
           if (neiAgg == agg) connect++;
         }
         connectivities_(i) = connect;
-      }
+      } else
+        connectivities_(i) = 0;
     }
 
     lno_t numVerts_;
@@ -1224,9 +1225,9 @@ struct D2_MIS_Aggregation {
     // neighboring aggregate.
     labels_t labelsOld("old", numVerts);
     Kokkos::deep_copy(labelsOld, labels);
-    labels_t connectivities("connect", numVerts);
-    labels_t aggSizes(
-        Kokkos::ViewAllocateWithoutInitializing("Phase3 Agg Sizes"), numAggs);
+    labels_t connectivities(Kokkos::ViewAllocateWithoutInitializing("connect"),
+                            numVerts);
+    labels_t aggSizes("Phase3 Agg Sizes", numAggs);
     Kokkos::parallel_for(
         range_pol(0, numVerts),
         SizeAndConnectivityFunctor(numVerts, rowmap, entries, labels,


### PR DESCRIPTION
A Kokkos view (aggSizes) in the phase 3 aggregation kernel was not initialized when it should have been. It needs to start out filled with 0 because it counts up from there in-place with atomics. Another view (connectivities) was initialized but actually didn't need to be. This didn't necessarily affect the correctness of the aggregation, only the quality and determinism, since aggSizes is only needed as a tiebreak in the phase 3 heuristic.

Fixes https://github.com/trilinos/Trilinos/issues/10950 and makes MIS2 unit tests run cleanly under valgrind.