### PR TITLE
Change template type for StaticCrsGraph in BsrMatrix

### DIFF
--- a/sparse/src/KokkosSparse_BsrMatrix.hpp
+++ b/sparse/src/KokkosSparse_BsrMatrix.hpp
@@ -391,11 +391,11 @@ class BsrMatrix {
       HostMirror;
   //! Type of the graph structure of the sparse matrix.
   typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft,
-                                 execution_space, memory_traits, size_type>
+                                 device_type, memory_traits, size_type>
       StaticCrsGraphType;
   //! Type of the graph structure of the sparse matrix - consistent with Kokkos.
   typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft,
-                                 execution_space, memory_traits, size_type>
+                                 device_type, memory_traits, size_type>
       staticcrsgraph_type;
   //! Type of column indices in the sparse matrix.
   typedef typename staticcrsgraph_type::entries_type index_type;

--- a/sparse/src/KokkosSparse_BsrMatrix.hpp
+++ b/sparse/src/KokkosSparse_BsrMatrix.hpp
@@ -390,12 +390,12 @@ class BsrMatrix {
   typedef BsrMatrix<ScalarType, OrdinalType, host_mirror_space, MemoryTraits>
       HostMirror;
   //! Type of the graph structure of the sparse matrix.
-  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft,
-                                 device_type, memory_traits, size_type>
+  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, device_type,
+                                 memory_traits, size_type>
       StaticCrsGraphType;
   //! Type of the graph structure of the sparse matrix - consistent with Kokkos.
-  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft,
-                                 device_type, memory_traits, size_type>
+  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, device_type,
+                                 memory_traits, size_type>
       staticcrsgraph_type;
   //! Type of column indices in the sparse matrix.
   typedef typename staticcrsgraph_type::entries_type index_type;


### PR DESCRIPTION
This change matches `KokkosSparse_BsrMatrix.hpp` to `KokkosSparse_CrsMatrix.hpp`, namely, using `device_type` instead of `execution_space` to define `Kokkos::StaticCrsGraph` type. This is motivated by using `BsrMatrix` in `Trilinos/tpetra/BlockCrsMatrix` where we need this change on the trilinos side in PR https://github.com/trilinos/Trilinos/pull/10965