### PR TITLE
Warning fixes: Apple Clang complains about [-Werror,-Wunused-but-set-variable]

### DIFF
--- a/graph/impl/KokkosGraph_Distance2Color_impl.hpp
+++ b/graph/impl/KokkosGraph_Distance2Color_impl.hpp
@@ -371,6 +371,8 @@ class GraphColorDistance2 {
       total_time += time;
       std::cout << "\tTime serial conflict resolution   : " << time
                 << std::endl;
+      std::cout << "\tTotal time for coloring           : " << total_time
+		<< std::endl;
       gc_handle->add_to_overall_coloring_time_phase3(time);
     }
 

--- a/perf_test/sparse/KokkosSparse_spmv_struct.cpp
+++ b/perf_test/sparse/KokkosSparse_spmv_struct.cpp
@@ -411,21 +411,15 @@ int main(int argc, char **argv) {
 
       Kokkos::deep_copy(h_y, y_check);
       Scalar error = 0;
-      Scalar sum   = 0;
       for (int rowIdx = 0; rowIdx < A.numRows(); ++rowIdx) {
         for (int vecIdx = 0; vecIdx < numVecs; ++vecIdx) {
           error += (h_y_compare(rowIdx, vecIdx) - h_y(rowIdx, vecIdx)) *
                    (h_y_compare(rowIdx, vecIdx) - h_y(rowIdx, vecIdx));
-          sum += h_y_compare(rowIdx, vecIdx) * h_y_compare(rowIdx, vecIdx);
         }
       }
 
-      int num_errors     = 0;
       double total_error = 0;
-      double total_sum   = 0;
-      num_errors += (error / (sum == 0 ? 1 : sum)) > 1e-5 ? 1 : 0;
       total_error += error;
-      total_sum += sum;
 
       if (total_error == 0) {
         printf("Kokkos::MultiVector Test: Passed\n");

--- a/perf_test/sparse/KokkosSparse_spmv_struct_tuning.cpp
+++ b/perf_test/sparse/KokkosSparse_spmv_struct_tuning.cpp
@@ -771,21 +771,15 @@ int main(int argc, char** argv) {
 
       Kokkos::deep_copy(h_y, y_check);
       Scalar error = 0;
-      Scalar sum   = 0;
       for (int rowIdx = 0; rowIdx < A.numRows(); ++rowIdx) {
         for (int vecIdx = 0; vecIdx < numVecs; ++vecIdx) {
           error += (h_y_compare(rowIdx) - h_y(rowIdx)) *
                    (h_y_compare(rowIdx) - h_y(rowIdx));
-          sum += h_y_compare(rowIdx) * h_y_compare(rowIdx);
         }
       }
 
-      int num_errors     = 0;
       double total_error = 0;
-      double total_sum   = 0;
-      num_errors += (error / (sum == 0 ? 1 : sum)) > 1e-5 ? 1 : 0;
       total_error += error;
-      total_sum += sum;
 
       if (total_error == 0) {
         printf("Kokkos::MultiVector Test: Passed\n");


### PR DESCRIPTION
Fixing a few spots in performance tests and graph algorithms where the clang compiler on M1 macbook fails with warning as errors.