### PR TITLE
Fix spgemm cusparse

### DIFF
--- a/sparse/impl/KokkosSparse_spgemm_cuSPARSE_impl.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_cuSPARSE_impl.hpp
@@ -171,7 +171,6 @@ void cuSPARSE_symbolic(KernelHandle *handle, typename KernelHandle::nnz_lno_t m,
   h->C_populated = false;  // sparsity pattern of C is not set yet
   (void)row_mapC;
 
-
 #elif defined(CUSPARSE_VERSION) && (11000 <= CUSPARSE_VERSION)
   throw std::runtime_error(
       "SpGEMM cuSPARSE backend is not yet supported for this CUDA version\n");
@@ -321,9 +320,9 @@ void cuSPARSE_apply(
   KOKKOS_CUSPARSE_SAFE_CALL(
       cusparseSetPointerMode(h->cusparseHandle, oldPtrMode));
 
-  (void) m;
-  (void) n;
-  (void) k;
+  (void)m;
+  (void)n;
+  (void)k;
 
 #elif (CUSPARSE_VERSION >= 11000)
   throw std::runtime_error(

--- a/sparse/impl/KokkosSparse_spgemm_cuSPARSE_impl.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_cuSPARSE_impl.hpp
@@ -169,6 +169,8 @@ void cuSPARSE_symbolic(KernelHandle *handle, typename KernelHandle::nnz_lno_t m,
   }
   handle->set_c_nnz(C_nnz);
   h->C_populated = false;  // sparsity pattern of C is not set yet
+  (void)row_mapC;
+
 
 #elif defined(CUSPARSE_VERSION) && (11000 <= CUSPARSE_VERSION)
   throw std::runtime_error(
@@ -318,6 +320,10 @@ void cuSPARSE_apply(
       h->descr_C, h->scalarType, h->alg, h->spgemmDescr));
   KOKKOS_CUSPARSE_SAFE_CALL(
       cusparseSetPointerMode(h->cusparseHandle, oldPtrMode));
+
+  (void) m;
+  (void) n;
+  (void) k;
 
 #elif (CUSPARSE_VERSION >= 11000)
   throw std::runtime_error(


### PR DESCRIPTION
@jczhang07
Fixing a build issue with cuda+cusparse build of spgemm, a few variables are not used in that 11040 branch of the code.
Also are we sure that version 11040 is correct, what about version 11000, is it different?
If not then we should simplify the pre-processor logic, currently spgemm is not supporting cusparse TPL for versions between 11000 and 11040