### PR TITLE
Batched sparse kernels update

### DIFF
--- a/batched/sparse/impl/KokkosBatched_CG_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_CG_TeamVector_Impl.hpp
@@ -75,13 +75,6 @@ KOKKOS_INLINE_FUNCTION int TeamVectorCG<MemberType>::invoke(
   const size_t maximum_iteration = handle.get_max_iteration();
   const MagnitudeType tolerance  = handle.get_tolerance();
 
-  using ScratchPadNormViewType = Kokkos::View<
-      MagnitudeType*,
-      typename VectorViewType::execution_space::scratch_memory_space>;
-  using ScratchPadVectorViewType = Kokkos::View<
-      typename VectorViewType::non_const_value_type**,
-      typename VectorViewType::array_layout,
-      typename VectorViewType::execution_space::scratch_memory_space>;
   using TeamVectorCopy1D = TeamVectorCopy<MemberType, Trans::NoTranspose, 1>;
 
   const OrdinalType numMatrices = _X.extent(0);

--- a/batched/sparse/impl/KokkosBatched_CG_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_CG_TeamVector_Impl.hpp
@@ -62,10 +62,12 @@ namespace KokkosBatched {
 
 template <typename MemberType>
 template <typename OperatorType, typename VectorViewType,
-          typename KrylovHandleType>
+          typename KrylovHandleType, typename TMPViewType,
+          typename TMPNormViewType>
 KOKKOS_INLINE_FUNCTION int TeamVectorCG<MemberType>::invoke(
     const MemberType& member, const OperatorType& A, const VectorViewType& _B,
-    const VectorViewType& _X, const KrylovHandleType& handle) {
+    const VectorViewType& _X, const KrylovHandleType& handle,
+    const TMPViewType& _TMPView, const TMPNormViewType& _TMPNormView) {
   typedef int OrdinalType;
   typedef typename Kokkos::Details::ArithTraits<
       typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
@@ -85,29 +87,25 @@ KOKKOS_INLINE_FUNCTION int TeamVectorCG<MemberType>::invoke(
   const OrdinalType numMatrices = _X.extent(0);
   const OrdinalType numRows     = _X.extent(1);
 
-  ScratchPadVectorViewType P(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-      numRows);
-  ScratchPadVectorViewType Q(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-      numRows);
-  ScratchPadVectorViewType R(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-      numRows);
-  ScratchPadVectorViewType X(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-      numRows);
+  int offset_P = 0;
+  int offset_Q = offset_P + numRows;
+  int offset_R = offset_Q + numRows;
+  int offset_X = offset_R + numRows;
 
-  ScratchPadNormViewType sqr_norm_0(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
-  ScratchPadNormViewType sqr_norm_j(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
-  ScratchPadNormViewType alpha(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
-  ScratchPadNormViewType mask(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
-  ScratchPadNormViewType tmp(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
+  auto P = Kokkos::subview(_TMPView, Kokkos::ALL,
+                           Kokkos::make_pair(offset_P, offset_P + numRows));
+  auto Q = Kokkos::subview(_TMPView, Kokkos::ALL,
+                           Kokkos::make_pair(offset_Q, offset_Q + numRows));
+  auto R = Kokkos::subview(_TMPView, Kokkos::ALL,
+                           Kokkos::make_pair(offset_R, offset_R + numRows));
+  auto X = Kokkos::subview(_TMPView, Kokkos::ALL,
+                           Kokkos::make_pair(offset_X, offset_X + numRows));
+
+  auto sqr_norm_0 = Kokkos::subview(_TMPNormView, Kokkos::ALL, 0);
+  auto sqr_norm_j = Kokkos::subview(_TMPNormView, Kokkos::ALL, 1);
+  auto alpha      = Kokkos::subview(_TMPNormView, Kokkos::ALL, 2);
+  auto mask       = Kokkos::subview(_TMPNormView, Kokkos::ALL, 3);
+  auto tmp        = Kokkos::subview(_TMPNormView, Kokkos::ALL, 4);
 
   TeamVectorCopy<MemberType>::invoke(member, _X, X);
   // Deep copy of b into r_0:
@@ -200,6 +198,61 @@ KOKKOS_INLINE_FUNCTION int TeamVectorCG<MemberType>::invoke(
   TeamVectorCopy<MemberType>::invoke(member, X, _X);
   return status;
 }
+
+template <typename MemberType>
+template <typename OperatorType, typename VectorViewType,
+          typename KrylovHandleType>
+KOKKOS_INLINE_FUNCTION int TeamVectorCG<MemberType>::invoke(
+    const MemberType& member, const OperatorType& A, const VectorViewType& _B,
+    const VectorViewType& _X, const KrylovHandleType& handle) {
+  const int strategy = handle.get_memory_strategy();
+  if (strategy == 0) {
+    using ScratchPadVectorViewType = Kokkos::View<
+        typename VectorViewType::non_const_value_type**,
+        typename VectorViewType::array_layout,
+        typename VectorViewType::execution_space::scratch_memory_space>;
+    using ScratchPadNormViewType = Kokkos::View<
+        typename Kokkos::Details::ArithTraits<
+            typename VectorViewType::non_const_value_type>::mag_type**,
+        typename VectorViewType::execution_space::scratch_memory_space>;
+
+    const int numMatrices = _X.extent(0);
+    const int numRows     = _X.extent(1);
+
+    ScratchPadVectorViewType _TMPView(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+        4 * numRows);
+
+    ScratchPadNormViewType _TMPNormView(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices, 5);
+
+    return invoke<OperatorType, VectorViewType, KrylovHandleType>(
+        member, A, _B, _X, handle, _TMPView, _TMPNormView);
+  }
+  if (strategy == 1) {
+    const int first_matrix = handle.first_index(member.league_rank());
+    const int last_matrix  = handle.last_index(member.league_rank());
+
+    using ScratchPadNormViewType = Kokkos::View<
+        typename Kokkos::Details::ArithTraits<
+            typename VectorViewType::non_const_value_type>::mag_type**,
+        typename VectorViewType::execution_space::scratch_memory_space>;
+
+    const int numMatrices = _X.extent(0);
+
+    auto _TMPView = Kokkos::subview(
+        handle.tmp_view, Kokkos::make_pair(first_matrix, last_matrix),
+        Kokkos::ALL);
+
+    ScratchPadNormViewType _TMPNormView(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices, 5);
+
+    return invoke<OperatorType, VectorViewType, KrylovHandleType>(
+        member, A, _B, _X, handle, _TMPView, _TMPNormView);
+  }
+  return 0;
+}
+
 }  // namespace KokkosBatched
 
 #endif

--- a/batched/sparse/impl/KokkosBatched_CG_Team_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_CG_Team_Impl.hpp
@@ -73,13 +73,6 @@ KOKKOS_INLINE_FUNCTION int TeamCG<MemberType>::invoke(
   size_t maximum_iteration      = handle.get_max_iteration();
   const MagnitudeType tolerance = handle.get_tolerance();
 
-  using ScratchPadNormViewType = Kokkos::View<
-      MagnitudeType*,
-      typename VectorViewType::execution_space::scratch_memory_space>;
-  using ScratchPadVectorViewType = Kokkos::View<
-      typename VectorViewType::non_const_value_type**,
-      typename VectorViewType::array_layout,
-      typename VectorViewType::execution_space::scratch_memory_space>;
   using TeamCopy1D = TeamCopy<MemberType, Trans::NoTranspose, 1>;
 
   const OrdinalType numMatrices = _X.extent(0);

--- a/batched/sparse/impl/KokkosBatched_CG_Team_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_CG_Team_Impl.hpp
@@ -60,10 +60,12 @@ namespace KokkosBatched {
 ///
 
 template <typename MemberType>
-template <typename OperatorType, typename VectorViewType, typename KrylovHandle>
+template <typename OperatorType, typename VectorViewType, typename KrylovHandle,
+          typename TMPViewType, typename TMPNormViewType>
 KOKKOS_INLINE_FUNCTION int TeamCG<MemberType>::invoke(
     const MemberType& member, const OperatorType& A, const VectorViewType& _B,
-    const VectorViewType& _X, const KrylovHandle& handle) {
+    const VectorViewType& _X, const KrylovHandle& handle,
+    const TMPViewType& _TMPView, const TMPNormViewType& _TMPNormView) {
   typedef int OrdinalType;
   typedef typename Kokkos::Details::ArithTraits<
       typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
@@ -83,29 +85,25 @@ KOKKOS_INLINE_FUNCTION int TeamCG<MemberType>::invoke(
   const OrdinalType numMatrices = _X.extent(0);
   const OrdinalType numRows     = _X.extent(1);
 
-  ScratchPadVectorViewType P(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-      numRows);
-  ScratchPadVectorViewType Q(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-      numRows);
-  ScratchPadVectorViewType R(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-      numRows);
-  ScratchPadVectorViewType X(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-      numRows);
+  int offset_P = 0;
+  int offset_Q = offset_P + numRows;
+  int offset_R = offset_Q + numRows;
+  int offset_X = offset_R + numRows;
 
-  ScratchPadNormViewType sqr_norm_0(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
-  ScratchPadNormViewType sqr_norm_j(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
-  ScratchPadNormViewType alpha(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
-  ScratchPadNormViewType mask(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
-  ScratchPadNormViewType tmp(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices);
+  auto P = Kokkos::subview(_TMPView, Kokkos::ALL,
+                           Kokkos::make_pair(offset_P, offset_P + numRows));
+  auto Q = Kokkos::subview(_TMPView, Kokkos::ALL,
+                           Kokkos::make_pair(offset_Q, offset_Q + numRows));
+  auto R = Kokkos::subview(_TMPView, Kokkos::ALL,
+                           Kokkos::make_pair(offset_R, offset_R + numRows));
+  auto X = Kokkos::subview(_TMPView, Kokkos::ALL,
+                           Kokkos::make_pair(offset_X, offset_X + numRows));
+
+  auto sqr_norm_0 = Kokkos::subview(_TMPNormView, Kokkos::ALL, 0);
+  auto sqr_norm_j = Kokkos::subview(_TMPNormView, Kokkos::ALL, 1);
+  auto alpha      = Kokkos::subview(_TMPNormView, Kokkos::ALL, 2);
+  auto mask       = Kokkos::subview(_TMPNormView, Kokkos::ALL, 3);
+  auto tmp        = Kokkos::subview(_TMPNormView, Kokkos::ALL, 4);
 
   TeamCopy<MemberType>::invoke(member, _X, X);
   // Deep copy of b into r_0:
@@ -197,6 +195,60 @@ KOKKOS_INLINE_FUNCTION int TeamCG<MemberType>::invoke(
 
   TeamCopy<MemberType>::invoke(member, X, _X);
   return status;
+}
+
+template <typename MemberType>
+template <typename OperatorType, typename VectorViewType,
+          typename KrylovHandleType>
+KOKKOS_INLINE_FUNCTION int TeamCG<MemberType>::invoke(
+    const MemberType& member, const OperatorType& A, const VectorViewType& _B,
+    const VectorViewType& _X, const KrylovHandleType& handle) {
+  const int strategy = handle.get_memory_strategy();
+  if (strategy == 0) {
+    using ScratchPadVectorViewType = Kokkos::View<
+        typename VectorViewType::non_const_value_type**,
+        typename VectorViewType::array_layout,
+        typename VectorViewType::execution_space::scratch_memory_space>;
+    using ScratchPadNormViewType = Kokkos::View<
+        typename Kokkos::Details::ArithTraits<
+            typename VectorViewType::non_const_value_type>::mag_type**,
+        typename VectorViewType::execution_space::scratch_memory_space>;
+
+    const int numMatrices = _X.extent(0);
+    const int numRows     = _X.extent(1);
+
+    ScratchPadVectorViewType _TMPView(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+        4 * numRows);
+
+    ScratchPadNormViewType _TMPNormView(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices, 5);
+
+    return invoke<OperatorType, VectorViewType, KrylovHandleType>(
+        member, A, _B, _X, handle, _TMPView, _TMPNormView);
+  }
+  if (strategy == 1) {
+    const int first_matrix = handle.first_index(member.league_rank());
+    const int last_matrix  = handle.last_index(member.league_rank());
+
+    using ScratchPadNormViewType = Kokkos::View<
+        typename Kokkos::Details::ArithTraits<
+            typename VectorViewType::non_const_value_type>::mag_type**,
+        typename VectorViewType::execution_space::scratch_memory_space>;
+
+    const int numMatrices = _X.extent(0);
+
+    auto _TMPView = Kokkos::subview(
+        handle.tmp_view, Kokkos::make_pair(first_matrix, last_matrix),
+        Kokkos::ALL);
+
+    ScratchPadNormViewType _TMPNormView(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices, 5);
+
+    return invoke<OperatorType, VectorViewType, KrylovHandleType>(
+        member, A, _B, _X, handle, _TMPView, _TMPNormView);
+  }
+  return 0;
 }
 
 }  // namespace KokkosBatched

--- a/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
@@ -78,10 +78,6 @@ KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::invoke(
       typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
   typedef Kokkos::Details::ArithTraits<MagnitudeType> ATM;
 
-  using ScratchPadVectorViewType = Kokkos::View<
-      typename VectorViewType::non_const_value_type**,
-      typename VectorViewType::array_layout,
-      typename VectorViewType::execution_space::scratch_memory_space>;
   using TeamVectorCopy1D = TeamVectorCopy<MemberType, Trans::NoTranspose, 1>;
 
   const OrdinalType numMatrices = _X.extent(0);

--- a/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
@@ -66,11 +66,13 @@ namespace KokkosBatched {
 
 template <typename MemberType>
 template <typename OperatorType, typename VectorViewType,
-          typename PrecOperatorType, typename KrylovHandleType>
+          typename PrecOperatorType, typename KrylovHandleType,
+          typename ArnoldiViewType, typename TMPViewType>
 KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::invoke(
     const MemberType& member, const OperatorType& A, const VectorViewType& _B,
     const VectorViewType& _X, const PrecOperatorType& P,
-    const KrylovHandleType& handle) {
+    const KrylovHandleType& handle, const ArnoldiViewType& _ArnoldiView,
+    const TMPViewType& _TMPView) {
   typedef int OrdinalType;
   typedef typename Kokkos::Details::ArithTraits<
       typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
@@ -99,51 +101,36 @@ KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::invoke(
   int offset_H      = offset_V + n_V;
   int offset_Givens = offset_H + n_H;
 
-  const int first_matrix = handle.first_index(member.league_rank());
-  const int last_matrix  = handle.last_index(member.league_rank());
-
-  auto V_view = Kokkos::subview(
-      handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
-      Kokkos::ALL, Kokkos::make_pair(offset_V, offset_V + n_V));
-  auto H_view = Kokkos::subview(
-      handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
-      Kokkos::ALL, Kokkos::make_pair(offset_H, offset_H + n_H));
+  auto V_view      = Kokkos::subview(_ArnoldiView, Kokkos::ALL, Kokkos::ALL,
+                                Kokkos::make_pair(offset_V, offset_V + n_V));
+  auto H_view      = Kokkos::subview(_ArnoldiView, Kokkos::ALL, Kokkos::ALL,
+                                Kokkos::make_pair(offset_H, offset_H + n_H));
   auto Givens_view = Kokkos::subview(
-      handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
-      Kokkos::ALL, Kokkos::make_pair(offset_Givens, offset_Givens + n_Givens));
+      _ArnoldiView, Kokkos::ALL, Kokkos::ALL,
+      Kokkos::make_pair(offset_Givens, offset_Givens + n_Givens));
 
   int n_G    = maximum_iteration + 1;
   int n_W    = numRows;
-  int n_X    = numRows;
   int n_mask = 1;
-  int n_tmp  = 1;
 
   int offset_G    = 0;
   int offset_W    = offset_G + n_G;
-  int offset_X    = offset_W + n_W;
-  int offset_mask = offset_X + n_X;
+  int offset_mask = offset_W + n_W;
   int offset_tmp  = offset_mask + n_mask;
 
-  ScratchPadVectorViewType tmp_2D(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-      n_G + n_W + n_X + n_mask + n_tmp);
-
-  auto G    = Kokkos::subview(tmp_2D, Kokkos::ALL,
+  auto G    = Kokkos::subview(_TMPView, Kokkos::ALL,
                            Kokkos::make_pair(offset_G, offset_G + n_G));
-  auto W    = Kokkos::subview(tmp_2D, Kokkos::ALL,
+  auto W    = Kokkos::subview(_TMPView, Kokkos::ALL,
                            Kokkos::make_pair(offset_W, offset_W + n_W));
-  auto X    = Kokkos::subview(tmp_2D, Kokkos::ALL,
-                           Kokkos::make_pair(offset_X, offset_X + n_X));
-  auto mask = Kokkos::subview(tmp_2D, Kokkos::ALL, offset_mask);
-  auto tmp  = Kokkos::subview(tmp_2D, Kokkos::ALL, offset_tmp);
+  auto mask = Kokkos::subview(_TMPView, Kokkos::ALL, offset_mask);
+  auto tmp  = Kokkos::subview(_TMPView, Kokkos::ALL, offset_tmp);
 
-  TeamVectorCopy<MemberType>::invoke(member, _X, X);
   // Deep copy of b into r_0:
   TeamVectorCopy<MemberType>::invoke(member, _B, W);
 
   // r_0 := b - A x_0
   member.team_barrier();
-  A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, X, W, -1, 1);
+  A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, _X, W, -1, 1);
   member.team_barrier();
 
   P.template apply<Trans::NoTranspose, Mode::TeamVector, 1>(member, W, W);
@@ -333,26 +320,23 @@ KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::invoke(
     TeamVectorGemv<MemberType, Trans::Transpose, Algo::Gemv::Unblocked>::invoke(
         member, 1,
         Kokkos::subview(V_view, Kokkos::ALL, first_indices, Kokkos::ALL),
-        Kokkos::subview(G, Kokkos::ALL, first_indices), 1, X);
-    member.team_barrier();  // Finish writing to X
+        Kokkos::subview(G, Kokkos::ALL, first_indices), 1, _X);
+    member.team_barrier();  // Finish writing to _X
   }
   if (handle.get_ortho_strategy() == 1) {
     for (size_t j = 0; j < maximum_iteration; ++j) {
       TeamVectorAxpy<MemberType>::invoke(
           member, Kokkos::subview(G, Kokkos::ALL, j),
-          Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL), X);
-      member.team_barrier();  // Finish writing to X
+          Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL), _X);
+      member.team_barrier();  // Finish writing to _X
     }
   }
-
-  TeamVectorCopy<MemberType>::invoke(member, X, _X);
-
-  member.team_barrier();
 
   if (handle.get_compute_last_residual()) {
     TeamVectorCopy<MemberType>::invoke(member, _B, W);
     member.team_barrier();
-    A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, X, W, -1, 1);
+    A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, _X, W, -1,
+                                                           1);
     member.team_barrier();
     P.template apply<Trans::NoTranspose, Mode::TeamVector, 1>(member, W, W);
     member.team_barrier();
@@ -367,6 +351,101 @@ KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::invoke(
                          });
   }
   return status;
+}
+
+template <typename MemberType>
+template <typename OperatorType, typename VectorViewType,
+          typename PrecOperatorType, typename KrylovHandleType>
+KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::invoke(
+    const MemberType& member, const OperatorType& A, const VectorViewType& _B,
+    const VectorViewType& _X, const PrecOperatorType& P,
+    const KrylovHandleType& handle) {
+  const int strategy = handle.get_memory_strategy();
+  if (strategy == 0) {
+    const int first_matrix = handle.first_index(member.league_rank());
+    const int last_matrix  = handle.last_index(member.league_rank());
+
+    auto _ArnoldiView = Kokkos::subview(
+        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+        Kokkos::ALL, Kokkos::ALL);
+
+    const int numMatrices = _X.extent(0);
+    const int numRows     = _X.extent(1);
+
+    size_t maximum_iteration = handle.get_max_iteration() < numRows
+                                   ? handle.get_max_iteration()
+                                   : numRows;
+
+    int n_G    = maximum_iteration + 1;
+    int n_W    = numRows;
+    int n_mask = 1;
+    int n_tmp  = 1;
+
+    using ScratchPadVectorViewType = Kokkos::View<
+        typename VectorViewType::non_const_value_type**,
+        typename VectorViewType::array_layout,
+        typename VectorViewType::execution_space::scratch_memory_space>;
+
+    ScratchPadVectorViewType _TMPView(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+        n_G + n_W + n_mask + n_tmp);
+
+    return invoke<OperatorType, VectorViewType, PrecOperatorType,
+                  KrylovHandleType>(member, A, _B, _X, P, handle, _ArnoldiView,
+                                    _TMPView);
+  }
+  if (strategy == 1) {
+    const int first_matrix = handle.first_index(member.league_rank());
+    const int last_matrix  = handle.last_index(member.league_rank());
+
+    auto _ArnoldiView = Kokkos::subview(
+        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+        Kokkos::ALL, Kokkos::ALL);
+
+    auto _TMPView = Kokkos::subview(
+        handle.tmp_view, Kokkos::make_pair(first_matrix, last_matrix),
+        Kokkos::ALL);
+
+    return invoke<OperatorType, VectorViewType, PrecOperatorType,
+                  KrylovHandleType>(member, A, _B, _X, P, handle, _ArnoldiView,
+                                    _TMPView);
+  }
+  if (strategy == 2) {
+    using ScratchPadArnoldiViewType = Kokkos::View<
+        typename VectorViewType::non_const_value_type***,
+        typename VectorViewType::array_layout,
+        typename VectorViewType::execution_space::scratch_memory_space>;
+
+    using ScratchPadVectorViewType = Kokkos::View<
+        typename VectorViewType::non_const_value_type**,
+        typename VectorViewType::array_layout,
+        typename VectorViewType::execution_space::scratch_memory_space>;
+
+    const int numMatrices = _X.extent(0);
+    const int numRows     = _X.extent(1);
+
+    size_t maximum_iteration = handle.get_max_iteration() < numRows
+                                   ? handle.get_max_iteration()
+                                   : numRows;
+
+    int n_G    = maximum_iteration + 1;
+    int n_W    = numRows;
+    int n_mask = 1;
+    int n_tmp  = 1;
+
+    ScratchPadArnoldiViewType _ArnoldiView(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+        maximum_iteration, numRows + maximum_iteration + 3);
+
+    ScratchPadVectorViewType _TMPView(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+        n_G + n_W + n_mask + n_tmp);
+
+    return invoke<OperatorType, VectorViewType, PrecOperatorType,
+                  KrylovHandleType>(member, A, _B, _X, P, handle, _ArnoldiView,
+                                    _TMPView);
+  }
+  return 0;
 }
 
 template <typename MemberType>

--- a/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
@@ -77,10 +77,6 @@ KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::invoke(
       typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
   typedef Kokkos::Details::ArithTraits<MagnitudeType> ATM;
 
-  using ScratchPadVectorViewType = Kokkos::View<
-      typename VectorViewType::non_const_value_type**,
-      typename VectorViewType::array_layout,
-      typename VectorViewType::execution_space::scratch_memory_space>;
   using TeamCopy1D = TeamCopy<MemberType, Trans::NoTranspose, 1>;
 
   const OrdinalType numMatrices = _X.extent(0);

--- a/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
@@ -65,11 +65,13 @@ namespace KokkosBatched {
 
 template <typename MemberType>
 template <typename OperatorType, typename VectorViewType,
-          typename PrecOperatorType, typename KrylovHandleType>
+          typename PrecOperatorType, typename KrylovHandleType,
+          typename ArnoldiViewType, typename TMPViewType>
 KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::invoke(
     const MemberType& member, const OperatorType& A, const VectorViewType& _B,
     const VectorViewType& _X, const PrecOperatorType& P,
-    const KrylovHandleType& handle) {
+    const KrylovHandleType& handle, const ArnoldiViewType& _ArnoldiView,
+    const TMPViewType& _TMPView) {
   typedef int OrdinalType;
   typedef typename Kokkos::Details::ArithTraits<
       typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
@@ -98,51 +100,36 @@ KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::invoke(
   int offset_H      = offset_V + n_V;
   int offset_Givens = offset_H + n_H;
 
-  const int first_matrix = handle.first_index(member.league_rank());
-  const int last_matrix  = handle.last_index(member.league_rank());
-
-  auto V_view = Kokkos::subview(
-      handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
-      Kokkos::ALL, Kokkos::make_pair(offset_V, offset_V + n_V));
-  auto H_view = Kokkos::subview(
-      handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
-      Kokkos::ALL, Kokkos::make_pair(offset_H, offset_H + n_H));
+  auto V_view      = Kokkos::subview(_ArnoldiView, Kokkos::ALL, Kokkos::ALL,
+                                Kokkos::make_pair(offset_V, offset_V + n_V));
+  auto H_view      = Kokkos::subview(_ArnoldiView, Kokkos::ALL, Kokkos::ALL,
+                                Kokkos::make_pair(offset_H, offset_H + n_H));
   auto Givens_view = Kokkos::subview(
-      handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
-      Kokkos::ALL, Kokkos::make_pair(offset_Givens, offset_Givens + n_Givens));
+      _ArnoldiView, Kokkos::ALL, Kokkos::ALL,
+      Kokkos::make_pair(offset_Givens, offset_Givens + n_Givens));
 
   int n_G    = maximum_iteration + 1;
   int n_W    = numRows;
-  int n_X    = numRows;
   int n_mask = 1;
-  int n_tmp  = 1;
 
   int offset_G    = 0;
   int offset_W    = offset_G + n_G;
-  int offset_X    = offset_W + n_W;
-  int offset_mask = offset_X + n_X;
+  int offset_mask = offset_W + n_W;
   int offset_tmp  = offset_mask + n_mask;
 
-  ScratchPadVectorViewType tmp_2D(
-      member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
-      n_G + n_W + n_X + n_mask + n_tmp);
-
-  auto G    = Kokkos::subview(tmp_2D, Kokkos::ALL,
+  auto G    = Kokkos::subview(_TMPView, Kokkos::ALL,
                            Kokkos::make_pair(offset_G, offset_G + n_G));
-  auto W    = Kokkos::subview(tmp_2D, Kokkos::ALL,
+  auto W    = Kokkos::subview(_TMPView, Kokkos::ALL,
                            Kokkos::make_pair(offset_W, offset_W + n_W));
-  auto X    = Kokkos::subview(tmp_2D, Kokkos::ALL,
-                           Kokkos::make_pair(offset_X, offset_X + n_X));
-  auto mask = Kokkos::subview(tmp_2D, Kokkos::ALL, offset_mask);
-  auto tmp  = Kokkos::subview(tmp_2D, Kokkos::ALL, offset_tmp);
+  auto mask = Kokkos::subview(_TMPView, Kokkos::ALL, offset_mask);
+  auto tmp  = Kokkos::subview(_TMPView, Kokkos::ALL, offset_tmp);
 
-  TeamCopy<MemberType>::invoke(member, _X, X);
   // Deep copy of b into r_0:
   TeamCopy<MemberType>::invoke(member, _B, W);
 
   // r_0 := b - A x_0
   member.team_barrier();
-  A.template apply<Trans::NoTranspose, Mode::Team>(member, X, W, -1, 1);
+  A.template apply<Trans::NoTranspose, Mode::Team>(member, _X, W, -1, 1);
   member.team_barrier();
 
   P.template apply<Trans::NoTranspose, Mode::Team, 1>(member, W, W);
@@ -330,26 +317,22 @@ KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::invoke(
     TeamGemv<MemberType, Trans::Transpose, Algo::Gemv::Unblocked>::invoke(
         member, 1,
         Kokkos::subview(V_view, Kokkos::ALL, first_indices, Kokkos::ALL),
-        Kokkos::subview(G, Kokkos::ALL, first_indices), 1, X);
-    member.team_barrier();  // Finish writing to X
+        Kokkos::subview(G, Kokkos::ALL, first_indices), 1, _X);
+    member.team_barrier();  // Finish writing to _X
   }
   if (handle.get_ortho_strategy() == 1) {
     for (size_t j = 0; j < maximum_iteration; ++j) {
       TeamAxpy<MemberType>::invoke(
           member, Kokkos::subview(G, Kokkos::ALL, j),
-          Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL), X);
-      member.team_barrier();  // Finish writing to X
+          Kokkos::subview(V_view, Kokkos::ALL, j, Kokkos::ALL), _X);
+      member.team_barrier();  // Finish writing to _X
     }
   }
-
-  TeamCopy<MemberType>::invoke(member, X, _X);
-
-  member.team_barrier();
 
   if (handle.get_compute_last_residual()) {
     TeamCopy<MemberType>::invoke(member, _B, W);
     member.team_barrier();
-    A.template apply<Trans::NoTranspose, Mode::Team>(member, X, W, -1, 1);
+    A.template apply<Trans::NoTranspose, Mode::Team>(member, _X, W, -1, 1);
     member.team_barrier();
     P.template apply<Trans::NoTranspose, Mode::Team, 1>(member, W, W);
     member.team_barrier();
@@ -364,6 +347,101 @@ KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::invoke(
                          });
   }
   return status;
+}
+
+template <typename MemberType>
+template <typename OperatorType, typename VectorViewType,
+          typename PrecOperatorType, typename KrylovHandleType>
+KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::invoke(
+    const MemberType& member, const OperatorType& A, const VectorViewType& _B,
+    const VectorViewType& _X, const PrecOperatorType& P,
+    const KrylovHandleType& handle) {
+  const int strategy = handle.get_memory_strategy();
+  if (strategy == 0) {
+    const int first_matrix = handle.first_index(member.league_rank());
+    const int last_matrix  = handle.last_index(member.league_rank());
+
+    auto _ArnoldiView = Kokkos::subview(
+        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+        Kokkos::ALL, Kokkos::ALL);
+
+    const int numMatrices = _X.extent(0);
+    const int numRows     = _X.extent(1);
+
+    size_t maximum_iteration = handle.get_max_iteration() < numRows
+                                   ? handle.get_max_iteration()
+                                   : numRows;
+
+    int n_G    = maximum_iteration + 1;
+    int n_W    = numRows;
+    int n_mask = 1;
+    int n_tmp  = 1;
+
+    using ScratchPadVectorViewType = Kokkos::View<
+        typename VectorViewType::non_const_value_type**,
+        typename VectorViewType::array_layout,
+        typename VectorViewType::execution_space::scratch_memory_space>;
+
+    ScratchPadVectorViewType _TMPView(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+        n_G + n_W + n_mask + n_tmp);
+
+    return invoke<OperatorType, VectorViewType, PrecOperatorType,
+                  KrylovHandleType>(member, A, _B, _X, P, handle, _ArnoldiView,
+                                    _TMPView);
+  }
+  if (strategy == 1) {
+    const int first_matrix = handle.first_index(member.league_rank());
+    const int last_matrix  = handle.last_index(member.league_rank());
+
+    auto _ArnoldiView = Kokkos::subview(
+        handle.Arnoldi_view, Kokkos::make_pair(first_matrix, last_matrix),
+        Kokkos::ALL, Kokkos::ALL);
+
+    auto _TMPView = Kokkos::subview(
+        handle.tmp_view, Kokkos::make_pair(first_matrix, last_matrix),
+        Kokkos::ALL);
+
+    return invoke<OperatorType, VectorViewType, PrecOperatorType,
+                  KrylovHandleType>(member, A, _B, _X, P, handle, _ArnoldiView,
+                                    _TMPView);
+  }
+  if (strategy == 2) {
+    using ScratchPadArnoldiViewType = Kokkos::View<
+        typename VectorViewType::non_const_value_type***,
+        typename VectorViewType::array_layout,
+        typename VectorViewType::execution_space::scratch_memory_space>;
+
+    using ScratchPadVectorViewType = Kokkos::View<
+        typename VectorViewType::non_const_value_type**,
+        typename VectorViewType::array_layout,
+        typename VectorViewType::execution_space::scratch_memory_space>;
+
+    const int numMatrices = _X.extent(0);
+    const int numRows     = _X.extent(1);
+
+    size_t maximum_iteration = handle.get_max_iteration() < numRows
+                                   ? handle.get_max_iteration()
+                                   : numRows;
+
+    int n_G    = maximum_iteration + 1;
+    int n_W    = numRows;
+    int n_mask = 1;
+    int n_tmp  = 1;
+
+    ScratchPadArnoldiViewType _ArnoldiView(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+        maximum_iteration, numRows + maximum_iteration + 3);
+
+    ScratchPadVectorViewType _TMPView(
+        member.team_scratch(handle.get_scratch_pad_level()), numMatrices,
+        n_G + n_W + n_mask + n_tmp);
+
+    return invoke<OperatorType, VectorViewType, PrecOperatorType,
+                  KrylovHandleType>(member, A, _B, _X, P, handle, _ArnoldiView,
+                                    _TMPView);
+  }
+  return 0;
 }
 
 template <typename MemberType>

--- a/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
@@ -98,7 +98,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorSpmvInternal::invoke(
     const OrdinalType ys1) {
 #if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
   if (member.team_size() == 1) {
-    if (N_team != 0 && valuess0 == 1) {
+    if (N_team > 1 && valuess0 == 1) {
       /*
         Left layout as valuess0 = 1 and non-zero vector length given at
         compilation time. Here we use the SIMD data type which is using Intel

--- a/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
@@ -136,10 +136,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorSpmvInternal::invoke(
         sum_v.storeAligned(&Y[iRow * ys1]);
       }
     } else {
-      Kokkos::Impl::integral_nonzero_constant<unsigned, N_team> n_team(
-          numMatrices);
-
-      for (unsigned iMatrix = 0; iMatrix < unsigned(n_team.value); ++iMatrix) {
+      for (unsigned iMatrix = 0; iMatrix < unsigned(numMatrices); ++iMatrix) {
         for (OrdinalType iRow = 0; iRow < numRows; ++iRow) {
           const OrdinalType rowLength =
               row_ptr[(iRow + 1) * row_ptrs0] - row_ptr[iRow * row_ptrs0];
@@ -222,7 +219,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorSpmvInternal::invoke(
     const OrdinalType ys1) {
 #if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
   if (member.team_size() == 1) {
-    if (N_team != 0 && valuess0 == 1) {
+    if (N_team > 1 && valuess0 == 1) {
       /*
         Left layout as valuess0 = 1 and non-zero vector length given at
         compilation time Here we use the SIMD data type which is using Intel
@@ -257,10 +254,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorSpmvInternal::invoke(
         sum_v.storeAligned(&Y[iRow * ys1]);
       }
     } else {
-      Kokkos::Impl::integral_nonzero_constant<unsigned, N_team> n_team(
-          numMatrices);
-
-      for (unsigned iMatrix = 0; iMatrix < unsigned(n_team.value); ++iMatrix) {
+      for (unsigned iMatrix = 0; iMatrix < unsigned(numMatrices); ++iMatrix) {
         for (OrdinalType iRow = 0; iRow < numRows; ++iRow) {
           const OrdinalType rowLength =
               row_ptr[(iRow + 1) * row_ptrs0] - row_ptr[iRow * row_ptrs0];

--- a/batched/sparse/src/KokkosBatched_CrsMatrix.hpp
+++ b/batched/sparse/src/KokkosBatched_CrsMatrix.hpp
@@ -111,14 +111,25 @@ class CrsMatrix {
       MagnitudeType alpha = Kokkos::Details::ArithTraits<MagnitudeType>::one(),
       MagnitudeType beta =
           Kokkos::Details::ArithTraits<MagnitudeType>::zero()) const {
-    if (beta == Kokkos::Details::ArithTraits<MagnitudeType>::zero())
-      KokkosBatched::TeamVectorSpmv<MemberType, ArgTrans>::template invoke<
-          ValuesViewType, IntViewType, XViewType, YViewType, 0>(
-          member, alpha, values, row_ptr, colIndices, X, beta, Y);
-    else
-      KokkosBatched::TeamVectorSpmv<MemberType, ArgTrans>::template invoke<
-          ValuesViewType, IntViewType, XViewType, YViewType, 1>(
-          member, alpha, values, row_ptr, colIndices, X, beta, Y);
+    if (beta == Kokkos::Details::ArithTraits<MagnitudeType>::zero()) {
+      if (member.team_size() == 1 && n_operators == 8)
+        KokkosBatched::TeamVectorSpmv<MemberType, ArgTrans, 8>::template invoke<
+            ValuesViewType, IntViewType, XViewType, YViewType, 0>(
+            member, alpha, values, row_ptr, colIndices, X, beta, Y);
+      else
+        KokkosBatched::TeamVectorSpmv<MemberType, ArgTrans>::template invoke<
+            ValuesViewType, IntViewType, XViewType, YViewType, 0>(
+            member, alpha, values, row_ptr, colIndices, X, beta, Y);
+    } else {
+      if (member.team_size() == 1 && n_operators == 8)
+        KokkosBatched::TeamVectorSpmv<MemberType, ArgTrans, 8>::template invoke<
+            ValuesViewType, IntViewType, XViewType, YViewType, 1>(
+            member, alpha, values, row_ptr, colIndices, X, beta, Y);
+      else
+        KokkosBatched::TeamVectorSpmv<MemberType, ArgTrans>::template invoke<
+            ValuesViewType, IntViewType, XViewType, YViewType, 1>(
+            member, alpha, values, row_ptr, colIndices, X, beta, Y);
+    }
   }
 
   template <typename ArgTrans, typename XViewType, typename YViewType>

--- a/batched/sparse/src/KokkosBatched_Krylov_Handle.hpp
+++ b/batched/sparse/src/KokkosBatched_Krylov_Handle.hpp
@@ -124,7 +124,7 @@ class KrylovHandle {
     iteration_numbers = IntViewType("", batched_size);
     Kokkos::deep_copy(iteration_numbers, -1);
 
-    n_teams     = ceil(1. * batched_size / N_team);
+    n_teams     = ceil(static_cast<double>(batched_size) / N_team);
     first_index = IntViewType("", n_teams);
     last_index  = IntViewType("", n_teams);
 

--- a/batched/sparse/src/KokkosBatched_Krylov_Handle.hpp
+++ b/batched/sparse/src/KokkosBatched_Krylov_Handle.hpp
@@ -103,6 +103,7 @@ class KrylovHandle {
   int n_teams;
   int ortho_strategy;
   int scratch_pad_level;
+  int memory_strategy;
   bool compute_last_residual;
   bool monitor_residual;
   bool host_synchronised;
@@ -146,6 +147,7 @@ class KrylovHandle {
     scratch_pad_level     = 0;
     compute_last_residual = true;
     host_synchronised     = false;
+    memory_strategy       = 0;
   }
 
   /// \brief get_number_of_systems_per_team
@@ -410,6 +412,14 @@ class KrylovHandle {
     else
       return false;
   }
+
+  KOKKOS_INLINE_FUNCTION
+  void set_memory_strategy(int _memory_strategy) {
+    memory_strategy = _memory_strategy;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  int get_memory_strategy() const { return memory_strategy; }
 
  private:
   /// \brief set_norm

--- a/batched/sparse/src/KokkosBatched_Krylov_Solvers.hpp
+++ b/batched/sparse/src/KokkosBatched_Krylov_Solvers.hpp
@@ -67,6 +67,14 @@ struct SerialGMRES {
 template <typename MemberType>
 struct TeamGMRES {
   template <typename OperatorType, typename VectorViewType,
+            typename PrecOperatorType, typename KrylovHandleType,
+            typename ArnoldiViewType, typename TMPViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(
+      const MemberType& member, const OperatorType& A, const VectorViewType& _B,
+      const VectorViewType& _X, const PrecOperatorType& P,
+      const KrylovHandleType& handle, const ArnoldiViewType& _ArnoldiView,
+      const TMPViewType& _TMPView);
+  template <typename OperatorType, typename VectorViewType,
             typename PrecOperatorType, typename KrylovHandleType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
                                            const OperatorType& A,
@@ -85,6 +93,14 @@ struct TeamGMRES {
 
 template <typename MemberType>
 struct TeamVectorGMRES {
+  template <typename OperatorType, typename VectorViewType,
+            typename PrecOperatorType, typename KrylovHandleType,
+            typename ArnoldiViewType, typename TMPViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(
+      const MemberType& member, const OperatorType& A, const VectorViewType& _B,
+      const VectorViewType& _X, const PrecOperatorType& P,
+      const KrylovHandleType& handle, const ArnoldiViewType& _ArnoldiView,
+      const TMPViewType& _TMPView);
   template <typename OperatorType, typename VectorViewType,
             typename PrecOperatorType, typename KrylovHandleType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
@@ -105,6 +121,13 @@ struct TeamVectorGMRES {
 template <typename MemberType>
 struct TeamCG {
   template <typename OperatorType, typename VectorViewType,
+            typename KrylovHandleType, typename TMPViewType,
+            typename TMPNormViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(
+      const MemberType& member, const OperatorType& A, const VectorViewType& _B,
+      const VectorViewType& _X, const KrylovHandleType& handle,
+      const TMPViewType& _TMPView, const TMPNormViewType& _TMPNormView);
+  template <typename OperatorType, typename VectorViewType,
             typename KrylovHandleType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,
                                            const OperatorType& A,
@@ -115,6 +138,13 @@ struct TeamCG {
 
 template <typename MemberType>
 struct TeamVectorCG {
+  template <typename OperatorType, typename VectorViewType,
+            typename KrylovHandleType, typename TMPViewType,
+            typename TMPNormViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(
+      const MemberType& member, const OperatorType& A, const VectorViewType& _B,
+      const VectorViewType& _X, const KrylovHandleType& handle,
+      const TMPViewType& _TMPView, const TMPNormViewType& _TMPNormView);
   template <typename OperatorType, typename VectorViewType,
             typename KrylovHandleType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member,

--- a/batched/sparse/src/KokkosBatched_Spmv.hpp
+++ b/batched/sparse/src/KokkosBatched_Spmv.hpp
@@ -216,7 +216,7 @@ struct TeamSpmv {
 ///
 
 template <typename MemberType, typename ArgTrans = Trans::NoTranspose,
-          unsigned N_team = 0>
+          unsigned N_team = 1>
 struct TeamVectorSpmv {
   template <typename ValuesViewType, typename IntView, typename xViewType,
             typename yViewType, typename alphaViewType, typename betaViewType,

--- a/batched/sparse/src/KokkosBatched_Spmv.hpp
+++ b/batched/sparse/src/KokkosBatched_Spmv.hpp
@@ -215,7 +215,8 @@ struct TeamSpmv {
 /// (or one with TeamVectorRange) are used inside.
 ///
 
-template <typename MemberType, typename ArgTrans = Trans::NoTranspose>
+template <typename MemberType, typename ArgTrans = Trans::NoTranspose,
+          unsigned N_team = 0>
 struct TeamVectorSpmv {
   template <typename ValuesViewType, typename IntView, typename xViewType,
             typename yViewType, typename alphaViewType, typename betaViewType,

--- a/batched/sparse/unit_test/Test_Batched_TeamVectorSpmv.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamVectorSpmv.hpp
@@ -79,11 +79,10 @@ struct Functor_TestBatchedTeamVectorSpmv {
                               alphaViewType, betaViewType, dobeta>(
           member, alpha, d, _r, _c, x, beta, y);
     else
-      KokkosBatched::TeamVectorSpmv<
-          MemberType, typename ParamTagType::trans,
-          0>::template invoke<ValuesViewType, IntView, xViewType, yViewType,
-                              alphaViewType, betaViewType, dobeta>(
-          member, alpha, d, _r, _c, x, beta, y);
+      KokkosBatched::TeamVectorSpmv<MemberType, typename ParamTagType::trans>::
+          template invoke<ValuesViewType, IntView, xViewType, yViewType,
+                          alphaViewType, betaViewType, dobeta>(
+              member, alpha, d, _r, _c, x, beta, y);
   }
 
   inline void run() {

--- a/batched/sparse/unit_test/Test_Batched_TeamVectorSpmv.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamVectorSpmv.hpp
@@ -72,10 +72,18 @@ struct Functor_TestBatchedTeamVectorSpmv {
     auto y = Kokkos::subview(_Y, Kokkos::make_pair(first_matrix, last_matrix),
                              Kokkos::ALL);
 
-    KokkosBatched::TeamVectorSpmv<MemberType, typename ParamTagType::trans>::
-        template invoke<ValuesViewType, IntView, xViewType, yViewType,
-                        alphaViewType, betaViewType, dobeta>(
-            member, alpha, d, _r, _c, x, beta, y);
+    if (last_matrix != N)
+      KokkosBatched::TeamVectorSpmv<
+          MemberType, typename ParamTagType::trans,
+          2>::template invoke<ValuesViewType, IntView, xViewType, yViewType,
+                              alphaViewType, betaViewType, dobeta>(
+          member, alpha, d, _r, _c, x, beta, y);
+    else
+      KokkosBatched::TeamVectorSpmv<
+          MemberType, typename ParamTagType::trans,
+          0>::template invoke<ValuesViewType, IntView, xViewType, yViewType,
+                              alphaViewType, betaViewType, dobeta>(
+          member, alpha, d, _r, _c, x, beta, y);
   }
 
   inline void run() {
@@ -85,7 +93,7 @@ struct Functor_TestBatchedTeamVectorSpmv {
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::TeamPolicy<DeviceType, ParamTagType> policy(
-        _D.extent(0) / _N_team, Kokkos::AUTO(), Kokkos::AUTO());
+        ceil(1. * _D.extent(0) / _N_team), Kokkos::AUTO(), Kokkos::AUTO());
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }
@@ -187,12 +195,12 @@ int test_batched_teamvector_spmv() {
     for (int i = 3; i < 10; ++i) {
       Test::TeamVectorSpmv::impl_test_batched_spmv<
           DeviceType, ParamTagType, ViewType, IntView, ViewType, ViewType,
-          alphaViewType, alphaViewType, 0>(1024, i, 2);
+          alphaViewType, alphaViewType, 0>(1025, i, 2);
     }
     for (int i = 3; i < 10; ++i) {
       Test::TeamVectorSpmv::impl_test_batched_spmv<
           DeviceType, ParamTagType, ViewType, IntView, ViewType, ViewType,
-          alphaViewType, alphaViewType, 1>(1024, i, 2);
+          alphaViewType, alphaViewType, 1>(1025, i, 2);
     }
   }
 #endif
@@ -207,12 +215,12 @@ int test_batched_teamvector_spmv() {
     for (int i = 3; i < 10; ++i) {
       Test::TeamVectorSpmv::impl_test_batched_spmv<
           DeviceType, ParamTagType, ViewType, IntView, ViewType, ViewType,
-          alphaViewType, alphaViewType, 0>(1024, i, 2);
+          alphaViewType, alphaViewType, 0>(1025, i, 2);
     }
     for (int i = 3; i < 10; ++i) {
       Test::TeamVectorSpmv::impl_test_batched_spmv<
           DeviceType, ParamTagType, ViewType, IntView, ViewType, ViewType,
-          alphaViewType, alphaViewType, 1>(1024, i, 2);
+          alphaViewType, alphaViewType, 1>(1025, i, 2);
     }
   }
 #endif

--- a/batched/sparse/unit_test/Test_Batched_TeamVectorSpmv.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamVectorSpmv.hpp
@@ -93,7 +93,8 @@ struct Functor_TestBatchedTeamVectorSpmv {
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::TeamPolicy<DeviceType, ParamTagType> policy(
-        ceil(1. * _D.extent(0) / _N_team), Kokkos::AUTO(), Kokkos::AUTO());
+        ceil(static_cast<double>(_D.extent(0)) / _N_team), Kokkos::AUTO(),
+        Kokkos::AUTO());
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }


### PR DESCRIPTION
Update the batched sparse kernels to add SIMD data types and options for the temporary variable allocations.

