### PR TITLE
Use CRS matrix sort, instead of Kokkos::sort on each row

### DIFF
--- a/sparse/impl/KokkosSparse_spiluk_symbolic_impl.hpp
+++ b/sparse/impl/KokkosSparse_spiluk_symbolic_impl.hpp
@@ -51,7 +51,7 @@
 #include <KokkosKernels_config.h>
 #include <Kokkos_ArithTraits.hpp>
 #include <KokkosSparse_spiluk_handle.hpp>
-#include <Kokkos_Sort.hpp>
+#include <KokkosSparse_SortCrs.hpp>
 #include <KokkosKernels_Error.hpp>
 
 //#define SYMBOLIC_OUTPUT_INFO
@@ -451,18 +451,12 @@ void iluk_symbolic(IlukHandle& thandle,
     thandle.set_nnzU(cntU);
 
     // Sort
-    for (size_type row_id = 0;
-         row_id < static_cast<size_type>(L_row_map.extent(0)) - 1; row_id++) {
-      size_type row_start = L_row_map(row_id);
-      size_type row_end   = L_row_map(row_id + 1);
-      Kokkos::sort(subview(L_entries, Kokkos::make_pair(row_start, row_end)));
-    }
-    for (size_type row_id = 0;
-         row_id < static_cast<size_type>(U_row_map.extent(0)) - 1; row_id++) {
-      size_type row_start = U_row_map(row_id);
-      size_type row_end   = U_row_map(row_id + 1);
-      Kokkos::sort(subview(U_entries, Kokkos::make_pair(row_start, row_end)));
-    }
+    KokkosSparse::sort_crs_graph<Kokkos::DefaultHostExecutionSpace,
+                                 decltype(L_row_map), decltype(L_entries)>(
+        L_row_map, L_entries);
+    KokkosSparse::sort_crs_graph<Kokkos::DefaultHostExecutionSpace,
+                                 decltype(U_row_map), decltype(U_entries)>(
+        U_row_map, U_entries);
 
     // Level scheduling on L
     if (thandle.get_algorithm() ==


### PR DESCRIPTION
spiluk_symbolic needs to sort the rows of the L and U graphs. Instead of using Kokkos::sort on each row (since this is meant for device-wide sorts of large arrays), use the KokkosSparse::sort_crs_graph function executing on host.

This fixes https://github.com/trilinos/Trilinos/issues/11041. The issue appeared to come from Kokkos because the default behavior of Kokkos::sort changed recently. In 3.6.1, given a UVM space view it dispatched to std::sort because it's host-accessible. In 3.7, In was dispatching to Kokkos bin sort on the GPU. This is definitely the way it should be in general given how Kokkos::sort is intended to be used, but it made this case of sorting many small arrays a lot slower. Especially when those small arrays live in UVM that's resident in host memory.

For biggest local matrix on abnormal energy surrogate problem (the one from Trilinos issue), here are the timings just for sorting L and U a few different ways:

Kokkos::sort each row, with force kokkos=true (current behavior): 169.452
My radix sort_crs_matrix, all on Serial/host (this PR): 3.42121
My bitonic sort_crs_matrix on V100, but not including the transfer back to host: 3.3849
std::sort each row in a normal for loop: 1.92318

This data suggests a follow-up change to sort_crs_graph, that uses std::sort instead of my radix sort where possible. That can come later though - this PR fixes the big slowdown.