### PR TITLE
TeamGemvInternal: reintroduce 12-arg invoke method

### DIFF
--- a/batched/dense/impl/KokkosBatched_Gemv_Team_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemv_Team_Internal.hpp
@@ -5,9 +5,9 @@
 
 #include "KokkosBatched_Util.hpp"
 
-// #include "KokkosBlas1_set_impl.hpp"
-// #include "KokkosBlas1_team_scal_impl.hpp"
-// #include "KokkosBlas2_serial_gemv_inner_multiple_dot.hpp"
+//#include "KokkosBlas1_set_impl.hpp"
+//#include "KokkosBlas1_team_scal_impl.hpp"
+//#include "KokkosBlas2_serial_gemv_inner_multiple_dot.hpp"
 
 namespace KokkosBatched {
 

--- a/batched/dense/src/KokkosBatched_Gemv_Decl.hpp
+++ b/batched/dense/src/KokkosBatched_Gemv_Decl.hpp
@@ -95,6 +95,7 @@ struct Gemv {
 
 #include "KokkosBatched_Gemv_Team_Impl.hpp"
 #include "KokkosBatched_Gemv_TeamVector_Impl.hpp"
+#include "KokkosBlas2_serial_gemv_internal.hpp"
 
 #define KOKKOSBATCHED_SERIAL_GEMV_NO_TRANSPOSE_INTERNAL_INVOKE( \
     ALGOTYPE, M, N, ALPHA, A, AS0, AS1, X, XS, BETA, Y, YS)     \
@@ -108,12 +109,12 @@ struct Gemv {
 
 #define KOKKOSBATCHED_TEAM_GEMV_NO_TRANSPOSE_INTERNAL_INVOKE(       \
     ALGOTYPE, MEMBER, M, N, ALPHA, A, AS0, AS1, X, XS, BETA, Y, YS) \
-  KokkosBatched::TeamGemvInternal<ALGOTYPE>::invoke(                \
+  KokkosBlas::Impl::TeamGemvInternal<ALGOTYPE>::invoke(             \
       MEMBER, M, N, ALPHA, A, AS0, AS1, X, XS, BETA, Y, YS)
 
 #define KOKKOSBATCHED_TEAM_GEMV_TRANSPOSE_INTERNAL_INVOKE(          \
     ALGOTYPE, MEMBER, M, N, ALPHA, A, AS0, AS1, X, XS, BETA, Y, YS) \
-  KokkosBatched::TeamGemvInternal<ALGOTYPE>::invoke(                \
+  KokkosBlas::Impl::TeamGemvInternal<ALGOTYPE>::invoke(             \
       MEMBER, N, M, ALPHA, A, AS1, AS0, X, XS, BETA, Y, YS)
 
 #define KOKKOSBATCHED_GEMV_NO_TRANSPOSE_INTERNAL_INVOKE(                      \


### PR DESCRIPTION
Adds the 12-arg overload of invoke, see #1435
Potential (short term?) solution to #1537