### PR TITLE
Fix docs build

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -11,9 +11,12 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/conf.py DESTINATION ${CMAKE_CURRENT_BINARY
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/index.rst DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 # Find all public headers in KokkosKernels and Kokkos::kokkos
-file(GLOB_RECURSE ${PROJECT_NAME}_PUBLIC_HEADERS ${PROJECT_SOURCE_DIR}/src/*.hpp ${KOKKOS_INCLUDE_DIR}/*.hpp)
+file(GLOB_RECURSE ${PROJECT_NAME}_PUBLIC_HEADERS ${PROJECT_SOURCE_DIR}/sparse/src/*.hpp
+                                                 ${PROJECT_SOURCE_DIR}/blas/src/*.hpp
+                                                 ${PROJECT_SOURCE_DIR}/batched/dense/src/*.hpp
+                                                 ${PROJECT_SOURCE_DIR}/batched/sparse/src/*.hpp
+                                                 ${KOKKOS_INCLUDE_DIR}/*.hpp)
 
-set(DOXYGEN_KOKKOSKERNELS_INPUT_DIR ${PROJECT_SOURCE_DIR}/src)
 set(DOXYGEN_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/doxygen/)
 set(DOXYGEN_INDEX_FILE ${DOXYGEN_OUTPUT_DIR}/xml/index.xml)
 set(DOXYFILE_IN ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -871,7 +871,10 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = "@DOXYGEN_KOKKOSKERNELS_INPUT_DIR@"
+INPUT                  = @CMAKE_SOURCE_DIR@/sparse/src/ \
+                         @CMAKE_SOURCE_DIR@/blas/src/ \
+                         @CMAKE_SOURCE_DIR@/batched/dense/src/ \
+                         @CMAKE_SOURCE_DIR@/batched/sparse/src/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ breathe_projects = {}
 if read_the_docs_build:
     cwd = os.getcwd()
     print(cwd)
-    input_dir = cwd + '/../src/'
+    input_dir = cwd + '/..'
     output_dir = cwd +'/doxygen/'
     doxyfile_in = cwd + '/Doxyfile.in'
     doxyfile_out = cwd + '/Doxyfile'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ def configureDoxyfile(input_dir, output_dir, doxyfile_in, doxyfile_out):
     with open(doxyfile_in, 'r') as file :
         filedata = file.read()
 
-    filedata = filedata.replace('@DOXYGEN_KOKKOSKERNELS_INPUT_DIR@', input_dir)
+    filedata = filedata.replace('@CMAKE_SOURCE_DIR@', input_dir)
     filedata = filedata.replace('@DOXYGEN_OUTPUT_DIR@', output_dir)
 
     with open(doxyfile_out, 'w') as file:

--- a/docs/developer/apidocs/blas3.rst
+++ b/docs/developer/apidocs/blas3.rst
@@ -3,6 +3,5 @@ BLAS3 -- KokkosKernels blas3 interfaces
 
 gemm
 ----
-.. doxygenfunction:: KokkosBlas::gemm(const char transA, const char transB, AMat::const_value_type alpha, const AMat &a, const BMat &b, CMat::const_value_type beta, const CMat &c)
 .. doxygenfunction:: KokkosBlas::gemm(const char transA[], const char transB[], typename AViewType::const_value_type &alpha, const AViewType &A, const BViewType &B, typename CViewType::const_value_type &beta, const CViewType &C)
 .. doxygenfunction:: KokkosBlas::gemm(const typename CViewType::execution_space &space, const char transA[], const char transB[], typename AViewType::const_value_type &alpha, const AViewType &A, const BViewType &B, typename CViewType::const_value_type &beta, const CViewType &C)

--- a/docs/developer/apidocs/sparse.rst
+++ b/docs/developer/apidocs/sparse.rst
@@ -8,11 +8,13 @@ crsmatrix
 
 spmv
 ----
-.. doxygenfunction:: KokkosSparse::spmv(KokkosKernels::Experimental::Controls, const char[], const AlphaType&, const AMatrix&, const XVector&, const BetaType&, const YVector&)
-.. doxygenfunction:: KokkosSparse::spmv(KokkosKernels::Experimental::Controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y)
-.. doxygenfunction:: KokkosSparse::spmv(KokkosKernels::Experimental::Controls controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y, const RANK_ONE)
-.. doxygenfunction:: KokkosSparse::spmv(KokkosKernels::Experimental::Controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y, const RANK_TWO)
-.. doxygenfunction:: KokkosSparse::spmv(const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y)
+
+.. doxygenfunctions:: KokkosSparse::spmv(KokkosKernels::Experimental::Controls, const char[], const AlphaType&, const AMatrix&, const XVector&, const BetaType&, const YVector&)
+.. doxygenfunctions:: KokkosSparse::spmv(KokkosKernels::Experimental::Controls controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y)
+.. doxygenfunctions:: KokkosSparse::spmv(KokkosKernels::Experimental::Controls controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y, const RANK_ONE)
+.. doxygenfunctions:: KokkosSparse::spmv(KokkosKernels::Experimental::Controls controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y, const RANK_TWO)
+.. doxygenfunctions:: KokkosSparse::spmv(const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y)
+
 
 trsv
 ----

--- a/sparse/src/KokkosKernels_Handle.hpp
+++ b/sparse/src/KokkosKernels_Handle.hpp
@@ -444,7 +444,7 @@ class KokkosKernelsHandle {
   /**
    * \brief Sets whether to use dynamic scheduling or
    * not for those kernels where load-imbalances might occur.
-   * \input is_dynamic: true or false -> dynamic or static scheduling.
+   * @param is_dynamic: true or false -> dynamic or static scheduling..
    */
   void set_dynamic_scheduling(const bool is_dynamic) {
     this->use_dynamic_scheduling = is_dynamic;


### PR DESCRIPTION
This PR corrects the source paths for the documentation build. Thanks to @ndellingwood for pointing this out!
The PR also fixes a few regressions (https://github.com/kokkos/kokkos-kernels/commit/50d812c0250f3c95f7b4b74fa47a114aa1b50d71) noted in doxygen warnings. Note that there are several more doxygen warnings that are currently being ignored.

To guard against regressions going forward, I suggest that we change: `WARN_AS_ERROR = YES` in `Doxyfile.in` and add a github actions documentation build. For example:
```
$ git diff
diff --git a/docs/Doxyfile.in b/docs/Doxyfile.in
index 5cb072a46..c3a662197 100644
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -843,7 +843,7 @@ WARN_NO_PARAMDOC       = NO
 # Possible values are: NO, YES and FAIL_ON_WARNINGS.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = YES
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which
@@ -871,7 +871,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @CMAKE_SOURCE_DIR@/sparse/src/ \
+INPUT                  = @CMAKE_SOURCE_DIR@/dne/src/ \
                          @CMAKE_SOURCE_DIR@/blas/src/ \
                          @CMAKE_SOURCE_DIR@/batched/dense/src/ \
                          @CMAKE_SOURCE_DIR@/batched/sparse/src/
```
```
$ make Doxygen
Generating docs
warning: Tag 'CLASS_DIAGRAMS' at line 2320 of file 'Doxyfile' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: tag INPUT: input source '/path/to/kokkos-kernels/dne/src/' does not exist
Doxygen version used: 1.9.4
Searching for include files...
Searching for example files...
Searching for images...
Searching for dot files...
Searching for msc files...
Searching for dia files...
Searching for files to exclude
Searching INPUT for files to process...
error: source '/path/to/kokkos-kernels/dne/src' is not a readable file or directory... skipping.
 (warning treated as error, aborting now)
Exiting...
make[3]: *** [docs/doxygen/xml/index.xml] Error 1
make[2]: *** [docs/CMakeFiles/Doxygen.dir/all] Error 2
make[1]: *** [docs/CMakeFiles/Doxygen.dir/rule] Error 2
make: *** [Doxygen] Error 2
```

The RTD builds the docs post-merge and will update the README badge but we seem to need a pre-merge CI check to catch these regressions too.