### PR TITLE
scripts/cm_test_all_sandia: Add cuda11 tpl spot check

### DIFF
--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -704,7 +704,7 @@ elif [ "$MACHINE" = "weaver" ]; then
 # used with rhel8 queue
   RHEL8_BASE_MODULE_LIST="cmake/3.21.2,<COMPILER_NAME>/<COMPILER_VERSION>"
   # Cuda/11 modules available only on the dev queue (rhel8 OS); gcc/8.3.1 load by default
-  RHEL8_CUDA11_MODULE_LIST="cmake/3.21.2,<COMPILER_NAME>/<COMPILER_VERSION>,openblas/0.3.18/gcc/8.3.1"
+  RHEL8_CUDA11_MODULE_LIST="cmake/3.21.2,<COMPILER_NAME>/<COMPILER_VERSION>,openblas/0.3.20/gcc/9.3.0"
 
   # Don't do Threads on weaver
   GCC_IBM_BUILD_LIST="OpenMP,Serial,OpenMP_Serial"
@@ -722,6 +722,7 @@ elif [ "$MACHINE" = "weaver" ]; then
                "gcc/7.4.0 $GCC74_MODULE_TPL_LIST "OpenMP" g++ $GCC_WARNING_FLAGS"
                "cuda/9.2.88 $CUDA_MODULE_TPL_LIST "Cuda_OpenMP" ${KOKKOS_PATH}/bin/nvcc_wrapper $CUDA_WARNING_FLAGS"
                "cuda/10.1.243 $CUDA10_MODULE_TPL_LIST "Cuda_Serial" ${KOKKOS_PATH}/bin/nvcc_wrapper $CUDA_WARNING_FLAGS"
+               "cuda/11.2.2 $RHEL8_CUDA11_MODULE_LIST "Cuda_Serial" ${KOKKOS_PATH}/bin/nvcc_wrapper $CUDA_WARNING_FLAGS"
                "gcc/9.3.0 $GCC93_MODULE_TPL_LIST "OpenMP,Serial" g++ $GCC_WARNING_FLAGS"
                "clang/13.0.0 $CLANG13_MODULE_TPL_LIST "Cuda" clang++ $CUDA_WARNING_FLAGS"
     )


### PR DESCRIPTION
No further errors reported beyond what's reported in #1564.

```bash
$ ../scripts/cm_test_all_sandia --spot-check-tpls cuda/11.2.2 --kokkos-path=../../kokkos --kokkoskernels-path=../ --arch=Volta70 --cxxstandard=17
<snip>
$ cd TestAll_2022-10-25_14.24.42/cuda/11.2.2/Cuda_Serial-release/
$ source ./reload_modules.sh
$ make -i -k -j48 2>&1 | grep 'error:' | sort | uniq
1 error detected in the compilation of "/path/to/KOKKOS.base/kokkos-kernels/testing/TestAll_2022-10-25_14.24.42/cuda/11.2.2/Cuda_Serial-release/sparse/eti/generated_specializations_cpp/spadd_numeric/Sparse_spadd_numeric_eti_COMPLEX_DOUBLE_ORDINAL_INT_OFFSET_SIZE_T_LAYOUTLEFT_EXECSPACE_CUDA_MEMSPACE_CUDASPACE.cpp"./path/to/KOKKOS.base/kokkos-kernels/sparse/src/KokkosSparse_spgemm_handle.hpp(238): error: identifier "cusparse_spgemm_handle_t" is undefined
/path/to/KOKKOS.base/kokkos-kernels/sparse/src/KokkosSparse_spgemm_handle.hpp(238): error: identifier "cusparse_spgemm_handle_t" is undefined
```

Link errors may show up when #1564 is worked.