### PR TITLE
cm_generate_makefile: add rocblas, rocsparse tpl options

### DIFF
--- a/cm_generate_makefile.bash
+++ b/cm_generate_makefile.bash
@@ -178,6 +178,8 @@ get_kernels_tpls_list() {
   KOKKOSKERNELS_USER_TPL_LIBNAME_CMD=
   CUBLAS_DEFAULT=OFF
   CUSPARSE_DEFAULT=OFF
+  ROCBLAS_DEFAULT=OFF
+  ROCSPARSE_DEFAULT=OFF
   PARSE_TPLS_LIST=$(echo $KOKKOSKERNELS_TPLS | tr "," "\n")
   for TPLS_ in $PARSE_TPLS_LIST
   do
@@ -188,6 +190,12 @@ get_kernels_tpls_list() {
     fi
     if [ "$UC_TPLS" == "CUSPARSE" ]; then
       CUSPARSE_DEFAULT=ON
+    fi
+    if [ "$UC_TPLS" == "ROCBLAS" ]; then
+      ROCBLAS_DEFAULT=ON
+    fi
+    if [ "$UC_TPLS" == "ROCSPARSE" ]; then
+      ROCSPARSE_DEFAULT=ON
     fi
     if [ "$UC_TPLS" == "BLAS" ]; then
       if [ "$BLAS_PATH" != "" ]; then
@@ -215,6 +223,12 @@ get_kernels_tpls_list() {
   fi
   if [ "$CUSPARSE_DEFAULT" == "OFF" ]; then
     KOKKOSKERNELS_TPLS_CMD="-DKokkosKernels_ENABLE_TPL_CUSPARSE=OFF ${KOKKOSKERNELS_TPLS_CMD}"
+  fi
+  if [ "$ROCBLAS_DEFAULT" == "OFF" ]; then
+    KOKKOSKERNELS_TPLS_CMD="-DKokkosKernels_ENABLE_TPL_ROCBLAS=OFF ${KOKKOSKERNELS_TPLS_CMD}"
+  fi
+  if [ "$ROCSPARSE_DEFAULT" == "OFF" ]; then
+    KOKKOSKERNELS_TPLS_CMD="-DKokkosKernels_ENABLE_TPL_ROCSPARSE=OFF ${KOKKOSKERNELS_TPLS_CMD}"
   fi
 }
 
@@ -331,7 +345,7 @@ display_help_text() {
       echo "--with-tpls=[TPLS]:           Set tpls to be instantiated (Proper support requies that appropriate compiler and device must be enabled)."
       echo "                              This may require providing paths and the library name if using custom installs not on a default path"
       echo "                              that CMake searches"
-      echo "                                Options: blas, mkl, cublas, cusparse, magma, armpl"
+      echo "                                Options: blas, mkl, cublas, cusparse, magma, armpl, rocblas, rocsparse"
       echo "--user-blas-path=[PATH]:      Set path to location of user-specified BLAS library."
       echo "--user-blas-lib=[LIB]:        Library name of desired BLAS install."
       echo "                                Example: For the typical \"libblas.a\" provide \"blas\""


### PR DESCRIPTION
Tested on Caraway with rocm/5.2.0, 100% tests pass
Will add nightly tests with rocblas and rocsparse tpls enabled after this PR merges