### PR TITLE
First phase of SpGEMM TPL refactor

### DIFF
--- a/sparse/src/KokkosSparse_CrsMatrix.hpp
+++ b/sparse/src/KokkosSparse_CrsMatrix.hpp
@@ -486,8 +486,7 @@ class CrsMatrix {
       : graph(B.graph.entries, B.graph.row_map),
         values(B.values),
         numCols_(B.numCols()),
-        dev_config(B.dev_config)
-  {
+        dev_config(B.dev_config) {
     graph.row_block_offsets = B.graph.row_block_offsets;
     // TODO: MD 07/2017: Changed the copy constructor of graph
     // as the constructor of StaticCrsGraph does not allow copy from non const

--- a/sparse/src/KokkosSparse_CrsMatrix.hpp
+++ b/sparse/src/KokkosSparse_CrsMatrix.hpp
@@ -438,11 +438,6 @@ class CrsMatrix {
                     size_type>
       const_type;
 
-#ifdef KOKKOS_USE_CUSPARSE
-  cusparseHandle_t cusparse_handle;
-  cusparseMatDescr_t cusparse_descr;
-#endif  // KOKKOS_USE_CUSPARSE
-
   /// \name Storage of the actual sparsity structure and values.
   ///
   /// CrsMatrix uses the compressed sparse row (CSR) storage format to
@@ -492,11 +487,6 @@ class CrsMatrix {
         values(B.values),
         numCols_(B.numCols()),
         dev_config(B.dev_config)
-#ifdef KOKKOS_USE_CUSPARSE
-        ,
-        cusparse_handle(B.cusparse_handle),
-        cusparse_descr(B.cusparse_descr)
-#endif  // KOKKOS_USE_CUSPARSE
   {
     graph.row_block_offsets = B.graph.row_block_offsets;
     // TODO: MD 07/2017: Changed the copy constructor of graph
@@ -523,11 +513,6 @@ class CrsMatrix {
 
     numCols_ = mat_.numCols();
     graph    = StaticCrsGraphType(cols, rowmap);
-
-#ifdef KOKKOS_USE_CUSPARSE
-    cusparseCreate(&cusparse_handle);
-    cusparseCreateMatDescr(&cusparse_descr);
-#endif  // KOKKOS_USE_CUSPARSE
   }
 
   /// \brief Construct with a graph that will be shared.
@@ -560,12 +545,7 @@ class CrsMatrix {
             const OrdinalType& ncols)
       : graph(graph_.entries, graph_.row_map),
         values(label, graph_.entries.extent(0)),
-        numCols_(ncols) {
-#ifdef KOKKOS_USE_CUSPARSE
-    cusparseCreate(&cusparse_handle);
-    cusparseCreateMatDescr(&cusparse_descr);
-#endif  // KOKKOS_USE_CUSPARSE
-  }
+        numCols_(ncols) {}
 
   /// \brief Constructor that accepts a a static graph, and values.
   ///
@@ -586,12 +566,7 @@ class CrsMatrix {
             const values_type& vals,
             const Kokkos::StaticCrsGraph<InOrdinal, InLayout, InDevice,
                                          InMemTraits, InSizeType>& graph_)
-      : graph(graph_.entries, graph_.row_map), values(vals), numCols_(ncols) {
-#ifdef KOKKOS_USE_CUSPARSE
-    cusparseCreate(&cusparse_handle);
-    cusparseCreateMatDescr(&cusparse_descr);
-#endif  // KOKKOS_USE_CUSPARSE
-  }
+      : graph(graph_.entries, graph_.row_map), values(vals), numCols_(ncols) {}
 
   /// \brief Constructor that copies raw arrays of host data in
   ///   3-array CRS (compresed row storage) format.
@@ -654,20 +629,6 @@ class CrsMatrix {
         Kokkos::view_alloc(Kokkos::WithoutInitializing, "values"), annz);
     UnmanagedValues valuesRaw(val, annz);
     Kokkos::deep_copy(this->values, valuesRaw);
-
-    // FIXME (mfh 09 Aug 2013) Specialize this on the Device type.
-    // Only use cuSPARSE for the Cuda Device.
-#ifdef KOKKOS_USE_CUSPARSE
-    // FIXME (mfh 09 Aug 2013) This is actually static initialization
-    // of the library; you should do it once for the whole program,
-    // not once per matrix.  We need to protect this somehow.
-    cusparseCreate(&cusparse_handle);
-
-    // This is a per-matrix attribute.  It encapsulates things like
-    // whether the matrix is lower or upper triangular, etc.  Ditto
-    // for other TPLs like MKL.
-    cusparseCreateMatDescr(&cusparse_descr);
-#endif  // KOKKOS_USE_CUSPARSE
   }
 
   /// \brief Constructor that accepts a row map, column indices, and
@@ -708,11 +669,6 @@ class CrsMatrix {
          << ".";
       throw std::invalid_argument(os.str());
     }
-
-#ifdef KOKKOS_USE_CUSPARSE
-    cusparseCreate(&cusparse_handle);
-    cusparseCreateMatDescr(&cusparse_descr);
-#endif  // KOKKOS_USE_CUSPARSE
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/sparse/src/KokkosSparse_spgemm_handle.hpp
+++ b/sparse/src/KokkosSparse_spgemm_handle.hpp
@@ -189,7 +189,7 @@ class SPGEMMHandle {
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
-#if (CUDA_VERSION >= 11040)
+#if (CUDA_VERSION >= 11000)
   struct cuSparseSpgemmHandleType {
     KokkosKernels::Experimental::Controls kkControls;
     cusparseHandle_t cusparseHandle;
@@ -672,15 +672,19 @@ class SPGEMMHandle {
 
 #if defined(KOKKOS_ENABLE_CUDA)
     if (std::is_same<Kokkos::Cuda, ExecutionSpace>::value) {
-#if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) && \
-    (CUDA_VERSION >= 11040 || CUSPARSE_VERSION < 11000)
+#if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE)
       this->algorithm_type = SPGEMM_CUSPARSE;
-#else
-      this->algorithm_type = SPGEMM_KK;
-#endif
 #ifdef VERBOSE
       std::cout << "Cuda Execution Space, Default Algorithm: SPGEMM_CUSPARSE"
                 << std::endl;
+#endif
+#else
+      this->algorithm_type = SPGEMM_KK;
+#ifdef VERBOSE
+      std::cout << "Cuda Execution Space, without cuSPARSE, Default Algorithm: "
+                   "SPGEMM_KK"
+                << std::endl;
+#endif
 #endif
     }
 #endif


### PR DESCRIPTION
- Add support for SpGEMM in cuSPARSE versions 11.0-11.3. With this, all versions 10.x and 11.x are supported.
- Cleanup: remove cuSPARSE handle and matrix descriptor from CrsMatrix, since these were not used by any TPL wrappers. The cuSPARSE general handle definitely doesn't belong in the matrix, since the singleton handle (lazily created by Controls) can be used for all cuSPARSE calls. The matrix descriptor also doesn't need to be in the matrix, since it takes about 1us to create in both cuSPARSE and rocSPARSE, so caching it doesn't really provide noticeable savings even for fast-running kernels like SpMV.

Note: we can always add the matrix descriptor back into CrsMatrix, but we would need to fix several things:
- Need to have not only the ``cusparseMatDescr_t``, but also the ``cusparseSpMatDescr_t`` if on CUDA 11.x. The former just contains things like general vs. symmetric, unit diagonal vs not, etc, but the latter actually has pointers and extents of rowptrs, entries and values.
- Instead of shallow copying the descriptor in the CrsMatrix copy constructors, we need to recreate it for each matrix. Otherwise ownership is ambiguous.
- The descriptor should also be destroyed it in the CrsMatrix destructor. In the existing code it was leaked (not sure if it actually allocates any resources, but if ``cusparseDestroyMatDescr`` exists we should use it).
- Need to make rowptrs/entries/values views const somehow, so that the user can't just replace a view (leaving a stale descriptor). Or provide setters that refresh the descriptor.

Because of this I would prefer to just not cache these things.