### PR TITLE
Move destroying dense vector descriptors out of cuSparse sptrsv handle

### DIFF
--- a/sparse/impl/KokkosSparse_sptrsv_cuSPARSE_impl.hpp
+++ b/sparse/impl/KokkosSparse_sptrsv_cuSPARSE_impl.hpp
@@ -167,6 +167,10 @@ void sptrsvcuSPARSE_symbolic(KernelHandle* sptrsv_handle,
         h->handle, h->transpose, &alpha, h->matDescr, h->vecBDescr_dummy,
         h->vecXDescr_dummy, cudaValueType, CUSPARSE_SPSV_ALG_DEFAULT,
         h->spsvDescr, h->pBuffer));
+
+    //Destroy dummy dense vector descriptors
+    KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(h->vecBDescr_dummy));
+    KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(h->vecXDescr_dummy));
   }
 #else  // CUDA_VERSION < 11030
   typedef typename KernelHandle::nnz_lno_t idx_type;
@@ -361,6 +365,10 @@ void sptrsvcuSPARSE_solve(KernelHandle* sptrsv_handle,
     KOKKOS_CUSPARSE_SAFE_CALL(cusparseSpSV_solve(
         h->handle, h->transpose, &alpha, h->matDescr, h->vecBDescr,
         h->vecXDescr, cudaValueType, CUSPARSE_SPSV_ALG_DEFAULT, h->spsvDescr));
+
+    //Destroy dense vector descriptors
+    KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(h->vecBDescr));
+    KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(h->vecXDescr));
   }
 #else  // CUDA_VERSION < 11030
   typedef typename KernelHandle::nnz_lno_t idx_type;

--- a/sparse/impl/KokkosSparse_sptrsv_cuSPARSE_impl.hpp
+++ b/sparse/impl/KokkosSparse_sptrsv_cuSPARSE_impl.hpp
@@ -168,7 +168,7 @@ void sptrsvcuSPARSE_symbolic(KernelHandle* sptrsv_handle,
         h->vecXDescr_dummy, cudaValueType, CUSPARSE_SPSV_ALG_DEFAULT,
         h->spsvDescr, h->pBuffer));
 
-    //Destroy dummy dense vector descriptors
+    // Destroy dummy dense vector descriptors
     KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(h->vecBDescr_dummy));
     KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(h->vecXDescr_dummy));
   }
@@ -366,7 +366,7 @@ void sptrsvcuSPARSE_solve(KernelHandle* sptrsv_handle,
         h->handle, h->transpose, &alpha, h->matDescr, h->vecBDescr,
         h->vecXDescr, cudaValueType, CUSPARSE_SPSV_ALG_DEFAULT, h->spsvDescr));
 
-    //Destroy dense vector descriptors
+    // Destroy dense vector descriptors
     KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(h->vecBDescr));
     KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(h->vecXDescr));
   }

--- a/sparse/src/KokkosSparse_sptrsv_handle.hpp
+++ b/sparse/src/KokkosSparse_sptrsv_handle.hpp
@@ -187,10 +187,6 @@ class SPTRSVHandle {
         pBuffer = nullptr;
       }
       KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroySpMat(matDescr));
-      KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(vecBDescr));
-      KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(vecBDescr_dummy));
-      KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(vecXDescr));
-      KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(vecXDescr_dummy));
       KOKKOS_CUSPARSE_SAFE_CALL(cusparseSpSV_destroyDescr(spsvDescr));
       KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroy(handle));
     }


### PR DESCRIPTION
Just a simple fix for seg faults encountered when destroying cuSparse SPTRSV handle without ```sptrsvcuSPARSE_symbolic``` or ```sptrsvcuSPARSE_solve```. Solution: moving these ```cusparseDestroyDnVec``` calls  out of cuSparse SPTRSV handle to the symbolic and solve phases.