### PR TITLE
Fix cuda_data_type_from to return CUDA_C_64F for Kokkos::complex<double>

### DIFF
--- a/sparse/src/KokkosSparse_Utils_cusparse.hpp
+++ b/sparse/src/KokkosSparse_Utils_cusparse.hpp
@@ -153,7 +153,7 @@ inline cudaDataType cuda_data_type_from<Kokkos::complex<float>>() {
 }
 template <>
 inline cudaDataType cuda_data_type_from<Kokkos::complex<double>>() {
-  return CUDA_C_32F;
+  return CUDA_C_64F;
 }
 
 #if defined(CUSPARSE_VERSION) && (10300 <= CUSPARSE_VERSION)


### PR DESCRIPTION
Just a minor change to fix the typo in ```cuda_data_type_from``` to return ```CUDA_C_64F``` for ```Kokkos::complex<double>```