### PR TITLE
Disable compile-time check in cuda_data_type_from on supported scalar types for cuSPARSE

### DIFF
--- a/sparse/src/KokkosSparse_Utils_cusparse.hpp
+++ b/sparse/src/KokkosSparse_Utils_cusparse.hpp
@@ -118,9 +118,12 @@ inline void cusparse_internal_safe_call(cusparseStatus_t cusparseStatus,
 
 template <typename T>
 cudaDataType cuda_data_type_from() {
+  // Note:  compile-time failure is disabled to allow for packages such as
+  // Ifpack2 to more easily support scalar types that cuSPARSE may not.
+
   // compile-time failure with a nice message if called on an unsupported type
-  static_assert(!std::is_same<T, T>::value,
-                "cuSparse TPL does not support scalar type");
+  // static_assert(!std::is_same<T, T>::value,
+  //               "cuSparse TPL does not support scalar type");
   // static_assert(false, ...) is allowed to error even if the code is not
   // instantiated. obfuscate the predicate Despite this function being
   // uncompilable, the compiler may decide that a return statement is missing,


### PR DESCRIPTION
This PR matches changes in https://github.com/trilinos/Trilinos/pull/11308 (by @etphipp) for issue https://github.com/trilinos/Trilinos/issues/11297