### PR TITLE
Mdf alg upgrade

### DIFF
--- a/perf_test/sparse/CMakeLists.txt
+++ b/perf_test/sparse/CMakeLists.txt
@@ -110,3 +110,8 @@ KOKKOSKERNELS_ADD_EXECUTABLE(
         sparse_spiluk
         SOURCES KokkosSparse_spiluk.cpp
 )
+
+KOKKOSKERNELS_ADD_EXECUTABLE(
+        sparse_mdf
+        SOURCES KokkosSparse_mdf.cpp
+)

--- a/perf_test/sparse/KokkosSparse_mdf.cpp
+++ b/perf_test/sparse/KokkosSparse_mdf.cpp
@@ -1,0 +1,320 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <iostream>
+#include "KokkosKernels_config.h"
+#include "KokkosKernels_Handle.hpp"
+#include "KokkosSparse_IOUtils.hpp"
+#include "KokkosSparse_Utils_cusparse.hpp"
+#include "KokkosSparse_mdf.hpp"
+#include "KokkosKernels_TestUtils.hpp"
+
+struct Params {
+  int use_cuda    = 0;
+  int use_hip     = 0;
+  int use_sycl    = 0;
+  int use_openmp  = 0;
+  int use_threads = 0;
+  std::string amtx;
+  int m         = 10000;
+  int n         = 10000;
+  int nnzPerRow = 30;
+  bool diag = false;  // Whether B should be diagonal only (requires A square)
+  bool verbose = false;
+  int repeat   = 1;
+};
+
+template <class row_map_t, class entries_t>
+struct diag_generator_functor {
+  using size_type = typename row_map_t::non_const_value_type;
+
+  row_map_t row_map;
+  entries_t entries;
+
+  diag_generator_functor(row_map_t row_map_, entries_t entries_)
+      : row_map(row_map_), entries(entries_){};
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const size_type rowIdx) const {
+    row_map(rowIdx + 1) = rowIdx + 1;
+    entries(rowIdx)     = rowIdx;
+  }
+};
+
+template <typename crsMat_t>
+void run_experiment(const Params& params) {
+  using size_type  = typename crsMat_t::size_type;
+  using lno_t      = typename crsMat_t::ordinal_type;
+  using scalar_t   = typename crsMat_t::value_type;
+  using device_t   = typename crsMat_t::device_type;
+  using exec_space = typename device_t::execution_space;
+
+  using graph_t   = typename crsMat_t::StaticCrsGraphType;
+  using rowmap_t  = typename graph_t::row_map_type::non_const_type;
+  using entries_t = typename graph_t::entries_type::non_const_type;
+  using values_t  = typename crsMat_t::values_type::non_const_type;
+
+  std::cout << "************************************* \n";
+  std::cout << "************************************* \n";
+  crsMat_t A;
+  lno_t m = params.m;
+  lno_t n = params.n;
+  if (params.amtx.length()) {
+    std::cout << "Loading A from " << params.amtx << '\n';
+    A = KokkosSparse::Impl::read_kokkos_crst_matrix<crsMat_t>(
+        params.amtx.c_str());
+    m = A.numRows();
+    n = A.numCols();
+  } else {
+    if (params.diag) {
+      std::cout << "Randomly generating diag matrix\n";
+      rowmap_t rowmapA("A row map", m + 1);
+      entries_t entriesA("A entries", m);
+      values_t valuesA("A values", m);
+
+      // Generate the graph of A
+      diag_generator_functor diag_generator(rowmapA, entriesA);
+      Kokkos::parallel_for(Kokkos::RangePolicy<size_type, exec_space>(0, m),
+                           diag_generator);
+
+      // Generate the values of A
+      Kokkos::Random_XorShift64_Pool<exec_space> rand_pool(13718);
+      Kokkos::fill_random(valuesA, rand_pool,
+                          10 * Kokkos::ArithTraits<scalar_t>::one());
+
+      // Actually put A together
+      graph_t graph(entriesA, rowmapA);
+      A = crsMat_t("A matrix", m, valuesA, graph);
+    } else {
+      std::cout << "Randomly generating matrix\n";
+      size_type nnzUnused = m * params.nnzPerRow;
+      A = KokkosSparse::Impl::kk_generate_sparse_matrix<crsMat_t>(
+          m, n, nnzUnused, 0, (n + 3) / 3);
+    }
+  }
+
+  if (params.verbose) {
+    std::cout << "Matrix A" << std::endl;
+    std::cout << "  row_map A:" << std::endl;
+    KokkosKernels::Impl::print_1Dview(A.graph.row_map);
+    std::cout << "  entries A:" << std::endl;
+    KokkosKernels::Impl::print_1Dview(A.graph.entries);
+    std::cout << "  values A:" << std::endl;
+    KokkosKernels::Impl::print_1Dview(A.values);
+    std::cout << std::endl;
+  }
+
+  Kokkos::Timer timer;
+  double handleTime   = 0;
+  double symbolicTime = 0;
+  double numericTime  = 0;
+
+  timer.reset();
+  KokkosSparse::Experimental::MDF_handle<crsMat_t> handle(A);
+  handle.set_verbosity(0);
+  handleTime += timer.seconds();
+
+  for (int sumRep = 0; sumRep < params.repeat; sumRep++) {
+    timer.reset();
+    KokkosSparse::Experimental::mdf_symbolic(A, handle);
+    Kokkos::fence();
+    symbolicTime += timer.seconds();
+
+    timer.reset();
+    KokkosSparse::Experimental::mdf_numeric(A, handle);
+    Kokkos::fence();
+    numericTime += timer.seconds();
+  }
+
+  std::cout << "Mean total time:    "
+            << handleTime + (symbolicTime / params.repeat) +
+                   (numericTime / params.repeat)
+            << std::endl
+            << "Handle time: " << handleTime << std::endl
+            << "Mean symbolic time: " << (symbolicTime / params.repeat)
+            << std::endl
+            << "Mean numeric time:  " << (numericTime / params.repeat)
+            << std::endl;
+
+  if (params.verbose) {
+    entries_t permutation = handle.get_permutation();
+
+    std::cout << "MDF permutation:" << std::endl;
+    KokkosKernels::Impl::print_1Dview(permutation);
+  }
+}  // run_experiment
+
+void print_options() {
+  std::cerr << "Options\n" << std::endl;
+
+  std::cerr
+      << "\t[Required] BACKEND: '--threads[numThreads]' | '--openmp "
+         "[numThreads]' | '--cuda [cudaDeviceIndex]' | '--hip [hipDeviceIndex]'"
+         " | '--sycl [syclDeviceIndex]'"
+      << std::endl;
+
+  std::cerr << "\t[Optional] --amtx <path> :: input matrix" << std::endl;
+  std::cerr << "\t[Optional] --repeat      :: how many times to repeat overall "
+               "MDF"
+            << std::endl;
+  std::cerr << "\t[Optional] --verbose     :: enable verbose output"
+            << std::endl;
+  std::cerr << "\nSettings for randomly generated A matrix" << std::endl;
+  std::cerr << "\t[Optional] --m           :: number of rows to generate"
+            << std::endl;
+  std::cerr << "\t[Optional] --n           :: number of cols to generate"
+            << std::endl;
+  std::cerr
+      << "\t[Optional] --nnz         :: number of entries per row to generate"
+      << std::endl;
+  std::cerr << "\t[Optional] --diag        :: generate a diagonal matrix"
+            << std::endl;
+}  // print_options
+
+int parse_inputs(Params& params, int argc, char** argv) {
+  for (int i = 1; i < argc; ++i) {
+    if (0 == Test::string_compare_no_case(argv[i], "--threads")) {
+      params.use_threads = atoi(argv[++i]);
+    } else if (0 == Test::string_compare_no_case(argv[i], "--openmp")) {
+      params.use_openmp = atoi(argv[++i]);
+    } else if (0 == Test::string_compare_no_case(argv[i], "--cuda")) {
+      params.use_cuda = atoi(argv[++i]) + 1;
+    } else if (0 == Test::string_compare_no_case(argv[i], "--hip")) {
+      params.use_hip = atoi(argv[++i]) + 1;
+    } else if (0 == Test::string_compare_no_case(argv[i], "--sycl")) {
+      params.use_sycl = atoi(argv[++i]) + 1;
+    } else if (0 == Test::string_compare_no_case(argv[i], "--amtx")) {
+      params.amtx = argv[++i];
+    } else if (0 == Test::string_compare_no_case(argv[i], "--m")) {
+      params.m = atoi(argv[++i]);
+    } else if (0 == Test::string_compare_no_case(argv[i], "--n")) {
+      params.n = atoi(argv[++i]);
+    } else if (0 == Test::string_compare_no_case(argv[i], "--nnz")) {
+      params.nnzPerRow = atoi(argv[++i]);
+    } else if (0 == Test::string_compare_no_case(argv[i], "--diag")) {
+      params.diag = true;
+    } else if (0 == Test::string_compare_no_case(argv[i], "--repeat")) {
+      params.repeat = atoi(argv[++i]);
+    } else if (0 == Test::string_compare_no_case(argv[i], "--verbose")) {
+      params.verbose = true;
+    } else {
+      std::cerr << "Unrecognized command line argument #" << i << ": "
+                << argv[i] << std::endl;
+      print_options();
+      return 1;
+    }
+  }
+  return 0;
+}  // parse_inputs
+
+int main(int argc, char** argv) {
+  Params params;
+
+  if (parse_inputs(params, argc, argv)) {
+    return 1;
+  }
+  const int num_threads =
+      std::max(params.use_openmp,
+               params.use_threads);  // Assumption is that use_openmp variable
+                                     // is provided as number of threads
+
+  // If cuda, hip or sycl is used, set device_id
+  int device_id = 0;
+  if (params.use_cuda > 0) {
+    device_id = params.use_cuda - 1;
+  }
+  if (params.use_hip > 0) {
+    device_id = params.use_hip - 1;
+  }
+  if (params.use_sycl > 0) {
+    device_id = params.use_sycl - 1;
+  }
+
+  Kokkos::initialize(Kokkos::InitializationSettings()
+                         .set_num_threads(num_threads)
+                         .set_device_id(device_id));
+
+  bool useOMP     = params.use_openmp != 0;
+  bool useThreads = params.use_threads != 0;
+  bool useCUDA    = params.use_cuda != 0;
+  bool useHIP     = params.use_hip != 0;
+  bool useSYCL    = params.use_sycl != 0;
+  bool useSerial  = !useOMP && !useCUDA && !useHIP && !useSYCL;
+
+  if (useOMP) {
+#if defined(KOKKOS_ENABLE_OPENMP)
+    using crsMat_t =
+        KokkosSparse::CrsMatrix<double, int, Kokkos::OpenMP, void, int>;
+    run_experiment<crsMat_t>(params);
+#else
+    std::cout << "ERROR: OpenMP requested, but not available.\n";
+    return 1;
+#endif
+  }
+  if (useThreads) {
+#if defined(KOKKOS_ENABLE_THREADS)
+    using crsMat_t =
+        KokkosSparse::CrsMatrix<double, int, Kokkos::Threads, void, int>;
+    run_experiment<crsMat_t>(params);
+#else
+    std::cout << "ERROR: OpenMP requested, but not available.\n";
+    return 1;
+#endif
+  }
+  if (useCUDA) {
+#if defined(KOKKOS_ENABLE_CUDA)
+    using crsMat_t =
+        KokkosSparse::CrsMatrix<double, int, Kokkos::Cuda, void, int>;
+    run_experiment<crsMat_t>(params);
+#else
+    std::cout << "ERROR: CUDA requested, but not available.\n";
+    return 1;
+#endif
+  }
+  if (useHIP) {
+#if defined(KOKKOS_ENABLE_HIP)
+    using crsMat_t =
+        KokkosSparse::CrsMatrix<double, int, Kokkos::HIP, void, int>;
+    run_experiment<crsMat_t>(params);
+#else
+    std::cout << "ERROR: HIP requested, but not available.\n";
+    return 1;
+#endif
+  }
+  if (useSYCL) {
+#if defined(KOKKOS_ENABLE_SYCL)
+    using crsMat_t =
+        KokkosSparse::CrsMatrix<double, int, Kokkos::Experimental::SYCL, void,
+                                int>;
+    run_experiment<crsMat_t>(params);
+#else
+    std::cout << "ERROR: SYCL requested, but not available.\n";
+    return 1;
+#endif
+  }
+  if (useSerial) {
+#if defined(KOKKOS_ENABLE_SERIAL)
+    using crsMat_t =
+        KokkosSparse::CrsMatrix<double, int, Kokkos::Serial, void, int>;
+    run_experiment<crsMat_t>(params);
+#else
+    std::cout << "ERROR: Serial device requested, but not available.\n";
+    return 1;
+#endif
+  }
+  Kokkos::finalize();
+  return 0;
+}  // main

--- a/sparse/impl/KokkosSparse_mdf_impl.hpp
+++ b/sparse/impl/KokkosSparse_mdf_impl.hpp
@@ -155,11 +155,132 @@ struct MDF_discarded_fill_norm {
                                                A.graph.row_map(rowIdx) - 1);
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "Row %d has discarded fill of %f, deficiency of %d and degree %d\n",
-          rowIdx, KAS::sqrt(discard_norm), deficiency(rowIdx), degree);
+          static_cast<int>(rowIdx),
+          static_cast<double>(KAS::sqrt(discard_norm)),
+          static_cast<int>(deficiency(rowIdx)), static_cast<int>(degree));
     }
   }
 
 };  // MDF_discarded_fill_norm
+
+template <class crs_matrix_type>
+struct MDF_selective_discarded_fill_norm {
+  using static_crs_graph_type = typename crs_matrix_type::StaticCrsGraphType;
+  using col_ind_type =
+      typename static_crs_graph_type::entries_type::non_const_type;
+  using values_type  = typename crs_matrix_type::values_type::non_const_type;
+  using size_type    = typename crs_matrix_type::size_type;
+  using ordinal_type = typename crs_matrix_type::ordinal_type;
+  using scalar_type  = typename crs_matrix_type::value_type;
+  using KAS          = typename Kokkos::ArithTraits<scalar_type>;
+
+  const scalar_type zero = KAS::zero();
+
+  crs_matrix_type A, At;
+  ordinal_type factorization_step;
+  col_ind_type permutation;
+  col_ind_type update_list;
+
+  values_type discarded_fill;
+  col_ind_type deficiency;
+  int verbosity;
+
+  MDF_selective_discarded_fill_norm(crs_matrix_type A_, crs_matrix_type At_,
+                                    ordinal_type factorization_step_,
+                                    col_ind_type permutation_,
+                                    col_ind_type update_list_,
+                                    values_type discarded_fill_,
+                                    col_ind_type deficiency_, int verbosity_)
+      : A(A_),
+        At(At_),
+        factorization_step(factorization_step_),
+        permutation(permutation_),
+        update_list(update_list_),
+        discarded_fill(discarded_fill_),
+        deficiency(deficiency_),
+        verbosity(verbosity_){};
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const ordinal_type i) const {
+    ordinal_type rowIdx      = permutation(update_list(i));
+    scalar_type discard_norm = zero, diag_val = zero;
+    bool entryIsDiscarded       = true;
+    ordinal_type numFillEntries = 0;
+    for (size_type alphaIdx = At.graph.row_map(rowIdx);
+         alphaIdx < At.graph.row_map(rowIdx + 1); ++alphaIdx) {
+      ordinal_type fillRowIdx = At.graph.entries(alphaIdx);
+      bool row_not_eliminated = true;
+      for (ordinal_type stepIdx = 0; stepIdx < factorization_step; ++stepIdx) {
+        if (fillRowIdx == permutation(stepIdx)) {
+          row_not_eliminated = false;
+        }
+      }
+
+      if (fillRowIdx != rowIdx && row_not_eliminated) {
+        for (size_type betaIdx = A.graph.row_map(rowIdx);
+             betaIdx < A.graph.row_map(rowIdx + 1); ++betaIdx) {
+          ordinal_type fillColIdx = A.graph.entries(betaIdx);
+          bool col_not_eliminated = true;
+          for (ordinal_type stepIdx = 0; stepIdx < factorization_step;
+               ++stepIdx) {
+            if (fillColIdx == permutation(stepIdx)) {
+              col_not_eliminated = false;
+            }
+          }
+
+          if (fillColIdx != rowIdx && col_not_eliminated) {
+            entryIsDiscarded = true;
+            for (size_type entryIdx = A.graph.row_map(fillRowIdx);
+                 entryIdx < A.graph.row_map(fillRowIdx + 1); ++entryIdx) {
+              if (A.graph.entries(entryIdx) == fillColIdx) {
+                entryIsDiscarded = false;
+              }
+            }
+            if (entryIsDiscarded) {
+              numFillEntries += 1;
+              discard_norm +=
+                  KAS::abs(At.values(alphaIdx) * A.values(betaIdx)) *
+                  KAS::abs(At.values(alphaIdx) * A.values(betaIdx));
+              if (verbosity > 1) {
+                KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+                    "Adding value A[%d,%d]=%f to discard norm of row %d\n",
+                    static_cast<int>(At.graph.entries(alphaIdx)),
+                    static_cast<int>(A.graph.entries(betaIdx)),
+                    static_cast<double>(
+                        KAS::abs(At.values(alphaIdx) * A.values(betaIdx)) *
+                        KAS::abs(At.values(alphaIdx) * A.values(betaIdx))),
+                    static_cast<int>(rowIdx));
+              }
+            }
+          }
+        }
+      } else if (fillRowIdx == rowIdx) {
+        diag_val = At.values(alphaIdx);
+        if (verbosity > 1) {
+          KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+              "Row %d diagonal value dected, values(%d)=%f\n",
+              static_cast<int>(rowIdx), static_cast<int>(alphaIdx),
+              static_cast<double>(At.values(alphaIdx)));
+        }
+      }
+    }
+
+    // TODO add a check on `diag_val == zero`
+    discard_norm           = discard_norm / (diag_val * diag_val);
+    discarded_fill(rowIdx) = discard_norm;
+    deficiency(rowIdx)     = numFillEntries;
+    if (verbosity > 0) {
+      const ordinal_type degree = ordinal_type(A.graph.row_map(rowIdx + 1) -
+                                               A.graph.row_map(rowIdx) - 1);
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "Row %d has discarded fill of %f, deficiency of %d and degree %d\n",
+          static_cast<int>(rowIdx),
+          static_cast<double>(KAS::sqrt(discard_norm)),
+          static_cast<int>(deficiency(rowIdx)), static_cast<int>(degree));
+    }
+  }
+
+};  // MDF_selective_discarded_fill_norm
 
 template <class crs_matrix_type>
 struct MDF_select_row {
@@ -294,6 +415,8 @@ struct MDF_factorize_row {
   values_type valuesU;
 
   col_ind_type permutation, permutation_inv;
+  values_type discarded_fill;
+  col_ind_type factored;
   ordinal_type selected_row_idx, factorization_step;
 
   int verbosity;
@@ -303,6 +426,7 @@ struct MDF_factorize_row {
                     values_type valuesL_, row_map_type row_mapU_,
                     col_ind_type entriesU_, values_type valuesU_,
                     col_ind_type permutation_, col_ind_type permutation_inv_,
+                    values_type discarded_fill_, col_ind_type factored_,
                     ordinal_type selected_row_idx_,
                     ordinal_type factorization_step_, int verbosity_)
       : A(A_),
@@ -315,6 +439,8 @@ struct MDF_factorize_row {
         valuesU(valuesU_),
         permutation(permutation_),
         permutation_inv(permutation_inv_),
+        discarded_fill(discarded_fill_),
+        factored(factored_),
         selected_row_idx(selected_row_idx_),
         factorization_step(factorization_step_),
         verbosity(verbosity_){};
@@ -322,6 +448,7 @@ struct MDF_factorize_row {
   KOKKOS_INLINE_FUNCTION
   void operator()(const ordinal_type /* idx */) const {
     const ordinal_type selected_row = permutation(selected_row_idx);
+    discarded_fill(selected_row)    = Kokkos::ArithTraits<value_type>::max();
 
     // Swap entries in permutation vectors
     permutation(selected_row_idx)   = permutation(factorization_step);
@@ -332,7 +459,8 @@ struct MDF_factorize_row {
     if (verbosity > 0) {
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("Permutation vector: { ");
       for (ordinal_type rowIdx = 0; rowIdx < A.numRows(); ++rowIdx) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("%d ", permutation(rowIdx));
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("%d ",
+                                      static_cast<int>(permutation(rowIdx)));
       }
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("}\n");
     }
@@ -356,23 +484,27 @@ struct MDF_factorize_row {
 
     if (verbosity > 0) {
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("Diagonal values of row %d is %f\n",
-                                    selected_row, diag);
+                                    static_cast<int>(selected_row),
+                                    static_cast<double>(diag));
     }
 
     if (verbosity > 2) {
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("U, row_map={ ");
       for (ordinal_type rowIdx = 0; rowIdx < factorization_step + 1; ++rowIdx) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("%d ", int(row_mapU(rowIdx)));
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("%d ",
+                                      static_cast<int>(row_mapU(rowIdx)));
       }
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("}, entries={ ");
       for (size_type entryIdx = row_mapU(0);
            entryIdx < row_mapU(factorization_step + 1); ++entryIdx) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("%d ", int(entriesU(entryIdx)));
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("%d ",
+                                      static_cast<int>(entriesU(entryIdx)));
       }
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("}, values={ ");
       for (size_type entryIdx = row_mapU(0);
            entryIdx < row_mapU(factorization_step + 1); ++entryIdx) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("%f ", valuesU(entryIdx));
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("%f ",
+                                      static_cast<double>(valuesU(entryIdx)));
       }
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("}\n");
     }
@@ -397,17 +529,21 @@ struct MDF_factorize_row {
     if (verbosity > 2) {
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "L(%d), [row_map(%d), row_map(%d)[ = [%d, %d[, entries={ ",
-          int(factorization_step), int(factorization_step),
-          int(factorization_step + 1), int(row_mapL(factorization_step)),
-          int(row_mapL(factorization_step + 1)));
+          static_cast<int>(factorization_step),
+          static_cast<int>(factorization_step),
+          static_cast<int>(factorization_step + 1),
+          static_cast<int>(row_mapL(factorization_step)),
+          static_cast<int>(row_mapL(factorization_step + 1)));
       for (size_type entryIdx = row_mapL(factorization_step);
            entryIdx < row_mapL(factorization_step + 1); ++entryIdx) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("%d ", int(entriesL(entryIdx)));
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("%d ",
+                                      static_cast<int>(entriesL(entryIdx)));
       }
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("}, values={ ");
       for (size_type entryIdx = row_mapL(factorization_step);
            entryIdx < row_mapL(factorization_step + 1); ++entryIdx) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("%f ", valuesL(entryIdx));
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("%f ",
+                                      static_cast<double>(valuesL(entryIdx)));
       }
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("}\n");
     }
@@ -466,8 +602,10 @@ struct MDF_factorize_row {
 
                 if (verbosity > 1) {
                   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-                      "A[%d, %d] -= %f\n", int(fillRowIdx), int(fillColIdx),
-                      At.values(alphaIdx) * A.values(betaIdx) / diag_val);
+                      "A[%d, %d] -= %f\n", static_cast<int>(fillRowIdx),
+                      static_cast<int>(fillColIdx),
+                      static_cast<double>(At.values(alphaIdx) *
+                                          A.values(betaIdx) / diag_val));
                 }
               }
             }
@@ -484,21 +622,89 @@ struct MDF_factorize_row {
       }
     }
 
+    factored(selected_row) = 1;
+
     if (verbosity > 0) {
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("New values in A: { ");
       for (size_type entryIdx = 0; entryIdx < A.nnz(); ++entryIdx) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("%f ", A.values(entryIdx));
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("%f ",
+                                      static_cast<double>(A.values(entryIdx)));
       }
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("}\n");
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("New values in At: { ");
       for (size_type entryIdx = 0; entryIdx < At.nnz(); ++entryIdx) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("%f ", At.values(entryIdx));
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("%f ",
+                                      static_cast<double>(At.values(entryIdx)));
       }
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("}\n");
     }
   }  // operator()
 
 };  // MDF_factorize_row
+
+template <class crs_matrix_type>
+struct MDF_compute_list_length {
+  using col_ind_type = typename crs_matrix_type::StaticCrsGraphType::
+      entries_type::non_const_type;
+  using ordinal_type = typename crs_matrix_type::ordinal_type;
+  using size_type    = typename crs_matrix_type::size_type;
+
+  ordinal_type selected_row_idx;
+  crs_matrix_type A;
+  crs_matrix_type At;
+  col_ind_type permutation;
+  col_ind_type factored;
+  col_ind_type update_list_length;
+  col_ind_type update_list;
+
+  MDF_compute_list_length(const ordinal_type rowIdx_, const crs_matrix_type& A_,
+                          const crs_matrix_type& At_,
+                          const col_ind_type& permutation_,
+                          const col_ind_type factored_,
+                          col_ind_type& update_list_length_,
+                          col_ind_type& update_list_)
+      : selected_row_idx(rowIdx_),
+        A(A_),
+        At(At_),
+        permutation(permutation_),
+        factored(factored_),
+        update_list_length(update_list_length_),
+        update_list(update_list_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const size_type /*idx*/) const {
+    const ordinal_type selected_row = permutation(selected_row_idx);
+
+    size_type updateIdx = 0;
+    for (size_type entryIdx = A.graph.row_map(selected_row);
+         entryIdx < A.graph.row_map(selected_row + 1); ++entryIdx) {
+      if ((A.graph.entries(entryIdx) != selected_row) &&
+          (factored(A.graph.entries(entryIdx)) != 1)) {
+        update_list(updateIdx) = A.graph.entries(entryIdx);
+        ++updateIdx;
+      }
+    }
+    size_type update_rows = updateIdx;
+    for (size_type entryIdx = At.graph.row_map(selected_row);
+         entryIdx < At.graph.row_map(selected_row + 1); ++entryIdx) {
+      if ((At.graph.entries(entryIdx) != selected_row) &&
+          (factored(A.graph.entries(entryIdx)) != 1)) {
+        bool already_updated = false;
+        for (size_type checkIdx = 0; checkIdx < update_rows; ++checkIdx) {
+          if (At.graph.entries(entryIdx) == update_list(checkIdx)) {
+            already_updated = true;
+            break;
+          }
+        }
+        if (already_updated == false) {
+          update_list(updateIdx) = At.graph.entries(entryIdx);
+          ++updateIdx;
+        }
+      }
+    }
+    update_list_length(0) = updateIdx;
+  }
+};
 
 template <class col_ind_type>
 struct MDF_reindex_matrix {

--- a/sparse/src/KokkosSparse_mdf.hpp
+++ b/sparse/src/KokkosSparse_mdf.hpp
@@ -34,7 +34,7 @@ namespace KokkosSparse {
 namespace Experimental {
 
 template <class crs_matrix_type, class MDF_handle>
-void mdf_symbolic_phase(crs_matrix_type& A, MDF_handle& handle) {
+void mdf_symbolic(crs_matrix_type& A, MDF_handle& handle) {
   using size_type    = typename crs_matrix_type::size_type;
   using ordinal_type = typename crs_matrix_type::ordinal_type;
 
@@ -60,10 +60,10 @@ void mdf_symbolic_phase(crs_matrix_type& A, MDF_handle& handle) {
   }
 
   return;
-}  // mdf_symbolic_phase
+}  // mdf_symbolic
 
 template <class crs_matrix_type, class MDF_handle>
-void mdf_numeric_phase(crs_matrix_type& A, MDF_handle& handle) {
+void mdf_numeric(crs_matrix_type& A, MDF_handle& handle) {
   using col_ind_type = typename crs_matrix_type::StaticCrsGraphType::
       entries_type::non_const_type;
   using values_type  = typename crs_matrix_type::values_type::non_const_type;
@@ -78,13 +78,26 @@ void mdf_numeric_phase(crs_matrix_type& A, MDF_handle& handle) {
   //   compute discarded fill of each row
   //   selected pivot based on MDF
   //   factorize pivot row of A
-  crs_matrix_type Atmp = crs_matrix_type("A fill", A);
+  const int verbosity_level = handle.verbosity;
+  crs_matrix_type Atmp      = crs_matrix_type("A fill", A);
   crs_matrix_type At = KokkosSparse::Impl::transpose_matrix<crs_matrix_type>(A);
   KokkosSparse::sort_crs_matrix<crs_matrix_type>(At);
   values_type discarded_fill("discarded fill", A.numRows());
   col_ind_type deficiency("deficiency", A.numRows());
+  col_ind_type update_list_length("update list length", 1);
+  typename col_ind_type::HostMirror update_list_length_host =
+      Kokkos::create_mirror_view(update_list_length);
+  col_ind_type update_list("update list", A.numRows());
+  col_ind_type factored("factored rows", A.numRows());
+  Kokkos::deep_copy(discarded_fill, Kokkos::ArithTraits<value_type>::max());
+  Kokkos::deep_copy(deficiency, Kokkos::ArithTraits<ordinal_type>::max());
 
-  const int verbosity_level = handle.verbosity;
+  KokkosSparse::Impl::MDF_discarded_fill_norm<crs_matrix_type> MDF_df_norm(
+      Atmp, At, 0, handle.permutation, discarded_fill, deficiency,
+      verbosity_level);
+  Kokkos::parallel_for("MDF: initial fill computation",
+                       range_policy_type(0, Atmp.numRows()), MDF_df_norm);
+
   for (ordinal_type factorization_step = 0; factorization_step < A.numRows();
        ++factorization_step) {
     if (verbosity_level > 0) {
@@ -92,44 +105,58 @@ void mdf_numeric_phase(crs_matrix_type& A, MDF_handle& handle) {
              static_cast<int>(factorization_step));
     }
 
-    range_policy_type stepPolicy(factorization_step, Atmp.numRows());
-    Kokkos::deep_copy(discarded_fill, Kokkos::ArithTraits<value_type>::max());
-    Kokkos::deep_copy(deficiency, Kokkos::ArithTraits<ordinal_type>::max());
-    KokkosSparse::Impl::MDF_discarded_fill_norm<crs_matrix_type> MDF_df_norm(
-        Atmp, At, factorization_step, handle.permutation, discarded_fill,
-        deficiency, verbosity_level);
-    Kokkos::parallel_for(stepPolicy, MDF_df_norm);
+    Kokkos::deep_copy(update_list_length_host, update_list_length);
+    range_policy_type updatePolicy(0, update_list_length_host(0));
+    KokkosSparse::Impl::MDF_selective_discarded_fill_norm<crs_matrix_type>
+        MDF_update_df_norm(Atmp, At, factorization_step, handle.permutation,
+                           update_list, discarded_fill, deficiency,
+                           verbosity_level);
+    Kokkos::parallel_for("MDF: updating fill norms", updatePolicy,
+                         MDF_update_df_norm);
 
+    range_policy_type stepPolicy(factorization_step, Atmp.numRows());
     ordinal_type selected_row_idx = 0;
     KokkosSparse::Impl::MDF_select_row<crs_matrix_type> MDF_row_selector(
         factorization_step, discarded_fill, deficiency, Atmp.graph.row_map,
         handle.permutation);
-    Kokkos::parallel_reduce(stepPolicy, MDF_row_selector, selected_row_idx);
+    Kokkos::parallel_reduce("MDF: select pivot", stepPolicy, MDF_row_selector,
+                            selected_row_idx);
+
+    KokkosSparse::Impl::MDF_compute_list_length<crs_matrix_type>
+        compute_list_length(selected_row_idx, Atmp, At, handle.permutation,
+                            factored, update_list_length, update_list);
+    Kokkos::parallel_for("MDF: compute update list", range_policy_type(0, 1),
+                         compute_list_length);
 
     KokkosSparse::Impl::MDF_factorize_row<crs_matrix_type> factorize_row(
         Atmp, At, handle.row_mapL, handle.entriesL, handle.valuesL,
         handle.row_mapU, handle.entriesU, handle.valuesU, handle.permutation,
-        handle.permutation_inv, selected_row_idx, factorization_step,
-        verbosity_level);
-    Kokkos::parallel_for(range_policy_type(0, 1), factorize_row);
+        handle.permutation_inv, discarded_fill, factored, selected_row_idx,
+        factorization_step, verbosity_level);
+    Kokkos::parallel_for("MDF: factorize row", range_policy_type(0, 1),
+                         factorize_row);
 
     if (verbosity_level > 0) {
       printf("\n");
     }
-  }
+  }  // Loop over factorization steps
 
   KokkosSparse::Impl::MDF_reindex_matrix<col_ind_type> reindex_U(
       handle.permutation_inv, handle.entriesU);
-  Kokkos::parallel_for(range_policy_type(0, handle.entriesU.extent(0)),
+  Kokkos::parallel_for("MDF: re-index U",
+                       range_policy_type(0, handle.entriesU.extent(0)),
                        reindex_U);
 
   KokkosSparse::Impl::MDF_reindex_matrix<col_ind_type> reindex_L(
       handle.permutation_inv, handle.entriesL);
-  Kokkos::parallel_for(range_policy_type(0, handle.entriesL.extent(0)),
+  Kokkos::parallel_for("MDF: re-index L",
+                       range_policy_type(0, handle.entriesL.extent(0)),
                        reindex_L);
 
+  handle.L = KokkosSparse::Impl::transpose_matrix<crs_matrix_type>(handle.L);
+
   return;
-}  // mdf_numeric_phase
+}  // mdf_numeric
 
 }  // namespace Experimental
 }  // namespace KokkosSparse


### PR DESCRIPTION
Modifying the implementation of MDF to reduce its algorithmic complexity and increase performance where possible.
The changes include the following:

1. only recomputing the discard factor for rows/columns impacted by the last factorization
2. improving the performance of the reduction to rank discard fills from smallest to largest after DF have been updated