### PR TITLE
Cuda/12 with CuSPARSE updates

### DIFF
--- a/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
@@ -179,7 +179,11 @@ void spmv_mv_cusparse(const KokkosKernels::Experimental::Controls &controls,
   cusparseOperation_t opB =
       xIsLL ? CUSPARSE_OPERATION_NON_TRANSPOSE : CUSPARSE_OPERATION_TRANSPOSE;
 
+#if CUDA_VERSION < 12000
   const cusparseSpMMAlg_t alg = CUSPARSE_MM_ALG_DEFAULT;
+#else
+  const cusparseSpMMAlg_t alg = CUSPARSE_SPMM_ALG_DEFAULT;
+#endif
 
   // the precision of the SpMV
   const cudaDataType computeType =

--- a/test_common/Test_Cuda.hpp
+++ b/test_common/Test_Cuda.hpp
@@ -9,14 +9,14 @@
 #define KOKKOSKERNELS_ETI_ONLY
 #endif
 
-class cuda : public ::testing::Test {
+class Cuda : public ::testing::Test {
  protected:
   static void SetUpTestCase() {}
 
   static void TearDownTestCase() {}
 };
 
-#define TestCategory cuda
+#define TestCategory Cuda
 #define TestExecSpace Kokkos::Cuda
 
 #endif  // TEST_CUDA_HPP


### PR DESCRIPTION
Two updates are made in this PR to allow compilation with cuda/12 using cusparse tpls:

* Renaming of CUSPARSE_MM_ALG_DEFAULT to CUSPARSE_SPMM_ALG_DEFAULT when cuda version >= 12, addressing #1630 
* Renaming the class cuda to Cuda in Test_Cuda.hpp to avoid conflicts within cuda/12 of the form:

```
    /ascldap/users/projects/x86-64/cuda/12.0/include/cuda/std/cstddef(26): error: "cuda" has already been declared in the current scope
    
    1 error detected in the compilation of "/ascldap/users/ndellin/kokkos-kernels/common/unit_test/backends/Test_Cuda_Common.cpp".
```

The second change breaks class-naming conventions used for the other backends; I can update those similarly in this PR, or the second item can be addressed differently if devs have alternative suggestions.

This PR is sufficient to get the kokkos-kernels lib and unit tests compiling with cuda/12 and cusparse tpl enabled.

There is additional work needed to allow compilation of the perf_tests which I would like to address in a separate PR. That will require update of CuSparse API calls used in `perf_test/sparse/KokkosSparse_sptrsv_aux.hpp`:
```
/ascldap/users/ndellin/kokkos-kernels/perf_test/sparse/KokkosSparse_sptrsv_aux.hpp(300): error: identifier "csrsv2Info_t" is undefined

/ascldap/users/ndellin/kokkos-kernels/perf_test/sparse/KokkosSparse_sptrsv_aux.hpp(301): error: identifier "cusparseCreateCsrsv2Info" is undefined

/ascldap/users/ndellin/kokkos-kernels/perf_test/sparse/KokkosSparse_sptrsv_aux.hpp(373): error: identifier "cusparseXcsrsv2_zeroPivot" is undefined

/ascldap/users/ndellin/kokkos-kernels/perf_test/sparse/KokkosSparse_sptrsv_aux.hpp(442): error: identifier "csrsv2Info_t" is undefined


```