### PR TITLE
Fix #1631

### DIFF
--- a/sparse/src/KokkosSparse_CrsMatrix.hpp
+++ b/sparse/src/KokkosSparse_CrsMatrix.hpp
@@ -426,7 +426,8 @@ class CrsMatrix {
   //! Nonconst version of the type of row offsets in the sparse matrix.
   typedef typename row_map_type::non_const_value_type non_const_size_type;
   //! Kokkos Array type of the entries (values) in the sparse matrix.
-  typedef Kokkos::View<value_type*, default_layout, device_type, MemoryTraits>
+  typedef Kokkos::View<value_type*, Kokkos::LayoutRight, device_type,
+                       MemoryTraits>
       values_type;
   //! Const version of the type of the entries in the sparse matrix.
   typedef typename values_type::const_value_type const_value_type;


### PR DESCRIPTION
Revert one line from #1620 which changed CrsMatrix::values_type (a 1D view) to be default_layout instead of LayoutRight. This seemed totally reasonable (the graph's rowptrs/entries already used default_layout, so this improved consistency), but the change makes spmv give wrong answers with Sacado PCE or MPVector as the scalar type.

A better fix would be to not revert the change, and replace LayoutRight with ``default_layout`` in Stokhos, for example in Stokhos_CrsMatrix.hpp:
```
 77 /** \brief  CRS matrix.  */
 78 template <typename ValueType, typename Device,
 79           typename Layout = Kokkos::LayoutRight>
 80 class CrsMatrix {
...
```
The problem is, ``default_layout`` was really only meant to be used by KokkosKernels internally, to help the unification layers pick the "internal" unmanaged view types. It's in the global namespace, so I don't want to introduce it to Trilinos. I will plan on moving the default typedefs to the ``KokkosKernels::`` namespace though so they can be used externally.