### PR TITLE
KokkosKernels: Use KOKKOSKERNELS_INCLUDE_DIRECTORIES() (TriBITSPub/TriBITS#429)

### DIFF
--- a/perf_test/CMakeLists.txt
+++ b/perf_test/CMakeLists.txt
@@ -26,7 +26,7 @@ if (KokkosKernels_ENABLE_PERFTESTS)
     #Gtest minimally requires C++ 11
     TARGET_COMPILE_FEATURES(kokkoskernelsperf_gtest PUBLIC cxx_std_11)
 
-    include_directories(sparse)
+    KOKKOSKERNELS_INCLUDE_DIRECTORIES(sparse)
     
     if(Kokkos_ENABLE_TESTS_AND_PERFSUITE)
         #Add RPS implementations of KK perf tests here


### PR DESCRIPTION
This replaces the usage of raw include_directories() with the wrapper KOKKOSKERNELS_INCLUDE_DIRECTORIES().

The deprecated TriBITS macro include_directories() now issues a CMake Deprecation warning.  The fix is to use tribits_include_directories() in a TriBITS build instead.

This is the same patch made in Trilinos PR trilinos/Trilinos#11380.