### PR TITLE
#5 Refactor blas1 test for benchmark feature

### DIFF
--- a/perf_test/Benchmark_Context.hpp
+++ b/perf_test/Benchmark_Context.hpp
@@ -19,6 +19,8 @@
 #ifndef KOKKOSKERNELS_PERFTEST_BENCHMARK_CONTEXT_HPP
 #define KOKKOSKERNELS_PERFTEST_BENCHMARK_CONTEXT_HPP
 
+#include "KokkosKernels_PrintConfiguration.hpp"
+
 #include <string>
 
 #include <benchmark/benchmark.h>
@@ -46,6 +48,7 @@ std::string remove_unwanted_characters(std::string str) {
 void add_kokkos_configuration(bool verbose) {
   std::ostringstream msg;
   Kokkos::print_configuration(msg, verbose);
+  KokkosKernels::print_configuration(msg);
 
   // Iterate over lines returned from kokkos and extract key:value pairs
   std::stringstream ss{msg.str()};

--- a/perf_test/CMakeLists.txt
+++ b/perf_test/CMakeLists.txt
@@ -142,6 +142,7 @@ IF(KokkosKernels_ENABLE_BENCHMARK)
       BENCHMARK_SOURCES
       BenchmarkMain.cpp
       blas/blas1/KokkosBlas_dot_perf_test_benchmark.cpp
+      blas/blas1/KokkosBlas_dot_mv_perf_test_benchmark.cpp
     )
 
     KOKKOSKERNELS_ADD_BENCHMARK(

--- a/perf_test/CMakeLists.txt
+++ b/perf_test/CMakeLists.txt
@@ -141,6 +141,7 @@ IF(KokkosKernels_ENABLE_BENCHMARK)
     SET(
       BENCHMARK_SOURCES
       BenchmarkMain.cpp
+      blas/blas1/KokkosBlas_dot_perf_test_benchmark.cpp
     )
 
     KOKKOSKERNELS_ADD_BENCHMARK(

--- a/perf_test/CMakeLists.txt
+++ b/perf_test/CMakeLists.txt
@@ -143,6 +143,7 @@ IF(KokkosKernels_ENABLE_BENCHMARK)
       BenchmarkMain.cpp
       blas/blas1/KokkosBlas_dot_perf_test_benchmark.cpp
       blas/blas1/KokkosBlas_dot_mv_perf_test_benchmark.cpp
+      blas/blas1/KokkosBlas_team_dot_perf_test_benchmark.cpp
     )
 
     KOKKOSKERNELS_ADD_BENCHMARK(

--- a/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test_benchmark.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test_benchmark.cpp
@@ -136,6 +136,7 @@ static void run(benchmark::State& state) {
 }
 
 BENCHMARK(run<Kokkos::DefaultExecutionSpace>)
+    ->Name("KokkosBlas_dot_mv")
     ->ArgNames({"m", "n", "repeat"})
     ->Args({100000, 5, 20})
     ->UseManualTime();

--- a/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test_benchmark.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test_benchmark.cpp
@@ -1,0 +1,141 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
+
+#include "KokkosBlas_dot_perf_test.hpp"
+#include <benchmark/benchmark.h>
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// The Level 1 BLAS perform scalar, vector and vector-vector operations;
+//
+// https://github.com/kokkos/kokkos-kernels/wiki/BLAS-1%3A%3Adot
+//
+// Usage: result = KokkosBlas::dot(x,y); KokkosBlas::dot(r,x,y);
+// Multiplies each value of x(i) [x(i,j)] with y(i) or [y(i,j)] and computes the
+// sum. (If x and y have scalar type Kokkos::complex, the complex conjugate of
+// x(i) or x(i,j) will be used.) VectorX: A rank-1 Kokkos::View VectorY: A
+// rank-1 Kokkos::View ReturnVector: A rank-0 or rank-1 Kokkos::View
+//
+// REQUIREMENTS:
+// Y.rank == 1 or X.rank == 1
+// Y.extent(0) == X.extent(0)
+
+// Dot Test design:
+// 1) create 1D View containing 1D matrix, aka a vector; this will be your X
+// input matrix; 2) create 1D View containing 1D matrix, aka a vector; this will
+// be your Y input matrix; 3) perform the dot operation on the two inputs, and
+// capture result in "result"
+
+// Here, m represents the desired length for each 1D matrix;
+// "m" is used here, because code from another test was adapted for this test.
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class ExecSpace>
+static void run(benchmark::State& state) {
+  const auto m      = state.range(0);
+  const auto n      = state.range(1);
+  const auto repeat = state.range(2);
+  // Declare type aliases
+  using Scalar   = double;
+  using MemSpace = typename ExecSpace::memory_space;
+  using Device   = Kokkos::Device<ExecSpace, MemSpace>;
+
+  std::cout << "Running BLAS Level 1 DOT perfomrance experiment ("
+            << ExecSpace::name() << ")\n";
+
+  std::cout << "Each test input vector has a length of " << m << std::endl;
+
+  Kokkos::View<Scalar**, Kokkos::LayoutLeft, Device> x(
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "x"), m, n);
+
+  Kokkos::View<Scalar**, Kokkos::LayoutLeft, Device> y(
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "y"), m, n);
+
+  Kokkos::View<Scalar*, Device> result(
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "x dot y"), n);
+
+  // Declaring variable pool w/ a seeded random number;
+  // a parallel random number generator, so you
+  // won't get the same number with a given seed each time
+  Kokkos::Random_XorShift64_Pool<ExecSpace> pool(123);
+
+  Kokkos::fill_random(x, pool, 10.0);
+  Kokkos::fill_random(y, pool, 10.0);
+
+  for (auto _ : state) {
+    // do a warm up run of dot:
+      KokkosBlas::dot(result, x, y);
+
+    // The live test of dot:
+
+    Kokkos::fence();
+    Kokkos::Timer timer;
+
+    for (int i = 0; i < repeat; i++) {
+      KokkosBlas::dot(result, x, y);
+      ExecSpace().fence();
+    }
+
+    // Kokkos Timer set up
+    double total = timer.seconds();
+    double avg   = total / repeat;
+    // Flops calculation for a 1D matrix dot product per test run;
+    size_t flopsPerRun = (size_t)2 * m * n;
+    printf("Avg DOT time: %f s.\n", avg);
+    printf("Avg DOT FLOP/s: %.3e\n", flopsPerRun / avg);
+        state.SetIterationTime(timer.seconds());
+
+    state.counters["Avg DOT time (s):"] =
+        benchmark::Counter(avg, benchmark::Counter::kDefaults);
+    state.counters["Avg DOT FLOP/s:"] =
+        benchmark::Counter(flopsPerRun / avg, benchmark::Counter::kDefaults);
+  }
+}
+
+BENCHMARK(run<Kokkos::DefaultExecutionSpace>)
+    ->ArgNames({"m", "n", "repeat"})
+    ->Args({100000, 5, 20})
+    ->UseManualTime();

--- a/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test_benchmark.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test_benchmark.cpp
@@ -107,7 +107,7 @@ static void run(benchmark::State& state) {
 
   for (auto _ : state) {
     // do a warm up run of dot:
-      KokkosBlas::dot(result, x, y);
+    KokkosBlas::dot(result, x, y);
 
     // The live test of dot:
 
@@ -126,7 +126,7 @@ static void run(benchmark::State& state) {
     size_t flopsPerRun = (size_t)2 * m * n;
     printf("Avg DOT time: %f s.\n", avg);
     printf("Avg DOT FLOP/s: %.3e\n", flopsPerRun / avg);
-        state.SetIterationTime(timer.seconds());
+    state.SetIterationTime(timer.seconds());
 
     state.counters["Avg DOT time (s):"] =
         benchmark::Counter(avg, benchmark::Counter::kDefaults);

--- a/perf_test/blas/blas1/KokkosBlas_dot_perf_test_benchmark.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_perf_test_benchmark.cpp
@@ -45,9 +45,7 @@
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Random.hpp>
 
-// For RPS implementation
 #include "KokkosBlas_dot_perf_test.hpp"
-#include "KokkosKernels_TestUtils.hpp"
 #include <benchmark/benchmark.h>
 
 
@@ -130,14 +128,15 @@ static void run(benchmark::State& state) {
     printf("Avg DOT FLOP/s: %.3e\n", flopsPerRun / avg);
     state.SetIterationTime(timer.seconds());
 
-    state.counters["Avg DOT time:"] =
+    state.counters["Avg DOT time (s):"] =
         benchmark::Counter(avg, benchmark::Counter::kDefaults);
     state.counters["Avg DOT FLOP/s:"] =
         benchmark::Counter(flopsPerRun / avg, benchmark::Counter::kDefaults);
     }
 }
 
-BENCHMARK(run<Kokkos::Serial>)
+BENCHMARK(run<Kokkos::DefaultExecutionSpace>)
     ->ArgNames({"m","repeat"})
     ->Args({100000,1})
     ->UseManualTime();
+

--- a/perf_test/blas/blas1/KokkosBlas_dot_perf_test_benchmark.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_perf_test_benchmark.cpp
@@ -48,7 +48,6 @@
 #include "KokkosBlas_dot_perf_test.hpp"
 #include <benchmark/benchmark.h>
 
-
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // The Level 1 BLAS perform scalar, vector and vector-vector operations;
 //
@@ -76,8 +75,7 @@
 
 template <class ExecSpace>
 static void run(benchmark::State& state) {
-
-  const auto m = state.range(0);
+  const auto m      = state.range(0);
   const auto repeat = state.range(1);
   // Declare type aliases
   using Scalar   = double;
@@ -132,11 +130,10 @@ static void run(benchmark::State& state) {
         benchmark::Counter(avg, benchmark::Counter::kDefaults);
     state.counters["Avg DOT FLOP/s:"] =
         benchmark::Counter(flopsPerRun / avg, benchmark::Counter::kDefaults);
-    }
+  }
 }
 
 BENCHMARK(run<Kokkos::DefaultExecutionSpace>)
-    ->ArgNames({"m","repeat"})
-    ->Args({100000,1})
+    ->ArgNames({"m", "repeat"})
+    ->Args({100000, 1})
     ->UseManualTime();
-

--- a/perf_test/blas/blas1/KokkosBlas_dot_perf_test_benchmark.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_perf_test_benchmark.cpp
@@ -1,0 +1,143 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
+
+// For RPS implementation
+#include "KokkosBlas_dot_perf_test.hpp"
+#include "KokkosKernels_TestUtils.hpp"
+#include <benchmark/benchmark.h>
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// The Level 1 BLAS perform scalar, vector and vector-vector operations;
+//
+// https://github.com/kokkos/kokkos-kernels/wiki/BLAS-1%3A%3Adot
+//
+// Usage: result = KokkosBlas::dot(x,y); KokkosBlas::dot(r,x,y);
+// Multiplies each value of x(i) [x(i,j)] with y(i) or [y(i,j)] and computes the
+// sum. (If x and y have scalar type Kokkos::complex, the complex conjugate of
+// x(i) or x(i,j) will be used.) VectorX: A rank-1 Kokkos::View VectorY: A
+// rank-1 Kokkos::View ReturnVector: A rank-0 or rank-1 Kokkos::View
+//
+// REQUIREMENTS:
+// Y.rank == 1 or X.rank == 1
+// Y.extent(0) == X.extent(0)
+
+// Dot Test design:
+// 1) create 1D View containing 1D matrix, aka a vector; this will be your X
+// input matrix; 2) create 1D View containing 1D matrix, aka a vector; this will
+// be your Y input matrix; 3) perform the dot operation on the two inputs, and
+// capture result in "result"
+
+// Here, m represents the desired length for each 1D matrix;
+// "m" is used here, because code from another test was adapted for this test.
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <class ExecSpace>
+static void run(benchmark::State& state) {
+
+  const auto m = state.range(0);
+  const auto repeat = state.range(1);
+  // Declare type aliases
+  using Scalar   = double;
+  using MemSpace = typename ExecSpace::memory_space;
+  using Device   = Kokkos::Device<ExecSpace, MemSpace>;
+
+  std::cout << "Running BLAS Level 1 DOT perfomrance experiment ("
+            << ExecSpace::name() << ")\n";
+
+  std::cout << "Each test input vector has a length of " << m << std::endl;
+
+  // Create 1D view w/ Device as the ExecSpace; this is an input vector
+  // A(view_alloc(WithoutInitializing, "label"), m, n);
+  Kokkos::View<Scalar*, Device> x(
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "x"), m);
+
+  // Create 1D view w/ Device as the ExecSpace; this is the output vector
+  Kokkos::View<Scalar*, Device> y(
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "y"), m);
+
+  // Declaring variable pool w/ a seeded random number;
+  // a parallel random number generator, so you
+  // won't get the same number with a given seed each time
+  Kokkos::Random_XorShift64_Pool<ExecSpace> pool(123);
+
+  Kokkos::fill_random(x, pool, 10.0);
+  Kokkos::fill_random(y, pool, 10.0);
+
+  for (auto _ : state) {
+    // do a warm up run of dot:
+    KokkosBlas::dot(x, y);
+
+    // The live test of dot:
+    Kokkos::fence();
+    Kokkos::Timer timer;
+
+    for (int i = 0; i < repeat; i++) {
+      KokkosBlas::dot(x, y);
+      ExecSpace().fence();
+    }
+
+    // Kokkos Timer set up
+    double total = timer.seconds();
+    double avg   = total / repeat;
+    // Flops calculation for a 1D matrix dot product per test run;
+    size_t flopsPerRun = (size_t)2 * m;
+    printf("Avg DOT time: %f s.\n", avg);
+    printf("Avg DOT FLOP/s: %.3e\n", flopsPerRun / avg);
+    state.SetIterationTime(timer.seconds());
+
+    state.counters["Avg DOT time:"] =
+        benchmark::Counter(avg, benchmark::Counter::kDefaults);
+    state.counters["Avg DOT FLOP/s:"] =
+        benchmark::Counter(flopsPerRun / avg, benchmark::Counter::kDefaults);
+    }
+}
+
+BENCHMARK(run<Kokkos::Serial>)
+    ->ArgNames({"m","repeat"})
+    ->Args({100000,1})
+    ->UseManualTime();

--- a/perf_test/blas/blas1/KokkosBlas_dot_perf_test_benchmark.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_perf_test_benchmark.cpp
@@ -134,6 +134,7 @@ static void run(benchmark::State& state) {
 }
 
 BENCHMARK(run<Kokkos::DefaultExecutionSpace>)
+    ->Name("KokkosBlas_dot")
     ->ArgNames({"m", "repeat"})
     ->Args({100000, 1})
     ->UseManualTime();

--- a/perf_test/blas/blas1/KokkosBlas_team_dot_perf_test_benchmark.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_team_dot_perf_test_benchmark.cpp
@@ -1,0 +1,145 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <Kokkos_Core.hpp>
+#include <KokkosBlas1_team_dot.hpp>
+#include <Kokkos_Random.hpp>
+#include "KokkosKernels_TestUtils.hpp"
+
+#include <benchmark/benchmark.h>
+
+// Functor to handle the case of a "without Cuda" build
+template <class Vector, class ExecSpace>
+struct teamDotFunctor {
+  // Compile - time check to see if your data type is a Kokkos::View:
+  static_assert(Kokkos::is_view<Vector>::value,
+                "Vector is not a Kokkos::View.");
+
+  using Scalar = typename Vector::non_const_value_type;
+  // Vector is templated on memory space
+  using execution_space = ExecSpace;  // Kokkos Execution Space
+  typedef typename Kokkos::TeamPolicy<execution_space> team_policy;
+  typedef typename team_policy::member_type team_member;
+
+  // Declare Kokkos::View Vectors, x and y
+  Vector x;
+  Vector y;
+
+  // Functor instead of KOKKOS_LAMBDA expression
+
+  KOKKOS_INLINE_FUNCTION void operator()(const team_member& team) const {
+    KokkosBlas::Experimental::dot(team, x, y);
+  }
+  // Constructor
+  teamDotFunctor(Vector X_, Vector Y_) {
+    x = X_;
+    y = Y_;
+  }
+};
+
+template <class ExecSpace>
+static void run(benchmark::State& state) {
+  const auto m      = state.range(0);
+  const auto repeat = state.range(1);
+  // Declare type aliases
+  using Scalar   = double;
+  using MemSpace = typename ExecSpace::memory_space;
+
+  // For the Team implementation of dot; ExecSpace is implicit;
+  using policy = Kokkos::TeamPolicy<ExecSpace>;
+
+  // Create 1D view w/ Device as the ExecSpace; this is an input vector
+  Kokkos::View<Scalar*, MemSpace> x("X", m);
+  // Create 1D view w/ Device as the ExecSpace; this is the output vector
+  Kokkos::View<Scalar*, MemSpace> y("Y", m);
+
+  // Here, deep_copy is filling / copying values into Host memory from Views X
+  // and Y
+  Kokkos::deep_copy(x, 3.0);
+  Kokkos::deep_copy(y, 2.0);
+
+  std::cout << "Running BLAS Level 1 Kokkos Teams-based implementation DOT "
+               "performance experiment ("
+            << ExecSpace::name() << ")\n";
+
+  std::cout << "Each test input vector has a length of " << m << std::endl;
+
+  for (auto _ : state) {
+    // Warm up run of dot:
+    teamDotFunctor<Kokkos::View<Scalar*, MemSpace>, ExecSpace>
+        teamDotFunctorWarmUpInstance(x, y);
+
+    Kokkos::parallel_for("TeamDotUsage -- Warm Up Run", policy(1, Kokkos::AUTO),
+                         teamDotFunctorWarmUpInstance);
+
+    // The live test of dot:
+
+    Kokkos::fence();
+    Kokkos::Timer timer;
+
+    teamDotFunctor<Kokkos::View<Scalar*, MemSpace>, ExecSpace>
+        teamDotFunctorLiveTestInstance(x, y);
+    Kokkos::parallel_for("TeamDotUsage -- Live Test", policy(1, Kokkos::AUTO),
+                         teamDotFunctorLiveTestInstance);
+
+    // Kokkos Timer set up and data capture
+    double total = timer.seconds();
+    double avg   = total / repeat;
+    // Flops calculation for a 1D matrix dot product per test run;
+    size_t flopsPerRun = (size_t)2 * m;
+    printf("Avg DOT time: %f s.\n", avg);
+    printf("Avg DOT FLOP/s: %.3e\n", flopsPerRun / avg);
+    state.SetIterationTime(timer.seconds());
+
+    state.counters["Avg DOT time (s):"] =
+        benchmark::Counter(avg, benchmark::Counter::kDefaults);
+    state.counters["Avg DOT FLOP/s:"] =
+        benchmark::Counter(flopsPerRun / avg, benchmark::Counter::kDefaults);
+  }
+}
+
+BENCHMARK(run<Kokkos::DefaultExecutionSpace>)
+    ->ArgNames({"m", "repeat"})
+    ->Args({100000, 1})
+    ->UseManualTime();

--- a/perf_test/blas/blas1/KokkosBlas_team_dot_perf_test_benchmark.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_team_dot_perf_test_benchmark.cpp
@@ -140,6 +140,7 @@ static void run(benchmark::State& state) {
 }
 
 BENCHMARK(run<Kokkos::DefaultExecutionSpace>)
+    ->Name("KokkosBlas_team_dot/run<Kokkos::DefaultExecutionSpace>")
     ->ArgNames({"m", "repeat"})
     ->Args({100000, 1})
     ->UseManualTime();


### PR DESCRIPTION
This PR provides a first example converting one blas test (KokkosBlas_dot) to using google bench. 
The idea is that to show what the tests would look like and what output they generate, and if accepted, we can use the same "structure" for porting all other performance tests

Configuration to enable benchmark:
 cmake .<KOKKOS-KERNELS_SOURCE_DIR> -DKokkos_DIR:DIR==<KOKKOS_INSTALL_DIR>/lib/cmake/Kokkos -DKokkosKernels_ENABLE_BENCHMARK=ON -DKokkosKernels_ENABLE_TESTS=ON -DKokkosKernels_ENABLE_ALL_COMPONENTS=ON -DKokkosKernels_ENABLE_PERFTESTS=ON

The file containing the code that was changed is this: https://github.com/kokkos/kokkos-kernels/pull/1636/files#diff-467ac095c3b5b7db0d220fbfa379fe328b2024ff6d516cd80a910cdcbeb78c1a"

See below the json output from googlebench that gives a summary of the configuration, metrics, etc for the test

<details> <summary> <b> benchmark output in json format </b> </summary> <br>

```json
{
  "context": {
    "date": "2023-03-02T19:19:26+01:00",
    "host_name": "perrinel-MS-7C75",
    "executable": "/home/perrinel/Dev/kokkos/build_kernel_benchmark/perf_test/KokkosKernels_PerformanceTest_Benchmark",
    "num_cpus": 20,
    "mhz_per_cpu": 5300,
    "cpu_scaling_enabled": true,
    "caches": [
      {
        "type": "Data",
        "level": 1,
        "size": 32768,
        "num_sharing": 2
      },
      {
        "type": "Instruction",
        "level": 1,
        "size": 32768,
        "num_sharing": 2
      },
      {
        "type": "Unified",
        "level": 2,
        "size": 262144,
        "num_sharing": 2
      },
      {
        "type": "Unified",
        "level": 3,
        "size": 20971520,
        "num_sharing": 20
      }
    ],
    "load_avg": [3.13,1.83,0.87],
    "library_build_type": "debug",
    "CPU architecture": "none",
    "Default Device": "N6Kokkos6SerialE",
    "GPU architecture": "none",
    "KOKKOSKERNELS_ENABLE_TPL_ARMPL": "no",
    "KOKKOSKERNELS_ENABLE_TPL_BLAS": "no",
    "KOKKOSKERNELS_ENABLE_TPL_CBLAS": "no",
    "KOKKOSKERNELS_ENABLE_TPL_CHOLMOD": "no",
    "KOKKOSKERNELS_ENABLE_TPL_CUBLAS": "no",
    "KOKKOSKERNELS_ENABLE_TPL_CUSPARSE": "no",
    "KOKKOSKERNELS_ENABLE_TPL_LAPACK": "no",
    "KOKKOSKERNELS_ENABLE_TPL_LAPACKE": "no",
    "KOKKOSKERNELS_ENABLE_TPL_MAGMA": "no",
    "KOKKOSKERNELS_ENABLE_TPL_METIS": "no",
    "KOKKOSKERNELS_ENABLE_TPL_MKL": "no",
    "KOKKOSKERNELS_ENABLE_TPL_ROCBLAS": "no",
    "KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE": "no",
    "KOKKOSKERNELS_ENABLE_TPL_SUPERLU": "no",
    "KOKKOS_COMPILER_GNU": "940",
    "KOKKOS_ENABLE_ASM": "yes",
    "KOKKOS_ENABLE_CXX17": "yes",
    "KOKKOS_ENABLE_CXX20": "no",
    "KOKKOS_ENABLE_CXX23": "no",
    "KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK": "no",
    "KOKKOS_ENABLE_GNU_ATOMICS": "no",
    "KOKKOS_ENABLE_HBWSPACE": "no",
    "KOKKOS_ENABLE_HWLOC": "no",
    "KOKKOS_ENABLE_INTEL_ATOMICS": "no",
    "KOKKOS_ENABLE_INTEL_MM_ALLOC": "no",
    "KOKKOS_ENABLE_LIBDL": "yes",
    "KOKKOS_ENABLE_LIBRT": "no",
    "KOKKOS_ENABLE_PRAGMA_IVDEP": "no",
    "KOKKOS_ENABLE_PRAGMA_LOOPCOUNT": "no",
    "KOKKOS_ENABLE_PRAGMA_UNROLL": "no",
    "KOKKOS_ENABLE_PRAGMA_VECTOR": "no",
    "KOKKOS_ENABLE_SERIAL": "yes",
    "KOKKOS_ENABLE_SERIAL_ATOMICS": "no",
    "KOKKOS_ENABLE_WINDOWS_ATOMICS": "no",
    "Kokkos Version": "4.0.99",
    "KokkosKernels Version": "4.0.99"
  },
  "benchmarks": [
    {
      "name": "KokkosBlas_dot/m:100000/repeat:1/manual_time",
      "family_index": 0,
      "per_family_instance_index": 0,
      "run_name": "KokkosBlas_dot/m:100000/repeat:1/manual_time",
      "run_type": "iteration",
      "repetitions": 1,
      "repetition_index": 0,
      "threads": 1,
      "iterations": 484,
      "real_time": 1.4449344855371896e-03,
      "cpu_time": 2.8886822851239670e-03,
      "time_unit": "s",
      "Avg DOT FLOP/s:": 1.4001346929574627e+08,
      "Avg DOT time (s):": 1.4284339999999999e-03
    },
    {
      "name": "KokkosBlas_dot_mv/m:100000/n:5/repeat:20/manual_time",
      "family_index": 1,
      "per_family_instance_index": 0,
      "run_name": "KokkosBlas_dot_mv/m:100000/n:5/repeat:20/manual_time",
      "run_type": "iteration",
      "repetitions": 1,
      "repetition_index": 0,
      "threads": 1,
      "iterations": 3,
      "real_time": 2.0546729999999999e-01,
      "cpu_time": 2.1573627266666673e-01,
      "time_unit": "s",
      "Avg DOT FLOP/s:": 9.7024361318100587e+07,
      "Avg DOT time (s):": 1.0306689850000000e-02
    },
    {
      "name": "KokkosBlas_team_dot/run<Kokkos::DefaultExecutionSpace>/m:100000/repeat:1/manual_time",
      "family_index": 2,
      "per_family_instance_index": 0,
      "run_name": "KokkosBlas_team_dot/run<Kokkos::DefaultExecutionSpace>/m:100000/repeat:1/manual_time",
      "run_type": "iteration",
      "repetitions": 1,
      "repetition_index": 0,
      "threads": 1,
      "iterations": 429,
      "real_time": 1.6436447202797205e-03,
      "cpu_time": 3.2831944988344999e-03,
      "time_unit": "s",
      "Avg DOT FLOP/s:": 1.2376153380144070e+08,
      "Avg DOT time (s):": 1.6160110000000001e-03
    }
  ]
}
```

</details>