### PR TITLE
ROTMG: loosen unit-test tolerance for Host TPLs

### DIFF
--- a/blas/unit_test/Test_Blas1_rotmg.hpp
+++ b/blas/unit_test/Test_Blas1_rotmg.hpp
@@ -13,7 +13,8 @@ void test_rotmg_impl(View0& d1, View0& d2, View0& x1, View0& y1, PView& param,
 
   const scalar_type eps = Kokkos::ArithTraits<scalar_type>::eps();
   const scalar_type tol =
-#ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
+#if defined(KOKKOSKERNELS_ENABLE_TPL_BLAS) || \
+    defined(KOKKOSKERNELS_ENABLE_TPL_MKL)
       100 *
       eps;  // Guessing MKL implements sin/cos differently so need larger tol
 #else


### PR DESCRIPTION
It seems that we are having the same issue with OpenBLAS and MKL so I am changing the logic just a bit to have a slightly higher tolerance when using host BLAS in our unit-test.

I think this should work fine but since Blake is unavailable at the moment we might discover that the tolerance needs to be modified once more during testing...

In any case this should eventually fix the problem and allow us to close #1622 