### PR TITLE
CMake: update package COMPATIBILITY mode in anticipation of release 4.0

### DIFF
--- a/cmake/kokkoskernels_tribits.cmake
+++ b/cmake/kokkoskernels_tribits.cmake
@@ -23,7 +23,7 @@ MACRO(KOKKOSKERNELS_PACKAGE_POSTPROCESS)
          INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/KokkosKernels)
     write_basic_package_version_file("${KokkosKernels_BINARY_DIR}/KokkosKernelsConfigVersion.cmake"
             VERSION "${KokkosKernels_VERSION_MAJOR}.${KokkosKernels_VERSION_MINOR}.${KokkosKernels_VERSION_PATCH}"
-            COMPATIBILITY SameMajorVersion)
+            COMPATIBILITY AnyNewerVersion)
 
     INSTALL(FILES
       "${KokkosKernels_BINARY_DIR}/KokkosKernelsConfig.cmake"


### PR DESCRIPTION
Without that change, projects doing `find_package(KokkosKernels 3.X)` with the 3.X version argument would not be able to build against KokkosKernels release 4.0

See kokkos/kokkos#5759