### PR TITLE
Replace printf in device code for SYCL

### DIFF
--- a/common/src/KokkosKernels_SimpleUtils.hpp
+++ b/common/src/KokkosKernels_SimpleUtils.hpp
@@ -292,7 +292,7 @@ struct IsRelativelyIdenticalFunctor {
     }
 
     if (val_diff > mag_type(eps)) {
-      printf(
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "Values at index %d, %.6f + %.6fi and %.6f + %.6fi, differ too much "
           "(eps = %e)\n",
           (int)i, KAT::real(view1(i)), KAT::imag(view1(i)), KAT::real(view2(i)),


### PR DESCRIPTION
This prevents compiling with `SYCL`.