### PR TITLE
Hands off `Kokkos::Impl::clock_tic`

### DIFF
--- a/batched/dense/unit_test/Test_Batched_SerialTrmm.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTrmm.hpp
@@ -22,6 +22,8 @@
 
 #include "KokkosKernels_TestUtils.hpp"
 
+#include <chrono>
+
 using namespace KokkosBatched;
 
 namespace Test {
@@ -165,7 +167,8 @@ void impl_test_batched_trmm(const int N, const int nRows, const int nCols,
       Kokkos::create_mirror_view(B_actual);
   typename ViewType::HostMirror B_expected_host =
       Kokkos::create_mirror_view(B_expected);
-  uint64_t seed = Kokkos::Impl::clock_tic();
+  uint64_t seed =
+      std::chrono::high_resolution_clock::now().time_since_epoch().count();
 
   using ViewTypeSubA =
       decltype(Kokkos::subview(A, 0, Kokkos::ALL(), Kokkos::ALL()));

--- a/batched/dense/unit_test/Test_Batched_SerialTrtri.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTrtri.hpp
@@ -22,6 +22,8 @@
 
 #include "KokkosKernels_TestUtils.hpp"
 
+#include <chrono>
+
 #define PRINT_MAT 0
 
 using namespace KokkosBatched;
@@ -161,7 +163,8 @@ void impl_test_batched_trtri(const int N, const int K) {
   typename ViewType::HostMirror I_host = Kokkos::create_mirror_view(A_I);
   typename ViewType::HostMirror A_host = Kokkos::create_mirror_view(A);
 
-  uint64_t seed = Kokkos::Impl::clock_tic();
+  uint64_t seed =
+      std::chrono::high_resolution_clock::now().time_since_epoch().count();
 
   using ViewTypeSubA =
       decltype(Kokkos::subview(A, 0, Kokkos::ALL(), Kokkos::ALL()));

--- a/blas/unit_test/Test_Blas3_gemm.hpp
+++ b/blas/unit_test/Test_Blas3_gemm.hpp
@@ -19,6 +19,8 @@
 #include <KokkosBlas3_gemm.hpp>
 #include <KokkosKernels_TestUtils.hpp>
 
+#include <chrono>
+
 namespace Test {
 
 template <class ViewTypeA, class ViewTypeB, class ViewTypeC,
@@ -91,7 +93,8 @@ void build_matrices(const int M, const int N, const int K,
 
   // (SA 11 Dec 2019) Max (previously: 10) increased to detect the bug in
   // Trilinos issue #6418
-  const uint64_t seed = Kokkos::Impl::clock_tic();
+  const uint64_t seed =
+      std::chrono::high_resolution_clock::now().time_since_epoch().count();
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(seed);
   Kokkos::fill_random(A, rand_pool,
                       Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<
@@ -184,7 +187,8 @@ void impl_test_gemm(const char* TA, const char* TB, int M, int N, int K,
   ViewTypeC C("C", M, N);
   ViewTypeC C2("C", M, N);
 
-  const uint64_t seed = Kokkos::Impl::clock_tic();
+  const uint64_t seed =
+      std::chrono::high_resolution_clock::now().time_since_epoch().count();
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(seed);
 
   // (SA 11 Dec 2019) Max (previously: 10) increased to detect the bug in

--- a/blas/unit_test/Test_Blas3_trmm.hpp
+++ b/blas/unit_test/Test_Blas3_trmm.hpp
@@ -19,6 +19,8 @@
 #include <KokkosBlas3_trmm.hpp>
 #include <KokkosKernels_TestUtils.hpp>
 
+#include <chrono>
+
 namespace Test {
 
 template <class ViewTypeA, class ExecutionSpace>
@@ -110,8 +112,9 @@ void impl_test_trmm(const char* side, const char* uplo, const char* trans,
   ViewTypeA A("A", K, K);
   ViewTypeB B("B", M, N);
   ViewTypeB B_expected("B_expected", M, N);
-  uint64_t seed = Kokkos::Impl::clock_tic();
-  ScalarA beta  = ScalarA(0);
+  uint64_t seed =
+      std::chrono::high_resolution_clock::now().time_since_epoch().count();
+  ScalarA beta = ScalarA(0);
 
   // printf("KokkosBlas::trmm test for alpha %g, %c %c %c %c, M %d, N %d, eps
   // %g, ViewType: %s\n",

--- a/blas/unit_test/Test_Blas3_trsm.hpp
+++ b/blas/unit_test/Test_Blas3_trsm.hpp
@@ -19,6 +19,8 @@
 #include <KokkosBlas3_trsm.hpp>
 #include <KokkosKernels_TestUtils.hpp>
 
+#include <chrono>
+
 namespace Test {
 
 template <class ViewTypeA, class ExecutionSpace>
@@ -121,7 +123,8 @@ void impl_test_trsm(const char* side, const char* uplo, const char* trans,
   typename ViewTypeB::HostMirror h_B  = Kokkos::create_mirror_view(B);
   typename ViewTypeB::HostMirror h_X0 = Kokkos::create_mirror_view(X0);
 
-  uint64_t seed = Kokkos::Impl::clock_tic();
+  uint64_t seed =
+      std::chrono::high_resolution_clock::now().time_since_epoch().count();
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(seed);
 
   if ((diag[0] == 'U') || (diag[0] == 'u')) {

--- a/blas/unit_test/Test_Blas_trtri.hpp
+++ b/blas/unit_test/Test_Blas_trtri.hpp
@@ -19,6 +19,8 @@
 #include <KokkosBlas_trtri.hpp>
 #include <KokkosKernels_TestUtils.hpp>
 
+#include <chrono>
+
 namespace Test {
 
 template <class ViewTypeA, class ExecutionSpace>
@@ -109,8 +111,9 @@ int impl_test_trtri(int bad_diag_idx, const char* uplo, const char* diag,
   ViewTypeA A("A", M, N);
   ViewTypeA A_original("A_original", M, N);
   ViewTypeA A_I("A_I", M, N);  // is I taken...?
-  uint64_t seed = Kokkos::Impl::clock_tic();
-  ScalarA beta  = ScalarA(0);
+  uint64_t seed =
+      std::chrono::high_resolution_clock::now().time_since_epoch().count();
+  ScalarA beta = ScalarA(0);
   ScalarA cur_check_val;  // Either 1 or 0, to check A_I
 
   // const int As0 = A.stride(0), As1 = A.stride(1);

--- a/perf_test/blas/blas3/KokkosBlas3_gemm_perf_test.hpp
+++ b/perf_test/blas/blas3/KokkosBlas3_gemm_perf_test.hpp
@@ -33,6 +33,8 @@
 #include "gtest/gtest.h"  // EXPECT_NEAR
 #include "KokkosKernels_TestUtils.hpp"
 
+#include <chrono>
+
 #if defined(KOKKOSKERNELS_ENABLE_TPL_ARMPL)
 #include "armpl.h"
 #else
@@ -1334,7 +1336,8 @@ void __do_gemm_parallel_experiment5(options_t options, gemm_args_t gemm_args) {
   simd_view_type C("C", simd_batch_size, gemm_args.C.extent(0),
                    gemm_args.C.extent(1));
 
-  // uint64_t seed = Kokkos::Impl::clock_tic();
+  // uint64_t seed =
+  //     std::chrono::high_resolution_clock::now().time_since_epoch().count();
   // Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(seed);
   // Kokkos::fill_random(A, rand_pool,
   // Kokkos::rand<Kokkos::Random_XorShift64<execution_space>,
@@ -1444,7 +1447,7 @@ void __do_gemm_parallel_experiment6(options_t options, gemm_args_t gemm_args) {
   view_type C((scalar_type *)C_vector.data(), simd_batch_size, gemm_args.C.extent(0), gemm_args.C.extent(1));
   internal_vector_view_type C_vector_internal(C_vector.data(), simd_batch_size, gemm_args.C.extent(0), gemm_args.C.extent(1));
 
-  uint64_t seed = Kokkos::Impl::clock_tic();
+  uint64_t seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(seed);
   Kokkos::fill_random(A, rand_pool, Kokkos::rand<Kokkos::Random_XorShift64<execution_space>, scalar_type>::max());
   Kokkos::fill_random(B, rand_pool, Kokkos::rand<Kokkos::Random_XorShift64<execution_space>, scalar_type>::max());
@@ -1914,7 +1917,8 @@ gemm_args_t __do_setup(options_t options, matrix_dims_t dims) {
   using execution_space = typename device_type::execution_space;
 
   gemm_args_t gemm_args;
-  uint64_t seed = Kokkos::Impl::clock_tic();
+  uint64_t seed =
+      std::chrono::high_resolution_clock::now().time_since_epoch().count();
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(seed);
   STATUS;
 

--- a/perf_test/blas/blas3/KokkosBlas3_trmm_perf_test.hpp
+++ b/perf_test/blas/blas3/KokkosBlas3_trmm_perf_test.hpp
@@ -27,6 +27,8 @@
 #include "KokkosBatched_Trmm_Serial_Impl.hpp"
 #include "KokkosBatched_Util.hpp"
 
+#include <chrono>
+
 //#define PERF_TEST_DEBUG
 
 // Forward declarations
@@ -611,7 +613,8 @@ trmm_args_t __do_setup(options_t options, matrix_dims_t dim) {
   using execution_space = typename device_type::execution_space;
 
   trmm_args_t trmm_args;
-  uint64_t seed = Kokkos::Impl::clock_tic();
+  uint64_t seed =
+      std::chrono::high_resolution_clock::now().time_since_epoch().count();
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(seed);
   decltype(dim.a.m) min_dim = dim.a.m < dim.a.n ? dim.a.m : dim.a.n;
   typename vta::HostMirror host_A;

--- a/perf_test/blas/blas3/KokkosBlas_trtri_perf_test.hpp
+++ b/perf_test/blas/blas3/KokkosBlas_trtri_perf_test.hpp
@@ -27,6 +27,8 @@
 #include "KokkosBatched_Trtri_Serial_Impl.hpp"
 #include "KokkosBatched_Util.hpp"
 
+#include <chrono>
+
 //#define TRTRI_PERF_TEST_DEBUG
 
 // Forward declarations
@@ -436,7 +438,8 @@ trtri_args_t __do_setup(options_t options, matrix_dims_t dim) {
   using execution_space = typename device_type::execution_space;
 
   trtri_args_t trtri_args;
-  uint64_t seed = Kokkos::Impl::clock_tic();
+  uint64_t seed =
+      std::chrono::high_resolution_clock::now().time_since_epoch().count();
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(seed);
   decltype(dim.a.m) min_dim = dim.a.m < dim.a.n ? dim.a.m : dim.a.n;
   typename vta::HostMirror host_A;


### PR DESCRIPTION
I am not convinced it is a good idea to use a random seed in the first place, but if you do, since the seed are being taken on the host, you can just use `std::chrono::high_resolution_clock::now().time_since_epoch().count()` directly.