### PR TITLE
Fix an error in Krylov Handle documentation

### DIFF
--- a/batched/sparse/src/KokkosBatched_Krylov_Handle.hpp
+++ b/batched/sparse/src/KokkosBatched_Krylov_Handle.hpp
@@ -114,7 +114,7 @@ class KrylovHandle {
     Kokkos::deep_copy(first_index, first_index_host);
     Kokkos::deep_copy(last_index, last_index_host);
 
-    // Default Classical GS
+    // Default modified GS
     ortho_strategy        = 1;
     scratch_pad_level     = 0;
     compute_last_residual = true;


### PR DESCRIPTION
Fix a documentation error.
I put the WIT label not to use CI tests.