### PR TITLE
Call concurrency(), not impl_thread_pool_size()

### DIFF
--- a/sparse/impl/KokkosSparse_spmv_impl.hpp
+++ b/sparse/impl/KokkosSparse_spmv_impl.hpp
@@ -512,21 +512,7 @@ static void spmv_beta_transpose(typename YVector::const_value_type& alpha,
 #if defined(KOKKOS_ENABLE_SERIAL) || defined(KOKKOS_ENABLE_OPENMP) || \
     defined(KOKKOS_ENABLE_THREADS)
   {
-    int impl_thread_pool_size(0);
-#if defined(KOKKOS_ENABLE_SERIAL)
-    if (std::is_same<execution_space, Kokkos::Serial>::value)
-      impl_thread_pool_size = 1;
-#endif
-#if defined(KOKKOS_ENABLE_OPENMP)
-    if (std::is_same<execution_space, Kokkos::OpenMP>::value)
-      impl_thread_pool_size = Kokkos::OpenMP::impl_thread_pool_size();
-#endif
-#if defined(KOKKOS_ENABLE_THREADS)
-    if (std::is_same<execution_space, Kokkos::Threads>::value)
-      impl_thread_pool_size = Kokkos::Threads::impl_thread_pool_size();
-#endif
-
-    if (impl_thread_pool_size == 1) {
+    if (execution_space().concurrency() == 1) {
       /// serial impl
       typedef typename AMatrix::non_const_value_type value_type;
       typedef Kokkos::Details::ArithTraits<value_type> ATV;


### PR DESCRIPTION
Update in response to https://github.com/kokkos/kokkos/pull/5836.

Instead of calling a Kokkos internal function, call ``concurrency`` which is part of the public interface. The two functions have equivalent behavior.

This unblocks PR testing builds with OpenMP.