### PR TITLE
Use the options ENABLE_PERFTEST, ENABLE_EXAMPLES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,9 +64,9 @@ IF (NOT KOKKOSKERNELS_HAS_TRILINOS)
   )
   KOKKOSKERNELS_ADD_OPTION(
           "ENABLE_PERFTESTS"
-          ON
+          OFF
           BOOL
-          "Whether to build performance tests. Default: ON"
+          "Whether to build performance tests. Default: OFF"
   )
   KOKKOSKERNELS_ADD_OPTION(
           "ENABLE_TESTS_AND_PERFSUITE"
@@ -391,13 +391,15 @@ ELSE()
       MESSAGE(STATUS "Enabling examples.")
       KOKKOSKERNELS_ADD_EXAMPLE_DIRECTORIES(example)
     ENDIF ()
-  ENDIF()
-
-  IF (NOT KokkosKernels_ENABLE_ALL_COMPONENTS AND KokkosKernels_ENABLE_PERFTESTS)
-    MESSAGE(STATUS "Could not enable perf tests because KokkosKernels_ENABLE_ALL_COMPONENTS=OFF")
-  ENDIF ()
-  IF (NOT KokkosKernels_ENABLE_ALL_COMPONENTS AND KokkosKernels_ENABLE_EXAMPLES)
-    MESSAGE(STATUS "Could not enable examples because KokkosKernels_ENABLE_ALL_COMPONENTS=OFF")
+  ELSE ()
+    # ENABLE_ALL_COMPONENTS is OFF, so perftests and examples can't be enabled.
+    # Warn if they were requested.
+    IF (KokkosKernels_ENABLE_PERFTESTS)
+      MESSAGE(WARNING "Could not enable perf tests because KokkosKernels_ENABLE_ALL_COMPONENTS=OFF")
+    ENDIF ()
+    IF (KokkosKernels_ENABLE_EXAMPLES)
+      MESSAGE(WARNING "Could not enable examples because KokkosKernels_ENABLE_ALL_COMPONENTS=OFF")
+    ENDIF ()
   ENDIF ()
 
   KOKKOSKERNELS_PACKAGE_POSTPROCESS()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ IF (NOT KOKKOSKERNELS_HAS_TRILINOS)
           "ENABLE_PERFTESTS"
           ON
           BOOL
-          "Whether to build performance tests. Default: OFF"
+          "Whether to build performance tests. Default: ON"
   )
   KOKKOSKERNELS_ADD_OPTION(
           "ENABLE_TESTS_AND_PERFSUITE"
@@ -383,9 +383,22 @@ ELSE()
     KOKKOSKERNELS_ADD_TEST_DIRECTORIES(sparse/unit_test)
   ENDIF()
   IF (KokkosKernels_ENABLE_ALL_COMPONENTS)
-    KOKKOSKERNELS_ADD_TEST_DIRECTORIES(perf_test)
-    KOKKOSKERNELS_ADD_EXAMPLE_DIRECTORIES(example)
+    IF (KokkosKernels_ENABLE_PERFTESTS)
+      MESSAGE(STATUS "Enabling perf tests.")
+      KOKKOSKERNELS_ADD_TEST_DIRECTORIES(perf_test)
+    ENDIF ()
+    IF (KokkosKernels_ENABLE_EXAMPLES)
+      MESSAGE(STATUS "Enabling examples.")
+      KOKKOSKERNELS_ADD_EXAMPLE_DIRECTORIES(example)
+    ENDIF ()
   ENDIF()
+
+  IF (NOT KokkosKernels_ENABLE_ALL_COMPONENTS AND KokkosKernels_ENABLE_PERFTESTS)
+    MESSAGE(STATUS "Could not enable perf tests because KokkosKernels_ENABLE_ALL_COMPONENTS=OFF")
+  ENDIF ()
+  IF (NOT KokkosKernels_ENABLE_ALL_COMPONENTS AND KokkosKernels_ENABLE_EXAMPLES)
+    MESSAGE(STATUS "Could not enable examples because KokkosKernels_ENABLE_ALL_COMPONENTS=OFF")
+  ENDIF ()
 
   KOKKOSKERNELS_PACKAGE_POSTPROCESS()
   IF (KokkosKernels_ENABLE_DOCS)

--- a/perf_test/CMakeLists.txt
+++ b/perf_test/CMakeLists.txt
@@ -28,7 +28,7 @@ if (KokkosKernels_ENABLE_PERFTESTS)
 
     KOKKOSKERNELS_INCLUDE_DIRECTORIES(sparse)
     
-    if(Kokkos_ENABLE_TESTS_AND_PERFSUITE)
+    if(KokkosKernels_ENABLE_TESTS_AND_PERFSUITE)
         #Add RPS implementations of KK perf tests here
         KOKKOSKERNELS_ADD_EXECUTABLE(
             tracked_testing


### PR DESCRIPTION
The cmake options ``KokkosKernels_ENABLE_PERFTESTS`` and ``KokkosKernels_ENABLE_EXAMPLES`` were not actually used. Both ``perf_test/`` and ``example/`` were always built as long as ``KokkosKernels_ENABLE_ALL_COMPONENTS=ON``.

This makes these options have an effect again. If perftests or examples are enabled but ``KokkosKernels_ENABLE_ALL_COMPONENTS=OFF``, print a message about why they can't actually be enabled.