### PR TITLE
Prefer `Kokkos::View::{R->r}ank`

### DIFF
--- a/batched/dense/impl/KokkosBatched_Axpy_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Axpy_Impl.hpp
@@ -188,11 +188,11 @@ KOKKOS_INLINE_FUNCTION int SerialAxpy::invoke(const alphaViewType& alpha,
                 "KokkosBatched::axpy: YViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<alphaViewType>::value,
                 "KokkosBatched::axpy: alphaViewType is not a Kokkos::View.");
-  static_assert(XViewType::Rank == 2,
+  static_assert(XViewType::rank == 2,
                 "KokkosBatched::axpy: XViewType must have rank 2.");
-  static_assert(YViewType::Rank == 2,
+  static_assert(YViewType::rank == 2,
                 "KokkosBatched::axpy: YViewType must have rank 2.");
-  static_assert(alphaViewType::Rank == 1,
+  static_assert(alphaViewType::rank == 1,
                 "KokkosBatched::axpy: alphaViewType must have rank 1.");
 
   // Check compatibility of dimensions at run time.
@@ -235,11 +235,11 @@ KOKKOS_INLINE_FUNCTION int TeamAxpy<MemberType>::invoke(
                 "KokkosBatched::axpy: YViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<alphaViewType>::value,
                 "KokkosBatched::axpy: alphaViewType is not a Kokkos::View.");
-  static_assert(XViewType::Rank == 2,
+  static_assert(XViewType::rank == 2,
                 "KokkosBatched::axpy: XViewType must have rank 2.");
-  static_assert(YViewType::Rank == 2,
+  static_assert(YViewType::rank == 2,
                 "KokkosBatched::axpy: YViewType must have rank 2.");
-  static_assert(alphaViewType::Rank == 1,
+  static_assert(alphaViewType::rank == 1,
                 "KokkosBatched::axpy: alphaViewType must have rank 1.");
 
   // Check compatibility of dimensions at run time.
@@ -283,11 +283,11 @@ KOKKOS_INLINE_FUNCTION int TeamVectorAxpy<MemberType>::invoke(
                 "KokkosBatched::axpy: YViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<alphaViewType>::value,
                 "KokkosBatched::axpy: alphaViewType is not a Kokkos::View.");
-  static_assert(XViewType::Rank == 2,
+  static_assert(XViewType::rank == 2,
                 "KokkosBatched::axpy: XViewType must have rank 2.");
-  static_assert(YViewType::Rank == 2,
+  static_assert(YViewType::rank == 2,
                 "KokkosBatched::axpy: YViewType must have rank 2.");
-  static_assert(alphaViewType::Rank == 1,
+  static_assert(alphaViewType::rank == 1,
                 "KokkosBatched::axpy: alphaViewType must have rank 1.");
 
   // Check compatibility of dimensions at run time.

--- a/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
@@ -175,11 +175,11 @@ struct SerialDot<Trans::Transpose> {
                   "KokkosBatched::dot: YViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<NormViewType>::value,
                   "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
-    static_assert(XViewType::Rank == 2,
+    static_assert(XViewType::rank == 2,
                   "KokkosBatched::dot: XViewType must have rank 2.");
-    static_assert(YViewType::Rank == 2,
+    static_assert(YViewType::rank == 2,
                   "KokkosBatched::dot: YViewType must have rank 2.");
-    static_assert(NormViewType::Rank == 1,
+    static_assert(NormViewType::rank == 1,
                   "KokkosBatched::dot: NormViewType must have rank 1.");
 
     // Check compatibility of dimensions at run time.
@@ -221,11 +221,11 @@ struct SerialDot<Trans::NoTranspose> {
                   "KokkosBatched::dot: YViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<NormViewType>::value,
                   "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
-    static_assert(XViewType::Rank == 2,
+    static_assert(XViewType::rank == 2,
                   "KokkosBatched::dot: XViewType must have rank 2.");
-    static_assert(YViewType::Rank == 2,
+    static_assert(YViewType::rank == 2,
                   "KokkosBatched::dot: YViewType must have rank 2.");
-    static_assert(NormViewType::Rank == 1,
+    static_assert(NormViewType::rank == 1,
                   "KokkosBatched::dot: NormViewType must have rank 1.");
 
     // Check compatibility of dimensions at run time.
@@ -270,11 +270,11 @@ struct TeamDot<MemberType, Trans::Transpose> {
                   "KokkosBatched::dot: YViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<NormViewType>::value,
                   "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
-    static_assert(XViewType::Rank == 2,
+    static_assert(XViewType::rank == 2,
                   "KokkosBatched::dot: XViewType must have rank 2.");
-    static_assert(YViewType::Rank == 2,
+    static_assert(YViewType::rank == 2,
                   "KokkosBatched::dot: YViewType must have rank 2.");
-    static_assert(NormViewType::Rank == 1,
+    static_assert(NormViewType::rank == 1,
                   "KokkosBatched::dot: NormViewType must have rank 1.");
 
     // Check compatibility of dimensions at run time.
@@ -317,11 +317,11 @@ struct TeamDot<MemberType, Trans::NoTranspose> {
                   "KokkosBatched::dot: YViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<NormViewType>::value,
                   "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
-    static_assert(XViewType::Rank == 2,
+    static_assert(XViewType::rank == 2,
                   "KokkosBatched::dot: XViewType must have rank 2.");
-    static_assert(YViewType::Rank == 2,
+    static_assert(YViewType::rank == 2,
                   "KokkosBatched::dot: YViewType must have rank 2.");
-    static_assert(NormViewType::Rank == 1,
+    static_assert(NormViewType::rank == 1,
                   "KokkosBatched::dot: NormViewType must have rank 1.");
 
     // Check compatibility of dimensions at run time.
@@ -366,11 +366,11 @@ struct TeamVectorDot<MemberType, Trans::Transpose> {
                   "KokkosBatched::dot: YViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<NormViewType>::value,
                   "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
-    static_assert(XViewType::Rank == 2,
+    static_assert(XViewType::rank == 2,
                   "KokkosBatched::dot: XViewType must have rank 2.");
-    static_assert(YViewType::Rank == 2,
+    static_assert(YViewType::rank == 2,
                   "KokkosBatched::dot: YViewType must have rank 2.");
-    static_assert(NormViewType::Rank == 1,
+    static_assert(NormViewType::rank == 1,
                   "KokkosBatched::dot: NormViewType must have rank 1.");
 
     // Check compatibility of dimensions at run time.
@@ -413,11 +413,11 @@ struct TeamVectorDot<MemberType, Trans::NoTranspose> {
                   "KokkosBatched::dot: YViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<NormViewType>::value,
                   "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
-    static_assert(XViewType::Rank == 2,
+    static_assert(XViewType::rank == 2,
                   "KokkosBatched::dot: XViewType must have rank 2.");
-    static_assert(YViewType::Rank == 2,
+    static_assert(YViewType::rank == 2,
                   "KokkosBatched::dot: YViewType must have rank 2.");
-    static_assert(NormViewType::Rank == 1,
+    static_assert(NormViewType::rank == 1,
                   "KokkosBatched::dot: NormViewType must have rank 1.");
 
     // Check compatibility of dimensions at run time.

--- a/batched/dense/impl/KokkosBatched_Gemv_TeamVector_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemv_TeamVector_Impl.hpp
@@ -45,7 +45,7 @@ struct TeamVectorGemv<MemberType, Trans::NoTranspose, Algo::Gemv::Unblocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType &member, const ScalarType alpha, const AViewType &A,
       const xViewType &x, const ScalarType beta, const yViewType &y) {
-    static_assert(AViewType::Rank == 3,
+    static_assert(AViewType::rank == 3,
                   "Batched TeamVectorGemv requires rank-3 A matrix (use "
                   "KokkosBlas::TeamVectorGemv for regular rank-2 matrix)");
     return TeamVectorGemvInternal<Algo::Gemv::Unblocked>::template invoke<
@@ -67,7 +67,7 @@ struct TeamVectorGemv<MemberType, Trans::NoTranspose, Algo::Gemv::Blocked> {
                                            const xViewType & /*x*/,
                                            const ScalarType /*beta*/,
                                            const yViewType & /*y*/) {
-    static_assert(AViewType::Rank == 3,
+    static_assert(AViewType::rank == 3,
                   "Batched TeamVectorGemv requires rank-3 A matrix (use "
                   "KokkosBlas::TeamVectorGemv for regular rank-2 matrix)");
     Kokkos::abort(
@@ -87,7 +87,7 @@ struct TeamVectorGemv<MemberType, Trans::Transpose, Algo::Gemv::Unblocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType &member, const ScalarType alpha, const AViewType &A,
       const xViewType &x, const ScalarType beta, const yViewType &y) {
-    static_assert(AViewType::Rank == 3,
+    static_assert(AViewType::rank == 3,
                   "Batched TeamVectorGemv requires rank-3 A matrix (use "
                   "KokkosBlas::TeamVectorGemv for regular rank-2 matrix)");
     return TeamVectorGemvInternal<Algo::Gemv::Unblocked>::template invoke<
@@ -109,7 +109,7 @@ struct TeamVectorGemv<MemberType, Trans::Transpose, Algo::Gemv::Blocked> {
                                            const xViewType & /*x*/,
                                            const ScalarType /*beta*/,
                                            const yViewType & /*y*/) {
-    static_assert(AViewType::Rank == 3,
+    static_assert(AViewType::rank == 3,
                   "Batched TeamVectorGemv requires rank-3 A matrix (use "
                   "KokkosBlas::TeamVectorGemv for regular rank-2 matrix)");
     Kokkos::abort(

--- a/batched/dense/impl/KokkosBatched_Gemv_Team_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemv_Team_Impl.hpp
@@ -45,7 +45,7 @@ struct TeamGemv<MemberType, Trans::NoTranspose, Algo::Gemv::Unblocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType &member, const ScalarType alpha, const AViewType &A,
       const xViewType &x, const ScalarType beta, const yViewType &y) {
-    static_assert(AViewType::Rank == 3,
+    static_assert(AViewType::rank == 3,
                   "Batched TeamGemv requires rank-3 A matrix (use "
                   "KokkosBlas::TeamGemv for regular rank-2 matrix)");
     return TeamGemvInternal<Algo::Gemv::Unblocked>::template invoke<
@@ -67,7 +67,7 @@ struct TeamGemv<MemberType, Trans::NoTranspose, Algo::Gemv::Blocked> {
                                            const xViewType & /*x*/,
                                            const ScalarType /*beta*/,
                                            const yViewType & /*y*/) {
-    static_assert(AViewType::Rank == 3,
+    static_assert(AViewType::rank == 3,
                   "Batched TeamGemv requires rank-3 A matrix (use "
                   "KokkosBlas::TeamGemv for regular rank-2 matrix)");
     Kokkos::abort(
@@ -87,7 +87,7 @@ struct TeamGemv<MemberType, Trans::Transpose, Algo::Gemv::Unblocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType &member, const ScalarType alpha, const AViewType &A,
       const xViewType &x, const ScalarType beta, const yViewType &y) {
-    static_assert(AViewType::Rank == 3,
+    static_assert(AViewType::rank == 3,
                   "Batched TeamGemv requires rank-3 A matrix (use "
                   "KokkosBlas::TeamGemv for regular rank-2 matrix)");
     return TeamGemvInternal<Algo::Gemv::Unblocked>::template invoke<
@@ -109,7 +109,7 @@ struct TeamGemv<MemberType, Trans::Transpose, Algo::Gemv::Blocked> {
                                            const xViewType & /*x*/,
                                            const ScalarType /*beta*/,
                                            const yViewType & /*y*/) {
-    static_assert(AViewType::Rank == 3,
+    static_assert(AViewType::rank == 3,
                   "Batched TeamGemv requires rank-3 A matrix (use "
                   "KokkosBlas::TeamGemv for regular rank-2 matrix)");
     Kokkos::abort(

--- a/batched/dense/impl/KokkosBatched_Gesv_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gesv_Impl.hpp
@@ -376,9 +376,9 @@ struct SerialGesv<Gesv::StaticPivoting> {
                   "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<VectorType>::value,
                   "KokkosBatched::gesv: VectorType is not a Kokkos::View.");
-    static_assert(MatrixType::Rank == 2,
+    static_assert(MatrixType::rank == 2,
                   "KokkosBatched::gesv: MatrixType must have rank 2.");
-    static_assert(VectorType::Rank == 1,
+    static_assert(VectorType::rank == 1,
                   "KokkosBatched::gesv: VectorType must have rank 1.");
 
     // Check compatibility of dimensions at run time.
@@ -449,9 +449,9 @@ struct SerialGesv<Gesv::NoPivoting> {
                   "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<VectorType>::value,
                   "KokkosBatched::gesv: VectorType is not a Kokkos::View.");
-    static_assert(MatrixType::Rank == 2,
+    static_assert(MatrixType::rank == 2,
                   "KokkosBatched::gesv: MatrixType must have rank 2.");
-    static_assert(VectorType::Rank == 1,
+    static_assert(VectorType::rank == 1,
                   "KokkosBatched::gesv: VectorType must have rank 1.");
 
     // Check compatibility of dimensions at run time.
@@ -501,9 +501,9 @@ struct TeamGesv<MemberType, Gesv::StaticPivoting> {
                   "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<VectorType>::value,
                   "KokkosBatched::gesv: VectorType is not a Kokkos::View.");
-    static_assert(MatrixType::Rank == 2,
+    static_assert(MatrixType::rank == 2,
                   "KokkosBatched::gesv: MatrixType must have rank 2.");
-    static_assert(VectorType::Rank == 1,
+    static_assert(VectorType::rank == 1,
                   "KokkosBatched::gesv: VectorType must have rank 1.");
 
     // Check compatibility of dimensions at run time.
@@ -579,9 +579,9 @@ struct TeamGesv<MemberType, Gesv::NoPivoting> {
                   "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<VectorType>::value,
                   "KokkosBatched::gesv: VectorType is not a Kokkos::View.");
-    static_assert(MatrixType::Rank == 2,
+    static_assert(MatrixType::rank == 2,
                   "KokkosBatched::gesv: MatrixType must have rank 2.");
-    static_assert(VectorType::Rank == 1,
+    static_assert(VectorType::rank == 1,
                   "KokkosBatched::gesv: VectorType must have rank 1.");
 
     // Check compatibility of dimensions at run time.
@@ -637,9 +637,9 @@ struct TeamVectorGesv<MemberType, Gesv::StaticPivoting> {
                   "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<VectorType>::value,
                   "KokkosBatched::gesv: VectorType is not a Kokkos::View.");
-    static_assert(MatrixType::Rank == 2,
+    static_assert(MatrixType::rank == 2,
                   "KokkosBatched::gesv: MatrixType must have rank 2.");
-    static_assert(VectorType::Rank == 1,
+    static_assert(VectorType::rank == 1,
                   "KokkosBatched::gesv: VectorType must have rank 1.");
 
     // Check compatibility of dimensions at run time.
@@ -716,9 +716,9 @@ struct TeamVectorGesv<MemberType, Gesv::NoPivoting> {
                   "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<VectorType>::value,
                   "KokkosBatched::gesv: VectorType is not a Kokkos::View.");
-    static_assert(MatrixType::Rank == 2,
+    static_assert(MatrixType::rank == 2,
                   "KokkosBatched::gesv: MatrixType must have rank 2.");
-    static_assert(VectorType::Rank == 1,
+    static_assert(VectorType::rank == 1,
                   "KokkosBatched::gesv: VectorType must have rank 1.");
 
     // Check compatibility of dimensions at run time.

--- a/batched/dense/impl/KokkosBatched_HadamardProduct_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_HadamardProduct_Impl.hpp
@@ -101,11 +101,11 @@ KOKKOS_INLINE_FUNCTION int SerialHadamardProduct::invoke(const XViewType& X,
   static_assert(
       Kokkos::is_view<VViewType>::value,
       "KokkosBatched::HadamardProduct: VViewType is not a Kokkos::View.");
-  static_assert(XViewType::Rank == 2,
+  static_assert(XViewType::rank == 2,
                 "KokkosBatched::HadamardProduct: XViewType must have rank 2.");
-  static_assert(YViewType::Rank == 2,
+  static_assert(YViewType::rank == 2,
                 "KokkosBatched::HadamardProduct: YViewType must have rank 2.");
-  static_assert(VViewType::Rank == 2,
+  static_assert(VViewType::rank == 2,
                 "KokkosBatched::HadamardProduct: VViewType must have rank 2.");
 
   // Check compatibility of dimensions at run time.
@@ -152,11 +152,11 @@ KOKKOS_INLINE_FUNCTION int TeamHadamardProduct<MemberType>::invoke(
   static_assert(
       Kokkos::is_view<VViewType>::value,
       "KokkosBatched::HadamardProduct: VViewType is not a Kokkos::View.");
-  static_assert(XViewType::Rank == 2,
+  static_assert(XViewType::rank == 2,
                 "KokkosBatched::HadamardProduct: XViewType must have rank 2.");
-  static_assert(YViewType::Rank == 2,
+  static_assert(YViewType::rank == 2,
                 "KokkosBatched::HadamardProduct: YViewType must have rank 2.");
-  static_assert(VViewType::Rank == 2,
+  static_assert(VViewType::rank == 2,
                 "KokkosBatched::HadamardProduct: VViewType must have rank 2.");
 
   // Check compatibility of dimensions at run time.
@@ -205,11 +205,11 @@ KOKKOS_INLINE_FUNCTION int TeamVectorHadamardProduct<MemberType>::invoke(
   static_assert(
       Kokkos::is_view<VViewType>::value,
       "KokkosBatched::HadamardProduct: VViewType is not a Kokkos::View.");
-  static_assert(XViewType::Rank == 2,
+  static_assert(XViewType::rank == 2,
                 "KokkosBatched::HadamardProduct: XViewType must have rank 2.");
-  static_assert(YViewType::Rank == 2,
+  static_assert(YViewType::rank == 2,
                 "KokkosBatched::HadamardProduct: YViewType must have rank 2.");
-  static_assert(VViewType::Rank == 2,
+  static_assert(VViewType::rank == 2,
                 "KokkosBatched::HadamardProduct: VViewType must have rank 2.");
 
   // Check compatibility of dimensions at run time.

--- a/batched/dense/impl/KokkosBatched_Xpay_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Xpay_Impl.hpp
@@ -197,9 +197,9 @@ KOKKOS_INLINE_FUNCTION int SerialXpay::invoke(const alphaViewType& alpha,
                 "KokkosBatched::xpay: ViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<alphaViewType>::value,
                 "KokkosBatched::xpay: alphaViewType is not a Kokkos::View.");
-  static_assert(ViewType::Rank == 2,
+  static_assert(ViewType::rank == 2,
                 "KokkosBatched::xpay: ViewType must have rank 2.");
-  static_assert(alphaViewType::Rank == 1,
+  static_assert(alphaViewType::rank == 1,
                 "KokkosBatched::xpay: alphaViewType must have rank 1.");
 
   // Check compatibility of dimensions at run time.
@@ -240,9 +240,9 @@ KOKKOS_INLINE_FUNCTION int TeamXpay<MemberType>::invoke(
                 "KokkosBatched::xpay: ViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<alphaViewType>::value,
                 "KokkosBatched::xpay: alphaViewType is not a Kokkos::View.");
-  static_assert(ViewType::Rank == 2,
+  static_assert(ViewType::rank == 2,
                 "KokkosBatched::xpay: ViewType must have rank 2.");
-  static_assert(alphaViewType::Rank == 1,
+  static_assert(alphaViewType::rank == 1,
                 "KokkosBatched::xpay: alphaViewType must have rank 1.");
 
   // Check compatibility of dimensions at run time.
@@ -284,9 +284,9 @@ KOKKOS_INLINE_FUNCTION int TeamVectorXpay<MemberType>::invoke(
                 "KokkosBatched::xpay: ViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<alphaViewType>::value,
                 "KokkosBatched::xpay: alphaViewType is not a Kokkos::View.");
-  static_assert(ViewType::Rank == 2,
+  static_assert(ViewType::rank == 2,
                 "KokkosBatched::xpay: ViewType must have rank 2.");
-  static_assert(alphaViewType::Rank == 1,
+  static_assert(alphaViewType::rank == 1,
                 "KokkosBatched::xpay: alphaViewType must have rank 1.");
 
   // Check compatibility of dimensions at run time.

--- a/batched/sparse/impl/KokkosBatched_Spmv_Serial_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_Serial_Impl.hpp
@@ -138,17 +138,17 @@ struct SerialSpmv<Trans::NoTranspose> {
     static_assert(Kokkos::is_view<betaViewType>::value,
                   "KokkosBatched::spmv: betaViewType is not a Kokkos::View.");
 
-    static_assert(ValuesViewType::Rank == 2,
+    static_assert(ValuesViewType::rank == 2,
                   "KokkosBatched::spmv: ValuesViewType must have rank 2.");
-    static_assert(IntView::Rank == 1,
+    static_assert(IntView::rank == 1,
                   "KokkosBatched::spmv: IntView must have rank 2.");
-    static_assert(xViewType::Rank == 2,
+    static_assert(xViewType::rank == 2,
                   "KokkosBatched::spmv: xViewType must have rank 2.");
-    static_assert(yViewType::Rank == 2,
+    static_assert(yViewType::rank == 2,
                   "KokkosBatched::spmv: yViewType must have rank 2.");
-    static_assert(alphaViewType::Rank == 1,
+    static_assert(alphaViewType::rank == 1,
                   "KokkosBatched::spmv: alphaViewType must have rank 1.");
-    static_assert(betaViewType::Rank == 1,
+    static_assert(betaViewType::rank == 1,
                   "KokkosBatched::spmv: betaViewType must have rank 1.");
 
     // Check compatibility of dimensions at run time.
@@ -232,13 +232,13 @@ struct SerialSpmv<Trans::NoTranspose> {
     static_assert(Kokkos::is_view<yViewType>::value,
                   "KokkosBatched::spmv: yViewType is not a Kokkos::View.");
 
-    static_assert(ValuesViewType::Rank == 2,
+    static_assert(ValuesViewType::rank == 2,
                   "KokkosBatched::spmv: ValuesViewType must have rank 2.");
-    static_assert(IntView::Rank == 1,
+    static_assert(IntView::rank == 1,
                   "KokkosBatched::spmv: IntView must have rank 2.");
-    static_assert(xViewType::Rank == 2,
+    static_assert(xViewType::rank == 2,
                   "KokkosBatched::spmv: xViewType must have rank 2.");
-    static_assert(yViewType::Rank == 2,
+    static_assert(yViewType::rank == 2,
                   "KokkosBatched::spmv: yViewType must have rank 2.");
 
     // Check compatibility of dimensions at run time.

--- a/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
@@ -321,21 +321,21 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
     static_assert(Kokkos::is_view<betaViewType>::value,
                   "KokkosBatched::spmv: betaViewType is not a Kokkos::View.");
 
-    static_assert(ValuesViewType::Rank == 2,
+    static_assert(ValuesViewType::rank == 2,
                   "KokkosBatched::spmv: ValuesViewType must have rank 2.");
-    static_assert(IntView::Rank == 1,
+    static_assert(IntView::rank == 1,
                   "KokkosBatched::spmv: IntView must have rank 2.");
-    static_assert(xViewType::Rank == 2,
+    static_assert(xViewType::rank == 2,
                   "KokkosBatched::spmv: xViewType must have rank 2.");
-    static_assert(yViewType::Rank == 2,
+    static_assert(yViewType::rank == 2,
                   "KokkosBatched::spmv: yViewType must have rank 2.");
-    static_assert(alphaViewType::Rank == 1,
+    static_assert(alphaViewType::rank == 1,
                   "KokkosBatched::spmv: alphaViewType must have rank 1.");
-    static_assert(betaViewType::Rank == 1,
+    static_assert(betaViewType::rank == 1,
                   "KokkosBatched::spmv: betaViewType must have rank 1.");
-    static_assert(alphaViewType::Rank == 1,
+    static_assert(alphaViewType::rank == 1,
                   "KokkosBatched::spmv: alphaViewType must have rank 1.");
-    static_assert(betaViewType::Rank == 1,
+    static_assert(betaViewType::rank == 1,
                   "KokkosBatched::spmv: betaViewType must have rank 1.");
 
     // Check compatibility of dimensions at run time.
@@ -420,13 +420,13 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
     static_assert(Kokkos::is_view<yViewType>::value,
                   "KokkosBatched::spmv: yViewType is not a Kokkos::View.");
 
-    static_assert(ValuesViewType::Rank == 2,
+    static_assert(ValuesViewType::rank == 2,
                   "KokkosBatched::spmv: ValuesViewType must have rank 2.");
-    static_assert(IntView::Rank == 1,
+    static_assert(IntView::rank == 1,
                   "KokkosBatched::spmv: IntView must have rank 2.");
-    static_assert(xViewType::Rank == 2,
+    static_assert(xViewType::rank == 2,
                   "KokkosBatched::spmv: xViewType must have rank 2.");
-    static_assert(yViewType::Rank == 2,
+    static_assert(yViewType::rank == 2,
                   "KokkosBatched::spmv: yViewType must have rank 2.");
 
     // Check compatibility of dimensions at run time.

--- a/batched/sparse/impl/KokkosBatched_Spmv_Team_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_Team_Impl.hpp
@@ -176,17 +176,17 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
     static_assert(Kokkos::is_view<betaViewType>::value,
                   "KokkosBatched::spmv: betaViewType is not a Kokkos::View.");
 
-    static_assert(ValuesViewType::Rank == 2,
+    static_assert(ValuesViewType::rank == 2,
                   "KokkosBatched::spmv: ValuesViewType must have rank 2.");
-    static_assert(IntView::Rank == 1,
+    static_assert(IntView::rank == 1,
                   "KokkosBatched::spmv: IntView must have rank 2.");
-    static_assert(xViewType::Rank == 2,
+    static_assert(xViewType::rank == 2,
                   "KokkosBatched::spmv: xViewType must have rank 2.");
-    static_assert(yViewType::Rank == 2,
+    static_assert(yViewType::rank == 2,
                   "KokkosBatched::spmv: yViewType must have rank 2.");
-    static_assert(alphaViewType::Rank == 1,
+    static_assert(alphaViewType::rank == 1,
                   "KokkosBatched::spmv: alphaViewType must have rank 1.");
-    static_assert(betaViewType::Rank == 1,
+    static_assert(betaViewType::rank == 1,
                   "KokkosBatched::spmv: betaViewType must have rank 1.");
 
     // Check compatibility of dimensions at run time.
@@ -271,13 +271,13 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
     static_assert(Kokkos::is_view<yViewType>::value,
                   "KokkosBatched::spmv: yViewType is not a Kokkos::View.");
 
-    static_assert(ValuesViewType::Rank == 2,
+    static_assert(ValuesViewType::rank == 2,
                   "KokkosBatched::spmv: ValuesViewType must have rank 2.");
-    static_assert(IntView::Rank == 1,
+    static_assert(IntView::rank == 1,
                   "KokkosBatched::spmv: IntView must have rank 2.");
-    static_assert(xViewType::Rank == 2,
+    static_assert(xViewType::rank == 2,
                   "KokkosBatched::spmv: xViewType must have rank 2.");
-    static_assert(yViewType::Rank == 2,
+    static_assert(yViewType::rank == 2,
                   "KokkosBatched::spmv: yViewType must have rank 2.");
 
     // Check compatibility of dimensions at run time.

--- a/blas/impl/KokkosBlas1_axpby_impl.hpp
+++ b/blas/impl/KokkosBlas1_axpby_impl.hpp
@@ -75,10 +75,10 @@ struct Axpby_Functor {
                   "KokkosBlas::Impl::Axpby_Functor: Y is const.  "
                   "It must be nonconst, because it is an output argument "
                   "(we have to be able to write to its entries).");
-    static_assert((int)YV::Rank == (int)XV::Rank,
+    static_assert((int)YV::rank == (int)XV::rank,
                   "KokkosBlas::Impl::"
                   "Axpby_Functor: X and Y must have the same rank.");
-    static_assert(YV::Rank == 1,
+    static_assert(YV::rank == 1,
                   "KokkosBlas::Impl::Axpby_Functor: "
                   "XV and YV must have rank 1.");
 
@@ -211,10 +211,10 @@ struct Axpby_Functor<typename XV::non_const_value_type, XV,
                   "KokkosBlas::Impl::Axpby_Functor: R is const.  "
                   "It must be nonconst, because it is an output argument "
                   "(we have to be able to write to its entries).");
-    static_assert((int)YV::Rank == (int)XV::Rank,
+    static_assert((int)YV::rank == (int)XV::rank,
                   "KokkosBlas::Impl::"
                   "Axpby_Functor: X and Y must have the same rank.");
-    static_assert(YV::Rank == 1,
+    static_assert(YV::rank == 1,
                   "KokkosBlas::Impl::Axpby_Functor: "
                   "XV and YV must have rank 1.");
   }
@@ -316,10 +316,10 @@ void Axpby_Generic(const AV& av, const XV& x, const BV& bv, const YV& y,
                 "KokkosBlas::Impl::Axpby_Generic: Y is const.  "
                 "It must be nonconst, because it is an output argument "
                 "(we have to be able to write to its entries).");
-  static_assert((int)YV::Rank == (int)XV::Rank,
+  static_assert((int)YV::rank == (int)XV::rank,
                 "KokkosBlas::Impl::"
                 "Axpby_Generic: X and Y must have the same rank.");
-  static_assert(YV::Rank == 1,
+  static_assert(YV::rank == 1,
                 "KokkosBlas::Impl::Axpby_Generic: "
                 "XV and YV must have rank 1.");
 

--- a/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
+++ b/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
@@ -74,16 +74,16 @@ struct Axpby_MV_Functor {
                   "KokkosBlas::Impl::Axpby_MV_Functor: Y is const.  "
                   "It must be nonconst, because it is an output argument "
                   "(we have to be able to write to its entries).");
-    static_assert((int)YMV::Rank == (int)XMV::Rank,
+    static_assert((int)YMV::rank == (int)XMV::rank,
                   "KokkosBlas::Impl::Axpby_MV_Functor: "
                   "X and Y must have the same rank.");
-    static_assert(YMV::Rank == 2,
+    static_assert(YMV::rank == 2,
                   "KokkosBlas::Impl::Axpby_MV_Functor: "
                   "XMV and YMV must have rank 2.");
-    static_assert(AV::Rank == 1,
+    static_assert(AV::rank == 1,
                   "KokkosBlas::Impl::Axpby_MV_Functor: "
                   "AV must have rank 1.");
-    static_assert(BV::Rank == 1,
+    static_assert(BV::rank == 1,
                   "KokkosBlas::Impl::Axpby_MV_Functor: "
                   "BV must have rank 1.");
   }
@@ -311,10 +311,10 @@ struct Axpby_MV_Functor<typename XMV::non_const_value_type, XMV,
                   "KokkosBlas::Impl::Axpby_MV_Functor: Y is const.  "
                   "It must be nonconst, because it is an output argument "
                   "(we have to be able to write to its entries).");
-    static_assert((int)YMV::Rank == (int)XMV::Rank,
+    static_assert((int)YMV::rank == (int)XMV::rank,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Functor: X and Y must have the same rank.");
-    static_assert(YMV::Rank == 2,
+    static_assert(YMV::rank == 2,
                   "KokkosBlas::Impl::Axpby_MV_Functor: "
                   "XMV and YMV must have rank 2.");
   }
@@ -529,16 +529,16 @@ struct Axpby_MV_Unroll_Functor {
                   "KokkosBlas::Impl::Axpby_MV_Unroll_Functor: Y is const.  "
                   "It must be nonconst, because it is an output argument "
                   "(we have to be able to write to its entries).");
-    static_assert((int)YMV::Rank == (int)XMV::Rank,
+    static_assert((int)YMV::rank == (int)XMV::rank,
                   "KokkosBlas::Impl::Axpby_MV_Unroll_Functor: "
                   "X and Y must have the same rank.");
-    static_assert(YMV::Rank == 2,
+    static_assert(YMV::rank == 2,
                   "KokkosBlas::Impl::Axpby_MV_Unroll_Functor: "
                   "XMV and YMV must have rank 2.");
-    static_assert(AV::Rank == 1,
+    static_assert(AV::rank == 1,
                   "KokkosBlas::Impl::Axpby_MV_Unroll_Functor: "
                   "AV must have rank 1.");
-    static_assert(BV::Rank == 1,
+    static_assert(BV::rank == 1,
                   "KokkosBlas::Impl::Axpby_MV_Unroll_Functor: "
                   "BV must have rank 1.");
 
@@ -753,10 +753,10 @@ struct Axpby_MV_Unroll_Functor<typename XMV::non_const_value_type, XMV,
                   "KokkosBlas::Impl::Axpby_MV_Unroll_Functor: Y is const.  "
                   "It must be nonconst, because it is an output argument "
                   "(we have to be able to write to its entries).");
-    static_assert((int)YMV::Rank == (int)XMV::Rank,
+    static_assert((int)YMV::rank == (int)XMV::rank,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Unroll_Functor: X and Y must have the same rank.");
-    static_assert(YMV::Rank == 2,
+    static_assert(YMV::rank == 2,
                   "KokkosBlas::Impl::Axpby_MV_Unroll_Functor: "
                   "XMV and YMV must have rank 2.");
   }
@@ -965,10 +965,10 @@ void Axpby_MV_Unrolled(const AV& av, const XMV& x, const BV& bv, const YMV& y,
                 "KokkosBlas::Impl::Axpby_MV_Unrolled: Y is const.  "
                 "It must be nonconst, because it is an output argument "
                 "(we have to be able to write to its entries).");
-  static_assert((int)YMV::Rank == (int)XMV::Rank,
+  static_assert((int)YMV::rank == (int)XMV::rank,
                 "KokkosBlas::Impl::"
                 "Axpby_MV_Unrolled: X and Y must have the same rank.");
-  static_assert(YMV::Rank == 2,
+  static_assert(YMV::rank == 2,
                 "KokkosBlas::Impl::Axpby_MV_Unrolled: "
                 "XMV and YMV must have rank 2.");
 
@@ -1120,10 +1120,10 @@ void Axpby_MV_Generic(const AV& av, const XMV& x, const BV& bv, const YMV& y,
                 "KokkosBlas::Impl::Axpby_MV_Generic: Y is const.  "
                 "It must be nonconst, because it is an output argument "
                 "(we have to be able to write to its entries).");
-  static_assert((int)YMV::Rank == (int)XMV::Rank,
+  static_assert((int)YMV::rank == (int)XMV::rank,
                 "KokkosBlas::Impl::"
                 "Axpby_MV_Generic: X and Y must have the same rank.");
-  static_assert(YMV::Rank == 2,
+  static_assert(YMV::rank == 2,
                 "KokkosBlas::Impl::Axpby_MV_Generic: "
                 "XMV and YMV must have rank 2.");
 
@@ -1260,10 +1260,10 @@ struct Axpby_MV_Invoke_Left {
                   "KokkosBlas::Impl::Axpby_MV_Invoke_Left: Y is const.  "
                   "It must be nonconst, because it is an output argument "
                   "(we have to be able to write to its entries).");
-    static_assert((int)YMV::Rank == (int)XMV::Rank,
+    static_assert((int)YMV::rank == (int)XMV::rank,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Invoke_Left: X and Y must have the same rank.");
-    static_assert(YMV::Rank == 2,
+    static_assert(YMV::rank == 2,
                   "KokkosBlas::Impl::Axpby_MV_Invoke_Left: "
                   "X and Y must have rank 2.");
 
@@ -1341,10 +1341,10 @@ struct Axpby_MV_Invoke_Right {
                   "KokkosBlas::Impl::Axpby_MV_Invoke_Right: Y is const.  "
                   "It must be nonconst, because it is an output argument "
                   "(we have to be able to write to its entries).");
-    static_assert((int)YMV::Rank == (int)XMV::Rank,
+    static_assert((int)YMV::rank == (int)XMV::rank,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Invoke_Right: X and Y must have the same rank.");
-    static_assert(YMV::Rank == 2,
+    static_assert(YMV::rank == 2,
                   "KokkosBlas::Impl::Axpby_MV_Invoke_Right: "
                   "X and Y must have rank 2.");
 

--- a/blas/impl/KokkosBlas1_axpby_spec.hpp
+++ b/blas/impl/KokkosBlas1_axpby_spec.hpp
@@ -28,7 +28,7 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class AV, class XMV, class BV, class YMV, int rank = YMV::Rank>
+template <class AV, class XMV, class BV, class YMV, int rank = YMV::rank>
 struct axpby_eti_spec_avail {
   enum : bool { value = false };
 };
@@ -127,7 +127,7 @@ namespace Impl {
 /// Any <i>scalar</i> coefficient of zero has BLAS semantics of
 /// ignoring the corresponding (multi)vector entry.  This does NOT
 /// apply to coefficients in av and bv vectors, if they are used.
-template <class AV, class XMV, class BV, class YMV, int rank = YMV::Rank,
+template <class AV, class XMV, class BV, class YMV, int rank = YMV::rank,
           bool tpl_spec_avail = axpby_tpl_spec_avail<AV, XMV, BV, YMV>::value,
           bool eti_spec_avail = axpby_eti_spec_avail<AV, XMV, BV, YMV>::value>
 struct Axpby {
@@ -138,7 +138,7 @@ template <class AV, class XMV, class BV, class YMV>
 struct Axpby<AV, XMV, BV, YMV, 0, true, true> {
   static void axpby(const AV& /* av */, const XMV& /* X */, const BV& /* bv */,
                     const YMV& /* Y */) {
-    static_assert(YMV::Rank == 0, "Oh My God");
+    static_assert(YMV::rank == 0, "Oh My God");
   }
 };
 
@@ -160,10 +160,10 @@ struct Axpby<AV, XMV, BV, YMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
                   "KokkosBlas::Impl::Axpby<rank-2>::axpby: Y is const.  "
                   "It must be nonconst, because it is an output argument "
                   "(we have to be able to write to its entries).");
-    static_assert((int)YMV::Rank == (int)XMV::Rank,
+    static_assert((int)YMV::rank == (int)XMV::rank,
                   "KokkosBlas::Impl::Axpby<rank-2>::axpby (MV): "
                   "X and Y must have the same rank.");
-    static_assert(YMV::Rank == 2,
+    static_assert(YMV::rank == 2,
                   "KokkosBlas::Impl::Axpby<rank-2>::axpby: "
                   "X and Y must have rank 2.");
     Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
@@ -241,10 +241,10 @@ struct Axpby<typename XMV::non_const_value_type, XMV,
                   "KokkosBlas::Impl::Axpby::axpby (MV): Y is const.  "
                   "It must be nonconst, because it is an output argument "
                   "(we have to be able to write to its entries).");
-    static_assert((int)YMV::Rank == (int)XMV::Rank,
+    static_assert((int)YMV::rank == (int)XMV::rank,
                   "KokkosBlas::Impl::Axpby::axpby (MV): "
                   "X and Y must have the same rank.");
-    static_assert(YMV::Rank == 2,
+    static_assert(YMV::rank == 2,
                   "KokkosBlas::Impl::Axpby::axpby (MV): "
                   "X and Y must have rank 2.");
     Kokkos::Profiling::pushRegion(KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
@@ -342,10 +342,10 @@ struct Axpby<typename XV::non_const_value_type, XV,
                   "KokkosBlas::Impl::Axpby<rank-1>::axpby: Y is const.  "
                   "It must be nonconst, because it is an output argument "
                   "(we have to be able to write to its entries).");
-    static_assert((int)YV::Rank == (int)XV::Rank,
+    static_assert((int)YV::rank == (int)XV::rank,
                   "KokkosBlas::Impl::"
                   "Axpby<rank-1>::axpby: X and Y must have the same rank.");
-    static_assert(YV::Rank == 1,
+    static_assert(YV::rank == 1,
                   "KokkosBlas::Impl::Axpby<rank-1>::axpby: "
                   "X and Y must have rank 1.");
 

--- a/blas/impl/KokkosBlas2_team_gemv_spec.hpp
+++ b/blas/impl/KokkosBlas2_team_gemv_spec.hpp
@@ -61,7 +61,7 @@ struct TeamGemv<MemberType, Trans::NoTranspose, Algo::Gemv::Unblocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType& member, const ScalarType alpha, const AViewType& A,
       const xViewType& x, const ScalarType beta, const yViewType& y) {
-    static_assert(AViewType::Rank == 2,
+    static_assert(AViewType::rank == 2,
                   "KokkosBlas::TeamGemv requires rank-2 A matrix");
     return Impl::TeamGemvInternal<Algo::Gemv::Unblocked>::invoke(
         member, A.extent(0), A.extent(1), alpha, A.data(), A.stride_0(),
@@ -76,7 +76,7 @@ struct TeamGemv<MemberType, Trans::NoTranspose, Algo::Gemv::Blocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType& member, const ScalarType alpha, const AViewType& A,
       const xViewType& x, const ScalarType beta, const yViewType& y) {
-    static_assert(AViewType::Rank == 2,
+    static_assert(AViewType::rank == 2,
                   "KokkosBlas::TeamGemv requires rank-2 A matrix");
     return Impl::TeamGemvInternal<Algo::Gemv::Blocked>::invoke(
         member, A.extent(0), A.extent(1), alpha, A.data(), A.stride_0(),
@@ -95,7 +95,7 @@ struct TeamGemv<MemberType, Trans::Transpose, Algo::Gemv::Unblocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType& member, const ScalarType alpha, const AViewType& A,
       const xViewType& x, const ScalarType beta, const yViewType& y) {
-    static_assert(AViewType::Rank == 2,
+    static_assert(AViewType::rank == 2,
                   "BLAS TeamGemv requires rank-2 A matrix");
     return Impl::TeamGemvInternal<Algo::Gemv::Unblocked>::invoke(
         member, A.extent(1), A.extent(0), alpha, A.data(), A.stride_1(),
@@ -110,7 +110,7 @@ struct TeamGemv<MemberType, Trans::Transpose, Algo::Gemv::Blocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType& member, const ScalarType alpha, const AViewType& A,
       const xViewType& x, const ScalarType beta, const yViewType& y) {
-    static_assert(AViewType::Rank == 2,
+    static_assert(AViewType::rank == 2,
                   "BLAS TeamGemv requires rank-2 A matrix");
     return Impl::TeamGemvInternal<Algo::Gemv::Blocked>::invoke(
         member, A.extent(1), A.extent(0), alpha, A.data(), A.stride_1(),
@@ -129,7 +129,7 @@ struct TeamGemv<MemberType, Trans::ConjTranspose, Algo::Gemv::Unblocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType& member, const ScalarType alpha, const AViewType& A,
       const xViewType& x, const ScalarType beta, const yViewType& y) {
-    static_assert(AViewType::Rank == 2,
+    static_assert(AViewType::rank == 2,
                   "BLAS TeamGemv requires rank-2 A matrix");
     return Impl::TeamGemvInternal<Algo::Gemv::Unblocked>::invoke(
         member, Impl::OpConj{}, A.extent(1), A.extent(0), alpha, A.data(),
@@ -145,7 +145,7 @@ struct TeamGemv<MemberType, Trans::ConjTranspose, Algo::Gemv::Blocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType& member, const ScalarType alpha, const AViewType& A,
       const xViewType& x, const ScalarType beta, const yViewType& y) {
-    static_assert(AViewType::Rank == 2,
+    static_assert(AViewType::rank == 2,
                   "BLAS TeamGemv requires rank-2 A matrix");
     return Impl::TeamGemvInternal<Algo::Gemv::Blocked>::invoke(
         member, Impl::OpConj{}, A.extent(1), A.extent(0), alpha, A.data(),
@@ -165,7 +165,7 @@ struct TeamVectorGemv<MemberType, Trans::NoTranspose, Algo::Gemv::Unblocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType& member, const ScalarType alpha, const AViewType& A,
       const xViewType& x, const ScalarType beta, const yViewType& y) {
-    static_assert(AViewType::Rank == 2,
+    static_assert(AViewType::rank == 2,
                   "Batched TeamVectorGemv requires rank-2 A matrix");
     return Impl::TeamVectorGemvInternal<Algo::Gemv::Unblocked>::invoke(
         member, A.extent(0), A.extent(1), alpha, A.data(), A.stride_0(),
@@ -184,7 +184,7 @@ struct TeamVectorGemv<MemberType, Trans::Transpose, Algo::Gemv::Unblocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType& member, const ScalarType alpha, const AViewType& A,
       const xViewType& x, const ScalarType beta, const yViewType& y) {
-    static_assert(AViewType::Rank == 2,
+    static_assert(AViewType::rank == 2,
                   "Batched TeamVectorGemv requires rank-2 A matrix");
     return Impl::TeamVectorGemvInternal<Algo::Gemv::Unblocked>::invoke(
         member, A.extent(1), A.extent(0), alpha, A.data(), A.stride_1(),
@@ -203,7 +203,7 @@ struct TeamVectorGemv<MemberType, Trans::ConjTranspose, Algo::Gemv::Unblocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType& member, const ScalarType alpha, const AViewType& A,
       const xViewType& x, const ScalarType beta, const yViewType& y) {
-    static_assert(AViewType::Rank == 2,
+    static_assert(AViewType::rank == 2,
                   "Batched TeamVectorGemv requires rank-2 A matrix");
     return Impl::TeamVectorGemvInternal<Algo::Gemv::Unblocked>::invoke(
         member, Impl::OpConj{}, A.extent(1), A.extent(0), alpha, A.data(),

--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -43,10 +43,10 @@ void axpby(const AV& a, const XMV& X, const BV& b, const YMV& Y) {
                 "KokkosBlas::axpby: Y is const.  It must be nonconst, "
                 "because it is an output argument "
                 "(we must be able to write to its entries).");
-  static_assert(int(YMV::Rank) == int(XMV::Rank),
+  static_assert(int(YMV::rank) == int(XMV::rank),
                 "KokkosBlas::axpby: "
                 "X and Y must have the same rank.");
-  static_assert(YMV::Rank == 1 || YMV::Rank == 2,
+  static_assert(YMV::rank == 1 || YMV::rank == 2,
                 "KokkosBlas::axpby: "
                 "XMV and YMV must either have rank 1 or rank 2.");
 
@@ -107,10 +107,10 @@ KOKKOS_FUNCTION void serial_axpy(const scalar_type alpha, const XMV X, YMV Y) {
                 "KokkosBlas::serial_axpy: XMV is not a Kokkos::View");
   static_assert(Kokkos::is_view<YMV>::value,
                 "KokkosBlas::serial_axpy: YMV is not a Kokkos::View");
-  static_assert(XMV::Rank == 1 || XMV::Rank == 2,
+  static_assert(XMV::rank == 1 || XMV::rank == 2,
                 "KokkosBlas::serial_axpy: XMV must have rank 1 or 2.");
   static_assert(
-      XMV::Rank == YMV::Rank,
+      XMV::rank == YMV::rank,
       "KokkosBlas::serial_axpy: XMV and YMV must have the same rank.");
 
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {

--- a/blas/src/KokkosBlas1_nrm2.hpp
+++ b/blas/src/KokkosBlas1_nrm2.hpp
@@ -140,7 +140,7 @@ serial_nrm2(const XMV X) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
   static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::serial_nrm2: XMV is not a Kokkos::View");
-  static_assert(XMV::Rank == 1,
+  static_assert(XMV::rank == 1,
                 "KokkosBlas::serial_nrm2: XMV must have rank 1");
 #endif  // KOKKOSKERNELS_DEBUG_LEVEL
 

--- a/blas/tpls/KokkosBlas1_axpby_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_axpby_tpl_spec_avail.hpp
@@ -20,7 +20,7 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class AV, class XMV, class BV, class YMV, int rank = YMV::Rank>
+template <class AV, class XMV, class BV, class YMV, int rank = YMV::rank>
 struct axpby_tpl_spec_avail {
   enum : bool { value = false };
 };

--- a/blas/tpls/KokkosBlas1_axpby_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_axpby_tpl_spec_decl.hpp
@@ -69,7 +69,7 @@ namespace Impl {
         int one = 1;                                                           \
         HostBlas<double>::axpy(N, alpha, X.data(), one, Y.data(), one);        \
       } else                                                                   \
-        Axpby<AV, XV, BV, YV, YV::Rank, false, ETI_SPEC_AVAIL>::axpby(         \
+        Axpby<AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(         \
             alpha, X, beta, Y);                                                \
       Kokkos::Profiling::popRegion();                                          \
     }                                                                          \
@@ -104,7 +104,7 @@ namespace Impl {
         int one = 1;                                                          \
         HostBlas<float>::axpy(N, alpha, X.data(), one, Y.data(), one);        \
       } else                                                                  \
-        Axpby<AV, XV, BV, YV, YV::Rank, false, ETI_SPEC_AVAIL>::axpby(        \
+        Axpby<AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(        \
             alpha, X, beta, Y);                                               \
       Kokkos::Profiling::popRegion();                                         \
     }                                                                         \
@@ -146,7 +146,7 @@ namespace Impl {
             reinterpret_cast<const std::complex<double>*>(X.data()), one, \
             reinterpret_cast<std::complex<double>*>(Y.data()), one);      \
       } else                                                              \
-        Axpby<AV, XV, BV, YV, YV::Rank, false, ETI_SPEC_AVAIL>::axpby(    \
+        Axpby<AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(    \
             alpha, X, beta, Y);                                           \
       Kokkos::Profiling::popRegion();                                     \
     }                                                                     \
@@ -188,7 +188,7 @@ namespace Impl {
             reinterpret_cast<const std::complex<float>*>(X.data()), one, \
             reinterpret_cast<std::complex<float>*>(Y.data()), one);      \
       } else                                                             \
-        Axpby<AV, XV, BV, YV, YV::Rank, false, ETI_SPEC_AVAIL>::axpby(   \
+        Axpby<AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(   \
             alpha, X, beta, Y);                                          \
       Kokkos::Profiling::popRegion();                                    \
     }                                                                    \
@@ -255,7 +255,7 @@ namespace Impl {
             KokkosBlas::Impl::CudaBlasSingleton::singleton();                  \
         cublasDaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one);        \
       } else                                                                   \
-        Axpby<AV, XV, BV, YV, YV::Rank, false, ETI_SPEC_AVAIL>::axpby(         \
+        Axpby<AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(         \
             alpha, X, beta, Y);                                                \
       Kokkos::Profiling::popRegion();                                          \
     }                                                                          \
@@ -294,7 +294,7 @@ namespace Impl {
             KokkosBlas::Impl::CudaBlasSingleton::singleton();                 \
         cublasSaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one);       \
       } else                                                                  \
-        Axpby<AV, XV, BV, YV, YV::Rank, false, ETI_SPEC_AVAIL>::axpby(        \
+        Axpby<AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(        \
             alpha, X, beta, Y);                                               \
       Kokkos::Profiling::popRegion();                                         \
     }                                                                         \
@@ -339,7 +339,7 @@ namespace Impl {
                     reinterpret_cast<const cuDoubleComplex*>(X.data()), one, \
                     reinterpret_cast<cuDoubleComplex*>(Y.data()), one);      \
       } else                                                                 \
-        Axpby<AV, XV, BV, YV, YV::Rank, false, ETI_SPEC_AVAIL>::axpby(       \
+        Axpby<AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(       \
             alpha, X, beta, Y);                                              \
       Kokkos::Profiling::popRegion();                                        \
     }                                                                        \
@@ -383,7 +383,7 @@ namespace Impl {
                     reinterpret_cast<const cuComplex*>(X.data()), one,       \
                     reinterpret_cast<cuComplex*>(Y.data()), one);            \
       } else                                                                 \
-        Axpby<AV, XV, BV, YV, YV::Rank, false, ETI_SPEC_AVAIL>::axpby(       \
+        Axpby<AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(       \
             alpha, X, beta, Y);                                              \
       Kokkos::Profiling::popRegion();                                        \
     }                                                                        \

--- a/blas/tpls/KokkosBlas1_dot_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_dot_tpl_spec_avail.hpp
@@ -20,8 +20,8 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class AV, class XMV, class YMV, int Xrank = XMV::Rank,
-          int Yrank = YMV::Rank>
+template <class AV, class XMV, class YMV, int Xrank = XMV::rank,
+          int Yrank = YMV::rank>
 struct dot_tpl_spec_avail {
   enum : bool { value = false };
 };

--- a/blas/tpls/KokkosBlas1_iamax_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_iamax_tpl_spec_avail.hpp
@@ -20,7 +20,7 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class RV, class XMV, int Xrank = XMV::Rank>
+template <class RV, class XMV, int Xrank = XMV::rank>
 struct iamax_tpl_spec_avail {
   enum : bool { value = false };
 };

--- a/blas/tpls/KokkosBlas1_nrm1_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_nrm1_tpl_spec_avail.hpp
@@ -20,7 +20,7 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class AV, class XMV, int Xrank = XMV::Rank>
+template <class AV, class XMV, int Xrank = XMV::rank>
 struct nrm1_tpl_spec_avail {
   enum : bool { value = false };
 };

--- a/blas/tpls/KokkosBlas1_nrm2_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_nrm2_tpl_spec_avail.hpp
@@ -20,7 +20,7 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class AV, class XMV, int Xrank = XMV::Rank>
+template <class AV, class XMV, int Xrank = XMV::rank>
 struct nrm2_tpl_spec_avail {
   enum : bool { value = false };
 };

--- a/blas/tpls/KokkosBlas1_nrminf_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_nrminf_tpl_spec_avail.hpp
@@ -20,7 +20,7 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class AV, class XMV, int Xrank = XMV::Rank>
+template <class AV, class XMV, int Xrank = XMV::rank>
 struct nrminf_tpl_spec_avail {
   enum : bool { value = false };
 };

--- a/blas/tpls/KokkosBlas1_scal_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_scal_tpl_spec_avail.hpp
@@ -20,7 +20,7 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class RV, class AV, class XV, int Xrank = XV::Rank>
+template <class RV, class AV, class XV, int Xrank = XV::rank>
 struct scal_tpl_spec_avail {
   enum : bool { value = false };
 };


### PR DESCRIPTION
`View::Rank` is not documented and may get deprecated (see kokkos/kokkos#5870)
To be on the safe side, avoid using it.