### PR TITLE
Add utility KokkosSparse::removeCrsMatrixZeros(A, tol)

### DIFF
--- a/sparse/src/KokkosSparse_Utils.hpp
+++ b/sparse/src/KokkosSparse_Utils.hpp
@@ -2298,6 +2298,7 @@ Matrix removeCrsMatrixZeros(
                           typename Matrix::row_map_type::non_const_type,
                           Ordinal>(A.graph.row_map, compactFilteredRowmap,
                                    filteredRowmap));
+  ExecSpace().fence();
   return Matrix("A filtered", A.numRows(), A.numCols(), filteredNNZ,
                 filteredValues, filteredRowmap, filteredEntries);
 }

--- a/sparse/src/KokkosSparse_Utils.hpp
+++ b/sparse/src/KokkosSparse_Utils.hpp
@@ -24,6 +24,7 @@
 #include "KokkosKernels_PrintUtils.hpp"
 #include "KokkosSparse_CrsMatrix.hpp"
 #include "KokkosSparse_BsrMatrix.hpp"
+#include "Kokkos_Bitset.hpp"
 
 #ifdef KOKKOSKERNELS_HAVE_PARALLEL_GNUSORT
 #include <parallel/algorithm>

--- a/sparse/unit_test/Test_Sparse.hpp
+++ b/sparse/unit_test/Test_Sparse.hpp
@@ -41,6 +41,7 @@
 #include "Test_Sparse_TestUtils_RandCsMat.hpp"
 #include "Test_Sparse_ccs2crs.hpp"
 #include "Test_Sparse_crs2ccs.hpp"
+#include "Test_Sparse_removeCrsMatrixZeros.hpp"
 
 // TPL specific tests, these require
 // particular pairs of backend and TPL

--- a/sparse/unit_test/Test_Sparse_Utils.hpp
+++ b/sparse/unit_test/Test_Sparse_Utils.hpp
@@ -18,6 +18,7 @@
 #define TEST_SPARSE_UTILS_HPP
 
 #include "KokkosSparse_spmv.hpp"
+#include "KokkosSparse_SortCrs.hpp"
 
 namespace Test {
 
@@ -37,6 +38,103 @@ vector_t create_random_y_vector_mv(crsMat_t crsMat, vector_t x_vector) {
   return y_vector;
 }
 
+template <typename crsMat_t, typename device>
+bool is_same_matrix(crsMat_t output_mat_actual, crsMat_t output_mat_reference) {
+  typedef typename crsMat_t::StaticCrsGraphType graph_t;
+  typedef typename graph_t::row_map_type::non_const_type lno_view_t;
+  typedef typename graph_t::entries_type::non_const_type lno_nnz_view_t;
+  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
+
+  size_t nrows_actual    = output_mat_actual.numRows();
+  size_t ncols_actual    = output_mat_actual.numCols();
+  size_t nentries_actual = output_mat_actual.graph.entries.extent(0);
+  size_t nvals_actual    = output_mat_actual.values.extent(0);
+
+  size_t nrows_reference    = output_mat_reference.numRows();
+  size_t ncols_reference    = output_mat_reference.numCols();
+  size_t nentries_reference = output_mat_reference.graph.entries.extent(0);
+  size_t nvals_reference    = output_mat_reference.values.extent(0);
+
+  if (nrows_actual != nrows_reference || ncols_actual != ncols_reference) {
+    std::cout << "dimensions (actual):" << nrows_actual << 'x' << ncols_actual
+              << ", dimensions (reference): " << nrows_reference << 'x'
+              << ncols_reference << '\n';
+    return false;
+  }
+  if (nentries_actual != nentries_reference) {
+    std::cout << "nentries_actual:" << nentries_actual
+              << " nentries_reference:" << nentries_reference << std::endl;
+    return false;
+  }
+  if (nvals_actual != nvals_reference) {
+    std::cout << "nvals_actual:" << nvals_actual
+              << " nvals_reference:" << nvals_reference << std::endl;
+    return false;
+  }
+
+  bool is_identical = true;
+  // Special case: a matrix with 0 rows can have a rowmap of length 0 or 1.
+  // Treat these as equivalent.
+  bool zero_row_equivalent = false;
+  if (nrows_reference == 0) {
+    auto rm1 = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), output_mat_actual.graph.row_map);
+    auto rm2 = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), output_mat_reference.graph.row_map);
+    if (rm1.extent_int(0) == 0 && rm2.extent_int(0) == 1) {
+      // Make sure the one element of rm2 is 0
+      zero_row_equivalent = !rm2(0);
+    } else if (rm1.extent_int(0) == 1 && rm2.extent_int(0) == 0) {
+      // Make sure the one element of rm1 is 0
+      zero_row_equivalent = !rm1(0);
+    }
+  }
+  if (!zero_row_equivalent) {
+    is_identical = KokkosKernels::Impl::kk_is_identical_view<
+        typename graph_t::row_map_type, typename graph_t::row_map_type,
+        typename lno_view_t::value_type, typename device::execution_space>(
+        output_mat_actual.graph.row_map, output_mat_reference.graph.row_map, 0);
+  }
+
+  if (!is_identical) {
+    std::cout << "rowmaps are different." << std::endl;
+    std::cout << "Actual rowmap:\n";
+    KokkosKernels::Impl::kk_print_1Dview(output_mat_actual.graph.row_map, true);
+    std::cout << "Correct rowmap:\n";
+    KokkosKernels::Impl::kk_print_1Dview(output_mat_reference.graph.row_map,
+                                         true);
+    return false;
+  }
+
+  is_identical = KokkosKernels::Impl::kk_is_identical_view<
+      lno_nnz_view_t, lno_nnz_view_t, typename lno_nnz_view_t::value_type,
+      typename device::execution_space>(output_mat_actual.graph.entries,
+                                        output_mat_reference.graph.entries, 0);
+
+  if (!is_identical) {
+    std::cout << "entries are different." << std::endl;
+    KokkosKernels::Impl::kk_print_1Dview(output_mat_actual.graph.entries);
+    KokkosKernels::Impl::kk_print_1Dview(output_mat_reference.graph.entries);
+    return false;
+  }
+
+  typedef typename Kokkos::Details::ArithTraits<
+      typename scalar_view_t::non_const_value_type>::mag_type eps_type;
+  eps_type eps = std::is_same<eps_type, float>::value ? 3.7e-3 : 1e-7;
+
+  is_identical = KokkosKernels::Impl::kk_is_relatively_identical_view<
+      scalar_view_t, scalar_view_t, eps_type, typename device::execution_space>(
+      output_mat_actual.values, output_mat_reference.values, eps);
+
+  if (!is_identical) {
+    std::cout << "values are different." << std::endl;
+    KokkosKernels::Impl::kk_print_1Dview(output_mat_actual.values);
+    KokkosKernels::Impl::kk_print_1Dview(output_mat_reference.values);
+
+    return false;
+  }
+  return true;
+}
 }  // namespace Test
 
 #endif  // TEST_SPARSE_UTILS_HPP

--- a/sparse/unit_test/Test_Sparse_removeCrsMatrixZeros.hpp
+++ b/sparse/unit_test/Test_Sparse_removeCrsMatrixZeros.hpp
@@ -1,0 +1,193 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+/// \file Test_Sparse_SortCrs.hpp
+/// \brief Tests for sort_crs_matrix and sort_crs_graph in
+/// KokkosSparse_SortCrs.hpp
+
+#ifndef KOKKOSSPARSE_REMOVECRSZEROS_HPP
+#define KOKKOSSPARSE_REMOVECRSZEROS_HPP
+
+#include <Kokkos_Core.hpp>
+#include <KokkosSparse_CrsMatrix.hpp>
+#include <KokkosSparse_Utils.hpp>
+#include <Kokkos_ArithTraits.hpp>
+
+namespace TestRemoveCrsMatrixZeros {
+
+// Simple, sequential implementation of zero-removal to compare against
+template <typename Matrix>
+Matrix removeMatrixZerosReference(const Matrix& A) {
+  using Offset  = typename Matrix::non_const_size_type;
+  using Ordinal = typename Matrix::ordinal_type;
+  using Scalar  = typename Matrix::value_type;
+  using KAT     = Kokkos::ArithTraits<Scalar>;
+  auto rowmapHost =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A.graph.row_map);
+  auto entriesHost =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A.graph.entries);
+  auto valuesHost =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A.values);
+  // First, create the filtered rowmap (the CrsMatrix constructor taking host
+  // pointers does expect rowmap to be in Ordinal)
+  std::vector<Ordinal> filteredRowmap;
+  Offset filteredNNZ = 0;
+  for (Ordinal i = 0; i <= A.numRows(); i++) {
+    filteredRowmap.push_back(filteredNNZ);
+    if (i == A.numRows()) break;
+    for (Offset j = rowmapHost(i); j < rowmapHost(i + 1); j++) {
+      if (valuesHost(j) != KAT::zero()) {
+        filteredNNZ++;
+      }
+    }
+  }
+  // Then allocate and fill in the filtered entries and values
+  std::vector<Ordinal> filteredEntries;
+  std::vector<Scalar> filteredValues;
+  for (Offset i = 0; i < A.nnz(); i++) {
+    if (valuesHost(i) != KAT::zero()) {
+      filteredEntries.push_back(entriesHost(i));
+      filteredValues.push_back(valuesHost(i));
+    }
+  }
+  // Copy all the views back to device and construct matrix
+  return Matrix("A filtered", A.numRows(), A.numCols(), filteredNNZ,
+                filteredValues.data(), filteredRowmap.data(),
+                filteredEntries.data());
+}
+
+template <typename Matrix>
+Matrix loadMatrixFromVectors(int numRows, int numCols,
+                             const std::vector<int>& rowmapRawInt,
+                             const std::vector<int>& entriesRawInt,
+                             const std::vector<double>& valuesRawDouble) {
+  using Offset  = typename Matrix::non_const_size_type;
+  using Ordinal = typename Matrix::ordinal_type;
+  using Scalar  = typename Matrix::value_type;
+  // The CrsMatrix constructor taking host pointers expects rowmap to be in
+  // Ordinal
+  std::vector<Ordinal> rowmapRaw;
+  std::vector<Ordinal> entriesRaw;
+  std::vector<Scalar> valuesRaw;
+  for (auto val : rowmapRawInt) rowmapRaw.push_back(val);
+  for (auto val : entriesRawInt) entriesRaw.push_back(val);
+  for (auto val : valuesRawDouble) valuesRaw.push_back(Scalar(val));
+  Offset nnz = rowmapRaw.size() ? rowmapRaw[numRows] : 0;
+  return Matrix("A", numRows, numCols, nnz, valuesRaw.data(), rowmapRaw.data(),
+                entriesRaw.data());
+}
+
+template <typename Matrix>
+Matrix getTestInput(int test) {
+  using Offset = typename Matrix::size_type;
+  switch (test) {
+    case 0: {
+      // No entries, but nonzero dimensions.
+      std::vector<int> rowmap = {0, 0, 0, 0, 0};
+      std::vector<int> entries;
+      std::vector<double> values;
+      return loadMatrixFromVectors<Matrix>(4, 4, rowmap, entries, values);
+    }
+    case 1: {
+      // Some empty rows, and some zero values
+      std::vector<int> rowmap    = {0, 0, 3, 3, 5};
+      std::vector<int> entries   = {0, 1, 3, 1, 2};
+      std::vector<double> values = {1, 3, 0, 0, 2};
+      return loadMatrixFromVectors<Matrix>(4, 4, rowmap, entries, values);
+    }
+    case 2: {
+      // Zero-row matrix, length-0 rowmap
+      typename Matrix::row_map_type rowmap;
+      typename Matrix::index_type entries;
+      typename Matrix::values_type values;
+      return Matrix("A empty", 0, 0, 0, values, rowmap, entries);
+    }
+    case 3: {
+      // Zero-row matrix, length-1 rowmap
+      std::vector<int> rowmap = {0};
+      std::vector<int> entries;
+      std::vector<double> values;
+      return loadMatrixFromVectors<Matrix>(0, 0, rowmap, entries, values);
+    }
+    case 4: {
+      // A row of all zeros that will be filtered
+      std::vector<int> rowmap    = {0, 3, 6};
+      std::vector<int> entries   = {0, 1, 2, 3, 4, 5};
+      std::vector<double> values = {0, 0, 0, 1, 1, 1};
+      return loadMatrixFromVectors<Matrix>(2, 6, rowmap, entries, values);
+    }
+    case 5: {
+      // One zero in each row that will be filtered
+      std::vector<int> rowmap    = {0, 2, 4, 7};
+      std::vector<int> entries   = {0, 1, 1, 2, 0, 1, 2};
+      std::vector<double> values = {0, 1, 1, 0, 0, 3, -3};
+      return loadMatrixFromVectors<Matrix>(3, 3, rowmap, entries, values);
+    }
+    case 6: {
+      // First and last rows empty
+      std::vector<int> rowmap    = {0, 0, 2, 2};
+      std::vector<int> entries   = {0, 1};
+      std::vector<double> values = {0, 3.14};
+      return loadMatrixFromVectors<Matrix>(3, 2, rowmap, entries, values);
+    }
+    case 7: {
+      // First and last rows nonempty, but will be empty after filtering
+      std::vector<int> rowmap    = {0, 2, 4, 6};
+      std::vector<int> entries   = {0, 1, 1, 2, 0, 3};
+      std::vector<double> values = {0, 0, 1, -1, 0, 0};
+      return loadMatrixFromVectors<Matrix>(3, 4, rowmap, entries, values);
+    }
+    case 8: {
+      // Large, random matrix with 30% of values converted to zero
+      Offset nnz = 40 * 10000;
+      Matrix A   = KokkosSparse::Impl::kk_generate_sparse_matrix<Matrix>(
+          10000, 10000, nnz, 10, 5000);
+      auto valuesHost = Kokkos::create_mirror_view(A.values);
+      Kokkos::deep_copy(valuesHost, A.values);
+      for (Offset i = 0; i < A.nnz(); i++) {
+        if (rand() % 10 < 3) valuesHost(i) = 0.0;
+      }
+      Kokkos::deep_copy(A.values, valuesHost);
+      return A;
+    }
+  }
+  throw std::invalid_argument("Test case number of out bounds");
+}
+
+}  // namespace TestRemoveCrsMatrixZeros
+
+void testRemoveCrsMatrixZeros(int testCase) {
+  using namespace TestRemoveCrsMatrixZeros;
+  using Device =
+      Kokkos::Device<TestExecSpace, typename TestExecSpace::memory_space>;
+  using Matrix = KokkosSparse::CrsMatrix<default_scalar, default_lno_t, Device,
+                                         void, default_size_type>;
+  Matrix A     = getTestInput<Matrix>(testCase);
+  Matrix Afiltered_actual = KokkosSparse::removeCrsMatrixZeros(A);
+  Matrix Afiltered_ref    = removeMatrixZerosReference(A);
+  bool matches =
+      Test::is_same_matrix<Matrix, Device>(Afiltered_actual, Afiltered_ref);
+  EXPECT_TRUE(matches)
+      << "Test case " << testCase
+      << ": matrix with zeros filtered out does not match reference.";
+}
+
+TEST_F(TestCategory, sparse_remove_crs_zeros) {
+  for (int testCase = 0; testCase < 9; testCase++)
+    testRemoveCrsMatrixZeros(testCase);
+}
+
+#endif  // KOKKOSSPARSE_REMOVECRSZEROS_HPP

--- a/sparse/unit_test/Test_Sparse_removeCrsMatrixZeros.hpp
+++ b/sparse/unit_test/Test_Sparse_removeCrsMatrixZeros.hpp
@@ -43,16 +43,15 @@ Matrix removeMatrixZerosReference(const Matrix& A) {
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A.values);
   // First, create the filtered rowmap (the CrsMatrix constructor taking host
   // pointers does expect rowmap to be in Ordinal)
-  std::vector<Ordinal> filteredRowmap;
-  Offset filteredNNZ = 0;
-  for (Ordinal i = 0; i <= A.numRows(); i++) {
-    filteredRowmap.push_back(filteredNNZ);
-    if (i == A.numRows()) break;
+  Ordinal filteredNNZ                 = 0;
+  std::vector<Ordinal> filteredRowmap = {0};  // first row begins at 0
+  for (Ordinal i = 0; i < A.numRows(); i++) {
     for (Offset j = rowmapHost(i); j < rowmapHost(i + 1); j++) {
       if (valuesHost(j) != KAT::zero()) {
         filteredNNZ++;
       }
     }
+    filteredRowmap.push_back(filteredNNZ);
   }
   // Then allocate and fill in the filtered entries and values
   std::vector<Ordinal> filteredEntries;
@@ -91,80 +90,146 @@ Matrix loadMatrixFromVectors(int numRows, int numCols,
 }
 
 template <typename Matrix>
-Matrix getTestInput(int test) {
+void getTestInput(int test, Matrix& A, Matrix& Afiltered_ref) {
   using Offset = typename Matrix::size_type;
+  using Device =
+      Kokkos::Device<TestExecSpace, typename TestExecSpace::memory_space>;
+  bool haveHardcodedReference = true;
   switch (test) {
     case 0: {
       // No entries, but nonzero dimensions.
       std::vector<int> rowmap = {0, 0, 0, 0, 0};
       std::vector<int> entries;
       std::vector<double> values;
-      return loadMatrixFromVectors<Matrix>(4, 4, rowmap, entries, values);
+      A = loadMatrixFromVectors<Matrix>(4, 4, rowmap, entries, values);
+      Afiltered_ref =
+          loadMatrixFromVectors<Matrix>(4, 4, rowmap, entries, values);
+      break;
     }
     case 1: {
       // Some empty rows, and some zero values
       std::vector<int> rowmap    = {0, 0, 3, 3, 5};
       std::vector<int> entries   = {0, 1, 3, 1, 2};
       std::vector<double> values = {1, 3, 0, 0, 2};
-      return loadMatrixFromVectors<Matrix>(4, 4, rowmap, entries, values);
+      A = loadMatrixFromVectors<Matrix>(4, 4, rowmap, entries, values);
+      std::vector<int> rowmapFilt    = {0, 0, 2, 2, 3};
+      std::vector<int> entriesFilt   = {0, 1, 2};
+      std::vector<double> valuesFilt = {1, 3, 2};
+      Afiltered_ref = loadMatrixFromVectors<Matrix>(4, 4, rowmapFilt,
+                                                    entriesFilt, valuesFilt);
+      break;
     }
     case 2: {
       // Zero-row matrix, length-0 rowmap
       typename Matrix::row_map_type rowmap;
       typename Matrix::index_type entries;
       typename Matrix::values_type values;
-      return Matrix("A empty", 0, 0, 0, values, rowmap, entries);
+      A             = Matrix("A empty", 0, 0, 0, values, rowmap, entries);
+      Afiltered_ref = A;
+      break;
     }
     case 3: {
       // Zero-row matrix, length-1 rowmap
       std::vector<int> rowmap = {0};
       std::vector<int> entries;
       std::vector<double> values;
-      return loadMatrixFromVectors<Matrix>(0, 0, rowmap, entries, values);
+      A = loadMatrixFromVectors<Matrix>(0, 0, rowmap, entries, values);
+      Afiltered_ref = A;
+      break;
     }
     case 4: {
       // A row of all zeros that will be filtered
       std::vector<int> rowmap    = {0, 3, 6};
       std::vector<int> entries   = {0, 1, 2, 3, 4, 5};
       std::vector<double> values = {0, 0, 0, 1, 1, 1};
-      return loadMatrixFromVectors<Matrix>(2, 6, rowmap, entries, values);
+      A = loadMatrixFromVectors<Matrix>(2, 6, rowmap, entries, values);
+      std::vector<int> rowmapFilt    = {0, 0, 3};
+      std::vector<int> entriesFilt   = {3, 4, 5};
+      std::vector<double> valuesFilt = {1, 1, 1};
+      Afiltered_ref = loadMatrixFromVectors<Matrix>(2, 6, rowmapFilt,
+                                                    entriesFilt, valuesFilt);
+      break;
     }
     case 5: {
       // One zero in each row that will be filtered
       std::vector<int> rowmap    = {0, 2, 4, 7};
       std::vector<int> entries   = {0, 1, 1, 2, 0, 1, 2};
       std::vector<double> values = {0, 1, 1, 0, 0, 3, -3};
-      return loadMatrixFromVectors<Matrix>(3, 3, rowmap, entries, values);
+      A = loadMatrixFromVectors<Matrix>(3, 3, rowmap, entries, values);
+      std::vector<int> rowmapFilt    = {0, 1, 2, 4};
+      std::vector<int> entriesFilt   = {1, 1, 1, 2};
+      std::vector<double> valuesFilt = {1, 1, 3, -3};
+      Afiltered_ref = loadMatrixFromVectors<Matrix>(3, 3, rowmapFilt,
+                                                    entriesFilt, valuesFilt);
+      break;
     }
     case 6: {
       // First and last rows empty
       std::vector<int> rowmap    = {0, 0, 2, 2};
       std::vector<int> entries   = {0, 1};
       std::vector<double> values = {0, 3.14};
-      return loadMatrixFromVectors<Matrix>(3, 2, rowmap, entries, values);
+      A = loadMatrixFromVectors<Matrix>(3, 2, rowmap, entries, values);
+      std::vector<int> rowmapFilt    = {0, 0, 1, 1};
+      std::vector<int> entriesFilt   = {1};
+      std::vector<double> valuesFilt = {3.14};
+      Afiltered_ref = loadMatrixFromVectors<Matrix>(3, 2, rowmapFilt,
+                                                    entriesFilt, valuesFilt);
+      break;
     }
     case 7: {
       // First and last rows nonempty, but will be empty after filtering
       std::vector<int> rowmap    = {0, 2, 4, 6};
       std::vector<int> entries   = {0, 1, 1, 2, 0, 3};
       std::vector<double> values = {0, 0, 1, -1, 0, 0};
-      return loadMatrixFromVectors<Matrix>(3, 4, rowmap, entries, values);
+      A = loadMatrixFromVectors<Matrix>(3, 4, rowmap, entries, values);
+      std::vector<int> rowmapFilt    = {0, 0, 2, 2};
+      std::vector<int> entriesFilt   = {1, 2};
+      std::vector<double> valuesFilt = {1, -1};
+      Afiltered_ref = loadMatrixFromVectors<Matrix>(3, 4, rowmapFilt,
+                                                    entriesFilt, valuesFilt);
+      break;
     }
     case 8: {
       // Large, random matrix with 30% of values converted to zero
       Offset nnz = 40 * 10000;
-      Matrix A   = KokkosSparse::Impl::kk_generate_sparse_matrix<Matrix>(
-          10000, 10000, nnz, 10, 5000);
+      A = KokkosSparse::Impl::kk_generate_sparse_matrix<Matrix>(10000, 10000,
+                                                                nnz, 10, 5000);
       auto valuesHost = Kokkos::create_mirror_view(A.values);
       Kokkos::deep_copy(valuesHost, A.values);
       for (Offset i = 0; i < A.nnz(); i++) {
         if (rand() % 10 < 3) valuesHost(i) = 0.0;
       }
       Kokkos::deep_copy(A.values, valuesHost);
-      return A;
+      Afiltered_ref          = removeMatrixZerosReference(A);
+      haveHardcodedReference = false;
+      break;
     }
+    case 9: {
+      // Large, sparser random matrix with 99% of values converted to zero
+      Offset nnz = 10 * 40000;
+      A = KokkosSparse::Impl::kk_generate_sparse_matrix<Matrix>(40000, 40000,
+                                                                nnz, 10, 10000);
+      auto valuesHost = Kokkos::create_mirror_view(A.values);
+      Kokkos::deep_copy(valuesHost, A.values);
+      for (Offset i = 0; i < A.nnz(); i++) {
+        if (rand() % 100 != 99) valuesHost(i) = 0.0;
+      }
+      Kokkos::deep_copy(A.values, valuesHost);
+      Afiltered_ref          = removeMatrixZerosReference(A);
+      haveHardcodedReference = false;
+      break;
+    }
+    default: throw std::invalid_argument("Test case number of out bounds");
   }
-  throw std::invalid_argument("Test case number of out bounds");
+  // If we have a hardcoded reference, check that the reference impl is correct
+  // on this case
+  if (haveHardcodedReference) {
+    Matrix Afiltered_refimpl = removeMatrixZerosReference(A);
+    bool referenceImplMatchesHardcoded =
+        Test::is_same_matrix<Matrix, Device>(Afiltered_ref, Afiltered_refimpl);
+    ASSERT_TRUE(referenceImplMatchesHardcoded)
+        << "Test case " << test << ": reference impl gave wrong answer!";
+  }
 }
 
 }  // namespace TestRemoveCrsMatrixZeros
@@ -175,9 +240,9 @@ void testRemoveCrsMatrixZeros(int testCase) {
       Kokkos::Device<TestExecSpace, typename TestExecSpace::memory_space>;
   using Matrix = KokkosSparse::CrsMatrix<default_scalar, default_lno_t, Device,
                                          void, default_size_type>;
-  Matrix A     = getTestInput<Matrix>(testCase);
+  Matrix A, Afiltered_ref;
+  getTestInput<Matrix>(testCase, A, Afiltered_ref);
   Matrix Afiltered_actual = KokkosSparse::removeCrsMatrixZeros(A);
-  Matrix Afiltered_ref    = removeMatrixZerosReference(A);
   bool matches =
       Test::is_same_matrix<Matrix, Device>(Afiltered_actual, Afiltered_ref);
   EXPECT_TRUE(matches)
@@ -186,7 +251,7 @@ void testRemoveCrsMatrixZeros(int testCase) {
 }
 
 TEST_F(TestCategory, sparse_remove_crs_zeros) {
-  for (int testCase = 0; testCase < 9; testCase++)
+  for (int testCase = 0; testCase < 10; testCase++)
     testRemoveCrsMatrixZeros(testCase);
 }
 

--- a/sparse/unit_test/Test_Sparse_spgemm.hpp
+++ b/sparse/unit_test/Test_Sparse_spgemm.hpp
@@ -19,6 +19,8 @@
 
 #include "KokkosSparse_Utils.hpp"
 #include "KokkosSparse_SortCrs.hpp"
+// For Test::is_same_matrix
+#include "Test_Sparse_Utils.hpp"
 #include <string>
 #include <stdexcept>
 
@@ -187,86 +189,6 @@ int run_spgemm_old_interface(crsMat_t A, crsMat_t B,
   }
   kh.destroy_spgemm_handle();
   return 0;
-}
-
-template <typename crsMat_t, typename device>
-bool is_same_matrix(crsMat_t output_mat_actual, crsMat_t output_mat_reference) {
-  typedef typename crsMat_t::StaticCrsGraphType graph_t;
-  typedef typename graph_t::row_map_type::non_const_type lno_view_t;
-  typedef typename graph_t::entries_type::non_const_type lno_nnz_view_t;
-  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
-
-  size_t nrows_actual    = output_mat_actual.numRows();
-  size_t nentries_actual = output_mat_actual.graph.entries.extent(0);
-  size_t nvals_actual    = output_mat_actual.values.extent(0);
-
-  size_t nrows_reference    = output_mat_reference.numRows();
-  size_t nentries_reference = output_mat_reference.graph.entries.extent(0);
-  size_t nvals_reference    = output_mat_reference.values.extent(0);
-
-  if (nrows_actual != nrows_reference) {
-    std::cout << "nrows_actual:" << nrows_actual
-              << " nrows_reference:" << nrows_reference << std::endl;
-    return false;
-  }
-  if (nentries_actual != nentries_reference) {
-    std::cout << "nentries_actual:" << nentries_actual
-              << " nentries_reference:" << nentries_reference << std::endl;
-    return false;
-  }
-  if (nvals_actual != nvals_reference) {
-    std::cout << "nvals_actual:" << nvals_actual
-              << " nvals_reference:" << nvals_reference << std::endl;
-    return false;
-  }
-
-  // Do not sort the actual product matrix - test that it's already sorted
-  KokkosSparse::sort_crs_matrix(output_mat_reference);
-
-  bool is_identical = true;
-  is_identical      = KokkosKernels::Impl::kk_is_identical_view<
-      typename graph_t::row_map_type, typename graph_t::row_map_type,
-      typename lno_view_t::value_type, typename device::execution_space>(
-      output_mat_actual.graph.row_map, output_mat_reference.graph.row_map, 0);
-
-  if (!is_identical) {
-    std::cout << "rowmaps are different." << std::endl;
-    std::cout << "Actual rowmap:\n";
-    KokkosKernels::Impl::kk_print_1Dview(output_mat_actual.graph.row_map, true);
-    std::cout << "Correct rowmap (SPGEMM_DEBUG):\n";
-    KokkosKernels::Impl::kk_print_1Dview(output_mat_reference.graph.row_map,
-                                         true);
-    return false;
-  }
-
-  is_identical = KokkosKernels::Impl::kk_is_identical_view<
-      lno_nnz_view_t, lno_nnz_view_t, typename lno_nnz_view_t::value_type,
-      typename device::execution_space>(output_mat_actual.graph.entries,
-                                        output_mat_reference.graph.entries, 0);
-
-  if (!is_identical) {
-    std::cout << "entries are different." << std::endl;
-    KokkosKernels::Impl::kk_print_1Dview(output_mat_actual.graph.entries);
-    KokkosKernels::Impl::kk_print_1Dview(output_mat_reference.graph.entries);
-    return false;
-  }
-
-  typedef typename Kokkos::Details::ArithTraits<
-      typename scalar_view_t::non_const_value_type>::mag_type eps_type;
-  eps_type eps = std::is_same<eps_type, float>::value ? 3.7e-3 : 1e-7;
-
-  is_identical = KokkosKernels::Impl::kk_is_relatively_identical_view<
-      scalar_view_t, scalar_view_t, eps_type, typename device::execution_space>(
-      output_mat_actual.values, output_mat_reference.values, eps);
-
-  if (!is_identical) {
-    std::cout << "values are different." << std::endl;
-    KokkosKernels::Impl::kk_print_1Dview(output_mat_actual.values);
-    KokkosKernels::Impl::kk_print_1Dview(output_mat_reference.values);
-
-    return false;
-  }
-  return true;
 }
 }  // namespace Test
 


### PR DESCRIPTION
And testing for it. It removes explicit zeros (or, entries where $|A_{ij}| \leq tol$) - tol defaults to 0 - from a matrix and returns a new matrix. If A has no entries to remove, A is returned unchanged. It does not change the matrix dimensions or the order of non-removed entries within rows.

Also move the test helper function ``is_same_matrix`` from Test_Sparse_spgemm.hpp to Test_Sparse_Utils.hpp, since I needed it for this test (and probably other tests could use it too).