### PR TITLE
sparse: Add coo2crs, crs2coo and CooMatrix

### DIFF
--- a/docs/developer/apidocs/sparse.rst
+++ b/docs/developer/apidocs/sparse.rst
@@ -29,7 +29,7 @@ ccs2crs
 coo2crs
 -------
 .. doxygenfunction:: KokkosSparse::coo2crs(DimType, DimType, RowViewType, ColViewType, DataViewType)
-.. doxygenfunction:: KokkosSparse::coo2crs(KokkosSparse::CooMatrix<RowViewType, ColViewType, DataViewType, DeviceType> &cooMatrix)
+.. doxygenfunction:: KokkosSparse::coo2crs(KokkosSparse::CooMatrix<ScalarType, OrdinalType, DeviceType, MemoryTraitsType, SizeType> &cooMatrix)
 
 crs2coo
 -------

--- a/docs/developer/apidocs/sparse.rst
+++ b/docs/developer/apidocs/sparse.rst
@@ -11,6 +11,11 @@ ccsmatrix
 .. doxygenclass::    KokkosSparse::CcsMatrix
     :members:
 
+coomatrix
+---------
+.. doxygenclass::    KokkosSparse::CooMatrix
+    :members:
+
 crs2ccs
 -------
 .. doxygenfunction:: KokkosSparse::crs2ccs(OrdinalType nrows, OrdinalType ncols, SizeType nnz, ValViewType vals, RowMapViewType row_map, ColIdViewType col_ids)
@@ -20,6 +25,16 @@ ccs2crs
 -------
 .. doxygenfunction:: KokkosSparse::ccs2crs(OrdinalType nrows, OrdinalType ncols, SizeType nnz, ValViewType vals, ColMapViewType col_map, RowIdViewType row_ids)
 .. doxygenfunction:: KokkosSparse::ccs2crs(KokkosSparse::CcsMatrix<ScalarType, OrdinalType, DeviceType, MemoryTraitsType, SizeType> &ccsMatrix)
+
+coo2crs
+-------
+.. doxygenfunction:: KokkosSparse::coo2crs(DimType, DimType, RowViewType, ColViewType, DataViewType)
+.. doxygenfunction:: KokkosSparse::coo2crs(KokkosSparse::CooMatrix<RowViewType, ColViewType, DataViewType, DeviceType> &cooMatrix)
+
+crs2coo
+-------
+.. doxygenfunction:: KokkosSparse::crs2coo(OrdinalType, OrdinalType, SizeType, ValViewType, RowMapViewType, ColIdViewType)
+.. doxygenfunction:: KokkosSparse::crs2coo(KokkosSparse::CrsMatrix<ScalarType, OrdinalType, DeviceType, MemoryTraitsType, SizeType> &crsMatrix)
 
 spmv
 ----

--- a/graph/impl/KokkosGraph_Distance2MIS_impl.hpp
+++ b/graph/impl/KokkosGraph_Distance2MIS_impl.hpp
@@ -829,6 +829,7 @@ struct D2_MIS_FixedPriority {
                          InitWorklistFunctor(worklist1));
     lno_t workRemain = numVerts;
     int numIter      = 0;
+    (void)numIter;
     while (workRemain) {
       // do another iteration
       Kokkos::parallel_for(

--- a/graph/impl/KokkosGraph_Distance2MIS_impl.hpp
+++ b/graph/impl/KokkosGraph_Distance2MIS_impl.hpp
@@ -828,8 +828,6 @@ struct D2_MIS_FixedPriority {
     Kokkos::parallel_for(range_pol(0, numVerts),
                          InitWorklistFunctor(worklist1));
     lno_t workRemain = numVerts;
-    int numIter      = 0;
-    (void)numIter;
     while (workRemain) {
       // do another iteration
       Kokkos::parallel_for(
@@ -854,7 +852,6 @@ struct D2_MIS_FixedPriority {
       // Finally, flip the worklists
       std::swap(worklist1, worklist2);
       workRemain = newWorkRemain;
-      numIter++;
     }
     // now that every vertex has been decided IN_SET/OUT_SET,
     // build a compact list of the vertices which are IN_SET.

--- a/sparse/src/KokkosSparse_CooMatrix.hpp
+++ b/sparse/src/KokkosSparse_CooMatrix.hpp
@@ -1,0 +1,129 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+/// \file KokkosSparse_CooMatrix.hpp
+/// \brief Local sparse matrix interface
+///
+/// This file provides KokkosSparse::CooMatrix.  This implements a
+/// local (no MPI) sparse matrix stored in coordinate ("Coo") format
+/// which is also known as ivj or triplet format.
+
+#ifndef KOKKOS_SPARSE_COOMATRIX_HPP_
+#define KOKKOS_SPARSE_COOMATRIX_HPP_
+
+#include "Kokkos_Core.hpp"
+#include "KokkosKernels_Error.hpp"
+#include <sstream>
+#include <stdexcept>
+
+namespace KokkosSparse {
+/// \class CooMatrix
+///
+/// \brief Coordinate format implementation of a sparse matrix.
+///
+/// \tparam RowView    The type of row index view.
+/// \tparam ColumnView The type of column index view.
+/// \tparam DataView   The type of data view.
+/// \tparam Device     The Kokkos Device type.
+/// \tparam MemoryTraits Traits describing how Kokkos manages and
+///   accesses data.  The default parameter suffices for most users.
+///
+/// "Coo" stands for "coordinate format".
+template <class RowView, class ColumnView, class DataView, class Device>
+class CooMatrix {
+ public:
+  using execution_space   = typename Device::execution_space;
+  using memory_space      = typename Device::memory_space;
+  using data_type         = typename DataView::non_const_value_type;
+  using const_data_type   = typename DataView::const_value_type;
+  using row_type          = typename RowView::non_const_value_type;
+  using const_row_type    = typename RowView::const_value_type;
+  using column_type       = typename ColumnView::non_const_value_type;
+  using const_column_type = typename ColumnView::const_value_type;
+  using size_type         = size_t;
+
+  static_assert(std::is_integral_v<row_type>,
+                "RowView::value_type must be an integral.");
+  static_assert(std::is_integral_v<column_type>,
+                "ColumnView::value_type must be an integral.");
+
+ private:
+  size_type m_num_rows, m_num_cols;
+
+ public:
+  RowView row;
+  ColumnView col;
+  DataView data;
+
+  /// \brief Default constructor; constructs an empty sparse matrix.
+  KOKKOS_INLINE_FUNCTION
+  CooMatrix() : m_num_rows(0), m_num_cols(0) {}
+
+  // clang-format off
+  /// \brief Constructor that accepts a column indicies view, row indices view, and
+  ///        values view.
+  ///
+  /// The matrix will store and use the column indices, rows indices, and values
+  /// directly (by view, not by deep copy).
+  ///
+  /// \param nrows   [in] The number of rows.
+  /// \param ncols   [in] The number of columns.
+  /// \param row_in  [in] The row indexes.
+  /// \param col_in  [in] The column indexes.
+  /// \param data_in [in] The values.
+  // clang-format on
+  CooMatrix(size_type nrows, size_type ncols, RowView row_in, ColumnView col_in,
+            DataView data_in)
+      : m_num_rows(nrows),
+        m_num_cols(ncols),
+        row(row_in),
+        col(col_in),
+        data(data_in) {
+    if (data.extent(0) != row.extent(0) || row.extent(0) != col.extent(0)) {
+      std::ostringstream os;
+      os << "data.extent(0): " << data.extent(0) << " != "
+         << "row.extent(0): " << row.extent(0) << " != "
+         << "col.extent(0): " << col.extent(0) << ".";
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
+  }
+
+  //! The number of columns in the sparse matrix.
+  KOKKOS_INLINE_FUNCTION size_type numCols() const { return m_num_cols; }
+
+  //! The number of rows in the sparse matrix.
+  KOKKOS_INLINE_FUNCTION size_type numRows() const { return m_num_rows; }
+
+  //! The number of stored entries in the sparse matrix, including zeros.
+  KOKKOS_INLINE_FUNCTION size_type nnz() const {
+    assert(data.extent(0) == row.extent(0) == col.extent(0) &&
+           "Error lengths of RowView != ColView != DataView");
+    return data.extent(0);
+  }
+};
+
+/// \class is_coo_matrix
+/// \brief is_coo_matrix<T>::value is true if T is a CooMatrix<...>, false
+/// otherwise
+template <typename>
+struct is_coo_matrix : public std::false_type {};
+template <typename... P>
+struct is_coo_matrix<CooMatrix<P...>> : public std::true_type {};
+template <typename... P>
+struct is_coo_matrix<const CooMatrix<P...>> : public std::true_type {};
+
+}  // namespace KokkosSparse
+#endif

--- a/sparse/src/KokkosSparse_CooMatrix.hpp
+++ b/sparse/src/KokkosSparse_CooMatrix.hpp
@@ -91,15 +91,11 @@ class CooMatrix {
 
  private:
   size_type m_num_rows, m_num_cols;
+  row_view m_row;
+  column_view m_col;
+  scalar_view m_data;
 
  public:
-  //! The row indexes of the matrix
-  row_view row;
-  //! The column indexes of the matrix
-  column_view col;
-  //! The scalar values of the matrix
-  scalar_view data;
-
   /// \brief Default constructor; constructs an empty sparse matrix.
   KOKKOS_INLINE_FUNCTION
   CooMatrix() : m_num_rows(0), m_num_cols(0) {}
@@ -121,14 +117,15 @@ class CooMatrix {
             column_view col_in, scalar_view data_in)
       : m_num_rows(nrows),
         m_num_cols(ncols),
-        row(row_in),
-        col(col_in),
-        data(data_in) {
-    if (data.extent(0) != row.extent(0) || row.extent(0) != col.extent(0)) {
+        m_row(row_in),
+        m_col(col_in),
+        m_data(data_in) {
+    if (m_data.extent(0) != m_row.extent(0) ||
+        m_row.extent(0) != m_col.extent(0)) {
       std::ostringstream os;
-      os << "data.extent(0): " << data.extent(0) << " != "
-         << "row.extent(0): " << row.extent(0) << " != "
-         << "col.extent(0): " << col.extent(0) << ".";
+      os << "data.extent(0): " << m_data.extent(0) << " != "
+         << "row.extent(0): " << m_row.extent(0) << " != "
+         << "col.extent(0): " << m_col.extent(0) << ".";
       KokkosKernels::Impl::throw_runtime_exception(os.str());
     }
   }
@@ -140,7 +137,16 @@ class CooMatrix {
   KOKKOS_INLINE_FUNCTION size_type numRows() const { return m_num_rows; }
 
   //! The number of stored entries in the sparse matrix, including zeros.
-  KOKKOS_INLINE_FUNCTION size_type nnz() const { return data.extent(0); }
+  KOKKOS_INLINE_FUNCTION size_type nnz() const { return m_data.extent(0); }
+
+  //! The row indexes of the matrix
+  KOKKOS_INLINE_FUNCTION row_view row() const { return m_row; }
+
+  //! The column indexes of the matrix
+  KOKKOS_INLINE_FUNCTION column_view col() const { return m_col; }
+
+  //! The scalar values of the matrix
+  KOKKOS_INLINE_FUNCTION scalar_view data() const { return m_data; }
 };
 
 /// \class is_coo_matrix

--- a/sparse/src/KokkosSparse_CooMatrix.hpp
+++ b/sparse/src/KokkosSparse_CooMatrix.hpp
@@ -76,13 +76,16 @@ class CooMatrix {
   static_assert(std::is_integral_v<OrdinalType>,
                 "OrdinalType must be an integral.");
 
+  //! The type of the row index view in the matrix
   using row_view =
       Kokkos::View<row_type*, Kokkos::LayoutRight, device_type, memory_traits>;
+  //! The type of the column index view in the matrix
   using column_view = Kokkos::View<column_type*, Kokkos::LayoutRight,
                                    device_type, memory_traits>;
+  //! The type of the scalar values view in the matrix
   using scalar_view = Kokkos::View<scalar_type*, Kokkos::LayoutRight,
                                    device_type, memory_traits>;
-
+  //! The type of a constant CooMatrix
   using const_type = CooMatrix<const_scalar_type, const_ordinal_type,
                                device_type, memory_traits, size_type>;
 

--- a/sparse/src/KokkosSparse_ccs2crs.hpp
+++ b/sparse/src/KokkosSparse_ccs2crs.hpp
@@ -115,7 +115,7 @@ auto ccs2crs(OrdinalType nrows, OrdinalType ncols, SizeType nnz,
 ///
 /// \tparam ScalarType   The ccsMatrix::scalar_type
 /// \tparam OrdinalType  The ccsMatrix::ordinal_type
-/// \tparam Device       The ccsMatrix::device_type
+/// \tparam DeviceType   The ccsMatrix::device_type
 /// \tparam MemoryTraits The ccsMatrix::memory_traits
 /// \tparam SizeType     The ccsMatrix::size_type
 /// \param ccsMatrix The KokkosSparse::CcsMatrix.

--- a/sparse/src/KokkosSparse_coo2crs.hpp
+++ b/sparse/src/KokkosSparse_coo2crs.hpp
@@ -1,0 +1,344 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "KokkosSparse_CooMatrix.hpp"
+#include "KokkosSparse_CrsMatrix.hpp"
+#include "KokkosKernels_Utils.hpp"
+#include "Kokkos_UnorderedMap.hpp"
+#include <Kokkos_StdAlgorithms.hpp>
+
+#ifndef _KOKKOSSPARSE_COO2CRS_HPP
+#define _KOKKOSSPARSE_COO2CRS_HPP
+namespace KokkosSparse {
+namespace Impl {
+template <class DimType, class RowViewType, class ColViewType,
+          class DataViewType, bool InsertMode = false>
+class Coo2Crs {
+ private:
+  using RowViewScalarType  = typename RowViewType::value_type;
+  using ColViewScalarType  = typename ColViewType::value_type;
+  using DataViewScalarType = typename DataViewType::value_type;
+  using CrsST              = DataViewScalarType;
+  using CrsOT              = RowViewScalarType;
+  using CrsET              = typename DataViewType::execution_space;
+  using CrsMT              = void;
+  using CrsSzT             = ColViewScalarType;
+  using CrsType            = CrsMatrix<CrsST, CrsOT, CrsET, CrsMT, CrsSzT>;
+  using CrsValsViewType    = typename CrsType::values_type;
+  using CrsRowMapViewType  = typename CrsType::row_map_type::non_const_type;
+  using CrsColIdViewType   = typename CrsType::index_type;
+
+  using UmapValueViewType = Kokkos::View<CrsST *, CrsET>;
+  using UmapOpTypes =
+      Kokkos::UnorderedMapInsertOpTypes<UmapValueViewType, CrsOT>;
+  using UmapOpType = typename UmapOpTypes::AtomicAdd;
+
+  // Make public for Kokkos::View
+ public:
+  using UmapHasherType  = typename Kokkos::pod_hash<CrsOT>;
+  using UmapEqualToType = typename Kokkos::pod_equal_to<CrsOT>;
+  using UmapType = Kokkos::UnorderedMap<CrsOT, CrsST, CrsET, UmapHasherType,
+                                        UmapEqualToType>;
+
+  // Public for kokkos policies
+  struct coo2crsRp1 {};
+  struct rowmapRp1 {};
+  struct copyTp1 {};
+  struct copyRp1 {};
+
+  using copyTp1Pt         = Kokkos::TeamPolicy<copyTp1, CrsET>;
+  using copyTp1MemberType = typename copyTp1Pt::member_type;
+
+ private:
+  using BmapViewType = Kokkos::View<bool *, CrsET>;
+
+  using CrsRowMapView = Kokkos::View<CrsOT *, CrsET>;
+  using CrsRowMapAtomicView =
+      Kokkos::View<CrsOT *, CrsET, Kokkos::MemoryTraits<Kokkos::Atomic>>;
+  using CrsValuesView = Kokkos::View<CrsST *, CrsET>;
+  using CrsColIdsView = Kokkos::View<CrsSzT *, CrsET>;
+
+  CrsRowMapView m_crs_row_map;
+  CrsRowMapAtomicView m_crs_row_map_tmp;
+  CrsValuesView m_crs_vals;
+  CrsColIdsView m_crs_col_ids;
+  UmapType *m_umaps;
+  BmapViewType m_capacity_bmap;
+  BmapViewType m_tuple_bmap;
+  UmapOpType m_insert_op;
+  CrsOT m_nrows;
+  CrsOT m_ncols;
+  RowViewType m_row;
+  ColViewType m_col;
+  DataViewType m_data;
+  CrsSzT m_nnz;
+
+  int m_n_tuples;
+
+ public:
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const coo2crsRp1 &, const int &idx) const {
+    auto i           = m_row(idx);
+    auto j           = m_col(idx);
+    auto is_inserted = m_tuple_bmap(idx);
+
+    if (i >= m_nrows || j >= m_ncols) {
+      Kokkos::abort("tuple is out of bounds");
+    } else if (!is_inserted && i >= 0 && j >= 0) {
+      if (m_umaps[i].insert(j, m_data(idx), m_insert_op).failed()) {
+        m_capacity_bmap(i) = true;  // hmap at index i reached capacity
+      } else {
+        m_tuple_bmap(idx) = true;  // checklist of inserted tuples
+      }
+    }
+  }
+
+  // TODO: umap.size cannot be called in a kernel.
+  // Requires updating Kokkos::BitSet::count() to be
+  // a host device function.
+  /* KOKKOS_INLINE_FUNCTION
+  void operator()(const rowmapRp1 &, const int &row_idx) const {
+    auto i = row_idx - 1;
+    m_crs_row_map(row_idx) = m_crs_row_map(i) + m_umaps[i].ptr->size();
+  } */
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const copyRp1 &, const int &i) const {
+#if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
+#pragma unroll
+#endif  // KOKKOS_ENABLE_PRAGMA_UN
+    for (int j = 0; j < m_ncols; j++) {
+      if (m_umaps[i].exists(j)) {
+        auto umap_idx         = m_umaps[i].find(j);
+        auto offset           = m_crs_row_map_tmp(i)++;
+        m_crs_vals(offset)    = m_umaps[i].value_at(umap_idx);
+        m_crs_col_ids(offset) = m_umaps[i].key_at(umap_idx);
+      }
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const copyTp1 &, const copyTp1MemberType &member) const {
+    auto row_idx = member.league_rank();
+    auto cpy_beg = m_crs_row_map(row_idx);
+    auto cpy_end = m_crs_row_map(row_idx + 1);
+    auto cpy_len = cpy_end - cpy_beg;
+
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, cpy_len),
+                         [&](const int &i) {
+                           auto offset           = i + cpy_beg;
+                           m_crs_vals(offset)    = m_umaps[i].value_at(i);
+                           m_crs_col_ids(offset) = m_umaps[i].key_at(i);
+                         });
+  }
+
+  Coo2Crs(DimType m, DimType n, RowViewType row, ColViewType col,
+          DataViewType data) {
+    m_n_tuples = data.extent(0);
+    m_nrows    = m;
+    m_ncols    = n;
+    m_row      = row;
+    m_col      = col;
+    m_data     = data;
+
+    typename UmapType::size_type arg_capacity_hint = m_n_tuples / m_nrows / 4;
+    typename UmapType::hasher_type arg_hasher;
+    typename UmapType::equal_to_type arg_equal_to;
+    arg_capacity_hint = arg_capacity_hint < 16 ? 16 : arg_capacity_hint;
+
+    m_capacity_bmap = BmapViewType("m_capacity_bmap", m_nrows);
+    typename BmapViewType::HostMirror m_capacity_bmap_mirror =
+        Kokkos::create_mirror_view(m_capacity_bmap);
+    m_tuple_bmap = BmapViewType("m_tuple_bmap", m_n_tuples);
+
+    m_crs_row_map = CrsRowMapView(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing, "m_crs_row_map"),
+        m_nrows + 1);
+
+    // Memory management notes for `umap_ptrs` and `m_umaps`:
+    //   `umap_ptrs` is a two dimensional array. The first dimension contains
+    //   pointers to mixed-memory (host and device memory). The second
+    //   dimension is the array of UnorderedMap objects. Some of the object
+    //   methods are callable from only the device (device-callable), others
+    //   are callable from only the host. Some of the host-callable methods,
+    //   such as rehash are intended to be observable on the device.
+    //   See Kokkos::UnorderedMap for details.
+    //
+    //   `m_umaps` is a single dimension array of device memory. This array
+    //   contains a shallow copy of all the UnorderedMap members that are
+    //   allocated manually below.
+    //
+    //   Any time a host-callable method with device observable results is
+    //   invoked, we must shallow-copy the given `umap_ptrs` member back to
+    //   the device.
+    //
+    //   However, since we are using shallow copies of objects of type
+    //   UnorderedMap, we do not need to copy the device memory back to
+    //   the host before using a host-callable method.
+
+    // Setup a nrows length array of Unordered Maps
+    m_umaps = reinterpret_cast<UmapType *>(
+        Kokkos::kokkos_malloc("m_umaps", m_nrows * sizeof(UmapType)));
+
+    using shallow_copy_to_device =
+        Kokkos::Impl::DeepCopy<typename UmapType::device_type::memory_space,
+                               typename Kokkos::HostSpace>;
+
+    UmapType **umap_ptrs = new UmapType *[m_nrows];
+
+    // TODO: use host-level parallel_for with tag rowmapRp1
+    for (int i = 0; i < m_nrows; i++) {
+      umap_ptrs[i] = new UmapType(arg_capacity_hint, arg_hasher, arg_equal_to);
+      shallow_copy_to_device(m_umaps + i, umap_ptrs[i], sizeof(UmapType));
+    }
+
+    using coo2crsRp1Pt = Kokkos::RangePolicy<coo2crsRp1, CrsET>;
+    bool rehashed      = true;
+    while (rehashed) {
+      Kokkos::parallel_for("coo2crsRp1", coo2crsRp1Pt(0, m_n_tuples), *this);
+
+      CrsET().fence();  // Wait for bitmap writes to land
+      Kokkos::deep_copy(m_capacity_bmap_mirror, m_capacity_bmap);
+      CrsET().fence();
+
+      rehashed = false;
+      // TODO: covert to host-level parallel for.
+      for (int i = 0; i < m_nrows; i++) {
+        if (m_capacity_bmap_mirror(i)) {
+          umap_ptrs[i]->rehash(umap_ptrs[i]->capacity() * 2);
+          rehashed                  = true;
+          m_capacity_bmap_mirror(i) = false;
+          shallow_copy_to_device(m_umaps + i, umap_ptrs[i], sizeof(UmapType));
+        }
+      }
+      Kokkos::deep_copy(m_capacity_bmap, m_capacity_bmap_mirror);
+      CrsET().fence();
+    }
+
+    typename CrsRowMapView::HostMirror m_crs_row_map_h =
+        Kokkos::create_mirror_view(m_crs_row_map);
+
+    // TODO: convert to host-level parallel_for / prefix sum
+    m_crs_row_map_h(0) = 0;
+    for (int i = 1; i < m_nrows + 1; i++) {
+      auto adj_i         = i - 1;
+      auto sz            = umap_ptrs[adj_i]->size();
+      m_crs_row_map_h(i) = m_crs_row_map_h(adj_i) + sz;
+    }
+
+    m_crs_row_map_tmp = CrsRowMapAtomicView(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing, "m_crs_row_map_tmp"),
+        m_nrows + 1);
+    Kokkos::deep_copy(m_crs_row_map, m_crs_row_map_h);
+    Kokkos::deep_copy(m_crs_row_map_tmp, m_crs_row_map_h);
+    CrsET().fence();
+
+    m_nnz = m_crs_row_map_h(m_nrows);
+
+    m_crs_vals = CrsValuesView(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing, "m_crs_vals"), m_nnz);
+    m_crs_col_ids = CrsColIdsView(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing, "m_crs_col_ids"),
+        m_nnz);
+
+    using copyRp1Pt = Kokkos::RangePolicy<copyRp1, CrsET>;
+    Kokkos::parallel_for("copyRp1", copyRp1Pt(0, m_nrows), *this);
+    CrsET().fence();
+
+    // Cleanup
+    for (int i = 0; i < m_nrows; i++) {
+      delete umap_ptrs[i];
+    }
+    delete[] umap_ptrs;
+    Kokkos::kokkos_free(m_umaps);
+  }
+
+  CrsType get_crsMat() {
+    return CrsType("coo2crs", m_nrows, m_ncols, m_nnz, m_crs_vals,
+                   m_crs_row_map, m_crs_col_ids);
+  }
+};
+}  // namespace Impl
+
+// clang-format off
+///
+/// \brief Blocking function that converts a CooMatrix into a CrsMatrix. Values are summed.
+/// \tparam DimType the dimension type
+/// \tparam RowViewType The row array view type
+/// \tparam ColViewType The column array view type
+/// \tparam DataViewType The data array view type
+/// \param m the number of rows
+/// \param n the number of columns
+/// \param row the array of row ids
+/// \param col the array of col ids
+/// \param data the array of data
+/// \return A KokkosSparse::CrsMatrix.
+// clang-format on
+template <class DimType, class RowViewType, class ColViewType,
+          class DataViewType>
+auto coo2crs(DimType m, DimType n, RowViewType row, ColViewType col,
+             DataViewType data) {
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+  static_assert(Kokkos::is_view<RowViewType>::value,
+                "RowViewType must be a Kokkos::View.");
+  static_assert(Kokkos::is_view<ColViewType>::value,
+                "CalViewType must be a Kokkos::View.");
+  static_assert(Kokkos::is_view<DataViewType>::value,
+                "DataViewType must be a Kokkos::View.");
+  static_assert(static_cast<int>(RowViewType::rank) == 1,
+                "RowViewType must have rank 1.");
+  static_assert(static_cast<int>(ColViewType::rank) == 1,
+                "ColViewType must have rank 1.");
+  static_assert(static_cast<int>(DataViewType::rank) == 1,
+                "DataViewType must have rank 1.");
+#endif
+
+  static_assert(std::is_integral<typename RowViewType::value_type>::value,
+                "RowViewType::value_type must be an integral.");
+  static_assert(std::is_integral<typename ColViewType::value_type>::value,
+                "ColViewType::value_type must be an integral.");
+
+  if (row.extent(0) != col.extent(0) || row.extent(0) != data.extent(0))
+    Kokkos::abort("row.extent(0) = col.extent(0) = data.extent(0) required.");
+
+  if (m <= 0 || n <= 0) Kokkos::abort("m > 0 and n > 0 required.");
+
+  using Coo2crsType =
+      Impl::Coo2Crs<DimType, RowViewType, ColViewType, DataViewType, true>;
+  Coo2crsType Coo2Crs(m, n, row, col, data);
+  return Coo2Crs.get_crsMat();
+}
+
+// clang-format off
+///
+/// \brief Blocking function that converts a CooMatrix into a CrsMatrix. Values are summed.
+/// \tparam DimType      The dimension type
+/// \tparam RowViewType  The row array view type
+/// \tparam ColViewType  The column array view type
+/// \tparam DataViewType The data array view type
+/// \tparam DeviceType   The cooMatrix::execution_space
+/// \param cooMatrix     The sparse matrix stored in coordinate ("Coo") format.
+/// \return A KokkosSparse::CrsMatrix.
+// clang-format on
+template <class DimType, class RowViewType, class ColViewType,
+          class DataViewType, class DeviceType>
+auto coo2crs(KokkosSparse::CooMatrix<RowViewType, ColViewType, DataViewType,
+                                     DeviceType> &cooMatrix) {
+  return coo2crs(cooMatrix.numRows(), cooMatrix.numCols(), cooMatrix.row,
+                 cooMatrix.col, cooMatrix.data);
+}
+}  // namespace KokkosSparse
+#endif  //  _KOKKOSSPARSE_COO2CRS_HPP

--- a/sparse/src/KokkosSparse_coo2crs.hpp
+++ b/sparse/src/KokkosSparse_coo2crs.hpp
@@ -71,8 +71,9 @@ class Coo2Crs {
   using CrsColIdsView = Kokkos::View<CrsSzT *, CrsET>;
 
   // Needed since Kokkos::Bitset cannot be accessed on the host
-  using BmapViewType = Kokkos::View<bool *, CrsET>;
-  using Bitset       = Kokkos::Bitset<CrsET>;
+  using BmapViewType =
+      Kokkos::View<bool *, CrsET, Kokkos::MemoryTraits<Kokkos::RandomAccess>>;
+  using Bitset = Kokkos::Bitset<CrsET>;
 
   CrsRowMapView m_crs_row_map;
   CrsRowMapAtomicView m_crs_row_map_tmp;

--- a/sparse/src/KokkosSparse_coo2crs.hpp
+++ b/sparse/src/KokkosSparse_coo2crs.hpp
@@ -325,18 +325,17 @@ auto coo2crs(DimType m, DimType n, RowViewType row, ColViewType col,
 // clang-format off
 ///
 /// \brief Blocking function that converts a CooMatrix into a CrsMatrix. Values are summed.
-/// \tparam DimType      The dimension type
-/// \tparam RowViewType  The row array view type
-/// \tparam ColViewType  The column array view type
-/// \tparam DataViewType The data array view type
-/// \tparam DeviceType   The cooMatrix::execution_space
+/// \tparam ScalarType   The `KokkosSparse::CooMatrix::scalar_type`
+/// \tparam OrdinalType  The KokkosSparse::CooMatrix::ordinal_type
+/// \tparam DeviceType   The KokkosSparse::CooMatrix::device_type
+/// \tparam MemoryTraits The KokkosSparse::CooMatrix::memory_traits
+/// \tparam SizeType     The KokkosSparse::CooMatrix::size_type
 /// \param cooMatrix     The sparse matrix stored in coordinate ("Coo") format.
 /// \return A KokkosSparse::CrsMatrix.
-// clang-format on
-template <class DimType, class RowViewType, class ColViewType,
-          class DataViewType, class DeviceType>
-auto coo2crs(KokkosSparse::CooMatrix<RowViewType, ColViewType, DataViewType,
-                                     DeviceType> &cooMatrix) {
+template <typename ScalarType, typename OrdinalType, class DeviceType,
+          class MemoryTraitsType, typename SizeType>
+auto coo2crs(KokkosSparse::CooMatrix<ScalarType, OrdinalType, DeviceType,
+                                     MemoryTraitsType, SizeType> &cooMatrix) {
   return coo2crs(cooMatrix.numRows(), cooMatrix.numCols(), cooMatrix.row,
                  cooMatrix.col, cooMatrix.data);
 }

--- a/sparse/src/KokkosSparse_coo2crs.hpp
+++ b/sparse/src/KokkosSparse_coo2crs.hpp
@@ -321,7 +321,9 @@ auto coo2crs(DimType m, DimType n, RowViewType row, ColViewType col,
   if (row.extent(0) != col.extent(0) || row.extent(0) != data.extent(0))
     Kokkos::abort("row.extent(0) = col.extent(0) = data.extent(0) required.");
 
-  if (m < 0 || n < 0) Kokkos::abort("m >= 0 and n >= 0 required.");
+  if constexpr (std::is_signed_v<DimType>) {
+    if (m < 0 || n < 0) Kokkos::abort("m >= 0 and n >= 0 required.");
+  }
 
   using Coo2crsType =
       Impl::Coo2Crs<DimType, RowViewType, ColViewType, DataViewType, true>;

--- a/sparse/src/KokkosSparse_coo2crs.hpp
+++ b/sparse/src/KokkosSparse_coo2crs.hpp
@@ -110,15 +110,6 @@ class Coo2Crs {
     }
   }
 
-  // TODO: umap.size cannot be called in a kernel.
-  // Requires updating Kokkos::BitSet::count() to be
-  // a host device function.
-  /* KOKKOS_INLINE_FUNCTION
-  void operator()(const rowmapRp1 &, const int &row_idx) const {
-    auto i = row_idx - 1;
-    m_crs_row_map(row_idx) = m_crs_row_map(i) + m_umaps[i].ptr->size();
-  } */
-
   KOKKOS_INLINE_FUNCTION
   void operator()(const copyRp1 &, const int &i) const {
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)

--- a/sparse/src/KokkosSparse_crs2ccs.hpp
+++ b/sparse/src/KokkosSparse_crs2ccs.hpp
@@ -113,7 +113,7 @@ auto crs2ccs(OrdinalType nrows, OrdinalType ncols, SizeType nnz,
 ///
 /// \tparam ScalarType   The crsMatrix::scalar_type
 /// \tparam OrdinalType  The crsMatrix::ordinal_type
-/// \tparam Device       The crsMatrix::device_type
+/// \tparam DeviceType   The crsMatrix::device_type
 /// \tparam MemoryTraits The crsMatrix::memory_traits
 /// \tparam SizeType     The crsMatrix::size_type
 /// \param crsMatrix The KokkosSparse::CrsMatrix.

--- a/sparse/src/KokkosSparse_crs2coo.hpp
+++ b/sparse/src/KokkosSparse_crs2coo.hpp
@@ -99,7 +99,7 @@ class Crs2Coo {
     auto row_end   = row_start + row_len;
 
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, row_start, row_end),
-                         [&](const int &id) {
+                         [&](const size_type &id) {
                            m_data(id) = m_vals(id);
                            m_col(id)  = m_col_ids(id);
                            m_row(id)  = i;

--- a/sparse/src/KokkosSparse_crs2coo.hpp
+++ b/sparse/src/KokkosSparse_crs2coo.hpp
@@ -1,0 +1,154 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "KokkosKernels_Utils.hpp"
+#include "KokkosSparse_CooMatrix.hpp"
+#include "KokkosSparse_CrsMatrix.hpp"
+
+#ifndef _KOKKOSSPARSE_CRS2COO_HPP
+#define _KOKKOSSPARSE_CRS2COO_HPP
+namespace KokkosSparse {
+namespace Impl {
+template <class OrdinalType, class SizeType, class ValViewType,
+          class RowMapViewType, class ColIdViewType,
+          class DeviceType = typename ValViewType::execution_space>
+class Crs2Coo {
+ private:
+  using non_const_ordinal_type = std::remove_const_t<OrdinalType>;
+  using non_const_size_type    = std::remove_const_t<SizeType>;
+  using coo_row_view =
+      typename Kokkos::View<non_const_ordinal_type *, DeviceType>;
+  using coo_col_view  = coo_row_view;
+  using coo_data_view = typename ValViewType::non_const_type;
+  using coo_type =
+      CooMatrix<coo_row_view, coo_col_view, coo_data_view, DeviceType>;
+
+  non_const_ordinal_type m_nrows;
+  non_const_ordinal_type m_ncols;
+  non_const_size_type m_nnz;
+
+  coo_data_view m_data;
+  coo_col_view m_col;
+  coo_row_view m_row;
+
+  ValViewType m_vals;
+  RowMapViewType m_row_map;
+  ColIdViewType m_col_ids;
+
+  using copy_tp1_pt          = Kokkos::TeamPolicy<DeviceType>;
+  using copy_tp1_member_type = typename copy_tp1_pt::member_type;
+
+ public:
+  Crs2Coo(OrdinalType nrows, OrdinalType ncols, SizeType nnz, ValViewType vals,
+          RowMapViewType row_map, ColIdViewType col_ids)
+      : m_nrows(nrows),
+        m_ncols(ncols),
+        m_nnz(nnz),
+        m_vals(vals),
+        m_row_map(row_map),
+        m_col_ids(col_ids) {
+    m_data = coo_data_view(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing, "m_data"), nnz);
+    m_col = coo_col_view(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing, "m_col"), nnz);
+    m_row = coo_row_view(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing, "m_row"), nnz);
+
+    copy_tp1_pt policy(m_nrows, 1, 1);
+    {
+      auto vec_len_max = policy.vector_length_max();
+      copy_tp1_pt query_policy(m_nrows, 1, vec_len_max);
+      policy = copy_tp1_pt(
+          m_nrows,
+          query_policy.team_size_recommended(*this, Kokkos::ParallelForTag()),
+          vec_len_max);
+    }
+
+    Kokkos::parallel_for("Crs2Coo", policy, *this);
+    DeviceType().fence();
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const copy_tp1_member_type &member) const {
+    auto i         = member.league_rank();
+    auto row_start = m_row_map(i);
+    auto row_len   = m_row_map(i + 1) - row_start;
+    auto row_end   = row_start + row_len;
+
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(member, row_start, row_end),
+                         [&](const int &id) {
+                           m_data(id) = m_vals(id);
+                           m_col(id)  = m_col_ids(id);
+                           m_row(id)  = i;
+                         });
+  }
+
+  coo_type get_cooMat() {
+    return coo_type(m_nrows, m_ncols, m_row, m_col, m_data);
+  }
+};
+}  // namespace Impl
+// clang-format off
+///
+/// \brief Blocking function that converts a CrsMatrix to a CooMatrix.
+/// Crs values are copied into the CooMatrix in the order they appear
+/// within the CrsMatrix, starting from row 0 to row nrows - 1.
+/// \tparam OrdinalType The view value type associated with the RowIdViewType
+/// \tparam SizeType The type of nnz
+/// \tparam ValViewType    The values view type
+/// \tparam RowMapViewType The column map view type
+/// \tparam ColIdViewType  The row ids view type
+/// \param nrows   The number of rows in the crs matrix
+/// \param ncols   The number of columns in the crs matrix
+/// \param nnz     The number of non-zeros in the crs matrix
+/// \param vals    The values view of the crs matrix
+/// \param row_map The row map view of the crs matrix
+/// \param col_ids The col ids view of the crs matrix
+/// \return A KokkosSparse::CooMatrix.
+///
+// clang-format on
+template <class OrdinalType, class SizeType, class ValViewType,
+          class RowMapViewType, class ColIdViewType>
+auto crs2coo(OrdinalType nrows, OrdinalType ncols, SizeType nnz,
+             ValViewType vals, RowMapViewType row_map, ColIdViewType col_ids) {
+  using Crs2cooType = Impl::Crs2Coo<OrdinalType, SizeType, ValViewType,
+                                    RowMapViewType, ColIdViewType>;
+  Crs2cooType crs2Coo(nrows, ncols, nnz, vals, row_map, col_ids);
+  return crs2Coo.get_cooMat();
+}
+
+///
+/// @brief Blocking function that converts a CrsMatrix to a CooMatrix.
+/// Crs values are copied into the CooMatrix in the order they appear
+/// within the CrsMatrix, starting from row 0 to row nrows - 1.
+///
+/// \tparam ScalarType   The crsMatrix::scalar_type
+/// \tparam OrdinalType  The crsMatrix::ordinal_type
+/// \tparam DeviceType   The crsMatrix::device_type
+/// \tparam MemoryTraits The crsMatrix::memory_traits
+/// \tparam SizeType     The crsMatrix::size_type
+/// \param crsMatrix The KokkosSparse::CrsMatrix.
+/// \return A KokkosSparse::CooMatrix.
+template <typename ScalarType, typename OrdinalType, class DeviceType,
+          class MemoryTraitsType, typename SizeType>
+auto crs2coo(KokkosSparse::CrsMatrix<ScalarType, OrdinalType, DeviceType,
+                                     MemoryTraitsType, SizeType> &crsMatrix) {
+  return crs2coo(crsMatrix.numRows(), crsMatrix.numCols(), crsMatrix.nnz(),
+                 crsMatrix.values, crsMatrix.graph.row_map,
+                 crsMatrix.graph.entries);
+}
+}  // namespace KokkosSparse
+#endif  //  _KOKKOSSPARSE_CRS2COO_HPP

--- a/sparse/unit_test/Test_Sparse.hpp
+++ b/sparse/unit_test/Test_Sparse.hpp
@@ -16,6 +16,8 @@
 #ifndef TEST_SPARSE_HPP
 #define TEST_SPARSE_HPP
 
+#include "Test_Sparse_coo2crs.hpp"
+#include "Test_Sparse_crs2coo.hpp"
 #include "Test_Sparse_block_gauss_seidel.hpp"
 #include "Test_Sparse_Controls.hpp"
 #include "Test_Sparse_CrsMatrix.hpp"

--- a/sparse/unit_test/Test_Sparse_TestUtils_RandCsMat.hpp
+++ b/sparse/unit_test/Test_Sparse_TestUtils_RandCsMat.hpp
@@ -45,7 +45,7 @@ void doCsMat(size_t m, size_t n, ScalarType min_val, ScalarType max_val) {
   ASSERT_EQ(vals.extent(0), cm.get_nnz() + 1) << cm.info;
 
   auto row_ids = cm.get_ids();
-  ASSERT_EQ(row_ids.extent(0), cm.get_dim1() * cm.get_dim2() + 1) << cm.info;
+  ASSERT_EQ(row_ids.extent(0), cm.get_nnz()) << cm.info;
 
   auto col_map = cm.get_map();
   ASSERT_EQ(col_map.extent(0), cm.get_dim1() + 1);

--- a/sparse/unit_test/Test_Sparse_TestUtils_RandCsMat.hpp
+++ b/sparse/unit_test/Test_Sparse_TestUtils_RandCsMat.hpp
@@ -51,7 +51,7 @@ void doCsMat(size_t m, size_t n, ScalarType min_val, ScalarType max_val) {
   auto col_map = cm.get_map();
   ASSERT_EQ(col_map.extent(0), cm.get_dim1() + 1);
 
-  ASSERT_EQ(col_map(cm.get_dim1()), expected_nnz) << cm.info;
+  ASSERT_EQ(map(cm.get_dim1()), expected_nnz) << cm.info;
 }
 
 template <class ExeSpaceType>

--- a/sparse/unit_test/Test_Sparse_TestUtils_RandCsMat.hpp
+++ b/sparse/unit_test/Test_Sparse_TestUtils_RandCsMat.hpp
@@ -30,13 +30,14 @@ void doCsMat(size_t m, size_t n, ScalarType min_val, ScalarType max_val) {
   auto map   = Kokkos::create_mirror_view(map_d);
   Kokkos::deep_copy(map, map_d);
 
+  // Here we treat 'cm' as a Ccs matrix
   for (int64_t j = 0; j < cm.get_dim1(); ++j) {
-    int64_t row_len = j < static_cast<int64_t>(m) ? (map(j + 1) - map(j)) : 0;
-    for (int64_t i = 0; i < row_len; ++i) {
-      int64_t row_start = j < static_cast<int64_t>(m) ? map(j) : 0;
-      ASSERT_FLOAT_EQ(cm(row_start + i), cm(expected_nnz + i)) << cm.info;
+    int64_t col_len = j < static_cast<int64_t>(m) ? (map(j + 1) - map(j)) : 0;
+    for (int64_t i = 0; i < col_len; ++i) {
+      int64_t col_start = j < static_cast<int64_t>(m) ? map(j) : 0;
+      ASSERT_FLOAT_EQ(cm(col_start + i), cm(expected_nnz + i)) << cm.info;
     }
-    expected_nnz += row_len;
+    expected_nnz += col_len;
   }
   ASSERT_EQ(cm.get_nnz(), expected_nnz) << cm.info;
 
@@ -49,6 +50,8 @@ void doCsMat(size_t m, size_t n, ScalarType min_val, ScalarType max_val) {
 
   auto col_map = cm.get_map();
   ASSERT_EQ(col_map.extent(0), cm.get_dim1() + 1);
+
+  ASSERT_EQ(col_map(cm.get_dim1()), expected_nnz) << cm.info;
 }
 
 template <class ExeSpaceType>

--- a/sparse/unit_test/Test_Sparse_coo2crs.hpp
+++ b/sparse/unit_test/Test_Sparse_coo2crs.hpp
@@ -264,7 +264,8 @@ TEST_F(TestCategory, sparse_coo2crs) {
                                          cooMat.get_col(), cooMat.get_data());
   auto cooMatrix = KokkosSparse::crs2coo(crsMatrix);
 
-  check_crs_matrix(crsMatrix, cooMatrix.row, cooMatrix.col, cooMatrix.data);
+  check_crs_matrix(crsMatrix, cooMatrix.row(), cooMatrix.col(),
+                   cooMatrix.data());
 }
 
 TEST_F(TestCategory, sparse_coo2crs_staticMatrix_edgeCases) {

--- a/sparse/unit_test/Test_Sparse_coo2crs.hpp
+++ b/sparse/unit_test/Test_Sparse_coo2crs.hpp
@@ -242,6 +242,8 @@ TEST_F(TestCategory, sparse_coo2crs) {
       UINT32_MAX;
   std::srand(ticks);
 
+  doAllCoo2Crs<TestExecSpace>(0, 0);
+
   // Square cases
   for (size_t i = 1; i < 256; i *= 4) {
     size_t dim = (std::rand() % 511) + 1;

--- a/sparse/unit_test/Test_Sparse_coo2crs.hpp
+++ b/sparse/unit_test/Test_Sparse_coo2crs.hpp
@@ -1,0 +1,329 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "KokkosSparse_coo2crs.hpp"
+#include "KokkosSparse_crs2coo.hpp"
+#include "KokkosKernels_TestUtils.hpp"
+
+namespace Test {
+template <class CrsType, class RowType, class ColType, class DataType>
+CrsType vanilla_coo2crs(size_t m, size_t n, RowType row, ColType col,
+                        DataType data) {
+  using RowIndexType = typename RowType::value_type;
+  using ColIndexType = typename ColType::value_type;
+  using ValueType    = typename DataType::value_type;
+  std::unordered_map<RowIndexType,
+                     std::unordered_map<ColIndexType, ValueType> *>
+      umap;
+  int nnz = 0;
+
+  for (uint64_t i = 0; i < data.extent(0); i++) {
+    auto r = row(i);
+    auto c = col(i);
+    auto d = data(i);
+
+    if (r >= 0 && c >= 0) {
+      if (umap.find(r) != umap.end()) {  // exists
+        auto my_row = umap.at(r);
+        if (my_row->find(c) != my_row->end())
+          my_row->at(c) += d;
+        else {
+          my_row->insert(std::make_pair(c, d));
+          nnz++;
+        }
+      } else {  // create a new row.
+        auto new_row = new std::unordered_map<ColIndexType, ValueType>();
+        umap.insert(std::make_pair(r, new_row));
+        new_row->insert(std::make_pair(c, d));
+        nnz++;
+      }
+    }
+  }
+
+  typename CrsType::row_map_type::non_const_type row_map("vanilla_row_map",
+                                                         m + 1);
+  typename CrsType::values_type values("vanilla_values", nnz);
+  typename CrsType::staticcrsgraph_type::entries_type col_ids("vanilla_col_ids",
+                                                              nnz);
+
+  typename CrsType::row_map_type::non_const_type::HostMirror row_map_h =
+      Kokkos::create_mirror_view(row_map);
+  typename CrsType::values_type::HostMirror values_h =
+      Kokkos::create_mirror_view(values);
+  typename CrsType::staticcrsgraph_type::entries_type::HostMirror col_ids_h =
+      Kokkos::create_mirror_view(col_ids);
+
+  int row_len = 0;
+  for (uint64_t i = 0; i < m; i++) {
+    if (umap.find(i) != umap.end()) row_len += umap.at(i)->size();
+    row_map_h(i + 1) = row_len;
+  }
+
+  for (uint64_t i = 0; i < m; i++) {
+    if (umap.find(i) == umap.end())  // Fully sparse row
+      continue;
+
+    auto row_start = row_map_h(i);
+    auto row_end   = row_map_h(i + 1);
+    auto my_row    = umap.at(i);
+    auto iter      = my_row->begin();
+    for (auto j = row_start; j < row_end; j++, iter++) {
+      col_ids_h(j) = iter->first;
+      values_h(j)  = iter->second;
+    }
+    delete my_row;
+  }
+
+  Kokkos::deep_copy(row_map, row_map_h);
+  Kokkos::deep_copy(col_ids, col_ids_h);
+  Kokkos::deep_copy(values, values_h);
+
+  return CrsType("vanilla_coo2csr", m, n, nnz, values, row_map, col_ids);
+}
+
+template <class CrsType, class RowType, class ColType, class DataType>
+void check_crs_matrix(CrsType crsMat, RowType row, ColType col, DataType data,
+                      std::string failure_info = "no failure information!") {
+  using value_type = typename DataType::value_type;
+  using ats        = Kokkos::ArithTraits<value_type>;
+
+  // Copy coo to host
+  typename RowType::HostMirror row_h = Kokkos::create_mirror_view(row);
+  Kokkos::deep_copy(row_h, row);
+  typename ColType::HostMirror col_h = Kokkos::create_mirror_view(col);
+  Kokkos::deep_copy(col_h, col);
+  typename DataType::HostMirror data_h = Kokkos::create_mirror_view(data);
+  Kokkos::deep_copy(data_h, data);
+
+  auto crsMatRef = vanilla_coo2crs<CrsType, typename RowType::HostMirror,
+                                   typename ColType::HostMirror,
+                                   typename DataType::HostMirror>(
+      crsMat.numRows(), crsMat.numCols(), row_h, col_h, data_h);
+
+  auto crs_col_ids_ref_d = crsMatRef.graph.entries;
+  auto crs_row_map_ref_d = crsMatRef.graph.row_map;
+  auto crs_vals_ref_d    = crsMatRef.values;
+
+  using ViewTypeCrsColIdsRef = decltype(crs_col_ids_ref_d);
+  using ViewTypeCrsRowMapRef = decltype(crs_row_map_ref_d);
+  using ViewTypeCrsValsRef   = decltype(crs_vals_ref_d);
+
+  // Copy crs to host
+  typename ViewTypeCrsColIdsRef::HostMirror crs_col_ids_ref =
+      Kokkos::create_mirror_view(crs_col_ids_ref_d);
+  Kokkos::deep_copy(crs_col_ids_ref, crs_col_ids_ref_d);
+  typename ViewTypeCrsRowMapRef::HostMirror crs_row_map_ref =
+      Kokkos::create_mirror_view(crs_row_map_ref_d);
+  Kokkos::deep_copy(crs_row_map_ref, crs_row_map_ref_d);
+  typename ViewTypeCrsValsRef::HostMirror crs_vals_ref =
+      Kokkos::create_mirror_view(crs_vals_ref_d);
+  Kokkos::deep_copy(crs_vals_ref, crs_vals_ref_d);
+
+  auto crs_col_ids_d = crsMat.graph.entries;
+  auto crs_row_map_d = crsMat.graph.row_map;
+  auto crs_vals_d    = crsMat.values;
+
+  using ViewTypeCrsColIds = decltype(crs_col_ids_d);
+  using ViewTypeCrsRowMap = decltype(crs_row_map_d);
+  using ViewTypeCrsVals   = decltype(crs_vals_d);
+
+  // Copy crs to host
+  typename ViewTypeCrsColIds::HostMirror crs_col_ids =
+      Kokkos::create_mirror_view(crs_col_ids_d);
+  Kokkos::deep_copy(crs_col_ids, crs_col_ids_d);
+  typename ViewTypeCrsRowMap::HostMirror crs_row_map =
+      Kokkos::create_mirror_view(crs_row_map_d);
+  Kokkos::deep_copy(crs_row_map, crs_row_map_d);
+  typename ViewTypeCrsVals::HostMirror crs_vals =
+      Kokkos::create_mirror_view(crs_vals_d);
+  Kokkos::deep_copy(crs_vals, crs_vals_d);
+
+  Kokkos::fence();
+
+  ASSERT_EQ(crsMatRef.nnz(), crsMat.nnz()) << failure_info;
+
+  for (int i = 0; i < crsMatRef.numRows(); i++) {
+    ASSERT_EQ(crs_row_map_ref(i), crs_row_map(i))
+        << "crs_row_map_ref(" << i << " = " << crs_row_map_ref(i) << " != "
+        << "crs_row_map(" << i << " = " << crs_row_map(i) << " -- "
+        << failure_info;
+  }
+
+  for (int i = 0; i < crsMatRef.numRows(); ++i) {
+    auto row_start_ref = crs_row_map_ref(i);
+    auto row_stop_ref  = crs_row_map_ref(i + 1);
+    auto row_len_ref   = row_stop_ref - row_start_ref;
+
+    auto row_start = crs_row_map(i);
+    auto row_len   = crs_row_map(i + 1) - row_start;
+
+    ASSERT_EQ(row_start_ref, row_start);
+    ASSERT_EQ(row_len_ref, row_len);
+
+    for (auto j = row_start_ref; j < row_stop_ref; ++j) {
+      // Look for the corresponding col_id
+      auto col_id_ref      = crs_col_ids_ref(j);
+      std::string fail_msg = "row: " + std::to_string(i) +
+                             ", crs_col_ids_ref(" + std::to_string(j) +
+                             ") = " + std::to_string(col_id_ref);
+
+      auto k = row_start_ref;
+      for (; k < row_stop_ref; ++k) {
+        if (crs_col_ids(k) == col_id_ref) break;
+      }
+      if (k == row_stop_ref)
+        FAIL() << fail_msg << " not found in crs_col_ids!" << failure_info;
+
+      // NOTE: ASSERT_EQ doesn't work -- values may be summed in different
+      // orders We sum at most m x n values.
+      auto eps =
+          crsMatRef.numCols() * crsMatRef.numRows() * 10e1 * ats::epsilon();
+      EXPECT_NEAR_KK(crs_vals_ref(j), crs_vals(k), eps,
+                     fail_msg + " mismatched values!" + failure_info);
+    }
+  }
+}
+
+template <class ScalarType, class LayoutType, class ExeSpaceType>
+void doCoo2Crs(size_t m, size_t n, ScalarType min_val, ScalarType max_val) {
+  RandCooMat<ScalarType, LayoutType, ExeSpaceType> cooMat(m, n, m * n, min_val,
+                                                          max_val);
+  auto randRow  = cooMat.get_row();
+  auto randCol  = cooMat.get_col();
+  auto randData = cooMat.get_data();
+
+  std::string failure_info =
+      "\nBegin arguments for above failure...\n" + cooMat.info +
+      "scalar: " + std::string(typeid(ScalarType).name()) + "\n" +
+      "layout: " + std::string(typeid(LayoutType).name()) + "\n" +
+      "m: " + std::to_string(m) + ", n: " + std::to_string(n) +
+      "\n...end arguments for above failure.\n";
+
+  auto crsMat = KokkosSparse::coo2crs(m, n, randRow, randCol, randData);
+  check_crs_matrix(crsMat, randRow, randCol, randData, failure_info);
+}
+
+template <class LayoutType, class ExeSpaceType>
+void doAllScalarsCoo2Crs(size_t m, size_t n, int min, int max) {
+  doCoo2Crs<float, LayoutType, ExeSpaceType>(m, n, min, max);
+  doCoo2Crs<double, LayoutType, ExeSpaceType>(m, n, min, max);
+  doCoo2Crs<Kokkos::complex<float>, LayoutType, ExeSpaceType>(m, n, min, max);
+  doCoo2Crs<Kokkos::complex<double>, LayoutType, ExeSpaceType>(m, n, min, max);
+}
+
+template <class ExeSpaceType>
+void doAllLayoutsCoo2Crs(size_t m, size_t n, int min, int max) {
+  doAllScalarsCoo2Crs<Kokkos::LayoutLeft, ExeSpaceType>(m, n, min, max);
+  doAllScalarsCoo2Crs<Kokkos::LayoutRight, ExeSpaceType>(m, n, min, max);
+}
+
+template <class ExeSpaceType>
+void doAllCoo2Crs(size_t m, size_t n) {
+  int min = 1, max = 10;
+  doAllLayoutsCoo2Crs<ExeSpaceType>(m, n, min, max);
+}
+
+TEST_F(TestCategory, sparse_coo2crs) {
+  uint64_t ticks =
+      std::chrono::high_resolution_clock::now().time_since_epoch().count() %
+      UINT32_MAX;
+  std::srand(ticks);
+
+  // Square cases
+  for (size_t i = 1; i < 256; i *= 4) {
+    size_t dim = (std::rand() % 511) + 1;
+    doAllCoo2Crs<TestExecSpace>(dim, dim);
+  }
+
+  // Non-square cases
+  for (size_t i = 1; i < 256; i *= 4) {
+    size_t m = (std::rand() % 511) + 1;
+    size_t n = (std::rand() % 511) + 1;
+    while (n == m) n = (std::rand() % 511) + 1;
+    doAllCoo2Crs<TestExecSpace>(m, n);
+  }
+
+  RandCooMat<double, Kokkos::LayoutRight, TestExecSpace> cooMat(2, 2, 2 * 2, 10,
+                                                                10);
+  auto crsMatrix = KokkosSparse::coo2crs(2, 2, cooMat.get_row(),
+                                         cooMat.get_col(), cooMat.get_data());
+  auto cooMatrix = KokkosSparse::crs2coo(crsMatrix);
+
+  check_crs_matrix(crsMatrix, cooMatrix.row, cooMatrix.col, cooMatrix.data);
+}
+
+TEST_F(TestCategory, sparse_coo2crs_staticMatrix_edgeCases) {
+  int m = 4;
+  int n = 4;
+  long long staticRow[16]{0, 1, 3, 2, 3, 2, 2, 2, 0, 0, 0, 1, 2, 0, 3, 0};
+  long long staticCol[16]{1, 1, 2, 3, 3, 2, 3, 2, 0, 0, 1, 3, 1, 2, 0, 0};
+  float staticData[16]{7.28411, 8.17991, 8.84304, 5.01788, 9.85646, 5.79404,
+                       8.42014, 1.90238, 8.24195, 4.39955, 3.2637,  5.4546,
+                       6.51895, 8.09302, 9.36294, 3.44206};
+  Kokkos::View<long long *, TestExecSpace> row("coo row", 16);
+  Kokkos::View<long long *, TestExecSpace> col("coo col", 16);
+  Kokkos::View<float *, TestExecSpace> data("coo data", 16);
+
+  typename Kokkos::View<long long *, TestExecSpace>::HostMirror row_h =
+      Kokkos::create_mirror_view(row);
+  typename Kokkos::View<long long *, TestExecSpace>::HostMirror col_h =
+      Kokkos::create_mirror_view(col);
+  typename Kokkos::View<float *, TestExecSpace>::HostMirror data_h =
+      Kokkos::create_mirror_view(data);
+  for (int i = 0; i < 16; i++) {
+    row_h(i)  = staticRow[i];
+    col_h(i)  = staticCol[i];
+    data_h(i) = staticData[i];
+  }
+
+  Kokkos::deep_copy(row, row_h);
+  Kokkos::deep_copy(col, col_h);
+  Kokkos::deep_copy(data, data_h);
+
+  // Even partitions with multiple threads
+  auto crsMatTs4 = KokkosSparse::coo2crs(m, n, row, col, data);
+  check_crs_matrix(crsMatTs4, row_h, col_h, data_h);
+
+  // Even partitions, single thread, fully sparse row
+  long long staticRowTs1[16]{0, 3, 0, 2, 2, 3, 0, 3, 2, 0, 0, 0, 0, 3, 3, 0};
+  long long staticColTs1[16]{3, 1, 3, 1, 2, 2, 1, 1, 2, 3, 3, 1, 1, 0, 0, 0};
+  float staticDataTs1[16]{6.1355,  6.53989, 8.58559, 6.37476, 4.18964, 2.41146,
+                          1.82177, 1.4249,  1.52659, 5.50521, 8.0484,  3.98874,
+                          6.74709, 3.35072, 7.81944, 5.83494};
+  for (int i = 0; i < 16; i++) {
+    row_h(i)  = staticRowTs1[i];
+    col_h(i)  = staticColTs1[i];
+    data_h(i) = staticDataTs1[i];
+  }
+  Kokkos::deep_copy(row, row_h);
+  Kokkos::deep_copy(col, col_h);
+  Kokkos::deep_copy(data, data_h);
+
+  auto crsMatTs1 = KokkosSparse::coo2crs(m, n, row, col, data);
+  check_crs_matrix(crsMatTs1, row_h, col_h, data_h);
+
+  // Fully sparse
+  for (int i = 0; i < 16; i++) {
+    row_h(i) = -staticRowTs1[i];
+    col_h(i) = -staticColTs1[i];
+  }
+  Kokkos::deep_copy(row, row_h);
+  Kokkos::deep_copy(col, col_h);
+
+  auto crsMatFsTs1 = KokkosSparse::coo2crs(m, n, row, col, data);
+  check_crs_matrix(crsMatFsTs1, row_h, col_h, data);
+}
+}  // namespace Test

--- a/sparse/unit_test/Test_Sparse_crs2coo.hpp
+++ b/sparse/unit_test/Test_Sparse_crs2coo.hpp
@@ -1,0 +1,142 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "KokkosSparse_coo2crs.hpp"
+#include "KokkosSparse_crs2coo.hpp"
+#include "KokkosKernels_TestUtils.hpp"
+
+namespace Test {
+template <class CrsType, class RowType, class ColType, class DataType>
+void check_coo_matrix(CrsType crsMatRef, RowType row, ColType col,
+                      DataType data) {
+  // Copy coo to host
+  typename RowType::HostMirror row_h = Kokkos::create_mirror_view(row);
+  Kokkos::deep_copy(row_h, row);
+  typename ColType::HostMirror col_h = Kokkos::create_mirror_view(col);
+  Kokkos::deep_copy(col_h, col);
+  typename DataType::HostMirror data_h = Kokkos::create_mirror_view(data);
+  Kokkos::deep_copy(data_h, data);
+
+  // printf("coo in:\n");
+  // for (unsigned i = 0; i < data_h.extent(0); i++)
+  // printf("(%lld, %lld, %g)\n", row_h(i), col_h(i), data_h(i));
+
+  auto crs_col_ids_ref_d = crsMatRef.graph.entries;
+  auto crs_row_map_ref_d = crsMatRef.graph.row_map;
+  auto crs_vals_ref_d    = crsMatRef.values;
+
+  using ViewTypeCrsColIdsRef = decltype(crs_col_ids_ref_d);
+  using ViewTypeCrsRowMapRef = decltype(crs_row_map_ref_d);
+  using ViewTypeCrsValsRef   = decltype(crs_vals_ref_d);
+
+  // Copy crs to host
+  typename ViewTypeCrsColIdsRef::HostMirror crs_col_ids_ref =
+      Kokkos::create_mirror_view(crs_col_ids_ref_d);
+  Kokkos::deep_copy(crs_col_ids_ref, crs_col_ids_ref_d);
+  typename ViewTypeCrsRowMapRef::HostMirror crs_row_map_ref =
+      Kokkos::create_mirror_view(crs_row_map_ref_d);
+  Kokkos::deep_copy(crs_row_map_ref, crs_row_map_ref_d);
+  typename ViewTypeCrsValsRef::HostMirror crs_vals_ref =
+      Kokkos::create_mirror_view(crs_vals_ref_d);
+  Kokkos::deep_copy(crs_vals_ref, crs_vals_ref_d);
+
+  Kokkos::fence();
+
+  ASSERT_EQ(crsMatRef.nnz(), row.extent(0));
+  ASSERT_EQ(crsMatRef.nnz(), col.extent(0));
+  ASSERT_EQ(crsMatRef.nnz(), data.extent(0));
+
+  for (decltype(row.extent(0)) idx = 0; idx < row.extent(0); ++idx) {
+    auto row_id          = row_h(idx);
+    auto col_id          = col_h(idx);
+    auto val             = data_h(idx);
+    std::string fail_msg = "idx - " + std::to_string(idx) +
+                           " row: " + std::to_string(row_id) +
+                           ", col: " + std::to_string(col_id);
+
+    auto row_start_ref = crs_row_map_ref(row_id);
+    auto row_stop_ref  = crs_row_map_ref(row_id + 1);
+
+    auto crs_idx = row_start_ref;
+    for (; crs_idx < row_stop_ref; crs_idx++) {
+      if (crs_col_ids_ref(crs_idx) == col_id) {
+        // crs2coo does a direct copy, no need for an epsilon.
+        if (crs_vals_ref(crs_idx) == val) break;
+      }
+    }
+    if (crs_idx == row_stop_ref)
+      FAIL() << fail_msg << " not found in crsMatRef!";
+  }
+}
+
+template <class ScalarType, class LayoutType, class ExeSpaceType>
+void doCrs2Coo(size_t m, size_t n, ScalarType min_val, ScalarType max_val) {
+  using RandCrsMatType = RandCsMatrix<ScalarType, LayoutType, ExeSpaceType>;
+  RandCrsMatType crsMat(m, n, min_val, max_val, m == 0 || n == 0);
+
+  using CrsOT   = typename RandCrsMatType::IdViewTypeD::value_type;
+  using CrsType = typename KokkosSparse::CrsMatrix<ScalarType, CrsOT,
+                                                   ExeSpaceType, void, CrsOT>;
+  auto map      = crsMat.get_map();
+  auto ids      = crsMat.get_ids();
+  CrsType crsMatrix("doCrs2Coo", crsMat.get_dim1(), crsMat.get_dim2(),
+                    crsMat.get_nnz(), crsMat.get_vals(), map, ids);
+
+  auto cooMat = KokkosSparse::crs2coo(crsMatrix);
+  check_coo_matrix(crsMatrix, cooMat.row, cooMat.col, cooMat.data);
+}
+
+template <class LayoutType, class ExeSpaceType>
+void doAllScalarsCrs2Coo(size_t m, size_t n, int min, int max) {
+  doCrs2Coo<float, LayoutType, ExeSpaceType>(m, n, min, max);
+  doCrs2Coo<double, LayoutType, ExeSpaceType>(m, n, min, max);
+  doCrs2Coo<Kokkos::complex<float>, LayoutType, ExeSpaceType>(m, n, min, max);
+  doCrs2Coo<Kokkos::complex<double>, LayoutType, ExeSpaceType>(m, n, min, max);
+}
+
+template <class ExeSpaceType>
+void doAllLayoutsCrs2Coo(size_t m, size_t n, int min, int max) {
+  doAllScalarsCrs2Coo<Kokkos::LayoutLeft, ExeSpaceType>(m, n, min, max);
+  doAllScalarsCrs2Coo<Kokkos::LayoutRight, ExeSpaceType>(m, n, min, max);
+}
+
+template <class ExeSpaceType>
+void doAllCrs2Coo(size_t m, size_t n) {
+  int min = 1, max = 10;
+  doAllLayoutsCrs2Coo<ExeSpaceType>(m, n, min, max);
+}
+
+TEST_F(TestCategory, sparse_crs2coo) {
+  uint64_t ticks =
+      std::chrono::high_resolution_clock::now().time_since_epoch().count() %
+      UINT32_MAX;
+  std::srand(ticks);
+
+  // Square cases
+  for (size_t i = 1; i < 256; i *= 4) {
+    size_t dim = (std::rand() % 511) + 1;
+    doAllCrs2Coo<TestExecSpace>(dim, dim);
+  }
+
+  // Non-square cases
+  for (size_t i = 1; i < 256; i *= 4) {
+    size_t m = (std::rand() % 511) + 1;
+    size_t n = (std::rand() % 511) + 1;
+    while (n == m) n = (std::rand() % 511) + 1;
+    doAllCrs2Coo<TestExecSpace>(m, n);
+  }
+}
+}  // namespace Test

--- a/sparse/unit_test/Test_Sparse_crs2coo.hpp
+++ b/sparse/unit_test/Test_Sparse_crs2coo.hpp
@@ -96,7 +96,7 @@ void doCrs2Coo(size_t m, size_t n, ScalarType min_val, ScalarType max_val) {
                     crsMat.get_nnz(), crsMat.get_vals(), map, ids);
 
   auto cooMat = KokkosSparse::crs2coo(crsMatrix);
-  check_coo_matrix(crsMatrix, cooMat.row, cooMat.col, cooMat.data);
+  check_coo_matrix(crsMatrix, cooMat.row(), cooMat.col(), cooMat.data());
 }
 
 template <class LayoutType, class ExeSpaceType>

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -562,6 +562,64 @@ int string_compare_no_case(const char* str1, const char* str2) {
 int string_compare_no_case(const std::string& str1, const std::string& str2) {
   return string_compare_no_case(str1.c_str(), str2.c_str());
 }
+/// /brief Coo matrix class for testing purposes.
+/// \tparam ScalarType
+/// \tparam LayoutType
+/// \tparam ExeSpaceType
+template <class ScalarType, class LayoutType, class ExeSpaceType>
+class RandCooMat {
+ private:
+  using RowViewTypeD  = Kokkos::View<int64_t*, LayoutType, ExeSpaceType>;
+  using ColViewTypeD  = Kokkos::View<int64_t*, LayoutType, ExeSpaceType>;
+  using DataViewTypeD = Kokkos::View<ScalarType*, LayoutType, ExeSpaceType>;
+  RowViewTypeD __row_d;
+  ColViewTypeD __col_d;
+  DataViewTypeD __data_d;
+
+  template <class T>
+  T __getter_copy_helper(T src) {
+    T dst(std::string("RandCooMat.") + typeid(T).name() + " copy",
+          src.extent(0));
+    Kokkos::deep_copy(dst, src);
+    ExeSpaceType().fence();
+    return dst;
+  }
+
+ public:
+  std::string info;
+  /// Constructs a random coo matrix with negative indices.
+  /// \param m The max row id
+  /// \param n The max col id
+  /// \param n_tuples The number of tuples.
+  /// \param min_val The minimum scalar value in the matrix.
+  /// \param max_val The maximum scalar value in the matrix.
+  RandCooMat(int64_t m, int64_t n, int64_t n_tuples, ScalarType min_val,
+             ScalarType max_val) {
+    uint64_t ticks =
+        std::chrono::high_resolution_clock::now().time_since_epoch().count() %
+        UINT32_MAX;
+
+    info = std::string(std::string("RandCooMat<") + typeid(ScalarType).name() +
+                       ", " + typeid(LayoutType).name() + ", " +
+                       typeid(ExeSpaceType).name() + std::to_string(n) +
+                       "...): rand seed: " + std::to_string(ticks) + "\n");
+    Kokkos::Random_XorShift64_Pool<ExeSpaceType> random(ticks);
+
+    __row_d = RowViewTypeD("RandCooMat.RowViewType", n_tuples);
+    Kokkos::fill_random(__row_d, random, -m, m);
+
+    __col_d = ColViewTypeD("RandCooMat.ColViewType", n_tuples);
+    Kokkos::fill_random(__col_d, random, -n, n);
+
+    __data_d = DataViewTypeD("RandCooMat.DataViewType", n_tuples);
+    Kokkos::fill_random(__data_d, random, min_val, max_val);
+
+    ExeSpaceType().fence();
+  }
+  auto get_row() { return __getter_copy_helper(__row_d); }
+  auto get_col() { return __getter_copy_helper(__col_d); }
+  auto get_data() { return __getter_copy_helper(__data_d); }
+};
 
 /// /brief Cs (Compressed Sparse) matrix class for testing purposes.
 /// This class is for testing purposes only and will generate a random
@@ -574,10 +632,12 @@ int string_compare_no_case(const std::string& str1, const std::string& str2) {
 /// \tparam ExeSpaceType
 template <class ScalarType, class LayoutType, class ExeSpaceType>
 class RandCsMatrix {
- private:
+ public:
   using ValViewTypeD = Kokkos::View<ScalarType*, LayoutType, ExeSpaceType>;
   using IdViewTypeD  = Kokkos::View<int64_t*, LayoutType, ExeSpaceType>;
   using MapViewTypeD = Kokkos::View<int64_t*, LayoutType, ExeSpaceType>;
+
+ private:
   int64_t __dim2;
   int64_t __dim1;
   int64_t __nnz = 0;
@@ -624,8 +684,14 @@ class RandCsMatrix {
 
     // Copy to device
     Kokkos::deep_copy(__map_d, __map);
-    Kokkos::deep_copy(__ids_d, __ids);
+    IdViewTypeD tight_ids(Kokkos::view_alloc(Kokkos::WithoutInitializing,
+                                             "RandCsMatrix.IdViewTypeD"),
+                          __nnz);
+    Kokkos::deep_copy(
+        tight_ids,
+        Kokkos::subview(__ids, Kokkos::make_pair(0, static_cast<int>(__nnz))));
     ExeSpaceType().fence();
+    __ids_d = tight_ids;
   }
 
   template <class T>


### PR DESCRIPTION
Depends on https://github.com/kokkos/kokkos/pull/5877.

Adds a coo2crs implementation which relies on `Kokkos::UnorderedMap`:
- An array of nrow unordered maps is created
- The coo entires are inserted into these unordered maps
- The coo row index determines which unordered map to insert into
- The coo col index is the key into the given unordered map
- Negative indices are ignored
- Duplicate i,j entries are summed
- The row map is computed from the size of each unordered map
- At the end we copy the values and col ids into the crs members

Adds crs2coo:
- This iterates over the crs and writes each i,j,v into the coo matrix

CooMatrix:
- This is a minimal CooMatrix for coo2crs/crs2coo convenience wrappers that accept/return a CooMatrix type.

Related to https://github.com/kokkos/kokkos-kernels/issues/1164.