### PR TITLE
#5: added TplsVersion file and  print methods

### DIFF
--- a/common/src/KokkosKernels_PrintConfiguration.hpp
+++ b/common/src/KokkosKernels_PrintConfiguration.hpp
@@ -24,7 +24,7 @@
 namespace KokkosKernels {
 namespace Impl {
 
-inline void print_cublas_version(std::ostream& os) {
+inline void print_cublas_version_if_enabled(std::ostream& os) {
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUBLAS
   os << "  "
      << "KOKKOSKERNELS_ENABLE_TPL_CUBLAS: " << get_cublas_version() << "\n";
@@ -34,7 +34,7 @@ inline void print_cublas_version(std::ostream& os) {
 #endif
 }
 
-inline void print_cusparse_version(std::ostream& os) {
+inline void print_cusparse_version_if_enabled(std::ostream& os) {
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
   os << "  "
      << "KOKKOSKERNELS_ENABLE_TPL_CUSPARSE: " << get_cusparse_version() << "\n";
@@ -93,8 +93,8 @@ inline void print_enabled_tpls(std::ostream& os) {
   os << "  "
      << "KOKKOSKERNELS_ENABLE_TPL_MKL: no\n";
 #endif
-  print_cublas_version(os);
-  print_cusparse_version(os);
+  print_cublas_version_if_enabled(os);
+  print_cusparse_version_if_enabled(os);
 #ifdef KOKKOSKERNELS_ENABLE_TPL_ROCBLAS
   os << "  "
      << "KOKKOSKERNELS_ENABLE_TPL_ROCBLAS: yes\n";

--- a/common/src/KokkosKernels_PrintConfiguration.hpp
+++ b/common/src/KokkosKernels_PrintConfiguration.hpp
@@ -18,11 +18,31 @@
 #define _KOKKOSKERNELS_PRINT_CONFIGURATION_HPP
 
 #include "KokkosKernels_config.h"
-
+#include "KokkosKernels_TplsVersion.hpp"
 #include <iostream>
 
 namespace KokkosKernels {
 namespace Impl {
+
+inline void print_cublas_version(std::ostream& os) {
+#ifdef KOKKOSKERNELS_ENABLE_TPL_CUBLAS
+  os << "  "
+     << "KOKKOSKERNELS_ENABLE_TPL_CUBLAS: " << get_cublas_version() << "\n";
+#else
+  os << "  "
+     << "KOKKOSKERNELS_ENABLE_TPL_CUBLAS: no\n";
+#endif
+}
+
+inline void print_cusparse_version(std::ostream& os) {
+#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+  os << "  "
+     << "KOKKOSKERNELS_ENABLE_TPL_CUSPARSE: " << get_cusparse_version() << "\n";
+#else
+  os << "  "
+     << "KOKKOSKERNELS_ENABLE_TPL_CUSPARSE: no\n";
+#endif
+}
 inline void print_enabled_tpls(std::ostream& os) {
 #ifdef KOKKOSKERNELS_ENABLE_TPL_LAPACK
   os << "  "
@@ -73,20 +93,8 @@ inline void print_enabled_tpls(std::ostream& os) {
   os << "  "
      << "KOKKOSKERNELS_ENABLE_TPL_MKL: no\n";
 #endif
-#ifdef KOKKOSKERNELS_ENABLE_TPL_CUBLAS
-  os << "  "
-     << "KOKKOSKERNELS_ENABLE_TPL_CUBLAS: yes\n";
-#else
-  os << "  "
-     << "KOKKOSKERNELS_ENABLE_TPL_CUBLAS: no\n";
-#endif
-#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
-  os << "  "
-     << "KOKKOSKERNELS_ENABLE_TPL_CUSPARSE: yes\n";
-#else
-  os << "  "
-     << "KOKKOSKERNELS_ENABLE_TPL_CUSPARSE: no\n";
-#endif
+  print_cublas_version(os);
+  print_cusparse_version(os);
 #ifdef KOKKOSKERNELS_ENABLE_TPL_ROCBLAS
   os << "  "
      << "KOKKOSKERNELS_ENABLE_TPL_ROCBLAS: yes\n";

--- a/common/src/KokkosKernels_PrintConfiguration.hpp
+++ b/common/src/KokkosKernels_PrintConfiguration.hpp
@@ -27,7 +27,7 @@ namespace Impl {
 inline void print_cublas_version_if_enabled(std::ostream& os) {
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUBLAS
   os << "  "
-     << "KOKKOSKERNELS_ENABLE_TPL_CUBLAS: " << get_cublas_version() << "\n";
+     << "KOKKOSKERNELS_ENABLE_TPL_CUBLAS: " << cublas_version_string() << "\n";
 #else
   os << "  "
      << "KOKKOSKERNELS_ENABLE_TPL_CUBLAS: no\n";
@@ -37,7 +37,8 @@ inline void print_cublas_version_if_enabled(std::ostream& os) {
 inline void print_cusparse_version_if_enabled(std::ostream& os) {
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
   os << "  "
-     << "KOKKOSKERNELS_ENABLE_TPL_CUSPARSE: " << get_cusparse_version() << "\n";
+     << "KOKKOSKERNELS_ENABLE_TPL_CUSPARSE: " << cusparse_version_string()
+     << "\n";
 #else
   os << "  "
      << "KOKKOSKERNELS_ENABLE_TPL_CUSPARSE: no\n";

--- a/common/src/KokkosKernels_TplsVersion.hpp
+++ b/common/src/KokkosKernels_TplsVersion.hpp
@@ -35,8 +35,7 @@ inline std::string get_cublas_version() {
   // Print version
   std::stringstream ss;
 
-  ss << CUBLAS_VER_MAJOR << "." << CUBLAS_VER_MINOR << "." << CUBLAS_VER_PATCH
-     << CUBLAS_VER_BUILD;
+  ss << CUBLAS_VER_MAJOR << "." << CUBLAS_VER_MINOR << "." << CUBLAS_VER_PATCH;
 
   return ss.str();
 }

--- a/common/src/KokkosKernels_TplsVersion.hpp
+++ b/common/src/KokkosKernels_TplsVersion.hpp
@@ -18,7 +18,7 @@
 #define _KOKKOSKERNELS_TPLS_VERSIONS_HPP
 
 #include "KokkosKernels_config.h"
-#include <iostream>
+#include <sstream>
 
 #if defined(KOKKOSKERNELS_ENABLE_TPL_CUBLAS)
 #include "cublas_v2.h"
@@ -31,7 +31,7 @@
 namespace KokkosKernels {
 
 #if defined(KOKKOSKERNELS_ENABLE_TPL_CUBLAS)
-inline std::string get_cublas_version() {
+inline std::string cublas_version_string() {
   // Print version
   std::stringstream ss;
 
@@ -42,12 +42,12 @@ inline std::string get_cublas_version() {
 #endif
 
 #if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE)
-inline std::string get_cusparse_version() {
+inline std::string cusparse_version_string() {
   // Print version
   std::stringstream ss;
 
   ss << CUSPARSE_VER_MAJOR << "." << CUSPARSE_VER_MINOR << "."
-     << CUSPARSE_VER_PATCH << CUSPARSE_VER_BUILD;
+     << CUSPARSE_VER_PATCH << "." << CUSPARSE_VER_BUILD;
 
   return ss.str();
 }

--- a/common/src/KokkosKernels_TplsVersion.hpp
+++ b/common/src/KokkosKernels_TplsVersion.hpp
@@ -1,0 +1,58 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef _KOKKOSKERNELS_TPLS_VERSIONS_HPP
+#define _KOKKOSKERNELS_TPLS_VERSIONS_HPP
+
+#include "KokkosKernels_config.h"
+#include <iostream>
+
+#if defined(KOKKOSKERNELS_ENABLE_TPL_CUBLAS)
+#include "cublas_v2.h"
+#endif
+
+#if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE)
+#include "cusparse.h"
+#endif
+
+namespace KokkosKernels {
+
+#if defined(KOKKOSKERNELS_ENABLE_TPL_CUBLAS)
+inline std::string get_cublas_version() {
+  // Print version
+  std::stringstream ss;
+
+  ss << CUBLAS_VER_MAJOR << "." << CUBLAS_VER_MINOR << "." << CUBLAS_VER_PATCH
+     << CUBLAS_VER_BUILD;
+
+  return ss.str();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE)
+inline std::string get_cusparse_version() {
+  // Print version
+  std::stringstream ss;
+
+  ss << CUSPARSE_VER_MAJOR << "." << CUSPARSE_VER_MINOR << "."
+     << CUSPARSE_VER_PATCH << CUSPARSE_VER_BUILD;
+
+  return ss.str();
+}
+#endif
+
+}  // namespace KokkosKernels
+#endif  // _KOKKOSKERNELS_TPLS_VERSIONS_HPP


### PR DESCRIPTION
This PR provides a way to get and print CUBLAS and CUSPARSE TPLs version.
The idea is to print the TPL version instead of 'yes' when the TPL is activated. We still print 'no' if the TPL is not activated.

<details>
  <summary> extract of the test with CUBLAS and CUSPARSE TPLs activated </summary>

```
  KokkosKernels Version: 4.0.99
TPLs: 
1:   KOKKOSKERNELS_ENABLE_TPL_LAPACK: no
1:   KOKKOSKERNELS_ENABLE_TPL_BLAS: no
1:   KOKKOSKERNELS_ENABLE_TPL_CBLAS: no
1:   KOKKOSKERNELS_ENABLE_TPL_LAPACKE: no
1:   KOKKOSKERNELS_ENABLE_TPL_SUPERLU: no
1:   KOKKOSKERNELS_ENABLE_TPL_CHOLMOD: no
1:   KOKKOSKERNELS_ENABLE_TPL_MKL: no
1:   KOKKOSKERNELS_ENABLE_TPL_CUBLAS: 11.10.125
1:   KOKKOSKERNELS_ENABLE_TPL_CUSPARSE: 11.7.350
1:   KOKKOSKERNELS_ENABLE_TPL_ROCBLAS: no
1:   KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE: no
1:   KOKKOSKERNELS_ENABLE_TPL_METIS: no
1:   KOKKOSKERNELS_ENABLE_TPL_ARMPL: no
1:   KOKKOSKERNELS_ENABLE_TPL_MAGMA: no
```

</details>
