### PR TITLE
Test mixed scalars: more fixes related to mixed scalar tests

### DIFF
--- a/blas/unit_test/Test_Blas1_nrm2w.hpp
+++ b/blas/unit_test/Test_Blas1_nrm2w.hpp
@@ -32,8 +32,8 @@ void impl_test_nrm2w(int N) {
   typename ViewTypeA::HostMirror h_a = Kokkos::create_mirror_view(a);
   typename ViewTypeA::HostMirror h_w = Kokkos::create_mirror_view(w);
 
-  const MagnitudeA max_val = 10;
-  const MagnitudeA eps     = AT::epsilon();
+  constexpr MagnitudeA max_val = 10;
+  const MagnitudeA eps         = AT::epsilon();
   const MagnitudeA max_error =
       max_val * std::sqrt(static_cast<MagnitudeA>(N)) * eps;
 
@@ -82,8 +82,8 @@ void impl_test_nrm2w_mv(int N, int K) {
   typename ViewTypeA::HostMirror h_a = h_vfA_type::view(h_b_a);
   typename ViewTypeA::HostMirror h_w = h_vfA_type::view(h_b_w);
 
-  const MagnitudeA max_val = 10;
-  const MagnitudeA eps     = AT::epsilon();
+  constexpr MagnitudeA max_val = 10;
+  const MagnitudeA eps         = AT::epsilon();
   const MagnitudeA max_error =
       max_val * std::sqrt(static_cast<MagnitudeA>(N)) * eps;
 

--- a/blas/unit_test/Test_Blas1_nrm2w.hpp
+++ b/blas/unit_test/Test_Blas1_nrm2w.hpp
@@ -22,8 +22,9 @@
 namespace Test {
 template <class ViewTypeA, class Device>
 void impl_test_nrm2w(int N) {
-  typedef typename ViewTypeA::value_type ScalarA;
-  typedef Kokkos::ArithTraits<ScalarA> AT;
+  using ScalarA    = typename ViewTypeA::value_type;
+  using AT         = Kokkos::ArithTraits<ScalarA>;
+  using MagnitudeA = typename AT::mag_type;
 
   ViewTypeA a("A", N);
   ViewTypeA w("W", N);
@@ -31,18 +32,21 @@ void impl_test_nrm2w(int N) {
   typename ViewTypeA::HostMirror h_a = Kokkos::create_mirror_view(a);
   typename ViewTypeA::HostMirror h_w = Kokkos::create_mirror_view(w);
 
+  const MagnitudeA max_val = 10;
+  const MagnitudeA eps     = AT::epsilon();
+  const MagnitudeA max_error =
+      max_val * std::sqrt(static_cast<MagnitudeA>(N)) * eps;
+
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
   ScalarA randStart, randEnd;
-  Test::getRandomBounds(1.0, randStart, randEnd);
+  Test::getRandomBounds(max_val, randStart, randEnd);
   Kokkos::fill_random(a, rand_pool, randStart, randEnd);
-  Kokkos::fill_random(w, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(w, rand_pool, AT::one(), randEnd);  // Avoid divide by 0
 
   Kokkos::deep_copy(h_a, a);
   Kokkos::deep_copy(h_w, w);
-
-  double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
 
   typename AT::mag_type expected_result = 0;
   for (int i = 0; i < N; i++) {
@@ -53,15 +57,16 @@ void impl_test_nrm2w(int N) {
       Kokkos::ArithTraits<typename AT::mag_type>::sqrt(expected_result);
 
   typename AT::mag_type nonconst_result = KokkosBlas::nrm2w(a, w);
-  EXPECT_NEAR_KK(nonconst_result, expected_result, eps * expected_result);
+  EXPECT_NEAR_KK(nonconst_result, expected_result, max_error);
 }
 
 template <class ViewTypeA, class Device>
 void impl_test_nrm2w_mv(int N, int K) {
-  typedef typename ViewTypeA::value_type ScalarA;
-  typedef Kokkos::ArithTraits<ScalarA> AT;
+  using ScalarA    = typename ViewTypeA::value_type;
+  using AT         = Kokkos::ArithTraits<ScalarA>;
+  using MagnitudeA = typename AT::mag_type;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
+  using vfA_type = multivector_layout_adapter<ViewTypeA>;
 
   typename vfA_type::BaseType b_a("A", N, K);
   typename vfA_type::BaseType b_w("W", N, K);
@@ -69,7 +74,7 @@ void impl_test_nrm2w_mv(int N, int K) {
   ViewTypeA a = vfA_type::view(b_a);
   ViewTypeA w = vfA_type::view(b_w);
 
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
+  using h_vfA_type = multivector_layout_adapter<typename ViewTypeA::HostMirror>;
 
   typename h_vfA_type::BaseType h_b_a = Kokkos::create_mirror_view(b_a);
   typename h_vfA_type::BaseType h_b_w = Kokkos::create_mirror_view(b_w);
@@ -77,13 +82,19 @@ void impl_test_nrm2w_mv(int N, int K) {
   typename ViewTypeA::HostMirror h_a = h_vfA_type::view(h_b_a);
   typename ViewTypeA::HostMirror h_w = h_vfA_type::view(h_b_w);
 
+  const MagnitudeA max_val = 10;
+  const MagnitudeA eps     = AT::epsilon();
+  const MagnitudeA max_error =
+      max_val * std::sqrt(static_cast<MagnitudeA>(N)) * eps;
+
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
   ScalarA randStart, randEnd;
-  Test::getRandomBounds(1.0, randStart, randEnd);
+  Test::getRandomBounds(max_val, randStart, randEnd);
   Kokkos::fill_random(b_a, rand_pool, randStart, randEnd);
-  Kokkos::fill_random(b_w, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(b_w, rand_pool, AT::one(),
+                      randEnd);  // Avoid dividing by 0
 
   Kokkos::deep_copy(h_b_a, b_a);
   Kokkos::deep_copy(h_b_w, b_w);
@@ -99,16 +110,13 @@ void impl_test_nrm2w_mv(int N, int K) {
         Kokkos::ArithTraits<typename AT::mag_type>::sqrt(expected_result[j]);
   }
 
-  double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
-
   Kokkos::View<typename AT::mag_type*, Device> r("Dot::Result", K);
   KokkosBlas::nrm2w(r, a, w);
   auto r_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), r);
 
   for (int k = 0; k < K; k++) {
     typename AT::mag_type nonconst_result = r_host(k);
-    EXPECT_NEAR_KK(nonconst_result, expected_result[k],
-                   eps * expected_result[k]);
+    EXPECT_NEAR_KK(nonconst_result, expected_result[k], max_error);
   }
 
   delete[] expected_result;

--- a/blas/unit_test/Test_Blas1_nrm2w_squared.hpp
+++ b/blas/unit_test/Test_Blas1_nrm2w_squared.hpp
@@ -32,9 +32,9 @@ void impl_test_nrm2w_squared(int N) {
   typename ViewTypeA::HostMirror h_a = Kokkos::create_mirror_view(a);
   typename ViewTypeA::HostMirror h_w = Kokkos::create_mirror_view(w);
 
-  const MagnitudeA max_val   = 10;
-  const MagnitudeA eps       = AT::epsilon();
-  const MagnitudeA max_error = max_val * max_val * N * eps;
+  constexpr MagnitudeA max_val = 10;
+  const MagnitudeA eps         = AT::epsilon();
+  const MagnitudeA max_error   = max_val * max_val * N * eps;
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
@@ -79,9 +79,9 @@ void impl_test_nrm2w_squared_mv(int N, int K) {
   typename ViewTypeA::HostMirror h_a = h_vfA_type::view(h_b_a);
   typename ViewTypeA::HostMirror h_w = h_vfA_type::view(h_b_w);
 
-  const MagnitudeA max_val   = 10;
-  const MagnitudeA eps       = AT::epsilon();
-  const MagnitudeA max_error = max_val * max_val * N * eps;
+  constexpr MagnitudeA max_val = 10;
+  const MagnitudeA eps         = AT::epsilon();
+  const MagnitudeA max_error   = max_val * max_val * N * eps;
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);

--- a/blas/unit_test/Test_Blas1_team_mult.hpp
+++ b/blas/unit_test/Test_Blas1_team_mult.hpp
@@ -225,9 +225,10 @@ void impl_test_team_mult_mv(int N, int K) {
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
-  Kokkos::fill_random(b_x, rand_pool, ScalarA(10));
-  Kokkos::fill_random(b_y, rand_pool, ScalarB(10));
-  Kokkos::fill_random(b_z, rand_pool, ScalarC(10));
+  typename Kokkos::ArithTraits<ScalarC>::mag_type const max_val = 10;
+  Kokkos::fill_random(b_x, rand_pool, ScalarA(max_val));
+  Kokkos::fill_random(b_y, rand_pool, ScalarB(max_val));
+  Kokkos::fill_random(b_z, rand_pool, ScalarC(max_val));
 
   Kokkos::deep_copy(b_org_z, b_z);
 
@@ -242,6 +243,8 @@ void impl_test_team_mult_mv(int N, int K) {
 
   typename Kokkos::ArithTraits<ScalarC>::mag_type const eps =
       Kokkos::ArithTraits<ScalarC>::epsilon();
+  typename Kokkos::ArithTraits<ScalarC>::mag_type const max_error =
+      3 * max_val * max_val * eps;
 
   // KokkosBlas::mult(b,z,a,x,y);
   Kokkos::parallel_for(
@@ -262,7 +265,7 @@ void impl_test_team_mult_mv(int N, int K) {
   for (int j = 0; j < K; j++) {
     for (int i = 0; i < N; i++) {
       temp = ScalarC(b * h_b_org_z(i, j) + a * h_x(i) * h_y(i, j));
-      EXPECT_NEAR_KK(temp, h_b_z_res(i, j), 10 * eps);
+      EXPECT_NEAR_KK(temp, h_b_z_res(i, j), max_error);
     }
   }
 
@@ -281,7 +284,7 @@ void impl_test_team_mult_mv(int N, int K) {
   for (int k = 0; k < K; k++) {
     for (int i = 0; i < N; ++i) {
       temp = ScalarC(b * h_b_org_z(i, k) + a * h_x(i) * h_y(i, k));
-      EXPECT_NEAR_KK(temp, h_b_z_res(i, k), 10 * eps);
+      EXPECT_NEAR_KK(temp, h_b_z_res(i, k), max_error);
     }
   }
 }
@@ -366,7 +369,6 @@ int test_team_mult_mv() {
   // view_type_c_ll, Device>(132231,5);
 #endif
 
-  /*
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&       \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -382,7 +384,6 @@ int test_team_mult_mv() {
   // Test::impl_test_team_mult_mv<view_type_a_lr, view_type_b_lr,
   // view_type_c_lr, Device>(132231,5);
 #endif
-  */
 
   /*
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \

--- a/blas/unit_test/Test_Blas1_team_mult.hpp
+++ b/blas/unit_test/Test_Blas1_team_mult.hpp
@@ -240,24 +240,6 @@ void impl_test_team_mult_mv(int N, int K) {
   typename ViewTypeA::const_type c_x = x;
   typename ViewTypeB::const_type c_y = y;
 
-  std::cout << "Input values:" << std::endl;
-  std::cout << "\ta=" << a << ", b=" << b << std::endl;
-  std::cout << "\tx: { ";
-  for (int i = 0; i < static_cast<int>(h_b_x.extent(0)); ++i) {
-    std::cout << h_b_x(i, 0) << " ";
-  }
-  std::cout << "}" << std::endl;
-  std::cout << "\ty: { ";
-  for (int i = 0; i < static_cast<int>(h_b_y.extent(0)); ++i) {
-    std::cout << h_b_y(i, 0) << " ";
-  }
-  std::cout << "}" << std::endl;
-  std::cout << "\tz: { ";
-  for (int i = 0; i < static_cast<int>(h_b_z.extent(0)); ++i) {
-    std::cout << h_b_z(i, 0) << " ";
-  }
-  std::cout << "}" << std::endl;
-
   typename Kokkos::ArithTraits<ScalarC>::mag_type const eps =
       Kokkos::ArithTraits<ScalarC>::epsilon();
 
@@ -276,13 +258,6 @@ void impl_test_team_mult_mv(int N, int K) {
   Kokkos::deep_copy(h_b_z_res, b_z);
   typename h_vfC_type::BaseType h_b_org_z = Kokkos::create_mirror_view(b_org_z);
   Kokkos::deep_copy(h_b_org_z, b_org_z);
-
-  std::cout << "Output values:" << std::endl;
-  std::cout << "\tz: { ";
-  for (int i = 0; i < static_cast<int>(h_b_z_res.extent(0)); ++i) {
-    std::cout << h_b_z_res(i, 0) << " ";
-  }
-  std::cout << "}" << std::endl;
 
   for (int j = 0; j < K; j++) {
     for (int i = 0; i < N; i++) {

--- a/blas/unit_test/Test_Blas1_team_mult.hpp
+++ b/blas/unit_test/Test_Blas1_team_mult.hpp
@@ -241,10 +241,15 @@ void impl_test_team_mult_mv(int N, int K) {
   typename ViewTypeA::const_type c_x = x;
   typename ViewTypeB::const_type c_y = y;
 
+  // In the operation z = (b*z) + (a*x*y) we estimate
+  // the largest rounding error to be dominated by max(b*z, a*x*y)
+  // Since b and a are known and the largest value in z, x and y
+  // is set by the variables max_val, the error upper bound will be
+  //         max_error = a * max_val * max_val
   typename Kokkos::ArithTraits<ScalarC>::mag_type const eps =
       Kokkos::ArithTraits<ScalarC>::epsilon();
   typename Kokkos::ArithTraits<ScalarC>::mag_type const max_error =
-      3 * max_val * max_val * eps;
+      a * max_val * max_val * eps;
 
   // KokkosBlas::mult(b,z,a,x,y);
   Kokkos::parallel_for(

--- a/blas/unit_test/Test_Blas1_team_update.hpp
+++ b/blas/unit_test/Test_Blas1_team_update.hpp
@@ -249,7 +249,7 @@ void impl_test_team_update_mv(int N, int K) {
           ScalarC(a * h_x(i, j) + b * h_y(i, j) + c * h_z(i, j));
   }
 
-  double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
+  double eps = std::is_same<ScalarC, float>::value ? 2 * 1e-5 : 1e-7;
 
   Kokkos::View<ScalarC *, Kokkos::HostSpace> r("Dot::Result", K);
 

--- a/blas/unit_test/Test_Blas2_gemv.hpp
+++ b/blas/unit_test/Test_Blas2_gemv.hpp
@@ -30,7 +30,7 @@ void impl_test_gemv(const char* mode, int M, int N) {
 
   typedef multivector_layout_adapter<ViewTypeA> vfA_type;
 
-  ScalarA alpha                      = 3;
+  const ScalarA alpha                = 3;
   ScalarY beta                       = 5;
   typename KAT_Y::mag_type const eps = KAT_Y::epsilon();
 
@@ -63,9 +63,9 @@ void impl_test_gemv(const char* mode, int M, int N) {
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
-  const double max_valX = 1;
-  const double max_valY = 1;
-  const double max_valA = 1;
+  constexpr double max_valX = 1;
+  constexpr double max_valY = 1;
+  constexpr double max_valA = 1;
   {
     ScalarX randStart, randEnd;
     Test::getRandomBounds(max_valX, randStart, randEnd);

--- a/blas/unit_test/Test_Blas2_gemv.hpp
+++ b/blas/unit_test/Test_Blas2_gemv.hpp
@@ -105,7 +105,8 @@ void impl_test_gemv(const char* mode, int M, int N) {
   for (int i = 0; i < ldy; i++) {
     if (KAT_Y::abs(expected(i) - h_y(i)) > tol) {
       numErrors++;
-      std::cout << "expected(i)=" << expected(i) << ", h_y(i)=" << h_y(i)
+      std::cerr << __FILE__ << ":" << __LINE__
+                << ": expected(i)=" << expected(i) << ", h_y(i)=" << h_y(i)
                 << std::endl;
     }
   }
@@ -148,8 +149,9 @@ void impl_test_gemv(const char* mode, int M, int N) {
         KAT_Y::abs(expected(i) - h_y(i)) >
             KAT_Y::abs(alpha * max_valA * max_valX * ldx * eps * 2)) {
       numErrors++;
-      std::cout << "expected(" << i << ")=" << expected(i) << ", h_y(" << i
-                << ")=" << h_y(i) << ", eps=" << eps
+      std::cerr << __FILE__ << ":" << __LINE__ << ": expected(" << i
+                << ")=" << expected(i) << ", h_y(" << i << ")=" << h_y(i)
+                << ", eps=" << eps
                 << ", 1024*2*eps=" << 1024 * 2 * KAT_Y::epsilon() << std::endl;
     }
   }

--- a/blas/unit_test/Test_Blas2_gemv.hpp
+++ b/blas/unit_test/Test_Blas2_gemv.hpp
@@ -30,10 +30,9 @@ void impl_test_gemv(const char* mode, int M, int N) {
 
   typedef multivector_layout_adapter<ViewTypeA> vfA_type;
 
-  ScalarA alpha = 3;
-  ScalarY beta  = 5;
-  double eps =
-      (std::is_same<typename KAT_Y::mag_type, float>::value ? 1e-2 : 5e-10);
+  ScalarA alpha                      = 3;
+  ScalarY beta                       = 5;
+  typename KAT_Y::mag_type const eps = KAT_Y::epsilon();
 
   int ldx;
   int ldy;
@@ -64,21 +63,29 @@ void impl_test_gemv(const char* mode, int M, int N) {
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
+  const double max_valX = 1;
+  const double max_valY = 1;
+  const double max_valA = 1;
   {
     ScalarX randStart, randEnd;
-    Test::getRandomBounds(1.0, randStart, randEnd);
+    Test::getRandomBounds(max_valX, randStart, randEnd);
     Kokkos::fill_random(x, rand_pool, randStart, randEnd);
   }
   {
     ScalarY randStart, randEnd;
-    Test::getRandomBounds(1.0, randStart, randEnd);
+    Test::getRandomBounds(max_valY, randStart, randEnd);
     Kokkos::fill_random(y, rand_pool, randStart, randEnd);
   }
   {
     ScalarA randStart, randEnd;
-    Test::getRandomBounds(1.0, randStart, randEnd);
+    Test::getRandomBounds(max_valA, randStart, randEnd);
     Kokkos::fill_random(b_A, rand_pool, randStart, randEnd);
   }
+
+  const typename KAT_Y::mag_type max_error =
+      KAT_Y::abs(alpha * max_valA * max_valX * ldx + beta * max_valY);
+  const typename KAT_Y::mag_type tol =
+      max_error * eps * 2;  // adding small fudge factor of 2
 
   Kokkos::deep_copy(org_y, y);
   auto h_org_y =
@@ -96,8 +103,11 @@ void impl_test_gemv(const char* mode, int M, int N) {
   Kokkos::deep_copy(h_y, y);
   int numErrors = 0;
   for (int i = 0; i < ldy; i++) {
-    if (KAT_Y::abs(expected(i) - h_y(i)) > KAT_Y::abs(eps * expected(i)))
+    if (KAT_Y::abs(expected(i) - h_y(i)) > tol) {
       numErrors++;
+      std::cout << "expected(i)=" << expected(i) << ", h_y(i)=" << h_y(i)
+                << std::endl;
+    }
   }
   EXPECT_EQ(numErrors, 0) << "Nonconst input, " << M << 'x' << N
                           << ", alpha = " << alpha << ", beta = " << beta
@@ -108,8 +118,7 @@ void impl_test_gemv(const char* mode, int M, int N) {
   Kokkos::deep_copy(h_y, y);
   numErrors = 0;
   for (int i = 0; i < ldy; i++) {
-    if (KAT_Y::abs(expected(i) - h_y(i)) > KAT_Y::abs(eps * expected(i)))
-      numErrors++;
+    if (KAT_Y::abs(expected(i) - h_y(i)) > tol) numErrors++;
   }
   EXPECT_EQ(numErrors, 0) << "Const vector input, " << M << 'x' << N
                           << ", alpha = " << alpha << ", beta = " << beta
@@ -120,8 +129,7 @@ void impl_test_gemv(const char* mode, int M, int N) {
   Kokkos::deep_copy(h_y, y);
   numErrors = 0;
   for (int i = 0; i < ldy; i++) {
-    if (KAT_Y::abs(expected(i) - h_y(i)) > KAT_Y::abs(eps * expected(i)))
-      numErrors++;
+    if (KAT_Y::abs(expected(i) - h_y(i)) > tol) numErrors++;
   }
   EXPECT_EQ(numErrors, 0) << "Const matrix/vector input, " << M << 'x' << N
                           << ", alpha = " << alpha << ", beta = " << beta
@@ -137,8 +145,13 @@ void impl_test_gemv(const char* mode, int M, int N) {
   numErrors = 0;
   for (int i = 0; i < ldy; i++) {
     if (KAT_Y::isNan(h_y(i)) ||
-        KAT_Y::abs(expected(i) - h_y(i)) > KAT_Y::abs(eps * expected(i)))
+        KAT_Y::abs(expected(i) - h_y(i)) >
+            KAT_Y::abs(alpha * max_valA * max_valX * ldx * eps * 2)) {
       numErrors++;
+      std::cout << "expected(" << i << ")=" << expected(i) << ", h_y(" << i
+                << ")=" << h_y(i) << ", eps=" << eps
+                << ", 1024*2*eps=" << 1024 * 2 * KAT_Y::epsilon() << std::endl;
+    }
   }
   EXPECT_EQ(numErrors, 0) << "beta = 0, input contains NaN, A is " << M << 'x'
                           << N << ", mode " << mode << ": gemv incorrect";


### PR DESCRIPTION
Mostly fixing issues that stemed from not running these tests on a regular basis, for instance generating FPE because of changes in how random inputs are generated.

With the changes in this PR, Kokkos Kernels using the CI configuration for GCC1020 builds and runs fine with `-D KokkosKernels_TEST_ETI_ONLY=OFF` this would allow us to test for mixed scalar types in one of our builds...