### PR TITLE
cast Kokkos::Impl::integral_constant to int

### DIFF
--- a/common/src/KokkosKernels_PrintUtils.hpp
+++ b/common/src/KokkosKernels_PrintUtils.hpp
@@ -104,7 +104,8 @@ inline std::enable_if_t<idx_array_type::rank >= 2> kk_print_1Dview(
     return;
   }
   os << "[" << view.extent(0);
-  for (int i = 1; i < idx_array_type::rank; ++i) {
+  // ::rank is a Kokkos::...::integral_constant, not appropriate for `i`
+  for (int i = 1; i < int(idx_array_type::rank); ++i) {
     os << "x" << view.extent(i);
   }
   os << " multi-vector]" << std::endl;


### PR DESCRIPTION
The bounds on this loop is a `Kokkos::Impl::integral_constant`, which is not appropriate for the iteration variable. So cast it to `int`.