### PR TITLE
CUSPARSE_MM_ALG_DEFAULT deprecated by cuSparse 11.1

### DIFF
--- a/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
@@ -151,7 +151,8 @@ void spmv_mv_cusparse(const KokkosKernels::Experimental::Controls &controls,
   cusparseOperation_t opB =
       xIsLL ? CUSPARSE_OPERATION_NON_TRANSPOSE : CUSPARSE_OPERATION_TRANSPOSE;
 
-#if CUDA_VERSION < 12000
+// CUSPARSE_MM_ALG_DEFAULT was deprecated as early as 11.1 (maybe earlier)
+#if CUSPARSE_VERSION < 11010
   const cusparseSpMMAlg_t alg = CUSPARSE_MM_ALG_DEFAULT;
 #else
   const cusparseSpMMAlg_t alg = CUSPARSE_SPMM_ALG_DEFAULT;


### PR DESCRIPTION
This may have actually been deprecated as early as 11.0, but the online documentation is down so I can't check for sure.