### PR TITLE
blas/blas1: Fix a couple documentation typos.

### DIFF
--- a/blas/src/KokkosBlas1_mult.hpp
+++ b/blas/src/KokkosBlas1_mult.hpp
@@ -23,6 +23,20 @@
 
 namespace KokkosBlas {
 
+/// \brief Element wise multiplication of two vectors:
+///        Y[i] = gamma * Y[i] + alpha * A[i] * X[i]
+///
+/// \tparam YMV Type of the first vector Y; a 1-D or 2-D Kokkos::View.
+/// \tparam AV  Type of the second vector A; a 1-D Kokkos::View.
+/// \tparam XMV Type of the third vector X; a 1-D or 2-D Kokkos::View.
+///
+/// \param gamma [in] The scalar to apply to Y.
+/// \param Y [in/out] The Y vector.
+/// \param alpha [in] The scalar to apply to A.
+/// \param A [in]     The vector to apply to X.
+/// \param X [in]     The X vector.
+///
+/// \return Y = gamma * Y + alpha * A * X.
 template <class YMV, class AV, class XMV>
 void mult(typename YMV::const_value_type& gamma, const YMV& Y,
           typename AV::const_value_type& alpha, const AV& A, const XMV& X) {

--- a/blas/src/KokkosBlas1_nrm2w.hpp
+++ b/blas/src/KokkosBlas1_nrm2w.hpp
@@ -66,7 +66,7 @@ nrm2w(const XVector& x, const XVector& w) {
 
 /// \brief R(i,j) = nrm2w(X(i,j))
 ///
-/// Replace each entry in R with the nrm2wolute value (magnitude) of the
+/// Replace each entry in R with the nrm2w, absolute value (magnitude), of the
 /// corresponding entry in X.
 ///
 /// \tparam RMV 1-D or 2-D Kokkos::View specialization.

--- a/blas/src/KokkosBlas1_reciprocal.hpp
+++ b/blas/src/KokkosBlas1_reciprocal.hpp
@@ -25,8 +25,8 @@ namespace KokkosBlas {
 
 /// \brief R(i,j) = reciprocal(X(i,j))
 ///
-/// Replace each entry in R with the reciprocalolute value (magnitude) of the
-/// corresponding entry in X.
+/// Replace each entry in R with the absolute value (magnitude), of the
+/// reciprocal of the corresponding entry in X.
 ///
 /// \tparam RMV 1-D or 2-D Kokkos::View specialization.
 /// \tparam XMV 1-D or 2-D Kokkos::View specialization.  It must have


### PR DESCRIPTION
I noticed a couple documentation typos in https://kokkos-kernels.readthedocs.io/en/latest/.

Leaving the `AT: WIP` label applied here such that only github-{DOCS,FORMAT} CI checks are run. There is no need to run a full build and test.