### PR TITLE
Kokkos Kernels version: need to use upper case variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,7 @@ ELSE()
   # ==================================================================
   MESSAGE("")
   MESSAGE("================================")
-  MESSAGE("Kokkos Kernels version: ${KokkosKernels_VERSION_MAJOR}.${KokkosKernels_VERSION_MINOR}.${KokkosKernels_VERSION_PATCH}")
+  MESSAGE("Kokkos Kernels version: ${KOKKOSKERNELS_VERSION_MAJOR}.${KOKKOSKERNELS_VERSION_MINOR}.${KOKKOSKERNELS_VERSION_PATCH}")
   MESSAGE("================================")
   MESSAGE("Kokkos Kernels ETI Types")
   MESSAGE("   Devices:  ${DEVICE_LIST}")


### PR DESCRIPTION
It appears that we need to use the upper case spelling of the variables defining the current version of Kokkos Kernels. I'm not totally sure why but it could have something to do with the fact that we are re-using the same variable names twice...