### PR TITLE
4.0.0 compatibility

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -625,6 +625,18 @@ KOKKOS_INLINE_FUNCTION auto subview_wrapper(ViewType v, IdxType1 i1,
                                             const Trans::NoTranspose) {
   return subview_wrapper(v, i1, i2, i3, layout_tag);
 }
+#if KOKKOS_VERSION <= 40000
+template <class ViewType, class IdxType1>
+KOKKOS_INLINE_FUNCTION auto subview_wrapper(ViewType v, IdxType1 i1,
+                                            Kokkos::Impl::ALL_t i2,
+                                            Kokkos::Impl::ALL_t i3,
+                                            const BatchLayout::Left &layout_tag,
+                                            const Trans::Transpose) {
+  auto sv_nt = subview_wrapper(v, i1, i3, i2, layout_tag);
+
+  return transpose_2d_view(sv_nt, layout_tag);
+}
+#else
 template <class ViewType, class IdxType1>
 KOKKOS_INLINE_FUNCTION auto subview_wrapper(ViewType v, IdxType1 i1,
                                             Kokkos::ALL_t i2, Kokkos::ALL_t i3,
@@ -634,6 +646,7 @@ KOKKOS_INLINE_FUNCTION auto subview_wrapper(ViewType v, IdxType1 i1,
 
   return transpose_2d_view(sv_nt, layout_tag);
 }
+#endif
 template <class ViewType, class IdxType1, class IdxType2, class IdxType3>
 KOKKOS_INLINE_FUNCTION auto subview_wrapper(ViewType v, IdxType1 i1,
                                             IdxType2 i2, IdxType3 i3,
@@ -657,6 +670,16 @@ KOKKOS_INLINE_FUNCTION auto subview_wrapper(
     const BatchLayout::Right &layout_tag, const Trans::NoTranspose &) {
   return subview_wrapper(v, i1, i2, i3, layout_tag);
 }
+#if KOKKOS_VERSION <= 40000
+template <class ViewType, class IdxType1>
+KOKKOS_INLINE_FUNCTION auto subview_wrapper(
+    ViewType v, IdxType1 i1, Kokkos::Impl::ALL_t i2, Kokkos::Impl::ALL_t i3,
+    const BatchLayout::Right &layout_tag, const Trans::Transpose &) {
+  auto sv_nt = subview_wrapper(v, i1, i3, i2, layout_tag);
+
+  return transpose_2d_view(sv_nt, layout_tag);
+}
+#else
 template <class ViewType, class IdxType1>
 KOKKOS_INLINE_FUNCTION auto subview_wrapper(
     ViewType v, IdxType1 i1, Kokkos::ALL_t i2, Kokkos::ALL_t i3,
@@ -665,6 +688,7 @@ KOKKOS_INLINE_FUNCTION auto subview_wrapper(
 
   return transpose_2d_view(sv_nt, layout_tag);
 }
+#endif
 template <class ViewType, class IdxType1, class IdxType2, class IdxType3>
 KOKKOS_INLINE_FUNCTION auto subview_wrapper(
     ViewType v, IdxType1 i1, IdxType2 i2, IdxType3 i3,


### PR DESCRIPTION
Compatibility upgrade: adding compatibility branch in code with the `#ifdef` introduced, the code will compile against 4.0.0 and develop versions of Kokkos Core.