### PR TITLE
Always generate HTML docs, only add Sphinx targets if possible

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          sudo apt install doxygen
+          sudo apt install --no-install-recommends doxygen-latex
           pip install sphinx
           pip install breathe
           pip install sphinx-rtd-theme

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,10 +1,7 @@
 # Source: https://devblogs.microsoft.com/cppblog/clear-functional-c-documentation-with-sphinx-breathe-doxygen-cmake/
 # Author: Evan Harvey <eharvey@sandia.gov>
 find_package(Doxygen REQUIRED)
-find_package(Sphinx REQUIRED)
 
-set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR})
-set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/docs/sphinx)
 set(KOKKOS_INCLUDE_DIR ${Kokkos_DIR}/../../../include)
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/conf.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
@@ -36,12 +33,21 @@ add_custom_command(OUTPUT ${DOXYGEN_INDEX_FILE}
 
 add_custom_target(Doxygen ALL DEPENDS ${DOXYGEN_INDEX_FILE})
 
+## If we can find sphinx, add that target too
+find_package(Sphinx)
 
-add_custom_target(Sphinx ALL
-        COMMAND ${SPHINX_EXECUTABLE} -b html
-        # Tell Breathe where to find the Doxygen output
-        -Dbreathe_projects.${PROJECT_NAME}=${DOXYGEN_OUTPUT_DIR}/xml
-        ${SPHINX_SOURCE} ${SPHINX_BUILD}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        DEPENDS Doxygen
-        COMMENT "Generating documentation with Sphinx")
+if (Sphinx_FOUND)
+        set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR})
+        set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/docs/sphinx)
+
+        add_custom_target(Sphinx ALL
+                COMMAND ${SPHINX_EXECUTABLE} -b html
+                # Tell Breathe where to find the Doxygen output
+                -Dbreathe_projects.${PROJECT_NAME}=${DOXYGEN_OUTPUT_DIR}/xml
+                ${SPHINX_SOURCE} ${SPHINX_BUILD}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                DEPENDS Doxygen
+                COMMENT "Generating documentation with Sphinx")
+else() # Sphinx_FOUND
+        message(STATUS "Sphinx not found. Only Doxygen docs can be built")
+endif() # Sphinx_FOUND

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -871,10 +871,10 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @CMAKE_SOURCE_DIR@/sparse/src/ \
-                         @CMAKE_SOURCE_DIR@/blas/src/ \
-                         @CMAKE_SOURCE_DIR@/batched/dense/src/ \
-                         @CMAKE_SOURCE_DIR@/batched/sparse/src/
+INPUT                  = @PROJECT_SOURCE_DIR@/sparse/src/ \
+                         @PROJECT_SOURCE_DIR@/blas/src/ \
+                         @PROJECT_SOURCE_DIR@/batched/dense/src/ \
+                         @PROJECT_SOURCE_DIR@/batched/sparse/src/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -602,12 +602,6 @@ HIDE_SCOPE_NAMES       = NO
 
 HIDE_COMPOUND_REFERENCE= NO
 
-# If the SHOW_HEADERFILE tag is set to YES then the documentation for a class
-# will show which file needs to be included to use the class.
-# The default value is: YES.
-
-SHOW_HEADERFILE        = YES
-
 # If the SHOW_INCLUDE_FILES tag is set to YES then doxygen will put a list of
 # the files that are included by a file in the documentation of that file.
 # The default value is: YES.
@@ -818,13 +812,6 @@ WARN_IF_UNDOCUMENTED   = YES
 # The default value is: YES.
 
 WARN_IF_DOC_ERROR      = YES
-
-# If WARN_IF_INCOMPLETE_DOC is set to YES, doxygen will warn about incomplete
-# function parameter documentation. If set to NO, doxygen will accept that some
-# parameters have no documentation without warning.
-# The default value is: YES.
-
-WARN_IF_INCOMPLETE_DOC = YES
 
 # This WARN_NO_PARAMDOC option can be enabled to get warnings for functions that
 # are documented, but have no documentation for their parameters or return
@@ -1561,18 +1548,6 @@ DISABLE_INDEX          = NO
 
 GENERATE_TREEVIEW      = NO
 
-# When both GENERATE_TREEVIEW and DISABLE_INDEX are set to YES, then the
-# FULL_SIDEBAR option determines if the side bar is limited to only the treeview
-# area (value NO) or if it should extend to the full height of the window (value
-# YES). Setting this to YES gives a layout similar to
-# https://docs.readthedocs.io with more room for contents, but less room for the
-# project logo, title, and description. If either GENERATOR_TREEVIEW or
-# DISABLE_INDEX is set to NO, this option has no effect.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-FULL_SIDEBAR           = NO
-
 # The ENUM_VALUES_PER_LINE tag can be used to set the number of enum values that
 # doxygen will group on one line in the generated HTML documentation.
 #
@@ -1644,17 +1619,6 @@ FORMULA_MACROFILE      =
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
 USE_MATHJAX            = NO
-
-# With MATHJAX_VERSION it is possible to specify the MathJax version to be used.
-# Note that the different versions of MathJax have different requirements with
-# regards to the different settings, so it is possible that also other MathJax
-# settings have to be changed when switching between the different MathJax
-# versions.
-# Possible values are: MathJax_2 and MathJax_3.
-# The default value is: MathJax_2.
-# This tag requires that the tag USE_MATHJAX is set to YES.
-
-MATHJAX_VERSION        = MathJax_2
 
 # When MathJax is enabled you can set the default output format to be used for
 # the MathJax output. For more details about the output format see MathJax

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1186,7 +1186,7 @@ IGNORE_PREFIX          =
 # If the GENERATE_HTML tag is set to YES, doxygen will generate HTML output
 # The default value is: YES.
 
-GENERATE_HTML          = NO
+GENERATE_HTML          = YES
 
 # The HTML_OUTPUT tag is used to specify where the HTML docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of


### PR DESCRIPTION
This is nice for locally hacking on the docs without a complete setup for Sphinx.