### PR TITLE
CUDA 11.4: fixing some failing build while trying to reproduce issue #1725

### DIFF
--- a/sparse/impl/KokkosSparse_sptrsv_cuSPARSE_impl.hpp
+++ b/sparse/impl/KokkosSparse_sptrsv_cuSPARSE_impl.hpp
@@ -299,6 +299,10 @@ void sptrsvcuSPARSE_solve(KernelHandle* sptrsv_handle,
   typedef typename KernelHandle::scalar_t scalar_type;
   typedef typename KernelHandle::memory_space memory_space;
 
+  (void)row_map;
+  (void)entries;
+  (void)values;
+
   const bool is_cuda_space =
       std::is_same<memory_space, Kokkos::CudaSpace>::value ||
       std::is_same<memory_space, Kokkos::CudaUVMSpace>::value ||

--- a/sparse/src/KokkosSparse_sptrsv_handle.hpp
+++ b/sparse/src/KokkosSparse_sptrsv_handle.hpp
@@ -138,7 +138,7 @@ class SPTRSVHandle {
     cusparseSpSVDescr_t spsvDescr;
     void *pBuffer{nullptr};
 
-    cuSparseHandleType(bool transpose_, bool is_lower) {
+    cuSparseHandleType(bool transpose_, bool /*is_lower*/) {
       KOKKOS_CUSPARSE_SAFE_CALL(cusparseCreate(&handle));
 
       KOKKOS_CUSPARSE_SAFE_CALL(

--- a/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_decl.hpp
@@ -45,7 +45,7 @@ template <typename KernelHandle, typename lno_t, typename ConstRowMapType,
           typename ConstEntriesType, typename ConstValuesType,
           typename EntriesType, typename ValuesType>
 void spgemm_numeric_cusparse(
-    KernelHandle *handle, lno_t m, lno_t n, lno_t k,
+    KernelHandle *handle, lno_t /*m*/, lno_t /*n*/, lno_t /*k*/,
     const ConstRowMapType &row_mapA, const ConstEntriesType &entriesA,
     const ConstValuesType &valuesA, const ConstRowMapType &row_mapB,
     const ConstEntriesType &entriesB, const ConstValuesType &valuesB,


### PR DESCRIPTION
This basically removes a few function parameters that are unused in the cuda branch for version higher than 11.4.