### PR TITLE
Improve BSR matrix SpMV Performance

### DIFF
--- a/common/impl/KokkosKernels_AlwaysFalse.hpp
+++ b/common/impl/KokkosKernels_AlwaysFalse.hpp
@@ -17,23 +17,12 @@
 #ifndef KOKKOSKERNELS_ALWAYSFALSE_HPP
 #define KOKKOSKERNELS_ALWAYSFALSE_HPP
 
-#include <type_traits>
+namespace KokkosKernels::Impl {
 
-/*! \file KokkosKernels_AlwaysFalse.hpp
-    \brief A convenience type to be used in a static_assert that should always
-   fail
-*/
+// for use in static asserts
+template <typename...>
+inline constexpr bool always_false_v = false;
 
-namespace KokkosKernels {
-namespace Impl {
-
-template <typename T>
-using always_false = std::false_type;
-
-template <typename T>
-inline constexpr bool always_false_v = always_false<T>::value;
-
-}  // namespace Impl
-}  // namespace KokkosKernels
+}  // namespace KokkosKernels::Impl
 
 #endif  // KOKKOSKERNELS_ALWAYSFALSE_HPP

--- a/common/impl/KokkosKernels_ViewUtils.hpp
+++ b/common/impl/KokkosKernels_ViewUtils.hpp
@@ -1,0 +1,59 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOSKERNELS_VIEWUTILS_HPP
+#define KOKKOSKERNELS_VIEWUTILS_HPP
+#include "Kokkos_Core.hpp"
+
+namespace KokkosKernels::Impl {
+
+/*! \brief Yields a type that is View with Kokkos::Unmanaged added to the memory
+ * traits
+ */
+template <typename View>
+class with_unmanaged {
+  using data_type    = typename View::data_type;
+  using layout_type  = typename View::array_layout;
+  using memory_space = typename View::memory_space;
+
+  using orig_traits = typename View::memory_traits;
+  static constexpr unsigned new_traits =
+      orig_traits::impl_value | Kokkos::Unmanaged;
+
+ public:
+  using type = Kokkos::View<data_type, layout_type, memory_space,
+                            Kokkos::MemoryTraits<new_traits> >;
+};
+
+/*! \brief A type that is View with Kokkos::Unmanaged added to the memory traits
+
+    \tparam View the type to add Kokkos::Unmanaged to
+ */
+template <typename View>
+using with_unmanaged_t = typename with_unmanaged<View>::type;
+
+/*! \brief Returns an unmanaged version of v
+
+    \tparam View the type of the input view v
+ */
+template <typename View>
+auto make_unmanaged(const View &v) {
+  return typename with_unmanaged<View>::type(v);
+}
+
+}  // namespace KokkosKernels::Impl
+
+#endif

--- a/common/src/KokkosKernels_Error.hpp
+++ b/common/src/KokkosKernels_Error.hpp
@@ -18,6 +18,7 @@
 #define KOKKOSKERNELS_ERROR_HPP
 
 #include <stdexcept>
+#include <sstream>
 
 namespace KokkosKernels {
 namespace Impl {

--- a/perf_test/Benchmark_Utils.hpp
+++ b/perf_test/Benchmark_Utils.hpp
@@ -1,0 +1,45 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+*/
+
+#ifndef KOKKOSKERNELS_PERFTEST_BENCHMARK_UTILS_HPP
+#define KOKKOSKERNELS_PERFTEST_BENCHMARK_UTILS_HPP
+
+namespace KokkosKernelsBenchmark {
+
+class WrappedBool {
+ public:
+  WrappedBool(const bool &val) : val_(val) {}
+
+  operator bool() const { return val_; }
+
+ protected:
+  bool val_;
+};
+
+class DieOnError : public WrappedBool {
+ public:
+  DieOnError(const bool &val) : WrappedBool(val) {}
+};
+class SkipOnError : public WrappedBool {
+ public:
+  SkipOnError(const bool &val) : WrappedBool(val) {}
+};
+
+}  // namespace KokkosKernelsBenchmark
+
+#endif  // KOKKOSKERNELS_PERFTEST_BENCHMARK_UTILS_HPP

--- a/perf_test/sparse/CMakeLists.txt
+++ b/perf_test/sparse/CMakeLists.txt
@@ -139,4 +139,10 @@ if (KokkosKernels_ENABLE_BENCHMARK)
   KOKKOSKERNELS_ADD_BENCHMARK(
     sparse_spmv_bsr_benchmark SOURCES KokkosSparse_spmv_bsr_benchmark.cpp
   )
+
+  # hipcc 5.2 has an underlying clang that has the std::filesystem
+  # in an experimental namespace and a different library
+  if (Kokkos_CXX_COMPILER_ID STREQUAL HIPCC AND Kokkos_CXX_COMPILER_VERSION VERSION_LESS 5.3)
+    target_link_libraries(KokkosKernels_sparse_spmv_bsr_benchmark PRIVATE -lstdc++fs)
+  endif()
 endif()

--- a/sparse/impl/KokkosSparse_crs_detect_block_size.hpp
+++ b/sparse/impl/KokkosSparse_crs_detect_block_size.hpp
@@ -28,8 +28,7 @@
    for performance-sensitive use.
 */
 
-namespace KokkosSparse {
-namespace Impl {
+namespace KokkosSparse::Impl {
 
 /**
  * \class BlockPopulations
@@ -86,14 +85,14 @@ class BlockPopulations {
  * @return The largest block size that results in completely dense blocks
     The smallest valid block size is 1
     Since blocks must be dense, sqrt(nnz), num rows, num cols, and min nnz/row
- among non-empty rows are all easy upper bounds of the block size Block sizes
- are tested from 1 to the minimum of the above The matrix dimensions must divide
- evenly into a trial block size (otherwise a block would not be full)
- Furthermore, if a block size of N is not dense, any multiple of N will also not
- be dense, and can be skipped. This is because blocks of 2N contain blocks of N,
- at least one of which is already known not to be dense. In practice, this ends
- up testing only small composite factors and all prime factors up to the upper
- bound
+ among non-empty rows are all easy upper bounds of the block size.
+ Block sizes are tested from 1 to the minimum of the above.
+ The matrix dimensions must divide  evenly into a trial block size (otherwise a
+ block would not be full). Furthermore, if a block size of N is not dense, any
+ multiple of N will also not be dense, and can be skipped. This is because
+ blocks of 2N contain blocks of N, at least one of which is already known not to
+ be dense. In practice, this ends up testing only small composite factors and
+ all prime factors up to the upper bound.
 */
 template <typename Crs>
 size_t detect_block_size(const Crs &crs) {
@@ -124,12 +123,14 @@ size_t detect_block_size(const Crs &crs) {
   for (size_t trialSize = 2; trialSize <= upperBound; ++trialSize) {
     // trial size must be factor of rows / cols
     if ((crs.numRows() % trialSize) || (crs.numCols() % trialSize)) {
+      rejectedSizes.push_back(trialSize);
       continue;
     }
 
     // trial size must not be a multiple of previously-rejected size
     if (std::any_of(rejectedSizes.begin(), rejectedSizes.end(),
                     [&](size_t f) { return trialSize % f == 0; })) {
+      rejectedSizes.push_back(trialSize);
       continue;
     }
 
@@ -152,7 +153,6 @@ size_t detect_block_size(const Crs &crs) {
   return largestBlockSize;
 }
 
-}  // namespace Impl
-}  // namespace KokkosSparse
+}  // namespace KokkosSparse::Impl
 
 #endif  // KOKKOSSPARSE_CRS_DETECT_BLOCK_SIZE_HPP

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl_v42.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl_v42.hpp
@@ -1,0 +1,144 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOSSPARSE_BSRMATRIX_SPMV_IMPL_V42_HPP
+#define KOKKOSSPARSE_BSRMATRIX_SPMV_IMPL_V42_HPP
+
+#include <Kokkos_Core.hpp>
+
+#include <KokkosKernels_ViewUtils.hpp>
+
+namespace KokkosSparse {
+namespace Impl {
+
+/* One thread for each entry in the product multivector
+
+   Each thread accumulates the partial products for its entry, and writes it
+   out.
+*/
+template <typename Alpha, typename AMatrix, typename XVector, typename Beta,
+          typename YVector>
+class BsrSpmvV42NonTrans {
+  Alpha alpha_;
+  AMatrix a_;
+  XVector x_;
+  Beta beta_;
+  YVector y_;
+
+ public:
+  BsrSpmvV42NonTrans(const Alpha &alpha, const AMatrix &a, const XVector &x,
+                     const Beta &beta, const YVector &y)
+      : alpha_(alpha), a_(a), x_(x), beta_(beta), y_(y) {}
+
+  template <unsigned BLOCK_SIZE = 0>
+  KOKKOS_INLINE_FUNCTION void impl(const size_t k) const {
+    using a_ordinal_type   = typename AMatrix::non_const_ordinal_type;
+    using a_size_type      = typename AMatrix::non_const_size_type;
+    using y_value_type     = typename YVector::non_const_value_type;
+    using const_block_type = typename AMatrix::const_block_type;
+
+    const a_ordinal_type irhs = k / y_.extent(0);
+    const a_ordinal_type row  = k % y_.extent(0);
+
+    // scale by beta
+    if (0 == beta_) {
+      y_(row, irhs) = 0;  // convert NaN to 0
+    } else if (1 != beta_) {
+      y_(row, irhs) *= beta_;
+    }
+
+    // for non-zero template instantiations,
+    // constant propagation should optimize divmod
+    a_ordinal_type blocksz;
+    if constexpr (0 == BLOCK_SIZE) {
+      blocksz = a_.blockDim();
+    } else {
+      blocksz = BLOCK_SIZE;
+    }
+
+    if (0 != alpha_) {
+      const a_ordinal_type blockRow = row / blocksz;
+      const a_ordinal_type lclrow   = row % blocksz;
+      y_value_type accum            = 0;
+      const a_size_type j_begin     = a_.graph.row_map(blockRow);
+      const a_size_type j_end       = a_.graph.row_map(blockRow + 1);
+      for (a_size_type j = j_begin; j < j_end; ++j) {
+        const_block_type b            = a_.unmanaged_block_const(j);
+        const a_ordinal_type blockcol = a_.graph.entries(j);
+        const a_ordinal_type x_start  = blockcol * blocksz;
+
+        const auto x_lcl = Kokkos::subview(
+            x_, Kokkos::make_pair(x_start, x_start + blocksz), irhs);
+        for (a_ordinal_type i = 0; i < blocksz; ++i) {
+          accum += b(lclrow, i) * x_lcl(i);
+        }
+      }
+      y_(row, irhs) += alpha_ * accum;
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION void operator()(const size_t k) const {
+    if (false) {
+    }
+    // clang-format off
+    else if ( 1 == a_.blockDim()) { impl< 1>(k); }
+    else if ( 2 == a_.blockDim()) { impl< 2>(k); }
+    else if ( 3 == a_.blockDim()) { impl< 3>(k); }
+    else if ( 4 == a_.blockDim()) { impl< 4>(k); }
+    else if ( 5 == a_.blockDim()) { impl< 5>(k); }
+    else if ( 6 == a_.blockDim()) { impl< 6>(k); }
+    else if ( 7 == a_.blockDim()) { impl< 7>(k); }
+    else if ( 8 == a_.blockDim()) { impl< 8>(k); }
+    else if ( 9 == a_.blockDim()) { impl< 9>(k); }
+    else if (10 == a_.blockDim()) { impl<10>(k); }
+    else if (11 == a_.blockDim()) { impl<11>(k); }
+    // clang-format on
+    else {
+      impl<0>(k);
+    }
+  }
+};
+
+template <typename Alpha, typename AMatrix, typename XVector, typename Beta,
+          typename YVector>
+void apply_v42(const Alpha &alpha, const AMatrix &a, const XVector &x,
+               const Beta &beta, const YVector &y) {
+  using execution_space = typename YVector::execution_space;
+
+  Kokkos::RangePolicy<execution_space> policy(0, y.size());
+  if constexpr (YVector::rank == 1) {
+    // Implementation expects a 2D view, so create an unmanaged 2D view
+    // with extent 1 in the second dimension
+    using Y2D = KokkosKernels::Impl::with_unmanaged_t<Kokkos::View<
+        typename YVector::value_type * [1], typename YVector::array_layout,
+        typename YVector::device_type, typename YVector::memory_traits>>;
+    using X2D = KokkosKernels::Impl::with_unmanaged_t<Kokkos::View<
+        typename XVector::value_type * [1], typename XVector::array_layout,
+        typename XVector::device_type, typename XVector::memory_traits>>;
+    const Y2D yu(y.data(), y.extent(0), 1);
+    const X2D xu(x.data(), x.extent(0), 1);
+    BsrSpmvV42NonTrans op(alpha, a, xu, beta, yu);
+    Kokkos::parallel_for(policy, op);
+  } else {
+    BsrSpmvV42NonTrans op(alpha, a, x, beta, y);
+    Kokkos::parallel_for(policy, op);
+  }
+}
+
+}  // namespace Impl
+}  // namespace KokkosSparse
+
+#endif  // KOKKOSSPARSE_BSRMATRIX_SPMV_IMPL_V42_HPP

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -25,6 +25,7 @@
 #include "KokkosKernels_Error.hpp"
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 #include <KokkosSparse_spmv_bsrmatrix_impl.hpp>
+#include "KokkosSparse_spmv_bsrmatrix_impl_v42.hpp"
 #endif
 
 namespace KokkosSparse {
@@ -136,6 +137,11 @@ struct SPMV_MV_BSRMATRIX {
 // actual implementations to be compiled
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 
+// these should all be different
+constexpr inline const char *ALG_V41 = "v4.1";
+constexpr inline const char *ALG_V42 = "v4.2";
+constexpr inline const char *ALG_TC  = "experimental_bsr_tc";
+
 template <class AT, class AO, class AD, class AM, class AS, class XT, class XL,
           class XD, class XM, class YT, class YL, class YD, class YM>
 struct SPMV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM, false,
@@ -149,16 +155,47 @@ struct SPMV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM, false,
       const KokkosKernels::Experimental::Controls &controls, const char mode[],
       const YScalar &alpha, const AMatrix &A, const XVector &X,
       const YScalar &beta, const YVector &Y) {
-    //
-    if ((mode[0] == NoTranspose[0]) || (mode[0] == Conjugate[0])) {
-      bool useConjugate = (mode[0] == Conjugate[0]);
+    const bool modeIsNoTrans        = (mode[0] == NoTranspose[0]);
+    const bool modeIsConjugate      = (mode[0] == Conjugate[0]);
+    const bool modeIsConjugateTrans = (mode[0] == ConjugateTranspose[0]);
+    const bool modeIsTrans          = (mode[0] == Transpose[0]);
+
+    // use V41 if requested
+    if (controls.getParameter("algorithm") == ALG_V41) {
+      if (modeIsNoTrans || modeIsConjugate) {
+        return Bsr::spMatVec_no_transpose(controls, alpha, A, X, beta, Y,
+                                          modeIsConjugate);
+      } else if (modeIsTrans || modeIsConjugateTrans) {
+        return Bsr::spMatVec_transpose(controls, alpha, A, X, beta, Y,
+                                       modeIsConjugateTrans);
+      }
+    }
+
+    // use V42 if possible
+    if (KokkosKernels::Impl::kk_is_gpu_exec_space<
+            typename YVector::execution_space>() ||
+        controls.getParameter("algorithm") == ALG_V42) {
+      if (modeIsNoTrans) {
+        ::KokkosSparse::Impl::apply_v42(alpha, A, X, beta, Y);
+        return;
+      }
+    }
+
+    // fall back to V41 all else fails
+    if (modeIsNoTrans || modeIsConjugate) {
       return Bsr::spMatVec_no_transpose(controls, alpha, A, X, beta, Y,
-                                        useConjugate);
-    } else if ((mode[0] == Transpose[0]) ||
-               (mode[0] == ConjugateTranspose[0])) {
-      bool useConjugate = (mode[0] == ConjugateTranspose[0]);
+                                        modeIsConjugate);
+    } else if (modeIsTrans || modeIsConjugateTrans) {
       return Bsr::spMatVec_transpose(controls, alpha, A, X, beta, Y,
-                                     useConjugate);
+                                     modeIsConjugateTrans);
+    }
+
+    {
+      std::stringstream ss;
+      ss << __FILE__ << ":" << __LINE__ << " ";
+      ss << "Internal logic error: no applicable BsrMatrix SpMV implementation "
+            ". Please report this";
+      throw std::runtime_error(ss.str());
     }
   }
 };
@@ -194,7 +231,7 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
       typedef typename AMatrix::non_const_value_type AScalar;
       typedef typename XVector::non_const_value_type XScalar;
       // try to use tensor cores if requested
-      if (controls.getParameter("algorithm") == "experimental_bsr_tc")
+      if (controls.getParameter("algorithm") == ALG_TC)
         method = Method::TensorCores;
       // can't use tensor cores for complex
       if (Kokkos::ArithTraits<YScalar>::is_complex) method = Method::Fallback;
@@ -289,17 +326,49 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
         return;
       }
     }
-#endif  // KOKKOS_ARCH
+#endif  // defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_ARCH_AMPERE)
 
-    if ((mode[0] == NoTranspose[0]) || (mode[0] == Conjugate[0])) {
-      bool useConjugate = (mode[0] == Conjugate[0]);
+    const bool modeIsNoTrans        = (mode[0] == NoTranspose[0]);
+    const bool modeIsConjugate      = (mode[0] == Conjugate[0]);
+    const bool modeIsConjugateTrans = (mode[0] == ConjugateTranspose[0]);
+    const bool modeIsTrans          = (mode[0] == Transpose[0]);
+
+    // use V41 if requested
+    if (controls.getParameter("algorithm") == ALG_V41) {
+      if (modeIsNoTrans || modeIsConjugate) {
+        return Bsr::spMatMultiVec_no_transpose(controls, alpha, A, X, beta, Y,
+                                               modeIsConjugate);
+      } else if (modeIsTrans || modeIsConjugateTrans) {
+        return Bsr::spMatMultiVec_transpose(controls, alpha, A, X, beta, Y,
+                                            modeIsConjugateTrans);
+      }
+    }
+
+    // use V42 if possible
+    if (KokkosKernels::Impl::kk_is_gpu_exec_space<
+            typename YVector::execution_space>() ||
+        controls.getParameter("algorithm") == ALG_V42) {
+      if (modeIsNoTrans) {
+        ::KokkosSparse::Impl::apply_v42(alpha, A, X, beta, Y);
+        return;
+      }
+    }
+
+    // use V41 as the ultimate fallback
+    if (modeIsNoTrans || modeIsConjugate) {
       return Bsr::spMatMultiVec_no_transpose(controls, alpha, A, X, beta, Y,
-                                             useConjugate);
-    } else if ((mode[0] == Transpose[0]) ||
-               (mode[0] == ConjugateTranspose[0])) {
-      bool useConjugate = (mode[0] == ConjugateTranspose[0]);
+                                             modeIsConjugate);
+    } else if (modeIsTrans || modeIsConjugateTrans) {
       return Bsr::spMatMultiVec_transpose(controls, alpha, A, X, beta, Y,
-                                          useConjugate);
+                                          modeIsConjugateTrans);
+    }
+
+    {
+      std::stringstream ss;
+      ss << __FILE__ << ":" << __LINE__ << " ";
+      ss << "Internal logic error: no applicable BsrMatrix SpMV implementation "
+            ". Please report this";
+      throw std::runtime_error(ss.str());
     }
   }
 };

--- a/sparse/src/KokkosKernels_Controls.hpp
+++ b/sparse/src/KokkosKernels_Controls.hpp
@@ -64,8 +64,6 @@ class Controls {
                            const std::string& orUnset = "") const {
     auto search = kernel_parameters.find(name);
     if (kernel_parameters.end() == search) {
-      std::cerr << "WARNING: Controls::getParameter for name \"" << name
-                << "\" was unset" << std::endl;
       return orUnset;
     } else {
       return search->second;

--- a/sparse/src/KokkosSparse_BsrMatrix.hpp
+++ b/sparse/src/KokkosSparse_BsrMatrix.hpp
@@ -393,10 +393,18 @@ class BsrMatrix {
   //! Nonconst version of the type of the entries in the sparse matrix.
   typedef typename values_type::non_const_value_type non_const_value_type;
 
-  // block values are actually a 1-D view, however they are implicitly
-  // arranged in LayoutRight, e.g. consecutive entries in the values view
-  // are consecutive entries within a row inside a block
-  using block_layout = Kokkos::LayoutRight;
+  //! block values are actually a 1-D view, however they are implicitly
+  //! arranged in LayoutRight, e.g. consecutive entries in the values view
+  //! are consecutive entries within a row inside a block
+  using block_layout_type = Kokkos::LayoutRight;
+
+  //! Type returned by \c unmanaged_block
+  using block_type = Kokkos::View<value_type**, block_layout_type, device_type,
+                                  Kokkos::MemoryUnmanaged>;
+
+  //! Type returned by \c unmanaged_block_const
+  using const_block_type = Kokkos::View<const value_type**, block_layout_type,
+                                        device_type, Kokkos::MemoryUnmanaged>;
 
   /// \name Storage of the actual sparsity structure and values.
   ///
@@ -480,15 +488,12 @@ class BsrMatrix {
   /// \param cols [in] The column indices. cols[k] is the column
   ///   index of val[k].
   /// \param blockdim [in] The block size of the constructed BsrMatrix.
-  /// \param pad [in] If true, pad the sparse matrix's storage with
-  ///   zeros in order to improve cache alignment and / or
-  ///   vectorization.
+  /// \param pad [in] Ignored
   ///
   /// The \c pad argument is currently not used.
   BsrMatrix(const std::string& label, OrdinalType nrows, OrdinalType ncols,
             size_type annz, ScalarType* vals, OrdinalType* rows,
             OrdinalType* cols, OrdinalType blockdim, bool pad = false) {
-    (void)label;
     (void)pad;
     blockDim_ = blockdim;
 
@@ -517,6 +522,16 @@ class BsrMatrix {
           "BsrMatrix:: annz should be a multiple of the number of entries in a "
           "block");
     }
+    if (annz % (blockDim_ * blockDim_)) {
+      throw std::runtime_error(
+          "BsrMatrix:: annz should be a multiple of the number of entries in a "
+          "block");
+    }
+    if (annz % (blockDim_ * blockDim_)) {
+      throw std::runtime_error(
+          "BsrMatrix:: annz should be a multiple of the number of entries in a "
+          "block");
+    }
 
     using Coord     = std::pair<OrdinalType, OrdinalType>;  // row, col
     using CoordComp = std::function<bool(
@@ -532,10 +547,10 @@ class BsrMatrix {
 
     // device data
     typename row_map_type::non_const_type row_map_device(
-        Kokkos::view_alloc(Kokkos::WithoutInitializing, "row_map_device"),
+        Kokkos::view_alloc(Kokkos::WithoutInitializing, label + " row_map"),
         numRows + 1);
-    index_type entries_device("entries_device", numBlocks);
-    Kokkos::resize(values, annz);
+    index_type entries_device(label + " entries", numBlocks);
+    values = values_type(label + " values", annz);
 
     // mirror views on host
     auto row_map_host = Kokkos::create_mirror_view(row_map_device);
@@ -986,6 +1001,20 @@ class BsrMatrix {
       return BsrRowViewConst<BsrMatrix>(values, graph.entries, blockDim(),
                                         count, start);
     }
+  }
+
+  /*! \brief return an unmanaged view of block i */
+  KOKKOS_INLINE_FUNCTION
+  block_type unmanaged_block(const size_type i) const {
+    // cast up to the size_type to help avoid an overflow
+
+    return block_type(&values(i * blockDim_ * blockDim_), blockDim_, blockDim_);
+  }
+  KOKKOS_INLINE_FUNCTION
+  const_block_type unmanaged_block_const(const size_type i) const {
+    // cast up to the size_type to help avoid an overflow
+    return const_block_type(&values(i * blockDim_ * blockDim_), blockDim_,
+                            blockDim_);
   }
 
  protected:

--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -145,7 +145,7 @@ void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
   // Whether to call KokkosKernel's native implementation, even if a TPL impl is
   // available
   bool useFallback = controls.isParameter("algorithm") &&
-                     controls.getParameter("algorithm") == "native";
+                     (controls.getParameter("algorithm") != "tpl");
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
   // cuSPARSE does not support the conjugate mode (C), and cuSPARSE 9 only
@@ -343,7 +343,7 @@ void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
   // Whether to call KokkosKernel's native implementation, even if a TPL impl is
   // available
   bool useFallback = controls.isParameter("algorithm") &&
-                     controls.getParameter("algorithm") == "native";
+                     (controls.getParameter("algorithm") != "tpl");
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
   // cuSPARSE does not support the modes (C), (T), (H)
@@ -634,7 +634,7 @@ void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
     useNative = useNative || (Conjugate[0] == mode[0]);
 #endif
     useNative = useNative || (controls.isParameter("algorithm") &&
-                              (controls.getParameter("algorithm") == "native"));
+                              (controls.getParameter("algorithm") != "tpl"));
 
     if (useNative) {
       return Impl::SPMV_MV<
@@ -798,10 +798,8 @@ void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
   //
   // Whether to call KokkosKernel's native implementation, even if a TPL impl is
   // available
-  bool useFallback =
-      controls.isParameter("algorithm") &&
-      (controls.getParameter("algorithm") == "native" ||
-       controls.getParameter("algorithm") == "experimental_bsr_tc");
+  bool useFallback = controls.isParameter("algorithm") &&
+                     (controls.getParameter("algorithm") != "tpl");
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
   // cuSPARSE does not support the modes (C), (T), (H)

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
@@ -914,7 +914,7 @@ void spmv_block_impl_rocsparse(
   */
   // KokkosSparse Bsr matrix blocks are layoutright (row-major)
   static_assert(
-      std::is_same_v<typename AMatrix::block_layout, Kokkos::LayoutRight>,
+      std::is_same_v<typename AMatrix::block_layout_type, Kokkos::LayoutRight>,
       "A blocks must be stored layout-right");
   rocsparse_direction dir = rocsparse_direction_row;
 

--- a/sparse/unit_test/Test_Sparse_spmv_bsr.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv_bsr.hpp
@@ -373,7 +373,8 @@ void test_spmv_combos(const char *mode, const Bsr &a) {
 
   auto [x, y] = random_vecs_for_spmv(mode, a);
 
-  for (auto alg : {(const char *)(nullptr), "native", "experimental_tc_bsr"}) {
+  for (auto alg :
+       {(const char *)(nullptr), "native", "experimental_tc", "v4.1", "v4.2"}) {
     for (scalar_type alpha :
          {scalar_type(0), scalar_type(1), scalar_type(-1), scalar_type(3.7)}) {
       for (scalar_type beta : {scalar_type(0), scalar_type(1), scalar_type(-1),
@@ -569,8 +570,8 @@ void test_spm_mv_combos(const char *mode, const Bsr &a) {
 
   for (size_t numVecs : {1, 2, 7}) {  // num multivecs
     auto [x, y] = random_multivecs_for_spm_mv<Layout>(mode, a, numVecs);
-    for (auto alg :
-         {(const char *)(nullptr), "native", "experimental_tc_bsr"}) {
+    for (auto alg : {(const char *)(nullptr), "native", "experimental_tc",
+                     "v4.1", "v4.2"}) {
       for (scalar_type alpha : {scalar_type(0), scalar_type(1), scalar_type(-1),
                                 scalar_type(3.7)}) {
         for (scalar_type beta : {scalar_type(0), scalar_type(1),


### PR DESCRIPTION
Improve performance of the native `BsrMatrix` SpMV, especially for single-vector cases.

* Adds a new `"v4.2"` BsrMatrix SpMV implementation for non-transpose mode.
  * It is the default (when TPLs are disabled or not supported) on the GPU for non-transpose mode
  * The old implementation is retained for all other modes
  * old implementation may be requested explicitly with `controls.setParameter("algorithm", "v4.1")`
* Adds explicit invocation of old "4.1" impl to `KokkosKernels_sparse_spmv_bsr_benchmark`
* When TPLs are enabled, the new implementation may be requested anyway with `controls.setParameter("algorithm", "v4.2")`

# Results

*sp* is speedup of 4.2 vs 4.1. TPLs only support specific integer combinations. The table below summarizes the speedup achieved across various operand types

| GPU | single vec | multivec |
|-|-|-|
| V100 | 2.3-3.1x | 1.0-1.2x |
| A100 | 5.5x-9.4x | 1.5x-2.3x |
| MI250 | 2.1-3.9x | 1.5-2.4x |

## V100, bs=7, k=1, rows=1.84m, nnz=88m

*GB / second* 
| scalar/ordinal/offset | TPL | KK 4.2 | KK 4.1 | *sp* |
|-|-|-|-|-|
| f32/i32/i32 | 524 | 312 | 99.3 | 3.1x |
| f64/i32/i32 | 711 | 400 | 156 | 2.5x |
| f32/i32/u32 | N/A | 301 | 100 | 3.0x |
| f32/i64/u64 | N/A | 362 | 153 | 2.3x |
| f32/i64/i64 | N/A | 362 | 155 | 2.3x |

## V100, bs=7, k=3, rows=1.84m, nnz=88m

*GB / second* 
| scalar/ordinal/offset | TPL | KK 4.2 | KK 4.1 | *sp* |
|-|-|-|-|-|
| f32/i32/i32 | 503 | 119 | 94.5 | 1.2x |
| f64/i32/i32 | 635 | 152 | 152 | 1.0x |
| f32/i32/u32 | N/A | 114 | 95 | 1.2x |
| f32/i64/u64 | N/A | 140 | 121 | 1.1x |
| f32/i64/i64 | N/A | 140 | 119 | 1.1x |

## A100, bs=7, k=1, rows=1.84m, nnz=88m

*GB / second* 
| scalar/ordinal/offset | TPL | KK 4.2 | KK 4.1 | *sp* |
|-|-|-|-|-|
| f32/i32/i32 | 503 | 551 | 63.7 | 8.6x |
| f64/i32/i32 | 854 | 703 | 126 | 5.5x |
| f32/i32/u32 | N/A | 524 | 69.3 | 7.5x |
| f32/i64/u64 | N/A | 696 | 76.0 | 9.1x |
| f32/i64/i64 | N/A | 707 | 74.6 | 9.4x |

## A100, bs=7, k=3, rows=1.84m, nnz=88m

*GB / second* 
| scalar/ordinal/offset | TPL | KK 4.2 | KK 4.1 | *sp* |
|-|-|-|-|-|
| f32/i32/i32 | 501 | 208 | 90.7 | 2.3x |
| f64/i32/i32 | 756 | 267 | 173 | 1.5x |
| f32/i32/u32 | N/A | 200 | 99.4 | 2.0x |
| f32/i64/u64 | N/A | 268 | 146 | 1.8x |
| f32/i64/i64 | N/A | 272 | 143 | 1.9x |

## MI250, bs=7, k=1, rows=1.84m, nnz=88m

*GB / second* 
| scalar/ordinal/offset | TPL | KK 4.2 | KK 4.1 | *sp* |
|-|-|-|-|-|
| f32/i32/i32 | 701 | 713 | 182 | 3.9x |
| f64/i32/i32 | 974 | 675 | 324 | 2.1x |
| f32/i32/u32 | N/A | 713 | 183 | 3.9x |
| f32/i64/u64 | N/A | 672 | 321 | 2.1x |
| f32/i64/i64 | N/A | 672 | 321 | 2.1x |

## MI250, bs=7, k=3, rows=1.84m, nnz=88m

*GB / second* 
| scalar/ordinal/offset | TPL | KK 4.2 | KK 4.1 | *sp* |
|-|-|-|-|-|
| f32/i32/i32 | N/A | 280 | 116 | 2.4 |
| f64/i32/i32 | N/A | 262 | 172 | 1.5 |
| f32/i32/u32 | N/A | 280 | 115 | 2.4 |
| f32/i64/u64 | N/A | 259 | 169 | 1.5 |
| f32/i64/i64 | N/A | 259 | 169 | 1.5 |

# Results (Tpetra BlockCrs Performance Test Matrix)

*sp* is speedup of 4.2 vs 4.1. TPLs only support specific integer combinations. The table below summarizes the speedup achieved across various operand types

| GPU | single vec | multivec |
|-|-|-|
| V100 | 1.3-3.3x | 0.68-1.3x |
| A100 |  |  |
| MI250 | 2.4-5x | 2.6-3.6x |

## V100, bs=7, k=1, rows=1.84m, nnz=88m

*GB / second* 
| scalar/ordinal/offset | TPL | KK 4.2 | KK 4.1 | *sp* |
|-|-|-|-|-|
| f32/i32/i32 | 307 | 305  | 108 | 2.8x |
| f64/i32/i32 | 505 | 233 | 174 | 1.3x |
| f32/i32/u32 | N/A | 349 | 106 | 3.3x |
| f32/i64/u64 | N/A | 370 | 173 | 2.1x |
| f32/i64/i64 | N/A | 369 | 175 | 2.1x |

## V100, bs=7, k=3, rows=1.84m, nnz=88m

*GB / second* 
| scalar/ordinal/offset | TPL | KK 4.2 | KK 4.1 | *sp* |
|-|-|-|-|-|
| f32/i32/i32 | 135 | 111 | 93 | 1.2x |
| f64/i32/i32 | 195 | 85 | 125 | 0.68x |
| f32/i32/u32 | N/A | 126 | 93 | 1.3x |
| f32/i64/u64 | N/A | 134 | 123 | 1.08x |
| f32/i64/i64 | N/A | 133 | 123 | 1.08x |

## MI250, bs=7, k=1, rows=1.84m, nnz=88m

*GB / second* 
| scalar/ordinal/offset | TPL | KK 4.2 | KK 4.1 | *sp* |
|-|-|-|-|-|
| f32/i32/i32 | 443 | 835 | 165 | 5x |
| f64/i32/i32 | 730 | 726 | 295 | 2.4x |
| f32/i32/u32 | N/A | 836 | 165 | 5x |
| f32/i64/u64 | N/A | 713 | 290 | 2.4x |
| f32/i64/i64 | N/A | 718 | 290 | 2.4x |

## MI250, bs=7, k=3, rows=1.84m, nnz=88m

*GB / second* 
| scalar/ordinal/offset | TPL | KK 4.2 | KK 4.1 | *sp* |
|-|-|-|-|-|
| f32/i32/i32 | 307 | 307 | 85 | 3.6x |
| f64/i32/i32 | 266 | 266 | 100 | 2.6x |
| f32/i32/u32 | N/A | 306 | 85 | 3.6x |
| f32/i64/u64 | N/A | 263 | 98 | 2.6x |
| f32/i64/i64 | N/A | 263 | 98 | 2.6x |

Other changes:

* simplify `KokkosKernels::Impl::always_false_v`
* Add `template <typename View> class with_unmanaged` which provides a `type` alias reproducing `View` with `Kokkos::Unmanaged` added to its memory traits
* Add `KokkosKernels::Impl::with_unmanaged_t` as an alias for `typename with_unamanged::type`
* Add `template <typename View> auto KokkosKernels::Impl:make_unmanaged(const View &v)` which constructs a `with_unmanaged_t<View>` from v
* Add `<sstream>` to `KokkosKernels_Error.hpp`
* Add `DieOnError` and `SkipOnError` wrapped `bool`s to give names to boolean function arguments
* Link `KokkosKernels_sparse_spmv_bsr_benchmark` against `stdc++fs` for rocm 5.2
* More aggressive block size filtering in `KokkosSparse_csr_detect_block_size.hpp`
* Removes a useless warning from `Controls::getParameter` since what happens when a parameter is unset was made explicit in https://github.com/kokkos/kokkos-kernels/commit/be87154a2f83f25c269eb3ce2bcca0b82356a8c5
* `BsrMatrix` constructor throws when combination of nnz, rows, and columns don't make sense
* Change `BsrMatrix::block_layout` to `BsrMatrix::block_layout_type` for consistency
* Adds `BsrMatrix::unmanaged_block` to return an unmanged view to a 2D block of values
* Adds `BsrMatrix::unmanaged_block_const` to return a const unmanged view to a 2D block of values