### PR TITLE
spgemm handle: check that A,B,C graphs never change

### DIFF
--- a/common/src/KokkosKernels_SimpleUtils.hpp
+++ b/common/src/KokkosKernels_SimpleUtils.hpp
@@ -380,6 +380,38 @@ KOKKOS_FORCEINLINE_FUNCTION Value xorshiftHash(Value v) {
              : static_cast<Value>(x * 2685821657736338717ULL - 1);
 }
 
+struct ViewHashFunctor {
+  ViewHashFunctor(const uint8_t *data_) : data(data_) {}
+
+  KOKKOS_INLINE_FUNCTION void operator()(size_t i, uint32_t &lhash) const {
+    // Compute a hash/digest of both the index i, and data[i]. Then add that to
+    // overall hash.
+    uint32_t x = uint32_t(i);
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    x ^= uint32_t(data[i]);
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    lhash += x;
+  }
+
+  const uint8_t *data;
+};
+
+// Compute a hash of a contiguous view's data.
+template <typename View>
+uint32_t hashView(const View &v) {
+  assert(v.span_is_contiguous());
+  size_t nbytes = v.span() * sizeof(typename View::value_type);
+  uint32_t h;
+  Kokkos::parallel_reduce(
+      Kokkos::RangePolicy<typename View::execution_space, size_t>(0, nbytes),
+      ViewHashFunctor(reinterpret_cast<const uint8_t *>(v.data())), h);
+  return h;
+}
+
 template <typename V>
 struct SequentialFillFunctor {
   using size_type = typename V::size_type;

--- a/common/src/KokkosKernels_SimpleUtils.hpp
+++ b/common/src/KokkosKernels_SimpleUtils.hpp
@@ -406,10 +406,15 @@ struct ViewHashFunctor {
 template <typename View>
 uint32_t hashView(const View &v) {
   assert(v.span_is_contiguous());
+  // Note: This type trait is supposed to be part of C++17,
+  // but it's not defined on Intel 19 (with GCC 7.2.0 standard library).
+  // So just check if it's available before using.
+#ifdef __cpp_lib_has_unique_object_representations
   static_assert(std::has_unique_object_representations<
                     typename View::non_const_value_type>::value,
                 "KokkosKernels::Impl::hashView: the view's element type must "
                 "not have any padding bytes.");
+#endif
   size_t nbytes = v.span() * sizeof(typename View::value_type);
   uint32_t h;
   Kokkos::parallel_reduce(

--- a/common/src/KokkosKernels_SimpleUtils.hpp
+++ b/common/src/KokkosKernels_SimpleUtils.hpp
@@ -400,10 +400,16 @@ struct ViewHashFunctor {
   const uint8_t *data;
 };
 
-// Compute a hash of a contiguous view's data.
+/// \brief Compute a hash of a view.
+/// \param v: the view to hash. Must be contiguous, and its element type must
+/// not contain any padding bytes.
 template <typename View>
 uint32_t hashView(const View &v) {
   assert(v.span_is_contiguous());
+  static_assert(std::has_unique_object_representations<
+                    typename View::non_const_value_type>::value,
+                "KokkosKernels::Impl::hashView: the view's element type must "
+                "not have any padding bytes.");
   size_t nbytes = v.span() * sizeof(typename View::value_type);
   uint32_t h;
   Kokkos::parallel_reduce(

--- a/sparse/src/KokkosSparse_spgemm_handle.hpp
+++ b/sparse/src/KokkosSparse_spgemm_handle.hpp
@@ -810,8 +810,7 @@ class SPGEMMHandle {
       const void *ArowptrsIn, const void *AentriesIn, const void *BrowptrsIn,
       const void *BentriesIn, const void *CrowptrsIn, const void *CentriesIn) {
     // A, B rowptrs and entries will have already been set.
-    // If this is the first numeric call, assign the pointer Centries and the
-    // values pointers of each matrix
+    // If this is the first numeric call, assign the pointer Centries
     if (!Centries) Centries = CentriesIn;
     // Then make sure they all match
     if (Arowptrs != ArowptrsIn || Aentries != AentriesIn) return false;

--- a/sparse/src/KokkosSparse_spgemm_handle.hpp
+++ b/sparse/src/KokkosSparse_spgemm_handle.hpp
@@ -788,12 +788,11 @@ class SPGEMMHandle {
 
  public:
   template <typename a_rowptrs_t, typename a_entries_t, typename b_rowptrs_t,
-            typename b_entries_t, typename c_rowptrs_t>
+            typename b_entries_t>
   bool checkMatrixIdentitiesSymbolic(const a_rowptrs_t &a_rowptrsIn,
                                      const a_entries_t &a_entriesIn,
                                      const b_rowptrs_t &b_rowptrsIn,
-                                     const b_entries_t &b_entriesIn,
-                                     const c_rowptrs_t &c_rowptrsIn) {
+                                     const b_entries_t &b_entriesIn) {
 #ifndef NDEBUG
     // If this is the first symbolic call, assign the handle's CRS pointers to
     // check against later

--- a/sparse/src/KokkosSparse_spgemm_handle.hpp
+++ b/sparse/src/KokkosSparse_spgemm_handle.hpp
@@ -782,40 +782,85 @@ class SPGEMMHandle {
   // the sparsity patterns of A and B do not change. Enforce this by recording
   // the raw data pointers of the matrices' rowptrs and entries during symbolic
   // and numeric, and make sure they never change.
-  const void *Arowptrs = nullptr, *Aentries = nullptr;
-  const void *Browptrs = nullptr, *Bentries = nullptr;
-  const void *Crowptrs = nullptr, *Centries = nullptr;
+  const void *a_rowptrs = nullptr, *a_entries = nullptr;
+  const void *b_rowptrs = nullptr, *b_entries = nullptr;
+  const void *c_rowptrs = nullptr, *c_entries = nullptr;
+  // In a debug build, also hash A,B rowptrs/entries to make sure their actual
+  // contents do not change.
+#ifndef NDEBUG
+  uint32_t a_graph_hash = 0U;
+  uint32_t b_graph_hash = 0U;
+#endif
 
  public:
-  bool checkMatrixIdentitiesSymbolic(const void *ArowptrsIn,
-                                     const void *AentriesIn,
-                                     const void *BrowptrsIn,
-                                     const void *BentriesIn,
-                                     const void *CrowptrsIn) {
+  template <typename a_rowptrs_t, typename a_entries_t, typename b_rowptrs_t,
+            typename b_entries_t, typename c_rowptrs_t>
+  bool checkMatrixIdentitiesSymbolic(const a_rowptrs_t &a_rowptrsIn,
+                                     const a_entries_t &a_entriesIn,
+                                     const b_rowptrs_t &b_rowptrsIn,
+                                     const b_entries_t &b_entriesIn,
+                                     const c_rowptrs_t &c_rowptrsIn) {
     // If this is the first symbolic call, assign the handle's CRS pointers to
     // check against later
-    if (!Arowptrs) Arowptrs = ArowptrsIn;
-    if (!Browptrs) Browptrs = BrowptrsIn;
-    if (!Aentries) Aentries = AentriesIn;
-    if (!Bentries) Bentries = BentriesIn;
-    if (!Crowptrs) Crowptrs = CrowptrsIn;
-    // Then make sure they all match
-    if (Arowptrs != ArowptrsIn || Aentries != AentriesIn) return false;
-    if (Browptrs != BrowptrsIn || Bentries != BentriesIn) return false;
-    if (Crowptrs != CrowptrsIn) return false;
+    if (!a_rowptrs) {
+      a_rowptrs = a_rowptrsIn.data();
+      b_rowptrs = b_rowptrsIn.data();
+      a_entries = a_entriesIn.data();
+      b_entries = b_entriesIn.data();
+      c_rowptrs = c_rowptrsIn.data();
+#ifndef NDEBUG
+      a_graph_hash = KokkosKernels::Impl::hashView(a_rowptrsIn) ^
+                     KokkosKernels::Impl::hashView(a_entriesIn);
+      b_graph_hash = KokkosKernels::Impl::hashView(b_rowptrsIn) ^
+                     KokkosKernels::Impl::hashView(b_entriesIn);
+#endif
+    } else {
+      // Not the first call: make sure all views match what was passed to the
+      // first call
+      if (a_rowptrs != a_rowptrsIn.data() || a_entries != a_entriesIn.data())
+        return false;
+      if (b_rowptrs != b_rowptrsIn.data() || b_entries != b_entriesIn.data())
+        return false;
+      if (c_rowptrs != c_rowptrsIn.data()) return false;
+#ifndef NDEBUG
+      if (a_graph_hash != (KokkosKernels::Impl::hashView(a_rowptrsIn) ^
+                           KokkosKernels::Impl::hashView(a_entriesIn)))
+        return false;
+      if (b_graph_hash != (KokkosKernels::Impl::hashView(b_rowptrsIn) ^
+                           KokkosKernels::Impl::hashView(b_entriesIn)))
+        return false;
+#endif
+    }
     return true;
   }
 
-  bool checkMatrixIdentitiesNumeric(
-      const void *ArowptrsIn, const void *AentriesIn, const void *BrowptrsIn,
-      const void *BentriesIn, const void *CrowptrsIn, const void *CentriesIn) {
-    // A, B rowptrs and entries will have already been set.
-    // If this is the first numeric call, assign the pointer Centries
-    if (!Centries) Centries = CentriesIn;
-    // Then make sure they all match
-    if (Arowptrs != ArowptrsIn || Aentries != AentriesIn) return false;
-    if (Browptrs != BrowptrsIn || Bentries != BentriesIn) return false;
-    if (Crowptrs != CrowptrsIn || Centries != CentriesIn) return false;
+  template <typename a_rowptrs_t, typename a_entries_t, typename b_rowptrs_t,
+            typename b_entries_t, typename c_rowptrs_t, typename c_entries_t>
+  bool checkMatrixIdentitiesNumeric(const a_rowptrs_t &a_rowptrsIn,
+                                    const a_entries_t &a_entriesIn,
+                                    const b_rowptrs_t &b_rowptrsIn,
+                                    const b_entries_t &b_entriesIn,
+                                    const c_rowptrs_t &c_rowptrsIn,
+                                    const c_entries_t &c_entriesIn) {
+    // A, B rowptrs and entries (pointers and hashes) will have already been
+    // set. If this is the first numeric call, assign the pointer c_entries
+    if (!c_entries) {
+      c_entries = c_entriesIn.data();
+    }
+    if (a_rowptrs != a_rowptrsIn.data() || a_entries != a_entriesIn.data())
+      return false;
+    if (b_rowptrs != b_rowptrsIn.data() || b_entries != b_entriesIn.data())
+      return false;
+    if (c_rowptrs != c_rowptrsIn.data() || c_entries != c_entriesIn.data())
+      return false;
+#ifndef NDEBUG
+    if (a_graph_hash != (KokkosKernels::Impl::hashView(a_rowptrsIn) ^
+                         KokkosKernels::Impl::hashView(a_entriesIn)))
+      return false;
+    if (b_graph_hash != (KokkosKernels::Impl::hashView(b_rowptrsIn) ^
+                         KokkosKernels::Impl::hashView(b_entriesIn)))
+      return false;
+#endif
     return true;
   }
 };

--- a/sparse/src/KokkosSparse_spgemm_numeric.hpp
+++ b/sparse/src/KokkosSparse_spgemm_numeric.hpp
@@ -244,9 +244,9 @@ void spgemm_numeric(KernelHandle *handle,
         "an SpGEMM handle associated with it.");
   }
 
-  if (!spgemmHandle->checkMatrixIdentitiesNumeric(
-          const_a_r.data(), const_a_l.data(), const_b_r.data(),
-          const_b_l.data(), const_c_r.data(), nonconst_c_l.data())) {
+  if (!spgemmHandle->checkMatrixIdentitiesNumeric(const_a_r, const_a_l,
+                                                  const_b_r, const_b_l,
+                                                  const_c_r, nonconst_c_l)) {
     throw std::invalid_argument(
         "KokkosSparse::spgemm_numeric: once used, an spgemm handle cannot be "
         "reused for a product with a different sparsity pattern.\n"

--- a/sparse/src/KokkosSparse_spgemm_numeric.hpp
+++ b/sparse/src/KokkosSparse_spgemm_numeric.hpp
@@ -245,12 +245,11 @@ void spgemm_numeric(KernelHandle *handle,
   }
 
   if (!spgemmHandle->checkMatrixIdentitiesNumeric(const_a_r, const_a_l,
-                                                  const_b_r, const_b_l,
-                                                  const_c_r, nonconst_c_l)) {
+                                                  const_b_r, const_b_l)) {
     throw std::invalid_argument(
         "KokkosSparse::spgemm_numeric: once used, an spgemm handle cannot be "
         "reused for a product with a different sparsity pattern.\n"
-        "The rowptrs and entries of A, B and C must be identical to those "
+        "The rowptrs and entries of A and B must be identical to those "
         "passed to the first spgemm_symbolic and spgemm_numeric calls.");
   }
 

--- a/sparse/src/KokkosSparse_spgemm_symbolic.hpp
+++ b/sparse/src/KokkosSparse_spgemm_symbolic.hpp
@@ -160,7 +160,7 @@ void spgemm_symbolic(KernelHandle *handle,
   }
 
   if (!spgemmHandle->checkMatrixIdentitiesSymbolic(const_a_r, const_a_l,
-                                                   const_b_r, const_b_l, c_r)) {
+                                                   const_b_r, const_b_l)) {
     throw std::invalid_argument(
         "KokkosSparse::spgemm_symbolic: once used, an spgemm handle cannot be "
         "reused for a product with a different sparsity pattern.\n"

--- a/sparse/src/KokkosSparse_spgemm_symbolic.hpp
+++ b/sparse/src/KokkosSparse_spgemm_symbolic.hpp
@@ -159,9 +159,8 @@ void spgemm_symbolic(KernelHandle *handle,
         "an SpGEMM handle associated with it.");
   }
 
-  if (!spgemmHandle->checkMatrixIdentitiesSymbolic(
-          const_a_r.data(), const_a_l.data(), const_b_r.data(),
-          const_b_l.data(), c_r.data())) {
+  if (!spgemmHandle->checkMatrixIdentitiesSymbolic(const_a_r, const_a_l,
+                                                   const_b_r, const_b_l, c_r)) {
     throw std::invalid_argument(
         "KokkosSparse::spgemm_symbolic: once used, an spgemm handle cannot be "
         "reused for a product with a different sparsity pattern.\n"

--- a/sparse/src/KokkosSparse_spgemm_symbolic.hpp
+++ b/sparse/src/KokkosSparse_spgemm_symbolic.hpp
@@ -151,7 +151,25 @@ void spgemm_symbolic(KernelHandle *handle,
         "rows. May use KokkosSparse::sort_crs_matrix to sort it.");
 #endif
 
-  auto algo = tmp_handle.get_spgemm_handle()->get_algorithm_type();
+  auto spgemmHandle = tmp_handle.get_spgemm_handle();
+
+  if (!spgemmHandle) {
+    throw std::invalid_argument(
+        "KokkosSparse::spgemm_symbolic: the given KernelHandle does not have "
+        "an SpGEMM handle associated with it.");
+  }
+
+  if (!spgemmHandle->checkMatrixIdentitiesSymbolic(
+          const_a_r.data(), const_a_l.data(), const_b_r.data(),
+          const_b_l.data(), c_r.data())) {
+    throw std::invalid_argument(
+        "KokkosSparse::spgemm_symbolic: once used, an spgemm handle cannot be "
+        "reused for a product with a different sparsity pattern.\n"
+        "The rowptrs and entries of A, B and C must be identical to those "
+        "passed to the first spgemm_symbolic call.");
+  }
+
+  auto algo = spgemmHandle->get_algorithm_type();
 
   if (algo == SPGEMM_DEBUG || algo == SPGEMM_SERIAL) {
     // Never call a TPL if serial/debug is requested (this is needed for

--- a/sparse/src/KokkosSparse_spgemm_symbolic.hpp
+++ b/sparse/src/KokkosSparse_spgemm_symbolic.hpp
@@ -164,7 +164,7 @@ void spgemm_symbolic(KernelHandle *handle,
     throw std::invalid_argument(
         "KokkosSparse::spgemm_symbolic: once used, an spgemm handle cannot be "
         "reused for a product with a different sparsity pattern.\n"
-        "The rowptrs and entries of A, B and C must be identical to those "
+        "The rowptrs and entries of A and B must be identical to those "
         "passed to the first spgemm_symbolic call.");
   }
 


### PR DESCRIPTION
Resolves #1738. The graphs (rowptrs/entries) of A, B and C can't
change for a given spgemm handle (over all symbolic and numeric calls).
This adds checks to symbolic and numeric for this (the raw pointers of
rowptrs/entries are recorded in the handle, and then compared against in
all subsequent calls).

Since the A/B values views are allowed to change in between numeric calls, strengthen the spgemm reuse testing to actually reallocate those views (not just fill them with new values).

Tested on serial+openmp+cuda without TPLs, then with cusparse, rocsparse and MKL.