### PR TITLE
Deprecate Kokkos::Details::ArithTraits

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -69,13 +69,12 @@ struct is_vector : public std::false_type {};
 
 template <typename Ta, typename Tb>
 struct is_same_mag_type {
-  static const bool is_specialized =
-      (Kokkos::Details::ArithTraits<Ta>::is_specialized &&
-       Kokkos::Details::ArithTraits<Tb>::is_specialized);
+  static const bool is_specialized = (Kokkos::ArithTraits<Ta>::is_specialized &&
+                                      Kokkos::ArithTraits<Tb>::is_specialized);
 
   static const bool is_mag_type_same =
-      std::is_same<typename Kokkos::Details::ArithTraits<Ta>::mag_type,
-                   typename Kokkos::Details::ArithTraits<Tb>::mag_type>::value;
+      std::is_same<typename Kokkos::ArithTraits<Ta>::mag_type,
+                   typename Kokkos::ArithTraits<Tb>::mag_type>::value;
 
   static const bool value = is_specialized && is_mag_type_same;
 };

--- a/batched/dense/impl/KokkosBatched_AddRadial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_AddRadial_Internal.hpp
@@ -38,8 +38,7 @@ struct SerialAddRadialInternal {
 #endif
     for (int i = 0; i < m; ++i) {
       // const auto a_real = RealPart(A[i*as]);
-      const auto a_real =
-          Kokkos::Details::ArithTraits<ValueType>::real(A[i * as]);
+      const auto a_real = Kokkos::ArithTraits<ValueType>::real(A[i * as]);
       A[i * as] += ValueType(minus_abs_tiny) * ValueType(a_real < 0);
       A[i * as] += ValueType(abs_tiny) * ValueType(a_real >= 0);
     }
@@ -62,8 +61,7 @@ struct TeamAddRadialInternal {
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, m), [&](const int &i) {
       // const auto a_real = RealPart(A[i*as]);
-      const auto a_real =
-          Kokkos::Details::ArithTraits<ValueType>::real(A[i * as]);
+      const auto a_real = Kokkos::ArithTraits<ValueType>::real(A[i * as]);
       A[i * as] += ValueType(minus_abs_tiny) * ValueType(a_real < 0);
       A[i * as] += ValueType(abs_tiny) * ValueType(a_real >= 0);
     });

--- a/batched/dense/impl/KokkosBatched_ApplyHouseholder_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_ApplyHouseholder_Serial_Internal.hpp
@@ -56,7 +56,7 @@ struct SerialApplyLeftHouseholderInternal {
     for (int j = 0; j < n; ++j) {
       value_type tmp = a1t[j * a1ts];
       for (int i = 0; i < m; ++i)
-        tmp += Kokkos::Details::ArithTraits<value_type>::conj(u2[i * u2s]) *
+        tmp += Kokkos::ArithTraits<value_type>::conj(u2[i * u2s]) *
                A2[i * as0 + j * as1];
       w1t[j] = tmp * inv_tau;  // /= (*tau);
     }
@@ -109,7 +109,7 @@ struct SerialApplyRightHouseholderInternal {
     for (int j = 0; j < n; ++j)
       for (int i = 0; i < m; ++i)
         A2[i * as0 + j * as1] -=
-            w1[i] * Kokkos::Details::ArithTraits<ValueType>::conj(u2[j * u2s]);
+            w1[i] * Kokkos::ArithTraits<ValueType>::conj(u2[j * u2s]);
 
     return 0;
   }

--- a/batched/dense/impl/KokkosBatched_ApplyHouseholder_TeamVector_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_ApplyHouseholder_TeamVector_Internal.hpp
@@ -59,7 +59,7 @@ struct TeamVectorApplyLeftHouseholderInternal {
       Kokkos::parallel_reduce(
           Kokkos::ThreadVectorRange(member, m),
           [&](const int &i, value_type &val) {
-            val += Kokkos::Details::ArithTraits<value_type>::conj(u2[i * u2s]) *
+            val += Kokkos::ArithTraits<value_type>::conj(u2[i * u2s]) *
                    A2[i * as0 + j * as1];
           },
           tmp);
@@ -146,8 +146,7 @@ struct TeamVectorApplyRightHouseholderInternal {
             Kokkos::parallel_for(
                 Kokkos::ThreadVectorRange(member, m), [&](const int &i) {
                   A2[i * as0 + j * as1] -=
-                      w1[i] * Kokkos::Details::ArithTraits<ValueType>::conj(
-                                  u2[j * u2s]);
+                      w1[i] * Kokkos::ArithTraits<ValueType>::conj(u2[j * u2s]);
                 });
           });
     } else {
@@ -156,8 +155,7 @@ struct TeamVectorApplyRightHouseholderInternal {
             Kokkos::parallel_for(
                 Kokkos::TeamThreadRange(member, m), [&](const int &i) {
                   A2[i * as0 + j * as1] -=
-                      w1[i] * Kokkos::Details::ArithTraits<ValueType>::conj(
-                                  u2[j * u2s]);
+                      w1[i] * Kokkos::ArithTraits<ValueType>::conj(u2[j * u2s]);
                 });
           });
     }

--- a/batched/dense/impl/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Eigendecomposition_Serial_Internal.hpp
@@ -72,7 +72,7 @@ struct SerialEigendecompositionInternal {
                   "Serial eigendecomposition on device and/or without LAPACK "
                   "is not implemented yet");
     //       typedef RealType real_type;
-    //       typedef Kokkos::Details::ArithTraits<real_type> ats;
+    //       typedef Kokkos::ArithTraits<real_type> ats;
 
     //       const real_type one(1), zero(0), tol = 1e2*ats::epsilon();
     //       //const Kokkos::pair<real_type,real_type> identity(one, zero);

--- a/batched/dense/impl/KokkosBatched_Eigenvalue_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Eigenvalue_Serial_Internal.hpp
@@ -68,7 +68,7 @@ struct SerialEigenvalueInternal {
                                            const bool restart           = false,
                                            const int user_max_iteration = -1) {
     typedef RealType real_type;
-    typedef Kokkos::Details::ArithTraits<real_type> ats;
+    typedef Kokkos::ArithTraits<real_type> ats;
     const real_type zero(0), nan(ats::nan()), tol = 1e2 * ats::epsilon();
     const int max_iteration = user_max_iteration < 0 ? 300 : user_max_iteration;
 

--- a/batched/dense/impl/KokkosBatched_Francis_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Francis_Serial_Internal.hpp
@@ -82,9 +82,9 @@ struct SerialFrancisInternal {
       } else {
         const value_type val = H[(m - 1) * hs];
         const auto dist_lambda1 =
-            Kokkos::Details::ArithTraits<value_type>::abs(lambda1.real() - val);
+            Kokkos::ArithTraits<value_type>::abs(lambda1.real() - val);
         const auto dist_lambda2 =
-            Kokkos::Details::ArithTraits<value_type>::abs(lambda2.real() - val);
+            Kokkos::ArithTraits<value_type>::abs(lambda2.real() - val);
         const value_type lambda =
             dist_lambda1 < dist_lambda2 ? lambda1.real() : lambda2.real();
         s = 2 * lambda;

--- a/batched/dense/impl/KokkosBatched_Givens_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Givens_Serial_Internal.hpp
@@ -54,13 +54,12 @@ struct SerialGivensInternal {
     } else {
       // here we do not care overflow caused by the division although it is
       // probable....
-      r  = Kokkos::Details::ArithTraits<value_type>::sqrt(chi1 * chi1 +
-                                                         chi2 * chi2);
+      r  = Kokkos::ArithTraits<value_type>::sqrt(chi1 * chi1 + chi2 * chi2);
       cs = chi1 / r;
       sn = chi2 / r;
 
-      if (Kokkos::Details::ArithTraits<value_type>::abs(chi1) >
-              Kokkos::Details::ArithTraits<value_type>::abs(chi2) &&
+      if (Kokkos::ArithTraits<value_type>::abs(chi1) >
+              Kokkos::ArithTraits<value_type>::abs(chi2) &&
           cs < zero) {
         cs = -cs;
         sn = -sn;

--- a/batched/dense/impl/KokkosBatched_HessenbergQR_WithShift_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_HessenbergQR_WithShift_Serial_Internal.hpp
@@ -37,7 +37,7 @@ struct SerialHessenbergQR_WithShiftInternal {
       /* */ ValueType *HH, const int hs0, const int hs1, const ValueType shift,
       /* */ Kokkos::pair<ValueType, ValueType> *GG, const bool request_schur) {
     typedef ValueType value_type;
-    // typedef Kokkos::Details::ArithTraits<value_type> ats;
+    // typedef Kokkos::ArithTraits<value_type> ats;
 
     const int hs = hs0 + hs1;
     const value_type zero(0), one(1);

--- a/batched/dense/impl/KokkosBatched_Householder_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Householder_Serial_Internal.hpp
@@ -35,7 +35,7 @@ struct SerialLeftHouseholderInternal {
                                            /* */ ValueType* x2, const int x2s,
                                            /* */ ValueType* tau) {
     typedef ValueType value_type;
-    typedef typename Kokkos::Details::ArithTraits<ValueType>::mag_type mag_type;
+    typedef typename Kokkos::ArithTraits<ValueType>::mag_type mag_type;
 
     const mag_type zero(0);
     const mag_type half(0.5);
@@ -58,11 +58,10 @@ struct SerialLeftHouseholderInternal {
     }
 
     /// compute magnitude of chi1, equal to norm2 of chi1
-    const mag_type norm_chi1 =
-        Kokkos::Details::ArithTraits<value_type>::abs(*chi1);
+    const mag_type norm_chi1 = Kokkos::ArithTraits<value_type>::abs(*chi1);
 
     /// compute 2 norm of x using norm_chi1 and norm_x2
-    const mag_type norm_x = Kokkos::Details::ArithTraits<mag_type>::sqrt(
+    const mag_type norm_x = Kokkos::ArithTraits<mag_type>::sqrt(
         norm_x2_square + norm_chi1 * norm_chi1);
 
     /// compute alpha

--- a/batched/dense/impl/KokkosBatched_Householder_TeamVector_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Householder_TeamVector_Internal.hpp
@@ -36,7 +36,7 @@ struct TeamVectorLeftHouseholderInternal {
                                            /* */ ValueType *x2, const int x2s,
                                            /* */ ValueType *tau) {
     typedef ValueType value_type;
-    typedef typename Kokkos::Details::ArithTraits<ValueType>::mag_type mag_type;
+    typedef typename Kokkos::ArithTraits<ValueType>::mag_type mag_type;
 
     const mag_type zero(0);
     const mag_type half(0.5);
@@ -64,11 +64,10 @@ struct TeamVectorLeftHouseholderInternal {
     }
 
     /// compute magnitude of chi1, equal to norm2 of chi1
-    const mag_type norm_chi1 =
-        Kokkos::Details::ArithTraits<value_type>::abs(*chi1);
+    const mag_type norm_chi1 = Kokkos::ArithTraits<value_type>::abs(*chi1);
 
     /// compute 2 norm of x using norm_chi1 and norm_x2
-    const mag_type norm_x = Kokkos::Details::ArithTraits<mag_type>::sqrt(
+    const mag_type norm_x = Kokkos::ArithTraits<mag_type>::sqrt(
         norm_x2_square + norm_chi1 * norm_chi1);
 
     /// compute alpha

--- a/batched/dense/impl/KokkosBatched_LU_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_LU_Serial_Internal.hpp
@@ -62,7 +62,7 @@ KOKKOS_INLINE_FUNCTION int SerialLU_Internal<Algo::LU::Unblocked>::invoke(
     if (tiny != 0) {
       ValueType &alpha11_reference = A[p * as0 + p * as1];
       const auto alpha11_real =
-          Kokkos::Details::ArithTraits<ValueType>::real(alpha11_reference);
+          Kokkos::ArithTraits<ValueType>::real(alpha11_reference);
       alpha11_reference += minus_abs_tiny * ValueType(alpha11_real < 0);
       alpha11_reference += abs_tiny * ValueType(alpha11_real >= 0);
     }

--- a/batched/dense/impl/KokkosBatched_LU_Team_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_LU_Team_Internal.hpp
@@ -68,7 +68,7 @@ KOKKOS_INLINE_FUNCTION int TeamLU_Internal<Algo::LU::Unblocked>::invoke(
       if (member.team_rank() == 0) {
         ValueType &alpha11_reference = A[p * as0 + p * as1];
         const auto alpha11_real =
-            Kokkos::Details::ArithTraits<ValueType>::real(alpha11_reference);
+            Kokkos::ArithTraits<ValueType>::real(alpha11_reference);
         alpha11_reference += minus_abs_tiny * ValueType(alpha11_real < 0);
         alpha11_reference += abs_tiny * ValueType(alpha11_real >= 0);
       }

--- a/batched/dense/impl/KokkosBatched_LeftEigenvectorFromSchur_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_LeftEigenvectorFromSchur_Serial_Internal.hpp
@@ -52,7 +52,7 @@ struct SerialLeftEigenvectorFromSchurInternal {
                                            /* */ ValueType *w,
                                            const int *blks) {
     typedef ValueType value_type;
-    typedef Kokkos::Details::ArithTraits<value_type> ats;
+    typedef Kokkos::ArithTraits<value_type> ats;
     // typedef typename ats::mag_type mag_type;
     typedef Kokkos::complex<value_type> complex_type;
 

--- a/batched/dense/impl/KokkosBatched_Normalize_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Normalize_Internal.hpp
@@ -31,7 +31,7 @@ struct SerialNormalizeInternal {
                                            /* */ ValueType *KOKKOS_RESTRICT v,
                                            const int vs) {
     typedef ValueType value_type;
-    typedef Kokkos::Details::ArithTraits<value_type> ats;
+    typedef Kokkos::ArithTraits<value_type> ats;
     typedef typename ats::mag_type mag_type;
 
     mag_type norm(0);
@@ -42,7 +42,7 @@ struct SerialNormalizeInternal {
       const auto v_at_i = v[i * vs];
       norm += ats::real(v_at_i * ats::conj(v_at_i));
     }
-    norm = Kokkos::Details::ArithTraits<mag_type>::sqrt(norm);
+    norm = Kokkos::ArithTraits<mag_type>::sqrt(norm);
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
 #endif
@@ -58,7 +58,7 @@ struct SerialNormalizeInternal {
                                            /* */ RealType *KOKKOS_RESTRICT vi,
                                            const int vis) {
     typedef RealType real_type;
-    typedef Kokkos::Details::ArithTraits<real_type> ats;
+    typedef Kokkos::ArithTraits<real_type> ats;
     typedef typename ats::mag_type mag_type;
 
     mag_type norm(0);
@@ -70,7 +70,7 @@ struct SerialNormalizeInternal {
       const auto vi_at_i = vi[i * vis];
       norm += vr_at_i * vr_at_i + vi_at_i * vi_at_i;
     }
-    norm = Kokkos::Details::ArithTraits<mag_type>::sqrt(norm);
+    norm = Kokkos::ArithTraits<mag_type>::sqrt(norm);
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
 #endif

--- a/batched/dense/impl/KokkosBatched_RightEigenvectorFromSchur_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_RightEigenvectorFromSchur_Serial_Internal.hpp
@@ -52,7 +52,7 @@ struct SerialRightEigenvectorFromSchurInternal {
                                            /* */ ValueType *w,
                                            const int *blks) {
     typedef ValueType value_type;
-    typedef Kokkos::Details::ArithTraits<value_type> ats;
+    typedef Kokkos::ArithTraits<value_type> ats;
     // typedef typename ats::mag_type mag_type;
     typedef Kokkos::complex<value_type> complex_type;
 

--- a/batched/dense/impl/KokkosBatched_Schur2x2_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Schur2x2_Serial_Internal.hpp
@@ -37,7 +37,7 @@ struct SerialSchur2x2Internal {
                                            Kokkos::complex<RealType>* lambda2,
                                            bool* is_complex) {
     typedef RealType real_type;
-    typedef Kokkos::Details::ArithTraits<real_type> ats;
+    typedef Kokkos::ArithTraits<real_type> ats;
     const real_type zero(0), one(1), half(0.5), minus_one(-1);
     /// compute G = [ gamma -sigma;
     ///               sigma  gamma ];

--- a/batched/dense/impl/KokkosBatched_Schur_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Schur_Serial_Internal.hpp
@@ -76,7 +76,7 @@ struct SerialSchurInternal {
                                            const bool restart           = false,
                                            const int user_max_iteration = -1) {
     typedef RealType real_type;
-    typedef Kokkos::Details::ArithTraits<real_type> ats;
+    typedef Kokkos::ArithTraits<real_type> ats;
     const real_type /* one(1), */ zero(0), tol = 1e2 * ats::epsilon();
     const int max_iteration = user_max_iteration < 0 ? 300 : user_max_iteration;
     if (wlen < m * 5)

--- a/batched/dense/impl/KokkosBatched_Trmm_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Trmm_Serial_Internal.hpp
@@ -77,7 +77,7 @@ SerialTrmmInternalLeftLower<Algo::Trmm::Unblocked>::invoke(
     const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
     /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   const ScalarType one(1.0), zero(0.0);
-  typedef Kokkos::Details::ArithTraits<ValueType> AT;
+  typedef Kokkos::ArithTraits<ValueType> AT;
   int left_m  = am;
   int right_n = bn;
   // echo-TODO: See about coniditionally setting conjOp at compile time.
@@ -162,7 +162,7 @@ SerialTrmmInternalRightLower<Algo::Trmm::Unblocked>::invoke(
     const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
     /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   const ScalarType one(1.0), zero(0.0);
-  typedef Kokkos::Details::ArithTraits<ValueType> AT;
+  typedef Kokkos::ArithTraits<ValueType> AT;
   int left_m  = bm;
   int right_n = an;
   // echo-TODO: See about coniditionally setting conjOp at compile time.
@@ -248,7 +248,7 @@ SerialTrmmInternalLeftUpper<Algo::Trmm::Unblocked>::invoke(
     const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
     /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   const ScalarType one(1.0), zero(0.0);
-  typedef Kokkos::Details::ArithTraits<ValueType> AT;
+  typedef Kokkos::ArithTraits<ValueType> AT;
   int left_m  = am;
   int right_n = bn;
   // echo-TODO: See about coniditionally setting conjOp at compile time.
@@ -330,7 +330,7 @@ SerialTrmmInternalRightUpper<Algo::Trmm::Unblocked>::invoke(
     const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
     /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   const ScalarType one(1.0), zero(0.0);
-  typedef Kokkos::Details::ArithTraits<ValueType> AT;
+  typedef Kokkos::ArithTraits<ValueType> AT;
   int left_m  = bm;
   int right_n = an;
   // echo-TODO: See about coniditionally setting conjOp at compile time.

--- a/batched/dense/impl/KokkosBatched_Vector_SIMD_Arith.hpp
+++ b/batched/dense/impl/KokkosBatched_Vector_SIMD_Arith.hpp
@@ -152,7 +152,7 @@ template <typename T, int l>
 KOKKOS_FORCEINLINE_FUNCTION static KOKKOSKERNELS_SIMD_ARITH_RETURN_TYPE(T, l)
 operator++(Vector<SIMD<T>, l> &a, int) {
   Vector<SIMD<T>, l> a0 = a;
-  a = a + typename Kokkos::Details::ArithTraits<T>::mag_type(1);
+  a                     = a + typename Kokkos::ArithTraits<T>::mag_type(1);
   return a0;
 }
 
@@ -160,7 +160,7 @@ template <typename T, int l>
 KOKKOS_FORCEINLINE_FUNCTION static KOKKOSKERNELS_SIMD_ARITH_RETURN_REFERENCE_TYPE(
     T, l)
 operator++(Vector<SIMD<T>, l> &a) {
-  a = a + typename Kokkos::Details::ArithTraits<T>::mag_type(1);
+  a = a + typename Kokkos::ArithTraits<T>::mag_type(1);
   return a;
 }
 
@@ -355,7 +355,7 @@ template <typename T, int l>
 KOKKOS_FORCEINLINE_FUNCTION static KOKKOSKERNELS_SIMD_ARITH_RETURN_TYPE(T, l)
 operator--(Vector<SIMD<T>, l> &a, int) {
   Vector<SIMD<T>, l> a0 = a;
-  a = a - typename Kokkos::Details::ArithTraits<T>::mag_type(1);
+  a                     = a - typename Kokkos::ArithTraits<T>::mag_type(1);
   return a0;
 }
 
@@ -363,7 +363,7 @@ template <typename T, int l>
 KOKKOS_FORCEINLINE_FUNCTION static KOKKOSKERNELS_SIMD_ARITH_RETURN_REFERENCE_TYPE(
     T, l)
 operator--(Vector<SIMD<T>, l> &a) {
-  a = a - typename Kokkos::Details::ArithTraits<T>::mag_type(1);
+  a = a - typename Kokkos::ArithTraits<T>::mag_type(1);
   return a;
 }
 

--- a/batched/dense/impl/KokkosBatched_Vector_SIMD_Math.hpp
+++ b/batched/dense/impl/KokkosBatched_Vector_SIMD_Math.hpp
@@ -32,7 +32,7 @@ namespace KokkosBatched {
 template <typename T, int l>
 KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_TYPE(T, l)
     sqrt(const Vector<SIMD<T>, l> &a) {
-  typedef Kokkos::Details::ArithTraits<T> ats;
+  typedef Kokkos::ArithTraits<T> ats;
   Vector<SIMD<T>, l> r_val;
 #if defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
 #pragma ivdep
@@ -48,7 +48,7 @@ KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_TYPE(T, l)
 template <typename T, int l>
 KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_TYPE(T, l)
     cbrt(const Vector<SIMD<T>, l> &a) {
-  typedef Kokkos::Details::ArithTraits<T> ats;
+  typedef Kokkos::ArithTraits<T> ats;
   Vector<SIMD<T>, l> r_val;
 #if defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
 #pragma ivdep
@@ -64,7 +64,7 @@ KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_TYPE(T, l)
 template <typename T, int l>
 KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_TYPE(T, l)
     log(const Vector<SIMD<T>, l> &a) {
-  typedef Kokkos::Details::ArithTraits<T> ats;
+  typedef Kokkos::ArithTraits<T> ats;
   Vector<SIMD<T>, l> r_val;
 #if defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
 #pragma ivdep
@@ -80,7 +80,7 @@ KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_TYPE(T, l)
 template <typename T, int l>
 KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_TYPE(T, l)
     log10(const Vector<SIMD<T>, l> &a) {
-  typedef Kokkos::Details::ArithTraits<T> ats;
+  typedef Kokkos::ArithTraits<T> ats;
   Vector<SIMD<T>, l> r_val;
 #if defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
 #pragma ivdep
@@ -96,7 +96,7 @@ KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_TYPE(T, l)
 template <typename T, int l>
 KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_TYPE(T, l)
     exp(const Vector<SIMD<T>, l> &a) {
-  typedef Kokkos::Details::ArithTraits<T> ats;
+  typedef Kokkos::ArithTraits<T> ats;
   Vector<SIMD<T>, l> r_val;
 #if defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
 #pragma ivdep
@@ -112,7 +112,7 @@ KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_TYPE(T, l)
 template <typename T0, typename T1, int l>
 KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_TYPE(T0, l)
     pow(const Vector<SIMD<T0>, l> &a, const Vector<SIMD<T1>, l> &b) {
-  typedef Kokkos::Details::ArithTraits<T0> ats;
+  typedef Kokkos::ArithTraits<T0> ats;
   Vector<SIMD<T0>, l> r_val;
 #if defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
 #pragma ivdep
@@ -140,7 +140,7 @@ KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_TYPE(T0, l)
 template <typename T, int l>
 KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_FLOAT_TYPE(T, l)
     sin(const Vector<SIMD<T>, l> &a) {
-  typedef Kokkos::Details::ArithTraits<T> ats;
+  typedef Kokkos::ArithTraits<T> ats;
   Vector<SIMD<T>, l> r_val;
 #if defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
 #pragma ivdep
@@ -156,7 +156,7 @@ KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_FLOAT_TYPE(T, l)
 template <typename T, int l>
 KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_FLOAT_TYPE(T, l)
     cos(const Vector<SIMD<T>, l> &a) {
-  typedef Kokkos::Details::ArithTraits<T> ats;
+  typedef Kokkos::ArithTraits<T> ats;
   Vector<SIMD<T>, l> r_val;
 #if defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
 #pragma ivdep
@@ -172,7 +172,7 @@ KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_FLOAT_TYPE(T, l)
 template <typename T, int l>
 KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_FLOAT_TYPE(T, l)
     tan(const Vector<SIMD<T>, l> &a) {
-  typedef Kokkos::Details::ArithTraits<T> ats;
+  typedef Kokkos::ArithTraits<T> ats;
   Vector<SIMD<T>, l> r_val;
 #if defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
 #pragma ivdep
@@ -188,7 +188,7 @@ KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_FLOAT_TYPE(T, l)
 template <typename T, int l>
 KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_FLOAT_TYPE(T, l)
     sinh(const Vector<SIMD<T>, l> &a) {
-  typedef Kokkos::Details::ArithTraits<T> ats;
+  typedef Kokkos::ArithTraits<T> ats;
   Vector<SIMD<T>, l> r_val;
 #if defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
 #pragma ivdep
@@ -204,7 +204,7 @@ KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_FLOAT_TYPE(T, l)
 template <typename T, int l>
 KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_FLOAT_TYPE(T, l)
     cosh(const Vector<SIMD<T>, l> &a) {
-  typedef Kokkos::Details::ArithTraits<T> ats;
+  typedef Kokkos::ArithTraits<T> ats;
   Vector<SIMD<T>, l> r_val;
 #if defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
 #pragma ivdep
@@ -220,7 +220,7 @@ KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_FLOAT_TYPE(T, l)
 template <typename T, int l>
 KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_FLOAT_TYPE(T, l)
     tanh(const Vector<SIMD<T>, l> &a) {
-  typedef Kokkos::Details::ArithTraits<T> ats;
+  typedef Kokkos::ArithTraits<T> ats;
   Vector<SIMD<T>, l> r_val;
 #if defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
 #pragma ivdep
@@ -236,7 +236,7 @@ KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_FLOAT_TYPE(T, l)
 template <typename T, int l>
 KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_FLOAT_TYPE(T, l)
     asin(const Vector<SIMD<T>, l> &a) {
-  typedef Kokkos::Details::ArithTraits<T> ats;
+  typedef Kokkos::ArithTraits<T> ats;
   Vector<SIMD<T>, l> r_val;
 #if defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
 #pragma ivdep
@@ -252,7 +252,7 @@ KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_FLOAT_TYPE(T, l)
 template <typename T, int l>
 KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_FLOAT_TYPE(T, l)
     acos(const Vector<SIMD<T>, l> &a) {
-  typedef Kokkos::Details::ArithTraits<T> ats;
+  typedef Kokkos::ArithTraits<T> ats;
   Vector<SIMD<T>, l> r_val;
 #if defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
 #pragma ivdep
@@ -268,7 +268,7 @@ KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_FLOAT_TYPE(T, l)
 template <typename T, int l>
 KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_FLOAT_TYPE(T, l)
     atan(const Vector<SIMD<T>, l> &a) {
-  typedef Kokkos::Details::ArithTraits<T> ats;
+  typedef Kokkos::ArithTraits<T> ats;
   Vector<SIMD<T>, l> r_val;
 #if defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
 #pragma ivdep
@@ -284,7 +284,7 @@ KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_FLOAT_TYPE(T, l)
 template <typename T, int l>
 KOKKOS_INLINE_FUNCTION static KOKKOSKERNELS_SIMD_MATH_RETURN_FLOAT_TYPE(T, l)
     atan2(const Vector<SIMD<T>, l> &a, const Vector<SIMD<T>, l> &b) {
-  // typedef Kokkos::Details::ArithTraits<T> ats;
+  // typedef Kokkos::ArithTraits<T> ats;
   Vector<SIMD<T>, l> r_val;
 #if defined(KOKKOS_ENABLE_PRAGMA_IVDEP)
 #pragma ivdep

--- a/batched/dense/impl/KokkosBatched_WilkinsonShift_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_WilkinsonShift_Serial_Internal.hpp
@@ -52,18 +52,16 @@ struct SerialWilkinsonShiftInternal {
 
     if (v < 0) {
       // complex
-      const value_type sqrt_v =
-          Kokkos::Details::ArithTraits<value_type>::sqrt(-v);
-      *lambda1    = Kokkos::complex<value_type>(p, sqrt_v);
-      *lambda2    = Kokkos::complex<value_type>(p, -sqrt_v);
-      *is_complex = true;
+      const value_type sqrt_v = Kokkos::ArithTraits<value_type>::sqrt(-v);
+      *lambda1                = Kokkos::complex<value_type>(p, sqrt_v);
+      *lambda2                = Kokkos::complex<value_type>(p, -sqrt_v);
+      *is_complex             = true;
     } else {
       // real
-      const value_type sqrt_v =
-          Kokkos::Details::ArithTraits<value_type>::sqrt(v);
-      *lambda1    = Kokkos::complex<value_type>(p + sqrt_v);
-      *lambda2    = Kokkos::complex<value_type>(p - sqrt_v);
-      *is_complex = false;
+      const value_type sqrt_v = Kokkos::ArithTraits<value_type>::sqrt(v);
+      *lambda1                = Kokkos::complex<value_type>(p + sqrt_v);
+      *lambda2                = Kokkos::complex<value_type>(p - sqrt_v);
+      *is_complex             = false;
     }
     return 0;
   }

--- a/batched/dense/src/KokkosBatched_Vector.hpp
+++ b/batched/dense/src/KokkosBatched_Vector.hpp
@@ -251,7 +251,6 @@ struct MagnitudeScalarType<Vector<SIMD<Kokkos::complex<double>>, l>> {
 
 // arith traits overload for vector types
 namespace Kokkos {
-namespace Details {
 
 // do not use Vector alone as other can use the name.
 
@@ -337,7 +336,6 @@ class ArithTraits<
   }
 };
 
-}  // namespace Details
 }  // namespace Kokkos
 
 #endif

--- a/batched/dense/src/KokkosBatched_Vector_SIMD.hpp
+++ b/batched/dense/src/KokkosBatched_Vector_SIMD.hpp
@@ -36,7 +36,7 @@ class Vector<SIMD<T>, l> {
  public:
   using type       = Vector<SIMD<T>, l>;
   using value_type = T;
-  using mag_type   = typename Kokkos::Details::ArithTraits<T>::mag_type;
+  using mag_type   = typename Kokkos::ArithTraits<T>::mag_type;
 
   enum : int { vector_length = l };
 

--- a/batched/dense/unit_test/Test_Batched_BatchedGemm.hpp
+++ b/batched/dense/unit_test/Test_Batched_BatchedGemm.hpp
@@ -37,7 +37,7 @@ void impl_test_batched_gemm_with_handle(BatchedGemmHandle* batchedGemmHandle,
   using transB          = typename ParamTagType::transB;
   using batchLayout     = typename ParamTagType::batchLayout;
   using view_layout     = typename ViewType::array_layout;
-  using ats             = Kokkos::Details::ArithTraits<ScalarType>;
+  using ats             = Kokkos::ArithTraits<ScalarType>;
 
   int ret        = 0;
   auto algo_type = batchedGemmHandle->get_kernel_algo_type();

--- a/batched/dense/unit_test/Test_Batched_SerialAxpy.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialAxpy.hpp
@@ -65,7 +65,7 @@ void impl_test_batched_axpy(const int N, const int BlkSize) {
   typedef typename ViewType::value_type value_type;
   typedef typename ViewType::const_value_type const_value_type;
   typedef typename alphaViewType::const_value_type alpha_const_value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   ViewType X0("x0", N, BlkSize), X1("x1", N, BlkSize), Y0("y0", N, BlkSize),
       Y1("y1", N, BlkSize);

--- a/batched/dense/unit_test/Test_Batched_SerialGemm.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialGemm.hpp
@@ -81,7 +81,7 @@ void impl_test_batched_gemm(const int N, const int matAdim1, const int matAdim2,
   using transA          = typename ParamTagType::transA;
   using transB          = typename ParamTagType::transB;
   using value_type      = typename ViewType::value_type;
-  using ats             = Kokkos::Details::ArithTraits<value_type>;
+  using ats             = Kokkos::ArithTraits<value_type>;
 
   /// randomized input testing views
   ScalarType alpha = ScalarType(1.5);

--- a/batched/dense/unit_test/Test_Batched_SerialGesv.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialGesv.hpp
@@ -71,10 +71,9 @@ template <typename DeviceType, typename MatrixType, typename VectorType,
           typename AlgoTagType>
 void impl_test_batched_gesv(const int N, const int BlkSize) {
   typedef typename MatrixType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
-  using MagnitudeType =
-      typename Kokkos::Details::ArithTraits<value_type>::mag_type;
+  using MagnitudeType = typename Kokkos::ArithTraits<value_type>::mag_type;
   using NormViewType =
       Kokkos::View<MagnitudeType *, Kokkos::LayoutLeft, DeviceType>;
 

--- a/batched/dense/unit_test/Test_Batched_SerialInverseLU.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialInverseLU.hpp
@@ -140,7 +140,7 @@ template <typename DeviceType, typename AViewType, typename WViewType,
           typename AlgoTagType>
 void impl_test_batched_inverselu(const int N, const int BlkSize) {
   typedef typename AViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   /// randomized input testing views
   AViewType a0("a0", N, BlkSize, BlkSize);

--- a/batched/dense/unit_test/Test_Batched_SerialLU.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialLU.hpp
@@ -61,7 +61,7 @@ struct Functor_TestBatchedSerialLU {
 template <typename DeviceType, typename ViewType, typename AlgoTagType>
 void impl_test_batched_lu(const int N, const int BlkSize) {
   typedef typename ViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   /// randomized input testing views
   ViewType a0("a0", N, BlkSize, BlkSize), a1("a1", N, BlkSize, BlkSize);

--- a/batched/dense/unit_test/Test_Batched_SerialSolveLU.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialSolveLU.hpp
@@ -139,7 +139,7 @@ struct Functor_TestBatchedSerialSolveLU {
 template <typename DeviceType, typename ViewType, typename AlgoTagType>
 void impl_test_batched_solvelu(const int N, const int BlkSize) {
   typedef typename ViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   /// randomized input testing views
   ViewType a0("a0", N, BlkSize, BlkSize);

--- a/batched/dense/unit_test/Test_Batched_SerialTrmm.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTrmm.hpp
@@ -61,7 +61,7 @@ struct VanillaGEMM {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
   typedef typename ViewTypeC::value_type ScalarC;
-  typedef Kokkos::Details::ArithTraits<ScalarC> APT;
+  typedef Kokkos::ArithTraits<ScalarC> APT;
   typedef typename APT::mag_type mag_type;
   ScalarA alpha;
   ScalarC beta;
@@ -150,7 +150,7 @@ void impl_test_batched_trmm(const int N, const int nRows, const int nCols,
                             const char* trans) {
   typedef typename ViewType::value_type value_type;
   typedef typename DeviceType::execution_space execution_space;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   ScalarType alpha(1.0);
   ScalarType beta(0.0);

--- a/batched/dense/unit_test/Test_Batched_SerialTrsm.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTrsm.hpp
@@ -75,7 +75,7 @@ template <typename DeviceType, typename ViewType, typename ScalarType,
           typename ParamTagType, typename AlgoTagType>
 void impl_test_batched_trsm(const int N, const int BlkSize, const int NumCols) {
   typedef typename ViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   /// randomized input testing views
   ScalarType alpha(1.0);

--- a/batched/dense/unit_test/Test_Batched_SerialTrsv.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTrsv.hpp
@@ -74,7 +74,7 @@ template <typename DeviceType, typename ViewType, typename ScalarType,
           typename ParamTagType, typename AlgoTagType>
 void impl_test_batched_trsv(const int N, const int BlkSize) {
   typedef typename ViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   /// randomized input testing views
   ScalarType alpha(1.5);

--- a/batched/dense/unit_test/Test_Batched_SerialTrtri.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTrtri.hpp
@@ -63,7 +63,7 @@ struct VanillaGEMM {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
   typedef typename ViewTypeC::value_type ScalarC;
-  typedef Kokkos::Details::ArithTraits<ScalarC> APT;
+  typedef Kokkos::ArithTraits<ScalarC> APT;
   typedef typename APT::mag_type mag_type;
   ScalarA alpha;
   ScalarC beta;
@@ -143,7 +143,7 @@ template <typename DeviceType, typename ViewType, typename ScalarType,
 void impl_test_batched_trtri(const int N, const int K) {
   typedef typename ViewType::value_type value_type;
   typedef typename DeviceType::execution_space execution_space;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   ScalarType alpha(1.0);
   ScalarType beta(0.0);

--- a/batched/dense/unit_test/Test_Batched_TeamAxpy.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamAxpy.hpp
@@ -77,7 +77,7 @@ void impl_test_batched_axpy(const int N, const int BlkSize, const int N_team) {
   typedef typename ViewType::value_type value_type;
   typedef typename ViewType::const_value_type const_value_type;
   typedef typename alphaViewType::const_value_type alpha_const_value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   ViewType X0("x0", N, BlkSize), X1("x1", N, BlkSize), Y0("y0", N, BlkSize),
       Y1("y1", N, BlkSize);

--- a/batched/dense/unit_test/Test_Batched_TeamGemm.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamGemm.hpp
@@ -90,7 +90,7 @@ void impl_test_batched_teamgemm(const int N, const int matAdim1,
   using transB          = typename ParamTagType::transB;
   using execution_space = typename DeviceType::execution_space;
   using value_type      = typename ViewType::value_type;
-  using ats             = Kokkos::Details::ArithTraits<value_type>;
+  using ats             = Kokkos::ArithTraits<value_type>;
 
   /// randomized input testing views
   ScalarType alpha = ScalarType(1.5), beta = ScalarType(3.0);

--- a/batched/dense/unit_test/Test_Batched_TeamGesv.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamGesv.hpp
@@ -83,10 +83,9 @@ template <typename DeviceType, typename MatrixType, typename VectorType,
           typename AlgoTagType>
 void impl_test_batched_gesv(const int N, const int BlkSize) {
   typedef typename MatrixType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
-  using MagnitudeType =
-      typename Kokkos::Details::ArithTraits<value_type>::mag_type;
+  using MagnitudeType = typename Kokkos::ArithTraits<value_type>::mag_type;
   using NormViewType =
       Kokkos::View<MagnitudeType *, Kokkos::LayoutLeft, DeviceType>;
 

--- a/batched/dense/unit_test/Test_Batched_TeamInverseLU.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamInverseLU.hpp
@@ -161,7 +161,7 @@ template <typename DeviceType, typename AViewType, typename WViewType,
           typename AlgoTagType>
 void impl_test_batched_inverselu(const int N, const int BlkSize) {
   typedef typename AViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   /// randomized input testing views
   AViewType a0("a0", N, BlkSize, BlkSize);

--- a/batched/dense/unit_test/Test_Batched_TeamLU.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamLU.hpp
@@ -69,7 +69,7 @@ struct Functor_TestBatchedTeamLU {
 template <typename DeviceType, typename ViewType, typename AlgoTagType>
 void impl_test_batched_lu(const int N, const int BlkSize) {
   typedef typename ViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   /// randomized input testing views
   ViewType a0("a0", N, BlkSize, BlkSize), a1("a1", N, BlkSize, BlkSize);

--- a/batched/dense/unit_test/Test_Batched_TeamSolveLU.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamSolveLU.hpp
@@ -155,7 +155,7 @@ struct Functor_TestBatchedTeamSolveLU {
 template <typename DeviceType, typename ViewType, typename AlgoTagType>
 void impl_test_batched_solvelu(const int N, const int BlkSize) {
   typedef typename ViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   /// randomized input testing views
   ViewType a0("a0", N, BlkSize, BlkSize);

--- a/batched/dense/unit_test/Test_Batched_TeamTrsm.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamTrsm.hpp
@@ -85,7 +85,7 @@ template <typename DeviceType, typename ViewType, typename ScalarType,
           typename ParamTagType, typename AlgoTagType>
 void impl_test_batched_trsm(const int N, const int BlkSize, const int NumCols) {
   typedef typename ViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   /// randomized input testing views
   ScalarType alpha(1.0);

--- a/batched/dense/unit_test/Test_Batched_TeamTrsv.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamTrsv.hpp
@@ -83,7 +83,7 @@ template <typename DeviceType, typename ViewType, typename ScalarType,
           typename ParamTagType, typename AlgoTagType>
 void impl_test_batched_trsv(const int N, const int BlkSize) {
   typedef typename ViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   /// randomized input testing views
   ScalarType alpha(1.5);

--- a/batched/dense/unit_test/Test_Batched_TeamVectorAxpy.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorAxpy.hpp
@@ -78,7 +78,7 @@ void impl_test_batched_axpy(const int N, const int BlkSize, const int N_team) {
   typedef typename ViewType::value_type value_type;
   typedef typename ViewType::const_value_type const_value_type;
   typedef typename alphaViewType::const_value_type alpha_const_value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   ViewType X0("x0", N, BlkSize), X1("x1", N, BlkSize), Y0("y0", N, BlkSize),
       Y1("y1", N, BlkSize);

--- a/batched/dense/unit_test/Test_Batched_TeamVectorGemm.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorGemm.hpp
@@ -85,7 +85,7 @@ void impl_test_batched_teamvectorgemm(const int N, const int matAdim1,
   using transB          = typename ParamTagType::transB;
   using execution_space = typename DeviceType::execution_space;
   using value_type      = typename ViewType::value_type;
-  using ats             = Kokkos::Details::ArithTraits<value_type>;
+  using ats             = Kokkos::ArithTraits<value_type>;
 
   /// randomized input testing views
   ScalarType alpha = ScalarType(1.5), beta = ScalarType(3.0);

--- a/batched/dense/unit_test/Test_Batched_TeamVectorGesv.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorGesv.hpp
@@ -84,10 +84,9 @@ template <typename DeviceType, typename MatrixType, typename VectorType,
           typename AlgoTagType>
 void impl_test_batched_gesv(const int N, const int BlkSize) {
   typedef typename MatrixType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
-  using MagnitudeType =
-      typename Kokkos::Details::ArithTraits<value_type>::mag_type;
+  using MagnitudeType = typename Kokkos::ArithTraits<value_type>::mag_type;
   using NormViewType =
       Kokkos::View<MagnitudeType *, Kokkos::LayoutLeft, DeviceType>;
 

--- a/batched/dense/unit_test/Test_Batched_TeamVectorQR.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorQR.hpp
@@ -110,7 +110,7 @@ template <typename DeviceType, typename MatrixViewType, typename VectorViewType,
           typename WorkViewType, typename AlgoTagType>
 void impl_test_batched_qr(const int N, const int BlkSize) {
   typedef typename MatrixViewType::non_const_value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
   const value_type one(1);
   /// randomized input testing views
   MatrixViewType a("a", N, BlkSize, BlkSize);

--- a/batched/dense/unit_test/Test_Batched_TeamVectorQR_WithColumnPivoting.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorQR_WithColumnPivoting.hpp
@@ -119,7 +119,7 @@ template <typename DeviceType, typename MatrixViewType, typename VectorViewType,
           typename PivotViewType, typename WorkViewType, typename AlgoTagType>
 void impl_test_batched_qr_with_columnpivoting(const int N, const int BlkSize) {
   typedef typename MatrixViewType::non_const_value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
   // const value_type one(1);
   /// randomized input testing views
   MatrixViewType a("a", N, BlkSize, BlkSize);

--- a/batched/dense/unit_test/Test_Batched_TeamVectorSolveUTV.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorSolveUTV.hpp
@@ -132,7 +132,7 @@ template <typename DeviceType, typename MatrixViewType, typename VectorViewType,
           typename PivViewType, typename WorkViewType, typename AlgoTagType>
 void impl_test_batched_solve_utv(const int N, const int BlkSize) {
   typedef typename MatrixViewType::non_const_value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
   // const value_type one(1);
   /// randomized input testing views
   MatrixViewType r("r", N, BlkSize, 3);

--- a/batched/dense/unit_test/Test_Batched_TeamVectorSolveUTV2.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorSolveUTV2.hpp
@@ -136,7 +136,7 @@ template <typename DeviceType, typename MatrixViewType, typename VectorViewType,
           typename PivViewType, typename WorkViewType, typename AlgoTagType>
 void impl_test_batched_solve_utv2(const int N, const int BlkSize) {
   typedef typename MatrixViewType::non_const_value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
   // const value_type one(1);
   /// randomized input testing views
   MatrixViewType r("r", N, BlkSize, 3);

--- a/batched/dense/unit_test/Test_Batched_TeamVectorUTV.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorUTV.hpp
@@ -166,7 +166,7 @@ template <typename DeviceType, typename MatrixViewType, typename VectorViewType,
           typename PivViewType, typename WorkViewType, typename AlgoTagType>
 void impl_test_batched_utv(const int N, const int BlkSize) {
   typedef typename MatrixViewType::non_const_value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
   // const value_type one(1);
   /// randomized input testing views
   MatrixViewType r("r", N, BlkSize, 3);

--- a/batched/dense/unit_test/Test_Batched_VectorArithmatic.hpp
+++ b/batched/dense/unit_test/Test_Batched_VectorArithmatic.hpp
@@ -52,10 +52,10 @@ void impl_test_complex_real_imag_value() {
     a[k].imag() = k * 5 + 4;
   }
 
-  const auto a_real = Kokkos::Details::ArithTraits<vector_type>::real(a);
-  const auto a_imag = Kokkos::Details::ArithTraits<vector_type>::imag(a);
+  const auto a_real = Kokkos::ArithTraits<vector_type>::real(a);
+  const auto a_imag = Kokkos::ArithTraits<vector_type>::imag(a);
 
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
   const typename ats::mag_type eps = 1.0e3 * ats::epsilon();
   for (int k = 0; k < vector_length; ++k) {
     EXPECT_NEAR(a[k].real(), a_real[k], eps);
@@ -71,7 +71,7 @@ void impl_test_batched_vector_arithmatic() {
   typedef typename vector_type::value_type value_type;
   const int vector_length = vector_type::vector_length;
 
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
   typedef typename ats::mag_type mag_type;
 
   vector_type a, b, c;

--- a/batched/dense/unit_test/Test_Batched_VectorLogical.hpp
+++ b/batched/dense/unit_test/Test_Batched_VectorLogical.hpp
@@ -45,7 +45,7 @@ void impl_test_batched_vector_logical() {
   typedef ValueType value_type;
   const int vector_length = VectorLength;
 
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
   typedef typename ats::mag_type mag_type;
 
   vector_int_type a, b;

--- a/batched/dense/unit_test/Test_Batched_VectorMath.hpp
+++ b/batched/dense/unit_test/Test_Batched_VectorMath.hpp
@@ -46,7 +46,7 @@ void impl_test_batched_vector_math() {
   typedef typename vector_type::value_type value_type;
   const int vector_length = vector_type::vector_length;
 
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
   typedef typename ats::mag_type mag_type;
 
   vector_type a, b, aref, bref;
@@ -136,7 +136,7 @@ int test_batched_vector_math() {
 
 // template<typename ValueType>
 // int test_complex_pow() {
-//   typedef Kokkos::Details::ArithTraits<Kokkos::complex<ValueType> > ats;
+//   typedef Kokkos::ArithTraits<Kokkos::complex<ValueType> > ats;
 //   typedef typename ats::mag_type mag_type;
 
 //   const mag_type eps = 1.0e3 * ats::epsilon();

--- a/batched/dense/unit_test/Test_Batched_VectorMisc.hpp
+++ b/batched/dense/unit_test/Test_Batched_VectorMisc.hpp
@@ -46,7 +46,7 @@ void impl_test_batched_vector_misc() {
   typedef typename vector_type::value_type value_type;
   const int vector_length = vector_type::vector_length;
 
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
   typedef typename ats::mag_type mag_type;
 
   vector_type a, b, c;

--- a/batched/dense/unit_test/Test_Batched_VectorRelation.hpp
+++ b/batched/dense/unit_test/Test_Batched_VectorRelation.hpp
@@ -46,7 +46,7 @@ void impl_test_batched_vector_relation() {
   typedef typename vector_type::value_type value_type;
   const int vector_length = vector_type::vector_length;
 
-  // typedef Kokkos::Details::ArithTraits<value_type> ats;
+  // typedef Kokkos::ArithTraits<value_type> ats;
   // typedef typename ats::mag_type mag_type;
 
   vector_type a, b;

--- a/batched/dense/unit_test/Test_Batched_VectorView.hpp
+++ b/batched/dense/unit_test/Test_Batched_VectorView.hpp
@@ -67,7 +67,7 @@ void impl_verify_vector_view(
     const SimdViewAccess<VectorViewType, PackDim<0> >& b) {
   typedef typename VectorViewType::value_type vector_type;
   constexpr int vl = vector_type::vector_length;
-  typedef Kokkos::Details::ArithTraits<typename vector_type::value_type> ats;
+  typedef Kokkos::ArithTraits<typename vector_type::value_type> ats;
   const typename ats::mag_type eps = 1.0e3 * ats::epsilon();
   TEST_LOOP
   EXPECT_NEAR_KK(a.access(i0 / vl, i1, i2, i3, i4, i5, i6, i7)[i0 % vl],
@@ -79,7 +79,7 @@ void impl_verify_vector_view(
     const SimdViewAccess<VectorViewType, PackDim<1> >& b) {
   typedef typename VectorViewType::value_type vector_type;
   constexpr int vl = vector_type::vector_length;
-  typedef Kokkos::Details::ArithTraits<typename vector_type::value_type> ats;
+  typedef Kokkos::ArithTraits<typename vector_type::value_type> ats;
   const typename ats::mag_type eps = 1.0e3 * ats::epsilon();
   TEST_LOOP
   EXPECT_NEAR_KK(a.access(i0, i1 / vl, i2, i3, i4, i5, i6, i7)[i1 % vl],
@@ -91,7 +91,7 @@ void impl_verify_vector_view(
     const SimdViewAccess<VectorViewType, PackDim<2> >& b) {
   typedef typename VectorViewType::value_type vector_type;
   constexpr int vl = vector_type::vector_length;
-  typedef Kokkos::Details::ArithTraits<typename vector_type::value_type> ats;
+  typedef Kokkos::ArithTraits<typename vector_type::value_type> ats;
   const typename ats::mag_type eps = 1.0e3 * ats::epsilon();
   TEST_LOOP
   EXPECT_NEAR_KK(a.access(i0, i1, i2 / vl, i3, i4, i5, i6, i7)[i2 % vl],
@@ -103,7 +103,7 @@ void impl_verify_vector_view(
     const SimdViewAccess<VectorViewType, PackDim<3> >& b) {
   typedef typename VectorViewType::value_type vector_type;
   constexpr int vl = vector_type::vector_length;
-  typedef Kokkos::Details::ArithTraits<typename vector_type::value_type> ats;
+  typedef Kokkos::ArithTraits<typename vector_type::value_type> ats;
   const typename ats::mag_type eps = 1.0e3 * ats::epsilon();
   TEST_LOOP
   EXPECT_NEAR_KK(a.access(i0, i1, i2, i3 / vl, i4, i5, i6, i7)[i3 % vl],
@@ -115,7 +115,7 @@ void impl_verify_vector_view(
     const SimdViewAccess<VectorViewType, PackDim<4> >& b) {
   typedef typename VectorViewType::value_type vector_type;
   constexpr int vl = vector_type::vector_length;
-  typedef Kokkos::Details::ArithTraits<typename vector_type::value_type> ats;
+  typedef Kokkos::ArithTraits<typename vector_type::value_type> ats;
   const typename ats::mag_type eps = 1.0e3 * ats::epsilon();
   TEST_LOOP
   EXPECT_NEAR_KK(a.access(i0, i1, i2, i3, i4 / vl, i5, i6, i7)[i4 % vl],
@@ -127,7 +127,7 @@ void impl_verify_vector_view(
     const SimdViewAccess<VectorViewType, PackDim<5> >& b) {
   typedef typename VectorViewType::value_type vector_type;
   constexpr int vl = vector_type::vector_length;
-  typedef Kokkos::Details::ArithTraits<typename vector_type::value_type> ats;
+  typedef Kokkos::ArithTraits<typename vector_type::value_type> ats;
   const typename ats::mag_type eps = 1.0e3 * ats::epsilon();
   TEST_LOOP
   EXPECT_NEAR_KK(a.access(i0, i1, i2, i3, i4, i5 / vl, i6, i7)[i5 % vl],
@@ -139,7 +139,7 @@ void impl_verify_vector_view(
     const SimdViewAccess<VectorViewType, PackDim<6> >& b) {
   typedef typename VectorViewType::value_type vector_type;
   constexpr int vl = vector_type::vector_length;
-  typedef Kokkos::Details::ArithTraits<typename vector_type::value_type> ats;
+  typedef Kokkos::ArithTraits<typename vector_type::value_type> ats;
   const typename ats::mag_type eps = 1.0e3 * ats::epsilon();
   TEST_LOOP
   EXPECT_NEAR_KK(a.access(i0, i1, i2, i3, i4, i5, i6 / vl, i7)[i6 % vl],
@@ -151,7 +151,7 @@ void impl_verify_vector_view(
     const SimdViewAccess<VectorViewType, PackDim<7> >& b) {
   typedef typename VectorViewType::value_type vector_type;
   constexpr int vl = vector_type::vector_length;
-  typedef Kokkos::Details::ArithTraits<typename vector_type::value_type> ats;
+  typedef Kokkos::ArithTraits<typename vector_type::value_type> ats;
   const typename ats::mag_type eps = 1.0e3 * ats::epsilon();
   TEST_LOOP
   EXPECT_NEAR_KK(a.access(i0, i1, i2, i3, i4, i5, i6, i7 / vl)[i7 % vl],

--- a/batched/sparse/impl/KokkosBatched_CG_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_CG_TeamVector_Impl.hpp
@@ -43,7 +43,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorCG<MemberType>::invoke(
     const VectorViewType& _X, const KrylovHandleType& handle,
     const TMPViewType& _TMPView, const TMPNormViewType& _TMPNormView) {
   typedef int OrdinalType;
-  typedef typename Kokkos::Details::ArithTraits<
+  typedef typename Kokkos::ArithTraits<
       typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
 
   const size_t maximum_iteration = handle.get_max_iteration();
@@ -179,7 +179,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorCG<MemberType>::invoke(
         typename VectorViewType::array_layout,
         typename VectorViewType::execution_space::scratch_memory_space>;
     using ScratchPadNormViewType = Kokkos::View<
-        typename Kokkos::Details::ArithTraits<
+        typename Kokkos::ArithTraits<
             typename VectorViewType::non_const_value_type>::mag_type**,
         typename VectorViewType::execution_space::scratch_memory_space>;
 
@@ -201,7 +201,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorCG<MemberType>::invoke(
     const int last_matrix  = handle.last_index(member.league_rank());
 
     using ScratchPadNormViewType = Kokkos::View<
-        typename Kokkos::Details::ArithTraits<
+        typename Kokkos::ArithTraits<
             typename VectorViewType::non_const_value_type>::mag_type**,
         typename VectorViewType::execution_space::scratch_memory_space>;
 

--- a/batched/sparse/impl/KokkosBatched_CG_Team_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_CG_Team_Impl.hpp
@@ -41,7 +41,7 @@ KOKKOS_INLINE_FUNCTION int TeamCG<MemberType>::invoke(
     const VectorViewType& _X, const KrylovHandle& handle,
     const TMPViewType& _TMPView, const TMPNormViewType& _TMPNormView) {
   typedef int OrdinalType;
-  typedef typename Kokkos::Details::ArithTraits<
+  typedef typename Kokkos::ArithTraits<
       typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
 
   size_t maximum_iteration      = handle.get_max_iteration();
@@ -177,7 +177,7 @@ KOKKOS_INLINE_FUNCTION int TeamCG<MemberType>::invoke(
         typename VectorViewType::array_layout,
         typename VectorViewType::execution_space::scratch_memory_space>;
     using ScratchPadNormViewType = Kokkos::View<
-        typename Kokkos::Details::ArithTraits<
+        typename Kokkos::ArithTraits<
             typename VectorViewType::non_const_value_type>::mag_type**,
         typename VectorViewType::execution_space::scratch_memory_space>;
 
@@ -199,7 +199,7 @@ KOKKOS_INLINE_FUNCTION int TeamCG<MemberType>::invoke(
     const int last_matrix  = handle.last_index(member.league_rank());
 
     using ScratchPadNormViewType = Kokkos::View<
-        typename Kokkos::Details::ArithTraits<
+        typename Kokkos::ArithTraits<
             typename VectorViewType::non_const_value_type>::mag_type**,
         typename VectorViewType::execution_space::scratch_memory_space>;
 

--- a/batched/sparse/impl/KokkosBatched_GMRES_Serial_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_GMRES_Serial_Impl.hpp
@@ -45,9 +45,9 @@ KOKKOS_INLINE_FUNCTION int SerialGMRES::invoke(const OperatorType& A,
                                                const KrylovHandleType& handle,
                                                const int GMRES_id) {
   typedef int OrdinalType;
-  typedef typename Kokkos::Details::ArithTraits<
+  typedef typename Kokkos::ArithTraits<
       typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
-  typedef Kokkos::Details::ArithTraits<MagnitudeType> ATM;
+  typedef Kokkos::ArithTraits<MagnitudeType> ATM;
 
   using SerialCopy1D = SerialCopy<Trans::NoTranspose, 1>;
   using SerialCopy2D = SerialCopy<Trans::NoTranspose, 2>;

--- a/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
@@ -48,9 +48,9 @@ KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::invoke(
     const KrylovHandleType& handle, const ArnoldiViewType& _ArnoldiView,
     const TMPViewType& _TMPView) {
   typedef int OrdinalType;
-  typedef typename Kokkos::Details::ArithTraits<
+  typedef typename Kokkos::ArithTraits<
       typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
-  typedef Kokkos::Details::ArithTraits<MagnitudeType> ATM;
+  typedef Kokkos::ArithTraits<MagnitudeType> ATM;
 
   using TeamVectorCopy1D = TeamVectorCopy<MemberType, Trans::NoTranspose, 1>;
 

--- a/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
@@ -47,9 +47,9 @@ KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::invoke(
     const KrylovHandleType& handle, const ArnoldiViewType& _ArnoldiView,
     const TMPViewType& _TMPView) {
   typedef int OrdinalType;
-  typedef typename Kokkos::Details::ArithTraits<
+  typedef typename Kokkos::ArithTraits<
       typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
-  typedef Kokkos::Details::ArithTraits<MagnitudeType> ATM;
+  typedef Kokkos::ArithTraits<MagnitudeType> ATM;
 
   using TeamCopy1D = TeamCopy<MemberType, Trans::NoTranspose, 1>;
 

--- a/batched/sparse/impl/KokkosBatched_Spmv_Serial_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_Serial_Impl.hpp
@@ -215,11 +215,11 @@ struct SerialSpmv<Trans::NoTranspose> {
   template <typename ValuesViewType, typename IntView, typename xViewType,
             typename yViewType, int dobeta>
   KOKKOS_INLINE_FUNCTION static int invoke(
-      const typename Kokkos::Details::ArithTraits<
+      const typename Kokkos::ArithTraits<
           typename ValuesViewType::non_const_value_type>::mag_type& alpha,
       const ValuesViewType& values, const IntView& row_ptr,
       const IntView& colIndices, const xViewType& X,
-      const typename Kokkos::Details::ArithTraits<
+      const typename Kokkos::ArithTraits<
           typename ValuesViewType::non_const_value_type>::mag_type& beta,
       const yViewType& Y) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
@@ -277,7 +277,7 @@ struct SerialSpmv<Trans::NoTranspose> {
 #endif
 
     return SerialSpmvInternal::template invoke<
-        typename Kokkos::Details::ArithTraits<
+        typename Kokkos::ArithTraits<
             typename ValuesViewType::non_const_value_type>::mag_type,
         typename ValuesViewType::non_const_value_type,
         typename IntView::non_const_value_type,

--- a/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
@@ -403,11 +403,11 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
             typename yViewType, int dobeta>
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType& member,
-      const typename Kokkos::Details::ArithTraits<
+      const typename Kokkos::ArithTraits<
           typename ValuesViewType::non_const_value_type>::mag_type& alpha,
       const ValuesViewType& values, const IntView& row_ptr,
       const IntView& colIndices, const xViewType& X,
-      const typename Kokkos::Details::ArithTraits<
+      const typename Kokkos::ArithTraits<
           typename ValuesViewType::non_const_value_type>::mag_type& beta,
       const yViewType& Y) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
@@ -466,7 +466,7 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
 
     return TeamVectorSpmvInternal::template invoke<
         MemberType,
-        typename Kokkos::Details::ArithTraits<
+        typename Kokkos::ArithTraits<
             typename ValuesViewType::non_const_value_type>::mag_type,
         typename ValuesViewType::non_const_value_type,
         typename IntView::non_const_value_type,

--- a/batched/sparse/impl/KokkosBatched_Spmv_Team_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_Team_Impl.hpp
@@ -254,11 +254,11 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
             typename yViewType, int dobeta>
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType& member,
-      const typename Kokkos::Details::ArithTraits<
+      const typename Kokkos::ArithTraits<
           typename ValuesViewType::non_const_value_type>::mag_type& alpha,
       const ValuesViewType& values, const IntView& row_ptr,
       const IntView& colIndices, const xViewType& X,
-      const typename Kokkos::Details::ArithTraits<
+      const typename Kokkos::ArithTraits<
           typename ValuesViewType::non_const_value_type>::mag_type& beta,
       const yViewType& Y) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
@@ -317,7 +317,7 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
 
     return TeamSpmvInternal::template invoke<
         MemberType,
-        typename Kokkos::Details::ArithTraits<
+        typename Kokkos::ArithTraits<
             typename ValuesViewType::non_const_value_type>::mag_type,
         typename ValuesViewType::non_const_value_type,
         typename IntView::non_const_value_type,

--- a/batched/sparse/src/KokkosBatched_CrsMatrix.hpp
+++ b/batched/sparse/src/KokkosBatched_CrsMatrix.hpp
@@ -29,9 +29,8 @@ namespace KokkosBatched {
 template <class ValuesViewType, class IntViewType>
 class CrsMatrix {
  public:
-  using ScalarType = typename ValuesViewType::non_const_value_type;
-  using MagnitudeType =
-      typename Kokkos::Details::ArithTraits<ScalarType>::mag_type;
+  using ScalarType    = typename ValuesViewType::non_const_value_type;
+  using MagnitudeType = typename Kokkos::ArithTraits<ScalarType>::mag_type;
 
  private:
   ValuesViewType values;
@@ -82,10 +81,9 @@ class CrsMatrix {
             typename XViewType, typename YViewType>
   KOKKOS_INLINE_FUNCTION void apply(
       const MemberType &member, const XViewType &X, const YViewType &Y,
-      MagnitudeType alpha = Kokkos::Details::ArithTraits<MagnitudeType>::one(),
-      MagnitudeType beta =
-          Kokkos::Details::ArithTraits<MagnitudeType>::zero()) const {
-    if (beta == Kokkos::Details::ArithTraits<MagnitudeType>::zero()) {
+      MagnitudeType alpha = Kokkos::ArithTraits<MagnitudeType>::one(),
+      MagnitudeType beta  = Kokkos::ArithTraits<MagnitudeType>::zero()) const {
+    if (beta == Kokkos::ArithTraits<MagnitudeType>::zero()) {
       if (member.team_size() == 1 && n_operators == 8)
         KokkosBatched::TeamVectorSpmv<MemberType, ArgTrans, 8>::template invoke<
             ValuesViewType, IntViewType, XViewType, YViewType, 0>(
@@ -109,10 +107,9 @@ class CrsMatrix {
   template <typename ArgTrans, typename XViewType, typename YViewType>
   KOKKOS_INLINE_FUNCTION void apply(
       const XViewType &X, const YViewType &Y,
-      MagnitudeType alpha = Kokkos::Details::ArithTraits<MagnitudeType>::one(),
-      MagnitudeType beta =
-          Kokkos::Details::ArithTraits<MagnitudeType>::zero()) const {
-    if (beta == Kokkos::Details::ArithTraits<MagnitudeType>::zero())
+      MagnitudeType alpha = Kokkos::ArithTraits<MagnitudeType>::one(),
+      MagnitudeType beta  = Kokkos::ArithTraits<MagnitudeType>::zero()) const {
+    if (beta == Kokkos::ArithTraits<MagnitudeType>::zero())
       KokkosBatched::SerialSpmv<ArgTrans>::template invoke<
           ValuesViewType, IntViewType, XViewType, YViewType, 0>(
           alpha, values, row_ptr, colIndices, X, beta, Y);

--- a/batched/sparse/src/KokkosBatched_JacobiPrec.hpp
+++ b/batched/sparse/src/KokkosBatched_JacobiPrec.hpp
@@ -29,9 +29,8 @@ namespace KokkosBatched {
 template <class ValuesViewType>
 class JacobiPrec {
  public:
-  using ScalarType = typename ValuesViewType::non_const_value_type;
-  using MagnitudeType =
-      typename Kokkos::Details::ArithTraits<ScalarType>::mag_type;
+  using ScalarType    = typename ValuesViewType::non_const_value_type;
+  using MagnitudeType = typename Kokkos::ArithTraits<ScalarType>::mag_type;
 
  private:
   ValuesViewType diag_values;
@@ -55,8 +54,8 @@ class JacobiPrec {
 
   template <typename MemberType, typename ArgMode>
   KOKKOS_INLINE_FUNCTION void computeInverse(const MemberType &member) const {
-    auto one     = Kokkos::Details::ArithTraits<MagnitudeType>::one();
-    auto epsilon = Kokkos::Details::ArithTraits<MagnitudeType>::epsilon();
+    auto one     = Kokkos::ArithTraits<MagnitudeType>::one();
+    auto epsilon = Kokkos::ArithTraits<MagnitudeType>::epsilon();
     int tooSmall = 0;
     if (std::is_same<ArgMode, Mode::Serial>::value) {
       for (int i = 0; i < n_operators; ++i)
@@ -118,8 +117,8 @@ class JacobiPrec {
   }
 
   KOKKOS_INLINE_FUNCTION void computeInverse() const {
-    auto one     = Kokkos::Details::ArithTraits<MagnitudeType>::one();
-    auto epsilon = Kokkos::Details::ArithTraits<MagnitudeType>::epsilon();
+    auto one     = Kokkos::ArithTraits<MagnitudeType>::one();
+    auto epsilon = Kokkos::ArithTraits<MagnitudeType>::epsilon();
     int tooSmall = 0;
 
     for (int i = 0; i < n_operators; ++i)

--- a/batched/sparse/src/KokkosBatched_Krylov_Handle.hpp
+++ b/batched/sparse/src/KokkosBatched_Krylov_Handle.hpp
@@ -87,7 +87,7 @@ class KrylovHandle {
         batched_size(_batched_size),
         N_team(_N_team),
         monitor_residual(_monitor_residual) {
-    tolerance     = Kokkos::Details::ArithTraits<norm_type>::epsilon();
+    tolerance     = Kokkos::ArithTraits<norm_type>::epsilon();
     max_tolerance = 1e-30;
     if (std::is_same<norm_type, double>::value) max_tolerance = 1e-50;
     if (monitor_residual) {

--- a/batched/sparse/src/KokkosBatched_Spmv.hpp
+++ b/batched/sparse/src/KokkosBatched_Spmv.hpp
@@ -75,11 +75,11 @@ struct SerialSpmv {
   template <typename ValuesViewType, typename IntView, typename xViewType,
             typename yViewType, int dobeta>
   KOKKOS_INLINE_FUNCTION static int invoke(
-      const typename Kokkos::Details::ArithTraits<
+      const typename Kokkos::ArithTraits<
           typename ValuesViewType::non_const_value_type>::mag_type &alpha,
       const ValuesViewType &values, const IntView &row_ptr,
       const IntView &colIndices, const xViewType &X,
-      const typename Kokkos::Details::ArithTraits<
+      const typename Kokkos::ArithTraits<
           typename ValuesViewType::non_const_value_type>::mag_type &beta,
       const yViewType &Y);
 };
@@ -139,11 +139,11 @@ struct TeamSpmv {
             typename yViewType, int dobeta>
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType &member,
-      const typename Kokkos::Details::ArithTraits<
+      const typename Kokkos::ArithTraits<
           typename ValuesViewType::non_const_value_type>::mag_type &alpha,
       const ValuesViewType &values, const IntView &row_ptr,
       const IntView &colIndices, const xViewType &x,
-      const typename Kokkos::Details::ArithTraits<
+      const typename Kokkos::ArithTraits<
           typename ValuesViewType::non_const_value_type>::mag_type &beta,
       const yViewType &y);
 };
@@ -205,11 +205,11 @@ struct TeamVectorSpmv {
             typename yViewType, int dobeta>
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType &member,
-      const typename Kokkos::Details::ArithTraits<
+      const typename Kokkos::ArithTraits<
           typename ValuesViewType::non_const_value_type>::mag_type &alpha,
       const ValuesViewType &values, const IntView &row_ptr,
       const IntView &colIndices, const xViewType &x,
-      const typename Kokkos::Details::ArithTraits<
+      const typename Kokkos::ArithTraits<
           typename ValuesViewType::non_const_value_type>::mag_type &beta,
       const yViewType &y);
 };
@@ -276,11 +276,11 @@ struct Spmv {
             typename yViewType, int dobeta>
   KOKKOS_INLINE_FUNCTION static int invoke(
       const MemberType &member,
-      const typename Kokkos::Details::ArithTraits<
+      const typename Kokkos::ArithTraits<
           typename ValuesViewType::non_const_value_type>::mag_type &alpha,
       const ValuesViewType &values, const IntView &row_ptr,
       const IntView &colIndices, const xViewType &x,
-      const typename Kokkos::Details::ArithTraits<
+      const typename Kokkos::ArithTraits<
           typename ValuesViewType::non_const_value_type>::mag_type &beta,
       const yViewType &y) {
     int r_val = 0;

--- a/batched/sparse/unit_test/Test_Batched_SerialGMRES.hpp
+++ b/batched/sparse/unit_test/Test_Batched_SerialGMRES.hpp
@@ -109,7 +109,7 @@ template <typename DeviceType, typename ValuesViewType, typename IntView,
           typename VectorViewType>
 void impl_test_batched_GMRES(const int N, const int BlkSize, const int N_team) {
   typedef typename ValuesViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   const int nnz = (BlkSize - 2) * 3 + 2 * 2;
 
@@ -125,9 +125,8 @@ void impl_test_batched_GMRES(const int N, const int BlkSize, const int N_team) {
   using Layout     = typename ValuesViewType::array_layout;
   using EXSP       = typename ValuesViewType::execution_space;
 
-  using MagnitudeType =
-      typename Kokkos::Details::ArithTraits<ScalarType>::mag_type;
-  using NormViewType = Kokkos::View<MagnitudeType *, Layout, EXSP>;
+  using MagnitudeType = typename Kokkos::ArithTraits<ScalarType>::mag_type;
+  using NormViewType  = Kokkos::View<MagnitudeType *, Layout, EXSP>;
 
   using Norm2DViewType   = Kokkos::View<MagnitudeType **, Layout, EXSP>;
   using Scalar3DViewType = Kokkos::View<ScalarType ***, Layout, EXSP>;

--- a/batched/sparse/unit_test/Test_Batched_SerialSpmv.hpp
+++ b/batched/sparse/unit_test/Test_Batched_SerialSpmv.hpp
@@ -86,7 +86,7 @@ template <typename DeviceType, typename ParamTagType, typename ValuesViewType,
           typename alphaViewType, typename betaViewType, int dobeta>
 void impl_test_batched_spmv(const int N, const int BlkSize) {
   typedef typename ValuesViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   const int nnz = (BlkSize - 2) * 3 + 2 * 2;
 

--- a/batched/sparse/unit_test/Test_Batched_TeamCG.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamCG.hpp
@@ -95,7 +95,7 @@ template <typename DeviceType, typename ValuesViewType, typename IntView,
           typename VectorViewType>
 void impl_test_batched_CG(const int N, const int BlkSize, const int N_team) {
   typedef typename ValuesViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   const int nnz = (BlkSize - 2) * 3 + 2 * 2;
 
@@ -110,9 +110,8 @@ void impl_test_batched_CG(const int N, const int BlkSize, const int N_team) {
   using Layout     = typename ValuesViewType::array_layout;
   using EXSP       = typename ValuesViewType::execution_space;
 
-  using MagnitudeType =
-      typename Kokkos::Details::ArithTraits<ScalarType>::mag_type;
-  using NormViewType = Kokkos::View<MagnitudeType *, Layout, EXSP>;
+  using MagnitudeType = typename Kokkos::ArithTraits<ScalarType>::mag_type;
+  using NormViewType  = Kokkos::View<MagnitudeType *, Layout, EXSP>;
 
   using Norm2DViewType   = Kokkos::View<MagnitudeType **, Layout, EXSP>;
   using Scalar3DViewType = Kokkos::View<ScalarType ***, Layout, EXSP>;

--- a/batched/sparse/unit_test/Test_Batched_TeamGMRES.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamGMRES.hpp
@@ -133,7 +133,7 @@ template <typename DeviceType, typename ValuesViewType, typename IntView,
           typename VectorViewType>
 void impl_test_batched_GMRES(const int N, const int BlkSize, const int N_team) {
   typedef typename ValuesViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   const int nnz = (BlkSize - 2) * 3 + 2 * 2;
 
@@ -149,9 +149,8 @@ void impl_test_batched_GMRES(const int N, const int BlkSize, const int N_team) {
   using Layout     = typename ValuesViewType::array_layout;
   using EXSP       = typename ValuesViewType::execution_space;
 
-  using MagnitudeType =
-      typename Kokkos::Details::ArithTraits<ScalarType>::mag_type;
-  using NormViewType = Kokkos::View<MagnitudeType *, Layout, EXSP>;
+  using MagnitudeType = typename Kokkos::ArithTraits<ScalarType>::mag_type;
+  using NormViewType  = Kokkos::View<MagnitudeType *, Layout, EXSP>;
 
   using Norm2DViewType   = Kokkos::View<MagnitudeType **, Layout, EXSP>;
   using Scalar3DViewType = Kokkos::View<ScalarType ***, Layout, EXSP>;

--- a/batched/sparse/unit_test/Test_Batched_TeamSpmv.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamSpmv.hpp
@@ -111,7 +111,7 @@ template <typename DeviceType, typename ParamTagType, typename ValuesViewType,
           typename alphaViewType, typename betaViewType, int dobeta>
 void impl_test_batched_spmv(const int N, const int BlkSize, const int N_team) {
   typedef typename ValuesViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   const int nnz = (BlkSize - 2) * 3 + 2 * 2;
 

--- a/batched/sparse/unit_test/Test_Batched_TeamVectorCG.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamVectorCG.hpp
@@ -97,7 +97,7 @@ template <typename DeviceType, typename ValuesViewType, typename IntView,
           typename VectorViewType>
 void impl_test_batched_CG(const int N, const int BlkSize, const int N_team) {
   typedef typename ValuesViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   const int nnz = (BlkSize - 2) * 3 + 2 * 2;
 
@@ -112,9 +112,8 @@ void impl_test_batched_CG(const int N, const int BlkSize, const int N_team) {
   using Layout     = typename ValuesViewType::array_layout;
   using EXSP       = typename ValuesViewType::execution_space;
 
-  using MagnitudeType =
-      typename Kokkos::Details::ArithTraits<ScalarType>::mag_type;
-  using NormViewType = Kokkos::View<MagnitudeType *, Layout, EXSP>;
+  using MagnitudeType = typename Kokkos::ArithTraits<ScalarType>::mag_type;
+  using NormViewType  = Kokkos::View<MagnitudeType *, Layout, EXSP>;
 
   using Norm2DViewType   = Kokkos::View<MagnitudeType **, Layout, EXSP>;
   using Scalar3DViewType = Kokkos::View<ScalarType ***, Layout, EXSP>;

--- a/batched/sparse/unit_test/Test_Batched_TeamVectorGMRES.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamVectorGMRES.hpp
@@ -133,7 +133,7 @@ template <typename DeviceType, typename ValuesViewType, typename IntView,
           typename VectorViewType>
 void impl_test_batched_GMRES(const int N, const int BlkSize, const int N_team) {
   typedef typename ValuesViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   const int nnz = (BlkSize - 2) * 3 + 2 * 2;
 
@@ -149,9 +149,8 @@ void impl_test_batched_GMRES(const int N, const int BlkSize, const int N_team) {
   using Layout     = typename ValuesViewType::array_layout;
   using EXSP       = typename ValuesViewType::execution_space;
 
-  using MagnitudeType =
-      typename Kokkos::Details::ArithTraits<ScalarType>::mag_type;
-  using NormViewType = Kokkos::View<MagnitudeType *, Layout, EXSP>;
+  using MagnitudeType = typename Kokkos::ArithTraits<ScalarType>::mag_type;
+  using NormViewType  = Kokkos::View<MagnitudeType *, Layout, EXSP>;
 
   using Norm2DViewType   = Kokkos::View<MagnitudeType **, Layout, EXSP>;
   using Scalar3DViewType = Kokkos::View<ScalarType ***, Layout, EXSP>;

--- a/batched/sparse/unit_test/Test_Batched_TeamVectorSpmv.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamVectorSpmv.hpp
@@ -119,7 +119,7 @@ template <typename DeviceType, typename ParamTagType, typename ValuesViewType,
           typename alphaViewType, typename betaViewType, int dobeta>
 void impl_test_batched_spmv(const int N, const int BlkSize, const int N_team) {
   typedef typename ValuesViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   const int nnz = (BlkSize - 2) * 3 + 2 * 2;
 

--- a/blas/impl/KokkosBlas1_abs_impl.hpp
+++ b/blas/impl/KokkosBlas1_abs_impl.hpp
@@ -32,7 +32,7 @@ template <class RMV, class XMV, class SizeType = typename RMV::size_type>
 struct MV_Abs_Functor {
   typedef typename RMV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename XMV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename XMV::non_const_value_type> ATS;
 
   const size_type numCols;
   RMV R_;
@@ -70,7 +70,7 @@ template <class RMV, class SizeType = typename RMV::size_type>
 struct MV_AbsSelf_Functor {
   typedef typename RMV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename RMV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename RMV::non_const_value_type> ATS;
 
   const size_type numCols;
   RMV R_;
@@ -100,7 +100,7 @@ template <class RV, class XV, class SizeType = typename RV::size_type>
 struct V_Abs_Functor {
   typedef typename RV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename XV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename XV::non_const_value_type> ATS;
 
   RV R_;
   XV X_;
@@ -130,7 +130,7 @@ template <class RV, class SizeType = typename RV::size_type>
 struct V_AbsSelf_Functor {
   typedef typename RV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename RV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename RV::non_const_value_type> ATS;
 
   RV R_;
 

--- a/blas/impl/KokkosBlas1_axpby_impl.hpp
+++ b/blas/impl/KokkosBlas1_axpby_impl.hpp
@@ -54,7 +54,7 @@ template <class AV, class XV, class BV, class YV, int scalar_x, int scalar_y,
 struct Axpby_Functor {
   typedef typename YV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename YV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename YV::non_const_value_type> ATS;
 
   XV m_x;
   YV m_y;
@@ -188,7 +188,7 @@ struct Axpby_Functor<typename XV::non_const_value_type, XV,
                      SizeType> {
   typedef typename YV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename YV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename YV::non_const_value_type> ATS;
 
   XV m_x;
   YV m_y;

--- a/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
+++ b/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
@@ -45,7 +45,7 @@ template <class AV, class XMV, class BV, class YMV, int scalar_x, int scalar_y,
 struct Axpby_MV_Functor {
   typedef typename YMV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename YMV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename YMV::non_const_value_type> ATS;
 
   const size_type numCols;
   XMV m_x;
@@ -288,7 +288,7 @@ struct Axpby_MV_Functor<typename XMV::non_const_value_type, XMV,
                         scalar_y, SizeType> {
   typedef typename YMV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename YMV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename YMV::non_const_value_type> ATS;
 
   const size_type numCols;
   XMV m_x;
@@ -502,7 +502,7 @@ template <class AV, class XMV, class BV, class YMV, int scalar_x, int scalar_y,
 struct Axpby_MV_Unroll_Functor {
   typedef typename YMV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename YMV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename YMV::non_const_value_type> ATS;
 
   XMV m_x;
   YMV m_y;
@@ -730,7 +730,7 @@ struct Axpby_MV_Unroll_Functor<typename XMV::non_const_value_type, XMV,
                                scalar_x, scalar_y, UNROLL, SizeType> {
   typedef typename YMV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename YMV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename YMV::non_const_value_type> ATS;
 
   XMV m_x;
   YMV m_y;

--- a/blas/impl/KokkosBlas1_axpby_spec.hpp
+++ b/blas/impl/KokkosBlas1_axpby_spec.hpp
@@ -225,8 +225,8 @@ struct Axpby<typename XMV::non_const_value_type, XMV,
   typedef typename XMV::non_const_value_type AV;
   typedef typename YMV::non_const_value_type BV;
   typedef typename YMV::size_type size_type;
-  typedef Kokkos::Details::ArithTraits<typename XMV::non_const_value_type> ATA;
-  typedef Kokkos::Details::ArithTraits<typename YMV::non_const_value_type> ATB;
+  typedef Kokkos::ArithTraits<typename XMV::non_const_value_type> ATA;
+  typedef Kokkos::ArithTraits<typename YMV::non_const_value_type> ATB;
 
   static void axpby(const AV& alpha, const XMV& X, const BV& beta,
                     const YMV& Y) {
@@ -327,8 +327,8 @@ struct Axpby<typename XV::non_const_value_type, XV,
   typedef typename XV::non_const_value_type AV;
   typedef typename YV::non_const_value_type BV;
   typedef typename YV::size_type size_type;
-  typedef Kokkos::Details::ArithTraits<typename XV::non_const_value_type> ATA;
-  typedef Kokkos::Details::ArithTraits<typename YV::non_const_value_type> ATB;
+  typedef Kokkos::ArithTraits<typename XV::non_const_value_type> ATA;
+  typedef Kokkos::ArithTraits<typename YV::non_const_value_type> ATB;
 
   static void axpby(const AV& alpha, const XV& X, const BV& beta, const YV& Y) {
     static_assert(Kokkos::is_view<XV>::value,

--- a/blas/impl/KokkosBlas1_dot_impl.hpp
+++ b/blas/impl/KokkosBlas1_dot_impl.hpp
@@ -56,7 +56,7 @@ struct DotFunctor {
   }
 
   KOKKOS_INLINE_FUNCTION void init(value_type& update) const {
-    update = Kokkos::Details::ArithTraits<value_type>::zero();
+    update = Kokkos::ArithTraits<value_type>::zero();
   }
 
   KOKKOS_INLINE_FUNCTION void join(value_type& update,

--- a/blas/impl/KokkosBlas1_iamax_impl.hpp
+++ b/blas/impl/KokkosBlas1_iamax_impl.hpp
@@ -82,7 +82,7 @@ struct V_Iamax_Functor {
 template <class RV, class XV, class SizeType>
 void V_Iamax_Invoke(const RV& r, const XV& X) {
   using execution_space = typename XV::execution_space;
-  using AT = Kokkos::Details::ArithTraits<typename XV::non_const_value_type>;
+  using AT       = Kokkos::ArithTraits<typename XV::non_const_value_type>;
   using mag_type = typename AT::mag_type;
 
   const SizeType numRows = static_cast<SizeType>(X.extent(0));

--- a/blas/impl/KokkosBlas1_mult_impl.hpp
+++ b/blas/impl/KokkosBlas1_mult_impl.hpp
@@ -39,7 +39,7 @@ template <class CMV, class AV, class BMV, int scalar_ab, int scalar_c,
 struct MV_MultFunctor {
   typedef typename CMV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename CMV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename CMV::non_const_value_type> ATS;
 
   const size_type m_n;
   typename CMV::const_value_type m_c;
@@ -107,7 +107,7 @@ template <class CV, class AV, class BV, int scalar_ab, int scalar_c,
 struct V_MultFunctor {
   typedef typename CV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename CV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename CV::non_const_value_type> ATS;
 
   typename CV::const_value_type m_c;
   CV m_C;
@@ -152,8 +152,8 @@ void V_Mult_Generic(typename CV::const_value_type& c, const CV& C,
                     const BV& B) {
   using Kokkos::ALL;
   using Kokkos::subview;
-  typedef Kokkos::Details::ArithTraits<typename AV::non_const_value_type> ATA;
-  typedef Kokkos::Details::ArithTraits<typename CV::non_const_value_type> ATC;
+  typedef Kokkos::ArithTraits<typename AV::non_const_value_type> ATA;
+  typedef Kokkos::ArithTraits<typename CV::non_const_value_type> ATC;
   typedef typename CV::execution_space execution_space;
 
   const SizeType numRows = C.extent(0);
@@ -197,8 +197,8 @@ template <class CMV, class AV, class BMV, class SizeType>
 void MV_Mult_Generic(typename CMV::const_value_type& c, const CMV& C,
                      typename AV::const_value_type& ab, const AV& A,
                      const BMV& B) {
-  typedef Kokkos::Details::ArithTraits<typename AV::non_const_value_type> ATA;
-  typedef Kokkos::Details::ArithTraits<typename CMV::non_const_value_type> ATC;
+  typedef Kokkos::ArithTraits<typename AV::non_const_value_type> ATA;
+  typedef Kokkos::ArithTraits<typename CMV::non_const_value_type> ATC;
   typedef typename CMV::execution_space execution_space;
 
   if (C.extent(1) == 1) {

--- a/blas/impl/KokkosBlas1_nrm2_impl.hpp
+++ b/blas/impl/KokkosBlas1_nrm2_impl.hpp
@@ -39,7 +39,7 @@ struct V_Nrm2_Functor {
   typedef SizeType size_type;
   typedef typename XV::non_const_value_type xvalue_type;
   typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type> AT;
+  typedef Kokkos::ArithTraits<typename IPT::mag_type> AT;
   typedef typename IPT::mag_type value_type;
 
   typename XV::const_type m_x;
@@ -80,8 +80,7 @@ struct V_Nrm2_Functor {
   KOKKOS_INLINE_FUNCTION void final(value_type& update) const {
     if (m_take_sqrt)
       update =
-          Kokkos::Details::ArithTraits<typename RV::non_const_value_type>::sqrt(
-              update);
+          Kokkos::ArithTraits<typename RV::non_const_value_type>::sqrt(update);
   }
 };
 
@@ -96,7 +95,7 @@ struct Nrm2_MV_Functor {
   typedef typename RV::non_const_value_type rvalue_type;
   typedef typename XV::non_const_value_type xvalue_type;
   typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type> AT;
+  typedef Kokkos::ArithTraits<typename IPT::mag_type> AT;
   typedef typename IPT::mag_type value_type;
 
   using TeamMem = typename Kokkos::TeamPolicy<ExecSpace>::member_type;

--- a/blas/impl/KokkosBlas1_nrm2w_impl.hpp
+++ b/blas/impl/KokkosBlas1_nrm2w_impl.hpp
@@ -40,7 +40,7 @@ struct V_Nrm2w_Functor {
   typedef SizeType size_type;
   typedef typename XV::non_const_value_type xvalue_type;
   typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type> AT;
+  typedef Kokkos::ArithTraits<typename IPT::mag_type> AT;
   typedef typename IPT::mag_type value_type;
 
   typename XV::const_type m_x, m_w;
@@ -83,8 +83,7 @@ struct V_Nrm2w_Functor {
   KOKKOS_INLINE_FUNCTION void final(value_type& update) const {
     if (m_take_sqrt)
       update =
-          Kokkos::Details::ArithTraits<typename RV::non_const_value_type>::sqrt(
-              update);
+          Kokkos::ArithTraits<typename RV::non_const_value_type>::sqrt(update);
   }
 };
 
@@ -93,7 +92,7 @@ struct Nrm2w_MV_Functor {
   typedef typename RV::non_const_value_type rvalue_type;
   typedef typename XV::non_const_value_type xvalue_type;
   typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type> AT;
+  typedef Kokkos::ArithTraits<typename IPT::mag_type> AT;
   typedef typename IPT::mag_type value_type;
 
   using TeamMem = typename Kokkos::TeamPolicy<ExecSpace>::member_type;

--- a/blas/impl/KokkosBlas1_nrminf_impl.hpp
+++ b/blas/impl/KokkosBlas1_nrminf_impl.hpp
@@ -38,7 +38,7 @@ struct V_NrmInf_Functor {
   typedef SizeType size_type;
   typedef typename XV::non_const_value_type xvalue_type;
   typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type> AT;
+  typedef Kokkos::ArithTraits<typename IPT::mag_type> AT;
   typedef typename IPT::mag_type value_type;
 
   typename XV::const_type m_x;
@@ -72,7 +72,7 @@ struct V_NrmInf_Functor {
 template <class RV, class XV, class SizeType>
 void V_NrmInf_Invoke(const RV& r, const XV& X) {
   typedef typename XV::execution_space execution_space;
-  typedef Kokkos::Details::ArithTraits<typename RV::non_const_value_type> AT;
+  typedef Kokkos::ArithTraits<typename RV::non_const_value_type> AT;
 
   const SizeType numRows = static_cast<SizeType>(X.extent(0));
 

--- a/blas/impl/KokkosBlas1_reciprocal_impl.hpp
+++ b/blas/impl/KokkosBlas1_reciprocal_impl.hpp
@@ -32,7 +32,7 @@ template <class RMV, class XMV, class SizeType = typename RMV::size_type>
 struct MV_Reciprocal_Functor {
   typedef typename RMV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename XMV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename XMV::non_const_value_type> ATS;
 
   const size_type numCols;
   RMV R_;
@@ -71,7 +71,7 @@ template <class RMV, class SizeType = typename RMV::size_type>
 struct MV_ReciprocalSelf_Functor {
   typedef typename RMV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename RMV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename RMV::non_const_value_type> ATS;
 
   const size_type numCols;
   RMV R_;
@@ -102,7 +102,7 @@ template <class RV, class XV, class SizeType = typename RV::size_type>
 struct V_Reciprocal_Functor {
   typedef typename RV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename XV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename XV::non_const_value_type> ATS;
 
   RV R_;
   XV X_;
@@ -132,7 +132,7 @@ template <class RV, class SizeType = typename RV::size_type>
 struct V_ReciprocalSelf_Functor {
   typedef typename RV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename RV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename RV::non_const_value_type> ATS;
 
   RV R_;
 

--- a/blas/impl/KokkosBlas1_scal_impl.hpp
+++ b/blas/impl/KokkosBlas1_scal_impl.hpp
@@ -46,7 +46,7 @@ template <class RV, class AV, class XV, int scalar_x, class SizeType>
 struct V_Scal_Functor {
   typedef typename RV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename RV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename RV::non_const_value_type> ATS;
 
   RV m_r;
   XV m_x;
@@ -103,7 +103,7 @@ struct V_Scal_Functor<RV, typename XV::non_const_value_type, XV, scalar_x,
                       SizeType> {
   typedef typename RV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename RV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename RV::non_const_value_type> ATS;
 
   RV m_r;
   XV m_x;

--- a/blas/impl/KokkosBlas1_scal_mv_impl.hpp
+++ b/blas/impl/KokkosBlas1_scal_mv_impl.hpp
@@ -47,7 +47,7 @@ template <class RMV, class aVector, class XMV, int scalar_x,
 struct MV_Scal_Functor {
   typedef typename RMV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename RMV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename RMV::non_const_value_type> ATS;
 
   const size_type numCols;
   RMV R_;
@@ -129,7 +129,7 @@ struct MV_Scal_Functor<RMV, typename XMV::non_const_value_type, XMV, scalar_x,
                        SizeType> {
   typedef typename RMV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename RMV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename RMV::non_const_value_type> ATS;
 
   const size_type numCols;
   RMV m_r;
@@ -200,7 +200,7 @@ template <class RMV, class aVector, class XMV, int scalar_x, int UNROLL,
 struct MV_Scal_Unroll_Functor {
   typedef typename RMV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename RMV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename RMV::non_const_value_type> ATS;
 
   RMV m_r;
   XMV m_x;
@@ -261,7 +261,7 @@ struct MV_Scal_Unroll_Functor<RMV, typename XMV::non_const_value_type, XMV,
                               scalar_x, UNROLL, SizeType> {
   typedef typename RMV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename RMV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename RMV::non_const_value_type> ATS;
 
   RMV m_r;
   XMV m_x;

--- a/blas/impl/KokkosBlas1_scal_spec.hpp
+++ b/blas/impl/KokkosBlas1_scal_spec.hpp
@@ -113,7 +113,7 @@ struct Scal<RV, typename XV::non_const_value_type, XV, 1, false,
             KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XV::non_const_value_type AV;
   typedef typename XV::size_type size_type;
-  typedef Kokkos::Details::ArithTraits<typename XV::non_const_value_type> ATA;
+  typedef Kokkos::ArithTraits<typename XV::non_const_value_type> ATA;
 
   static void scal(const RV& R, const AV& alpha, const XV& X) {
     static_assert(Kokkos::is_view<RV>::value,
@@ -172,7 +172,7 @@ struct Scal<RV, typename XV::non_const_value_type, XV, 1, false,
 template <class RMV, class AV, class XMV>
 struct Scal<RMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
-  typedef Kokkos::Details::ArithTraits<typename XMV::non_const_value_type> ATA;
+  typedef Kokkos::ArithTraits<typename XMV::non_const_value_type> ATA;
 
   static void scal(const RMV& R, const AV& av, const XMV& X) {
     static_assert(Kokkos::is_view<RMV>::value,
@@ -232,7 +232,7 @@ struct Scal<RMV, typename XMV::non_const_value_type, XMV, 2, false,
             KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::non_const_value_type AV;
   typedef typename XMV::size_type size_type;
-  typedef Kokkos::Details::ArithTraits<typename XMV::non_const_value_type> ATA;
+  typedef Kokkos::ArithTraits<typename XMV::non_const_value_type> ATA;
 
   static void scal(const RMV& R, const AV& alpha, const XMV& X) {
     static_assert(Kokkos::is_view<RMV>::value,

--- a/blas/impl/KokkosBlas1_sum_impl.hpp
+++ b/blas/impl/KokkosBlas1_sum_impl.hpp
@@ -40,7 +40,7 @@ struct V_Sum_Functor {
   typedef SizeType size_type;
   typedef typename XV::non_const_value_type xvalue_type;
   typedef Kokkos::Details::InnerProductSpaceTraits<xvalue_type> IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type> AT;
+  typedef Kokkos::ArithTraits<typename IPT::mag_type> AT;
   typedef typename RV::non_const_value_type value_type;
 
   typename XV::const_type m_x;

--- a/blas/impl/KokkosBlas1_team_abs_spec.hpp
+++ b/blas/impl/KokkosBlas1_team_abs_spec.hpp
@@ -35,7 +35,7 @@ struct team_abs_tpl_spec_avail {
 template <class TeamType, class RV, class XV,
           bool tpl_spec_avail = team_abs_tpl_spec_avail<RV, XV>::value>
 struct TeamAbs {
-  typedef Kokkos::Details::ArithTraits<typename XV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename XV::non_const_value_type> ATS;
 
   static KOKKOS_INLINE_FUNCTION void team_abs(const TeamType& team, const RV& R,
                                               const XV& X);
@@ -43,7 +43,7 @@ struct TeamAbs {
 
 template <class TeamType, class RV, class XV>
 struct TeamAbs<TeamType, RV, XV, false> {
-  typedef Kokkos::Details::ArithTraits<typename XV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename XV::non_const_value_type> ATS;
 
   static KOKKOS_INLINE_FUNCTION void team_abs(const TeamType& team, const RV& R,
                                               const XV& X) {

--- a/blas/impl/KokkosBlas1_team_dot_spec.hpp
+++ b/blas/impl/KokkosBlas1_team_dot_spec.hpp
@@ -53,7 +53,7 @@ struct TeamDot<TeamType, XV, YV, false> {
 
   static KOKKOS_INLINE_FUNCTION dot_type team_dot(const TeamType& team,
                                                   const XV& X, const YV& Y) {
-    dot_type result = 0.0;  // Kokkos::Details::ArithTraits<dot_type>zero();
+    dot_type result = 0.0;  // Kokkos::ArithTraits<dot_type>zero();
     int N           = X.extent(0);
     Kokkos::parallel_reduce(
         Kokkos::TeamThreadRange(team, N),

--- a/blas/impl/KokkosBlas1_team_nrm2_spec.hpp
+++ b/blas/impl/KokkosBlas1_team_nrm2_spec.hpp
@@ -40,7 +40,7 @@ struct TeamNrm2 {
   typedef Kokkos::Details::InnerProductSpaceTraits<
       typename XV::non_const_value_type>
       IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type> AT;
+  typedef Kokkos::ArithTraits<typename IPT::mag_type> AT;
 
   static KOKKOS_INLINE_FUNCTION mag_type team_nrm2(const TeamType& team,
                                                    const XV& X);
@@ -53,11 +53,11 @@ struct TeamNrm2<TeamType, XV, false> {
   typedef Kokkos::Details::InnerProductSpaceTraits<
       typename XV::non_const_value_type>
       IPT;
-  typedef Kokkos::Details::ArithTraits<typename IPT::mag_type> AT;
+  typedef Kokkos::ArithTraits<typename IPT::mag_type> AT;
 
   static KOKKOS_INLINE_FUNCTION mag_type team_nrm2(const TeamType& team,
                                                    const XV& X) {
-    mag_type result = 0.0;  // Kokkos::Details::ArithTraits<mag_type>zero();
+    mag_type result = 0.0;  // Kokkos::ArithTraits<mag_type>zero();
     int N           = X.extent(0);
     Kokkos::parallel_reduce(
         Kokkos::TeamThreadRange(team, N),

--- a/blas/impl/KokkosBlas1_update_impl.hpp
+++ b/blas/impl/KokkosBlas1_update_impl.hpp
@@ -45,7 +45,7 @@ template <class XMV, class YMV, class ZMV, int scalar_x, int scalar_y,
 struct MV_Update_Functor {
   typedef typename ZMV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename ZMV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename ZMV::non_const_value_type> ATS;
 
   const size_type numCols;
   const typename XMV::non_const_value_type alpha_;
@@ -215,7 +215,7 @@ template <class XV, class YV, class ZV, int scalar_x, int scalar_y,
 struct V_Update_Functor {
   typedef typename ZV::execution_space execution_space;
   typedef SizeType size_type;
-  typedef Kokkos::Details::ArithTraits<typename ZV::non_const_value_type> ATS;
+  typedef Kokkos::ArithTraits<typename ZV::non_const_value_type> ATS;
 
   const size_type numCols;
   const typename XV::non_const_value_type alpha_;

--- a/blas/impl/KokkosBlas1_update_spec.hpp
+++ b/blas/impl/KokkosBlas1_update_spec.hpp
@@ -117,9 +117,9 @@ struct Update {
 template <class XMV, class YMV, class ZMV>
 struct Update<XMV, YMV, ZMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
-  typedef Kokkos::Details::ArithTraits<typename XMV::non_const_value_type> ATA;
-  typedef Kokkos::Details::ArithTraits<typename YMV::non_const_value_type> ATB;
-  typedef Kokkos::Details::ArithTraits<typename ZMV::non_const_value_type> ATC;
+  typedef Kokkos::ArithTraits<typename XMV::non_const_value_type> ATA;
+  typedef Kokkos::ArithTraits<typename YMV::non_const_value_type> ATB;
+  typedef Kokkos::ArithTraits<typename ZMV::non_const_value_type> ATC;
 
   static void update(const typename XMV::non_const_value_type& alpha,
                      const XMV& X,
@@ -222,9 +222,9 @@ struct Update<XMV, YMV, ZMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 template <class XV, class YV, class ZV>
 struct Update<XV, YV, ZV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XV::size_type size_type;
-  typedef Kokkos::Details::ArithTraits<typename XV::non_const_value_type> ATA;
-  typedef Kokkos::Details::ArithTraits<typename YV::non_const_value_type> ATB;
-  typedef Kokkos::Details::ArithTraits<typename ZV::non_const_value_type> ATC;
+  typedef Kokkos::ArithTraits<typename XV::non_const_value_type> ATA;
+  typedef Kokkos::ArithTraits<typename YV::non_const_value_type> ATB;
+  typedef Kokkos::ArithTraits<typename ZV::non_const_value_type> ATC;
 
   static void update(const typename XV::non_const_value_type& alpha,
                      const XV& X, const typename YV::non_const_value_type& beta,

--- a/blas/impl/KokkosBlas2_gemv_impl.hpp
+++ b/blas/impl/KokkosBlas2_gemv_impl.hpp
@@ -180,7 +180,7 @@ struct SingleLevelTransposeGEMV {
 
   KOKKOS_INLINE_FUNCTION void operator()(const IndexType& i,
                                          value_type y_cur) const {
-    using Kokkos::Details::ArithTraits;
+    using Kokkos::ArithTraits;
     using KAT = ArithTraits<typename AViewType::non_const_value_type>;
 
     const auto x_i = x_(i);
@@ -238,9 +238,9 @@ void singleLevelGemv(const typename AViewType::execution_space& space,
   // depend on that or its implementation details.  Instead, we reuse
   // an instantiation of the non-transpose case for alpha=0.
   if (A.extent(0) == 0 && (tr != 'N' && tr != 'n')) {
-    if (beta == Kokkos::Details::ArithTraits<BetaCoeffType>::zero()) {
-      Kokkos::deep_copy(y, Kokkos::Details::ArithTraits<BetaCoeffType>::zero());
-    } else if (beta != Kokkos::Details::ArithTraits<BetaCoeffType>::one()) {
+    if (beta == Kokkos::ArithTraits<BetaCoeffType>::zero()) {
+      Kokkos::deep_copy(y, Kokkos::ArithTraits<BetaCoeffType>::zero());
+    } else if (beta != Kokkos::ArithTraits<BetaCoeffType>::one()) {
       // "Fake out" a scal() by using the non-transpose alpha=0,
       // general beta case.  This assumes that the functor doesn't
       // check dimensions.
@@ -255,12 +255,11 @@ void singleLevelGemv(const typename AViewType::execution_space& space,
   }
 
   if (tr == 'N' || tr == 'n') {
-    if (alpha == Kokkos::Details::ArithTraits<AlphaCoeffType>::zero()) {
-      if (beta == Kokkos::Details::ArithTraits<BetaCoeffType>::zero()) {
+    if (alpha == Kokkos::ArithTraits<AlphaCoeffType>::zero()) {
+      if (beta == Kokkos::ArithTraits<BetaCoeffType>::zero()) {
         // Fill y with zeros
-        Kokkos::deep_copy(y,
-                          Kokkos::Details::ArithTraits<y_value_type>::zero());
-      } else if (beta == Kokkos::Details::ArithTraits<BetaCoeffType>::one()) {
+        Kokkos::deep_copy(y, Kokkos::ArithTraits<y_value_type>::zero());
+      } else if (beta == Kokkos::ArithTraits<BetaCoeffType>::one()) {
         // Do nothing (y := 1 * y)
       } else {  // beta != 0 && beta != 1
         using functor_type =
@@ -269,14 +268,14 @@ void singleLevelGemv(const typename AViewType::execution_space& space,
         functor_type functor(alpha, A, x, beta, y);
         Kokkos::parallel_for("KokkosBlas::gemv[SingleLevel]", range, functor);
       }
-    } else if (alpha == Kokkos::Details::ArithTraits<AlphaCoeffType>::one()) {
-      if (beta == Kokkos::Details::ArithTraits<BetaCoeffType>::zero()) {
+    } else if (alpha == Kokkos::ArithTraits<AlphaCoeffType>::one()) {
+      if (beta == Kokkos::ArithTraits<BetaCoeffType>::zero()) {
         using functor_type =
             SingleLevelNontransposeGEMV<AViewType, XViewType, YViewType, 1, 0,
                                         IndexType>;
         functor_type functor(alpha, A, x, beta, y);
         Kokkos::parallel_for("KokkosBlas::gemv[SingleLevel]", range, functor);
-      } else if (beta == Kokkos::Details::ArithTraits<BetaCoeffType>::one()) {
+      } else if (beta == Kokkos::ArithTraits<BetaCoeffType>::one()) {
         using functor_type =
             SingleLevelNontransposeGEMV<AViewType, XViewType, YViewType, 1, 1,
                                         IndexType>;
@@ -290,13 +289,13 @@ void singleLevelGemv(const typename AViewType::execution_space& space,
         Kokkos::parallel_for("KokkosBlas::gemv[SingleLevel]", range, functor);
       }
     } else {  // alpha != 0 and alpha != 1
-      if (beta == Kokkos::Details::ArithTraits<BetaCoeffType>::zero()) {
+      if (beta == Kokkos::ArithTraits<BetaCoeffType>::zero()) {
         using functor_type =
             SingleLevelNontransposeGEMV<AViewType, XViewType, YViewType, -1, 0,
                                         IndexType>;
         functor_type functor(alpha, A, x, beta, y);
         Kokkos::parallel_for("KokkosBlas::gemv[SingleLevel]", range, functor);
-      } else if (beta == Kokkos::Details::ArithTraits<BetaCoeffType>::one()) {
+      } else if (beta == Kokkos::ArithTraits<BetaCoeffType>::one()) {
         using functor_type =
             SingleLevelNontransposeGEMV<AViewType, XViewType, YViewType, -1, 1,
                                         IndexType>;
@@ -311,12 +310,11 @@ void singleLevelGemv(const typename AViewType::execution_space& space,
       }
     }
   } else if (tr == 'T' || tr == 't') {  // transpose, no conjugate
-    if (alpha == Kokkos::Details::ArithTraits<AlphaCoeffType>::zero()) {
-      if (beta == Kokkos::Details::ArithTraits<BetaCoeffType>::zero()) {
+    if (alpha == Kokkos::ArithTraits<AlphaCoeffType>::zero()) {
+      if (beta == Kokkos::ArithTraits<BetaCoeffType>::zero()) {
         // Fill y with zeros
-        Kokkos::deep_copy(y,
-                          Kokkos::Details::ArithTraits<y_value_type>::zero());
-      } else if (beta == Kokkos::Details::ArithTraits<BetaCoeffType>::one()) {
+        Kokkos::deep_copy(y, Kokkos::ArithTraits<y_value_type>::zero());
+      } else if (beta == Kokkos::ArithTraits<BetaCoeffType>::one()) {
         // Do nothing (y := 1 * y)
       } else {  // beta != 0 && beta != 1
         using functor_type =
@@ -326,15 +324,15 @@ void singleLevelGemv(const typename AViewType::execution_space& space,
         Kokkos::parallel_reduce("KokkosBlas::gemv[SingleLevelTranspose]", range,
                                 functor);
       }
-    } else if (alpha == Kokkos::Details::ArithTraits<AlphaCoeffType>::one()) {
-      if (beta == Kokkos::Details::ArithTraits<BetaCoeffType>::zero()) {
+    } else if (alpha == Kokkos::ArithTraits<AlphaCoeffType>::one()) {
+      if (beta == Kokkos::ArithTraits<BetaCoeffType>::zero()) {
         using functor_type =
             SingleLevelTransposeGEMV<AViewType, XViewType, YViewType, false, 1,
                                      0, IndexType>;
         functor_type functor(alpha, A, x, beta, y);
         Kokkos::parallel_reduce("KokkosBlas::gemv[SingleLevelTranspose]", range,
                                 functor);
-      } else if (beta == Kokkos::Details::ArithTraits<BetaCoeffType>::one()) {
+      } else if (beta == Kokkos::ArithTraits<BetaCoeffType>::one()) {
         using functor_type =
             SingleLevelTransposeGEMV<AViewType, XViewType, YViewType, false, 1,
                                      1, IndexType>;
@@ -350,14 +348,14 @@ void singleLevelGemv(const typename AViewType::execution_space& space,
                                 functor);
       }
     } else {  // alpha != 0 and alpha != 1
-      if (beta == Kokkos::Details::ArithTraits<BetaCoeffType>::zero()) {
+      if (beta == Kokkos::ArithTraits<BetaCoeffType>::zero()) {
         using functor_type =
             SingleLevelTransposeGEMV<AViewType, XViewType, YViewType, false, -1,
                                      0, IndexType>;
         functor_type functor(alpha, A, x, beta, y);
         Kokkos::parallel_reduce("KokkosBlas::gemv[SingleLevelTranspose]", range,
                                 functor);
-      } else if (beta == Kokkos::Details::ArithTraits<BetaCoeffType>::one()) {
+      } else if (beta == Kokkos::ArithTraits<BetaCoeffType>::one()) {
         using functor_type =
             SingleLevelTransposeGEMV<AViewType, XViewType, YViewType, false, -1,
                                      1, IndexType>;
@@ -374,12 +372,11 @@ void singleLevelGemv(const typename AViewType::execution_space& space,
       }
     }
   } else if (tr == 'C' || tr == 'c' || tr == 'H' || tr == 'h') {  // conj xpose
-    if (alpha == Kokkos::Details::ArithTraits<AlphaCoeffType>::zero()) {
-      if (beta == Kokkos::Details::ArithTraits<BetaCoeffType>::zero()) {
+    if (alpha == Kokkos::ArithTraits<AlphaCoeffType>::zero()) {
+      if (beta == Kokkos::ArithTraits<BetaCoeffType>::zero()) {
         // Fill y with zeros
-        Kokkos::deep_copy(y,
-                          Kokkos::Details::ArithTraits<y_value_type>::zero());
-      } else if (beta == Kokkos::Details::ArithTraits<BetaCoeffType>::one()) {
+        Kokkos::deep_copy(y, Kokkos::ArithTraits<y_value_type>::zero());
+      } else if (beta == Kokkos::ArithTraits<BetaCoeffType>::one()) {
         // Do nothing (y := 1 * y)
       } else {  // beta != 0 && beta != 1
         using functor_type =
@@ -389,15 +386,15 @@ void singleLevelGemv(const typename AViewType::execution_space& space,
         Kokkos::parallel_reduce("KokkosBlas::gemv[SingleLevelTranspose]", range,
                                 functor);
       }
-    } else if (alpha == Kokkos::Details::ArithTraits<AlphaCoeffType>::one()) {
-      if (beta == Kokkos::Details::ArithTraits<BetaCoeffType>::zero()) {
+    } else if (alpha == Kokkos::ArithTraits<AlphaCoeffType>::one()) {
+      if (beta == Kokkos::ArithTraits<BetaCoeffType>::zero()) {
         using functor_type =
             SingleLevelTransposeGEMV<AViewType, XViewType, YViewType, true, 1,
                                      0, IndexType>;
         functor_type functor(alpha, A, x, beta, y);
         Kokkos::parallel_reduce("KokkosBlas::gemv[SingleLevelTranspose]", range,
                                 functor);
-      } else if (beta == Kokkos::Details::ArithTraits<BetaCoeffType>::one()) {
+      } else if (beta == Kokkos::ArithTraits<BetaCoeffType>::one()) {
         using functor_type =
             SingleLevelTransposeGEMV<AViewType, XViewType, YViewType, true, 1,
                                      1, IndexType>;
@@ -413,14 +410,14 @@ void singleLevelGemv(const typename AViewType::execution_space& space,
                                 functor);
       }
     } else {  // alpha != 0 and alpha != 1
-      if (beta == Kokkos::Details::ArithTraits<BetaCoeffType>::zero()) {
+      if (beta == Kokkos::ArithTraits<BetaCoeffType>::zero()) {
         using functor_type =
             SingleLevelTransposeGEMV<AViewType, XViewType, YViewType, true, -1,
                                      0, IndexType>;
         functor_type functor(alpha, A, x, beta, y);
         Kokkos::parallel_reduce("KokkosBlas::gemv[SingleLevelTranspose]", range,
                                 functor);
-      } else if (beta == Kokkos::Details::ArithTraits<BetaCoeffType>::one()) {
+      } else if (beta == Kokkos::ArithTraits<BetaCoeffType>::one()) {
         using functor_type =
             SingleLevelTransposeGEMV<AViewType, XViewType, YViewType, true, -1,
                                      1, IndexType>;
@@ -604,7 +601,7 @@ struct TwoLevelTransposeGEMV {
 
  public:
   KOKKOS_INLINE_FUNCTION void operator()(const member_type& team) const {
-    using Kokkos::Details::ArithTraits;
+    using Kokkos::ArithTraits;
     using KAT_A = ArithTraits<typename AViewType::non_const_value_type>;
     using KAT_Y = ArithTraits<typename YViewType::non_const_value_type>;
 
@@ -668,7 +665,7 @@ void twoLevelGemv(const typename AViewType::execution_space& space,
   using team_policy_type  = Kokkos::TeamPolicy<execution_space>;
   using range_policy_type = Kokkos::RangePolicy<execution_space, IndexType>;
 
-  using Kokkos::Details::ArithTraits;
+  using Kokkos::ArithTraits;
   using KAT  = ArithTraits<typename AViewType::non_const_value_type>;
   using YKAT = ArithTraits<typename YViewType::non_const_value_type>;
 
@@ -746,7 +743,7 @@ void twoLevelGemv(const typename AViewType::execution_space& space,
   } else {
     if (alpha == KAT::zero() && beta == KAT::zero()) {
       // Fill y with zeros
-      Kokkos::deep_copy(y, Kokkos::Details::ArithTraits<y_value_type>::zero());
+      Kokkos::deep_copy(y, Kokkos::ArithTraits<y_value_type>::zero());
     } else if (alpha == KAT::zero() && beta == KAT::one()) {
       // Do nothing (y := 1 * y)
     } else if (tr == 'T') {

--- a/blas/impl/KokkosBlas2_serial_gemv_inner_multiple_dot.hpp
+++ b/blas/impl/KokkosBlas2_serial_gemv_inner_multiple_dot.hpp
@@ -31,7 +31,7 @@ struct OpID {
 struct OpConj {
   template <typename ValueType>
   KOKKOS_INLINE_FUNCTION ValueType operator()(ValueType v) const {
-    using KAT = Kokkos::Details::ArithTraits<ValueType>;
+    using KAT = Kokkos::ArithTraits<ValueType>;
     return KAT::conj(v);
   }
 };

--- a/blas/impl/KokkosBlas3_gemm_dotbased_impl.hpp
+++ b/blas/impl/KokkosBlas3_gemm_dotbased_impl.hpp
@@ -43,8 +43,8 @@ struct DotBasedGEMM {
   using size_A   = typename AV::size_type;
   using scalar_C = typename CV::non_const_value_type;
   using size_C   = typename CV::size_type;
-  using AVT      = Kokkos::Details::ArithTraits<scalar_A>;
-  using CVT      = Kokkos::Details::ArithTraits<scalar_C>;
+  using AVT      = Kokkos::ArithTraits<scalar_A>;
+  using CVT      = Kokkos::ArithTraits<scalar_C>;
 
   const scalar_A alpha;
   const scalar_C beta;

--- a/blas/impl/KokkosBlas3_gemm_impl.hpp
+++ b/blas/impl/KokkosBlas3_gemm_impl.hpp
@@ -65,7 +65,7 @@ template <class TeamHandle, class ViewTypeScratch, class ViewType, class Layout,
 struct impl_deep_copy_matrix_block<TeamHandle, ViewTypeScratch, ViewType,
                                    Layout, blockDim_i, blockDim_j, 0> {
   typedef typename ViewType::non_const_value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ATV;
+  typedef Kokkos::ArithTraits<value_type> ATV;
 
   KOKKOS_INLINE_FUNCTION
   static void copy(const TeamHandle& team, const ViewTypeScratch& A_scr,
@@ -115,7 +115,7 @@ struct impl_deep_copy_matrix_block<TeamHandle, ViewTypeScratch, ViewType,
                                    Kokkos::LayoutRight, blockDim_i, blockDim_j,
                                    0> {
   typedef typename ViewType::non_const_value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ATV;
+  typedef Kokkos::ArithTraits<value_type> ATV;
 
   KOKKOS_INLINE_FUNCTION
   static void copy(const TeamHandle& team, const ViewTypeScratch& A_scr,
@@ -159,7 +159,7 @@ template <class TeamHandle, class ViewTypeScratch, class ViewType, class Layout,
 struct impl_deep_copy_matrix_block<TeamHandle, ViewTypeScratch, ViewType,
                                    Layout, blockDim_i, blockDim_j, 1> {
   typedef typename ViewType::non_const_value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ATV;
+  typedef Kokkos::ArithTraits<value_type> ATV;
 
   KOKKOS_INLINE_FUNCTION
   static void copy(const TeamHandle& team, const ViewTypeScratch& A_scr,
@@ -209,7 +209,7 @@ struct impl_deep_copy_matrix_block<TeamHandle, ViewTypeScratch, ViewType,
                                    Kokkos::LayoutRight, blockDim_i, blockDim_j,
                                    1> {
   typedef typename ViewType::non_const_value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ATV;
+  typedef Kokkos::ArithTraits<value_type> ATV;
 
   KOKKOS_INLINE_FUNCTION
   static void copy(const TeamHandle& team, const ViewTypeScratch& A_scr,
@@ -258,7 +258,7 @@ template <class TeamHandle, class ViewTypeScratch, class ViewType, class Layout,
 struct impl_deep_copy_matrix_block<TeamHandle, ViewTypeScratch, ViewType,
                                    Layout, blockDim_i, blockDim_j, 2> {
   typedef typename ViewType::non_const_value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ATV;
+  typedef Kokkos::ArithTraits<value_type> ATV;
 
   KOKKOS_INLINE_FUNCTION
   static void copy(const TeamHandle& team, const ViewTypeScratch& A_scr,
@@ -308,7 +308,7 @@ struct impl_deep_copy_matrix_block<TeamHandle, ViewTypeScratch, ViewType,
                                    Kokkos::LayoutRight, blockDim_i, blockDim_j,
                                    2> {
   typedef typename ViewType::non_const_value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ATV;
+  typedef Kokkos::ArithTraits<value_type> ATV;
 
   KOKKOS_INLINE_FUNCTION
   static void copy(const TeamHandle& team, const ViewTypeScratch& A_scr,
@@ -356,7 +356,7 @@ template <class TeamHandle, class ViewType, class ViewTypeScratch, class Layout,
           int blockDim_i, int blockDim_j>
 struct impl_update_matrix_block {
   typedef typename ViewType::non_const_value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ATV;
+  typedef Kokkos::ArithTraits<value_type> ATV;
 
   KOKKOS_INLINE_FUNCTION
   static void update(const TeamHandle& team, const value_type& beta,
@@ -417,7 +417,7 @@ template <class TeamHandle, class ViewType, class ViewTypeScratch,
 struct impl_update_matrix_block<TeamHandle, ViewType, ViewTypeScratch,
                                 Kokkos::LayoutRight, blockDim_i, blockDim_j> {
   typedef typename ViewType::non_const_value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ATV;
+  typedef Kokkos::ArithTraits<value_type> ATV;
 
   KOKKOS_INLINE_FUNCTION
   static void update(const TeamHandle& team, const value_type& beta,

--- a/blas/impl/KokkosBlas3_trsm_impl.hpp
+++ b/blas/impl/KokkosBlas3_trsm_impl.hpp
@@ -40,7 +40,7 @@ int SerialTrsmInternalLeftLowerConj(const bool use_unit_diag, const int m,
                                     const int as0, const int as1,
                                     /**/ ValueType* KOKKOS_RESTRICT B,
                                     const int bs0, const int bs1) {
-  typedef Kokkos::Details::ArithTraits<ValueType> AT;
+  typedef Kokkos::ArithTraits<ValueType> AT;
 
   const ScalarType one(1.0), zero(0.0);
 
@@ -79,7 +79,7 @@ int SerialTrsmInternalLeftUpperConj(const bool use_unit_diag, const int m,
                                     const int as0, const int as1,
                                     /**/ ValueType* KOKKOS_RESTRICT B,
                                     const int bs0, const int bs1) {
-  typedef Kokkos::Details::ArithTraits<ValueType> AT;
+  typedef Kokkos::ArithTraits<ValueType> AT;
 
   const ScalarType one(1.0), zero(0.0);
 

--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -92,8 +92,7 @@ void axpby(const AV& a, const XMV& X, const BV& b, const YMV& Y) {
 
 template <class AV, class XMV, class YMV>
 void axpy(const AV& a, const XMV& X, const YMV& Y) {
-  axpby(a, X,
-        Kokkos::Details::ArithTraits<typename YMV::non_const_value_type>::one(),
+  axpby(a, X, Kokkos::ArithTraits<typename YMV::non_const_value_type>::one(),
         Y);
 }
 

--- a/blas/src/KokkosBlas1_team_axpby.hpp
+++ b/blas/src/KokkosBlas1_team_axpby.hpp
@@ -37,9 +37,7 @@ axpy(const TeamType& team, const typename XVector::non_const_value_type& a,
      const XVector& x, const YVector& y) {
   KokkosBlas::Experimental::axpby<TeamType, XVector, YVector>(
       team, a, x,
-      Kokkos::Details::ArithTraits<
-          typename YVector::non_const_value_type>::one(),
-      y);
+      Kokkos::ArithTraits<typename YVector::non_const_value_type>::one(), y);
 }
 
 }  // namespace Experimental

--- a/blas/unit_test/Test_Blas1_abs.hpp
+++ b/blas/unit_test/Test_Blas1_abs.hpp
@@ -24,7 +24,7 @@ template <class ViewTypeA, class ViewTypeB, class Device>
 void impl_test_abs(int N) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   typedef Kokkos::View<
       ScalarA * [2],
@@ -97,7 +97,7 @@ template <class ViewTypeA, class ViewTypeB, class Device>
 void impl_test_abs_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   typedef multivector_layout_adapter<ViewTypeA> vfA_type;
   typedef multivector_layout_adapter<ViewTypeB> vfB_type;

--- a/blas/unit_test/Test_Blas1_asum.hpp
+++ b/blas/unit_test/Test_Blas1_asum.hpp
@@ -23,7 +23,7 @@ namespace Test {
 template <class ViewTypeA, class Device>
 void impl_test_asum(int N) {
   typedef typename ViewTypeA::value_type ScalarA;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
   typedef Kokkos::ArithTraits<typename AT::mag_type> MAT;
 
   typedef Kokkos::View<

--- a/blas/unit_test/Test_Blas1_iamax.hpp
+++ b/blas/unit_test/Test_Blas1_iamax.hpp
@@ -23,7 +23,7 @@ namespace Test {
 template <class ViewTypeA, class Device>
 void impl_test_iamax(int N) {
   typedef typename ViewTypeA::non_const_value_type ScalarA;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
   typedef typename AT::mag_type mag_type;
   using size_type = typename ViewTypeA::size_type;
 
@@ -42,7 +42,7 @@ void impl_test_iamax(int N) {
 
   typename ViewTypeA::const_type c_a = a;
 
-  mag_type expected_result   = Kokkos::Details::ArithTraits<mag_type>::min();
+  mag_type expected_result   = Kokkos::ArithTraits<mag_type>::min();
   size_type expected_max_loc = 0;
   for (int i = 0; i < N; i++) {
     mag_type val = AT::abs(h_a(i));
@@ -114,7 +114,7 @@ void impl_test_iamax(int N) {
 template <class ViewTypeA, class Device>
 void impl_test_iamax_mv(int N, int K) {
   typedef typename ViewTypeA::non_const_value_type ScalarA;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
   typedef typename AT::mag_type mag_type;
   typedef typename ViewTypeA::size_type size_type;
 
@@ -145,7 +145,7 @@ void impl_test_iamax_mv(int N, int K) {
   size_type* expected_max_loc = new size_type[K];
 
   for (int j = 0; j < K; j++) {
-    expected_result[j] = Kokkos::Details::ArithTraits<mag_type>::min();
+    expected_result[j] = Kokkos::ArithTraits<mag_type>::min();
     for (int i = 0; i < N; i++) {
       mag_type val = AT::abs(h_a(i, j));
       if (val > expected_result[j]) {

--- a/blas/unit_test/Test_Blas1_nrm1.hpp
+++ b/blas/unit_test/Test_Blas1_nrm1.hpp
@@ -66,7 +66,7 @@ void impl_test_nrm1(int N) {
 template <class ViewTypeA, class Device>
 void impl_test_nrm1_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
   typedef typename AT::mag_type mag_type;
   typedef Kokkos::ArithTraits<mag_type> MAT;
 

--- a/blas/unit_test/Test_Blas1_nrm2.hpp
+++ b/blas/unit_test/Test_Blas1_nrm2.hpp
@@ -23,7 +23,7 @@ namespace Test {
 template <class ViewTypeA, class Device>
 void impl_test_nrm2(int N) {
   typedef typename ViewTypeA::value_type ScalarA;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   ViewTypeA a("A", N);
 
@@ -45,8 +45,8 @@ void impl_test_nrm2(int N) {
   for (int i = 0; i < N; i++) {
     expected_result += AT::abs(h_a(i)) * AT::abs(h_a(i));
   }
-  expected_result = Kokkos::Details::ArithTraits<typename AT::mag_type>::sqrt(
-      expected_result);
+  expected_result =
+      Kokkos::ArithTraits<typename AT::mag_type>::sqrt(expected_result);
 
   typename AT::mag_type nonconst_result = KokkosBlas::nrm2(a);
   EXPECT_NEAR_KK(nonconst_result, expected_result, eps * expected_result);
@@ -58,7 +58,7 @@ void impl_test_nrm2(int N) {
 template <class ViewTypeA, class Device>
 void impl_test_nrm2_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   typedef multivector_layout_adapter<ViewTypeA> vfA_type;
 
@@ -90,8 +90,7 @@ void impl_test_nrm2_mv(int N, int K) {
       expected_result[j] += AT::abs(h_a(i, j)) * AT::abs(h_a(i, j));
     }
     expected_result[j] =
-        Kokkos::Details::ArithTraits<typename AT::mag_type>::sqrt(
-            expected_result[j]);
+        Kokkos::ArithTraits<typename AT::mag_type>::sqrt(expected_result[j]);
   }
 
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;

--- a/blas/unit_test/Test_Blas1_nrm2_squared.hpp
+++ b/blas/unit_test/Test_Blas1_nrm2_squared.hpp
@@ -23,7 +23,7 @@ namespace Test {
 template <class ViewTypeA, class Device>
 void impl_test_nrm2_squared(int N) {
   typedef typename ViewTypeA::value_type ScalarA;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   typedef Kokkos::View<
       ScalarA * [2],
@@ -68,7 +68,7 @@ void impl_test_nrm2_squared(int N) {
 template <class ViewTypeA, class Device>
 void impl_test_nrm2_squared_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   typedef multivector_layout_adapter<ViewTypeA> vfA_type;
 

--- a/blas/unit_test/Test_Blas1_nrminf.hpp
+++ b/blas/unit_test/Test_Blas1_nrminf.hpp
@@ -23,7 +23,7 @@ namespace Test {
 template <class ViewTypeA, class Device>
 void impl_test_nrminf(int N) {
   typedef typename ViewTypeA::non_const_value_type ScalarA;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   ViewTypeA a("A", N);
 
@@ -42,7 +42,7 @@ void impl_test_nrminf(int N) {
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
 
   typename AT::mag_type expected_result =
-      Kokkos::Details::ArithTraits<typename AT::mag_type>::min();
+      Kokkos::ArithTraits<typename AT::mag_type>::min();
   for (int i = 0; i < N; i++)
     if (AT::abs(h_a(i)) > expected_result) expected_result = AT::abs(h_a(i));
 
@@ -58,7 +58,7 @@ void impl_test_nrminf(int N) {
 template <class ViewTypeA, class Device>
 void impl_test_nrminf_mv(int N, int K) {
   typedef typename ViewTypeA::non_const_value_type ScalarA;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   typedef multivector_layout_adapter<ViewTypeA> vfA_type;
 
@@ -85,8 +85,7 @@ void impl_test_nrminf_mv(int N, int K) {
 
   typename AT::mag_type* expected_result = new typename AT::mag_type[K];
   for (int j = 0; j < K; j++) {
-    expected_result[j] =
-        Kokkos::Details::ArithTraits<typename AT::mag_type>::min();
+    expected_result[j] = Kokkos::ArithTraits<typename AT::mag_type>::min();
     for (int i = 0; i < N; i++) {
       if (AT::abs(h_a(i, j)) > expected_result[j])
         expected_result[j] = AT::abs(h_a(i, j));

--- a/blas/unit_test/Test_Blas1_reciprocal.hpp
+++ b/blas/unit_test/Test_Blas1_reciprocal.hpp
@@ -25,7 +25,7 @@ template <class ViewTypeA, class ViewTypeB, class Device>
 void impl_test_reciprocal(int N) {
   using ScalarA    = typename ViewTypeA::value_type;
   using ScalarB    = typename ViewTypeB::value_type;
-  using AT         = Kokkos::Details::ArithTraits<ScalarA>;
+  using AT         = Kokkos::ArithTraits<ScalarA>;
   using MagnitudeA = typename AT::mag_type;
   using MagnitudeB = typename Kokkos::ArithTraits<ScalarB>::mag_type;
 

--- a/blas/unit_test/Test_Blas1_scal.hpp
+++ b/blas/unit_test/Test_Blas1_scal.hpp
@@ -25,7 +25,7 @@ template <class ViewTypeA, class ViewTypeB, class Device>
 void impl_test_scal(int N) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   ScalarA a(3);
   typename AT::mag_type eps = AT::epsilon() * 1000;
@@ -76,7 +76,7 @@ template <class ViewTypeA, class ViewTypeB, class Device>
 void impl_test_scal_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   typedef multivector_layout_adapter<ViewTypeA> vfA_type;
   typedef multivector_layout_adapter<ViewTypeB> vfB_type;

--- a/blas/unit_test/Test_Blas1_serial_setscal.hpp
+++ b/blas/unit_test/Test_Blas1_serial_setscal.hpp
@@ -99,7 +99,7 @@ template <typename DeviceType, typename ViewType, typename ScalarType,
 void impl_test_blas_matutil(const int N, const int BlkSize) {
   /// typedefs
   typedef typename ViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   /// radomized input testing views
   const ScalarType alpha = 11.1;

--- a/blas/unit_test/Test_Blas1_team_abs.hpp
+++ b/blas/unit_test/Test_Blas1_team_abs.hpp
@@ -39,7 +39,7 @@ void impl_test_team_abs(int N) {
 
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   typedef Kokkos::View<
       ScalarA * [2],
@@ -141,7 +141,7 @@ void impl_test_team_abs_mv(int N, int K) {
 
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   typedef multivector_layout_adapter<ViewTypeA> vfA_type;
   typedef multivector_layout_adapter<ViewTypeB> vfB_type;

--- a/blas/unit_test/Test_Blas1_team_axpby.hpp
+++ b/blas/unit_test/Test_Blas1_team_axpby.hpp
@@ -193,7 +193,7 @@ void impl_test_team_axpby_mv(int N, int K) {
 
   Kokkos::View<ScalarB *, Kokkos::HostSpace> r("Dot::Result", K);
 
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   // KokkosBlas::axpby(a,x,b,y);
   Kokkos::parallel_for(

--- a/blas/unit_test/Test_Blas1_team_nrm2.hpp
+++ b/blas/unit_test/Test_Blas1_team_nrm2.hpp
@@ -35,7 +35,7 @@ void impl_test_team_nrm2(int N, int K) {
   const team_policy policy(K, Kokkos::AUTO);
 
   typedef typename ViewTypeA::value_type ScalarA;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   typedef multivector_layout_adapter<ViewTypeA> vfA_type;
 
@@ -64,8 +64,7 @@ void impl_test_team_nrm2(int N, int K) {
     for (int i = 0; i < N; i++)
       expected_result[j] += AT::abs(h_a(i, j)) * AT::abs(h_a(i, j));
     expected_result[j] =
-        Kokkos::Details::ArithTraits<typename AT::mag_type>::sqrt(
-            expected_result[j]);
+        Kokkos::ArithTraits<typename AT::mag_type>::sqrt(expected_result[j]);
   }
 
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;

--- a/blas/unit_test/Test_Blas1_team_scal.hpp
+++ b/blas/unit_test/Test_Blas1_team_scal.hpp
@@ -39,7 +39,7 @@ void impl_test_team_scal(int N) {
 
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   typedef Kokkos::View<
       ScalarA * [2],
@@ -157,7 +157,7 @@ void impl_test_team_scal_mv(int N, int K) {
 
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
-  typedef Kokkos::Details::ArithTraits<ScalarA> AT;
+  typedef Kokkos::ArithTraits<ScalarA> AT;
 
   typedef multivector_layout_adapter<ViewTypeA> vfA_type;
   typedef multivector_layout_adapter<ViewTypeB> vfB_type;

--- a/blas/unit_test/Test_Blas1_team_setscal.hpp
+++ b/blas/unit_test/Test_Blas1_team_setscal.hpp
@@ -111,7 +111,7 @@ template <typename DeviceType, typename ViewType, typename ScalarType,
 void impl_test_blas_matutil(const int N, const int BlkSize) {
   /// typedefs
   typedef typename ViewType::value_type value_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ats;
+  typedef Kokkos::ArithTraits<value_type> ats;
 
   /// radomized input testing views
   const ScalarType alpha = 11.1;

--- a/blas/unit_test/Test_Blas3_gemm.hpp
+++ b/blas/unit_test/Test_Blas3_gemm.hpp
@@ -35,7 +35,7 @@ struct gemm_VanillaGEMM {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
   typedef typename ViewTypeC::value_type ScalarC;
-  typedef Kokkos::Details::ArithTraits<ScalarC> APT;
+  typedef Kokkos::ArithTraits<ScalarC> APT;
   typedef typename APT::mag_type mag_type;
   ScalarA alpha;
   ScalarC beta;
@@ -142,7 +142,7 @@ struct DiffGEMM {
   ViewTypeC C, C2;
 
   typedef typename ViewTypeC::value_type ScalarC;
-  typedef Kokkos::Details::ArithTraits<ScalarC> APT;
+  typedef Kokkos::ArithTraits<ScalarC> APT;
   typedef typename APT::mag_type mag_type;
 
   KOKKOS_INLINE_FUNCTION
@@ -177,7 +177,7 @@ void impl_test_gemm(const char* TA, const char* TB, int M, int N, int K,
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
   typedef typename ViewTypeC::value_type ScalarC;
-  typedef Kokkos::Details::ArithTraits<ScalarC> APT;
+  typedef Kokkos::ArithTraits<ScalarC> APT;
   typedef typename APT::mag_type mag_type;
 
   double machine_eps = APT::epsilon();
@@ -265,7 +265,7 @@ void impl_test_stream_gemm(const int M, const int N, const int K,
   using ViewTypeB       = Kokkos::View<Scalar**, Layout, TestExecSpace>;
   using ViewTypeC       = Kokkos::View<Scalar**, Layout, TestExecSpace>;
   using ScalarC         = typename ViewTypeC::value_type;
-  using APT             = Kokkos::Details::ArithTraits<ScalarC>;
+  using APT             = Kokkos::ArithTraits<ScalarC>;
   using mag_type        = typename APT::mag_type;
 
   const char tA[]          = {"N"};

--- a/blas/unit_test/Test_Blas3_trmm.hpp
+++ b/blas/unit_test/Test_Blas3_trmm.hpp
@@ -56,7 +56,7 @@ struct trmm_VanillaGEMM {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
   typedef typename ViewTypeC::value_type ScalarC;
-  typedef Kokkos::Details::ArithTraits<ScalarC> APT;
+  typedef Kokkos::ArithTraits<ScalarC> APT;
   typedef typename APT::mag_type mag_type;
   ScalarA alpha;
   ScalarC beta;
@@ -102,7 +102,7 @@ void impl_test_trmm(const char* side, const char* uplo, const char* trans,
                     const char* diag, int M, int N, Scalar alpha) {
   using execution_space = typename ViewTypeA::device_type::execution_space;
   using ScalarA         = typename ViewTypeA::value_type;
-  using APT             = Kokkos::Details::ArithTraits<ScalarA>;
+  using APT             = Kokkos::ArithTraits<ScalarA>;
   using mag_type        = typename APT::mag_type;
 
   double machine_eps = APT::epsilon();
@@ -118,7 +118,7 @@ void impl_test_trmm(const char* side, const char* uplo, const char* trans,
 
   // printf("KokkosBlas::trmm test for alpha %g, %c %c %c %c, M %d, N %d, eps
   // %g, ViewType: %s\n",
-  // Kokkos::Details::ArithTraits<Scalar>::real(alpha),side[0],uplo[0],trans[0],diag[0],M,N,eps,typeid(ViewTypeA).name());
+  // Kokkos::ArithTraits<Scalar>::real(alpha),side[0],uplo[0],trans[0],diag[0],M,N,eps,typeid(ViewTypeA).name());
 
   typename ViewTypeA::HostMirror host_A        = Kokkos::create_mirror_view(A);
   typename ViewTypeB::HostMirror host_B_actual = Kokkos::create_mirror_view(B);

--- a/blas/unit_test/Test_Blas3_trsm.hpp
+++ b/blas/unit_test/Test_Blas3_trsm.hpp
@@ -56,7 +56,7 @@ struct trsm_VanillaGEMM {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
   typedef typename ViewTypeC::value_type ScalarC;
-  typedef Kokkos::Details::ArithTraits<ScalarC> APT;
+  typedef Kokkos::ArithTraits<ScalarC> APT;
   typedef typename APT::mag_type mag_type;
   ScalarA alpha;
   ScalarC beta;
@@ -104,7 +104,7 @@ void impl_test_trsm(const char* side, const char* uplo, const char* trans,
                     typename ViewTypeA::value_type alpha) {
   using execution_space = typename ViewTypeA::device_type::execution_space;
   using ScalarA         = typename ViewTypeA::value_type;
-  using APT             = Kokkos::Details::ArithTraits<ScalarA>;
+  using APT             = Kokkos::ArithTraits<ScalarA>;
   using mag_type        = typename APT::mag_type;
 
   double machine_eps = APT::epsilon();

--- a/blas/unit_test/Test_Blas_gesv.hpp
+++ b/blas/unit_test/Test_Blas_gesv.hpp
@@ -36,7 +36,7 @@ template <class ViewTypeA, class ViewTypeB, class Device>
 void impl_test_gesv(const char* mode, const char* padding, int N) {
   typedef typename Device::execution_space execution_space;
   typedef typename ViewTypeA::value_type ScalarA;
-  typedef Kokkos::Details::ArithTraits<ScalarA> ats;
+  typedef Kokkos::ArithTraits<ScalarA> ats;
 
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
@@ -141,7 +141,7 @@ void impl_test_gesv_mrhs(const char* mode, const char* padding, int N,
                          int nrhs) {
   typedef typename Device::execution_space execution_space;
   typedef typename ViewTypeA::value_type ScalarA;
-  typedef Kokkos::Details::ArithTraits<ScalarA> ats;
+  typedef Kokkos::ArithTraits<ScalarA> ats;
 
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 

--- a/blas/unit_test/Test_Blas_trtri.hpp
+++ b/blas/unit_test/Test_Blas_trtri.hpp
@@ -55,7 +55,7 @@ struct VanillaGEMM {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
   typedef typename ViewTypeC::value_type ScalarC;
-  typedef Kokkos::Details::ArithTraits<ScalarC> APT;
+  typedef Kokkos::ArithTraits<ScalarC> APT;
   typedef typename APT::mag_type mag_type;
   ScalarA alpha;
   ScalarC beta;
@@ -101,7 +101,7 @@ int impl_test_trtri(int bad_diag_idx, const char* uplo, const char* diag,
                     const int M, const int N) {
   using execution_space = typename ViewTypeA::device_type::execution_space;
   using ScalarA         = typename ViewTypeA::value_type;
-  using APT             = Kokkos::Details::ArithTraits<ScalarA>;
+  using APT             = Kokkos::ArithTraits<ScalarA>;
   using mag_type        = typename APT::mag_type;
 
   double machine_eps         = APT::epsilon();

--- a/common/src/KokkosKernels_SimpleUtils.hpp
+++ b/common/src/KokkosKernels_SimpleUtils.hpp
@@ -22,7 +22,7 @@
 #define KOKKOSKERNELS_MACRO_MIN(x, y) ((x) < (y) ? (x) : (y))
 #define KOKKOSKERNELS_MACRO_MAX(x, y) ((x) < (y) ? (y) : (x))
 #define KOKKOSKERNELS_MACRO_ABS(x) \
-  Kokkos::Details::ArithTraits<typename std::decay<decltype(x)>::type>::abs(x)
+  Kokkos::ArithTraits<typename std::decay<decltype(x)>::type>::abs(x)
 
 namespace KokkosKernels {
 
@@ -38,7 +38,7 @@ class SquareRootFunctor {
 
   KOKKOS_INLINE_FUNCTION void operator()(const size_type i) const {
     typedef typename ViewType::value_type value_type;
-    theView_(i) = Kokkos::Details::ArithTraits<value_type>::sqrt(theView_(i));
+    theView_(i) = Kokkos::ArithTraits<value_type>::sqrt(theView_(i));
   }
 
  private:
@@ -219,7 +219,7 @@ inline void kk_reduce_view2(size_t num_elements, view_t arr,
 }
 
 template <typename view_type1, typename view_type2,
-          typename eps_type = typename Kokkos::Details::ArithTraits<
+          typename eps_type = typename Kokkos::ArithTraits<
               typename view_type2::non_const_value_type>::mag_type>
 struct IsIdenticalFunctor {
   view_type1 view1;
@@ -232,7 +232,7 @@ struct IsIdenticalFunctor {
   KOKKOS_INLINE_FUNCTION
   void operator()(const size_t &i, size_t &is_equal) const {
     typedef typename view_type2::non_const_value_type val_type;
-    typedef Kokkos::Details::ArithTraits<val_type> KAT;
+    typedef Kokkos::ArithTraits<val_type> KAT;
     typedef typename KAT::mag_type mag_type;
     const mag_type val_diff = KAT::abs(view1(i) - view2(i));
 
@@ -266,7 +266,7 @@ bool kk_is_identical_view(view_type1 view1, view_type2 view2, eps_type eps) {
 }
 
 template <typename view_type1, typename view_type2,
-          typename eps_type = typename Kokkos::Details::ArithTraits<
+          typename eps_type = typename Kokkos::ArithTraits<
               typename view_type2::non_const_value_type>::mag_type>
 struct IsRelativelyIdenticalFunctor {
   view_type1 view1;

--- a/common/src/KokkosKernels_Utils.hpp
+++ b/common/src/KokkosKernels_Utils.hpp
@@ -837,7 +837,7 @@ template <typename value_array_type, typename MyExecSpace>
 void zero_vector(typename value_array_type::value_type /* num_elements */,
                  value_array_type &vector) {
   typedef typename value_array_type::non_const_value_type val_type;
-  Kokkos::deep_copy(vector, Kokkos::Details::ArithTraits<val_type>::zero());
+  Kokkos::deep_copy(vector, Kokkos::ArithTraits<val_type>::zero());
 }
 
 template <typename v1, typename v2, typename v3>

--- a/common/src/Kokkos_ArithTraits.hpp
+++ b/common/src/Kokkos_ArithTraits.hpp
@@ -18,7 +18,7 @@
 #define KOKKOS_ARITHTRAITS_HPP
 
 /// \file Kokkos_ArithTraits.hpp
-/// \brief Declaration and definition of Kokkos::Details::ArithTraits
+/// \brief Declaration and definition of Kokkos::ArithTraits
 
 #include <KokkosKernels_config.h>
 #include <Kokkos_NumericTraits.hpp>
@@ -195,7 +195,6 @@ KOKKOS_FORCEINLINE_FUNCTION IntType intPowUnsigned(const IntType x,
 }  // namespace
 
 namespace Kokkos {
-namespace Details {
 
 // Macro to automate the wrapping of Kokkos Mathematical Functions
 // in the ArithTraits struct for real floating point types, hopefully
@@ -2043,13 +2042,12 @@ struct [[deprecated]] ArithTraits<qd_real> {
 };
 #endif  // HAVE_KOKKOS_QD
 
-}  // namespace Details
+namespace Details {
+template <typename T>
+using ArithTraits [[deprecated("Use Kokkos::ArithTraits instead")]] =
+    ::Kokkos::ArithTraits<T>;
 
-// Promote ArithTraits into Kokkos namespace.  At some point, we
-// will remove it from the Details namespace completely.  We leave
-// it there for now, because a lot of code depends on it being
-// there.
-using Details::ArithTraits;
+}  // namespace Details
 }  // namespace Kokkos
 
 #endif  // KOKKOS_ARITHTRAITS_HPP

--- a/common/src/Kokkos_InnerProductSpaceTraits.hpp
+++ b/common/src/Kokkos_InnerProductSpaceTraits.hpp
@@ -105,7 +105,7 @@ namespace Details {
 ///
 /// \section Kokkos_IPST_new Adding a specialization for a new type T
 ///
-/// You must first add a specialization of ArithTraits<T>.  Please
+/// You must first add a specialization of Kokkos::ArithTraits<T>.  Please
 /// note that if CUDA does not support using T in device functions,
 /// then you must <i>not</t> mark norm() or dot() as device functions
 /// in your specialization.  (Simply omit the KOKKOS_FORCEINLINE_FUNCTION
@@ -119,14 +119,14 @@ class InnerProductSpaceTraits {
   typedef T val_type;
 
   //! The type returned by norm(x) for a value x of type val_type.
-  typedef typename ArithTraits<val_type>::mag_type mag_type;
+  typedef typename Kokkos::ArithTraits<val_type>::mag_type mag_type;
 
   //! The type returned by dot(x,y) for values x and y of type val_type.
   typedef val_type dot_type;
 
   //! The "norm" (absolute value or magnitude) of a value x of type val_type.
   static KOKKOS_FORCEINLINE_FUNCTION mag_type norm(const val_type& x) {
-    return ArithTraits<val_type>::abs(x);
+    return Kokkos::ArithTraits<val_type>::abs(x);
   }
   /// \brief The "dot product" of two values x and y of type val_type.
   ///
@@ -146,11 +146,11 @@ class InnerProductSpaceTraits {
 template <>
 struct InnerProductSpaceTraits<long double> {
   typedef long double val_type;
-  typedef ArithTraits<val_type>::mag_type mag_type;
+  typedef Kokkos::ArithTraits<val_type>::mag_type mag_type;
   typedef val_type dot_type;
 
   static mag_type norm(const val_type& x) {
-    return ArithTraits<val_type>::abs(x);
+    return Kokkos::ArithTraits<val_type>::abs(x);
   }
   static dot_type dot(const val_type& x, const val_type& y) { return x * y; }
 };
@@ -160,11 +160,11 @@ template <class T>
 class InnerProductSpaceTraits<Kokkos::complex<T>> {
  public:
   typedef Kokkos::complex<T> val_type;
-  typedef typename ArithTraits<val_type>::mag_type mag_type;
+  typedef typename Kokkos::ArithTraits<val_type>::mag_type mag_type;
   typedef val_type dot_type;
 
   static KOKKOS_FORCEINLINE_FUNCTION mag_type norm(const val_type& x) {
-    return ArithTraits<val_type>::abs(x);
+    return Kokkos::ArithTraits<val_type>::abs(x);
   }
   static KOKKOS_FORCEINLINE_FUNCTION dot_type dot(const val_type& x,
                                                   const val_type& y) {
@@ -179,11 +179,11 @@ class InnerProductSpaceTraits<Kokkos::complex<T>> {
 template <class T>
 struct InnerProductSpaceTraits<std::complex<T>> {
   typedef std::complex<T> val_type;
-  typedef typename ArithTraits<val_type>::mag_type mag_type;
+  typedef typename Kokkos::ArithTraits<val_type>::mag_type mag_type;
   typedef val_type dot_type;
 
   static mag_type norm(const val_type& x) {
-    return ArithTraits<val_type>::abs(x);
+    return Kokkos::ArithTraits<val_type>::abs(x);
   }
   static dot_type dot(const val_type& x, const val_type& y) {
     return std::conj(x) * y;
@@ -200,11 +200,11 @@ struct InnerProductSpaceTraits<std::complex<T>> {
 template <>
 struct InnerProductSpaceTraits<__float128> {
   typedef __float128 val_type;
-  typedef typename ArithTraits<val_type>::mag_type mag_type;
+  typedef typename Kokkos::ArithTraits<val_type>::mag_type mag_type;
   typedef val_type dot_type;
 
   static mag_type norm(const val_type& x) {
-    return ArithTraits<val_type>::abs(x);
+    return Kokkos::ArithTraits<val_type>::abs(x);
   }
   static dot_type dot(const val_type& x, const val_type& y) { return x * y; }
 };
@@ -223,17 +223,17 @@ struct InnerProductSpaceTraits<__float128> {
 // functions.  It should be possible to use Kokkos' support for
 // aggregate types to implement device function support for dd_real
 // and qd_real, but we have not done this yet (as of 07 Jan 2014).
-// Hence, the class methods of the ArithTraits specializations for
+// Hence, the class methods of the Kokkos::ArithTraits specializations for
 // dd_real and qd_real are not marked as device functions.
 #ifdef HAVE_KOKKOS_QD
 template <>
 struct InnerProductSpaceTraits<dd_real> {
   typedef dd_real val_type;
-  typedef ArithTraits<val_type>::mag_type mag_type;
+  typedef Kokkos::ArithTraits<val_type>::mag_type mag_type;
   typedef val_type dot_type;
 
   static mag_type norm(const val_type& x) {
-    return ArithTraits<val_type>::abs(x);
+    return Kokkos::ArithTraits<val_type>::abs(x);
   }
   static dot_type dot(const val_type& x, const val_type& y) { return x * y; }
 };
@@ -241,11 +241,11 @@ struct InnerProductSpaceTraits<dd_real> {
 template <>
 struct InnerProductSpaceTraits<qd_real> {
   typedef qd_real val_type;
-  typedef ArithTraits<val_type>::mag_type mag_type;
+  typedef Kokkos::ArithTraits<val_type>::mag_type mag_type;
   typedef val_type dot_type;
 
   static mag_type norm(const val_type& x) {
-    return ArithTraits<val_type>::abs(x);
+    return Kokkos::ArithTraits<val_type>::abs(x);
   }
   static dot_type dot(const val_type& x, const val_type& y) { return x * y; }
 };

--- a/common/unit_test/Test_Common_ArithTraits.hpp
+++ b/common/unit_test/Test_Common_ArithTraits.hpp
@@ -15,15 +15,15 @@
 //@HEADER
 
 /// \file ArithTraitsTest.hpp
-/// \brief Templated test for Kokkos::Details::ArithTraits
+/// \brief Templated test for Kokkos::ArithTraits
 ///
 /// This header file is an implementation detail of the tests for
-/// Kokkos::Details::ArithTraits.  Users must not rely on it existing,
+/// Kokkos::ArithTraits.  Users must not rely on it existing,
 /// or on its contents.  This header file should <i>not</i> be
 /// installed with Kokkos' other header files.
 ///
 /// On the other hand, this header file does give examples of how to
-/// use Kokkos::Details::ArithTraits, so it may be useful for users to
+/// use Kokkos::ArithTraits, so it may be useful for users to
 /// read it.
 
 #ifndef KOKKOS_ARITHTRAITSTEST_HPP
@@ -51,7 +51,7 @@
 #endif
 
 namespace {
-// Whether Kokkos::Details::ArithTraits<ScalarType> implements
+// Whether Kokkos::ArithTraits<ScalarType> implements
 // transcendental functions.  These include sqrt, pow, log, and
 // log10.
 template <class ScalarType>
@@ -92,8 +92,8 @@ struct HasTranscendentals<long double> {
 }  // namespace
 
 /// \class ArithTraitsTesterBase
-/// \brief Base class providing tests for Kokkos::Details::ArithTraits
-/// \tparam ScalarType Any type for which Kokkos::Details::ArithTraits
+/// \brief Base class providing tests for Kokkos::ArithTraits
+/// \tparam ScalarType Any type for which Kokkos::ArithTraits
 ///   has a specialization, and which can be executed on the parallel
 ///   device.
 /// \tparam DeviceType A Kokkos parallel device type.
@@ -107,8 +107,8 @@ struct HasTranscendentals<long double> {
 /// types.
 ///
 /// This class provides a Kokkos reduction operator for testing
-/// Kokkos::Details::ArithTraits.  This test works for any type
-/// <tt>ScalarType</tt> for which Kokkos::Details::ArithTraits has a
+/// Kokkos::ArithTraits.  This test works for any type
+/// <tt>ScalarType</tt> for which Kokkos::ArithTraits has a
 /// specialization, and which can be executed on the parallel device.
 ///
 /// The tests include those suitable for execution on the parallel
@@ -162,7 +162,7 @@ class ArithTraitsTesterBase {
   KOKKOS_INLINE_FUNCTION void operator()(size_type iwork,
                                          value_type& dst) const {
     TRACE();
-    typedef Kokkos::Details::ArithTraits<ScalarType> AT;
+    typedef Kokkos::ArithTraits<ScalarType> AT;
     (void)iwork;  // not using this argument
     int success = 1;
 
@@ -273,7 +273,7 @@ class ArithTraitsTesterBase {
   ///
   /// \return \c 1 if all the tests pass, else \c 0.
   int testHost(std::ostream& out) const {
-    typedef Kokkos::Details::ArithTraits<ScalarType> AT;
+    typedef Kokkos::ArithTraits<ScalarType> AT;
     using std::endl;
     int success = 1;
 
@@ -378,7 +378,7 @@ class ArithTraitsTesterBase {
 /// \brief Base class of ArithTraitsTester that exercises
 ///   transcendental functions, if and only if ArithTraits<ScalarType>
 ///   implements them.
-/// \tparam ScalarType Any type for which Kokkos::Details::ArithTraits
+/// \tparam ScalarType Any type for which Kokkos::ArithTraits
 ///   implements transcendental functions, along with the requirements
 ///   imposed by ArithTraitsTesterBase.
 /// \tparam DeviceType A Kokkos parallel device type.
@@ -441,7 +441,7 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 0>
   KOKKOS_INLINE_FUNCTION void operator()(size_type iwork,
                                          value_type& dst) const {
     TRACE();
-    // typedef Kokkos::Details::ArithTraits<ScalarType> AT;
+    // typedef Kokkos::ArithTraits<ScalarType> AT;
     (void)iwork;  // forestall compiler warning for unused variable
     int success = 1;
 
@@ -462,7 +462,7 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 0>
  protected:
   virtual int testHostImpl(std::ostream& out) const {
     using std::endl;
-    // typedef Kokkos::Details::ArithTraits<ScalarType> AT;
+    // typedef Kokkos::ArithTraits<ScalarType> AT;
     int success = 1;
 
     if (HasTranscendentals<ScalarType>::value) {
@@ -495,20 +495,16 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
 
   KOKKOS_INLINE_FUNCTION
   bool equal(const ScalarType& a, const ScalarType& b) const {
-    if (b != Kokkos::Details::ArithTraits<ScalarType>::zero()) {
+    if (b != Kokkos::ArithTraits<ScalarType>::zero()) {
       if (a > b)
-        return (a - b) / b <
-               2 * Kokkos::Details::ArithTraits<ScalarType>::epsilon();
+        return (a - b) / b < 2 * Kokkos::ArithTraits<ScalarType>::epsilon();
       else
-        return (b - a) / b <
-               2 * Kokkos::Details::ArithTraits<ScalarType>::epsilon();
+        return (b - a) / b < 2 * Kokkos::ArithTraits<ScalarType>::epsilon();
     } else {
       if (a > b)
-        return (a - b) <
-               2 * Kokkos::Details::ArithTraits<ScalarType>::epsilon();
+        return (a - b) < 2 * Kokkos::ArithTraits<ScalarType>::epsilon();
       else
-        return (b - a) <
-               2 * Kokkos::Details::ArithTraits<ScalarType>::epsilon();
+        return (b - a) < 2 * Kokkos::ArithTraits<ScalarType>::epsilon();
     }
   }
 
@@ -524,7 +520,7 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
   KOKKOS_INLINE_FUNCTION void operator()(size_type iwork,
                                          value_type& dst) const {
     TRACE();
-    typedef Kokkos::Details::ArithTraits<ScalarType> AT;
+    typedef Kokkos::ArithTraits<ScalarType> AT;
     (void)iwork;  // forestall compiler warning for unused variable
     int success = 1;
 
@@ -733,7 +729,7 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
  protected:
   virtual int testHostImpl(std::ostream& out) const {
     using std::endl;
-    typedef Kokkos::Details::ArithTraits<ScalarType> AT;
+    typedef Kokkos::ArithTraits<ScalarType> AT;
     int success = 1;
 
     if (!HasTranscendentals<ScalarType>::value) {
@@ -946,7 +942,7 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
 };
 
 /// \class ArithTraitsTesterComplexBase
-/// \brief Execute Kokkos::Details::ArithTraits tests relevant to
+/// \brief Execute Kokkos::ArithTraits tests relevant to
 ///   complex numbers (whether or not \c ScalarType is itself a
 ///   complex-valued type).
 ///
@@ -958,8 +954,7 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
 /// complex, but the specific tests that are run will depend on
 /// <tt>ScalarType</tt>.
 template <class ScalarType, class DeviceType,
-          const int is_complex =
-              Kokkos::Details::ArithTraits<ScalarType>::is_complex>
+          const int is_complex = Kokkos::ArithTraits<ScalarType>::is_complex>
 class ArithTraitsTesterComplexBase
     : public ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType> {
  private:
@@ -1009,7 +1004,7 @@ class ArithTraitsTesterComplexBase<ScalarType, DeviceType, 0>
   KOKKOS_INLINE_FUNCTION void operator()(size_type iwork,
                                          value_type& dst) const {
     TRACE();
-    typedef Kokkos::Details::ArithTraits<ScalarType> AT;
+    typedef Kokkos::ArithTraits<ScalarType> AT;
     (void)iwork;  // forestall compiler warning for unused variable
     int success = 1;
 
@@ -1048,7 +1043,7 @@ class ArithTraitsTesterComplexBase<ScalarType, DeviceType, 0>
  protected:
   virtual int testHostImpl(std::ostream& out) const {
     using std::endl;
-    typedef Kokkos::Details::ArithTraits<ScalarType> AT;
+    typedef Kokkos::ArithTraits<ScalarType> AT;
 
     int success = 1;
     // Apparently, std::numeric_limits<ScalarType>::is_signed is 1 only for real
@@ -1095,7 +1090,7 @@ class ArithTraitsTesterComplexBase<ScalarType, DeviceType, 1>
   KOKKOS_INLINE_FUNCTION void operator()(size_type iwork,
                                          value_type& dst) const {
     TRACE();
-    typedef Kokkos::Details::ArithTraits<ScalarType> AT;
+    typedef Kokkos::ArithTraits<ScalarType> AT;
     (void)iwork;  // forestall compiler warning for unused variable
     int success = 1;
 
@@ -1103,7 +1098,7 @@ class ArithTraitsTesterComplexBase<ScalarType, DeviceType, 1>
       FAILURE();
     }
     typedef typename AT::mag_type mag_type;
-    const mag_type one = Kokkos::Details::ArithTraits<mag_type>::one();
+    const mag_type one = Kokkos::ArithTraits<mag_type>::one();
 
     // This presumes that ScalarType, being a complex number, has a
     // constructor which takes two mag_type arguments.
@@ -1129,7 +1124,7 @@ class ArithTraitsTesterComplexBase<ScalarType, DeviceType, 1>
  protected:
   virtual int testHostImpl(std::ostream& out) const {
     using std::endl;
-    typedef Kokkos::Details::ArithTraits<ScalarType> AT;
+    typedef Kokkos::ArithTraits<ScalarType> AT;
     int success = 1;
 
     if (!AT::is_complex) {
@@ -1137,7 +1132,7 @@ class ArithTraitsTesterComplexBase<ScalarType, DeviceType, 1>
       FAILURE();
     }
     typedef typename AT::mag_type mag_type;
-    const mag_type one = Kokkos::Details::ArithTraits<mag_type>::one();
+    const mag_type one = Kokkos::ArithTraits<mag_type>::one();
 
     // This presumes that ScalarType, being a complex number, has a
     // constructor which takes two mag_type arguments.
@@ -1173,7 +1168,7 @@ class ArithTraitsTesterComplexBase<ScalarType, DeviceType, 1>
 /// \tparam DeviceType A Kokkos parallel device type.
 ///
 /// Kokkos reduction operator for testing those attributes of
-/// Kokkos::Details::ArithTraits relevant to floating-point types.
+/// Kokkos::ArithTraits relevant to floating-point types.
 ///
 /// The tests include those suitable for execution on the parallel
 /// device (operator()) and those suitable for execution on the host
@@ -1181,17 +1176,14 @@ class ArithTraitsTesterComplexBase<ScalarType, DeviceType, 1>
 /// executions of the test.  All redundant executions must return
 /// '1' (passed).
 template <class ScalarType, class DeviceType,
-          const int is_exact =
-              Kokkos::Details::ArithTraits<ScalarType>::is_exact>
+          const int is_exact = Kokkos::ArithTraits<ScalarType>::is_exact>
 class ArithTraitsTesterFloatingPointBase
     : public ArithTraitsTesterComplexBase<
-          ScalarType, DeviceType,
-          Kokkos::Details::ArithTraits<ScalarType>::is_complex> {
+          ScalarType, DeviceType, Kokkos::ArithTraits<ScalarType>::is_complex> {
  private:
   //! The base class of this class.
   typedef ArithTraitsTesterComplexBase<
-      ScalarType, DeviceType,
-      Kokkos::Details::ArithTraits<ScalarType>::is_complex>
+      ScalarType, DeviceType, Kokkos::ArithTraits<ScalarType>::is_complex>
       base_type;
 
  public:
@@ -1217,13 +1209,11 @@ class ArithTraitsTesterFloatingPointBase
 template <class ScalarType, class DeviceType>
 class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 0>
     : public ArithTraitsTesterComplexBase<
-          ScalarType, DeviceType,
-          Kokkos::Details::ArithTraits<ScalarType>::is_complex> {
+          ScalarType, DeviceType, Kokkos::ArithTraits<ScalarType>::is_complex> {
  private:
   //! The base class of this class.
   typedef ArithTraitsTesterComplexBase<
-      ScalarType, DeviceType,
-      Kokkos::Details::ArithTraits<ScalarType>::is_complex>
+      ScalarType, DeviceType, Kokkos::ArithTraits<ScalarType>::is_complex>
       base_type;
 
  public:
@@ -1238,7 +1228,7 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 0>
   KOKKOS_INLINE_FUNCTION void operator()(size_type iwork,
                                          value_type& dst) const {
     TRACE();
-    typedef Kokkos::Details::ArithTraits<ScalarType> AT;
+    typedef Kokkos::ArithTraits<ScalarType> AT;
     (void)iwork;  // forestall compiler warning for unused variable
     int success = 1;
 
@@ -1284,7 +1274,7 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 0>
 
  protected:
   virtual int testHostImpl(std::ostream& out) const {
-    typedef Kokkos::Details::ArithTraits<ScalarType> AT;
+    typedef Kokkos::ArithTraits<ScalarType> AT;
     using std::endl;
     int success = 1;
 
@@ -1338,13 +1328,11 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 0>
 template <class ScalarType, class DeviceType>
 class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 1>
     : public ArithTraitsTesterComplexBase<
-          ScalarType, DeviceType,
-          Kokkos::Details::ArithTraits<ScalarType>::is_complex> {
+          ScalarType, DeviceType, Kokkos::ArithTraits<ScalarType>::is_complex> {
  private:
   //! The base class of this class.
   typedef ArithTraitsTesterComplexBase<
-      ScalarType, DeviceType,
-      Kokkos::Details::ArithTraits<ScalarType>::is_complex>
+      ScalarType, DeviceType, Kokkos::ArithTraits<ScalarType>::is_complex>
       base_type;
 
  public:
@@ -1359,7 +1347,7 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 1>
   KOKKOS_INLINE_FUNCTION void operator()(size_type iwork,
                                          value_type& dst) const {
     TRACE();
-    typedef Kokkos::Details::ArithTraits<ScalarType> AT;
+    typedef Kokkos::ArithTraits<ScalarType> AT;
     (void)iwork;  // forestall compiler warning for unused variable
     int success = 1;
 
@@ -1380,7 +1368,7 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 1>
 
  protected:
   virtual int testHostImpl(std::ostream& out) const {
-    typedef Kokkos::Details::ArithTraits<ScalarType> AT;
+    typedef Kokkos::ArithTraits<ScalarType> AT;
     using std::endl;
     int success = 1;
 
@@ -1399,8 +1387,8 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 1>
 };
 
 /// \class ArithTraitsTester
-/// \brief Tests for Kokkos::Details::ArithTraits
-/// \tparam ScalarType Any type for which Kokkos::Details::ArithTraits
+/// \brief Tests for Kokkos::ArithTraits
+/// \tparam ScalarType Any type for which Kokkos::ArithTraits
 ///   has a specialization, and which can be executed on the parallel
 ///   device.
 /// \tparam DeviceType A Kokkos parallel device type.
@@ -1415,9 +1403,9 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 1>
 /// for host functions <i>do</i> use run-time polymorphism.
 ///
 /// This class (through its base class) provides a Kokkos reduction
-/// operator for testing Kokkos::Details::ArithTraits.  This test
+/// operator for testing Kokkos::ArithTraits.  This test
 /// works for any type <tt>ScalarType</tt> for which
-/// Kokkos::Details::ArithTraits has a specialization, and which can
+/// Kokkos::ArithTraits has a specialization, and which can
 /// be executed on the parallel device.
 ///
 /// The tests include those suitable for execution on the parallel
@@ -1438,8 +1426,8 @@ class ArithTraitsTester
   KOKKOS_INLINE_FUNCTION ArithTraitsTester() {}
 };
 
-/// \brief Run the Kokkos::Details::ArithTraits tests on the parallel device.
-/// \tparam ScalarType Any type for which Kokkos::Details::ArithTraits
+/// \brief Run the Kokkos::ArithTraits tests on the parallel device.
+/// \tparam ScalarType Any type for which Kokkos::ArithTraits
 ///   has a specialization, and which can be executed on the parallel
 ///   device.
 /// \tparam DeviceType A Kokkos parallel device type.
@@ -1457,17 +1445,15 @@ int testArithTraitsOnDevice(std::ostream& out, const int verbose) {
                           functor_type(), success);
   if (success) {
     if (verbose)
-      out << Kokkos::Details::ArithTraits<ScalarType>::name() << " passed"
-          << endl;
+      out << Kokkos::ArithTraits<ScalarType>::name() << " passed" << endl;
   } else {
-    out << Kokkos::Details::ArithTraits<ScalarType>::name() << " FAILED"
-        << endl;
+    out << Kokkos::ArithTraits<ScalarType>::name() << " FAILED" << endl;
   }
   return success;
 }
 
-/// \brief Run the Kokkos::Details::ArithTraits tests on the host.
-/// \tparam ScalarType Any type for which Kokkos::Details::ArithTraits
+/// \brief Run the Kokkos::ArithTraits tests on the host.
+/// \tparam ScalarType Any type for which Kokkos::ArithTraits
 ///   has a specialization.
 /// \tparam DeviceType A Kokkos parallel device type.
 ///
@@ -1482,16 +1468,14 @@ int testArithTraitsOnHost(std::ostream& out, const int verbose) {
 
   if (localSuccess) {
     if (verbose)
-      out << Kokkos::Details::ArithTraits<ScalarType>::name() << " passed"
-          << endl;
+      out << Kokkos::ArithTraits<ScalarType>::name() << " passed" << endl;
   } else {
-    out << Kokkos::Details::ArithTraits<ScalarType>::name() << " FAILED"
-        << endl;
+    out << Kokkos::ArithTraits<ScalarType>::name() << " FAILED" << endl;
   }
   return localSuccess;
 }
 
-/// \brief Run the Kokkos::Details::ArithTraits tests for all (valid)
+/// \brief Run the Kokkos::ArithTraits tests for all (valid)
 ///   scalar types, on the given parallel device.
 /// \tparam DeviceType A Kokkos parallel device type.
 ///
@@ -1586,7 +1570,7 @@ int runAllArithTraitsDeviceTests(std::ostream& out, const int verbose) {
   return success && curSuccess;
 }
 
-/// \brief Run the Kokkos::Details::ArithTraits tests for all scalar
+/// \brief Run the Kokkos::ArithTraits tests for all scalar
 ///   types, on the host.
 /// \tparam DeviceType A Kokkos parallel device type.
 ///

--- a/example/batched_solve/team_GMRES.cpp
+++ b/example/batched_solve/team_GMRES.cpp
@@ -236,8 +236,7 @@ int main(int /*argc*/, char ** /*argv*/) {
     using Layout     = typename AMatrixValueView::array_layout;
     using EXSP       = typename AMatrixValueView::execution_space;
 
-    using MagnitudeType =
-        typename Kokkos::Details::ArithTraits<ScalarType>::mag_type;
+    using MagnitudeType = typename Kokkos::ArithTraits<ScalarType>::mag_type;
 
     using Norm2DViewType   = Kokkos::View<MagnitudeType **, Layout, EXSP>;
     using Scalar3DViewType = Kokkos::View<ScalarType ***, Layout, EXSP>;

--- a/perf_test/batched/dense/KokkosBatched_Test_BlockTridiagDirect.cpp
+++ b/perf_test/batched/dense/KokkosBatched_Test_BlockTridiagDirect.cpp
@@ -245,7 +245,7 @@ int main(int argc, char *argv[]) {
 #endif
     Kokkos::print_configuration(std::cout);
 
-    // typedef Kokkos::Details::ArithTraits<value_type> ats;
+    // typedef Kokkos::ArithTraits<value_type> ats;
     Kokkos::Timer timer;
 
     ///

--- a/perf_test/batched/dense/KokkosBatched_Test_BlockTridiagJacobi.cpp
+++ b/perf_test/batched/dense/KokkosBatched_Test_BlockTridiagJacobi.cpp
@@ -178,7 +178,7 @@ int main(int argc, char *argv[]) {
 #endif
     Kokkos::print_configuration(std::cout);
 
-    // typedef Kokkos::Details::ArithTraits<value_type> ats;
+    // typedef Kokkos::ArithTraits<value_type> ats;
     Kokkos::Timer timer;
 
     ///

--- a/perf_test/batched/sparse/CG/KokkosBatched_Test_CG.cpp
+++ b/perf_test/batched/sparse/CG/KokkosBatched_Test_CG.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[]) {
 #endif
     Kokkos::print_configuration(std::cout);
 
-    // typedef Kokkos::Details::ArithTraits<value_type> ats;
+    // typedef Kokkos::ArithTraits<value_type> ats;
     Kokkos::Timer timer;
 
     ///
@@ -220,8 +220,7 @@ int main(int argc, char *argv[]) {
       using Layout     = typename AMatrixValueViewLL::array_layout;
       using EXSP       = typename AMatrixValueViewLL::execution_space;
 
-      using MagnitudeType =
-          typename Kokkos::Details::ArithTraits<ScalarType>::mag_type;
+      using MagnitudeType = typename Kokkos::ArithTraits<ScalarType>::mag_type;
 
       using Norm2DViewType   = Kokkos::View<MagnitudeType **, Layout, EXSP>;
       using Scalar3DViewType = Kokkos::View<ScalarType ***, Layout, EXSP>;

--- a/perf_test/batched/sparse/GMRES/KokkosBatched_Test_GMRES.cpp
+++ b/perf_test/batched/sparse/GMRES/KokkosBatched_Test_GMRES.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[]) {
 #endif
     Kokkos::print_configuration(std::cout);
 
-    // typedef Kokkos::Details::ArithTraits<value_type> ats;
+    // typedef Kokkos::ArithTraits<value_type> ats;
 
     ///
     /// input arguments parsing
@@ -250,8 +250,7 @@ int main(int argc, char *argv[]) {
       using Layout     = typename AMatrixValueViewLL::array_layout;
       using EXSP       = typename AMatrixValueViewLL::execution_space;
 
-      using MagnitudeType =
-          typename Kokkos::Details::ArithTraits<ScalarType>::mag_type;
+      using MagnitudeType = typename Kokkos::ArithTraits<ScalarType>::mag_type;
 
       using Norm2DViewType   = Kokkos::View<MagnitudeType **, Layout, EXSP>;
       using Scalar3DViewType = Kokkos::View<ScalarType ***, Layout, EXSP>;

--- a/perf_test/batched/sparse/SPMV/KokkosBatched_SPMV_View.hpp
+++ b/perf_test/batched/sparse/SPMV/KokkosBatched_SPMV_View.hpp
@@ -23,7 +23,7 @@ struct BSPMV_Functor_View {
   typedef typename Kokkos::TeamPolicy<exec_space> team_policy;
   typedef typename team_policy::member_type team_member;
   typedef typename AMatrix::non_const_value_type entries_type;
-  typedef Kokkos::Details::ArithTraits<value_type> ATV;
+  typedef Kokkos::ArithTraits<value_type> ATV;
 
   const value_type* alpha;
   const AMatrix m_A_values;

--- a/perf_test/batched/sparse/SPMV/KokkosBatched_Test_SPMV.cpp
+++ b/perf_test/batched/sparse/SPMV/KokkosBatched_Test_SPMV.cpp
@@ -126,7 +126,7 @@ int main(int argc, char *argv[]) {
 #endif
     Kokkos::print_configuration(std::cout);
 
-    // typedef Kokkos::Details::ArithTraits<value_type> ats;
+    // typedef Kokkos::ArithTraits<value_type> ats;
     Kokkos::Timer timer;
 
     ///

--- a/perf_test/batched/sparse/cusolver/KokkosBatched_Test_cusolverDn.cpp
+++ b/perf_test/batched/sparse/cusolver/KokkosBatched_Test_cusolverDn.cpp
@@ -163,7 +163,7 @@ int main(int argc, char *argv[]) {
 #endif
     Kokkos::print_configuration(std::cout);
 
-    // typedef Kokkos::Details::ArithTraits<value_type> ats;
+    // typedef Kokkos::ArithTraits<value_type> ats;
 
     ///
     /// input arguments parsing

--- a/perf_test/batched/sparse/cusolver/KokkosBatched_Test_cusolverSp.cpp
+++ b/perf_test/batched/sparse/cusolver/KokkosBatched_Test_cusolverSp.cpp
@@ -381,7 +381,7 @@ int main(int argc, char *argv[]) {
 #endif
     Kokkos::print_configuration(std::cout);
 
-    // typedef Kokkos::Details::ArithTraits<value_type> ats;
+    // typedef Kokkos::ArithTraits<value_type> ats;
 
     ///
     /// input arguments parsing

--- a/perf_test/sparse/KokkosSparse_sptrsv_aux.hpp
+++ b/perf_test/sparse/KokkosSparse_sptrsv_aux.hpp
@@ -66,7 +66,7 @@ bool check_errors(mag_t tol, crsmat_t &Mtx, scalar_view_t rhs,
   using lno_t          = typename entries_view_t::non_const_value_type;
   using values_view_t  = typename crsmat_t::values_type::non_const_type;
   using scalar_t       = typename values_view_t::value_type;
-  using STS            = Kokkos::Details::ArithTraits<scalar_t>;
+  using STS            = Kokkos::ArithTraits<scalar_t>;
 
   using execution_space = typename scalar_view_t::execution_space;
 

--- a/perf_test/sparse/KokkosSparse_sptrsv_cholmod.cpp
+++ b/perf_test/sparse/KokkosSparse_sptrsv_cholmod.cpp
@@ -153,7 +153,7 @@ template <typename scalar_type>
 int test_sptrsv_perf(std::vector<int> tests, std::string &filename,
                      bool u_in_csr, bool invert_diag, bool invert_offdiag,
                      int block_size, int loop) {
-  using STS      = Kokkos::Details::ArithTraits<scalar_type>;
+  using STS      = Kokkos::ArithTraits<scalar_type>;
   using mag_type = typename STS::mag_type;
 
   // using cholmod_int_type = long;

--- a/perf_test/sparse/KokkosSparse_sptrsv_superlu.cpp
+++ b/perf_test/sparse/KokkosSparse_sptrsv_superlu.cpp
@@ -308,7 +308,7 @@ int test_sptrsv_perf(std::vector<int> tests, bool verbose,
                      int relax_size, int block_size, int loop) {
   using ordinal_type = int;
   using size_type    = int;
-  using STS          = Kokkos::Details::ArithTraits<scalar_type>;
+  using STS          = Kokkos::ArithTraits<scalar_type>;
   using mag_type     = typename STS::mag_type;
 
   // Default spaces

--- a/perf_test/sparse/KokkosSparse_sptrsv_supernode.cpp
+++ b/perf_test/sparse/KokkosSparse_sptrsv_supernode.cpp
@@ -52,7 +52,7 @@ int test_sptrsv_perf(std::vector<int> tests, bool verbose,
                      bool invert_offdiag, bool u_in_csr, int loop) {
   using ordinal_type = int;
   using size_type    = int;
-  using STS          = Kokkos::Details::ArithTraits<scalar_type>;
+  using STS          = Kokkos::ArithTraits<scalar_type>;
   using mag_type     = typename STS::mag_type;
 
   // Default spaces

--- a/perf_test/sparse/spmv/Kokkos_SPMV.hpp
+++ b/perf_test/sparse/spmv/Kokkos_SPMV.hpp
@@ -25,7 +25,7 @@ struct SPMV_Functor {
   typedef typename AMatrix::non_const_value_type value_type;
   typedef typename Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
-  typedef Kokkos::Details::ArithTraits<value_type> ATV;
+  typedef Kokkos::ArithTraits<value_type> ATV;
 
   const value_type alpha;
   AMatrix m_A;

--- a/perf_test/sparse/spmv/Kokkos_SPMV_Inspector.hpp
+++ b/perf_test/sparse/spmv/Kokkos_SPMV_Inspector.hpp
@@ -28,7 +28,7 @@ struct SPMV_Inspector_Functor {
   typedef typename AMatrix::non_const_size_type size_type;
   typedef typename Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
-  typedef Kokkos::Details::ArithTraits<value_type> ATV;
+  typedef Kokkos::ArithTraits<value_type> ATV;
 
   const value_type alpha;
   AMatrix m_A;

--- a/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
+++ b/sparse/impl/KokkosSparse_cluster_gauss_seidel_impl.hpp
@@ -247,16 +247,16 @@ class ClusterGaussSeidel {
 
     nnz_scalar_t _omega;
 
-    Team_PSGS(
-        const_lno_row_view_t xadj_, const_lno_nnz_view_t adj_,
-        const_scalar_nnz_view_t adj_vals_, x_value_array_type Xvector_,
-        y_value_array_type Yvector_, nnz_lno_t color_set_begin_,
-        nnz_lno_t color_set_end_, nnz_lno_persistent_work_view_t color_adj_,
-        nnz_lno_persistent_work_view_t cluster_offsets_,
-        nnz_lno_persistent_work_view_t cluster_verts_,
-        scalar_persistent_work_view_t inverse_diagonal_,
-        nnz_lno_t clusters_per_team_,
-        nnz_scalar_t omega_ = Kokkos::Details::ArithTraits<nnz_scalar_t>::one())
+    Team_PSGS(const_lno_row_view_t xadj_, const_lno_nnz_view_t adj_,
+              const_scalar_nnz_view_t adj_vals_, x_value_array_type Xvector_,
+              y_value_array_type Yvector_, nnz_lno_t color_set_begin_,
+              nnz_lno_t color_set_end_,
+              nnz_lno_persistent_work_view_t color_adj_,
+              nnz_lno_persistent_work_view_t cluster_offsets_,
+              nnz_lno_persistent_work_view_t cluster_verts_,
+              scalar_persistent_work_view_t inverse_diagonal_,
+              nnz_lno_t clusters_per_team_,
+              nnz_scalar_t omega_ = Kokkos::ArithTraits<nnz_scalar_t>::one())
         : _xadj(xadj_),
           _adj(adj_),
           _adj_vals(adj_vals_),
@@ -691,7 +691,7 @@ class ClusterGaussSeidel {
           _diagonals(diagonals_),
           num_total_rows(num_total_rows_),
           rows_per_team(rows_per_team_),
-          one(Kokkos::Details::ArithTraits<nnz_scalar_t>::one()) {}
+          one(Kokkos::ArithTraits<nnz_scalar_t>::one()) {}
 
     KOKKOS_INLINE_FUNCTION
     void operator()(const nnz_lno_t row_id) const {
@@ -781,12 +781,12 @@ class ClusterGaussSeidel {
   }
 
   template <typename x_value_array_type, typename y_value_array_type>
-  void apply(
-      x_value_array_type x_lhs_output_vec, y_value_array_type y_rhs_input_vec,
-      bool init_zero_x_vector = false, int numIter = 1,
-      nnz_scalar_t omega = Kokkos::Details::ArithTraits<nnz_scalar_t>::one(),
-      bool apply_forward = true, bool apply_backward = true,
-      bool /*update_y_vector*/ = true) {
+  void apply(x_value_array_type x_lhs_output_vec,
+             y_value_array_type y_rhs_input_vec,
+             bool init_zero_x_vector = false, int numIter = 1,
+             nnz_scalar_t omega = Kokkos::ArithTraits<nnz_scalar_t>::one(),
+             bool apply_forward = true, bool apply_backward = true,
+             bool /*update_y_vector*/ = true) {
     auto gsHandle = get_gs_handle();
 
     size_type nnz                            = entries.extent(0);

--- a/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
+++ b/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
@@ -260,21 +260,20 @@ class PointGaussSeidel {
                               // long rows.
     nnz_lno_t _long_row_par;
 
-    Team_PSGS(
-        row_lno_persistent_work_view_t xadj_,
-        nnz_lno_persistent_work_view_t adj_,
-        scalar_persistent_work_view_t adj_vals_,
-        scalar_persistent_work_view2d_t Xvector_,
-        scalar_persistent_work_view2d_t Yvector_, nnz_lno_t color_set_begin,
-        nnz_lno_t color_set_end,
-        scalar_persistent_work_view_t permuted_inverse_diagonal_,
-        pool_memory_space pms, nnz_lno_t _num_max_vals_in_l1 = 0,
-        nnz_lno_t _num_max_vals_in_l2 = 0,
-        nnz_scalar_t omega_ = Kokkos::Details::ArithTraits<nnz_scalar_t>::one(),
+    Team_PSGS(row_lno_persistent_work_view_t xadj_,
+              nnz_lno_persistent_work_view_t adj_,
+              scalar_persistent_work_view_t adj_vals_,
+              scalar_persistent_work_view2d_t Xvector_,
+              scalar_persistent_work_view2d_t Yvector_,
+              nnz_lno_t color_set_begin, nnz_lno_t color_set_end,
+              scalar_persistent_work_view_t permuted_inverse_diagonal_,
+              pool_memory_space pms, nnz_lno_t _num_max_vals_in_l1 = 0,
+              nnz_lno_t _num_max_vals_in_l2 = 0,
+              nnz_scalar_t omega_ = Kokkos::ArithTraits<nnz_scalar_t>::one(),
 
-        nnz_lno_t block_size_ = 1, nnz_lno_t team_work_size_ = 1,
-        size_t shared_memory_size_ = 16, int suggested_team_size_ = 1,
-        int vector_size_ = 1)
+              nnz_lno_t block_size_ = 1, nnz_lno_t team_work_size_ = 1,
+              size_t shared_memory_size_ = 16, int suggested_team_size_ = 1,
+              int vector_size_ = 1)
         : _xadj(xadj_),
           _adj(adj_),
           _adj_vals(adj_vals_),
@@ -1283,7 +1282,7 @@ class PointGaussSeidel {
           rows_per_team(rows_per_team_),
           block_size(block_size_),
           block_matrix_size(block_matrix_size_),
-          one(Kokkos::Details::ArithTraits<nnz_scalar_t>::one()) {}
+          one(Kokkos::ArithTraits<nnz_scalar_t>::one()) {}
 
     KOKKOS_INLINE_FUNCTION
     void operator()(const nnz_lno_t& row_id) const {
@@ -1489,7 +1488,7 @@ class PointGaussSeidel {
   void block_apply(
       x_value_array_type x_lhs_output_vec, y_value_array_type y_rhs_input_vec,
       bool init_zero_x_vector = false, int numIter = 1,
-      nnz_scalar_t omega = Kokkos::Details::ArithTraits<nnz_scalar_t>::one(),
+      nnz_scalar_t omega = Kokkos::ArithTraits<nnz_scalar_t>::one(),
       bool apply_forward = true, bool apply_backward = true,
       bool update_y_vector = true) {
     auto gsHandle = this->get_gs_handle();
@@ -1613,7 +1612,7 @@ class PointGaussSeidel {
   void point_apply(
       x_value_array_type x_lhs_output_vec, y_value_array_type y_rhs_input_vec,
       bool init_zero_x_vector = false, int numIter = 1,
-      nnz_scalar_t omega = Kokkos::Details::ArithTraits<nnz_scalar_t>::one(),
+      nnz_scalar_t omega = Kokkos::ArithTraits<nnz_scalar_t>::one(),
       bool apply_forward = true, bool apply_backward = true,
       bool update_y_vector = true) {
     auto gsHandle = get_gs_handle();
@@ -1690,12 +1689,12 @@ class PointGaussSeidel {
   }
 
   template <typename x_value_array_type, typename y_value_array_type>
-  void apply(
-      x_value_array_type x_lhs_output_vec, y_value_array_type y_rhs_input_vec,
-      bool init_zero_x_vector = false, int numIter = 1,
-      nnz_scalar_t omega = Kokkos::Details::ArithTraits<nnz_scalar_t>::one(),
-      bool apply_forward = true, bool apply_backward = true,
-      bool update_y_vector = true) {
+  void apply(x_value_array_type x_lhs_output_vec,
+             y_value_array_type y_rhs_input_vec,
+             bool init_zero_x_vector = false, int numIter = 1,
+             nnz_scalar_t omega = Kokkos::ArithTraits<nnz_scalar_t>::one(),
+             bool apply_forward = true, bool apply_backward = true,
+             bool update_y_vector = true) {
     auto gsHandle = get_gs_handle();
     if (gsHandle->is_numeric_called() == false) {
       this->initialize_numeric();

--- a/sparse/impl/KokkosSparse_getDiagCopyWithOffsets_impl.hpp
+++ b/sparse/impl/KokkosSparse_getDiagCopyWithOffsets_impl.hpp
@@ -75,7 +75,7 @@ struct CrsMatrixGetDiagCopyWithOffsetsFunctor {
   /// \param lclRow [in] The current (local) row of the sparse matrix.
   KOKKOS_INLINE_FUNCTION void operator()(const LO& lclRow) const {
     const offset_type INV = KokkosSparse::OrdinalTraits<offset_type>::invalid();
-    const scalar_type ZERO = Kokkos::Details::ArithTraits<scalar_type>::zero();
+    const scalar_type ZERO = Kokkos::ArithTraits<scalar_type>::zero();
 
     // If the row lacks a stored diagonal entry, then its value is zero.
     D_(lclRow)               = ZERO;

--- a/sparse/impl/KokkosSparse_sor_sequential_impl.hpp
+++ b/sparse/impl/KokkosSparse_sor_sequential_impl.hpp
@@ -77,7 +77,7 @@ void gaussSeidel(const LocalOrdinal numRows, const LocalOrdinal numCols,
                  const OffsetType b_stride, RangeScalar* const X,
                  const OffsetType x_stride, const MatrixScalar* const D,
                  const MatrixScalar omega, const char direction[]) {
-  using Kokkos::Details::ArithTraits;
+  using Kokkos::ArithTraits;
   typedef LocalOrdinal LO;
   const OffsetType theNumRows = static_cast<OffsetType>(numRows);
   const OffsetType theNumCols = static_cast<OffsetType>(numCols);
@@ -247,7 +247,7 @@ void reorderedGaussSeidel(
     const MatrixScalar* const D, const LocalOrdinal* const rowInd,
     const LocalOrdinal numRowInds,  // length of rowInd
     const MatrixScalar omega, const char direction[]) {
-  using Kokkos::Details::ArithTraits;
+  using Kokkos::ArithTraits;
   typedef LocalOrdinal LO;
   const OffsetType theNumRows = static_cast<OffsetType>(numRows);
   const OffsetType theNumCols = static_cast<OffsetType>(numCols);
@@ -323,7 +323,7 @@ void reorderedGaussSeidel(
       for (LO ii = 0; ii < numRowInds; ++ii) {
         LO i = rowInd[ii];
         for (OffsetType c = 0; c < theNumCols; ++c) {
-          x_temp[c] = Kokkos::Details::ArithTraits<RangeScalar>::zero();
+          x_temp[c] = Kokkos::ArithTraits<RangeScalar>::zero();
         }
         for (OffsetType k = ptr[i]; k < ptr[i + 1]; ++k) {
           const LO j              = ind[k];
@@ -344,7 +344,7 @@ void reorderedGaussSeidel(
       for (LO ii = numRowInds - 1; ii != 0; --ii) {
         LO i = rowInd[ii];
         for (OffsetType c = 0; c < theNumCols; ++c) {
-          x_temp[c] = Kokkos::Details::ArithTraits<RangeScalar>::zero();
+          x_temp[c] = Kokkos::ArithTraits<RangeScalar>::zero();
         }
         for (OffsetType k = ptr[i]; k < ptr[i + 1]; ++k) {
           const LO j              = ind[k];
@@ -362,7 +362,7 @@ void reorderedGaussSeidel(
         const LO ii = 0;
         LO i        = rowInd[ii];
         for (OffsetType c = 0; c < theNumCols; ++c) {
-          x_temp[c] = Kokkos::Details::ArithTraits<RangeScalar>::zero();
+          x_temp[c] = Kokkos::ArithTraits<RangeScalar>::zero();
         }
         for (OffsetType k = ptr[i]; k < ptr[i + 1]; ++k) {
           const LO j              = ind[k];

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
@@ -528,7 +528,7 @@ struct BSR_GEMV_Functor {
   typedef typename AMatrix::non_const_value_type value_type;
   typedef typename Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
-  typedef Kokkos::Details::ArithTraits<value_type> ATV;
+  typedef Kokkos::ArithTraits<value_type> ATV;
 
   //! Nonconst version of the type of column indices in the sparse matrix.
   typedef typename AMatrix::non_const_ordinal_type ordinal_type;
@@ -816,7 +816,7 @@ struct BSR_GEMV_Transpose_Functor {
   typedef typename AMatrix::non_const_value_type value_type;
   typedef typename Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
-  typedef Kokkos::Details::ArithTraits<value_type> ATV;
+  typedef Kokkos::ArithTraits<value_type> ATV;
 
   //! Nonconst version of the type of column indices in the sparse matrix.
   typedef typename AMatrix::non_const_ordinal_type ordinal_type;
@@ -1143,7 +1143,7 @@ struct BSR_GEMM_Functor {
   typedef typename AMatrix::non_const_value_type value_type;
   typedef typename Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
-  typedef Kokkos::Details::ArithTraits<value_type> ATV;
+  typedef Kokkos::ArithTraits<value_type> ATV;
 
   //! Nonconst version of the type of column indices in the sparse matrix.
   typedef typename AMatrix::non_const_ordinal_type ordinal_type;
@@ -1449,7 +1449,7 @@ struct BSR_GEMM_Transpose_Functor {
   typedef typename AMatrix::non_const_value_type value_type;
   typedef typename Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
-  typedef Kokkos::Details::ArithTraits<value_type> ATV;
+  typedef Kokkos::ArithTraits<value_type> ATV;
 
   //! Nonconst version of the type of column indices in the sparse matrix.
   typedef typename AMatrix::non_const_ordinal_type ordinal_type;

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -198,12 +198,9 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
       if (controls.getParameter("algorithm") == "experimental_bsr_tc")
         method = Method::TensorCores;
       // can't use tensor cores for complex
-      if (Kokkos::Details::ArithTraits<YScalar>::is_complex)
-        method = Method::Fallback;
-      if (Kokkos::Details::ArithTraits<XScalar>::is_complex)
-        method = Method::Fallback;
-      if (Kokkos::Details::ArithTraits<AScalar>::is_complex)
-        method = Method::Fallback;
+      if (Kokkos::ArithTraits<YScalar>::is_complex) method = Method::Fallback;
+      if (Kokkos::ArithTraits<XScalar>::is_complex) method = Method::Fallback;
+      if (Kokkos::ArithTraits<AScalar>::is_complex) method = Method::Fallback;
       // can't use tensor cores outside GPU
       if (!KokkosKernels::Impl::kk_is_gpu_exec_space<
               typename AMatrix::execution_space>())

--- a/sparse/impl/KokkosSparse_spmv_impl.hpp
+++ b/sparse/impl/KokkosSparse_spmv_impl.hpp
@@ -58,7 +58,7 @@ struct SPMV_Transpose_Functor {
   typedef typename AMatrix::non_const_value_type value_type;
   typedef typename Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
-  typedef Kokkos::Details::ArithTraits<value_type> ATV;
+  typedef Kokkos::ArithTraits<value_type> ATV;
   typedef typename YVector::non_const_value_type coefficient_type;
   typedef typename YVector::non_const_value_type y_value_type;
 
@@ -118,7 +118,7 @@ struct SPMV_Functor {
   typedef typename AMatrix::non_const_value_type value_type;
   typedef typename Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
-  typedef Kokkos::Details::ArithTraits<value_type> ATV;
+  typedef Kokkos::ArithTraits<value_type> ATV;
 
   const value_type alpha;
   AMatrix m_A;
@@ -515,7 +515,7 @@ static void spmv_beta_transpose(typename YVector::const_value_type& alpha,
     if (execution_space().concurrency() == 1) {
       /// serial impl
       typedef typename AMatrix::non_const_value_type value_type;
-      typedef Kokkos::Details::ArithTraits<value_type> ATV;
+      typedef Kokkos::ArithTraits<value_type> ATV;
       const size_type* KOKKOS_RESTRICT row_map_ptr    = A.graph.row_map.data();
       const ordinal_type* KOKKOS_RESTRICT col_idx_ptr = A.graph.entries.data();
       const value_type* KOKKOS_RESTRICT values_ptr    = A.values.data();
@@ -701,8 +701,7 @@ struct SPMV_MV_Transpose_Functor {
 
     for (ordinal_type iEntry = 0; iEntry < row_length; iEntry++) {
       const A_value_type val =
-          conjugate ? Kokkos::Details::ArithTraits<A_value_type>::conj(
-                          row.value(iEntry))
+          conjugate ? Kokkos::ArithTraits<A_value_type>::conj(row.value(iEntry))
                     : row.value(iEntry);
       const ordinal_type ind = row.colidx(iEntry);
 
@@ -744,10 +743,9 @@ struct SPMV_MV_Transpose_Functor {
               Kokkos::ThreadVectorRange(dev, row_length),
               [&](ordinal_type iEntry) {
                 const A_value_type val =
-                    conjugate
-                        ? Kokkos::Details::ArithTraits<A_value_type>::conj(
-                              row.value(iEntry))
-                        : row.value(iEntry);
+                    conjugate ? Kokkos::ArithTraits<A_value_type>::conj(
+                                    row.value(iEntry))
+                              : row.value(iEntry);
                 const ordinal_type ind = row.colidx(iEntry);
 
                 if (doalpha != 1) {
@@ -821,7 +819,7 @@ struct SPMV_MV_LayoutLeft_Functor {
 #pragma unroll
 #endif
     for (int k = 0; k < UNROLL; ++k) {
-      sum[k] = Kokkos::Details::ArithTraits<y_value_type>::zero();
+      sum[k] = Kokkos::ArithTraits<y_value_type>::zero();
     }
 
     const auto row = m_A.rowConst(iRow);
@@ -834,9 +832,9 @@ struct SPMV_MV_LayoutLeft_Functor {
     Kokkos::parallel_for(
         Kokkos::ThreadVectorRange(dev, row.length), [&](ordinal_type iEntry) {
           const A_value_type val =
-              conjugate ? Kokkos::Details::ArithTraits<A_value_type>::conj(
-                              row.value(iEntry))
-                        : row.value(iEntry);
+              conjugate
+                  ? Kokkos::ArithTraits<A_value_type>::conj(row.value(iEntry))
+                  : row.value(iEntry);
           const ordinal_type ind = row.colidx(iEntry);
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
 #pragma unroll
@@ -911,7 +909,7 @@ struct SPMV_MV_LayoutLeft_Functor {
 #pragma unroll
 #endif
     for (int k = 0; k < UNROLL; ++k) {
-      sum[k] = Kokkos::Details::ArithTraits<y_value_type>::zero();
+      sum[k] = Kokkos::ArithTraits<y_value_type>::zero();
     }
 
     const auto row = m_A.rowConst(iRow);
@@ -923,8 +921,7 @@ struct SPMV_MV_LayoutLeft_Functor {
 
     for (ordinal_type iEntry = 0; iEntry < row.length; iEntry++) {
       const A_value_type val =
-          conjugate ? Kokkos::Details::ArithTraits<A_value_type>::conj(
-                          row.value(iEntry))
+          conjugate ? Kokkos::ArithTraits<A_value_type>::conj(row.value(iEntry))
                     : row.value(iEntry);
       const ordinal_type ind = row.colidx(iEntry);
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
@@ -968,9 +965,9 @@ struct SPMV_MV_LayoutLeft_Functor {
         Kokkos::ThreadVectorRange(dev, row.length),
         [&](ordinal_type iEntry, y_value_type& lsum) {
           const A_value_type val =
-              conjugate ? Kokkos::Details::ArithTraits<A_value_type>::conj(
-                              row.value(iEntry))
-                        : row.value(iEntry);
+              conjugate
+                  ? Kokkos::ArithTraits<A_value_type>::conj(row.value(iEntry))
+                  : row.value(iEntry);
           lsum += val * m_x(row.colidx(iEntry), 0);
         },
         sum);
@@ -1004,8 +1001,7 @@ struct SPMV_MV_LayoutLeft_Functor {
     y_value_type sum = y_value_type();
     for (ordinal_type iEntry = 0; iEntry < row.length; iEntry++) {
       const A_value_type val =
-          conjugate ? Kokkos::Details::ArithTraits<A_value_type>::conj(
-                          row.value(iEntry))
+          conjugate ? Kokkos::ArithTraits<A_value_type>::conj(row.value(iEntry))
                     : row.value(iEntry);
       sum += val * m_x(row.colidx(iEntry), 0);
     }
@@ -1488,7 +1484,7 @@ void spmv_alpha_mv(const char mode[],
                    const typename YVector::non_const_value_type& beta,
                    const YVector& y) {
   typedef typename YVector::non_const_value_type coefficient_type;
-  typedef Kokkos::Details::ArithTraits<coefficient_type> KAT;
+  typedef Kokkos::ArithTraits<coefficient_type> KAT;
 
   if (beta == KAT::zero()) {
     spmv_alpha_beta_mv<AMatrix, XVector, YVector, doalpha, 0>(mode, alpha, A, x,

--- a/sparse/impl/KokkosSparse_spmv_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_spec.hpp
@@ -200,7 +200,7 @@ struct SPMV<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM, false,
                    const char mode[], const coefficient_type& alpha,
                    const AMatrix& A, const XVector& x,
                    const coefficient_type& beta, const YVector& y) {
-    typedef Kokkos::Details::ArithTraits<coefficient_type> KAT;
+    typedef Kokkos::ArithTraits<coefficient_type> KAT;
 
     if (alpha == KAT::zero()) {
       if (beta != KAT::one()) {
@@ -240,7 +240,7 @@ struct SPMV_MV<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM, false, false,
                       const char mode[], const coefficient_type& alpha,
                       const AMatrix& A, const XVector& x,
                       const coefficient_type& beta, const YVector& y) {
-    typedef Kokkos::Details::ArithTraits<coefficient_type> KAT;
+    typedef Kokkos::ArithTraits<coefficient_type> KAT;
 
     if (alpha == KAT::zero()) {
       spmv_alpha_mv<AMatrix, XVector, YVector, 0>(mode, alpha, A, x, beta, y);

--- a/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
+++ b/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
@@ -37,7 +37,7 @@ struct SPMV_Struct_Transpose_Functor {
   typedef typename AMatrix::non_const_value_type value_type;
   typedef typename Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
-  typedef Kokkos::Details::ArithTraits<value_type> ATV;
+  typedef Kokkos::ArithTraits<value_type> ATV;
   typedef typename YVector::non_const_value_type coefficient_type;
   typedef typename YVector::non_const_value_type y_value_type;
 
@@ -102,7 +102,7 @@ struct SPMV_Struct_Functor {
   typedef typename KokkosSparse::SparseRowViewConst<AMatrix> row_view_const;
   typedef typename Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
-  typedef Kokkos::Details::ArithTraits<value_type> ATV;
+  typedef Kokkos::ArithTraits<value_type> ATV;
   typedef Kokkos::View<ordinal_type*, scratch_space,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       shared_ordinal_1d;
@@ -979,10 +979,9 @@ struct SPMV_MV_Struct_Transpose_Functor {
               Kokkos::ThreadVectorRange(dev, row_length),
               [&](ordinal_type iEntry) {
                 const A_value_type val =
-                    conjugate
-                        ? Kokkos::Details::ArithTraits<A_value_type>::conj(
-                              row.value(iEntry))
-                        : row.value(iEntry);
+                    conjugate ? Kokkos::ArithTraits<A_value_type>::conj(
+                                    row.value(iEntry))
+                              : row.value(iEntry);
                 const ordinal_type ind = row.colidx(iEntry);
 
                 if (doalpha != 1) {
@@ -1054,7 +1053,7 @@ struct SPMV_MV_Struct_LayoutLeft_Functor {
 #pragma unroll
 #endif
     for (int k = 0; k < UNROLL; ++k) {
-      sum[k] = Kokkos::Details::ArithTraits<y_value_type>::zero();
+      sum[k] = Kokkos::ArithTraits<y_value_type>::zero();
     }
 
     const auto row = m_A.rowConst(iRow);
@@ -1062,9 +1061,9 @@ struct SPMV_MV_Struct_LayoutLeft_Functor {
     Kokkos::parallel_for(
         Kokkos::ThreadVectorRange(dev, row.length), [&](ordinal_type iEntry) {
           const A_value_type val =
-              conjugate ? Kokkos::Details::ArithTraits<A_value_type>::conj(
-                              row.value(iEntry))
-                        : row.value(iEntry);
+              conjugate
+                  ? Kokkos::ArithTraits<A_value_type>::conj(row.value(iEntry))
+                  : row.value(iEntry);
           const ordinal_type ind = row.colidx(iEntry);
 
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
@@ -1139,9 +1138,9 @@ struct SPMV_MV_Struct_LayoutLeft_Functor {
         Kokkos::ThreadVectorRange(dev, row.length),
         [&](ordinal_type iEntry, y_value_type& lsum) {
           const A_value_type val =
-              conjugate ? Kokkos::Details::ArithTraits<A_value_type>::conj(
-                              row.value(iEntry))
-                        : row.value(iEntry);
+              conjugate
+                  ? Kokkos::ArithTraits<A_value_type>::conj(row.value(iEntry))
+                  : row.value(iEntry);
           lsum += val * m_x(row.colidx(iEntry), 0);
         },
         sum);
@@ -1465,7 +1464,7 @@ void spmv_alpha_mv_struct(const char mode[],
                           const typename YVector::non_const_value_type& beta,
                           const YVector& y) {
   typedef typename YVector::non_const_value_type coefficient_type;
-  typedef Kokkos::Details::ArithTraits<coefficient_type> KAT;
+  typedef Kokkos::ArithTraits<coefficient_type> KAT;
 
   if (beta == KAT::zero()) {
     spmv_alpha_beta_mv_struct<AMatrix, XVector, YVector, doalpha, 0>(

--- a/sparse/impl/KokkosSparse_spmv_struct_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_struct_spec.hpp
@@ -201,9 +201,9 @@ struct SPMV_STRUCT<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM, false,
                          Kokkos::HostSpace>& structure,
       const coefficient_type& alpha, const AMatrix& A, const XVector& x,
       const coefficient_type& beta, const YVector& y) {
-    typedef Kokkos::Details::ArithTraits<coefficient_type> KAT;
+    typedef Kokkos::ArithTraits<coefficient_type> KAT;
 
-    typedef Kokkos::Details::ArithTraits<coefficient_type> KAT;
+    typedef Kokkos::ArithTraits<coefficient_type> KAT;
 
     if (alpha == KAT::zero()) {
       if (beta != KAT::one()) {
@@ -242,7 +242,7 @@ struct SPMV_MV_STRUCT<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM, false,
   static void spmv_mv_struct(const char mode[], const coefficient_type& alpha,
                              const AMatrix& A, const XVector& x,
                              const coefficient_type& beta, const YVector& y) {
-    typedef Kokkos::Details::ArithTraits<coefficient_type> KAT;
+    typedef Kokkos::ArithTraits<coefficient_type> KAT;
 
     if (alpha == KAT::zero()) {
       spmv_alpha_mv_struct<AMatrix, XVector, YVector, 0>(mode, alpha, A, x,

--- a/sparse/impl/KokkosSparse_trsv_impl.hpp
+++ b/sparse/impl/KokkosSparse_trsv_impl.hpp
@@ -72,7 +72,7 @@ void lowerTriSolveCsr(RangeMultiVectorType X, const CrsMatrixType& A,
       local_ordinal_type;
   typedef typename CrsMatrixType::values_type::non_const_value_type
       matrix_scalar_type;
-  typedef Kokkos::Details::ArithTraits<matrix_scalar_type> STS;
+  typedef Kokkos::ArithTraits<matrix_scalar_type> STS;
 
   const local_ordinal_type numRows = A.numRows();
   // const local_ordinal_type numCols = A.numCols ();
@@ -190,7 +190,7 @@ void upperTriSolveCsr(RangeMultiVectorType X, const CrsMatrixType& A,
   typename CrsMatrixType::row_map_type ptr = A.graph.row_map;
   typename CrsMatrixType::index_type ind   = A.graph.entries;
   typename CrsMatrixType::values_type val  = A.values;
-  typedef Kokkos::Details::ArithTraits<matrix_scalar_type> STS;
+  typedef Kokkos::ArithTraits<matrix_scalar_type> STS;
 
   // If local_ordinal_type is unsigned and numRows is 0, the loop
   // below will have entirely the wrong number of iterations.
@@ -425,7 +425,7 @@ void upperTriSolveCscUnitDiagConj(RangeMultiVectorType X,
       local_ordinal_type;
   typedef typename CrsMatrixType::values_type::non_const_value_type
       matrix_scalar_type;
-  typedef Kokkos::Details::ArithTraits<matrix_scalar_type> STS;
+  typedef Kokkos::ArithTraits<matrix_scalar_type> STS;
 
   const local_ordinal_type numRows         = A.numRows();
   const local_ordinal_type numCols         = A.numCols();
@@ -486,7 +486,7 @@ void upperTriSolveCscConj(RangeMultiVectorType X, const CrsMatrixType& A,
       local_ordinal_type;
   typedef typename CrsMatrixType::values_type::non_const_value_type
       matrix_scalar_type;
-  typedef Kokkos::Details::ArithTraits<matrix_scalar_type> STS;
+  typedef Kokkos::ArithTraits<matrix_scalar_type> STS;
 
   const local_ordinal_type numRows         = A.numRows();
   const local_ordinal_type numCols         = A.numCols();
@@ -600,7 +600,7 @@ void lowerTriSolveCscUnitDiagConj(RangeMultiVectorType X,
       local_ordinal_type;
   typedef typename CrsMatrixType::values_type::non_const_value_type
       matrix_scalar_type;
-  typedef Kokkos::Details::ArithTraits<matrix_scalar_type> STS;
+  typedef Kokkos::ArithTraits<matrix_scalar_type> STS;
 
   const local_ordinal_type numRows         = A.numRows();
   const local_ordinal_type numCols         = A.numCols();
@@ -638,7 +638,7 @@ void lowerTriSolveCscConj(RangeMultiVectorType X, const CrsMatrixType& A,
       local_ordinal_type;
   typedef typename CrsMatrixType::values_type::non_const_value_type
       matrix_scalar_type;
-  typedef Kokkos::Details::ArithTraits<matrix_scalar_type> STS;
+  typedef Kokkos::ArithTraits<matrix_scalar_type> STS;
 
   const local_ordinal_type numRows         = A.numRows();
   const local_ordinal_type numCols         = A.numCols();

--- a/sparse/impl/KokkosSparse_twostage_gauss_seidel_impl.hpp
+++ b/sparse/impl/KokkosSparse_twostage_gauss_seidel_impl.hpp
@@ -82,7 +82,7 @@ class TwostageGaussSeidel {
   using internal_vector_view_t =
       typename TwoStageGaussSeidelHandleType::vector_view_t;
 
-  using ST    = Kokkos::Details::ArithTraits<scalar_t>;
+  using ST    = Kokkos::ArithTraits<scalar_t>;
   using mag_t = typename ST::mag_type;
 
  private:
@@ -407,7 +407,7 @@ class TwostageGaussSeidel {
     // functor for storing both valuesL & valuesU (with parallel_for)
     KOKKOS_INLINE_FUNCTION
     void operator()(const Tag_valuesLU &, const ordinal_t i) const {
-      const_scalar_t one = Kokkos::Details::ArithTraits<scalar_t>::one();
+      const_scalar_t one = Kokkos::ArithTraits<scalar_t>::one();
       ordinal_t nnzL     = row_map(i);
       ordinal_t nnzU     = row_map2(i);
       ordinal_t nnzLa    = 0;
@@ -851,8 +851,8 @@ class TwostageGaussSeidel {
              bool init_zero_x_vector = false, int numIter = 1,
              scalar_t omega = ST::one(), bool apply_forward = true,
              bool apply_backward = true, bool /*update_y_vector*/ = true) {
-    const_scalar_t one  = Kokkos::Details::ArithTraits<scalar_t>::one();
-    const_scalar_t zero = Kokkos::Details::ArithTraits<scalar_t>::zero();
+    const_scalar_t one  = Kokkos::ArithTraits<scalar_t>::one();
+    const_scalar_t zero = Kokkos::ArithTraits<scalar_t>::zero();
 #ifdef KOKKOSSPARSE_IMPL_TIME_TWOSTAGE_GS
     double tic;
     Kokkos::Timer timer;

--- a/sparse/src/KokkosSparse_BsrMatrix.hpp
+++ b/sparse/src/KokkosSparse_BsrMatrix.hpp
@@ -156,12 +156,12 @@ struct BsrRowView {
   }
 
   /// \brief Return offset into colidx_ for the requested block idx
-  ///        If none found, return Kokkos::Details::ArithTraits::max
+  ///        If none found, return Kokkos::ArithTraits::max
   /// \param idx_to_match [in] local block idx within block-row
   KOKKOS_INLINE_FUNCTION
   ordinal_type findRelBlockOffset(const ordinal_type idx_to_match,
                                   bool /*is_sorted*/ = false) const {
-    ordinal_type offset = Kokkos::Details::ArithTraits<ordinal_type>::max();
+    ordinal_type offset = Kokkos::ArithTraits<ordinal_type>::max();
     for (ordinal_type blk_offset = 0; blk_offset < length; ++blk_offset) {
       ordinal_type idx = colidx_[blk_offset];
       if (idx == idx_to_match) {
@@ -292,14 +292,14 @@ struct BsrRowViewConst {
   }
 
   /// \brief Return offset into colidx_ for the requested block idx
-  ///        If none found, return Kokkos::Details::ArithTraits::max
+  ///        If none found, return Kokkos::ArithTraits::max
   /// \param idx_to_match [in] local block idx within block-row
   KOKKOS_INLINE_FUNCTION
   ordinal_type findRelBlockOffset(const ordinal_type& idx_to_match,
                                   bool /*is_sorted*/ = false) const {
     typedef typename std::remove_cv<ordinal_type>::type non_const_ordinal_type;
     non_const_ordinal_type offset =
-        Kokkos::Details::ArithTraits<non_const_ordinal_type>::max();
+        Kokkos::ArithTraits<non_const_ordinal_type>::max();
     for (non_const_ordinal_type blk_offset = 0; blk_offset < length;
          ++blk_offset) {
       ordinal_type idx = colidx_[blk_offset];
@@ -979,7 +979,7 @@ class BsrMatrix {
       // + 1] (not global offset) colidx_ and values_ are already offset to the
       // beginning of blockrow rowi
       auto blk_offset = row_view.findRelBlockOffset(cols[i], is_sorted);
-      if (blk_offset != Kokkos::Details::ArithTraits<ordinal_type>::max()) {
+      if (blk_offset != Kokkos::ArithTraits<ordinal_type>::max()) {
         ordinal_type offset_into_vals =
             i * block_size *
             block_size;  // stride == 1 assumed between elements

--- a/sparse/src/KokkosSparse_IOUtils.hpp
+++ b/sparse/src/KokkosSparse_IOUtils.hpp
@@ -177,8 +177,7 @@ void kk_diagonally_dominant_sparseMatrix_generate(
           entriesInRow.insert(pos);
           colInd[k] = pos;
           values[k] = 100.0 * rand() / RAND_MAX - 50.0;
-          total_values +=
-              Kokkos::Details::ArithTraits<ScalarType>::abs(values[k]);
+          total_values += Kokkos::ArithTraits<ScalarType>::abs(values[k]);
           break;
         }
       }

--- a/sparse/unit_test/Test_Sparse_Utils.hpp
+++ b/sparse/unit_test/Test_Sparse_Utils.hpp
@@ -118,7 +118,7 @@ bool is_same_matrix(crsMat_t output_mat_actual, crsMat_t output_mat_reference) {
     return false;
   }
 
-  typedef typename Kokkos::Details::ArithTraits<
+  typedef typename Kokkos::ArithTraits<
       typename scalar_view_t::non_const_value_type>::mag_type eps_type;
   eps_type eps = std::is_same<eps_type, float>::value ? 3.7e-3 : 1e-7;
 

--- a/sparse/unit_test/Test_Sparse_block_gauss_seidel.hpp
+++ b/sparse/unit_test/Test_Sparse_block_gauss_seidel.hpp
@@ -75,7 +75,7 @@ int run_block_gauss_seidel_1(
     GSApplyType apply_type = Test::symmetric, bool skip_symbolic = false,
     bool skip_numeric = false, size_t shmem_size = 32128,
     typename mtx_t::value_type omega =
-        Kokkos::Details::ArithTraits<typename mtx_t::value_type>::one()) {
+        Kokkos::ArithTraits<typename mtx_t::value_type>::one()) {
   typedef typename mtx_t::StaticCrsGraphType graph_t;
   typedef typename graph_t::row_map_type lno_view_t;
   typedef typename graph_t::entries_type lno_nnz_view_t;
@@ -156,7 +156,7 @@ void test_block_gauss_seidel_rank1(lno_t numRows, size_type nnz,
       lno_view_t;
   typedef typename crsMat_t::StaticCrsGraphType::entries_type::non_const_type
       lno_nnz_view_t;
-  typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;
+  typedef typename Kokkos::ArithTraits<scalar_t>::mag_type mag_t;
 
   lno_t numCols = numRows;
 
@@ -243,7 +243,7 @@ void test_block_gauss_seidel_rank2(lno_t numRows, size_type nnz,
   typedef typename crsMat_t::StaticCrsGraphType::entries_type::non_const_type
       lno_nnz_view_t;
   typedef Kokkos::View<scalar_t**, default_layout, device> scalar_view2d_t;
-  typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;
+  typedef typename Kokkos::ArithTraits<scalar_t>::mag_type mag_t;
 
   lno_t numCols = numRows;
 
@@ -289,8 +289,8 @@ void test_block_gauss_seidel_rank2(lno_t numRows, size_type nnz,
     for (lno_t j = 0; j < nv; j++) {
       sum += solution_host(j, i) * solution_host(j, i);
     }
-    initial_norms[i] = Kokkos::Details::ArithTraits<mag_t>::sqrt(
-        Kokkos::Details::ArithTraits<scalar_t>::abs(sum));
+    initial_norms[i] = Kokkos::ArithTraits<mag_t>::sqrt(
+        Kokkos::ArithTraits<scalar_t>::abs(sum));
   }
 
   for (const auto gs_algorithm : params.gs_algorithms) {
@@ -322,8 +322,8 @@ void test_block_gauss_seidel_rank2(lno_t numRows, size_type nnz,
                 scalar_t diff = x_host(r, c) - solution_host(r, c);
                 sum += diff * diff;
               }
-              mag_t result_res = Kokkos::Details::ArithTraits<mag_t>::sqrt(
-                  Kokkos::Details::ArithTraits<scalar_t>::abs(sum));
+              mag_t result_res = Kokkos::ArithTraits<mag_t>::sqrt(
+                  Kokkos::ArithTraits<scalar_t>::abs(sum));
               EXPECT_LT(result_res, params.tolerance * initial_norms[c]);
             }
           }

--- a/sparse/unit_test/Test_Sparse_bspgemm.hpp
+++ b/sparse/unit_test/Test_Sparse_bspgemm.hpp
@@ -123,7 +123,7 @@ bool is_same_block_matrix(bsrMat_t output_mat_actual,
     return false;
   }
 
-  typedef typename Kokkos::Details::ArithTraits<
+  typedef typename Kokkos::ArithTraits<
       typename scalar_view_t::non_const_value_type>::mag_type eps_type;
   eps_type eps = std::is_same<eps_type, float>::value ? 3e-2 : 5e-7;
 

--- a/sparse/unit_test/Test_Sparse_gauss_seidel.hpp
+++ b/sparse/unit_test/Test_Sparse_gauss_seidel.hpp
@@ -153,7 +153,7 @@ void test_gauss_seidel_rank1(lno_t numRows, size_type nnz, lno_t bandwidth,
       typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>
           crsMat_t;
   typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
-  typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;
+  typedef typename Kokkos::ArithTraits<scalar_t>::mag_type mag_t;
   srand(245);
   lno_t numCols = numRows;
   crsMat_t input_mat =
@@ -177,8 +177,8 @@ void test_gauss_seidel_rank1(lno_t numRows, size_type nnz, lno_t bandwidth,
   int apply_count = 3;  // test symmetric, forward, backward
   scalar_view_t x_vector(
       Kokkos::view_alloc(Kokkos::WithoutInitializing, "x vector"), nv);
-  const scalar_t one  = Kokkos::Details::ArithTraits<scalar_t>::one();
-  const scalar_t zero = Kokkos::Details::ArithTraits<scalar_t>::zero();
+  const scalar_t one  = Kokkos::ArithTraits<scalar_t>::one();
+  const scalar_t zero = Kokkos::ArithTraits<scalar_t>::zero();
   //*** Point-coloring version ****
   for (int apply_type = 0; apply_type < apply_count; ++apply_type) {
     Kokkos::Timer timer1;
@@ -242,7 +242,7 @@ void test_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth,
   typedef Kokkos::View<scalar_t**, default_layout, device> scalar_view2d_t;
   typedef Kokkos::View<scalar_t**, default_layout, Kokkos::HostSpace>
       host_scalar_view2d_t;
-  typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;
+  typedef typename Kokkos::ArithTraits<scalar_t>::mag_type mag_t;
 
   lno_t numCols = numRows;
   crsMat_t input_mat =
@@ -270,11 +270,11 @@ void test_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth,
     for (lno_t j = 0; j < nv; j++) {
       sum += solution_x(j, i) * solution_x(j, i);
     }
-    initial_norms[i] = Kokkos::Details::ArithTraits<mag_t>::sqrt(
-        Kokkos::Details::ArithTraits<scalar_t>::abs(sum));
+    initial_norms[i] = Kokkos::ArithTraits<mag_t>::sqrt(
+        Kokkos::ArithTraits<scalar_t>::abs(sum));
   }
   int apply_count     = 3;  // test symmetric, forward, backward
-  const scalar_t zero = Kokkos::Details::ArithTraits<scalar_t>::zero();
+  const scalar_t zero = Kokkos::ArithTraits<scalar_t>::zero();
   //*** Point-coloring version ****
   for (int apply_type = 0; apply_type < apply_count; ++apply_type) {
     Kokkos::Timer timer1;
@@ -289,8 +289,8 @@ void test_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth,
         scalar_t diff = x_host(j, i) - solution_x(j, i);
         diffDot += diff * diff;
       }
-      mag_t res = Kokkos::Details::ArithTraits<mag_t>::sqrt(
-          Kokkos::Details::ArithTraits<scalar_t>::abs(diffDot));
+      mag_t res = Kokkos::ArithTraits<mag_t>::sqrt(
+          Kokkos::ArithTraits<scalar_t>::abs(diffDot));
       EXPECT_LT(res, initial_norms[i]);
     }
   }
@@ -312,8 +312,8 @@ void test_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth,
             scalar_t diff = x_host(j, i) - solution_x(j, i);
             diffDot += diff * diff;
           }
-          mag_t res = Kokkos::Details::ArithTraits<mag_t>::sqrt(
-              Kokkos::Details::ArithTraits<scalar_t>::abs(diffDot));
+          mag_t res = Kokkos::ArithTraits<mag_t>::sqrt(
+              Kokkos::ArithTraits<scalar_t>::abs(diffDot));
           EXPECT_LT(res, initial_norms[i]);
         }
       }
@@ -332,8 +332,8 @@ void test_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth,
         scalar_t diff = x_host(j, i) - solution_x(j, i);
         diffDot += diff * diff;
       }
-      mag_t res = Kokkos::Details::ArithTraits<mag_t>::sqrt(
-          Kokkos::Details::ArithTraits<scalar_t>::abs(diffDot));
+      mag_t res = Kokkos::ArithTraits<mag_t>::sqrt(
+          Kokkos::ArithTraits<scalar_t>::abs(diffDot));
       EXPECT_LT(res, initial_norms[i]);
     }
   }
@@ -350,8 +350,8 @@ void test_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth,
         scalar_t diff = x_host(j, i) - solution_x(j, i);
         diffDot += diff * diff;
       }
-      mag_t res = Kokkos::Details::ArithTraits<mag_t>::sqrt(
-          Kokkos::Details::ArithTraits<scalar_t>::abs(diffDot));
+      mag_t res = Kokkos::ArithTraits<mag_t>::sqrt(
+          Kokkos::ArithTraits<scalar_t>::abs(diffDot));
       EXPECT_LT(res, initial_norms[i]);
     }
   }
@@ -361,8 +361,8 @@ template <typename scalar_t, typename lno_t, typename size_type,
           typename device>
 void test_sequential_sor(lno_t numRows, size_type nnz, lno_t bandwidth,
                          lno_t row_size_variance) {
-  const scalar_t zero = Kokkos::Details::ArithTraits<scalar_t>::zero();
-  const scalar_t one  = Kokkos::Details::ArithTraits<scalar_t>::one();
+  const scalar_t zero = Kokkos::ArithTraits<scalar_t>::zero();
+  const scalar_t one  = Kokkos::ArithTraits<scalar_t>::one();
   srand(245);
   typedef typename device::execution_space exec_space;
   typedef
@@ -419,10 +419,9 @@ void test_sequential_sor(lno_t numRows, size_type nnz, lno_t bandwidth,
   // Copy solution back
   Kokkos::deep_copy(x, x_host);
   // Check against gold solution
-  scalar_t xSq     = KokkosBlas::dot(x, x);
-  scalar_t solnDot = KokkosBlas::dot(x, xgold);
-  double scaledSolutionDot =
-      Kokkos::Details::ArithTraits<scalar_t>::abs(solnDot / xSq);
+  scalar_t xSq             = KokkosBlas::dot(x, x);
+  scalar_t solnDot         = KokkosBlas::dot(x, xgold);
+  double scaledSolutionDot = Kokkos::ArithTraits<scalar_t>::abs(solnDot / xSq);
   EXPECT_TRUE(0.99 < scaledSolutionDot);
 }
 
@@ -533,7 +532,7 @@ void test_gauss_seidel_long_rows(lno_t numRows, lno_t numLongRows,
   typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
   typedef typename crsMat_t::index_type::non_const_type entries_view_t;
   typedef typename crsMat_t::row_map_type::non_const_type rowmap_view_t;
-  typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;
+  typedef typename Kokkos::ArithTraits<scalar_t>::mag_type mag_t;
   const scalar_t one = Kokkos::ArithTraits<scalar_t>::one();
   srand(245);
   std::vector<size_type> rowmap = {0};
@@ -630,7 +629,7 @@ void test_gauss_seidel_custom_coloring(lno_t numRows, lno_t nnzPerRow) {
       typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>
           crsMat_t;
   typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
-  typedef typename Kokkos::Details::ArithTraits<scalar_t>::mag_type mag_t;
+  typedef typename Kokkos::ArithTraits<scalar_t>::mag_type mag_t;
   const scalar_t one = Kokkos::ArithTraits<scalar_t>::one();
   size_type nnz      = nnzPerRow * numRows;
   crsMat_t input_mat =

--- a/sparse/unit_test/Test_Sparse_replaceSumInto.hpp
+++ b/sparse/unit_test/Test_Sparse_replaceSumInto.hpp
@@ -50,7 +50,7 @@ class ModifyEvenNumberedRows {
       ordinal_type cols[1];
       value_type vals[1];
 
-      const value_type ONE   = Kokkos::Details::ArithTraits<value_type>::one();
+      const value_type ONE   = Kokkos::ArithTraits<value_type>::one();
       const value_type THREE = ONE + ONE + ONE;
 
       cols[0] = lclRow;
@@ -97,7 +97,7 @@ bool checkWhetherEvenNumberedRowsWereModified(const CrsMatrixType& A,
   typedef typename CrsMatrixType::value_type SC;
   typedef typename CrsMatrixType::ordinal_type LO;
 
-  const SC ONE   = Kokkos::Details::ArithTraits<SC>::one();
+  const SC ONE   = Kokkos::ArithTraits<SC>::one();
   const SC TWO   = ONE + ONE;
   const SC THREE = ONE + ONE + ONE;
 
@@ -135,7 +135,7 @@ void testOneCase(bool& /*success*/,
                  // Teuchos::FancyOStream& out,
                  std::ostream& out, const CrsMatrixType& A, const bool replace,
                  const bool sorted, const bool atomic) {
-  using Kokkos::Details::ArithTraits;
+  using Kokkos::ArithTraits;
   typedef typename CrsMatrixType::value_type value_type;
 
   // Teuchos::OSTab tab0 (out);

--- a/sparse/unit_test/Test_Sparse_replaceSumIntoLonger.hpp
+++ b/sparse/unit_test/Test_Sparse_replaceSumIntoLonger.hpp
@@ -47,7 +47,7 @@ class ModifyEntries {
 
   KOKKOS_FUNCTION void operator()(const ordinal_type& lclRow,
                                   ordinal_type& numModified) const {
-    typedef Kokkos::Details::ArithTraits<scalar_type> KAT;
+    typedef Kokkos::ArithTraits<scalar_type> KAT;
     typedef typename KAT::mag_type mag_type;
     const scalar_type ONE = KAT::one();
 
@@ -171,7 +171,7 @@ void checkWhetherEntriesWereModified(
   // using Teuchos::RCP;
   typedef typename CrsMatrixType::value_type value_type;
   typedef typename CrsMatrixType::ordinal_type ordinal_type;
-  typedef Kokkos::Details::ArithTraits<value_type> KAT;
+  typedef Kokkos::ArithTraits<value_type> KAT;
 
   // If debug is false, we capture all output in an
   // std::ostringstream, and don't print it unless the test fails
@@ -281,7 +281,7 @@ void testOneCaseImpl(bool& /*success*/, std::ostream& out,
 
     // Restore original values.
     auto val_h            = Kokkos::create_mirror_view(A.values);
-    const scalar_type ONE = Kokkos::Details::ArithTraits<scalar_type>::one();
+    const scalar_type ONE = Kokkos::ArithTraits<scalar_type>::one();
     scalar_type curVal    = ONE;
     for (ordinal_type k = 0; k < A.numCols(); ++k, curVal += ONE) {
       val_h[k] = curVal;
@@ -388,7 +388,7 @@ void testAllSizes(bool& success,
   typedef typename matrix_type::value_type value_type;
   typedef typename matrix_type::ordinal_type ordinal_type;
   typedef typename matrix_type::size_type size_type;
-  const value_type ONE = Kokkos::Details::ArithTraits<value_type>::one();
+  const value_type ONE = Kokkos::ArithTraits<value_type>::one();
 
   // Teuchos::OSTab tab0 (out);
   out << "maxNumEnt: " << maxNumEnt << endl;

--- a/sparse/unit_test/Test_Sparse_spgemm_jacobi.hpp
+++ b/sparse/unit_test/Test_Sparse_spgemm_jacobi.hpp
@@ -165,7 +165,7 @@ bool is_same_mat(crsMat_t output_mat1, crsMat_t output_mat2) {
     return false;
   }
 
-  typedef typename Kokkos::Details::ArithTraits<
+  typedef typename Kokkos::ArithTraits<
       typename scalar_view_t::non_const_value_type>::mag_type eps_type;
   eps_type eps = std::is_same<eps_type, float>::value ? 2 * 1e-3 : 1e-7;
 

--- a/sparse/unit_test/Test_Sparse_spiluk.hpp
+++ b/sparse/unit_test/Test_Sparse_spiluk.hpp
@@ -50,7 +50,7 @@ void run_test_spiluk() {
   typedef Kokkos::View<size_type*, device> RowMapType;
   typedef Kokkos::View<lno_t*, device> EntriesType;
   typedef Kokkos::View<scalar_t*, device> ValuesType;
-  typedef Kokkos::Details::ArithTraits<scalar_t> AT;
+  typedef Kokkos::ArithTraits<scalar_t> AT;
 
   const size_type nrows = 9;
   const size_type nnz   = 21;

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -106,8 +106,8 @@ struct multivector_layout_adapter<ViewType, false> {
 template <class Scalar1, class Scalar2, class Scalar3>
 void EXPECT_NEAR_KK(Scalar1 val1, Scalar2 val2, Scalar3 tol,
                     std::string msg = "") {
-  typedef Kokkos::Details::ArithTraits<Scalar1> AT1;
-  typedef Kokkos::Details::ArithTraits<Scalar3> AT3;
+  typedef Kokkos::ArithTraits<Scalar1> AT1;
+  typedef Kokkos::ArithTraits<Scalar3> AT3;
   EXPECT_LE((double)AT1::abs(val1 - val2), (double)AT3::abs(tol)) << msg;
 }
 
@@ -116,8 +116,8 @@ void EXPECT_NEAR_KK_REL(Scalar1 val1, Scalar2 val2, Scalar3 tol,
                         std::string msg = "") {
   typedef typename std::remove_reference<decltype(val1)>::type hv1_type;
   typedef typename std::remove_reference<decltype(val2)>::type hv2_type;
-  const auto ahv1 = Kokkos::Details::ArithTraits<hv1_type>::abs(val1);
-  const auto ahv2 = Kokkos::Details::ArithTraits<hv2_type>::abs(val2);
+  const auto ahv1 = Kokkos::ArithTraits<hv1_type>::abs(val1);
+  const auto ahv2 = Kokkos::ArithTraits<hv2_type>::abs(val2);
   EXPECT_NEAR_KK(val1, val2, tol * Kokkos::max(ahv1, ahv2), msg);
 }
 
@@ -205,7 +205,7 @@ struct SharedVanillaGEMM {
   typedef Kokkos::View<ScalarB*, Kokkos::LayoutStride,
                        typename ViewTypeB::device_type>
       SubviewTypeB;
-  typedef Kokkos::Details::ArithTraits<ScalarC> APT;
+  typedef Kokkos::ArithTraits<ScalarC> APT;
   typedef typename APT::mag_type mag_type;
   ScalarA alpha;
   ScalarC beta;


### PR DESCRIPTION
Use Kokkos::ArithTraits instead.

Aside from warnings and places with custom ArithTraits specializations, this is backwards compatible.