### PR TITLE
Include `google/benchmark` lib version in benchmark output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,9 @@ IF (NOT KOKKOSKERNELS_HAS_TRILINOS)
     include_directories(tpls/rajaperf/src)
     set(KokkosKernels_ENABLE_PERFTESTS ON CACHE BOOL "Whether to build tests including Perfsuite. Default: OFF" FORCE)
   ENDIF()
+  IF(KokkosKernels_ENABLE_BENCHMARK)
+    INCLUDE(cmake/kokkoskernels_benchmarks.cmake)
+  ENDIF()
 ENDIF ()
 
 KOKKOSKERNELS_ADD_OPTION(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,11 +324,11 @@ ELSE()
     ENDFOREACH()
     TARGET_INCLUDE_DIRECTORIES(kokkoskernels PUBLIC
       $<INSTALL_INTERFACE:${KOKKOSKERNELS_HEADER_INSTALL_DIR}>)
-  ENDIF()
 
-  IF(NOT KOKKOSKERNELS_HAS_TRILINOS)
-    INCLUDE(cmake/kokkoskernels_git_info.cmake)
-    check_git_setup()
+    IF(KokkosKernels_ENABLE_BENCHMARK)
+      INCLUDE(cmake/kokkoskernels_version_info.cmake)
+      check_version_info()
+    ENDIF()
   ENDIF()
 
   # FIXME_SYCL waiting for compiler support

--- a/cmake/KokkosKernels_Version_Info.hpp.in
+++ b/cmake/KokkosKernels_Version_Info.hpp.in
@@ -14,8 +14,8 @@
 //
 //@HEADER
 
-#ifndef KOKKOSKERNELS_GIT_VERSION_INFO_H
-#define KOKKOSKERNELS_GIT_VERSION_INFO_H
+#ifndef KOKKOSKERNELS_VERSION_INFO_HPP
+#define KOKKOSKERNELS_VERSION_INFO_HPP
 
 #include <string_view>
 
@@ -27,9 +27,10 @@ constexpr std::string_view GIT_COMMIT_HASH  = "@GIT_COMMIT_HASH@";
 constexpr std::string_view GIT_CLEAN_STATUS = "@GIT_CLEAN_STATUS@";
 constexpr std::string_view GIT_COMMIT_DESCRIPTION =
     R"message(@GIT_COMMIT_DESCRIPTION@)message";
-constexpr std::string_view GIT_COMMIT_DATE = "@GIT_COMMIT_DATE@";
+constexpr std::string_view GIT_COMMIT_DATE   = "@GIT_COMMIT_DATE@";
+constexpr std::string_view BENCHMARK_VERSION = "@BENCHMARK_VERSION@";
 
 }  // namespace Impl
 }  // namespace KokkosKernels
 
-#endif
+#endif  // KOKKOSKERNELS_VERSION_INFO_HPP

--- a/cmake/kokkoskernels_benchmarks.cmake
+++ b/cmake/kokkoskernels_benchmarks.cmake
@@ -1,0 +1,84 @@
+IF(KOKKOSKERNELS_HAS_TRILINOS)
+    MESSAGE(
+        FATAL_ERROR
+        "Benchmarks are not supported when building as part of Trilinos")
+ENDIF()
+
+FIND_PACKAGE(benchmark QUIET)
+
+IF(benchmark_FOUND)
+    MESSAGE(STATUS "Using google benchmark found in ${benchmark_DIR}")
+ELSE()
+    MESSAGE(STATUS "No installed google benchmark found, fetching from GitHub")
+    INCLUDE(FetchContent)
+    SET(BENCHMARK_ENABLE_TESTING OFF)
+
+    LIST(APPEND CMAKE_MESSAGE_INDENT "[benchmark] ")
+
+    # Note: recent bug (google/benchmark#1441) is preventing us from using
+    # the latest benchmark release.
+    FetchContent_Declare(
+        googlebenchmark
+        URL https://github.com/google/benchmark/archive/refs/tags/v1.6.2.tar.gz
+        URL_HASH MD5=14d14849e075af116143a161bc3b927b
+    )
+    FetchContent_MakeAvailable(googlebenchmark)
+    LIST(POP_BACK CMAKE_MESSAGE_INDENT)
+
+    TARGET_COMPILE_OPTIONS(benchmark PRIVATE -w)
+    TARGET_COMPILE_OPTIONS(benchmark_main PRIVATE -w)
+ENDIF()
+
+KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
+
+FUNCTION(KOKKOSKERNELS_ADD_BENCHMARK NAME)
+    CMAKE_PARSE_ARGUMENTS(
+        BENCHMARK
+        ""
+        ""
+        "SOURCES"
+        ${ARGN}
+    )
+
+    IF(DEFINED BENCHMARK_UNPARSED_ARGUMENTS)
+        MESSAGE(
+            WARNING
+            "Unexpected arguments when adding a benchmark: "
+            ${BENCHMARK_UNPARSED_ARGUMENTS}
+        )
+    ENDIF()
+
+    SET(BENCHMARK_NAME ${PACKAGE_NAME}_${NAME})
+
+    ADD_EXECUTABLE(
+        ${BENCHMARK_NAME}
+        ${CMAKE_SOURCE_DIR}/perf_test/BenchmarkMain.cpp ${BENCHMARK_SOURCES}
+    )
+    TARGET_LINK_LIBRARIES(
+        ${BENCHMARK_NAME}
+        PRIVATE benchmark::benchmark Kokkos::kokkoskernels
+    )
+    TARGET_INCLUDE_DIRECTORIES(
+        ${BENCHMARK_NAME}
+        SYSTEM PRIVATE ${benchmark_SOURCE_DIR}/include
+    )
+
+    FOREACH(SOURCE_FILE ${BENCHMARK_SOURCES})
+        SET_SOURCE_FILES_PROPERTIES(
+            ${SOURCE_FILE}
+            PROPERTIES LANGUAGE CXX
+        )
+    ENDFOREACH()
+
+    STRING(TIMESTAMP BENCHMARK_TIME "%Y-%m-%d_T%H-%M-%S" UTC)
+    SET(
+        BENCHMARK_ARGS
+        --benchmark_counters_tabular=true
+        --benchmark_out=${BENCHMARK_NAME}_${BENCHMARK_TIME}.json
+    )
+
+    ADD_TEST(
+        NAME ${BENCHMARK_NAME}
+        COMMAND ${BENCHMARK_NAME} ${BENCHMARK_ARGS}
+    )
+ENDFUNCTION()

--- a/cmake/kokkoskernels_benchmarks.cmake
+++ b/cmake/kokkoskernels_benchmarks.cmake
@@ -17,9 +17,10 @@ ELSE()
 
     # Note: recent bug (google/benchmark#1441) is preventing us from using
     # the latest benchmark release.
+    SET(BENCHMARK_VERSION 1.6.2)
     FetchContent_Declare(
         googlebenchmark
-        URL https://github.com/google/benchmark/archive/refs/tags/v1.6.2.tar.gz
+        URL https://github.com/google/benchmark/archive/refs/tags/v${BENCHMARK_VERSION}.tar.gz
         URL_HASH MD5=14d14849e075af116143a161bc3b927b
     )
     FetchContent_MakeAvailable(googlebenchmark)

--- a/cmake/kokkoskernels_version_info.cmake
+++ b/cmake/kokkoskernels_version_info.cmake
@@ -87,12 +87,14 @@ FUNCTION(check_git_version)
   ENDIF()
 ENDFUNCTION()
 
-FUNCTION(check_git_setup)
+# Pass BENCHMARK_VERSION variable to configure benchmark library version
+FUNCTION(check_version_info)
   add_custom_target(
     AlwaysCheckGit COMMAND ${CMAKE_COMMAND}
     -DRUN_CHECK_GIT_VERSION=1
     -DKOKKOSKERNELS_TOP_SOURCE_DIR=${KOKKOSKERNELS_TOP_SOURCE_DIR}
-    -P ${CURRENT_LIST_DIR}/kokkoskernels_git_info.cmake
+    -DBENCHMARK_VERSION=${BENCHMARK_VERSION}
+    -P ${CURRENT_LIST_DIR}/kokkoskernels_version_info.cmake
     BYPRODUCTS ${post_configure_file})
 
   add_dependencies(kokkoskernels AlwaysCheckGit)

--- a/perf_test/Benchmark_Context.hpp
+++ b/perf_test/Benchmark_Context.hpp
@@ -33,7 +33,7 @@ namespace KokkosKernelsBenchmark {
 
 /// \brief Remove unwanted spaces and colon signs from input string. In case of
 /// invalid input it will return an empty string.
-std::string remove_unwanted_characters(std::string str) {
+inline std::string remove_unwanted_characters(std::string str) {
   auto from = str.find_first_not_of(" :");
   auto to   = str.find_last_not_of(" :");
 
@@ -47,7 +47,7 @@ std::string remove_unwanted_characters(std::string str) {
 
 /// \brief Extract all key:value pairs from kokkos configuration and add it to
 /// the benchmark context
-void add_kokkos_configuration(bool verbose) {
+inline void add_kokkos_configuration(bool verbose) {
   std::ostringstream msg;
   Kokkos::print_configuration(msg, verbose);
   KokkosKernels::print_configuration(msg);
@@ -88,7 +88,7 @@ inline void add_version_info() {
 }
 
 /// \brief Gather all context information and add it to benchmark context data
-void add_benchmark_context(bool verbose = false) {
+inline void add_benchmark_context(bool verbose = false) {
   // Add Kokkos configuration to benchmark context data
   add_kokkos_configuration(verbose);
 

--- a/perf_test/Benchmark_Context.hpp
+++ b/perf_test/Benchmark_Context.hpp
@@ -67,19 +67,23 @@ void add_kokkos_configuration(bool verbose) {
   }
 }
 
-inline void add_git_info() {
-  if (!KokkosKernels::Impl::GIT_BRANCH.empty()) {
-    benchmark::AddCustomContext("GIT_BRANCH",
-                                std::string(KokkosKernels::Impl::GIT_BRANCH));
-    benchmark::AddCustomContext(
-        "GIT_COMMIT_HASH", std::string(KokkosKernels::Impl::GIT_COMMIT_HASH));
-    benchmark::AddCustomContext(
-        "GIT_CLEAN_STATUS", std::string(KokkosKernels::Impl::GIT_CLEAN_STATUS));
-    benchmark::AddCustomContext(
-        "GIT_COMMIT_DESCRIPTION",
-        std::string(KokkosKernels::Impl::GIT_COMMIT_DESCRIPTION));
-    benchmark::AddCustomContext(
-        "GIT_COMMIT_DATE", std::string(KokkosKernels::Impl::GIT_COMMIT_DATE));
+inline void add_version_info() {
+  using namespace KokkosKernels::Impl;
+
+  if (!GIT_BRANCH.empty()) {
+    benchmark::AddCustomContext("GIT_BRANCH", std::string(GIT_BRANCH));
+    benchmark::AddCustomContext("GIT_COMMIT_HASH",
+                                std::string(GIT_COMMIT_HASH));
+    benchmark::AddCustomContext("GIT_CLEAN_STATUS",
+                                std::string(GIT_CLEAN_STATUS));
+    benchmark::AddCustomContext("GIT_COMMIT_DESCRIPTION",
+                                std::string(GIT_COMMIT_DESCRIPTION));
+    benchmark::AddCustomContext("GIT_COMMIT_DATE",
+                                std::string(GIT_COMMIT_DATE));
+  }
+  if (!BENCHMARK_VERSION.empty()) {
+    benchmark::AddCustomContext("GOOGLE_BENCHMARK_VERSION",
+                                std::string(BENCHMARK_VERSION));
   }
 }
 
@@ -88,7 +92,7 @@ void add_benchmark_context(bool verbose = false) {
   // Add Kokkos configuration to benchmark context data
   add_kokkos_configuration(verbose);
 
-  add_git_info();
+  add_version_info();
 }
 
 }  // namespace KokkosKernelsBenchmark

--- a/perf_test/Benchmark_Context.hpp
+++ b/perf_test/Benchmark_Context.hpp
@@ -67,6 +67,8 @@ inline void add_kokkos_configuration(bool verbose) {
   }
 }
 
+/// \brief Add Kokkos Kernels git info and google benchmark release to
+/// benchmark context.
 inline void add_version_info() {
   using namespace KokkosKernels::Impl;
 
@@ -87,11 +89,9 @@ inline void add_version_info() {
   }
 }
 
-/// \brief Gather all context information and add it to benchmark context data
+/// \brief Gather all context information and add it to benchmark context
 inline void add_benchmark_context(bool verbose = false) {
-  // Add Kokkos configuration to benchmark context data
   add_kokkos_configuration(verbose);
-
   add_version_info();
 }
 

--- a/perf_test/CMakeLists.txt
+++ b/perf_test/CMakeLists.txt
@@ -53,102 +53,12 @@ if (KokkosKernels_ENABLE_PERFTESTS)
 
 endif()
 
-IF(KokkosKernels_ENABLE_BENCHMARK)
-
-    IF (KOKKOSKERNELS_HAS_TRILINOS)
-      message(FATAL_ERROR "Benchmarks are not supported when building as part of Trilinos")
-    ENDIF()
-
-    find_package(benchmark QUIET)
-
-    IF(benchmark_FOUND)
-      MESSAGE(STATUS "Using google benchmark found in ${benchmark_DIR}")
-    ELSE()
-      message(STATUS "No installed google benchmark found, fetching from GitHub")
-      include(FetchContent)
-      SET(BENCHMARK_ENABLE_TESTING OFF)
-
-      list(APPEND CMAKE_MESSAGE_INDENT "    ")
-      #Note: recent bug (google/benchmark#1441) is preventing us from using
-      # the latest benchmark release.
-      FetchContent_Declare(
-        googlebenchmark
-        URL https://github.com/google/benchmark/archive/refs/tags/v1.6.2.tar.gz
-        URL_HASH MD5=14d14849e075af116143a161bc3b927b
-      )
-      FetchContent_MakeAvailable(googlebenchmark)
-      list(POP_BACK CMAKE_MESSAGE_INDENT)
-
-      include_directories(${benchmark_SOURCE_DIR}/include)
-
-      # Suppress clang-tidy diagnostics on code that we do not have control over
-      IF(CMAKE_CXX_CLANG_TIDY)
-        SET_TARGET_PROPERTIES(benchmark PROPERTIES CXX_CLANG_TIDY "")
-      ENDIF()
-
-      target_compile_options(benchmark PRIVATE -w)
-      target_compile_options(benchmark_main PRIVATE -w)
-    ENDIF()
-
-    KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
-
-    FUNCTION(KOKKOSKERNELS_ADD_BENCHMARK NAME)
-      CMAKE_PARSE_ARGUMENTS(
-        BENCHMARK
-        ""
-        ""
-        "SOURCES"
-        ${ARGN}
-      )
-      IF(DEFINED BENCHMARK_UNPARSED_ARGUMENTS)
-        MESSAGE(
-          WARNING
-          "Unexpected arguments when adding a benchmark: "
-          ${BENCHMARK_UNPARSED_ARGUMENTS}
-        )
-      ENDIF()
-
-      SET(BENCHMARK_NAME ${PACKAGE_NAME}_${NAME})
-
-      ADD_EXECUTABLE(
-        ${BENCHMARK_NAME}
-        ${BENCHMARK_SOURCES}
-      )
-      TARGET_LINK_LIBRARIES(
-        ${BENCHMARK_NAME}
-        PRIVATE benchmark::benchmark Kokkos::kokkoskernels
-      )
-      FOREACH(SOURCE_FILE ${BENCHMARK_SOURCES})
-        SET_SOURCE_FILES_PROPERTIES(
-          ${SOURCE_FILE}
-          PROPERTIES LANGUAGE CXX
-        )
-      ENDFOREACH()
-
-      STRING(TIMESTAMP BENCHMARK_TIME "%Y-%m-%d_T%H-%M-%S" UTC)
-      SET(
-        BENCHMARK_ARGS
-        --benchmark_counters_tabular=true
-        --benchmark_out=${BENCHMARK_NAME}_${BENCHMARK_TIME}.json
-      )
-
-      ADD_TEST(
-        NAME ${BENCHMARK_NAME}
-        COMMAND ${BENCHMARK_NAME} ${BENCHMARK_ARGS}
-      )
-    ENDFUNCTION()
-
-    SET(
-      BENCHMARK_SOURCES
-      BenchmarkMain.cpp
-      blas/blas1/KokkosBlas_dot_perf_test_benchmark.cpp
-      blas/blas1/KokkosBlas_dot_mv_perf_test_benchmark.cpp
-      blas/blas1/KokkosBlas_team_dot_perf_test_benchmark.cpp
-    )
-
+if(KokkosKernels_ENABLE_BENCHMARK)
     KOKKOSKERNELS_ADD_BENCHMARK(
       PerformanceTest_Benchmark
-      SOURCES ${BENCHMARK_SOURCES}
+      SOURCES
+        blas/blas1/KokkosBlas_dot_perf_test_benchmark.cpp
+        blas/blas1/KokkosBlas_dot_mv_perf_test_benchmark.cpp
+        blas/blas1/KokkosBlas_team_dot_perf_test_benchmark.cpp
     )
-
 endif()


### PR DESCRIPTION
fixes #1718 (3.)

Include google/benchmark library version in benchmark output.

Sample output (console):
```
2023-03-22T17:43:14+01:00
Running ./build/perf_test/KokkosKernels_PerformanceTest_Benchmark
(...)GIT_BRANCH: 1718-print-google-benchmark-version
GIT_CLEAN_STATUS: CLEAN
GIT_COMMIT_DATE: 2023-03-22T17:42:42+01:00
GIT_COMMIT_DESCRIPTION: Clarify comments for context helper functions
GIT_COMMIT_HASH: f1005386c
GOOGLE_BENCHMARK_VERSION: 1.6.2
(...)
```

Note: this also moves benchmark related CMake code around and cleans it up a bit (1554ee7).