### PR TITLE
Refactor blas3 tests to use benchmark library

### DIFF
--- a/perf_test/blas/blas3/CMakeLists.txt
+++ b/perf_test/blas/blas3/CMakeLists.txt
@@ -12,3 +12,9 @@ KOKKOSKERNELS_ADD_EXECUTABLE(
     SOURCES KokkosBlas3_gemm_standalone_perf_test.cpp
 )
 
+IF(KokkosKernels_ENABLE_BENCHMARK)
+    KOKKOSKERNELS_ADD_BENCHMARK(
+        Blas3_gemm_benchmark
+        SOURCES KokkosBlas3_gemm_standalone_perf_test_benchmark.cpp
+    )
+ENDIF()

--- a/perf_test/blas/blas3/KokkosBlas3_gemm_standalone_perf_test_benchmark.cpp
+++ b/perf_test/blas/blas3/KokkosBlas3_gemm_standalone_perf_test_benchmark.cpp
@@ -1,0 +1,205 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "KokkosBlas3_gemm.hpp"
+#include <Kokkos_Random.hpp>
+#include "KokkosKernels_TestUtils.hpp"
+#include "KokkosKernels_perf_test_utilities.hpp"
+#include "Benchmark_Context.hpp"
+#include <benchmark/benchmark.h>
+
+struct blas3_gemm_params : public perf_test::CommonInputParams {
+  int m = 1000;
+  int n = 1000;
+  int k = 1000;
+
+  static blas3_gemm_params get_params(int& argc, char** argv) {
+    blas3_gemm_params params;
+    perf_test::parse_common_options(argc, argv, params);
+
+    for (int i = 1; i < argc; ++i) {
+      if (perf_test::check_arg_int(i, argc, argv, "--m", params.m)) {
+        ++i;
+      } else if (perf_test::check_arg_int(i, argc, argv, "--n", params.n)) {
+        ++i;
+      } else if (perf_test::check_arg_int(i, argc, argv, "--k", params.k)) {
+        ++i;
+      } else if (std::string(argv[i]).find("--benchmark") == 0) {
+        continue;  // ignore benchmark arguments
+      } else {
+        std::cerr << "Unrecognized command line argument #" << i << ": "
+                  << argv[i] << std::endl;
+        print_options();
+        exit(1);
+      }
+    }
+    return params;
+  }
+
+  static void print_options() {
+    std::cerr << "Options\n" << std::endl;
+    std::cerr << perf_test::list_common_options();
+
+    std::cerr << "\t[Optional] --m      :: Rows in A (default 1000)"
+              << std::endl;
+    std::cerr
+        << "\t[Optional] --n      :: Columns in A / Rows in B (default 1000)"
+        << std::endl;
+    std::cerr << "\t[Optional] --k      :: Columns in B (default 1000)"
+              << std::endl;
+  }
+};
+
+template <typename ExecSpace, typename Scalar, typename ALayout,
+          typename BLayout>
+static void KokkosBlas3_GEMM(benchmark::State& state) {
+  const auto m = state.range(0);
+  const auto n = state.range(1);
+  const auto k = state.range(2);
+
+  using MemSpace = typename ExecSpace::memory_space;
+  using Device   = Kokkos::Device<ExecSpace, MemSpace>;
+  Kokkos::View<Scalar**, ALayout, Device> A(
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "A"), m, n);
+  Kokkos::View<Scalar**, BLayout, Device> B(
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "B"), n, k);
+  Kokkos::View<Scalar**, Kokkos::LayoutLeft, Device> C(
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "C"), m, k);
+  Kokkos::Random_XorShift64_Pool<ExecSpace> pool(123);
+  Kokkos::fill_random(A, pool, 10.0);
+  Kokkos::fill_random(B, pool, 10.0);
+
+  // Do a warm-up run
+  KokkosBlas::gemm("N", "N", 1.0, A, B, 0.0, C);
+  Kokkos::fence();
+  double total_time = 0.0;
+
+  for (auto _ : state) {
+    Kokkos::Timer timer;
+    KokkosBlas::gemm("N", "N", 1.0, A, B, 0.0, C);
+    ExecSpace().fence();
+
+    double time = timer.seconds();
+    total_time += time;
+    state.SetIterationTime(time);
+  }
+
+  state.counters[ExecSpace::name()] = 1;
+  state.counters["Avg GEMM time (s):"] =
+      benchmark::Counter(total_time, benchmark::Counter::kAvgIterations);
+  size_t flopsPerRun                   = (size_t)2 * m * n * k;
+  state.counters["Avg GEMM (FLOP/s):"] = benchmark::Counter(
+      flopsPerRun, benchmark::Counter::kIsIterationInvariantRate);
+}
+
+template <typename ExecSpace>
+void run(const blas3_gemm_params& params) {
+  using LL     = Kokkos::LayoutLeft;
+  using LR     = Kokkos::LayoutRight;
+  using Scalar = double;
+
+  const auto name      = "KokkosBlas3_GEMM";
+  const auto arg_names = std::vector<std::string>{"m", "n", "k"};
+  const auto args      = std::vector<int64_t>{params.m, params.n, params.k};
+
+  KokkosKernelsBenchmark::register_benchmark(
+      name, KokkosBlas3_GEMM<Kokkos::OpenMP, Scalar, LL, LL>, arg_names, args,
+      params.repeat);
+  KokkosKernelsBenchmark::register_benchmark(
+      name, KokkosBlas3_GEMM<Kokkos::OpenMP, Scalar, LL, LR>, arg_names, args,
+      params.repeat);
+  KokkosKernelsBenchmark::register_benchmark(
+      name, KokkosBlas3_GEMM<Kokkos::OpenMP, Scalar, LR, LL>, arg_names, args,
+      params.repeat);
+  KokkosKernelsBenchmark::register_benchmark(
+      name, KokkosBlas3_GEMM<Kokkos::OpenMP, Scalar, LR, LR>, arg_names, args,
+      params.repeat);
+}
+
+int main(int argc, char** argv) {
+  const auto params     = blas3_gemm_params::get_params(argc, argv);
+  const int num_threads = params.use_openmp;
+  const int device_id   = params.use_cuda - 1;
+
+  Kokkos::initialize(Kokkos::InitializationSettings()
+                         .set_num_threads(num_threads)
+                         .set_device_id(device_id));
+  benchmark::Initialize(&argc, argv);
+  benchmark::SetDefaultTimeUnit(benchmark::kSecond);
+  KokkosKernelsBenchmark::add_benchmark_context(true);
+
+  if (params.use_threads) {
+#if defined(KOKKOS_ENABLE_THREADS)
+    run<Kokkos::Threads>(params);
+#else
+    std::cout << "ERROR:  PThreads requested, but not available.\n";
+    return 1;
+#endif
+  }
+
+  if (params.use_openmp) {
+#if defined(KOKKOS_ENABLE_OPENMP)
+    run<Kokkos::OpenMP>(params);
+#else
+    std::cout << "ERROR: OpenMP requested, but not available.\n";
+    return 1;
+#endif
+  }
+
+  if (params.use_cuda) {
+#if defined(KOKKOS_ENABLE_CUDA)
+    run<Kokkos::Cuda>(params);
+#else
+    std::cout << "ERROR: CUDA requested, but not available.\n";
+    return 1;
+#endif
+  }
+
+  if (params.use_hip) {
+#if defined(KOKKOS_ENABLE_HIP)
+    run<Kokkos::Experimental::HIP>(params);
+#else
+    std::cout << "ERROR: HIP requested, but not available.\n";
+    return 1;
+#endif
+  }
+
+  if (params.use_sycl) {
+#if defined(KOKKOS_ENABLE_SYCL)
+    run<Kokkos::Experimental::SYCL>(params);
+#else
+    std::cout << "ERROR: SYCL requested, but not available.\n";
+    return 1;
+#endif
+  }
+
+  // use serial if no backend is specified
+  if (!params.use_cuda and !params.use_hip and !params.use_openmp and
+      !params.use_sycl and !params.use_threads) {
+#if defined(KOKKOS_ENABLE_SERIAL)
+    run<Kokkos::Serial>(params);
+#else
+    std::cout << "ERROR: Serial device requested, but not available.\n";
+    return 1;
+#endif
+  }
+
+  benchmark::RunSpecifiedBenchmarks();
+
+  benchmark::Shutdown();
+  Kokkos::finalize();
+  return 0;
+}

--- a/perf_test/blas/blas3/KokkosBlas3_gemm_standalone_perf_test_benchmark.cpp
+++ b/perf_test/blas/blas3/KokkosBlas3_gemm_standalone_perf_test_benchmark.cpp
@@ -103,6 +103,16 @@ static void KokkosBlas3_GEMM(benchmark::State& state) {
   size_t flopsPerRun                   = (size_t)2 * m * n * k;
   state.counters["Avg GEMM (FLOP/s):"] = benchmark::Counter(
       flopsPerRun, benchmark::Counter::kIsIterationInvariantRate);
+  if constexpr (std::is_same_v<ALayout, Kokkos::LayoutLeft>) {
+    state.counters["Memory Layout in A: LayoutLeft"] = 1;
+  } else {
+    state.counters["Memory Layout in A: LayoutRight"] = 1;
+  }
+  if constexpr (std::is_same_v<BLayout, Kokkos::LayoutLeft>) {
+    state.counters["Memory Layout in B: LayoutLeft"] = 1;
+  } else {
+    state.counters["Memory Layout in B: LayoutRight"] = 1;
+  }
 }
 
 template <typename ExecSpace>


### PR DESCRIPTION
Note: to avoid later conflicts, this contains changes from PR #1733. Changes specific to this PR are in `blas3` directory.

Sample output:
```
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                  Time             CPU   Iterations Avg GEMM (FLOP/s): Avg GEMM time (s): Memory Layout in A: LayoutLeft Memory Layout in B: LayoutLeft     OpenMP
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
KokkosBlas3_GEMM/m:1000/n:1000/k:1000/manual_time       5.11 s          4.87 s             1         391.454M/s            5.10915                              1                              1          1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                  Time             CPU   Iterations Avg GEMM (FLOP/s): Avg GEMM time (s): Memory Layout in A: LayoutLeft Memory Layout in B: LayoutRight     OpenMP
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
KokkosBlas3_GEMM/m:1000/n:1000/k:1000/manual_time       4.95 s          4.89 s             1         403.861M/s             4.9522                              1                               1          1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
Full output:
<details>
  <summary>Console</summary>

```
./build/perf_test/blas/blas3/KokkosKernels_Blas3_gemm_benchmark --benchmark_counters_tabular=true --openmp 8
```
```
2023-04-11T22:15:43+02:00
Running ./build/perf_test/blas/blas3/KokkosKernels_Blas3_gemm_benchmark
Run on (8 X 4700 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 256 KiB (x8)
  L3 Unified 12288 KiB (x1)
Load Average: 5.17, 3.13, 2.00
CPU architecture: none
Default Device: N6Kokkos6OpenMPE
GIT_BRANCH: benchmark-blas3-tests
GIT_CLEAN_STATUS: CLEAN
GIT_COMMIT_DATE: 2023-04-11T21:30:47+02:00
GIT_COMMIT_DESCRIPTION: Port Blas3 perf test
GIT_COMMIT_HASH: 4fa5a069b
GOOGLE_BENCHMARK_VERSION: 1.6.2
GPU architecture: none
KOKKOSKERNELS_ENABLE_TPL_ARMPL: no
KOKKOSKERNELS_ENABLE_TPL_BLAS: no
KOKKOSKERNELS_ENABLE_TPL_CBLAS: no
KOKKOSKERNELS_ENABLE_TPL_CHOLMOD: no
KOKKOSKERNELS_ENABLE_TPL_CUBLAS: no
KOKKOSKERNELS_ENABLE_TPL_CUSPARSE: no
KOKKOSKERNELS_ENABLE_TPL_LAPACK: no
KOKKOSKERNELS_ENABLE_TPL_LAPACKE: no
KOKKOSKERNELS_ENABLE_TPL_MAGMA: no
KOKKOSKERNELS_ENABLE_TPL_METIS: no
KOKKOSKERNELS_ENABLE_TPL_MKL: no
KOKKOSKERNELS_ENABLE_TPL_ROCBLAS: no
KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE: no
KOKKOSKERNELS_ENABLE_TPL_SUPERLU: no
KOKKOS_COMPILER_CLANG: 1507
KOKKOS_ENABLE_ASM: no
KOKKOS_ENABLE_CXX17: yes
KOKKOS_ENABLE_CXX20: no
KOKKOS_ENABLE_CXX23: no
KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK: yes
KOKKOS_ENABLE_GNU_ATOMICS: no
KOKKOS_ENABLE_HBWSPACE: no
KOKKOS_ENABLE_HWLOC: yes
KOKKOS_ENABLE_INTEL_ATOMICS: no
KOKKOS_ENABLE_INTEL_MM_ALLOC: no
KOKKOS_ENABLE_LIBDL: yes
KOKKOS_ENABLE_LIBRT: no
KOKKOS_ENABLE_OPENMP: yes
KOKKOS_ENABLE_OPENMP_ATOMICS: no
KOKKOS_ENABLE_PRAGMA_IVDEP: no
KOKKOS_ENABLE_PRAGMA_LOOPCOUNT: no
KOKKOS_ENABLE_PRAGMA_UNROLL: no
KOKKOS_ENABLE_PRAGMA_VECTOR: no
KOKKOS_ENABLE_WINDOWS_ATOMICS: no
Kokkos: OpenMP thread_pool_topology[ 1 x 8 x 1 ]
Kokkos Version: 4.0.0
KokkosKernels Version: 4.0.99
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
***WARNING*** Library was built as DEBUG. Timings may be affected.
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                  Time             CPU   Iterations Avg GEMM (FLOP/s): Avg GEMM time (s): Memory Layout in A: LayoutLeft Memory Layout in B: LayoutLeft     OpenMP
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
KokkosBlas3_GEMM/m:1000/n:1000/k:1000/manual_time       5.11 s          4.87 s             1         391.454M/s            5.10915                              1                              1          1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                  Time             CPU   Iterations Avg GEMM (FLOP/s): Avg GEMM time (s): Memory Layout in A: LayoutLeft Memory Layout in B: LayoutRight     OpenMP
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
KokkosBlas3_GEMM/m:1000/n:1000/k:1000/manual_time       4.95 s          4.89 s             1         403.861M/s             4.9522                              1                               1          1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                  Time             CPU   Iterations Avg GEMM (FLOP/s): Avg GEMM time (s): Memory Layout in A: LayoutRight Memory Layout in B: LayoutLeft     OpenMP
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
KokkosBlas3_GEMM/m:1000/n:1000/k:1000/manual_time       4.88 s          4.82 s             1          410.05M/s            4.87745                               1                              1          1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                  Time             CPU   Iterations Avg GEMM (FLOP/s): Avg GEMM time (s): Memory Layout in A: LayoutRight Memory Layout in B: LayoutRight     OpenMP
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
KokkosBlas3_GEMM/m:1000/n:1000/k:1000/manual_time       4.82 s          4.78 s             1         414.585M/s             4.8241                               1                               1          1
```
</details>

<details>
  <summary>JSON</summary>

```
./build/perf_test/blas/blas3/KokkosKernels_Blas3_gemm_benchmark --openmp 8 --benchmark_format=json
```
```json
{
  "context": {
    "date": "2023-04-11T22:18:07+02:00",
    "host_name": "rysy",
    "executable": "./build/perf_test/blas/blas3/KokkosKernels_Blas3_gemm_benchmark",
    "num_cpus": 8,
    "mhz_per_cpu": 4700,
    "cpu_scaling_enabled": true,
    "caches": [
      {
        "type": "Data",
        "level": 1,
        "size": 32768,
        "num_sharing": 1
      },
      {
        "type": "Instruction",
        "level": 1,
        "size": 32768,
        "num_sharing": 1
      },
      {
        "type": "Unified",
        "level": 2,
        "size": 262144,
        "num_sharing": 1
      },
      {
        "type": "Unified",
        "level": 3,
        "size": 12582912,
        "num_sharing": 8
      }
    ],
    "load_avg": [2.11523,3.01611,2.15039],
    "library_build_type": "debug",
    "CPU architecture": "none",
    "Default Device": "N6Kokkos6OpenMPE",
    "GIT_BRANCH": "benchmark-blas3-tests",
    "GIT_CLEAN_STATUS": "CLEAN",
    "GIT_COMMIT_DATE": "2023-04-11T21:30:47+02:00",
    "GIT_COMMIT_DESCRIPTION": "Port Blas3 perf test",
    "GIT_COMMIT_HASH": "4fa5a069b",
    "GOOGLE_BENCHMARK_VERSION": "1.6.2",
    "GPU architecture": "none",
    "KOKKOSKERNELS_ENABLE_TPL_ARMPL": "no",
    "KOKKOSKERNELS_ENABLE_TPL_BLAS": "no",
    "KOKKOSKERNELS_ENABLE_TPL_CBLAS": "no",
    "KOKKOSKERNELS_ENABLE_TPL_CHOLMOD": "no",
    "KOKKOSKERNELS_ENABLE_TPL_CUBLAS": "no",
    "KOKKOSKERNELS_ENABLE_TPL_CUSPARSE": "no",
    "KOKKOSKERNELS_ENABLE_TPL_LAPACK": "no",
    "KOKKOSKERNELS_ENABLE_TPL_LAPACKE": "no",
    "KOKKOSKERNELS_ENABLE_TPL_MAGMA": "no",
    "KOKKOSKERNELS_ENABLE_TPL_METIS": "no",
    "KOKKOSKERNELS_ENABLE_TPL_MKL": "no",
    "KOKKOSKERNELS_ENABLE_TPL_ROCBLAS": "no",
    "KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE": "no",
    "KOKKOSKERNELS_ENABLE_TPL_SUPERLU": "no",
    "KOKKOS_COMPILER_CLANG": "1507",
    "KOKKOS_ENABLE_ASM": "no",
    "KOKKOS_ENABLE_CXX17": "yes",
    "KOKKOS_ENABLE_CXX20": "no",
    "KOKKOS_ENABLE_CXX23": "no",
    "KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK": "yes",
    "KOKKOS_ENABLE_GNU_ATOMICS": "no",
    "KOKKOS_ENABLE_HBWSPACE": "no",
    "KOKKOS_ENABLE_HWLOC": "yes",
    "KOKKOS_ENABLE_INTEL_ATOMICS": "no",
    "KOKKOS_ENABLE_INTEL_MM_ALLOC": "no",
    "KOKKOS_ENABLE_LIBDL": "yes",
    "KOKKOS_ENABLE_LIBRT": "no",
    "KOKKOS_ENABLE_OPENMP": "yes",
    "KOKKOS_ENABLE_OPENMP_ATOMICS": "no",
    "KOKKOS_ENABLE_PRAGMA_IVDEP": "no",
    "KOKKOS_ENABLE_PRAGMA_LOOPCOUNT": "no",
    "KOKKOS_ENABLE_PRAGMA_UNROLL": "no",
    "KOKKOS_ENABLE_PRAGMA_VECTOR": "no",
    "KOKKOS_ENABLE_WINDOWS_ATOMICS": "no",
    "Kokkos": "OpenMP thread_pool_topology[ 1 x 8 x 1 ]",
    "Kokkos Version": "4.0.0",
    "KokkosKernels Version": "4.0.99"
  },
  "benchmarks": [
    {
      "name": "KokkosBlas3_GEMM/m:1000/n:1000/k:1000/manual_time",
      "family_index": 0,
      "per_family_instance_index": 0,
      "run_name": "KokkosBlas3_GEMM/m:1000/n:1000/k:1000/manual_time",
      "run_type": "iteration",
      "repetitions": 1,
      "repetition_index": 0,
      "threads": 1,
      "iterations": 1,
      "real_time": 5.0940380709999999e+00,
      "cpu_time": 4.8996136329999995e+00,
      "time_unit": "s",
      "Avg GEMM (FLOP/s):": 3.9261583288626349e+08,
      "Avg GEMM time (s):": 5.0940380709999999e+00,
      "Memory Layout in A: LayoutLeft": 1.0000000000000000e+00,
      "Memory Layout in B: LayoutLeft": 1.0000000000000000e+00,
      "OpenMP": 1.0000000000000000e+00
    },
    {
      "name": "KokkosBlas3_GEMM/m:1000/n:1000/k:1000/manual_time",
      "family_index": 1,
      "per_family_instance_index": 0,
      "run_name": "KokkosBlas3_GEMM/m:1000/n:1000/k:1000/manual_time",
      "run_type": "iteration",
      "repetitions": 1,
      "repetition_index": 0,
      "threads": 1,
      "iterations": 1,
      "real_time": 5.0014757019999996e+00,
      "cpu_time": 4.8630787929999997e+00,
      "time_unit": "s",
      "Avg GEMM (FLOP/s):": 3.9988197867286175e+08,
      "Avg GEMM time (s):": 5.0014757019999996e+00,
      "Memory Layout in A: LayoutLeft": 1.0000000000000000e+00,
      "Memory Layout in B: LayoutRight": 1.0000000000000000e+00,
      "OpenMP": 1.0000000000000000e+00
    },
    {
      "name": "KokkosBlas3_GEMM/m:1000/n:1000/k:1000/manual_time",
      "family_index": 2,
      "per_family_instance_index": 0,
      "run_name": "KokkosBlas3_GEMM/m:1000/n:1000/k:1000/manual_time",
      "run_type": "iteration",
      "repetitions": 1,
      "repetition_index": 0,
      "threads": 1,
      "iterations": 1,
      "real_time": 5.0713342260000003e+00,
      "cpu_time": 4.9486325149999999e+00,
      "time_unit": "s",
      "Avg GEMM (FLOP/s):": 3.9437353384170341e+08,
      "Avg GEMM time (s):": 5.0713342260000003e+00,
      "Memory Layout in A: LayoutRight": 1.0000000000000000e+00,
      "Memory Layout in B: LayoutLeft": 1.0000000000000000e+00,
      "OpenMP": 1.0000000000000000e+00
    },
    {
      "name": "KokkosBlas3_GEMM/m:1000/n:1000/k:1000/manual_time",
      "family_index": 3,
      "per_family_instance_index": 0,
      "run_name": "KokkosBlas3_GEMM/m:1000/n:1000/k:1000/manual_time",
      "run_type": "iteration",
      "repetitions": 1,
      "repetition_index": 0,
      "threads": 1,
      "iterations": 1,
      "real_time": 5.0581920660000002e+00,
      "cpu_time": 4.8651972959999981e+00,
      "time_unit": "s",
      "Avg GEMM (FLOP/s):": 3.9539819245764482e+08,
      "Avg GEMM time (s):": 5.0581920660000002e+00,
      "Memory Layout in A: LayoutRight": 1.0000000000000000e+00,
      "Memory Layout in B: LayoutRight": 1.0000000000000000e+00,
      "OpenMP": 1.0000000000000000e+00
    }
  ]
}
```
</details>

