### PR TITLE
Add calls to KokkosBlas Dot and Axpy for team batched kernels when m==1

### DIFF
--- a/batched/dense/impl/KokkosBatched_Copy_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Copy_Impl.hpp
@@ -47,6 +47,25 @@ template <>
 template <typename AViewType, typename BViewType>
 KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::NoTranspose, 2>::invoke(
     const AViewType &A, const BViewType &B) {
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+  static_assert(Kokkos::is_view<AViewType>::value,
+                "KokkosBatched::copy: AViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view<BViewType>::value,
+                "KokkosBatched::copy: BViewType is not a Kokkos::View.");
+  static_assert(AViewType::rank == 2,
+                "KokkosBatched::copy: AViewType must have rank 2.");
+  static_assert(BViewType::rank == 2,
+                "KokkosBatched::copy: BViewType must have rank 2.");
+
+  // Check compatibility of dimensions at run time.
+  if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+        "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x %d, "
+        "B: %d x %d\n",
+        (int)A.extent(0), (int)A.extent(1), (int)B.extent(0), (int)B.extent(1));
+    return 1;
+  }
+#endif
   return SerialCopyInternal::invoke(A.extent(0), A.extent(1), A.data(),
                                     A.stride_0(), A.stride_1(), B.data(),
                                     B.stride_0(), B.stride_1());
@@ -56,6 +75,25 @@ template <>
 template <typename AViewType, typename BViewType>
 KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::Transpose, 2>::invoke(
     const AViewType &A, const BViewType &B) {
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+  static_assert(Kokkos::is_view<AViewType>::value,
+                "KokkosBatched::copy: AViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view<BViewType>::value,
+                "KokkosBatched::copy: BViewType is not a Kokkos::View.");
+  static_assert(AViewType::rank == 2,
+                "KokkosBatched::copy: AViewType must have rank 2.");
+  static_assert(BViewType::rank == 2,
+                "KokkosBatched::copy: BViewType must have rank 2.");
+
+  // Check compatibility of dimensions at run time.
+  if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+        "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x %d, "
+        "B: %d x %d\n",
+        (int)A.extent(0), (int)A.extent(1), (int)B.extent(0), (int)B.extent(1));
+    return 1;
+  }
+#endif
   return SerialCopyInternal::invoke(A.extent(1), A.extent(0), A.data(),
                                     A.stride_1(), A.stride_0(), B.data(),
                                     B.stride_0(), B.stride_1());
@@ -93,6 +131,32 @@ struct TeamCopy<MemberType, Trans::NoTranspose, 2> {
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const AViewType &A,
                                            const BViewType &B) {
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+    static_assert(Kokkos::is_view<AViewType>::value,
+                  "KokkosBatched::copy: AViewType is not a Kokkos::View.");
+    static_assert(Kokkos::is_view<BViewType>::value,
+                  "KokkosBatched::copy: BViewType is not a Kokkos::View.");
+    static_assert(AViewType::rank == 2,
+                  "KokkosBatched::copy: AViewType must have rank 2.");
+    static_assert(BViewType::rank == 2,
+                  "KokkosBatched::copy: BViewType must have rank 2.");
+
+    // Check compatibility of dimensions at run time.
+    if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
+          "%d, "
+          "B: %d x %d\n",
+          (int)A.extent(0), (int)A.extent(1), (int)B.extent(0),
+          (int)B.extent(1));
+      return 1;
+    }
+#endif
+    if (A.extent(0) == 1) {
+      return TeamCopy<MemberType, Trans::NoTranspose, 1>::invoke(
+          member, Kokkos::subview(A, 0, Kokkos::ALL),
+          Kokkos::subview(B, 0, Kokkos::ALL));
+    }
     return TeamCopyInternal::invoke(member, A.extent(0), A.extent(1), A.data(),
                                     A.stride_0(), A.stride_1(), B.data(),
                                     B.stride_0(), B.stride_1());
@@ -105,6 +169,32 @@ struct TeamCopy<MemberType, Trans::Transpose, 2> {
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const AViewType &A,
                                            const BViewType &B) {
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+    static_assert(Kokkos::is_view<AViewType>::value,
+                  "KokkosBatched::copy: AViewType is not a Kokkos::View.");
+    static_assert(Kokkos::is_view<BViewType>::value,
+                  "KokkosBatched::copy: BViewType is not a Kokkos::View.");
+    static_assert(AViewType::rank == 2,
+                  "KokkosBatched::copy: AViewType must have rank 2.");
+    static_assert(BViewType::rank == 2,
+                  "KokkosBatched::copy: BViewType must have rank 2.");
+
+    // Check compatibility of dimensions at run time.
+    if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
+          "%d, "
+          "B: %d x %d\n",
+          (int)A.extent(0), (int)A.extent(1), (int)B.extent(0),
+          (int)B.extent(1));
+      return 1;
+    }
+#endif
+    if (A.extent(1) == 1) {
+      return TeamCopy<MemberType, Trans::Transpose, 1>::invoke(
+          member, Kokkos::subview(A, Kokkos::ALL, 0),
+          Kokkos::subview(B, Kokkos::ALL, 0));
+    }
     return TeamCopyInternal::invoke(member, A.extent(1), A.extent(0), A.data(),
                                     A.stride_1(), A.stride_0(), B.data(),
                                     B.stride_0(), B.stride_1());
@@ -143,6 +233,32 @@ struct TeamVectorCopy<MemberType, Trans::NoTranspose, 2> {
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const AViewType &A,
                                            const BViewType &B) {
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+    static_assert(Kokkos::is_view<AViewType>::value,
+                  "KokkosBatched::copy: AViewType is not a Kokkos::View.");
+    static_assert(Kokkos::is_view<BViewType>::value,
+                  "KokkosBatched::copy: BViewType is not a Kokkos::View.");
+    static_assert(AViewType::rank == 2,
+                  "KokkosBatched::copy: AViewType must have rank 2.");
+    static_assert(BViewType::rank == 2,
+                  "KokkosBatched::copy: BViewType must have rank 2.");
+
+    // Check compatibility of dimensions at run time.
+    if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
+          "%d, "
+          "B: %d x %d\n",
+          (int)A.extent(0), (int)A.extent(1), (int)B.extent(0),
+          (int)B.extent(1));
+      return 1;
+    }
+#endif
+    if (A.extent(0) == 1) {
+      return TeamVectorCopy<MemberType, Trans::NoTranspose, 1>::invoke(
+          member, Kokkos::subview(A, 0, Kokkos::ALL),
+          Kokkos::subview(B, 0, Kokkos::ALL));
+    }
     return TeamVectorCopyInternal::invoke(member, A.extent(0), A.extent(1),
                                           A.data(), A.stride_0(), A.stride_1(),
                                           B.data(), B.stride_0(), B.stride_1());
@@ -155,6 +271,32 @@ struct TeamVectorCopy<MemberType, Trans::Transpose, 2> {
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member,
                                            const AViewType &A,
                                            const BViewType &B) {
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+    static_assert(Kokkos::is_view<AViewType>::value,
+                  "KokkosBatched::copy: AViewType is not a Kokkos::View.");
+    static_assert(Kokkos::is_view<BViewType>::value,
+                  "KokkosBatched::copy: BViewType is not a Kokkos::View.");
+    static_assert(AViewType::rank == 2,
+                  "KokkosBatched::copy: AViewType must have rank 2.");
+    static_assert(BViewType::rank == 2,
+                  "KokkosBatched::copy: BViewType must have rank 2.");
+
+    // Check compatibility of dimensions at run time.
+    if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
+          "%d, "
+          "B: %d x %d\n",
+          (int)A.extent(0), (int)A.extent(1), (int)B.extent(0),
+          (int)B.extent(1));
+      return 1;
+    }
+#endif
+    if (A.extent(1) == 1) {
+      return TeamVectorCopy<MemberType, Trans::NoTranspose, 1>::invoke(
+          member, Kokkos::subview(A, Kokkos::ALL, 0),
+          Kokkos::subview(B, Kokkos::ALL, 0));
+    }
     return TeamVectorCopyInternal::invoke(member, A.extent(1), A.extent(0),
                                           A.data(), A.stride_1(), A.stride_0(),
                                           B.data(), B.stride_0(), B.stride_1());

--- a/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
@@ -19,6 +19,7 @@
 /// \author Kyungjoo Kim (kyukim@sandia.gov)
 
 #include "KokkosBatched_Util.hpp"
+#include "KokkosBlas1_team_dot.hpp"
 
 namespace KokkosBatched {
 
@@ -162,6 +163,7 @@ struct TeamVectorDotInternal {
 ///
 /// Serial Impl
 /// ===========
+
 template <>
 struct SerialDot<Trans::Transpose> {
   template <typename XViewType, typename YViewType, typename NormViewType>
@@ -256,6 +258,7 @@ struct SerialDot<Trans::NoTranspose> {
 ///
 /// Team Impl
 /// ===============
+
 template <typename MemberType>
 struct TeamDot<MemberType, Trans::Transpose> {
   template <typename XViewType, typename YViewType, typename NormViewType>
@@ -295,6 +298,14 @@ struct TeamDot<MemberType, Trans::Transpose> {
       return 1;
     }
 #endif
+
+    if (X.extent(1) == 1) {
+      dot(0) = KokkosBlas::Experimental::dot(
+          member, Kokkos::subview(X, Kokkos::ALL, 0),
+          Kokkos::subview(Y, Kokkos::ALL, 0));
+      return 0;
+    }
+
     return TeamDotInternal::template invoke<
         MemberType, typename XViewType::non_const_value_type,
         typename NormViewType::non_const_value_type>(
@@ -341,6 +352,14 @@ struct TeamDot<MemberType, Trans::NoTranspose> {
       return 1;
     }
 #endif
+
+    if (X.extent(0) == 1) {
+      dot(0) = KokkosBlas::Experimental::dot(
+          member, Kokkos::subview(X, 0, Kokkos::ALL),
+          Kokkos::subview(Y, 0, Kokkos::ALL));
+      return 0;
+    }
+
     return TeamDotInternal::template invoke<
         MemberType, typename XViewType::non_const_value_type,
         typename NormViewType::non_const_value_type>(
@@ -352,6 +371,7 @@ struct TeamDot<MemberType, Trans::NoTranspose> {
 ///
 /// TeamVector Impl
 /// ===============
+
 template <typename MemberType>
 struct TeamVectorDot<MemberType, Trans::Transpose> {
   template <typename XViewType, typename YViewType, typename NormViewType>
@@ -391,6 +411,14 @@ struct TeamVectorDot<MemberType, Trans::Transpose> {
       return 1;
     }
 #endif
+
+    if (X.extent(1) == 1) {
+      dot(0) = KokkosBlas::Experimental::dot(
+          member, Kokkos::subview(X, Kokkos::ALL, 0),
+          Kokkos::subview(Y, Kokkos::ALL, 0));
+      return 0;
+    }
+
     return TeamVectorDotInternal::template invoke<
         MemberType, typename XViewType::non_const_value_type,
         typename NormViewType::non_const_value_type>(
@@ -437,6 +465,14 @@ struct TeamVectorDot<MemberType, Trans::NoTranspose> {
       return 1;
     }
 #endif
+
+    if (X.extent(0) == 1) {
+      dot(0) = KokkosBlas::Experimental::dot(
+          member, Kokkos::subview(X, 0, Kokkos::ALL),
+          Kokkos::subview(Y, 0, Kokkos::ALL));
+      return 0;
+    }
+
     return TeamVectorDotInternal::template invoke<
         MemberType, typename XViewType::non_const_value_type,
         typename NormViewType::non_const_value_type>(

--- a/batched/dense/unit_test/Test_Batched_TeamVectorQR.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorQR.hpp
@@ -78,7 +78,7 @@ struct Functor_TestBatchedTeamVectorQR {
     member.team_barrier();
 
     /// xx = bb;
-    TeamVectorCopy<MemberType, Trans::NoTranspose>::invoke(member, bb, xx);
+    TeamVectorCopy<MemberType, Trans::NoTranspose, 1>::invoke(member, bb, xx);
     member.team_barrier();
 
     /// xx = Q^{T}xx;

--- a/batched/dense/unit_test/Test_Batched_TeamVectorQR_WithColumnPivoting.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorQR_WithColumnPivoting.hpp
@@ -80,7 +80,7 @@ struct Functor_TestBatchedTeamVectorQR_WithColumnPivoting {
     member.team_barrier();
 
     /// xx = bb;
-    TeamVectorCopy<MemberType, Trans::NoTranspose>::invoke(member, bb, xx);
+    TeamVectorCopy<MemberType, Trans::NoTranspose, 1>::invoke(member, bb, xx);
     member.team_barrier();
 
     /// xx = Q^{T} xx;


### PR DESCRIPTION
This PR adds calls to KokkosBlas functions for 2 KokkosBatched functions when the number of systems per team is equal to 1.

This has been tested on my workstation.