### PR TITLE
Jgfouca/remove par ilut limitations

### DIFF
--- a/sparse/impl/KokkosSparse_gmres_impl.hpp
+++ b/sparse/impl/KokkosSparse_gmres_impl.hpp
@@ -92,6 +92,7 @@ struct GmresWrap {
       std::cout << "  ortho:      "
                 << ((ortho == GmresHandle::Ortho::CGS2) ? "CGS2" : "MGS")
                 << std::endl;
+      std::cout << "  precond:    " << (precond ? "ON" : "OFF") << std::endl;
     }
 
     // Make tmp work views

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -555,7 +555,8 @@ struct IlutWrap {
           "available");
 #endif
     } else {
-      const auto policy = ih.get_default_team_policy();
+      const size_type nrows = ih.get_nrows();
+      policy_type policy(nrows, 1); // Team parallelism breaks the algorithm
 
       Kokkos::parallel_for(
           "compute_l_u_factors", policy,
@@ -904,7 +905,6 @@ struct IlutWrap {
     size_type itr          = 0;
     scalar_t curr_residual = std::numeric_limits<scalar_t>::max();
     scalar_t prev_residual = std::numeric_limits<scalar_t>::max();
-    bool converged         = false;
 
     // Set the initial L/U values for the initial approximation
     initialize_LU(thandle, A_row_map, A_entries, A_values, L_row_map, L_entries,
@@ -985,15 +985,15 @@ struct IlutWrap {
         }
 
         const auto curr_delta = karith::abs(prev_residual - curr_residual);
-        if (curr_residual > prev_residual) {
+        // if (curr_residual > prev_residual) {
+        //   if (verbose) {
+        //     std::cout << "  Residuals are going backwards, stop" << std::endl;
+        //   }
+        //   stop = true;
+        // }
+        if (curr_delta <= residual_norm_delta_stop) {
           if (verbose) {
-            std::cout << "  Residuals are going backwards, stop" << std::endl;
-          }
-          stop = true;
-        }
-        else if (curr_delta <= residual_norm_delta_stop) {
-          if (verbose) {
-            std::cout << "  Itr-to-itr residual improvement has dropped below residual_norm_delta_stop, stop" << std::endl;
+            std::cout << "  Itr-to-itr residual change has dropped below residual_norm_delta_stop, stop" << std::endl;
           }
           stop = true;
         }

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -556,7 +556,7 @@ struct IlutWrap {
 #endif
     } else {
       const size_type nrows = ih.get_nrows();
-      policy_type policy(nrows, 1); // Team parallelism breaks the algorithm
+      policy_type policy(nrows, 1);  // Team parallelism breaks the algorithm
 
       Kokkos::parallel_for(
           "compute_l_u_factors", policy,
@@ -855,7 +855,6 @@ struct IlutWrap {
                            LEntriesType& L_entries, LValuesType& L_values,
                            URowMapType& U_row_map, UEntriesType& U_entries,
                            UValuesType& U_values, bool deterministic) {
-
     // Get config settings from handle
     const size_type nrows    = thandle.get_nrows();
     const auto fill_in_limit = thandle.get_fill_in_limit();
@@ -875,7 +874,8 @@ struct IlutWrap {
       std::cout << "  num_rows:            " << nrows << std::endl;
       std::cout << "  fill_in_limit:       " << fill_in_limit << std::endl;
       std::cout << "  max_iter:            " << max_iter << std::endl;
-      std::cout << "  res_norm_delta_stop: " << residual_norm_delta_stop << std::endl;
+      std::cout << "  res_norm_delta_stop: " << residual_norm_delta_stop
+                << std::endl;
     }
 
     kh.create_spadd_handle(true /*we expect inputs to be sorted*/);
@@ -981,23 +981,26 @@ struct IlutWrap {
             R_values, LU_row_map, LU_entries, LU_values);
 
         if (verbose) {
-          std::cout << "Completed itr " << itr << ", residual is: " << curr_residual << std::endl;
+          std::cout << "Completed itr " << itr
+                    << ", residual is: " << curr_residual << std::endl;
         }
 
         const auto curr_delta = karith::abs(prev_residual - curr_residual);
         // if (curr_residual > prev_residual) {
         //   if (verbose) {
-        //     std::cout << "  Residuals are going backwards, stop" << std::endl;
+        //     std::cout << "  Residuals are going backwards, stop" <<
+        //     std::endl;
         //   }
         //   stop = true;
         // }
         if (curr_delta <= residual_norm_delta_stop) {
           if (verbose) {
-            std::cout << "  Itr-to-itr residual change has dropped below residual_norm_delta_stop, stop" << std::endl;
+            std::cout << "  Itr-to-itr residual change has dropped below "
+                         "residual_norm_delta_stop, stop"
+                      << std::endl;
           }
           stop = true;
-        }
-        else {
+        } else {
           prev_residual = curr_residual;
         }
       }
@@ -1006,7 +1009,8 @@ struct IlutWrap {
     }
 
     if (verbose) {
-      std::cout << "PAR_ILUT stopped in " << itr << " iterations with residual " << curr_residual << std::endl;
+      std::cout << "PAR_ILUT stopped in " << itr << " iterations with residual "
+                << curr_residual << std::endl;
     }
     thandle.set_stats(itr, curr_residual);
 

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -844,7 +844,7 @@ struct IlutWrap {
     //
     // main loop
     //
-    bool stop = nrows == 0; // Don't iterate at all if nrows=0
+    bool stop = nrows == 0;  // Don't iterate at all if nrows=0
     while (!stop && itr < max_iter) {
       // LU = L*U
       if (prev_residual == std::numeric_limits<scalar_t>::max()) {

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -844,7 +844,7 @@ struct IlutWrap {
     //
     // main loop
     //
-    bool stop = false;
+    bool stop = nrows == 0; // Don't iterate at all if nrows=0
     while (!stop && itr < max_iter) {
       // LU = L*U
       if (prev_residual == std::numeric_limits<scalar_t>::max()) {
@@ -917,13 +917,6 @@ struct IlutWrap {
         }
 
         const auto curr_delta = karith::abs(prev_residual - curr_residual);
-        // if (curr_residual > prev_residual) {
-        //   if (verbose) {
-        //     std::cout << "  Residuals are going backwards, stop" <<
-        //     std::endl;
-        //   }
-        //   stop = true;
-        // }
         if (curr_delta <= residual_norm_delta_stop) {
           if (verbose) {
             std::cout << "  Itr-to-itr residual change has dropped below "
@@ -939,6 +932,7 @@ struct IlutWrap {
       ++itr;
     }
 
+    curr_residual = nrows == 0 ? scalar_t(0.) : curr_residual;
     if (verbose) {
       std::cout << "PAR_ILUT stopped in " << itr << " iterations with residual "
                 << curr_residual << std::endl;

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -448,7 +448,7 @@ struct IlutWrap {
     const auto l_row_nnz_end =
         L_row_map(row_idx + 1) - 1;  // skip diagonal for L
 
-    for (size_t l_nnz = l_row_nnz_begin; l_nnz < l_row_nnz_end; ++l_nnz) {
+    for (auto l_nnz = l_row_nnz_begin; l_nnz < l_row_nnz_end; ++l_nnz) {
       const auto col_idx = L_entries(l_nnz);
       const auto u_diag  = Ut_values(Ut_row_map(col_idx + 1) - 1);
       if (u_diag != 0.0) {
@@ -465,7 +465,7 @@ struct IlutWrap {
     const auto u_row_nnz_begin = U_row_map(row_idx);
     const auto u_row_nnz_end   = U_row_map(row_idx + 1);
 
-    for (size_t u_nnz = u_row_nnz_begin; u_nnz < u_row_nnz_end; ++u_nnz) {
+    for (auto u_nnz = u_row_nnz_begin; u_nnz < u_row_nnz_end; ++u_nnz) {
       const auto col_idx = U_entries(u_nnz);
       const auto sum     = compute_sum(row_idx, col_idx, A_row_map, A_entries,
                                    A_values, L_row_map, L_entries, L_values,

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -445,18 +445,19 @@ struct IlutWrap {
       UtEntriesType& Ut_entries, UtValuesType& Ut_values, const size_t row_idx,
       const bool async_update) {
     const auto l_row_nnz_begin = L_row_map(row_idx);
-    const auto l_row_nnz_end   = L_row_map(row_idx + 1) - 1; // skip diagonal for L
+    const auto l_row_nnz_end =
+        L_row_map(row_idx + 1) - 1;  // skip diagonal for L
 
     for (size_t l_nnz = l_row_nnz_begin; l_nnz < l_row_nnz_end; ++l_nnz) {
       const auto col_idx = L_entries(l_nnz);
       const auto u_diag  = Ut_values(Ut_row_map(col_idx + 1) - 1);
       if (u_diag != 0.0) {
         const auto new_val =
-          compute_sum(row_idx, col_idx, A_row_map, A_entries, A_values,
-                      L_row_map, L_entries, L_values, Ut_row_map,
-                      Ut_entries, Ut_values)
-          .first /
-          u_diag;
+            compute_sum(row_idx, col_idx, A_row_map, A_entries, A_values,
+                        L_row_map, L_entries, L_values, Ut_row_map, Ut_entries,
+                        Ut_values)
+                .first /
+            u_diag;
         L_values(l_nnz) = new_val;
       }
     }
@@ -466,7 +467,7 @@ struct IlutWrap {
 
     for (size_t u_nnz = u_row_nnz_begin; u_nnz < u_row_nnz_end; ++u_nnz) {
       const auto col_idx = U_entries(u_nnz);
-      const auto sum = compute_sum(row_idx, col_idx, A_row_map, A_entries,
+      const auto sum     = compute_sum(row_idx, col_idx, A_row_map, A_entries,
                                    A_values, L_row_map, L_entries, L_values,
                                    Ut_row_map, Ut_entries, Ut_values);
       const auto new_val = sum.first;
@@ -534,13 +535,13 @@ struct IlutWrap {
       Kokkos::deep_copy(Ut_values_h, Ut_values);
 
       Kokkos::parallel_for(
-        "compute_l_u_factors", spolicy_type(0, nrows),
-        KOKKOS_LAMBDA(const size_type row_idx) {
-          compute_l_u_factors_impl(
-            A_row_map_h, A_entries_h, A_values_h, L_row_map_h, L_entries_h,
-            L_values_h, U_row_map_h, U_entries_h, U_values_h, Ut_row_map_h,
-            Ut_entries_h, Ut_values_h, row_idx, true);
-      });
+          "compute_l_u_factors", spolicy_type(0, nrows),
+          KOKKOS_LAMBDA(const size_type row_idx) {
+            compute_l_u_factors_impl(
+                A_row_map_h, A_entries_h, A_values_h, L_row_map_h, L_entries_h,
+                L_values_h, U_row_map_h, U_entries_h, U_values_h, Ut_row_map_h,
+                Ut_entries_h, Ut_values_h, row_idx, true);
+          });
 
       Kokkos::deep_copy(L_values, L_values_h);
       Kokkos::deep_copy(U_values, U_values_h);
@@ -552,15 +553,15 @@ struct IlutWrap {
 #endif
     } else {
       constexpr bool on_gpu =
-        KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>();
+          KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>();
       Kokkos::parallel_for(
-        "compute_l_u_factors", range_policy(0, nrows),
-        KOKKOS_LAMBDA(const size_type row_idx) {
-          compute_l_u_factors_impl(A_row_map, A_entries, A_values, L_row_map,
-                                   L_entries, L_values, U_row_map, U_entries,
-                                   U_values, Ut_row_map, Ut_entries,
-                                   Ut_values, row_idx, !on_gpu);
-      });
+          "compute_l_u_factors", range_policy(0, nrows),
+          KOKKOS_LAMBDA(const size_type row_idx) {
+            compute_l_u_factors_impl(A_row_map, A_entries, A_values, L_row_map,
+                                     L_entries, L_values, U_row_map, U_entries,
+                                     U_values, Ut_row_map, Ut_entries,
+                                     Ut_values, row_idx, !on_gpu);
+          });
     }
   }
 

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_spec.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_spec.hpp
@@ -114,8 +114,7 @@ struct PAR_ILUT_NUMERIC {
                                const AValuesType &A_values,
                                LRowMapType &L_row_map, LEntriesType &L_entries,
                                LValuesType &L_values, URowMapType &U_row_map,
-                               UEntriesType &U_entries, UValuesType &U_values,
-                               bool deterministic = false);
+                               UEntriesType &U_entries, UValuesType &U_values);
 };
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
@@ -135,15 +134,14 @@ struct PAR_ILUT_NUMERIC<KernelHandle, ARowMapType, AEntriesType, AValuesType,
                                const AValuesType &A_values,
                                LRowMapType &L_row_map, LEntriesType &L_entries,
                                LValuesType &L_values, URowMapType &U_row_map,
-                               UEntriesType &U_entries, UValuesType &U_values,
-                               bool deterministic = false) {
+                               UEntriesType &U_entries, UValuesType &U_values) {
     auto par_ilut_handle = handle->get_par_ilut_handle();
     using Ilut           = Experimental::IlutWrap<
         typename std::remove_pointer<decltype(par_ilut_handle)>::type>;
 
     Ilut::ilut_numeric(*handle, *par_ilut_handle, A_row_map, A_entries,
                        A_values, L_row_map, L_entries, L_values, U_row_map,
-                       U_entries, U_values, deterministic);
+                       U_entries, U_values);
   }
 };
 

--- a/sparse/impl/KokkosSparse_par_ilut_symbolic_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_symbolic_impl.hpp
@@ -44,7 +44,9 @@ void ilut_symbolic(IlutHandle& thandle, const ARowMapType& A_row_map_d,
   using size_type       = typename IlutHandle::size_type;
   using Ilut            = IlutWrap<IlutHandle>;
 
-  thandle.set_nrows(A_row_map_d.extent(0) - 1);
+  const size_type a_nrows = A_row_map_d.extent(0);
+  const size_type nrows = a_nrows > 0 ? (a_nrows - 1) : 0;
+  thandle.set_nrows(nrows);
 
   const auto policy = thandle.get_default_team_policy();
 

--- a/sparse/impl/KokkosSparse_par_ilut_symbolic_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_symbolic_impl.hpp
@@ -83,8 +83,11 @@ void ilut_symbolic(IlutHandle& thandle, const ARowMapType& A_row_map_d,
   const size_type nnzsL = Ilut::prefix_sum(L_row_map_d);
   const size_type nnzsU = Ilut::prefix_sum(U_row_map_d);
 
+  // Set symbolic info on handle
+  thandle.set_nrows(A_row_map_d.extent(0) - 1);
   thandle.set_nnzL(nnzsL);
   thandle.set_nnzU(nnzsU);
+  thandle.set_symbolic_complete();
 
 }  // end ilut_symbolic
 

--- a/sparse/impl/KokkosSparse_par_ilut_symbolic_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_symbolic_impl.hpp
@@ -44,6 +44,8 @@ void ilut_symbolic(IlutHandle& thandle, const ARowMapType& A_row_map_d,
   using size_type       = typename IlutHandle::size_type;
   using Ilut            = IlutWrap<IlutHandle>;
 
+  thandle.set_nrows(A_row_map_d.extent(0) - 1);
+
   const auto policy = thandle.get_default_team_policy();
 
   // Sizing for the initial L/U approximation
@@ -84,7 +86,6 @@ void ilut_symbolic(IlutHandle& thandle, const ARowMapType& A_row_map_d,
   const size_type nnzsU = Ilut::prefix_sum(U_row_map_d);
 
   // Set symbolic info on handle
-  thandle.set_nrows(A_row_map_d.extent(0) - 1);
   thandle.set_nnzL(nnzsL);
   thandle.set_nnzU(nnzsU);
   thandle.set_symbolic_complete();

--- a/sparse/impl/KokkosSparse_par_ilut_symbolic_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_symbolic_impl.hpp
@@ -45,7 +45,7 @@ void ilut_symbolic(IlutHandle& thandle, const ARowMapType& A_row_map_d,
   using Ilut            = IlutWrap<IlutHandle>;
 
   const size_type a_nrows = A_row_map_d.extent(0);
-  const size_type nrows = a_nrows > 0 ? (a_nrows - 1) : 0;
+  const size_type nrows   = a_nrows > 0 ? (a_nrows - 1) : 0;
   thandle.set_nrows(nrows);
 
   const auto policy = thandle.get_default_team_policy();

--- a/sparse/impl/KokkosSparse_par_ilut_symbolic_spec.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_symbolic_spec.hpp
@@ -108,7 +108,6 @@ struct PAR_ILUT_SYMBOLIC<KernelHandle, ARowMapType, AEntriesType, LRowMapType,
 
     Experimental::ilut_symbolic(*par_ilut_handle, A_row_map, A_entries,
                                 L_row_map, U_row_map);
-    par_ilut_handle->set_symbolic_complete();
   }
 };
 #endif

--- a/sparse/src/KokkosKernels_Handle.hpp
+++ b/sparse/src/KokkosKernels_Handle.hpp
@@ -867,12 +867,13 @@ class KokkosKernelsHandle {
   }
 
   PAR_ILUTHandleType *get_par_ilut_handle() { return this->par_ilutHandle; }
-  void create_par_ilut_handle(const size_type nrows, const size_type nnzL = 0,
-                              const size_type nnzU     = 0,
-                              const size_type max_iter = 50) {
+  void create_par_ilut_handle(const size_type max_iter = 20,
+                              const typename PAR_ILUTHandleType::float_t residual_norm_delta_stop = 1e-2,
+                              const typename PAR_ILUTHandleType::float_t fill_in_limit = 0.75,
+                              const bool verbose = false) {
     this->destroy_par_ilut_handle();
     this->is_owner_of_the_par_ilut_handle = true;
-    this->par_ilutHandle = new PAR_ILUTHandleType(nrows, nnzL, nnzU, max_iter);
+    this->par_ilutHandle = new PAR_ILUTHandleType(max_iter, residual_norm_delta_stop, fill_in_limit, verbose);
     this->par_ilutHandle->set_team_size(this->team_work_size);
     this->par_ilutHandle->set_vector_size(this->vector_size);
   }

--- a/sparse/src/KokkosKernels_Handle.hpp
+++ b/sparse/src/KokkosKernels_Handle.hpp
@@ -869,7 +869,7 @@ class KokkosKernelsHandle {
   PAR_ILUTHandleType *get_par_ilut_handle() { return this->par_ilutHandle; }
   void create_par_ilut_handle(const size_type nrows, const size_type nnzL = 0,
                               const size_type nnzU     = 0,
-                              const size_type max_iter = 1) {
+                              const size_type max_iter = 50) {
     this->destroy_par_ilut_handle();
     this->is_owner_of_the_par_ilut_handle = true;
     this->par_ilutHandle = new PAR_ILUTHandleType(nrows, nnzL, nnzU, max_iter);

--- a/sparse/src/KokkosKernels_Handle.hpp
+++ b/sparse/src/KokkosKernels_Handle.hpp
@@ -870,10 +870,11 @@ class KokkosKernelsHandle {
   void create_par_ilut_handle(const size_type max_iter = 20,
                               const typename PAR_ILUTHandleType::float_t residual_norm_delta_stop = 1e-2,
                               const typename PAR_ILUTHandleType::float_t fill_in_limit = 0.75,
+                              const bool async_update = true,
                               const bool verbose = false) {
     this->destroy_par_ilut_handle();
     this->is_owner_of_the_par_ilut_handle = true;
-    this->par_ilutHandle = new PAR_ILUTHandleType(max_iter, residual_norm_delta_stop, fill_in_limit, verbose);
+    this->par_ilutHandle = new PAR_ILUTHandleType(max_iter, residual_norm_delta_stop, fill_in_limit, async_update, verbose);
     this->par_ilutHandle->set_team_size(this->team_work_size);
     this->par_ilutHandle->set_vector_size(this->vector_size);
   }

--- a/sparse/src/KokkosKernels_Handle.hpp
+++ b/sparse/src/KokkosKernels_Handle.hpp
@@ -867,14 +867,17 @@ class KokkosKernelsHandle {
   }
 
   PAR_ILUTHandleType *get_par_ilut_handle() { return this->par_ilutHandle; }
-  void create_par_ilut_handle(const size_type max_iter = 20,
-                              const typename PAR_ILUTHandleType::float_t residual_norm_delta_stop = 1e-2,
-                              const typename PAR_ILUTHandleType::float_t fill_in_limit = 0.75,
-                              const bool async_update = true,
-                              const bool verbose = false) {
+  void create_par_ilut_handle(
+      const size_type max_iter = 20,
+      const typename PAR_ILUTHandleType::float_t residual_norm_delta_stop =
+          1e-2,
+      const typename PAR_ILUTHandleType::float_t fill_in_limit = 0.75,
+      const bool async_update = true, const bool verbose = false) {
     this->destroy_par_ilut_handle();
     this->is_owner_of_the_par_ilut_handle = true;
-    this->par_ilutHandle = new PAR_ILUTHandleType(max_iter, residual_norm_delta_stop, fill_in_limit, async_update, verbose);
+    this->par_ilutHandle =
+        new PAR_ILUTHandleType(max_iter, residual_norm_delta_stop,
+                               fill_in_limit, async_update, verbose);
     this->par_ilutHandle->set_team_size(this->team_work_size);
     this->par_ilutHandle->set_vector_size(this->vector_size);
   }

--- a/sparse/src/KokkosSparse_par_ilut.hpp
+++ b/sparse/src/KokkosSparse_par_ilut.hpp
@@ -118,10 +118,12 @@ void par_ilut_symbolic(KernelHandle* handle, ARowMapType& A_rowmap,
       "par_ilut_symbolic: KernelHandle and Views have different execution "
       "spaces.");
 
-  KK_REQUIRE_MSG(A_rowmap.extent(0) == L_rowmap.extent(0),
-                 "L row map size does not match A row map");
-  KK_REQUIRE_MSG(A_rowmap.extent(0) == U_rowmap.extent(0),
-                 "U row map size does not match A row map");
+  if (A_rowmap.extent(0) != 0) {
+    KK_REQUIRE_MSG(A_rowmap.extent(0) == L_rowmap.extent(0),
+                   "L row map size does not match A row map");
+    KK_REQUIRE_MSG(A_rowmap.extent(0) == U_rowmap.extent(0),
+                   "U row map size does not match A row map");
+  }
 
   using c_size_t   = typename KernelHandle::const_size_type;
   using c_lno_t    = typename KernelHandle::const_nnz_lno_t;

--- a/sparse/src/KokkosSparse_par_ilut.hpp
+++ b/sparse/src/KokkosSparse_par_ilut.hpp
@@ -20,10 +20,11 @@
 /// This file provides KokkosSparse::par_ilut.  This function performs a
 /// local (no MPI) sparse ILU(t) on matrices stored in
 /// compressed row sparse ("Crs") format. It is expected that symbolic
-/// is called before numeric. The numeric function offers a deterministic
-/// flag that will force the function to have deterministic results. This
-/// is useful for testing but incurs a big performance penalty. The par_ilut
-/// algorithm will repeat (iterate) until max_iters is hit or the improvement
+/// is called before numeric. The handle offers an async_update
+/// flag that controls whether asynchronous updates are allowed while computing
+/// L U factors. This is useful for testing as it allows for repeatable (deterministic)
+/// results but may cause the algorithm to take longer (more iterations) to converge.
+/// The par_ilut algorithm will repeat (iterate) until max_iters is hit or the improvement
 /// in the residual from iter to iter drops below a certain threshold.
 ///
 /// This algorithm is described in the paper:
@@ -178,8 +179,7 @@ void par_ilut_numeric(KernelHandle* handle, ARowMapType& A_rowmap,
                       AEntriesType& A_entries, AValuesType& A_values,
                       LRowMapType& L_rowmap, LEntriesType& L_entries,
                       LValuesType& L_values, URowMapType& U_rowmap,
-                      UEntriesType& U_entries, UValuesType& U_values,
-                      bool deterministic) {
+                      UEntriesType& U_entries, UValuesType& U_values) {
   using size_type    = typename KernelHandle::size_type;
   using ordinal_type = typename KernelHandle::nnz_lno_t;
   using scalar_type  = typename KernelHandle::nnz_scalar_t;
@@ -446,7 +446,7 @@ void par_ilut_numeric(KernelHandle* handle, ARowMapType& A_rowmap,
       UValues_Internal>::par_ilut_numeric(&tmp_handle, A_rowmap_i, A_entries_i,
                                           A_values_i, L_rowmap_i, L_entries_i,
                                           L_values_i, U_rowmap_i, U_entries_i,
-                                          U_values_i, deterministic);
+                                          U_values_i);
 
   // These may have been resized
   L_entries = L_entries_i;

--- a/sparse/src/KokkosSparse_par_ilut.hpp
+++ b/sparse/src/KokkosSparse_par_ilut.hpp
@@ -22,7 +22,9 @@
 /// compressed row sparse ("Crs") format. It is expected that symbolic
 /// is called before numeric. The numeric function offers a deterministic
 /// flag that will force the function to have deterministic results. This
-/// is useful for testing but incurs a big performance penalty.
+/// is useful for testing but incurs a big performance penalty. The par_ilut
+/// algorithm will repeat (iterate) until max_iters is hit or the improvement
+/// in the residual from iter to iter drops below a certain threshold.
 ///
 /// This algorithm is described in the paper:
 /// PARILUT - A New Parallel Threshold ILU Factorization - Anzt, Chow, Dongarra
@@ -113,6 +115,9 @@ void par_ilut_symbolic(KernelHandle* handle, ARowMapType& A_rowmap,
           typename KernelHandle::PAR_ILUTHandleType::execution_space>::value,
       "par_ilut_symbolic: KernelHandle and Views have different execution "
       "spaces.");
+
+  KK_REQUIRE_MSG(A_rowmap.extent(0) == L_rowmap.extent(0), "L row map size does not match A row map");
+  KK_REQUIRE_MSG(A_rowmap.extent(0) == U_rowmap.extent(0), "U row map size does not match A row map");
 
   using c_size_t   = typename KernelHandle::const_size_type;
   using c_lno_t    = typename KernelHandle::const_nnz_lno_t;

--- a/sparse/src/KokkosSparse_par_ilut.hpp
+++ b/sparse/src/KokkosSparse_par_ilut.hpp
@@ -22,10 +22,11 @@
 /// compressed row sparse ("Crs") format. It is expected that symbolic
 /// is called before numeric. The handle offers an async_update
 /// flag that controls whether asynchronous updates are allowed while computing
-/// L U factors. This is useful for testing as it allows for repeatable (deterministic)
-/// results but may cause the algorithm to take longer (more iterations) to converge.
-/// The par_ilut algorithm will repeat (iterate) until max_iters is hit or the improvement
-/// in the residual from iter to iter drops below a certain threshold.
+/// L U factors. This is useful for testing as it allows for repeatable
+/// (deterministic) results but may cause the algorithm to take longer (more
+/// iterations) to converge. The par_ilut algorithm will repeat (iterate) until
+/// max_iters is hit or the improvement in the residual from iter to iter drops
+/// below a certain threshold.
 ///
 /// This algorithm is described in the paper:
 /// PARILUT - A New Parallel Threshold ILU Factorization - Anzt, Chow, Dongarra
@@ -117,8 +118,10 @@ void par_ilut_symbolic(KernelHandle* handle, ARowMapType& A_rowmap,
       "par_ilut_symbolic: KernelHandle and Views have different execution "
       "spaces.");
 
-  KK_REQUIRE_MSG(A_rowmap.extent(0) == L_rowmap.extent(0), "L row map size does not match A row map");
-  KK_REQUIRE_MSG(A_rowmap.extent(0) == U_rowmap.extent(0), "U row map size does not match A row map");
+  KK_REQUIRE_MSG(A_rowmap.extent(0) == L_rowmap.extent(0),
+                 "L row map size does not match A row map");
+  KK_REQUIRE_MSG(A_rowmap.extent(0) == U_rowmap.extent(0),
+                 "U row map size does not match A row map");
 
   using c_size_t   = typename KernelHandle::const_size_type;
   using c_lno_t    = typename KernelHandle::const_nnz_lno_t;
@@ -442,11 +445,16 @@ void par_ilut_numeric(KernelHandle* handle, ARowMapType& A_rowmap,
   KokkosSparse::Impl::PAR_ILUT_NUMERIC<
       const_handle_type, ARowMap_Internal, AEntries_Internal, AValues_Internal,
       LRowMap_Internal, LEntries_Internal, LValues_Internal, URowMap_Internal,
-      UEntries_Internal,
-      UValues_Internal>::par_ilut_numeric(&tmp_handle, A_rowmap_i, A_entries_i,
-                                          A_values_i, L_rowmap_i, L_entries_i,
-                                          L_values_i, U_rowmap_i, U_entries_i,
-                                          U_values_i);
+      UEntries_Internal, UValues_Internal>::par_ilut_numeric(&tmp_handle,
+                                                             A_rowmap_i,
+                                                             A_entries_i,
+                                                             A_values_i,
+                                                             L_rowmap_i,
+                                                             L_entries_i,
+                                                             L_values_i,
+                                                             U_rowmap_i,
+                                                             U_entries_i,
+                                                             U_values_i);
 
   // These may have been resized
   L_entries = L_entries_i;

--- a/sparse/src/KokkosSparse_par_ilut_handle.hpp
+++ b/sparse/src/KokkosSparse_par_ilut_handle.hpp
@@ -117,12 +117,12 @@ class PAR_ILUTHandle {
         fill_in_limit(fill_in_limit_),
         async_update(async_update_),
         verbose(verbose_),
+        team_size(-1),
+        vector_size(-1),
         nrows(0),
         nnzL(0),
         nnzU(0),
         symbolic_complete(false),
-        team_size(-1),
-        vector_size(-1),
         num_iters(-1),
         end_rel_res(-1) {}
 

--- a/sparse/src/KokkosSparse_par_ilut_handle.hpp
+++ b/sparse/src/KokkosSparse_par_ilut_handle.hpp
@@ -89,7 +89,7 @@ class PAR_ILUTHandle {
         nnzL(nnzL_),
         nnzU(nnzU_),
         max_iter(max_iter_),
-        residual_norm_delta_stop(1e-15),
+        residual_norm_delta_stop(1e-2),
         symbolic_complete(false),
         team_size(-1),
         vector_size(-1),
@@ -104,7 +104,7 @@ class PAR_ILUTHandle {
     set_nrows(nrows_);
     set_nnzL(nnzL_);
     set_nnzU(nnzU_);
-    set_residual_norm_delta_stop(1e-15);
+    set_residual_norm_delta_stop(1e-2);
     reset_symbolic_complete();
     set_fill_in_limit(0.75);
     set_verbose(false);

--- a/sparse/src/KokkosSparse_par_ilut_handle.hpp
+++ b/sparse/src/KokkosSparse_par_ilut_handle.hpp
@@ -96,8 +96,7 @@ class PAR_ILUTHandle {
         fill_in_limit(0.75),
         verbose(false),
         num_iters(-1),
-        end_rel_res(-1)
- {}
+        end_rel_res(-1) {}
 
   void reset_handle(const size_type nrows_, const size_type nnzL_,
                     const size_type nnzU_) {
@@ -108,8 +107,8 @@ class PAR_ILUTHandle {
     reset_symbolic_complete();
     set_fill_in_limit(0.75);
     set_verbose(false);
-    num_iters     = -1;
-    end_rel_res   = -1;
+    num_iters   = -1;
+    end_rel_res = -1;
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -147,8 +146,7 @@ class PAR_ILUTHandle {
   void set_max_iter(const size_type max_iter_) { this->max_iter = max_iter_; }
   int get_max_iter() const { return this->max_iter; }
 
-  void set_residual_norm_delta_stop(
-      const float_t residual_norm_delta_stop_) {
+  void set_residual_norm_delta_stop(const float_t residual_norm_delta_stop_) {
     this->residual_norm_delta_stop = residual_norm_delta_stop_;
   }
   float_t get_residual_norm_delta_stop() const {
@@ -172,19 +170,14 @@ class PAR_ILUTHandle {
     }
   }
 
-  int get_num_iters() const {
-    return num_iters;
-  }
+  int get_num_iters() const { return num_iters; }
 
-  float_t get_end_rel_res() const {
-    return end_rel_res;
-  }
+  float_t get_end_rel_res() const { return end_rel_res; }
 
   void set_stats(int num_iters_, float_t end_rel_res_) {
-    num_iters     = num_iters_;
-    end_rel_res   = end_rel_res_;
+    num_iters   = num_iters_;
+    end_rel_res = end_rel_res_;
   }
-
 };
 
 }  // namespace Experimental

--- a/sparse/src/KokkosSparse_par_ilut_handle.hpp
+++ b/sparse/src/KokkosSparse_par_ilut_handle.hpp
@@ -25,8 +25,8 @@ namespace KokkosSparse {
 namespace Experimental {
 
 /**
- * Handle for par_ilut. Contains useful types, par_ilut configuration settings, symbolic settings
- * and scalar output info.
+ * Handle for par_ilut. Contains useful types, par_ilut configuration settings,
+ * symbolic settings and scalar output info.
  *
  * For more info, see KokkosSparse_par_ilut.hpp doxygen
  */
@@ -73,29 +73,43 @@ class PAR_ILUTHandle {
 
  private:
   // User inputs
-  size_type max_iter;               /// Hard cap on the number of par_ilut iterations
-  float_t residual_norm_delta_stop; /// When the change in residual from iteration to iteration drops below this, the algorithm will stop (even if max_iters has not been hit)
-  float_t fill_in_limit;            /// The threshold for the ILU factorization
-  bool async_update;                /// Whether compute LU factors should do asychronous updates. When ON, the algorithm will usually converge faster but it makes the algorithm non-deterministic. This will always be OFF for GPU since it doesn't work there.
-  bool verbose;                     /// Print information while executing par_ilut
+  size_type max_iter;  /// Hard cap on the number of par_ilut iterations
+  float_t residual_norm_delta_stop;  /// When the change in residual from
+                                     /// iteration to iteration drops below
+                                     /// this, the algorithm will stop (even if
+                                     /// max_iters has not been hit)
+  float_t fill_in_limit;             /// The threshold for the ILU factorization
+  bool async_update;  /// Whether compute LU factors should do asychronous
+                      /// updates. When ON, the algorithm will usually converge
+                      /// faster but it makes the algorithm non-deterministic.
+                      /// This will always be OFF for GPU since it doesn't work
+                      /// there.
+  bool verbose;       /// Print information while executing par_ilut
 
   // Stored by parent KokkosKernelsHandle
-  int team_size;   /// Kokkos team size. Set by the parent handle. -1 implies AUTO
-  int vector_size; /// Kokkos vector size. Set by the parent handle.
+  int team_size;    /// Kokkos team size. Set by the parent handle. -1 implies
+                    /// AUTO
+  int vector_size;  /// Kokkos vector size. Set by the parent handle.
 
   // Stored by symbolic phase
-  size_type nrows;        /// Number of rows in the CSRs given to the symbolic par_ilut
-  size_type nnzL;         /// Number of non-zero entries in the L part of A in the CSRs given to the symbolic par_ilut
-  size_type nnzU;         /// Number of non-zero entries in the U part of A in the CSRs given to the symbolic par_ilut
-  bool symbolic_complete; /// Whether symbolic par_ilut has been called
+  size_type
+      nrows;       /// Number of rows in the CSRs given to the symbolic par_ilut
+  size_type nnzL;  /// Number of non-zero entries in the L part of A in the CSRs
+                   /// given to the symbolic par_ilut
+  size_type nnzU;  /// Number of non-zero entries in the U part of A in the CSRs
+                   /// given to the symbolic par_ilut
+  bool symbolic_complete;  /// Whether symbolic par_ilut has been called
 
   // Outputs
-  int num_iters;            /// The number of iterations par_ilut took to finish
-  nnz_scalar_t end_rel_res; /// The A - LU residual norm at the time the algorithm finished
+  int num_iters;  /// The number of iterations par_ilut took to finish
+  nnz_scalar_t end_rel_res;  /// The A - LU residual norm at the time the
+                             /// algorithm finished
 
  public:
-  // See KokkosKernelsHandle::create_par_ilut_handle for default user input values
-  PAR_ILUTHandle(const size_type max_iter_, const float_t residual_norm_delta_stop_,
+  // See KokkosKernelsHandle::create_par_ilut_handle for default user input
+  // values
+  PAR_ILUTHandle(const size_type max_iter_,
+                 const float_t residual_norm_delta_stop_,
                  const float_t fill_in_limit_, const bool async_update_,
                  const bool verbose_)
       : max_iter(max_iter_),
@@ -165,7 +179,9 @@ class PAR_ILUTHandle {
 
   bool get_async_update() const { return async_update; }
 
-  void set_async_update(const bool async_update_) { this->async_update = async_update_; }
+  void set_async_update(const bool async_update_) {
+    this->async_update = async_update_;
+  }
 
   TeamPolicy get_default_team_policy() const {
     if (team_size == -1) {

--- a/sparse/src/KokkosSparse_par_ilut_handle.hpp
+++ b/sparse/src/KokkosSparse_par_ilut_handle.hpp
@@ -80,7 +80,7 @@ class PAR_ILUTHandle {
 
   // Outputs
   int num_iters;
-  float_t end_rel_res;
+  nnz_scalar_t end_rel_res;
 
  public:
   PAR_ILUTHandle(const size_type nrows_, const size_type nnzL_ = 0,
@@ -172,9 +172,9 @@ class PAR_ILUTHandle {
 
   int get_num_iters() const { return num_iters; }
 
-  float_t get_end_rel_res() const { return end_rel_res; }
+  nnz_scalar_t get_end_rel_res() const { return end_rel_res; }
 
-  void set_stats(int num_iters_, float_t end_rel_res_) {
+  void set_stats(int num_iters_, nnz_scalar_t end_rel_res_) {
     num_iters   = num_iters_;
     end_rel_res = end_rel_res_;
   }

--- a/sparse/src/KokkosSparse_par_ilut_handle.hpp
+++ b/sparse/src/KokkosSparse_par_ilut_handle.hpp
@@ -24,6 +24,8 @@
 namespace KokkosSparse {
 namespace Experimental {
 
+// Handle for par_ilut. Contains useful types, par_ilut configuration settings, symbolic settings
+// and scalar output info.
 template <class size_type_, class lno_t_, class scalar_t_, class ExecutionSpace,
           class TemporaryMemorySpace, class PersistentMemorySpace>
 class PAR_ILUTHandle {
@@ -66,50 +68,42 @@ class PAR_ILUTHandle {
                    typename nnz_row_view_t::memory_traits>;
 
  private:
-  // Inputs
+  // User inputs
+  size_type max_iter;
+  float_t residual_norm_delta_stop;
+  float_t fill_in_limit;
+  bool verbose;
+
+  // Stored by parent KokkosKernelsHandle
+  int team_size;
+  int vector_size;
+
+  // Stored by symbolic phase
   size_type nrows;
   size_type nnzL;
   size_type nnzU;
-  size_type max_iter;
-  float_t residual_norm_delta_stop;
   bool symbolic_complete;
-  int team_size;
-  int vector_size;
-  float_t fill_in_limit;
-  bool verbose;
 
   // Outputs
   int num_iters;
   nnz_scalar_t end_rel_res;
 
  public:
-  PAR_ILUTHandle(const size_type nrows_, const size_type nnzL_ = 0,
-                 const size_type nnzU_ = 0, const size_type max_iter_ = 50)
-      : nrows(nrows_),
-        nnzL(nnzL_),
-        nnzU(nnzU_),
-        max_iter(max_iter_),
-        residual_norm_delta_stop(1e-2),
+  // See KokkosKernelsHandle::create_par_ilut_handle for default user input values
+  PAR_ILUTHandle(const size_type max_iter_, const float_t residual_norm_delta_stop_,
+                 const float_t fill_in_limit_, const bool verbose_)
+      : max_iter(max_iter_),
+        residual_norm_delta_stop(residual_norm_delta_stop_),
+        fill_in_limit(fill_in_limit_),
+        verbose(verbose_),
+        nrows(0),
+        nnzL(0),
+        nnzU(0),
         symbolic_complete(false),
         team_size(-1),
         vector_size(-1),
-        fill_in_limit(0.75),
-        verbose(false),
         num_iters(-1),
         end_rel_res(-1) {}
-
-  void reset_handle(const size_type nrows_, const size_type nnzL_,
-                    const size_type nnzU_) {
-    set_nrows(nrows_);
-    set_nnzL(nnzL_);
-    set_nnzU(nnzU_);
-    set_residual_norm_delta_stop(1e-2);
-    reset_symbolic_complete();
-    set_fill_in_limit(0.75);
-    set_verbose(false);
-    num_iters   = -1;
-    end_rel_res = -1;
-  }
 
   KOKKOS_INLINE_FUNCTION
   ~PAR_ILUTHandle() {}

--- a/sparse/unit_test/Test_Sparse_par_ilut.hpp
+++ b/sparse/unit_test/Test_Sparse_par_ilut.hpp
@@ -294,7 +294,8 @@ void run_test_par_ilut_precond() {
   using float_t = typename Kokkos::ArithTraits<scalar_t>::mag_type;
 
   // Create a diagonally dominant sparse matrix to test:
-  //  par_ilut settings max_iters, res_delta_stop, fill_in_limit, and async_update are all left as defaults
+  //  par_ilut settings max_iters, res_delta_stop, fill_in_limit, and
+  //  async_update are all left as defaults
   constexpr auto n             = 5000;
   constexpr auto m             = 15;
   constexpr auto tol           = ParIlut::TolMeta<float_t>::value;

--- a/sparse/unit_test/Test_Sparse_par_ilut.hpp
+++ b/sparse/unit_test/Test_Sparse_par_ilut.hpp
@@ -489,20 +489,20 @@ void test_par_ilut_zerorow_A() {
   Test::run_test_par_ilut_zerorow_A<scalar_t, lno_t, size_type, device>();
 }
 
-
-#define KOKKOSKERNELS_EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE)               \
-  TEST_F(TestCategory,                                                            \
-         sparse##_##par_ilut##_##SCALAR##_##ORDINAL##_##OFFSET##_##DEVICE) {      \
-    test_par_ilut<SCALAR, ORDINAL, OFFSET, DEVICE>();                             \
-  }                                                                               \
-  TEST_F(TestCategory,                                                            \
-         sparse##_##par_ilut_zerorow_A##_##SCALAR##_##ORDINAL##_##OFFSET##_##DEVICE) { \
-    test_par_ilut_zerorow_A<SCALAR, ORDINAL, OFFSET, DEVICE>();                   \
-  }                                                                               \
-  TEST_F(                                                                         \
-      TestCategory,                                                               \
-      sparse##_##par_ilut_precond##_##SCALAR##_##ORDINAL##_##OFFSET##_##DEVICE) { \
-    test_par_ilut_precond<SCALAR, ORDINAL, OFFSET, DEVICE>();                     \
+#define KOKKOSKERNELS_EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE)                 \
+  TEST_F(TestCategory,                                                              \
+         sparse##_##par_ilut##_##SCALAR##_##ORDINAL##_##OFFSET##_##DEVICE) {        \
+    test_par_ilut<SCALAR, ORDINAL, OFFSET, DEVICE>();                               \
+  }                                                                                 \
+  TEST_F(                                                                           \
+      TestCategory,                                                                 \
+      sparse##_##par_ilut_zerorow_A##_##SCALAR##_##ORDINAL##_##OFFSET##_##DEVICE) { \
+    test_par_ilut_zerorow_A<SCALAR, ORDINAL, OFFSET, DEVICE>();                     \
+  }                                                                                 \
+  TEST_F(                                                                           \
+      TestCategory,                                                                 \
+      sparse##_##par_ilut_precond##_##SCALAR##_##ORDINAL##_##OFFSET##_##DEVICE) {   \
+    test_par_ilut_precond<SCALAR, ORDINAL, OFFSET, DEVICE>();                       \
   }
 
 #define NO_TEST_COMPLEX

--- a/sparse/unit_test/Test_Sparse_par_ilut.hpp
+++ b/sparse/unit_test/Test_Sparse_par_ilut.hpp
@@ -176,7 +176,7 @@ void run_test_par_ilut() {
   // Make kernel handle
   KernelHandle kh;
 
-  kh.create_par_ilut_handle(nrows);
+  kh.create_par_ilut_handle();
 
   auto par_ilut_handle = kh.get_par_ilut_handle();
 
@@ -330,7 +330,7 @@ void run_test_par_ilut_precond() {
       typename std::remove_reference<decltype(*gmres_handle)>::type;
   using ViewVectorType = typename GMRESHandle::nnz_value_view_t;
 
-  kh.create_par_ilut_handle(numRows);
+  kh.create_par_ilut_handle();
   auto par_ilut_handle = kh.get_par_ilut_handle();
   par_ilut_handle->set_verbose(verbose);
 

--- a/sparse/unit_test/Test_Sparse_par_ilut.hpp
+++ b/sparse/unit_test/Test_Sparse_par_ilut.hpp
@@ -332,6 +332,7 @@ void run_test_par_ilut_precond() {
 
   kh.create_par_ilut_handle(numRows);
   auto par_ilut_handle = kh.get_par_ilut_handle();
+  par_ilut_handle->set_verbose(verbose);
 
   // Pull out views from CRS
   auto row_map = A.graph.row_map;

--- a/sparse/unit_test/Test_Sparse_par_ilut.hpp
+++ b/sparse/unit_test/Test_Sparse_par_ilut.hpp
@@ -294,6 +294,7 @@ void run_test_par_ilut_precond() {
   using float_t = typename Kokkos::ArithTraits<scalar_t>::mag_type;
 
   // Create a diagonally dominant sparse matrix to test:
+  //  par_ilut settings max_iters, res_delta_stop, fill_in_limit, and async_update are all left as defaults
   constexpr auto n             = 5000;
   constexpr auto m             = 15;
   constexpr auto tol           = ParIlut::TolMeta<float_t>::value;

--- a/sparse/unit_test/Test_Sparse_par_ilut.hpp
+++ b/sparse/unit_test/Test_Sparse_par_ilut.hpp
@@ -355,12 +355,7 @@ void run_test_par_ilut_precond() {
 
   par_ilut_numeric(&kh, row_map, entries, values, L_row_map, L_entries,
                    L_values, U_row_map, U_entries, U_values,
-#ifdef KOKKOS_ENABLE_SERIAL
-                   true /*deterministic*/
-#else
-                   false /*cannot ask for determinism*/
-#endif
-  );
+                   false /* non-deterministic*/);
 
   // Create CRSs
   sp_matrix_type L("L", numRows, numCols, L_values.extent(0), L_values,
@@ -396,10 +391,7 @@ void run_test_par_ilut_precond() {
     EXPECT_EQ(conv_flag, GMRESHandle::Flag::Conv);
   }
 
-  // Solve Ax = b with LU preconditioner. Currently only works
-  // when deterministic mode in par_ilut is on, which is only
-  // possible when Kokkos::Serial has been enabled.
-#ifdef KOKKOS_ENABLE_SERIAL
+  // Solve Ax = b with LU preconditioner.
   {
     gmres_handle->reset_handle(m, tol);
     gmres_handle->set_verbose(verbose);
@@ -426,9 +418,6 @@ void run_test_par_ilut_precond() {
     EXPECT_EQ(conv_flag, GMRESHandle::Flag::Conv);
     EXPECT_LT(num_iters_precond, num_iters_plain);
   }
-#else
-  EXPECT_EQ(num_iters_precond, 0);
-#endif
 }
 
 }  // namespace Test


### PR DESCRIPTION
1) Fixes iterating of par_ilut. Previously, max_iter was defaulting to 1, now it defaults to 20.
2) Use a simple range_policy for compute_l_u_factors. Team_size>1 blows up the algorithm on GPU, so hierarchical parallelism is pointless.
3) Add optional verbose output for par_ilut
4) Add more documentation in the par_ilut handle
5) Refactor the `deterministic` setting: rename it to async_update and move it to the handle. Turning off async_update is enough to get determinism; running in a serial exe space was way overkill. async_updates must be always be off on GPU for things to work.
6) Reorganize par_ilut handle members based on their intent (user inputs vs symbolic setting vs outputs).