### PR TITLE
Support command line parameters in benchmarks

### DIFF
--- a/perf_test/BenchmarkMain.cpp
+++ b/perf_test/BenchmarkMain.cpp
@@ -21,11 +21,15 @@
 #include <Benchmark_Context.hpp>
 #include <Kokkos_Core.hpp>
 
+std::map<std::string, int> KokkosKernelsBenchmark::Params::params_;
+
 int main(int argc, char** argv) {
   Kokkos::initialize(argc, argv);
   benchmark::Initialize(&argc, argv);
   benchmark::SetDefaultTimeUnit(benchmark::kSecond);
+
   KokkosKernelsBenchmark::add_benchmark_context(true);
+  KokkosKernelsBenchmark::Params::parse_inputs(argc, argv);
 
   benchmark::RunSpecifiedBenchmarks();
 

--- a/perf_test/Benchmark_Context.hpp
+++ b/perf_test/Benchmark_Context.hpp
@@ -95,6 +95,21 @@ inline void add_benchmark_context(bool verbose = false) {
   add_version_info();
 }
 
+struct Params {
+  static std::map<std::string, int> params_;
+
+  static void parse_inputs(int argc, char** argv) {
+    for (int i = 1; i < argc; i += 2) {
+      params_[argv[i]] = std::atoi(argv[i + 1]);
+    }
+  }
+
+  static int get_param_or_default(std::string param, int default_value) {
+    return (params_.find(param) != params_.end()) ? params_[param]
+                                                  : default_value;
+  }
+};
+
 }  // namespace KokkosKernelsBenchmark
 
 #endif

--- a/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test_benchmark.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test_benchmark.cpp
@@ -74,7 +74,7 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <class ExecSpace>
-static void run(benchmark::State& state) {
+static void Blas1_dot_mv(benchmark::State& state) {
   const auto m      = state.range(0);
   const auto n      = state.range(1);
   const auto repeat = state.range(2);
@@ -82,11 +82,6 @@ static void run(benchmark::State& state) {
   using Scalar   = double;
   using MemSpace = typename ExecSpace::memory_space;
   using Device   = Kokkos::Device<ExecSpace, MemSpace>;
-
-  std::cout << "Running BLAS Level 1 DOT perfomrance experiment ("
-            << ExecSpace::name() << ")\n";
-
-  std::cout << "Each test input vector has a length of " << m << std::endl;
 
   Kokkos::View<Scalar**, Kokkos::LayoutLeft, Device> x(
       Kokkos::view_alloc(Kokkos::WithoutInitializing, "x"), m, n);
@@ -124,9 +119,7 @@ static void run(benchmark::State& state) {
     double avg   = total / repeat;
     // Flops calculation for a 1D matrix dot product per test run;
     size_t flopsPerRun = (size_t)2 * m * n;
-    printf("Avg DOT time: %f s.\n", avg);
-    printf("Avg DOT FLOP/s: %.3e\n", flopsPerRun / avg);
-    state.SetIterationTime(timer.seconds());
+    state.SetIterationTime(total);
 
     state.counters["Avg DOT time (s):"] =
         benchmark::Counter(avg, benchmark::Counter::kDefaults);
@@ -135,8 +128,7 @@ static void run(benchmark::State& state) {
   }
 }
 
-BENCHMARK(run<Kokkos::DefaultExecutionSpace>)
-    ->Name("KokkosBlas_dot_mv")
+BENCHMARK(Blas1_dot_mv<Kokkos::DefaultExecutionSpace>)
     ->ArgNames({"m", "n", "repeat"})
     ->Args({100000, 5, 20})
     ->UseManualTime();

--- a/perf_test/blas/blas1/KokkosBlas_dot_perf_test_benchmark.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_perf_test_benchmark.cpp
@@ -74,18 +74,13 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <class ExecSpace>
-static void run(benchmark::State& state) {
+static void Blas1_dot(benchmark::State& state) {
   const auto m      = state.range(0);
   const auto repeat = state.range(1);
   // Declare type aliases
   using Scalar   = double;
   using MemSpace = typename ExecSpace::memory_space;
   using Device   = Kokkos::Device<ExecSpace, MemSpace>;
-
-  std::cout << "Running BLAS Level 1 DOT perfomrance experiment ("
-            << ExecSpace::name() << ")\n";
-
-  std::cout << "Each test input vector has a length of " << m << std::endl;
 
   // Create 1D view w/ Device as the ExecSpace; this is an input vector
   // A(view_alloc(WithoutInitializing, "label"), m, n);
@@ -122,9 +117,7 @@ static void run(benchmark::State& state) {
     double avg   = total / repeat;
     // Flops calculation for a 1D matrix dot product per test run;
     size_t flopsPerRun = (size_t)2 * m;
-    printf("Avg DOT time: %f s.\n", avg);
-    printf("Avg DOT FLOP/s: %.3e\n", flopsPerRun / avg);
-    state.SetIterationTime(timer.seconds());
+    state.SetIterationTime(total);
 
     state.counters["Avg DOT time (s):"] =
         benchmark::Counter(avg, benchmark::Counter::kDefaults);
@@ -133,8 +126,7 @@ static void run(benchmark::State& state) {
   }
 }
 
-BENCHMARK(run<Kokkos::DefaultExecutionSpace>)
-    ->Name("KokkosBlas_dot")
+BENCHMARK(Blas1_dot<Kokkos::DefaultExecutionSpace>)
     ->ArgNames({"m", "repeat"})
     ->Args({100000, 1})
     ->UseManualTime();

--- a/perf_test/blas/blas1/KokkosBlas_team_dot_perf_test_benchmark.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_team_dot_perf_test_benchmark.cpp
@@ -79,7 +79,7 @@ struct teamDotFunctor {
 };
 
 template <class ExecSpace>
-static void run(benchmark::State& state) {
+static void Blas1_team_dot(benchmark::State& state) {
   const auto m      = state.range(0);
   const auto repeat = state.range(1);
   // Declare type aliases
@@ -98,12 +98,6 @@ static void run(benchmark::State& state) {
   // and Y
   Kokkos::deep_copy(x, 3.0);
   Kokkos::deep_copy(y, 2.0);
-
-  std::cout << "Running BLAS Level 1 Kokkos Teams-based implementation DOT "
-               "performance experiment ("
-            << ExecSpace::name() << ")\n";
-
-  std::cout << "Each test input vector has a length of " << m << std::endl;
 
   for (auto _ : state) {
     // Warm up run of dot:
@@ -128,9 +122,7 @@ static void run(benchmark::State& state) {
     double avg   = total / repeat;
     // Flops calculation for a 1D matrix dot product per test run;
     size_t flopsPerRun = (size_t)2 * m;
-    printf("Avg DOT time: %f s.\n", avg);
-    printf("Avg DOT FLOP/s: %.3e\n", flopsPerRun / avg);
-    state.SetIterationTime(timer.seconds());
+    state.SetIterationTime(total);
 
     state.counters["Avg DOT time (s):"] =
         benchmark::Counter(avg, benchmark::Counter::kDefaults);
@@ -139,8 +131,7 @@ static void run(benchmark::State& state) {
   }
 }
 
-BENCHMARK(run<Kokkos::DefaultExecutionSpace>)
-    ->Name("KokkosBlas_team_dot/run<Kokkos::DefaultExecutionSpace>")
+BENCHMARK(Blas1_team_dot<Kokkos::DefaultExecutionSpace>)
     ->ArgNames({"m", "repeat"})
     ->Args({100000, 1})
     ->UseManualTime();


### PR DESCRIPTION
Support command line parameters matching the behavior of original performance tests as closely as possible.

Sample output (console):
```
./build/perf_test/KokkosKernels_PerformanceTest_Benchmark --benchmark_format=console --benchmark_counters_tabular=true --m 99 --n 3 --repeat 2 --benchmark_filter=Blas1_dot_mv --use_openmp 1
```
```
Running ./build/perf_test/KokkosKernels_PerformanceTest_Benchmark
(...)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                 Time             CPU   Iterations Avg DOT FLOP/s: Avg DOT time (s):     OpenMP  Params::m  Params::n Params::repeat Params::use_cuda Params::use_hip Params::use_openmp Params::use_sycl Params::use_threads
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Blas1_dot_mv<double>/manual_time      0.000 s         0.000 s         44468         85.443M            6.952u          1         99          3              2                0               0                  1                0                   0
```

Sample output (json):
```json
{
  "context": {
(...)
    "Default Device": "N6Kokkos6OpenMPE",
    "GIT_BRANCH": "benchmark-command-line-params",
    "GIT_CLEAN_STATUS": "CLEAN",
    "GIT_COMMIT_DATE": "2023-03-30T15:57:56+02:00",
    "GIT_COMMIT_DESCRIPTION": "Parse command line parameters",
    "GIT_COMMIT_HASH": "f58c6469f",
    "GOOGLE_BENCHMARK_VERSION": "1.6.2",
(...)
  },
  "benchmarks": [
    {
      "name": "Blas1_dot_mv<double>/manual_time",
      "family_index": 0,
      "per_family_instance_index": 0,
      "run_name": "Blas1_dot_mv<double>/manual_time",
      "run_type": "iteration",
      "repetitions": 1,
      "repetition_index": 0,
      "threads": 1,
      "iterations": 44285,
      "real_time": 1.5161024026193994e-05,
      "cpu_time": 2.3002449520153550e-05,
      "time_unit": "s",
      "Avg DOT FLOP/s:": 8.5566119273984447e+07,
      "Avg DOT time (s):": 6.9419999999999998e-06,
      "OpenMP": 1.0000000000000000e+00,
      "Params::m": 9.9000000000000000e+01,
      "Params::n": 3.0000000000000000e+00,
      "Params::repeat": 2.0000000000000000e+00,
      "Params::use_cuda": 1.0000000000000000e+00,
      "Params::use_hip": 0.0000000000000000e+00,
      "Params::use_openmp": 1.0000000000000000e+00,
      "Params::use_sycl": 0.0000000000000000e+00,
      "Params::use_threads": 0.0000000000000000e+00
    }
  ]
}
```


Error when requesting unavailable `ExecSpace`:
```
Running ./build/perf_test/KokkosKernels_PerformanceTest_Benchmark
(...)
---------------------------------------------------------------------------
Benchmark                                 Time             CPU   Iterations
---------------------------------------------------------------------------
Blas1_dot_mv<double>/manual_time ERROR OCCURRED: 'CUDA requested, but not available.'
```