### PR TITLE
Fix #1758

### DIFF
--- a/CheckHostBlasReturnComplex.cmake
+++ b/CheckHostBlasReturnComplex.cmake
@@ -20,8 +20,8 @@ FUNCTION(CHECK_HOST_BLAS_RETURN_COMPLEX VARNAME)
 #define F77_BLAS_MANGLE${F77_BLAS_MANGLE}
 
 extern \"C\" {
-  std::complex<double> F77_BLAS_MANGLE(zdotc,ZDOTC)(
-    const int* n, 
+  void F77_BLAS_MANGLE(zdotc,ZDOTC)(
+    std::complex<double>* result, const int* n, 
     const std::complex<double> x[], const int* incx, 
     const std::complex<double> y[], const int* incy);
 }
@@ -35,13 +35,23 @@ int main() {
     TWO = std::complex<double>(0.0,2.0);
   f[0] =  ONE;
   f[1] =  TWO;
-  std::complex<double> ret
-   = F77_BLAS_MANGLE(zdotc,ZDOTC)(&NUM, f, &INC, f, &INC);
+  std::complex<double> ret;
+  F77_BLAS_MANGLE(zdotc,ZDOTC)(&ret, &NUM, f, &INC, f, &INC);
   return (ret.real() == double(5.0) ? 0 : 1);
 }
   "
   )
 
-  CHECK_CXX_SOURCE_RUNS("${SOURCE}" ${VARNAME})
+# Test whether the above program, which assumes BLAS can give back complex results
+# via pointer arguments, compiles and runs correctly.
+# If it does, assume that we don't need to get complex results as direct return values,
+# which causes -Wreturn-type-c-linkage warnings.
+CHECK_CXX_SOURCE_RUNS("${SOURCE}" KK_BLAS_RESULT_AS_POINTER_ARG)
+
+IF(${KK_BLAS_RESULT_AS_POINTER_ARG})
+  SET(VARNAME OFF)
+ELSE()
+  SET(VARNAME ON)
+ENDIF()
 
 ENDFUNCTION()


### PR DESCRIPTION
For BLAS routines producing a complex scalar result (like zdotc), prefer to get the result via a pointer argument, rather than as a direct return value. Directly returning a std::complex from an ``extern "C"`` function is technically not allowed and Clang warns about it.

For example, prefer:
```
zdotc_(&result, ...);
```
over:
```
result = zdotc_(...);
```