### PR TITLE
docs: Add stubs for some sparse APIs

### DIFF
--- a/docs/developer/apidocs/sparse.rst
+++ b/docs/developer/apidocs/sparse.rst
@@ -68,6 +68,7 @@ par_ilut
 .. doxygenfunction:: par_ilut_numeric(KernelHandle* handle, ARowMapType& A_rowmap, AEntriesType& A_entries, AValuesType& A_values, LRowMapType& L_rowmap, LEntriesType& L_entries, LValuesType& L_values, URowMapType& U_rowmap, UEntriesType& U_entries, UValuesType& U_values, bool deterministic)
 .. doxygenclass::    KokkosSparse::PAR_ILUTHandle
     :members:
+
 gmres
 -----
 .. doxygenfunction:: gmres(KernelHandle* handle, AMatrix& A, BType& B, XType& X, Preconditioner<AMatrix>* precond)

--- a/docs/developer/apidocs/sparse.rst
+++ b/docs/developer/apidocs/sparse.rst
@@ -65,7 +65,7 @@ block_gauss_seidel
 par_ilut
 --------
 .. doxygenfunction:: par_ilut_symbolic(KernelHandle* handle, ARowMapType& A_rowmap, AEntriesType& A_entries, LRowMapType& L_rowmap, URowMapType& U_rowmap)
-.. doxygenfunction:: par_ilut_numeric(KernelHandle* handle, ARowMapType& A_rowmap, AEntriesType& A_entries, AValuesType& A_values, LRowMapType& L_rowmap, LEntriesType& L_entries, LValuesType& L_values, URowMapType& U_rowmap, UEntriesType& U_entries, UValuesType& U_values, bool deterministic)
+.. doxygenfunction:: par_ilut_numeric(KernelHandle* handle, ARowMapType& A_rowmap, AEntriesType& A_entries, AValuesType& A_values, LRowMapType& L_rowmap, LEntriesType& L_entries, LValuesType& L_values, URowMapType& U_rowmap, UEntriesType& U_entries, UValuesType& U_values)
 .. doxygenclass::    KokkosSparse::PAR_ILUTHandle
     :members:
 

--- a/docs/developer/apidocs/sparse.rst
+++ b/docs/developer/apidocs/sparse.rst
@@ -66,7 +66,8 @@ par_ilut
 --------
 .. doxygenfunction:: par_ilut_symbolic(KernelHandle* handle, ARowMapType& A_rowmap, AEntriesType& A_entries, LRowMapType& L_rowmap, URowMapType& U_rowmap)
 .. doxygenfunction:: par_ilut_numeric(KernelHandle* handle, ARowMapType& A_rowmap, AEntriesType& A_entries, AValuesType& A_values, LRowMapType& L_rowmap, LEntriesType& L_entries, LValuesType& L_values, URowMapType& U_rowmap, UEntriesType& U_entries, UValuesType& U_values, bool deterministic)
-
+.. doxygenclass::    KokkosSparse::PAR_ILUTHandle
+    :members:
 gmres
 -----
 .. doxygenfunction:: gmres(KernelHandle* handle, AMatrix& A, BType& B, XType& X, Preconditioner<AMatrix>* precond)

--- a/docs/developer/apidocs/sparse.rst
+++ b/docs/developer/apidocs/sparse.rst
@@ -37,8 +37,36 @@ trsv
 
 spgemm
 ------
-.. doxygenfunction:: KokkosSparse::spgemm
+.. doxygenfunction:: spgemm_symbolic(KernelHandle& kh, const AMatrix& A, const bool Amode, const BMatrix& B, const bool Bmode, CMatrix& C)
+.. doxygenfunction:: spgemm_numeric(KernelHandle& kh, const AMatrix& A, const bool Amode, const BMatrix& B, const bool Bmode, CMatrix& C)
+.. doxygenfunction:: spgemm(const AMatrix& A, const bool Amode, const BMatrix& B, const bool Bmode)
 
-gauss
+block_spgemm
+------------
+.. doxygenfunction:: block_spgemm_symbolic(KernelHandle& kh, const AMatrixType& A, const bool transposeA, const BMatrixType& B,const bool transposeB, CMatrixType& C)
+.. doxygenfunction:: block_spgemm_numeric(KernelHandle& kh, const AMatrix& A, const bool Amode, const BMatrix& B, const bool Bmode, CMatrix& C)
+
+gauss_seidel
+------------
+.. doxygenfunction:: gauss_seidel_symbolic(KernelHandle *handle, typename KernelHandle::const_nnz_lno_t num_rows, typename KernelHandle::const_nnz_lno_t num_cols, lno_row_view_t_ row_map, lno_nnz_view_t_ entries, bool is_graph_symmetric)
+.. doxygenfunctions:: gauss_seidel_numeric(KernelHandle *handle, typename KernelHandle::const_nnz_lno_t num_rows, typename KernelHandle::const_nnz_lno_t num_cols, lno_row_view_t_ row_map, lno_nnz_view_t_ entries, scalar_nnz_view_t_ values, bool is_graph_symmetric)
+.. doxygenfunctions:: gauss_seidel_numeric(KernelHandle *handle, typename KernelHandle::const_nnz_lno_t num_rows, typename KernelHandle::const_nnz_lno_t num_cols, lno_row_view_t_ row_map, lno_nnz_view_t_ entries, scalar_nnz_view_t_ values, scalar_nnz_view_t_ given_inverse_diagonal, bool is_graph_symmetric)
+.. doxygenfunction:: symmetric_gauss_seidel_apply(KernelHandle *handle, typename KernelHandle::const_nnz_lno_t num_rows, typename KernelHandle::const_nnz_lno_t num_cols, lno_row_view_t_ row_map, lno_nnz_view_t_ entries, scalar_nnz_view_t_ values, x_scalar_view_t x_lhs_output_vec, y_scalar_view_t y_rhs_input_vec, bool init_zero_x_vector, bool update_y_vector, typename KernelHandle::nnz_scalar_t omega, int numIter)
+.. doxygenfunction:: backward_sweep_gauss_seidel_apply(KernelHandle *handle, typename KernelHandle::const_nnz_lno_t num_rows, typename KernelHandle::const_nnz_lno_t num_cols, lno_row_view_t_ row_map, lno_nnz_view_t_ entries, scalar_nnz_view_t_ values, x_scalar_view_t x_lhs_output_vec, y_scalar_view_t y_rhs_input_vec, bool init_zero_x_vector, bool update_y_vector, typename KernelHandle::nnz_scalar_t omega, int numIter)
+
+block_gauss_seidel
+------------------
+.. doxygenfunction:: block_gauss_seidel_symbolic(KernelHandle *handle, typename KernelHandle::const_nnz_lno_t num_rows, typename KernelHandle::const_nnz_lno_t num_cols, typename KernelHandle::const_nnz_lno_t block_size, lno_row_view_t_ row_map, lno_nnz_view_t_ entries, bool is_graph_symmetric)
+.. doxygenfunction:: block_gauss_seidel_numeric(KernelHandle *handle, typename KernelHandle::const_nnz_lno_t num_rows, typename KernelHandle::const_nnz_lno_t num_cols,typename KernelHandle::const_nnz_lno_t block_size, lno_row_view_t_ row_map, lno_nnz_view_t_ entries, scalar_nnz_view_t_ values, bool is_graph_symmetric)
+.. doxygenfunction:: symmetric_block_gauss_seidel_apply(KernelHandle *handle, typename KernelHandle::const_nnz_lno_t num_rows, typename KernelHandle::const_nnz_lno_t num_cols, typename KernelHandle::const_nnz_lno_t block_size, lno_row_view_t_ row_map, lno_nnz_view_t_ entries, scalar_nnz_view_t_ values, x_scalar_view_t x_lhs_output_vec, y_scalar_view_t y_rhs_input_vec, bool init_zero_x_vector, bool update_y_vector, typename KernelHandle::nnz_scalar_t omega, int numIter)
+.. doxygenfunction:: forward_sweep_block_gauss_seidel_apply(KernelHandle *handle, typename KernelHandle::const_nnz_lno_t num_rows, typename KernelHandle::const_nnz_lno_t num_cols, typename KernelHandle::const_nnz_lno_t block_size, lno_row_view_t_ row_map, lno_nnz_view_t_ entries, scalar_nnz_view_t_ values, x_scalar_view_t x_lhs_output_vec, y_scalar_view_t y_rhs_input_vec, bool init_zero_x_vector, bool update_y_vector, typename KernelHandle::nnz_scalar_t omega, int numIter)
+.. doxygenfunction:: backward_sweep_block_gauss_seidel_apply(KernelHandle *handle, typename KernelHandle::const_nnz_lno_t num_rows, typename KernelHandle::const_nnz_lno_t num_cols, typename KernelHandle::const_nnz_lno_t block_size,  lno_row_view_t_ row_map, lno_nnz_view_t_ entries, scalar_nnz_view_t_ values, x_scalar_view_t x_lhs_output_vec, y_scalar_view_t y_rhs_input_vec, bool init_zero_x_vector, bool update_y_vector, typename KernelHandle::nnz_scalar_t omega, int numIter)  
+
+par_ilut
+--------
+.. doxygenfunction:: par_ilut_symbolic(KernelHandle* handle, ARowMapType& A_rowmap, AEntriesType& A_entries, LRowMapType& L_rowmap, URowMapType& U_rowmap)
+.. doxygenfunction:: par_ilut_numeric(KernelHandle* handle, ARowMapType& A_rowmap, AEntriesType& A_entries, AValuesType& A_values, LRowMapType& L_rowmap, LEntriesType& L_entries, LValuesType& L_values, URowMapType& U_rowmap, UEntriesType& U_entries, UValuesType& U_values, bool deterministic)
+
+gmres
 -----
-.. doxygenfunction:: KokkosSparse::gauss
+.. doxygenfunction:: gmres(KernelHandle* handle, AMatrix& A, BType& B, XType& X, Preconditioner<AMatrix>* precond)

--- a/docs/developer/build_doc.rst
+++ b/docs/developer/build_doc.rst
@@ -16,3 +16,5 @@ Building Developer Documentation
         make Doxygen
         make Sphinx
         open build/docs/docs/sphinx/index.html
+
+Alternatively, pass the --enable-docs option to cm_generate_makefile.bash.

--- a/docs/developer/contrib.rst
+++ b/docs/developer/contrib.rst
@@ -54,7 +54,7 @@ In general, we prefer that the prototype has the doxygen style comment rather th
 
 **NOTE:** To have vscode generate the "\\\\\\" style stubs:
 
-1. install the C/C++ IntelliSense, debugging, and code browsing extention.
+1. install the C/C++ IntelliSense, debugging, and code browsing extension.
 
 2. go to Settings, Extensions, C/C++, Doxygen Documentation Generator Settings, and ensure the setting for Doxdocgen is "\\\\\\".
 

--- a/docs/developer/contrib.rst
+++ b/docs/developer/contrib.rst
@@ -24,6 +24,34 @@ In general, we prefer that the prototype has the doxygen style comment rather th
         KOKKOS_INLINE_FUNCTION ViewValueType
         access_view_bounds_check(ViewType v, int m, int n, const BoundsCheck::Yes &);
 
+.. code-block::
+    :caption: Type Doxygen Style Example
+
+    /// \class CooMatrix
+    ///
+    /// \brief Coordinate format implementation of a sparse matrix.
+    ///
+    /// \tparam ScalarType The type of scalar entries in the sparse matrix.
+    /// \tparam OrdinalType The type of index entries in the sparse matrix.
+    /// \tparam Device The Kokkos Device type.
+    /// "Coo" stands for "coordinate format".
+    template <class ScalarType>
+    class CooMatrix {
+      public:
+        //! Type of each value in the matrix
+        using scalar_type = ScalarType;
+
+      private:
+        size_type m_num_rows, m_num_cols;
+
+      public:
+        //! The data in the matrix
+        scalar_type data;
+
+      /// \brief Default constructor; constructs an empty sparse matrix.
+      KOKKOS_INLINE_FUNCTION
+      CooMatrix() : m_num_rows(0), m_num_cols(0) {}
+
 **NOTE:** To have vscode generate the "\\\\\\" style stubs:
 
 1. install the C/C++ IntelliSense, debugging, and code browsing extention.
@@ -31,6 +59,33 @@ In general, we prefer that the prototype has the doxygen style comment rather th
 2. go to Settings, Extensions, C/C++, Doxygen Documentation Generator Settings, and ensure the setting for Doxdocgen is "\\\\\\".
 
 3. place your cursor on the line above `template ...` and type "\\\\\\".
+
+Including your documentation with directives
+--------------------------------------------
+Rather than have the documentation generation system default to generating documentation for the entire code base,
+we opt-in to what we would like to include in the generated documentation. To opt-in, simply place the publicly facing
+function signature or the class name in the appropriate ReStructuredText file. For example, to document a sparse
+function and class open up kokkos-kernels/docs/developer/apidocs/sparse.rst:
+
+.. code-block::
+    :caption: Function signature example
+
+    coo2crs
+    -------
+    .. doxygenfunction:: KokkosSparse::coo2crs(DimType, DimType, RowViewType, ColViewType, DataViewType)
+    .. doxygenfunction:: KokkosSparse::coo2crs(KokkosSparse::CooMatrix<ScalarType, OrdinalType, DeviceType, MemoryTraitsType, SizeType> &cooMatrix)
+
+Note that only the signature is required. One may specify the parameter names and any default values, but this is not required.
+
+.. code-block::
+    :caption: User defined type example
+
+    coomatrix
+    ---------
+    .. doxygenclass::    KokkosSparse::CooMatrix
+      :members:
+
+For a full list of available directives, see https://breathe.readthedocs.io/en/latest/.
 
 Library policies
 ----------------

--- a/docs/developer/contrib.rst
+++ b/docs/developer/contrib.rst
@@ -24,6 +24,14 @@ In general, we prefer that the prototype has the doxygen style comment rather th
         KOKKOS_INLINE_FUNCTION ViewValueType
         access_view_bounds_check(ViewType v, int m, int n, const BoundsCheck::Yes &);
 
+**NOTE:** To have vscode generate the "\\\\\\" style stubs:
+
+1. install the C/C++ IntelliSense, debugging, and code browsing extention.
+
+2. go to Settings, Extensions, C/C++, Doxygen Documentation Generator Settings, and ensure the setting for Doxdocgen is "\\\\\\".
+
+3. place your cursor on the line above `template ...` and type "\\\\\\".
+
 Library policies
 ----------------
 

--- a/sparse/src/KokkosSparse_gauss_seidel.hpp
+++ b/sparse/src/KokkosSparse_gauss_seidel.hpp
@@ -25,6 +25,19 @@ namespace KokkosSparse {
 
 namespace Experimental {
 
+///
+/// @brief
+///
+/// @tparam KernelHandle
+/// @tparam lno_row_view_t_
+/// @tparam lno_nnz_view_t_
+/// @param handle
+/// @param num_rows
+/// @param num_cols
+/// @param row_map
+/// @param entries
+/// @param is_graph_symmetric
+///
 template <typename KernelHandle, typename lno_row_view_t_,
           typename lno_nnz_view_t_>
 void gauss_seidel_symbolic(KernelHandle *handle,
@@ -85,6 +98,20 @@ void gauss_seidel_symbolic(KernelHandle *handle,
                                                         is_graph_symmetric);
 }
 
+///
+/// @brief
+///
+/// @tparam KernelHandle
+/// @tparam lno_row_view_t_
+/// @tparam lno_nnz_view_t_
+/// @param handle
+/// @param num_rows
+/// @param num_cols
+/// @param block_size
+/// @param row_map
+/// @param entries
+/// @param is_graph_symmetric
+///
 template <typename KernelHandle, typename lno_row_view_t_,
           typename lno_nnz_view_t_>
 void block_gauss_seidel_symbolic(
@@ -104,6 +131,22 @@ void block_gauss_seidel_symbolic(
                         is_graph_symmetric);
 }
 
+///
+/// @brief
+///
+/// @tparam format
+/// @tparam KernelHandle
+/// @tparam lno_row_view_t_
+/// @tparam lno_nnz_view_t_
+/// @tparam scalar_nnz_view_t_
+/// @param handle
+/// @param num_rows
+/// @param num_cols
+/// @param row_map
+/// @param entries
+/// @param values
+/// @param is_graph_symmetric
+///
 template <KokkosSparse::SparseMatrixFormat format =
               KokkosSparse::SparseMatrixFormat::CRS,
           typename KernelHandle, typename lno_row_view_t_,
@@ -180,6 +223,23 @@ void gauss_seidel_numeric(KernelHandle *handle,
                                                           is_graph_symmetric);
 }
 
+///
+/// @brief
+///
+/// @tparam format
+/// @tparam KernelHandle
+/// @tparam lno_row_view_t_
+/// @tparam lno_nnz_view_t_
+/// @tparam scalar_nnz_view_t_
+/// @param handle
+/// @param num_rows
+/// @param num_cols
+/// @param row_map
+/// @param entries
+/// @param values
+/// @param given_inverse_diagonal
+/// @param is_graph_symmetric
+///
 template <KokkosSparse::SparseMatrixFormat format =
               KokkosSparse::SparseMatrixFormat::CRS,
           typename KernelHandle, typename lno_row_view_t_,
@@ -260,6 +320,23 @@ void gauss_seidel_numeric(KernelHandle *handle,
                                                           is_graph_symmetric);
 }
 
+///
+/// @brief
+///
+/// @tparam format
+/// @tparam KernelHandle
+/// @tparam lno_row_view_t_
+/// @tparam lno_nnz_view_t_
+/// @tparam scalar_nnz_view_t_
+/// @param handle
+/// @param num_rows
+/// @param num_cols
+/// @param block_size
+/// @param row_map
+/// @param entries
+/// @param values
+/// @param is_graph_symmetric
+///
 template <KokkosSparse::SparseMatrixFormat format =
               KokkosSparse::SparseMatrixFormat::BSR,
           typename KernelHandle, typename lno_row_view_t_,
@@ -282,6 +359,29 @@ void block_gauss_seidel_numeric(
                                values, is_graph_symmetric);
 }
 
+///
+/// @brief
+///
+/// @tparam format
+/// @tparam KernelHandle
+/// @tparam lno_row_view_t_
+/// @tparam lno_nnz_view_t_
+/// @tparam scalar_nnz_view_t_
+/// @tparam x_scalar_view_t
+/// @tparam y_scalar_view_t
+/// @param handle
+/// @param num_rows
+/// @param num_cols
+/// @param row_map
+/// @param entries
+/// @param values
+/// @param x_lhs_output_vec
+/// @param y_rhs_input_vec
+/// @param init_zero_x_vector
+/// @param update_y_vector
+/// @param omega
+/// @param numIter
+///
 template <KokkosSparse::SparseMatrixFormat format =
               KokkosSparse::SparseMatrixFormat::CRS,
           typename KernelHandle, typename lno_row_view_t_,
@@ -413,6 +513,30 @@ void symmetric_gauss_seidel_apply(
                          update_y_vector, omega, numIter, true, true);
 }
 
+///
+/// @brief
+///
+/// @tparam format
+/// @tparam KernelHandle
+/// @tparam lno_row_view_t_
+/// @tparam lno_nnz_view_t_
+/// @tparam scalar_nnz_view_t_
+/// @tparam x_scalar_view_t
+/// @tparam y_scalar_view_t
+/// @param handle
+/// @param num_rows
+/// @param num_cols
+/// @param block_size
+/// @param row_map
+/// @param entries
+/// @param values
+/// @param x_lhs_output_vec
+/// @param y_rhs_input_vec
+/// @param init_zero_x_vector
+/// @param update_y_vector
+/// @param omega
+/// @param numIter
+///
 template <KokkosSparse::SparseMatrixFormat format =
               KokkosSparse::SparseMatrixFormat::BSR,
           typename KernelHandle, typename lno_row_view_t_,
@@ -448,6 +572,30 @@ void symmetric_block_gauss_seidel_apply(
       handle, num_rows, num_cols, row_map, entries, values, x_lhs_output_vec,
       y_rhs_input_vec, init_zero_x_vector, update_y_vector, omega, numIter);
 }
+
+///
+/// @brief
+///
+/// @tparam format
+/// @tparam KernelHandle
+/// @tparam lno_row_view_t_
+/// @tparam lno_nnz_view_t_
+/// @tparam scalar_nnz_view_t_
+/// @tparam x_scalar_view_t
+/// @tparam y_scalar_view_t
+/// @param handle
+/// @param num_rows
+/// @param num_cols
+/// @param row_map
+/// @param entries
+/// @param values
+/// @param x_lhs_output_vec
+/// @param y_rhs_input_vec
+/// @param init_zero_x_vector
+/// @param update_y_vector
+/// @param omega
+/// @param numIter
+///
 template <KokkosSparse::SparseMatrixFormat format =
               KokkosSparse::SparseMatrixFormat::CRS,
           class KernelHandle, typename lno_row_view_t_,
@@ -581,6 +729,30 @@ void forward_sweep_gauss_seidel_apply(
                          update_y_vector, omega, numIter, true, false);
 }
 
+///
+/// @brief
+///
+/// @tparam format
+/// @tparam KernelHandle
+/// @tparam lno_row_view_t_
+/// @tparam lno_nnz_view_t_
+/// @tparam scalar_nnz_view_t_
+/// @tparam x_scalar_view_t
+/// @tparam y_scalar_view_t
+/// @param handle
+/// @param num_rows
+/// @param num_cols
+/// @param block_size
+/// @param row_map
+/// @param entries
+/// @param values
+/// @param x_lhs_output_vec
+/// @param y_rhs_input_vec
+/// @param init_zero_x_vector
+/// @param update_y_vector
+/// @param omega
+/// @param numIter
+///
 template <KokkosSparse::SparseMatrixFormat format =
               KokkosSparse::SparseMatrixFormat::BSR,
           typename KernelHandle, typename lno_row_view_t_,
@@ -616,6 +788,30 @@ void forward_sweep_block_gauss_seidel_apply(
       handle, num_rows, num_cols, row_map, entries, values, x_lhs_output_vec,
       y_rhs_input_vec, init_zero_x_vector, update_y_vector, omega, numIter);
 }
+
+///
+/// @brief
+///
+/// @tparam format
+/// @tparam KernelHandle
+/// @tparam lno_row_view_t_
+/// @tparam lno_nnz_view_t_
+/// @tparam scalar_nnz_view_t_
+/// @tparam x_scalar_view_t
+/// @tparam y_scalar_view_t
+/// @param handle
+/// @param num_rows
+/// @param num_cols
+/// @param row_map
+/// @param entries
+/// @param values
+/// @param x_lhs_output_vec
+/// @param y_rhs_input_vec
+/// @param init_zero_x_vector
+/// @param update_y_vector
+/// @param omega
+/// @param numIter
+///
 template <KokkosSparse::SparseMatrixFormat format =
               KokkosSparse::SparseMatrixFormat::CRS,
           class KernelHandle, typename lno_row_view_t_,
@@ -749,6 +945,30 @@ void backward_sweep_gauss_seidel_apply(
                          update_y_vector, omega, numIter, false, true);
 }
 
+///
+/// @brief
+///
+/// @tparam format
+/// @tparam KernelHandle
+/// @tparam lno_row_view_t_
+/// @tparam lno_nnz_view_t_
+/// @tparam scalar_nnz_view_t_
+/// @tparam x_scalar_view_t
+/// @tparam y_scalar_view_t
+/// @param handle
+/// @param num_rows
+/// @param num_cols
+/// @param block_size
+/// @param row_map
+/// @param entries
+/// @param values
+/// @param x_lhs_output_vec
+/// @param y_rhs_input_vec
+/// @param init_zero_x_vector
+/// @param update_y_vector
+/// @param omega
+/// @param numIter
+///
 template <KokkosSparse::SparseMatrixFormat format =
               KokkosSparse::SparseMatrixFormat::BSR,
           typename KernelHandle, typename lno_row_view_t_,

--- a/sparse/src/KokkosSparse_gmres.hpp
+++ b/sparse/src/KokkosSparse_gmres.hpp
@@ -46,6 +46,16 @@ namespace Experimental {
   std::is_same<typename std::remove_const<A>::type, \
                typename std::remove_const<B>::type>::value
 
+/// @brief
+/// @tparam KernelHandle
+/// @tparam AMatrix
+/// @tparam BType
+/// @tparam XType
+/// @param handle
+/// @param A
+/// @param B
+/// @param X
+/// @param precond
 template <typename KernelHandle, typename AMatrix, typename BType,
           typename XType>
 void gmres(KernelHandle* handle, AMatrix& A, BType& B, XType& X,

--- a/sparse/src/KokkosSparse_par_ilut.hpp
+++ b/sparse/src/KokkosSparse_par_ilut.hpp
@@ -215,7 +215,6 @@ void par_ilut_symbolic(KernelHandle* handle, ARowMapType& A_rowmap,
 /// @param U_rowmap The row map (row nnz offsets) for the U CSR (Input/Output)
 /// @param U_entries The entries (column ids) for the U CSR (Output)
 /// @param U_values The values (non-zero matrix values) for the U CSR (Output)
-/// @param deterministic Please ignore. This parameter will be removed soon.
 template <typename KernelHandle, typename ARowMapType, typename AEntriesType,
           typename AValuesType, typename LRowMapType, typename LEntriesType,
           typename LValuesType, typename URowMapType, typename UEntriesType,

--- a/sparse/src/KokkosSparse_par_ilut.hpp
+++ b/sparse/src/KokkosSparse_par_ilut.hpp
@@ -44,7 +44,8 @@ namespace Experimental {
   std::is_same<typename std::remove_const<A>::type, \
                typename std::remove_const<B>::type>::value
 
-/// @brief Performs the symbolic phase of par_ilut (non-blocking).
+/// @brief Performs the symbolic phase of par_ilut.
+///        This is a non-blocking function.
 ///
 /// The sparsity pattern of A will be analyzed and L_rowmap and U_rowmap will be
 /// populated with the L (lower triangular) and U (upper triagular) non-zero
@@ -186,28 +187,34 @@ void par_ilut_symbolic(KernelHandle* handle, ARowMapType& A_rowmap,
 
 }  // par_ilut_symbolic
 
-/// @brief
-/// @tparam KernelHandle
-/// @tparam ARowMapType
-/// @tparam AEntriesType
-/// @tparam AValuesType
-/// @tparam LRowMapType
-/// @tparam LEntriesType
-/// @tparam LValuesType
-/// @tparam URowMapType
-/// @tparam UEntriesType
-/// @tparam UValuesType
-/// @param handle
-/// @param A_rowmap
-/// @param A_entries
-/// @param A_values
-/// @param L_rowmap
-/// @param L_entries
-/// @param L_values
-/// @param U_rowmap
-/// @param U_entries
-/// @param U_values
-/// @param deterministic
+/// @brief Performs the numeric phase (for specific CSRs, not reusable) of the
+/// par_ilut
+///        algorithm (described in the header). This is a non-blocking
+///        functions. It is expected that par_ilut_symbolic has already been
+///        called for the
+//         provided KernelHandle.
+///
+/// @tparam KernelHandle Template for the handle type
+/// @tparam ARowMapType Template for the A_rowmap type
+/// @tparam AEntriesType Template for the A_entries type
+/// @tparam AValuesType Template for the A_values type
+/// @tparam LRowMapType Template for the L_rowmap type
+/// @tparam LEntriesType Template for the L_entries type
+/// @tparam LValuesType Template for the L_values type
+/// @tparam URowMapType Template for the U_rowmap type
+/// @tparam UEntriesType Template for the U_entries type
+/// @tparam UValuesType Template for the U_values type
+/// @param handle The kernel handle. It is expected that create_par_ilut_handle
+/// has been called on it
+/// @param A_rowmap The row map (row nnz offsets) for the A CSR (Input)
+/// @param A_entries The entries (column ids) for the A CSR (Input)
+/// @param A_values The values (non-zero matrix values) for the A CSR (Input)
+/// @param L_rowmap The row map (row nnz offsets) for the L CSR (Input/Output)
+/// @param L_entries The entries (column ids) for the L CSR (Output)
+/// @param L_values The values (non-zero matrix values) for the L CSR (Output)
+/// @param U_rowmap The row map (row nnz offsets) for the U CSR (Input/Output)
+/// @param U_entries The entries (column ids) for the U CSR (Output)
+/// @param U_values The values (non-zero matrix values) for the U CSR (Output)
 template <typename KernelHandle, typename ARowMapType, typename AEntriesType,
           typename AValuesType, typename LRowMapType, typename LEntriesType,
           typename LValuesType, typename URowMapType, typename UEntriesType,

--- a/sparse/src/KokkosSparse_par_ilut.hpp
+++ b/sparse/src/KokkosSparse_par_ilut.hpp
@@ -215,6 +215,7 @@ void par_ilut_symbolic(KernelHandle* handle, ARowMapType& A_rowmap,
 /// @param U_rowmap The row map (row nnz offsets) for the U CSR (Input/Output)
 /// @param U_entries The entries (column ids) for the U CSR (Output)
 /// @param U_values The values (non-zero matrix values) for the U CSR (Output)
+/// @param deterministic Please ignore. This parameter will be removed soon.
 template <typename KernelHandle, typename ARowMapType, typename AEntriesType,
           typename AValuesType, typename LRowMapType, typename LEntriesType,
           typename LValuesType, typename URowMapType, typename UEntriesType,

--- a/sparse/src/KokkosSparse_par_ilut.hpp
+++ b/sparse/src/KokkosSparse_par_ilut.hpp
@@ -44,6 +44,17 @@ namespace Experimental {
   std::is_same<typename std::remove_const<A>::type, \
                typename std::remove_const<B>::type>::value
 
+/// @brief
+/// @tparam KernelHandle
+/// @tparam ARowMapType
+/// @tparam AEntriesType
+/// @tparam LRowMapType
+/// @tparam URowMapType
+/// @param handle
+/// @param A_rowmap
+/// @param A_entries
+/// @param L_rowmap
+/// @param U_rowmap
 template <typename KernelHandle, typename ARowMapType, typename AEntriesType,
           typename LRowMapType, typename URowMapType>
 void par_ilut_symbolic(KernelHandle* handle, ARowMapType& A_rowmap,
@@ -165,6 +176,28 @@ void par_ilut_symbolic(KernelHandle* handle, ARowMapType& A_rowmap,
 
 }  // par_ilut_symbolic
 
+/// @brief
+/// @tparam KernelHandle
+/// @tparam ARowMapType
+/// @tparam AEntriesType
+/// @tparam AValuesType
+/// @tparam LRowMapType
+/// @tparam LEntriesType
+/// @tparam LValuesType
+/// @tparam URowMapType
+/// @tparam UEntriesType
+/// @tparam UValuesType
+/// @param handle
+/// @param A_rowmap
+/// @param A_entries
+/// @param A_values
+/// @param L_rowmap
+/// @param L_entries
+/// @param L_values
+/// @param U_rowmap
+/// @param U_entries
+/// @param U_values
+/// @param deterministic
 template <typename KernelHandle, typename ARowMapType, typename AEntriesType,
           typename AValuesType, typename LRowMapType, typename LEntriesType,
           typename LValuesType, typename URowMapType, typename UEntriesType,

--- a/sparse/src/KokkosSparse_par_ilut.hpp
+++ b/sparse/src/KokkosSparse_par_ilut.hpp
@@ -44,17 +44,27 @@ namespace Experimental {
   std::is_same<typename std::remove_const<A>::type, \
                typename std::remove_const<B>::type>::value
 
-/// @brief
-/// @tparam KernelHandle
-/// @tparam ARowMapType
-/// @tparam AEntriesType
-/// @tparam LRowMapType
-/// @tparam URowMapType
-/// @param handle
-/// @param A_rowmap
-/// @param A_entries
-/// @param L_rowmap
-/// @param U_rowmap
+/// @brief Performs the symbolic phase of par_ilut (non-blocking).
+///
+/// The sparsity pattern of A will be analyzed and L_rowmap and U_rowmap will be
+/// populated with the L (lower triangular) and U (upper triagular) non-zero
+/// counts respectively. Having a separate symbolic phase allows for reuse when
+/// dealing with multiple matrices with the same sparsity pattern. This routine
+/// will set some values on handle for symbolic info (row count, nnz counts).
+///
+/// @tparam KernelHandle Template for the KernelHandle type
+/// @tparam ARowMapType Template for A_rowmap type
+/// @tparam AEntriesType Template for A_entries type
+/// @tparam LRowMapType Template for L_rowmap type
+/// @tparam URowMapType Template for U_rowmap type
+/// @param handle The kernel handle. It is expected that create_par_ilut_handle
+/// has been called on it
+/// @param A_rowmap The row map (row nnz offsets) for the A CSR (Input)
+/// @param A_entries The entries (column ids) for the A CSR (Input)
+/// @param L_rowmap The row map for the L CSR, should already be sized correctly
+/// (numRows+1) (Output)
+/// @param U_rowmap The row map for the U CSR, should already be sized correctly
+/// (numRows+1) (Output)
 template <typename KernelHandle, typename ARowMapType, typename AEntriesType,
           typename LRowMapType, typename URowMapType>
 void par_ilut_symbolic(KernelHandle* handle, ARowMapType& A_rowmap,

--- a/sparse/src/KokkosSparse_spgemm.hpp
+++ b/sparse/src/KokkosSparse_spgemm.hpp
@@ -23,6 +23,20 @@
 
 namespace KokkosSparse {
 
+///
+/// @brief
+///
+/// @tparam KernelHandle
+/// @tparam AMatrix
+/// @tparam BMatrix
+/// @tparam CMatrix
+/// @param kh
+/// @param A
+/// @param Amode
+/// @param B
+/// @param Bmode
+/// @param C
+////
 template <class KernelHandle, class AMatrix, class BMatrix, class CMatrix>
 void spgemm_symbolic(KernelHandle& kh, const AMatrix& A, const bool Amode,
                      const BMatrix& B, const bool Bmode, CMatrix& C) {
@@ -54,7 +68,20 @@ void spgemm_symbolic(KernelHandle& kh, const AMatrix& A, const bool Amode,
               entriesC);
 }
 
-// Symbolic phase for block SpGEMM (BSR matrices)
+///
+/// @brief Symbolic phase for block SpGEMM (BSR matrices)
+///
+/// @tparam KernelHandle
+/// @tparam AMatrixType
+/// @tparam BMatrixType
+/// @tparam CMatrixType
+/// @param kh
+/// @param A
+/// @param transposeA
+/// @param B
+/// @param transposeB
+/// @param C
+///
 template <class KernelHandle, class AMatrixType, class BMatrixType,
           class CMatrixType>
 void block_spgemm_symbolic(KernelHandle& kh, const AMatrixType& A,
@@ -95,6 +122,20 @@ void block_spgemm_symbolic(KernelHandle& kh, const AMatrixType& A,
                   row_mapC, entriesC, blockDim);
 }
 
+///
+/// @brief
+///
+/// @tparam KernelHandle
+/// @tparam AMatrix
+/// @tparam BMatrix
+/// @tparam CMatrix
+/// @param kh
+/// @param A
+/// @param Amode
+/// @param B
+/// @param Bmode
+/// @param C
+///
 template <class KernelHandle, class AMatrix, class BMatrix, class CMatrix>
 void spgemm_numeric(KernelHandle& kh, const AMatrix& A, const bool Amode,
                     const BMatrix& B, const bool Bmode, CMatrix& C) {
@@ -108,6 +149,20 @@ void spgemm_numeric(KernelHandle& kh, const AMatrix& A, const bool Amode,
       B.values, Bmode, C.graph.row_map, C.graph.entries, C.values);
 }
 
+///
+/// @brief
+///
+/// @tparam KernelHandle
+/// @tparam AMatrix
+/// @tparam BMatrix
+/// @tparam CMatrix
+/// @param kh
+/// @param A
+/// @param Amode
+/// @param B
+/// @param Bmode
+/// @param C
+///
 template <class KernelHandle, class AMatrix, class BMatrix, class CMatrix>
 void block_spgemm_numeric(KernelHandle& kh, const AMatrix& A, const bool Amode,
                           const BMatrix& B, const bool Bmode, CMatrix& C) {
@@ -123,6 +178,18 @@ void block_spgemm_numeric(KernelHandle& kh, const AMatrix& A, const bool Amode,
       B.values, Bmode, C.graph.row_map, C.graph.entries, C.values, blockDim);
 }
 
+///
+/// @brief
+///
+/// @tparam CMatrix
+/// @tparam AMatrix
+/// @tparam BMatrix
+/// @param A
+/// @param Amode
+/// @param B
+/// @param Bmode
+/// @return CMatrix
+///
 template <class CMatrix, class AMatrix, class BMatrix>
 CMatrix spgemm(const AMatrix& A, const bool Amode, const BMatrix& B,
                const bool Bmode) {


### PR DESCRIPTION
@jgfouca: Please fill in the comment content for `par_ilut`
@jennloe: Please fill in the comment content for `gmres`
@brian-kelley: Please fill in the comment content for `gauss_seidel` and `block_gauss_seidel`
@lucbv: Please fill in the comment content for `spgemm` and `block_spgemm`

Feel free to open PRs against `more_sparse_docs` or just use the suggested changes feature.

Using `AT: WIP` since there's no need to run more than github-DOCS and github-FORMAT on these changes.

