### PR TITLE
par_ilut: make Ut_values view atomic in compute_l_u_factors

### DIFF
--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -28,7 +28,6 @@
 #include <KokkosSparse_Utils.hpp>
 #include <KokkosSparse_SortCrs.hpp>
 #include <KokkosKernels_Utils.hpp>
-#include <Kokkos_Atomic.hpp>
 
 #include <limits>
 

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -478,7 +478,7 @@ struct IlutWrap {
 
     // UtValues needs to be Atomic if async updates are on. Otherwise,
     // non-atomic is fine.
-    using UtValuesSafeType = typename ParIlutOnly::UtViewType<async_update>::UtValuesViewType<UtValuesType>;
+    using UtValuesSafeType = typename ParIlutOnly::UtViewType<async_update>::template UtValuesViewType<UtValuesType>;
 
     UtValuesSafeType Ut_values = Ut_values_arg;
 

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -475,8 +475,9 @@ struct IlutWrap {
       UtValuesType& Ut_values_arg) {
     // UtValues needs to be Atomic if async updates are on. Otherwise,
     // non-atomic is fine.
-    using UtValuesSafeType = typename ParIlutOnly::UtViewType<
-        async_update>::template UtValuesViewType<UtValuesType>;
+    using UtValuesSafeType = std::conditional_t<async_update,
+      Kokkos::View<typename UtValuesType::non_const_value_type*, typename UtValuesType::array_layout, typename UtValuesType::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess | Kokkos::Atomic> >,
+      UtValuesType>;
 
     UtValuesSafeType Ut_values = Ut_values_arg;
 

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -496,8 +496,7 @@ struct IlutWrap {
 
             // ut_nnz is not guarateed to fail into range used exclusively
             // by this thread. Updating it here opens up potential race
-            // conditions that cause problems on GPU but usually causes
-            // faster convergence.
+            // conditions but usually causes faster convergence.
             if (async_update) {
               Ut_values(ut_nnz) = new_val;
             }

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -454,10 +454,10 @@ struct IlutWrap {
       UtValuesType& Ut_values_arg, const bool async_update) {
     // Use an atomic view for Ut_values due to race condition
     using UtValuesAtomic = Kokkos::View<
-      typename UtValuesType::non_const_value_type*,
-      typename UtValuesType::array_layout,
-      typename UtValuesType::device_type,
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess | Kokkos::Atomic> >;
+        typename UtValuesType::non_const_value_type*,
+        typename UtValuesType::array_layout, typename UtValuesType::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess |
+                             Kokkos::Atomic> >;
 
     UtValuesAtomic Ut_values = Ut_values_arg;
 

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -420,7 +420,8 @@ struct IlutWrap {
       const auto l_col = L_entries(l_row_nnz);
       const auto u_row = Ut_entries(ut_row_nnz);
       if (l_col == u_row && l_col < last_entry) {
-        sum += L_values(l_row_nnz) * Ut_values(ut_row_nnz);
+        const scalar_t ut_val = Ut_values(ut_row_nnz);
+        sum += L_values(l_row_nnz) * ut_val;
       }
       if (static_cast<size_type>(u_row) == row_idx) {
         ut_nnz = ut_row_nnz;
@@ -470,7 +471,7 @@ struct IlutWrap {
 
           for (auto l_nnz = l_row_nnz_begin; l_nnz < l_row_nnz_end; ++l_nnz) {
             const auto col_idx = L_entries(l_nnz);
-            const auto u_diag  = Ut_values(Ut_row_map(col_idx + 1) - 1);
+            const scalar_t u_diag  = Ut_values(Ut_row_map(col_idx + 1) - 1);
             if (u_diag != 0.0) {
               const auto new_val =
                   compute_sum(row_idx, col_idx, A_row_map, A_entries, A_values,

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -35,26 +35,6 @@ namespace KokkosSparse {
 namespace Impl {
 namespace Experimental {
 
-namespace ParIlutOnly {
-
-template <bool async_update>
-struct UtViewType {
-  template <class UtValuesType>
-  using UtValuesViewType = UtValuesType;
-};
-
-template <>
-struct UtViewType<true> {
-  template <class UtValuesType>
-  using UtValuesViewType = Kokkos::View<
-      typename UtValuesType::non_const_value_type*,
-      typename UtValuesType::array_layout, typename UtValuesType::device_type,
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess |
-                           Kokkos::Atomic> >;
-};
-
-}  // namespace ParIlutOnly
-
 template <class IlutHandle>
 struct IlutWrap {
   //

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -470,8 +470,8 @@ struct IlutWrap {
               L_row_map(row_idx + 1) - 1;  // skip diagonal for L
 
           for (auto l_nnz = l_row_nnz_begin; l_nnz < l_row_nnz_end; ++l_nnz) {
-            const auto col_idx = L_entries(l_nnz);
-            const scalar_t u_diag  = Ut_values(Ut_row_map(col_idx + 1) - 1);
+            const auto col_idx    = L_entries(l_nnz);
+            const scalar_t u_diag = Ut_values(Ut_row_map(col_idx + 1) - 1);
             if (u_diag != 0.0) {
               const auto new_val =
                   compute_sum(row_idx, col_idx, A_row_map, A_entries, A_values,

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -455,9 +455,15 @@ struct IlutWrap {
       UtValuesType& Ut_values_arg) {
     // UtValues needs to be Atomic if async updates are on. Otherwise,
     // non-atomic is fine.
-    using UtValuesSafeType = std::conditional_t<async_update,
-      Kokkos::View<typename UtValuesType::non_const_value_type*, typename UtValuesType::array_layout, typename UtValuesType::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess | Kokkos::Atomic> >,
-      UtValuesType>;
+    using UtValuesSafeType = std::conditional_t<
+        async_update,
+        Kokkos::View<
+            typename UtValuesType::non_const_value_type*,
+            typename UtValuesType::array_layout,
+            typename UtValuesType::device_type,
+            Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess |
+                                 Kokkos::Atomic> >,
+        UtValuesType>;
 
     UtValuesSafeType Ut_values = Ut_values_arg;
 

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -804,10 +804,8 @@ struct IlutWrap {
         thandle.get_residual_norm_delta_stop();
     const size_type max_iter = thandle.get_max_iter();
 
-    const auto verbose = thandle.get_verbose();
-    constexpr bool on_gpu =
-        KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>();
-    const auto async_update = !on_gpu && thandle.get_async_update();
+    const auto verbose      = thandle.get_verbose();
+    const auto async_update = thandle.get_async_update();
 
     if (verbose) {
       std::cout << "Starting PARILUT with..." << std::endl;

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -38,24 +38,22 @@ namespace Experimental {
 namespace ParIlutOnly {
 
 template <bool async_update>
-struct UtViewType
-{
+struct UtViewType {
   template <class UtValuesType>
   using UtValuesViewType = UtValuesType;
 };
 
 template <>
-struct UtViewType<true>
-{
+struct UtViewType<true> {
   template <class UtValuesType>
   using UtValuesViewType = Kokkos::View<
-    typename UtValuesType::non_const_value_type*,
-    typename UtValuesType::array_layout, typename UtValuesType::device_type,
-    Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess |
-                         Kokkos::Atomic> >;
+      typename UtValuesType::non_const_value_type*,
+      typename UtValuesType::array_layout, typename UtValuesType::device_type,
+      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess |
+                           Kokkos::Atomic> >;
 };
 
-}
+}  // namespace ParIlutOnly
 
 template <class IlutHandle>
 struct IlutWrap {
@@ -463,11 +461,11 @@ struct IlutWrap {
    * make this function determistic, but that could cause par_ilut
    * to take longer (more iterations) to converge.
    */
-  template <bool async_update,
-    class ARowMapType, class AEntriesType, class AValuesType,
-    class LRowMapType, class LEntriesType, class LValuesType,
-    class URowMapType, class UEntriesType, class UValuesType,
-    class UtRowMapType, class UtEntriesType, class UtValuesType>
+  template <bool async_update, class ARowMapType, class AEntriesType,
+            class AValuesType, class LRowMapType, class LEntriesType,
+            class LValuesType, class URowMapType, class UEntriesType,
+            class UValuesType, class UtRowMapType, class UtEntriesType,
+            class UtValuesType>
   static void compute_l_u_factors_impl(
       IlutHandle& ih, const ARowMapType& A_row_map,
       const AEntriesType& A_entries, const AValuesType& A_values,
@@ -475,10 +473,10 @@ struct IlutWrap {
       URowMapType& U_row_map, UEntriesType& U_entries, UValuesType& U_values,
       UtRowMapType& Ut_row_map, UtEntriesType& Ut_entries,
       UtValuesType& Ut_values_arg) {
-
     // UtValues needs to be Atomic if async updates are on. Otherwise,
     // non-atomic is fine.
-    using UtValuesSafeType = typename ParIlutOnly::UtViewType<async_update>::template UtValuesViewType<UtValuesType>;
+    using UtValuesSafeType = typename ParIlutOnly::UtViewType<
+        async_update>::template UtValuesViewType<UtValuesType>;
 
     UtValuesSafeType Ut_values = Ut_values_arg;
 
@@ -526,10 +524,10 @@ struct IlutWrap {
         });
   }
 
-  template<class ARowMapType, class AEntriesType, class AValuesType,
-           class LRowMapType, class LEntriesType, class LValuesType,
-           class URowMapType, class UEntriesType, class UValuesType,
-           class UtRowMapType, class UtEntriesType, class UtValuesType>
+  template <class ARowMapType, class AEntriesType, class AValuesType,
+            class LRowMapType, class LEntriesType, class LValuesType,
+            class URowMapType, class UEntriesType, class UValuesType,
+            class UtRowMapType, class UtEntriesType, class UtValuesType>
   static void compute_l_u_factors(
       IlutHandle& ih, const ARowMapType& A_row_map,
       const AEntriesType& A_entries, const AValuesType& A_values,
@@ -538,17 +536,15 @@ struct IlutWrap {
       UtRowMapType& Ut_row_map, UtEntriesType& Ut_entries,
       UtValuesType& Ut_values, const bool async_update) {
     if (async_update) {
-      compute_l_u_factors_impl<true>(ih, A_row_map, A_entries, A_values, L_row_map, L_entries,
-                                     L_values, U_row_map, U_entries, U_values,
-                                     Ut_row_map, Ut_entries, Ut_values);
-    }
-    else {
-      compute_l_u_factors_impl<false>(ih, A_row_map, A_entries, A_values, L_row_map, L_entries,
-                                      L_values, U_row_map, U_entries, U_values,
-                                      Ut_row_map, Ut_entries, Ut_values);
+      compute_l_u_factors_impl<true>(
+          ih, A_row_map, A_entries, A_values, L_row_map, L_entries, L_values,
+          U_row_map, U_entries, U_values, Ut_row_map, Ut_entries, Ut_values);
+    } else {
+      compute_l_u_factors_impl<false>(
+          ih, A_row_map, A_entries, A_values, L_row_map, L_entries, L_values,
+          U_row_map, U_entries, U_values, Ut_row_map, Ut_entries, Ut_values);
     }
   }
-
 
   /**
    * Select threshold based on filter rank. Do all this on host
@@ -848,8 +844,8 @@ struct IlutWrap {
         thandle.get_residual_norm_delta_stop();
     const size_type max_iter = thandle.get_max_iter();
 
-    const auto verbose      = thandle.get_verbose();
-    const auto async_update = false; //thandle.get_async_update();
+    const auto verbose = thandle.get_verbose();
+    const auto async_update = false;  // thandle.get_async_update();
 
     if (verbose) {
       std::cout << "Starting PARILUT with..." << std::endl;

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -844,7 +844,7 @@ struct IlutWrap {
         thandle.get_residual_norm_delta_stop();
     const size_type max_iter = thandle.get_max_iter();
 
-    const auto verbose = thandle.get_verbose();
+    const auto verbose      = thandle.get_verbose();
     const auto async_update = false;  // thandle.get_async_update();
 
     if (verbose) {

--- a/sparse/src/KokkosKernels_Handle.hpp
+++ b/sparse/src/KokkosKernels_Handle.hpp
@@ -872,7 +872,7 @@ class KokkosKernelsHandle {
       const typename PAR_ILUTHandleType::float_t residual_norm_delta_stop =
           1e-2,
       const typename PAR_ILUTHandleType::float_t fill_in_limit = 0.75,
-      const bool async_update = true, const bool verbose = false) {
+      const bool async_update = false, const bool verbose = false) {
     this->destroy_par_ilut_handle();
     this->is_owner_of_the_par_ilut_handle = true;
     this->par_ilutHandle =

--- a/sparse/src/KokkosSparse_par_ilut_handle.hpp
+++ b/sparse/src/KokkosSparse_par_ilut_handle.hpp
@@ -82,8 +82,6 @@ class PAR_ILUTHandle {
   bool async_update;  /// Whether compute LU factors should do asychronous
                       /// updates. When ON, the algorithm will usually converge
                       /// faster but it makes the algorithm non-deterministic.
-                      /// This will always be OFF for GPU since it doesn't work
-                      /// there.
   bool verbose;       /// Print information while executing par_ilut
 
   // Stored by parent KokkosKernelsHandle

--- a/sparse/unit_test/Test_Sparse_par_ilut.hpp
+++ b/sparse/unit_test/Test_Sparse_par_ilut.hpp
@@ -302,7 +302,7 @@ void run_test_par_ilut_precond() {
   constexpr auto numRows       = n;
   constexpr auto numCols       = n;
   constexpr auto diagDominance = 1;
-  constexpr bool verbose       = true;
+  constexpr bool verbose       = false;
 
   typename sp_matrix_type::non_const_size_type nnz = 10 * numRows;
   auto A = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<

--- a/sparse/unit_test/Test_Sparse_par_ilut.hpp
+++ b/sparse/unit_test/Test_Sparse_par_ilut.hpp
@@ -302,7 +302,7 @@ void run_test_par_ilut_precond() {
   constexpr auto numRows       = n;
   constexpr auto numCols       = n;
   constexpr auto diagDominance = 1;
-  constexpr bool verbose       = false;
+  constexpr bool verbose       = true;
 
   typename sp_matrix_type::non_const_size_type nnz = 10 * numRows;
   auto A = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<


### PR DESCRIPTION
Default async updates to off since we can't trust it to work everywhere all the time, even with Atomic Ut_values. I think this is the best approach since we will likely be revisiting the compute_l_u_factors implementation anyway.

Fixes #1775 