### PR TITLE
Include OpenMP environment variables in benchmark context

### DIFF
--- a/perf_test/Benchmark_Context.hpp
+++ b/perf_test/Benchmark_Context.hpp
@@ -21,6 +21,7 @@
 
 #include "KokkosKernels_PrintConfiguration.hpp"
 
+#include <cstdlib>
 #include <string>
 
 #include <benchmark/benchmark.h>
@@ -89,10 +90,30 @@ inline void add_version_info() {
   }
 }
 
+inline void add_env_info() {
+  auto num_threads = std::getenv("OMP_NUM_THREADS");
+  if (num_threads) {
+    benchmark::AddCustomContext("OMP_NUM_THREADS", num_threads);
+  }
+  auto dynamic = std::getenv("OMP_DYNAMIC");
+  if (dynamic) {
+    benchmark::AddCustomContext("OMP_DYNAMIC", dynamic);
+  }
+  auto proc_bind = std::getenv("OMP_PROC_BIND");
+  if (proc_bind) {
+    benchmark::AddCustomContext("OMP_PROC_BIND", proc_bind);
+  }
+  auto places = std::getenv("OMP_PLACES");
+  if (places) {
+    benchmark::AddCustomContext("OMP_PLACES", places);
+  }
+}
+
 /// \brief Gather all context information and add it to benchmark context
 inline void add_benchmark_context(bool verbose = false) {
   add_kokkos_configuration(verbose);
   add_version_info();
+  add_env_info();
 }
 
 }  // namespace KokkosKernelsBenchmark


### PR DESCRIPTION
Fixes #1718 (4.)

Sample output:
```
OMP_PROC_BIND=spread OMP_PLACES=threads OMP_NUM_THREADS=4 ./build/perf_test/KokkosKernels_PerformanceTest_Benchmark
```

```
2023-04-12T23:31:06+02:00
Running ./build/perf_test/KokkosKernels_PerformanceTest_Benchmark
(...)
KokkosKernels Version: 4.0.99
OMP_NUM_THREADS: 4
OMP_PLACES: threads
OMP_PROC_BIND: spread
---------------------------------------------------------------------------------------------------------------
Benchmark                                                     Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------------------------
KokkosBlas_dot_mv/m:100000/n:5/repeat:20/manual_time  (...)
```