### PR TITLE
BLAS: fixes and testing for LayoutStride

### DIFF
--- a/blas/src/KokkosBlas1_iamax.hpp
+++ b/blas/src/KokkosBlas1_iamax.hpp
@@ -49,13 +49,14 @@ typename XVector::size_type iamax(const XVector& x) {
       typename XVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       XVector_Internal;
 
-  typedef Kokkos::View<index_type, typename XVector_Internal::array_layout,
-                       Kokkos::HostSpace,
+  using layout_t = typename XVector_Internal::array_layout;
+
+  typedef Kokkos::View<index_type, layout_t, Kokkos::HostSpace,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RVector_Internal;
 
   index_type result;
-  RVector_Internal R = RVector_Internal(&result);
+  RVector_Internal R = RVector_Internal(&result, layout_t());
   XVector_Internal X = x;
 
   Impl::Iamax<RVector_Internal, XVector_Internal>::iamax(R, X);

--- a/blas/src/KokkosBlas1_nrm2.hpp
+++ b/blas/src/KokkosBlas1_nrm2.hpp
@@ -49,13 +49,14 @@ nrm2(const XVector& x) {
       typename XVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       XVector_Internal;
 
-  typedef Kokkos::View<mag_type, typename XVector_Internal::array_layout,
-                       Kokkos::HostSpace,
+  using layout_t = typename XVector_Internal::array_layout;
+
+  typedef Kokkos::View<mag_type, layout_t, Kokkos::HostSpace,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RVector_Internal;
 
   mag_type result;
-  RVector_Internal R = RVector_Internal(&result);
+  RVector_Internal R = RVector_Internal(&result, layout_t());
   XVector_Internal X = x;
 
   Impl::Nrm2<RVector_Internal, XVector_Internal>::nrm2(R, X, true);

--- a/blas/src/KokkosBlas1_nrm2w.hpp
+++ b/blas/src/KokkosBlas1_nrm2w.hpp
@@ -49,13 +49,14 @@ nrm2w(const XVector& x, const XVector& w) {
       typename XVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       XVector_Internal;
 
-  typedef Kokkos::View<mag_type, typename XVector_Internal::array_layout,
-                       Kokkos::HostSpace,
+  using layout_t = typename XVector_Internal::array_layout;
+
+  typedef Kokkos::View<mag_type, layout_t, Kokkos::HostSpace,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RVector_Internal;
 
   mag_type result;
-  RVector_Internal R = RVector_Internal(&result);
+  RVector_Internal R = RVector_Internal(&result, layout_t());
   XVector_Internal X = x;
   XVector_Internal W = w;
 

--- a/blas/src/KokkosBlas1_nrm2w_squared.hpp
+++ b/blas/src/KokkosBlas1_nrm2w_squared.hpp
@@ -50,12 +50,14 @@ nrm2w_squared(const XVector& x, const XVector& w) {
       typename XVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       XVector_Internal;
 
-  typedef Kokkos::View<mag_type, default_layout, Kokkos::HostSpace,
+  using layout_t = typename XVector_Internal::array_layout;
+
+  typedef Kokkos::View<mag_type, layout_t, Kokkos::HostSpace,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RVector_Internal;
 
   mag_type result;
-  RVector_Internal R = RVector_Internal(&result);
+  RVector_Internal R = RVector_Internal(&result, layout_t());
   XVector_Internal X = x;
   XVector_Internal W = w;
 

--- a/blas/src/KokkosBlas1_nrminf.hpp
+++ b/blas/src/KokkosBlas1_nrminf.hpp
@@ -48,13 +48,14 @@ nrminf(const XVector& x) {
       typename XVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       XVector_Internal;
 
-  typedef Kokkos::View<mag_type, typename XVector_Internal::array_layout,
-                       Kokkos::HostSpace,
+  using layout_t = typename XVector_Internal::array_layout;
+
+  typedef Kokkos::View<mag_type, layout_t, Kokkos::HostSpace,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RVector_Internal;
 
   mag_type result;
-  RVector_Internal R = RVector_Internal(&result);
+  RVector_Internal R = RVector_Internal(&result, layout_t());
   XVector_Internal X = x;
 
   Impl::NrmInf<RVector_Internal, XVector_Internal>::nrminf(R, X);

--- a/blas/src/KokkosBlas1_sum.hpp
+++ b/blas/src/KokkosBlas1_sum.hpp
@@ -44,14 +44,15 @@ typename XVector::non_const_value_type sum(const XVector& x) {
       typename XVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       XVector_Internal;
 
-  typedef Kokkos::View<typename XVector::non_const_value_type,
-                       typename XVector_Internal::array_layout,
+  using layout_t = typename XVector_Internal::array_layout;
+
+  typedef Kokkos::View<typename XVector::non_const_value_type, layout_t,
                        Kokkos::HostSpace,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RVector_Internal;
 
   typename XVector::non_const_value_type result;
-  RVector_Internal R = RVector_Internal(&result);
+  RVector_Internal R = RVector_Internal(&result, layout_t());
   XVector_Internal X = x;
 
   Impl::Sum<RVector_Internal, XVector_Internal>::sum(R, X);

--- a/blas/unit_test/Test_Blas.hpp
+++ b/blas/unit_test/Test_Blas.hpp
@@ -20,64 +20,64 @@
 #include "Test_Blas_trtri.hpp"
 
 // Blas 1
-//#include "Test_Blas1_abs.hpp"
-//#include "Test_Blas1_asum.hpp"
-//#include "Test_Blas1_axpby.hpp"
-//#include "Test_Blas1_axpy.hpp"
-//#include "Test_Blas1_dot.hpp"
-//#include "Test_Blas1_iamax.hpp"
-//#include "Test_Blas1_mult.hpp"
-//#include "Test_Blas1_nrm1.hpp"
-//#include "Test_Blas1_nrm2_squared.hpp"
-//#include "Test_Blas1_nrm2.hpp"
-//#include "Test_Blas1_nrm2w_squared.hpp"
-//#include "Test_Blas1_nrm2w.hpp"
-//#include "Test_Blas1_nrminf.hpp"
-//#include "Test_Blas1_reciprocal.hpp"
-//#include "Test_Blas1_rot.hpp"
-//#include "Test_Blas1_rotg.hpp"
-//#include "Test_Blas1_rotm.hpp"
-//#include "Test_Blas1_rotmg.hpp"
-//#include "Test_Blas1_scal.hpp"
-//#include "Test_Blas1_sum.hpp"
-//#include "Test_Blas1_swap.hpp"
-//#include "Test_Blas1_update.hpp"
-//
-//// Serial Blas 1
-//#include "Test_Blas1_serial_setscal.hpp"
-//#include "Test_Blas_serial_axpy.hpp"
-//#include "Test_Blas_serial_nrm2.hpp"
-//
-//// Team Blas 1
-//#include "Test_Blas1_team_setscal.hpp"
-//#include "Test_Blas1_team_abs.hpp"
-//#include "Test_Blas1_team_axpby.hpp"
-//#include "Test_Blas1_team_axpy.hpp"
-//#include "Test_Blas1_team_dot.hpp"
-//#include "Test_Blas1_team_mult.hpp"
-//#include "Test_Blas1_team_nrm2.hpp"
-//#include "Test_Blas1_team_scal.hpp"
-//#include "Test_Blas1_team_update.hpp"
-//
-//// Blas 2
-//#include "Test_Blas2_gemv.hpp"
-//
-//// Serial Blas 2
-//#include "Test_Blas2_serial_gemv.hpp"
-//
-//// Team Blas 2
-//#include "Test_Blas2_team_gemv.hpp"
-//#include "Test_Blas2_teamvector_gemv.hpp"
+#include "Test_Blas1_abs.hpp"
+#include "Test_Blas1_asum.hpp"
+#include "Test_Blas1_axpby.hpp"
+#include "Test_Blas1_axpy.hpp"
+#include "Test_Blas1_dot.hpp"
+#include "Test_Blas1_iamax.hpp"
+#include "Test_Blas1_mult.hpp"
+#include "Test_Blas1_nrm1.hpp"
+#include "Test_Blas1_nrm2_squared.hpp"
+#include "Test_Blas1_nrm2.hpp"
+#include "Test_Blas1_nrm2w_squared.hpp"
+#include "Test_Blas1_nrm2w.hpp"
+#include "Test_Blas1_nrminf.hpp"
+#include "Test_Blas1_reciprocal.hpp"
+#include "Test_Blas1_rot.hpp"
+#include "Test_Blas1_rotg.hpp"
+#include "Test_Blas1_rotm.hpp"
+#include "Test_Blas1_rotmg.hpp"
+#include "Test_Blas1_scal.hpp"
+#include "Test_Blas1_sum.hpp"
+#include "Test_Blas1_swap.hpp"
+#include "Test_Blas1_update.hpp"
+
+// Serial Blas 1
+#include "Test_Blas1_serial_setscal.hpp"
+#include "Test_Blas_serial_axpy.hpp"
+#include "Test_Blas_serial_nrm2.hpp"
+
+// Team Blas 1
+#include "Test_Blas1_team_setscal.hpp"
+#include "Test_Blas1_team_abs.hpp"
+#include "Test_Blas1_team_axpby.hpp"
+#include "Test_Blas1_team_axpy.hpp"
+#include "Test_Blas1_team_dot.hpp"
+#include "Test_Blas1_team_mult.hpp"
+#include "Test_Blas1_team_nrm2.hpp"
+#include "Test_Blas1_team_scal.hpp"
+#include "Test_Blas1_team_update.hpp"
+
+// Blas 2
+#include "Test_Blas2_gemv.hpp"
+
+// Serial Blas 2
+#include "Test_Blas2_serial_gemv.hpp"
+
+// Team Blas 2
+#include "Test_Blas2_team_gemv.hpp"
+#include "Test_Blas2_teamvector_gemv.hpp"
 
 // Blas 3
 #include "Test_Blas3_gemm.hpp"
-//#include "Test_Blas3_trmm.hpp"
-//#include "Test_Blas3_trsm.hpp"
-//
-//// Stuff that should move later on
-//#include "Test_Blas_Newton.hpp"
-//
-//// TPLs
-//#include "Test_Blas_rocblas.hpp"
+#include "Test_Blas3_trmm.hpp"
+#include "Test_Blas3_trsm.hpp"
+
+// Stuff that should move later on
+#include "Test_Blas_Newton.hpp"
+
+// TPLs
+#include "Test_Blas_rocblas.hpp"
 
 #endif  // TEST_BLAS_HPP

--- a/blas/unit_test/Test_Blas.hpp
+++ b/blas/unit_test/Test_Blas.hpp
@@ -20,64 +20,64 @@
 #include "Test_Blas_trtri.hpp"
 
 // Blas 1
-#include "Test_Blas1_abs.hpp"
-#include "Test_Blas1_asum.hpp"
-#include "Test_Blas1_axpby.hpp"
-#include "Test_Blas1_axpy.hpp"
-#include "Test_Blas1_dot.hpp"
-#include "Test_Blas1_iamax.hpp"
-#include "Test_Blas1_mult.hpp"
-#include "Test_Blas1_nrm1.hpp"
-#include "Test_Blas1_nrm2_squared.hpp"
-#include "Test_Blas1_nrm2.hpp"
-#include "Test_Blas1_nrm2w_squared.hpp"
-#include "Test_Blas1_nrm2w.hpp"
-#include "Test_Blas1_nrminf.hpp"
-#include "Test_Blas1_reciprocal.hpp"
-#include "Test_Blas1_rot.hpp"
-#include "Test_Blas1_rotg.hpp"
-#include "Test_Blas1_rotm.hpp"
-#include "Test_Blas1_rotmg.hpp"
-#include "Test_Blas1_scal.hpp"
-#include "Test_Blas1_sum.hpp"
-#include "Test_Blas1_swap.hpp"
-#include "Test_Blas1_update.hpp"
-
-// Serial Blas 1
-#include "Test_Blas1_serial_setscal.hpp"
-#include "Test_Blas_serial_axpy.hpp"
-#include "Test_Blas_serial_nrm2.hpp"
-
-// Team Blas 1
-#include "Test_Blas1_team_setscal.hpp"
-#include "Test_Blas1_team_abs.hpp"
-#include "Test_Blas1_team_axpby.hpp"
-#include "Test_Blas1_team_axpy.hpp"
-#include "Test_Blas1_team_dot.hpp"
-#include "Test_Blas1_team_mult.hpp"
-#include "Test_Blas1_team_nrm2.hpp"
-#include "Test_Blas1_team_scal.hpp"
-#include "Test_Blas1_team_update.hpp"
-
-// Blas 2
-#include "Test_Blas2_gemv.hpp"
-
-// Serial Blas 2
-#include "Test_Blas2_serial_gemv.hpp"
-
-// Team Blas 2
-#include "Test_Blas2_team_gemv.hpp"
-#include "Test_Blas2_teamvector_gemv.hpp"
+//#include "Test_Blas1_abs.hpp"
+//#include "Test_Blas1_asum.hpp"
+//#include "Test_Blas1_axpby.hpp"
+//#include "Test_Blas1_axpy.hpp"
+//#include "Test_Blas1_dot.hpp"
+//#include "Test_Blas1_iamax.hpp"
+//#include "Test_Blas1_mult.hpp"
+//#include "Test_Blas1_nrm1.hpp"
+//#include "Test_Blas1_nrm2_squared.hpp"
+//#include "Test_Blas1_nrm2.hpp"
+//#include "Test_Blas1_nrm2w_squared.hpp"
+//#include "Test_Blas1_nrm2w.hpp"
+//#include "Test_Blas1_nrminf.hpp"
+//#include "Test_Blas1_reciprocal.hpp"
+//#include "Test_Blas1_rot.hpp"
+//#include "Test_Blas1_rotg.hpp"
+//#include "Test_Blas1_rotm.hpp"
+//#include "Test_Blas1_rotmg.hpp"
+//#include "Test_Blas1_scal.hpp"
+//#include "Test_Blas1_sum.hpp"
+//#include "Test_Blas1_swap.hpp"
+//#include "Test_Blas1_update.hpp"
+//
+//// Serial Blas 1
+//#include "Test_Blas1_serial_setscal.hpp"
+//#include "Test_Blas_serial_axpy.hpp"
+//#include "Test_Blas_serial_nrm2.hpp"
+//
+//// Team Blas 1
+//#include "Test_Blas1_team_setscal.hpp"
+//#include "Test_Blas1_team_abs.hpp"
+//#include "Test_Blas1_team_axpby.hpp"
+//#include "Test_Blas1_team_axpy.hpp"
+//#include "Test_Blas1_team_dot.hpp"
+//#include "Test_Blas1_team_mult.hpp"
+//#include "Test_Blas1_team_nrm2.hpp"
+//#include "Test_Blas1_team_scal.hpp"
+//#include "Test_Blas1_team_update.hpp"
+//
+//// Blas 2
+//#include "Test_Blas2_gemv.hpp"
+//
+//// Serial Blas 2
+//#include "Test_Blas2_serial_gemv.hpp"
+//
+//// Team Blas 2
+//#include "Test_Blas2_team_gemv.hpp"
+//#include "Test_Blas2_teamvector_gemv.hpp"
 
 // Blas 3
 #include "Test_Blas3_gemm.hpp"
-#include "Test_Blas3_trmm.hpp"
-#include "Test_Blas3_trsm.hpp"
-
-// Stuff that should move later on
-#include "Test_Blas_Newton.hpp"
-
-// TPLs
-#include "Test_Blas_rocblas.hpp"
+//#include "Test_Blas3_trmm.hpp"
+//#include "Test_Blas3_trsm.hpp"
+//
+//// Stuff that should move later on
+//#include "Test_Blas_Newton.hpp"
+//
+//// TPLs
+//#include "Test_Blas_rocblas.hpp"
 
 #endif  // TEST_BLAS_HPP

--- a/blas/unit_test/Test_Blas1_abs.hpp
+++ b/blas/unit_test/Test_Blas1_abs.hpp
@@ -26,36 +26,11 @@ void impl_test_abs(int N) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef Kokkos::ArithTraits<ScalarA> AT;
 
-  typedef Kokkos::View<
-      ScalarA * [2],
-      typename std::conditional<std::is_same<typename ViewTypeA::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeA;
-  typedef Kokkos::View<
-      ScalarB * [2],
-      typename std::conditional<std::is_same<typename ViewTypeB::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeB;
-
   typename AT::mag_type eps = AT::epsilon() * 10;
 
-  BaseTypeA b_x("X", N);
-  BaseTypeB b_y("Y", N);
-  BaseTypeB b_org_y("Org_Y", N);
-
-  ViewTypeA x                        = Kokkos::subview(b_x, Kokkos::ALL(), 0);
-  ViewTypeB y                        = Kokkos::subview(b_y, Kokkos::ALL(), 0);
-  typename ViewTypeA::const_type c_x = x;
-
-  typename BaseTypeA::HostMirror h_b_x = Kokkos::create_mirror_view(b_x);
-  typename BaseTypeB::HostMirror h_b_y = Kokkos::create_mirror_view(b_y);
-
-  typename ViewTypeA::HostMirror h_x = Kokkos::subview(h_b_x, Kokkos::ALL(), 0);
-  typename ViewTypeB::HostMirror h_y = Kokkos::subview(h_b_y, Kokkos::ALL(), 0);
+  view_stride_adapter<ViewTypeA> x("X", N);
+  view_stride_adapter<ViewTypeB> y("Y", N);
+  view_stride_adapter<ViewTypeB> org_y("Org_Y", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
@@ -63,33 +38,34 @@ void impl_test_abs(int N) {
   {
     ScalarA randStart, randEnd;
     Test::getRandomBounds(1.0, randStart, randEnd);
-    Kokkos::fill_random(b_x, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
     Test::getRandomBounds(1.0, randStart, randEnd);
-    Kokkos::fill_random(b_y, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
   }
 
-  Kokkos::deep_copy(b_org_y, b_y);
+  Kokkos::deep_copy(org_y.h_base, y.d_base);
 
-  Kokkos::deep_copy(h_b_x, b_x);
-  Kokkos::deep_copy(h_b_y, b_y);
+  Kokkos::deep_copy(x.h_base, x.d_base);
 
   // Run with nonconst input
-  KokkosBlas::abs(y, x);
+  KokkosBlas::abs(y.d_view, x.d_view);
   // Copy result to host (h_y is subview of h_b_y)
-  Kokkos::deep_copy(h_b_y, b_y);
+  Kokkos::deep_copy(y.h_base, y.d_base);
   for (int i = 0; i < N; i++) {
-    EXPECT_NEAR_KK(h_y(i), AT::abs(h_x(i)), eps * AT::abs(h_x(i)));
+    EXPECT_NEAR_KK(y.h_view(i), AT::abs(x.h_view(i)),
+                   eps * AT::abs(x.h_view(i)));
   }
   // Run with const input
   // Reset output
-  Kokkos::deep_copy(b_y, b_org_y);
-  KokkosBlas::abs(y, c_x);
-  Kokkos::deep_copy(h_b_y, b_y);
+  Kokkos::deep_copy(y.d_base, org_y.h_base);
+  KokkosBlas::abs(y.d_view, x.d_view_const);
+  Kokkos::deep_copy(y.h_base, y.d_base);
   for (int i = 0; i < N; i++) {
-    EXPECT_NEAR_KK(h_y(i), AT::abs(h_x(i)), eps * AT::abs(h_x(i)));
+    EXPECT_NEAR_KK(y.h_view(i), AT::abs(x.h_view(i)),
+                   eps * AT::abs(x.h_view(i)));
   }
 }
 
@@ -99,24 +75,9 @@ void impl_test_abs_mv(int N, int K) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef Kokkos::ArithTraits<ScalarA> AT;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-  typedef multivector_layout_adapter<ViewTypeB> vfB_type;
-
-  typename vfA_type::BaseType b_x("A", N, K);
-  typename vfB_type::BaseType b_y("B", N, K);
-  typename vfB_type::BaseType b_org_y("B", N, K);
-
-  ViewTypeA x = vfA_type::view(b_x);
-  ViewTypeB y = vfB_type::view(b_y);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-  typedef multivector_layout_adapter<typename ViewTypeB::HostMirror> h_vfB_type;
-
-  typename h_vfA_type::BaseType h_b_x = Kokkos::create_mirror_view(b_x);
-  typename h_vfB_type::BaseType h_b_y = Kokkos::create_mirror_view(b_y);
-
-  typename ViewTypeA::HostMirror h_x = h_vfA_type::view(h_b_x);
-  typename ViewTypeB::HostMirror h_y = h_vfB_type::view(h_b_y);
+  view_stride_adapter<ViewTypeA> x("X", N, K);
+  view_stride_adapter<ViewTypeB> y("Y", N, K);
+  view_stride_adapter<ViewTypeB> org_y("Org_Y", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
@@ -124,38 +85,38 @@ void impl_test_abs_mv(int N, int K) {
   {
     ScalarA randStart, randEnd;
     Test::getRandomBounds(1.0, randStart, randEnd);
-    Kokkos::fill_random(b_x, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
     Test::getRandomBounds(1.0, randStart, randEnd);
-    Kokkos::fill_random(b_y, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
   }
 
-  Kokkos::deep_copy(b_org_y, b_y);
+  Kokkos::deep_copy(org_y.h_base, y.d_base);
 
-  Kokkos::deep_copy(h_b_x, b_x);
-
-  typename ViewTypeA::const_type c_x = x;
+  Kokkos::deep_copy(x.h_base, x.d_base);
 
   typename AT::mag_type eps = AT::epsilon() * 10;
 
   // Test and verify non-const input
-  KokkosBlas::abs(y, x);
-  Kokkos::deep_copy(h_b_y, b_y);
+  KokkosBlas::abs(y.d_view, x.d_view);
+  Kokkos::deep_copy(y.h_base, y.d_base);
   for (int i = 0; i < N; i++) {
     for (int j = 0; j < K; j++) {
-      EXPECT_NEAR_KK(h_y(i, j), AT::abs(h_x(i, j)), eps * AT::abs(h_x(i, j)));
+      EXPECT_NEAR_KK(y.h_view(i, j), AT::abs(x.h_view(i, j)),
+                     eps * AT::abs(x.h_view(i, j)));
     }
   }
   // Test and verify const input
   // Reset y
-  Kokkos::deep_copy(b_y, b_org_y);
-  KokkosBlas::abs(y, c_x);
-  Kokkos::deep_copy(h_b_y, b_y);
+  Kokkos::deep_copy(y.d_base, org_y.h_base);
+  KokkosBlas::abs(y.d_view, x.d_view_const);
+  Kokkos::deep_copy(y.h_base, y.d_base);
   for (int i = 0; i < N; i++) {
     for (int j = 0; j < K; j++) {
-      EXPECT_NEAR_KK(h_y(i, j), AT::abs(h_x(i, j)), eps * AT::abs(h_x(i, j)));
+      EXPECT_NEAR_KK(y.h_view(i, j), AT::abs(x.h_view(i, j)),
+                     eps * AT::abs(x.h_view(i, j)));
     }
   }
 }

--- a/blas/unit_test/Test_Blas1_asum.hpp
+++ b/blas/unit_test/Test_Blas1_asum.hpp
@@ -26,32 +26,17 @@ void impl_test_asum(int N) {
   typedef Kokkos::ArithTraits<ScalarA> AT;
   typedef Kokkos::ArithTraits<typename AT::mag_type> MAT;
 
-  typedef Kokkos::View<
-      ScalarA * [2],
-      typename std::conditional<std::is_same<typename ViewTypeA::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeA;
-
-  BaseTypeA b_a("A", N);
-
-  ViewTypeA a = Kokkos::subview(b_a, Kokkos::ALL(), 0);
-
-  typename BaseTypeA::HostMirror h_b_a = Kokkos::create_mirror_view(b_a);
-
-  typename ViewTypeA::HostMirror h_a = Kokkos::subview(h_b_a, Kokkos::ALL(), 0);
+  view_stride_adapter<ViewTypeA> a("A", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
   ScalarA randStart, randEnd;
   Test::getRandomBounds(10.0, randStart, randEnd);
-  Kokkos::fill_random(b_a, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
-  Kokkos::deep_copy(h_b_a, b_a);
+  Kokkos::deep_copy(a.h_base, a.d_base);
 
-  typename ViewTypeA::const_type c_a = a;
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
 
   typename AT::mag_type expected_result = 0;
@@ -61,13 +46,14 @@ void impl_test_asum(int N) {
     // parts.
     //
     // This is safe; ArithTraits<T>::imag is 0 if T is real.
-    expected_result += MAT::abs(AT::real(h_a(i))) + MAT::abs(AT::imag(h_a(i)));
+    expected_result +=
+        MAT::abs(AT::real(a.h_view(i))) + MAT::abs(AT::imag(a.h_view(i)));
   }
 
-  typename AT::mag_type nonconst_result = KokkosBlas::asum(a);
+  typename AT::mag_type nonconst_result = KokkosBlas::asum(a.d_view);
   EXPECT_NEAR_KK(nonconst_result, expected_result, eps * expected_result);
 
-  typename AT::mag_type const_result = KokkosBlas::asum(c_a);
+  typename AT::mag_type const_result = KokkosBlas::asum(a.d_view_const);
   EXPECT_NEAR_KK(const_result, expected_result, eps * expected_result);
 }
 

--- a/blas/unit_test/Test_Blas1_axpby.hpp
+++ b/blas/unit_test/Test_Blas1_axpby.hpp
@@ -27,19 +27,6 @@ void impl_test_axpby(int N) {
   using ScalarB    = typename ViewTypeB::value_type;
   using MagnitudeB = typename Kokkos::ArithTraits<ScalarB>::mag_type;
 
-  using BaseTypeA = Kokkos::View<
-      ScalarA * [2],
-      typename std::conditional<std::is_same<typename ViewTypeA::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>;
-  using BaseTypeB = Kokkos::View<
-      ScalarB * [2],
-      typename std::conditional<std::is_same<typename ViewTypeB::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>;
-
   ScalarA a = 3;
   ScalarB b = 5;
   // eps should probably be based on ScalarB since that is the type
@@ -51,22 +38,9 @@ void impl_test_axpby(int N) {
        Kokkos::ArithTraits<ScalarB>::abs(b)) *
       max_val * eps;
 
-  BaseTypeA b_x("X", N);
-  BaseTypeB b_y("Y", N);
-  BaseTypeB b_org_y("Org_Y", N);
-
-  auto h_b_org_y =
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_org_y);
-  ViewTypeA x                        = Kokkos::subview(b_x, Kokkos::ALL(), 0);
-  ViewTypeB y                        = Kokkos::subview(b_y, Kokkos::ALL(), 0);
-  typename ViewTypeA::const_type c_x = x;
-  typename ViewTypeB::const_type c_y = y;
-
-  typename BaseTypeA::HostMirror h_b_x = Kokkos::create_mirror_view(b_x);
-  typename BaseTypeB::HostMirror h_b_y = Kokkos::create_mirror_view(b_y);
-
-  typename ViewTypeA::HostMirror h_x = Kokkos::subview(h_b_x, Kokkos::ALL(), 0);
-  typename ViewTypeB::HostMirror h_y = Kokkos::subview(h_b_y, Kokkos::ALL(), 0);
+  view_stride_adapter<ViewTypeA> x("X", N);
+  view_stride_adapter<ViewTypeB> y("Y", N);
+  view_stride_adapter<ViewTypeB> org_y("Org_Y", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
@@ -74,34 +48,28 @@ void impl_test_axpby(int N) {
   {
     ScalarA randStart, randEnd;
     Test::getRandomBounds(max_val, randStart, randEnd);
-    Kokkos::fill_random(b_x, rand_pool, randStart, randEnd);
-  }
-  {
-    ScalarB randStart, randEnd;
-    Test::getRandomBounds(max_val, randStart, randEnd);
-    Kokkos::fill_random(b_y, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
 
-  Kokkos::deep_copy(b_org_y, b_y);
-  Kokkos::deep_copy(h_b_org_y, b_org_y);
+  Kokkos::deep_copy(x.h_base, x.d_base);
+  Kokkos::deep_copy(org_y.h_base, y.d_base);
 
-  Kokkos::deep_copy(h_b_x, b_x);
-
-  // Run with non-const input (x) and verify
-  KokkosBlas::axpby(a, x, b, y);
-  Kokkos::deep_copy(h_b_y, b_y);
+  // Run with non-const input and verify
+  KokkosBlas::axpby(a, x.d_view, b, y.d_view);
+  Kokkos::deep_copy(y.h_base, y.d_base);
   for (int i = 0; i < N; i++) {
-    EXPECT_NEAR_KK(static_cast<ScalarB>(a * h_x(i) + b * h_b_org_y(i, 0)),
-                   h_y(i), 2 * max_error);
+    EXPECT_NEAR_KK(static_cast<ScalarB>(a * x.h_view(i) + b * org_y.h_view(i)),
+                   y.h_view(i), 2 * max_error);
   }
 
-  Kokkos::deep_copy(b_y, b_org_y);
-  // Run again with const input (c_x)
-  KokkosBlas::axpby(a, c_x, b, y);
-  Kokkos::deep_copy(h_b_y, b_y);
+  // Re-randomize y
+  Kokkos::deep_copy(y.d_base, org_y.h_base);
+  // Run again with const input
+  KokkosBlas::axpby(a, x.d_view_const, b, y.d_view);
+  Kokkos::deep_copy(y.h_base, y.d_base);
   for (int i = 0; i < N; i++) {
-    EXPECT_NEAR_KK(static_cast<ScalarB>(a * h_x(i) + b * h_b_org_y(i, 0)),
-                   h_y(i), 2 * max_error);
+    EXPECT_NEAR_KK(static_cast<ScalarB>(a * x.h_view(i) + b * org_y.h_view(i)),
+                   y.h_view(i), 2 * max_error);
   }
 }
 
@@ -111,24 +79,9 @@ void impl_test_axpby_mv(int N, int K) {
   using ScalarB    = typename ViewTypeB::value_type;
   using MagnitudeB = typename Kokkos::ArithTraits<ScalarB>::mag_type;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-  typedef multivector_layout_adapter<ViewTypeB> vfB_type;
-
-  typename vfA_type::BaseType b_x("A", N, K);
-  typename vfB_type::BaseType b_y("B", N, K);
-  typename vfB_type::BaseType b_org_y("B", N, K);
-
-  ViewTypeA x = vfA_type::view(b_x);
-  ViewTypeB y = vfB_type::view(b_y);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-  typedef multivector_layout_adapter<typename ViewTypeB::HostMirror> h_vfB_type;
-
-  typename h_vfA_type::BaseType h_b_x = Kokkos::create_mirror_view(b_x);
-  typename h_vfB_type::BaseType h_b_y = Kokkos::create_mirror_view(b_y);
-
-  typename ViewTypeA::HostMirror h_x = h_vfA_type::view(h_b_x);
-  typename ViewTypeB::HostMirror h_y = h_vfB_type::view(h_b_y);
+  view_stride_adapter<ViewTypeA> x("X", N, K);
+  view_stride_adapter<ViewTypeB> y("Y", N, K);
+  view_stride_adapter<ViewTypeB> org_y("Org_Y", N, K);
 
   ScalarA a                = 3;
   ScalarB b                = 5;
@@ -145,44 +98,39 @@ void impl_test_axpby_mv(int N, int K) {
   {
     ScalarA randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(b_x, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(b_y, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
   }
 
-  Kokkos::deep_copy(b_org_y, b_y);
-  ViewTypeB org_y = vfB_type::view(b_org_y);
-  auto h_org_y =
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), org_y);
-
-  Kokkos::deep_copy(h_b_x, b_x);
-  Kokkos::deep_copy(h_b_y, b_y);
-
-  typename ViewTypeA::const_type c_x = x;
+  Kokkos::deep_copy(org_y.h_base, y.d_base);
+  Kokkos::deep_copy(x.h_base, x.d_base);
 
   Kokkos::View<ScalarB*, Kokkos::HostSpace> r("Dot::Result", K);
 
-  KokkosBlas::axpby(a, x, b, y);
-  Kokkos::deep_copy(h_b_y, b_y);
+  KokkosBlas::axpby(a, x.d_view, b, y.d_view);
+  Kokkos::deep_copy(y.h_base, y.d_base);
 
   for (int i = 0; i < N; i++) {
     for (int j = 0; j < K; j++) {
-      EXPECT_NEAR_KK(static_cast<ScalarB>(a * h_x(i, j) + b * h_org_y(i, j)),
-                     h_y(i, j), 2 * max_error);
+      EXPECT_NEAR_KK(
+          static_cast<ScalarB>(a * x.h_view(i, j) + b * org_y.h_view(i, j)),
+          y.h_view(i, j), 2 * max_error);
     }
   }
 
-  Kokkos::deep_copy(b_y, b_org_y);
-  KokkosBlas::axpby(a, c_x, b, y);
-  Kokkos::deep_copy(h_b_y, b_y);
+  Kokkos::deep_copy(y.d_base, org_y.h_base);
+  KokkosBlas::axpby(a, x.d_view_const, b, y.d_view);
+  Kokkos::deep_copy(y.h_base, y.d_base);
 
   for (int i = 0; i < N; i++) {
     for (int j = 0; j < K; j++) {
-      EXPECT_NEAR_KK(static_cast<ScalarB>(a * h_x(i, j) + b * h_org_y(i, j)),
-                     h_y(i, j), 2 * max_error);
+      EXPECT_NEAR_KK(
+          static_cast<ScalarB>(a * x.h_view(i, j) + b * org_y.h_view(i, j)),
+          y.h_view(i, j), 2 * max_error);
     }
   }
 }

--- a/blas/unit_test/Test_Blas1_axpy.hpp
+++ b/blas/unit_test/Test_Blas1_axpy.hpp
@@ -27,19 +27,6 @@ void impl_test_axpy(int N) {
   using ScalarB    = typename ViewTypeB::value_type;
   using MagnitudeB = typename Kokkos::ArithTraits<ScalarB>::mag_type;
 
-  using BaseTypeA = Kokkos::View<
-      ScalarA * [2],
-      typename std::conditional<std::is_same<typename ViewTypeA::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>;
-  using BaseTypeB = Kokkos::View<
-      ScalarB * [2],
-      typename std::conditional<std::is_same<typename ViewTypeB::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>;
-
   ScalarA a                = 3;
   const MagnitudeB max_val = 10;
   const MagnitudeB eps     = Kokkos::ArithTraits<ScalarB>::epsilon();
@@ -48,20 +35,9 @@ void impl_test_axpy(int N) {
        max_val) *
       eps;
 
-  BaseTypeA b_x("X", N);
-  BaseTypeB b_y("Y", N);
-  BaseTypeB b_org_y("Org_Y", N);
-
-  ViewTypeA x                        = Kokkos::subview(b_x, Kokkos::ALL(), 0);
-  ViewTypeB y                        = Kokkos::subview(b_y, Kokkos::ALL(), 0);
-  typename ViewTypeA::const_type c_x = x;
-  typename ViewTypeB::const_type c_y = y;
-
-  typename BaseTypeA::HostMirror h_b_x = Kokkos::create_mirror_view(b_x);
-  typename BaseTypeB::HostMirror h_b_y = Kokkos::create_mirror_view(b_y);
-
-  typename ViewTypeA::HostMirror h_x = Kokkos::subview(h_b_x, Kokkos::ALL(), 0);
-  typename ViewTypeB::HostMirror h_y = Kokkos::subview(h_b_y, Kokkos::ALL(), 0);
+  view_stride_adapter<ViewTypeA> x("X", N);
+  view_stride_adapter<ViewTypeB> y("Y", N);
+  view_stride_adapter<ViewTypeB> org_y("Org_Y", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
@@ -69,35 +45,32 @@ void impl_test_axpy(int N) {
   {
     ScalarA randStart, randEnd;
     Test::getRandomBounds(max_val, randStart, randEnd);
-    Kokkos::fill_random(x, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
     Test::getRandomBounds(max_val, randStart, randEnd);
-    Kokkos::fill_random(y, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
   }
 
-  Kokkos::deep_copy(b_org_y, b_y);
-  auto h_b_org_y =
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_org_y);
+  Kokkos::deep_copy(x.h_base, x.d_base);
+  Kokkos::deep_copy(org_y.h_base, y.d_base);
 
-  Kokkos::deep_copy(h_b_x, b_x);
-
-  KokkosBlas::axpy(a, x, y);
-  Kokkos::deep_copy(h_b_y, b_y);
+  KokkosBlas::axpy(a, x.d_view, y.d_view);
+  Kokkos::deep_copy(y.h_base, y.d_base);
 
   for (int i = 0; i < N; i++) {
-    ScalarB expected = a * h_x(i) + h_b_org_y(i, 0);
-    EXPECT_NEAR_KK(expected, h_y(i), 2 * max_error);
+    ScalarB expected = a * x.h_view(i) + org_y.h_view(i);
+    EXPECT_NEAR_KK(expected, y.h_view(i), 2 * max_error);
   }
 
   // reset y to orig, and run again with const-valued x
-  Kokkos::deep_copy(b_y, b_org_y);
-  KokkosBlas::axpy(a, c_x, y);
-  Kokkos::deep_copy(h_b_y, b_y);
+  Kokkos::deep_copy(y.d_base, org_y.h_base);
+  KokkosBlas::axpy(a, x.d_view_const, y.d_view);
+  Kokkos::deep_copy(y.h_base, y.d_base);
   for (int i = 0; i < N; i++) {
-    ScalarB expected = a * h_x(i) + h_b_org_y(i, 0);
-    EXPECT_NEAR_KK(expected, h_y(i), 2 * max_error);
+    ScalarB expected = a * x.h_view(i) + org_y.h_view(i);
+    EXPECT_NEAR_KK(expected, y.h_view(i), 2 * max_error);
   }
 }
 
@@ -107,24 +80,9 @@ void impl_test_axpy_mv(int N, int K) {
   using ScalarB    = typename ViewTypeB::value_type;
   using MagnitudeB = typename Kokkos::ArithTraits<ScalarB>::mag_type;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-  typedef multivector_layout_adapter<ViewTypeB> vfB_type;
-
-  typename vfA_type::BaseType b_x("A", N, K);
-  typename vfB_type::BaseType b_y("B", N, K);
-  typename vfB_type::BaseType b_org_y("B", N, K);
-
-  ViewTypeA x = vfA_type::view(b_x);
-  ViewTypeB y = vfB_type::view(b_y);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-  typedef multivector_layout_adapter<typename ViewTypeB::HostMirror> h_vfB_type;
-
-  typename h_vfA_type::BaseType h_b_x = Kokkos::create_mirror_view(b_x);
-  typename h_vfB_type::BaseType h_b_y = Kokkos::create_mirror_view(b_y);
-
-  typename ViewTypeA::HostMirror h_x = h_vfA_type::view(h_b_x);
-  typename ViewTypeB::HostMirror h_y = h_vfB_type::view(h_b_y);
+  view_stride_adapter<ViewTypeA> x("X", N, K);
+  view_stride_adapter<ViewTypeB> y("Y", N, K);
+  view_stride_adapter<ViewTypeB> org_y("Org_Y", N, K);
 
   ScalarA a                = 3;
   const MagnitudeB eps     = Kokkos::ArithTraits<ScalarB>::epsilon();
@@ -140,40 +98,36 @@ void impl_test_axpy_mv(int N, int K) {
   {
     ScalarA randStart, randEnd;
     Test::getRandomBounds(max_val, randStart, randEnd);
-    Kokkos::fill_random(b_x, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
     Test::getRandomBounds(max_val, randStart, randEnd);
-    Kokkos::fill_random(b_y, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
   }
 
-  Kokkos::deep_copy(b_org_y, b_y);
-  ViewTypeB org_y = vfB_type::view(b_org_y);
-  auto h_org_y =
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), org_y);
+  Kokkos::deep_copy(org_y.h_base, y.d_base);
+  Kokkos::deep_copy(x.h_base, x.d_base);
 
-  Kokkos::deep_copy(h_b_x, b_x);
-  Kokkos::deep_copy(h_b_y, b_y);
-
-  typename ViewTypeA::const_type c_x = x;
-
-  KokkosBlas::axpy(a, x, y);
-  Kokkos::deep_copy(h_b_y, b_y);
+  KokkosBlas::axpy(a, x.d_view, y.d_view);
+  Kokkos::deep_copy(y.h_base, y.d_base);
   for (int i = 0; i < N; i++) {
     for (int j = 0; j < K; j++) {
-      EXPECT_NEAR_KK(static_cast<ScalarB>(a * h_x(i, j) + h_org_y(i, j)),
-                     h_y(i, j), 2 * max_error);
+      EXPECT_NEAR_KK(
+          static_cast<ScalarB>(a * x.h_view(i, j) + org_y.h_view(i, j)),
+          y.h_view(i, j), 2 * max_error);
     }
   }
 
-  Kokkos::deep_copy(b_y, b_org_y);
-  KokkosBlas::axpy(a, c_x, y);
-  Kokkos::deep_copy(h_b_y, b_y);
+  // reset y to orig, and run again with const-valued x
+  Kokkos::deep_copy(y.d_base, org_y.h_base);
+  KokkosBlas::axpy(a, x.d_view, y.d_view);
+  Kokkos::deep_copy(y.h_base, y.d_base);
   for (int i = 0; i < N; i++) {
     for (int j = 0; j < K; j++) {
-      EXPECT_NEAR_KK(static_cast<ScalarB>(a * h_x(i, j) + h_org_y(i, j)),
-                     h_y(i, j), 2 * max_error);
+      EXPECT_NEAR_KK(
+          static_cast<ScalarB>(a * x.h_view(i, j) + org_y.h_view(i, j)),
+          y.h_view(i, j), 2 * max_error);
     }
   }
 }

--- a/blas/unit_test/Test_Blas1_dot.hpp
+++ b/blas/unit_test/Test_Blas1_dot.hpp
@@ -48,7 +48,8 @@ void impl_test_dot(int N) {
   Kokkos::deep_copy(b.h_base, b.d_base);
 
   ScalarA expected_result = 0;
-  for (int i = 0; i < N; i++) expected_result += ats::conj(a.h_view(i)) * b.h_view(i);
+  for (int i = 0; i < N; i++)
+    expected_result += ats::conj(a.h_view(i)) * b.h_view(i);
 
   ScalarA nonconst_nonconst_result = KokkosBlas::dot(a.d_view, b.d_view);
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
@@ -70,7 +71,6 @@ void impl_test_dot_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
   typedef Kokkos::ArithTraits<ScalarA> ats;
-
 
   view_stride_adapter<ViewTypeA> a("A", N, K);
   view_stride_adapter<ViewTypeB> b("B", N, K);
@@ -163,22 +163,22 @@ int test_dot() {
   // Test::impl_test_dot<view_type_a_lr, view_type_b_lr, Device>(132231);
 #endif
 
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
-    typedef Kokkos::View<ScalarB*, Kokkos::LayoutStride, Device> view_type_b_ls;
-    Test::impl_test_dot<view_type_a_ls, view_type_b_ls, Device>(0);
-    Test::impl_test_dot<view_type_a_ls, view_type_b_ls, Device>(13);
-    Test::impl_test_dot<view_type_a_ls, view_type_b_ls, Device>(1024);
-    // Test::impl_test_dot<view_type_a_ls, view_type_b_ls, Device>(132231);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
+  typedef Kokkos::View<ScalarB*, Kokkos::LayoutStride, Device> view_type_b_ls;
+  Test::impl_test_dot<view_type_a_ls, view_type_b_ls, Device>(0);
+  Test::impl_test_dot<view_type_a_ls, view_type_b_ls, Device>(13);
+  Test::impl_test_dot<view_type_a_ls, view_type_b_ls, Device>(1024);
+  // Test::impl_test_dot<view_type_a_ls, view_type_b_ls, Device>(132231);
+#endif
 
-  #if !defined(KOKKOSKERNELS_ETI_ONLY) && \
-      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-    Test::impl_test_dot<view_type_a_ls, view_type_b_ll, Device>(1024);
-    Test::impl_test_dot<view_type_a_ll, view_type_b_ls, Device>(1024);
-  #endif
+#if !defined(KOKKOSKERNELS_ETI_ONLY) && \
+    !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
+  Test::impl_test_dot<view_type_a_ls, view_type_b_ll, Device>(1024);
+  Test::impl_test_dot<view_type_a_ll, view_type_b_ls, Device>(1024);
+#endif
 
   return 1;
 }
@@ -209,26 +209,25 @@ int test_dot_mv() {
   // Test::impl_test_dot_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
 #endif
 
-  // Removing the layout stride test as ViewTypeA a("a", N);
-  // is invalid since the view constructor needs a stride object!
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device>
-  view_type_a_ls; typedef Kokkos::View<ScalarB**, Kokkos::LayoutStride, Device>
-  view_type_b_ls; Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls,
-  Device>(0, 5); Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls,
-  Device>(13, 5); Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls,
-  Device>(1024, 5); Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls,
-  Device>(789, 1);
-    // Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
-  #endif
+// Removing the layout stride test as ViewTypeA a("a", N);
+// is invalid since the view constructor needs a stride object!
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device> view_type_a_ls;
+  typedef Kokkos::View<ScalarB**, Kokkos::LayoutStride, Device> view_type_b_ls;
+  Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls, Device>(0, 5);
+  Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls, Device>(13, 5);
+  Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls, Device>(1024, 5);
+  Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls, Device>(789, 1);
+  // Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
+#endif
 
-  #if !defined(KOKKOSKERNELS_ETI_ONLY) && \
-      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-    Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ll, Device>(1024, 5);
-    Test::impl_test_dot_mv<view_type_a_ll, view_type_b_ls, Device>(1024, 5);
-  #endif
+#if !defined(KOKKOSKERNELS_ETI_ONLY) && \
+    !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
+  Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ll, Device>(1024, 5);
+  Test::impl_test_dot_mv<view_type_a_ll, view_type_b_ls, Device>(1024, 5);
+#endif
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_dot.hpp
+++ b/blas/unit_test/Test_Blas1_dot.hpp
@@ -185,9 +185,6 @@ int test_dot() {
   // Test::impl_test_dot<view_type_a_lr, view_type_b_lr, Device>(132231);
 #endif
 
-  // Removing the layout stride test as ViewTypeA a("a", N);
-  // is invalid since the view constructor needs a stride object!
-  /*
   #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
       (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
        !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -204,7 +201,6 @@ int test_dot() {
     Test::impl_test_dot<view_type_a_ls, view_type_b_ll, Device>(1024);
     Test::impl_test_dot<view_type_a_ll, view_type_b_ls, Device>(1024);
   #endif
-  */
 
   return 1;
 }
@@ -237,7 +233,6 @@ int test_dot_mv() {
 
   // Removing the layout stride test as ViewTypeA a("a", N);
   // is invalid since the view constructor needs a stride object!
-  /*
   #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
       (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
        !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -256,7 +251,6 @@ int test_dot_mv() {
     Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ll, Device>(1024, 5);
     Test::impl_test_dot_mv<view_type_a_ll, view_type_b_ls, Device>(1024, 5);
   #endif
-  */
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_dot.hpp
+++ b/blas/unit_test/Test_Blas1_dot.hpp
@@ -27,11 +27,8 @@ void impl_test_dot(int N) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef Kokkos::ArithTraits<ScalarA> ats;
 
-  ViewTypeA a("a", N);
-  ViewTypeB b("b", N);
-
-  typename ViewTypeA::HostMirror h_a = Kokkos::create_mirror_view(a);
-  typename ViewTypeB::HostMirror h_b = Kokkos::create_mirror_view(b);
+  view_stride_adapter<ViewTypeA> a("a", N);
+  view_stride_adapter<ViewTypeB> b("b", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
@@ -39,34 +36,32 @@ void impl_test_dot(int N) {
   {
     ScalarA randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(a, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(b, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(b.d_view, rand_pool, randStart, randEnd);
   }
 
-  Kokkos::deep_copy(h_a, a);
-  Kokkos::deep_copy(h_b, b);
+  Kokkos::deep_copy(a.h_base, a.d_base);
+  Kokkos::deep_copy(b.h_base, b.d_base);
 
   ScalarA expected_result = 0;
-  for (int i = 0; i < N; i++) expected_result += ats::conj(h_a(i)) * h_b(i);
+  for (int i = 0; i < N; i++) expected_result += ats::conj(a.h_view(i)) * b.h_view(i);
 
-  ScalarA nonconst_nonconst_result = KokkosBlas::dot(a, b);
+  ScalarA nonconst_nonconst_result = KokkosBlas::dot(a.d_view, b.d_view);
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
   EXPECT_NEAR_KK(nonconst_nonconst_result, expected_result,
                  eps * expected_result);
-  typename ViewTypeA::const_type c_a = a;
-  typename ViewTypeB::const_type c_b = b;
 
-  ScalarA const_const_result = KokkosBlas::dot(c_a, c_b);
+  ScalarA const_const_result = KokkosBlas::dot(a.d_view_const, b.d_view_const);
   EXPECT_NEAR_KK(const_const_result, expected_result, eps * expected_result);
 
-  ScalarA nonconst_const_result = KokkosBlas::dot(a, c_b);
+  ScalarA nonconst_const_result = KokkosBlas::dot(a.d_view, b.d_view_const);
   EXPECT_NEAR_KK(nonconst_const_result, expected_result, eps * expected_result);
 
-  ScalarA const_nonconst_result = KokkosBlas::dot(c_a, b);
+  ScalarA const_nonconst_result = KokkosBlas::dot(a.d_view_const, b.d_view);
   EXPECT_NEAR_KK(const_nonconst_result, expected_result, eps * expected_result);
 }
 
@@ -76,23 +71,9 @@ void impl_test_dot_mv(int N, int K) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef Kokkos::ArithTraits<ScalarA> ats;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-  typedef multivector_layout_adapter<ViewTypeB> vfB_type;
 
-  typename vfA_type::BaseType b_a("A", N, K);
-  typename vfB_type::BaseType b_b("B", N, K);
-
-  ViewTypeA a = vfA_type::view(b_a);
-  ViewTypeB b = vfB_type::view(b_b);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-  typedef multivector_layout_adapter<typename ViewTypeB::HostMirror> h_vfB_type;
-
-  typename h_vfA_type::BaseType h_b_a = Kokkos::create_mirror_view(b_a);
-  typename h_vfB_type::BaseType h_b_b = Kokkos::create_mirror_view(b_b);
-
-  typename ViewTypeA::HostMirror h_a = h_vfA_type::view(h_b_a);
-  typename ViewTypeB::HostMirror h_b = h_vfB_type::view(h_b_b);
+  view_stride_adapter<ViewTypeA> a("A", N, K);
+  view_stride_adapter<ViewTypeB> b("B", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
@@ -100,32 +81,29 @@ void impl_test_dot_mv(int N, int K) {
   {
     ScalarA randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(b_a, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(b_b, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(b.d_view, rand_pool, randStart, randEnd);
   }
 
-  Kokkos::deep_copy(h_b_a, b_a);
-  Kokkos::deep_copy(h_b_b, b_b);
-
-  typename ViewTypeA::const_type c_a = a;
-  typename ViewTypeB::const_type c_b = b;
+  Kokkos::deep_copy(a.h_base, a.d_base);
+  Kokkos::deep_copy(b.h_base, b.d_base);
 
   ScalarA* expected_result = new ScalarA[K];
   for (int j = 0; j < K; j++) {
     expected_result[j] = ScalarA();
     for (int i = 0; i < N; i++)
-      expected_result[j] += ats::conj(h_a(i, j)) * h_b(i, j);
+      expected_result[j] += ats::conj(a.h_view(i, j)) * b.h_view(i, j);
   }
 
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
 
   Kokkos::View<ScalarB*, Kokkos::HostSpace> r("Dot::Result", K);
 
-  KokkosBlas::dot(r, a, b);
+  KokkosBlas::dot(r, a.d_view, b.d_view);
   Kokkos::fence();
   for (int k = 0; k < K; k++) {
     ScalarA nonconst_nonconst_result = r(k);
@@ -133,7 +111,7 @@ void impl_test_dot_mv(int N, int K) {
                    eps * expected_result[k]);
   }
 
-  KokkosBlas::dot(r, c_a, c_b);
+  KokkosBlas::dot(r, a.d_view_const, b.d_view_const);
   Kokkos::fence();
   for (int k = 0; k < K; k++) {
     ScalarA const_const_result = r(k);
@@ -141,7 +119,7 @@ void impl_test_dot_mv(int N, int K) {
                    eps * expected_result[k]);
   }
 
-  KokkosBlas::dot(r, a, c_b);
+  KokkosBlas::dot(r, a.d_view, b.d_view_const);
   Kokkos::fence();
   for (int k = 0; k < K; k++) {
     ScalarA non_const_const_result = r(k);
@@ -149,7 +127,7 @@ void impl_test_dot_mv(int N, int K) {
                    eps * expected_result[k]);
   }
 
-  KokkosBlas::dot(r, c_a, b);
+  KokkosBlas::dot(r, a.d_view_const, b.d_view);
   Kokkos::fence();
   for (int k = 0; k < K; k++) {
     ScalarA const_non_const_result = r(k);

--- a/blas/unit_test/Test_Blas1_iamax.hpp
+++ b/blas/unit_test/Test_Blas1_iamax.hpp
@@ -240,7 +240,6 @@ int test_iamax() {
   // Test::impl_test_iamax<view_type_a_lr, Device>(132231);
 #endif
 
-  /*
   #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
       (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
        !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -250,7 +249,6 @@ int test_iamax() {
     Test::impl_test_iamax<view_type_a_ls, Device>(1024);
     // Test::impl_test_iamax<view_type_a_ls, Device>(132231);
   #endif
-  */
 
   return 1;
 }
@@ -277,7 +275,6 @@ int test_iamax_mv() {
   // Test::impl_test_iamax_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
-  /*
   #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
       (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
        !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -287,7 +284,6 @@ int test_iamax_mv() {
     Test::impl_test_iamax_mv<view_type_a_ls, Device>(1024, 5);
     // Test::impl_test_iamax_mv<view_type_a_ls, Device>(132231,5);
   #endif
-  */
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_iamax.hpp
+++ b/blas/unit_test/Test_Blas1_iamax.hpp
@@ -27,25 +27,21 @@ void impl_test_iamax(int N) {
   typedef typename AT::mag_type mag_type;
   using size_type = typename ViewTypeA::size_type;
 
-  ViewTypeA a("A", N);
-
-  typename ViewTypeA::HostMirror h_a = Kokkos::create_mirror_view(a);
+  view_stride_adapter<ViewTypeA> a("X", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
   ScalarA randStart, randEnd;
   Test::getRandomBounds(10.0, randStart, randEnd);
-  Kokkos::fill_random(a, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
-  Kokkos::deep_copy(h_a, a);
-
-  typename ViewTypeA::const_type c_a = a;
+  Kokkos::deep_copy(a.h_base, a.d_base);
 
   mag_type expected_result   = Kokkos::ArithTraits<mag_type>::min();
   size_type expected_max_loc = 0;
   for (int i = 0; i < N; i++) {
-    mag_type val = AT::abs(h_a(i));
+    mag_type val = AT::abs(a.h_view(i));
     if (val > expected_result) {
       expected_result  = val;
       expected_max_loc = i + 1;
@@ -60,10 +56,10 @@ void impl_test_iamax(int N) {
   {
     // printf("impl_test_iamax -- return result as a scalar on host -- N %d\n",
     // N);
-    size_type nonconst_max_loc = KokkosBlas::iamax(a);
+    size_type nonconst_max_loc = KokkosBlas::iamax(a.d_view);
     ASSERT_EQ(nonconst_max_loc, expected_max_loc);
 
-    size_type const_max_loc = KokkosBlas::iamax(c_a);
+    size_type const_max_loc = KokkosBlas::iamax(a.d_view_const);
     ASSERT_EQ(const_max_loc, expected_max_loc);
   }
 
@@ -73,14 +69,15 @@ void impl_test_iamax(int N) {
     typedef Kokkos::View<size_type, typename ViewTypeA::array_layout,
                          Kokkos::HostSpace>
         ViewType0D;
-    ViewType0D r("Iamax::Result 0-D View on host");
+    ViewType0D r("Iamax::Result 0-D View on host",
+                 typename ViewTypeA::array_layout());
 
-    KokkosBlas::iamax(r, a);
+    KokkosBlas::iamax(r, a.d_view);
     Kokkos::fence();
     size_type nonconst_max_loc = r();
     ASSERT_EQ(nonconst_max_loc, expected_max_loc);
 
-    KokkosBlas::iamax(r, c_a);
+    KokkosBlas::iamax(r, a.d_view_const);
     size_type const_max_loc = r();
     ASSERT_EQ(const_max_loc, expected_max_loc);
   }
@@ -90,19 +87,20 @@ void impl_test_iamax(int N) {
     // %d\n", N);
     typedef Kokkos::View<size_type, typename ViewTypeA::array_layout, Device>
         ViewType0D;
-    ViewType0D r("Iamax::Result 0-D View on device");
+    ViewType0D r("Iamax::Result 0-D View on device",
+                 typename ViewTypeA::array_layout());
     typename ViewType0D::HostMirror h_r = Kokkos::create_mirror_view(r);
 
     size_type nonconst_max_loc, const_max_loc;
 
-    KokkosBlas::iamax(r, a);
+    KokkosBlas::iamax(r, a.d_view);
     Kokkos::deep_copy(h_r, r);
 
     nonconst_max_loc = h_r();
 
     ASSERT_EQ(nonconst_max_loc, expected_max_loc);
 
-    KokkosBlas::iamax(r, c_a);
+    KokkosBlas::iamax(r, a.d_view_const);
     Kokkos::deep_copy(h_r, r);
 
     const_max_loc = h_r();
@@ -118,28 +116,16 @@ void impl_test_iamax_mv(int N, int K) {
   typedef typename AT::mag_type mag_type;
   typedef typename ViewTypeA::size_type size_type;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-
-  typename vfA_type::BaseType b_a("A", N, K);
-
-  ViewTypeA a = vfA_type::view(b_a);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-
-  typename h_vfA_type::BaseType h_b_a = Kokkos::create_mirror_view(b_a);
-
-  typename ViewTypeA::HostMirror h_a = h_vfA_type::view(h_b_a);
+  view_stride_adapter<ViewTypeA> a("A", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
   ScalarA randStart, randEnd;
   Test::getRandomBounds(10.0, randStart, randEnd);
-  Kokkos::fill_random(b_a, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
-  Kokkos::deep_copy(h_b_a, b_a);
-
-  typename ViewTypeA::const_type c_a = a;
+  Kokkos::deep_copy(a.h_base, a.d_base);
 
   mag_type* expected_result   = new mag_type[K];
   size_type* expected_max_loc = new size_type[K];
@@ -147,7 +133,7 @@ void impl_test_iamax_mv(int N, int K) {
   for (int j = 0; j < K; j++) {
     expected_result[j] = Kokkos::ArithTraits<mag_type>::min();
     for (int i = 0; i < N; i++) {
-      mag_type val = AT::abs(h_a(i, j));
+      mag_type val = AT::abs(a.h_view(i, j));
       if (val > expected_result[j]) {
         expected_result[j]  = val;
         expected_max_loc[j] = i + 1;
@@ -162,11 +148,13 @@ void impl_test_iamax_mv(int N, int K) {
   {
     // printf("impl_test_iamax_mv -- return results as a 1-D View on host -- N
     // %d\n", N);
+    Kokkos::View<size_type*, Kokkos::HostSpace> rcontig(
+        "Iamax::Result View on host", K);
     Kokkos::View<size_type*, typename ViewTypeA::array_layout,
                  Kokkos::HostSpace>
-        r("Iamax::Result View on host", K);
+        r = rcontig;
 
-    KokkosBlas::iamax(r, a);
+    KokkosBlas::iamax(r, a.d_view);
     Kokkos::fence();
 
     for (int k = 0; k < K; k++) {
@@ -175,7 +163,7 @@ void impl_test_iamax_mv(int N, int K) {
       ASSERT_EQ(nonconst_result, exp_result);
     }
 
-    KokkosBlas::iamax(r, c_a);
+    KokkosBlas::iamax(r, a.d_view_const);
     Kokkos::fence();
 
     for (int k = 0; k < K; k++) {
@@ -188,13 +176,14 @@ void impl_test_iamax_mv(int N, int K) {
   {
     // printf("impl_test_iamax_mv -- return results as a 1-D View on device -- N
     // %d\n", N);
-    Kokkos::View<size_type*, typename ViewTypeA::array_layout, Device> r(
-        "Iamax::Result View on device", K);
+    Kokkos::View<size_type*, Device> rcontig("Iamax::Result View on host", K);
+    Kokkos::View<size_type*, typename ViewTypeA::array_layout, Device> r =
+        rcontig;
     typename Kokkos::View<size_type*, typename ViewTypeA::array_layout,
                           Device>::HostMirror h_r =
-        Kokkos::create_mirror_view(r);
+        Kokkos::create_mirror_view(rcontig);
 
-    KokkosBlas::iamax(r, a);
+    KokkosBlas::iamax(r, a.d_view);
     Kokkos::deep_copy(h_r, r);
 
     for (int k = 0; k < K; k++) {
@@ -203,7 +192,7 @@ void impl_test_iamax_mv(int N, int K) {
       ASSERT_EQ(nonconst_result, exp_result);
     }
 
-    KokkosBlas::iamax(r, c_a);
+    KokkosBlas::iamax(r, a.d_view_const);
     Kokkos::deep_copy(h_r, r);
 
     for (int k = 0; k < K; k++) {
@@ -240,15 +229,15 @@ int test_iamax() {
   // Test::impl_test_iamax<view_type_a_lr, Device>(132231);
 #endif
 
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
-    Test::impl_test_iamax<view_type_a_ls, Device>(0);
-    Test::impl_test_iamax<view_type_a_ls, Device>(13);
-    Test::impl_test_iamax<view_type_a_ls, Device>(1024);
-    // Test::impl_test_iamax<view_type_a_ls, Device>(132231);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
+  Test::impl_test_iamax<view_type_a_ls, Device>(0);
+  Test::impl_test_iamax<view_type_a_ls, Device>(13);
+  Test::impl_test_iamax<view_type_a_ls, Device>(1024);
+  // Test::impl_test_iamax<view_type_a_ls, Device>(132231);
+#endif
 
   return 1;
 }
@@ -275,15 +264,15 @@ int test_iamax_mv() {
   // Test::impl_test_iamax_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device>
-  view_type_a_ls; Test::impl_test_iamax_mv<view_type_a_ls, Device>(0, 5);
-    Test::impl_test_iamax_mv<view_type_a_ls, Device>(13, 5);
-    Test::impl_test_iamax_mv<view_type_a_ls, Device>(1024, 5);
-    // Test::impl_test_iamax_mv<view_type_a_ls, Device>(132231,5);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device> view_type_a_ls;
+  Test::impl_test_iamax_mv<view_type_a_ls, Device>(0, 5);
+  Test::impl_test_iamax_mv<view_type_a_ls, Device>(13, 5);
+  Test::impl_test_iamax_mv<view_type_a_ls, Device>(1024, 5);
+  // Test::impl_test_iamax_mv<view_type_a_ls, Device>(132231,5);
+#endif
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_mult.hpp
+++ b/blas/unit_test/Test_Blas1_mult.hpp
@@ -31,17 +31,10 @@ void impl_test_mult(int N) {
   ScalarB b  = 5;
   double eps = std::is_same<ScalarC, float>::value ? 1e-4 : 1e-7;
 
-  ViewTypeA x("X", N);
-  ViewTypeB y("Y", N);
-  ViewTypeC z("Y", N);
-  ViewTypeC b_org_z("Org_Z", N);
-
-  typename ViewTypeA::const_type c_x = x;
-  typename ViewTypeB::const_type c_y = y;
-
-  typename ViewTypeA::HostMirror h_x = Kokkos::create_mirror_view(x);
-  typename ViewTypeB::HostMirror h_y = Kokkos::create_mirror_view(y);
-  typename ViewTypeC::HostMirror h_z = Kokkos::create_mirror_view(z);
+  view_stride_adapter<ViewTypeA> x("X", N);
+  view_stride_adapter<ViewTypeB> y("Y", N);
+  view_stride_adapter<ViewTypeC> z("Z", N);
+  view_stride_adapter<ViewTypeC> org_z("Org_Z", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
@@ -49,49 +42,48 @@ void impl_test_mult(int N) {
   {
     ScalarA randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(x, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(y, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarC randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(z, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(z.d_view, rand_pool, randStart, randEnd);
   }
 
-  Kokkos::deep_copy(b_org_z, z);
-  auto h_b_org_z =
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_org_z);
+  Kokkos::deep_copy(org_z.h_base, z.d_base);
 
-  Kokkos::deep_copy(h_x, x);
-  Kokkos::deep_copy(h_y, y);
+  Kokkos::deep_copy(x.h_base, x.d_base);
+  Kokkos::deep_copy(y.h_base, y.d_base);
 
-  // expected_result = ScalarC(b*h_z(i) + a*h_x(i)*h_y(i))
-
-  KokkosBlas::mult(b, z, a, x, y);
-  Kokkos::deep_copy(h_z, z);
+  KokkosBlas::mult(b, z.d_view, a, x.d_view, y.d_view);
+  Kokkos::deep_copy(z.h_base, z.d_base);
   for (int i = 0; i < N; i++) {
-    EXPECT_NEAR_KK(static_cast<ScalarC>(a * h_x(i) * h_y(i) + b * h_b_org_z(i)),
-                   h_z(i), eps);
+    EXPECT_NEAR_KK(static_cast<ScalarC>(a * x.h_view(i) * y.h_view(i) +
+                                        b * org_z.h_view(i)),
+                   z.h_view(i), eps);
   }
 
-  Kokkos::deep_copy(z, b_org_z);
-  KokkosBlas::mult(b, z, a, x, c_y);
-  Kokkos::deep_copy(h_z, z);
+  Kokkos::deep_copy(z.d_base, org_z.h_base);
+  KokkosBlas::mult(b, z.d_view, a, x.d_view, y.d_view_const);
+  Kokkos::deep_copy(z.h_base, z.d_base);
   for (int i = 0; i < N; i++) {
-    EXPECT_NEAR_KK(static_cast<ScalarC>(a * h_x(i) * h_y(i) + b * h_b_org_z(i)),
-                   h_z(i), eps);
+    EXPECT_NEAR_KK(static_cast<ScalarC>(a * x.h_view(i) * y.h_view(i) +
+                                        b * org_z.h_view(i)),
+                   z.h_view(i), eps);
   }
 
-  Kokkos::deep_copy(z, b_org_z);
-  KokkosBlas::mult(b, z, a, c_x, c_y);
-  Kokkos::deep_copy(h_z, z);
+  Kokkos::deep_copy(z.d_base, org_z.h_base);
+  KokkosBlas::mult(b, z.d_view, a, x.d_view_const, y.d_view_const);
+  Kokkos::deep_copy(z.h_base, z.d_base);
   for (int i = 0; i < N; i++) {
-    EXPECT_NEAR_KK(static_cast<ScalarC>(a * h_x(i) * h_y(i) + b * h_b_org_z(i)),
-                   h_z(i), eps);
+    EXPECT_NEAR_KK(static_cast<ScalarC>(a * x.h_view(i) * y.h_view(i) +
+                                        b * org_z.h_view(i)),
+                   z.h_view(i), eps);
   }
 }
 
@@ -101,26 +93,11 @@ void impl_test_mult_mv(int N, int K) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef typename ViewTypeC::value_type ScalarC;
 
-  typedef multivector_layout_adapter<ViewTypeB> vfB_type;
-  typedef multivector_layout_adapter<ViewTypeC> vfC_type;
-
-  ViewTypeA x("X", N);
-  typename vfB_type::BaseType b_y("Y", N, K);
-  typename vfC_type::BaseType b_z("Z", N, K);
-  typename vfC_type::BaseType b_org_z("Z", N, K);
-
-  ViewTypeB y = vfB_type::view(b_y);
-  ViewTypeC z = vfC_type::view(b_z);
-
-  typedef multivector_layout_adapter<typename ViewTypeB::HostMirror> h_vfB_type;
-  typedef multivector_layout_adapter<typename ViewTypeC::HostMirror> h_vfC_type;
-
-  typename h_vfB_type::BaseType h_b_y = Kokkos::create_mirror_view(b_y);
-  typename h_vfC_type::BaseType h_b_z = Kokkos::create_mirror_view(b_z);
-
-  typename ViewTypeA::HostMirror h_x = Kokkos::create_mirror_view(x);
-  typename ViewTypeB::HostMirror h_y = h_vfB_type::view(h_b_y);
-  typename ViewTypeC::HostMirror h_z = h_vfC_type::view(h_b_z);
+  // x is rank-1, all others are rank-2
+  view_stride_adapter<ViewTypeA> x("X", N);
+  view_stride_adapter<ViewTypeB> y("Y", N, K);
+  view_stride_adapter<ViewTypeC> z("Z", N, K);
+  view_stride_adapter<ViewTypeC> org_z("Org_Z", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
@@ -128,52 +105,46 @@ void impl_test_mult_mv(int N, int K) {
   {
     ScalarA randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(x, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(b_y, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarC randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(b_z, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(z.d_view, rand_pool, randStart, randEnd);
   }
 
-  Kokkos::deep_copy(b_org_z, b_z);
-  auto h_b_org_z =
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_org_z);
+  Kokkos::deep_copy(org_z.h_base, z.d_base);
+  Kokkos::deep_copy(x.h_base, x.d_base);
+  Kokkos::deep_copy(y.h_base, y.d_base);
 
-  Kokkos::deep_copy(h_x, x);
-  Kokkos::deep_copy(h_b_y, b_y);
-  Kokkos::deep_copy(h_b_z, b_z);
-
-  ScalarA a                          = 3;
-  ScalarB b                          = 5;
-  typename ViewTypeA::const_type c_x = x;
-  typename ViewTypeB::const_type c_y = y;
+  ScalarA a = 3;
+  ScalarB b = 5;
 
   double eps = std::is_same<ScalarA, float>::value ? 1e-4 : 1e-7;
 
-  KokkosBlas::mult(b, z, a, x, y);
-  Kokkos::deep_copy(h_b_z, b_z);
+  KokkosBlas::mult(b, z.d_view, a, x.d_view, y.d_view);
+  Kokkos::deep_copy(z.h_base, z.d_base);
   for (int i = 0; i < N; i++) {
     for (int j = 0; j < K; j++) {
-      EXPECT_NEAR_KK(
-          static_cast<ScalarC>(a * h_x(i) * h_y(i, j) + b * h_b_org_z(i, j)),
-          h_z(i, j), eps);
+      EXPECT_NEAR_KK(static_cast<ScalarC>(a * x.h_view(i) * y.h_view(i, j) +
+                                          b * org_z.h_view(i, j)),
+                     z.h_view(i, j), eps);
     }
   }
 
-  Kokkos::deep_copy(b_z, b_org_z);
-  KokkosBlas::mult(b, z, a, x, c_y);
-  Kokkos::deep_copy(h_b_z, b_z);
+  Kokkos::deep_copy(z.d_base, org_z.h_base);
+  KokkosBlas::mult(b, z.d_view, a, x.d_view, y.d_view_const);
+  Kokkos::deep_copy(z.h_base, z.d_base);
   for (int i = 0; i < N; i++) {
     for (int j = 0; j < K; j++) {
-      EXPECT_NEAR_KK(
-          static_cast<ScalarC>(a * h_x(i) * h_y(i, j) + b * h_b_org_z(i, j)),
-          h_z(i, j), eps);
+      EXPECT_NEAR_KK(static_cast<ScalarC>(a * x.h_view(i) * y.h_view(i, j) +
+                                          b * org_z.h_view(i, j)),
+                     z.h_view(i, j), eps);
     }
   }
 }
@@ -213,27 +184,29 @@ int test_mult() {
   // Device>(132231);
 #endif
 
-  /*
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
-    typedef Kokkos::View<ScalarB*, Kokkos::LayoutStride, Device> view_type_b_ls;
-    typedef Kokkos::View<ScalarC*, Kokkos::LayoutStride, Device> view_type_c_ls;
-    Test::impl_test_mult<view_type_a_ls, view_type_b_ls, view_type_c_ls,
-  Device>( 0); Test::impl_test_mult<view_type_a_ls, view_type_b_ls,
-  view_type_c_ls, Device>( 13); Test::impl_test_mult<view_type_a_ls,
-  view_type_b_ls, view_type_c_ls, Device>( 1024);
-    // Test::impl_test_mult<view_type_a_ls, view_type_b_ls, view_type_c_ls,
-    // Device>(132231);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
+  typedef Kokkos::View<ScalarB*, Kokkos::LayoutStride, Device> view_type_b_ls;
+  typedef Kokkos::View<ScalarC*, Kokkos::LayoutStride, Device> view_type_c_ls;
+  Test::impl_test_mult<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(
+      0);
+  Test::impl_test_mult<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(
+      13);
+  Test::impl_test_mult<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(
+      1024);
+  // Test::impl_test_mult<view_type_a_ls, view_type_b_ls, view_type_c_ls,
+  // Device>(132231);
+#endif
 
-  #if !defined(KOKKOSKERNELS_ETI_ONLY) && \
-      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-    Test::impl_test_mult<view_type_a_ls, view_type_b_ll, view_type_c_lr,
-  Device>( 1024); Test::impl_test_mult<view_type_a_ll, view_type_b_ls,
-  view_type_c_lr, Device>( 1024); #endif
-  */
+#if !defined(KOKKOSKERNELS_ETI_ONLY) && \
+    !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
+  Test::impl_test_mult<view_type_a_ls, view_type_b_ll, view_type_c_lr, Device>(
+      1024);
+  Test::impl_test_mult<view_type_a_ll, view_type_b_ls, view_type_c_lr, Device>(
+      1024);
+#endif
 
   return 1;
 }
@@ -272,30 +245,29 @@ int test_mult_mv() {
   // Device>(132231,5);
 #endif
 
-  /*
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
-    typedef Kokkos::View<ScalarB**, Kokkos::LayoutStride, Device>
-  view_type_b_ls; typedef Kokkos::View<ScalarC**, Kokkos::LayoutStride, Device>
-  view_type_c_ls; Test::impl_test_mult_mv<view_type_a_ls, view_type_b_ls,
-  view_type_c_ls, Device>(0, 5); Test::impl_test_mult_mv<view_type_a_ls,
-  view_type_b_ls, view_type_c_ls, Device>(13, 5);
-    Test::impl_test_mult_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls,
-                            Device>(1024, 5);
-    // Test::impl_test_mult_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls,
-    // Device>(132231,5);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
+  typedef Kokkos::View<ScalarB**, Kokkos::LayoutStride, Device> view_type_b_ls;
+  typedef Kokkos::View<ScalarC**, Kokkos::LayoutStride, Device> view_type_c_ls;
+  Test::impl_test_mult_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls,
+                          Device>(0, 5);
+  Test::impl_test_mult_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls,
+                          Device>(13, 5);
+  Test::impl_test_mult_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls,
+                          Device>(1024, 5);
+  // Test::impl_test_mult_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls,
+  // Device>(132231,5);
+#endif
 
-  #if !defined(KOKKOSKERNELS_ETI_ONLY) && \
-      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-    Test::impl_test_mult_mv<view_type_a_ls, view_type_b_ll, view_type_c_lr,
-                            Device>(1024, 5);
-    Test::impl_test_mult_mv<view_type_a_ll, view_type_b_ls, view_type_c_lr,
-                            Device>(1024, 5);
-  #endif
-  */
+#if !defined(KOKKOSKERNELS_ETI_ONLY) && \
+    !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
+  Test::impl_test_mult_mv<view_type_a_ls, view_type_b_ll, view_type_c_lr,
+                          Device>(1024, 5);
+  Test::impl_test_mult_mv<view_type_a_ll, view_type_b_ls, view_type_c_lr,
+                          Device>(1024, 5);
+#endif
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_nrm1.hpp
+++ b/blas/unit_test/Test_Blas1_nrm1.hpp
@@ -27,20 +27,17 @@ void impl_test_nrm1(int N) {
   typedef typename AT::mag_type mag_type;
   typedef Kokkos::ArithTraits<mag_type> MAT;
 
-  ViewTypeA a("A", N);
-
-  typename ViewTypeA::HostMirror h_a = Kokkos::create_mirror_view(a);
+  view_stride_adapter<ViewTypeA> a("a", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
   ScalarA randStart, randEnd;
   Test::getRandomBounds(10.0, randStart, randEnd);
-  Kokkos::fill_random(a, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
-  Kokkos::deep_copy(h_a, a);
+  Kokkos::deep_copy(a.h_base, a.d_base);
 
-  typename ViewTypeA::const_type c_a = a;
   double eps = (std::is_same<typename Kokkos::ArithTraits<ScalarA>::mag_type,
                              float>::value
                     ? 1e-4
@@ -53,13 +50,14 @@ void impl_test_nrm1(int N) {
     // parts. See netlib, MKL, and CUBLAS documentation.
     //
     // This is safe; ArithTraits<T>::imag is 0 if T is real.
-    expected_result += MAT::abs(AT::real(h_a(i))) + MAT::abs(AT::imag(h_a(i)));
+    expected_result +=
+        MAT::abs(AT::real(a.h_view(i))) + MAT::abs(AT::imag(a.h_view(i)));
   }
 
-  mag_type nonconst_result = KokkosBlas::nrm1(a);
+  mag_type nonconst_result = KokkosBlas::nrm1(a.d_view);
   EXPECT_NEAR_KK(nonconst_result, expected_result, eps * expected_result);
 
-  mag_type const_result = KokkosBlas::nrm1(c_a);
+  mag_type const_result = KokkosBlas::nrm1(a.d_view_const);
   EXPECT_NEAR_KK(const_result, expected_result, eps * expected_result);
 }
 
@@ -70,28 +68,16 @@ void impl_test_nrm1_mv(int N, int K) {
   typedef typename AT::mag_type mag_type;
   typedef Kokkos::ArithTraits<mag_type> MAT;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-
-  typename vfA_type::BaseType b_a("A", N, K);
-
-  ViewTypeA a = vfA_type::view(b_a);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-
-  typename h_vfA_type::BaseType h_b_a = Kokkos::create_mirror_view(b_a);
-
-  typename ViewTypeA::HostMirror h_a = h_vfA_type::view(h_b_a);
+  view_stride_adapter<ViewTypeA> a("A", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
   ScalarA randStart, randEnd;
   Test::getRandomBounds(10.0, randStart, randEnd);
-  Kokkos::fill_random(b_a, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
-  Kokkos::deep_copy(h_b_a, b_a);
-
-  typename ViewTypeA::const_type c_a = a;
+  Kokkos::deep_copy(a.h_base, a.d_base);
 
   double eps = (std::is_same<typename Kokkos::ArithTraits<ScalarA>::mag_type,
                              float>::value
@@ -103,20 +89,19 @@ void impl_test_nrm1_mv(int N, int K) {
   for (int k = 0; k < K; k++) {
     expected_result(k) = MAT::zero();
     for (int i = 0; i < N; i++) {
-      expected_result(k) +=
-          MAT::abs(AT::real(h_a(i, k))) + MAT::abs(AT::imag(h_a(i, k)));
+      expected_result(k) += MAT::abs(AT::real(a.h_view(i, k))) +
+                            MAT::abs(AT::imag(a.h_view(i, k)));
     }
   }
 
   Kokkos::View<mag_type*, Kokkos::HostSpace> r("Nrm1::Result", K);
   Kokkos::View<mag_type*, Kokkos::HostSpace> c_r("Nrm1::ConstResult", K);
 
-  KokkosBlas::nrm1(r, a);
-  KokkosBlas::nrm1(c_r, a);
+  KokkosBlas::nrm1(r, a.d_view);
+  KokkosBlas::nrm1(c_r, a.d_view_const);
   Kokkos::fence();
   for (int k = 0; k < K; k++) {
     EXPECT_NEAR_KK(r(k), expected_result(k), eps * expected_result(k));
-    EXPECT_NEAR_KK(c_r(k), expected_result(k), eps * expected_result(k));
   }
 }
 }  // namespace Test
@@ -143,15 +128,15 @@ int test_nrm1() {
   Test::impl_test_nrm1<view_type_a_lr, Device>(132231);
 #endif
 
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
-    Test::impl_test_nrm1<view_type_a_ls, Device>(0);
-    Test::impl_test_nrm1<view_type_a_ls, Device>(13);
-    Test::impl_test_nrm1<view_type_a_ls, Device>(1024);
-    Test::impl_test_nrm1<view_type_a_ls, Device>(132231);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
+  Test::impl_test_nrm1<view_type_a_ls, Device>(0);
+  Test::impl_test_nrm1<view_type_a_ls, Device>(13);
+  Test::impl_test_nrm1<view_type_a_ls, Device>(1024);
+  Test::impl_test_nrm1<view_type_a_ls, Device>(132231);
+#endif
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_nrm1.hpp
+++ b/blas/unit_test/Test_Blas1_nrm1.hpp
@@ -143,7 +143,6 @@ int test_nrm1() {
   Test::impl_test_nrm1<view_type_a_lr, Device>(132231);
 #endif
 
-  /*
   #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
       (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
        !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -153,7 +152,6 @@ int test_nrm1() {
     Test::impl_test_nrm1<view_type_a_ls, Device>(1024);
     Test::impl_test_nrm1<view_type_a_ls, Device>(132231);
   #endif
-  */
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_nrm2.hpp
+++ b/blas/unit_test/Test_Blas1_nrm2.hpp
@@ -25,33 +25,30 @@ void impl_test_nrm2(int N) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef Kokkos::ArithTraits<ScalarA> AT;
 
-  ViewTypeA a("A", N);
-
-  typename ViewTypeA::HostMirror h_a = Kokkos::create_mirror_view(a);
+  view_stride_adapter<ViewTypeA> a("a", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
   ScalarA randStart, randEnd;
   Test::getRandomBounds(1.0, randStart, randEnd);
-  Kokkos::fill_random(a, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
-  Kokkos::deep_copy(h_a, a);
+  Kokkos::deep_copy(a.h_base, a.d_base);
 
-  typename ViewTypeA::const_type c_a = a;
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
 
   typename AT::mag_type expected_result = 0;
   for (int i = 0; i < N; i++) {
-    expected_result += AT::abs(h_a(i)) * AT::abs(h_a(i));
+    expected_result += AT::abs(a.h_view(i)) * AT::abs(a.h_view(i));
   }
   expected_result =
       Kokkos::ArithTraits<typename AT::mag_type>::sqrt(expected_result);
 
-  typename AT::mag_type nonconst_result = KokkosBlas::nrm2(a);
+  typename AT::mag_type nonconst_result = KokkosBlas::nrm2(a.d_view);
   EXPECT_NEAR_KK(nonconst_result, expected_result, eps * expected_result);
 
-  typename AT::mag_type const_result = KokkosBlas::nrm2(c_a);
+  typename AT::mag_type const_result = KokkosBlas::nrm2(a.d_view_const);
   EXPECT_NEAR_KK(const_result, expected_result, eps * expected_result);
 }
 
@@ -60,34 +57,22 @@ void impl_test_nrm2_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef Kokkos::ArithTraits<ScalarA> AT;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-
-  typename vfA_type::BaseType b_a("A", N, K);
-
-  ViewTypeA a = vfA_type::view(b_a);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-
-  typename h_vfA_type::BaseType h_b_a = Kokkos::create_mirror_view(b_a);
-
-  typename ViewTypeA::HostMirror h_a = h_vfA_type::view(h_b_a);
+  view_stride_adapter<ViewTypeA> a("A", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
   ScalarA randStart, randEnd;
   Test::getRandomBounds(1.0, randStart, randEnd);
-  Kokkos::fill_random(b_a, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
-  Kokkos::deep_copy(h_b_a, b_a);
-
-  typename ViewTypeA::const_type c_a = a;
+  Kokkos::deep_copy(a.h_base, a.d_base);
 
   typename AT::mag_type* expected_result = new typename AT::mag_type[K];
   for (int j = 0; j < K; j++) {
     expected_result[j] = typename AT::mag_type();
     for (int i = 0; i < N; i++) {
-      expected_result[j] += AT::abs(h_a(i, j)) * AT::abs(h_a(i, j));
+      expected_result[j] += AT::abs(a.h_view(i, j)) * AT::abs(a.h_view(i, j));
     }
     expected_result[j] =
         Kokkos::ArithTraits<typename AT::mag_type>::sqrt(expected_result[j]);
@@ -97,7 +82,7 @@ void impl_test_nrm2_mv(int N, int K) {
 
   Kokkos::View<typename AT::mag_type*, Kokkos::HostSpace> r("Dot::Result", K);
 
-  KokkosBlas::nrm2(r, a);
+  KokkosBlas::nrm2(r, a.d_view);
   Kokkos::fence();
   for (int k = 0; k < K; k++) {
     typename AT::mag_type nonconst_result = r(k);
@@ -105,7 +90,7 @@ void impl_test_nrm2_mv(int N, int K) {
                    eps * expected_result[k]);
   }
 
-  KokkosBlas::nrm2(r, c_a);
+  KokkosBlas::nrm2(r, a.d_view_const);
   Kokkos::fence();
   for (int k = 0; k < K; k++) {
     typename AT::mag_type const_result = r(k);
@@ -138,15 +123,15 @@ int test_nrm2() {
   // Test::impl_test_nrm2<view_type_a_lr, Device>(132231);
 #endif
 
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
-    Test::impl_test_nrm2<view_type_a_ls, Device>(0);
-    Test::impl_test_nrm2<view_type_a_ls, Device>(13);
-    Test::impl_test_nrm2<view_type_a_ls, Device>(1024);
-    // Test::impl_test_nrm2<view_type_a_ls, Device>(132231);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
+  Test::impl_test_nrm2<view_type_a_ls, Device>(0);
+  Test::impl_test_nrm2<view_type_a_ls, Device>(13);
+  Test::impl_test_nrm2<view_type_a_ls, Device>(1024);
+  // Test::impl_test_nrm2<view_type_a_ls, Device>(132231);
+#endif
 
   return 1;
 }
@@ -175,16 +160,16 @@ int test_nrm2_mv() {
   // Test::impl_test_nrm2_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device>
-  view_type_a_ls; Test::impl_test_nrm2_mv<view_type_a_ls, Device>(0, 5);
-    Test::impl_test_nrm2_mv<view_type_a_ls, Device>(13, 5);
-    Test::impl_test_nrm2_mv<view_type_a_ls, Device>(1024, 5);
-    Test::impl_test_nrm2_mv<view_type_a_ls, Device>(789, 1);
-    // Test::impl_test_nrm2_mv<view_type_a_ls, Device>(132231,5);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device> view_type_a_ls;
+  Test::impl_test_nrm2_mv<view_type_a_ls, Device>(0, 5);
+  Test::impl_test_nrm2_mv<view_type_a_ls, Device>(13, 5);
+  Test::impl_test_nrm2_mv<view_type_a_ls, Device>(1024, 5);
+  Test::impl_test_nrm2_mv<view_type_a_ls, Device>(789, 1);
+  // Test::impl_test_nrm2_mv<view_type_a_ls, Device>(132231,5);
+#endif
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_nrm2.hpp
+++ b/blas/unit_test/Test_Blas1_nrm2.hpp
@@ -138,7 +138,6 @@ int test_nrm2() {
   // Test::impl_test_nrm2<view_type_a_lr, Device>(132231);
 #endif
 
-  /*
   #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
       (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
        !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -148,7 +147,6 @@ int test_nrm2() {
     Test::impl_test_nrm2<view_type_a_ls, Device>(1024);
     // Test::impl_test_nrm2<view_type_a_ls, Device>(132231);
   #endif
-  */
 
   return 1;
 }
@@ -177,7 +175,6 @@ int test_nrm2_mv() {
   // Test::impl_test_nrm2_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
-  /*
   #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
       (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
        !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -188,7 +185,6 @@ int test_nrm2_mv() {
     Test::impl_test_nrm2_mv<view_type_a_ls, Device>(789, 1);
     // Test::impl_test_nrm2_mv<view_type_a_ls, Device>(132231,5);
   #endif
-  */
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_nrm2_squared.hpp
+++ b/blas/unit_test/Test_Blas1_nrm2_squared.hpp
@@ -25,43 +25,28 @@ void impl_test_nrm2_squared(int N) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef Kokkos::ArithTraits<ScalarA> AT;
 
-  typedef Kokkos::View<
-      ScalarA * [2],
-      typename std::conditional<std::is_same<typename ViewTypeA::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeA;
-
-  BaseTypeA b_a("A", N);
-
-  ViewTypeA a = Kokkos::subview(b_a, Kokkos::ALL(), 0);
-
-  typename BaseTypeA::HostMirror h_b_a = Kokkos::create_mirror_view(b_a);
-
-  typename ViewTypeA::HostMirror h_a = Kokkos::subview(h_b_a, Kokkos::ALL(), 0);
+  view_stride_adapter<ViewTypeA> a("a", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
   ScalarA randStart, randEnd;
   Test::getRandomBounds(1.0, randStart, randEnd);
-  Kokkos::fill_random(b_a, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
-  Kokkos::deep_copy(h_b_a, b_a);
+  Kokkos::deep_copy(a.h_base, a.d_base);
 
-  typename ViewTypeA::const_type c_a = a;
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
 
   typename AT::mag_type expected_result(0);
   for (int i = 0; i < N; i++) {
-    expected_result += AT::abs(h_a(i)) * AT::abs(h_a(i));
+    expected_result += AT::abs(a.h_view(i)) * AT::abs(a.h_view(i));
   }
 
-  typename AT::mag_type nonconst_result = KokkosBlas::nrm2_squared(a);
+  typename AT::mag_type nonconst_result = KokkosBlas::nrm2_squared(a.d_view);
   EXPECT_NEAR_KK(nonconst_result, expected_result, eps * expected_result);
 
-  typename AT::mag_type const_result = KokkosBlas::nrm2_squared(c_a);
+  typename AT::mag_type const_result = KokkosBlas::nrm2_squared(a.d_view_const);
   EXPECT_NEAR_KK(const_result, expected_result, eps * expected_result);
 }
 
@@ -70,34 +55,22 @@ void impl_test_nrm2_squared_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef Kokkos::ArithTraits<ScalarA> AT;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-
-  typename vfA_type::BaseType b_a("A", N, K);
-
-  ViewTypeA a = vfA_type::view(b_a);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-
-  typename h_vfA_type::BaseType h_b_a = Kokkos::create_mirror_view(b_a);
-
-  typename ViewTypeA::HostMirror h_a = h_vfA_type::view(h_b_a);
+  view_stride_adapter<ViewTypeA> a("A", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
   ScalarA randStart, randEnd;
   Test::getRandomBounds(1.0, randStart, randEnd);
-  Kokkos::fill_random(b_a, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
-  Kokkos::deep_copy(h_b_a, b_a);
-
-  typename ViewTypeA::const_type c_a = a;
+  Kokkos::deep_copy(a.h_base, a.d_base);
 
   typename AT::mag_type* expected_result = new typename AT::mag_type[K];
   for (int j = 0; j < K; j++) {
     expected_result[j] = typename AT::mag_type();
     for (int i = 0; i < N; i++) {
-      expected_result[j] += AT::abs(h_a(i, j)) * AT::abs(h_a(i, j));
+      expected_result[j] += AT::abs(a.h_view(i, j)) * AT::abs(a.h_view(i, j));
     }
   }
 
@@ -107,7 +80,7 @@ void impl_test_nrm2_squared_mv(int N, int K) {
 
   Kokkos::View<typename AT::mag_type*, Kokkos::HostSpace> r("Dot::Result", K);
 
-  KokkosBlas::nrm2_squared(r, a);
+  KokkosBlas::nrm2_squared(r, a.d_view);
   Kokkos::fence();
   for (int k = 0; k < K; k++) {
     typename AT::mag_type nonconst_result = r(k);
@@ -118,7 +91,7 @@ void impl_test_nrm2_squared_mv(int N, int K) {
     EXPECT_NEAR_KK(diff, zero, eps);
   }
 
-  KokkosBlas::nrm2_squared(r, c_a);
+  KokkosBlas::nrm2_squared(r, a.d_view_const);
   Kokkos::fence();
   for (int k = 0; k < K; k++) {
     typename AT::mag_type const_result = r(k);

--- a/blas/unit_test/Test_Blas1_nrm2w.hpp
+++ b/blas/unit_test/Test_Blas1_nrm2w.hpp
@@ -145,7 +145,6 @@ int test_nrm2w() {
   // Test::impl_test_nrm2<view_type_a_lr, Device>(132231);
 #endif
 
-  /*
   #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
       (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
        !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -155,7 +154,6 @@ int test_nrm2w() {
     Test::impl_test_nrm2w<view_type_a_ls, Device>(1024);
     // Test::impl_test_nrm2<view_type_a_ls, Device>(132231);
   #endif
-  */
 
   return 1;
 }
@@ -184,7 +182,6 @@ int test_nrm2w_mv() {
   // Test::impl_test_nrm2w_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
-  /*
   #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
       (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
        !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -195,7 +192,6 @@ int test_nrm2w_mv() {
     Test::impl_test_nrm2w_mv<view_type_a_ls, Device>(789, 1);
     // Test::impl_test_nrm2w_mv<view_type_a_ls, Device>(132231,5);
   #endif
-  */
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_nrm2w.hpp
+++ b/blas/unit_test/Test_Blas1_nrm2w.hpp
@@ -26,11 +26,8 @@ void impl_test_nrm2w(int N) {
   using AT         = Kokkos::ArithTraits<ScalarA>;
   using MagnitudeA = typename AT::mag_type;
 
-  ViewTypeA a("A", N);
-  ViewTypeA w("W", N);
-
-  typename ViewTypeA::HostMirror h_a = Kokkos::create_mirror_view(a);
-  typename ViewTypeA::HostMirror h_w = Kokkos::create_mirror_view(w);
+  view_stride_adapter<ViewTypeA> a("A", N);
+  view_stride_adapter<ViewTypeA> w("W", N);
 
   constexpr MagnitudeA max_val = 10;
   const MagnitudeA eps         = AT::epsilon();
@@ -42,21 +39,22 @@ void impl_test_nrm2w(int N) {
 
   ScalarA randStart, randEnd;
   Test::getRandomBounds(max_val, randStart, randEnd);
-  Kokkos::fill_random(a, rand_pool, randStart, randEnd);
-  Kokkos::fill_random(w, rand_pool, AT::one(), randEnd);  // Avoid divide by 0
+  Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(w.d_view, rand_pool, AT::one(),
+                      randEnd);  // Avoid divide by 0
 
-  Kokkos::deep_copy(h_a, a);
-  Kokkos::deep_copy(h_w, w);
+  Kokkos::deep_copy(a.h_base, a.d_base);
+  Kokkos::deep_copy(w.h_base, w.d_base);
 
   typename AT::mag_type expected_result = 0;
   for (int i = 0; i < N; i++) {
-    typename AT::mag_type term = AT::abs(h_a(i)) / AT::abs(h_w(i));
+    typename AT::mag_type term = AT::abs(a.h_view(i)) / AT::abs(w.h_view(i));
     expected_result += term * term;
   }
   expected_result =
       Kokkos::ArithTraits<typename AT::mag_type>::sqrt(expected_result);
 
-  typename AT::mag_type nonconst_result = KokkosBlas::nrm2w(a, w);
+  typename AT::mag_type nonconst_result = KokkosBlas::nrm2w(a.d_view, w.d_view);
   EXPECT_NEAR_KK(nonconst_result, expected_result, max_error);
 }
 
@@ -66,21 +64,8 @@ void impl_test_nrm2w_mv(int N, int K) {
   using AT         = Kokkos::ArithTraits<ScalarA>;
   using MagnitudeA = typename AT::mag_type;
 
-  using vfA_type = multivector_layout_adapter<ViewTypeA>;
-
-  typename vfA_type::BaseType b_a("A", N, K);
-  typename vfA_type::BaseType b_w("W", N, K);
-
-  ViewTypeA a = vfA_type::view(b_a);
-  ViewTypeA w = vfA_type::view(b_w);
-
-  using h_vfA_type = multivector_layout_adapter<typename ViewTypeA::HostMirror>;
-
-  typename h_vfA_type::BaseType h_b_a = Kokkos::create_mirror_view(b_a);
-  typename h_vfA_type::BaseType h_b_w = Kokkos::create_mirror_view(b_w);
-
-  typename ViewTypeA::HostMirror h_a = h_vfA_type::view(h_b_a);
-  typename ViewTypeA::HostMirror h_w = h_vfA_type::view(h_b_w);
+  view_stride_adapter<ViewTypeA> a("A", N, K);
+  view_stride_adapter<ViewTypeA> w("W", N, K);
 
   constexpr MagnitudeA max_val = 10;
   const MagnitudeA eps         = AT::epsilon();
@@ -92,18 +77,19 @@ void impl_test_nrm2w_mv(int N, int K) {
 
   ScalarA randStart, randEnd;
   Test::getRandomBounds(max_val, randStart, randEnd);
-  Kokkos::fill_random(b_a, rand_pool, randStart, randEnd);
-  Kokkos::fill_random(b_w, rand_pool, AT::one(),
+  Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(w.d_view, rand_pool, AT::one(),
                       randEnd);  // Avoid dividing by 0
 
-  Kokkos::deep_copy(h_b_a, b_a);
-  Kokkos::deep_copy(h_b_w, b_w);
+  Kokkos::deep_copy(a.h_base, a.d_base);
+  Kokkos::deep_copy(w.h_base, w.d_base);
 
   typename AT::mag_type* expected_result = new typename AT::mag_type[K];
   for (int j = 0; j < K; j++) {
     expected_result[j] = typename AT::mag_type();
     for (int i = 0; i < N; i++) {
-      typename AT::mag_type term = AT::abs(h_a(i, j)) / AT::abs(h_w(i, j));
+      typename AT::mag_type term =
+          AT::abs(a.h_view(i, j)) / AT::abs(w.h_view(i, j));
       expected_result[j] += term * term;
     }
     expected_result[j] =
@@ -111,7 +97,7 @@ void impl_test_nrm2w_mv(int N, int K) {
   }
 
   Kokkos::View<typename AT::mag_type*, Device> r("Dot::Result", K);
-  KokkosBlas::nrm2w(r, a, w);
+  KokkosBlas::nrm2w(r, a.d_view, w.d_view);
   auto r_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), r);
 
   for (int k = 0; k < K; k++) {
@@ -145,15 +131,15 @@ int test_nrm2w() {
   // Test::impl_test_nrm2<view_type_a_lr, Device>(132231);
 #endif
 
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
-    Test::impl_test_nrm2w<view_type_a_ls, Device>(0);
-    Test::impl_test_nrm2w<view_type_a_ls, Device>(13);
-    Test::impl_test_nrm2w<view_type_a_ls, Device>(1024);
-    // Test::impl_test_nrm2<view_type_a_ls, Device>(132231);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
+  Test::impl_test_nrm2w<view_type_a_ls, Device>(0);
+  Test::impl_test_nrm2w<view_type_a_ls, Device>(13);
+  Test::impl_test_nrm2w<view_type_a_ls, Device>(1024);
+  // Test::impl_test_nrm2<view_type_a_ls, Device>(132231);
+#endif
 
   return 1;
 }
@@ -182,16 +168,16 @@ int test_nrm2w_mv() {
   // Test::impl_test_nrm2w_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device>
-  view_type_a_ls; Test::impl_test_nrm2w_mv<view_type_a_ls, Device>(0, 5);
-    Test::impl_test_nrm2w_mv<view_type_a_ls, Device>(13, 5);
-    Test::impl_test_nrm2w_mv<view_type_a_ls, Device>(1024, 5);
-    Test::impl_test_nrm2w_mv<view_type_a_ls, Device>(789, 1);
-    // Test::impl_test_nrm2w_mv<view_type_a_ls, Device>(132231,5);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device> view_type_a_ls;
+  Test::impl_test_nrm2w_mv<view_type_a_ls, Device>(0, 5);
+  Test::impl_test_nrm2w_mv<view_type_a_ls, Device>(13, 5);
+  Test::impl_test_nrm2w_mv<view_type_a_ls, Device>(1024, 5);
+  Test::impl_test_nrm2w_mv<view_type_a_ls, Device>(789, 1);
+  // Test::impl_test_nrm2w_mv<view_type_a_ls, Device>(132231,5);
+#endif
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_nrm2w_squared.hpp
+++ b/blas/unit_test/Test_Blas1_nrm2w_squared.hpp
@@ -138,7 +138,6 @@ int test_nrm2w_squared() {
   // Test::impl_test_nrm2<view_type_a_lr, Device>(132231);
 #endif
 
-  /*
   #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
       (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
        !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -148,7 +147,6 @@ int test_nrm2w_squared() {
     Test::impl_test_nrm2w_squared<view_type_a_ls, Device>(1024);
     // Test::impl_test_nrm2<view_type_a_ls, Device>(132231);
   #endif
-  */
 
   return 1;
 }
@@ -177,7 +175,6 @@ int test_nrm2w_squared_mv() {
   // Test::impl_test_nrm2w_squared_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
-  /*
   #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
       (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
        !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -188,7 +185,6 @@ int test_nrm2w_squared_mv() {
     Test::impl_test_nrm2w_squared_mv<view_type_a_ls, Device>(789, 1);
     // Test::impl_test_nrm2w_squared_mv<view_type_a_ls, Device>(132231,5);
   #endif
-  */
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_nrm2w_squared.hpp
+++ b/blas/unit_test/Test_Blas1_nrm2w_squared.hpp
@@ -26,11 +26,8 @@ void impl_test_nrm2w_squared(int N) {
   using AT         = Kokkos::ArithTraits<ScalarA>;
   using MagnitudeA = typename AT::mag_type;
 
-  ViewTypeA a("A", N);
-  ViewTypeA w("W", N);
-
-  typename ViewTypeA::HostMirror h_a = Kokkos::create_mirror_view(a);
-  typename ViewTypeA::HostMirror h_w = Kokkos::create_mirror_view(w);
+  view_stride_adapter<ViewTypeA> a("A", N);
+  view_stride_adapter<ViewTypeA> w("W", N);
 
   constexpr MagnitudeA max_val = 10;
   const MagnitudeA eps         = AT::epsilon();
@@ -41,19 +38,21 @@ void impl_test_nrm2w_squared(int N) {
 
   ScalarA randStart, randEnd;
   Test::getRandomBounds(max_val, randStart, randEnd);
-  Kokkos::fill_random(a, rand_pool, randStart, randEnd);
-  Kokkos::fill_random(w, rand_pool, AT::one(), randEnd);  // Avoid divide by 0
+  Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(w.d_view, rand_pool, AT::one(),
+                      randEnd);  // Avoid divide by 0
 
-  Kokkos::deep_copy(h_a, a);
-  Kokkos::deep_copy(h_w, w);
+  Kokkos::deep_copy(a.h_base, a.d_base);
+  Kokkos::deep_copy(w.h_base, w.d_base);
 
   typename AT::mag_type expected_result = 0;
   for (int i = 0; i < N; i++) {
-    typename AT::mag_type term = AT::abs(h_a(i)) / AT::abs(h_w(i));
+    typename AT::mag_type term = AT::abs(a.h_view(i)) / AT::abs(w.h_view(i));
     expected_result += term * term;
   }
 
-  typename AT::mag_type nonconst_result = KokkosBlas::nrm2w_squared(a, w);
+  typename AT::mag_type nonconst_result =
+      KokkosBlas::nrm2w_squared(a.d_view, w.d_view);
   EXPECT_NEAR_KK(nonconst_result, expected_result, max_error);
 }
 
@@ -63,21 +62,8 @@ void impl_test_nrm2w_squared_mv(int N, int K) {
   using AT         = Kokkos::ArithTraits<ScalarA>;
   using MagnitudeA = typename AT::mag_type;
 
-  using vfA_type = multivector_layout_adapter<ViewTypeA>;
-
-  typename vfA_type::BaseType b_a("A", N, K);
-  typename vfA_type::BaseType b_w("W", N, K);
-
-  ViewTypeA a = vfA_type::view(b_a);
-  ViewTypeA w = vfA_type::view(b_w);
-
-  using h_vfA_type = multivector_layout_adapter<typename ViewTypeA::HostMirror>;
-
-  typename h_vfA_type::BaseType h_b_a = Kokkos::create_mirror_view(b_a);
-  typename h_vfA_type::BaseType h_b_w = Kokkos::create_mirror_view(b_w);
-
-  typename ViewTypeA::HostMirror h_a = h_vfA_type::view(h_b_a);
-  typename ViewTypeA::HostMirror h_w = h_vfA_type::view(h_b_w);
+  view_stride_adapter<ViewTypeA> a("A", N, K);
+  view_stride_adapter<ViewTypeA> w("W", N, K);
 
   constexpr MagnitudeA max_val = 10;
   const MagnitudeA eps         = AT::epsilon();
@@ -88,23 +74,24 @@ void impl_test_nrm2w_squared_mv(int N, int K) {
 
   ScalarA randStart, randEnd;
   Test::getRandomBounds(max_val, randStart, randEnd);
-  Kokkos::fill_random(b_a, rand_pool, randStart, randEnd);
-  Kokkos::fill_random(b_w, rand_pool, AT::one(), randEnd);
+  Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(w.d_view, rand_pool, AT::one(), randEnd);
 
-  Kokkos::deep_copy(h_b_a, b_a);
-  Kokkos::deep_copy(h_b_w, b_w);
+  Kokkos::deep_copy(a.h_base, a.d_base);
+  Kokkos::deep_copy(w.h_base, w.d_base);
 
   typename AT::mag_type* expected_result = new typename AT::mag_type[K];
   for (int j = 0; j < K; j++) {
     expected_result[j] = typename AT::mag_type();
     for (int i = 0; i < N; i++) {
-      typename AT::mag_type term = AT::abs(h_a(i, j)) / AT::abs(h_w(i, j));
+      typename AT::mag_type term =
+          AT::abs(a.h_view(i, j)) / AT::abs(w.h_view(i, j));
       expected_result[j] += term * term;
     }
   }
 
   Kokkos::View<typename AT::mag_type*, Device> r("Dot::Result", K);
-  KokkosBlas::nrm2w_squared(r, a, w);
+  KokkosBlas::nrm2w_squared(r, a.d_view, w.d_view);
   auto r_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), r);
 
   for (int k = 0; k < K; k++) {
@@ -138,15 +125,15 @@ int test_nrm2w_squared() {
   // Test::impl_test_nrm2<view_type_a_lr, Device>(132231);
 #endif
 
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
-    Test::impl_test_nrm2w_squared<view_type_a_ls, Device>(0);
-    Test::impl_test_nrm2w_squared<view_type_a_ls, Device>(13);
-    Test::impl_test_nrm2w_squared<view_type_a_ls, Device>(1024);
-    // Test::impl_test_nrm2<view_type_a_ls, Device>(132231);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
+  Test::impl_test_nrm2w_squared<view_type_a_ls, Device>(0);
+  Test::impl_test_nrm2w_squared<view_type_a_ls, Device>(13);
+  Test::impl_test_nrm2w_squared<view_type_a_ls, Device>(1024);
+  // Test::impl_test_nrm2<view_type_a_ls, Device>(132231);
+#endif
 
   return 1;
 }
@@ -175,16 +162,16 @@ int test_nrm2w_squared_mv() {
   // Test::impl_test_nrm2w_squared_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device>
-  view_type_a_ls; Test::impl_test_nrm2w_squared_mv<view_type_a_ls, Device>(0,
-  5); Test::impl_test_nrm2w_squared_mv<view_type_a_ls, Device>(13, 5);
-    Test::impl_test_nrm2w_squared_mv<view_type_a_ls, Device>(1024, 5);
-    Test::impl_test_nrm2w_squared_mv<view_type_a_ls, Device>(789, 1);
-    // Test::impl_test_nrm2w_squared_mv<view_type_a_ls, Device>(132231,5);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device> view_type_a_ls;
+  Test::impl_test_nrm2w_squared_mv<view_type_a_ls, Device>(0, 5);
+  Test::impl_test_nrm2w_squared_mv<view_type_a_ls, Device>(13, 5);
+  Test::impl_test_nrm2w_squared_mv<view_type_a_ls, Device>(1024, 5);
+  Test::impl_test_nrm2w_squared_mv<view_type_a_ls, Device>(789, 1);
+  // Test::impl_test_nrm2w_squared_mv<view_type_a_ls, Device>(132231,5);
+#endif
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_nrminf.hpp
+++ b/blas/unit_test/Test_Blas1_nrminf.hpp
@@ -25,33 +25,31 @@ void impl_test_nrminf(int N) {
   typedef typename ViewTypeA::non_const_value_type ScalarA;
   typedef Kokkos::ArithTraits<ScalarA> AT;
 
-  ViewTypeA a("A", N);
-
-  typename ViewTypeA::HostMirror h_a = Kokkos::create_mirror_view(a);
+  view_stride_adapter<ViewTypeA> a("A", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
   ScalarA randStart, randEnd;
   Test::getRandomBounds(10.0, randStart, randEnd);
-  Kokkos::fill_random(a, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
-  Kokkos::deep_copy(h_a, a);
+  Kokkos::deep_copy(a.h_base, a.d_base);
 
-  typename ViewTypeA::const_type c_a = a;
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
 
   typename AT::mag_type expected_result =
       Kokkos::ArithTraits<typename AT::mag_type>::min();
   for (int i = 0; i < N; i++)
-    if (AT::abs(h_a(i)) > expected_result) expected_result = AT::abs(h_a(i));
+    if (AT::abs(a.h_view(i)) > expected_result)
+      expected_result = AT::abs(a.h_view(i));
 
   if (N == 0) expected_result = typename AT::mag_type(0);
 
-  typename AT::mag_type nonconst_result = KokkosBlas::nrminf(a);
+  typename AT::mag_type nonconst_result = KokkosBlas::nrminf(a.d_view);
   EXPECT_NEAR_KK(nonconst_result, expected_result, eps * expected_result);
 
-  typename AT::mag_type const_result = KokkosBlas::nrminf(c_a);
+  typename AT::mag_type const_result = KokkosBlas::nrminf(a.d_view_const);
   EXPECT_NEAR_KK(const_result, expected_result, eps * expected_result);
 }
 
@@ -60,35 +58,23 @@ void impl_test_nrminf_mv(int N, int K) {
   typedef typename ViewTypeA::non_const_value_type ScalarA;
   typedef Kokkos::ArithTraits<ScalarA> AT;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-
-  typename vfA_type::BaseType b_a("A", N, K);
-
-  ViewTypeA a = vfA_type::view(b_a);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-
-  typename h_vfA_type::BaseType h_b_a = Kokkos::create_mirror_view(b_a);
-
-  typename ViewTypeA::HostMirror h_a = h_vfA_type::view(h_b_a);
+  view_stride_adapter<ViewTypeA> a("A", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
   ScalarA randStart, randEnd;
   Test::getRandomBounds(10.0, randStart, randEnd);
-  Kokkos::fill_random(b_a, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
-  Kokkos::deep_copy(h_b_a, b_a);
-
-  typename ViewTypeA::const_type c_a = a;
+  Kokkos::deep_copy(a.h_base, a.d_base);
 
   typename AT::mag_type* expected_result = new typename AT::mag_type[K];
   for (int j = 0; j < K; j++) {
     expected_result[j] = Kokkos::ArithTraits<typename AT::mag_type>::min();
     for (int i = 0; i < N; i++) {
-      if (AT::abs(h_a(i, j)) > expected_result[j])
-        expected_result[j] = AT::abs(h_a(i, j));
+      if (AT::abs(a.h_view(i, j)) > expected_result[j])
+        expected_result[j] = AT::abs(a.h_view(i, j));
     }
     if (N == 0) expected_result[j] = typename AT::mag_type(0);
   }
@@ -97,14 +83,14 @@ void impl_test_nrminf_mv(int N, int K) {
 
   Kokkos::View<typename AT::mag_type*, Kokkos::HostSpace> r("Dot::Result", K);
 
-  KokkosBlas::nrminf(r, a);
+  KokkosBlas::nrminf(r, a.d_view);
   for (int k = 0; k < K; k++) {
     typename AT::mag_type nonconst_result = r(k);
     typename AT::mag_type exp_result      = expected_result[k];
     EXPECT_NEAR_KK(nonconst_result, exp_result, eps * exp_result);
   }
 
-  KokkosBlas::nrminf(r, c_a);
+  KokkosBlas::nrminf(r, a.d_view_const);
   for (int k = 0; k < K; k++) {
     typename AT::mag_type const_result = r(k);
     typename AT::mag_type exp_result   = expected_result[k];
@@ -136,15 +122,15 @@ int test_nrminf() {
   // Test::impl_test_nrminf<view_type_a_lr, Device>(132231);
 #endif
 
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
-    Test::impl_test_nrminf<view_type_a_ls, Device>(0);
-    Test::impl_test_nrminf<view_type_a_ls, Device>(13);
-    Test::impl_test_nrminf<view_type_a_ls, Device>(1024);
-    // Test::impl_test_nrminf<view_type_a_ls, Device>(132231);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
+  Test::impl_test_nrminf<view_type_a_ls, Device>(0);
+  Test::impl_test_nrminf<view_type_a_ls, Device>(13);
+  Test::impl_test_nrminf<view_type_a_ls, Device>(1024);
+  // Test::impl_test_nrminf<view_type_a_ls, Device>(132231);
+#endif
 
   return 1;
 }
@@ -171,15 +157,15 @@ int test_nrminf_mv() {
   // Test::impl_test_nrminf_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device>
-  view_type_a_ls; Test::impl_test_nrminf_mv<view_type_a_ls, Device>(0, 5);
-    Test::impl_test_nrminf_mv<view_type_a_ls, Device>(13, 5);
-    Test::impl_test_nrminf_mv<view_type_a_ls, Device>(1024, 5);
-    // Test::impl_test_nrminf_mv<view_type_a_ls, Device>(132231,5);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device> view_type_a_ls;
+  Test::impl_test_nrminf_mv<view_type_a_ls, Device>(0, 5);
+  Test::impl_test_nrminf_mv<view_type_a_ls, Device>(13, 5);
+  Test::impl_test_nrminf_mv<view_type_a_ls, Device>(1024, 5);
+  // Test::impl_test_nrminf_mv<view_type_a_ls, Device>(132231,5);
+#endif
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_nrminf.hpp
+++ b/blas/unit_test/Test_Blas1_nrminf.hpp
@@ -136,7 +136,6 @@ int test_nrminf() {
   // Test::impl_test_nrminf<view_type_a_lr, Device>(132231);
 #endif
 
-  /*
   #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
       (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
        !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -146,7 +145,6 @@ int test_nrminf() {
     Test::impl_test_nrminf<view_type_a_ls, Device>(1024);
     // Test::impl_test_nrminf<view_type_a_ls, Device>(132231);
   #endif
-  */
 
   return 1;
 }
@@ -173,7 +171,6 @@ int test_nrminf_mv() {
   // Test::impl_test_nrminf_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
-  /*
   #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
       (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
        !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -183,7 +180,6 @@ int test_nrminf_mv() {
     Test::impl_test_nrminf_mv<view_type_a_ls, Device>(1024, 5);
     // Test::impl_test_nrminf_mv<view_type_a_ls, Device>(132231,5);
   #endif
-  */
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_reciprocal.hpp
+++ b/blas/unit_test/Test_Blas1_reciprocal.hpp
@@ -29,38 +29,12 @@ void impl_test_reciprocal(int N) {
   using MagnitudeA = typename AT::mag_type;
   using MagnitudeB = typename Kokkos::ArithTraits<ScalarB>::mag_type;
 
-  typedef Kokkos::View<
-      ScalarA * [2],
-      typename std::conditional<std::is_same<typename ViewTypeA::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeA;
-  typedef Kokkos::View<
-      ScalarB * [2],
-      typename std::conditional<std::is_same<typename ViewTypeB::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeB;
-
   const MagnitudeB eps     = Kokkos::ArithTraits<ScalarB>::epsilon();
   const MagnitudeA one     = AT::abs(AT::one());
   const MagnitudeA max_val = 10;
 
-  BaseTypeA b_x("X", N);
-  BaseTypeB b_y("Y", N);
-  BaseTypeB b_org_y("Org_Y", N);
-
-  ViewTypeA x                        = Kokkos::subview(b_x, Kokkos::ALL(), 0);
-  ViewTypeB y                        = Kokkos::subview(b_y, Kokkos::ALL(), 0);
-  typename ViewTypeA::const_type c_x = x;
-
-  typename BaseTypeA::HostMirror h_b_x = Kokkos::create_mirror_view(b_x);
-  typename BaseTypeB::HostMirror h_b_y = Kokkos::create_mirror_view(b_y);
-
-  typename ViewTypeA::HostMirror h_x = Kokkos::subview(h_b_x, Kokkos::ALL(), 0);
-  typename ViewTypeB::HostMirror h_y = Kokkos::subview(h_b_y, Kokkos::ALL(), 0);
+  view_stride_adapter<ViewTypeA> x("X", N);
+  view_stride_adapter<ViewTypeB> y("Y", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
@@ -68,30 +42,24 @@ void impl_test_reciprocal(int N) {
   {
     ScalarA randStart, randEnd;
     Test::getRandomBounds(max_val, randStart, randEnd);
-    Kokkos::fill_random(b_x, rand_pool, one, randEnd);
-  }
-  {
-    ScalarB randStart, randEnd;
-    Test::getRandomBounds(10, randStart, randEnd);
-    Kokkos::fill_random(b_y, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(x.d_view, rand_pool, one, randEnd);
   }
 
-  Kokkos::deep_copy(b_org_y, b_y);
+  Kokkos::deep_copy(x.h_base, x.d_base);
 
-  Kokkos::deep_copy(h_b_x, b_x);
-  Kokkos::deep_copy(h_b_y, b_y);
-
-  KokkosBlas::reciprocal(y, x);
-  Kokkos::deep_copy(h_b_y, b_y);
+  KokkosBlas::reciprocal(y.d_view, x.d_view);
+  Kokkos::deep_copy(y.h_base, y.d_base);
   for (int i = 0; i < N; ++i) {
-    EXPECT_NEAR_KK(h_b_y(i, 0), ScalarB(one / h_b_x(i, 0)), 2 * eps);
+    EXPECT_NEAR_KK(y.h_view(i), ScalarB(one / x.h_view(i)), 2 * eps);
   }
 
-  Kokkos::deep_copy(b_y, b_org_y);
-  KokkosBlas::reciprocal(y, c_x);
-  Kokkos::deep_copy(h_b_y, b_y);
+  // Zero out y again, and run again with const input
+  Kokkos::deep_copy(y.d_view, Kokkos::ArithTraits<ScalarB>::zero());
+
+  KokkosBlas::reciprocal(y.d_view, x.d_view_const);
+  Kokkos::deep_copy(y.h_base, y.d_base);
   for (int i = 0; i < N; ++i) {
-    EXPECT_NEAR_KK(h_b_y(i, 0), ScalarB(one / h_b_x(i, 0)), 2 * eps);
+    EXPECT_NEAR_KK(y.h_view(i), ScalarB(one / x.h_view(i)), 2 * eps);
   }
 }
 
@@ -100,24 +68,8 @@ void impl_test_reciprocal_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-  typedef multivector_layout_adapter<ViewTypeB> vfB_type;
-
-  typename vfA_type::BaseType b_x("A", N, K);
-  typename vfB_type::BaseType b_y("B", N, K);
-  typename vfB_type::BaseType b_org_y("B", N, K);
-
-  ViewTypeA x = vfA_type::view(b_x);
-  ViewTypeB y = vfB_type::view(b_y);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-  typedef multivector_layout_adapter<typename ViewTypeB::HostMirror> h_vfB_type;
-
-  typename h_vfA_type::BaseType h_b_x = Kokkos::create_mirror_view(b_x);
-  typename h_vfB_type::BaseType h_b_y = Kokkos::create_mirror_view(b_y);
-
-  typename ViewTypeA::HostMirror h_x = h_vfA_type::view(h_b_x);
-  typename ViewTypeB::HostMirror h_y = h_vfB_type::view(h_b_y);
+  view_stride_adapter<ViewTypeA> x("X", N, K);
+  view_stride_adapter<ViewTypeB> y("Y", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
@@ -125,40 +77,35 @@ void impl_test_reciprocal_mv(int N, int K) {
   {
     ScalarA randStart, randEnd;
     Test::getRandomBounds(10, randStart, randEnd);
-    Kokkos::fill_random(b_x, rand_pool, Kokkos::ArithTraits<ScalarA>::one(),
-                        randEnd);
-  }
-  {
-    ScalarB randStart, randEnd;
-    Test::getRandomBounds(10, randStart, randEnd);
-    Kokkos::fill_random(b_y, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(x.d_view, rand_pool,
+                        Kokkos::ArithTraits<ScalarA>::one(), randEnd);
   }
 
-  Kokkos::deep_copy(b_org_y, b_y);
+  Kokkos::deep_copy(x.h_base, x.d_base);
 
-  Kokkos::deep_copy(h_b_x, b_x);
-  Kokkos::deep_copy(h_b_y, b_y);
+  KokkosBlas::reciprocal(y.d_view, x.d_view);
 
-  typename ViewTypeA::const_type c_x = x;
-
-  KokkosBlas::reciprocal(y, x);
-  Kokkos::deep_copy(h_b_y, b_y);
+  Kokkos::deep_copy(y.h_base, y.d_base);
   for (int j = 0; j < K; ++j) {
     for (int i = 0; i < N; ++i) {
-      EXPECT_NEAR_KK(h_b_y(i, j),
-                     Kokkos::ArithTraits<ScalarB>::one() / ScalarB(h_b_x(i, j)),
-                     2 * Kokkos::ArithTraits<ScalarB>::epsilon());
+      EXPECT_NEAR_KK(
+          y.h_view(i, j),
+          Kokkos::ArithTraits<ScalarB>::one() / ScalarB(x.h_view(i, j)),
+          2 * Kokkos::ArithTraits<ScalarB>::epsilon());
     }
   }
 
-  Kokkos::deep_copy(b_y, b_org_y);
-  KokkosBlas::reciprocal(y, c_x);
-  Kokkos::deep_copy(h_b_y, b_y);
+  // Zero out y again, and run again with const input
+  Kokkos::deep_copy(y.d_view, Kokkos::ArithTraits<ScalarB>::zero());
+
+  KokkosBlas::reciprocal(y.d_view, x.d_view_const);
+  Kokkos::deep_copy(y.h_base, y.d_base);
   for (int j = 0; j < K; j++) {
     for (int i = 0; i < N; ++i) {
-      EXPECT_NEAR_KK(h_b_y(i, j),
-                     Kokkos::ArithTraits<ScalarB>::one() / ScalarB(h_b_x(i, j)),
-                     2 * Kokkos::ArithTraits<ScalarB>::epsilon());
+      EXPECT_NEAR_KK(
+          y.h_view(i, j),
+          Kokkos::ArithTraits<ScalarB>::one() / ScalarB(x.h_view(i, j)),
+          2 * Kokkos::ArithTraits<ScalarB>::epsilon());
     }
   }
 }
@@ -188,24 +135,22 @@ int test_reciprocal() {
   // Test::impl_test_reciprocal<view_type_a_lr, view_type_b_lr, Device>(132231);
 #endif
 
-  /*
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
-    typedef Kokkos::View<ScalarB*, Kokkos::LayoutStride, Device> view_type_b_ls;
-    Test::impl_test_reciprocal<view_type_a_ls, view_type_b_ls, Device>(0);
-    Test::impl_test_reciprocal<view_type_a_ls, view_type_b_ls, Device>(13);
-    Test::impl_test_reciprocal<view_type_a_ls, view_type_b_ls, Device>(1024);
-    // Test::impl_test_reciprocal<view_type_a_ls, view_type_b_ls,
-  Device>(132231); #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
+  typedef Kokkos::View<ScalarB*, Kokkos::LayoutStride, Device> view_type_b_ls;
+  Test::impl_test_reciprocal<view_type_a_ls, view_type_b_ls, Device>(0);
+  Test::impl_test_reciprocal<view_type_a_ls, view_type_b_ls, Device>(13);
+  Test::impl_test_reciprocal<view_type_a_ls, view_type_b_ls, Device>(1024);
+  // Test::impl_test_reciprocal<view_type_a_ls, view_type_b_ls, Device>(132231);
+#endif
 
-  #if !defined(KOKKOSKERNELS_ETI_ONLY) && \
-      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-    Test::impl_test_reciprocal<view_type_a_ls, view_type_b_ll, Device>(1024);
-    Test::impl_test_reciprocal<view_type_a_ll, view_type_b_ls, Device>(1024);
-  #endif
-  */
+#if !defined(KOKKOSKERNELS_ETI_ONLY) && \
+    !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
+  Test::impl_test_reciprocal<view_type_a_ls, view_type_b_ll, Device>(1024);
+  Test::impl_test_reciprocal<view_type_a_ll, view_type_b_ls, Device>(1024);
+#endif
 
   return 1;
 }
@@ -238,28 +183,26 @@ int test_reciprocal_mv() {
   // Device>(132231,5);
 #endif
 
-  /*
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device>
-  view_type_a_ls; typedef Kokkos::View<ScalarB**, Kokkos::LayoutStride, Device>
-  view_type_b_ls; Test::impl_test_reciprocal_mv<view_type_a_ls, view_type_b_ls,
-  Device>(0, 5); Test::impl_test_reciprocal_mv<view_type_a_ls, view_type_b_ls,
-  Device>(13, 5); Test::impl_test_reciprocal_mv<view_type_a_ls, view_type_b_ls,
-  Device>(1024, 5);
-    // Test::impl_test_reciprocal_mv<view_type_a_ls, view_type_b_ls,
-    // Device>(132231,5);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device> view_type_a_ls;
+  typedef Kokkos::View<ScalarB**, Kokkos::LayoutStride, Device> view_type_b_ls;
+  Test::impl_test_reciprocal_mv<view_type_a_ls, view_type_b_ls, Device>(0, 5);
+  Test::impl_test_reciprocal_mv<view_type_a_ls, view_type_b_ls, Device>(13, 5);
+  Test::impl_test_reciprocal_mv<view_type_a_ls, view_type_b_ls, Device>(1024,
+                                                                        5);
+  // Test::impl_test_reciprocal_mv<view_type_a_ls, view_type_b_ls,
+  // Device>(132231,5);
+#endif
 
-  #if !defined(KOKKOSKERNELS_ETI_ONLY) && \
-      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-    Test::impl_test_reciprocal_mv<view_type_a_ls, view_type_b_ll, Device>(1024,
-                                                                          5);
-    Test::impl_test_reciprocal_mv<view_type_a_ll, view_type_b_ls, Device>(1024,
-                                                                          5);
-  #endif
-  */
+#if !defined(KOKKOSKERNELS_ETI_ONLY) && \
+    !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
+  Test::impl_test_reciprocal_mv<view_type_a_ls, view_type_b_ll, Device>(1024,
+                                                                        5);
+  Test::impl_test_reciprocal_mv<view_type_a_ll, view_type_b_ls, Device>(1024,
+                                                                        5);
+#endif
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_scal.hpp
+++ b/blas/unit_test/Test_Blas1_scal.hpp
@@ -30,15 +30,8 @@ void impl_test_scal(int N) {
   ScalarA a(3);
   typename AT::mag_type eps = AT::epsilon() * 1000;
 
-  ViewTypeA x("X", N);
-  ViewTypeB y("Y", N);
-  ViewTypeB org_y("Org_Y", N);
-
-  typename ViewTypeA::const_type c_x = x;
-  typename ViewTypeB::const_type c_y = y;
-
-  typename ViewTypeA::HostMirror h_x = Kokkos::create_mirror_view(x);
-  typename ViewTypeB::HostMirror h_y = Kokkos::create_mirror_view(y);
+  view_stride_adapter<ViewTypeA> x("X", N);
+  view_stride_adapter<ViewTypeB> y("Y", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
@@ -46,29 +39,23 @@ void impl_test_scal(int N) {
   {
     ScalarA randStart, randEnd;
     Test::getRandomBounds(1.0, randStart, randEnd);
-    Kokkos::fill_random(x, rand_pool, randStart, randEnd);
-  }
-  {
-    ScalarB randStart, randEnd;
-    Test::getRandomBounds(1.0, randStart, randEnd);
-    Kokkos::fill_random(y, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
 
-  Kokkos::deep_copy(org_y, y);
+  Kokkos::deep_copy(x.h_base, x.d_base);
 
-  Kokkos::deep_copy(h_x, x);
-
-  KokkosBlas::scal(y, a, x);
-  Kokkos::deep_copy(h_y, y);
+  KokkosBlas::scal(y.d_view, a, x.d_view);
+  Kokkos::deep_copy(y.h_base, y.d_base);
   for (int i = 0; i < N; i++) {
-    EXPECT_NEAR_KK(static_cast<ScalarB>(a * h_x(i)), h_y(i), eps);
+    EXPECT_NEAR_KK(static_cast<ScalarB>(a * x.h_view(i)), y.h_view(i), eps);
   }
 
-  Kokkos::deep_copy(y, org_y);
-  KokkosBlas::scal(y, a, c_x);
-  Kokkos::deep_copy(h_y, y);
+  // Zero out y again and run with const input
+  Kokkos::deep_copy(y.d_view, Kokkos::ArithTraits<ScalarB>::zero());
+  KokkosBlas::scal(y.d_view, a, x.d_view_const);
+  Kokkos::deep_copy(y.h_base, y.d_base);
   for (int i = 0; i < N; i++) {
-    EXPECT_NEAR_KK(static_cast<ScalarB>(a * h_x(i)), h_y(i), eps);
+    EXPECT_NEAR_KK(static_cast<ScalarB>(a * x.h_view(i)), y.h_view(i), eps);
   }
 }
 
@@ -78,24 +65,8 @@ void impl_test_scal_mv(int N, int K) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef Kokkos::ArithTraits<ScalarA> AT;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-  typedef multivector_layout_adapter<ViewTypeB> vfB_type;
-
-  typename vfA_type::BaseType b_x("A", N, K);
-  typename vfB_type::BaseType b_y("B", N, K);
-  typename vfB_type::BaseType b_org_y("B", N, K);
-
-  ViewTypeA x = vfA_type::view(b_x);
-  ViewTypeB y = vfB_type::view(b_y);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-  typedef multivector_layout_adapter<typename ViewTypeB::HostMirror> h_vfB_type;
-
-  typename h_vfA_type::BaseType h_b_x = Kokkos::create_mirror_view(b_x);
-  typename h_vfB_type::BaseType h_b_y = Kokkos::create_mirror_view(b_y);
-
-  typename ViewTypeA::HostMirror h_x = h_vfA_type::view(h_b_x);
-  typename ViewTypeB::HostMirror h_y = h_vfB_type::view(h_b_y);
+  view_stride_adapter<ViewTypeA> x("X", N, K);
+  view_stride_adapter<ViewTypeB> y("Y", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
@@ -103,41 +74,34 @@ void impl_test_scal_mv(int N, int K) {
   {
     ScalarA randStart, randEnd;
     Test::getRandomBounds(1.0, randStart, randEnd);
-    Kokkos::fill_random(b_x, rand_pool, randStart, randEnd);
-  }
-  {
-    ScalarB randStart, randEnd;
-    Test::getRandomBounds(1.0, randStart, randEnd);
-    Kokkos::fill_random(b_y, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
 
-  Kokkos::fence();
-
-  Kokkos::deep_copy(b_org_y, b_y);
-
-  Kokkos::deep_copy(h_b_x, b_x);
+  Kokkos::deep_copy(x.h_base, x.d_base);
 
   ScalarA a(3.0);
-  typename ViewTypeA::const_type c_x = x;
 
   typename AT::mag_type eps = AT::epsilon() * 1000;
 
   Kokkos::View<ScalarB*, Kokkos::HostSpace> r("Dot::Result", K);
 
-  KokkosBlas::scal(y, a, x);
-  Kokkos::deep_copy(h_b_y, b_y);
+  KokkosBlas::scal(y.d_view, a, x.d_view);
+  Kokkos::deep_copy(y.h_base, y.d_base);
   for (int i = 0; i < N; i++) {
     for (int j = 0; j < K; j++) {
-      EXPECT_NEAR_KK(static_cast<ScalarB>(a * h_x(i, j)), h_y(i, j), eps);
+      EXPECT_NEAR_KK(static_cast<ScalarB>(a * x.h_view(i, j)), y.h_view(i, j),
+                     eps);
     }
   }
 
-  Kokkos::deep_copy(b_y, b_org_y);
-  KokkosBlas::scal(y, a, c_x);
-  Kokkos::deep_copy(h_b_y, b_y);
+  // Zero out y again, and run again with const input
+  Kokkos::deep_copy(y.d_view, Kokkos::ArithTraits<ScalarB>::zero());
+  KokkosBlas::scal(y.d_view, a, x.d_view_const);
+  Kokkos::deep_copy(y.h_base, y.d_base);
   for (int i = 0; i < N; i++) {
     for (int j = 0; j < K; j++) {
-      EXPECT_NEAR_KK(static_cast<ScalarB>(a * h_x(i, j)), h_y(i, j), eps);
+      EXPECT_NEAR_KK(static_cast<ScalarB>(a * x.h_view(i, j)), y.h_view(i, j),
+                     eps);
     }
   }
 
@@ -152,22 +116,23 @@ void impl_test_scal_mv(int N, int K) {
   auto h_params =
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), params);
 
-  KokkosBlas::scal(y, params, x);
-  Kokkos::deep_copy(h_b_y, b_y);
+  Kokkos::deep_copy(y.d_view, Kokkos::ArithTraits<ScalarB>::zero());
+  KokkosBlas::scal(y.d_view, params, x.d_view);
+  Kokkos::deep_copy(y.h_base, y.d_base);
   for (int i = 0; i < N; i++) {
     for (int j = 0; j < K; j++) {
-      EXPECT_NEAR_KK(static_cast<ScalarB>(h_params(j) * h_x(i, j)), h_y(i, j),
-                     eps);
+      EXPECT_NEAR_KK(static_cast<ScalarB>(h_params(j) * x.h_view(i, j)),
+                     y.h_view(i, j), eps);
     }
   }
 
-  Kokkos::deep_copy(b_y, b_org_y);
-  KokkosBlas::scal(y, params, c_x);
-  Kokkos::deep_copy(h_b_y, b_y);
+  Kokkos::deep_copy(y.d_view, Kokkos::ArithTraits<ScalarB>::zero());
+  KokkosBlas::scal(y.d_view, params, x.d_view_const);
+  Kokkos::deep_copy(y.h_base, y.d_base);
   for (int i = 0; i < N; i++) {
     for (int j = 0; j < K; j++) {
-      EXPECT_NEAR_KK(static_cast<ScalarB>(h_params(j) * h_x(i, j)), h_y(i, j),
-                     eps);
+      EXPECT_NEAR_KK(static_cast<ScalarB>(h_params(j) * x.h_view(i, j)),
+                     y.h_view(i, j), eps);
     }
   }
 }
@@ -197,24 +162,22 @@ int test_scal() {
   // Test::impl_test_scal<view_type_a_lr, view_type_b_lr, Device>(132231);
 #endif
 
-  /*
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
-    typedef Kokkos::View<ScalarB*, Kokkos::LayoutStride, Device> view_type_b_ls;
-    Test::impl_test_scal<view_type_a_ls, view_type_b_ls, Device>(0);
-    Test::impl_test_scal<view_type_a_ls, view_type_b_ls, Device>(13);
-    Test::impl_test_scal<view_type_a_ls, view_type_b_ls, Device>(1024);
-    // Test::impl_test_scal<view_type_a_ls, view_type_b_ls, Device>(132231);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
+  typedef Kokkos::View<ScalarB*, Kokkos::LayoutStride, Device> view_type_b_ls;
+  Test::impl_test_scal<view_type_a_ls, view_type_b_ls, Device>(0);
+  Test::impl_test_scal<view_type_a_ls, view_type_b_ls, Device>(13);
+  Test::impl_test_scal<view_type_a_ls, view_type_b_ls, Device>(1024);
+  // Test::impl_test_scal<view_type_a_ls, view_type_b_ls, Device>(132231);
+#endif
 
-  #if !defined(KOKKOSKERNELS_ETI_ONLY) && \
-      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-    Test::impl_test_scal<view_type_a_ls, view_type_b_ll, Device>(1024);
-    Test::impl_test_scal<view_type_a_ll, view_type_b_ls, Device>(1024);
-  #endif
-  */
+#if !defined(KOKKOSKERNELS_ETI_ONLY) && \
+    !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
+  Test::impl_test_scal<view_type_a_ls, view_type_b_ll, Device>(1024);
+  Test::impl_test_scal<view_type_a_ll, view_type_b_ls, Device>(1024);
+#endif
 
   return 1;
 }
@@ -243,25 +206,22 @@ int test_scal_mv() {
   // Test::impl_test_scal_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
 #endif
 
-  /*
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device>
-  view_type_a_ls; typedef Kokkos::View<ScalarB**, Kokkos::LayoutStride, Device>
-  view_type_b_ls; Test::impl_test_scal_mv<view_type_a_ls, view_type_b_ls,
-  Device>(0, 5); Test::impl_test_scal_mv<view_type_a_ls, view_type_b_ls,
-  Device>(13, 5); Test::impl_test_scal_mv<view_type_a_ls, view_type_b_ls,
-  Device>(1024, 5);
-    // Test::impl_test_scal_mv<view_type_a_ls, view_type_b_ls,
-  Device>(132231,5); #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device> view_type_a_ls;
+  typedef Kokkos::View<ScalarB**, Kokkos::LayoutStride, Device> view_type_b_ls;
+  Test::impl_test_scal_mv<view_type_a_ls, view_type_b_ls, Device>(0, 5);
+  Test::impl_test_scal_mv<view_type_a_ls, view_type_b_ls, Device>(13, 5);
+  Test::impl_test_scal_mv<view_type_a_ls, view_type_b_ls, Device>(1024, 5);
+  // Test::impl_test_scal_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
+#endif
 
-  #if !defined(KOKKOSKERNELS_ETI_ONLY) && \
-      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-    Test::impl_test_scal_mv<view_type_a_ls, view_type_b_ll, Device>(1024, 5);
-    Test::impl_test_scal_mv<view_type_a_ll, view_type_b_ls, Device>(1024, 5);
-  #endif
-  */
+#if !defined(KOKKOSKERNELS_ETI_ONLY) && \
+    !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
+  Test::impl_test_scal_mv<view_type_a_ls, view_type_b_ll, Device>(1024, 5);
+  Test::impl_test_scal_mv<view_type_a_ll, view_type_b_ls, Device>(1024, 5);
+#endif
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_sum.hpp
+++ b/blas/unit_test/Test_Blas1_sum.hpp
@@ -128,7 +128,6 @@ int test_sum() {
   // Test::impl_test_sum<view_type_a_lr, Device>(132231);
 #endif
 
-  /*
   #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
       (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
        !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -138,7 +137,6 @@ int test_sum() {
     Test::impl_test_sum<view_type_a_ls, Device>(1024);
     // Test::impl_test_sum<view_type_a_ls, Device>(132231);
   #endif
-  */
 
   return 1;
 }
@@ -167,7 +165,6 @@ int test_sum_mv() {
   // Test::impl_test_sum_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
-  /*
   #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
       (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
        !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -178,7 +175,6 @@ int test_sum_mv() {
     Test::impl_test_sum_mv<view_type_a_ls, Device>(789, 1);
     // Test::impl_test_sum_mv<view_type_a_ls, Device>(132231,5);
   #endif
-  */
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_sum.hpp
+++ b/blas/unit_test/Test_Blas1_sum.hpp
@@ -24,29 +24,26 @@ template <class ViewTypeA, class Device>
 void impl_test_sum(int N) {
   typedef typename ViewTypeA::value_type ScalarA;
 
-  ViewTypeA a("A", N);
-
-  typename ViewTypeA::HostMirror h_a = Kokkos::create_mirror_view(a);
+  view_stride_adapter<ViewTypeA> a("A", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
   ScalarA randStart, randEnd;
   Test::getRandomBounds(10.0, randStart, randEnd);
-  Kokkos::fill_random(a, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
-  Kokkos::deep_copy(h_a, a);
+  Kokkos::deep_copy(a.h_base, a.d_base);
 
-  typename ViewTypeA::const_type c_a = a;
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
 
   ScalarA expected_result = 0;
-  for (int i = 0; i < N; i++) expected_result += h_a(i);
+  for (int i = 0; i < N; i++) expected_result += a.h_view(i);
 
-  ScalarA nonconst_result = KokkosBlas::sum(a);
+  ScalarA nonconst_result = KokkosBlas::sum(a.d_view);
   EXPECT_NEAR_KK(nonconst_result, expected_result, eps * expected_result);
 
-  ScalarA const_result = KokkosBlas::sum(c_a);
+  ScalarA const_result = KokkosBlas::sum(a.d_view_const);
   EXPECT_NEAR_KK(const_result, expected_result, eps * expected_result);
 }
 
@@ -54,40 +51,28 @@ template <class ViewTypeA, class Device>
 void impl_test_sum_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-
-  typename vfA_type::BaseType b_a("A", N, K);
-
-  ViewTypeA a = vfA_type::view(b_a);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-
-  typename h_vfA_type::BaseType h_b_a = Kokkos::create_mirror_view(b_a);
-
-  typename ViewTypeA::HostMirror h_a = h_vfA_type::view(h_b_a);
+  view_stride_adapter<ViewTypeA> a("A", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
   ScalarA randStart, randEnd;
   Test::getRandomBounds(10.0, randStart, randEnd);
-  Kokkos::fill_random(b_a, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
-  Kokkos::deep_copy(h_b_a, b_a);
-
-  typename ViewTypeA::const_type c_a = a;
+  Kokkos::deep_copy(a.h_base, a.d_base);
 
   ScalarA* expected_result = new ScalarA[K];
   for (int j = 0; j < K; j++) {
     expected_result[j] = ScalarA();
-    for (int i = 0; i < N; i++) expected_result[j] += h_a(i, j);
+    for (int i = 0; i < N; i++) expected_result[j] += a.h_view(i, j);
   }
 
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
 
   Kokkos::View<ScalarA*, Kokkos::HostSpace> r("Sum::Result", K);
 
-  KokkosBlas::sum(r, a);
+  KokkosBlas::sum(r, a.d_view);
   Kokkos::fence();
   for (int k = 0; k < K; k++) {
     ScalarA nonconst_result = r(k);
@@ -95,7 +80,7 @@ void impl_test_sum_mv(int N, int K) {
                    eps * expected_result[k]);
   }
 
-  KokkosBlas::sum(r, c_a);
+  KokkosBlas::sum(r, a.d_view_const);
   Kokkos::fence();
   for (int k = 0; k < K; k++) {
     ScalarA const_result = r(k);
@@ -128,15 +113,15 @@ int test_sum() {
   // Test::impl_test_sum<view_type_a_lr, Device>(132231);
 #endif
 
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
-    Test::impl_test_sum<view_type_a_ls, Device>(0);
-    Test::impl_test_sum<view_type_a_ls, Device>(13);
-    Test::impl_test_sum<view_type_a_ls, Device>(1024);
-    // Test::impl_test_sum<view_type_a_ls, Device>(132231);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
+  Test::impl_test_sum<view_type_a_ls, Device>(0);
+  Test::impl_test_sum<view_type_a_ls, Device>(13);
+  Test::impl_test_sum<view_type_a_ls, Device>(1024);
+  // Test::impl_test_sum<view_type_a_ls, Device>(132231);
+#endif
 
   return 1;
 }
@@ -165,16 +150,16 @@ int test_sum_mv() {
   // Test::impl_test_sum_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device>
-  view_type_a_ls; Test::impl_test_sum_mv<view_type_a_ls, Device>(0, 5);
-    Test::impl_test_sum_mv<view_type_a_ls, Device>(13, 5);
-    Test::impl_test_sum_mv<view_type_a_ls, Device>(1024, 5);
-    Test::impl_test_sum_mv<view_type_a_ls, Device>(789, 1);
-    // Test::impl_test_sum_mv<view_type_a_ls, Device>(132231,5);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device> view_type_a_ls;
+  Test::impl_test_sum_mv<view_type_a_ls, Device>(0, 5);
+  Test::impl_test_sum_mv<view_type_a_ls, Device>(13, 5);
+  Test::impl_test_sum_mv<view_type_a_ls, Device>(1024, 5);
+  Test::impl_test_sum_mv<view_type_a_ls, Device>(789, 1);
+  // Test::impl_test_sum_mv<view_type_a_ls, Device>(132231,5);
+#endif
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_team_abs.hpp
+++ b/blas/unit_test/Test_Blas1_team_abs.hpp
@@ -41,51 +41,22 @@ void impl_test_team_abs(int N) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef Kokkos::ArithTraits<ScalarA> AT;
 
-  typedef Kokkos::View<
-      ScalarA * [2],
-      typename std::conditional<std::is_same<typename ViewTypeA::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeA;
-  typedef Kokkos::View<
-      ScalarB * [2],
-      typename std::conditional<std::is_same<typename ViewTypeB::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeB;
-
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
 
-  BaseTypeA b_x("X", N);
-  BaseTypeB b_y("Y", N);
-  BaseTypeB b_org_y("Org_Y", N);
-
-  ViewTypeA x                        = Kokkos::subview(b_x, Kokkos::ALL(), 0);
-  ViewTypeB y                        = Kokkos::subview(b_y, Kokkos::ALL(), 0);
-  typename ViewTypeA::const_type c_x = x;
-
-  typename BaseTypeA::HostMirror h_b_x = Kokkos::create_mirror_view(b_x);
-  typename BaseTypeB::HostMirror h_b_y = Kokkos::create_mirror_view(b_y);
-
-  typename ViewTypeA::HostMirror h_x = Kokkos::subview(h_b_x, Kokkos::ALL(), 0);
-  typename ViewTypeB::HostMirror h_y = Kokkos::subview(h_b_y, Kokkos::ALL(), 0);
+  view_stride_adapter<ViewTypeA> x("X", N);
+  view_stride_adapter<ViewTypeB> y("Y", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
-  Kokkos::fill_random(b_x, rand_pool, ScalarA(1));
-  Kokkos::fill_random(b_y, rand_pool, ScalarB(1));
+  Kokkos::fill_random(x.d_view, rand_pool, ScalarA(1));
+  Kokkos::fill_random(y.d_view, rand_pool, ScalarB(1));
 
-  Kokkos::deep_copy(b_org_y, b_y);
-
-  Kokkos::deep_copy(h_b_x, b_x);
-  Kokkos::deep_copy(h_b_y, b_y);
+  Kokkos::deep_copy(x.h_base, x.d_base);
 
   ScalarA expected_result = 0;
   for (int i = 0; i < N; i++)
-    expected_result += AT::abs(h_x(i)) * AT::abs(h_x(i));
+    expected_result += AT::abs(x.h_view(i)) * AT::abs(x.h_view(i));
 
   // KokkosBlas::abs(y,x);
   Kokkos::parallel_for(
@@ -95,20 +66,23 @@ void impl_test_team_abs(int N) {
         KokkosBlas::Experimental::abs(
             teamMember,
             Kokkos::subview(
-                y, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                y.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             Kokkos::subview(
-                x, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
+                x.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
       });
 
-  ScalarB nonconst_nonconst_result = KokkosBlas::dot(y, y);
+  ScalarB nonconst_nonconst_result = KokkosBlas::dot(y.d_view, y.d_view);
   EXPECT_NEAR_KK(nonconst_nonconst_result, expected_result,
                  eps * expected_result);
 
-  Kokkos::deep_copy(b_y, b_org_y);
+  // Zero out y and run again with const input
+  Kokkos::deep_copy(y.d_view, Kokkos::ArithTraits<ScalarB>::zero());
 
   // KokkosBlas::abs(y,c_x);
   Kokkos::parallel_for(
@@ -118,16 +92,18 @@ void impl_test_team_abs(int N) {
         KokkosBlas::Experimental::abs(
             teamMember,
             Kokkos::subview(
-                y, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                y.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             Kokkos::subview(
-                c_x, Kokkos::make_pair(
-                         teamId * team_data_siz,
-                         (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
+                x.d_view_const,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
       });
 
-  ScalarB const_nonconst_result = KokkosBlas::dot(y, y);
+  ScalarB const_nonconst_result = KokkosBlas::dot(y.d_view, y.d_view);
   EXPECT_NEAR_KK(const_nonconst_result, expected_result, eps * expected_result);
 }
 
@@ -143,43 +119,22 @@ void impl_test_team_abs_mv(int N, int K) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef Kokkos::ArithTraits<ScalarA> AT;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-  typedef multivector_layout_adapter<ViewTypeB> vfB_type;
-
-  typename vfA_type::BaseType b_x("A", N, K);
-  typename vfB_type::BaseType b_y("B", N, K);
-  typename vfB_type::BaseType b_org_y("B", N, K);
-
-  ViewTypeA x = vfA_type::view(b_x);
-  ViewTypeB y = vfB_type::view(b_y);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-  typedef multivector_layout_adapter<typename ViewTypeB::HostMirror> h_vfB_type;
-
-  typename h_vfA_type::BaseType h_b_x = Kokkos::create_mirror_view(b_x);
-  typename h_vfB_type::BaseType h_b_y = Kokkos::create_mirror_view(b_y);
-
-  typename ViewTypeA::HostMirror h_x = h_vfA_type::view(h_b_x);
-  typename ViewTypeB::HostMirror h_y = h_vfB_type::view(h_b_y);
+  view_stride_adapter<ViewTypeA> x("X", N, K);
+  view_stride_adapter<ViewTypeB> y("Y", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
-  Kokkos::fill_random(b_x, rand_pool, ScalarA(1));
-  Kokkos::fill_random(b_y, rand_pool, ScalarB(1));
+  Kokkos::fill_random(x.d_view, rand_pool, ScalarA(1));
+  Kokkos::fill_random(y.d_view, rand_pool, ScalarB(1));
 
-  Kokkos::deep_copy(b_org_y, b_y);
-
-  Kokkos::deep_copy(h_b_x, b_x);
-  Kokkos::deep_copy(h_b_y, b_y);
-
-  typename ViewTypeA::const_type c_x = x;
+  Kokkos::deep_copy(x.h_base, x.d_base);
 
   ScalarA *expected_result = new ScalarA[K];
   for (int j = 0; j < K; j++) {
     expected_result[j] = ScalarA();
     for (int i = 0; i < N; i++)
-      expected_result[j] += AT::abs(h_x(i, j)) * AT::abs(h_x(i, j));
+      expected_result[j] += AT::abs(x.h_view(i, j)) * AT::abs(x.h_view(i, j));
   }
 
   //    double eps = std::is_same<ScalarA,float>::value?2*1e-5:1e-7;
@@ -195,11 +150,11 @@ void impl_test_team_abs_mv(int N, int K) {
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         KokkosBlas::Experimental::abs(
-            teamMember, Kokkos::subview(y, Kokkos::ALL(), teamId),
-            Kokkos::subview(x, Kokkos::ALL(), teamId));
+            teamMember, Kokkos::subview(y.d_view, Kokkos::ALL(), teamId),
+            Kokkos::subview(x.d_view, Kokkos::ALL(), teamId));
       });
 
-  KokkosBlas::dot(r, y, y);
+  KokkosBlas::dot(r, y.d_view, y.d_view);
   for (int k = 0; k < K; k++) {
     ScalarA nonconst_result = r(k);
     typename AT::mag_type divisor =
@@ -211,7 +166,8 @@ void impl_test_team_abs_mv(int N, int K) {
     //      eps*expected_result[k]);
   }
 
-  Kokkos::deep_copy(b_y, b_org_y);
+  // Zero out y and run again with const input
+  Kokkos::deep_copy(y.d_view, Kokkos::ArithTraits<ScalarB>::zero());
 
   // KokkosBlas::abs(y,c_x);
   Kokkos::parallel_for(
@@ -219,11 +175,11 @@ void impl_test_team_abs_mv(int N, int K) {
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         KokkosBlas::Experimental::abs(
-            teamMember, Kokkos::subview(y, Kokkos::ALL(), teamId),
-            Kokkos::subview(c_x, Kokkos::ALL(), teamId));
+            teamMember, Kokkos::subview(y.d_view, Kokkos::ALL(), teamId),
+            Kokkos::subview(x.d_view_const, Kokkos::ALL(), teamId));
       });
 
-  KokkosBlas::dot(r, y, y);
+  KokkosBlas::dot(r, y.d_view, y.d_view);
   for (int k = 0; k < K; k++) {
     ScalarA const_result = r(k);
     typename AT::mag_type divisor =

--- a/blas/unit_test/Test_Blas1_team_axpby.hpp
+++ b/blas/unit_test/Test_Blas1_team_axpby.hpp
@@ -40,55 +40,28 @@ void impl_test_team_axpby(int N) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
 
-  typedef Kokkos::View<
-      ScalarA * [2],
-      typename std::conditional<std::is_same<typename ViewTypeA::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeA;
-  typedef Kokkos::View<
-      ScalarB * [2],
-      typename std::conditional<std::is_same<typename ViewTypeB::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeB;
-
   ScalarA a  = 3;
   ScalarB b  = 5;
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
 
-  BaseTypeA b_x("X", N);
-  BaseTypeB b_y("Y", N);
-  BaseTypeB b_org_y("Org_Y", N);
-
-  ViewTypeA x                        = Kokkos::subview(b_x, Kokkos::ALL(), 0);
-  ViewTypeB y                        = Kokkos::subview(b_y, Kokkos::ALL(), 0);
-  typename ViewTypeA::const_type c_x = x;
-  typename ViewTypeB::const_type c_y = y;
-
-  typename BaseTypeA::HostMirror h_b_x = Kokkos::create_mirror_view(b_x);
-  typename BaseTypeB::HostMirror h_b_y = Kokkos::create_mirror_view(b_y);
-
-  typename ViewTypeA::HostMirror h_x = Kokkos::subview(h_b_x, Kokkos::ALL(), 0);
-  typename ViewTypeB::HostMirror h_y = Kokkos::subview(h_b_y, Kokkos::ALL(), 0);
+  view_stride_adapter<ViewTypeA> x("X", N);
+  view_stride_adapter<ViewTypeB> y("Y", N);
+  view_stride_adapter<ViewTypeB> org_y("Y", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
-  Kokkos::fill_random(b_x, rand_pool, ScalarA(10));
-  Kokkos::fill_random(b_y, rand_pool, ScalarB(10));
+  Kokkos::fill_random(x.d_view, rand_pool, ScalarA(10));
+  Kokkos::fill_random(y.d_view, rand_pool, ScalarB(10));
 
-  Kokkos::deep_copy(b_org_y, b_y);
-
-  Kokkos::deep_copy(h_b_x, b_x);
-  Kokkos::deep_copy(h_b_y, b_y);
+  Kokkos::deep_copy(x.h_base, x.d_base);
+  Kokkos::deep_copy(y.h_base, y.d_base);
+  Kokkos::deep_copy(org_y.h_base, y.d_base);
 
   ScalarA expected_result = 0;
   for (int i = 0; i < N; i++)
-    expected_result +=
-        ScalarB(a * h_x(i) + b * h_y(i)) * ScalarB(a * h_x(i) + b * h_y(i));
+    expected_result += ScalarB(a * x.h_view(i) + b * y.h_view(i)) *
+                       ScalarB(a * x.h_view(i) + b * y.h_view(i));
 
   // KokkosBlas::axpby(a,x,b,y);
   Kokkos::parallel_for(
@@ -98,21 +71,23 @@ void impl_test_team_axpby(int N) {
         KokkosBlas::Experimental::axpby(
             teamMember, a,
             Kokkos::subview(
-                x, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                x.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             b,
             Kokkos::subview(
-                y, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
+                y.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
       });
 
-  ScalarB nonconst_nonconst_result = KokkosBlas::dot(y, y);
+  ScalarB nonconst_nonconst_result = KokkosBlas::dot(y.d_view, y.d_view);
   EXPECT_NEAR_KK(nonconst_nonconst_result, expected_result,
                  eps * expected_result);
 
-  Kokkos::deep_copy(b_y, b_org_y);
+  Kokkos::deep_copy(y.d_base, org_y.h_base);
 
   // KokkosBlas::axpby(a,c_x,b,y);
   Kokkos::parallel_for(
@@ -122,17 +97,20 @@ void impl_test_team_axpby(int N) {
         KokkosBlas::Experimental::axpby(
             teamMember, a,
             Kokkos::subview(
-                c_x, Kokkos::make_pair(
-                         teamId * team_data_siz,
-                         (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                x.d_view_const,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             b,
             Kokkos::subview(
-                y, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
+                y.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
       });
 
-  ScalarB const_nonconst_result = KokkosBlas::dot(c_y, c_y);
+  ScalarB const_nonconst_result =
+      KokkosBlas::dot(y.d_view_const, y.d_view_const);
   EXPECT_NEAR_KK(const_nonconst_result, expected_result, eps * expected_result);
 }
 
@@ -147,46 +125,29 @@ void impl_test_team_axpby_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-  typedef multivector_layout_adapter<ViewTypeB> vfB_type;
-
-  typename vfA_type::BaseType b_x("A", N, K);
-  typename vfB_type::BaseType b_y("B", N, K);
-  typename vfB_type::BaseType b_org_y("B", N, K);
-
-  ViewTypeA x = vfA_type::view(b_x);
-  ViewTypeB y = vfB_type::view(b_y);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-  typedef multivector_layout_adapter<typename ViewTypeB::HostMirror> h_vfB_type;
-
-  typename h_vfA_type::BaseType h_b_x = Kokkos::create_mirror_view(b_x);
-  typename h_vfB_type::BaseType h_b_y = Kokkos::create_mirror_view(b_y);
-
-  typename ViewTypeA::HostMirror h_x = h_vfA_type::view(h_b_x);
-  typename ViewTypeB::HostMirror h_y = h_vfB_type::view(h_b_y);
+  view_stride_adapter<ViewTypeA> x("X", N, K);
+  view_stride_adapter<ViewTypeB> y("Y", N, K);
+  view_stride_adapter<ViewTypeB> org_y("Org_Y", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
-  Kokkos::fill_random(b_x, rand_pool, ScalarA(10));
-  Kokkos::fill_random(b_y, rand_pool, ScalarB(10));
+  Kokkos::fill_random(x.d_view, rand_pool, ScalarA(10));
+  Kokkos::fill_random(y.d_view, rand_pool, ScalarB(10));
 
-  Kokkos::deep_copy(b_org_y, b_y);
+  Kokkos::deep_copy(x.h_base, x.d_base);
+  Kokkos::deep_copy(y.h_base, y.d_base);
+  Kokkos::deep_copy(org_y.h_base, y.d_base);
 
-  Kokkos::deep_copy(h_b_x, b_x);
-  Kokkos::deep_copy(h_b_y, b_y);
-
-  ScalarA a                          = 3;
-  ScalarB b                          = 5;
-  typename ViewTypeA::const_type c_x = x;
+  ScalarA a = 3;
+  ScalarB b = 5;
 
   ScalarA *expected_result = new ScalarA[K];
   for (int j = 0; j < K; j++) {
     expected_result[j] = ScalarA();
     for (int i = 0; i < N; i++)
-      expected_result[j] += ScalarB(a * h_x(i, j) + b * h_y(i, j)) *
-                            ScalarB(a * h_x(i, j) + b * h_y(i, j));
+      expected_result[j] += ScalarB(a * x.h_view(i, j) + b * y.h_view(i, j)) *
+                            ScalarB(a * x.h_view(i, j) + b * y.h_view(i, j));
   }
 
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
@@ -201,11 +162,11 @@ void impl_test_team_axpby_mv(int N, int K) {
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         KokkosBlas::Experimental::axpby(
-            teamMember, a, Kokkos::subview(x, Kokkos::ALL(), teamId), b,
-            Kokkos::subview(y, Kokkos::ALL(), teamId));
+            teamMember, a, Kokkos::subview(x.d_view, Kokkos::ALL(), teamId), b,
+            Kokkos::subview(y.d_view, Kokkos::ALL(), teamId));
       });
 
-  KokkosBlas::dot(r, y, y);
+  KokkosBlas::dot(r, y.d_view, y.d_view);
   for (int k = 0; k < K; k++) {
     ScalarA nonconst_nonconst_result = r(k);
     EXPECT_NEAR_KK(AT::abs(nonconst_nonconst_result),
@@ -213,7 +174,7 @@ void impl_test_team_axpby_mv(int N, int K) {
                    AT::abs(expected_result[k] * eps));
   }
 
-  Kokkos::deep_copy(b_y, b_org_y);
+  Kokkos::deep_copy(y.d_base, org_y.h_base);
 
   // KokkosBlas::axpby(a,c_x,b,y);
   Kokkos::parallel_for(
@@ -221,11 +182,12 @@ void impl_test_team_axpby_mv(int N, int K) {
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         KokkosBlas::Experimental::axpby(
-            teamMember, a, Kokkos::subview(c_x, Kokkos::ALL(), teamId), b,
-            Kokkos::subview(y, Kokkos::ALL(), teamId));
+            teamMember, a,
+            Kokkos::subview(x.d_view_const, Kokkos::ALL(), teamId), b,
+            Kokkos::subview(y.d_view, Kokkos::ALL(), teamId));
       });
 
-  KokkosBlas::dot(r, y, y);
+  KokkosBlas::dot(r, y.d_view, y.d_view);
   for (int k = 0; k < K; k++) {
     ScalarA const_non_const_result = r(k);
     EXPECT_NEAR_KK(AT::abs(const_non_const_result), AT::abs(expected_result[k]),

--- a/blas/unit_test/Test_Blas1_team_axpy.hpp
+++ b/blas/unit_test/Test_Blas1_team_axpy.hpp
@@ -40,54 +40,27 @@ void impl_test_team_axpy(int N) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
 
-  typedef Kokkos::View<
-      ScalarA * [2],
-      typename std::conditional<std::is_same<typename ViewTypeA::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeA;
-  typedef Kokkos::View<
-      ScalarB * [2],
-      typename std::conditional<std::is_same<typename ViewTypeB::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeB;
+  view_stride_adapter<ViewTypeA> x("X", N);
+  view_stride_adapter<ViewTypeB> y("Y", N);
+  view_stride_adapter<ViewTypeB> org_y("Y", N);
 
   ScalarA a  = 3;
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
 
-  BaseTypeA b_x("X", N);
-  BaseTypeB b_y("Y", N);
-  BaseTypeB b_org_y("Org_Y", N);
-
-  ViewTypeA x                        = Kokkos::subview(b_x, Kokkos::ALL(), 0);
-  ViewTypeB y                        = Kokkos::subview(b_y, Kokkos::ALL(), 0);
-  typename ViewTypeA::const_type c_x = x;
-  typename ViewTypeB::const_type c_y = y;
-
-  typename BaseTypeA::HostMirror h_b_x = Kokkos::create_mirror_view(b_x);
-  typename BaseTypeB::HostMirror h_b_y = Kokkos::create_mirror_view(b_y);
-
-  typename ViewTypeA::HostMirror h_x = Kokkos::subview(h_b_x, Kokkos::ALL(), 0);
-  typename ViewTypeB::HostMirror h_y = Kokkos::subview(h_b_y, Kokkos::ALL(), 0);
-
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
-  Kokkos::fill_random(b_x, rand_pool, ScalarA(10));
-  Kokkos::fill_random(b_y, rand_pool, ScalarB(10));
+  Kokkos::fill_random(x.d_view, rand_pool, ScalarA(10));
+  Kokkos::fill_random(y.d_view, rand_pool, ScalarB(10));
 
-  Kokkos::deep_copy(b_org_y, b_y);
-
-  Kokkos::deep_copy(h_b_x, b_x);
-  Kokkos::deep_copy(h_b_y, b_y);
+  Kokkos::deep_copy(x.h_base, x.d_base);
+  Kokkos::deep_copy(y.h_base, y.d_base);
+  Kokkos::deep_copy(org_y.h_base, y.d_base);
 
   ScalarA expected_result = 0;
   for (int i = 0; i < N; i++)
-    expected_result +=
-        ScalarB(a * h_x(i) + h_y(i)) * ScalarB(a * h_x(i) + h_y(i));
+    expected_result += ScalarB(a * x.h_view(i) + y.h_view(i)) *
+                       ScalarB(a * x.h_view(i) + y.h_view(i));
 
   // KokkosBlas::axpy(a,x,y);
   Kokkos::parallel_for(
@@ -97,20 +70,22 @@ void impl_test_team_axpy(int N) {
         KokkosBlas::Experimental::axpy(
             teamMember, a,
             Kokkos::subview(
-                x, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                x.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             Kokkos::subview(
-                y, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
+                y.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
       });
 
-  ScalarB nonconst_nonconst_result = KokkosBlas::dot(y, y);
+  ScalarB nonconst_nonconst_result = KokkosBlas::dot(y.d_view, y.d_view);
   EXPECT_NEAR_KK(nonconst_nonconst_result, expected_result,
                  eps * expected_result);
 
-  Kokkos::deep_copy(b_y, b_org_y);
+  Kokkos::deep_copy(y.d_base, org_y.h_base);
 
   // KokkosBlas::axpy(a,c_x,y);
   Kokkos::parallel_for(
@@ -120,16 +95,19 @@ void impl_test_team_axpy(int N) {
         KokkosBlas::Experimental::axpy(
             teamMember, a,
             Kokkos::subview(
-                c_x, Kokkos::make_pair(
-                         teamId * team_data_siz,
-                         (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                x.d_view_const,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             Kokkos::subview(
-                y, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
+                y.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
       });
 
-  ScalarB const_nonconst_result = KokkosBlas::dot(c_y, c_y);
+  ScalarB const_nonconst_result =
+      KokkosBlas::dot(y.d_view_const, y.d_view_const);
   EXPECT_NEAR_KK(const_nonconst_result, expected_result, eps * expected_result);
 }
 
@@ -144,45 +122,28 @@ void impl_test_team_axpy_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-  typedef multivector_layout_adapter<ViewTypeB> vfB_type;
-
-  typename vfA_type::BaseType b_x("A", N, K);
-  typename vfB_type::BaseType b_y("B", N, K);
-  typename vfB_type::BaseType b_org_y("B", N, K);
-
-  ViewTypeA x = vfA_type::view(b_x);
-  ViewTypeB y = vfB_type::view(b_y);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-  typedef multivector_layout_adapter<typename ViewTypeB::HostMirror> h_vfB_type;
-
-  typename h_vfA_type::BaseType h_b_x = Kokkos::create_mirror_view(b_x);
-  typename h_vfB_type::BaseType h_b_y = Kokkos::create_mirror_view(b_y);
-
-  typename ViewTypeA::HostMirror h_x = h_vfA_type::view(h_b_x);
-  typename ViewTypeB::HostMirror h_y = h_vfB_type::view(h_b_y);
+  view_stride_adapter<ViewTypeA> x("X", N, K);
+  view_stride_adapter<ViewTypeB> y("Y", N, K);
+  view_stride_adapter<ViewTypeB> org_y("Org_Y", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
-  Kokkos::fill_random(b_x, rand_pool, ScalarA(10));
-  Kokkos::fill_random(b_y, rand_pool, ScalarB(10));
+  Kokkos::fill_random(x.d_view, rand_pool, ScalarA(10));
+  Kokkos::fill_random(y.d_view, rand_pool, ScalarB(10));
 
-  Kokkos::deep_copy(b_org_y, b_y);
+  Kokkos::deep_copy(x.h_base, x.d_base);
+  Kokkos::deep_copy(y.h_base, y.d_base);
+  Kokkos::deep_copy(org_y.h_base, y.d_base);
 
-  Kokkos::deep_copy(h_b_x, b_x);
-  Kokkos::deep_copy(h_b_y, b_y);
-
-  ScalarA a                          = 3;
-  typename ViewTypeA::const_type c_x = x;
+  ScalarA a = 3;
 
   ScalarA *expected_result = new ScalarA[K];
   for (int j = 0; j < K; j++) {
     expected_result[j] = ScalarA();
     for (int i = 0; i < N; i++)
-      expected_result[j] += ScalarB(a * h_x(i, j) + h_y(i, j)) *
-                            ScalarB(a * h_x(i, j) + h_y(i, j));
+      expected_result[j] += ScalarB(a * x.h_view(i, j) + y.h_view(i, j)) *
+                            ScalarB(a * x.h_view(i, j) + y.h_view(i, j));
   }
 
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
@@ -195,18 +156,18 @@ void impl_test_team_axpy_mv(int N, int K) {
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         KokkosBlas::Experimental::axpy(
-            teamMember, a, Kokkos::subview(x, Kokkos::ALL(), teamId),
-            Kokkos::subview(y, Kokkos::ALL(), teamId));
+            teamMember, a, Kokkos::subview(x.d_view, Kokkos::ALL(), teamId),
+            Kokkos::subview(y.d_view, Kokkos::ALL(), teamId));
       });
 
-  KokkosBlas::dot(r, y, y);
+  KokkosBlas::dot(r, y.d_view, y.d_view);
   for (int k = 0; k < K; k++) {
     ScalarA nonconst_nonconst_result = r(k);
     EXPECT_NEAR_KK(nonconst_nonconst_result, expected_result[k],
                    eps * expected_result[k]);
   }
 
-  Kokkos::deep_copy(b_y, b_org_y);
+  Kokkos::deep_copy(y.d_base, org_y.h_base);
 
   // KokkosBlas::axpy(a,c_x,y);
   Kokkos::parallel_for(
@@ -214,11 +175,12 @@ void impl_test_team_axpy_mv(int N, int K) {
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         KokkosBlas::Experimental::axpy(
-            teamMember, a, Kokkos::subview(c_x, Kokkos::ALL(), teamId),
-            Kokkos::subview(y, Kokkos::ALL(), teamId));
+            teamMember, a,
+            Kokkos::subview(x.d_view_const, Kokkos::ALL(), teamId),
+            Kokkos::subview(y.d_view, Kokkos::ALL(), teamId));
       });
 
-  KokkosBlas::dot(r, y, y);
+  KokkosBlas::dot(r, y.d_view, y.d_view);
   for (int k = 0; k < K; k++) {
     ScalarA const_non_const_result = r(k);
     EXPECT_NEAR_KK(const_non_const_result, expected_result[k],

--- a/blas/unit_test/Test_Blas1_team_dot.hpp
+++ b/blas/unit_test/Test_Blas1_team_dot.hpp
@@ -39,44 +39,20 @@ void impl_test_team_dot(int N) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
 
-  typedef Kokkos::View<
-      ScalarA * [2],
-      typename std::conditional<std::is_same<typename ViewTypeA::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeA;
-  typedef Kokkos::View<
-      ScalarB * [2],
-      typename std::conditional<std::is_same<typename ViewTypeB::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeB;
-
-  BaseTypeA b_a("A", N);
-  BaseTypeB b_b("B", N);
-
-  ViewTypeA a = Kokkos::subview(b_a, Kokkos::ALL(), 0);
-  ViewTypeB b = Kokkos::subview(b_b, Kokkos::ALL(), 0);
-
-  typename BaseTypeA::HostMirror h_b_a = Kokkos::create_mirror_view(b_a);
-  typename BaseTypeB::HostMirror h_b_b = Kokkos::create_mirror_view(b_b);
-
-  typename ViewTypeA::HostMirror h_a = Kokkos::subview(h_b_a, Kokkos::ALL(), 0);
-  typename ViewTypeB::HostMirror h_b = Kokkos::subview(h_b_b, Kokkos::ALL(), 0);
+  view_stride_adapter<ViewTypeA> a("a", N);
+  view_stride_adapter<ViewTypeB> b("b", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
-  Kokkos::fill_random(b_a, rand_pool, ScalarA(10));
-  Kokkos::fill_random(b_b, rand_pool, ScalarB(10));
+  Kokkos::fill_random(a.d_view, rand_pool, ScalarA(10));
+  Kokkos::fill_random(b.d_view, rand_pool, ScalarB(10));
 
-  Kokkos::deep_copy(h_b_a, b_a);
-  Kokkos::deep_copy(h_b_b, b_b);
+  Kokkos::deep_copy(a.h_base, a.d_base);
+  Kokkos::deep_copy(b.h_base, b.d_base);
 
   ScalarA expected_result = 0;
-  for (int i = 0; i < N; i++) expected_result += h_a(i) * h_b(i);
+  for (int i = 0; i < N; i++) expected_result += a.h_view(i) * b.h_view(i);
 
   Kokkos::View<ScalarB *, Kokkos::HostSpace> r("PartialDots", M);
   Kokkos::View<ScalarB *, Device> d_r("PartialDots", M);
@@ -91,13 +67,15 @@ void impl_test_team_dot(int N) {
         d_r(teamId)      = KokkosBlas::Experimental::dot(
             teamMember,
             Kokkos::subview(
-                a, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                a.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             Kokkos::subview(
-                b, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
+                b.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
       });
   Kokkos::deep_copy(r, d_r);
   for (int k = 0; k < M; k++) nonconst_nonconst_result += r(k);
@@ -106,10 +84,6 @@ void impl_test_team_dot(int N) {
   EXPECT_NEAR_KK(nonconst_nonconst_result, expected_result,
                  eps * expected_result);
 
-  typename ViewTypeA::const_type c_a = a;
-  typename ViewTypeB::const_type c_b = b;
-
-  // ScalarA const_const_result = KokkosBlas::dot(c_a,c_b);
   ScalarA const_const_result = 0;
 
   Kokkos::parallel_for(
@@ -119,13 +93,15 @@ void impl_test_team_dot(int N) {
         d_r(teamId)      = KokkosBlas::Experimental::dot(
             teamMember,
             Kokkos::subview(
-                c_a, Kokkos::make_pair(
-                         teamId * team_data_siz,
-                         (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                a.d_view_const,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             Kokkos::subview(
-                c_b, Kokkos::make_pair(
-                         teamId * team_data_siz,
-                         (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
+                b.d_view_const,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
       });
   Kokkos::deep_copy(r, d_r);
   for (int k = 0; k < M; k++) const_const_result += r(k);
@@ -142,13 +118,15 @@ void impl_test_team_dot(int N) {
         d_r(teamId)      = KokkosBlas::Experimental::dot(
             teamMember,
             Kokkos::subview(
-                a, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                a.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             Kokkos::subview(
-                c_b, Kokkos::make_pair(
-                         teamId * team_data_siz,
-                         (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
+                b.d_view_const,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
       });
   Kokkos::deep_copy(r, d_r);
   for (int k = 0; k < M; k++) nonconst_const_result += r(k);
@@ -165,13 +143,15 @@ void impl_test_team_dot(int N) {
         d_r(teamId)      = KokkosBlas::Experimental::dot(
             teamMember,
             Kokkos::subview(
-                c_a, Kokkos::make_pair(
-                         teamId * team_data_siz,
-                         (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                a.d_view_const,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             Kokkos::subview(
-                b, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
+                b.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
       });
   Kokkos::deep_copy(r, d_r);
   for (int k = 0; k < M; k++) const_nonconst_result += r(k);
@@ -190,40 +170,23 @@ void impl_test_team_dot_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-  typedef multivector_layout_adapter<ViewTypeB> vfB_type;
-
-  typename vfA_type::BaseType b_a("A", N, K);
-  typename vfB_type::BaseType b_b("B", N, K);
-
-  ViewTypeA a = vfA_type::view(b_a);
-  ViewTypeB b = vfB_type::view(b_b);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-  typedef multivector_layout_adapter<typename ViewTypeB::HostMirror> h_vfB_type;
-
-  typename h_vfA_type::BaseType h_b_a = Kokkos::create_mirror_view(b_a);
-  typename h_vfB_type::BaseType h_b_b = Kokkos::create_mirror_view(b_b);
-
-  typename ViewTypeA::HostMirror h_a = h_vfA_type::view(h_b_a);
-  typename ViewTypeB::HostMirror h_b = h_vfB_type::view(h_b_b);
+  view_stride_adapter<ViewTypeA> a("A", N, K);
+  view_stride_adapter<ViewTypeB> b("B", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
-  Kokkos::fill_random(b_a, rand_pool, ScalarA(10));
-  Kokkos::fill_random(b_b, rand_pool, ScalarB(10));
+  Kokkos::fill_random(a.d_view, rand_pool, ScalarA(10));
+  Kokkos::fill_random(b.d_view, rand_pool, ScalarB(10));
 
-  Kokkos::deep_copy(h_b_a, b_a);
-  Kokkos::deep_copy(h_b_b, b_b);
-
-  typename ViewTypeA::const_type c_a = a;
-  typename ViewTypeB::const_type c_b = b;
+  Kokkos::deep_copy(a.h_base, a.d_base);
+  Kokkos::deep_copy(b.h_base, b.d_base);
 
   ScalarA *expected_result = new ScalarA[K];
   for (int j = 0; j < K; j++) {
     expected_result[j] = ScalarA();
-    for (int i = 0; i < N; i++) expected_result[j] += h_a(i, j) * h_b(i, j);
+    for (int i = 0; i < N; i++)
+      expected_result[j] += a.h_view(i, j) * b.h_view(i, j);
   }
 
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
@@ -237,8 +200,8 @@ void impl_test_team_dot_mv(int N, int K) {
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         d_r(teamId)      = KokkosBlas::Experimental::dot(
-            teamMember, Kokkos::subview(a, Kokkos::ALL(), teamId),
-            Kokkos::subview(b, Kokkos::ALL(), teamId));
+            teamMember, Kokkos::subview(a.d_view, Kokkos::ALL(), teamId),
+            Kokkos::subview(b.d_view, Kokkos::ALL(), teamId));
       });
   Kokkos::deep_copy(r, d_r);
   for (int k = 0; k < K; k++) {
@@ -253,8 +216,8 @@ void impl_test_team_dot_mv(int N, int K) {
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         d_r(teamId)      = KokkosBlas::Experimental::dot(
-            teamMember, Kokkos::subview(c_a, Kokkos::ALL(), teamId),
-            Kokkos::subview(c_b, Kokkos::ALL(), teamId));
+            teamMember, Kokkos::subview(a.d_view_const, Kokkos::ALL(), teamId),
+            Kokkos::subview(b.d_view_const, Kokkos::ALL(), teamId));
       });
   Kokkos::deep_copy(r, d_r);
   for (int k = 0; k < K; k++) {
@@ -269,8 +232,8 @@ void impl_test_team_dot_mv(int N, int K) {
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         d_r(teamId)      = KokkosBlas::Experimental::dot(
-            teamMember, Kokkos::subview(a, Kokkos::ALL(), teamId),
-            Kokkos::subview(c_b, Kokkos::ALL(), teamId));
+            teamMember, Kokkos::subview(a.d_view, Kokkos::ALL(), teamId),
+            Kokkos::subview(b.d_view_const, Kokkos::ALL(), teamId));
       });
   Kokkos::deep_copy(r, d_r);
   for (int k = 0; k < K; k++) {
@@ -285,8 +248,8 @@ void impl_test_team_dot_mv(int N, int K) {
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         d_r(teamId)      = KokkosBlas::Experimental::dot(
-            teamMember, Kokkos::subview(c_a, Kokkos::ALL(), teamId),
-            Kokkos::subview(b, Kokkos::ALL(), teamId));
+            teamMember, Kokkos::subview(a.d_view_const, Kokkos::ALL(), teamId),
+            Kokkos::subview(b.d_view, Kokkos::ALL(), teamId));
       });
   Kokkos::deep_copy(r, d_r);
   for (int k = 0; k < K; k++) {

--- a/blas/unit_test/Test_Blas1_team_mult.hpp
+++ b/blas/unit_test/Test_Blas1_team_mult.hpp
@@ -41,68 +41,33 @@ void impl_test_team_mult(int N) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef typename ViewTypeC::value_type ScalarC;
 
-  typedef Kokkos::View<
-      ScalarA * [2],
-      typename std::conditional<std::is_same<typename ViewTypeA::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeA;
-  typedef Kokkos::View<
-      ScalarB * [2],
-      typename std::conditional<std::is_same<typename ViewTypeB::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeB;
-  typedef Kokkos::View<
-      ScalarC * [2],
-      typename std::conditional<std::is_same<typename ViewTypeC::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeC;
-
   ScalarA a  = 3;
   ScalarB b  = 5;
   double eps = std::is_same<ScalarC, float>::value ? 2 * 1e-5 : 1e-7;
 
-  BaseTypeA b_x("X", N);
-  BaseTypeB b_y("Y", N);
-  BaseTypeC b_z("Y", N);
-  BaseTypeC b_org_z("Org_Z", N);
-
-  ViewTypeA x                        = Kokkos::subview(b_x, Kokkos::ALL(), 0);
-  ViewTypeB y                        = Kokkos::subview(b_y, Kokkos::ALL(), 0);
-  ViewTypeC z                        = Kokkos::subview(b_z, Kokkos::ALL(), 0);
-  typename ViewTypeA::const_type c_x = x;
-  typename ViewTypeB::const_type c_y = y;
-
-  typename BaseTypeA::HostMirror h_b_x = Kokkos::create_mirror_view(b_x);
-  typename BaseTypeB::HostMirror h_b_y = Kokkos::create_mirror_view(b_y);
-  typename BaseTypeC::HostMirror h_b_z = Kokkos::create_mirror_view(b_z);
-
-  typename ViewTypeA::HostMirror h_x = Kokkos::subview(h_b_x, Kokkos::ALL(), 0);
-  typename ViewTypeB::HostMirror h_y = Kokkos::subview(h_b_y, Kokkos::ALL(), 0);
-  typename ViewTypeC::HostMirror h_z = Kokkos::subview(h_b_z, Kokkos::ALL(), 0);
+  view_stride_adapter<ViewTypeA> x("X", N);
+  view_stride_adapter<ViewTypeB> y("Y", N);
+  view_stride_adapter<ViewTypeC> z("Z", N);
+  view_stride_adapter<ViewTypeC> org_z("Org_Z", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
-  Kokkos::fill_random(b_x, rand_pool, ScalarA(10));
-  Kokkos::fill_random(b_y, rand_pool, ScalarB(10));
-  Kokkos::fill_random(b_z, rand_pool, ScalarC(10));
+  Kokkos::fill_random(x.d_view, rand_pool, ScalarA(10));
+  Kokkos::fill_random(y.d_view, rand_pool, ScalarB(10));
+  Kokkos::fill_random(z.d_view, rand_pool, ScalarC(10));
 
-  Kokkos::deep_copy(b_org_z, b_z);
+  Kokkos::deep_copy(org_z.h_base, z.d_base);
 
-  Kokkos::deep_copy(h_b_x, b_x);
-  Kokkos::deep_copy(h_b_y, b_y);
-  Kokkos::deep_copy(h_b_z, b_z);
+  Kokkos::deep_copy(x.h_base, x.d_base);
+  Kokkos::deep_copy(y.h_base, y.d_base);
+  Kokkos::deep_copy(z.h_base, z.d_base);
 
   ScalarA expected_result = 0;
   for (int i = 0; i < N; i++)
-    expected_result += ScalarC(b * h_z(i) + a * h_x(i) * h_y(i)) *
-                       ScalarC(b * h_z(i) + a * h_x(i) * h_y(i));
+    expected_result +=
+        ScalarC(b * z.h_view(i) + a * x.h_view(i) * y.h_view(i)) *
+        ScalarC(b * z.h_view(i) + a * x.h_view(i) * y.h_view(i));
 
   // KokkosBlas::mult(b,z,a,x,y);
   Kokkos::parallel_for(
@@ -112,24 +77,28 @@ void impl_test_team_mult(int N) {
         KokkosBlas::Experimental::mult(
             teamMember, b,
             Kokkos::subview(
-                z, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                z.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             a,
             Kokkos::subview(
-                x, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                x.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             Kokkos::subview(
-                y, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
+                y.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
       });
-  ScalarC nonconst_nonconst_result = KokkosBlas::dot(z, z);
+  ScalarC nonconst_nonconst_result = KokkosBlas::dot(z.d_view, z.d_view);
   EXPECT_NEAR_KK(nonconst_nonconst_result, expected_result,
                  eps * expected_result);
 
-  Kokkos::deep_copy(b_z, b_org_z);
+  // Reset z on device to orig and run again with const-valued y
+  Kokkos::deep_copy(z.d_base, org_z.h_base);
   // KokkosBlas::mult(b,z,a,x,c_y);
   Kokkos::parallel_for(
       "KokkosBlas::Test::TeamMult", policy,
@@ -138,23 +107,27 @@ void impl_test_team_mult(int N) {
         KokkosBlas::Experimental::mult(
             teamMember, b,
             Kokkos::subview(
-                z, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                z.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             a,
             Kokkos::subview(
-                x, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                x.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             Kokkos::subview(
-                c_y, Kokkos::make_pair(
-                         teamId * team_data_siz,
-                         (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
+                y.d_view_const,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
       });
-  ScalarC const_nonconst_result = KokkosBlas::dot(z, z);
+  ScalarC const_nonconst_result = KokkosBlas::dot(z.d_view, z.d_view);
   EXPECT_NEAR_KK(const_nonconst_result, expected_result, eps * expected_result);
 
-  Kokkos::deep_copy(b_z, b_org_z);
+  // Reset z again to orig, and run with both x and y const
+  Kokkos::deep_copy(z.d_base, org_z.h_base);
   // KokkosBlas::mult(b,z,a,c_x,c_y);
   Kokkos::parallel_for(
       "KokkosBlas::Test::TeamMult", policy,
@@ -163,20 +136,23 @@ void impl_test_team_mult(int N) {
         KokkosBlas::Experimental::mult(
             teamMember, b,
             Kokkos::subview(
-                z, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                z.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             a,
             Kokkos::subview(
-                c_x, Kokkos::make_pair(
-                         teamId * team_data_siz,
-                         (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                x.d_view_const,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             Kokkos::subview(
-                c_y, Kokkos::make_pair(
-                         teamId * team_data_siz,
-                         (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
+                y.d_view_const,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
       });
-  ScalarC const_const_result = KokkosBlas::dot(z, z);
+  ScalarC const_const_result = KokkosBlas::dot(z.d_view, z.d_view);
   EXPECT_NEAR_KK(const_const_result, expected_result, eps * expected_result);
 }
 
@@ -192,54 +168,27 @@ void impl_test_team_mult_mv(int N, int K) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef typename ViewTypeC::value_type ScalarC;
 
-  typedef Kokkos::View<
-      ScalarA * [2],
-      typename std::conditional<std::is_same<typename ViewTypeA::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeA;
-  typedef multivector_layout_adapter<ViewTypeB> vfB_type;
-  typedef multivector_layout_adapter<ViewTypeC> vfC_type;
-
-  BaseTypeA b_x("X", N);
-  typename vfB_type::BaseType b_y("Y", N, K);
-  typename vfC_type::BaseType b_z("Z", N, K);
-  typename vfC_type::BaseType b_org_z("Z", N, K);
-
-  ViewTypeA x = Kokkos::subview(b_x, Kokkos::ALL(), 0);
-  ViewTypeB y = vfB_type::view(b_y);
-  ViewTypeC z = vfC_type::view(b_z);
-
-  typedef multivector_layout_adapter<typename ViewTypeB::HostMirror> h_vfB_type;
-  typedef multivector_layout_adapter<typename ViewTypeC::HostMirror> h_vfC_type;
-
-  typename BaseTypeA::HostMirror h_b_x = Kokkos::create_mirror_view(b_x);
-  typename h_vfB_type::BaseType h_b_y  = Kokkos::create_mirror_view(b_y);
-  typename h_vfC_type::BaseType h_b_z  = Kokkos::create_mirror_view(b_z);
-
-  typename ViewTypeA::HostMirror h_x = Kokkos::subview(h_b_x, Kokkos::ALL(), 0);
-  typename ViewTypeB::HostMirror h_y = h_vfB_type::view(h_b_y);
-  typename ViewTypeC::HostMirror h_z = h_vfC_type::view(h_b_z);
+  // x is rank-1, all others are rank-2
+  view_stride_adapter<ViewTypeA> x("X", N);
+  view_stride_adapter<ViewTypeB> y("Y", N, K);
+  view_stride_adapter<ViewTypeC> z("Z", N, K);
+  view_stride_adapter<ViewTypeC> org_z("Org_Z", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
   typename Kokkos::ArithTraits<ScalarC>::mag_type const max_val = 10;
-  Kokkos::fill_random(b_x, rand_pool, ScalarA(max_val));
-  Kokkos::fill_random(b_y, rand_pool, ScalarB(max_val));
-  Kokkos::fill_random(b_z, rand_pool, ScalarC(max_val));
+  Kokkos::fill_random(x.d_view, rand_pool, ScalarA(max_val));
+  Kokkos::fill_random(y.d_view, rand_pool, ScalarB(max_val));
+  Kokkos::fill_random(z.d_view, rand_pool, ScalarC(max_val));
 
-  Kokkos::deep_copy(b_org_z, b_z);
+  Kokkos::deep_copy(org_z.h_base, z.d_base);
 
-  Kokkos::deep_copy(h_b_x, b_x);
-  Kokkos::deep_copy(h_b_y, b_y);
-  Kokkos::deep_copy(h_b_z, b_z);
+  Kokkos::deep_copy(x.h_base, x.d_base);
+  Kokkos::deep_copy(y.h_base, y.d_base);
 
-  ScalarA a                          = 3;
-  ScalarB b                          = 5;
-  typename ViewTypeA::const_type c_x = x;
-  typename ViewTypeB::const_type c_y = y;
+  ScalarA a = 3;
+  ScalarB b = 5;
 
   // In the operation z = (b*z) + (a*x*y) we estimate
   // the largest rounding error to be dominated by max(b*z, a*x*y)
@@ -257,39 +206,37 @@ void impl_test_team_mult_mv(int N, int K) {
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         KokkosBlas::Experimental::mult(
-            teamMember, b, Kokkos::subview(z, Kokkos::ALL(), teamId), a, x,
-            Kokkos::subview(y, Kokkos::ALL(), teamId));
+            teamMember, b, Kokkos::subview(z.d_view, Kokkos::ALL(), teamId), a,
+            x.d_view, Kokkos::subview(y.d_view, Kokkos::ALL(), teamId));
       });
 
-  ScalarC temp;
-  typename h_vfC_type::BaseType h_b_z_res = Kokkos::create_mirror_view(b_z);
-  Kokkos::deep_copy(h_b_z_res, b_z);
-  typename h_vfC_type::BaseType h_b_org_z = Kokkos::create_mirror_view(b_org_z);
-  Kokkos::deep_copy(h_b_org_z, b_org_z);
+  Kokkos::deep_copy(z.h_base, z.d_base);
 
+  ScalarC temp;
   for (int j = 0; j < K; j++) {
     for (int i = 0; i < N; i++) {
-      temp = ScalarC(b * h_b_org_z(i, j) + a * h_x(i) * h_y(i, j));
-      EXPECT_NEAR_KK(temp, h_b_z_res(i, j), max_error);
+      temp = ScalarC(b * org_z.h_view(i, j) + a * x.h_view(i) * y.h_view(i, j));
+      EXPECT_NEAR_KK(temp, z.h_view(i, j), max_error);
     }
   }
 
-  Kokkos::deep_copy(b_z, b_org_z);
+  // Reset z on device and run again with const y
+  Kokkos::deep_copy(z.d_base, org_z.h_base);
   // KokkosBlas::mult(b,z,a,x,c_y);
   Kokkos::parallel_for(
       "KokkosBlas::Test::TeamMult", policy,
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         KokkosBlas::Experimental::mult(
-            teamMember, b, Kokkos::subview(z, Kokkos::ALL(), teamId), a, x,
-            Kokkos::subview(c_y, Kokkos::ALL(), teamId));
+            teamMember, b, Kokkos::subview(z.d_view, Kokkos::ALL(), teamId), a,
+            x.d_view, Kokkos::subview(y.d_view_const, Kokkos::ALL(), teamId));
       });
-  Kokkos::deep_copy(h_b_z_res, b_z);
+  Kokkos::deep_copy(z.h_base, z.d_base);
 
   for (int k = 0; k < K; k++) {
     for (int i = 0; i < N; ++i) {
-      temp = ScalarC(b * h_b_org_z(i, k) + a * h_x(i) * h_y(i, k));
-      EXPECT_NEAR_KK(temp, h_b_z_res(i, k), max_error);
+      temp = ScalarC(b * org_z.h_view(i, k) + a * x.h_view(i) * y.h_view(i, k));
+      EXPECT_NEAR_KK(temp, z.h_view(i, k), max_error);
     }
   }
 }
@@ -390,7 +337,6 @@ int test_team_mult_mv() {
   // view_type_c_lr, Device>(132231,5);
 #endif
 
-  /*
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -414,7 +360,6 @@ int test_team_mult_mv() {
   Test::impl_test_team_mult_mv<view_type_a_ll, view_type_b_ls, view_type_c_lr,
                                Device>(124, 5);
 #endif
-  */
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_team_nrm2.hpp
+++ b/blas/unit_test/Test_Blas1_team_nrm2.hpp
@@ -37,32 +37,20 @@ void impl_test_team_nrm2(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef Kokkos::ArithTraits<ScalarA> AT;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-
-  typename vfA_type::BaseType b_a("A", N, K);
-
-  ViewTypeA a = vfA_type::view(b_a);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-
-  typename h_vfA_type::BaseType h_b_a = Kokkos::create_mirror_view(b_a);
-
-  typename ViewTypeA::HostMirror h_a = h_vfA_type::view(h_b_a);
+  view_stride_adapter<ViewTypeA> a("A", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
-  Kokkos::fill_random(b_a, rand_pool, ScalarA(10));
+  Kokkos::fill_random(a.d_view, rand_pool, ScalarA(10));
 
-  Kokkos::deep_copy(h_b_a, b_a);
-
-  typename ViewTypeA::const_type c_a = a;
+  Kokkos::deep_copy(a.h_base, a.d_base);
 
   typename AT::mag_type *expected_result = new typename AT::mag_type[K];
   for (int j = 0; j < K; j++) {
     expected_result[j] = typename AT::mag_type();
     for (int i = 0; i < N; i++)
-      expected_result[j] += AT::abs(h_a(i, j)) * AT::abs(h_a(i, j));
+      expected_result[j] += AT::abs(a.h_view(i, j)) * AT::abs(a.h_view(i, j));
     expected_result[j] =
         Kokkos::ArithTraits<typename AT::mag_type>::sqrt(expected_result[j]);
   }
@@ -78,7 +66,7 @@ void impl_test_team_nrm2(int N, int K) {
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         d_r(teamId)      = KokkosBlas::Experimental::nrm2(
-            teamMember, Kokkos::subview(a, Kokkos::ALL(), teamId));
+            teamMember, Kokkos::subview(a.d_view, Kokkos::ALL(), teamId));
       });
   Kokkos::deep_copy(r, d_r);
   for (int k = 0; k < K; k++) {
@@ -93,7 +81,7 @@ void impl_test_team_nrm2(int N, int K) {
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         d_r(teamId)      = KokkosBlas::Experimental::nrm2(
-            teamMember, Kokkos::subview(c_a, Kokkos::ALL(), teamId));
+            teamMember, Kokkos::subview(a.d_view_const, Kokkos::ALL(), teamId));
       });
   Kokkos::deep_copy(r, d_r);
   for (int k = 0; k < K; k++) {

--- a/blas/unit_test/Test_Blas1_team_scal.hpp
+++ b/blas/unit_test/Test_Blas1_team_scal.hpp
@@ -41,55 +41,24 @@ void impl_test_team_scal(int N) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef Kokkos::ArithTraits<ScalarA> AT;
 
-  typedef Kokkos::View<
-      ScalarA * [2],
-      typename std::conditional<std::is_same<typename ViewTypeA::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeA;
-  typedef Kokkos::View<
-      ScalarB * [2],
-      typename std::conditional<std::is_same<typename ViewTypeB::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeB;
+  view_stride_adapter<ViewTypeA> x("X", N);
+  view_stride_adapter<ViewTypeB> y("Y", N);
 
   ScalarA a(3);
   typename AT::mag_type eps  = AT::epsilon() * 1000;
   typename AT::mag_type zero = AT::abs(AT::zero());
   typename AT::mag_type one  = AT::abs(AT::one());
 
-  BaseTypeA b_x("X", N);
-  BaseTypeB b_y("Y", N);
-  BaseTypeB b_org_y("Org_Y", N);
-
-  ViewTypeA x                        = Kokkos::subview(b_x, Kokkos::ALL(), 0);
-  ViewTypeB y                        = Kokkos::subview(b_y, Kokkos::ALL(), 0);
-  typename ViewTypeA::const_type c_x = x;
-  typename ViewTypeB::const_type c_y = y;
-
-  typename BaseTypeA::HostMirror h_b_x = Kokkos::create_mirror_view(b_x);
-  typename BaseTypeB::HostMirror h_b_y = Kokkos::create_mirror_view(b_y);
-
-  typename ViewTypeA::HostMirror h_x = Kokkos::subview(h_b_x, Kokkos::ALL(), 0);
-  typename ViewTypeB::HostMirror h_y = Kokkos::subview(h_b_y, Kokkos::ALL(), 0);
-
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
-  Kokkos::fill_random(b_x, rand_pool, ScalarA(1));
-  Kokkos::fill_random(b_y, rand_pool, ScalarB(1));
+  Kokkos::fill_random(x.d_view, rand_pool, ScalarA(1));
 
-  Kokkos::deep_copy(b_org_y, b_y);
-
-  Kokkos::deep_copy(h_b_x, b_x);
-  Kokkos::deep_copy(h_b_y, b_y);
+  Kokkos::deep_copy(x.h_base, x.d_base);
 
   ScalarA expected_result(0);
   for (int i = 0; i < N; i++) {
-    expected_result += ScalarB(a * h_x(i)) * ScalarB(a * h_x(i));
+    expected_result += ScalarB(a * x.h_view(i)) * ScalarB(a * x.h_view(i));
   }
 
   Kokkos::parallel_for(
@@ -99,18 +68,20 @@ void impl_test_team_scal(int N) {
         KokkosBlas::Experimental::scal(
             teamMember,
             Kokkos::subview(
-                y, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                y.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             a,
             Kokkos::subview(
-                x, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
+                x.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
       });
 
   {
-    ScalarB nonconst_nonconst_result = KokkosBlas::dot(y, y);
+    ScalarB nonconst_nonconst_result = KokkosBlas::dot(y.d_view, y.d_view);
     typename AT::mag_type divisor =
         AT::abs(expected_result) == zero ? one : AT::abs(expected_result);
     typename AT::mag_type diff =
@@ -118,7 +89,7 @@ void impl_test_team_scal(int N) {
     EXPECT_NEAR_KK(diff, zero, eps);
   }
 
-  Kokkos::deep_copy(b_y, b_org_y);
+  Kokkos::deep_copy(y.d_view, Kokkos::ArithTraits<ScalarB>::zero());
 
   Kokkos::parallel_for(
       "KokkosBlas::Test::TeamScal", policy,
@@ -127,18 +98,20 @@ void impl_test_team_scal(int N) {
         KokkosBlas::Experimental::scal(
             teamMember,
             Kokkos::subview(
-                y, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                y.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             a,
             Kokkos::subview(
-                c_x, Kokkos::make_pair(
-                         teamId * team_data_siz,
-                         (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
+                x.d_view_const,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
       });
 
   {
-    ScalarB const_nonconst_result = KokkosBlas::dot(y, y);
+    ScalarB const_nonconst_result = KokkosBlas::dot(y.d_view, y.d_view);
     typename AT::mag_type divisor =
         AT::abs(expected_result) == zero ? one : AT::abs(expected_result);
     typename AT::mag_type diff =
@@ -159,44 +132,23 @@ void impl_test_team_scal_mv(int N, int K) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef Kokkos::ArithTraits<ScalarA> AT;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-  typedef multivector_layout_adapter<ViewTypeB> vfB_type;
-
-  typename vfA_type::BaseType b_x("A", N, K);
-  typename vfB_type::BaseType b_y("B", N, K);
-  typename vfB_type::BaseType b_org_y("B", N, K);
-
-  ViewTypeA x = vfA_type::view(b_x);
-  ViewTypeB y = vfB_type::view(b_y);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-  typedef multivector_layout_adapter<typename ViewTypeB::HostMirror> h_vfB_type;
-
-  typename h_vfA_type::BaseType h_b_x = Kokkos::create_mirror_view(b_x);
-  typename h_vfB_type::BaseType h_b_y = Kokkos::create_mirror_view(b_y);
-
-  typename ViewTypeA::HostMirror h_x = h_vfA_type::view(h_b_x);
-  typename ViewTypeB::HostMirror h_y = h_vfB_type::view(h_b_y);
+  view_stride_adapter<ViewTypeA> x("X", N, K);
+  view_stride_adapter<ViewTypeB> y("Y", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
-  Kokkos::fill_random(b_x, rand_pool, ScalarA(1));
-  Kokkos::fill_random(b_y, rand_pool, ScalarB(1));
-
-  Kokkos::deep_copy(b_org_y, b_y);
-
-  Kokkos::deep_copy(h_b_x, b_x);
-  Kokkos::deep_copy(h_b_y, b_y);
+  Kokkos::fill_random(x.d_view, rand_pool, ScalarA(1));
+  Kokkos::deep_copy(x.h_base, x.d_base);
 
   ScalarA a(3);
-  typename ViewTypeA::const_type c_x = x;
 
   ScalarA *expected_result = new ScalarA[K];
   for (int j = 0; j < K; j++) {
     expected_result[j] = ScalarA();
     for (int i = 0; i < N; i++) {
-      expected_result[j] += ScalarB(a * h_x(i, j)) * ScalarB(a * h_x(i, j));
+      expected_result[j] +=
+          ScalarB(a * x.h_view(i, j)) * ScalarB(a * x.h_view(i, j));
     }
   }
 
@@ -211,11 +163,11 @@ void impl_test_team_scal_mv(int N, int K) {
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         KokkosBlas::Experimental::scal(
-            teamMember, Kokkos::subview(y, Kokkos::ALL(), teamId), a,
-            Kokkos::subview(x, Kokkos::ALL(), teamId));
+            teamMember, Kokkos::subview(y.d_view, Kokkos::ALL(), teamId), a,
+            Kokkos::subview(x.d_view, Kokkos::ALL(), teamId));
       });
 
-  KokkosBlas::dot(r, y, y);
+  KokkosBlas::dot(r, y.d_view, y.d_view);
   for (int k = 0; k < K; k++) {
     ScalarA nonconst_scalar_result = r(k);
     typename AT::mag_type divisor =
@@ -225,18 +177,19 @@ void impl_test_team_scal_mv(int N, int K) {
     EXPECT_NEAR_KK(diff, zero, eps);
   }
 
-  Kokkos::deep_copy(b_y, b_org_y);
+  // Zero out y again, and run again with const input
+  Kokkos::deep_copy(y.d_view, Kokkos::ArithTraits<ScalarB>::zero());
 
   Kokkos::parallel_for(
       "KokkosBlas::Test::TeamScal", policy,
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         KokkosBlas::Experimental::scal(
-            teamMember, Kokkos::subview(y, Kokkos::ALL(), teamId), a,
-            Kokkos::subview(c_x, Kokkos::ALL(), teamId));
+            teamMember, Kokkos::subview(y.d_view, Kokkos::ALL(), teamId), a,
+            Kokkos::subview(x.d_view_const, Kokkos::ALL(), teamId));
       });
 
-  KokkosBlas::dot(r, y, y);
+  KokkosBlas::dot(r, y.d_view, y.d_view);
   for (int k = 0; k < K; k++) {
     ScalarA const_scalar_result = r(k);
     typename AT::mag_type divisor =
@@ -258,21 +211,24 @@ void impl_test_team_scal_mv(int N, int K) {
   for (int j = 0; j < K; j++) {
     expected_result[j] = ScalarA();
     for (int i = 0; i < N; i++) {
-      expected_result[j] +=
-          ScalarB((3.0 + j) * h_x(i, j)) * ScalarB((3.0 + j) * h_x(i, j));
+      expected_result[j] += ScalarB((3.0 + j) * x.h_view(i, j)) *
+                            ScalarB((3.0 + j) * x.h_view(i, j));
     }
   }
+
+  // Zero out y to run again
+  Kokkos::deep_copy(y.d_view, Kokkos::ArithTraits<ScalarB>::zero());
 
   Kokkos::parallel_for(
       "KokkosBlas::Test::TeamScal", policy,
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         KokkosBlas::Experimental::scal(
-            teamMember, Kokkos::subview(y, Kokkos::ALL(), teamId),
-            params(teamId), Kokkos::subview(x, Kokkos::ALL(), teamId));
+            teamMember, Kokkos::subview(y.d_view, Kokkos::ALL(), teamId),
+            params(teamId), Kokkos::subview(x.d_view, Kokkos::ALL(), teamId));
       });
 
-  KokkosBlas::dot(r, y, y);
+  KokkosBlas::dot(r, y.d_view, y.d_view);
   for (int k = 0; k < K; k++) {
     ScalarA nonconst_vector_result = r(k);
     typename AT::mag_type divisor =
@@ -282,18 +238,20 @@ void impl_test_team_scal_mv(int N, int K) {
     EXPECT_NEAR_KK(diff, zero, eps);
   }
 
-  Kokkos::deep_copy(b_y, b_org_y);
+  // Zero out y again, and run again with const input
+  Kokkos::deep_copy(y.d_view, Kokkos::ArithTraits<ScalarB>::zero());
 
   Kokkos::parallel_for(
       "KokkosBlas::Test::TeamScal", policy,
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         KokkosBlas::Experimental::scal(
-            teamMember, Kokkos::subview(y, Kokkos::ALL(), teamId),
-            params(teamId), Kokkos::subview(c_x, Kokkos::ALL(), teamId));
+            teamMember, Kokkos::subview(y.d_view, Kokkos::ALL(), teamId),
+            params(teamId),
+            Kokkos::subview(x.d_view_const, Kokkos::ALL(), teamId));
       });
 
-  KokkosBlas::dot(r, y, y);
+  KokkosBlas::dot(r, y.d_view, y.d_view);
   for (int k = 0; k < K; k++) {
     ScalarA const_vector_result = r(k);
     typename AT::mag_type divisor =

--- a/blas/unit_test/Test_Blas1_team_update.hpp
+++ b/blas/unit_test/Test_Blas1_team_update.hpp
@@ -41,69 +41,34 @@ void impl_test_team_update(int N) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef typename ViewTypeC::value_type ScalarC;
 
-  typedef Kokkos::View<
-      ScalarA * [2],
-      typename std::conditional<std::is_same<typename ViewTypeA::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeA;
-  typedef Kokkos::View<
-      ScalarB * [2],
-      typename std::conditional<std::is_same<typename ViewTypeB::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeB;
-  typedef Kokkos::View<
-      ScalarC * [2],
-      typename std::conditional<std::is_same<typename ViewTypeC::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeC;
-
   ScalarA a  = 3;
   ScalarB b  = 5;
   ScalarC c  = 7;
   double eps = std::is_same<ScalarC, float>::value ? 2 * 1e-5 : 1e-7;
 
-  BaseTypeA b_x("X", N);
-  BaseTypeB b_y("Y", N);
-  BaseTypeC b_z("Y", N);
-  BaseTypeC b_org_z("Org_Z", N);
-
-  ViewTypeA x                        = Kokkos::subview(b_x, Kokkos::ALL(), 0);
-  ViewTypeB y                        = Kokkos::subview(b_y, Kokkos::ALL(), 0);
-  ViewTypeC z                        = Kokkos::subview(b_z, Kokkos::ALL(), 0);
-  typename ViewTypeA::const_type c_x = x;
-  typename ViewTypeB::const_type c_y = y;
-
-  typename BaseTypeA::HostMirror h_b_x = Kokkos::create_mirror_view(b_x);
-  typename BaseTypeB::HostMirror h_b_y = Kokkos::create_mirror_view(b_y);
-  typename BaseTypeC::HostMirror h_b_z = Kokkos::create_mirror_view(b_z);
-
-  typename ViewTypeA::HostMirror h_x = Kokkos::subview(h_b_x, Kokkos::ALL(), 0);
-  typename ViewTypeB::HostMirror h_y = Kokkos::subview(h_b_y, Kokkos::ALL(), 0);
-  typename ViewTypeC::HostMirror h_z = Kokkos::subview(h_b_z, Kokkos::ALL(), 0);
+  view_stride_adapter<ViewTypeA> x("X", N);
+  view_stride_adapter<ViewTypeB> y("Y", N);
+  view_stride_adapter<ViewTypeC> z("Z", N);
+  view_stride_adapter<ViewTypeC> org_z("Org_Z", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
-  Kokkos::fill_random(b_x, rand_pool, ScalarA(10));
-  Kokkos::fill_random(b_y, rand_pool, ScalarB(10));
-  Kokkos::fill_random(b_z, rand_pool, ScalarC(10));
+  Kokkos::fill_random(x.d_view, rand_pool, ScalarA(10));
+  Kokkos::fill_random(y.d_view, rand_pool, ScalarB(10));
+  Kokkos::fill_random(z.d_view, rand_pool, ScalarC(10));
 
-  Kokkos::deep_copy(b_org_z, b_z);
+  Kokkos::deep_copy(org_z.h_base, z.d_base);
 
-  Kokkos::deep_copy(h_b_x, b_x);
-  Kokkos::deep_copy(h_b_y, b_y);
-  Kokkos::deep_copy(h_b_z, b_z);
+  Kokkos::deep_copy(x.h_base, x.d_base);
+  Kokkos::deep_copy(y.h_base, y.d_base);
+  Kokkos::deep_copy(z.h_base, z.d_base);
 
   ScalarA expected_result = 0;
   for (int i = 0; i < N; i++)
-    expected_result += ScalarC(c * h_z(i) + a * h_x(i) + b * h_y(i)) *
-                       ScalarC(c * h_z(i) + a * h_x(i) + b * h_y(i));
+    expected_result +=
+        ScalarC(c * z.h_view(i) + a * x.h_view(i) + b * y.h_view(i)) *
+        ScalarC(c * z.h_view(i) + a * x.h_view(i) + b * y.h_view(i));
 
   // KokkosBlas::update(a,x,b,y,c,z);
   Kokkos::parallel_for(
@@ -113,25 +78,28 @@ void impl_test_team_update(int N) {
         KokkosBlas::Experimental::update(
             teamMember, a,
             Kokkos::subview(
-                x, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                x.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             b,
             Kokkos::subview(
-                y, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                y.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             c,
             Kokkos::subview(
-                z, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
+                z.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
       });
-  ScalarC nonconst_nonconst_result = KokkosBlas::dot(z, z);
+  ScalarC nonconst_nonconst_result = KokkosBlas::dot(z.d_view, z.d_view);
   EXPECT_NEAR_KK(nonconst_nonconst_result, expected_result,
                  eps * expected_result);
 
-  Kokkos::deep_copy(b_z, b_org_z);
+  Kokkos::deep_copy(z.d_base, org_z.h_base);
   // KokkosBlas::update(a,c_x,b,y,c,z);
   Kokkos::parallel_for(
       "KokkosBlas::Test::TeamUpdate", policy,
@@ -140,24 +108,27 @@ void impl_test_team_update(int N) {
         KokkosBlas::Experimental::update(
             teamMember, a,
             Kokkos::subview(
-                c_x, Kokkos::make_pair(
-                         teamId * team_data_siz,
-                         (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                x.d_view_const,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             b,
             Kokkos::subview(
-                y, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                y.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             c,
             Kokkos::subview(
-                z, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
+                z.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
       });
-  ScalarC const_nonconst_result = KokkosBlas::dot(z, z);
+  ScalarC const_nonconst_result = KokkosBlas::dot(z.d_view, z.d_view);
   EXPECT_NEAR_KK(const_nonconst_result, expected_result, eps * expected_result);
 
-  Kokkos::deep_copy(b_z, b_org_z);
+  Kokkos::deep_copy(z.d_base, org_z.h_base);
   // KokkosBlas::update(a,c_x,b,c_y,c,z);
   Kokkos::parallel_for(
       "KokkosBlas::Test::TeamUpdate", policy,
@@ -166,21 +137,24 @@ void impl_test_team_update(int N) {
         KokkosBlas::Experimental::update(
             teamMember, a,
             Kokkos::subview(
-                c_x, Kokkos::make_pair(
-                         teamId * team_data_siz,
-                         (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                x.d_view_const,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             b,
             Kokkos::subview(
-                c_y, Kokkos::make_pair(
-                         teamId * team_data_siz,
-                         (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
+                y.d_view_const,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)),
             c,
             Kokkos::subview(
-                z, Kokkos::make_pair(
-                       teamId * team_data_siz,
-                       (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
+                z.d_view,
+                Kokkos::make_pair(
+                    teamId * team_data_siz,
+                    (teamId < M - 1) ? (teamId + 1) * team_data_siz : N)));
       });
-  ScalarC const_const_result = KokkosBlas::dot(z, z);
+  ScalarC const_const_result = KokkosBlas::dot(z.d_view, z.d_view);
   EXPECT_NEAR_KK(const_const_result, expected_result, eps * expected_result);
 }
 
@@ -196,57 +170,36 @@ void impl_test_team_update_mv(int N, int K) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef typename ViewTypeC::value_type ScalarC;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-  typedef multivector_layout_adapter<ViewTypeB> vfB_type;
-  typedef multivector_layout_adapter<ViewTypeC> vfC_type;
-
-  typename vfA_type::BaseType b_x("X", N, K);
-  typename vfB_type::BaseType b_y("Y", N, K);
-  typename vfC_type::BaseType b_z("Z", N, K);
-  typename vfC_type::BaseType b_org_z("Z", N, K);
-
-  ViewTypeA x = vfA_type::view(b_x);
-  ViewTypeB y = vfB_type::view(b_y);
-  ViewTypeC z = vfC_type::view(b_z);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-  typedef multivector_layout_adapter<typename ViewTypeB::HostMirror> h_vfB_type;
-  typedef multivector_layout_adapter<typename ViewTypeC::HostMirror> h_vfC_type;
-
-  typename h_vfA_type::BaseType h_b_x = Kokkos::create_mirror_view(b_x);
-  typename h_vfB_type::BaseType h_b_y = Kokkos::create_mirror_view(b_y);
-  typename h_vfC_type::BaseType h_b_z = Kokkos::create_mirror_view(b_z);
-
-  typename ViewTypeA::HostMirror h_x = h_vfA_type::view(h_b_x);
-  typename ViewTypeB::HostMirror h_y = h_vfB_type::view(h_b_y);
-  typename ViewTypeC::HostMirror h_z = h_vfC_type::view(h_b_z);
+  view_stride_adapter<ViewTypeA> x("X", N, K);
+  view_stride_adapter<ViewTypeB> y("Y", N, K);
+  view_stride_adapter<ViewTypeC> z("Z", N, K);
+  view_stride_adapter<ViewTypeC> org_z("Org_Z", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
 
-  Kokkos::fill_random(b_x, rand_pool, ScalarA(10));
-  Kokkos::fill_random(b_y, rand_pool, ScalarB(10));
-  Kokkos::fill_random(b_z, rand_pool, ScalarC(10));
+  Kokkos::fill_random(x.d_view, rand_pool, ScalarA(10));
+  Kokkos::fill_random(y.d_view, rand_pool, ScalarB(10));
+  Kokkos::fill_random(z.d_view, rand_pool, ScalarC(10));
 
-  Kokkos::deep_copy(b_org_z, b_z);
+  Kokkos::deep_copy(org_z.h_base, z.d_base);
 
-  Kokkos::deep_copy(h_b_x, b_x);
-  Kokkos::deep_copy(h_b_y, b_y);
-  Kokkos::deep_copy(h_b_z, b_z);
+  Kokkos::deep_copy(x.h_base, x.d_base);
+  Kokkos::deep_copy(y.h_base, y.d_base);
+  Kokkos::deep_copy(z.h_base, z.d_base);
 
-  ScalarA a                          = 3;
-  ScalarB b                          = 5;
-  ScalarC c                          = 5;
-  typename ViewTypeA::const_type c_x = x;
-  typename ViewTypeB::const_type c_y = y;
+  ScalarA a = 3;
+  ScalarB b = 5;
+  ScalarC c = 5;
 
   ScalarC *expected_result = new ScalarC[K];
   for (int j = 0; j < K; j++) {
     expected_result[j] = ScalarC();
     for (int i = 0; i < N; i++)
       expected_result[j] +=
-          ScalarC(a * h_x(i, j) + b * h_y(i, j) + c * h_z(i, j)) *
-          ScalarC(a * h_x(i, j) + b * h_y(i, j) + c * h_z(i, j));
+          ScalarC(a * x.h_view(i, j) + b * y.h_view(i, j) +
+                  c * z.h_view(i, j)) *
+          ScalarC(a * x.h_view(i, j) + b * y.h_view(i, j) + c * z.h_view(i, j));
   }
 
   double eps = std::is_same<ScalarC, float>::value ? 2 * 1e-5 : 1e-7;
@@ -259,29 +212,30 @@ void impl_test_team_update_mv(int N, int K) {
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         KokkosBlas::Experimental::update(
-            teamMember, a, Kokkos::subview(x, Kokkos::ALL(), teamId), b,
-            Kokkos::subview(y, Kokkos::ALL(), teamId), c,
-            Kokkos::subview(z, Kokkos::ALL(), teamId));
+            teamMember, a, Kokkos::subview(x.d_view, Kokkos::ALL(), teamId), b,
+            Kokkos::subview(y.d_view, Kokkos::ALL(), teamId), c,
+            Kokkos::subview(z.d_view, Kokkos::ALL(), teamId));
       });
-  KokkosBlas::dot(r, z, z);
+  KokkosBlas::dot(r, z.d_view, z.d_view);
   for (int k = 0; k < K; k++) {
     ScalarA nonconst_nonconst_result = r(k);
     EXPECT_NEAR_KK(nonconst_nonconst_result, expected_result[k],
                    eps * expected_result[k]);
   }
 
-  Kokkos::deep_copy(b_z, b_org_z);
+  Kokkos::deep_copy(z.d_base, org_z.h_base);
   // KokkosBlas::update(a,c_x,b,y,c,z);
   Kokkos::parallel_for(
       "KokkosBlas::Test::TeamUpdate", policy,
       KOKKOS_LAMBDA(const team_member &teamMember) {
         const int teamId = teamMember.league_rank();
         KokkosBlas::Experimental::update(
-            teamMember, a, Kokkos::subview(c_x, Kokkos::ALL(), teamId), b,
-            Kokkos::subview(y, Kokkos::ALL(), teamId), c,
-            Kokkos::subview(z, Kokkos::ALL(), teamId));
+            teamMember, a,
+            Kokkos::subview(x.d_view_const, Kokkos::ALL(), teamId), b,
+            Kokkos::subview(y.d_view, Kokkos::ALL(), teamId), c,
+            Kokkos::subview(z.d_view, Kokkos::ALL(), teamId));
       });
-  KokkosBlas::dot(r, z, z);
+  KokkosBlas::dot(r, z.d_view, z.d_view);
   for (int k = 0; k < K; k++) {
     ScalarA const_non_const_result = r(k);
     EXPECT_NEAR_KK(const_non_const_result, expected_result[k],

--- a/blas/unit_test/Test_Blas1_update.hpp
+++ b/blas/unit_test/Test_Blas1_update.hpp
@@ -27,51 +27,15 @@ void impl_test_update(int N) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef typename ViewTypeC::value_type ScalarC;
 
-  typedef Kokkos::View<
-      ScalarA * [2],
-      typename std::conditional<std::is_same<typename ViewTypeA::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeA;
-  typedef Kokkos::View<
-      ScalarB * [2],
-      typename std::conditional<std::is_same<typename ViewTypeB::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeB;
-  typedef Kokkos::View<
-      ScalarC * [2],
-      typename std::conditional<std::is_same<typename ViewTypeC::array_layout,
-                                             Kokkos::LayoutStride>::value,
-                                Kokkos::LayoutRight, Kokkos::LayoutLeft>::type,
-      Device>
-      BaseTypeC;
-
   ScalarA a  = 3;
   ScalarB b  = 5;
   ScalarC c  = 7;
   double eps = std::is_same<ScalarC, float>::value ? 2 * 1e-5 : 1e-7;
 
-  BaseTypeA b_x("X", N);
-  BaseTypeB b_y("Y", N);
-  BaseTypeC b_z("Y", N);
-  BaseTypeC b_org_z("Org_Z", N);
-
-  ViewTypeA x                        = Kokkos::subview(b_x, Kokkos::ALL(), 0);
-  ViewTypeB y                        = Kokkos::subview(b_y, Kokkos::ALL(), 0);
-  ViewTypeC z                        = Kokkos::subview(b_z, Kokkos::ALL(), 0);
-  typename ViewTypeA::const_type c_x = x;
-  typename ViewTypeB::const_type c_y = y;
-
-  typename BaseTypeA::HostMirror h_b_x = Kokkos::create_mirror_view(b_x);
-  typename BaseTypeB::HostMirror h_b_y = Kokkos::create_mirror_view(b_y);
-  typename BaseTypeC::HostMirror h_b_z = Kokkos::create_mirror_view(b_z);
-
-  typename ViewTypeA::HostMirror h_x = Kokkos::subview(h_b_x, Kokkos::ALL(), 0);
-  typename ViewTypeB::HostMirror h_y = Kokkos::subview(h_b_y, Kokkos::ALL(), 0);
-  typename ViewTypeC::HostMirror h_z = Kokkos::subview(h_b_z, Kokkos::ALL(), 0);
+  view_stride_adapter<ViewTypeA> x("X", N);
+  view_stride_adapter<ViewTypeB> y("Y", N);
+  view_stride_adapter<ViewTypeC> z("Z", N);
+  view_stride_adapter<ViewTypeC> org_z("Org_Z", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
@@ -79,52 +43,48 @@ void impl_test_update(int N) {
   {
     ScalarA randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(b_x, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(b_y, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarC randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(b_z, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(z.d_view, rand_pool, randStart, randEnd);
   }
 
-  Kokkos::deep_copy(b_org_z, b_z);
-  auto h_b_org_z =
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_org_z);
-  auto h_org_z = Kokkos::subview(h_b_org_z, Kokkos::ALL(), 0);
+  Kokkos::deep_copy(org_z.h_base, z.d_base);
 
-  Kokkos::deep_copy(h_b_x, b_x);
-  Kokkos::deep_copy(h_b_y, b_y);
-  Kokkos::deep_copy(h_b_z, b_z);
+  Kokkos::deep_copy(x.h_base, x.d_base);
+  Kokkos::deep_copy(y.h_base, y.d_base);
 
-  KokkosBlas::update(a, x, b, y, c, z);
-  Kokkos::deep_copy(h_b_z, b_z);
+  KokkosBlas::update(a, x.d_view, b, y.d_view, c, z.d_view);
+  Kokkos::deep_copy(z.h_base, z.d_base);
   for (int i = 0; i < N; i++) {
-    EXPECT_NEAR_KK(
-        static_cast<ScalarC>(a * h_x(i) + b * h_y(i) + c * h_org_z(i)), h_z(i),
-        eps);
+    EXPECT_NEAR_KK(static_cast<ScalarC>(a * x.h_view(i) + b * y.h_view(i) +
+                                        c * org_z.h_view(i)),
+                   z.h_view(i), eps);
   }
 
-  Kokkos::deep_copy(b_z, b_org_z);
-  KokkosBlas::update(a, c_x, b, y, c, z);
-  Kokkos::deep_copy(h_b_z, b_z);
+  Kokkos::deep_copy(z.d_base, org_z.h_base);
+  KokkosBlas::update(a, x.d_view_const, b, y.d_view, c, z.d_view);
+  Kokkos::deep_copy(z.h_base, z.d_base);
   for (int i = 0; i < N; i++) {
-    EXPECT_NEAR_KK(
-        static_cast<ScalarC>(a * h_x(i) + b * h_y(i) + c * h_org_z(i)), h_z(i),
-        eps);
+    EXPECT_NEAR_KK(static_cast<ScalarC>(a * x.h_view(i) + b * y.h_view(i) +
+                                        c * org_z.h_view(i)),
+                   z.h_view(i), eps);
   }
 
-  Kokkos::deep_copy(b_z, b_org_z);
-  KokkosBlas::update(a, c_x, b, c_y, c, z);
-  Kokkos::deep_copy(h_b_z, b_z);
+  Kokkos::deep_copy(z.d_base, org_z.h_base);
+  KokkosBlas::update(a, x.d_view_const, b, y.d_view_const, c, z.d_view);
+  Kokkos::deep_copy(z.h_base, z.d_base);
   for (int i = 0; i < N; i++) {
-    EXPECT_NEAR_KK(
-        static_cast<ScalarC>(a * h_x(i) + b * h_y(i) + c * h_org_z(i)), h_z(i),
-        eps);
+    EXPECT_NEAR_KK(static_cast<ScalarC>(a * x.h_view(i) + b * y.h_view(i) +
+                                        c * org_z.h_view(i)),
+                   z.h_view(i), eps);
   }
 }
 
@@ -134,30 +94,10 @@ void impl_test_update_mv(int N, int K) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef typename ViewTypeC::value_type ScalarC;
 
-  typedef multivector_layout_adapter<ViewTypeA> vfA_type;
-  typedef multivector_layout_adapter<ViewTypeB> vfB_type;
-  typedef multivector_layout_adapter<ViewTypeC> vfC_type;
-
-  typename vfA_type::BaseType b_x("X", N, K);
-  typename vfB_type::BaseType b_y("Y", N, K);
-  typename vfC_type::BaseType b_z("Z", N, K);
-  typename vfC_type::BaseType b_org_z("Z", N, K);
-
-  ViewTypeA x = vfA_type::view(b_x);
-  ViewTypeB y = vfB_type::view(b_y);
-  ViewTypeC z = vfC_type::view(b_z);
-
-  typedef multivector_layout_adapter<typename ViewTypeA::HostMirror> h_vfA_type;
-  typedef multivector_layout_adapter<typename ViewTypeB::HostMirror> h_vfB_type;
-  typedef multivector_layout_adapter<typename ViewTypeC::HostMirror> h_vfC_type;
-
-  typename h_vfA_type::BaseType h_b_x = Kokkos::create_mirror_view(b_x);
-  typename h_vfB_type::BaseType h_b_y = Kokkos::create_mirror_view(b_y);
-  typename h_vfC_type::BaseType h_b_z = Kokkos::create_mirror_view(b_z);
-
-  typename ViewTypeA::HostMirror h_x = h_vfA_type::view(h_b_x);
-  typename ViewTypeB::HostMirror h_y = h_vfB_type::view(h_b_y);
-  typename ViewTypeC::HostMirror h_z = h_vfC_type::view(h_b_z);
+  view_stride_adapter<ViewTypeA> x("X", N, K);
+  view_stride_adapter<ViewTypeB> y("Y", N, K);
+  view_stride_adapter<ViewTypeC> z("Z", N, K);
+  view_stride_adapter<ViewTypeC> org_z("Org_Z", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
       13718);
@@ -165,53 +105,50 @@ void impl_test_update_mv(int N, int K) {
   {
     ScalarA randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(b_x, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(b_y, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarC randStart, randEnd;
     Test::getRandomBounds(10.0, randStart, randEnd);
-    Kokkos::fill_random(b_z, rand_pool, randStart, randEnd);
+    Kokkos::fill_random(z.d_view, rand_pool, randStart, randEnd);
   }
 
-  Kokkos::deep_copy(b_org_z, b_z);
-  auto h_b_org_z =
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_org_z);
+  Kokkos::deep_copy(org_z.h_base, z.d_base);
 
-  Kokkos::deep_copy(h_b_x, b_x);
-  Kokkos::deep_copy(h_b_y, b_y);
-  Kokkos::deep_copy(h_b_z, b_z);
+  Kokkos::deep_copy(x.h_base, x.d_base);
+  Kokkos::deep_copy(y.h_base, y.d_base);
 
-  ScalarA a                          = 3;
-  ScalarB b                          = 5;
-  ScalarC c                          = 5;
-  typename ViewTypeA::const_type c_x = x;
-  typename ViewTypeB::const_type c_y = y;
+  ScalarA a = 3;
+  ScalarB b = 5;
+  ScalarC c = 5;
 
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
 
-  KokkosBlas::update(a, x, b, y, c, z);
-  Kokkos::deep_copy(h_b_z, b_z);
+  KokkosBlas::update(a, x.d_view, b, y.d_view, c, z.d_view);
+  Kokkos::deep_copy(z.h_base, z.d_base);
   for (int i = 0; i < N; i++) {
     for (int j = 0; j < K; j++) {
-      EXPECT_NEAR_KK(static_cast<ScalarC>(a * h_x(i, j) + b * h_y(i, j) +
-                                          c * h_b_org_z(i, j)),
-                     h_z(i, j), eps);
+      EXPECT_NEAR_KK(
+          static_cast<ScalarC>(a * x.h_view(i, j) + b * y.h_view(i, j) +
+                               c * org_z.h_view(i, j)),
+          z.h_view(i, j), eps);
     }
   }
 
-  Kokkos::deep_copy(b_z, b_org_z);
-  KokkosBlas::update(a, c_x, b, y, c, z);
-  Kokkos::deep_copy(h_b_z, b_z);
+  Kokkos::deep_copy(z.d_base, org_z.h_base);
+  KokkosBlas::update(a, x.d_view_const, b, y.d_view, c, z.d_view);
+  Kokkos::deep_copy(z.h_base, z.d_base);
   for (int i = 0; i < N; i++) {
     for (int j = 0; j < K; j++) {
-      EXPECT_NEAR_KK(static_cast<ScalarC>(a * h_x(i, j) + b * h_y(i, j) +
-                                          c * h_b_org_z(i, j)),
-                     h_z(i, j), eps);
+      EXPECT_NEAR_KK(
+          static_cast<ScalarC>(a * x.h_view(i, j) + b * y.h_view(i, j) +
+                               c * org_z.h_view(i, j)),
+          z.h_view(i, j), eps);
     }
   }
 }
@@ -251,31 +188,29 @@ int test_update() {
   // Device>(132231);
 #endif
 
-  /*
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
-    typedef Kokkos::View<ScalarB*, Kokkos::LayoutStride, Device> view_type_b_ls;
-    typedef Kokkos::View<ScalarC*, Kokkos::LayoutStride, Device> view_type_c_ls;
-    Test::impl_test_update<view_type_a_ls, view_type_b_ls, view_type_c_ls,
-                           Device>(0);
-    Test::impl_test_update<view_type_a_ls, view_type_b_ls, view_type_c_ls,
-                           Device>(13);
-    Test::impl_test_update<view_type_a_ls, view_type_b_ls, view_type_c_ls,
-                           Device>(1024);
-    // Test::impl_test_update<view_type_a_ls, view_type_b_ls, view_type_c_ls,
-    // Device>(132231);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA*, Kokkos::LayoutStride, Device> view_type_a_ls;
+  typedef Kokkos::View<ScalarB*, Kokkos::LayoutStride, Device> view_type_b_ls;
+  typedef Kokkos::View<ScalarC*, Kokkos::LayoutStride, Device> view_type_c_ls;
+  Test::impl_test_update<view_type_a_ls, view_type_b_ls, view_type_c_ls,
+                         Device>(0);
+  Test::impl_test_update<view_type_a_ls, view_type_b_ls, view_type_c_ls,
+                         Device>(13);
+  Test::impl_test_update<view_type_a_ls, view_type_b_ls, view_type_c_ls,
+                         Device>(1024);
+  // Test::impl_test_update<view_type_a_ls, view_type_b_ls, view_type_c_ls,
+  // Device>(132231);
+#endif
 
-  #if !defined(KOKKOSKERNELS_ETI_ONLY) && \
-      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-    Test::impl_test_update<view_type_a_ls, view_type_b_ll, view_type_c_lr,
-                           Device>(1024);
-    Test::impl_test_update<view_type_a_ll, view_type_b_ls, view_type_c_lr,
-                           Device>(1024);
-  #endif
-  */
+#if !defined(KOKKOSKERNELS_ETI_ONLY) && \
+    !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
+  Test::impl_test_update<view_type_a_ls, view_type_b_ll, view_type_c_lr,
+                         Device>(1024);
+  Test::impl_test_update<view_type_a_ll, view_type_b_ls, view_type_c_lr,
+                         Device>(1024);
+#endif
 
   return 1;
 }
@@ -314,30 +249,29 @@ int test_update_mv() {
                             Device>(132231, 5);
 #endif
 
-  /*
-  #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
-      (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
-       !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-    typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device>
-  view_type_a_ls; typedef Kokkos::View<ScalarB**, Kokkos::LayoutStride, Device>
-  view_type_b_ls; typedef Kokkos::View<ScalarC**, Kokkos::LayoutStride, Device>
-  view_type_c_ls; Test::impl_test_update_mv<view_type_a_ls, view_type_b_ls,
-  view_type_c_ls, Device>(0, 5); Test::impl_test_update_mv<view_type_a_ls,
-  view_type_b_ls, view_type_c_ls, Device>(13, 5);
-    Test::impl_test_update_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls,
-                              Device>(1024, 5);
-    Test::impl_test_update_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls,
-                              Device>(132231, 5);
-  #endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
+     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device> view_type_a_ls;
+  typedef Kokkos::View<ScalarB**, Kokkos::LayoutStride, Device> view_type_b_ls;
+  typedef Kokkos::View<ScalarC**, Kokkos::LayoutStride, Device> view_type_c_ls;
+  Test::impl_test_update_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls,
+                            Device>(0, 5);
+  Test::impl_test_update_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls,
+                            Device>(13, 5);
+  Test::impl_test_update_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls,
+                            Device>(1024, 5);
+  Test::impl_test_update_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls,
+                            Device>(132231, 5);
+#endif
 
-  #if !defined(KOKKOSKERNELS_ETI_ONLY) && \
-      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-    Test::impl_test_update_mv<view_type_a_ls, view_type_b_ll, view_type_c_lr,
-                              Device>(1024, 5);
-    Test::impl_test_update_mv<view_type_a_ll, view_type_b_ls, view_type_c_lr,
-                              Device>(1024, 5);
-  #endif
-  */
+#if !defined(KOKKOSKERNELS_ETI_ONLY) && \
+    !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
+  Test::impl_test_update_mv<view_type_a_ls, view_type_b_ll, view_type_c_lr,
+                            Device>(1024, 5);
+  Test::impl_test_update_mv<view_type_a_ll, view_type_b_ls, view_type_c_lr,
+                            Device>(1024, 5);
+#endif
 
   return 1;
 }

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -63,61 +63,69 @@
 
 namespace Test {
 
-  // Utility class for testing kernels with rank-1 and rank-2 views that may be LayoutStride.
-  // Simplifies making a LayoutStride view of a given size that is actually noncontiguous,
-  // and host-device transfers for checking results on host.
-  //
-  // Constructed with extent, and then provides 4 views as members:
-  //  - d_view
-  //  - h_view
-  //  - d_base
-  //  - h_base
-  // d_view is of type ViewType, and has the extents passed to the constructor.
-  // h_view is a mirror of d_view.
-  // d_base (and its mirror h_base) are contiguous views, so they can be deep-copied to each other.
-  // d_view aliases d_base, and h_view aliases h_base. This means that copying between d_base and h_base
-  //    also copies between d_view and h_view.
+// Utility class for testing kernels with rank-1 and rank-2 views that may be
+// LayoutStride. Simplifies making a LayoutStride view of a given size that is
+// actually noncontiguous, and host-device transfers for checking results on
+// host.
+//
+// Constructed with extent, and then provides 4 views as members:
+//  - d_view
+//  - h_view
+//  - d_base
+//  - h_base
+// d_view is of type ViewType, and has the extents passed to the constructor.
+// h_view is a mirror of d_view.
+// d_base (and its mirror h_base) are contiguous views, so they can be
+// deep-copied to each other. d_view aliases d_base, and h_view aliases h_base.
+// This means that copying between d_base and h_base
+//    also copies between d_view and h_view.
 template <class ViewType>
-struct view_stride_adapter
-{
-  static_assert(Kokkos::is_view_v<ViewType>, "view_stride_adapter: ViewType must be a Kokkos::View");
-  static_assert(ViewType::rank >= 1 && ViewType::rank <= 2, "view_stride_adapter: ViewType must be rank 1 or rank 2");
+struct view_stride_adapter {
+  static_assert(Kokkos::is_view_v<ViewType>,
+                "view_stride_adapter: ViewType must be a Kokkos::View");
+  static_assert(ViewType::rank >= 1 && ViewType::rank <= 2,
+                "view_stride_adapter: ViewType must be rank 1 or rank 2");
 
-  static constexpr bool strided = std::is_same<typename ViewType::array_layout, Kokkos::LayoutStride>::value;
-  static constexpr int rank = ViewType::rank;
+  static constexpr bool strided = std::is_same<typename ViewType::array_layout,
+                                               Kokkos::LayoutStride>::value;
+  static constexpr int rank     = ViewType::rank;
 
   using DView = ViewType;
   using HView = typename DView::HostMirror;
-  //If not strided, the base view types are the same as DView/HView.
-  //But if strided, the base views have one additional dimension, so that d_view/h_view have stride > 1 between consecutive elements.
-  using DViewBase = std::conditional_t<strided, Kokkos::View<typename ViewType::data_type*, Kokkos::LayoutRight, typename ViewType::device_type>, DView>;
+  // If not strided, the base view types are the same as DView/HView.
+  // But if strided, the base views have one additional dimension, so that
+  // d_view/h_view have stride > 1 between consecutive elements.
+  using DViewBase = std::conditional_t<
+      strided,
+      Kokkos::View<typename ViewType::data_type*, Kokkos::LayoutRight,
+                   typename ViewType::device_type>,
+      DView>;
   using HViewBase = typename DViewBase::HostMirror;
 
-  view_stride_adapter(const std::string& label, int m, int n = 1)
-  {
-    if constexpr(rank == 1) {
-      if constexpr(strided) {
+  view_stride_adapter(const std::string& label, int m, int n = 1) {
+    if constexpr (rank == 1) {
+      if constexpr (strided) {
         d_base = DViewBase(label, m, 2);
-        h_base = Kokkos::create_mirror_view(d_base);
+        h_base = Kokkos::create_mirror_view(Kokkos::HostSpace(), d_base);
         d_view = Kokkos::subview(d_base, Kokkos::ALL(), 0);
         h_view = Kokkos::subview(h_base, Kokkos::ALL(), 0);
       } else {
         d_base = DViewBase(label, m);
-        h_base = Kokkos::create_mirror(d_base);
+        h_base = Kokkos::create_mirror_view(Kokkos::HostSpace(), d_base);
         d_view = d_base;
         h_view = h_base;
       }
-    }
-    else {
-      if constexpr(strided) {
+    } else {
+      if constexpr (strided) {
         d_base = DViewBase(label, m, n, 2);
-        h_base = Kokkos::create_mirror_view(d_base);
-        d_view = Kokkos::subview(d_base, Kokkos::ALL(), Kokkos::make_pair(0, n), 0);
-        h_view = Kokkos::subview(h_base, Kokkos::ALL(), Kokkos::make_pair(0, n), 0);
-      }
-      else {
+        h_base = Kokkos::create_mirror_view(Kokkos::HostSpace(), d_base);
+        d_view =
+            Kokkos::subview(d_base, Kokkos::ALL(), Kokkos::make_pair(0, n), 0);
+        h_view =
+            Kokkos::subview(h_base, Kokkos::ALL(), Kokkos::make_pair(0, n), 0);
+      } else {
         d_base = DViewBase(label, m, n);
-        h_base = Kokkos::create_mirror(d_base);
+        h_base = Kokkos::create_mirror_view(Kokkos::HostSpace(), d_base);
         d_view = d_base;
         h_view = h_base;
       }
@@ -125,7 +133,8 @@ struct view_stride_adapter
     d_view_const = d_view;
   }
 
-  // Have both const and nonconst versions of d_view, since we test BLAS with both
+  // Have both const and nonconst versions of d_view (with same underlying
+  // data), since we often test BLAS with both
   DView d_view;
   typename DView::const_type d_view_const;
   HView h_view;


### PR DESCRIPTION
- Fix some build failures in BLAS-1 functions where LayoutStride views are constructed from pointers (fixes #1787)
- Re-enable all LayoutStride testing for BLAS functions when test-eti-only is off
- Refactor BLAS tests to improve consistency and cut ~800 lines of boilerplate from managing LayoutStride views
- In KokkosKernels_TestUtils.hpp, add ``view_stride_adapter<V>``
  - Creates a view of type V (rank 1 or 2) called ``d_view``, and its mirror ``h_view``
  - Also create ``d_base`` and ``h_base``, which are contiguous and can be deep-copied between each other
  - If V is LayoutStride, then ``d_view`` is a subview of ``d_base`` and ``h_view`` is a subview of ``h_base``. Each "base" has an extra innermost dimension of 2 so that each "view" has a nontrivial stride. This is just like Kyungjoo's original BLAS-1 tests, but it works consistently with both rank 1 and rank 2. Before, rank 1 and rank 2 ("mv") were handled differently, and the rank-2 tests were done with contiguous views cast to LayoutStride.
  - If V is not LayoutStride, then ``d_view == d_base`` and ``h_view == h_base``.
  - ``d_view`` can be used in tests to exercise LayoutStride, and ``h_view`` can be used on host to check results