### PR TITLE
scripts: Fix github-DOCS

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          sudo apt install --no-install-recommends doxygen-latex
+          sudo apt install doxygen
           pip install sphinx
           pip install breathe
           pip install sphinx-rtd-theme


### PR DESCRIPTION
Using, `AT: WIP`. There is no need to run the other CI checks on these changes.