### PR TITLE
apt-get update in hosted runner docs check

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          sudo apt install doxygen
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends doxygen-latex
           pip install sphinx
           pip install breathe
           pip install sphinx-rtd-theme


### PR DESCRIPTION
Github suggests this, as the cache may be very out of date to keep builds consistent

https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners