### PR TITLE
New performance test for par_ilut, ginkgo::par_ilut, and spill

### DIFF
--- a/perf_test/Benchmark_Context.hpp
+++ b/perf_test/Benchmark_Context.hpp
@@ -122,18 +122,18 @@ inline auto register_benchmark(const char* name, FuncType func,
                                std::vector<int64_t> args, int repeat,
                                ArgsToCallOp&&... func_args) {
   if (repeat > 0) {
-    return benchmark::RegisterBenchmark(name, func,
-                                        std::forward<ArgsToCallOp>(func_args)...)
-      ->ArgNames(arg_names)
-      ->Args(args)
-      ->UseManualTime()
-      ->Iterations(repeat);
+    return benchmark::RegisterBenchmark(
+               name, func, std::forward<ArgsToCallOp>(func_args)...)
+        ->ArgNames(arg_names)
+        ->Args(args)
+        ->UseManualTime()
+        ->Iterations(repeat);
   } else {
-    return benchmark::RegisterBenchmark(name, func,
-                                        std::forward<ArgsToCallOp>(func_args)...)
-      ->ArgNames(arg_names)
-      ->Args(args)
-      ->UseManualTime();
+    return benchmark::RegisterBenchmark(
+               name, func, std::forward<ArgsToCallOp>(func_args)...)
+        ->ArgNames(arg_names)
+        ->Args(args)
+        ->UseManualTime();
   }
 }
 
@@ -143,21 +143,20 @@ inline auto register_benchmark_real_time(const char* name, FuncType func,
                                          std::vector<int64_t> args, int repeat,
                                          ArgsToCallOp&&... func_args) {
   if (repeat > 0) {
-    return benchmark::RegisterBenchmark(name, func,
-                                 std::forward<ArgsToCallOp>(func_args)...)
+    return benchmark::RegisterBenchmark(
+               name, func, std::forward<ArgsToCallOp>(func_args)...)
         ->ArgNames(arg_names)
         ->Args(args)
         ->UseRealTime()
         ->Iterations(repeat);
   } else {
-    return benchmark::RegisterBenchmark(name, func,
-                                 std::forward<ArgsToCallOp>(func_args)...)
+    return benchmark::RegisterBenchmark(
+               name, func, std::forward<ArgsToCallOp>(func_args)...)
         ->ArgNames(arg_names)
         ->Args(args)
         ->UseRealTime();
   }
 }
-
 
 }  // namespace KokkosKernelsBenchmark
 

--- a/perf_test/Benchmark_Context.hpp
+++ b/perf_test/Benchmark_Context.hpp
@@ -117,25 +117,47 @@ inline void add_benchmark_context(bool verbose = false) {
 }
 
 template <class FuncType, class... ArgsToCallOp>
-inline void register_benchmark(const char* name, FuncType func,
+inline auto register_benchmark(const char* name, FuncType func,
                                std::vector<std::string> arg_names,
                                std::vector<int64_t> args, int repeat,
                                ArgsToCallOp&&... func_args) {
+  if (repeat > 0) {
+    return benchmark::RegisterBenchmark(name, func,
+                                        std::forward<ArgsToCallOp>(func_args)...)
+      ->ArgNames(arg_names)
+      ->Args(args)
+      ->UseManualTime()
+      ->Iterations(repeat);
+  } else {
+    return benchmark::RegisterBenchmark(name, func,
+                                        std::forward<ArgsToCallOp>(func_args)...)
+      ->ArgNames(arg_names)
+      ->Args(args)
+      ->UseManualTime();
+  }
+}
+
+template <class FuncType, class... ArgsToCallOp>
+inline void register_benchmark_real_time(const char* name, FuncType func,
+                                         std::vector<std::string> arg_names,
+                                         std::vector<int64_t> args, int repeat,
+                                         ArgsToCallOp&&... func_args) {
   if (repeat > 0) {
     benchmark::RegisterBenchmark(name, func,
                                  std::forward<ArgsToCallOp>(func_args)...)
         ->ArgNames(arg_names)
         ->Args(args)
-        ->UseManualTime()
+        ->UseRealTime()
         ->Iterations(repeat);
   } else {
     benchmark::RegisterBenchmark(name, func,
                                  std::forward<ArgsToCallOp>(func_args)...)
         ->ArgNames(arg_names)
         ->Args(args)
-        ->UseManualTime();
+        ->UseRealTime();
   }
 }
+
 
 }  // namespace KokkosKernelsBenchmark
 

--- a/perf_test/Benchmark_Context.hpp
+++ b/perf_test/Benchmark_Context.hpp
@@ -143,14 +143,14 @@ inline auto register_benchmark_real_time(const char* name, FuncType func,
                                          std::vector<int64_t> args, int repeat,
                                          ArgsToCallOp&&... func_args) {
   if (repeat > 0) {
-    benchmark::RegisterBenchmark(name, func,
+    return benchmark::RegisterBenchmark(name, func,
                                  std::forward<ArgsToCallOp>(func_args)...)
         ->ArgNames(arg_names)
         ->Args(args)
         ->UseRealTime()
         ->Iterations(repeat);
   } else {
-    benchmark::RegisterBenchmark(name, func,
+    return benchmark::RegisterBenchmark(name, func,
                                  std::forward<ArgsToCallOp>(func_args)...)
         ->ArgNames(arg_names)
         ->Args(args)

--- a/perf_test/Benchmark_Context.hpp
+++ b/perf_test/Benchmark_Context.hpp
@@ -138,7 +138,7 @@ inline auto register_benchmark(const char* name, FuncType func,
 }
 
 template <class FuncType, class... ArgsToCallOp>
-inline void register_benchmark_real_time(const char* name, FuncType func,
+inline auto register_benchmark_real_time(const char* name, FuncType func,
                                          std::vector<std::string> arg_names,
                                          std::vector<int64_t> args, int repeat,
                                          ArgsToCallOp&&... func_args) {

--- a/perf_test/sparse/CMakeLists.txt
+++ b/perf_test/sparse/CMakeLists.txt
@@ -1,22 +1,6 @@
 KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
 KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
-
-set(USE_GINKGO On)
-set(GINKGO_INSTALL_DIR "$ENV{HOME}/ginkgo/install-release-cuda-omp")
-
-if (USE_GINKGO)
-  add_compile_definitions("USE_GINKGO")
-  KOKKOSKERNELS_INCLUDE_DIRECTORIES("${GINKGO_INSTALL_DIR}/include")
-
-  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo.so")
-  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_omp.so")
-  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_cuda.so")
-  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_hip.so")
-  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_dpcpp.so")
-  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_device.so")
-endif()
-
 IF(KOKKOSKERNELS_INST_DOUBLE)
   KOKKOSKERNELS_ADD_EXECUTABLE(
           sparse_pcg
@@ -136,3 +120,13 @@ KOKKOSKERNELS_ADD_EXECUTABLE(
         sparse_mdf
         SOURCES KokkosSparse_mdf.cpp
 )
+
+# Provide -DGinkgo_DIR to cmake to enable the ginkgo test in sparse_par_ilut. Ginkgo_DIR should
+# point to the dir in the ginkgo install area that contains the GinkgoConfig.cmake file.
+# For me, this was $gingko_install_dir/lib64/cmake/Ginkgo
+if (Ginkgo_DIR)
+  find_package(Ginkgo REQUIRED)
+
+  target_compile_definitions(sparse_par_ilut PRIVATE "USE_GINKGO")
+  target_link_libraries(sparse_par_ilut PRIVATE Ginkgo::ginkgo)
+endif()

--- a/perf_test/sparse/CMakeLists.txt
+++ b/perf_test/sparse/CMakeLists.txt
@@ -3,7 +3,7 @@ KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
 
 set(USE_GINKGO On)
-set(GINKGO_INSTALL_DIR "/ascldap/users/jgfouca/ginkgo/install-release")
+set(GINKGO_INSTALL_DIR "$ENV{HOME}/ginkgo/install-release-cuda-omp")
 
 if (USE_GINKGO)
   add_compile_definitions("USE_GINKGO")

--- a/perf_test/sparse/CMakeLists.txt
+++ b/perf_test/sparse/CMakeLists.txt
@@ -6,8 +6,15 @@ set(USE_GINKGO On)
 set(GINKGO_INSTALL_DIR "/ascldap/users/jgfouca/ginkgo/install")
 
 if (USE_GINKGO)
-  add_compile_definitions("-DUSE_GINKGO")
+  add_compile_definitions("USE_GINKGO")
   KOKKOSKERNELS_INCLUDE_DIRECTORIES("${GINKGO_INSTALL_DIR}/include")
+
+  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgod.so")
+  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_ompd.so")
+  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_cudad.so")
+  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_hipd.so")
+  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_dpcppd.so")
+  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_deviced.so")
 endif()
 
 IF(KOKKOSKERNELS_INST_DOUBLE)
@@ -129,12 +136,3 @@ KOKKOSKERNELS_ADD_EXECUTABLE(
         sparse_mdf
         SOURCES KokkosSparse_mdf.cpp
 )
-
-if (USE_GINKGO)
-  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgod.so")
-  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_ompd.so")
-  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_cudad.so")
-  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_hipd.so")
-  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_dpcppd.so")
-  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_deviced.so")
-endif()

--- a/perf_test/sparse/CMakeLists.txt
+++ b/perf_test/sparse/CMakeLists.txt
@@ -3,18 +3,18 @@ KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
 
 set(USE_GINKGO On)
-set(GINKGO_INSTALL_DIR "/ascldap/users/jgfouca/ginkgo/install")
+set(GINKGO_INSTALL_DIR "/ascldap/users/jgfouca/ginkgo/install-release")
 
 if (USE_GINKGO)
   add_compile_definitions("USE_GINKGO")
   KOKKOSKERNELS_INCLUDE_DIRECTORIES("${GINKGO_INSTALL_DIR}/include")
 
-  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgod.so")
-  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_ompd.so")
-  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_cudad.so")
-  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_hipd.so")
-  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_dpcppd.so")
-  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_deviced.so")
+  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo.so")
+  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_omp.so")
+  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_cuda.so")
+  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_hip.so")
+  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_dpcpp.so")
+  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_device.so")
 endif()
 
 IF(KOKKOSKERNELS_INST_DOUBLE)

--- a/perf_test/sparse/CMakeLists.txt
+++ b/perf_test/sparse/CMakeLists.txt
@@ -1,6 +1,15 @@
 KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
 KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 
+
+set(USE_GINKGO On)
+set(GINKGO_INSTALL_DIR "/ascldap/users/jgfouca/ginkgo/install")
+
+if (USE_GINKGO)
+  add_compile_definitions("-DUSE_GINKGO")
+  KOKKOSKERNELS_INCLUDE_DIRECTORIES("${GINKGO_INSTALL_DIR}/include")
+endif()
+
 IF(KOKKOSKERNELS_INST_DOUBLE)
   KOKKOSKERNELS_ADD_EXECUTABLE(
           sparse_pcg
@@ -112,6 +121,20 @@ KOKKOSKERNELS_ADD_EXECUTABLE(
 )
 
 KOKKOSKERNELS_ADD_EXECUTABLE(
+        sparse_par_ilut
+        SOURCES KokkosSparse_par_ilut.cpp
+)
+
+KOKKOSKERNELS_ADD_EXECUTABLE(
         sparse_mdf
         SOURCES KokkosSparse_mdf.cpp
 )
+
+if (USE_GINKGO)
+  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgod.so")
+  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_ompd.so")
+  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_cudad.so")
+  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_hipd.so")
+  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_dpcppd.so")
+  link_libraries("${GINKGO_INSTALL_DIR}/lib64/libginkgo_deviced.so")
+endif()

--- a/perf_test/sparse/CMakeLists.txt
+++ b/perf_test/sparse/CMakeLists.txt
@@ -112,21 +112,23 @@ KOKKOSKERNELS_ADD_EXECUTABLE(
 )
 
 KOKKOSKERNELS_ADD_EXECUTABLE(
-        sparse_par_ilut
-        SOURCES KokkosSparse_par_ilut.cpp
-)
-
-KOKKOSKERNELS_ADD_EXECUTABLE(
         sparse_mdf
         SOURCES KokkosSparse_mdf.cpp
 )
 
-# Provide -DGinkgo_DIR to cmake to enable the ginkgo test in sparse_par_ilut. Ginkgo_DIR should
-# point to the dir in the ginkgo install area that contains the GinkgoConfig.cmake file.
-# For me, this was $gingko_install_dir/lib64/cmake/Ginkgo
-if (Ginkgo_DIR)
-  find_package(Ginkgo REQUIRED)
+if (KokkosKernels_ENABLE_BENCHMARK)
+  KOKKOSKERNELS_ADD_BENCHMARK(
+    sparse_par_ilut
+    SOURCES KokkosSparse_par_ilut.cpp
+  )
 
-  target_compile_definitions(sparse_par_ilut PRIVATE "USE_GINKGO")
-  target_link_libraries(sparse_par_ilut PRIVATE Ginkgo::ginkgo)
+  # Provide -DGinkgo_DIR to cmake to enable the ginkgo test in sparse_par_ilut. Ginkgo_DIR should
+  # point to the dir in the ginkgo install area that contains the GinkgoConfig.cmake file.
+  # For me, this was $gingko_install_dir/lib64/cmake/Ginkgo
+  if (Ginkgo_DIR)
+    find_package(Ginkgo REQUIRED)
+
+    target_compile_definitions(sparse_par_ilut PRIVATE "USE_GINKGO")
+    target_link_libraries(sparse_par_ilut PRIVATE Ginkgo::ginkgo)
+  endif()
 endif()

--- a/perf_test/sparse/KokkosSparse_par_ilut.cpp
+++ b/perf_test/sparse/KokkosSparse_par_ilut.cpp
@@ -69,7 +69,7 @@ using float_t = typename Kokkos::ArithTraits<scalar_t>::mag_type;
 
 ///////////////////////////////////////////////////////////////////////////////
 int run_par_ilut_test(KernelHandle& kh, const sp_matrix_type& A,
-                      const int rows, const int team_size, const int loop)
+                      const int rows, const int loop)
 ///////////////////////////////////////////////////////////////////////////////
 {
   auto par_ilut_handle = kh.get_par_ilut_handle();
@@ -166,7 +166,7 @@ std::shared_ptr<gko::CudaExecutor> get_ginkgo_exec<gko::CudaExecutor>()
 
 ///////////////////////////////////////////////////////////////////////////////
 void run_par_ilut_test_ginkgo(KernelHandle& kh, const sp_matrix_type& A,
-                              const int rows, const int team_size, const int loop, const int num_iters)
+                              const int rows, const int loop, const int num_iters)
 ///////////////////////////////////////////////////////////////////////////////
 {
   auto par_ilut_handle = kh.get_par_ilut_handle();
@@ -334,12 +334,12 @@ int test_par_ilut_perf(const int rows, const int nnz_per_row, const int bandwidt
 
   int num_iters = 6;
   if (test & 1) {
-    num_iters = run_par_ilut_test(kh, A, rows, team_size, loop);
+    num_iters = run_par_ilut_test(kh, A, rows, loop);
   }
 
 #ifdef USE_GINKGO
   if (test & 2) {
-    run_par_ilut_test_ginkgo(kh, A, rows, team_size, loop, num_iters);
+    run_par_ilut_test_ginkgo(kh, A, rows, loop, num_iters);
   }
 #endif
 

--- a/perf_test/sparse/KokkosSparse_par_ilut.cpp
+++ b/perf_test/sparse/KokkosSparse_par_ilut.cpp
@@ -158,7 +158,7 @@ std::shared_ptr<GinkgoT> get_ginkgo_exec()
 template <>
 std::shared_ptr<gko::CudaExecutor> get_ginkgo_exec<gko::CudaExecutor>()
 {
-  auto ref_exec = gko::OmpExecutor::create();
+  auto ref_exec = gko::ReferenceExecutor::create();
   return gko::CudaExecutor::create(0 /*device id*/, ref_exec);
 }
 

--- a/perf_test/sparse/KokkosSparse_par_ilut.cpp
+++ b/perf_test/sparse/KokkosSparse_par_ilut.cpp
@@ -211,6 +211,7 @@ void run_spiluk_test(KernelHandle& kh, const sp_matrix_type& A,
   const size_type handle_nnz = EXPAND_FACT * A.nnz() * (fill_lev + 1);
   kh.create_spiluk_handle(SPILUKAlgorithm::SEQLVLSCHD_TP1, rows, handle_nnz, handle_nnz);
   auto spiluk_handle = kh.get_spiluk_handle();
+  spiluk_handle->set_team_size(team_size);
 
   // Pull out views from CRS
   auto A_row_map = A.graph.row_map;

--- a/perf_test/sparse/KokkosSparse_par_ilut.cpp
+++ b/perf_test/sparse/KokkosSparse_par_ilut.cpp
@@ -1,0 +1,289 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <cstdio>
+
+#include <ctime>
+#include <cstring>
+#include <cstdlib>
+#include <limits>
+#include <cmath>
+#include <unordered_map>
+#include <iomanip>  // std::setprecision
+
+#include <Kokkos_Core.hpp>
+
+#include "KokkosSparse_Utils.hpp"
+#include "KokkosSparse_spiluk.hpp"
+#include "KokkosSparse_par_ilut.hpp"
+#include "KokkosSparse_spmv.hpp"
+#include "KokkosBlas1_nrm2.hpp"
+#include "KokkosSparse_CrsMatrix.hpp"
+#include "KokkosKernels_default_types.hpp"
+#include <KokkosKernels_IOUtils.hpp>
+#include <KokkosSparse_IOUtils.hpp>
+
+#ifdef USE_GINKGO
+#include <ginkgo/ginkgo.hpp>
+#endif
+
+struct RunPerfTest {
+
+  // Build up useful types
+  using scalar_t  = default_scalar;
+  using lno_t     = default_lno_t;
+  using size_type = default_size_type;
+  using exe_space = Kokkos::DefaultExecutionSpace;
+  using mem_space = typename exe_space::memory_space;
+
+  using RowMapType  = Kokkos::View<size_type*, device>;
+  using EntriesType = Kokkos::View<lno_t*, device>;
+  using ValuesType  = Kokkos::View<scalar_t*, device>;
+
+  using device = Kokkos::Device<exe_space, mem_space>;
+
+  using sp_matrix_type =
+      KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>;
+  using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<
+      size_type, lno_t, scalar_t, exe_space, mem_space, mem_space>;
+  using float_t = typename Kokkos::ArithTraits<scalar_t>::mag_type;
+
+  /////////////////////////////////////////////////////////////////////////////
+  void run_par_ilut_test(KernelHandle& kh, const sp_matrix_type& A, int rows, int team_size, int loop)
+  /////////////////////////////////////////////////////////////////////////////
+  {
+    auto par_ilut_handle = kh.get_par_ilut_handle();
+
+    // Pull out views from CRS
+    auto A_row_map = A.graph.row_map;
+    auto A_entries = A.graph.entries;
+    auto A_values  = A.values;
+
+    // Allocate L and U CRS views as outputs
+    RowMapType L_row_map("L_row_map", numRows + 1);
+    RowMapType U_row_map("U_row_map", numRows + 1);
+    RowMapType L_row_map_orig("L_row_map", numRows + 1);
+    RowMapType U_row_map_orig("U_row_map", numRows + 1);
+
+    // Initial L/U approximations for A
+    par_ilut_symbolic(&kh, row_map, entries, L_row_map, U_row_map);
+
+    const size_type nnzL = par_ilut_handle->get_nnzL();
+    const size_type nnzU = par_ilut_handle->get_nnzU();
+
+    EntriesType L_entries("L_entries", nnzL);
+    ValuesType L_values("L_values", nnzL);
+    EntriesType U_entries("U_entries", nnzU);
+    ValuesType U_values("U_values", nnzU);
+
+    Kokkos::Timer timer;
+    double min_time = std::numeric_limits<double>::infinity();
+    double max_time = 0.0;
+    double ave_time = 0.0;
+    for (int i = 0; i < loop; ++i) {
+      timer.reset();
+      par_ilut_numeric(&kh, A_row_map, A_entries, A_values, L_row_map, L_entries,
+                       L_values, U_row_map, U_entries, U_values);
+      Kokkos::fence();
+      double time = timer.seconds();
+      ave_time += time;
+      if (time > max_time) max_time = time;
+      if (time < min_time) min_time = time;
+    }
+
+    std::cout << "PAR_ILUT LOOP_AVG_TIME:  " << ave_time / loop << std::endl;
+    std::cout << "PAR_ILUT LOOP_MAX_TIME:  " << max_time << std::endl;
+    std::cout << "PAR_ILUT LOOP_MIN_TIME:  " << min_time << std::endl;
+  }
+
+#ifdef USE_GINKGO
+  /////////////////////////////////////////////////////////////////////////////
+  void run_par_ilut_test_ginkgo(const sp_matrix_type& A, int rows, int team_size, int loop)
+  /////////////////////////////////////////////////////////////////////////////
+  {
+    // Use ginko!
+
+    using mtx = gko::matrix::Csr<scalar_t, lno_t>;
+    auto exec = gko::OmpExecutor::create();
+
+    EntriesType A_row_map_cp("A_row_map_cp", numRows+1);
+    for (size_type i = 0; i < row_map.extent(0); ++i) {
+      A_row_map_cp(i) = row_map(i);
+    }
+
+    // Populate mtx
+    auto a_mtx_uniq = mtx::create_const(exec, gko::dim<2>(n, n),
+                                        gko::array<scalar_t>::const_view(exec, values.extent(0), values.data()),
+                                        gko::array<lno_t>::const_view(exec, entries.extent(0), entries.data()),
+                                        gko::array<lno_t>::const_view(exec, A_row_map_cp.extent(0), A_row_map_cp.data()));
+
+    std::shared_ptr<const mtx> a_mtx = std::move(a_mtx_uniq);
+
+    auto fact = gko::factorization::ParIlut<scalar_t, lno_t>::build()
+      .with_fill_in_limit(par_ilut_handle->get_fill_in_limit())
+      .with_approximate_select(false)
+      .on(exec)->generate(a_mtx);
+  }
+#endif
+
+  /////////////////////////////////////////////////////////////////////////////
+  int test_par_ilut_perf(int rows, int nnz_per_row, float bandwidth_per_nnz,
+                         int team_size, int loop)
+  /////////////////////////////////////////////////////////////////////////////
+  {
+    // Generate A
+    const size_type nnz   = rows * nnz_per_row;
+    const lno_t bandwidth = nnz_per_row * bandwidth_per_nnz;
+    const lno_t row_size_variance = 0;
+    const scalar_t diag_dominance = 1;
+    auto A = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<
+      sp_matrix_type>(rows, rows, nnz, row_size_variance, bandwidth, diag_dominance);
+
+    KokkosSparse::sort_crs_matrix(A);
+
+    KernelHandle kh;
+    kh.create_par_ilut_handle();
+
+    run_par_ilut_test(kh, A, rows, team_size, loop);
+
+#ifdef USE_GINKGO
+    run_par_ilut_test_ginkgo(A, rows, team_size, loop);
+#endif
+
+    return 0;
+  }
+
+};
+
+void print_help_par_ilut() {
+  printf("Options:\n");
+  printf("  --test [OPTION] : Use different kernel implementations\n");
+  printf("                    Options:\n");
+  printf("                      lvlrp, lvltp1, lvltp2\n\n");
+  printf(
+      "  -f [file]       : Read in Matrix Market formatted text file "
+      "'file'.\n");
+  //  printf("  -s [N]          : generate a semi-random banded (band size
+  //  0.01xN) NxN matrix\n"); printf("                    with average of 10
+  //  entries per row.\n"); printf("  --schedule [SCH]: Set schedule for kk
+  //  variant (static,dynamic,auto [ default ]).\n"); printf("  -afb [file] :
+  //  Read in binary Matrix files 'file'.\n"); printf("  --write-binary  : In
+  //  combination with -f, generate binary files.\n"); printf("  --offset [O] :
+  //  Subtract O from every index.\n"); printf("                    Useful in
+  //  case the matrix market file is not 0 based.\n\n");
+  printf("  -k [K]          : Fill level (default: 0)\n");
+  printf("  -ts [T]         : Number of threads per team.\n");
+  printf(
+      "  -vl [V]         : Vector-length (i.e. how many Cuda threads are a "
+      "Kokkos 'thread').\n");
+  printf(
+      "  --loop [LOOP]   : How many runs to aggregate average time. "
+      "\n");
+}
+
+int main(int argc, char **argv) {
+  std::vector<int> tests;
+
+  std::string afilename;
+
+  int kin           = 0;
+  int vector_length = -1;
+  int team_size     = -1;
+  // int idx_offset = 0;
+  int loop = 1;
+  // int schedule=AUTO;
+
+  if (argc == 1) {
+    print_help_par_ilut();
+    return 0;
+  }
+
+  for (int i = 0; i < argc; i++) {
+    if ((strcmp(argv[i], "--test") == 0)) {
+      i++;
+      if ((strcmp(argv[i], "lvlrp") == 0)) {
+        tests.push_back(LVLSCHED_RP);
+      }
+      if ((strcmp(argv[i], "lvltp1") == 0)) {
+        tests.push_back(LVLSCHED_TP1);
+      }
+      /*
+            if((strcmp(argv[i],"lvltp2")==0)) {
+              tests.push_back( LVLSCHED_TP2 );
+            }
+      */
+      continue;
+    }
+    if ((strcmp(argv[i], "-f") == 0)) {
+      afilename = argv[++i];
+      continue;
+    }
+    if ((strcmp(argv[i], "-k") == 0)) {
+      kin = atoi(argv[++i]);
+      continue;
+    }
+    if ((strcmp(argv[i], "-ts") == 0)) {
+      team_size = atoi(argv[++i]);
+      continue;
+    }
+    if ((strcmp(argv[i], "-vl") == 0)) {
+      vector_length = atoi(argv[++i]);
+      continue;
+    }
+    // if((strcmp(argv[i],"--offset")==0)) {idx_offset = atoi(argv[++i]);
+    // continue;}
+    if ((strcmp(argv[i], "--loop") == 0)) {
+      loop = atoi(argv[++i]);
+      continue;
+    }
+    /*
+        if((strcmp(argv[i],"-afb")==0)) {afilename = argv[++i]; binaryfile =
+       true; continue;} if((strcmp(argv[i],"--schedule")==0)) { i++;
+          if((strcmp(argv[i],"auto")==0))
+            schedule = AUTO;
+          if((strcmp(argv[i],"dynamic")==0))
+            schedule = DYNAMIC;
+          if((strcmp(argv[i],"static")==0))
+            schedule = STATIC;
+          continue;
+        }
+    */
+    if ((strcmp(argv[i], "--help") == 0) || (strcmp(argv[i], "-h") == 0)) {
+      print_help_par_ilut();
+      return 0;
+    }
+  }
+
+  if (tests.size() == 0) {
+    tests.push_back(DEFAULT);
+  }
+  for (size_t i = 0; i < tests.size(); ++i) {
+    std::cout << "tests[" << i << "] = " << tests[i] << std::endl;
+  }
+
+  Kokkos::initialize(argc, argv);
+  {
+    int total_errors = test_par_perf(tests, afilename, kin, team_size,
+                                        vector_length, /*idx_offset,*/ loop);
+
+    if (total_errors == 0)
+      printf("Kokkos::PAR_ILUT Test: Passed\n");
+    else
+      printf("Kokkos::PAR_ILUT Test: Failed\n");
+  }
+  Kokkos::finalize();
+  return 0;
+}

--- a/perf_test/sparse/KokkosSparse_par_ilut.cpp
+++ b/perf_test/sparse/KokkosSparse_par_ilut.cpp
@@ -42,11 +42,11 @@
 
 namespace {
 
-using KokkosSparse::Experimental::par_ilut_symbolic;
 using KokkosSparse::Experimental::par_ilut_numeric;
+using KokkosSparse::Experimental::par_ilut_symbolic;
 
-using KokkosSparse::Experimental::spiluk_symbolic;
 using KokkosSparse::Experimental::spiluk_numeric;
+using KokkosSparse::Experimental::spiluk_symbolic;
 using KokkosSparse::Experimental::SPILUKAlgorithm;
 
 // Build up useful types
@@ -62,14 +62,14 @@ using EntriesType = Kokkos::View<lno_t*, device>;
 using ValuesType  = Kokkos::View<scalar_t*, device>;
 
 using sp_matrix_type =
-  KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>;
+    KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>;
 using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<
-  size_type, lno_t, scalar_t, exe_space, mem_space, mem_space>;
+    size_type, lno_t, scalar_t, exe_space, mem_space, mem_space>;
 using float_t = typename Kokkos::ArithTraits<scalar_t>::mag_type;
 
 ///////////////////////////////////////////////////////////////////////////////
-int run_par_ilut_test(KernelHandle& kh, const sp_matrix_type& A,
-                      const int rows, const int loop)
+int run_par_ilut_test(KernelHandle& kh, const sp_matrix_type& A, const int rows,
+                      const int loop)
 ///////////////////////////////////////////////////////////////////////////////
 {
   auto par_ilut_handle = kh.get_par_ilut_handle();
@@ -93,9 +93,9 @@ int run_par_ilut_test(KernelHandle& kh, const sp_matrix_type& A,
   double min_time = std::numeric_limits<double>::infinity();
   double max_time = 0.0;
   double ave_time = 0.0;
-  int num_iters = -1;
-  size_type nnzL = 0;
-  size_type nnzU = 0;
+  int num_iters   = -1;
+  size_type nnzL  = 0;
+  size_type nnzU  = 0;
   for (int i = 0; i < loop; ++i) {
     // Run par_ilut
     timer.reset();
@@ -119,7 +119,8 @@ int run_par_ilut_test(KernelHandle& kh, const sp_matrix_type& A,
 
     // Check worked
     num_iters = par_ilut_handle->get_num_iters();
-    KK_REQUIRE_MSG(num_iters < par_ilut_handle->get_max_iter(), "par_ilut hit max iters");
+    KK_REQUIRE_MSG(num_iters < par_ilut_handle->get_max_iter(),
+                   "par_ilut hit max iters");
 
     // Measure time
     double time = timer.seconds();
@@ -132,7 +133,8 @@ int run_par_ilut_test(KernelHandle& kh, const sp_matrix_type& A,
     Kokkos::deep_copy(U_row_map, 0);
 
     // Report run so user knows something is happening
-    std::cout << "PAR_ILUT Finished a run in:  " << time << " seconds and " << num_iters << " iters" << std::endl;
+    std::cout << "PAR_ILUT Finished a run in:  " << time << " seconds and "
+              << num_iters << " iters" << std::endl;
   }
 
   std::cout << "PAR_ILUT LOOP_AVG_TIME:  " << ave_time / loop << std::endl;
@@ -144,20 +146,17 @@ int run_par_ilut_test(KernelHandle& kh, const sp_matrix_type& A,
 
 #ifdef USE_GINKGO
 ///////////////////////////////////////////////////////////////////////////////
-using ginkgo_exec = std::conditional_t<
-  KokkosKernels::Impl::kk_is_gpu_exec_space<exe_space>(),
-  gko::CudaExecutor,
-  gko::OmpExecutor>;
+using ginkgo_exec =
+    std::conditional_t<KokkosKernels::Impl::kk_is_gpu_exec_space<exe_space>(),
+                       gko::CudaExecutor, gko::OmpExecutor>;
 
 template <typename GinkgoT>
-std::shared_ptr<GinkgoT> get_ginkgo_exec()
-{
+std::shared_ptr<GinkgoT> get_ginkgo_exec() {
   return GinkgoT::create();
 }
 
 template <>
-std::shared_ptr<gko::CudaExecutor> get_ginkgo_exec<gko::CudaExecutor>()
-{
+std::shared_ptr<gko::CudaExecutor> get_ginkgo_exec<gko::CudaExecutor>() {
   auto ref_exec = gko::ReferenceExecutor::create();
   return gko::CudaExecutor::create(0 /*device id*/, ref_exec);
 }
@@ -166,7 +165,8 @@ std::shared_ptr<gko::CudaExecutor> get_ginkgo_exec<gko::CudaExecutor>()
 
 ///////////////////////////////////////////////////////////////////////////////
 void run_par_ilut_test_ginkgo(KernelHandle& kh, const sp_matrix_type& A,
-                              const int rows, const int loop, const int num_iters)
+                              const int rows, const int loop,
+                              const int num_iters)
 ///////////////////////////////////////////////////////////////////////////////
 {
   auto par_ilut_handle = kh.get_par_ilut_handle();
@@ -182,15 +182,18 @@ void run_par_ilut_test_ginkgo(KernelHandle& kh, const sp_matrix_type& A,
 
   // ginkgo does not differentiate between index type and size type. We need
   // to convert A_row_map to lno_t.
-  EntriesType A_row_map_cp("A_row_map_cp", rows+1);
+  EntriesType A_row_map_cp("A_row_map_cp", rows + 1);
   Kokkos::deep_copy(A_row_map_cp, A_row_map);
 
   // Populate mtx
-  auto a_mtx_uniq = mtx::create_const(
-    exec, gko::dim<2>(rows, rows),
-    gko::array<scalar_t>::const_view(exec, A_values.extent(0), A_values.data()),
-    gko::array<lno_t>::const_view(exec, A_entries.extent(0), A_entries.data()),
-    gko::array<lno_t>::const_view(exec, A_row_map_cp.extent(0), A_row_map_cp.data()));
+  auto a_mtx_uniq =
+      mtx::create_const(exec, gko::dim<2>(rows, rows),
+                        gko::array<scalar_t>::const_view(
+                            exec, A_values.extent(0), A_values.data()),
+                        gko::array<lno_t>::const_view(exec, A_entries.extent(0),
+                                                      A_entries.data()),
+                        gko::array<lno_t>::const_view(
+                            exec, A_row_map_cp.extent(0), A_row_map_cp.data()));
 
   std::shared_ptr<const mtx> a_mtx = std::move(a_mtx_uniq);
 
@@ -201,10 +204,11 @@ void run_par_ilut_test_ginkgo(KernelHandle& kh, const sp_matrix_type& A,
   for (int i = 0; i < loop; ++i) {
     timer.reset();
     auto fact = gko::factorization::ParIlut<scalar_t, lno_t>::build()
-      .with_fill_in_limit(par_ilut_handle->get_fill_in_limit())
-      .with_approximate_select(false)
-      .with_iterations(num_iters)
-      .on(exec)->generate(a_mtx);
+                    .with_fill_in_limit(par_ilut_handle->get_fill_in_limit())
+                    .with_approximate_select(false)
+                    .with_iterations(num_iters)
+                    .on(exec)
+                    ->generate(a_mtx);
 
     double time = timer.seconds();
     ave_time += time;
@@ -212,7 +216,8 @@ void run_par_ilut_test_ginkgo(KernelHandle& kh, const sp_matrix_type& A,
     if (time < min_time) min_time = time;
 
     // Report run so user knows something is happening
-    std::cout << "GINKGO Finished a run in:  " << time << " seconds" << std::endl;
+    std::cout << "GINKGO Finished a run in:  " << time << " seconds"
+              << std::endl;
   }
 
   std::cout << "GINKGO LOOP_AVG_TIME:  " << ave_time / loop << std::endl;
@@ -222,14 +227,15 @@ void run_par_ilut_test_ginkgo(KernelHandle& kh, const sp_matrix_type& A,
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-void run_spiluk_test(KernelHandle& kh, const sp_matrix_type& A,
-                     const int rows, const int team_size, const int loop)
+void run_spiluk_test(KernelHandle& kh, const sp_matrix_type& A, const int rows,
+                     const int team_size, const int loop)
 ///////////////////////////////////////////////////////////////////////////////
 {
-  constexpr int EXPAND_FACT = 10;
-  const lno_t fill_lev = 2;
+  constexpr int EXPAND_FACT  = 10;
+  const lno_t fill_lev       = 2;
   const size_type handle_nnz = EXPAND_FACT * A.nnz() * (fill_lev + 1);
-  kh.create_spiluk_handle(SPILUKAlgorithm::SEQLVLSCHD_TP1, rows, handle_nnz, handle_nnz);
+  kh.create_spiluk_handle(SPILUKAlgorithm::SEQLVLSCHD_TP1, rows, handle_nnz,
+                          handle_nnz);
   auto spiluk_handle = kh.get_spiluk_handle();
   spiluk_handle->set_team_size(team_size);
 
@@ -255,7 +261,8 @@ void run_spiluk_test(KernelHandle& kh, const sp_matrix_type& A,
   for (int i = 0; i < loop; ++i) {
     // Run par_ilut
     timer.reset();
-    spiluk_symbolic(&kh, fill_lev, A_row_map, A_entries, L_row_map, L_entries, U_row_map, U_entries);
+    spiluk_symbolic(&kh, fill_lev, A_row_map, A_entries, L_row_map, L_entries,
+                    U_row_map, U_entries);
 
     const size_type nnzL = spiluk_handle->get_nnzL();
     const size_type nnzU = spiluk_handle->get_nnzU();
@@ -265,8 +272,8 @@ void run_spiluk_test(KernelHandle& kh, const sp_matrix_type& A,
     Kokkos::resize(L_values, nnzL);
     Kokkos::resize(U_values, nnzU);
 
-    spiluk_numeric(&kh, fill_lev, A_row_map, A_entries, A_values, L_row_map, L_entries,
-                   L_values, U_row_map, U_entries, U_values);
+    spiluk_numeric(&kh, fill_lev, A_row_map, A_entries, A_values, L_row_map,
+                   L_entries, L_values, U_row_map, U_entries, U_values);
     Kokkos::fence();
 
     // Measure time
@@ -288,7 +295,8 @@ void run_spiluk_test(KernelHandle& kh, const sp_matrix_type& A,
     spiluk_handle->reset_handle(rows, handle_nnz, handle_nnz);
 
     // Report run so user knows something is happening
-    std::cout << "SPILUK Finished a run in:  " << time << " seconds" << std::endl;
+    std::cout << "SPILUK Finished a run in:  " << time << " seconds"
+              << std::endl;
   }
 
   std::cout << "SPILUK LOOP_AVG_TIME:  " << ave_time / loop << std::endl;
@@ -297,8 +305,9 @@ void run_spiluk_test(KernelHandle& kh, const sp_matrix_type& A,
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-int test_par_ilut_perf(const int rows, const int nnz_per_row, const int bandwidth_per_nnz,
-                       const int team_size, const int loop, const int test)
+int test_par_ilut_perf(const int rows, const int nnz_per_row,
+                       const int bandwidth_per_nnz, const int team_size,
+                       const int loop, const int test)
 ///////////////////////////////////////////////////////////////////////////////
 {
   KernelHandle kh;
@@ -312,12 +321,13 @@ int test_par_ilut_perf(const int rows, const int nnz_per_row, const int bandwidt
   const auto default_policy = par_ilut_handle->get_default_team_policy();
 
   // Generate A
-  size_type nnz   = rows * nnz_per_row;
-  const lno_t bandwidth = nnz_per_row * bandwidth_per_nnz;
+  size_type nnz                 = rows * nnz_per_row;
+  const lno_t bandwidth         = nnz_per_row * bandwidth_per_nnz;
   const lno_t row_size_variance = 0;
   const scalar_t diag_dominance = 1;
   auto A = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<
-    sp_matrix_type>(rows, rows, nnz, row_size_variance, bandwidth, diag_dominance);
+      sp_matrix_type>(rows, rows, nnz, row_size_variance, bandwidth,
+                      diag_dominance);
 
   KokkosSparse::sort_crs_matrix(A);
 
@@ -328,9 +338,9 @@ int test_par_ilut_perf(const int rows, const int nnz_per_row, const int bandwidt
             << "\n  total nnz=" << A.nnz()
             << "\n  league_size=" << default_policy.league_size()
             << "\n  team_size=" << default_policy.team_size()
-            << "\n  concurrent teams=" << exe_space().concurrency() / default_policy.team_size()
-            << "\n  loop=" << loop
-            << std::endl;
+            << "\n  concurrent teams="
+            << exe_space().concurrency() / default_policy.team_size()
+            << "\n  loop=" << loop << std::endl;
 
   int num_iters = 6;
   if (test & 1) {
@@ -350,7 +360,7 @@ int test_par_ilut_perf(const int rows, const int nnz_per_row, const int bandwidt
   return 0;
 }
 
-}
+}  // namespace
 
 ///////////////////////////////////////////////////////////////////////////////
 void print_help_par_ilut()
@@ -358,51 +368,57 @@ void print_help_par_ilut()
 {
   printf("Options:\n");
   // printf(
-  //     "  -f [file]       : Read in Matrix Market formatted text file. Not yet supported "
+  //     "  -f [file]       : Read in Matrix Market formatted text file. Not yet
+  //     supported "
   //     "'file'.\n");
-  printf("  -n [N]  : generate a semi-random banded NxN matrix. Default 10000.\n");
+  printf(
+      "  -n [N]  : generate a semi-random banded NxN matrix. Default 10000.\n");
   printf("  -z [Z]  : number nnz per row. Default is 1%% of N.\n");
   printf("  -b [B]  : bandwidth nnz multiplier. Default is 5.\n");
-  printf("  -ts [T] : Number of threads per team. Default is 1 on OpenMP, nnz_per_row on CUDA\n");
-  //printf("  -vl [V] : Vector-length (i.e. how many Cuda threads are a Kokkos 'thread').\n");
-  printf("  -l [L]  : How many runs to aggregate average time. Default is 4\n\n");
-  printf("  -t [T]  : Which tests to run. Bitwise. e.g. 7 => run all, 1 => par_ilut, 2 => ginkgo, 4 => spiluk,. Default is 7\n\n");
+  printf(
+      "  -ts [T] : Number of threads per team. Default is 1 on OpenMP, "
+      "nnz_per_row on CUDA\n");
+  // printf("  -vl [V] : Vector-length (i.e. how many Cuda threads are a Kokkos
+  // 'thread').\n");
+  printf(
+      "  -l [L]  : How many runs to aggregate average time. Default is 4\n\n");
+  printf(
+      "  -t [T]  : Which tests to run. Bitwise. e.g. 7 => run all, 1 => "
+      "par_ilut, 2 => ginkgo, 4 => spiluk,. Default is 7\n\n");
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void handle_int_arg(int argc, char** argv, int& i, std::map<std::string, int*> option_map)
+void handle_int_arg(int argc, char** argv, int& i,
+                    std::map<std::string, int*> option_map)
 ///////////////////////////////////////////////////////////////////////////////
 {
   std::string arg = argv[i];
-  auto it = option_map.find(arg);
+  auto it         = option_map.find(arg);
   if (it == option_map.end()) {
     throw std::runtime_error(std::string("Unknown option: ") + arg);
   }
-  if (i+1 == argc) {
-    throw std::runtime_error(std::string("Missing option value for option: ") + arg);
+  if (i + 1 == argc) {
+    throw std::runtime_error(std::string("Missing option value for option: ") +
+                             arg);
   }
   *(it->second) = atoi(argv[++i]);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 ///////////////////////////////////////////////////////////////////////////////
 {
-  int rows          = 10000;
-  int nnz_per_row   = -1; // depends on other options, so don't set to default yet
-  int band_per_nnz  = 5;
-  int team_size     = -1;
-  int loop          = 4;
-  int test          = 7;
+  int rows = 10000;
+  int nnz_per_row =
+      -1;  // depends on other options, so don't set to default yet
+  int band_per_nnz = 5;
+  int team_size    = -1;
+  int loop         = 4;
+  int test         = 7;
 
   std::map<std::string, int*> option_map = {
-    {"-n" , &rows},
-    {"-z" , &nnz_per_row},
-    {"-b" , &band_per_nnz},
-    {"-ts", &team_size},
-    {"-l" , &loop},
-    {"-t" , &test}
-  };
+      {"-n", &rows},       {"-z", &nnz_per_row}, {"-b", &band_per_nnz},
+      {"-ts", &team_size}, {"-l", &loop},        {"-t", &test}};
 
   if (argc == 1) {
     print_help_par_ilut();
@@ -414,8 +430,7 @@ int main(int argc, char **argv)
     if ((strcmp(argv[i], "--help") == 0) || (strcmp(argv[i], "-h") == 0)) {
       print_help_par_ilut();
       return 0;
-    }
-    else {
+    } else {
       handle_int_arg(argc, argv, i, option_map);
     }
   }
@@ -429,7 +444,9 @@ int main(int argc, char **argv)
     nnz_per_row = rows / 100;
   }
   if (team_size == -1) {
-    team_size = KokkosKernels::Impl::kk_is_gpu_exec_space<exe_space>() ? nnz_per_row : 1;
+    team_size = KokkosKernels::Impl::kk_is_gpu_exec_space<exe_space>()
+                    ? nnz_per_row
+                    : 1;
   }
 
   Kokkos::initialize(argc, argv);

--- a/perf_test/sparse/KokkosSparse_par_ilut.cpp
+++ b/perf_test/sparse/KokkosSparse_par_ilut.cpp
@@ -455,7 +455,7 @@ int main(int argc, char** argv)
     nnz_per_row = std::min(rows / 100, 50);
   }
   if (bandwidth == -1) {
-    bandwidth = std::max(2 * (int)std::sqrt(rows), nnz_per_row);
+    bandwidth = std::max(2 * (int)std::sqrt(rows), 2 * nnz_per_row);
   }
   if (team_size == -1) {
     team_size = KokkosKernels::Impl::kk_is_gpu_exec_space<exe_space>()

--- a/perf_test/sparse/KokkosSparse_par_ilut.cpp
+++ b/perf_test/sparse/KokkosSparse_par_ilut.cpp
@@ -40,249 +40,247 @@
 #include <ginkgo/ginkgo.hpp>
 #endif
 
-struct RunPerfTest {
+namespace {
 
-  // Build up useful types
-  using scalar_t  = default_scalar;
-  using lno_t     = default_lno_t;
-  using size_type = default_size_type;
-  using exe_space = Kokkos::DefaultExecutionSpace;
-  using mem_space = typename exe_space::memory_space;
+using KokkosSparse::Experimental::par_ilut_symbolic;
+using KokkosSparse::Experimental::par_ilut_numeric;
 
-  using RowMapType  = Kokkos::View<size_type*, device>;
-  using EntriesType = Kokkos::View<lno_t*, device>;
-  using ValuesType  = Kokkos::View<scalar_t*, device>;
+// Build up useful types
+using scalar_t  = default_scalar;
+using lno_t     = default_lno_t;
+using size_type = default_size_type;
+using exe_space = Kokkos::DefaultExecutionSpace;
+using mem_space = typename exe_space::memory_space;
+using device    = Kokkos::Device<exe_space, mem_space>;
 
-  using device = Kokkos::Device<exe_space, mem_space>;
+using RowMapType  = Kokkos::View<size_type*, device>;
+using EntriesType = Kokkos::View<lno_t*, device>;
+using ValuesType  = Kokkos::View<scalar_t*, device>;
 
-  using sp_matrix_type =
-      KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>;
-  using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<
-      size_type, lno_t, scalar_t, exe_space, mem_space, mem_space>;
-  using float_t = typename Kokkos::ArithTraits<scalar_t>::mag_type;
+using sp_matrix_type =
+  KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>;
+using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<
+  size_type, lno_t, scalar_t, exe_space, mem_space, mem_space>;
+using float_t = typename Kokkos::ArithTraits<scalar_t>::mag_type;
 
-  /////////////////////////////////////////////////////////////////////////////
-  void run_par_ilut_test(KernelHandle& kh, const sp_matrix_type& A, int rows, int team_size, int loop)
-  /////////////////////////////////////////////////////////////////////////////
-  {
-    auto par_ilut_handle = kh.get_par_ilut_handle();
+///////////////////////////////////////////////////////////////////////////////
+void run_par_ilut_test(KernelHandle& kh, const sp_matrix_type& A, int rows, int team_size, int loop)
+///////////////////////////////////////////////////////////////////////////////
+{
+  auto par_ilut_handle = kh.get_par_ilut_handle();
 
-    // Pull out views from CRS
-    auto A_row_map = A.graph.row_map;
-    auto A_entries = A.graph.entries;
-    auto A_values  = A.values;
+  // Pull out views from CRS
+  auto A_row_map = A.graph.row_map;
+  auto A_entries = A.graph.entries;
+  auto A_values  = A.values;
 
-    // Allocate L and U CRS views as outputs
-    RowMapType L_row_map("L_row_map", numRows + 1);
-    RowMapType U_row_map("U_row_map", numRows + 1);
-    RowMapType L_row_map_orig("L_row_map", numRows + 1);
-    RowMapType U_row_map_orig("U_row_map", numRows + 1);
+  // Allocate L and U CRS views as outputs
+  RowMapType L_row_map("L_row_map", rows + 1);
+  RowMapType U_row_map("U_row_map", rows + 1);
 
-    // Initial L/U approximations for A
-    par_ilut_symbolic(&kh, row_map, entries, L_row_map, U_row_map);
+  // Initial L/U approximations for A
+  EntriesType L_entries("L_entries");
+  ValuesType L_values("L_values");
+  EntriesType U_entries("U_entries");
+  ValuesType U_values("U_values");
+
+  Kokkos::Timer timer;
+  double min_time = std::numeric_limits<double>::infinity();
+  double max_time = 0.0;
+  double ave_time = 0.0;
+  for (int i = 0; i < loop; ++i) {
+    // Run par_ilut
+    timer.reset();
+    par_ilut_symbolic(&kh, A_row_map, A_entries, L_row_map, U_row_map);
 
     const size_type nnzL = par_ilut_handle->get_nnzL();
     const size_type nnzU = par_ilut_handle->get_nnzU();
 
-    EntriesType L_entries("L_entries", nnzL);
-    ValuesType L_values("L_values", nnzL);
-    EntriesType U_entries("U_entries", nnzU);
-    ValuesType U_values("U_values", nnzU);
+    Kokkos::resize(L_entries, nnzL);
+    Kokkos::resize(U_entries, nnzU);
+    Kokkos::resize(L_values, nnzL);
+    Kokkos::resize(U_values, nnzU);
+    Kokkos::deep_copy(L_entries, 0);
+    Kokkos::deep_copy(U_entries, 0);
+    Kokkos::deep_copy(L_values, 0);
+    Kokkos::deep_copy(U_values, 0);
 
-    Kokkos::Timer timer;
-    double min_time = std::numeric_limits<double>::infinity();
-    double max_time = 0.0;
-    double ave_time = 0.0;
-    for (int i = 0; i < loop; ++i) {
-      timer.reset();
-      par_ilut_numeric(&kh, A_row_map, A_entries, A_values, L_row_map, L_entries,
-                       L_values, U_row_map, U_entries, U_values);
-      Kokkos::fence();
-      double time = timer.seconds();
-      ave_time += time;
-      if (time > max_time) max_time = time;
-      if (time < min_time) min_time = time;
-    }
+    par_ilut_numeric(&kh, A_row_map, A_entries, A_values, L_row_map, L_entries,
+                     L_values, U_row_map, U_entries, U_values);
+    Kokkos::fence();
 
-    std::cout << "PAR_ILUT LOOP_AVG_TIME:  " << ave_time / loop << std::endl;
-    std::cout << "PAR_ILUT LOOP_MAX_TIME:  " << max_time << std::endl;
-    std::cout << "PAR_ILUT LOOP_MIN_TIME:  " << min_time << std::endl;
+    // Check worked
+    const auto num_iters = par_ilut_handle->get_num_iters();
+    KK_REQUIRE_MSG(num_iters < par_ilut_handle->get_max_iter(), "par_ilut hit max iters");
+
+    // Measure time
+    double time = timer.seconds();
+    ave_time += time;
+    if (time > max_time) max_time = time;
+    if (time < min_time) min_time = time;
+
+    // Reset inputs
+    Kokkos::deep_copy(L_row_map, 0);
+    Kokkos::deep_copy(U_row_map, 0);
   }
 
+  std::cout << "PAR_ILUT LOOP_AVG_TIME:  " << ave_time / loop << std::endl;
+  std::cout << "PAR_ILUT LOOP_MAX_TIME:  " << max_time << std::endl;
+  std::cout << "PAR_ILUT LOOP_MIN_TIME:  " << min_time << std::endl;
+}
+
 #ifdef USE_GINKGO
-  /////////////////////////////////////////////////////////////////////////////
-  void run_par_ilut_test_ginkgo(const sp_matrix_type& A, int rows, int team_size, int loop)
-  /////////////////////////////////////////////////////////////////////////////
-  {
-    // Use ginko!
+///////////////////////////////////////////////////////////////////////////////
+void run_par_ilut_test_ginkgo(KernelHandle& kh, const sp_matrix_type& A, int rows, int team_size, int loop)
+///////////////////////////////////////////////////////////////////////////////
+{
+  auto par_ilut_handle = kh.get_par_ilut_handle();
 
-    using mtx = gko::matrix::Csr<scalar_t, lno_t>;
-    auto exec = gko::OmpExecutor::create();
+  // Pull out views from CRS
+  auto A_row_map = A.graph.row_map;
+  auto A_entries = A.graph.entries;
+  auto A_values  = A.values;
 
-    EntriesType A_row_map_cp("A_row_map_cp", numRows+1);
-    for (size_type i = 0; i < row_map.extent(0); ++i) {
-      A_row_map_cp(i) = row_map(i);
-    }
+  using mtx = gko::matrix::Csr<scalar_t, lno_t>;
+  auto exec = gko::OmpExecutor::create();
 
-    // Populate mtx
-    auto a_mtx_uniq = mtx::create_const(exec, gko::dim<2>(n, n),
-                                        gko::array<scalar_t>::const_view(exec, values.extent(0), values.data()),
-                                        gko::array<lno_t>::const_view(exec, entries.extent(0), entries.data()),
-                                        gko::array<lno_t>::const_view(exec, A_row_map_cp.extent(0), A_row_map_cp.data()));
+  // ginkgo does not differentiate between index type and size type. We need
+  // to convert A_row_map to lno_t.
+  EntriesType A_row_map_cp("A_row_map_cp", rows+1);
+  for (size_type i = 0; i < A_row_map.extent(0); ++i) {
+    A_row_map_cp(i) = A_row_map(i);
+  }
 
-    std::shared_ptr<const mtx> a_mtx = std::move(a_mtx_uniq);
+  // Populate mtx
+  auto a_mtx_uniq = mtx::create_const(
+    exec, gko::dim<2>(rows, rows),
+    gko::array<scalar_t>::const_view(exec, A_values.extent(0), A_values.data()),
+    gko::array<lno_t>::const_view(exec, A_entries.extent(0), A_entries.data()),
+    gko::array<lno_t>::const_view(exec, A_row_map_cp.extent(0), A_row_map_cp.data()));
 
+  std::shared_ptr<const mtx> a_mtx = std::move(a_mtx_uniq);
+
+  Kokkos::Timer timer;
+  double min_time = std::numeric_limits<double>::infinity();
+  double max_time = 0.0;
+  double ave_time = 0.0;
+  for (int i = 0; i < loop; ++i) {
+    timer.reset();
     auto fact = gko::factorization::ParIlut<scalar_t, lno_t>::build()
       .with_fill_in_limit(par_ilut_handle->get_fill_in_limit())
       .with_approximate_select(false)
       .on(exec)->generate(a_mtx);
+
+    double time = timer.seconds();
+    ave_time += time;
+    if (time > max_time) max_time = time;
+    if (time < min_time) min_time = time;
   }
+
+  std::cout << "GINKGO LOOP_AVG_TIME:  " << ave_time / loop << std::endl;
+  std::cout << "GINKGO LOOP_MAX_TIME:  " << max_time << std::endl;
+  std::cout << "GINKGO LOOP_MIN_TIME:  " << min_time << std::endl;
+}
 #endif
 
-  /////////////////////////////////////////////////////////////////////////////
-  int test_par_ilut_perf(int rows, int nnz_per_row, float bandwidth_per_nnz,
-                         int team_size, int loop)
-  /////////////////////////////////////////////////////////////////////////////
-  {
-    // Generate A
-    const size_type nnz   = rows * nnz_per_row;
-    const lno_t bandwidth = nnz_per_row * bandwidth_per_nnz;
-    const lno_t row_size_variance = 0;
-    const scalar_t diag_dominance = 1;
-    auto A = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<
-      sp_matrix_type>(rows, rows, nnz, row_size_variance, bandwidth, diag_dominance);
+///////////////////////////////////////////////////////////////////////////////
+int test_par_ilut_perf(int rows, int nnz_per_row, float bandwidth_per_nnz,
+                       int team_size, int loop)
+///////////////////////////////////////////////////////////////////////////////
+{
+  // Generate A
+  std::cout << "Testing " << std::endl;
 
-    KokkosSparse::sort_crs_matrix(A);
+  size_type nnz   = rows * nnz_per_row;
+  const lno_t bandwidth = nnz_per_row * bandwidth_per_nnz;
+  const lno_t row_size_variance = 0;
+  const scalar_t diag_dominance = 1;
+  auto A = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<
+    sp_matrix_type>(rows, rows, nnz, row_size_variance, bandwidth, diag_dominance);
 
-    KernelHandle kh;
-    kh.create_par_ilut_handle();
+  KokkosSparse::sort_crs_matrix(A);
 
-    run_par_ilut_test(kh, A, rows, team_size, loop);
+  KernelHandle kh;
+  kh.create_par_ilut_handle();
+
+  run_par_ilut_test(kh, A, rows, team_size, loop);
 
 #ifdef USE_GINKGO
-    run_par_ilut_test_ginkgo(A, rows, team_size, loop);
+  run_par_ilut_test_ginkgo(kh, A, rows, team_size, loop);
 #endif
 
-    return 0;
-  }
-
-};
-
-void print_help_par_ilut() {
-  printf("Options:\n");
-  printf("  --test [OPTION] : Use different kernel implementations\n");
-  printf("                    Options:\n");
-  printf("                      lvlrp, lvltp1, lvltp2\n\n");
-  printf(
-      "  -f [file]       : Read in Matrix Market formatted text file "
-      "'file'.\n");
-  //  printf("  -s [N]          : generate a semi-random banded (band size
-  //  0.01xN) NxN matrix\n"); printf("                    with average of 10
-  //  entries per row.\n"); printf("  --schedule [SCH]: Set schedule for kk
-  //  variant (static,dynamic,auto [ default ]).\n"); printf("  -afb [file] :
-  //  Read in binary Matrix files 'file'.\n"); printf("  --write-binary  : In
-  //  combination with -f, generate binary files.\n"); printf("  --offset [O] :
-  //  Subtract O from every index.\n"); printf("                    Useful in
-  //  case the matrix market file is not 0 based.\n\n");
-  printf("  -k [K]          : Fill level (default: 0)\n");
-  printf("  -ts [T]         : Number of threads per team.\n");
-  printf(
-      "  -vl [V]         : Vector-length (i.e. how many Cuda threads are a "
-      "Kokkos 'thread').\n");
-  printf(
-      "  --loop [LOOP]   : How many runs to aggregate average time. "
-      "\n");
+  return 0;
 }
 
-int main(int argc, char **argv) {
-  std::vector<int> tests;
+}
 
-  std::string afilename;
+///////////////////////////////////////////////////////////////////////////////
+void print_help_par_ilut()
+///////////////////////////////////////////////////////////////////////////////
+{
+  printf("Options:\n");
+  // printf(
+  //     "  -f [file]       : Read in Matrix Market formatted text file. Not yet supported "
+  //     "'file'.\n");
+  printf("  -n [N]  : generate a semi-random banded NxN matrix. Default 10000.\n");
+  printf("  -z [Z]  : number nnz per row. Default is 1% of N.\n");
+  printf("  -b [B]  : bandwidth nnz multiplier. Default is 5.\n");
+  printf("  -ts [T] : Number of threads per team.\n");
+  //printf("  -vl [V] : Vector-length (i.e. how many Cuda threads are a Kokkos 'thread').\n");
+  printf("  -l [L]  : How many runs to aggregate average time. Default is 10\n\n");
+}
 
-  int kin           = 0;
-  int vector_length = -1;
+///////////////////////////////////////////////////////////////////////////////
+void handle_int_arg(int argc, char** argv, int& i, std::map<std::string, int*> option_map)
+///////////////////////////////////////////////////////////////////////////////
+{
+  std::string arg = argv[i];
+  auto it = option_map.find(arg);
+  if (it == option_map.end()) {
+    throw std::runtime_error(std::string("Unknown option: ") + arg);
+  }
+  if (i+1 == argc) {
+    throw std::runtime_error(std::string("Missing option value for option: ") + arg);
+  }
+  *(it->second) = atoi(argv[++i]);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char **argv)
+///////////////////////////////////////////////////////////////////////////////
+{
+  int rows          = 10000;
+  int nnz_per_row   = -1; // depends on other options, so don't set to default yet
+  int band_per_nnz  = 5;
   int team_size     = -1;
-  // int idx_offset = 0;
-  int loop = 1;
-  // int schedule=AUTO;
+  int loop          = 10;
+
+  std::map<std::string, int*> option_map = {
+    {"-n" , &rows},
+    {"-z" , &nnz_per_row},
+    {"-b" , &band_per_nnz},
+    {"-ts", &team_size},
+    {"-l" , &loop}
+  };
 
   if (argc == 1) {
     print_help_par_ilut();
     return 0;
   }
 
-  for (int i = 0; i < argc; i++) {
-    if ((strcmp(argv[i], "--test") == 0)) {
-      i++;
-      if ((strcmp(argv[i], "lvlrp") == 0)) {
-        tests.push_back(LVLSCHED_RP);
-      }
-      if ((strcmp(argv[i], "lvltp1") == 0)) {
-        tests.push_back(LVLSCHED_TP1);
-      }
-      /*
-            if((strcmp(argv[i],"lvltp2")==0)) {
-              tests.push_back( LVLSCHED_TP2 );
-            }
-      */
-      continue;
-    }
-    if ((strcmp(argv[i], "-f") == 0)) {
-      afilename = argv[++i];
-      continue;
-    }
-    if ((strcmp(argv[i], "-k") == 0)) {
-      kin = atoi(argv[++i]);
-      continue;
-    }
-    if ((strcmp(argv[i], "-ts") == 0)) {
-      team_size = atoi(argv[++i]);
-      continue;
-    }
-    if ((strcmp(argv[i], "-vl") == 0)) {
-      vector_length = atoi(argv[++i]);
-      continue;
-    }
-    // if((strcmp(argv[i],"--offset")==0)) {idx_offset = atoi(argv[++i]);
-    // continue;}
-    if ((strcmp(argv[i], "--loop") == 0)) {
-      loop = atoi(argv[++i]);
-      continue;
-    }
-    /*
-        if((strcmp(argv[i],"-afb")==0)) {afilename = argv[++i]; binaryfile =
-       true; continue;} if((strcmp(argv[i],"--schedule")==0)) { i++;
-          if((strcmp(argv[i],"auto")==0))
-            schedule = AUTO;
-          if((strcmp(argv[i],"dynamic")==0))
-            schedule = DYNAMIC;
-          if((strcmp(argv[i],"static")==0))
-            schedule = STATIC;
-          continue;
-        }
-    */
+  for (int i = 1; i < argc; i++) {
     if ((strcmp(argv[i], "--help") == 0) || (strcmp(argv[i], "-h") == 0)) {
       print_help_par_ilut();
       return 0;
     }
-  }
-
-  if (tests.size() == 0) {
-    tests.push_back(DEFAULT);
-  }
-  for (size_t i = 0; i < tests.size(); ++i) {
-    std::cout << "tests[" << i << "] = " << tests[i] << std::endl;
+    else {
+      handle_int_arg(argc, argv, i, option_map);
+    }
   }
 
   Kokkos::initialize(argc, argv);
   {
-    int total_errors = test_par_perf(tests, afilename, kin, team_size,
-                                        vector_length, /*idx_offset,*/ loop);
-
-    if (total_errors == 0)
-      printf("Kokkos::PAR_ILUT Test: Passed\n");
-    else
-      printf("Kokkos::PAR_ILUT Test: Failed\n");
+    test_par_ilut_perf(rows, nnz_per_row, band_per_nnz, team_size, loop);
   }
   Kokkos::finalize();
   return 0;

--- a/perf_test/sparse/KokkosSparse_par_ilut.cpp
+++ b/perf_test/sparse/KokkosSparse_par_ilut.cpp
@@ -45,6 +45,10 @@ namespace {
 using KokkosSparse::Experimental::par_ilut_symbolic;
 using KokkosSparse::Experimental::par_ilut_numeric;
 
+using KokkosSparse::Experimental::spiluk_symbolic;
+using KokkosSparse::Experimental::spiluk_numeric;
+using KokkosSparse::Experimental::SPILUKAlgorithm;
+
 // Build up useful types
 using scalar_t  = default_scalar;
 using lno_t     = default_lno_t;
@@ -64,7 +68,8 @@ using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<
 using float_t = typename Kokkos::ArithTraits<scalar_t>::mag_type;
 
 ///////////////////////////////////////////////////////////////////////////////
-void run_par_ilut_test(KernelHandle& kh, const sp_matrix_type& A, int rows, int team_size, int loop)
+int run_par_ilut_test(KernelHandle& kh, const sp_matrix_type& A,
+                      const int rows, const int team_size, const int loop)
 ///////////////////////////////////////////////////////////////////////////////
 {
   auto par_ilut_handle = kh.get_par_ilut_handle();
@@ -79,22 +84,25 @@ void run_par_ilut_test(KernelHandle& kh, const sp_matrix_type& A, int rows, int 
   RowMapType U_row_map("U_row_map", rows + 1);
 
   // Initial L/U approximations for A
-  EntriesType L_entries("L_entries");
-  ValuesType L_values("L_values");
-  EntriesType U_entries("U_entries");
-  ValuesType U_values("U_values");
+  EntriesType L_entries("L_entries", 0);
+  ValuesType L_values("L_values", 0);
+  EntriesType U_entries("U_entries", 0);
+  ValuesType U_values("U_values", 0);
 
   Kokkos::Timer timer;
   double min_time = std::numeric_limits<double>::infinity();
   double max_time = 0.0;
   double ave_time = 0.0;
+  int num_iters = -1;
+  size_type nnzL = 0;
+  size_type nnzU = 0;
   for (int i = 0; i < loop; ++i) {
     // Run par_ilut
     timer.reset();
     par_ilut_symbolic(&kh, A_row_map, A_entries, L_row_map, U_row_map);
 
-    const size_type nnzL = par_ilut_handle->get_nnzL();
-    const size_type nnzU = par_ilut_handle->get_nnzU();
+    nnzL = par_ilut_handle->get_nnzL();
+    nnzU = par_ilut_handle->get_nnzU();
 
     Kokkos::resize(L_entries, nnzL);
     Kokkos::resize(U_entries, nnzU);
@@ -110,7 +118,7 @@ void run_par_ilut_test(KernelHandle& kh, const sp_matrix_type& A, int rows, int 
     Kokkos::fence();
 
     // Check worked
-    const auto num_iters = par_ilut_handle->get_num_iters();
+    num_iters = par_ilut_handle->get_num_iters();
     KK_REQUIRE_MSG(num_iters < par_ilut_handle->get_max_iter(), "par_ilut hit max iters");
 
     // Measure time
@@ -122,16 +130,22 @@ void run_par_ilut_test(KernelHandle& kh, const sp_matrix_type& A, int rows, int 
     // Reset inputs
     Kokkos::deep_copy(L_row_map, 0);
     Kokkos::deep_copy(U_row_map, 0);
+
+    // Report run so user knows something is happening
+    std::cout << "PAR_ILUT Finished a run in:  " << time << " seconds and " << num_iters << " iters" << std::endl;
   }
 
   std::cout << "PAR_ILUT LOOP_AVG_TIME:  " << ave_time / loop << std::endl;
   std::cout << "PAR_ILUT LOOP_MAX_TIME:  " << max_time << std::endl;
   std::cout << "PAR_ILUT LOOP_MIN_TIME:  " << min_time << std::endl;
+
+  return num_iters;
 }
 
 #ifdef USE_GINKGO
 ///////////////////////////////////////////////////////////////////////////////
-void run_par_ilut_test_ginkgo(KernelHandle& kh, const sp_matrix_type& A, int rows, int team_size, int loop)
+void run_par_ilut_test_ginkgo(KernelHandle& kh, const sp_matrix_type& A,
+                              const int rows, const int team_size, const int loop, const int num_iters)
 ///////////////////////////////////////////////////////////////////////////////
 {
   auto par_ilut_handle = kh.get_par_ilut_handle();
@@ -169,12 +183,16 @@ void run_par_ilut_test_ginkgo(KernelHandle& kh, const sp_matrix_type& A, int row
     auto fact = gko::factorization::ParIlut<scalar_t, lno_t>::build()
       .with_fill_in_limit(par_ilut_handle->get_fill_in_limit())
       .with_approximate_select(false)
+      .with_iterations(num_iters)
       .on(exec)->generate(a_mtx);
 
     double time = timer.seconds();
     ave_time += time;
     if (time > max_time) max_time = time;
     if (time < min_time) min_time = time;
+
+    // Report run so user knows something is happening
+    std::cout << "GINKGO Finished a run in:  " << time << " seconds" << std::endl;
   }
 
   std::cout << "GINKGO LOOP_AVG_TIME:  " << ave_time / loop << std::endl;
@@ -184,13 +202,95 @@ void run_par_ilut_test_ginkgo(KernelHandle& kh, const sp_matrix_type& A, int row
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-int test_par_ilut_perf(int rows, int nnz_per_row, float bandwidth_per_nnz,
-                       int team_size, int loop)
+void run_spiluk_test(KernelHandle& kh, const sp_matrix_type& A,
+                     const int rows, const int team_size, const int loop)
 ///////////////////////////////////////////////////////////////////////////////
 {
-  // Generate A
-  std::cout << "Testing " << std::endl;
+  constexpr int EXPAND_FACT = 10;
+  const lno_t fill_lev = 2;
+  const size_type handle_nnz = EXPAND_FACT * A.nnz() * (fill_lev + 1);
+  kh.create_spiluk_handle(SPILUKAlgorithm::SEQLVLSCHD_TP1, rows, handle_nnz, handle_nnz);
+  auto spiluk_handle = kh.get_spiluk_handle();
 
+  // Pull out views from CRS
+  auto A_row_map = A.graph.row_map;
+  auto A_entries = A.graph.entries;
+  auto A_values  = A.values;
+
+  // Allocate L and U CRS views as outputs
+  RowMapType L_row_map("L_row_map", rows + 1);
+  RowMapType U_row_map("U_row_map", rows + 1);
+
+  // Initial L/U approximations for A
+  EntriesType L_entries("L_entries", handle_nnz);
+  ValuesType L_values("L_values", handle_nnz);
+  EntriesType U_entries("U_entries", handle_nnz);
+  ValuesType U_values("U_values", handle_nnz);
+
+  Kokkos::Timer timer;
+  double min_time = std::numeric_limits<double>::infinity();
+  double max_time = 0.0;
+  double ave_time = 0.0;
+  for (int i = 0; i < loop; ++i) {
+    // Run par_ilut
+    timer.reset();
+    spiluk_symbolic(&kh, fill_lev, A_row_map, A_entries, L_row_map, L_entries, U_row_map, U_entries);
+
+    const size_type nnzL = spiluk_handle->get_nnzL();
+    const size_type nnzU = spiluk_handle->get_nnzU();
+
+    Kokkos::resize(L_entries, nnzL);
+    Kokkos::resize(U_entries, nnzU);
+    Kokkos::resize(L_values, nnzL);
+    Kokkos::resize(U_values, nnzU);
+
+    spiluk_numeric(&kh, fill_lev, A_row_map, A_entries, A_values, L_row_map, L_entries,
+                   L_values, U_row_map, U_entries, U_values);
+    Kokkos::fence();
+
+    // Measure time
+    double time = timer.seconds();
+    ave_time += time;
+    if (time > max_time) max_time = time;
+    if (time < min_time) min_time = time;
+
+    // Reset inputs
+    Kokkos::deep_copy(L_row_map, 0);
+    Kokkos::deep_copy(U_row_map, 0);
+    Kokkos::deep_copy(L_entries, 0);
+    Kokkos::deep_copy(U_entries, 0);
+    Kokkos::deep_copy(L_values, 0);
+    Kokkos::deep_copy(U_values, 0);
+    Kokkos::resize(L_entries, handle_nnz);
+    Kokkos::resize(U_entries, handle_nnz);
+
+    spiluk_handle->reset_handle(rows, handle_nnz, handle_nnz);
+
+    // Report run so user knows something is happening
+    std::cout << "SPILUK Finished a run in:  " << time << " seconds" << std::endl;
+  }
+
+  std::cout << "SPILUK LOOP_AVG_TIME:  " << ave_time / loop << std::endl;
+  std::cout << "SPILUK LOOP_MAX_TIME:  " << max_time << std::endl;
+  std::cout << "SPILUK LOOP_MIN_TIME:  " << min_time << std::endl;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int test_par_ilut_perf(const int rows, const int nnz_per_row, const int bandwidth_per_nnz,
+                       const int team_size, const int loop)
+///////////////////////////////////////////////////////////////////////////////
+{
+  KernelHandle kh;
+  kh.create_par_ilut_handle();
+
+  // Report test config to user
+  auto par_ilut_handle = kh.get_par_ilut_handle();
+  par_ilut_handle->set_team_size(team_size);
+  par_ilut_handle->set_nrows(rows);
+
+  const auto default_policy = par_ilut_handle->get_default_team_policy();
+
+  // Generate A
   size_type nnz   = rows * nnz_per_row;
   const lno_t bandwidth = nnz_per_row * bandwidth_per_nnz;
   const lno_t row_size_variance = 0;
@@ -200,14 +300,24 @@ int test_par_ilut_perf(int rows, int nnz_per_row, float bandwidth_per_nnz,
 
   KokkosSparse::sort_crs_matrix(A);
 
-  KernelHandle kh;
-  kh.create_par_ilut_handle();
+  // Report test config
+  std::cout << "Testing par_ilut with rows=" << rows
+            << "\n  nnz_per_row=" << nnz_per_row
+            << "\n  bandwidth_per_nnz=" << bandwidth_per_nnz
+            << "\n  total nnz=" << A.nnz()
+            << "\n  league_size=" << default_policy.league_size()
+            << "\n  team_size=" << default_policy.team_size()
+            << "\n  concurrent teams=" << exe_space::concurrency() / default_policy.team_size()
+            << "\n  loop=" << loop
+            << std::endl;
 
-  run_par_ilut_test(kh, A, rows, team_size, loop);
+  const auto num_iters = run_par_ilut_test(kh, A, rows, team_size, loop);
 
 #ifdef USE_GINKGO
-  run_par_ilut_test_ginkgo(kh, A, rows, team_size, loop);
+  run_par_ilut_test_ginkgo(kh, A, rows, team_size, loop, num_iters);
 #endif
+
+  run_spiluk_test(kh, A, rows, team_size, loop);
 
   return 0;
 }
@@ -225,7 +335,7 @@ void print_help_par_ilut()
   printf("  -n [N]  : generate a semi-random banded NxN matrix. Default 10000.\n");
   printf("  -z [Z]  : number nnz per row. Default is 1% of N.\n");
   printf("  -b [B]  : bandwidth nnz multiplier. Default is 5.\n");
-  printf("  -ts [T] : Number of threads per team.\n");
+  printf("  -ts [T] : Number of threads per team. Default is 1 on OpenMP, nnz_per_row on CUDA\n");
   //printf("  -vl [V] : Vector-length (i.e. how many Cuda threads are a Kokkos 'thread').\n");
   printf("  -l [L]  : How many runs to aggregate average time. Default is 10\n\n");
 }
@@ -268,6 +378,7 @@ int main(int argc, char **argv)
     return 0;
   }
 
+  // Handle user options
   for (int i = 1; i < argc; i++) {
     if ((strcmp(argv[i], "--help") == 0) || (strcmp(argv[i], "-h") == 0)) {
       print_help_par_ilut();
@@ -276,6 +387,18 @@ int main(int argc, char **argv)
     else {
       handle_int_arg(argc, argv, i, option_map);
     }
+  }
+
+  if (rows < 100) {
+    throw std::runtime_error("Need to have at least 100 rows");
+  }
+
+  // Set dependent defaults
+  if (nnz_per_row == -1) {
+    nnz_per_row = rows / 100;
+  }
+  if (team_size == -1) {
+    team_size = KokkosKernels::Impl::kk_is_gpu_exec_space<exe_space>() ? nnz_per_row : 1;
   }
 
   Kokkos::initialize(argc, argv);

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -28,7 +28,6 @@
 #include <KokkosSparse_Utils.hpp>
 #include <KokkosSparse_SortCrs.hpp>
 #include <KokkosKernels_Utils.hpp>
-#include <Kokkos_Atomic.hpp>
 
 #include <limits>
 

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -35,6 +35,28 @@ namespace KokkosSparse {
 namespace Impl {
 namespace Experimental {
 
+namespace ParIlutOnly {
+
+template <bool async_update>
+struct UtViewType
+{
+  template <class UtValuesType>
+  using UtValuesViewType = UtValuesType;
+};
+
+template <>
+struct UtViewType<true>
+{
+  template <class UtValuesType>
+  using UtValuesViewType = Kokkos::View<
+    typename UtValuesType::non_const_value_type*,
+    typename UtValuesType::array_layout, typename UtValuesType::device_type,
+    Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess |
+                         Kokkos::Atomic> >;
+};
+
+}
+
 template <class IlutHandle>
 struct IlutWrap {
   //
@@ -832,7 +854,7 @@ struct IlutWrap {
     const size_type max_iter = thandle.get_max_iter();
 
     const auto verbose      = thandle.get_verbose();
-    const auto async_update = thandle.get_async_update();
+    const auto async_update = false; //thandle.get_async_update();
 
     if (verbose) {
       std::cout << "Starting PARILUT with..." << std::endl;

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -28,6 +28,7 @@
 #include <KokkosSparse_Utils.hpp>
 #include <KokkosSparse_SortCrs.hpp>
 #include <KokkosKernels_Utils.hpp>
+#include <Kokkos_Atomic.hpp>
 
 #include <limits>
 

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -832,7 +832,7 @@ struct IlutWrap {
     const size_type max_iter = thandle.get_max_iter();
 
     const auto verbose      = thandle.get_verbose();
-    const auto async_update = false; // thandle.get_async_update();
+    const auto async_update = false;  // thandle.get_async_update();
 
     if (verbose) {
       std::cout << "Starting PARILUT with..." << std::endl;

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -833,7 +833,7 @@ struct IlutWrap {
     const size_type max_iter = thandle.get_max_iter();
 
     const auto verbose      = thandle.get_verbose();
-    const auto async_update = false;  // thandle.get_async_update();
+    const auto async_update = thandle.get_async_update();
 
     if (verbose) {
       std::cout << "Starting PARILUT with..." << std::endl;

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -832,7 +832,7 @@ struct IlutWrap {
     const size_type max_iter = thandle.get_max_iter();
 
     const auto verbose      = thandle.get_verbose();
-    const auto async_update = false; //thandle.get_async_update();
+    const auto async_update = false; // thandle.get_async_update();
 
     if (verbose) {
       std::cout << "Starting PARILUT with..." << std::endl;

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -35,28 +35,6 @@ namespace KokkosSparse {
 namespace Impl {
 namespace Experimental {
 
-namespace ParIlutOnly {
-
-template <bool async_update>
-struct UtViewType
-{
-  template <class UtValuesType>
-  using UtValuesViewType = UtValuesType;
-};
-
-template <>
-struct UtViewType<true>
-{
-  template <class UtValuesType>
-  using UtValuesViewType = Kokkos::View<
-    typename UtValuesType::non_const_value_type*,
-    typename UtValuesType::array_layout, typename UtValuesType::device_type,
-    Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess |
-                         Kokkos::Atomic> >;
-};
-
-}
-
 template <class IlutHandle>
 struct IlutWrap {
   //

--- a/sparse/unit_test/Test_Sparse_par_ilut.hpp
+++ b/sparse/unit_test/Test_Sparse_par_ilut.hpp
@@ -304,7 +304,7 @@ void run_test_par_ilut_precond() {
   constexpr auto diagDominance = 1;
   constexpr bool verbose       = false;
 
-  typename sp_matrix_type::non_const_size_type nnz = 10 * numRows;
+  const size_type nnz = 10 * numRows;
   auto A = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<
       sp_matrix_type>(numRows, numCols, nnz, 0, lno_t(0.01 * numRows),
                       diagDominance);

--- a/sparse/unit_test/Test_Sparse_par_ilut.hpp
+++ b/sparse/unit_test/Test_Sparse_par_ilut.hpp
@@ -304,7 +304,7 @@ void run_test_par_ilut_precond() {
   constexpr auto diagDominance = 1;
   constexpr bool verbose       = false;
 
-  const size_type nnz = 10 * numRows;
+  size_type nnz = 10 * numRows;
   auto A = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<
       sp_matrix_type>(numRows, numCols, nnz, 0, lno_t(0.01 * numRows),
                       diagDominance);

--- a/sparse/unit_test/Test_Sparse_par_ilut.hpp
+++ b/sparse/unit_test/Test_Sparse_par_ilut.hpp
@@ -302,7 +302,7 @@ void run_test_par_ilut_precond() {
   constexpr auto numRows       = n;
   constexpr auto numCols       = n;
   constexpr auto diagDominance = 1;
-  constexpr bool verbose       = true;
+  constexpr bool verbose       = false;
 
   typename sp_matrix_type::non_const_size_type nnz = 10 * numRows;
   auto A = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<

--- a/sparse/unit_test/Test_Sparse_par_ilut.hpp
+++ b/sparse/unit_test/Test_Sparse_par_ilut.hpp
@@ -302,7 +302,7 @@ void run_test_par_ilut_precond() {
   constexpr auto numRows       = n;
   constexpr auto numCols       = n;
   constexpr auto diagDominance = 1;
-  constexpr bool verbose       = false;
+  constexpr bool verbose       = true;
 
   typename sp_matrix_type::non_const_size_type nnz = 10 * numRows;
   auto A = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<


### PR DESCRIPTION
Change list:
1) Adds a new perf_test/sparse test, spare_par_ilut that can test performance of our par_ilut, ginkgo's par_ilut, and our spiluk.
2) Adds ability to interface KK sparse perf tests with Ginkgo via the CMake option `Ginkgo_DIR`
3) Couple other minor cleanups.

Perf test results:

All tests were done with a randomly generated NxN sparse matrix that is **1% nnz and bandwidth=5%**, taking the best time out of 4 runs.

OMP:

It looks like our OMP performance is very similar to ginkgo. Our impl seems to do comparatively better for lower thread counts and high row counts. The big surprise here is spiluk, which appears to show no speedup as threads are increased. Spiluk is much faster for low thread counts but, since it doesn't improve with more threads, gets passed by the other two algorithms as threads are increased.

CUDA:

Testing on CUDA was problematic because, for relatively small row counts 10000-20000, par_ilut and ginkgo finish very quickly, but when row counts are increased, ginkgo quickly begins to fail with out-of-memory errors. When ginkgo had enough memory, it was 2-3x times faster than our par_ilut, but ours was able to run up to 40000 rows whereas ginkgo could not run more than 20000.

Plots (lower is better for all plots):
<img width="1001" alt="omp_thread_scaling" src="https://user-images.githubusercontent.com/7292036/232866339-21888f6d-000b-42ad-805e-6aa4a52bcf33.png">
<img width="1024" alt="omp_thread_scaling_logy" src="https://user-images.githubusercontent.com/7292036/232866384-b2340e59-7cf5-41d5-9721-0a20c6474b69.png">
<img width="948" alt="omp_row_scaling" src="https://user-images.githubusercontent.com/7292036/232866403-6d1975bc-be4b-4a38-8cf5-0577e27c2a23.png">
<img width="952" alt="omp_row_scaling_logy" src="https://user-images.githubusercontent.com/7292036/232866413-6bd23530-397d-475e-a2e7-014f1c12bedd.png">
<img width="864" alt="cuda_row_scaling" src="https://user-images.githubusercontent.com/7292036/232866441-78087fe0-6401-45cb-b506-8c3470e82b13.png">
<img width="998" alt="cuda_row_scaling_logy" src="https://user-images.githubusercontent.com/7292036/232866469-9586419c-5a1e-4286-a478-d390f041fef7.png">

After consulting with @brian-kelley and @vqd8a , my nnz and bandwidth were too high to be representative of common use cases. I changed nnz to be hardcoded to 50 (no longer scales with N) and bandwidth to 2*sqrt(N) (regular square grid). With those new values, I redid all the above tests:

<img width="991" alt="omp_thread_scaling" src="https://user-images.githubusercontent.com/7292036/234357073-9af7d79e-0f96-4a61-b228-6975acbc8e5c.png">
<img width="1053" alt="omp_thread_scaling_logy" src="https://user-images.githubusercontent.com/7292036/234357094-79944c34-c1da-496d-98df-c56bca94d23b.png">
<img width="976" alt="omp_row_scaling" src="https://user-images.githubusercontent.com/7292036/234357115-41dc03fb-7578-4b9c-9265-059b0a9aabf4.png">
<img width="1088" alt="omp_row_scaling_logy" src="https://user-images.githubusercontent.com/7292036/234357126-d9a1a578-0df5-416d-ae40-75809ac550c7.png">
<img width="1027" alt="cuda_row_scaling" src="https://user-images.githubusercontent.com/7292036/234371596-30a669e3-c5c2-48bd-b2a1-f89729609fa5.png">
<img width="1052" alt="cuda_row_scaling_logy" src="https://user-images.githubusercontent.com/7292036/234371630-b2fd9659-10c4-42fc-a01d-e634db08a318.png">

Takeaways: on OMP, ginkgo and par_ilut performance is very similar, with par_ilut being a bit faster for lower thread counts and ginkgo scaling a bit better as threads increase. Spiluk does not improve, numeric actually gets worse, as threads increase. Spiluk also seems to scale a bit worse as rows increase.

on CUDA, ginkgo is very fast but runs out of memory much sooner.