### PR TITLE
scripts: Include OMP settings

### DIFF
--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -1183,6 +1183,9 @@ single_build_and_test() {
   fi
   echo "        module purge" &>> reload_modules.sh
   echo "        module load $compiler_modules_list" &>> reload_modules.sh
+  echo "        export OMP_NUM_THREADS=$omp_num_threads" &>> reload_modules.sh
+  echo "        export OMP_PROC_BIND=$omp_proc_bind" &>> reload_modules.sh
+  echo "        export OMP_PLACES=$omp_places" &>> reload_modules.sh
   echo "" &>> reload_modules.sh
   chmod +x reload_modules.sh
 


### PR DESCRIPTION
When re-running CI tests locally, I had to manually set the OMP runtime settings. This PR adds those settings to reload_modules.sh, which is part of the reproducer instructions.