### PR TITLE
Blas1 on stream

### DIFF
--- a/blas/impl/KokkosBlas1_abs_impl.hpp
+++ b/blas/impl/KokkosBlas1_abs_impl.hpp
@@ -30,7 +30,6 @@ namespace Impl {
 // Entry-wise absolute value / magnitude: R(i,j) = abs(X(i,j)).
 template <class RMV, class XMV, class SizeType = typename RMV::size_type>
 struct MV_Abs_Functor {
-  typedef typename RMV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename XMV::non_const_value_type> ATS;
 
@@ -68,7 +67,6 @@ struct MV_Abs_Functor {
 // Entry-wise, in-place absolute value / magnitude: R(i,j) = abs(R(i,j)).
 template <class RMV, class SizeType = typename RMV::size_type>
 struct MV_AbsSelf_Functor {
-  typedef typename RMV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename RMV::non_const_value_type> ATS;
 
@@ -98,7 +96,6 @@ struct MV_AbsSelf_Functor {
 // Single-vector, entry-wise absolute value / magnitude: R(i) = abs(X(i)).
 template <class RV, class XV, class SizeType = typename RV::size_type>
 struct V_Abs_Functor {
-  typedef typename RV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename XV::non_const_value_type> ATS;
 
@@ -128,7 +125,6 @@ struct V_Abs_Functor {
 // abs(R(i)).
 template <class RV, class SizeType = typename RV::size_type>
 struct V_AbsSelf_Functor {
-  typedef typename RV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename RV::non_const_value_type> ATS;
 
@@ -149,8 +145,8 @@ struct V_AbsSelf_Functor {
 
 // Invoke the "generic" (not unrolled) multivector functor that
 // computes entry-wise absolute value.
-template <class RMV, class XMV, class SizeType>
-void MV_Abs_Generic(const RMV& R, const XMV& X) {
+template <class execution_space, class RMV, class XMV, class SizeType>
+void MV_Abs_Generic(const execution_space& space, const RMV& R, const XMV& X) {
   static_assert(Kokkos::is_view<RMV>::value,
                 "KokkosBlas::Impl::"
                 "MV_Abs_Generic: RMV is not a Kokkos::View.");
@@ -164,9 +160,8 @@ void MV_Abs_Generic(const RMV& R, const XMV& X) {
                 "KokkosBlas::Impl::"
                 "MV_Abs_Generic: XMV is not rank 2");
 
-  typedef typename XMV::execution_space execution_space;
   const SizeType numRows = X.extent(0);
-  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
+  Kokkos::RangePolicy<execution_space, SizeType> policy(space, 0, numRows);
 
   if ((void*)(R.data()) ==
       (void*)(X.data())) {  // if R and X are the same (alias one another)
@@ -179,8 +174,8 @@ void MV_Abs_Generic(const RMV& R, const XMV& X) {
 }
 
 // Variant of MV_Abs_Generic for single vectors (1-D Views) R and X.
-template <class RV, class XV, class SizeType>
-void V_Abs_Generic(const RV& R, const XV& X) {
+template <class execution_space, class RV, class XV, class SizeType>
+void V_Abs_Generic(const execution_space& space, const RV& R, const XV& X) {
   static_assert(Kokkos::is_view<RV>::value,
                 "KokkosBlas::Impl::"
                 "V_Abs_Generic: RV is not a Kokkos::View.");
@@ -194,9 +189,8 @@ void V_Abs_Generic(const RV& R, const XV& X) {
                 "KokkosBlas::Impl::"
                 "V_Abs_Generic: XV is not rank 1");
 
-  typedef typename XV::execution_space execution_space;
   const SizeType numRows = X.extent(0);
-  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
+  Kokkos::RangePolicy<execution_space, SizeType> policy(space, 0, numRows);
 
   if ((void*)(R.data()) ==
       (void*)(X.data())) {  // if R and X are the same (alias one another)

--- a/blas/impl/KokkosBlas1_abs_spec.hpp
+++ b/blas/impl/KokkosBlas1_abs_spec.hpp
@@ -28,7 +28,7 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class RMV, class XMV, int rank = RMV::rank>
+template <class execution_space, class RMV, class XMV, int rank = RMV::rank>
 struct abs_eti_spec_avail {
   enum : bool { value = false };
 };
@@ -45,6 +45,7 @@ struct abs_eti_spec_avail {
 #define KOKKOSBLAS1_ABS_ETI_SPEC_AVAIL(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE) \
   template <>                                                                 \
   struct abs_eti_spec_avail<                                                  \
+      EXEC_SPACE,                                                             \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,    \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                 \
       Kokkos::View<const SCALAR*, LAYOUT,                                     \
@@ -65,6 +66,7 @@ struct abs_eti_spec_avail {
                                           MEM_SPACE)                        \
   template <>                                                               \
   struct abs_eti_spec_avail<                                                \
+      EXEC_SPACE,                                                           \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
       Kokkos::View<const SCALAR**, LAYOUT,                                  \
@@ -83,20 +85,20 @@ namespace KokkosBlas {
 namespace Impl {
 
 // Unification layer
-template <class RMV, class XMV, int rank = RMV::rank,
-          bool tpl_spec_avail = abs_tpl_spec_avail<RMV, XMV>::value,
-          bool eti_spec_avail = abs_eti_spec_avail<RMV, XMV>::value>
+template <class execution_space, class RMV, class XMV, int rank = RMV::rank,
+          bool tpl_spec_avail = abs_tpl_spec_avail<execution_space, RMV, XMV>::value,
+          bool eti_spec_avail = abs_eti_spec_avail<execution_space, RMV, XMV>::value>
 struct Abs {
-  static void abs(const RMV& R, const XMV& X);
+  static void abs(const execution_space& space, const RMV& R, const XMV& X);
 };
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 //! Full specialization of Abs for single vectors (1-D Views).
-template <class RMV, class XMV>
-struct Abs<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
-  typedef typename XMV::size_type size_type;
+template <class execution_space, class RMV, class XMV>
+struct Abs<execution_space, RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+  using size_type = typename XMV::size_type;
 
-  static void abs(const RMV& R, const XMV& X) {
+  static void abs(const execution_space& space, const RMV& R, const XMV& X) {
     static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Abs<1-D>: RMV is not a Kokkos::View.");
@@ -125,20 +127,20 @@ struct Abs<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 
     if (numRows < static_cast<size_type>(INT_MAX)) {
       typedef int index_type;
-      V_Abs_Generic<RMV, XMV, index_type>(R, X);
+      V_Abs_Generic<execution_space, RMV, XMV, index_type>(space, R, X);
     } else {
       typedef std::int64_t index_type;
-      V_Abs_Generic<RMV, XMV, index_type>(R, X);
+      V_Abs_Generic<execution_space, RMV, XMV, index_type>(space, R, X);
     }
     Kokkos::Profiling::popRegion();
   }
 };
 
-template <class RMV, class XMV>
-struct Abs<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
-  typedef typename XMV::size_type size_type;
+template <class execution_space, class RMV, class XMV>
+struct Abs<execution_space, RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+  using size_type = typename XMV::size_type;
 
-  static void abs(const RMV& R, const XMV& X) {
+  static void abs(const execution_space& space, const RMV& R, const XMV& X) {
     static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Abs<2-D>: RMV is not a Kokkos::View.");
@@ -169,10 +171,10 @@ struct Abs<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
     if (numRows < static_cast<size_type>(INT_MAX) &&
         numRows * numCols < static_cast<size_type>(INT_MAX)) {
       typedef int index_type;
-      MV_Abs_Generic<RMV, XMV, index_type>(R, X);
+      MV_Abs_Generic<execution_space, RMV, XMV, index_type>(space, R, X);
     } else {
       typedef std::int64_t index_type;
-      MV_Abs_Generic<RMV, XMV, index_type>(R, X);
+      MV_Abs_Generic<execution_space, RMV, XMV, index_type>(space, R, X);
     }
     Kokkos::Profiling::popRegion();
   }
@@ -191,6 +193,7 @@ struct Abs<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 //
 #define KOKKOSBLAS1_ABS_ETI_SPEC_DECL(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE) \
   extern template struct Abs<                                                \
+      EXEC_SPACE,                                                            \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,   \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                \
       Kokkos::View<const SCALAR*, LAYOUT,                                    \
@@ -205,6 +208,7 @@ struct Abs<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 //
 #define KOKKOSBLAS1_ABS_ETI_SPEC_INST(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE) \
   template struct Abs<                                                       \
+      EXEC_SPACE,                                                            \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,   \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                \
       Kokkos::View<const SCALAR*, LAYOUT,                                    \
@@ -222,6 +226,7 @@ struct Abs<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 #define KOKKOSBLAS1_ABS_MV_ETI_SPEC_DECL(SCALAR, LAYOUT, EXEC_SPACE,        \
                                          MEM_SPACE)                         \
   extern template struct Abs<                                               \
+      EXEC_SPACE,                                                           \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
       Kokkos::View<const SCALAR**, LAYOUT,                                  \
@@ -237,6 +242,7 @@ struct Abs<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 #define KOKKOSBLAS1_ABS_MV_ETI_SPEC_INST(SCALAR, LAYOUT, EXEC_SPACE,        \
                                          MEM_SPACE)                         \
   template struct Abs<                                                      \
+      EXEC_SPACE,                                                           \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
       Kokkos::View<const SCALAR**, LAYOUT,                                  \

--- a/blas/impl/KokkosBlas1_abs_spec.hpp
+++ b/blas/impl/KokkosBlas1_abs_spec.hpp
@@ -85,9 +85,10 @@ namespace KokkosBlas {
 namespace Impl {
 
 // Unification layer
-template <class execution_space, class RMV, class XMV, int rank = RMV::rank,
-          bool tpl_spec_avail = abs_tpl_spec_avail<execution_space, RMV, XMV>::value,
-          bool eti_spec_avail = abs_eti_spec_avail<execution_space, RMV, XMV>::value>
+template <
+    class execution_space, class RMV, class XMV, int rank = RMV::rank,
+    bool tpl_spec_avail = abs_tpl_spec_avail<execution_space, RMV, XMV>::value,
+    bool eti_spec_avail = abs_eti_spec_avail<execution_space, RMV, XMV>::value>
 struct Abs {
   static void abs(const execution_space& space, const RMV& R, const XMV& X);
 };
@@ -95,7 +96,8 @@ struct Abs {
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 //! Full specialization of Abs for single vectors (1-D Views).
 template <class execution_space, class RMV, class XMV>
-struct Abs<execution_space, RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+struct Abs<execution_space, RMV, XMV, 1, false,
+           KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   using size_type = typename XMV::size_type;
 
   static void abs(const execution_space& space, const RMV& R, const XMV& X) {
@@ -137,7 +139,8 @@ struct Abs<execution_space, RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRA
 };
 
 template <class execution_space, class RMV, class XMV>
-struct Abs<execution_space, RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+struct Abs<execution_space, RMV, XMV, 2, false,
+           KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   using size_type = typename XMV::size_type;
 
   static void abs(const execution_space& space, const RMV& R, const XMV& X) {

--- a/blas/impl/KokkosBlas1_axpby_impl.hpp
+++ b/blas/impl/KokkosBlas1_axpby_impl.hpp
@@ -302,8 +302,8 @@ struct Axpby_Functor<typename XV::non_const_value_type, XV,
 //
 // This takes the starting column, so that if av and bv are both 1-D
 // Views, then the functor can take a subview if appropriate.
-template <class AV, class XV, class BV, class YV, class SizeType>
-void Axpby_Generic(const AV& av, const XV& x, const BV& bv, const YV& y,
+template <class execution_space, class AV, class XV, class BV, class YV, class SizeType>
+void Axpby_Generic(const execution_space& space, const AV& av, const XV& x, const BV& bv, const YV& y,
                    const SizeType startingColumn, int a = 2, int b = 2) {
   static_assert(Kokkos::is_view<XV>::value,
                 "KokkosBlas::Impl::"
@@ -323,9 +323,8 @@ void Axpby_Generic(const AV& av, const XV& x, const BV& bv, const YV& y,
                 "KokkosBlas::Impl::Axpby_Generic: "
                 "XV and YV must have rank 1.");
 
-  typedef typename YV::execution_space execution_space;
   const SizeType numRows = x.extent(0);
-  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
+  Kokkos::RangePolicy<execution_space, SizeType> policy(space, 0, numRows);
 
   if (a == 0 && b == 0) {
     Axpby_Functor<AV, XV, BV, YV, 0, 0, SizeType> op(x, y, av, bv,

--- a/blas/impl/KokkosBlas1_axpby_impl.hpp
+++ b/blas/impl/KokkosBlas1_axpby_impl.hpp
@@ -302,9 +302,11 @@ struct Axpby_Functor<typename XV::non_const_value_type, XV,
 //
 // This takes the starting column, so that if av and bv are both 1-D
 // Views, then the functor can take a subview if appropriate.
-template <class execution_space, class AV, class XV, class BV, class YV, class SizeType>
-void Axpby_Generic(const execution_space& space, const AV& av, const XV& x, const BV& bv, const YV& y,
-                   const SizeType startingColumn, int a = 2, int b = 2) {
+template <class execution_space, class AV, class XV, class BV, class YV,
+          class SizeType>
+void Axpby_Generic(const execution_space& space, const AV& av, const XV& x,
+                   const BV& bv, const YV& y, const SizeType startingColumn,
+                   int a = 2, int b = 2) {
   static_assert(Kokkos::is_view<XV>::value,
                 "KokkosBlas::Impl::"
                 "Axpby_Generic: X is not a Kokkos::View.");

--- a/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
+++ b/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
@@ -947,8 +947,10 @@ struct Axpby_MV_Unroll_Functor<typename XMV::non_const_value_type, XMV,
 // coefficients in av and bv vectors, if they are used.
 //
 // Either av and bv are both 1-D Views, or av and bv are both scalars.
-template <class execution_space, class AV, class XMV, class BV, class YMV, int UNROLL, class SizeType>
-void Axpby_MV_Unrolled(const execution_space& space, const AV& av, const XMV& x, const BV& bv, const YMV& y,
+template <class execution_space, class AV, class XMV, class BV, class YMV,
+          int UNROLL, class SizeType>
+void Axpby_MV_Unrolled(const execution_space& space, const AV& av, const XMV& x,
+                       const BV& bv, const YMV& y,
                        const SizeType startingColumn, int a = 2, int b = 2) {
   static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::Impl::"
@@ -1101,9 +1103,10 @@ void Axpby_MV_Unrolled(const execution_space& space, const AV& av, const XMV& x,
 // coefficients in av and bv vectors, if they are used.
 //
 // Either av and bv are both 1-D Views, or av and bv are both scalars.
-template <class execution_space, class AV, class XMV, class BV, class YMV, class SizeType>
-void Axpby_MV_Generic(const execution_space& space, const AV& av, const XMV& x, const BV& bv, const YMV& y,
-                      int a = 2, int b = 2) {
+template <class execution_space, class AV, class XMV, class BV, class YMV,
+          class SizeType>
+void Axpby_MV_Generic(const execution_space& space, const AV& av, const XMV& x,
+                      const BV& bv, const YMV& y, int a = 2, int b = 2) {
   static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::Impl::"
                 "Axpby_MV_Generic: X is not a Kokkos::View.");
@@ -1239,10 +1242,11 @@ void Axpby_MV_Generic(const execution_space& space, const AV& av, const XMV& x, 
 // coefficients in av and bv vectors, if they are used.
 //
 // Either av and bv are both 1-D Views, or av and bv are both scalars.
-template <class execution_space, class AV, class XMV, class BV, class YMV, class SizeType>
+template <class execution_space, class AV, class XMV, class BV, class YMV,
+          class SizeType>
 struct Axpby_MV_Invoke_Left {
-  static void run(const execution_space& space, const AV& av, const XMV& x, const BV& bv, const YMV& y,
-                  int a = 2, int b = 2) {
+  static void run(const execution_space& space, const AV& av, const XMV& x,
+                  const BV& bv, const YMV& y, int a = 2, int b = 2) {
     static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Invoke_Left: X is not a Kokkos::View.");
@@ -1274,8 +1278,8 @@ struct Axpby_MV_Invoke_Left {
       // Passing in the starting column index lets the functor take
       // subviews of av and bv, if they are Views.  If they are scalars,
       // the functor doesn't have to do anything to them.
-      Axpby_MV_Unrolled<execution_space, AV, XMV, BV, YMV, 8, SizeType>(space, av, X_cur, bv, Y_cur, j,
-                                                       a, b);
+      Axpby_MV_Unrolled<execution_space, AV, XMV, BV, YMV, 8, SizeType>(
+          space, av, X_cur, bv, Y_cur, j, a, b);
     }
     for (; j + 4 <= numCols; j += 4) {
       XMV X_cur = Kokkos::subview(x, Kokkos::ALL(), std::make_pair(j, j + 4));
@@ -1284,8 +1288,8 @@ struct Axpby_MV_Invoke_Left {
       // Passing in the starting column index lets the functor take
       // subviews of av and bv, if they are Views.  If they are scalars,
       // the functor doesn't have to do anything to them.
-      Axpby_MV_Unrolled<execution_space, AV, XMV, BV, YMV, 4, SizeType>(space, av, X_cur, bv, Y_cur, j,
-                                                       a, b);
+      Axpby_MV_Unrolled<execution_space, AV, XMV, BV, YMV, 4, SizeType>(
+          space, av, X_cur, bv, Y_cur, j, a, b);
     }
     for (; j < numCols; ++j) {
       auto x_cur = Kokkos::subview(x, Kokkos::ALL(), j);
@@ -1296,7 +1300,8 @@ struct Axpby_MV_Invoke_Left {
       // the functor doesn't have to do anything to them.
       typedef decltype(x_cur) XV;
       typedef decltype(y_cur) YV;
-      Axpby_Generic<execution_space, AV, XV, BV, YV, SizeType>(space, av, x_cur, bv, y_cur, j, a, b);
+      Axpby_Generic<execution_space, AV, XV, BV, YV, SizeType>(
+          space, av, x_cur, bv, y_cur, j, a, b);
     }
   }
 };
@@ -1320,10 +1325,11 @@ struct Axpby_MV_Invoke_Left {
 // coefficients in av and bv vectors, if they are used.
 //
 // Either av and bv are both 1-D Views, or av and bv are both scalars.
-template <class execution_space, class AV, class XMV, class BV, class YMV, class SizeType>
+template <class execution_space, class AV, class XMV, class BV, class YMV,
+          class SizeType>
 struct Axpby_MV_Invoke_Right {
-  static void run(const execution_space& space, const AV& av, const XMV& x, const BV& bv, const YMV& y,
-                  int a = 2, int b = 2) {
+  static void run(const execution_space& space, const AV& av, const XMV& x,
+                  const BV& bv, const YMV& y, int a = 2, int b = 2) {
     static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
                   "Axpby_MV_Invoke_Right: X is not a Kokkos::View.");
@@ -1348,9 +1354,11 @@ struct Axpby_MV_Invoke_Right {
       auto y_0 = Kokkos::subview(y, Kokkos::ALL(), 0);
       typedef decltype(x_0) XV;
       typedef decltype(y_0) YV;
-      Axpby_Generic<execution_space, AV, XV, BV, YV, SizeType>(space, av, x_0, bv, y_0, 0, a, b);
+      Axpby_Generic<execution_space, AV, XV, BV, YV, SizeType>(
+          space, av, x_0, bv, y_0, 0, a, b);
     } else {
-      Axpby_MV_Generic<execution_space, AV, XMV, BV, YMV, SizeType>(space, av, x, bv, y, a, b);
+      Axpby_MV_Generic<execution_space, AV, XMV, BV, YMV, SizeType>(
+          space, av, x, bv, y, a, b);
     }
   }
 };

--- a/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
+++ b/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
@@ -43,7 +43,6 @@ namespace Impl {
 template <class AV, class XMV, class BV, class YMV, int scalar_x, int scalar_y,
           class SizeType = typename YMV::size_type>
 struct Axpby_MV_Functor {
-  typedef typename YMV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename YMV::non_const_value_type> ATS;
 
@@ -286,7 +285,6 @@ template <class XMV, class YMV, int scalar_x, int scalar_y, class SizeType>
 struct Axpby_MV_Functor<typename XMV::non_const_value_type, XMV,
                         typename YMV::non_const_value_type, YMV, scalar_x,
                         scalar_y, SizeType> {
-  typedef typename YMV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename YMV::non_const_value_type> ATS;
 
@@ -500,7 +498,6 @@ struct Axpby_MV_Functor<typename XMV::non_const_value_type, XMV,
 template <class AV, class XMV, class BV, class YMV, int scalar_x, int scalar_y,
           int UNROLL, class SizeType>
 struct Axpby_MV_Unroll_Functor {
-  typedef typename YMV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename YMV::non_const_value_type> ATS;
 
@@ -728,7 +725,6 @@ template <class XMV, class YMV, int scalar_x, int scalar_y, int UNROLL,
 struct Axpby_MV_Unroll_Functor<typename XMV::non_const_value_type, XMV,
                                typename YMV::non_const_value_type, YMV,
                                scalar_x, scalar_y, UNROLL, SizeType> {
-  typedef typename YMV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename YMV::non_const_value_type> ATS;
 
@@ -951,8 +947,8 @@ struct Axpby_MV_Unroll_Functor<typename XMV::non_const_value_type, XMV,
 // coefficients in av and bv vectors, if they are used.
 //
 // Either av and bv are both 1-D Views, or av and bv are both scalars.
-template <class AV, class XMV, class BV, class YMV, int UNROLL, class SizeType>
-void Axpby_MV_Unrolled(const AV& av, const XMV& x, const BV& bv, const YMV& y,
+template <class execution_space, class AV, class XMV, class BV, class YMV, int UNROLL, class SizeType>
+void Axpby_MV_Unrolled(const execution_space& space, const AV& av, const XMV& x, const BV& bv, const YMV& y,
                        const SizeType startingColumn, int a = 2, int b = 2) {
   static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::Impl::"
@@ -972,9 +968,8 @@ void Axpby_MV_Unrolled(const AV& av, const XMV& x, const BV& bv, const YMV& y,
                 "KokkosBlas::Impl::Axpby_MV_Unrolled: "
                 "XMV and YMV must have rank 2.");
 
-  typedef typename YMV::execution_space execution_space;
   const SizeType numRows = x.extent(0);
-  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
+  Kokkos::RangePolicy<execution_space, SizeType> policy(space, 0, numRows);
 
   if (a == 0 && b == 0) {
     Axpby_MV_Unroll_Functor<AV, XMV, BV, YMV, 0, 0, UNROLL, SizeType> op(
@@ -1106,8 +1101,8 @@ void Axpby_MV_Unrolled(const AV& av, const XMV& x, const BV& bv, const YMV& y,
 // coefficients in av and bv vectors, if they are used.
 //
 // Either av and bv are both 1-D Views, or av and bv are both scalars.
-template <class AV, class XMV, class BV, class YMV, class SizeType>
-void Axpby_MV_Generic(const AV& av, const XMV& x, const BV& bv, const YMV& y,
+template <class execution_space, class AV, class XMV, class BV, class YMV, class SizeType>
+void Axpby_MV_Generic(const execution_space& space, const AV& av, const XMV& x, const BV& bv, const YMV& y,
                       int a = 2, int b = 2) {
   static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::Impl::"
@@ -1127,9 +1122,8 @@ void Axpby_MV_Generic(const AV& av, const XMV& x, const BV& bv, const YMV& y,
                 "KokkosBlas::Impl::Axpby_MV_Generic: "
                 "XMV and YMV must have rank 2.");
 
-  typedef typename YMV::execution_space execution_space;
   const SizeType numRows = x.extent(0);
-  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
+  Kokkos::RangePolicy<execution_space, SizeType> policy(space, 0, numRows);
 
   if (a == 0 && b == 0) {
     Axpby_MV_Functor<AV, XMV, BV, YMV, 0, 0, SizeType> op(x, y, av, bv);
@@ -1245,9 +1239,9 @@ void Axpby_MV_Generic(const AV& av, const XMV& x, const BV& bv, const YMV& y,
 // coefficients in av and bv vectors, if they are used.
 //
 // Either av and bv are both 1-D Views, or av and bv are both scalars.
-template <class AV, class XMV, class BV, class YMV, class SizeType>
+template <class execution_space, class AV, class XMV, class BV, class YMV, class SizeType>
 struct Axpby_MV_Invoke_Left {
-  static void run(const AV& av, const XMV& x, const BV& bv, const YMV& y,
+  static void run(const execution_space& space, const AV& av, const XMV& x, const BV& bv, const YMV& y,
                   int a = 2, int b = 2) {
     static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
@@ -1280,7 +1274,7 @@ struct Axpby_MV_Invoke_Left {
       // Passing in the starting column index lets the functor take
       // subviews of av and bv, if they are Views.  If they are scalars,
       // the functor doesn't have to do anything to them.
-      Axpby_MV_Unrolled<AV, XMV, BV, YMV, 8, SizeType>(av, X_cur, bv, Y_cur, j,
+      Axpby_MV_Unrolled<execution_space, AV, XMV, BV, YMV, 8, SizeType>(space, av, X_cur, bv, Y_cur, j,
                                                        a, b);
     }
     for (; j + 4 <= numCols; j += 4) {
@@ -1290,7 +1284,7 @@ struct Axpby_MV_Invoke_Left {
       // Passing in the starting column index lets the functor take
       // subviews of av and bv, if they are Views.  If they are scalars,
       // the functor doesn't have to do anything to them.
-      Axpby_MV_Unrolled<AV, XMV, BV, YMV, 4, SizeType>(av, X_cur, bv, Y_cur, j,
+      Axpby_MV_Unrolled<execution_space, AV, XMV, BV, YMV, 4, SizeType>(space, av, X_cur, bv, Y_cur, j,
                                                        a, b);
     }
     for (; j < numCols; ++j) {
@@ -1302,7 +1296,7 @@ struct Axpby_MV_Invoke_Left {
       // the functor doesn't have to do anything to them.
       typedef decltype(x_cur) XV;
       typedef decltype(y_cur) YV;
-      Axpby_Generic<AV, XV, BV, YV, SizeType>(av, x_cur, bv, y_cur, j, a, b);
+      Axpby_Generic<execution_space, AV, XV, BV, YV, SizeType>(space, av, x_cur, bv, y_cur, j, a, b);
     }
   }
 };
@@ -1326,9 +1320,9 @@ struct Axpby_MV_Invoke_Left {
 // coefficients in av and bv vectors, if they are used.
 //
 // Either av and bv are both 1-D Views, or av and bv are both scalars.
-template <class AV, class XMV, class BV, class YMV, class SizeType>
+template <class execution_space, class AV, class XMV, class BV, class YMV, class SizeType>
 struct Axpby_MV_Invoke_Right {
-  static void run(const AV& av, const XMV& x, const BV& bv, const YMV& y,
+  static void run(const execution_space& space, const AV& av, const XMV& x, const BV& bv, const YMV& y,
                   int a = 2, int b = 2) {
     static_assert(Kokkos::is_view<XMV>::value,
                   "KokkosBlas::Impl::"
@@ -1354,9 +1348,9 @@ struct Axpby_MV_Invoke_Right {
       auto y_0 = Kokkos::subview(y, Kokkos::ALL(), 0);
       typedef decltype(x_0) XV;
       typedef decltype(y_0) YV;
-      Axpby_Generic<AV, XV, BV, YV, SizeType>(av, x_0, bv, y_0, 0, a, b);
+      Axpby_Generic<execution_space, AV, XV, BV, YV, SizeType>(space, av, x_0, bv, y_0, 0, a, b);
     } else {
-      Axpby_MV_Generic<AV, XMV, BV, YMV, SizeType>(av, x, bv, y, a, b);
+      Axpby_MV_Generic<execution_space, AV, XMV, BV, YMV, SizeType>(space, av, x, bv, y, a, b);
     }
   }
 };

--- a/blas/impl/KokkosBlas1_mult_impl.hpp
+++ b/blas/impl/KokkosBlas1_mult_impl.hpp
@@ -145,7 +145,8 @@ struct V_MultFunctor {
 /// C(i) = c * C(i) + ab * A(i) * B(i), subject to the usual BLAS
 /// update rules.
 template <class execution_space, class CV, class AV, class BV, class SizeType>
-void V_Mult_Generic(const execution_space& space, typename CV::const_value_type& c, const CV& C,
+void V_Mult_Generic(const execution_space& space,
+                    typename CV::const_value_type& c, const CV& C,
                     typename AV::const_value_type& ab, const AV& A,
                     const BV& B) {
   using Kokkos::ALL;
@@ -191,7 +192,8 @@ void V_Mult_Generic(const execution_space& space, typename CV::const_value_type&
 /// C(i,j) = c * C(i,j) + ab * A(i) * B(i,j), subject to the usual
 /// BLAS update rules.
 template <class execution_space, class CMV, class AV, class BMV, class SizeType>
-void MV_Mult_Generic(const execution_space& space, typename CMV::const_value_type& c, const CMV& C,
+void MV_Mult_Generic(const execution_space& space,
+                     typename CMV::const_value_type& c, const CMV& C,
                      typename AV::const_value_type& ab, const AV& A,
                      const BMV& B) {
   typedef Kokkos::ArithTraits<typename AV::non_const_value_type> ATA;
@@ -203,7 +205,8 @@ void MV_Mult_Generic(const execution_space& space, typename CMV::const_value_typ
     typedef decltype(C_0) CV;
     typedef decltype(B_0) BV;
 
-    V_Mult_Generic<execution_space, CV, AV, BV, SizeType>(space, c, C_0, ab, A, B_0);
+    V_Mult_Generic<execution_space, CV, AV, BV, SizeType>(space, c, C_0, ab, A,
+                                                          B_0);
     return;
   }
 

--- a/blas/impl/KokkosBlas1_mult_impl.hpp
+++ b/blas/impl/KokkosBlas1_mult_impl.hpp
@@ -37,7 +37,6 @@ namespace Impl {
 template <class CMV, class AV, class BMV, int scalar_ab, int scalar_c,
           class SizeType = typename CMV::size_type>
 struct MV_MultFunctor {
-  typedef typename CMV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename CMV::non_const_value_type> ATS;
 
@@ -105,7 +104,6 @@ struct MV_MultFunctor {
 template <class CV, class AV, class BV, int scalar_ab, int scalar_c,
           class SizeType = typename CV::size_type>
 struct V_MultFunctor {
-  typedef typename CV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename CV::non_const_value_type> ATS;
 
@@ -146,18 +144,17 @@ struct V_MultFunctor {
 ///
 /// C(i) = c * C(i) + ab * A(i) * B(i), subject to the usual BLAS
 /// update rules.
-template <class CV, class AV, class BV, class SizeType>
-void V_Mult_Generic(typename CV::const_value_type& c, const CV& C,
+template <class execution_space, class CV, class AV, class BV, class SizeType>
+void V_Mult_Generic(const execution_space& space, typename CV::const_value_type& c, const CV& C,
                     typename AV::const_value_type& ab, const AV& A,
                     const BV& B) {
   using Kokkos::ALL;
   using Kokkos::subview;
   typedef Kokkos::ArithTraits<typename AV::non_const_value_type> ATA;
   typedef Kokkos::ArithTraits<typename CV::non_const_value_type> ATC;
-  typedef typename CV::execution_space execution_space;
 
   const SizeType numRows = C.extent(0);
-  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
+  Kokkos::RangePolicy<execution_space, SizeType> policy(space, 0, numRows);
 
   if (c == ATC::zero()) {
     if (ab == ATA::zero()) {
@@ -193,13 +190,12 @@ void V_Mult_Generic(typename CV::const_value_type& c, const CV& C,
 ///
 /// C(i,j) = c * C(i,j) + ab * A(i) * B(i,j), subject to the usual
 /// BLAS update rules.
-template <class CMV, class AV, class BMV, class SizeType>
-void MV_Mult_Generic(typename CMV::const_value_type& c, const CMV& C,
+template <class execution_space, class CMV, class AV, class BMV, class SizeType>
+void MV_Mult_Generic(const execution_space& space, typename CMV::const_value_type& c, const CMV& C,
                      typename AV::const_value_type& ab, const AV& A,
                      const BMV& B) {
   typedef Kokkos::ArithTraits<typename AV::non_const_value_type> ATA;
   typedef Kokkos::ArithTraits<typename CMV::non_const_value_type> ATC;
-  typedef typename CMV::execution_space execution_space;
 
   if (C.extent(1) == 1) {
     auto C_0 = Kokkos::subview(C, Kokkos::ALL(), 0);
@@ -207,12 +203,12 @@ void MV_Mult_Generic(typename CMV::const_value_type& c, const CMV& C,
     typedef decltype(C_0) CV;
     typedef decltype(B_0) BV;
 
-    V_Mult_Generic<CV, AV, BV, SizeType>(c, C_0, ab, A, B_0);
+    V_Mult_Generic<execution_space, CV, AV, BV, SizeType>(space, c, C_0, ab, A, B_0);
     return;
   }
 
   const SizeType numRows = C.extent(0);
-  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
+  Kokkos::RangePolicy<execution_space, SizeType> policy(space, 0, numRows);
 
   if (c == ATC::zero()) {
     if (ab == ATA::zero()) {

--- a/blas/impl/KokkosBlas1_mult_spec.hpp
+++ b/blas/impl/KokkosBlas1_mult_spec.hpp
@@ -27,7 +27,8 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class execution_space, class YMV, class AV, class XMV, int rank = XMV::rank>
+template <class execution_space, class YMV, class AV, class XMV,
+          int rank = XMV::rank>
 struct mult_eti_spec_avail {
   enum : bool { value = false };
 };
@@ -100,11 +101,15 @@ namespace Impl {
 /// Y(i,j) = alpha*A(i,j)*X(i,j) + gamma*Y(i,j)
 ///
 /// with special cases for alpha, or gamma = 0.
-template <class execution_space, class YMV, class AV, class XMV, int rank = XMV::rank,
-          bool tpl_spec_avail = mult_tpl_spec_avail<execution_space, YMV, AV, XMV>::value,
-          bool eti_spec_avail = mult_eti_spec_avail<execution_space, YMV, AV, XMV>::value>
+template <class execution_space, class YMV, class AV, class XMV,
+          int rank = XMV::rank,
+          bool tpl_spec_avail =
+              mult_tpl_spec_avail<execution_space, YMV, AV, XMV>::value,
+          bool eti_spec_avail =
+              mult_eti_spec_avail<execution_space, YMV, AV, XMV>::value>
 struct Mult {
-  static void mult(const execution_space& space, const typename YMV::non_const_value_type& gamma,
+  static void mult(const execution_space& space,
+                   const typename YMV::non_const_value_type& gamma,
                    const YMV& Y,
                    const typename XMV::non_const_value_type& alpha, const AV& A,
                    const XMV& X);
@@ -113,13 +118,15 @@ struct Mult {
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 // Partial specialization for YMV, AV, and XMV rank-2 Views.
 template <class execution_space, class YMV, class AV, class XMV>
-struct Mult<execution_space, YMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+struct Mult<execution_space, YMV, AV, XMV, 2, false,
+            KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename YMV::size_type size_type;
   typedef typename YMV::non_const_value_type YMV_scalar;
   typedef typename XMV::non_const_value_type XMV_scalar;
 
-  static void mult(const execution_space& space, const YMV_scalar& gamma, const YMV& Y,
-                   const XMV_scalar& alpha, const AV& A, const XMV& X) {
+  static void mult(const execution_space& space, const YMV_scalar& gamma,
+                   const YMV& Y, const XMV_scalar& alpha, const AV& A,
+                   const XMV& X) {
     static_assert(Kokkos::is_view<YMV>::value,
                   "KokkosBlas::Impl::"
                   "Mult<rank 2>::mult: Y is not a Kokkos::View.");
@@ -162,9 +169,11 @@ struct Mult<execution_space, YMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_
 
     if (numRows < static_cast<int>(INT_MAX) &&
         numRows * numCols < static_cast<int>(INT_MAX)) {
-      MV_Mult_Generic<execution_space, YMV, AV, XMV, int>(space, gamma, Y, alpha, A, X);
+      MV_Mult_Generic<execution_space, YMV, AV, XMV, int>(space, gamma, Y,
+                                                          alpha, A, X);
     } else {
-      MV_Mult_Generic<execution_space, YMV, AV, XMV, int64_t>(space, gamma, Y, alpha, A, X);
+      MV_Mult_Generic<execution_space, YMV, AV, XMV, int64_t>(space, gamma, Y,
+                                                              alpha, A, X);
     }
     Kokkos::Profiling::popRegion();
   }
@@ -172,13 +181,15 @@ struct Mult<execution_space, YMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_
 
 // Partial specialization for YV, AV, and XV rank-1 Views.
 template <class execution_space, class YV, class AV, class XV>
-struct Mult<execution_space, YV, AV, XV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+struct Mult<execution_space, YV, AV, XV, 1, false,
+            KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename YV::size_type size_type;
   typedef typename YV::non_const_value_type YV_scalar;
   typedef typename XV::non_const_value_type XV_scalar;
 
-  static void mult(const execution_space& space, const YV_scalar& gamma, const YV& Y, const XV_scalar& alpha,
-                   const AV& A, const XV& X) {
+  static void mult(const execution_space& space, const YV_scalar& gamma,
+                   const YV& Y, const XV_scalar& alpha, const AV& A,
+                   const XV& X) {
     // YV, AV, and XV must be Kokkos::View specializations.
     static_assert(Kokkos::is_view<YV>::value,
                   "KokkosBlas::Impl::"
@@ -214,9 +225,11 @@ struct Mult<execution_space, YV, AV, XV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LI
 
     const size_type numRows = Y.extent(0);
     if (numRows < static_cast<int>(INT_MAX)) {
-      V_Mult_Generic<execution_space, YV, AV, XV, int>(space, gamma, Y, alpha, A, X);
+      V_Mult_Generic<execution_space, YV, AV, XV, int>(space, gamma, Y, alpha,
+                                                       A, X);
     } else {
-      V_Mult_Generic<execution_space, YV, AV, XV, int64_t>(space, gamma, Y, alpha, A, X);
+      V_Mult_Generic<execution_space, YV, AV, XV, int64_t>(space, gamma, Y,
+                                                           alpha, A, X);
     }
     Kokkos::Profiling::popRegion();
   }

--- a/blas/impl/KokkosBlas1_mult_spec.hpp
+++ b/blas/impl/KokkosBlas1_mult_spec.hpp
@@ -27,7 +27,7 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class YMV, class AV, class XMV, int rank = XMV::rank>
+template <class execution_space, class YMV, class AV, class XMV, int rank = XMV::rank>
 struct mult_eti_spec_avail {
   enum : bool { value = false };
 };
@@ -44,6 +44,7 @@ struct mult_eti_spec_avail {
 #define KOKKOSBLAS1_MULT_ETI_SPEC_AVAIL(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE) \
   template <>                                                                  \
   struct mult_eti_spec_avail<                                                  \
+      EXEC_SPACE,                                                              \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,     \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       Kokkos::View<const SCALAR*, LAYOUT,                                      \
@@ -67,6 +68,7 @@ struct mult_eti_spec_avail {
                                            MEM_SPACE)                       \
   template <>                                                               \
   struct mult_eti_spec_avail<                                               \
+      EXEC_SPACE,                                                           \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
       Kokkos::View<const SCALAR*, LAYOUT,                                   \
@@ -98,11 +100,11 @@ namespace Impl {
 /// Y(i,j) = alpha*A(i,j)*X(i,j) + gamma*Y(i,j)
 ///
 /// with special cases for alpha, or gamma = 0.
-template <class YMV, class AV, class XMV, int rank = XMV::rank,
-          bool tpl_spec_avail = mult_tpl_spec_avail<YMV, AV, XMV>::value,
-          bool eti_spec_avail = mult_eti_spec_avail<YMV, AV, XMV>::value>
+template <class execution_space, class YMV, class AV, class XMV, int rank = XMV::rank,
+          bool tpl_spec_avail = mult_tpl_spec_avail<execution_space, YMV, AV, XMV>::value,
+          bool eti_spec_avail = mult_eti_spec_avail<execution_space, YMV, AV, XMV>::value>
 struct Mult {
-  static void mult(const typename YMV::non_const_value_type& gamma,
+  static void mult(const execution_space& space, const typename YMV::non_const_value_type& gamma,
                    const YMV& Y,
                    const typename XMV::non_const_value_type& alpha, const AV& A,
                    const XMV& X);
@@ -110,13 +112,13 @@ struct Mult {
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 // Partial specialization for YMV, AV, and XMV rank-2 Views.
-template <class YMV, class AV, class XMV>
-struct Mult<YMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+template <class execution_space, class YMV, class AV, class XMV>
+struct Mult<execution_space, YMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename YMV::size_type size_type;
   typedef typename YMV::non_const_value_type YMV_scalar;
   typedef typename XMV::non_const_value_type XMV_scalar;
 
-  static void mult(const YMV_scalar& gamma, const YMV& Y,
+  static void mult(const execution_space& space, const YMV_scalar& gamma, const YMV& Y,
                    const XMV_scalar& alpha, const AV& A, const XMV& X) {
     static_assert(Kokkos::is_view<YMV>::value,
                   "KokkosBlas::Impl::"
@@ -160,22 +162,22 @@ struct Mult<YMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 
     if (numRows < static_cast<int>(INT_MAX) &&
         numRows * numCols < static_cast<int>(INT_MAX)) {
-      MV_Mult_Generic<YMV, AV, XMV, int>(gamma, Y, alpha, A, X);
+      MV_Mult_Generic<execution_space, YMV, AV, XMV, int>(space, gamma, Y, alpha, A, X);
     } else {
-      MV_Mult_Generic<YMV, AV, XMV, int64_t>(gamma, Y, alpha, A, X);
+      MV_Mult_Generic<execution_space, YMV, AV, XMV, int64_t>(space, gamma, Y, alpha, A, X);
     }
     Kokkos::Profiling::popRegion();
   }
 };
 
 // Partial specialization for YV, AV, and XV rank-1 Views.
-template <class YV, class AV, class XV>
-struct Mult<YV, AV, XV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+template <class execution_space, class YV, class AV, class XV>
+struct Mult<execution_space, YV, AV, XV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename YV::size_type size_type;
   typedef typename YV::non_const_value_type YV_scalar;
   typedef typename XV::non_const_value_type XV_scalar;
 
-  static void mult(const YV_scalar& gamma, const YV& Y, const XV_scalar& alpha,
+  static void mult(const execution_space& space, const YV_scalar& gamma, const YV& Y, const XV_scalar& alpha,
                    const AV& A, const XV& X) {
     // YV, AV, and XV must be Kokkos::View specializations.
     static_assert(Kokkos::is_view<YV>::value,
@@ -212,9 +214,9 @@ struct Mult<YV, AV, XV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 
     const size_type numRows = Y.extent(0);
     if (numRows < static_cast<int>(INT_MAX)) {
-      V_Mult_Generic<YV, AV, XV, int>(gamma, Y, alpha, A, X);
+      V_Mult_Generic<execution_space, YV, AV, XV, int>(space, gamma, Y, alpha, A, X);
     } else {
-      V_Mult_Generic<YV, AV, XV, int64_t>(gamma, Y, alpha, A, X);
+      V_Mult_Generic<execution_space, YV, AV, XV, int64_t>(space, gamma, Y, alpha, A, X);
     }
     Kokkos::Profiling::popRegion();
   }
@@ -235,6 +237,7 @@ struct Mult<YV, AV, XV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 
 #define KOKKOSBLAS1_MULT_ETI_SPEC_DECL(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE) \
   extern template struct Mult<                                                \
+      EXEC_SPACE,                                                             \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,    \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                 \
       Kokkos::View<const SCALAR*, LAYOUT,                                     \
@@ -247,6 +250,7 @@ struct Mult<YV, AV, XV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 
 #define KOKKOSBLAS1_MULT_ETI_SPEC_INST(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE) \
   template struct Mult<                                                       \
+      EXEC_SPACE,                                                             \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,    \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                 \
       Kokkos::View<const SCALAR*, LAYOUT,                                     \
@@ -268,6 +272,7 @@ struct Mult<YV, AV, XV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 #define KOKKOSBLAS1_MULT_MV_ETI_SPEC_DECL(SCALAR, LAYOUT, EXEC_SPACE,       \
                                           MEM_SPACE)                        \
   extern template struct Mult<                                              \
+      EXEC_SPACE,                                                           \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
       Kokkos::View<const SCALAR*, LAYOUT,                                   \
@@ -281,6 +286,7 @@ struct Mult<YV, AV, XV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 #define KOKKOSBLAS1_MULT_MV_ETI_SPEC_INST(SCALAR, LAYOUT, EXEC_SPACE,       \
                                           MEM_SPACE)                        \
   template struct Mult<                                                     \
+      EXEC_SPACE,                                                           \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
       Kokkos::View<const SCALAR*, LAYOUT,                                   \

--- a/blas/impl/KokkosBlas1_reciprocal_impl.hpp
+++ b/blas/impl/KokkosBlas1_reciprocal_impl.hpp
@@ -30,7 +30,6 @@ namespace Impl {
 // Entry-wise reciprocalolute value / magnitude: R(i,j) = reciprocal(X(i,j)).
 template <class RMV, class XMV, class SizeType = typename RMV::size_type>
 struct MV_Reciprocal_Functor {
-  typedef typename RMV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename XMV::non_const_value_type> ATS;
 
@@ -69,7 +68,6 @@ struct MV_Reciprocal_Functor {
 // reciprocal(R(i,j)).
 template <class RMV, class SizeType = typename RMV::size_type>
 struct MV_ReciprocalSelf_Functor {
-  typedef typename RMV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename RMV::non_const_value_type> ATS;
 
@@ -100,7 +98,6 @@ struct MV_ReciprocalSelf_Functor {
 // reciprocal(X(i)).
 template <class RV, class XV, class SizeType = typename RV::size_type>
 struct V_Reciprocal_Functor {
-  typedef typename RV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename XV::non_const_value_type> ATS;
 
@@ -130,7 +127,6 @@ struct V_Reciprocal_Functor {
 // reciprocal(R(i)).
 template <class RV, class SizeType = typename RV::size_type>
 struct V_ReciprocalSelf_Functor {
-  typedef typename RV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename RV::non_const_value_type> ATS;
 
@@ -151,8 +147,8 @@ struct V_ReciprocalSelf_Functor {
 
 // Invoke the "generic" (not unrolled) multivector functor that
 // computes entry-wise reciprocalolute value.
-template <class RMV, class XMV, class SizeType>
-void MV_Reciprocal_Generic(const RMV& R, const XMV& X) {
+template <class execution_space, class RMV, class XMV, class SizeType>
+void MV_Reciprocal_Generic(const execution_space& space, const RMV& R, const XMV& X) {
   static_assert(Kokkos::is_view<RMV>::value,
                 "KokkosBlas::Impl::"
                 "MV_Reciprocal_Generic: RMV is not a Kokkos::View.");
@@ -166,9 +162,8 @@ void MV_Reciprocal_Generic(const RMV& R, const XMV& X) {
                 "KokkosBlas::Impl::"
                 "MV_Reciprocal_Generic: XMV is not rank 2");
 
-  typedef typename XMV::execution_space execution_space;
   const SizeType numRows = X.extent(0);
-  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
+  Kokkos::RangePolicy<execution_space, SizeType> policy(space, 0, numRows);
 
   if (R == X) {  // if R and X are the same (alias one another)
     MV_ReciprocalSelf_Functor<RMV, SizeType> op(R);
@@ -180,8 +175,8 @@ void MV_Reciprocal_Generic(const RMV& R, const XMV& X) {
 }
 
 // Variant of MV_Reciprocal_Generic for single vectors (1-D Views) R and X.
-template <class RV, class XV, class SizeType>
-void V_Reciprocal_Generic(const RV& R, const XV& X) {
+template <class execution_space, class RV, class XV, class SizeType>
+void V_Reciprocal_Generic(const execution_space& space, const RV& R, const XV& X) {
   static_assert(Kokkos::is_view<RV>::value,
                 "KokkosBlas::Impl::"
                 "V_Reciprocal_Generic: RV is not a Kokkos::View.");
@@ -195,9 +190,8 @@ void V_Reciprocal_Generic(const RV& R, const XV& X) {
                 "KokkosBlas::Impl::"
                 "V_Reciprocal_Generic: XV is not rank 1");
 
-  typedef typename XV::execution_space execution_space;
   const SizeType numRows = X.extent(0);
-  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
+  Kokkos::RangePolicy<execution_space, SizeType> policy(space, 0, numRows);
 
   if (R == X) {  // if R and X are the same (alias one another)
     V_ReciprocalSelf_Functor<RV, SizeType> op(R);

--- a/blas/impl/KokkosBlas1_reciprocal_impl.hpp
+++ b/blas/impl/KokkosBlas1_reciprocal_impl.hpp
@@ -148,7 +148,8 @@ struct V_ReciprocalSelf_Functor {
 // Invoke the "generic" (not unrolled) multivector functor that
 // computes entry-wise reciprocalolute value.
 template <class execution_space, class RMV, class XMV, class SizeType>
-void MV_Reciprocal_Generic(const execution_space& space, const RMV& R, const XMV& X) {
+void MV_Reciprocal_Generic(const execution_space& space, const RMV& R,
+                           const XMV& X) {
   static_assert(Kokkos::is_view<RMV>::value,
                 "KokkosBlas::Impl::"
                 "MV_Reciprocal_Generic: RMV is not a Kokkos::View.");
@@ -176,7 +177,8 @@ void MV_Reciprocal_Generic(const execution_space& space, const RMV& R, const XMV
 
 // Variant of MV_Reciprocal_Generic for single vectors (1-D Views) R and X.
 template <class execution_space, class RV, class XV, class SizeType>
-void V_Reciprocal_Generic(const execution_space& space, const RV& R, const XV& X) {
+void V_Reciprocal_Generic(const execution_space& space, const RV& R,
+                          const XV& X) {
   static_assert(Kokkos::is_view<RV>::value,
                 "KokkosBlas::Impl::"
                 "V_Reciprocal_Generic: RV is not a Kokkos::View.");

--- a/blas/impl/KokkosBlas1_reciprocal_spec.hpp
+++ b/blas/impl/KokkosBlas1_reciprocal_spec.hpp
@@ -87,19 +87,24 @@ namespace Impl {
 
 // Unification layer
 template <class execution_space, class RMV, class XMV, int rank = RMV::rank,
-          bool tpl_spec_avail = reciprocal_tpl_spec_avail<execution_space, RMV, XMV>::value,
-          bool eti_spec_avail = reciprocal_eti_spec_avail<execution_space, RMV, XMV>::value>
+          bool tpl_spec_avail =
+              reciprocal_tpl_spec_avail<execution_space, RMV, XMV>::value,
+          bool eti_spec_avail =
+              reciprocal_eti_spec_avail<execution_space, RMV, XMV>::value>
 struct Reciprocal {
-  static void reciprocal(const execution_space& space, const RMV& R, const XMV& X);
+  static void reciprocal(const execution_space& space, const RMV& R,
+                         const XMV& X);
 };
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 //! Full specialization of Reciprocal for single vectors (1-D Views).
 template <class execution_space, class RMV, class XMV>
-struct Reciprocal<execution_space, RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+struct Reciprocal<execution_space, RMV, XMV, 1, false,
+                  KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
 
-  static void reciprocal(const execution_space& space, const RMV& R, const XMV& X) {
+  static void reciprocal(const execution_space& space, const RMV& R,
+                         const XMV& X) {
     static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Reciprocal<1-D>: RMV is not a Kokkos::View.");
@@ -139,10 +144,12 @@ struct Reciprocal<execution_space, RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPIL
 };
 
 template <class execution_space, class RMV, class XMV>
-struct Reciprocal<execution_space, RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+struct Reciprocal<execution_space, RMV, XMV, 2, false,
+                  KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
 
-  static void reciprocal(const execution_space& space, const RMV& R, const XMV& X) {
+  static void reciprocal(const execution_space& space, const RMV& R,
+                         const XMV& X) {
     static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Reciprocal<2-D>: RMV is not a Kokkos::View.");

--- a/blas/impl/KokkosBlas1_reciprocal_spec.hpp
+++ b/blas/impl/KokkosBlas1_reciprocal_spec.hpp
@@ -28,7 +28,7 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class RMV, class XMV, int rank = RMV::rank>
+template <class execution_space, class RMV, class XMV, int rank = RMV::rank>
 struct reciprocal_eti_spec_avail {
   enum : bool { value = false };
 };
@@ -46,6 +46,7 @@ struct reciprocal_eti_spec_avail {
                                               MEM_SPACE)                   \
   template <>                                                              \
   struct reciprocal_eti_spec_avail<                                        \
+      EXEC_SPACE,                                                          \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,              \
       Kokkos::View<const SCALAR*, LAYOUT,                                  \
@@ -66,6 +67,7 @@ struct reciprocal_eti_spec_avail {
                                                  MEM_SPACE)                  \
   template <>                                                                \
   struct reciprocal_eti_spec_avail<                                          \
+      EXEC_SPACE,                                                            \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,  \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                \
       Kokkos::View<const SCALAR**, LAYOUT,                                   \
@@ -84,20 +86,20 @@ namespace KokkosBlas {
 namespace Impl {
 
 // Unification layer
-template <class RMV, class XMV, int rank = RMV::rank,
-          bool tpl_spec_avail = reciprocal_tpl_spec_avail<RMV, XMV>::value,
-          bool eti_spec_avail = reciprocal_eti_spec_avail<RMV, XMV>::value>
+template <class execution_space, class RMV, class XMV, int rank = RMV::rank,
+          bool tpl_spec_avail = reciprocal_tpl_spec_avail<execution_space, RMV, XMV>::value,
+          bool eti_spec_avail = reciprocal_eti_spec_avail<execution_space, RMV, XMV>::value>
 struct Reciprocal {
-  static void reciprocal(const RMV& R, const XMV& X);
+  static void reciprocal(const execution_space& space, const RMV& R, const XMV& X);
 };
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 //! Full specialization of Reciprocal for single vectors (1-D Views).
-template <class RMV, class XMV>
-struct Reciprocal<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+template <class execution_space, class RMV, class XMV>
+struct Reciprocal<execution_space, RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
 
-  static void reciprocal(const RMV& R, const XMV& X) {
+  static void reciprocal(const execution_space& space, const RMV& R, const XMV& X) {
     static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Reciprocal<1-D>: RMV is not a Kokkos::View.");
@@ -127,20 +129,20 @@ struct Reciprocal<RMV, XMV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 
     if (numRows < static_cast<size_type>(INT_MAX)) {
       typedef int index_type;
-      V_Reciprocal_Generic<RMV, XMV, index_type>(R, X);
+      V_Reciprocal_Generic<execution_space, RMV, XMV, index_type>(space, R, X);
     } else {
       typedef std::int64_t index_type;
-      V_Reciprocal_Generic<RMV, XMV, index_type>(R, X);
+      V_Reciprocal_Generic<execution_space, RMV, XMV, index_type>(space, R, X);
     }
     Kokkos::Profiling::popRegion();
   }
 };
 
-template <class RMV, class XMV>
-struct Reciprocal<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+template <class execution_space, class RMV, class XMV>
+struct Reciprocal<execution_space, RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
 
-  static void reciprocal(const RMV& R, const XMV& X) {
+  static void reciprocal(const execution_space& space, const RMV& R, const XMV& X) {
     static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Reciprocal<2-D>: RMV is not a Kokkos::View.");
@@ -171,10 +173,10 @@ struct Reciprocal<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
     if (numRows < static_cast<size_type>(INT_MAX) &&
         numRows * numCols < static_cast<size_type>(INT_MAX)) {
       typedef int index_type;
-      MV_Reciprocal_Generic<RMV, XMV, index_type>(R, X);
+      MV_Reciprocal_Generic<execution_space, RMV, XMV, index_type>(space, R, X);
     } else {
       typedef std::int64_t index_type;
-      MV_Reciprocal_Generic<RMV, XMV, index_type>(R, X);
+      MV_Reciprocal_Generic<execution_space, RMV, XMV, index_type>(space, R, X);
     }
     Kokkos::Profiling::popRegion();
   }
@@ -194,6 +196,7 @@ struct Reciprocal<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 #define KOKKOSBLAS1_RECIPROCAL_ETI_SPEC_DECL(SCALAR, LAYOUT, EXEC_SPACE,   \
                                              MEM_SPACE)                    \
   extern template struct Reciprocal<                                       \
+      EXEC_SPACE,                                                          \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,              \
       Kokkos::View<const SCALAR*, LAYOUT,                                  \
@@ -209,6 +212,7 @@ struct Reciprocal<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 #define KOKKOSBLAS1_RECIPROCAL_ETI_SPEC_INST(SCALAR, LAYOUT, EXEC_SPACE,   \
                                              MEM_SPACE)                    \
   template struct Reciprocal<                                              \
+      EXEC_SPACE,                                                          \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,              \
       Kokkos::View<const SCALAR*, LAYOUT,                                  \
@@ -226,6 +230,7 @@ struct Reciprocal<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 #define KOKKOSBLAS1_RECIPROCAL_MV_ETI_SPEC_DECL(SCALAR, LAYOUT, EXEC_SPACE, \
                                                 MEM_SPACE)                  \
   extern template struct Reciprocal<                                        \
+      EXEC_SPACE,                                                           \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
       Kokkos::View<const SCALAR**, LAYOUT,                                  \
@@ -241,6 +246,7 @@ struct Reciprocal<RMV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 #define KOKKOSBLAS1_RECIPROCAL_MV_ETI_SPEC_INST(SCALAR, LAYOUT, EXEC_SPACE, \
                                                 MEM_SPACE)                  \
   template struct Reciprocal<                                               \
+      EXEC_SPACE,                                                           \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
       Kokkos::View<const SCALAR**, LAYOUT,                                  \

--- a/blas/impl/KokkosBlas1_scal_impl.hpp
+++ b/blas/impl/KokkosBlas1_scal_impl.hpp
@@ -44,7 +44,6 @@ namespace Impl {
 // coefficients in the a vector, if used.
 template <class RV, class AV, class XV, int scalar_x, class SizeType>
 struct V_Scal_Functor {
-  typedef typename RV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename RV::non_const_value_type> ATS;
 
@@ -101,7 +100,6 @@ struct V_Scal_Functor {
 template <class RV, class XV, int scalar_x, class SizeType>
 struct V_Scal_Functor<RV, typename XV::non_const_value_type, XV, scalar_x,
                       SizeType> {
-  typedef typename RV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename RV::non_const_value_type> ATS;
 
@@ -134,8 +132,8 @@ struct V_Scal_Functor<RV, typename XV::non_const_value_type, XV, scalar_x,
 // Variant of MV_Scal_Generic for single vectors (1-D Views) r and x.
 // As above, av is either a 1-D View (and only its first entry will be
 // read), or a scalar.
-template <class RV, class AV, class XV, class SizeType>
-void V_Scal_Generic(const RV& r, const AV& av, const XV& x,
+template <class execution_space, class RV, class AV, class XV, class SizeType>
+void V_Scal_Generic(const execution_space& space, const RV& r, const AV& av, const XV& x,
                     const SizeType startingColumn, int a = 2) {
   static_assert(Kokkos::is_view<RV>::value,
                 "V_Scal_Generic: RV is not a Kokkos::View.");
@@ -144,9 +142,8 @@ void V_Scal_Generic(const RV& r, const AV& av, const XV& x,
   static_assert(RV::rank == 1, "V_Scal_Generic: RV is not rank 1.");
   static_assert(XV::rank == 1, "V_Scal_Generic: XV is not rank 1.");
 
-  typedef typename RV::execution_space execution_space;
   const SizeType numRows = x.extent(0);
-  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
+  Kokkos::RangePolicy<execution_space, SizeType> policy(space, 0, numRows);
 
   if (a == 0) {
     V_Scal_Functor<RV, AV, XV, 0, SizeType> op(r, x, av, startingColumn);

--- a/blas/impl/KokkosBlas1_scal_impl.hpp
+++ b/blas/impl/KokkosBlas1_scal_impl.hpp
@@ -133,8 +133,8 @@ struct V_Scal_Functor<RV, typename XV::non_const_value_type, XV, scalar_x,
 // As above, av is either a 1-D View (and only its first entry will be
 // read), or a scalar.
 template <class execution_space, class RV, class AV, class XV, class SizeType>
-void V_Scal_Generic(const execution_space& space, const RV& r, const AV& av, const XV& x,
-                    const SizeType startingColumn, int a = 2) {
+void V_Scal_Generic(const execution_space& space, const RV& r, const AV& av,
+                    const XV& x, const SizeType startingColumn, int a = 2) {
   static_assert(Kokkos::is_view<RV>::value,
                 "V_Scal_Generic: RV is not a Kokkos::View.");
   static_assert(Kokkos::is_view<XV>::value,

--- a/blas/impl/KokkosBlas1_scal_mv_impl.hpp
+++ b/blas/impl/KokkosBlas1_scal_mv_impl.hpp
@@ -319,10 +319,11 @@ struct MV_Scal_Unroll_Functor<RMV, typename XMV::non_const_value_type, XMV,
 // Any literal coefficient of zero has BLAS semantics of ignoring the
 // corresponding (multi)vector entry.  This does NOT apply to
 // coefficient(s) in av, if used.
-template <class execution_space, class RMV, class aVector, class XMV, int UNROLL, class SizeType>
-void MV_Scal_Unrolled(const execution_space& space, const RMV& r, const aVector& av, const XMV& x,
+template <class execution_space, class RMV, class aVector, class XMV,
+          int UNROLL, class SizeType>
+void MV_Scal_Unrolled(const execution_space& space, const RMV& r,
+                      const aVector& av, const XMV& x,
                       const SizeType startingColumn, int a = 2) {
-
   if (a == 0) {
     MV_Scal_Unroll_Functor<RMV, aVector, XMV, 0, UNROLL, SizeType> op(
         r, x, av, startingColumn);
@@ -370,8 +371,10 @@ void MV_Scal_Unrolled(const execution_space& space, const RMV& r, const aVector&
 // Any literal coefficient of zero has BLAS semantics of ignoring the
 // corresponding (multi)vector entry.  This does NOT apply to
 // coefficient(s) in av, if used.
-template <class execution_space, class RVector, class aVector, class XVector, class SizeType>
-void MV_Scal_Generic(const execution_space& space, const RVector& r, const aVector& av, const XVector& x,
+template <class execution_space, class RVector, class aVector, class XVector,
+          class SizeType>
+void MV_Scal_Generic(const execution_space& space, const RVector& r,
+                     const aVector& av, const XVector& x,
                      const SizeType startingColumn, int a = 2) {
   const SizeType numRows = x.extent(0);
   Kokkos::RangePolicy<execution_space, SizeType> policy(space, 0, numRows);
@@ -416,7 +419,8 @@ void MV_Scal_Generic(const execution_space& space, const RVector& r, const aVect
 // corresponding (multi)vector entry.  This does NOT apply to
 // coefficient(s) in av, if used.
 template <class execution_space, class RMV, class AV, class XMV, class SizeType>
-void MV_Scal_Invoke_Left(const execution_space& space, const RMV& r, const AV& av, const XMV& x, int a = 2) {
+void MV_Scal_Invoke_Left(const execution_space& space, const RMV& r,
+                         const AV& av, const XMV& x, int a = 2) {
   const SizeType numCols = x.extent(1);
 
 #if KOKKOSBLAS_OPTIMIZATION_LEVEL_SCAL <= 2
@@ -433,7 +437,8 @@ void MV_Scal_Invoke_Left(const execution_space& space, const RMV& r, const AV& a
     typedef decltype(X_cur) XMV2D;
     typedef decltype(R_cur) RMV2D;
 
-    MV_Scal_Unrolled<execution_space, RMV2D, AV, XMV2D, 8, SizeType>(space, R_cur, av, X_cur, j, a);
+    MV_Scal_Unrolled<execution_space, RMV2D, AV, XMV2D, 8, SizeType>(
+        space, R_cur, av, X_cur, j, a);
   }
   for (; j + 4 <= numCols; j += 4) {
     const std::pair<SizeType, SizeType> rng(j, j + 4);
@@ -442,7 +447,8 @@ void MV_Scal_Invoke_Left(const execution_space& space, const RMV& r, const AV& a
     typedef decltype(X_cur) XMV2D;
     typedef decltype(R_cur) RMV2D;
 
-    MV_Scal_Unrolled<execution_space, RMV2D, AV, XMV2D, 4, SizeType>(space, R_cur, av, X_cur, j, a);
+    MV_Scal_Unrolled<execution_space, RMV2D, AV, XMV2D, 4, SizeType>(
+        space, R_cur, av, X_cur, j, a);
   }
   for (; j < numCols; ++j) {
     // RMV and XMV need to turn 1-D.
@@ -451,7 +457,8 @@ void MV_Scal_Invoke_Left(const execution_space& space, const RMV& r, const AV& a
     typedef decltype(r_cur) RV;
     typedef decltype(x_cur) XV;
 
-    V_Scal_Generic<execution_space, RV, AV, XV, SizeType>(space, r_cur, av, x_cur, j, a);
+    V_Scal_Generic<execution_space, RV, AV, XV, SizeType>(space, r_cur, av,
+                                                          x_cur, j, a);
   }
 
 #else  // KOKKOSBLAS_OPTIMIZATION_LEVEL_SCAL > 2
@@ -463,39 +470,73 @@ void MV_Scal_Invoke_Left(const execution_space& space, const RMV& r, const AV& a
       typedef decltype(r_0) RV;
       typedef decltype(x_0) XV;
 
-      V_Scal_Generic<execution_space, RV, AV, XV, SizeType>(space, r_0, av, x_0, 0, a);
+      V_Scal_Generic<execution_space, RV, AV, XV, SizeType>(space, r_0, av, x_0,
+                                                            0, a);
       break;
     }
-    case 2: MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 2, SizeType>(space, r, av, x, 0, a); break;
-    case 3: MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 3, SizeType>(space, r, av, x, 0, a); break;
-    case 4: MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 4, SizeType>(space, r, av, x, 0, a); break;
-    case 5: MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 5, SizeType>(space, r, av, x, 0, a); break;
-    case 6: MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 6, SizeType>(space, r, av, x, 0, a); break;
-    case 7: MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 7, SizeType>(space, r, av, x, 0, a); break;
-    case 8: MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 8, SizeType>(space, r, av, x, 0, a); break;
-    case 9: MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 9, SizeType>(space, r, av, x, 0, a); break;
+    case 2:
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 2, SizeType>(space, r, av,
+                                                                   x, 0, a);
+      break;
+    case 3:
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 3, SizeType>(space, r, av,
+                                                                   x, 0, a);
+      break;
+    case 4:
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 4, SizeType>(space, r, av,
+                                                                   x, 0, a);
+      break;
+    case 5:
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 5, SizeType>(space, r, av,
+                                                                   x, 0, a);
+      break;
+    case 6:
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 6, SizeType>(space, r, av,
+                                                                   x, 0, a);
+      break;
+    case 7:
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 7, SizeType>(space, r, av,
+                                                                   x, 0, a);
+      break;
+    case 8:
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 8, SizeType>(space, r, av,
+                                                                   x, 0, a);
+      break;
+    case 9:
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 9, SizeType>(space, r, av,
+                                                                   x, 0, a);
+      break;
     case 10:
-      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 10, SizeType>(space, r, av, x, 0, a);
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 10, SizeType>(
+          space, r, av, x, 0, a);
       break;
     case 11:
-      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 11, SizeType>(space, r, av, x, 0, a);
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 11, SizeType>(
+          space, r, av, x, 0, a);
       break;
     case 12:
-      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 12, SizeType>(space, r, av, x, 0, a);
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 12, SizeType>(
+          space, r, av, x, 0, a);
       break;
     case 13:
-      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 13, SizeType>(space, r, av, x, 0, a);
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 13, SizeType>(
+          space, r, av, x, 0, a);
       break;
     case 14:
-      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 14, SizeType>(space, r, av, x, 0, a);
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 14, SizeType>(
+          space, r, av, x, 0, a);
       break;
     case 15:
-      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 15, SizeType>(space, r, av, x, 0, a);
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 15, SizeType>(
+          space, r, av, x, 0, a);
       break;
     case 16:
-      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 16, SizeType>(space, r, av, x, 0, a);
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 16, SizeType>(
+          space, r, av, x, 0, a);
       break;
-    default: MV_Scal_Generic<execution_space, RMV, AV, XMV, SizeType>(space, r, av, x, 0, a);
+    default:
+      MV_Scal_Generic<execution_space, RMV, AV, XMV, SizeType>(space, r, av, x,
+                                                               0, a);
   }
 
 #endif  // KOKKOSBLAS_OPTIMIZATION_LEVEL_SCAL
@@ -515,9 +556,10 @@ void MV_Scal_Invoke_Left(const execution_space& space, const RMV& r, const AV& a
 // Any literal coefficient of zero has BLAS semantics of ignoring the
 // corresponding (multi)vector entry.  This does NOT apply to
 // coefficient(s) in av, if used.
-template <class execution_space, class RMV, class aVector, class XMV, class SizeType>
-void MV_Scal_Invoke_Right(const execution_space& space, const RMV& r, const aVector& av, const XMV& x,
-                          int a = 2) {
+template <class execution_space, class RMV, class aVector, class XMV,
+          class SizeType>
+void MV_Scal_Invoke_Right(const execution_space& space, const RMV& r,
+                          const aVector& av, const XMV& x, int a = 2) {
   const SizeType numCols = x.extent(1);
 
   if (numCols == 1) {
@@ -530,9 +572,11 @@ void MV_Scal_Invoke_Right(const execution_space& space, const RMV& r, const aVec
 
     RV r_0 = Kokkos::subview(r, Kokkos::ALL(), 0);
     XV x_0 = Kokkos::subview(x, Kokkos::ALL(), 0);
-    V_Scal_Generic<execution_space, RMV, aVector, XMV, 1, SizeType>(space, r_0, av, x_0, a);
+    V_Scal_Generic<execution_space, RMV, aVector, XMV, 1, SizeType>(space, r_0,
+                                                                    av, x_0, a);
   } else {
-    MV_Scal_Generic<execution_space, RMV, aVector, XMV, SizeType>(space, r, av, x, a);
+    MV_Scal_Generic<execution_space, RMV, aVector, XMV, SizeType>(space, r, av,
+                                                                  x, a);
   }
 }
 

--- a/blas/impl/KokkosBlas1_scal_mv_impl.hpp
+++ b/blas/impl/KokkosBlas1_scal_mv_impl.hpp
@@ -45,7 +45,6 @@ namespace Impl {
 template <class RMV, class aVector, class XMV, int scalar_x,
           class SizeType = typename RMV::size_type>
 struct MV_Scal_Functor {
-  typedef typename RMV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename RMV::non_const_value_type> ATS;
 
@@ -127,7 +126,6 @@ struct MV_Scal_Functor {
 template <class RMV, class XMV, int scalar_x, class SizeType>
 struct MV_Scal_Functor<RMV, typename XMV::non_const_value_type, XMV, scalar_x,
                        SizeType> {
-  typedef typename RMV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename RMV::non_const_value_type> ATS;
 
@@ -198,7 +196,6 @@ struct MV_Scal_Functor<RMV, typename XMV::non_const_value_type, XMV, scalar_x,
 template <class RMV, class aVector, class XMV, int scalar_x, int UNROLL,
           class SizeType>
 struct MV_Scal_Unroll_Functor {
-  typedef typename RMV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename RMV::non_const_value_type> ATS;
 
@@ -259,7 +256,6 @@ struct MV_Scal_Unroll_Functor {
 template <class RMV, class XMV, int scalar_x, int UNROLL, class SizeType>
 struct MV_Scal_Unroll_Functor<RMV, typename XMV::non_const_value_type, XMV,
                               scalar_x, UNROLL, SizeType> {
-  typedef typename RMV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename RMV::non_const_value_type> ATS;
 
@@ -323,16 +319,15 @@ struct MV_Scal_Unroll_Functor<RMV, typename XMV::non_const_value_type, XMV,
 // Any literal coefficient of zero has BLAS semantics of ignoring the
 // corresponding (multi)vector entry.  This does NOT apply to
 // coefficient(s) in av, if used.
-template <class RMV, class aVector, class XMV, int UNROLL, class SizeType>
-void MV_Scal_Unrolled(const RMV& r, const aVector& av, const XMV& x,
+template <class execution_space, class RMV, class aVector, class XMV, int UNROLL, class SizeType>
+void MV_Scal_Unrolled(const execution_space& space, const RMV& r, const aVector& av, const XMV& x,
                       const SizeType startingColumn, int a = 2) {
-  typedef typename XMV::execution_space execution_space;
 
   if (a == 0) {
     MV_Scal_Unroll_Functor<RMV, aVector, XMV, 0, UNROLL, SizeType> op(
         r, x, av, startingColumn);
     const SizeType numRows = x.extent(0);
-    Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
+    Kokkos::RangePolicy<execution_space, SizeType> policy(space, 0, numRows);
     Kokkos::parallel_for("KokkosBlas::Scal::MV::S0", policy, op);
     return;
   }
@@ -340,7 +335,7 @@ void MV_Scal_Unrolled(const RMV& r, const aVector& av, const XMV& x,
     MV_Scal_Unroll_Functor<RMV, aVector, XMV, -1, UNROLL, SizeType> op(
         r, x, av, startingColumn);
     const SizeType numRows = x.extent(0);
-    Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
+    Kokkos::RangePolicy<execution_space, SizeType> policy(space, 0, numRows);
     Kokkos::parallel_for("KokkosBlas::Scal::MV::S1", policy, op);
     return;
   }
@@ -348,7 +343,7 @@ void MV_Scal_Unrolled(const RMV& r, const aVector& av, const XMV& x,
     MV_Scal_Unroll_Functor<RMV, aVector, XMV, 1, UNROLL, SizeType> op(
         r, x, av, startingColumn);
     const SizeType numRows = x.extent(0);
-    Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
+    Kokkos::RangePolicy<execution_space, SizeType> policy(space, 0, numRows);
     Kokkos::parallel_for("KokkosBlas::Scal::MV::S2", policy, op);
     return;
   }
@@ -357,7 +352,7 @@ void MV_Scal_Unrolled(const RMV& r, const aVector& av, const XMV& x,
   MV_Scal_Unroll_Functor<RMV, aVector, XMV, 2, UNROLL, SizeType> op(
       r, x, av, startingColumn);
   const SizeType numRows = x.extent(0);
-  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
+  Kokkos::RangePolicy<execution_space, SizeType> policy(space, 0, numRows);
   Kokkos::parallel_for("KokkosBlas::Scal::MV::S3", policy, op);
 }
 
@@ -375,12 +370,11 @@ void MV_Scal_Unrolled(const RMV& r, const aVector& av, const XMV& x,
 // Any literal coefficient of zero has BLAS semantics of ignoring the
 // corresponding (multi)vector entry.  This does NOT apply to
 // coefficient(s) in av, if used.
-template <class RVector, class aVector, class XVector, class SizeType>
-void MV_Scal_Generic(const RVector& r, const aVector& av, const XVector& x,
+template <class execution_space, class RVector, class aVector, class XVector, class SizeType>
+void MV_Scal_Generic(const execution_space& space, const RVector& r, const aVector& av, const XVector& x,
                      const SizeType startingColumn, int a = 2) {
-  typedef typename XVector::execution_space execution_space;
   const SizeType numRows = x.extent(0);
-  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
+  Kokkos::RangePolicy<execution_space, SizeType> policy(space, 0, numRows);
 
   if (a == 0) {
     MV_Scal_Functor<RVector, aVector, XVector, 0, SizeType> op(r, x, av,
@@ -421,8 +415,8 @@ void MV_Scal_Generic(const RVector& r, const aVector& av, const XVector& x,
 // Any literal coefficient of zero has BLAS semantics of ignoring the
 // corresponding (multi)vector entry.  This does NOT apply to
 // coefficient(s) in av, if used.
-template <class RMV, class AV, class XMV, class SizeType>
-void MV_Scal_Invoke_Left(const RMV& r, const AV& av, const XMV& x, int a = 2) {
+template <class execution_space, class RMV, class AV, class XMV, class SizeType>
+void MV_Scal_Invoke_Left(const execution_space& space, const RMV& r, const AV& av, const XMV& x, int a = 2) {
   const SizeType numCols = x.extent(1);
 
 #if KOKKOSBLAS_OPTIMIZATION_LEVEL_SCAL <= 2
@@ -439,7 +433,7 @@ void MV_Scal_Invoke_Left(const RMV& r, const AV& av, const XMV& x, int a = 2) {
     typedef decltype(X_cur) XMV2D;
     typedef decltype(R_cur) RMV2D;
 
-    MV_Scal_Unrolled<RMV2D, AV, XMV2D, 8, SizeType>(R_cur, av, X_cur, j, a);
+    MV_Scal_Unrolled<execution_space, RMV2D, AV, XMV2D, 8, SizeType>(space, R_cur, av, X_cur, j, a);
   }
   for (; j + 4 <= numCols; j += 4) {
     const std::pair<SizeType, SizeType> rng(j, j + 4);
@@ -448,7 +442,7 @@ void MV_Scal_Invoke_Left(const RMV& r, const AV& av, const XMV& x, int a = 2) {
     typedef decltype(X_cur) XMV2D;
     typedef decltype(R_cur) RMV2D;
 
-    MV_Scal_Unrolled<RMV2D, AV, XMV2D, 4, SizeType>(R_cur, av, X_cur, j, a);
+    MV_Scal_Unrolled<execution_space, RMV2D, AV, XMV2D, 4, SizeType>(space, R_cur, av, X_cur, j, a);
   }
   for (; j < numCols; ++j) {
     // RMV and XMV need to turn 1-D.
@@ -457,7 +451,7 @@ void MV_Scal_Invoke_Left(const RMV& r, const AV& av, const XMV& x, int a = 2) {
     typedef decltype(r_cur) RV;
     typedef decltype(x_cur) XV;
 
-    V_Scal_Generic<RV, AV, XV, SizeType>(r_cur, av, x_cur, j, a);
+    V_Scal_Generic<execution_space, RV, AV, XV, SizeType>(space, r_cur, av, x_cur, j, a);
   }
 
 #else  // KOKKOSBLAS_OPTIMIZATION_LEVEL_SCAL > 2
@@ -469,39 +463,39 @@ void MV_Scal_Invoke_Left(const RMV& r, const AV& av, const XMV& x, int a = 2) {
       typedef decltype(r_0) RV;
       typedef decltype(x_0) XV;
 
-      V_Scal_Generic<RV, AV, XV, SizeType>(r_0, av, x_0, 0, a);
+      V_Scal_Generic<execution_space, RV, AV, XV, SizeType>(space, r_0, av, x_0, 0, a);
       break;
     }
-    case 2: MV_Scal_Unrolled<RMV, AV, XMV, 2, SizeType>(r, av, x, 0, a); break;
-    case 3: MV_Scal_Unrolled<RMV, AV, XMV, 3, SizeType>(r, av, x, 0, a); break;
-    case 4: MV_Scal_Unrolled<RMV, AV, XMV, 4, SizeType>(r, av, x, 0, a); break;
-    case 5: MV_Scal_Unrolled<RMV, AV, XMV, 5, SizeType>(r, av, x, 0, a); break;
-    case 6: MV_Scal_Unrolled<RMV, AV, XMV, 6, SizeType>(r, av, x, 0, a); break;
-    case 7: MV_Scal_Unrolled<RMV, AV, XMV, 7, SizeType>(r, av, x, 0, a); break;
-    case 8: MV_Scal_Unrolled<RMV, AV, XMV, 8, SizeType>(r, av, x, 0, a); break;
-    case 9: MV_Scal_Unrolled<RMV, AV, XMV, 9, SizeType>(r, av, x, 0, a); break;
+    case 2: MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 2, SizeType>(space, r, av, x, 0, a); break;
+    case 3: MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 3, SizeType>(space, r, av, x, 0, a); break;
+    case 4: MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 4, SizeType>(space, r, av, x, 0, a); break;
+    case 5: MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 5, SizeType>(space, r, av, x, 0, a); break;
+    case 6: MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 6, SizeType>(space, r, av, x, 0, a); break;
+    case 7: MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 7, SizeType>(space, r, av, x, 0, a); break;
+    case 8: MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 8, SizeType>(space, r, av, x, 0, a); break;
+    case 9: MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 9, SizeType>(space, r, av, x, 0, a); break;
     case 10:
-      MV_Scal_Unrolled<RMV, AV, XMV, 10, SizeType>(r, av, x, 0, a);
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 10, SizeType>(space, r, av, x, 0, a);
       break;
     case 11:
-      MV_Scal_Unrolled<RMV, AV, XMV, 11, SizeType>(r, av, x, 0, a);
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 11, SizeType>(space, r, av, x, 0, a);
       break;
     case 12:
-      MV_Scal_Unrolled<RMV, AV, XMV, 12, SizeType>(r, av, x, 0, a);
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 12, SizeType>(space, r, av, x, 0, a);
       break;
     case 13:
-      MV_Scal_Unrolled<RMV, AV, XMV, 13, SizeType>(r, av, x, 0, a);
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 13, SizeType>(space, r, av, x, 0, a);
       break;
     case 14:
-      MV_Scal_Unrolled<RMV, AV, XMV, 14, SizeType>(r, av, x, 0, a);
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 14, SizeType>(space, r, av, x, 0, a);
       break;
     case 15:
-      MV_Scal_Unrolled<RMV, AV, XMV, 15, SizeType>(r, av, x, 0, a);
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 15, SizeType>(space, r, av, x, 0, a);
       break;
     case 16:
-      MV_Scal_Unrolled<RMV, AV, XMV, 16, SizeType>(r, av, x, 0, a);
+      MV_Scal_Unrolled<execution_space, RMV, AV, XMV, 16, SizeType>(space, r, av, x, 0, a);
       break;
-    default: MV_Scal_Generic<RMV, AV, XMV, SizeType>(r, av, x, 0, a);
+    default: MV_Scal_Generic<execution_space, RMV, AV, XMV, SizeType>(space, r, av, x, 0, a);
   }
 
 #endif  // KOKKOSBLAS_OPTIMIZATION_LEVEL_SCAL
@@ -521,8 +515,8 @@ void MV_Scal_Invoke_Left(const RMV& r, const AV& av, const XMV& x, int a = 2) {
 // Any literal coefficient of zero has BLAS semantics of ignoring the
 // corresponding (multi)vector entry.  This does NOT apply to
 // coefficient(s) in av, if used.
-template <class RMV, class aVector, class XMV, class SizeType>
-void MV_Scal_Invoke_Right(const RMV& r, const aVector& av, const XMV& x,
+template <class execution_space, class RMV, class aVector, class XMV, class SizeType>
+void MV_Scal_Invoke_Right(const execution_space& space, const RMV& r, const aVector& av, const XMV& x,
                           int a = 2) {
   const SizeType numCols = x.extent(1);
 
@@ -536,9 +530,9 @@ void MV_Scal_Invoke_Right(const RMV& r, const aVector& av, const XMV& x,
 
     RV r_0 = Kokkos::subview(r, Kokkos::ALL(), 0);
     XV x_0 = Kokkos::subview(x, Kokkos::ALL(), 0);
-    V_Scal_Generic<RMV, aVector, XMV, 1, SizeType>(r_0, av, x_0, a);
+    V_Scal_Generic<execution_space, RMV, aVector, XMV, 1, SizeType>(space, r_0, av, x_0, a);
   } else {
-    MV_Scal_Generic<RMV, aVector, XMV, SizeType>(r, av, x, a);
+    MV_Scal_Generic<execution_space, RMV, aVector, XMV, SizeType>(space, r, av, x, a);
   }
 }
 

--- a/blas/impl/KokkosBlas1_scal_spec.hpp
+++ b/blas/impl/KokkosBlas1_scal_spec.hpp
@@ -29,7 +29,8 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class execution_space, class RV, class AV, class XV, int Xrank = XV::rank>
+template <class execution_space, class RV, class AV, class XV,
+          int Xrank = XV::rank>
 struct scal_eti_spec_avail {
   enum : bool { value = false };
 };
@@ -102,23 +103,28 @@ namespace KokkosBlas {
 namespace Impl {
 
 // Unification layer
-  template <class execution_space, class RV, class AV, class XV, int XV_Rank = XV::rank,
-          bool tpl_spec_avail = scal_tpl_spec_avail<execution_space, RV, AV, XV>::value,
-          bool eti_spec_avail = scal_eti_spec_avail<execution_space, RV, AV, XV>::value>
+template <class execution_space, class RV, class AV, class XV,
+          int XV_Rank = XV::rank,
+          bool tpl_spec_avail =
+              scal_tpl_spec_avail<execution_space, RV, AV, XV>::value,
+          bool eti_spec_avail =
+              scal_eti_spec_avail<execution_space, RV, AV, XV>::value>
 struct Scal {
-  static void scal(const execution_space& space, const RV& R, const AV& A, const XV& X);
+  static void scal(const execution_space& space, const RV& R, const AV& A,
+                   const XV& X);
 };
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 //! Full specialization of Scal for single vectors (1-D Views).
 template <class execution_space, class RV, class XV>
-struct Scal<execution_space, RV, typename XV::non_const_value_type, XV, 1, false,
-            KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+struct Scal<execution_space, RV, typename XV::non_const_value_type, XV, 1,
+            false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XV::non_const_value_type AV;
   typedef typename XV::size_type size_type;
   typedef Kokkos::ArithTraits<typename XV::non_const_value_type> ATA;
 
-  static void scal(const execution_space& space, const RV& R, const AV& alpha, const XV& X) {
+  static void scal(const execution_space& space, const RV& R, const AV& alpha,
+                   const XV& X) {
     static_assert(Kokkos::is_view<RV>::value,
                   "KokkosBlas::Impl::"
                   "Scal<1-D>: RV is not a Kokkos::View.");
@@ -157,10 +163,12 @@ struct Scal<execution_space, RV, typename XV::non_const_value_type, XV, 1, false
 
     if (numRows < static_cast<size_type>(INT_MAX)) {
       typedef int index_type;
-      V_Scal_Generic<execution_space, RV, AV, XV, index_type>(space, R, alpha, X, a);
+      V_Scal_Generic<execution_space, RV, AV, XV, index_type>(space, R, alpha,
+                                                              X, a);
     } else {
       typedef typename XV::size_type index_type;
-      V_Scal_Generic<execution_space, RV, AV, XV, index_type>(space, R, alpha, X, a);
+      V_Scal_Generic<execution_space, RV, AV, XV, index_type>(space, R, alpha,
+                                                              X, a);
     }
     Kokkos::Profiling::popRegion();
   }
@@ -173,11 +181,13 @@ struct Scal<execution_space, RV, typename XV::non_const_value_type, XV, 1, false
 /// 1. R(i,j) = a*X(i,j) for a in -1,0,1
 /// 2. R(i,j) = alpha(j)*X(i,j)
 template <class execution_space, class RMV, class AV, class XMV>
-struct Scal<execution_space, RMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+struct Scal<execution_space, RMV, AV, XMV, 2, false,
+            KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
   typedef Kokkos::ArithTraits<typename XMV::non_const_value_type> ATA;
 
-  static void scal(const execution_space& space, const RMV& R, const AV& av, const XMV& X) {
+  static void scal(const execution_space& space, const RMV& R, const AV& av,
+                   const XMV& X) {
     static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Scal<2-D>: RMV is not a Kokkos::View.");
@@ -215,10 +225,12 @@ struct Scal<execution_space, RMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_
     if (numRows < static_cast<size_type>(INT_MAX) &&
         numRows * numCols < static_cast<size_type>(INT_MAX)) {
       typedef int index_type;
-      MV_Scal_Invoke_Left<execution_space, RMV, AV, XMV, index_type>(space, R, av, X, a);
+      MV_Scal_Invoke_Left<execution_space, RMV, AV, XMV, index_type>(space, R,
+                                                                     av, X, a);
     } else {
       typedef typename XMV::size_type index_type;
-      MV_Scal_Invoke_Left<execution_space, RMV, AV, XMV, index_type>(space, R, av, X, a);
+      MV_Scal_Invoke_Left<execution_space, RMV, AV, XMV, index_type>(space, R,
+                                                                     av, X, a);
     }
     Kokkos::Profiling::popRegion();
   }
@@ -231,13 +243,14 @@ struct Scal<execution_space, RMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_
 /// 1. R(i,j) = a*X(i,j) for a in -1,0,1
 /// 2. R(i,j) = alpha*X(i,j)
 template <class execution_space, class RMV, class XMV>
-struct Scal<execution_space, RMV, typename XMV::non_const_value_type, XMV, 2, false,
-            KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+struct Scal<execution_space, RMV, typename XMV::non_const_value_type, XMV, 2,
+            false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::non_const_value_type AV;
   typedef typename XMV::size_type size_type;
   typedef Kokkos::ArithTraits<typename XMV::non_const_value_type> ATA;
 
-  static void scal(const execution_space& space, const RMV& R, const AV& alpha, const XMV& X) {
+  static void scal(const execution_space& space, const RMV& R, const AV& alpha,
+                   const XMV& X) {
     static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Scal<2-D, AV=scalar>: RMV is not a Kokkos::View.");
@@ -278,12 +291,14 @@ struct Scal<execution_space, RMV, typename XMV::non_const_value_type, XMV, 2, fa
     if (numRows < static_cast<size_type>(INT_MAX) &&
         numRows * numCols < static_cast<size_type>(INT_MAX)) {
       typedef int index_type;
-      MV_Scal_Invoke_Left<execution_space, RMV, typename XMV::non_const_value_type, XMV,
-                          index_type>(space, R, alpha, X, a);
+      MV_Scal_Invoke_Left<execution_space, RMV,
+                          typename XMV::non_const_value_type, XMV, index_type>(
+          space, R, alpha, X, a);
     } else {
       typedef typename XMV::size_type index_type;
-      MV_Scal_Invoke_Left<execution_space, RMV, typename XMV::non_const_value_type, XMV,
-                          index_type>(space, R, alpha, X, a);
+      MV_Scal_Invoke_Left<execution_space, RMV,
+                          typename XMV::non_const_value_type, XMV, index_type>(
+          space, R, alpha, X, a);
     }
     Kokkos::Profiling::popRegion();
   }

--- a/blas/impl/KokkosBlas1_scal_spec.hpp
+++ b/blas/impl/KokkosBlas1_scal_spec.hpp
@@ -29,7 +29,7 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class RV, class AV, class XV, int Xrank = XV::rank>
+template <class execution_space, class RV, class AV, class XV, int Xrank = XV::rank>
 struct scal_eti_spec_avail {
   enum : bool { value = false };
 };
@@ -46,6 +46,7 @@ struct scal_eti_spec_avail {
 #define KOKKOSBLAS1_SCAL_ETI_SPEC_AVAIL(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE) \
   template <>                                                                  \
   struct scal_eti_spec_avail<                                                  \
+      EXEC_SPACE,                                                              \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,     \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       SCALAR,                                                                  \
@@ -67,6 +68,7 @@ struct scal_eti_spec_avail {
                                            MEM_SPACE)                       \
   template <>                                                               \
   struct scal_eti_spec_avail<                                               \
+      EXEC_SPACE,                                                           \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
       Kokkos::View<const SCALAR*, LAYOUT,                                   \
@@ -80,6 +82,7 @@ struct scal_eti_spec_avail {
   };                                                                        \
   template <>                                                               \
   struct scal_eti_spec_avail<                                               \
+      EXEC_SPACE,                                                           \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
       SCALAR,                                                               \
@@ -99,23 +102,23 @@ namespace KokkosBlas {
 namespace Impl {
 
 // Unification layer
-template <class RV, class AV, class XV, int XV_Rank = XV::rank,
-          bool tpl_spec_avail = scal_tpl_spec_avail<RV, AV, XV>::value,
-          bool eti_spec_avail = scal_eti_spec_avail<RV, AV, XV>::value>
+  template <class execution_space, class RV, class AV, class XV, int XV_Rank = XV::rank,
+          bool tpl_spec_avail = scal_tpl_spec_avail<execution_space, RV, AV, XV>::value,
+          bool eti_spec_avail = scal_eti_spec_avail<execution_space, RV, AV, XV>::value>
 struct Scal {
-  static void scal(const RV& R, const AV& A, const XV& X);
+  static void scal(const execution_space& space, const RV& R, const AV& A, const XV& X);
 };
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 //! Full specialization of Scal for single vectors (1-D Views).
-template <class RV, class XV>
-struct Scal<RV, typename XV::non_const_value_type, XV, 1, false,
+template <class execution_space, class RV, class XV>
+struct Scal<execution_space, RV, typename XV::non_const_value_type, XV, 1, false,
             KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XV::non_const_value_type AV;
   typedef typename XV::size_type size_type;
   typedef Kokkos::ArithTraits<typename XV::non_const_value_type> ATA;
 
-  static void scal(const RV& R, const AV& alpha, const XV& X) {
+  static void scal(const execution_space& space, const RV& R, const AV& alpha, const XV& X) {
     static_assert(Kokkos::is_view<RV>::value,
                   "KokkosBlas::Impl::"
                   "Scal<1-D>: RV is not a Kokkos::View.");
@@ -154,10 +157,10 @@ struct Scal<RV, typename XV::non_const_value_type, XV, 1, false,
 
     if (numRows < static_cast<size_type>(INT_MAX)) {
       typedef int index_type;
-      V_Scal_Generic<RV, AV, XV, index_type>(R, alpha, X, a);
+      V_Scal_Generic<execution_space, RV, AV, XV, index_type>(space, R, alpha, X, a);
     } else {
       typedef typename XV::size_type index_type;
-      V_Scal_Generic<RV, AV, XV, index_type>(R, alpha, X, a);
+      V_Scal_Generic<execution_space, RV, AV, XV, index_type>(space, R, alpha, X, a);
     }
     Kokkos::Profiling::popRegion();
   }
@@ -169,12 +172,12 @@ struct Scal<RV, typename XV::non_const_value_type, XV, 1, false,
 ///
 /// 1. R(i,j) = a*X(i,j) for a in -1,0,1
 /// 2. R(i,j) = alpha(j)*X(i,j)
-template <class RMV, class AV, class XMV>
-struct Scal<RMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+template <class execution_space, class RMV, class AV, class XMV>
+struct Scal<execution_space, RMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
   typedef Kokkos::ArithTraits<typename XMV::non_const_value_type> ATA;
 
-  static void scal(const RMV& R, const AV& av, const XMV& X) {
+  static void scal(const execution_space& space, const RMV& R, const AV& av, const XMV& X) {
     static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Scal<2-D>: RMV is not a Kokkos::View.");
@@ -212,10 +215,10 @@ struct Scal<RMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
     if (numRows < static_cast<size_type>(INT_MAX) &&
         numRows * numCols < static_cast<size_type>(INT_MAX)) {
       typedef int index_type;
-      MV_Scal_Invoke_Left<RMV, AV, XMV, index_type>(R, av, X, a);
+      MV_Scal_Invoke_Left<execution_space, RMV, AV, XMV, index_type>(space, R, av, X, a);
     } else {
       typedef typename XMV::size_type index_type;
-      MV_Scal_Invoke_Left<RMV, AV, XMV, index_type>(R, av, X, a);
+      MV_Scal_Invoke_Left<execution_space, RMV, AV, XMV, index_type>(space, R, av, X, a);
     }
     Kokkos::Profiling::popRegion();
   }
@@ -227,14 +230,14 @@ struct Scal<RMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 ///
 /// 1. R(i,j) = a*X(i,j) for a in -1,0,1
 /// 2. R(i,j) = alpha*X(i,j)
-template <class RMV, class XMV>
-struct Scal<RMV, typename XMV::non_const_value_type, XMV, 2, false,
+template <class execution_space, class RMV, class XMV>
+struct Scal<execution_space, RMV, typename XMV::non_const_value_type, XMV, 2, false,
             KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::non_const_value_type AV;
   typedef typename XMV::size_type size_type;
   typedef Kokkos::ArithTraits<typename XMV::non_const_value_type> ATA;
 
-  static void scal(const RMV& R, const AV& alpha, const XMV& X) {
+  static void scal(const execution_space& space, const RMV& R, const AV& alpha, const XMV& X) {
     static_assert(Kokkos::is_view<RMV>::value,
                   "KokkosBlas::Impl::"
                   "Scal<2-D, AV=scalar>: RMV is not a Kokkos::View.");
@@ -275,12 +278,12 @@ struct Scal<RMV, typename XMV::non_const_value_type, XMV, 2, false,
     if (numRows < static_cast<size_type>(INT_MAX) &&
         numRows * numCols < static_cast<size_type>(INT_MAX)) {
       typedef int index_type;
-      MV_Scal_Invoke_Left<RMV, typename XMV::non_const_value_type, XMV,
-                          index_type>(R, alpha, X, a);
+      MV_Scal_Invoke_Left<execution_space, RMV, typename XMV::non_const_value_type, XMV,
+                          index_type>(space, R, alpha, X, a);
     } else {
       typedef typename XMV::size_type index_type;
-      MV_Scal_Invoke_Left<RMV, typename XMV::non_const_value_type, XMV,
-                          index_type>(R, alpha, X, a);
+      MV_Scal_Invoke_Left<execution_space, RMV, typename XMV::non_const_value_type, XMV,
+                          index_type>(space, R, alpha, X, a);
     }
     Kokkos::Profiling::popRegion();
   }
@@ -299,6 +302,7 @@ struct Scal<RMV, typename XMV::non_const_value_type, XMV, 2, false,
 //
 #define KOKKOSBLAS1_SCAL_ETI_SPEC_DECL(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE) \
   extern template struct Scal<                                                \
+      EXEC_SPACE,                                                             \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,    \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                 \
       SCALAR,                                                                 \
@@ -309,6 +313,7 @@ struct Scal<RMV, typename XMV::non_const_value_type, XMV, 2, false,
 
 #define KOKKOSBLAS1_SCAL_ETI_SPEC_INST(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE) \
   template struct Scal<                                                       \
+      EXEC_SPACE,                                                             \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,    \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                 \
       SCALAR,                                                                 \
@@ -326,6 +331,7 @@ struct Scal<RMV, typename XMV::non_const_value_type, XMV, 2, false,
 #define KOKKOSBLAS1_SCAL_MV_ETI_SPEC_DECL(SCALAR, LAYOUT, EXEC_SPACE,       \
                                           MEM_SPACE)                        \
   extern template struct Scal<                                              \
+      EXEC_SPACE,                                                           \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
       Kokkos::View<const SCALAR*, LAYOUT,                                   \
@@ -336,6 +342,7 @@ struct Scal<RMV, typename XMV::non_const_value_type, XMV, 2, false,
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
       2, false, true>;                                                      \
   extern template struct Scal<                                              \
+      EXEC_SPACE,                                                           \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
       SCALAR,                                                               \
@@ -347,6 +354,7 @@ struct Scal<RMV, typename XMV::non_const_value_type, XMV, 2, false,
 #define KOKKOSBLAS1_SCAL_MV_ETI_SPEC_INST(SCALAR, LAYOUT, EXEC_SPACE,       \
                                           MEM_SPACE)                        \
   template struct Scal<                                                     \
+      EXEC_SPACE,                                                           \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
       Kokkos::View<const SCALAR*, LAYOUT,                                   \
@@ -357,6 +365,7 @@ struct Scal<RMV, typename XMV::non_const_value_type, XMV, 2, false,
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
       2, false, true>;                                                      \
   template struct Scal<                                                     \
+      EXEC_SPACE,                                                           \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
       SCALAR,                                                               \

--- a/blas/impl/KokkosBlas1_update_impl.hpp
+++ b/blas/impl/KokkosBlas1_update_impl.hpp
@@ -314,9 +314,10 @@ struct V_Update_Functor {
 //
 // Any literal coefficient of zero has BLAS semantics of ignoring the
 // corresponding multivector entry.
-template <class execution_space, class XMV, class YMV, class ZMV, class SizeType>
+template <class execution_space, class XMV, class YMV, class ZMV,
+          class SizeType>
 void MV_Update_Generic(const execution_space& space,
-		       const typename XMV::non_const_value_type& alpha,
+                       const typename XMV::non_const_value_type& alpha,
                        const XMV& X,
                        const typename YMV::non_const_value_type& beta,
                        const YMV& Y,
@@ -417,7 +418,7 @@ void MV_Update_Generic(const execution_space& space,
 // corresponding vector entry.
 template <class execution_space, class XV, class YV, class ZV, class SizeType>
 void V_Update_Generic(const execution_space& space,
-		      const typename XV::non_const_value_type& alpha,
+                      const typename XV::non_const_value_type& alpha,
                       const XV& X,
                       const typename YV::non_const_value_type& beta,
                       const YV& Y,

--- a/blas/impl/KokkosBlas1_update_impl.hpp
+++ b/blas/impl/KokkosBlas1_update_impl.hpp
@@ -43,7 +43,6 @@ namespace Impl {
 template <class XMV, class YMV, class ZMV, int scalar_x, int scalar_y,
           int scalar_z, class SizeType = typename ZMV::size_type>
 struct MV_Update_Functor {
-  typedef typename ZMV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename ZMV::non_const_value_type> ATS;
 
@@ -213,7 +212,6 @@ struct MV_Update_Functor {
 template <class XV, class YV, class ZV, int scalar_x, int scalar_y,
           int scalar_z, class SizeType = typename ZV::size_type>
 struct V_Update_Functor {
-  typedef typename ZV::execution_space execution_space;
   typedef SizeType size_type;
   typedef Kokkos::ArithTraits<typename ZV::non_const_value_type> ATS;
 
@@ -316,8 +314,9 @@ struct V_Update_Functor {
 //
 // Any literal coefficient of zero has BLAS semantics of ignoring the
 // corresponding multivector entry.
-template <class XMV, class YMV, class ZMV, class SizeType>
-void MV_Update_Generic(const typename XMV::non_const_value_type& alpha,
+template <class execution_space, class XMV, class YMV, class ZMV, class SizeType>
+void MV_Update_Generic(const execution_space& space,
+		       const typename XMV::non_const_value_type& alpha,
                        const XMV& X,
                        const typename YMV::non_const_value_type& beta,
                        const YMV& Y,
@@ -347,9 +346,8 @@ void MV_Update_Generic(const typename XMV::non_const_value_type& alpha,
                 "KokkosBlas::Impl::MV_Update_Generic: "
                 "XMV, YMV, and ZMV must have rank 2.");
 
-  typedef typename XMV::execution_space execution_space;
   const SizeType numRows = X.extent(0);
-  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
+  Kokkos::RangePolicy<execution_space, SizeType> policy(space, 0, numRows);
 
   if (a == 0) {
     if (b == 0) {
@@ -417,8 +415,9 @@ void MV_Update_Generic(const typename XMV::non_const_value_type& alpha,
 //
 // Any literal coefficient of zero has BLAS semantics of ignoring the
 // corresponding vector entry.
-template <class XV, class YV, class ZV, class SizeType>
-void V_Update_Generic(const typename XV::non_const_value_type& alpha,
+template <class execution_space, class XV, class YV, class ZV, class SizeType>
+void V_Update_Generic(const execution_space& space,
+		      const typename XV::non_const_value_type& alpha,
                       const XV& X,
                       const typename YV::non_const_value_type& beta,
                       const YV& Y,
@@ -448,9 +447,8 @@ void V_Update_Generic(const typename XV::non_const_value_type& alpha,
                 "KokkosBlas::Impl::V_Update_Generic: "
                 "XV, YV, and ZV must have rank 1.");
 
-  typedef typename XV::execution_space execution_space;
   const SizeType numRows = X.extent(0);
-  Kokkos::RangePolicy<execution_space, SizeType> policy(0, numRows);
+  Kokkos::RangePolicy<execution_space, SizeType> policy(space, 0, numRows);
 
   if (a == 0) {
     if (b == 0) {

--- a/blas/impl/KokkosBlas1_update_spec.hpp
+++ b/blas/impl/KokkosBlas1_update_spec.hpp
@@ -27,7 +27,7 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class XMV, class YMV, class ZMV, int rank = ZMV::rank>
+template <class execution_space, class XMV, class YMV, class ZMV, int rank = ZMV::rank>
 struct update_eti_spec_avail {
   enum : bool { value = false };
 };
@@ -45,6 +45,7 @@ struct update_eti_spec_avail {
                                           MEM_SPACE)                       \
   template <>                                                              \
   struct update_eti_spec_avail<                                            \
+      EXEC_SPACE,                                                          \
       Kokkos::View<const SCALAR*, LAYOUT,                                  \
                    Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                  \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,              \
@@ -68,6 +69,7 @@ struct update_eti_spec_avail {
                                              MEM_SPACE)                     \
   template <>                                                               \
   struct update_eti_spec_avail<                                             \
+      EXEC_SPACE,                                                           \
       Kokkos::View<const SCALAR**, LAYOUT,                                  \
                    Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                   \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
@@ -100,11 +102,12 @@ namespace Impl {
 /// Z(i,j) = alpha*X(i,j) + beta*Y(i,j) + gamma*Z(i,j),
 ///
 /// with special cases for alpha, beta, or gamma = 0.
-template <class XMV, class YMV, class ZMV, int rank = ZMV::rank,
-          bool tpl_spec_avail = update_tpl_spec_avail<XMV, YMV, ZMV>::value,
-          bool eti_spec_avail = update_eti_spec_avail<XMV, YMV, ZMV>::value>
+template <class execution_space, class XMV, class YMV, class ZMV, int rank = ZMV::rank,
+          bool tpl_spec_avail = update_tpl_spec_avail<execution_space, XMV, YMV, ZMV>::value,
+          bool eti_spec_avail = update_eti_spec_avail<execution_space, XMV, YMV, ZMV>::value>
 struct Update {
-  static void update(const typename XMV::non_const_value_type& alpha,
+  static void update(const execution_space& space,
+		     const typename XMV::non_const_value_type& alpha,
                      const XMV& X,
                      const typename YMV::non_const_value_type& beta,
                      const YMV& Y,
@@ -114,14 +117,15 @@ struct Update {
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 // Partial specialization for XMV, YMV, and ZMV rank-2 Views.
-template <class XMV, class YMV, class ZMV>
-struct Update<XMV, YMV, ZMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+template <class execution_space, class XMV, class YMV, class ZMV>
+struct Update<execution_space, XMV, YMV, ZMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
   typedef Kokkos::ArithTraits<typename XMV::non_const_value_type> ATA;
   typedef Kokkos::ArithTraits<typename YMV::non_const_value_type> ATB;
   typedef Kokkos::ArithTraits<typename ZMV::non_const_value_type> ATC;
 
-  static void update(const typename XMV::non_const_value_type& alpha,
+  static void update(const execution_space& space,
+		     const typename XMV::non_const_value_type& alpha,
                      const XMV& X,
                      const typename YMV::non_const_value_type& beta,
                      const YMV& Y,
@@ -194,23 +198,23 @@ struct Update<XMV, YMV, ZMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 
       if (numRows * numCols < static_cast<size_type>(INT_MAX)) {
         typedef int index_type;
-        V_Update_Generic<decltype(X_0), decltype(Y_0), decltype(Z_0),
-                         index_type>(alpha, X_0, beta, Y_0, gamma, Z_0, a, b,
+        V_Update_Generic<execution_space, decltype(X_0), decltype(Y_0), decltype(Z_0),
+                         index_type>(space, alpha, X_0, beta, Y_0, gamma, Z_0, a, b,
                                      c);
       } else {
         typedef typename XMV::size_type index_type;
-        V_Update_Generic<decltype(X_0), decltype(Y_0), decltype(Z_0),
-                         index_type>(alpha, X_0, beta, Y_0, gamma, Z_0, a, b,
+        V_Update_Generic<execution_space, decltype(X_0), decltype(Y_0), decltype(Z_0),
+                         index_type>(space, alpha, X_0, beta, Y_0, gamma, Z_0, a, b,
                                      c);
       }
     } else {
       if (numRows * numCols < static_cast<size_type>(INT_MAX)) {
         typedef int index_type;
-        MV_Update_Generic<XMV, YMV, ZMV, index_type>(alpha, X, beta, Y, gamma,
+        MV_Update_Generic<execution_space, XMV, YMV, ZMV, index_type>(space, alpha, X, beta, Y, gamma,
                                                      Z, a, b, c);
       } else {
         typedef typename XMV::size_type index_type;
-        MV_Update_Generic<XMV, YMV, ZMV, index_type>(alpha, X, beta, Y, gamma,
+        MV_Update_Generic<execution_space, XMV, YMV, ZMV, index_type>(space, alpha, X, beta, Y, gamma,
                                                      Z, a, b, c);
       }
     }
@@ -219,14 +223,15 @@ struct Update<XMV, YMV, ZMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 };
 
 // Partial specialization for XV, YV, and ZV rank-1 Views.
-template <class XV, class YV, class ZV>
-struct Update<XV, YV, ZV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+template <class execution_space, class XV, class YV, class ZV>
+struct Update<execution_space, XV, YV, ZV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XV::size_type size_type;
   typedef Kokkos::ArithTraits<typename XV::non_const_value_type> ATA;
   typedef Kokkos::ArithTraits<typename YV::non_const_value_type> ATB;
   typedef Kokkos::ArithTraits<typename ZV::non_const_value_type> ATC;
 
-  static void update(const typename XV::non_const_value_type& alpha,
+  static void update(const execution_space& space,
+		     const typename XV::non_const_value_type& alpha,
                      const XV& X, const typename YV::non_const_value_type& beta,
                      const YV& Y,
                      const typename ZV::non_const_value_type& gamma,
@@ -291,11 +296,11 @@ struct Update<XV, YV, ZV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
     if (numRows < static_cast<size_type>(INT_MAX) &&
         numRows * numCols < static_cast<size_type>(INT_MAX)) {
       typedef int index_type;
-      V_Update_Generic<XV, YV, ZV, index_type>(alpha, X, beta, Y, gamma, Z, a,
+      V_Update_Generic<execution_space, XV, YV, ZV, index_type>(space, alpha, X, beta, Y, gamma, Z, a,
                                                b, c);
     } else {
       typedef typename XV::size_type index_type;
-      V_Update_Generic<XV, YV, ZV, index_type>(alpha, X, beta, Y, gamma, Z, a,
+      V_Update_Generic<execution_space, XV, YV, ZV, index_type>(space, alpha, X, beta, Y, gamma, Z, a,
                                                b, c);
     }
     Kokkos::Profiling::popRegion();
@@ -318,6 +323,7 @@ struct Update<XV, YV, ZV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 #define KOKKOSBLAS1_UPDATE_ETI_SPEC_DECL(SCALAR, LAYOUT, EXEC_SPACE,       \
                                          MEM_SPACE)                        \
   extern template struct Update<                                           \
+      EXEC_SPACE,                                                          \
       Kokkos::View<const SCALAR*, LAYOUT,                                  \
                    Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                  \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,              \
@@ -331,6 +337,7 @@ struct Update<XV, YV, ZV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 #define KOKKOSBLAS1_UPDATE_ETI_SPEC_INST(SCALAR, LAYOUT, EXEC_SPACE,       \
                                          MEM_SPACE)                        \
   template struct Update<                                                  \
+      EXEC_SPACE,                                                          \
       Kokkos::View<const SCALAR*, LAYOUT,                                  \
                    Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                  \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,              \
@@ -352,6 +359,7 @@ struct Update<XV, YV, ZV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 #define KOKKOSBLAS1_UPDATE_MV_ETI_SPEC_DECL(SCALAR, LAYOUT, EXEC_SPACE,     \
                                             MEM_SPACE)                      \
   extern template struct Update<                                            \
+      EXEC_SPACE,                                                           \
       Kokkos::View<const SCALAR**, LAYOUT,                                  \
                    Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                   \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
@@ -365,6 +373,7 @@ struct Update<XV, YV, ZV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
 #define KOKKOSBLAS1_UPDATE_MV_ETI_SPEC_INST(SCALAR, LAYOUT, EXEC_SPACE,     \
                                             MEM_SPACE)                      \
   template struct Update<                                                   \
+      EXEC_SPACE,                                                           \
       Kokkos::View<const SCALAR**, LAYOUT,                                  \
                    Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                   \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \

--- a/blas/impl/KokkosBlas1_update_spec.hpp
+++ b/blas/impl/KokkosBlas1_update_spec.hpp
@@ -27,7 +27,8 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class execution_space, class XMV, class YMV, class ZMV, int rank = ZMV::rank>
+template <class execution_space, class XMV, class YMV, class ZMV,
+          int rank = ZMV::rank>
 struct update_eti_spec_avail {
   enum : bool { value = false };
 };
@@ -102,12 +103,15 @@ namespace Impl {
 /// Z(i,j) = alpha*X(i,j) + beta*Y(i,j) + gamma*Z(i,j),
 ///
 /// with special cases for alpha, beta, or gamma = 0.
-template <class execution_space, class XMV, class YMV, class ZMV, int rank = ZMV::rank,
-          bool tpl_spec_avail = update_tpl_spec_avail<execution_space, XMV, YMV, ZMV>::value,
-          bool eti_spec_avail = update_eti_spec_avail<execution_space, XMV, YMV, ZMV>::value>
+template <class execution_space, class XMV, class YMV, class ZMV,
+          int rank = ZMV::rank,
+          bool tpl_spec_avail =
+              update_tpl_spec_avail<execution_space, XMV, YMV, ZMV>::value,
+          bool eti_spec_avail =
+              update_eti_spec_avail<execution_space, XMV, YMV, ZMV>::value>
 struct Update {
   static void update(const execution_space& space,
-		     const typename XMV::non_const_value_type& alpha,
+                     const typename XMV::non_const_value_type& alpha,
                      const XMV& X,
                      const typename YMV::non_const_value_type& beta,
                      const YMV& Y,
@@ -118,14 +122,15 @@ struct Update {
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 // Partial specialization for XMV, YMV, and ZMV rank-2 Views.
 template <class execution_space, class XMV, class YMV, class ZMV>
-struct Update<execution_space, XMV, YMV, ZMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+struct Update<execution_space, XMV, YMV, ZMV, 2, false,
+              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XMV::size_type size_type;
   typedef Kokkos::ArithTraits<typename XMV::non_const_value_type> ATA;
   typedef Kokkos::ArithTraits<typename YMV::non_const_value_type> ATB;
   typedef Kokkos::ArithTraits<typename ZMV::non_const_value_type> ATC;
 
   static void update(const execution_space& space,
-		     const typename XMV::non_const_value_type& alpha,
+                     const typename XMV::non_const_value_type& alpha,
                      const XMV& X,
                      const typename YMV::non_const_value_type& beta,
                      const YMV& Y,
@@ -198,24 +203,24 @@ struct Update<execution_space, XMV, YMV, ZMV, 2, false, KOKKOSKERNELS_IMPL_COMPI
 
       if (numRows * numCols < static_cast<size_type>(INT_MAX)) {
         typedef int index_type;
-        V_Update_Generic<execution_space, decltype(X_0), decltype(Y_0), decltype(Z_0),
-                         index_type>(space, alpha, X_0, beta, Y_0, gamma, Z_0, a, b,
-                                     c);
+        V_Update_Generic<execution_space, decltype(X_0), decltype(Y_0),
+                         decltype(Z_0), index_type>(space, alpha, X_0, beta,
+                                                    Y_0, gamma, Z_0, a, b, c);
       } else {
         typedef typename XMV::size_type index_type;
-        V_Update_Generic<execution_space, decltype(X_0), decltype(Y_0), decltype(Z_0),
-                         index_type>(space, alpha, X_0, beta, Y_0, gamma, Z_0, a, b,
-                                     c);
+        V_Update_Generic<execution_space, decltype(X_0), decltype(Y_0),
+                         decltype(Z_0), index_type>(space, alpha, X_0, beta,
+                                                    Y_0, gamma, Z_0, a, b, c);
       }
     } else {
       if (numRows * numCols < static_cast<size_type>(INT_MAX)) {
         typedef int index_type;
-        MV_Update_Generic<execution_space, XMV, YMV, ZMV, index_type>(space, alpha, X, beta, Y, gamma,
-                                                     Z, a, b, c);
+        MV_Update_Generic<execution_space, XMV, YMV, ZMV, index_type>(
+            space, alpha, X, beta, Y, gamma, Z, a, b, c);
       } else {
         typedef typename XMV::size_type index_type;
-        MV_Update_Generic<execution_space, XMV, YMV, ZMV, index_type>(space, alpha, X, beta, Y, gamma,
-                                                     Z, a, b, c);
+        MV_Update_Generic<execution_space, XMV, YMV, ZMV, index_type>(
+            space, alpha, X, beta, Y, gamma, Z, a, b, c);
       }
     }
     Kokkos::Profiling::popRegion();
@@ -224,14 +229,15 @@ struct Update<execution_space, XMV, YMV, ZMV, 2, false, KOKKOSKERNELS_IMPL_COMPI
 
 // Partial specialization for XV, YV, and ZV rank-1 Views.
 template <class execution_space, class XV, class YV, class ZV>
-struct Update<execution_space, XV, YV, ZV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+struct Update<execution_space, XV, YV, ZV, 1, false,
+              KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename XV::size_type size_type;
   typedef Kokkos::ArithTraits<typename XV::non_const_value_type> ATA;
   typedef Kokkos::ArithTraits<typename YV::non_const_value_type> ATB;
   typedef Kokkos::ArithTraits<typename ZV::non_const_value_type> ATC;
 
   static void update(const execution_space& space,
-		     const typename XV::non_const_value_type& alpha,
+                     const typename XV::non_const_value_type& alpha,
                      const XV& X, const typename YV::non_const_value_type& beta,
                      const YV& Y,
                      const typename ZV::non_const_value_type& gamma,
@@ -296,12 +302,12 @@ struct Update<execution_space, XV, YV, ZV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_
     if (numRows < static_cast<size_type>(INT_MAX) &&
         numRows * numCols < static_cast<size_type>(INT_MAX)) {
       typedef int index_type;
-      V_Update_Generic<execution_space, XV, YV, ZV, index_type>(space, alpha, X, beta, Y, gamma, Z, a,
-                                               b, c);
+      V_Update_Generic<execution_space, XV, YV, ZV, index_type>(
+          space, alpha, X, beta, Y, gamma, Z, a, b, c);
     } else {
       typedef typename XV::size_type index_type;
-      V_Update_Generic<execution_space, XV, YV, ZV, index_type>(space, alpha, X, beta, Y, gamma, Z, a,
-                                               b, c);
+      V_Update_Generic<execution_space, XV, YV, ZV, index_type>(
+          space, alpha, X, beta, Y, gamma, Z, a, b, c);
     }
     Kokkos::Profiling::popRegion();
   }

--- a/blas/src/KokkosBlas1_abs.hpp
+++ b/blas/src/KokkosBlas1_abs.hpp
@@ -28,18 +28,25 @@ namespace KokkosBlas {
 /// Replace each entry in R with the absolute value (magnitude) of the
 /// corresponding entry in X.
 ///
+/// \tparam execution_space a Kokkos execution space to run the kernels on.
 /// \tparam RMV 1-D or 2-D Kokkos::View specialization.
 /// \tparam XMV 1-D or 2-D Kokkos::View specialization.  It must have
 ///   the same rank as RMV, and its entries must be assignable to
 ///   those of RMV.
-template <class RMV, class XMV>
-void abs(const RMV& R, const XMV& X) {
+template <class execution_space, class RMV, class XMV>
+void abs(const execution_space& space, const RMV& R, const XMV& X) {
+  static_assert(Kokkos::is_execution_space_v<execution_space>,
+		"KokkosBlas::abs: execution_space must be a valid Kokkos execution space.");
   static_assert(Kokkos::is_view<RMV>::value,
                 "KokkosBlas::abs: "
                 "R is not a Kokkos::View.");
+  static_assert(Kokkos::SpaceAccessibility<execution_space, typename RMV::memory_space>::accessible,
+		"KokkosBlas::abs: RMV must be accessible from execution space");
   static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::abs: "
                 "X is not a Kokkos::View.");
+  static_assert(Kokkos::SpaceAccessibility<execution_space, typename XMV::memory_space>::accessible,
+		"KokkosBlas::abs: XMV must be accessible from execution space");
   static_assert(std::is_same<typename RMV::value_type,
                              typename RMV::non_const_value_type>::value,
                 "KokkosBlas::abs: R is const.  "
@@ -63,24 +70,36 @@ void abs(const RMV& R, const XMV& X) {
 
   // Create unmanaged versions of the input Views.  RMV and XMV may be
   // rank 1 or rank 2.
-  typedef Kokkos::View<
+  using RMV_Internal = Kokkos::View<
       typename std::conditional<RMV::rank == 1,
                                 typename RMV::non_const_value_type*,
                                 typename RMV::non_const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<RMV>::array_layout,
-      typename RMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
-      RMV_Internal;
-  typedef Kokkos::View<
+      typename RMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+  using XMV_Internal = Kokkos::View<
       typename std::conditional<XMV::rank == 1, typename XMV::const_value_type*,
                                 typename XMV::const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
-      typename XMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
-      XMV_Internal;
+      typename XMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
 
   RMV_Internal R_internal = R;
   XMV_Internal X_internal = X;
 
-  Impl::Abs<RMV_Internal, XMV_Internal>::abs(R_internal, X_internal);
+  Impl::Abs<execution_space, RMV_Internal, XMV_Internal>::abs(space, R_internal, X_internal);
+}
+
+/// \brief R(i,j) = abs(X(i,j))
+///
+/// Replace each entry in R with the absolute value (magnitude) of the
+/// corresponding entry in X.
+///
+/// \tparam RMV 1-D or 2-D Kokkos::View specialization.
+/// \tparam XMV 1-D or 2-D Kokkos::View specialization.  It must have
+///   the same rank as RMV, and its entries must be assignable to
+///   those of RMV.
+template <class RMV, class XMV>
+void abs(const RMV& R, const XMV& X) {
+  abs(typename RMV::execution_space{}, R, X);
 }
 }  // namespace KokkosBlas
 

--- a/blas/src/KokkosBlas1_abs.hpp
+++ b/blas/src/KokkosBlas1_abs.hpp
@@ -36,17 +36,22 @@ namespace KokkosBlas {
 template <class execution_space, class RMV, class XMV>
 void abs(const execution_space& space, const RMV& R, const XMV& X) {
   static_assert(Kokkos::is_execution_space_v<execution_space>,
-		"KokkosBlas::abs: execution_space must be a valid Kokkos execution space.");
+                "KokkosBlas::abs: execution_space must be a valid Kokkos "
+                "execution space.");
   static_assert(Kokkos::is_view<RMV>::value,
                 "KokkosBlas::abs: "
                 "R is not a Kokkos::View.");
-  static_assert(Kokkos::SpaceAccessibility<execution_space, typename RMV::memory_space>::accessible,
-		"KokkosBlas::abs: RMV must be accessible from execution space");
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename RMV::memory_space>::accessible,
+      "KokkosBlas::abs: RMV must be accessible from execution space");
   static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::abs: "
                 "X is not a Kokkos::View.");
-  static_assert(Kokkos::SpaceAccessibility<execution_space, typename XMV::memory_space>::accessible,
-		"KokkosBlas::abs: XMV must be accessible from execution space");
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename XMV::memory_space>::accessible,
+      "KokkosBlas::abs: XMV must be accessible from execution space");
   static_assert(std::is_same<typename RMV::value_type,
                              typename RMV::non_const_value_type>::value,
                 "KokkosBlas::abs: R is const.  "
@@ -85,7 +90,8 @@ void abs(const execution_space& space, const RMV& R, const XMV& X) {
   RMV_Internal R_internal = R;
   XMV_Internal X_internal = X;
 
-  Impl::Abs<execution_space, RMV_Internal, XMV_Internal>::abs(space, R_internal, X_internal);
+  Impl::Abs<execution_space, RMV_Internal, XMV_Internal>::abs(space, R_internal,
+                                                              X_internal);
 }
 
 /// \brief R(i,j) = abs(X(i,j))

--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -31,19 +31,25 @@
 namespace KokkosBlas {
 
 template <class execution_space, class AV, class XMV, class BV, class YMV>
-void axpby(const execution_space& space, const AV& a, const XMV& X, const BV& b, const YMV& Y) {
+void axpby(const execution_space& space, const AV& a, const XMV& X, const BV& b,
+           const YMV& Y) {
   static_assert(Kokkos::is_execution_space_v<execution_space>,
-		"KokkosBlas::axpby: execution_space must be a valid Kokkos execution space.");
+                "KokkosBlas::axpby: execution_space must be a valid Kokkos "
+                "execution space.");
   static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::axpby: "
                 "X is not a Kokkos::View.");
-  static_assert(Kokkos::SpaceAccessibility<execution_space, typename XMV::memory_space>::accessible,
-		"KokkosBlas::axpby: XMV must be accessible from execution_space");
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename XMV::memory_space>::accessible,
+      "KokkosBlas::axpby: XMV must be accessible from execution_space");
   static_assert(Kokkos::is_view<YMV>::value,
                 "KokkosBlas::axpby: "
                 "Y is not a Kokkos::View.");
-  static_assert(Kokkos::SpaceAccessibility<execution_space, typename YMV::memory_space>::accessible,
-		"KokkosBlas::axpby: XMV must be accessible from execution_space");
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename YMV::memory_space>::accessible,
+      "KokkosBlas::axpby: XMV must be accessible from execution_space");
   static_assert(std::is_same<typename YMV::value_type,
                              typename YMV::non_const_value_type>::value,
                 "KokkosBlas::axpby: Y is const.  It must be nonconst, "
@@ -74,23 +80,27 @@ void axpby(const execution_space& space, const AV& a, const XMV& X, const BV& b,
   // Create unmanaged versions of the input Views.  XMV and YMV may be
   // rank 1 or rank 2.  AV and BV may be either rank-1 Views, or
   // scalar values.
-  using XMV_Internal = Kokkos::View<typename XMV::const_data_type, UnifiedXLayout,
-                       typename XMV::device_type,
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
-  using YMV_Internal = Kokkos::View<typename YMV::non_const_data_type, UnifiedYLayout,
-                       typename YMV::device_type,
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
-  using AV_Internal = typename KokkosKernels::Impl::GetUnifiedScalarViewType<
-      AV, XMV_Internal, true>::type;
-  using BV_Internal = typename KokkosKernels::Impl::GetUnifiedScalarViewType<
-      BV, YMV_Internal, true>::type;
+  using XMV_Internal = Kokkos::View<typename XMV::const_data_type,
+                                    UnifiedXLayout, typename XMV::device_type,
+                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+  using YMV_Internal = Kokkos::View<typename YMV::non_const_data_type,
+                                    UnifiedYLayout, typename YMV::device_type,
+                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+  using AV_Internal =
+      typename KokkosKernels::Impl::GetUnifiedScalarViewType<AV, XMV_Internal,
+                                                             true>::type;
+  using BV_Internal =
+      typename KokkosKernels::Impl::GetUnifiedScalarViewType<BV, YMV_Internal,
+                                                             true>::type;
 
   AV_Internal a_internal  = a;
   XMV_Internal X_internal = X;
   BV_Internal b_internal  = b;
   YMV_Internal Y_internal = Y;
 
-  Impl::Axpby<execution_space, AV_Internal, XMV_Internal, BV_Internal, YMV_Internal>::axpby(space, a_internal, X_internal, b_internal, Y_internal);
+  Impl::Axpby<execution_space, AV_Internal, XMV_Internal, BV_Internal,
+              YMV_Internal>::axpby(space, a_internal, X_internal, b_internal,
+                                   Y_internal);
 }
 
 template <class AV, class XMV, class BV, class YMV>
@@ -99,9 +109,10 @@ void axpby(const AV& a, const XMV& X, const BV& b, const YMV& Y) {
 }
 
 template <class execution_space, class AV, class XMV, class YMV>
-void axpy(const execution_space& space, const AV& a, const XMV& X, const YMV& Y) {
-  axpby(space, a, X, Kokkos::ArithTraits<typename YMV::non_const_value_type>::one(),
-        Y);
+void axpy(const execution_space& space, const AV& a, const XMV& X,
+          const YMV& Y) {
+  axpby(space, a, X,
+        Kokkos::ArithTraits<typename YMV::non_const_value_type>::one(), Y);
 }
 
 template <class AV, class XMV, class YMV>

--- a/blas/src/KokkosBlas1_fill.hpp
+++ b/blas/src/KokkosBlas1_fill.hpp
@@ -27,6 +27,19 @@ namespace KokkosBlas {
 ///
 /// \param X [out] Output View (1-D or 2-D).
 /// \param val [in] Value with which to fill the entries of X.
+template <class execution_space, class XMV>
+void fill(const execution_space& space, const XMV& X, const typename XMV::non_const_value_type& val) {
+  Kokkos::Profiling::pushRegion("KokkosBlas::fill<execution_space, XMV>");
+  Kokkos::deep_copy(space, X, val);
+  Kokkos::Profiling::popRegion();
+}
+
+/// \brief Fill the multivector or single vector X with the given value.
+///
+/// \tparam XMV 1-D or 2-D output View
+///
+/// \param X [out] Output View (1-D or 2-D).
+/// \param val [in] Value with which to fill the entries of X.
 template <class XMV>
 void fill(const XMV& X, const typename XMV::non_const_value_type& val) {
   Kokkos::Profiling::pushRegion("KokkosBlas::fill");

--- a/blas/src/KokkosBlas1_fill.hpp
+++ b/blas/src/KokkosBlas1_fill.hpp
@@ -28,7 +28,8 @@ namespace KokkosBlas {
 /// \param X [out] Output View (1-D or 2-D).
 /// \param val [in] Value with which to fill the entries of X.
 template <class execution_space, class XMV>
-void fill(const execution_space& space, const XMV& X, const typename XMV::non_const_value_type& val) {
+void fill(const execution_space& space, const XMV& X,
+          const typename XMV::non_const_value_type& val) {
   Kokkos::Profiling::pushRegion("KokkosBlas::fill<execution_space, XMV>");
   Kokkos::deep_copy(space, X, val);
   Kokkos::Profiling::popRegion();

--- a/blas/src/KokkosBlas1_fill.hpp
+++ b/blas/src/KokkosBlas1_fill.hpp
@@ -23,8 +23,11 @@ namespace KokkosBlas {
 
 /// \brief Fill the multivector or single vector X with the given value.
 ///
+/// \tparam execution_space a Kokkos execution space
 /// \tparam XMV 1-D or 2-D output View
 ///
+/// \param space [in] A Kokkos instance of execution_space on which the
+///                   kernel will run.
 /// \param X [out] Output View (1-D or 2-D).
 /// \param val [in] Value with which to fill the entries of X.
 template <class execution_space, class XMV>

--- a/blas/src/KokkosBlas1_mult.hpp
+++ b/blas/src/KokkosBlas1_mult.hpp
@@ -38,25 +38,33 @@ namespace KokkosBlas {
 ///
 /// \return Y = gamma * Y + alpha * A * X.
 template <class execution_space, class YMV, class AV, class XMV>
-void mult(const execution_space& space, typename YMV::const_value_type& gamma, const YMV& Y,
-          typename AV::const_value_type& alpha, const AV& A, const XMV& X) {
+void mult(const execution_space& space, typename YMV::const_value_type& gamma,
+          const YMV& Y, typename AV::const_value_type& alpha, const AV& A,
+          const XMV& X) {
   static_assert(Kokkos::is_execution_space_v<execution_space>,
-		"KokkosBlas::mult: execution_space must be a valid Kokkos execution space.");
+                "KokkosBlas::mult: execution_space must be a valid Kokkos "
+                "execution space.");
   static_assert(Kokkos::is_view<YMV>::value,
                 "KokkosBlas::mult: "
                 "Y is not a Kokkos::View.");
-  static_assert(Kokkos::SpaceAccessibility<execution_space, typename YMV::memory_space>::accessible,
-		"KokkosBlas::mult: YMV must be accessible from execution_space.");
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename YMV::memory_space>::accessible,
+      "KokkosBlas::mult: YMV must be accessible from execution_space.");
   static_assert(Kokkos::is_view<AV>::value,
                 "KokkosBlas::mult: "
                 "A is not a Kokkos::View.");
-  static_assert(Kokkos::SpaceAccessibility<execution_space, typename AV::memory_space>::accessible,
-		"KokkosBlas::mult: AV must be accessible from execution_space.");
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename AV::memory_space>::accessible,
+      "KokkosBlas::mult: AV must be accessible from execution_space.");
   static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::mult: "
                 "X is not a Kokkos::View.");
-  static_assert(Kokkos::SpaceAccessibility<execution_space, typename XMV::memory_space>::accessible,
-		"KokkosBlas::mult: AV must be accessible from execution_space.");
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename XMV::memory_space>::accessible,
+      "KokkosBlas::mult: AV must be accessible from execution_space.");
   static_assert(std::is_same<typename YMV::value_type,
                              typename YMV::non_const_value_type>::value,
                 "KokkosBlas::mult: Y is const.  "
@@ -107,7 +115,7 @@ void mult(const execution_space& space, typename YMV::const_value_type& gamma, c
   XMV_Internal X_internal = X;
 
   Impl::Mult<execution_space, YMV_Internal, AV_Internal, XMV_Internal>::mult(
-									     space, gamma, Y_internal, alpha, A_internal, X_internal);
+      space, gamma, Y_internal, alpha, A_internal, X_internal);
 }
 
 /// \brief Element wise multiplication of two vectors:

--- a/blas/src/KokkosBlas1_mult.hpp
+++ b/blas/src/KokkosBlas1_mult.hpp
@@ -26,10 +26,13 @@ namespace KokkosBlas {
 /// \brief Element wise multiplication of two vectors:
 ///        Y[i] = gamma * Y[i] + alpha * A[i] * X[i]
 ///
+/// \tparam execution_type a Kokkos execution space type.
 /// \tparam YMV Type of the first vector Y; a 1-D or 2-D Kokkos::View.
 /// \tparam AV  Type of the second vector A; a 1-D Kokkos::View.
 /// \tparam XMV Type of the third vector X; a 1-D or 2-D Kokkos::View.
 ///
+/// \param space [in] An instance of execution_space on which the kernel
+///                   will run (it may specify an execution stream/queue).
 /// \param gamma [in] The scalar to apply to Y.
 /// \param Y [in/out] The Y vector.
 /// \param alpha [in] The scalar to apply to A.

--- a/blas/src/KokkosBlas1_mult.hpp
+++ b/blas/src/KokkosBlas1_mult.hpp
@@ -37,15 +37,26 @@ namespace KokkosBlas {
 /// \param X [in]     The X vector.
 ///
 /// \return Y = gamma * Y + alpha * A * X.
-template <class YMV, class AV, class XMV>
-void mult(typename YMV::const_value_type& gamma, const YMV& Y,
+template <class execution_space, class YMV, class AV, class XMV>
+void mult(const execution_space& space, typename YMV::const_value_type& gamma, const YMV& Y,
           typename AV::const_value_type& alpha, const AV& A, const XMV& X) {
+  static_assert(Kokkos::is_execution_space_v<execution_space>,
+		"KokkosBlas::mult: execution_space must be a valid Kokkos execution space.");
   static_assert(Kokkos::is_view<YMV>::value,
                 "KokkosBlas::mult: "
                 "Y is not a Kokkos::View.");
+  static_assert(Kokkos::SpaceAccessibility<execution_space, typename YMV::memory_space>::accessible,
+		"KokkosBlas::mult: YMV must be accessible from execution_space.");
   static_assert(Kokkos::is_view<AV>::value,
                 "KokkosBlas::mult: "
                 "A is not a Kokkos::View.");
+  static_assert(Kokkos::SpaceAccessibility<execution_space, typename AV::memory_space>::accessible,
+		"KokkosBlas::mult: AV must be accessible from execution_space.");
+  static_assert(Kokkos::is_view<XMV>::value,
+                "KokkosBlas::mult: "
+                "X is not a Kokkos::View.");
+  static_assert(Kokkos::SpaceAccessibility<execution_space, typename XMV::memory_space>::accessible,
+		"KokkosBlas::mult: AV must be accessible from execution_space.");
   static_assert(std::is_same<typename YMV::value_type,
                              typename YMV::non_const_value_type>::value,
                 "KokkosBlas::mult: Y is const.  "
@@ -95,8 +106,28 @@ void mult(typename YMV::const_value_type& gamma, const YMV& Y,
   AV_Internal A_internal  = A;
   XMV_Internal X_internal = X;
 
-  Impl::Mult<YMV_Internal, AV_Internal, XMV_Internal>::mult(
-      gamma, Y_internal, alpha, A_internal, X_internal);
+  Impl::Mult<execution_space, YMV_Internal, AV_Internal, XMV_Internal>::mult(
+									     space, gamma, Y_internal, alpha, A_internal, X_internal);
+}
+
+/// \brief Element wise multiplication of two vectors:
+///        Y[i] = gamma * Y[i] + alpha * A[i] * X[i]
+///
+/// \tparam YMV Type of the first vector Y; a 1-D or 2-D Kokkos::View.
+/// \tparam AV  Type of the second vector A; a 1-D Kokkos::View.
+/// \tparam XMV Type of the third vector X; a 1-D or 2-D Kokkos::View.
+///
+/// \param gamma [in] The scalar to apply to Y.
+/// \param Y [in/out] The Y vector.
+/// \param alpha [in] The scalar to apply to A.
+/// \param A [in]     The vector to apply to X.
+/// \param X [in]     The X vector.
+///
+/// \return Y = gamma * Y + alpha * A * X.
+template <class YMV, class AV, class XMV>
+void mult(typename YMV::const_value_type& gamma, const YMV& Y,
+          typename AV::const_value_type& alpha, const AV& A, const XMV& X) {
+  mult(typename YMV::execution_space{}, gamma, Y, alpha, A, X);
 }
 
 }  // namespace KokkosBlas

--- a/blas/src/KokkosBlas1_reciprocal.hpp
+++ b/blas/src/KokkosBlas1_reciprocal.hpp
@@ -35,17 +35,22 @@ namespace KokkosBlas {
 template <class execution_space, class RMV, class XMV>
 void reciprocal(const execution_space& space, const RMV& R, const XMV& X) {
   static_assert(Kokkos::is_execution_space_v<execution_space>,
-		"KokkosBlas::reciprocal: execution_space must be a valid Kokkos execition space.");
+                "KokkosBlas::reciprocal: execution_space must be a valid "
+                "Kokkos execition space.");
   static_assert(Kokkos::is_view<RMV>::value,
                 "KokkosBlas::reciprocal: "
                 "R is not a Kokkos::View.");
-  static_assert(Kokkos::SpaceAccessibility<execution_space, typename RMV::memory_space>::accessible,
-		"KokkosBlas::reciprocal: RMV must be accessible from execution_space");
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename RMV::memory_space>::accessible,
+      "KokkosBlas::reciprocal: RMV must be accessible from execution_space");
   static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::reciprocal: "
                 "X is not a Kokkos::View.");
-  static_assert(Kokkos::SpaceAccessibility<execution_space, typename XMV::memory_space>::accessible,
-		"KokkosBlas::reciprocal: XMV must be accessible from execution_space");
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename XMV::memory_space>::accessible,
+      "KokkosBlas::reciprocal: XMV must be accessible from execution_space");
   static_assert(std::is_same<typename RMV::value_type,
                              typename RMV::non_const_value_type>::value,
                 "KokkosBlas::reciprocal: R is const.  "
@@ -86,9 +91,8 @@ void reciprocal(const execution_space& space, const RMV& R, const XMV& X) {
   RMV_Internal R_internal = R;
   XMV_Internal X_internal = X;
 
-  Impl::Reciprocal<execution_space, RMV_Internal, XMV_Internal>::reciprocal(space,
-									    R_internal,
-									    X_internal);
+  Impl::Reciprocal<execution_space, RMV_Internal, XMV_Internal>::reciprocal(
+      space, R_internal, X_internal);
 }
 
 /// \brief R(i,j) = reciprocal(X(i,j))

--- a/blas/src/KokkosBlas1_reciprocal.hpp
+++ b/blas/src/KokkosBlas1_reciprocal.hpp
@@ -32,14 +32,20 @@ namespace KokkosBlas {
 /// \tparam XMV 1-D or 2-D Kokkos::View specialization.  It must have
 ///   the same rank as RMV, and its entries must be assignable to
 ///   those of RMV.
-template <class RMV, class XMV>
-void reciprocal(const RMV& R, const XMV& X) {
+template <class execution_space, class RMV, class XMV>
+void reciprocal(const execution_space& space, const RMV& R, const XMV& X) {
+  static_assert(Kokkos::is_execution_space_v<execution_space>,
+		"KokkosBlas::reciprocal: execution_space must be a valid Kokkos execition space.");
   static_assert(Kokkos::is_view<RMV>::value,
                 "KokkosBlas::reciprocal: "
                 "R is not a Kokkos::View.");
+  static_assert(Kokkos::SpaceAccessibility<execution_space, typename RMV::memory_space>::accessible,
+		"KokkosBlas::reciprocal: RMV must be accessible from execution_space");
   static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::reciprocal: "
                 "X is not a Kokkos::View.");
+  static_assert(Kokkos::SpaceAccessibility<execution_space, typename XMV::memory_space>::accessible,
+		"KokkosBlas::reciprocal: XMV must be accessible from execution_space");
   static_assert(std::is_same<typename RMV::value_type,
                              typename RMV::non_const_value_type>::value,
                 "KokkosBlas::reciprocal: R is const.  "
@@ -80,8 +86,23 @@ void reciprocal(const RMV& R, const XMV& X) {
   RMV_Internal R_internal = R;
   XMV_Internal X_internal = X;
 
-  Impl::Reciprocal<RMV_Internal, XMV_Internal>::reciprocal(R_internal,
-                                                           X_internal);
+  Impl::Reciprocal<execution_space, RMV_Internal, XMV_Internal>::reciprocal(space,
+									    R_internal,
+									    X_internal);
+}
+
+/// \brief R(i,j) = reciprocal(X(i,j))
+///
+/// Replace each entry in R with the absolute value (magnitude), of the
+/// reciprocal of the corresponding entry in X.
+///
+/// \tparam RMV 1-D or 2-D Kokkos::View specialization.
+/// \tparam XMV 1-D or 2-D Kokkos::View specialization.  It must have
+///   the same rank as RMV, and its entries must be assignable to
+///   those of RMV.
+template <class RMV, class XMV>
+void reciprocal(const RMV& R, const XMV& X) {
+  reciprocal(typename RMV::execution_space{}, R, X);
 }
 }  // namespace KokkosBlas
 

--- a/blas/src/KokkosBlas1_scal.hpp
+++ b/blas/src/KokkosBlas1_scal.hpp
@@ -30,21 +30,29 @@
 namespace KokkosBlas {
 
 template <class execution_space, class RMV, class AV, class XMV>
-void scal(const execution_space& space, const RMV& R, const AV& a, const XMV& X) {
+void scal(const execution_space& space, const RMV& R, const AV& a,
+          const XMV& X) {
   static_assert(Kokkos::is_execution_space_v<execution_space>,
-		"KokkosBlas::scal: execution_space must be a valid Kokkos execution space");
+                "KokkosBlas::scal: execution_space must be a valid Kokkos "
+                "execution space");
   static_assert(Kokkos::is_view<RMV>::value,
                 "KokkosBlas::scal: "
                 "R is not a Kokkos::View.");
-  static_assert(Kokkos::SpaceAccessibility<execution_space, typename RMV::memory_space>::accessible,
-		"KokkosBlas::scal: RMV must be accessible from execution_space.");
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename RMV::memory_space>::accessible,
+      "KokkosBlas::scal: RMV must be accessible from execution_space.");
   static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::scal: "
                 "X is not a Kokkos::View.");
-  static_assert(Kokkos::SpaceAccessibility<execution_space, typename XMV::memory_space>::accessible,
-		"KokkosBlas::scal: XMV must be accessible from execution_space");
-  static_assert(Kokkos::SpaceAccessibility<typename RMV::memory_space, typename XMV::memory_space>::assignable,
-		"KokkosBlas::scal: XMV must be assignable to RMV");
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename XMV::memory_space>::accessible,
+      "KokkosBlas::scal: XMV must be accessible from execution_space");
+  static_assert(
+      Kokkos::SpaceAccessibility<typename RMV::memory_space,
+                                 typename XMV::memory_space>::assignable,
+      "KokkosBlas::scal: XMV must be assignable to RMV");
   static_assert(std::is_same<typename RMV::value_type,
                              typename RMV::non_const_value_type>::value,
                 "KokkosBlas::scal: R is const.  "
@@ -75,21 +83,22 @@ void scal(const execution_space& space, const RMV& R, const AV& a, const XMV& X)
   // Create unmanaged versions of the input Views.  RMV and XMV may be
   // rank 1 or rank 2.  AV may be either a rank-1 View, or a scalar
   // value.
-  using RMV_Internal = Kokkos::View<typename RMV::non_const_data_type, UnifiedRLayout,
-                       typename RMV::device_type,
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
-  using XMV_Internal = Kokkos::View<typename XMV::const_data_type, UnifiedXLayout,
-                       typename XMV::device_type,
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
-  using AV_Internal = typename KokkosKernels::Impl::GetUnifiedScalarViewType<
-      AV, XMV_Internal, true>::type;
+  using RMV_Internal = Kokkos::View<typename RMV::non_const_data_type,
+                                    UnifiedRLayout, typename RMV::device_type,
+                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+  using XMV_Internal = Kokkos::View<typename XMV::const_data_type,
+                                    UnifiedXLayout, typename XMV::device_type,
+                                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+  using AV_Internal =
+      typename KokkosKernels::Impl::GetUnifiedScalarViewType<AV, XMV_Internal,
+                                                             true>::type;
 
   RMV_Internal R_internal = R;
   AV_Internal a_internal  = a;
   XMV_Internal X_internal = X;
 
   Impl::Scal<execution_space, RMV_Internal, AV_Internal, XMV_Internal>::scal(
-									     space, R_internal, a_internal, X_internal);
+      space, R_internal, a_internal, X_internal);
 }
 
 template <class RMV, class AV, class XMV>

--- a/blas/src/KokkosBlas1_scal.hpp
+++ b/blas/src/KokkosBlas1_scal.hpp
@@ -29,14 +29,22 @@
 
 namespace KokkosBlas {
 
-template <class RMV, class AV, class XMV>
-void scal(const RMV& R, const AV& a, const XMV& X) {
+template <class execution_space, class RMV, class AV, class XMV>
+void scal(const execution_space& space, const RMV& R, const AV& a, const XMV& X) {
+  static_assert(Kokkos::is_execution_space_v<execution_space>,
+		"KokkosBlas::scal: execution_space must be a valid Kokkos execution space");
   static_assert(Kokkos::is_view<RMV>::value,
                 "KokkosBlas::scal: "
                 "R is not a Kokkos::View.");
+  static_assert(Kokkos::SpaceAccessibility<execution_space, typename RMV::memory_space>::accessible,
+		"KokkosBlas::scal: RMV must be accessible from execution_space.");
   static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::scal: "
                 "X is not a Kokkos::View.");
+  static_assert(Kokkos::SpaceAccessibility<execution_space, typename XMV::memory_space>::accessible,
+		"KokkosBlas::scal: XMV must be accessible from execution_space");
+  static_assert(Kokkos::SpaceAccessibility<typename RMV::memory_space, typename XMV::memory_space>::assignable,
+		"KokkosBlas::scal: XMV must be assignable to RMV");
   static_assert(std::is_same<typename RMV::value_type,
                              typename RMV::non_const_value_type>::value,
                 "KokkosBlas::scal: R is const.  "
@@ -67,23 +75,26 @@ void scal(const RMV& R, const AV& a, const XMV& X) {
   // Create unmanaged versions of the input Views.  RMV and XMV may be
   // rank 1 or rank 2.  AV may be either a rank-1 View, or a scalar
   // value.
-  typedef Kokkos::View<typename RMV::non_const_data_type, UnifiedRLayout,
+  using RMV_Internal = Kokkos::View<typename RMV::non_const_data_type, UnifiedRLayout,
                        typename RMV::device_type,
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >
-      RMV_Internal;
-  typedef Kokkos::View<typename XMV::const_data_type, UnifiedXLayout,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+  using XMV_Internal = Kokkos::View<typename XMV::const_data_type, UnifiedXLayout,
                        typename XMV::device_type,
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >
-      XMV_Internal;
-  typedef typename KokkosKernels::Impl::GetUnifiedScalarViewType<
-      AV, XMV_Internal, true>::type AV_Internal;
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+  using AV_Internal = typename KokkosKernels::Impl::GetUnifiedScalarViewType<
+      AV, XMV_Internal, true>::type;
 
   RMV_Internal R_internal = R;
   AV_Internal a_internal  = a;
   XMV_Internal X_internal = X;
 
-  Impl::Scal<RMV_Internal, AV_Internal, XMV_Internal>::scal(
-      R_internal, a_internal, X_internal);
+  Impl::Scal<execution_space, RMV_Internal, AV_Internal, XMV_Internal>::scal(
+									     space, R_internal, a_internal, X_internal);
+}
+
+template <class RMV, class AV, class XMV>
+void scal(const RMV& R, const AV& a, const XMV& X) {
+  scal(typename RMV::execution_space{}, R, a, X);
 }
 
 ///

--- a/blas/src/KokkosBlas1_update.hpp
+++ b/blas/src/KokkosBlas1_update.hpp
@@ -25,6 +25,7 @@ namespace KokkosBlas {
 
 /// \brief Compute Z := alpha*X + beta*Y + gamma*Z.
 ///
+/// \tparam execution_space a Kokkos execution space where the kernel will run.
 /// \tparam XMV 1-D or 2-D Kokkos::View specialization.
 /// \tparam YMV 1-D or 2-D Kokkos::View specialization.  It must have
 ///   the same rank as XMV.
@@ -32,10 +33,13 @@ namespace KokkosBlas {
 ///   the same rank as XMV and YMV, and it must make sense to add up
 ///   the entries of XMV and YMV and assign them to the entries of
 ///   ZMV.
-template <class XMV, class YMV, class ZMV>
-void update(const typename XMV::non_const_value_type& alpha, const XMV& X,
+template <class execution_space, class XMV, class YMV, class ZMV>
+void update(const execution_space& space,
+	    const typename XMV::non_const_value_type& alpha, const XMV& X,
             const typename YMV::non_const_value_type& beta, const YMV& Y,
             const typename ZMV::non_const_value_type& gamma, const ZMV& Z) {
+  static_assert(Kokkos::is_execution_space_v<execution_space>,
+		"KokkosBlas::update: execution_space must be a valid Kokkos execution space.");
   static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::update: "
                 "X is not a Kokkos::View.");
@@ -45,6 +49,12 @@ void update(const typename XMV::non_const_value_type& alpha, const XMV& X,
   static_assert(Kokkos::is_view<ZMV>::value,
                 "KokkosBlas::update: "
                 "Z is not a Kokkos::View.");
+  static_assert(Kokkos::SpaceAccessibility<execution_space, typename XMV::memory_space>::accessible,
+		"KokkosBlas::update: XMV must be accessible from execution_space.");
+  static_assert(Kokkos::SpaceAccessibility<execution_space, typename YMV::memory_space>::accessible,
+		"KokkosBlas::update: YMV must be accessible from execution_space.");
+  static_assert(Kokkos::SpaceAccessibility<execution_space, typename ZMV::memory_space>::accessible,
+		"KokkosBlas::update: ZMV must be accessible from execution_space.");
   static_assert(std::is_same<typename ZMV::value_type,
                              typename ZMV::non_const_value_type>::value,
                 "KokkosBlas::update: Z is const.  "
@@ -74,27 +84,24 @@ void update(const typename XMV::non_const_value_type& alpha, const XMV& X,
   // Create unmanaged versions of the input Views.  XMV, YMV, and ZMV
   // may be rank 1 or rank 2, but they must all have the same rank.
 
-  typedef Kokkos::View<
+  using XMV_Internal = Kokkos::View<
       typename std::conditional<XMV::rank == 1, typename XMV::const_value_type*,
                                 typename XMV::const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout,
-      typename XMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
-      XMV_Internal;
+      typename XMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
 
-  typedef Kokkos::View<
+  using YMV_Internal = Kokkos::View<
       typename std::conditional<YMV::rank == 1, typename YMV::const_value_type*,
                                 typename YMV::const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<YMV>::array_layout,
-      typename YMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
-      YMV_Internal;
+      typename YMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
 
-  typedef Kokkos::View<
+  using ZMV_Internal = Kokkos::View<
       typename std::conditional<ZMV::rank == 1,
                                 typename ZMV::non_const_value_type*,
                                 typename ZMV::non_const_value_type**>::type,
       typename KokkosKernels::Impl::GetUnifiedLayout<ZMV>::array_layout,
-      typename ZMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
-      ZMV_Internal;
+      typename ZMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
 
   XMV_Internal X_internal = X;
   YMV_Internal Y_internal = Y;
@@ -110,10 +117,25 @@ void update(const typename XMV::non_const_value_type& alpha, const XMV& X,
        << endl;
 #endif  // KOKKOSKERNELS_PRINT_DEMANGLED_TYPE_INFO
 
-  return Impl::Update<XMV_Internal, YMV_Internal, ZMV_Internal>::update(
-      alpha, X_internal, beta, Y_internal, gamma, Z_internal);
+  Impl::Update<execution_space, XMV_Internal, YMV_Internal, ZMV_Internal>::update(
+										  space, alpha, X_internal, beta, Y_internal, gamma, Z_internal);
 }
 
+/// \brief Compute Z := alpha*X + beta*Y + gamma*Z.
+///
+/// \tparam XMV 1-D or 2-D Kokkos::View specialization.
+/// \tparam YMV 1-D or 2-D Kokkos::View specialization.  It must have
+///   the same rank as XMV.
+/// \tparam ZMV 1-D or 2-D Kokkos::View specialization.  It must have
+///   the same rank as XMV and YMV, and it must make sense to add up
+///   the entries of XMV and YMV and assign them to the entries of
+///   ZMV.
+template <class XMV, class YMV, class ZMV>
+void update(const typename XMV::non_const_value_type& alpha, const XMV& X,
+            const typename YMV::non_const_value_type& beta, const YMV& Y,
+            const typename ZMV::non_const_value_type& gamma, const ZMV& Z) {
+  update(typename ZMV::execution_space{}, alpha, X, beta, Y, gamma, Z);
+}
 }  // namespace KokkosBlas
 
 #endif  // KOKKOSBLAS1_UPDATE_HPP_

--- a/blas/src/KokkosBlas1_update.hpp
+++ b/blas/src/KokkosBlas1_update.hpp
@@ -35,11 +35,12 @@ namespace KokkosBlas {
 ///   ZMV.
 template <class execution_space, class XMV, class YMV, class ZMV>
 void update(const execution_space& space,
-	    const typename XMV::non_const_value_type& alpha, const XMV& X,
+            const typename XMV::non_const_value_type& alpha, const XMV& X,
             const typename YMV::non_const_value_type& beta, const YMV& Y,
             const typename ZMV::non_const_value_type& gamma, const ZMV& Z) {
   static_assert(Kokkos::is_execution_space_v<execution_space>,
-		"KokkosBlas::update: execution_space must be a valid Kokkos execution space.");
+                "KokkosBlas::update: execution_space must be a valid Kokkos "
+                "execution space.");
   static_assert(Kokkos::is_view<XMV>::value,
                 "KokkosBlas::update: "
                 "X is not a Kokkos::View.");
@@ -49,12 +50,18 @@ void update(const execution_space& space,
   static_assert(Kokkos::is_view<ZMV>::value,
                 "KokkosBlas::update: "
                 "Z is not a Kokkos::View.");
-  static_assert(Kokkos::SpaceAccessibility<execution_space, typename XMV::memory_space>::accessible,
-		"KokkosBlas::update: XMV must be accessible from execution_space.");
-  static_assert(Kokkos::SpaceAccessibility<execution_space, typename YMV::memory_space>::accessible,
-		"KokkosBlas::update: YMV must be accessible from execution_space.");
-  static_assert(Kokkos::SpaceAccessibility<execution_space, typename ZMV::memory_space>::accessible,
-		"KokkosBlas::update: ZMV must be accessible from execution_space.");
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename XMV::memory_space>::accessible,
+      "KokkosBlas::update: XMV must be accessible from execution_space.");
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename YMV::memory_space>::accessible,
+      "KokkosBlas::update: YMV must be accessible from execution_space.");
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename ZMV::memory_space>::accessible,
+      "KokkosBlas::update: ZMV must be accessible from execution_space.");
   static_assert(std::is_same<typename ZMV::value_type,
                              typename ZMV::non_const_value_type>::value,
                 "KokkosBlas::update: Z is const.  "
@@ -117,8 +124,9 @@ void update(const execution_space& space,
        << endl;
 #endif  // KOKKOSKERNELS_PRINT_DEMANGLED_TYPE_INFO
 
-  Impl::Update<execution_space, XMV_Internal, YMV_Internal, ZMV_Internal>::update(
-										  space, alpha, X_internal, beta, Y_internal, gamma, Z_internal);
+  Impl::Update<execution_space, XMV_Internal, YMV_Internal,
+               ZMV_Internal>::update(space, alpha, X_internal, beta, Y_internal,
+                                     gamma, Z_internal);
 }
 
 /// \brief Compute Z := alpha*X + beta*Y + gamma*Z.

--- a/blas/tpls/KokkosBlas1_abs_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_abs_tpl_spec_avail.hpp
@@ -20,7 +20,7 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class RMV, class XMV, int rank = RMV::rank>
+template <class execution_space, class RMV, class XMV, int rank = RMV::rank>
 struct abs_tpl_spec_avail {
   enum : bool { value = false };
 };

--- a/blas/tpls/KokkosBlas1_axpby_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_axpby_tpl_spec_avail.hpp
@@ -20,7 +20,7 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class AV, class XMV, class BV, class YMV, int rank = YMV::rank>
+template <class execution_space, class AV, class XMV, class BV, class YMV, int rank = YMV::rank>
 struct axpby_tpl_spec_avail {
   enum : bool { value = false };
 };
@@ -36,6 +36,7 @@ namespace Impl {
 #define KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(SCALAR, LAYOUT, MEMSPACE)        \
   template <class ExecSpace>                                                   \
   struct axpby_tpl_spec_avail<                                                 \
+      ExecSpace,                                                               \
       SCALAR,                                                                  \
       Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
@@ -63,6 +64,7 @@ KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::complex<float>,
 #define KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(SCALAR, LAYOUT, MEMSPACE)      \
   template <class ExecSpace>                                                   \
   struct axpby_tpl_spec_avail<                                                 \
+      ExecSpace,                                                               \
       SCALAR,                                                                  \
       Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \

--- a/blas/tpls/KokkosBlas1_axpby_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_axpby_tpl_spec_avail.hpp
@@ -20,7 +20,8 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class execution_space, class AV, class XMV, class BV, class YMV, int rank = YMV::rank>
+template <class execution_space, class AV, class XMV, class BV, class YMV,
+          int rank = YMV::rank>
 struct axpby_tpl_spec_avail {
   enum : bool { value = false };
 };
@@ -36,8 +37,7 @@ namespace Impl {
 #define KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(SCALAR, LAYOUT, MEMSPACE)        \
   template <class ExecSpace>                                                   \
   struct axpby_tpl_spec_avail<                                                 \
-      ExecSpace,                                                               \
-      SCALAR,                                                                  \
+      ExecSpace, SCALAR,                                                       \
       Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       SCALAR,                                                                  \
@@ -64,8 +64,7 @@ KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::complex<float>,
 #define KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(SCALAR, LAYOUT, MEMSPACE)      \
   template <class ExecSpace>                                                   \
   struct axpby_tpl_spec_avail<                                                 \
-      ExecSpace,                                                               \
-      SCALAR,                                                                  \
+      ExecSpace, SCALAR,                                                       \
       Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       SCALAR,                                                                  \

--- a/blas/tpls/KokkosBlas1_axpby_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_axpby_tpl_spec_decl.hpp
@@ -224,9 +224,8 @@ namespace Impl {
 
 #define KOKKOSBLAS1_DAXPBY_CUBLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)            \
   template <class ExecSpace>                                                   \
-  struct Axpby<								\
-  ExecSpace,								\
-      double,                                                                  \
+  struct Axpby<                                                                \
+      ExecSpace, double,                                                       \
       Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       double,                                                                  \
@@ -244,8 +243,8 @@ namespace Impl {
         YV;                                                                    \
     typedef typename XV::size_type size_type;                                  \
                                                                                \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, \
-                      const YV& Y) {                                           \
+    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X,    \
+                      const BV& beta, const YV& Y) {                           \
       Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,double]");   \
       const size_type numElems = X.extent(0);                                  \
       if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0)) {     \
@@ -254,23 +253,22 @@ namespace Impl {
         constexpr int one = 1;                                                 \
         KokkosBlas::Impl::CudaBlasSingleton& s =                               \
             KokkosBlas::Impl::CudaBlasSingleton::singleton();                  \
-      KOKKOS_CUBLAS_SAFE_CALL_IMPL(                                            \
-          cublasSetStream(s.handle, space.cuda_stream()));                     \
-      KOKKOS_CUBLAS_SAFE_CALL_IMPL(cublasDaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one)); \
-      KOKKOS_CUBLAS_SAFE_CALL_IMPL(                                            \
-          cublasSetStream(s.handle, NULL));                     \
+        KOKKOS_CUBLAS_SAFE_CALL_IMPL(                                          \
+            cublasSetStream(s.handle, space.cuda_stream()));                   \
+        KOKKOS_CUBLAS_SAFE_CALL_IMPL(                                          \
+            cublasDaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one));   \
+        KOKKOS_CUBLAS_SAFE_CALL_IMPL(cublasSetStream(s.handle, NULL));         \
       } else                                                                   \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby( \
-										 space, alpha, X, beta, Y); \
+        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false,                      \
+              ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);                \
       Kokkos::Profiling::popRegion();                                          \
     }                                                                          \
   };
 
 #define KOKKOSBLAS1_SAXPBY_CUBLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)           \
   template <class ExecSpace>                                                  \
-  struct Axpby<								\
-  ExecSpace,								\
-      float,                                                                  \
+  struct Axpby<                                                               \
+      ExecSpace, float,                                                       \
       Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                 \
       float,                                                                  \
@@ -288,8 +286,8 @@ namespace Impl {
         YV;                                                                   \
     typedef typename XV::size_type size_type;                                 \
                                                                               \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, \
-                      const YV& Y) {                                          \
+    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X,   \
+                      const BV& beta, const YV& Y) {                          \
       Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,float]");   \
       const size_type numElems = X.extent(0);                                 \
       if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {   \
@@ -298,115 +296,112 @@ namespace Impl {
         constexpr int one = 1;                                                \
         KokkosBlas::Impl::CudaBlasSingleton& s =                              \
             KokkosBlas::Impl::CudaBlasSingleton::singleton();                 \
-      KOKKOS_CUBLAS_SAFE_CALL_IMPL(                                            \
-          cublasSetStream(s.handle, space.cuda_stream()));                     \
-      KOKKOS_CUBLAS_SAFE_CALL_IMPL(cublasSaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one)); \
-      KOKKOS_CUBLAS_SAFE_CALL_IMPL(                                            \
-          cublasSetStream(s.handle, NULL));                     \
+        KOKKOS_CUBLAS_SAFE_CALL_IMPL(                                         \
+            cublasSetStream(s.handle, space.cuda_stream()));                  \
+        KOKKOS_CUBLAS_SAFE_CALL_IMPL(                                         \
+            cublasSaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one));  \
+        KOKKOS_CUBLAS_SAFE_CALL_IMPL(cublasSetStream(s.handle, NULL));        \
       } else                                                                  \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby( \
-										 space, alpha, X, beta, Y); \
+        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false,                     \
+              ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);               \
       Kokkos::Profiling::popRegion();                                         \
     }                                                                         \
   };
 
-#define KOKKOSBLAS1_ZAXPBY_CUBLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)          \
-  template <class ExecSpace>                                                 \
-  struct Axpby<ExecSpace,						\
-	       Kokkos::complex<double>,					\
-               Kokkos::View<const Kokkos::complex<double>*, LAYOUT,          \
-                            Kokkos::Device<ExecSpace, MEMSPACE>,             \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,       \
-               Kokkos::complex<double>,                                      \
-               Kokkos::View<Kokkos::complex<double>*, LAYOUT,                \
-                            Kokkos::Device<ExecSpace, MEMSPACE>,             \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,       \
-               1, true, ETI_SPEC_AVAIL> {                                    \
-    typedef Kokkos::complex<double> AV;                                      \
-    typedef Kokkos::complex<double> BV;                                      \
-    typedef Kokkos::View<const Kokkos::complex<double>*, LAYOUT,             \
-                         Kokkos::Device<ExecSpace, MEMSPACE>,                \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >           \
-        XV;                                                                  \
-    typedef Kokkos::View<Kokkos::complex<double>*, LAYOUT,                   \
-                         Kokkos::Device<ExecSpace, MEMSPACE>,                \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >           \
-        YV;                                                                  \
-    typedef typename XV::size_type size_type;                                \
-                                                                             \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, \
-                      const YV& Y) {                                         \
-      Kokkos::Profiling::pushRegion(                                         \
-          "KokkosBlas::axpby[TPL_CUBLAS,complex<double>]");                  \
-      const size_type numElems = X.extent(0);                                \
-      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {  \
-        axpby_print_specialization<AV, XV, BV, YV>();                        \
-        const int N       = static_cast<int>(numElems);                      \
-        constexpr int one = 1;                                               \
-        KokkosBlas::Impl::CudaBlasSingleton& s =                             \
-            KokkosBlas::Impl::CudaBlasSingleton::singleton();                \
-      KOKKOS_CUBLAS_SAFE_CALL_IMPL(                                            \
-          cublasSetStream(s.handle, space.cuda_stream()));                     \
-        KOKKOS_CUBLAS_SAFE_CALL_IMPL(cublasZaxpy(s.handle, N,                                             \
-						 reinterpret_cast<const cuDoubleComplex*>(&alpha), \
-						 reinterpret_cast<const cuDoubleComplex*>(X.data()), one, \
-						 reinterpret_cast<cuDoubleComplex*>(Y.data()), one)); \
-      KOKKOS_CUBLAS_SAFE_CALL_IMPL(                                            \
-          cublasSetStream(s.handle, NULL));                     \
-      } else                                                                 \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby( \
-										 space, alpha, X, beta, Y); \
-      Kokkos::Profiling::popRegion();                                        \
-    }                                                                        \
+#define KOKKOSBLAS1_ZAXPBY_CUBLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)         \
+  template <class ExecSpace>                                                \
+  struct Axpby<ExecSpace, Kokkos::complex<double>,                          \
+               Kokkos::View<const Kokkos::complex<double>*, LAYOUT,         \
+                            Kokkos::Device<ExecSpace, MEMSPACE>,            \
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
+               Kokkos::complex<double>,                                     \
+               Kokkos::View<Kokkos::complex<double>*, LAYOUT,               \
+                            Kokkos::Device<ExecSpace, MEMSPACE>,            \
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
+               1, true, ETI_SPEC_AVAIL> {                                   \
+    typedef Kokkos::complex<double> AV;                                     \
+    typedef Kokkos::complex<double> BV;                                     \
+    typedef Kokkos::View<const Kokkos::complex<double>*, LAYOUT,            \
+                         Kokkos::Device<ExecSpace, MEMSPACE>,               \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >          \
+        XV;                                                                 \
+    typedef Kokkos::View<Kokkos::complex<double>*, LAYOUT,                  \
+                         Kokkos::Device<ExecSpace, MEMSPACE>,               \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >          \
+        YV;                                                                 \
+    typedef typename XV::size_type size_type;                               \
+                                                                            \
+    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, \
+                      const BV& beta, const YV& Y) {                        \
+      Kokkos::Profiling::pushRegion(                                        \
+          "KokkosBlas::axpby[TPL_CUBLAS,complex<double>]");                 \
+      const size_type numElems = X.extent(0);                               \
+      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) { \
+        axpby_print_specialization<AV, XV, BV, YV>();                       \
+        const int N       = static_cast<int>(numElems);                     \
+        constexpr int one = 1;                                              \
+        KokkosBlas::Impl::CudaBlasSingleton& s =                            \
+            KokkosBlas::Impl::CudaBlasSingleton::singleton();               \
+        KOKKOS_CUBLAS_SAFE_CALL_IMPL(                                       \
+            cublasSetStream(s.handle, space.cuda_stream()));                \
+        KOKKOS_CUBLAS_SAFE_CALL_IMPL(cublasZaxpy(                           \
+            s.handle, N, reinterpret_cast<const cuDoubleComplex*>(&alpha),  \
+            reinterpret_cast<const cuDoubleComplex*>(X.data()), one,        \
+            reinterpret_cast<cuDoubleComplex*>(Y.data()), one));            \
+        KOKKOS_CUBLAS_SAFE_CALL_IMPL(cublasSetStream(s.handle, NULL));      \
+      } else                                                                \
+        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false,                   \
+              ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);             \
+      Kokkos::Profiling::popRegion();                                       \
+    }                                                                       \
   };
 
-#define KOKKOSBLAS1_CAXPBY_CUBLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)          \
-  template <class ExecSpace>                                                 \
-  struct Axpby<ExecSpace,						     \
-               Kokkos::complex<float>,					     \
-               Kokkos::View<const Kokkos::complex<float>*, LAYOUT,           \
-                            Kokkos::Device<ExecSpace, MEMSPACE>,             \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,       \
-               Kokkos::complex<float>,                                       \
-               Kokkos::View<Kokkos::complex<float>*, LAYOUT,                 \
-                            Kokkos::Device<ExecSpace, MEMSPACE>,             \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,       \
-               1, true, ETI_SPEC_AVAIL> {                                    \
-    typedef Kokkos::complex<float> AV;                                       \
-    typedef Kokkos::complex<float> BV;                                       \
-    typedef Kokkos::View<const Kokkos::complex<float>*, LAYOUT,              \
-                         Kokkos::Device<ExecSpace, MEMSPACE>,                \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >           \
-        XV;                                                                  \
-    typedef Kokkos::View<Kokkos::complex<float>*, LAYOUT,                    \
-                         Kokkos::Device<ExecSpace, MEMSPACE>,                \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >           \
-        YV;                                                                  \
-    typedef typename XV::size_type size_type;                                \
-                                                                             \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, \
-                      const YV& Y) {                                         \
-      Kokkos::Profiling::pushRegion(                                         \
-          "KokkosBlas::axpby[TPL_CUBLAS,complex<float>]");                   \
-      const size_type numElems = X.extent(0);                                \
-      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {  \
-        axpby_print_specialization<AV, XV, BV, YV>();                        \
-        const int N       = static_cast<int>(numElems);                      \
-        constexpr int one = 1;                                               \
-        KokkosBlas::Impl::CudaBlasSingleton& s =                             \
-            KokkosBlas::Impl::CudaBlasSingleton::singleton();                \
-      KOKKOS_CUBLAS_SAFE_CALL_IMPL(                                            \
-          cublasSetStream(s.handle, space.cuda_stream()));                     \
-        KOKKOS_CUBLAS_SAFE_CALL_IMPL(cublasCaxpy(s.handle, N, reinterpret_cast<const cuComplex*>(&alpha), \
-						 reinterpret_cast<const cuComplex*>(X.data()), one, \
-						 reinterpret_cast<cuComplex*>(Y.data()), one));	\
-      KOKKOS_CUBLAS_SAFE_CALL_IMPL(                                            \
-          cublasSetStream(s.handle, NULL));                     \
-      } else                                                                 \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby( \
-										 space, alpha, X, beta, Y); \
-      Kokkos::Profiling::popRegion();                                        \
-    }                                                                        \
+#define KOKKOSBLAS1_CAXPBY_CUBLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)         \
+  template <class ExecSpace>                                                \
+  struct Axpby<ExecSpace, Kokkos::complex<float>,                           \
+               Kokkos::View<const Kokkos::complex<float>*, LAYOUT,          \
+                            Kokkos::Device<ExecSpace, MEMSPACE>,            \
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
+               Kokkos::complex<float>,                                      \
+               Kokkos::View<Kokkos::complex<float>*, LAYOUT,                \
+                            Kokkos::Device<ExecSpace, MEMSPACE>,            \
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
+               1, true, ETI_SPEC_AVAIL> {                                   \
+    typedef Kokkos::complex<float> AV;                                      \
+    typedef Kokkos::complex<float> BV;                                      \
+    typedef Kokkos::View<const Kokkos::complex<float>*, LAYOUT,             \
+                         Kokkos::Device<ExecSpace, MEMSPACE>,               \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >          \
+        XV;                                                                 \
+    typedef Kokkos::View<Kokkos::complex<float>*, LAYOUT,                   \
+                         Kokkos::Device<ExecSpace, MEMSPACE>,               \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >          \
+        YV;                                                                 \
+    typedef typename XV::size_type size_type;                               \
+                                                                            \
+    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, \
+                      const BV& beta, const YV& Y) {                        \
+      Kokkos::Profiling::pushRegion(                                        \
+          "KokkosBlas::axpby[TPL_CUBLAS,complex<float>]");                  \
+      const size_type numElems = X.extent(0);                               \
+      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) { \
+        axpby_print_specialization<AV, XV, BV, YV>();                       \
+        const int N       = static_cast<int>(numElems);                     \
+        constexpr int one = 1;                                              \
+        KokkosBlas::Impl::CudaBlasSingleton& s =                            \
+            KokkosBlas::Impl::CudaBlasSingleton::singleton();               \
+        KOKKOS_CUBLAS_SAFE_CALL_IMPL(                                       \
+            cublasSetStream(s.handle, space.cuda_stream()));                \
+        KOKKOS_CUBLAS_SAFE_CALL_IMPL(cublasCaxpy(                           \
+            s.handle, N, reinterpret_cast<const cuComplex*>(&alpha),        \
+            reinterpret_cast<const cuComplex*>(X.data()), one,              \
+            reinterpret_cast<cuComplex*>(Y.data()), one));                  \
+        KOKKOS_CUBLAS_SAFE_CALL_IMPL(cublasSetStream(s.handle, NULL));      \
+      } else                                                                \
+        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false,                   \
+              ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);             \
+      Kokkos::Profiling::popRegion();                                       \
+    }                                                                       \
   };
 
 KOKKOSBLAS1_DAXPBY_CUBLAS(Kokkos::LayoutLeft, Kokkos::CudaSpace, true)

--- a/blas/tpls/KokkosBlas1_axpby_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_axpby_tpl_spec_decl.hpp
@@ -43,8 +43,7 @@ namespace Impl {
 #define KOKKOSBLAS1_DAXPBY_BLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)              \
   template <class ExecSpace>                                                   \
   struct Axpby<                                                                \
-      ExecSpace,                                                               \
-      double,                                                                  \
+      ExecSpace, double,                                                       \
       Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       double,                                                                  \
@@ -61,8 +60,8 @@ namespace Impl {
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         YV;                                                                    \
                                                                                \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, \
-                      const YV& Y) {                                           \
+    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X,    \
+                      const BV& beta, const YV& Y) {                           \
       Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,double]");     \
       if ((X.extent(0) < INT_MAX) && (beta == 1.0)) {                          \
         axpby_print_specialization<AV, XV, BV, YV>();                          \
@@ -70,8 +69,8 @@ namespace Impl {
         int one = 1;                                                           \
         HostBlas<double>::axpy(N, alpha, X.data(), one, Y.data(), one);        \
       } else                                                                   \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby( \
-	        space, alpha, X, beta, Y); \
+        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false,                      \
+              ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);                \
       Kokkos::Profiling::popRegion();                                          \
     }                                                                          \
   };
@@ -79,8 +78,7 @@ namespace Impl {
 #define KOKKOSBLAS1_SAXPBY_BLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)             \
   template <class ExecSpace>                                                  \
   struct Axpby<                                                               \
-      ExecSpace,                                                              \
-      float,                                                                  \
+      ExecSpace, float,                                                       \
       Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                 \
       float,                                                                  \
@@ -97,8 +95,8 @@ namespace Impl {
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >            \
         YV;                                                                   \
                                                                               \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta,           \
-                      const YV& Y) {                                          \
+    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X,   \
+                      const BV& beta, const YV& Y) {                          \
       Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,float]");     \
       if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {                        \
         axpby_print_specialization<AV, XV, BV, YV>();                         \
@@ -106,98 +104,94 @@ namespace Impl {
         int one = 1;                                                          \
         HostBlas<float>::axpy(N, alpha, X.data(), one, Y.data(), one);        \
       } else                                                                  \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby( \
-										 space, alpha, X, beta, Y); \
+        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false,                     \
+              ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);               \
       Kokkos::Profiling::popRegion();                                         \
     }                                                                         \
   };
 
-#define KOKKOSBLAS1_ZAXPBY_BLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)         \
-  template <class ExecSpace>                                              \
-  struct Axpby<								  \
-               ExecSpace,                                                 \
-               Kokkos::complex<double>,                                   \
-               Kokkos::View<const Kokkos::complex<double>*, LAYOUT,       \
-                            Kokkos::Device<ExecSpace, MEMSPACE>,          \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,    \
-               Kokkos::complex<double>,                                   \
-               Kokkos::View<Kokkos::complex<double>*, LAYOUT,             \
-                            Kokkos::Device<ExecSpace, MEMSPACE>,          \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,    \
-               1, true, ETI_SPEC_AVAIL> {                                 \
-    typedef Kokkos::complex<double> AV;                                   \
-    typedef Kokkos::complex<double> BV;                                   \
-    typedef Kokkos::View<const Kokkos::complex<double>*, LAYOUT,          \
-                         Kokkos::Device<ExecSpace, MEMSPACE>,             \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >        \
-        XV;                                                               \
-    typedef Kokkos::View<Kokkos::complex<double>*, LAYOUT,                \
-                         Kokkos::Device<ExecSpace, MEMSPACE>,             \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >        \
-        YV;                                                               \
-                                                                          \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta,       \
-                      const YV& Y) {                                      \
-      Kokkos::Profiling::pushRegion(                                      \
-          "KokkosBlas::axpby[TPL_BLAS,complex<double>]");                 \
-      if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {                    \
-        axpby_print_specialization<AV, XV, BV, YV>();                     \
-        int N                                = X.extent(0);               \
-        int one                              = 1;                         \
-        const std::complex<double> alpha_val = alpha;                     \
-        HostBlas<std::complex<double> >::axpy(                            \
-            N, alpha_val,                                                 \
-            reinterpret_cast<const std::complex<double>*>(X.data()), one, \
-            reinterpret_cast<std::complex<double>*>(Y.data()), one);      \
-      } else                                                              \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby( \
-										 space, alpha, X, beta, Y); \
-      Kokkos::Profiling::popRegion();                                     \
-    }                                                                     \
+#define KOKKOSBLAS1_ZAXPBY_BLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)           \
+  template <class ExecSpace>                                                \
+  struct Axpby<ExecSpace, Kokkos::complex<double>,                          \
+               Kokkos::View<const Kokkos::complex<double>*, LAYOUT,         \
+                            Kokkos::Device<ExecSpace, MEMSPACE>,            \
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
+               Kokkos::complex<double>,                                     \
+               Kokkos::View<Kokkos::complex<double>*, LAYOUT,               \
+                            Kokkos::Device<ExecSpace, MEMSPACE>,            \
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
+               1, true, ETI_SPEC_AVAIL> {                                   \
+    typedef Kokkos::complex<double> AV;                                     \
+    typedef Kokkos::complex<double> BV;                                     \
+    typedef Kokkos::View<const Kokkos::complex<double>*, LAYOUT,            \
+                         Kokkos::Device<ExecSpace, MEMSPACE>,               \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >          \
+        XV;                                                                 \
+    typedef Kokkos::View<Kokkos::complex<double>*, LAYOUT,                  \
+                         Kokkos::Device<ExecSpace, MEMSPACE>,               \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >          \
+        YV;                                                                 \
+                                                                            \
+    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, \
+                      const BV& beta, const YV& Y) {                        \
+      Kokkos::Profiling::pushRegion(                                        \
+          "KokkosBlas::axpby[TPL_BLAS,complex<double>]");                   \
+      if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {                      \
+        axpby_print_specialization<AV, XV, BV, YV>();                       \
+        int N                                = X.extent(0);                 \
+        int one                              = 1;                           \
+        const std::complex<double> alpha_val = alpha;                       \
+        HostBlas<std::complex<double> >::axpy(                              \
+            N, alpha_val,                                                   \
+            reinterpret_cast<const std::complex<double>*>(X.data()), one,   \
+            reinterpret_cast<std::complex<double>*>(Y.data()), one);        \
+      } else                                                                \
+        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false,                   \
+              ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);             \
+      Kokkos::Profiling::popRegion();                                       \
+    }                                                                       \
   };
 
-#define KOKKOSBLAS1_CAXPBY_BLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)        \
-  template <class ExecSpace>                                             \
-  struct Axpby<								 \
-               ExecSpace,                                                \
-               Kokkos::complex<float>,                                   \
-               Kokkos::View<const Kokkos::complex<float>*, LAYOUT,       \
-                            Kokkos::Device<ExecSpace, MEMSPACE>,         \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,   \
-               Kokkos::complex<float>,                                   \
-               Kokkos::View<Kokkos::complex<float>*, LAYOUT,             \
-                            Kokkos::Device<ExecSpace, MEMSPACE>,         \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,   \
-               1, true, ETI_SPEC_AVAIL> {                                \
-    typedef Kokkos::complex<float> AV;                                   \
-    typedef Kokkos::complex<float> BV;                                   \
-    typedef Kokkos::View<const Kokkos::complex<float>*, LAYOUT,          \
-                         Kokkos::Device<ExecSpace, MEMSPACE>,            \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >       \
-        XV;                                                              \
-    typedef Kokkos::View<Kokkos::complex<float>*, LAYOUT,                \
-                         Kokkos::Device<ExecSpace, MEMSPACE>,            \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >       \
-        YV;                                                              \
-                                                                         \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta,      \
-                      const YV& Y) {                                     \
-      Kokkos::Profiling::pushRegion(                                     \
-          "KokkosBlas::axpby[TPL_BLAS,complex<float>]");                 \
-      if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {                   \
-        axpby_print_specialization<AV, XV, BV, YV>();                    \
-        int N                               = X.extent(0);               \
-        int one                             = 1;                         \
-        const std::complex<float> alpha_val = alpha;                     \
-        HostBlas<std::complex<float> >::axpy(                            \
-            N, alpha_val,                                                \
-            reinterpret_cast<const std::complex<float>*>(X.data()), one, \
-            reinterpret_cast<std::complex<float>*>(Y.data()), one);      \
-      } else                                                             \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby( \
-										 space, alpha, X, beta, Y); \
-      Kokkos::Profiling::popRegion();                                    \
-    }                                                                    \
+#define KOKKOSBLAS1_CAXPBY_BLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)           \
+  template <class ExecSpace>                                                \
+  struct Axpby<ExecSpace, Kokkos::complex<float>,                           \
+               Kokkos::View<const Kokkos::complex<float>*, LAYOUT,          \
+                            Kokkos::Device<ExecSpace, MEMSPACE>,            \
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
+               Kokkos::complex<float>,                                      \
+               Kokkos::View<Kokkos::complex<float>*, LAYOUT,                \
+                            Kokkos::Device<ExecSpace, MEMSPACE>,            \
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
+               1, true, ETI_SPEC_AVAIL> {                                   \
+    typedef Kokkos::complex<float> AV;                                      \
+    typedef Kokkos::complex<float> BV;                                      \
+    typedef Kokkos::View<const Kokkos::complex<float>*, LAYOUT,             \
+                         Kokkos::Device<ExecSpace, MEMSPACE>,               \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >          \
+        XV;                                                                 \
+    typedef Kokkos::View<Kokkos::complex<float>*, LAYOUT,                   \
+                         Kokkos::Device<ExecSpace, MEMSPACE>,               \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >          \
+        YV;                                                                 \
+                                                                            \
+    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, \
+                      const BV& beta, const YV& Y) {                        \
+      Kokkos::Profiling::pushRegion(                                        \
+          "KokkosBlas::axpby[TPL_BLAS,complex<float>]");                    \
+      if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {                      \
+        axpby_print_specialization<AV, XV, BV, YV>();                       \
+        int N                               = X.extent(0);                  \
+        int one                             = 1;                            \
+        const std::complex<float> alpha_val = alpha;                        \
+        HostBlas<std::complex<float> >::axpy(                               \
+            N, alpha_val,                                                   \
+            reinterpret_cast<const std::complex<float>*>(X.data()), one,    \
+            reinterpret_cast<std::complex<float>*>(Y.data()), one);         \
+      } else                                                                \
+        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false,                   \
+              ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);             \
+      Kokkos::Profiling::popRegion();                                       \
+    }                                                                       \
   };
 
 KOKKOSBLAS1_DAXPBY_BLAS(Kokkos::LayoutLeft, Kokkos::HostSpace, true)

--- a/blas/tpls/KokkosBlas1_axpby_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_axpby_tpl_spec_decl.hpp
@@ -43,6 +43,7 @@ namespace Impl {
 #define KOKKOSBLAS1_DAXPBY_BLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)              \
   template <class ExecSpace>                                                   \
   struct Axpby<                                                                \
+      ExecSpace,                                                               \
       double,                                                                  \
       Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
@@ -60,7 +61,7 @@ namespace Impl {
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         YV;                                                                    \
                                                                                \
-    static void axpby(const AV& alpha, const XV& X, const BV& beta,            \
+    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, \
                       const YV& Y) {                                           \
       Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,double]");     \
       if ((X.extent(0) < INT_MAX) && (beta == 1.0)) {                          \
@@ -69,8 +70,8 @@ namespace Impl {
         int one = 1;                                                           \
         HostBlas<double>::axpy(N, alpha, X.data(), one, Y.data(), one);        \
       } else                                                                   \
-        Axpby<AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(         \
-            alpha, X, beta, Y);                                                \
+        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby( \
+	        space, alpha, X, beta, Y); \
       Kokkos::Profiling::popRegion();                                          \
     }                                                                          \
   };
@@ -78,6 +79,7 @@ namespace Impl {
 #define KOKKOSBLAS1_SAXPBY_BLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)             \
   template <class ExecSpace>                                                  \
   struct Axpby<                                                               \
+      ExecSpace,                                                              \
       float,                                                                  \
       Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                 \
@@ -95,7 +97,7 @@ namespace Impl {
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >            \
         YV;                                                                   \
                                                                               \
-    static void axpby(const AV& alpha, const XV& X, const BV& beta,           \
+    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta,           \
                       const YV& Y) {                                          \
       Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,float]");     \
       if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {                        \
@@ -104,15 +106,17 @@ namespace Impl {
         int one = 1;                                                          \
         HostBlas<float>::axpy(N, alpha, X.data(), one, Y.data(), one);        \
       } else                                                                  \
-        Axpby<AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(        \
-            alpha, X, beta, Y);                                               \
+        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby( \
+										 space, alpha, X, beta, Y); \
       Kokkos::Profiling::popRegion();                                         \
     }                                                                         \
   };
 
 #define KOKKOSBLAS1_ZAXPBY_BLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)         \
   template <class ExecSpace>                                              \
-  struct Axpby<Kokkos::complex<double>,                                   \
+  struct Axpby<								  \
+               ExecSpace,                                                 \
+               Kokkos::complex<double>,                                   \
                Kokkos::View<const Kokkos::complex<double>*, LAYOUT,       \
                             Kokkos::Device<ExecSpace, MEMSPACE>,          \
                             Kokkos::MemoryTraits<Kokkos::Unmanaged> >,    \
@@ -132,7 +136,7 @@ namespace Impl {
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >        \
         YV;                                                               \
                                                                           \
-    static void axpby(const AV& alpha, const XV& X, const BV& beta,       \
+    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta,       \
                       const YV& Y) {                                      \
       Kokkos::Profiling::pushRegion(                                      \
           "KokkosBlas::axpby[TPL_BLAS,complex<double>]");                 \
@@ -146,15 +150,17 @@ namespace Impl {
             reinterpret_cast<const std::complex<double>*>(X.data()), one, \
             reinterpret_cast<std::complex<double>*>(Y.data()), one);      \
       } else                                                              \
-        Axpby<AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(    \
-            alpha, X, beta, Y);                                           \
+        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby( \
+										 space, alpha, X, beta, Y); \
       Kokkos::Profiling::popRegion();                                     \
     }                                                                     \
   };
 
 #define KOKKOSBLAS1_CAXPBY_BLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)        \
   template <class ExecSpace>                                             \
-  struct Axpby<Kokkos::complex<float>,                                   \
+  struct Axpby<								 \
+               ExecSpace,                                                \
+               Kokkos::complex<float>,                                   \
                Kokkos::View<const Kokkos::complex<float>*, LAYOUT,       \
                             Kokkos::Device<ExecSpace, MEMSPACE>,         \
                             Kokkos::MemoryTraits<Kokkos::Unmanaged> >,   \
@@ -174,7 +180,7 @@ namespace Impl {
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >       \
         YV;                                                              \
                                                                          \
-    static void axpby(const AV& alpha, const XV& X, const BV& beta,      \
+    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta,      \
                       const YV& Y) {                                     \
       Kokkos::Profiling::pushRegion(                                     \
           "KokkosBlas::axpby[TPL_BLAS,complex<float>]");                 \
@@ -188,8 +194,8 @@ namespace Impl {
             reinterpret_cast<const std::complex<float>*>(X.data()), one, \
             reinterpret_cast<std::complex<float>*>(Y.data()), one);      \
       } else                                                             \
-        Axpby<AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(   \
-            alpha, X, beta, Y);                                          \
+        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby( \
+										 space, alpha, X, beta, Y); \
       Kokkos::Profiling::popRegion();                                    \
     }                                                                    \
   };

--- a/blas/tpls/KokkosBlas1_mult_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_mult_tpl_spec_avail.hpp
@@ -20,7 +20,7 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class YMV, class AV, class XMV, int rank = XMV::rank>
+template <class execution_space, class YMV, class AV, class XMV, int rank = XMV::rank>
 struct mult_tpl_spec_avail {
   enum : bool { value = false };
 };

--- a/blas/tpls/KokkosBlas1_mult_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_mult_tpl_spec_avail.hpp
@@ -20,7 +20,8 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class execution_space, class YMV, class AV, class XMV, int rank = XMV::rank>
+template <class execution_space, class YMV, class AV, class XMV,
+          int rank = XMV::rank>
 struct mult_tpl_spec_avail {
   enum : bool { value = false };
 };

--- a/blas/tpls/KokkosBlas1_reciprocal_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_reciprocal_tpl_spec_avail.hpp
@@ -20,7 +20,7 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class RMV, class XMV, int rank = RMV::rank>
+template <class execution_space, class RMV, class XMV, int rank = RMV::rank>
 struct reciprocal_tpl_spec_avail {
   enum : bool { value = false };
 };

--- a/blas/tpls/KokkosBlas1_scal_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_scal_tpl_spec_avail.hpp
@@ -20,7 +20,8 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class execution_space, class RV, class AV, class XV, int Xrank = XV::rank>
+template <class execution_space, class RV, class AV, class XV,
+          int Xrank = XV::rank>
 struct scal_tpl_spec_avail {
   enum : bool { value = false };
 };
@@ -59,9 +60,9 @@ KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_BLAS(Kokkos::complex<float>, Kokkos::LayoutLeft,
 // cuBLAS
 #if defined(KOKKOSKERNELS_ENABLE_TPL_CUBLAS)
 // double
-#define KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(SCALAR, LAYOUT, EXECSPACE, \
-					       MEMSPACE)		\
-  template <>                                                   \
+#define KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(SCALAR, LAYOUT, EXECSPACE,      \
+                                               MEMSPACE)                       \
+  template <>                                                                  \
   struct scal_tpl_spec_avail<                                                  \
       EXECSPACE,                                                               \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXECSPACE, MEMSPACE>,       \
@@ -73,32 +74,36 @@ KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_BLAS(Kokkos::complex<float>, Kokkos::LayoutLeft,
     enum : bool { value = true };                                              \
   };
 
-KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(double, Kokkos::LayoutLeft,
-                                       Kokkos::Cuda, Kokkos::CudaSpace)
-KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(float, Kokkos::LayoutLeft,
-                                       Kokkos::Cuda, Kokkos::CudaSpace)
+KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(double, Kokkos::LayoutLeft, Kokkos::Cuda,
+                                       Kokkos::CudaSpace)
+KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(float, Kokkos::LayoutLeft, Kokkos::Cuda,
+                                       Kokkos::CudaSpace)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<double>,
-                                       Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace)
+                                       Kokkos::LayoutLeft, Kokkos::Cuda,
+                                       Kokkos::CudaSpace)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<float>,
-                                       Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace)
+                                       Kokkos::LayoutLeft, Kokkos::Cuda,
+                                       Kokkos::CudaSpace)
 
-KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(double, Kokkos::LayoutLeft,
-                                       Kokkos::Cuda, Kokkos::CudaUVMSpace)
-KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(float, Kokkos::LayoutLeft,
-                                       Kokkos::Cuda, Kokkos::CudaUVMSpace)
+KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(double, Kokkos::LayoutLeft, Kokkos::Cuda,
+                                       Kokkos::CudaUVMSpace)
+KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(float, Kokkos::LayoutLeft, Kokkos::Cuda,
+                                       Kokkos::CudaUVMSpace)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<double>,
-                                       Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaUVMSpace)
+                                       Kokkos::LayoutLeft, Kokkos::Cuda,
+                                       Kokkos::CudaUVMSpace)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<float>,
-                                       Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaUVMSpace)
+                                       Kokkos::LayoutLeft, Kokkos::Cuda,
+                                       Kokkos::CudaUVMSpace)
 
 #endif
 
 // rocBLAS
 #if defined(KOKKOSKERNELS_ENABLE_TPL_ROCBLAS)
 
-#define KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_ROCBLAS(SCALAR, LAYOUT, EXECSPACE,\
-						MEMSPACE)		\
-  template <>                                                   \
+#define KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_ROCBLAS(SCALAR, LAYOUT, EXECSPACE,     \
+                                                MEMSPACE)                      \
+  template <>                                                                  \
   struct scal_tpl_spec_avail<                                                  \
       EXECSPACE,                                                               \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,       \
@@ -110,16 +115,16 @@ KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<float>,
     enum : bool { value = true };                                              \
   };
 
-KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_ROCBLAS(double, Kokkos::LayoutLeft,
-                                        Kokkos::HIP, Kokkos::HIPSpace)
-KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_ROCBLAS(float, Kokkos::LayoutLeft,
-                                        Kokkos::HIP, Kokkos::HIPSpace)
+KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_ROCBLAS(double, Kokkos::LayoutLeft, Kokkos::HIP,
+                                        Kokkos::HIPSpace)
+KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_ROCBLAS(float, Kokkos::LayoutLeft, Kokkos::HIP,
+                                        Kokkos::HIPSpace)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<double>,
-                                        Kokkos::LayoutLeft,
-                                        Kokkos::HIP, Kokkos::HIPSpace)
+                                        Kokkos::LayoutLeft, Kokkos::HIP,
+                                        Kokkos::HIPSpace)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<float>,
-                                        Kokkos::LayoutLeft,
-                                        Kokkos::HIP, Kokkos::HIPSpace)
+                                        Kokkos::LayoutLeft, Kokkos::HIP,
+                                        Kokkos::HIPSpace)
 
 #endif
 

--- a/blas/tpls/KokkosBlas1_scal_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_scal_tpl_spec_avail.hpp
@@ -20,7 +20,7 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class RV, class AV, class XV, int Xrank = XV::rank>
+template <class execution_space, class RV, class AV, class XV, int Xrank = XV::rank>
 struct scal_tpl_spec_avail {
   enum : bool { value = false };
 };
@@ -59,44 +59,48 @@ KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_BLAS(Kokkos::complex<float>, Kokkos::LayoutLeft,
 // cuBLAS
 #if defined(KOKKOSKERNELS_ENABLE_TPL_CUBLAS)
 // double
-#define KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(SCALAR, LAYOUT, MEMSPACE)       \
-  template <class ExecSpace>                                                   \
+#define KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(SCALAR, LAYOUT, EXECSPACE, \
+					       MEMSPACE)		\
+  template <>                                                   \
   struct scal_tpl_spec_avail<                                                  \
-      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,       \
+      EXECSPACE,                                                               \
+      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXECSPACE, MEMSPACE>,       \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       SCALAR,                                                                  \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
+      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXECSPACE, MEMSPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       1> {                                                                     \
     enum : bool { value = true };                                              \
   };
 
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(double, Kokkos::LayoutLeft,
-                                       Kokkos::CudaSpace)
+                                       Kokkos::Cuda, Kokkos::CudaSpace)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(float, Kokkos::LayoutLeft,
-                                       Kokkos::CudaSpace)
+                                       Kokkos::Cuda, Kokkos::CudaSpace)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<double>,
-                                       Kokkos::LayoutLeft, Kokkos::CudaSpace)
+                                       Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<float>,
-                                       Kokkos::LayoutLeft, Kokkos::CudaSpace)
+                                       Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace)
 
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(double, Kokkos::LayoutLeft,
-                                       Kokkos::CudaUVMSpace)
+                                       Kokkos::Cuda, Kokkos::CudaUVMSpace)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(float, Kokkos::LayoutLeft,
-                                       Kokkos::CudaUVMSpace)
+                                       Kokkos::Cuda, Kokkos::CudaUVMSpace)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<double>,
-                                       Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+                                       Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaUVMSpace)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<float>,
-                                       Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+                                       Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaUVMSpace)
 
 #endif
 
 // rocBLAS
 #if defined(KOKKOSKERNELS_ENABLE_TPL_ROCBLAS)
 
-#define KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_ROCBLAS(SCALAR, LAYOUT, MEMSPACE)      \
-  template <class ExecSpace>                                                   \
+#define KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_ROCBLAS(SCALAR, LAYOUT, EXECSPACE,\
+						MEMSPACE)		\
+  template <>                                                   \
   struct scal_tpl_spec_avail<                                                  \
+      EXECSPACE,                                                               \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,       \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       SCALAR,                                                                  \
@@ -107,15 +111,15 @@ KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<float>,
   };
 
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_ROCBLAS(double, Kokkos::LayoutLeft,
-                                        Kokkos::Experimental::HIPSpace)
+                                        Kokkos::HIP, Kokkos::HIPSpace)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_ROCBLAS(float, Kokkos::LayoutLeft,
-                                        Kokkos::Experimental::HIPSpace)
+                                        Kokkos::HIP, Kokkos::HIPSpace)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<double>,
                                         Kokkos::LayoutLeft,
-                                        Kokkos::Experimental::HIPSpace)
+                                        Kokkos::HIP, Kokkos::HIPSpace)
 KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<float>,
                                         Kokkos::LayoutLeft,
-                                        Kokkos::Experimental::HIPSpace)
+                                        Kokkos::HIP, Kokkos::HIPSpace)
 
 #endif
 

--- a/blas/tpls/KokkosBlas1_scal_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_scal_tpl_spec_avail.hpp
@@ -37,6 +37,7 @@ namespace Impl {
 #define KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_BLAS(SCALAR, LAYOUT, MEMSPACE)         \
   template <class ExecSpace>                                                   \
   struct scal_tpl_spec_avail<                                                  \
+      ExecSpace,                                                               \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,       \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       SCALAR,                                                                  \

--- a/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
@@ -61,7 +61,8 @@ namespace Impl {
         XV;                                                                    \
     typedef typename XV::size_type size_type;                                  \
                                                                                \
-    static void scal(const ExecSpace& space, const RV& R, const AS& alpha, const XV& X) { \
+    static void scal(const ExecSpace& space, const RV& R, const AS& alpha,     \
+                     const XV& X) {                                            \
       Kokkos::Profiling::pushRegion("KokkosBlas::scal[TPL_BLAS," #SCALAR_TYPE  \
                                     "]");                                      \
       const size_type numElems = X.extent(0);                                  \
@@ -74,7 +75,8 @@ namespace Impl {
         HostBlas<BASE_SCALAR_TYPE>::scal(                                      \
             N, alpha_b, reinterpret_cast<BASE_SCALAR_TYPE*>(R.data()), one);   \
       } else {                                                                 \
-        Scal<ExecSpace, RV, AS, XV, 1, false, ETI_SPEC_AVAIL>::scal(space, R, alpha, X); \
+        Scal<ExecSpace, RV, AS, XV, 1, false, ETI_SPEC_AVAIL>::scal(space, R,  \
+                                                                    alpha, X); \
       }                                                                        \
       Kokkos::Profiling::popRegion();                                          \
     }                                                                          \

--- a/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
@@ -248,10 +248,11 @@ namespace KokkosBlas {
 namespace Impl {
 
 #define KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(                               \
-    SCALAR_TYPE, ROCBLAS_SCALAR_TYPE, ROCBLAS_FN, LAYOUT, MEMSPACE,            \
+    SCALAR_TYPE, ROCBLAS_SCALAR_TYPE, ROCBLAS_FN, LAYOUT, EXECSPACE, MEMSPACE  \
     ETI_SPEC_AVAIL)                                                            \
-  template <class ExecSpace>                                                   \
+  template <>								\
   struct Scal<                                                                 \
+      EXECSPACE,                                                               \
       Kokkos::View<SCALAR_TYPE*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,  \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       SCALAR_TYPE,                                                             \
@@ -259,6 +260,7 @@ namespace Impl {
                    Kokkos::Device<ExecSpace, MEMSPACE>,                        \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       1, true, ETI_SPEC_AVAIL> {                                               \
+    using execution_space = EXECSPACE;                                         \
     typedef Kokkos::View<SCALAR_TYPE*, LAYOUT,                                 \
                          Kokkos::Device<ExecSpace, MEMSPACE>,                  \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
@@ -270,7 +272,8 @@ namespace Impl {
         XV;                                                                    \
     typedef typename XV::size_type size_type;                                  \
                                                                                \
-    static void scal(const RV& R, const AS& alpha, const XV& X) {              \
+    static void scal(const execution_space& space, const RV& R,                \
+		     const AS& alpha, const XV& X) {			       \
       Kokkos::Profiling::pushRegion(                                           \
           "KokkosBlas::scal[TPL_ROCBLAS," #SCALAR_TYPE "]");                   \
       const size_type numElems = X.extent(0);                                  \
@@ -281,9 +284,18 @@ namespace Impl {
         constexpr int one = 1;                                                 \
         KokkosBlas::Impl::RocBlasSingleton& s =                                \
             KokkosBlas::Impl::RocBlasSingleton::singleton();                   \
+      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                           \
+          rocblas_set_stream(s.handle, space.hip_stream()));                   \
+      rocblas_pointer_mode pointer_mode;                                       \
+      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                           \
+          rocblas_get_pointer_mode(s.handle, &pointer_mode));                  \
+      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                           \
+          rocblas_set_pointer_mode(s.handle, rocblas_pointer_mode_device));    \
         KOKKOS_ROCBLAS_SAFE_CALL_IMPL(ROCBLAS_FN(                              \
             s.handle, N, reinterpret_cast<const ROCBLAS_SCALAR_TYPE*>(&alpha), \
             reinterpret_cast<ROCBLAS_SCALAR_TYPE*>(R.data()), one));           \
+      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                           \
+          rocblas_set_pointer_mode(s.handle, pointer_mode));                   \
       } else {                                                                 \
         Scal<RV, AS, XV, 1, false, ETI_SPEC_AVAIL>::scal(R, alpha, X);         \
       }                                                                        \
@@ -291,47 +303,48 @@ namespace Impl {
     }                                                                          \
   };
 
-#define KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, MEMSPACE,        \
+#define KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE, \
+						MEMSPACE,	   \
                                                 ETI_SPEC_AVAIL)          \
   KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(double, double, rocblas_dscal, \
-                                          LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)
+                                          LAYOUT, EXECSPACE, MEMSPACE, ETI_SPEC_AVAIL)
 
-#define KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, MEMSPACE,              \
+#define KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE, MEMSPACE \
                                                 ETI_SPEC_AVAIL)                \
   KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(float, float, rocblas_sscal, LAYOUT, \
-                                          MEMSPACE, ETI_SPEC_AVAIL)
+                                          EXECSPACE, MEMSPACE, ETI_SPEC_AVAIL)
 
-#define KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, MEMSPACE,             \
+#define KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE, MEMSPACE \
                                                 ETI_SPEC_AVAIL)               \
   KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(                                    \
       Kokkos::complex<double>, rocblas_double_complex, rocblas_zscal, LAYOUT, \
-      MEMSPACE, ETI_SPEC_AVAIL)
+      EXECSPACE, MEMSPACE, ETI_SPEC_AVAIL)
 
-#define KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, MEMSPACE,           \
+#define KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE, MEMSPACE \
                                                 ETI_SPEC_AVAIL)             \
   KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(                                  \
       Kokkos::complex<float>, rocblas_float_complex, rocblas_cscal, LAYOUT, \
-      MEMSPACE, ETI_SPEC_AVAIL)
+      EXECSPACE, MEMSPACE, ETI_SPEC_AVAIL)
 
-KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft,
-                                        Kokkos::Experimental::HIPSpace, true)
-KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft,
-                                        Kokkos::Experimental::HIPSpace, false)
+KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIP,
+                                        Kokkos::HIPSpace, true)
+KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIP,
+                                        Kokkos::HIPSpace, false)
 
-KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft,
-                                        Kokkos::Experimental::HIPSpace, true)
-KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft,
-                                        Kokkos::Experimental::HIPSpace, false)
+KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIP,
+                                        Kokkos::HIPSpace, true)
+KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIP,
+                                        Kokkos::HIPSpace, false)
 
-KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft,
-                                        Kokkos::Experimental::HIPSpace, true)
-KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft,
-                                        Kokkos::Experimental::HIPSpace, false)
+KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIP,
+                                        Kokkos::HIPSpace, true)
+KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIP,
+                                        Kokkos::HIPSpace, false)
 
-KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft,
-                                        Kokkos::Experimental::HIPSpace, true)
-KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft,
-                                        Kokkos::Experimental::HIPSpace, false)
+KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIP,
+                                        Kokkos::HIPSpace, true)
+KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIP,
+                                        Kokkos::HIPSpace, false)
 
 }  // namespace Impl
 }  // namespace KokkosBlas

--- a/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
@@ -42,6 +42,7 @@ namespace Impl {
                                              LAYOUT, MEMSPACE, ETI_SPEC_AVAIL) \
   template <class ExecSpace>                                                   \
   struct Scal<                                                                 \
+      ExecSpace,                                                               \
       Kokkos::View<SCALAR_TYPE*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,  \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       SCALAR_TYPE,                                                             \
@@ -60,7 +61,7 @@ namespace Impl {
         XV;                                                                    \
     typedef typename XV::size_type size_type;                                  \
                                                                                \
-    static void scal(const RV& R, const AS& alpha, const XV& X) {              \
+    static void scal(const ExecSpace& space, const RV& R, const AS& alpha, const XV& X) { \
       Kokkos::Profiling::pushRegion("KokkosBlas::scal[TPL_BLAS," #SCALAR_TYPE  \
                                     "]");                                      \
       const size_type numElems = X.extent(0);                                  \
@@ -73,7 +74,7 @@ namespace Impl {
         HostBlas<BASE_SCALAR_TYPE>::scal(                                      \
             N, alpha_b, reinterpret_cast<BASE_SCALAR_TYPE*>(R.data()), one);   \
       } else {                                                                 \
-        Scal<RV, AS, XV, 1, false, ETI_SPEC_AVAIL>::scal(R, alpha, X);         \
+        Scal<ExecSpace, RV, AS, XV, 1, false, ETI_SPEC_AVAIL>::scal(space, R, alpha, X); \
       }                                                                        \
       Kokkos::Profiling::popRegion();                                          \
     }                                                                          \

--- a/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
@@ -248,9 +248,9 @@ namespace KokkosBlas {
 namespace Impl {
 
 #define KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(                               \
-    SCALAR_TYPE, ROCBLAS_SCALAR_TYPE, ROCBLAS_FN, LAYOUT, EXECSPACE, MEMSPACE  \
-    ETI_SPEC_AVAIL)                                                            \
-  template <>								\
+    SCALAR_TYPE, ROCBLAS_SCALAR_TYPE, ROCBLAS_FN, LAYOUT, EXECSPACE,           \
+    MEMSPACE ETI_SPEC_AVAIL)                                                   \
+  template <>                                                                  \
   struct Scal<                                                                 \
       EXECSPACE,                                                               \
       Kokkos::View<SCALAR_TYPE*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,  \
@@ -273,7 +273,7 @@ namespace Impl {
     typedef typename XV::size_type size_type;                                  \
                                                                                \
     static void scal(const execution_space& space, const RV& R,                \
-		     const AS& alpha, const XV& X) {			       \
+                     const AS& alpha, const XV& X) {                           \
       Kokkos::Profiling::pushRegion(                                           \
           "KokkosBlas::scal[TPL_ROCBLAS," #SCALAR_TYPE "]");                   \
       const size_type numElems = X.extent(0);                                  \
@@ -284,18 +284,18 @@ namespace Impl {
         constexpr int one = 1;                                                 \
         KokkosBlas::Impl::RocBlasSingleton& s =                                \
             KokkosBlas::Impl::RocBlasSingleton::singleton();                   \
-      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                           \
-          rocblas_set_stream(s.handle, space.hip_stream()));                   \
-      rocblas_pointer_mode pointer_mode;                                       \
-      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                           \
-          rocblas_get_pointer_mode(s.handle, &pointer_mode));                  \
-      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                           \
-          rocblas_set_pointer_mode(s.handle, rocblas_pointer_mode_device));    \
+        KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                         \
+            rocblas_set_stream(s.handle, space.hip_stream()));                 \
+        rocblas_pointer_mode pointer_mode;                                     \
+        KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                         \
+            rocblas_get_pointer_mode(s.handle, &pointer_mode));                \
+        KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                         \
+            rocblas_set_pointer_mode(s.handle, rocblas_pointer_mode_device));  \
         KOKKOS_ROCBLAS_SAFE_CALL_IMPL(ROCBLAS_FN(                              \
             s.handle, N, reinterpret_cast<const ROCBLAS_SCALAR_TYPE*>(&alpha), \
             reinterpret_cast<ROCBLAS_SCALAR_TYPE*>(R.data()), one));           \
-      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                           \
-          rocblas_set_pointer_mode(s.handle, pointer_mode));                   \
+        KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                         \
+            rocblas_set_pointer_mode(s.handle, pointer_mode));                 \
       } else {                                                                 \
         Scal<RV, AS, XV, 1, false, ETI_SPEC_AVAIL>::scal(R, alpha, X);         \
       }                                                                        \
@@ -303,25 +303,25 @@ namespace Impl {
     }                                                                          \
   };
 
-#define KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE, \
-						MEMSPACE,	   \
-                                                ETI_SPEC_AVAIL)          \
-  KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(double, double, rocblas_dscal, \
-                                          LAYOUT, EXECSPACE, MEMSPACE, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE, MEMSPACE, \
+                                                ETI_SPEC_AVAIL)              \
+  KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(double, double, rocblas_dscal,     \
+                                          LAYOUT, EXECSPACE, MEMSPACE,       \
+                                          ETI_SPEC_AVAIL)
 
-#define KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE, MEMSPACE \
-                                                ETI_SPEC_AVAIL)                \
+#define KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE,             \
+                                                MEMSPACE ETI_SPEC_AVAIL)       \
   KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(float, float, rocblas_sscal, LAYOUT, \
                                           EXECSPACE, MEMSPACE, ETI_SPEC_AVAIL)
 
-#define KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE, MEMSPACE \
-                                                ETI_SPEC_AVAIL)               \
+#define KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE,            \
+                                                MEMSPACE ETI_SPEC_AVAIL)      \
   KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(                                    \
       Kokkos::complex<double>, rocblas_double_complex, rocblas_zscal, LAYOUT, \
       EXECSPACE, MEMSPACE, ETI_SPEC_AVAIL)
 
-#define KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE, MEMSPACE \
-                                                ETI_SPEC_AVAIL)             \
+#define KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE,          \
+                                                MEMSPACE ETI_SPEC_AVAIL)    \
   KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(                                  \
       Kokkos::complex<float>, rocblas_float_complex, rocblas_cscal, LAYOUT, \
       EXECSPACE, MEMSPACE, ETI_SPEC_AVAIL)

--- a/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
@@ -132,54 +132,54 @@ KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_BLAS(Kokkos::LayoutLeft, Kokkos::HostSpace,
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_CUBLAS(SCALAR_TYPE, CUDA_SCALAR_TYPE, \
-                                               CUBLAS_FN, LAYOUT, MEMSPACE,   \
-                                               ETI_SPEC_AVAIL)                \
-  template <class ExecSpace>                                                  \
-  struct Scal<                                                                \
-      ExecSpace,							      \
-      Kokkos::View<SCALAR_TYPE*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                 \
-      SCALAR_TYPE,                                                            \
-      Kokkos::View<const SCALAR_TYPE*, LAYOUT,                                \
-                   Kokkos::Device<ExecSpace, MEMSPACE>,                       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                 \
-      1, true, ETI_SPEC_AVAIL> {                                              \
-    typedef Kokkos::View<SCALAR_TYPE*, LAYOUT,                                \
-                         Kokkos::Device<ExecSpace, MEMSPACE>,                 \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >            \
-        RV;                                                                   \
-    typedef SCALAR_TYPE AS;                                                   \
-    typedef Kokkos::View<const SCALAR_TYPE*, LAYOUT,                          \
-                         Kokkos::Device<ExecSpace, MEMSPACE>,                 \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >            \
-        XV;                                                                   \
-    typedef typename XV::size_type size_type;                                 \
-                                                                              \
-    static void scal(const ExecSpace& space, const RV& R, const AS& alpha,    \
-		     const XV& X) {					      \
-      Kokkos::Profiling::pushRegion(                                          \
-          "KokkosBlas::scal[TPL_CUBLAS," #SCALAR_TYPE "]");                   \
-      const size_type numElems = X.extent(0);                                 \
-      if ((numElems < static_cast<size_type>(INT_MAX)) &&                     \
-          (R.data() == X.data())) {                                           \
-        scal_print_specialization<RV, AS, XV>();                              \
-        const int N       = static_cast<int>(numElems);                       \
-        constexpr int one = 1;                                                \
-        KokkosBlas::Impl::CudaBlasSingleton& s =                              \
-            KokkosBlas::Impl::CudaBlasSingleton::singleton();                 \
-      KOKKOS_CUBLAS_SAFE_CALL_IMPL(                                           \
-          cublasSetStream(s.handle, space.cuda_stream()));                    \
-        KOKKOS_CUBLAS_SAFE_CALL_IMPL(CUBLAS_FN(                               \
-            s.handle, N, reinterpret_cast<const CUDA_SCALAR_TYPE*>(&alpha),   \
-            reinterpret_cast<CUDA_SCALAR_TYPE*>(R.data()), one));             \
-      KOKKOS_CUBLAS_SAFE_CALL_IMPL(                                           \
-          cublasSetStream(s.handle, NULL));                                   \
-      } else {                                                                \
-        Scal<ExecSpace, RV, AS, XV, 1, false, ETI_SPEC_AVAIL>::scal(space, R, alpha, X); \
-      }                                                                       \
-      Kokkos::Profiling::popRegion();                                         \
-    }                                                                         \
+#define KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_CUBLAS(SCALAR_TYPE, CUDA_SCALAR_TYPE,  \
+                                               CUBLAS_FN, LAYOUT, MEMSPACE,    \
+                                               ETI_SPEC_AVAIL)                 \
+  template <class ExecSpace>                                                   \
+  struct Scal<                                                                 \
+      ExecSpace,                                                               \
+      Kokkos::View<SCALAR_TYPE*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,  \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
+      SCALAR_TYPE,                                                             \
+      Kokkos::View<const SCALAR_TYPE*, LAYOUT,                                 \
+                   Kokkos::Device<ExecSpace, MEMSPACE>,                        \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
+      1, true, ETI_SPEC_AVAIL> {                                               \
+    typedef Kokkos::View<SCALAR_TYPE*, LAYOUT,                                 \
+                         Kokkos::Device<ExecSpace, MEMSPACE>,                  \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
+        RV;                                                                    \
+    typedef SCALAR_TYPE AS;                                                    \
+    typedef Kokkos::View<const SCALAR_TYPE*, LAYOUT,                           \
+                         Kokkos::Device<ExecSpace, MEMSPACE>,                  \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
+        XV;                                                                    \
+    typedef typename XV::size_type size_type;                                  \
+                                                                               \
+    static void scal(const ExecSpace& space, const RV& R, const AS& alpha,     \
+                     const XV& X) {                                            \
+      Kokkos::Profiling::pushRegion(                                           \
+          "KokkosBlas::scal[TPL_CUBLAS," #SCALAR_TYPE "]");                    \
+      const size_type numElems = X.extent(0);                                  \
+      if ((numElems < static_cast<size_type>(INT_MAX)) &&                      \
+          (R.data() == X.data())) {                                            \
+        scal_print_specialization<RV, AS, XV>();                               \
+        const int N       = static_cast<int>(numElems);                        \
+        constexpr int one = 1;                                                 \
+        KokkosBlas::Impl::CudaBlasSingleton& s =                               \
+            KokkosBlas::Impl::CudaBlasSingleton::singleton();                  \
+        KOKKOS_CUBLAS_SAFE_CALL_IMPL(                                          \
+            cublasSetStream(s.handle, space.cuda_stream()));                   \
+        KOKKOS_CUBLAS_SAFE_CALL_IMPL(CUBLAS_FN(                                \
+            s.handle, N, reinterpret_cast<const CUDA_SCALAR_TYPE*>(&alpha),    \
+            reinterpret_cast<CUDA_SCALAR_TYPE*>(R.data()), one));              \
+        KOKKOS_CUBLAS_SAFE_CALL_IMPL(cublasSetStream(s.handle, NULL));         \
+      } else {                                                                 \
+        Scal<ExecSpace, RV, AS, XV, 1, false, ETI_SPEC_AVAIL>::scal(space, R,  \
+                                                                    alpha, X); \
+      }                                                                        \
+      Kokkos::Profiling::popRegion();                                          \
+    }                                                                          \
   };
 
 #define KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_CUBLAS(LAYOUT, MEMSPACE,              \

--- a/blas/tpls/KokkosBlas1_update_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_update_tpl_spec_avail.hpp
@@ -20,7 +20,7 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class XMV, class YMV, class ZMV, int rank = ZMV::rank>
+template <class execution_space, class XMV, class YMV, class ZMV, int rank = ZMV::rank>
 struct update_tpl_spec_avail {
   enum : bool { value = false };
 };

--- a/blas/tpls/KokkosBlas1_update_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_update_tpl_spec_avail.hpp
@@ -20,7 +20,8 @@
 namespace KokkosBlas {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class execution_space, class XMV, class YMV, class ZMV, int rank = ZMV::rank>
+template <class execution_space, class XMV, class YMV, class ZMV,
+          int rank = ZMV::rank>
 struct update_tpl_spec_avail {
   enum : bool { value = false };
 };

--- a/perf_test/blas/blas3/KokkosBlas3_gemm_standalone_perf_test_benchmark.cpp
+++ b/perf_test/blas/blas3/KokkosBlas3_gemm_standalone_perf_test_benchmark.cpp
@@ -126,16 +126,16 @@ void run(const blas3_gemm_params& params) {
   const auto args      = std::vector<int64_t>{params.m, params.n, params.k};
 
   KokkosKernelsBenchmark::register_benchmark(
-      name, KokkosBlas3_GEMM<Kokkos::OpenMP, Scalar, LL, LL>, arg_names, args,
+      name, KokkosBlas3_GEMM<ExecSpace, Scalar, LL, LL>, arg_names, args,
       params.repeat);
   KokkosKernelsBenchmark::register_benchmark(
-      name, KokkosBlas3_GEMM<Kokkos::OpenMP, Scalar, LL, LR>, arg_names, args,
+      name, KokkosBlas3_GEMM<ExecSpace, Scalar, LL, LR>, arg_names, args,
       params.repeat);
   KokkosKernelsBenchmark::register_benchmark(
-      name, KokkosBlas3_GEMM<Kokkos::OpenMP, Scalar, LR, LL>, arg_names, args,
+      name, KokkosBlas3_GEMM<ExecSpace, Scalar, LR, LL>, arg_names, args,
       params.repeat);
   KokkosKernelsBenchmark::register_benchmark(
-      name, KokkosBlas3_GEMM<Kokkos::OpenMP, Scalar, LR, LR>, arg_names, args,
+      name, KokkosBlas3_GEMM<ExecSpace, Scalar, LR, LR>, arg_names, args,
       params.repeat);
 }
 


### PR DESCRIPTION
Implementing an execution space interface for BLAS1 functions that were not included in PR #1795 
Basically these are kernels that do not perform reductions and are hence a little easier to handle in my opinion.
These new interfaces will be useful for libraries and applications that use Kokkos Kernels and have already started executing there kernels on streams/queues and need to either use the same stream/queue with Kokkos Kernels or at least need to synchronize with it.