### PR TITLE
Blas1: docs update for PR #1803

### DIFF
--- a/blas/src/KokkosBlas1_abs.hpp
+++ b/blas/src/KokkosBlas1_abs.hpp
@@ -25,8 +25,8 @@ namespace KokkosBlas {
 
 /// \brief R(i,j) = abs(X(i,j))
 ///
-/// Non-blocking function to replace each entry in R with the absolute value (magnitude) of the
-/// corresponding entry in X.
+/// Non-blocking function to replace each entry in R with the absolute value
+/// (magnitude) of the corresponding entry in X.
 ///
 /// \tparam execution_space a Kokkos execution space to run the kernels on.
 /// \tparam RMV 1-D or 2-D Kokkos::View specialization.
@@ -35,7 +35,8 @@ namespace KokkosBlas {
 ///   those of RMV.
 ///
 /// \param space [in] an execution_space instance where the kernel will run.
-/// \param R [out] view of type RMV that contains the absolute value X on output.
+/// \param R [out] view of type RMV that contains the absolute value X on
+/// output.
 /// \param X [in] view of type XMV.
 template <class execution_space, class RMV, class XMV>
 void abs(const execution_space& space, const RMV& R, const XMV& X) {
@@ -109,7 +110,8 @@ void abs(const execution_space& space, const RMV& R, const XMV& X) {
 ///   the same rank as RMV, and its entries must be assignable to
 ///   those of RMV.
 ///
-/// \param R [out] view of type RMV that contains the absolute value X on output.
+/// \param R [out] view of type RMV that contains the absolute value X on
+/// output.
 /// \param X [in] view of type XMV.
 template <class RMV, class XMV>
 void abs(const RMV& R, const XMV& X) {

--- a/blas/src/KokkosBlas1_abs.hpp
+++ b/blas/src/KokkosBlas1_abs.hpp
@@ -33,6 +33,10 @@ namespace KokkosBlas {
 /// \tparam XMV 1-D or 2-D Kokkos::View specialization.  It must have
 ///   the same rank as RMV, and its entries must be assignable to
 ///   those of RMV.
+///
+/// \param space [in] an execution_space instance where the kernel will run.
+/// \param R [out] view of type RMV that contains the absolute value X on output.
+/// \param X [in] view of type XMV.
 template <class execution_space, class RMV, class XMV>
 void abs(const execution_space& space, const RMV& R, const XMV& X) {
   static_assert(Kokkos::is_execution_space_v<execution_space>,
@@ -103,6 +107,9 @@ void abs(const execution_space& space, const RMV& R, const XMV& X) {
 /// \tparam XMV 1-D or 2-D Kokkos::View specialization.  It must have
 ///   the same rank as RMV, and its entries must be assignable to
 ///   those of RMV.
+///
+/// \param R [out] view of type RMV that contains the absolute value X on output.
+/// \param X [in] view of type XMV.
 template <class RMV, class XMV>
 void abs(const RMV& R, const XMV& X) {
   abs(typename RMV::execution_space{}, R, X);

--- a/blas/src/KokkosBlas1_abs.hpp
+++ b/blas/src/KokkosBlas1_abs.hpp
@@ -25,7 +25,7 @@ namespace KokkosBlas {
 
 /// \brief R(i,j) = abs(X(i,j))
 ///
-/// Replace each entry in R with the absolute value (magnitude) of the
+/// Non-blocking function to replace each entry in R with the absolute value (magnitude) of the
 /// corresponding entry in X.
 ///
 /// \tparam execution_space a Kokkos execution space to run the kernels on.
@@ -100,8 +100,9 @@ void abs(const execution_space& space, const RMV& R, const XMV& X) {
 
 /// \brief R(i,j) = abs(X(i,j))
 ///
-/// Replace each entry in R with the absolute value (magnitude) of the
-/// corresponding entry in X.
+/// Non-blocking function to replace each entry in R with the absolute value
+/// (magnitude) of the corresponding entry in X. The kernel is executed in the
+/// default stream/queue associated with the execution space of RMV.
 ///
 /// \tparam RMV 1-D or 2-D Kokkos::View specialization.
 /// \tparam XMV 1-D or 2-D Kokkos::View specialization.  It must have

--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -32,6 +32,8 @@ namespace KokkosBlas {
 
 /// \brief Computes Y := a*X + b*Y
 ///
+/// This function is non-blocking and thread safe.
+///
 /// \tparam execution_space a Kokkos execution space where the kernel will run.
 /// \tparam AV 1-D or 2-D Kokkos::View specialization.
 /// \tparam XMV 1-D or 2-D Kokkos::View specialization.
@@ -119,6 +121,10 @@ void axpby(const execution_space& space, const AV& a, const XMV& X, const BV& b,
 
 /// \brief Computes Y := a*X + b*Y
 ///
+/// This function is non-blocking and thread-safe
+/// The kernel is executed in the default stream/queue
+/// associated with the execution space of XMV.
+///
 /// \tparam AV 1-D or 2-D Kokkos::View specialization.
 /// \tparam XMV 1-D or 2-D Kokkos::View specialization.
 /// \tparam BV 1-D or 2-D Kokkos::View specialization.
@@ -135,6 +141,8 @@ void axpby(const AV& a, const XMV& X, const BV& b, const YMV& Y) {
 }
 
 /// \brief Computes Y := a*X + Y
+///
+/// This function is non-blocking and thread-safe
 ///
 /// \tparam execution_space a Kokkos execution space where the kernel will run.
 /// \tparam AV 1-D or 2-D Kokkos::View specialization.
@@ -154,6 +162,10 @@ void axpy(const execution_space& space, const AV& a, const XMV& X,
 }
 
 /// \brief Computes Y := a*X + Y
+///
+/// This function is non-blocking and thread-safe
+/// The kernel is executed in the default stream/queue
+/// associated with the execution space of XMV.
 ///
 /// \tparam AV 1-D or 2-D Kokkos::View specialization.
 /// \tparam XMV 1-D or 2-D Kokkos::View specialization.

--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -30,6 +30,20 @@
 
 namespace KokkosBlas {
 
+/// \brief Computes Y := a*X + b*Y
+///
+/// \tparam execution_space a Kokkos execution space where the kernel will run.
+/// \tparam AV 1-D or 2-D Kokkos::View specialization.
+/// \tparam XMV 1-D or 2-D Kokkos::View specialization.
+/// \tparam BV 1-D or 2-D Kokkos::View specialization.
+/// \tparam YMV 1-D or 2-D Kokkos::View specialization. It must have
+///   the same rank as XMV.
+///
+/// \param space [in] the execution space instance on which the kernel will run.
+/// \param a [in] view of type AV, scaling parameter for X.
+/// \param X [in] input view of type XMV.
+/// \param b [in] view of type BV, scaling parameter for Y.
+/// \param Y [in/out] view of type YMV in which the results will be stored.
 template <class execution_space, class AV, class XMV, class BV, class YMV>
 void axpby(const execution_space& space, const AV& a, const XMV& X, const BV& b,
            const YMV& Y) {
@@ -103,11 +117,35 @@ void axpby(const execution_space& space, const AV& a, const XMV& X, const BV& b,
                                    Y_internal);
 }
 
+/// \brief Computes Y := a*X + b*Y
+///
+/// \tparam AV 1-D or 2-D Kokkos::View specialization.
+/// \tparam XMV 1-D or 2-D Kokkos::View specialization.
+/// \tparam BV 1-D or 2-D Kokkos::View specialization.
+/// \tparam YMV 1-D or 2-D Kokkos::View specialization. It must have
+///   the same rank as XMV.
+///
+/// \param a [in] view of type AV, scaling parameter for X.
+/// \param X [in] input view of type XMV.
+/// \param b [in] view of type BV, scaling parameter for Y.
+/// \param Y [in/out] view of type YMV in which the results will be stored.
 template <class AV, class XMV, class BV, class YMV>
 void axpby(const AV& a, const XMV& X, const BV& b, const YMV& Y) {
   axpby(typename XMV::execution_space{}, a, X, b, Y);
 }
 
+/// \brief Computes Y := a*X + Y
+///
+/// \tparam execution_space a Kokkos execution space where the kernel will run.
+/// \tparam AV 1-D or 2-D Kokkos::View specialization.
+/// \tparam XMV 1-D or 2-D Kokkos::View specialization.
+/// \tparam YMV 1-D or 2-D Kokkos::View specialization. It must have
+///   the same rank as XMV.
+///
+/// \param space [in] the execution space instance on which the kernel will run.
+/// \param a [in] view of type AV, scaling parameter for X.
+/// \param X [in] input view of type XMV.
+/// \param Y [in/out] view of type YMV in which the results will be stored.
 template <class execution_space, class AV, class XMV, class YMV>
 void axpy(const execution_space& space, const AV& a, const XMV& X,
           const YMV& Y) {
@@ -115,6 +153,16 @@ void axpy(const execution_space& space, const AV& a, const XMV& X,
         Kokkos::ArithTraits<typename YMV::non_const_value_type>::one(), Y);
 }
 
+/// \brief Computes Y := a*X + Y
+///
+/// \tparam AV 1-D or 2-D Kokkos::View specialization.
+/// \tparam XMV 1-D or 2-D Kokkos::View specialization.
+/// \tparam YMV 1-D or 2-D Kokkos::View specialization. It must have
+///   the same rank as XMV.
+///
+/// \param a [in] view of type AV, scaling parameter for X.
+/// \param X [in] input view of type XMV.
+/// \param Y [in/out] view of type YMV in which the results will be stored.
 template <class AV, class XMV, class YMV>
 void axpy(const AV& a, const XMV& X, const YMV& Y) {
   axpy(typename XMV::execution_space{}, a, X, Y);

--- a/blas/src/KokkosBlas1_fill.hpp
+++ b/blas/src/KokkosBlas1_fill.hpp
@@ -23,6 +23,8 @@ namespace KokkosBlas {
 
 /// \brief Fill the multivector or single vector X with the given value.
 ///
+/// This function is non-blocking and thread-safe
+///
 /// \tparam execution_space a Kokkos execution space
 /// \tparam XMV 1-D or 2-D output View
 ///
@@ -39,6 +41,10 @@ void fill(const execution_space& space, const XMV& X,
 }
 
 /// \brief Fill the multivector or single vector X with the given value.
+///
+/// This function is non-blocking and thread-safe
+/// The kernel is executed in the default stream/queue
+/// associated with the execution space of XMV.
 ///
 /// \tparam XMV 1-D or 2-D output View
 ///

--- a/blas/src/KokkosBlas1_mult.hpp
+++ b/blas/src/KokkosBlas1_mult.hpp
@@ -26,6 +26,8 @@ namespace KokkosBlas {
 /// \brief Element wise multiplication of two vectors:
 ///        Y[i] = gamma * Y[i] + alpha * A[i] * X[i]
 ///
+/// This function is non-blocking and thread-safe
+///
 /// \tparam execution_type a Kokkos execution space type.
 /// \tparam YMV Type of the first vector Y; a 1-D or 2-D Kokkos::View.
 /// \tparam AV  Type of the second vector A; a 1-D Kokkos::View.
@@ -123,6 +125,10 @@ void mult(const execution_space& space, typename YMV::const_value_type& gamma,
 
 /// \brief Element wise multiplication of two vectors:
 ///        Y[i] = gamma * Y[i] + alpha * A[i] * X[i]
+///
+/// This function is non-blocking and thread-safe
+/// The kernel is executed in the default stream/queue
+/// associated with the execution space of YMV.
 ///
 /// \tparam YMV Type of the first vector Y; a 1-D or 2-D Kokkos::View.
 /// \tparam AV  Type of the second vector A; a 1-D Kokkos::View.

--- a/blas/src/KokkosBlas1_reciprocal.hpp
+++ b/blas/src/KokkosBlas1_reciprocal.hpp
@@ -28,10 +28,15 @@ namespace KokkosBlas {
 /// Replace each entry in R with the absolute value (magnitude), of the
 /// reciprocal of the corresponding entry in X.
 ///
+/// \tparam execution_space a Kokkos execution space
 /// \tparam RMV 1-D or 2-D Kokkos::View specialization.
 /// \tparam XMV 1-D or 2-D Kokkos::View specialization.  It must have
 ///   the same rank as RMV, and its entries must be assignable to
 ///   those of RMV.
+///
+/// \param space [in] an instance of execution space where the kernel will run
+/// \param R [out] a view of type RMV that contains the inverse of the values in X.
+/// \param X [in] a view of type XMV that contains the values to invert.
 template <class execution_space, class RMV, class XMV>
 void reciprocal(const execution_space& space, const RMV& R, const XMV& X) {
   static_assert(Kokkos::is_execution_space_v<execution_space>,

--- a/blas/src/KokkosBlas1_reciprocal.hpp
+++ b/blas/src/KokkosBlas1_reciprocal.hpp
@@ -27,6 +27,7 @@ namespace KokkosBlas {
 ///
 /// Replace each entry in R with the absolute value (magnitude), of the
 /// reciprocal of the corresponding entry in X.
+/// This function is non-blocking and thread-safe
 ///
 /// \tparam execution_space a Kokkos execution space
 /// \tparam RMV 1-D or 2-D Kokkos::View specialization.
@@ -104,6 +105,9 @@ void reciprocal(const execution_space& space, const RMV& R, const XMV& X) {
 ///
 /// Replace each entry in R with the absolute value (magnitude), of the
 /// reciprocal of the corresponding entry in X.
+/// This function is non-blocking and thread-safe
+/// The kernel is executed in the default stream/queue
+/// associated with the execution space of RMV.
 ///
 /// \tparam RMV 1-D or 2-D Kokkos::View specialization.
 /// \tparam XMV 1-D or 2-D Kokkos::View specialization.  It must have

--- a/blas/src/KokkosBlas1_reciprocal.hpp
+++ b/blas/src/KokkosBlas1_reciprocal.hpp
@@ -36,7 +36,8 @@ namespace KokkosBlas {
 ///   those of RMV.
 ///
 /// \param space [in] an instance of execution space where the kernel will run
-/// \param R [out] a view of type RMV that contains the inverse of the values in X.
+/// \param R [out] a view of type RMV that contains the inverse of the values in
+/// X.
 /// \param X [in] a view of type XMV that contains the values to invert.
 template <class execution_space, class RMV, class XMV>
 void reciprocal(const execution_space& space, const RMV& R, const XMV& X) {

--- a/blas/src/KokkosBlas1_scal.hpp
+++ b/blas/src/KokkosBlas1_scal.hpp
@@ -31,6 +31,8 @@ namespace KokkosBlas {
 
 /// \brief Computes R := alpha*X
 ///
+/// This function is non-blocking and thread-safe
+///
 /// \tparam execution_space a Kokkos execution space where the kernel will run.
 /// \tparam RMV 1-D or 2-D Kokkos::View specialization.
 /// \tparam XMV 1-D or 2-D Kokkos::View specialization. It must have
@@ -114,6 +116,10 @@ void scal(const execution_space& space, const RMV& R, const AV& a,
 }
 
 /// \brief Computes R := alpha*X
+///
+/// This function is non-blocking and thread-safe
+/// The kernel is executed in the default stream/queue
+/// associated with the execution space of YMV.
 ///
 /// \tparam RMV 1-D or 2-D Kokkos::View specialization.
 /// \tparam XMV 1-D or 2-D Kokkos::View specialization. It must have

--- a/blas/src/KokkosBlas1_scal.hpp
+++ b/blas/src/KokkosBlas1_scal.hpp
@@ -29,6 +29,18 @@
 
 namespace KokkosBlas {
 
+/// \brief Computes R := alpha*X
+///
+/// \tparam execution_space a Kokkos execution space where the kernel will run.
+/// \tparam RMV 1-D or 2-D Kokkos::View specialization.
+/// \tparam XMV 1-D or 2-D Kokkos::View specialization. It must have
+///   the same rank as RMV.
+/// \tparam AV 1-D or 2-D Kokkos::View specialization.
+///
+/// \param space [in] the execution space instance on which the kernel will run.
+/// \param R [in/out] view of type RMV in which the results will be stored.
+/// \param a [in] view of type AV, scaling parameter for X.
+/// \param X [in] input view of type XMV.
 template <class execution_space, class RMV, class AV, class XMV>
 void scal(const execution_space& space, const RMV& R, const AV& a,
           const XMV& X) {
@@ -101,6 +113,16 @@ void scal(const execution_space& space, const RMV& R, const AV& a,
       space, R_internal, a_internal, X_internal);
 }
 
+/// \brief Computes R := alpha*X
+///
+/// \tparam RMV 1-D or 2-D Kokkos::View specialization.
+/// \tparam XMV 1-D or 2-D Kokkos::View specialization. It must have
+///   the same rank as RMV.
+/// \tparam AV 1-D or 2-D Kokkos::View specialization.
+///
+/// \param R [in/out] view of type RMV in which the results will be stored.
+/// \param a [in] view of type AV, scaling parameter for X.
+/// \param X [in] input view of type XMV.
 template <class RMV, class AV, class XMV>
 void scal(const RMV& R, const AV& a, const XMV& X) {
   scal(typename RMV::execution_space{}, R, a, X);

--- a/blas/src/KokkosBlas1_update.hpp
+++ b/blas/src/KokkosBlas1_update.hpp
@@ -25,6 +25,8 @@ namespace KokkosBlas {
 
 /// \brief Compute Z := alpha*X + beta*Y + gamma*Z.
 ///
+/// This function is non-blocking and thread-safe
+///
 /// \tparam execution_space a Kokkos execution space where the kernel will run.
 /// \tparam XMV 1-D or 2-D Kokkos::View specialization.
 /// \tparam YMV 1-D or 2-D Kokkos::View specialization.  It must have
@@ -138,6 +140,10 @@ void update(const execution_space& space,
 }
 
 /// \brief Compute Z := alpha*X + beta*Y + gamma*Z.
+///
+/// This function is non-blocking and thread-safe
+/// The kernel is executed in the default stream/queue
+/// associated with the execution space of ZMV.
 ///
 /// \tparam XMV 1-D or 2-D Kokkos::View specialization.
 /// \tparam YMV 1-D or 2-D Kokkos::View specialization.  It must have

--- a/blas/src/KokkosBlas1_update.hpp
+++ b/blas/src/KokkosBlas1_update.hpp
@@ -33,6 +33,14 @@ namespace KokkosBlas {
 ///   the same rank as XMV and YMV, and it must make sense to add up
 ///   the entries of XMV and YMV and assign them to the entries of
 ///   ZMV.
+///
+/// \param space [in] the execution space instance on which the kernel will run.
+/// \param alpha [in] scaling parameter for X
+/// \param X [in] input view of type XMV
+/// \param beta [in] scaling parameter for Y
+/// \param Y [in] input view of type YMV
+/// \param gamma [in] scaling parameter for Z
+/// \param Z [in/out] view of type ZMV in which the results will be stored.
 template <class execution_space, class XMV, class YMV, class ZMV>
 void update(const execution_space& space,
             const typename XMV::non_const_value_type& alpha, const XMV& X,
@@ -138,6 +146,13 @@ void update(const execution_space& space,
 ///   the same rank as XMV and YMV, and it must make sense to add up
 ///   the entries of XMV and YMV and assign them to the entries of
 ///   ZMV.
+///
+/// \param alpha [in] scaling parameter for X
+/// \param X [in] input view of type XMV
+/// \param beta [in] scaling parameter for Y
+/// \param Y [in] input view of type YMV
+/// \param gamma [in] scaling parameter for Z
+/// \param Z [in/out] view of type ZMV in which the results will be stored.
 template <class XMV, class YMV, class ZMV>
 void update(const typename XMV::non_const_value_type& alpha, const XMV& X,
             const typename YMV::non_const_value_type& beta, const YMV& Y,

--- a/docs/developer/apidocs/blas1.rst
+++ b/docs/developer/apidocs/blas1.rst
@@ -1,9 +1,15 @@
 BLAS1 -- KokkosKernels blas1 interfaces
 =======================================
 
+abs
+___
+.. doxygenfunction:: KokkosBlas::abs(const execution_space& space, const RMV& R, const XMV& X)
+.. doxygenfunction:: KokkosBlas::abs(const RMV& R, const XMV& X)
+
 axpby
 -----
-.. doxygenfunction:: KokkosBlas::axpby
+.. doxygenfunction:: KokkosBlas::axpby(const execution_space& space, const AV& a, const XMV& X, const BV& b, const YMV& Y)
+.. doxygenfunction:: KokkosBlas::axpby(const AV& a, const XMV& X, const BV& b, const YMV& Y)
 
 dot
 ---
@@ -12,11 +18,13 @@ dot
 
 fill
 ----
-.. doxygenfunction:: KokkosBlas::fill
+.. doxygenfunction:: KokkosBlas::fill(const execution_space& space, const XMV& X, const typename XMV::non_const_value_type& val)
+.. doxygenfunction:: KokkosBlas::fill(const XMV& X, const typename XMV::non_const_value_type& val)
 
 mult
 ----
-.. doxygenfunction:: KokkosBlas::mult
+.. doxygenfunction:: KokkosBlas::mult(const execution_space& space, typename YMV::const_value_type& gamma, const YMV& Y, typename AV::const_value_type& alpha, const AV& A, const XMV& X)
+.. doxygenfunction:: KokkosBlas::mult(typename YMV::const_value_type& gamma, const YMV& Y, typename AV::const_value_type& alpha, const AV& A, const XMV& X)
 
 nrm1
 ----
@@ -40,11 +48,13 @@ nrminf
 
 reciprocal
 ----------
-.. doxygenfunction:: KokkosBlas::reciprocal
+.. doxygenfunction:: KokkosBlas::reciprocal(const execution_space& space, const RMV& R, const XMV& X)
+.. doxygenfunction:: KokkosBlas::reciprocal(const RMV& R, const XMV& X)
 
 scal
 ----
-.. doxygenfunction:: KokkosBlas::scal
+.. doxygenfunction:: KokkosBlas::scal(const execution_space& space, const RMV& R, const AV& a, const XMV& X)
+.. doxygenfunction:: KokkosBlas::scal(const RMV& R, const AV& a, const XMV& X)
 
 sum
 ---
@@ -57,4 +67,5 @@ swap
 
 update
 ------
-.. doxygenfunction:: KokkosBlas::update
+.. doxygenfunction:: KokkosBlas::update(const execution_space& space, const typename XMV::non_const_value_type& alpha, const XMV& X, const typename YMV::non_const_value_type& beta, const YMV& Y, const typename ZMV::non_const_value_type& gamma, const ZMV& Z)
+.. doxygenfunction:: KokkosBlas::update(const typename XMV::non_const_value_type& alpha, const XMV& X, const typename YMV::non_const_value_type& beta, const YMV& Y, const typename ZMV::non_const_value_type& gamma, const ZMV& Z)


### PR DESCRIPTION
updating documentation for changes in PR #1803, this PR will be rebased once #1803 is merged.
It mostly includes additional overloads of our BLAS1 functions to accept an execution space instance.
Additional documentation improvement have been made as well.