### PR TITLE
Fix name mismatch with rocblas tpl spec layer for scal

### DIFF
--- a/blas/tpls/KokkosBlas1_scal_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_scal_tpl_spec_avail.hpp
@@ -107,10 +107,10 @@ KOKKOSBLAS1_SCAL_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<float>,
   template <>                                                                  \
   struct scal_tpl_spec_avail<                                                  \
       EXECSPACE,                                                               \
-      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,       \
+      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXECSPACE, MEMSPACE>,       \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       SCALAR,                                                                  \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
+      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXECSPACE, MEMSPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       1> {                                                                     \
     enum : bool { value = true };                                              \


### PR DESCRIPTION
Fixes ExecSpace vs EXECSPACE naming mismatch in `blas/tpls/KokkosBlas1_scal_tpl_spec_avail.hpp` following #1803 

Caught in the rocm tpl nightly build that enables rocblas and rocsparse

This change should resolve compilation errors of the form:
```
05:12:41 /home/jenkins/caraway-new/workspace/KokkosKernels_CarawayMI100_Rocm520_HipSerial_RocBlas_RocSparse/kokkos-kernels/blas/tpls/KokkosBlas1_scal_tpl_spec_avail.hpp:119:1: error: use of undeclared identifier 'ExecSpace'
```