### PR TITLE
Workaround for #1777 - cusparse spgemm test hang

### DIFF
--- a/sparse/unit_test/Test_Sparse_spgemm.hpp
+++ b/sparse/unit_test/Test_Sparse_spgemm.hpp
@@ -486,6 +486,16 @@ void test_issue402() {
 template <typename scalar_t, typename lno_t, typename size_type,
           typename device>
 void test_issue1738() {
+#if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) && (CUDA_VERSION >= 11000) && \
+    (CUDA_VERSION < 11040)
+  {
+    std::cerr
+        << "TEST SKIPPED: See "
+           "https://github.com/kokkos/kokkos-kernels/issues/1777 for details."
+        << std::endl;
+    return;
+  }
+#endif  // KOKKOSKERNELS_ENABLE_TPL_ARMPL
   // Make sure that std::invalid_argument is thrown if you:
   //  - call numeric where an input matrix's entries have changed.
   //  - try to reuse an spgemm handle by calling symbolic with new input


### PR DESCRIPTION
Disable issue 1738 test in spgemm, if in cuda 11.0-11.3 and cusparse is enabled. For some reason (that appears to be a compiler bug?) _other_ spgemm tests hang after this particular unit test is run.

I talked with F. Busato about this and it appears that the wrapper for the cuSPARSE non-reuse spgemm functions is correct, and the way we use it is valid. The non-reuse interface is used in this version range by all our spgemm tests. So as far as I can tell there isn't an actual code bug here.