### PR TITLE
Add `KokkosKernels_PullRequest_VEGA908_Tpls_ROCM520` support, only enable `KokkosBlas::gesv` where supported

### DIFF
--- a/blas/unit_test/Test_Blas_gesv.hpp
+++ b/blas/unit_test/Test_Blas_gesv.hpp
@@ -13,13 +13,14 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //@HEADER
-// Note: Luc Berger-Vergiat 04/15/21
-//       This test should only be included
-//       in the CUDA backend if TPL MAGMA
-//       has been enabled.
 
-#if !defined(TEST_CUDA_BLAS_CPP) || \
-    (defined(TEST_CUDA_BLAS_CPP) && defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA))
+// only enable this test where KokkosBlas supports gesv:
+// CUDA+MAGMA and HOST+BLAS
+#if (defined(TEST_CUDA_BLAS_CPP) &&                                           \
+     defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA)) ||                              \
+    (defined(KOKKOSKERNELS_ENABLE_TPL_BLAS) &&                                \
+     (defined(TEST_OPENMP_BLAS_CPP) || defined(TEST_OPENMPTARGET_BLAS_CPP) || \
+      defined(TEST_SERIAL_BLAS_CPP) || defined(TEST_THREADS_BLAS_CPP)))
 
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
@@ -128,9 +129,9 @@ void impl_test_gesv(const char* mode, const char* padding, int N) {
     if (ats::abs(h_B(i) - h_X0(i)) > eps) {
       test_flag = false;
       // printf( "    Error %d, pivot %c, padding %c: result( %.15lf ) !=
-      // solution( %.15lf ) at (%ld)\n", N, mode[0], padding[0],
-      // ats::abs(h_B(i)), ats::abs(h_X0(i)), i );
-      break;
+      // solution( %.15lf ) at (%d)\n", N, mode[0], padding[0],
+      // ats::abs(h_B(i)), ats::abs(h_X0(i)), int(i) );
+      // break;
     }
   }
   ASSERT_EQ(test_flag, true);
@@ -337,9 +338,6 @@ int test_gesv_mrhs(const char* mode) {
   return 1;
 }
 
-#if defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA) || \
-    defined(KOKKOSKERNELS_ENABLE_TPL_BLAS)
-
 #if defined(KOKKOSKERNELS_INST_FLOAT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -414,6 +412,4 @@ TEST_F(TestCategory, gesv_mrhs_complex_float) {
 }
 #endif
 
-#endif  // KOKKOSKERNELS_ENABLE_TPL_MAGMA || KOKKOSKERNELS_ENABLE_TPL_BLAS
-
-#endif  // Check for TPL MAGMA when compiling the CUDA tests
+#endif  // CUDA+MAGMA or BLAS+HOST

--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -692,17 +692,26 @@ elif [ "$MACHINE" = "caraway" ]; then
   #   output description and success based only on build succes; build time output (no run-time)
 
   BASE_MODULE_LIST="cmake/3.19.3,<COMPILER_NAME>/<COMPILER_VERSION>"
+  ROCM520_MODULE_LIST="$BASE_MODULE_LIST,openblas/0.3.20/rocm/5.2.0"
 
   HIPCLANG_BUILD_LIST="Hip_Serial"
   HIPCLANG_WARNING_FLAGS=""
 
-  # Format: (compiler module-list build-list exe-name warning-flag)
-  COMPILERS=("rocm/5.2.0 $BASE_MODULE_LIST $HIPCLANG_BUILD_LIST hipcc $HIPCLANG_WARNING_FLAGS"
-             "gcc/8.2.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
-             "gcc/9.2.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
-             "gcc/10.2.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
-             "gcc/11.2.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
-  )
+  if [ "$SPOT_CHECK_TPLS" = "True" ]; then
+    # Format: (compiler module-list build-list exe-name warning-flag)
+    COMPILERS=("rocm/5.2.0 $ROCM520_MODULE_LIST $HIPCLANG_BUILD_LIST hipcc $HIPCLANG_WARNING_FLAGS"
+    )
+  else
+    # Format: (compiler module-list build-list exe-name warning-flag)
+    COMPILERS=("rocm/5.2.0 $BASE_MODULE_LIST $HIPCLANG_BUILD_LIST hipcc $HIPCLANG_WARNING_FLAGS"
+              "gcc/8.2.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
+              "gcc/9.2.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
+              "gcc/10.2.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
+              "gcc/11.2.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
+    )
+  fi
+
+
 
   if [ -z "$ARCH_FLAG" ]; then
     ARCH_FLAG="--arch=VEGA908"


### PR DESCRIPTION
cm_test_all_sandia: adds a BLAS module to load when TPLs are enabled
Changes how KokkosBlas::gesv unit tests are enabled so they are only enabled for supported backends.