### PR TITLE
Fix rocblas build 2

### DIFF
--- a/blas/tpls/KokkosBlas1_nrm1_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_nrm1_tpl_spec_avail.hpp
@@ -103,7 +103,7 @@ KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<float>,
   };
 
 KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_ROCBLAS(double, Kokkos::LayoutLeft,
-                                         Kokkos::HIPSpace)
+                                        Kokkos::HIPSpace)
 KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_ROCBLAS(float, Kokkos::LayoutLeft,
                                         Kokkos::HIPSpace)
 KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<double>,

--- a/blas/tpls/KokkosBlas1_nrm1_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_nrm1_tpl_spec_avail.hpp
@@ -102,7 +102,7 @@ KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<float>,
     enum : bool { value = true };                                              \
   };
 
-KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_ROCUBLAS(double, Kokkos::LayoutLeft,
+KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_ROCBLAS(double, Kokkos::LayoutLeft,
                                          Kokkos::HIPSpace)
 KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_ROCBLAS(float, Kokkos::LayoutLeft,
                                         Kokkos::HIPSpace)

--- a/blas/tpls/KokkosBlas1_nrm1_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_nrm1_tpl_spec_decl.hpp
@@ -415,6 +415,7 @@ namespace Impl {
                                                 ETI_SPEC_AVAIL)                \
   template <class ExecSpace>                                                   \
   struct Nrm1<                                                                 \
+      ExecSpace,                                                               \
       Kokkos::View<double, LAYOUT, Kokkos::HostSpace,                          \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
@@ -444,7 +445,7 @@ namespace Impl {
             rocblas_dasum(s.handle, N, X.data(), one, R.data()));              \
         KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL));     \
       } else {                                                                 \
-        Nrm1<RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(R, X);                    \
+        Nrm1<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(space, R, X);                    \
       }                                                                        \
       Kokkos::Profiling::popRegion();                                          \
     }                                                                          \
@@ -454,6 +455,7 @@ namespace Impl {
                                                 ETI_SPEC_AVAIL)               \
   template <class ExecSpace>                                                  \
   struct Nrm1<                                                                \
+      ExecSpace,                                                              \
       Kokkos::View<float, LAYOUT, Kokkos::HostSpace,                          \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                 \
       Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, \
@@ -483,7 +485,7 @@ namespace Impl {
             rocblas_sasum(s.handle, N, X.data(), one, R.data()));             \
         KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL));    \
       } else {                                                                \
-        Nrm1<RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(R, X);                   \
+        Nrm1<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(space, R, X);                   \
       }                                                                       \
       Kokkos::Profiling::popRegion();                                         \
     }                                                                         \
@@ -492,7 +494,7 @@ namespace Impl {
 #define KOKKOSBLAS1_ZNRM1_TPL_SPEC_DECL_ROCBLAS(LAYOUT, MEMSPACE,           \
                                                 ETI_SPEC_AVAIL)             \
   template <class ExecSpace>                                                \
-  struct Nrm1<Kokkos::View<double, LAYOUT, Kokkos::HostSpace,               \
+  struct Nrm1<ExecSpace, Kokkos::View<double, LAYOUT, Kokkos::HostSpace,               \
                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,       \
               Kokkos::View<const Kokkos::complex<double>*, LAYOUT,          \
                            Kokkos::Device<ExecSpace, MEMSPACE>,             \
@@ -525,7 +527,7 @@ namespace Impl {
             R.data()));                                                     \
         KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL));  \
       } else {                                                              \
-        Nrm1<RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(R, X);                 \
+        Nrm1<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(space, R, X);                 \
       }                                                                     \
       Kokkos::Profiling::popRegion();                                       \
     }                                                                       \
@@ -534,7 +536,7 @@ namespace Impl {
 #define KOKKOSBLAS1_CNRM1_TPL_SPEC_DECL_ROCBLAS(LAYOUT, MEMSPACE,          \
                                                 ETI_SPEC_AVAIL)            \
   template <class ExecSpace>                                               \
-  struct Nrm1<Kokkos::View<float, LAYOUT, Kokkos::HostSpace,               \
+  struct Nrm1<ExecSpace, Kokkos::View<float, LAYOUT, Kokkos::HostSpace,               \
                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
               Kokkos::View<const Kokkos::complex<float>*, LAYOUT,          \
                            Kokkos::Device<ExecSpace, MEMSPACE>,            \
@@ -567,7 +569,7 @@ namespace Impl {
             R.data()));                                                    \
         KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL)); \
       } else {                                                             \
-        Nrm1<RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(R, X);                \
+        Nrm1<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(space, R, X);                \
       }                                                                    \
       Kokkos::Profiling::popRegion();                                      \
     }                                                                      \

--- a/blas/tpls/KokkosBlas1_nrm1_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_nrm1_tpl_spec_decl.hpp
@@ -445,7 +445,7 @@ namespace Impl {
             rocblas_dasum(s.handle, N, X.data(), one, R.data()));              \
         KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL));     \
       } else {                                                                 \
-        Nrm1<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(space, R, X);                    \
+        Nrm1<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(space, R, X);  \
       }                                                                        \
       Kokkos::Profiling::popRegion();                                          \
     }                                                                          \
@@ -485,94 +485,96 @@ namespace Impl {
             rocblas_sasum(s.handle, N, X.data(), one, R.data()));             \
         KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL));    \
       } else {                                                                \
-        Nrm1<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(space, R, X);                   \
+        Nrm1<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(space, R, X); \
       }                                                                       \
       Kokkos::Profiling::popRegion();                                         \
     }                                                                         \
   };
 
-#define KOKKOSBLAS1_ZNRM1_TPL_SPEC_DECL_ROCBLAS(LAYOUT, MEMSPACE,           \
-                                                ETI_SPEC_AVAIL)             \
-  template <class ExecSpace>                                                \
-  struct Nrm1<ExecSpace, Kokkos::View<double, LAYOUT, Kokkos::HostSpace,               \
-                           Kokkos::MemoryTraits<Kokkos::Unmanaged> >,       \
-              Kokkos::View<const Kokkos::complex<double>*, LAYOUT,          \
-                           Kokkos::Device<ExecSpace, MEMSPACE>,             \
-                           Kokkos::MemoryTraits<Kokkos::Unmanaged> >,       \
-              1, true, ETI_SPEC_AVAIL> {                                    \
-    typedef Kokkos::View<double, LAYOUT, Kokkos::HostSpace,                 \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >          \
-        RV;                                                                 \
-    typedef Kokkos::View<const Kokkos::complex<double>*, LAYOUT,            \
-                         Kokkos::Device<ExecSpace, MEMSPACE>,               \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >          \
-        XV;                                                                 \
-    typedef typename XV::size_type size_type;                               \
-                                                                            \
-    static void nrm1(const ExecSpace& space, RV& R, const XV& X) {          \
-      Kokkos::Profiling::pushRegion(                                        \
-          "KokkosBlas::nrm1[TPL_ROCBLAS,complex<double>]");                 \
-      const size_type numElems = X.extent(0);                               \
-      if (numElems < static_cast<size_type>(INT_MAX)) {                     \
-        nrm1_print_specialization<RV, XV>();                                \
-        const int N       = static_cast<int>(numElems);                     \
-        constexpr int one = 1;                                              \
-        KokkosBlas::Impl::RocBlasSingleton& s =                             \
-            KokkosBlas::Impl::RocBlasSingleton::singleton();                \
-        KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                      \
-            rocblas_set_stream(s.handle, space.hip_stream()));              \
-        KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_dzasum(                       \
-            s.handle, N,                                                    \
-            reinterpret_cast<const rocblas_double_complex*>(X.data()), one, \
-            R.data()));                                                     \
-        KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL));  \
-      } else {                                                              \
-        Nrm1<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(space, R, X);                 \
-      }                                                                     \
-      Kokkos::Profiling::popRegion();                                       \
-    }                                                                       \
+#define KOKKOSBLAS1_ZNRM1_TPL_SPEC_DECL_ROCBLAS(LAYOUT, MEMSPACE,             \
+                                                ETI_SPEC_AVAIL)               \
+  template <class ExecSpace>                                                  \
+  struct Nrm1<ExecSpace,                                                      \
+              Kokkos::View<double, LAYOUT, Kokkos::HostSpace,                 \
+                           Kokkos::MemoryTraits<Kokkos::Unmanaged> >,         \
+              Kokkos::View<const Kokkos::complex<double>*, LAYOUT,            \
+                           Kokkos::Device<ExecSpace, MEMSPACE>,               \
+                           Kokkos::MemoryTraits<Kokkos::Unmanaged> >,         \
+              1, true, ETI_SPEC_AVAIL> {                                      \
+    typedef Kokkos::View<double, LAYOUT, Kokkos::HostSpace,                   \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >            \
+        RV;                                                                   \
+    typedef Kokkos::View<const Kokkos::complex<double>*, LAYOUT,              \
+                         Kokkos::Device<ExecSpace, MEMSPACE>,                 \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >            \
+        XV;                                                                   \
+    typedef typename XV::size_type size_type;                                 \
+                                                                              \
+    static void nrm1(const ExecSpace& space, RV& R, const XV& X) {            \
+      Kokkos::Profiling::pushRegion(                                          \
+          "KokkosBlas::nrm1[TPL_ROCBLAS,complex<double>]");                   \
+      const size_type numElems = X.extent(0);                                 \
+      if (numElems < static_cast<size_type>(INT_MAX)) {                       \
+        nrm1_print_specialization<RV, XV>();                                  \
+        const int N       = static_cast<int>(numElems);                       \
+        constexpr int one = 1;                                                \
+        KokkosBlas::Impl::RocBlasSingleton& s =                               \
+            KokkosBlas::Impl::RocBlasSingleton::singleton();                  \
+        KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                        \
+            rocblas_set_stream(s.handle, space.hip_stream()));                \
+        KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_dzasum(                         \
+            s.handle, N,                                                      \
+            reinterpret_cast<const rocblas_double_complex*>(X.data()), one,   \
+            R.data()));                                                       \
+        KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL));    \
+      } else {                                                                \
+        Nrm1<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(space, R, X); \
+      }                                                                       \
+      Kokkos::Profiling::popRegion();                                         \
+    }                                                                         \
   };
 
-#define KOKKOSBLAS1_CNRM1_TPL_SPEC_DECL_ROCBLAS(LAYOUT, MEMSPACE,          \
-                                                ETI_SPEC_AVAIL)            \
-  template <class ExecSpace>                                               \
-  struct Nrm1<ExecSpace, Kokkos::View<float, LAYOUT, Kokkos::HostSpace,               \
-                           Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
-              Kokkos::View<const Kokkos::complex<float>*, LAYOUT,          \
-                           Kokkos::Device<ExecSpace, MEMSPACE>,            \
-                           Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
-              1, true, ETI_SPEC_AVAIL> {                                   \
-    typedef Kokkos::View<float, LAYOUT, Kokkos::HostSpace,                 \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >         \
-        RV;                                                                \
-    typedef Kokkos::View<const Kokkos::complex<float>*, LAYOUT,            \
-                         Kokkos::Device<ExecSpace, MEMSPACE>,              \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >         \
-        XV;                                                                \
-    typedef typename XV::size_type size_type;                              \
-                                                                           \
-    static void nrm1(const ExecSpace& space, RV& R, const XV& X) {         \
-      Kokkos::Profiling::pushRegion(                                       \
-          "KokkosBlas::nrm1[TPL_ROCBLAS,complex<float>]");                 \
-      const size_type numElems = X.extent(0);                              \
-      if (numElems < static_cast<size_type>(INT_MAX)) {                    \
-        nrm1_print_specialization<RV, XV>();                               \
-        const int N       = static_cast<int>(numElems);                    \
-        constexpr int one = 1;                                             \
-        KokkosBlas::Impl::RocBlasSingleton& s =                            \
-            KokkosBlas::Impl::RocBlasSingleton::singleton();               \
-        KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                     \
-            rocblas_set_stream(s.handle, space.hip_stream()));             \
-        KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_scasum(                      \
-            s.handle, N,                                                   \
-            reinterpret_cast<const rocblas_float_complex*>(X.data()), one, \
-            R.data()));                                                    \
-        KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL)); \
-      } else {                                                             \
-        Nrm1<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(space, R, X);                \
-      }                                                                    \
-      Kokkos::Profiling::popRegion();                                      \
-    }                                                                      \
+#define KOKKOSBLAS1_CNRM1_TPL_SPEC_DECL_ROCBLAS(LAYOUT, MEMSPACE,             \
+                                                ETI_SPEC_AVAIL)               \
+  template <class ExecSpace>                                                  \
+  struct Nrm1<ExecSpace,                                                      \
+              Kokkos::View<float, LAYOUT, Kokkos::HostSpace,                  \
+                           Kokkos::MemoryTraits<Kokkos::Unmanaged> >,         \
+              Kokkos::View<const Kokkos::complex<float>*, LAYOUT,             \
+                           Kokkos::Device<ExecSpace, MEMSPACE>,               \
+                           Kokkos::MemoryTraits<Kokkos::Unmanaged> >,         \
+              1, true, ETI_SPEC_AVAIL> {                                      \
+    typedef Kokkos::View<float, LAYOUT, Kokkos::HostSpace,                    \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >            \
+        RV;                                                                   \
+    typedef Kokkos::View<const Kokkos::complex<float>*, LAYOUT,               \
+                         Kokkos::Device<ExecSpace, MEMSPACE>,                 \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >            \
+        XV;                                                                   \
+    typedef typename XV::size_type size_type;                                 \
+                                                                              \
+    static void nrm1(const ExecSpace& space, RV& R, const XV& X) {            \
+      Kokkos::Profiling::pushRegion(                                          \
+          "KokkosBlas::nrm1[TPL_ROCBLAS,complex<float>]");                    \
+      const size_type numElems = X.extent(0);                                 \
+      if (numElems < static_cast<size_type>(INT_MAX)) {                       \
+        nrm1_print_specialization<RV, XV>();                                  \
+        const int N       = static_cast<int>(numElems);                       \
+        constexpr int one = 1;                                                \
+        KokkosBlas::Impl::RocBlasSingleton& s =                               \
+            KokkosBlas::Impl::RocBlasSingleton::singleton();                  \
+        KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                        \
+            rocblas_set_stream(s.handle, space.hip_stream()));                \
+        KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_scasum(                         \
+            s.handle, N,                                                      \
+            reinterpret_cast<const rocblas_float_complex*>(X.data()), one,    \
+            R.data()));                                                       \
+        KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL));    \
+      } else {                                                                \
+        Nrm1<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(space, R, X); \
+      }                                                                       \
+      Kokkos::Profiling::popRegion();                                         \
+    }                                                                         \
   };
 
 KOKKOSBLAS1_DNRM1_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace,

--- a/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
@@ -257,8 +257,8 @@ namespace KokkosBlas {
 namespace Impl {
 
 #define KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(                               \
-    SCALAR_TYPE, ROCBLAS_SCALAR_TYPE, ROCBLAS_FN, LAYOUT, EXECSPACE,           \
-    MEMSPACE, ETI_SPEC_AVAIL)                                                  \
+    SCALAR_TYPE, ROCBLAS_SCALAR_TYPE, ROCBLAS_FN, LAYOUT, EXECSPACE, MEMSPACE, \
+    ETI_SPEC_AVAIL)                                                            \
   template <>                                                                  \
   struct Scal<                                                                 \
       EXECSPACE,                                                               \
@@ -318,21 +318,21 @@ namespace Impl {
                                           LAYOUT, EXECSPACE, MEMSPACE,       \
                                           ETI_SPEC_AVAIL)
 
-#define KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE,             \
-                                                MEMSPACE, ETI_SPEC_AVAIL)      \
+#define KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE, MEMSPACE,   \
+                                                ETI_SPEC_AVAIL)                \
   KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(float, float, rocblas_sscal, LAYOUT, \
                                           EXECSPACE, MEMSPACE, ETI_SPEC_AVAIL)
 
-#define KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE,            \
-                                                MEMSPACE, ETI_SPEC_AVAIL)     \
+#define KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE, MEMSPACE,  \
+                                                ETI_SPEC_AVAIL)               \
   KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(                                    \
       Kokkos::complex<double>, rocblas_double_complex, rocblas_zscal, LAYOUT, \
       EXECSPACE, MEMSPACE, ETI_SPEC_AVAIL)
 
-#define KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE,          \
-                                                MEMSPACE, ETI_SPEC_AVAIL)   \
-  KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(                                  \
-      Kokkos::complex<float>, rocblas_float_complex, rocblas_cscal, LAYOUT, \
+#define KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE, MEMSPACE, \
+                                                ETI_SPEC_AVAIL)              \
+  KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(                                   \
+      Kokkos::complex<float>, rocblas_float_complex, rocblas_cscal, LAYOUT,  \
       EXECSPACE, MEMSPACE, ETI_SPEC_AVAIL)
 
 KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIP,

--- a/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
@@ -258,7 +258,7 @@ namespace Impl {
 
 #define KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(                               \
     SCALAR_TYPE, ROCBLAS_SCALAR_TYPE, ROCBLAS_FN, LAYOUT, EXECSPACE,           \
-    MEMSPACE ETI_SPEC_AVAIL)                                                   \
+    MEMSPACE, ETI_SPEC_AVAIL)                                                  \
   template <>                                                                  \
   struct Scal<                                                                 \
       EXECSPACE,                                                               \
@@ -319,18 +319,18 @@ namespace Impl {
                                           ETI_SPEC_AVAIL)
 
 #define KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE,             \
-                                                MEMSPACE ETI_SPEC_AVAIL)       \
+                                                MEMSPACE, ETI_SPEC_AVAIL)      \
   KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(float, float, rocblas_sscal, LAYOUT, \
                                           EXECSPACE, MEMSPACE, ETI_SPEC_AVAIL)
 
 #define KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE,            \
-                                                MEMSPACE ETI_SPEC_AVAIL)      \
+                                                MEMSPACE, ETI_SPEC_AVAIL)     \
   KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(                                    \
       Kokkos::complex<double>, rocblas_double_complex, rocblas_zscal, LAYOUT, \
       EXECSPACE, MEMSPACE, ETI_SPEC_AVAIL)
 
 #define KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_ROCBLAS(LAYOUT, EXECSPACE,          \
-                                                MEMSPACE ETI_SPEC_AVAIL)    \
+                                                MEMSPACE, ETI_SPEC_AVAIL)   \
   KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(                                  \
       Kokkos::complex<float>, rocblas_float_complex, rocblas_cscal, LAYOUT, \
       EXECSPACE, MEMSPACE, ETI_SPEC_AVAIL)

--- a/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
@@ -306,7 +306,8 @@ namespace Impl {
         KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                         \
             rocblas_set_pointer_mode(s.handle, pointer_mode));                 \
       } else {                                                                 \
-        Scal<EXECSPACE, RV, AS, XV, 1, false, ETI_SPEC_AVAIL>::scal(space, R, alpha, X); \
+        Scal<EXECSPACE, RV, AS, XV, 1, false, ETI_SPEC_AVAIL>::scal(space, R,  \
+                                                                    alpha, X); \
       }                                                                        \
       Kokkos::Profiling::popRegion();                                          \
     }                                                                          \

--- a/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
@@ -262,21 +262,21 @@ namespace Impl {
   template <>                                                                  \
   struct Scal<                                                                 \
       EXECSPACE,                                                               \
-      Kokkos::View<SCALAR_TYPE*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,  \
+      Kokkos::View<SCALAR_TYPE*, LAYOUT, Kokkos::Device<EXECSPACE, MEMSPACE>,  \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       SCALAR_TYPE,                                                             \
       Kokkos::View<const SCALAR_TYPE*, LAYOUT,                                 \
-                   Kokkos::Device<ExecSpace, MEMSPACE>,                        \
+                   Kokkos::Device<EXECSPACE, MEMSPACE>,                        \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       1, true, ETI_SPEC_AVAIL> {                                               \
     using execution_space = EXECSPACE;                                         \
     typedef Kokkos::View<SCALAR_TYPE*, LAYOUT,                                 \
-                         Kokkos::Device<ExecSpace, MEMSPACE>,                  \
+                         Kokkos::Device<EXECSPACE, MEMSPACE>,                  \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         RV;                                                                    \
     typedef SCALAR_TYPE AS;                                                    \
     typedef Kokkos::View<const SCALAR_TYPE*, LAYOUT,                           \
-                         Kokkos::Device<ExecSpace, MEMSPACE>,                  \
+                         Kokkos::Device<EXECSPACE, MEMSPACE>,                  \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         XV;                                                                    \
     typedef typename XV::size_type size_type;                                  \
@@ -306,7 +306,7 @@ namespace Impl {
         KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                         \
             rocblas_set_pointer_mode(s.handle, pointer_mode));                 \
       } else {                                                                 \
-        Scal<RV, AS, XV, 1, false, ETI_SPEC_AVAIL>::scal(R, alpha, X);         \
+        Scal<EXECSPACE, RV, AS, XV, 1, false, ETI_SPEC_AVAIL>::scal(space, R, alpha, X); \
       }                                                                        \
       Kokkos::Profiling::popRegion();                                          \
     }                                                                          \

--- a/blas/tpls/KokkosBlas2_ger_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas2_ger_tpl_spec_avail.hpp
@@ -160,22 +160,20 @@ KOKKOSBLAS2_GER_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<float>,
 // rocBLAS
 #ifdef KOKKOSKERNELS_ENABLE_TPL_ROCBLAS
 
-#define KOKKOSBLAS2_GER_TPL_SPEC_AVAIL_ROCBLAS(SCALAR, LAYOUT, EXEC_SPACE, \
-                                               MEM_SPACE)                  \
-  template <>                                                              \
-      struct ger_tpl_spec_avail < \
-      EXEC_SPACE,                              \
-      Kokkos::View < const SCALAR*, LAYOUT,                                \
-                     Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >,            \
-      Kokkos::View < const SCALAR*, LAYOUT,                                \
-      Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >,            \
-      Kokkos::View<                                                        \
-          SCALAR**, LAYOUT,                                                \
-          Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                            \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {     \
-    enum : bool { value = true };                                          \
+#define KOKKOSBLAS2_GER_TPL_SPEC_AVAIL_ROCBLAS(SCALAR, LAYOUT, EXEC_SPACE,  \
+                                               MEM_SPACE)                   \
+  template <>                                                               \
+  struct ger_tpl_spec_avail<                                                \
+      EXEC_SPACE,                                                           \
+      Kokkos::View<const SCALAR*, LAYOUT,                                   \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                   \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
+      Kokkos::View<const SCALAR*, LAYOUT,                                   \
+                   Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                   \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {            \
+    enum : bool { value = true };                                           \
   };
 
 KOKKOSBLAS2_GER_TPL_SPEC_AVAIL_ROCBLAS(double, Kokkos::LayoutLeft, Kokkos::HIP,

--- a/blas/tpls/KokkosBlas2_ger_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas2_ger_tpl_spec_avail.hpp
@@ -163,16 +163,17 @@ KOKKOSBLAS2_GER_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<float>,
 #define KOKKOSBLAS2_GER_TPL_SPEC_AVAIL_ROCBLAS(SCALAR, LAYOUT, EXEC_SPACE, \
                                                MEM_SPACE)                  \
   template <>                                                              \
-      struct ger_tpl_spec_avail < EXEC_SPACE,                              \
+      struct ger_tpl_spec_avail < \
+      EXEC_SPACE,                              \
       Kokkos::View < const SCALAR*, LAYOUT,                                \
-      Kokkos::Device<EXEC_SPACE, MEM_SPACE,                                \
+                     Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >,            \
       Kokkos::View < const SCALAR*, LAYOUT,                                \
-      Kokkos::Device<EXEC_SPACE, MEM_SPACE,                                \
+      Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >,            \
       Kokkos::View<                                                        \
           SCALAR**, LAYOUT,                                                \
-          Kokkos::Device<EXEC_SPACE, MEM_SPACE,                            \
+          Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                            \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {     \
     enum : bool { value = true };                                          \
   };


### PR DESCRIPTION
A few more fixes to add commas missed in some macros

Resolves errors of type:
```
05:12:42 /home/jenkins/caraway-new/workspace/KokkosKernels_CarawayMI100_Rocm520_HipSerial_RocBlas_RocSparse/kokkos-kernels/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp:261:14: error: expected comma in macro parameter list
05:12:42     MEMSPACE ETI_SPEC_AVAIL) 
...
```