### PR TITLE
Fix errors and warnings in sems-rhel nighly

### DIFF
--- a/common/unit_test/Test_Common_LowerBound.hpp
+++ b/common/unit_test/Test_Common_LowerBound.hpp
@@ -190,12 +190,14 @@ void test_lower_bound() {
   test_lower_bound<T, Device>({0, 1, T(2.5), 3, 4, 5}, T(5));
   test_lower_bound<T, Device>({0, 1, T(2.5), 3, 4, 5}, T(6));
 
-  auto randn = [](T n) {
+  auto randn = [](T n) -> T {
+    T ret;
     if constexpr (std::is_floating_point_v<T>) {
-      return T(rand()) / T(RAND_MAX) * n;
+      ret = T(rand()) / T(RAND_MAX) * n;
     } else {
-      return T(rand()) % n;
+      ret = T(rand()) % n;
     }
+    return ret;
   };
 
   T maxEntry         = 20;

--- a/common/unit_test/Test_Common_UpperBound.hpp
+++ b/common/unit_test/Test_Common_UpperBound.hpp
@@ -181,12 +181,14 @@ void test_upper_bound() {
   test_upper_bound<T, Device>({0, 1, T(2.5), 3, 4, 5}, T(5));
   test_upper_bound<T, Device>({0, 1, T(2.5), 3, 4, 5}, T(6));
 
-  auto randn = [](T n) {
+  auto randn = [](T n) -> T {
+    T ret;
     if constexpr (std::is_floating_point_v<T>) {
-      return T(rand()) / T(RAND_MAX) * n;
+      ret = T(rand()) / T(RAND_MAX) * n;
     } else {
-      return T(rand()) % n;
+      ret = T(rand()) % n;
     }
+    return ret;
   };
 
   constexpr T maxEntry = 20;

--- a/sparse/unit_test/Test_Sparse_spmv_bsr.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv_bsr.hpp
@@ -115,10 +115,10 @@ Bsr bsr_random(const int blockSize, const int blockRows, const int blockCols) {
                      ordinal_type, size_type>
       rcs(blockRows, blockCols, scalar_type(0), max_a<scalar_type>());
 
-  const auto colids =
-      Kokkos::subview(rcs.get_ids(), Kokkos::pair{size_t(0), rcs.get_nnz()});
-  const auto vals =
-      Kokkos::subview(rcs.get_vals(), Kokkos::pair{size_t(0), rcs.get_nnz()});
+  const auto colids = Kokkos::subview(
+      rcs.get_ids(), Kokkos::make_pair(size_t(0), rcs.get_nnz()));
+  const auto vals = Kokkos::subview(
+      rcs.get_vals(), Kokkos::make_pair(size_t(0), rcs.get_nnz()));
   Graph graph(colids, rcs.get_map());
   Crs crs("crs", blockCols, vals, graph);
 


### PR DESCRIPTION
Fix errors and warnings in cuda 11.1/gcc 8.3.0 RHEL nightly builds.
- Errors: it looks like CTAD isn't working in 8.3, because "Kokkos::pair(...)" causes build error but "Kokkos::make_pair(...)" does not
- Warnings: 8.3 is also bad at figuring out that if both branches of "if constexpr" have return statements, that the function as a whole must end in a return