### PR TITLE
Support rocSparse in rocm 5.2.0

### DIFF
--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_avail.hpp
@@ -265,8 +265,7 @@ KOKKOSSPARSE_SPMV_MV_BSRMATRIX_TPL_SPEC_AVAIL_MKL(Kokkos::complex<double>,
     enum : bool { value = true };                                              \
   };
 
-// These things may also be valid before 5.4, but I haven't tested it.
-#if KOKKOSSPARSE_IMPL_ROCM_VERSION >= 50400
+#if KOKKOSSPARSE_IMPL_ROCM_VERSION >= 50200
 
 KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_ROCSPARSE(float, rocsparse_int,
                                                      rocsparse_int,
@@ -305,7 +304,7 @@ KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_ROCSPARSE(Kokkos::complex<double>,
                                                      Kokkos::LayoutRight,
                                                      Kokkos::HIPSpace)
 
-#endif  // KOKKOSSPARSE_IMPL_ROCM_VERSION >= 50400
+#endif  // KOKKOSSPARSE_IMPL_ROCM_VERSION >= 50200
 
 #undef KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_ROCSPARSE
 


### PR DESCRIPTION
Trying to close https://github.com/kokkos/kokkos-kernels/issues/1829

Don't use the `*_ex*` functions before rocm 5.4.0