### PR TITLE
Add `rocsparse,rocblas,` to enabled TPLs in `cm_test_all_sandia` when `--spot-check-tpls`

### DIFF
--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -1052,6 +1052,9 @@ setup_env() {
       NEW_TPL_LIST="cublas,cusparse,"
       export KOKKOS_CUDA_OPTIONS="${KOKKOS_CUDA_OPTIONS},enable_lambda"
     fi
+    if [[ "$compiler" == rocm* ]]; then
+      NEW_TPL_LIST="rocblas,rocsparse,"
+    fi
     # host tpls - use mkl with intel, else use host blas
     if [[ "$compiler" == intel* ]]; then
       NEW_TPL_LIST="mkl,"


### PR DESCRIPTION
`cm_generate_makefile` already knows what to do with these TPLs, but `cm_test_all_sandia` was not telling it to turn them on.