### PR TITLE
KokkosKernels: Remove non-existent common/src/[impl,tpls] include dirs (trilinos/Trilinos#11545)

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,7 +1,5 @@
 # Adding source directory to the build
 LIST(APPEND KK_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/common/src)
-LIST(APPEND KK_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/common/src/impl)
-LIST(APPEND KK_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/common/src/tpls)
 LIST(APPEND KK_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/common/unit_test)
 
 # Adding unit-tests


### PR DESCRIPTION
This matches the commit https://github.com/trilinos/Trilinos/pull/11863/commits/29fab02654a91f093ecbcecc325f7e9243ecde11 in Trilinos PR:

* https://github.com/trilinos/Trilinos/pull/11863

See the commit message for more details.
