### PR TITLE
Update cmake option naming in docs/comments

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -192,7 +192,7 @@ endif()
   * Whether to pre instantiate kernels for the scalar type double.  This option is KokkosKernels_INST_DOUBLE=ON by default.  Disabling this may increase build times.
   * Default: ON
 * KokkosKernels_INST_EXECSPACE_OPENMP: BOOL
-  * Whether to pre instantiate kernels for the execution space Kokkos::OpenMP.  Disabling this when Kokkos_ENABLE_OpenMP is enabled may increase build times.
+  * Whether to pre instantiate kernels for the execution space Kokkos::OpenMP.  Disabling this when Kokkos_ENABLE_OPENMP is enabled may increase build times.
   * Default: ON if Kokkos is OpenMP-enabled, OFF otherwise.
 * KokkosKernels_INST_EXECSPACE_SERIAL: BOOL
   * Whether to build kernels for the execution space Kokkos::Serial.  If explicit template instantiation (ETI) is enabled in Trilinos, disabling this when Kokkos_ENABLE_SERIAL is enabled may increase build times.

--- a/cmake/kokkoskernels_eti_devices.cmake
+++ b/cmake/kokkoskernels_eti_devices.cmake
@@ -127,7 +127,7 @@ IF(KOKKOS_ENABLE_OPENMPTARGET)
    INST_EXECSPACE_OPENMPTARGET
    ${KOKKOSKERNELS_INST_EXECSPACE_OPENMPTARGET_DEFAULT}
    BOOL
-   "Whether to pre instantiate kernels for the execution space Kokkos::Experimental::OpenMPTarget. Disabling this when Kokkos_ENABLE_OpenMPTarget is enabled may increase build times. Default: ON if Kokkos is OpenMPTarget-enabled, OFF otherwise."
+   "Whether to pre instantiate kernels for the execution space Kokkos::Experimental::OpenMPTarget. Disabling this when Kokkos_ENABLE_OPENMPTARGET is enabled may increase build times. Default: ON if Kokkos is OpenMPTarget-enabled, OFF otherwise."
    )
  KOKKOSKERNELS_ADD_OPTION(
    INST_MEMSPACE_OPENMPTARGETSPACE
@@ -163,7 +163,7 @@ KOKKOSKERNELS_ADD_OPTION(
   INST_EXECSPACE_OPENMP
   ${KOKKOSKERNELS_INST_EXECSPACE_OPENMP_DEFAULT}
   BOOL
-  "Whether to pre instantiate kernels for the execution space Kokkos::OpenMP.  Disabling this when Kokkos_ENABLE_OpenMP is enabled may increase build times. Default: ON if Kokkos is OpenMP-enabled, OFF otherwise."
+  "Whether to pre instantiate kernels for the execution space Kokkos::OpenMP.  Disabling this when Kokkos_ENABLE_OPENMP is enabled may increase build times. Default: ON if Kokkos is OpenMP-enabled, OFF otherwise."
 )
 IF(KOKKOSKERNELS_INST_EXECSPACE_OPENMP AND KOKKOSKERNELS_INST_MEMSPACE_HOSTSPACE)
   LIST(APPEND DEVICE_LIST "<OpenMP,HostSpace>")


### PR DESCRIPTION
Kokkos_ENABLE_OpenMP* to Kokkos_ENALBE_OPENMP*

Related to trilinos/Trilinos#11930 and kokkos/kokkos#6138