### PR TITLE
Benchmark cleanup for par_ilut and spmv

### DIFF
--- a/common/src/KokkosKernels_Error.hpp
+++ b/common/src/KokkosKernels_Error.hpp
@@ -62,6 +62,8 @@ inline void hip_internal_safe_call(hipError_t e, const char *name,
  *
  * For _MSG checks, the msg argument can contain '<<' if not a kernel check.
  *
+ * KK_USER_REQUIRE* are for checking user inputs
+ *
  * This code is adapted from EKAT/src/ekat/ekat_assert.hpp
  */
 
@@ -102,6 +104,10 @@ inline void hip_internal_safe_call(hipError_t e, const char *name,
 #define KK_REQUIRE(condition) IMPL_THROW(condition, "", std::logic_error)
 #define KK_REQUIRE_MSG(condition, msg) \
   IMPL_THROW(condition, msg, std::logic_error)
+
+#define KK_USER_REQUIRE(condition) IMPL_THROW(condition, "", std::runtime_error)
+#define KK_USER_REQUIRE_MSG(condition, msg) \
+  IMPL_THROW(condition, msg, std::runtime_error)
 
 #define KK_KERNEL_REQUIRE(condition) IMPL_KERNEL_THROW(condition, "")
 #define KK_KERNEL_REQUIRE_MSG(condition, msg) IMPL_KERNEL_THROW(condition, msg)

--- a/perf_test/sparse/CMakeLists.txt
+++ b/perf_test/sparse/CMakeLists.txt
@@ -117,20 +117,20 @@ KOKKOSKERNELS_ADD_EXECUTABLE(
 )
 
 if (KokkosKernels_ENABLE_BENCHMARK)
-#   KOKKOSKERNELS_ADD_BENCHMARK(
-#     sparse_par_ilut
-#     SOURCES KokkosSparse_par_ilut.cpp
-#   )
+  KOKKOSKERNELS_ADD_BENCHMARK(
+    sparse_par_ilut
+    SOURCES KokkosSparse_par_ilut.cpp
+  )
 
-#   # Provide -DGinkgo_DIR to cmake to enable the ginkgo test in sparse_par_ilut. Ginkgo_DIR should
-#   # point to the dir in the ginkgo install area that contains the GinkgoConfig.cmake file.
-#   # For me, this was $gingko_install_dir/lib64/cmake/Ginkgo
-#   if (Ginkgo_DIR)
-#     find_package(Ginkgo REQUIRED)
+  # Provide -DGinkgo_DIR to cmake to enable the ginkgo test in sparse_par_ilut. Ginkgo_DIR should
+  # point to the dir in the ginkgo install area that contains the GinkgoConfig.cmake file.
+  # For me, this was $gingko_install_dir/lib64/cmake/Ginkgo
+  if (Ginkgo_DIR)
+    find_package(Ginkgo REQUIRED)
 
-#     target_compile_definitions(KokkosKernels_sparse_par_ilut PRIVATE "USE_GINKGO")
-#     target_link_libraries(KokkosKernels_sparse_par_ilut PRIVATE Ginkgo::ginkgo)
-#   endif()
+    target_compile_definitions(KokkosKernels_sparse_par_ilut PRIVATE "USE_GINKGO")
+    target_link_libraries(KokkosKernels_sparse_par_ilut PRIVATE Ginkgo::ginkgo)
+  endif()
 
   KOKKOSKERNELS_ADD_BENCHMARK(
     sparse_spmv_benchmark SOURCES KokkosSparse_spmv_benchmark.cpp


### PR DESCRIPTION
1) Make better use of google benchmark in par_ilut benchmark
2) Re-enable par_ilut benchmark, warnings should be fixed
3) Add new KK_USER_REQUIRE macros to KokkosKernels_Error. Makes it
   convenient to check and throw a good exception for user errors.
4) Fix option help in spmv benchmark (was saying -s instead of -n)
5) Fix option parsing in spmv benchmark. Bad options were printed to cerr
   but program execution was not halted.
6) Fix google bm argument list in spmv benchmark. It was always reporting
   n=100000 even when that was not the case. It will still report an incorrect
   n if an input A is used, but this is a step in the right direction. This
   requires run_spmv to a spmv_parameters object instead of argc/argv.
7) Use register_benchmark_real_time in spmv benchmark. The code there was identical
   to it.