### PR TITLE
KokkosKernels: Don't list include for non-existant 'batched' build dir (trilinos/Trilinos#11966)

### DIFF
--- a/batched/CMakeLists.txt
+++ b/batched/CMakeLists.txt
@@ -17,9 +17,18 @@ IF (NOT KokkosKernels_ENABLE_COMPONENT_BLAS)
   LIST(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/batched/KokkosBatched_Util.cpp)
 ENDIF()
 
-# Adding unit-tests
-KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/batched)
-KOKKOSKERNELS_INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_CURRENT_SOURCE_DIR}/batched)
+IF(KokkosKernels_ENABLE_TESTS OR KokkosKernels_ENABLE_TESTS_AND_PERFSUITE)
+  # Adding unit-tests
+  KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/batched)
+  KOKKOSKERNELS_INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING
+    ${CMAKE_CURRENT_SOURCE_DIR}/batched)
+ENDIF()
+# NOTE: Above, the build directory 'batched' is not created unless unit tests
+# are actually enabled (which are actually included from the base-level
+# CMakeLists.txt file).  And the KokkosKernelsTargets.cmake file that gets
+# generated from this CMake package in the build dir will be broken if these
+# are listed in the `INTERFACE_INCLUDE_DIRECTORIES` property when the build
+# `batched` is not created (see Trilinos PR #11966).
 
 KOKKOSKERNELS_GENERATE_ETI(Batched_Gemm_nt_nt_bll Gemm
   COMPONENTS  batched


### PR DESCRIPTION
This matches the commit https://github.com/bartlettroscoe/kokkos-kernels/commit/aee776e44588481b2b99cb047c1b572f77c66ef7 in Trilinos PR:

* https://github.com/trilinos/Trilinos/pull/11966

This is a clear defect that just happens to not cause a problem unless you try to use the KokkosKernelsTargets.cmake file generated for the build dir (see https://github.com/trilinos/Trilinos/pull/11966#issuecomment-1590146876).

See the log message and embedded comment for more details.

