### PR TITLE
MKL: support indices properly

### DIFF
--- a/blas/tpls/KokkosBlas2_serial_gemv_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas2_serial_gemv_tpl_spec_decl.hpp
@@ -19,7 +19,7 @@
 #include "KokkosBlas_util.hpp"
 #include "KokkosBatched_Vector.hpp"
 
-#if defined(KOKKOSKERNELS_ENABLE_TPL_MKL)
+#if defined(KOKKOSKERNELS_ENABLE_TPL_MKL) && !defined(KOKKOS_ENABLE_SYCL)
 #include "mkl_version.h"
 #if __INTEL_MKL__ >= 2018
 #define __KOKKOSBLAS_ENABLE_INTEL_MKL_COMPACT__ 1

--- a/perf_test/sparse/KokkosSparse_spadd.cpp
+++ b/perf_test/sparse/KokkosSparse_spadd.cpp
@@ -338,7 +338,8 @@ void run_experiment(int argc, char** argv, CommonInputParams) {
           (int*)B.graph.row_map.data() + 1, B.graph.entries.data(),
           B.values.data()));
     } else {
-      throw std::runtime_error("MKL configured with long long int not supported in Kokkos Kernels");
+      throw std::runtime_error(
+          "MKL configured with long long int not supported in Kokkos Kernels");
     }
   }
 #endif

--- a/perf_test/sparse/KokkosSparse_spadd.cpp
+++ b/perf_test/sparse/KokkosSparse_spadd.cpp
@@ -328,14 +328,18 @@ void run_experiment(int argc, char** argv, CommonInputParams) {
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
   sparse_matrix_t Amkl, Bmkl, Cmkl;
   if (params.use_mkl) {
-    KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_d_create_csr(
-        &Amkl, SPARSE_INDEX_BASE_ZERO, m, n, (int*)A.graph.row_map.data(),
-        (int*)A.graph.row_map.data() + 1, A.graph.entries.data(),
-        A.values.data()));
-    KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_d_create_csr(
-        &Bmkl, SPARSE_INDEX_BASE_ZERO, m, n, (int*)B.graph.row_map.data(),
-        (int*)B.graph.row_map.data() + 1, B.graph.entries.data(),
-        B.values.data()));
+    if constexpr (std::is_same_v<int, MKL_INT>) {
+      KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_d_create_csr(
+          &Amkl, SPARSE_INDEX_BASE_ZERO, m, n, (int*)A.graph.row_map.data(),
+          (int*)A.graph.row_map.data() + 1, A.graph.entries.data(),
+          A.values.data()));
+      KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_d_create_csr(
+          &Bmkl, SPARSE_INDEX_BASE_ZERO, m, n, (int*)B.graph.row_map.data(),
+          (int*)B.graph.row_map.data() + 1, B.graph.entries.data(),
+          B.values.data()));
+    } else {
+      throw std::runtime_error("MKL configured with long long int not supported in Kokkos Kernels");
+    }
   }
 #endif
 

--- a/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_avail.hpp
@@ -63,18 +63,21 @@ SPGEMM_NOREUSE_AVAIL_CUSPARSE_S(Kokkos::complex<double>)
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
-#define SPGEMM_NOREUSE_AVAIL_MKL(SCALAR, EXEC)                              \
-  template <>                                                               \
-  struct spgemm_noreuse_tpl_spec_avail<                                     \
-      KokkosSparse::CrsMatrix<                                              \
-          SCALAR, MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, void, MKL_INT>, \
-      KokkosSparse::CrsMatrix<                                              \
-          const SCALAR, const MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>,              \
-      KokkosSparse::CrsMatrix<                                              \
-          const SCALAR, const MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>> {            \
-    enum : bool { value = true };                                           \
+#define SPGEMM_NOREUSE_AVAIL_MKL(SCALAR, EXEC)                               \
+  template <>                                                                \
+  struct spgemm_noreuse_tpl_spec_avail<                                      \
+      KokkosSparse::CrsMatrix<SCALAR, MKL_INT,                               \
+                              Kokkos::Device<EXEC, Kokkos::HostSpace>, void, \
+                              MKL_INT>,                                      \
+      KokkosSparse::CrsMatrix<const SCALAR, const MKL_INT,                   \
+                              Kokkos::Device<EXEC, Kokkos::HostSpace>,       \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,       \
+                              const MKL_INT>,                                \
+      KokkosSparse::CrsMatrix<const SCALAR, const MKL_INT,                   \
+                              Kokkos::Device<EXEC, Kokkos::HostSpace>,       \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,       \
+                              const MKL_INT>> {                              \
+    enum : bool { value = true };                                            \
   };
 
 #define SPGEMM_NOREUSE_AVAIL_MKL_E(EXEC)                 \

--- a/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_avail.hpp
@@ -19,6 +19,10 @@
 #ifndef KOKKOSPARSE_SPGEMM_NOREUSE_TPL_SPEC_AVAIL_HPP_
 #define KOKKOSPARSE_SPGEMM_NOREUSE_TPL_SPEC_AVAIL_HPP_
 
+#ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
+#include "mkl.h"
+#endif
+
 namespace KokkosSparse {
 namespace Impl {
 
@@ -63,13 +67,13 @@ SPGEMM_NOREUSE_AVAIL_CUSPARSE_S(Kokkos::complex<double>)
   template <>                                                               \
   struct spgemm_noreuse_tpl_spec_avail<                                     \
       KokkosSparse::CrsMatrix<                                              \
-          SCALAR, int, Kokkos::Device<EXEC, Kokkos::HostSpace>, void, int>, \
+          SCALAR, MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, void, MKL_INT>, \
       KokkosSparse::CrsMatrix<                                              \
-          const SCALAR, const int, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const int>,              \
+          const SCALAR, const MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>,              \
       KokkosSparse::CrsMatrix<                                              \
-          const SCALAR, const int, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const int>> {            \
+          const SCALAR, const MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>> {            \
     enum : bool { value = true };                                           \
   };
 

--- a/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_decl.hpp
@@ -226,33 +226,39 @@ Matrix spgemm_noreuse_mkl(const MatrixConst &A, const MatrixConst &B) {
   return Matrix("C", m, k, c_nnz, valuesC, row_mapC, entriesC);
 }
 
-#define SPGEMM_NOREUSE_DECL_MKL(SCALAR, EXEC, TPL_AVAIL)                     \
-  template <>                                                                \
-  struct SPGEMM_NOREUSE<                                                     \
-      KokkosSparse::CrsMatrix<                                               \
-          SCALAR, MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, void, MKL_INT>,  \
-      KokkosSparse::CrsMatrix<                                               \
-          const SCALAR, const MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>,               \
-      KokkosSparse::CrsMatrix<                                               \
-          const SCALAR, const MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>,               \
-      true, TPL_AVAIL> {                                                     \
-    using Matrix = KokkosSparse::CrsMatrix<                                  \
-        SCALAR, MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, void, MKL_INT>;    \
-    using ConstMatrix = KokkosSparse::CrsMatrix<                             \
-        const SCALAR, const MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>,    \
-        Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>;                 \
-    static KokkosSparse::CrsMatrix<                                          \
-        SCALAR, MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, void, MKL_INT>     \
-    spgemm_noreuse(const ConstMatrix &A, bool, const ConstMatrix &B, bool) { \
-      std::string label = "KokkosSparse::spgemm_noreuse[TPL_MKL," +          \
-                          Kokkos::ArithTraits<SCALAR>::name() + "]";         \
-      Kokkos::Profiling::pushRegion(label);                                  \
-      Matrix C = spgemm_noreuse_mkl<Matrix>(A, B);                           \
-      Kokkos::Profiling::popRegion();                                        \
-      return C;                                                              \
-    }                                                                        \
+#define SPGEMM_NOREUSE_DECL_MKL(SCALAR, EXEC, TPL_AVAIL)                       \
+  template <>                                                                  \
+  struct SPGEMM_NOREUSE<                                                       \
+      KokkosSparse::CrsMatrix<SCALAR, MKL_INT,                                 \
+                              Kokkos::Device<EXEC, Kokkos::HostSpace>, void,   \
+                              MKL_INT>,                                        \
+      KokkosSparse::CrsMatrix<const SCALAR, const MKL_INT,                     \
+                              Kokkos::Device<EXEC, Kokkos::HostSpace>,         \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,         \
+                              const MKL_INT>,                                  \
+      KokkosSparse::CrsMatrix<const SCALAR, const MKL_INT,                     \
+                              Kokkos::Device<EXEC, Kokkos::HostSpace>,         \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,         \
+                              const MKL_INT>,                                  \
+      true, TPL_AVAIL> {                                                       \
+    using Matrix =                                                             \
+        KokkosSparse::CrsMatrix<SCALAR, MKL_INT,                               \
+                                Kokkos::Device<EXEC, Kokkos::HostSpace>, void, \
+                                MKL_INT>;                                      \
+    using ConstMatrix = KokkosSparse::CrsMatrix<                               \
+        const SCALAR, const MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
+        Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>;               \
+    static KokkosSparse::CrsMatrix<SCALAR, MKL_INT,                            \
+                                   Kokkos::Device<EXEC, Kokkos::HostSpace>,    \
+                                   void, MKL_INT>                              \
+    spgemm_noreuse(const ConstMatrix &A, bool, const ConstMatrix &B, bool) {   \
+      std::string label = "KokkosSparse::spgemm_noreuse[TPL_MKL," +            \
+                          Kokkos::ArithTraits<SCALAR>::name() + "]";           \
+      Kokkos::Profiling::pushRegion(label);                                    \
+      Matrix C = spgemm_noreuse_mkl<Matrix>(A, B);                             \
+      Kokkos::Profiling::popRegion();                                          \
+      return C;                                                                \
+    }                                                                          \
   };
 
 #define SPGEMM_NOREUSE_DECL_MKL_SE(SCALAR, EXEC) \

--- a/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_decl.hpp
@@ -230,21 +230,21 @@ Matrix spgemm_noreuse_mkl(const MatrixConst &A, const MatrixConst &B) {
   template <>                                                                \
   struct SPGEMM_NOREUSE<                                                     \
       KokkosSparse::CrsMatrix<                                               \
-          SCALAR, int, Kokkos::Device<EXEC, Kokkos::HostSpace>, void, int>,  \
+          SCALAR, MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, void, MKL_INT>,  \
       KokkosSparse::CrsMatrix<                                               \
-          const SCALAR, const int, Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const int>,               \
+          const SCALAR, const MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>,               \
       KokkosSparse::CrsMatrix<                                               \
-          const SCALAR, const int, Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const int>,               \
+          const SCALAR, const MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>,               \
       true, TPL_AVAIL> {                                                     \
     using Matrix = KokkosSparse::CrsMatrix<                                  \
-        SCALAR, int, Kokkos::Device<EXEC, Kokkos::HostSpace>, void, int>;    \
+        SCALAR, MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, void, MKL_INT>;    \
     using ConstMatrix = KokkosSparse::CrsMatrix<                             \
-        const SCALAR, const int, Kokkos::Device<EXEC, Kokkos::HostSpace>,    \
-        Kokkos::MemoryTraits<Kokkos::Unmanaged>, const int>;                 \
+        const SCALAR, const MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>,    \
+        Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>;                 \
     static KokkosSparse::CrsMatrix<                                          \
-        SCALAR, int, Kokkos::Device<EXEC, Kokkos::HostSpace>, void, int>     \
+        SCALAR, MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, void, MKL_INT>     \
     spgemm_noreuse(const ConstMatrix &A, bool, const ConstMatrix &B, bool) { \
       std::string label = "KokkosSparse::spgemm_noreuse[TPL_MKL," +          \
                           Kokkos::ArithTraits<SCALAR>::name() + "]";         \

--- a/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_avail.hpp
@@ -19,6 +19,10 @@
 #ifndef KOKKOSPARSE_SPGEMM_NUMERIC_TPL_SPEC_AVAIL_HPP_
 #define KOKKOSPARSE_SPGEMM_NUMERIC_TPL_SPEC_AVAIL_HPP_
 
+#ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
+#include "mkl.h"
+#endif
+
 namespace KokkosSparse {
 namespace Impl {
 
@@ -133,30 +137,30 @@ SPGEMM_NUMERIC_AVAIL_ROCSPARSE(Kokkos::complex<double>)
   template <>                                                          \
   struct spgemm_numeric_tpl_spec_avail<                                \
       KokkosKernels::Experimental::KokkosKernelsHandle<                \
-          const int, const int, const SCALAR, EXEC, Kokkos::HostSpace, \
+          const MKL_INT, const MKL_INT, const SCALAR, EXEC, Kokkos::HostSpace, \
           Kokkos::HostSpace>,                                          \
-      Kokkos::View<const int *, default_layout,                        \
+      Kokkos::View<const MKL_INT *, default_layout,                        \
                    Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<const int *, default_layout,                        \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<const SCALAR *, default_layout,                     \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<const int *, default_layout,                        \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<const int *, default_layout,                        \
+      Kokkos::View<const MKL_INT *, default_layout,                        \
                    Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
       Kokkos::View<const SCALAR *, default_layout,                     \
                    Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<const int *, default_layout,                        \
+      Kokkos::View<const MKL_INT *, default_layout,                        \
                    Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<int *, default_layout,                              \
+      Kokkos::View<const MKL_INT *, default_layout,                        \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
+      Kokkos::View<const SCALAR *, default_layout,                     \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
+      Kokkos::View<const MKL_INT *, default_layout,                        \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
+      Kokkos::View<MKL_INT *, default_layout,                              \
                    Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
       Kokkos::View<SCALAR *, default_layout,                           \

--- a/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_avail.hpp
@@ -133,40 +133,40 @@ SPGEMM_NUMERIC_AVAIL_ROCSPARSE(Kokkos::complex<double>)
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
-#define SPGEMM_NUMERIC_AVAIL_MKL(SCALAR, EXEC)                         \
-  template <>                                                          \
-  struct spgemm_numeric_tpl_spec_avail<                                \
-      KokkosKernels::Experimental::KokkosKernelsHandle<                \
+#define SPGEMM_NUMERIC_AVAIL_MKL(SCALAR, EXEC)                                 \
+  template <>                                                                  \
+  struct spgemm_numeric_tpl_spec_avail<                                        \
+      KokkosKernels::Experimental::KokkosKernelsHandle<                        \
           const MKL_INT, const MKL_INT, const SCALAR, EXEC, Kokkos::HostSpace, \
-          Kokkos::HostSpace>,                                          \
-      Kokkos::View<const MKL_INT *, default_layout,                        \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<const MKL_INT *, default_layout,                        \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<const SCALAR *, default_layout,                     \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<const MKL_INT *, default_layout,                        \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<const MKL_INT *, default_layout,                        \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<const SCALAR *, default_layout,                     \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<const MKL_INT *, default_layout,                        \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<MKL_INT *, default_layout,                              \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<SCALAR *, default_layout,                           \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {       \
-    enum : bool { value = true };                                      \
+          Kokkos::HostSpace>,                                                  \
+      Kokkos::View<const MKL_INT *, default_layout,                            \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
+      Kokkos::View<const MKL_INT *, default_layout,                            \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
+      Kokkos::View<const SCALAR *, default_layout,                             \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
+      Kokkos::View<const MKL_INT *, default_layout,                            \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
+      Kokkos::View<const MKL_INT *, default_layout,                            \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
+      Kokkos::View<const SCALAR *, default_layout,                             \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
+      Kokkos::View<const MKL_INT *, default_layout,                            \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
+      Kokkos::View<MKL_INT *, default_layout,                                  \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
+      Kokkos::View<SCALAR *, default_layout,                                   \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {               \
+    enum : bool { value = true };                                              \
   };
 
 #define SPGEMM_NUMERIC_AVAIL_MKL_E(EXEC)                 \

--- a/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_decl.hpp
@@ -553,30 +553,30 @@ void spgemm_numeric_mkl(
 #define SPGEMM_NUMERIC_DECL_MKL(SCALAR, EXEC, TPL_AVAIL)                       \
   template <>                                                                  \
   struct SPGEMM_NUMERIC<KokkosKernels::Experimental::KokkosKernelsHandle<      \
-                            const MKL_INT, const MKL_INT, const SCALAR, EXEC,          \
+                            const MKL_INT, const MKL_INT, const SCALAR, EXEC,  \
                             Kokkos::HostSpace, Kokkos::HostSpace>,             \
-                        Kokkos::View<const MKL_INT *, default_layout,              \
+                        Kokkos::View<const MKL_INT *, default_layout,          \
                                      Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-                        Kokkos::View<const MKL_INT *, default_layout,              \
-                                     Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-                        Kokkos::View<const SCALAR *, default_layout,           \
-                                     Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-                        Kokkos::View<const MKL_INT *, default_layout,              \
-                                     Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-                        Kokkos::View<const MKL_INT *, default_layout,              \
+                        Kokkos::View<const MKL_INT *, default_layout,          \
                                      Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
                         Kokkos::View<const SCALAR *, default_layout,           \
                                      Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-                        Kokkos::View<const MKL_INT *, default_layout,              \
+                        Kokkos::View<const MKL_INT *, default_layout,          \
                                      Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-                        Kokkos::View<MKL_INT *, default_layout,                    \
+                        Kokkos::View<const MKL_INT *, default_layout,          \
+                                     Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
+                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+                        Kokkos::View<const SCALAR *, default_layout,           \
+                                     Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
+                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+                        Kokkos::View<const MKL_INT *, default_layout,          \
+                                     Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
+                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+                        Kokkos::View<MKL_INT *, default_layout,                \
                                      Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
                         Kokkos::View<SCALAR *, default_layout,                 \
@@ -584,13 +584,13 @@ void spgemm_numeric_mkl(
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
                         true, TPL_AVAIL> {                                     \
     using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<     \
-        const MKL_INT, const MKL_INT, const SCALAR, EXEC, Kokkos::HostSpace,           \
+        const MKL_INT, const MKL_INT, const SCALAR, EXEC, Kokkos::HostSpace,   \
         Kokkos::HostSpace>;                                                    \
     using c_int_view_t =                                                       \
-        Kokkos::View<const MKL_INT *, default_layout,                              \
+        Kokkos::View<const MKL_INT *, default_layout,                          \
                      Kokkos::Device<EXEC, Kokkos::HostSpace>,                  \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                 \
-    using int_view_t = Kokkos::View<MKL_INT *, default_layout,                     \
+    using int_view_t = Kokkos::View<MKL_INT *, default_layout,                 \
                                     Kokkos::Device<EXEC, Kokkos::HostSpace>,   \
                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;  \
     using c_scalar_view_t =                                                    \

--- a/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_decl.hpp
@@ -553,30 +553,30 @@ void spgemm_numeric_mkl(
 #define SPGEMM_NUMERIC_DECL_MKL(SCALAR, EXEC, TPL_AVAIL)                       \
   template <>                                                                  \
   struct SPGEMM_NUMERIC<KokkosKernels::Experimental::KokkosKernelsHandle<      \
-                            const int, const int, const SCALAR, EXEC,          \
+                            const MKL_INT, const MKL_INT, const SCALAR, EXEC,          \
                             Kokkos::HostSpace, Kokkos::HostSpace>,             \
-                        Kokkos::View<const int *, default_layout,              \
+                        Kokkos::View<const MKL_INT *, default_layout,              \
                                      Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-                        Kokkos::View<const int *, default_layout,              \
-                                     Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-                        Kokkos::View<const SCALAR *, default_layout,           \
-                                     Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-                        Kokkos::View<const int *, default_layout,              \
-                                     Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-                        Kokkos::View<const int *, default_layout,              \
+                        Kokkos::View<const MKL_INT *, default_layout,              \
                                      Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
                         Kokkos::View<const SCALAR *, default_layout,           \
                                      Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-                        Kokkos::View<const int *, default_layout,              \
+                        Kokkos::View<const MKL_INT *, default_layout,              \
                                      Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-                        Kokkos::View<int *, default_layout,                    \
+                        Kokkos::View<const MKL_INT *, default_layout,              \
+                                     Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
+                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+                        Kokkos::View<const SCALAR *, default_layout,           \
+                                     Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
+                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+                        Kokkos::View<const MKL_INT *, default_layout,              \
+                                     Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
+                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+                        Kokkos::View<MKL_INT *, default_layout,                    \
                                      Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
                         Kokkos::View<SCALAR *, default_layout,                 \
@@ -584,13 +584,13 @@ void spgemm_numeric_mkl(
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
                         true, TPL_AVAIL> {                                     \
     using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<     \
-        const int, const int, const SCALAR, EXEC, Kokkos::HostSpace,           \
+        const MKL_INT, const MKL_INT, const SCALAR, EXEC, Kokkos::HostSpace,           \
         Kokkos::HostSpace>;                                                    \
     using c_int_view_t =                                                       \
-        Kokkos::View<const int *, default_layout,                              \
+        Kokkos::View<const MKL_INT *, default_layout,                              \
                      Kokkos::Device<EXEC, Kokkos::HostSpace>,                  \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                 \
-    using int_view_t = Kokkos::View<int *, default_layout,                     \
+    using int_view_t = Kokkos::View<MKL_INT *, default_layout,                     \
                                     Kokkos::Device<EXEC, Kokkos::HostSpace>,   \
                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;  \
     using c_scalar_view_t =                                                    \

--- a/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_avail.hpp
@@ -105,28 +105,28 @@ SPGEMM_SYMBOLIC_AVAIL_ROCSPARSE(Kokkos::complex<double>)
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
-#define SPGEMM_SYMBOLIC_AVAIL_MKL(SCALAR, EXEC)                        \
-  template <>                                                          \
-  struct spgemm_symbolic_tpl_spec_avail<                               \
-      KokkosKernels::Experimental::KokkosKernelsHandle<                \
+#define SPGEMM_SYMBOLIC_AVAIL_MKL(SCALAR, EXEC)                                \
+  template <>                                                                  \
+  struct spgemm_symbolic_tpl_spec_avail<                                       \
+      KokkosKernels::Experimental::KokkosKernelsHandle<                        \
           const MKL_INT, const MKL_INT, const SCALAR, EXEC, Kokkos::HostSpace, \
-          Kokkos::HostSpace>,                                          \
-      Kokkos::View<const MKL_INT *, default_layout,                        \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<const MKL_INT *, default_layout,                        \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<const MKL_INT *, default_layout,                        \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<const MKL_INT *, default_layout,                        \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<MKL_INT *, default_layout,                              \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {       \
-    enum : bool { value = true };                                      \
+          Kokkos::HostSpace>,                                                  \
+      Kokkos::View<const MKL_INT *, default_layout,                            \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
+      Kokkos::View<const MKL_INT *, default_layout,                            \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
+      Kokkos::View<const MKL_INT *, default_layout,                            \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
+      Kokkos::View<const MKL_INT *, default_layout,                            \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
+      Kokkos::View<MKL_INT *, default_layout,                                  \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {               \
+    enum : bool { value = true };                                              \
   };
 
 #define SPGEMM_SYMBOLIC_AVAIL_MKL_E(EXEC)                 \

--- a/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_avail.hpp
@@ -19,6 +19,10 @@
 #ifndef KOKKOSPARSE_SPGEMM_SYMBOLIC_TPL_SPEC_AVAIL_HPP_
 #define KOKKOSPARSE_SPGEMM_SYMBOLIC_TPL_SPEC_AVAIL_HPP_
 
+#ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
+#include <mkl.h>
+#endif
+
 namespace KokkosSparse {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
@@ -105,21 +109,21 @@ SPGEMM_SYMBOLIC_AVAIL_ROCSPARSE(Kokkos::complex<double>)
   template <>                                                          \
   struct spgemm_symbolic_tpl_spec_avail<                               \
       KokkosKernels::Experimental::KokkosKernelsHandle<                \
-          const int, const int, const SCALAR, EXEC, Kokkos::HostSpace, \
+          const MKL_INT, const MKL_INT, const SCALAR, EXEC, Kokkos::HostSpace, \
           Kokkos::HostSpace>,                                          \
-      Kokkos::View<const int *, default_layout,                        \
+      Kokkos::View<const MKL_INT *, default_layout,                        \
                    Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<const int *, default_layout,                        \
+      Kokkos::View<const MKL_INT *, default_layout,                        \
                    Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<const int *, default_layout,                        \
+      Kokkos::View<const MKL_INT *, default_layout,                        \
                    Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<const int *, default_layout,                        \
+      Kokkos::View<const MKL_INT *, default_layout,                        \
                    Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
-      Kokkos::View<int *, default_layout,                              \
+      Kokkos::View<MKL_INT *, default_layout,                              \
                    Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {       \
     enum : bool { value = true };                                      \

--- a/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp
@@ -594,8 +594,10 @@ void spgemm_symbolic_mkl(
     handle->set_c_nnz(0);
     return;
   }
-  MKLMatrix A(m, n, (MKL_INT *)rowptrA.data(), (MKL_INT *)colidxA.data(), nullptr);
-  MKLMatrix B(n, k, (MKL_INT *)rowptrB.data(), (MKL_INT *)colidxB.data(), nullptr);
+  MKLMatrix A(m, n, (MKL_INT *)rowptrA.data(), (MKL_INT *)colidxA.data(),
+              nullptr);
+  MKLMatrix B(n, k, (MKL_INT *)rowptrB.data(), (MKL_INT *)colidxB.data(),
+              nullptr);
   sparse_matrix_t C;
   matrix_descr generalDescr;
   generalDescr.type = SPARSE_MATRIX_TYPE_GENERAL;
@@ -621,53 +623,53 @@ void spgemm_symbolic_mkl(
   handle->set_c_nnz(rowptrC(m));
 }
 
-#define SPGEMM_SYMBOLIC_DECL_MKL(SCALAR, EXEC, TPL_AVAIL)                     \
-  template <>                                                                 \
-  struct SPGEMM_SYMBOLIC<                                                     \
-      KokkosKernels::Experimental::KokkosKernelsHandle<                       \
-          const MKL_INT, const MKL_INT, const SCALAR, EXEC, Kokkos::HostSpace,        \
-          Kokkos::HostSpace>,                                                 \
-      Kokkos::View<const MKL_INT *, default_layout,                               \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                   \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
-      Kokkos::View<const MKL_INT *, default_layout,                               \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                   \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
-      Kokkos::View<const MKL_INT *, default_layout,                               \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                   \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
-      Kokkos::View<const MKL_INT *, default_layout,                               \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                   \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
-      Kokkos::View<MKL_INT *, default_layout,                                     \
-                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                   \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
-      true, TPL_AVAIL> {                                                      \
-    using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<    \
-        const MKL_INT, const MKL_INT, const SCALAR, EXEC, Kokkos::HostSpace,          \
-        Kokkos::HostSpace>;                                                   \
-    using c_int_view_t =                                                      \
-        Kokkos::View<const MKL_INT *, default_layout,                             \
-                     Kokkos::Device<EXEC, Kokkos::HostSpace>,                 \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                \
-    using int_view_t = Kokkos::View<MKL_INT *, default_layout,                    \
-                                    Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
-                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
-    static void spgemm_symbolic(KernelHandle *handle,                         \
-                                typename KernelHandle::nnz_lno_t m,           \
-                                typename KernelHandle::nnz_lno_t n,           \
-                                typename KernelHandle::nnz_lno_t k,           \
-                                c_int_view_t row_mapA, c_int_view_t entriesA, \
-                                bool, c_int_view_t row_mapB,                  \
-                                c_int_view_t entriesB, bool,                  \
-                                int_view_t row_mapC, bool) {                  \
-      std::string label = "KokkosSparse::spgemm_symbolic[TPL_MKL," +          \
-                          Kokkos::ArithTraits<SCALAR>::name() + "]";          \
-      Kokkos::Profiling::pushRegion(label);                                   \
-      spgemm_symbolic_mkl(handle->get_spgemm_handle(), m, n, k, row_mapA,     \
-                          entriesA, row_mapB, entriesB, row_mapC);            \
-      Kokkos::Profiling::popRegion();                                         \
-    }                                                                         \
+#define SPGEMM_SYMBOLIC_DECL_MKL(SCALAR, EXEC, TPL_AVAIL)                      \
+  template <>                                                                  \
+  struct SPGEMM_SYMBOLIC<                                                      \
+      KokkosKernels::Experimental::KokkosKernelsHandle<                        \
+          const MKL_INT, const MKL_INT, const SCALAR, EXEC, Kokkos::HostSpace, \
+          Kokkos::HostSpace>,                                                  \
+      Kokkos::View<const MKL_INT *, default_layout,                            \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
+      Kokkos::View<const MKL_INT *, default_layout,                            \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
+      Kokkos::View<const MKL_INT *, default_layout,                            \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
+      Kokkos::View<const MKL_INT *, default_layout,                            \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
+      Kokkos::View<MKL_INT *, default_layout,                                  \
+                   Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
+      true, TPL_AVAIL> {                                                       \
+    using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<     \
+        const MKL_INT, const MKL_INT, const SCALAR, EXEC, Kokkos::HostSpace,   \
+        Kokkos::HostSpace>;                                                    \
+    using c_int_view_t =                                                       \
+        Kokkos::View<const MKL_INT *, default_layout,                          \
+                     Kokkos::Device<EXEC, Kokkos::HostSpace>,                  \
+                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                 \
+    using int_view_t = Kokkos::View<MKL_INT *, default_layout,                 \
+                                    Kokkos::Device<EXEC, Kokkos::HostSpace>,   \
+                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;  \
+    static void spgemm_symbolic(KernelHandle *handle,                          \
+                                typename KernelHandle::nnz_lno_t m,            \
+                                typename KernelHandle::nnz_lno_t n,            \
+                                typename KernelHandle::nnz_lno_t k,            \
+                                c_int_view_t row_mapA, c_int_view_t entriesA,  \
+                                bool, c_int_view_t row_mapB,                   \
+                                c_int_view_t entriesB, bool,                   \
+                                int_view_t row_mapC, bool) {                   \
+      std::string label = "KokkosSparse::spgemm_symbolic[TPL_MKL," +           \
+                          Kokkos::ArithTraits<SCALAR>::name() + "]";           \
+      Kokkos::Profiling::pushRegion(label);                                    \
+      spgemm_symbolic_mkl(handle->get_spgemm_handle(), m, n, k, row_mapA,      \
+                          entriesA, row_mapB, entriesB, row_mapC);             \
+      Kokkos::Profiling::popRegion();                                          \
+    }                                                                          \
   };
 
 #define SPGEMM_SYMBOLIC_DECL_MKL_SE(SCALAR, EXEC) \

--- a/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp
@@ -594,8 +594,8 @@ void spgemm_symbolic_mkl(
     handle->set_c_nnz(0);
     return;
   }
-  MKLMatrix A(m, n, (int *)rowptrA.data(), (int *)colidxA.data(), nullptr);
-  MKLMatrix B(n, k, (int *)rowptrB.data(), (int *)colidxB.data(), nullptr);
+  MKLMatrix A(m, n, (MKL_INT *)rowptrA.data(), (MKL_INT *)colidxA.data(), nullptr);
+  MKLMatrix B(n, k, (MKL_INT *)rowptrB.data(), (MKL_INT *)colidxB.data(), nullptr);
   sparse_matrix_t C;
   matrix_descr generalDescr;
   generalDescr.type = SPARSE_MATRIX_TYPE_GENERAL;
@@ -625,32 +625,32 @@ void spgemm_symbolic_mkl(
   template <>                                                                 \
   struct SPGEMM_SYMBOLIC<                                                     \
       KokkosKernels::Experimental::KokkosKernelsHandle<                       \
-          const int, const int, const SCALAR, EXEC, Kokkos::HostSpace,        \
+          const MKL_INT, const MKL_INT, const SCALAR, EXEC, Kokkos::HostSpace,        \
           Kokkos::HostSpace>,                                                 \
-      Kokkos::View<const int *, default_layout,                               \
+      Kokkos::View<const MKL_INT *, default_layout,                               \
                    Kokkos::Device<EXEC, Kokkos::HostSpace>,                   \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
-      Kokkos::View<const int *, default_layout,                               \
+      Kokkos::View<const MKL_INT *, default_layout,                               \
                    Kokkos::Device<EXEC, Kokkos::HostSpace>,                   \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
-      Kokkos::View<const int *, default_layout,                               \
+      Kokkos::View<const MKL_INT *, default_layout,                               \
                    Kokkos::Device<EXEC, Kokkos::HostSpace>,                   \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
-      Kokkos::View<const int *, default_layout,                               \
+      Kokkos::View<const MKL_INT *, default_layout,                               \
                    Kokkos::Device<EXEC, Kokkos::HostSpace>,                   \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
-      Kokkos::View<int *, default_layout,                                     \
+      Kokkos::View<MKL_INT *, default_layout,                                     \
                    Kokkos::Device<EXEC, Kokkos::HostSpace>,                   \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
       true, TPL_AVAIL> {                                                      \
     using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<    \
-        const int, const int, const SCALAR, EXEC, Kokkos::HostSpace,          \
+        const MKL_INT, const MKL_INT, const SCALAR, EXEC, Kokkos::HostSpace,          \
         Kokkos::HostSpace>;                                                   \
     using c_int_view_t =                                                      \
-        Kokkos::View<const int *, default_layout,                             \
+        Kokkos::View<const MKL_INT *, default_layout,                             \
                      Kokkos::Device<EXEC, Kokkos::HostSpace>,                 \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                \
-    using int_view_t = Kokkos::View<int *, default_layout,                    \
+    using int_view_t = Kokkos::View<MKL_INT *, default_layout,                    \
                                     Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
     static void spgemm_symbolic(KernelHandle *handle,                         \

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_avail.hpp
@@ -17,6 +17,10 @@
 #ifndef KOKKOSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_HPP_
 #define KOKKOSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_HPP_
 
+#ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
+#include <mkl.h>
+#endif
+
 namespace KokkosSparse {
 namespace Experimental {
 namespace Impl {
@@ -124,8 +128,8 @@ KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>,
 #define KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_MKL(SCALAR, EXECSPACE)      \
   template <>                                                                  \
   struct spmv_bsrmatrix_tpl_spec_avail<                                        \
-      const SCALAR, const int, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,   \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const int, const SCALAR*,       \
+      const SCALAR, const MKL_INT, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,\
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT, const SCALAR*,   \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_avail.hpp
@@ -128,7 +128,8 @@ KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>,
 #define KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_MKL(SCALAR, EXECSPACE)      \
   template <>                                                                  \
   struct spmv_bsrmatrix_tpl_spec_avail<                                        \
-      const SCALAR, const MKL_INT, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,\
+      const SCALAR, const MKL_INT,                                             \
+      Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                            \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT, const SCALAR*,   \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
@@ -42,14 +42,14 @@ inline matrix_descr getDescription() {
 }
 
 inline void spmv_block_impl_mkl(sparse_operation_t op, float alpha, float beta,
-                                int m, int n, int b, const int* Arowptrs,
-                                const int* Aentries, const float* Avalues,
+                                MKL_INT m, MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
+                                const MKL_INT* Aentries, const float* Avalues,
                                 const float* x, float* y) {
   sparse_matrix_t A_mkl;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_s_create_bsr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, SPARSE_LAYOUT_ROW_MAJOR, m, n, b,
-      const_cast<int*>(Arowptrs), const_cast<int*>(Arowptrs + 1),
-      const_cast<int*>(Aentries), const_cast<float*>(Avalues)));
+      const_cast<MKL_INT*>(Arowptrs), const_cast<MKL_INT*>(Arowptrs + 1),
+      const_cast<MKL_INT*>(Aentries), const_cast<float*>(Avalues)));
 
   matrix_descr A_descr = getDescription();
   KOKKOSKERNELS_MKL_SAFE_CALL(
@@ -57,15 +57,15 @@ inline void spmv_block_impl_mkl(sparse_operation_t op, float alpha, float beta,
 }
 
 inline void spmv_block_impl_mkl(sparse_operation_t op, double alpha,
-                                double beta, int m, int n, int b,
-                                const int* Arowptrs, const int* Aentries,
+                                double beta, MKL_INT m, MKL_INT n, MKL_INT b,
+                                const MKL_INT* Arowptrs, const MKL_INT* Aentries,
                                 const double* Avalues, const double* x,
                                 double* y) {
   sparse_matrix_t A_mkl;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_d_create_bsr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, SPARSE_LAYOUT_ROW_MAJOR, m, n, b,
-      const_cast<int*>(Arowptrs), const_cast<int*>(Arowptrs + 1),
-      const_cast<int*>(Aentries), const_cast<double*>(Avalues)));
+      const_cast<MKL_INT*>(Arowptrs), const_cast<MKL_INT*>(Arowptrs + 1),
+      const_cast<MKL_INT*>(Aentries), const_cast<double*>(Avalues)));
 
   matrix_descr A_descr = getDescription();
   KOKKOSKERNELS_MKL_SAFE_CALL(
@@ -74,16 +74,16 @@ inline void spmv_block_impl_mkl(sparse_operation_t op, double alpha,
 
 inline void spmv_block_impl_mkl(sparse_operation_t op,
                                 Kokkos::complex<float> alpha,
-                                Kokkos::complex<float> beta, int m, int n,
-                                int b, const int* Arowptrs, const int* Aentries,
+                                Kokkos::complex<float> beta, MKL_INT m, MKL_INT n,
+                                MKL_INT b, const MKL_INT* Arowptrs, const MKL_INT* Aentries,
                                 const Kokkos::complex<float>* Avalues,
                                 const Kokkos::complex<float>* x,
                                 Kokkos::complex<float>* y) {
   sparse_matrix_t A_mkl;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_c_create_bsr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, SPARSE_LAYOUT_ROW_MAJOR, m, n, b,
-      const_cast<int*>(Arowptrs), const_cast<int*>(Arowptrs + 1),
-      const_cast<int*>(Aentries), (MKL_Complex8*)Avalues));
+      const_cast<MKL_INT*>(Arowptrs), const_cast<MKL_INT*>(Arowptrs + 1),
+      const_cast<MKL_INT*>(Aentries), (MKL_Complex8*)Avalues));
 
   MKL_Complex8 alpha_mkl{alpha.real(), alpha.imag()};
   MKL_Complex8 beta_mkl{beta.real(), beta.imag()};
@@ -95,16 +95,16 @@ inline void spmv_block_impl_mkl(sparse_operation_t op,
 
 inline void spmv_block_impl_mkl(sparse_operation_t op,
                                 Kokkos::complex<double> alpha,
-                                Kokkos::complex<double> beta, int m, int n,
-                                int b, const int* Arowptrs, const int* Aentries,
+                                Kokkos::complex<double> beta, MKL_INT m, MKL_INT n,
+                                MKL_INT b, const MKL_INT* Arowptrs, const MKL_INT* Aentries,
                                 const Kokkos::complex<double>* Avalues,
                                 const Kokkos::complex<double>* x,
                                 Kokkos::complex<double>* y) {
   sparse_matrix_t A_mkl;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_z_create_bsr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, SPARSE_LAYOUT_ROW_MAJOR, m, n, b,
-      const_cast<int*>(Arowptrs), const_cast<int*>(Arowptrs + 1),
-      const_cast<int*>(Aentries), (MKL_Complex16*)Avalues));
+      const_cast<MKL_INT*>(Arowptrs), const_cast<MKL_INT*>(Arowptrs + 1),
+      const_cast<MKL_INT*>(Aentries), (MKL_Complex16*)Avalues));
 
   matrix_descr A_descr = getDescription();
   MKL_Complex16 alpha_mkl{alpha.real(), alpha.imag()};
@@ -115,15 +115,15 @@ inline void spmv_block_impl_mkl(sparse_operation_t op,
 }
 
 inline void spm_mv_block_impl_mkl(sparse_operation_t op, float alpha,
-                                  float beta, int m, int n, int b,
-                                  const int* Arowptrs, const int* Aentries,
+                                  float beta, MKL_INT m, MKL_INT n, MKL_INT b,
+                                  const MKL_INT* Arowptrs, const MKL_INT* Aentries,
                                   const float* Avalues, const float* x,
                                   int colx, int ldx, float* y, int ldy) {
   sparse_matrix_t A_mkl;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_s_create_bsr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, SPARSE_LAYOUT_ROW_MAJOR, m, n, b,
-      const_cast<int*>(Arowptrs), const_cast<int*>(Arowptrs + 1),
-      const_cast<int*>(Aentries), const_cast<float*>(Avalues)));
+      const_cast<MKL_INT*>(Arowptrs), const_cast<MKL_INT*>(Arowptrs + 1),
+      const_cast<MKL_INT*>(Aentries), const_cast<float*>(Avalues)));
 
   matrix_descr A_descr = getDescription();
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_s_mm(op, alpha, A_mkl, A_descr,
@@ -132,15 +132,15 @@ inline void spm_mv_block_impl_mkl(sparse_operation_t op, float alpha,
 }
 
 inline void spm_mv_block_impl_mkl(sparse_operation_t op, double alpha,
-                                  double beta, int m, int n, int b,
-                                  const int* Arowptrs, const int* Aentries,
+                                  double beta, MKL_INT m, MKL_INT n, MKL_INT b,
+                                  const MKL_INT* Arowptrs, const MKL_INT* Aentries,
                                   const double* Avalues, const double* x,
                                   int colx, int ldx, double* y, int ldy) {
   sparse_matrix_t A_mkl;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_d_create_bsr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, SPARSE_LAYOUT_ROW_MAJOR, m, n, b,
-      const_cast<int*>(Arowptrs), const_cast<int*>(Arowptrs + 1),
-      const_cast<int*>(Aentries), const_cast<double*>(Avalues)));
+      const_cast<MKL_INT*>(Arowptrs), const_cast<MKL_INT*>(Arowptrs + 1),
+      const_cast<MKL_INT*>(Aentries), const_cast<double*>(Avalues)));
 
   matrix_descr A_descr = getDescription();
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_d_mm(op, alpha, A_mkl, A_descr,
@@ -150,17 +150,17 @@ inline void spm_mv_block_impl_mkl(sparse_operation_t op, double alpha,
 
 inline void spm_mv_block_impl_mkl(sparse_operation_t op,
                                   Kokkos::complex<float> alpha,
-                                  Kokkos::complex<float> beta, int m, int n,
-                                  int b, const int* Arowptrs,
-                                  const int* Aentries,
+                                  Kokkos::complex<float> beta, MKL_INT m, MKL_INT n,
+                                  MKL_INT b, const MKL_INT* Arowptrs,
+                                  const MKL_INT* Aentries,
                                   const Kokkos::complex<float>* Avalues,
                                   const Kokkos::complex<float>* x, int colx,
                                   int ldx, Kokkos::complex<float>* y, int ldy) {
   sparse_matrix_t A_mkl;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_c_create_bsr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, SPARSE_LAYOUT_ROW_MAJOR, m, n, b,
-      const_cast<int*>(Arowptrs), const_cast<int*>(Arowptrs + 1),
-      const_cast<int*>(Aentries), (MKL_Complex8*)Avalues));
+      const_cast<MKL_INT*>(Arowptrs), const_cast<MKL_INT*>(Arowptrs + 1),
+      const_cast<MKL_INT*>(Aentries), (MKL_Complex8*)Avalues));
 
   MKL_Complex8 alpha_mkl{alpha.real(), alpha.imag()};
   MKL_Complex8 beta_mkl{beta.real(), beta.imag()};
@@ -173,15 +173,15 @@ inline void spm_mv_block_impl_mkl(sparse_operation_t op,
 
 inline void spm_mv_block_impl_mkl(
     sparse_operation_t op, Kokkos::complex<double> alpha,
-    Kokkos::complex<double> beta, int m, int n, int b, const int* Arowptrs,
-    const int* Aentries, const Kokkos::complex<double>* Avalues,
+    Kokkos::complex<double> beta, MKL_INT m, MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
+    const MKL_INT* Aentries, const Kokkos::complex<double>* Avalues,
     const Kokkos::complex<double>* x, int colx, int ldx,
     Kokkos::complex<double>* y, int ldy) {
   sparse_matrix_t A_mkl;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_z_create_bsr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, SPARSE_LAYOUT_ROW_MAJOR, m, n, b,
-      const_cast<int*>(Arowptrs), const_cast<int*>(Arowptrs + 1),
-      const_cast<int*>(Aentries), (MKL_Complex16*)Avalues));
+      const_cast<MKL_INT*>(Arowptrs), const_cast<MKL_INT*>(Arowptrs + 1),
+      const_cast<MKL_INT*>(Aentries), (MKL_Complex16*)Avalues));
 
   matrix_descr A_descr = getDescription();
   MKL_Complex16 alpha_mkl{alpha.real(), alpha.imag()};
@@ -196,25 +196,25 @@ inline void spm_mv_block_impl_mkl(
 
 #if (__INTEL_MKL__ == 2017)
 
-inline void spmv_block_impl_mkl(char mode, float alpha, float beta, int m,
-                                int n, int b, const int* Arowptrs,
-                                const int* Aentries, const float* Avalues,
+inline void spmv_block_impl_mkl(char mode, float alpha, float beta, MKL_INT m,
+                                MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
+                                const MKL_INT* Aentries, const float* Avalues,
                                 const float* x, float* y) {
   mkl_sbsrmv(&mode, &m, &n, &b, &alpha, "G**C", Avalues, Aentries, Arowptrs,
              Arowptrs + 1, x, &beta, y);
 }
 
-inline void spmv_block_impl_mkl(char mode, double alpha, double beta, int m,
-                                int n, int b, const int* Arowptrs,
-                                const int* Aentries, const double* Avalues,
+inline void spmv_block_impl_mkl(char mode, double alpha, double beta, MKL_INT m,
+                                MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
+                                const MKL_INT* Aentries, const double* Avalues,
                                 const double* x, double* y) {
   mkl_dbsrmv(&mode, &m, &n, &b, &alpha, "G**C", Avalues, Aentries, Arowptrs,
              Arowptrs + 1, x, &beta, y);
 }
 
 inline void spmv_block_impl_mkl(char mode, Kokkos::complex<float> alpha,
-                                Kokkos::complex<float> beta, int m, int n,
-                                int b, const int* Arowptrs, const int* Aentries,
+                                Kokkos::complex<float> beta, MKL_INT m, MKL_INT n,
+                                MKL_INT b, const MKL_INT* Arowptrs, const MKL_INT* Aentries,
                                 const Kokkos::complex<float>* Avalues,
                                 const Kokkos::complex<float>* x,
                                 Kokkos::complex<float>* y) {
@@ -229,8 +229,8 @@ inline void spmv_block_impl_mkl(char mode, Kokkos::complex<float> alpha,
 }
 
 inline void spmv_block_impl_mkl(char mode, Kokkos::complex<double> alpha,
-                                Kokkos::complex<double> beta, int m, int n,
-                                int b, const int* Arowptrs, const int* Aentries,
+                                Kokkos::complex<double> beta, MKL_INT m, MKL_INT n,
+                                MKL_INT b, const MKL_INT* Arowptrs, const MKL_INT* Aentries,
                                 const Kokkos::complex<double>* Avalues,
                                 const Kokkos::complex<double>* x,
                                 Kokkos::complex<double>* y) {
@@ -245,18 +245,18 @@ inline void spmv_block_impl_mkl(char mode, Kokkos::complex<double> alpha,
              Arowptrs, Arowptrs + 1, x_mkl, beta_mkl, y_mkl);
 }
 
-inline void spm_mv_block_impl_mkl(char mode, float alpha, float beta, int m,
-                                  int n, int b, const int* Arowptrs,
-                                  const int* Aentries, const float* Avalues,
+inline void spm_mv_block_impl_mkl(char mode, float alpha, float beta, MKL_INT m,
+                                  MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
+                                  const MKL_INT* Aentries, const float* Avalues,
                                   const float* x, int colx, int ldx, float* y,
                                   int ldy) {
   mkl_sbsrmm(&mode, &m, &n, &colx, &b, &alpha, "G**C", Avalues, Aentries,
              Arowptrs, Arowptrs + 1, x, &beta, y);
 }
 
-inline void spm_mv_block_impl_mkl(char mode, double alpha, double beta, int m,
-                                  int n, int b, const int* Arowptrs,
-                                  const int* Aentries, const double* Avalues,
+inline void spm_mv_block_impl_mkl(char mode, double alpha, double beta, MKL_INT m,
+                                  MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
+                                  const MKL_INT* Aentries, const double* Avalues,
                                   const double* x, int colx, int ldx, double* y,
                                   int ldy) {
   mkl_dbsrmm(&mode, &m, &n, &colx, &b, &alpha, "G**C", Avalues, Aentries,
@@ -264,9 +264,9 @@ inline void spm_mv_block_impl_mkl(char mode, double alpha, double beta, int m,
 }
 
 inline void spm_mv_block_impl_mkl(char mode, Kokkos::complex<float> alpha,
-                                  Kokkos::complex<float> beta, int m, int n,
-                                  int b, const int* Arowptrs,
-                                  const int* Aentries,
+                                  Kokkos::complex<float> beta, MKL_INT m, MKL_INT n,
+                                  MKL_INT b, const MKL_INT* Arowptrs,
+                                  const MKL_INT* Aentries,
                                   const Kokkos::complex<float>* Avalues,
                                   const Kokkos::complex<float>* x, int colx,
                                   int ldx, Kokkos::complex<float>* y, int ldy) {
@@ -282,7 +282,7 @@ inline void spm_mv_block_impl_mkl(char mode, Kokkos::complex<float> alpha,
 
 inline void spm_mv_block_impl_mkl(
     char mode, Kokkos::complex<double> alpha, Kokkos::complex<double> beta,
-    int m, int n, int b, const int* Arowptrs, const int* Aentries,
+    MKL_INT m, MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs, const MKL_INT* Aentries,
     const Kokkos::complex<double>* Avalues, const Kokkos::complex<double>* x,
     int colx, int ldx, Kokkos::complex<double>* y, int ldy) {
   const MKL_Complex16* alpha_mkl =
@@ -301,16 +301,16 @@ inline void spm_mv_block_impl_mkl(
 #define KOKKOSSPARSE_SPMV_MKL(SCALAR, EXECSPACE, COMPILE_LIBRARY)              \
   template <>                                                                  \
   struct SPMV_BSRMATRIX<                                                       \
-      SCALAR const, int const, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,   \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, int const, SCALAR const*,       \
+      SCALAR const, MKL_INT const, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,   \
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const, SCALAR const*,       \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, true, COMPILE_LIBRARY> {        \
     using device_type = Kokkos::Device<EXECSPACE, Kokkos::HostSpace>;          \
     using AMatrix =                                                            \
-        BsrMatrix<SCALAR const, int const, device_type,                        \
-                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, int const>;         \
+        BsrMatrix<SCALAR const, MKL_INT const, device_type,                        \
+                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;         \
     using XVector = Kokkos::View<                                              \
         SCALAR const*, Kokkos::LayoutLeft, device_type,                        \
         Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;       \
@@ -358,8 +358,8 @@ KOKKOSSPARSE_SPMV_MKL(Kokkos::complex<double>, Kokkos::OpenMP,
 #define KOKKOSSPARSE_SPMV_MV_MKL(SCALAR, EXECSPACE, COMPILE_LIBRARY)           \
   template <>                                                                  \
   struct SPMV_MV_BSRMATRIX<                                                    \
-      SCALAR const, int const, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,   \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, int const, SCALAR const**,      \
+      SCALAR const, MKL_INT const, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,   \
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const, SCALAR const**,      \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,          \
       SCALAR**, Kokkos::LayoutLeft,                                            \
@@ -367,8 +367,8 @@ KOKKOSSPARSE_SPMV_MKL(Kokkos::complex<double>, Kokkos::OpenMP,
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, true, true, COMPILE_LIBRARY> {  \
     using device_type = Kokkos::Device<EXECSPACE, Kokkos::HostSpace>;          \
     using AMatrix =                                                            \
-        BsrMatrix<SCALAR const, int const, device_type,                        \
-                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, int const>;         \
+        BsrMatrix<SCALAR const, MKL_INT const, device_type,                        \
+                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;         \
     using XVector = Kokkos::View<                                              \
         SCALAR const**, Kokkos::LayoutLeft, device_type,                       \
         Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;       \

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
@@ -121,8 +121,8 @@ inline void spm_mv_block_impl_mkl(sparse_operation_t op, float alpha,
                                   float beta, MKL_INT m, MKL_INT n, MKL_INT b,
                                   const MKL_INT* Arowptrs,
                                   const MKL_INT* Aentries, const float* Avalues,
-                                  const float* x, int colx, int ldx, float* y,
-                                  int ldy) {
+                                  const float* x, MKL_INT colx, MKL_INT ldx, float* y,
+                                  MKL_INT ldy) {
   sparse_matrix_t A_mkl;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_s_create_bsr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, SPARSE_LAYOUT_ROW_MAJOR, m, n, b,
@@ -140,7 +140,7 @@ inline void spm_mv_block_impl_mkl(sparse_operation_t op, double alpha,
                                   const MKL_INT* Arowptrs,
                                   const MKL_INT* Aentries,
                                   const double* Avalues, const double* x,
-                                  int colx, int ldx, double* y, int ldy) {
+                                  MKL_INT colx, MKL_INT ldx, double* y, MKL_INT ldy) {
   sparse_matrix_t A_mkl;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_d_create_bsr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, SPARSE_LAYOUT_ROW_MAJOR, m, n, b,
@@ -159,8 +159,8 @@ inline void spm_mv_block_impl_mkl(sparse_operation_t op,
                                   MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
                                   const MKL_INT* Aentries,
                                   const Kokkos::complex<float>* Avalues,
-                                  const Kokkos::complex<float>* x, int colx,
-                                  int ldx, Kokkos::complex<float>* y, int ldy) {
+                                  const Kokkos::complex<float>* x, MKL_INT colx,
+                                  MKL_INT ldx, Kokkos::complex<float>* y, MKL_INT ldy) {
   sparse_matrix_t A_mkl;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_c_create_bsr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, SPARSE_LAYOUT_ROW_MAJOR, m, n, b,
@@ -181,7 +181,7 @@ inline void spm_mv_block_impl_mkl(
     Kokkos::complex<double> beta, MKL_INT m, MKL_INT n, MKL_INT b,
     const MKL_INT* Arowptrs, const MKL_INT* Aentries,
     const Kokkos::complex<double>* Avalues, const Kokkos::complex<double>* x,
-    int colx, int ldx, Kokkos::complex<double>* y, int ldy) {
+    MKL_INT colx, MKL_INT ldx, Kokkos::complex<double>* y, MKL_INT ldy) {
   sparse_matrix_t A_mkl;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_z_create_bsr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, SPARSE_LAYOUT_ROW_MAJOR, m, n, b,
@@ -255,8 +255,8 @@ inline void spmv_block_impl_mkl(char mode, Kokkos::complex<double> alpha,
 inline void spm_mv_block_impl_mkl(char mode, float alpha, float beta, MKL_INT m,
                                   MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
                                   const MKL_INT* Aentries, const float* Avalues,
-                                  const float* x, int colx, int ldx, float* y,
-                                  int ldy) {
+                                  const float* x, MKL_INT colx, MKL_INT ldx, float* y,
+                                  MKL_INT ldy) {
   mkl_sbsrmm(&mode, &m, &n, &colx, &b, &alpha, "G**C", Avalues, Aentries,
              Arowptrs, Arowptrs + 1, x, &beta, y);
 }
@@ -266,7 +266,7 @@ inline void spm_mv_block_impl_mkl(char mode, double alpha, double beta,
                                   const MKL_INT* Arowptrs,
                                   const MKL_INT* Aentries,
                                   const double* Avalues, const double* x,
-                                  int colx, int ldx, double* y, int ldy) {
+                                  MKL_INT colx, MKL_INT ldx, double* y, MKL_INT ldy) {
   mkl_dbsrmm(&mode, &m, &n, &colx, &b, &alpha, "G**C", Avalues, Aentries,
              Arowptrs, Arowptrs + 1, x, ldx, &beta, y, ldy);
 }
@@ -276,8 +276,8 @@ inline void spm_mv_block_impl_mkl(char mode, Kokkos::complex<float> alpha,
                                   MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
                                   const MKL_INT* Aentries,
                                   const Kokkos::complex<float>* Avalues,
-                                  const Kokkos::complex<float>* x, int colx,
-                                  int ldx, Kokkos::complex<float>* y, int ldy) {
+                                  const Kokkos::complex<float>* x, MKL_INT colx,
+                                  MKL_INT ldx, Kokkos::complex<float>* y, MKL_INT ldy) {
   const MKL_Complex8* alpha_mkl = reinterpret_cast<const MKL_Complex8*>(&alpha);
   const MKL_Complex8* beta_mkl  = reinterpret_cast<const MKL_Complex8*>(&beta);
   const MKL_Complex8* Avalues_mkl =
@@ -293,9 +293,9 @@ inline void spm_mv_block_impl_mkl(char mode, Kokkos::complex<double> alpha,
                                   MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
                                   const MKL_INT* Aentries,
                                   const Kokkos::complex<double>* Avalues,
-                                  const Kokkos::complex<double>* x, int colx,
-                                  int ldx, Kokkos::complex<double>* y,
-                                  int ldy) {
+                                  const Kokkos::complex<double>* x, MKL_INT colx,
+                                  MKL_INT ldx, Kokkos::complex<double>* y,
+                                  MKL_INT ldy) {
   const MKL_Complex16* alpha_mkl =
       reinterpret_cast<const MKL_Complex16*>(&alpha);
   const MKL_Complex16* beta_mkl = reinterpret_cast<const MKL_Complex16*>(&beta);
@@ -396,9 +396,9 @@ KOKKOSSPARSE_SPMV_MKL(Kokkos::complex<double>, Kokkos::OpenMP,
       std::string label = "KokkosSparse::spmv[TPL_MKL,BSRMATRIX" +             \
                           Kokkos::ArithTraits<SCALAR>::name() + "]";           \
       Kokkos::Profiling::pushRegion(label);                                    \
-      int colx = static_cast<int>(X.extent(1));                                \
-      int ldx  = static_cast<int>(X.stride_1());                               \
-      int ldy  = static_cast<int>(Y.stride_1());                               \
+      MKL_INT colx = static_cast<MKL_INT>(X.extent(1));                                \
+      MKL_INT ldx  = static_cast<MKL_INT>(X.stride_1());                               \
+      MKL_INT ldy  = static_cast<MKL_INT>(Y.stride_1());                               \
       spm_mv_block_impl_mkl(mode_kk_to_mkl(mode[0]), alpha, beta, A.numRows(), \
                             A.numCols(), A.blockDim(), A.graph.row_map.data(), \
                             A.graph.entries.data(), A.values.data(), X.data(), \

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
@@ -121,8 +121,8 @@ inline void spm_mv_block_impl_mkl(sparse_operation_t op, float alpha,
                                   float beta, MKL_INT m, MKL_INT n, MKL_INT b,
                                   const MKL_INT* Arowptrs,
                                   const MKL_INT* Aentries, const float* Avalues,
-                                  const float* x, MKL_INT colx, MKL_INT ldx, float* y,
-                                  MKL_INT ldy) {
+                                  const float* x, MKL_INT colx, MKL_INT ldx,
+                                  float* y, MKL_INT ldy) {
   sparse_matrix_t A_mkl;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_s_create_bsr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, SPARSE_LAYOUT_ROW_MAJOR, m, n, b,
@@ -140,7 +140,8 @@ inline void spm_mv_block_impl_mkl(sparse_operation_t op, double alpha,
                                   const MKL_INT* Arowptrs,
                                   const MKL_INT* Aentries,
                                   const double* Avalues, const double* x,
-                                  MKL_INT colx, MKL_INT ldx, double* y, MKL_INT ldy) {
+                                  MKL_INT colx, MKL_INT ldx, double* y,
+                                  MKL_INT ldy) {
   sparse_matrix_t A_mkl;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_d_create_bsr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, SPARSE_LAYOUT_ROW_MAJOR, m, n, b,
@@ -153,14 +154,12 @@ inline void spm_mv_block_impl_mkl(sparse_operation_t op, double alpha,
                                               ldx, beta, y, ldy));
 }
 
-inline void spm_mv_block_impl_mkl(sparse_operation_t op,
-                                  Kokkos::complex<float> alpha,
-                                  Kokkos::complex<float> beta, MKL_INT m,
-                                  MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
-                                  const MKL_INT* Aentries,
-                                  const Kokkos::complex<float>* Avalues,
-                                  const Kokkos::complex<float>* x, MKL_INT colx,
-                                  MKL_INT ldx, Kokkos::complex<float>* y, MKL_INT ldy) {
+inline void spm_mv_block_impl_mkl(
+    sparse_operation_t op, Kokkos::complex<float> alpha,
+    Kokkos::complex<float> beta, MKL_INT m, MKL_INT n, MKL_INT b,
+    const MKL_INT* Arowptrs, const MKL_INT* Aentries,
+    const Kokkos::complex<float>* Avalues, const Kokkos::complex<float>* x,
+    MKL_INT colx, MKL_INT ldx, Kokkos::complex<float>* y, MKL_INT ldy) {
   sparse_matrix_t A_mkl;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_c_create_bsr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, SPARSE_LAYOUT_ROW_MAJOR, m, n, b,
@@ -255,18 +254,16 @@ inline void spmv_block_impl_mkl(char mode, Kokkos::complex<double> alpha,
 inline void spm_mv_block_impl_mkl(char mode, float alpha, float beta, MKL_INT m,
                                   MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
                                   const MKL_INT* Aentries, const float* Avalues,
-                                  const float* x, MKL_INT colx, MKL_INT ldx, float* y,
-                                  MKL_INT ldy) {
+                                  const float* x, MKL_INT colx, MKL_INT ldx,
+                                  float* y, MKL_INT ldy) {
   mkl_sbsrmm(&mode, &m, &n, &colx, &b, &alpha, "G**C", Avalues, Aentries,
              Arowptrs, Arowptrs + 1, x, &beta, y);
 }
 
-inline void spm_mv_block_impl_mkl(char mode, double alpha, double beta,
-                                  MKL_INT m, MKL_INT n, MKL_INT b,
-                                  const MKL_INT* Arowptrs,
-                                  const MKL_INT* Aentries,
-                                  const double* Avalues, const double* x,
-                                  MKL_INT colx, MKL_INT ldx, double* y, MKL_INT ldy) {
+inline void spm_mv_block_impl_mkl(
+    char mode, double alpha, double beta, MKL_INT m, MKL_INT n, MKL_INT b,
+    const MKL_INT* Arowptrs, const MKL_INT* Aentries, const double* Avalues,
+    const double* x, MKL_INT colx, MKL_INT ldx, double* y, MKL_INT ldy) {
   mkl_dbsrmm(&mode, &m, &n, &colx, &b, &alpha, "G**C", Avalues, Aentries,
              Arowptrs, Arowptrs + 1, x, ldx, &beta, y, ldy);
 }
@@ -277,7 +274,8 @@ inline void spm_mv_block_impl_mkl(char mode, Kokkos::complex<float> alpha,
                                   const MKL_INT* Aentries,
                                   const Kokkos::complex<float>* Avalues,
                                   const Kokkos::complex<float>* x, MKL_INT colx,
-                                  MKL_INT ldx, Kokkos::complex<float>* y, MKL_INT ldy) {
+                                  MKL_INT ldx, Kokkos::complex<float>* y,
+                                  MKL_INT ldy) {
   const MKL_Complex8* alpha_mkl = reinterpret_cast<const MKL_Complex8*>(&alpha);
   const MKL_Complex8* beta_mkl  = reinterpret_cast<const MKL_Complex8*>(&beta);
   const MKL_Complex8* Avalues_mkl =
@@ -293,9 +291,9 @@ inline void spm_mv_block_impl_mkl(char mode, Kokkos::complex<double> alpha,
                                   MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
                                   const MKL_INT* Aentries,
                                   const Kokkos::complex<double>* Avalues,
-                                  const Kokkos::complex<double>* x, MKL_INT colx,
-                                  MKL_INT ldx, Kokkos::complex<double>* y,
-                                  MKL_INT ldy) {
+                                  const Kokkos::complex<double>* x,
+                                  MKL_INT colx, MKL_INT ldx,
+                                  Kokkos::complex<double>* y, MKL_INT ldy) {
   const MKL_Complex16* alpha_mkl =
       reinterpret_cast<const MKL_Complex16*>(&alpha);
   const MKL_Complex16* beta_mkl = reinterpret_cast<const MKL_Complex16*>(&beta);
@@ -396,9 +394,9 @@ KOKKOSSPARSE_SPMV_MKL(Kokkos::complex<double>, Kokkos::OpenMP,
       std::string label = "KokkosSparse::spmv[TPL_MKL,BSRMATRIX" +             \
                           Kokkos::ArithTraits<SCALAR>::name() + "]";           \
       Kokkos::Profiling::pushRegion(label);                                    \
-      MKL_INT colx = static_cast<MKL_INT>(X.extent(1));                                \
-      MKL_INT ldx  = static_cast<MKL_INT>(X.stride_1());                               \
-      MKL_INT ldy  = static_cast<MKL_INT>(Y.stride_1());                               \
+      MKL_INT colx = static_cast<MKL_INT>(X.extent(1));                        \
+      MKL_INT ldx  = static_cast<MKL_INT>(X.stride_1());                       \
+      MKL_INT ldy  = static_cast<MKL_INT>(Y.stride_1());                       \
       spm_mv_block_impl_mkl(mode_kk_to_mkl(mode[0]), alpha, beta, A.numRows(), \
                             A.numCols(), A.blockDim(), A.graph.row_map.data(), \
                             A.graph.entries.data(), A.values.data(), X.data(), \

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
@@ -42,7 +42,8 @@ inline matrix_descr getDescription() {
 }
 
 inline void spmv_block_impl_mkl(sparse_operation_t op, float alpha, float beta,
-                                MKL_INT m, MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
+                                MKL_INT m, MKL_INT n, MKL_INT b,
+                                const MKL_INT* Arowptrs,
                                 const MKL_INT* Aentries, const float* Avalues,
                                 const float* x, float* y) {
   sparse_matrix_t A_mkl;
@@ -58,9 +59,9 @@ inline void spmv_block_impl_mkl(sparse_operation_t op, float alpha, float beta,
 
 inline void spmv_block_impl_mkl(sparse_operation_t op, double alpha,
                                 double beta, MKL_INT m, MKL_INT n, MKL_INT b,
-                                const MKL_INT* Arowptrs, const MKL_INT* Aentries,
-                                const double* Avalues, const double* x,
-                                double* y) {
+                                const MKL_INT* Arowptrs,
+                                const MKL_INT* Aentries, const double* Avalues,
+                                const double* x, double* y) {
   sparse_matrix_t A_mkl;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_d_create_bsr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, SPARSE_LAYOUT_ROW_MAJOR, m, n, b,
@@ -74,8 +75,9 @@ inline void spmv_block_impl_mkl(sparse_operation_t op, double alpha,
 
 inline void spmv_block_impl_mkl(sparse_operation_t op,
                                 Kokkos::complex<float> alpha,
-                                Kokkos::complex<float> beta, MKL_INT m, MKL_INT n,
-                                MKL_INT b, const MKL_INT* Arowptrs, const MKL_INT* Aentries,
+                                Kokkos::complex<float> beta, MKL_INT m,
+                                MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
+                                const MKL_INT* Aentries,
                                 const Kokkos::complex<float>* Avalues,
                                 const Kokkos::complex<float>* x,
                                 Kokkos::complex<float>* y) {
@@ -95,8 +97,9 @@ inline void spmv_block_impl_mkl(sparse_operation_t op,
 
 inline void spmv_block_impl_mkl(sparse_operation_t op,
                                 Kokkos::complex<double> alpha,
-                                Kokkos::complex<double> beta, MKL_INT m, MKL_INT n,
-                                MKL_INT b, const MKL_INT* Arowptrs, const MKL_INT* Aentries,
+                                Kokkos::complex<double> beta, MKL_INT m,
+                                MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
+                                const MKL_INT* Aentries,
                                 const Kokkos::complex<double>* Avalues,
                                 const Kokkos::complex<double>* x,
                                 Kokkos::complex<double>* y) {
@@ -116,9 +119,10 @@ inline void spmv_block_impl_mkl(sparse_operation_t op,
 
 inline void spm_mv_block_impl_mkl(sparse_operation_t op, float alpha,
                                   float beta, MKL_INT m, MKL_INT n, MKL_INT b,
-                                  const MKL_INT* Arowptrs, const MKL_INT* Aentries,
-                                  const float* Avalues, const float* x,
-                                  int colx, int ldx, float* y, int ldy) {
+                                  const MKL_INT* Arowptrs,
+                                  const MKL_INT* Aentries, const float* Avalues,
+                                  const float* x, int colx, int ldx, float* y,
+                                  int ldy) {
   sparse_matrix_t A_mkl;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_s_create_bsr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, SPARSE_LAYOUT_ROW_MAJOR, m, n, b,
@@ -133,7 +137,8 @@ inline void spm_mv_block_impl_mkl(sparse_operation_t op, float alpha,
 
 inline void spm_mv_block_impl_mkl(sparse_operation_t op, double alpha,
                                   double beta, MKL_INT m, MKL_INT n, MKL_INT b,
-                                  const MKL_INT* Arowptrs, const MKL_INT* Aentries,
+                                  const MKL_INT* Arowptrs,
+                                  const MKL_INT* Aentries,
                                   const double* Avalues, const double* x,
                                   int colx, int ldx, double* y, int ldy) {
   sparse_matrix_t A_mkl;
@@ -150,8 +155,8 @@ inline void spm_mv_block_impl_mkl(sparse_operation_t op, double alpha,
 
 inline void spm_mv_block_impl_mkl(sparse_operation_t op,
                                   Kokkos::complex<float> alpha,
-                                  Kokkos::complex<float> beta, MKL_INT m, MKL_INT n,
-                                  MKL_INT b, const MKL_INT* Arowptrs,
+                                  Kokkos::complex<float> beta, MKL_INT m,
+                                  MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
                                   const MKL_INT* Aentries,
                                   const Kokkos::complex<float>* Avalues,
                                   const Kokkos::complex<float>* x, int colx,
@@ -173,10 +178,10 @@ inline void spm_mv_block_impl_mkl(sparse_operation_t op,
 
 inline void spm_mv_block_impl_mkl(
     sparse_operation_t op, Kokkos::complex<double> alpha,
-    Kokkos::complex<double> beta, MKL_INT m, MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
-    const MKL_INT* Aentries, const Kokkos::complex<double>* Avalues,
-    const Kokkos::complex<double>* x, int colx, int ldx,
-    Kokkos::complex<double>* y, int ldy) {
+    Kokkos::complex<double> beta, MKL_INT m, MKL_INT n, MKL_INT b,
+    const MKL_INT* Arowptrs, const MKL_INT* Aentries,
+    const Kokkos::complex<double>* Avalues, const Kokkos::complex<double>* x,
+    int colx, int ldx, Kokkos::complex<double>* y, int ldy) {
   sparse_matrix_t A_mkl;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_z_create_bsr(
       &A_mkl, SPARSE_INDEX_BASE_ZERO, SPARSE_LAYOUT_ROW_MAJOR, m, n, b,
@@ -213,8 +218,9 @@ inline void spmv_block_impl_mkl(char mode, double alpha, double beta, MKL_INT m,
 }
 
 inline void spmv_block_impl_mkl(char mode, Kokkos::complex<float> alpha,
-                                Kokkos::complex<float> beta, MKL_INT m, MKL_INT n,
-                                MKL_INT b, const MKL_INT* Arowptrs, const MKL_INT* Aentries,
+                                Kokkos::complex<float> beta, MKL_INT m,
+                                MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
+                                const MKL_INT* Aentries,
                                 const Kokkos::complex<float>* Avalues,
                                 const Kokkos::complex<float>* x,
                                 Kokkos::complex<float>* y) {
@@ -229,8 +235,9 @@ inline void spmv_block_impl_mkl(char mode, Kokkos::complex<float> alpha,
 }
 
 inline void spmv_block_impl_mkl(char mode, Kokkos::complex<double> alpha,
-                                Kokkos::complex<double> beta, MKL_INT m, MKL_INT n,
-                                MKL_INT b, const MKL_INT* Arowptrs, const MKL_INT* Aentries,
+                                Kokkos::complex<double> beta, MKL_INT m,
+                                MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
+                                const MKL_INT* Aentries,
                                 const Kokkos::complex<double>* Avalues,
                                 const Kokkos::complex<double>* x,
                                 Kokkos::complex<double>* y) {
@@ -254,18 +261,19 @@ inline void spm_mv_block_impl_mkl(char mode, float alpha, float beta, MKL_INT m,
              Arowptrs, Arowptrs + 1, x, &beta, y);
 }
 
-inline void spm_mv_block_impl_mkl(char mode, double alpha, double beta, MKL_INT m,
-                                  MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
-                                  const MKL_INT* Aentries, const double* Avalues,
-                                  const double* x, int colx, int ldx, double* y,
-                                  int ldy) {
+inline void spm_mv_block_impl_mkl(char mode, double alpha, double beta,
+                                  MKL_INT m, MKL_INT n, MKL_INT b,
+                                  const MKL_INT* Arowptrs,
+                                  const MKL_INT* Aentries,
+                                  const double* Avalues, const double* x,
+                                  int colx, int ldx, double* y, int ldy) {
   mkl_dbsrmm(&mode, &m, &n, &colx, &b, &alpha, "G**C", Avalues, Aentries,
              Arowptrs, Arowptrs + 1, x, ldx, &beta, y, ldy);
 }
 
 inline void spm_mv_block_impl_mkl(char mode, Kokkos::complex<float> alpha,
-                                  Kokkos::complex<float> beta, MKL_INT m, MKL_INT n,
-                                  MKL_INT b, const MKL_INT* Arowptrs,
+                                  Kokkos::complex<float> beta, MKL_INT m,
+                                  MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
                                   const MKL_INT* Aentries,
                                   const Kokkos::complex<float>* Avalues,
                                   const Kokkos::complex<float>* x, int colx,
@@ -280,11 +288,14 @@ inline void spm_mv_block_impl_mkl(char mode, Kokkos::complex<float> alpha,
              Arowptrs, Arowptrs + 1, x_mkl, ldx, beta_mkl, y_mkl, ldy);
 }
 
-inline void spm_mv_block_impl_mkl(
-    char mode, Kokkos::complex<double> alpha, Kokkos::complex<double> beta,
-    MKL_INT m, MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs, const MKL_INT* Aentries,
-    const Kokkos::complex<double>* Avalues, const Kokkos::complex<double>* x,
-    int colx, int ldx, Kokkos::complex<double>* y, int ldy) {
+inline void spm_mv_block_impl_mkl(char mode, Kokkos::complex<double> alpha,
+                                  Kokkos::complex<double> beta, MKL_INT m,
+                                  MKL_INT n, MKL_INT b, const MKL_INT* Arowptrs,
+                                  const MKL_INT* Aentries,
+                                  const Kokkos::complex<double>* Avalues,
+                                  const Kokkos::complex<double>* x, int colx,
+                                  int ldx, Kokkos::complex<double>* y,
+                                  int ldy) {
   const MKL_Complex16* alpha_mkl =
       reinterpret_cast<const MKL_Complex16*>(&alpha);
   const MKL_Complex16* beta_mkl = reinterpret_cast<const MKL_Complex16*>(&beta);
@@ -301,16 +312,17 @@ inline void spm_mv_block_impl_mkl(
 #define KOKKOSSPARSE_SPMV_MKL(SCALAR, EXECSPACE, COMPILE_LIBRARY)              \
   template <>                                                                  \
   struct SPMV_BSRMATRIX<                                                       \
-      SCALAR const, MKL_INT const, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,   \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const, SCALAR const*,       \
+      SCALAR const, MKL_INT const,                                             \
+      Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                            \
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const, SCALAR const*,   \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, true, COMPILE_LIBRARY> {        \
     using device_type = Kokkos::Device<EXECSPACE, Kokkos::HostSpace>;          \
     using AMatrix =                                                            \
-        BsrMatrix<SCALAR const, MKL_INT const, device_type,                        \
-                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;         \
+        BsrMatrix<SCALAR const, MKL_INT const, device_type,                    \
+                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;     \
     using XVector = Kokkos::View<                                              \
         SCALAR const*, Kokkos::LayoutLeft, device_type,                        \
         Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;       \
@@ -358,8 +370,9 @@ KOKKOSSPARSE_SPMV_MKL(Kokkos::complex<double>, Kokkos::OpenMP,
 #define KOKKOSSPARSE_SPMV_MV_MKL(SCALAR, EXECSPACE, COMPILE_LIBRARY)           \
   template <>                                                                  \
   struct SPMV_MV_BSRMATRIX<                                                    \
-      SCALAR const, MKL_INT const, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,   \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const, SCALAR const**,      \
+      SCALAR const, MKL_INT const,                                             \
+      Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                            \
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const, SCALAR const**,  \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,          \
       SCALAR**, Kokkos::LayoutLeft,                                            \
@@ -367,8 +380,8 @@ KOKKOSSPARSE_SPMV_MKL(Kokkos::complex<double>, Kokkos::OpenMP,
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, true, true, COMPILE_LIBRARY> {  \
     using device_type = Kokkos::Device<EXECSPACE, Kokkos::HostSpace>;          \
     using AMatrix =                                                            \
-        BsrMatrix<SCALAR const, MKL_INT const, device_type,                        \
-                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;         \
+        BsrMatrix<SCALAR const, MKL_INT const, device_type,                    \
+                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;     \
     using XVector = Kokkos::View<                                              \
         SCALAR const**, Kokkos::LayoutLeft, device_type,                       \
         Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;       \

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
@@ -17,6 +17,10 @@
 #ifndef KOKKOSPARSE_SPMV_TPL_SPEC_AVAIL_HPP_
 #define KOKKOSPARSE_SPMV_TPL_SPEC_AVAIL_HPP_
 
+#ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
+#include <mkl.h>
+#endif
+
 namespace KokkosSparse {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
@@ -214,8 +218,8 @@ KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ROCSPARSE(Kokkos::complex<float>,
 #define KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_MKL(SCALAR, EXECSPACE)                \
   template <>                                                                  \
   struct spmv_tpl_spec_avail<                                                  \
-      const SCALAR, const int, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,   \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const int, const SCALAR*,       \
+      const SCALAR, const MKL_INT, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,   \
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT, const SCALAR*,       \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
@@ -218,8 +218,9 @@ KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ROCSPARSE(Kokkos::complex<float>,
 #define KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_MKL(SCALAR, EXECSPACE)                \
   template <>                                                                  \
   struct spmv_tpl_spec_avail<                                                  \
-      const SCALAR, const MKL_INT, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,   \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT, const SCALAR*,       \
+      const SCALAR, const MKL_INT,                                             \
+      Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                            \
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT, const SCALAR*,   \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -522,8 +522,8 @@ namespace Impl {
 #if (__INTEL_MKL__ > 2017)
 // MKL 2018 and above: use new interface: sparse_matrix_t and mkl_sparse_?_mv()
 
-inline void spmv_mkl(sparse_operation_t op, float alpha, float beta, int m,
-                     int n, const int* Arowptrs, const int* Aentries,
+inline void spmv_mkl(sparse_operation_t op, float alpha, float beta, MKL_INT m,
+                     MKL_INT n, const MKL_INT* Arowptrs, const MKL_INT* Aentries,
                      const float* Avalues, const float* x, float* y) {
   sparse_matrix_t A_mkl;
   matrix_descr A_descr;
@@ -531,15 +531,15 @@ inline void spmv_mkl(sparse_operation_t op, float alpha, float beta, int m,
   A_descr.mode = SPARSE_FILL_MODE_FULL;
   A_descr.diag = SPARSE_DIAG_NON_UNIT;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_s_create_csr(
-      &A_mkl, SPARSE_INDEX_BASE_ZERO, m, n, const_cast<int*>(Arowptrs),
-      const_cast<int*>(Arowptrs + 1), const_cast<int*>(Aentries),
+      &A_mkl, SPARSE_INDEX_BASE_ZERO, m, n, const_cast<MKL_INT*>(Arowptrs),
+      const_cast<MKL_INT*>(Arowptrs + 1), const_cast<MKL_INT*>(Aentries),
       const_cast<float*>(Avalues)));
   KOKKOSKERNELS_MKL_SAFE_CALL(
       mkl_sparse_s_mv(op, alpha, A_mkl, A_descr, x, beta, y));
 }
 
-inline void spmv_mkl(sparse_operation_t op, double alpha, double beta, int m,
-                     int n, const int* Arowptrs, const int* Aentries,
+inline void spmv_mkl(sparse_operation_t op, double alpha, double beta, MKL_INT m,
+                     MKL_INT n, const MKL_INT* Arowptrs, const MKL_INT* Aentries,
                      const double* Avalues, const double* x, double* y) {
   sparse_matrix_t A_mkl;
   matrix_descr A_descr;
@@ -547,16 +547,16 @@ inline void spmv_mkl(sparse_operation_t op, double alpha, double beta, int m,
   A_descr.mode = SPARSE_FILL_MODE_FULL;
   A_descr.diag = SPARSE_DIAG_NON_UNIT;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_d_create_csr(
-      &A_mkl, SPARSE_INDEX_BASE_ZERO, m, n, const_cast<int*>(Arowptrs),
-      const_cast<int*>(Arowptrs + 1), const_cast<int*>(Aentries),
+      &A_mkl, SPARSE_INDEX_BASE_ZERO, m, n, const_cast<MKL_INT*>(Arowptrs),
+      const_cast<MKL_INT*>(Arowptrs + 1), const_cast<MKL_INT*>(Aentries),
       const_cast<double*>(Avalues)));
   KOKKOSKERNELS_MKL_SAFE_CALL(
       mkl_sparse_d_mv(op, alpha, A_mkl, A_descr, x, beta, y));
 }
 
 inline void spmv_mkl(sparse_operation_t op, Kokkos::complex<float> alpha,
-                     Kokkos::complex<float> beta, int m, int n,
-                     const int* Arowptrs, const int* Aentries,
+                     Kokkos::complex<float> beta, MKL_INT m, MKL_INT n,
+                     const MKL_INT* Arowptrs, const MKL_INT* Aentries,
                      const Kokkos::complex<float>* Avalues,
                      const Kokkos::complex<float>* x,
                      Kokkos::complex<float>* y) {
@@ -566,8 +566,8 @@ inline void spmv_mkl(sparse_operation_t op, Kokkos::complex<float> alpha,
   A_descr.mode = SPARSE_FILL_MODE_FULL;
   A_descr.diag = SPARSE_DIAG_NON_UNIT;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_c_create_csr(
-      &A_mkl, SPARSE_INDEX_BASE_ZERO, m, n, const_cast<int*>(Arowptrs),
-      const_cast<int*>(Arowptrs + 1), const_cast<int*>(Aentries),
+      &A_mkl, SPARSE_INDEX_BASE_ZERO, m, n, const_cast<MKL_INT*>(Arowptrs),
+      const_cast<MKL_INT*>(Arowptrs + 1), const_cast<MKL_INT*>(Aentries),
       (MKL_Complex8*)Avalues));
   MKL_Complex8 alpha_mkl{alpha.real(), alpha.imag()};
   MKL_Complex8 beta_mkl{beta.real(), beta.imag()};
@@ -577,8 +577,8 @@ inline void spmv_mkl(sparse_operation_t op, Kokkos::complex<float> alpha,
 }
 
 inline void spmv_mkl(sparse_operation_t op, Kokkos::complex<double> alpha,
-                     Kokkos::complex<double> beta, int m, int n,
-                     const int* Arowptrs, const int* Aentries,
+                     Kokkos::complex<double> beta, MKL_INT m, MKL_INT n,
+                     const MKL_INT* Arowptrs, const MKL_INT* Aentries,
                      const Kokkos::complex<double>* Avalues,
                      const Kokkos::complex<double>* x,
                      Kokkos::complex<double>* y) {
@@ -588,8 +588,8 @@ inline void spmv_mkl(sparse_operation_t op, Kokkos::complex<double> alpha,
   A_descr.mode = SPARSE_FILL_MODE_FULL;
   A_descr.diag = SPARSE_DIAG_NON_UNIT;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_z_create_csr(
-      &A_mkl, SPARSE_INDEX_BASE_ZERO, m, n, const_cast<int*>(Arowptrs),
-      const_cast<int*>(Arowptrs + 1), const_cast<int*>(Aentries),
+      &A_mkl, SPARSE_INDEX_BASE_ZERO, m, n, const_cast<MKL_INT*>(Arowptrs),
+      const_cast<MKL_INT*>(Arowptrs + 1), const_cast<MKL_INT*>(Aentries),
       (MKL_Complex16*)Avalues));
   MKL_Complex16 alpha_mkl{alpha.real(), alpha.imag()};
   MKL_Complex16 beta_mkl{beta.real(), beta.imag()};
@@ -601,16 +601,16 @@ inline void spmv_mkl(sparse_operation_t op, Kokkos::complex<double> alpha,
 #define KOKKOSSPARSE_SPMV_MKL(SCALAR, EXECSPACE, COMPILE_LIBRARY)              \
   template <>                                                                  \
   struct SPMV<                                                                 \
-      SCALAR const, int const, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,   \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, int const, SCALAR const*,       \
+      SCALAR const, MKL_INT const, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,   \
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const, SCALAR const*,       \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, true, COMPILE_LIBRARY> {        \
     using device_type = Kokkos::Device<EXECSPACE, Kokkos::HostSpace>;          \
     using AMatrix =                                                            \
-        CrsMatrix<SCALAR const, int const, device_type,                        \
-                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, int const>;         \
+        CrsMatrix<SCALAR const, MKL_INT const, device_type,                        \
+                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;         \
     using XVector = Kokkos::View<                                              \
         SCALAR const*, Kokkos::LayoutLeft, device_type,                        \
         Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;       \
@@ -647,23 +647,23 @@ inline char mode_kk_to_mkl(char mode_kk) {
       "Invalid mode for MKL (should be one of N, T, H)");
 }
 
-inline void spmv_mkl(char mode, float alpha, float beta, int m, int n,
-                     const int* Arowptrs, const int* Aentries,
+inline void spmv_mkl(char mode, float alpha, float beta, MKL_INT m, MKL_INT n,
+                     const MKL_INT* Arowptrs, const MKL_INT* Aentries,
                      const float* Avalues, const float* x, float* y) {
   mkl_scsrmv(&mode, &m, &n, &alpha, "G**C", Avalues, Aentries, Arowptrs,
              Arowptrs + 1, x, &beta, y);
 }
 
-inline void spmv_mkl(char mode, double alpha, double beta, int m, int n,
-                     const int* Arowptrs, const int* Aentries,
+inline void spmv_mkl(char mode, double alpha, double beta, MKL_INT m, MKL_INT n,
+                     const MKL_INT* Arowptrs, const MKL_INT* Aentries,
                      const double* Avalues, const double* x, double* y) {
   mkl_dcsrmv(&mode, &m, &n, &alpha, "G**C", Avalues, Aentries, Arowptrs,
              Arowptrs + 1, x, &beta, y);
 }
 
 inline void spmv_mkl(char mode, Kokkos::complex<float> alpha,
-                     Kokkos::complex<float> beta, int m, int n,
-                     const int* Arowptrs, const int* Aentries,
+                     Kokkos::complex<float> beta, MKL_INT m, MKL_INT n,
+                     const MKL_INT* Arowptrs, const MKL_INT* Aentries,
                      const Kokkos::complex<float>* Avalues,
                      const Kokkos::complex<float>* x,
                      Kokkos::complex<float>* y) {
@@ -678,8 +678,8 @@ inline void spmv_mkl(char mode, Kokkos::complex<float> alpha,
 }
 
 inline void spmv_mkl(char mode, Kokkos::complex<double> alpha,
-                     Kokkos::complex<double> beta, int m, int n,
-                     const int* Arowptrs, const int* Aentries,
+                     Kokkos::complex<double> beta, MKL_INT m, MKL_INT n,
+                     const MKL_INT* Arowptrs, const MKL_INT* Aentries,
                      const Kokkos::complex<double>* Avalues,
                      const Kokkos::complex<double>* x,
                      Kokkos::complex<double>* y) {
@@ -697,16 +697,16 @@ inline void spmv_mkl(char mode, Kokkos::complex<double> alpha,
 #define KOKKOSSPARSE_SPMV_MKL(SCALAR, EXECSPACE, COMPILE_LIBRARY)              \
   template <>                                                                  \
   struct SPMV<                                                                 \
-      SCALAR const, int const, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,   \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, int const, SCALAR const*,       \
+      SCALAR const, MKL_INT const, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,   \
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const, SCALAR const*,       \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, true, COMPILE_LIBRARY> {        \
     using device_type = Kokkos::Device<EXECSPACE, Kokkos::HostSpace>;          \
     using AMatrix =                                                            \
-        CrsMatrix<SCALAR const, int const, device_type,                        \
-                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, int const>;         \
+        CrsMatrix<SCALAR const, MKL_INT const, device_type,                        \
+                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;         \
     using XVector = Kokkos::View<                                              \
         SCALAR const*, Kokkos::LayoutLeft, device_type,                        \
         Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;       \

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -523,8 +523,9 @@ namespace Impl {
 // MKL 2018 and above: use new interface: sparse_matrix_t and mkl_sparse_?_mv()
 
 inline void spmv_mkl(sparse_operation_t op, float alpha, float beta, MKL_INT m,
-                     MKL_INT n, const MKL_INT* Arowptrs, const MKL_INT* Aentries,
-                     const float* Avalues, const float* x, float* y) {
+                     MKL_INT n, const MKL_INT* Arowptrs,
+                     const MKL_INT* Aentries, const float* Avalues,
+                     const float* x, float* y) {
   sparse_matrix_t A_mkl;
   matrix_descr A_descr;
   A_descr.type = SPARSE_MATRIX_TYPE_GENERAL;
@@ -538,9 +539,10 @@ inline void spmv_mkl(sparse_operation_t op, float alpha, float beta, MKL_INT m,
       mkl_sparse_s_mv(op, alpha, A_mkl, A_descr, x, beta, y));
 }
 
-inline void spmv_mkl(sparse_operation_t op, double alpha, double beta, MKL_INT m,
-                     MKL_INT n, const MKL_INT* Arowptrs, const MKL_INT* Aentries,
-                     const double* Avalues, const double* x, double* y) {
+inline void spmv_mkl(sparse_operation_t op, double alpha, double beta,
+                     MKL_INT m, MKL_INT n, const MKL_INT* Arowptrs,
+                     const MKL_INT* Aentries, const double* Avalues,
+                     const double* x, double* y) {
   sparse_matrix_t A_mkl;
   matrix_descr A_descr;
   A_descr.type = SPARSE_MATRIX_TYPE_GENERAL;
@@ -601,16 +603,17 @@ inline void spmv_mkl(sparse_operation_t op, Kokkos::complex<double> alpha,
 #define KOKKOSSPARSE_SPMV_MKL(SCALAR, EXECSPACE, COMPILE_LIBRARY)              \
   template <>                                                                  \
   struct SPMV<                                                                 \
-      SCALAR const, MKL_INT const, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,   \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const, SCALAR const*,       \
+      SCALAR const, MKL_INT const,                                             \
+      Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                            \
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const, SCALAR const*,   \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, true, COMPILE_LIBRARY> {        \
     using device_type = Kokkos::Device<EXECSPACE, Kokkos::HostSpace>;          \
     using AMatrix =                                                            \
-        CrsMatrix<SCALAR const, MKL_INT const, device_type,                        \
-                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;         \
+        CrsMatrix<SCALAR const, MKL_INT const, device_type,                    \
+                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;     \
     using XVector = Kokkos::View<                                              \
         SCALAR const*, Kokkos::LayoutLeft, device_type,                        \
         Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;       \
@@ -697,16 +700,17 @@ inline void spmv_mkl(char mode, Kokkos::complex<double> alpha,
 #define KOKKOSSPARSE_SPMV_MKL(SCALAR, EXECSPACE, COMPILE_LIBRARY)              \
   template <>                                                                  \
   struct SPMV<                                                                 \
-      SCALAR const, MKL_INT const, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,   \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const, SCALAR const*,       \
+      SCALAR const, MKL_INT const,                                             \
+      Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                            \
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const, SCALAR const*,   \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, true, COMPILE_LIBRARY> {        \
     using device_type = Kokkos::Device<EXECSPACE, Kokkos::HostSpace>;          \
     using AMatrix =                                                            \
-        CrsMatrix<SCALAR const, MKL_INT const, device_type,                        \
-                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;         \
+        CrsMatrix<SCALAR const, MKL_INT const, device_type,                    \
+                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;     \
     using XVector = Kokkos::View<                                              \
         SCALAR const*, Kokkos::LayoutLeft, device_type,                        \
         Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;       \


### PR DESCRIPTION
Modifying the TPL support for MKL to use the MKL_INT in favor of int when indexing sparse matrices.
This allows us to building against 32 bit and 64 bit installations of MKL