### PR TITLE
Correcting 'syr test' bug causing compilation errors with Trilinos

### DIFF
--- a/blas/unit_test/Test_Blas2_syr.hpp
+++ b/blas/unit_test/Test_Blas2_syr.hpp
@@ -155,7 +155,7 @@ class SyrTester {
   void callKkGerAndCompareKkSyrAgainstIt(
       const ScalarA& alpha, TX& x,
       view_stride_adapter<_ViewTypeA, false>& org_A,
-      const _ViewTypeExpected& h_A_syr, const std::string& situation);
+      const _HostViewTypeA& h_A_syr, const std::string& situation);
 
   const bool _A_is_complex;
   const bool _A_is_lr;
@@ -1429,7 +1429,7 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::
     callKkGerAndCompareKkSyrAgainstIt(
         const ScalarA& alpha, TX& x,
         view_stride_adapter<_ViewTypeA, false>& org_A,
-        const _ViewTypeExpected& h_A_syr, const std::string& situation) {
+        const _HostViewTypeA& h_A_syr, const std::string& situation) {
   view_stride_adapter<_ViewTypeA, false> A_ger("A_ger", _M, _N);
   Kokkos::deep_copy(A_ger.d_base, org_A.d_base);
 


### PR DESCRIPTION
The compilation error happens in kk syr unit tests, independent of any interactions with, or calls from, Trilinos.

I was able to replicate the problem at weaver with some of the information in the error email sent by Nathan. I think the key aspect causing the error was the presence of CudaUVM options in the configurations of Kokkos and kk. I will include those options in my own work from now on.

+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

1) Environment:

ssh weaver

bsub -Is -n 1 -q rhel8 -gpu num=1 bash

source /etc/profile.d/modules.sh
source /projects/ppc64le-pwr9-rhel8/legacy-env.sh
module load git
module load cmake/3.23.1
module load cuda/11.2.2/gcc/8.3.1
module load openblas/0.3.18/gcc/8.3.1

+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

2) Kokkos code:

cmake \
--install-prefix <BASE_PATH>/install/kokkos_git \
-D CMAKE_BUILD_TYPE:STRING=Debug \
-D CMAKE_CXX_STANDARD:STRING=17 \
-D CMAKE_CXX_FLAGS:STRING="" \
-D CMAKE_CXX_EXTENSIONS:BOOL=OFF \
-D CMAKE_VERBOSE_MAKEFILE:BOOL=OFF \
-D Kokkos_ENABLE_CUDA_LAMBDA=ON \
-D Kokkos_ENABLE_SERIAL:BOOL=ON \
-D Kokkos_ENABLE_OPENMP:BOOL=ON \
-D Kokkos_ENABLE_THREADS:BOOL=OFF \
-D Kokkos_ENABLE_DEPRECATED_CODE_3:BOOL=OFF \
-D Kokkos_ENABLE_DEBUG_BOUNDS_CHECK:BOOL=ON \
-D Kokkos_ENABLE_TESTS:BOOL=OFF \
-D Kokkos_ENABLE_EXAMPLES:BOOL=OFF \
-D Kokkos_ENABLE_CUDA=ON \
-D Kokkos_ENABLE_CUDA_UVM=ON \
-D Kokkos_ARCH_VOLTA70=ON \
-D Kokkos_ARCH_POWER9=ON \
~/work/Kokkos/kokkos
make -j16
make install

+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

3) Kokkos-Kernels

cmake \
--install-prefix <BASE_PATH>/install/kokkos_kernels_syr_compbug \
-D CMAKE_BUILD_TYPE:STRING=Debug \
-D CMAKE_CXX_STANDARD:STRING=17 \
-D CMAKE_CXX_FLAGS:STRING="-Wall -Wunused-parameter -Wshadow -pedantic -Werror -Wsign-compare -Wtype-limits -Wuninitialized" \
-D CMAKE_CXX_EXTENSIONS:BOOL=OFF \
-D CMAKE_VERBOSE_MAKEFILE:BOOL=OFF \
-D Kokkos_ROOT:PATH="<BASE_PATH>/install/kokkos_git" \
-D KokkosKernels_ENABLE_TPL_BLAS:BOOL=ON \
-D KokkosKernels_ENABLE_TPL_CUBLAS:BOOL=ON \
-D KokkosKernels_ENABLE_COMPONENT_BLAS=ON \
-D KokkosKernels_ENABLE_COMPONENT_BATCHED=OFF \
-D KokkosKernels_ENABLE_COMPONENT_GRAPH=OFF \
-D KokkosKernels_ENABLE_COMPONENT_SPARSE=OFF \
-D KokkosKernels_INST_INT:BOOL=ON \
-D KokkosKernels_INST_FLOAT:BOOL=ON \
-D KokkosKernels_INST_DOUBLE:BOOL=ON \
-D KokkosKernels_INST_COMPLEX_FLOAT:BOOL=ON \
-D KokkosKernels_INST_COMPLEX_DOUBLE:BOOL=ON \
-D KokkosKernels_INST_OFFSET_SIZE_T:BOOL=ON \
-D KokkosKernels_INST_OFFSET_INT:BOOL=ON \
-D KokkosKernels_INST_ORDINAL_INT:BOOL=ON \
-D KokkosKernels_INST_LAYOUTLEFT:BOOL=ON \
-D KokkosKernels_INST_LAYOUTRIGHT:BOOL=ON \
-D KokkosKernels_INST_LAYOUTSTRIDE:BOOL=ON \
-D KokkosKernels_INST_MEMSPACE_CUDAUVMSPACE=ON \
-D KokkosKernels_ENABLE_TESTS:BOOL=ON \
-D KokkosKernels_TEST_ETI_ONLY:BOOL=ON \
-D KokkosKernels_ENABLE_EXAMPLES:BOOL=OFF \
-D KokkosKernels_ENABLE_BENCHMARK:BOOL=OFF \
~/work/Kokkos/kokkos-kernels
make -j16

+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

The kk compilation worked fine (with the change present in this PR) and the following 3 tests passed:

./blas/unit_test/KokkosKernels_blas_serial --gtest_filter=serial.syr_\*
./blas/unit_test/KokkosKernels_blas_openmp --gtest_filter=openmp.syr_\*
./blas/unit_test/KokkosKernels_blas_cuda --gtest_filter=Cuda.syr_\*
