### PR TITLE
Backward-compatible fix with kokkos@4.0

### DIFF
--- a/batched/dense/impl/KokkosBatched_HostLevel_Gemm_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_HostLevel_Gemm_Impl.hpp
@@ -94,9 +94,11 @@ int BatchedGemmImpl(BatchedGemmHandleType *const handle, const ScalarType alpha,
       case BaseKokkosBatchedAlgos::KK_SERIAL:
       case BaseHeuristicAlgos::SQUARE:
       case BaseTplAlgos::ARMPL:
+#if KOKKOS_VERSION > 40099
         assert(A.rank_dynamic() == 3 && "AViewType must have rank 3.");
         assert(B.rank_dynamic() == 3 && "BViewType must have rank 3.");
         assert(C.rank_dynamic() == 3 && "CViewType must have rank 3.");
+#endif
         break;
       default:
         std::ostringstream os;


### PR DESCRIPTION
Guard use of `rank_dynamic` for KOKKOS_VERSION > 40099 (i.e. 4.1 and above)