### PR TITLE
Improve help text in perf tests

### DIFF
--- a/perf_test/KokkosKernels_perf_test_instantiation.hpp
+++ b/perf_test/KokkosKernels_perf_test_instantiation.hpp
@@ -26,9 +26,19 @@
 #error "The macro KOKKOSKERNELS_PERF_TEST_NAME was not defined"
 #endif
 
+// All perf tests must implement print_options()
+void print_options();
+
 int main_instantiation(int argc, char** argv) {
   perf_test::CommonInputParams params;
   perf_test::parse_common_options(argc, argv, params);
+
+  // If help is requested with "-h" or "--help", then just print the options
+  // and quit.
+  if (params.print_help) {
+    print_options();
+    return 0;
+  }
 
   /* Assumption is that use_openmp/use_threads variables are */
   /* provided as numbers of threads */

--- a/perf_test/KokkosKernels_perf_test_utilities.hpp
+++ b/perf_test/KokkosKernels_perf_test_utilities.hpp
@@ -33,20 +33,56 @@ struct CommonInputParams {
   int use_openmp  = 0;
   int use_threads = 0;
 
-  int repeat = 0;
+  int repeat      = 0;
+  bool print_help = false;
 };
 
 std::string list_common_options() {
   std::ostringstream common_options;
   common_options
-      << "\t[Required] BACKEND:\n"
-      << "\t\t'--threads [numThreads]' |\n"
-      << "\t\t'--openmp [numThreads]' |\n"
-      << "\t\t'--cuda [deviceIndex]' |\n"
-      << "\t\t'--hip [deviceIndex]' |\n"
-      << "\t\t'--sycl [deviceIndex]'\n\n"
-      << "\tIf no parallel backend is requested, Serial will be used "
-         "(if enabled)\n\n";
+      << "\t[Required] Backend: the available backends are:\n"
+#ifdef KOKKOS_ENABLE_THREADS
+      << "\t\t'--threads [numThreads]'\n"
+#endif
+#ifdef KOKKOS_ENABLE_OPENMP
+      << "\t\t'--openmp [numThreads]'\n"
+#endif
+#ifdef KOKKOS_ENABLE_CUDA
+      << "\t\t'--cuda [deviceIndex]'\n"
+#endif
+#ifdef KOKKOS_ENABLE_HIP
+      << "\t\t'--hip [deviceIndex]'\n"
+#endif
+#ifdef KOKKOS_ENABLE_SYCL
+      << "\t\t'--sycl [deviceIndex]'\n"
+#endif
+#ifdef KOKKOS_ENABLE_SERIAL
+      << "\t\tIf no parallel backend is requested, Serial will be used.\n"
+#endif
+      << "\n"
+      << "\t The following backends are not available because Kokkos was not "
+         "configured with them:\n"
+#ifndef KOKKOS_ENABLE_THREADS
+      << "\t\t'--threads [numThreads]'\n"
+#endif
+#ifndef KOKKOS_ENABLE_OPENMP
+      << "\t\t'--openmp [numThreads]'\n"
+#endif
+#ifndef KOKKOS_ENABLE_CUDA
+      << "\t\t'--cuda [deviceIndex]'\n"
+#endif
+#ifndef KOKKOS_ENABLE_HIP
+      << "\t\t'--hip [deviceIndex]'\n"
+#endif
+#ifndef KOKKOS_ENABLE_SYCL
+      << "\t\t'--sycl [deviceIndex]'\n"
+#endif
+#ifndef KOKKOS_ENABLE_SERIAL
+      << "\t\tSerial is not enabled so a parallel backend must be selected.\n"
+#endif
+      << "\n"
+      << "\t[Optional]:\n"
+      << "\t\t'-h', '--help': show available options\n\n";
 
   return common_options.str();
 }
@@ -155,34 +191,42 @@ void parse_common_options(int& argc, char** argv, CommonInputParams& params) {
   // If e.g. params.use_cuda is 0, that means CUDA will not be used at all.
   // But if it's N, then it means run on CUDA device N-1.
   while (argIdx < argc) {
-    bool remove_flag = false;
+    // How many flags to delete from argc/argv
+    // 0: not a common option, so leave it
+    // 1: a bool parameter like '-h'
+    // 2: a parameter followed by a value, like "--cuda 0"
+    int remove_flags = 0;
     if (check_arg_int(argIdx, argc, argv, "--threads", params.use_threads)) {
-      remove_flag = true;
+      remove_flags = 2;
     } else if (check_arg_int(argIdx, argc, argv, "--openmp",
                              params.use_openmp)) {
-      remove_flag = true;
+      remove_flags = 2;
     } else if (check_arg_int(argIdx, argc, argv, "--cuda", params.use_cuda)) {
       params.use_cuda++;
-      remove_flag = true;
+      remove_flags = 2;
     } else if (check_arg_int(argIdx, argc, argv, "--hip", params.use_hip)) {
       params.use_hip++;
-      remove_flag = true;
+      remove_flags = 2;
     } else if (check_arg_int(argIdx, argc, argv, "--sycl", params.use_sycl)) {
       params.use_sycl++;
-      remove_flag = true;
+      remove_flags = 2;
     } else if (check_arg_int(argIdx, argc, argv, "--repeat", params.repeat)) {
-      remove_flag = true;
+      remove_flags = 2;
+    } else if (check_arg_bool(argIdx, argc, argv, "-h", params.print_help) ||
+               check_arg_bool(argIdx, argc, argv, "--help",
+                              params.print_help)) {
+      remove_flags = 1;
     }
 
-    if (remove_flag) {
-      // Shift the remainder of the argv list by one.  Note that argv has
-      // (argc + 1) arguments, the last one always being nullptr.  The following
-      // loop moves the trailing nullptr element as well
-      for (int k = argIdx; k < argc - 1; ++k) {
-        argv[k]     = argv[k + 2];
-        argv[k + 1] = argv[k + 3];
+    if (remove_flags) {
+      // Shift the remainder of the argv list left by the number of flags
+      // removed. Note that argv has (argc + 1) arguments, the last one always
+      // being nullptr.  The following loop moves the trailing nullptr element
+      // as well
+      for (int k = argIdx + remove_flags; k <= argc; ++k) {
+        argv[k - remove_flags] = argv[k];
       }
-      argc = argc - 2;
+      argc -= remove_flags;
     } else {
       ++argIdx;
     }

--- a/perf_test/sparse/KokkosSparse_spadd.cpp
+++ b/perf_test/sparse/KokkosSparse_spadd.cpp
@@ -90,7 +90,6 @@ void print_options() {
 }
 
 int parse_inputs(LocalParams& params, int argc, char** argv) {
-  bool printHelp = false;
   bool discard;
   for (int i = 1; i < argc; ++i) {
     // if (perf_test::check_arg_str(i, argc, argv, "--amtx", params.amtx)) {
@@ -131,18 +130,12 @@ int parse_inputs(LocalParams& params, int argc, char** argv) {
       ++i;
     } else if (perf_test::check_arg_bool(i, argc, argv, "--verbose",
                                          params.verbose)) {
-    } else if (perf_test::check_arg_bool(i, argc, argv, "-h", printHelp)) {
-    } else if (perf_test::check_arg_bool(i, argc, argv, "--help", printHelp)) {
     } else {
       std::cerr << "Unrecognized command line argument #" << i << ": "
                 << argv[i] << std::endl;
       print_options();
       return 1;
     }
-  }
-  if (printHelp) {
-    print_options();
-    return 1;
   }
   return 0;
 }

--- a/perf_test/sparse/KokkosSparse_spgemm.cpp
+++ b/perf_test/sparse/KokkosSparse_spgemm.cpp
@@ -158,7 +158,6 @@ void print_options() {
 int parse_inputs(KokkosKernels::Experiment::Parameters& params, int argc,
                  char** argv) {
   std::string algoStr;
-  bool printHelp;
   for (int i = 1; i < argc; ++i) {
     if (perf_test::check_arg_int(i, argc, argv, "--repeat", params.repeat)) {
       ++i;
@@ -276,18 +275,12 @@ int parse_inputs(KokkosKernels::Experiment::Parameters& params, int argc,
         return 1;
       }
       ++i;
-    } else if (perf_test::check_arg_bool(i, argc, argv, "-h", printHelp)) {
-    } else if (perf_test::check_arg_bool(i, argc, argv, "--help", printHelp)) {
     } else {
       std::cerr << "Unrecognized command line argument #" << i << ": "
                 << argv[i] << std::endl;
       print_options();
       return 1;
     }
-  }
-  if (printHelp) {
-    print_options();
-    return 1;
   }
   return 0;
 }


### PR DESCRIPTION
I noticed that some perf tests like graph_triangle use the common infrastructure, but weren't able to print the help text unless an available backend was selected. So now help is printed whenever the user passes "-h" or "--help", no matter what the configuration is.

- Have common infrastructure detect "-h" and "--help", and print options
- In help text, distinguish between enabled and non-enabled backends

For build with OpenMP only, ``./graph_triangle -h`` output before:
```
ERROR: Tried to run on Serial device (as no parallel backends requested), but Serial is not enabled.
```
output after:
```
Options

	[Required] Backend: the available backends are:
		'--openmp [numThreads]'

	 The following backends are not available because Kokkos was not configured with them:
		'--threads [numThreads]'
...
```