### PR TITLE
Add missing KokkosKernels_Macros.hpp include

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -35,6 +35,7 @@
 #include "Kokkos_Complex.hpp"
 
 #include "KokkosKernels_config.h"
+#include "KokkosKernels_Macros.hpp"
 #include "KokkosKernels_SimpleUtils.hpp"
 #include "KokkosBlas_util.hpp"
 


### PR DESCRIPTION
in batched dense.

In this example, everything that should be needed to run a SerialCopy is included, but without this include the ``KOKKOSKERNELS_DEBUG_LEVEL`` macro isn't defined so static_asserts in the impl of SerialCopy are skipped when they shouldn't be.

```
#include "Kokkos_Core.hpp"
#include "KokkosBatched_Copy_Decl.hpp"
int main()
{
  Kokkos::initialize();
  {
    Kokkos::View<double*> v1("v1", 10);
    Kokkos::View<double*> v2("v2", 10);
    KokkosBatched::SerialCopy<KokkosBatched::Trans::NoTranspose>::invoke(v1, v2);
  }
  Kokkos::finalize();
  return 0;
}
```