### PR TITLE
Change 'or' to '||' to fix compilation on MSVC

### DIFF
--- a/sparse/src/KokkosSparse_spgemm.hpp
+++ b/sparse/src/KokkosSparse_spgemm.hpp
@@ -167,7 +167,7 @@ template <class KernelHandle, class AMatrix, class BMatrix, class CMatrix>
 void block_spgemm_numeric(KernelHandle& kh, const AMatrix& A, const bool Amode,
                           const BMatrix& B, const bool Bmode, CMatrix& C) {
   auto blockDim = A.blockDim();
-  if (blockDim != B.blockDim() or blockDim != C.blockDim()) {
+  if (blockDim != B.blockDim() || blockDim != C.blockDim()) {
     throw std::invalid_argument(
         "Block SpGEMM must be called for matrices with the same block size");
   }


### PR DESCRIPTION
It was suggested by the Trilinos project to submit a PR here for a problem I was having in Trilinos.  I don't know if MSVC is in your test matrix, but this is a simple change that shouldn't affect any results and will allow compilation on MSVC.