### PR TITLE
cusparse 12 spmv: check y vector alignment

### DIFF
--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -161,6 +161,12 @@ void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
     useFallback = useFallback || (mode[0] == Conjugate[0]);
 #endif
   }
+  // cuSPARSE 12 requires that the output (y) vector is 16-byte aligned for all
+  // scalar types
+#if defined(CUSPARSE_VER_MAJOR) && (CUSPARSE_VER_MAJOR == 12)
+  uintptr_t yptr = uintptr_t((void*)y.data());
+  if (yptr % 16 != 0) useFallback = true;
+#endif
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE


### PR DESCRIPTION
cusparse 12 requires that the y (output) vector in ``cusparseSpMV`` has 16-byte alignment (for all scalar types).
So check for this and call the native fallback if y has less than 16 bytes alignment.

This will fix https://github.com/trilinos/trilinos/issues/11926.