### PR TITLE
Don't write to source tree during build

### DIFF
--- a/perf_test/batched/sparse/CMakeLists.txt
+++ b/perf_test/batched/sparse/CMakeLists.txt
@@ -3,6 +3,15 @@ ADD_SUBDIRECTORY(cusolver)
 ADD_SUBDIRECTORY(GMRES)
 ADD_SUBDIRECTORY(SPMV)
 
-FILE(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/scripts/binary_dir.txt
-"${CMAKE_CURRENT_BINARY_DIR}"
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_CG.sh.in
+    ${CMAKE_CURRENT_BINARY_DIR}/scripts/run_CG.sh
+)
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_GMRES.sh.in
+    ${CMAKE_CURRENT_BINARY_DIR}/scripts/run_GMRES.sh
+)
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_SPMV.sh.in
+    ${CMAKE_CURRENT_BINARY_DIR}/scripts/run_SPMV.sh
 )

--- a/perf_test/batched/sparse/scripts/run_CG.sh
+++ b/perf_test/batched/sparse/scripts/run_CG.sh
@@ -1,3 +1,0 @@
-exe_path=$(head -n 1 "binary_dir.txt")
-
-${exe_path}/CG/KokkosBatched_Test_CG -A ../data/A.mm -B ../data/B.mm -X ../output/X_CG -timers ../output/timers_CG -n1 10 -n2 100 -team_size -1 -implementation 0 -l -n_iterations 20 -tol 1e-8 -vector_length 8 -N_team 8

--- a/perf_test/batched/sparse/scripts/run_CG.sh.in
+++ b/perf_test/batched/sparse/scripts/run_CG.sh.in
@@ -1,0 +1,1 @@
+@CMAKE_CURRENT_BINARY_DIR@/CG/KokkosBatched_Test_CG -A ../data/A.mm -B ../data/B.mm -X ../output/X_CG -timers ../output/timers_CG -n1 10 -n2 100 -team_size -1 -implementation 0 -l -n_iterations 20 -tol 1e-8 -vector_length 8 -N_team 8

--- a/perf_test/batched/sparse/scripts/run_GMRES.sh
+++ b/perf_test/batched/sparse/scripts/run_GMRES.sh
@@ -1,3 +1,0 @@
-exe_path=$(head -n 1 "binary_dir.txt")
-
-${exe_path}/GMRES/KokkosBatched_Test_GMRES -A ../data/A.mm -B ../data/B.mm -X ../output/X_GMRES -timers ../output/timers_GMRES -n1 10 -n2 100 -team_size -1 -implementation 0 -l -n_iterations 20 -tol 1e-8 -vector_length 8 -N_team 8

--- a/perf_test/batched/sparse/scripts/run_GMRES.sh.in
+++ b/perf_test/batched/sparse/scripts/run_GMRES.sh.in
@@ -1,0 +1,1 @@
+@CMAKE_CURRENT_BINARY_DIR@/GMRES/KokkosBatched_Test_GMRES -A ../data/A.mm -B ../data/B.mm -X ../output/X_GMRES -timers ../output/timers_GMRES -n1 10 -n2 100 -team_size -1 -implementation 0 -l -n_iterations 20 -tol 1e-8 -vector_length 8 -N_team 8

--- a/perf_test/batched/sparse/scripts/run_SPMV.sh
+++ b/perf_test/batched/sparse/scripts/run_SPMV.sh
@@ -1,3 +1,0 @@
-exe_path=$(head -n 1 "binary_dir.txt")
-
-${exe_path}/SPMV/KokkosBatched_Test_SPMV -A ../data/A.mm -B ../data/B.mm -X ../output/X_SPMV -timers ../output/timers_SPMV -n1 10 -n2 100 -team_size -1 -implementation 3 -l -vector_length 8 -N_team 8

--- a/perf_test/batched/sparse/scripts/run_SPMV.sh.in
+++ b/perf_test/batched/sparse/scripts/run_SPMV.sh.in
@@ -1,0 +1,1 @@
+@CMAKE_CURRENT_BINARY_DIR@/SPMV/KokkosBatched_Test_SPMV -A ../data/A.mm -B ../data/B.mm -X ../output/X_SPMV -timers ../output/timers_SPMV -n1 10 -n2 100 -team_size -1 -implementation 3 -l -vector_length 8 -N_team 8


### PR DESCRIPTION
Fix for https://github.com/kokkos/kokkos-kernels/issues/1898

Produces scripts that look like this:

```
/opt/kokkos-kernels-build/perf_test/batched/sparse/CG/KokkosBatched_Test_CG -A ../data/A.mm -B ../data/B.mm -X ../output/X_CG -timers ../output/timers_CG -n1 10 -n2 100 -team_size -1 -implementation 0 -l -n_iterations 20 -tol 1e-8 -vector_length 8 -N_team 8
```
```
/opt/kokkos-kernels-build/perf_test/batched/sparse/GMRES/KokkosBatched_Test_GMRES -A ../data/A.mm -B ../data/B.mm -X ../output/X_GMRES -timers ../output/timers_GMRES -n1 10 -n2 100 -team_size -1 -implementation 0 -l -n_iterations 20 -tol 1e-8 -vector_length 8 -N_team 8
```
```
/opt/kokkos-kernels-build/perf_test/batched/sparse/SPMV/KokkosBatched_Test_SPMV -A ../data/A.mm -B ../data/B.mm -X ../output/X_SPMV -timers ../output/timers_SPMV -n1 10 -n2 100 -team_size -1 -implementation 3 -l -vector_length 8 -N_team 8
```