### PR TITLE
Add missing `<vector>` include to `Test_Sparse_MergeMatrix.hpp`

### DIFF
--- a/sparse/unit_test/Test_Sparse_MergeMatrix.hpp
+++ b/sparse/unit_test/Test_Sparse_MergeMatrix.hpp
@@ -17,6 +17,8 @@
 #ifndef TEST_COMMON_MERGE_MATRIX
 #define TEST_COMMON_MERGE_MATRIX
 
+#include <vector>
+
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
 


### PR DESCRIPTION
This corrects a definite omission, and may also fix https://github.com/kokkos/kokkos-kernels/issues/1905 (I don't have access to the test system yet).