### PR TITLE
Fix #1891

### DIFF
--- a/common/src/KokkosKernels_BlockHashmapAccumulator.hpp
+++ b/common/src/KokkosKernels_BlockHashmapAccumulator.hpp
@@ -250,9 +250,8 @@ struct BlockHashmapAccumulator {
       KokkosSparse::Impl::kk_block_set_mul(
           block_dim, values + my_write_index * block_size, valA, valB);
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -327,9 +326,8 @@ struct BlockHashmapAccumulator {
       KokkosSparse::Impl::kk_block_set_mul(
           block_dim, values + my_write_index * block_size, valA, valB);
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -407,9 +405,8 @@ struct BlockHashmapAccumulator {
     } else {
       keys[my_write_index] = key;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -460,9 +457,8 @@ struct BlockHashmapAccumulator {
       keys[my_write_index]   = key;
       values[my_write_index] = value;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -514,9 +510,8 @@ struct BlockHashmapAccumulator {
       keys[my_write_index]   = key;
       values[my_write_index] = value;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -564,9 +559,8 @@ struct BlockHashmapAccumulator {
     } else {
       keys[my_write_index] = key;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done

--- a/common/src/KokkosKernels_HashmapAccumulator.hpp
+++ b/common/src/KokkosKernels_HashmapAccumulator.hpp
@@ -16,6 +16,7 @@
 #ifndef _KOKKOSKERNELS_HASHMAPACCUMULATOR_HPP
 #define _KOKKOSKERNELS_HASHMAPACCUMULATOR_HPP
 #include <Kokkos_Atomic.hpp>
+#include "KokkosKernels_Macros.hpp"
 #include <atomic>
 
 namespace KokkosKernels {
@@ -412,9 +413,8 @@ struct HashmapAccumulator {
       keys[my_write_index]   = key;
       values[my_write_index] = value;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA because warps do not go in SIMD fashion
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ because warps do not go in SIMD fashion
       // anymore. while some thread might insert my_write_index into linked
       // list, another thread in the warp might be reading keys in above loop.
       // before inserting the new value in liked list -- which is done with
@@ -483,9 +483,8 @@ struct HashmapAccumulator {
       keys[my_write_index]   = key;
       values[my_write_index] = value;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -601,9 +600,8 @@ struct HashmapAccumulator {
       keys[my_write_index]   = key;
       values[my_write_index] = value;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -679,9 +677,8 @@ struct HashmapAccumulator {
     } else {
       keys[my_write_index] = key;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -732,9 +729,8 @@ struct HashmapAccumulator {
       keys[my_write_index]   = key;
       values[my_write_index] = value;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -786,9 +782,8 @@ struct HashmapAccumulator {
       keys[my_write_index]   = key;
       values[my_write_index] = value;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done
@@ -836,9 +831,8 @@ struct HashmapAccumulator {
     } else {
       keys[my_write_index] = key;
 
-#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
-    defined(KOKKOS_ARCH_AMPERE)
-      // this is an issue on VOLTA and up because warps do not go in SIMD
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+      // this is an issue on VOLTA+ and up because warps do not go in SIMD
       // fashion anymore. while some thread might insert my_write_index into
       // linked list, another thread in the warp might be reading keys in above
       // loop. before inserting the new value in liked list -- which is done

--- a/common/src/KokkosKernels_Macros.hpp
+++ b/common/src/KokkosKernels_Macros.hpp
@@ -96,4 +96,13 @@
 #endif  // KOKKOS_COMPILER_GNU
 /******* END other helper macros *******/
 
+// define KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS if we are targeting a CUDA
+// architecture with "independent thread scheduling" (Volta70 and up). This
+// requires some extra logic in HashmapAccumulator to avoid data races.
+#if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || \
+    defined(KOKKOS_ARCH_AMPERE) || defined(KOKKOS_ARCH_ADA89) ||   \
+    defined(KOKKOS_ARCH_HOPPER)
+#define KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+#endif
+
 #endif  // KOKKOSKERNELS_MACROS_HPP_


### PR DESCRIPTION
(HashmapAccumulator data races on Ada and Hopper architectures). To avoid checking for every architecture at every location, add a new macro ``KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS`` which is defined if we're targeting an architecture with independent thread scheduling (Volta, Ampere, Turing, Ada, Hopper, and any future ones).