### PR TITLE
ODE: BDF methods

### DIFF
--- a/batched/dense/impl/KokkosBatched_Gesv_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gesv_Impl.hpp
@@ -366,20 +366,24 @@ KOKKOS_INLINE_FUNCTION void TeamVectorHadamard1D(const MemberType &member,
 /// ===========
 template <>
 struct SerialGesv<Gesv::StaticPivoting> {
-  template <typename MatrixType, typename VectorType>
+  template <typename MatrixType, typename XVectorType, typename YVectorType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MatrixType A,
-                                           const VectorType X,
-                                           const VectorType Y,
+                                           const XVectorType X,
+                                           const YVectorType Y,
                                            const MatrixType tmp) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
     static_assert(Kokkos::is_view<MatrixType>::value,
                   "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<VectorType>::value,
-                  "KokkosBatched::gesv: VectorType is not a Kokkos::View.");
+    static_assert(Kokkos::is_view<XVectorType>::value,
+                  "KokkosBatched::gesv: XVectorType is not a Kokkos::View.");
+    static_assert(Kokkos::is_view<YVectorType>::value,
+                  "KokkosBatched::gesv: YVectorType is not a Kokkos::View.");
     static_assert(MatrixType::rank == 2,
                   "KokkosBatched::gesv: MatrixType must have rank 2.");
-    static_assert(VectorType::rank == 1,
-                  "KokkosBatched::gesv: VectorType must have rank 1.");
+    static_assert(XVectorType::rank == 1,
+                  "KokkosBatched::gesv: XVectorType must have rank 1.");
+    static_assert(YVectorType::rank == 1,
+                  "KokkosBatched::gesv: YVectorType must have rank 1.");
 
     // Check compatibility of dimensions at run time.
 
@@ -462,20 +466,24 @@ struct SerialGesv<Gesv::StaticPivoting> {
 
 template <>
 struct SerialGesv<Gesv::NoPivoting> {
-  template <typename MatrixType, typename VectorType>
+  template <typename MatrixType, typename XVectorType, typename YVectorType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MatrixType A,
-                                           const VectorType X,
-                                           const VectorType Y,
+                                           const XVectorType X,
+                                           const YVectorType Y,
                                            const MatrixType /*tmp*/) {
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
     static_assert(Kokkos::is_view<MatrixType>::value,
                   "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<VectorType>::value,
-                  "KokkosBatched::gesv: VectorType is not a Kokkos::View.");
+    static_assert(Kokkos::is_view<XVectorType>::value,
+                  "KokkosBatched::gesv: XVectorType is not a Kokkos::View.");
+    static_assert(Kokkos::is_view<YVectorType>::value,
+                  "KokkosBatched::gesv: YVectorType is not a Kokkos::View.");
     static_assert(MatrixType::rank == 2,
                   "KokkosBatched::gesv: MatrixType must have rank 2.");
-    static_assert(VectorType::rank == 1,
-                  "KokkosBatched::gesv: VectorType must have rank 1.");
+    static_assert(XVectorType::rank == 1,
+                  "KokkosBatched::gesv: XVectorType must have rank 1.");
+    static_assert(YVectorType::rank == 1,
+                  "KokkosBatched::gesv: YVectorType must have rank 1.");
 
     // Check compatibility of dimensions at run time.
 

--- a/batched/dense/src/KokkosBatched_Gesv.hpp
+++ b/batched/dense/src/KokkosBatched_Gesv.hpp
@@ -63,11 +63,20 @@ struct Gesv {
 
 template <typename ArgAlgo>
 struct SerialGesv {
+  template <typename MatrixType, typename XVectorType, typename YVectorType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MatrixType A,
+                                           const XVectorType X,
+                                           const YVectorType Y,
+                                           const MatrixType tmp);
+
   template <typename MatrixType, typename VectorType>
+  [[deprecated]]
   KOKKOS_INLINE_FUNCTION static int invoke(const MatrixType A,
                                            const VectorType X,
                                            const VectorType Y,
-                                           const MatrixType tmp);
+                                           const MatrixType tmp) {
+    return invoke(A, X, Y, tmp);
+  }
 };
 
 /// \brief Team Batched GESV:

--- a/batched/dense/src/KokkosBatched_Gesv.hpp
+++ b/batched/dense/src/KokkosBatched_Gesv.hpp
@@ -70,11 +70,9 @@ struct SerialGesv {
                                            const MatrixType tmp);
 
   template <typename MatrixType, typename VectorType>
-  [[deprecated]]
-  KOKKOS_INLINE_FUNCTION static int invoke(const MatrixType A,
-                                           const VectorType X,
-                                           const VectorType Y,
-                                           const MatrixType tmp) {
+  [[deprecated]] KOKKOS_INLINE_FUNCTION static int invoke(
+      const MatrixType A, const VectorType X, const VectorType Y,
+      const MatrixType tmp) {
     return invoke(A, X, Y, tmp);
   }
 };

--- a/ode/impl/KokkosODE_BDF_impl.hpp
+++ b/ode/impl/KokkosODE_BDF_impl.hpp
@@ -235,14 +235,14 @@ KOKKOS_FUNCTION void initial_step_size(const ode_type ode, const int order, cons
 				       const mat_type& temp, scalar_type& dt_ini) {
   using KAT = Kokkos::ArithTraits<scalar_type>;
 
-  Kokkos::printf("Estimating initial step size\n");
+  // Kokkos::printf("Estimating initial step size\n");
 
   // Extract subviews to store intermediate data
   auto scale = Kokkos::subview(temp, Kokkos::ALL(), 0); // Scaling coefficients for error calculation
   auto y1    = Kokkos::subview(temp, Kokkos::ALL(), 1); // Scaling coefficients for error calculation
   auto f1    = Kokkos::subview(temp, Kokkos::ALL(), 2); // Scaling coefficients for error calculation
 
-  Kokkos::printf("scale: rank=%d, extent(0)=%d\n", (int)scale.rank(), scale.extent_int(0));
+  // Kokkos::printf("scale: rank=%d, extent(0)=%d\n", (int)scale.rank(), scale.extent_int(0));
 
   // Compute norms for y0 and f0
   double n0 = KAT::zero(), n1 = KAT::zero(), dt0;

--- a/ode/impl/KokkosODE_BDF_impl.hpp
+++ b/ode/impl/KokkosODE_BDF_impl.hpp
@@ -121,17 +121,18 @@ struct BDF_system_wrapper {
   }
 };
 
-  template <class system_type, class subview_type>
+template <class system_type, class subview_type, class d_vec_type>
 struct BDF_system_wrapper2 {
   const system_type mySys;
   const int neqs;
-  const subview_type psi, d;
+  const subview_type psi;
+  const d_vec_type d;
 
   double t, dt, c = 0;
 
   KOKKOS_FUNCTION
   BDF_system_wrapper2(const system_type& mySys_,
-		      const subview_type& psi_, const subview_type& d_,
+		      const subview_type& psi_, const d_vec_type& d_,
 		      const double t_, const double dt_)
       : mySys(mySys_),
         neqs(mySys_.neqs),
@@ -144,6 +145,8 @@ struct BDF_system_wrapper2 {
   KOKKOS_FUNCTION void residual(const vec_type& y, const vec_type& f) const {
     // f = f(t+dt, y)
     mySys.evaluate_function(t, dt, y, f);
+
+    // std::cout << "f = psi + d - c * f = " << psi(0) << " + " << d(0) << " - " << c << " * " << f(0) << std::endl;
 
     // rhs = higher order terms + y_{n+1}^i - y_n - dt*f
     for (int eqIdx = 0; eqIdx < neqs; ++eqIdx) {
@@ -208,26 +211,39 @@ template <class mat_type, class scalar_type>
 KOKKOS_FUNCTION void update_D(const int order, const scalar_type factor,
 			      const mat_type& coeffs,
 			      const mat_type& tempD, const mat_type& D) {
-  std::cout << "Extract subviews from D and tempD" << std::endl;
+  // std::cout << "Extract subviews from D and tempD" << std::endl;
+  // std::cout << "D: {" << D(0, 0) << ", " << D(0, 1) << ", " << D(0, 2) << ", " << D(0, 3) << ", " << D(0, 4) << "}" << std::endl;
   auto subD     = Kokkos::subview(D,     Kokkos::ALL(), Kokkos::pair<int, int>(0, order + 1));
   auto subTempD = Kokkos::subview(tempD, Kokkos::ALL(), Kokkos::pair<int, int>(0, order + 1));
 
+  // std::cout << "subD: { " << subD(0, 0);
+  // for(int orderIdx = 1; orderIdx < order + 1; ++orderIdx) {
+  //   std::cout << ", " << subD(0, orderIdx);
+  // }
+  // std::cout << " }"<< std::endl;
+  // std::cout << "subD shape: (" << subD.extent(0) << ", " << subD.extent(1) << ")" << std::endl;
+
   compute_coeffs(order, factor, coeffs);
   auto R = Kokkos::subview(coeffs, Kokkos::pair<int, int>(0, order + 1), Kokkos::pair<int, int>(0, order + 1));
-  KokkosBatched::SerialGemm<KokkosBatched::Trans::Transpose,
+  // std::cout << "R: " << R(0, 0) << ", " << R(0, 1) << ", " << R(1, 0) << ", " << R(1, 1) << std::endl;
+  // std::cout << "R shape: (" << R.extent(0) << ", " << R.extent(1) << ")" << std::endl;
+  KokkosBatched::SerialGemm<KokkosBatched::Trans::NoTranspose,
 			    KokkosBatched::Trans::NoTranspose,
-			    KokkosBatched::Algo::Gemm::Blocked>::invoke(1.0, R, subD, 0.0, subTempD);
+			    KokkosBatched::Algo::Gemm::Blocked>::invoke(1.0, subD, R, 0.0, subTempD);
+  // std::cout << "subTempD: " << subTempD(0, 0) << ", " << subTempD(0, 1) << std::endl;
 
   compute_coeffs(order, 1.0, coeffs);
   auto U = Kokkos::subview(coeffs, Kokkos::pair<int, int>(0, order + 1), Kokkos::pair<int, int>(0, order + 1));
-  KokkosBatched::SerialGemm<KokkosBatched::Trans::Transpose,
+  // std::cout << "U: " << R(0, 0) << ", " << R(0, 1) << ", " << R(1, 0) << ", " << R(1, 1) << std::endl;
+  KokkosBatched::SerialGemm<KokkosBatched::Trans::NoTranspose,
 			    KokkosBatched::Trans::NoTranspose,
-			    KokkosBatched::Algo::Gemm::Blocked>::invoke(1.0, U, subTempD, 0.0, subD);
+			    KokkosBatched::Algo::Gemm::Blocked>::invoke(1.0, subTempD, U, 0.0, subD);
+  // std::cout << "subTempD: " << subD(0, 0) << ", " << subD(0, 1) << std::endl;
 }
 
 template <class ode_type, class vec_type,
           class mat_type, class scalar_type>
-KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type t, scalar_type& dt,
+KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type& t, scalar_type& dt,
 			     scalar_type t_end, int& order, int& num_equal_steps,
 			     const int max_newton_iters,
 			     const scalar_type atol, const scalar_type rtol,
@@ -236,26 +252,30 @@ KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type t, scalar_type& dt,
                              const vec_type& rhs, const vec_type& update,
                              const mat_type& temp, const mat_type& temp2) {
   using newton_params = KokkosODE::Experimental::Newton_params;
-  // Kokkos::Array<double, 6> kappa{{0., -0.1850, -1/9      , -0.0823000, -0.0415000, 0.}};
+
+  constexpr int max_order = 5;
+
+  // For NDF coefficients see Sahmpine and Reichelt, The Matlab ODE suite, SIAM SISCm 18, 1, p1-22, January 1997
+  // Kokkos::Array<double, 6> kappa{{0., -0.1850, -1/9      , -0.0823000, -0.0415000, 0.}}; // NDF coefficients kappa
+  // gamma(i) = sum_{k=1}^i(1.0 / k); gamma(0) = 0;                                         // NDF coefficients gamma_k
   // alpha(i) = (1 - kappa(i)) * gamma(i)
   // error_const(i) = kappa(i) * gamma(i) + 1 / (i + 1)
-  // gamma(i) = sum_{k=0}^i(1.0 / k); gamma(0) = 0;
-  Kokkos::Array<double, 6> alpha{{0., 1.185  , 1.66666667, 1.98421667, 2.16979167, 2.28333333}};
-  Kokkos::Array<double, 6> error_const{{1.        , 0.315     , 0.16666667, 0.09911667, 0.11354167, 0.16666667}};
+  const Kokkos::Array<const double, 6> alpha{{0., 1.185  , 1.66666667, 1.98421667, 2.16979167, 2.28333333}};
+  const Kokkos::Array<const double, 6> error_const{{1.        , 0.315     , 0.16666667, 0.09911667, 0.11354167, 0.16666667}};
 
   // Extract columns of temp to form temporary
   // subviews to operate on.
-  const int numRows = temp.extent_int(0); const int numCols = temp.extent_int(1);
-  std::cout << "numRows: " << numRows << ", numCols: " << numCols << std::endl;
-  std::cout << "Extract subview from temp" << std::endl;
+  // const int numRows = temp.extent_int(0); const int numCols = temp.extent_int(1);
+  // std::cout << "numRows: " << numRows << ", numCols: " << numCols << std::endl;
+  // std::cout << "Extract subview from temp" << std::endl;
   int offset = 0;
-  auto D         = Kokkos::subview(temp, Kokkos::ALL(), Kokkos::pair<int, int>(offset, offset + 8));
+  auto D         = Kokkos::subview(temp, Kokkos::ALL(), Kokkos::pair<int, int>(offset, offset + 8)); // y and its derivatives
   offset += 8;
   auto tempD     = Kokkos::subview(temp, Kokkos::ALL(), Kokkos::pair<int, int>(offset, offset + 8));
   offset += 8;
   auto scale     = Kokkos::subview(temp, Kokkos::ALL(), offset + 1); ++offset; // Scaling coefficients for error calculation
   auto y_predict = Kokkos::subview(temp, Kokkos::ALL(), offset + 1); ++offset; // Initial guess for y_{n+1}
-  auto d         = Kokkos::subview(temp, Kokkos::ALL(), offset + 1); ++offset; // Newton update: y_{n+1}^i - y_n
+  // auto d         = Kokkos::subview(temp, Kokkos::ALL(), offset + 1); ++offset; // Newton update: y_{n+1}^i - y_n
   auto psi       = Kokkos::subview(temp, Kokkos::ALL(), offset + 1); ++offset; // Higher order terms contribution to rhs
   auto error     = Kokkos::subview(temp, Kokkos::ALL(), offset + 1); ++offset; // Error estimate
   auto jac       = Kokkos::subview(temp, Kokkos::ALL(), Kokkos::pair<int, int>(offset, offset + ode.neqs)); // Jacobian matrix
@@ -264,17 +284,20 @@ KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type t, scalar_type& dt,
 				   Kokkos::pair<int, int>(offset, offset + ode.neqs + 4)); // Buffer space for gesv calculation
   offset += ode.neqs + 4;
 
-  std::cout << "Extract subview from temp2" << std::endl;
-  std::cout << "  temp2: (" << temp2.extent(0) << ", " << temp2.extent(1) << ")" << std::endl;
-  auto coeffs = Kokkos::subview(temp2, Kokkos::ALL(), Kokkos::pair<int, int>(0, order + 1));
+  // std::cout << "update.span_is_contiguous()? " << update.span_is_contiguous() << std::endl;
+
+  // std::cout << "Extract subview from temp2" << std::endl;
+  // std::cout << "  temp2: (" << temp2.extent(0) << ", " << temp2.extent(1) << ")" << std::endl;
+  auto coeffs = Kokkos::subview(temp2, Kokkos::ALL(), Kokkos::pair<int, int>(0, 6));
   auto gamma  = Kokkos::subview(temp2, Kokkos::ALL(), 6);
   gamma(0) = 0.0; gamma(1) = 1.0; gamma(2) = 1.5; gamma(3) = 1.83333333; gamma(4) = 2.08333333; gamma(5) = 2.28333333;
 
-  BDF_system_wrapper2 sys(ode, psi, d, t, dt);
+  BDF_system_wrapper2 sys(ode, psi, update, t, dt);
   const newton_params param(max_newton_iters, atol, rtol);
 
   scalar_type max_step = Kokkos::ArithTraits<scalar_type>::max();
   scalar_type min_step = Kokkos::ArithTraits<scalar_type>::min();
+  scalar_type safety, error_norm;
   if(dt > max_step) {
     update_D(order, max_step / dt, coeffs, tempD, D);
     dt = max_step;
@@ -290,10 +313,12 @@ KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type t, scalar_type& dt,
     y_new(eqIdx) = y_old(eqIdx);
   }
 
-  std::cout << "Hello 1" << std::endl;
+  // std::cout << "Hello 1" << std::endl;
+  // std::cout << "dt=" << dt << std::endl;
 
   double t_new = 0;
   bool step_accepted = false;
+  int count = 0;
   while (!step_accepted) {
     if(dt < min_step) {return ;}
     t_new = t + dt;
@@ -305,9 +330,10 @@ KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type t, scalar_type& dt,
     }
     dt = t_new - t;
 
-    std::cout << "Hello 2" << std::endl;
+    // std::cout << "Hello 2" << std::endl;
 
     for(int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
+      y_predict(eqIdx) = 0;
       for(int orderIdx = 0; orderIdx < order + 1; ++orderIdx) {
 	y_predict(eqIdx) += D(eqIdx, orderIdx);
       }
@@ -320,18 +346,24 @@ KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type t, scalar_type& dt,
     auto subGamma = Kokkos::subview(gamma, Kokkos::pair<int, int>(1, order + 1));
     KokkosBlas::Experimental::serial_gemv('N', 1.0 / alpha[order], subD, subGamma, 0.0, psi);
 
-    std::cout << "Hello 3" << std::endl;
+    // std::cout << "Hello 3" << std::endl;
+    // std::cout << "dt=" << dt << std::endl;
 
     sys.c = dt / alpha[order];
     sys.jacobian(y_new, jac);
-    std::cout << "c=" << sys.c << ", psi=" << psi(0) << ", y_predict=" << y_predict(0) << std::endl;
-    std::cout << "jac: " << jac(0, 0) << std::endl;
+    // std::cout << "c=" << sys.c << ", psi=" << psi(0) << ", y_predict=" << y_predict(0) << std::endl;
+    // std::cout << "jac: " << jac(0, 0) << std::endl;
     Kokkos::deep_copy(y_new, y_predict);
+    Kokkos::deep_copy(update, 0);
     KokkosODE::Experimental::newton_solver_status newton_status = 
       KokkosODE::Experimental::Newton::Solve(sys, param, jac, tmp_gesv, y_new, rhs,
 					     update);
 
-    std::cout << "Newton Status: " << (newton_status == KokkosODE::Experimental::newton_solver_status::NLS_SUCCESS ? "converged" : "not converged") << std::endl;
+    for(int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
+      update(eqIdx) = y_new(eqIdx) - y_predict(eqIdx);
+    }
+
+    // std::cout << "\n******** Newton Status: " << (newton_status == KokkosODE::Experimental::newton_solver_status::NLS_SUCCESS ? "converged" : "not converged") << " ********\n" << std::endl;
     if(newton_status == KokkosODE::Experimental::newton_solver_status::MAX_ITER) {
       dt = 0.5*dt;
       update_D(order, 0.5, coeffs, tempD, D);
@@ -339,11 +371,11 @@ KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type t, scalar_type& dt,
 
     } else {
       // Estimate the solution error
-      scalar_type safety = 0.9*(2*max_newton_iters + 1) / (2*max_newton_iters + param.iters);
-      scalar_type error_norm = 0;
+      safety = 0.9*(2*max_newton_iters + 1) / (2*max_newton_iters + param.iters);
+      error_norm = 0;
       for(int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
 	scale(eqIdx) = atol + rtol*Kokkos::abs(y_new(eqIdx));
-	error(eqIdx) = error_const[order]*d(eqIdx) / scale(eqIdx);
+	error(eqIdx) = error_const[order]*update(eqIdx) / scale(eqIdx);
 	error_norm += error(eqIdx)*error(eqIdx);
       }
       error_norm = Kokkos::sqrt(error_norm);
@@ -359,8 +391,85 @@ KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type t, scalar_type& dt,
       }
     }
 
-    std::cout << "Hello 5" << std::endl;
+    // std::cout << "Hello 5" << std::endl;
+    ++count;
+    if(count == 5) {step_accepted = true;}
   } // while(!step_accepted)
+
+  // std::cout << "d=" << d(0) << std::endl;
+  // std::cout << "update=" << update(0) << std::endl;
+
+  // Now that our time step has been
+  // accepted we update all our states
+  // and see if we can adapt the order
+  // or the time step before going to
+  // the next step.
+  ++num_equal_steps; // std::cout << "num equal steps: " << num_equal_steps << std::endl;
+  t = t_new;
+  for(int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
+    D(eqIdx, order + 2) = update(eqIdx) - D(eqIdx, order + 1);
+    D(eqIdx, order + 1) = update(eqIdx);
+    for(int orderIdx = order; 0 <= orderIdx; --orderIdx) {
+      // std::cout << "updating D(:, " << orderIdx << ")" << std::endl;
+      D(eqIdx, orderIdx) += D(eqIdx, orderIdx + 1);
+    }
+  }
+  // std::cout << "D: {" << D(0, 0) << ", " << D(0, 1) << ", " << D(0, 2) << ", " << D(0, 3) << ", " << D(0, 4) << "}" << std::endl;
+
+  // std::cout << "Hello 6" << std::endl;
+
+  // Not enough steps at constant dt
+  // have been succesfull so we do not
+  // attempt order adaptation.
+  double error_low = 0, error_high = 0;
+  if(num_equal_steps < order + 1) { return; }
+
+  // std::cout << "Hello 7" << std::endl;
+
+  if(1 < order) {
+    for(int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
+      error_low += Kokkos::pow(error_const[order - 1] * D(eqIdx, order) / scale(eqIdx), 2);
+    }
+    error_low = Kokkos::sqrt(error_low);
+  } else {
+    error_low = Kokkos::ArithTraits<double>::max();
+  }
+
+  if(order < max_order) {
+    for(int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
+      error_high += Kokkos::pow(error_const[order + 1] * D(eqIdx, order + 2) / scale(eqIdx), 2);
+    }
+    error_high = Kokkos::sqrt(error_high);
+  } else {
+    error_high = Kokkos::ArithTraits<double>::max();
+  }
+
+  // std::cout << "Hello 8" << std::endl;
+
+  double factor_low, factor_mid, factor_high, factor;
+  factor_low  = Kokkos::pow(error_low,  -1.0 / order);
+  factor_mid  = Kokkos::pow(error_norm, -1.0 / (order + 1));
+  factor_high = Kokkos::pow(error_high, -1.0 / (order + 2));
+
+  if((factor_mid < factor_low) && (factor_high < factor_low)) {
+    --order;
+    factor = factor_low;
+  } else if((factor_low < factor_high) && (factor_mid < factor_high)) {
+    ++order;
+    factor = factor_high;
+  } else {
+    factor = factor_mid;
+  }
+  factor = Kokkos::fmin(10, safety*factor);
+  dt *= factor;
+  // std::cout << "D: {" << D(0, 0) << ", " << D(0, 1) << ", " << D(0, 2) << ", " << D(0, 3) << ", " << D(0, 4) << "}" << std::endl;
+  // std::cout << "new order= " << order << ", factor= " << factor << std::endl;
+  update_D(order, factor, coeffs, tempD, D);
+  num_equal_steps = 0;
+
+  // std::cout << "Hello 9" << std::endl;
+  // std::cout << "factor=" << factor << std::endl;
+  // std::cout << "dt=" << dt << std::endl;
 
 }  // BDFStep
 

--- a/ode/impl/KokkosODE_BDF_impl.hpp
+++ b/ode/impl/KokkosODE_BDF_impl.hpp
@@ -1,0 +1,149 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOSBLAS_BDF_IMPL_HPP
+#define KOKKOSBLAS_BDF_IMPL_HPP
+
+#include "Kokkos_Core.hpp"
+
+#include "KokkosODE_Newton.hpp"
+
+namespace KokkosODE {
+namespace Impl {
+
+template <int order>
+struct BDF_table {};
+
+template <>
+struct BDF_table<1> {
+  static constexpr int order = 1;
+  Kokkos::Array<double, 2> coefficients{{-1.0, 1.0}};
+};
+
+template <>
+struct BDF_table<2> {
+  static constexpr int order = 2;
+  Kokkos::Array<double, 3> coefficients{{-4.0 / 3.0, 1.0 / 3.0, 2.0 / 3.0}};
+};
+
+template <>
+struct BDF_table<3> {
+  static constexpr int order = 3;
+  Kokkos::Array<double, 4> coefficients{
+      {-18.0 / 11.0, 9.0 / 11.0, -2.0 / 11.0, 6.0 / 11.0}};
+};
+
+template <>
+struct BDF_table<4> {
+  static constexpr int order = 4;
+  Kokkos::Array<double, 5> coefficients{
+      {-48.0 / 25.0, 36.0 / 25.0, -16.0 / 25.0, 3.0 / 25.0, 12.0 / 25.0}};
+};
+
+template <>
+struct BDF_table<5> {
+  static constexpr int order = 5;
+  Kokkos::Array<double, 6> coefficients{{-300.0 / 137.0, 300.0 / 137.0,
+                                         -200.0 / 137.0, 75.0 / 137.0,
+                                         -12.0 / 137.0, 60.0 / 137.0}};
+};
+
+template <>
+struct BDF_table<6> {
+  static constexpr int order = 6;
+  Kokkos::Array<double, 7> coefficients{
+      {-360.0 / 147.0, 450.0 / 147.0, -400.0 / 147.0, 225.0 / 147.0,
+       -72.0 / 147.0, 10.0 / 147.0, 60.0 / 147.0}};
+};
+
+template <class system_type, class table_type, class mv_type>
+struct BDF_system_wrapper {
+  const system_type mySys;
+  const int neqs;
+  const table_type table;
+  const int order = table.order;
+
+  double t, dt;
+  mv_type yn;
+
+  KOKKOS_FUNCTION
+  BDF_system_wrapper(const system_type& mySys_, const table_type& table_,
+                     const double t_, const double dt_, const mv_type& yn_)
+      : mySys(mySys_),
+        neqs(mySys_.neqs),
+        table(table_),
+        t(t_),
+        dt(dt_),
+        yn(yn_) {}
+
+  template <class vec_type>
+  KOKKOS_FUNCTION void residual(const vec_type& y, const vec_type& f) const {
+    // f = f(t+dt, y)
+    mySys.evaluate_function(t, dt, y, f);
+
+    for (int eqIdx = 0; eqIdx < neqs; ++eqIdx) {
+      f(eqIdx) = y(eqIdx) - table.coefficients[order] * dt * f(eqIdx);
+      for (int orderIdx = 0; orderIdx < order; ++orderIdx) {
+        f(eqIdx) +=
+            table.coefficients[order - 1 - orderIdx] * yn(eqIdx, orderIdx);
+      }
+    }
+  }
+
+  template <class vec_type, class mat_type>
+  KOKKOS_FUNCTION void jacobian(const vec_type& y, const mat_type& jac) const {
+    mySys.evaluate_jacobian(t, dt, y, jac);
+
+    for (int rowIdx = 0; rowIdx < neqs; ++rowIdx) {
+      for (int colIdx = 0; colIdx < neqs; ++colIdx) {
+        jac(rowIdx, colIdx) =
+            -table.coefficients[order] * dt * jac(rowIdx, colIdx);
+      }
+      jac(rowIdx, rowIdx) += 1.0;
+    }
+  }
+};
+
+template <class ode_type, class table_type, class vec_type, class mv_type,
+          class mat_type, class scalar_type>
+KOKKOS_FUNCTION void BDFStep(ode_type& ode, const table_type& table,
+                             scalar_type t, scalar_type dt,
+                             const vec_type& y_old, const vec_type& y_new,
+                             const vec_type& rhs, const vec_type& update,
+                             const mv_type& y_vecs, const mat_type& temp,
+                             const mat_type& jac) {
+  using newton_params = KokkosODE::Experimental::Newton_params;
+
+  BDF_system_wrapper sys(ode, table, t, dt, y_vecs);
+  const newton_params param(50, 1e-14, 1e-12);
+
+  // first set y_new = y_old
+  for (int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
+    y_new(eqIdx) = y_old(eqIdx);
+  }
+
+  // solver the nonlinear problem
+  {
+    KokkosODE::Experimental::Newton::Solve(sys, param, jac, temp, y_new, rhs,
+                                           update);
+  }
+
+}  // BDFStep
+
+}  // namespace Impl
+}  // namespace KokkosODE
+
+#endif  // KOKKOSBLAS_BDF_IMPL_HPP

--- a/ode/impl/KokkosODE_BDF_impl.hpp
+++ b/ode/impl/KokkosODE_BDF_impl.hpp
@@ -336,7 +336,7 @@ KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type& t, scalar_type& dt,
 
   scalar_type max_step = Kokkos::ArithTraits<scalar_type>::max();
   scalar_type min_step = Kokkos::ArithTraits<scalar_type>::min();
-  scalar_type safety, error_norm;
+  scalar_type safety = 0.675, error_norm;
   if(dt > max_step) {
     update_D(order, max_step / dt, coeffs, tempD, D);
     dt = max_step;

--- a/ode/impl/KokkosODE_BDF_impl.hpp
+++ b/ode/impl/KokkosODE_BDF_impl.hpp
@@ -20,6 +20,8 @@
 #include "Kokkos_Core.hpp"
 
 #include "KokkosODE_Newton.hpp"
+#include "KokkosBlas2_serial_gemv.hpp"
+#include "KokkosBatched_Gemm_Decl.hpp"
 
 namespace KokkosODE {
 namespace Impl {
@@ -69,6 +71,8 @@ struct BDF_table<6> {
        -72.0 / 147.0, 10.0 / 147.0, 60.0 / 147.0}};
 };
 
+
+
 template <class system_type, class table_type, class mv_type>
 struct BDF_system_wrapper {
   const system_type mySys;
@@ -117,6 +121,50 @@ struct BDF_system_wrapper {
   }
 };
 
+  template <class system_type, class subview_type>
+struct BDF_system_wrapper2 {
+  const system_type mySys;
+  const int neqs;
+  const subview_type psi, d;
+
+  double t, dt, c = 0;
+
+  KOKKOS_FUNCTION
+  BDF_system_wrapper2(const system_type& mySys_,
+		      const subview_type& psi_, const subview_type& d_,
+		      const double t_, const double dt_)
+      : mySys(mySys_),
+        neqs(mySys_.neqs),
+	psi(psi_),
+	d(d_),
+        t(t_),
+        dt(dt_) {}
+
+  template <class vec_type>
+  KOKKOS_FUNCTION void residual(const vec_type& y, const vec_type& f) const {
+    // f = f(t+dt, y)
+    mySys.evaluate_function(t, dt, y, f);
+
+    // rhs = higher order terms + y_{n+1}^i - y_n - dt*f
+    for (int eqIdx = 0; eqIdx < neqs; ++eqIdx) {
+      f(eqIdx) =  psi(eqIdx) + d(eqIdx) - c * f(eqIdx);
+    }
+  }
+
+  template <class vec_type, class mat_type>
+  KOKKOS_FUNCTION void jacobian(const vec_type& y, const mat_type& jac) const {
+    mySys.evaluate_jacobian(t, dt, y, jac);
+
+    // J = I - dt*(dy/dy)
+    for (int rowIdx = 0; rowIdx < neqs; ++rowIdx) {
+      for (int colIdx = 0; colIdx < neqs; ++colIdx) {
+        jac(rowIdx, colIdx) = -dt * jac(rowIdx, colIdx);
+      }
+      jac(rowIdx, rowIdx) += 1.0;
+    }
+  }
+};
+
 template <class ode_type, class table_type, class vec_type, class mv_type,
           class mat_type, class scalar_type>
 KOKKOS_FUNCTION void BDFStep(ode_type& ode, const table_type& table,
@@ -140,6 +188,179 @@ KOKKOS_FUNCTION void BDFStep(ode_type& ode, const table_type& table,
     KokkosODE::Experimental::Newton::Solve(sys, param, jac, temp, y_new, rhs,
                                            update);
   }
+
+}  // BDFStep
+
+template <class mat_type, class scalar_type>
+KOKKOS_FUNCTION void compute_coeffs(const int order,
+				    const scalar_type factor,
+				    const mat_type& coeffs) {
+  coeffs(0, 0) = 1.0;
+  for(int colIdx = 0; colIdx < order; ++colIdx) {
+    coeffs(0, colIdx + 1) = 1.0;
+    for(int rowIdx = 0; rowIdx < order; ++rowIdx) {
+      coeffs(rowIdx + 1, colIdx + 1) = ((rowIdx - factor*(colIdx + 1.0)) / (rowIdx + 1.0)) * coeffs(rowIdx, colIdx + 1);
+    }
+  }
+}
+
+template <class mat_type, class scalar_type>
+KOKKOS_FUNCTION void update_D(const int order, const scalar_type factor,
+			      const mat_type& coeffs,
+			      const mat_type& tempD, const mat_type& D) {
+  std::cout << "Extract subviews from D and tempD" << std::endl;
+  auto subD     = Kokkos::subview(D,     Kokkos::ALL(), Kokkos::pair<int, int>(0, order + 1));
+  auto subTempD = Kokkos::subview(tempD, Kokkos::ALL(), Kokkos::pair<int, int>(0, order + 1));
+
+  compute_coeffs(order, factor, coeffs);
+  auto R = Kokkos::subview(coeffs, Kokkos::pair<int, int>(0, order + 1), Kokkos::pair<int, int>(0, order + 1));
+  KokkosBatched::SerialGemm<KokkosBatched::Trans::Transpose,
+			    KokkosBatched::Trans::NoTranspose,
+			    KokkosBatched::Algo::Gemm::Blocked>::invoke(1.0, R, subD, 0.0, subTempD);
+
+  compute_coeffs(order, 1.0, coeffs);
+  auto U = Kokkos::subview(coeffs, Kokkos::pair<int, int>(0, order + 1), Kokkos::pair<int, int>(0, order + 1));
+  KokkosBatched::SerialGemm<KokkosBatched::Trans::Transpose,
+			    KokkosBatched::Trans::NoTranspose,
+			    KokkosBatched::Algo::Gemm::Blocked>::invoke(1.0, U, subTempD, 0.0, subD);
+}
+
+template <class ode_type, class vec_type,
+          class mat_type, class scalar_type>
+KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type t, scalar_type& dt,
+			     scalar_type t_end, int& order, int& num_equal_steps,
+			     const int max_newton_iters,
+			     const scalar_type atol, const scalar_type rtol,
+			     const scalar_type min_factor,
+                             const vec_type& y_old, const vec_type& y_new,
+                             const vec_type& rhs, const vec_type& update,
+                             const mat_type& temp, const mat_type& temp2) {
+  using newton_params = KokkosODE::Experimental::Newton_params;
+  // Kokkos::Array<double, 6> kappa{{0., -0.1850, -1/9      , -0.0823000, -0.0415000, 0.}};
+  // alpha(i) = (1 - kappa(i)) * gamma(i)
+  // error_const(i) = kappa(i) * gamma(i) + 1 / (i + 1)
+  // gamma(i) = sum_{k=0}^i(1.0 / k); gamma(0) = 0;
+  Kokkos::Array<double, 6> alpha{{0., 1.185  , 1.66666667, 1.98421667, 2.16979167, 2.28333333}};
+  Kokkos::Array<double, 6> error_const{{1.        , 0.315     , 0.16666667, 0.09911667, 0.11354167, 0.16666667}};
+
+  // Extract columns of temp to form temporary
+  // subviews to operate on.
+  const int numRows = temp.extent_int(0); const int numCols = temp.extent_int(1);
+  std::cout << "numRows: " << numRows << ", numCols: " << numCols << std::endl;
+  std::cout << "Extract subview from temp" << std::endl;
+  int offset = 0;
+  auto D         = Kokkos::subview(temp, Kokkos::ALL(), Kokkos::pair<int, int>(offset, offset + 8));
+  offset += 8;
+  auto tempD     = Kokkos::subview(temp, Kokkos::ALL(), Kokkos::pair<int, int>(offset, offset + 8));
+  offset += 8;
+  auto scale     = Kokkos::subview(temp, Kokkos::ALL(), offset + 1); ++offset; // Scaling coefficients for error calculation
+  auto y_predict = Kokkos::subview(temp, Kokkos::ALL(), offset + 1); ++offset; // Initial guess for y_{n+1}
+  auto d         = Kokkos::subview(temp, Kokkos::ALL(), offset + 1); ++offset; // Newton update: y_{n+1}^i - y_n
+  auto psi       = Kokkos::subview(temp, Kokkos::ALL(), offset + 1); ++offset; // Higher order terms contribution to rhs
+  auto error     = Kokkos::subview(temp, Kokkos::ALL(), offset + 1); ++offset; // Error estimate
+  auto jac       = Kokkos::subview(temp, Kokkos::ALL(), Kokkos::pair<int, int>(offset, offset + ode.neqs)); // Jacobian matrix
+  offset += ode.neqs;
+  auto tmp_gesv  = Kokkos::subview(temp, Kokkos::ALL(),
+				   Kokkos::pair<int, int>(offset, offset + ode.neqs + 4)); // Buffer space for gesv calculation
+  offset += ode.neqs + 4;
+
+  std::cout << "Extract subview from temp2" << std::endl;
+  std::cout << "  temp2: (" << temp2.extent(0) << ", " << temp2.extent(1) << ")" << std::endl;
+  auto coeffs = Kokkos::subview(temp2, Kokkos::ALL(), Kokkos::pair<int, int>(0, order + 1));
+  auto gamma  = Kokkos::subview(temp2, Kokkos::ALL(), 6);
+  gamma(0) = 0.0; gamma(1) = 1.0; gamma(2) = 1.5; gamma(3) = 1.83333333; gamma(4) = 2.08333333; gamma(5) = 2.28333333;
+
+  BDF_system_wrapper2 sys(ode, psi, d, t, dt);
+  const newton_params param(max_newton_iters, atol, rtol);
+
+  scalar_type max_step = Kokkos::ArithTraits<scalar_type>::max();
+  scalar_type min_step = Kokkos::ArithTraits<scalar_type>::min();
+  if(dt > max_step) {
+    update_D(order, max_step / dt, coeffs, tempD, D);
+    dt = max_step;
+    num_equal_steps = 0;
+  } else if(dt < min_step) {
+    update_D(order, min_step / dt, coeffs, tempD, D);
+    dt = min_step;
+    num_equal_steps = 0;
+  }
+
+  // first set y_new = y_old
+  for (int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
+    y_new(eqIdx) = y_old(eqIdx);
+  }
+
+  std::cout << "Hello 1" << std::endl;
+
+  double t_new = 0;
+  bool step_accepted = false;
+  while (!step_accepted) {
+    if(dt < min_step) {return ;}
+    t_new = t + dt;
+
+    if(t_new > t_end) {
+      t_new = t_end;
+      update_D(order, (t_new - t) / dt, coeffs, tempD, D);
+      num_equal_steps = 0;
+    }
+    dt = t_new - t;
+
+    std::cout << "Hello 2" << std::endl;
+
+    for(int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
+      for(int orderIdx = 0; orderIdx < order + 1; ++orderIdx) {
+	y_predict(eqIdx) += D(eqIdx, orderIdx);
+      }
+      scale(eqIdx) = atol + rtol*Kokkos::abs(y_predict(eqIdx));
+    }
+
+    // Compute psi, the sum of the higher order
+    // contribution to the residual
+    auto subD     = Kokkos::subview(D, Kokkos::ALL(), Kokkos::pair<int, int>(1, order + 1));
+    auto subGamma = Kokkos::subview(gamma, Kokkos::pair<int, int>(1, order + 1));
+    KokkosBlas::Experimental::serial_gemv('N', 1.0 / alpha[order], subD, subGamma, 0.0, psi);
+
+    std::cout << "Hello 3" << std::endl;
+
+    sys.c = dt / alpha[order];
+    sys.jacobian(y_new, jac);
+    std::cout << "c=" << sys.c << ", psi=" << psi(0) << ", y_predict=" << y_predict(0) << std::endl;
+    std::cout << "jac: " << jac(0, 0) << std::endl;
+    Kokkos::deep_copy(y_new, y_predict);
+    KokkosODE::Experimental::newton_solver_status newton_status = 
+      KokkosODE::Experimental::Newton::Solve(sys, param, jac, tmp_gesv, y_new, rhs,
+					     update);
+
+    std::cout << "Newton Status: " << (newton_status == KokkosODE::Experimental::newton_solver_status::NLS_SUCCESS ? "converged" : "not converged") << std::endl;
+    if(newton_status == KokkosODE::Experimental::newton_solver_status::MAX_ITER) {
+      dt = 0.5*dt;
+      update_D(order, 0.5, coeffs, tempD, D);
+      num_equal_steps = 0;
+
+    } else {
+      // Estimate the solution error
+      scalar_type safety = 0.9*(2*max_newton_iters + 1) / (2*max_newton_iters + param.iters);
+      scalar_type error_norm = 0;
+      for(int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
+	scale(eqIdx) = atol + rtol*Kokkos::abs(y_new(eqIdx));
+	error(eqIdx) = error_const[order]*d(eqIdx) / scale(eqIdx);
+	error_norm += error(eqIdx)*error(eqIdx);
+      }
+      error_norm = Kokkos::sqrt(error_norm);
+
+      // Check error norm and adapt step size or accept step
+      if(error_norm > 1) {
+	scalar_type factor = Kokkos::max(min_factor, safety*Kokkos::pow(error_norm, -1.0 / (order + 1)));
+	dt = factor*dt;
+	update_D(order, factor, coeffs, tempD, D);
+	num_equal_steps = 0;
+      } else {
+	step_accepted = true;
+      }
+    }
+
+    std::cout << "Hello 5" << std::endl;
+  } // while(!step_accepted)
 
 }  // BDFStep
 

--- a/ode/impl/KokkosODE_BDF_impl.hpp
+++ b/ode/impl/KokkosODE_BDF_impl.hpp
@@ -239,9 +239,9 @@ KOKKOS_FUNCTION void initial_step_size(const ode_type ode, const int order, cons
   using KAT = Kokkos::ArithTraits<scalar_type>;
 
   // Extract subviews to store intermediate data
-  auto scale = Kokkos::subview(temp, Kokkos::ALL(), 0); // Scaling coefficients for error calculation
-  auto y1    = Kokkos::subview(temp, Kokkos::ALL(), 1); // Scaling coefficients for error calculation
-  auto f1    = Kokkos::subview(temp, Kokkos::ALL(), 2); // Scaling coefficients for error calculation
+  auto scale = Kokkos::subview(temp, Kokkos::ALL(), 1);
+  auto y1    = Kokkos::subview(temp, Kokkos::ALL(), 2);
+  auto f1    = Kokkos::subview(temp, Kokkos::ALL(), 3);
 
   // Compute norms for y0 and f0
   double n0 = KAT::zero(), n1 = KAT::zero(), dt0;
@@ -282,6 +282,13 @@ KOKKOS_FUNCTION void initial_step_size(const ode_type ode, const int order, cons
   }
 
   dt_ini = Kokkos::min(100 * dt0, dt_ini);
+
+  // Zero out temp variables just to be safe...
+  for(int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
+    scale(eqIdx) = 0;
+    y1(eqIdx) = 0;
+    f1(eqIdx) = 0;
+  }
 } // initial_step_size
 
   template <class ode_type, class vec_type, class res_type,

--- a/ode/impl/KokkosODE_BDF_impl.hpp
+++ b/ode/impl/KokkosODE_BDF_impl.hpp
@@ -71,8 +71,6 @@ struct BDF_table<6> {
        -72.0 / 147.0, 10.0 / 147.0, 60.0 / 147.0}};
 };
 
-
-
 template <class system_type, class table_type, class mv_type>
 struct BDF_system_wrapper {
   const system_type mySys;
@@ -132,26 +130,22 @@ struct BDF_system_wrapper2 {
   double t, dt, c = 0;
 
   KOKKOS_FUNCTION
-  BDF_system_wrapper2(const system_type& mySys_,
-		      const subview_type& psi_, const d_vec_type& d_,
-		      const double t_, const double dt_)
-      : mySys(mySys_),
-        neqs(mySys_.neqs),
-	psi(psi_),
-	d(d_),
-        t(t_),
-        dt(dt_) {}
+  BDF_system_wrapper2(const system_type& mySys_, const subview_type& psi_,
+                      const d_vec_type& d_, const double t_, const double dt_)
+      : mySys(mySys_), neqs(mySys_.neqs), psi(psi_), d(d_), t(t_), dt(dt_) {}
 
   template <class YVectorType, class FVectorType>
-  KOKKOS_FUNCTION void residual(const YVectorType& y, const FVectorType& f) const {
+  KOKKOS_FUNCTION void residual(const YVectorType& y,
+                                const FVectorType& f) const {
     // f = f(t+dt, y)
     mySys.evaluate_function(t, dt, y, f);
 
-    // std::cout << "f = psi + d - c * f = " << psi(0) << " + " << d(0) << " - " << c << " * " << f(0) << std::endl;
+    // std::cout << "f = psi + d - c * f = " << psi(0) << " + " << d(0) << " - "
+    // << c << " * " << f(0) << std::endl;
 
     // rhs = higher order terms + y_{n+1}^i - y_n - dt*f
     for (int eqIdx = 0; eqIdx < neqs; ++eqIdx) {
-      f(eqIdx) =  psi(eqIdx) + d(eqIdx) - c * f(eqIdx);
+      f(eqIdx) = psi(eqIdx) + d(eqIdx) - c * f(eqIdx);
     }
   }
 
@@ -162,10 +156,10 @@ struct BDF_system_wrapper2 {
 
       // J = I - dt*(dy/dy)
       for (int rowIdx = 0; rowIdx < neqs; ++rowIdx) {
-	for (int colIdx = 0; colIdx < neqs; ++colIdx) {
-	  jac(rowIdx, colIdx) = -dt * jac(rowIdx, colIdx);
-	}
-	jac(rowIdx, rowIdx) += 1.0;
+        for (int colIdx = 0; colIdx < neqs; ++colIdx) {
+          jac(rowIdx, colIdx) = -dt * jac(rowIdx, colIdx);
+        }
+        jac(rowIdx, rowIdx) += 1.0;
       }
     }
   }
@@ -198,44 +192,49 @@ KOKKOS_FUNCTION void BDFStep(ode_type& ode, const table_type& table,
 }  // BDFStep
 
 template <class mat_type, class scalar_type>
-KOKKOS_FUNCTION void compute_coeffs(const int order,
-				    const scalar_type factor,
-				    const mat_type& coeffs) {
+KOKKOS_FUNCTION void compute_coeffs(const int order, const scalar_type factor,
+                                    const mat_type& coeffs) {
   coeffs(0, 0) = 1.0;
-  for(int colIdx = 0; colIdx < order; ++colIdx) {
+  for (int colIdx = 0; colIdx < order; ++colIdx) {
     coeffs(0, colIdx + 1) = 1.0;
-    for(int rowIdx = 0; rowIdx < order; ++rowIdx) {
-      coeffs(rowIdx + 1, colIdx + 1) = ((rowIdx - factor*(colIdx + 1.0)) / (rowIdx + 1.0)) * coeffs(rowIdx, colIdx + 1);
+    for (int rowIdx = 0; rowIdx < order; ++rowIdx) {
+      coeffs(rowIdx + 1, colIdx + 1) =
+          ((rowIdx - factor * (colIdx + 1.0)) / (rowIdx + 1.0)) *
+          coeffs(rowIdx, colIdx + 1);
     }
   }
 }
 
 template <class mat_type, class scalar_type>
 KOKKOS_FUNCTION void update_D(const int order, const scalar_type factor,
-			      const mat_type& coeffs,
-			      const mat_type& tempD, const mat_type& D) {
-
-  auto subD     = Kokkos::subview(D,     Kokkos::ALL(), Kokkos::pair<int, int>(0, order + 1));
-  auto subTempD = Kokkos::subview(tempD, Kokkos::ALL(), Kokkos::pair<int, int>(0, order + 1));
+                              const mat_type& coeffs, const mat_type& tempD,
+                              const mat_type& D) {
+  auto subD =
+      Kokkos::subview(D, Kokkos::ALL(), Kokkos::pair<int, int>(0, order + 1));
+  auto subTempD = Kokkos::subview(tempD, Kokkos::ALL(),
+                                  Kokkos::pair<int, int>(0, order + 1));
 
   compute_coeffs(order, factor, coeffs);
-  auto R = Kokkos::subview(coeffs, Kokkos::pair<int, int>(0, order + 1), Kokkos::pair<int, int>(0, order + 1));
-  KokkosBatched::SerialGemm<KokkosBatched::Trans::NoTranspose,
-			    KokkosBatched::Trans::NoTranspose,
-			    KokkosBatched::Algo::Gemm::Blocked>::invoke(1.0, subD, R, 0.0, subTempD);
+  auto R = Kokkos::subview(coeffs, Kokkos::pair<int, int>(0, order + 1),
+                           Kokkos::pair<int, int>(0, order + 1));
+  KokkosBatched::SerialGemm<
+      KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose,
+      KokkosBatched::Algo::Gemm::Blocked>::invoke(1.0, subD, R, 0.0, subTempD);
 
   compute_coeffs(order, 1.0, coeffs);
-  auto U = Kokkos::subview(coeffs, Kokkos::pair<int, int>(0, order + 1), Kokkos::pair<int, int>(0, order + 1));
-  KokkosBatched::SerialGemm<KokkosBatched::Trans::NoTranspose,
-			    KokkosBatched::Trans::NoTranspose,
-			    KokkosBatched::Algo::Gemm::Blocked>::invoke(1.0, subTempD, U, 0.0, subD);
+  auto U = Kokkos::subview(coeffs, Kokkos::pair<int, int>(0, order + 1),
+                           Kokkos::pair<int, int>(0, order + 1));
+  KokkosBatched::SerialGemm<
+      KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose,
+      KokkosBatched::Algo::Gemm::Blocked>::invoke(1.0, subTempD, U, 0.0, subD);
 }
 
-  template <class ode_type, class mat_type, class vec_type, class res_type, class scalar_type>
-KOKKOS_FUNCTION void initial_step_size(const ode_type ode, const int order, const scalar_type t0,
-				       const scalar_type atol, const scalar_type rtol,
-				       const vec_type& y0, const res_type& f0,
-				       const mat_type& temp, scalar_type& dt_ini) {
+template <class ode_type, class mat_type, class vec_type, class res_type,
+          class scalar_type>
+KOKKOS_FUNCTION void initial_step_size(
+    const ode_type ode, const int order, const scalar_type t0,
+    const scalar_type atol, const scalar_type rtol, const vec_type& y0,
+    const res_type& f0, const mat_type& temp, scalar_type& dt_ini) {
   using KAT = Kokkos::ArithTraits<scalar_type>;
 
   // Extract subviews to store intermediate data
@@ -245,7 +244,7 @@ KOKKOS_FUNCTION void initial_step_size(const ode_type ode, const int order, cons
 
   // Compute norms for y0 and f0
   double n0 = KAT::zero(), n1 = KAT::zero(), dt0;
-  for(int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
+  for (int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
     scale(eqIdx) = atol + rtol * Kokkos::abs(y0(eqIdx));
     n0 += Kokkos::pow(y0(eqIdx) / scale(eqIdx), 2);
     n1 += Kokkos::pow(f0(eqIdx) / scale(eqIdx), 2);
@@ -254,14 +253,14 @@ KOKKOS_FUNCTION void initial_step_size(const ode_type ode, const int order, cons
   n1 = Kokkos::sqrt(n1) / Kokkos::sqrt(ode.neqs);
 
   // Select dt0
-  if((n0 < 1e-5) || (n1 < 1e-5)) {
+  if ((n0 < 1e-5) || (n1 < 1e-5)) {
     dt0 = 1e-6;
   } else {
     dt0 = 0.01 * n0 / n1;
   }
 
   // Estimate y at t0 + dt0
-  for(int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
+  for (int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
     y1(eqIdx) = y0(eqIdx) + dt0 * f0(eqIdx);
   }
 
@@ -269,13 +268,13 @@ KOKKOS_FUNCTION void initial_step_size(const ode_type ode, const int order, cons
   // then compute the norm of f(t0+dt0, y1) - f(t0, y0)
   scalar_type n2 = KAT::zero();
   ode.evaluate_function(t0 + dt0, dt0, y1, f1);
-  for(int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
+  for (int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
     n2 += Kokkos::pow((f1(eqIdx) - f0(eqIdx)) / scale(eqIdx), 2);
   }
   n2 = Kokkos::sqrt(n2) / (dt0 * Kokkos::sqrt(ode.neqs));
 
   // Finally select initial time step dt_ini
-  if((n1 <= 1e-15) && (n2 <= 1e-15)) {
+  if ((n1 <= 1e-15) && (n2 <= 1e-15)) {
     dt_ini = Kokkos::max(1e-6, dt0 * 1e-3);
   } else {
     dt_ini = Kokkos::pow(0.01 / Kokkos::max(n1, n2), KAT::one() / (order + 1));
@@ -284,20 +283,20 @@ KOKKOS_FUNCTION void initial_step_size(const ode_type ode, const int order, cons
   dt_ini = Kokkos::min(100 * dt0, dt_ini);
 
   // Zero out temp variables just to be safe...
-  for(int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
+  for (int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
     scale(eqIdx) = 0;
-    y1(eqIdx) = 0;
-    f1(eqIdx) = 0;
+    y1(eqIdx)    = 0;
+    f1(eqIdx)    = 0;
   }
-} // initial_step_size
+}  // initial_step_size
 
-  template <class ode_type, class vec_type, class res_type,
-          class mat_type, class scalar_type>
+template <class ode_type, class vec_type, class res_type, class mat_type,
+          class scalar_type>
 KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type& t, scalar_type& dt,
-			     scalar_type t_end, int& order, int& num_equal_steps,
-			     const int max_newton_iters,
-			     const scalar_type atol, const scalar_type rtol,
-			     const scalar_type min_factor,
+                             scalar_type t_end, int& order,
+                             int& num_equal_steps, const int max_newton_iters,
+                             const scalar_type atol, const scalar_type rtol,
+                             const scalar_type min_factor,
                              const vec_type& y_old, const vec_type& y_new,
                              const res_type& rhs, const res_type& update,
                              const mat_type& temp, const mat_type& temp2) {
@@ -305,51 +304,75 @@ KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type& t, scalar_type& dt,
 
   constexpr int max_order = 5;
 
-  // For NDF coefficients see Sahmpine and Reichelt, The Matlab ODE suite, SIAM SISCm 18, 1, p1-22, January 1997
-  // Kokkos::Array<double, 6> kappa{{0., -0.1850, -1/9      , -0.0823000, -0.0415000, 0.}}; // NDF coefficients kappa
-  // gamma(i) = sum_{k=1}^i(1.0 / k); gamma(0) = 0;                                         // NDF coefficients gamma_k
-  // alpha(i) = (1 - kappa(i)) * gamma(i)
-  // error_const(i) = kappa(i) * gamma(i) + 1 / (i + 1)
-  const Kokkos::Array<const double, 6> alpha{{0., 1.185  , 1.66666667, 1.98421667, 2.16979167, 2.28333333}};
-  const Kokkos::Array<const double, 6> error_const{{1.        , 0.315     , 0.16666667, 0.09911667, 0.11354167, 0.16666667}};
+  // For NDF coefficients see Sahmpine and Reichelt, The Matlab ODE suite, SIAM
+  // SISCm 18, 1, p1-22, January 1997 Kokkos::Array<double, 6> kappa{{0.,
+  // -0.1850, -1/9      , -0.0823000, -0.0415000, 0.}}; // NDF coefficients
+  // kappa gamma(i) = sum_{k=1}^i(1.0 / k); gamma(0) = 0; // NDF coefficients
+  // gamma_k alpha(i) = (1 - kappa(i)) * gamma(i) error_const(i) = kappa(i) *
+  // gamma(i) + 1 / (i + 1)
+  const Kokkos::Array<const double, 6> alpha{
+      {0., 1.185, 1.66666667, 1.98421667, 2.16979167, 2.28333333}};
+  const Kokkos::Array<const double, 6> error_const{
+      {1., 0.315, 0.16666667, 0.09911667, 0.11354167, 0.16666667}};
 
   // Extract columns of temp to form temporary
   // subviews to operate on.
-  // const int numRows = temp.extent_int(0); const int numCols = temp.extent_int(1);
-  // std::cout << "numRows: " << numRows << ", numCols: " << numCols << std::endl;
-  // std::cout << "Extract subview from temp" << std::endl;
+  // const int numRows = temp.extent_int(0); const int numCols =
+  // temp.extent_int(1); std::cout << "numRows: " << numRows << ", numCols: " <<
+  // numCols << std::endl; std::cout << "Extract subview from temp" <<
+  // std::endl;
   int offset = 2;
-  auto D         = Kokkos::subview(temp, Kokkos::ALL(), Kokkos::pair<int, int>(offset, offset + 8)); // y and its derivatives
+  auto D     = Kokkos::subview(
+      temp, Kokkos::ALL(),
+      Kokkos::pair<int, int>(offset, offset + 8));  // y and its derivatives
   offset += 8;
-  auto tempD     = Kokkos::subview(temp, Kokkos::ALL(), Kokkos::pair<int, int>(offset, offset + 8));
+  auto tempD = Kokkos::subview(temp, Kokkos::ALL(),
+                               Kokkos::pair<int, int>(offset, offset + 8));
   offset += 8;
-  auto scale     = Kokkos::subview(temp, Kokkos::ALL(), offset + 1); ++offset; // Scaling coefficients for error calculation
-  auto y_predict = Kokkos::subview(temp, Kokkos::ALL(), offset + 1); ++offset; // Initial guess for y_{n+1}
-  auto psi       = Kokkos::subview(temp, Kokkos::ALL(), offset + 1); ++offset; // Higher order terms contribution to rhs
-  auto error     = Kokkos::subview(temp, Kokkos::ALL(), offset + 1); ++offset; // Error estimate
-  auto jac       = Kokkos::subview(temp, Kokkos::ALL(), Kokkos::pair<int, int>(offset, offset + ode.neqs)); // Jacobian matrix
+  auto scale = Kokkos::subview(temp, Kokkos::ALL(), offset + 1);
+  ++offset;  // Scaling coefficients for error calculation
+  auto y_predict = Kokkos::subview(temp, Kokkos::ALL(), offset + 1);
+  ++offset;  // Initial guess for y_{n+1}
+  auto psi = Kokkos::subview(temp, Kokkos::ALL(), offset + 1);
+  ++offset;  // Higher order terms contribution to rhs
+  auto error = Kokkos::subview(temp, Kokkos::ALL(), offset + 1);
+  ++offset;  // Error estimate
+  auto jac = Kokkos::subview(
+      temp, Kokkos::ALL(),
+      Kokkos::pair<int, int>(offset, offset + ode.neqs));  // Jacobian matrix
   offset += ode.neqs;
-  auto tmp_gesv  = Kokkos::subview(temp, Kokkos::ALL(),
-				   Kokkos::pair<int, int>(offset, offset + ode.neqs + 4)); // Buffer space for gesv calculation
+  auto tmp_gesv = Kokkos::subview(
+      temp, Kokkos::ALL(),
+      Kokkos::pair<int, int>(
+          offset, offset + ode.neqs + 4));  // Buffer space for gesv calculation
   offset += ode.neqs + 4;
 
-  auto coeffs = Kokkos::subview(temp2, Kokkos::ALL(), Kokkos::pair<int, int>(0, 6));
-  auto gamma  = Kokkos::subview(temp2, Kokkos::ALL(), 6);
-  gamma(0) = 0.0; gamma(1) = 1.0; gamma(2) = 1.5; gamma(3) = 1.83333333; gamma(4) = 2.08333333; gamma(5) = 2.28333333;
+  auto coeffs =
+      Kokkos::subview(temp2, Kokkos::ALL(), Kokkos::pair<int, int>(0, 6));
+  auto gamma = Kokkos::subview(temp2, Kokkos::ALL(), 6);
+  gamma(0)   = 0.0;
+  gamma(1)   = 1.0;
+  gamma(2)   = 1.5;
+  gamma(3)   = 1.83333333;
+  gamma(4)   = 2.08333333;
+  gamma(5)   = 2.28333333;
 
   BDF_system_wrapper2 sys(ode, psi, update, t, dt);
-  const newton_params param(max_newton_iters, atol, Kokkos::max(10*Kokkos::ArithTraits<scalar_type>::eps() / rtol, Kokkos::min(0.03, Kokkos::sqrt(rtol))));
+  const newton_params param(
+      max_newton_iters, atol,
+      Kokkos::max(10 * Kokkos::ArithTraits<scalar_type>::eps() / rtol,
+                  Kokkos::min(0.03, Kokkos::sqrt(rtol))));
 
   scalar_type max_step = Kokkos::ArithTraits<scalar_type>::max();
   scalar_type min_step = Kokkos::ArithTraits<scalar_type>::min();
-  scalar_type safety = 0.675, error_norm;
-  if(dt > max_step) {
+  scalar_type safety   = 0.675, error_norm;
+  if (dt > max_step) {
     update_D(order, max_step / dt, coeffs, tempD, D);
-    dt = max_step;
+    dt              = max_step;
     num_equal_steps = 0;
-  } else if(dt < min_step) {
+  } else if (dt < min_step) {
     update_D(order, min_step / dt, coeffs, tempD, D);
-    dt = min_step;
+    dt              = min_step;
     num_equal_steps = 0;
   }
 
@@ -358,74 +381,82 @@ KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type& t, scalar_type& dt,
     y_new(eqIdx) = y_old(eqIdx);
   }
 
-  double t_new = 0;
+  double t_new       = 0;
   bool step_accepted = false;
   while (!step_accepted) {
-    if(dt < min_step) {return ;}
+    if (dt < min_step) {
+      return;
+    }
     t_new = t + dt;
 
-    if(t_new > t_end) {
+    if (t_new > t_end) {
       t_new = t_end;
       update_D(order, (t_new - t) / dt, coeffs, tempD, D);
       num_equal_steps = 0;
     }
     dt = t_new - t;
 
-    for(int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
+    for (int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
       y_predict(eqIdx) = 0;
-      for(int orderIdx = 0; orderIdx < order + 1; ++orderIdx) {
-	y_predict(eqIdx) += D(eqIdx, orderIdx);
+      for (int orderIdx = 0; orderIdx < order + 1; ++orderIdx) {
+        y_predict(eqIdx) += D(eqIdx, orderIdx);
       }
-      scale(eqIdx) = atol + rtol*Kokkos::abs(y_predict(eqIdx));
+      scale(eqIdx) = atol + rtol * Kokkos::abs(y_predict(eqIdx));
     }
 
     // Compute psi, the sum of the higher order
     // contribution to the residual
-    auto subD     = Kokkos::subview(D, Kokkos::ALL(), Kokkos::pair<int, int>(1, order + 1));
-    auto subGamma = Kokkos::subview(gamma, Kokkos::pair<int, int>(1, order + 1));
-    KokkosBlas::Experimental::serial_gemv('N', 1.0 / alpha[order], subD, subGamma, 0.0, psi);
+    auto subD =
+        Kokkos::subview(D, Kokkos::ALL(), Kokkos::pair<int, int>(1, order + 1));
+    auto subGamma =
+        Kokkos::subview(gamma, Kokkos::pair<int, int>(1, order + 1));
+    KokkosBlas::Experimental::serial_gemv('N', 1.0 / alpha[order], subD,
+                                          subGamma, 0.0, psi);
 
     sys.compute_jac = true;
-    sys.c = dt / alpha[order];
+    sys.c           = dt / alpha[order];
     sys.jacobian(y_new, jac);
     sys.compute_jac = true;
     Kokkos::Experimental::local_deep_copy(y_new, y_predict);
     Kokkos::Experimental::local_deep_copy(update, 0);
-    KokkosODE::Experimental::newton_solver_status newton_status = 
-      KokkosODE::Experimental::Newton::Solve(sys, param, jac, tmp_gesv, y_new, rhs,
-					     update, scale);
+    KokkosODE::Experimental::newton_solver_status newton_status =
+        KokkosODE::Experimental::Newton::Solve(sys, param, jac, tmp_gesv, y_new,
+                                               rhs, update, scale);
 
-    for(int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
+    for (int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
       update(eqIdx) = y_new(eqIdx) - y_predict(eqIdx);
     }
 
-    if(newton_status == KokkosODE::Experimental::newton_solver_status::MAX_ITER) {
-      dt = 0.5*dt;
+    if (newton_status ==
+        KokkosODE::Experimental::newton_solver_status::MAX_ITER) {
+      dt = 0.5 * dt;
       update_D(order, 0.5, coeffs, tempD, D);
       num_equal_steps = 0;
 
     } else {
       // Estimate the solution error
-      safety = 0.9*(2*max_newton_iters + 1) / (2*max_newton_iters + param.iters);
+      safety = 0.9 * (2 * max_newton_iters + 1) /
+               (2 * max_newton_iters + param.iters);
       error_norm = 0;
-      for(int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
-	scale(eqIdx) = atol + rtol*Kokkos::abs(y_new(eqIdx));
-	error(eqIdx) = error_const[order]*update(eqIdx) / scale(eqIdx);
-	error_norm += error(eqIdx)*error(eqIdx);
+      for (int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
+        scale(eqIdx) = atol + rtol * Kokkos::abs(y_new(eqIdx));
+        error(eqIdx) = error_const[order] * update(eqIdx) / scale(eqIdx);
+        error_norm += error(eqIdx) * error(eqIdx);
       }
       error_norm = Kokkos::sqrt(error_norm) / Kokkos::sqrt(sys.neqs);
 
       // Check error norm and adapt step size or accept step
-      if(error_norm > 1) {
-	scalar_type factor = Kokkos::max(min_factor, safety*Kokkos::pow(error_norm, -1.0 / (order + 1)));
-	dt = factor*dt;
-	update_D(order, factor, coeffs, tempD, D);
-	num_equal_steps = 0;
+      if (error_norm > 1) {
+        scalar_type factor = Kokkos::max(
+            min_factor, safety * Kokkos::pow(error_norm, -1.0 / (order + 1)));
+        dt = factor * dt;
+        update_D(order, factor, coeffs, tempD, D);
+        num_equal_steps = 0;
       } else {
-	step_accepted = true;
+        step_accepted = true;
       }
     }
-  } // while(!step_accepted)
+  }  // while(!step_accepted)
 
   // Now that our time step has been
   // accepted we update all our states
@@ -434,10 +465,10 @@ KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type& t, scalar_type& dt,
   // the next step.
   ++num_equal_steps;
   t = t_new;
-  for(int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
+  for (int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
     D(eqIdx, order + 2) = update(eqIdx) - D(eqIdx, order + 1);
     D(eqIdx, order + 1) = update(eqIdx);
-    for(int orderIdx = order; 0 <= orderIdx; --orderIdx) {
+    for (int orderIdx = order; 0 <= orderIdx; --orderIdx) {
       D(eqIdx, orderIdx) += D(eqIdx, orderIdx + 1);
     }
   }
@@ -446,20 +477,24 @@ KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type& t, scalar_type& dt,
   // have been succesfull so we do not
   // attempt order adaptation.
   double error_low = 0, error_high = 0;
-  if(num_equal_steps < order + 1) { return; }
+  if (num_equal_steps < order + 1) {
+    return;
+  }
 
-  if(1 < order) {
-    for(int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
-      error_low += Kokkos::pow(error_const[order - 1] * D(eqIdx, order) / scale(eqIdx), 2);
+  if (1 < order) {
+    for (int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
+      error_low += Kokkos::pow(
+          error_const[order - 1] * D(eqIdx, order) / scale(eqIdx), 2);
     }
     error_low = Kokkos::sqrt(error_low) / Kokkos::sqrt(sys.neqs);
   } else {
     error_low = Kokkos::ArithTraits<double>::max();
   }
 
-  if(order < max_order) {
-    for(int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
-      error_high += Kokkos::pow(error_const[order + 1] * D(eqIdx, order + 2) / scale(eqIdx), 2);
+  if (order < max_order) {
+    for (int eqIdx = 0; eqIdx < sys.neqs; ++eqIdx) {
+      error_high += Kokkos::pow(
+          error_const[order + 1] * D(eqIdx, order + 2) / scale(eqIdx), 2);
     }
     error_high = Kokkos::sqrt(error_high) / Kokkos::sqrt(sys.neqs);
   } else {
@@ -467,23 +502,23 @@ KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type& t, scalar_type& dt,
   }
 
   double factor_low, factor_mid, factor_high, factor;
-  factor_low  = Kokkos::pow(error_low,  -1.0 / order);
+  factor_low  = Kokkos::pow(error_low, -1.0 / order);
   factor_mid  = Kokkos::pow(error_norm, -1.0 / (order + 1));
   factor_high = Kokkos::pow(error_high, -1.0 / (order + 2));
 
   int delta_order = 0;
-  if((factor_mid < factor_low) && (factor_high < factor_low)) {
+  if ((factor_mid < factor_low) && (factor_high < factor_low)) {
     delta_order = -1;
-    factor = factor_low;
-  } else if((factor_low < factor_high) && (factor_mid < factor_high)) {
+    factor      = factor_low;
+  } else if ((factor_low < factor_high) && (factor_mid < factor_high)) {
     delta_order = 1;
-    factor = factor_high;
+    factor      = factor_high;
   } else {
     delta_order = 0;
-    factor = factor_mid;
+    factor      = factor_mid;
   }
   order += delta_order;
-  factor = Kokkos::fmin(10, safety*factor);
+  factor = Kokkos::fmin(10, safety * factor);
   dt *= factor;
 
   update_D(order, factor, coeffs, tempD, D);

--- a/ode/impl/KokkosODE_BDF_impl.hpp
+++ b/ode/impl/KokkosODE_BDF_impl.hpp
@@ -336,7 +336,7 @@ KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type& t, scalar_type& dt,
 
   scalar_type max_step = Kokkos::ArithTraits<scalar_type>::max();
   scalar_type min_step = Kokkos::ArithTraits<scalar_type>::min();
-  scalar_type safety = 0.675, error_norm;
+  scalar_type safety, error_norm;
   if(dt > max_step) {
     update_D(order, max_step / dt, coeffs, tempD, D);
     dt = max_step;

--- a/ode/impl/KokkosODE_Newton_impl.hpp
+++ b/ode/impl/KokkosODE_Newton_impl.hpp
@@ -110,7 +110,6 @@ KOKKOS_FUNCTION KokkosODE::Experimental::newton_solver_status NewtonSolve(
 
     norm_old = norm_new;
   }
-  std::cout << "Final norm: " << norm << ", acceptance citeria: " << params.rel_tol * norm0 << std::endl;
   return newton_solver_status::MAX_ITER;
 }
 

--- a/ode/impl/KokkosODE_Newton_impl.hpp
+++ b/ode/impl/KokkosODE_Newton_impl.hpp
@@ -42,6 +42,7 @@ KOKKOS_FUNCTION KokkosODE::Experimental::newton_solver_status NewtonSolve(
   using norm_type = typename Kokkos::Details::InnerProductSpaceTraits<
       typename vec_type::non_const_value_type>::mag_type;
   sys.residual(y0, rhs);
+  std::cout << "rhs0= " << rhs(0) << std::endl;
   const norm_type norm0 = KokkosBlas::serial_nrm2(rhs);
   norm_type norm        = Kokkos::ArithTraits<norm_type>::zero();
 
@@ -60,6 +61,8 @@ KOKKOS_FUNCTION KokkosODE::Experimental::newton_solver_status NewtonSolve(
     // problem at each iteration: J*update=-rhs
     // with J=du/dx, rhs=f(u_n+update)-f(u_n)
     norm = KokkosBlas::serial_nrm2(rhs);
+
+    std::cout << "norm=" << norm << std::endl;
 
     if ((norm < (params.rel_tol * norm0)) ||
         (it > 0 ? KokkosBlas::serial_nrm2(update) < params.abs_tol : false)) {
@@ -87,6 +90,7 @@ KOKKOS_FUNCTION KokkosODE::Experimental::newton_solver_status NewtonSolve(
 
     // update solution // x = x + alpha*update
     KokkosBlas::serial_axpy(alpha, update, y0);
+    std::cout << "newton vector y= " << y0(0) << std::endl;
   }
   return newton_solver_status::MAX_ITER;
 }

--- a/ode/impl/KokkosODE_Newton_impl.hpp
+++ b/ode/impl/KokkosODE_Newton_impl.hpp
@@ -42,7 +42,8 @@ KOKKOS_FUNCTION KokkosODE::Experimental::newton_solver_status NewtonSolve(
   using norm_type = typename Kokkos::Details::InnerProductSpaceTraits<
       typename vec_type::non_const_value_type>::mag_type;
   sys.residual(y0, rhs);
-  std::cout << "rhs0= " << rhs(0) << std::endl;
+  // std::cout << "y0=" << y0(0) << std::endl;
+  // std::cout << "rhs0= " << rhs(0) << std::endl;
   const norm_type norm0 = KokkosBlas::serial_nrm2(rhs);
   norm_type norm        = Kokkos::ArithTraits<norm_type>::zero();
 
@@ -62,7 +63,7 @@ KOKKOS_FUNCTION KokkosODE::Experimental::newton_solver_status NewtonSolve(
     // with J=du/dx, rhs=f(u_n+update)-f(u_n)
     norm = KokkosBlas::serial_nrm2(rhs);
 
-    std::cout << "norm=" << norm << std::endl;
+    // std::cout << "norm=" << norm << std::endl;
 
     if ((norm < (params.rel_tol * norm0)) ||
         (it > 0 ? KokkosBlas::serial_nrm2(update) < params.abs_tol : false)) {
@@ -90,7 +91,7 @@ KOKKOS_FUNCTION KokkosODE::Experimental::newton_solver_status NewtonSolve(
 
     // update solution // x = x + alpha*update
     KokkosBlas::serial_axpy(alpha, update, y0);
-    std::cout << "newton vector y= " << y0(0) << std::endl;
+    // std::cout << "newton vector y= " << y0(0) << std::endl;
   }
   return newton_solver_status::MAX_ITER;
 }

--- a/ode/impl/KokkosODE_Newton_impl.hpp
+++ b/ode/impl/KokkosODE_Newton_impl.hpp
@@ -30,10 +30,12 @@
 namespace KokkosODE {
 namespace Impl {
 
-  template <class system_type, class mat_type, class ini_vec_type, class rhs_vec_type, class update_type, class scale_type>
+template <class system_type, class mat_type, class ini_vec_type,
+          class rhs_vec_type, class update_type, class scale_type>
 KOKKOS_FUNCTION KokkosODE::Experimental::newton_solver_status NewtonSolve(
     system_type& sys, const KokkosODE::Experimental::Newton_params& params,
-    mat_type& J, mat_type& tmp, ini_vec_type& y0, rhs_vec_type& rhs, update_type& update, const scale_type& scale) {
+    mat_type& J, mat_type& tmp, ini_vec_type& y0, rhs_vec_type& rhs,
+    update_type& update, const scale_type& scale) {
   using newton_solver_status = KokkosODE::Experimental::newton_solver_status;
   using value_type           = typename ini_vec_type::non_const_value_type;
 
@@ -48,8 +50,9 @@ KOKKOS_FUNCTION KokkosODE::Experimental::newton_solver_status NewtonSolve(
   norm_type norm_new    = Kokkos::ArithTraits<norm_type>::zero();
   norm_type rate        = Kokkos::ArithTraits<norm_type>::zero();
 
-  const norm_type tol = Kokkos::max(10 * Kokkos::ArithTraits<norm_type>::eps() / params.rel_tol,
-				    Kokkos::min(0.03, Kokkos::sqrt(params.rel_tol)));
+  const norm_type tol =
+      Kokkos::max(10 * Kokkos::ArithTraits<norm_type>::eps() / params.rel_tol,
+                  Kokkos::min(0.03, Kokkos::sqrt(params.rel_tol)));
 
   // LBV - 07/24/2023: for now assume that we take
   // a full Newton step. Eventually this value can
@@ -80,16 +83,18 @@ KOKKOS_FUNCTION KokkosODE::Experimental::newton_solver_status NewtonSolve(
     norm = KokkosBlas::serial_nrm2(rhs);
 
     // Compute rms norm of the scaled update
-    for(int idx = 0; idx < sys.neqs; ++idx) {
+    for (int idx = 0; idx < sys.neqs; ++idx) {
       norm_new = (update(idx) * update(idx)) / (scale(idx) * scale(idx));
     }
     norm_new = Kokkos::sqrt(norm_new / sys.neqs);
-    if((it > 0) && norm_old > Kokkos::ArithTraits<norm_type>::zero()) {
+    if ((it > 0) && norm_old > Kokkos::ArithTraits<norm_type>::zero()) {
       rate = norm_new / norm_old;
-      if((rate >= 1) || Kokkos::pow(rate, params.max_iters - it) / (1 - rate) * norm_new > tol) {
-	return newton_solver_status::NLS_DIVERGENCE;
-      } else if((norm_new == 0) || ((rate / (1 - rate)) * norm_new < tol)) {
-	return newton_solver_status::NLS_SUCCESS;
+      if ((rate >= 1) ||
+          Kokkos::pow(rate, params.max_iters - it) / (1 - rate) * norm_new >
+              tol) {
+        return newton_solver_status::NLS_DIVERGENCE;
+      } else if ((norm_new == 0) || ((rate / (1 - rate)) * norm_new < tol)) {
+        return newton_solver_status::NLS_SUCCESS;
       }
     }
 

--- a/ode/impl/KokkosODE_Newton_impl.hpp
+++ b/ode/impl/KokkosODE_Newton_impl.hpp
@@ -30,17 +30,17 @@
 namespace KokkosODE {
 namespace Impl {
 
-template <class system_type, class mat_type, class vec_type>
+template <class system_type, class mat_type, class ini_vec_type, class rhs_vec_type, class update_type>
 KOKKOS_FUNCTION KokkosODE::Experimental::newton_solver_status NewtonSolve(
     system_type& sys, const KokkosODE::Experimental::Newton_params& params,
-    mat_type& J, mat_type& tmp, vec_type& y0, vec_type& rhs, vec_type& update) {
+    mat_type& J, mat_type& tmp, ini_vec_type& y0, rhs_vec_type& rhs, update_type& update) {
   using newton_solver_status = KokkosODE::Experimental::newton_solver_status;
-  using value_type           = typename vec_type::non_const_value_type;
+  using value_type           = typename ini_vec_type::non_const_value_type;
 
   // Define the type returned by nrm2 to store
   // the norm of the residual.
   using norm_type = typename Kokkos::Details::InnerProductSpaceTraits<
-      typename vec_type::non_const_value_type>::mag_type;
+      typename ini_vec_type::non_const_value_type>::mag_type;
   sys.residual(y0, rhs);
   // std::cout << "y0=" << y0(0) << std::endl;
   // std::cout << "rhs0= " << rhs(0) << std::endl;

--- a/ode/impl/KokkosODE_Newton_impl.hpp
+++ b/ode/impl/KokkosODE_Newton_impl.hpp
@@ -41,7 +41,9 @@ KOKKOS_FUNCTION KokkosODE::Experimental::newton_solver_status NewtonSolve(
   // the norm of the residual.
   using norm_type = typename Kokkos::Details::InnerProductSpaceTraits<
       typename vec_type::non_const_value_type>::mag_type;
-  norm_type norm = Kokkos::ArithTraits<norm_type>::zero();
+  sys.residual(y0, rhs);
+  const norm_type norm0 = KokkosBlas::serial_nrm2(rhs);
+  norm_type norm        = Kokkos::ArithTraits<norm_type>::zero();
 
   // LBV - 07/24/2023: for now assume that we take
   // a full Newton step. Eventually this value can
@@ -59,7 +61,7 @@ KOKKOS_FUNCTION KokkosODE::Experimental::newton_solver_status NewtonSolve(
     // with J=du/dx, rhs=f(u_n+update)-f(u_n)
     norm = KokkosBlas::serial_nrm2(rhs);
 
-    if ((norm < params.rel_tol) ||
+    if ((norm < (params.rel_tol * norm0)) ||
         (it > 0 ? KokkosBlas::serial_nrm2(update) < params.abs_tol : false)) {
       return newton_solver_status::NLS_SUCCESS;
     }

--- a/ode/src/KokkosODE_BDF.hpp
+++ b/ode/src/KokkosODE_BDF.hpp
@@ -1,0 +1,135 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOSODE_BDF_HPP
+#define KOKKOSODE_BDF_HPP
+
+/// \author Luc Berger-Vergiat (lberge@sandia.gov)
+/// \file KokkosODE_BDF.hpp
+
+#include "Kokkos_Core.hpp"
+#include "KokkosODE_Types.hpp"
+#include "KokkosODE_RungeKutta.hpp"
+
+#include "KokkosODE_BDF_impl.hpp"
+
+namespace KokkosODE {
+namespace Experimental {
+
+enum BDF_type : int {
+  BDF1 = 0,
+  BDF2 = 1,
+  BDF3 = 2,
+  BDF4 = 3,
+  BDF5 = 4,
+  BDF6 = 5
+};
+
+template <BDF_type T>
+struct BDF_coeff_helper {
+  using table_type = void;
+};
+
+template <>
+struct BDF_coeff_helper<BDF_type::BDF1> {
+  using table_type = KokkosODE::Impl::BDF_table<1>;
+};
+
+template <>
+struct BDF_coeff_helper<BDF_type::BDF2> {
+  using table_type = KokkosODE::Impl::BDF_table<2>;
+};
+
+template <>
+struct BDF_coeff_helper<BDF_type::BDF3> {
+  using table_type = KokkosODE::Impl::BDF_table<3>;
+};
+
+template <>
+struct BDF_coeff_helper<BDF_type::BDF4> {
+  using table_type = KokkosODE::Impl::BDF_table<4>;
+};
+
+template <>
+struct BDF_coeff_helper<BDF_type::BDF5> {
+  using table_type = KokkosODE::Impl::BDF_table<5>;
+};
+
+template <>
+struct BDF_coeff_helper<BDF_type::BDF6> {
+  using table_type = KokkosODE::Impl::BDF_table<6>;
+};
+
+template <BDF_type T>
+struct BDF {
+  using table_type = typename BDF_coeff_helper<T>::table_type;
+
+  template <class ode_type, class vec_type, class mv_type, class mat_type,
+            class scalar_type>
+  KOKKOS_FUNCTION static void Solve(
+      const ode_type& ode, const scalar_type t_start, const scalar_type t_end,
+      const int num_steps, const vec_type& y0, const vec_type& y,
+      const vec_type& rhs, const vec_type& update, const mv_type& y_vecs,
+      const mat_type& temp, const mat_type& jac) {
+    const table_type table;
+
+    const double dt = (t_end - t_start) / num_steps;
+    double t        = t_start;
+
+    // Load y0 into y_vecs(:, 0)
+    for (int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
+      y_vecs(eqIdx, 0) = y0(eqIdx);
+    }
+
+    // Compute initial start-up history vectors
+    // Using a non adaptive explicit method.
+    const int init_steps = table.order - 1;
+    if (num_steps < init_steps) {
+      return;
+    }
+    KokkosODE::Experimental::ODE_params params(table.order - 1);
+    for (int stepIdx = 0; stepIdx < init_steps; ++stepIdx) {
+      KokkosODE::Experimental::RungeKutta<RK_type::RKF45>::Solve(
+          ode, params, t, t + dt, y0, y, update, temp);
+
+      for (int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
+        y_vecs(eqIdx, stepIdx + 1) = y(eqIdx);
+        y0(eqIdx)                  = y(eqIdx);
+      }
+      t += dt;
+    }
+
+    for (int stepIdx = init_steps; stepIdx < num_steps; ++stepIdx) {
+      KokkosODE::Impl::BDFStep(ode, table, t, dt, y0, y, rhs, update, y_vecs,
+                               temp, jac);
+
+      // Update history
+      for (int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
+        y0(eqIdx) = y(eqIdx);
+        for (int orderIdx = 0; orderIdx < table.order - 1; ++orderIdx) {
+          y_vecs(eqIdx, orderIdx) = y_vecs(eqIdx, orderIdx + 1);
+        }
+        y_vecs(eqIdx, table.order - 1) = y(eqIdx);
+      }
+      t += dt;
+    }
+  }
+};
+
+}  // namespace Experimental
+}  // namespace KokkosODE
+
+#endif  // KOKKOSODE_BDF_HPP

--- a/ode/src/KokkosODE_BDF.hpp
+++ b/ode/src/KokkosODE_BDF.hpp
@@ -198,7 +198,7 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
   }
 
   // Initialize D(:, 0) = y0 and D(:, 1) = dt*rhs
-  auto D = Kokkos::subview(temp, Kokkos::ALL(), Kokkos::pair<int, int>(0, 8));
+  auto D = Kokkos::subview(temp, Kokkos::ALL(), Kokkos::pair<int, int>(2, 10));
   for(int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
     D(eqIdx, 0) = y0(eqIdx);
     D(eqIdx, 1) = dt*rhs(eqIdx);
@@ -215,8 +215,8 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
     for(int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
       y0(eqIdx) = y_new(eqIdx);
     }
-    Kokkos::printf("At t=%f, y={%f, %f, %f}, next dt will be %f, order will be %d\n",
-		   t, y_new(0), y_new(1), y_new(2), dt, order);
+    std::cout << "At t=" << t << ", y={" << y_new(0) << ", " << y_new(1) << ", " << y_new(2)
+	      << "}, next dt will be " << dt << ", order will be " << order << std::endl;
   }
 
 } // BDFSolve

--- a/ode/src/KokkosODE_BDF.hpp
+++ b/ode/src/KokkosODE_BDF.hpp
@@ -96,8 +96,9 @@ struct BDF {
   KOKKOS_FUNCTION static void Solve(
       const ode_type& ode, const scalar_type t_start, const scalar_type t_end,
       const int num_steps, const vec_type& y0, const vec_type& y,
-      const vec_type& rhs, const vec_type& update, const mv_type& y_vecs,
-      const mv_type& kstack, const mat_type& temp, const mat_type& jac) {
+      const vec_type& rhs, const vec_type& update, const vec_type& scale,
+      const mv_type& y_vecs, const mv_type& kstack, const mat_type& temp,
+      const mat_type& jac) {
     const table_type table{};
 
     const double dt = (t_end - t_start) / num_steps;
@@ -127,8 +128,8 @@ struct BDF {
     }
 
     for (int stepIdx = init_steps; stepIdx < num_steps; ++stepIdx) {
-      KokkosODE::Impl::BDFStep(ode, table, t, dt, y0, y, rhs, update, y_vecs,
-                               temp, jac);
+      KokkosODE::Impl::BDFStep(ode, table, t, dt, y0, y, rhs, update, scale,
+                               y_vecs, temp, jac);
 
       // Update history
       for (int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
@@ -189,7 +190,7 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
   scalar_type dt = initial_step;
   scalar_type t  = t_start;
 
-  constexpr int max_newton_iters = 4;
+  constexpr int max_newton_iters = 10;
   scalar_type atol = 1.0e-6, rtol = 1.0e-3;
 
   // Compute rhs = f(t_start, y0)

--- a/ode/src/KokkosODE_BDF.hpp
+++ b/ode/src/KokkosODE_BDF.hpp
@@ -172,8 +172,6 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
 			      mat_type& temp, mat_type& temp2) {
   using KAT = Kokkos::ArithTraits<scalar_type>;
 
-  Kokkos::printf("y0 = {%f, %f, %f}\n", y0(0), y0(1), y0(2));
-
   // This needs to go away and be pulled out of temp instead...
   auto rhs    = Kokkos::subview(temp, Kokkos::ALL(), 0);
   auto update = Kokkos::subview(temp, Kokkos::ALL(), 1);

--- a/ode/src/KokkosODE_BDF.hpp
+++ b/ode/src/KokkosODE_BDF.hpp
@@ -41,36 +41,50 @@ enum BDF_type : int {
 template <BDF_type T>
 struct BDF_coeff_helper {
   using table_type = void;
+
+  BDF_coeff_helper() = default;
 };
 
 template <>
 struct BDF_coeff_helper<BDF_type::BDF1> {
   using table_type = KokkosODE::Impl::BDF_table<1>;
+
+  BDF_coeff_helper() = default;
 };
 
 template <>
 struct BDF_coeff_helper<BDF_type::BDF2> {
   using table_type = KokkosODE::Impl::BDF_table<2>;
+
+  BDF_coeff_helper() = default;
 };
 
 template <>
 struct BDF_coeff_helper<BDF_type::BDF3> {
   using table_type = KokkosODE::Impl::BDF_table<3>;
+
+  BDF_coeff_helper() = default;
 };
 
 template <>
 struct BDF_coeff_helper<BDF_type::BDF4> {
   using table_type = KokkosODE::Impl::BDF_table<4>;
+
+  BDF_coeff_helper() = default;
 };
 
 template <>
 struct BDF_coeff_helper<BDF_type::BDF5> {
   using table_type = KokkosODE::Impl::BDF_table<5>;
+
+  BDF_coeff_helper() = default;
 };
 
 template <>
 struct BDF_coeff_helper<BDF_type::BDF6> {
   using table_type = KokkosODE::Impl::BDF_table<6>;
+
+  BDF_coeff_helper() = default;
 };
 
 template <BDF_type T>
@@ -84,7 +98,7 @@ struct BDF {
       const int num_steps, const vec_type& y0, const vec_type& y,
       const vec_type& rhs, const vec_type& update, const mv_type& y_vecs,
       const mv_type& kstack, const mat_type& temp, const mat_type& jac) {
-    const table_type table;
+    const table_type table{};
 
     const double dt = (t_end - t_start) / num_steps;
     double t        = t_start;
@@ -159,7 +173,9 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
   using KAT = Kokkos::ArithTraits<scalar_type>;
 
   // This needs to go away and be pulled out of temp instead...
-  vec_type rhs("rhs", ode.neqs), update("update", ode.neqs);
+  auto rhs    = Kokkos::subview(temp, Kokkos::ALL(), 0);
+  auto update = Kokkos::subview(temp, Kokkos::ALL(), 1);
+  // vec_type rhs("rhs", ode.neqs), update("update", ode.neqs);
   (void) max_step;
 
   int order = 1, num_equal_steps = 0;

--- a/ode/src/KokkosODE_BDF.hpp
+++ b/ode/src/KokkosODE_BDF.hpp
@@ -189,8 +189,8 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
   scalar_type dt = initial_step;
   scalar_type t  = t_start;
 
-  constexpr int max_newton_iters = 5;
-  scalar_type atol = 1.0e-6, rtol = 1.0e-4;
+  constexpr int max_newton_iters = 4;
+  scalar_type atol = 1.0e-6, rtol = 1.0e-3;
 
   // Compute rhs = f(t_start, y0)
   ode.evaluate_function(t_start, 0, y0, rhs);
@@ -219,13 +219,13 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
     for(int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
       y0(eqIdx) = y_new(eqIdx);
     }
-// #if KOKKOS_VERSION < 40199
-//     KOKKOS_IMPL_DO_NOT_USE_PRINTF("At t=%f, y={%f, %f, %f}, next dt will be %f, order will be %d\n",
-// 				  t, y_new(0), y_new(1), y_new(2), dt, order);
-// #else
-//     Kokkos::printf("At t=%f, y={%f, %f, %f}, next dt will be %f, order will be %d\n",
-// 		   t, y_new(0), y_new(1), y_new(2), dt, order);
-// #endif
+#if KOKKOS_VERSION < 40199
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF("At t=%f, y={%8.6e, %8.6e, %8.6e}, next dt will be %f, order will be %d\n",
+				  t, y_new(0), y_new(1), y_new(2), dt, order);
+#else
+    Kokkos::printf("At t=%f, y={%8.6e, %8.6e, %8.6e}, next dt will be %f, order will be %d\n",
+		   t, y_new(0), y_new(1), y_new(2), dt, order);
+#endif
   }
 // #if KOKKOS_VERSION < 40199
 //     KOKKOS_IMPL_DO_NOT_USE_PRINTF("At t=%f, y={%f, %f, %f}\n",

--- a/ode/src/KokkosODE_BDF.hpp
+++ b/ode/src/KokkosODE_BDF.hpp
@@ -173,12 +173,6 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
 			      mat_type& temp, mat_type& temp2) {
   using KAT = Kokkos::ArithTraits<scalar_type>;
 
-// #if KOKKOS_VERSION < 40199
-//   KOKKOS_IMPL_DO_NOT_USE_PRINTF("y0 = {%f, %f, %f}\n", y0(0), y0(1), y0(2));
-// #else
-//   Kokkos::printf("y0 = {%f, %f, %f}\n", y0(0), y0(1), y0(2));
-// #endif
-
   // This needs to go away and be pulled out of temp instead...
   auto rhs    = Kokkos::subview(temp, Kokkos::ALL(), 0);
   auto update = Kokkos::subview(temp, Kokkos::ALL(), 1);
@@ -220,22 +214,7 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
     for(int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
       y0(eqIdx) = y_new(eqIdx);
     }
-#if KOKKOS_VERSION < 40199
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF("At t=%f, y={%8.6e, %8.6e, %8.6e}, next dt will be %f, order will be %d\n",
-				  t, y_new(0), y_new(1), y_new(2), dt, order);
-#else
-    Kokkos::printf("At t=%f, y={%8.6e, %8.6e, %8.6e}, next dt will be %f, order will be %d\n",
-		   t, y_new(0), y_new(1), y_new(2), dt, order);
-#endif
   }
-// #if KOKKOS_VERSION < 40199
-//     KOKKOS_IMPL_DO_NOT_USE_PRINTF("At t=%f, y={%f, %f, %f}\n",
-// 				  t, y_new(0), y_new(1), y_new(2));
-// #else
-//     Kokkos::printf("At t=%f, y={%f, %f, %f}\n",
-// 		   t, y_new(0), y_new(1), y_new(2));
-// #endif
-
 } // BDFSolve
 
 }  // namespace Experimental

--- a/ode/src/KokkosODE_BDF.hpp
+++ b/ode/src/KokkosODE_BDF.hpp
@@ -172,6 +172,8 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
 			      mat_type& temp, mat_type& temp2) {
   using KAT = Kokkos::ArithTraits<scalar_type>;
 
+  Kokkos::printf("y0 = {%f, %f, %f}\n", y0(0), y0(1), y0(2));
+
   // This needs to go away and be pulled out of temp instead...
   auto rhs    = Kokkos::subview(temp, Kokkos::ALL(), 0);
   auto update = Kokkos::subview(temp, Kokkos::ALL(), 1);

--- a/ode/src/KokkosODE_BDF.hpp
+++ b/ode/src/KokkosODE_BDF.hpp
@@ -83,7 +83,7 @@ struct BDF {
       const ode_type& ode, const scalar_type t_start, const scalar_type t_end,
       const int num_steps, const vec_type& y0, const vec_type& y,
       const vec_type& rhs, const vec_type& update, const mv_type& y_vecs,
-      const mat_type& temp, const mat_type& jac) {
+      const mv_type& kstack, const mat_type& temp, const mat_type& jac) {
     const table_type table;
 
     const double dt = (t_end - t_start) / num_steps;
@@ -103,7 +103,7 @@ struct BDF {
     KokkosODE::Experimental::ODE_params params(table.order - 1);
     for (int stepIdx = 0; stepIdx < init_steps; ++stepIdx) {
       KokkosODE::Experimental::RungeKutta<RK_type::RKF45>::Solve(
-          ode, params, t, t + dt, y0, y, update, temp);
+          ode, params, t, t + dt, y0, y, update, kstack);
 
       for (int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
         y_vecs(eqIdx, stepIdx + 1) = y(eqIdx);

--- a/ode/src/KokkosODE_BDF.hpp
+++ b/ode/src/KokkosODE_BDF.hpp
@@ -214,6 +214,7 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
     for(int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
       y0(eqIdx) = y_new(eqIdx);
     }
+    // printf("t=%f, dt=%f, y={%f, %f, %f}\n", t, dt, y0(0), y0(1), y0(2));
   }
 } // BDFSolve
 

--- a/ode/src/KokkosODE_BDF.hpp
+++ b/ode/src/KokkosODE_BDF.hpp
@@ -172,7 +172,8 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
 			      mat_type& temp, mat_type& temp2) {
   using KAT = Kokkos::ArithTraits<scalar_type>;
 
-  Kokkos::printf("y0 = {%f, %f, %f}\n", y0(0), y0(1), y0(2));
+  // Kokkos::printf("y0 = {%f, %f, %f}\n", y0(0), y0(1), y0(2));
+  printf("y0 = {%f, %f, %f}\n", y0(0), y0(1), y0(2));
 
   // This needs to go away and be pulled out of temp instead...
   auto rhs    = Kokkos::subview(temp, Kokkos::ALL(), 0);

--- a/ode/src/KokkosODE_BDF.hpp
+++ b/ode/src/KokkosODE_BDF.hpp
@@ -172,8 +172,11 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
 			      mat_type& temp, mat_type& temp2) {
   using KAT = Kokkos::ArithTraits<scalar_type>;
 
-  // Kokkos::printf("y0 = {%f, %f, %f}\n", y0(0), y0(1), y0(2));
-  printf("y0 = {%f, %f, %f}\n", y0(0), y0(1), y0(2));
+#if KOKKOS_VERSION < 40199
+  KOKKOS_IMPL_DO_NOT_USE_PRINTF("y0 = {%f, %f, %f}\n", y0(0), y0(1), y0(2));
+#else
+  Kokkos::printf("y0 = {%f, %f, %f}\n", y0(0), y0(1), y0(2));
+#endif
 
   // This needs to go away and be pulled out of temp instead...
   auto rhs    = Kokkos::subview(temp, Kokkos::ALL(), 0);
@@ -216,8 +219,13 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
     for(int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
       y0(eqIdx) = y_new(eqIdx);
     }
-    std::cout << "At t=" << t << ", y={" << y_new(0) << ", " << y_new(1) << ", " << y_new(2)
-	      << "}, next dt will be " << dt << ", order will be " << order << std::endl;
+#if KOKKOS_VERSION < 40199
+    KOKKOS_IMPL_DO_NOT_USE_PRINTF("At t=%f, y={%f, %f, %f}, next dt will be %f, order will be %d\n",
+				  t, y_new(0), y_new(1), y_new(2), dt, order);
+#else
+    Kokkos::printf("At t=%f, y={%f, %f, %f}, next dt will be %f, order will be %d\n",
+		   t, y_new(0), y_new(1), y_new(2), dt, order);
+#endif
   }
 
 } // BDFSolve

--- a/ode/src/KokkosODE_BDF.hpp
+++ b/ode/src/KokkosODE_BDF.hpp
@@ -126,7 +126,18 @@ struct BDF {
       }
       t += dt;
     }
-  }
+  } // Solve()
+
+  template <class ode_type, class mat_type, class vec_type, class scalar_type>
+  KOKKOS_FUNCTION static void SolveODE(
+      const ode_type& ode, const KokkosODE::Experimental::ODE_params& params,
+      const scalar_type t_start, const scalar_type t_end, const vec_type& y0,
+      const vec_type& y, const mat_type& buffer) {
+    const table_type table;
+
+    (void) ode, params, t_start, t_end, y0, y, buffer;
+
+  } // SolveODE
 };
 
 }  // namespace Experimental

--- a/ode/src/KokkosODE_BDF.hpp
+++ b/ode/src/KokkosODE_BDF.hpp
@@ -172,6 +172,8 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
 			      mat_type& temp, mat_type& temp2) {
   using KAT = Kokkos::ArithTraits<scalar_type>;
 
+  Kokkos::printf("y0 = {%f, %f, %f}\n", y0(0), y0(1), y0(2));
+
   // This needs to go away and be pulled out of temp instead...
   auto rhs    = Kokkos::subview(temp, Kokkos::ALL(), 0);
   auto update = Kokkos::subview(temp, Kokkos::ALL(), 1);
@@ -213,8 +215,8 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
     for(int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
       y0(eqIdx) = y_new(eqIdx);
     }
-    // std::cout << "At t=" << t << ", y={" << y_new(0) << ", " << y_new(1) << ", " << y_new(2)
-    // 	      << "}, next dt will be " << dt << ", order will be " << order << std::endl;
+    Kokkos::printf("At t=%f, y={%f, %f, %f}, next dt will be %f, order will be %d\n",
+		   t, y_new(0), y_new(1), y_new(2), dt, order);
   }
 
 } // BDFSolve

--- a/ode/src/KokkosODE_BDF.hpp
+++ b/ode/src/KokkosODE_BDF.hpp
@@ -127,18 +127,72 @@ struct BDF {
       t += dt;
     }
   } // Solve()
-
-  template <class ode_type, class mat_type, class vec_type, class scalar_type>
-  KOKKOS_FUNCTION static void SolveODE(
-      const ode_type& ode, const KokkosODE::Experimental::ODE_params& params,
-      const scalar_type t_start, const scalar_type t_end, const vec_type& y0,
-      const vec_type& y, const mat_type& buffer) {
-    const table_type table;
-
-    (void) ode, params, t_start, t_end, y0, y, buffer;
-
-  } // SolveODE
 };
+
+/// \brief BDF Solve integrates an ordinary differential equation
+/// using an order and time adaptive BDF method.
+///
+/// The integration starts with a BDF1 method and adaptively increases
+/// or decreases both dt and the order of integration based on error
+/// estimators. This function is marked as KOKKOS_FUNCTION so it can
+/// be called on host and device.
+///
+/// \tparam ode_type the type of the ode object to integrated
+/// \tparam mv_type a rank-2 view
+/// \tparam vec_type a rank-1 view
+///
+/// \param ode [in]: the ode to integrate
+/// \param t_start [in]: time at which the integration starts
+/// \param t_end [in]: time at which the integration stops
+/// \param initial_step [in]: initial value for dt
+/// \param max_step [in]: maximum value for dt
+/// \param y0 [in/out]: vector of initial conditions, set to the solution
+/// at the end of the integration
+/// \param y_new [out]: vector of solution at t_end
+/// \param temp [in]: vectors for temporary storage
+/// \param temp2 [in]: vectors for temporary storage
+template <class ode_type, class mat_type, class vec_type>
+KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const double t_start, const double t_end,
+			      const double initial_step, const double max_step,
+			      const vec_type& y0, const vec_type& y_new,
+			      mat_type& temp, mat_type& temp2) {
+
+  // This needs to go away and be pulled out of temp instead...
+  vec_type rhs("rhs", ode.neqs), update("update", ode.neqs);
+  (void) max_step;
+
+  int order = 1, num_equal_steps = 0;
+  constexpr double min_factor = 0.2;
+  double dt = initial_step;
+  double t  = t_start;
+
+  constexpr int max_newton_iters = 5;
+  double atol = 1.0e-6, rtol = 1.0e-4;
+
+  // Initialize D(:, 0) = y0 and D(:, 1) = dt*rhs
+  auto D = Kokkos::subview(temp, Kokkos::ALL(), Kokkos::pair<int, int>(0, 8));
+  ode.evaluate_function(0, 0, y0, rhs);
+  for(int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
+    D(eqIdx, 0) = y0(0);
+    D(eqIdx, 1) = dt*rhs(eqIdx);
+    rhs(eqIdx) = 0;
+  }
+
+  // Now we loop over the time interval [t_start, t_end]
+  // and solve our ODE.
+  while(t < t_end) {
+    KokkosODE::Impl::BDFStep(ode, t, dt, t_end, order,
+			     num_equal_steps, max_newton_iters, atol, rtol, min_factor,
+			     y0, y_new, rhs, update, temp, temp2);
+
+    for(int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
+      y0(eqIdx) = y_new(eqIdx);
+    }
+    std::cout << "At t=" << t << ", y=" << y_new(0)
+	      << ", next dt will be " << dt << ", order will be " << order << std::endl;
+  }
+
+} // BDFSolve
 
 }  // namespace Experimental
 }  // namespace KokkosODE

--- a/ode/src/KokkosODE_BDF.hpp
+++ b/ode/src/KokkosODE_BDF.hpp
@@ -172,11 +172,11 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
 			      mat_type& temp, mat_type& temp2) {
   using KAT = Kokkos::ArithTraits<scalar_type>;
 
-#if KOKKOS_VERSION < 40199
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("y0 = {%f, %f, %f}\n", y0(0), y0(1), y0(2));
-#else
-  Kokkos::printf("y0 = {%f, %f, %f}\n", y0(0), y0(1), y0(2));
-#endif
+// #if KOKKOS_VERSION < 40199
+//   KOKKOS_IMPL_DO_NOT_USE_PRINTF("y0 = {%f, %f, %f}\n", y0(0), y0(1), y0(2));
+// #else
+//   Kokkos::printf("y0 = {%f, %f, %f}\n", y0(0), y0(1), y0(2));
+// #endif
 
   // This needs to go away and be pulled out of temp instead...
   auto rhs    = Kokkos::subview(temp, Kokkos::ALL(), 0);
@@ -219,14 +219,21 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
     for(int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
       y0(eqIdx) = y_new(eqIdx);
     }
-#if KOKKOS_VERSION < 40199
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF("At t=%f, y={%f, %f, %f}, next dt will be %f, order will be %d\n",
-				  t, y_new(0), y_new(1), y_new(2), dt, order);
-#else
-    Kokkos::printf("At t=%f, y={%f, %f, %f}, next dt will be %f, order will be %d\n",
-		   t, y_new(0), y_new(1), y_new(2), dt, order);
-#endif
+// #if KOKKOS_VERSION < 40199
+//     KOKKOS_IMPL_DO_NOT_USE_PRINTF("At t=%f, y={%f, %f, %f}, next dt will be %f, order will be %d\n",
+// 				  t, y_new(0), y_new(1), y_new(2), dt, order);
+// #else
+//     Kokkos::printf("At t=%f, y={%f, %f, %f}, next dt will be %f, order will be %d\n",
+// 		   t, y_new(0), y_new(1), y_new(2), dt, order);
+// #endif
   }
+// #if KOKKOS_VERSION < 40199
+//     KOKKOS_IMPL_DO_NOT_USE_PRINTF("At t=%f, y={%f, %f, %f}\n",
+// 				  t, y_new(0), y_new(1), y_new(2));
+// #else
+//     Kokkos::printf("At t=%f, y={%f, %f, %f}\n",
+// 		   t, y_new(0), y_new(1), y_new(2));
+// #endif
 
 } // BDFSolve
 

--- a/ode/src/KokkosODE_Newton.hpp
+++ b/ode/src/KokkosODE_Newton.hpp
@@ -30,13 +30,14 @@ namespace Experimental {
 
 /// \brief Newton solver for non-linear system of equations
 struct Newton {
-  template <class system_type, class mat_type, class ini_vec_type, class rhs_vec_type,
-	    class update_type, class scale_type>
+  template <class system_type, class mat_type, class ini_vec_type,
+            class rhs_vec_type, class update_type, class scale_type>
   KOKKOS_FUNCTION static newton_solver_status Solve(
       const system_type& sys, const Newton_params& params, const mat_type& J,
       const mat_type& tmp, const ini_vec_type& y0, const rhs_vec_type& rhs,
       const update_type& update, const scale_type& scale) {
-    return KokkosODE::Impl::NewtonSolve(sys, params, J, tmp, y0, rhs, update, scale);
+    return KokkosODE::Impl::NewtonSolve(sys, params, J, tmp, y0, rhs, update,
+                                        scale);
   }
 };
 

--- a/ode/src/KokkosODE_Newton.hpp
+++ b/ode/src/KokkosODE_Newton.hpp
@@ -31,12 +31,12 @@ namespace Experimental {
 /// \brief Newton solver for non-linear system of equations
 struct Newton {
   template <class system_type, class mat_type, class ini_vec_type, class rhs_vec_type,
-	    class update_type>
+	    class update_type, class scale_type>
   KOKKOS_FUNCTION static newton_solver_status Solve(
       const system_type& sys, const Newton_params& params, const mat_type& J,
       const mat_type& tmp, const ini_vec_type& y0, const rhs_vec_type& rhs,
-      const update_type& update) {
-    return KokkosODE::Impl::NewtonSolve(sys, params, J, tmp, y0, rhs, update);
+      const update_type& update, const scale_type& scale) {
+    return KokkosODE::Impl::NewtonSolve(sys, params, J, tmp, y0, rhs, update, scale);
   }
 };
 

--- a/ode/src/KokkosODE_Newton.hpp
+++ b/ode/src/KokkosODE_Newton.hpp
@@ -30,11 +30,12 @@ namespace Experimental {
 
 /// \brief Newton solver for non-linear system of equations
 struct Newton {
-  template <class system_type, class mat_type, class vec_type>
+  template <class system_type, class mat_type, class ini_vec_type, class rhs_vec_type,
+	    class update_type>
   KOKKOS_FUNCTION static newton_solver_status Solve(
       const system_type& sys, const Newton_params& params, const mat_type& J,
-      const mat_type& tmp, const vec_type& y0, const vec_type& rhs,
-      const vec_type& update) {
+      const mat_type& tmp, const ini_vec_type& y0, const rhs_vec_type& rhs,
+      const update_type& update) {
     return KokkosODE::Impl::NewtonSolve(sys, params, J, tmp, y0, rhs, update);
   }
 };

--- a/ode/src/KokkosODE_Types.hpp
+++ b/ode/src/KokkosODE_Types.hpp
@@ -58,7 +58,7 @@ enum newton_solver_status : int {
 };
 
 struct Newton_params {
-  int max_iters;
+  int max_iters, iters = 0;
   double abs_tol, rel_tol;
 
   // Constructor that sets basic solver parameters

--- a/ode/src/KokkosODE_Types.hpp
+++ b/ode/src/KokkosODE_Types.hpp
@@ -61,9 +61,11 @@ struct Newton_params {
   int max_iters;
   double abs_tol, rel_tol;
 
-  // Constructor that only specify the desired number of steps.
-  // In this case no adaptivity is provided, the time step will
-  // be constant such that dt = (tend - tstart) / num_steps;
+  // Constructor that sets basic solver parameters
+  // used while solving the nonlinear system
+  // int max_iters_  [in]: maximum number of iterations allowed
+  // double abs_tol_ [in]: absolute tolerance to reach for successful solve
+  // double rel_tol_ [in]: relative tolerance to reach for successful solve
   KOKKOS_FUNCTION
   Newton_params(const int max_iters_, const double abs_tol_,
                 const double rel_tol_)

--- a/ode/src/KokkosODE_Types.hpp
+++ b/ode/src/KokkosODE_Types.hpp
@@ -54,7 +54,8 @@ struct ODE_params {
 enum newton_solver_status : int {
   NLS_SUCCESS    = 0,
   MAX_ITER       = 1,
-  LIN_SOLVE_FAIL = 2
+  LIN_SOLVE_FAIL = 2,
+  NLS_DIVERGENCE = 3,
 };
 
 struct Newton_params {

--- a/ode/unit_test/Test_ODE.hpp
+++ b/ode/unit_test/Test_ODE.hpp
@@ -22,5 +22,6 @@
 
 // Implicit integrators
 #include "Test_ODE_Newton.hpp"
+#include "Test_ODE_BDF.hpp"
 
 #endif  // TEST_ODE_HPP

--- a/ode/unit_test/Test_ODE_BDF.hpp
+++ b/ode/unit_test/Test_ODE_BDF.hpp
@@ -751,7 +751,7 @@ void test_BDF_adaptive_stiff() {
 
   StiffChemistry mySys{};
 
-  const scalar_type t_start = KAT::zero(), t_end = 500*KAT::one();
+  const scalar_type t_start = KAT::zero(), t_end = 350*KAT::one();
   scalar_type dt = KAT::zero();
   vec_type y0("initial conditions", mySys.neqs), y_new("solution", mySys.neqs);
 

--- a/ode/unit_test/Test_ODE_BDF.hpp
+++ b/ode/unit_test/Test_ODE_BDF.hpp
@@ -174,8 +174,9 @@ struct BDFSolve_wrapper {
   }
 };
 
-template <class execution_space, class scalar_type>
+template <class device_type, class scalar_type>
 void test_BDF_Logistic() {
+  using execution_space = typename device_type::execution_space;
   using vec_type = Kokkos::View<scalar_type*, execution_space>;
   using mv_type  = Kokkos::View<scalar_type**, execution_space>;
   using mat_type = Kokkos::View<scalar_type**, execution_space>;
@@ -347,8 +348,9 @@ void test_BDF_Logistic() {
 
 }  // test_BDF_Logistic
 
-template <class execution_space, class scalar_type>
+template <class device_type, class scalar_type>
 void test_BDF_LotkaVolterra() {
+  using execution_space = typename device_type::execution_space;
   using vec_type = Kokkos::View<scalar_type*, execution_space>;
   using mv_type  = Kokkos::View<scalar_type**, execution_space>;
   using mat_type = Kokkos::View<scalar_type**, execution_space>;
@@ -376,8 +378,9 @@ void test_BDF_LotkaVolterra() {
   Kokkos::parallel_for(myPolicy, solve_wrapper);
 }
 
-template <class execution_space, class scalar_type>
+template <class device_type, class scalar_type>
 void test_BDF_StiffChemistry() {
+  using execution_space = typename device_type::execution_space;
   using vec_type = Kokkos::View<scalar_type*, execution_space>;
   using mv_type  = Kokkos::View<scalar_type**, execution_space>;
   using mat_type = Kokkos::View<scalar_type**, execution_space>;
@@ -474,8 +477,9 @@ struct BDFSolve_parallel {
   }
 };
 
-template <class execution_space, class scalar_type>
+template <class device_type, class scalar_type>
 void test_BDF_parallel() {
+  using execution_space = typename device_type::execution_space;
   using vec_type = Kokkos::View<scalar_type*, execution_space>;
   using mv_type  = Kokkos::View<scalar_type**, execution_space>;
   using mat_type = Kokkos::View<scalar_type**, execution_space>;
@@ -537,8 +541,9 @@ void update_D(const int order, const scalar_type factor, const mat_type& coeffs,
 			    KokkosBatched::Algo::Gemm::Blocked>::invoke(1.0, U, subTempD, 0.0, subD);
 }
 
-template <class execution_space, class scalar_type>
+template <class device_type, class scalar_type>
 void test_Nordsieck() {
+  using execution_space = typename device_type::execution_space;
   StiffChemistry mySys{};
 
   Kokkos::View<scalar_type**, execution_space> R("coeffs", 6, 6), U("coeffs", 6, 6);
@@ -580,8 +585,9 @@ void test_Nordsieck() {
   std::cout << "  { " << D(1, 0) << ", " << D(1, 1) << ", " << D(1, 2) << " }" << std::endl;
 }
 
-template <class execution_space, class scalar_type>
+template <class device_type, class scalar_type>
 void test_adaptive_BDF() {
+  using execution_space = typename device_type::execution_space;
   using vec_type = Kokkos::View<scalar_type*, execution_space>;
   using mat_type = Kokkos::View<scalar_type**, execution_space>;
 
@@ -595,13 +601,13 @@ void test_adaptive_BDF() {
 
   vec_type y0("initial conditions", mySys.neqs), y_new("solution", mySys.neqs);
   vec_type rhs("rhs", mySys.neqs), update("update", mySys.neqs);
-  mat_type temp("buffer1", mySys.neqs, 21 + 2*mySys.neqs + 4), temp2("buffer2", 6, 7);
+  mat_type temp("buffer1", mySys.neqs, 23 + 2*mySys.neqs + 4), temp2("buffer2", 6, 7);
 
   // Initial condition
   Kokkos::deep_copy(y0, 0.5);
 
   // Initialize D
-  auto D = Kokkos::subview(temp, Kokkos::ALL(), Kokkos::pair<int, int>(0, 8));
+  auto D = Kokkos::subview(temp, Kokkos::ALL(), Kokkos::pair<int, int>(2, 10));
   D(0, 0) = y0(0);
   mySys.evaluate_function(0, 0, y0, rhs);
   D(0, 1) = dt*rhs(0);
@@ -674,7 +680,7 @@ void test_adaptive_BDF_v2() {
   vec_type y0("initial conditions", mySys.neqs), y_new("solution", mySys.neqs);
   Kokkos::deep_copy(y0, 0.5);
 
-  mat_type temp("buffer1", mySys.neqs, 21 + 2*mySys.neqs + 4), temp2("buffer2", 6, 7);
+  mat_type temp("buffer1", mySys.neqs, 23 + 2*mySys.neqs + 4), temp2("buffer2", 6, 7);
 
   {
     scalar_type dt = KAT::zero();
@@ -707,7 +713,7 @@ void test_BDF_adaptive_stiff() {
   y0_h(2) = KAT::zero();
   Kokkos::deep_copy(y0, y0_h);
 
-  mat_type temp("buffer1", mySys.neqs, 21 + 2*mySys.neqs + 4), temp2("buffer2", 6, 7);
+  mat_type temp("buffer1", mySys.neqs, 23 + 2*mySys.neqs + 4), temp2("buffer2", 6, 7);
 
   {
     vec_type f0("initial value f", mySys.neqs);

--- a/ode/unit_test/Test_ODE_BDF.hpp
+++ b/ode/unit_test/Test_ODE_BDF.hpp
@@ -716,7 +716,7 @@ void test_adaptive_BDF_v2() {
     scalar_type dt = KAT::zero();
     vec_type f0("initial value f", mySys.neqs);
     mySys.evaluate_function(t_start, KAT::zero(), y0, f0);
-    KokkosODE::Impl::initial_step_size(mySys, 1, t_start, 1e-6, 1e-4, y0, f0, temp, dt);
+    KokkosODE::Impl::initial_step_size(mySys, 1, t_start, 1e-6, 1e-3, y0, f0, temp, dt);
 
     std::cout << "Initial Step Size: dt=" << dt << std::endl;
   }
@@ -735,7 +735,7 @@ void test_BDF_adaptive_stiff() {
 
   StiffChemistry mySys{};
 
-  const scalar_type t_start = KAT::zero(), t_end = 500*KAT::one();
+  const scalar_type t_start = KAT::zero(), t_end = 0.02*KAT::one();
   scalar_type dt = KAT::zero();
   vec_type y0("initial conditions", mySys.neqs), y_new("solution", mySys.neqs);
 
@@ -755,7 +755,7 @@ void test_BDF_adaptive_stiff() {
     auto f0_h = Kokkos::create_mirror_view(f0);
 
     mySys.evaluate_function(t_start, KAT::zero(), y0_h, f0_h);
-    KokkosODE::Impl::initial_step_size(mySys, 1, t_start, 1e-6, 1e-4, y0_h, f0_h, temp_h, dt);
+    KokkosODE::Impl::initial_step_size(mySys, 1, t_start, 1e-6, 1e-3, y0_h, f0_h, temp_h, dt);
   }
   std::cout << "Initial Step Size: dt=" << dt << std::endl;
 

--- a/ode/unit_test/Test_ODE_BDF.hpp
+++ b/ode/unit_test/Test_ODE_BDF.hpp
@@ -162,15 +162,15 @@ struct BDFSolve_wrapper {
         rhs(rhs_),
         update(update_),
         y_vecs(y_vecs_),
-	kstack(kstack_),
+        kstack(kstack_),
         temp(temp_),
         jac(jac_) {}
 
   KOKKOS_FUNCTION
   void operator()(const int /*idx*/) const {
-    KokkosODE::Experimental::BDF<bdf_type>::Solve(my_ode, tstart, tend,
-                                                  num_steps, y_old, y_new, rhs,
-                                                  update, y_vecs, kstack, temp, jac);
+    KokkosODE::Experimental::BDF<bdf_type>::Solve(
+        my_ode, tstart, tend, num_steps, y_old, y_new, rhs, update, y_vecs,
+        kstack, temp, jac);
   }
 };
 
@@ -434,29 +434,35 @@ struct BDFSolve_parallel {
         rhs(rhs_),
         update(update_),
         y_vecs(y_vecs_),
-	kstack(kstack_),
+        kstack(kstack_),
         temp(temp_),
         jac(jac_) {}
 
   KOKKOS_FUNCTION
   void operator()(const int idx) const {
     auto local_y_old = Kokkos::subview(
-        y_old, Kokkos::pair<int, int>(my_ode.neqs * idx, my_ode.neqs * (idx + 1)));
+        y_old,
+        Kokkos::pair<int, int>(my_ode.neqs * idx, my_ode.neqs * (idx + 1)));
     auto local_y_new = Kokkos::subview(
-        y_new, Kokkos::pair<int, int>(my_ode.neqs * idx, my_ode.neqs * (idx + 1)));
+        y_new,
+        Kokkos::pair<int, int>(my_ode.neqs * idx, my_ode.neqs * (idx + 1)));
     auto local_rhs = Kokkos::subview(
-        rhs, Kokkos::pair<int, int>(my_ode.neqs * idx, my_ode.neqs * (idx + 1)));
+        rhs,
+        Kokkos::pair<int, int>(my_ode.neqs * idx, my_ode.neqs * (idx + 1)));
     auto local_update = Kokkos::subview(
-        update, Kokkos::pair<int, int>(my_ode.neqs * idx, my_ode.neqs * (idx + 1)));
+        update,
+        Kokkos::pair<int, int>(my_ode.neqs * idx, my_ode.neqs * (idx + 1)));
 
     auto local_y_vecs = Kokkos::subview(
-        y_vecs, Kokkos::pair<int, int>(my_ode.neqs * idx, my_ode.neqs * (idx + 1)),
+        y_vecs,
+        Kokkos::pair<int, int>(my_ode.neqs * idx, my_ode.neqs * (idx + 1)),
         Kokkos::ALL());
     auto local_kstack = Kokkos::subview(
         kstack, Kokkos::ALL(),
-	Kokkos::pair<int, int>(my_ode.neqs * idx, my_ode.neqs * (idx + 1)));
+        Kokkos::pair<int, int>(my_ode.neqs * idx, my_ode.neqs * (idx + 1)));
     auto local_temp = Kokkos::subview(
-        temp, Kokkos::pair<int, int>(my_ode.neqs * idx, my_ode.neqs * (idx + 1)),
+        temp,
+        Kokkos::pair<int, int>(my_ode.neqs * idx, my_ode.neqs * (idx + 1)),
         Kokkos::ALL());
     auto local_jac = Kokkos::subview(
         jac, Kokkos::pair<int, int>(my_ode.neqs * idx, my_ode.neqs * (idx + 1)),
@@ -487,7 +493,7 @@ void test_BDF_parallel() {
 
   // Test BDF5
   mv_type y_vecs("history vectors", mySys.neqs * num_solves, 5),
-    kstack("Startup RK vectors", 6, mySys.neqs * num_solves);
+      kstack("Startup RK vectors", 6, mySys.neqs * num_solves);
 
   Kokkos::deep_copy(y0, 10.0);
   Kokkos::deep_copy(y_vecs, 10.0);

--- a/ode/unit_test/Test_ODE_BDF.hpp
+++ b/ode/unit_test/Test_ODE_BDF.hpp
@@ -764,17 +764,6 @@ void test_BDF_adaptive_stiff() {
 
   mat_type temp("buffer1", mySys.neqs, 23 + 2*mySys.neqs + 4), temp2("buffer2", 6, 7);
 
-  {
-    auto temp_h = Kokkos::create_mirror_view(temp);
-    Kokkos::deep_copy(temp_h, temp);
-    vec_type f0("initial value f", mySys.neqs);
-    auto f0_h = Kokkos::create_mirror_view(f0);
-
-    mySys.evaluate_function(t_start, KAT::zero(), y0_h, f0_h);
-    KokkosODE::Impl::initial_step_size(mySys, 1, t_start, 1e-6, 1e-3, y0_h, f0_h, temp_h, dt);
-  }
-  std::cout << "Initial Step Size: dt=" << dt << std::endl;
-
   Kokkos::RangePolicy<execution_space> policy(0, 1);
   BDF_Solve_wrapper bdf_wrapper(mySys, t_start, t_end, dt,
 				(t_end - t_start) / 10,

--- a/ode/unit_test/Test_ODE_BDF.hpp
+++ b/ode/unit_test/Test_ODE_BDF.hpp
@@ -1,0 +1,502 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <gtest/gtest.h>
+#include "KokkosKernels_TestUtils.hpp"
+
+#include "KokkosODE_BDF.hpp"
+
+namespace Test {
+
+// Logistic equation
+// Used to model population growth
+// it is a simple nonlinear ODE with
+// a lot of literature.
+//
+// Equation: y'(t) = r*y(t)*(1-y(t)/K)
+// Jacobian: df/dy = r - 2*r*y/K
+// Solution: y = K / (1 + ((K - y0) / y0)*exp(-rt))
+struct Logistic {
+  static constexpr int neqs = 1;
+
+  const double r, K;
+
+  Logistic(double r_, double K_) : r(r_), K(K_){};
+
+  template <class vec_type1, class vec_type2>
+  KOKKOS_FUNCTION void evaluate_function(const double /*t*/,
+                                         const double /*dt*/,
+                                         const vec_type1& y,
+                                         const vec_type2& f) const {
+    f(0) = r * y(0) * (1.0 - y(0) / K);
+  }
+
+  template <class vec_type, class mat_type>
+  KOKKOS_FUNCTION void evaluate_jacobian(const double /*t*/,
+                                         const double /*dt*/, const vec_type& y,
+                                         const mat_type& jac) const {
+    jac(0, 0) = r - 2 * r * y(0) / K;
+  }
+
+  template <class vec_type>
+  KOKKOS_FUNCTION void solution(const double t, const vec_type& y0,
+                                const vec_type& y) const {
+    y(0) = K / (1 + (K - y0) / y0 * Kokkos::exp(-r * t));
+  }
+
+};  // Logistic
+
+// Lotka-Volterra equation
+// A predator-prey model that describe
+// population dynamics when two species
+// interact.
+//
+// Equations: y0'(t) = alpha*y0(t) - beta*y0(t)*y1(t)
+//            y1'(t) = delta*y0(t)*y1(t) - gamma*y1(t)
+// Jacobian: df0/dy = [alpha-beta*y1(t);     beta*y0(t)]
+//           df1/dy = [delta*y1(t);          delta*y0(t)-gamma]
+// Solution: y = K / (1 + ((K - y0) / y0)*exp(-rt))
+struct LotkaVolterra {
+  static constexpr int neqs = 2;
+
+  const double alpha, beta, delta, gamma;
+
+  LotkaVolterra(double alpha_, double beta_, double delta_, double gamma_)
+      : alpha(alpha_), beta(beta_), delta(delta_), gamma(gamma_){};
+
+  template <class vec_type1, class vec_type2>
+  KOKKOS_FUNCTION void evaluate_function(const double /*t*/,
+                                         const double /*dt*/,
+                                         const vec_type1& y,
+                                         const vec_type2& f) const {
+    f(0) = alpha * y(0) - beta * y(0) * y(1);
+    f(1) = delta * y(0) * y(1) - gamma * y(1);
+  }
+
+  template <class vec_type, class mat_type>
+  KOKKOS_FUNCTION void evaluate_jacobian(const double /*t*/,
+                                         const double /*dt*/, const vec_type& y,
+                                         const mat_type& jac) const {
+    jac(0, 0) = alpha - beta * y(1);
+    jac(0, 1) = -beta * y(0);
+    jac(1, 0) = delta * y(1);
+    jac(1, 1) = delta * y(0) - gamma;
+  }
+
+};  // LotkaVolterra
+
+// Robertson's autocatalytic chemical reaction:
+// H. H. Robertson, The solution of a set of reaction rate equations,
+// in J. Walsh (Ed.), Numerical Analysis: An Introduction,
+// pp. 178–182, Academic Press, London (1966).
+//
+// Equations: y0' = -0.04*y0 + 10e4*y1*y2
+//            y1' =  0.04*y0 - 10e4*y1*y2 - 3e-7 * y1**2
+//            y2' = 3e-7 * y1**2
+struct StiffChemestry {
+  static constexpr int neqs = 3;
+
+  StiffChemestry() {}
+
+  template <class vec_type1, class vec_type2>
+  KOKKOS_FUNCTION void evaluate_function(const double /*t*/,
+                                         const double /*dt*/,
+                                         const vec_type1& y,
+                                         const vec_type2& f) const {
+    f(0) = -0.04 * y(0) + 1.e4 * y(1) * y(2);
+    f(1) = 0.04 * y(0) - 1.e4 * y(1) * y(2) - 3.e7 * y(1) * y(1);
+    f(2) = 3.e7 * y(1) * y(1);
+  }
+
+  template <class vec_type, class mat_type>
+  KOKKOS_FUNCTION void evaluate_jacobian(const double /*t*/,
+                                         const double /*dt*/, const vec_type& y,
+                                         const mat_type& jac) const {
+    jac(0, 0) = -0.04;
+    jac(0, 1) = 1.e4 * y(2);
+    jac(0, 2) = 1.e4 * y(1);
+    jac(1, 0) = 0.04;
+    jac(1, 1) = -1.e4 * y(2) - 3.e7 * 2.0 * y(1);
+    jac(1, 2) = -1.e4 * y(1);
+    jac(2, 0) = 0.00;
+    jac(2, 1) = 3.e7 * 2.0 * y(1);
+    jac(2, 2) = 0.0;
+  }
+};
+
+template <class ode_type, KokkosODE::Experimental::BDF_type bdf_type,
+          class vec_type, class mv_type, class mat_type, class scalar_type>
+struct BDFSolve_wrapper {
+  ode_type my_ode;
+  scalar_type tstart, tend;
+  int num_steps;
+  vec_type y_old, y_new, rhs, update;
+  mv_type y_vecs;
+  mat_type temp, jac;
+
+  BDFSolve_wrapper(const ode_type& my_ode_, const scalar_type tstart_,
+                   const scalar_type tend_, const int num_steps_,
+                   const vec_type& y_old_, const vec_type& y_new_,
+                   const vec_type& rhs_, const vec_type& update_,
+                   const mv_type& y_vecs_, const mat_type& temp_,
+                   const mat_type& jac_)
+      : my_ode(my_ode_),
+        tstart(tstart_),
+        tend(tend_),
+        num_steps(num_steps_),
+        y_old(y_old_),
+        y_new(y_new_),
+        rhs(rhs_),
+        update(update_),
+        y_vecs(y_vecs_),
+        temp(temp_),
+        jac(jac_) {}
+
+  KOKKOS_FUNCTION
+  void operator()(const int /*idx*/) const {
+    KokkosODE::Experimental::BDF<bdf_type>::Solve(my_ode, tstart, tend,
+                                                  num_steps, y_old, y_new, rhs,
+                                                  update, y_vecs, temp, jac);
+  }
+};
+
+template <class execution_space, class scalar_type>
+void test_BDF_Logistic() {
+  using vec_type = Kokkos::View<scalar_type*, execution_space>;
+  using mv_type  = Kokkos::View<scalar_type**, execution_space>;
+  using mat_type = Kokkos::View<scalar_type**, execution_space>;
+
+  Kokkos::RangePolicy<execution_space> myPolicy(0, 1);
+  Logistic mySys(1, 1);
+
+  constexpr int num_tests   = 7;
+  int num_steps[num_tests]  = {512, 256, 128, 64, 32, 16, 8};
+  double errors[num_tests]  = {0};
+  const scalar_type t_start = 0.0, t_end = 6.0;
+  vec_type y0("initial conditions", mySys.neqs), y_new("solution", mySys.neqs);
+  vec_type rhs("rhs", mySys.neqs), update("update", mySys.neqs);
+  mat_type jac("jacobian", mySys.neqs, mySys.neqs),
+      temp("temp storage", mySys.neqs, mySys.neqs + 4);
+
+  scalar_type measured_order;
+
+  // Test BDF1
+#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+  std::cout << "\nBDF1 convergence test" << std::endl;
+#endif
+  for (int idx = 0; idx < num_tests; idx++) {
+    mv_type y_vecs("history vectors", mySys.neqs, 1);
+
+    Kokkos::deep_copy(y0, 0.5);
+    Kokkos::deep_copy(y_vecs, 0.5);
+
+    BDFSolve_wrapper<Logistic, KokkosODE::Experimental::BDF_type::BDF1,
+                     vec_type, mv_type, mat_type, scalar_type>
+        solve_wrapper(mySys, t_start, t_end, num_steps[idx], y0, y_new, rhs,
+                      update, y_vecs, temp, jac);
+    Kokkos::parallel_for(myPolicy, solve_wrapper);
+
+    auto y_new_h = Kokkos::create_mirror_view(y_new);
+    Kokkos::deep_copy(y_new_h, y_new);
+
+    errors[idx] = Kokkos::abs(y_new_h(0) - 1 / (1 + Kokkos::exp(-t_end))) /
+                  Kokkos::abs(1 / (1 + Kokkos::exp(-t_end)));
+  }
+  measured_order =
+      Kokkos::pow(errors[num_tests - 1] / errors[0], 1.0 / (num_tests - 1));
+  EXPECT_NEAR_KK_REL(measured_order, 2.0, 0.15);
+#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+  std::cout << "expected ratio: 2, actual ratio: " << measured_order
+            << ", order error=" << Kokkos::abs(measured_order - 2.0) / 2.0
+            << std::endl;
+#endif
+
+  // Test BDF2
+#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+  std::cout << "\nBDF2 convergence test" << std::endl;
+#endif
+  for (int idx = 0; idx < num_tests; idx++) {
+    mv_type y_vecs("history vectors", mySys.neqs, 2);
+    Kokkos::deep_copy(y0, 0.5);
+
+    BDFSolve_wrapper<Logistic, KokkosODE::Experimental::BDF_type::BDF2,
+                     vec_type, mv_type, mat_type, scalar_type>
+        solve_wrapper(mySys, t_start, t_end, num_steps[idx], y0, y_new, rhs,
+                      update, y_vecs, temp, jac);
+    Kokkos::parallel_for(myPolicy, solve_wrapper);
+
+    auto y_new_h = Kokkos::create_mirror_view(y_new);
+    Kokkos::deep_copy(y_new_h, y_new);
+
+    errors[idx] = Kokkos::abs(y_new_h(0) - 1 / (1 + Kokkos::exp(-t_end))) /
+                  Kokkos::abs(1 / (1 + Kokkos::exp(-t_end)));
+  }
+  measured_order =
+      Kokkos::pow(errors[num_tests - 1] / errors[0], 1.0 / (num_tests - 1));
+  EXPECT_NEAR_KK_REL(measured_order, 4.0, 0.15);
+#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+  std::cout << "expected ratio: 4, actual ratio: " << measured_order
+            << ", order error=" << Kokkos::abs(measured_order - 4.0) / 4.0
+            << std::endl;
+#endif
+
+  // Test BDF3
+#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+  std::cout << "\nBDF3 convergence test" << std::endl;
+#endif
+  for (int idx = 0; idx < num_tests; idx++) {
+    mv_type y_vecs("history vectors", mySys.neqs, 3);
+    Kokkos::deep_copy(y0, 0.5);
+
+    BDFSolve_wrapper<Logistic, KokkosODE::Experimental::BDF_type::BDF3,
+                     vec_type, mv_type, mat_type, scalar_type>
+        solve_wrapper(mySys, t_start, t_end, num_steps[idx], y0, y_new, rhs,
+                      update, y_vecs, temp, jac);
+    Kokkos::parallel_for(myPolicy, solve_wrapper);
+
+    auto y_new_h = Kokkos::create_mirror_view(y_new);
+    Kokkos::deep_copy(y_new_h, y_new);
+
+    errors[idx] = Kokkos::abs(y_new_h(0) - 1 / (1 + Kokkos::exp(-t_end))) /
+                  Kokkos::abs(1 / (1 + Kokkos::exp(-t_end)));
+  }
+  measured_order =
+      Kokkos::pow(errors[num_tests - 1] / errors[0], 1.0 / (num_tests - 1));
+  EXPECT_NEAR_KK_REL(measured_order, 8.0, 0.15);
+#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+  std::cout << "expected ratio: 8, actual ratio: " << measured_order
+            << ", order error=" << Kokkos::abs(measured_order - 8.0) / 8.0
+            << std::endl;
+#endif
+
+  // Test BDF4
+#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+  std::cout << "\nBDF4 convergence test" << std::endl;
+#endif
+  for (int idx = 0; idx < num_tests; idx++) {
+    mv_type y_vecs("history vectors", mySys.neqs, 4);
+    Kokkos::deep_copy(y0, 0.5);
+
+    BDFSolve_wrapper<Logistic, KokkosODE::Experimental::BDF_type::BDF4,
+                     vec_type, mv_type, mat_type, scalar_type>
+        solve_wrapper(mySys, t_start, t_end, num_steps[idx], y0, y_new, rhs,
+                      update, y_vecs, temp, jac);
+    Kokkos::parallel_for(myPolicy, solve_wrapper);
+
+    auto y_new_h = Kokkos::create_mirror_view(y_new);
+    Kokkos::deep_copy(y_new_h, y_new);
+
+    errors[idx] = Kokkos::abs(y_new_h(0) - 1 / (1 + Kokkos::exp(-t_end))) /
+                  Kokkos::abs(1 / (1 + Kokkos::exp(-t_end)));
+  }
+  measured_order =
+      Kokkos::pow(errors[num_tests - 1] / errors[0], 1.0 / (num_tests - 1));
+#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+  std::cout << "expected ratio: 16, actual ratio: " << measured_order
+            << ", order error=" << Kokkos::abs(measured_order - 16.0) / 16.0
+            << std::endl;
+#endif
+
+  // Test BDF5
+#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+  std::cout << "\nBDF5 convergence test" << std::endl;
+#endif
+  for (int idx = 0; idx < num_tests; idx++) {
+    mv_type y_vecs("history vectors", mySys.neqs, 5);
+    Kokkos::deep_copy(y0, 0.5);
+
+    BDFSolve_wrapper<Logistic, KokkosODE::Experimental::BDF_type::BDF5,
+                     vec_type, mv_type, mat_type, scalar_type>
+        solve_wrapper(mySys, t_start, t_end, num_steps[idx], y0, y_new, rhs,
+                      update, y_vecs, temp, jac);
+    Kokkos::parallel_for(myPolicy, solve_wrapper);
+
+    auto y_new_h = Kokkos::create_mirror_view(y_new);
+    Kokkos::deep_copy(y_new_h, y_new);
+
+    errors[idx] = Kokkos::abs(y_new_h(0) - 1 / (1 + Kokkos::exp(-t_end))) /
+                  Kokkos::abs(1 / (1 + Kokkos::exp(-t_end)));
+  }
+  measured_order =
+      Kokkos::pow(errors[num_tests - 1] / errors[0], 1.0 / (num_tests - 1));
+#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+  std::cout << "expected ratio: 32, actual ratio: " << measured_order
+            << ", order error=" << Kokkos::abs(measured_order - 32.0) / 32.0
+            << std::endl;
+#endif
+
+}  // test_BDF_Logistic
+
+template <class execution_space, class scalar_type>
+void test_BDF_LotkaVolterra() {
+  using vec_type = Kokkos::View<scalar_type*, execution_space>;
+  using mv_type  = Kokkos::View<scalar_type**, execution_space>;
+  using mat_type = Kokkos::View<scalar_type**, execution_space>;
+
+  LotkaVolterra mySys(1.1, 0.4, 0.1, 0.4);
+
+  const scalar_type t_start = 0.0, t_end = 100.0;
+  vec_type y0("initial conditions", mySys.neqs), y_new("solution", mySys.neqs);
+  vec_type rhs("rhs", mySys.neqs), update("update", mySys.neqs);
+  mat_type jac("jacobian", mySys.neqs, mySys.neqs),
+      temp("temp storage", mySys.neqs, mySys.neqs + 4);
+
+  // Test BDF5
+  mv_type y_vecs("history vectors", mySys.neqs, 5);
+
+  Kokkos::deep_copy(y0, 10.0);
+  Kokkos::deep_copy(y_vecs, 10.0);
+
+  Kokkos::RangePolicy<execution_space> myPolicy(0, 1);
+  BDFSolve_wrapper<LotkaVolterra, KokkosODE::Experimental::BDF_type::BDF5,
+                   vec_type, mv_type, mat_type, scalar_type>
+      solve_wrapper(mySys, t_start, t_end, 1000, y0, y_new, rhs, update, y_vecs,
+                    temp, jac);
+  Kokkos::parallel_for(myPolicy, solve_wrapper);
+}
+
+template <class execution_space, class scalar_type>
+void test_BDF_StiffChemestry() {
+  using vec_type = Kokkos::View<scalar_type*, execution_space>;
+  using mv_type  = Kokkos::View<scalar_type**, execution_space>;
+  using mat_type = Kokkos::View<scalar_type**, execution_space>;
+
+  StiffChemestry mySys{};
+
+  const scalar_type t_start = 0.0, t_end = 500.0;
+  vec_type y0("initial conditions", mySys.neqs), y_new("solution", mySys.neqs);
+  vec_type rhs("rhs", mySys.neqs), update("update", mySys.neqs);
+  mat_type jac("jacobian", mySys.neqs, mySys.neqs),
+      temp("temp storage", mySys.neqs, mySys.neqs + 4);
+
+  // Test BDF5
+  mv_type y_vecs("history vectors", mySys.neqs, 5);
+
+  auto y0_h = Kokkos::create_mirror_view(y0);
+  y0_h(0)   = 1.0;
+  y0_h(1)   = 0.0;
+  y0_h(2)   = 0.0;
+  Kokkos::deep_copy(y0, y0_h);
+  Kokkos::deep_copy(y_vecs, 0.0);
+
+  Kokkos::RangePolicy<execution_space> myPolicy(0, 1);
+  BDFSolve_wrapper<StiffChemestry, KokkosODE::Experimental::BDF_type::BDF5,
+                   vec_type, mv_type, mat_type, scalar_type>
+      solve_wrapper(mySys, t_start, t_end, 200000, y0, y_new, rhs, update,
+                    y_vecs, temp, jac);
+  Kokkos::parallel_for(myPolicy, solve_wrapper);
+}
+
+template <class ode_type, KokkosODE::Experimental::BDF_type bdf_type,
+          class vec_type, class mv_type, class mat_type, class scalar_type>
+struct BDFSolve_parallel {
+  ode_type my_ode;
+  scalar_type tstart, tend;
+  int num_steps;
+  vec_type y_old, y_new, rhs, update;
+  mv_type y_vecs;
+  mat_type temp, jac;
+
+  BDFSolve_parallel(const ode_type& my_ode_, const scalar_type tstart_,
+                    const scalar_type tend_, const int num_steps_,
+                    const vec_type& y_old_, const vec_type& y_new_,
+                    const vec_type& rhs_, const vec_type& update_,
+                    const mv_type& y_vecs_, const mat_type& temp_,
+                    const mat_type& jac_)
+      : my_ode(my_ode_),
+        tstart(tstart_),
+        tend(tend_),
+        num_steps(num_steps_),
+        y_old(y_old_),
+        y_new(y_new_),
+        rhs(rhs_),
+        update(update_),
+        y_vecs(y_vecs_),
+        temp(temp_),
+        jac(jac_) {}
+
+  KOKKOS_FUNCTION
+  void operator()(const int idx) const {
+    auto local_y_old = Kokkos::subview(
+        y_old, Kokkos::pair(my_ode.neqs * idx, my_ode.neqs * (idx + 1)));
+    auto local_y_new = Kokkos::subview(
+        y_new, Kokkos::pair(my_ode.neqs * idx, my_ode.neqs * (idx + 1)));
+    auto local_rhs = Kokkos::subview(
+        rhs, Kokkos::pair(my_ode.neqs * idx, my_ode.neqs * (idx + 1)));
+    auto local_update = Kokkos::subview(
+        update, Kokkos::pair(my_ode.neqs * idx, my_ode.neqs * (idx + 1)));
+
+    auto local_y_vecs = Kokkos::subview(
+        y_vecs, Kokkos::pair(my_ode.neqs * idx, my_ode.neqs * (idx + 1)),
+        Kokkos::ALL());
+    auto local_temp = Kokkos::subview(
+        temp, Kokkos::pair(my_ode.neqs * idx, my_ode.neqs * (idx + 1)),
+        Kokkos::ALL());
+    auto local_jac = Kokkos::subview(
+        jac, Kokkos::pair(my_ode.neqs * idx, my_ode.neqs * (idx + 1)),
+        Kokkos::ALL());
+
+    KokkosODE::Experimental::BDF<bdf_type>::Solve(
+        my_ode, tstart, tend, num_steps, local_y_old, local_y_new, local_rhs,
+        local_update, local_y_vecs, local_temp, local_jac);
+  }
+};
+
+template <class execution_space, class scalar_type>
+void test_BDF_parallel() {
+  using vec_type = Kokkos::View<scalar_type*, execution_space>;
+  using mv_type  = Kokkos::View<scalar_type**, execution_space>;
+  using mat_type = Kokkos::View<scalar_type**, execution_space>;
+
+  LotkaVolterra mySys(1.1, 0.4, 0.1, 0.4);
+  constexpr int num_solves = 1000;
+
+  const scalar_type t_start = 0.0, t_end = 100.0;
+  vec_type y0("initial conditions", mySys.neqs * num_solves),
+      y_new("solution", mySys.neqs * num_solves);
+  vec_type rhs("rhs", mySys.neqs * num_solves),
+      update("update", mySys.neqs * num_solves);
+  mat_type jac("jacobian", mySys.neqs * num_solves, mySys.neqs),
+      temp("temp storage", mySys.neqs * num_solves, mySys.neqs + 4);
+
+  // Test BDF5
+  mv_type y_vecs("history vectors", mySys.neqs * num_solves, 5);
+
+  Kokkos::deep_copy(y0, 10.0);
+  Kokkos::deep_copy(y_vecs, 10.0);
+
+  Kokkos::RangePolicy<execution_space> myPolicy(0, num_solves);
+  BDFSolve_parallel<LotkaVolterra, KokkosODE::Experimental::BDF_type::BDF5,
+                    vec_type, mv_type, mat_type, scalar_type>
+      solve_wrapper(mySys, t_start, t_end, 1000, y0, y_new, rhs, update, y_vecs,
+                    temp, jac);
+  Kokkos::parallel_for(myPolicy, solve_wrapper);
+}
+
+}  // namespace Test
+
+TEST_F(TestCategory, BDF_Logistic_serial) {
+  ::Test::test_BDF_Logistic<TestExecSpace, double>();
+}
+TEST_F(TestCategory, BDF_LotkaVolterra_serial) {
+  ::Test::test_BDF_LotkaVolterra<TestExecSpace, double>();
+}
+TEST_F(TestCategory, BDF_StiffChemestry_serial) {
+  ::Test::test_BDF_StiffChemestry<TestExecSpace, double>();
+}
+TEST_F(TestCategory, BDF_parallel_serial) {
+  ::Test::test_BDF_parallel<TestExecSpace, double>();
+}

--- a/ode/unit_test/Test_ODE_BDF.hpp
+++ b/ode/unit_test/Test_ODE_BDF.hpp
@@ -174,6 +174,29 @@ struct BDFSolve_wrapper {
   }
 };
 
+template <class ode_type, class mat_type, class vec_type, class scalar_type>
+struct BDF_Solve_wrapper {
+
+  const ode_type my_ode;
+  const scalar_type t_start, t_end, dt, max_step;
+  const vec_type y0, y_new;
+  const mat_type temp, temp2;
+
+  BDF_Solve_wrapper(const ode_type& my_ode_, const scalar_type& t_start_,
+		    const scalar_type& t_end_, const scalar_type& dt_,
+		    const scalar_type& max_step_, const vec_type& y0_,
+		    const vec_type& y_new_, const mat_type& temp_,
+		    const mat_type& temp2_)
+    : my_ode(my_ode_), t_start(t_start_), t_end(t_end_), dt(dt_),
+      max_step(max_step_), y0(y0_), y_new(y_new_), temp(temp_),
+      temp2(temp2_) {}
+
+  KOKKOS_FUNCTION void operator()(const int) const {
+    KokkosODE::Experimental::BDFSolve(my_ode, t_start, t_end, dt,
+				      max_step, y0, y_new, temp, temp2);
+  }
+};
+
 template <class device_type, class scalar_type>
 void test_BDF_Logistic() {
   using execution_space = typename device_type::execution_space;
@@ -514,6 +537,8 @@ void test_BDF_parallel() {
 
 template <class mat_type, class scalar_type>
 void compute_coeffs(const int order, const scalar_type factor, const mat_type& coeffs) {
+  std::cout << "compute_coeffs" << std::endl;
+
   coeffs(0, 0) = 1.0;
   for(int colIdx = 0; colIdx < order; ++colIdx) {
     coeffs(0, colIdx + 1) = 1.0;
@@ -530,12 +555,14 @@ void update_D(const int order, const scalar_type factor, const mat_type& coeffs,
 
   compute_coeffs(order, factor, coeffs);
   auto R = Kokkos::subview(coeffs, Kokkos::pair<int, int>(0, order + 1), Kokkos::pair<int, int>(0, order + 1));
+  std::cout << "SerialGemm" << std::endl; 
   KokkosBatched::SerialGemm<KokkosBatched::Trans::Transpose,
 			    KokkosBatched::Trans::NoTranspose,
 			    KokkosBatched::Algo::Gemm::Blocked>::invoke(1.0, R, subD, 0.0, subTempD);
 
   compute_coeffs(order, 1.0, coeffs);
   auto U = Kokkos::subview(coeffs, Kokkos::pair<int, int>(0, order + 1), Kokkos::pair<int, int>(0, order + 1));
+  std::cout << "SerialGemm" << std::endl; 
   KokkosBatched::SerialGemm<KokkosBatched::Trans::Transpose,
 			    KokkosBatched::Trans::NoTranspose,
 			    KokkosBatched::Algo::Gemm::Blocked>::invoke(1.0, U, subTempD, 0.0, subD);
@@ -543,7 +570,7 @@ void update_D(const int order, const scalar_type factor, const mat_type& coeffs,
 
 template <class device_type, class scalar_type>
 void test_Nordsieck() {
-  using execution_space = typename device_type::execution_space;
+  using execution_space = Kokkos::HostSpace;
   StiffChemistry mySys{};
 
   Kokkos::View<scalar_type**, execution_space> R("coeffs", 6, 6), U("coeffs", 6, 6);
@@ -558,6 +585,7 @@ void test_Nordsieck() {
   auto y0 = Kokkos::subview(D, 0, Kokkos::ALL());
   auto f  = Kokkos::subview(D, 1, Kokkos::ALL());
   y0(0) = 1.0;
+
   mySys.evaluate_function(0, 0, y0, f);
   for(int eqIdx = 0; eqIdx < mySys.neqs; ++eqIdx) {
     f(eqIdx) *= dt;
@@ -566,13 +594,15 @@ void test_Nordsieck() {
   compute_coeffs(order, factor, R);
   compute_coeffs(order, 1.0, U);
 
-  std::cout << "R: " << std::endl;
-  for(int i = 0; i < order + 1; ++i) {
-    std::cout << "{ ";
-    for(int j =  0; j < order + 1; ++j) {
-      std::cout << R(i,j) << ", ";
+  {
+    std::cout << "R: " << std::endl;
+    for(int i = 0; i < order + 1; ++i) {
+      std::cout << "{ ";
+      for(int j =  0; j < order + 1; ++j) {
+	std::cout << R(i,j) << ", ";
+      }
+      std::cout << "}" << std::endl;
     }
-    std::cout << "}" << std::endl;
   }
 
   std::cout << "D before update:" << std::endl;
@@ -696,8 +726,9 @@ void test_adaptive_BDF_v2() {
 				    y0, y_new, temp, temp2);
 }
 
-template <class execution_space, class scalar_type>
+template <class Device, class scalar_type>
 void test_BDF_adaptive_stiff() {
+  using execution_space = typename Device::execution_space;
   using vec_type = Kokkos::View<scalar_type*, execution_space>;
   using mat_type = Kokkos::View<scalar_type**, execution_space>;
   using KAT      = Kokkos::ArithTraits<scalar_type>;
@@ -707,6 +738,8 @@ void test_BDF_adaptive_stiff() {
   const scalar_type t_start = KAT::zero(), t_end = 500*KAT::one();
   scalar_type dt = KAT::zero();
   vec_type y0("initial conditions", mySys.neqs), y_new("solution", mySys.neqs);
+
+  // Set initial conditions
   auto y0_h = Kokkos::create_mirror_view(y0);
   y0_h(0) = KAT::one();
   y0_h(1) = KAT::zero();
@@ -716,17 +749,27 @@ void test_BDF_adaptive_stiff() {
   mat_type temp("buffer1", mySys.neqs, 23 + 2*mySys.neqs + 4), temp2("buffer2", 6, 7);
 
   {
+    auto temp_h = Kokkos::create_mirror_view(temp);
+    Kokkos::deep_copy(temp_h, temp);
     vec_type f0("initial value f", mySys.neqs);
-    mySys.evaluate_function(t_start, KAT::zero(), y0, f0);
-    KokkosODE::Impl::initial_step_size(mySys, 1, t_start, 1e-6, 1e-4, y0, f0, temp, dt);
-    Kokkos::deep_copy(temp, KAT::zero()); // zeroing out temp to avoid surprises down the road...
+    auto f0_h = Kokkos::create_mirror_view(f0);
+
+    mySys.evaluate_function(t_start, KAT::zero(), y0_h, f0_h);
+    KokkosODE::Impl::initial_step_size(mySys, 1, t_start, 1e-6, 1e-4, y0_h, f0_h, temp_h, dt);
   }
   std::cout << "Initial Step Size: dt=" << dt << std::endl;
 
-  KokkosODE::Experimental::BDFSolve(mySys, t_start, t_end, dt,
-				    (t_end - t_start) / 10,
-				    y0, y_new, temp, temp2);
+  Kokkos::RangePolicy<execution_space> policy(0, 1);
+  BDF_Solve_wrapper bdf_wrapper(mySys, t_start, t_end, dt,
+				(t_end - t_start) / 10,
+				y0, y_new, temp, temp2);
 
+  Kokkos::parallel_for(policy, bdf_wrapper);
+
+  auto y_new_h = Kokkos::create_mirror_view(y_new);
+  Kokkos::deep_copy(y_new_h, y_new);
+  std::cout << "Stiff Chemistry solution at t=500: {" << y_new_h(0)
+	    << ", " << y_new_h(1) << ", " << y_new_h(2) << "}" << std::endl;
 }
 
 }  // namespace Test
@@ -746,10 +789,10 @@ TEST_F(TestCategory, BDF_parallel_serial) {
 TEST_F(TestCategory, BDF_Nordsieck) {
   ::Test::test_Nordsieck<TestDevice, double>();
 }
-TEST_F(TestCategory, BDF_adaptive) {
-  ::Test::test_adaptive_BDF<TestDevice, double>();
-  ::Test::test_adaptive_BDF_v2<TestDevice, double>();
-}
+// TEST_F(TestCategory, BDF_adaptive) {
+//   ::Test::test_adaptive_BDF<TestDevice, double>();
+//   ::Test::test_adaptive_BDF_v2<TestDevice, double>();
+// }
 TEST_F(TestCategory, BDF_StiffChemistry_adaptive) {
   ::Test::test_BDF_adaptive_stiff<TestDevice, double>();
 }

--- a/ode/unit_test/Test_ODE_BDF.hpp
+++ b/ode/unit_test/Test_ODE_BDF.hpp
@@ -126,14 +126,14 @@ struct StiffChemistry {
                                          const double /*dt*/, const vec_type& y,
                                          const mat_type& jac) const {
     jac(0, 0) = -0.04;
-    jac(0, 1) =  1.e4 * y(2);
-    jac(0, 2) =  1.e4 * y(1);
-    jac(1, 0) =  0.04;
+    jac(0, 1) = 1.e4 * y(2);
+    jac(0, 2) = 1.e4 * y(1);
+    jac(1, 0) = 0.04;
     jac(1, 1) = -1.e4 * y(2) - 3.e7 * 2.0 * y(1);
     jac(1, 2) = -1.e4 * y(1);
-    jac(2, 0) =  0.0;
-    jac(2, 1) =  3.e7 * 2.0 * y(1);
-    jac(2, 2) =  0.0;
+    jac(2, 0) = 0.0;
+    jac(2, 1) = 3.e7 * 2.0 * y(1);
+    jac(2, 2) = 0.0;
   }
 };
 
@@ -152,8 +152,8 @@ struct BDFSolve_wrapper {
                    const vec_type& y_old_, const vec_type& y_new_,
                    const vec_type& rhs_, const vec_type& update_,
                    const vec_type& scale_, const mv_type& y_vecs_,
-		   const mv_type& kstack_, const mat_type& temp_,
-		   const mat_type& jac_)
+                   const mv_type& kstack_, const mat_type& temp_,
+                   const mat_type& jac_)
       : my_ode(my_ode_),
         tstart(tstart_),
         tend(tend_),
@@ -162,7 +162,7 @@ struct BDFSolve_wrapper {
         y_new(y_new_),
         rhs(rhs_),
         update(update_),
-	scale(scale_),
+        scale(scale_),
         y_vecs(y_vecs_),
         kstack(kstack_),
         temp(temp_),
@@ -171,40 +171,45 @@ struct BDFSolve_wrapper {
   KOKKOS_FUNCTION
   void operator()(const int /*idx*/) const {
     KokkosODE::Experimental::BDF<bdf_type>::Solve(
-	my_ode, tstart, tend, num_steps, y_old, y_new, rhs, update, scale,
+        my_ode, tstart, tend, num_steps, y_old, y_new, rhs, update, scale,
         y_vecs, kstack, temp, jac);
   }
 };
 
 template <class ode_type, class mat_type, class vec_type, class scalar_type>
 struct BDF_Solve_wrapper {
-
   const ode_type my_ode;
   const scalar_type t_start, t_end, dt, max_step;
   const vec_type y0, y_new;
   const mat_type temp, temp2;
 
   BDF_Solve_wrapper(const ode_type& my_ode_, const scalar_type& t_start_,
-		    const scalar_type& t_end_, const scalar_type& dt_,
-		    const scalar_type& max_step_, const vec_type& y0_,
-		    const vec_type& y_new_, const mat_type& temp_,
-		    const mat_type& temp2_)
-    : my_ode(my_ode_), t_start(t_start_), t_end(t_end_), dt(dt_),
-      max_step(max_step_), y0(y0_), y_new(y_new_), temp(temp_),
-      temp2(temp2_) {}
+                    const scalar_type& t_end_, const scalar_type& dt_,
+                    const scalar_type& max_step_, const vec_type& y0_,
+                    const vec_type& y_new_, const mat_type& temp_,
+                    const mat_type& temp2_)
+      : my_ode(my_ode_),
+        t_start(t_start_),
+        t_end(t_end_),
+        dt(dt_),
+        max_step(max_step_),
+        y0(y0_),
+        y_new(y_new_),
+        temp(temp_),
+        temp2(temp2_) {}
 
   KOKKOS_FUNCTION void operator()(const int) const {
-    KokkosODE::Experimental::BDFSolve(my_ode, t_start, t_end, dt,
-				      max_step, y0, y_new, temp, temp2);
+    KokkosODE::Experimental::BDFSolve(my_ode, t_start, t_end, dt, max_step, y0,
+                                      y_new, temp, temp2);
   }
 };
 
 template <class device_type, class scalar_type>
 void test_BDF_Logistic() {
   using execution_space = typename device_type::execution_space;
-  using vec_type = Kokkos::View<scalar_type*, execution_space>;
-  using mv_type  = Kokkos::View<scalar_type**, execution_space>;
-  using mat_type = Kokkos::View<scalar_type**, execution_space>;
+  using vec_type        = Kokkos::View<scalar_type*, execution_space>;
+  using mv_type         = Kokkos::View<scalar_type**, execution_space>;
+  using mat_type        = Kokkos::View<scalar_type**, execution_space>;
 
   Kokkos::RangePolicy<execution_space> myPolicy(0, 1);
   Logistic mySys(1, 1);
@@ -379,9 +384,9 @@ void test_BDF_Logistic() {
 template <class device_type, class scalar_type>
 void test_BDF_LotkaVolterra() {
   using execution_space = typename device_type::execution_space;
-  using vec_type = Kokkos::View<scalar_type*, execution_space>;
-  using mv_type  = Kokkos::View<scalar_type**, execution_space>;
-  using mat_type = Kokkos::View<scalar_type**, execution_space>;
+  using vec_type        = Kokkos::View<scalar_type*, execution_space>;
+  using mv_type         = Kokkos::View<scalar_type**, execution_space>;
+  using mat_type        = Kokkos::View<scalar_type**, execution_space>;
 
   LotkaVolterra mySys(1.1, 0.4, 0.1, 0.4);
 
@@ -412,9 +417,9 @@ void test_BDF_LotkaVolterra() {
 template <class device_type, class scalar_type>
 void test_BDF_StiffChemistry() {
   using execution_space = typename device_type::execution_space;
-  using vec_type = Kokkos::View<scalar_type*, execution_space>;
-  using mv_type  = Kokkos::View<scalar_type**, execution_space>;
-  using mat_type = Kokkos::View<scalar_type**, execution_space>;
+  using vec_type        = Kokkos::View<scalar_type*, execution_space>;
+  using mv_type         = Kokkos::View<scalar_type**, execution_space>;
+  using mat_type        = Kokkos::View<scalar_type**, execution_space>;
 
   StiffChemistry mySys{};
 
@@ -441,8 +446,8 @@ void test_BDF_StiffChemistry() {
   Kokkos::RangePolicy<execution_space> myPolicy(0, 1);
   BDFSolve_wrapper<StiffChemistry, KokkosODE::Experimental::BDF_type::BDF5,
                    vec_type, mv_type, mat_type, scalar_type>
-      solve_wrapper(mySys, t_start, t_end, 110000, y0, y_new, rhs, update, scale,
-                    y_vecs, kstack, temp, jac);
+      solve_wrapper(mySys, t_start, t_end, 110000, y0, y_new, rhs, update,
+                    scale, y_vecs, kstack, temp, jac);
   Kokkos::parallel_for(myPolicy, solve_wrapper);
 }
 
@@ -504,12 +509,13 @@ void test_BDF_StiffChemistry() {
 //         Kokkos::pair<int, int>(my_ode.neqs * idx, my_ode.neqs * (idx + 1)),
 //         Kokkos::ALL());
 //     auto local_jac = Kokkos::subview(
-//         jac, Kokkos::pair<int, int>(my_ode.neqs * idx, my_ode.neqs * (idx + 1)),
-//         Kokkos::ALL());
+//         jac, Kokkos::pair<int, int>(my_ode.neqs * idx, my_ode.neqs * (idx +
+//         1)), Kokkos::ALL());
 
 //     KokkosODE::Experimental::BDF<bdf_type>::Solve(
 //         my_ode, tstart, tend, num_steps, local_y_old, local_y_new, local_rhs,
-//         local_update, scale, local_y_vecs, local_kstack, local_temp, local_jac);
+//         local_update, scale, local_y_vecs, local_kstack, local_temp,
+//         local_jac);
 //   }
 // };
 
@@ -544,7 +550,8 @@ void test_BDF_StiffChemistry() {
 //   Kokkos::RangePolicy<execution_space> myPolicy(0, num_solves);
 //   BDFSolve_parallel<LotkaVolterra, KokkosODE::Experimental::BDF_type::BDF5,
 //                     vec_type, mv_type, mat_type, scalar_type>
-//       solve_wrapper(mySys, t_start, t_end, 1000, y0, y_new, rhs, update, scale, y_vecs,
+//       solve_wrapper(mySys, t_start, t_end, 1000, y0, y_new, rhs, update,
+//       scale, y_vecs,
 //                     kstack, temp, jac);
 //   Kokkos::parallel_for(myPolicy, solve_wrapper);
 
@@ -552,36 +559,44 @@ void test_BDF_StiffChemistry() {
 // }
 
 template <class mat_type, class scalar_type>
-void compute_coeffs(const int order, const scalar_type factor, const mat_type& coeffs) {
+void compute_coeffs(const int order, const scalar_type factor,
+                    const mat_type& coeffs) {
   std::cout << "compute_coeffs" << std::endl;
 
   coeffs(0, 0) = 1.0;
-  for(int colIdx = 0; colIdx < order; ++colIdx) {
+  for (int colIdx = 0; colIdx < order; ++colIdx) {
     coeffs(0, colIdx + 1) = 1.0;
-    for(int rowIdx = 0; rowIdx < order; ++rowIdx) {
-      coeffs(rowIdx + 1, colIdx + 1) = ((rowIdx - factor*(colIdx + 1.0)) / (rowIdx + 1.0)) * coeffs(rowIdx, colIdx + 1);
+    for (int rowIdx = 0; rowIdx < order; ++rowIdx) {
+      coeffs(rowIdx + 1, colIdx + 1) =
+          ((rowIdx - factor * (colIdx + 1.0)) / (rowIdx + 1.0)) *
+          coeffs(rowIdx, colIdx + 1);
     }
   }
 }
 
 template <class mat_type, class scalar_type>
-void update_D(const int order, const scalar_type factor, const mat_type& coeffs, const mat_type& tempD, const mat_type& D) {
-  auto subD     = Kokkos::subview(D,     Kokkos::pair<int, int>(0, order + 1), Kokkos::ALL);
-  auto subTempD = Kokkos::subview(tempD, Kokkos::pair<int, int>(0, order + 1), Kokkos::ALL);
+void update_D(const int order, const scalar_type factor, const mat_type& coeffs,
+              const mat_type& tempD, const mat_type& D) {
+  auto subD =
+      Kokkos::subview(D, Kokkos::pair<int, int>(0, order + 1), Kokkos::ALL);
+  auto subTempD =
+      Kokkos::subview(tempD, Kokkos::pair<int, int>(0, order + 1), Kokkos::ALL);
 
   compute_coeffs(order, factor, coeffs);
-  auto R = Kokkos::subview(coeffs, Kokkos::pair<int, int>(0, order + 1), Kokkos::pair<int, int>(0, order + 1));
-  std::cout << "SerialGemm" << std::endl; 
-  KokkosBatched::SerialGemm<KokkosBatched::Trans::Transpose,
-			    KokkosBatched::Trans::NoTranspose,
-			    KokkosBatched::Algo::Gemm::Blocked>::invoke(1.0, R, subD, 0.0, subTempD);
+  auto R = Kokkos::subview(coeffs, Kokkos::pair<int, int>(0, order + 1),
+                           Kokkos::pair<int, int>(0, order + 1));
+  std::cout << "SerialGemm" << std::endl;
+  KokkosBatched::SerialGemm<
+      KokkosBatched::Trans::Transpose, KokkosBatched::Trans::NoTranspose,
+      KokkosBatched::Algo::Gemm::Blocked>::invoke(1.0, R, subD, 0.0, subTempD);
 
   compute_coeffs(order, 1.0, coeffs);
-  auto U = Kokkos::subview(coeffs, Kokkos::pair<int, int>(0, order + 1), Kokkos::pair<int, int>(0, order + 1));
-  std::cout << "SerialGemm" << std::endl; 
-  KokkosBatched::SerialGemm<KokkosBatched::Trans::Transpose,
-			    KokkosBatched::Trans::NoTranspose,
-			    KokkosBatched::Algo::Gemm::Blocked>::invoke(1.0, U, subTempD, 0.0, subD);
+  auto U = Kokkos::subview(coeffs, Kokkos::pair<int, int>(0, order + 1),
+                           Kokkos::pair<int, int>(0, order + 1));
+  std::cout << "SerialGemm" << std::endl;
+  KokkosBatched::SerialGemm<
+      KokkosBatched::Trans::Transpose, KokkosBatched::Trans::NoTranspose,
+      KokkosBatched::Algo::Gemm::Blocked>::invoke(1.0, U, subTempD, 0.0, subD);
 }
 
 template <class device_type, class scalar_type>
@@ -589,21 +604,23 @@ void test_Nordsieck() {
   using execution_space = Kokkos::HostSpace;
   StiffChemistry mySys{};
 
-  Kokkos::View<scalar_type**, execution_space> R("coeffs", 6, 6), U("coeffs", 6, 6);
-  Kokkos::View<scalar_type**, execution_space> D("D", 8, mySys.neqs), tempD("tmp", 8, mySys.neqs);
-  int order = 1;
+  Kokkos::View<scalar_type**, execution_space> R("coeffs", 6, 6),
+      U("coeffs", 6, 6);
+  Kokkos::View<scalar_type**, execution_space> D("D", 8, mySys.neqs),
+      tempD("tmp", 8, mySys.neqs);
+  int order     = 1;
   double factor = 0.8;
 
   constexpr double t_start = 0.0, t_end = 500.0;
   int max_steps = 200000;
-  double dt = (t_end - t_start) / max_steps;
+  double dt     = (t_end - t_start) / max_steps;
 
   auto y0 = Kokkos::subview(D, 0, Kokkos::ALL());
   auto f  = Kokkos::subview(D, 1, Kokkos::ALL());
-  y0(0) = 1.0;
+  y0(0)   = 1.0;
 
   mySys.evaluate_function(0, 0, y0, f);
-  for(int eqIdx = 0; eqIdx < mySys.neqs; ++eqIdx) {
+  for (int eqIdx = 0; eqIdx < mySys.neqs; ++eqIdx) {
     f(eqIdx) *= dt;
   }
 
@@ -612,30 +629,34 @@ void test_Nordsieck() {
 
   {
     std::cout << "R: " << std::endl;
-    for(int i = 0; i < order + 1; ++i) {
+    for (int i = 0; i < order + 1; ++i) {
       std::cout << "{ ";
-      for(int j =  0; j < order + 1; ++j) {
-	std::cout << R(i,j) << ", ";
+      for (int j = 0; j < order + 1; ++j) {
+        std::cout << R(i, j) << ", ";
       }
       std::cout << "}" << std::endl;
     }
   }
 
   std::cout << "D before update:" << std::endl;
-  std::cout << "  { " << D(0, 0) << ", " << D(0, 1) << ", " << D(0, 2) << " }" << std::endl;
-  std::cout << "  { " << D(1, 0) << ", " << D(1, 1) << ", " << D(1, 2) << " }" << std::endl;
+  std::cout << "  { " << D(0, 0) << ", " << D(0, 1) << ", " << D(0, 2) << " }"
+            << std::endl;
+  std::cout << "  { " << D(1, 0) << ", " << D(1, 1) << ", " << D(1, 2) << " }"
+            << std::endl;
   update_D(order, factor, R, tempD, D);
 
   std::cout << "D after update:" << std::endl;
-  std::cout << "  { " << D(0, 0) << ", " << D(0, 1) << ", " << D(0, 2) << " }" << std::endl;
-  std::cout << "  { " << D(1, 0) << ", " << D(1, 1) << ", " << D(1, 2) << " }" << std::endl;
+  std::cout << "  { " << D(0, 0) << ", " << D(0, 1) << ", " << D(0, 2) << " }"
+            << std::endl;
+  std::cout << "  { " << D(1, 0) << ", " << D(1, 1) << ", " << D(1, 2) << " }"
+            << std::endl;
 }
 
 template <class device_type, class scalar_type>
 void test_adaptive_BDF() {
   using execution_space = typename device_type::execution_space;
-  using vec_type = Kokkos::View<scalar_type*, execution_space>;
-  using mat_type = Kokkos::View<scalar_type**, execution_space>;
+  using vec_type        = Kokkos::View<scalar_type*, execution_space>;
+  using mat_type        = Kokkos::View<scalar_type**, execution_space>;
 
   Logistic mySys(1, 1);
 
@@ -647,70 +668,73 @@ void test_adaptive_BDF() {
 
   vec_type y0("initial conditions", mySys.neqs), y_new("solution", mySys.neqs);
   vec_type rhs("rhs", mySys.neqs), update("update", mySys.neqs);
-  mat_type temp("buffer1", mySys.neqs, 23 + 2*mySys.neqs + 4), temp2("buffer2", 6, 7);
+  mat_type temp("buffer1", mySys.neqs, 23 + 2 * mySys.neqs + 4),
+      temp2("buffer2", 6, 7);
 
   // Initial condition
   Kokkos::deep_copy(y0, 0.5);
 
   // Initialize D
-  auto D = Kokkos::subview(temp, Kokkos::ALL(), Kokkos::pair<int, int>(2, 10));
+  auto D  = Kokkos::subview(temp, Kokkos::ALL(), Kokkos::pair<int, int>(2, 10));
   D(0, 0) = y0(0);
   mySys.evaluate_function(0, 0, y0, rhs);
-  D(0, 1) = dt*rhs(0);
+  D(0, 1) = dt * rhs(0);
   Kokkos::deep_copy(rhs, 0);
 
   std::cout << "**********************\n"
-	    << "        Step 1\n"
-	    << "**********************" << std::endl;
+            << "        Step 1\n"
+            << "**********************" << std::endl;
 
   std::cout << "Initial conditions" << std::endl;
   std::cout << "   y0=" << y0(0) << ", t=" << t << ", dt=" << dt << std::endl;
 
-  std::cout << "Initial D: {" << D(0, 0) << ", " << D(0, 1) << ", " << D(0, 2) << ", " << D(0, 3)
-	    << ", " << D(0, 4) << ", " << D(0, 5) << ", " << D(0, 6) << ", " << D(0, 7) << "}" << std::endl;
+  std::cout << "Initial D: {" << D(0, 0) << ", " << D(0, 1) << ", " << D(0, 2)
+            << ", " << D(0, 3) << ", " << D(0, 4) << ", " << D(0, 5) << ", "
+            << D(0, 6) << ", " << D(0, 7) << "}" << std::endl;
 
+  KokkosODE::Impl::BDFStep(mySys, t, dt, t_end, order, num_equal_steps,
+                           max_newton_iters, atol, rtol, 0.2, y0, y_new, rhs,
+                           update, temp, temp2);
 
-  KokkosODE::Impl::BDFStep(mySys, t, dt, t_end, order,
-			   num_equal_steps, max_newton_iters, atol, rtol, 0.2,
-			   y0, y_new, rhs, update, temp, temp2);
-
-  for(int eqIdx = 0; eqIdx < mySys.neqs; ++eqIdx) {
+  for (int eqIdx = 0; eqIdx < mySys.neqs; ++eqIdx) {
     y0(eqIdx) = y_new(eqIdx);
   }
 
   std::cout << "**********************\n"
-	    << "        Step 2\n"
-	    << "**********************" << std::endl;
+            << "        Step 2\n"
+            << "**********************" << std::endl;
 
   std::cout << "   y0=" << y0(0) << ", t=" << t << ", dt: " << dt << std::endl;
 
-  std::cout << "Initial D: {" << D(0, 0) << ", " << D(0, 1) << ", " << D(0, 2) << ", " << D(0, 3)
-	    << ", " << D(0, 4) << ", " << D(0, 5) << ", " << D(0, 6) << ", " << D(0, 7) << "}" << std::endl;
+  std::cout << "Initial D: {" << D(0, 0) << ", " << D(0, 1) << ", " << D(0, 2)
+            << ", " << D(0, 3) << ", " << D(0, 4) << ", " << D(0, 5) << ", "
+            << D(0, 6) << ", " << D(0, 7) << "}" << std::endl;
 
-  KokkosODE::Impl::BDFStep(mySys, t, dt, t_end, order,
-			   num_equal_steps, max_newton_iters, atol, rtol, 0.2,
-			   y0, y_new, rhs, update, temp, temp2);
+  KokkosODE::Impl::BDFStep(mySys, t, dt, t_end, order, num_equal_steps,
+                           max_newton_iters, atol, rtol, 0.2, y0, y_new, rhs,
+                           update, temp, temp2);
 
-  for(int eqIdx = 0; eqIdx < mySys.neqs; ++eqIdx) {
+  for (int eqIdx = 0; eqIdx < mySys.neqs; ++eqIdx) {
     y0(eqIdx) = y_new(eqIdx);
   }
 
   std::cout << "**********************\n"
-	    << "        Step 3\n"
-	    << "**********************" << std::endl;
+            << "        Step 3\n"
+            << "**********************" << std::endl;
 
   std::cout << "   y0=" << y0(0) << ", t=" << t << ", dt: " << dt << std::endl;
 
-  std::cout << "Initial D: {" << D(0, 0) << ", " << D(0, 1) << ", " << D(0, 2) << ", " << D(0, 3)
-	    << ", " << D(0, 4) << ", " << D(0, 5) << ", " << D(0, 6) << ", " << D(0, 7) << "}" << std::endl;
+  std::cout << "Initial D: {" << D(0, 0) << ", " << D(0, 1) << ", " << D(0, 2)
+            << ", " << D(0, 3) << ", " << D(0, 4) << ", " << D(0, 5) << ", "
+            << D(0, 6) << ", " << D(0, 7) << "}" << std::endl;
 
-  KokkosODE::Impl::BDFStep(mySys, t, dt, t_end, order,
-			   num_equal_steps, max_newton_iters, atol, rtol, 0.2,
-			   y0, y_new, rhs, update, temp, temp2);
+  KokkosODE::Impl::BDFStep(mySys, t, dt, t_end, order, num_equal_steps,
+                           max_newton_iters, atol, rtol, 0.2, y0, y_new, rhs,
+                           update, temp, temp2);
 
   std::cout << "Final t: " << t << ", y=" << y_new(0) << std::endl;
 
-} // test_adaptive_BDF()
+}  // test_adaptive_BDF()
 
 template <class execution_space, class scalar_type>
 void test_adaptive_BDF_v2() {
@@ -722,59 +746,62 @@ void test_adaptive_BDF_v2() {
 
   Logistic mySys(1, 1);
 
-  const scalar_type t_start = KAT::zero(), t_end = 6 * KAT::one(); //, atol = 1.0e-6, rtol = 1.0e-4;
+  const scalar_type t_start = KAT::zero(),
+                    t_end   = 6 * KAT::one();  //, atol = 1.0e-6, rtol = 1.0e-4;
   vec_type y0("initial conditions", mySys.neqs), y_new("solution", mySys.neqs);
   Kokkos::deep_copy(y0, 0.5);
 
-  mat_type temp("buffer1", mySys.neqs, 23 + 2*mySys.neqs + 4), temp2("buffer2", 6, 7);
+  mat_type temp("buffer1", mySys.neqs, 23 + 2 * mySys.neqs + 4),
+      temp2("buffer2", 6, 7);
 
   {
     scalar_type dt = KAT::zero();
     vec_type f0("initial value f", mySys.neqs);
     mySys.evaluate_function(t_start, KAT::zero(), y0, f0);
-    KokkosODE::Impl::initial_step_size(mySys, 1, t_start, 1e-6, 1e-3, y0, f0, temp, dt);
+    KokkosODE::Impl::initial_step_size(mySys, 1, t_start, 1e-6, 1e-3, y0, f0,
+                                       temp, dt);
 
     std::cout << "Initial Step Size: dt=" << dt << std::endl;
   }
 
   KokkosODE::Experimental::BDFSolve(mySys, t_start, t_end, 0.0117188,
-				    (t_end - t_start) / 10,
-				    y0, y_new, temp, temp2);
+                                    (t_end - t_start) / 10, y0, y_new, temp,
+                                    temp2);
 }
 
 template <class Device, class scalar_type>
 void test_BDF_adaptive_stiff() {
   using execution_space = typename Device::execution_space;
-  using vec_type = Kokkos::View<scalar_type*, execution_space>;
-  using mat_type = Kokkos::View<scalar_type**, execution_space>;
-  using KAT      = Kokkos::ArithTraits<scalar_type>;
+  using vec_type        = Kokkos::View<scalar_type*, execution_space>;
+  using mat_type        = Kokkos::View<scalar_type**, execution_space>;
+  using KAT             = Kokkos::ArithTraits<scalar_type>;
 
   StiffChemistry mySys{};
 
-  const scalar_type t_start = KAT::zero(), t_end = 350*KAT::one();
+  const scalar_type t_start = KAT::zero(), t_end = 350 * KAT::one();
   scalar_type dt = KAT::zero();
   vec_type y0("initial conditions", mySys.neqs), y_new("solution", mySys.neqs);
 
   // Set initial conditions
   auto y0_h = Kokkos::create_mirror_view(y0);
-  y0_h(0) = KAT::one();
-  y0_h(1) = KAT::zero();
-  y0_h(2) = KAT::zero();
+  y0_h(0)   = KAT::one();
+  y0_h(1)   = KAT::zero();
+  y0_h(2)   = KAT::zero();
   Kokkos::deep_copy(y0, y0_h);
 
-  mat_type temp("buffer1", mySys.neqs, 23 + 2*mySys.neqs + 4), temp2("buffer2", 6, 7);
+  mat_type temp("buffer1", mySys.neqs, 23 + 2 * mySys.neqs + 4),
+      temp2("buffer2", 6, 7);
 
   Kokkos::RangePolicy<execution_space> policy(0, 1);
   BDF_Solve_wrapper bdf_wrapper(mySys, t_start, t_end, dt,
-				(t_end - t_start) / 10,
-				y0, y_new, temp, temp2);
+                                (t_end - t_start) / 10, y0, y_new, temp, temp2);
 
   Kokkos::parallel_for(policy, bdf_wrapper);
 
   auto y_new_h = Kokkos::create_mirror_view(y_new);
   Kokkos::deep_copy(y_new_h, y_new);
-  std::cout << "Stiff Chemistry solution at t=500: {" << y_new_h(0)
-	    << ", " << y_new_h(1) << ", " << y_new_h(2) << "}" << std::endl;
+  std::cout << "Stiff Chemistry solution at t=500: {" << y_new_h(0) << ", "
+            << y_new_h(1) << ", " << y_new_h(2) << "}" << std::endl;
 }
 
 }  // namespace Test

--- a/ode/unit_test/Test_ODE_Newton.hpp
+++ b/ode/unit_test/Test_ODE_Newton.hpp
@@ -238,7 +238,7 @@ void test_newton_status() {
   scalar_type solution[3] = {2.0, -1.0, 0.0};
 #endif
   newton_solver_status newton_status[3] = {
-      newton_solver_status::NLS_SUCCESS, newton_solver_status::MAX_ITER,
+      newton_solver_status::NLS_SUCCESS, newton_solver_status::NLS_DIVERGENCE,
       newton_solver_status::LIN_SOLVE_FAIL};
   vec_type x("solution vector", 1), rhs("right hand side vector", 1);
   auto x_h = Kokkos::create_mirror_view(x);

--- a/ode/unit_test/Test_ODE_Newton.hpp
+++ b/ode/unit_test/Test_ODE_Newton.hpp
@@ -21,7 +21,7 @@
 
 namespace Test {
 
-template <class system_type, class mat_type, class vec_type, class status_view>
+template <class system_type, class mat_type, class vec_type, class status_view, class scale_type>
 struct NewtonSolve_wrapper {
   using newton_params = KokkosODE::Experimental::Newton_params;
 
@@ -32,10 +32,13 @@ struct NewtonSolve_wrapper {
   mat_type J, tmp;
   status_view status;
 
+  scale_type scale;
+
   NewtonSolve_wrapper(const system_type& my_nls_, const newton_params& params_,
                       const vec_type& x_, const vec_type& rhs_,
                       const vec_type& update_, const mat_type& J_,
-                      const mat_type& tmp_, const status_view& status_)
+                      const mat_type& tmp_, const status_view& status_,
+		      const scale_type& scale_)
       : my_nls(my_nls_),
         params(params_),
         x(x_),
@@ -43,7 +46,8 @@ struct NewtonSolve_wrapper {
         update(update_),
         J(J_),
         tmp(tmp_),
-        status(status_) {}
+        status(status_),
+	scale(scale_) {}
 
   KOKKOS_FUNCTION
   void operator()(const int idx) const {
@@ -71,7 +75,8 @@ struct NewtonSolve_wrapper {
 
     // Run Newton nonlinear solver
     status(idx) = KokkosODE::Experimental::Newton::Solve(
-        my_nls, params, local_J, local_tmp, local_x, local_rhs, local_update);
+	my_nls, params, local_J, local_tmp, local_x, local_rhs, local_update,
+	scale);
   }
 };
 
@@ -86,6 +91,9 @@ void run_newton_test(const system_type& mySys,
   using mat_type             = typename Kokkos::View<scalar_type**, Device>;
 
   Kokkos::View<newton_solver_status*, Device> status("Newton status", 1);
+
+  vec_type scale("scaling factors", mySys.neqs);
+  Kokkos::deep_copy(scale, 1);
 
   vec_type x("solution vector", mySys.neqs),
       rhs("right hand side vector", mySys.neqs);
@@ -104,7 +112,7 @@ void run_newton_test(const system_type& mySys,
 
   Kokkos::RangePolicy<execution_space> my_policy(0, 1);
   NewtonSolve_wrapper solve_wrapper(mySys, params, x, rhs, update, J, tmp,
-                                    status);
+                                    status, scale);
 
   Kokkos::parallel_for(my_policy, solve_wrapper);
 
@@ -205,6 +213,9 @@ void test_newton_status() {
   using vec_type             = typename Kokkos::View<scalar_type*, Device>;
   using mat_type             = typename Kokkos::View<scalar_type**, Device>;
 
+  vec_type scale("scaling factors", 1);
+  Kokkos::deep_copy(scale, 1);
+
   double abs_tol, rel_tol;
   if (std::is_same_v<scalar_type, float>) {
     rel_tol = 10e-5;
@@ -242,7 +253,7 @@ void test_newton_status() {
 
     Kokkos::RangePolicy<execution_space> my_policy(0, 1);
     NewtonSolve_wrapper solve_wrapper(my_system, params, x, rhs, update, J, tmp,
-                                      status);
+                                      status, scale);
     Kokkos::parallel_for(my_policy, solve_wrapper);
 
     Kokkos::deep_copy(status_h, status);
@@ -481,6 +492,9 @@ void test_newton_on_device() {
 
   system_type mySys{};
 
+  vec_type scale("scaling factors", mySys.neqs);
+  Kokkos::deep_copy(scale, 1);
+
   vec_type x("solution vector", mySys.neqs * num_systems);
   vec_type rhs("right hand side vector", mySys.neqs * num_systems);
   vec_type update("update", mySys.neqs * num_systems);
@@ -503,7 +517,7 @@ void test_newton_on_device() {
 
   Kokkos::RangePolicy<execution_space> my_policy(0, num_systems);
   NewtonSolve_wrapper solve_wrapper(mySys, params, x, rhs, update, J, tmp,
-                                    status);
+                                    status, scale);
 
   Kokkos::parallel_for(my_policy, solve_wrapper);
   Kokkos::fence();

--- a/ode/unit_test/Test_ODE_Newton.hpp
+++ b/ode/unit_test/Test_ODE_Newton.hpp
@@ -21,7 +21,8 @@
 
 namespace Test {
 
-template <class system_type, class mat_type, class vec_type, class status_view, class scale_type>
+template <class system_type, class mat_type, class vec_type, class status_view,
+          class scale_type>
 struct NewtonSolve_wrapper {
   using newton_params = KokkosODE::Experimental::Newton_params;
 
@@ -38,7 +39,7 @@ struct NewtonSolve_wrapper {
                       const vec_type& x_, const vec_type& rhs_,
                       const vec_type& update_, const mat_type& J_,
                       const mat_type& tmp_, const status_view& status_,
-		      const scale_type& scale_)
+                      const scale_type& scale_)
       : my_nls(my_nls_),
         params(params_),
         x(x_),
@@ -47,7 +48,7 @@ struct NewtonSolve_wrapper {
         J(J_),
         tmp(tmp_),
         status(status_),
-	scale(scale_) {}
+        scale(scale_) {}
 
   KOKKOS_FUNCTION
   void operator()(const int idx) const {
@@ -75,8 +76,8 @@ struct NewtonSolve_wrapper {
 
     // Run Newton nonlinear solver
     status(idx) = KokkosODE::Experimental::Newton::Solve(
-	my_nls, params, local_J, local_tmp, local_x, local_rhs, local_update,
-	scale);
+        my_nls, params, local_J, local_tmp, local_x, local_rhs, local_update,
+        scale);
   }
 };
 

--- a/perf_test/ode/CMakeLists.txt
+++ b/perf_test/ode/CMakeLists.txt
@@ -5,4 +5,8 @@ if(KOKKOSKERNELS_ENABLE_BENCHMARK)
   KOKKOSKERNELS_ADD_BENCHMARK(
     ode_runge_kutta SOURCES KokkosODE_RK.cpp
   )
+
+  KOKKOSKERNELS_ADD_BENCHMARK(
+    ode_bdf_solver SOURCES KokkosODE_BDF.cpp
+  )
 endif()

--- a/perf_test/ode/KokkosODE_BDF.cpp
+++ b/perf_test/ode/KokkosODE_BDF.cpp
@@ -1,0 +1,227 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "KokkosODE_BDF.hpp"
+
+#include "KokkosKernels_TestUtils.hpp"
+#include "KokkosKernels_perf_test_utilities.hpp"
+
+#include <benchmark/benchmark.h>
+#include "Benchmark_Context.hpp"
+
+namespace {
+// Robertson's autocatalytic chemical reaction:
+// H. H. Robertson, The solution of a set of reaction rate equations,
+// in J. Walsh (Ed.), Numerical Analysis: An Introduction,
+// pp. 178–182, Academic Press, London (1966).
+//
+// Equations: y0' = -0.04*y0 + 10e4*y1*y2
+//            y1' =  0.04*y0 - 10e4*y1*y2 - 3e7 * y1**2
+//            y2' = 3e7 * y1**2
+struct StiffChemistry {
+  static constexpr int neqs = 3;
+
+  StiffChemistry() {}
+
+  template <class vec_type1, class vec_type2>
+  KOKKOS_FUNCTION void evaluate_function(const double /*t*/,
+                                         const double /*dt*/,
+                                         const vec_type1& y,
+                                         const vec_type2& f) const {
+    f(0) = -0.04 * y(0) + 1.e4 * y(1) * y(2);
+    f(1) = 0.04 * y(0) - 1.e4 * y(1) * y(2) - 3.e7 * y(1) * y(1);
+    f(2) = 3.e7 * y(1) * y(1);
+  }
+
+  template <class vec_type, class mat_type>
+  KOKKOS_FUNCTION void evaluate_jacobian(const double /*t*/,
+                                         const double /*dt*/, const vec_type& y,
+                                         const mat_type& jac) const {
+    jac(0, 0) = -0.04;
+    jac(0, 1) =  1.e4 * y(2);
+    jac(0, 2) =  1.e4 * y(1);
+    jac(1, 0) =  0.04;
+    jac(1, 1) = -1.e4 * y(2) - 3.e7 * 2.0 * y(1);
+    jac(1, 2) = -1.e4 * y(1);
+    jac(2, 0) =  0.0;
+    jac(2, 1) =  3.e7 * 2.0 * y(1);
+    jac(2, 2) =  0.0;
+  }
+};
+
+template <class ode_type, class mat_type, class vec_type, class scalar_type>
+struct BDF_Solve_wrapper {
+
+  const ode_type my_ode;
+  const scalar_type t_start, t_end, dt, max_step;
+  const vec_type y0, y_new;
+  const mat_type temp, temp2;
+
+  BDF_Solve_wrapper(const ode_type& my_ode_, const scalar_type& t_start_,
+		    const scalar_type& t_end_, const scalar_type& dt_,
+		    const scalar_type& max_step_, const vec_type& y0_,
+		    const vec_type& y_new_, const mat_type& temp_,
+		    const mat_type& temp2_)
+    : my_ode(my_ode_), t_start(t_start_), t_end(t_end_), dt(dt_),
+      max_step(max_step_), y0(y0_), y_new(y_new_), temp(temp_),
+      temp2(temp2_) {}
+
+  KOKKOS_FUNCTION void operator()(const int idx) const {
+    auto subTemp  = Kokkos::subview(temp, Kokkos::ALL(), Kokkos::ALL(), idx);
+    auto subTemp2 = Kokkos::subview(temp2, Kokkos::ALL(), Kokkos::ALL(), idx);
+    auto subY0    = Kokkos::subview(y0, Kokkos::ALL(), idx);
+    auto subYnew  = Kokkos::subview(y_new, Kokkos::ALL(), idx);
+
+    KokkosODE::Experimental::BDFSolve(my_ode, t_start, t_end, dt,
+				      max_step, subY0, subYnew, subTemp, subTemp2);
+  }
+};
+
+}  // namespace Anonymous
+
+struct bdf_input_parameters {
+  int num_odes;
+  int repeat;
+  bool verbose;
+
+  bdf_input_parameters(const int num_odes_, const int repeat_, const bool verbose_)
+      : num_odes(num_odes_),
+        repeat(repeat_),
+        verbose(verbose_){};
+};
+
+template <class execution_space>
+void run_ode_chem(benchmark::State& state, const bdf_input_parameters& inputs) {
+  using scalar_type = double;
+  using KAT         = Kokkos::ArithTraits<scalar_type>;
+  using vec_type    = Kokkos::View<scalar_type**, execution_space>;
+  using mat_type    = Kokkos::View<scalar_type***, execution_space>;
+
+  StiffChemistry mySys{};
+
+  const int num_odes = inputs.num_odes;
+  const int neqs     = mySys.neqs;
+
+  const scalar_type t_start = KAT::zero(), t_end = 500*KAT::one();
+  scalar_type dt = KAT::zero();
+  vec_type y0("initial conditions", neqs, num_odes);
+  vec_type y_new("solution", neqs, num_odes);
+
+  // Set initial conditions
+  auto y0_h = Kokkos::create_mirror_view(y0);
+  for(int sysIdx = 0; sysIdx < num_odes; ++sysIdx) {
+    y0_h(0, sysIdx) = KAT::one();
+    y0_h(1, sysIdx) = KAT::zero();
+    y0_h(2, sysIdx) = KAT::zero();
+  }
+  Kokkos::deep_copy(y0, y0_h);
+
+  mat_type temp("buffer1", neqs, 23 + 2*neqs + 4, num_odes), temp2("buffer2", 6, 7, num_odes);
+
+  Kokkos::RangePolicy<execution_space> policy(0, num_odes);
+  BDF_Solve_wrapper bdf_wrapper(mySys, t_start, t_end, dt,
+				(t_end - t_start) / 10,
+				y0, y_new, temp, temp2);
+
+  Kokkos::Timer time;
+  time.reset();
+  for (auto _ : state) {
+    (void)_;
+    Kokkos::parallel_for(policy, bdf_wrapper);
+    Kokkos::fence();
+  }
+  double run_time = time.seconds();
+  std::cout << "Run time: " << run_time << std::endl;
+
+}
+
+void print_options() {
+  std::cerr << "Options\n" << std::endl;
+
+  std::cerr << perf_test::list_common_options();
+
+  std::cerr
+      << "\t[Optional] --repeat      :: how many times to repeat overall test"
+      << std::endl;
+  std::cerr << "\t[Optional] --verbose     :: enable verbose output"
+            << std::endl;
+  std::cerr << "\t[Optional] --n           :: number of ode problems to solve"
+            << std::endl;
+}  // print_options
+
+int parse_inputs(bdf_input_parameters& params, int argc, char** argv) {
+  for (int i = 1; i < argc; ++i) {
+    if (perf_test::check_arg_int(i, argc, argv, "--n", params.num_odes)) {
+      ++i;
+    } else if (perf_test::check_arg_int(i, argc, argv, "--repeat",
+                                        params.repeat)) {
+      ++i;
+    } else if (perf_test::check_arg_bool(i, argc, argv, "--verbose",
+                                         params.verbose)) {
+    } else {
+      std::cerr << "Unrecognized command line argument #" << i << ": "
+                << argv[i] << std::endl;
+      print_options();
+      return 1;
+    }
+  }
+  return 0;
+}  // parse_inputs
+
+template <class execution_space>
+void run_benchmark_wrapper(benchmark::State& state, int argc, char** argv) {
+  bdf_input_parameters params(state.range(0), 1, false);
+  parse_inputs(params, argc, argv);
+  run_ode_chem<execution_space>(state, params);
+}
+
+int main(int argc, char** argv) {
+  Kokkos::initialize(argc, argv);
+  {
+    benchmark::Initialize(&argc, argv);
+    benchmark::SetDefaultTimeUnit(benchmark::kMillisecond);
+    KokkosKernelsBenchmark::add_benchmark_context(true);
+
+    perf_test::CommonInputParams common_params;
+    perf_test::parse_common_options(argc, argv, common_params);
+
+    std::string bench_name = "KokkosODE_BDF_Stiff_Chem";
+
+    if (0 < common_params.repeat) {
+      benchmark::RegisterBenchmark(
+				   bench_name.c_str(),
+				   run_benchmark_wrapper<Kokkos::DefaultExecutionSpace>, argc, argv)
+        ->UseRealTime()
+        ->ArgNames({"n"})
+        ->Args({1000})
+        ->Iterations(common_params.repeat);
+    } else {
+      benchmark::RegisterBenchmark(
+				   bench_name.c_str(),
+				   run_benchmark_wrapper<Kokkos::DefaultExecutionSpace>, argc, argv)
+        ->UseRealTime()
+        ->ArgNames({"n"})
+        ->Args({1000});
+    }
+
+    benchmark::RunSpecifiedBenchmarks();
+
+    benchmark::Shutdown();
+  }
+  Kokkos::finalize();
+
+  return 0;
+}

--- a/perf_test/ode/KokkosODE_BDF.cpp
+++ b/perf_test/ode/KokkosODE_BDF.cpp
@@ -151,6 +151,19 @@ void run_ode_chem(benchmark::State& state, const bdf_input_parameters& inputs) {
   double run_time = time.seconds();
   std::cout << "Run time: " << run_time << std::endl;
 
+  Kokkos::deep_copy(y0_h, y0);
+  double error;
+  for(int odeIdx = 0; odeIdx < num_odes; ++odeIdx) {
+    error = 0;
+    error += Kokkos::abs(y0_h(0, odeIdx) - 0.4193639) / 0.4193639;
+    error += Kokkos::abs(y0_h(1, odeIdx) - 0.000002843646) / 0.000002843646;
+    error += Kokkos::abs(y0_h(2, odeIdx) - 0.5806333) / 0.5806333;
+    error = error / 3;
+
+    if(error > 1e-6) {
+      std::cout << "Large error in problem " << odeIdx << ": " << error << std::endl;
+    }
+  }
 }
 
 void print_options() {


### PR DESCRIPTION
Adding backward difference formula methods orders 1 to 5 (coefficients for 6 exist but no accurate start-up implemented).
Also implementing a fix for the convergence criteria of the Newton solver...
Fixing some documentation related to the Newton solver input parameters.

@vbrunini when you have time please have a look