### PR TITLE
Adding exec space instance to spmv

### DIFF
--- a/docs/developer/apidocs/sparse.rst
+++ b/docs/developer/apidocs/sparse.rst
@@ -38,10 +38,10 @@ crs2coo
 
 spmv
 ----
-.. doxygenfunction:: KokkosSparse::spmv(KokkosKernels::Experimental::Controls controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y, const RANK_ONE)
-.. doxygenfunction:: KokkosSparse::spmv(KokkosKernels::Experimental::Controls controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y, const RANK_TWO)
-.. doxygenfunction:: KokkosSparse::spmv(const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y)
-
+.. doxygenfunction:: KokkosSparse::spmv(KokkosKernels::Experimental::Controls controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y, const RANK_ONE& tag)
+.. doxygenfunction:: KokkosSparse::spmv(const execution_space& exec, KokkosKernels::Experimental::Controls controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y, const RANK_ONE& tag)
+.. doxygenfunction:: KokkosSparse::spmv(KokkosKernels::Experimental::Controls controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y, const RANK_TWO& tag)
+.. doxygenfunction:: KokkosSparse::spmv(const execution_space& exec, KokkosKernels::Experimental::Controls controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y, const RANK_TWO& tag)
 
 trsv
 ----

--- a/docs/developer/apidocs/sparse.rst
+++ b/docs/developer/apidocs/sparse.rst
@@ -38,9 +38,9 @@ crs2coo
 
 spmv
 ----
-.. doxygenfunction:: KokkosSparse::spmv(const execution_space& exec, KokkosKernels::Experimental::Controls controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y)
+.. doxygenfunction:: KokkosSparse::spmv(const ExecutionSpace& space, KokkosKernels::Experimental::Controls controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y)
 .. doxygenfunction:: KokkosSparse::spmv(KokkosKernels::Experimental::Controls controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y)
-.. doxygenfunction:: KokkosSparse::spmv(const execution_space& exec, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y)
+.. doxygenfunction:: KokkosSparse::spmv(const ExecutionSpace& space, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y)
 .. doxygenfunction:: KokkosSparse::spmv(const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y)
 
 trsv

--- a/docs/developer/apidocs/sparse.rst
+++ b/docs/developer/apidocs/sparse.rst
@@ -38,10 +38,10 @@ crs2coo
 
 spmv
 ----
-.. doxygenfunction:: KokkosSparse::spmv(KokkosKernels::Experimental::Controls controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y, const RANK_ONE& tag)
-.. doxygenfunction:: KokkosSparse::spmv(const execution_space& exec, KokkosKernels::Experimental::Controls controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y, const RANK_ONE& tag)
-.. doxygenfunction:: KokkosSparse::spmv(KokkosKernels::Experimental::Controls controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y, const RANK_TWO& tag)
-.. doxygenfunction:: KokkosSparse::spmv(const execution_space& exec, KokkosKernels::Experimental::Controls controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y, const RANK_TWO& tag)
+.. doxygenfunction:: KokkosSparse::spmv(const execution_space& exec, KokkosKernels::Experimental::Controls controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y)
+.. doxygenfunction:: KokkosSparse::spmv(KokkosKernels::Experimental::Controls controls, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y)
+.. doxygenfunction:: KokkosSparse::spmv(const execution_space& exec, const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y)
+.. doxygenfunction:: KokkosSparse::spmv(const char mode[], const AlphaType &alpha, const AMatrix &A, const XVector &x, const BetaType &beta, const YVector &y)
 
 trsv
 ----

--- a/perf_test/sparse/KokkosSparse_spmv_merge.cpp
+++ b/perf_test/sparse/KokkosSparse_spmv_merge.cpp
@@ -303,8 +303,10 @@ int main(int argc, char** argv) {
         for (int iterIdx = 0; iterIdx < loop; ++iterIdx) {
           Kokkos::Timer timer;
           // KokkosSparse::spmv(controls, "N", alpha, test_matrix, x, beta, y);
-          KokkosSparse::Impl::spmv_beta<matrix_type, values_type, values_type,
-                                        1>(controls, "N", alpha, test_matrix, x,
+          KokkosSparse::Impl::spmv_beta<Kokkos::DefaultExecutionSpace,
+                                        matrix_type, values_type, values_type,
+                                        1>(Kokkos::DefaultExecutionSpace{},
+                                           controls, "N", alpha, test_matrix, x,
                                            beta, y);
           Kokkos::fence();
           double time = timer.seconds();

--- a/perf_test/sparse/KokkosSparse_spmv_struct_tuning.cpp
+++ b/perf_test/sparse/KokkosSparse_spmv_struct_tuning.cpp
@@ -179,7 +179,8 @@ void struct_matvec(const int stencil_type,
   int64_t worksets_ext =
       (numInteriorPts + rows_per_team_ext - 1) / rows_per_team_ext;
 
-  KokkosSparse::Impl::SPMV_Struct_Functor<AMatrix, XVector, YVector, 1, false>
+  KokkosSparse::Impl::SPMV_Struct_Functor<execution_space, AMatrix, XVector,
+                                          YVector, 1, false>
       spmv_struct(structure, stencil_type, alpha, A, x, beta, y,
                   rows_per_team_int, rows_per_team_ext);
 
@@ -188,8 +189,10 @@ void struct_matvec(const int stencil_type,
               << ", vector_length=" << vector_length << std::endl;
   }
 
-  spmv_struct.compute_interior(worksets_int, team_size_int, vector_length);
-  spmv_struct.compute_exterior(worksets_ext, team_size_ext, vector_length);
+  spmv_struct.compute_interior(execution_space{}, worksets_int, team_size_int,
+                               vector_length);
+  spmv_struct.compute_exterior(execution_space{}, worksets_ext, team_size_ext,
+                               vector_length);
 
 }  // struct_matvec
 
@@ -210,8 +213,9 @@ void matvec(typename YVector::const_value_type& alpha, const AMatrix& A,
           A.numRows(), A.nnz(), rows_per_thread, team_size, vector_length);
   int64_t worksets = (y.extent(0) + rows_per_team - 1) / rows_per_team;
 
-  KokkosSparse::Impl::SPMV_Functor<AMatrix, XVector, YVector, 1, false> func(
-      alpha, A, x, beta, y, rows_per_team);
+  KokkosSparse::Impl::SPMV_Functor<execution_space, AMatrix, XVector, YVector,
+                                   1, false>
+      func(alpha, A, x, beta, y, rows_per_team);
 
   if (print_lp) {
     std::cout << "worksets=" << worksets << ", team_size=" << team_size

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
@@ -185,8 +185,9 @@ struct BsrMatrixSpMVTensorCoreFunctor {
     typename BsrMatrixSpMVTensorCoreFunctor::team_policy policy(
         exec, league_size(), team_size());
     policy.set_scratch_size(0, Kokkos::PerTeam(team_scratch_size()));
-    Kokkos::parallel_for("KokkosSparse::BsrMatrixSpMVTensorCoreFunctor", policy,
-                         *this);
+    Kokkos::parallel_for(
+        "KokkosSparse::Experimental::BsrMatrixSpMVTensorCoreFunctor", policy,
+        *this);
   }
 
   /*

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
@@ -423,9 +423,10 @@ struct BsrMatrixSpMVTensorCoreDispatcher {
   typedef typename XMatrix::value_type XScalar;
 
   template <unsigned X, unsigned Y, unsigned Z>
-  using Dyn = BsrMatrixSpMVTensorCoreFunctor<AMatrix, AFragScalar, XMatrix,
-                                             XFragScalar, YMatrix, YFragScalar,
-                                             FRAG_M, FRAG_N, FRAG_K, X, Y, Z>;
+  using Dyn =
+      BsrMatrixSpMVTensorCoreFunctor<execution_space, AMatrix, AFragScalar,
+                                     XMatrix, XFragScalar, YMatrix, YFragScalar,
+                                     FRAG_M, FRAG_N, FRAG_K, X, Y, Z>;
 
   // to be used when the various matrix types are supported
   static void tag_dispatch(std::true_type, const execution_space &exec,

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl_v42.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl_v42.hpp
@@ -114,11 +114,12 @@ class BsrSpmvV42NonTrans {
 
 template <typename Alpha, typename AMatrix, typename XVector, typename Beta,
           typename YVector>
-void apply_v42(const Alpha &alpha, const AMatrix &a, const XVector &x,
+void apply_v42(const typename AMatrix::execution_space &exec,
+               const Alpha &alpha, const AMatrix &a, const XVector &x,
                const Beta &beta, const YVector &y) {
-  using execution_space = typename YVector::execution_space;
+  using execution_space = typename AMatrix::execution_space;
 
-  Kokkos::RangePolicy<execution_space> policy(0, y.size());
+  Kokkos::RangePolicy<execution_space> policy(exec, 0, y.size());
   if constexpr (YVector::rank == 1) {
 // lbv - 07/26/2023:
 // with_unmanaged_t<...> required Kokkos 4.1.0,

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -33,14 +33,14 @@ namespace Experimental {
 namespace Impl {
 
 // default is no eti available
-template <class AT, class AO, class AD, class AM, class AS, class XT, class XL,
-          class XD, class XM, class YT, class YL, class YD, class YM>
+template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
+          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
 struct spmv_bsrmatrix_eti_spec_avail {
   enum : bool { value = false };
 };
 
-template <class AT, class AO, class AD, class AM, class AS, class XT, class XL,
-          class XD, class XM, class YT, class YL, class YD, class YM,
+template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
+          class XL, class XD, class XM, class YT, class YL, class YD, class YM,
           const bool integerScalarType =
               std::is_integral<typename std::decay<AT>::type>::value>
 struct spmv_mv_bsrmatrix_eti_spec_avail {
@@ -56,7 +56,7 @@ struct spmv_mv_bsrmatrix_eti_spec_avail {
     MEM_SPACE_TYPE)                                                       \
   template <>                                                             \
   struct spmv_bsrmatrix_eti_spec_avail<                                   \
-      const SCALAR_TYPE, const ORDINAL_TYPE,                              \
+      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,             \
       Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,         \
       SCALAR_TYPE const *, LAYOUT_TYPE,                                   \
@@ -73,7 +73,7 @@ struct spmv_mv_bsrmatrix_eti_spec_avail {
     MEM_SPACE_TYPE)                                                       \
   template <>                                                             \
   struct spmv_mv_bsrmatrix_eti_spec_avail<                                \
-      const SCALAR_TYPE, const ORDINAL_TYPE,                              \
+      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,             \
       Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,         \
       SCALAR_TYPE const **, LAYOUT_TYPE,                                  \
@@ -95,12 +95,12 @@ namespace Experimental {
 namespace Impl {
 
 // declaration
-template <class AT, class AO, class AD, class AM, class AS, class XT, class XL,
-          class XD, class XM, class YT, class YL, class YD, class YM,
+template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
+          class XL, class XD, class XM, class YT, class YL, class YD, class YM,
           bool tpl_spec_avail = spmv_bsrmatrix_tpl_spec_avail<
-              AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value,
+              ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value,
           bool eti_spec_avail = spmv_bsrmatrix_eti_spec_avail<
-              AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value>
+              ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value>
 struct SPMV_BSRMATRIX {
   typedef BsrMatrix<AT, AO, AD, AM, AS> AMatrix;
   typedef Kokkos::View<XT, XL, XD, XM> XVector;
@@ -108,21 +108,20 @@ struct SPMV_BSRMATRIX {
   typedef typename YVector::non_const_value_type YScalar;
 
   static void spmv_bsrmatrix(
-      const typename AD::execution_space &exec,
-      const KokkosKernels::Experimental::Controls &controls, const char mode[],
-      const YScalar &alpha, const AMatrix &A, const XVector &x,
-      const YScalar &beta, const YVector &y);
+      const ES &exec, const KokkosKernels::Experimental::Controls &controls,
+      const char mode[], const YScalar &alpha, const AMatrix &A,
+      const XVector &x, const YScalar &beta, const YVector &y);
 };
 
 // declaration
-template <class AT, class AO, class AD, class AM, class AS, class XT, class XL,
-          class XD, class XM, class YT, class YL, class YD, class YM,
+template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
+          class XL, class XD, class XM, class YT, class YL, class YD, class YM,
           const bool integerScalarType =
               std::is_integral<typename std::decay<AT>::type>::value,
           bool tpl_spec_avail = spmv_mv_bsrmatrix_tpl_spec_avail<
-              AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value,
+              ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value,
           bool eti_spec_avail = spmv_mv_bsrmatrix_eti_spec_avail<
-              AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value>
+              ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value>
 struct SPMV_MV_BSRMATRIX {
   typedef BsrMatrix<AT, AO, AD, AM, AS> AMatrix;
   typedef Kokkos::View<XT, XL, XD, XM> XVector;
@@ -130,10 +129,9 @@ struct SPMV_MV_BSRMATRIX {
   typedef typename YVector::non_const_value_type YScalar;
 
   static void spmv_mv_bsrmatrix(
-      const typename AD::execution_space &exec,
-      const KokkosKernels::Experimental::Controls &controls, const char mode[],
-      const YScalar &alpha, const AMatrix &A, const XVector &x,
-      const YScalar &beta, const YVector &y);
+      const ES &exec, const KokkosKernels::Experimental::Controls &controls,
+      const char mode[], const YScalar &alpha, const AMatrix &A,
+      const XVector &x, const YScalar &beta, const YVector &y);
 };
 
 // actual implementations to be compiled
@@ -144,20 +142,19 @@ constexpr inline const char *ALG_V41 = "v4.1";
 constexpr inline const char *ALG_V42 = "v4.2";
 constexpr inline const char *ALG_TC  = "experimental_bsr_tc";
 
-template <class AT, class AO, class AD, class AM, class AS, class XT, class XL,
-          class XD, class XM, class YT, class YL, class YD, class YM>
-struct SPMV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM, false,
-                      KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
+          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
+struct SPMV_BSRMATRIX<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
+                      false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef BsrMatrix<AT, AO, AD, AM, AS> AMatrix;
   typedef Kokkos::View<XT, XL, XD, XM> XVector;
   typedef Kokkos::View<YT, YL, YD, YM> YVector;
   typedef typename YVector::non_const_value_type YScalar;
 
   static void spmv_bsrmatrix(
-      const typename AD::execution_space &exec,
-      const KokkosKernels::Experimental::Controls &controls, const char mode[],
-      const YScalar &alpha, const AMatrix &A, const XVector &X,
-      const YScalar &beta, const YVector &Y) {
+      const ES &exec, const KokkosKernels::Experimental::Controls &controls,
+      const char mode[], const YScalar &alpha, const AMatrix &A,
+      const XVector &X, const YScalar &beta, const YVector &Y) {
     const bool modeIsNoTrans        = (mode[0] == NoTranspose[0]);
     const bool modeIsConjugate      = (mode[0] == Conjugate[0]);
     const bool modeIsConjugateTrans = (mode[0] == ConjugateTranspose[0]);
@@ -175,8 +172,7 @@ struct SPMV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM, false,
     }
 
     // use V42 if possible
-    if (KokkosKernels::Impl::kk_is_gpu_exec_space<
-            typename YVector::execution_space>() ||
+    if (KokkosKernels::Impl::kk_is_gpu_exec_space<ES>() ||
         controls.getParameter("algorithm") == ALG_V42) {
       if (modeIsNoTrans) {
         ::KokkosSparse::Impl::apply_v42(exec, alpha, A, X, beta, Y);
@@ -203,9 +199,9 @@ struct SPMV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM, false,
   }
 };
 
-template <class AT, class AO, class AD, class AM, class AS, class XT, class XL,
-          class XD, class XM, class YT, class YL, class YD, class YM>
-struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
+template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
+          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
+struct SPMV_MV_BSRMATRIX<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
                          false, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef BsrMatrix<AT, AO, AD, AM, AS> AMatrix;
   typedef Kokkos::View<XT, XL, XD, XM> XVector;
@@ -225,10 +221,9 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
   };
 
   static void spmv_mv_bsrmatrix(
-      const typename AD::execution_space &exec,
-      const KokkosKernels::Experimental::Controls &controls, const char mode[],
-      const YScalar &alpha, const AMatrix &A, const XVector &X,
-      const YScalar &beta, const YVector &Y) {
+      const ES &exec, const KokkosKernels::Experimental::Controls &controls,
+      const char mode[], const YScalar &alpha, const AMatrix &A,
+      const XVector &X, const YScalar &beta, const YVector &Y) {
 #if defined(KOKKOS_ARCH_AMPERE) || defined(KOKKOS_ARCH_VOLTA)
     Method method = Method::Fallback;
     {
@@ -241,15 +236,8 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
       if (Kokkos::ArithTraits<YScalar>::is_complex) method = Method::Fallback;
       if (Kokkos::ArithTraits<XScalar>::is_complex) method = Method::Fallback;
       if (Kokkos::ArithTraits<AScalar>::is_complex) method = Method::Fallback;
-      // can't use tensor cores outside GPU
-      if (!KokkosKernels::Impl::kk_is_gpu_exec_space<
-              typename AMatrix::execution_space>())
-        method = Method::Fallback;
-      if (!KokkosKernels::Impl::kk_is_gpu_exec_space<
-              typename XVector::execution_space>())
-        method = Method::Fallback;
-      if (!KokkosKernels::Impl::kk_is_gpu_exec_space<
-              typename YVector::execution_space>())
+      // can't use tensor cores outside Nvidia GPU
+      if constexpr (!std::is_same_v<ES, Kokkos::Cuda>)
         method = Method::Fallback;
       // can't use tensor cores unless mode is no-transpose
       if (mode[0] != KokkosSparse::NoTranspose[0]) method = Method::Fallback;
@@ -281,15 +269,15 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
 
         switch (precision) {
           case Precision::Mixed: {
-            BsrMatrixSpMVTensorCoreDispatcher<AMatrix, half, XVector, half,
+            BsrMatrixSpMVTensorCoreDispatcher<ES, AMatrix, half, XVector, half,
                                               YVector, float, 16, 16,
                                               16>::dispatch(exec, alpha, A, X,
                                                             beta, Y);
             return;
           }
           case Precision::Double: {
-            BsrMatrixSpMVTensorCoreDispatcher<AMatrix, double, XVector, double,
-                                              YVector, double, 8, 8,
+            BsrMatrixSpMVTensorCoreDispatcher<ES, AMatrix, double, XVector,
+                                              double, YVector, double, 8, 8,
                                               4>::dispatch(exec, alpha, A, X,
                                                            beta, Y);
             return;
@@ -301,13 +289,13 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
                 std::is_same<XScalar, Half>::value &&
                 std::is_same<YScalar, float>::value;
             if (operandsHalfHalfFloat) {
-              BsrMatrixSpMVTensorCoreDispatcher<AMatrix, half, XVector, half,
-                                                YVector, float, 16, 16,
+              BsrMatrixSpMVTensorCoreDispatcher<ES, AMatrix, half, XVector,
+                                                half, YVector, float, 16, 16,
                                                 16>::dispatch(exec, alpha, A, X,
                                                               beta, Y);
               return;
             } else {
-              BsrMatrixSpMVTensorCoreDispatcher<AMatrix, double, XVector,
+              BsrMatrixSpMVTensorCoreDispatcher<ES, AMatrix, double, XVector,
                                                 double, YVector, double, 8, 8,
                                                 4>::dispatch(exec, alpha, A, X,
                                                              beta, Y);
@@ -323,11 +311,10 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
          use it for all matrices
       */
       if (Method::TensorCores == method) {
-        BsrMatrixSpMVTensorCoreDispatcher<AMatrix, half, XVector, half, YVector,
-                                          float, 16, 16, 16>::dispatch(exec,
-                                                                       alpha, A,
-                                                                       X, beta,
-                                                                       Y);
+        BsrMatrixSpMVTensorCoreDispatcher<ES, AMatrix, half, XVector, half,
+                                          YVector, float, 16, 16,
+                                          16>::dispatch(exec, alpha, A, X, beta,
+                                                        Y);
         return;
       }
     }
@@ -350,8 +337,7 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
     }
 
     // use V42 if possible
-    if (KokkosKernels::Impl::kk_is_gpu_exec_space<
-            typename YVector::execution_space>() ||
+    if (KokkosKernels::Impl::kk_is_gpu_exec_space<ES>() ||
         controls.getParameter("algorithm") == ALG_V42) {
       if (modeIsNoTrans) {
         ::KokkosSparse::Impl::apply_v42(exec, alpha, A, X, beta, Y);
@@ -378,9 +364,9 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
   }
 };
 
-template <class AT, class AO, class AD, class AM, class AS, class XT, class XL,
-          class XD, class XM, class YT, class YL, class YD, class YM>
-struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
+template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
+          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
+struct SPMV_MV_BSRMATRIX<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
                          true, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef BsrMatrix<AT, AO, AD, AM, AS> AMatrix;
   typedef Kokkos::View<XT, XL, XD, XM> XVector;
@@ -388,15 +374,14 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
   typedef typename YVector::non_const_value_type YScalar;
 
   static void spmv_mv_bsrmatrix(
-      const typename AD::execution_space &exec,
-      const KokkosKernels::Experimental::Controls &controls, const char mode[],
-      const YScalar &alpha, const AMatrix &A, const XVector &X,
-      const YScalar &beta, const YVector &Y) {
+      const ES &exec, const KokkosKernels::Experimental::Controls &controls,
+      const char mode[], const YScalar &alpha, const AMatrix &A,
+      const XVector &X, const YScalar &beta, const YVector &Y) {
     static_assert(std::is_integral<AT>::value,
                   "This implementation is only for integer Scalar types.");
-    typedef SPMV_BSRMATRIX<AT, AO, AD, AM, AS, typename XVector::value_type *,
-                           XL, XD, XM, typename YVector::value_type *, YL, YD,
-                           YM>
+    typedef SPMV_BSRMATRIX<ES, AT, AO, AD, AM, AS,
+                           typename XVector::value_type *, XL, XD, XM,
+                           typename YVector::value_type *, YL, YD, YM>
         impl_type;
     for (typename AMatrix::non_const_size_type j = 0; j < X.extent(1); ++j) {
       const auto x_j = Kokkos::subview(X, Kokkos::ALL(), j);
@@ -418,7 +403,7 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
     SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, \
     MEM_SPACE_TYPE)                                                       \
   extern template struct SPMV_BSRMATRIX<                                  \
-      const SCALAR_TYPE, const ORDINAL_TYPE,                              \
+      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,             \
       Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,         \
       SCALAR_TYPE const *, LAYOUT_TYPE,                                   \
@@ -432,7 +417,7 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
     SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, \
     MEM_SPACE_TYPE)                                                       \
   template struct SPMV_BSRMATRIX<                                         \
-      const SCALAR_TYPE, const ORDINAL_TYPE,                              \
+      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,             \
       Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,         \
       SCALAR_TYPE const *, LAYOUT_TYPE,                                   \
@@ -449,7 +434,7 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
     SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,     \
     MEM_SPACE_TYPE)                                                           \
   extern template struct SPMV_MV_BSRMATRIX<                                   \
-      const SCALAR_TYPE, const ORDINAL_TYPE,                                  \
+      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,                 \
       Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,             \
       SCALAR_TYPE const **, LAYOUT_TYPE,                                      \
@@ -465,7 +450,7 @@ struct SPMV_MV_BSRMATRIX<AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
     SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,     \
     MEM_SPACE_TYPE)                                                           \
   template struct SPMV_MV_BSRMATRIX<                                          \
-      const SCALAR_TYPE, const ORDINAL_TYPE,                                  \
+      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,                 \
       Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,             \
       SCALAR_TYPE const **, LAYOUT_TYPE,                                      \

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -55,7 +55,7 @@ struct spmv_mv_bsrmatrix_eti_spec_avail {
   template <>                                                              \
   struct spmv_bsrmatrix_eti_spec_avail<                                    \
       EXEC_SPACE_TYPE,                                                     \
-      KokkosSparse::Experimental::BsrMatrix<                               \
+      ::KokkosSparse::Experimental::BsrMatrix<                               \
           const SCALAR_TYPE, const ORDINAL_TYPE,                           \
           Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
           Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE>,     \
@@ -75,7 +75,7 @@ struct spmv_mv_bsrmatrix_eti_spec_avail {
   template <>                                                              \
   struct spmv_mv_bsrmatrix_eti_spec_avail<                                 \
       EXEC_SPACE_TYPE,                                                     \
-      KokkosSparse::Experimental::BsrMatrix<                               \
+      ::KokkosSparse::Experimental::BsrMatrix<                               \
           const SCALAR_TYPE, const ORDINAL_TYPE,                           \
           Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
           Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE>,     \
@@ -389,7 +389,7 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, AMatrix, XVector, YVector, true, false,
     MEM_SPACE_TYPE)                                                        \
   extern template struct SPMV_BSRMATRIX<                                   \
       EXEC_SPACE_TYPE,                                                     \
-      KokkosSparse::Experimental::BsrMatrix<                               \
+      ::KokkosSparse::Experimental::BsrMatrix<                               \
           const SCALAR_TYPE, const ORDINAL_TYPE,                           \
           Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
           Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE>,     \
@@ -407,7 +407,7 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, AMatrix, XVector, YVector, true, false,
     MEM_SPACE_TYPE)                                                        \
   template struct SPMV_BSRMATRIX<                                          \
       EXEC_SPACE_TYPE,                                                     \
-      KokkosSparse::Experimental::BsrMatrix<                               \
+      ::KokkosSparse::Experimental::BsrMatrix<                               \
           const SCALAR_TYPE, const ORDINAL_TYPE,                           \
           Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
           Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE>,     \
@@ -428,7 +428,7 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, AMatrix, XVector, YVector, true, false,
     MEM_SPACE_TYPE)                                                        \
   extern template struct SPMV_MV_BSRMATRIX<                                \
       EXEC_SPACE_TYPE,                                                     \
-      KokkosSparse::Experimental::BsrMatrix<                               \
+      ::KokkosSparse::Experimental::BsrMatrix<                               \
           const SCALAR_TYPE, const ORDINAL_TYPE,                           \
           Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
           Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE>,     \
@@ -446,7 +446,7 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, AMatrix, XVector, YVector, true, false,
     MEM_SPACE_TYPE)                                                        \
   template struct SPMV_MV_BSRMATRIX<                                       \
       EXEC_SPACE_TYPE,                                                     \
-      KokkosSparse::Experimental::BsrMatrix<                               \
+      ::KokkosSparse::Experimental::BsrMatrix<                               \
           const SCALAR_TYPE, const ORDINAL_TYPE,                           \
           Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
           Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE>,     \

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -55,7 +55,7 @@ struct spmv_mv_bsrmatrix_eti_spec_avail {
   template <>                                                              \
   struct spmv_bsrmatrix_eti_spec_avail<                                    \
       EXEC_SPACE_TYPE,                                                     \
-      ::KokkosSparse::Experimental::BsrMatrix<                               \
+      ::KokkosSparse::Experimental::BsrMatrix<                             \
           const SCALAR_TYPE, const ORDINAL_TYPE,                           \
           Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
           Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE>,     \
@@ -75,7 +75,7 @@ struct spmv_mv_bsrmatrix_eti_spec_avail {
   template <>                                                              \
   struct spmv_mv_bsrmatrix_eti_spec_avail<                                 \
       EXEC_SPACE_TYPE,                                                     \
-      ::KokkosSparse::Experimental::BsrMatrix<                               \
+      ::KokkosSparse::Experimental::BsrMatrix<                             \
           const SCALAR_TYPE, const ORDINAL_TYPE,                           \
           Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
           Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE>,     \
@@ -389,7 +389,7 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, AMatrix, XVector, YVector, true, false,
     MEM_SPACE_TYPE)                                                        \
   extern template struct SPMV_BSRMATRIX<                                   \
       EXEC_SPACE_TYPE,                                                     \
-      ::KokkosSparse::Experimental::BsrMatrix<                               \
+      ::KokkosSparse::Experimental::BsrMatrix<                             \
           const SCALAR_TYPE, const ORDINAL_TYPE,                           \
           Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
           Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE>,     \
@@ -407,7 +407,7 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, AMatrix, XVector, YVector, true, false,
     MEM_SPACE_TYPE)                                                        \
   template struct SPMV_BSRMATRIX<                                          \
       EXEC_SPACE_TYPE,                                                     \
-      ::KokkosSparse::Experimental::BsrMatrix<                               \
+      ::KokkosSparse::Experimental::BsrMatrix<                             \
           const SCALAR_TYPE, const ORDINAL_TYPE,                           \
           Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
           Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE>,     \
@@ -428,7 +428,7 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, AMatrix, XVector, YVector, true, false,
     MEM_SPACE_TYPE)                                                        \
   extern template struct SPMV_MV_BSRMATRIX<                                \
       EXEC_SPACE_TYPE,                                                     \
-      ::KokkosSparse::Experimental::BsrMatrix<                               \
+      ::KokkosSparse::Experimental::BsrMatrix<                             \
           const SCALAR_TYPE, const ORDINAL_TYPE,                           \
           Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
           Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE>,     \
@@ -446,7 +446,7 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, AMatrix, XVector, YVector, true, false,
     MEM_SPACE_TYPE)                                                        \
   template struct SPMV_MV_BSRMATRIX<                                       \
       EXEC_SPACE_TYPE,                                                     \
-      ::KokkosSparse::Experimental::BsrMatrix<                               \
+      ::KokkosSparse::Experimental::BsrMatrix<                             \
           const SCALAR_TYPE, const ORDINAL_TYPE,                           \
           Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
           Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE>,     \

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -33,16 +33,14 @@ namespace Experimental {
 namespace Impl {
 
 // default is no eti available
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector>
 struct spmv_bsrmatrix_eti_spec_avail {
   enum : bool { value = false };
 };
 
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM,
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector,
           const bool integerScalarType =
-              std::is_integral<typename std::decay<AT>::type>::value>
+              std::is_integral_v<typename AMatrix::non_const_value_type>>
 struct spmv_mv_bsrmatrix_eti_spec_avail {
   enum : bool { value = false };
 };
@@ -51,38 +49,44 @@ struct spmv_mv_bsrmatrix_eti_spec_avail {
 }  // namespace Experimental
 }  // namespace KokkosSparse
 
-#define KOKKOSSPARSE_SPMV_BSRMATRIX_ETI_SPEC_AVAIL(                       \
-    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, \
-    MEM_SPACE_TYPE)                                                       \
-  template <>                                                             \
-  struct spmv_bsrmatrix_eti_spec_avail<                                   \
-      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,             \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,         \
-      SCALAR_TYPE const *, LAYOUT_TYPE,                                   \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,     \
-      SCALAR_TYPE *, LAYOUT_TYPE,                                         \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> > {                         \
-    enum : bool { value = true };                                         \
+#define KOKKOSSPARSE_SPMV_BSRMATRIX_ETI_SPEC_AVAIL(                        \
+    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,  \
+    MEM_SPACE_TYPE)                                                        \
+  template <>                                                              \
+  struct spmv_bsrmatrix_eti_spec_avail<                                    \
+      EXEC_SPACE_TYPE,                                                     \
+      KokkosSparse::Experimental::BsrMatrix<                               \
+          const SCALAR_TYPE, const ORDINAL_TYPE,                           \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE>,     \
+      Kokkos::View<                                                        \
+          SCALAR_TYPE const *, LAYOUT_TYPE,                                \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>, \
+      Kokkos::View<SCALAR_TYPE *, LAYOUT_TYPE,                             \
+                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,        \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {             \
+    enum : bool { value = true };                                          \
   };
 
-#define KOKKOSSPARSE_SPMV_MV_BSRMATRIX_ETI_SPEC_AVAIL(                    \
-    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, \
-    MEM_SPACE_TYPE)                                                       \
-  template <>                                                             \
-  struct spmv_mv_bsrmatrix_eti_spec_avail<                                \
-      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,             \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,         \
-      SCALAR_TYPE const **, LAYOUT_TYPE,                                  \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,     \
-      SCALAR_TYPE **, LAYOUT_TYPE,                                        \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> > {                         \
-    enum : bool { value = true };                                         \
+#define KOKKOSSPARSE_SPMV_MV_BSRMATRIX_ETI_SPEC_AVAIL(                     \
+    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,  \
+    MEM_SPACE_TYPE)                                                        \
+  template <>                                                              \
+  struct spmv_mv_bsrmatrix_eti_spec_avail<                                 \
+      EXEC_SPACE_TYPE,                                                     \
+      KokkosSparse::Experimental::BsrMatrix<                               \
+          const SCALAR_TYPE, const ORDINAL_TYPE,                           \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE>,     \
+      Kokkos::View<                                                        \
+          SCALAR_TYPE const **, LAYOUT_TYPE,                               \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>, \
+      Kokkos::View<SCALAR_TYPE **, LAYOUT_TYPE,                            \
+                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,        \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {             \
+    enum : bool { value = true };                                          \
   };
 
 // Include which ETIs are available
@@ -95,43 +99,37 @@ namespace Experimental {
 namespace Impl {
 
 // declaration
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM,
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector,
           bool tpl_spec_avail = spmv_bsrmatrix_tpl_spec_avail<
-              ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value,
+              ExecutionSpace, AMatrix, XVector, YVector>::value,
           bool eti_spec_avail = spmv_bsrmatrix_eti_spec_avail<
-              ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value>
+              ExecutionSpace, AMatrix, XVector, YVector>::value>
 struct SPMV_BSRMATRIX {
-  typedef BsrMatrix<AT, AO, AD, AM, AS> AMatrix;
-  typedef Kokkos::View<XT, XL, XD, XM> XVector;
-  typedef Kokkos::View<YT, YL, YD, YM> YVector;
   typedef typename YVector::non_const_value_type YScalar;
 
   static void spmv_bsrmatrix(
-      const ES &exec, const KokkosKernels::Experimental::Controls &controls,
-      const char mode[], const YScalar &alpha, const AMatrix &A,
-      const XVector &x, const YScalar &beta, const YVector &y);
+      const ExecutionSpace &space,
+      const KokkosKernels::Experimental::Controls &controls, const char mode[],
+      const YScalar &alpha, const AMatrix &A, const XVector &x,
+      const YScalar &beta, const YVector &y);
 };
 
 // declaration
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM,
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector,
           const bool integerScalarType =
-              std::is_integral<typename std::decay<AT>::type>::value,
+              std::is_integral_v<typename AMatrix::non_const_value_type>,
           bool tpl_spec_avail = spmv_mv_bsrmatrix_tpl_spec_avail<
-              ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value,
+              ExecutionSpace, AMatrix, XVector, YVector>::value,
           bool eti_spec_avail = spmv_mv_bsrmatrix_eti_spec_avail<
-              ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value>
+              ExecutionSpace, AMatrix, XVector, YVector>::value>
 struct SPMV_MV_BSRMATRIX {
-  typedef BsrMatrix<AT, AO, AD, AM, AS> AMatrix;
-  typedef Kokkos::View<XT, XL, XD, XM> XVector;
-  typedef Kokkos::View<YT, YL, YD, YM> YVector;
   typedef typename YVector::non_const_value_type YScalar;
 
   static void spmv_mv_bsrmatrix(
-      const ES &exec, const KokkosKernels::Experimental::Controls &controls,
-      const char mode[], const YScalar &alpha, const AMatrix &A,
-      const XVector &x, const YScalar &beta, const YVector &y);
+      const ExecutionSpace &space,
+      const KokkosKernels::Experimental::Controls &controls, const char mode[],
+      const YScalar &alpha, const AMatrix &A, const XVector &x,
+      const YScalar &beta, const YVector &y);
 };
 
 // actual implementations to be compiled
@@ -142,19 +140,16 @@ constexpr inline const char *ALG_V41 = "v4.1";
 constexpr inline const char *ALG_V42 = "v4.2";
 constexpr inline const char *ALG_TC  = "experimental_bsr_tc";
 
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
-struct SPMV_BSRMATRIX<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
-                      false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
-  typedef BsrMatrix<AT, AO, AD, AM, AS> AMatrix;
-  typedef Kokkos::View<XT, XL, XD, XM> XVector;
-  typedef Kokkos::View<YT, YL, YD, YM> YVector;
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector>
+struct SPMV_BSRMATRIX<ExecutionSpace, AMatrix, XVector, YVector, false,
+                      KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename YVector::non_const_value_type YScalar;
 
   static void spmv_bsrmatrix(
-      const ES &exec, const KokkosKernels::Experimental::Controls &controls,
-      const char mode[], const YScalar &alpha, const AMatrix &A,
-      const XVector &X, const YScalar &beta, const YVector &Y) {
+      const ExecutionSpace &space,
+      const KokkosKernels::Experimental::Controls &controls, const char mode[],
+      const YScalar &alpha, const AMatrix &A, const XVector &X,
+      const YScalar &beta, const YVector &Y) {
     const bool modeIsNoTrans        = (mode[0] == NoTranspose[0]);
     const bool modeIsConjugate      = (mode[0] == Conjugate[0]);
     const bool modeIsConjugateTrans = (mode[0] == ConjugateTranspose[0]);
@@ -163,29 +158,29 @@ struct SPMV_BSRMATRIX<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
     // use V41 if requested
     if (controls.getParameter("algorithm") == ALG_V41) {
       if (modeIsNoTrans || modeIsConjugate) {
-        return Bsr::spMatVec_no_transpose(exec, controls, alpha, A, X, beta, Y,
+        return Bsr::spMatVec_no_transpose(space, controls, alpha, A, X, beta, Y,
                                           modeIsConjugate);
       } else if (modeIsTrans || modeIsConjugateTrans) {
-        return Bsr::spMatVec_transpose(exec, controls, alpha, A, X, beta, Y,
+        return Bsr::spMatVec_transpose(space, controls, alpha, A, X, beta, Y,
                                        modeIsConjugateTrans);
       }
     }
 
     // use V42 if possible
-    if (KokkosKernels::Impl::kk_is_gpu_exec_space<ES>() ||
+    if (KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>() ||
         controls.getParameter("algorithm") == ALG_V42) {
       if (modeIsNoTrans) {
-        ::KokkosSparse::Impl::apply_v42(exec, alpha, A, X, beta, Y);
+        ::KokkosSparse::Impl::apply_v42(space, alpha, A, X, beta, Y);
         return;
       }
     }
 
     // fall back to V41 all else fails
     if (modeIsNoTrans || modeIsConjugate) {
-      return Bsr::spMatVec_no_transpose(exec, controls, alpha, A, X, beta, Y,
+      return Bsr::spMatVec_no_transpose(space, controls, alpha, A, X, beta, Y,
                                         modeIsConjugate);
     } else if (modeIsTrans || modeIsConjugateTrans) {
-      return Bsr::spMatVec_transpose(exec, controls, alpha, A, X, beta, Y,
+      return Bsr::spMatVec_transpose(space, controls, alpha, A, X, beta, Y,
                                      modeIsConjugateTrans);
     }
 
@@ -199,13 +194,9 @@ struct SPMV_BSRMATRIX<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
   }
 };
 
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
-struct SPMV_MV_BSRMATRIX<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
-                         false, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
-  typedef BsrMatrix<AT, AO, AD, AM, AS> AMatrix;
-  typedef Kokkos::View<XT, XL, XD, XM> XVector;
-  typedef Kokkos::View<YT, YL, YD, YM> YVector;
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector>
+struct SPMV_MV_BSRMATRIX<ExecutionSpace, AMatrix, XVector, YVector, false,
+                         false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename YVector::non_const_value_type YScalar;
 
   enum class Method {
@@ -221,9 +212,10 @@ struct SPMV_MV_BSRMATRIX<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
   };
 
   static void spmv_mv_bsrmatrix(
-      const ES &exec, const KokkosKernels::Experimental::Controls &controls,
-      const char mode[], const YScalar &alpha, const AMatrix &A,
-      const XVector &X, const YScalar &beta, const YVector &Y) {
+      const ExecutionSpace &space,
+      const KokkosKernels::Experimental::Controls &controls, const char mode[],
+      const YScalar &alpha, const AMatrix &A, const XVector &X,
+      const YScalar &beta, const YVector &Y) {
 #if defined(KOKKOS_ARCH_AMPERE) || defined(KOKKOS_ARCH_VOLTA)
     Method method = Method::Fallback;
     {
@@ -237,7 +229,7 @@ struct SPMV_MV_BSRMATRIX<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
       if (Kokkos::ArithTraits<XScalar>::is_complex) method = Method::Fallback;
       if (Kokkos::ArithTraits<AScalar>::is_complex) method = Method::Fallback;
       // can't use tensor cores outside Nvidia GPU
-      if constexpr (!std::is_same_v<ES, Kokkos::Cuda>)
+      if constexpr (!std::is_same_v<ExecutionSpace, Kokkos::Cuda>)
         method = Method::Fallback;
       // can't use tensor cores unless mode is no-transpose
       if (mode[0] != KokkosSparse::NoTranspose[0]) method = Method::Fallback;
@@ -269,17 +261,17 @@ struct SPMV_MV_BSRMATRIX<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
 
         switch (precision) {
           case Precision::Mixed: {
-            BsrMatrixSpMVTensorCoreDispatcher<ES, AMatrix, half, XVector, half,
-                                              YVector, float, 16, 16,
-                                              16>::dispatch(exec, alpha, A, X,
-                                                            beta, Y);
+            BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, half,
+                                              XVector, half, YVector, float, 16,
+                                              16, 16>::dispatch(space, alpha, A,
+                                                                X, beta, Y);
             return;
           }
           case Precision::Double: {
-            BsrMatrixSpMVTensorCoreDispatcher<ES, AMatrix, double, XVector,
-                                              double, YVector, double, 8, 8,
-                                              4>::dispatch(exec, alpha, A, X,
-                                                           beta, Y);
+            BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, double,
+                                              XVector, double, YVector, double,
+                                              8, 8, 4>::dispatch(space, alpha,
+                                                                 A, X, beta, Y);
             return;
           }
           case Precision::Automatic:  // fallthrough
@@ -289,16 +281,14 @@ struct SPMV_MV_BSRMATRIX<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
                 std::is_same<XScalar, Half>::value &&
                 std::is_same<YScalar, float>::value;
             if (operandsHalfHalfFloat) {
-              BsrMatrixSpMVTensorCoreDispatcher<ES, AMatrix, half, XVector,
-                                                half, YVector, float, 16, 16,
-                                                16>::dispatch(exec, alpha, A, X,
-                                                              beta, Y);
+              BsrMatrixSpMVTensorCoreDispatcher<
+                  ExecutionSpace, AMatrix, half, XVector, half, YVector, float,
+                  16, 16, 16>::dispatch(space, alpha, A, X, beta, Y);
               return;
             } else {
-              BsrMatrixSpMVTensorCoreDispatcher<ES, AMatrix, double, XVector,
-                                                double, YVector, double, 8, 8,
-                                                4>::dispatch(exec, alpha, A, X,
-                                                             beta, Y);
+              BsrMatrixSpMVTensorCoreDispatcher<
+                  ExecutionSpace, AMatrix, double, XVector, double, YVector,
+                  double, 8, 8, 4>::dispatch(space, alpha, A, X, beta, Y);
               return;
             }
           }
@@ -311,10 +301,10 @@ struct SPMV_MV_BSRMATRIX<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
          use it for all matrices
       */
       if (Method::TensorCores == method) {
-        BsrMatrixSpMVTensorCoreDispatcher<ES, AMatrix, half, XVector, half,
-                                          YVector, float, 16, 16,
-                                          16>::dispatch(exec, alpha, A, X, beta,
-                                                        Y);
+        BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, half,
+                                          XVector, half, YVector, float, 16, 16,
+                                          16>::dispatch(space, alpha, A, X,
+                                                        beta, Y);
         return;
       }
     }
@@ -328,29 +318,29 @@ struct SPMV_MV_BSRMATRIX<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
     // use V41 if requested
     if (controls.getParameter("algorithm") == ALG_V41) {
       if (modeIsNoTrans || modeIsConjugate) {
-        return Bsr::spMatMultiVec_no_transpose(exec, controls, alpha, A, X,
+        return Bsr::spMatMultiVec_no_transpose(space, controls, alpha, A, X,
                                                beta, Y, modeIsConjugate);
       } else if (modeIsTrans || modeIsConjugateTrans) {
-        return Bsr::spMatMultiVec_transpose(exec, controls, alpha, A, X, beta,
+        return Bsr::spMatMultiVec_transpose(space, controls, alpha, A, X, beta,
                                             Y, modeIsConjugateTrans);
       }
     }
 
     // use V42 if possible
-    if (KokkosKernels::Impl::kk_is_gpu_exec_space<ES>() ||
+    if (KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>() ||
         controls.getParameter("algorithm") == ALG_V42) {
       if (modeIsNoTrans) {
-        ::KokkosSparse::Impl::apply_v42(exec, alpha, A, X, beta, Y);
+        ::KokkosSparse::Impl::apply_v42(space, alpha, A, X, beta, Y);
         return;
       }
     }
 
     // use V41 as the ultimate fallback
     if (modeIsNoTrans || modeIsConjugate) {
-      return Bsr::spMatMultiVec_no_transpose(exec, controls, alpha, A, X, beta,
+      return Bsr::spMatMultiVec_no_transpose(space, controls, alpha, A, X, beta,
                                              Y, modeIsConjugate);
     } else if (modeIsTrans || modeIsConjugateTrans) {
-      return Bsr::spMatMultiVec_transpose(exec, controls, alpha, A, X, beta, Y,
+      return Bsr::spMatMultiVec_transpose(space, controls, alpha, A, X, beta, Y,
                                           modeIsConjugateTrans);
     }
 
@@ -364,29 +354,24 @@ struct SPMV_MV_BSRMATRIX<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
   }
 };
 
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
-struct SPMV_MV_BSRMATRIX<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
-                         true, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
-  typedef BsrMatrix<AT, AO, AD, AM, AS> AMatrix;
-  typedef Kokkos::View<XT, XL, XD, XM> XVector;
-  typedef Kokkos::View<YT, YL, YD, YM> YVector;
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector>
+struct SPMV_MV_BSRMATRIX<ExecutionSpace, AMatrix, XVector, YVector, true, false,
+                         KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename YVector::non_const_value_type YScalar;
 
   static void spmv_mv_bsrmatrix(
-      const ES &exec, const KokkosKernels::Experimental::Controls &controls,
-      const char mode[], const YScalar &alpha, const AMatrix &A,
-      const XVector &X, const YScalar &beta, const YVector &Y) {
-    static_assert(std::is_integral<AT>::value,
+      const ExecutionSpace &space,
+      const KokkosKernels::Experimental::Controls &controls, const char mode[],
+      const YScalar &alpha, const AMatrix &A, const XVector &X,
+      const YScalar &beta, const YVector &Y) {
+    static_assert(std::is_integral_v<typename AMatrix::non_const_value_type>,
                   "This implementation is only for integer Scalar types.");
-    typedef SPMV_BSRMATRIX<ES, AT, AO, AD, AM, AS,
-                           typename XVector::value_type *, XL, XD, XM,
-                           typename YVector::value_type *, YL, YD, YM>
-        impl_type;
+    typedef SPMV_BSRMATRIX<ExecutionSpace, AMatrix, XVector, YVector> impl_type;
     for (typename AMatrix::non_const_size_type j = 0; j < X.extent(1); ++j) {
       const auto x_j = Kokkos::subview(X, Kokkos::ALL(), j);
       auto y_j       = Kokkos::subview(Y, Kokkos::ALL(), j);
-      impl_type::spmv_bsrmatrix(exec, controls, mode, alpha, A, x_j, beta, y_j);
+      impl_type::spmv_bsrmatrix(space, controls, mode, alpha, A, x_j, beta,
+                                y_j);
     }
   }
 };
@@ -399,68 +384,80 @@ struct SPMV_MV_BSRMATRIX<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
 // declare / instantiate the vector version
 // Instantiate with A,x,y are all the requested Scalar type (no instantiation of
 // mixed-precision operands)
-#define KOKKOSSPARSE_SPMV_BSRMATRIX_ETI_SPEC_DECL(                        \
-    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, \
-    MEM_SPACE_TYPE)                                                       \
-  extern template struct SPMV_BSRMATRIX<                                  \
-      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,             \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,         \
-      SCALAR_TYPE const *, LAYOUT_TYPE,                                   \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,     \
-      SCALAR_TYPE *, LAYOUT_TYPE,                                         \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, false, true>;
+#define KOKKOSSPARSE_SPMV_BSRMATRIX_ETI_SPEC_DECL(                         \
+    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,  \
+    MEM_SPACE_TYPE)                                                        \
+  extern template struct SPMV_BSRMATRIX<                                   \
+      EXEC_SPACE_TYPE,                                                     \
+      KokkosSparse::Experimental::BsrMatrix<                               \
+          const SCALAR_TYPE, const ORDINAL_TYPE,                           \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE>,     \
+      Kokkos::View<                                                        \
+          SCALAR_TYPE const *, LAYOUT_TYPE,                                \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>, \
+      Kokkos::View<SCALAR_TYPE *, LAYOUT_TYPE,                             \
+                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,        \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,               \
+      false, true>;
 
-#define KOKKOSSPARSE_SPMV_BSRMATRIX_ETI_SPEC_INST(                        \
-    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, \
-    MEM_SPACE_TYPE)                                                       \
-  template struct SPMV_BSRMATRIX<                                         \
-      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,             \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,         \
-      SCALAR_TYPE const *, LAYOUT_TYPE,                                   \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,     \
-      SCALAR_TYPE *, LAYOUT_TYPE,                                         \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, false, true>;
+#define KOKKOSSPARSE_SPMV_BSRMATRIX_ETI_SPEC_INST(                         \
+    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,  \
+    MEM_SPACE_TYPE)                                                        \
+  template struct SPMV_BSRMATRIX<                                          \
+      EXEC_SPACE_TYPE,                                                     \
+      KokkosSparse::Experimental::BsrMatrix<                               \
+          const SCALAR_TYPE, const ORDINAL_TYPE,                           \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE>,     \
+      Kokkos::View<                                                        \
+          SCALAR_TYPE const *, LAYOUT_TYPE,                                \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>, \
+      Kokkos::View<SCALAR_TYPE *, LAYOUT_TYPE,                             \
+                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,        \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,               \
+      false, true>;
 
 // declare / instantiate the 2D MV version
 // Instantiate with A,x,y are all the requested Scalar type (no instantiation of
 // mixed-precision operands)
-#define KOKKOSSPARSE_SPMV_MV_BSRMATRIX_ETI_SPEC_DECL(                         \
-    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,     \
-    MEM_SPACE_TYPE)                                                           \
-  extern template struct SPMV_MV_BSRMATRIX<                                   \
-      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,                 \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,             \
-      SCALAR_TYPE const **, LAYOUT_TYPE,                                      \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,         \
-      SCALAR_TYPE **, LAYOUT_TYPE,                                            \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>,                                \
-      std::is_integral<typename std::decay<SCALAR_TYPE>::type>::value, false, \
-      true>;
+#define KOKKOSSPARSE_SPMV_MV_BSRMATRIX_ETI_SPEC_DECL(                      \
+    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,  \
+    MEM_SPACE_TYPE)                                                        \
+  extern template struct SPMV_MV_BSRMATRIX<                                \
+      EXEC_SPACE_TYPE,                                                     \
+      KokkosSparse::Experimental::BsrMatrix<                               \
+          const SCALAR_TYPE, const ORDINAL_TYPE,                           \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE>,     \
+      Kokkos::View<                                                        \
+          SCALAR_TYPE const **, LAYOUT_TYPE,                               \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>, \
+      Kokkos::View<SCALAR_TYPE **, LAYOUT_TYPE,                            \
+                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,        \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,               \
+      std::is_integral_v<SCALAR_TYPE>, false, true>;
 
-#define KOKKOSSPARSE_SPMV_MV_BSRMATRIX_ETI_SPEC_INST(                         \
-    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,     \
-    MEM_SPACE_TYPE)                                                           \
-  template struct SPMV_MV_BSRMATRIX<                                          \
-      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,                 \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,             \
-      SCALAR_TYPE const **, LAYOUT_TYPE,                                      \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,         \
-      SCALAR_TYPE **, LAYOUT_TYPE,                                            \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>,                                \
-      std::is_integral<typename std::decay<SCALAR_TYPE>::type>::value, false, \
-      true>;
+#define KOKKOSSPARSE_SPMV_MV_BSRMATRIX_ETI_SPEC_INST(                      \
+    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,  \
+    MEM_SPACE_TYPE)                                                        \
+  template struct SPMV_MV_BSRMATRIX<                                       \
+      EXEC_SPACE_TYPE,                                                     \
+      KokkosSparse::Experimental::BsrMatrix<                               \
+          const SCALAR_TYPE, const ORDINAL_TYPE,                           \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE>,     \
+      Kokkos::View<                                                        \
+          SCALAR_TYPE const **, LAYOUT_TYPE,                               \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>, \
+      Kokkos::View<SCALAR_TYPE **, LAYOUT_TYPE,                            \
+                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,        \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,               \
+      std::is_integral_v<SCALAR_TYPE>, false, true>;
 
 #include <KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp>
 

--- a/sparse/impl/KokkosSparse_spmv_impl.hpp
+++ b/sparse/impl/KokkosSparse_spmv_impl.hpp
@@ -29,9 +29,9 @@ namespace KokkosSparse {
 namespace Impl {
 
 // This TransposeFunctor is functional, but not necessarily performant.
-template <class AMatrix, class XVector, class YVector, bool conjugate>
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          bool conjugate>
 struct SPMV_Transpose_Functor {
-  typedef typename AMatrix::execution_space execution_space;
   typedef typename AMatrix::non_const_ordinal_type ordinal_type;
   typedef typename AMatrix::non_const_value_type value_type;
   typedef typename Kokkos::TeamPolicy<execution_space> team_policy;
@@ -88,10 +88,9 @@ struct SPMV_Transpose_Functor {
   }
 };
 
-template <class AMatrix, class XVector, class YVector, int dobeta,
-          bool conjugate>
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int dobeta, bool conjugate>
 struct SPMV_Functor {
-  typedef typename AMatrix::execution_space execution_space;
   typedef typename AMatrix::non_const_ordinal_type ordinal_type;
   typedef typename AMatrix::non_const_value_type value_type;
   typedef typename Kokkos::TeamPolicy<execution_space> team_policy;
@@ -246,18 +245,17 @@ int64_t spmv_launch_parameters(int64_t numRows, int64_t nnz,
 
 // spmv_beta_no_transpose: version for CPU execution spaces (RangePolicy or
 // trivial serial impl used)
-template <class AMatrix, class XVector, class YVector, int dobeta,
-          bool conjugate,
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int dobeta, bool conjugate,
           typename std::enable_if<!KokkosKernels::Impl::kk_is_gpu_exec_space<
-              typename AMatrix::execution_space>()>::type* = nullptr>
+              execution_space>()>::type* = nullptr>
 static void spmv_beta_no_transpose(
-    const typename AMatrix::execution_space& exec,
+    const execution_space& exec,
     const KokkosKernels::Experimental::Controls& controls,
     typename YVector::const_value_type& alpha, const AMatrix& A,
     const XVector& x, typename YVector::const_value_type& beta,
     const YVector& y) {
   typedef typename AMatrix::non_const_ordinal_type ordinal_type;
-  typedef typename AMatrix::execution_space execution_space;
 
   if (A.numRows() <= static_cast<ordinal_type>(0)) {
     return;
@@ -354,7 +352,7 @@ static void spmv_beta_no_transpose(
       (((uintptr_t)(const void*)(y.data()) % 64) == 0) && !conjugate) {
     // Note BMK: this case is typically not called in practice even for OpenMP,
     // since it requires row_block_offsets to have been computed in the graph.
-    // Also, as this is raw OpenMP the execution space instance isn't used
+    // Also, as this is raw OpenMP the execution space instance is not used
     spmv_raw_openmp_no_transpose<AMatrix, XVector, YVector>(alpha, A, x, beta,
                                                             y);
     return;
@@ -370,8 +368,8 @@ static void spmv_beta_no_transpose(
       use_static_schedule = true;
     }
   }
-  SPMV_Functor<AMatrix, XVector, YVector, dobeta, conjugate> func(alpha, A, x,
-                                                                  beta, y, 1);
+  SPMV_Functor<execution_space, AMatrix, XVector, YVector, dobeta, conjugate>
+      func(alpha, A, x, beta, y, 1);
   if (((A.nnz() > 10000000) || use_dynamic_schedule) && !use_static_schedule)
     Kokkos::parallel_for(
         "KokkosSparse::spmv<NoTranspose,Dynamic>",
@@ -387,18 +385,17 @@ static void spmv_beta_no_transpose(
 }
 
 // spmv_beta_no_transpose: version for GPU execution spaces (TeamPolicy used)
-template <class AMatrix, class XVector, class YVector, int dobeta,
-          bool conjugate,
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int dobeta, bool conjugate,
           typename std::enable_if<KokkosKernels::Impl::kk_is_gpu_exec_space<
-              typename AMatrix::execution_space>()>::type* = nullptr>
+              execution_space>()>::type* = nullptr>
 static void spmv_beta_no_transpose(
-    const typename AMatrix::execution_space& exec,
+    const execution_space& exec,
     const KokkosKernels::Experimental::Controls& controls,
     typename YVector::const_value_type& alpha, const AMatrix& A,
     const XVector& x, typename YVector::const_value_type& beta,
     const YVector& y) {
   typedef typename AMatrix::non_const_ordinal_type ordinal_type;
-  typedef typename AMatrix::execution_space execution_space;
 
   if (A.numRows() <= static_cast<ordinal_type>(0)) {
     return;
@@ -434,8 +431,8 @@ static void spmv_beta_no_transpose(
       A.numRows(), A.nnz(), rows_per_thread, team_size, vector_length);
   int64_t worksets = (y.extent(0) + rows_per_team - 1) / rows_per_team;
 
-  SPMV_Functor<AMatrix, XVector, YVector, dobeta, conjugate> func(
-      alpha, A, x, beta, y, rows_per_team);
+  SPMV_Functor<execution_space, AMatrix, XVector, YVector, dobeta, conjugate>
+      func(alpha, A, x, beta, y, rows_per_team);
 
   if (((A.nnz() > 10000000) || use_dynamic_schedule) && !use_static_schedule) {
     Kokkos::TeamPolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>
@@ -468,18 +465,17 @@ static void spmv_beta_no_transpose(
 
 // spmv_beta_transpose: version for CPU execution spaces (RangePolicy or trivial
 // serial impl used)
-template <class AMatrix, class XVector, class YVector, int dobeta,
-          bool conjugate,
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int dobeta, bool conjugate,
           typename std::enable_if<!KokkosKernels::Impl::kk_is_gpu_exec_space<
-              typename AMatrix::execution_space>()>::type* = nullptr>
-static void spmv_beta_transpose(const typename AMatrix::execution_space& exec,
+              execution_space>()>::type* = nullptr>
+static void spmv_beta_transpose(const execution_space& exec,
                                 typename YVector::const_value_type& alpha,
                                 const AMatrix& A, const XVector& x,
                                 typename YVector::const_value_type& beta,
                                 const YVector& y) {
-  using ordinal_type    = typename AMatrix::non_const_ordinal_type;
-  using size_type       = typename AMatrix::non_const_size_type;
-  using execution_space = typename AMatrix::execution_space;
+  using ordinal_type = typename AMatrix::non_const_ordinal_type;
+  using size_type    = typename AMatrix::non_const_size_type;
 
   if (A.numRows() <= static_cast<ordinal_type>(0)) {
     return;
@@ -549,7 +545,9 @@ static void spmv_beta_transpose(const typename AMatrix::execution_space& exec,
   }
 #endif
 
-  typedef SPMV_Transpose_Functor<AMatrix, XVector, YVector, conjugate> OpType;
+  typedef SPMV_Transpose_Functor<execution_space, AMatrix, XVector, YVector,
+                                 conjugate>
+      OpType;
   typename AMatrix::const_ordinal_type nrow = A.numRows();
   Kokkos::parallel_for("KokkosSparse::spmv<Transpose>",
                        Kokkos::RangePolicy<execution_space>(exec, 0, nrow),
@@ -557,18 +555,17 @@ static void spmv_beta_transpose(const typename AMatrix::execution_space& exec,
 }
 
 // spmv_beta_transpose: version for GPU execution spaces (TeamPolicy used)
-template <class AMatrix, class XVector, class YVector, int dobeta,
-          bool conjugate,
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int dobeta, bool conjugate,
           typename std::enable_if<KokkosKernels::Impl::kk_is_gpu_exec_space<
-              typename AMatrix::execution_space>()>::type* = nullptr>
-static void spmv_beta_transpose(const typename AMatrix::execution_space& exec,
+              execution_space>()>::type* = nullptr>
+static void spmv_beta_transpose(const execution_space& exec,
                                 typename YVector::const_value_type& alpha,
                                 const AMatrix& A, const XVector& x,
                                 typename YVector::const_value_type& beta,
                                 const YVector& y) {
-  using ordinal_type    = typename AMatrix::non_const_ordinal_type;
-  using size_type       = typename AMatrix::non_const_size_type;
-  using execution_space = typename AMatrix::execution_space;
+  using ordinal_type = typename AMatrix::non_const_ordinal_type;
+  using size_type    = typename AMatrix::non_const_size_type;
 
   if (A.numRows() <= static_cast<ordinal_type>(0)) {
     return;
@@ -599,7 +596,9 @@ static void spmv_beta_transpose(const typename AMatrix::execution_space& exec,
          (vector_length < max_vector_length))
     vector_length *= 2;
 
-  typedef SPMV_Transpose_Functor<AMatrix, XVector, YVector, conjugate> OpType;
+  typedef SPMV_Transpose_Functor<execution_space, AMatrix, XVector, YVector,
+                                 conjugate>
+      OpType;
 
   typename AMatrix::const_ordinal_type nrow = A.numRows();
 
@@ -620,8 +619,9 @@ static void spmv_beta_transpose(const typename AMatrix::execution_space& exec,
                        op);
 }
 
-template <class AMatrix, class XVector, class YVector, int dobeta>
-static void spmv_beta(const typename AMatrix::execution_space& exec,
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int dobeta>
+static void spmv_beta(const execution_space& exec,
                       const KokkosKernels::Experimental::Controls& controls,
                       const char mode[],
                       typename YVector::const_value_type& alpha,
@@ -629,17 +629,17 @@ static void spmv_beta(const typename AMatrix::execution_space& exec,
                       typename YVector::const_value_type& beta,
                       const YVector& y) {
   if (mode[0] == NoTranspose[0]) {
-    spmv_beta_no_transpose<AMatrix, XVector, YVector, dobeta, false>(
-        exec, controls, alpha, A, x, beta, y);
+    spmv_beta_no_transpose<execution_space, AMatrix, XVector, YVector, dobeta,
+                           false>(exec, controls, alpha, A, x, beta, y);
   } else if (mode[0] == Conjugate[0]) {
-    spmv_beta_no_transpose<AMatrix, XVector, YVector, dobeta, true>(
-        exec, controls, alpha, A, x, beta, y);
+    spmv_beta_no_transpose<execution_space, AMatrix, XVector, YVector, dobeta,
+                           true>(exec, controls, alpha, A, x, beta, y);
   } else if (mode[0] == Transpose[0]) {
-    spmv_beta_transpose<AMatrix, XVector, YVector, dobeta, false>(
-        exec, alpha, A, x, beta, y);
+    spmv_beta_transpose<execution_space, AMatrix, XVector, YVector, dobeta,
+                        false>(exec, alpha, A, x, beta, y);
   } else if (mode[0] == ConjugateTranspose[0]) {
-    spmv_beta_transpose<AMatrix, XVector, YVector, dobeta, true>(exec, alpha, A,
-                                                                 x, beta, y);
+    spmv_beta_transpose<execution_space, AMatrix, XVector, YVector, dobeta,
+                        true>(exec, alpha, A, x, beta, y);
   } else {
     KokkosKernels::Impl::throw_runtime_exception(
         "Invalid Transpose Mode for KokkosSparse::spmv()");
@@ -649,10 +649,9 @@ static void spmv_beta(const typename AMatrix::execution_space& exec,
 // Functor for implementing transpose and conjugate transpose sparse
 // matrix-vector multiply with multivector (2-D View) input and
 // output.  This functor works, but is not necessarily performant.
-template <class AMatrix, class XVector, class YVector, int doalpha, int dobeta,
-          bool conjugate>
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int doalpha, int dobeta, bool conjugate>
 struct SPMV_MV_Transpose_Functor {
-  typedef typename AMatrix::execution_space execution_space;
   typedef typename AMatrix::non_const_ordinal_type ordinal_type;
   typedef typename AMatrix::non_const_value_type A_value_type;
   typedef typename YVector::non_const_value_type y_value_type;
@@ -755,10 +754,9 @@ struct SPMV_MV_Transpose_Functor {
   }
 };
 
-template <class AMatrix, class XVector, class YVector, int doalpha, int dobeta,
-          bool conjugate>
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int doalpha, int dobeta, bool conjugate>
 struct SPMV_MV_LayoutLeft_Functor {
-  typedef typename AMatrix::execution_space execution_space;
   typedef typename AMatrix::non_const_ordinal_type ordinal_type;
   typedef typename AMatrix::non_const_value_type A_value_type;
   typedef typename YVector::non_const_value_type y_value_type;
@@ -1156,12 +1154,12 @@ struct SPMV_MV_LayoutLeft_Functor {
 
 // spmv_alpha_beta_mv_no_transpose: version for CPU execution spaces
 // (RangePolicy)
-template <class AMatrix, class XVector, class YVector, int doalpha, int dobeta,
-          bool conjugate,
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int doalpha, int dobeta, bool conjugate,
           typename std::enable_if<!KokkosKernels::Impl::kk_is_gpu_exec_space<
-              typename AMatrix::execution_space>()>::type* = nullptr>
+              execution_space>()>::type* = nullptr>
 static void spmv_alpha_beta_mv_no_transpose(
-    const typename AMatrix::execution_space& exec,
+    const execution_space& exec,
     const typename YVector::non_const_value_type& alpha, const AMatrix& A,
     const XVector& x, const typename YVector::non_const_value_type& beta,
     const YVector& y) {
@@ -1185,49 +1183,45 @@ static void spmv_alpha_beta_mv_no_transpose(
 #ifndef KOKKOS_FAST_COMPILE  // This uses templated functions on doalpha and
                              // dobeta and will produce 16 kernels
 
-    typedef SPMV_MV_LayoutLeft_Functor<AMatrix, XVector, YVector, doalpha,
-                                       dobeta, conjugate>
+    typedef SPMV_MV_LayoutLeft_Functor<execution_space, AMatrix, XVector,
+                                       YVector, doalpha, dobeta, conjugate>
         OpType;
-    OpType op(alpha, A, x, beta, y,
-              RowsPerThread<typename AMatrix::execution_space>(NNZPerRow),
+    OpType op(alpha, A, x, beta, y, RowsPerThread<execution_space>(NNZPerRow),
               vector_length);
 
     typename AMatrix::const_ordinal_type nrow = A.numRows();
 
-    Kokkos::parallel_for(
-        "KokkosSparse::spmv<MV,NoTranspose>",
-        Kokkos::RangePolicy<typename AMatrix::execution_space>(exec, 0, nrow),
-        op);
+    Kokkos::parallel_for("KokkosSparse::spmv<MV,NoTranspose>",
+                         Kokkos::RangePolicy<execution_space>(exec, 0, nrow),
+                         op);
 
 #else   // KOKKOS_FAST_COMPILE this will only instantiate one Kernel for
         // alpha/beta
 
-    typedef SPMV_MV_LayoutLeft_Functor<AMatrix, XVector, YVector, 2, 2,
-                                       conjugate>
+    typedef SPMV_MV_LayoutLeft_Functor<execution_space, AMatrix, XVector,
+                                       YVector, 2, 2, conjugate>
         OpType;
 
     typename AMatrix::const_ordinal_type nrow = A.numRows();
 
-    OpType op(alpha, A, x, beta, y,
-              RowsPerThread<typename AMatrix::execution_space>(NNZPerRow),
+    OpType op(alpha, A, x, beta, y, RowsPerThread<execution_space>(NNZPerRow),
               vector_length);
 
-    Kokkos::parallel_for(
-        "KokkosSparse::spmv<MV,NoTranspose>",
-        Kokkos::RangePolicy<typename AMatrix::execution_space>(exec, 0, nrow),
-        op);
+    Kokkos::parallel_for("KokkosSparse::spmv<MV,NoTranspose>",
+                         Kokkos::RangePolicy<execution_space>(exec, 0, nrow),
+                         op);
 #endif  // KOKKOS_FAST_COMPILE
   }
 }
 
 // spmv_alpha_beta_mv_no_transpose: version for GPU execution spaces
 // (TeamPolicy)
-template <class AMatrix, class XVector, class YVector, int doalpha, int dobeta,
-          bool conjugate,
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int doalpha, int dobeta, bool conjugate,
           typename std::enable_if<KokkosKernels::Impl::kk_is_gpu_exec_space<
-              typename AMatrix::execution_space>()>::type* = nullptr>
+              execution_space>()>::type* = nullptr>
 static void spmv_alpha_beta_mv_no_transpose(
-    const typename AMatrix::execution_space& exec,
+    const execution_space& exec,
     const typename YVector::non_const_value_type& alpha, const AMatrix& A,
     const XVector& x, const typename YVector::non_const_value_type& beta,
     const YVector& y) {
@@ -1255,51 +1249,49 @@ static void spmv_alpha_beta_mv_no_transpose(
 #ifndef KOKKOS_FAST_COMPILE  // This uses templated functions on doalpha and
                              // dobeta and will produce 16 kernels
 
-    typedef SPMV_MV_LayoutLeft_Functor<AMatrix, XVector, YVector, doalpha,
-                                       dobeta, conjugate>
+    typedef SPMV_MV_LayoutLeft_Functor<execution_space, AMatrix, XVector,
+                                       YVector, doalpha, dobeta, conjugate>
         OpType;
-    OpType op(alpha, A, x, beta, y,
-              RowsPerThread<typename AMatrix::execution_space>(NNZPerRow),
+    OpType op(alpha, A, x, beta, y, RowsPerThread<execution_space>(NNZPerRow),
               vector_length);
 
     typename AMatrix::const_ordinal_type nrow = A.numRows();
 
     const ordinal_type rows_per_thread =
-        RowsPerThread<typename AMatrix::execution_space>(NNZPerRow);
+        RowsPerThread<execution_space>(NNZPerRow);
     const ordinal_type team_size =
-        Kokkos::TeamPolicy<typename AMatrix::execution_space>(
-            exec, rows_per_thread, Kokkos::AUTO, vector_length)
+        Kokkos::TeamPolicy<execution_space>(exec, rows_per_thread, Kokkos::AUTO,
+                                            vector_length)
             .team_size_recommended(op, Kokkos::ParallelForTag());
     const ordinal_type rows_per_team = rows_per_thread * team_size;
     const size_type nteams = (nrow + rows_per_team - 1) / rows_per_team;
     Kokkos::parallel_for("KokkosSparse::spmv<MV,NoTranspose>",
-                         Kokkos::TeamPolicy<typename AMatrix::execution_space>(
+                         Kokkos::TeamPolicy<execution_space>(
                              exec, nteams, team_size, vector_length),
                          op);
 
 #else   // KOKKOS_FAST_COMPILE this will only instantiate one Kernel for
         // alpha/beta
 
-    typedef SPMV_MV_LayoutLeft_Functor<AMatrix, XVector, YVector, 2, 2,
-                                       conjugate>
+    typedef SPMV_MV_LayoutLeft_Functor<execution_space, AMatrix, XVector,
+                                       YVector, 2, 2, conjugate>
         OpType;
 
     typename AMatrix::const_ordinal_type nrow = A.numRows();
 
-    OpType op(alpha, A, x, beta, y,
-              RowsPerThread<typename AMatrix::execution_space>(NNZPerRow),
+    OpType op(alpha, A, x, beta, y, RowsPerThread<execution_space>(NNZPerRow),
               vector_length);
 
     const ordinal_type rows_per_thread =
-        RowsPerThread<typename AMatrix::execution_space>(NNZPerRow);
+        RowsPerThread<execution_space>(NNZPerRow);
     const ordinal_type team_size =
-        Kokkos::TeamPolicy<typename AMatrix::execution_space>(
-            rows_per_thread, Kokkos::AUTO, vector_length)
+        Kokkos::TeamPolicy<execution_space>(exec, rows_per_thread, Kokkos::AUTO,
+                                            vector_length)
             .team_size_recommended(op, Kokkos::ParallelForTag());
     const ordinal_type rows_per_team = rows_per_thread * team_size;
     const size_type nteams = (nrow + rows_per_team - 1) / rows_per_team;
     Kokkos::parallel_for("KokkosSparse::spmv<MV,NoTranspose>",
-                         Kokkos::TeamPolicy<typename AMatrix::execution_space>(
+                         Kokkos::TeamPolicy<execution_space>(
                              exec, nteams, team_size, vector_length),
                          op);
 #endif  // KOKKOS_FAST_COMPILE
@@ -1307,12 +1299,12 @@ static void spmv_alpha_beta_mv_no_transpose(
 }
 
 // spmv_alpha_beta_mv_transpose: version for CPU execution spaces (RangePolicy)
-template <class AMatrix, class XVector, class YVector, int doalpha, int dobeta,
-          bool conjugate,
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int doalpha, int dobeta, bool conjugate,
           typename std::enable_if<!KokkosKernels::Impl::kk_is_gpu_exec_space<
-              typename AMatrix::execution_space>()>::type* = nullptr>
+              execution_space>()>::type* = nullptr>
 static void spmv_alpha_beta_mv_transpose(
-    const typename AMatrix::execution_space& exec,
+    const execution_space& exec,
     const typename YVector::non_const_value_type& alpha, const AMatrix& A,
     const XVector& x, const typename YVector::non_const_value_type& beta,
     const YVector& y) {
@@ -1332,41 +1324,39 @@ static void spmv_alpha_beta_mv_transpose(
 #ifndef KOKKOS_FAST_COMPILE  // This uses templated functions on doalpha and
                              // dobeta and will produce 16 kernels
 
-    typedef SPMV_MV_Transpose_Functor<AMatrix, XVector, YVector, doalpha,
-                                      dobeta, conjugate>
+    typedef SPMV_MV_Transpose_Functor<execution_space, AMatrix, XVector,
+                                      YVector, doalpha, dobeta, conjugate>
         OpType;
     OpType op(alpha, A, x, beta, y);
 
     const ordinal_type nrow = A.numRows();
-    Kokkos::parallel_for(
-        "KokkosSparse::spmv<MV,Transpose>",
-        Kokkos::RangePolicy<typename AMatrix::execution_space>(exec, 0, nrow),
-        op);
+    Kokkos::parallel_for("KokkosSparse::spmv<MV,Transpose>",
+                         Kokkos::RangePolicy<execution_space>(exec, 0, nrow),
+                         op);
 
 #else  // KOKKOS_FAST_COMPILE this will only instantiate one Kernel for
        // alpha/beta
 
-    typedef SPMV_MV_Transpose_Functor<AMatrix, XVector, YVector, 2, 2,
-                                      conjugate, SizeType>
+    typedef SPMV_MV_Transpose_Functor<execution_space, AMatrix, XVector,
+                                      YVector, 2, 2, conjugate, SizeType>
         OpType;
 
     typename AMatrix::const_ordinal_type nrow = A.numRows();
-    Kokkos::parallel_for(
-        "KokkosSparse::spmv<MV,Transpose>",
-        Kokkos::RangePolicy<typename AMatrix::execution_space>(exec, 0, nrow),
-        op);
+    Kokkos::parallel_for("KokkosSparse::spmv<MV,Transpose>",
+                         Kokkos::RangePolicy<execution_space>(exec, 0, nrow),
+                         op);
 
 #endif  // KOKKOS_FAST_COMPILE
   }
 }
 
 // spmv_alpha_beta_mv_transpose: version for GPU execution spaces (TeamPolicy)
-template <class AMatrix, class XVector, class YVector, int doalpha, int dobeta,
-          bool conjugate,
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int doalpha, int dobeta, bool conjugate,
           typename std::enable_if<KokkosKernels::Impl::kk_is_gpu_exec_space<
-              typename AMatrix::execution_space>()>::type* = nullptr>
+              execution_space>()>::type* = nullptr>
 static void spmv_alpha_beta_mv_transpose(
-    const typename AMatrix::execution_space& exec,
+    const execution_space& exec,
     const typename YVector::non_const_value_type& alpha, const AMatrix& A,
     const XVector& x, const typename YVector::non_const_value_type& beta,
     const YVector& y) {
@@ -1398,47 +1388,47 @@ static void spmv_alpha_beta_mv_transpose(
 #ifndef KOKKOS_FAST_COMPILE  // This uses templated functions on doalpha and
                              // dobeta and will produce 16 kernels
 
-    typedef SPMV_MV_Transpose_Functor<AMatrix, XVector, YVector, doalpha,
-                                      dobeta, conjugate>
+    typedef SPMV_MV_Transpose_Functor<execution_space, AMatrix, XVector,
+                                      YVector, doalpha, dobeta, conjugate>
         OpType;
     OpType op(alpha, A, x, beta, y);
 
     const ordinal_type nrow = A.numRows();
     const ordinal_type rows_per_thread =
-        RowsPerThread<typename AMatrix::execution_space>(NNZPerRow);
+        RowsPerThread<execution_space>(NNZPerRow);
     const ordinal_type team_size =
-        Kokkos::TeamPolicy<typename AMatrix::execution_space>(
-            rows_per_thread, Kokkos::AUTO, vector_length)
+        Kokkos::TeamPolicy<execution_space>(exec, rows_per_thread, Kokkos::AUTO,
+                                            vector_length)
             .team_size_recommended(op, Kokkos::ParallelForTag());
     const ordinal_type rows_per_team = rows_per_thread * team_size;
     op.rows_per_team                 = rows_per_team;
     const size_type nteams = (nrow + rows_per_team - 1) / rows_per_team;
     Kokkos::parallel_for("KokkosSparse::spmv<MV,Transpose>",
-                         Kokkos::TeamPolicy<typename AMatrix::execution_space>(
+                         Kokkos::TeamPolicy<execution_space>(
                              exec, nteams, team_size, vector_length),
                          op);
 
 #else  // KOKKOS_FAST_COMPILE this will only instantiate one Kernel for
        // alpha/beta
 
-    typedef SPMV_MV_Transpose_Functor<AMatrix, XVector, YVector, 2, 2,
-                                      conjugate, SizeType>
+    typedef SPMV_MV_Transpose_Functor<execution_space, AMatrix, XVector,
+                                      YVector, 2, 2, conjugate, SizeType>
         OpType;
 
     typename AMatrix::const_ordinal_type nrow = A.numRows();
     OpType op(alpha, A, x, beta, y);
 
     const ordinal_type rows_per_thread =
-        RowsPerThread<typename AMatrix::execution_space>(NNZPerRow);
+        RowsPerThread<execution_space>(NNZPerRow);
     const ordinal_type team_size =
-        Kokkos::TeamPolicy<typename AMatrix::execution_space>(
-            rows_per_thread, Kokkos::AUTO, vector_length)
+        Kokkos::TeamPolicy<execution_space>(exec, rows_per_thread, Kokkos::AUTO,
+                                            vector_length)
             .team_size_recommended(op, Kokkos::ParallelForTag());
     const ordinal_type rows_per_team = rows_per_thread * team_size;
     op.rows_per_team                 = rows_per_team;
     const size_type nteams = (nrow + rows_per_team - 1) / rows_per_team;
     Kokkos::parallel_for("KokkosSparse::spmv<MV,Transpose>",
-                         Kokkos::TeamPolicy<typename AMatrix::execution_space>(
+                         Kokkos::TeamPolicy<execution_space>(
                              exec, nteams, team_size, vector_length),
                          op);
 
@@ -1446,33 +1436,38 @@ static void spmv_alpha_beta_mv_transpose(
   }
 }
 
-template <class AMatrix, class XVector, class YVector, int doalpha, int dobeta>
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int doalpha, int dobeta>
 static void spmv_alpha_beta_mv(
-    const typename AMatrix::execution_space& exec, const char mode[],
+    const execution_space& exec, const char mode[],
     const typename YVector::non_const_value_type& alpha, const AMatrix& A,
     const XVector& x, const typename YVector::non_const_value_type& beta,
     const YVector& y) {
   if (mode[0] == NoTranspose[0]) {
-    spmv_alpha_beta_mv_no_transpose<AMatrix, XVector, YVector, doalpha, dobeta,
-                                    false>(exec, alpha, A, x, beta, y);
+    spmv_alpha_beta_mv_no_transpose<execution_space, AMatrix, XVector, YVector,
+                                    doalpha, dobeta, false>(exec, alpha, A, x,
+                                                            beta, y);
   } else if (mode[0] == Conjugate[0]) {
-    spmv_alpha_beta_mv_no_transpose<AMatrix, XVector, YVector, doalpha, dobeta,
-                                    true>(exec, alpha, A, x, beta, y);
+    spmv_alpha_beta_mv_no_transpose<execution_space, AMatrix, XVector, YVector,
+                                    doalpha, dobeta, true>(exec, alpha, A, x,
+                                                           beta, y);
   } else if (mode[0] == Transpose[0]) {
-    spmv_alpha_beta_mv_transpose<AMatrix, XVector, YVector, doalpha, dobeta,
-                                 false>(exec, alpha, A, x, beta, y);
+    spmv_alpha_beta_mv_transpose<execution_space, AMatrix, XVector, YVector,
+                                 doalpha, dobeta, false>(exec, alpha, A, x,
+                                                         beta, y);
   } else if (mode[0] == ConjugateTranspose[0]) {
-    spmv_alpha_beta_mv_transpose<AMatrix, XVector, YVector, doalpha, dobeta,
-                                 true>(exec, alpha, A, x, beta, y);
+    spmv_alpha_beta_mv_transpose<execution_space, AMatrix, XVector, YVector,
+                                 doalpha, dobeta, true>(exec, alpha, A, x, beta,
+                                                        y);
   } else {
     KokkosKernels::Impl::throw_runtime_exception(
         "Invalid Transpose Mode for KokkosSparse::spmv()");
   }
 }
 
-template <class AMatrix, class XVector, class YVector, int doalpha>
-void spmv_alpha_mv(const typename AMatrix::execution_space& exec,
-                   const char mode[],
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int doalpha>
+void spmv_alpha_mv(const execution_space& exec, const char mode[],
                    const typename YVector::non_const_value_type& alpha,
                    const AMatrix& A, const XVector& x,
                    const typename YVector::non_const_value_type& beta,
@@ -1481,17 +1476,17 @@ void spmv_alpha_mv(const typename AMatrix::execution_space& exec,
   typedef Kokkos::ArithTraits<coefficient_type> KAT;
 
   if (beta == KAT::zero()) {
-    spmv_alpha_beta_mv<AMatrix, XVector, YVector, doalpha, 0>(exec, mode, alpha,
-                                                              A, x, beta, y);
+    spmv_alpha_beta_mv<execution_space, AMatrix, XVector, YVector, doalpha, 0>(
+        exec, mode, alpha, A, x, beta, y);
   } else if (beta == KAT::one()) {
-    spmv_alpha_beta_mv<AMatrix, XVector, YVector, doalpha, 1>(exec, mode, alpha,
-                                                              A, x, beta, y);
+    spmv_alpha_beta_mv<execution_space, AMatrix, XVector, YVector, doalpha, 1>(
+        exec, mode, alpha, A, x, beta, y);
   } else if (beta == -KAT::one()) {
-    spmv_alpha_beta_mv<AMatrix, XVector, YVector, doalpha, -1>(
+    spmv_alpha_beta_mv<execution_space, AMatrix, XVector, YVector, doalpha, -1>(
         exec, mode, alpha, A, x, beta, y);
   } else {
-    spmv_alpha_beta_mv<AMatrix, XVector, YVector, doalpha, 2>(exec, mode, alpha,
-                                                              A, x, beta, y);
+    spmv_alpha_beta_mv<execution_space, AMatrix, XVector, YVector, doalpha, 2>(
+        exec, mode, alpha, A, x, beta, y);
   }
 }
 

--- a/sparse/impl/KokkosSparse_spmv_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_spec.hpp
@@ -30,15 +30,13 @@
 namespace KokkosSparse {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector>
 struct spmv_eti_spec_avail {
   enum : bool { value = false };
 };
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM,
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector,
           const bool integerScalarType =
-              std::is_integral<typename std::decay<AT>::type>::value>
+              std::is_integral_v<typename AMatrix::non_const_value_type>>
 struct spmv_mv_eti_spec_avail {
   enum : bool { value = false };
 };
@@ -46,38 +44,44 @@ struct spmv_mv_eti_spec_avail {
 }  // namespace Impl
 }  // namespace KokkosSparse
 
-#define KOKKOSSPARSE_SPMV_ETI_SPEC_AVAIL(SCALAR_TYPE, ORDINAL_TYPE,       \
-                                         OFFSET_TYPE, LAYOUT_TYPE,        \
-                                         EXEC_SPACE_TYPE, MEM_SPACE_TYPE) \
-  template <>                                                             \
-  struct spmv_eti_spec_avail<                                             \
-      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,             \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,         \
-      SCALAR_TYPE const*, LAYOUT_TYPE,                                    \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,     \
-      SCALAR_TYPE*, LAYOUT_TYPE,                                          \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> > {                         \
-    enum : bool { value = true };                                         \
+#define KOKKOSSPARSE_SPMV_ETI_SPEC_AVAIL(SCALAR_TYPE, ORDINAL_TYPE,            \
+                                         OFFSET_TYPE, LAYOUT_TYPE,             \
+                                         EXEC_SPACE_TYPE, MEM_SPACE_TYPE)      \
+  template <>                                                                  \
+  struct spmv_eti_spec_avail<                                                  \
+      EXEC_SPACE_TYPE,                                                         \
+      KokkosSparse::CrsMatrix<const SCALAR_TYPE, const ORDINAL_TYPE,           \
+                              Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,         \
+                              const OFFSET_TYPE>,                              \
+      Kokkos::View<                                                            \
+          SCALAR_TYPE const*, LAYOUT_TYPE,                                     \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                     \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR_TYPE*, LAYOUT_TYPE,                                  \
+                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                 \
+    enum : bool { value = true };                                              \
   };
 
-#define KOKKOSSPARSE_SPMV_MV_ETI_SPEC_AVAIL(SCALAR_TYPE, ORDINAL_TYPE,       \
-                                            OFFSET_TYPE, LAYOUT_TYPE,        \
-                                            EXEC_SPACE_TYPE, MEM_SPACE_TYPE) \
-  template <>                                                                \
-  struct spmv_mv_eti_spec_avail<                                             \
-      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,                \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                       \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,            \
-      SCALAR_TYPE const**, LAYOUT_TYPE,                                      \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                       \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,        \
-      SCALAR_TYPE**, LAYOUT_TYPE,                                            \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                       \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> > {                            \
-    enum : bool { value = true };                                            \
+#define KOKKOSSPARSE_SPMV_MV_ETI_SPEC_AVAIL(SCALAR_TYPE, ORDINAL_TYPE,         \
+                                            OFFSET_TYPE, LAYOUT_TYPE,          \
+                                            EXEC_SPACE_TYPE, MEM_SPACE_TYPE)   \
+  template <>                                                                  \
+  struct spmv_mv_eti_spec_avail<                                               \
+      EXEC_SPACE_TYPE,                                                         \
+      KokkosSparse::CrsMatrix<const SCALAR_TYPE, const ORDINAL_TYPE,           \
+                              Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,         \
+                              const OFFSET_TYPE>,                              \
+      Kokkos::View<                                                            \
+          SCALAR_TYPE const**, LAYOUT_TYPE,                                    \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                     \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR_TYPE**, LAYOUT_TYPE,                                 \
+                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                 \
+    enum : bool { value = true };                                              \
   };
 
 // Include the actual specialization declarations
@@ -94,33 +98,18 @@ namespace Impl {
 /// \brief Implementation of KokkosSparse::spmv (sparse matrix - dense
 ///   vector multiply) for single vectors (1-D Views).
 ///
-/// The first 5 template parameters are the same as those of
-/// KokkosSparse::CrsMatrix.  In particular:
-///
-/// AT: type of each entry of the sparse matrix
-/// AO: ordinal type (type of column indices) of the sparse matrix
-/// AS: offset type (type of row offsets) of the sparse matrix
-///
-/// The next 4 template parameters (that start with X) correspond to
-/// the input Kokkos::View.  The last 4 template parameters (that start
-/// with Y) correspond to the output Kokkos::View.
-///
 /// For the implementation of KokkosSparse::spmv for multivectors (2-D
 /// Views), see the SPMV_MV struct below.
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM,
-          bool tpl_spec_avail = spmv_tpl_spec_avail<
-              ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value,
-          bool eti_spec_avail = spmv_eti_spec_avail<
-              ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value>
+template <
+    class ExecutionSpace, class AMatrix, class XVector, class YVector,
+    bool tpl_spec_avail =
+        spmv_tpl_spec_avail<ExecutionSpace, AMatrix, XVector, YVector>::value,
+    bool eti_spec_avail =
+        spmv_eti_spec_avail<ExecutionSpace, AMatrix, XVector, YVector>::value>
 struct SPMV {
-  typedef CrsMatrix<AT, AO, AD, AM, AS> AMatrix;
-  typedef Kokkos::View<XT, XL, XD, XM> XVector;
-  typedef Kokkos::View<YT, YL, YD, YM> YVector;
-
   typedef typename YVector::non_const_value_type coefficient_type;
 
-  static void spmv(const ES& exec,
+  static void spmv(const ExecutionSpace& space,
                    const KokkosKernels::Experimental::Controls& controls,
                    const char mode[], const coefficient_type& alpha,
                    const AMatrix& A, const XVector& x,
@@ -147,39 +136,21 @@ struct SPMV {
 /// matrix, and Op(A) is either A itself, its transpose, or its
 /// conjugate transpose, depending on the 'mode' argument.
 ///
-/// The first 5 template parameters are the template parameters of the
-/// input 1-D View of coefficients 'alpha'.  The next 5 template
-/// parameters are the same as those of KokkosSparse::CrsMatrix. In
-/// particular:
-///
-/// AT: type of each entry of the sparse matrix
-/// AO: ordinal type (type of column indices) of the sparse matrix
-/// AS: offset type (type of row offsets) of the sparse matrix
-///
-/// The next 4 template parameters (that start with X) correspond to
-/// the input Kokkos::View.  The 4 template parameters after that
-/// (that start with lower-case b) are the template parameters of the
-/// input 1-D View of coefficients 'beta'.  Next, the 5 template
-/// parameters that start with Y correspond to the output
-/// Kokkos::View.  The last template parameter indicates whether the
+/// The last template parameter (integerScalarType) indicates whether the
 /// matrix's entries have integer type.  Per Github Issue #700, we
 /// don't optimize as heavily for that case, in order to reduce build
 /// times and library sizes.
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM,
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector,
           const bool integerScalarType =
-              std::is_integral<typename std::decay<AT>::type>::value,
-          bool tpl_spec_avail = spmv_mv_tpl_spec_avail<
-              ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value,
-          bool eti_spec_avail = spmv_mv_eti_spec_avail<
-              ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value>
+              std::is_integral_v<typename AMatrix::non_const_value_type>,
+          bool tpl_spec_avail = spmv_mv_tpl_spec_avail<ExecutionSpace, AMatrix,
+                                                       XVector, YVector>::value,
+          bool eti_spec_avail = spmv_mv_eti_spec_avail<ExecutionSpace, AMatrix,
+                                                       XVector, YVector>::value>
 struct SPMV_MV {
-  typedef CrsMatrix<AT, AO, AD, AM, AS> AMatrix;
-  typedef Kokkos::View<XT, XL, XD, XM> XVector;
-  typedef Kokkos::View<YT, YL, YD, YM> YVector;
   typedef typename YVector::non_const_value_type coefficient_type;
 
-  static void spmv_mv(const ES& exec,
+  static void spmv_mv(const ExecutionSpace& space,
                       const KokkosKernels::Experimental::Controls& controls,
                       const char mode[], const coefficient_type& alpha,
                       const AMatrix& A, const XVector& x,
@@ -189,16 +160,12 @@ struct SPMV_MV {
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 //! Full specialization of spmv for single vectors (1-D Views).
 // Unification layer
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
-struct SPMV<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM, false,
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector>
+struct SPMV<ExecutionSpace, AMatrix, XVector, YVector, false,
             KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
-  typedef CrsMatrix<AT, AO, AD, AM, AS> AMatrix;
-  typedef Kokkos::View<XT, XL, XD, XM> XVector;
-  typedef Kokkos::View<YT, YL, YD, YM> YVector;
   typedef typename YVector::non_const_value_type coefficient_type;
 
-  static void spmv(const ES& exec,
+  static void spmv(const ExecutionSpace& space,
                    const KokkosKernels::Experimental::Controls& controls,
                    const char mode[], const coefficient_type& alpha,
                    const AMatrix& A, const XVector& x,
@@ -207,39 +174,35 @@ struct SPMV<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM, false,
 
     if (alpha == KAT::zero()) {
       if (beta != KAT::one()) {
-        KokkosBlas::scal(exec, y, beta, y);
+        KokkosBlas::scal(space, y, beta, y);
       }
       return;
     }
 
     if (beta == KAT::zero()) {
-      spmv_beta<ES, AMatrix, XVector, YVector, 0>(exec, controls, mode, alpha,
-                                                  A, x, beta, y);
+      spmv_beta<ExecutionSpace, AMatrix, XVector, YVector, 0>(
+          space, controls, mode, alpha, A, x, beta, y);
     } else if (beta == KAT::one()) {
-      spmv_beta<ES, AMatrix, XVector, YVector, 1>(exec, controls, mode, alpha,
-                                                  A, x, beta, y);
+      spmv_beta<ExecutionSpace, AMatrix, XVector, YVector, 1>(
+          space, controls, mode, alpha, A, x, beta, y);
     } else if (beta == -KAT::one()) {
-      spmv_beta<ES, AMatrix, XVector, YVector, -1>(exec, controls, mode, alpha,
-                                                   A, x, beta, y);
+      spmv_beta<ExecutionSpace, AMatrix, XVector, YVector, -1>(
+          space, controls, mode, alpha, A, x, beta, y);
     } else {
-      spmv_beta<ES, AMatrix, XVector, YVector, 2>(exec, controls, mode, alpha,
-                                                  A, x, beta, y);
+      spmv_beta<ExecutionSpace, AMatrix, XVector, YVector, 2>(
+          space, controls, mode, alpha, A, x, beta, y);
     }
   }
 };
 
 //! Full specialization of spmv_mv for single vectors (2-D Views).
 // Unification layer
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
-struct SPMV_MV<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM, false,
-               false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
-  typedef CrsMatrix<AT, AO, AD, AM, AS> AMatrix;
-  typedef Kokkos::View<XT, XL, XD, XM> XVector;
-  typedef Kokkos::View<YT, YL, YD, YM> YVector;
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector>
+struct SPMV_MV<ExecutionSpace, AMatrix, XVector, YVector, false, false,
+               KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename YVector::non_const_value_type coefficient_type;
 
-  static void spmv_mv(const ES& exec,
+  static void spmv_mv(const ExecutionSpace& space,
                       const KokkosKernels::Experimental::Controls& /*controls*/,
                       const char mode[], const coefficient_type& alpha,
                       const AMatrix& A, const XVector& x,
@@ -247,45 +210,39 @@ struct SPMV_MV<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM, false,
     typedef Kokkos::ArithTraits<coefficient_type> KAT;
 
     if (alpha == KAT::zero()) {
-      spmv_alpha_mv<ES, AMatrix, XVector, YVector, 0>(exec, mode, alpha, A, x,
-                                                      beta, y);
+      spmv_alpha_mv<ExecutionSpace, AMatrix, XVector, YVector, 0>(
+          space, mode, alpha, A, x, beta, y);
     } else if (alpha == KAT::one()) {
-      spmv_alpha_mv<ES, AMatrix, XVector, YVector, 1>(exec, mode, alpha, A, x,
-                                                      beta, y);
+      spmv_alpha_mv<ExecutionSpace, AMatrix, XVector, YVector, 1>(
+          space, mode, alpha, A, x, beta, y);
     } else if (alpha == -KAT::one()) {
-      spmv_alpha_mv<ES, AMatrix, XVector, YVector, -1>(exec, mode, alpha, A, x,
-                                                       beta, y);
+      spmv_alpha_mv<ExecutionSpace, AMatrix, XVector, YVector, -1>(
+          space, mode, alpha, A, x, beta, y);
     } else {
-      spmv_alpha_mv<ES, AMatrix, XVector, YVector, 2>(exec, mode, alpha, A, x,
-                                                      beta, y);
+      spmv_alpha_mv<ExecutionSpace, AMatrix, XVector, YVector, 2>(
+          space, mode, alpha, A, x, beta, y);
     }
   }
 };
 
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
-struct SPMV_MV<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM, true,
-               false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
-  typedef CrsMatrix<AT, AO, AD, AM, AS> AMatrix;
-  typedef Kokkos::View<XT, XL, XD, XM> XVector;
-  typedef Kokkos::View<YT, YL, YD, YM> YVector;
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector>
+struct SPMV_MV<ExecutionSpace, AMatrix, XVector, YVector, true, false,
+               KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename YVector::non_const_value_type coefficient_type;
 
-  static void spmv_mv(const ES& exec,
+  static void spmv_mv(const ExecutionSpace& space,
                       const KokkosKernels::Experimental::Controls& /*controls*/,
                       const char mode[], const coefficient_type& alpha,
                       const AMatrix& A, const XVector& x,
                       const coefficient_type& beta, const YVector& y) {
-    static_assert(std::is_integral<AT>::value,
+    static_assert(std::is_integral_v<typename AMatrix::non_const_value_type>,
                   "This implementation is only for integer Scalar types.");
-    typedef SPMV<ES, AT, AO, AD, AM, AS, typename XVector::value_type*, XL, XD,
-                 XM, typename YVector::value_type*, YL, YD, YM>
-        impl_type;
+    typedef SPMV<ExecutionSpace, AMatrix, XVector, YVector> impl_type;
     KokkosKernels::Experimental::Controls defaultControls;
     for (typename AMatrix::non_const_size_type j = 0; j < x.extent(1); ++j) {
       auto x_j = Kokkos::subview(x, Kokkos::ALL(), j);
       auto y_j = Kokkos::subview(y, Kokkos::ALL(), j);
-      impl_type::spmv(exec, defaultControls, mode, alpha, A, x_j, beta, y_j);
+      impl_type::spmv(space, defaultControls, mode, alpha, A, x_j, beta, y_j);
     }
   }
 };
@@ -301,65 +258,77 @@ struct SPMV_MV<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM, true,
 // We may spread out definitions (see _DEF macro below) across one or
 // more .cpp files.
 //
-#define KOKKOSSPARSE_SPMV_ETI_SPEC_DECL(SCALAR_TYPE, ORDINAL_TYPE,       \
-                                        OFFSET_TYPE, LAYOUT_TYPE,        \
-                                        EXEC_SPACE_TYPE, MEM_SPACE_TYPE) \
-  extern template struct SPMV<                                           \
-      const SCALAR_TYPE, const ORDINAL_TYPE,                             \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                   \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,        \
-      SCALAR_TYPE const*, LAYOUT_TYPE,                                   \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                   \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,    \
-      SCALAR_TYPE*, LAYOUT_TYPE,                                         \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                   \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, false, true>;
+#define KOKKOSSPARSE_SPMV_ETI_SPEC_DECL(SCALAR_TYPE, ORDINAL_TYPE,             \
+                                        OFFSET_TYPE, LAYOUT_TYPE,              \
+                                        EXEC_SPACE_TYPE, MEM_SPACE_TYPE)       \
+  extern template struct SPMV<                                                 \
+      EXEC_SPACE_TYPE,                                                         \
+      KokkosSparse::CrsMatrix<const SCALAR_TYPE, const ORDINAL_TYPE,           \
+                              Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,         \
+                              const OFFSET_TYPE>,                              \
+      Kokkos::View<                                                            \
+          SCALAR_TYPE const*, LAYOUT_TYPE,                                     \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                     \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR_TYPE*, LAYOUT_TYPE,                                  \
+                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
+      false, true>;
 
-#define KOKKOSSPARSE_SPMV_ETI_SPEC_INST(SCALAR_TYPE, ORDINAL_TYPE,       \
-                                        OFFSET_TYPE, LAYOUT_TYPE,        \
-                                        EXEC_SPACE_TYPE, MEM_SPACE_TYPE) \
-  template struct SPMV<                                                  \
-      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,            \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                   \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,        \
-      SCALAR_TYPE const*, LAYOUT_TYPE,                                   \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                   \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,    \
-      SCALAR_TYPE*, LAYOUT_TYPE,                                         \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                   \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, false, true>;
+#define KOKKOSSPARSE_SPMV_ETI_SPEC_INST(SCALAR_TYPE, ORDINAL_TYPE,             \
+                                        OFFSET_TYPE, LAYOUT_TYPE,              \
+                                        EXEC_SPACE_TYPE, MEM_SPACE_TYPE)       \
+  template struct SPMV<                                                        \
+      EXEC_SPACE_TYPE,                                                         \
+      KokkosSparse::CrsMatrix<const SCALAR_TYPE, const ORDINAL_TYPE,           \
+                              Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,         \
+                              const OFFSET_TYPE>,                              \
+      Kokkos::View<                                                            \
+          SCALAR_TYPE const*, LAYOUT_TYPE,                                     \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                     \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR_TYPE*, LAYOUT_TYPE,                                  \
+                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
+      false, true>;
 
-#define KOKKOSSPARSE_SPMV_MV_ETI_SPEC_DECL(SCALAR_TYPE, ORDINAL_TYPE,         \
-                                           OFFSET_TYPE, LAYOUT_TYPE,          \
-                                           EXEC_SPACE_TYPE, MEM_SPACE_TYPE)   \
-  extern template struct SPMV_MV<                                             \
-      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,                 \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,             \
-      SCALAR_TYPE const**, LAYOUT_TYPE,                                       \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,         \
-      SCALAR_TYPE**, LAYOUT_TYPE,                                             \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>,                                \
-      std::is_integral<typename std::decay<SCALAR_TYPE>::type>::value, false, \
-      true>;
+#define KOKKOSSPARSE_SPMV_MV_ETI_SPEC_DECL(SCALAR_TYPE, ORDINAL_TYPE,          \
+                                           OFFSET_TYPE, LAYOUT_TYPE,           \
+                                           EXEC_SPACE_TYPE, MEM_SPACE_TYPE)    \
+  extern template struct SPMV_MV<                                              \
+      EXEC_SPACE_TYPE,                                                         \
+      KokkosSparse::CrsMatrix<const SCALAR_TYPE, const ORDINAL_TYPE,           \
+                              Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,         \
+                              const OFFSET_TYPE>,                              \
+      Kokkos::View<                                                            \
+          SCALAR_TYPE const**, LAYOUT_TYPE,                                    \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                     \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR_TYPE**, LAYOUT_TYPE,                                 \
+                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
+      std::is_integral_v<SCALAR_TYPE>, false, true>;
 
-#define KOKKOSSPARSE_SPMV_MV_ETI_SPEC_INST(SCALAR_TYPE, ORDINAL_TYPE,         \
-                                           OFFSET_TYPE, LAYOUT_TYPE,          \
-                                           EXEC_SPACE_TYPE, MEM_SPACE_TYPE)   \
-  template struct SPMV_MV<                                                    \
-      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,                 \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,             \
-      SCALAR_TYPE const**, LAYOUT_TYPE,                                       \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,         \
-      SCALAR_TYPE**, LAYOUT_TYPE,                                             \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>,                                \
-      std::is_integral<typename std::decay<SCALAR_TYPE>::type>::value, false, \
-      true>;
+#define KOKKOSSPARSE_SPMV_MV_ETI_SPEC_INST(SCALAR_TYPE, ORDINAL_TYPE,          \
+                                           OFFSET_TYPE, LAYOUT_TYPE,           \
+                                           EXEC_SPACE_TYPE, MEM_SPACE_TYPE)    \
+  template struct SPMV_MV<                                                     \
+      EXEC_SPACE_TYPE,                                                         \
+      KokkosSparse::CrsMatrix<const SCALAR_TYPE, const ORDINAL_TYPE,           \
+                              Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,         \
+                              const OFFSET_TYPE>,                              \
+      Kokkos::View<                                                            \
+          SCALAR_TYPE const**, LAYOUT_TYPE,                                    \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                     \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR_TYPE**, LAYOUT_TYPE,                                 \
+                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
+      std::is_integral_v<SCALAR_TYPE>, false, true>;
 
 #include <KokkosSparse_spmv_tpl_spec_decl.hpp>
 

--- a/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
+++ b/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
@@ -29,10 +29,9 @@ namespace Impl {
 enum { FD, FE };
 
 // This TransposeFunctor is functional, but not necessarily performant.
-template <class AMatrix, class XVector, class YVector, int dobeta,
-          bool conjugate>
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int dobeta, bool conjugate>
 struct SPMV_Struct_Transpose_Functor {
-  typedef typename AMatrix::execution_space execution_space;
   typedef typename AMatrix::non_const_ordinal_type ordinal_type;
   typedef typename AMatrix::non_const_value_type value_type;
   typedef typename Kokkos::TeamPolicy<execution_space> team_policy;
@@ -91,13 +90,12 @@ struct SPMV_Struct_Transpose_Functor {
   }
 };
 
-template <class AMatrix, class XVector, class YVector, int dobeta,
-          bool conjugate>
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int dobeta, bool conjugate>
 struct SPMV_Struct_Functor {
   typedef typename AMatrix::non_const_size_type size_type;
   typedef typename AMatrix::non_const_ordinal_type ordinal_type;
   typedef typename AMatrix::non_const_value_type value_type;
-  typedef typename AMatrix::execution_space execution_space;
   typedef typename execution_space::scratch_memory_space scratch_space;
   typedef typename KokkosSparse::SparseRowViewConst<AMatrix> row_view_const;
   typedef typename Kokkos::TeamPolicy<execution_space> team_policy;
@@ -164,8 +162,8 @@ struct SPMV_Struct_Functor {
     }
   }
 
-  void compute_interior(const int64_t worksets, const int team_size,
-                        const int vector_length) {
+  void compute_interior(const execution_space& exec, const int64_t worksets,
+                        const int team_size, const int vector_length) {
     if (numDimensions == 1) {
       // Treat interior points using structured algorithm
       numInterior = ni - 2;
@@ -173,16 +171,16 @@ struct SPMV_Struct_Functor {
         size_t shared_size = shared_ordinal_1d::shmem_size(3);
         Kokkos::TeamPolicy<interior3ptTag, execution_space,
                            Kokkos::Schedule<Kokkos::Static> >
-            policy(1, 1);
+            policy(exec, 1, 1);
         if (team_size < 0) {
           policy = Kokkos::TeamPolicy<interior3ptTag, execution_space,
                                       Kokkos::Schedule<Kokkos::Static> >(
-                       worksets, Kokkos::AUTO, vector_length)
+                       exec, worksets, Kokkos::AUTO, vector_length)
                        .set_scratch_size(0, Kokkos::PerTeam(shared_size));
         } else {
           policy = Kokkos::TeamPolicy<interior3ptTag, execution_space,
                                       Kokkos::Schedule<Kokkos::Static> >(
-                       worksets, team_size, vector_length)
+                       exec, worksets, team_size, vector_length)
                        .set_scratch_size(0, Kokkos::PerTeam(shared_size));
         }
         Kokkos::parallel_for(
@@ -198,16 +196,16 @@ struct SPMV_Struct_Functor {
           size_t shared_size = shared_ordinal_1d::shmem_size(5);
           Kokkos::TeamPolicy<interior5ptTag, execution_space,
                              Kokkos::Schedule<Kokkos::Static> >
-              policy(1, 1);
+              policy(exec, 1, 1);
           if (team_size < 0) {
             policy = Kokkos::TeamPolicy<interior5ptTag, execution_space,
                                         Kokkos::Schedule<Kokkos::Static> >(
-                         worksets, Kokkos::AUTO, vector_length)
+                         exec, worksets, Kokkos::AUTO, vector_length)
                          .set_scratch_size(0, Kokkos::PerTeam(shared_size));
           } else {
             policy = Kokkos::TeamPolicy<interior5ptTag, execution_space,
                                         Kokkos::Schedule<Kokkos::Static> >(
-                         worksets, team_size, vector_length)
+                         exec, worksets, team_size, vector_length)
                          .set_scratch_size(0, Kokkos::PerTeam(shared_size));
           }
           Kokkos::parallel_for(
@@ -217,16 +215,16 @@ struct SPMV_Struct_Functor {
           size_t shared_size = shared_ordinal_1d::shmem_size(9);
           Kokkos::TeamPolicy<interior9ptTag, execution_space,
                              Kokkos::Schedule<Kokkos::Static> >
-              policy(1, 1);
+              policy(exec, 1, 1);
           if (team_size < 0) {
             policy = Kokkos::TeamPolicy<interior9ptTag, execution_space,
                                         Kokkos::Schedule<Kokkos::Static> >(
-                         worksets, Kokkos::AUTO, vector_length)
+                         exec, worksets, Kokkos::AUTO, vector_length)
                          .set_scratch_size(0, Kokkos::PerTeam(shared_size));
           } else {
             policy = Kokkos::TeamPolicy<interior9ptTag, execution_space,
                                         Kokkos::Schedule<Kokkos::Static> >(
-                         worksets, team_size, vector_length)
+                         exec, worksets, team_size, vector_length)
                          .set_scratch_size(0, Kokkos::PerTeam(shared_size));
           }
           Kokkos::parallel_for(
@@ -243,16 +241,16 @@ struct SPMV_Struct_Functor {
           size_t shared_size = shared_ordinal_1d::shmem_size(7);
           Kokkos::TeamPolicy<interior7ptTag, execution_space,
                              Kokkos::Schedule<Kokkos::Static> >
-              policy(1, 1);
+              policy(exec, 1, 1);
           if (team_size < 0) {
             policy = Kokkos::TeamPolicy<interior7ptTag, execution_space,
                                         Kokkos::Schedule<Kokkos::Static> >(
-                         worksets, Kokkos::AUTO, vector_length)
+                         exec, worksets, Kokkos::AUTO, vector_length)
                          .set_scratch_size(0, Kokkos::PerTeam(shared_size));
           } else {
             policy = Kokkos::TeamPolicy<interior7ptTag, execution_space,
                                         Kokkos::Schedule<Kokkos::Static> >(
-                         worksets, team_size, vector_length)
+                         exec, worksets, team_size, vector_length)
                          .set_scratch_size(0, Kokkos::PerTeam(shared_size));
           }
           Kokkos::parallel_for(
@@ -262,16 +260,16 @@ struct SPMV_Struct_Functor {
           size_t shared_size = shared_ordinal_1d::shmem_size(27);
           Kokkos::TeamPolicy<interior27ptTag, execution_space,
                              Kokkos::Schedule<Kokkos::Static> >
-              policy(1, 1);
+              policy(exec, 1, 1);
           if (team_size < 0) {
             policy = Kokkos::TeamPolicy<interior27ptTag, execution_space,
                                         Kokkos::Schedule<Kokkos::Static> >(
-                         worksets, Kokkos::AUTO, vector_length)
+                         exec, worksets, Kokkos::AUTO, vector_length)
                          .set_scratch_size(0, Kokkos::PerTeam(shared_size));
           } else {
             policy = Kokkos::TeamPolicy<interior27ptTag, execution_space,
                                         Kokkos::Schedule<Kokkos::Static> >(
-                         worksets, team_size, vector_length)
+                         exec, worksets, team_size, vector_length)
                          .set_scratch_size(0, Kokkos::PerTeam(shared_size));
           }
           Kokkos::parallel_for(
@@ -548,15 +546,15 @@ struct SPMV_Struct_Functor {
         });
   }
 
-  void compute_exterior(const int64_t worksets, const int team_size,
-                        const int vector_length) {
+  void compute_exterior(const execution_space& exec, const int64_t worksets,
+                        const int team_size, const int vector_length) {
     // Treat exterior points using unstructured algorithm
     if (numDimensions == 1) {
       numExterior = 2;
       if (numExterior > 0) {
         Kokkos::RangePolicy<exterior1DTag, execution_space,
                             Kokkos::Schedule<Kokkos::Static> >
-            policy(0, numExterior);
+            policy(exec, 0, numExterior);
         Kokkos::parallel_for(
             "KokkosSparse::spmv_struct<NoTranspose,Static>: exterior", policy,
             *this);
@@ -567,15 +565,15 @@ struct SPMV_Struct_Functor {
       if (numExterior > 0) {
         Kokkos::TeamPolicy<exterior2DTag, execution_space,
                            Kokkos::Schedule<Kokkos::Static> >
-            policy(1, 1);
+            policy(exec, 1, 1);
         if (team_size < 0) {
           policy = Kokkos::TeamPolicy<exterior2DTag, execution_space,
                                       Kokkos::Schedule<Kokkos::Static> >(
-              worksets, Kokkos::AUTO, vector_length);
+              exec, worksets, Kokkos::AUTO, vector_length);
         } else {
           policy = Kokkos::TeamPolicy<exterior2DTag, execution_space,
                                       Kokkos::Schedule<Kokkos::Static> >(
-              worksets, team_size, vector_length);
+              exec, worksets, team_size, vector_length);
         }
         Kokkos::parallel_for(
             "KokkosSparse::spmv_struct<NoTranspose,Static>: exterior", policy,
@@ -587,15 +585,15 @@ struct SPMV_Struct_Functor {
       if (numExterior > 0) {
         Kokkos::TeamPolicy<exterior3DTag, execution_space,
                            Kokkos::Schedule<Kokkos::Static> >
-            policy(1, 1);
+            policy(exec, 1, 1);
         if (team_size < 0) {
           policy = Kokkos::TeamPolicy<exterior3DTag, execution_space,
                                       Kokkos::Schedule<Kokkos::Static> >(
-              worksets, Kokkos::AUTO, vector_length);
+              exec, worksets, Kokkos::AUTO, vector_length);
         } else {
           policy = Kokkos::TeamPolicy<exterior3DTag, execution_space,
                                       Kokkos::Schedule<Kokkos::Static> >(
-              worksets, team_size, vector_length);
+              exec, worksets, team_size, vector_length);
         }
 
         Kokkos::parallel_for(
@@ -773,17 +771,16 @@ int64_t spmv_struct_launch_parameters(int64_t numInterior, int64_t nnz,
   return rows_per_team;
 }  // spmv_struct_launch_parameters
 
-template <class AMatrix, class XVector, class YVector, int dobeta,
-          bool conjugate>
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int dobeta, bool conjugate>
 static void spmv_struct_beta_no_transpose(
-    const int stencil_type,
+    const execution_space& exec, const int stencil_type,
     const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                        Kokkos::HostSpace>& structure,
     typename YVector::const_value_type& alpha, const AMatrix& A,
     const XVector& x, typename YVector::const_value_type& beta,
     const YVector& y) {
   typedef typename AMatrix::ordinal_type ordinal_type;
-  typedef typename AMatrix::execution_space execution_space;
   if (A.numRows() <= static_cast<ordinal_type>(0)) {
     return;
   }
@@ -833,18 +830,21 @@ static void spmv_struct_beta_no_transpose(
   int64_t worksets_exterior =
       (numExteriorPts + rows_per_team_ext - 1) / rows_per_team_ext;
 
-  SPMV_Struct_Functor<AMatrix, XVector, YVector, dobeta, conjugate> spmv_struct(
-      structure, stencil_type, alpha, A, x, beta, y, rows_per_team_int,
-      rows_per_team_ext);
+  SPMV_Struct_Functor<execution_space, AMatrix, XVector, YVector, dobeta,
+                      conjugate>
+      spmv_struct(structure, stencil_type, alpha, A, x, beta, y,
+                  rows_per_team_int, rows_per_team_ext);
 
-  spmv_struct.compute_interior(worksets_interior, team_size_int, vector_length);
-  spmv_struct.compute_exterior(worksets_exterior, team_size_ext, vector_length);
+  spmv_struct.compute_interior(exec, worksets_interior, team_size_int,
+                               vector_length);
+  spmv_struct.compute_exterior(exec, worksets_exterior, team_size_ext,
+                               vector_length);
 }  // spmv_struct_beta_no_transpose
 
-template <class AMatrix, class XVector, class YVector, int dobeta,
-          bool conjugate>
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int dobeta, bool conjugate>
 static void spmv_struct_beta_transpose(
-    const int /*stencil_type*/,
+    const execution_space& exec, const int /*stencil_type*/,
     const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                        Kokkos::HostSpace>& /*structure*/,
     typename YVector::const_value_type& alpha, const AMatrix& A,
@@ -859,7 +859,7 @@ static void spmv_struct_beta_transpose(
   // We need to scale y first ("scaling" by zero just means filling
   // with zeros), since the functor works by atomic-adding into y.
   if (dobeta != 1) {
-    KokkosBlas::scal(y, beta, y);
+    KokkosBlas::scal(exec, y, beta, y);
   }
 
   typedef typename AMatrix::size_type size_type;
@@ -875,49 +875,52 @@ static void spmv_struct_beta_transpose(
          (vector_length < 32))
     vector_length *= 2;
 
-  typedef SPMV_Struct_Transpose_Functor<AMatrix, XVector, YVector, dobeta,
-                                        conjugate>
+  typedef SPMV_Struct_Transpose_Functor<execution_space, AMatrix, XVector,
+                                        YVector, dobeta, conjugate>
       OpType;
 
   typename AMatrix::const_ordinal_type nrow = A.numRows();
 
-  OpType op(alpha, A, x, beta, y,
-            RowsPerThread<typename AMatrix::execution_space>(NNZPerRow));
+  OpType op(alpha, A, x, beta, y, RowsPerThread<execution_space>(NNZPerRow));
 
-  const int rows_per_thread =
-      RowsPerThread<typename AMatrix::execution_space>(NNZPerRow);
+  const int rows_per_thread = RowsPerThread<execution_space>(NNZPerRow);
   const int team_size =
-      Kokkos::TeamPolicy<typename AMatrix::execution_space>(
-          rows_per_thread, Kokkos::AUTO, vector_length)
+      Kokkos::TeamPolicy<execution_space>(rows_per_thread, Kokkos::AUTO,
+                                          vector_length)
           .team_size_recommended(op, Kokkos::ParallelForTag());
   const int rows_per_team = rows_per_thread * team_size;
   const size_type nteams  = (nrow + rows_per_team - 1) / rows_per_team;
   Kokkos::parallel_for("KokkosSparse::spmv_struct<Transpose>",
-                       Kokkos::TeamPolicy<typename AMatrix::execution_space>(
-                           nteams, team_size, vector_length),
+                       Kokkos::TeamPolicy<execution_space>(
+                           exec, nteams, team_size, vector_length),
                        op);
 }
 
-template <class AMatrix, class XVector, class YVector, int dobeta>
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int dobeta>
 static void spmv_struct_beta(
-    const char mode[], const int stencil_type,
+    const execution_space& exec, const char mode[], const int stencil_type,
     const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                        Kokkos::HostSpace>& structure,
     typename YVector::const_value_type& alpha, const AMatrix& A,
     const XVector& x, typename YVector::const_value_type& beta,
     const YVector& y) {
   if (mode[0] == NoTranspose[0]) {
-    spmv_struct_beta_no_transpose<AMatrix, XVector, YVector, dobeta, false>(
-        stencil_type, structure, alpha, A, x, beta, y);
+    spmv_struct_beta_no_transpose<execution_space, AMatrix, XVector, YVector,
+                                  dobeta, false>(exec, stencil_type, structure,
+                                                 alpha, A, x, beta, y);
   } else if (mode[0] == Conjugate[0]) {
-    spmv_struct_beta_no_transpose<AMatrix, XVector, YVector, dobeta, true>(
-        stencil_type, structure, alpha, A, x, beta, y);
+    spmv_struct_beta_no_transpose<execution_space, AMatrix, XVector, YVector,
+                                  dobeta, true>(exec, stencil_type, structure,
+                                                alpha, A, x, beta, y);
   } else if (mode[0] == Transpose[0]) {
-    spmv_struct_beta_transpose<AMatrix, XVector, YVector, dobeta, false>(
-        stencil_type, structure, alpha, A, x, beta, y);
+    spmv_struct_beta_transpose<execution_space, AMatrix, XVector, YVector,
+                               dobeta, false>(exec, stencil_type, structure,
+                                              alpha, A, x, beta, y);
   } else if (mode[0] == ConjugateTranspose[0]) {
-    spmv_struct_beta_transpose<AMatrix, XVector, YVector, dobeta, true>(
-        stencil_type, structure, alpha, A, x, beta, y);
+    spmv_struct_beta_transpose<execution_space, AMatrix, XVector, YVector,
+                               dobeta, true>(exec, stencil_type, structure,
+                                             alpha, A, x, beta, y);
   } else {
     KokkosKernels::Impl::throw_runtime_exception(
         "Invalid Transpose Mode for KokkosSparse::spmv_struct()");
@@ -927,10 +930,9 @@ static void spmv_struct_beta(
 // Functor for implementing transpose and conjugate transpose sparse
 // matrix-vector multiply with multivector (2-D View) input and
 // output.  This functor works, but is not necessarily performant.
-template <class AMatrix, class XVector, class YVector, int doalpha, int dobeta,
-          bool conjugate>
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int doalpha, int dobeta, bool conjugate>
 struct SPMV_MV_Struct_Transpose_Functor {
-  typedef typename AMatrix::execution_space execution_space;
   typedef typename AMatrix::non_const_ordinal_type ordinal_type;
   typedef typename AMatrix::non_const_value_type A_value_type;
   typedef typename YVector::non_const_value_type y_value_type;
@@ -1007,10 +1009,9 @@ struct SPMV_MV_Struct_Transpose_Functor {
   }
 };
 
-template <class AMatrix, class XVector, class YVector, int doalpha, int dobeta,
-          bool conjugate>
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int doalpha, int dobeta, bool conjugate>
 struct SPMV_MV_Struct_LayoutLeft_Functor {
-  typedef typename AMatrix::execution_space execution_space;
   typedef typename AMatrix::non_const_ordinal_type ordinal_type;
   typedef typename AMatrix::non_const_value_type A_value_type;
   typedef typename YVector::non_const_value_type y_value_type;
@@ -1245,9 +1246,10 @@ struct SPMV_MV_Struct_LayoutLeft_Functor {
   }
 };
 
-template <class AMatrix, class XVector, class YVector, int doalpha, int dobeta,
-          bool conjugate>
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int doalpha, int dobeta, bool conjugate>
 static void spmv_alpha_beta_mv_struct_no_transpose(
+    const execution_space& exec,
     const typename YVector::non_const_value_type& alpha, const AMatrix& A,
     const XVector& x, const typename YVector::non_const_value_type& beta,
     const YVector& y) {
@@ -1258,7 +1260,7 @@ static void spmv_alpha_beta_mv_struct_no_transpose(
   }
   if (doalpha == 0) {
     if (dobeta != 1) {
-      KokkosBlas::scal(y, beta, y);
+      KokkosBlas::scal(exec, y, beta, y);
     }
     return;
   } else {
@@ -1278,11 +1280,10 @@ static void spmv_alpha_beta_mv_struct_no_transpose(
 #ifndef KOKKOS_FAST_COMPILE  // This uses templated functions on doalpha and
                              // dobeta and will produce 16 kernels
 
-    typedef SPMV_MV_Struct_LayoutLeft_Functor<AMatrix, XVector, YVector,
-                                              doalpha, dobeta, conjugate>
+    typedef SPMV_MV_Struct_LayoutLeft_Functor<
+        execution_space, AMatrix, XVector, YVector, doalpha, dobeta, conjugate>
         OpType;
-    OpType op(alpha, A, x, beta, y,
-              RowsPerThread<typename AMatrix::execution_space>(NNZPerRow),
+    OpType op(alpha, A, x, beta, y, RowsPerThread<execution_space>(NNZPerRow),
               vector_length);
 
     typename AMatrix::const_ordinal_type nrow = A.numRows();
@@ -1292,30 +1293,28 @@ static void spmv_alpha_beta_mv_struct_no_transpose(
     // then this is just the number of rows.  Ditto for rows_per_team.
     // team_size is a hardware resource thing so it might legitimately
     // be int.
-    const int rows_per_thread =
-        RowsPerThread<typename AMatrix::execution_space>(NNZPerRow);
+    const int rows_per_thread = RowsPerThread<execution_space>(NNZPerRow);
     const int team_size =
-        Kokkos::TeamPolicy<typename AMatrix::execution_space>(
-            rows_per_thread, Kokkos::AUTO, vector_length)
+        Kokkos::TeamPolicy<execution_space>(exec, rows_per_thread, Kokkos::AUTO,
+                                            vector_length)
             .team_size_recommended(op, Kokkos::ParallelForTag());
     const int rows_per_team = rows_per_thread * team_size;
     const size_type nteams  = (nrow + rows_per_team - 1) / rows_per_team;
     Kokkos::parallel_for("KokkosSparse::spmv_struct<MV,NoTranspose>",
-                         Kokkos::TeamPolicy<typename AMatrix::execution_space>(
-                             nteams, team_size, vector_length),
+                         Kokkos::TeamPolicy<execution_space>(
+                             exec, nteams, team_size, vector_length),
                          op);
 
 #else   // KOKKOS_FAST_COMPILE this will only instantiate one Kernel for
         // alpha/beta
 
-    typedef SPMV_MV_Struct_LayoutLeft_Functor<AMatrix, XVector, YVector, 2, 2,
-                                              conjugate>
+    typedef SPMV_MV_Struct_LayoutLeft_Functor<execution_space, AMatrix, XVector,
+                                              YVector, 2, 2, conjugate>
         OpType;
 
     typename AMatrix::const_ordinal_type nrow = A.numRows();
 
-    OpType op(alpha, A, x, beta, y,
-              RowsPerThread<typename AMatrix::execution_space>(NNZPerRow),
+    OpType op(alpha, A, x, beta, y, RowsPerThread<execution_space>(NNZPerRow),
               vector_length);
 
     // FIXME (mfh 07 Jun 2016) Shouldn't we use ordinal_type here
@@ -1323,25 +1322,25 @@ static void spmv_alpha_beta_mv_struct_no_transpose(
     // then this is just the number of rows.  Ditto for rows_per_team.
     // team_size is a hardware resource thing so it might legitimately
     // be int.
-    const int rows_per_thread =
-        RowsPerThread<typename AMatrix::execution_space>(NNZPerRow);
+    const int rows_per_thread = RowsPerThread<execution_space>(NNZPerRow);
     const int team_size =
-        Kokkos::TeamPolicy<typename AMatrix::execution_space>(
-            rows_per_thread, Kokkos::AUTO, vector_length)
+        Kokkos::TeamPolicy<execution_space>(exec, rows_per_thread, Kokkos::AUTO,
+                                            vector_length)
             .team_size_recommended(op, Kokkos::ParallelForTag());
     const int rows_per_team = rows_per_thread * team_size;
     const size_type nteams = (nrow + rows_per_team - 1) / rows_per_team;
     Kokkos::parallel_for("KokkosSparse::spmv_struct<MV,NoTranspose>",
-                         Kokkos::TeamPolicy<typename AMatrix::execution_space>(
-                             nteams, team_size, vector_length),
+                         Kokkos::TeamPolicy<execution_space>(
+                             exec, nteams, team_size, vector_length),
                          op);
 #endif  // KOKKOS_FAST_COMPILE
   }
 }
 
-template <class AMatrix, class XVector, class YVector, int doalpha, int dobeta,
-          bool conjugate>
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int doalpha, int dobeta, bool conjugate>
 static void spmv_alpha_beta_mv_struct_transpose(
+    const execution_space& exec,
     const typename YVector::non_const_value_type& alpha, const AMatrix& A,
     const XVector& x, const typename YVector::non_const_value_type& beta,
     const YVector& y) {
@@ -1354,7 +1353,7 @@ static void spmv_alpha_beta_mv_struct_transpose(
   // We need to scale y first ("scaling" by zero just means filling
   // with zeros), since the functor works by atomic-adding into y.
   if (dobeta != 1) {
-    KokkosBlas::scal(y, beta, y);
+    KokkosBlas::scal(exec, y, beta, y);
   }
 
   if (doalpha != 0) {
@@ -1374,11 +1373,10 @@ static void spmv_alpha_beta_mv_struct_transpose(
 #ifndef KOKKOS_FAST_COMPILE  // This uses templated functions on doalpha and
                              // dobeta and will produce 16 kernels
 
-    typedef SPMV_MV_Struct_Transpose_Functor<AMatrix, XVector, YVector, doalpha,
-                                             dobeta, conjugate>
+    typedef SPMV_MV_Struct_Transpose_Functor<
+        execution_space, AMatrix, XVector, YVector, doalpha, dobeta, conjugate>
         OpType;
-    OpType op(alpha, A, x, beta, y,
-              RowsPerThread<typename AMatrix::execution_space>(NNZPerRow));
+    OpType op(alpha, A, x, beta, y, RowsPerThread<execution_space>(NNZPerRow));
 
     typename AMatrix::const_ordinal_type nrow = A.numRows();
 
@@ -1387,78 +1385,82 @@ static void spmv_alpha_beta_mv_struct_transpose(
     // then this is just the number of rows.  Ditto for rows_per_team.
     // team_size is a hardware resource thing so it might legitimately
     // be int.
-    const int rows_per_thread =
-        RowsPerThread<typename AMatrix::execution_space>(NNZPerRow);
+    const int rows_per_thread = RowsPerThread<execution_space>(NNZPerRow);
     const int team_size =
-        Kokkos::TeamPolicy<typename AMatrix::execution_space>(
-            rows_per_thread, Kokkos::AUTO, vector_length)
+        Kokkos::TeamPolicy<execution_space>(exec, rows_per_thread, Kokkos::AUTO,
+                                            vector_length)
             .team_size_recommended(op, Kokkos::ParallelForTag());
     const int rows_per_team = rows_per_thread * team_size;
     const size_type nteams  = (nrow + rows_per_team - 1) / rows_per_team;
     Kokkos::parallel_for("KokkosSparse::spmv_struct<MV,Transpose>",
-                         Kokkos::TeamPolicy<typename AMatrix::execution_space>(
-                             nteams, team_size, vector_length),
+                         Kokkos::TeamPolicy<execution_space>(
+                             exec, nteams, team_size, vector_length),
                          op);
 
 #else  // KOKKOS_FAST_COMPILE this will only instantiate one Kernel for
        // alpha/beta
 
-    typedef SPMV_MV_Struct_Transpose_Functor<AMatrix, XVector, YVector, 2, 2,
-                                             conjugate, SizeType>
+    typedef SPMV_MV_Struct_Transpose_Functor<execution_space, AMatrix, XVector,
+                                             YVector, 2, 2, conjugate, SizeType>
         OpType;
 
     typename AMatrix::const_ordinal_type nrow = A.numRows();
 
-    OpType op(alpha, A, x, beta, y,
-              RowsPerThread<typename AMatrix::execution_space>(NNZPerRow));
+    OpType op(alpha, A, x, beta, y, RowsPerThread<execution_space>(NNZPerRow));
 
     // FIXME (mfh 07 Jun 2016) Shouldn't we use ordinal_type here
     // instead of int?  For example, if the number of threads is 1,
     // then this is just the number of rows.  Ditto for rows_per_team.
     // team_size is a hardware resource thing so it might legitimately
     // be int.
-    const int rows_per_thread =
-        RowsPerThread<typename AMatrix::execution_space>(NNZPerRow);
+    const int rows_per_thread = RowsPerThread<execution_space>(NNZPerRow);
     const int team_size =
-        Kokkos::TeamPolicy<typename AMatrix::execution_space>(
-            rows_per_thread, Kokkos::AUTO, vector_length)
+        Kokkos::TeamPolicy<execution_space>(exec, rows_per_thread, Kokkos::AUTO,
+                                            vector_length)
             .team_size_recommended(op, Kokkos::ParallelForTag());
     const int rows_per_team = rows_per_thread * team_size;
     const size_type nteams = (nrow + rows_per_team - 1) / rows_per_team;
     Kokkos::parallel_for("KokkosSparse::spmv_struct<MV,Transpose>",
-                         Kokkos::TeamPolicy<typename AMatrix::execution_space>(
-                             nteams, team_size, vector_length),
+                         Kokkos::TeamPolicy<execution_space>(
+                             exec, nteams, team_size, vector_length),
                          op);
 
 #endif  // KOKKOS_FAST_COMPILE
   }
 }
 
-template <class AMatrix, class XVector, class YVector, int doalpha, int dobeta>
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int doalpha, int dobeta>
 static void spmv_alpha_beta_mv_struct(
-    const char mode[], const typename YVector::non_const_value_type& alpha,
-    const AMatrix& A, const XVector& x,
-    const typename YVector::non_const_value_type& beta, const YVector& y) {
+    const execution_space& exec, const char mode[],
+    const typename YVector::non_const_value_type& alpha, const AMatrix& A,
+    const XVector& x, const typename YVector::non_const_value_type& beta,
+    const YVector& y) {
   if (mode[0] == NoTranspose[0]) {
-    spmv_alpha_beta_mv_struct_no_transpose<AMatrix, XVector, YVector, doalpha,
-                                           dobeta, false>(alpha, A, x, beta, y);
+    spmv_alpha_beta_mv_struct_no_transpose<execution_space, AMatrix, XVector,
+                                           YVector, doalpha, dobeta, false>(
+        exec, alpha, A, x, beta, y);
   } else if (mode[0] == Conjugate[0]) {
-    spmv_alpha_beta_mv_struct_no_transpose<AMatrix, XVector, YVector, doalpha,
-                                           dobeta, true>(alpha, A, x, beta, y);
+    spmv_alpha_beta_mv_struct_no_transpose<execution_space, AMatrix, XVector,
+                                           YVector, doalpha, dobeta, true>(
+        exec, alpha, A, x, beta, y);
   } else if (mode[0] == Transpose[0]) {
-    spmv_alpha_beta_mv_struct_transpose<AMatrix, XVector, YVector, doalpha,
-                                        dobeta, false>(alpha, A, x, beta, y);
+    spmv_alpha_beta_mv_struct_transpose<execution_space, AMatrix, XVector,
+                                        YVector, doalpha, dobeta, false>(
+        exec, alpha, A, x, beta, y);
   } else if (mode[0] == ConjugateTranspose[0]) {
-    spmv_alpha_beta_mv_struct_transpose<AMatrix, XVector, YVector, doalpha,
-                                        dobeta, true>(alpha, A, x, beta, y);
+    spmv_alpha_beta_mv_struct_transpose<execution_space, AMatrix, XVector,
+                                        YVector, doalpha, dobeta, true>(
+        exec, alpha, A, x, beta, y);
   } else {
     KokkosKernels::Impl::throw_runtime_exception(
         "Invalid Transpose Mode for KokkosSparse::spmv()");
   }
 }
 
-template <class AMatrix, class XVector, class YVector, int doalpha>
-void spmv_alpha_mv_struct(const char mode[],
+template <class execution_space, class AMatrix, class XVector, class YVector,
+          int doalpha>
+void spmv_alpha_mv_struct(const execution_space& exec, const char mode[],
                           const typename YVector::non_const_value_type& alpha,
                           const AMatrix& A, const XVector& x,
                           const typename YVector::non_const_value_type& beta,
@@ -1467,17 +1469,17 @@ void spmv_alpha_mv_struct(const char mode[],
   typedef Kokkos::ArithTraits<coefficient_type> KAT;
 
   if (beta == KAT::zero()) {
-    spmv_alpha_beta_mv_struct<AMatrix, XVector, YVector, doalpha, 0>(
-        mode, alpha, A, x, beta, y);
+    spmv_alpha_beta_mv_struct<execution_space, AMatrix, XVector, YVector,
+                              doalpha, 0>(exec, mode, alpha, A, x, beta, y);
   } else if (beta == KAT::one()) {
-    spmv_alpha_beta_mv_struct<AMatrix, XVector, YVector, doalpha, 1>(
-        mode, alpha, A, x, beta, y);
+    spmv_alpha_beta_mv_struct<execution_space, AMatrix, XVector, YVector,
+                              doalpha, 1>(exec, mode, alpha, A, x, beta, y);
   } else if (beta == -KAT::one()) {
-    spmv_alpha_beta_mv_struct<AMatrix, XVector, YVector, doalpha, -1>(
-        mode, alpha, A, x, beta, y);
+    spmv_alpha_beta_mv_struct<execution_space, AMatrix, XVector, YVector,
+                              doalpha, -1>(exec, mode, alpha, A, x, beta, y);
   } else {
-    spmv_alpha_beta_mv_struct<AMatrix, XVector, YVector, doalpha, 2>(
-        mode, alpha, A, x, beta, y);
+    spmv_alpha_beta_mv_struct<execution_space, AMatrix, XVector, YVector,
+                              doalpha, 2>(exec, mode, alpha, A, x, beta, y);
   }
 }
 

--- a/sparse/impl/KokkosSparse_spmv_struct_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_struct_spec.hpp
@@ -29,16 +29,14 @@
 namespace KokkosSparse {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector>
 struct spmv_struct_eti_spec_avail {
   enum : bool { value = false };
 };
 
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM,
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector,
           const bool integerScalarType =
-              std::is_integral<typename std::decay<AT>::type>::value>
+              std::is_integral_v<typename AMatrix::non_const_value_type>>
 struct spmv_mv_struct_eti_spec_avail {
   enum : bool { value = false };
 };
@@ -46,38 +44,44 @@ struct spmv_mv_struct_eti_spec_avail {
 }  // namespace Impl
 }  // namespace KokkosSparse
 
-#define KOKKOSSPARSE_SPMV_STRUCT_ETI_SPEC_AVAIL(                          \
-    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, \
-    MEM_SPACE_TYPE)                                                       \
-  template <>                                                             \
-  struct spmv_struct_eti_spec_avail<                                      \
-      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,             \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,         \
-      SCALAR_TYPE const*, LAYOUT_TYPE,                                    \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,     \
-      SCALAR_TYPE*, LAYOUT_TYPE,                                          \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> > {                         \
-    enum : bool { value = true };                                         \
+#define KOKKOSSPARSE_SPMV_STRUCT_ETI_SPEC_AVAIL(                               \
+    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,      \
+    MEM_SPACE_TYPE)                                                            \
+  template <>                                                                  \
+  struct spmv_struct_eti_spec_avail<                                           \
+      EXEC_SPACE_TYPE,                                                         \
+      KokkosSparse::CrsMatrix<const SCALAR_TYPE, const ORDINAL_TYPE,           \
+                              Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,         \
+                              const OFFSET_TYPE>,                              \
+      Kokkos::View<                                                            \
+          SCALAR_TYPE const*, LAYOUT_TYPE,                                     \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                     \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR_TYPE*, LAYOUT_TYPE,                                  \
+                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                 \
+    enum : bool { value = true };                                              \
   };
 
-#define KOKKOSSPARSE_SPMV_MV_STRUCT_ETI_SPEC_AVAIL(                       \
-    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, \
-    MEM_SPACE_TYPE)                                                       \
-  template <>                                                             \
-  struct spmv_mv_struct_eti_spec_avail<                                   \
-      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,             \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,         \
-      SCALAR_TYPE const**, LAYOUT_TYPE,                                   \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,     \
-      SCALAR_TYPE**, LAYOUT_TYPE,                                         \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> > {                         \
-    enum : bool { value = true };                                         \
+#define KOKKOSSPARSE_SPMV_MV_STRUCT_ETI_SPEC_AVAIL(                            \
+    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,      \
+    MEM_SPACE_TYPE)                                                            \
+  template <>                                                                  \
+  struct spmv_mv_struct_eti_spec_avail<                                        \
+      EXEC_SPACE_TYPE,                                                         \
+      KokkosSparse::CrsMatrix<const SCALAR_TYPE, const ORDINAL_TYPE,           \
+                              Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,         \
+                              const OFFSET_TYPE>,                              \
+      Kokkos::View<                                                            \
+          SCALAR_TYPE const**, LAYOUT_TYPE,                                    \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                     \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR_TYPE**, LAYOUT_TYPE,                                 \
+                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                 \
+    enum : bool { value = true };                                              \
   };
 
 // Include the actual specialization declarations
@@ -92,34 +96,18 @@ namespace Impl {
 /// \brief Implementation of KokkosSparse::spmv_struct (sparse structured matrix
 ///   - dense vector multiply) for single vectors (1-D Views).
 ///
-/// The first 5 template parameters are the same as those of
-/// KokkosSparse::CrsMatrix.  In particular:
-///
-/// AT: type of each entry of the sparse matrix
-/// AO: ordinal type (type of column indices) of the sparse matrix
-/// AS: offset type (type of row offsets) of the sparse matrix
-///
-/// The next 4 template parameters (that start with X) correspond to
-/// the input Kokkos::View.  The last 4 template parameters (that start
-/// with Y) correspond to the output Kokkos::View.
-///
 /// For the implementation of KokkosSparse::spmv_struct for multivectors (2-D
 /// Views), see the SPMV_STRUCT struct below.
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM,
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector,
           bool tpl_spec_avail = spmv_struct_tpl_spec_avail<
-              ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value,
+              ExecutionSpace, AMatrix, XVector, YVector>::value,
           bool eti_spec_avail = spmv_struct_eti_spec_avail<
-              ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value>
+              ExecutionSpace, AMatrix, XVector, YVector>::value>
 struct SPMV_STRUCT {
-  typedef CrsMatrix<AT, AO, AD, AM, AS> AMatrix;
-  typedef Kokkos::View<XT, XL, XD, XM> XVector;
-  typedef Kokkos::View<YT, YL, YD, YM> YVector;
-
   typedef typename YVector::non_const_value_type coefficient_type;
 
   static void spmv_struct(
-      const ES& exec, const char mode[], const int stencil_type,
+      const ExecutionSpace& space, const char mode[], const int stencil_type,
       const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                          Kokkos::HostSpace>& structure,
       const coefficient_type& alpha, const AMatrix& A, const XVector& x,
@@ -146,39 +134,21 @@ struct SPMV_STRUCT {
 /// matrix, and Op(A) is either A itself, its transpose, or its
 /// conjugate transpose, depending on the 'mode' argument.
 ///
-/// The first 5 template parameters are the template parameters of the
-/// input 1-D View of coefficients 'alpha'.  The next 5 template
-/// parameters are the same as those of KokkosSparse::CrsMatrix. In
-/// particular:
-///
-/// AT: type of each entry of the sparse matrix
-/// AO: ordinal type (type of column indices) of the sparse matrix
-/// AS: offset type (type of row offsets) of the sparse matrix
-///
-/// The next 4 template parameters (that start with X) correspond to
-/// the input Kokkos::View.  The 4 template parameters after that
-/// (that start with lower-case b) are the template parameters of the
-/// input 1-D View of coefficients 'beta'.  Next, the 4 template
-/// parameters that start with Y correspond to the output
-/// Kokkos::View.  The last template parameter indicates whether the
+/// The last template parameter integerScalarType indicates whether the
 /// matrix's entries have integer type.  Per Github Issue #700, we
 /// don't optimize as heavily for that case, in order to reduce build
 /// times and library sizes.
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM,
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector,
           const bool integerScalarType =
-              std::is_integral<typename std::decay<AT>::type>::value,
+              std::is_integral_v<typename AMatrix::non_const_value_type>,
           bool tpl_spec_avail = spmv_mv_struct_tpl_spec_avail<
-              ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value,
+              ExecutionSpace, AMatrix, XVector, YVector>::value,
           bool eti_spec_avail = spmv_mv_struct_eti_spec_avail<
-              ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM>::value>
+              ExecutionSpace, AMatrix, XVector, YVector>::value>
 struct SPMV_MV_STRUCT {
-  typedef CrsMatrix<AT, AO, AD, AM, AS> AMatrix;
-  typedef Kokkos::View<XT, XL, XD, XM> XVector;
-  typedef Kokkos::View<YT, YL, YD, YM> YVector;
   typedef typename YVector::non_const_value_type coefficient_type;
 
-  static void spmv_mv_struct(const ES& exec, const char mode[],
+  static void spmv_mv_struct(const ExecutionSpace& space, const char mode[],
                              const coefficient_type& alpha, const AMatrix& A,
                              const XVector& x, const coefficient_type& beta,
                              const YVector& y);
@@ -187,17 +157,13 @@ struct SPMV_MV_STRUCT {
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 //! Full specialization of spmv for single vectors (1-D Views).
 // Unification layer
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
-struct SPMV_STRUCT<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
-                   false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
-  typedef CrsMatrix<AT, AO, AD, AM, AS> AMatrix;
-  typedef Kokkos::View<XT, XL, XD, XM> XVector;
-  typedef Kokkos::View<YT, YL, YD, YM> YVector;
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector>
+struct SPMV_STRUCT<ExecutionSpace, AMatrix, XVector, YVector, false,
+                   KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename YVector::non_const_value_type coefficient_type;
 
   static void spmv_struct(
-      const ES& exec, const char mode[], const int stencil_type,
+      const ExecutionSpace& space, const char mode[], const int stencil_type,
       const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                          Kokkos::HostSpace>& structure,
       const coefficient_type& alpha, const AMatrix& A, const XVector& x,
@@ -208,82 +174,72 @@ struct SPMV_STRUCT<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
 
     if (alpha == KAT::zero()) {
       if (beta != KAT::one()) {
-        KokkosBlas::scal(exec, y, beta, y);
+        KokkosBlas::scal(space, y, beta, y);
       }
       return;
     }
 
     if (beta == KAT::zero()) {
-      spmv_struct_beta<ES, AMatrix, XVector, YVector, 0>(
-          exec, mode, stencil_type, structure, alpha, A, x, beta, y);
+      spmv_struct_beta<ExecutionSpace, AMatrix, XVector, YVector, 0>(
+          space, mode, stencil_type, structure, alpha, A, x, beta, y);
     } else if (beta == KAT::one()) {
-      spmv_struct_beta<ES, AMatrix, XVector, YVector, 1>(
-          exec, mode, stencil_type, structure, alpha, A, x, beta, y);
+      spmv_struct_beta<ExecutionSpace, AMatrix, XVector, YVector, 1>(
+          space, mode, stencil_type, structure, alpha, A, x, beta, y);
     } else if (beta == -KAT::one()) {
-      spmv_struct_beta<ES, AMatrix, XVector, YVector, -1>(
-          exec, mode, stencil_type, structure, alpha, A, x, beta, y);
+      spmv_struct_beta<ExecutionSpace, AMatrix, XVector, YVector, -1>(
+          space, mode, stencil_type, structure, alpha, A, x, beta, y);
     } else {
-      spmv_struct_beta<ES, AMatrix, XVector, YVector, 2>(
-          exec, mode, stencil_type, structure, alpha, A, x, beta, y);
+      spmv_struct_beta<ExecutionSpace, AMatrix, XVector, YVector, 2>(
+          space, mode, stencil_type, structure, alpha, A, x, beta, y);
     }
   }
 };
 
 //! Full specialization of spmv_mv for single vectors (2-D Views).
 // Unification layer
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
-struct SPMV_MV_STRUCT<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
-                      false, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
-  typedef CrsMatrix<AT, AO, AD, AM, AS> AMatrix;
-  typedef Kokkos::View<XT, XL, XD, XM> XVector;
-  typedef Kokkos::View<YT, YL, YD, YM> YVector;
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector>
+struct SPMV_MV_STRUCT<ExecutionSpace, AMatrix, XVector, YVector, false, false,
+                      KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename YVector::non_const_value_type coefficient_type;
 
-  static void spmv_mv_struct(const ES& exec, const char mode[],
+  static void spmv_mv_struct(const ExecutionSpace& space, const char mode[],
                              const coefficient_type& alpha, const AMatrix& A,
                              const XVector& x, const coefficient_type& beta,
                              const YVector& y) {
     typedef Kokkos::ArithTraits<coefficient_type> KAT;
 
     if (alpha == KAT::zero()) {
-      spmv_alpha_mv_struct<ES, AMatrix, XVector, YVector, 0>(exec, mode, alpha,
-                                                             A, x, beta, y);
+      spmv_alpha_mv_struct<ExecutionSpace, AMatrix, XVector, YVector, 0>(
+          space, mode, alpha, A, x, beta, y);
     } else if (alpha == KAT::one()) {
-      spmv_alpha_mv_struct<ES, AMatrix, XVector, YVector, 1>(exec, mode, alpha,
-                                                             A, x, beta, y);
+      spmv_alpha_mv_struct<ExecutionSpace, AMatrix, XVector, YVector, 1>(
+          space, mode, alpha, A, x, beta, y);
     } else if (alpha == -KAT::one()) {
-      spmv_alpha_mv_struct<ES, AMatrix, XVector, YVector, -1>(exec, mode, alpha,
-                                                              A, x, beta, y);
+      spmv_alpha_mv_struct<ExecutionSpace, AMatrix, XVector, YVector, -1>(
+          space, mode, alpha, A, x, beta, y);
     } else {
-      spmv_alpha_mv_struct<ES, AMatrix, XVector, YVector, 2>(exec, mode, alpha,
-                                                             A, x, beta, y);
+      spmv_alpha_mv_struct<ExecutionSpace, AMatrix, XVector, YVector, 2>(
+          space, mode, alpha, A, x, beta, y);
     }
   }
 };
 
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
-struct SPMV_MV_STRUCT<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
-                      true, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
-  typedef CrsMatrix<AT, AO, AD, AM, AS> AMatrix;
-  typedef Kokkos::View<XT, XL, XD, XM> XVector;
-  typedef Kokkos::View<YT, YL, YD, YM> YVector;
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector>
+struct SPMV_MV_STRUCT<ExecutionSpace, AMatrix, XVector, YVector, true, false,
+                      KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename YVector::non_const_value_type coefficient_type;
 
-  static void spmv_mv_struct(const ES& exec, const char mode[],
+  static void spmv_mv_struct(const ExecutionSpace& space, const char mode[],
                              const coefficient_type& alpha, const AMatrix& A,
                              const XVector& x, const coefficient_type& beta,
                              const YVector& y) {
-    static_assert(std::is_integral<AT>::value,
+    static_assert(std::is_integral_v<typename AMatrix::non_const_value_type>,
                   "This implementation is only for integer Scalar types.");
-    typedef SPMV_STRUCT<ES, AT, AO, AD, AM, AS, typename XVector::value_type*,
-                        XL, XD, XM, typename YVector::value_type*, YL, YD, YM>
-        impl_type;
+    typedef SPMV_STRUCT<ExecutionSpace, AMatrix, XVector, YVector> impl_type;
     for (typename AMatrix::non_const_size_type j = 0; j < x.extent(1); ++j) {
       auto x_j = Kokkos::subview(x, Kokkos::ALL(), j);
       auto y_j = Kokkos::subview(y, Kokkos::ALL(), j);
-      impl_type::spmv_struct(exec, mode, alpha, A, x_j, beta, y_j);
+      impl_type::spmv_struct(space, mode, alpha, A, x_j, beta, y_j);
     }
   }
 };
@@ -299,65 +255,77 @@ struct SPMV_MV_STRUCT<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
 // We may spread out definitions (see _DEF macro below) across one or
 // more .cpp files.
 //
-#define KOKKOSSPARSE_SPMV_STRUCT_ETI_SPEC_DECL(                           \
-    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, \
-    MEM_SPACE_TYPE)                                                       \
-  extern template struct SPMV_STRUCT<                                     \
-      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,             \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,         \
-      SCALAR_TYPE const*, LAYOUT_TYPE,                                    \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,     \
-      SCALAR_TYPE*, LAYOUT_TYPE,                                          \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, false, true>;
+#define KOKKOSSPARSE_SPMV_STRUCT_ETI_SPEC_DECL(                                \
+    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,      \
+    MEM_SPACE_TYPE)                                                            \
+  extern template struct SPMV_STRUCT<                                          \
+      EXEC_SPACE_TYPE,                                                         \
+      KokkosSparse::CrsMatrix<const SCALAR_TYPE, const ORDINAL_TYPE,           \
+                              Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,         \
+                              const OFFSET_TYPE>,                              \
+      Kokkos::View<                                                            \
+          SCALAR_TYPE const*, LAYOUT_TYPE,                                     \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                     \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR_TYPE*, LAYOUT_TYPE,                                  \
+                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
+      false, true>;
 
-#define KOKKOSSPARSE_SPMV_STRUCT_ETI_SPEC_INST(                           \
-    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, \
-    MEM_SPACE_TYPE)                                                       \
-  template struct SPMV_STRUCT<                                            \
-      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,             \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,         \
-      SCALAR_TYPE const*, LAYOUT_TYPE,                                    \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,     \
-      SCALAR_TYPE*, LAYOUT_TYPE,                                          \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, false, true>;
+#define KOKKOSSPARSE_SPMV_STRUCT_ETI_SPEC_INST(                                \
+    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,      \
+    MEM_SPACE_TYPE)                                                            \
+  template struct SPMV_STRUCT<                                                 \
+      EXEC_SPACE_TYPE,                                                         \
+      KokkosSparse::CrsMatrix<const SCALAR_TYPE, const ORDINAL_TYPE,           \
+                              Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,         \
+                              const OFFSET_TYPE>,                              \
+      Kokkos::View<                                                            \
+          SCALAR_TYPE const*, LAYOUT_TYPE,                                     \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                     \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR_TYPE*, LAYOUT_TYPE,                                  \
+                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
+      false, true>;
 
-#define KOKKOSSPARSE_SPMV_MV_STRUCT_ETI_SPEC_DECL(                            \
-    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,     \
-    MEM_SPACE_TYPE)                                                           \
-  extern template struct SPMV_MV_STRUCT<                                      \
-      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,                 \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,             \
-      SCALAR_TYPE const**, LAYOUT_TYPE,                                       \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,         \
-      SCALAR_TYPE**, LAYOUT_TYPE,                                             \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>,                                \
-      std::is_integral<typename std::decay<SCALAR_TYPE>::type>::value, false, \
-      true>;
+#define KOKKOSSPARSE_SPMV_MV_STRUCT_ETI_SPEC_DECL(                             \
+    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,      \
+    MEM_SPACE_TYPE)                                                            \
+  extern template struct SPMV_MV_STRUCT<                                       \
+      EXEC_SPACE_TYPE,                                                         \
+      KokkosSparse::CrsMatrix<const SCALAR_TYPE, const ORDINAL_TYPE,           \
+                              Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,         \
+                              const OFFSET_TYPE>,                              \
+      Kokkos::View<                                                            \
+          SCALAR_TYPE const**, LAYOUT_TYPE,                                    \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                     \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR_TYPE**, LAYOUT_TYPE,                                 \
+                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
+      std::is_integral_v<SCALAR_TYPE>, false, true>;
 
-#define KOKKOSSPARSE_SPMV_MV_STRUCT_ETI_SPEC_INST(                            \
-    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,     \
-    MEM_SPACE_TYPE)                                                           \
-  template struct SPMV_MV_STRUCT<                                             \
-      EXEC_SPACE_TYPE, const SCALAR_TYPE, const ORDINAL_TYPE,                 \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET_TYPE,             \
-      SCALAR_TYPE const**, LAYOUT_TYPE,                                       \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,         \
-      SCALAR_TYPE**, LAYOUT_TYPE,                                             \
-      Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>,                                \
-      std::is_integral<typename std::decay<SCALAR_TYPE>::type>::value, false, \
-      true>;
+#define KOKKOSSPARSE_SPMV_MV_STRUCT_ETI_SPEC_INST(                             \
+    SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,      \
+    MEM_SPACE_TYPE)                                                            \
+  template struct SPMV_MV_STRUCT<                                              \
+      EXEC_SPACE_TYPE,                                                         \
+      KokkosSparse::CrsMatrix<const SCALAR_TYPE, const ORDINAL_TYPE,           \
+                              Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,         \
+                              const OFFSET_TYPE>,                              \
+      Kokkos::View<                                                            \
+          SCALAR_TYPE const**, LAYOUT_TYPE,                                    \
+          Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                     \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR_TYPE**, LAYOUT_TYPE,                                 \
+                   Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
+      std::is_integral_v<SCALAR_TYPE>, false, true>;
 
 #include <KokkosSparse_spmv_struct_tpl_spec_decl.hpp>
 

--- a/sparse/impl/KokkosSparse_spmv_struct_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_struct_spec.hpp
@@ -283,7 +283,7 @@ struct SPMV_MV_STRUCT<ES, AT, AO, AD, AM, AS, XT, XL, XD, XM, YT, YL, YD, YM,
     for (typename AMatrix::non_const_size_type j = 0; j < x.extent(1); ++j) {
       auto x_j = Kokkos::subview(x, Kokkos::ALL(), j);
       auto y_j = Kokkos::subview(y, Kokkos::ALL(), j);
-      impl_type::spmv_struct(mode, alpha, A, x_j, beta, y_j);
+      impl_type::spmv_struct(exec, mode, alpha, A, x_j, beta, y_j);
     }
   }
 };

--- a/sparse/src/KokkosSparse_BsrMatrix.hpp
+++ b/sparse/src/KokkosSparse_BsrMatrix.hpp
@@ -463,7 +463,8 @@ class BsrMatrix {
         blockDim_(blockDimIn) {
     if (blockDim_ < 1) {
       std::ostringstream os;
-      os << "KokkosSparse::BsrMatrix: Inappropriate block size: " << blockDim_;
+      os << "KokkosSparse::Experimental::BsrMatrix: Inappropriate block size: "
+         << blockDim_;
       KokkosKernels::Impl::throw_runtime_exception(os.str());
     }
   }
@@ -499,7 +500,8 @@ class BsrMatrix {
 
     if (blockDim_ < 1) {
       std::ostringstream os;
-      os << "KokkosSparse::BsrMatrix: Inappropriate block size: " << blockDim_;
+      os << "KokkosSparse::Experimental::BsrMatrix: Inappropriate block size: "
+         << blockDim_;
       KokkosKernels::Impl::throw_runtime_exception(os.str());
     }
 
@@ -661,7 +663,8 @@ class BsrMatrix {
         blockDim_(blockDimIn) {
     if (blockDim_ < 1) {
       std::ostringstream os;
-      os << "KokkosSparse::BsrMatrix: Inappropriate block size: " << blockDim_;
+      os << "KokkosSparse::Experimental::BsrMatrix: Inappropriate block size: "
+         << blockDim_;
       KokkosKernels::Impl::throw_runtime_exception(os.str());
     }
 
@@ -703,7 +706,8 @@ class BsrMatrix {
       : graph(graph_), values(vals), numCols_(ncols), blockDim_(blockDimIn) {
     if (blockDim_ < 1) {
       std::ostringstream os;
-      os << "KokkosSparse::BsrMatrix: Inappropriate block size: " << blockDim_;
+      os << "KokkosSparse::Experimental::BsrMatrix: Inappropriate block size: "
+         << blockDim_;
       KokkosKernels::Impl::throw_runtime_exception(os.str());
     }
   }
@@ -724,7 +728,8 @@ class BsrMatrix {
     blockDim_ = blockDimIn;
     if (blockDim_ < 1) {
       std::ostringstream os;
-      os << "KokkosSparse::BsrMatrix: Inappropriate block size: " << blockDim_;
+      os << "KokkosSparse::Experimental::BsrMatrix: Inappropriate block size: "
+         << blockDim_;
       KokkosKernels::Impl::throw_runtime_exception(os.str());
     }
 

--- a/sparse/src/KokkosSparse_Utils_cusparse.hpp
+++ b/sparse/src/KokkosSparse_Utils_cusparse.hpp
@@ -168,6 +168,23 @@ inline cusparseIndexType_t cusparse_index_type_t_from<unsigned short>() {
 }
 #endif
 
+// Set the stream on the given cuSPARSE handle when this object
+// is constructed, and reset to the default stream when this object is
+// destructed.
+struct TemporarySetCusparseStream {
+  TemporarySetCusparseStream(cusparseHandle_t handle_,
+                             const Kokkos::Cuda& exec_)
+      : handle(handle_) {
+    KOKKOS_CUSPARSE_SAFE_CALL(cusparseSetStream(handle, exec_.cuda_stream()));
+  }
+
+  ~TemporarySetCusparseStream() {
+    KOKKOS_CUSPARSE_SAFE_CALL(cusparseSetStream(handle, NULL));
+  }
+
+  cusparseHandle_t handle;
+};
+
 }  // namespace Impl
 
 }  // namespace KokkosSparse

--- a/sparse/src/KokkosSparse_Utils_rocsparse.hpp
+++ b/sparse/src/KokkosSparse_Utils_rocsparse.hpp
@@ -178,6 +178,24 @@ struct kokkos_to_rocsparse_type<Kokkos::complex<double>> {
 #define KOKKOSSPARSE_IMPL_ROCM_VERSION \
   ROCM_VERSION_MAJOR * 10000 + ROCM_VERSION_MINOR * 100 + ROCM_VERSION_PATCH
 
+// Set the stream on the given rocSPARSE handle when this object
+// is constructed, and reset to the default stream when this object is
+// destructed.
+struct TemporarySetRocsparseStream {
+  TemporarySetRocsparseStream(rocsparse_handle handle_,
+                              const Kokkos::HIP& exec_)
+      : handle(handle_) {
+    KOKKOS_ROCSPARSE_SAFE_CALL_IMPL(
+        rocsparse_set_stream(handle, exec_.hip_stream()));
+  }
+
+  ~TemporarySetRocsparseStream() {
+    KOKKOS_ROCSPARSE_SAFE_CALL_IMPL(rocsparse_set_stream(handle, NULL));
+  }
+
+  rocsparse_handle handle;
+};
+
 }  // namespace Impl
 
 }  // namespace KokkosSparse

--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -40,38 +40,39 @@ struct RANK_ONE {};
 struct RANK_TWO {};
 }  // namespace
 
-/// \brief \c Kokkos sparse matrix-vector multiply on single
-/// vectors (RANK_ONE tag). Computes y := alpha*Op(A)*x + beta*y, where Op(A) is controlled by mode (see below).
+/// \brief Kokkos sparse matrix-vector multiply on single
+/// vectors (RANK_ONE tag). Computes y := alpha*Op(A)*x + beta*y, where Op(A) is
+/// controlled by mode (see below).
 ///
 /// \tparam execution_space A Kokkos execution space. Must be able to access
 ///   the memory spaces of A, x, and y.
-/// \tparam AlphaType Type of coefficient alpha. Must be convertible to YVector::value_type.
-/// \tparam AMatrix A KokkosSparse::CrsMatrix, or KokkosSparse::BsrMatrix
-/// \tparam XVector Type of x, must be a rank-1 Kokkos::View
-/// \tparam BetaType Type of coefficient beta. Must be convertible to YVector::value_type.
-/// \tparam YVector Type of y, must be a rank-1 Kokkos::View and its rank must match that of XVector
+/// \tparam AlphaType Type of coefficient alpha. Must be convertible to
+/// YVector::value_type. \tparam AMatrix A KokkosSparse::CrsMatrix, or
+/// KokkosSparse::BsrMatrix \tparam XVector Type of x, must be a rank-1
+/// Kokkos::View \tparam BetaType Type of coefficient beta. Must be convertible
+/// to YVector::value_type. \tparam YVector Type of y, must be a rank-1
+/// Kokkos::View and its rank must match that of XVector
 ///
 /// \param exec [in] The execution space instance on which to run the
 ///   kernel.
 /// \param controls [in] kokkos-kernels control structure.
-/// \param mode [in] Select A's operator mode: "N" for normal, "T" for transpose, "C" for conjugate or "H" for conjugate transpose.
-/// \param alpha [in] Scalar multiplier for the matrix A.
-/// \param A [in] The sparse matrix A.
+/// \param mode [in] Select A's operator mode: "N" for normal, "T" for
+/// transpose, "C" for conjugate or "H" for conjugate transpose. \param alpha
+/// [in] Scalar multiplier for the matrix A. \param A [in] The sparse matrix A.
 /// \param x [in] A vector to multiply on the left by A.
 /// \param beta [in] Scalar multiplier for the vector y.
 /// \param y [in/out] Result vector.
 /// \param tag RANK_ONE dispatch
-//#ifdef DOXY // documentation version - don't separately document SFINAE specializations for BSR and CRS
+#ifdef DOXY  // documentation version - don't separately document SFINAE
+             // specializations for BSR and CRS
 template <class execution_space, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector>
-          /*
 #else
 template <class execution_space, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector,
           typename std::enable_if<
               KokkosSparse::is_crs_matrix<AMatrix>::value>::type* = nullptr>
 #endif
-              */
 void spmv(const execution_space& exec,
           KokkosKernels::Experimental::Controls controls, const char mode[],
           const AlphaType& alpha, const AMatrix& A, const XVector& x,
@@ -259,34 +260,34 @@ void spmv(const execution_space& exec,
   }
 }
 
-/// \brief \c Kokkos sparse matrix-vector multiply on single
-/// vector (RANK_ONE tag). Computes y := alpha*Op(A)*x + beta*y, where Op(A) is controlled by mode (see below).
+/// \brief Kokkos sparse matrix-vector multiply on single
+/// vector (RANK_ONE tag). Computes y := alpha*Op(A)*x + beta*y, where Op(A) is
+/// controlled by mode (see below).
 ///
-/// \tparam AlphaType Type of coefficient alpha. Must be convertible to YVector::value_type.
-/// \tparam AMatrix A KokkosSparse::CrsMatrix, or KokkosSparse::BsrMatrix
-/// \tparam XVector Type of x, must be a rank-1 Kokkos::View
-/// \tparam BetaType Type of coefficient beta. Must be convertible to YVector::value_type.
-/// \tparam YVector Type of y, must be a rank-1 Kokkos::View and its rank must match that of XVector
+/// \tparam AlphaType Type of coefficient alpha. Must be convertible to
+/// YVector::value_type. \tparam AMatrix A KokkosSparse::CrsMatrix, or
+/// KokkosSparse::BsrMatrix \tparam XVector Type of x, must be a rank-1
+/// Kokkos::View \tparam BetaType Type of coefficient beta. Must be convertible
+/// to YVector::value_type. \tparam YVector Type of y, must be a rank-1
+/// Kokkos::View and its rank must match that of XVector
 ///
 /// \param controls [in] kokkos-kernels control structure.
-/// \param mode [in] Select A's operator mode: "N" for normal, "T" for transpose, "C" for conjugate or "H" for conjugate transpose.
-/// \param alpha [in] Scalar multiplier for the matrix A.
-/// \param A [in] The sparse matrix A.
+/// \param mode [in] Select A's operator mode: "N" for normal, "T" for
+/// transpose, "C" for conjugate or "H" for conjugate transpose. \param alpha
+/// [in] Scalar multiplier for the matrix A. \param A [in] The sparse matrix A.
 /// \param x [in] A vector to multiply on the left by A.
 /// \param beta [in] Scalar multiplier for the vector y.
 /// \param y [in/out] Result vector.
 /// \param tag RANK_ONE dispatch
-//#ifdef DOXY  // documentation version
+#ifdef DOXY  // documentation version
 template <class AlphaType, class AMatrix, class XVector, class BetaType,
           class YVector>
-        /*
 #else
 template <class AlphaType, class AMatrix, class XVector, class BetaType,
           class YVector,
           typename std::enable_if<
               KokkosSparse::is_crs_matrix<AMatrix>::value>::type* = nullptr>
 #endif
-*/
 void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
           const AlphaType& alpha, const AMatrix& A, const XVector& x,
           const BetaType& beta, const YVector& y, const RANK_ONE& tag) {
@@ -294,233 +295,233 @@ void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
        y, tag);
 }
 
-//#ifndef DOXY  // hide SFINAE specialization for BSR
-//template <class execution_space, class AlphaType, class AMatrix, class XVector,
-//          class BetaType, class YVector,
-//          typename std::enable_if<KokkosSparse::Experimental::is_bsr_matrix<
-//              AMatrix>::value>::type* = nullptr>
-//template <class execution_space, class AlphaType, class AMatrix, class XVector,
-//          class BetaType, class YVector>
-//void spmv(const execution_space& exec,
-//          KokkosKernels::Experimental::Controls controls, const char mode[],
-//          const AlphaType& alpha, const AMatrix& A, const XVector& x,
-//          const BetaType& beta, const YVector& y, const RANK_ONE& tag) {
-//  // Make sure that x and y are Views.
-//  static_assert(Kokkos::is_view<XVector>::value,
-//                "KokkosSparse::spmv: XVector must be a Kokkos::View.");
-//  static_assert(Kokkos::is_view<YVector>::value,
-//                "KokkosSparse::spmv: YVector must be a Kokkos::View.");
-//  // Make sure A, x, y are accessible to execution_space
-//  static_assert(
-//      Kokkos::SpaceAccessibility<execution_space,
-//                                 typename AMatrix::memory_space>::accessible,
-//      "KokkosBlas::spmv: AMatrix must be accessible from execution_space");
-//  static_assert(
-//      Kokkos::SpaceAccessibility<execution_space,
-//                                 typename XVector::memory_space>::accessible,
-//      "KokkosBlas::spmv: XVector must be accessible from execution_space");
-//  static_assert(
-//      Kokkos::SpaceAccessibility<execution_space,
-//                                 typename YVector::memory_space>::accessible,
-//      "KokkosBlas::spmv: YVector must be accessible from execution_space");
-//  // Make sure that x and y have the same rank.
-//  static_assert(XVector::rank == YVector::rank,
-//                "KokkosSparse::spmv: Vector ranks do not match.");
-//  // Make sure that x (and therefore y) is rank 1.
-//  static_assert(static_cast<int>(XVector::rank) == 1,
-//                "KokkosSparse::spmv: Both Vector inputs must have rank 1 "
-//                "in order to call this specialization of spmv.");
-//  // Make sure that y is non-const.
-//  static_assert(std::is_same<typename YVector::value_type,
-//                             typename YVector::non_const_value_type>::value,
-//                "KokkosSparse::spmv: Output Vector must be non-const.");
-//
-//  //
-//  if (A.blockDim() == 1) {
-//    KokkosSparse::CrsMatrix<
-//        typename AMatrix::value_type, typename AMatrix::ordinal_type,
-//        typename AMatrix::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>,
-//        typename AMatrix::size_type>
-//        Acrs("bsr_to_crs", A.numCols(), A.values, A.graph);
-//    KokkosSparse::spmv(exec, controls, mode, alpha, Acrs, x, beta, y,
-//                       RANK_ONE());
-//    return;
-//  }
-//  // Check compatibility of dimensions at run time.
-//  if ((mode[0] == NoTranspose[0]) || (mode[0] == Conjugate[0])) {
-//    if ((x.extent(1) != y.extent(1)) ||
-//        (static_cast<size_t>(A.numCols() * A.blockDim()) !=
-//         static_cast<size_t>(x.extent(0))) ||
-//        (static_cast<size_t>(A.numRows() * A.blockDim()) !=
-//         static_cast<size_t>(y.extent(0)))) {
-//      std::ostringstream os;
-//      os << "KokkosSparse::spmv (BsrMatrix): Dimensions do not match: "
-//         << ", A: " << A.numRows() * A.blockDim() << " x "
-//         << A.numCols() * A.blockDim() << ", x: " << x.extent(0) << " x "
-//         << x.extent(1) << ", y: " << y.extent(0) << " x " << y.extent(1);
-//
-//      KokkosKernels::Impl::throw_runtime_exception(os.str());
-//    }
-//  } else {
-//    if ((x.extent(1) != y.extent(1)) ||
-//        (static_cast<size_t>(A.numCols() * A.blockDim()) !=
-//         static_cast<size_t>(y.extent(0))) ||
-//        (static_cast<size_t>(A.numRows() * A.blockDim()) !=
-//         static_cast<size_t>(x.extent(0)))) {
-//      std::ostringstream os;
-//      os << "KokkosSparse::spmv (BsrMatrix): Dimensions do not match "
-//            "(transpose): "
-//         << ", A: " << A.numRows() * A.blockDim() << " x "
-//         << A.numCols() * A.blockDim() << ", x: " << x.extent(0) << " x "
-//         << x.extent(1) << ", y: " << y.extent(0) << " x " << y.extent(1);
-//
-//      KokkosKernels::Impl::throw_runtime_exception(os.str());
-//    }
-//  }
-//  //
-//  typedef KokkosSparse::Experimental::BsrMatrix<
-//      typename AMatrix::const_value_type, typename AMatrix::const_ordinal_type,
-//      typename AMatrix::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>,
-//      typename AMatrix::const_size_type>
-//      AMatrix_Internal;
-//
-//  typedef Kokkos::View<
-//      typename XVector::const_value_type*,
-//      typename KokkosKernels::Impl::GetUnifiedLayout<XVector>::array_layout,
-//      typename XVector::device_type,
-//      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >
-//      XVector_Internal;
-//
-//  typedef Kokkos::View<
-//      typename YVector::non_const_value_type*,
-//      typename KokkosKernels::Impl::GetUnifiedLayout<YVector>::array_layout,
-//      typename YVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
-//      YVector_Internal;
-//
-//  AMatrix_Internal A_i(A);
-//  XVector_Internal x_i(x);
-//  YVector_Internal y_i(y);
-//
-//  if (alpha == Kokkos::ArithTraits<AlphaType>::zero() || A_i.numRows() == 0 ||
-//      A_i.numCols() == 0 || A_i.nnz() == 0) {
-//    // This is required to maintain semantics of KokkosKernels native SpMV:
-//    // if y contains NaN but beta = 0, the result y should be filled with 0.
-//    // For example, this is useful for passing in uninitialized y and beta=0.
-//    if (beta == Kokkos::ArithTraits<BetaType>::zero())
-//      Kokkos::deep_copy(exec, y_i, Kokkos::ArithTraits<BetaType>::zero());
-//    else
-//      KokkosBlas::scal(exec, y_i, beta, y_i);
-//    return;
-//  }
-//
-//  //
-//  // Whether to call KokkosKernel's native implementation, even if a TPL impl is
-//  // available
-//  bool useFallback = controls.isParameter("algorithm") &&
-//                     (controls.getParameter("algorithm") != "tpl");
-//
-//#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
-//  // cuSPARSE does not support the modes (C), (T), (H)
-//  if (std::is_same<typename AMatrix_Internal::memory_space,
-//                   Kokkos::CudaSpace>::value ||
-//      std::is_same<typename AMatrix_Internal::memory_space,
-//                   Kokkos::CudaUVMSpace>::value) {
-//    useFallback = useFallback || (mode[0] != NoTranspose[0]);
-//  }
-//#endif
-//
-//#ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
-//  if (std::is_same<typename AMatrix_Internal::memory_space,
-//                   Kokkos::HostSpace>::value) {
-//    useFallback = useFallback || (mode[0] == Conjugate[0]);
-//  }
-//#endif
-//
-//#ifdef KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE
-//  // rocSparse does not support the modes (C), (T), (H)
-//  if constexpr (std::is_same_v<typename AMatrix_Internal::memory_space,
-//                               Kokkos::HIPSpace>) {
-//    useFallback = useFallback || (mode[0] != NoTranspose[0]);
-//  }
-//#endif
-//
-//  if (useFallback) {
-//    // Explicitly call the non-TPL SPMV_BSRMATRIX implementation
-//    std::string label =
-//        "KokkosSparse::spmv[NATIVE,BSRMATRIX," +
-//        Kokkos::ArithTraits<
-//            typename AMatrix_Internal::non_const_value_type>::name() +
-//        "]";
-//    Kokkos::Profiling::pushRegion(label);
-//    Experimental::Impl::SPMV_BSRMATRIX<
-//        execution_space, typename AMatrix_Internal::const_value_type,
-//        typename AMatrix_Internal::const_ordinal_type,
-//        typename AMatrix_Internal::device_type,
-//        typename AMatrix_Internal::memory_traits,
-//        typename AMatrix_Internal::const_size_type,
-//        typename XVector_Internal::const_value_type*,
-//        typename XVector_Internal::array_layout,
-//        typename XVector_Internal::device_type,
-//        typename XVector_Internal::memory_traits,
-//        typename YVector_Internal::value_type*,
-//        typename YVector_Internal::array_layout,
-//        typename YVector_Internal::device_type,
-//        typename YVector_Internal::memory_traits,
-//        false>::spmv_bsrmatrix(exec, controls, mode, alpha, A_i, x_i, beta,
-//                               y_i);
-//    Kokkos::Profiling::popRegion();
-//  } else {
-//#define __SPMV_TYPES__                                          \
-//  execution_space, typename AMatrix_Internal::const_value_type, \
-//      typename AMatrix_Internal::const_ordinal_type,            \
-//      typename AMatrix_Internal::device_type,                   \
-//      typename AMatrix_Internal::memory_traits,                 \
-//      typename AMatrix_Internal::const_size_type,               \
-//      typename XVector_Internal::const_value_type*,             \
-//      typename XVector_Internal::array_layout,                  \
-//      typename XVector_Internal::device_type,                   \
-//      typename XVector_Internal::memory_traits,                 \
-//      typename YVector_Internal::value_type*,                   \
-//      typename YVector_Internal::array_layout,                  \
-//      typename YVector_Internal::device_type,                   \
-//      typename YVector_Internal::memory_traits
-//
-//    constexpr bool tpl_spec_avail =
-//        KokkosSparse::Experimental::Impl::spmv_bsrmatrix_tpl_spec_avail<
-//            __SPMV_TYPES__>::value;
-//
-//    constexpr bool eti_spec_avail =
-//        tpl_spec_avail
-//            ? KOKKOSKERNELS_IMPL_COMPILE_LIBRARY /* force FALSE in app/test */
-//            : KokkosSparse::Experimental::Impl::spmv_bsrmatrix_eti_spec_avail<
-//                  __SPMV_TYPES__>::value;
-//
-//    Experimental::Impl::SPMV_BSRMATRIX<__SPMV_TYPES__, tpl_spec_avail,
-//                                       eti_spec_avail>::spmv_bsrmatrix(exec,
-//                                                                       controls,
-//                                                                       mode,
-//                                                                       alpha,
-//                                                                       A_i, x_i,
-//                                                                       beta,
-//                                                                       y_i);
-//
-//#undef __SPMV_TYPES__
-//  }
-//}
-//
-//template <class AlphaType, class AMatrix, class XVector, class BetaType,
-//          class YVector>
-//template <class AlphaType, class AMatrix, class XVector, class BetaType,
-//          class YVector,
-//          typename std::enable_if<KokkosSparse::Experimental::is_bsr_matrix<
-//              AMatrix>::value>::type* = nullptr>
-//void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
-//          const AlphaType& alpha, const AMatrix& A, const XVector& x,
-//          const BetaType& beta, const YVector& y, const RANK_ONE& tag) {
-//  spmv(typename AMatrix::execution_space{}, controls, mode, alpha, A, x, beta,
-//       y, tag);
-//}
-//#endif // ifndef DOXY
+#ifndef DOXY  // hide SFINAE specialization for BSR
+template <class execution_space, class AlphaType, class AMatrix, class XVector,
+          class BetaType, class YVector,
+          typename std::enable_if<KokkosSparse::Experimental::is_bsr_matrix<
+              AMatrix>::value>::type* = nullptr>
+template <class execution_space, class AlphaType, class AMatrix, class XVector,
+          class BetaType, class YVector>
+void spmv(const execution_space& exec,
+          KokkosKernels::Experimental::Controls controls, const char mode[],
+          const AlphaType& alpha, const AMatrix& A, const XVector& x,
+          const BetaType& beta, const YVector& y, const RANK_ONE& tag) {
+  // Make sure that x and y are Views.
+  static_assert(Kokkos::is_view<XVector>::value,
+                "KokkosSparse::spmv: XVector must be a Kokkos::View.");
+  static_assert(Kokkos::is_view<YVector>::value,
+                "KokkosSparse::spmv: YVector must be a Kokkos::View.");
+  // Make sure A, x, y are accessible to execution_space
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename AMatrix::memory_space>::accessible,
+      "KokkosBlas::spmv: AMatrix must be accessible from execution_space");
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename XVector::memory_space>::accessible,
+      "KokkosBlas::spmv: XVector must be accessible from execution_space");
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename YVector::memory_space>::accessible,
+      "KokkosBlas::spmv: YVector must be accessible from execution_space");
+  // Make sure that x and y have the same rank.
+  static_assert(XVector::rank == YVector::rank,
+                "KokkosSparse::spmv: Vector ranks do not match.");
+  // Make sure that x (and therefore y) is rank 1.
+  static_assert(static_cast<int>(XVector::rank) == 1,
+                "KokkosSparse::spmv: Both Vector inputs must have rank 1 "
+                "in order to call this specialization of spmv.");
+  // Make sure that y is non-const.
+  static_assert(std::is_same<typename YVector::value_type,
+                             typename YVector::non_const_value_type>::value,
+                "KokkosSparse::spmv: Output Vector must be non-const.");
+
+  //
+  if (A.blockDim() == 1) {
+    KokkosSparse::CrsMatrix<
+        typename AMatrix::value_type, typename AMatrix::ordinal_type,
+        typename AMatrix::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>,
+        typename AMatrix::size_type>
+        Acrs("bsr_to_crs", A.numCols(), A.values, A.graph);
+    KokkosSparse::spmv(exec, controls, mode, alpha, Acrs, x, beta, y,
+                       RANK_ONE());
+    return;
+  }
+  // Check compatibility of dimensions at run time.
+  if ((mode[0] == NoTranspose[0]) || (mode[0] == Conjugate[0])) {
+    if ((x.extent(1) != y.extent(1)) ||
+        (static_cast<size_t>(A.numCols() * A.blockDim()) !=
+         static_cast<size_t>(x.extent(0))) ||
+        (static_cast<size_t>(A.numRows() * A.blockDim()) !=
+         static_cast<size_t>(y.extent(0)))) {
+      std::ostringstream os;
+      os << "KokkosSparse::spmv (BsrMatrix): Dimensions do not match: "
+         << ", A: " << A.numRows() * A.blockDim() << " x "
+         << A.numCols() * A.blockDim() << ", x: " << x.extent(0) << " x "
+         << x.extent(1) << ", y: " << y.extent(0) << " x " << y.extent(1);
+
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
+  } else {
+    if ((x.extent(1) != y.extent(1)) ||
+        (static_cast<size_t>(A.numCols() * A.blockDim()) !=
+         static_cast<size_t>(y.extent(0))) ||
+        (static_cast<size_t>(A.numRows() * A.blockDim()) !=
+         static_cast<size_t>(x.extent(0)))) {
+      std::ostringstream os;
+      os << "KokkosSparse::spmv (BsrMatrix): Dimensions do not match "
+            "(transpose): "
+         << ", A: " << A.numRows() * A.blockDim() << " x "
+         << A.numCols() * A.blockDim() << ", x: " << x.extent(0) << " x "
+         << x.extent(1) << ", y: " << y.extent(0) << " x " << y.extent(1);
+
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
+  }
+  //
+  typedef KokkosSparse::Experimental::BsrMatrix<
+      typename AMatrix::const_value_type, typename AMatrix::const_ordinal_type,
+      typename AMatrix::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>,
+      typename AMatrix::const_size_type>
+      AMatrix_Internal;
+
+  typedef Kokkos::View<
+      typename XVector::const_value_type*,
+      typename KokkosKernels::Impl::GetUnifiedLayout<XVector>::array_layout,
+      typename XVector::device_type,
+      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >
+      XVector_Internal;
+
+  typedef Kokkos::View<
+      typename YVector::non_const_value_type*,
+      typename KokkosKernels::Impl::GetUnifiedLayout<YVector>::array_layout,
+      typename YVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+      YVector_Internal;
+
+  AMatrix_Internal A_i(A);
+  XVector_Internal x_i(x);
+  YVector_Internal y_i(y);
+
+  if (alpha == Kokkos::ArithTraits<AlphaType>::zero() || A_i.numRows() == 0 ||
+      A_i.numCols() == 0 || A_i.nnz() == 0) {
+    // This is required to maintain semantics of KokkosKernels native SpMV:
+    // if y contains NaN but beta = 0, the result y should be filled with 0.
+    // For example, this is useful for passing in uninitialized y and beta=0.
+    if (beta == Kokkos::ArithTraits<BetaType>::zero())
+      Kokkos::deep_copy(exec, y_i, Kokkos::ArithTraits<BetaType>::zero());
+    else
+      KokkosBlas::scal(exec, y_i, beta, y_i);
+    return;
+  }
+
+  //
+  // Whether to call KokkosKernel's native implementation, even if a TPL impl is
+  // available
+  bool useFallback = controls.isParameter("algorithm") &&
+                     (controls.getParameter("algorithm") != "tpl");
+
+#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+  // cuSPARSE does not support the modes (C), (T), (H)
+  if (std::is_same<typename AMatrix_Internal::memory_space,
+                   Kokkos::CudaSpace>::value ||
+      std::is_same<typename AMatrix_Internal::memory_space,
+                   Kokkos::CudaUVMSpace>::value) {
+    useFallback = useFallback || (mode[0] != NoTranspose[0]);
+  }
+#endif
+
+#ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
+  if (std::is_same<typename AMatrix_Internal::memory_space,
+                   Kokkos::HostSpace>::value) {
+    useFallback = useFallback || (mode[0] == Conjugate[0]);
+  }
+#endif
+
+#ifdef KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE
+  // rocSparse does not support the modes (C), (T), (H)
+  if constexpr (std::is_same_v<typename AMatrix_Internal::memory_space,
+                               Kokkos::HIPSpace>) {
+    useFallback = useFallback || (mode[0] != NoTranspose[0]);
+  }
+#endif
+
+  if (useFallback) {
+    // Explicitly call the non-TPL SPMV_BSRMATRIX implementation
+    std::string label =
+        "KokkosSparse::spmv[NATIVE,BSRMATRIX," +
+        Kokkos::ArithTraits<
+            typename AMatrix_Internal::non_const_value_type>::name() +
+        "]";
+    Kokkos::Profiling::pushRegion(label);
+    Experimental::Impl::SPMV_BSRMATRIX<
+        execution_space, typename AMatrix_Internal::const_value_type,
+        typename AMatrix_Internal::const_ordinal_type,
+        typename AMatrix_Internal::device_type,
+        typename AMatrix_Internal::memory_traits,
+        typename AMatrix_Internal::const_size_type,
+        typename XVector_Internal::const_value_type*,
+        typename XVector_Internal::array_layout,
+        typename XVector_Internal::device_type,
+        typename XVector_Internal::memory_traits,
+        typename YVector_Internal::value_type*,
+        typename YVector_Internal::array_layout,
+        typename YVector_Internal::device_type,
+        typename YVector_Internal::memory_traits,
+        false>::spmv_bsrmatrix(exec, controls, mode, alpha, A_i, x_i, beta,
+                               y_i);
+    Kokkos::Profiling::popRegion();
+  } else {
+#define __SPMV_TYPES__                                          \
+  execution_space, typename AMatrix_Internal::const_value_type, \
+      typename AMatrix_Internal::const_ordinal_type,            \
+      typename AMatrix_Internal::device_type,                   \
+      typename AMatrix_Internal::memory_traits,                 \
+      typename AMatrix_Internal::const_size_type,               \
+      typename XVector_Internal::const_value_type*,             \
+      typename XVector_Internal::array_layout,                  \
+      typename XVector_Internal::device_type,                   \
+      typename XVector_Internal::memory_traits,                 \
+      typename YVector_Internal::value_type*,                   \
+      typename YVector_Internal::array_layout,                  \
+      typename YVector_Internal::device_type,                   \
+      typename YVector_Internal::memory_traits
+
+    constexpr bool tpl_spec_avail =
+        KokkosSparse::Experimental::Impl::spmv_bsrmatrix_tpl_spec_avail<
+            __SPMV_TYPES__>::value;
+
+    constexpr bool eti_spec_avail =
+        tpl_spec_avail
+            ? KOKKOSKERNELS_IMPL_COMPILE_LIBRARY /* force FALSE in app/test */
+            : KokkosSparse::Experimental::Impl::spmv_bsrmatrix_eti_spec_avail<
+                  __SPMV_TYPES__>::value;
+
+    Experimental::Impl::SPMV_BSRMATRIX<__SPMV_TYPES__, tpl_spec_avail,
+                                       eti_spec_avail>::spmv_bsrmatrix(exec,
+                                                                       controls,
+                                                                       mode,
+                                                                       alpha,
+                                                                       A_i, x_i,
+                                                                       beta,
+                                                                       y_i);
+
+#undef __SPMV_TYPES__
+  }
+}
+
+template <class AlphaType, class AMatrix, class XVector, class BetaType,
+          class YVector>
+template <class AlphaType, class AMatrix, class XVector, class BetaType,
+          class YVector,
+          typename std::enable_if<KokkosSparse::Experimental::is_bsr_matrix<
+              AMatrix>::value>::type* = nullptr>
+void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
+          const AlphaType& alpha, const AMatrix& A, const XVector& x,
+          const BetaType& beta, const YVector& y, const RANK_ONE& tag) {
+  spmv(typename AMatrix::execution_space{}, controls, mode, alpha, A, x, beta,
+       y, tag);
+}
+#endif  // ifndef DOXY
 
 namespace Impl {
 template <class AlphaType, class AMatrix, class XVector, class BetaType,
@@ -677,36 +678,38 @@ using SPMV2D1D
                  "use KokkosSparse::spmv instead")]] =
         Impl::SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector>;
 
-/// \brief \c Kokkos sparse matrix-vector multiply on multivectors
-/// (RANK_TWO tag). Computes y := alpha*Op(A)*x + beta*y, where Op(A) is controlled by mode (see below).
+/// \brief Kokkos sparse matrix-vector multiply on multivectors
+/// (RANK_TWO tag). Computes y := alpha*Op(A)*x + beta*y, where Op(A) is
+/// controlled by mode (see below).
 ///
 /// \tparam execution_space A Kokkos execution space. Must be able to access
 ///   the memory spaces of A, x, and y.
-/// \tparam AlphaType Type of coefficient alpha. Must be convertible to YVector::value_type.
-/// \tparam AMatrix A KokkosSparse::CrsMatrix, or KokkosSparse::BsrMatrix
-/// \tparam XVector Type of x, must be a rank-2 Kokkos::View
-/// \tparam BetaType Type of coefficient beta. Must be convertible to YVector::value_type.
-/// \tparam YVector Type of y, must be a rank-2 Kokkos::View and its rank must match that of XVector
+/// \tparam AlphaType Type of coefficient alpha. Must be convertible to
+/// YVector::value_type. \tparam AMatrix A KokkosSparse::CrsMatrix, or
+/// KokkosSparse::BsrMatrix \tparam XVector Type of x, must be a rank-2
+/// Kokkos::View \tparam BetaType Type of coefficient beta. Must be convertible
+/// to YVector::value_type. \tparam YVector Type of y, must be a rank-2
+/// Kokkos::View and its rank must match that of XVector
 ///
 /// \param exec [in] The execution space instance on which to run the
 ///   kernel.
 /// \param controls [in] kokkos-kernels control structure.
-/// \param mode [in] Select A's operator mode: "N" for normal, "T" for transpose, "C" for conjugate or "H" for conjugate transpose.
-/// \param alpha [in] Scalar multiplier for the matrix A.
-/// \param A [in] The sparse matrix A.
+/// \param mode [in] Select A's operator mode: "N" for normal, "T" for
+/// transpose, "C" for conjugate or "H" for conjugate transpose. \param alpha
+/// [in] Scalar multiplier for the matrix A. \param A [in] The sparse matrix A.
 /// \param x [in] A vector to multiply on the left by A.
 /// \param beta [in] Scalar multiplier for the vector y.
 /// \param y [in/out] Result vector.
 /// \param tag RANK_TWO dispatch
-//#ifdef DOXY //documentation version
+#ifdef DOXY  // documentation version
 template <class execution_space, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector>
-//#else
-//template <class execution_space, class AlphaType, class AMatrix, class XVector,
-//          class BetaType, class YVector,
-//          typename std::enable_if<
-//              KokkosSparse::is_crs_matrix<AMatrix>::value>::type* = nullptr>
-//#endif
+#else
+template <class execution_space, class AlphaType, class AMatrix, class XVector,
+          class BetaType, class YVector,
+          typename std::enable_if<
+              KokkosSparse::is_crs_matrix<AMatrix>::value>::type* = nullptr>
+#endif
 void spmv(const execution_space& exec,
           KokkosKernels::Experimental::Controls controls, const char mode[],
           const AlphaType& alpha, const AMatrix& A, const XVector& x,
@@ -864,32 +867,34 @@ void spmv(const execution_space& exec,
   }
 }
 
-/// \brief \c Kokkos sparse matrix-vector multiply on multivectors
-/// (RANK_TWO tag). Computes y := alpha*Op(A)*x + beta*y, where Op(A) is controlled by mode (see below).
+/// \brief Kokkos sparse matrix-vector multiply on multivectors
+/// (RANK_TWO tag). Computes y := alpha*Op(A)*x + beta*y, where Op(A) is
+/// controlled by mode (see below).
 ///
-/// \tparam AlphaType Type of coefficient alpha. Must be convertible to YVector::value_type.
-/// \tparam AMatrix A KokkosSparse::CrsMatrix, or KokkosSparse::BsrMatrix
-/// \tparam XVector Type of x, must be a rank-2 Kokkos::View
-/// \tparam BetaType Type of coefficient beta. Must be convertible to YVector::value_type.
-/// \tparam YVector Type of y, must be a rank-2 Kokkos::View and its rank must match that of XVector
+/// \tparam AlphaType Type of coefficient alpha. Must be convertible to
+/// YVector::value_type. \tparam AMatrix A KokkosSparse::CrsMatrix, or
+/// KokkosSparse::BsrMatrix \tparam XVector Type of x, must be a rank-2
+/// Kokkos::View \tparam BetaType Type of coefficient beta. Must be convertible
+/// to YVector::value_type. \tparam YVector Type of y, must be a rank-2
+/// Kokkos::View and its rank must match that of XVector
 ///
 /// \param controls [in] kokkos-kernels control structure.
-/// \param mode [in] Select A's operator mode: "N" for normal, "T" for transpose, "C" for conjugate or "H" for conjugate transpose.
-/// \param alpha [in] Scalar multiplier for the matrix A.
-/// \param A [in] The sparse matrix A.
+/// \param mode [in] Select A's operator mode: "N" for normal, "T" for
+/// transpose, "C" for conjugate or "H" for conjugate transpose. \param alpha
+/// [in] Scalar multiplier for the matrix A. \param A [in] The sparse matrix A.
 /// \param x [in] A vector to multiply on the left by A.
 /// \param beta [in] Scalar multiplier for the vector y.
 /// \param y [in/out] Result vector.
 /// \param tag RANK_TWO dispatch
-//#ifdef DOXY
+#ifdef DOXY
 template <class AlphaType, class AMatrix, class XVector, class BetaType,
           class YVector>
-//#else
-//template <class AlphaType, class AMatrix, class XVector, class BetaType,
-//          class YVector,
-//          typename std::enable_if<
-//              KokkosSparse::is_crs_matrix<AMatrix>::value>::type* = nullptr>
-//#endif
+#else
+template <class AlphaType, class AMatrix, class XVector, class BetaType,
+          class YVector,
+          typename std::enable_if<
+              KokkosSparse::is_crs_matrix<AMatrix>::value>::type* = nullptr>
+#endif
 void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
           const AlphaType& alpha, const AMatrix& A, const XVector& x,
           const BetaType& beta, const YVector& y, const RANK_TWO& tag) {
@@ -897,223 +902,223 @@ void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
        y, tag);
 }
 
-//#ifndef DOXY  // hide SFINAE
-//template <class execution_space, class AlphaType, class AMatrix, class XVector,
-//          class BetaType, class YVector,
-//          typename std::enable_if<KokkosSparse::Experimental::is_bsr_matrix<
-//              AMatrix>::value>::type* = nullptr>
-//void spmv(const execution_space& exec,
-//          KokkosKernels::Experimental::Controls controls, const char mode[],
-//          const AlphaType& alpha, const AMatrix& A, const XVector& x,
-//          const BetaType& beta, const YVector& y, const RANK_TWO& tag) {
-//  // Make sure that x and y are Views.
-//  static_assert(Kokkos::is_view<XVector>::value,
-//                "KokkosSparse::spmv: XVector must be a Kokkos::View.");
-//  static_assert(Kokkos::is_view<YVector>::value,
-//                "KokkosSparse::spmv: YVector must be a Kokkos::View.");
-//  // Make sure A, x, y are accessible to execution_space
-//  static_assert(
-//      Kokkos::SpaceAccessibility<execution_space,
-//                                 typename AMatrix::memory_space>::accessible,
-//      "KokkosBlas::spmv: AMatrix must be accessible from execution_space");
-//  static_assert(
-//      Kokkos::SpaceAccessibility<execution_space,
-//                                 typename XVector::memory_space>::accessible,
-//      "KokkosBlas::spmv: XVector must be accessible from execution_space");
-//  static_assert(
-//      Kokkos::SpaceAccessibility<execution_space,
-//                                 typename YVector::memory_space>::accessible,
-//      "KokkosBlas::spmv: YVector must be accessible from execution_space");
-//  // Make sure that x and y have the same rank.
-//  static_assert(
-//      static_cast<int>(XVector::rank) == static_cast<int>(YVector::rank),
-//      "KokkosSparse::spmv: Vector ranks do not match.");
-//  // Make sure that x (and therefore y) is rank 2.
-//  static_assert(static_cast<int>(XVector::rank) == 2,
-//                "KokkosSparse::spmv: Both Vector inputs must have rank 2 "
-//                "in order to call this specialization of spmv.");
-//  // Make sure that y is non-const.
-//  static_assert(std::is_same<typename YVector::value_type,
-//                             typename YVector::non_const_value_type>::value,
-//                "KokkosSparse::spmv: Output Vector must be non-const.");
-//
-//  //
-//  if (A.blockDim() == 1) {
-//    KokkosSparse::CrsMatrix<
-//        typename AMatrix::value_type, typename AMatrix::ordinal_type,
-//        typename AMatrix::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>,
-//        typename AMatrix::size_type>
-//        Acrs("bsr_to_crs", A.numCols(), A.values, A.graph);
-//    KokkosSparse::spmv(exec, controls, mode, alpha, Acrs, x, beta, y,
-//                       RANK_TWO());
-//    return;
-//  }
-//  // Check compatibility of dimensions at run time.
-//  if ((mode[0] == NoTranspose[0]) || (mode[0] == Conjugate[0])) {
-//    if ((x.extent(1) != y.extent(1)) ||
-//        (static_cast<size_t>(A.numCols() * A.blockDim()) !=
-//         static_cast<size_t>(x.extent(0))) ||
-//        (static_cast<size_t>(A.numRows() * A.blockDim()) !=
-//         static_cast<size_t>(y.extent(0)))) {
-//      std::ostringstream os;
-//      os << "KokkosSparse::spmv (BsrMatrix): Dimensions do not match: "
-//         << ", A: " << A.numRows() * A.blockDim() << " x "
-//         << A.numCols() * A.blockDim() << ", x: " << x.extent(0) << " x "
-//         << x.extent(1) << ", y: " << y.extent(0) << " x " << y.extent(1);
-//
-//      KokkosKernels::Impl::throw_runtime_exception(os.str());
-//    }
-//  } else {
-//    if ((x.extent(1) != y.extent(1)) ||
-//        (static_cast<size_t>(A.numCols() * A.blockDim()) !=
-//         static_cast<size_t>(y.extent(0))) ||
-//        (static_cast<size_t>(A.numRows() * A.blockDim()) !=
-//         static_cast<size_t>(x.extent(0)))) {
-//      std::ostringstream os;
-//      os << "KokkosSparse::spmv (BsrMatrix): Dimensions do not match "
-//            "(transpose): "
-//         << ", A: " << A.numRows() * A.blockDim() << " x "
-//         << A.numCols() * A.blockDim() << ", x: " << x.extent(0) << " x "
-//         << x.extent(1) << ", y: " << y.extent(0) << " x " << y.extent(1);
-//
-//      KokkosKernels::Impl::throw_runtime_exception(os.str());
-//    }
-//  }
-//  //
-//  typedef KokkosSparse::Experimental::BsrMatrix<
-//      typename AMatrix::const_value_type, typename AMatrix::const_ordinal_type,
-//      typename AMatrix::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>,
-//      typename AMatrix::const_size_type>
-//      AMatrix_Internal;
-//  AMatrix_Internal A_i(A);
-//
-//  typedef Kokkos::View<
-//      typename XVector::const_value_type**,
-//      typename KokkosKernels::Impl::GetUnifiedLayout<XVector>::array_layout,
-//      typename XVector::device_type,
-//      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >
-//      XVector_Internal;
-//  XVector_Internal x_i(x);
-//
-//  typedef Kokkos::View<
-//      typename YVector::non_const_value_type**,
-//      typename KokkosKernels::Impl::GetUnifiedLayout<YVector>::array_layout,
-//      typename YVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
-//      YVector_Internal;
-//  YVector_Internal y_i(y);
-//  //
-//  if (alpha == Kokkos::ArithTraits<AlphaType>::zero() || A_i.numRows() == 0 ||
-//      A_i.numCols() == 0 || A_i.nnz() == 0) {
-//    // This is required to maintain semantics of KokkosKernels native SpMV:
-//    // if y contains NaN but beta = 0, the result y should be filled with 0.
-//    // For example, this is useful for passing in uninitialized y and beta=0.
-//    if (beta == Kokkos::ArithTraits<BetaType>::zero())
-//      Kokkos::deep_copy(exec, y_i, Kokkos::ArithTraits<BetaType>::zero());
-//    else
-//      KokkosBlas::scal(exec, y_i, beta, y_i);
-//    return;
-//  }
-//  //
-//  // Call single-vector version if appropriate
-//  //
-//  if (x.extent(1) == 1) {
-//    typedef Kokkos::View<
-//        typename XVector::const_value_type*,
-//        typename KokkosKernels::Impl::GetUnifiedLayout<XVector>::array_layout,
-//        typename XVector::device_type,
-//        Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >
-//        XVector_SubInternal;
-//    typedef Kokkos::View<
-//        typename YVector::non_const_value_type*,
-//        typename KokkosKernels::Impl::GetUnifiedLayout<YVector>::array_layout,
-//        typename YVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
-//        YVector_SubInternal;
-//
-//    XVector_SubInternal x_0 = Kokkos::subview(x_i, Kokkos::ALL(), 0);
-//    YVector_SubInternal y_0 = Kokkos::subview(y_i, Kokkos::ALL(), 0);
-//
-//    return spmv(exec, controls, mode, alpha, A_i, x_0, beta, y_0, RANK_ONE());
-//  }
-//  //
-//  // Whether to call KokkosKernel's native implementation, even if a TPL impl is
-//  // available
-//  bool useFallback = controls.isParameter("algorithm") &&
-//                     (controls.getParameter("algorithm") != "tpl");
-//
-//#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
-//  // cuSPARSE does not support the modes (C), (T), (H)
-//  if (std::is_same<typename AMatrix_Internal::memory_space,
-//                   Kokkos::CudaSpace>::value ||
-//      std::is_same<typename AMatrix_Internal::memory_space,
-//                   Kokkos::CudaUVMSpace>::value) {
-//    useFallback = useFallback || (mode[0] != NoTranspose[0]);
-//  }
-//#endif
-//
-//#ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
-//  if (std::is_same<typename AMatrix_Internal::memory_space,
-//                   Kokkos::HostSpace>::value) {
-//    useFallback = useFallback || (mode[0] == Conjugate[0]);
-//  }
-//#endif
-//
-//  if (useFallback) {
-//    // Explicitly call the non-TPL SPMV_BSRMATRIX implementation
-//    std::string label =
-//        "KokkosSparse::spmv[NATIVE,BSMATRIX," +
-//        Kokkos::ArithTraits<
-//            typename AMatrix_Internal::non_const_value_type>::name() +
-//        "]";
-//    Kokkos::Profiling::pushRegion(label);
-//    Experimental::Impl::SPMV_MV_BSRMATRIX<
-//        execution_space, typename AMatrix_Internal::const_value_type,
-//        typename AMatrix_Internal::const_ordinal_type,
-//        typename AMatrix_Internal::device_type,
-//        typename AMatrix_Internal::memory_traits,
-//        typename AMatrix_Internal::const_size_type,
-//        typename XVector_Internal::const_value_type**,
-//        typename XVector_Internal::array_layout,
-//        typename XVector_Internal::device_type,
-//        typename XVector_Internal::memory_traits,
-//        typename YVector_Internal::value_type**,
-//        typename YVector_Internal::array_layout,
-//        typename YVector_Internal::device_type,
-//        typename YVector_Internal::memory_traits,
-//        std::is_integral<typename AMatrix_Internal::const_value_type>::value,
-//        false>::spmv_mv_bsrmatrix(exec, controls, mode, alpha, A_i, x_i, beta,
-//                                  y_i);
-//    Kokkos::Profiling::popRegion();
-//  } else {
-//    Experimental::Impl::SPMV_MV_BSRMATRIX<
-//        execution_space, typename AMatrix_Internal::const_value_type,
-//        typename AMatrix_Internal::const_ordinal_type,
-//        typename AMatrix_Internal::device_type,
-//        typename AMatrix_Internal::memory_traits,
-//        typename AMatrix_Internal::const_size_type,
-//        typename XVector_Internal::const_value_type**,
-//        typename XVector_Internal::array_layout,
-//        typename XVector_Internal::device_type,
-//        typename XVector_Internal::memory_traits,
-//        typename YVector_Internal::value_type**,
-//        typename YVector_Internal::array_layout,
-//        typename YVector_Internal::device_type,
-//        typename YVector_Internal::memory_traits,
-//        std::is_integral<typename AMatrix_Internal::const_value_type>::value>::
-//        spmv_mv_bsrmatrix(exec, controls, mode, alpha, A_i, x_i, beta, y_i);
-//  }
-//}
-//
-//template <class AlphaType, class AMatrix, class XVector, class BetaType,
-//          class YVector,
-//          typename std::enable_if<KokkosSparse::Experimental::is_bsr_matrix<
-//              AMatrix>::value>::type* = nullptr>
-//void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
-//          const AlphaType& alpha, const AMatrix& A, const XVector& x,
-//          const BetaType& beta, const YVector& y, const RANK_TWO& tag) {
-//  spmv(typename AMatrix::execution_space{}, controls, mode, alpha, A, x, beta,
-//       y, tag);
-//}
-//#endif
+#ifndef DOXY  // hide SFINAE
+template <class execution_space, class AlphaType, class AMatrix, class XVector,
+          class BetaType, class YVector,
+          typename std::enable_if<KokkosSparse::Experimental::is_bsr_matrix<
+              AMatrix>::value>::type* = nullptr>
+void spmv(const execution_space& exec,
+          KokkosKernels::Experimental::Controls controls, const char mode[],
+          const AlphaType& alpha, const AMatrix& A, const XVector& x,
+          const BetaType& beta, const YVector& y, const RANK_TWO& tag) {
+  // Make sure that x and y are Views.
+  static_assert(Kokkos::is_view<XVector>::value,
+                "KokkosSparse::spmv: XVector must be a Kokkos::View.");
+  static_assert(Kokkos::is_view<YVector>::value,
+                "KokkosSparse::spmv: YVector must be a Kokkos::View.");
+  // Make sure A, x, y are accessible to execution_space
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename AMatrix::memory_space>::accessible,
+      "KokkosBlas::spmv: AMatrix must be accessible from execution_space");
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename XVector::memory_space>::accessible,
+      "KokkosBlas::spmv: XVector must be accessible from execution_space");
+  static_assert(
+      Kokkos::SpaceAccessibility<execution_space,
+                                 typename YVector::memory_space>::accessible,
+      "KokkosBlas::spmv: YVector must be accessible from execution_space");
+  // Make sure that x and y have the same rank.
+  static_assert(
+      static_cast<int>(XVector::rank) == static_cast<int>(YVector::rank),
+      "KokkosSparse::spmv: Vector ranks do not match.");
+  // Make sure that x (and therefore y) is rank 2.
+  static_assert(static_cast<int>(XVector::rank) == 2,
+                "KokkosSparse::spmv: Both Vector inputs must have rank 2 "
+                "in order to call this specialization of spmv.");
+  // Make sure that y is non-const.
+  static_assert(std::is_same<typename YVector::value_type,
+                             typename YVector::non_const_value_type>::value,
+                "KokkosSparse::spmv: Output Vector must be non-const.");
+
+  //
+  if (A.blockDim() == 1) {
+    KokkosSparse::CrsMatrix<
+        typename AMatrix::value_type, typename AMatrix::ordinal_type,
+        typename AMatrix::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>,
+        typename AMatrix::size_type>
+        Acrs("bsr_to_crs", A.numCols(), A.values, A.graph);
+    KokkosSparse::spmv(exec, controls, mode, alpha, Acrs, x, beta, y,
+                       RANK_TWO());
+    return;
+  }
+  // Check compatibility of dimensions at run time.
+  if ((mode[0] == NoTranspose[0]) || (mode[0] == Conjugate[0])) {
+    if ((x.extent(1) != y.extent(1)) ||
+        (static_cast<size_t>(A.numCols() * A.blockDim()) !=
+         static_cast<size_t>(x.extent(0))) ||
+        (static_cast<size_t>(A.numRows() * A.blockDim()) !=
+         static_cast<size_t>(y.extent(0)))) {
+      std::ostringstream os;
+      os << "KokkosSparse::spmv (BsrMatrix): Dimensions do not match: "
+         << ", A: " << A.numRows() * A.blockDim() << " x "
+         << A.numCols() * A.blockDim() << ", x: " << x.extent(0) << " x "
+         << x.extent(1) << ", y: " << y.extent(0) << " x " << y.extent(1);
+
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
+  } else {
+    if ((x.extent(1) != y.extent(1)) ||
+        (static_cast<size_t>(A.numCols() * A.blockDim()) !=
+         static_cast<size_t>(y.extent(0))) ||
+        (static_cast<size_t>(A.numRows() * A.blockDim()) !=
+         static_cast<size_t>(x.extent(0)))) {
+      std::ostringstream os;
+      os << "KokkosSparse::spmv (BsrMatrix): Dimensions do not match "
+            "(transpose): "
+         << ", A: " << A.numRows() * A.blockDim() << " x "
+         << A.numCols() * A.blockDim() << ", x: " << x.extent(0) << " x "
+         << x.extent(1) << ", y: " << y.extent(0) << " x " << y.extent(1);
+
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
+  }
+  //
+  typedef KokkosSparse::Experimental::BsrMatrix<
+      typename AMatrix::const_value_type, typename AMatrix::const_ordinal_type,
+      typename AMatrix::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>,
+      typename AMatrix::const_size_type>
+      AMatrix_Internal;
+  AMatrix_Internal A_i(A);
+
+  typedef Kokkos::View<
+      typename XVector::const_value_type**,
+      typename KokkosKernels::Impl::GetUnifiedLayout<XVector>::array_layout,
+      typename XVector::device_type,
+      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >
+      XVector_Internal;
+  XVector_Internal x_i(x);
+
+  typedef Kokkos::View<
+      typename YVector::non_const_value_type**,
+      typename KokkosKernels::Impl::GetUnifiedLayout<YVector>::array_layout,
+      typename YVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+      YVector_Internal;
+  YVector_Internal y_i(y);
+  //
+  if (alpha == Kokkos::ArithTraits<AlphaType>::zero() || A_i.numRows() == 0 ||
+      A_i.numCols() == 0 || A_i.nnz() == 0) {
+    // This is required to maintain semantics of KokkosKernels native SpMV:
+    // if y contains NaN but beta = 0, the result y should be filled with 0.
+    // For example, this is useful for passing in uninitialized y and beta=0.
+    if (beta == Kokkos::ArithTraits<BetaType>::zero())
+      Kokkos::deep_copy(exec, y_i, Kokkos::ArithTraits<BetaType>::zero());
+    else
+      KokkosBlas::scal(exec, y_i, beta, y_i);
+    return;
+  }
+  //
+  // Call single-vector version if appropriate
+  //
+  if (x.extent(1) == 1) {
+    typedef Kokkos::View<
+        typename XVector::const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<XVector>::array_layout,
+        typename XVector::device_type,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >
+        XVector_SubInternal;
+    typedef Kokkos::View<
+        typename YVector::non_const_value_type*,
+        typename KokkosKernels::Impl::GetUnifiedLayout<YVector>::array_layout,
+        typename YVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+        YVector_SubInternal;
+
+    XVector_SubInternal x_0 = Kokkos::subview(x_i, Kokkos::ALL(), 0);
+    YVector_SubInternal y_0 = Kokkos::subview(y_i, Kokkos::ALL(), 0);
+
+    return spmv(exec, controls, mode, alpha, A_i, x_0, beta, y_0, RANK_ONE());
+  }
+  //
+  // Whether to call KokkosKernel's native implementation, even if a TPL impl is
+  // available
+  bool useFallback = controls.isParameter("algorithm") &&
+                     (controls.getParameter("algorithm") != "tpl");
+
+#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+  // cuSPARSE does not support the modes (C), (T), (H)
+  if (std::is_same<typename AMatrix_Internal::memory_space,
+                   Kokkos::CudaSpace>::value ||
+      std::is_same<typename AMatrix_Internal::memory_space,
+                   Kokkos::CudaUVMSpace>::value) {
+    useFallback = useFallback || (mode[0] != NoTranspose[0]);
+  }
+#endif
+
+#ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
+  if (std::is_same<typename AMatrix_Internal::memory_space,
+                   Kokkos::HostSpace>::value) {
+    useFallback = useFallback || (mode[0] == Conjugate[0]);
+  }
+#endif
+
+  if (useFallback) {
+    // Explicitly call the non-TPL SPMV_BSRMATRIX implementation
+    std::string label =
+        "KokkosSparse::spmv[NATIVE,BSMATRIX," +
+        Kokkos::ArithTraits<
+            typename AMatrix_Internal::non_const_value_type>::name() +
+        "]";
+    Kokkos::Profiling::pushRegion(label);
+    Experimental::Impl::SPMV_MV_BSRMATRIX<
+        execution_space, typename AMatrix_Internal::const_value_type,
+        typename AMatrix_Internal::const_ordinal_type,
+        typename AMatrix_Internal::device_type,
+        typename AMatrix_Internal::memory_traits,
+        typename AMatrix_Internal::const_size_type,
+        typename XVector_Internal::const_value_type**,
+        typename XVector_Internal::array_layout,
+        typename XVector_Internal::device_type,
+        typename XVector_Internal::memory_traits,
+        typename YVector_Internal::value_type**,
+        typename YVector_Internal::array_layout,
+        typename YVector_Internal::device_type,
+        typename YVector_Internal::memory_traits,
+        std::is_integral<typename AMatrix_Internal::const_value_type>::value,
+        false>::spmv_mv_bsrmatrix(exec, controls, mode, alpha, A_i, x_i, beta,
+                                  y_i);
+    Kokkos::Profiling::popRegion();
+  } else {
+    Experimental::Impl::SPMV_MV_BSRMATRIX<
+        execution_space, typename AMatrix_Internal::const_value_type,
+        typename AMatrix_Internal::const_ordinal_type,
+        typename AMatrix_Internal::device_type,
+        typename AMatrix_Internal::memory_traits,
+        typename AMatrix_Internal::const_size_type,
+        typename XVector_Internal::const_value_type**,
+        typename XVector_Internal::array_layout,
+        typename XVector_Internal::device_type,
+        typename XVector_Internal::memory_traits,
+        typename YVector_Internal::value_type**,
+        typename YVector_Internal::array_layout,
+        typename YVector_Internal::device_type,
+        typename YVector_Internal::memory_traits,
+        std::is_integral<typename AMatrix_Internal::const_value_type>::value>::
+        spmv_mv_bsrmatrix(exec, controls, mode, alpha, A_i, x_i, beta, y_i);
+  }
+}
+
+template <class AlphaType, class AMatrix, class XVector, class BetaType,
+          class YVector,
+          typename std::enable_if<KokkosSparse::Experimental::is_bsr_matrix<
+              AMatrix>::value>::type* = nullptr>
+void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
+          const AlphaType& alpha, const AMatrix& A, const XVector& x,
+          const BetaType& beta, const YVector& y, const RANK_TWO& tag) {
+  spmv(typename AMatrix::execution_space{}, controls, mode, alpha, A, x, beta,
+       y, tag);
+}
+#endif
 
 /// \brief Public interface to local sparse matrix-vector multiply.
 ///
@@ -1142,18 +1147,19 @@ void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
 ///
 /// \tparam execution_space A Kokkos execution space. Must be able to access
 ///   the memory spaces of A, x, and y.
-/// \tparam AlphaType Type of coefficient alpha. Must be convertible to YVector::value_type.
-/// \tparam AMatrix A KokkosSparse::CrsMatrix, or KokkosSparse::BsrMatrix
-/// \tparam XVector Type of x, must be a rank 1 or 2 Kokkos::View
-/// \tparam BetaType Type of coefficient beta. Must be convertible to YVector::value_type.
-/// \tparam YVector Type of y, must be a rank 1 or 2 Kokkos::View and its rank must match that of XVector
+/// \tparam AlphaType Type of coefficient alpha. Must be convertible to
+/// YVector::value_type. \tparam AMatrix A KokkosSparse::CrsMatrix, or
+/// KokkosSparse::BsrMatrix \tparam XVector Type of x, must be a rank 1 or 2
+/// Kokkos::View \tparam BetaType Type of coefficient beta. Must be convertible
+/// to YVector::value_type. \tparam YVector Type of y, must be a rank 1 or 2
+/// Kokkos::View and its rank must match that of XVector
 ///
 /// \param exec [in] The execution space instance on which to run the
 ///   kernel.
 /// \param controls [in] kokkos-kernels control structure
-/// \param mode [in] Select A's operator mode: "N" for normal, "T" for transpose, "C" for conjugate or "H" for conjugate transpose.
-/// \param alpha [in] Scalar multiplier for the matrix A.
-/// \param A [in] The sparse matrix A.
+/// \param mode [in] Select A's operator mode: "N" for normal, "T" for
+/// transpose, "C" for conjugate or "H" for conjugate transpose. \param alpha
+/// [in] Scalar multiplier for the matrix A. \param A [in] The sparse matrix A.
 /// \param x [in] Either a single vector (rank-1 Kokkos::View) or
 ///   multivector (rank-2 Kokkos::View).
 /// \param beta [in] Scalar multiplier for the (multi)vector y.
@@ -1291,13 +1297,13 @@ void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
        y);
 }
 
+#ifndef DOXY
 /// \brief Catch-all public interface to error on invalid Kokkos::Sparse spmv
 /// argument types
 ///
 /// This is a catch-all interface that throws a compile-time error if \c
 /// AMatrix is not a CrsMatrix, or BsrMatrix
 ///
-#ifndef DOXY
 template <class AlphaType, class AMatrix, class XVector, class BetaType,
           class YVector,
           typename std::enable_if<
@@ -1336,20 +1342,22 @@ void spmv(const execution_space& /* exec */,
                     KokkosSparse::Experimental::is_bsr_matrix<AMatrix>::value,
                 "SpMV: AMatrix must be CrsMatrix or BsrMatrix");
 }
-#endif // ifndef DOXY
+#endif  // ifndef DOXY
 
-/// \brief \c Kokkos sparse matrix-vector multiply.
-///   Computes y := alpha*Op(A)*x + beta*y, where Op(A) is controlled by mode (see below).
+/// \brief Kokkos sparse matrix-vector multiply.
+///   Computes y := alpha*Op(A)*x + beta*y, where Op(A) is controlled by mode
+///   (see below).
 ///
-/// \tparam AlphaType Type of coefficient alpha. Must be convertible to YVector::value_type.
-/// \tparam AMatrix A KokkosSparse::CrsMatrix, or KokkosSparse::BsrMatrix
-/// \tparam XVector Type of x, must be a rank-2 Kokkos::View
-/// \tparam BetaType Type of coefficient beta. Must be convertible to YVector::value_type.
-/// \tparam YVector Type of y, must be a rank-2 Kokkos::View and its rank must match that of XVector
+/// \tparam AlphaType Type of coefficient alpha. Must be convertible to
+/// YVector::value_type. \tparam AMatrix A KokkosSparse::CrsMatrix, or
+/// KokkosSparse::BsrMatrix \tparam XVector Type of x, must be a rank-2
+/// Kokkos::View \tparam BetaType Type of coefficient beta. Must be convertible
+/// to YVector::value_type. \tparam YVector Type of y, must be a rank-2
+/// Kokkos::View and its rank must match that of XVector
 ///
-/// \param mode [in] Select A's operator mode: "N" for normal, "T" for transpose, "C" for conjugate or "H" for conjugate transpose.
-/// \param alpha [in] Scalar multiplier for the matrix A.
-/// \param A [in] The sparse matrix A.
+/// \param mode [in] Select A's operator mode: "N" for normal, "T" for
+/// transpose, "C" for conjugate or "H" for conjugate transpose. \param alpha
+/// [in] Scalar multiplier for the matrix A. \param A [in] The sparse matrix A.
 /// \param x [in] A vector to multiply on the left by A.
 /// \param beta [in] Scalar multiplier for the vector y.
 /// \param y [in/out] Result vector.
@@ -1361,22 +1369,24 @@ void spmv(const char mode[], const AlphaType& alpha, const AMatrix& A,
   spmv(controls, mode, alpha, A, x, beta, y);
 }
 
-/// \brief \c Kokkos sparse matrix-vector multiply.
-///   Computes y := alpha*Op(A)*x + beta*y, where Op(A) is controlled by mode (see below).
+/// \brief Kokkos sparse matrix-vector multiply.
+///   Computes y := alpha*Op(A)*x + beta*y, where Op(A) is controlled by mode
+///   (see below).
 ///
 /// \tparam execution_space A Kokkos execution space. Must be able to access
 ///   the memory spaces of A, x, and y.
-/// \tparam AlphaType Type of coefficient alpha. Must be convertible to YVector::value_type.
-/// \tparam AMatrix A KokkosSparse::CrsMatrix, or KokkosSparse::BsrMatrix
-/// \tparam XVector Type of x, must be a rank-2 Kokkos::View
-/// \tparam BetaType Type of coefficient beta. Must be convertible to YVector::value_type.
-/// \tparam YVector Type of y, must be a rank-2 Kokkos::View and its rank must match that of XVector
+/// \tparam AlphaType Type of coefficient alpha. Must be convertible to
+/// YVector::value_type. \tparam AMatrix A KokkosSparse::CrsMatrix, or
+/// KokkosSparse::BsrMatrix \tparam XVector Type of x, must be a rank-2
+/// Kokkos::View \tparam BetaType Type of coefficient beta. Must be convertible
+/// to YVector::value_type. \tparam YVector Type of y, must be a rank-2
+/// Kokkos::View and its rank must match that of XVector
 ///
 /// \param exec [in] The execution space instance on which to run the
 ///   kernel.
-/// \param mode [in] Select A's operator mode: "N" for normal, "T" for transpose, "C" for conjugate or "H" for conjugate transpose.
-/// \param alpha [in] Scalar multiplier for the matrix A.
-/// \param A [in] The sparse matrix A.
+/// \param mode [in] Select A's operator mode: "N" for normal, "T" for
+/// transpose, "C" for conjugate or "H" for conjugate transpose. \param alpha
+/// [in] Scalar multiplier for the matrix A. \param A [in] The sparse matrix A.
 /// \param x [in] A vector to multiply on the left by A.
 /// \param beta [in] Scalar multiplier for the vector y.
 /// \param y [in/out] Result vector.

--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -53,7 +53,7 @@ struct RANK_TWO {};
 /// to YVector::value_type. \tparam YVector Type of y, must be a rank-1
 /// Kokkos::View and its rank must match that of XVector
 ///
-/// \param exec [in] The execution space instance on which to run the
+/// \param space [in] The execution space instance on which to run the
 ///   kernel.
 /// \param controls [in] kokkos-kernels control structure.
 /// \param mode [in] Select A's operator mode: "N" for normal, "T" for
@@ -73,7 +73,7 @@ template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           typename std::enable_if<
               KokkosSparse::is_crs_matrix<AMatrix>::value>::type* = nullptr>
 #endif
-void spmv(const ExecutionSpace& exec,
+void spmv(const ExecutionSpace& space,
           KokkosKernels::Experimental::Controls controls, const char mode[],
           const AlphaType& alpha, const AMatrix& A, const XVector& x,
           const BetaType& beta, const YVector& y,
@@ -164,9 +164,9 @@ void spmv(const ExecutionSpace& exec,
     // if y contains NaN but beta = 0, the result y should be filled with 0.
     // For example, this is useful for passing in uninitialized y and beta=0.
     if (beta == Kokkos::ArithTraits<BetaType>::zero())
-      Kokkos::deep_copy(exec, y_i, Kokkos::ArithTraits<BetaType>::zero());
+      Kokkos::deep_copy(space, y_i, Kokkos::ArithTraits<BetaType>::zero());
     else
-      KokkosBlas::scal(exec, y_i, beta, y_i);
+      KokkosBlas::scal(space, y_i, beta, y_i);
     return;
   }
 
@@ -231,7 +231,7 @@ void spmv(const ExecutionSpace& exec,
                typename YVector_Internal::value_type*,
                typename YVector_Internal::array_layout,
                typename YVector_Internal::device_type,
-               typename YVector_Internal::memory_traits, false>::spmv(exec,
+               typename YVector_Internal::memory_traits, false>::spmv(space,
                                                                       controls,
                                                                       mode,
                                                                       alpha,
@@ -254,7 +254,7 @@ void spmv(const ExecutionSpace& exec,
                typename YVector_Internal::value_type*,
                typename YVector_Internal::array_layout,
                typename YVector_Internal::device_type,
-               typename YVector_Internal::memory_traits>::spmv(exec, controls,
+               typename YVector_Internal::memory_traits>::spmv(space, controls,
                                                                mode, alpha, A_i,
                                                                x_i, beta, y_i);
   }
@@ -300,7 +300,7 @@ template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector,
           typename std::enable_if<KokkosSparse::Experimental::is_bsr_matrix<
               AMatrix>::value>::type* = nullptr>
-void spmv(const ExecutionSpace& exec,
+void spmv(const ExecutionSpace& space,
           KokkosKernels::Experimental::Controls controls, const char mode[],
           const AlphaType& alpha, const AMatrix& A, const XVector& x,
           const BetaType& beta, const YVector& y,
@@ -342,7 +342,7 @@ void spmv(const ExecutionSpace& exec,
         typename AMatrix::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>,
         typename AMatrix::size_type>
         Acrs("bsr_to_crs", A.numCols(), A.values, A.graph);
-    KokkosSparse::spmv(exec, controls, mode, alpha, Acrs, x, beta, y,
+    KokkosSparse::spmv(space, controls, mode, alpha, Acrs, x, beta, y,
                        RANK_ONE());
     return;
   }
@@ -407,9 +407,9 @@ void spmv(const ExecutionSpace& exec,
     // if y contains NaN but beta = 0, the result y should be filled with 0.
     // For example, this is useful for passing in uninitialized y and beta=0.
     if (beta == Kokkos::ArithTraits<BetaType>::zero())
-      Kokkos::deep_copy(exec, y_i, Kokkos::ArithTraits<BetaType>::zero());
+      Kokkos::deep_copy(space, y_i, Kokkos::ArithTraits<BetaType>::zero());
     else
-      KokkosBlas::scal(exec, y_i, beta, y_i);
+      KokkosBlas::scal(space, y_i, beta, y_i);
     return;
   }
 
@@ -466,7 +466,7 @@ void spmv(const ExecutionSpace& exec,
         typename YVector_Internal::array_layout,
         typename YVector_Internal::device_type,
         typename YVector_Internal::memory_traits,
-        false>::spmv_bsrmatrix(exec, controls, mode, alpha, A_i, x_i, beta,
+        false>::spmv_bsrmatrix(space, controls, mode, alpha, A_i, x_i, beta,
                                y_i);
     Kokkos::Profiling::popRegion();
   } else {
@@ -496,7 +496,7 @@ void spmv(const ExecutionSpace& exec,
                   __SPMV_TYPES__>::value;
 
     Experimental::Impl::SPMV_BSRMATRIX<__SPMV_TYPES__, tpl_spec_avail,
-                                       eti_spec_avail>::spmv_bsrmatrix(exec,
+                                       eti_spec_avail>::spmv_bsrmatrix(space,
                                                                        controls,
                                                                        mode,
                                                                        alpha,
@@ -529,7 +529,7 @@ struct SPMV2D1D {
                        const YVector& y);
 
   template <typename ExecutionSpace>
-  static bool spmv2d1d(const ExecutionSpace& exec, const char mode[],
+  static bool spmv2d1d(const ExecutionSpace& space, const char mode[],
                        const AlphaType& alpha, const AMatrix& A,
                        const XVector& x, const BetaType& beta,
                        const YVector& y);
@@ -548,11 +548,11 @@ struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector,
   }
 
   template <typename ExecutionSpace>
-  static bool spmv2d1d(const ExecutionSpace& exec, const char mode[],
+  static bool spmv2d1d(const ExecutionSpace& space, const char mode[],
                        const AlphaType& alpha, const AMatrix& A,
                        const XVector& x, const BetaType& beta,
                        const YVector& y) {
-    spmv(exec, mode, alpha, A, x, beta, y);
+    spmv(space, mode, alpha, A, x, beta, y);
     return true;
   }
 };
@@ -570,7 +570,7 @@ struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector,
   }
 
   template <typename ExecutionSpace>
-  static bool spmv2d1d(const ExecutionSpace& /* exec */, const char /*mode*/[],
+  static bool spmv2d1d(const ExecutionSpace& /* space */, const char /*mode*/[],
                        const AlphaType& /*alpha*/, const AMatrix& /*A*/,
                        const XVector& /*x*/, const BetaType& /*beta*/,
                        const YVector& /*y*/) {
@@ -592,11 +592,11 @@ struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector,
   }
 
   template <typename ExecutionSpace>
-  static bool spmv2d1d(const ExecutionSpace& exec, const char mode[],
+  static bool spmv2d1d(const ExecutionSpace& space, const char mode[],
                        const AlphaType& alpha, const AMatrix& A,
                        const XVector& x, const BetaType& beta,
                        const YVector& y) {
-    spmv(exec, mode, alpha, A, x, beta, y);
+    spmv(space, mode, alpha, A, x, beta, y);
     return true;
   }
 };
@@ -614,7 +614,7 @@ struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector,
   }
 
   template <typename ExecutionSpace>
-  static bool spmv2d1d(const ExecutionSpace& /* exec */, const char /*mode*/[],
+  static bool spmv2d1d(const ExecutionSpace& /* space */, const char /*mode*/[],
                        const AlphaType& /*alpha*/, const AMatrix& /*A*/,
                        const XVector& /*x*/, const BetaType& /*beta*/,
                        const YVector& /*y*/) {
@@ -636,11 +636,11 @@ struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector,
   }
 
   template <typename ExecutionSpace>
-  static bool spmv2d1d(const ExecutionSpace& exec, const char mode[],
+  static bool spmv2d1d(const ExecutionSpace& space, const char mode[],
                        const AlphaType& alpha, const AMatrix& A,
                        const XVector& x, const BetaType& beta,
                        const YVector& y) {
-    spmv(exec, mode, alpha, A, x, beta, y);
+    spmv(space, mode, alpha, A, x, beta, y);
     return true;
   }
 };
@@ -658,7 +658,7 @@ struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector,
   }
 
   template <typename ExecutionSpace>
-  static bool spmv2d1d(const ExecutionSpace& /* exec */, const char /*mode*/[],
+  static bool spmv2d1d(const ExecutionSpace& /* space */, const char /*mode*/[],
                        const AlphaType& /*alpha*/, const AMatrix& /*A*/,
                        const XVector& /*x*/, const BetaType& /*beta*/,
                        const YVector& /*y*/) {
@@ -688,7 +688,7 @@ using SPMV2D1D
 /// to YVector::value_type. \tparam YVector Type of y, must be a rank-2
 /// Kokkos::View and its rank must match that of XVector
 ///
-/// \param exec [in] The execution space instance on which to run the
+/// \param space [in] The execution space instance on which to run the
 ///   kernel.
 /// \param controls [in] kokkos-kernels control structure.
 /// \param mode [in] Select A's operator mode: "N" for normal, "T" for
@@ -707,7 +707,7 @@ template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           typename std::enable_if<
               KokkosSparse::is_crs_matrix<AMatrix>::value>::type* = nullptr>
 #endif
-void spmv(const ExecutionSpace& exec,
+void spmv(const ExecutionSpace& space,
           KokkosKernels::Experimental::Controls controls, const char mode[],
           const AlphaType& alpha, const AMatrix& A, const XVector& x,
           const BetaType& beta, const YVector& y,
@@ -797,7 +797,7 @@ void spmv(const ExecutionSpace& exec,
         Impl::SPMV2D1D<AlphaType, AMatrix_Internal, XVector_SubInternal,
                        BetaType, YVector_SubInternal,
                        typename XVector_SubInternal::array_layout>;
-    if (impl_type::spmv2d1d(exec, mode, alpha, A, x_i, beta, y_i)) {
+    if (impl_type::spmv2d1d(space, mode, alpha, A, x_i, beta, y_i)) {
       return;
     }
   }
@@ -842,7 +842,7 @@ void spmv(const ExecutionSpace& exec,
           typename YVector_Internal::device_type,
           typename YVector_Internal::memory_traits,
           std::is_integral<typename AMatrix_Internal::value_type>::value,
-          false>::spmv_mv(exec, controls, mode, alpha, A_i, x_i, beta, y_i);
+          false>::spmv_mv(space, controls, mode, alpha, A_i, x_i, beta, y_i);
     } else {
       return Impl::SPMV_MV<
           ExecutionSpace, typename AMatrix_Internal::value_type,
@@ -857,7 +857,7 @@ void spmv(const ExecutionSpace& exec,
           typename YVector_Internal::value_type**,
           typename YVector_Internal::array_layout,
           typename YVector_Internal::device_type,
-          typename YVector_Internal::memory_traits>::spmv_mv(exec, controls,
+          typename YVector_Internal::memory_traits>::spmv_mv(space, controls,
                                                              mode, alpha, A_i,
                                                              x_i, beta, y_i);
     }
@@ -904,7 +904,7 @@ template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector,
           typename std::enable_if<KokkosSparse::Experimental::is_bsr_matrix<
               AMatrix>::value>::type* = nullptr>
-void spmv(const ExecutionSpace& exec,
+void spmv(const ExecutionSpace& space,
           KokkosKernels::Experimental::Controls controls, const char mode[],
           const AlphaType& alpha, const AMatrix& A, const XVector& x,
           const BetaType& beta, const YVector& y,
@@ -947,7 +947,7 @@ void spmv(const ExecutionSpace& exec,
         typename AMatrix::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>,
         typename AMatrix::size_type>
         Acrs("bsr_to_crs", A.numCols(), A.values, A.graph);
-    KokkosSparse::spmv(exec, controls, mode, alpha, Acrs, x, beta, y,
+    KokkosSparse::spmv(space, controls, mode, alpha, Acrs, x, beta, y,
                        RANK_TWO());
     return;
   }
@@ -1011,9 +1011,9 @@ void spmv(const ExecutionSpace& exec,
     // if y contains NaN but beta = 0, the result y should be filled with 0.
     // For example, this is useful for passing in uninitialized y and beta=0.
     if (beta == Kokkos::ArithTraits<BetaType>::zero())
-      Kokkos::deep_copy(exec, y_i, Kokkos::ArithTraits<BetaType>::zero());
+      Kokkos::deep_copy(space, y_i, Kokkos::ArithTraits<BetaType>::zero());
     else
-      KokkosBlas::scal(exec, y_i, beta, y_i);
+      KokkosBlas::scal(space, y_i, beta, y_i);
     return;
   }
   //
@@ -1035,7 +1035,7 @@ void spmv(const ExecutionSpace& exec,
     XVector_SubInternal x_0 = Kokkos::subview(x_i, Kokkos::ALL(), 0);
     YVector_SubInternal y_0 = Kokkos::subview(y_i, Kokkos::ALL(), 0);
 
-    return spmv(exec, controls, mode, alpha, A_i, x_0, beta, y_0, RANK_ONE());
+    return spmv(space, controls, mode, alpha, A_i, x_0, beta, y_0, RANK_ONE());
   }
   //
   // Whether to call KokkosKernel's native implementation, even if a TPL impl is
@@ -1083,7 +1083,7 @@ void spmv(const ExecutionSpace& exec,
         typename YVector_Internal::device_type,
         typename YVector_Internal::memory_traits,
         std::is_integral<typename AMatrix_Internal::const_value_type>::value,
-        false>::spmv_mv_bsrmatrix(exec, controls, mode, alpha, A_i, x_i, beta,
+        false>::spmv_mv_bsrmatrix(space, controls, mode, alpha, A_i, x_i, beta,
                                   y_i);
     Kokkos::Profiling::popRegion();
   } else {
@@ -1102,7 +1102,7 @@ void spmv(const ExecutionSpace& exec,
         typename YVector_Internal::device_type,
         typename YVector_Internal::memory_traits,
         std::is_integral<typename AMatrix_Internal::const_value_type>::value>::
-        spmv_mv_bsrmatrix(exec, controls, mode, alpha, A_i, x_i, beta, y_i);
+        spmv_mv_bsrmatrix(space, controls, mode, alpha, A_i, x_i, beta, y_i);
   }
 }
 
@@ -1152,7 +1152,7 @@ void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
 /// to YVector::value_type. \tparam YVector Type of y, must be a rank 1 or 2
 /// Kokkos::View and its rank must match that of XVector
 ///
-/// \param exec [in] The execution space instance on which to run the
+/// \param space [in] The execution space instance on which to run the
 ///   kernel.
 /// \param controls [in] kokkos-kernels control structure
 /// \param mode [in] Select A's operator mode: "N" for normal, "T" for
@@ -1166,7 +1166,7 @@ void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
 ///   of columns as x.
 template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector>
-void spmv(const ExecutionSpace& exec,
+void spmv(const ExecutionSpace& space,
           KokkosKernels::Experimental::Controls controls, const char mode[],
           const AlphaType& alpha, const AMatrix& A, const XVector& x,
           const BetaType& beta, const YVector& y) {
@@ -1235,16 +1235,16 @@ void spmv(const ExecutionSpace& exec,
     // if y contains NaN but beta = 0, the result y should be filled with 0.
     // For example, this is useful for passing in uninitialized y and beta=0.
     if (beta == Kokkos::ArithTraits<BetaType>::zero())
-      Kokkos::deep_copy(exec, y, Kokkos::ArithTraits<BetaType>::zero());
+      Kokkos::deep_copy(space, y, Kokkos::ArithTraits<BetaType>::zero());
     else
-      KokkosBlas::scal(exec, y, beta, y);
+      KokkosBlas::scal(space, y, beta, y);
     return;
   }
   //
   using RANK_SPECIALISE =
       typename std::conditional<static_cast<int>(XVector::rank) == 2, RANK_TWO,
                                 RANK_ONE>::type;
-  spmv(exec, controls, mode, alpha, A, x, beta, y, RANK_SPECIALISE());
+  spmv(space, controls, mode, alpha, A, x, beta, y, RANK_SPECIALISE());
 }
 
 /// \brief Public interface to local sparse matrix-vector multiply.
@@ -1329,7 +1329,7 @@ template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           typename std::enable_if<
               !KokkosSparse::Experimental::is_bsr_matrix<AMatrix>::value &&
               !KokkosSparse::is_crs_matrix<AMatrix>::value>::type* = nullptr>
-void spmv(const ExecutionSpace& /* exec */,
+void spmv(const ExecutionSpace& /* space */,
           KokkosKernels::Experimental::Controls /*controls*/,
           const char[] /*mode*/, const AlphaType& /*alpha*/,
           const AMatrix& /*A*/, const XVector& /*x*/, const BetaType& /*beta*/,
@@ -1380,7 +1380,7 @@ void spmv(const char mode[], const AlphaType& alpha, const AMatrix& A,
 /// to YVector::value_type. \tparam YVector Type of y, must be a rank-2
 /// Kokkos::View and its rank must match that of XVector
 ///
-/// \param exec [in] The execution space instance on which to run the
+/// \param space [in] The execution space instance on which to run the
 ///   kernel.
 /// \param mode [in] Select A's operator mode: "N" for normal, "T" for
 /// transpose, "C" for conjugate or "H" for conjugate transpose. \param alpha
@@ -1390,18 +1390,18 @@ void spmv(const char mode[], const AlphaType& alpha, const AMatrix& A,
 /// \param y [in/out] Result vector.
 template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector>
-void spmv(const ExecutionSpace& exec, const char mode[], const AlphaType& alpha,
+void spmv(const ExecutionSpace& space, const char mode[], const AlphaType& alpha,
           const AMatrix& A, const XVector& x, const BetaType& beta,
           const YVector& y) {
   KokkosKernels::Experimental::Controls controls;
-  spmv(exec, controls, mode, alpha, A, x, beta, y);
+  spmv(space, controls, mode, alpha, A, x, beta, y);
 }
 
 namespace Experimental {
 
 template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector>
-void spmv_struct(const ExecutionSpace& exec, const char mode[],
+void spmv_struct(const ExecutionSpace& space, const char mode[],
                  const int stencil_type,
                  const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                                     Kokkos::HostSpace>& structure,
@@ -1500,7 +1500,7 @@ void spmv_struct(const ExecutionSpace& exec, const char mode[],
       typename YVector_Internal::value_type*,
       typename YVector_Internal::array_layout,
       typename YVector_Internal::device_type,
-      typename YVector_Internal::memory_traits>::spmv_struct(exec, mode,
+      typename YVector_Internal::memory_traits>::spmv_struct(space, mode,
                                                              stencil_type,
                                                              structure, alpha,
                                                              A_i, x_i, beta,
@@ -1531,7 +1531,7 @@ struct SPMV2D1D_STRUCT {
 
   template <typename ExecutionSpace>
   static bool spmv2d1d_struct(
-      const ExecutionSpace& exec, const char mode[], const int stencil_type,
+      const ExecutionSpace& space, const char mode[], const int stencil_type,
       const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                          Kokkos::HostSpace>& structure,
       const AlphaType& alpha, const AMatrix& A, const XVector& x,
@@ -1556,12 +1556,12 @@ struct SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector,
 
   template <typename ExecutionSpace>
   static bool spmv2d1d_struct(
-      const ExecutionSpace& exec, const char mode[], const int stencil_type,
+      const ExecutionSpace& space, const char mode[], const int stencil_type,
       const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                          Kokkos::HostSpace>& structure,
       const AlphaType& alpha, const AMatrix& A, const XVector& x,
       const BetaType& beta, const YVector& y) {
-    spmv_struct(exec, mode, stencil_type, structure, alpha, A, x, beta, y,
+    spmv_struct(space, mode, stencil_type, structure, alpha, A, x, beta, y,
                 RANK_ONE());
     return true;
   }
@@ -1582,7 +1582,7 @@ struct SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector,
 
   template <typename ExecutionSpace>
   static bool spmv2d1d_struct(
-      const ExecutionSpace& /* exec*/, const char /*mode*/[],
+      const ExecutionSpace& /* space*/, const char /*mode*/[],
       const int /*stencil_type*/,
       const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                          Kokkos::HostSpace>& /*structure*/,
@@ -1611,12 +1611,12 @@ struct SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector,
 
   template <typename ExecutionSpace>
   static bool spmv2d1d_struct(
-      const ExecutionSpace& exec, const char mode[], const int stencil_type,
+      const ExecutionSpace& space, const char mode[], const int stencil_type,
       const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                          Kokkos::HostSpace>& structure,
       const AlphaType& alpha, const AMatrix& A, const XVector& x,
       const BetaType& beta, const YVector& y) {
-    spmv_struct(exec, mode, stencil_type, structure, alpha, A, x, beta, y,
+    spmv_struct(space, mode, stencil_type, structure, alpha, A, x, beta, y,
                 RANK_ONE());
     return true;
   }
@@ -1637,7 +1637,7 @@ struct SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector,
 
   template <typename ExecutionSpace>
   static bool spmv2d1d_struct(
-      const ExecutionSpace /*exec*/, const char /*mode*/[],
+      const ExecutionSpace /*space*/, const char /*mode*/[],
       const int /*stencil_type*/,
       const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                          Kokkos::HostSpace>& /*structure*/,
@@ -1666,12 +1666,12 @@ struct SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector,
 
   template <typename ExecutionSpace>
   static bool spmv2d1d_struct(
-      const ExecutionSpace& exec, const char mode[], const int stencil_type,
+      const ExecutionSpace& space, const char mode[], const int stencil_type,
       const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                          Kokkos::HostSpace>& structure,
       const AlphaType& alpha, const AMatrix& A, const XVector& x,
       const BetaType& beta, const YVector& y) {
-    spmv_struct(exec, mode, stencil_type, structure, alpha, A, x, beta, y,
+    spmv_struct(space, mode, stencil_type, structure, alpha, A, x, beta, y,
                 RANK_ONE());
     return true;
   }
@@ -1692,7 +1692,7 @@ struct SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector,
 
   template <typename ExecutionSpace>
   static bool spmv2d1d_struct(
-      const ExecutionSpace& /*exec*/, const char /*mode*/[],
+      const ExecutionSpace& /*space*/, const char /*mode*/[],
       const int /*stencil_type*/,
       const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                          Kokkos::HostSpace>& /*structure*/,
@@ -1713,7 +1713,7 @@ using SPMV2D1D_STRUCT
 
 template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector>
-void spmv_struct(const ExecutionSpace& exec, const char mode[],
+void spmv_struct(const ExecutionSpace& space, const char mode[],
                  const int stencil_type,
                  const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                                     Kokkos::HostSpace>& structure,
@@ -1796,7 +1796,7 @@ void spmv_struct(const ExecutionSpace& exec, const char mode[],
     if (Impl::SPMV2D1D_STRUCT<AlphaType, AMatrix_Internal, XVector_SubInternal,
                               BetaType, YVector_SubInternal,
                               typename XVector_SubInternal::array_layout>::
-            spmv2d1d_struct(exec, mode, stencil_type, structure, alpha, A, x_i,
+            spmv2d1d_struct(space, mode, stencil_type, structure, alpha, A, x_i,
                             beta, y_i)) {
       return;
     }
@@ -1833,7 +1833,7 @@ void spmv_struct(const ExecutionSpace& exec, const char mode[],
         typename YVector_Internal::array_layout,
         typename YVector_Internal::device_type,
         typename YVector_Internal::memory_traits>::
-        spmv_mv(exec, KokkosKernels::Experimental::Controls(), mode, alpha, A_i,
+        spmv_mv(space, KokkosKernels::Experimental::Controls(), mode, alpha, A_i,
                 x_i, beta, y_i);
   }
 }
@@ -1893,7 +1893,7 @@ void spmv_struct(const char mode[], const int stencil_type,
 /// by \c mode.  If beta == 0, ignore and overwrite the initial
 /// entries of y; if alpha == 0, ignore the entries of A and x.
 ///
-/// \param exec [in] The execution space instance on which to run the
+/// \param space [in] The execution space instance on which to run the
 ///   kernel.
 /// \param mode [in] "N" for no transpose, "T" for transpose, or "C"
 ///             for conjugate transpose.
@@ -1911,7 +1911,7 @@ void spmv_struct(const char mode[], const int stencil_type,
 ///   of columns as x.
 template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector>
-void spmv_struct(const ExecutionSpace& exec, const char mode[],
+void spmv_struct(const ExecutionSpace& space, const char mode[],
                  const int stencil_type,
                  const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                                     Kokkos::HostSpace>& structure,
@@ -1920,7 +1920,7 @@ void spmv_struct(const ExecutionSpace& exec, const char mode[],
   typedef
       typename std::conditional<XVector::rank == 2, RANK_TWO, RANK_ONE>::type
           RANK_SPECIALISE;
-  spmv_struct(exec, mode, stencil_type, structure, alpha, A, x, beta, y,
+  spmv_struct(space, mode, stencil_type, structure, alpha, A, x, beta, y,
               RANK_SPECIALISE());
 }
 

--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -303,7 +303,8 @@ template <class execution_space, class AlphaType, class AMatrix, class XVector,
 void spmv(const execution_space& exec,
           KokkosKernels::Experimental::Controls controls, const char mode[],
           const AlphaType& alpha, const AMatrix& A, const XVector& x,
-          const BetaType& beta, const YVector& y, const RANK_ONE& tag) {
+          const BetaType& beta, const YVector& y,
+          [[maybe_unused]] const RANK_ONE& tag) {
   // Make sure that x and y are Views.
   static_assert(Kokkos::is_view<XVector>::value,
                 "KokkosSparse::spmv: XVector must be a Kokkos::View.");
@@ -906,7 +907,8 @@ template <class execution_space, class AlphaType, class AMatrix, class XVector,
 void spmv(const execution_space& exec,
           KokkosKernels::Experimental::Controls controls, const char mode[],
           const AlphaType& alpha, const AMatrix& A, const XVector& x,
-          const BetaType& beta, const YVector& y, const RANK_TWO& tag) {
+          const BetaType& beta, const YVector& y,
+          [[maybe_unused]] const RANK_TWO& tag) {
   // Make sure that x and y are Views.
   static_assert(Kokkos::is_view<XVector>::value,
                 "KokkosSparse::spmv: XVector must be a Kokkos::View.");
@@ -1404,7 +1406,8 @@ void spmv_struct(const execution_space& exec, const char mode[],
                  const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                                     Kokkos::HostSpace>& structure,
                  const AlphaType& alpha, const AMatrix& A, const XVector& x,
-                 const BetaType& beta, const YVector& y, const RANK_ONE& tag) {
+                 const BetaType& beta, const YVector& y,
+                 [[maybe_unused]] const RANK_ONE& tag) {
   // Make sure that both x and y have the same rank.
   static_assert((int)XVector::rank == (int)YVector::rank,
                 "KokkosSparse::spmv_struct: Vector ranks do not match.");
@@ -1715,7 +1718,8 @@ void spmv_struct(const execution_space& exec, const char mode[],
                  const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                                     Kokkos::HostSpace>& structure,
                  const AlphaType& alpha, const AMatrix& A, const XVector& x,
-                 const BetaType& beta, const YVector& y, const RANK_TWO& tag) {
+                 const BetaType& beta, const YVector& y,
+                 [[maybe_unused]] const RANK_TWO& tag) {
   // Make sure A, x, y are accessible to execution_space
   static_assert(
       Kokkos::SpaceAccessibility<execution_space,

--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -48,10 +48,10 @@ struct RANK_TWO {};
 ///   the memory spaces of A, x, and y.
 /// \tparam AlphaType Type of coefficient alpha. Must be convertible to
 /// YVector::value_type. \tparam AMatrix A KokkosSparse::CrsMatrix, or
-/// KokkosSparse::BsrMatrix \tparam XVector Type of x, must be a rank-1
-/// Kokkos::View \tparam BetaType Type of coefficient beta. Must be convertible
-/// to YVector::value_type. \tparam YVector Type of y, must be a rank-1
-/// Kokkos::View and its rank must match that of XVector
+/// KokkosSparse::Experimental::BsrMatrix \tparam XVector Type of x, must be a
+/// rank-1 Kokkos::View \tparam BetaType Type of coefficient beta. Must be
+/// convertible to YVector::value_type. \tparam YVector Type of y, must be a
+/// rank-1 Kokkos::View and its rank must match that of XVector
 ///
 /// \param space [in] The execution space instance on which to run the
 ///   kernel.
@@ -219,44 +219,16 @@ void spmv(const ExecutionSpace& space,
             typename AMatrix_Internal::non_const_value_type>::name() +
         "]";
     Kokkos::Profiling::pushRegion(label);
-    Impl::SPMV<ExecutionSpace, typename AMatrix_Internal::value_type,
-               typename AMatrix_Internal::ordinal_type,
-               typename AMatrix_Internal::device_type,
-               typename AMatrix_Internal::memory_traits,
-               typename AMatrix_Internal::size_type,
-               typename XVector_Internal::value_type*,
-               typename XVector_Internal::array_layout,
-               typename XVector_Internal::device_type,
-               typename XVector_Internal::memory_traits,
-               typename YVector_Internal::value_type*,
-               typename YVector_Internal::array_layout,
-               typename YVector_Internal::device_type,
-               typename YVector_Internal::memory_traits, false>::spmv(space,
-                                                                      controls,
-                                                                      mode,
-                                                                      alpha,
-                                                                      A_i, x_i,
-                                                                      beta,
-                                                                      y_i);
+    Impl::SPMV<ExecutionSpace, AMatrix_Internal, XVector_Internal,
+               YVector_Internal, false>::spmv(space, controls, mode, alpha, A_i,
+                                              x_i, beta, y_i);
     Kokkos::Profiling::popRegion();
   } else {
     // note: the cuSPARSE spmv wrapper defines a profiling region, so one is not
     // needed here.
-    Impl::SPMV<ExecutionSpace, typename AMatrix_Internal::value_type,
-               typename AMatrix_Internal::ordinal_type,
-               typename AMatrix_Internal::device_type,
-               typename AMatrix_Internal::memory_traits,
-               typename AMatrix_Internal::size_type,
-               typename XVector_Internal::value_type*,
-               typename XVector_Internal::array_layout,
-               typename XVector_Internal::device_type,
-               typename XVector_Internal::memory_traits,
-               typename YVector_Internal::value_type*,
-               typename YVector_Internal::array_layout,
-               typename YVector_Internal::device_type,
-               typename YVector_Internal::memory_traits>::spmv(space, controls,
-                                                               mode, alpha, A_i,
-                                                               x_i, beta, y_i);
+    Impl::SPMV<ExecutionSpace, AMatrix_Internal, XVector_Internal,
+               YVector_Internal>::spmv(space, controls, mode, alpha, A_i, x_i,
+                                       beta, y_i);
   }
 }
 
@@ -266,10 +238,10 @@ void spmv(const ExecutionSpace& space,
 ///
 /// \tparam AlphaType Type of coefficient alpha. Must be convertible to
 /// YVector::value_type. \tparam AMatrix A KokkosSparse::CrsMatrix, or
-/// KokkosSparse::BsrMatrix \tparam XVector Type of x, must be a rank-1
-/// Kokkos::View \tparam BetaType Type of coefficient beta. Must be convertible
-/// to YVector::value_type. \tparam YVector Type of y, must be a rank-1
-/// Kokkos::View and its rank must match that of XVector
+/// KokkosSparse::Experimental::BsrMatrix \tparam XVector Type of x, must be a
+/// rank-1 Kokkos::View \tparam BetaType Type of coefficient beta. Must be
+/// convertible to YVector::value_type. \tparam YVector Type of y, must be a
+/// rank-1 Kokkos::View and its rank must match that of XVector
 ///
 /// \param controls [in] kokkos-kernels control structure.
 /// \param mode [in] Select A's operator mode: "N" for normal, "T" for
@@ -452,59 +424,30 @@ void spmv(const ExecutionSpace& space,
             typename AMatrix_Internal::non_const_value_type>::name() +
         "]";
     Kokkos::Profiling::pushRegion(label);
-    Experimental::Impl::SPMV_BSRMATRIX<
-        ExecutionSpace, typename AMatrix_Internal::const_value_type,
-        typename AMatrix_Internal::const_ordinal_type,
-        typename AMatrix_Internal::device_type,
-        typename AMatrix_Internal::memory_traits,
-        typename AMatrix_Internal::const_size_type,
-        typename XVector_Internal::const_value_type*,
-        typename XVector_Internal::array_layout,
-        typename XVector_Internal::device_type,
-        typename XVector_Internal::memory_traits,
-        typename YVector_Internal::value_type*,
-        typename YVector_Internal::array_layout,
-        typename YVector_Internal::device_type,
-        typename YVector_Internal::memory_traits,
-        false>::spmv_bsrmatrix(space, controls, mode, alpha, A_i, x_i, beta,
-                               y_i);
+    Experimental::Impl::SPMV_BSRMATRIX<ExecutionSpace, AMatrix_Internal,
+                                       XVector_Internal, YVector_Internal,
+                                       false>::spmv_bsrmatrix(space, controls,
+                                                              mode, alpha, A_i,
+                                                              x_i, beta, y_i);
     Kokkos::Profiling::popRegion();
   } else {
-#define __SPMV_TYPES__                                         \
-  ExecutionSpace, typename AMatrix_Internal::const_value_type, \
-      typename AMatrix_Internal::const_ordinal_type,           \
-      typename AMatrix_Internal::device_type,                  \
-      typename AMatrix_Internal::memory_traits,                \
-      typename AMatrix_Internal::const_size_type,              \
-      typename XVector_Internal::const_value_type*,            \
-      typename XVector_Internal::array_layout,                 \
-      typename XVector_Internal::device_type,                  \
-      typename XVector_Internal::memory_traits,                \
-      typename YVector_Internal::value_type*,                  \
-      typename YVector_Internal::array_layout,                 \
-      typename YVector_Internal::device_type,                  \
-      typename YVector_Internal::memory_traits
-
     constexpr bool tpl_spec_avail =
         KokkosSparse::Experimental::Impl::spmv_bsrmatrix_tpl_spec_avail<
-            __SPMV_TYPES__>::value;
+            ExecutionSpace, AMatrix_Internal, XVector_Internal,
+            YVector_Internal>::value;
 
     constexpr bool eti_spec_avail =
         tpl_spec_avail
             ? KOKKOSKERNELS_IMPL_COMPILE_LIBRARY /* force FALSE in app/test */
             : KokkosSparse::Experimental::Impl::spmv_bsrmatrix_eti_spec_avail<
-                  __SPMV_TYPES__>::value;
+                  ExecutionSpace, AMatrix_Internal, XVector_Internal,
+                  YVector_Internal>::value;
 
-    Experimental::Impl::SPMV_BSRMATRIX<__SPMV_TYPES__, tpl_spec_avail,
-                                       eti_spec_avail>::spmv_bsrmatrix(space,
-                                                                       controls,
-                                                                       mode,
-                                                                       alpha,
-                                                                       A_i, x_i,
-                                                                       beta,
-                                                                       y_i);
-
-#undef __SPMV_TYPES__
+    Experimental::Impl::SPMV_BSRMATRIX<
+        ExecutionSpace, AMatrix_Internal, XVector_Internal, YVector_Internal,
+        tpl_spec_avail, eti_spec_avail>::spmv_bsrmatrix(space, controls, mode,
+                                                        alpha, A_i, x_i, beta,
+                                                        y_i);
   }
 }
 
@@ -683,10 +626,10 @@ using SPMV2D1D
 ///   the memory spaces of A, x, and y.
 /// \tparam AlphaType Type of coefficient alpha. Must be convertible to
 /// YVector::value_type. \tparam AMatrix A KokkosSparse::CrsMatrix, or
-/// KokkosSparse::BsrMatrix \tparam XVector Type of x, must be a rank-2
-/// Kokkos::View \tparam BetaType Type of coefficient beta. Must be convertible
-/// to YVector::value_type. \tparam YVector Type of y, must be a rank-2
-/// Kokkos::View and its rank must match that of XVector
+/// KokkosSparse::Experimental::BsrMatrix \tparam XVector Type of x, must be a
+/// rank-2 Kokkos::View \tparam BetaType Type of coefficient beta. Must be
+/// convertible to YVector::value_type. \tparam YVector Type of y, must be a
+/// rank-2 Kokkos::View and its rank must match that of XVector
 ///
 /// \param space [in] The execution space instance on which to run the
 ///   kernel.
@@ -828,38 +771,14 @@ void spmv(const ExecutionSpace& space,
 
     if (useNative) {
       return Impl::SPMV_MV<
-          ExecutionSpace, typename AMatrix_Internal::value_type,
-          typename AMatrix_Internal::ordinal_type,
-          typename AMatrix_Internal::device_type,
-          typename AMatrix_Internal::memory_traits,
-          typename AMatrix_Internal::size_type,
-          typename XVector_Internal::value_type**,
-          typename XVector_Internal::array_layout,
-          typename XVector_Internal::device_type,
-          typename XVector_Internal::memory_traits,
-          typename YVector_Internal::value_type**,
-          typename YVector_Internal::array_layout,
-          typename YVector_Internal::device_type,
-          typename YVector_Internal::memory_traits,
+          ExecutionSpace, AMatrix_Internal, XVector_Internal, YVector_Internal,
           std::is_integral<typename AMatrix_Internal::value_type>::value,
           false>::spmv_mv(space, controls, mode, alpha, A_i, x_i, beta, y_i);
     } else {
-      return Impl::SPMV_MV<
-          ExecutionSpace, typename AMatrix_Internal::value_type,
-          typename AMatrix_Internal::ordinal_type,
-          typename AMatrix_Internal::device_type,
-          typename AMatrix_Internal::memory_traits,
-          typename AMatrix_Internal::size_type,
-          typename XVector_Internal::value_type**,
-          typename XVector_Internal::array_layout,
-          typename XVector_Internal::device_type,
-          typename XVector_Internal::memory_traits,
-          typename YVector_Internal::value_type**,
-          typename YVector_Internal::array_layout,
-          typename YVector_Internal::device_type,
-          typename YVector_Internal::memory_traits>::spmv_mv(space, controls,
-                                                             mode, alpha, A_i,
-                                                             x_i, beta, y_i);
+      return Impl::SPMV_MV<ExecutionSpace, AMatrix_Internal, XVector_Internal,
+                           YVector_Internal>::spmv_mv(space, controls, mode,
+                                                      alpha, A_i, x_i, beta,
+                                                      y_i);
     }
   }
 }
@@ -870,10 +789,10 @@ void spmv(const ExecutionSpace& space,
 ///
 /// \tparam AlphaType Type of coefficient alpha. Must be convertible to
 /// YVector::value_type. \tparam AMatrix A KokkosSparse::CrsMatrix, or
-/// KokkosSparse::BsrMatrix \tparam XVector Type of x, must be a rank-2
-/// Kokkos::View \tparam BetaType Type of coefficient beta. Must be convertible
-/// to YVector::value_type. \tparam YVector Type of y, must be a rank-2
-/// Kokkos::View and its rank must match that of XVector
+/// KokkosSparse::Experimental::BsrMatrix \tparam XVector Type of x, must be a
+/// rank-2 Kokkos::View \tparam BetaType Type of coefficient beta. Must be
+/// convertible to YVector::value_type. \tparam YVector Type of y, must be a
+/// rank-2 Kokkos::View and its rank must match that of XVector
 ///
 /// \param controls [in] kokkos-kernels control structure.
 /// \param mode [in] Select A's operator mode: "N" for normal, "T" for
@@ -1069,38 +988,14 @@ void spmv(const ExecutionSpace& space,
         "]";
     Kokkos::Profiling::pushRegion(label);
     Experimental::Impl::SPMV_MV_BSRMATRIX<
-        ExecutionSpace, typename AMatrix_Internal::const_value_type,
-        typename AMatrix_Internal::const_ordinal_type,
-        typename AMatrix_Internal::device_type,
-        typename AMatrix_Internal::memory_traits,
-        typename AMatrix_Internal::const_size_type,
-        typename XVector_Internal::const_value_type**,
-        typename XVector_Internal::array_layout,
-        typename XVector_Internal::device_type,
-        typename XVector_Internal::memory_traits,
-        typename YVector_Internal::value_type**,
-        typename YVector_Internal::array_layout,
-        typename YVector_Internal::device_type,
-        typename YVector_Internal::memory_traits,
+        ExecutionSpace, AMatrix_Internal, XVector_Internal, YVector_Internal,
         std::is_integral<typename AMatrix_Internal::const_value_type>::value,
         false>::spmv_mv_bsrmatrix(space, controls, mode, alpha, A_i, x_i, beta,
                                   y_i);
     Kokkos::Profiling::popRegion();
   } else {
     Experimental::Impl::SPMV_MV_BSRMATRIX<
-        ExecutionSpace, typename AMatrix_Internal::const_value_type,
-        typename AMatrix_Internal::const_ordinal_type,
-        typename AMatrix_Internal::device_type,
-        typename AMatrix_Internal::memory_traits,
-        typename AMatrix_Internal::const_size_type,
-        typename XVector_Internal::const_value_type**,
-        typename XVector_Internal::array_layout,
-        typename XVector_Internal::device_type,
-        typename XVector_Internal::memory_traits,
-        typename YVector_Internal::value_type**,
-        typename YVector_Internal::array_layout,
-        typename YVector_Internal::device_type,
-        typename YVector_Internal::memory_traits,
+        ExecutionSpace, AMatrix_Internal, XVector_Internal, YVector_Internal,
         std::is_integral<typename AMatrix_Internal::const_value_type>::value>::
         spmv_mv_bsrmatrix(space, controls, mode, alpha, A_i, x_i, beta, y_i);
   }
@@ -1147,10 +1042,10 @@ void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
 ///   the memory spaces of A, x, and y.
 /// \tparam AlphaType Type of coefficient alpha. Must be convertible to
 /// YVector::value_type. \tparam AMatrix A KokkosSparse::CrsMatrix, or
-/// KokkosSparse::BsrMatrix \tparam XVector Type of x, must be a rank 1 or 2
-/// Kokkos::View \tparam BetaType Type of coefficient beta. Must be convertible
-/// to YVector::value_type. \tparam YVector Type of y, must be a rank 1 or 2
-/// Kokkos::View and its rank must match that of XVector
+/// KokkosSparse::Experimental::BsrMatrix \tparam XVector Type of x, must be a
+/// rank 1 or 2 Kokkos::View \tparam BetaType Type of coefficient beta. Must be
+/// convertible to YVector::value_type. \tparam YVector Type of y, must be a
+/// rank 1 or 2 Kokkos::View and its rank must match that of XVector
 ///
 /// \param space [in] The execution space instance on which to run the
 ///   kernel.
@@ -1348,10 +1243,10 @@ void spmv(const ExecutionSpace& /* space */,
 ///
 /// \tparam AlphaType Type of coefficient alpha. Must be convertible to
 /// YVector::value_type. \tparam AMatrix A KokkosSparse::CrsMatrix, or
-/// KokkosSparse::BsrMatrix \tparam XVector Type of x, must be a rank-2
-/// Kokkos::View \tparam BetaType Type of coefficient beta. Must be convertible
-/// to YVector::value_type. \tparam YVector Type of y, must be a rank-2
-/// Kokkos::View and its rank must match that of XVector
+/// KokkosSparse::Experimental::BsrMatrix \tparam XVector Type of x, must be a
+/// rank-2 Kokkos::View \tparam BetaType Type of coefficient beta. Must be
+/// convertible to YVector::value_type. \tparam YVector Type of y, must be a
+/// rank-2 Kokkos::View and its rank must match that of XVector
 ///
 /// \param mode [in] Select A's operator mode: "N" for normal, "T" for
 /// transpose, "C" for conjugate or "H" for conjugate transpose. \param alpha
@@ -1375,10 +1270,10 @@ void spmv(const char mode[], const AlphaType& alpha, const AMatrix& A,
 ///   the memory spaces of A, x, and y.
 /// \tparam AlphaType Type of coefficient alpha. Must be convertible to
 /// YVector::value_type. \tparam AMatrix A KokkosSparse::CrsMatrix, or
-/// KokkosSparse::BsrMatrix \tparam XVector Type of x, must be a rank-2
-/// Kokkos::View \tparam BetaType Type of coefficient beta. Must be convertible
-/// to YVector::value_type. \tparam YVector Type of y, must be a rank-2
-/// Kokkos::View and its rank must match that of XVector
+/// KokkosSparse::Experimental::BsrMatrix \tparam XVector Type of x, must be a
+/// rank-2 Kokkos::View \tparam BetaType Type of coefficient beta. Must be
+/// convertible to YVector::value_type. \tparam YVector Type of y, must be a
+/// rank-2 Kokkos::View and its rank must match that of XVector
 ///
 /// \param space [in] The execution space instance on which to run the
 ///   kernel.
@@ -1390,9 +1285,9 @@ void spmv(const char mode[], const AlphaType& alpha, const AMatrix& A,
 /// \param y [in/out] Result vector.
 template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector>
-void spmv(const ExecutionSpace& space, const char mode[], const AlphaType& alpha,
-          const AMatrix& A, const XVector& x, const BetaType& beta,
-          const YVector& y) {
+void spmv(const ExecutionSpace& space, const char mode[],
+          const AlphaType& alpha, const AMatrix& A, const XVector& x,
+          const BetaType& beta, const YVector& y) {
   KokkosKernels::Experimental::Controls controls;
   spmv(space, controls, mode, alpha, A, x, beta, y);
 }
@@ -1488,23 +1383,9 @@ void spmv_struct(const ExecutionSpace& space, const char mode[],
   YVector_Internal y_i = y;
 
   return KokkosSparse::Impl::SPMV_STRUCT<
-      ExecutionSpace, typename AMatrix_Internal::value_type,
-      typename AMatrix_Internal::ordinal_type,
-      typename AMatrix_Internal::device_type,
-      typename AMatrix_Internal::memory_traits,
-      typename AMatrix_Internal::size_type,
-      typename XVector_Internal::value_type*,
-      typename XVector_Internal::array_layout,
-      typename XVector_Internal::device_type,
-      typename XVector_Internal::memory_traits,
-      typename YVector_Internal::value_type*,
-      typename YVector_Internal::array_layout,
-      typename YVector_Internal::device_type,
-      typename YVector_Internal::memory_traits>::spmv_struct(space, mode,
-                                                             stencil_type,
-                                                             structure, alpha,
-                                                             A_i, x_i, beta,
-                                                             y_i);
+      ExecutionSpace, AMatrix_Internal, XVector_Internal,
+      YVector_Internal>::spmv_struct(space, mode, stencil_type, structure,
+                                     alpha, A_i, x_i, beta, y_i);
 }
 
 template <class AlphaType, class AMatrix, class XVector, class BetaType,
@@ -1820,21 +1701,10 @@ void spmv_struct(const ExecutionSpace& space, const char mode[],
     YVector_Internal y_i = y;
 
     return KokkosSparse::Impl::SPMV_MV<
-        ExecutionSpace, typename AMatrix_Internal::value_type,
-        typename AMatrix_Internal::ordinal_type,
-        typename AMatrix_Internal::device_type,
-        typename AMatrix_Internal::memory_traits,
-        typename AMatrix_Internal::size_type,
-        typename XVector_Internal::value_type**,
-        typename XVector_Internal::array_layout,
-        typename XVector_Internal::device_type,
-        typename XVector_Internal::memory_traits,
-        typename YVector_Internal::value_type**,
-        typename YVector_Internal::array_layout,
-        typename YVector_Internal::device_type,
-        typename YVector_Internal::memory_traits>::
-        spmv_mv(space, KokkosKernels::Experimental::Controls(), mode, alpha, A_i,
-                x_i, beta, y_i);
+        ExecutionSpace, AMatrix_Internal, XVector_Internal,
+        YVector_Internal>::spmv_mv(space,
+                                   KokkosKernels::Experimental::Controls(),
+                                   mode, alpha, A_i, x_i, beta, y_i);
   }
 }
 

--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -516,6 +516,7 @@ void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
        y, tag);
 }
 
+namespace Impl {
 template <class AlphaType, class AMatrix, class XVector, class BetaType,
           class YVector, class XLayout = typename XVector::array_layout>
 struct SPMV2D1D {
@@ -661,6 +662,14 @@ struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector,
   }
 };
 #endif
+}  // namespace Impl
+
+template <class AlphaType, class AMatrix, class XVector, class BetaType,
+          class YVector, class XLayout = typename XVector::array_layout>
+using SPMV2D1D
+    [[deprecated("KokkosSparse::SPMV2D1D is not part of the public interface - "
+                 "use KokkosSparse::spmv instead")]] =
+        Impl::SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector>;
 
 /// \brief Tag-dispatch sparse matrix-vector multiply on multivectors
 ///
@@ -775,9 +784,10 @@ void spmv(const execution_space& exec,
     YVector_SubInternal y_i = Kokkos::subview(y, Kokkos::ALL(), 0);
 
     // spmv (mode, alpha, A, x_i, beta, y_i);
-    using impl_type = SPMV2D1D<AlphaType, AMatrix_Internal, XVector_SubInternal,
-                               BetaType, YVector_SubInternal,
-                               typename XVector_SubInternal::array_layout>;
+    using impl_type =
+        Impl::SPMV2D1D<AlphaType, AMatrix_Internal, XVector_SubInternal,
+                       BetaType, YVector_SubInternal,
+                       typename XVector_SubInternal::array_layout>;
     if (impl_type::spmv2d1d(exec, mode, alpha, A, x_i, beta, y_i)) {
       return;
     }
@@ -1463,6 +1473,7 @@ void spmv_struct(const char mode[], const int stencil_type,
               structure, alpha, A, x, beta, y, tag);
 }
 
+namespace Impl {
 template <class AlphaType, class AMatrix, class XVector, class BetaType,
           class YVector, class XLayout = typename XVector::array_layout>
 struct SPMV2D1D_STRUCT {
@@ -1646,6 +1657,14 @@ struct SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector,
   }
 };
 #endif
+}  // namespace Impl
+
+template <class AlphaType, class AMatrix, class XVector, class BetaType,
+          class YVector, class XLayout = typename XVector::array_layout>
+using SPMV2D1D_STRUCT
+    [[deprecated("KokkosSparse::SPMV2D1D_STRUCT is not part of the public "
+                 "interface - use KokkosSparse::spmv_struct instead")]] =
+        Impl::SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector>;
 
 template <class execution_space, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector>
@@ -1728,9 +1747,9 @@ void spmv_struct(const execution_space& exec, const char mode[],
     YVector_SubInternal y_i = Kokkos::subview(y, Kokkos::ALL(), 0);
 
     // spmv_struct (mode, alpha, A, x_i, beta, y_i);
-    if (SPMV2D1D_STRUCT<AlphaType, AMatrix_Internal, XVector_SubInternal,
-                        BetaType, YVector_SubInternal,
-                        typename XVector_SubInternal::array_layout>::
+    if (Impl::SPMV2D1D_STRUCT<AlphaType, AMatrix_Internal, XVector_SubInternal,
+                              BetaType, YVector_SubInternal,
+                              typename XVector_SubInternal::array_layout>::
             spmv2d1d_struct(exec, mode, stencil_type, structure, alpha, A, x_i,
                             beta, y_i)) {
       return;

--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -300,8 +300,6 @@ template <class execution_space, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector,
           typename std::enable_if<KokkosSparse::Experimental::is_bsr_matrix<
               AMatrix>::value>::type* = nullptr>
-template <class execution_space, class AlphaType, class AMatrix, class XVector,
-          class BetaType, class YVector>
 void spmv(const execution_space& exec,
           KokkosKernels::Experimental::Controls controls, const char mode[],
           const AlphaType& alpha, const AMatrix& A, const XVector& x,
@@ -509,8 +507,6 @@ void spmv(const execution_space& exec,
   }
 }
 
-template <class AlphaType, class AMatrix, class XVector, class BetaType,
-          class YVector>
 template <class AlphaType, class AMatrix, class XVector, class BetaType,
           class YVector,
           typename std::enable_if<KokkosSparse::Experimental::is_bsr_matrix<

--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -44,7 +44,7 @@ struct RANK_TWO {};
 /// vectors (RANK_ONE tag). Computes y := alpha*Op(A)*x + beta*y, where Op(A) is
 /// controlled by mode (see below).
 ///
-/// \tparam execution_space A Kokkos execution space. Must be able to access
+/// \tparam ExecutionSpace A Kokkos execution space. Must be able to access
 ///   the memory spaces of A, x, and y.
 /// \tparam AlphaType Type of coefficient alpha. Must be convertible to
 /// YVector::value_type. \tparam AMatrix A KokkosSparse::CrsMatrix, or
@@ -65,15 +65,15 @@ struct RANK_TWO {};
 /// \param tag RANK_ONE dispatch
 #ifdef DOXY  // documentation version - don't separately document SFINAE
              // specializations for BSR and CRS
-template <class execution_space, class AlphaType, class AMatrix, class XVector,
+template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector>
 #else
-template <class execution_space, class AlphaType, class AMatrix, class XVector,
+template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector,
           typename std::enable_if<
               KokkosSparse::is_crs_matrix<AMatrix>::value>::type* = nullptr>
 #endif
-void spmv(const execution_space& exec,
+void spmv(const ExecutionSpace& exec,
           KokkosKernels::Experimental::Controls controls, const char mode[],
           const AlphaType& alpha, const AMatrix& A, const XVector& x,
           const BetaType& beta, const YVector& y,
@@ -84,19 +84,19 @@ void spmv(const execution_space& exec,
                 "KokkosSparse::spmv: XVector must be a Kokkos::View.");
   static_assert(Kokkos::is_view<YVector>::value,
                 "KokkosSparse::spmv: YVector must be a Kokkos::View.");
-  // Make sure A, x, y are accessible to execution_space
+  // Make sure A, x, y are accessible to ExecutionSpace
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename AMatrix::memory_space>::accessible,
-      "KokkosBlas::spmv: AMatrix must be accessible from execution_space");
+      "KokkosBlas::spmv: AMatrix must be accessible from ExecutionSpace");
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename XVector::memory_space>::accessible,
-      "KokkosBlas::spmv: XVector must be accessible from execution_space");
+      "KokkosBlas::spmv: XVector must be accessible from ExecutionSpace");
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename YVector::memory_space>::accessible,
-      "KokkosBlas::spmv: YVector must be accessible from execution_space");
+      "KokkosBlas::spmv: YVector must be accessible from ExecutionSpace");
 
   // Make sure that x and y have the same rank.
   static_assert(XVector::rank == YVector::rank,
@@ -219,7 +219,7 @@ void spmv(const execution_space& exec,
             typename AMatrix_Internal::non_const_value_type>::name() +
         "]";
     Kokkos::Profiling::pushRegion(label);
-    Impl::SPMV<execution_space, typename AMatrix_Internal::value_type,
+    Impl::SPMV<ExecutionSpace, typename AMatrix_Internal::value_type,
                typename AMatrix_Internal::ordinal_type,
                typename AMatrix_Internal::device_type,
                typename AMatrix_Internal::memory_traits,
@@ -242,7 +242,7 @@ void spmv(const execution_space& exec,
   } else {
     // note: the cuSPARSE spmv wrapper defines a profiling region, so one is not
     // needed here.
-    Impl::SPMV<execution_space, typename AMatrix_Internal::value_type,
+    Impl::SPMV<ExecutionSpace, typename AMatrix_Internal::value_type,
                typename AMatrix_Internal::ordinal_type,
                typename AMatrix_Internal::device_type,
                typename AMatrix_Internal::memory_traits,
@@ -296,11 +296,11 @@ void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
 }
 
 #ifndef DOXY  // hide SFINAE specialization for BSR
-template <class execution_space, class AlphaType, class AMatrix, class XVector,
+template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector,
           typename std::enable_if<KokkosSparse::Experimental::is_bsr_matrix<
               AMatrix>::value>::type* = nullptr>
-void spmv(const execution_space& exec,
+void spmv(const ExecutionSpace& exec,
           KokkosKernels::Experimental::Controls controls, const char mode[],
           const AlphaType& alpha, const AMatrix& A, const XVector& x,
           const BetaType& beta, const YVector& y,
@@ -310,19 +310,19 @@ void spmv(const execution_space& exec,
                 "KokkosSparse::spmv: XVector must be a Kokkos::View.");
   static_assert(Kokkos::is_view<YVector>::value,
                 "KokkosSparse::spmv: YVector must be a Kokkos::View.");
-  // Make sure A, x, y are accessible to execution_space
+  // Make sure A, x, y are accessible to ExecutionSpace
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename AMatrix::memory_space>::accessible,
-      "KokkosBlas::spmv: AMatrix must be accessible from execution_space");
+      "KokkosBlas::spmv: AMatrix must be accessible from ExecutionSpace");
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename XVector::memory_space>::accessible,
-      "KokkosBlas::spmv: XVector must be accessible from execution_space");
+      "KokkosBlas::spmv: XVector must be accessible from ExecutionSpace");
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename YVector::memory_space>::accessible,
-      "KokkosBlas::spmv: YVector must be accessible from execution_space");
+      "KokkosBlas::spmv: YVector must be accessible from ExecutionSpace");
   // Make sure that x and y have the same rank.
   static_assert(XVector::rank == YVector::rank,
                 "KokkosSparse::spmv: Vector ranks do not match.");
@@ -453,7 +453,7 @@ void spmv(const execution_space& exec,
         "]";
     Kokkos::Profiling::pushRegion(label);
     Experimental::Impl::SPMV_BSRMATRIX<
-        execution_space, typename AMatrix_Internal::const_value_type,
+        ExecutionSpace, typename AMatrix_Internal::const_value_type,
         typename AMatrix_Internal::const_ordinal_type,
         typename AMatrix_Internal::device_type,
         typename AMatrix_Internal::memory_traits,
@@ -470,19 +470,19 @@ void spmv(const execution_space& exec,
                                y_i);
     Kokkos::Profiling::popRegion();
   } else {
-#define __SPMV_TYPES__                                          \
-  execution_space, typename AMatrix_Internal::const_value_type, \
-      typename AMatrix_Internal::const_ordinal_type,            \
-      typename AMatrix_Internal::device_type,                   \
-      typename AMatrix_Internal::memory_traits,                 \
-      typename AMatrix_Internal::const_size_type,               \
-      typename XVector_Internal::const_value_type*,             \
-      typename XVector_Internal::array_layout,                  \
-      typename XVector_Internal::device_type,                   \
-      typename XVector_Internal::memory_traits,                 \
-      typename YVector_Internal::value_type*,                   \
-      typename YVector_Internal::array_layout,                  \
-      typename YVector_Internal::device_type,                   \
+#define __SPMV_TYPES__                                         \
+  ExecutionSpace, typename AMatrix_Internal::const_value_type, \
+      typename AMatrix_Internal::const_ordinal_type,           \
+      typename AMatrix_Internal::device_type,                  \
+      typename AMatrix_Internal::memory_traits,                \
+      typename AMatrix_Internal::const_size_type,              \
+      typename XVector_Internal::const_value_type*,            \
+      typename XVector_Internal::array_layout,                 \
+      typename XVector_Internal::device_type,                  \
+      typename XVector_Internal::memory_traits,                \
+      typename YVector_Internal::value_type*,                  \
+      typename YVector_Internal::array_layout,                 \
+      typename YVector_Internal::device_type,                  \
       typename YVector_Internal::memory_traits
 
     constexpr bool tpl_spec_avail =
@@ -528,8 +528,8 @@ struct SPMV2D1D {
                        const AMatrix& A, const XVector& x, const BetaType& beta,
                        const YVector& y);
 
-  template <typename execution_space>
-  static bool spmv2d1d(const execution_space& exec, const char mode[],
+  template <typename ExecutionSpace>
+  static bool spmv2d1d(const ExecutionSpace& exec, const char mode[],
                        const AlphaType& alpha, const AMatrix& A,
                        const XVector& x, const BetaType& beta,
                        const YVector& y);
@@ -547,8 +547,8 @@ struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector,
     return true;
   }
 
-  template <typename execution_space>
-  static bool spmv2d1d(const execution_space& exec, const char mode[],
+  template <typename ExecutionSpace>
+  static bool spmv2d1d(const ExecutionSpace& exec, const char mode[],
                        const AlphaType& alpha, const AMatrix& A,
                        const XVector& x, const BetaType& beta,
                        const YVector& y) {
@@ -569,8 +569,8 @@ struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector,
     return false;
   }
 
-  template <typename execution_space>
-  static bool spmv2d1d(const execution_space& /* exec */, const char /*mode*/[],
+  template <typename ExecutionSpace>
+  static bool spmv2d1d(const ExecutionSpace& /* exec */, const char /*mode*/[],
                        const AlphaType& /*alpha*/, const AMatrix& /*A*/,
                        const XVector& /*x*/, const BetaType& /*beta*/,
                        const YVector& /*y*/) {
@@ -591,8 +591,8 @@ struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector,
     return true;
   }
 
-  template <typename execution_space>
-  static bool spmv2d1d(const execution_space& exec, const char mode[],
+  template <typename ExecutionSpace>
+  static bool spmv2d1d(const ExecutionSpace& exec, const char mode[],
                        const AlphaType& alpha, const AMatrix& A,
                        const XVector& x, const BetaType& beta,
                        const YVector& y) {
@@ -613,8 +613,8 @@ struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector,
     return false;
   }
 
-  template <typename execution_space>
-  static bool spmv2d1d(const execution_space& /* exec */, const char /*mode*/[],
+  template <typename ExecutionSpace>
+  static bool spmv2d1d(const ExecutionSpace& /* exec */, const char /*mode*/[],
                        const AlphaType& /*alpha*/, const AMatrix& /*A*/,
                        const XVector& /*x*/, const BetaType& /*beta*/,
                        const YVector& /*y*/) {
@@ -635,8 +635,8 @@ struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector,
     return true;
   }
 
-  template <typename execution_space>
-  static bool spmv2d1d(const execution_space& exec, const char mode[],
+  template <typename ExecutionSpace>
+  static bool spmv2d1d(const ExecutionSpace& exec, const char mode[],
                        const AlphaType& alpha, const AMatrix& A,
                        const XVector& x, const BetaType& beta,
                        const YVector& y) {
@@ -657,8 +657,8 @@ struct SPMV2D1D<AlphaType, AMatrix, XVector, BetaType, YVector,
     return false;
   }
 
-  template <typename execution_space>
-  static bool spmv2d1d(const execution_space& /* exec */, const char /*mode*/[],
+  template <typename ExecutionSpace>
+  static bool spmv2d1d(const ExecutionSpace& /* exec */, const char /*mode*/[],
                        const AlphaType& /*alpha*/, const AMatrix& /*A*/,
                        const XVector& /*x*/, const BetaType& /*beta*/,
                        const YVector& /*y*/) {
@@ -679,7 +679,7 @@ using SPMV2D1D
 /// (RANK_TWO tag). Computes y := alpha*Op(A)*x + beta*y, where Op(A) is
 /// controlled by mode (see below).
 ///
-/// \tparam execution_space A Kokkos execution space. Must be able to access
+/// \tparam ExecutionSpace A Kokkos execution space. Must be able to access
 ///   the memory spaces of A, x, and y.
 /// \tparam AlphaType Type of coefficient alpha. Must be convertible to
 /// YVector::value_type. \tparam AMatrix A KokkosSparse::CrsMatrix, or
@@ -699,15 +699,15 @@ using SPMV2D1D
 /// \param y [in/out] Result vector.
 /// \param tag RANK_TWO dispatch
 #ifdef DOXY  // documentation version
-template <class execution_space, class AlphaType, class AMatrix, class XVector,
+template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector>
 #else
-template <class execution_space, class AlphaType, class AMatrix, class XVector,
+template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector,
           typename std::enable_if<
               KokkosSparse::is_crs_matrix<AMatrix>::value>::type* = nullptr>
 #endif
-void spmv(const execution_space& exec,
+void spmv(const ExecutionSpace& exec,
           KokkosKernels::Experimental::Controls controls, const char mode[],
           const AlphaType& alpha, const AMatrix& A, const XVector& x,
           const BetaType& beta, const YVector& y,
@@ -717,19 +717,19 @@ void spmv(const execution_space& exec,
                 "KokkosSparse::spmv: XVector must be a Kokkos::View.");
   static_assert(Kokkos::is_view<YVector>::value,
                 "KokkosSparse::spmv: YVector must be a Kokkos::View.");
-  // Make sure A, x, y are accessible to execution_space
+  // Make sure A, x, y are accessible to ExecutionSpace
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename AMatrix::memory_space>::accessible,
-      "KokkosBlas::spmv: AMatrix must be accessible from execution_space");
+      "KokkosBlas::spmv: AMatrix must be accessible from ExecutionSpace");
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename XVector::memory_space>::accessible,
-      "KokkosBlas::spmv: XVector must be accessible from execution_space");
+      "KokkosBlas::spmv: XVector must be accessible from ExecutionSpace");
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename YVector::memory_space>::accessible,
-      "KokkosBlas::spmv: YVector must be accessible from execution_space");
+      "KokkosBlas::spmv: YVector must be accessible from ExecutionSpace");
   // Make sure that x and y have the same rank.
   static_assert(XVector::rank == YVector::rank,
                 "KokkosSparse::spmv: Vector ranks do not match.");
@@ -828,7 +828,7 @@ void spmv(const execution_space& exec,
 
     if (useNative) {
       return Impl::SPMV_MV<
-          execution_space, typename AMatrix_Internal::value_type,
+          ExecutionSpace, typename AMatrix_Internal::value_type,
           typename AMatrix_Internal::ordinal_type,
           typename AMatrix_Internal::device_type,
           typename AMatrix_Internal::memory_traits,
@@ -845,7 +845,7 @@ void spmv(const execution_space& exec,
           false>::spmv_mv(exec, controls, mode, alpha, A_i, x_i, beta, y_i);
     } else {
       return Impl::SPMV_MV<
-          execution_space, typename AMatrix_Internal::value_type,
+          ExecutionSpace, typename AMatrix_Internal::value_type,
           typename AMatrix_Internal::ordinal_type,
           typename AMatrix_Internal::device_type,
           typename AMatrix_Internal::memory_traits,
@@ -900,11 +900,11 @@ void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
 }
 
 #ifndef DOXY  // hide SFINAE
-template <class execution_space, class AlphaType, class AMatrix, class XVector,
+template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector,
           typename std::enable_if<KokkosSparse::Experimental::is_bsr_matrix<
               AMatrix>::value>::type* = nullptr>
-void spmv(const execution_space& exec,
+void spmv(const ExecutionSpace& exec,
           KokkosKernels::Experimental::Controls controls, const char mode[],
           const AlphaType& alpha, const AMatrix& A, const XVector& x,
           const BetaType& beta, const YVector& y,
@@ -914,19 +914,19 @@ void spmv(const execution_space& exec,
                 "KokkosSparse::spmv: XVector must be a Kokkos::View.");
   static_assert(Kokkos::is_view<YVector>::value,
                 "KokkosSparse::spmv: YVector must be a Kokkos::View.");
-  // Make sure A, x, y are accessible to execution_space
+  // Make sure A, x, y are accessible to ExecutionSpace
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename AMatrix::memory_space>::accessible,
-      "KokkosBlas::spmv: AMatrix must be accessible from execution_space");
+      "KokkosBlas::spmv: AMatrix must be accessible from ExecutionSpace");
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename XVector::memory_space>::accessible,
-      "KokkosBlas::spmv: XVector must be accessible from execution_space");
+      "KokkosBlas::spmv: XVector must be accessible from ExecutionSpace");
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename YVector::memory_space>::accessible,
-      "KokkosBlas::spmv: YVector must be accessible from execution_space");
+      "KokkosBlas::spmv: YVector must be accessible from ExecutionSpace");
   // Make sure that x and y have the same rank.
   static_assert(
       static_cast<int>(XVector::rank) == static_cast<int>(YVector::rank),
@@ -1069,7 +1069,7 @@ void spmv(const execution_space& exec,
         "]";
     Kokkos::Profiling::pushRegion(label);
     Experimental::Impl::SPMV_MV_BSRMATRIX<
-        execution_space, typename AMatrix_Internal::const_value_type,
+        ExecutionSpace, typename AMatrix_Internal::const_value_type,
         typename AMatrix_Internal::const_ordinal_type,
         typename AMatrix_Internal::device_type,
         typename AMatrix_Internal::memory_traits,
@@ -1088,7 +1088,7 @@ void spmv(const execution_space& exec,
     Kokkos::Profiling::popRegion();
   } else {
     Experimental::Impl::SPMV_MV_BSRMATRIX<
-        execution_space, typename AMatrix_Internal::const_value_type,
+        ExecutionSpace, typename AMatrix_Internal::const_value_type,
         typename AMatrix_Internal::const_ordinal_type,
         typename AMatrix_Internal::device_type,
         typename AMatrix_Internal::memory_traits,
@@ -1143,7 +1143,7 @@ void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
 /// enabled for Kokkos::CrsMatrix and Kokkos::Experimental::BsrMatrix on a
 /// single vector, or for Kokkos::Experimental::BsrMatrix with a multivector.
 ///
-/// \tparam execution_space A Kokkos execution space. Must be able to access
+/// \tparam ExecutionSpace A Kokkos execution space. Must be able to access
 ///   the memory spaces of A, x, and y.
 /// \tparam AlphaType Type of coefficient alpha. Must be convertible to
 /// YVector::value_type. \tparam AMatrix A KokkosSparse::CrsMatrix, or
@@ -1164,9 +1164,9 @@ void spmv(KokkosKernels::Experimental::Controls controls, const char mode[],
 /// \param y [in/out] Either a single vector (rank-1 Kokkos::View) or
 ///   multivector (rank-2 Kokkos::View).  It must have the same number
 ///   of columns as x.
-template <class execution_space, class AlphaType, class AMatrix, class XVector,
+template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector>
-void spmv(const execution_space& exec,
+void spmv(const ExecutionSpace& exec,
           KokkosKernels::Experimental::Controls controls, const char mode[],
           const AlphaType& alpha, const AMatrix& A, const XVector& x,
           const BetaType& beta, const YVector& y) {
@@ -1175,19 +1175,19 @@ void spmv(const execution_space& exec,
                 "KokkosSparse::spmv: XVector must be a Kokkos::View.");
   static_assert(Kokkos::is_view<YVector>::value,
                 "KokkosSparse::spmv: YVector must be a Kokkos::View.");
-  // Make sure A, x, y are accessible to execution_space
+  // Make sure A, x, y are accessible to ExecutionSpace
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename AMatrix::memory_space>::accessible,
-      "KokkosBlas::spmv: AMatrix must be accessible from execution_space");
+      "KokkosBlas::spmv: AMatrix must be accessible from ExecutionSpace");
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename XVector::memory_space>::accessible,
-      "KokkosBlas::spmv: XVector must be accessible from execution_space");
+      "KokkosBlas::spmv: XVector must be accessible from ExecutionSpace");
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename YVector::memory_space>::accessible,
-      "KokkosBlas::spmv: YVector must be accessible from execution_space");
+      "KokkosBlas::spmv: YVector must be accessible from ExecutionSpace");
   // Make sure that both x and y have the same rank.
   static_assert(
       static_cast<int>(XVector::rank) == static_cast<int>(YVector::rank),
@@ -1324,12 +1324,12 @@ void spmv(KokkosKernels::Experimental::Controls /*controls*/,
 /// This is a catch-all interface that throws a compile-time error if \c
 /// AMatrix is not a CrsMatrix, or BsrMatrix
 ///
-template <class execution_space, class AlphaType, class AMatrix, class XVector,
+template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector,
           typename std::enable_if<
               !KokkosSparse::Experimental::is_bsr_matrix<AMatrix>::value &&
               !KokkosSparse::is_crs_matrix<AMatrix>::value>::type* = nullptr>
-void spmv(const execution_space& /* exec */,
+void spmv(const ExecutionSpace& /* exec */,
           KokkosKernels::Experimental::Controls /*controls*/,
           const char[] /*mode*/, const AlphaType& /*alpha*/,
           const AMatrix& /*A*/, const XVector& /*x*/, const BetaType& /*beta*/,
@@ -1371,7 +1371,7 @@ void spmv(const char mode[], const AlphaType& alpha, const AMatrix& A,
 ///   Computes y := alpha*Op(A)*x + beta*y, where Op(A) is controlled by mode
 ///   (see below).
 ///
-/// \tparam execution_space A Kokkos execution space. Must be able to access
+/// \tparam ExecutionSpace A Kokkos execution space. Must be able to access
 ///   the memory spaces of A, x, and y.
 /// \tparam AlphaType Type of coefficient alpha. Must be convertible to
 /// YVector::value_type. \tparam AMatrix A KokkosSparse::CrsMatrix, or
@@ -1388,20 +1388,20 @@ void spmv(const char mode[], const AlphaType& alpha, const AMatrix& A,
 /// \param x [in] A vector to multiply on the left by A.
 /// \param beta [in] Scalar multiplier for the vector y.
 /// \param y [in/out] Result vector.
-template <class execution_space, class AlphaType, class AMatrix, class XVector,
+template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector>
-void spmv(const execution_space& exec, const char mode[],
-          const AlphaType& alpha, const AMatrix& A, const XVector& x,
-          const BetaType& beta, const YVector& y) {
+void spmv(const ExecutionSpace& exec, const char mode[], const AlphaType& alpha,
+          const AMatrix& A, const XVector& x, const BetaType& beta,
+          const YVector& y) {
   KokkosKernels::Experimental::Controls controls;
   spmv(exec, controls, mode, alpha, A, x, beta, y);
 }
 
 namespace Experimental {
 
-template <class execution_space, class AlphaType, class AMatrix, class XVector,
+template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector>
-void spmv_struct(const execution_space& exec, const char mode[],
+void spmv_struct(const ExecutionSpace& exec, const char mode[],
                  const int stencil_type,
                  const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                                     Kokkos::HostSpace>& structure,
@@ -1411,22 +1411,22 @@ void spmv_struct(const execution_space& exec, const char mode[],
   // Make sure that both x and y have the same rank.
   static_assert((int)XVector::rank == (int)YVector::rank,
                 "KokkosSparse::spmv_struct: Vector ranks do not match.");
-  // Make sure A, x, y are accessible to execution_space
+  // Make sure A, x, y are accessible to ExecutionSpace
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename AMatrix::memory_space>::accessible,
       "KokkosBlas::spmv_struct: AMatrix must be accessible from "
-      "execution_space");
+      "ExecutionSpace");
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename XVector::memory_space>::accessible,
       "KokkosBlas::spmv_struct: XVector must be accessible from "
-      "execution_space");
+      "ExecutionSpace");
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename YVector::memory_space>::accessible,
       "KokkosBlas::spmv_struct: YVector must be accessible from "
-      "execution_space");
+      "ExecutionSpace");
   // Make sure that x (and therefore y) is rank 1.
   static_assert(
       (int)XVector::rank == 1,
@@ -1488,7 +1488,7 @@ void spmv_struct(const execution_space& exec, const char mode[],
   YVector_Internal y_i = y;
 
   return KokkosSparse::Impl::SPMV_STRUCT<
-      execution_space, typename AMatrix_Internal::value_type,
+      ExecutionSpace, typename AMatrix_Internal::value_type,
       typename AMatrix_Internal::ordinal_type,
       typename AMatrix_Internal::device_type,
       typename AMatrix_Internal::memory_traits,
@@ -1529,9 +1529,9 @@ struct SPMV2D1D_STRUCT {
       const AlphaType& alpha, const AMatrix& A, const XVector& x,
       const BetaType& beta, const YVector& y);
 
-  template <typename execution_space>
+  template <typename ExecutionSpace>
   static bool spmv2d1d_struct(
-      const execution_space& exec, const char mode[], const int stencil_type,
+      const ExecutionSpace& exec, const char mode[], const int stencil_type,
       const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                          Kokkos::HostSpace>& structure,
       const AlphaType& alpha, const AMatrix& A, const XVector& x,
@@ -1554,9 +1554,9 @@ struct SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector,
     return true;
   }
 
-  template <typename execution_space>
+  template <typename ExecutionSpace>
   static bool spmv2d1d_struct(
-      const execution_space& exec, const char mode[], const int stencil_type,
+      const ExecutionSpace& exec, const char mode[], const int stencil_type,
       const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                          Kokkos::HostSpace>& structure,
       const AlphaType& alpha, const AMatrix& A, const XVector& x,
@@ -1580,9 +1580,9 @@ struct SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector,
     return false;
   }
 
-  template <typename execution_space>
+  template <typename ExecutionSpace>
   static bool spmv2d1d_struct(
-      const execution_space& /* exec*/, const char /*mode*/[],
+      const ExecutionSpace& /* exec*/, const char /*mode*/[],
       const int /*stencil_type*/,
       const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                          Kokkos::HostSpace>& /*structure*/,
@@ -1609,9 +1609,9 @@ struct SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector,
     return true;
   }
 
-  template <typename execution_space>
+  template <typename ExecutionSpace>
   static bool spmv2d1d_struct(
-      const execution_space& exec, const char mode[], const int stencil_type,
+      const ExecutionSpace& exec, const char mode[], const int stencil_type,
       const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                          Kokkos::HostSpace>& structure,
       const AlphaType& alpha, const AMatrix& A, const XVector& x,
@@ -1635,9 +1635,9 @@ struct SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector,
     return false;
   }
 
-  template <typename execution_space>
+  template <typename ExecutionSpace>
   static bool spmv2d1d_struct(
-      const execution_space /*exec*/, const char /*mode*/[],
+      const ExecutionSpace /*exec*/, const char /*mode*/[],
       const int /*stencil_type*/,
       const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                          Kokkos::HostSpace>& /*structure*/,
@@ -1664,9 +1664,9 @@ struct SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector,
     return true;
   }
 
-  template <typename execution_space>
+  template <typename ExecutionSpace>
   static bool spmv2d1d_struct(
-      const execution_space& exec, const char mode[], const int stencil_type,
+      const ExecutionSpace& exec, const char mode[], const int stencil_type,
       const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                          Kokkos::HostSpace>& structure,
       const AlphaType& alpha, const AMatrix& A, const XVector& x,
@@ -1690,9 +1690,9 @@ struct SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector,
     return false;
   }
 
-  template <typename execution_space>
+  template <typename ExecutionSpace>
   static bool spmv2d1d_struct(
-      const execution_space& /*exec*/, const char /*mode*/[],
+      const ExecutionSpace& /*exec*/, const char /*mode*/[],
       const int /*stencil_type*/,
       const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                          Kokkos::HostSpace>& /*structure*/,
@@ -1711,31 +1711,31 @@ using SPMV2D1D_STRUCT
                  "interface - use KokkosSparse::spmv_struct instead")]] =
         Impl::SPMV2D1D_STRUCT<AlphaType, AMatrix, XVector, BetaType, YVector>;
 
-template <class execution_space, class AlphaType, class AMatrix, class XVector,
+template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector>
-void spmv_struct(const execution_space& exec, const char mode[],
+void spmv_struct(const ExecutionSpace& exec, const char mode[],
                  const int stencil_type,
                  const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                                     Kokkos::HostSpace>& structure,
                  const AlphaType& alpha, const AMatrix& A, const XVector& x,
                  const BetaType& beta, const YVector& y,
                  [[maybe_unused]] const RANK_TWO& tag) {
-  // Make sure A, x, y are accessible to execution_space
+  // Make sure A, x, y are accessible to ExecutionSpace
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename AMatrix::memory_space>::accessible,
       "KokkosBlas::spmv_struct: AMatrix must be accessible from "
-      "execution_space");
+      "ExecutionSpace");
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename XVector::memory_space>::accessible,
       "KokkosBlas::spmv_struct: XVector must be accessible from "
-      "execution_space");
+      "ExecutionSpace");
   static_assert(
-      Kokkos::SpaceAccessibility<execution_space,
+      Kokkos::SpaceAccessibility<ExecutionSpace,
                                  typename YVector::memory_space>::accessible,
       "KokkosBlas::spmv_struct: YVector must be accessible from "
-      "execution_space");
+      "ExecutionSpace");
   // Make sure that both x and y have the same rank.
   static_assert(XVector::rank == YVector::rank,
                 "KokkosBlas::spmv: Vector ranks do not match.");
@@ -1820,7 +1820,7 @@ void spmv_struct(const execution_space& exec, const char mode[],
     YVector_Internal y_i = y;
 
     return KokkosSparse::Impl::SPMV_MV<
-        execution_space, typename AMatrix_Internal::value_type,
+        ExecutionSpace, typename AMatrix_Internal::value_type,
         typename AMatrix_Internal::ordinal_type,
         typename AMatrix_Internal::device_type,
         typename AMatrix_Internal::memory_traits,
@@ -1909,9 +1909,9 @@ void spmv_struct(const char mode[], const int stencil_type,
 /// \param y [in/out] Either a single vector (rank-1 Kokkos::View) or
 ///   multivector (rank-2 Kokkos::View).  It must have the same number
 ///   of columns as x.
-template <class execution_space, class AlphaType, class AMatrix, class XVector,
+template <class ExecutionSpace, class AlphaType, class AMatrix, class XVector,
           class BetaType, class YVector>
-void spmv_struct(const execution_space& exec, const char mode[],
+void spmv_struct(const ExecutionSpace& exec, const char mode[],
                  const int stencil_type,
                  const Kokkos::View<typename AMatrix::non_const_ordinal_type*,
                                     Kokkos::HostSpace>& structure,

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_avail.hpp
@@ -36,20 +36,20 @@ struct spmv_bsrmatrix_tpl_spec_avail {
 // These versions of cuSPARSE require the ordinal and offset types to be the
 // same. For KokkosKernels, this means int/int only.
 
-#define KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_CUSPARSE(                   \
-    SCALAR, ORDINAL, OFFSET, XL, YL, MEMSPACE)                                 \
-  template <>                                                                  \
-  struct spmv_bsrmatrix_tpl_spec_avail<                                        \
-      Kokkos::Cuda,                                                            \
-      KokkosSparse::Experimental::BsrMatrix<                                   \
-          const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET>,              \
-      Kokkos::View<                                                            \
-          const SCALAR*, XL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,           \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
-      Kokkos::View<SCALAR*, YL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,        \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                 \
-    enum : bool { value = true };                                              \
+#define KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_CUSPARSE(               \
+    SCALAR, ORDINAL, OFFSET, XL, YL, MEMSPACE)                             \
+  template <>                                                              \
+  struct spmv_bsrmatrix_tpl_spec_avail<                                    \
+      Kokkos::Cuda,                                                        \
+      ::KokkosSparse::Experimental::BsrMatrix<const SCALAR, const ORDINAL,                               \
+                Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                    \
+                Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET>,    \
+      Kokkos::View<                                                        \
+          const SCALAR*, XL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,       \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>, \
+      Kokkos::View<SCALAR*, YL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {             \
+    enum : bool { value = true };                                          \
   };
 
 #if (9000 <= CUDA_VERSION)
@@ -129,18 +129,18 @@ KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>,
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
 #define KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_MKL(SCALAR, EXECSPACE)  \
   template <>                                                              \
-      struct spmv_bsrmatrix_tpl_spec_avail < EXECSPACE,                    \
-      KokkosSparse::Experimental::BsrMatrix<                               \
-          const SCALAR, const MKL_INT,                                     \
-          Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                    \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>,         \
+  struct spmv_bsrmatrix_tpl_spec_avail<                                    \
+      EXECSPACE,                                                           \
+      ::KokkosSparse::Experimental::BsrMatrix<const SCALAR, const MKL_INT,                               \
+                Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,              \
+                Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>,   \
       Kokkos::View<                                                        \
           const SCALAR*, Kokkos::LayoutLeft,                               \
           Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                    \
           Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>, \
       Kokkos::View<SCALAR*, Kokkos::LayoutLeft,                            \
                    Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,           \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>> {              \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {             \
     enum : bool { value = true };                                          \
   };
 
@@ -178,21 +178,21 @@ struct spmv_mv_bsrmatrix_tpl_spec_avail {
 // These versions of cuSPARSE require the ordinal and offset types to be the
 // same. For KokkosKernels, this means int/int only.
 // cuSparse level 3 does not currently support LayoutRight
-#define KOKKOSSPARSE_SPMV_MV_BSRMATRIX_TPL_SPEC_AVAIL_CUSPARSE(                \
-    SCALAR, ORDINAL, OFFSET, LAYOUT, MEMSPACE)                                 \
-  template <>                                                                  \
-  struct spmv_mv_bsrmatrix_tpl_spec_avail<                                     \
-      Kokkos::Cuda,                                                            \
-      KokkosSparse::Experimental::BsrMatrix<                                   \
-          const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET>,              \
-      Kokkos::View<                                                            \
-          const SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,      \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
-      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,   \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
-      false> {                                                                 \
-    enum : bool { value = true };                                              \
+#define KOKKOSSPARSE_SPMV_MV_BSRMATRIX_TPL_SPEC_AVAIL_CUSPARSE(              \
+    SCALAR, ORDINAL, OFFSET, LAYOUT, MEMSPACE)                               \
+  template <>                                                                \
+  struct spmv_mv_bsrmatrix_tpl_spec_avail<                                   \
+      Kokkos::Cuda,                                                          \
+      ::KokkosSparse::Experimental::BsrMatrix<const SCALAR, const ORDINAL,                                 \
+                Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                      \
+                Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET>,      \
+      Kokkos::View<                                                          \
+          const SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,    \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,   \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      false> {                                                               \
+    enum : bool { value = true };                                            \
   };
 
 #if (9000 <= CUDA_VERSION)
@@ -230,17 +230,23 @@ KOKKOSSPARSE_SPMV_MV_BSRMATRIX_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>,
 #endif  // KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
-#define KOKKOSSPARSE_SPMV_MV_BSRMATRIX_TPL_SPEC_AVAIL_MKL(SCALAR, EXECSPACE)   \
-  template <>                                                                  \
-  struct spmv_mv_bsrmatrix_tpl_spec_avail<                                     \
-      EXECSPACE, const SCALAR, const int,                                      \
-      Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                            \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const int, const SCALAR*,       \
-      Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
-      Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, true> {                         \
-    enum : bool { value = true };                                              \
+#define KOKKOSSPARSE_SPMV_MV_BSRMATRIX_TPL_SPEC_AVAIL_MKL(SCALAR, EXECSPACE) \
+  template <>                                                                \
+  struct spmv_mv_bsrmatrix_tpl_spec_avail<                                   \
+      EXECSPACE,                                                             \
+      ::KokkosSparse::Experimental::BsrMatrix<                                 \
+          const SCALAR, const int,                                           \
+          Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                      \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const int>,               \
+      Kokkos::View<                                                          \
+          const SCALAR*, Kokkos::LayoutLeft,                                 \
+          Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                      \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,   \
+      Kokkos::View<SCALAR*, Kokkos::LayoutLeft,                              \
+                   Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,             \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
+      true> {                                                                \
+    enum : bool { value = true };                                            \
   };
 
 #ifdef KOKKOS_ENABLE_SERIAL
@@ -267,20 +273,20 @@ KOKKOSSPARSE_SPMV_MV_BSRMATRIX_TPL_SPEC_AVAIL_MKL(Kokkos::complex<double>,
 
 #include "KokkosSparse_Utils_rocsparse.hpp"
 
-#define KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_ROCSPARSE(                 \
-    SCALAR, ORDINAL, OFFSET, LAYOUT, MEMSPACE)                                \
-  template <>                                                                 \
-  struct spmv_bsrmatrix_tpl_spec_avail<                                       \
-      Kokkos::HIP,                                                            \
-      KokkosSparse::Experimental::BsrMatrix<                                  \
-          const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::HIP, MEMSPACE>, \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET>,             \
-      Kokkos::View<                                                           \
-          const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>,       \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,    \
-      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>,    \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                \
-    enum : bool { value = true };                                             \
+#define KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_ROCSPARSE(              \
+    SCALAR, ORDINAL, OFFSET, LAYOUT, MEMSPACE)                             \
+  template <>                                                              \
+  struct spmv_bsrmatrix_tpl_spec_avail<                                    \
+      Kokkos::HIP,                                                         \
+      ::KokkosSparse::Experimental::BsrMatrix<const SCALAR, const ORDINAL,                               \
+                Kokkos::Device<Kokkos::HIP, MEMSPACE>,                     \
+                Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET>,    \
+      Kokkos::View<                                                        \
+          const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>,    \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>, \
+      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {             \
+    enum : bool { value = true };                                          \
   };
 
 #if KOKKOSSPARSE_IMPL_ROCM_VERSION >= 50200

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_avail.hpp
@@ -25,8 +25,8 @@ namespace KokkosSparse {
 namespace Experimental {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class AT, class AO, class AD, class AM, class AS, class XT, class XL,
-          class XD, class XM, class YT, class YL, class YD, class YM>
+template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
+          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
 struct spmv_bsrmatrix_tpl_spec_avail {
   enum : bool { value = false };
 };
@@ -41,7 +41,8 @@ struct spmv_bsrmatrix_tpl_spec_avail {
     SCALAR, ORDINAL, OFFSET, XL, YL, MEMSPACE)                                 \
   template <>                                                                  \
   struct spmv_bsrmatrix_tpl_spec_avail<                                        \
-      const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,     \
+      Kokkos::Cuda, const SCALAR, const ORDINAL,                               \
+      Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                                  \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET, const SCALAR*,    \
       XL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                              \
       Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
@@ -128,7 +129,7 @@ KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>,
 #define KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_MKL(SCALAR, EXECSPACE)      \
   template <>                                                                  \
   struct spmv_bsrmatrix_tpl_spec_avail<                                        \
-      const SCALAR, const MKL_INT,                                             \
+      EXECSPACE, const SCALAR, const MKL_INT,                                  \
       Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                            \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT, const SCALAR*,   \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
@@ -159,8 +160,8 @@ KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_MKL(Kokkos::complex<double>,
 #endif
 
 // Specialization struct which defines whether a specialization exists
-template <class AT, class AO, class AD, class AM, class AS, class XT, class XL,
-          class XD, class XM, class YT, class YL, class YD, class YM,
+template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
+          class XL, class XD, class XM, class YT, class YL, class YD, class YM,
           const bool integerScalarType =
               std::is_integral<typename std::decay<AT>::type>::value>
 struct spmv_mv_bsrmatrix_tpl_spec_avail {
@@ -177,7 +178,8 @@ struct spmv_mv_bsrmatrix_tpl_spec_avail {
     SCALAR, ORDINAL, OFFSET, LAYOUT, MEMSPACE)                               \
   template <>                                                                \
   struct spmv_mv_bsrmatrix_tpl_spec_avail<                                   \
-      const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,   \
+      Kokkos::Cuda, const SCALAR, const ORDINAL,                             \
+      Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                                \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET, const SCALAR**, \
       LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,        \
@@ -224,7 +226,8 @@ KOKKOSSPARSE_SPMV_MV_BSRMATRIX_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>,
 #define KOKKOSSPARSE_SPMV_MV_BSRMATRIX_TPL_SPEC_AVAIL_MKL(SCALAR, EXECSPACE)   \
   template <>                                                                  \
   struct spmv_mv_bsrmatrix_tpl_spec_avail<                                     \
-      const SCALAR, const int, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,   \
+      EXECSPACE, const SCALAR, const int,                                      \
+      Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                            \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, const int, const SCALAR*,       \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
       Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
@@ -261,7 +264,8 @@ KOKKOSSPARSE_SPMV_MV_BSRMATRIX_TPL_SPEC_AVAIL_MKL(Kokkos::complex<double>,
     SCALAR, ORDINAL, OFFSET, LAYOUT, MEMSPACE)                                 \
   template <>                                                                  \
   struct spmv_bsrmatrix_tpl_spec_avail<                                        \
-      const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::HIP, MEMSPACE>,      \
+      Kokkos::HIP, const SCALAR, const ORDINAL,                                \
+      Kokkos::Device<Kokkos::HIP, MEMSPACE>,                                   \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET, const SCALAR*,    \
       LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>,                           \
       Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_avail.hpp
@@ -36,20 +36,20 @@ struct spmv_bsrmatrix_tpl_spec_avail {
 // These versions of cuSPARSE require the ordinal and offset types to be the
 // same. For KokkosKernels, this means int/int only.
 
-#define KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_CUSPARSE(               \
-    SCALAR, ORDINAL, OFFSET, XL, YL, MEMSPACE)                             \
-  template <>                                                              \
-  struct spmv_bsrmatrix_tpl_spec_avail<                                    \
-      Kokkos::Cuda,                                                        \
-      ::KokkosSparse::Experimental::BsrMatrix<const SCALAR, const ORDINAL,                               \
-                Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                    \
-                Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET>,    \
-      Kokkos::View<                                                        \
-          const SCALAR*, XL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,       \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>, \
-      Kokkos::View<SCALAR*, YL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,    \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {             \
-    enum : bool { value = true };                                          \
+#define KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_CUSPARSE(                   \
+    SCALAR, ORDINAL, OFFSET, XL, YL, MEMSPACE)                                 \
+  template <>                                                                  \
+  struct spmv_bsrmatrix_tpl_spec_avail<                                        \
+      Kokkos::Cuda,                                                            \
+      ::KokkosSparse::Experimental::BsrMatrix<                                 \
+          const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET>,              \
+      Kokkos::View<                                                            \
+          const SCALAR*, XL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,           \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR*, YL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,        \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                 \
+    enum : bool { value = true };                                              \
   };
 
 #if (9000 <= CUDA_VERSION)
@@ -131,9 +131,10 @@ KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>,
   template <>                                                              \
   struct spmv_bsrmatrix_tpl_spec_avail<                                    \
       EXECSPACE,                                                           \
-      ::KokkosSparse::Experimental::BsrMatrix<const SCALAR, const MKL_INT,                               \
-                Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,              \
-                Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>,   \
+      ::KokkosSparse::Experimental::BsrMatrix<                             \
+          const SCALAR, const MKL_INT,                                     \
+          Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                    \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>,         \
       Kokkos::View<                                                        \
           const SCALAR*, Kokkos::LayoutLeft,                               \
           Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                    \
@@ -178,21 +179,21 @@ struct spmv_mv_bsrmatrix_tpl_spec_avail {
 // These versions of cuSPARSE require the ordinal and offset types to be the
 // same. For KokkosKernels, this means int/int only.
 // cuSparse level 3 does not currently support LayoutRight
-#define KOKKOSSPARSE_SPMV_MV_BSRMATRIX_TPL_SPEC_AVAIL_CUSPARSE(              \
-    SCALAR, ORDINAL, OFFSET, LAYOUT, MEMSPACE)                               \
-  template <>                                                                \
-  struct spmv_mv_bsrmatrix_tpl_spec_avail<                                   \
-      Kokkos::Cuda,                                                          \
-      ::KokkosSparse::Experimental::BsrMatrix<const SCALAR, const ORDINAL,                                 \
-                Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                      \
-                Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET>,      \
-      Kokkos::View<                                                          \
-          const SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,    \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,   \
-      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
-      false> {                                                               \
-    enum : bool { value = true };                                            \
+#define KOKKOSSPARSE_SPMV_MV_BSRMATRIX_TPL_SPEC_AVAIL_CUSPARSE(                \
+    SCALAR, ORDINAL, OFFSET, LAYOUT, MEMSPACE)                                 \
+  template <>                                                                  \
+  struct spmv_mv_bsrmatrix_tpl_spec_avail<                                     \
+      Kokkos::Cuda,                                                            \
+      ::KokkosSparse::Experimental::BsrMatrix<                                 \
+          const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET>,              \
+      Kokkos::View<                                                            \
+          const SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,      \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,   \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
+      false> {                                                                 \
+    enum : bool { value = true };                                              \
   };
 
 #if (9000 <= CUDA_VERSION)
@@ -234,7 +235,7 @@ KOKKOSSPARSE_SPMV_MV_BSRMATRIX_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>,
   template <>                                                                \
   struct spmv_mv_bsrmatrix_tpl_spec_avail<                                   \
       EXECSPACE,                                                             \
-      ::KokkosSparse::Experimental::BsrMatrix<                                 \
+      ::KokkosSparse::Experimental::BsrMatrix<                               \
           const SCALAR, const int,                                           \
           Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                      \
           Kokkos::MemoryTraits<Kokkos::Unmanaged>, const int>,               \
@@ -273,20 +274,20 @@ KOKKOSSPARSE_SPMV_MV_BSRMATRIX_TPL_SPEC_AVAIL_MKL(Kokkos::complex<double>,
 
 #include "KokkosSparse_Utils_rocsparse.hpp"
 
-#define KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_ROCSPARSE(              \
-    SCALAR, ORDINAL, OFFSET, LAYOUT, MEMSPACE)                             \
-  template <>                                                              \
-  struct spmv_bsrmatrix_tpl_spec_avail<                                    \
-      Kokkos::HIP,                                                         \
-      ::KokkosSparse::Experimental::BsrMatrix<const SCALAR, const ORDINAL,                               \
-                Kokkos::Device<Kokkos::HIP, MEMSPACE>,                     \
-                Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET>,    \
-      Kokkos::View<                                                        \
-          const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>,    \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>, \
-      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>, \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {             \
-    enum : bool { value = true };                                          \
+#define KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_ROCSPARSE(                 \
+    SCALAR, ORDINAL, OFFSET, LAYOUT, MEMSPACE)                                \
+  template <>                                                                 \
+  struct spmv_bsrmatrix_tpl_spec_avail<                                       \
+      Kokkos::HIP,                                                            \
+      ::KokkosSparse::Experimental::BsrMatrix<                                \
+          const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::HIP, MEMSPACE>, \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET>,             \
+      Kokkos::View<                                                           \
+          const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>,       \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,    \
+      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>,    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                \
+    enum : bool { value = true };                                             \
   };
 
 #if KOKKOSSPARSE_IMPL_ROCM_VERSION >= 50200

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_avail.hpp
@@ -25,8 +25,7 @@ namespace KokkosSparse {
 namespace Experimental {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector>
 struct spmv_bsrmatrix_tpl_spec_avail {
   enum : bool { value = false };
 };
@@ -41,13 +40,15 @@ struct spmv_bsrmatrix_tpl_spec_avail {
     SCALAR, ORDINAL, OFFSET, XL, YL, MEMSPACE)                                 \
   template <>                                                                  \
   struct spmv_bsrmatrix_tpl_spec_avail<                                        \
-      Kokkos::Cuda, const SCALAR, const ORDINAL,                               \
-      Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                                  \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET, const SCALAR*,    \
-      XL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                              \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
-      YL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                              \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> > {                              \
+      Kokkos::Cuda,                                                            \
+      KokkosSparse::Experimental::BsrMatrix<                                   \
+          const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET>,              \
+      Kokkos::View<                                                            \
+          const SCALAR*, XL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,           \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR*, YL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,        \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                 \
     enum : bool { value = true };                                              \
   };
 
@@ -126,17 +127,21 @@ KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>,
 #endif  // KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
-#define KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_MKL(SCALAR, EXECSPACE)      \
-  template <>                                                                  \
-  struct spmv_bsrmatrix_tpl_spec_avail<                                        \
-      EXECSPACE, const SCALAR, const MKL_INT,                                  \
-      Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                            \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT, const SCALAR*,   \
-      Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
-      Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> > {                              \
-    enum : bool { value = true };                                              \
+#define KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_MKL(SCALAR, EXECSPACE)  \
+  template <>                                                              \
+      struct spmv_bsrmatrix_tpl_spec_avail < EXECSPACE,                    \
+      KokkosSparse::Experimental::BsrMatrix<                               \
+          const SCALAR, const MKL_INT,                                     \
+          Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                    \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>,         \
+      Kokkos::View<                                                        \
+          const SCALAR*, Kokkos::LayoutLeft,                               \
+          Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                    \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>, \
+      Kokkos::View<SCALAR*, Kokkos::LayoutLeft,                            \
+                   Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,           \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>> {              \
+    enum : bool { value = true };                                          \
   };
 
 #ifdef KOKKOS_ENABLE_SERIAL
@@ -160,10 +165,9 @@ KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_MKL(Kokkos::complex<double>,
 #endif
 
 // Specialization struct which defines whether a specialization exists
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM,
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector,
           const bool integerScalarType =
-              std::is_integral<typename std::decay<AT>::type>::value>
+              std::is_integral_v<typename AMatrix::non_const_value_type>>
 struct spmv_mv_bsrmatrix_tpl_spec_avail {
   enum : bool { value = false };
 };
@@ -174,18 +178,21 @@ struct spmv_mv_bsrmatrix_tpl_spec_avail {
 // These versions of cuSPARSE require the ordinal and offset types to be the
 // same. For KokkosKernels, this means int/int only.
 // cuSparse level 3 does not currently support LayoutRight
-#define KOKKOSSPARSE_SPMV_MV_BSRMATRIX_TPL_SPEC_AVAIL_CUSPARSE(              \
-    SCALAR, ORDINAL, OFFSET, LAYOUT, MEMSPACE)                               \
-  template <>                                                                \
-  struct spmv_mv_bsrmatrix_tpl_spec_avail<                                   \
-      Kokkos::Cuda, const SCALAR, const ORDINAL,                             \
-      Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                                \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET, const SCALAR**, \
-      LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,        \
-      SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,              \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, false> {                      \
-    enum : bool { value = true };                                            \
+#define KOKKOSSPARSE_SPMV_MV_BSRMATRIX_TPL_SPEC_AVAIL_CUSPARSE(                \
+    SCALAR, ORDINAL, OFFSET, LAYOUT, MEMSPACE)                                 \
+  template <>                                                                  \
+  struct spmv_mv_bsrmatrix_tpl_spec_avail<                                     \
+      Kokkos::Cuda,                                                            \
+      KokkosSparse::Experimental::BsrMatrix<                                   \
+          const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET>,              \
+      Kokkos::View<                                                            \
+          const SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,      \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,   \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
+      false> {                                                                 \
+    enum : bool { value = true };                                              \
   };
 
 #if (9000 <= CUDA_VERSION)
@@ -260,18 +267,20 @@ KOKKOSSPARSE_SPMV_MV_BSRMATRIX_TPL_SPEC_AVAIL_MKL(Kokkos::complex<double>,
 
 #include "KokkosSparse_Utils_rocsparse.hpp"
 
-#define KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_ROCSPARSE(                  \
-    SCALAR, ORDINAL, OFFSET, LAYOUT, MEMSPACE)                                 \
-  template <>                                                                  \
-  struct spmv_bsrmatrix_tpl_spec_avail<                                        \
-      Kokkos::HIP, const SCALAR, const ORDINAL,                                \
-      Kokkos::Device<Kokkos::HIP, MEMSPACE>,                                   \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET, const SCALAR*,    \
-      LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>,                           \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
-      LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>,                           \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> > {                              \
-    enum : bool { value = true };                                              \
+#define KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_ROCSPARSE(                 \
+    SCALAR, ORDINAL, OFFSET, LAYOUT, MEMSPACE)                                \
+  template <>                                                                 \
+  struct spmv_bsrmatrix_tpl_spec_avail<                                       \
+      Kokkos::HIP,                                                            \
+      KokkosSparse::Experimental::BsrMatrix<                                  \
+          const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::HIP, MEMSPACE>, \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET>,             \
+      Kokkos::View<                                                           \
+          const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>,       \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,    \
+      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>,    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                \
+    enum : bool { value = true };                                             \
   };
 
 #if KOKKOSSPARSE_IMPL_ROCM_VERSION >= 50200

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
@@ -203,7 +203,7 @@ inline void spm_mv_block_impl_mkl(
   template <>                                                                \
   struct SPMV_BSRMATRIX<                                                     \
       EXECSPACE,                                                             \
-      BsrMatrix<SCALAR const, MKL_INT const,                                 \
+      ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, MKL_INT const,                                 \
                 Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                \
                 Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>,     \
       Kokkos::View<                                                          \
@@ -216,7 +216,7 @@ inline void spm_mv_block_impl_mkl(
       true, COMPILE_LIBRARY> {                                               \
     using device_type = Kokkos::Device<EXECSPACE, Kokkos::HostSpace>;        \
     using AMatrix =                                                          \
-        BsrMatrix<SCALAR const, MKL_INT const, device_type,                  \
+        ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, MKL_INT const, device_type,                  \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;   \
     using XVector = Kokkos::View<                                            \
         SCALAR const*, Kokkos::LayoutLeft, device_type,                      \
@@ -267,7 +267,7 @@ KOKKOSSPARSE_SPMV_MKL(Kokkos::complex<double>, Kokkos::OpenMP,
   template <>                                                                  \
   struct SPMV_MV_BSRMATRIX<                                                    \
       EXECSPACE,                                                               \
-      BsrMatrix<SCALAR const, MKL_INT const,                                   \
+      ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, MKL_INT const,                                   \
                 Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                  \
                 Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>,       \
       Kokkos::View<                                                            \
@@ -280,7 +280,7 @@ KOKKOSSPARSE_SPMV_MKL(Kokkos::complex<double>, Kokkos::OpenMP,
       true, true, COMPILE_LIBRARY> {                                           \
     using device_type = Kokkos::Device<EXECSPACE, Kokkos::HostSpace>;          \
     using AMatrix =                                                            \
-        BsrMatrix<SCALAR const, MKL_INT const, device_type,                    \
+        ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, MKL_INT const, device_type,                    \
                   Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;     \
     using XVector = Kokkos::View<                                              \
         SCALAR const**, Kokkos::LayoutLeft, device_type,                       \
@@ -576,7 +576,7 @@ void spm_mv_block_impl_cusparse(
   template <>                                                               \
   struct SPMV_BSRMATRIX<                                                    \
       Kokkos::Cuda,                                                         \
-      BsrMatrix<SCALAR const, ORDINAL const,                                \
+      ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, ORDINAL const,                                \
                 Kokkos::Device<Kokkos::Cuda, SPACE>,                        \
                 Kokkos::MemoryTraits<Kokkos::Unmanaged>, OFFSET const>,     \
       Kokkos::View<                                                         \
@@ -587,7 +587,7 @@ void spm_mv_block_impl_cusparse(
       true, COMPILE_LIBRARY> {                                              \
     using device_type       = Kokkos::Device<Kokkos::Cuda, SPACE>;          \
     using memory_trait_type = Kokkos::MemoryTraits<Kokkos::Unmanaged>;      \
-    using AMatrix = BsrMatrix<SCALAR const, ORDINAL const, device_type,     \
+    using AMatrix = ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, ORDINAL const, device_type,     \
                               memory_trait_type, OFFSET const>;             \
     using XVector = Kokkos::View<                                           \
         SCALAR const*, LAYOUT, device_type,                                 \
@@ -672,7 +672,7 @@ KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>, int, int,
   template <>                                                                  \
   struct SPMV_MV_BSRMATRIX<                                                    \
       Kokkos::Cuda,                                                            \
-      BsrMatrix<SCALAR const, ORDINAL const,                                   \
+      ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, ORDINAL const,                                   \
                 Kokkos::Device<Kokkos::Cuda, SPACE>,                           \
                 Kokkos::MemoryTraits<Kokkos::Unmanaged>, OFFSET const>,        \
       Kokkos::View<                                                            \
@@ -685,7 +685,7 @@ KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>, int, int,
       false, true, ETI_AVAIL> {                                                \
     using device_type       = Kokkos::Device<Kokkos::Cuda, SPACE>;             \
     using memory_trait_type = Kokkos::MemoryTraits<Kokkos::Unmanaged>;         \
-    using AMatrix = BsrMatrix<SCALAR const, ORDINAL const, device_type,        \
+    using AMatrix = ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, ORDINAL const, device_type,        \
                               memory_trait_type, OFFSET const>;                \
     using XVector = Kokkos::View<                                              \
         SCALAR const**, Kokkos::LayoutLeft, device_type,                       \
@@ -933,7 +933,7 @@ void spmv_block_impl_rocsparse(
   template <>                                                                \
   struct SPMV_BSRMATRIX<                                                     \
       Kokkos::HIP,                                                           \
-      BsrMatrix<SCALAR const, ORDINAL const,                                 \
+      ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, ORDINAL const,                                 \
                 Kokkos::Device<Kokkos::HIP, SPACE>,                          \
                 Kokkos::MemoryTraits<Kokkos::Unmanaged>, OFFSET const>,      \
       Kokkos::View<                                                          \
@@ -944,7 +944,7 @@ void spmv_block_impl_rocsparse(
       true, COMPILE_LIBRARY> {                                               \
     using device_type       = Kokkos::Device<Kokkos::HIP, SPACE>;            \
     using memory_trait_type = Kokkos::MemoryTraits<Kokkos::Unmanaged>;       \
-    using AMatrix = BsrMatrix<SCALAR const, ORDINAL const, device_type,      \
+    using AMatrix = ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, ORDINAL const, device_type,      \
                               memory_trait_type, OFFSET const>;              \
     using XVector = Kokkos::View<                                            \
         SCALAR const*, LAYOUT, device_type,                                  \

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
@@ -221,17 +221,17 @@ inline void spm_mv_block_impl_mkl(
     using coefficient_type = typename YVector::non_const_value_type;           \
                                                                                \
     static void spmv_bsrmatrix(                                                \
-        const EXECSPACE& exec,                                                 \
+        const EXECSPACE&,                                                      \
         const KokkosKernels::Experimental::Controls& /*controls*/,             \
         const char mode[], const coefficient_type& alpha, const AMatrix& A,    \
         const XVector& X, const coefficient_type& beta, const YVector& Y) {    \
       std::string label = "KokkosSparse::spmv[TPL_MKL,BSRMATRIX" +             \
                           Kokkos::ArithTraits<SCALAR>::name() + "]";           \
       Kokkos::Profiling::pushRegion(label);                                    \
-      spmv_block_impl_mkl(exec, mode_kk_to_mkl(mode[0]), alpha, beta,          \
-                          A.numRows(), A.numCols(), A.blockDim(),              \
-                          A.graph.row_map.data(), A.graph.entries.data(),      \
-                          A.values.data(), X.data(), Y.data());                \
+      spmv_block_impl_mkl(mode_kk_to_mkl(mode[0]), alpha, beta, A.numRows(),   \
+                          A.numCols(), A.blockDim(), A.graph.row_map.data(),   \
+                          A.graph.entries.data(), A.values.data(), X.data(),   \
+                          Y.data());                                           \
       Kokkos::Profiling::popRegion();                                          \
     }                                                                          \
   };
@@ -258,46 +258,45 @@ KOKKOSSPARSE_SPMV_MKL(Kokkos::complex<double>, Kokkos::OpenMP,
 
 #undef KOKKOSSPARSE_SPMV_MKL
 
-#define KOKKOSSPARSE_SPMV_MV_MKL(SCALAR, EXECSPACE, COMPILE_LIBRARY)          \
-  template <>                                                                 \
-  struct SPMV_MV_BSRMATRIX<                                                   \
-      EXECSPACE, SCALAR const, MKL_INT const,                                 \
-      Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                           \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const, SCALAR const**, \
-      Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,       \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,         \
-      SCALAR**, Kokkos::LayoutLeft,                                           \
-      Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                           \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, true, true, COMPILE_LIBRARY> { \
-    using device_type = Kokkos::Device<EXECSPACE, Kokkos::HostSpace>;         \
-    using AMatrix =                                                           \
-        BsrMatrix<SCALAR const, MKL_INT const, device_type,                   \
-                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;    \
-    using XVector = Kokkos::View<                                             \
-        SCALAR const**, Kokkos::LayoutLeft, device_type,                      \
-        Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;      \
-    using YVector = Kokkos::View<SCALAR**, Kokkos::LayoutLeft, device_type,   \
-                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;    \
-    using coefficient_type = typename YVector::non_const_value_type;          \
-                                                                              \
-    static void spmv_mv_bsrmatrix(                                            \
-        const EXECSPACE& exec,                                                \
-        const KokkosKernels::Experimental::Controls& /*controls*/,            \
-        const char mode[], const coefficient_type& alpha, const AMatrix& A,   \
-        const XVector& X, const coefficient_type& beta, const YVector& Y) {   \
-      std::string label = "KokkosSparse::spmv[TPL_MKL,BSRMATRIX" +            \
-                          Kokkos::ArithTraits<SCALAR>::name() + "]";          \
-      Kokkos::Profiling::pushRegion(label);                                   \
-      MKL_INT colx = static_cast<MKL_INT>(X.extent(1));                       \
-      MKL_INT ldx  = static_cast<MKL_INT>(X.stride_1());                      \
-      MKL_INT ldy  = static_cast<MKL_INT>(Y.stride_1());                      \
-      spm_mv_block_impl_mkl(exec, mode_kk_to_mkl(mode[0]), alpha, beta,       \
-                            A.numRows(), A.numCols(), A.blockDim(),           \
-                            A.graph.row_map.data(), A.graph.entries.data(),   \
-                            A.values.data(), X.data(), colx, ldx, Y.data(),   \
-                            ldy);                                             \
-      Kokkos::Profiling::popRegion();                                         \
-    }                                                                         \
+#define KOKKOSSPARSE_SPMV_MV_MKL(SCALAR, EXECSPACE, COMPILE_LIBRARY)           \
+  template <>                                                                  \
+  struct SPMV_MV_BSRMATRIX<                                                    \
+      EXECSPACE, SCALAR const, MKL_INT const,                                  \
+      Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                            \
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const, SCALAR const**,  \
+      Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
+      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,          \
+      SCALAR**, Kokkos::LayoutLeft,                                            \
+      Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                            \
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>, true, true, COMPILE_LIBRARY> {  \
+    using device_type = Kokkos::Device<EXECSPACE, Kokkos::HostSpace>;          \
+    using AMatrix =                                                            \
+        BsrMatrix<SCALAR const, MKL_INT const, device_type,                    \
+                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;     \
+    using XVector = Kokkos::View<                                              \
+        SCALAR const**, Kokkos::LayoutLeft, device_type,                       \
+        Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;       \
+    using YVector = Kokkos::View<SCALAR**, Kokkos::LayoutLeft, device_type,    \
+                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;     \
+    using coefficient_type = typename YVector::non_const_value_type;           \
+                                                                               \
+    static void spmv_mv_bsrmatrix(                                             \
+        const EXECSPACE&,                                                      \
+        const KokkosKernels::Experimental::Controls& /*controls*/,             \
+        const char mode[], const coefficient_type& alpha, const AMatrix& A,    \
+        const XVector& X, const coefficient_type& beta, const YVector& Y) {    \
+      std::string label = "KokkosSparse::spmv[TPL_MKL,BSRMATRIX" +             \
+                          Kokkos::ArithTraits<SCALAR>::name() + "]";           \
+      Kokkos::Profiling::pushRegion(label);                                    \
+      MKL_INT colx = static_cast<MKL_INT>(X.extent(1));                        \
+      MKL_INT ldx  = static_cast<MKL_INT>(X.stride_1());                       \
+      MKL_INT ldy  = static_cast<MKL_INT>(Y.stride_1());                       \
+      spm_mv_block_impl_mkl(mode_kk_to_mkl(mode[0]), alpha, beta, A.numRows(), \
+                            A.numCols(), A.blockDim(), A.graph.row_map.data(), \
+                            A.graph.entries.data(), A.values.data(), X.data(), \
+                            colx, ldx, Y.data(), ldy);                         \
+      Kokkos::Profiling::popRegion();                                          \
+    }                                                                          \
   };
 
 #ifdef KOKKOS_ENABLE_SERIAL

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
@@ -203,9 +203,10 @@ inline void spm_mv_block_impl_mkl(
   template <>                                                                \
   struct SPMV_BSRMATRIX<                                                     \
       EXECSPACE,                                                             \
-      ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, MKL_INT const,                                 \
-                Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                \
-                Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>,     \
+      ::KokkosSparse::Experimental::BsrMatrix<                               \
+          SCALAR const, MKL_INT const,                                       \
+          Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                      \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>,           \
       Kokkos::View<                                                          \
           SCALAR const*, Kokkos::LayoutLeft,                                 \
           Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                      \
@@ -215,9 +216,9 @@ inline void spm_mv_block_impl_mkl(
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
       true, COMPILE_LIBRARY> {                                               \
     using device_type = Kokkos::Device<EXECSPACE, Kokkos::HostSpace>;        \
-    using AMatrix =                                                          \
-        ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, MKL_INT const, device_type,                  \
-                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;   \
+    using AMatrix     = ::KokkosSparse::Experimental::BsrMatrix<             \
+        SCALAR const, MKL_INT const, device_type,                        \
+        Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;         \
     using XVector = Kokkos::View<                                            \
         SCALAR const*, Kokkos::LayoutLeft, device_type,                      \
         Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;     \
@@ -267,9 +268,10 @@ KOKKOSSPARSE_SPMV_MKL(Kokkos::complex<double>, Kokkos::OpenMP,
   template <>                                                                  \
   struct SPMV_MV_BSRMATRIX<                                                    \
       EXECSPACE,                                                               \
-      ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, MKL_INT const,                                   \
-                Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                  \
-                Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>,       \
+      ::KokkosSparse::Experimental::BsrMatrix<                                 \
+          SCALAR const, MKL_INT const,                                         \
+          Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                        \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>,             \
       Kokkos::View<                                                            \
           SCALAR const**, Kokkos::LayoutLeft,                                  \
           Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                        \
@@ -279,9 +281,9 @@ KOKKOSSPARSE_SPMV_MKL(Kokkos::complex<double>, Kokkos::OpenMP,
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
       true, true, COMPILE_LIBRARY> {                                           \
     using device_type = Kokkos::Device<EXECSPACE, Kokkos::HostSpace>;          \
-    using AMatrix =                                                            \
-        ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, MKL_INT const, device_type,                    \
-                  Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;     \
+    using AMatrix     = ::KokkosSparse::Experimental::BsrMatrix<               \
+        SCALAR const, MKL_INT const, device_type,                          \
+        Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const>;           \
     using XVector = Kokkos::View<                                              \
         SCALAR const**, Kokkos::LayoutLeft, device_type,                       \
         Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;       \
@@ -571,45 +573,46 @@ void spm_mv_block_impl_cusparse(
 #endif  // (9000 <= CUDA_VERSION)
 }
 
-#define KOKKOSSPARSE_SPMV_CUSPARSE(SCALAR, ORDINAL, OFFSET, LAYOUT, SPACE,  \
-                                   COMPILE_LIBRARY)                         \
-  template <>                                                               \
-  struct SPMV_BSRMATRIX<                                                    \
-      Kokkos::Cuda,                                                         \
-      ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, ORDINAL const,                                \
-                Kokkos::Device<Kokkos::Cuda, SPACE>,                        \
-                Kokkos::MemoryTraits<Kokkos::Unmanaged>, OFFSET const>,     \
-      Kokkos::View<                                                         \
-          SCALAR const*, LAYOUT, Kokkos::Device<Kokkos::Cuda, SPACE>,       \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,  \
-      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Cuda, SPACE>,    \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                \
-      true, COMPILE_LIBRARY> {                                              \
-    using device_type       = Kokkos::Device<Kokkos::Cuda, SPACE>;          \
-    using memory_trait_type = Kokkos::MemoryTraits<Kokkos::Unmanaged>;      \
-    using AMatrix = ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, ORDINAL const, device_type,     \
-                              memory_trait_type, OFFSET const>;             \
-    using XVector = Kokkos::View<                                           \
-        SCALAR const*, LAYOUT, device_type,                                 \
-        Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;    \
-    using YVector =                                                         \
-        Kokkos::View<SCALAR*, LAYOUT, device_type, memory_trait_type>;      \
-    using Controls = KokkosKernels::Experimental::Controls;                 \
-                                                                            \
-    using coefficient_type = typename YVector::non_const_value_type;        \
-                                                                            \
-    static void spmv_bsrmatrix(const Kokkos::Cuda& exec,                    \
-                               const Controls& controls, const char mode[], \
-                               const coefficient_type& alpha,               \
-                               const AMatrix& A, const XVector& x,          \
-                               const coefficient_type& beta,                \
-                               const YVector& y) {                          \
-      std::string label = "KokkosSparse::spmv[TPL_CUSPARSE,BSRMATRIX" +     \
-                          Kokkos::ArithTraits<SCALAR>::name() + "]";        \
-      Kokkos::Profiling::pushRegion(label);                                 \
-      spmv_block_impl_cusparse(exec, controls, mode, alpha, A, x, beta, y); \
-      Kokkos::Profiling::popRegion();                                       \
-    }                                                                       \
+#define KOKKOSSPARSE_SPMV_CUSPARSE(SCALAR, ORDINAL, OFFSET, LAYOUT, SPACE,     \
+                                   COMPILE_LIBRARY)                            \
+  template <>                                                                  \
+  struct SPMV_BSRMATRIX<                                                       \
+      Kokkos::Cuda,                                                            \
+      ::KokkosSparse::Experimental::BsrMatrix<                                 \
+          SCALAR const, ORDINAL const, Kokkos::Device<Kokkos::Cuda, SPACE>,    \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, OFFSET const>,              \
+      Kokkos::View<                                                            \
+          SCALAR const*, LAYOUT, Kokkos::Device<Kokkos::Cuda, SPACE>,          \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Cuda, SPACE>,       \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
+      true, COMPILE_LIBRARY> {                                                 \
+    using device_type       = Kokkos::Device<Kokkos::Cuda, SPACE>;             \
+    using memory_trait_type = Kokkos::MemoryTraits<Kokkos::Unmanaged>;         \
+    using AMatrix           = ::KokkosSparse::Experimental::BsrMatrix<         \
+        SCALAR const, ORDINAL const, device_type, memory_trait_type, \
+        OFFSET const>;                                               \
+    using XVector = Kokkos::View<                                              \
+        SCALAR const*, LAYOUT, device_type,                                    \
+        Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;       \
+    using YVector =                                                            \
+        Kokkos::View<SCALAR*, LAYOUT, device_type, memory_trait_type>;         \
+    using Controls = KokkosKernels::Experimental::Controls;                    \
+                                                                               \
+    using coefficient_type = typename YVector::non_const_value_type;           \
+                                                                               \
+    static void spmv_bsrmatrix(const Kokkos::Cuda& exec,                       \
+                               const Controls& controls, const char mode[],    \
+                               const coefficient_type& alpha,                  \
+                               const AMatrix& A, const XVector& x,             \
+                               const coefficient_type& beta,                   \
+                               const YVector& y) {                             \
+      std::string label = "KokkosSparse::spmv[TPL_CUSPARSE,BSRMATRIX" +        \
+                          Kokkos::ArithTraits<SCALAR>::name() + "]";           \
+      Kokkos::Profiling::pushRegion(label);                                    \
+      spmv_block_impl_cusparse(exec, controls, mode, alpha, A, x, beta, y);    \
+      Kokkos::Profiling::popRegion();                                          \
+    }                                                                          \
   };
 
 #if (9000 <= CUDA_VERSION)
@@ -672,9 +675,9 @@ KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>, int, int,
   template <>                                                                  \
   struct SPMV_MV_BSRMATRIX<                                                    \
       Kokkos::Cuda,                                                            \
-      ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, ORDINAL const,                                   \
-                Kokkos::Device<Kokkos::Cuda, SPACE>,                           \
-                Kokkos::MemoryTraits<Kokkos::Unmanaged>, OFFSET const>,        \
+      ::KokkosSparse::Experimental::BsrMatrix<                                 \
+          SCALAR const, ORDINAL const, Kokkos::Device<Kokkos::Cuda, SPACE>,    \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, OFFSET const>,              \
       Kokkos::View<                                                            \
           SCALAR const**, Kokkos::LayoutLeft,                                  \
           Kokkos::Device<Kokkos::Cuda, SPACE>,                                 \
@@ -685,8 +688,9 @@ KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>, int, int,
       false, true, ETI_AVAIL> {                                                \
     using device_type       = Kokkos::Device<Kokkos::Cuda, SPACE>;             \
     using memory_trait_type = Kokkos::MemoryTraits<Kokkos::Unmanaged>;         \
-    using AMatrix = ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, ORDINAL const, device_type,        \
-                              memory_trait_type, OFFSET const>;                \
+    using AMatrix           = ::KokkosSparse::Experimental::BsrMatrix<         \
+        SCALAR const, ORDINAL const, device_type, memory_trait_type, \
+        OFFSET const>;                                               \
     using XVector = Kokkos::View<                                              \
         SCALAR const**, Kokkos::LayoutLeft, device_type,                       \
         Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;       \
@@ -928,45 +932,46 @@ void spmv_block_impl_rocsparse(
 
 }  // spmv_block_impl_rocsparse
 
-#define KOKKOSSPARSE_SPMV_ROCSPARSE(SCALAR, ORDINAL, OFFSET, LAYOUT, SPACE,  \
-                                    COMPILE_LIBRARY)                         \
-  template <>                                                                \
-  struct SPMV_BSRMATRIX<                                                     \
-      Kokkos::HIP,                                                           \
-      ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, ORDINAL const,                                 \
-                Kokkos::Device<Kokkos::HIP, SPACE>,                          \
-                Kokkos::MemoryTraits<Kokkos::Unmanaged>, OFFSET const>,      \
-      Kokkos::View<                                                          \
-          SCALAR const*, LAYOUT, Kokkos::Device<Kokkos::HIP, SPACE>,         \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,   \
-      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, SPACE>,      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
-      true, COMPILE_LIBRARY> {                                               \
-    using device_type       = Kokkos::Device<Kokkos::HIP, SPACE>;            \
-    using memory_trait_type = Kokkos::MemoryTraits<Kokkos::Unmanaged>;       \
-    using AMatrix = ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, ORDINAL const, device_type,      \
-                              memory_trait_type, OFFSET const>;              \
-    using XVector = Kokkos::View<                                            \
-        SCALAR const*, LAYOUT, device_type,                                  \
-        Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;     \
-    using YVector =                                                          \
-        Kokkos::View<SCALAR*, LAYOUT, device_type, memory_trait_type>;       \
-    using Controls = KokkosKernels::Experimental::Controls;                  \
-                                                                             \
-    using coefficient_type = typename YVector::non_const_value_type;         \
-                                                                             \
-    static void spmv_bsrmatrix(const Kokkos::HIP& exec,                      \
-                               const Controls& controls, const char mode[],  \
-                               const coefficient_type& alpha,                \
-                               const AMatrix& A, const XVector& x,           \
-                               const coefficient_type& beta,                 \
-                               const YVector& y) {                           \
-      std::string label = "KokkosSparse::spmv[TPL_ROCSPARSE,BSRMATRIX" +     \
-                          Kokkos::ArithTraits<SCALAR>::name() + "]";         \
-      Kokkos::Profiling::pushRegion(label);                                  \
-      spmv_block_impl_rocsparse(exec, controls, mode, alpha, A, x, beta, y); \
-      Kokkos::Profiling::popRegion();                                        \
-    }                                                                        \
+#define KOKKOSSPARSE_SPMV_ROCSPARSE(SCALAR, ORDINAL, OFFSET, LAYOUT, SPACE,    \
+                                    COMPILE_LIBRARY)                           \
+  template <>                                                                  \
+  struct SPMV_BSRMATRIX<                                                       \
+      Kokkos::HIP,                                                             \
+      ::KokkosSparse::Experimental::BsrMatrix<                                 \
+          SCALAR const, ORDINAL const, Kokkos::Device<Kokkos::HIP, SPACE>,     \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, OFFSET const>,              \
+      Kokkos::View<                                                            \
+          SCALAR const*, LAYOUT, Kokkos::Device<Kokkos::HIP, SPACE>,           \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, SPACE>,        \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
+      true, COMPILE_LIBRARY> {                                                 \
+    using device_type       = Kokkos::Device<Kokkos::HIP, SPACE>;              \
+    using memory_trait_type = Kokkos::MemoryTraits<Kokkos::Unmanaged>;         \
+    using AMatrix           = ::KokkosSparse::Experimental::BsrMatrix<         \
+        SCALAR const, ORDINAL const, device_type, memory_trait_type, \
+        OFFSET const>;                                               \
+    using XVector = Kokkos::View<                                              \
+        SCALAR const*, LAYOUT, device_type,                                    \
+        Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;       \
+    using YVector =                                                            \
+        Kokkos::View<SCALAR*, LAYOUT, device_type, memory_trait_type>;         \
+    using Controls = KokkosKernels::Experimental::Controls;                    \
+                                                                               \
+    using coefficient_type = typename YVector::non_const_value_type;           \
+                                                                               \
+    static void spmv_bsrmatrix(const Kokkos::HIP& exec,                        \
+                               const Controls& controls, const char mode[],    \
+                               const coefficient_type& alpha,                  \
+                               const AMatrix& A, const XVector& x,             \
+                               const coefficient_type& beta,                   \
+                               const YVector& y) {                             \
+      std::string label = "KokkosSparse::spmv[TPL_ROCSPARSE,BSRMATRIX" +       \
+                          Kokkos::ArithTraits<SCALAR>::name() + "]";           \
+      Kokkos::Profiling::pushRegion(label);                                    \
+      spmv_block_impl_rocsparse(exec, controls, mode, alpha, A, x, beta, y);   \
+      Kokkos::Profiling::popRegion();                                          \
+    }                                                                          \
   };
 
 KOKKOSSPARSE_SPMV_ROCSPARSE(float, rocsparse_int, rocsparse_int,

--- a/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_avail.hpp
@@ -21,8 +21,8 @@ namespace KokkosSparse {
 namespace Impl {
 
 // Specialization struct which defines whether a specialization exists
-template <class AT, class AO, class AD, class AM, class AS, class XT, class XL,
-          class XD, class XM, class YT, class YL, class YD, class YM,
+template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
+          class XL, class XD, class XM, class YT, class YL, class YD, class YM,
           const bool integerScalarType =
               std::is_integral<typename std::decay<AT>::type>::value>
 struct spmv_mv_tpl_spec_avail {
@@ -33,7 +33,8 @@ struct spmv_mv_tpl_spec_avail {
                                                      XL, YL, MEMSPACE)        \
   template <>                                                                 \
   struct spmv_mv_tpl_spec_avail<                                              \
-      const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,    \
+      Kokkos::Cuda, const SCALAR, const ORDINAL,                              \
+      Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                                 \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET, const SCALAR**,  \
       XL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                             \
       Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,         \

--- a/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_avail.hpp
@@ -21,26 +21,27 @@ namespace KokkosSparse {
 namespace Impl {
 
 // Specialization struct which defines whether a specialization exists
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM,
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector,
           const bool integerScalarType =
-              std::is_integral<typename std::decay<AT>::type>::value>
+              std::is_integral_v<typename AMatrix::non_const_value_type>>
 struct spmv_mv_tpl_spec_avail {
   enum : bool { value = false };
 };
 
-#define KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(SCALAR, ORDINAL, OFFSET, \
-                                                     XL, YL, MEMSPACE)        \
-  template <>                                                                 \
-  struct spmv_mv_tpl_spec_avail<                                              \
-      Kokkos::Cuda, const SCALAR, const ORDINAL,                              \
-      Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                                 \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET, const SCALAR**,  \
-      XL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                             \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,         \
-      SCALAR**, YL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                   \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> > {                             \
-    enum : bool { value = true };                                             \
+#define KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(SCALAR, ORDINAL, OFFSET,  \
+                                                     XL, YL, MEMSPACE)         \
+  template <>                                                                  \
+  struct spmv_mv_tpl_spec_avail<                                               \
+      Kokkos::Cuda,                                                            \
+      KokkosSparse::CrsMatrix<                                                 \
+          const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET>,              \
+      Kokkos::View<                                                            \
+          const SCALAR**, XL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,          \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR**, YL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,       \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                 \
+    enum : bool { value = true };                                              \
   };
 
 /* CUSPARSE_VERSION 10300 and lower seem to have a bug in cusparseSpMM

--- a/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
@@ -198,7 +198,8 @@ void spmv_mv_cusparse(const Kokkos::Cuda &exec,
                                       COMPILE_LIBRARY)                         \
   template <>                                                                  \
   struct SPMV_MV<                                                              \
-      SCALAR const, ORDINAL const, Kokkos::Device<Kokkos::Cuda, SPACE>,        \
+      Kokkos::Cuda, SCALAR const, ORDINAL const,                               \
+      Kokkos::Device<Kokkos::Cuda, SPACE>,                                     \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, OFFSET const, SCALAR const **,  \
       XL, Kokkos::Device<Kokkos::Cuda, SPACE>,                                 \
       Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,          \

--- a/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
@@ -194,40 +194,43 @@ void spmv_mv_cusparse(const Kokkos::Cuda &exec,
   KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroySpMat(A_cusparse));
 }
 
-#define KOKKOSSPARSE_SPMV_MV_CUSPARSE(SCALAR, ORDINAL, OFFSET, XL, YL, SPACE,  \
-                                      COMPILE_LIBRARY)                         \
-  template <>                                                                  \
-  struct SPMV_MV<                                                              \
-      Kokkos::Cuda, SCALAR const, ORDINAL const,                               \
-      Kokkos::Device<Kokkos::Cuda, SPACE>,                                     \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, OFFSET const, SCALAR const **,  \
-      XL, Kokkos::Device<Kokkos::Cuda, SPACE>,                                 \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>,          \
-      SCALAR **, YL, Kokkos::Device<Kokkos::Cuda, SPACE>,                      \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, false, true, COMPILE_LIBRARY> { \
-    using device_type       = Kokkos::Device<Kokkos::Cuda, SPACE>;             \
-    using memory_trait_type = Kokkos::MemoryTraits<Kokkos::Unmanaged>;         \
-    using AMatrix = CrsMatrix<SCALAR const, ORDINAL const, device_type,        \
-                              memory_trait_type, OFFSET const>;                \
-    using XVector = Kokkos::View<                                              \
-        SCALAR const **, XL, device_type,                                      \
-        Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;       \
-    using YVector =                                                            \
-        Kokkos::View<SCALAR **, YL, device_type, memory_trait_type>;           \
-                                                                               \
-    using coefficient_type = typename YVector::non_const_value_type;           \
-                                                                               \
-    using Controls = KokkosKernels::Experimental::Controls;                    \
-    static void spmv_mv(const Kokkos::Cuda &exec, const Controls &controls,    \
-                        const char mode[], const coefficient_type &alpha,      \
-                        const AMatrix &A, const XVector &x,                    \
-                        const coefficient_type &beta, const YVector &y) {      \
-      std::string label = "KokkosSparse::spmv[TPL_CUSPARSE," +                 \
-                          Kokkos::ArithTraits<SCALAR>::name() + "]";           \
-      Kokkos::Profiling::pushRegion(label);                                    \
-      spmv_mv_cusparse(exec, controls, mode, alpha, A, x, beta, y);            \
-      Kokkos::Profiling::popRegion();                                          \
-    }                                                                          \
+#define KOKKOSSPARSE_SPMV_MV_CUSPARSE(SCALAR, ORDINAL, OFFSET, XL, YL, SPACE, \
+                                      COMPILE_LIBRARY)                        \
+  template <>                                                                 \
+  struct SPMV_MV<                                                             \
+      Kokkos::Cuda,                                                           \
+      KokkosSparse::CrsMatrix<                                                \
+          SCALAR const, ORDINAL const, Kokkos::Device<Kokkos::Cuda, SPACE>,   \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, OFFSET const>,             \
+      Kokkos::View<                                                           \
+          SCALAR const **, XL, Kokkos::Device<Kokkos::Cuda, SPACE>,           \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,    \
+      Kokkos::View<SCALAR **, YL, Kokkos::Device<Kokkos::Cuda, SPACE>,        \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
+      false, true, COMPILE_LIBRARY> {                                         \
+    using device_type       = Kokkos::Device<Kokkos::Cuda, SPACE>;            \
+    using memory_trait_type = Kokkos::MemoryTraits<Kokkos::Unmanaged>;        \
+    using AMatrix = CrsMatrix<SCALAR const, ORDINAL const, device_type,       \
+                              memory_trait_type, OFFSET const>;               \
+    using XVector = Kokkos::View<                                             \
+        SCALAR const **, XL, device_type,                                     \
+        Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;      \
+    using YVector =                                                           \
+        Kokkos::View<SCALAR **, YL, device_type, memory_trait_type>;          \
+                                                                              \
+    using coefficient_type = typename YVector::non_const_value_type;          \
+                                                                              \
+    using Controls = KokkosKernels::Experimental::Controls;                   \
+    static void spmv_mv(const Kokkos::Cuda &exec, const Controls &controls,   \
+                        const char mode[], const coefficient_type &alpha,     \
+                        const AMatrix &A, const XVector &x,                   \
+                        const coefficient_type &beta, const YVector &y) {     \
+      std::string label = "KokkosSparse::spmv[TPL_CUSPARSE," +                \
+                          Kokkos::ArithTraits<SCALAR>::name() + "]";          \
+      Kokkos::Profiling::pushRegion(label);                                   \
+      spmv_mv_cusparse(exec, controls, mode, alpha, A, x, beta, y);           \
+      Kokkos::Profiling::popRegion();                                         \
+    }                                                                         \
   };
 
 /* cusparseSpMM with following restrictions

--- a/sparse/tpls/KokkosSparse_spmv_struct_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_struct_tpl_spec_avail.hpp
@@ -20,15 +20,15 @@
 namespace KokkosSparse {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class AT, class AO, class AD, class AM, class AS, class XT, class XL,
-          class XD, class XM, class YT, class YL, class YD, class YM>
+template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
+          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
 struct spmv_struct_tpl_spec_avail {
   enum : bool { value = false };
 };
 
 // Specialization struct which defines whether a specialization exists
-template <class AT, class AO, class AD, class AM, class AS, class XT, class XL,
-          class XD, class XM, class YT, class YL, class YD, class YM>
+template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
+          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
 struct spmv_mv_struct_tpl_spec_avail {
   enum : bool { value = false };
 };

--- a/sparse/tpls/KokkosSparse_spmv_struct_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_struct_tpl_spec_avail.hpp
@@ -20,15 +20,13 @@
 namespace KokkosSparse {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector>
 struct spmv_struct_tpl_spec_avail {
   enum : bool { value = false };
 };
 
 // Specialization struct which defines whether a specialization exists
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector>
 struct spmv_mv_struct_tpl_spec_avail {
   enum : bool { value = false };
 };

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
@@ -24,8 +24,8 @@
 namespace KokkosSparse {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class AT, class AO, class AD, class AM, class AS, class XT, class XL,
-          class XD, class XM, class YT, class YL, class YD, class YM>
+template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
+          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
 struct spmv_tpl_spec_avail {
   enum : bool { value = false };
 };
@@ -40,7 +40,8 @@ struct spmv_tpl_spec_avail {
                                                   YL, MEMSPACE)                \
   template <>                                                                  \
   struct spmv_tpl_spec_avail<                                                  \
-      const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,     \
+      Kokkos::Cuda, const SCALAR, const ORDINAL,                               \
+      Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                                  \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET, const SCALAR*,    \
       XL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                              \
       Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
@@ -184,7 +185,7 @@ KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int64_t,
 #define KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ROCSPARSE(SCALAR, LAYOUT)             \
   template <>                                                                  \
   struct spmv_tpl_spec_avail<                                                  \
-      const SCALAR, const rocsparse_int,                                       \
+      Kokkos::HIP, const SCALAR, const rocsparse_int,                          \
       Kokkos::Device<Kokkos::Experimental::HIP,                                \
                      Kokkos::Experimental::HIPSpace>,                          \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, const rocsparse_int,            \
@@ -218,7 +219,7 @@ KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ROCSPARSE(Kokkos::complex<float>,
 #define KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_MKL(SCALAR, EXECSPACE)                \
   template <>                                                                  \
   struct spmv_tpl_spec_avail<                                                  \
-      const SCALAR, const MKL_INT,                                             \
+      EXECSPACE, const SCALAR, const MKL_INT,                                  \
       Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                            \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT, const SCALAR*,   \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
@@ -246,7 +247,7 @@ KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_MKL(Kokkos::complex<double>, Kokkos::OpenMP)
 #define KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ONEMKL(SCALAR, ORDINAL, MEMSPACE)     \
   template <>                                                                  \
   struct spmv_tpl_spec_avail<                                                  \
-      const SCALAR, const ORDINAL,                                             \
+      Kokkos::Experimental::SYCL, const SCALAR, const ORDINAL,                 \
       Kokkos::Device<Kokkos::Experimental::SYCL, MEMSPACE>,                    \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, const ORDINAL, const SCALAR*,   \
       Kokkos::LayoutLeft,                                                      \

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
@@ -24,8 +24,7 @@
 namespace KokkosSparse {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
-template <class ES, class AT, class AO, class AD, class AM, class AS, class XT,
-          class XL, class XD, class XM, class YT, class YL, class YD, class YM>
+template <class ExecutionSpace, class AMatrix, class XVector, class YVector>
 struct spmv_tpl_spec_avail {
   enum : bool { value = false };
 };
@@ -40,13 +39,15 @@ struct spmv_tpl_spec_avail {
                                                   YL, MEMSPACE)                \
   template <>                                                                  \
   struct spmv_tpl_spec_avail<                                                  \
-      Kokkos::Cuda, const SCALAR, const ORDINAL,                               \
-      Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                                  \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET, const SCALAR*,    \
-      XL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                              \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
-      YL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                              \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> > {                              \
+      Kokkos::Cuda,                                                            \
+      KokkosSparse::CrsMatrix<                                                 \
+          const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET>,              \
+      Kokkos::View<                                                            \
+          const SCALAR*, XL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,           \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,     \
+      Kokkos::View<SCALAR*, YL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,        \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                 \
     enum : bool { value = true };                                              \
   };
 
@@ -182,22 +183,25 @@ KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int64_t,
 
 #if defined(KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE)
 
-#define KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ROCSPARSE(SCALAR, LAYOUT)             \
-  template <>                                                                  \
-  struct spmv_tpl_spec_avail<                                                  \
-      Kokkos::HIP, const SCALAR, const rocsparse_int,                          \
-      Kokkos::Device<Kokkos::Experimental::HIP,                                \
-                     Kokkos::Experimental::HIPSpace>,                          \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const rocsparse_int,            \
-      const SCALAR*, LAYOUT,                                                   \
-      Kokkos::Device<Kokkos::Experimental::HIP,                                \
-                     Kokkos::Experimental::HIPSpace>,                          \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
-      LAYOUT,                                                                  \
-      Kokkos::Device<Kokkos::Experimental::HIP,                                \
-                     Kokkos::Experimental::HIPSpace>,                          \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> > {                              \
-    enum : bool { value = true };                                              \
+#define KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ROCSPARSE(SCALAR, LAYOUT)            \
+  template <>                                                                 \
+  struct spmv_tpl_spec_avail<                                                 \
+      Kokkos::HIP,                                                            \
+      KokkosSparse::CrsMatrix<const SCALAR, const rocsparse_int,              \
+                              Kokkos::Device<Kokkos::Experimental::HIP,       \
+                                             Kokkos::Experimental::HIPSpace>, \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,        \
+                              const rocsparse_int>,                           \
+      Kokkos::View<                                                           \
+          const SCALAR*, LAYOUT,                                              \
+          Kokkos::Device<Kokkos::Experimental::HIP,                           \
+                         Kokkos::Experimental::HIPSpace>,                     \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,    \
+      Kokkos::View<SCALAR*, LAYOUT,                                           \
+                   Kokkos::Device<Kokkos::Experimental::HIP,                  \
+                                  Kokkos::Experimental::HIPSpace>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                \
+    enum : bool { value = true };                                             \
   };
 
 KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ROCSPARSE(double, Kokkos::LayoutLeft)
@@ -216,17 +220,22 @@ KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ROCSPARSE(Kokkos::complex<float>,
 #endif  // KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
-#define KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_MKL(SCALAR, EXECSPACE)                \
-  template <>                                                                  \
-  struct spmv_tpl_spec_avail<                                                  \
-      EXECSPACE, const SCALAR, const MKL_INT,                                  \
-      Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                            \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT, const SCALAR*,   \
-      Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
-      Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> > {                              \
-    enum : bool { value = true };                                              \
+#define KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_MKL(SCALAR, EXECSPACE)             \
+  template <>                                                               \
+  struct spmv_tpl_spec_avail<                                               \
+      EXECSPACE,                                                            \
+      KokkosSparse::CrsMatrix<const SCALAR, const MKL_INT,                  \
+                              Kokkos::Device<EXECSPACE, Kokkos::HostSpace>, \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,      \
+                              const MKL_INT>,                               \
+      Kokkos::View<                                                         \
+          const SCALAR*, Kokkos::LayoutLeft,                                \
+          Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                     \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,  \
+      Kokkos::View<SCALAR*, Kokkos::LayoutLeft,                             \
+                   Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {              \
+    enum : bool { value = true };                                           \
   };
 
 #ifdef KOKKOS_ENABLE_SERIAL
@@ -244,19 +253,22 @@ KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_MKL(Kokkos::complex<double>, Kokkos::OpenMP)
 #endif
 
 #ifdef KOKKOS_ENABLE_SYCL
-#define KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ONEMKL(SCALAR, ORDINAL, MEMSPACE)     \
-  template <>                                                                  \
-  struct spmv_tpl_spec_avail<                                                  \
-      Kokkos::Experimental::SYCL, const SCALAR, const ORDINAL,                 \
-      Kokkos::Device<Kokkos::Experimental::SYCL, MEMSPACE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, const ORDINAL, const SCALAR*,   \
-      Kokkos::LayoutLeft,                                                      \
-      Kokkos::Device<Kokkos::Experimental::SYCL, MEMSPACE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
-      Kokkos::LayoutLeft,                                                      \
-      Kokkos::Device<Kokkos::Experimental::SYCL, MEMSPACE>,                    \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged> > {                              \
-    enum : bool { value = true };                                              \
+#define KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ONEMKL(SCALAR, ORDINAL, MEMSPACE) \
+  template <>                                                              \
+  struct spmv_tpl_spec_avail<                                              \
+      Kokkos::Experimental::SYCL,                                          \
+      KokkosSparse::CrsMatrix<                                             \
+          const SCALAR, const ORDINAL,                                     \
+          Kokkos::Device<Kokkos::Experimental::SYCL, MEMSPACE>,            \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>, const ORDINAL>,         \
+      Kokkos::View<                                                        \
+          const SCALAR*, Kokkos::LayoutLeft,                               \
+          Kokkos::Device<Kokkos::Experimental::SYCL, MEMSPACE>,            \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>, \
+      Kokkos::View<SCALAR*, Kokkos::LayoutLeft,                            \
+                   Kokkos::Device<Kokkos::Experimental::SYCL, MEMSPACE>,   \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {             \
+    enum : bool { value = true };                                          \
   };
 
 KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ONEMKL(

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -201,39 +201,40 @@ void spmv_cusparse(const Kokkos::Cuda& exec,
 #endif  // CUDA_VERSION
 }
 
-#define KOKKOSSPARSE_SPMV_CUSPARSE(SCALAR, ORDINAL, OFFSET, LAYOUT, SPACE,     \
-                                   COMPILE_LIBRARY)                            \
-  template <>                                                                  \
-  struct SPMV<                                                                 \
-      SCALAR const, ORDINAL const, Kokkos::Device<Kokkos::Cuda, SPACE>,        \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, OFFSET const, SCALAR const*,    \
-      LAYOUT, Kokkos::Device<Kokkos::Cuda, SPACE>,                             \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, SCALAR*, \
-      LAYOUT, Kokkos::Device<Kokkos::Cuda, SPACE>,                             \
-      Kokkos::MemoryTraits<Kokkos::Unmanaged>, true, COMPILE_LIBRARY> {        \
-    using device_type       = Kokkos::Device<Kokkos::Cuda, SPACE>;             \
-    using memory_trait_type = Kokkos::MemoryTraits<Kokkos::Unmanaged>;         \
-    using AMatrix = CrsMatrix<SCALAR const, ORDINAL const, device_type,        \
-                              memory_trait_type, OFFSET const>;                \
-    using XVector = Kokkos::View<                                              \
-        SCALAR const*, LAYOUT, device_type,                                    \
-        Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;       \
-    using YVector =                                                            \
-        Kokkos::View<SCALAR*, LAYOUT, device_type, memory_trait_type>;         \
-    using Controls = KokkosKernels::Experimental::Controls;                    \
-                                                                               \
-    using coefficient_type = typename YVector::non_const_value_type;           \
-                                                                               \
-    static void spmv(const Kokkos::Cuda& exec, const Controls& controls,       \
-                     const char mode[], const coefficient_type& alpha,         \
-                     const AMatrix& A, const XVector& x,                       \
-                     const coefficient_type& beta, const YVector& y) {         \
-      std::string label = "KokkosSparse::spmv[TPL_CUSPARSE," +                 \
-                          Kokkos::ArithTraits<SCALAR>::name() + "]";           \
-      Kokkos::Profiling::pushRegion(label);                                    \
-      spmv_cusparse(exec, controls, mode, alpha, A, x, beta, y);               \
-      Kokkos::Profiling::popRegion();                                          \
-    }                                                                          \
+#define KOKKOSSPARSE_SPMV_CUSPARSE(SCALAR, ORDINAL, OFFSET, LAYOUT, SPACE,    \
+                                   COMPILE_LIBRARY)                           \
+  template <>                                                                 \
+  struct SPMV<Kokkos::Cuda, SCALAR const, ORDINAL const,                      \
+              Kokkos::Device<Kokkos::Cuda, SPACE>,                            \
+              Kokkos::MemoryTraits<Kokkos::Unmanaged>, OFFSET const,          \
+              SCALAR const*, LAYOUT, Kokkos::Device<Kokkos::Cuda, SPACE>,     \
+              Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, \
+              SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Cuda, SPACE>,           \
+              Kokkos::MemoryTraits<Kokkos::Unmanaged>, true,                  \
+              COMPILE_LIBRARY> {                                              \
+    using device_type       = Kokkos::Device<Kokkos::Cuda, SPACE>;            \
+    using memory_trait_type = Kokkos::MemoryTraits<Kokkos::Unmanaged>;        \
+    using AMatrix = CrsMatrix<SCALAR const, ORDINAL const, device_type,       \
+                              memory_trait_type, OFFSET const>;               \
+    using XVector = Kokkos::View<                                             \
+        SCALAR const*, LAYOUT, device_type,                                   \
+        Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;      \
+    using YVector =                                                           \
+        Kokkos::View<SCALAR*, LAYOUT, device_type, memory_trait_type>;        \
+    using Controls = KokkosKernels::Experimental::Controls;                   \
+                                                                              \
+    using coefficient_type = typename YVector::non_const_value_type;          \
+                                                                              \
+    static void spmv(const Kokkos::Cuda& exec, const Controls& controls,      \
+                     const char mode[], const coefficient_type& alpha,        \
+                     const AMatrix& A, const XVector& x,                      \
+                     const coefficient_type& beta, const YVector& y) {        \
+      std::string label = "KokkosSparse::spmv[TPL_CUSPARSE," +                \
+                          Kokkos::ArithTraits<SCALAR>::name() + "]";          \
+      Kokkos::Profiling::pushRegion(label);                                   \
+      spmv_cusparse(exec, controls, mode, alpha, A, x, beta, y);              \
+      Kokkos::Profiling::popRegion();                                         \
+    }                                                                         \
   };
 
 // BMK: cuSPARSE that comes with CUDA 9 does not support tranpose or conjugate
@@ -462,7 +463,7 @@ void spmv_rocsparse(const Kokkos::HIP& exec,
 #define KOKKOSSPARSE_SPMV_ROCSPARSE(SCALAR, LAYOUT, COMPILE_LIBRARY)           \
   template <>                                                                  \
   struct SPMV<                                                                 \
-      SCALAR const, rocsparse_int const,                                       \
+      Kokkos::HIP, SCALAR const, rocsparse_int const,                          \
       Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,                           \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, rocsparse_int const,            \
       SCALAR const*, LAYOUT, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,    \
@@ -608,7 +609,7 @@ inline void spmv_mkl(sparse_operation_t op, Kokkos::complex<double> alpha,
 #define KOKKOSSPARSE_SPMV_MKL(SCALAR, EXECSPACE, COMPILE_LIBRARY)              \
   template <>                                                                  \
   struct SPMV<                                                                 \
-      SCALAR const, MKL_INT const,                                             \
+      EXECSPACE, SCALAR const, MKL_INT const,                                  \
       Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                            \
       Kokkos::MemoryTraits<Kokkos::Unmanaged>, MKL_INT const, SCALAR const*,   \
       Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,        \
@@ -627,15 +628,15 @@ inline void spmv_mkl(sparse_operation_t op, Kokkos::complex<double> alpha,
     using coefficient_type = typename YVector::non_const_value_type;           \
     using Controls         = KokkosKernels::Experimental::Controls;            \
                                                                                \
-    static void spmv(const Controls&, const char mode[],                       \
-                     const coefficient_type& alpha, const AMatrix& A,          \
-                     const XVector& x, const coefficient_type& beta,           \
-                     const YVector& y) {                                       \
+    static void spmv(const EXECSPACE& exec, const Controls&,                   \
+                     const char mode[], const coefficient_type& alpha,         \
+                     const AMatrix& A, const XVector& x,                       \
+                     const coefficient_type& beta, const YVector& y) {         \
       std::string label = "KokkosSparse::spmv[TPL_MKL," +                      \
                           Kokkos::ArithTraits<SCALAR>::name() + "]";           \
       Kokkos::Profiling::pushRegion(label);                                    \
-      spmv_mkl(mode_kk_to_mkl(mode[0]), alpha, beta, A.numRows(), A.numCols(), \
-               A.graph.row_map.data(), A.graph.entries.data(),                 \
+      spmv_mkl(exec, mode_kk_to_mkl(mode[0]), alpha, beta, A.numRows(),        \
+               A.numCols(), A.graph.row_map.data(), A.graph.entries.data(),    \
                A.values.data(), x.data(), y.data());                           \
       Kokkos::Profiling::popRegion();                                          \
     }                                                                          \
@@ -753,7 +754,7 @@ struct spmv_onemkl_wrapper<true> {
 
 #define KOKKOSSPARSE_SPMV_ONEMKL(SCALAR, ORDINAL, MEMSPACE, COMPILE_LIBRARY)  \
   template <>                                                                 \
-  struct SPMV<SCALAR const, ORDINAL const,                                    \
+  struct SPMV<SCALAR const, ORDINAL const, Kokkos::Experimental::SYCL,        \
               Kokkos::Device<Kokkos::Experimental::SYCL, MEMSPACE>,           \
               Kokkos::MemoryTraits<Kokkos::Unmanaged>, ORDINAL const,         \
               SCALAR const*, Kokkos::LayoutLeft,                              \

--- a/sparse/unit_test/Test_Sparse_replaceSumIntoLonger.hpp
+++ b/sparse/unit_test/Test_Sparse_replaceSumIntoLonger.hpp
@@ -490,9 +490,7 @@ void test_replaceSumIntoLonger() {
 
 // FIXME SYCL: test hangs or gives "CL error -46 invalid kernel name"
 #ifndef KOKKOS_ENABLE_SYCL
-
 #include <Test_Common_Test_All_Type_Combos.hpp>
+#endif  // KOKKOS_ENABLE_SYCL
 
 #undef KOKKOSKERNELS_EXECUTE_TEST
-
-#endif  // KOKKOS_ENABLE_SYCL

--- a/sparse/unit_test/Test_Sparse_spmv.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv.hpp
@@ -1181,11 +1181,12 @@ void test_spmv_all_interfaces_light() {
     EXPECT_EQ(num_errors, 0);
   };
   // Now run through the interfaces and check results each time.
-  auto space_partitions =
-      Kokkos::Experimental::partition_space(execution_space(), 1, 1);
-  // For versions taking an exec space instance, use the second partition out of
-  // 2 (since the first partition might just be the default instance)
-  execution_space space = space_partitions[1];
+  execution_space space;
+  std::vector<execution_space> space_partitions;
+  if (space.concurrency() > 1) {
+    space_partitions = Kokkos::Experimental::partition_space(space, 1, 1);
+    space            = space_partitions[1];
+  }
   KokkosKernels::Experimental::Controls controls;
   // All tagged versions
   KokkosSparse::spmv(space, controls, "N", 1.0, A, x, 0.0, y,

--- a/sparse/unit_test/Test_Sparse_spmv.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv.hpp
@@ -90,8 +90,21 @@ struct fSPMV {
     if (error > eps * max_val) {
       err++;
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-          "expected_y(%d)=%f, y(%d)=%f err=%f, max_error=%f\n", i,
+          "expected_y(%d)=%f, y(%d)=%f err=%e, max_error=%e\n", i,
           AT::abs(expected_y(i)), i, AT::abs(y(i)), error, eps * max_val);
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int i, const int j, value_type &err) const {
+    const mag_type error = AT::abs(expected_y(i, j) - y(i, j));
+
+    if (error > eps * max_val) {
+      err++;
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+          "expected_y(%d,%d)=%f, y(%d,%d)=%f err=%e, max_error=%e\n", i, j,
+          AT::abs(expected_y(i, j)), i, j, AT::abs(y(i, j)), error,
+          eps * max_val);
     }
   }
 };
@@ -1112,6 +1125,112 @@ void test_github_issue_101() {
   }
 }
 
+template <class scalar_t, class lno_t, class size_type, class layout_t,
+          class DeviceType>
+void test_spmv_all_interfaces_light() {
+  // Using a small matrix, run through the various SpMV interfaces and
+  // make sure they produce the correct results.
+  using execution_space = typename DeviceType::execution_space;
+  using mag_t           = typename Kokkos::ArithTraits<scalar_t>::mag_type;
+  using crsMat_t = typename KokkosSparse::CrsMatrix<scalar_t, lno_t, DeviceType,
+                                                    void, size_type>;
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
+  const lno_t m      = 111;
+  const lno_t n      = 99;
+  const mag_t maxVal = 10.0;
+  const mag_t eps    = 10.0 * Kokkos::ArithTraits<mag_t>::eps();
+  size_type nnz      = 600;
+  crsMat_t A         = KokkosSparse::Impl::kk_generate_sparse_matrix<crsMat_t>(
+      m, n, nnz, 2, lno_t(n * 0.7));
+  // note: A's values are in range [0, 50)
+  const mag_t maxError = (nnz / m) * 50.0 * maxVal;
+  using multivector_t  = Kokkos::View<scalar_t **, layout_t, DeviceType>;
+  using vector_t       = Kokkos::View<scalar_t *, layout_t, DeviceType>;
+  using range1D_t      = Kokkos::RangePolicy<execution_space>;
+  using range2D_t = Kokkos::MDRangePolicy<execution_space, Kokkos::Rank<2>>;
+  multivector_t x_mv("x_mv", n, 3);
+  vector_t x("x", n);
+  // Randomize x (it won't be modified after that)
+  Kokkos::fill_random(x_mv, rand_pool, randomUpperBound<scalar_t>(maxVal));
+  Kokkos::fill_random(x, rand_pool, randomUpperBound<scalar_t>(maxVal));
+  multivector_t y_mv("y_mv", m, 3);
+  vector_t y("y", m);
+  // Compute the correct y = Ax once
+  multivector_t ygold_mv("ygold_mv", m, 3);
+  vector_t ygold("ygold", m);
+  for (lno_t i = 0; i < 3; i++)
+    Test::sequential_spmv(A, Kokkos::subview(x_mv, Kokkos::ALL(), i),
+                          Kokkos::subview(ygold_mv, Kokkos::ALL(), i), 1.0,
+                          0.0);
+  Test::sequential_spmv(A, x, ygold, 1.0, 0.0);
+  auto clear_y = [&]() { Kokkos::deep_copy(y_mv, scalar_t(0)); };
+  auto verify  = [&]() {
+    int num_errors = 0;
+    Kokkos::parallel_reduce(
+        "KokkosSparse::Test::spmv", range1D_t(0, m),
+        Test::fSPMV<vector_t, vector_t>(ygold, y, eps, maxError), num_errors);
+    EXPECT_EQ(num_errors, 0);
+  };
+  auto verify_mv = [&]() {
+    int num_errors = 0;
+    Kokkos::parallel_reduce("KokkosSparse::Test::spmv",
+                            range2D_t({0, 0}, {m, 3}),
+                            Test::fSPMV<multivector_t, multivector_t>(
+                                ygold_mv, y_mv, eps, maxError),
+                            num_errors);
+    EXPECT_EQ(num_errors, 0);
+  };
+  // Now run through the interfaces and check results each time
+  execution_space exec;
+  KokkosKernels::Experimental::Controls controls;
+  // All tagged versions
+  KokkosSparse::spmv(exec, controls, "N", 1.0, A, x, 0.0, y,
+                     KokkosSparse::RANK_ONE());
+  verify();
+  clear_y();
+  KokkosSparse::spmv(controls, "N", 1.0, A, x, 0.0, y,
+                     KokkosSparse::RANK_ONE());
+  verify();
+  clear_y();
+  KokkosSparse::spmv(exec, controls, "N", 1.0, A, x_mv, 0.0, y_mv,
+                     KokkosSparse::RANK_TWO());
+  verify_mv();
+  clear_y();
+  KokkosSparse::spmv(controls, "N", 1.0, A, x_mv, 0.0, y_mv,
+                     KokkosSparse::RANK_TWO());
+  verify_mv();
+  clear_y();
+  // Non-tagged versions
+  // exec and controls
+  spmv(exec, controls, "N", 1.0, A, x, 0.0, y);
+  verify();
+  clear_y();
+  spmv(exec, controls, "N", 1.0, A, x_mv, 0.0, y_mv);
+  verify_mv();
+  clear_y();
+  // controls
+  spmv(controls, "N", 1.0, A, x, 0.0, y);
+  verify();
+  clear_y();
+  spmv(controls, "N", 1.0, A, x_mv, 0.0, y_mv);
+  verify_mv();
+  clear_y();
+  // exec
+  spmv(exec, "N", 1.0, A, x, 0.0, y);
+  verify();
+  clear_y();
+  spmv(exec, "N", 1.0, A, x_mv, 0.0, y_mv);
+  verify_mv();
+  clear_y();
+  // neither
+  spmv("N", 1.0, A, x, 0.0, y);
+  verify();
+  clear_y();
+  spmv("N", 1.0, A, x_mv, 0.0, y_mv);
+  verify_mv();
+  clear_y();
+}
+
 #define EXECUTE_TEST_ISSUE_101(DEVICE)                                    \
   TEST_F(TestCategory, sparse##_##spmv_issue_101##_##OFFSET##_##DEVICE) { \
     test_github_issue_101<DEVICE>();                                      \
@@ -1134,6 +1253,14 @@ void test_github_issue_101() {
                                                           100, 5, false);      \
     test_spmv_controls<SCALAR, ORDINAL, OFFSET, DEVICE>(10000, 10000 * 20,     \
                                                         100, 5);               \
+  }
+
+#define EXECUTE_TEST_INTERFACES(SCALAR, ORDINAL, OFFSET, LAYOUT, DEVICE)              \
+  TEST_F(                                                                             \
+      TestCategory,                                                                   \
+      sparse_spmv_interfaces_##SCALAR##_##ORDINAL##_##OFFSET##_##LAYOUT##_##DEVICE) { \
+    test_spmv_all_interfaces_light<SCALAR, ORDINAL, OFFSET, Kokkos::LAYOUT,           \
+                                   DEVICE>();                                         \
   }
 
 #define EXECUTE_TEST_MV(SCALAR, ORDINAL, OFFSET, LAYOUT, DEVICE)                    \
@@ -1198,9 +1325,10 @@ EXECUTE_TEST_ISSUE_101(TestExecSpace)
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&      \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 
-#define KOKKOSKERNELS_EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE)   \
-  EXECUTE_TEST_MV(SCALAR, ORDINAL, OFFSET, LayoutLeft, TestExecSpace) \
-  EXECUTE_TEST_MV_STRUCT(SCALAR, ORDINAL, OFFSET, LayoutLeft, TestExecSpace)
+#define KOKKOSKERNELS_EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE)          \
+  EXECUTE_TEST_MV(SCALAR, ORDINAL, OFFSET, LayoutLeft, TestExecSpace)        \
+  EXECUTE_TEST_MV_STRUCT(SCALAR, ORDINAL, OFFSET, LayoutLeft, TestExecSpace) \
+  EXECUTE_TEST_INTERFACES(SCALAR, ORDINAL, OFFSET, LayoutLeft, TestExecSpace)
 
 #include <Test_Common_Test_All_Type_Combos.hpp>
 
@@ -1212,8 +1340,9 @@ EXECUTE_TEST_ISSUE_101(TestExecSpace)
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&       \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 
-#define KOKKOSKERNELS_EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE) \
-  EXECUTE_TEST_MV(SCALAR, ORDINAL, OFFSET, LayoutRight, TestExecSpace)
+#define KOKKOSKERNELS_EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE)    \
+  EXECUTE_TEST_MV(SCALAR, ORDINAL, OFFSET, LayoutRight, TestExecSpace) \
+  EXECUTE_TEST_INTERFACES(SCALAR, ORDINAL, OFFSET, LayoutRight, TestExecSpace)
 
 #include <Test_Common_Test_All_Type_Combos.hpp>
 

--- a/sparse/unit_test/Test_Sparse_spmv.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv.hpp
@@ -1180,20 +1180,26 @@ void test_spmv_all_interfaces_light() {
                             num_errors);
     EXPECT_EQ(num_errors, 0);
   };
-  // Now run through the interfaces and check results each time
-  execution_space exec;
+  // Now run through the interfaces and check results each time.
+  auto space_partitions =
+      Kokkos::Experimental::partition_space(execution_space(), 1, 1);
+  // For versions taking an exec space instance, use the second partition out of
+  // 2 (since the first partition might just be the default instance)
+  execution_space space = space_partitions[1];
   KokkosKernels::Experimental::Controls controls;
   // All tagged versions
-  KokkosSparse::spmv(exec, controls, "N", 1.0, A, x, 0.0, y,
+  KokkosSparse::spmv(space, controls, "N", 1.0, A, x, 0.0, y,
                      KokkosSparse::RANK_ONE());
+  space.fence();
   verify();
   clear_y();
   KokkosSparse::spmv(controls, "N", 1.0, A, x, 0.0, y,
                      KokkosSparse::RANK_ONE());
   verify();
   clear_y();
-  KokkosSparse::spmv(exec, controls, "N", 1.0, A, x_mv, 0.0, y_mv,
+  KokkosSparse::spmv(space, controls, "N", 1.0, A, x_mv, 0.0, y_mv,
                      KokkosSparse::RANK_TWO());
+  space.fence();
   verify_mv();
   clear_y();
   KokkosSparse::spmv(controls, "N", 1.0, A, x_mv, 0.0, y_mv,
@@ -1201,11 +1207,13 @@ void test_spmv_all_interfaces_light() {
   verify_mv();
   clear_y();
   // Non-tagged versions
-  // exec and controls
-  spmv(exec, controls, "N", 1.0, A, x, 0.0, y);
+  // space and controls
+  spmv(space, controls, "N", 1.0, A, x, 0.0, y);
+  space.fence();
   verify();
   clear_y();
-  spmv(exec, controls, "N", 1.0, A, x_mv, 0.0, y_mv);
+  spmv(space, controls, "N", 1.0, A, x_mv, 0.0, y_mv);
+  space.fence();
   verify_mv();
   clear_y();
   // controls
@@ -1215,11 +1223,13 @@ void test_spmv_all_interfaces_light() {
   spmv(controls, "N", 1.0, A, x_mv, 0.0, y_mv);
   verify_mv();
   clear_y();
-  // exec
-  spmv(exec, "N", 1.0, A, x, 0.0, y);
+  // space
+  spmv(space, "N", 1.0, A, x, 0.0, y);
+  space.fence();
   verify();
   clear_y();
-  spmv(exec, "N", 1.0, A, x_mv, 0.0, y_mv);
+  spmv(space, "N", 1.0, A, x_mv, 0.0, y_mv);
+  space.fence();
   verify_mv();
   clear_y();
   // neither


### PR DESCRIPTION
including cusparse, rocsparse, onemkl wrappers. Resolves #1878

Done for spmv and spmv_mv, both CRS and BSR. Did not do structured spmv yet.

Fix some misc. bugs too:
- Fallback check for cusparse was wrong - we were only calling the TPL for mode 'N', but TPL should be used for 'T' and 'H' also
- In SYCL build, forgetting to #undef a macro caused warning in sparse tests
- Can't call cuSPARSE or MKL spmv with mode 'H' and real scalars. In this case, just switch to mode 'T' since it's equivalent

Tested on weaver (no-TPL and cusparse), caraway (rocsparse) and sunspot (onemkl).