### PR TITLE
Update SYCL docker image to Cuda 11.7.1

### DIFF
--- a/scripts/docker/Dockerfile.sycl
+++ b/scripts/docker/Dockerfile.sycl
@@ -1,4 +1,4 @@
-ARG BASE=nvidia/cuda:11.7.0-devel-ubuntu22.04
+ARG BASE=nvidia/cuda:11.7.1-devel-ubuntu22.04
 FROM $BASE
 
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub


### PR DESCRIPTION
The SYCL nightly regression tester has been failing for a while because 11.7.0 isn't hosted anymore, only 11.7.1 is, see https://cloud.cees.ornl.gov/jenkins-ci/job/KokkosKernels/ and https://hub.docker.com/r/nvidia/cuda/tags?page=1&name=11.7. This pull request updates the base image to use that.