### PR TITLE
Avoid enum without fixed underlying type to fix SYCL

### DIFF
--- a/ode/src/KokkosODE_Types.hpp
+++ b/ode/src/KokkosODE_Types.hpp
@@ -51,7 +51,11 @@ struct ODE_params {
         min_step_size(min_step_size_) {}
 };
 
-enum newton_solver_status { NLS_SUCCESS = 0, MAX_ITER = 1, LIN_SOLVE_FAIL = 2 };
+enum newton_solver_status : int {
+  NLS_SUCCESS    = 0,
+  MAX_ITER       = 1,
+  LIN_SOLVE_FAIL = 2
+};
 
 struct Newton_params {
   int max_iters;


### PR DESCRIPTION
Compiling the tests for the  SYCL backend currently fails with
```
clang++: warning: CUDA version is newer than the latest supported version 11.5 [-Wunknown-cuda-version]
clang++: warning: CUDA version is newer than the latest supported version 11.5 [-Wunknown-cuda-version]
In file included from /app/kokkos-kernels/ode/unit_test/backends/Test_SYCL_ODE.cpp:19:
In file included from /app/kokkos-kernels/test_common/Test_SYCL.hpp:17:
In file included from /app/kokkos-install/include/Kokkos_Core.hpp:43:
In file included from /app/kokkos-install/include/Kokkos_Core_fwd.hpp:28:
In file included from /app/kokkos-install/include/Kokkos_Macros.hpp:96:
In file included from /app/kokkos-install/include/KokkosCore_Config_SetupBackend.hpp:22:
In file included from /app/kokkos-install/include/setup/Kokkos_Setup_SYCL.hpp:36:
In file included from /opt/intel/oneapi/compiler/2023.0.0/linux/bin-llvm/../include/sycl/sycl.hpp:16:
In file included from /opt/intel/oneapi/compiler/2023.0.0/linux/bin-llvm/../include/sycl/backend.hpp:18:
In file included from /opt/intel/oneapi/compiler/2023.0.0/linux/bin-llvm/../include/sycl/detail/backend_traits_opencl.hpp:26:
In file included from /opt/intel/oneapi/compiler/2023.0.0/linux/bin-llvm/../include/sycl/queue.hpp:21:
/opt/intel/oneapi/compiler/2023.0.0/linux/bin-llvm/../include/sycl/handler.hpp:1253:50: error: unscoped enum 'newton_solver_status' requires fixed underlying type
    kernel_parallel_for<KernelName, ElementType>(KernelFunc);
                                                 ^
/opt/intel/oneapi/compiler/2023.0.0/linux/bin-llvm/../include/sycl/handler.hpp:1042:7: note: in instantiation of function template specialization 'sycl::handler::kernel_parallel_for_wrapper<sycl::detail::RoundedRangeKernel<sycl::item<1, true>, 1, Kokkos::Impl::FunctorWrapperRangePolicyParallelFor<Kokkos::Experimental::Impl::SYCLFunctionWrapper<Kokkos::Impl::ViewValueFunctor<Kokkos::Device<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace>, KokkosODE::Experimental::newton_solver_status, true>, Kokkos::Experimental::Impl::SYCLInternal::USMObjectMem<sycl::usm::alloc::host>, true>, Kokkos::RangePolicy<Kokkos::Experimental::SYCL, Kokkos::IndexType<long>>>>, sycl::item<1, true>, sycl::detail::RoundedRangeKernel<sycl::item<1, true>, 1, Kokkos::Impl::FunctorWrapperRangePolicyParallelFor<Kokkos::Experimental::Impl::SYCLFunctionWrapper<Kokkos::Impl::ViewValueFunctor<Kokkos::Device<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace>, KokkosODE::Experimental::newton_solver_status, true>, Kokkos::Experimental::Impl::SYCLInternal::USMObjectMem<sycl::usm::alloc::host>, true>, Kokkos::RangePolicy<Kokkos::Experimental::SYCL, Kokkos::IndexType<long>>>>>' requested here
      kernel_parallel_for_wrapper<KName, TransformedArgType>(Wrapper);
      ^
/opt/intel/oneapi/compiler/2023.0.0/linux/bin-llvm/../include/sycl/handler.hpp:1471:5: note: in instantiation of function template specialization 'sycl::handler::parallel_for_lambda_impl<Kokkos::Impl::FunctorWrapperRangePolicyParallelFor<Kokkos::Experimental::Impl::SYCLFunctionWrapper<Kokkos::Impl::ViewValueFunctor<Kokkos::Device<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace>, KokkosODE::Experimental::newton_solver_status, true>, Kokkos::Experimental::Impl::SYCLInternal::USMObjectMem<sycl::usm::alloc::host>, true>, Kokkos::RangePolicy<Kokkos::Experimental::SYCL, Kokkos::IndexType<long>>>, Kokkos::Impl::FunctorWrapperRangePolicyParallelFor<Kokkos::Experimental::Impl::SYCLFunctionWrapper<Kokkos::Impl::ViewValueFunctor<Kokkos::Device<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace>, KokkosODE::Experimental::newton_solver_status, true>, Kokkos::Experimental::Impl::SYCLInternal::USMObjectMem<sycl::usm::alloc::host>, true>, Kokkos::RangePolicy<Kokkos::Experimental::SYCL, Kokkos::IndexType<long>>>, 1>' requested here
    parallel_for_lambda_impl<KernelName>(NumWorkItems, std::move(KernelFunc));
    ^
/app/kokkos-install/include/SYCL/Kokkos_SYCL_Parallel_Range.hpp:94:13: note: in instantiation of function template specialization 'sycl::handler::parallel_for<Kokkos::Impl::FunctorWrapperRangePolicyParallelFor<Kokkos::Experimental::Impl::SYCLFunctionWrapper<Kokkos::Impl::ViewValueFunctor<Kokkos::Device<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace>, KokkosODE::Experimental::newton_solver_status, true>, Kokkos::Experimental::Impl::SYCLInternal::USMObjectMem<sycl::usm::alloc::host>, true>, Kokkos::RangePolicy<Kokkos::Experimental::SYCL, Kokkos::IndexType<long>>>, Kokkos::Impl::FunctorWrapperRangePolicyParallelFor<Kokkos::Experimental::Impl::SYCLFunctionWrapper<Kokkos::Impl::ViewValueFunctor<Kokkos::Device<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace>, KokkosODE::Experimental::newton_solver_status, true>, Kokkos::Experimental::Impl::SYCLInternal::USMObjectMem<sycl::usm::alloc::host>, true>, Kokkos::RangePolicy<Kokkos::Experimental::SYCL, Kokkos::IndexType<long>>>>' requested here
        cgh.parallel_for<FunctorWrapperRangePolicyParallelFor<Functor, Policy>>(
            ^
/app/kokkos-install/include/SYCL/Kokkos_SYCL_Parallel_Range.hpp:133:25: note: in instantiation of function template specialization 'Kokkos::Impl::ParallelFor<Kokkos::Impl::ViewValueFunctor<Kokkos::Device<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace>, KokkosODE::Experimental::newton_solver_status, true>, Kokkos::RangePolicy<Kokkos::Experimental::SYCL, Kokkos::IndexType<long>>, Kokkos::Experimental::SYCL>::sycl_direct_launch<Kokkos::Experimental::Impl::SYCLFunctionWrapper<Kokkos::Impl::ViewValueFunctor<Kokkos::Device<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace>, KokkosODE::Experimental::newton_solver_status, true>, Kokkos::Experimental::Impl::SYCLInternal::USMObjectMem<sycl::usm::alloc::host>, true>>' requested here
    sycl::event event = sycl_direct_launch(m_policy, functor_wrapper,
                        ^
/app/kokkos-install/include/impl/Kokkos_ViewMapping.hpp:3105:15: note: in instantiation of member function 'Kokkos::Impl::ParallelFor<Kokkos::Impl::ViewValueFunctor<Kokkos::Device<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace>, KokkosODE::Experimental::newton_solver_status, true>, Kokkos::RangePolicy<Kokkos::Experimental::SYCL, Kokkos::IndexType<long>>, Kokkos::Experimental::SYCL>::execute' requested here
      closure.execute();
              ^
/app/kokkos-install/include/impl/Kokkos_ViewMapping.hpp:3075:7: note: (skipping 1 context in backtrace; use -ftemplate-backtrace-limit=0 to see all)
      parallel_for_implementation();
      ^
/app/kokkos-install/include/impl/Kokkos_ViewMapping.hpp:3456:27: note: in instantiation of function template specialization 'Kokkos::Impl::ViewValueFunctor<Kokkos::Device<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace>, KokkosODE::Experimental::newton_solver_status, true>::construct_shared_allocation<KokkosODE::Experimental::newton_solver_status>' requested here
        record->m_destroy.construct_shared_allocation();
                          ^
/app/kokkos-install/include/Kokkos_View.hpp:1421:60: note: in instantiation of function template specialization 'Kokkos::Impl::ViewMapping<Kokkos::ViewTraits<KokkosODE::Experimental::newton_solver_status *, Kokkos::Experimental::SYCL>, void>::allocate_shared<std::basic_string<char>, Kokkos::Experimental::SYCLDeviceUSMSpace, Kokkos::Experimental::SYCL>' requested here
    Kokkos::Impl::SharedAllocationRecord<>* record = m_map.allocate_shared(
                                                           ^
/app/kokkos-install/include/Kokkos_View.hpp:1512:9: note: in instantiation of function template specialization 'Kokkos::View<KokkosODE::Experimental::newton_solver_status *, Kokkos::Experimental::SYCL>::View<std::basic_string<char>>' requested here
      : View(Impl::ViewCtorProp<std::string>(arg_label),
        ^
/app/kokkos-kernels/ode/unit_test/Test_ODE_Newton.hpp:218:56: note: in instantiation of function template specialization 'Kokkos::View<KokkosODE::Experimental::newton_solver_status *, Kokkos::Experimental::SYCL>::View<char[21]>' requested here
  Kokkos::View<newton_solver_status*, execution_space> status(
                                                       ^
/app/kokkos-kernels/ode/unit_test/Test_ODE_Newton.hpp:525:11: note: in instantiation of function template specialization 'Test::test_newton_status<Kokkos::Experimental::SYCL, float>' requested here
  ::Test::test_newton_status<TestExecSpace, float>();
          ^
[...]
```
Just providing an underlying type for `enum` in question fixes the issue.