### PR TITLE
.github/workflows/docs.yml: Use up-to-date doxygen version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,15 +11,16 @@ permissions:
 
 jobs:
   docs-check:
-    runs-on: ubuntu-latest
+    runs-on: [macos-latest]
     steps:
       - name: Install Dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends doxygen-latex
-          pip install sphinx
-          pip install breathe
-          pip install sphinx-rtd-theme
+          brew install doxygen
+          python3 -m pip install sphinx
+          python3 -m pip install breathe
+          python3 -m pip install sphinx-rtd-theme
+          sphinx-build --version
+          doxygen --version
 
       - name: checkout_kokkos_kernels
         uses: actions/checkout@v3


### PR DESCRIPTION
There seems to be a bug we're hitting in versions of doxygen that are < 1.9.7.

Brian has been hitting this in https://github.com/kokkos/kokkos-kernels/pull/1932 while trying to document the spmv overloads.

To address this blocking issue, let us use doxygen 1.9.7, which is available via brew on the macos VMs.