### PR TITLE
Replace KOKKOS_IMPL_DO_NOT_USE_PRINTF with Kokkos::printf

### DIFF
--- a/batched/dense/impl/KokkosBatched_Axpy_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Axpy_Impl.hpp
@@ -199,14 +199,14 @@ KOKKOS_INLINE_FUNCTION int SerialAxpy::invoke(const alphaViewType& alpha,
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::axpy: Dimensions of X and Y do not match: X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
     return 1;
   }
   if (X.extent(0) != alpha.extent(0)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::axpy: First dimension of X and alpha do not match: X: "
         "%d x %d, alpha: %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
@@ -249,14 +249,14 @@ KOKKOS_INLINE_FUNCTION int TeamAxpy<MemberType>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::axpy: Dimensions of X and Y do not match: X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
     return 1;
   }
   if (X.extent(0) != alpha.extent(0)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::axpy: First dimension of X and alpha do not match: X: "
         "%d x %d, alpha: %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
@@ -304,14 +304,14 @@ KOKKOS_INLINE_FUNCTION int TeamVectorAxpy<MemberType>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::axpy: Dimensions of X and Y do not match: X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
     return 1;
   }
   if (X.extent(0) != alpha.extent(0)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::axpy: First dimension of X and alpha do not match: X: "
         "%d x %d, alpha: %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));

--- a/batched/dense/impl/KokkosBatched_Copy_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Copy_Impl.hpp
@@ -59,7 +59,7 @@ KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::NoTranspose, 2>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x %d, "
         "B: %d x %d\n",
         (int)A.extent(0), (int)A.extent(1), (int)B.extent(0), (int)B.extent(1));
@@ -87,7 +87,7 @@ KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::Transpose, 2>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x %d, "
         "B: %d x %d\n",
         (int)A.extent(0), (int)A.extent(1), (int)B.extent(0), (int)B.extent(1));
@@ -143,7 +143,7 @@ struct TeamCopy<MemberType, Trans::NoTranspose, 2> {
 
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
           "%d, "
           "B: %d x %d\n",
@@ -181,7 +181,7 @@ struct TeamCopy<MemberType, Trans::Transpose, 2> {
 
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
           "%d, "
           "B: %d x %d\n",
@@ -245,7 +245,7 @@ struct TeamVectorCopy<MemberType, Trans::NoTranspose, 2> {
 
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
           "%d, "
           "B: %d x %d\n",
@@ -283,7 +283,7 @@ struct TeamVectorCopy<MemberType, Trans::Transpose, 2> {
 
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
           "%d, "
           "B: %d x %d\n",

--- a/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
@@ -186,7 +186,7 @@ struct SerialDot<Trans::Transpose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
           "Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -194,7 +194,7 @@ struct SerialDot<Trans::Transpose> {
       return 1;
     }
     if (X.extent(1) != dot.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::dot: Second dimension of X and alpha do not match: "
           "X: "
           "%d x %d, dot: %d\n",
@@ -232,7 +232,7 @@ struct SerialDot<Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
           "Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -240,7 +240,7 @@ struct SerialDot<Trans::NoTranspose> {
       return 1;
     }
     if (X.extent(0) != dot.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::dot: First dimension of X and alpha do not match: X: "
           "%d x %d, dot: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
@@ -282,7 +282,7 @@ struct TeamDot<MemberType, Trans::Transpose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
           "Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -290,7 +290,7 @@ struct TeamDot<MemberType, Trans::Transpose> {
       return 1;
     }
     if (X.extent(1) != dot.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::dot: Second dimension of X and alpha do not match: "
           "X: "
           "%d x %d, dot: %d\n",
@@ -337,7 +337,7 @@ struct TeamDot<MemberType, Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
           "Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -345,7 +345,7 @@ struct TeamDot<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (X.extent(0) != dot.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::dot: First dimension of X and alpha do not match: X: "
           "%d x %d, dot: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
@@ -395,7 +395,7 @@ struct TeamVectorDot<MemberType, Trans::Transpose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
           "Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -403,7 +403,7 @@ struct TeamVectorDot<MemberType, Trans::Transpose> {
       return 1;
     }
     if (X.extent(1) != dot.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::dot: Second dimension of X and alpha do not match: "
           "X: "
           "%d x %d, dot: %d\n",
@@ -450,7 +450,7 @@ struct TeamVectorDot<MemberType, Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
           "Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -458,7 +458,7 @@ struct TeamVectorDot<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (X.extent(0) != dot.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::dot: First dimension of X and alpha do not match: X: "
           "%d x %d, dot: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));

--- a/batched/dense/impl/KokkosBatched_Gesv_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gesv_Impl.hpp
@@ -384,7 +384,7 @@ struct SerialGesv<Gesv::StaticPivoting> {
     // Check compatibility of dimensions at run time.
 
     if (A.extent(0) != tmp.extent(0) || A.extent(1) + 4 != tmp.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::gesv: dimensions of A and tmp do not match: A: "
           "%d x %d, tmp (note: its second dimension should be the second "
           "dimension of A + 4): %d x %d\n",
@@ -395,7 +395,7 @@ struct SerialGesv<Gesv::StaticPivoting> {
 
     if (A.extent(0) != X.extent(0) || A.extent(1) != X.extent(0) ||
         A.extent(0) != Y.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::gesv: dimensions of A and X and Y do not match: A: "
           "%d x %d, X: %d, Y: %d\n",
           (int)A.extent(0), (int)A.extent(1), (int)X.extent(0),
@@ -414,7 +414,7 @@ struct SerialGesv<Gesv::StaticPivoting> {
 
     if (SerialStaticPivoting::invoke(A, PDAD, Y, PDY, D2, tmp_v_1, tmp_v_2) ==
         1) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::gesv: the currently implemented static pivoting "
           "failed.\n");
       return 1;
@@ -458,7 +458,7 @@ struct SerialGesv<Gesv::NoPivoting> {
 
     if (A.extent(0) != X.extent(0) || A.extent(1) != X.extent(0) ||
         A.extent(0) != Y.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::gesv: dimensions of A and X and Y do not match: A: "
           "%d x %d, X: %d, Y: %d\n",
           (int)A.extent(0), (int)A.extent(1), (int)X.extent(0),
@@ -509,7 +509,7 @@ struct TeamGesv<MemberType, Gesv::StaticPivoting> {
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != X.extent(0) || A.extent(1) != X.extent(0) ||
         A.extent(0) != Y.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::gesv: dimensions of A and X and Y do not match: A: "
           "%d x %d, X: %d, Y: %d\n",
           (int)A.extent(0), (int)A.extent(1), (int)X.extent(0),
@@ -532,7 +532,7 @@ struct TeamGesv<MemberType, Gesv::StaticPivoting> {
 
     if (TeamStaticPivoting<MemberType>::invoke(member, A, PDAD, Y, PDY, D2,
                                                tmp_v_1, tmp_v_2) == 1) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::gesv: the currently implemented static pivoting "
           "failed.\n");
       return 1;
@@ -587,7 +587,7 @@ struct TeamGesv<MemberType, Gesv::NoPivoting> {
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != X.extent(0) || A.extent(1) != X.extent(0) ||
         A.extent(0) != Y.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::gesv: dimensions of A and X and Y do not match: A: "
           "%d x %d, X: %d, Y: %d\n",
           (int)A.extent(0), (int)A.extent(1), (int)X.extent(0),
@@ -645,7 +645,7 @@ struct TeamVectorGesv<MemberType, Gesv::StaticPivoting> {
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != X.extent(0) || A.extent(1) != X.extent(0) ||
         A.extent(0) != Y.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::gesv: dimensions of A and X and Y do not match: A: "
           "%d x %d, X: %d, Y: %d\n",
           (int)A.extent(0), (int)A.extent(1), (int)X.extent(0),
@@ -668,7 +668,7 @@ struct TeamVectorGesv<MemberType, Gesv::StaticPivoting> {
 
     if (TeamVectorStaticPivoting<MemberType>::invoke(
             member, A, PDAD, Y, PDY, D2, tmp_v_1, tmp_v_2) == 1) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::gesv: the currently implemented static pivoting "
           "failed.\n");
       return 1;
@@ -724,7 +724,7 @@ struct TeamVectorGesv<MemberType, Gesv::NoPivoting> {
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != X.extent(0) || A.extent(1) != X.extent(0) ||
         A.extent(0) != Y.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::gesv: dimensions of A and X and Y do not match: A: "
           "%d x %d, X: %d, Y: %d\n",
           (int)A.extent(0), (int)A.extent(1), (int)X.extent(0),

--- a/batched/dense/impl/KokkosBatched_HadamardProduct_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_HadamardProduct_Impl.hpp
@@ -110,7 +110,7 @@ KOKKOS_INLINE_FUNCTION int SerialHadamardProduct::invoke(const XViewType& X,
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::HadamardProduct: Dimensions of X and Y do not match: "
         "X: %d x %d, "
         "Y: %d x %d\n",
@@ -118,7 +118,7 @@ KOKKOS_INLINE_FUNCTION int SerialHadamardProduct::invoke(const XViewType& X,
     return 1;
   }
   if (X.extent(0) != V.extent(0) || X.extent(1) != V.extent(1)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::HadamardProduct: Dimensions of X and V do not match: "
         "X: %d x %d, "
         "V: %d x %d\n",
@@ -161,7 +161,7 @@ KOKKOS_INLINE_FUNCTION int TeamHadamardProduct<MemberType>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::HadamardProduct: Dimensions of X and Y do not match: "
         "X: %d x %d, "
         "Y: %d x %d\n",
@@ -169,7 +169,7 @@ KOKKOS_INLINE_FUNCTION int TeamHadamardProduct<MemberType>::invoke(
     return 1;
   }
   if (X.extent(0) != V.extent(0) || X.extent(1) != V.extent(1)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::HadamardProduct: Dimensions of X and V do not match: "
         "X: %d x %d, "
         "V: %d x %d\n",
@@ -214,7 +214,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorHadamardProduct<MemberType>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::HadamardProduct: Dimensions of X and Y do not match: "
         "X: %d x %d, "
         "Y: %d x %d\n",
@@ -222,7 +222,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorHadamardProduct<MemberType>::invoke(
     return 1;
   }
   if (X.extent(0) != V.extent(0) || X.extent(1) != V.extent(1)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::HadamardProduct: Dimensions of X and V do not match: "
         "X: %d x %d, "
         "V: %d x %d\n",

--- a/batched/dense/impl/KokkosBatched_Xpay_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Xpay_Impl.hpp
@@ -204,14 +204,14 @@ KOKKOS_INLINE_FUNCTION int SerialXpay::invoke(const alphaViewType& alpha,
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::xpay: Dimensions of X and Y do not match: X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
     return 1;
   }
   if (X.extent(0) != alpha.extent(0)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::xpay: First dimension of X and alpha do not match: X: "
         "%d x %d, alpha: %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
@@ -247,14 +247,14 @@ KOKKOS_INLINE_FUNCTION int TeamXpay<MemberType>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::xpay: Dimensions of X and Y do not match: X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
     return 1;
   }
   if (X.extent(0) != alpha.extent(0)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::xpay: First dimension of X and alpha do not match: X: "
         "%d x %d, alpha: %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
@@ -291,14 +291,14 @@ KOKKOS_INLINE_FUNCTION int TeamVectorXpay<MemberType>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::xpay: Dimensions of X and Y do not match: X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
     return 1;
   }
   if (X.extent(0) != alpha.extent(0)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBatched::xpay: First dimension of X and alpha do not match: X: "
         "%d x %d, alpha: %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));

--- a/batched/sparse/impl/KokkosBatched_Spmv_Serial_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_Serial_Impl.hpp
@@ -153,7 +153,7 @@ struct SerialSpmv<Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
           "%d, Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -161,21 +161,21 @@ struct SerialSpmv<Trans::NoTranspose> {
       return 1;
     }
     if (X.extent(0) != alpha.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: First dimension of X and alpha do not match: "
           "X: %d x %d, alpha: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
       return 1;
     }
     if (X.extent(0) != beta.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: First dimension of X and beta do not match: X: "
           "%d x %d, beta: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)beta.extent(0));
       return 1;
     }
     if (X.extent(0) != values.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: First dimension of X and the first dimension "
           "of values do not match: X: %d x %d, values: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
@@ -183,7 +183,7 @@ struct SerialSpmv<Trans::NoTranspose> {
       return 1;
     }
     if (colIndices.extent(0) != values.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: Dimension of colIndices and the second "
           "dimension of values do not match: colIndices: %d , values: %d x "
           "%d\n",
@@ -192,7 +192,7 @@ struct SerialSpmv<Trans::NoTranspose> {
       return 1;
     }
     if (row_ptr.extent(0) - 1 != X.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
           "of X do not match: colIndices (-1): %d , values: %d x %d\n",
           (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));
@@ -243,7 +243,7 @@ struct SerialSpmv<Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
           "%d, Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -251,7 +251,7 @@ struct SerialSpmv<Trans::NoTranspose> {
       return 1;
     }
     if (X.extent(0) != values.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: First dimension of X and the first dimension "
           "of values do not match: X: %d x %d, values: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
@@ -259,7 +259,7 @@ struct SerialSpmv<Trans::NoTranspose> {
       return 1;
     }
     if (colIndices.extent(0) != values.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: Dimension of colIndices and the second "
           "dimension of values do not match: colIndices: %d , values: %d x "
           "%d\n",
@@ -268,7 +268,7 @@ struct SerialSpmv<Trans::NoTranspose> {
       return 1;
     }
     if (row_ptr.extent(0) - 1 != X.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
           "of X do not match: colIndices (-1): %d , values: %d x %d\n",
           (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));

--- a/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
@@ -341,7 +341,7 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
           "%d, Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -349,21 +349,21 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
       return 1;
     }
     if (X.extent(0) != alpha.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: First dimension of X and alpha do not match: "
           "X: %d x %d, alpha: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
       return 1;
     }
     if (X.extent(0) != beta.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: First dimension of X and beta do not match: X: "
           "%d x %d, beta: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)beta.extent(0));
       return 1;
     }
     if (X.extent(0) != values.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: First dimension of X and the first dimension "
           "of values do not match: X: %d x %d, values: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
@@ -371,7 +371,7 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
       return 1;
     }
     if (colIndices.extent(0) != values.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: Dimension of colIndices and the second "
           "dimension of values do not match: colIndices: %d , values: %d x "
           "%d\n",
@@ -380,7 +380,7 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
       return 1;
     }
     if (row_ptr.extent(0) - 1 != X.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
           "of X do not match: colIndices (-1): %d , values: %d x %d\n",
           (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));
@@ -438,7 +438,7 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
           "%d, Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -446,7 +446,7 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
       return 1;
     }
     if (X.extent(0) != values.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: First dimension of X and the first dimension "
           "of values do not match: X: %d x %d, values: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
@@ -454,7 +454,7 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
       return 1;
     }
     if (colIndices.extent(0) != values.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: Dimension of colIndices and the second "
           "dimension of values do not match: colIndices: %d , values: %d x "
           "%d\n",
@@ -463,7 +463,7 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
       return 1;
     }
     if (row_ptr.extent(0) - 1 != X.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
           "of X do not match: colIndices (-1): %d , values: %d x %d\n",
           (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));

--- a/batched/sparse/impl/KokkosBatched_Spmv_Team_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_Team_Impl.hpp
@@ -192,7 +192,7 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
           "%d, Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -200,21 +200,21 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (X.extent(0) != alpha.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: First dimension of X and alpha do not match: "
           "X: %d x %d, alpha: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
       return 1;
     }
     if (X.extent(0) != beta.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: First dimension of X and beta do not match: X: "
           "%d x %d, beta: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)beta.extent(0));
       return 1;
     }
     if (X.extent(0) != values.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: First dimension of X and the first dimension "
           "of values do not match: X: %d x %d, values: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
@@ -222,7 +222,7 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (colIndices.extent(0) != values.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: Dimension of colIndices and the second "
           "dimension of values do not match: colIndices: %d , values: %d x "
           "%d\n",
@@ -231,7 +231,7 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (row_ptr.extent(0) - 1 != X.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
           "of X do not match: colIndices (-1): %d , values: %d x %d\n",
           (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));
@@ -289,7 +289,7 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
           "%d, Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
@@ -297,7 +297,7 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (X.extent(0) != values.extent(0)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: First dimension of X and the first dimension "
           "of values do not match: X: %d x %d, values: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
@@ -305,7 +305,7 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (colIndices.extent(0) != values.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: Dimension of colIndices and the second "
           "dimension of values do not match: colIndices: %d , values: %d x "
           "%d\n",
@@ -314,7 +314,7 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
       return 1;
     }
     if (row_ptr.extent(0) - 1 != X.extent(1)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
           "of X do not match: colIndices (-1): %d , values: %d x %d\n",
           (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));

--- a/batched/sparse/src/KokkosBatched_JacobiPrec.hpp
+++ b/batched/sparse/src/KokkosBatched_JacobiPrec.hpp
@@ -109,7 +109,7 @@ class JacobiPrec {
     }
 
     if (tooSmall > 0)
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::JacobiPrec: %d entrie(s) has/have a too small "
           "magnitude and have been replaced by one, \n",
           (int)tooSmall);
@@ -131,7 +131,7 @@ class JacobiPrec {
       }
 
     if (tooSmall > 0)
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "KokkosBatched::JacobiPrec: %d entrie(s) has/have a too small "
           "magnitude and have been replaced by one, \n",
           (int)tooSmall);

--- a/blas/src/KokkosBlas1_nrm2.hpp
+++ b/blas/src/KokkosBlas1_nrm2.hpp
@@ -241,7 +241,7 @@ KOKKOS_INLINE_FUNCTION int serial_nrm2(const XMV X, const RV& R) {
       " Kokkos::ArithTraits<XMV::value_type>::mag_type");
 
   if (R.extent(0) != X.extent(1)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosBlas::serial_nrm2 (MV): Dimensions of R and X do not match,"
         " R: %d and X: %d x %d.\n",
         R.extent_int(0), X.extent_int(0), X.extent_int(1));

--- a/blas/unit_test/Test_Blas2_ger.hpp
+++ b/blas/unit_test/Test_Blas2_ger.hpp
@@ -292,7 +292,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
   view_stride_adapter<_ViewTypeExpected, true> h_vanilla(
       "vanilla = A + alpha * x * y^{t,h}", _M, _N);
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf(
       "In Test_Blas2_ger.hpp, computing vanilla A with alpha type = %s\n",
       typeid(alpha).name());
 #endif
@@ -1357,7 +1357,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
                                        const _ViewTypeExpected& h_expected,
                                        const std::string& situation) {
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf(
       "In Test_Blas2_ger.hpp, right before calling KokkosBlas::ger(): "
       "ViewTypeA = %s, _kkGerShouldThrowException=%d\n",
       typeid(_ViewTypeA).name(), _kkGerShouldThrowException);
@@ -1402,11 +1402,11 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
 template <class ScalarX, class ScalarY, class ScalarA, class Device>
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
 int test_ger(const std::string& caseName) {
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf(
       "+======================================================================="
       "===\n");
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s, device = %s ...\n",
-                                caseName.c_str(), typeid(Device).name());
+  Kokkos::printf("Starting %s, device = %s ...\n", caseName.c_str(),
+                 typeid(Device).name());
 #else
 int test_ger(const std::string& /*caseName*/) {
 #endif
@@ -1428,11 +1428,10 @@ int test_ger(const std::string& /*caseName*/) {
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&      \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for LAYOUTLEFT ...\n",
-                                caseName.c_str());
+  Kokkos::printf("Starting %s for LAYOUTLEFT ...\n", caseName.c_str());
 #endif
   if (true) {
     Test::GerTester<ScalarX, Kokkos::LayoutLeft, ScalarY, Kokkos::LayoutLeft,
@@ -1463,9 +1462,8 @@ int test_ger(const std::string& /*caseName*/) {
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for LAYOUTLEFT\n",
-                                caseName.c_str());
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf("Finished %s for LAYOUTLEFT\n", caseName.c_str());
+  Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
 #endif
@@ -1475,11 +1473,10 @@ int test_ger(const std::string& /*caseName*/) {
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&       \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for LAYOUTRIGHT ...\n",
-                                caseName.c_str());
+  Kokkos::printf("Starting %s for LAYOUTRIGHT ...\n", caseName.c_str());
 #endif
   if (true) {
     Test::GerTester<ScalarX, Kokkos::LayoutRight, ScalarY, Kokkos::LayoutRight,
@@ -1510,9 +1507,8 @@ int test_ger(const std::string& /*caseName*/) {
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for LAYOUTRIGHT\n",
-                                caseName.c_str());
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf("Finished %s for LAYOUTRIGHT\n", caseName.c_str());
+  Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
 #endif
@@ -1521,11 +1517,10 @@ int test_ger(const std::string& /*caseName*/) {
 #if (!defined(KOKKOSKERNELS_ETI_ONLY) && \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for LAYOUTSTRIDE ...\n",
-                                caseName.c_str());
+  Kokkos::printf("Starting %s for LAYOUTSTRIDE ...\n", caseName.c_str());
 #endif
   if (true) {
     Test::GerTester<ScalarX, Kokkos::LayoutStride, ScalarY,
@@ -1553,9 +1548,8 @@ int test_ger(const std::string& /*caseName*/) {
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for LAYOUTSTRIDE\n",
-                                caseName.c_str());
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf("Finished %s for LAYOUTSTRIDE\n", caseName.c_str());
+  Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
 #endif
@@ -1564,11 +1558,10 @@ int test_ger(const std::string& /*caseName*/) {
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && \
     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for MIXED LAYOUTS ...\n",
-                                caseName.c_str());
+  Kokkos::printf("Starting %s for MIXED LAYOUTS ...\n", caseName.c_str());
 #endif
   if (true) {
     Test::GerTester<ScalarX, Kokkos::LayoutStride, ScalarY, Kokkos::LayoutLeft,
@@ -1591,17 +1584,16 @@ int test_ger(const std::string& /*caseName*/) {
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for MIXED LAYOUTS\n",
-                                caseName.c_str());
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf("Finished %s for MIXED LAYOUTS\n", caseName.c_str());
+  Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
 #endif
 #endif
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s\n", caseName.c_str());
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf("Finished %s\n", caseName.c_str());
+  Kokkos::printf(
       "+======================================================================="
       "===\n");
 #endif

--- a/blas/unit_test/Test_Blas2_syr.hpp
+++ b/blas/unit_test/Test_Blas2_syr.hpp
@@ -288,7 +288,7 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::test(
   view_stride_adapter<_ViewTypeExpected, true> h_vanilla(
       "vanilla = A + alpha * x * x^{t,h}", _M, _N);
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf(
       "In Test_Blas2_syr.hpp, computing vanilla A with alpha type = %s\n",
       typeid(alpha).name());
 #endif
@@ -1434,7 +1434,7 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "In Test_Blas2_syr, '" << situation << "', alpha = " << alpha
             << std::endl;
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf(
       "In Test_Blas2_syr.hpp, right before calling KokkosBlas::syr(): "
       "ViewTypeA = %s, _kkSyrShouldThrowException=%d\n",
       typeid(_ViewTypeA).name(), _kkSyrShouldThrowException);
@@ -1491,7 +1491,7 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "In Test_Blas2_syr, '" << situation << "', alpha = " << alpha
             << std::endl;
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf(
       "In Test_Blas2_syr.hpp, right before calling KokkosBlas::ger(): "
       "ViewTypeA = %s, _kkGerShouldThrowException=%d\n",
       typeid(_ViewTypeA).name(), _kkGerShouldThrowException);
@@ -1561,10 +1561,10 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::
 template <class ScalarX, class ScalarA, class Device>
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
 int test_syr(const std::string& caseName) {
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf(
       "+======================================================================="
       "===\n");
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s ...\n", caseName.c_str());
+  Kokkos::printf("Starting %s ...\n", caseName.c_str());
 #else
 int test_syr(const std::string& /*caseName*/) {
 #endif
@@ -1582,11 +1582,10 @@ int test_syr(const std::string& /*caseName*/) {
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&      \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for LAYOUTLEFT ...\n",
-                                caseName.c_str());
+  Kokkos::printf("Starting %s for LAYOUTLEFT ...\n", caseName.c_str());
 #endif
   if (true) {
     Test::SyrTester<ScalarX, Kokkos::LayoutLeft, ScalarA, Kokkos::LayoutLeft,
@@ -1617,9 +1616,8 @@ int test_syr(const std::string& /*caseName*/) {
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for LAYOUTLEFT\n",
-                                caseName.c_str());
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf("Finished %s for LAYOUTLEFT\n", caseName.c_str());
+  Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
 #endif
@@ -1629,11 +1627,10 @@ int test_syr(const std::string& /*caseName*/) {
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&       \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for LAYOUTRIGHT ...\n",
-                                caseName.c_str());
+  Kokkos::printf("Starting %s for LAYOUTRIGHT ...\n", caseName.c_str());
 #endif
   if (true) {
     Test::SyrTester<ScalarX, Kokkos::LayoutRight, ScalarA, Kokkos::LayoutRight,
@@ -1664,9 +1661,8 @@ int test_syr(const std::string& /*caseName*/) {
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for LAYOUTRIGHT\n",
-                                caseName.c_str());
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf("Finished %s for LAYOUTRIGHT\n", caseName.c_str());
+  Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
 #endif
@@ -1676,11 +1672,10 @@ int test_syr(const std::string& /*caseName*/) {
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for LAYOUTSTRIDE ...\n",
-                                caseName.c_str());
+  Kokkos::printf("Starting %s for LAYOUTSTRIDE ...\n", caseName.c_str());
 #endif
   if (true) {
     Test::SyrTester<ScalarX, Kokkos::LayoutStride, ScalarA,
@@ -1711,9 +1706,8 @@ int test_syr(const std::string& /*caseName*/) {
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for LAYOUTSTRIDE\n",
-                                caseName.c_str());
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf("Finished %s for LAYOUTSTRIDE\n", caseName.c_str());
+  Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
 #endif
@@ -1722,11 +1716,10 @@ int test_syr(const std::string& /*caseName*/) {
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && \
     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for MIXED LAYOUTS ...\n",
-                                caseName.c_str());
+  Kokkos::printf("Starting %s for MIXED LAYOUTS ...\n", caseName.c_str());
 #endif
   if (true) {
     Test::SyrTester<ScalarX, Kokkos::LayoutStride, ScalarA, Kokkos::LayoutRight,
@@ -1755,17 +1748,16 @@ int test_syr(const std::string& /*caseName*/) {
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for MIXED LAYOUTS\n",
-                                caseName.c_str());
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf("Finished %s for MIXED LAYOUTS\n", caseName.c_str());
+  Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
 #endif
 #endif
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s\n", caseName.c_str());
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+  Kokkos::printf("Finished %s\n", caseName.c_str());
+  Kokkos::printf(
       "+======================================================================="
       "===\n");
 #endif

--- a/common/src/KokkosKernels_Error.hpp
+++ b/common/src/KokkosKernels_Error.hpp
@@ -80,13 +80,12 @@ inline void hip_internal_safe_call(hipError_t e, const char *name,
   } while (0)
 
 // SYCL cannot printf like the other backends quite yet
-#define IMPL_KERNEL_THROW(condition, msg)                                   \
-  do {                                                                      \
-    if (!(condition)) {                                                     \
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("KERNEL CHECK FAILED:\n   %s\n   %s\n", \
-                                    #condition, msg);                       \
-      Kokkos::abort("");                                                    \
-    }                                                                       \
+#define IMPL_KERNEL_THROW(condition, msg)                                      \
+  do {                                                                         \
+    if (!(condition)) {                                                        \
+      Kokkos::printf("KERNEL CHECK FAILED:\n   %s\n   %s\n", #condition, msg); \
+      Kokkos::abort("");                                                       \
+    }                                                                          \
   } while (0)
 
 #ifndef NDEBUG

--- a/common/src/KokkosKernels_SimpleUtils.hpp
+++ b/common/src/KokkosKernels_SimpleUtils.hpp
@@ -324,7 +324,7 @@ struct IsRelativelyIdenticalFunctor {
     }
 
     if (val_diff > mag_type(eps)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      Kokkos::printf(
           "Values at index %d, %.6f + %.6fi and %.6f + %.6fi, differ too much "
           "(eps = %e)\n",
           (int)i, KAT::real(view1(i)), KAT::imag(view1(i)), KAT::real(view2(i)),

--- a/common/unit_test/Test_Common_ArithTraits.hpp
+++ b/common/unit_test/Test_Common_ArithTraits.hpp
@@ -35,17 +35,15 @@
 #include <typeinfo>  // typeid (T)
 #include <cstdio>
 
-#define FAILURE()                                                            \
-  {                                                                          \
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF("%s:%s:%d: Failure\n", __FILE__, __func__, \
-                                  __LINE__);                                 \
-    success = 0;                                                             \
+#define FAILURE()                                                        \
+  {                                                                      \
+    Kokkos::printf("%s:%s:%d: Failure\n", __FILE__, __func__, __LINE__); \
+    success = 0;                                                         \
   }
 
 #if 0
-#define TRACE()                                                          \
-  KOKKOS_IMPL_DO_NOT_USE_PRINTF("%s:%s:%d: Trace\n", __FILE__, __func__, \
-                                __LINE__);
+#define TRACE() \
+  Kokkos::printf("%s:%s:%d: Trace\n", __FILE__, __func__, __LINE__);
 #else
 #define TRACE()
 #endif
@@ -181,7 +179,7 @@ class ArithTraitsTesterBase {
     // T, but we check for this int constant for compatibility with
     // std::numeric_limits.
     if (!AT::is_specialized) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("! AT::is_specialized\n");
+      Kokkos::printf("! AT::is_specialized\n");
       FAILURE();
     }
 
@@ -189,13 +187,11 @@ class ArithTraitsTesterBase {
     // function, just not to its class methods (which are not marked
     // as device functions).
     if (AT::is_integer != std::numeric_limits<ScalarType>::is_integer) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-          "AT::is_integer not same as numeric_limits\n");
+      Kokkos::printf("AT::is_integer not same as numeric_limits\n");
       FAILURE();
     }
     if (AT::is_exact != std::numeric_limits<ScalarType>::is_exact) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-          "AT::is_exact not same as numeric_limits\n");
+      Kokkos::printf("AT::is_exact not same as numeric_limits\n");
       FAILURE();
     }
 
@@ -204,34 +200,34 @@ class ArithTraitsTesterBase {
 
     // Test properties of the arithmetic and multiplicative identities.
     if (zero + zero != zero) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("0 + 0 != 0\n");
+      Kokkos::printf("0 + 0 != 0\n");
       FAILURE();
     }
     if (zero + one != one) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("0 + 1 != 1\n");
+      Kokkos::printf("0 + 1 != 1\n");
       FAILURE();
     }
     if (one - one != zero) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("1 - 1 != 0\n");
+      Kokkos::printf("1 - 1 != 0\n");
       FAILURE();
     }
     // This is technically 1 even of Z_2, since in that field, one
     // is its own inverse (so -one == one).
     if ((one + one) - one != one) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("(1 + 1) - 1 != 1\n");
+      Kokkos::printf("(1 + 1) - 1 != 1\n");
       FAILURE();
     }
 
     if (AT::abs(zero) != zero) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::abs(0) != 0\n");
+      Kokkos::printf("AT::abs(0) != 0\n");
       FAILURE();
     }
     if (AT::abs(one) != one) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::abs(1) != 1\n");
+      Kokkos::printf("AT::abs(1) != 1\n");
       FAILURE();
     }
     if (AT::is_signed && AT::abs(-one) != one) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::is_signed and AT::abs(-1) != 1\n");
+      Kokkos::printf("AT::is_signed and AT::abs(-1) != 1\n");
       FAILURE();
     }
     // Need enable_if to test whether T can be compared using <=.
@@ -240,7 +236,7 @@ class ArithTraitsTesterBase {
     // These are very mild ordering properties.
     // They should work even for a set only containing zero.
     if (AT::abs(zero) > AT::abs(AT::max())) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::abs(0) > AT::abs (AT::max ())\n");
+      Kokkos::printf("AT::abs(0) > AT::abs (AT::max ())\n");
       FAILURE();
     }
 
@@ -553,20 +549,20 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
     if (!AT::is_complex) {
       result = AT::pow(two, three);
       if (!equal(result, eight)) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(2,3) != 8\n");
+        Kokkos::printf("AT::pow(2,3) != 8\n");
         FAILURE();
       }
     }
     if (!equal(AT::pow(three, zero), one)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(3,0) != 1\n");
+      Kokkos::printf("AT::pow(3,0) != 1\n");
       FAILURE();
     }
     if (!equal(AT::pow(three, one), three)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(3,1) != 3\n");
+      Kokkos::printf("AT::pow(3,1) != 3\n");
       FAILURE();
     }
     if (!equal(AT::pow(three, two), nine)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(3,2) != 9\n");
+      Kokkos::printf("AT::pow(3,2) != 9\n");
       FAILURE();
     }
 
@@ -574,7 +570,7 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
     if (!AT::is_complex) {
       result = AT::pow(three, three);
       if (!equal(result, twentySeven)) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(3,3) != 27\n");
+        Kokkos::printf("AT::pow(3,3) != 27\n");
         FAILURE();
       }
     }
@@ -583,93 +579,93 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
     if (AT::is_signed && !AT::is_complex) {
       result = AT::pow(-three, one);
       if (!equal(result, -three)) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(-3,1) != -3\n");
+        Kokkos::printf("AT::pow(-3,1) != -3\n");
         FAILURE();
       }
       result = AT::pow(-three, two);
       if (!equal(result, nine)) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(-3,2) != 9\n");
+        Kokkos::printf("AT::pow(-3,2) != 9\n");
         FAILURE();
       }
       result = AT::pow(-three, three);
       if (!equal(result, -twentySeven)) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(-3,3) != 27\n");
+        Kokkos::printf("AT::pow(-3,3) != 27\n");
         FAILURE();
       }
     }
 
     if (!equal(AT::sqrt(zero), zero)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::sqrt(0) != 0\n");
+      Kokkos::printf("AT::sqrt(0) != 0\n");
       FAILURE();
     }
     if (!equal(AT::sqrt(one), one)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::sqrt(1) != 1\n");
+      Kokkos::printf("AT::sqrt(1) != 1\n");
       FAILURE();
     }
     if (!equal(AT::sqrt(thirtySix), six)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::sqrt(36) != 6\n");
+      Kokkos::printf("AT::sqrt(36) != 6\n");
       FAILURE();
     }
     if (!equal(AT::sqrt(sixtyFour), eight)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::sqrt(64) != 8\n");
+      Kokkos::printf("AT::sqrt(64) != 8\n");
       FAILURE();
     }
     if (AT::is_integer) {
       if (!equal(AT::sqrt(fortyTwo), six)) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT:sqrt(42) != 6\n");
+        Kokkos::printf("AT:sqrt(42) != 6\n");
         FAILURE();
       }
       if (!equal(AT::sqrt(oneTwentySeven), eleven)) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::sqrt(127) != 11\n");
+        Kokkos::printf("AT::sqrt(127) != 11\n");
         FAILURE();
       }
     }
 
     if (!equal(AT::cbrt(zero), zero)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(0) != 0\n");
+      Kokkos::printf("AT::cbrt(0) != 0\n");
       FAILURE();
     }
     if (!equal(AT::cbrt(one), one)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(1) != 1\n");
+      Kokkos::printf("AT::cbrt(1) != 1\n");
       FAILURE();
     }
     if (!equal(AT::cbrt(twentySeven), three)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(27) != 3\n");
+      Kokkos::printf("AT::cbrt(27) != 3\n");
       FAILURE();
     }
     if (!equal(AT::cbrt(sixtyFour), four)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(64) != 4\n");
+      Kokkos::printf("AT::cbrt(64) != 4\n");
       FAILURE();
     }
     if (AT::is_integer) {
       if (!equal(AT::cbrt(fortyTwo), three)) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT:cbrt(42) != 3\n");
+        Kokkos::printf("AT:cbrt(42) != 3\n");
         FAILURE();
       }
       if (!equal(AT::cbrt(oneTwentySeven), five)) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(127) != 5\n");
+        Kokkos::printf("AT::cbrt(127) != 5\n");
         FAILURE();
       }
     }
 
     if (!equal(AT::exp(zero), one)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(0) != 1\n");
+      Kokkos::printf("AT::cbrt(0) != 1\n");
       FAILURE();
     }
     if (AT::is_complex) {
       const ScalarType val = two;  //(two.real(), two.real());
       if (!equal(AT::conj(AT::exp(val)), AT::exp(AT::conj(val)))) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+        Kokkos::printf(
             "AT::conj(exp(complex(2,2))) != AT::exp(conj(complex(2,2)))\n");
         FAILURE();
       }
     }
     if (!equal(AT::log(one), zero)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::log(1) != 0\n");
+      Kokkos::printf("AT::log(1) != 0\n");
       FAILURE();
     }
     if (!equal(AT::log10(one), zero)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::log10(1) != 0\n");
+      Kokkos::printf("AT::log10(1) != 0\n");
       FAILURE();
     }
 
@@ -678,12 +674,12 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
       const auto val_sin = AT::sin(val);
       const auto val_cos = AT::cos(val);
       if (!equal(val_sin * val_sin + val_cos * val_cos, one)) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+        Kokkos::printf(
             "AT(complex):: sin(val)*sin(val) + cos(val)*cos(val) != 1\n");
         FAILURE();
       }
       if (!equal(val_sin / val_cos, AT::tan(val))) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+        Kokkos::printf(
             "AT(complex):: sin(val)/cos(val) != AT(real)::tan(val)\n");
         FAILURE();
       }
@@ -692,27 +688,25 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
       const auto val_sin = AT::sin(val);
       const auto val_cos = AT::cos(val);
       if (!equal(val_sin * val_sin + val_cos * val_cos, one)) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-            "AT(real):: sin(val)*sin(val) + cos(a)*cos(a) != 1\n");
+        Kokkos::printf("AT(real):: sin(val)*sin(val) + cos(a)*cos(a) != 1\n");
         FAILURE();
       }
       if (!equal(val_sin / val_cos, AT::tan(val))) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-            "AT(real):: sin(val)/cos(val) != AT(real)::tan(val)\n");
+        Kokkos::printf("AT(real):: sin(val)/cos(val) != AT(real)::tan(val)\n");
         FAILURE();
       }
     }
 
     if (!equal(AT::asin(AT::sin(one)), one)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::asin(sin(1)) != 1\n");
+      Kokkos::printf("AT::asin(sin(1)) != 1\n");
       FAILURE();
     }
     if (!equal(AT::acos(AT::cos(one)), one)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::acos(cos(1)) != 1\n");
+      Kokkos::printf("AT::acos(cos(1)) != 1\n");
       FAILURE();
     }
     if (!equal(AT::atan(AT::tan(one)), one)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::atan(tan(1)) != 1\n");
+      Kokkos::printf("AT::atan(tan(1)) != 1\n");
       FAILURE();
     }
 
@@ -839,40 +833,40 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
     }
 
     if (!equal(AT::cbrt(zero), zero)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(0) != 0\n");
+      Kokkos::printf("AT::cbrt(0) != 0\n");
       FAILURE();
     }
     if (!equal(AT::cbrt(one), one)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(1) != 1\n");
+      Kokkos::printf("AT::cbrt(1) != 1\n");
       FAILURE();
     }
     if (!equal(AT::cbrt(twentySeven), three)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(27) != 3\n");
+      Kokkos::printf("AT::cbrt(27) != 3\n");
       FAILURE();
     }
     if (!equal(AT::cbrt(sixtyFour), four)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(64) != 4\n");
+      Kokkos::printf("AT::cbrt(64) != 4\n");
       FAILURE();
     }
     if (AT::is_integer) {
       if (!equal(AT::cbrt(fortyTwo), three)) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT:cbrt(42) != 3\n");
+        Kokkos::printf("AT:cbrt(42) != 3\n");
         FAILURE();
       }
       if (!equal(AT::cbrt(oneTwentySeven), five)) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(127) != 5\n");
+        Kokkos::printf("AT::cbrt(127) != 5\n");
         FAILURE();
       }
     }
 
     if (!equal(AT::exp(zero), one)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(0) != 1\n");
+      Kokkos::printf("AT::cbrt(0) != 1\n");
       FAILURE();
     }
     if (AT::is_complex) {
       const ScalarType val = two;  //(two.real(), two.real());
       if (!equal(AT::conj(AT::exp(val)), AT::exp(AT::conj(val)))) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+        Kokkos::printf(
             "AT::conj(exp(complex(2,0))) != AT::exp(conj(complex(2,0)))\n");
         FAILURE();
       }
@@ -891,12 +885,12 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
       const auto val_sin   = AT::sin(val);
       const auto val_cos   = AT::cos(val);
       if (!equal(val_sin * val_sin + val_cos * val_cos, one)) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+        Kokkos::printf(
             "AT(complex):: sin(val)*sin(val) + cos(val)*cos(val) != 1\n");
         FAILURE();
       }
       if (!equal(val_sin / val_cos, AT::tan(val))) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+        Kokkos::printf(
             "AT(complex):: sin(val)/cos(val) != AT(real)::tan(val)\n");
         FAILURE();
       }
@@ -905,27 +899,25 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
       const auto val_sin   = AT::sin(val);
       const auto val_cos   = AT::cos(val);
       if (!equal(val_sin * val_sin + val_cos * val_cos, one)) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-            "AT(real):: sin(val)*sin(val) + cos(a)*cos(a) != 1\n");
+        Kokkos::printf("AT(real):: sin(val)*sin(val) + cos(a)*cos(a) != 1\n");
         FAILURE();
       }
       if (!equal(val_sin / val_cos, AT::tan(val))) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-            "AT(real):: sin(val)/cos(val) != AT(real)::tan(val)\n");
+        Kokkos::printf("AT(real):: sin(val)/cos(val) != AT(real)::tan(val)\n");
         FAILURE();
       }
     }
 
     if (!equal(AT::asin(AT::sin(three)), three)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::asin(sin(3)) != 3\n");
+      Kokkos::printf("AT::asin(sin(3)) != 3\n");
       FAILURE();
     }
     if (!equal(AT::acos(AT::cos(three)), three)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::acos(cos(3)) != 3\n");
+      Kokkos::printf("AT::acos(cos(3)) != 3\n");
       FAILURE();
     }
     if (!equal(AT::atan(AT::tan(three)), three)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::atan(tan(3)) != 3\n");
+      Kokkos::printf("AT::atan(tan(3)) != 3\n");
       FAILURE();
     }
 
@@ -1017,7 +1009,7 @@ class ArithTraitsTesterComplexBase<ScalarType, DeviceType, 0>
 #else
     {
       if (AT::is_signed != std::numeric_limits<ScalarType>::is_signed) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+        Kokkos::printf(
             "AT::is_signed = 0x%x, std::numeric_limits<ScalarType>::is_signed "
             "= 0x%x\n",
             AT::is_signed, std::numeric_limits<ScalarType>::is_signed);
@@ -1233,12 +1225,12 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 0>
     int success = 1;
 
     if (AT::is_exact) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::is_exact is 1\n");
+      Kokkos::printf("AT::is_exact is 1\n");
       FAILURE();
     }
 
     if (!AT::isNan(AT::nan())) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("NaN is not NaN\n");
+      Kokkos::printf("NaN is not NaN\n");
       FAILURE();
     }
 
@@ -1246,19 +1238,19 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 0>
     const ScalarType one  = AT::one();
 
     if (AT::isInf(zero)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("0 is Inf\n");
+      Kokkos::printf("0 is Inf\n");
       FAILURE();
     }
     if (AT::isInf(one)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("1 is Inf\n");
+      Kokkos::printf("1 is Inf\n");
       FAILURE();
     }
     if (AT::isNan(zero)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("0 is NaN\n");
+      Kokkos::printf("0 is NaN\n");
       FAILURE();
     }
     if (AT::isNan(one)) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("1 is NaN\n");
+      Kokkos::printf("1 is NaN\n");
       FAILURE();
     }
 
@@ -1352,7 +1344,7 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 1>
     int success = 1;
 
     if (!AT::is_exact) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("! AT:is_exact\n");
+      Kokkos::printf("! AT:is_exact\n");
       FAILURE();
     }
 

--- a/common/unit_test/Test_Common_LowerBound.hpp
+++ b/common/unit_test/Test_Common_LowerBound.hpp
@@ -43,9 +43,8 @@ struct ThreadLowerBoundFunctor {
     if (0 == i) {
       hv_size_type idx = KokkosKernels::lower_bound_thread(haystack_, needle_);
       if (idx != expected_) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("%s:%d thread %d expected %d got %d\n",
-                                      __FILE__, __LINE__, int(i),
-                                      int(expected_), int(idx));
+        Kokkos::printf("%s:%d thread %d expected %d got %d\n", __FILE__,
+                       __LINE__, int(i), int(expected_), int(idx));
         ++lerrCount;
       }
     }
@@ -100,9 +99,8 @@ struct TeamLowerBoundFunctor {
     hv_size_type idx =
         KokkosKernels::lower_bound_team(handle, haystack_, needle_);
     if (idx != expected_) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("%s:%d thread %d expected %d got %d\n",
-                                    __FILE__, __LINE__, int(handle.team_rank()),
-                                    int(expected_), int(idx));
+      Kokkos::printf("%s:%d thread %d expected %d got %d\n", __FILE__, __LINE__,
+                     int(handle.team_rank()), int(expected_), int(idx));
       ++lerrCount;
     }
   }

--- a/common/unit_test/Test_Common_UpperBound.hpp
+++ b/common/unit_test/Test_Common_UpperBound.hpp
@@ -43,9 +43,8 @@ struct ThreadUpperBoundFunctor {
     if (0 == i) {
       hv_size_type idx = KokkosKernels::upper_bound_thread(haystack_, needle_);
       if (idx != expected_) {
-        KOKKOS_IMPL_DO_NOT_USE_PRINTF("%s:%d thread %d expected %d got %d\n",
-                                      __FILE__, __LINE__, int(i),
-                                      int(expected_), int(idx));
+        Kokkos::printf("%s:%d thread %d expected %d got %d\n", __FILE__,
+                       __LINE__, int(i), int(expected_), int(idx));
         ++lerrCount;
       }
     }
@@ -100,9 +99,8 @@ struct TeamUpperBoundFunctor {
     hv_size_type idx =
         KokkosKernels::upper_bound_team(handle, haystack_, needle_);
     if (idx != expected_) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("%s:%d thread %d expected %d got %d\n",
-                                    __FILE__, __LINE__, int(handle.team_rank()),
-                                    int(expected_), int(idx));
+      Kokkos::printf("%s:%d thread %d expected %d got %d\n", __FILE__, __LINE__,
+                     int(handle.team_rank()), int(expected_), int(idx));
       ++lerrCount;
     }
   }

--- a/ode/impl/KokkosODE_Newton_impl.hpp
+++ b/ode/impl/KokkosODE_Newton_impl.hpp
@@ -74,8 +74,7 @@ KOKKOS_FUNCTION KokkosODE::Experimental::newton_solver_status NewtonSolve(
     KokkosBlas::SerialScale::invoke(-1, update);
 
     if (linSolverStat == 1) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-          "NewtonFunctor: Linear solve gesv returned failure! \n");
+      Kokkos::printf("NewtonFunctor: Linear solve gesv returned failure! \n");
       return newton_solver_status::LIN_SOLVE_FAIL;
     }
 

--- a/sparse/src/KokkosSparse_spmv_team.hpp
+++ b/sparse/src/KokkosSparse_spmv_team.hpp
@@ -55,7 +55,7 @@ int KOKKOS_INLINE_FUNCTION team_spmv(
 
   // Check compatibility of dimensions at run time.
   if (values.extent(0) != colIndices.extent(0)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosSparse::spmv: Dimensions of values and colIndices do not match: "
         "values: %d, colIndices: %d",
         (int)values.extent(0), (int)colIndices.extent(0));
@@ -63,7 +63,7 @@ int KOKKOS_INLINE_FUNCTION team_spmv(
   }
 
   if (x.extent(0) != y.extent(0) || (x.extent(0) + 1) != row_ptr.extent(0)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosSparse::spmv: Dimensions of x, y, and row_ptr do not match: "
         "x: %d, y: %d, row_ptr: %d",
         (int)x.extent(0), (int)y.extent(0), (int)row_ptr.extent(0));
@@ -109,7 +109,7 @@ int KOKKOS_INLINE_FUNCTION team_vector_spmv(
 
   // Check compatibility of dimensions at run time.
   if (values.extent(0) != colIndices.extent(0)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosSparse::spmv: Dimensions of values and colIndices do not match: "
         "values: %d, colIndices: %d",
         (int)values.extent(0), (int)colIndices.extent(0));
@@ -117,7 +117,7 @@ int KOKKOS_INLINE_FUNCTION team_vector_spmv(
   }
 
   if (x.extent(0) != y.extent(0) || (x.extent(0) + 1) != row_ptr.extent(0)) {
-    KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+    Kokkos::printf(
         "KokkosSparse::spmv: Dimensions of x, y, and row_ptr do not match: "
         "x: %d, y: %d, row_ptr: %d",
         (int)x.extent(0), (int)y.extent(0), (int)row_ptr.extent(0));

--- a/sparse/unit_test/Test_Sparse_spmv.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv.hpp
@@ -89,9 +89,9 @@ struct fSPMV {
 
     if (error > eps * max_val) {
       err++;
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF(
-          "expected_y(%d)=%f, y(%d)=%f err=%f, max_error=%f\n", i,
-          AT::abs(expected_y(i)), i, AT::abs(y(i)), error, eps * max_val);
+      Kokkos::printf("expected_y(%d)=%f, y(%d)=%f err=%f, max_error=%f\n", i,
+                     AT::abs(expected_y(i)), i, AT::abs(y(i)), error,
+                     eps * max_val);
     }
   }
 };


### PR DESCRIPTION
For this release we are still keeping `KOKKOS_IMPL_DO_NOT_USE_PRINTF` but it's not clear when we are removing it, possibly after the next release.
The original Kokkos pull request was https://github.com/kokkos/kokkos/pull/6083.