### PR TITLE
.github/workflows: Pin sphinx version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Dependencies
         run: |
           brew install doxygen
-          python3 -m pip install sphinx
+          python3 -m pip install sphinx -v "sphinx==6.2.1"
           python3 -m pip install breathe
           python3 -m pip install sphinx-rtd-theme
           sphinx-build --version


### PR DESCRIPTION
@cwpearson, @lucbv: There appear to be some bugs in sphinx version 7.2.2, see: https://github.com/kokkos/kokkos-kernels/actions/runs/5932096448/job/16085261062?pr=1906.

If these failures continue to be a blocker for our PRs, let us pin sphinx to version 6.2.1.