### PR TITLE
Fix #1951

### DIFF
--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -366,10 +366,12 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, AMatrix, XVector, YVector, true, false,
       const YScalar &beta, const YVector &Y) {
     static_assert(std::is_integral_v<typename AMatrix::non_const_value_type>,
                   "This implementation is only for integer Scalar types.");
-    typedef SPMV_BSRMATRIX<ExecutionSpace, AMatrix, XVector, YVector> impl_type;
     for (typename AMatrix::non_const_size_type j = 0; j < X.extent(1); ++j) {
       const auto x_j = Kokkos::subview(X, Kokkos::ALL(), j);
       auto y_j       = Kokkos::subview(Y, Kokkos::ALL(), j);
+      typedef SPMV_BSRMATRIX<ExecutionSpace, AMatrix, decltype(x_j),
+                             decltype(y_j)>
+          impl_type;
       impl_type::spmv_bsrmatrix(space, controls, mode, alpha, A, x_j, beta,
                                 y_j);
     }

--- a/sparse/impl/KokkosSparse_spmv_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_spec.hpp
@@ -237,11 +237,12 @@ struct SPMV_MV<ExecutionSpace, AMatrix, XVector, YVector, true, false,
                       const coefficient_type& beta, const YVector& y) {
     static_assert(std::is_integral_v<typename AMatrix::non_const_value_type>,
                   "This implementation is only for integer Scalar types.");
-    typedef SPMV<ExecutionSpace, AMatrix, XVector, YVector> impl_type;
     KokkosKernels::Experimental::Controls defaultControls;
     for (typename AMatrix::non_const_size_type j = 0; j < x.extent(1); ++j) {
       auto x_j = Kokkos::subview(x, Kokkos::ALL(), j);
       auto y_j = Kokkos::subview(y, Kokkos::ALL(), j);
+      typedef SPMV<ExecutionSpace, AMatrix, decltype(x_j), decltype(y_j)>
+          impl_type;
       impl_type::spmv(space, defaultControls, mode, alpha, A, x_j, beta, y_j);
     }
   }


### PR DESCRIPTION
In spmv, for versions where x/y are rank-2 but it works on a single vector subview at a time, use the correct rank-1 vector types on the impl_type template params.

Tested by building Tpetra with this version of KK.