### PR TITLE
perf_test/sparse: Update GS perf_test for streams

### DIFF
--- a/common/src/KokkosKernels_Utils.hpp
+++ b/common/src/KokkosKernels_Utils.hpp
@@ -899,7 +899,6 @@ void zero_vector(ExecSpaceIn &exec_space_in,
   typedef typename value_array_type::non_const_value_type val_type;
   Kokkos::deep_copy(exec_space_in, vector,
                     Kokkos::ArithTraits<val_type>::zero());
-  exec_space_in.fence();
 }
 
 template <typename value_array_type, typename MyExecSpace>

--- a/common/src/KokkosKernels_Utils.hpp
+++ b/common/src/KokkosKernels_Utils.hpp
@@ -899,6 +899,7 @@ void zero_vector(ExecSpaceIn &exec_space_in,
   typedef typename value_array_type::non_const_value_type val_type;
   Kokkos::deep_copy(exec_space_in, vector,
                     Kokkos::ArithTraits<val_type>::zero());
+  exec_space_in.fence();
 }
 
 template <typename value_array_type, typename MyExecSpace>

--- a/perf_test/sparse/KokkosSparse_gs.cpp
+++ b/perf_test/sparse/KokkosSparse_gs.cpp
@@ -338,16 +338,24 @@ void runGS(const GS_Parameters& params) {
             << '\n';
   std::cout << "\n*** Total Symbolic launch time: " << symbolicLaunchTimeTotal
             << '\n';
-  std::cout << "\n*** Total Symbolic compute time: " << symbolicComputeTimeTotal
+  std::cout << "*** Total Symbolic compute time: " << symbolicComputeTimeTotal
             << '\n';
   std::cout << "\n*** Total Numeric launch time: " << numericLaunchTimeTotal
             << '\n';
-  std::cout << "\n*** Total Numeric compute time: " << numericComputeTimeTotal
+  std::cout << "*** Total Numeric compute time: " << numericComputeTimeTotal
             << '\n';
   std::cout << "\n*** Total Apply launch time: " << applyLaunchTimeTotal
             << '\n';
-  std::cout << "\n*** Total Apply compute time: " << applyComputeTimeTotal
+  std::cout << "*** Total Apply compute time: " << applyComputeTimeTotal
             << '\n';
+  double launchTimeTotal =
+      symbolicLaunchTimeTotal + numericLaunchTimeTotal + applyLaunchTimeTotal;
+  std::cout << "\n*** Total launch time: " << launchTimeTotal << '\n';
+  double computeTimeTotal = symbolicComputeTimeTotal + numericComputeTimeTotal +
+                            applyComputeTimeTotal;
+  std::cout << "*** Total compute time: " << computeTimeTotal << '\n';
+  std::cout << "\n*** Total compute and launch time: "
+            << launchTimeTotal + computeTimeTotal << '\n';
 }
 
 int main(int argc, char** argv) {

--- a/perf_test/sparse/KokkosSparse_gs.cpp
+++ b/perf_test/sparse/KokkosSparse_gs.cpp
@@ -233,7 +233,7 @@ void runGS(const GS_Parameters& params) {
     b[i] = scalar_view_t("b[" + std::to_string(i) + "]", blk_nrows);
     x[i] = scalar_view_t("x[" + std::to_string(i) + "]", blk_nrows);
     {
-      srand(54321);
+      srand(54321 + i);
       auto bhost = Kokkos::create_mirror_view(b[i]);
       for (lno_t row_id = 0; row_id < blk_nrows; row_id++) {
         bhost(row_id) = 10.0 * rand() / RAND_MAX - 5.0;

--- a/perf_test/sparse/KokkosSparse_gs.cpp
+++ b/perf_test/sparse/KokkosSparse_gs.cpp
@@ -205,24 +205,9 @@ void runGS(const GS_Parameters& params) {
     namespace KE = Kokkos::Experimental;
     auto ns      = params.nstreams;
     auto es      = exec_space();
-    if (ns == 1)
-      instances = KE::partition_space(es, 1);
-    else if (ns == 2)
-      instances = KE::partition_space(es, 1, 1);
-    else if (ns == 3)
-      instances = KE::partition_space(es, 1, 1, 1);
-    else if (ns == 4)
-      instances = KE::partition_space(es, 1, 1, 1, 1);
-    else if (ns == 5)
-      instances = KE::partition_space(es, 1, 1, 1, 1, 1);
-    else if (ns == 6)
-      instances = KE::partition_space(es, 1, 1, 1, 1, 1, 1);
-    else if (ns == 7)
-      instances = KE::partition_space(es, 1, 1, 1, 1, 1, 1, 1);
-    else if (ns == 8)
-      instances = KE::partition_space(es, 1, 1, 1, 1, 1, 1, 1, 1);
-    else
-      Kokkos::abort("--streams outside of [1, 8] is not supported.");
+    std::vector<int> weights(ns);
+    std::fill(weights.begin(), weights.end(), 1);
+    instances = KE::partition_space(es, weights);
   }
 
   double blockExtractionTime = 0, symbolicLaunchTimeTotal = 0,

--- a/perf_test/sparse/KokkosSparse_gs.cpp
+++ b/perf_test/sparse/KokkosSparse_gs.cpp
@@ -53,6 +53,7 @@ struct GS_Parameters {
   int maxNnzPerLongRow    = 2000;
   bool graph_symmetric    = false;
   int sweeps              = 1;
+  int nstreams            = 1;
   GSAlgorithm algo        = GS_DEFAULT;
   GSDirection direction   = GS_FORWARD;
   // Point:
@@ -187,92 +188,170 @@ void runGS(const GS_Parameters& params) {
     Kokkos::finalize();
     exit(1);
   }
+  std::vector<exec_space> instances;
   // size_type nnz = A.nnz();
-  KernelHandle kh;
+  std::vector<KernelHandle> kh(params.nstreams);
   // use a random RHS - uniformly distributed over (-5, 5)
-  scalar_view_t b("b", nrows);
-  {
-    srand(54321);
-    auto bhost = Kokkos::create_mirror_view(b);
-    for (lno_t i = 0; i < nrows; i++) {
-      bhost(i) = 10.0 * rand() / RAND_MAX - 5.0;
-    }
-    Kokkos::deep_copy(b, bhost);
-  }
-  double bnorm = KokkosBlas::nrm2(b);
+  std::vector<scalar_view_t> b(params.nstreams);
   // initial LHS is 0
-  scalar_view_t x("x", nrows);
+  std::vector<scalar_view_t> x(params.nstreams);
+  // Extract diagonal blocks of CRS matrix
+  std::vector<crsMat_t> DiagBlks(params.nstreams);
   // how long symbolic/numeric phases take (the graph reuse case isn't that
   // interesting since numeric doesn't do much)
   Kokkos::Timer timer;
-  // cluster size of 1 is standard multicolor GS
-  if (params.algo == GS_DEFAULT) {
-    kh.create_gs_handle();
-    kh.get_point_gs_handle()->set_long_row_threshold(params.longRowThreshold);
-  } else if (params.algo == GS_CLUSTER) {
-    kh.create_gs_handle(params.coarse_algo, params.cluster_size);
-  } else {
-    kh.create_gs_handle(params.algo);
-    if (params.algo == GS_TWOSTAGE) kh.set_gs_twostage(!params.classic, nrows);
-  }
-  timer.reset();
-  KokkosSparse::Experimental::gauss_seidel_symbolic(
-      &kh, nrows, nrows, A.graph.row_map, A.graph.entries,
-      params.graph_symmetric);
-  double symbolicLaunchTime = timer.seconds();
-  timer.reset();
-  Kokkos::fence();
-  double symbolicComputeTime = timer.seconds();
-  timer.reset();
-  KokkosSparse::Experimental::gauss_seidel_numeric(
-      &kh, nrows, nrows, A.graph.row_map, A.graph.entries, A.values,
-      params.graph_symmetric);
-  double numericLaunchTime = timer.seconds();
-  timer.reset();
-  Kokkos::fence();
-  double numericComputeTime = timer.seconds();
-  timer.reset();
-  // Last two parameters are damping factor (should be 1) and sweeps
-  switch (params.direction) {
-    case GS_SYMMETRIC:
-      KokkosSparse::Experimental::symmetric_gauss_seidel_apply(
-          &kh, nrows, nrows, A.graph.row_map, A.graph.entries, A.values, x, b,
-          true, true, 1.0, params.sweeps);
-      break;
-    case GS_FORWARD:
-      KokkosSparse::Experimental::forward_sweep_gauss_seidel_apply(
-          &kh, nrows, nrows, A.graph.row_map, A.graph.entries, A.values, x, b,
-          true, true, 1.0, params.sweeps);
-      break;
-    case GS_BACKWARD:
-      KokkosSparse::Experimental::backward_sweep_gauss_seidel_apply(
-          &kh, nrows, nrows, A.graph.row_map, A.graph.entries, A.values, x, b,
-          true, true, 1.0, params.sweeps);
-      break;
+
+  {
+    namespace KE = Kokkos::Experimental;
+    auto ns      = params.nstreams;
+    auto es      = exec_space();
+    if (ns == 1)
+      instances = KE::partition_space(es, 1);
+    else if (ns == 2)
+      instances = KE::partition_space(es, 1, 1);
+    else if (ns == 3)
+      instances = KE::partition_space(es, 1, 1, 1);
+    else if (ns == 4)
+      instances = KE::partition_space(es, 1, 1, 1, 1);
+    else if (ns == 5)
+      instances = KE::partition_space(es, 1, 1, 1, 1, 1);
+    else if (ns == 6)
+      instances = KE::partition_space(es, 1, 1, 1, 1, 1, 1);
+    else if (ns == 7)
+      instances = KE::partition_space(es, 1, 1, 1, 1, 1, 1, 1);
+    else if (ns == 8)
+      instances = KE::partition_space(es, 1, 1, 1, 1, 1, 1, 1, 1);
+    else
+      Kokkos::abort("--streams outside of [1, 8] is not supported.");
   }
 
-  double applyLaunchTime = timer.seconds();
+  double blockExtractionTime = 0, symbolicLaunchTimeTotal = 0,
+         symbolicComputeTimeTotal = 0, numericLaunchTimeTotal = 0,
+         numericComputeTimeTotal = 0, applyLaunchTimeTotal = 0,
+         applyComputeTimeTotal = 0;
+
   timer.reset();
+  KokkosSparse::Impl::kk_extract_diagonal_blocks_crsmatrix_sequential(A,
+                                                                      DiagBlks);
   Kokkos::fence();
-  double applyComputeTime = timer.seconds();
-  timer.reset();
-  kh.destroy_gs_handle();
-  // Now, compute the 2-norm of residual
-  scalar_view_t res("Ax-b", nrows);
-  Kokkos::deep_copy(res, b);
-  scalar_t alpha = Kokkos::reduction_identity<scalar_t>::prod();
-  scalar_t beta  = -alpha;
-  KokkosSparse::spmv<scalar_t, crsMat_t, scalar_view_t, scalar_t,
-                     scalar_view_t>("N", alpha, A, x, beta, res);
-  double resnorm = KokkosBlas::nrm2(res);
-  std::cout << "\n*** Symbolic launch time: " << symbolicLaunchTime << '\n';
-  std::cout << "\n*** Symbolic compute time: " << symbolicComputeTime << '\n';
-  std::cout << "\n*** Numeric launch time: " << numericLaunchTime << '\n';
-  std::cout << "\n*** Numeric compute time: " << numericComputeTime << '\n';
-  std::cout << "\n*** Apply launch time: " << applyLaunchTime << '\n';
-  std::cout << "\n*** Apply compute time: " << applyComputeTime << '\n';
-  // note: this still works if the solution diverges
-  std::cout << "Relative res norm: " << resnorm / bnorm << '\n';
+  blockExtractionTime = timer.seconds();
+
+  for (int i = 0; i < params.nstreams; i++) {
+    auto blk_A     = DiagBlks[i];
+    auto blk_nrows = blk_A.numRows();
+    auto blk_ncols = blk_A.numCols();
+    if (blk_nrows != blk_ncols) {
+      cout << "ERROR: Gauss-Seidel only works for square matrices\n";
+      Kokkos::finalize();
+      exit(1);
+    }
+    b[i] = scalar_view_t("b[" + std::to_string(i) + "]", blk_nrows);
+    x[i] = scalar_view_t("x[" + std::to_string(i) + "]", blk_nrows);
+    {
+      srand(54321);
+      auto bhost = Kokkos::create_mirror_view(b[i]);
+      for (lno_t row_id = 0; row_id < blk_nrows; row_id++) {
+        bhost(row_id) = 10.0 * rand() / RAND_MAX - 5.0;
+      }
+      Kokkos::deep_copy(instances[i], b[i], bhost);
+    }
+    double bnorm = KokkosBlas::nrm2(instances[i], b[i]);
+    // cluster size of 1 is standard multicolor GS
+    if (params.algo == GS_DEFAULT) {
+      kh[i].create_gs_handle(instances[i], params.nstreams);
+      kh[i].get_point_gs_handle()->set_long_row_threshold(
+          params.longRowThreshold);
+    } else if (params.algo == GS_CLUSTER) {
+      kh[i].create_gs_handle(params.coarse_algo, params.cluster_size);
+    } else {
+      kh[i].create_gs_handle(params.algo);
+      if (params.algo == GS_TWOSTAGE)
+        kh[i].set_gs_twostage(!params.classic, blk_nrows);
+    }
+    timer.reset();
+    KokkosSparse::Experimental::gauss_seidel_symbolic(
+        instances[i], &kh[i], blk_nrows, blk_nrows, blk_A.graph.row_map,
+        blk_A.graph.entries, params.graph_symmetric);
+    double symbolicLaunchTime = timer.seconds();
+    timer.reset();
+    Kokkos::fence();
+    double symbolicComputeTime = timer.seconds();
+    timer.reset();
+    KokkosSparse::Experimental::gauss_seidel_numeric(
+        instances[i], &kh[i], blk_nrows, blk_nrows, blk_A.graph.row_map,
+        blk_A.graph.entries, blk_A.values, params.graph_symmetric);
+    double numericLaunchTime = timer.seconds();
+    timer.reset();
+    Kokkos::fence();
+    double numericComputeTime = timer.seconds();
+    timer.reset();
+    // Last two parameters are damping factor (should be 1) and sweeps
+    switch (params.direction) {
+      case GS_SYMMETRIC:
+        KokkosSparse::Experimental::symmetric_gauss_seidel_apply(
+            instances[i], &kh[i], blk_nrows, blk_nrows, blk_A.graph.row_map,
+            blk_A.graph.entries, blk_A.values, x[i], b[i], true, true, 1.0,
+            params.sweeps);
+        break;
+      case GS_FORWARD:
+        KokkosSparse::Experimental::forward_sweep_gauss_seidel_apply(
+            instances[i], &kh[i], blk_nrows, blk_nrows, blk_A.graph.row_map,
+            blk_A.graph.entries, blk_A.values, x[i], b[i], true, true, 1.0,
+            params.sweeps);
+        break;
+      case GS_BACKWARD:
+        KokkosSparse::Experimental::backward_sweep_gauss_seidel_apply(
+            instances[i], &kh[i], blk_nrows, blk_nrows, blk_A.graph.row_map,
+            blk_A.graph.entries, blk_A.values, x[i], b[i], true, true, 1.0,
+            params.sweeps);
+        break;
+    }
+
+    double applyLaunchTime = timer.seconds();
+    timer.reset();
+    Kokkos::fence();
+    double applyComputeTime = timer.seconds();
+    timer.reset();
+    kh[i].destroy_gs_handle();
+    // Now, compute the 2-norm of residual
+    scalar_view_t res("Ax-b", blk_nrows);
+    Kokkos::deep_copy(instances[i], res, b[i]);
+    scalar_t alpha = Kokkos::reduction_identity<scalar_t>::prod();
+    scalar_t beta  = -alpha;
+    KokkosSparse::spmv<exec_space, scalar_t, crsMat_t, scalar_view_t, scalar_t,
+                       scalar_view_t>(instances[i], "N", alpha, blk_A, x[i],
+                                      beta, res);
+    double resnorm = KokkosBlas::nrm2(instances[i], res);
+    std::cout << "\n***Stream ID: " << i << std::endl;
+    std::cout << "\n*** Symbolic launch time: " << symbolicLaunchTime << '\n';
+    std::cout << "\n*** Symbolic compute time: " << symbolicComputeTime << '\n';
+    std::cout << "\n*** Numeric launch time: " << numericLaunchTime << '\n';
+    std::cout << "\n*** Numeric compute time: " << numericComputeTime << '\n';
+    std::cout << "\n*** Apply launch time: " << applyLaunchTime << '\n';
+    std::cout << "\n*** Apply compute time: " << applyComputeTime << '\n';
+    // note: this still works if the solution diverges
+    std::cout << "Relative res norm: " << resnorm / bnorm << '\n';
+    symbolicLaunchTimeTotal += symbolicLaunchTime;
+    symbolicComputeTimeTotal += symbolicComputeTime;
+    numericLaunchTimeTotal += numericLaunchTime;
+    numericComputeTimeTotal += numericComputeTime;
+    applyLaunchTimeTotal += applyLaunchTime;
+    applyComputeTimeTotal += applyComputeTime;
+  }
+  std::cout << "\n\n\n*** Total block extraction time: " << blockExtractionTime
+            << '\n';
+  std::cout << "\n*** Total Symbolic launch time: " << symbolicLaunchTimeTotal
+            << '\n';
+  std::cout << "\n*** Total Symbolic compute time: " << symbolicComputeTimeTotal
+            << '\n';
+  std::cout << "\n*** Total Numeric launch time: " << numericLaunchTimeTotal
+            << '\n';
+  std::cout << "\n*** Total Numeric compute time: " << numericComputeTimeTotal
+            << '\n';
+  std::cout << "\n*** Total Apply launch time: " << applyLaunchTimeTotal
+            << '\n';
+  std::cout << "\n*** Total Apply compute time: " << applyComputeTimeTotal
+            << '\n';
 }
 
 int main(int argc, char** argv) {
@@ -288,6 +367,8 @@ int main(int argc, char** argv) {
             "symmetric.\n";
     cout << "            : if generating matrix randomly, it is symmetrized\n";
     cout << "--sweeps S: run S times (default 1)\n";
+    cout << "--streams N: partition matrix and run across N streams (default "
+            "1)\n";
     cout << "Randomized matrix settings, if not reading from file:\n";
     cout << "  --n <N> : number of rows/columns\n";
     cout << "  --nnz <N> : number of nonzeros in each regular row\n";
@@ -354,6 +435,8 @@ int main(int argc, char** argv) {
       params.direction = GS_BACKWARD;
     else if (!strcmp(argv[i], "--sweeps"))
       params.sweeps = atoi(getNextArg(i, argc, argv));
+    else if (!strcmp(argv[i], "--streams"))
+      params.nstreams = atoi(getNextArg(i, argc, argv));
     else if (!strcmp(argv[i], "--point"))
       params.algo = GS_DEFAULT;
     else if (!strcmp(argv[i], "--cluster"))

--- a/perf_test/sparse/KokkosSparse_gs.cpp
+++ b/perf_test/sparse/KokkosSparse_gs.cpp
@@ -30,6 +30,7 @@
 #include <vector>
 #include <string>
 #include <unordered_set>
+#include <thread>
 
 using std::cout;
 using std::string;
@@ -175,6 +176,7 @@ void runGS(const GS_Parameters& params) {
       crsMat_t;
   // typedef typename crsMat_t::StaticCrsGraphType graph_t;
   typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
+  namespace KSE = KokkosSparse::Experimental;
   crsMat_t A;
   if (params.matrix_path)
     A = KokkosSparse::Impl::read_kokkos_crst_matrix<crsMat_t>(
@@ -260,9 +262,9 @@ void runGS(const GS_Parameters& params) {
   for (int i = 0; i < params.nstreams; i++) {
     auto blk_A     = DiagBlks[i];
     auto blk_nrows = blk_A.numRows();
-    KokkosSparse::Experimental::gauss_seidel_symbolic(
-        instances[i], &kh[i], blk_nrows, blk_nrows, blk_A.graph.row_map,
-        blk_A.graph.entries, params.graph_symmetric);
+    KSE::gauss_seidel_symbolic(instances[i], &kh[i], blk_nrows, blk_nrows,
+                               blk_A.graph.row_map, blk_A.graph.entries,
+                               params.graph_symmetric);
   }
   symbolicLaunchTimeTotal = timer.seconds();
   timer.reset();
@@ -274,42 +276,46 @@ void runGS(const GS_Parameters& params) {
   for (int i = 0; i < params.nstreams; i++) {
     auto blk_A     = DiagBlks[i];
     auto blk_nrows = blk_A.numRows();
-    KokkosSparse::Experimental::gauss_seidel_numeric(
-        instances[i], &kh[i], blk_nrows, blk_nrows, blk_A.graph.row_map,
-        blk_A.graph.entries, blk_A.values, params.graph_symmetric);
+    KSE::gauss_seidel_numeric(instances[i], &kh[i], blk_nrows, blk_nrows,
+                              blk_A.graph.row_map, blk_A.graph.entries,
+                              blk_A.values, params.graph_symmetric);
   }
   numericLaunchTimeTotal = timer.seconds();
   timer.reset();
   Kokkos::fence();
   numericComputeTimeTotal = timer.seconds();
 
-  /////////////////// Apply /////////////////
-  timer.reset();
-  for (int i = 0; i < params.nstreams; i++) {
-    auto blk_A     = DiagBlks[i];
-    auto blk_nrows = blk_A.numRows();
+  /////////////////// Apply ///////////////
+  // NOTE: You cannot use capture by value in the 'apply' lambda since 'kh' has
+  // no copy constructor.
+  auto apply = [&](const int i) {
     // Last two parameters are damping factor (should be 1) and sweeps
     switch (params.direction) {
       case GS_SYMMETRIC:
-        KokkosSparse::Experimental::symmetric_gauss_seidel_apply(
-            instances[i], &kh[i], blk_nrows, blk_nrows, blk_A.graph.row_map,
-            blk_A.graph.entries, blk_A.values, x[i], b[i], true, true, 1.0,
-            params.sweeps);
+        KSE::symmetric_gauss_seidel_apply(
+            instances[i], &kh[i], DiagBlks[i].numRows(), DiagBlks[i].numRows(),
+            DiagBlks[i].graph.row_map, DiagBlks[i].graph.entries,
+            DiagBlks[i].values, x[i], b[i], true, true, 1.0, params.sweeps);
         break;
       case GS_FORWARD:
-        KokkosSparse::Experimental::forward_sweep_gauss_seidel_apply(
-            instances[i], &kh[i], blk_nrows, blk_nrows, blk_A.graph.row_map,
-            blk_A.graph.entries, blk_A.values, x[i], b[i], true, true, 1.0,
-            params.sweeps);
+        KSE::forward_sweep_gauss_seidel_apply(
+            instances[i], &kh[i], DiagBlks[i].numRows(), DiagBlks[i].numRows(),
+            DiagBlks[i].graph.row_map, DiagBlks[i].graph.entries,
+            DiagBlks[i].values, x[i], b[i], true, true, 1.0, params.sweeps);
         break;
       case GS_BACKWARD:
-        KokkosSparse::Experimental::backward_sweep_gauss_seidel_apply(
-            instances[i], &kh[i], blk_nrows, blk_nrows, blk_A.graph.row_map,
-            blk_A.graph.entries, blk_A.values, x[i], b[i], true, true, 1.0,
-            params.sweeps);
+        KSE::backward_sweep_gauss_seidel_apply(
+            instances[i], &kh[i], DiagBlks[i].numRows(), DiagBlks[i].numRows(),
+            DiagBlks[i].graph.row_map, DiagBlks[i].graph.entries,
+            DiagBlks[i].values, x[i], b[i], true, true, 1.0, params.sweeps);
         break;
     }
-  }
+  };
+  std::vector<std::thread> apply_thread(params.nstreams);
+  timer.reset();
+  for (int i = 0; i < params.nstreams; i++)
+    apply_thread[i] = std::thread(apply, i);
+  for (int i = 0; i < params.nstreams; i++) apply_thread[i].join();
   applyLaunchTimeTotal = timer.seconds();
   timer.reset();
   Kokkos::fence();
@@ -326,9 +332,7 @@ void runGS(const GS_Parameters& params) {
     double bnorm   = KokkosBlas::nrm2(instances[i], b[i]);
     scalar_t alpha = Kokkos::reduction_identity<scalar_t>::prod();
     scalar_t beta  = -alpha;
-    KokkosSparse::spmv<exec_space, scalar_t, crsMat_t, scalar_view_t, scalar_t,
-                       scalar_view_t>(instances[i], "N", alpha, blk_A, x[i],
-                                      beta, res);
+    KokkosSparse::spmv(instances[i], "N", alpha, blk_A, x[i], beta, res);
     double resnorm = KokkosBlas::nrm2(instances[i], res);
     // note: this still works if the solution diverges
     std::cout << "StreamID(" << i << "): Relative res norm: " << resnorm / bnorm


### PR DESCRIPTION
This PR updates the sparse_gs perf test to use streams. It also updates the perf_test to partition the A matrix into nstream diagonal blocks.

## Initial results with these changes.

### Using 1 streams on VOLTA70 with cuda/11.2
```
StreamID(0): Relative res norm: 0.407859

*** Total block extraction time: 0.658307

*** Total Symbolic launch time: 0.257969
*** Total Symbolic compute time: 3.132e-06

*** Total Numeric launch time: 0.000741617
*** Total Numeric compute time: 0.00274391

*** Total Apply launch time: 0.000514701
*** Total Apply compute time: 0.0176633

*** Total launch time: 0.259225
*** Total compute time: 0.0204104

*** Total compute and launch time: 0.279635
```

### Using 8 streams on VOLTA70 with cuda/11.2
```
$ ./sparse_gs --cuda --amtx ~/matrix_market_files/bone010/bone010.mtx --point --sweeps 1 --streams 8
StreamID(0): Relative res norm: 0.40769
StreamID(1): Relative res norm: 0.393488
StreamID(2): Relative res norm: 0.393181
StreamID(3): Relative res norm: 0.396506
StreamID(4): Relative res norm: 0.404566
StreamID(5): Relative res norm: 0.402509
StreamID(6): Relative res norm: 0.404058
StreamID(7): Relative res norm: 0.40843

*** Total block extraction time: 1.58044

*** Total Symbolic launch time: 0.248238
*** Total Symbolic compute time: 2.222e-06

*** Total Numeric launch time: 0.00176186
*** Total Numeric compute time: 0.00125347

*** Total Apply launch time: 0.00836959
*** Total Apply compute time: 0.00863987

*** Total launch time: 0.258369
*** Total compute time: 0.00989556

*** Total compute and launch time: 0.268265
```

### Speedups
Total launch time speed up: 1.003x

Total compute time speed up: 2.063x

Total compute and launch time speed up: 1.042x