### PR TITLE
Fix sort_and_merge functions for in-place case

### DIFF
--- a/sparse/src/KokkosSparse_SortCrs.hpp
+++ b/sparse/src/KokkosSparse_SortCrs.hpp
@@ -627,6 +627,12 @@ void sort_and_merge_matrix(const exec_space& exec,
     values_out  = values_in;
     return;
   }
+  // Have to do the compression. Create a _shallow_ copy of the input
+  // to preserve it, in case the input and output views are identical
+  // references.
+  auto rowmap_orig  = rowmap_in;
+  auto entries_orig = entries_in;
+  auto values_orig  = values_in;
   // Prefix sum to get rowmap
   KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<nc_rowmap_t,
                                                         exec_space>(
@@ -642,7 +648,7 @@ void sort_and_merge_matrix(const exec_space& exec,
   Kokkos::parallel_for(
       range_t(exec, 0, numRows),
       Impl::MatrixMergedEntriesFunctor<rowmap_t, entries_t, values_t>(
-          rowmap_in, entries_in, values_in, rowmap_out, entries_out,
+          rowmap_orig, entries_orig, values_orig, rowmap_out, entries_out,
           values_out));
 }
 
@@ -746,6 +752,11 @@ void sort_and_merge_graph(const exec_space& exec,
     entries_out = entries_in;
     return;
   }
+  // Have to do the compression. Create a _shallow_ copy of the input
+  // to preserve it, in case the input and output views are identical
+  // references.
+  auto rowmap_orig  = rowmap_in;
+  auto entries_orig = entries_in;
   // Prefix sum to get rowmap.
   // In the case where the output rowmap is the same as the input, we could just
   // assign "rowmap_out = rowmap_in" except that would break const-correctness.
@@ -760,7 +771,7 @@ void sort_and_merge_graph(const exec_space& exec,
   // Compute merged entries and values
   Kokkos::parallel_for(range_t(exec, 0, numRows),
                        Impl::GraphMergedEntriesFunctor<rowmap_t, entries_t>(
-                           rowmap_in, entries_in, rowmap_out, entries_out));
+                           rowmap_orig, entries_orig, rowmap_out, entries_out));
 }
 
 template <typename exec_space, typename rowmap_t, typename entries_t>


### PR DESCRIPTION
``sort_and_merge_graph`` and ``sort_and_merge_matrix`` produced incorrect output if any input view (rowptrs, entries, values) was the same object as the corresponding output view. Fix this and add testing that catches the bug.