### PR TITLE
MDF: set default verbosity explicitly to avoid valgrind warnings

### DIFF
--- a/sparse/src/KokkosSparse_mdf_handle.hpp
+++ b/sparse/src/KokkosSparse_mdf_handle.hpp
@@ -58,7 +58,7 @@ struct MDF_handle {
   // elimination during the factorization.
   col_ind_type permutation, permutation_inv;
 
-  int verbosity;
+  int verbosity = 0;
 
   crs_matrix_type L, U;
 


### PR DESCRIPTION
Explicitly default to 0 verbosity to avoid false positive "uninitialized condition" Valgrind warnings (see https://github.com/trilinos/Trilinos/issues/11934#issuecomment-1721849102 ).