### PR TITLE
Don't assume the default memory space is used

### DIFF
--- a/batched/dense/unit_test/Test_Batched_SerialAxpy.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialAxpy.hpp
@@ -30,6 +30,7 @@ namespace Axpy {
 
 template <typename DeviceType, typename ViewType, typename alphaViewType>
 struct Functor_TestBatchedSerialAxpy {
+  using execution_space = typename DeviceType::execution_space;
   const alphaViewType _alpha;
   const ViewType _X;
   const ViewType _Y;
@@ -54,7 +55,7 @@ struct Functor_TestBatchedSerialAxpy {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType> policy(0, _X.extent(0));
+    Kokkos::RangePolicy<execution_space> policy(0, _X.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/dense/unit_test/Test_Batched_SerialEigendecomposition.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialEigendecomposition.hpp
@@ -34,6 +34,7 @@ namespace Test {
            typename ViewRank2Type,
            typename WorkViewType>
   struct Functor_TestBatchedSerialEigendecomposition {
+    using execution_space = typename DeviceType::execution_space;
     ViewRank3Type _A;
     ViewRank2Type _Er, _Ei;
     ViewRank3Type _UL, _UR;
@@ -70,7 +71,7 @@ namespace Test {
 >::value ? "::ComplexFloat" : std::is_same<value_type,Kokkos::complex<double>
 >::value ? "::ComplexDouble" : "::UnknownValueType" ); std::string name =
 name_region + name_value_type; Kokkos::Profiling::pushRegion( name.c_str() );
-      Kokkos::RangePolicy<DeviceType> policy(0, _A.extent(0));
+      Kokkos::RangePolicy<execution_space> policy(0, _A.extent(0));
       Kokkos::parallel_for(name.c_str(), policy, *this);
       Kokkos::Profiling::popRegion();
     }

--- a/batched/dense/unit_test/Test_Batched_SerialGemm.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialGemm.hpp
@@ -40,6 +40,7 @@ struct ParamTag {
 template <typename DeviceType, typename ViewType, typename ScalarType,
           typename ParamTagType, typename AlgoTagType>
 struct Functor_TestBatchedSerialGemm {
+  using execution_space = typename DeviceType::execution_space;
   ViewType _a, _b, _c;
 
   ScalarType _alpha, _beta;
@@ -66,7 +67,7 @@ struct Functor_TestBatchedSerialGemm {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType, ParamTagType> policy(0, _c.extent(0));
+    Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, _c.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/dense/unit_test/Test_Batched_SerialGesv.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialGesv.hpp
@@ -35,6 +35,7 @@ namespace Gesv {
 template <typename DeviceType, typename MatrixType, typename VectorType,
           typename AlgoTagType>
 struct Functor_TestBatchedSerialGesv {
+  using execution_space = typename DeviceType::execution_space;
   const MatrixType _A;
   const MatrixType _tmp;
   const VectorType _X;
@@ -61,7 +62,7 @@ struct Functor_TestBatchedSerialGesv {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType> policy(0, _X.extent(0));
+    Kokkos::RangePolicy<execution_space> policy(0, _X.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/dense/unit_test/Test_Batched_SerialInverseLU.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialInverseLU.hpp
@@ -44,6 +44,7 @@ struct ParamTag {
 template <typename DeviceType, typename ViewType, typename ScalarType,
           typename ParamTagType, typename AlgoTagType>
 struct Functor_BatchedSerialGemm {
+  using execution_space = typename DeviceType::execution_space;
   ViewType _a, _b, _c;
 
   ScalarType _alpha, _beta;
@@ -72,7 +73,7 @@ struct Functor_BatchedSerialGemm {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType, ParamTagType> policy(0, _c.extent(0));
+    Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, _c.extent(0));
     Kokkos::parallel_for((name + "::GemmFunctor").c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }
@@ -80,6 +81,7 @@ struct Functor_BatchedSerialGemm {
 
 template <typename DeviceType, typename ViewType, typename AlgoTagType>
 struct Functor_BatchedSerialLU {
+  using execution_space = typename DeviceType::execution_space;
   ViewType _a;
 
   KOKKOS_INLINE_FUNCTION
@@ -100,7 +102,7 @@ struct Functor_BatchedSerialLU {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType> policy(0, _a.extent(0));
+    Kokkos::RangePolicy<execution_space> policy(0, _a.extent(0));
     Kokkos::parallel_for((name + "::LUFunctor").c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }
@@ -109,6 +111,7 @@ struct Functor_BatchedSerialLU {
 template <typename DeviceType, typename AViewType, typename WViewType,
           typename AlgoTagType>
 struct Functor_TestBatchedSerialInverseLU {
+  using execution_space = typename DeviceType::execution_space;
   AViewType _a;
   WViewType _w;
 
@@ -130,7 +133,7 @@ struct Functor_TestBatchedSerialInverseLU {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType> policy(0, _a.extent(0));
+    Kokkos::RangePolicy<execution_space> policy(0, _a.extent(0));
     Kokkos::parallel_for((name + "::InverseLUFunctor").c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/dense/unit_test/Test_Batched_SerialLU.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialLU.hpp
@@ -32,6 +32,7 @@ namespace Test {
 
 template <typename DeviceType, typename ViewType, typename AlgoTagType>
 struct Functor_TestBatchedSerialLU {
+  using execution_space = typename DeviceType::execution_space;
   ViewType _a;
 
   KOKKOS_INLINE_FUNCTION
@@ -52,7 +53,7 @@ struct Functor_TestBatchedSerialLU {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType> policy(0, _a.extent(0));
+    Kokkos::RangePolicy<execution_space> policy(0, _a.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/dense/unit_test/Test_Batched_SerialSVD.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialSVD.hpp
@@ -406,13 +406,14 @@ void GenerateTestData(ViewT data) {
       });
 }
 
-template <typename Scalar, typename Layout, typename ExeSpace, int N = 3>
+template <typename Scalar, typename Layout, typename Device, int N = 3>
 void testIssue1786() {
-  using memory_space      = typename ExeSpace::memory_space;
+  using execution_space   = typename Device::execution_space;
+  using memory_space      = typename Device::memory_space;
   constexpr int num_tests = 4;
   Kokkos::View<Scalar * [3][3], Layout, memory_space> matrices("data",
                                                                num_tests);
-  GenerateTestData<ExeSpace>(matrices);
+  GenerateTestData<execution_space>(matrices);
   Kokkos::View<Scalar * [N][N], Layout, memory_space> Us("Us",
                                                          matrices.extent(0));
   Kokkos::View<Scalar * [N], Layout, memory_space> Ss("Ss", matrices.extent(0));
@@ -425,7 +426,7 @@ void testIssue1786() {
       "matrices_copy", matrices.extent(0));
   // make a copy of the input data to avoid overwriting it
   Kokkos::deep_copy(matrices_copy, matrices);
-  auto policy = Kokkos::RangePolicy<ExeSpace>(0, matrices.extent(0));
+  auto policy = Kokkos::RangePolicy<execution_space>(0, matrices.extent(0));
   Kokkos::parallel_for(
       "polar decomposition", policy, KOKKOS_LAMBDA(int i) {
         auto matrix_copy =

--- a/batched/dense/unit_test/Test_Batched_SerialSolveLU.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialSolveLU.hpp
@@ -44,6 +44,7 @@ struct ParamTag {
 template <typename DeviceType, typename ViewType, typename ScalarType,
           typename ParamTagType, typename AlgoTagType>
 struct Functor_BatchedSerialGemm {
+  using execution_space = typename DeviceType::execution_space;
   ViewType _a, _b, _c;
 
   ScalarType _alpha, _beta;
@@ -72,7 +73,7 @@ struct Functor_BatchedSerialGemm {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType, ParamTagType> policy(0, _c.extent(0));
+    Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, _c.extent(0));
     Kokkos::parallel_for((name + "::GemmFunctor").c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }
@@ -80,6 +81,7 @@ struct Functor_BatchedSerialGemm {
 
 template <typename DeviceType, typename ViewType, typename AlgoTagType>
 struct Functor_BatchedSerialLU {
+  using execution_space = typename DeviceType::execution_space;
   ViewType _a;
 
   KOKKOS_INLINE_FUNCTION
@@ -100,7 +102,7 @@ struct Functor_BatchedSerialLU {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType> policy(0, _a.extent(0));
+    Kokkos::RangePolicy<execution_space> policy(0, _a.extent(0));
     Kokkos::parallel_for((name + "::LUFunctor").c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }
@@ -109,6 +111,7 @@ struct Functor_BatchedSerialLU {
 template <typename DeviceType, typename ViewType, typename TransType,
           typename AlgoTagType>
 struct Functor_TestBatchedSerialSolveLU {
+  using execution_space = typename DeviceType::execution_space;
   ViewType _a;
   ViewType _b;
 
@@ -130,7 +133,7 @@ struct Functor_TestBatchedSerialSolveLU {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType> policy(0, _a.extent(0));
+    Kokkos::RangePolicy<execution_space> policy(0, _a.extent(0));
     Kokkos::parallel_for((name + "::SolveLUFunctor").c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/dense/unit_test/Test_Batched_SerialTrmm.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTrmm.hpp
@@ -113,6 +113,7 @@ struct ParamTag {
 template <typename DeviceType, typename ViewType, typename ScalarType,
           typename ParamTagType, typename AlgoTagType>
 struct Functor_TestBatchedSerialTrmm {
+  using execution_space = typename DeviceType::execution_space;
   ViewType _a, _b;
 
   ScalarType _alpha;
@@ -138,7 +139,7 @@ struct Functor_TestBatchedSerialTrmm {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType, ParamTagType> policy(0, _a.extent(0));
+    Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, _a.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/dense/unit_test/Test_Batched_SerialTrsm.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTrsm.hpp
@@ -40,6 +40,7 @@ struct ParamTag {
 template <typename DeviceType, typename ViewType, typename ScalarType,
           typename ParamTagType, typename AlgoTagType>
 struct Functor_TestBatchedSerialTrsm {
+  using execution_space = typename DeviceType::execution_space;
   ViewType _a, _b;
 
   ScalarType _alpha;
@@ -65,7 +66,7 @@ struct Functor_TestBatchedSerialTrsm {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType, ParamTagType> policy(0, _b.extent(0));
+    Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, _b.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/dense/unit_test/Test_Batched_SerialTrsv.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTrsv.hpp
@@ -39,6 +39,7 @@ struct ParamTag {
 template <typename DeviceType, typename ViewType, typename ScalarType,
           typename ParamTagType, typename AlgoTagType>
 struct Functor_TestBatchedSerialTrsv {
+  using execution_space = typename DeviceType::execution_space;
   ViewType _a, _b;
 
   ScalarType _alpha;
@@ -64,7 +65,7 @@ struct Functor_TestBatchedSerialTrsv {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType, ParamTagType> policy(0, _b.extent(0));
+    Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, _b.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/dense/unit_test/Test_Batched_SerialTrtri.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTrtri.hpp
@@ -113,6 +113,7 @@ struct ParamTag {
 template <typename DeviceType, typename ViewType, typename ParamTagType,
           typename AlgoTagType>
 struct Functor_TestBatchedSerialTrtri {
+  using execution_space = typename DeviceType::execution_space;
   ViewType _a;
 
   KOKKOS_INLINE_FUNCTION
@@ -132,7 +133,7 @@ struct Functor_TestBatchedSerialTrtri {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType, ParamTagType> policy(0, _a.extent(0));
+    Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, _a.extent(0));
     Kokkos::parallel_for("Functor_TestBatchedSerialTrtri", policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/dense/unit_test/Test_Batched_TeamAxpy.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamAxpy.hpp
@@ -30,6 +30,7 @@ namespace TeamAxpy {
 
 template <typename DeviceType, typename ViewType, typename alphaViewType>
 struct Functor_TestBatchedTeamAxpy {
+  using execution_space = typename DeviceType::execution_space;
   const alphaViewType _alpha;
   const ViewType _X;
   const ViewType _Y;
@@ -65,8 +66,8 @@ struct Functor_TestBatchedTeamAxpy {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::TeamPolicy<DeviceType> policy(_X.extent(0) / _N_team,
-                                          Kokkos::AUTO(), Kokkos::AUTO());
+    Kokkos::TeamPolicy<execution_space> policy(_X.extent(0) / _N_team,
+                                               Kokkos::AUTO(), Kokkos::AUTO());
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/dense/unit_test/Test_Batched_TeamGemm.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamGemm.hpp
@@ -41,6 +41,7 @@ struct ParamTag {
 template <typename DeviceType, typename ViewType, typename ScalarType,
           typename ParamTagType, typename AlgoTagType>
 struct Functor_TestBatchedTeamGemm {
+  using execution_space = typename DeviceType::execution_space;
   ViewType _a, _b, _c;
 
   ScalarType _alpha, _beta;
@@ -73,8 +74,8 @@ struct Functor_TestBatchedTeamGemm {
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     const int league_size = _c.extent(0);
-    Kokkos::TeamPolicy<DeviceType, ParamTagType> policy(league_size,
-                                                        Kokkos::AUTO);
+    Kokkos::TeamPolicy<execution_space, ParamTagType> policy(league_size,
+                                                             Kokkos::AUTO);
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/dense/unit_test/Test_Batched_TeamGesv.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamGesv.hpp
@@ -35,6 +35,7 @@ namespace TeamGesv {
 template <typename DeviceType, typename MatrixType, typename VectorType,
           typename AlgoTagType>
 struct Functor_TestBatchedTeamGesv {
+  using execution_space = typename DeviceType::execution_space;
   const MatrixType _A;
   const VectorType _X;
   const VectorType _B;
@@ -62,8 +63,8 @@ struct Functor_TestBatchedTeamGesv {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::TeamPolicy<DeviceType> policy(_X.extent(0), Kokkos::AUTO(),
-                                          Kokkos::AUTO());
+    Kokkos::TeamPolicy<execution_space> policy(_X.extent(0), Kokkos::AUTO(),
+                                               Kokkos::AUTO());
 
     using MatrixViewType =
         Kokkos::View<typename MatrixType::non_const_value_type **,

--- a/batched/dense/unit_test/Test_Batched_TeamInverseLU.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamInverseLU.hpp
@@ -44,6 +44,7 @@ struct ParamTag {
 template <typename DeviceType, typename ViewType, typename ScalarType,
           typename ParamTagType, typename AlgoTagType>
 struct Functor_BatchedTeamGemm {
+  using execution_space = typename DeviceType::execution_space;
   ViewType _a, _b, _c;
 
   ScalarType _alpha, _beta;
@@ -82,8 +83,8 @@ struct Functor_BatchedTeamGemm {
     Kokkos::Profiling::pushRegion(name.c_str());
 
     const int league_size = _c.extent(0);
-    Kokkos::TeamPolicy<DeviceType, ParamTagType> policy(league_size,
-                                                        Kokkos::AUTO);
+    Kokkos::TeamPolicy<execution_space, ParamTagType> policy(league_size,
+                                                             Kokkos::AUTO);
     Kokkos::parallel_for((name + "::GemmFunctor").c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/dense/unit_test/Test_Batched_TeamLU.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamLU.hpp
@@ -34,6 +34,8 @@ namespace TeamLU {
 
 template <typename DeviceType, typename ViewType, typename AlgoTagType>
 struct Functor_TestBatchedTeamLU {
+  using execution_space = typename DeviceType::execution_space;
+
   ViewType _a;
 
   KOKKOS_INLINE_FUNCTION
@@ -60,7 +62,7 @@ struct Functor_TestBatchedTeamLU {
     Kokkos::Profiling::pushRegion(name.c_str());
 
     const int league_size = _a.extent(0);
-    Kokkos::TeamPolicy<DeviceType> policy(league_size, Kokkos::AUTO);
+    Kokkos::TeamPolicy<execution_space> policy(league_size, Kokkos::AUTO);
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/dense/unit_test/Test_Batched_TeamSolveLU.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamSolveLU.hpp
@@ -44,6 +44,7 @@ struct ParamTag {
 template <typename DeviceType, typename ViewType, typename ScalarType,
           typename ParamTagType, typename AlgoTagType>
 struct Functor_BatchedTeamGemm {
+  using execution_space = typename DeviceType::execution_space;
   ViewType _a, _b, _c;
 
   ScalarType _alpha, _beta;
@@ -81,14 +82,15 @@ struct Functor_BatchedTeamGemm {
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     const int league_size = _c.extent(0);
-    Kokkos::TeamPolicy<DeviceType, ParamTagType> policy(league_size,
-                                                        Kokkos::AUTO);
+    Kokkos::TeamPolicy<execution_space, ParamTagType> policy(league_size,
+                                                             Kokkos::AUTO);
     Kokkos::parallel_for((name + "::GemmFunctor").c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }
 };
 template <typename DeviceType, typename ViewType, typename AlgoTagType>
 struct Functor_BatchedTeamLU {
+  using execution_space = typename DeviceType::execution_space;
   ViewType _a;
 
   KOKKOS_INLINE_FUNCTION
@@ -113,7 +115,7 @@ struct Functor_BatchedTeamLU {
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     const int league_size = _a.extent(0);
-    Kokkos::TeamPolicy<DeviceType> policy(league_size, Kokkos::AUTO);
+    Kokkos::TeamPolicy<execution_space> policy(league_size, Kokkos::AUTO);
     Kokkos::parallel_for((name + "::LUFunctor").c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }
@@ -121,6 +123,7 @@ struct Functor_BatchedTeamLU {
 template <typename DeviceType, typename ViewType, typename TransType,
           typename AlgoTagType>
 struct Functor_TestBatchedTeamSolveLU {
+  using execution_space = typename DeviceType::execution_space;
   ViewType _a;
   ViewType _b;
 
@@ -146,7 +149,7 @@ struct Functor_TestBatchedTeamSolveLU {
     Kokkos::Profiling::pushRegion(name.c_str());
 
     const int league_size = _a.extent(0);
-    Kokkos::TeamPolicy<DeviceType> policy(league_size, Kokkos::AUTO);
+    Kokkos::TeamPolicy<execution_space> policy(league_size, Kokkos::AUTO);
     Kokkos::parallel_for((name + "::SolveLU").c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/dense/unit_test/Test_Batched_TeamTrsm.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamTrsm.hpp
@@ -43,6 +43,7 @@ struct ParamTag {
 template <typename DeviceType, typename ViewType, typename ScalarType,
           typename ParamTagType, typename AlgoTagType>
 struct Functor_TestBatchedTeamTrsm {
+  using execution_space = typename DeviceType::execution_space;
   ViewType _a, _b;
 
   ScalarType _alpha;
@@ -74,8 +75,8 @@ struct Functor_TestBatchedTeamTrsm {
     Kokkos::Profiling::pushRegion(name.c_str());
 
     const int league_size = _b.extent(0);
-    Kokkos::TeamPolicy<DeviceType, ParamTagType> policy(league_size,
-                                                        Kokkos::AUTO);
+    Kokkos::TeamPolicy<execution_space, ParamTagType> policy(league_size,
+                                                             Kokkos::AUTO);
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/dense/unit_test/Test_Batched_TeamTrsv.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamTrsv.hpp
@@ -41,6 +41,7 @@ struct ParamTag {
 template <typename DeviceType, typename ViewType, typename ScalarType,
           typename ParamTagType, typename AlgoTagType>
 struct Functor_TestBatchedTeamTrsv {
+  using execution_space = typename DeviceType::execution_space;
   ViewType _a, _b;
 
   ScalarType _alpha;
@@ -72,8 +73,8 @@ struct Functor_TestBatchedTeamTrsv {
     Kokkos::Profiling::pushRegion(name.c_str());
 
     const int league_size = _b.extent(0);
-    Kokkos::TeamPolicy<DeviceType, ParamTagType> policy(league_size,
-                                                        Kokkos::AUTO);
+    Kokkos::TeamPolicy<execution_space, ParamTagType> policy(league_size,
+                                                             Kokkos::AUTO);
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/dense/unit_test/Test_Batched_TeamVectorAxpy.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorAxpy.hpp
@@ -30,6 +30,7 @@ namespace TeamVectorAxpy {
 
 template <typename DeviceType, typename ViewType, typename alphaViewType>
 struct Functor_TestBatchedTeamVectorAxpy {
+  using execution_space = typename DeviceType::execution_space;
   const alphaViewType _alpha;
   const ViewType _X;
   const ViewType _Y;
@@ -66,8 +67,8 @@ struct Functor_TestBatchedTeamVectorAxpy {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::TeamPolicy<DeviceType> policy(_X.extent(0) / _N_team,
-                                          Kokkos::AUTO(), Kokkos::AUTO());
+    Kokkos::TeamPolicy<execution_space> policy(_X.extent(0) / _N_team,
+                                               Kokkos::AUTO(), Kokkos::AUTO());
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/dense/unit_test/Test_Batched_TeamVectorEigendecomposition.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorEigendecomposition.hpp
@@ -74,7 +74,7 @@ name_value_type = ( std::is_same<value_type,float>::value ? "::Float" :
 "::ComplexFloat" : std::is_same<value_type,Kokkos::complex<double> >::value ?
 "::ComplexDouble" : "::UnknownValueType" ); std::string name = name_region +
 name_value_type; Kokkos::Profiling::pushRegion( name.c_str() );
-      Kokkos::TeamPolicy<DeviceType> policy(_A.extent(0), Kokkos::AUTO);
+      Kokkos::TeamPolicy<execution_space> policy(_A.extent(0), Kokkos::AUTO);
       Kokkos::parallel_for(name.c_str(), policy, *this);
       Kokkos::Profiling::popRegion();
     }

--- a/batched/dense/unit_test/Test_Batched_TeamVectorGemm.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorGemm.hpp
@@ -36,6 +36,7 @@ struct ParamTag {
 template <typename DeviceType, typename ViewType, typename ScalarType,
           typename ParamTagType, typename AlgoTagType>
 struct Functor_TestBatchedTeamVector {
+  using execution_space = typename DeviceType::execution_space;
   ViewType _a, _b, _c;
 
   ScalarType _alpha, _beta;
@@ -68,8 +69,8 @@ struct Functor_TestBatchedTeamVector {
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     const int league_size = _c.extent(0);
-    Kokkos::TeamPolicy<DeviceType, ParamTagType> policy(league_size,
-                                                        Kokkos::AUTO);
+    Kokkos::TeamPolicy<execution_space, ParamTagType> policy(league_size,
+                                                             Kokkos::AUTO);
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/dense/unit_test/Test_Batched_TeamVectorGesv.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorGesv.hpp
@@ -35,6 +35,7 @@ namespace TeamVectorGesv {
 template <typename DeviceType, typename MatrixType, typename VectorType,
           typename AlgoTagType>
 struct Functor_TestBatchedTeamVectorGesv {
+  using execution_space = typename DeviceType::execution_space;
   const MatrixType _A;
   const VectorType _X;
   const VectorType _B;
@@ -63,8 +64,8 @@ struct Functor_TestBatchedTeamVectorGesv {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::TeamPolicy<DeviceType> policy(_X.extent(0), Kokkos::AUTO(),
-                                          Kokkos::AUTO());
+    Kokkos::TeamPolicy<execution_space> policy(_X.extent(0), Kokkos::AUTO(),
+                                               Kokkos::AUTO());
 
     using MatrixViewType =
         Kokkos::View<typename MatrixType::non_const_value_type **,

--- a/batched/dense/unit_test/Test_Batched_TeamVectorQR.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorQR.hpp
@@ -35,6 +35,7 @@ namespace Test {
 template <typename DeviceType, typename MatrixViewType, typename VectorViewType,
           typename WorkViewType, typename AlgoTagType>
 struct Functor_TestBatchedTeamVectorQR {
+  using execution_space = typename DeviceType::execution_space;
   MatrixViewType _a;
   VectorViewType _x, _b, _t;
   WorkViewType _w;
@@ -99,7 +100,7 @@ struct Functor_TestBatchedTeamVectorQR {
     Kokkos::Profiling::pushRegion(name.c_str());
 
     const int league_size = _a.extent(0);
-    Kokkos::TeamPolicy<DeviceType> policy(league_size, Kokkos::AUTO);
+    Kokkos::TeamPolicy<execution_space> policy(league_size, Kokkos::AUTO);
 
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();

--- a/batched/dense/unit_test/Test_Batched_TeamVectorQR_WithColumnPivoting.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorQR_WithColumnPivoting.hpp
@@ -35,6 +35,7 @@ namespace Test {
 template <typename DeviceType, typename MatrixViewType, typename VectorViewType,
           typename PivotViewType, typename WorkViewType, typename AlgoTagType>
 struct Functor_TestBatchedTeamVectorQR_WithColumnPivoting {
+  using execution_space = typename DeviceType::execution_space;
   MatrixViewType _a;
   VectorViewType _x, _b, _t;
   PivotViewType _p;
@@ -108,7 +109,7 @@ struct Functor_TestBatchedTeamVectorQR_WithColumnPivoting {
     Kokkos::Profiling::pushRegion(name.c_str());
 
     const int league_size = _a.extent(0);
-    Kokkos::TeamPolicy<DeviceType> policy(league_size, Kokkos::AUTO);
+    Kokkos::TeamPolicy<execution_space> policy(league_size, Kokkos::AUTO);
 
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();

--- a/batched/dense/unit_test/Test_Batched_TeamVectorSolveUTV.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorSolveUTV.hpp
@@ -35,6 +35,7 @@ namespace Test {
 template <typename DeviceType, typename MatrixViewType, typename VectorViewType,
           typename PivViewType, typename WorkViewType, typename AlgoTagType>
 struct Functor_TestBatchedTeamVectorSolveUTV {
+  using execution_space = typename DeviceType::execution_space;
   MatrixViewType _r, _a, _acopy, _u, _v;
   PivViewType _p;
   VectorViewType _x, _b;
@@ -121,7 +122,7 @@ struct Functor_TestBatchedTeamVectorSolveUTV {
     Kokkos::Profiling::pushRegion(name.c_str());
 
     const int league_size = _a.extent(0);
-    Kokkos::TeamPolicy<DeviceType> policy(league_size, Kokkos::AUTO);
+    Kokkos::TeamPolicy<execution_space> policy(league_size, Kokkos::AUTO);
 
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();

--- a/batched/dense/unit_test/Test_Batched_TeamVectorSolveUTV2.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorSolveUTV2.hpp
@@ -35,6 +35,7 @@ namespace Test {
 template <typename DeviceType, typename MatrixViewType, typename VectorViewType,
           typename PivViewType, typename WorkViewType, typename AlgoTagType>
 struct Functor_TestBatchedTeamVectorSolveUTV2 {
+  using execution_space = typename DeviceType::execution_space;
   MatrixViewType _r, _a, _acopy, _u, _v;
   PivViewType _p;
   VectorViewType _x, _b;
@@ -125,7 +126,7 @@ struct Functor_TestBatchedTeamVectorSolveUTV2 {
     Kokkos::Profiling::pushRegion(name.c_str());
 
     const int league_size = _a.extent(0);
-    Kokkos::TeamPolicy<DeviceType> policy(league_size, Kokkos::AUTO);
+    Kokkos::TeamPolicy<execution_space> policy(league_size, Kokkos::AUTO);
 
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();

--- a/batched/dense/unit_test/Test_Batched_TeamVectorUTV.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorUTV.hpp
@@ -34,6 +34,7 @@ namespace Test {
 template <typename DeviceType, typename MatrixViewType, typename VectorViewType,
           typename PivViewType, typename WorkViewType, typename AlgoTagType>
 struct Functor_TestBatchedTeamVectorUTV {
+  using execution_space = typename DeviceType::execution_space;
   MatrixViewType _r, _a, _acopy, _u, _v;
   PivViewType _p;
   VectorViewType _x, _b;
@@ -155,7 +156,7 @@ struct Functor_TestBatchedTeamVectorUTV {
     Kokkos::Profiling::pushRegion(name.c_str());
 
     const int league_size = _a.extent(0);
-    Kokkos::TeamPolicy<DeviceType> policy(league_size, Kokkos::AUTO);
+    Kokkos::TeamPolicy<execution_space> policy(league_size, Kokkos::AUTO);
 
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();

--- a/batched/sparse/unit_test/Test_Batched_SerialGMRES.hpp
+++ b/batched/sparse/unit_test/Test_Batched_SerialGMRES.hpp
@@ -32,6 +32,7 @@ namespace GMRES {
 template <typename DeviceType, typename ValuesViewType, typename IntView,
           typename VectorViewType, typename KrylovHandleType>
 struct Functor_TestBatchedSerialGMRES {
+  using execution_space = typename DeviceType::execution_space;
   const ValuesViewType _D;
   const IntView _r;
   const IntView _c;
@@ -85,7 +86,7 @@ struct Functor_TestBatchedSerialGMRES {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType> policy(0, _D.extent(0) / _N_team);
+    Kokkos::RangePolicy<execution_space> policy(0, _D.extent(0) / _N_team);
 
     const int N                 = _D.extent(0);
     const int n                 = _X.extent(1);

--- a/batched/sparse/unit_test/Test_Batched_SerialSpmv.hpp
+++ b/batched/sparse/unit_test/Test_Batched_SerialSpmv.hpp
@@ -41,6 +41,7 @@ template <typename DeviceType, typename ParamTagType, typename ValuesViewType,
           typename IntView, typename xViewType, typename yViewType,
           typename alphaViewType, typename betaViewType, int dobeta>
 struct Functor_TestBatchedSerialSpmv {
+  using execution_space = typename DeviceType::execution_space;
   const alphaViewType _alpha;
   const ValuesViewType _D;
   const IntView _r;
@@ -75,7 +76,7 @@ struct Functor_TestBatchedSerialSpmv {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType, ParamTagType> policy(0, _D.extent(0));
+    Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, _D.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }

--- a/batched/sparse/unit_test/Test_Batched_TeamCG.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamCG.hpp
@@ -31,6 +31,7 @@ namespace TeamCG {
 template <typename DeviceType, typename ValuesViewType, typename IntView,
           typename VectorViewType, typename KrylovHandleType>
 struct Functor_TestBatchedTeamCG {
+  using execution_space = typename DeviceType::execution_space;
   const ValuesViewType _D;
   const IntView _r;
   const IntView _c;
@@ -79,8 +80,8 @@ struct Functor_TestBatchedTeamCG {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::TeamPolicy<DeviceType> policy(_D.extent(0) / _N_team,
-                                          Kokkos::AUTO(), Kokkos::AUTO());
+    Kokkos::TeamPolicy<execution_space> policy(_D.extent(0) / _N_team,
+                                               Kokkos::AUTO(), Kokkos::AUTO());
 
     size_t bytes_0 = ValuesViewType::shmem_size(_N_team, _X.extent(1));
     size_t bytes_1 = ValuesViewType::shmem_size(_N_team, 1);

--- a/batched/sparse/unit_test/Test_Batched_TeamGMRES.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamGMRES.hpp
@@ -32,6 +32,7 @@ namespace TeamGMRES {
 template <typename DeviceType, typename ValuesViewType, typename IntView,
           typename VectorViewType, typename KrylovHandleType>
 struct Functor_TestBatchedTeamGMRES {
+  using execution_space = typename DeviceType::execution_space;
   const ValuesViewType _D;
   const IntView _r;
   const IntView _c;
@@ -91,8 +92,8 @@ struct Functor_TestBatchedTeamGMRES {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::TeamPolicy<DeviceType> policy(_D.extent(0) / _N_team,
-                                          Kokkos::AUTO(), Kokkos::AUTO());
+    Kokkos::TeamPolicy<execution_space> policy(_D.extent(0) / _N_team,
+                                               Kokkos::AUTO(), Kokkos::AUTO());
 
     const int N                 = _D.extent(0);
     const int n                 = _X.extent(1);

--- a/batched/sparse/unit_test/Test_Batched_TeamSpmv.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamSpmv.hpp
@@ -42,6 +42,7 @@ template <typename DeviceType, typename ParamTagType, typename ValuesViewType,
           typename IntView, typename xViewType, typename yViewType,
           typename alphaViewType, typename betaViewType, int dobeta>
 struct Functor_TestBatchedTeamSpmv {
+  using execution_space = typename DeviceType::execution_space;
   const alphaViewType _alpha;
   const ValuesViewType _D;
   const IntView _r;
@@ -99,7 +100,7 @@ struct Functor_TestBatchedTeamSpmv {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::TeamPolicy<DeviceType, ParamTagType> policy(
+    Kokkos::TeamPolicy<execution_space, ParamTagType> policy(
         _D.extent(0) / _N_team, Kokkos::AUTO(), Kokkos::AUTO());
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();

--- a/batched/sparse/unit_test/Test_Batched_TeamVectorCG.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamVectorCG.hpp
@@ -31,6 +31,7 @@ namespace TeamVectorCG {
 template <typename DeviceType, typename ValuesViewType, typename IntView,
           typename VectorViewType, typename KrylovHandleType>
 struct Functor_TestBatchedTeamVectorCG {
+  using execution_space = typename DeviceType::execution_space;
   const ValuesViewType _D;
   const IntView _r;
   const IntView _c;
@@ -81,8 +82,8 @@ struct Functor_TestBatchedTeamVectorCG {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::TeamPolicy<DeviceType> policy(_D.extent(0) / _N_team,
-                                          Kokkos::AUTO(), Kokkos::AUTO());
+    Kokkos::TeamPolicy<execution_space> policy(_D.extent(0) / _N_team,
+                                               Kokkos::AUTO(), Kokkos::AUTO());
 
     size_t bytes_0 = ValuesViewType::shmem_size(_N_team, _X.extent(1));
     size_t bytes_1 = ValuesViewType::shmem_size(_N_team, 1);

--- a/batched/sparse/unit_test/Test_Batched_TeamVectorGMRES.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamVectorGMRES.hpp
@@ -32,6 +32,7 @@ namespace TeamVectorGMRES {
 template <typename DeviceType, typename ValuesViewType, typename IntView,
           typename VectorViewType, typename KrylovHandleType>
 struct Functor_TestBatchedTeamVectorGMRES {
+  using execution_space = typename DeviceType::execution_space;
   const ValuesViewType _D;
   const IntView _r;
   const IntView _c;
@@ -91,8 +92,8 @@ struct Functor_TestBatchedTeamVectorGMRES {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::TeamPolicy<DeviceType> policy(_D.extent(0) / _N_team,
-                                          Kokkos::AUTO(), Kokkos::AUTO());
+    Kokkos::TeamPolicy<execution_space> policy(_D.extent(0) / _N_team,
+                                               Kokkos::AUTO(), Kokkos::AUTO());
 
     const int N                 = _D.extent(0);
     const int n                 = _X.extent(1);

--- a/batched/sparse/unit_test/Test_Batched_TeamVectorSpmv.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamVectorSpmv.hpp
@@ -42,6 +42,7 @@ template <typename DeviceType, typename ParamTagType, typename ValuesViewType,
           typename IntView, typename xViewType, typename yViewType,
           typename alphaViewType, typename betaViewType, int dobeta>
 struct Functor_TestBatchedTeamVectorSpmv {
+  using execution_space = typename DeviceType::execution_space;
   const alphaViewType _alpha;
   const ValuesViewType _D;
   const IntView _r;
@@ -106,7 +107,7 @@ struct Functor_TestBatchedTeamVectorSpmv {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::TeamPolicy<DeviceType, ParamTagType> policy(
+    Kokkos::TeamPolicy<execution_space, ParamTagType> policy(
         ceil(static_cast<double>(_D.extent(0)) / _N_team), Kokkos::AUTO(),
         Kokkos::AUTO());
     Kokkos::parallel_for(name.c_str(), policy, *this);

--- a/blas/unit_test/Test_Blas1_rotg.hpp
+++ b/blas/unit_test/Test_Blas1_rotg.hpp
@@ -16,12 +16,12 @@
 #include <KokkosBlas1_rotg.hpp>
 
 namespace Test {
-template <class ExecSpace, class Scalar>
-void test_rotg_impl(ExecSpace const& space, Scalar const a_in,
-                    Scalar const b_in) {
+template <class Device, class Scalar>
+void test_rotg_impl(typename Device::execution_space const& space,
+                    Scalar const a_in, Scalar const b_in) {
   using magnitude_type = typename Kokkos::ArithTraits<Scalar>::mag_type;
-  using SViewType      = Kokkos::View<Scalar, ExecSpace>;
-  using MViewType      = Kokkos::View<magnitude_type, ExecSpace>;
+  using SViewType      = Kokkos::View<Scalar, Device>;
+  using MViewType      = Kokkos::View<magnitude_type, Device>;
 
   // const magnitude_type eps = Kokkos::ArithTraits<Scalar>::eps();
   // const Scalar zero        = Kokkos::ArithTraits<Scalar>::zero();
@@ -43,17 +43,17 @@ void test_rotg_impl(ExecSpace const& space, Scalar const a_in,
 }
 }  // namespace Test
 
-template <class Scalar, class ExecutionSpace>
+template <class Scalar, class Device>
 int test_rotg() {
   const Scalar zero = Kokkos::ArithTraits<Scalar>::zero();
   const Scalar one  = Kokkos::ArithTraits<Scalar>::one();
   const Scalar two  = one + one;
 
-  ExecutionSpace space{};
+  typename Device::execution_space space{};
 
-  Test::test_rotg_impl(space, one, zero);
-  Test::test_rotg_impl(space, one / two, one / two);
-  Test::test_rotg_impl(space, 2.1 * one, 1.3 * one);
+  Test::test_rotg_impl<Device, Scalar>(space, one, zero);
+  Test::test_rotg_impl<Device, Scalar>(space, one / two, one / two);
+  Test::test_rotg_impl<Device, Scalar>(space, 2.1 * one, 1.3 * one);
 
   return 1;
 }

--- a/blas/unit_test/Test_Blas1_rotmg.hpp
+++ b/blas/unit_test/Test_Blas1_rotmg.hpp
@@ -218,14 +218,10 @@ void set_rotmg_input_ref_vals(const int test_case, View0& d1, View0& d2,
 }
 }  // namespace Test
 
-template <class Scalar, class ExecutionSpace>
+template <class Scalar, class Device>
 int test_rotmg() {
-  Kokkos::View<Scalar, Kokkos::Device<ExecutionSpace,
-                                      typename ExecutionSpace::memory_space>>
-      d1("d1"), d2("d2"), x1("x1"), y1("y1");
-  Kokkos::View<Scalar[5], Kokkos::Device<ExecutionSpace,
-                                         typename ExecutionSpace::memory_space>>
-      param("param");
+  Kokkos::View<Scalar, Device> d1("d1"), d2("d2"), x1("x1"), y1("y1");
+  Kokkos::View<Scalar[5], Device> param("param");
   Kokkos::View<Scalar[9], Kokkos::DefaultHostExecutionSpace> ref_vals(
       "reference values");
 

--- a/blas/unit_test/Test_Blas1_serial_setscal.hpp
+++ b/blas/unit_test/Test_Blas1_serial_setscal.hpp
@@ -87,7 +87,8 @@ struct Functor_TestBlasSerialMatUtil {
     std::string name =
         name_region + name_value_type + name_work_tag + name_test_id;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType, AlgoTagType> policy(0, _a.extent(0));
+    Kokkos::RangePolicy<typename DeviceType::execution_space, AlgoTagType>
+        policy(0, _a.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
     return 0;

--- a/blas/unit_test/Test_Blas1_team_abs.hpp
+++ b/blas/unit_test/Test_Blas1_team_abs.hpp
@@ -29,7 +29,8 @@
 namespace Test {
 template <class ViewTypeA, class ViewTypeB, class Device>
 void impl_test_team_abs(int N) {
-  typedef Kokkos::TeamPolicy<Device> team_policy;
+  using execution_space = typename Device::execution_space;
+  typedef Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
 
   // Launch M teams of the maximum number of threads per team
@@ -109,7 +110,8 @@ void impl_test_team_abs(int N) {
 
 template <class ViewTypeA, class ViewTypeB, class Device>
 void impl_test_team_abs_mv(int N, int K) {
-  typedef Kokkos::TeamPolicy<Device> team_policy;
+  using execution_space = typename Device::execution_space;
+  typedef Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
 
   // Launch K teams of the maximum number of threads per team
@@ -122,8 +124,7 @@ void impl_test_team_abs_mv(int N, int K) {
   view_stride_adapter<ViewTypeA> x("X", N, K);
   view_stride_adapter<ViewTypeB> y("Y", N, K);
 
-  Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
-      13718);
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
   Kokkos::fill_random(x.d_view, rand_pool, ScalarA(1));
   Kokkos::fill_random(y.d_view, rand_pool, ScalarB(1));

--- a/blas/unit_test/Test_Blas1_team_axpby.hpp
+++ b/blas/unit_test/Test_Blas1_team_axpby.hpp
@@ -29,7 +29,8 @@
 namespace Test {
 template <class ViewTypeA, class ViewTypeB, class Device>
 void impl_test_team_axpby(int N) {
-  typedef Kokkos::TeamPolicy<Device> team_policy;
+  using execution_space = typename Device::execution_space;
+  typedef Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
 
   // Launch M teams of the maximum number of threads per team
@@ -48,8 +49,7 @@ void impl_test_team_axpby(int N) {
   view_stride_adapter<ViewTypeB> y("Y", N);
   view_stride_adapter<ViewTypeB> org_y("Y", N);
 
-  Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
-      13718);
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
   Kokkos::fill_random(x.d_view, rand_pool, ScalarA(10));
   Kokkos::fill_random(y.d_view, rand_pool, ScalarB(10));
@@ -116,7 +116,8 @@ void impl_test_team_axpby(int N) {
 
 template <class ViewTypeA, class ViewTypeB, class Device>
 void impl_test_team_axpby_mv(int N, int K) {
-  typedef Kokkos::TeamPolicy<Device> team_policy;
+  using execution_space = typename Device::execution_space;
+  typedef Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
 
   // Launch K teams of the maximum number of threads per team
@@ -129,8 +130,7 @@ void impl_test_team_axpby_mv(int N, int K) {
   view_stride_adapter<ViewTypeB> y("Y", N, K);
   view_stride_adapter<ViewTypeB> org_y("Org_Y", N, K);
 
-  Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
-      13718);
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
   Kokkos::fill_random(x.d_view, rand_pool, ScalarA(10));
   Kokkos::fill_random(y.d_view, rand_pool, ScalarB(10));

--- a/blas/unit_test/Test_Blas1_team_axpy.hpp
+++ b/blas/unit_test/Test_Blas1_team_axpy.hpp
@@ -29,7 +29,8 @@
 namespace Test {
 template <class ViewTypeA, class ViewTypeB, class Device>
 void impl_test_team_axpy(int N) {
-  typedef Kokkos::TeamPolicy<Device> team_policy;
+  using execution_space = typename Device::execution_space;
+  typedef Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
 
   // Launch M teams of the maximum number of threads per team
@@ -113,7 +114,8 @@ void impl_test_team_axpy(int N) {
 
 template <class ViewTypeA, class ViewTypeB, class Device>
 void impl_test_team_axpy_mv(int N, int K) {
-  typedef Kokkos::TeamPolicy<Device> team_policy;
+  using execution_space = typename Device::execution_space;
+  typedef Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
 
   // Launch K teams of the maximum number of threads per team
@@ -126,8 +128,7 @@ void impl_test_team_axpy_mv(int N, int K) {
   view_stride_adapter<ViewTypeB> y("Y", N, K);
   view_stride_adapter<ViewTypeB> org_y("Org_Y", N, K);
 
-  Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
-      13718);
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
   Kokkos::fill_random(x.d_view, rand_pool, ScalarA(10));
   Kokkos::fill_random(y.d_view, rand_pool, ScalarB(10));

--- a/blas/unit_test/Test_Blas1_team_dot.hpp
+++ b/blas/unit_test/Test_Blas1_team_dot.hpp
@@ -28,7 +28,8 @@
 namespace Test {
 template <class ViewTypeA, class ViewTypeB, class Device>
 void impl_test_team_dot(int N) {
-  typedef Kokkos::TeamPolicy<Device> team_policy;
+  using execution_space = typename Device::execution_space;
+  typedef Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
 
   // Launch M teams of the maximum number of threads per team
@@ -42,8 +43,7 @@ void impl_test_team_dot(int N) {
   view_stride_adapter<ViewTypeA> a("a", N);
   view_stride_adapter<ViewTypeB> b("b", N);
 
-  Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
-      13718);
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
   Kokkos::fill_random(a.d_view, rand_pool, ScalarA(10));
   Kokkos::fill_random(b.d_view, rand_pool, ScalarB(10));
@@ -161,7 +161,8 @@ void impl_test_team_dot(int N) {
 
 template <class ViewTypeA, class ViewTypeB, class Device>
 void impl_test_team_dot_mv(int N, int K) {
-  typedef Kokkos::TeamPolicy<Device> team_policy;
+  using execution_space = typename Device::execution_space;
+  typedef Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
 
   // Launch K teams of the maximum number of threads per team
@@ -173,8 +174,7 @@ void impl_test_team_dot_mv(int N, int K) {
   view_stride_adapter<ViewTypeA> a("A", N, K);
   view_stride_adapter<ViewTypeB> b("B", N, K);
 
-  Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
-      13718);
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
   Kokkos::fill_random(a.d_view, rand_pool, ScalarA(10));
   Kokkos::fill_random(b.d_view, rand_pool, ScalarB(10));

--- a/blas/unit_test/Test_Blas1_team_mult.hpp
+++ b/blas/unit_test/Test_Blas1_team_mult.hpp
@@ -29,7 +29,8 @@
 namespace Test {
 template <class ViewTypeA, class ViewTypeB, class ViewTypeC, class Device>
 void impl_test_team_mult(int N) {
-  typedef Kokkos::TeamPolicy<Device> team_policy;
+  using execution_space = typename Device::execution_space;
+  typedef Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
 
   // Launch M teams of the maximum number of threads per team
@@ -50,8 +51,7 @@ void impl_test_team_mult(int N) {
   view_stride_adapter<ViewTypeC> z("Z", N);
   view_stride_adapter<ViewTypeC> org_z("Org_Z", N);
 
-  Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
-      13718);
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
   Kokkos::fill_random(x.d_view, rand_pool, ScalarA(10));
   Kokkos::fill_random(y.d_view, rand_pool, ScalarB(10));
@@ -158,7 +158,8 @@ void impl_test_team_mult(int N) {
 
 template <class ViewTypeA, class ViewTypeB, class ViewTypeC, class Device>
 void impl_test_team_mult_mv(int N, int K) {
-  typedef Kokkos::TeamPolicy<Device> team_policy;
+  using execution_space = typename Device::execution_space;
+  typedef Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
 
   // Launch K teams of the maximum number of threads per team
@@ -174,8 +175,7 @@ void impl_test_team_mult_mv(int N, int K) {
   view_stride_adapter<ViewTypeC> z("Z", N, K);
   view_stride_adapter<ViewTypeC> org_z("Org_Z", N, K);
 
-  Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
-      13718);
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
   typename Kokkos::ArithTraits<ScalarC>::mag_type const max_val = 10;
   Kokkos::fill_random(x.d_view, rand_pool, ScalarA(max_val));

--- a/blas/unit_test/Test_Blas1_team_nrm2.hpp
+++ b/blas/unit_test/Test_Blas1_team_nrm2.hpp
@@ -28,7 +28,8 @@
 namespace Test {
 template <class ViewTypeA, class Device>
 void impl_test_team_nrm2(int N, int K) {
-  typedef Kokkos::TeamPolicy<Device> team_policy;
+  using execution_space = typename Device::execution_space;
+  typedef Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
 
   // Launch K teams of the maximum number of threads per team
@@ -39,8 +40,7 @@ void impl_test_team_nrm2(int N, int K) {
 
   view_stride_adapter<ViewTypeA> a("A", N, K);
 
-  Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
-      13718);
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
   Kokkos::fill_random(a.d_view, rand_pool, ScalarA(10));
 

--- a/blas/unit_test/Test_Blas1_team_scal.hpp
+++ b/blas/unit_test/Test_Blas1_team_scal.hpp
@@ -29,7 +29,8 @@
 namespace Test {
 template <class ViewTypeA, class ViewTypeB, class Device>
 void impl_test_team_scal(int N) {
-  typedef Kokkos::TeamPolicy<Device> team_policy;
+  using execution_space = typename Device::execution_space;
+  typedef Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
 
   // Launch M teams of the maximum number of threads per team
@@ -49,8 +50,7 @@ void impl_test_team_scal(int N) {
   typename AT::mag_type zero = AT::abs(AT::zero());
   typename AT::mag_type one  = AT::abs(AT::one());
 
-  Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
-      13718);
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
   Kokkos::fill_random(x.d_view, rand_pool, ScalarA(1));
 
@@ -122,7 +122,8 @@ void impl_test_team_scal(int N) {
 
 template <class ViewTypeA, class ViewTypeB, class Device>
 void impl_test_team_scal_mv(int N, int K) {
-  typedef Kokkos::TeamPolicy<Device> team_policy;
+  using execution_space = typename Device::execution_space;
+  typedef Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
 
   // Launch K teams of the maximum number of threads per team
@@ -135,8 +136,7 @@ void impl_test_team_scal_mv(int N, int K) {
   view_stride_adapter<ViewTypeA> x("X", N, K);
   view_stride_adapter<ViewTypeB> y("Y", N, K);
 
-  Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
-      13718);
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
   Kokkos::fill_random(x.d_view, rand_pool, ScalarA(1));
   Kokkos::deep_copy(x.h_base, x.d_base);

--- a/blas/unit_test/Test_Blas1_team_setscal.hpp
+++ b/blas/unit_test/Test_Blas1_team_setscal.hpp
@@ -36,6 +36,7 @@ struct NaiveTag {};
 template <typename DeviceType, typename ViewType, typename ScalarType,
           typename AlgoTagType, int TestID>
 struct Functor_TestBlasTeamMatUtil {
+  using execution_space = typename DeviceType::execution_space;
   ScalarType _alpha;
   ViewType _a;
 
@@ -97,8 +98,8 @@ struct Functor_TestBlasTeamMatUtil {
     Kokkos::Profiling::pushRegion(name.c_str());
 
     const int league_size = _a.extent(0);
-    Kokkos::TeamPolicy<DeviceType, AlgoTagType> policy(league_size,
-                                                       Kokkos::AUTO);
+    Kokkos::TeamPolicy<execution_space, AlgoTagType> policy(league_size,
+                                                            Kokkos::AUTO);
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
 

--- a/blas/unit_test/Test_Blas1_team_update.hpp
+++ b/blas/unit_test/Test_Blas1_team_update.hpp
@@ -29,7 +29,8 @@
 namespace Test {
 template <class ViewTypeA, class ViewTypeB, class ViewTypeC, class Device>
 void impl_test_team_update(int N) {
-  typedef Kokkos::TeamPolicy<Device> team_policy;
+  using execution_space = typename Device::execution_space;
+  typedef Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
 
   // Launch M teams of the maximum number of threads per team
@@ -51,8 +52,7 @@ void impl_test_team_update(int N) {
   view_stride_adapter<ViewTypeC> z("Z", N);
   view_stride_adapter<ViewTypeC> org_z("Org_Z", N);
 
-  Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
-      13718);
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
   Kokkos::fill_random(x.d_view, rand_pool, ScalarA(10));
   Kokkos::fill_random(y.d_view, rand_pool, ScalarB(10));
@@ -160,7 +160,8 @@ void impl_test_team_update(int N) {
 
 template <class ViewTypeA, class ViewTypeB, class ViewTypeC, class Device>
 void impl_test_team_update_mv(int N, int K) {
-  typedef Kokkos::TeamPolicy<Device> team_policy;
+  using execution_space = typename Device::execution_space;
+  typedef Kokkos::TeamPolicy<execution_space> team_policy;
   typedef typename team_policy::member_type team_member;
 
   // Launch K teams of the maximum number of threads per team
@@ -175,8 +176,7 @@ void impl_test_team_update_mv(int N, int K) {
   view_stride_adapter<ViewTypeC> z("Z", N, K);
   view_stride_adapter<ViewTypeC> org_z("Org_Z", N, K);
 
-  Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(
-      13718);
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
   Kokkos::fill_random(x.d_view, rand_pool, ScalarA(10));
   Kokkos::fill_random(y.d_view, rand_pool, ScalarB(10));

--- a/blas/unit_test/Test_Blas2_gemv_util.hpp
+++ b/blas/unit_test/Test_Blas2_gemv_util.hpp
@@ -239,7 +239,8 @@ struct GEMVTest {
   template <class AlgoTag, class ViewTypeA, class ViewTypeX, class ViewTypeY>
   static void run_views(const char trans, ViewTypeA A, ViewTypeX x,
                         ViewTypeY y) {
-    Kokkos::TeamPolicy<Device> teams(1, 1);  // just run on device
+    Kokkos::TeamPolicy<typename Device::execution_space> teams(
+        1, 1);  // just run on device
     fill_inputs(A, x, y);
     ScalarType alpha = 3;  // TODO: test also with zero alpha/beta ?
     ScalarType beta  = 5;
@@ -279,7 +280,8 @@ struct GEMVTest {
                                                  ViewTypeY, Device, ScalarType>;
 
     op_type gemv_op(trans, alpha, A, x, beta, y);
-    Kokkos::parallel_for(Kokkos::TeamPolicy<Device>(1, 1), gemv_op);
+    Kokkos::parallel_for(
+        Kokkos::TeamPolicy<typename Device::execution_space>(1, 1), gemv_op);
 
     const double eps = epsilon(ScalarY{});
     EXPECT_NEAR_KK_REL_1DVIEW(y, y_ref, eps);

--- a/blas/unit_test/Test_Blas3_gemm.hpp
+++ b/blas/unit_test/Test_Blas3_gemm.hpp
@@ -81,7 +81,7 @@ void build_matrices(const int M, const int N, const int K,
                     const typename ViewTypeA::value_type alpha, ViewTypeA& A,
                     ViewTypeB& B, const typename ViewTypeA::value_type beta,
                     ViewTypeC& C, ViewTypeC& Cref) {
-  using execution_space = TestExecSpace;
+  using execution_space = typename TestExecSpace::execution_space;
   using ScalarA         = typename ViewTypeA::non_const_value_type;
   using ScalarB         = typename ViewTypeB::non_const_value_type;
   using ScalarC         = typename ViewTypeC::non_const_value_type;
@@ -257,15 +257,16 @@ void impl_test_gemm(const char* TA, const char* TB, int M, int N, int K,
   }
 }
 
-template <typename Scalar, typename Layout, typename execution_space>
+template <typename Scalar, typename Layout, typename Device>
 void impl_test_stream_gemm_psge2(const int M, const int N, const int K,
                                  const Scalar alpha, const Scalar beta) {
-  using ViewTypeA = Kokkos::View<Scalar**, Layout, TestExecSpace>;
-  using ViewTypeB = Kokkos::View<Scalar**, Layout, TestExecSpace>;
-  using ViewTypeC = Kokkos::View<Scalar**, Layout, TestExecSpace>;
-  using ScalarC   = typename ViewTypeC::value_type;
-  using APT       = Kokkos::ArithTraits<ScalarC>;
-  using mag_type  = typename APT::mag_type;
+  using execution_space = typename Device::execution_space;
+  using ViewTypeA       = Kokkos::View<Scalar**, Layout, Device>;
+  using ViewTypeB       = Kokkos::View<Scalar**, Layout, Device>;
+  using ViewTypeC       = Kokkos::View<Scalar**, Layout, Device>;
+  using ScalarC         = typename ViewTypeC::value_type;
+  using APT             = Kokkos::ArithTraits<ScalarC>;
+  using mag_type        = typename APT::mag_type;
 
   const char tA[]          = {"N"};
   const char tB[]          = {"N"};
@@ -336,6 +337,7 @@ void impl_test_stream_gemm_psge2(const int M, const int N, const int K,
 
 template <typename Scalar, typename Layout>
 void test_gemm() {
+  typedef typename TestExecSpace::execution_space execution_space;
   typedef Kokkos::View<Scalar**, Layout, TestExecSpace> view_type_a;
   typedef Kokkos::View<Scalar**, Layout, TestExecSpace> view_type_b;
   typedef Kokkos::View<Scalar**, Layout, TestExecSpace> view_type_c;
@@ -371,7 +373,7 @@ void test_gemm() {
       }
     }
   }
-  auto pool_size = TestExecSpace().concurrency();
+  auto pool_size = execution_space().concurrency();
   if (pool_size >= 2) {
     Test::impl_test_stream_gemm_psge2<Scalar, Layout, TestExecSpace>(
         53, 42, 17, 4.5,

--- a/blas/unit_test/Test_Blas_serial_axpy.hpp
+++ b/blas/unit_test/Test_Blas_serial_axpy.hpp
@@ -32,6 +32,7 @@ struct NaiveAxpyTag {};
 template <typename DeviceType, typename ViewType, typename ScalarType,
           typename AlgoTagType>
 struct Functor_TestBlasSerialAxpy {
+  using execution_space = typename DeviceType::execution_space;
   ScalarType _alpha;
   ViewType _x;
   ViewType _y;
@@ -71,7 +72,7 @@ struct Functor_TestBlasSerialAxpy {
     std::string name =
         name_region + name_value_type + name_work_tag + name_test_id;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType, AlgoTagType> policy(0, _x.extent(0));
+    Kokkos::RangePolicy<execution_space, AlgoTagType> policy(0, _x.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
     return;

--- a/blas/unit_test/Test_Blas_serial_nrm2.hpp
+++ b/blas/unit_test/Test_Blas_serial_nrm2.hpp
@@ -70,7 +70,7 @@ struct Functor_TestBlasSerialNrm2 {
     std::string name =
         name_region + name_value_type + name_work_tag + name_test_id;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType, AlgoTagType> policy(0, _x.extent(0));
+    Kokkos::RangePolicy<execution_space, AlgoTagType> policy(0, _x.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
     return;
@@ -125,7 +125,7 @@ struct Functor_TestBlasSerialNrm2MV {
     std::string name =
         name_region + name_value_type + name_work_tag + name_test_id;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<DeviceType, AlgoTagType> policy(0, _x.extent(0));
+    Kokkos::RangePolicy<execution_space, AlgoTagType> policy(0, _x.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
     return;

--- a/common/unit_test/Test_Common_ArithTraits.hpp
+++ b/common/unit_test/Test_Common_ArithTraits.hpp
@@ -119,7 +119,7 @@ struct HasTranscendentals<long double> {
 template <class ScalarType, class DeviceType>
 class ArithTraitsTesterBase {
  public:
-  typedef DeviceType execution_space;
+  typedef typename DeviceType::execution_space execution_space;
   typedef typename execution_space::size_type size_type;
   //! Type of the result of the reduction.
   typedef int value_type;
@@ -430,7 +430,7 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 0>
   typedef ArithTraitsTesterBase<ScalarType, DeviceType> base_type;
 
  public:
-  typedef DeviceType execution_space;
+  typedef typename DeviceType::execution_space execution_space;
   typedef typename execution_space::size_type size_type;
   //! Type of the result of the reduction.
   typedef int value_type;
@@ -509,7 +509,7 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
   }
 
  public:
-  typedef DeviceType execution_space;
+  typedef typename DeviceType::execution_space execution_space;
   typedef typename execution_space::size_type size_type;
   //! Type of the result of the reduction.
   typedef int value_type;
@@ -993,7 +993,7 @@ class ArithTraitsTesterComplexBase<ScalarType, DeviceType, 0>
   typedef ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType> base_type;
 
  public:
-  typedef DeviceType execution_space;
+  typedef typename DeviceType::execution_space execution_space;
   typedef typename execution_space::size_type size_type;
   //! Type of the result of the reduction.
   typedef int value_type;
@@ -1079,7 +1079,7 @@ class ArithTraitsTesterComplexBase<ScalarType, DeviceType, 1>
   typedef ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType> base_type;
 
  public:
-  typedef DeviceType execution_space;
+  typedef typename DeviceType::execution_space execution_space;
   typedef typename execution_space::size_type size_type;
   //! Type of the result of the reduction.
   typedef int value_type;
@@ -1217,7 +1217,7 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 0>
       base_type;
 
  public:
-  typedef DeviceType execution_space;
+  typedef typename DeviceType::execution_space execution_space;
   typedef typename execution_space::size_type size_type;
   //! Type of the result of the reduction.
   typedef int value_type;
@@ -1336,7 +1336,7 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 1>
       base_type;
 
  public:
-  typedef DeviceType execution_space;
+  typedef typename DeviceType::execution_space execution_space;
   typedef typename execution_space::size_type size_type;
   //! Type of the result of the reduction.
   typedef int value_type;
@@ -1417,7 +1417,7 @@ template <class ScalarType, class DeviceType>
 class ArithTraitsTester
     : public ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType> {
  public:
-  typedef DeviceType execution_space;
+  typedef typename DeviceType::execution_space execution_space;
   typedef typename execution_space::size_type size_type;
   //! Type of the result of the reduction.
   typedef int value_type;

--- a/common/unit_test/Test_Common_Sorting.hpp
+++ b/common/unit_test/Test_Common_Sorting.hpp
@@ -178,17 +178,18 @@ struct TestSerialRadix2Functor {
   OrdView offsets;
 };
 
-template <typename ExecSpace, typename Key>
+template <typename Device, typename Key>
 void testSerialRadixSort(size_t k, size_t subArraySize) {
   // Create a view of randomized data
-  typedef typename ExecSpace::memory_space mem_space;
+  typedef typename Device::execution_space exec_space;
+  typedef typename Device::memory_space mem_space;
   typedef Kokkos::View<int*, mem_space> OrdView;
   typedef Kokkos::View<Key*, mem_space> KeyView;
   OrdView counts("Subarray Sizes", k);
   OrdView offsets("Subarray Offsets", k);
   // Generate k sub-array sizes, each with size about 20
-  size_t n = generateRandomOffsets<OrdView, ExecSpace>(counts, offsets, k,
-                                                       subArraySize);
+  size_t n = generateRandomOffsets<OrdView, exec_space>(counts, offsets, k,
+                                                        subArraySize);
   KeyView keys("Radix sort testing data", n);
   fillRandom(keys);
   // Sort using std::sort on host to do correctness test
@@ -196,11 +197,11 @@ void testSerialRadixSort(size_t k, size_t subArraySize) {
   Kokkos::deep_copy(gold, keys);
   KeyView keysAux("Radix sort aux data", n);
   // Run the sorting on device in all sub-arrays in parallel
-  typedef Kokkos::RangePolicy<ExecSpace> range_policy;
+  typedef Kokkos::RangePolicy<exec_space> range_policy;
   Kokkos::parallel_for(
       range_policy(0, k),
       TestSerialRadixFunctor<KeyView, OrdView>(keys, keysAux, counts, offsets));
-  ExecSpace().fence();
+  exec_space().fence();
   auto countsHost =
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), counts);
   auto offsetsHost =
@@ -218,18 +219,19 @@ void testSerialRadixSort(size_t k, size_t subArraySize) {
   }
 }
 
-template <typename ExecSpace, typename Key, typename Value>
+template <typename Device, typename Key, typename Value>
 void testSerialRadixSort2(size_t k, size_t subArraySize) {
   // Create a view of randomized data
-  typedef typename ExecSpace::memory_space mem_space;
+  typedef typename Device::execution_space exec_space;
+  typedef typename Device::memory_space mem_space;
   typedef Kokkos::View<int*, mem_space> OrdView;
   typedef Kokkos::View<Key*, mem_space> KeyView;
   typedef Kokkos::View<Value*, mem_space> ValView;
   OrdView counts("Subarray Sizes", k);
   OrdView offsets("Subarray Offsets", k);
   // Generate k sub-array sizes, each with size about 20
-  size_t n = generateRandomOffsets<OrdView, ExecSpace>(counts, offsets, k,
-                                                       subArraySize);
+  size_t n = generateRandomOffsets<OrdView, exec_space>(counts, offsets, k,
+                                                        subArraySize);
   KeyView keys("Radix test keys", n);
   ValView data("Radix test data", n);
   // The keys are randomized
@@ -239,12 +241,12 @@ void testSerialRadixSort2(size_t k, size_t subArraySize) {
   KeyView keysAux("Radix sort aux keys", n);
   ValView dataAux("Radix sort aux data", n);
   // Run the sorting on device in all sub-arrays in parallel
-  typedef Kokkos::RangePolicy<ExecSpace> range_policy;
+  typedef Kokkos::RangePolicy<exec_space> range_policy;
   // Deliberately using a weird number for vector length
   Kokkos::parallel_for(range_policy(0, k),
                        TestSerialRadix2Functor<KeyView, ValView, OrdView>(
                            keys, keysAux, data, dataAux, counts, offsets));
-  ExecSpace().fence();
+  exec_space().fence();
   // Sort using std::sort on host to do correctness test
   auto countsHost =
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), counts);
@@ -312,30 +314,31 @@ struct TestTeamBitonic2Functor {
   OrdView offsets;
 };
 
-template <typename ExecSpace, typename Scalar>
+template <typename Device, typename Scalar>
 void testTeamBitonicSort(size_t k, size_t subArraySize) {
   // Create a view of randomized data
-  typedef typename ExecSpace::memory_space mem_space;
+  typedef typename Device::execution_space exec_space;
+  typedef typename Device::memory_space mem_space;
   typedef Kokkos::View<int*, mem_space> OrdView;
   typedef Kokkos::View<Scalar*, mem_space> ValView;
   OrdView counts("Subarray Sizes", k);
   OrdView offsets("Subarray Offsets", k);
   // Generate k sub-array sizes, each with size about 20
-  size_t n = generateRandomOffsets<OrdView, ExecSpace>(counts, offsets, k,
-                                                       subArraySize);
+  size_t n = generateRandomOffsets<OrdView, exec_space>(counts, offsets, k,
+                                                        subArraySize);
   ValView data("Bitonic sort testing data", n);
   fillRandom(data);
   Kokkos::View<Scalar*, Kokkos::HostSpace> gold("Host sorted", n);
   Kokkos::deep_copy(gold, data);
   // Run the sorting on device in all sub-arrays in parallel
   Kokkos::parallel_for(
-      Kokkos::TeamPolicy<ExecSpace>(k, Kokkos::AUTO()),
+      Kokkos::TeamPolicy<exec_space>(k, Kokkos::AUTO()),
       TestTeamBitonicFunctor<ValView, OrdView>(data, counts, offsets));
   // Copy result to host
   auto dataHost = Kokkos::create_mirror_view(data);
   Kokkos::deep_copy(dataHost, data);
   // Sort using std::sort on host to do correctness test
-  ExecSpace().fence();
+  exec_space().fence();
   auto countsHost =
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), counts);
   auto offsetsHost =
@@ -350,18 +353,19 @@ void testTeamBitonicSort(size_t k, size_t subArraySize) {
   }
 }
 
-template <typename ExecSpace, typename Key, typename Value>
+template <typename Device, typename Key, typename Value>
 void testTeamBitonicSort2(size_t k, size_t subArraySize) {
   // Create a view of randomized data
-  typedef typename ExecSpace::memory_space mem_space;
+  typedef typename Device::execution_space exec_space;
+  typedef typename Device::memory_space mem_space;
   typedef Kokkos::View<int*, mem_space> OrdView;
   typedef Kokkos::View<Key*, mem_space> KeyView;
   typedef Kokkos::View<Value*, mem_space> ValView;
   OrdView counts("Subarray Sizes", k);
   OrdView offsets("Subarray Offsets", k);
   // Generate k sub-array sizes, each with size about 20
-  size_t n = generateRandomOffsets<OrdView, ExecSpace>(counts, offsets, k,
-                                                       subArraySize);
+  size_t n = generateRandomOffsets<OrdView, exec_space>(counts, offsets, k,
+                                                        subArraySize);
   KeyView keys("Bitonic test keys", n);
   ValView data("Bitonic test data", n);
   // The keys are randomized
@@ -370,10 +374,10 @@ void testTeamBitonicSort2(size_t k, size_t subArraySize) {
   Kokkos::deep_copy(gold, keys);
   // Run the sorting on device in all sub-arrays in parallel, just using vector
   // loops Deliberately using a weird number for vector length
-  Kokkos::parallel_for(Kokkos::TeamPolicy<ExecSpace>(k, Kokkos::AUTO()),
+  Kokkos::parallel_for(Kokkos::TeamPolicy<exec_space>(k, Kokkos::AUTO()),
                        TestTeamBitonic2Functor<KeyView, ValView, OrdView>(
                            keys, data, counts, offsets));
-  ExecSpace().fence();
+  exec_space().fence();
   auto countsHost =
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), counts);
   auto offsetsHost =
@@ -409,16 +413,17 @@ struct CheckSortedFunctor {
   View v;
 };
 
-template <typename ExecSpace, typename Scalar>
+template <typename Device, typename Scalar>
 void testBitonicSort(size_t n) {
   // Create a view of randomized data
-  typedef typename ExecSpace::memory_space mem_space;
+  typedef typename Device::execution_space exec_space;
+  typedef typename Device::memory_space mem_space;
   typedef Kokkos::View<Scalar*, mem_space> ValView;
   ValView data("Bitonic sort testing data", n);
   fillRandom(data);
-  KokkosKernels::bitonicSort<ValView, ExecSpace, int>(data);
+  KokkosKernels::bitonicSort<ValView, exec_space, int>(data);
   int ordered = 1;
-  Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, n - 1),
+  Kokkos::parallel_reduce(Kokkos::RangePolicy<exec_space>(0, n - 1),
                           CheckSortedFunctor<ValView>(data),
                           Kokkos::Min<int>(ordered));
   ASSERT_TRUE(ordered);
@@ -444,19 +449,20 @@ struct CompareDescending {
   }
 };
 
-template <typename ExecSpace>
+template <typename Device>
 void testBitonicSortDescending() {
+  typedef typename Device::execution_space exec_space;
+  typedef typename Device::memory_space mem_space;
   typedef char Scalar;
   typedef CompareDescending<Scalar> Comp;
   // Create a view of randomized data
-  typedef typename ExecSpace::memory_space mem_space;
   typedef Kokkos::View<Scalar*, mem_space> ValView;
   size_t n = 12521;
   ValView data("Bitonic sort testing data", n);
   fillRandom(data);
-  KokkosKernels::bitonicSort<ValView, ExecSpace, int, Comp>(data);
+  KokkosKernels::bitonicSort<ValView, exec_space, int, Comp>(data);
   int ordered = 1;
-  Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, n - 1),
+  Kokkos::parallel_reduce(Kokkos::RangePolicy<exec_space>(0, n - 1),
                           CheckOrderedFunctor<ValView, Comp>(data),
                           Kokkos::Min<int>(ordered));
   ASSERT_TRUE(ordered);
@@ -479,18 +485,19 @@ struct LexCompare {
   }
 };
 
-template <typename ExecSpace>
+template <typename Device>
 void testBitonicSortLexicographic() {
+  typedef typename Device::execution_space exec_space;
+  typedef typename Device::memory_space mem_space;
   typedef Coordinates Scalar;
   // Create a view of randomized data
-  typedef typename ExecSpace::memory_space mem_space;
   typedef Kokkos::View<Scalar*, mem_space> ValView;
   size_t n = 9521;
   ValView data("Bitonic sort testing data", n);
   fillRandom(data);
-  KokkosKernels::bitonicSort<ValView, ExecSpace, int, LexCompare>(data);
+  KokkosKernels::bitonicSort<ValView, exec_space, int, LexCompare>(data);
   int ordered = 1;
-  Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, n - 1),
+  Kokkos::parallel_reduce(Kokkos::RangePolicy<exec_space>(0, n - 1),
                           CheckOrderedFunctor<ValView, LexCompare>(data),
                           Kokkos::Min<int>(ordered));
   ASSERT_TRUE(ordered);

--- a/graph/unit_test/Test_Graph_graph_color.hpp
+++ b/graph/unit_test/Test_Graph_graph_color.hpp
@@ -96,9 +96,10 @@ void test_coloring(lno_t numRows, size_type nnz, lno_t bandwidth,
 
   KokkosKernels::Impl::symmetrize_graph_symbolic_hashmap<
       lno_view_t, lno_nnz_view_t, typename lno_view_t::non_const_type,
-      typename lno_nnz_view_t::non_const_type, device>(
-      numRows, input_mat.graph.row_map, input_mat.graph.entries, sym_xadj,
-      sym_adj);
+      typename lno_nnz_view_t::non_const_type,
+      typename device::execution_space>(numRows, input_mat.graph.row_map,
+                                        input_mat.graph.entries, sym_xadj,
+                                        sym_adj);
   size_type numentries = sym_adj.extent(0);
   scalar_view_t newValues("vals", numentries);
 

--- a/ode/unit_test/Test_ODE_RK.hpp
+++ b/ode/unit_test/Test_ODE_RK.hpp
@@ -174,11 +174,12 @@ void test_method(const std::string label, ode_type& my_ode,
 
 }  // test_method
 
-template <class execution_space>
+template <class Device>
 void test_RK() {
-  using RK_type  = KokkosODE::Experimental::RK_type;
-  using vec_type = Kokkos::View<double*, execution_space>;
-  using mv_type  = Kokkos::View<double**, execution_space>;
+  using execution_space = typename Device::execution_space;
+  using RK_type         = KokkosODE::Experimental::RK_type;
+  using vec_type        = Kokkos::View<double*, Device>;
+  using mv_type         = Kokkos::View<double**, Device>;
 
   duho my_oscillator(1, 1, 4);
   const int neqs = my_oscillator.neqs;
@@ -349,11 +350,12 @@ void test_rate(ode_type& my_ode, const scalar_type& tstart,
 
 }  // test_method
 
-template <class execution_space>
+template <class Device>
 void test_convergence_rate() {
-  using RK_type  = KokkosODE::Experimental::RK_type;
-  using vec_type = Kokkos::View<double*, execution_space>;
-  using mv_type  = Kokkos::View<double**, execution_space>;
+  using execution_space = typename Device::execution_space;
+  using RK_type         = KokkosODE::Experimental::RK_type;
+  using vec_type        = Kokkos::View<double*, Device>;
+  using mv_type         = Kokkos::View<double**, Device>;
 
   duho my_oscillator(1, 1, 4);
   const int neqs = my_oscillator.neqs;
@@ -463,11 +465,12 @@ void test_convergence_rate() {
   }
 }  // test_convergence_rate
 
-template <class execution_space>
+template <class Device>
 void test_adaptivity() {
-  using RK_type  = KokkosODE::Experimental::RK_type;
-  using vec_type = Kokkos::View<double*, execution_space>;
-  using mv_type  = Kokkos::View<double**, execution_space>;
+  using execution_space = typename Device::execution_space;
+  using RK_type         = KokkosODE::Experimental::RK_type;
+  using vec_type        = Kokkos::View<double*, Device>;
+  using mv_type         = Kokkos::View<double**, Device>;
 
   duho my_oscillator(1, 1, 4);
   const int neqs = my_oscillator.neqs;

--- a/ode/unit_test/Test_ODE_RK_chem.hpp
+++ b/ode/unit_test/Test_ODE_RK_chem.hpp
@@ -89,12 +89,13 @@ struct chem_model_2 {
   }
 };
 
-template <class execution_space>
+template <class Device>
 void test_chem() {
-  using vec_type    = Kokkos::View<double*, execution_space>;
-  using mv_type     = Kokkos::View<double**, execution_space>;
-  using RK_type     = KokkosODE::Experimental::RK_type;
-  using solver_type = KokkosODE::Experimental::RungeKutta<RK_type::RKCK>;
+  using execution_space = typename Device::execution_space;
+  using vec_type        = Kokkos::View<double*, Device>;
+  using mv_type         = Kokkos::View<double**, Device>;
+  using RK_type         = KokkosODE::Experimental::RK_type;
+  using solver_type     = KokkosODE::Experimental::RungeKutta<RK_type::RKCK>;
 
   {
     chem_model_1 chem_model;

--- a/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
+++ b/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
@@ -2915,7 +2915,7 @@ void lower_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
 
 #if defined(KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV)
   using namespace KokkosSparse::Experimental;
-  using memory_space        = typename execution_space::memory_space;
+  using memory_space        = typename TriSolveHandle::memory_space;
   using integer_view_t      = typename TriSolveHandle::integer_view_t;
   using integer_view_host_t = typename TriSolveHandle::integer_view_host_t;
   using scalar_t            = typename ValuesType::non_const_value_type;
@@ -3289,7 +3289,7 @@ void upper_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
 
 #if defined(KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV)
   using namespace KokkosSparse::Experimental;
-  using memory_space        = typename execution_space::memory_space;
+  using memory_space        = typename TriSolveHandle::memory_space;
   using integer_view_t      = typename TriSolveHandle::integer_view_t;
   using integer_view_host_t = typename TriSolveHandle::integer_view_host_t;
   using scalar_t            = typename ValuesType::non_const_value_type;

--- a/sparse/src/KokkosSparse_sptrsv_supernode.hpp
+++ b/sparse/src/KokkosSparse_sptrsv_supernode.hpp
@@ -1402,8 +1402,8 @@ void invert_supernodal_columns(KernelHandle *kernelHandle, bool unit_diag,
   // If we are running KokkosKernels::trmm on device,
   // then we need to allocate a workspace on device
   using trmm_execution_space = typename KernelHandle::HandleExecSpace;
-  using trmm_memory_space    = typename trmm_execution_space::memory_space;
-  using trmm_view_t          = Kokkos::View<scalar_t *, trmm_execution_space>;
+  using trmm_memory_space = typename KernelHandle::HandlePersistentMemorySpace;
+  using trmm_view_t       = Kokkos::View<scalar_t *, trmm_execution_space>;
 #if !defined(KOKKOSKERNELS_ENABLE_TPL_CUBLAS)
   // use KokkosBlas::trmm only with CUBLAS (since deep-copy to host throws an
   // error)

--- a/sparse/unit_test/Test_Sparse_SortCrs.hpp
+++ b/sparse/unit_test/Test_Sparse_SortCrs.hpp
@@ -41,15 +41,14 @@ enum : int {
 };
 }
 
-template <typename exec_space>
+template <typename device_t>
 void testSortCRS(default_lno_t numRows, default_lno_t numCols,
                  default_size_type nnz, bool doValues, bool doStructInterface,
                  int howExecSpecified) {
-  using scalar_t  = default_scalar;
-  using lno_t     = default_lno_t;
-  using size_type = default_size_type;
-  using mem_space = typename exec_space::memory_space;
-  using device_t  = Kokkos::Device<exec_space, mem_space>;
+  using scalar_t   = default_scalar;
+  using lno_t      = default_lno_t;
+  using size_type  = default_size_type;
+  using exec_space = typename device_t::execution_space;
   using crsMat_t =
       KokkosSparse::CrsMatrix<scalar_t, lno_t, device_t, void, size_type>;
   // Create a random matrix on device
@@ -160,14 +159,13 @@ void testSortCRS(default_lno_t numRows, default_lno_t numCols,
   }
 }
 
-template <typename exec_space>
+template <typename device_t>
 void testSortCRSUnmanaged(bool doValues, bool doStructInterface) {
   // This test is about bug #960.
-  using scalar_t  = default_scalar;
-  using lno_t     = default_lno_t;
-  using size_type = default_size_type;
-  using mem_space = typename exec_space::memory_space;
-  using device_t  = Kokkos::Device<exec_space, mem_space>;
+  using scalar_t   = default_scalar;
+  using lno_t      = default_lno_t;
+  using size_type  = default_size_type;
+  using exec_space = typename device_t::execution_space;
   using crsMat_t =
       KokkosSparse::CrsMatrix<scalar_t, lno_t, device_t,
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>,
@@ -207,14 +205,13 @@ void testSortCRSUnmanaged(bool doValues, bool doStructInterface) {
   }
 }
 
-template <typename exec_space>
+template <typename device_t>
 void testSortAndMerge(bool justGraph, int howExecSpecified,
                       bool doStructInterface, bool inPlace, int testCase) {
-  using size_type = default_size_type;
-  using lno_t     = default_lno_t;
-  using scalar_t  = default_scalar;
-  using mem_space = typename exec_space::memory_space;
-  using device_t  = Kokkos::Device<exec_space, mem_space>;
+  using size_type  = default_size_type;
+  using lno_t      = default_lno_t;
+  using scalar_t   = default_scalar;
+  using exec_space = typename device_t::execution_space;
   using crsMat_t =
       KokkosSparse::CrsMatrix<scalar_t, lno_t, device_t, void, size_type>;
   using graph_t   = typename crsMat_t::staticcrsgraph_type;

--- a/sparse/unit_test/Test_Sparse_Transpose.hpp
+++ b/sparse/unit_test/Test_Sparse_Transpose.hpp
@@ -40,14 +40,13 @@ struct ExactCompare {
   V v2;
 };
 
-template <typename exec_space>
+template <typename device_t>
 void testTranspose(int numRows, int numCols, bool doValues) {
+  using exec_space = typename device_t::execution_space;
   using range_pol  = Kokkos::RangePolicy<exec_space>;
   using scalar_t   = default_scalar;
   using lno_t      = default_lno_t;
   using size_type  = default_size_type;
-  using mem_space  = typename exec_space::memory_space;
-  using device_t   = Kokkos::Device<exec_space, mem_space>;
   using crsMat_t   = typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device_t,
                                                     void, size_type>;
   using c_rowmap_t = typename crsMat_t::row_map_type;
@@ -158,13 +157,11 @@ void CompareBsrMatrices(bsrMat_t& A, bsrMat_t& B) {
   EXPECT_EQ(size_type(0), valuesDiffs);
 }
 
-template <typename exec_space>
+template <typename device_t>
 void testTransposeBsrRef() {
   using scalar_t  = default_scalar;
   using lno_t     = default_lno_t;
   using size_type = default_size_type;
-  using mem_space = typename exec_space::memory_space;
-  using device_t  = Kokkos::Device<exec_space, mem_space>;
   using bsrMat_t =
       typename KokkosSparse::Experimental::BsrMatrix<scalar_t, lno_t, device_t,
                                                      void, size_type>;
@@ -236,13 +233,12 @@ void testTransposeBsrRef() {
   CompareBsrMatrices(At, At_ref);
 }
 
-template <typename exec_space>
+template <typename device_t>
 void testTransposeBsr(int numRows, int numCols, int blockSize) {
-  using scalar_t  = default_scalar;
-  using lno_t     = default_lno_t;
-  using size_type = default_size_type;
-  using mem_space = typename exec_space::memory_space;
-  using device_t  = Kokkos::Device<exec_space, mem_space>;
+  using scalar_t   = default_scalar;
+  using lno_t      = default_lno_t;
+  using size_type  = default_size_type;
+  using exec_space = typename device_t::execution_space;
   using bsrMat_t =
       typename KokkosSparse::Experimental::BsrMatrix<scalar_t, lno_t, device_t,
                                                      void, size_type>;

--- a/sparse/unit_test/Test_Sparse_coo2crs.hpp
+++ b/sparse/unit_test/Test_Sparse_coo2crs.hpp
@@ -197,10 +197,10 @@ void check_crs_matrix(CrsType crsMat, RowType row, ColType col, DataType data,
   }
 }
 
-template <class ScalarType, class LayoutType, class ExeSpaceType>
+template <class ScalarType, class LayoutType, class Device>
 void doCoo2Crs(size_t m, size_t n, ScalarType min_val, ScalarType max_val) {
-  RandCooMat<ScalarType, LayoutType, ExeSpaceType> cooMat(m, n, m * n, min_val,
-                                                          max_val);
+  RandCooMat<ScalarType, LayoutType, Device> cooMat(m, n, m * n, min_val,
+                                                    max_val);
   auto randRow  = cooMat.get_row();
   auto randCol  = cooMat.get_col();
   auto randData = cooMat.get_data();

--- a/sparse/unit_test/Test_Sparse_removeCrsMatrixZeros.hpp
+++ b/sparse/unit_test/Test_Sparse_removeCrsMatrixZeros.hpp
@@ -91,9 +91,7 @@ Matrix loadMatrixFromVectors(int numRows, int numCols,
 
 template <typename Matrix>
 void getTestInput(int test, Matrix& A, Matrix& Afiltered_ref) {
-  using Offset = typename Matrix::size_type;
-  using Device =
-      Kokkos::Device<TestExecSpace, typename TestExecSpace::memory_space>;
+  using Offset                = typename Matrix::size_type;
   bool haveHardcodedReference = true;
   switch (test) {
     case 0: {
@@ -226,7 +224,8 @@ void getTestInput(int test, Matrix& A, Matrix& Afiltered_ref) {
   if (haveHardcodedReference) {
     Matrix Afiltered_refimpl = removeMatrixZerosReference(A);
     bool referenceImplMatchesHardcoded =
-        Test::is_same_matrix<Matrix, Device>(Afiltered_ref, Afiltered_refimpl);
+        Test::is_same_matrix<Matrix, TestExecSpace>(Afiltered_ref,
+                                                    Afiltered_refimpl);
     ASSERT_TRUE(referenceImplMatchesHardcoded)
         << "Test case " << test << ": reference impl gave wrong answer!";
   }
@@ -236,15 +235,14 @@ void getTestInput(int test, Matrix& A, Matrix& Afiltered_ref) {
 
 void testRemoveCrsMatrixZeros(int testCase) {
   using namespace TestRemoveCrsMatrixZeros;
-  using Device =
-      Kokkos::Device<TestExecSpace, typename TestExecSpace::memory_space>;
-  using Matrix = KokkosSparse::CrsMatrix<default_scalar, default_lno_t, Device,
-                                         void, default_size_type>;
+  using Matrix =
+      KokkosSparse::CrsMatrix<default_scalar, default_lno_t, TestExecSpace,
+                              void, default_size_type>;
   Matrix A, Afiltered_ref;
   getTestInput<Matrix>(testCase, A, Afiltered_ref);
   Matrix Afiltered_actual = KokkosSparse::removeCrsMatrixZeros(A);
-  bool matches =
-      Test::is_same_matrix<Matrix, Device>(Afiltered_actual, Afiltered_ref);
+  bool matches = Test::is_same_matrix<Matrix, TestExecSpace>(Afiltered_actual,
+                                                             Afiltered_ref);
   EXPECT_TRUE(matches)
       << "Test case " << testCase
       << ": matrix with zeros filtered out does not match reference.";

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -574,13 +574,14 @@ int string_compare_no_case(const std::string& str1, const std::string& str2) {
 /// /brief Coo matrix class for testing purposes.
 /// \tparam ScalarType
 /// \tparam LayoutType
-/// \tparam ExeSpaceType
-template <class ScalarType, class LayoutType, class ExeSpaceType>
+/// \tparam Device
+template <class ScalarType, class LayoutType, class Device>
 class RandCooMat {
  private:
-  using RowViewTypeD  = Kokkos::View<int64_t*, LayoutType, ExeSpaceType>;
-  using ColViewTypeD  = Kokkos::View<int64_t*, LayoutType, ExeSpaceType>;
-  using DataViewTypeD = Kokkos::View<ScalarType*, LayoutType, ExeSpaceType>;
+  using ExeSpaceType  = typename Device::execution_space;
+  using RowViewTypeD  = Kokkos::View<int64_t*, LayoutType, Device>;
+  using ColViewTypeD  = Kokkos::View<int64_t*, LayoutType, Device>;
+  using DataViewTypeD = Kokkos::View<ScalarType*, LayoutType, Device>;
   RowViewTypeD __row_d;
   ColViewTypeD __col_d;
   DataViewTypeD __data_d;

--- a/test_common/Test_Cuda.hpp
+++ b/test_common/Test_Cuda.hpp
@@ -32,6 +32,16 @@ class Cuda : public ::testing::Test {
 };
 
 #define TestCategory Cuda
-#define TestExecSpace Kokkos::Cuda
+
+using CudaSpaceDevice    = Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>;
+using CudaUVMSpaceDevice = Kokkos::Device<Kokkos::Cuda, Kokkos::CudaUVMSpace>;
+
+// Prefer <Cuda, CudaSpace> for any testing where only one exec space is used
+#if defined(KOKKOSKERNELS_INST_MEMSPACE_CUDAUVMSPACE) && \
+    !defined(KOKKOSKERNELS_INST_MEMSPACE_CUDASPACE)
+#define TestExecSpace CudaUVMSpaceDevice
+#else
+#define TestExecSpace CudaSpaceDevice
+#endif
 
 #endif  // TEST_CUDA_HPP


### PR DESCRIPTION
Fixes #1910

In the source and especially unit tests, assume the device type we're using can have any memory space (not just the default memory space of the execution space).

``TestExecSpace`` can now either be a general device type (``Kokkos::Device<E, M>``), or just an execution space (like the old behavior). In a follow on PR, I will rename it to ``TestDevice``. Not doing it here because it's a lot more line changes that would make this harder to review.

In all Cuda unit tests, use ``TestExecSpace = <Cuda, CudaUVMSpace>`` if CudaUVMSpace is instantiated but CudaSpace is not. Otherwise, use ``<Cuda, CudaSpace>``. All other backends are unchanged, but this would also let us test devices like ``<HIP, HIPManagedSpace>`` and ``<SYCL, SYCLSharedUSMSpace>`` in the future.

I think it might also make sense to add a CMake flag to instantiate for the SharedSpace (CudaUVMSpace, HIPManagedSpace, etc) instead of the default space. It would make things easier on users for when Kokkos core removes  ``Kokkos_ENABLE_CUDA_UVM`` as an option.