### PR TITLE
OrdinalTraits: constexpr functions

### DIFF
--- a/sparse/src/KokkosSparse_OrdinalTraits.hpp
+++ b/sparse/src/KokkosSparse_OrdinalTraits.hpp
@@ -55,44 +55,44 @@ struct OrdinalTraits {
 
 template <>
 struct OrdinalTraits<short int> {
-  static KOKKOS_INLINE_FUNCTION short int invalid() { return -1; }
+  static constexpr KOKKOS_INLINE_FUNCTION short int invalid() { return -1; }
 };
 
 template <>
 struct OrdinalTraits<unsigned short int> {
-  static KOKKOS_INLINE_FUNCTION unsigned short int invalid() {
+  static constexpr KOKKOS_INLINE_FUNCTION unsigned short int invalid() {
     return USHRT_MAX;
   }
 };
 
 template <>
 struct OrdinalTraits<int> {
-  static KOKKOS_INLINE_FUNCTION int invalid() { return -1; }
+  static constexpr KOKKOS_INLINE_FUNCTION int invalid() { return -1; }
 };
 
 template <>
 struct OrdinalTraits<unsigned int> {
-  static KOKKOS_INLINE_FUNCTION unsigned int invalid() { return UINT_MAX; }
+  static constexpr KOKKOS_INLINE_FUNCTION unsigned int invalid() { return UINT_MAX; }
 };
 
 template <>
 struct OrdinalTraits<long> {
-  static KOKKOS_INLINE_FUNCTION long invalid() { return -1; }
+  static constexpr KOKKOS_INLINE_FUNCTION long invalid() { return -1; }
 };
 
 template <>
 struct OrdinalTraits<unsigned long> {
-  static KOKKOS_INLINE_FUNCTION unsigned long invalid() { return ULONG_MAX; }
+  static constexpr KOKKOS_INLINE_FUNCTION unsigned long invalid() { return ULONG_MAX; }
 };
 
 template <>
 struct OrdinalTraits<long long> {
-  static KOKKOS_INLINE_FUNCTION long long invalid() { return -1; }
+  static constexpr KOKKOS_INLINE_FUNCTION long long invalid() { return -1; }
 };
 
 template <>
 struct OrdinalTraits<unsigned long long> {
-  static KOKKOS_INLINE_FUNCTION unsigned long long invalid() {
+  static constexpr KOKKOS_INLINE_FUNCTION unsigned long long invalid() {
     return ULLONG_MAX;
   }
 };

--- a/sparse/src/KokkosSparse_OrdinalTraits.hpp
+++ b/sparse/src/KokkosSparse_OrdinalTraits.hpp
@@ -72,7 +72,9 @@ struct OrdinalTraits<int> {
 
 template <>
 struct OrdinalTraits<unsigned int> {
-  static constexpr KOKKOS_INLINE_FUNCTION unsigned int invalid() { return UINT_MAX; }
+  static constexpr KOKKOS_INLINE_FUNCTION unsigned int invalid() {
+    return UINT_MAX;
+  }
 };
 
 template <>
@@ -82,7 +84,9 @@ struct OrdinalTraits<long> {
 
 template <>
 struct OrdinalTraits<unsigned long> {
-  static constexpr KOKKOS_INLINE_FUNCTION unsigned long invalid() { return ULONG_MAX; }
+  static constexpr KOKKOS_INLINE_FUNCTION unsigned long invalid() {
+    return ULONG_MAX;
+  }
 };
 
 template <>


### PR DESCRIPTION
@romintomasetti
Marking some functions as constexpr, I think this should work just fine but let us see if a compiler complains based on how some of these constant are defined.

 This PR is providing the implementation outlined in issue #1952 