### PR TITLE
KokkosKernels: switching from printf macro to function

### DIFF
--- a/batched/dense/impl/KokkosBatched_Axpy_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Axpy_Impl.hpp
@@ -199,17 +199,31 @@ KOKKOS_INLINE_FUNCTION int SerialAxpy::invoke(const alphaViewType& alpha,
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::axpy: Dimensions of X and Y do not match: X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+#else
+    Kokkos::printf(
+        "KokkosBatched::axpy: Dimensions of X and Y do not match: X: %d x %d, "
+        "Y: %d x %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+#endif
     return 1;
   }
   if (X.extent(0) != alpha.extent(0)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::axpy: First dimension of X and alpha do not match: X: "
         "%d x %d, alpha: %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
+#else
+    Kokkos::printf(
+        "KokkosBatched::axpy: First dimension of X and alpha do not match: X: "
+        "%d x %d, alpha: %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
+#endif
     return 1;
   }
 #endif
@@ -249,17 +263,31 @@ KOKKOS_INLINE_FUNCTION int TeamAxpy<MemberType>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::axpy: Dimensions of X and Y do not match: X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+#else
+    Kokkos::printf(
+        "KokkosBatched::axpy: Dimensions of X and Y do not match: X: %d x %d, "
+        "Y: %d x %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+#endif
     return 1;
   }
   if (X.extent(0) != alpha.extent(0)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::axpy: First dimension of X and alpha do not match: X: "
         "%d x %d, alpha: %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
+#else
+    Kokkos::printf(
+        "KokkosBatched::axpy: First dimension of X and alpha do not match: X: "
+        "%d x %d, alpha: %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
+#endif
     return 1;
   }
 #endif
@@ -304,17 +332,31 @@ KOKKOS_INLINE_FUNCTION int TeamVectorAxpy<MemberType>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::axpy: Dimensions of X and Y do not match: X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+#else
+    Kokkos::printf(
+        "KokkosBatched::axpy: Dimensions of X and Y do not match: X: %d x %d, "
+        "Y: %d x %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+#endif
     return 1;
   }
   if (X.extent(0) != alpha.extent(0)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::axpy: First dimension of X and alpha do not match: X: "
         "%d x %d, alpha: %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
+#else
+    Kokkos::printf(
+        "KokkosBatched::axpy: First dimension of X and alpha do not match: X: "
+        "%d x %d, alpha: %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
+#endif
     return 1;
   }
 #endif

--- a/batched/dense/impl/KokkosBatched_Copy_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Copy_Impl.hpp
@@ -59,10 +59,17 @@ KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::NoTranspose, 2>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x %d, "
         "B: %d x %d\n",
         (int)A.extent(0), (int)A.extent(1), (int)B.extent(0), (int)B.extent(1));
+#else
+    Kokkos::printf(
+        "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x %d, "
+        "B: %d x %d\n",
+        (int)A.extent(0), (int)A.extent(1), (int)B.extent(0), (int)B.extent(1));
+#endif
     return 1;
   }
 #endif
@@ -87,10 +94,17 @@ KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::Transpose, 2>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x %d, "
         "B: %d x %d\n",
         (int)A.extent(0), (int)A.extent(1), (int)B.extent(0), (int)B.extent(1));
+#else
+    Kokkos::printf(
+        "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x %d, "
+        "B: %d x %d\n",
+        (int)A.extent(0), (int)A.extent(1), (int)B.extent(0), (int)B.extent(1));
+#endif
     return 1;
   }
 #endif
@@ -143,12 +157,21 @@ struct TeamCopy<MemberType, Trans::NoTranspose, 2> {
 
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
           "%d, "
           "B: %d x %d\n",
           (int)A.extent(0), (int)A.extent(1), (int)B.extent(0),
           (int)B.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
+          "%d, "
+          "B: %d x %d\n",
+          (int)A.extent(0), (int)A.extent(1), (int)B.extent(0),
+          (int)B.extent(1));
+#endif
       return 1;
     }
 #endif
@@ -181,12 +204,21 @@ struct TeamCopy<MemberType, Trans::Transpose, 2> {
 
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
           "%d, "
           "B: %d x %d\n",
           (int)A.extent(0), (int)A.extent(1), (int)B.extent(0),
           (int)B.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
+          "%d, "
+          "B: %d x %d\n",
+          (int)A.extent(0), (int)A.extent(1), (int)B.extent(0),
+          (int)B.extent(1));
+#endif
       return 1;
     }
 #endif
@@ -245,12 +277,21 @@ struct TeamVectorCopy<MemberType, Trans::NoTranspose, 2> {
 
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
           "%d, "
           "B: %d x %d\n",
           (int)A.extent(0), (int)A.extent(1), (int)B.extent(0),
           (int)B.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
+          "%d, "
+          "B: %d x %d\n",
+          (int)A.extent(0), (int)A.extent(1), (int)B.extent(0),
+          (int)B.extent(1));
+#endif
       return 1;
     }
 #endif
@@ -283,12 +324,21 @@ struct TeamVectorCopy<MemberType, Trans::Transpose, 2> {
 
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
           "%d, "
           "B: %d x %d\n",
           (int)A.extent(0), (int)A.extent(1), (int)B.extent(0),
           (int)B.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
+          "%d, "
+          "B: %d x %d\n",
+          (int)A.extent(0), (int)A.extent(1), (int)B.extent(0),
+          (int)B.extent(1));
+#endif
       return 1;
     }
 #endif

--- a/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
@@ -186,19 +186,35 @@ struct SerialDot<Trans::Transpose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
           "Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
           (int)Y.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
+          "Y: %d x %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
+          (int)Y.extent(1));
+#endif
       return 1;
     }
     if (X.extent(1) != dot.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: Second dimension of X and alpha do not match: "
           "X: "
           "%d x %d, dot: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
+#else
+      Kokkos::printf(
+          "KokkosBatched::dot: Second dimension of X and alpha do not match: "
+          "X: "
+          "%d x %d, dot: %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
+#endif
       return 1;
     }
 #endif
@@ -232,18 +248,33 @@ struct SerialDot<Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
           "Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
           (int)Y.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
+          "Y: %d x %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
+          (int)Y.extent(1));
+#endif
       return 1;
     }
     if (X.extent(0) != dot.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: First dimension of X and alpha do not match: X: "
           "%d x %d, dot: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
+#else
+      Kokkos::printf(
+          "KokkosBatched::dot: First dimension of X and alpha do not match: X: "
+          "%d x %d, dot: %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
+#endif
       return 1;
     }
 #endif
@@ -282,19 +313,35 @@ struct TeamDot<MemberType, Trans::Transpose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
           "Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
           (int)Y.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
+          "Y: %d x %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
+          (int)Y.extent(1));
+#endif
       return 1;
     }
     if (X.extent(1) != dot.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: Second dimension of X and alpha do not match: "
           "X: "
           "%d x %d, dot: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
+#else
+      Kokkos::printf(
+          "KokkosBatched::dot: Second dimension of X and alpha do not match: "
+          "X: "
+          "%d x %d, dot: %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
+#endif
       return 1;
     }
 #endif
@@ -337,18 +384,33 @@ struct TeamDot<MemberType, Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
           "Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
           (int)Y.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
+          "Y: %d x %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
+          (int)Y.extent(1));
+#endif
       return 1;
     }
     if (X.extent(0) != dot.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: First dimension of X and alpha do not match: X: "
           "%d x %d, dot: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
+#else
+      Kokkos::printf(
+          "KokkosBatched::dot: First dimension of X and alpha do not match: X: "
+          "%d x %d, dot: %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
+#endif
       return 1;
     }
 #endif
@@ -395,19 +457,35 @@ struct TeamVectorDot<MemberType, Trans::Transpose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
           "Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
           (int)Y.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
+          "Y: %d x %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
+          (int)Y.extent(1));
+#endif
       return 1;
     }
     if (X.extent(1) != dot.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: Second dimension of X and alpha do not match: "
           "X: "
           "%d x %d, dot: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
+#else
+      Kokkos::printf(
+          "KokkosBatched::dot: Second dimension of X and alpha do not match: "
+          "X: "
+          "%d x %d, dot: %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
+#endif
       return 1;
     }
 #endif
@@ -450,18 +528,33 @@ struct TeamVectorDot<MemberType, Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
           "Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
           (int)Y.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
+          "Y: %d x %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
+          (int)Y.extent(1));
+#endif
       return 1;
     }
     if (X.extent(0) != dot.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::dot: First dimension of X and alpha do not match: X: "
           "%d x %d, dot: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
+#else
+      Kokkos::printf(
+          "KokkosBatched::dot: First dimension of X and alpha do not match: X: "
+          "%d x %d, dot: %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
+#endif
       return 1;
     }
 #endif

--- a/batched/dense/impl/KokkosBatched_Gesv_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gesv_Impl.hpp
@@ -384,22 +384,39 @@ struct SerialGesv<Gesv::StaticPivoting> {
     // Check compatibility of dimensions at run time.
 
     if (A.extent(0) != tmp.extent(0) || A.extent(1) + 4 != tmp.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::gesv: dimensions of A and tmp do not match: A: "
           "%d x %d, tmp (note: its second dimension should be the second "
           "dimension of A + 4): %d x %d\n",
           (int)A.extent(0), (int)A.extent(1), (int)tmp.extent(0),
           (int)tmp.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::gesv: dimensions of A and tmp do not match: A: "
+          "%d x %d, tmp (note: its second dimension should be the second "
+          "dimension of A + 4): %d x %d\n",
+          (int)A.extent(0), (int)A.extent(1), (int)tmp.extent(0),
+          (int)tmp.extent(1));
+#endif
       return 1;
     }
 
     if (A.extent(0) != X.extent(0) || A.extent(1) != X.extent(0) ||
         A.extent(0) != Y.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::gesv: dimensions of A and X and Y do not match: A: "
           "%d x %d, X: %d, Y: %d\n",
           (int)A.extent(0), (int)A.extent(1), (int)X.extent(0),
           (int)Y.extent(0));
+#else
+      Kokkos::printf(
+          "KokkosBatched::gesv: dimensions of A and X and Y do not match: A: "
+          "%d x %d, X: %d, Y: %d\n",
+          (int)A.extent(0), (int)A.extent(1), (int)X.extent(0),
+          (int)Y.extent(0));
+#endif
       return 1;
     }
 #endif
@@ -414,9 +431,15 @@ struct SerialGesv<Gesv::StaticPivoting> {
 
     if (SerialStaticPivoting::invoke(A, PDAD, Y, PDY, D2, tmp_v_1, tmp_v_2) ==
         1) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::gesv: the currently implemented static pivoting "
           "failed.\n");
+#else
+      Kokkos::printf(
+          "KokkosBatched::gesv: the currently implemented static pivoting "
+          "failed.\n");
+#endif
       return 1;
     }
 
@@ -458,11 +481,19 @@ struct SerialGesv<Gesv::NoPivoting> {
 
     if (A.extent(0) != X.extent(0) || A.extent(1) != X.extent(0) ||
         A.extent(0) != Y.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::gesv: dimensions of A and X and Y do not match: A: "
           "%d x %d, X: %d, Y: %d\n",
           (int)A.extent(0), (int)A.extent(1), (int)X.extent(0),
           (int)Y.extent(0));
+#else
+      Kokkos::printf(
+          "KokkosBatched::gesv: dimensions of A and X and Y do not match: A: "
+          "%d x %d, X: %d, Y: %d\n",
+          (int)A.extent(0), (int)A.extent(1), (int)X.extent(0),
+          (int)Y.extent(0));
+#endif
       return 1;
     }
 #endif
@@ -509,11 +540,19 @@ struct TeamGesv<MemberType, Gesv::StaticPivoting> {
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != X.extent(0) || A.extent(1) != X.extent(0) ||
         A.extent(0) != Y.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::gesv: dimensions of A and X and Y do not match: A: "
           "%d x %d, X: %d, Y: %d\n",
           (int)A.extent(0), (int)A.extent(1), (int)X.extent(0),
           (int)Y.extent(0));
+#else
+      Kokkos::printf(
+          "KokkosBatched::gesv: dimensions of A and X and Y do not match: A: "
+          "%d x %d, X: %d, Y: %d\n",
+          (int)A.extent(0), (int)A.extent(1), (int)X.extent(0),
+          (int)Y.extent(0));
+#endif
       return 1;
     }
 #endif
@@ -532,9 +571,15 @@ struct TeamGesv<MemberType, Gesv::StaticPivoting> {
 
     if (TeamStaticPivoting<MemberType>::invoke(member, A, PDAD, Y, PDY, D2,
                                                tmp_v_1, tmp_v_2) == 1) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::gesv: the currently implemented static pivoting "
           "failed.\n");
+#else
+      Kokkos::printf(
+          "KokkosBatched::gesv: the currently implemented static pivoting "
+          "failed.\n");
+#endif
       return 1;
     }
     member.team_barrier();
@@ -587,11 +632,19 @@ struct TeamGesv<MemberType, Gesv::NoPivoting> {
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != X.extent(0) || A.extent(1) != X.extent(0) ||
         A.extent(0) != Y.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::gesv: dimensions of A and X and Y do not match: A: "
           "%d x %d, X: %d, Y: %d\n",
           (int)A.extent(0), (int)A.extent(1), (int)X.extent(0),
           (int)Y.extent(0));
+#else
+      Kokkos::printf(
+          "KokkosBatched::gesv: dimensions of A and X and Y do not match: A: "
+          "%d x %d, X: %d, Y: %d\n",
+          (int)A.extent(0), (int)A.extent(1), (int)X.extent(0),
+          (int)Y.extent(0));
+#endif
       return 1;
     }
 #endif
@@ -645,11 +698,19 @@ struct TeamVectorGesv<MemberType, Gesv::StaticPivoting> {
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != X.extent(0) || A.extent(1) != X.extent(0) ||
         A.extent(0) != Y.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::gesv: dimensions of A and X and Y do not match: A: "
           "%d x %d, X: %d, Y: %d\n",
           (int)A.extent(0), (int)A.extent(1), (int)X.extent(0),
           (int)Y.extent(0));
+#else
+      Kokkos::printf(
+          "KokkosBatched::gesv: dimensions of A and X and Y do not match: A: "
+          "%d x %d, X: %d, Y: %d\n",
+          (int)A.extent(0), (int)A.extent(1), (int)X.extent(0),
+          (int)Y.extent(0));
+#endif
       return 1;
     }
 #endif
@@ -668,9 +729,15 @@ struct TeamVectorGesv<MemberType, Gesv::StaticPivoting> {
 
     if (TeamVectorStaticPivoting<MemberType>::invoke(
             member, A, PDAD, Y, PDY, D2, tmp_v_1, tmp_v_2) == 1) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::gesv: the currently implemented static pivoting "
           "failed.\n");
+#else
+      Kokkos::printf(
+          "KokkosBatched::gesv: the currently implemented static pivoting "
+          "failed.\n");
+#endif
       return 1;
     }
 
@@ -724,11 +791,19 @@ struct TeamVectorGesv<MemberType, Gesv::NoPivoting> {
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != X.extent(0) || A.extent(1) != X.extent(0) ||
         A.extent(0) != Y.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::gesv: dimensions of A and X and Y do not match: A: "
           "%d x %d, X: %d, Y: %d\n",
           (int)A.extent(0), (int)A.extent(1), (int)X.extent(0),
           (int)Y.extent(0));
+#else
+      Kokkos::printf(
+          "KokkosBatched::gesv: dimensions of A and X and Y do not match: A: "
+          "%d x %d, X: %d, Y: %d\n",
+          (int)A.extent(0), (int)A.extent(1), (int)X.extent(0),
+          (int)Y.extent(0));
+#endif
       return 1;
     }
 #endif

--- a/batched/dense/impl/KokkosBatched_HadamardProduct_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_HadamardProduct_Impl.hpp
@@ -110,19 +110,35 @@ KOKKOS_INLINE_FUNCTION int SerialHadamardProduct::invoke(const XViewType& X,
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::HadamardProduct: Dimensions of X and Y do not match: "
         "X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+#else
+    Kokkos::printf(
+        "KokkosBatched::HadamardProduct: Dimensions of X and Y do not match: "
+        "X: %d x %d, "
+        "Y: %d x %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+#endif
     return 1;
   }
   if (X.extent(0) != V.extent(0) || X.extent(1) != V.extent(1)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::HadamardProduct: Dimensions of X and V do not match: "
         "X: %d x %d, "
         "V: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)V.extent(0), (int)V.extent(1));
+#else
+    Kokkos::printf(
+        "KokkosBatched::HadamardProduct: Dimensions of X and V do not match: "
+        "X: %d x %d, "
+        "V: %d x %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)V.extent(0), (int)V.extent(1));
+#endif
     return 1;
   }
 #endif
@@ -161,19 +177,35 @@ KOKKOS_INLINE_FUNCTION int TeamHadamardProduct<MemberType>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::HadamardProduct: Dimensions of X and Y do not match: "
         "X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+#else
+    Kokkos::printf(
+        "KokkosBatched::HadamardProduct: Dimensions of X and Y do not match: "
+        "X: %d x %d, "
+        "Y: %d x %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+#endif
     return 1;
   }
   if (X.extent(0) != V.extent(0) || X.extent(1) != V.extent(1)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::HadamardProduct: Dimensions of X and V do not match: "
         "X: %d x %d, "
         "V: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)V.extent(0), (int)V.extent(1));
+#else
+    Kokkos::printf(
+        "KokkosBatched::HadamardProduct: Dimensions of X and V do not match: "
+        "X: %d x %d, "
+        "V: %d x %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)V.extent(0), (int)V.extent(1));
+#endif
     return 1;
   }
 #endif
@@ -214,19 +246,35 @@ KOKKOS_INLINE_FUNCTION int TeamVectorHadamardProduct<MemberType>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::HadamardProduct: Dimensions of X and Y do not match: "
         "X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+#else
+    Kokkos::printf(
+        "KokkosBatched::HadamardProduct: Dimensions of X and Y do not match: "
+        "X: %d x %d, "
+        "Y: %d x %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+#endif
     return 1;
   }
   if (X.extent(0) != V.extent(0) || X.extent(1) != V.extent(1)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::HadamardProduct: Dimensions of X and V do not match: "
         "X: %d x %d, "
         "V: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)V.extent(0), (int)V.extent(1));
+#else
+    Kokkos::printf(
+        "KokkosBatched::HadamardProduct: Dimensions of X and V do not match: "
+        "X: %d x %d, "
+        "V: %d x %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)V.extent(0), (int)V.extent(1));
+#endif
     return 1;
   }
 #endif

--- a/batched/dense/impl/KokkosBatched_Xpay_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Xpay_Impl.hpp
@@ -204,17 +204,31 @@ KOKKOS_INLINE_FUNCTION int SerialXpay::invoke(const alphaViewType& alpha,
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::xpay: Dimensions of X and Y do not match: X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+#else
+    Kokkos::printf(
+        "KokkosBatched::xpay: Dimensions of X and Y do not match: X: %d x %d, "
+        "Y: %d x %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+#endif
     return 1;
   }
   if (X.extent(0) != alpha.extent(0)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::xpay: First dimension of X and alpha do not match: X: "
         "%d x %d, alpha: %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
+#else
+    Kokkos::printf(
+        "KokkosBatched::xpay: First dimension of X and alpha do not match: X: "
+        "%d x %d, alpha: %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
+#endif
     return 1;
   }
 #endif
@@ -247,17 +261,31 @@ KOKKOS_INLINE_FUNCTION int TeamXpay<MemberType>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::xpay: Dimensions of X and Y do not match: X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+#else
+    Kokkos::printf(
+        "KokkosBatched::xpay: Dimensions of X and Y do not match: X: %d x %d, "
+        "Y: %d x %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+#endif
     return 1;
   }
   if (X.extent(0) != alpha.extent(0)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::xpay: First dimension of X and alpha do not match: X: "
         "%d x %d, alpha: %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
+#else
+    Kokkos::printf(
+        "KokkosBatched::xpay: First dimension of X and alpha do not match: X: "
+        "%d x %d, alpha: %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
+#endif
     return 1;
   }
 #endif
@@ -291,17 +319,31 @@ KOKKOS_INLINE_FUNCTION int TeamVectorXpay<MemberType>::invoke(
 
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::xpay: Dimensions of X and Y do not match: X: %d x %d, "
         "Y: %d x %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+#else
+    Kokkos::printf(
+        "KokkosBatched::xpay: Dimensions of X and Y do not match: X: %d x %d, "
+        "Y: %d x %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
+#endif
     return 1;
   }
   if (X.extent(0) != alpha.extent(0)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBatched::xpay: First dimension of X and alpha do not match: X: "
         "%d x %d, alpha: %d\n",
         (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
+#else
+    Kokkos::printf(
+        "KokkosBatched::xpay: First dimension of X and alpha do not match: X: "
+        "%d x %d, alpha: %d\n",
+        (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
+#endif
     return 1;
   }
 #endif

--- a/batched/sparse/impl/KokkosBatched_Spmv_Serial_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_Serial_Impl.hpp
@@ -153,49 +153,95 @@ struct SerialSpmv<Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
           "%d, Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
           (int)Y.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
+          "%d, Y: %d x %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
+          (int)Y.extent(1));
+#endif
       return 1;
     }
     if (X.extent(0) != alpha.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and alpha do not match: "
           "X: %d x %d, alpha: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: First dimension of X and alpha do not match: "
+          "X: %d x %d, alpha: %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
+#endif
       return 1;
     }
     if (X.extent(0) != beta.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and beta do not match: X: "
           "%d x %d, beta: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)beta.extent(0));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: First dimension of X and beta do not match: X: "
+          "%d x %d, beta: %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)beta.extent(0));
+#endif
       return 1;
     }
     if (X.extent(0) != values.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and the first dimension "
           "of values do not match: X: %d x %d, values: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
           (int)values.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: First dimension of X and the first dimension "
+          "of values do not match: X: %d x %d, values: %d x %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
+          (int)values.extent(1));
+#endif
       return 1;
     }
     if (colIndices.extent(0) != values.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of colIndices and the second "
           "dimension of values do not match: colIndices: %d , values: %d x "
           "%d\n",
           (int)colIndices.extent(0), (int)values.extent(0),
           (int)values.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: Dimension of colIndices and the second "
+          "dimension of values do not match: colIndices: %d , values: %d x "
+          "%d\n",
+          (int)colIndices.extent(0), (int)values.extent(0),
+          (int)values.extent(1));
+#endif
       return 1;
     }
     if (row_ptr.extent(0) - 1 != X.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
           "of X do not match: colIndices (-1): %d , values: %d x %d\n",
           (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
+          "of X do not match: colIndices (-1): %d , values: %d x %d\n",
+          (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));
+#endif
       return 1;
     }
 #endif
@@ -243,35 +289,67 @@ struct SerialSpmv<Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
           "%d, Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
           (int)Y.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
+          "%d, Y: %d x %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
+          (int)Y.extent(1));
+#endif
       return 1;
     }
     if (X.extent(0) != values.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and the first dimension "
           "of values do not match: X: %d x %d, values: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
           (int)values.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: First dimension of X and the first dimension "
+          "of values do not match: X: %d x %d, values: %d x %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
+          (int)values.extent(1));
+#endif
       return 1;
     }
     if (colIndices.extent(0) != values.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of colIndices and the second "
           "dimension of values do not match: colIndices: %d , values: %d x "
           "%d\n",
           (int)colIndices.extent(0), (int)values.extent(0),
           (int)values.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: Dimension of colIndices and the second "
+          "dimension of values do not match: colIndices: %d , values: %d x "
+          "%d\n",
+          (int)colIndices.extent(0), (int)values.extent(0),
+          (int)values.extent(1));
+#endif
       return 1;
     }
     if (row_ptr.extent(0) - 1 != X.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
           "of X do not match: colIndices (-1): %d , values: %d x %d\n",
           (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
+          "of X do not match: colIndices (-1): %d , values: %d x %d\n",
+          (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));
+#endif
       return 1;
     }
 #endif

--- a/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
@@ -341,49 +341,95 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
           "%d, Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
           (int)Y.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
+          "%d, Y: %d x %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
+          (int)Y.extent(1));
+#endif
       return 1;
     }
     if (X.extent(0) != alpha.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and alpha do not match: "
           "X: %d x %d, alpha: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: First dimension of X and alpha do not match: "
+          "X: %d x %d, alpha: %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
+#endif
       return 1;
     }
     if (X.extent(0) != beta.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and beta do not match: X: "
           "%d x %d, beta: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)beta.extent(0));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: First dimension of X and beta do not match: X: "
+          "%d x %d, beta: %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)beta.extent(0));
+#endif
       return 1;
     }
     if (X.extent(0) != values.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and the first dimension "
           "of values do not match: X: %d x %d, values: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
           (int)values.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: First dimension of X and the first dimension "
+          "of values do not match: X: %d x %d, values: %d x %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
+          (int)values.extent(1));
+#endif
       return 1;
     }
     if (colIndices.extent(0) != values.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of colIndices and the second "
           "dimension of values do not match: colIndices: %d , values: %d x "
           "%d\n",
           (int)colIndices.extent(0), (int)values.extent(0),
           (int)values.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: Dimension of colIndices and the second "
+          "dimension of values do not match: colIndices: %d , values: %d x "
+          "%d\n",
+          (int)colIndices.extent(0), (int)values.extent(0),
+          (int)values.extent(1));
+#endif
       return 1;
     }
     if (row_ptr.extent(0) - 1 != X.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
           "of X do not match: colIndices (-1): %d , values: %d x %d\n",
           (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
+          "of X do not match: colIndices (-1): %d , values: %d x %d\n",
+          (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));
+#endif
       return 1;
     }
 #endif
@@ -438,35 +484,67 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
           "%d, Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
           (int)Y.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
+          "%d, Y: %d x %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
+          (int)Y.extent(1));
+#endif
       return 1;
     }
     if (X.extent(0) != values.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and the first dimension "
           "of values do not match: X: %d x %d, values: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
           (int)values.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: First dimension of X and the first dimension "
+          "of values do not match: X: %d x %d, values: %d x %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
+          (int)values.extent(1));
+#endif
       return 1;
     }
     if (colIndices.extent(0) != values.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of colIndices and the second "
           "dimension of values do not match: colIndices: %d , values: %d x "
           "%d\n",
           (int)colIndices.extent(0), (int)values.extent(0),
           (int)values.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: Dimension of colIndices and the second "
+          "dimension of values do not match: colIndices: %d , values: %d x "
+          "%d\n",
+          (int)colIndices.extent(0), (int)values.extent(0),
+          (int)values.extent(1));
+#endif
       return 1;
     }
     if (row_ptr.extent(0) - 1 != X.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
           "of X do not match: colIndices (-1): %d , values: %d x %d\n",
           (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
+          "of X do not match: colIndices (-1): %d , values: %d x %d\n",
+          (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));
+#endif
       return 1;
     }
 #endif

--- a/batched/sparse/impl/KokkosBatched_Spmv_Team_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_Team_Impl.hpp
@@ -192,49 +192,95 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
           "%d, Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
           (int)Y.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
+          "%d, Y: %d x %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
+          (int)Y.extent(1));
+#endif
       return 1;
     }
     if (X.extent(0) != alpha.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and alpha do not match: "
           "X: %d x %d, alpha: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: First dimension of X and alpha do not match: "
+          "X: %d x %d, alpha: %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)alpha.extent(0));
+#endif
       return 1;
     }
     if (X.extent(0) != beta.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and beta do not match: X: "
           "%d x %d, beta: %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)beta.extent(0));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: First dimension of X and beta do not match: X: "
+          "%d x %d, beta: %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)beta.extent(0));
+#endif
       return 1;
     }
     if (X.extent(0) != values.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and the first dimension "
           "of values do not match: X: %d x %d, values: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
           (int)values.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: First dimension of X and the first dimension "
+          "of values do not match: X: %d x %d, values: %d x %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
+          (int)values.extent(1));
+#endif
       return 1;
     }
     if (colIndices.extent(0) != values.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of colIndices and the second "
           "dimension of values do not match: colIndices: %d , values: %d x "
           "%d\n",
           (int)colIndices.extent(0), (int)values.extent(0),
           (int)values.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: Dimension of colIndices and the second "
+          "dimension of values do not match: colIndices: %d , values: %d x "
+          "%d\n",
+          (int)colIndices.extent(0), (int)values.extent(0),
+          (int)values.extent(1));
+#endif
       return 1;
     }
     if (row_ptr.extent(0) - 1 != X.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
           "of X do not match: colIndices (-1): %d , values: %d x %d\n",
           (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
+          "of X do not match: colIndices (-1): %d , values: %d x %d\n",
+          (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));
+#endif
       return 1;
     }
 #endif
@@ -289,35 +335,67 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
 
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
           "%d, Y: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
           (int)Y.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: Dimensions of X and Y do not match: X: %d x "
+          "%d, Y: %d x %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0),
+          (int)Y.extent(1));
+#endif
       return 1;
     }
     if (X.extent(0) != values.extent(0)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: First dimension of X and the first dimension "
           "of values do not match: X: %d x %d, values: %d x %d\n",
           (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
           (int)values.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: First dimension of X and the first dimension "
+          "of values do not match: X: %d x %d, values: %d x %d\n",
+          (int)X.extent(0), (int)X.extent(1), (int)values.extent(0),
+          (int)values.extent(1));
+#endif
       return 1;
     }
     if (colIndices.extent(0) != values.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of colIndices and the second "
           "dimension of values do not match: colIndices: %d , values: %d x "
           "%d\n",
           (int)colIndices.extent(0), (int)values.extent(0),
           (int)values.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: Dimension of colIndices and the second "
+          "dimension of values do not match: colIndices: %d , values: %d x "
+          "%d\n",
+          (int)colIndices.extent(0), (int)values.extent(0),
+          (int)values.extent(1));
+#endif
       return 1;
     }
     if (row_ptr.extent(0) - 1 != X.extent(1)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
           "of X do not match: colIndices (-1): %d , values: %d x %d\n",
           (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));
+#else
+      Kokkos::printf(
+          "KokkosBatched::spmv: Dimension of row_ptr and the second dimension "
+          "of X do not match: colIndices (-1): %d , values: %d x %d\n",
+          (int)row_ptr.extent(0) - 1, (int)X.extent(0), (int)X.extent(1));
+#endif
       return 1;
     }
 #endif

--- a/batched/sparse/src/KokkosBatched_JacobiPrec.hpp
+++ b/batched/sparse/src/KokkosBatched_JacobiPrec.hpp
@@ -115,7 +115,7 @@ class JacobiPrec {
           "magnitude and have been replaced by one, \n",
           (int)tooSmall);
 #else
-    Kokkos::printf(
+      Kokkos::printf(
           "KokkosBatched::JacobiPrec: %d entrie(s) has/have a too small "
           "magnitude and have been replaced by one, \n",
           (int)tooSmall);

--- a/batched/sparse/src/KokkosBatched_JacobiPrec.hpp
+++ b/batched/sparse/src/KokkosBatched_JacobiPrec.hpp
@@ -109,10 +109,17 @@ class JacobiPrec {
     }
 
     if (tooSmall > 0)
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::JacobiPrec: %d entrie(s) has/have a too small "
           "magnitude and have been replaced by one, \n",
           (int)tooSmall);
+#else
+    Kokkos::printf(
+          "KokkosBatched::JacobiPrec: %d entrie(s) has/have a too small "
+          "magnitude and have been replaced by one, \n",
+          (int)tooSmall);
+#endif
     computed_inverse = true;
   }
 
@@ -131,10 +138,17 @@ class JacobiPrec {
       }
 
     if (tooSmall > 0)
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "KokkosBatched::JacobiPrec: %d entrie(s) has/have a too small "
           "magnitude and have been replaced by one, \n",
           (int)tooSmall);
+#else
+      Kokkos::printf(
+          "KokkosBatched::JacobiPrec: %d entrie(s) has/have a too small "
+          "magnitude and have been replaced by one, \n",
+          (int)tooSmall);
+#endif
     computed_inverse = true;
   }
 

--- a/blas/src/KokkosBlas1_nrm2.hpp
+++ b/blas/src/KokkosBlas1_nrm2.hpp
@@ -241,10 +241,17 @@ KOKKOS_INLINE_FUNCTION int serial_nrm2(const XMV X, const RV& R) {
       " Kokkos::ArithTraits<XMV::value_type>::mag_type");
 
   if (R.extent(0) != X.extent(1)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosBlas::serial_nrm2 (MV): Dimensions of R and X do not match,"
         " R: %d and X: %d x %d.\n",
         R.extent_int(0), X.extent_int(0), X.extent_int(1));
+#else
+    Kokkos::printf(
+        "KokkosBlas::serial_nrm2 (MV): Dimensions of R and X do not match,"
+        " R: %d and X: %d x %d.\n",
+        R.extent_int(0), X.extent_int(0), X.extent_int(1));
+#endif
     return 1;
   }
 #endif  // KOKKOSKERNELS_DEBUG_LEVEL

--- a/blas/unit_test/Test_Blas2_ger.hpp
+++ b/blas/unit_test/Test_Blas2_ger.hpp
@@ -1428,8 +1428,8 @@ int test_ger(const std::string& caseName) {
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s, device = %s ...\n",
                                 caseName.c_str(), typeid(Device).name());
 #else
-  Kokkos::printf("Starting %s, device = %s ...\n",
-                                caseName.c_str(), typeid(Device).name());
+  Kokkos::printf("Starting %s, device = %s ...\n", caseName.c_str(),
+                 typeid(Device).name());
 #endif
 #else
 int test_ger(const std::string& /*caseName*/) {
@@ -1465,8 +1465,7 @@ int test_ger(const std::string& /*caseName*/) {
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for LAYOUTLEFT ...\n",
                                 caseName.c_str());
 #else
-  Kokkos::printf("Starting %s for LAYOUTLEFT ...\n",
-                                caseName.c_str());
+  Kokkos::printf("Starting %s for LAYOUTLEFT ...\n", caseName.c_str());
 #endif
 #endif
   if (true) {
@@ -1502,8 +1501,7 @@ int test_ger(const std::string& /*caseName*/) {
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for LAYOUTLEFT\n",
                                 caseName.c_str());
 #else
-  Kokkos::printf("Finished %s for LAYOUTLEFT\n",
-                                caseName.c_str());
+  Kokkos::printf("Finished %s for LAYOUTLEFT\n", caseName.c_str());
 #endif
 #if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
@@ -1534,8 +1532,7 @@ int test_ger(const std::string& /*caseName*/) {
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for LAYOUTRIGHT ...\n",
                                 caseName.c_str());
 #else
-  Kokkos::printf("Starting %s for LAYOUTRIGHT ...\n",
-                                caseName.c_str());
+  Kokkos::printf("Starting %s for LAYOUTRIGHT ...\n", caseName.c_str());
 #endif
 #endif
   if (true) {
@@ -1571,8 +1568,7 @@ int test_ger(const std::string& /*caseName*/) {
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for LAYOUTRIGHT\n",
                                 caseName.c_str());
 #else
-  Kokkos::printf("Finished %s for LAYOUTRIGHT\n",
-                                caseName.c_str());
+  Kokkos::printf("Finished %s for LAYOUTRIGHT\n", caseName.c_str());
 #endif
 #if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
@@ -1602,8 +1598,7 @@ int test_ger(const std::string& /*caseName*/) {
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for LAYOUTSTRIDE ...\n",
                                 caseName.c_str());
 #else
-  Kokkos::printf("Starting %s for LAYOUTSTRIDE ...\n",
-                                caseName.c_str());
+  Kokkos::printf("Starting %s for LAYOUTSTRIDE ...\n", caseName.c_str());
 #endif
 #endif
   if (true) {
@@ -1636,8 +1631,7 @@ int test_ger(const std::string& /*caseName*/) {
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for LAYOUTSTRIDE\n",
                                 caseName.c_str());
 #else
-  Kokkos::printf("Finished %s for LAYOUTSTRIDE\n",
-                                caseName.c_str());
+  Kokkos::printf("Finished %s for LAYOUTSTRIDE\n", caseName.c_str());
 #endif
 #if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
@@ -1667,8 +1661,7 @@ int test_ger(const std::string& /*caseName*/) {
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for MIXED LAYOUTS ...\n",
                                 caseName.c_str());
 #else
-  Kokkos::printf("Starting %s for MIXED LAYOUTS ...\n",
-                                caseName.c_str());
+  Kokkos::printf("Starting %s for MIXED LAYOUTS ...\n", caseName.c_str());
 #endif
 #endif
   if (true) {
@@ -1696,8 +1689,7 @@ int test_ger(const std::string& /*caseName*/) {
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for MIXED LAYOUTS\n",
                                 caseName.c_str());
 #else
-  Kokkos::printf("Finished %s for MIXED LAYOUTS\n",
-                                caseName.c_str());
+  Kokkos::printf("Finished %s for MIXED LAYOUTS\n", caseName.c_str());
 #endif
 #if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(

--- a/blas/unit_test/Test_Blas2_ger.hpp
+++ b/blas/unit_test/Test_Blas2_ger.hpp
@@ -292,9 +292,15 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
   view_stride_adapter<_ViewTypeExpected, true> h_vanilla(
       "vanilla = A + alpha * x * y^{t,h}", _M, _N);
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "In Test_Blas2_ger.hpp, computing vanilla A with alpha type = %s\n",
       typeid(alpha).name());
+#else
+  Kokkos::printf(
+      "In Test_Blas2_ger.hpp, computing vanilla A with alpha type = %s\n",
+      typeid(alpha).name());
+#endif
 #endif
   this->populateVanillaValues(alpha, x.h_view, y.h_view, A.h_view,
                               h_vanilla.d_view);
@@ -1357,10 +1363,17 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
                                        const _ViewTypeExpected& h_expected,
                                        const std::string& situation) {
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "In Test_Blas2_ger.hpp, right before calling KokkosBlas::ger(): "
       "ViewTypeA = %s, _kkGerShouldThrowException=%d\n",
       typeid(_ViewTypeA).name(), _kkGerShouldThrowException);
+#else
+  Kokkos::printf(
+      "In Test_Blas2_ger.hpp, right before calling KokkosBlas::ger(): "
+      "ViewTypeA = %s, _kkGerShouldThrowException=%d\n",
+      typeid(_ViewTypeA).name(), _kkGerShouldThrowException);
+#endif
 #endif
   std::string mode = _useHermitianOption ? "H" : "T";
   bool gotStdException(false);
@@ -1402,11 +1415,22 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
 template <class ScalarX, class ScalarY, class ScalarA, class Device>
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
 int test_ger(const std::string& caseName) {
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+======================================================================="
       "===\n");
+#else
+  Kokkos::printf(
+      "+======================================================================="
+      "===\n");
+#endif
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s, device = %s ...\n",
                                 caseName.c_str(), typeid(Device).name());
+#else
+  Kokkos::printf("Starting %s, device = %s ...\n",
+                                caseName.c_str(), typeid(Device).name());
+#endif
 #else
 int test_ger(const std::string& /*caseName*/) {
 #endif
@@ -1428,11 +1452,22 @@ int test_ger(const std::string& /*caseName*/) {
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&      \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+-----------------------------------------------------------------------"
       "---\n");
+#else
+  Kokkos::printf(
+      "+-----------------------------------------------------------------------"
+      "---\n");
+#endif
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for LAYOUTLEFT ...\n",
                                 caseName.c_str());
+#else
+  Kokkos::printf("Starting %s for LAYOUTLEFT ...\n",
+                                caseName.c_str());
+#endif
 #endif
   if (true) {
     Test::GerTester<ScalarX, Kokkos::LayoutLeft, ScalarY, Kokkos::LayoutLeft,
@@ -1463,11 +1498,22 @@ int test_ger(const std::string& /*caseName*/) {
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for LAYOUTLEFT\n",
                                 caseName.c_str());
+#else
+  Kokkos::printf("Finished %s for LAYOUTLEFT\n",
+                                caseName.c_str());
+#endif
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+-----------------------------------------------------------------------"
       "---\n");
+#else
+  Kokkos::printf(
+      "+-----------------------------------------------------------------------"
+      "---\n");
+#endif
 #endif
 #endif
 
@@ -1475,11 +1521,22 @@ int test_ger(const std::string& /*caseName*/) {
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&       \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+-----------------------------------------------------------------------"
       "---\n");
+#else
+  Kokkos::printf(
+      "+-----------------------------------------------------------------------"
+      "---\n");
+#endif
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for LAYOUTRIGHT ...\n",
                                 caseName.c_str());
+#else
+  Kokkos::printf("Starting %s for LAYOUTRIGHT ...\n",
+                                caseName.c_str());
+#endif
 #endif
   if (true) {
     Test::GerTester<ScalarX, Kokkos::LayoutRight, ScalarY, Kokkos::LayoutRight,
@@ -1510,22 +1567,44 @@ int test_ger(const std::string& /*caseName*/) {
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for LAYOUTRIGHT\n",
                                 caseName.c_str());
+#else
+  Kokkos::printf("Finished %s for LAYOUTRIGHT\n",
+                                caseName.c_str());
+#endif
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+-----------------------------------------------------------------------"
       "---\n");
+#else
+  Kokkos::printf(
+      "+-----------------------------------------------------------------------"
+      "---\n");
+#endif
 #endif
 #endif
 
 #if (!defined(KOKKOSKERNELS_ETI_ONLY) && \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+-----------------------------------------------------------------------"
       "---\n");
+#else
+  Kokkos::printf(
+      "+-----------------------------------------------------------------------"
+      "---\n");
+#endif
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for LAYOUTSTRIDE ...\n",
                                 caseName.c_str());
+#else
+  Kokkos::printf("Starting %s for LAYOUTSTRIDE ...\n",
+                                caseName.c_str());
+#endif
 #endif
   if (true) {
     Test::GerTester<ScalarX, Kokkos::LayoutStride, ScalarY,
@@ -1553,22 +1632,44 @@ int test_ger(const std::string& /*caseName*/) {
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for LAYOUTSTRIDE\n",
                                 caseName.c_str());
+#else
+  Kokkos::printf("Finished %s for LAYOUTSTRIDE\n",
+                                caseName.c_str());
+#endif
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+-----------------------------------------------------------------------"
       "---\n");
+#else
+  Kokkos::printf(
+      "+-----------------------------------------------------------------------"
+      "---\n");
+#endif
 #endif
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && \
     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+-----------------------------------------------------------------------"
       "---\n");
+#else
+  Kokkos::printf(
+      "+-----------------------------------------------------------------------"
+      "---\n");
+#endif
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for MIXED LAYOUTS ...\n",
                                 caseName.c_str());
+#else
+  Kokkos::printf("Starting %s for MIXED LAYOUTS ...\n",
+                                caseName.c_str());
+#endif
 #endif
   if (true) {
     Test::GerTester<ScalarX, Kokkos::LayoutStride, ScalarY, Kokkos::LayoutLeft,
@@ -1591,19 +1692,40 @@ int test_ger(const std::string& /*caseName*/) {
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for MIXED LAYOUTS\n",
                                 caseName.c_str());
+#else
+  Kokkos::printf("Finished %s for MIXED LAYOUTS\n",
+                                caseName.c_str());
+#endif
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
+      "+-----------------------------------------------------------------------"
+      "---\n");
+#else
+  Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
 #endif
 #endif
+#endif
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s\n", caseName.c_str());
+#else
+  Kokkos::printf("Finished %s\n", caseName.c_str());
+#endif
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+======================================================================="
       "===\n");
+#else
+  Kokkos::printf(
+      "+======================================================================="
+      "===\n");
+#endif
 #endif
   return 1;
 }

--- a/blas/unit_test/Test_Blas2_syr.hpp
+++ b/blas/unit_test/Test_Blas2_syr.hpp
@@ -288,9 +288,15 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::test(
   view_stride_adapter<_ViewTypeExpected, true> h_vanilla(
       "vanilla = A + alpha * x * x^{t,h}", _M, _N);
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "In Test_Blas2_syr.hpp, computing vanilla A with alpha type = %s\n",
       typeid(alpha).name());
+#else
+  Kokkos::printf(
+      "In Test_Blas2_syr.hpp, computing vanilla A with alpha type = %s\n",
+      typeid(alpha).name());
+#endif
 #endif
   this->populateVanillaValues(alpha, x.h_view, A.h_view, h_vanilla.d_view);
 
@@ -1434,10 +1440,17 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "In Test_Blas2_syr, '" << situation << "', alpha = " << alpha
             << std::endl;
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "In Test_Blas2_syr.hpp, right before calling KokkosBlas::syr(): "
       "ViewTypeA = %s, _kkSyrShouldThrowException=%d\n",
       typeid(_ViewTypeA).name(), _kkSyrShouldThrowException);
+#else
+  Kokkos::printf(
+      "In Test_Blas2_syr.hpp, right before calling KokkosBlas::syr(): "
+      "ViewTypeA = %s, _kkSyrShouldThrowException=%d\n",
+      typeid(_ViewTypeA).name(), _kkSyrShouldThrowException);
+#endif
 #endif
   std::string mode = _useHermitianOption ? "H" : "T";
   std::string uplo = _useUpOption ? "U" : "L";
@@ -1491,10 +1504,17 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "In Test_Blas2_syr, '" << situation << "', alpha = " << alpha
             << std::endl;
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "In Test_Blas2_syr.hpp, right before calling KokkosBlas::ger(): "
       "ViewTypeA = %s, _kkGerShouldThrowException=%d\n",
       typeid(_ViewTypeA).name(), _kkGerShouldThrowException);
+#else
+  Kokkos::printf(
+      "In Test_Blas2_syr.hpp, right before calling KokkosBlas::ger(): "
+      "ViewTypeA = %s, _kkGerShouldThrowException=%d\n",
+      typeid(_ViewTypeA).name(), _kkGerShouldThrowException);
+#endif
 #endif
   std::string mode = _useHermitianOption ? "H" : "T";
   bool gotStdException(false);
@@ -1561,10 +1581,17 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::
 template <class ScalarX, class ScalarA, class Device>
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
 int test_syr(const std::string& caseName) {
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+======================================================================="
       "===\n");
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s ...\n", caseName.c_str());
+#else
+  Kokkos::printf(
+      "+======================================================================="
+      "===\n");
+  Kokkos::printf("Starting %s ...\n", caseName.c_str());
+#endif
 #else
 int test_syr(const std::string& /*caseName*/) {
 #endif
@@ -1582,11 +1609,19 @@ int test_syr(const std::string& /*caseName*/) {
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&      \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+-----------------------------------------------------------------------"
       "---\n");
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for LAYOUTLEFT ...\n",
                                 caseName.c_str());
+#else
+  Kokkos::printf(
+      "+-----------------------------------------------------------------------"
+      "---\n");
+  Kokkos::printf("Starting %s for LAYOUTLEFT ...\n",
+                                caseName.c_str());
+#endif
 #endif
   if (true) {
     Test::SyrTester<ScalarX, Kokkos::LayoutLeft, ScalarA, Kokkos::LayoutLeft,
@@ -1617,11 +1652,19 @@ int test_syr(const std::string& /*caseName*/) {
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for LAYOUTLEFT\n",
                                 caseName.c_str());
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+-----------------------------------------------------------------------"
       "---\n");
+#else
+  Kokkos::printf("Finished %s for LAYOUTLEFT\n",
+                                caseName.c_str());
+  Kokkos::printf(
+      "+-----------------------------------------------------------------------"
+      "---\n");
+#endif
 #endif
 #endif
 
@@ -1629,11 +1672,19 @@ int test_syr(const std::string& /*caseName*/) {
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&       \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+-----------------------------------------------------------------------"
       "---\n");
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for LAYOUTRIGHT ...\n",
                                 caseName.c_str());
+#else
+  Kokkos::printf(
+      "+-----------------------------------------------------------------------"
+      "---\n");
+  Kokkos::printf("Starting %s for LAYOUTRIGHT ...\n",
+                                caseName.c_str());
+#endif
 #endif
   if (true) {
     Test::SyrTester<ScalarX, Kokkos::LayoutRight, ScalarA, Kokkos::LayoutRight,
@@ -1664,11 +1715,19 @@ int test_syr(const std::string& /*caseName*/) {
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for LAYOUTRIGHT\n",
                                 caseName.c_str());
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+-----------------------------------------------------------------------"
       "---\n");
+#else
+  Kokkos::printf("Finished %s for LAYOUTRIGHT\n",
+                                caseName.c_str());
+  Kokkos::printf(
+      "+-----------------------------------------------------------------------"
+      "---\n");
+#endif
 #endif
 #endif
 
@@ -1676,11 +1735,19 @@ int test_syr(const std::string& /*caseName*/) {
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&        \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+-----------------------------------------------------------------------"
       "---\n");
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for LAYOUTSTRIDE ...\n",
                                 caseName.c_str());
+#else
+  Kokkos::printf(
+      "+-----------------------------------------------------------------------"
+      "---\n");
+  Kokkos::printf("Starting %s for LAYOUTSTRIDE ...\n",
+                                caseName.c_str());
+#endif
 #endif
   if (true) {
     Test::SyrTester<ScalarX, Kokkos::LayoutStride, ScalarA,
@@ -1711,22 +1778,38 @@ int test_syr(const std::string& /*caseName*/) {
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for LAYOUTSTRIDE\n",
                                 caseName.c_str());
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+-----------------------------------------------------------------------"
       "---\n");
+#else
+  Kokkos::printf("Finished %s for LAYOUTSTRIDE\n",
+                                caseName.c_str());
+  Kokkos::printf(
+      "+-----------------------------------------------------------------------"
+      "---\n");
+#endif
 #endif
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && \
     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+-----------------------------------------------------------------------"
       "---\n");
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Starting %s for MIXED LAYOUTS ...\n",
                                 caseName.c_str());
+#else
+  Kokkos::printf(
+      "+-----------------------------------------------------------------------"
+      "---\n");
+  Kokkos::printf("Starting %s for MIXED LAYOUTS ...\n",
+                                caseName.c_str());
+#endif
 #endif
   if (true) {
     Test::SyrTester<ScalarX, Kokkos::LayoutStride, ScalarA, Kokkos::LayoutRight,
@@ -1755,19 +1838,34 @@ int test_syr(const std::string& /*caseName*/) {
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for MIXED LAYOUTS\n",
                                 caseName.c_str());
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+-----------------------------------------------------------------------"
       "---\n");
+#else
+  Kokkos::printf("Finished %s for MIXED LAYOUTS\n",
+                                caseName.c_str());
+  Kokkos::printf(
+      "+-----------------------------------------------------------------------"
+      "---\n");
+#endif
 #endif
 #endif
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s\n", caseName.c_str());
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+======================================================================="
       "===\n");
+#else
+  Kokkos::printf("Finished %s\n", caseName.c_str());
+  Kokkos::printf(
+      "+======================================================================="
+      "===\n");
+#endif
 #endif
   return 1;
 }

--- a/blas/unit_test/Test_Blas2_syr.hpp
+++ b/blas/unit_test/Test_Blas2_syr.hpp
@@ -1619,8 +1619,7 @@ int test_syr(const std::string& /*caseName*/) {
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
-  Kokkos::printf("Starting %s for LAYOUTLEFT ...\n",
-                                caseName.c_str());
+  Kokkos::printf("Starting %s for LAYOUTLEFT ...\n", caseName.c_str());
 #endif
 #endif
   if (true) {
@@ -1659,8 +1658,7 @@ int test_syr(const std::string& /*caseName*/) {
       "+-----------------------------------------------------------------------"
       "---\n");
 #else
-  Kokkos::printf("Finished %s for LAYOUTLEFT\n",
-                                caseName.c_str());
+  Kokkos::printf("Finished %s for LAYOUTLEFT\n", caseName.c_str());
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
@@ -1682,8 +1680,7 @@ int test_syr(const std::string& /*caseName*/) {
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
-  Kokkos::printf("Starting %s for LAYOUTRIGHT ...\n",
-                                caseName.c_str());
+  Kokkos::printf("Starting %s for LAYOUTRIGHT ...\n", caseName.c_str());
 #endif
 #endif
   if (true) {
@@ -1722,8 +1719,7 @@ int test_syr(const std::string& /*caseName*/) {
       "+-----------------------------------------------------------------------"
       "---\n");
 #else
-  Kokkos::printf("Finished %s for LAYOUTRIGHT\n",
-                                caseName.c_str());
+  Kokkos::printf("Finished %s for LAYOUTRIGHT\n", caseName.c_str());
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
@@ -1745,8 +1741,7 @@ int test_syr(const std::string& /*caseName*/) {
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
-  Kokkos::printf("Starting %s for LAYOUTSTRIDE ...\n",
-                                caseName.c_str());
+  Kokkos::printf("Starting %s for LAYOUTSTRIDE ...\n", caseName.c_str());
 #endif
 #endif
   if (true) {
@@ -1785,8 +1780,7 @@ int test_syr(const std::string& /*caseName*/) {
       "+-----------------------------------------------------------------------"
       "---\n");
 #else
-  Kokkos::printf("Finished %s for LAYOUTSTRIDE\n",
-                                caseName.c_str());
+  Kokkos::printf("Finished %s for LAYOUTSTRIDE\n", caseName.c_str());
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
@@ -1807,8 +1801,7 @@ int test_syr(const std::string& /*caseName*/) {
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
-  Kokkos::printf("Starting %s for MIXED LAYOUTS ...\n",
-                                caseName.c_str());
+  Kokkos::printf("Starting %s for MIXED LAYOUTS ...\n", caseName.c_str());
 #endif
 #endif
   if (true) {
@@ -1845,8 +1838,7 @@ int test_syr(const std::string& /*caseName*/) {
       "+-----------------------------------------------------------------------"
       "---\n");
 #else
-  Kokkos::printf("Finished %s for MIXED LAYOUTS\n",
-                                caseName.c_str());
+  Kokkos::printf("Finished %s for MIXED LAYOUTS\n", caseName.c_str());
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");

--- a/common/src/KokkosKernels_Error.hpp
+++ b/common/src/KokkosKernels_Error.hpp
@@ -90,13 +90,12 @@ inline void hip_internal_safe_call(hipError_t e, const char *name,
     }                                                                       \
   } while (0)
 #else
-#define IMPL_KERNEL_THROW(condition, msg)				\
-  do {									\
-    if (!(condition)) {							\
-      Kokkos::printf("KERNEL CHECK FAILED:\n   %s\n   %s\n",		\
-		     #condition, msg);					\
-      Kokkos::abort("");						\
-    }									\
+#define IMPL_KERNEL_THROW(condition, msg)                                      \
+  do {                                                                         \
+    if (!(condition)) {                                                        \
+      Kokkos::printf("KERNEL CHECK FAILED:\n   %s\n   %s\n", #condition, msg); \
+      Kokkos::abort("");                                                       \
+    }                                                                          \
   } while (0)
 #endif
 

--- a/common/src/KokkosKernels_Error.hpp
+++ b/common/src/KokkosKernels_Error.hpp
@@ -80,6 +80,7 @@ inline void hip_internal_safe_call(hipError_t e, const char *name,
   } while (0)
 
 // SYCL cannot printf like the other backends quite yet
+#if KOKKOS_VERSION < 40199
 #define IMPL_KERNEL_THROW(condition, msg)                                   \
   do {                                                                      \
     if (!(condition)) {                                                     \
@@ -88,6 +89,16 @@ inline void hip_internal_safe_call(hipError_t e, const char *name,
       Kokkos::abort("");                                                    \
     }                                                                       \
   } while (0)
+#else
+#define IMPL_KERNEL_THROW(condition, msg)				\
+  do {									\
+    if (!(condition)) {							\
+      Kokkos::printf("KERNEL CHECK FAILED:\n   %s\n   %s\n",		\
+		     #condition, msg);					\
+      Kokkos::abort("");						\
+    }									\
+  } while (0)
+#endif
 
 #ifndef NDEBUG
 #define KK_ASSERT(condition) IMPL_THROW(condition, "", std::logic_error)

--- a/common/src/KokkosKernels_SimpleUtils.hpp
+++ b/common/src/KokkosKernels_SimpleUtils.hpp
@@ -340,11 +340,19 @@ struct IsRelativelyIdenticalFunctor {
     }
 
     if (val_diff > mag_type(eps)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "Values at index %d, %.6f + %.6fi and %.6f + %.6fi, differ too much "
           "(eps = %e)\n",
           (int)i, KAT::real(view1(i)), KAT::imag(view1(i)), KAT::real(view2(i)),
           KAT::imag(view2(i)), eps);
+#else
+      Kokkos::printf(
+          "Values at index %d, %.6f + %.6fi and %.6f + %.6fi, differ too much "
+          "(eps = %e)\n",
+          (int)i, KAT::real(view1(i)), KAT::imag(view1(i)), KAT::real(view2(i)),
+          KAT::imag(view2(i)), eps);
+#endif
       num_diffs++;
     }
   }

--- a/common/unit_test/Test_Common_ArithTraits.hpp
+++ b/common/unit_test/Test_Common_ArithTraits.hpp
@@ -35,17 +35,32 @@
 #include <typeinfo>  // typeid (T)
 #include <cstdio>
 
+#if KOKKOS_VERSION < 40199
 #define FAILURE()                                                            \
   {                                                                          \
     KOKKOS_IMPL_DO_NOT_USE_PRINTF("%s:%s:%d: Failure\n", __FILE__, __func__, \
                                   __LINE__);                                 \
     success = 0;                                                             \
   }
+#else
+#define FAILURE()							\
+  {									\
+    Kokkos::printf("%s:%s:%d: Failure\n", __FILE__, __func__,		\
+		   __LINE__);						\
+    success = 0;							\
+  }
+#endif
 
 #if 0
+#if KOKKOS_VERSION < 40199
 #define TRACE()                                                          \
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("%s:%s:%d: Trace\n", __FILE__, __func__, \
                                 __LINE__);
+#else
+#define TRACE()								\
+  Kokkos::printf("%s:%s:%d: Trace\n", __FILE__, __func__,		\
+		 __LINE__);
+#endif
 #else
 #define TRACE()
 #endif
@@ -181,7 +196,11 @@ class ArithTraitsTesterBase {
     // T, but we check for this int constant for compatibility with
     // std::numeric_limits.
     if (!AT::is_specialized) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("! AT::is_specialized\n");
+#else
+      Kokkos::printf("! AT::is_specialized\n");
+#endif
       FAILURE();
     }
 
@@ -189,13 +208,23 @@ class ArithTraitsTesterBase {
     // function, just not to its class methods (which are not marked
     // as device functions).
     if (AT::is_integer != std::numeric_limits<ScalarType>::is_integer) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "AT::is_integer not same as numeric_limits\n");
+#else
+      Kokkos::printf(
+          "AT::is_integer not same as numeric_limits\n");
+#endif
       FAILURE();
     }
     if (AT::is_exact != std::numeric_limits<ScalarType>::is_exact) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "AT::is_exact not same as numeric_limits\n");
+#else
+      Kokkos::printf(
+          "AT::is_exact not same as numeric_limits\n");
+#endif
       FAILURE();
     }
 
@@ -204,34 +233,62 @@ class ArithTraitsTesterBase {
 
     // Test properties of the arithmetic and multiplicative identities.
     if (zero + zero != zero) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("0 + 0 != 0\n");
+#else
+      Kokkos::printf("0 + 0 != 0\n");
+#endif
       FAILURE();
     }
     if (zero + one != one) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("0 + 1 != 1\n");
+#else
+      Kokkos::printf("0 + 1 != 1\n");
+#endif
       FAILURE();
     }
     if (one - one != zero) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("1 - 1 != 0\n");
+#else
+      Kokkos::printf("1 - 1 != 0\n");
+#endif
       FAILURE();
     }
     // This is technically 1 even of Z_2, since in that field, one
     // is its own inverse (so -one == one).
     if ((one + one) - one != one) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("(1 + 1) - 1 != 1\n");
+#else
+      Kokkos::printf("(1 + 1) - 1 != 1\n");
+#endif
       FAILURE();
     }
 
     if (AT::abs(zero) != zero) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::abs(0) != 0\n");
+#else
+      Kokkos::printf("AT::abs(0) != 0\n");
+#endif
       FAILURE();
     }
     if (AT::abs(one) != one) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::abs(1) != 1\n");
+#else
+      Kokkos::printf("AT::abs(1) != 1\n");
+#endif
       FAILURE();
     }
     if (AT::is_signed && AT::abs(-one) != one) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::is_signed and AT::abs(-1) != 1\n");
+#else
+      Kokkos::printf("AT::is_signed and AT::abs(-1) != 1\n");
+#endif
       FAILURE();
     }
     // Need enable_if to test whether T can be compared using <=.
@@ -240,7 +297,11 @@ class ArithTraitsTesterBase {
     // These are very mild ordering properties.
     // They should work even for a set only containing zero.
     if (AT::abs(zero) > AT::abs(AT::max())) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::abs(0) > AT::abs (AT::max ())\n");
+#else
+      Kokkos::printf("AT::abs(0) > AT::abs (AT::max ())\n");
+#endif
       FAILURE();
     }
 
@@ -553,20 +614,36 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
     if (!AT::is_complex) {
       result = AT::pow(two, three);
       if (!equal(result, eight)) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(2,3) != 8\n");
+#else
+        Kokkos::printf("AT::pow(2,3) != 8\n");
+#endif
         FAILURE();
       }
     }
     if (!equal(AT::pow(three, zero), one)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(3,0) != 1\n");
+#else
+      Kokkos::printf("AT::pow(3,0) != 1\n");
+#endif
       FAILURE();
     }
     if (!equal(AT::pow(three, one), three)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(3,1) != 3\n");
+#else
+      Kokkos::printf("AT::pow(3,1) != 3\n");
+#endif
       FAILURE();
     }
     if (!equal(AT::pow(three, two), nine)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(3,2) != 9\n");
+#else
+      Kokkos::printf("AT::pow(3,2) != 9\n");
+#endif
       FAILURE();
     }
 
@@ -574,7 +651,11 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
     if (!AT::is_complex) {
       result = AT::pow(three, three);
       if (!equal(result, twentySeven)) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(3,3) != 27\n");
+#else
+        Kokkos::printf("AT::pow(3,3) != 27\n");
+#endif
         FAILURE();
       }
     }
@@ -583,93 +664,170 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
     if (AT::is_signed && !AT::is_complex) {
       result = AT::pow(-three, one);
       if (!equal(result, -three)) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(-3,1) != -3\n");
+#else
+        Kokkos::printf("AT::pow(-3,1) != -3\n");
+#endif
         FAILURE();
       }
       result = AT::pow(-three, two);
       if (!equal(result, nine)) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(-3,2) != 9\n");
+#else
+        Kokkos::printf("AT::pow(-3,2) != 9\n");
+#endif
         FAILURE();
       }
       result = AT::pow(-three, three);
       if (!equal(result, -twentySeven)) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::pow(-3,3) != 27\n");
+#else
+        Kokkos::printf("AT::pow(-3,3) != 27\n");
+#endif
         FAILURE();
       }
     }
 
     if (!equal(AT::sqrt(zero), zero)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::sqrt(0) != 0\n");
+#else
+      Kokkos::printf("AT::sqrt(0) != 0\n");
+#endif
       FAILURE();
     }
     if (!equal(AT::sqrt(one), one)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::sqrt(1) != 1\n");
+#else
+      Kokkos::printf("AT::sqrt(1) != 1\n");
+#endif
       FAILURE();
     }
     if (!equal(AT::sqrt(thirtySix), six)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::sqrt(36) != 6\n");
+#else
+      Kokkos::printf("AT::sqrt(36) != 6\n");
+#endif
       FAILURE();
     }
     if (!equal(AT::sqrt(sixtyFour), eight)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::sqrt(64) != 8\n");
+#else
+      Kokkos::printf("AT::sqrt(64) != 8\n");
+#endif
       FAILURE();
     }
     if (AT::is_integer) {
       if (!equal(AT::sqrt(fortyTwo), six)) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT:sqrt(42) != 6\n");
+#else
+        Kokkos::printf("AT:sqrt(42) != 6\n");
+#endif
         FAILURE();
       }
       if (!equal(AT::sqrt(oneTwentySeven), eleven)) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::sqrt(127) != 11\n");
+#else
+        Kokkos::printf("AT::sqrt(127) != 11\n");
+#endif
         FAILURE();
       }
     }
 
     if (!equal(AT::cbrt(zero), zero)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(0) != 0\n");
+#else
+      Kokkos::printf("AT::cbrt(0) != 0\n");
+#endif
       FAILURE();
     }
     if (!equal(AT::cbrt(one), one)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(1) != 1\n");
+#else
+      Kokkos::printf("AT::cbrt(1) != 1\n");
+#endif
       FAILURE();
     }
     if (!equal(AT::cbrt(twentySeven), three)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(27) != 3\n");
+#else
+      Kokkos::printf("AT::cbrt(27) != 3\n");
+#endif
       FAILURE();
     }
     if (!equal(AT::cbrt(sixtyFour), four)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(64) != 4\n");
+#else
+      Kokkos::printf("AT::cbrt(64) != 4\n");
+#endif
       FAILURE();
     }
     if (AT::is_integer) {
       if (!equal(AT::cbrt(fortyTwo), three)) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT:cbrt(42) != 3\n");
+#else
+        Kokkos::printf("AT:cbrt(42) != 3\n");
+#endif
         FAILURE();
       }
       if (!equal(AT::cbrt(oneTwentySeven), five)) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(127) != 5\n");
+#else
+        Kokkos::printf("AT::cbrt(127) != 5\n");
+#endif
         FAILURE();
       }
     }
 
     if (!equal(AT::exp(zero), one)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(0) != 1\n");
+#else
+      Kokkos::printf("AT::cbrt(0) != 1\n");
+#endif
       FAILURE();
     }
     if (AT::is_complex) {
       const ScalarType val = two;  //(two.real(), two.real());
       if (!equal(AT::conj(AT::exp(val)), AT::exp(AT::conj(val)))) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF(
             "AT::conj(exp(complex(2,2))) != AT::exp(conj(complex(2,2)))\n");
+#else
+        Kokkos::printf(
+            "AT::conj(exp(complex(2,2))) != AT::exp(conj(complex(2,2)))\n");
+#endif
         FAILURE();
       }
     }
     if (!equal(AT::log(one), zero)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::log(1) != 0\n");
+#else
+      Kokkos::printf("AT::log(1) != 0\n");
+#endif
       FAILURE();
     }
     if (!equal(AT::log10(one), zero)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::log10(1) != 0\n");
+#else
+      Kokkos::printf("AT::log10(1) != 0\n");
+#endif
       FAILURE();
     }
 
@@ -678,13 +836,23 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
       const auto val_sin = AT::sin(val);
       const auto val_cos = AT::cos(val);
       if (!equal(val_sin * val_sin + val_cos * val_cos, one)) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF(
             "AT(complex):: sin(val)*sin(val) + cos(val)*cos(val) != 1\n");
+#else
+        Kokkos::printf(
+            "AT(complex):: sin(val)*sin(val) + cos(val)*cos(val) != 1\n");
+#endif
         FAILURE();
       }
       if (!equal(val_sin / val_cos, AT::tan(val))) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF(
             "AT(complex):: sin(val)/cos(val) != AT(real)::tan(val)\n");
+#else
+        Kokkos::printf(
+            "AT(complex):: sin(val)/cos(val) != AT(real)::tan(val)\n");
+#endif
         FAILURE();
       }
     } else {
@@ -692,27 +860,49 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
       const auto val_sin = AT::sin(val);
       const auto val_cos = AT::cos(val);
       if (!equal(val_sin * val_sin + val_cos * val_cos, one)) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF(
             "AT(real):: sin(val)*sin(val) + cos(a)*cos(a) != 1\n");
+#else
+        Kokkos::printf(
+            "AT(real):: sin(val)*sin(val) + cos(a)*cos(a) != 1\n");
+#endif
         FAILURE();
       }
       if (!equal(val_sin / val_cos, AT::tan(val))) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF(
             "AT(real):: sin(val)/cos(val) != AT(real)::tan(val)\n");
+#else
+        Kokkos::printf(
+            "AT(real):: sin(val)/cos(val) != AT(real)::tan(val)\n");
+#endif
         FAILURE();
       }
     }
 
     if (!equal(AT::asin(AT::sin(one)), one)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::asin(sin(1)) != 1\n");
+#else
+      Kokkos::printf("AT::asin(sin(1)) != 1\n");
+#endif
       FAILURE();
     }
     if (!equal(AT::acos(AT::cos(one)), one)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::acos(cos(1)) != 1\n");
+#else
+      Kokkos::printf("AT::acos(cos(1)) != 1\n");
+#endif
       FAILURE();
     }
     if (!equal(AT::atan(AT::tan(one)), one)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::atan(tan(1)) != 1\n");
+#else
+      Kokkos::printf("AT::atan(tan(1)) != 1\n");
+#endif
       FAILURE();
     }
 
@@ -839,41 +1029,74 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
     }
 
     if (!equal(AT::cbrt(zero), zero)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(0) != 0\n");
+#else
+      Kokkos::printf("AT::cbrt(0) != 0\n");
+#endif
       FAILURE();
     }
     if (!equal(AT::cbrt(one), one)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(1) != 1\n");
+#else
+      Kokkos::printf("AT::cbrt(1) != 1\n");
+#endif
       FAILURE();
     }
     if (!equal(AT::cbrt(twentySeven), three)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(27) != 3\n");
+#else
+      Kokkos::printf("AT::cbrt(27) != 3\n");
+#endif
       FAILURE();
     }
     if (!equal(AT::cbrt(sixtyFour), four)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(64) != 4\n");
+#else
+      Kokkos::printf("AT::cbrt(64) != 4\n");
+#endif
       FAILURE();
     }
     if (AT::is_integer) {
       if (!equal(AT::cbrt(fortyTwo), three)) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT:cbrt(42) != 3\n");
+#else
+        Kokkos::printf("AT:cbrt(42) != 3\n");
+#endif
         FAILURE();
       }
       if (!equal(AT::cbrt(oneTwentySeven), five)) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(127) != 5\n");
+#else
+        Kokkos::printf("AT::cbrt(127) != 5\n");
+#endif
         FAILURE();
       }
     }
 
     if (!equal(AT::exp(zero), one)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::cbrt(0) != 1\n");
+#else
+      Kokkos::printf("AT::cbrt(0) != 1\n");
+#endif
       FAILURE();
     }
     if (AT::is_complex) {
       const ScalarType val = two;  //(two.real(), two.real());
       if (!equal(AT::conj(AT::exp(val)), AT::exp(AT::conj(val)))) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF(
             "AT::conj(exp(complex(2,0))) != AT::exp(conj(complex(2,0)))\n");
+#else
+        Kokkos::printf(
+            "AT::conj(exp(complex(2,0))) != AT::exp(conj(complex(2,0)))\n");
+#endif
         FAILURE();
       }
     }
@@ -891,13 +1114,23 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
       const auto val_sin   = AT::sin(val);
       const auto val_cos   = AT::cos(val);
       if (!equal(val_sin * val_sin + val_cos * val_cos, one)) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF(
             "AT(complex):: sin(val)*sin(val) + cos(val)*cos(val) != 1\n");
+#else
+        Kokkos::printf(
+            "AT(complex):: sin(val)*sin(val) + cos(val)*cos(val) != 1\n");
+#endif
         FAILURE();
       }
       if (!equal(val_sin / val_cos, AT::tan(val))) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF(
             "AT(complex):: sin(val)/cos(val) != AT(real)::tan(val)\n");
+#else
+        Kokkos::printf(
+            "AT(complex):: sin(val)/cos(val) != AT(real)::tan(val)\n");
+#endif
         FAILURE();
       }
     } else {
@@ -905,27 +1138,49 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
       const auto val_sin   = AT::sin(val);
       const auto val_cos   = AT::cos(val);
       if (!equal(val_sin * val_sin + val_cos * val_cos, one)) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF(
             "AT(real):: sin(val)*sin(val) + cos(a)*cos(a) != 1\n");
+#else
+        Kokkos::printf(
+            "AT(real):: sin(val)*sin(val) + cos(a)*cos(a) != 1\n");
+#endif
         FAILURE();
       }
       if (!equal(val_sin / val_cos, AT::tan(val))) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF(
             "AT(real):: sin(val)/cos(val) != AT(real)::tan(val)\n");
+#else
+        Kokkos::printf(
+            "AT(real):: sin(val)/cos(val) != AT(real)::tan(val)\n");
+#endif
         FAILURE();
       }
     }
 
     if (!equal(AT::asin(AT::sin(three)), three)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::asin(sin(3)) != 3\n");
+#else
+      Kokkos::printf("AT::asin(sin(3)) != 3\n");
+#endif
       FAILURE();
     }
     if (!equal(AT::acos(AT::cos(three)), three)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::acos(cos(3)) != 3\n");
+#else
+      Kokkos::printf("AT::acos(cos(3)) != 3\n");
+#endif
       FAILURE();
     }
     if (!equal(AT::atan(AT::tan(three)), three)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::atan(tan(3)) != 3\n");
+#else
+      Kokkos::printf("AT::atan(tan(3)) != 3\n");
+#endif
       FAILURE();
     }
 
@@ -1017,10 +1272,17 @@ class ArithTraitsTesterComplexBase<ScalarType, DeviceType, 0>
 #else
     {
       if (AT::is_signed != std::numeric_limits<ScalarType>::is_signed) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF(
             "AT::is_signed = 0x%x, std::numeric_limits<ScalarType>::is_signed "
             "= 0x%x\n",
             AT::is_signed, std::numeric_limits<ScalarType>::is_signed);
+#else
+        Kokkos::printf(
+            "AT::is_signed = 0x%x, std::numeric_limits<ScalarType>::is_signed "
+            "= 0x%x\n",
+            AT::is_signed, std::numeric_limits<ScalarType>::is_signed);
+#endif
         FAILURE();
       }
     }
@@ -1233,12 +1495,20 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 0>
     int success = 1;
 
     if (AT::is_exact) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("AT::is_exact is 1\n");
+#else
+      Kokkos::printf("AT::is_exact is 1\n");
+#endif
       FAILURE();
     }
 
     if (!AT::isNan(AT::nan())) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("NaN is not NaN\n");
+#else
+      Kokkos::printf("NaN is not NaN\n");
+#endif
       FAILURE();
     }
 
@@ -1246,19 +1516,35 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 0>
     const ScalarType one  = AT::one();
 
     if (AT::isInf(zero)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("0 is Inf\n");
+#else
+      Kokkos::printf("0 is Inf\n");
+#endif
       FAILURE();
     }
     if (AT::isInf(one)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("1 is Inf\n");
+#else
+      Kokkos::printf("1 is Inf\n");
+#endif
       FAILURE();
     }
     if (AT::isNan(zero)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("0 is NaN\n");
+#else
+      Kokkos::printf("0 is NaN\n");
+#endif
       FAILURE();
     }
     if (AT::isNan(one)) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("1 is NaN\n");
+#else
+      Kokkos::printf("1 is NaN\n");
+#endif
       FAILURE();
     }
 
@@ -1352,7 +1638,11 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 1>
     int success = 1;
 
     if (!AT::is_exact) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("! AT:is_exact\n");
+#else
+      Kokkos::printf("! AT:is_exact\n");
+#endif
       FAILURE();
     }
 

--- a/common/unit_test/Test_Common_ArithTraits.hpp
+++ b/common/unit_test/Test_Common_ArithTraits.hpp
@@ -43,11 +43,10 @@
     success = 0;                                                             \
   }
 #else
-#define FAILURE()							\
-  {									\
-    Kokkos::printf("%s:%s:%d: Failure\n", __FILE__, __func__,		\
-		   __LINE__);						\
-    success = 0;							\
+#define FAILURE()                                                        \
+  {                                                                      \
+    Kokkos::printf("%s:%s:%d: Failure\n", __FILE__, __func__, __LINE__); \
+    success = 0;                                                         \
   }
 #endif
 
@@ -57,9 +56,8 @@
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("%s:%s:%d: Trace\n", __FILE__, __func__, \
                                 __LINE__);
 #else
-#define TRACE()								\
-  Kokkos::printf("%s:%s:%d: Trace\n", __FILE__, __func__,		\
-		 __LINE__);
+#define TRACE() \
+  Kokkos::printf("%s:%s:%d: Trace\n", __FILE__, __func__, __LINE__);
 #endif
 #else
 #define TRACE()
@@ -212,8 +210,7 @@ class ArithTraitsTesterBase {
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "AT::is_integer not same as numeric_limits\n");
 #else
-      Kokkos::printf(
-          "AT::is_integer not same as numeric_limits\n");
+      Kokkos::printf("AT::is_integer not same as numeric_limits\n");
 #endif
       FAILURE();
     }
@@ -222,8 +219,7 @@ class ArithTraitsTesterBase {
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "AT::is_exact not same as numeric_limits\n");
 #else
-      Kokkos::printf(
-          "AT::is_exact not same as numeric_limits\n");
+      Kokkos::printf("AT::is_exact not same as numeric_limits\n");
 #endif
       FAILURE();
     }
@@ -864,8 +860,7 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
         KOKKOS_IMPL_DO_NOT_USE_PRINTF(
             "AT(real):: sin(val)*sin(val) + cos(a)*cos(a) != 1\n");
 #else
-        Kokkos::printf(
-            "AT(real):: sin(val)*sin(val) + cos(a)*cos(a) != 1\n");
+        Kokkos::printf("AT(real):: sin(val)*sin(val) + cos(a)*cos(a) != 1\n");
 #endif
         FAILURE();
       }
@@ -874,8 +869,7 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
         KOKKOS_IMPL_DO_NOT_USE_PRINTF(
             "AT(real):: sin(val)/cos(val) != AT(real)::tan(val)\n");
 #else
-        Kokkos::printf(
-            "AT(real):: sin(val)/cos(val) != AT(real)::tan(val)\n");
+        Kokkos::printf("AT(real):: sin(val)/cos(val) != AT(real)::tan(val)\n");
 #endif
         FAILURE();
       }
@@ -1142,8 +1136,7 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
         KOKKOS_IMPL_DO_NOT_USE_PRINTF(
             "AT(real):: sin(val)*sin(val) + cos(a)*cos(a) != 1\n");
 #else
-        Kokkos::printf(
-            "AT(real):: sin(val)*sin(val) + cos(a)*cos(a) != 1\n");
+        Kokkos::printf("AT(real):: sin(val)*sin(val) + cos(a)*cos(a) != 1\n");
 #endif
         FAILURE();
       }
@@ -1152,8 +1145,7 @@ class ArithTraitsTesterTranscendentalBase<ScalarType, DeviceType, 1>
         KOKKOS_IMPL_DO_NOT_USE_PRINTF(
             "AT(real):: sin(val)/cos(val) != AT(real)::tan(val)\n");
 #else
-        Kokkos::printf(
-            "AT(real):: sin(val)/cos(val) != AT(real)::tan(val)\n");
+        Kokkos::printf("AT(real):: sin(val)/cos(val) != AT(real)::tan(val)\n");
 #endif
         FAILURE();
       }

--- a/common/unit_test/Test_Common_LowerBound.hpp
+++ b/common/unit_test/Test_Common_LowerBound.hpp
@@ -48,9 +48,8 @@ struct ThreadLowerBoundFunctor {
                                       __FILE__, __LINE__, int(i),
                                       int(expected_), int(idx));
 #else
-        Kokkos::printf("%s:%d thread %d expected %d got %d\n",
-                                      __FILE__, __LINE__, int(i),
-                                      int(expected_), int(idx));
+        Kokkos::printf("%s:%d thread %d expected %d got %d\n", __FILE__,
+                       __LINE__, int(i), int(expected_), int(idx));
 #endif
         ++lerrCount;
       }
@@ -111,9 +110,8 @@ struct TeamLowerBoundFunctor {
                                     __FILE__, __LINE__, int(handle.team_rank()),
                                     int(expected_), int(idx));
 #else
-      Kokkos::printf("%s:%d thread %d expected %d got %d\n",
-                                    __FILE__, __LINE__, int(handle.team_rank()),
-                                    int(expected_), int(idx));
+      Kokkos::printf("%s:%d thread %d expected %d got %d\n", __FILE__, __LINE__,
+                     int(handle.team_rank()), int(expected_), int(idx));
 #endif
       ++lerrCount;
     }

--- a/common/unit_test/Test_Common_LowerBound.hpp
+++ b/common/unit_test/Test_Common_LowerBound.hpp
@@ -43,9 +43,15 @@ struct ThreadLowerBoundFunctor {
     if (0 == i) {
       hv_size_type idx = KokkosKernels::lower_bound_thread(haystack_, needle_);
       if (idx != expected_) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF("%s:%d thread %d expected %d got %d\n",
                                       __FILE__, __LINE__, int(i),
                                       int(expected_), int(idx));
+#else
+        Kokkos::printf("%s:%d thread %d expected %d got %d\n",
+                                      __FILE__, __LINE__, int(i),
+                                      int(expected_), int(idx));
+#endif
         ++lerrCount;
       }
     }
@@ -100,9 +106,15 @@ struct TeamLowerBoundFunctor {
     hv_size_type idx =
         KokkosKernels::lower_bound_team(handle, haystack_, needle_);
     if (idx != expected_) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("%s:%d thread %d expected %d got %d\n",
                                     __FILE__, __LINE__, int(handle.team_rank()),
                                     int(expected_), int(idx));
+#else
+      Kokkos::printf("%s:%d thread %d expected %d got %d\n",
+                                    __FILE__, __LINE__, int(handle.team_rank()),
+                                    int(expected_), int(idx));
+#endif
       ++lerrCount;
     }
   }

--- a/common/unit_test/Test_Common_UpperBound.hpp
+++ b/common/unit_test/Test_Common_UpperBound.hpp
@@ -43,9 +43,15 @@ struct ThreadUpperBoundFunctor {
     if (0 == i) {
       hv_size_type idx = KokkosKernels::upper_bound_thread(haystack_, needle_);
       if (idx != expected_) {
+#if KOKKOS_VERSION < 40199
         KOKKOS_IMPL_DO_NOT_USE_PRINTF("%s:%d thread %d expected %d got %d\n",
                                       __FILE__, __LINE__, int(i),
                                       int(expected_), int(idx));
+#else
+        Kokkos::printf("%s:%d thread %d expected %d got %d\n",
+                                      __FILE__, __LINE__, int(i),
+                                      int(expected_), int(idx));
+#endif
         ++lerrCount;
       }
     }
@@ -100,9 +106,15 @@ struct TeamUpperBoundFunctor {
     hv_size_type idx =
         KokkosKernels::upper_bound_team(handle, haystack_, needle_);
     if (idx != expected_) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("%s:%d thread %d expected %d got %d\n",
                                     __FILE__, __LINE__, int(handle.team_rank()),
                                     int(expected_), int(idx));
+#else
+      Kokkos::printf("%s:%d thread %d expected %d got %d\n",
+                                    __FILE__, __LINE__, int(handle.team_rank()),
+                                    int(expected_), int(idx));
+#endif
       ++lerrCount;
     }
   }

--- a/common/unit_test/Test_Common_UpperBound.hpp
+++ b/common/unit_test/Test_Common_UpperBound.hpp
@@ -48,9 +48,8 @@ struct ThreadUpperBoundFunctor {
                                       __FILE__, __LINE__, int(i),
                                       int(expected_), int(idx));
 #else
-        Kokkos::printf("%s:%d thread %d expected %d got %d\n",
-                                      __FILE__, __LINE__, int(i),
-                                      int(expected_), int(idx));
+        Kokkos::printf("%s:%d thread %d expected %d got %d\n", __FILE__,
+                       __LINE__, int(i), int(expected_), int(idx));
 #endif
         ++lerrCount;
       }
@@ -111,9 +110,8 @@ struct TeamUpperBoundFunctor {
                                     __FILE__, __LINE__, int(handle.team_rank()),
                                     int(expected_), int(idx));
 #else
-      Kokkos::printf("%s:%d thread %d expected %d got %d\n",
-                                    __FILE__, __LINE__, int(handle.team_rank()),
-                                    int(expected_), int(idx));
+      Kokkos::printf("%s:%d thread %d expected %d got %d\n", __FILE__, __LINE__,
+                     int(handle.team_rank()), int(expected_), int(idx));
 #endif
       ++lerrCount;
     }

--- a/ode/impl/KokkosODE_Newton_impl.hpp
+++ b/ode/impl/KokkosODE_Newton_impl.hpp
@@ -74,8 +74,13 @@ KOKKOS_FUNCTION KokkosODE::Experimental::newton_solver_status NewtonSolve(
     KokkosBlas::SerialScale::invoke(-1, update);
 
     if (linSolverStat == 1) {
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "NewtonFunctor: Linear solve gesv returned failure! \n");
+#else
+      Kokkos::printf(
+          "NewtonFunctor: Linear solve gesv returned failure! \n");
+#endif
       return newton_solver_status::LIN_SOLVE_FAIL;
     }
 

--- a/ode/impl/KokkosODE_Newton_impl.hpp
+++ b/ode/impl/KokkosODE_Newton_impl.hpp
@@ -78,8 +78,7 @@ KOKKOS_FUNCTION KokkosODE::Experimental::newton_solver_status NewtonSolve(
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "NewtonFunctor: Linear solve gesv returned failure! \n");
 #else
-      Kokkos::printf(
-          "NewtonFunctor: Linear solve gesv returned failure! \n");
+      Kokkos::printf("NewtonFunctor: Linear solve gesv returned failure! \n");
 #endif
       return newton_solver_status::LIN_SOLVE_FAIL;
     }

--- a/sparse/src/KokkosSparse_spmv_team.hpp
+++ b/sparse/src/KokkosSparse_spmv_team.hpp
@@ -55,18 +55,32 @@ int KOKKOS_INLINE_FUNCTION team_spmv(
 
   // Check compatibility of dimensions at run time.
   if (values.extent(0) != colIndices.extent(0)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosSparse::spmv: Dimensions of values and colIndices do not match: "
         "values: %d, colIndices: %d",
         (int)values.extent(0), (int)colIndices.extent(0));
+#else
+    Kokkos::printf(
+        "KokkosSparse::spmv: Dimensions of values and colIndices do not match: "
+        "values: %d, colIndices: %d",
+        (int)values.extent(0), (int)colIndices.extent(0));
+#endif
     return 1;
   }
 
   if (x.extent(0) != y.extent(0) || (x.extent(0) + 1) != row_ptr.extent(0)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosSparse::spmv: Dimensions of x, y, and row_ptr do not match: "
         "x: %d, y: %d, row_ptr: %d",
         (int)x.extent(0), (int)y.extent(0), (int)row_ptr.extent(0));
+#else
+    Kokkos::printf(
+        "KokkosSparse::spmv: Dimensions of x, y, and row_ptr do not match: "
+        "x: %d, y: %d, row_ptr: %d",
+        (int)x.extent(0), (int)y.extent(0), (int)row_ptr.extent(0));
+#endif
     return 1;
   }
 #endif  // KOKKOSKERNELS_DEBUG_LEVEL
@@ -109,18 +123,32 @@ int KOKKOS_INLINE_FUNCTION team_vector_spmv(
 
   // Check compatibility of dimensions at run time.
   if (values.extent(0) != colIndices.extent(0)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosSparse::spmv: Dimensions of values and colIndices do not match: "
         "values: %d, colIndices: %d",
         (int)values.extent(0), (int)colIndices.extent(0));
+#else
+    Kokkos::printf(
+        "KokkosSparse::spmv: Dimensions of values and colIndices do not match: "
+        "values: %d, colIndices: %d",
+        (int)values.extent(0), (int)colIndices.extent(0));
+#endif
     return 1;
   }
 
   if (x.extent(0) != y.extent(0) || (x.extent(0) + 1) != row_ptr.extent(0)) {
+#if KOKKOS_VERSION < 40199
     KOKKOS_IMPL_DO_NOT_USE_PRINTF(
         "KokkosSparse::spmv: Dimensions of x, y, and row_ptr do not match: "
         "x: %d, y: %d, row_ptr: %d",
         (int)x.extent(0), (int)y.extent(0), (int)row_ptr.extent(0));
+#else
+    Kokkos::printf(
+        "KokkosSparse::spmv: Dimensions of x, y, and row_ptr do not match: "
+        "x: %d, y: %d, row_ptr: %d",
+        (int)x.extent(0), (int)y.extent(0), (int)row_ptr.extent(0));
+#endif
     return 1;
   }
 #endif  // KOKKOSKERNELS_DEBUG_LEVEL

--- a/sparse/unit_test/Test_Sparse_spmv.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv.hpp
@@ -94,9 +94,9 @@ struct fSPMV {
           "expected_y(%d)=%f, y(%d)=%f err=%e, max_error=%e\n", i,
           AT::abs(expected_y(i)), i, AT::abs(y(i)), error, eps * max_val);
 #else
-      Kokkos::printf(
-          "expected_y(%d)=%f, y(%d)=%f err=%e, max_error=%e\n", i,
-          AT::abs(expected_y(i)), i, AT::abs(y(i)), error, eps * max_val);
+      Kokkos::printf("expected_y(%d)=%f, y(%d)=%f err=%e, max_error=%e\n", i,
+                     AT::abs(expected_y(i)), i, AT::abs(y(i)), error,
+                     eps * max_val);
 #endif
     }
   }
@@ -113,10 +113,9 @@ struct fSPMV {
           AT::abs(expected_y(i, j)), i, j, AT::abs(y(i, j)), error,
           eps * max_val);
 #else
-      Kokkos::printf(
-          "expected_y(%d,%d)=%f, y(%d,%d)=%f err=%e, max_error=%e\n", i, j,
-          AT::abs(expected_y(i, j)), i, j, AT::abs(y(i, j)), error,
-          eps * max_val);
+      Kokkos::printf("expected_y(%d,%d)=%f, y(%d,%d)=%f err=%e, max_error=%e\n",
+                     i, j, AT::abs(expected_y(i, j)), i, j, AT::abs(y(i, j)),
+                     error, eps * max_val);
 #endif
     }
   }

--- a/sparse/unit_test/Test_Sparse_spmv.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv.hpp
@@ -89,9 +89,15 @@ struct fSPMV {
 
     if (error > eps * max_val) {
       err++;
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "expected_y(%d)=%f, y(%d)=%f err=%e, max_error=%e\n", i,
           AT::abs(expected_y(i)), i, AT::abs(y(i)), error, eps * max_val);
+#else
+      Kokkos::printf(
+          "expected_y(%d)=%f, y(%d)=%f err=%e, max_error=%e\n", i,
+          AT::abs(expected_y(i)), i, AT::abs(y(i)), error, eps * max_val);
+#endif
     }
   }
 
@@ -101,10 +107,17 @@ struct fSPMV {
 
     if (error > eps * max_val) {
       err++;
+#if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF(
           "expected_y(%d,%d)=%f, y(%d,%d)=%f err=%e, max_error=%e\n", i, j,
           AT::abs(expected_y(i, j)), i, j, AT::abs(y(i, j)), error,
           eps * max_val);
+#else
+      Kokkos::printf(
+          "expected_y(%d,%d)=%f, y(%d,%d)=%f err=%e, max_error=%e\n", i, j,
+          AT::abs(expected_y(i, j)), i, j, AT::abs(y(i, j)), error,
+          eps * max_val);
+#endif
     }
   }
 };


### PR DESCRIPTION
@masterleinad this PR will supersede #1946 
Kokkos Core is about to remove the KOKKOS_PRINTF macro in favor of Kokkos::printf function. To prepare for this we are guarding the old macro to no longer use it when compiling against newer versions of Kokkos Core.