### PR TITLE
Common: remove half and bhalf implementations

### DIFF
--- a/common/src/KokkosKernels_Half.hpp
+++ b/common/src/KokkosKernels_Half.hpp
@@ -14,6 +14,7 @@
 //
 //@HEADER
 
+#if KOKKOS_VERSION < 40199
 #ifndef KOKKOSKERNELS_HALF_HPP
 #define KOKKOSKERNELS_HALF_HPP
 
@@ -61,3 +62,4 @@ namespace Experimental {
 }  // namespace Experimental
 }  // namespace KokkosKernels
 #endif  // KOKKOSKERNELS_HALF_HPP
+#endif  // KOKKOS_VERSION < 40199

--- a/common/src/Kokkos_ArithTraits.hpp
+++ b/common/src/Kokkos_ArithTraits.hpp
@@ -924,7 +924,7 @@ class ArithTraits<Kokkos::Experimental::half_t> {
   static constexpr bool is_integer     = false;
   static constexpr bool is_exact       = false;
   static constexpr bool is_complex     = false;
-  static constexpr bool has_infinity = true;
+  static constexpr bool has_infinity   = true;
 
 #if KOKKOS_VERSION < 40199
   static KOKKOS_FUNCTION val_type infinity() {
@@ -1100,7 +1100,7 @@ class ArithTraits<Kokkos::Experimental::bhalf_t> {
   static constexpr bool is_integer     = false;
   static constexpr bool is_exact       = false;
   static constexpr bool is_complex     = false;
-  static constexpr bool has_infinity = true;
+  static constexpr bool has_infinity   = true;
 
 #if KOKKOS_VERSION < 40199
   static KOKKOS_FUNCTION val_type infinity() {
@@ -1203,8 +1203,8 @@ class ArithTraits<Kokkos::Experimental::bhalf_t> {
 #endif
 
   // Backwards compatibility with Teuchos::ScalarTraits.
-  using magnitudeType = mag_type;
-  using bhalfPrecision  = Kokkos::Experimental::bhalf_t;
+  using magnitudeType  = mag_type;
+  using bhalfPrecision = Kokkos::Experimental::bhalf_t;
   // There is no type that has twice the precision as bhalf_t.
   // The closest type would be float.
   using doublePrecision = void;

--- a/common/src/Kokkos_ArithTraits.hpp
+++ b/common/src/Kokkos_ArithTraits.hpp
@@ -279,6 +279,83 @@ namespace Kokkos {
   static FUNC_QUAL val_type squareroot(const val_type x) { return sqrt(x); }   \
   static FUNC_QUAL mag_type eps() { return epsilon(); }
 
+// Macro to automate the wrapping of Kokkos Mathematical Functions
+#define KOKKOSKERNELS_ARITHTRAITS_HALF_FP(FUNC_QUAL)                           \
+  static FUNC_QUAL val_type zero() { return static_cast<val_type>(0); }        \
+  static FUNC_QUAL val_type one() { return static_cast<val_type>(1); }         \
+  static FUNC_QUAL val_type min() {                                            \
+    return Kokkos::Experimental::finite_min<val_type>::value;                  \
+  }                                                                            \
+  static FUNC_QUAL val_type max() {                                            \
+    return Kokkos::Experimental::finite_max<val_type>::value;                  \
+  }                                                                            \
+  static FUNC_QUAL val_type infinity() {                                       \
+    return Kokkos::Experimental::infinity<val_type>::value;                    \
+  }                                                                            \
+  static FUNC_QUAL val_type nan() {                                            \
+    return Kokkos::Experimental::quiet_NaN<val_type>::value;                   \
+  }                                                                            \
+  static FUNC_QUAL mag_type epsilon() {                                        \
+    return Kokkos::Experimental::epsilon<val_type>::value;                     \
+  }                                                                            \
+  static FUNC_QUAL mag_type sfmin() {                                          \
+    return Kokkos::Experimental::norm_min<val_type>::value;                    \
+  }                                                                            \
+  static FUNC_QUAL int base() {                                                \
+    return Kokkos::Experimental::radix<val_type>::value;                       \
+  }                                                                            \
+  static FUNC_QUAL mag_type prec() {                                           \
+    return epsilon() * static_cast<mag_type>(base());                          \
+  }                                                                            \
+  static FUNC_QUAL int t() {                                                   \
+    return Kokkos::Experimental::digits<val_type>::value;                      \
+  }                                                                            \
+  static FUNC_QUAL mag_type rnd() { return one(); }                            \
+  static FUNC_QUAL int emin() {                                                \
+    return Kokkos::Experimental::min_exponent<val_type>::value;                \
+  }                                                                            \
+  static FUNC_QUAL mag_type rmin() {                                           \
+    return Kokkos::Experimental::norm_min<val_type>::value;                    \
+  }                                                                            \
+  static FUNC_QUAL int emax() {                                                \
+    return Kokkos::Experimental::max_exponent<val_type>::value;                \
+  }                                                                            \
+  static FUNC_QUAL mag_type rmax() {                                           \
+    return Kokkos::Experimental::finite_max<val_type>::value;                  \
+  }                                                                            \
+                                                                               \
+  static FUNC_QUAL bool isInf(const val_type x) { return Kokkos::isinf(x); }   \
+  static FUNC_QUAL mag_type abs(const val_type x) { return Kokkos::abs(x); }   \
+  static FUNC_QUAL mag_type real(const val_type x) { return Kokkos::real(x); } \
+  static FUNC_QUAL mag_type imag(const val_type x) { return Kokkos::imag(x); } \
+  static FUNC_QUAL val_type conj(const val_type x) { return x; }               \
+  static FUNC_QUAL val_type pow(const val_type x, const val_type y) {          \
+    return Kokkos::pow(x, y);                                                  \
+  }                                                                            \
+  static FUNC_QUAL val_type sqrt(const val_type x) { return Kokkos::sqrt(x); } \
+  static FUNC_QUAL val_type cbrt(const val_type x) { return Kokkos::cbrt(x); } \
+  static FUNC_QUAL val_type exp(const val_type x) { return Kokkos::exp(x); }   \
+  static FUNC_QUAL val_type log(const val_type x) { return Kokkos::log(x); }   \
+  static FUNC_QUAL val_type log10(const val_type x) {                          \
+    return Kokkos::log10(x);                                                   \
+  }                                                                            \
+  static FUNC_QUAL val_type sin(const val_type x) { return Kokkos::sin(x); }   \
+  static FUNC_QUAL val_type cos(const val_type x) { return Kokkos::cos(x); }   \
+  static FUNC_QUAL val_type tan(const val_type x) { return Kokkos::tan(x); }   \
+  static FUNC_QUAL val_type sinh(const val_type x) { return Kokkos::sinh(x); } \
+  static FUNC_QUAL val_type cosh(const val_type x) { return Kokkos::cosh(x); } \
+  static FUNC_QUAL val_type tanh(const val_type x) { return Kokkos::tanh(x); } \
+  static FUNC_QUAL val_type asin(const val_type x) { return Kokkos::asin(x); } \
+  static FUNC_QUAL val_type acos(const val_type x) { return Kokkos::acos(x); } \
+  static FUNC_QUAL val_type atan(const val_type x) { return Kokkos::atan(x); } \
+                                                                               \
+  static FUNC_QUAL magnitudeType magnitude(const val_type x) {                 \
+    return abs(x);                                                             \
+  }                                                                            \
+  static FUNC_QUAL val_type conjugate(const val_type x) { return conj(x); }    \
+  static FUNC_QUAL val_type squareroot(const val_type x) { return sqrt(x); }   \
+  static FUNC_QUAL mag_type eps() { return epsilon(); }
+
 #define KOKKOSKERNELS_ARITHTRAITS_CMPLX_FP(FUNC_QUAL)                          \
                                                                                \
   static constexpr bool is_specialized = true;                                 \
@@ -1081,7 +1158,11 @@ class ArithTraits<Kokkos::Experimental::half_t> {
     return Kokkos::Experimental::cast_to_half(KOKKOSKERNELS_IMPL_FP16_MAX);
   }
 #else
+#if defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_HIP)
+  KOKKOSKERNELS_ARITHTRAITS_HALF_FP(KOKKOS_FUNCTION)
+#else
   KOKKOSKERNELS_ARITHTRAITS_REAL_FP(KOKKOS_FUNCTION)
+#endif
 #endif
 };
 #endif  // #if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT

--- a/common/unit_test/Test_Common_ArithTraits.hpp
+++ b/common/unit_test/Test_Common_ArithTraits.hpp
@@ -1545,6 +1545,8 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 0>
 #endif
       FAILURE();
     }
+#if defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_HIP) // FIXME_SYCL, FIXME_HIP
+    if constexpr(!std::is_same_v<ScalarType, Kokkos::Experimental::half_t>) {
     if (AT::isNan(zero)) {
 #if KOKKOS_VERSION < 40199
       KOKKOS_IMPL_DO_NOT_USE_PRINTF("0 is NaN\n");
@@ -1561,6 +1563,25 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 0>
 #endif
       FAILURE();
     }
+    }
+#else
+    if (AT::isNan(zero)) {
+#if KOKKOS_VERSION < 40199
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("0 is NaN\n");
+#else
+      Kokkos::printf("0 is NaN\n");
+#endif
+      FAILURE();
+    }
+    if (AT::isNan(one)) {
+#if KOKKOS_VERSION < 40199
+      KOKKOS_IMPL_DO_NOT_USE_PRINTF("1 is NaN\n");
+#else
+      Kokkos::printf("1 is NaN\n");
+#endif
+      FAILURE();
+    }
+#endif
 
     // Call the base class' implementation.  Every subclass'
     // implementation of operator() must do this, in order to include
@@ -1585,10 +1606,19 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 0>
 
     // if (std::numeric_limits<ScalarType>::is_iec559) {
     // success = success && AT::isInf (AT::inf ());
+#if defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_HIP)
+    if constexpr (!std::is_same_v<ScalarType, Kokkos::Experimental::half_t>) {
+	if (!AT::isNan(AT::nan())) {
+	  out << "isNan or nan failed" << endl;
+	  FAILURE();
+	}
+      }
+#else
     if (!AT::isNan(AT::nan())) {
       out << "isNan or nan failed" << endl;
       FAILURE();
     }
+#endif
     //}
 
     const ScalarType zero = AT::zero();
@@ -1602,6 +1632,8 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 0>
       out << "isInf(one) is 1" << endl;
       FAILURE();
     }
+#if defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_HIP)
+    if constexpr (!std::is_same_v<ScalarType, Kokkos::Experimental::half_t>) {
     if (AT::isNan(zero)) {
       out << "isNan(zero) is 1" << endl;
       FAILURE();
@@ -1610,6 +1642,17 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 0>
       out << "isNan(one) is 1" << endl;
       FAILURE();
     }
+    }
+#else
+    if (AT::isNan(zero)) {
+      out << "isNan(zero) is 1" << endl;
+      FAILURE();
+    }
+    if (AT::isNan(one)) {
+      out << "isNan(one) is 1" << endl;
+      FAILURE();
+    }
+#endif
 
     // Call the base class' implementation.  Every subclass'
     // implementation of testHostImpl() should (must) do this, in

--- a/common/unit_test/Test_Common_ArithTraits.hpp
+++ b/common/unit_test/Test_Common_ArithTraits.hpp
@@ -1545,24 +1545,25 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 0>
 #endif
       FAILURE();
     }
-#if defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_HIP) // FIXME_SYCL, FIXME_HIP
-    if constexpr(!std::is_same_v<ScalarType, Kokkos::Experimental::half_t>) {
-    if (AT::isNan(zero)) {
+#if defined(KOKKOS_ENABLE_SYCL) || \
+    defined(KOKKOS_ENABLE_HIP)  // FIXME_SYCL, FIXME_HIP
+    if constexpr (!std::is_same_v<ScalarType, Kokkos::Experimental::half_t>) {
+      if (AT::isNan(zero)) {
 #if KOKKOS_VERSION < 40199
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("0 is NaN\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("0 is NaN\n");
 #else
-      Kokkos::printf("0 is NaN\n");
+        Kokkos::printf("0 is NaN\n");
 #endif
-      FAILURE();
-    }
-    if (AT::isNan(one)) {
+        FAILURE();
+      }
+      if (AT::isNan(one)) {
 #if KOKKOS_VERSION < 40199
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("1 is NaN\n");
+        KOKKOS_IMPL_DO_NOT_USE_PRINTF("1 is NaN\n");
 #else
-      Kokkos::printf("1 is NaN\n");
+        Kokkos::printf("1 is NaN\n");
 #endif
-      FAILURE();
-    }
+        FAILURE();
+      }
     }
 #else
     if (AT::isNan(zero)) {
@@ -1608,11 +1609,11 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 0>
     // success = success && AT::isInf (AT::inf ());
 #if defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_HIP)
     if constexpr (!std::is_same_v<ScalarType, Kokkos::Experimental::half_t>) {
-	if (!AT::isNan(AT::nan())) {
-	  out << "isNan or nan failed" << endl;
-	  FAILURE();
-	}
+      if (!AT::isNan(AT::nan())) {
+        out << "isNan or nan failed" << endl;
+        FAILURE();
       }
+    }
 #else
     if (!AT::isNan(AT::nan())) {
       out << "isNan or nan failed" << endl;
@@ -1634,14 +1635,14 @@ class ArithTraitsTesterFloatingPointBase<ScalarType, DeviceType, 0>
     }
 #if defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_HIP)
     if constexpr (!std::is_same_v<ScalarType, Kokkos::Experimental::half_t>) {
-    if (AT::isNan(zero)) {
-      out << "isNan(zero) is 1" << endl;
-      FAILURE();
-    }
-    if (AT::isNan(one)) {
-      out << "isNan(one) is 1" << endl;
-      FAILURE();
-    }
+      if (AT::isNan(zero)) {
+        out << "isNan(zero) is 1" << endl;
+        FAILURE();
+      }
+      if (AT::isNan(one)) {
+        out << "isNan(one) is 1" << endl;
+        FAILURE();
+      }
     }
 #else
     if (AT::isNan(zero)) {

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -411,6 +411,7 @@ class epsilon {
   constexpr static double value = std::numeric_limits<T>::epsilon();
 };
 
+#if KOKKOS_VERSION < 40199
 // explicit epsilon specializations
 #if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
 template <>
@@ -428,6 +429,7 @@ class epsilon<Kokkos::Experimental::bhalf_t> {
   constexpr static double value = 0.0078125F;
 };
 #endif  // KOKKOS_HALF_T_IS_FLOAT
+#endif  // KOKKOS_VERSION < 40199
 
 using KokkosKernels::Impl::getRandomBounds;
 


### PR DESCRIPTION
Both half and bhalf implementation details have been moved to Kokkos Core so their implementation in ArithTraits is replaced by the macro that calls Kokkos Core math functions instead.