### PR TITLE
Add sptrsv execution space overloads

### DIFF
--- a/blas/impl/KokkosBlas2_gemv_spec.hpp
+++ b/blas/impl/KokkosBlas2_gemv_spec.hpp
@@ -104,10 +104,10 @@ struct GEMV {
     // Prefer int as the index type, but use a larger type if needed.
     if (numRows < static_cast<size_type>(INT_MAX) &&
         numCols < static_cast<size_type>(INT_MAX)) {
-      generalGemvImpl<AViewType, XViewType, YViewType, int>(space, trans, alpha,
-                                                            A, x, beta, y);
+      generalGemvImpl<ExecutionSpace, AViewType, XViewType, YViewType, int>(
+          space, trans, alpha, A, x, beta, y);
     } else {
-      generalGemvImpl<AViewType, XViewType, YViewType, int64_t>(
+      generalGemvImpl<ExecutionSpace, AViewType, XViewType, YViewType, int64_t>(
           space, trans, alpha, A, x, beta, y);
     }
     Kokkos::Profiling::popRegion();

--- a/docs/developer/apidocs/sparse.rst
+++ b/docs/developer/apidocs/sparse.rst
@@ -94,3 +94,16 @@ par_ilut
 gmres
 -----
 .. doxygenfunction:: gmres(KernelHandle* handle, AMatrix& A, BType& B, XType& X, Preconditioner<AMatrix>* precond)
+
+sptrsv
+------
+.. doxygenfunction:: sptrsv_symbolic(const ExecutionSpace &space, KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries)
+.. doxygenfunction:: sptrsv_symbolic(KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries)
+.. doxygenfunction:: sptrsv_symbolic(ExecutionSpace &space, KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries, scalar_nnz_view_t_ values)
+.. doxygenfunction:: sptrsv_symbolic(KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries, scalar_nnz_view_t_ values)
+.. doxygenfunction:: sptrsv_solve(ExecutionSpace &space, KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries, scalar_nnz_view_t_ values, BType b, XType x)
+.. doxygenfunction:: sptrsv_solve(KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries, scalar_nnz_view_t_ values, BType b, XType x)
+.. doxygenfunction:: sptrsv_solve(ExecutionSpace &space, KernelHandle *handle, XType x, XType b)
+.. doxygenfunction:: sptrsv_solve(KernelHandle *handle, XType x, XType b)
+.. doxygenfunction:: sptrsv_solve(ExecutionSpace &space, KernelHandle *handleL, KernelHandle *handleU, XType x, XType b)
+.. doxygenfunction:: sptrsv_solve(KernelHandle *handleL, KernelHandle *handleU, XType x, XType b)

--- a/sparse/impl/KokkosSparse_sptrsv_cuSPARSE_impl.hpp
+++ b/sparse/impl/KokkosSparse_sptrsv_cuSPARSE_impl.hpp
@@ -22,10 +22,11 @@
 namespace KokkosSparse {
 namespace Impl {
 
-template <typename KernelHandle, typename ain_row_index_view_type,
+template <typename ExecutionSpace, typename KernelHandle,
+          typename ain_row_index_view_type,
           typename ain_nonzero_index_view_type,
           typename ain_values_scalar_view_type>
-void sptrsvcuSPARSE_symbolic(KernelHandle *sptrsv_handle,
+void sptrsvcuSPARSE_symbolic(ExecutionSpace &space, KernelHandle *sptrsv_handle,
                              typename KernelHandle::nnz_lno_t nrows,
                              ain_row_index_view_type row_map,
                              ain_nonzero_index_view_type entries,
@@ -60,6 +61,9 @@ void sptrsvcuSPARSE_symbolic(KernelHandle *sptrsv_handle,
 
     typename KernelHandle::SPTRSVcuSparseHandleType *h =
         sptrsv_handle->get_cuSparseHandle();
+
+    KOKKOS_CUSPARSE_SAFE_CALL(
+        cusparseSetStream(h->handle, space.cuda_stream()));
 
     int64_t nnz = static_cast<int64_t>(entries.extent(0));
     size_t pBufferSize;
@@ -98,13 +102,13 @@ void sptrsvcuSPARSE_symbolic(KernelHandle *sptrsv_handle,
         CUSPARSE_INDEX_BASE_ZERO, cudaValueType));
 
     // Create dummy dense vector B (RHS)
-    nnz_scalar_view_t b_dummy("b_dummy", nrows);
+    nnz_scalar_view_t b_dummy(Kokkos::view_alloc(space, "b_dummy"), nrows);
     KOKKOS_CUSPARSE_SAFE_CALL(
         cusparseCreateDnVec(&(h->vecBDescr_dummy), static_cast<int64_t>(nrows),
                             b_dummy.data(), cudaValueType));
 
     // Create dummy dense vector X (LHS)
-    nnz_scalar_view_t x_dummy("x_dummy", nrows);
+    nnz_scalar_view_t x_dummy(Kokkos::view_alloc(space, "x_dummy"), nrows);
     KOKKOS_CUSPARSE_SAFE_CALL(
         cusparseCreateDnVec(&(h->vecXDescr_dummy), static_cast<int64_t>(nrows),
                             x_dummy.data(), cudaValueType));
@@ -163,8 +167,11 @@ void sptrsvcuSPARSE_symbolic(KernelHandle *sptrsv_handle,
     bool is_lower = sptrsv_handle->is_lower_tri();
     sptrsv_handle->create_cuSPARSE_Handle(trans, is_lower);
 
-    typename KernelHandle::SPTRSVcuSparseHandleType* h =
+    typename KernelHandle::SPTRSVcuSparseHandleType *h =
         sptrsv_handle->get_cuSparseHandle();
+
+    KOKKOS_CUSPARSE_SAFE_CALL(
+        cusparseSetStream(h->handle, space.cuda_stream()));
 
     cusparseStatus_t status;
     status = cusparseCreateCsrsv2Info(&(h->info));
@@ -178,85 +185,86 @@ void sptrsvcuSPARSE_symbolic(KernelHandle *sptrsv_handle,
 
     if (!std::is_same<size_type, int>::value)
       sptrsv_handle->allocate_tmp_int_rowmap(row_map.extent(0));
-    const int* rm = !std::is_same<size_type, int>::value
+    const int *rm = !std::is_same<size_type, int>::value
                         ? sptrsv_handle->get_int_rowmap_ptr_copy(row_map)
-                        : (const int*)row_map.data();
-    const int* ent          = (const int*)entries.data();
-    const scalar_type* vals = values.data();
+                        : (const int *)row_map.data();
+    const int *ent          = (const int *)entries.data();
+    const scalar_type *vals = values.data();
 
     if (std::is_same<scalar_type, double>::value) {
       cusparseDcsrsv2_bufferSize(h->handle, h->transpose, nrows, nnz, h->descr,
-                                 (double*)vals, (int*)rm, (int*)ent, h->info,
+                                 (double *)vals, (int *)rm, (int *)ent, h->info,
                                  &pBufferSize);
 
       // pBuffer returned by cudaMalloc is automatically aligned to 128 bytes.
       cudaError_t my_error;
-      my_error = cudaMalloc((void**)&(h->pBuffer), pBufferSize);
+      my_error = cudaMalloc((void **)&(h->pBuffer), pBufferSize);
 
       if (cudaSuccess != my_error)
         std::cout << "cudmalloc pBuffer error_t error name "
                   << cudaGetErrorString(my_error) << std::endl;
 
       status = cusparseDcsrsv2_analysis(
-          h->handle, h->transpose, nrows, nnz, h->descr, (double*)vals,
-          (int*)rm, (int*)ent, h->info, h->policy, h->pBuffer);
+          h->handle, h->transpose, nrows, nnz, h->descr, (double *)vals,
+          (int *)rm, (int *)ent, h->info, h->policy, h->pBuffer);
 
       if (CUSPARSE_STATUS_SUCCESS != status)
         std::cout << "analysis status error name " << (status) << std::endl;
     } else if (std::is_same<scalar_type, float>::value) {
       cusparseScsrsv2_bufferSize(h->handle, h->transpose, nrows, nnz, h->descr,
-                                 (float*)vals, (int*)rm, (int*)ent, h->info,
+                                 (float *)vals, (int *)rm, (int *)ent, h->info,
                                  &pBufferSize);
 
       // pBuffer returned by cudaMalloc is automatically aligned to 128 bytes.
       cudaError_t my_error;
-      my_error = cudaMalloc((void**)&(h->pBuffer), pBufferSize);
+      my_error = cudaMalloc((void **)&(h->pBuffer), pBufferSize);
 
       if (cudaSuccess != my_error)
         std::cout << "cudmalloc pBuffer error_t error name "
                   << cudaGetErrorString(my_error) << std::endl;
 
       status = cusparseScsrsv2_analysis(
-          h->handle, h->transpose, nrows, nnz, h->descr, (float*)vals, (int*)rm,
-          (int*)ent, h->info, h->policy, h->pBuffer);
+          h->handle, h->transpose, nrows, nnz, h->descr, (float *)vals,
+          (int *)rm, (int *)ent, h->info, h->policy, h->pBuffer);
 
       if (CUSPARSE_STATUS_SUCCESS != status)
         std::cout << "analysis status error name " << (status) << std::endl;
     } else if (std::is_same<scalar_type, Kokkos::complex<double> >::value) {
       cusparseZcsrsv2_bufferSize(h->handle, h->transpose, nrows, nnz, h->descr,
-                                 (cuDoubleComplex*)vals, (int*)rm, (int*)ent,
+                                 (cuDoubleComplex *)vals, (int *)rm, (int *)ent,
                                  h->info, &pBufferSize);
 
       // pBuffer returned by cudaMalloc is automatically aligned to 128 bytes.
       cudaError_t my_error;
-      my_error = cudaMalloc((void**)&(h->pBuffer), pBufferSize);
+      my_error = cudaMalloc((void **)&(h->pBuffer), pBufferSize);
 
       if (cudaSuccess != my_error)
         std::cout << "cudmalloc pBuffer error_t error name "
                   << cudaGetErrorString(my_error) << std::endl;
 
-      status = cusparseZcsrsv2_analysis(
-          h->handle, h->transpose, nrows, nnz, h->descr, (cuDoubleComplex*)vals,
-          (int*)rm, (int*)ent, h->info, h->policy, h->pBuffer);
+      status =
+          cusparseZcsrsv2_analysis(h->handle, h->transpose, nrows, nnz,
+                                   h->descr, (cuDoubleComplex *)vals, (int *)rm,
+                                   (int *)ent, h->info, h->policy, h->pBuffer);
 
       if (CUSPARSE_STATUS_SUCCESS != status)
         std::cout << "analysis status error name " << (status) << std::endl;
     } else if (std::is_same<scalar_type, Kokkos::complex<float> >::value) {
       cusparseCcsrsv2_bufferSize(h->handle, h->transpose, nrows, nnz, h->descr,
-                                 (cuComplex*)vals, (int*)rm, (int*)ent, h->info,
-                                 &pBufferSize);
+                                 (cuComplex *)vals, (int *)rm, (int *)ent,
+                                 h->info, &pBufferSize);
 
       // pBuffer returned by cudaMalloc is automatically aligned to 128 bytes.
       cudaError_t my_error;
-      my_error = cudaMalloc((void**)&(h->pBuffer), pBufferSize);
+      my_error = cudaMalloc((void **)&(h->pBuffer), pBufferSize);
 
       if (cudaSuccess != my_error)
         std::cout << "cudmalloc pBuffer error_t error name "
                   << cudaGetErrorString(my_error) << std::endl;
 
       status = cusparseCcsrsv2_analysis(
-          h->handle, h->transpose, nrows, nnz, h->descr, (cuComplex*)vals,
-          (int*)rm, (int*)ent, h->info, h->policy, h->pBuffer);
+          h->handle, h->transpose, nrows, nnz, h->descr, (cuComplex *)vals,
+          (int *)rm, (int *)ent, h->info, h->policy, h->pBuffer);
 
       if (CUSPARSE_STATUS_SUCCESS != status)
         std::cout << "analysis status error name " << (status) << std::endl;
@@ -281,10 +289,11 @@ void sptrsvcuSPARSE_symbolic(KernelHandle *sptrsv_handle,
 }
 
 template <
-    typename KernelHandle, typename ain_row_index_view_type,
-    typename ain_nonzero_index_view_type, typename ain_values_scalar_view_type,
-    typename b_values_scalar_view_type, typename x_values_scalar_view_type>
-void sptrsvcuSPARSE_solve(KernelHandle *sptrsv_handle,
+    typename ExecutionSpace, typename KernelHandle,
+    typename ain_row_index_view_type, typename ain_nonzero_index_view_type,
+    typename ain_values_scalar_view_type, typename b_values_scalar_view_type,
+    typename x_values_scalar_view_type>
+void sptrsvcuSPARSE_solve(ExecutionSpace &space, KernelHandle *sptrsv_handle,
                           typename KernelHandle::nnz_lno_t nrows,
                           ain_row_index_view_type row_map,
                           ain_nonzero_index_view_type entries,
@@ -323,6 +332,9 @@ void sptrsvcuSPARSE_solve(KernelHandle *sptrsv_handle,
     typename KernelHandle::SPTRSVcuSparseHandleType *h =
         sptrsv_handle->get_cuSparseHandle();
 
+    KOKKOS_CUSPARSE_SAFE_CALL(
+        cusparseSetStream(h->handle, space.cuda_stream()));
+
     const scalar_type alpha = scalar_type(1.0);
 
     cudaDataType cudaValueType = cuda_data_type_from<scalar_type>();
@@ -354,18 +366,21 @@ void sptrsvcuSPARSE_solve(KernelHandle *sptrsv_handle,
   if (std::is_same<idx_type, int>::value) {
     cusparseStatus_t status;
 
-    typename KernelHandle::SPTRSVcuSparseHandleType* h =
+    typename KernelHandle::SPTRSVcuSparseHandleType *h =
         sptrsv_handle->get_cuSparseHandle();
+
+    KOKKOS_CUSPARSE_SAFE_CALL(
+        cusparseSetStream(h->handle, space.cuda_stream()));
 
     int nnz = entries.extent_int(0);
 
-    const int* rm = !std::is_same<size_type, int>::value
+    const int *rm = !std::is_same<size_type, int>::value
                         ? sptrsv_handle->get_int_rowmap_ptr()
-                        : (const int*)row_map.data();
-    const int* ent          = (const int*)entries.data();
-    const scalar_type* vals = values.data();
-    const scalar_type* bv   = rhs.data();
-    scalar_type* xv         = lhs.data();
+                        : (const int *)row_map.data();
+    const int *ent          = (const int *)entries.data();
+    const scalar_type *vals = values.data();
+    const scalar_type *bv   = rhs.data();
+    scalar_type *xv         = lhs.data();
 
     if (std::is_same<scalar_type, double>::value) {
       if (h->pBuffer == nullptr) {
@@ -373,10 +388,10 @@ void sptrsvcuSPARSE_solve(KernelHandle *sptrsv_handle,
       }
       const double alpha = double(1);
 
-      status = cusparseDcsrsv2_solve(h->handle, h->transpose, nrows, nnz,
-                                     &alpha, h->descr, (double*)vals, (int*)rm,
-                                     (int*)ent, h->info, (double*)bv,
-                                     (double*)xv, h->policy, h->pBuffer);
+      status = cusparseDcsrsv2_solve(
+          h->handle, h->transpose, nrows, nnz, &alpha, h->descr, (double *)vals,
+          (int *)rm, (int *)ent, h->info, (double *)bv, (double *)xv, h->policy,
+          h->pBuffer);
 
       if (CUSPARSE_STATUS_SUCCESS != status)
         std::cout << "solve status error name " << (status) << std::endl;
@@ -387,9 +402,9 @@ void sptrsvcuSPARSE_solve(KernelHandle *sptrsv_handle,
       const float alpha = float(1);
 
       status = cusparseScsrsv2_solve(h->handle, h->transpose, nrows, nnz,
-                                     &alpha, h->descr, (float*)vals, (int*)rm,
-                                     (int*)ent, h->info, (float*)bv, (float*)xv,
-                                     h->policy, h->pBuffer);
+                                     &alpha, h->descr, (float *)vals, (int *)rm,
+                                     (int *)ent, h->info, (float *)bv,
+                                     (float *)xv, h->policy, h->pBuffer);
 
       if (CUSPARSE_STATUS_SUCCESS != status)
         std::cout << "solve status error name " << (status) << std::endl;
@@ -399,8 +414,8 @@ void sptrsvcuSPARSE_solve(KernelHandle *sptrsv_handle,
       cualpha.y = 0.0;
       status    = cusparseZcsrsv2_solve(
           h->handle, h->transpose, nrows, nnz, &cualpha, h->descr,
-          (cuDoubleComplex*)vals, (int*)rm, (int*)ent, h->info,
-          (cuDoubleComplex*)bv, (cuDoubleComplex*)xv, h->policy, h->pBuffer);
+          (cuDoubleComplex *)vals, (int *)rm, (int *)ent, h->info,
+          (cuDoubleComplex *)bv, (cuDoubleComplex *)xv, h->policy, h->pBuffer);
 
       if (CUSPARSE_STATUS_SUCCESS != status)
         std::cout << "solve status error name " << (status) << std::endl;
@@ -410,8 +425,8 @@ void sptrsvcuSPARSE_solve(KernelHandle *sptrsv_handle,
       cualpha.y = 0.0;
       status    = cusparseCcsrsv2_solve(
           h->handle, h->transpose, nrows, nnz, &cualpha, h->descr,
-          (cuComplex*)vals, (int*)rm, (int*)ent, h->info, (cuComplex*)bv,
-          (cuComplex*)xv, h->policy, h->pBuffer);
+          (cuComplex *)vals, (int *)rm, (int *)ent, h->info, (cuComplex *)bv,
+          (cuComplex *)xv, h->policy, h->pBuffer);
 
       if (CUSPARSE_STATUS_SUCCESS != status)
         std::cout << "solve status error name " << (status) << std::endl;
@@ -539,13 +554,13 @@ void sptrsvcuSPARSE_solve_streams(
         "CUSPARSE requires local ordinals to be integer.\n");
   } else {
     const scalar_type alpha = scalar_type(1.0);
-    std::vector<sptrsvHandleType*> sptrsv_handle_v(nstreams);
-    std::vector<sptrsvCuSparseHandleType*> h_v(nstreams);
-    std::vector<const int*> rm_v(nstreams);
-    std::vector<const int*> ent_v(nstreams);
-    std::vector<const scalar_type*> vals_v(nstreams);
-    std::vector<const scalar_type*> bv_v(nstreams);
-    std::vector<scalar_type*> xv_v(nstreams);
+    std::vector<sptrsvHandleType *> sptrsv_handle_v(nstreams);
+    std::vector<sptrsvCuSparseHandleType *> h_v(nstreams);
+    std::vector<const int *> rm_v(nstreams);
+    std::vector<const int *> ent_v(nstreams);
+    std::vector<const scalar_type *> vals_v(nstreams);
+    std::vector<const scalar_type *> bv_v(nstreams);
+    std::vector<scalar_type *> xv_v(nstreams);
 
     for (int i = 0; i < nstreams; i++) {
       sptrsv_handle_v[i] = handle_v[i].get_sptrsv_handle();
@@ -560,8 +575,8 @@ void sptrsvcuSPARSE_solve_streams(
       }
       rm_v[i] = !std::is_same<size_type, int>::value
                     ? sptrsv_handle_v[i]->get_int_rowmap_ptr()
-                    : reinterpret_cast<const int*>(row_map_v[i].data());
-      ent_v[i]  = reinterpret_cast<const int*>(entries_v[i].data());
+                    : reinterpret_cast<const int *>(row_map_v[i].data());
+      ent_v[i]  = reinterpret_cast<const int *>(entries_v[i].data());
       vals_v[i] = values_v[i].data();
       bv_v[i]   = rhs_v[i].data();
       xv_v[i]   = lhs_v[i].data();
@@ -573,42 +588,42 @@ void sptrsvcuSPARSE_solve_streams(
       if (std::is_same<scalar_type, double>::value) {
         KOKKOS_CUSPARSE_SAFE_CALL(cusparseDcsrsv2_solve(
             h_v[i]->handle, h_v[i]->transpose, nrows, nnz,
-            reinterpret_cast<const double*>(&alpha), h_v[i]->descr,
-            reinterpret_cast<const double*>(vals_v[i]),
-            reinterpret_cast<const int*>(rm_v[i]),
-            reinterpret_cast<const int*>(ent_v[i]), h_v[i]->info,
-            reinterpret_cast<const double*>(bv_v[i]),
-            reinterpret_cast<double*>(xv_v[i]), h_v[i]->policy,
+            reinterpret_cast<const double *>(&alpha), h_v[i]->descr,
+            reinterpret_cast<const double *>(vals_v[i]),
+            reinterpret_cast<const int *>(rm_v[i]),
+            reinterpret_cast<const int *>(ent_v[i]), h_v[i]->info,
+            reinterpret_cast<const double *>(bv_v[i]),
+            reinterpret_cast<double *>(xv_v[i]), h_v[i]->policy,
             h_v[i]->pBuffer));
       } else if (std::is_same<scalar_type, float>::value) {
         KOKKOS_CUSPARSE_SAFE_CALL(cusparseScsrsv2_solve(
             h_v[i]->handle, h_v[i]->transpose, nrows, nnz,
-            reinterpret_cast<const float*>(&alpha), h_v[i]->descr,
-            reinterpret_cast<const float*>(vals_v[i]),
-            reinterpret_cast<const int*>(rm_v[i]),
-            reinterpret_cast<const int*>(ent_v[i]), h_v[i]->info,
-            reinterpret_cast<const float*>(bv_v[i]),
-            reinterpret_cast<float*>(xv_v[i]), h_v[i]->policy,
+            reinterpret_cast<const float *>(&alpha), h_v[i]->descr,
+            reinterpret_cast<const float *>(vals_v[i]),
+            reinterpret_cast<const int *>(rm_v[i]),
+            reinterpret_cast<const int *>(ent_v[i]), h_v[i]->info,
+            reinterpret_cast<const float *>(bv_v[i]),
+            reinterpret_cast<float *>(xv_v[i]), h_v[i]->policy,
             h_v[i]->pBuffer));
       } else if (std::is_same<scalar_type, Kokkos::complex<double> >::value) {
         KOKKOS_CUSPARSE_SAFE_CALL(cusparseZcsrsv2_solve(
             h_v[i]->handle, h_v[i]->transpose, nrows, nnz,
-            reinterpret_cast<const cuDoubleComplex*>(&alpha), h_v[i]->descr,
-            reinterpret_cast<const cuDoubleComplex*>(vals_v[i]),
-            reinterpret_cast<const int*>(rm_v[i]),
-            reinterpret_cast<const int*>(ent_v[i]), h_v[i]->info,
-            reinterpret_cast<const cuDoubleComplex*>(bv_v[i]),
-            reinterpret_cast<cuDoubleComplex*>(xv_v[i]), h_v[i]->policy,
+            reinterpret_cast<const cuDoubleComplex *>(&alpha), h_v[i]->descr,
+            reinterpret_cast<const cuDoubleComplex *>(vals_v[i]),
+            reinterpret_cast<const int *>(rm_v[i]),
+            reinterpret_cast<const int *>(ent_v[i]), h_v[i]->info,
+            reinterpret_cast<const cuDoubleComplex *>(bv_v[i]),
+            reinterpret_cast<cuDoubleComplex *>(xv_v[i]), h_v[i]->policy,
             h_v[i]->pBuffer));
       } else if (std::is_same<scalar_type, Kokkos::complex<float> >::value) {
         KOKKOS_CUSPARSE_SAFE_CALL(cusparseCcsrsv2_solve(
             h_v[i]->handle, h_v[i]->transpose, nrows, nnz,
-            reinterpret_cast<const cuComplex*>(&alpha), h_v[i]->descr,
-            reinterpret_cast<const cuComplex*>(vals_v[i]),
-            reinterpret_cast<const int*>(rm_v[i]),
-            reinterpret_cast<const int*>(ent_v[i]), h_v[i]->info,
-            reinterpret_cast<const cuComplex*>(bv_v[i]),
-            reinterpret_cast<cuComplex*>(xv_v[i]), h_v[i]->policy,
+            reinterpret_cast<const cuComplex *>(&alpha), h_v[i]->descr,
+            reinterpret_cast<const cuComplex *>(vals_v[i]),
+            reinterpret_cast<const int *>(rm_v[i]),
+            reinterpret_cast<const int *>(ent_v[i]), h_v[i]->info,
+            reinterpret_cast<const cuComplex *>(bv_v[i]),
+            reinterpret_cast<cuComplex *>(xv_v[i]), h_v[i]->policy,
             h_v[i]->pBuffer));
       } else {
         throw std::runtime_error("CUSPARSE wrapper error: unsupported type.\n");

--- a/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
+++ b/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
@@ -2891,16 +2891,15 @@ void upper_tri_solve_cg(TriSolveHandle &thandle, const RowMapType row_map,
 
 #endif
 
-template <class TriSolveHandle, class RowMapType, class EntriesType,
-          class ValuesType, class RHSType, class LHSType>
-void lower_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
-                     const EntriesType entries, const ValuesType values,
-                     const RHSType &rhs, LHSType &lhs) {
+template <class ExecutionSpace, class TriSolveHandle, class RowMapType,
+          class EntriesType, class ValuesType, class RHSType, class LHSType>
+void lower_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
+                     const RowMapType row_map, const EntriesType entries,
+                     const ValuesType values, const RHSType &rhs,
+                     LHSType &lhs) {
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOSPSTRSV_SOLVE_IMPL_PROFILE)
   cudaProfilerStop();
 #endif
-
-  typedef typename TriSolveHandle::execution_space execution_space;
   typedef typename TriSolveHandle::size_type size_type;
   typedef typename TriSolveHandle::nnz_lno_view_t NGBLType;
 
@@ -2981,8 +2980,10 @@ void lower_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
             KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_RP) {
           Kokkos::parallel_for(
               "parfor_fixed_lvl",
-              Kokkos::RangePolicy<execution_space>(node_count,
-                                                   node_count + lvl_nodes),
+              Kokkos::Experimental::require(
+                  Kokkos::RangePolicy<ExecutionSpace>(space, node_count,
+                                                      node_count + lvl_nodes),
+                  Kokkos::Experimental::WorkItemProperty::HintLightWeight),
               LowerTriLvlSchedRPSolverFunctor<RowMapType, EntriesType,
                                               ValuesType, LHSType, RHSType,
                                               NGBLType>(
@@ -2990,8 +2991,8 @@ void lower_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
         } else if (thandle.get_algorithm() ==
                    KokkosSparse::Experimental::SPTRSVAlgorithm::
                        SEQLVLSCHD_TP1) {
-          typedef Kokkos::TeamPolicy<execution_space> policy_type;
-          int team_size = thandle.get_team_size();
+          using team_policy_t = Kokkos::TeamPolicy<ExecutionSpace>;
+          int team_size       = thandle.get_team_size();
 
 #ifdef KOKKOSKERNELS_SPTRSV_TRILVLSCHED
           TriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
@@ -3005,11 +3006,19 @@ void lower_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
                    node_count);
 #endif
           if (team_size == -1)
-            Kokkos::parallel_for("parfor_l_team",
-                                 policy_type(lvl_nodes, Kokkos::AUTO), tstf);
+            Kokkos::parallel_for(
+                "parfor_l_team",
+                Kokkos::Experimental::require(
+                    team_policy_t(space, lvl_nodes, Kokkos::AUTO),
+                    Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+                tstf);
           else
-            Kokkos::parallel_for("parfor_l_team",
-                                 policy_type(lvl_nodes, team_size), tstf);
+            Kokkos::parallel_for(
+                "parfor_l_team",
+                Kokkos::Experimental::require(
+                    team_policy_t(space, lvl_nodes, team_size),
+                    Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+                tstf);
         }
         // TP2 algorithm has issues with some offset-ordinal combo to be
         // addressed
@@ -3064,7 +3073,7 @@ void lower_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
 #endif
 
           // NOTE: we currently supports only default_layout = LayoutLeft
-          using team_policy_type = Kokkos::TeamPolicy<execution_space>;
+          using team_policy_type = Kokkos::TeamPolicy<ExecutionSpace>;
           using supernode_view_type =
               Kokkos::View<scalar_t **, default_layout, memory_space,
                            Kokkos::MemoryUnmanaged>;
@@ -3079,9 +3088,12 @@ void lower_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
               SparseTriSupernodalSpMVFunctor<TriSolveHandle, LHSType, NGBLType>
                   sptrsv_init_functor(-2, node_count, nodes_grouped_by_level,
                                       supercols, work_offset_data, lhs, work);
-              Kokkos::parallel_for("parfor_tri_supernode_spmv",
-                                   team_policy_type(lvl_nodes, Kokkos::AUTO),
-                                   sptrsv_init_functor);
+              Kokkos::parallel_for(
+                  "parfor_tri_supernode_spmv",
+                  Kokkos::Experimental::require(
+                      team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                      Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+                  sptrsv_init_functor);
             }
 
             for (size_type league_rank = 0; league_rank < lvl_nodes;
@@ -3118,7 +3130,7 @@ void lower_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
                 auto Ljj = Kokkos::subview(
                     viewL, range_type(0, nsrow),
                     Kokkos::ALL());  // s-th supernocal column of L
-                KokkosBlas::gemv("N", one, Ljj, Xj, zero, Y);
+                KokkosBlas::gemv(space, "N", one, Ljj, Xj, zero, Y);
               } else {
                 auto Xj = Kokkos::subview(
                     lhs,
@@ -3131,7 +3143,7 @@ void lower_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
                 if (invert_diagonal) {
                   auto Y = Kokkos::subview(
                       work, range_type(workoffset, workoffset + nscol));
-                  KokkosBlas::gemv("N", one, Ljj, Y, zero, Xj);
+                  KokkosBlas::gemv(space, "N", one, Ljj, Y, zero, Xj);
                 } else {
                   char unit_diag = (unit_diagonal ? 'U' : 'N');
                   // NOTE: we currently supports only default_layout =
@@ -3139,7 +3151,9 @@ void lower_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
                   Kokkos::View<scalar_t **, default_layout, memory_space,
                                Kokkos::MemoryUnmanaged>
                       Xjj(Xj.data(), nscol, 1);
-                  KokkosBlas::trsm("L", "L", "N", &unit_diag, one, Ljj, Xjj);
+                  KokkosBlas::trsm(space, "L", "L", "N", &unit_diag, one, Ljj,
+                                   Xjj);
+                  // TODO: space.fence();
                   Kokkos::fence();
                 }
                 // update off-diagonal blocks
@@ -3155,7 +3169,7 @@ void lower_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
                       viewL, range_type(nscol, nsrow),
                       Kokkos::ALL());  // off-diagonal blocks of s-th supernodal
                                        // column of L
-                  KokkosBlas::gemv("N", one, Lij, Xj, zero, Z);
+                  KokkosBlas::gemv(space, "N", one, Lij, Xj, zero, Z);
                 }
               }
             }
@@ -3165,9 +3179,12 @@ void lower_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
               SparseTriSupernodalSpMVFunctor<TriSolveHandle, LHSType, NGBLType>
                   sptrsv_init_functor(-1, node_count, nodes_grouped_by_level,
                                       supercols, work_offset_data, lhs, work);
-              Kokkos::parallel_for("parfor_tri_supernode_spmv",
-                                   team_policy_type(lvl_nodes, Kokkos::AUTO),
-                                   sptrsv_init_functor);
+              Kokkos::parallel_for(
+                  "parfor_tri_supernode_spmv",
+                  Kokkos::Experimental::require(
+                      team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                      Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+                  sptrsv_init_functor);
             }
           }
 
@@ -3178,9 +3195,12 @@ void lower_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
                              supercols, row_map, entries, values, lvl,
                              kernel_type, diag_kernel_type, lhs, work,
                              work_offset, nodes_grouped_by_level, node_count);
-          Kokkos::parallel_for("parfor_lsolve_supernode",
-                               team_policy_type(lvl_nodes, Kokkos::AUTO),
-                               sptrsv_functor);
+          Kokkos::parallel_for(
+              "parfor_lsolve_supernode",
+              Kokkos::Experimental::require(
+                  team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                  Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+              sptrsv_functor);
 
 #ifdef profile_supernodal_etree
           Kokkos::fence();
@@ -3200,7 +3220,7 @@ void lower_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
 #endif
 
           // initialize input & output vectors
-          using team_policy_type = Kokkos::TeamPolicy<execution_space>;
+          using team_policy_type = Kokkos::TeamPolicy<ExecutionSpace>;
 
           // update with spmv (one or two SpMV)
           bool transpose_spmv =
@@ -3210,36 +3230,45 @@ void lower_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
           if (!invert_offdiagonal) {
             // solve with diagonals
             auto digmat = thandle.get_diagblock(lvl);
-            KokkosSparse::spmv(tran, one, digmat, lhs, one, work);
+            KokkosSparse::spmv(space, tran, one, digmat, lhs, one, work);
             // copy from work to lhs corresponding to diagonal blocks
             SparseTriSupernodalSpMVFunctor<TriSolveHandle, LHSType, NGBLType>
                 sptrsv_init_functor(-1, node_count, nodes_grouped_by_level,
                                     supercols, supercols, lhs, work);
-            Kokkos::parallel_for("parfor_lsolve_supernode",
-                                 team_policy_type(lvl_nodes, Kokkos::AUTO),
-                                 sptrsv_init_functor);
+            Kokkos::parallel_for(
+                "parfor_lsolve_supernode",
+                Kokkos::Experimental::require(
+                    team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                    Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+                sptrsv_init_functor);
           } else {
             // copy lhs corresponding to diagonal blocks to work and zero out in
             // lhs
             SparseTriSupernodalSpMVFunctor<TriSolveHandle, LHSType, NGBLType>
                 sptrsv_init_functor(1, node_count, nodes_grouped_by_level,
                                     supercols, supercols, lhs, work);
-            Kokkos::parallel_for("parfor_lsolve_supernode",
-                                 team_policy_type(lvl_nodes, Kokkos::AUTO),
-                                 sptrsv_init_functor);
+            Kokkos::parallel_for(
+                "parfor_lsolve_supernode",
+                Kokkos::Experimental::require(
+                    team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                    Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+                sptrsv_init_functor);
           }
           // update off-diagonals (potentiall combined with solve with
           // diagonals)
           auto submat = thandle.get_submatrix(lvl);
-          KokkosSparse::spmv(tran, one, submat, work, one, lhs);
+          KokkosSparse::spmv(space, tran, one, submat, work, one, lhs);
 
           // reinitialize workspace
           SparseTriSupernodalSpMVFunctor<TriSolveHandle, LHSType, NGBLType>
               sptrsv_finalize_functor(0, node_count, nodes_grouped_by_level,
                                       supercols, supercols, lhs, work);
-          Kokkos::parallel_for("parfor_lsolve_supernode",
-                               team_policy_type(lvl_nodes, Kokkos::AUTO),
-                               sptrsv_finalize_functor);
+          Kokkos::parallel_for(
+              "parfor_lsolve_supernode",
+              Kokkos::Experimental::require(
+                  team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                  Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+              sptrsv_finalize_functor);
 
 #ifdef profile_supernodal_etree
           Kokkos::fence();
@@ -3272,16 +3301,16 @@ void lower_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
 
 }  // end lower_tri_solve
 
-template <class TriSolveHandle, class RowMapType, class EntriesType,
-          class ValuesType, class RHSType, class LHSType>
-void upper_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
-                     const EntriesType entries, const ValuesType values,
-                     const RHSType &rhs, LHSType &lhs) {
+template <class ExecutionSpace, class TriSolveHandle, class RowMapType,
+          class EntriesType, class ValuesType, class RHSType, class LHSType>
+void upper_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
+                     const RowMapType row_map, const EntriesType entries,
+                     const ValuesType values, const RHSType &rhs,
+                     LHSType &lhs) {
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOSPSTRSV_SOLVE_IMPL_PROFILE)
   cudaProfilerStop();
 #endif
-  typedef typename TriSolveHandle::execution_space execution_space;
-
+  using memory_space = typename ExecutionSpace::memory_space;
   typedef typename TriSolveHandle::size_type size_type;
   typedef typename TriSolveHandle::nnz_lno_view_t NGBLType;
 
@@ -3298,7 +3327,6 @@ void upper_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
 
 #if defined(KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV)
   using namespace KokkosSparse::Experimental;
-  using memory_space        = typename TriSolveHandle::memory_space;
   using integer_view_t      = typename TriSolveHandle::integer_view_t;
   using integer_view_host_t = typename TriSolveHandle::integer_view_host_t;
   using scalar_t            = typename ValuesType::non_const_value_type;
@@ -3365,14 +3393,16 @@ void upper_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
           KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_RP) {
         Kokkos::parallel_for(
             "parfor_fixed_lvl",
-            Kokkos::RangePolicy<execution_space>(node_count,
-                                                 node_count + lvl_nodes),
+            Kokkos::Experimental::require(
+                Kokkos::RangePolicy<ExecutionSpace>(space, node_count,
+                                                    node_count + lvl_nodes),
+                Kokkos::Experimental::WorkItemProperty::HintLightWeight),
             UpperTriLvlSchedRPSolverFunctor<RowMapType, EntriesType, ValuesType,
                                             LHSType, RHSType, NGBLType>(
                 row_map, entries, values, lhs, rhs, nodes_grouped_by_level));
       } else if (thandle.get_algorithm() ==
                  KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_TP1) {
-        typedef Kokkos::TeamPolicy<execution_space> policy_type;
+        using team_policy_t = Kokkos::TeamPolicy<ExecutionSpace>;
 
         int team_size = thandle.get_team_size();
 
@@ -3388,11 +3418,19 @@ void upper_tri_solve(TriSolveHandle &thandle, const RowMapType row_map,
                  node_count);
 #endif
         if (team_size == -1)
-          Kokkos::parallel_for("parfor_u_team",
-                               policy_type(lvl_nodes, Kokkos::AUTO), tstf);
+          Kokkos::parallel_for(
+              "parfor_u_team",
+              Kokkos::Experimental::require(
+                  team_policy_t(space, lvl_nodes, Kokkos::AUTO),
+                  Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+              tstf);
         else
-          Kokkos::parallel_for("parfor_u_team",
-                               policy_type(lvl_nodes, team_size), tstf);
+          Kokkos::parallel_for(
+              "parfor_u_team",
+              Kokkos::Experimental::require(
+                  team_policy_t(space, lvl_nodes, team_size),
+                  Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+              tstf);
       }
       // TP2 algorithm has issues with some offset-ordinal combo to be addressed
       /*
@@ -3444,7 +3482,7 @@ tstf); } // end elseif
         timer.reset();
 #endif
 
-        using team_policy_type = Kokkos::TeamPolicy<execution_space>;
+        using team_policy_type = Kokkos::TeamPolicy<ExecutionSpace>;
         if (thandle.is_column_major()) {  // U stored in CSC
           if (diag_kernel_type_host(lvl) == 3) {
             // using device-level kernels (functor is called to gather the input
@@ -3457,9 +3495,12 @@ tstf); } // end elseif
               SparseTriSupernodalSpMVFunctor<TriSolveHandle, LHSType, NGBLType>
                   sptrsv_init_functor(-2, node_count, nodes_grouped_by_level,
                                       supercols, work_offset_data, lhs, work);
-              Kokkos::parallel_for("parfor_tri_supernode_spmv",
-                                   team_policy_type(lvl_nodes, Kokkos::AUTO),
-                                   sptrsv_init_functor);
+              Kokkos::parallel_for(
+                  "parfor_tri_supernode_spmv",
+                  Kokkos::Experimental::require(
+                      team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                      Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+                  sptrsv_init_functor);
             }
             for (size_type league_rank = 0; league_rank < lvl_nodes;
                  league_rank++) {
@@ -3500,7 +3541,7 @@ tstf); } // end elseif
                         workoffset,
                         workoffset +
                             nsrow));  // needed with gemv for update&scatter
-                KokkosBlas::gemv("N", one, Uij, Xj, zero, Z);
+                KokkosBlas::gemv(space, "N", one, Uij, Xj, zero, Z);
               } else {
                 // extract part of the solution, corresponding to the diagonal
                 // block
@@ -3517,14 +3558,14 @@ tstf); } // end elseif
                           workoffset,
                           workoffset +
                               nscol));  // needed for gemv instead of trmv/trsv
-                  KokkosBlas::gemv("N", one, Ujj, Y, zero, Xj);
+                  KokkosBlas::gemv(space, "N", one, Ujj, Y, zero, Xj);
                 } else {
                   // NOTE: we currently supports only default_layout =
                   // LayoutLeft
                   Kokkos::View<scalar_t **, default_layout, memory_space,
                                Kokkos::MemoryUnmanaged>
                       Xjj(Xj.data(), nscol, 1);
-                  KokkosBlas::trsm("L", "U", "N", "N", one, Ujj, Xjj);
+                  KokkosBlas::trsm(space, "L", "U", "N", "N", one, Ujj, Xjj);
                 }
                 // update off-diagonal blocks
                 if (nsrow2 > 0) {
@@ -3538,7 +3579,7 @@ tstf); } // end elseif
                           workoffset + nscol,
                           workoffset + nscol +
                               nsrow2));  // needed with gemv for update&scatter
-                  KokkosBlas::gemv("N", one, Uij, Xj, zero, Z);
+                  KokkosBlas::gemv(space, "N", one, Uij, Xj, zero, Z);
                 }
               }
             }
@@ -3548,9 +3589,12 @@ tstf); } // end elseif
               SparseTriSupernodalSpMVFunctor<TriSolveHandle, LHSType, NGBLType>
                   sptrsv_init_functor(-1, node_count, nodes_grouped_by_level,
                                       supercols, work_offset_data, lhs, work);
-              Kokkos::parallel_for("parfor_tri_supernode_spmv",
-                                   team_policy_type(lvl_nodes, Kokkos::AUTO),
-                                   sptrsv_init_functor);
+              Kokkos::parallel_for(
+                  "parfor_tri_supernode_spmv",
+                  Kokkos::Experimental::require(
+                      team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                      Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+                  sptrsv_init_functor);
             }
           }
 
@@ -3562,10 +3606,13 @@ tstf); } // end elseif
                              diag_kernel_type, lhs, work, work_offset,
                              nodes_grouped_by_level, node_count);
 
-          using policy_type = Kokkos::TeamPolicy<execution_space>;
-          Kokkos::parallel_for("parfor_usolve_tran_supernode",
-                               policy_type(lvl_nodes, Kokkos::AUTO),
-                               sptrsv_functor);
+          using team_policy_t = Kokkos::TeamPolicy<ExecutionSpace>;
+          Kokkos::parallel_for(
+              "parfor_usolve_tran_supernode",
+              Kokkos::Experimental::require(
+                  team_policy_t(space, lvl_nodes, Kokkos::AUTO),
+                  Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+              sptrsv_functor);
         } else {  // U stored in CSR
           // launching sparse-triangular solve functor
           UpperTriSupernodalFunctor<TriSolveHandle, RowMapType, EntriesType,
@@ -3575,10 +3622,13 @@ tstf); } // end elseif
                              work, work_offset, nodes_grouped_by_level,
                              node_count);
 
-          using policy_type = Kokkos::TeamPolicy<execution_space>;
-          Kokkos::parallel_for("parfor_usolve_supernode",
-                               policy_type(lvl_nodes, Kokkos::AUTO),
-                               sptrsv_functor);
+          using team_policy_t = Kokkos::TeamPolicy<ExecutionSpace>;
+          Kokkos::parallel_for(
+              "parfor_usolve_supernode",
+              Kokkos::Experimental::require(
+                  team_policy_t(space, lvl_nodes, Kokkos::AUTO),
+                  Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+              sptrsv_functor);
 
           if (diag_kernel_type_host(lvl) == 3) {
             // using device-level kernels (functor is called to gather the input
@@ -3634,7 +3684,7 @@ tstf); } // end elseif
                         workoffset + nscol,
                         workoffset + nscol +
                             nsrow2));  // needed with gemv for update&scatter
-                KokkosBlas::gemv("T", -one, Uij, Z, one, Xj);
+                KokkosBlas::gemv(space, "T", -one, Uij, Z, one, Xj);
               }
 
               // "triangular-solve" to compute Xj
@@ -3642,13 +3692,13 @@ tstf); } // end elseif
               auto Ujj =
                   Kokkos::subview(viewU, range_type(0, nscol), Kokkos::ALL());
               if (invert_diagonal) {
-                KokkosBlas::gemv("T", one, Ujj, Xj, zero, Y);
+                KokkosBlas::gemv(space, "T", one, Ujj, Xj, zero, Y);
               } else {
                 // NOTE: we currently supports only default_layout = LayoutLeft
                 Kokkos::View<scalar_t **, default_layout, memory_space,
                              Kokkos::MemoryUnmanaged>
                     Xjj(Xj.data(), nscol, 1);
-                KokkosBlas::trsm("L", "L", "T", "N", one, Ujj, Xjj);
+                KokkosBlas::trsm(space, "L", "L", "T", "N", one, Ujj, Xjj);
               }
             }
             if (invert_diagonal) {
@@ -3657,9 +3707,12 @@ tstf); } // end elseif
               SparseTriSupernodalSpMVFunctor<TriSolveHandle, LHSType, NGBLType>
                   sptrsv_init_functor(-1, node_count, nodes_grouped_by_level,
                                       supercols, work_offset_data, lhs, work);
-              Kokkos::parallel_for("parfor_tri_supernode_spmv",
-                                   team_policy_type(lvl_nodes, Kokkos::AUTO),
-                                   sptrsv_init_functor);
+              Kokkos::parallel_for(
+                  "parfor_tri_supernode_spmv",
+                  Kokkos::Experimental::require(
+                      team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                      Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+                  sptrsv_init_functor);
             }
           }
         }
@@ -3680,7 +3733,7 @@ tstf); } // end elseif
 #endif
 
         // initialize input & output vectors
-        using team_policy_type = Kokkos::TeamPolicy<execution_space>;
+        using team_policy_type = Kokkos::TeamPolicy<ExecutionSpace>;
 
         // update with one, or two, spmv
         bool transpose_spmv =
@@ -3691,28 +3744,34 @@ tstf); } // end elseif
           if (!invert_offdiagonal) {
             // solve with diagonals
             auto digmat = thandle.get_diagblock(lvl);
-            KokkosSparse::spmv(tran, one, digmat, lhs, one, work);
+            KokkosSparse::spmv(space, tran, one, digmat, lhs, one, work);
             // copy from work to lhs corresponding to diagonal blocks
             SparseTriSupernodalSpMVFunctor<TriSolveHandle, LHSType, NGBLType>
                 sptrsv_init_functor(-1, node_count, nodes_grouped_by_level,
                                     supercols, supercols, lhs, work);
-            Kokkos::parallel_for("parfor_lsolve_supernode",
-                                 team_policy_type(lvl_nodes, Kokkos::AUTO),
-                                 sptrsv_init_functor);
+            Kokkos::parallel_for(
+                "parfor_lsolve_supernode",
+                Kokkos::Experimental::require(
+                    team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                    Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+                sptrsv_init_functor);
           } else {
             // zero out lhs corresponding to diagonal blocks in lhs, and copy to
             // work
             SparseTriSupernodalSpMVFunctor<TriSolveHandle, LHSType, NGBLType>
                 sptrsv_init_functor(1, node_count, nodes_grouped_by_level,
                                     supercols, supercols, lhs, work);
-            Kokkos::parallel_for("parfor_lsolve_supernode",
-                                 team_policy_type(lvl_nodes, Kokkos::AUTO),
-                                 sptrsv_init_functor);
+            Kokkos::parallel_for(
+                "parfor_lsolve_supernode",
+                Kokkos::Experimental::require(
+                    team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                    Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+                sptrsv_init_functor);
           }
           // update with off-diagonals (potentiall combined with diagonal
           // solves)
           auto submat = thandle.get_submatrix(lvl);
-          KokkosSparse::spmv(tran, one, submat, work, one, lhs);
+          KokkosSparse::spmv(space, tran, one, submat, work, one, lhs);
         } else {
           if (!invert_offdiagonal) {
             // zero out lhs corresponding to diagonal blocks in lhs, and copy to
@@ -3720,17 +3779,20 @@ tstf); } // end elseif
             SparseTriSupernodalSpMVFunctor<TriSolveHandle, LHSType, NGBLType>
                 sptrsv_init_functor(1, node_count, nodes_grouped_by_level,
                                     supercols, supercols, lhs, work);
-            Kokkos::parallel_for("parfor_lsolve_supernode",
-                                 team_policy_type(lvl_nodes, Kokkos::AUTO),
-                                 sptrsv_init_functor);
+            Kokkos::parallel_for(
+                "parfor_lsolve_supernode",
+                Kokkos::Experimental::require(
+                    team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                    Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+                sptrsv_init_functor);
 
             // update with off-diagonals
             auto submat = thandle.get_submatrix(lvl);
-            KokkosSparse::spmv(tran, one, submat, lhs, one, work);
+            KokkosSparse::spmv(space, tran, one, submat, lhs, one, work);
 
             // solve with diagonals
             auto digmat = thandle.get_diagblock(lvl);
-            KokkosSparse::spmv(tran, one, digmat, work, one, lhs);
+            KokkosSparse::spmv(space, tran, one, digmat, work, one, lhs);
           } else {
             std::cout << " ** invert_offdiag with U in CSR not supported **"
                       << std::endl;
@@ -3740,9 +3802,12 @@ tstf); } // end elseif
         SparseTriSupernodalSpMVFunctor<TriSolveHandle, LHSType, NGBLType>
             sptrsv_finalize_functor(0, node_count, nodes_grouped_by_level,
                                     supercols, supercols, lhs, work);
-        Kokkos::parallel_for("parfor_lsolve_supernode",
-                             team_policy_type(lvl_nodes, Kokkos::AUTO),
-                             sptrsv_finalize_functor);
+        Kokkos::parallel_for(
+            "parfor_lsolve_supernode",
+            Kokkos::Experimental::require(
+                team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+            sptrsv_finalize_functor);
 
 #ifdef profile_supernodal_etree
         Kokkos::fence();
@@ -3765,23 +3830,22 @@ tstf); } // end elseif
   double sptrsv_time_seconds = sptrsv_timer.seconds();
   std::cout << " + SpTrsv(uppper) time: " << sptrsv_time_seconds << std::endl
             << std::endl;
-  std::cout << "  + Execution space    : " << execution_space::name()
+  std::cout << "  + Execution space    : " << ExecutionSpace::name()
             << std::endl;
   std::cout << " + Memory space       : " << memory_space::name() << std::endl;
 #endif
 
 }  // end upper_tri_solve
 
-template <class TriSolveHandle, class RowMapType, class EntriesType,
-          class ValuesType, class RHSType, class LHSType>
-void tri_solve_chain(TriSolveHandle &thandle, const RowMapType row_map,
-                     const EntriesType entries, const ValuesType values,
-                     const RHSType &rhs, LHSType &lhs,
+template <class ExecutionSpace, class TriSolveHandle, class RowMapType,
+          class EntriesType, class ValuesType, class RHSType, class LHSType>
+void tri_solve_chain(ExecutionSpace &space, TriSolveHandle &thandle,
+                     const RowMapType row_map, const EntriesType entries,
+                     const ValuesType values, const RHSType &rhs, LHSType &lhs,
                      const bool /*is_lowertri_*/) {
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOSPSTRSV_SOLVE_IMPL_PROFILE)
   cudaProfilerStop();
 #endif
-  typedef typename TriSolveHandle::execution_space execution_space;
   typedef typename TriSolveHandle::size_type size_type;
   typedef typename TriSolveHandle::nnz_lno_view_t NGBLType;
 
@@ -3802,9 +3866,9 @@ void tri_solve_chain(TriSolveHandle &thandle, const RowMapType row_map,
   size_type node_count = 0;
 
   // REFACTORED to cleanup; next, need debug and timer routines
-  using policy_type = Kokkos::TeamPolicy<execution_space>;
+  using policy_type = Kokkos::TeamPolicy<ExecutionSpace>;
   using large_cutoff_policy_type =
-      Kokkos::TeamPolicy<LargerCutoffTag, execution_space>;
+      Kokkos::TeamPolicy<LargerCutoffTag, ExecutionSpace>;
   /*
     using TP1Functor = TriLvlSchedTP1SolverFunctor<RowMapType, EntriesType,
     ValuesType, LHSType, RHSType, NGBLType>; using LTP1Functor =
@@ -3865,14 +3929,17 @@ void tri_solve_chain(TriSolveHandle &thandle, const RowMapType row_map,
 #endif
         if (team_size == -1) {
           team_size =
-              policy_type(1, 1, vector_size)
+              policy_type(space, 1, 1, vector_size)
                   .team_size_recommended(tstf, Kokkos::ParallelForTag());
         }
 
         size_type lvl_nodes = hnodes_per_level(schain);  // lvl == echain????
-        Kokkos::parallel_for("parfor_l_team_chain1",
-                             policy_type(lvl_nodes, team_size, vector_size),
-                             tstf);
+        Kokkos::parallel_for(
+            "parfor_l_team_chain1",
+            Kokkos::Experimental::require(
+                policy_type(space, lvl_nodes, team_size, vector_size),
+                Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+            tstf);
         node_count += lvl_nodes;
 
       } else {
@@ -3884,7 +3951,7 @@ void tri_solve_chain(TriSolveHandle &thandle, const RowMapType row_map,
 
         if (team_size_singleblock <= 0) {
           team_size_singleblock =
-              policy_type(1, 1, vector_size)
+              policy_type(space, 1, 1, vector_size)
                   .team_size_recommended(
                       SingleBlockFunctor(row_map, entries, values, lhs, rhs,
                                          nodes_grouped_by_level,
@@ -3907,7 +3974,10 @@ void tri_solve_chain(TriSolveHandle &thandle, const RowMapType row_map,
 #endif
           Kokkos::parallel_for(
               "parfor_l_team_chainmulti",
-              policy_type(1, team_size_singleblock, vector_size), tstf);
+              Kokkos::Experimental::require(
+                  policy_type(space, 1, team_size_singleblock, vector_size),
+                  Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+              tstf);
         } else {
           // team_size_singleblock < cutoff => kernel must allow for a
           // block-stride internally
@@ -3925,11 +3995,15 @@ void tri_solve_chain(TriSolveHandle &thandle, const RowMapType row_map,
 #endif
           Kokkos::parallel_for(
               "parfor_l_team_chainmulti_cutoff",
-              large_cutoff_policy_type(1, team_size_singleblock, vector_size),
+              Kokkos::Experimental::require(
+                  large_cutoff_policy_type(1, team_size_singleblock,
+                                           vector_size),
+                  Kokkos::Experimental::WorkItemProperty::HintLightWeight),
               tstf);
         }
         node_count += lvl_nodes;
       }
+      // TODO: space.fence()
       Kokkos::fence();  // TODO - is this necessary? that is, can the
                         // parallel_for launch before the s/echain values have
                         // been updated?
@@ -3955,16 +4029,19 @@ void tri_solve_chain(TriSolveHandle &thandle, const RowMapType row_map,
 #endif
         if (team_size == -1) {
           team_size =
-              policy_type(1, 1, vector_size)
+              policy_type(space, 1, 1, vector_size)
                   .team_size_recommended(tstf, Kokkos::ParallelForTag());
         }
 
         // TODO To use cudagraph here, need to know how many non-unit chains
         // there are, create a graph for each and launch accordingly
         size_type lvl_nodes = hnodes_per_level(schain);  // lvl == echain????
-        Kokkos::parallel_for("parfor_u_team_chain1",
-                             policy_type(lvl_nodes, team_size, vector_size),
-                             tstf);
+        Kokkos::parallel_for(
+            "parfor_u_team_chain1",
+            Kokkos::Experimental::require(
+                policy_type(space, lvl_nodes, team_size, vector_size),
+                Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+            tstf);
         node_count += lvl_nodes;
 
       } else {
@@ -3980,7 +4057,7 @@ void tri_solve_chain(TriSolveHandle &thandle, const RowMapType row_map,
           // values, lhs, rhs, nodes_grouped_by_level, is_lowertri, node_count),
           // Kokkos::ParallelForTag());
           team_size_singleblock =
-              policy_type(1, 1, vector_size)
+              policy_type(space, 1, 1, vector_size)
                   .team_size_recommended(
                       SingleBlockFunctor(row_map, entries, values, lhs, rhs,
                                          nodes_grouped_by_level,
@@ -4003,7 +4080,10 @@ void tri_solve_chain(TriSolveHandle &thandle, const RowMapType row_map,
 #endif
           Kokkos::parallel_for(
               "parfor_u_team_chainmulti",
-              policy_type(1, team_size_singleblock, vector_size), tstf);
+              Kokkos::Experimental::require(
+                  policy_type(space, 1, team_size_singleblock, vector_size),
+                  Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+              tstf);
         } else {
           // team_size_singleblock < cutoff => kernel must allow for a
           // block-stride internally
@@ -4021,11 +4101,15 @@ void tri_solve_chain(TriSolveHandle &thandle, const RowMapType row_map,
 #endif
           Kokkos::parallel_for(
               "parfor_u_team_chainmulti_cutoff",
-              large_cutoff_policy_type(1, team_size_singleblock, vector_size),
+              Kokkos::Experimental::require(
+                  large_cutoff_policy_type(1, team_size_singleblock,
+                                           vector_size),
+                  Kokkos::Experimental::WorkItemProperty::HintLightWeight),
               tstf);
         }
         node_count += lvl_nodes;
       }
+      // TODO: space.fence()
       Kokkos::fence();  // TODO - is this necessary? that is, can the
                         // parallel_for launch before the s/echain values have
                         // been updated?

--- a/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
+++ b/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
@@ -2913,7 +2913,8 @@ void lower_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
 
 #if defined(KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV)
   using namespace KokkosSparse::Experimental;
-  using memory_space        = typename TriSolveHandle::memory_space;
+  using memory_space        = typename ExecutionSpace::memory_space;
+  using device_t            = Kokkos::Device<ExecutionSpace, memory_space>;
   using integer_view_t      = typename TriSolveHandle::integer_view_t;
   using integer_view_host_t = typename TriSolveHandle::integer_view_host_t;
   using scalar_t            = typename ValuesType::non_const_value_type;
@@ -3075,7 +3076,7 @@ void lower_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
           // NOTE: we currently supports only default_layout = LayoutLeft
           using team_policy_type = Kokkos::TeamPolicy<ExecutionSpace>;
           using supernode_view_type =
-              Kokkos::View<scalar_t **, default_layout, memory_space,
+              Kokkos::View<scalar_t **, default_layout, device_t,
                            Kokkos::MemoryUnmanaged>;
           if (diag_kernel_type_host(lvl) == 3) {
             // using device-level kernels (functor is called to scatter the
@@ -3148,7 +3149,7 @@ void lower_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
                   char unit_diag = (unit_diagonal ? 'U' : 'N');
                   // NOTE: we currently supports only default_layout =
                   // LayoutLeft
-                  Kokkos::View<scalar_t **, default_layout, memory_space,
+                  Kokkos::View<scalar_t **, default_layout, device_t,
                                Kokkos::MemoryUnmanaged>
                       Xjj(Xj.data(), nscol, 1);
                   KokkosBlas::trsm(space, "L", "L", "N", &unit_diag, one, Ljj,
@@ -3311,6 +3312,7 @@ void upper_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
   cudaProfilerStop();
 #endif
   using memory_space = typename ExecutionSpace::memory_space;
+  using device_t     = Kokkos::Device<ExecutionSpace, memory_space>;
   typedef typename TriSolveHandle::size_type size_type;
   typedef typename TriSolveHandle::nnz_lno_view_t NGBLType;
 
@@ -3527,7 +3529,7 @@ tstf); } // end elseif
 
               // create a view for the s-th supernocal block column
               // NOTE: we currently supports only default_layout = LayoutLeft
-              Kokkos::View<scalar_t **, default_layout, memory_space,
+              Kokkos::View<scalar_t **, default_layout, device_t,
                            Kokkos::MemoryUnmanaged>
                   viewU(&dataU[i1], nsrow, nscol);
 
@@ -3562,7 +3564,7 @@ tstf); } // end elseif
                 } else {
                   // NOTE: we currently supports only default_layout =
                   // LayoutLeft
-                  Kokkos::View<scalar_t **, default_layout, memory_space,
+                  Kokkos::View<scalar_t **, default_layout, device_t,
                                Kokkos::MemoryUnmanaged>
                       Xjj(Xj.data(), nscol, 1);
                   KokkosBlas::trsm(space, "L", "U", "N", "N", one, Ujj, Xjj);
@@ -3658,7 +3660,7 @@ tstf); } // end elseif
 
               // create a view for the s-th supernocal block column
               // NOTE: we currently supports only default_layout = LayoutLeft
-              Kokkos::View<scalar_t **, default_layout, memory_space,
+              Kokkos::View<scalar_t **, default_layout, device_t,
                            Kokkos::MemoryUnmanaged>
                   viewU(&dataU[i1], nsrow, nscol);
 
@@ -3695,7 +3697,7 @@ tstf); } // end elseif
                 KokkosBlas::gemv(space, "T", one, Ujj, Xj, zero, Y);
               } else {
                 // NOTE: we currently supports only default_layout = LayoutLeft
-                Kokkos::View<scalar_t **, default_layout, memory_space,
+                Kokkos::View<scalar_t **, default_layout, device_t,
                              Kokkos::MemoryUnmanaged>
                     Xjj(Xj.data(), nscol, 1);
                 KokkosBlas::trsm(space, "L", "L", "T", "N", one, Ujj, Xjj);

--- a/sparse/impl/KokkosSparse_sptrsv_symbolic_spec.hpp
+++ b/sparse/impl/KokkosSparse_sptrsv_symbolic_spec.hpp
@@ -67,33 +67,37 @@ namespace Impl {
 // Unification layer
 /// \brief Implementation of KokkosSparse::sptrsv_symbolic
 
-template <class KernelHandle, class RowMapType, class EntriesType,
+template <class ExecutionSpace, class KernelHandle, class RowMapType,
+          class EntriesType,
           bool tpl_spec_avail = sptrsv_symbolic_tpl_spec_avail<
               KernelHandle, RowMapType, EntriesType>::value,
           bool eti_spec_avail = sptrsv_symbolic_eti_spec_avail<
               KernelHandle, RowMapType, EntriesType>::value>
 struct SPTRSV_SYMBOLIC {
-  static void sptrsv_symbolic(KernelHandle *handle, const RowMapType row_map,
+  static void sptrsv_symbolic(const ExecutionSpace &space, KernelHandle *handle,
+                              const RowMapType row_map,
                               const EntriesType entries);
 };
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 //! Full specialization of sptrsv_symbolic
 // Unification layer
-template <class KernelHandle, class RowMapType, class EntriesType>
-struct SPTRSV_SYMBOLIC<KernelHandle, RowMapType, EntriesType, false,
-                       KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
-  static void sptrsv_symbolic(KernelHandle *handle, const RowMapType row_map,
+template <class ExecutionSpace, class KernelHandle, class RowMapType,
+          class EntriesType>
+struct SPTRSV_SYMBOLIC<ExecutionSpace, KernelHandle, RowMapType, EntriesType,
+                       false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+  static void sptrsv_symbolic(const ExecutionSpace &space, KernelHandle *handle,
+                              const RowMapType row_map,
                               const EntriesType entries) {
     auto sptrsv_handle = handle->get_sptrsv_handle();
     auto nrows         = row_map.extent(0) - 1;
     sptrsv_handle->new_init_handle(nrows);
 
     if (sptrsv_handle->is_lower_tri()) {
-      Experimental::lower_tri_symbolic(*sptrsv_handle, row_map, entries);
+      Experimental::lower_tri_symbolic(space, *sptrsv_handle, row_map, entries);
       sptrsv_handle->set_symbolic_complete();
     } else {
-      Experimental::upper_tri_symbolic(*sptrsv_handle, row_map, entries);
+      Experimental::upper_tri_symbolic(space, *sptrsv_handle, row_map, entries);
       sptrsv_handle->set_symbolic_complete();
     }
   }
@@ -113,6 +117,7 @@ struct SPTRSV_SYMBOLIC<KernelHandle, RowMapType, EntriesType, false,
     SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,   \
     MEM_SPACE_TYPE)                                                         \
   extern template struct SPTRSV_SYMBOLIC<                                   \
+      EXEC_SPACE_TYPE,                                                      \
       KokkosKernels::Experimental::KokkosKernelsHandle<                     \
           const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,         \
           EXEC_SPACE_TYPE, MEM_SPACE_TYPE, MEM_SPACE_TYPE>,                 \
@@ -130,6 +135,7 @@ struct SPTRSV_SYMBOLIC<KernelHandle, RowMapType, EntriesType, false,
     SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,   \
     MEM_SPACE_TYPE)                                                         \
   template struct SPTRSV_SYMBOLIC<                                          \
+      EXEC_SPACE_TYPE,                                                      \
       KokkosKernels::Experimental::KokkosKernelsHandle<                     \
           const OFFSET_TYPE, const ORDINAL_TYPE, const SCALAR_TYPE,         \
           EXEC_SPACE_TYPE, MEM_SPACE_TYPE, MEM_SPACE_TYPE>,                 \

--- a/sparse/src/KokkosSparse_sptrsv.hpp
+++ b/sparse/src/KokkosSparse_sptrsv.hpp
@@ -40,10 +40,23 @@ namespace Experimental {
   std::is_same<typename std::remove_const<A>::type, \
                typename std::remove_const<B>::type>::value
 
-template <typename KernelHandle, typename lno_row_view_t_,
-          typename lno_nnz_view_t_>
-void sptrsv_symbolic(KernelHandle *handle, lno_row_view_t_ rowmap,
-                     lno_nnz_view_t_ entries) {
+/**
+ * @brief sptrsv symbolic phase for linear system Ax=b
+ *
+ * @tparam ExecutionSpace This kernels execution space type
+ * @tparam KernelHandle A specialization of
+ * KokkosKernels::Experimental::KokkosKernelsHandle
+ * @tparam lno_row_view_t_ The CRS matrix's (A) rowmap type
+ * @tparam lno_nnz_view_t_ The CRS matrix's (A) entries type
+ * @param space The execution space instance this kernel will run on
+ * @param handle KernelHandle instance
+ * @param rowmap The CRS matrix's (A) rowmap
+ * @param entries The CRS matrix's (A) entries
+ */
+template <typename ExecutionSpace, typename KernelHandle,
+          typename lno_row_view_t_, typename lno_nnz_view_t_>
+void sptrsv_symbolic(const ExecutionSpace &space, KernelHandle *handle,
+                     lno_row_view_t_ rowmap, lno_nnz_view_t_ entries) {
   typedef typename KernelHandle::size_type size_type;
   typedef typename KernelHandle::nnz_lno_t ordinal_type;
 
@@ -94,8 +107,9 @@ void sptrsv_symbolic(KernelHandle *handle, lno_row_view_t_ rowmap,
   Entries_Internal entries_i = entries;
 
   KokkosSparse::Impl::SPTRSV_SYMBOLIC<
-      const_handle_type, RowMap_Internal,
-      Entries_Internal>::sptrsv_symbolic(&tmp_handle, rowmap_i, entries_i);
+      ExecutionSpace, const_handle_type, RowMap_Internal,
+      Entries_Internal>::sptrsv_symbolic(space, &tmp_handle, rowmap_i,
+                                         entries_i);
 
 #ifdef KK_TRISOLVE_TIMERS
   std::cout << "     > sptrsv_symbolic time = " << timer_sptrsv.seconds()
@@ -103,10 +117,46 @@ void sptrsv_symbolic(KernelHandle *handle, lno_row_view_t_ rowmap,
 #endif
 }  // sptrsv_symbolic
 
+/**
+ * @brief sptrsv symbolic phase for linear system Ax=b
+ *
+ * @tparam KernelHandle A specialization of
+ * KokkosKernels::Experimental::KokkosKernelsHandle
+ * @tparam lno_row_view_t_ The CRS matrix's (A) rowmap type
+ * @tparam lno_nnz_view_t_ The CRS matrix's (A) entries type
+ * @param handle KernelHandle instance
+ * @param rowmap The CRS matrix's (A) rowmap
+ * @param entries The CRS matrix's (A) entries
+ */
 template <typename KernelHandle, typename lno_row_view_t_,
-          typename lno_nnz_view_t_, typename scalar_nnz_view_t_>
+          typename lno_nnz_view_t_>
 void sptrsv_symbolic(KernelHandle *handle, lno_row_view_t_ rowmap,
-                     lno_nnz_view_t_ entries, scalar_nnz_view_t_ values) {
+                     lno_nnz_view_t_ entries) {
+  using ExecutionSpace = typename KernelHandle::HandleExecSpace;
+  auto my_exec_space   = ExecutionSpace();
+  sptrsv_symbolic(my_exec_space, handle, rowmap, entries);
+}
+
+/**
+ * @brief sptrsv symbolic phase for linear system Ax=b
+ *
+ * @tparam ExecutionSpace This kernels execution space type
+ * @tparam KernelHandle A specialization of
+ * KokkosKernels::Experimental::KokkosKernelsHandle
+ * @tparam lno_row_view_t_ The CRS matrix's (A) rowmap type
+ * @tparam lno_nnz_view_t_ The CRS matrix's (A) entries type
+ * @param space The execution space instance this kernel will run on
+ * @param handle KernelHandle instance
+ * @param rowmap The CRS matrix's (A) rowmap
+ * @param entries The CRS matrix's (A) entries
+ * @param values The CRS matrix's (A) values
+ */
+template <typename ExecutionSpace, typename KernelHandle,
+          typename lno_row_view_t_, typename lno_nnz_view_t_,
+          typename scalar_nnz_view_t_>
+void sptrsv_symbolic(ExecutionSpace &space, KernelHandle *handle,
+                     lno_row_view_t_ rowmap, lno_nnz_view_t_ entries,
+                     scalar_nnz_view_t_ values) {
   typedef typename KernelHandle::size_type size_type;
   typedef typename KernelHandle::nnz_lno_t ordinal_type;
   typedef typename KernelHandle::nnz_scalar_t scalar_type;
@@ -179,11 +229,12 @@ void sptrsv_symbolic(KernelHandle *handle, lno_row_view_t_ rowmap,
     auto nrows           = sh->get_nrows();
 
     KokkosSparse::Impl::sptrsvcuSPARSE_symbolic<
-        sptrsvHandleType, RowMap_Internal, Entries_Internal, Values_Internal>(
-        sh, nrows, rowmap_i, entries_i, values_i, false);
+        ExecutionSpace, sptrsvHandleType, RowMap_Internal, Entries_Internal,
+        Values_Internal>(space, sh, nrows, rowmap_i, entries_i, values_i,
+                         false);
 
   } else {
-    KokkosSparse::Experimental::sptrsv_symbolic(handle, rowmap, entries);
+    KokkosSparse::Experimental::sptrsv_symbolic(space, handle, rowmap, entries);
   }
 #ifdef KK_TRISOLVE_TIMERS
   std::cout << "     + sptrsv_symbolic time = " << timer_sptrsv.seconds()
@@ -191,12 +242,52 @@ void sptrsv_symbolic(KernelHandle *handle, lno_row_view_t_ rowmap,
 #endif
 }  // sptrsv_symbolic
 
+/**
+ * @brief sptrsv symbolic phase for linear system Ax=b
+ *
+ * @tparam KernelHandle A specialization of
+ * KokkosKernels::Experimental::KokkosKernelsHandle
+ * @tparam lno_row_view_t_ The CRS matrix's (A) rowmap type
+ * @tparam lno_nnz_view_t_ The CRS matrix's (A) entries type
+ * @param handle KernelHandle instance
+ * @param rowmap The CRS matrix's (A) rowmap
+ * @param entries The CRS matrix's (A) entries
+ * @param values The CRS matrix's (A) values
+ */
 template <typename KernelHandle, typename lno_row_view_t_,
-          typename lno_nnz_view_t_, typename scalar_nnz_view_t_, class BType,
-          class XType>
-void sptrsv_solve(KernelHandle *handle, lno_row_view_t_ rowmap,
-                  lno_nnz_view_t_ entries, scalar_nnz_view_t_ values, BType b,
-                  XType x) {
+          typename lno_nnz_view_t_, typename scalar_nnz_view_t_>
+void sptrsv_symbolic(KernelHandle *handle, lno_row_view_t_ rowmap,
+                     lno_nnz_view_t_ entries, scalar_nnz_view_t_ values) {
+  using ExecutionSpace = typename KernelHandle::HandleExecSpace;
+  auto my_exec_space   = ExecutionSpace();
+  sptrsv_symbolic(my_exec_space, handle, rowmap, entries, values);
+}
+
+/**
+ * @brief sptrsv solve phase of x for linear system Ax=b
+ *
+ * @tparam ExecutionSpace This kernels execution space
+ * @tparam KernelHandle A specialization of
+ * KokkosKernels::Experimental::KokkosKernelsHandle
+ * @tparam lno_row_view_t_ The CRS matrix's (A) rowmap type
+ * @tparam lno_nnz_view_t_ The CRS matrix's (A) entries type
+ * @tparam scalar_nnz_view_t_ The CRS matrix's (A) values type
+ * @tparam BType The b vector type
+ * @tparam XType The x vector type
+ * @param space The execution space instance this kernel will be run on
+ * @param handle KernelHandle instance
+ * @param rowmap The CRS matrix's (A) rowmap
+ * @param entries The CRS matrix's (A) entries
+ * @param values The CRS matrix's (A) values
+ * @param b The b vector
+ * @param x The x vector
+ */
+template <typename ExecutionSpace, typename KernelHandle,
+          typename lno_row_view_t_, typename lno_nnz_view_t_,
+          typename scalar_nnz_view_t_, class BType, class XType>
+void sptrsv_solve(ExecutionSpace &space, KernelHandle *handle,
+                  lno_row_view_t_ rowmap, lno_nnz_view_t_ entries,
+                  scalar_nnz_view_t_ values, BType b, XType x) {
   typedef typename KernelHandle::size_type size_type;
   typedef typename KernelHandle::nnz_lno_t ordinal_type;
   typedef typename KernelHandle::nnz_scalar_t scalar_type;
@@ -305,25 +396,65 @@ void sptrsv_solve(KernelHandle *handle, lno_row_view_t_ rowmap,
     sptrsvHandleType *sh = handle->get_sptrsv_handle();
     auto nrows           = sh->get_nrows();
 
-    KokkosSparse::Impl::sptrsvcuSPARSE_solve<sptrsvHandleType, RowMap_Internal,
-                                             Entries_Internal, Values_Internal,
-                                             BType_Internal, XType_Internal>(
-        sh, nrows, rowmap_i, entries_i, values_i, b_i, x_i, false);
+    KokkosSparse::Impl::sptrsvcuSPARSE_solve<
+        ExecutionSpace, sptrsvHandleType, RowMap_Internal, Entries_Internal,
+        Values_Internal, BType_Internal, XType_Internal>(
+        space, sh, nrows, rowmap_i, entries_i, values_i, b_i, x_i, false);
 
   } else {
     KokkosSparse::Impl::SPTRSV_SOLVE<
-        typename scalar_nnz_view_t_::execution_space, const_handle_type,
-        RowMap_Internal, Entries_Internal, Values_Internal, BType_Internal,
-        XType_Internal>::sptrsv_solve(&tmp_handle, rowmap_i, entries_i,
+        ExecutionSpace, const_handle_type, RowMap_Internal, Entries_Internal,
+        Values_Internal, BType_Internal,
+        XType_Internal>::sptrsv_solve(space, &tmp_handle, rowmap_i, entries_i,
                                       values_i, b_i, x_i);
   }
 
 }  // sptrsv_solve
 
-#if defined(KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV)
-// ---------------------------------------------------------------------
-template <typename KernelHandle, class XType>
-void sptrsv_solve(KernelHandle *handle, XType x, XType b) {
+/**
+ * @brief sptrsv solve phase of x for linear system Ax=b
+ *
+ * @tparam KernelHandle A specialization of
+ * KokkosKernels::Experimental::KokkosKernelsHandle
+ * @tparam lno_row_view_t_ The CRS matrix's (A) rowmap type
+ * @tparam lno_nnz_view_t_ The CRS matrix's (A) entries type
+ * @tparam scalar_nnz_view_t_ The CRS matrix's (A) values type
+ * @tparam BType The b vector type
+ * @tparam XType The x vector type
+ * @param handle KernelHandle instance
+ * @param rowmap The CRS matrix's (A) rowmap
+ * @param entries The CRS matrix's (A) entries
+ * @param values The CRS matrix's (A) values
+ * @param b The b vector
+ * @param x The x vector
+ */
+template <typename KernelHandle, typename lno_row_view_t_,
+          typename lno_nnz_view_t_, typename scalar_nnz_view_t_, class BType,
+          class XType>
+void sptrsv_solve(KernelHandle *handle, lno_row_view_t_ rowmap,
+                  lno_nnz_view_t_ entries, scalar_nnz_view_t_ values, BType b,
+                  XType x) {
+  using ExecutionSpace = typename KernelHandle::HandleExecSpace;
+  auto my_exec_space   = ExecutionSpace();
+  sptrsv_solve(my_exec_space, handle, rowmap, entries, values, b, x);
+}
+
+#if defined(KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV) || defined(DOXY)
+/**
+ * @brief Supernodal sptrsv solve phase of x for linear system Ax=b
+ *
+ * @tparam ExecutionSpace This kernels execution space
+ * @tparam KernelHandle A specialization of
+ * KokkosKernels::Experimental::KokkosKernelsHandle
+ * @tparam XType The x and b vector type
+ * @param space The execution space instance this kernel will run on
+ * @param handle KernelHandle instance
+ * @param x The x vector
+ * @param b The b vector
+ */
+template <typename ExecutionSpace, typename KernelHandle, class XType>
+void sptrsv_solve(ExecutionSpace &space, KernelHandle *handle, XType x,
+                  XType b) {
   auto crsmat  = handle->get_sptrsv_handle()->get_crsmat();
   auto values  = crsmat.values;
   auto graph   = crsmat.graph;
@@ -341,31 +472,79 @@ void sptrsv_solve(KernelHandle *handle, XType x, XType b) {
 
   if (handle->is_sptrsv_lower_tri()) {
     // apply forward pivoting
-    Kokkos::deep_copy(x, b);
+    Kokkos::deep_copy(space, x, b);
 
     // the fifth argument (i.e., first x) is not used
-    sptrsv_solve(handle, row_map, entries, values, x, x);
+    sptrsv_solve(space, handle, row_map, entries, values, x, x);
   } else {
     // the fifth argument (i.e., first x) is not used
-    sptrsv_solve(handle, row_map, entries, values, b, b);
+    sptrsv_solve(space, handle, row_map, entries, values, b, b);
 
     // apply backward pivoting
-    Kokkos::deep_copy(x, b);
+    Kokkos::deep_copy(space, x, b);
   }
 }
 
-// ---------------------------------------------------------------------
+/**
+ * @brief Supernodal sptrsv solve phase of x for linear system Ax=b
+ *
+ * @tparam KernelHandle A specialization of
+ * KokkosKernels::Experimental::KokkosKernelsHandle
+ * @tparam XType The x and b vector type
+ * @param handle KernelHandle instance
+ * @param x The x vector
+ * @param b The b vector
+ */
+template <typename KernelHandle, class XType>
+void sptrsv_solve(KernelHandle *handle, XType x, XType b) {
+  using ExecutionSpace = typename KernelHandle::HandleExecSpace;
+  auto my_exec_space   = ExecutionSpace();
+  sptrsv_solve(my_exec_space, handle, x, b);
+}
+
+/**
+ * @brief Supernodal sptrsv solve phase of x for linear system Ax=b
+ *
+ * @tparam ExecutionSpace This kernels execution space
+ * @tparam KernelHandle A specialization of
+ * KokkosKernels::Experimental::KokkosKernelsHandle
+ * @tparam XType The x and b vector type
+ * @param space The execution space instance this kernel will run on
+ * @param handleL KernelHandle instance for lower triangular matrix
+ * @param handleU KernelHandle instance for upper triangular matrix
+ * @param x The x vector
+ * @param b The b vector
+ */
+template <typename ExecutionSpace, typename KernelHandle, class XType>
+void sptrsv_solve(ExecutionSpace &space, KernelHandle *handleL,
+                  KernelHandle *handleU, XType x, XType b) {
+  // Lower-triangular solve
+  sptrsv_solve(space, handleL, x, b);
+
+  // copy the solution to rhs
+  Kokkos::deep_copy(space, b, x);
+
+  // uper-triangular solve
+  sptrsv_solve(space, handleU, x, b);
+}
+
+/**
+ * @brief Supernodal sptrsv solve phase of x for linear system Ax=b
+ *
+ * @tparam KernelHandle A specialization of
+ * KokkosKernels::Experimental::KokkosKernelsHandle
+ * @tparam XType The x and b vector type
+ * @param handleL KernelHandle instance for lower triangular matrix
+ * @param handleU KernelHandle instance for upper triangular matrix
+ * @param x The x vector
+ * @param b The b vector
+ */
 template <typename KernelHandle, class XType>
 void sptrsv_solve(KernelHandle *handleL, KernelHandle *handleU, XType x,
                   XType b) {
-  // Lower-triangular solve
-  sptrsv_solve(handleL, x, b);
-
-  // copy the solution to rhs
-  Kokkos::deep_copy(b, x);
-
-  // uper-triangular solve
-  sptrsv_solve(handleU, x, b);
+  using ExecutionSpace = typename KernelHandle::HandleExecSpace;
+  auto my_exec_space   = ExecutionSpace();
+  sptrsv_solve(my_exec_space, handleL, handleU, x, b);
 }
 #endif
 


### PR DESCRIPTION
The twostage algorithm for https://github.com/kokkos/kokkos-kernels/issues/1860 requires sptrsv execution space overloads.

Fixes: #1994
Caused by: #1980