### PR TITLE
Test_Sparse_spmv_bsr.hpp: replace std::optional with custom struct

### DIFF
--- a/sparse/unit_test/Test_Sparse_Controls.hpp
+++ b/sparse/unit_test/Test_Sparse_Controls.hpp
@@ -38,7 +38,25 @@ void test_controls_set() {
   EXPECT_EQ(c.getParameter("", "default"), "default");
 }
 
+void test_controls_il() {
+  {
+    KokkosKernels::Experimental::Controls c({{"key1", "val1"}});
+    EXPECT_EQ(c.isParameter("blah"), false);
+    EXPECT_EQ(c.getParameter("blah"), "");
+    EXPECT_EQ(c.getParameter("key1"), "val1");
+  }
+  {
+    KokkosKernels::Experimental::Controls c(
+        {{"key1", "val1"}, {"key2", "val2"}});
+    EXPECT_EQ(c.isParameter("blah"), false);
+    EXPECT_EQ(c.getParameter("blah"), "");
+    EXPECT_EQ(c.getParameter("key1"), "val1");
+    EXPECT_EQ(c.getParameter("key2"), "val2");
+  }
+}
+
 TEST_F(TestCategory, controls_empty) { test_controls_empty(); }
 TEST_F(TestCategory, controls_set) { test_controls_set(); }
+TEST_F(TestCategory, controls_il) { test_controls_il(); }
 
 #endif  // TEST_SPARSE_CONTROLS_HPP

--- a/sparse/unit_test/Test_Sparse_spmv_bsr.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv_bsr.hpp
@@ -57,8 +57,8 @@ using kokkos_complex_float  = Kokkos::complex<float>;
    https://github.com/kokkos/kokkos-kernels/issues/1943
 */
 struct OptCtrls {
-  KokkosKernels::Experimental::Controls ctrls_;
   bool present_;
+  KokkosKernels::Experimental::Controls ctrls_;
 
   OptCtrls() : present_(false) {}
   OptCtrls(const KokkosKernels::Experimental::Controls &ctrls)


### PR DESCRIPTION
Fix for https://github.com/kokkos/kokkos-kernels/issues/1943