### PR TITLE
cm_test_all_sandia: update caraway mi250 queue modules

### DIFF
--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -177,12 +177,11 @@ if [[ "$HOSTNAME" == caraway* ]]; then # Warning: very generic name
 fi
 
 if [[ "$HOSTNAME" == fat* ]]; then # Caraway MI250 queues
-  MACHINE=caraway
-  source /etc/profile.d/lmod.sh
+  MACHINE=vega90a_caraway
 fi
 
 if [[ "$HOSTNAME" == lean* ]]; then # Caraway MI210 queues
-  MACHINE=caraway
+  MACHINE=vega90a_caraway
 fi
 
 if [[ "$HOSTNAME" == kokkos-dev\.sandia\.gov* ]]; then
@@ -698,6 +697,38 @@ elif [ "$MACHINE" = "caraway" ]; then
 
   if [ -z "$ARCH_FLAG" ]; then
     ARCH_FLAG="--arch=VEGA908"
+  fi
+elif [ "$MACHINE" = "vega90a_caraway" ]; then
+  SKIP_HWLOC=True
+  # BUILD_ONLY=True
+  # report_and_log_test_result: only testing compilation of code for now,
+  #   output description and success based only on build succes; build time output (no run-time)
+
+  BASE_MODULE_LIST="cmake,<COMPILER_NAME>/<COMPILER_VERSION>"
+  ROCM520_MODULE_LIST="$BASE_MODULE_LIST,openblas/0.3.20/rocm/5.2.0"
+
+  HIPCLANG_BUILD_LIST="Hip_Serial"
+  HIPCLANG_WARNING_FLAGS=""
+
+  if [ "$SPOT_CHECK_TPLS" = "True" ]; then
+    # Format: (compiler module-list build-list exe-name warning-flag)
+    COMPILERS=("rocm/5.6.0 $ROCM520_MODULE_LIST $HIPCLANG_BUILD_LIST hipcc $HIPCLANG_WARNING_FLAGS"
+    )
+  else
+    # Format: (compiler module-list build-list exe-name warning-flag)
+    COMPILERS=("rocm/5.6.0 $BASE_MODULE_LIST $HIPCLANG_BUILD_LIST hipcc $HIPCLANG_WARNING_FLAGS"
+               "rocm/5.6.1 $BASE_MODULE_LIST $HIPCLANG_BUILD_LIST hipcc $HIPCLANG_WARNING_FLAGS"
+               "gcc/8.2.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
+               "gcc/9.2.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
+               "gcc/10.2.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
+               "gcc/11.2.0 $BASE_MODULE_LIST $GCC_BUILD_LIST g++ $GCC_WARNING_FLAGS"
+    )
+  fi
+
+
+
+  if [ -z "$ARCH_FLAG" ]; then
+    ARCH_FLAG="--arch=VEGA90A"
   fi
 elif [ "$MACHINE" = "blake" ]; then
   MODULE_ENVIRONMENT="source /etc/profile.d/modules.sh"


### PR DESCRIPTION
```
Running on machine: mi250_caraway
WARNING!! THE FOLLOWING CHANGES ARE UNCOMMITTED!! :
 M scripts/cm_test_all_sandia

KokkosKernels Repository Status:  e8469fdeb6e733e34c1fef3cc5e2d1dc9497b881 Merge pull request #1974 from cwpearson/enhancement/issue-1671

Kokkos Repository Status:  41cf2e51cd8e63a614aa1b4a9564a35934b805d5 Merge pull request #6303 from thearusable/5635-threads-parallel-scan-with-value-TeamThreadRange


Going to test compilers:  rocm/5.6.0
Testing compiler rocm/5.6.0
Unrecognized compiler rocm/5.6.0 when looking for Spack variants
Unrecognized compiler rocm/5.6.0 when looking for Spack variants
Unrecognized compiler rocm/5.6.0 when looking for Spack variants
  Starting job rocm-5.6.0-Hip_Serial-release
Hip IS THE KOKKOS DEVICE
kokkos devices: Hip,Serial
kokkos arch: VEGA90A
kokkos options: 
kokkos cuda options: 
kokkos cxxflags: -O3  
extra_args: 
kokkoskernels scalars: 'double,complex_double'
kokkoskernels ordinals: int
kokkoskernels offsets: int,size_t
kokkoskernels layouts: LayoutLeft
  PASSED rocm-5.6.0-Hip_Serial-release
#######################################################
PASSED TESTS
#######################################################
rocm-5.6.0-Hip_Serial-release build_time=984 run_time=288
```