### PR TITLE
upstream iostream removal fix

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -31,6 +31,7 @@
 #include <ctime>
 
 #include <complex>
+#include <iostream>
 
 #include "Kokkos_Complex.hpp"
 

--- a/example/half/xpy.cpp
+++ b/example/half/xpy.cpp
@@ -17,6 +17,7 @@
 #include "Kokkos_Core.hpp"
 #include "Kokkos_Random.hpp"
 #include "KokkosKernels_default_types.hpp"
+#include <iostream>
 
 template <class ViewType>
 struct Functor_xpy {

--- a/sparse/src/KokkosSparse_Utils_rocsparse.hpp
+++ b/sparse/src/KokkosSparse_Utils_rocsparse.hpp
@@ -18,6 +18,7 @@
 #define _KOKKOSKERNELS_SPARSEUTILS_ROCSPARSE_HPP
 
 #include <type_traits>
+#include <sstream>
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE
 #include <rocm_version.h>
@@ -101,8 +102,9 @@ inline rocsparse_operation mode_kk_to_rocsparse(const char kk_mode[]) {
       myRocsparseOperation = rocsparse_operation_conjugate_transpose;
       break;
     default: {
-      std::cerr << "Mode " << kk_mode[0] << " invalid for rocSPARSE SpMV.\n";
-      throw std::invalid_argument("Invalid mode");
+      std::ostringstream out;
+      out << "Mode " << kk_mode[0] << " invalid for rocSPARSE SpMV.\n";
+      throw std::invalid_argument(out.str());
     }
   }
   return myRocsparseOperation;

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -17,6 +17,8 @@
 #ifndef KOKKOSPARSE_SPMV_TPL_SPEC_DECL_HPP_
 #define KOKKOSPARSE_SPMV_TPL_SPEC_DECL_HPP_
 
+#include <sstream>
+
 #include "KokkosKernels_Controls.hpp"
 
 // cuSPARSE
@@ -52,8 +54,9 @@ void spmv_cusparse(const Kokkos::Cuda& exec,
       myCusparseOperation = CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE;
       break;
     default: {
-      std::cerr << "Mode " << mode << " invalid for cuSPARSE SpMV.\n";
-      throw std::invalid_argument("Invalid mode");
+      std::ostringstream out;
+      out << "Mode " << mode << " invalid for cuSPARSE SpMV.\n";
+      throw std::invalid_argument(out.str());
     }
   }
   // cuSPARSE doesn't directly support mode H with real values, but this is


### PR DESCRIPTION
Without this change, we're getting build errors like:
```
kokkos-kernels/batched/KokkosBatched_Util.hpp:201:10: error: no member named 'cout' in namespace 'std'
```

Caused by: https://github.com/kokkos/kokkos/pull/6482