### PR TITLE
BSPGEMM: removing cusparse testing for version older than 11.4.0

### DIFF
--- a/sparse/unit_test/Test_Sparse_bspgemm.hpp
+++ b/sparse/unit_test/Test_Sparse_bspgemm.hpp
@@ -159,6 +159,15 @@ void test_bspgemm(lno_t blkDim, lno_t m, lno_t k, lno_t n, size_type nnz,
     return;
   }
 #endif  // KOKKOSKERNELS_ENABLE_TPL_ARMPL
+#if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) && (CUSPARSE_VERSION < 11600)
+  {
+    std::cerr
+        << "TEST SKIPPED: See "
+           "https://github.com/kokkos/kokkos-kernels/issues/1965 for details."
+        << std::endl;
+    return;
+  }
+#endif
   using namespace Test;
   // device::execution_space::initialize();
   // device::execution_space::print_configuration(std::cout);


### PR DESCRIPTION
Older version are either hanging or returning wrong results in our unit-tests, this is fixed with more recent versions of the TPL.
Further information on this problem can be found in issue #1965 