### PR TITLE
Experimental hip cleanup

### DIFF
--- a/batched/dense/impl/KokkosBatched_HostLevel_Gemm_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_HostLevel_Gemm_Impl.hpp
@@ -50,7 +50,7 @@ constexpr KOKKOS_INLINE_FUNCTION int kk_gemm_dbl_buf_tile_k() {
 #if defined(KOKKOS_ENABLE_HIP) && defined(KOKKOS_ARCH_VEGA908)
 template <>
 constexpr KOKKOS_INLINE_FUNCTION int
-kk_gemm_dbl_buf_tile_k<Kokkos::Experimental::HIP>() {
+kk_gemm_dbl_buf_tile_k<Kokkos::HIP>() {
   return 16;
 }
 #endif

--- a/batched/dense/impl/KokkosBatched_HostLevel_Gemm_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_HostLevel_Gemm_Impl.hpp
@@ -49,8 +49,7 @@ constexpr KOKKOS_INLINE_FUNCTION int kk_gemm_dbl_buf_tile_k() {
 // buffering algorithm by a factor of 2.
 #if defined(KOKKOS_ENABLE_HIP) && defined(KOKKOS_ARCH_VEGA908)
 template <>
-constexpr KOKKOS_INLINE_FUNCTION int
-kk_gemm_dbl_buf_tile_k<Kokkos::HIP>() {
+constexpr KOKKOS_INLINE_FUNCTION int kk_gemm_dbl_buf_tile_k<Kokkos::HIP>() {
   return 16;
 }
 #endif

--- a/batched/dense/src/KokkosBatched_Vector.hpp
+++ b/batched/dense/src/KokkosBatched_Vector.hpp
@@ -120,21 +120,21 @@ struct DefaultVectorLength<Kokkos::complex<double>, Kokkos::CudaUVMSpace> {
 
 #if defined(KOKKOS_ENABLE_HIP)
 template <>
-struct DefaultVectorLength<float, Kokkos::Experimental::HIPSpace> {
+struct DefaultVectorLength<float, Kokkos::HIPSpace> {
   enum : int { value = 16 };
 };
 template <>
-struct DefaultVectorLength<double, Kokkos::Experimental::HIPSpace> {
+struct DefaultVectorLength<double, Kokkos::HIPSpace> {
   enum : int { value = 16 };
 };
 template <>
 struct DefaultVectorLength<Kokkos::complex<float>,
-                           Kokkos::Experimental::HIPSpace> {
+                           Kokkos::HIPSpace> {
   enum : int { value = 16 };
 };
 template <>
 struct DefaultVectorLength<Kokkos::complex<double>,
-                           Kokkos::Experimental::HIPSpace> {
+                           Kokkos::HIPSpace> {
   enum : int { value = 16 };
 };
 #endif
@@ -189,21 +189,21 @@ struct DefaultInternalVectorLength<Kokkos::complex<double>,
 
 #if defined(KOKKOS_ENABLE_HIP)
 template <>
-struct DefaultInternalVectorLength<float, Kokkos::Experimental::HIPSpace> {
+struct DefaultInternalVectorLength<float, Kokkos::HIPSpace> {
   enum : int { value = 8 };
 };
 template <>
-struct DefaultInternalVectorLength<double, Kokkos::Experimental::HIPSpace> {
+struct DefaultInternalVectorLength<double, Kokkos::HIPSpace> {
   enum : int { value = 4 };
 };
 template <>
 struct DefaultInternalVectorLength<Kokkos::complex<float>,
-                                   Kokkos::Experimental::HIPSpace> {
+                                   Kokkos::HIPSpace> {
   enum : int { value = 4 };
 };
 template <>
 struct DefaultInternalVectorLength<Kokkos::complex<double>,
-                                   Kokkos::Experimental::HIPSpace> {
+                                   Kokkos::HIPSpace> {
   enum : int { value = 2 };
 };
 #endif

--- a/batched/dense/src/KokkosBatched_Vector.hpp
+++ b/batched/dense/src/KokkosBatched_Vector.hpp
@@ -128,13 +128,11 @@ struct DefaultVectorLength<double, Kokkos::HIPSpace> {
   enum : int { value = 16 };
 };
 template <>
-struct DefaultVectorLength<Kokkos::complex<float>,
-                           Kokkos::HIPSpace> {
+struct DefaultVectorLength<Kokkos::complex<float>, Kokkos::HIPSpace> {
   enum : int { value = 16 };
 };
 template <>
-struct DefaultVectorLength<Kokkos::complex<double>,
-                           Kokkos::HIPSpace> {
+struct DefaultVectorLength<Kokkos::complex<double>, Kokkos::HIPSpace> {
   enum : int { value = 16 };
 };
 #endif
@@ -197,13 +195,11 @@ struct DefaultInternalVectorLength<double, Kokkos::HIPSpace> {
   enum : int { value = 4 };
 };
 template <>
-struct DefaultInternalVectorLength<Kokkos::complex<float>,
-                                   Kokkos::HIPSpace> {
+struct DefaultInternalVectorLength<Kokkos::complex<float>, Kokkos::HIPSpace> {
   enum : int { value = 4 };
 };
 template <>
-struct DefaultInternalVectorLength<Kokkos::complex<double>,
-                                   Kokkos::HIPSpace> {
+struct DefaultInternalVectorLength<Kokkos::complex<double>, Kokkos::HIPSpace> {
   enum : int { value = 2 };
 };
 #endif

--- a/blas/impl/KokkosBlas3_gemm_impl.hpp
+++ b/blas/impl/KokkosBlas3_gemm_impl.hpp
@@ -49,7 +49,7 @@ struct impl_gemm_choose_copy_layout<Kokkos::Cuda, LayoutA, LayoutAScratch> {
 
 #ifdef KOKKOS_ENABLE_HIP
 template <class LayoutA, class LayoutAScratch>
-struct impl_gemm_choose_copy_layout<Kokkos::Experimental::HIP, LayoutA,
+struct impl_gemm_choose_copy_layout<Kokkos::HIP, LayoutA,
                                     LayoutAScratch> {
   using type = LayoutA;
 };

--- a/blas/impl/KokkosBlas3_gemm_impl.hpp
+++ b/blas/impl/KokkosBlas3_gemm_impl.hpp
@@ -49,8 +49,7 @@ struct impl_gemm_choose_copy_layout<Kokkos::Cuda, LayoutA, LayoutAScratch> {
 
 #ifdef KOKKOS_ENABLE_HIP
 template <class LayoutA, class LayoutAScratch>
-struct impl_gemm_choose_copy_layout<Kokkos::HIP, LayoutA,
-                                    LayoutAScratch> {
+struct impl_gemm_choose_copy_layout<Kokkos::HIP, LayoutA, LayoutAScratch> {
   using type = LayoutA;
 };
 #endif

--- a/blas/impl/KokkosBlas3_gemm_spec.hpp
+++ b/blas/impl/KokkosBlas3_gemm_spec.hpp
@@ -192,7 +192,7 @@ struct GEMM {
         team_size = blockA0;
 #endif
 #if defined(KOKKOS_ENABLE_HIP)
-      if (std::is_same<execution_space, Kokkos::Experimental::HIP>::value)
+      if (std::is_same<execution_space, Kokkos::HIP>::value)
         team_size = blockA0;
 #endif
 #if defined(KOKKOS_ENABLE_ROCM)

--- a/blas/src/KokkosBlas2_gemv.hpp
+++ b/blas/src/KokkosBlas2_gemv.hpp
@@ -151,7 +151,7 @@ void gemv(const ExecutionSpace& space, const char trans[],
                       std::is_same<typename AViewType::array_layout,
                                    Kokkos::LayoutRight>::value &&
                       std::is_same<typename AViewType::memory_space,
-                                   Kokkos::Experimental::HIPSpace>::value);
+                                   Kokkos::HIPSpace>::value);
 #endif
 #ifdef KOKKOSKERNELS_ENABLE_TPL_BLAS
   useFallback = useFallback || (tolower(*trans) == 'c' &&

--- a/blas/src/KokkosBlas2_gemv.hpp
+++ b/blas/src/KokkosBlas2_gemv.hpp
@@ -147,11 +147,11 @@ void gemv(const ExecutionSpace& space, const char trans[],
 #endif
 #ifdef KOKKOSKERNELS_ENABLE_TPL_ROCBLAS
   useFallback =
-      useFallback || (tolower(*trans) == 'c' &&
-                      std::is_same<typename AViewType::array_layout,
-                                   Kokkos::LayoutRight>::value &&
-                      std::is_same<typename AViewType::memory_space,
-                                   Kokkos::HIPSpace>::value);
+      useFallback ||
+      (tolower(*trans) == 'c' &&
+       std::is_same<typename AViewType::array_layout,
+                    Kokkos::LayoutRight>::value &&
+       std::is_same<typename AViewType::memory_space, Kokkos::HIPSpace>::value);
 #endif
 #ifdef KOKKOSKERNELS_ENABLE_TPL_BLAS
   useFallback = useFallback || (tolower(*trans) == 'c' &&

--- a/blas/tpls/KokkosBlas2_gemv_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas2_gemv_tpl_spec_avail.hpp
@@ -127,23 +127,20 @@ KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<float>,
 // rocBLAS
 #ifdef KOKKOSKERNELS_ENABLE_TPL_ROCBLAS
 
-#define KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ROCBLAS(SCALAR, LAYOUT)    \
-  template <class ExecSpace>                                       \
-  struct gemv_tpl_spec_avail<                                      \
-      ExecSpace,                                                   \
-      Kokkos::View<const SCALAR**, LAYOUT,                         \
-                   Kokkos::Device<Kokkos::HIP,       \
-                                  Kokkos::HIPSpace>, \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
-      Kokkos::View<const SCALAR*, LAYOUT,                          \
-                   Kokkos::Device<Kokkos::HIP,       \
-                                  Kokkos::HIPSpace>, \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
-      Kokkos::View<SCALAR*, LAYOUT,                                \
-                   Kokkos::Device<Kokkos::HIP,       \
-                                  Kokkos::HIPSpace>, \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {   \
-    enum : bool { value = true };                                  \
+#define KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ROCBLAS(SCALAR, LAYOUT)   \
+  template <class ExecSpace>                                      \
+  struct gemv_tpl_spec_avail<                                     \
+      ExecSpace,                                                  \
+      Kokkos::View<const SCALAR**, LAYOUT,                        \
+                   Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,     \
+      Kokkos::View<const SCALAR*, LAYOUT,                         \
+                   Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,     \
+      Kokkos::View<SCALAR*, LAYOUT,                               \
+                   Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {  \
+    enum : bool { value = true };                                 \
   };
 
 KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ROCBLAS(double, Kokkos::LayoutLeft)

--- a/blas/tpls/KokkosBlas2_gemv_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas2_gemv_tpl_spec_avail.hpp
@@ -132,16 +132,16 @@ KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<float>,
   struct gemv_tpl_spec_avail<                                      \
       ExecSpace,                                                   \
       Kokkos::View<const SCALAR**, LAYOUT,                         \
-                   Kokkos::Device<Kokkos::Experimental::HIP,       \
-                                  Kokkos::Experimental::HIPSpace>, \
+                   Kokkos::Device<Kokkos::HIP,       \
+                                  Kokkos::HIPSpace>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
       Kokkos::View<const SCALAR*, LAYOUT,                          \
-                   Kokkos::Device<Kokkos::Experimental::HIP,       \
-                                  Kokkos::Experimental::HIPSpace>, \
+                   Kokkos::Device<Kokkos::HIP,       \
+                                  Kokkos::HIPSpace>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
       Kokkos::View<SCALAR*, LAYOUT,                                \
-                   Kokkos::Device<Kokkos::Experimental::HIP,       \
-                                  Kokkos::Experimental::HIPSpace>, \
+                   Kokkos::Device<Kokkos::HIP,       \
+                                  Kokkos::HIPSpace>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {   \
     enum : bool { value = true };                                  \
   };

--- a/blas/tpls/KokkosBlas2_gemv_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas2_gemv_tpl_spec_decl.hpp
@@ -553,26 +553,26 @@ namespace Impl {
   struct GEMV<                                                                 \
       ExecSpace,                                                               \
       Kokkos::View<const double**, LAYOUT,                                     \
-                   Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>,       \
+                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       Kokkos::View<const double*, LAYOUT,                                      \
-                   Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>,       \
+                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       Kokkos::View<double*, LAYOUT,                                            \
-                   Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>,       \
+                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       true, ETI_SPEC_AVAIL> {                                                  \
     typedef double SCALAR;                                                     \
     typedef Kokkos::View<const SCALAR**, LAYOUT,                               \
-                         Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>, \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         AViewType;                                                             \
     typedef Kokkos::View<const SCALAR*, LAYOUT,                                \
-                         Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>, \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         XViewType;                                                             \
     typedef Kokkos::View<SCALAR*, LAYOUT,                                      \
-                         Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>, \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         YViewType;                                                             \
                                                                                \
@@ -600,26 +600,26 @@ namespace Impl {
   struct GEMV<                                                                 \
       ExecSpace,                                                               \
       Kokkos::View<const float**, LAYOUT,                                      \
-                   Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>,       \
+                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       Kokkos::View<const float*, LAYOUT,                                       \
-                   Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>,       \
+                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       Kokkos::View<float*, LAYOUT,                                             \
-                   Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>,       \
+                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       true, ETI_SPEC_AVAIL> {                                                  \
     typedef float SCALAR;                                                      \
     typedef Kokkos::View<const SCALAR**, LAYOUT,                               \
-                         Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>, \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         AViewType;                                                             \
     typedef Kokkos::View<const SCALAR*, LAYOUT,                                \
-                         Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>, \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         XViewType;                                                             \
     typedef Kokkos::View<SCALAR*, LAYOUT,                                      \
-                         Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>, \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         YViewType;                                                             \
                                                                                \
@@ -647,26 +647,26 @@ namespace Impl {
   struct GEMV<                                                                 \
       ExecSpace,                                                               \
       Kokkos::View<const Kokkos::complex<double>**, LAYOUT,                    \
-                   Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>,       \
+                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       Kokkos::View<const Kokkos::complex<double>*, LAYOUT,                     \
-                   Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>,       \
+                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       Kokkos::View<Kokkos::complex<double>*, LAYOUT,                           \
-                   Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>,       \
+                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       true, ETI_SPEC_AVAIL> {                                                  \
     typedef Kokkos::complex<double> SCALAR;                                    \
     typedef Kokkos::View<const SCALAR**, LAYOUT,                               \
-                         Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>, \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         AViewType;                                                             \
     typedef Kokkos::View<const SCALAR*, LAYOUT,                                \
-                         Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>, \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         XViewType;                                                             \
     typedef Kokkos::View<SCALAR*, LAYOUT,                                      \
-                         Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>, \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         YViewType;                                                             \
                                                                                \
@@ -699,26 +699,26 @@ namespace Impl {
   struct GEMV<                                                                 \
       ExecSpace,                                                               \
       Kokkos::View<const Kokkos::complex<float>**, LAYOUT,                     \
-                   Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>,       \
+                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       Kokkos::View<const Kokkos::complex<float>*, LAYOUT,                      \
-                   Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>,       \
+                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       Kokkos::View<Kokkos::complex<float>*, LAYOUT,                            \
-                   Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>,       \
+                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
       true, ETI_SPEC_AVAIL> {                                                  \
     typedef Kokkos::complex<float> SCALAR;                                     \
     typedef Kokkos::View<const SCALAR**, LAYOUT,                               \
-                         Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>, \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         AViewType;                                                             \
     typedef Kokkos::View<const SCALAR*, LAYOUT,                                \
-                         Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>, \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         XViewType;                                                             \
     typedef Kokkos::View<SCALAR*, LAYOUT,                                      \
-                         Kokkos::Device<Kokkos::Experimental::HIP, MEM_SPACE>, \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
         YViewType;                                                             \
                                                                                \
@@ -746,40 +746,40 @@ namespace Impl {
     }                                                                          \
   };
 
-KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::Experimental::HIPSpace,
+KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace,
                           true)
-KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::Experimental::HIPSpace,
+KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace,
                           false)
-KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::Experimental::HIPSpace,
+KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace,
                           true)
-KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::Experimental::HIPSpace,
-                          false)
-
-KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::Experimental::HIPSpace,
-                          true)
-KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::Experimental::HIPSpace,
-                          false)
-KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::Experimental::HIPSpace,
-                          true)
-KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::Experimental::HIPSpace,
+KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace,
                           false)
 
-KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::Experimental::HIPSpace,
+KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace,
                           true)
-KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::Experimental::HIPSpace,
+KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace,
                           false)
-KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::Experimental::HIPSpace,
+KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace,
                           true)
-KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::Experimental::HIPSpace,
+KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace,
                           false)
 
-KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::Experimental::HIPSpace,
+KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace,
                           true)
-KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::Experimental::HIPSpace,
+KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace,
                           false)
-KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::Experimental::HIPSpace,
+KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace,
                           true)
-KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::Experimental::HIPSpace,
+KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace,
+                          false)
+
+KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace,
+                          true)
+KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace,
+                          false)
+KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace,
+                          true)
+KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace,
                           false)
 
 }  // namespace Impl

--- a/blas/tpls/KokkosBlas2_gemv_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas2_gemv_tpl_spec_decl.hpp
@@ -548,239 +548,219 @@ namespace Impl {
     transa = rocblas_operation_conjugate_transpose;                          \
   }
 
-#define KOKKOSBLAS2_DGEMV_ROCBLAS(LAYOUT, MEM_SPACE, ETI_SPEC_AVAIL)           \
-  template <class ExecSpace>                                                   \
-  struct GEMV<                                                                 \
-      ExecSpace,                                                               \
-      Kokkos::View<const double**, LAYOUT,                                     \
-                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
-      Kokkos::View<const double*, LAYOUT,                                      \
-                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
-      Kokkos::View<double*, LAYOUT,                                            \
-                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
-      true, ETI_SPEC_AVAIL> {                                                  \
-    typedef double SCALAR;                                                     \
-    typedef Kokkos::View<const SCALAR**, LAYOUT,                               \
-                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
-        AViewType;                                                             \
-    typedef Kokkos::View<const SCALAR*, LAYOUT,                                \
-                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
-        XViewType;                                                             \
-    typedef Kokkos::View<SCALAR*, LAYOUT,                                      \
-                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
-        YViewType;                                                             \
-                                                                               \
-    static void gemv(const ExecSpace& space, const char trans[],               \
-                     typename AViewType::const_value_type& alpha,              \
-                     const AViewType& A, const XViewType& X,                   \
-                     typename YViewType::const_value_type& beta,               \
-                     const YViewType& Y) {                                     \
-      Kokkos::Profiling::pushRegion("KokkosBlas::gemv[TPL_ROCBLAS,double]");   \
-      KOKKOSBLAS2_GEMV_ROCBLAS_DETERMINE_ARGS(LAYOUT);                         \
-      KokkosBlas::Impl::RocBlasSingleton& s =                                  \
-          KokkosBlas::Impl::RocBlasSingleton::singleton();                     \
-      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                           \
-          rocblas_set_stream(s.handle, space.hip_stream()));                   \
-      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                           \
-          rocblas_dgemv(s.handle, transa, M, N, &alpha, A.data(), LDA,         \
-                        X.data(), one, &beta, Y.data(), one));                 \
-      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL));       \
-      Kokkos::Profiling::popRegion();                                          \
-    }                                                                          \
+#define KOKKOSBLAS2_DGEMV_ROCBLAS(LAYOUT, MEM_SPACE, ETI_SPEC_AVAIL)         \
+  template <class ExecSpace>                                                 \
+  struct GEMV<                                                               \
+      ExecSpace,                                                             \
+      Kokkos::View<const double**, LAYOUT,                                   \
+                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                   \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                \
+      Kokkos::View<const double*, LAYOUT,                                    \
+                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                   \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                \
+      Kokkos::View<double*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,  \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                \
+      true, ETI_SPEC_AVAIL> {                                                \
+    typedef double SCALAR;                                                   \
+    typedef Kokkos::View<const SCALAR**, LAYOUT,                             \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>,             \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >           \
+        AViewType;                                                           \
+    typedef Kokkos::View<const SCALAR*, LAYOUT,                              \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>,             \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >           \
+        XViewType;                                                           \
+    typedef Kokkos::View<SCALAR*, LAYOUT,                                    \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>,             \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >           \
+        YViewType;                                                           \
+                                                                             \
+    static void gemv(const ExecSpace& space, const char trans[],             \
+                     typename AViewType::const_value_type& alpha,            \
+                     const AViewType& A, const XViewType& X,                 \
+                     typename YViewType::const_value_type& beta,             \
+                     const YViewType& Y) {                                   \
+      Kokkos::Profiling::pushRegion("KokkosBlas::gemv[TPL_ROCBLAS,double]"); \
+      KOKKOSBLAS2_GEMV_ROCBLAS_DETERMINE_ARGS(LAYOUT);                       \
+      KokkosBlas::Impl::RocBlasSingleton& s =                                \
+          KokkosBlas::Impl::RocBlasSingleton::singleton();                   \
+      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                         \
+          rocblas_set_stream(s.handle, space.hip_stream()));                 \
+      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                         \
+          rocblas_dgemv(s.handle, transa, M, N, &alpha, A.data(), LDA,       \
+                        X.data(), one, &beta, Y.data(), one));               \
+      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL));     \
+      Kokkos::Profiling::popRegion();                                        \
+    }                                                                        \
   };
 
-#define KOKKOSBLAS2_SGEMV_ROCBLAS(LAYOUT, MEM_SPACE, ETI_SPEC_AVAIL)           \
-  template <class ExecSpace>                                                   \
-  struct GEMV<                                                                 \
-      ExecSpace,                                                               \
-      Kokkos::View<const float**, LAYOUT,                                      \
-                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
-      Kokkos::View<const float*, LAYOUT,                                       \
-                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
-      Kokkos::View<float*, LAYOUT,                                             \
-                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
-      true, ETI_SPEC_AVAIL> {                                                  \
-    typedef float SCALAR;                                                      \
-    typedef Kokkos::View<const SCALAR**, LAYOUT,                               \
-                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
-        AViewType;                                                             \
-    typedef Kokkos::View<const SCALAR*, LAYOUT,                                \
-                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
-        XViewType;                                                             \
-    typedef Kokkos::View<SCALAR*, LAYOUT,                                      \
-                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
-        YViewType;                                                             \
-                                                                               \
-    static void gemv(const ExecSpace& space, const char trans[],               \
-                     typename AViewType::const_value_type& alpha,              \
-                     const AViewType& A, const XViewType& X,                   \
-                     typename YViewType::const_value_type& beta,               \
-                     const YViewType& Y) {                                     \
-      Kokkos::Profiling::pushRegion("KokkosBlas::gemv[TPL_ROCBLAS,float]");    \
-      KOKKOSBLAS2_GEMV_ROCBLAS_DETERMINE_ARGS(LAYOUT);                         \
-      KokkosBlas::Impl::RocBlasSingleton& s =                                  \
-          KokkosBlas::Impl::RocBlasSingleton::singleton();                     \
-      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                           \
-          rocblas_set_stream(s.handle, space.hip_stream()));                   \
-      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                           \
-          rocblas_sgemv(s.handle, transa, M, N, &alpha, A.data(), LDA,         \
-                        X.data(), one, &beta, Y.data(), one));                 \
-      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL));       \
-      Kokkos::Profiling::popRegion();                                          \
-    }                                                                          \
+#define KOKKOSBLAS2_SGEMV_ROCBLAS(LAYOUT, MEM_SPACE, ETI_SPEC_AVAIL)        \
+  template <class ExecSpace>                                                \
+  struct GEMV<                                                              \
+      ExecSpace,                                                            \
+      Kokkos::View<const float**, LAYOUT,                                   \
+                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                  \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
+      Kokkos::View<const float*, LAYOUT,                                    \
+                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                  \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
+      Kokkos::View<float*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,  \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
+      true, ETI_SPEC_AVAIL> {                                               \
+    typedef float SCALAR;                                                   \
+    typedef Kokkos::View<const SCALAR**, LAYOUT,                            \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>,            \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >          \
+        AViewType;                                                          \
+    typedef Kokkos::View<const SCALAR*, LAYOUT,                             \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>,            \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >          \
+        XViewType;                                                          \
+    typedef Kokkos::View<SCALAR*, LAYOUT,                                   \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>,            \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >          \
+        YViewType;                                                          \
+                                                                            \
+    static void gemv(const ExecSpace& space, const char trans[],            \
+                     typename AViewType::const_value_type& alpha,           \
+                     const AViewType& A, const XViewType& X,                \
+                     typename YViewType::const_value_type& beta,            \
+                     const YViewType& Y) {                                  \
+      Kokkos::Profiling::pushRegion("KokkosBlas::gemv[TPL_ROCBLAS,float]"); \
+      KOKKOSBLAS2_GEMV_ROCBLAS_DETERMINE_ARGS(LAYOUT);                      \
+      KokkosBlas::Impl::RocBlasSingleton& s =                               \
+          KokkosBlas::Impl::RocBlasSingleton::singleton();                  \
+      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                        \
+          rocblas_set_stream(s.handle, space.hip_stream()));                \
+      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                        \
+          rocblas_sgemv(s.handle, transa, M, N, &alpha, A.data(), LDA,      \
+                        X.data(), one, &beta, Y.data(), one));              \
+      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL));    \
+      Kokkos::Profiling::popRegion();                                       \
+    }                                                                       \
   };
 
-#define KOKKOSBLAS2_ZGEMV_ROCBLAS(LAYOUT, MEM_SPACE, ETI_SPEC_AVAIL)           \
-  template <class ExecSpace>                                                   \
-  struct GEMV<                                                                 \
-      ExecSpace,                                                               \
-      Kokkos::View<const Kokkos::complex<double>**, LAYOUT,                    \
-                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
-      Kokkos::View<const Kokkos::complex<double>*, LAYOUT,                     \
-                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
-      Kokkos::View<Kokkos::complex<double>*, LAYOUT,                           \
-                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
-      true, ETI_SPEC_AVAIL> {                                                  \
-    typedef Kokkos::complex<double> SCALAR;                                    \
-    typedef Kokkos::View<const SCALAR**, LAYOUT,                               \
-                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
-        AViewType;                                                             \
-    typedef Kokkos::View<const SCALAR*, LAYOUT,                                \
-                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
-        XViewType;                                                             \
-    typedef Kokkos::View<SCALAR*, LAYOUT,                                      \
-                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
-        YViewType;                                                             \
-                                                                               \
-    static void gemv(const ExecSpace& space, const char trans[],               \
-                     typename AViewType::const_value_type& alpha,              \
-                     const AViewType& A, const XViewType& X,                   \
-                     typename YViewType::const_value_type& beta,               \
-                     const YViewType& Y) {                                     \
-      Kokkos::Profiling::pushRegion(                                           \
-          "KokkosBlas::gemv[TPL_ROCBLAS,complex<double>]");                    \
-      KOKKOSBLAS2_GEMV_ROCBLAS_DETERMINE_ARGS(LAYOUT);                         \
-      KokkosBlas::Impl::RocBlasSingleton& s =                                  \
-          KokkosBlas::Impl::RocBlasSingleton::singleton();                     \
-      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                           \
-          rocblas_set_stream(s.handle, space.hip_stream()));                   \
-      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_zgemv(                             \
-          s.handle, transa, M, N,                                              \
-          reinterpret_cast<const rocblas_double_complex*>(&alpha),             \
-          reinterpret_cast<const rocblas_double_complex*>(A.data()), LDA,      \
-          reinterpret_cast<const rocblas_double_complex*>(X.data()), one,      \
-          reinterpret_cast<const rocblas_double_complex*>(&beta),              \
-          reinterpret_cast<rocblas_double_complex*>(Y.data()), one));          \
-      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL));       \
-      Kokkos::Profiling::popRegion();                                          \
-    }                                                                          \
+#define KOKKOSBLAS2_ZGEMV_ROCBLAS(LAYOUT, MEM_SPACE, ETI_SPEC_AVAIL)      \
+  template <class ExecSpace>                                              \
+  struct GEMV<ExecSpace,                                                  \
+              Kokkos::View<const Kokkos::complex<double>**, LAYOUT,       \
+                           Kokkos::Device<Kokkos::HIP, MEM_SPACE>,        \
+                           Kokkos::MemoryTraits<Kokkos::Unmanaged> >,     \
+              Kokkos::View<const Kokkos::complex<double>*, LAYOUT,        \
+                           Kokkos::Device<Kokkos::HIP, MEM_SPACE>,        \
+                           Kokkos::MemoryTraits<Kokkos::Unmanaged> >,     \
+              Kokkos::View<Kokkos::complex<double>*, LAYOUT,              \
+                           Kokkos::Device<Kokkos::HIP, MEM_SPACE>,        \
+                           Kokkos::MemoryTraits<Kokkos::Unmanaged> >,     \
+              true, ETI_SPEC_AVAIL> {                                     \
+    typedef Kokkos::complex<double> SCALAR;                               \
+    typedef Kokkos::View<const SCALAR**, LAYOUT,                          \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>,          \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >        \
+        AViewType;                                                        \
+    typedef Kokkos::View<const SCALAR*, LAYOUT,                           \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>,          \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >        \
+        XViewType;                                                        \
+    typedef Kokkos::View<SCALAR*, LAYOUT,                                 \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>,          \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >        \
+        YViewType;                                                        \
+                                                                          \
+    static void gemv(const ExecSpace& space, const char trans[],          \
+                     typename AViewType::const_value_type& alpha,         \
+                     const AViewType& A, const XViewType& X,              \
+                     typename YViewType::const_value_type& beta,          \
+                     const YViewType& Y) {                                \
+      Kokkos::Profiling::pushRegion(                                      \
+          "KokkosBlas::gemv[TPL_ROCBLAS,complex<double>]");               \
+      KOKKOSBLAS2_GEMV_ROCBLAS_DETERMINE_ARGS(LAYOUT);                    \
+      KokkosBlas::Impl::RocBlasSingleton& s =                             \
+          KokkosBlas::Impl::RocBlasSingleton::singleton();                \
+      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                      \
+          rocblas_set_stream(s.handle, space.hip_stream()));              \
+      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_zgemv(                        \
+          s.handle, transa, M, N,                                         \
+          reinterpret_cast<const rocblas_double_complex*>(&alpha),        \
+          reinterpret_cast<const rocblas_double_complex*>(A.data()), LDA, \
+          reinterpret_cast<const rocblas_double_complex*>(X.data()), one, \
+          reinterpret_cast<const rocblas_double_complex*>(&beta),         \
+          reinterpret_cast<rocblas_double_complex*>(Y.data()), one));     \
+      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL));  \
+      Kokkos::Profiling::popRegion();                                     \
+    }                                                                     \
   };
 
-#define KOKKOSBLAS2_CGEMV_ROCBLAS(LAYOUT, MEM_SPACE, ETI_SPEC_AVAIL)           \
-  template <class ExecSpace>                                                   \
-  struct GEMV<                                                                 \
-      ExecSpace,                                                               \
-      Kokkos::View<const Kokkos::complex<float>**, LAYOUT,                     \
-                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
-      Kokkos::View<const Kokkos::complex<float>*, LAYOUT,                      \
-                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
-      Kokkos::View<Kokkos::complex<float>*, LAYOUT,                            \
-                   Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                  \
-      true, ETI_SPEC_AVAIL> {                                                  \
-    typedef Kokkos::complex<float> SCALAR;                                     \
-    typedef Kokkos::View<const SCALAR**, LAYOUT,                               \
-                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
-        AViewType;                                                             \
-    typedef Kokkos::View<const SCALAR*, LAYOUT,                                \
-                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
-        XViewType;                                                             \
-    typedef Kokkos::View<SCALAR*, LAYOUT,                                      \
-                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >             \
-        YViewType;                                                             \
-                                                                               \
-    static void gemv(const ExecSpace& space, const char trans[],               \
-                     typename AViewType::const_value_type& alpha,              \
-                     const AViewType& A, const XViewType& X,                   \
-                     typename YViewType::const_value_type& beta,               \
-                     const YViewType& Y) {                                     \
-      Kokkos::Profiling::pushRegion(                                           \
-          "KokkosBlas::gemv[TPL_ROCBLAS,complex<float>]");                     \
-      KOKKOSBLAS2_GEMV_ROCBLAS_DETERMINE_ARGS(LAYOUT);                         \
-      KokkosBlas::Impl::RocBlasSingleton& s =                                  \
-          KokkosBlas::Impl::RocBlasSingleton::singleton();                     \
-      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                           \
-          rocblas_set_stream(s.handle, space.hip_stream()));                   \
-      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_cgemv(                             \
-          s.handle, transa, M, N,                                              \
-          reinterpret_cast<const rocblas_float_complex*>(&alpha),              \
-          reinterpret_cast<const rocblas_float_complex*>(A.data()), LDA,       \
-          reinterpret_cast<const rocblas_float_complex*>(X.data()), one,       \
-          reinterpret_cast<const rocblas_float_complex*>(&beta),               \
-          reinterpret_cast<rocblas_float_complex*>(Y.data()), one));           \
-      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL));       \
-      Kokkos::Profiling::popRegion();                                          \
-    }                                                                          \
+#define KOKKOSBLAS2_CGEMV_ROCBLAS(LAYOUT, MEM_SPACE, ETI_SPEC_AVAIL)     \
+  template <class ExecSpace>                                             \
+  struct GEMV<ExecSpace,                                                 \
+              Kokkos::View<const Kokkos::complex<float>**, LAYOUT,       \
+                           Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
+                           Kokkos::MemoryTraits<Kokkos::Unmanaged> >,    \
+              Kokkos::View<const Kokkos::complex<float>*, LAYOUT,        \
+                           Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
+                           Kokkos::MemoryTraits<Kokkos::Unmanaged> >,    \
+              Kokkos::View<Kokkos::complex<float>*, LAYOUT,              \
+                           Kokkos::Device<Kokkos::HIP, MEM_SPACE>,       \
+                           Kokkos::MemoryTraits<Kokkos::Unmanaged> >,    \
+              true, ETI_SPEC_AVAIL> {                                    \
+    typedef Kokkos::complex<float> SCALAR;                               \
+    typedef Kokkos::View<const SCALAR**, LAYOUT,                         \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>,         \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >       \
+        AViewType;                                                       \
+    typedef Kokkos::View<const SCALAR*, LAYOUT,                          \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>,         \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >       \
+        XViewType;                                                       \
+    typedef Kokkos::View<SCALAR*, LAYOUT,                                \
+                         Kokkos::Device<Kokkos::HIP, MEM_SPACE>,         \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >       \
+        YViewType;                                                       \
+                                                                         \
+    static void gemv(const ExecSpace& space, const char trans[],         \
+                     typename AViewType::const_value_type& alpha,        \
+                     const AViewType& A, const XViewType& X,             \
+                     typename YViewType::const_value_type& beta,         \
+                     const YViewType& Y) {                               \
+      Kokkos::Profiling::pushRegion(                                     \
+          "KokkosBlas::gemv[TPL_ROCBLAS,complex<float>]");               \
+      KOKKOSBLAS2_GEMV_ROCBLAS_DETERMINE_ARGS(LAYOUT);                   \
+      KokkosBlas::Impl::RocBlasSingleton& s =                            \
+          KokkosBlas::Impl::RocBlasSingleton::singleton();               \
+      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(                                     \
+          rocblas_set_stream(s.handle, space.hip_stream()));             \
+      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_cgemv(                       \
+          s.handle, transa, M, N,                                        \
+          reinterpret_cast<const rocblas_float_complex*>(&alpha),        \
+          reinterpret_cast<const rocblas_float_complex*>(A.data()), LDA, \
+          reinterpret_cast<const rocblas_float_complex*>(X.data()), one, \
+          reinterpret_cast<const rocblas_float_complex*>(&beta),         \
+          reinterpret_cast<rocblas_float_complex*>(Y.data()), one));     \
+      KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL)); \
+      Kokkos::Profiling::popRegion();                                    \
+    }                                                                    \
   };
 
-KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace,
-                          true)
-KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace,
-                          false)
-KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace,
-                          true)
-KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace,
-                          false)
+KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace, true)
+KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace, false)
+KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace, true)
+KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace, false)
 
-KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace,
-                          true)
-KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace,
-                          false)
-KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace,
-                          true)
-KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace,
-                          false)
+KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace, true)
+KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace, false)
+KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace, true)
+KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace, false)
 
-KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace,
-                          true)
-KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace,
-                          false)
-KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace,
-                          true)
-KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace,
-                          false)
+KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace, true)
+KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace, false)
+KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace, true)
+KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace, false)
 
-KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace,
-                          true)
-KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace,
-                          false)
-KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace,
-                          true)
-KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace,
-                          false)
+KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace, true)
+KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutLeft, Kokkos::HIPSpace, false)
+KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace, true)
+KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace, false)
 
 }  // namespace Impl
 }  // namespace KokkosBlas

--- a/blas/tpls/KokkosBlas3_gemm_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas3_gemm_tpl_spec_avail.hpp
@@ -164,26 +164,26 @@ KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<float>,
   };
 
 KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_ROCBLAS(double, Kokkos::LayoutLeft,
-                                        Kokkos::Experimental::HIPSpace)
+                                        Kokkos::HIPSpace)
 KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_ROCBLAS(float, Kokkos::LayoutLeft,
-                                        Kokkos::Experimental::HIPSpace)
+                                        Kokkos::HIPSpace)
 KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<double>,
                                         Kokkos::LayoutLeft,
-                                        Kokkos::Experimental::HIPSpace)
+                                        Kokkos::HIPSpace)
 KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<float>,
                                         Kokkos::LayoutLeft,
-                                        Kokkos::Experimental::HIPSpace)
+                                        Kokkos::HIPSpace)
 
 KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_ROCBLAS(double, Kokkos::LayoutRight,
-                                        Kokkos::Experimental::HIPSpace)
+                                        Kokkos::HIPSpace)
 KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_ROCBLAS(float, Kokkos::LayoutRight,
-                                        Kokkos::Experimental::HIPSpace)
+                                        Kokkos::HIPSpace)
 KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<double>,
                                         Kokkos::LayoutRight,
-                                        Kokkos::Experimental::HIPSpace)
+                                        Kokkos::HIPSpace)
 KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<float>,
                                         Kokkos::LayoutRight,
-                                        Kokkos::Experimental::HIPSpace)
+                                        Kokkos::HIPSpace)
 
 #endif
 }  // namespace Impl

--- a/blas/tpls/KokkosBlas3_gemm_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas3_gemm_tpl_spec_avail.hpp
@@ -168,22 +168,18 @@ KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_ROCBLAS(double, Kokkos::LayoutLeft,
 KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_ROCBLAS(float, Kokkos::LayoutLeft,
                                         Kokkos::HIPSpace)
 KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<double>,
-                                        Kokkos::LayoutLeft,
-                                        Kokkos::HIPSpace)
+                                        Kokkos::LayoutLeft, Kokkos::HIPSpace)
 KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<float>,
-                                        Kokkos::LayoutLeft,
-                                        Kokkos::HIPSpace)
+                                        Kokkos::LayoutLeft, Kokkos::HIPSpace)
 
 KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_ROCBLAS(double, Kokkos::LayoutRight,
                                         Kokkos::HIPSpace)
 KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_ROCBLAS(float, Kokkos::LayoutRight,
                                         Kokkos::HIPSpace)
 KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<double>,
-                                        Kokkos::LayoutRight,
-                                        Kokkos::HIPSpace)
+                                        Kokkos::LayoutRight, Kokkos::HIPSpace)
 KOKKOSBLAS3_GEMM_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<float>,
-                                        Kokkos::LayoutRight,
-                                        Kokkos::HIPSpace)
+                                        Kokkos::LayoutRight, Kokkos::HIPSpace)
 
 #endif
 }  // namespace Impl

--- a/cmake/KokkosKernels_config.h.in
+++ b/cmake/KokkosKernels_config.h.in
@@ -49,14 +49,14 @@
 #cmakedefine KOKKOSKERNELS_INST_EXECSPACE_CUDA
 #cmakedefine KOKKOSKERNELS_INST_MEMSPACE_CUDASPACE
 #cmakedefine KOKKOSKERNELS_INST_MEMSPACE_CUDAUVMSPACE
-/* Whether to build kernels for execution space Kokkos::Experimental::HIP */
+/* Whether to build kernels for execution space Kokkos::HIP */
 #cmakedefine KOKKOSKERNELS_INST_EXECSPACE_HIP
 #cmakedefine KOKKOSKERNELS_INST_MEMSPACE_HIPSPACE
 /* Whether to build kernels for execution space Kokkos::Experimental::SYCL */
 #cmakedefine KOKKOSKERNELS_INST_EXECSPACE_SYCL
 #cmakedefine KOKKOSKERNELS_INST_MEMSPACE_SYCLSPACE
 #cmakedefine KOKKOSKERNELS_INST_MEMSPACE_SYCLSHAREDSPACE
-/* Whether to build kernels for execution space Kokkos::Experimental::HIP */
+/* Whether to build kernels for execution space Kokkos::Experimental::OpenMPTarget */
 #cmakedefine KOKKOSKERNELS_INST_EXECSPACE_OPENMPTARGET
 #cmakedefine KOKKOSKERNELS_INST_MEMSPACE_OPENMPTARGETSPACE
 /* Whether to build kernels for execution space Kokkos::OpenMP */

--- a/cmake/kokkoskernels_eti_devices.cmake
+++ b/cmake/kokkoskernels_eti_devices.cmake
@@ -12,7 +12,7 @@ SET(EXEC_SPACES
   EXECSPACE_SERIAL
 )
 SET(EXECSPACE_CUDA_CPP_TYPE         Kokkos::Cuda)
-SET(EXECSPACE_HIP_CPP_TYPE          Kokkos::Experimental::HIP)
+SET(EXECSPACE_HIP_CPP_TYPE          Kokkos::HIP)
 SET(EXECSPACE_SYCL_CPP_TYPE         Kokkos::Experimental::SYCL)
 SET(EXECSPACE_OPENMPTARGET_CPP_TYPE Kokkos::Experimental::OpenMPTarget)
 SET(EXECSPACE_OPENMP_CPP_TYPE       Kokkos::OpenMP)
@@ -31,7 +31,7 @@ SET(MEM_SPACES
 )
 SET(MEMSPACE_CUDASPACE_CPP_TYPE         Kokkos::CudaSpace)
 SET(MEMSPACE_CUDAUVMSPACE_CPP_TYPE      Kokkos::CudaUVMSpace)
-SET(MEMSPACE_HIPSPACE_CPP_TYPE          Kokkos::Experimental::HIPSpace)
+SET(MEMSPACE_HIPSPACE_CPP_TYPE          Kokkos::HIPSpace)
 SET(MEMSPACE_SYCLSPACE_CPP_TYPE         Kokkos::Experimental::SYCLDeviceUSMSpace)
 SET(MEMSPACE_SYCLSHAREDSPACE_CPP_TYPE   Kokkos::Experimental::SYCLSharedUSMSpace)
 SET(MEMSPACE_OPENMPTARGETSPACE_CPP_TYPE Kokkos::Experimental::OpenMPTargetSpace)
@@ -77,13 +77,13 @@ IF(KOKKOS_ENABLE_HIP)
    INST_EXECSPACE_HIP
    ${KOKKOSKERNELS_INST_EXECSPACE_HIP_DEFAULT}
    BOOL
-   "Whether to pre instantiate kernels for the execution space Kokkos::Experimental::HIP. Disabling this when Kokkos_ENABLE_HIP is enabled may increase build times. Default: ON if Kokkos is HIP-enabled, OFF otherwise."
+   "Whether to pre instantiate kernels for the execution space Kokkos::HIP. Disabling this when Kokkos_ENABLE_HIP is enabled may increase build times. Default: ON if Kokkos is HIP-enabled, OFF otherwise."
    )
  KOKKOSKERNELS_ADD_OPTION(
    INST_MEMSPACE_HIPSPACE
    ${KOKKOSKERNELS_INST_EXECSPACE_HIP_DEFAULT}
    BOOL
-   "Whether to pre instantiate kernels for the memory space Kokkos::Experimental::HIPSpace.  Disabling this when Kokkos_ENABLE_HIP is enabled may increase build times. Default: ON if Kokkos is HIP-enabled, OFF otherwise."
+   "Whether to pre instantiate kernels for the memory space Kokkos::HIPSpace.  Disabling this when Kokkos_ENABLE_HIP is enabled may increase build times. Default: ON if Kokkos is HIP-enabled, OFF otherwise."
    )
 
   IF(KOKKOSKERNELS_INST_EXECSPACE_HIP AND KOKKOSKERNELS_INST_MEMSPACE_HIPSPACE)

--- a/common/src/KokkosKernels_ExecSpaceUtils.hpp
+++ b/common/src/KokkosKernels_ExecSpaceUtils.hpp
@@ -98,8 +98,7 @@ constexpr KOKKOS_INLINE_FUNCTION bool kk_is_gpu_exec_space<Kokkos::Cuda>() {
 
 #ifdef KOKKOS_ENABLE_HIP
 template <>
-constexpr KOKKOS_INLINE_FUNCTION bool
-kk_is_gpu_exec_space<Kokkos::HIP>() {
+constexpr KOKKOS_INLINE_FUNCTION bool kk_is_gpu_exec_space<Kokkos::HIP>() {
   return true;
 }
 #endif
@@ -208,17 +207,17 @@ inline void kk_get_free_total_memory<Kokkos::CudaHostPinnedSpace>(
 
 #ifdef KOKKOS_ENABLE_HIP
 template <>
-inline void kk_get_free_total_memory<Kokkos::HIPSpace>(
-    size_t& free_mem, size_t& total_mem, int n_streams) {
+inline void kk_get_free_total_memory<Kokkos::HIPSpace>(size_t& free_mem,
+                                                       size_t& total_mem,
+                                                       int n_streams) {
   KOKKOSKERNELS_IMPL_HIP_SAFE_CALL(hipMemGetInfo(&free_mem, &total_mem));
   free_mem /= n_streams;
   total_mem /= n_streams;
 }
 template <>
-inline void kk_get_free_total_memory<Kokkos::HIPSpace>(
-    size_t& free_mem, size_t& total_mem) {
-  kk_get_free_total_memory<Kokkos::HIPSpace>(free_mem, total_mem,
-                                                           1);
+inline void kk_get_free_total_memory<Kokkos::HIPSpace>(size_t& free_mem,
+                                                       size_t& total_mem) {
+  kk_get_free_total_memory<Kokkos::HIPSpace>(free_mem, total_mem, 1);
 }
 #endif
 

--- a/common/src/KokkosKernels_ExecSpaceUtils.hpp
+++ b/common/src/KokkosKernels_ExecSpaceUtils.hpp
@@ -66,7 +66,7 @@ KOKKOS_FORCEINLINE_FUNCTION ExecSpaceType kk_get_exec_space_type() {
 #endif
 
 #if defined(KOKKOS_ENABLE_HIP)
-  if (std::is_same<Kokkos::Experimental::HIP, ExecutionSpace>::value) {
+  if (std::is_same<Kokkos::HIP, ExecutionSpace>::value) {
     exec_space = Exec_HIP;
   }
 #endif
@@ -99,7 +99,7 @@ constexpr KOKKOS_INLINE_FUNCTION bool kk_is_gpu_exec_space<Kokkos::Cuda>() {
 #ifdef KOKKOS_ENABLE_HIP
 template <>
 constexpr KOKKOS_INLINE_FUNCTION bool
-kk_is_gpu_exec_space<Kokkos::Experimental::HIP>() {
+kk_is_gpu_exec_space<Kokkos::HIP>() {
   return true;
 }
 #endif
@@ -208,16 +208,16 @@ inline void kk_get_free_total_memory<Kokkos::CudaHostPinnedSpace>(
 
 #ifdef KOKKOS_ENABLE_HIP
 template <>
-inline void kk_get_free_total_memory<Kokkos::Experimental::HIPSpace>(
+inline void kk_get_free_total_memory<Kokkos::HIPSpace>(
     size_t& free_mem, size_t& total_mem, int n_streams) {
   KOKKOSKERNELS_IMPL_HIP_SAFE_CALL(hipMemGetInfo(&free_mem, &total_mem));
   free_mem /= n_streams;
   total_mem /= n_streams;
 }
 template <>
-inline void kk_get_free_total_memory<Kokkos::Experimental::HIPSpace>(
+inline void kk_get_free_total_memory<Kokkos::HIPSpace>(
     size_t& free_mem, size_t& total_mem) {
-  kk_get_free_total_memory<Kokkos::Experimental::HIPSpace>(free_mem, total_mem,
+  kk_get_free_total_memory<Kokkos::HIPSpace>(free_mem, total_mem,
                                                            1);
 }
 #endif
@@ -405,13 +405,13 @@ struct SpaceInstance<Kokkos::Cuda> {
 
 #ifdef KOKKOS_ENABLE_HIP
 template <>
-struct SpaceInstance<Kokkos::Experimental::HIP> {
-  static Kokkos::Experimental::HIP create() {
+struct SpaceInstance<Kokkos::HIP> {
+  static Kokkos::HIP create() {
     hipStream_t stream;
     KOKKOSKERNELS_IMPL_HIP_SAFE_CALL(hipStreamCreate(&stream));
-    return Kokkos::Experimental::HIP(stream);
+    return Kokkos::HIP(stream);
   }
-  static void destroy(Kokkos::Experimental::HIP& space) {
+  static void destroy(Kokkos::HIP& space) {
     hipStream_t stream = space.hip_stream();
     KOKKOSKERNELS_IMPL_HIP_SAFE_CALL(hipStreamDestroy(stream));
   }

--- a/common/src/KokkosKernels_default_types.hpp
+++ b/common/src/KokkosKernels_default_types.hpp
@@ -62,7 +62,7 @@ using default_scalar = double;
 #if defined(KOKKOS_ENABLE_CUDA)
 using default_device = Kokkos::Cuda;
 #elif defined(KOKKOS_ENABLE_HIP)
-using default_device    = Kokkos::Experimental::HIP;
+using default_device    = Kokkos::HIP;
 #elif defined(KOKKOS_ENABLE_OPENMPTARGET)
 using default_device    = Kokkos::Experimental::OpenMPTarget;
 #elif defined(KOKKOS_ENABLE_OPENMP)

--- a/perf_test/batched/dense/KokkosBatched_Test_BlockTridiagDirect.cpp
+++ b/perf_test/batched/dense/KokkosBatched_Test_BlockTridiagDirect.cpp
@@ -117,7 +117,7 @@ struct FactorizeModeAndAlgo<Kokkos::Cuda> : FactorizeModeAndAlgoDeviceImpl {};
 
 #if defined(KOKKOS_ENABLE_HIP)
 template <>
-struct FactorizeModeAndAlgo<Kokkos::Experimental::HIP>
+struct FactorizeModeAndAlgo<Kokkos::HIP>
     : FactorizeModeAndAlgoDeviceImpl {};
 #endif
 
@@ -156,7 +156,7 @@ struct SolveModeAndAlgo<Kokkos::Cuda> : SolveModeAndAlgoDeviceImpl {};
 
 #if defined(KOKKOS_ENABLE_HIP)
 template <>
-struct SolveModeAndAlgo<Kokkos::Experimental::HIP>
+struct SolveModeAndAlgo<Kokkos::HIP>
     : SolveModeAndAlgoDeviceImpl {};
 #endif
 

--- a/perf_test/batched/dense/KokkosBatched_Test_BlockTridiagDirect.cpp
+++ b/perf_test/batched/dense/KokkosBatched_Test_BlockTridiagDirect.cpp
@@ -117,8 +117,7 @@ struct FactorizeModeAndAlgo<Kokkos::Cuda> : FactorizeModeAndAlgoDeviceImpl {};
 
 #if defined(KOKKOS_ENABLE_HIP)
 template <>
-struct FactorizeModeAndAlgo<Kokkos::HIP>
-    : FactorizeModeAndAlgoDeviceImpl {};
+struct FactorizeModeAndAlgo<Kokkos::HIP> : FactorizeModeAndAlgoDeviceImpl {};
 #endif
 
 template <typename ExecutionSpace>
@@ -156,8 +155,7 @@ struct SolveModeAndAlgo<Kokkos::Cuda> : SolveModeAndAlgoDeviceImpl {};
 
 #if defined(KOKKOS_ENABLE_HIP)
 template <>
-struct SolveModeAndAlgo<Kokkos::HIP>
-    : SolveModeAndAlgoDeviceImpl {};
+struct SolveModeAndAlgo<Kokkos::HIP> : SolveModeAndAlgoDeviceImpl {};
 #endif
 
 template <class VT>

--- a/perf_test/batched/dense/KokkosBatched_Test_BlockTridiagJacobi.cpp
+++ b/perf_test/batched/dense/KokkosBatched_Test_BlockTridiagJacobi.cpp
@@ -166,8 +166,7 @@ struct SolveModeAndAlgo<Kokkos::Cuda> : SolveModeAndAlgoDeviceImpl {};
 
 #if defined(KOKKOS_ENABLE_HIP)
 template <>
-struct SolveModeAndAlgo<Kokkos::HIP>
-    : SolveModeAndAlgoDeviceImpl {};
+struct SolveModeAndAlgo<Kokkos::HIP> : SolveModeAndAlgoDeviceImpl {};
 #endif
 
 int main(int argc, char *argv[]) {

--- a/perf_test/batched/dense/KokkosBatched_Test_BlockTridiagJacobi.cpp
+++ b/perf_test/batched/dense/KokkosBatched_Test_BlockTridiagJacobi.cpp
@@ -127,7 +127,7 @@ struct InverseDiagonalsModeAndAlgo<Kokkos::Cuda>
 
 #if defined(KOKKOS_ENABLE_HIP)
 template <>
-struct InverseDiagonalsModeAndAlgo<Kokkos::Experimental::HIP>
+struct InverseDiagonalsModeAndAlgo<Kokkos::HIP>
     : InverseDiagonalsModeAndAlgoDeviceImpl {};
 #endif
 
@@ -166,7 +166,7 @@ struct SolveModeAndAlgo<Kokkos::Cuda> : SolveModeAndAlgoDeviceImpl {};
 
 #if defined(KOKKOS_ENABLE_HIP)
 template <>
-struct SolveModeAndAlgo<Kokkos::Experimental::HIP>
+struct SolveModeAndAlgo<Kokkos::HIP>
     : SolveModeAndAlgoDeviceImpl {};
 #endif
 

--- a/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test.cpp
@@ -210,7 +210,7 @@ int main(int argc, char** argv) {
   }
   if (useHIP) {
 #if defined(KOKKOS_ENABLE_HIP)
-    run<Kokkos::Experimental::HIP>(params.m, params.n, params.repeat);
+    run<Kokkos::HIP>(params.m, params.n, params.repeat);
 #else
     std::cout << "ERROR: HIP requested, but not available.\n";
     return 1;

--- a/perf_test/blas/blas1/KokkosBlas_dot_perf_test.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_perf_test.cpp
@@ -207,7 +207,7 @@ int main(int argc, char** argv) {
 
   if (useHIP) {
 #if defined(KOKKOS_ENABLE_HIP)
-    run<Kokkos::Experimental::HIP>(params.m, params.repeat);
+    run<Kokkos::HIP>(params.m, params.repeat);
 #else
     std::cout << "ERROR: HIP requested, but not available.\n";
     return 1;

--- a/perf_test/blas/blas2/KokkosBlas2_gemv_perf_test.cpp
+++ b/perf_test/blas/blas2/KokkosBlas2_gemv_perf_test.cpp
@@ -211,11 +211,9 @@ int main(int argc, char** argv) {
   if (useHIP) {
 #if defined(KOKKOS_ENABLE_HIP)
     if (params.layoutLeft)
-      run<Kokkos::HIP, Kokkos::LayoutLeft>(params.m, params.n,
-                                                         params.repeat);
+      run<Kokkos::HIP, Kokkos::LayoutLeft>(params.m, params.n, params.repeat);
     else
-      run<Kokkos::HIP, Kokkos::LayoutRight>(params.m, params.n,
-                                                          params.repeat);
+      run<Kokkos::HIP, Kokkos::LayoutRight>(params.m, params.n, params.repeat);
 #else
     std::cout << "ERROR: HIP requested, but not available.\n";
     return 1;

--- a/perf_test/blas/blas2/KokkosBlas2_gemv_perf_test.cpp
+++ b/perf_test/blas/blas2/KokkosBlas2_gemv_perf_test.cpp
@@ -211,10 +211,10 @@ int main(int argc, char** argv) {
   if (useHIP) {
 #if defined(KOKKOS_ENABLE_HIP)
     if (params.layoutLeft)
-      run<Kokkos::Experimental::HIP, Kokkos::LayoutLeft>(params.m, params.n,
+      run<Kokkos::HIP, Kokkos::LayoutLeft>(params.m, params.n,
                                                          params.repeat);
     else
-      run<Kokkos::Experimental::HIP, Kokkos::LayoutRight>(params.m, params.n,
+      run<Kokkos::HIP, Kokkos::LayoutRight>(params.m, params.n,
                                                           params.repeat);
 #else
     std::cout << "ERROR: HIP requested, but not available.\n";

--- a/perf_test/blas/blas2/KokkosBlas2_gemv_perf_test_benchmark.cpp
+++ b/perf_test/blas/blas2/KokkosBlas2_gemv_perf_test_benchmark.cpp
@@ -188,7 +188,7 @@ int main(int argc, char** argv) {
 
   if (params.use_hip) {
 #if defined(KOKKOS_ENABLE_HIP)
-    run<Kokkos::Experimental::HIP>(params);
+    run<Kokkos::HIP>(params);
 #else
     std::cout << "ERROR: HIP requested, but not available.\n";
     return 1;

--- a/perf_test/blas/blas3/KokkosBlas3_gemm_standalone_perf_test_benchmark.cpp
+++ b/perf_test/blas/blas3/KokkosBlas3_gemm_standalone_perf_test_benchmark.cpp
@@ -180,7 +180,7 @@ int main(int argc, char** argv) {
 
   if (params.use_hip) {
 #if defined(KOKKOS_ENABLE_HIP)
-    run<Kokkos::Experimental::HIP>(params);
+    run<Kokkos::HIP>(params);
 #else
     std::cout << "ERROR: HIP requested, but not available.\n";
     return 1;

--- a/perf_test/graph/KokkosGraph_color.cpp
+++ b/perf_test/graph/KokkosGraph_color.cpp
@@ -632,8 +632,8 @@ int main(int argc, char **argv) {
 #if defined(KOKKOS_ENABLE_HIP)
   if (params.use_hip) {
     KokkosKernels::Experiment::run_multi_mem_experiment<
-        size_type, idx, Kokkos::Experimental::HIP,
-        Kokkos::Experimental::HIPSpace, Kokkos::Experimental::HIPSpace>(params);
+        size_type, idx, Kokkos::HIP,
+        Kokkos::HIPSpace, Kokkos::HIPSpace>(params);
   }
 #endif
 

--- a/perf_test/graph/KokkosGraph_color.cpp
+++ b/perf_test/graph/KokkosGraph_color.cpp
@@ -632,8 +632,8 @@ int main(int argc, char **argv) {
 #if defined(KOKKOS_ENABLE_HIP)
   if (params.use_hip) {
     KokkosKernels::Experiment::run_multi_mem_experiment<
-        size_type, idx, Kokkos::HIP,
-        Kokkos::HIPSpace, Kokkos::HIPSpace>(params);
+        size_type, idx, Kokkos::HIP, Kokkos::HIPSpace, Kokkos::HIPSpace>(
+        params);
   }
 #endif
 

--- a/perf_test/graph/KokkosGraph_color_d2.cpp
+++ b/perf_test/graph/KokkosGraph_color_d2.cpp
@@ -708,8 +708,8 @@ int main(int argc, char* argv[]) {
   if (params.use_hip) {
     if (!use_multi_mem) {
       KokkosKernels::Experiment::experiment_driver<
-          kk_size_type, kk_lno_t, Kokkos::Experimental::HIP,
-          Kokkos::Experimental::HIPSpace>(params);
+          kk_size_type, kk_lno_t, Kokkos::HIP,
+          Kokkos::HIPSpace>(params);
     }
   }
 #endif

--- a/perf_test/graph/KokkosGraph_color_d2.cpp
+++ b/perf_test/graph/KokkosGraph_color_d2.cpp
@@ -708,8 +708,7 @@ int main(int argc, char* argv[]) {
   if (params.use_hip) {
     if (!use_multi_mem) {
       KokkosKernels::Experiment::experiment_driver<
-          kk_size_type, kk_lno_t, Kokkos::HIP,
-          Kokkos::HIPSpace>(params);
+          kk_size_type, kk_lno_t, Kokkos::HIP, Kokkos::HIPSpace>(params);
     }
   }
 #endif

--- a/perf_test/graph/KokkosGraph_mis_d2.cpp
+++ b/perf_test/graph/KokkosGraph_mis_d2.cpp
@@ -316,7 +316,7 @@ int main(int argc, char* argv[]) {
 
 #if defined(KOKKOS_ENABLE_HIP)
   if (params.use_hip) {
-    run_mis2<Kokkos::Experimental::HIP>(params);
+    run_mis2<Kokkos::HIP>(params);
     run = true;
   }
 #endif

--- a/perf_test/sparse/KokkosSparse_pcg.cpp
+++ b/perf_test/sparse/KokkosSparse_pcg.cpp
@@ -367,7 +367,7 @@ int main(int argc, char **argv) {
 #endif
 #if defined(KOKKOS_ENABLE_HIP)
     if (cmdline[CMD_USE_HIP])
-      run_pcg<Kokkos::Experimental::HIP>(cmdline, mtx_file);
+      run_pcg<Kokkos::HIP>(cmdline, mtx_file);
 #endif
   }
   Kokkos::finalize();

--- a/perf_test/sparse/KokkosSparse_pcg.cpp
+++ b/perf_test/sparse/KokkosSparse_pcg.cpp
@@ -366,8 +366,7 @@ int main(int argc, char **argv) {
     if (cmdline[CMD_USE_CUDA]) run_pcg<Kokkos::Cuda>(cmdline, mtx_file);
 #endif
 #if defined(KOKKOS_ENABLE_HIP)
-    if (cmdline[CMD_USE_HIP])
-      run_pcg<Kokkos::HIP>(cmdline, mtx_file);
+    if (cmdline[CMD_USE_HIP]) run_pcg<Kokkos::HIP>(cmdline, mtx_file);
 #endif
   }
   Kokkos::finalize();

--- a/sparse/impl/KokkosSparse_spmv_impl.hpp
+++ b/sparse/impl/KokkosSparse_spmv_impl.hpp
@@ -205,7 +205,7 @@ int64_t spmv_launch_parameters(int64_t numRows, int64_t nnz,
     max_vector_length = 32;
 #endif
 #ifdef KOKKOS_ENABLE_HIP
-  if (std::is_same<execution_space, Kokkos::Experimental::HIP>::value)
+  if (std::is_same<execution_space, Kokkos::HIP>::value)
     max_vector_length = 64;
 #endif
 
@@ -594,7 +594,7 @@ static void spmv_beta_transpose(const execution_space& exec,
     max_vector_length = 32;
 #endif
 #ifdef KOKKOS_ENABLE_HIP
-  if (std::is_same<execution_space, Kokkos::Experimental::HIP>::value)
+  if (std::is_same<execution_space, Kokkos::HIP>::value)
     max_vector_length = 64;
 #endif
   while ((vector_length * 2 * 3 <= NNZPerRow) &&

--- a/sparse/impl/KokkosSparse_spmv_impl.hpp
+++ b/sparse/impl/KokkosSparse_spmv_impl.hpp
@@ -205,8 +205,7 @@ int64_t spmv_launch_parameters(int64_t numRows, int64_t nnz,
     max_vector_length = 32;
 #endif
 #ifdef KOKKOS_ENABLE_HIP
-  if (std::is_same<execution_space, Kokkos::HIP>::value)
-    max_vector_length = 64;
+  if (std::is_same<execution_space, Kokkos::HIP>::value) max_vector_length = 64;
 #endif
 
   if (vector_length < 1) {
@@ -594,8 +593,7 @@ static void spmv_beta_transpose(const execution_space& exec,
     max_vector_length = 32;
 #endif
 #ifdef KOKKOS_ENABLE_HIP
-  if (std::is_same<execution_space, Kokkos::HIP>::value)
-    max_vector_length = 64;
+  if (std::is_same<execution_space, Kokkos::HIP>::value) max_vector_length = 64;
 #endif
   while ((vector_length * 2 * 3 <= NNZPerRow) &&
          (vector_length < max_vector_length))

--- a/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
+++ b/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
@@ -2734,8 +2734,8 @@ struct ReturnRangePolicyType<Kokkos::Cuda> {
 #endif
 #ifdef KOKKOS_ENABLE_HIP
 template <>
-struct ReturnRangePolicyType<Kokkos::Experimental::HIP> {
-  using PolicyType = Kokkos::RangePolicy<Kokkos::Experimental::HIP>;
+struct ReturnRangePolicyType<Kokkos::HIP> {
+  using PolicyType = Kokkos::RangePolicy<Kokkos::HIP>;
 
   static inline PolicyType get_policy(int nt, int ts) {
     return PolicyType(nt, ts);

--- a/sparse/src/KokkosSparse_CrsMatrix.hpp
+++ b/sparse/src/KokkosSparse_CrsMatrix.hpp
@@ -63,7 +63,7 @@ inline int RowsPerThread<Kokkos::Cuda>(const int /*NNZPerRow*/) {
 #endif
 #ifdef KOKKOS_ENABLE_HIP
 template <>
-inline int RowsPerThread<Kokkos::Experimental::HIP>(const int /*NNZPerRow*/) {
+inline int RowsPerThread<Kokkos::HIP>(const int /*NNZPerRow*/) {
   return 1;
 }
 #endif

--- a/sparse/src/KokkosSparse_spgemm_handle.hpp
+++ b/sparse/src/KokkosSparse_spgemm_handle.hpp
@@ -661,7 +661,7 @@ class SPGEMMHandle {
 #endif
 
 #if defined(KOKKOS_ENABLE_HIP)
-    if (std::is_same<Kokkos::Experimental::HIP, ExecutionSpace>::value) {
+    if (std::is_same<Kokkos::HIP, ExecutionSpace>::value) {
       this->algorithm_type = SPGEMM_KK;
 #ifdef VERBOSE
       std::cout << "HIP Execution Space, Default Algorithm: SPGEMM_KK"

--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -203,7 +203,7 @@ void spmv(const ExecutionSpace& space,
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE
   if (std::is_same<typename AMatrix_Internal::memory_space,
-                   Kokkos::Experimental::HIPSpace>::value) {
+                   Kokkos::HIPSpace>::value) {
     useFallback = useFallback || (mode[0] != NoTranspose[0]);
   }
 #endif

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
@@ -183,25 +183,22 @@ KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int64_t,
 
 #if defined(KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE)
 
-#define KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ROCSPARSE(SCALAR, LAYOUT)            \
-  template <>                                                                 \
-  struct spmv_tpl_spec_avail<                                                 \
-      Kokkos::HIP,                                                            \
-      KokkosSparse::CrsMatrix<const SCALAR, const rocsparse_int,              \
-                              Kokkos::Device<Kokkos::HIP,       \
-                                             Kokkos::HIPSpace>, \
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,        \
-                              const rocsparse_int>,                           \
-      Kokkos::View<                                                           \
-          const SCALAR*, LAYOUT,                                              \
-          Kokkos::Device<Kokkos::HIP,                           \
-                         Kokkos::HIPSpace>,                     \
-          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,    \
-      Kokkos::View<SCALAR*, LAYOUT,                                           \
-                   Kokkos::Device<Kokkos::HIP,                  \
-                                  Kokkos::HIPSpace>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                \
-    enum : bool { value = true };                                             \
+#define KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ROCSPARSE(SCALAR, LAYOUT)           \
+  template <>                                                                \
+  struct spmv_tpl_spec_avail<                                                \
+      Kokkos::HIP,                                                           \
+      KokkosSparse::CrsMatrix<const SCALAR, const rocsparse_int,             \
+                              Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>, \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>,       \
+                              const rocsparse_int>,                          \
+      Kokkos::View<                                                          \
+          const SCALAR*, LAYOUT,                                             \
+          Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,                     \
+          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,   \
+      Kokkos::View<SCALAR*, LAYOUT,                                          \
+                   Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {               \
+    enum : bool { value = true };                                            \
   };
 
 KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ROCSPARSE(double, Kokkos::LayoutLeft)

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
@@ -188,18 +188,18 @@ KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int64_t,
   struct spmv_tpl_spec_avail<                                                 \
       Kokkos::HIP,                                                            \
       KokkosSparse::CrsMatrix<const SCALAR, const rocsparse_int,              \
-                              Kokkos::Device<Kokkos::Experimental::HIP,       \
-                                             Kokkos::Experimental::HIPSpace>, \
+                              Kokkos::Device<Kokkos::HIP,       \
+                                             Kokkos::HIPSpace>, \
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>,        \
                               const rocsparse_int>,                           \
       Kokkos::View<                                                           \
           const SCALAR*, LAYOUT,                                              \
-          Kokkos::Device<Kokkos::Experimental::HIP,                           \
-                         Kokkos::Experimental::HIPSpace>,                     \
+          Kokkos::Device<Kokkos::HIP,                           \
+                         Kokkos::HIPSpace>,                     \
           Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,    \
       Kokkos::View<SCALAR*, LAYOUT,                                           \
-                   Kokkos::Device<Kokkos::Experimental::HIP,                  \
-                                  Kokkos::Experimental::HIPSpace>,            \
+                   Kokkos::Device<Kokkos::HIP,                  \
+                                  Kokkos::HIPSpace>,            \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                \
     enum : bool { value = true };                                             \
   };

--- a/test_common/Test_HIP.hpp
+++ b/test_common/Test_HIP.hpp
@@ -32,6 +32,6 @@ class hip : public ::testing::Test {
 };
 
 #define TestCategory hip
-#define TestDevice Kokkos::Experimental::HIP
+#define TestDevice Kokkos::HIP
 
 #endif  // TEST_HIP_HPP


### PR DESCRIPTION
So it's a bit the PR of shame since we should really have done that when Kokkos Core 4.0.0 came out in Jan/Feb this year...
Anyway, it really does not change code that much just reflects that fact that HIP was moved out of Experimental!
I almost want to mark this as `BlockPromotion` but that's not really the case?