### PR TITLE
Remove /etc/profile.d/modules.sh from cm_test_all_sandia for blake

### DIFF
--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -731,7 +731,6 @@ elif [ "$MACHINE" = "vega90a_caraway" ]; then
     ARCH_FLAG="--arch=VEGA90A"
   fi
 elif [ "$MACHINE" = "blake" ]; then
-  MODULE_ENVIRONMENT="source /etc/profile.d/modules.sh"
   eval "$MODULE_ENVIRONMENT"
   SKIP_HWLOC=True
   export SLURM_TASKS_PER_NODE=32


### PR DESCRIPTION
This path doesn't exist on blake anymore, removing it so the PR tests currently running on Solo can be moved over