### PR TITLE
iostream clean-up in benchmarks

### DIFF
--- a/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test_benchmark.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_mv_perf_test_benchmark.cpp
@@ -42,6 +42,8 @@
 //@HEADER
 */
 
+#include <iostream>
+
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Random.hpp>
 

--- a/perf_test/blas/blas1/KokkosBlas_dot_perf_test_benchmark.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_perf_test_benchmark.cpp
@@ -42,6 +42,8 @@
 //@HEADER
 */
 
+#include <iostream>
+
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Random.hpp>
 


### PR DESCRIPTION
Still cleaning up a few cases of missing iostream, the perf tests and benchmarks do not build in our CI and nightly typically so we have not caught these yet...