### PR TITLE
KokkosBlas1_axpby: include <iostream> for debug builds

### DIFF
--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -17,6 +17,10 @@
 #ifndef KOKKOSBLAS1_AXPBY_HPP_
 #define KOKKOSBLAS1_AXPBY_HPP_
 
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#include <iostream>
+#endif
+
 #include <KokkosBlas1_axpby_spec.hpp>
 #include <KokkosBlas_serial_axpy.hpp>
 #include <KokkosKernels_helpers.hpp>


### PR DESCRIPTION
Resolve compilation errors in debug mode:
"error: no member named 'cout' in namespace 'std';"