### PR TITLE
Add option to use KokkosKernels:: as target namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,14 @@ KOKKOSKERNELS_PACKAGE()
 
 IF (NOT KOKKOSKERNELS_HAS_TRILINOS)
   SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
+  # TODO The KOKKOSKERNELS_ENABLE_TARGET_NAMESPACE_CHANGE will be defaulted to ON during the 4.3 release cycle and
+  #   removed after release 4.3 after the Kokkos:: namespace is changed to KokkosKernels::
+  KOKKOSKERNELS_ADD_OPTION(
+         "ENABLE_TARGET_NAMESPACE_CHANGE"
+          OFF
+          BOOL
+          "Whether to build KokkosKernels as a TPL - this is a TEMPORARY option added for a deprecation cycle to configure with the KokkosKernels:: namespace. Default: OFF"
+  )
   KOKKOSKERNELS_ADD_OPTION(
           "ENABLE_EXAMPLES"
           OFF

--- a/cmake/KokkosKernelsConfig.cmake.in
+++ b/cmake/KokkosKernelsConfig.cmake.in
@@ -11,3 +11,12 @@ find_dependency(Kokkos HINTS @Kokkos_DIR@)
 
 INCLUDE("${KokkosKernels_CMAKE_DIR}/KokkosKernelsTargets.cmake")
 
+IF(NOT TARGET KokkosKernels::all_libs)
+  # CMake Error at <prefix>/lib/cmake/Kokkos/KokkosConfigCommon.cmake:10 (ADD_LIBRARY):
+  #   ADD_LIBRARY cannot create ALIAS target "Kokkos::all_libs" because target
+  #   "KokkosKernels::kokkoskernels" is imported but not globally visible.
+  IF(CMAKE_VERSION VERSION_LESS "3.18")
+    SET_TARGET_PROPERTIES(KokkosKernels::kokkoskernels PROPERTIES IMPORTED_GLOBAL ON)
+  ENDIF()
+  ADD_LIBRARY(KokkosKernels::all_libs ALIAS KokkosKernels::kokkoskernels)
+ENDIF()

--- a/cmake/kokkoskernels_tribits.cmake
+++ b/cmake/kokkoskernels_tribits.cmake
@@ -30,9 +30,23 @@ MACRO(KOKKOSKERNELS_PACKAGE_POSTPROCESS)
       "${KokkosKernels_BINARY_DIR}/KokkosKernelsConfigVersion.cmake"
       DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/KokkosKernels)
 
-    INSTALL(EXPORT KokkosKernelsTargets
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/KokkosKernels
-            NAMESPACE Kokkos::)
+    # TODO The KOKKOSKERNELS_ENABLE_TARGET_NAMESPACE_CHANGE will be removed after release 4.3 after the
+    #   Kokkos:: namespace is changed to KokkosKernels::
+    IF (KOKKOSKERNELS_ENABLE_TARGET_NAMESPACE_CHANGE)
+      INSTALL(EXPORT KokkosKernelsTargets
+              DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/KokkosKernels
+              NAMESPACE KokkosKernels::)
+    ELSE()
+      IF(CMAKE_VERSION VERSION_GREATER "3.16")
+        # DEPRECATION was new in CMake version 3.17
+        MESSAGE(DEPRECATION "Use of the the Kokkos:: namespace for the Kokkos Kernels target is deprecated and will be changed to KokkosKernels:: in the 4.3 release cycle")
+      ELSE()
+        MESSAGE(WARNING "Use of the the Kokkos:: namespace for the Kokkos Kernels target is deprecated and will be changed to KokkosKernels:: in the 4.3 release cycle")
+      ENDIF()
+      INSTALL(EXPORT KokkosKernelsTargets
+              DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/KokkosKernels
+              NAMESPACE Kokkos::)
+    ENDIF()
   ENDIF()
 ENDMACRO(KOKKOSKERNELS_PACKAGE_POSTPROCESS)
 


### PR DESCRIPTION
* Add new cmake configuration option KokkosKernels_ENABLE_TARGET_NAMESPACE_CHANGE, added to use KokkosKernels:: as target namespace
* Deprecate the Kokkos:: target namespace in favor of KokkosKernels::
* Add KokkosKernels::all_libs target to the KokkosKerelesConfig.cmake file
* Intent of these changes is to allow for building Trilinos with KokkosKernels as an external TPL