### PR TITLE
hide native merge-path SpMV behind "native-merge"

### DIFF
--- a/sparse/impl/KokkosSparse_spmv_impl.hpp
+++ b/sparse/impl/KokkosSparse_spmv_impl.hpp
@@ -31,7 +31,7 @@
 namespace KokkosSparse {
 namespace Impl {
 
-constexpr const char* KOKKOSSPARSE_ALG_MERGE = "merge";
+constexpr const char* KOKKOSSPARSE_ALG_NATIVE_MERGE = "native-merge";
 
 // This TransposeFunctor is functional, but not necessarily performant.
 template <class execution_space, class AMatrix, class XVector, class YVector,
@@ -632,7 +632,7 @@ static void spmv_beta(const execution_space& exec,
                       typename YVector::const_value_type& beta,
                       const YVector& y) {
   if (mode[0] == NoTranspose[0]) {
-    if (controls.getParameter("algorithm") == KOKKOSSPARSE_ALG_MERGE) {
+    if (controls.getParameter("algorithm") == KOKKOSSPARSE_ALG_NATIVE_MERGE) {
       SpmvMergeHierarchical<execution_space, AMatrix, XVector, YVector>::spmv(
           exec, mode, alpha, A, x, beta, y);
     } else {
@@ -640,7 +640,7 @@ static void spmv_beta(const execution_space& exec,
                              false>(exec, controls, alpha, A, x, beta, y);
     }
   } else if (mode[0] == Conjugate[0]) {
-    if (controls.getParameter("algorithm") == KOKKOSSPARSE_ALG_MERGE) {
+    if (controls.getParameter("algorithm") == KOKKOSSPARSE_ALG_NATIVE_MERGE) {
       SpmvMergeHierarchical<execution_space, AMatrix, XVector, YVector>::spmv(
           exec, mode, alpha, A, x, beta, y);
     } else {

--- a/sparse/unit_test/Test_Sparse_spmv.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv.hpp
@@ -549,6 +549,12 @@ void test_spmv_algorithms(lno_t numRows, size_type nnz, lno_t bandwidth,
     test_spmv<scalar_t, lno_t, size_type, Device>(
         controls, numRows, nnz, bandwidth, row_size_variance, heavy);
   }
+  {
+    KokkosKernels::Experimental::Controls controls;
+    controls.setParameter("algorithm", "native-merge");
+    test_spmv<scalar_t, lno_t, size_type, Device>(
+        controls, numRows, nnz, bandwidth, row_size_variance, heavy);
+  }
 }
 
 template <typename scalar_t, typename lno_t, typename size_type,


### PR DESCRIPTION
Fix for https://github.com/kokkos/kokkos-kernels/issues/2010

Tpetra will set `controls.setParameter("algorithm", "merge")` when it detects a row-length imbalance. Before https://github.com/kokkos/kokkos-kernels/pull/1911, this would change the cuSPARSE implementation when TPLS were enabled and the datatypes were supported by cuSPARSE. After, it would additionally cause native code to use the new merge-path SpMV, which may have a small bug somewhere.

Rather than overload the meaning of "merge", let's just choose a different name.