### PR TITLE
Quick fix on 'lapack' subdirectory, for night compilation with Trilinos

### DIFF
--- a/lapack/unit_test/backends/Test_OpenMPTarget_Lapack.cpp
+++ b/lapack/unit_test/backends/Test_OpenMPTarget_Lapack.cpp
@@ -1,0 +1,22 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+#ifndef TEST_OPENMPTARGET_LAPACK_CPP
+#define TEST_OPENMPTARGET_LAPACK_CPP
+
+#include "Test_OpenMPTarget.hpp"
+#include "Test_Lapack.hpp"
+
+#endif  // TEST_OPENMPTARGET_LAPACK_CPP

--- a/lapack/unit_test/backends/Test_SYCL_Lapack.cpp
+++ b/lapack/unit_test/backends/Test_SYCL_Lapack.cpp
@@ -1,0 +1,22 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+#ifndef TEST_SYCL_LAPACK_CPP
+#define TEST_SYCL_LAPACK_CPP
+
+#include <Test_SYCL.hpp>
+#include <Test_Lapack.hpp>
+
+#endif  // TEST_SYCL_LAPACK_CPP


### PR DESCRIPTION
Missing file when compilation is done with SYCL option.