### PR TITLE
Add tpl onemkl sycl guard dev

### DIFF
--- a/blas/src/KokkosBlas2_gemv.hpp
+++ b/blas/src/KokkosBlas2_gemv.hpp
@@ -162,10 +162,12 @@ void gemv(const ExecutionSpace& space, const char trans[],
 #endif
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
 #ifdef KOKKOS_ENABLE_SYCL
+#ifdef KOKKOSKERNELS_ENABLE_TPL_ONEMKL_SYCL_COMPONENTS
   // oneMKL supports both row-major and column-major of A
   useFallback =
       useFallback || !std::is_same_v<typename AViewType::memory_space,
                                      Kokkos::Experimental::SYCLDeviceUSMSpace>;
+#endif
 #endif
 #endif
 

--- a/blas/tpls/KokkosBlas1_nrm2_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_nrm2_tpl_spec_avail.hpp
@@ -89,8 +89,10 @@ KOKKOSBLAS1_NRM2_TPL_SPEC_AVAIL(Kokkos::LayoutLeft, Kokkos::HIP,
 #endif
 
 #if defined(KOKKOSKERNELS_ENABLE_TPL_MKL) && defined(KOKKOS_ENABLE_SYCL)
+#ifdef KOKKOSKERNELS_ENABLE_TPL_ONEMKL_SYCL_COMPONENTS
 KOKKOSBLAS1_NRM2_TPL_SPEC_AVAIL(Kokkos::LayoutLeft, Kokkos::Experimental::SYCL,
                                 Kokkos::Experimental::SYCLDeviceUSMSpace)
+#endif
 #endif
 
 }  // namespace Impl

--- a/blas/tpls/KokkosBlas1_nrm2_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_nrm2_tpl_spec_decl.hpp
@@ -365,6 +365,7 @@ KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ROCBLAS_EXT(false)
 #endif
 
 #if defined(KOKKOSKERNELS_ENABLE_TPL_MKL) && defined(KOKKOS_ENABLE_SYCL)
+#ifdef KOKKOSKERNELS_ENABLE_TPL_ONEMKL_SYCL_COMPONENTS
 #include <mkl.h>
 #include <oneapi/mkl/blas.hpp>
 #include <KokkosBlas_tpl_spec.hpp>
@@ -437,6 +438,7 @@ KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL_EXT(false)
 }  // namespace Impl
 }  // namespace KokkosBlas
 
+#endif
 #endif
 
 #endif

--- a/blas/tpls/KokkosBlas2_gemv_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas2_gemv_tpl_spec_avail.hpp
@@ -163,6 +163,8 @@ KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<float>,
 
 #ifdef KOKKOS_ENABLE_SYCL
 
+#ifdef KOKKOSKERNELS_ENABLE_TPL_ONEMKL_SYCL_COMPONENTS
+
 #define KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ONEMKL(SCALAR, LAYOUT)               \
   template <class ExecSpace>                                                 \
   struct gemv_tpl_spec_avail<                                                \
@@ -195,6 +197,8 @@ KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ONEMKL(Kokkos::complex<double>,
                                        Kokkos::LayoutRight)
 KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ONEMKL(Kokkos::complex<float>,
                                        Kokkos::LayoutRight)
+
+#endif
 
 #endif
 

--- a/blas/tpls/KokkosBlas2_gemv_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas2_gemv_tpl_spec_decl.hpp
@@ -768,6 +768,7 @@ KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutRight, Kokkos::HIPSpace, false)
 
 // ONEMKL
 #if defined(KOKKOSKERNELS_ENABLE_TPL_MKL) && defined(KOKKOS_ENABLE_SYCL)
+#ifdef KOKKOSKERNELS_ENABLE_TPL_ONEMKL_SYCL_COMPONENTS
 #include <mkl.h>
 #include <oneapi/mkl/blas.hpp>
 #include <KokkosBlas_tpl_spec.hpp>
@@ -867,6 +868,7 @@ KOKKOSBLAS2_GEMV_ONEMKL(Kokkos::complex<double>, Kokkos::LayoutRight,
                         Kokkos::Experimental::SYCLDeviceUSMSpace, true)
 }  // namespace Impl
 }  // namespace KokkosBlas
+#endif
 #endif
 
 #endif

--- a/cmake/KokkosKernels_config.h.in
+++ b/cmake/KokkosKernels_config.h.in
@@ -154,6 +154,12 @@
 #endif
 
 /*
+ * Temp option to enable/disable tpl specializations of some routines
+ * with onemkl when sycl backend is enabled
+ */
+#cmakedefine KOKKOSKERNELS_ENABLE_TPL_ONEMKL_SYCL_COMPONENTS
+
+/*
  * "Optimization level" for computational kernels in this subpackage.
  * The higher the level, the more code variants get generated, and
  * thus the longer the compile times.  However, more code variants

--- a/cmake/kokkoskernels_eti_devices.cmake
+++ b/cmake/kokkoskernels_eti_devices.cmake
@@ -120,6 +120,21 @@ IF(KOKKOS_ENABLE_SYCL)
   IF( Trilinos_ENABLE_COMPLEX_DOUBLE AND ((NOT DEFINED CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS) OR (NOT CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS)) )
     MESSAGE( WARNING "The CMake option CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS is either undefined or OFF.  Please set CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS:BOOL=ON when building with SYCL and complex double	 enabled.")
   ENDIF()
+
+  # Temporary option for Trilinos to enable OneMKL with SYCL backend
+  # Added as part of issue https://github.com/kokkos/kokkos-kernels/issues/2023
+  IF (KOKKOSKERNELS_HAS_TRILINOS)
+    SET(KOKKOSKERNELS_ENABLE_TPL_ONEMKL_SYCL_COMPONENTS_DEFAULT OFF)
+  ELSE()
+    SET(KOKKOSKERNELS_ENABLE_TPL_ONEMKL_SYCL_COMPONENTS_DEFAULT ON)
+  ENDIF()
+
+ KOKKOSKERNELS_ADD_OPTION(
+   ENABLE_TPL_ONEMKL_SYCL_COMPONENTS
+   ${KOKKOSKERNELS_ENABLE_TPL_ONEMKL_SYCL_COMPONENTS_DEFAULT}
+   BOOL
+   "Whether to enable OneMKL TPL options for gemv and nrm2 with SYCL backend. Default: OFF with Trilinos if SYCL backend is enabled, ON otherwise."
+   )
 ENDIF()
 
 IF(KOKKOS_ENABLE_OPENMPTARGET)


### PR DESCRIPTION
    nrm2: guard tpl layer with KOKKOSKERNELS_ENABLE_TPL_ONEMKL_SYCL_COMPONENTS

    cmake: add option KOKKOSKERNELS_ENABLE_TPL_ONEMKL_SYCL_COMPONENTS
    
    Default ON for standalone Kokkos Kernels
    Option added for usages requiring updates for oneMKL usage