### PR TITLE
Axpby bug fix (issue # 2015)

### DIFF
--- a/blas/impl/KokkosBlas1_axpby_impl.hpp
+++ b/blas/impl/KokkosBlas1_axpby_impl.hpp
@@ -123,10 +123,11 @@ struct Axpby_Functor {
       } else if constexpr (scalar_y == 1) {
         // Nothing to do: m_y(i) = m_y(i);
       } else if constexpr (scalar_y == 2) {
-        if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
-          m_y(i) = Kokkos::ArithTraits<typename BV::non_const_value_type>::zero();
-        }
-        else {
+        if (m_b(0) ==
+            Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+          m_y(i) =
+              Kokkos::ArithTraits<typename YV::non_const_value_type>::zero();
+        } else {
           m_y(i) = m_b(0) * m_y(i);
         }
       }
@@ -142,10 +143,10 @@ struct Axpby_Functor {
       } else if constexpr (scalar_y == 1) {
         m_y(i) = -m_x(i) + m_y(i);
       } else if constexpr (scalar_y == 2) {
-        if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+        if (m_b(0) ==
+            Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
           m_y(i) = -m_x(i);
-        }
-        else {
+        } else {
           m_y(i) = -m_x(i) + m_b(0) * m_y(i);
         }
       }
@@ -161,10 +162,10 @@ struct Axpby_Functor {
       } else if constexpr (scalar_y == 1) {
         m_y(i) = m_x(i) + m_y(i);
       } else if constexpr (scalar_y == 2) {
-        if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+        if (m_b(0) ==
+            Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
           m_y(i) = m_x(i);
-        }
-        else {
+        } else {
           m_y(i) = m_x(i) + m_b(0) * m_y(i);
         }
       }
@@ -180,10 +181,10 @@ struct Axpby_Functor {
       } else if constexpr (scalar_y == 1) {
         m_y(i) = m_a(0) * m_x(i) + m_y(i);
       } else if constexpr (scalar_y == 2) {
-        if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+        if (m_b(0) ==
+            Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
           m_y(i) = m_a(0) * m_x(i);
-        }
-        else {
+        } else {
           m_y(i) = m_a(0) * m_x(i) + m_b(0) * m_y(i);
         }
       }

--- a/blas/impl/KokkosBlas1_axpby_impl.hpp
+++ b/blas/impl/KokkosBlas1_axpby_impl.hpp
@@ -123,7 +123,12 @@ struct Axpby_Functor {
       } else if constexpr (scalar_y == 1) {
         // Nothing to do: m_y(i) = m_y(i);
       } else if constexpr (scalar_y == 2) {
-        m_y(i) = m_b(0) * m_y(i);
+        if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+          m_y(i) = Kokkos::ArithTraits<typename BV::non_const_value_type>::zero();
+        }
+        else {
+          m_y(i) = m_b(0) * m_y(i);
+        }
       }
     }
     // **************************************************************
@@ -137,7 +142,12 @@ struct Axpby_Functor {
       } else if constexpr (scalar_y == 1) {
         m_y(i) = -m_x(i) + m_y(i);
       } else if constexpr (scalar_y == 2) {
-        m_y(i) = -m_x(i) + m_b(0) * m_y(i);
+        if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+          m_y(i) = -m_x(i);
+        }
+        else {
+          m_y(i) = -m_x(i) + m_b(0) * m_y(i);
+        }
       }
     }
     // **************************************************************
@@ -151,7 +161,12 @@ struct Axpby_Functor {
       } else if constexpr (scalar_y == 1) {
         m_y(i) = m_x(i) + m_y(i);
       } else if constexpr (scalar_y == 2) {
-        m_y(i) = m_x(i) + m_b(0) * m_y(i);
+        if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+          m_y(i) = m_x(i);
+        }
+        else {
+          m_y(i) = m_x(i) + m_b(0) * m_y(i);
+        }
       }
     }
     // **************************************************************
@@ -165,7 +180,12 @@ struct Axpby_Functor {
       } else if constexpr (scalar_y == 1) {
         m_y(i) = m_a(0) * m_x(i) + m_y(i);
       } else if constexpr (scalar_y == 2) {
-        m_y(i) = m_a(0) * m_x(i) + m_b(0) * m_y(i);
+        if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+          m_y(i) = m_a(0) * m_x(i);
+        }
+        else {
+          m_y(i) = m_a(0) * m_x(i) + m_b(0) * m_y(i);
+        }
       }
     }
   }

--- a/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
+++ b/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
@@ -123,19 +123,25 @@ struct Axpby_MV_Functor {
         // Nothing to do: Y(i,j) := Y(i,j)
       } else if constexpr (scalar_y == 2) {
         if (m_b.extent(0) == 1) {
+          if (m_b(0) ==
+              Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
 #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
 #pragma ivdep
 #endif
 #ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
 #pragma vector always
 #endif
-          if (m_b(0) ==
-              Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
             for (size_type k = 0; k < numCols; ++k) {
               m_y(i, k) = Kokkos::ArithTraits<
                   typename YMV::non_const_value_type>::zero();
             }
           } else {
+#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
+#pragma vector always
+#endif
             for (size_type k = 0; k < numCols; ++k) {
               m_y(i, k) = m_b(0) * m_y(i, k);
             }
@@ -189,18 +195,24 @@ struct Axpby_MV_Functor {
         }
       } else if constexpr (scalar_y == 2) {
         if (m_b.extent(0) == 1) {
+          if (m_b(0) ==
+              Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
 #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
 #pragma ivdep
 #endif
 #ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
 #pragma vector always
 #endif
-          if (m_b(0) ==
-              Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
             for (size_type k = 0; k < numCols; ++k) {
               m_y(i, k) = -m_x(i, k);
             }
           } else {
+#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
+#pragma vector always
+#endif
             for (size_type k = 0; k < numCols; ++k) {
               m_y(i, k) = -m_x(i, k) + m_b(0) * m_y(i, k);
             }
@@ -254,18 +266,24 @@ struct Axpby_MV_Functor {
         }
       } else if constexpr (scalar_y == 2) {
         if (m_b.extent(0) == 1) {
+          if (m_b(0) ==
+              Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
 #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
 #pragma ivdep
 #endif
 #ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
 #pragma vector always
 #endif
-          if (m_b(0) ==
-              Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
             for (size_type k = 0; k < numCols; ++k) {
               m_y(i, k) = m_x(i, k);
             }
           } else {
+#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
+#pragma vector always
+#endif
             for (size_type k = 0; k < numCols; ++k) {
               m_y(i, k) = m_x(i, k) + m_b(0) * m_y(i, k);
             }
@@ -356,18 +374,24 @@ struct Axpby_MV_Functor {
       } else if constexpr (scalar_y == 2) {
         if (m_a.extent(0) == 1) {
           if (m_b.extent(0) == 1) {
+            if (m_b(0) == Kokkos::ArithTraits<
+                              typename BV::non_const_value_type>::zero()) {
 #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
 #pragma ivdep
 #endif
 #ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
 #pragma vector always
 #endif
-            if (m_b(0) == Kokkos::ArithTraits<
-                              typename BV::non_const_value_type>::zero()) {
               for (size_type k = 0; k < numCols; ++k) {
                 m_y(i, k) = m_a(0) * m_x(i, k);
               }
             } else {
+#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
+#pragma vector always
+#endif
               for (size_type k = 0; k < numCols; ++k) {
                 m_y(i, k) = m_a(0) * m_x(i, k) + m_b(0) * m_y(i, k);
               }
@@ -385,18 +409,24 @@ struct Axpby_MV_Functor {
           }
         } else {
           if (m_b.extent(0) == 1) {
+            if (m_b(0) == Kokkos::ArithTraits<
+                              typename BV::non_const_value_type>::zero()) {
 #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
 #pragma ivdep
 #endif
 #ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
 #pragma vector always
 #endif
-            if (m_b(0) == Kokkos::ArithTraits<
-                              typename BV::non_const_value_type>::zero()) {
               for (size_type k = 0; k < numCols; ++k) {
                 m_y(i, k) = m_a(k) * m_x(i, k);
               }
             } else {
+#ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
+#pragma ivdep
+#endif
+#ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
+#pragma vector always
+#endif
               for (size_type k = 0; k < numCols; ++k) {
                 m_y(i, k) = m_a(k) * m_x(i, k) + m_b(0) * m_y(i, k);
               }
@@ -751,16 +781,19 @@ struct Axpby_MV_Unroll_Functor {
         // Nothing to do: Y(i,j) := Y(i,j)
       } else if constexpr (scalar_y == 2) {
         if (m_b.extent(0) == 1) {
+          if (m_b(0) ==
+              Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
 #pragma unroll
 #endif
-          if (m_b(0) ==
-              Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
             for (int k = 0; k < UNROLL; ++k) {
               m_y(i, k) = Kokkos::ArithTraits<
                   typename YMV::non_const_value_type>::zero();
             }
           } else {
+#ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
+#pragma unroll
+#endif
             for (int k = 0; k < UNROLL; ++k) {
               m_y(i, k) = m_b(0) * m_y(i, k);
             }
@@ -802,15 +835,18 @@ struct Axpby_MV_Unroll_Functor {
         }
       } else if constexpr (scalar_y == 2) {
         if (m_b.extent(0) == 1) {
+          if (m_b(0) ==
+              Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
 #pragma unroll
 #endif
-          if (m_b(0) ==
-              Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
             for (int k = 0; k < UNROLL; ++k) {
               m_y(i, k) = -m_x(i, k);
             }
           } else {
+#ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
+#pragma unroll
+#endif
             for (int k = 0; k < UNROLL; ++k) {
               m_y(i, k) = -m_x(i, k) + m_b(0) * m_y(i, k);
             }
@@ -852,15 +888,18 @@ struct Axpby_MV_Unroll_Functor {
         }
       } else if constexpr (scalar_y == 2) {
         if (m_b.extent(0) == 1) {
+          if (m_b(0) ==
+              Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
 #pragma unroll
 #endif
-          if (m_b(0) ==
-              Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
             for (int k = 0; k < UNROLL; ++k) {
               m_y(i, k) = m_x(i, k);
             }
           } else {
+#ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
+#pragma unroll
+#endif
             for (int k = 0; k < UNROLL; ++k) {
               m_y(i, k) = m_x(i, k) + m_b(0) * m_y(i, k);
             }
@@ -930,15 +969,18 @@ struct Axpby_MV_Unroll_Functor {
       } else if constexpr (scalar_y == 2) {
         if (m_a.extent(0) == 1) {
           if (m_b.extent(0) == 1) {
+            if (m_b(0) == Kokkos::ArithTraits<
+                              typename BV::non_const_value_type>::zero()) {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
 #pragma unroll
 #endif
-            if (m_b(0) == Kokkos::ArithTraits<
-                              typename BV::non_const_value_type>::zero()) {
               for (int k = 0; k < UNROLL; ++k) {
                 m_y(i, k) = m_a(0) * m_x(i, k);
               }
             } else {
+#ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
+#pragma unroll
+#endif
               for (int k = 0; k < UNROLL; ++k) {
                 m_y(i, k) = m_a(0) * m_x(i, k) + m_b(0) * m_y(i, k);
               }
@@ -953,15 +995,18 @@ struct Axpby_MV_Unroll_Functor {
           }
         } else {
           if (m_b.extent(0) == 1) {
+            if (m_b(0) == Kokkos::ArithTraits<
+                              typename BV::non_const_value_type>::zero()) {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
 #pragma unroll
 #endif
-            if (m_b(0) == Kokkos::ArithTraits<
-                              typename BV::non_const_value_type>::zero()) {
               for (int k = 0; k < UNROLL; ++k) {
                 m_y(i, k) = m_a(k) * m_x(i, k);
               }
             } else {
+#ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
+#pragma unroll
+#endif
               for (int k = 0; k < UNROLL; ++k) {
                 m_y(i, k) = m_a(k) * m_x(i, k) + m_b(0) * m_y(i, k);
               }

--- a/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
+++ b/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
@@ -129,12 +129,13 @@ struct Axpby_MV_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
 #pragma vector always
 #endif
-          if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+          if (m_b(0) ==
+              Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
             for (size_type k = 0; k < numCols; ++k) {
-              m_y(i, k) = Kokkos::ArithTraits<typename BV::non_const_value_type>::zero();
+              m_y(i, k) = Kokkos::ArithTraits<
+                  typename YMV::non_const_value_type>::zero();
             }
-          }
-          else {
+          } else {
             for (size_type k = 0; k < numCols; ++k) {
               m_y(i, k) = m_b(0) * m_y(i, k);
             }
@@ -194,12 +195,12 @@ struct Axpby_MV_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
 #pragma vector always
 #endif
-          if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+          if (m_b(0) ==
+              Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
             for (size_type k = 0; k < numCols; ++k) {
               m_y(i, k) = -m_x(i, k);
             }
-          }
-          else {
+          } else {
             for (size_type k = 0; k < numCols; ++k) {
               m_y(i, k) = -m_x(i, k) + m_b(0) * m_y(i, k);
             }
@@ -259,12 +260,12 @@ struct Axpby_MV_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
 #pragma vector always
 #endif
-          if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+          if (m_b(0) ==
+              Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
             for (size_type k = 0; k < numCols; ++k) {
               m_y(i, k) = m_x(i, k);
             }
-          }
-          else {
+          } else {
             for (size_type k = 0; k < numCols; ++k) {
               m_y(i, k) = m_x(i, k) + m_b(0) * m_y(i, k);
             }
@@ -361,12 +362,12 @@ struct Axpby_MV_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
 #pragma vector always
 #endif
-            if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+            if (m_b(0) == Kokkos::ArithTraits<
+                              typename BV::non_const_value_type>::zero()) {
               for (size_type k = 0; k < numCols; ++k) {
                 m_y(i, k) = m_a(0) * m_x(i, k);
               }
-            }
-            else {
+            } else {
               for (size_type k = 0; k < numCols; ++k) {
                 m_y(i, k) = m_a(0) * m_x(i, k) + m_b(0) * m_y(i, k);
               }
@@ -390,12 +391,12 @@ struct Axpby_MV_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
 #pragma vector always
 #endif
-            if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+            if (m_b(0) == Kokkos::ArithTraits<
+                              typename BV::non_const_value_type>::zero()) {
               for (size_type k = 0; k < numCols; ++k) {
                 m_y(i, k) = m_a(k) * m_x(i, k);
               }
-            }
-            else {
+            } else {
               for (size_type k = 0; k < numCols; ++k) {
                 m_y(i, k) = m_a(k) * m_x(i, k) + m_b(0) * m_y(i, k);
               }
@@ -753,12 +754,13 @@ struct Axpby_MV_Unroll_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
 #pragma unroll
 #endif
-          if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+          if (m_b(0) ==
+              Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
             for (int k = 0; k < UNROLL; ++k) {
-              m_y(i, k) = Kokkos::ArithTraits<typename BV::non_const_value_type>::zero();
+              m_y(i, k) = Kokkos::ArithTraits<
+                  typename YMV::non_const_value_type>::zero();
             }
-          }
-          else {
+          } else {
             for (int k = 0; k < UNROLL; ++k) {
               m_y(i, k) = m_b(0) * m_y(i, k);
             }
@@ -803,12 +805,12 @@ struct Axpby_MV_Unroll_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
 #pragma unroll
 #endif
-          if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+          if (m_b(0) ==
+              Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
             for (int k = 0; k < UNROLL; ++k) {
               m_y(i, k) = -m_x(i, k);
             }
-          }
-          else {
+          } else {
             for (int k = 0; k < UNROLL; ++k) {
               m_y(i, k) = -m_x(i, k) + m_b(0) * m_y(i, k);
             }
@@ -853,12 +855,12 @@ struct Axpby_MV_Unroll_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
 #pragma unroll
 #endif
-          if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+          if (m_b(0) ==
+              Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
             for (int k = 0; k < UNROLL; ++k) {
               m_y(i, k) = m_x(i, k);
             }
-          }
-          else {
+          } else {
             for (int k = 0; k < UNROLL; ++k) {
               m_y(i, k) = m_x(i, k) + m_b(0) * m_y(i, k);
             }
@@ -931,12 +933,12 @@ struct Axpby_MV_Unroll_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
 #pragma unroll
 #endif
-            if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+            if (m_b(0) == Kokkos::ArithTraits<
+                              typename BV::non_const_value_type>::zero()) {
               for (int k = 0; k < UNROLL; ++k) {
                 m_y(i, k) = m_a(0) * m_x(i, k);
               }
-            }
-            else {
+            } else {
               for (int k = 0; k < UNROLL; ++k) {
                 m_y(i, k) = m_a(0) * m_x(i, k) + m_b(0) * m_y(i, k);
               }
@@ -954,12 +956,12 @@ struct Axpby_MV_Unroll_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
 #pragma unroll
 #endif
-            if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+            if (m_b(0) == Kokkos::ArithTraits<
+                              typename BV::non_const_value_type>::zero()) {
               for (int k = 0; k < UNROLL; ++k) {
                 m_y(i, k) = m_a(k) * m_x(i, k);
               }
-            }
-            else {
+            } else {
               for (int k = 0; k < UNROLL; ++k) {
                 m_y(i, k) = m_a(k) * m_x(i, k) + m_b(0) * m_y(i, k);
               }

--- a/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
+++ b/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
@@ -129,8 +129,15 @@ struct Axpby_MV_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
 #pragma vector always
 #endif
-          for (size_type k = 0; k < numCols; ++k) {
-            m_y(i, k) = m_b(0) * m_y(i, k);
+          if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+            for (size_type k = 0; k < numCols; ++k) {
+              m_y(i, k) = Kokkos::ArithTraits<typename BV::non_const_value_type>::zero();
+            }
+          }
+          else {
+            for (size_type k = 0; k < numCols; ++k) {
+              m_y(i, k) = m_b(0) * m_y(i, k);
+            }
           }
         } else {
 #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
@@ -187,8 +194,15 @@ struct Axpby_MV_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
 #pragma vector always
 #endif
-          for (size_type k = 0; k < numCols; ++k) {
-            m_y(i, k) = -m_x(i, k) + m_b(0) * m_y(i, k);
+          if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+            for (size_type k = 0; k < numCols; ++k) {
+              m_y(i, k) = -m_x(i, k);
+            }
+          }
+          else {
+            for (size_type k = 0; k < numCols; ++k) {
+              m_y(i, k) = -m_x(i, k) + m_b(0) * m_y(i, k);
+            }
           }
         } else {
 #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
@@ -245,8 +259,15 @@ struct Axpby_MV_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
 #pragma vector always
 #endif
-          for (size_type k = 0; k < numCols; ++k) {
-            m_y(i, k) = m_x(i, k) + m_b(0) * m_y(i, k);
+          if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+            for (size_type k = 0; k < numCols; ++k) {
+              m_y(i, k) = m_x(i, k);
+            }
+          }
+          else {
+            for (size_type k = 0; k < numCols; ++k) {
+              m_y(i, k) = m_x(i, k) + m_b(0) * m_y(i, k);
+            }
           }
         } else {
 #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
@@ -340,8 +361,15 @@ struct Axpby_MV_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
 #pragma vector always
 #endif
-            for (size_type k = 0; k < numCols; ++k) {
-              m_y(i, k) = m_a(0) * m_x(i, k) + m_b(0) * m_y(i, k);
+            if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+              for (size_type k = 0; k < numCols; ++k) {
+                m_y(i, k) = m_a(0) * m_x(i, k);
+              }
+            }
+            else {
+              for (size_type k = 0; k < numCols; ++k) {
+                m_y(i, k) = m_a(0) * m_x(i, k) + m_b(0) * m_y(i, k);
+              }
             }
           } else {
 #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
@@ -362,8 +390,15 @@ struct Axpby_MV_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_VECTOR
 #pragma vector always
 #endif
-            for (size_type k = 0; k < numCols; ++k) {
-              m_y(i, k) = m_a(k) * m_x(i, k) + m_b(0) * m_y(i, k);
+            if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+              for (size_type k = 0; k < numCols; ++k) {
+                m_y(i, k) = m_a(k) * m_x(i, k);
+              }
+            }
+            else {
+              for (size_type k = 0; k < numCols; ++k) {
+                m_y(i, k) = m_a(k) * m_x(i, k) + m_b(0) * m_y(i, k);
+              }
             }
           } else {
 #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
@@ -718,8 +753,15 @@ struct Axpby_MV_Unroll_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
 #pragma unroll
 #endif
-          for (int k = 0; k < UNROLL; ++k) {
-            m_y(i, k) = m_b(0) * m_y(i, k);
+          if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+            for (int k = 0; k < UNROLL; ++k) {
+              m_y(i, k) = Kokkos::ArithTraits<typename BV::non_const_value_type>::zero();
+            }
+          }
+          else {
+            for (int k = 0; k < UNROLL; ++k) {
+              m_y(i, k) = m_b(0) * m_y(i, k);
+            }
           }
         } else {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
@@ -761,8 +803,15 @@ struct Axpby_MV_Unroll_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
 #pragma unroll
 #endif
-          for (int k = 0; k < UNROLL; ++k) {
-            m_y(i, k) = -m_x(i, k) + m_b(0) * m_y(i, k);
+          if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+            for (int k = 0; k < UNROLL; ++k) {
+              m_y(i, k) = -m_x(i, k);
+            }
+          }
+          else {
+            for (int k = 0; k < UNROLL; ++k) {
+              m_y(i, k) = -m_x(i, k) + m_b(0) * m_y(i, k);
+            }
           }
         } else {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
@@ -804,8 +853,15 @@ struct Axpby_MV_Unroll_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
 #pragma unroll
 #endif
-          for (int k = 0; k < UNROLL; ++k) {
-            m_y(i, k) = m_x(i, k) + m_b(0) * m_y(i, k);
+          if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+            for (int k = 0; k < UNROLL; ++k) {
+              m_y(i, k) = m_x(i, k);
+            }
+          }
+          else {
+            for (int k = 0; k < UNROLL; ++k) {
+              m_y(i, k) = m_x(i, k) + m_b(0) * m_y(i, k);
+            }
           }
         } else {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
@@ -875,8 +931,15 @@ struct Axpby_MV_Unroll_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
 #pragma unroll
 #endif
-            for (int k = 0; k < UNROLL; ++k) {
-              m_y(i, k) = m_a(0) * m_x(i, k) + m_b(0) * m_y(i, k);
+            if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+              for (int k = 0; k < UNROLL; ++k) {
+                m_y(i, k) = m_a(0) * m_x(i, k);
+              }
+            }
+            else {
+              for (int k = 0; k < UNROLL; ++k) {
+                m_y(i, k) = m_a(0) * m_x(i, k) + m_b(0) * m_y(i, k);
+              }
             }
           } else {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
@@ -891,8 +954,15 @@ struct Axpby_MV_Unroll_Functor {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL
 #pragma unroll
 #endif
-            for (int k = 0; k < UNROLL; ++k) {
-              m_y(i, k) = m_a(k) * m_x(i, k) + m_b(0) * m_y(i, k);
+            if (m_b(0) == Kokkos::ArithTraits<typename BV::non_const_value_type>::zero()) {
+              for (int k = 0; k < UNROLL; ++k) {
+                m_y(i, k) = m_a(k) * m_x(i, k);
+              }
+            }
+            else {
+              for (int k = 0; k < UNROLL; ++k) {
+                m_y(i, k) = m_a(k) * m_x(i, k) + m_b(0) * m_y(i, k);
+              }
             }
           } else {
 #ifdef KOKKOS_ENABLE_PRAGMA_UNROLL

--- a/blas/unit_test/Test_Blas1_axpby_unification.hpp
+++ b/blas/unit_test/Test_Blas1_axpby_unification.hpp
@@ -397,7 +397,7 @@ void impl_test_axpby_mv_unification_compare(
                   << ", vanillaValue = "   << vanillaValue
                   << std::endl;
 #endif
-        EXPECT_NEAR_KK(vanillaValue, y.h_view(i, k), 3. * max_error);
+        EXPECT_NEAR_KK(vanillaValue, y.h_view(i, k), 4. * max_error);
       }
     }
   } else {

--- a/blas/unit_test/Test_Blas1_axpby_unification.hpp
+++ b/blas/unit_test/Test_Blas1_axpby_unification.hpp
@@ -394,7 +394,7 @@ void impl_test_axpby_mv_unification_compare(
           (void)valueA;  // Avoid "set but not used" error
           int a_k(a.h_view.extent(0) == 1 ? 0 : k);
           vanillaValue = static_cast<ScalarTypeY>(a.h_view(a_k) * x.h_view(i, k));
-#if 1
+#if 0
           ScalarTypeY tmp = static_cast<ScalarTypeY>(a.h_view(a_k) * x.h_view(i, k) + valueB * org_y.h_view(i, k));
           std::cout << "i = "                    << i
                     << ", k = "                  << k
@@ -410,7 +410,7 @@ void impl_test_axpby_mv_unification_compare(
 #endif
         } else {
           vanillaValue = static_cast<ScalarTypeY>(valueA * x.h_view(i, k));
-#if 1
+#if 0
           ScalarTypeY tmp = static_cast<ScalarTypeY>(valueA * x.h_view(i, k) + valueB * org_y.h_view(i, k));
           std::cout << "i = "                    << i
                     << ", k = "                  << k
@@ -1048,7 +1048,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 01/36: Ascalar + Bscalar
   // ************************************************************
-  std::cout << "Starting case 01/36" << std::endl;
+  // std::cout << "Starting case 01/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1078,7 +1078,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 02/36: Ascalar + Br0
   // ************************************************************
-  std::cout << "Starting case 02/36" << std::endl;
+  // std::cout << "Starting case 02/36" << std::endl;
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -1112,7 +1112,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 03/36: Ascalar + Br1s_1
   // ************************************************************
-  std::cout << "Starting case 03/36" << std::endl;
+  // std::cout << "Starting case 03/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1142,7 +1142,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 04/36: Ascalar + Br1s_k
   // ************************************************************
-  std::cout << "Starting case 04/36" << std::endl;
+  // std::cout << "Starting case 04/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1176,7 +1176,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 05/36: Ascalar + Br1d,1
   // ************************************************************
-  std::cout << "Starting case 05/36" << std::endl;
+  // std::cout << "Starting case 05/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1206,7 +1206,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 06/36: Ascalar + Br1d,k
   // ************************************************************
-  std::cout << "Starting case 06/36" << std::endl;
+  // std::cout << "Starting case 06/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1240,7 +1240,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 07/36: Ar0 + Bscalar
   // ************************************************************w
-  std::cout << "Starting case 07/36" << std::endl;
+  // std::cout << "Starting case 07/36" << std::endl;
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -1274,7 +1274,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 08/36: Ar0 + Br0
   // ************************************************************
-  std::cout << "Starting case 08/36" << std::endl;
+  // std::cout << "Starting case 08/36" << std::endl;
   if constexpr ((std::is_same_v<tLayoutA, Kokkos::LayoutStride>) ||
                 (std::is_same_v<tLayoutB, Kokkos::LayoutStride>)) {
     // Avoid the test, due to compilation errors
@@ -1309,7 +1309,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 09/36: Ar0 + Br1s_1
   // ************************************************************
-  std::cout << "Starting case 09/36" << std::endl;
+  // std::cout << "Starting case 09/36" << std::endl;
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -1345,7 +1345,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 10/36: Ar0 + Br1s_k
   // ************************************************************
-  std::cout << "Starting case 10/36" << std::endl;
+  // std::cout << "Starting case 10/36" << std::endl;
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -1384,7 +1384,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 11/36: Ar0 + Br1d,1
   // ************************************************************
-  std::cout << "Starting case 11/36" << std::endl;
+  // std::cout << "Starting case 11/36" << std::endl;
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -1418,7 +1418,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 12/36: Ar0 + Br1d,k
   // ************************************************************
-  std::cout << "Starting case 12/36" << std::endl;
+  // std::cout << "Starting case 12/36" << std::endl;
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -1456,7 +1456,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 13/36: Ar1s_1 + Bscalar
   // ************************************************************w
-  std::cout << "Starting case 13/36" << std::endl;
+  // std::cout << "Starting case 13/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1488,7 +1488,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 14/36: Ar1s_1 + Br0
   // ************************************************************
-  std::cout << "Starting case 14/36" << std::endl;
+  // std::cout << "Starting case 14/36" << std::endl;
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -1524,7 +1524,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 15/36: Ar1s_1 + Br1s_1
   // ************************************************************
-  std::cout << "Starting case 15/36" << std::endl;
+  // std::cout << "Starting case 15/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1556,7 +1556,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 16/36: Ar1s_1 + Br1s_k
   // ************************************************************
-  std::cout << "Starting case 16/36" << std::endl;
+  // std::cout << "Starting case 16/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1591,7 +1591,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 17/36: Ar1s_1 + Br1d,1
   // ************************************************************
-  std::cout << "Starting case 17/36" << std::endl;
+  // std::cout << "Starting case 17/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1623,7 +1623,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 18/36: Ar1s_1 + Br1d,k
   // ************************************************************
-  std::cout << "Starting case 18/36" << std::endl;
+  // std::cout << "Starting case 18/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1658,7 +1658,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 19/36: Ar1s_k + Bscalar
   // ************************************************************
-  std::cout << "Starting case 19/36" << std::endl;
+  // std::cout << "Starting case 19/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1700,7 +1700,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 20/36: Ar1s_k + Br0
   // ************************************************************
-  std::cout << "Starting case 20/36" << std::endl;
+  // std::cout << "Starting case 20/36" << std::endl;
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -1746,7 +1746,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 21/36: Ar1s_k + Br1s_1
   // ************************************************************
-  std::cout << "Starting case 21/36" << std::endl;
+  // std::cout << "Starting case 21/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1788,7 +1788,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 22/36: Ar1s_k + Br1s_k
   // ************************************************************
-  std::cout << "Starting case 22/36" << std::endl;
+  // std::cout << "Starting case 22/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1834,7 +1834,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 23/36: Ar1s_k + Br1d,1
   // ************************************************************
-  std::cout << "Starting case 23/36" << std::endl;
+  // std::cout << "Starting case 23/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1876,7 +1876,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 24/36: Ar1s_k + Br1d,k
   // ************************************************************
-  std::cout << "Starting case 24/36" << std::endl;
+  // std::cout << "Starting case 24/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1923,7 +1923,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 25/36: Ar1d,1 + Bscalar
   // ************************************************************w
-  std::cout << "Starting case 25/36" << std::endl;
+  // std::cout << "Starting case 25/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1955,7 +1955,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 26/36: Ar1d,1 + Br0
   // ************************************************************
-  std::cout << "Starting case 26/36" << std::endl;
+  // std::cout << "Starting case 26/36" << std::endl;
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -1991,7 +1991,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 27/36: Ar1d,1 + Br1s_1
   // ************************************************************
-  std::cout << "Starting case 27/36" << std::endl;
+  // std::cout << "Starting case 27/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -2023,7 +2023,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 28/36: Ar1d,1 + Br1s_k
   // ************************************************************
-  std::cout << "Starting case 28/36" << std::endl;
+  // std::cout << "Starting case 28/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -2058,7 +2058,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 29/36: Ar1d,1 + Br1d,1
   // ************************************************************
-  std::cout << "Starting case 29/36" << std::endl;
+  // std::cout << "Starting case 29/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -2090,7 +2090,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 30/36: Ar1d,1 + Br1d,k
   // ************************************************************
-  std::cout << "Starting case 30/36" << std::endl;
+  // std::cout << "Starting case 30/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -2125,7 +2125,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 31/36: Ar1d,k + Bscalar
   // ************************************************************w
-  std::cout << "Starting case 31/36" << std::endl;
+  // std::cout << "Starting case 31/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -2167,7 +2167,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 32/36: Ar1d,k + Br0
   // ************************************************************
-  std::cout << "Starting case 32/36" << std::endl;
+  // std::cout << "Starting case 32/36" << std::endl;
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -2213,7 +2213,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 33/36: Ar1d,k + Br1s_1
   // ************************************************************
-  std::cout << "Starting case 33/36" << std::endl;
+  // std::cout << "Starting case 33/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -2255,7 +2255,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 34/36: Ar1d,k + Br1s_k
   // ************************************************************
-  std::cout << "Starting case 34/36" << std::endl;
+  // std::cout << "Starting case 34/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -2302,7 +2302,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 35/36: Ar1d,k + Br1d,1
   // ************************************************************
-  std::cout << "Starting case 35/36" << std::endl;
+  // std::cout << "Starting case 35/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -2344,7 +2344,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 36/36: Ar1d,k + Br1d,k
   // ************************************************************
-  std::cout << "Starting case 36/36" << std::endl;
+  // std::cout << "Starting case 36/36" << std::endl;
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {

--- a/blas/unit_test/Test_Blas1_axpby_unification.hpp
+++ b/blas/unit_test/Test_Blas1_axpby_unification.hpp
@@ -1043,7 +1043,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // in which the result is computed.
   using MagnitudeB         = typename Kokkos::ArithTraits<tScalarB>::mag_type;
   MagnitudeB const eps     = Kokkos::ArithTraits<tScalarB>::epsilon();
-  MagnitudeB const max_val = 20;
+  MagnitudeB const max_val = 40;
   MagnitudeB const max_error =
       static_cast<MagnitudeB>(
           Kokkos::ArithTraits<tScalarA>::abs(valuesA[valuesA.size() - 1]) +

--- a/blas/unit_test/Test_Blas1_axpby_unification.hpp
+++ b/blas/unit_test/Test_Blas1_axpby_unification.hpp
@@ -359,8 +359,7 @@ void impl_test_axpby_mv_unification_compare(
             if (b.h_view(b_k) == Kokkos::ArithTraits<tScalarB>::zero()) {
               vanillaValue =
                   static_cast<ScalarTypeY>(a.h_view(a_k) * x.h_view(i, k));
-            }
-            else {
+            } else {
               vanillaValue =
                   static_cast<ScalarTypeY>(a.h_view(a_k) * x.h_view(i, k) +
                                            b.h_view(b_k) * org_y.h_view(i, k));
@@ -368,10 +367,9 @@ void impl_test_axpby_mv_unification_compare(
           } else {
             int a_k(a.h_view.extent(0) == 1 ? 0 : k);
             if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
-              vanillaValue = static_cast<ScalarTypeY>(
-                  a.h_view(a_k) * x.h_view(i, k));
-            }
-            else {
+              vanillaValue =
+                  static_cast<ScalarTypeY>(a.h_view(a_k) * x.h_view(i, k));
+            } else {
               vanillaValue = static_cast<ScalarTypeY>(
                   a.h_view(a_k) * x.h_view(i, k) + valueB * org_y.h_view(i, k));
             }
@@ -383,17 +381,13 @@ void impl_test_axpby_mv_unification_compare(
             if (b.h_view(b_k) == Kokkos::ArithTraits<tScalarB>::zero()) {
               vanillaValue = static_cast<ScalarTypeY>(
                   valueA * x.h_view(i, k) + b.h_view(b_k) * org_y.h_view(i, k));
-            }
-            else {
-              vanillaValue = static_cast<ScalarTypeY>(
-                  valueA * x.h_view(i, k));
+            } else {
+              vanillaValue = static_cast<ScalarTypeY>(valueA * x.h_view(i, k));
             }
           } else {
             if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
-              vanillaValue = static_cast<ScalarTypeY>(
-                  valueA * x.h_view(i, k));
-            }
-            else {
+              vanillaValue = static_cast<ScalarTypeY>(valueA * x.h_view(i, k));
+            } else {
               vanillaValue = static_cast<ScalarTypeY>(
                   valueA * x.h_view(i, k) + valueB * org_y.h_view(i, k));
             }

--- a/blas/unit_test/Test_Blas1_axpby_unification.hpp
+++ b/blas/unit_test/Test_Blas1_axpby_unification.hpp
@@ -191,7 +191,7 @@ void impl_test_axpby_unification_compare(
     for (int i(0); i < N; ++i) {
       EXPECT_NEAR_KK(static_cast<ScalarTypeY>(valueA * x.h_view(i) +
                                               valueB * org_y.h_view(i)),
-                     y.h_view(i), 2. * max_error);
+                     y.h_view(i), 4. * max_error);
     }
   } else {
     // ********************************************************
@@ -221,7 +221,7 @@ void impl_test_axpby_unification_compare(
         EXPECT_NE(y.h_view(i), Kokkos::ArithTraits<ScalarTypeY>::nan());
       }
       EXPECT_NEAR_KK(static_cast<ScalarTypeY>(valueA * x.h_view(i)),
-                     y.h_view(i), 2. * max_error);
+                     y.h_view(i), 4. * max_error);
     }
   }
 }
@@ -462,7 +462,7 @@ void impl_test_axpby_mv_unification_compare(
                   << ", vanillaValue = "   << vanillaValue
                   << std::endl;
 #endif
-        EXPECT_NEAR_KK(vanillaValue, y.h_view(i, k), 2. * max_error);
+        EXPECT_NEAR_KK(vanillaValue, y.h_view(i, k), 4. * max_error);
       }
     }
   }

--- a/blas/unit_test/Test_Blas1_axpby_unification.hpp
+++ b/blas/unit_test/Test_Blas1_axpby_unification.hpp
@@ -379,10 +379,10 @@ void impl_test_axpby_mv_unification_compare(
             (void)valueB;  // Avoid "set but not used" error
             int b_k(b.h_view.extent(0) == 1 ? 0 : k);
             if (b.h_view(b_k) == Kokkos::ArithTraits<tScalarB>::zero()) {
+              vanillaValue = static_cast<ScalarTypeY>(valueA * x.h_view(i, k));
+            } else {
               vanillaValue = static_cast<ScalarTypeY>(
                   valueA * x.h_view(i, k) + b.h_view(b_k) * org_y.h_view(i, k));
-            } else {
-              vanillaValue = static_cast<ScalarTypeY>(valueA * x.h_view(i, k));
             }
           } else {
             if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {

--- a/blas/unit_test/Test_Blas1_axpby_unification.hpp
+++ b/blas/unit_test/Test_Blas1_axpby_unification.hpp
@@ -356,45 +356,48 @@ void impl_test_axpby_mv_unification_compare(
             (void)valueB;  // Avoid "set but not used" error
             int a_k(a.h_view.extent(0) == 1 ? 0 : k);
             int b_k(b.h_view.extent(0) == 1 ? 0 : k);
-            if (b.h_view(b_k) == Kokkos::ArithTraits<tScalarB>::zero()) {
-              vanillaValue =
-                  static_cast<ScalarTypeY>(a.h_view(a_k) * x.h_view(i, k));
-            } else {
-              vanillaValue =
-                  static_cast<ScalarTypeY>(a.h_view(a_k) * x.h_view(i, k) +
-                                           b.h_view(b_k) * org_y.h_view(i, k));
-            }
+#if 0
+            std::cout << "In impl_test_axpby_mv_unification_compare()"
+                      << ": i = " << i
+                      << ", k = " << k
+                      << ", a.h_view.extent(0) = " << a.h_view.extent(0)
+                      << ", a_k = "                << a_k
+                      << ", b.h_view.extent(0) = " << b.h_view.extent(0)
+                      << ", b_k = "                << b_k
+                      << ", a.h_view(a_k) = "      << a.h_view(a_k)
+                      << ", x.h_view(i, k) = "     << x.h_view(i, k)
+                      << ", b.h_view(b_k) = "      << b.h_view(b_k)
+                      << ", org_y.h_view(i, k) = " << org_y.h_view(i, k)
+                      << std::endl;
+#endif
+            vanillaValue =
+                static_cast<ScalarTypeY>(a.h_view(a_k) * x.h_view(i, k) +
+                                         b.h_view(b_k) * org_y.h_view(i, k));
           } else {
             int a_k(a.h_view.extent(0) == 1 ? 0 : k);
-            if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
-              vanillaValue =
-                  static_cast<ScalarTypeY>(a.h_view(a_k) * x.h_view(i, k));
-            } else {
-              vanillaValue = static_cast<ScalarTypeY>(
-                  a.h_view(a_k) * x.h_view(i, k) + valueB * org_y.h_view(i, k));
-            }
+            vanillaValue = static_cast<ScalarTypeY>(
+                a.h_view(a_k) * x.h_view(i, k) + valueB * org_y.h_view(i, k));
           }
         } else {
           if constexpr (bIsRank1) {
             (void)valueB;  // Avoid "set but not used" error
             int b_k(b.h_view.extent(0) == 1 ? 0 : k);
-            if (b.h_view(b_k) == Kokkos::ArithTraits<tScalarB>::zero()) {
-              vanillaValue = static_cast<ScalarTypeY>(valueA * x.h_view(i, k));
-            } else {
-              vanillaValue = static_cast<ScalarTypeY>(
-                  valueA * x.h_view(i, k) + b.h_view(b_k) * org_y.h_view(i, k));
-            }
+            vanillaValue = static_cast<ScalarTypeY>(
+                valueA * x.h_view(i, k) + b.h_view(b_k) * org_y.h_view(i, k));
           } else {
-            if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
-              vanillaValue = static_cast<ScalarTypeY>(valueA * x.h_view(i, k));
-            } else {
-              vanillaValue = static_cast<ScalarTypeY>(
-                  valueA * x.h_view(i, k) + valueB * org_y.h_view(i, k));
-            }
+            vanillaValue = static_cast<ScalarTypeY>(
+                valueA * x.h_view(i, k) + valueB * org_y.h_view(i, k));
           }
         }
-
-        EXPECT_NEAR_KK(vanillaValue, y.h_view(i, k), 2. * max_error);
+#if 0
+        std::cout << "In impl_test_axpby_mv_unification_compare(1)"
+                  << ": i = " << i
+                  << ", k = " << k
+                  << ", y.h_view(i, k) = " << y.h_view(i, k)
+                  << ", vanillaValue = "   << vanillaValue
+                  << std::endl;
+#endif
+        EXPECT_NEAR_KK(vanillaValue, y.h_view(i, k), 3. * max_error);
       }
     }
   } else {
@@ -451,7 +454,14 @@ void impl_test_axpby_mv_unification_compare(
         } else {
           EXPECT_NE(y.h_view(i, k), Kokkos::ArithTraits<ScalarTypeY>::nan());
         }
-
+#if 0
+        std::cout << "In impl_test_axpby_mv_unification_compare(2)"
+                  << ": i = " << i
+                  << ", k = " << k
+                  << ", y.h_view(i, k) = " << y.h_view(i, k)
+                  << ", vanillaValue = "   << vanillaValue
+                  << std::endl;
+#endif
         EXPECT_NEAR_KK(vanillaValue, y.h_view(i, k), 2. * max_error);
       }
     }
@@ -1061,7 +1071,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // in which the result is computed.
   using MagnitudeB         = typename Kokkos::ArithTraits<tScalarB>::mag_type;
   MagnitudeB const eps     = Kokkos::ArithTraits<tScalarB>::epsilon();
-  MagnitudeB const max_val = 100;
+  MagnitudeB const max_val = 10;
   MagnitudeB const max_error =
       static_cast<MagnitudeB>(
           Kokkos::ArithTraits<tScalarA>::abs(valuesA[valuesA.size() - 1]) +

--- a/blas/unit_test/Test_Blas1_axpby_unification.hpp
+++ b/blas/unit_test/Test_Blas1_axpby_unification.hpp
@@ -83,7 +83,8 @@ void impl_test_axpby_unification_compare(
     bool testWithNanY,
     typename Kokkos::ArithTraits<tScalarB>::mag_type const max_val,
     typename Kokkos::ArithTraits<tScalarB>::mag_type const max_error,
-    tScalarA const inputValueA = Kokkos::ArithTraits<tScalarA>::zero(), tScalarB const inputValueB = Kokkos::ArithTraits<tScalarB>::zero()) {
+    tScalarA const inputValueA = Kokkos::ArithTraits<tScalarA>::zero(),
+    tScalarB const inputValueB = Kokkos::ArithTraits<tScalarB>::zero()) {
   using ScalarTypeX =
       typename std::remove_const<typename tX::DView::value_type>::type;
   using ScalarTypeY =
@@ -104,8 +105,7 @@ void impl_test_axpby_unification_compare(
     Test::getRandomBounds(max_val, randStart, randEnd);
     if (testWithNanY) {
       Kokkos::deep_copy(y.d_view, Kokkos::ArithTraits<ScalarTypeY>::nan());
-    }
-    else {
+    } else {
       Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
     }
   }
@@ -193,8 +193,7 @@ void impl_test_axpby_unification_compare(
                                               valueB * org_y.h_view(i)),
                      y.h_view(i), 2. * max_error);
     }
-  }
-  else {
+  } else {
     // ********************************************************
     // Tests with 'Y == nan()' are called only for cases where
     // b == Kokkos::ArithTraits<tScalarB>::zero()
@@ -218,8 +217,7 @@ void impl_test_axpby_unification_compare(
         if (y.h_view(i) != -1) {
           EXPECT_NE(y.h_view(i), Kokkos::ArithTraits<ScalarTypeY>::nan());
         }
-      }
-      else {
+      } else {
         EXPECT_NE(y.h_view(i), Kokkos::ArithTraits<ScalarTypeY>::nan());
       }
       EXPECT_NEAR_KK(static_cast<ScalarTypeY>(valueA * x.h_view(i)),
@@ -235,7 +233,8 @@ void impl_test_axpby_mv_unification_compare(
     bool testWithNanY,
     typename Kokkos::ArithTraits<tScalarB>::mag_type const max_val,
     typename Kokkos::ArithTraits<tScalarB>::mag_type const max_error,
-    tScalarA const inputValueA = Kokkos::ArithTraits<tScalarA>::zero(), tScalarB const inputValueB = Kokkos::ArithTraits<tScalarB>::zero()) {
+    tScalarA const inputValueA = Kokkos::ArithTraits<tScalarA>::zero(),
+    tScalarB const inputValueB = Kokkos::ArithTraits<tScalarB>::zero()) {
   using ScalarTypeX =
       typename std::remove_const<typename tY::DView::value_type>::type;
   using ScalarTypeY =
@@ -256,8 +255,7 @@ void impl_test_axpby_mv_unification_compare(
     Test::getRandomBounds(max_val, randStart, randEnd);
     if (testWithNanY) {
       Kokkos::deep_copy(y.d_view, Kokkos::ArithTraits<ScalarTypeY>::nan());
-    }
-    else {
+    } else {
       Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
     }
   }
@@ -373,16 +371,15 @@ void impl_test_axpby_mv_unification_compare(
             vanillaValue = static_cast<ScalarTypeY>(
                 valueA * x.h_view(i, k) + b.h_view(b_k) * org_y.h_view(i, k));
           } else {
-            vanillaValue = static_cast<ScalarTypeY>(valueA * x.h_view(i, k) +
-                                                    valueB * org_y.h_view(i, k));
+            vanillaValue = static_cast<ScalarTypeY>(
+                valueA * x.h_view(i, k) + valueB * org_y.h_view(i, k));
           }
         }
 
         EXPECT_NEAR_KK(vanillaValue, y.h_view(i, k), 2. * max_error);
       }
     }
-  }
-  else {
+  } else {
     // ********************************************************
     // Tests with 'Y == nan()' are called only for cases where
     // b == Kokkos::ArithTraits<tScalarB>::zero()
@@ -393,7 +390,8 @@ void impl_test_axpby_mv_unification_compare(
         if constexpr (aIsRank1) {
           (void)valueA;  // Avoid "set but not used" error
           int a_k(a.h_view.extent(0) == 1 ? 0 : k);
-          vanillaValue = static_cast<ScalarTypeY>(a.h_view(a_k) * x.h_view(i, k));
+          vanillaValue =
+              static_cast<ScalarTypeY>(a.h_view(a_k) * x.h_view(i, k));
 #if 0
           ScalarTypeY tmp = static_cast<ScalarTypeY>(a.h_view(a_k) * x.h_view(i, k) + valueB * org_y.h_view(i, k));
           std::cout << "i = "                    << i
@@ -432,11 +430,10 @@ void impl_test_axpby_mv_unification_compare(
           if (y.h_view(i, k) != -1) {
             EXPECT_NE(y.h_view(i, k), Kokkos::ArithTraits<ScalarTypeY>::nan());
           }
-        }
-        else {
+        } else {
           EXPECT_NE(y.h_view(i, k), Kokkos::ArithTraits<ScalarTypeY>::nan());
         }
-	
+
         EXPECT_NEAR_KK(vanillaValue, y.h_view(i, k), 2. * max_error);
       }
     }
@@ -459,8 +456,10 @@ void impl_test_axpby_unification(int const N) {
 
   using ViewTypeY = Kokkos::View<tScalarY*, tLayoutY, Device>;
 
-  std::array<tScalarA, 4> const valuesA{-1, Kokkos::ArithTraits<tScalarA>::zero(), 1, 3};
-  std::array<tScalarB, 4> const valuesB{-1, Kokkos::ArithTraits<tScalarB>::zero(), 1, 5};
+  std::array<tScalarA, 4> const valuesA{
+      -1, Kokkos::ArithTraits<tScalarA>::zero(), 1, 3};
+  std::array<tScalarB, 4> const valuesB{
+      -1, Kokkos::ArithTraits<tScalarB>::zero(), 1, 5};
 
   // eps should probably be based on tScalarB since that is the type
   // in which the result is computed.
@@ -563,8 +562,9 @@ void impl_test_axpby_unification(int const N) {
         if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
           impl_test_axpby_unification_compare<
               tScalarA, tScalarA, view_stride_adapter<ViewTypeX>, tScalarB,
-              view_stride_adapter<ViewTypeBr1s_1>, view_stride_adapter<ViewTypeY>,
-              Device>(a, x, b, y, N, true, max_val, max_error);
+              view_stride_adapter<ViewTypeBr1s_1>,
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, true,
+                                                      max_val, max_error);
         }
       }
     }
@@ -691,14 +691,14 @@ void impl_test_axpby_unification(int const N) {
           impl_test_axpby_unification_compare<
               tScalarA, ViewTypeAr0, view_stride_adapter<ViewTypeX>, tScalarB,
               view_stride_adapter<ViewTypeBr1s_1>,
-              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, false, max_val,
-                                                      max_error);
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, false,
+                                                      max_val, max_error);
           if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
             impl_test_axpby_unification_compare<
                 tScalarA, ViewTypeAr0, view_stride_adapter<ViewTypeX>, tScalarB,
                 view_stride_adapter<ViewTypeBr1s_1>,
-                view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, true, max_val,
-                                                        max_error);
+                view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, true,
+                                                        max_val, max_error);
           }
         }
       }
@@ -731,8 +731,9 @@ void impl_test_axpby_unification(int const N) {
           if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
             impl_test_axpby_unification_compare<
                 tScalarA, ViewTypeAr0, view_stride_adapter<ViewTypeX>, tScalarB,
-                view_stride_adapter<ViewTypeBr1d>, view_stride_adapter<ViewTypeY>,
-                Device>(a, x, b, y, N, true, max_val, max_error);
+                view_stride_adapter<ViewTypeBr1d>,
+                view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, true,
+                                                        max_val, max_error);
           }
         }
       }
@@ -758,14 +759,14 @@ void impl_test_axpby_unification(int const N) {
         impl_test_axpby_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
             view_stride_adapter<ViewTypeX>, tScalarB, tScalarB,
-            view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, false, max_val,
-                                                    max_error);
+            view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, false,
+                                                    max_val, max_error);
         if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
           impl_test_axpby_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
               view_stride_adapter<ViewTypeX>, tScalarB, tScalarB,
-              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, true, max_val,
-                                                      max_error);
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, true,
+                                                      max_val, max_error);
         }
       }
     }
@@ -793,14 +794,14 @@ void impl_test_axpby_unification(int const N) {
           impl_test_axpby_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
               view_stride_adapter<ViewTypeX>, tScalarB, ViewTypeBr0,
-              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, false, max_val,
-                                                      max_error);
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, false,
+                                                      max_val, max_error);
           if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
             impl_test_axpby_unification_compare<
                 tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
                 view_stride_adapter<ViewTypeX>, tScalarB, ViewTypeBr0,
-                view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, true, max_val,
-                                                        max_error);
+                view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, true,
+                                                        max_val, max_error);
           }
         }
       }
@@ -832,8 +833,9 @@ void impl_test_axpby_unification(int const N) {
           impl_test_axpby_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
               view_stride_adapter<ViewTypeX>, tScalarB,
-              view_stride_adapter<ViewTypeBr1s_1>, view_stride_adapter<ViewTypeY>,
-              Device>(a, x, b, y, N, true, max_val, max_error);
+              view_stride_adapter<ViewTypeBr1s_1>,
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, true,
+                                                      max_val, max_error);
         }
       }
     }
@@ -890,14 +892,14 @@ void impl_test_axpby_unification(int const N) {
         impl_test_axpby_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1d>,
             view_stride_adapter<ViewTypeX>, tScalarB, tScalarB,
-            view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, false, max_val,
-                                                    max_error);
+            view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, false,
+                                                    max_val, max_error);
         if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
           impl_test_axpby_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1d>,
               view_stride_adapter<ViewTypeX>, tScalarB, tScalarB,
-              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, true, max_val,
-                                                      max_error);
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, true,
+                                                      max_val, max_error);
         }
       }
     }
@@ -925,14 +927,14 @@ void impl_test_axpby_unification(int const N) {
           impl_test_axpby_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1d>,
               view_stride_adapter<ViewTypeX>, tScalarB, ViewTypeBr0,
-              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, false, max_val,
-                                                      max_error);
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, false,
+                                                      max_val, max_error);
           if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
             impl_test_axpby_unification_compare<
                 tScalarA, view_stride_adapter<ViewTypeAr1d>,
                 view_stride_adapter<ViewTypeX>, tScalarB, ViewTypeBr0,
-                view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, true, max_val,
-                                                        max_error);
+                view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, true,
+                                                        max_val, max_error);
           }
         }
       }
@@ -964,8 +966,9 @@ void impl_test_axpby_unification(int const N) {
           impl_test_axpby_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1d>,
               view_stride_adapter<ViewTypeX>, tScalarB,
-              view_stride_adapter<ViewTypeBr1s_1>, view_stride_adapter<ViewTypeY>,
-              Device>(a, x, b, y, N, true, max_val, max_error);
+              view_stride_adapter<ViewTypeBr1s_1>,
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, true,
+                                                      max_val, max_error);
         }
       }
     }
@@ -1031,8 +1034,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
   using ViewTypeY = Kokkos::View<tScalarY**, tLayoutY, Device>;
 
-  std::array<tScalarA, 4> const valuesA{-1, Kokkos::ArithTraits<tScalarA>::zero(), 1, 3};
-  std::array<tScalarB, 4> const valuesB{-1, Kokkos::ArithTraits<tScalarB>::zero(), 1, 5};
+  std::array<tScalarA, 4> const valuesA{
+      -1, Kokkos::ArithTraits<tScalarA>::zero(), 1, 3};
+  std::array<tScalarB, 4> const valuesB{
+      -1, Kokkos::ArithTraits<tScalarB>::zero(), 1, 5};
 
   // eps should probably be based on tScalarB since that is the type
   // in which the result is computed.
@@ -1132,8 +1137,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
           impl_test_axpby_mv_unification_compare<
               tScalarA, tScalarA, view_stride_adapter<ViewTypeX>, tScalarB,
-              view_stride_adapter<ViewTypeBr1s_1>, view_stride_adapter<ViewTypeY>,
-              Device>(a, x, b, y, N, K, true, max_val, max_error);
+              view_stride_adapter<ViewTypeBr1s_1>,
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true,
+                                                      max_val, max_error);
         }
       }
     }
@@ -1328,14 +1334,14 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           impl_test_axpby_mv_unification_compare<
               tScalarA, ViewTypeAr0, view_stride_adapter<ViewTypeX>, tScalarB,
               view_stride_adapter<ViewTypeBr1s_1>,
-              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false, max_val,
-                                                      max_error);
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false,
+                                                      max_val, max_error);
           if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
             impl_test_axpby_mv_unification_compare<
                 tScalarA, ViewTypeAr0, view_stride_adapter<ViewTypeX>, tScalarB,
                 view_stride_adapter<ViewTypeBr1s_1>,
-                view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true, max_val,
-                                                        max_error);
+                view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true,
+                                                        max_val, max_error);
           }
         }
       }
@@ -1374,8 +1380,8 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           impl_test_axpby_mv_unification_compare<
               tScalarA, ViewTypeAr0, view_stride_adapter<ViewTypeX>, tScalarB,
               view_stride_adapter<ViewTypeBr1s_k>,
-              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false, max_val,
-                                                      max_error);
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false,
+                                                      max_val, max_error);
         }
       }
     }
@@ -1407,8 +1413,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
             impl_test_axpby_mv_unification_compare<
                 tScalarA, ViewTypeAr0, view_stride_adapter<ViewTypeX>, tScalarB,
-                view_stride_adapter<ViewTypeBr1d>, view_stride_adapter<ViewTypeY>,
-                Device>(a, x, b, y, N, K, true, max_val, max_error);
+                view_stride_adapter<ViewTypeBr1d>,
+                view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true,
+                                                        max_val, max_error);
           }
         }
       }
@@ -1472,14 +1479,14 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
             view_stride_adapter<ViewTypeX>, tScalarB, tScalarB,
-            view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false, max_val,
-                                                    max_error);
+            view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false,
+                                                    max_val, max_error);
         if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
               view_stride_adapter<ViewTypeX>, tScalarB, tScalarB,
-              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true, max_val,
-                                                      max_error);
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true,
+                                                      max_val, max_error);
         }
       }
     }
@@ -1507,14 +1514,14 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
               view_stride_adapter<ViewTypeX>, tScalarB, ViewTypeBr0,
-              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false, max_val,
-                                                      max_error);
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false,
+                                                      max_val, max_error);
           if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
             impl_test_axpby_mv_unification_compare<
                 tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
                 view_stride_adapter<ViewTypeX>, tScalarB, ViewTypeBr0,
-                view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true, max_val,
-                                                        max_error);
+                view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true,
+                                                        max_val, max_error);
           }
         }
       }
@@ -1546,8 +1553,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
               view_stride_adapter<ViewTypeX>, tScalarB,
-              view_stride_adapter<ViewTypeBr1s_1>, view_stride_adapter<ViewTypeY>,
-              Device>(a, x, b, y, N, K, true, max_val, max_error);
+              view_stride_adapter<ViewTypeBr1s_1>,
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true,
+                                                      max_val, max_error);
         }
       }
     }
@@ -1684,14 +1692,14 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1s_k>,
             view_stride_adapter<ViewTypeX>, tScalarB, tScalarB,
-            view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false, max_val,
-                                                    max_error);
+            view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false,
+                                                    max_val, max_error);
         if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1s_k>,
               view_stride_adapter<ViewTypeX>, tScalarB, tScalarB,
-              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true, max_val,
-                                                      max_error);
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true,
+                                                      max_val, max_error);
         }
       }
     }
@@ -1729,14 +1737,14 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1s_k>,
               view_stride_adapter<ViewTypeX>, tScalarB, ViewTypeBr0,
-              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false, max_val,
-                                                      max_error);
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false,
+                                                      max_val, max_error);
           if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
             impl_test_axpby_mv_unification_compare<
                 tScalarA, view_stride_adapter<ViewTypeAr1s_k>,
                 view_stride_adapter<ViewTypeX>, tScalarB, ViewTypeBr0,
-                view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true, max_val,
-                                                        max_error);
+                view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true,
+                                                        max_val, max_error);
           }
         }
       }
@@ -1778,8 +1786,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1s_k>,
               view_stride_adapter<ViewTypeX>, tScalarB,
-              view_stride_adapter<ViewTypeBr1s_1>, view_stride_adapter<ViewTypeY>,
-              Device>(a, x, b, y, N, K, true, max_val, max_error);
+              view_stride_adapter<ViewTypeBr1s_1>,
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true,
+                                                      max_val, max_error);
         }
       }
     }
@@ -1939,14 +1948,14 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1d>,
             view_stride_adapter<ViewTypeX>, tScalarB, tScalarB,
-            view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false, max_val,
-                                                    max_error);
+            view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false,
+                                                    max_val, max_error);
         if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1d>,
               view_stride_adapter<ViewTypeX>, tScalarB, tScalarB,
-              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true, max_val,
-                                                      max_error);
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true,
+                                                      max_val, max_error);
         }
       }
     }
@@ -1974,14 +1983,14 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1d>,
               view_stride_adapter<ViewTypeX>, tScalarB, ViewTypeBr0,
-              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false, max_val,
-                                                      max_error);
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false,
+                                                      max_val, max_error);
           if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
             impl_test_axpby_mv_unification_compare<
                 tScalarA, view_stride_adapter<ViewTypeAr1d>,
                 view_stride_adapter<ViewTypeX>, tScalarB, ViewTypeBr0,
-                view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true, max_val,
-                                                        max_error);
+                view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true,
+                                                        max_val, max_error);
           }
         }
       }
@@ -2013,8 +2022,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1d>,
               view_stride_adapter<ViewTypeX>, tScalarB,
-              view_stride_adapter<ViewTypeBr1s_1>, view_stride_adapter<ViewTypeY>,
-              Device>(a, x, b, y, N, K, true, max_val, max_error);
+              view_stride_adapter<ViewTypeBr1s_1>,
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true,
+                                                      max_val, max_error);
         }
       }
     }
@@ -2151,14 +2161,14 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1d>,
             view_stride_adapter<ViewTypeX>, tScalarB, tScalarB,
-            view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false, max_val,
-                                                    max_error);
+            view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false,
+                                                    max_val, max_error);
         if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1d>,
               view_stride_adapter<ViewTypeX>, tScalarB, tScalarB,
-              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true, max_val,
-                                                      max_error);
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true,
+                                                      max_val, max_error);
         }
       }
     }
@@ -2196,14 +2206,14 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1d>,
               view_stride_adapter<ViewTypeX>, tScalarB, ViewTypeBr0,
-              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false, max_val,
-                                                      max_error);
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, false,
+                                                      max_val, max_error);
           if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
             impl_test_axpby_mv_unification_compare<
                 tScalarA, view_stride_adapter<ViewTypeAr1d>,
                 view_stride_adapter<ViewTypeX>, tScalarB, ViewTypeBr0,
-                view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true, max_val,
-                                                        max_error);
+                view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true,
+                                                        max_val, max_error);
           }
         }
       }
@@ -2245,8 +2255,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1d>,
               view_stride_adapter<ViewTypeX>, tScalarB,
-              view_stride_adapter<ViewTypeBr1s_1>, view_stride_adapter<ViewTypeY>,
-              Device>(a, x, b, y, N, K, true, max_val, max_error);
+              view_stride_adapter<ViewTypeBr1s_1>,
+              view_stride_adapter<ViewTypeY>, Device>(a, x, b, y, N, K, true,
+                                                      max_val, max_error);
         }
       }
     }

--- a/blas/unit_test/Test_Blas1_axpby_unification.hpp
+++ b/blas/unit_test/Test_Blas1_axpby_unification.hpp
@@ -1043,7 +1043,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // in which the result is computed.
   using MagnitudeB         = typename Kokkos::ArithTraits<tScalarB>::mag_type;
   MagnitudeB const eps     = Kokkos::ArithTraits<tScalarB>::epsilon();
-  MagnitudeB const max_val = 40;
+  MagnitudeB const max_val = 10;
   MagnitudeB const max_error =
       static_cast<MagnitudeB>(
           Kokkos::ArithTraits<tScalarA>::abs(valuesA[valuesA.size() - 1]) +

--- a/blas/unit_test/Test_Blas1_axpby_unification.hpp
+++ b/blas/unit_test/Test_Blas1_axpby_unification.hpp
@@ -356,23 +356,47 @@ void impl_test_axpby_mv_unification_compare(
             (void)valueB;  // Avoid "set but not used" error
             int a_k(a.h_view.extent(0) == 1 ? 0 : k);
             int b_k(b.h_view.extent(0) == 1 ? 0 : k);
-            vanillaValue =
-                static_cast<ScalarTypeY>(a.h_view(a_k) * x.h_view(i, k) +
-                                         b.h_view(b_k) * org_y.h_view(i, k));
+            if (b.h_view(b_k) == Kokkos::ArithTraits<tScalarB>::zero()) {
+              vanillaValue =
+                  static_cast<ScalarTypeY>(a.h_view(a_k) * x.h_view(i, k));
+            }
+            else {
+              vanillaValue =
+                  static_cast<ScalarTypeY>(a.h_view(a_k) * x.h_view(i, k) +
+                                           b.h_view(b_k) * org_y.h_view(i, k));
+            }
           } else {
             int a_k(a.h_view.extent(0) == 1 ? 0 : k);
-            vanillaValue = static_cast<ScalarTypeY>(
-                a.h_view(a_k) * x.h_view(i, k) + valueB * org_y.h_view(i, k));
+            if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
+              vanillaValue = static_cast<ScalarTypeY>(
+                  a.h_view(a_k) * x.h_view(i, k));
+            }
+            else {
+              vanillaValue = static_cast<ScalarTypeY>(
+                  a.h_view(a_k) * x.h_view(i, k) + valueB * org_y.h_view(i, k));
+            }
           }
         } else {
           if constexpr (bIsRank1) {
             (void)valueB;  // Avoid "set but not used" error
             int b_k(b.h_view.extent(0) == 1 ? 0 : k);
-            vanillaValue = static_cast<ScalarTypeY>(
-                valueA * x.h_view(i, k) + b.h_view(b_k) * org_y.h_view(i, k));
+            if (b.h_view(b_k) == Kokkos::ArithTraits<tScalarB>::zero()) {
+              vanillaValue = static_cast<ScalarTypeY>(
+                  valueA * x.h_view(i, k) + b.h_view(b_k) * org_y.h_view(i, k));
+            }
+            else {
+              vanillaValue = static_cast<ScalarTypeY>(
+                  valueA * x.h_view(i, k));
+            }
           } else {
-            vanillaValue = static_cast<ScalarTypeY>(
-                valueA * x.h_view(i, k) + valueB * org_y.h_view(i, k));
+            if (valueB == Kokkos::ArithTraits<tScalarB>::zero()) {
+              vanillaValue = static_cast<ScalarTypeY>(
+                  valueA * x.h_view(i, k));
+            }
+            else {
+              vanillaValue = static_cast<ScalarTypeY>(
+                  valueA * x.h_view(i, k) + valueB * org_y.h_view(i, k));
+            }
           }
         }
 
@@ -1043,7 +1067,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // in which the result is computed.
   using MagnitudeB         = typename Kokkos::ArithTraits<tScalarB>::mag_type;
   MagnitudeB const eps     = Kokkos::ArithTraits<tScalarB>::epsilon();
-  MagnitudeB const max_val = 40;
+  MagnitudeB const max_val = 100;
   MagnitudeB const max_error =
       static_cast<MagnitudeB>(
           Kokkos::ArithTraits<tScalarA>::abs(valuesA[valuesA.size() - 1]) +

--- a/blas/unit_test/Test_Blas1_axpby_unification.hpp
+++ b/blas/unit_test/Test_Blas1_axpby_unification.hpp
@@ -1043,7 +1043,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // in which the result is computed.
   using MagnitudeB         = typename Kokkos::ArithTraits<tScalarB>::mag_type;
   MagnitudeB const eps     = Kokkos::ArithTraits<tScalarB>::epsilon();
-  MagnitudeB const max_val = 10;
+  MagnitudeB const max_val = 20;
   MagnitudeB const max_error =
       static_cast<MagnitudeB>(
           Kokkos::ArithTraits<tScalarA>::abs(valuesA[valuesA.size() - 1]) +

--- a/blas/unit_test/Test_Blas1_axpby_unification.hpp
+++ b/blas/unit_test/Test_Blas1_axpby_unification.hpp
@@ -1043,7 +1043,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // in which the result is computed.
   using MagnitudeB         = typename Kokkos::ArithTraits<tScalarB>::mag_type;
   MagnitudeB const eps     = Kokkos::ArithTraits<tScalarB>::epsilon();
-  MagnitudeB const max_val = 10;
+  MagnitudeB const max_val = 40;
   MagnitudeB const max_error =
       static_cast<MagnitudeB>(
           Kokkos::ArithTraits<tScalarA>::abs(valuesA[valuesA.size() - 1]) +

--- a/blas/unit_test/Test_Blas2_syr2.hpp
+++ b/blas/unit_test/Test_Blas2_syr2.hpp
@@ -207,8 +207,12 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
       // large enough to require 'relTol' to value 5.0e-3. The same
       // calculations show no discrepancies for calculations with double.
       // ****************************************************************
-      _absTol(std::is_same<_AuxType, float>::value ? 1.0e-6 : (std::is_same<_AuxType, double>::value ? 1.0e-9 : 0)),
-      _relTol(std::is_same<_AuxType, float>::value ? 5.0e-3 : (std::is_same<_AuxType, double>::value ? 1.0e-6 : 0)),
+      _absTol(std::is_same<_AuxType, float>::value
+                  ? 1.0e-6
+                  : (std::is_same<_AuxType, double>::value ? 1.0e-9 : 0)),
+      _relTol(std::is_same<_AuxType, float>::value
+                  ? 5.0e-3
+                  : (std::is_same<_AuxType, double>::value ? 1.0e-6 : 0)),
       _M(-1),
       _N(-1),
       _useAnalyticalResults(false),

--- a/blas/unit_test/Test_Blas2_syr2.hpp
+++ b/blas/unit_test/Test_Blas2_syr2.hpp
@@ -207,8 +207,8 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
       // large enough to require 'relTol' to value 5.0e-3. The same
       // calculations show no discrepancies for calculations with double.
       // ****************************************************************
-      _absTol(std::is_same<_AuxType, float>::value ? 1.0e-6 : 1.0e-9),
-      _relTol(std::is_same<_AuxType, float>::value ? 5.0e-3 : 1.0e-6),
+      _absTol(std::is_same<_AuxType, float>::value ? 1.0e-6 : (std::is_same<_AuxType, double>::value ? 1.0e-9 : 0)),
+      _relTol(std::is_same<_AuxType, float>::value ? 5.0e-3 : (std::is_same<_AuxType, double>::value ? 1.0e-6 : 0)),
       _M(-1),
       _N(-1),
       _useAnalyticalResults(false),
@@ -610,7 +610,7 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
                                              _HostViewTypeY& h_y,
                                              _HostViewTypeA& h_A,
                                              _ViewTypeExpected& h_expected) {
-  alpha = 1.1;
+  alpha = std::is_same<_AuxType, int>::value ? 1 : 1.1;
 
   for (int i = 0; i < _M; ++i) {
     _AuxType auxI = this->shrinkAngleToZeroTwoPiRange(static_cast<_AuxType>(i));


### PR DESCRIPTION
This error was happening only when X and Y were rank-2, Y had nan values, b was zero, and the final Y still had nan values, even though it should not. The error was detected on the Trilinos nightly tests.

Correction:
- neglect original Y when b is zero, so that nan values are not carried out.
- Impl files on axpby are corrected now, and new unit tests were added to replicate the issue.

Thanks for the help from Nathan, Luc, and Christian Glusa (Trilinos team).