### PR TITLE
Lapack: fixing issue with Magma TPL in gesv, trtri, etc...

### DIFF
--- a/blas/src/KokkosBlas1_swap.hpp
+++ b/blas/src/KokkosBlas1_swap.hpp
@@ -26,12 +26,12 @@ namespace KokkosBlas {
 /// \brief Swaps the entries of vectors x and y.
 ///
 /// \tparam execution_space an execution space to perform parallel work
-/// \tparam XVector Type of the first vector x; a 1-D Kokkos::View.
-/// \tparam YVector Type of the first vector y; a 1-D Kokkos::View.
+/// \tparam XVector Type of the first vector x; a rank 1 Kokkos::View.
+/// \tparam YVector Type of the first vector y; a rank 1 Kokkos::View.
 ///
 /// \param space [in] execution space passed to execution policies
-/// \param x [in/out] 1-D View.
-/// \param y [in/out] 1-D View.
+/// \param x [in/out] rank 1 View.
+/// \param y [in/out] rank 1 View.
 ///
 /// Swaps x and y. Note that this is akin to performing a deep_copy, swapping
 /// pointers inside view can only be performed if no aliasing, subviews, etc...
@@ -100,11 +100,11 @@ void swap(execution_space const& space, XVector const& x, YVector const& y) {
 
 /// \brief Swaps the entries of vectors x and y.
 ///
-/// \tparam XVector Type of the first vector x; a 1-D Kokkos::View.
-/// \tparam YVector Type of the first vector y; a 1-D Kokkos::View.
+/// \tparam XVector Type of the first vector x; a rank 1 Kokkos::View.
+/// \tparam YVector Type of the first vector y; a rank 1 Kokkos::View.
 ///
-/// \param x [in/out] 1-D View.
-/// \param y [in/out] 1-D View.
+/// \param x [in/out] rank 1 View.
+/// \param y [in/out] rank 1 View.
 ///
 /// This function is non-blocking unless the underlying TPL requested
 /// at compile time is itself blocking. Note that the kernel will be

--- a/blas/unit_test/Test_Blas1_swap.hpp
+++ b/blas/unit_test/Test_Blas1_swap.hpp
@@ -6,7 +6,7 @@ namespace Impl {
 template <class ScalarType, class DeviceType>
 void test_swap(int const vector_length) {
   using execution_space = typename DeviceType::execution_space;
-  using memory_space    = typename DeviceType::execution_space;
+  using memory_space    = typename DeviceType::memory_space;
   using vector_type     = Kokkos::View<ScalarType*, memory_space>;
   using scalar_type     = typename vector_type::non_const_value_type;
   using mag_type        = typename Kokkos::ArithTraits<scalar_type>::mag_type;

--- a/blas/unit_test/Test_Blas1_swap.hpp
+++ b/blas/unit_test/Test_Blas1_swap.hpp
@@ -3,11 +3,12 @@
 namespace Test {
 namespace Impl {
 
-template <class VectorType>
+template <class ScalarType, class DeviceType>
 void test_swap(int const vector_length) {
-  using vector_type     = VectorType;
-  using execution_space = typename vector_type::execution_space;
-  using scalar_type     = typename VectorType::non_const_value_type;
+  using execution_space = typename DeviceType::execution_space;
+  using memory_space    = typename DeviceType::execution_space;
+  using vector_type     = Kokkos::View<ScalarType*, memory_space>;
+  using scalar_type     = typename vector_type::non_const_value_type;
   using mag_type        = typename Kokkos::ArithTraits<scalar_type>::mag_type;
 
   // Note that Xref and Yref need to always be copies of X and Y
@@ -43,14 +44,12 @@ void test_swap(int const vector_length) {
 }  // namespace Impl
 }  // namespace Test
 
-template <class scalar_type, class execution_space>
+template <class ScalarType, class DeviceType>
 int test_swap() {
-  using Vector = Kokkos::View<scalar_type*, execution_space>;
-
-  Test::Impl::test_swap<Vector>(0);
-  Test::Impl::test_swap<Vector>(10);
-  Test::Impl::test_swap<Vector>(256);
-  Test::Impl::test_swap<Vector>(1024);
+  Test::Impl::test_swap<ScalarType, DeviceType>(0);
+  Test::Impl::test_swap<ScalarType, DeviceType>(10);
+  Test::Impl::test_swap<ScalarType, DeviceType>(256);
+  Test::Impl::test_swap<ScalarType, DeviceType>(1024);
 
   return 0;
 }

--- a/lapack/src/KokkosLapack_gesv.hpp
+++ b/lapack/src/KokkosLapack_gesv.hpp
@@ -40,6 +40,8 @@ namespace KokkosLapack {
 /// 1-D or 2-D Kokkos::View.
 /// \tparam IPIVV Output pivot indices, as a 1-D Kokkos::View
 ///
+/// \param space [in] execution space instance used to specified how to execute
+///   the gesv kernels.
 /// \param A [in,out] On entry, the N-by-N matrix to be solved. On exit, the
 /// factors L and U from
 ///   the factorization A = P*L*U; the unit diagonal elements of L are not
@@ -164,6 +166,29 @@ void gesv(const ExecutionSpace& space, const AMatrix& A, const BXMV& B,
     KokkosLapack::Impl::GESV<ExecutionSpace, AMatrix_Internal, BXMV_Internal,
                              IPIVV_Internal>::gesv(space, A_i, B_i, IPIV_i);
   }
+}
+
+/// \brief Solve the dense linear equation system A*X = B.
+///
+/// \tparam AMatrix Input matrix/Output LU, as a 2-D Kokkos::View.
+/// \tparam BXMV Input (right-hand side)/Output (solution) (multi)vector, as a
+/// 1-D or 2-D Kokkos::View.
+/// \tparam IPIVV Output pivot indices, as a 1-D Kokkos::View
+///
+/// \param A [in,out] On entry, the N-by-N matrix to be solved. On exit, the
+/// factors L and U from
+///   the factorization A = P*L*U; the unit diagonal elements of L are not
+///   stored.
+/// \param B [in,out] On entry, the right hand side (multi)vector B. On exit,
+/// the solution (multi)vector X.
+/// \param IPIV [out] On exit, the pivot indices (for partial pivoting).
+/// If the View extents are zero and its data pointer is NULL, pivoting is not
+/// used.
+///
+template <class AMatrix, class BXMV, class IPIVV>
+void gesv(const AMatrix& A, const BXMV& B, const IPIVV& IPIV) {
+  typename AMatrix::execution_space space{};
+  gesv(space, A, B, IPIV);
 }
 
 }  // namespace KokkosLapack

--- a/lapack/tpls/KokkosLapack_Cuda_tpl.hpp
+++ b/lapack/tpls/KokkosLapack_Cuda_tpl.hpp
@@ -40,7 +40,7 @@ CudaLapackSingleton& CudaLapackSingleton::singleton() {
 #endif  // defined (KOKKOSKERNELS_ENABLE_TPL_CUSOLVER)
 
 #if defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA)
-#include <KokkosLapack_tpl_spec.hpp>
+#include <KokkosLapack_magma.hpp>
 
 namespace KokkosLapack {
 namespace Impl {

--- a/lapack/tpls/KokkosLapack_gesv_tpl_spec_avail.hpp
+++ b/lapack/tpls/KokkosLapack_gesv_tpl_spec_avail.hpp
@@ -50,10 +50,15 @@ KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_LAPACK(Kokkos::complex<double>,
 KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_LAPACK(Kokkos::complex<float>,
                                         Kokkos::LayoutLeft, Kokkos::HostSpace)
 #endif
+}  // namespace Impl
+}  // namespace KokkosLapack
 
 // MAGMA
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MAGMA
+#include "magma_v2.h"
 
+namespace KokkosLapack {
+namespace Impl {
 #define KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(SCALAR, LAYOUT, MEMSPACE)     \
   template <>                                                                \
   struct gesv_tpl_spec_avail<                                                \
@@ -62,7 +67,9 @@ KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_LAPACK(Kokkos::complex<float>,
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                \
-      Kokkos::View<int*, LAYOUT, Kokkos::HostSpace,                          \
+      Kokkos::View<magma_int_t*, LAYOUT,                                     \
+                   Kokkos::Device<Kokkos::DefaultHostExecutionSpace,         \
+                                  Kokkos::HostSpace>,                        \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {             \
     enum : bool { value = true };                                            \
   };
@@ -75,9 +82,9 @@ KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(Kokkos::complex<double>,
                                        Kokkos::LayoutLeft, Kokkos::CudaSpace)
 KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(Kokkos::complex<float>,
                                        Kokkos::LayoutLeft, Kokkos::CudaSpace)
-#endif
 }  // namespace Impl
 }  // namespace KokkosLapack
+#endif  // KOKKOSKERNELS_ENABLE_TPL_MAGMA
 
 // CUSOLVER
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSOLVER
@@ -105,6 +112,19 @@ KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_CUSOLVER(Kokkos::complex<double>,
                                           Kokkos::LayoutLeft, Kokkos::CudaSpace)
 KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_CUSOLVER(Kokkos::complex<float>,
                                           Kokkos::LayoutLeft, Kokkos::CudaSpace)
+
+#if defined(KOKKOSKERNELS_INST_MEMSPACE_CUDAUVMSPACE)
+KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_CUSOLVER(double, Kokkos::LayoutLeft,
+                                          Kokkos::CudaUVMSpace)
+KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_CUSOLVER(float, Kokkos::LayoutLeft,
+                                          Kokkos::CudaUVMSpace)
+KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_CUSOLVER(Kokkos::complex<double>,
+                                          Kokkos::LayoutLeft,
+                                          Kokkos::CudaUVMSpace)
+KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_CUSOLVER(Kokkos::complex<float>,
+                                          Kokkos::LayoutLeft,
+                                          Kokkos::CudaUVMSpace)
+#endif
 
 }  // namespace Impl
 }  // namespace KokkosLapack

--- a/lapack/tpls/KokkosLapack_gesv_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_gesv_tpl_spec_decl.hpp
@@ -138,23 +138,35 @@ KOKKOSLAPACK_GESV_LAPACK(Kokkos::complex<double>, Kokkos::LayoutLeft,
                          Kokkos::OpenMP, Kokkos::HostSpace)
 #endif
 
+#if defined(KOKKOS_ENABLE_THREADS)
+KOKKOSLAPACK_GESV_LAPACK(float, Kokkos::LayoutLeft, Kokkos::Threads,
+                         Kokkos::HostSpace)
+KOKKOSLAPACK_GESV_LAPACK(double, Kokkos::LayoutLeft, Kokkos::Threads,
+                         Kokkos::HostSpace)
+KOKKOSLAPACK_GESV_LAPACK(Kokkos::complex<float>, Kokkos::LayoutLeft,
+                         Kokkos::Threads, Kokkos::HostSpace)
+KOKKOSLAPACK_GESV_LAPACK(Kokkos::complex<double>, Kokkos::LayoutLeft,
+                         Kokkos::Threads, Kokkos::HostSpace)
+#endif
+
 }  // namespace Impl
 }  // namespace KokkosLapack
 #endif  // KOKKOSKERNELS_ENABLE_TPL_LAPACK
 
 // MAGMA
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MAGMA
-#include <KokkosLapack_tpl_spec.hpp>
+#include <KokkosLapack_Cuda_tpl.hpp>
 
 namespace KokkosLapack {
 namespace Impl {
 
 #define KOKKOSLAPACK_DGESV_MAGMA(LAYOUT, MEM_SPACE, ETI_SPEC_AVAIL)           \
-  template <class ExecSpace>                                                  \
+  template <>                                                                 \
   struct GESV<                                                                \
-      Kokkos::View<double**, LAYOUT, Kokkos::Device<ExecSpace, MEM_SPACE>,    \
+      Kokkos::Cuda,                                                           \
+      Kokkos::View<double**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
-      Kokkos::View<double**, LAYOUT, Kokkos::Device<ExecSpace, MEM_SPACE>,    \
+      Kokkos::View<double**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
       Kokkos::View<magma_int_t*, LAYOUT,                                      \
                    Kokkos::Device<Kokkos::DefaultHostExecutionSpace,          \
@@ -163,11 +175,11 @@ namespace Impl {
       true, ETI_SPEC_AVAIL> {                                                 \
     typedef double SCALAR;                                                    \
     typedef Kokkos::View<SCALAR**, LAYOUT,                                    \
-                         Kokkos::Device<ExecSpace, MEM_SPACE>,                \
+                         Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,             \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>             \
         AViewType;                                                            \
     typedef Kokkos::View<SCALAR**, LAYOUT,                                    \
-                         Kokkos::Device<ExecSpace, MEM_SPACE>,                \
+                         Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,             \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>             \
         BViewType;                                                            \
     typedef Kokkos::View<                                                     \
@@ -176,8 +188,8 @@ namespace Impl {
         Kokkos::MemoryTraits<Kokkos::Unmanaged>>                              \
         PViewType;                                                            \
                                                                               \
-    static void gesv(const AViewType& A, const BViewType& B,                  \
-                     const PViewType& IPIV) {                                 \
+    static void gesv(const Kokkos::Cuda& /*space*/, const AViewType& A,       \
+                     const BViewType& B, const PViewType& IPIV) {             \
       Kokkos::Profiling::pushRegion("KokkosLapack::gesv[TPL_MAGMA,double]");  \
       gesv_print_specialization<AViewType, BViewType, PViewType>();           \
       const bool with_pivot =                                                 \
@@ -209,11 +221,12 @@ namespace Impl {
   };
 
 #define KOKKOSLAPACK_SGESV_MAGMA(LAYOUT, MEM_SPACE, ETI_SPEC_AVAIL)           \
-  template <class ExecSpace>                                                  \
+  template <>                                                                 \
   struct GESV<                                                                \
-      Kokkos::View<float**, LAYOUT, Kokkos::Device<ExecSpace, MEM_SPACE>,     \
+      Kokkos::Cuda,                                                           \
+      Kokkos::View<float**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,  \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
-      Kokkos::View<float**, LAYOUT, Kokkos::Device<ExecSpace, MEM_SPACE>,     \
+      Kokkos::View<float**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,  \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                  \
       Kokkos::View<magma_int_t*, LAYOUT,                                      \
                    Kokkos::Device<Kokkos::DefaultHostExecutionSpace,          \
@@ -222,11 +235,11 @@ namespace Impl {
       true, ETI_SPEC_AVAIL> {                                                 \
     typedef float SCALAR;                                                     \
     typedef Kokkos::View<SCALAR**, LAYOUT,                                    \
-                         Kokkos::Device<ExecSpace, MEM_SPACE>,                \
+                         Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,             \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>             \
         AViewType;                                                            \
     typedef Kokkos::View<SCALAR**, LAYOUT,                                    \
-                         Kokkos::Device<ExecSpace, MEM_SPACE>,                \
+                         Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,             \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>             \
         BViewType;                                                            \
     typedef Kokkos::View<                                                     \
@@ -235,8 +248,8 @@ namespace Impl {
         Kokkos::MemoryTraits<Kokkos::Unmanaged>>                              \
         PViewType;                                                            \
                                                                               \
-    static void gesv(const AViewType& A, const BViewType& B,                  \
-                     const PViewType& IPIV) {                                 \
+    static void gesv(const Kokkos::Cuda& /*space*/, const AViewType& A,       \
+                     const BViewType& B, const PViewType& IPIV) {             \
       Kokkos::Profiling::pushRegion("KokkosLapack::gesv[TPL_MAGMA,float]");   \
       gesv_print_specialization<AViewType, BViewType, PViewType>();           \
       const bool with_pivot =                                                 \
@@ -268,12 +281,13 @@ namespace Impl {
   };
 
 #define KOKKOSLAPACK_ZGESV_MAGMA(LAYOUT, MEM_SPACE, ETI_SPEC_AVAIL)           \
-  template <class ExecSpace>                                                  \
-  struct GESV<Kokkos::View<Kokkos::complex<double>**, LAYOUT,                 \
-                           Kokkos::Device<ExecSpace, MEM_SPACE>,              \
+  template <>                                                                 \
+  struct GESV<Kokkos::Cuda,                                                   \
+              Kokkos::View<Kokkos::complex<double>**, LAYOUT,                 \
+                           Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,           \
                            Kokkos::MemoryTraits<Kokkos::Unmanaged>>,          \
               Kokkos::View<Kokkos::complex<double>**, LAYOUT,                 \
-                           Kokkos::Device<ExecSpace, MEM_SPACE>,              \
+                           Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,           \
                            Kokkos::MemoryTraits<Kokkos::Unmanaged>>,          \
               Kokkos::View<magma_int_t*, LAYOUT,                              \
                            Kokkos::Device<Kokkos::DefaultHostExecutionSpace,  \
@@ -282,11 +296,11 @@ namespace Impl {
               true, ETI_SPEC_AVAIL> {                                         \
     typedef Kokkos::complex<double> SCALAR;                                   \
     typedef Kokkos::View<SCALAR**, LAYOUT,                                    \
-                         Kokkos::Device<ExecSpace, MEM_SPACE>,                \
+                         Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,             \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>             \
         AViewType;                                                            \
     typedef Kokkos::View<SCALAR**, LAYOUT,                                    \
-                         Kokkos::Device<ExecSpace, MEM_SPACE>,                \
+                         Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,             \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>             \
         BViewType;                                                            \
     typedef Kokkos::View<                                                     \
@@ -295,8 +309,8 @@ namespace Impl {
         Kokkos::MemoryTraits<Kokkos::Unmanaged>>                              \
         PViewType;                                                            \
                                                                               \
-    static void gesv(const AViewType& A, const BViewType& B,                  \
-                     const PViewType& IPIV) {                                 \
+    static void gesv(const Kokkos::Cuda& /*space*/, const AViewType& A,       \
+                     const BViewType& B, const PViewType& IPIV) {             \
       Kokkos::Profiling::pushRegion(                                          \
           "KokkosLapack::gesv[TPL_MAGMA,complex<double>]");                   \
       gesv_print_specialization<AViewType, BViewType, PViewType>();           \
@@ -329,12 +343,13 @@ namespace Impl {
   };
 
 #define KOKKOSLAPACK_CGESV_MAGMA(LAYOUT, MEM_SPACE, ETI_SPEC_AVAIL)           \
-  template <class ExecSpace>                                                  \
-  struct GESV<Kokkos::View<Kokkos::complex<float>**, LAYOUT,                  \
-                           Kokkos::Device<ExecSpace, MEM_SPACE>,              \
+  template <>                                                                 \
+  struct GESV<Kokkos::Cuda,                                                   \
+              Kokkos::View<Kokkos::complex<float>**, LAYOUT,                  \
+                           Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,           \
                            Kokkos::MemoryTraits<Kokkos::Unmanaged>>,          \
               Kokkos::View<Kokkos::complex<float>**, LAYOUT,                  \
-                           Kokkos::Device<ExecSpace, MEM_SPACE>,              \
+                           Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,           \
                            Kokkos::MemoryTraits<Kokkos::Unmanaged>>,          \
               Kokkos::View<magma_int_t*, LAYOUT,                              \
                            Kokkos::Device<Kokkos::DefaultHostExecutionSpace,  \
@@ -343,11 +358,11 @@ namespace Impl {
               true, ETI_SPEC_AVAIL> {                                         \
     typedef Kokkos::complex<float> SCALAR;                                    \
     typedef Kokkos::View<SCALAR**, LAYOUT,                                    \
-                         Kokkos::Device<ExecSpace, MEM_SPACE>,                \
+                         Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,             \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>             \
         AViewType;                                                            \
     typedef Kokkos::View<SCALAR**, LAYOUT,                                    \
-                         Kokkos::Device<ExecSpace, MEM_SPACE>,                \
+                         Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,             \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>             \
         BViewType;                                                            \
     typedef Kokkos::View<                                                     \
@@ -356,8 +371,8 @@ namespace Impl {
         Kokkos::MemoryTraits<Kokkos::Unmanaged>>                              \
         PViewType;                                                            \
                                                                               \
-    static void gesv(const AViewType& A, const BViewType& B,                  \
-                     const PViewType& IPIV) {                                 \
+    static void gesv(const Kokkos::Cuda& /*space*/, const AViewType& A,       \
+                     const BViewType& B, const PViewType& IPIV) {             \
       Kokkos::Profiling::pushRegion(                                          \
           "KokkosLapack::gesv[TPL_MAGMA,complex<float>]");                    \
       gesv_print_specialization<AViewType, BViewType, PViewType>();           \

--- a/lapack/tpls/KokkosLapack_magma.hpp
+++ b/lapack/tpls/KokkosLapack_magma.hpp
@@ -1,0 +1,39 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOSLAPACK_MAGMA_HPP_
+#define KOKKOSLAPACK_MAGMA_HPP_
+
+#ifdef KOKKOSKERNELS_ENABLE_TPL_MAGMA
+#include "magma_v2.h"
+
+namespace KokkosLapack {
+namespace Impl {
+
+// Declaration of the singleton for cusolver
+// this is the only header that needs to be
+// included when using cusolverDn.
+struct MagmaSingleton {
+  MagmaSingleton();
+
+  static MagmaSingleton& singleton();
+};
+
+}  // namespace Impl
+}  // namespace KokkosLapack
+#endif
+
+#endif  // KOKKOSLAPACK_MAGMA_HPP_

--- a/lapack/tpls/KokkosLapack_trtri_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_trtri_tpl_spec_decl.hpp
@@ -18,7 +18,10 @@
 #define KOKKOSLAPACK_TRTRI_TPL_SPEC_DECL_HPP_
 
 #include "KokkosLapack_Host_tpl.hpp"  // trtri prototype
-//#include "KokkosLapack_tpl_spec.hpp"
+
+#ifdef KOKKOSKERNELS_ENABLE_TPL_MAGMA
+#include "KokkosLapack_magma.hpp"
+#endif
 
 namespace KokkosLapack {
 namespace Impl {

--- a/lapack/unit_test/Test_Lapack_gesv.hpp
+++ b/lapack/unit_test/Test_Lapack_gesv.hpp
@@ -268,6 +268,13 @@ int test_gesv(const char* mode) {
   using view_type_a_ll = Kokkos::View<Scalar**, Kokkos::LayoutLeft, Device>;
   using view_type_b_ll = Kokkos::View<Scalar*, Kokkos::LayoutLeft, Device>;
 
+#if (defined(TEST_CUDA_LAPACK_CPP) &&                                       \
+     defined(KOKKOSKERNELS_ENABLE_TPL_CUSOLVER)) ||                         \
+    (defined(TEST_HIP_LAPACK_CPP) &&                                        \
+     defined(KOKKOSKERNELS_ENABLE_TPL_ROCSOLVER)) ||                        \
+    (defined(KOKKOSKERNELS_ENABLE_TPL_LAPACK) &&                            \
+     (defined(TEST_OPENMP_LAPACK_CPP) || defined(TEST_SERIAL_LAPACK_CPP) || \
+      defined(TEST_THREADS_LAPACK_CPP)))
   Test::impl_test_gesv<view_type_a_ll, view_type_b_ll, Device, false>(
       &mode[0], "N", 2);  // no padding
   Test::impl_test_gesv<view_type_a_ll, view_type_b_ll, Device, false>(
@@ -279,7 +286,7 @@ int test_gesv(const char* mode) {
   Test::impl_test_gesv<view_type_a_ll, view_type_b_ll, Device, false>(
       &mode[0], "N", 1024);  // no padding
 
-#if defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA) && defined(KOKKOS_ENABLE_CUDA)
+#elif defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA) && defined(KOKKOS_ENABLE_CUDA)
   if constexpr (std::is_same_v<Kokkos::Cuda,
                                typename Device::execution_space>) {
     Test::impl_test_gesv<view_type_a_ll, view_type_b_ll, Device, true>(
@@ -316,6 +323,13 @@ int test_gesv_mrhs(const char* mode) {
   using view_type_a_ll = Kokkos::View<Scalar**, Kokkos::LayoutLeft, Device>;
   using view_type_b_ll = Kokkos::View<Scalar**, Kokkos::LayoutLeft, Device>;
 
+#if (defined(TEST_CUDA_LAPACK_CPP) &&                                       \
+     defined(KOKKOSKERNELS_ENABLE_TPL_CUSOLVER)) ||                         \
+    (defined(TEST_HIP_LAPACK_CPP) &&                                        \
+     defined(KOKKOSKERNELS_ENABLE_TPL_ROCSOLVER)) ||                        \
+    (defined(KOKKOSKERNELS_ENABLE_TPL_LAPACK) &&                            \
+     (defined(TEST_OPENMP_LAPACK_CPP) || defined(TEST_SERIAL_LAPACK_CPP) || \
+      defined(TEST_THREADS_LAPACK_CPP)))
   Test::impl_test_gesv_mrhs<view_type_a_ll, view_type_b_ll, Device, false>(
       &mode[0], "N", 2, 5);  // no padding
   Test::impl_test_gesv_mrhs<view_type_a_ll, view_type_b_ll, Device, false>(
@@ -328,7 +342,7 @@ int test_gesv_mrhs(const char* mode) {
       &mode[0], "N", 1024, 5);  // no padding
 
 // When appropriate run MAGMA specific tests
-#if defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA) && defined(KOKKOS_ENABLE_CUDA)
+#elif defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA) && defined(KOKKOS_ENABLE_CUDA)
   if constexpr (std::is_same_v<Kokkos::Cuda,
                                typename Device::execution_space>) {
     Test::impl_test_gesv_mrhs<view_type_a_ll, view_type_b_ll, Device, true>(


### PR DESCRIPTION
Adding proper support for MAGMA after having it moved to the Lapack directory and checking it does not create issues with cuSOLVER.
This revealed an issue with how batched gemm and batched linear algebra works in general.