### PR TITLE
BLAS: fix bug in TPL layer of KokkosBlas::swap

### DIFF
--- a/blas/tpls/KokkosBlas1_swap_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_swap_tpl_spec_decl.hpp
@@ -293,10 +293,10 @@ namespace Impl {
                            Kokkos::Device<EXECSPACE, MEMSPACE>,             \
                            Kokkos::MemoryTraits<Kokkos::Unmanaged>>,        \
               true, ETI_SPEC_AVAIL> {                                       \
-    using XVector = Kokkos::View<Kokkos::complex<float>, LAYOUT,            \
+    using XVector = Kokkos::View<Kokkos::complex<float>*, LAYOUT,           \
                                  Kokkos::Device<EXECSPACE, MEMSPACE>,       \
                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;  \
-    using YVector = Kokkos::View<Kokkos::complex<float>, LAYOUT,            \
+    using YVector = Kokkos::View<Kokkos::complex<float>*, LAYOUT,           \
                                  Kokkos::Device<EXECSPACE, MEMSPACE>,       \
                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;  \
     static void swap(EXECSPACE const& space, XVector const& X,              \


### PR DESCRIPTION
The cuBLAS Kokkos::complex<float> specialization had a small bug where the rank of the view was not specified correctly!