### PR TITLE
Allow `KokkosKernels_ENABLE_PERFTESTS=ON` to build `perf_test` without `KokkosKernels_ENABLE_TESTS=ON`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -427,7 +427,7 @@ ELSE()
   IF (KOKKOSKERNELS_ALL_COMPONENTS_ENABLED)
     IF (KokkosKernels_ENABLE_PERFTESTS)
       MESSAGE(STATUS "Enabling perf tests.")
-      KOKKOSKERNELS_ADD_TEST_DIRECTORIES(perf_test)
+      add_subdirectory(perf_test) # doesn't require KokkosKernels_ENABLE_TESTS=ON
     ENDIF ()
     IF (KokkosKernels_ENABLE_EXAMPLES)
       MESSAGE(STATUS "Enabling examples.")


### PR DESCRIPTION
Sometimes I want the `perf_test` and I don't want the unit tests

Before:
```
-DKokkosKernels_ENABLE_TESTS=OFF \
-DKokkosKernels_ENABLE_PERFTESTS=ON
```
results in no `perf_test`

After
```
-DKokkosKernels_ENABLE_TESTS=OFF \ # or =ON
-DKokkosKernels_ENABLE_PERFTESTS=ON
```

gets the `perf_test`