### PR TITLE
fence Kokkos before timed iterations

### DIFF
--- a/perf_test/sparse/KokkosSparse_spmv_benchmark.cpp
+++ b/perf_test/sparse/KokkosSparse_spmv_benchmark.cpp
@@ -132,6 +132,7 @@ void run_spmv(benchmark::State& state, const spmv_parameters& inputs) {
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
   Kokkos::fill_random(x, rand_pool, 10);
   Kokkos::fill_random(y, rand_pool, 10);
+  Kokkos::fence();
 
   // Run the actual experiments
   for (auto _ : state) {


### PR DESCRIPTION
Can greatly impact reported timing from this benchmark (100x observed on Aurora)