### PR TITLE
Deprecate `KOKKOSLINALG_OPT_LEVEL`

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -227,7 +227,7 @@ endif()
 * KokkosKernels_LAPACK_ROOT: PATH
   * Location of LAPACK install root.
   * Default: None or the value of the environment variable LAPACK_ROOT if set
-* KokkosKernels_LINALG_OPT_LEVEL: BOOL
+* KokkosKernels_LINALG_OPT_LEVEL: BOOL **DEPRECATED**
   * Optimization level for KokkosKernels computational kernels: a nonnegative integer.  Higher levels result in better performance that is more uniform for corner cases, but increase build time and library size.  The default value is 1, which should give performance within ten percent of optimal on most platforms, for most problems.
   * Default: 1
 * KokkosKernels_MAGMA_ROOT: PATH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,13 @@ ELSE()
     "DEPRECATED. Optimization level for KokkosKernels computational kernels: a nonnegative integer.  Higher levels result in better performance that is more uniform for corner cases, but increase build time and library size.  The default value is 1, which should give performance within ten percent of optimal on most platforms, for most problems. Default: 1"
     "1")
 
+  if (KokkosKernels_LINALG_OPT_LEVEL AND NOT KokkosKernels_LINALG_OPT_LEVEL STREQUAL "1")
+   message(WARNING "KokkosKernels_LINALG_OPT_LEVEL is deprecated!")
+ endif()
+  if(KokkosKernels_KOKKOSLINALG_OPT_LEVEL AND NOT KokkosKernels_KOKKOSLINALG_OPT_LEVEL STREQUAL "1")
+    message(WARNING "KokkosKernels_KOKKOSLINALG_OPT_LEVEL is deprecated!")
+  endif()
+
   # Enable experimental features of KokkosKernels if set at configure
   # time. Default is no.
   KOKKOSKERNELS_ADD_OPTION_AND_DEFINE(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ ELSE()
   KOKKOSKERNELS_ADD_OPTION_AND_DEFINE(
     LINALG_OPT_LEVEL
     KOKKOSLINALG_OPT_LEVEL
-    "Optimization level for KokkosKernels computational kernels: a nonnegative integer.  Higher levels result in better performance that is more uniform for corner cases, but increase build time and library size.  The default value is 1, which should give performance within ten percent of optimal on most platforms, for most problems. Default: 1"
+    "DEPRECATED. Optimization level for KokkosKernels computational kernels: a nonnegative integer.  Higher levels result in better performance that is more uniform for corner cases, but increase build time and library size.  The default value is 1, which should give performance within ten percent of optimal on most platforms, for most problems. Default: 1"
     "1")
 
   # Enable experimental features of KokkosKernels if set at configure

--- a/common/src/KokkosLinAlg_config.h
+++ b/common/src/KokkosLinAlg_config.h
@@ -18,6 +18,8 @@
 #ifndef KOKKOSLINALG_CONFIG_H
 #define KOKKOSLINALG_CONFIG_H
 
+[[deprecated("KokkosLinAlg_config.h is deprecated!")]]
+
 #include <KokkosKernels_config.h>
 
 #endif  // KOKKOSLINALG_CONFIG_H


### PR DESCRIPTION
Two reasons:

1. we don't use it anywhere
2. Kokkos namespace