### PR TITLE
Correcting BLAS test failures with cuda when ETI_ONLY = OFF (issue #2061)

### DIFF
--- a/blas/tpls/KokkosBlas2_ger_tpl_spec_decl_blas.hpp
+++ b/blas/tpls/KokkosBlas2_ger_tpl_spec_decl_blas.hpp
@@ -149,8 +149,7 @@ namespace Impl {
                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>            \
         AViewType;                                                           \
                                                                              \
-    static void ger(const EXEC_SPACE& space,                                 \
-                    const char trans[],                                      \
+    static void ger(const EXEC_SPACE& space, const char trans[],             \
                     typename AViewType::const_value_type& alpha,             \
                     const XViewType& X, const YViewType& Y,                  \
                     const AViewType& A) {                                    \
@@ -218,8 +217,7 @@ namespace Impl {
                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>            \
         AViewType;                                                           \
                                                                              \
-    static void ger(const EXEC_SPACE& space,                                 \
-                    const char trans[],                                      \
+    static void ger(const EXEC_SPACE& space, const char trans[],             \
                     typename AViewType::const_value_type& alpha,             \
                     const XViewType& X, const YViewType& Y,                  \
                     const AViewType& A) {                                    \

--- a/blas/tpls/KokkosBlas2_ger_tpl_spec_decl_blas.hpp
+++ b/blas/tpls/KokkosBlas2_ger_tpl_spec_decl_blas.hpp
@@ -183,8 +183,9 @@ namespace Impl {
               reinterpret_cast<const std::complex<double>*>(X.data()), one,  \
               reinterpret_cast<std::complex<double>*>(A.data()), LDA);       \
         } else {                                                             \
-          throw std::runtime_error(                                          \
-              "Error: blasZgerc() requires LayoutLeft views.");              \
+          /* blasgerc() + ~A_ll => call kokkos-kernels' implementation */    \
+          GER<EXEC_SPACE, XViewType, YViewType, AViewType, false, ETI_SPEC_AVAIL>::ger( \
+            space, trans, alpha, X, Y, A);                                   \
         }                                                                    \
       }                                                                      \
       Kokkos::Profiling::popRegion();                                        \
@@ -252,8 +253,9 @@ namespace Impl {
               reinterpret_cast<const std::complex<float>*>(X.data()), one,   \
               reinterpret_cast<std::complex<float>*>(A.data()), LDA);        \
         } else {                                                             \
-          throw std::runtime_error(                                          \
-              "Error: blasCgerc() requires LayoutLeft views.");              \
+          /* blasgerc() + ~A_ll => call kokkos-kernels' implementation */    \
+          GER<EXEC_SPACE, XViewType, YViewType, AViewType, false, ETI_SPEC_AVAIL>::ger( \
+            space, trans, alpha, X, Y, A);                                   \
         }                                                                    \
       }                                                                      \
       Kokkos::Profiling::popRegion();                                        \

--- a/blas/tpls/KokkosBlas2_ger_tpl_spec_decl_blas.hpp
+++ b/blas/tpls/KokkosBlas2_ger_tpl_spec_decl_blas.hpp
@@ -149,8 +149,7 @@ namespace Impl {
                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>            \
         AViewType;                                                           \
                                                                              \
-    static void ger(const EXEC_SPACE& /* space */                            \
-                    ,                                                        \
+    static void ger(const EXEC_SPACE& space,                                 \
                     const char trans[],                                      \
                     typename AViewType::const_value_type& alpha,             \
                     const XViewType& X, const YViewType& Y,                  \
@@ -219,8 +218,7 @@ namespace Impl {
                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>            \
         AViewType;                                                           \
                                                                              \
-    static void ger(const EXEC_SPACE& /* space */                            \
-                    ,                                                        \
+    static void ger(const EXEC_SPACE&,                                       \
                     const char trans[],                                      \
                     typename AViewType::const_value_type& alpha,             \
                     const XViewType& X, const YViewType& Y,                  \

--- a/blas/tpls/KokkosBlas2_ger_tpl_spec_decl_blas.hpp
+++ b/blas/tpls/KokkosBlas2_ger_tpl_spec_decl_blas.hpp
@@ -218,7 +218,7 @@ namespace Impl {
                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>            \
         AViewType;                                                           \
                                                                              \
-    static void ger(const EXEC_SPACE&,                                       \
+    static void ger(const EXEC_SPACE& space,                                 \
                     const char trans[],                                      \
                     typename AViewType::const_value_type& alpha,             \
                     const XViewType& X, const YViewType& Y,                  \

--- a/blas/tpls/KokkosBlas2_ger_tpl_spec_decl_blas.hpp
+++ b/blas/tpls/KokkosBlas2_ger_tpl_spec_decl_blas.hpp
@@ -184,8 +184,8 @@ namespace Impl {
               reinterpret_cast<std::complex<double>*>(A.data()), LDA);       \
         } else {                                                             \
           /* blasgerc() + ~A_ll => call kokkos-kernels' implementation */    \
-          GER<EXEC_SPACE, XViewType, YViewType, AViewType, false, ETI_SPEC_AVAIL>::ger( \
-            space, trans, alpha, X, Y, A);                                   \
+          GER<EXEC_SPACE, XViewType, YViewType, AViewType, false,            \
+              ETI_SPEC_AVAIL>::ger(space, trans, alpha, X, Y, A);            \
         }                                                                    \
       }                                                                      \
       Kokkos::Profiling::popRegion();                                        \
@@ -254,8 +254,8 @@ namespace Impl {
               reinterpret_cast<std::complex<float>*>(A.data()), LDA);        \
         } else {                                                             \
           /* blasgerc() + ~A_ll => call kokkos-kernels' implementation */    \
-          GER<EXEC_SPACE, XViewType, YViewType, AViewType, false, ETI_SPEC_AVAIL>::ger( \
-            space, trans, alpha, X, Y, A);                                   \
+          GER<EXEC_SPACE, XViewType, YViewType, AViewType, false,            \
+              ETI_SPEC_AVAIL>::ger(space, trans, alpha, X, Y, A);            \
         }                                                                    \
       }                                                                      \
       Kokkos::Profiling::popRegion();                                        \

--- a/blas/tpls/KokkosBlas2_ger_tpl_spec_decl_cublas.hpp
+++ b/blas/tpls/KokkosBlas2_ger_tpl_spec_decl_cublas.hpp
@@ -197,8 +197,8 @@ namespace Impl {
               reinterpret_cast<cuDoubleComplex*>(A.data()), LDA));             \
         } else {                                                               \
           /* cublasZgerc() + ~A_ll => call kokkos-kernels' implementation */   \
-          GER<EXEC_SPACE, XViewType, YViewType, AViewType, false, ETI_SPEC_AVAIL>::ger( \
-            space, trans, alpha, X, Y, A);                                     \
+          GER<EXEC_SPACE, XViewType, YViewType, AViewType, false,              \
+              ETI_SPEC_AVAIL>::ger(space, trans, alpha, X, Y, A);              \
         }                                                                      \
       }                                                                        \
       KOKKOS_CUBLAS_SAFE_CALL_IMPL(cublasSetStream(s.handle, NULL));           \
@@ -268,8 +268,8 @@ namespace Impl {
               reinterpret_cast<cuComplex*>(A.data()), LDA));                   \
         } else {                                                               \
           /* cublasCgerc() + ~A_ll => call kokkos-kernels' implementation */   \
-          GER<EXEC_SPACE, XViewType, YViewType, AViewType, false, ETI_SPEC_AVAIL>::ger( \
-            space, trans, alpha, X, Y, A);                                     \
+          GER<EXEC_SPACE, XViewType, YViewType, AViewType, false,              \
+              ETI_SPEC_AVAIL>::ger(space, trans, alpha, X, Y, A);              \
         }                                                                      \
       }                                                                        \
       KOKKOS_CUBLAS_SAFE_CALL_IMPL(cublasSetStream(s.handle, NULL));           \

--- a/blas/tpls/KokkosBlas2_ger_tpl_spec_decl_cublas.hpp
+++ b/blas/tpls/KokkosBlas2_ger_tpl_spec_decl_cublas.hpp
@@ -196,8 +196,9 @@ namespace Impl {
               reinterpret_cast<const cuDoubleComplex*>(X.data()), one,         \
               reinterpret_cast<cuDoubleComplex*>(A.data()), LDA));             \
         } else {                                                               \
-          throw std::runtime_error(                                            \
-              "Error: cublasZgerc() requires LayoutLeft views.");              \
+          /* cublasZgerc() + ~A_ll => call kokkos-kernels' implementation */   \
+          GER<EXEC_SPACE, XViewType, YViewType, AViewType, false, ETI_SPEC_AVAIL>::ger( \
+            space, trans, alpha, X, Y, A);                                     \
         }                                                                      \
       }                                                                        \
       KOKKOS_CUBLAS_SAFE_CALL_IMPL(cublasSetStream(s.handle, NULL));           \
@@ -266,8 +267,9 @@ namespace Impl {
               reinterpret_cast<const cuComplex*>(X.data()), one,               \
               reinterpret_cast<cuComplex*>(A.data()), LDA));                   \
         } else {                                                               \
-          throw std::runtime_error(                                            \
-              "Error: cublasCgerc() requires LayoutLeft views.");              \
+          /* cublasCgerc() + ~A_ll => call kokkos-kernels' implementation */   \
+          GER<EXEC_SPACE, XViewType, YViewType, AViewType, false, ETI_SPEC_AVAIL>::ger( \
+            space, trans, alpha, X, Y, A);                                     \
         }                                                                      \
       }                                                                        \
       KOKKOS_CUBLAS_SAFE_CALL_IMPL(cublasSetStream(s.handle, NULL));           \

--- a/blas/tpls/KokkosBlas2_ger_tpl_spec_decl_rocblas.hpp
+++ b/blas/tpls/KokkosBlas2_ger_tpl_spec_decl_rocblas.hpp
@@ -200,8 +200,8 @@ namespace Impl {
               reinterpret_cast<rocblas_double_complex*>(A.data()), LDA));     \
         } else {                                                              \
           /* rocblas_zgerc() + ~A_ll => call k-kernels' implementation */     \
-          GER<EXEC_SPACE, XViewType, YViewType, AViewType, false, ETI_SPEC_AVAIL>::ger( \
-            space, trans, alpha, X, Y, A);                                    \
+          GER<EXEC_SPACE, XViewType, YViewType, AViewType, false,             \
+              ETI_SPEC_AVAIL>::ger(space, trans, alpha, X, Y, A);             \
         }                                                                     \
       }                                                                       \
       KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL));      \
@@ -275,8 +275,8 @@ namespace Impl {
               reinterpret_cast<rocblas_float_complex*>(A.data()), LDA));     \
         } else {                                                             \
           /* rocblas_cgerc() + ~A_ll => call k-kernels' implementation */    \
-          GER<EXEC_SPACE, XViewType, YViewType, AViewType, false, ETI_SPEC_AVAIL>::ger( \
-            space, trans, alpha, X, Y, A);                                   \
+          GER<EXEC_SPACE, XViewType, YViewType, AViewType, false,            \
+              ETI_SPEC_AVAIL>::ger(space, trans, alpha, X, Y, A);            \
         }                                                                    \
       }                                                                      \
       KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL));     \

--- a/blas/tpls/KokkosBlas2_ger_tpl_spec_decl_rocblas.hpp
+++ b/blas/tpls/KokkosBlas2_ger_tpl_spec_decl_rocblas.hpp
@@ -199,8 +199,9 @@ namespace Impl {
               reinterpret_cast<const rocblas_double_complex*>(X.data()), one, \
               reinterpret_cast<rocblas_double_complex*>(A.data()), LDA));     \
         } else {                                                              \
-          throw std::runtime_error(                                           \
-              "Error: rocblasZgerc() requires LayoutLeft views.");            \
+          /* rocblas_zgerc() + ~A_ll => call k-kernels' implementation */     \
+          GER<EXEC_SPACE, XViewType, YViewType, AViewType, false, ETI_SPEC_AVAIL>::ger( \
+            space, trans, alpha, X, Y, A);                                    \
         }                                                                     \
       }                                                                       \
       KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL));      \
@@ -273,8 +274,9 @@ namespace Impl {
               reinterpret_cast<const rocblas_float_complex*>(X.data()), one, \
               reinterpret_cast<rocblas_float_complex*>(A.data()), LDA));     \
         } else {                                                             \
-          throw std::runtime_error(                                          \
-              "Error: rocblasCgec() requires LayoutLeft views.");            \
+          /* rocblas_cgerc() + ~A_ll => call k-kernels' implementation */    \
+          GER<EXEC_SPACE, XViewType, YViewType, AViewType, false, ETI_SPEC_AVAIL>::ger( \
+            space, trans, alpha, X, Y, A);                                   \
         }                                                                    \
       }                                                                      \
       KOKKOS_ROCBLAS_SAFE_CALL_IMPL(rocblas_set_stream(s.handle, NULL));     \

--- a/blas/unit_test/Test_Blas1_axpby_unification.hpp
+++ b/blas/unit_test/Test_Blas1_axpby_unification.hpp
@@ -98,18 +98,21 @@ void impl_test_axpby_unification_compare(
     Test::getRandomBounds(max_val, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
+  std::cout << "kdc a-001" << std::endl;
   Kokkos::deep_copy(x.h_view, x.d_view);
 
   {
     ScalarTypeY randStart, randEnd;
     Test::getRandomBounds(max_val, randStart, randEnd);
     if (testWithNanY) {
+      std::cout << "kdc a-002" << std::endl;
       Kokkos::deep_copy(y.d_view, Kokkos::ArithTraits<ScalarTypeY>::nan());
     } else {
       Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
     }
   }
   tY org_y("Org_Y", N);
+  std::cout << "kdc a-003" << std::endl;
   Kokkos::deep_copy(org_y.h_view, y.d_view);
 
   tScalarA valueA(Kokkos::ArithTraits<tScalarA>::zero());
@@ -126,11 +129,13 @@ void impl_test_axpby_unification_compare(
         valueB = inputValueB;
       } else {
         typename tB::HostMirror h_b("h_B");
+        std::cout << "kdc a-004" << std::endl;
         Kokkos::deep_copy(h_b, b);
         valueB = h_b();
       }
       KokkosBlas::axpby(a, x.d_view, b, y.d_view);
     } else {
+      std::cout << "kdc a-005" << std::endl;
       Kokkos::deep_copy(b.h_view, b.d_view);
       valueB = b.h_view(0);
       KokkosBlas::axpby(a, x.d_view, b.d_view, y.d_view);
@@ -141,6 +146,7 @@ void impl_test_axpby_unification_compare(
       valueA = inputValueA;
     } else {
       typename tA::HostMirror h_a("h_A");
+      std::cout << "kdc a-006" << std::endl;
       Kokkos::deep_copy(h_a, a);
       valueA = h_a();
     }
@@ -153,16 +159,19 @@ void impl_test_axpby_unification_compare(
         valueB = inputValueB;
       } else {
         typename tB::HostMirror h_b("h_B");
+        std::cout << "kdc a-007" << std::endl;
         Kokkos::deep_copy(h_b, b);
         valueB = h_b();
       }
       KokkosBlas::axpby(a, x.d_view, b, y.d_view);
     } else {
+      std::cout << "kdc a-008" << std::endl;
       Kokkos::deep_copy(b.h_view, b.d_view);
       valueB = b.h_view(0);
       KokkosBlas::axpby(a, x.d_view, b.d_view, y.d_view);
     }
   } else {
+    std::cout << "kdc a-008" << std::endl;
     Kokkos::deep_copy(a.h_view, a.d_view);
     valueA = a.h_view(0);
     if constexpr (std::is_same_v<tB, tScalarB>) {
@@ -174,17 +183,20 @@ void impl_test_axpby_unification_compare(
         valueB = inputValueB;
       } else {
         typename tB::HostMirror h_b("h_B");
+        std::cout << "kdc a-009" << std::endl;
         Kokkos::deep_copy(h_b, b);
         valueB = h_b();
       }
       KokkosBlas::axpby(a.d_view, x.d_view, b, y.d_view);
     } else {
+      std::cout << "kdc a-010" << std::endl;
       Kokkos::deep_copy(b.h_view, b.d_view);
       valueB = b.h_view(0);
       KokkosBlas::axpby(a.d_view, x.d_view, b.d_view, y.d_view);
     }
   }
 
+  std::cout << "kdc a-011" << std::endl;
   Kokkos::deep_copy(y.h_view, y.d_view);
 
   if (testWithNanY == false) {
@@ -248,24 +260,28 @@ void impl_test_axpby_mv_unification_compare(
     Test::getRandomBounds(max_val, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
+  std::cout << "kdc b-001" << std::endl;
   Kokkos::deep_copy(x.h_view, x.d_view);
 
   {
     ScalarTypeY randStart, randEnd;
     Test::getRandomBounds(max_val, randStart, randEnd);
     if (testWithNanY) {
+      std::cout << "kdc b-002" << std::endl;
       Kokkos::deep_copy(y.d_view, Kokkos::ArithTraits<ScalarTypeY>::nan());
     } else {
       Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
     }
   }
   tY org_y("Org_Y", N, K);
+  std::cout << "kdc b-003" << std::endl;
   Kokkos::deep_copy(org_y.h_view, y.d_view);
 
   // Cannot use "if constexpr (isRank1<tA>()) {" because rank-1 variables
   // are passed to current routine with view_stride_adapter<...>
   bool constexpr aIsRank1 = !std::is_same_v<tA, tScalarA> && !isRank0<tA>();
   if constexpr (aIsRank1) {
+    std::cout << "kdc b-004" << std::endl;
     Kokkos::deep_copy(a.h_view, a.d_view);
   }
 
@@ -273,6 +289,7 @@ void impl_test_axpby_mv_unification_compare(
   // are passed to current routine with view_stride_adapter<...>
   bool constexpr bIsRank1 = !std::is_same_v<tB, tScalarB> && !isRank0<tB>();
   if constexpr (bIsRank1) {
+    std::cout << "kdc b-005" << std::endl;
     Kokkos::deep_copy(b.h_view, b.d_view);
   }
 
@@ -289,6 +306,7 @@ void impl_test_axpby_mv_unification_compare(
         valueB = inputValueB;
       } else {
         typename tB::HostMirror h_b("h_B");
+        std::cout << "kdc b-006" << std::endl;
         Kokkos::deep_copy(h_b, b);
         valueB = h_b();
       }
@@ -303,6 +321,7 @@ void impl_test_axpby_mv_unification_compare(
       valueA = inputValueA;
     } else {
       typename tA::HostMirror h_a("h_A");
+      std::cout << "kdc b-007" << std::endl;
       Kokkos::deep_copy(h_a, a);
       valueA = h_a();
     }
@@ -315,6 +334,7 @@ void impl_test_axpby_mv_unification_compare(
         valueB = inputValueB;
       } else {
         typename tB::HostMirror h_b("h_B");
+        std::cout << "kdc b-008" << std::endl;
         Kokkos::deep_copy(h_b, b);
         valueB = h_b();
       }
@@ -334,6 +354,7 @@ void impl_test_axpby_mv_unification_compare(
         valueB = inputValueB;
       } else {
         typename tB::HostMirror h_b("h_B");
+        std::cout << "kdc b-009" << std::endl;
         Kokkos::deep_copy(h_b, b);
         valueB = h_b();
       }
@@ -344,6 +365,7 @@ void impl_test_axpby_mv_unification_compare(
     }
   }
 
+  std::cout << "kdc b-010" << std::endl;
   Kokkos::deep_copy(y.h_view, y.d_view);
 
   if (testWithNanY == false) {
@@ -551,6 +573,7 @@ void impl_test_axpby_unification(int const N) {
           view_stride_adapter<ViewTypeY> y("Y", N);
 
           a = valueA;
+          std::cout << "kdc u-001" << std::endl;
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_unification_compare<
               tScalarA, tScalarA, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -582,6 +605,7 @@ void impl_test_axpby_unification(int const N) {
         view_stride_adapter<ViewTypeY> y("Y", N);
 
         a = valueA;
+        std::cout << "kdc u-002" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_unification_compare<
             tScalarA, tScalarA, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -613,6 +637,7 @@ void impl_test_axpby_unification(int const N) {
         view_stride_adapter<ViewTypeY> y("Y", N);
 
         a = valueA;
+        std::cout << "kdc u-003" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_unification_compare<
             tScalarA, tScalarA, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -645,6 +670,7 @@ void impl_test_axpby_unification(int const N) {
           tScalarB b;
           view_stride_adapter<ViewTypeY> y("Y", N);
 
+          std::cout << "kdc u-004" << std::endl;
           Kokkos::deep_copy(a, valueA);
           b = valueB;
           impl_test_axpby_unification_compare<
@@ -680,7 +706,9 @@ void impl_test_axpby_unification(int const N) {
           ViewTypeBr0 b("B");
           view_stride_adapter<ViewTypeY> y("Y", N);
 
+          std::cout << "kdc u-005" << std::endl;
           Kokkos::deep_copy(a, valueA);
+          std::cout << "kdc u-006" << std::endl;
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_unification_compare<
               tScalarA, ViewTypeAr0, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -714,7 +742,9 @@ void impl_test_axpby_unification(int const N) {
           view_stride_adapter<ViewTypeBr1s_1> b("B", 1);
           view_stride_adapter<ViewTypeY> y("Y", N);
 
+          std::cout << "kdc u-007" << std::endl;
           Kokkos::deep_copy(a, valueA);
+          std::cout << "kdc u-008" << std::endl;
           Kokkos::deep_copy(b.d_base, valueB);
           impl_test_axpby_unification_compare<
               tScalarA, ViewTypeAr0, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -750,7 +780,9 @@ void impl_test_axpby_unification(int const N) {
           view_stride_adapter<ViewTypeBr1d> b("B", 1);
           view_stride_adapter<ViewTypeY> y("Y", N);
 
+          std::cout << "kdc u-009" << std::endl;
           Kokkos::deep_copy(a, valueA);
+          std::cout << "kdc u-010" << std::endl;
           Kokkos::deep_copy(b.d_base, valueB);
           impl_test_axpby_unification_compare<
               tScalarA, ViewTypeAr0, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -782,6 +814,7 @@ void impl_test_axpby_unification(int const N) {
         tScalarB b;
         view_stride_adapter<ViewTypeY> y("Y", N);
 
+        std::cout << "kdc u-011" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
         b = valueB;
         impl_test_axpby_unification_compare<
@@ -817,7 +850,9 @@ void impl_test_axpby_unification(int const N) {
           ViewTypeBr0 b("B");
           view_stride_adapter<ViewTypeY> y("Y", N);
 
+          std::cout << "kdc u-012" << std::endl;
           Kokkos::deep_copy(a.d_base, valueA);
+          std::cout << "kdc u-013" << std::endl;
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
@@ -850,7 +885,9 @@ void impl_test_axpby_unification(int const N) {
         view_stride_adapter<ViewTypeBr1s_1> b("B", 1);
         view_stride_adapter<ViewTypeY> y("Y", N);
 
+        std::cout << "kdc u-014" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
+        std::cout << "kdc u-015" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
@@ -883,7 +920,9 @@ void impl_test_axpby_unification(int const N) {
         view_stride_adapter<ViewTypeBr1d> b("B", 1);
         view_stride_adapter<ViewTypeY> y("Y", N);
 
+        std::cout << "kdc u-016" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
+        std::cout << "kdc u-017" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
@@ -915,6 +954,7 @@ void impl_test_axpby_unification(int const N) {
         tScalarB b;
         view_stride_adapter<ViewTypeY> y("Y", N);
 
+        std::cout << "kdc u-018" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
         b = valueB;
         impl_test_axpby_unification_compare<
@@ -950,7 +990,9 @@ void impl_test_axpby_unification(int const N) {
           ViewTypeBr0 b("B");
           view_stride_adapter<ViewTypeY> y("Y", N);
 
+          std::cout << "kdc u-019" << std::endl;
           Kokkos::deep_copy(a.d_base, valueA);
+          std::cout << "kdc u-020" << std::endl;
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1d>,
@@ -983,7 +1025,9 @@ void impl_test_axpby_unification(int const N) {
         view_stride_adapter<ViewTypeBr1s_1> b("B", 1);
         view_stride_adapter<ViewTypeY> y("Y", N);
 
+        std::cout << "kdc u-021" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
+        std::cout << "kdc u-022" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1d>,
@@ -1016,7 +1060,9 @@ void impl_test_axpby_unification(int const N) {
         view_stride_adapter<ViewTypeBr1d> b("B", 1);
         view_stride_adapter<ViewTypeY> y("Y", N);
 
+        std::cout << "kdc u-023" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
+        std::cout << "kdc u-024" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1d>,
@@ -1126,6 +1172,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           view_stride_adapter<ViewTypeY> y("Y", N, K);
 
           a = valueA;
+          std::cout << "kdc mvu-001" << std::endl;
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_mv_unification_compare<
               tScalarA, tScalarA, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -1157,6 +1204,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
         a = valueA;
+        std::cout << "kdc mvu-002" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, tScalarA, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -1192,11 +1240,13 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           for (int k(0); k < K; ++k) {
             b.h_view[k] = valueB + k;
           }
+          std::cout << "kdc mvu-003" << std::endl;
           Kokkos::deep_copy(b.d_view, b.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
+          std::cout << "kdc mvu-004" << std::endl;
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
         impl_test_axpby_mv_unification_compare<
@@ -1222,6 +1272,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
         a = valueA;
+        std::cout << "kdc mvu-005" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, tScalarA, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -1256,11 +1307,13 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           for (int k(0); k < K; ++k) {
             b.h_view[k] = valueB + k;
           }
+          std::cout << "kdc mvu-006" << std::endl;
           Kokkos::deep_copy(b.d_view, b.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
+          std::cout << "kdc mvu-007" << std::endl;
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
         impl_test_axpby_mv_unification_compare<
@@ -1288,6 +1341,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           tScalarB b;
           view_stride_adapter<ViewTypeY> y("Y", N, K);
 
+          std::cout << "kdc mvu-008" << std::endl;
           Kokkos::deep_copy(a, valueA);
           b = valueB;
           impl_test_axpby_mv_unification_compare<
@@ -1323,7 +1377,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           ViewTypeBr0 b("B");
           view_stride_adapter<ViewTypeY> y("Y", N, K);
 
+          std::cout << "kdc mvu-009" << std::endl;
           Kokkos::deep_copy(a, valueA);
+          std::cout << "kdc mvu-010" << std::endl;
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_mv_unification_compare<
               tScalarA, ViewTypeAr0, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -1357,7 +1413,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           view_stride_adapter<ViewTypeBr1s_1> b("B", 1);
           view_stride_adapter<ViewTypeY> y("Y", N, K);
 
+          std::cout << "kdc mvu-011" << std::endl;
           Kokkos::deep_copy(a, valueA);
+          std::cout << "kdc mvu-012" << std::endl;
           Kokkos::deep_copy(b.d_base, valueB);
           impl_test_axpby_mv_unification_compare<
               tScalarA, ViewTypeAr0, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -1393,16 +1451,19 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           view_stride_adapter<ViewTypeBr1s_k> b("B", K);
           view_stride_adapter<ViewTypeY> y("Y", N, K);
 
+          std::cout << "kdc mvu-013" << std::endl;
           Kokkos::deep_copy(a, valueA);
           if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
             for (int k(0); k < K; ++k) {
               b.h_view[k] = valueB + k;
             }
+            std::cout << "kdc mvu-014" << std::endl;
             Kokkos::deep_copy(b.d_view, b.h_view);
           } else {
             for (int k(0); k < K; ++k) {
               b.h_base[k] = valueB + k;
             }
+            std::cout << "kdc mvu-015" << std::endl;
             Kokkos::deep_copy(b.d_base, b.h_base);
           }
           impl_test_axpby_mv_unification_compare<
@@ -1432,7 +1493,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           view_stride_adapter<ViewTypeBr1d> b("B", 1);
           view_stride_adapter<ViewTypeY> y("Y", N, K);
 
+          std::cout << "kdc mvu-016" << std::endl;
           Kokkos::deep_copy(a, valueA);
+          std::cout << "kdc mvu-017" << std::endl;
           Kokkos::deep_copy(b.d_base, valueB);
           impl_test_axpby_mv_unification_compare<
               tScalarA, ViewTypeAr0, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -1467,16 +1530,19 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           view_stride_adapter<ViewTypeBr1d> b("B", K);
           view_stride_adapter<ViewTypeY> y("Y", N, K);
 
+          std::cout << "kdc mvu-018" << std::endl;
           Kokkos::deep_copy(a, valueA);
           if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
             for (int k(0); k < K; ++k) {
               b.h_view[k] = valueB + k;
             }
+            std::cout << "kdc mvu-019" << std::endl;
             Kokkos::deep_copy(b.d_view, b.h_view);
           } else {
             for (int k(0); k < K; ++k) {
               b.h_base[k] = valueB + k;
             }
+            std::cout << "kdc mvu-020" << std::endl;
             Kokkos::deep_copy(b.d_base, b.h_base);
           }
           impl_test_axpby_mv_unification_compare<
@@ -1502,6 +1568,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         tScalarB b;
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
+        std::cout << "kdc mvu-021" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
         b = valueB;
         impl_test_axpby_mv_unification_compare<
@@ -1537,7 +1604,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           ViewTypeBr0 b("B");
           view_stride_adapter<ViewTypeY> y("Y", N, K);
 
+          std::cout << "kdc mvu-022" << std::endl;
           Kokkos::deep_copy(a.d_base, valueA);
+          std::cout << "kdc mvu-023" << std::endl;
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
@@ -1570,7 +1639,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeBr1s_1> b("B", 1);
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
+        std::cout << "kdc mvu-024" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
+        std::cout << "kdc mvu-025" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
@@ -1603,16 +1674,19 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeBr1s_k> b("B", K);
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
+        std::cout << "kdc mvu-026" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
             b.h_view[k] = valueB + k;
           }
+          std::cout << "kdc mvu-027" << std::endl;
           Kokkos::deep_copy(b.d_view, b.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
+          std::cout << "kdc mvu-028" << std::endl;
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
         impl_test_axpby_mv_unification_compare<
@@ -1638,7 +1712,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeBr1d> b("B", 1);
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
+        std::cout << "kdc mvu-029" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
+        std::cout << "kdc mvu-030" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
@@ -1670,16 +1746,19 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeBr1d> b("B", K);
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
+        std::cout << "kdc mvu-031" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
             b.h_view[k] = valueB + k;
           }
+          std::cout << "kdc mvu-032" << std::endl;
           Kokkos::deep_copy(b.d_view, b.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
+          std::cout << "kdc mvu-033" << std::endl;
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
         impl_test_axpby_mv_unification_compare<
@@ -1709,11 +1788,13 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           for (int k(0); k < K; ++k) {
             a.h_view[k] = valueA + k;
           }
+          std::cout << "kdc mvu-034" << std::endl;
           Kokkos::deep_copy(a.d_view, a.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
+          std::cout << "kdc mvu-035" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
         b = valueB;
@@ -1754,13 +1835,16 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
             for (int k(0); k < K; ++k) {
               a.h_view[k] = valueA + k;
             }
+            std::cout << "kdc mvu-036" << std::endl;
             Kokkos::deep_copy(a.d_view, a.h_view);
           } else {
             for (int k(0); k < K; ++k) {
               a.h_base[k] = valueA + k;
             }
+            std::cout << "kdc mvu-037" << std::endl;
             Kokkos::deep_copy(a.d_base, a.h_base);
           }
+          std::cout << "kdc mvu-038" << std::endl;
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1s_k>,
@@ -1797,13 +1881,16 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           for (int k(0); k < K; ++k) {
             a.h_view[k] = valueA + k;
           }
+          std::cout << "kdc mvu-039" << std::endl;
           Kokkos::deep_copy(a.d_view, a.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
+          std::cout << "kdc mvu-040" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
+        std::cout << "kdc mvu-041" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1s_k>,
@@ -1840,11 +1927,13 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           for (int k(0); k < K; ++k) {
             a.h_view[k] = valueA + k;
           }
+          std::cout << "kdc mvu-042" << std::endl;
           Kokkos::deep_copy(a.d_view, a.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
+          std::cout << "kdc mvu-043" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
 
@@ -1852,11 +1941,13 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           for (int k(0); k < K; ++k) {
             b.h_view[k] = valueB + k;
           }
+          std::cout << "kdc mvu-044" << std::endl;
           Kokkos::deep_copy(b.d_view, b.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
+          std::cout << "kdc mvu-045" << std::endl;
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
         impl_test_axpby_mv_unification_compare<
@@ -1886,13 +1977,16 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           for (int k(0); k < K; ++k) {
             a.h_view[k] = valueA + k;
           }
+          std::cout << "kdc mvu-046" << std::endl;
           Kokkos::deep_copy(a.d_view, a.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
+          std::cout << "kdc mvu-047" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
+        std::cout << "kdc mvu-048" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1s_k>,
@@ -1928,11 +2022,13 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           for (int k(0); k < K; ++k) {
             a.h_view[k] = valueA + k;
           }
+          std::cout << "kdc mvu-049" << std::endl;
           Kokkos::deep_copy(a.d_view, a.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
+          std::cout << "kdc mvu-050" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
 
@@ -1940,11 +2036,13 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           for (int k(0); k < K; ++k) {
             b.h_view[k] = valueB + k;
           }
+          std::cout << "kdc mvu-051" << std::endl;
           Kokkos::deep_copy(b.d_view, b.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
+          std::cout << "kdc mvu-052" << std::endl;
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
 
@@ -1971,6 +2069,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         tScalarB b;
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
+        std::cout << "kdc mvu-053" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
         b = valueB;
         impl_test_axpby_mv_unification_compare<
@@ -2006,7 +2105,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           ViewTypeBr0 b("B");
           view_stride_adapter<ViewTypeY> y("Y", N, K);
 
+          std::cout << "kdc mvu-054" << std::endl;
           Kokkos::deep_copy(a.d_base, valueA);
+          std::cout << "kdc mvu-055" << std::endl;
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1d>,
@@ -2039,7 +2140,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeBr1s_1> b("B", 1);
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
+        std::cout << "kdc mvu-056" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
+        std::cout << "kdc mvu-057" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1d>,
@@ -2072,16 +2175,19 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeBr1s_k> b("B", K);
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
+        std::cout << "kdc mvu-058" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
             b.h_view[k] = valueB + k;
           }
+          std::cout << "kdc mvu-059" << std::endl;
           Kokkos::deep_copy(b.d_view, b.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
+          std::cout << "kdc mvu-060" << std::endl;
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
         impl_test_axpby_mv_unification_compare<
@@ -2107,7 +2213,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeBr1d> b("B", 1);
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
+        std::cout << "kdc mvu-061" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
+        std::cout << "kdc mvu-062" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1d>,
@@ -2139,16 +2247,19 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeBr1d> b("B", K);
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
+        std::cout << "kdc mvu-063" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
             b.h_view[k] = valueB + k;
           }
+          std::cout << "kdc mvu-064" << std::endl;
           Kokkos::deep_copy(b.d_view, b.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
+          std::cout << "kdc mvu-065" << std::endl;
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
         impl_test_axpby_mv_unification_compare<
@@ -2178,11 +2289,13 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           for (int k(0); k < K; ++k) {
             a.h_view[k] = valueA + k;
           }
+          std::cout << "kdc mvu-066" << std::endl;
           Kokkos::deep_copy(a.d_view, a.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
+          std::cout << "kdc mvu-067" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
         b = valueB;
@@ -2223,13 +2336,16 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
             for (int k(0); k < K; ++k) {
               a.h_view[k] = valueA + k;
             }
+            std::cout << "kdc mvu-068" << std::endl;
             Kokkos::deep_copy(a.d_view, a.h_view);
           } else {
             for (int k(0); k < K; ++k) {
               a.h_base[k] = valueA + k;
             }
+            std::cout << "kdc mvu-069" << std::endl;
             Kokkos::deep_copy(a.d_base, a.h_base);
           }
+          std::cout << "kdc mvu-070" << std::endl;
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1d>,
@@ -2266,13 +2382,16 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           for (int k(0); k < K; ++k) {
             a.h_view[k] = valueA + k;
           }
+          std::cout << "kdc mvu-071" << std::endl;
           Kokkos::deep_copy(a.d_view, a.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
+          std::cout << "kdc mvu-072" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
+        std::cout << "kdc mvu-073" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1d>,
@@ -2309,11 +2428,13 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           for (int k(0); k < K; ++k) {
             a.h_view[k] = valueA + k;
           }
+          std::cout << "kdc mvu-074" << std::endl;
           Kokkos::deep_copy(a.d_view, a.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
+          std::cout << "kdc mvu-075" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
 
@@ -2321,11 +2442,13 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           for (int k(0); k < K; ++k) {
             b.h_view[k] = valueB + k;
           }
+          std::cout << "kdc mvu-076" << std::endl;
           Kokkos::deep_copy(b.d_view, b.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
+          std::cout << "kdc mvu-077" << std::endl;
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
 
@@ -2356,13 +2479,16 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           for (int k(0); k < K; ++k) {
             a.h_view[k] = valueA + k;
           }
+          std::cout << "kdc mvu-078" << std::endl;
           Kokkos::deep_copy(a.d_view, a.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
+          std::cout << "kdc mvu-079" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
+        std::cout << "kdc mvu-080" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1d>,
@@ -2398,11 +2524,13 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           for (int k(0); k < K; ++k) {
             a.h_view[k] = valueA + k;
           }
+          std::cout << "kdc mvu-081" << std::endl;
           Kokkos::deep_copy(a.d_view, a.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
+          std::cout << "kdc mvu-082" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
 
@@ -2410,11 +2538,13 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           for (int k(0); k < K; ++k) {
             b.h_view[k] = valueB + k;
           }
+          std::cout << "kdc mvu-083" << std::endl;
           Kokkos::deep_copy(b.d_view, b.h_view);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
+          std::cout << "kdc mvu-084" << std::endl;
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
 

--- a/blas/unit_test/Test_Blas1_axpby_unification.hpp
+++ b/blas/unit_test/Test_Blas1_axpby_unification.hpp
@@ -98,9 +98,6 @@ void impl_test_axpby_unification_compare(
     Test::getRandomBounds(max_val, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
-  std::cout << "kdc a-001" << std::endl;
-#endif
   Kokkos::deep_copy(x.h_base, x.d_base);
 
   {
@@ -188,9 +185,6 @@ void impl_test_axpby_unification_compare(
     }
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
-  std::cout << "kdc a-011" << std::endl;
-#endif
   Kokkos::deep_copy(y.h_base, y.d_base);
 
   if (testWithNanY == false) {
@@ -254,9 +248,6 @@ void impl_test_axpby_mv_unification_compare(
     Test::getRandomBounds(max_val, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
-  std::cout << "kdc b-001" << std::endl;
-#endif
   Kokkos::deep_copy(x.h_base, x.d_base);
 
   {
@@ -353,9 +344,6 @@ void impl_test_axpby_mv_unification_compare(
     }
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
-  std::cout << "kdc b-010" << std::endl;
-#endif
   Kokkos::deep_copy(y.h_base, y.d_base);
 
   if (testWithNanY == false) {
@@ -567,9 +555,6 @@ void impl_test_axpby_unification(int const N) {
           view_stride_adapter<ViewTypeY> y("Y", N);
 
           a = valueA;
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
-          std::cout << "kdc u-001" << std::endl;
-#endif
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_unification_compare<
               tScalarA, tScalarA, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -1064,9 +1049,6 @@ void impl_test_axpby_unification(int const N) {
         view_stride_adapter<ViewTypeY> y("Y", N);
 
         Kokkos::deep_copy(a.d_base, valueA);
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
-        std::cout << "kdc u-024" << std::endl;
-#endif
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1d>,
@@ -1180,9 +1162,6 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           view_stride_adapter<ViewTypeY> y("Y", N, K);
 
           a = valueA;
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
-          std::cout << "kdc mvu-001" << std::endl;
-#endif
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_mv_unification_compare<
               tScalarA, tScalarA, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -2540,9 +2519,6 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
-          std::cout << "kdc mvu-084" << std::endl;
-#endif
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
 

--- a/blas/unit_test/Test_Blas1_axpby_unification.hpp
+++ b/blas/unit_test/Test_Blas1_axpby_unification.hpp
@@ -98,22 +98,22 @@ void impl_test_axpby_unification_compare(
     Test::getRandomBounds(max_val, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "kdc a-001" << std::endl;
-  Kokkos::deep_copy(x.h_base, x.d_base); // Aqui
+#endif
+  Kokkos::deep_copy(x.h_base, x.d_base);
 
   {
     ScalarTypeY randStart, randEnd;
     Test::getRandomBounds(max_val, randStart, randEnd);
     if (testWithNanY) {
-      std::cout << "kdc a-002" << std::endl;
       Kokkos::deep_copy(y.d_view, Kokkos::ArithTraits<ScalarTypeY>::nan());
     } else {
       Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
     }
   }
   tY org_y("Org_Y", N);
-  std::cout << "kdc a-003" << std::endl;
-  Kokkos::deep_copy(org_y.h_base, y.d_base); // Aqui
+  Kokkos::deep_copy(org_y.h_base, y.d_base);
 
   tScalarA valueA(Kokkos::ArithTraits<tScalarA>::zero());
   tScalarB valueB(Kokkos::ArithTraits<tScalarB>::zero());
@@ -129,14 +129,12 @@ void impl_test_axpby_unification_compare(
         valueB = inputValueB;
       } else {
         typename tB::HostMirror h_b("h_B");
-        std::cout << "kdc a-004" << std::endl;
         Kokkos::deep_copy(h_b, b);
         valueB = h_b();
       }
       KokkosBlas::axpby(a, x.d_view, b, y.d_view);
     } else {
-      std::cout << "kdc a-005" << std::endl;
-      Kokkos::deep_copy(b.h_base, b.d_base); // Aqui
+      Kokkos::deep_copy(b.h_base, b.d_base);
       valueB = b.h_view(0);
       KokkosBlas::axpby(a, x.d_view, b.d_view, y.d_view);
     }
@@ -146,7 +144,6 @@ void impl_test_axpby_unification_compare(
       valueA = inputValueA;
     } else {
       typename tA::HostMirror h_a("h_A");
-      std::cout << "kdc a-006" << std::endl;
       Kokkos::deep_copy(h_a, a);
       valueA = h_a();
     }
@@ -159,20 +156,17 @@ void impl_test_axpby_unification_compare(
         valueB = inputValueB;
       } else {
         typename tB::HostMirror h_b("h_B");
-        std::cout << "kdc a-007" << std::endl;
         Kokkos::deep_copy(h_b, b);
         valueB = h_b();
       }
       KokkosBlas::axpby(a, x.d_view, b, y.d_view);
     } else {
-      std::cout << "kdc a-008" << std::endl;
-      Kokkos::deep_copy(b.h_base, b.d_base); // Aqui
+      Kokkos::deep_copy(b.h_base, b.d_base);
       valueB = b.h_view(0);
       KokkosBlas::axpby(a, x.d_view, b.d_view, y.d_view);
     }
   } else {
-    std::cout << "kdc a-008" << std::endl;
-    Kokkos::deep_copy(a.h_base, a.d_base); // Aqui
+    Kokkos::deep_copy(a.h_base, a.d_base);
     valueA = a.h_view(0);
     if constexpr (std::is_same_v<tB, tScalarB>) {
       valueB = b;
@@ -183,21 +177,21 @@ void impl_test_axpby_unification_compare(
         valueB = inputValueB;
       } else {
         typename tB::HostMirror h_b("h_B");
-        std::cout << "kdc a-009" << std::endl;
         Kokkos::deep_copy(h_b, b);
         valueB = h_b();
       }
       KokkosBlas::axpby(a.d_view, x.d_view, b, y.d_view);
     } else {
-      std::cout << "kdc a-010" << std::endl;
-      Kokkos::deep_copy(b.h_base, b.d_base); // Aqui
+      Kokkos::deep_copy(b.h_base, b.d_base);
       valueB = b.h_view(0);
       KokkosBlas::axpby(a.d_view, x.d_view, b.d_view, y.d_view);
     }
   }
 
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "kdc a-011" << std::endl;
-  Kokkos::deep_copy(y.h_base, y.d_base); // Aqui
+#endif
+  Kokkos::deep_copy(y.h_base, y.d_base);
 
   if (testWithNanY == false) {
     for (int i(0); i < N; ++i) {
@@ -238,7 +232,6 @@ void impl_test_axpby_unification_compare(
   }
 }
 
-#if 1 // Aqui
 template <class tScalarA, class tA, class tX, class tScalarB, class tB,
           class tY, class Device>
 void impl_test_axpby_mv_unification_compare(
@@ -261,37 +254,35 @@ void impl_test_axpby_mv_unification_compare(
     Test::getRandomBounds(max_val, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "kdc b-001" << std::endl;
-  Kokkos::deep_copy(x.h_base, x.d_base); // Aqui
+#endif
+  Kokkos::deep_copy(x.h_base, x.d_base);
 
   {
     ScalarTypeY randStart, randEnd;
     Test::getRandomBounds(max_val, randStart, randEnd);
     if (testWithNanY) {
-      std::cout << "kdc b-002" << std::endl;
       Kokkos::deep_copy(y.d_view, Kokkos::ArithTraits<ScalarTypeY>::nan());
     } else {
       Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
     }
   }
   tY org_y("Org_Y", N, K);
-  std::cout << "kdc b-003" << std::endl;
-  Kokkos::deep_copy(org_y.h_base, y.d_base); // Aqui
+  Kokkos::deep_copy(org_y.h_base, y.d_base);
 
   // Cannot use "if constexpr (isRank1<tA>()) {" because rank-1 variables
   // are passed to current routine with view_stride_adapter<...>
   bool constexpr aIsRank1 = !std::is_same_v<tA, tScalarA> && !isRank0<tA>();
   if constexpr (aIsRank1) {
-    std::cout << "kdc b-004" << std::endl;
-    Kokkos::deep_copy(a.h_base, a.d_base); // Aqui
+    Kokkos::deep_copy(a.h_base, a.d_base);
   }
 
   // Cannot use "if constexpr (isRank1<tB>()) {" because rank-1 variables
   // are passed to current routine with view_stride_adapter<...>
   bool constexpr bIsRank1 = !std::is_same_v<tB, tScalarB> && !isRank0<tB>();
   if constexpr (bIsRank1) {
-    std::cout << "kdc b-005" << std::endl;
-    Kokkos::deep_copy(b.h_base, b.d_base); // Aqui
+    Kokkos::deep_copy(b.h_base, b.d_base);
   }
 
   tScalarA valueA(Kokkos::ArithTraits<tScalarA>::zero());
@@ -307,7 +298,6 @@ void impl_test_axpby_mv_unification_compare(
         valueB = inputValueB;
       } else {
         typename tB::HostMirror h_b("h_B");
-        std::cout << "kdc b-006" << std::endl;
         Kokkos::deep_copy(h_b, b);
         valueB = h_b();
       }
@@ -322,7 +312,6 @@ void impl_test_axpby_mv_unification_compare(
       valueA = inputValueA;
     } else {
       typename tA::HostMirror h_a("h_A");
-      std::cout << "kdc b-007" << std::endl;
       Kokkos::deep_copy(h_a, a);
       valueA = h_a();
     }
@@ -335,7 +324,6 @@ void impl_test_axpby_mv_unification_compare(
         valueB = inputValueB;
       } else {
         typename tB::HostMirror h_b("h_B");
-        std::cout << "kdc b-008" << std::endl;
         Kokkos::deep_copy(h_b, b);
         valueB = h_b();
       }
@@ -355,7 +343,6 @@ void impl_test_axpby_mv_unification_compare(
         valueB = inputValueB;
       } else {
         typename tB::HostMirror h_b("h_B");
-        std::cout << "kdc b-009" << std::endl;
         Kokkos::deep_copy(h_b, b);
         valueB = h_b();
       }
@@ -366,8 +353,10 @@ void impl_test_axpby_mv_unification_compare(
     }
   }
 
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "kdc b-010" << std::endl;
-  Kokkos::deep_copy(y.h_base, y.d_base); // Aqui
+#endif
+  Kokkos::deep_copy(y.h_base, y.d_base);
 
   if (testWithNanY == false) {
     for (int i(0); i < N; ++i) {
@@ -490,7 +479,6 @@ void impl_test_axpby_mv_unification_compare(
     }
   }
 }
-#endif // Aqui
 
 template <class tScalarA, class tLayoutA, class tScalarX, class tLayoutX,
           class tScalarB, class tLayoutB, class tScalarY, class tLayoutY,
@@ -557,7 +545,9 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 02/16: Ascalar + Br0
   // ************************************************************
-  // std::cout << "Starting case 02/16" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 02/16" << std::endl;
+#endif
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
     // ViewTypeBr0 b;
@@ -575,7 +565,9 @@ void impl_test_axpby_unification(int const N) {
           view_stride_adapter<ViewTypeY> y("Y", N);
 
           a = valueA;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
           std::cout << "kdc u-001" << std::endl;
+#endif
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_unification_compare<
               tScalarA, tScalarA, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -595,7 +587,9 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 03/16: Ascalar + Br1s_1
   // ************************************************************
-  // std::cout << "Starting case 03/16" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 03/16" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -607,7 +601,6 @@ void impl_test_axpby_unification(int const N) {
         view_stride_adapter<ViewTypeY> y("Y", N);
 
         a = valueA;
-        std::cout << "kdc u-002" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_unification_compare<
             tScalarA, tScalarA, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -627,7 +620,9 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 04/16: Ascalar + Br1d
   // ************************************************************
-  // std::cout << "Starting case 04/16" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 04/16" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -639,7 +634,6 @@ void impl_test_axpby_unification(int const N) {
         view_stride_adapter<ViewTypeY> y("Y", N);
 
         a = valueA;
-        std::cout << "kdc u-003" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_unification_compare<
             tScalarA, tScalarA, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -658,7 +652,9 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 05/16: Ar0 + Bscalar
   // ************************************************************
-  // std::cout << "Starting case 05/16" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 05/16" << std::endl;
+#endif
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -672,7 +668,6 @@ void impl_test_axpby_unification(int const N) {
           tScalarB b;
           view_stride_adapter<ViewTypeY> y("Y", N);
 
-          std::cout << "kdc u-004" << std::endl;
           Kokkos::deep_copy(a, valueA);
           b = valueB;
           impl_test_axpby_unification_compare<
@@ -693,7 +688,9 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 06/16: Ar0 + Br0
   // ************************************************************
-  // std::cout << "Starting case 06/16" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 06/16" << std::endl;
+#endif
   if constexpr ((std::is_same_v<tLayoutA, Kokkos::LayoutStride>) ||
                 (std::is_same_v<tLayoutB, Kokkos::LayoutStride>)) {
     // Avoid the test, due to compilation errors
@@ -708,9 +705,7 @@ void impl_test_axpby_unification(int const N) {
           ViewTypeBr0 b("B");
           view_stride_adapter<ViewTypeY> y("Y", N);
 
-          std::cout << "kdc u-005" << std::endl;
           Kokkos::deep_copy(a, valueA);
-          std::cout << "kdc u-006" << std::endl;
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_unification_compare<
               tScalarA, ViewTypeAr0, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -730,7 +725,9 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 07/16: Ar0 + Br1s_1
   // ************************************************************
-  // std::cout << "Starting case 07/16" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 07/16" << std::endl;
+#endif
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -744,9 +741,7 @@ void impl_test_axpby_unification(int const N) {
           view_stride_adapter<ViewTypeBr1s_1> b("B", 1);
           view_stride_adapter<ViewTypeY> y("Y", N);
 
-          std::cout << "kdc u-007" << std::endl;
           Kokkos::deep_copy(a, valueA);
-          std::cout << "kdc u-008" << std::endl;
           Kokkos::deep_copy(b.d_base, valueB);
           impl_test_axpby_unification_compare<
               tScalarA, ViewTypeAr0, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -768,7 +763,9 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 08/16: Ar0 + Br1d
   // ************************************************************
-  // std::cout << "Starting case 08/16" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 08/16" << std::endl;
+#endif
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -782,9 +779,7 @@ void impl_test_axpby_unification(int const N) {
           view_stride_adapter<ViewTypeBr1d> b("B", 1);
           view_stride_adapter<ViewTypeY> y("Y", N);
 
-          std::cout << "kdc u-009" << std::endl;
           Kokkos::deep_copy(a, valueA);
-          std::cout << "kdc u-010" << std::endl;
           Kokkos::deep_copy(b.d_base, valueB);
           impl_test_axpby_unification_compare<
               tScalarA, ViewTypeAr0, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -805,7 +800,9 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 09/16: Ar1s_1 + Bscalar
   // ************************************************************
-  // std::cout << "Starting case 09/16" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 09/16" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -816,7 +813,6 @@ void impl_test_axpby_unification(int const N) {
         tScalarB b;
         view_stride_adapter<ViewTypeY> y("Y", N);
 
-        std::cout << "kdc u-011" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
         b = valueB;
         impl_test_axpby_unification_compare<
@@ -838,7 +834,9 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 10/16: Ar1s_1 + Br0
   // ************************************************************
-  // std::cout << "Starting case 10/16" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 10/16" << std::endl;
+#endif
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -852,9 +850,7 @@ void impl_test_axpby_unification(int const N) {
           ViewTypeBr0 b("B");
           view_stride_adapter<ViewTypeY> y("Y", N);
 
-          std::cout << "kdc u-012" << std::endl;
           Kokkos::deep_copy(a.d_base, valueA);
-          std::cout << "kdc u-013" << std::endl;
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
@@ -876,7 +872,9 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 11/16: Ar1s_1 + Br1s_1
   // ************************************************************
-  // std::cout << "Starting case 11/16" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 11/16" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -887,9 +885,7 @@ void impl_test_axpby_unification(int const N) {
         view_stride_adapter<ViewTypeBr1s_1> b("B", 1);
         view_stride_adapter<ViewTypeY> y("Y", N);
 
-        std::cout << "kdc u-014" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
-        std::cout << "kdc u-015" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
@@ -911,7 +907,9 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 12/16: Ar1s_1 + Br1d
   // ************************************************************
-  // std::cout << "Starting case 12/16" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 12/16" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -922,9 +920,7 @@ void impl_test_axpby_unification(int const N) {
         view_stride_adapter<ViewTypeBr1d> b("B", 1);
         view_stride_adapter<ViewTypeY> y("Y", N);
 
-        std::cout << "kdc u-016" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
-        std::cout << "kdc u-017" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
@@ -945,7 +941,9 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 13/16: Ar1d + Bscalar
   // ************************************************************
-  // std::cout << "Starting case 13/16" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 13/16" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -956,7 +954,6 @@ void impl_test_axpby_unification(int const N) {
         tScalarB b;
         view_stride_adapter<ViewTypeY> y("Y", N);
 
-        std::cout << "kdc u-018" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
         b = valueB;
         impl_test_axpby_unification_compare<
@@ -978,7 +975,9 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 14/16: Ar1d + Br0
   // ************************************************************
-  // std::cout << "Starting case 14/16" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 14/16" << std::endl;
+#endif
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -992,9 +991,7 @@ void impl_test_axpby_unification(int const N) {
           ViewTypeBr0 b("B");
           view_stride_adapter<ViewTypeY> y("Y", N);
 
-          std::cout << "kdc u-019" << std::endl;
           Kokkos::deep_copy(a.d_base, valueA);
-          std::cout << "kdc u-020" << std::endl;
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1d>,
@@ -1016,7 +1013,9 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 15/16: Ar1d + Br1s_1
   // ************************************************************
-  // std::cout << "Starting case 15/16" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 15/16" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1027,9 +1026,7 @@ void impl_test_axpby_unification(int const N) {
         view_stride_adapter<ViewTypeBr1s_1> b("B", 1);
         view_stride_adapter<ViewTypeY> y("Y", N);
 
-        std::cout << "kdc u-021" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
-        std::cout << "kdc u-022" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1d>,
@@ -1051,7 +1048,9 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 16/16: Ar1d + Br1d
   // ************************************************************
-  // std::cout << "Starting case 16/16" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 16/16" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1062,9 +1061,10 @@ void impl_test_axpby_unification(int const N) {
         view_stride_adapter<ViewTypeBr1d> b("B", 1);
         view_stride_adapter<ViewTypeY> y("Y", N);
 
-        std::cout << "kdc u-023" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
         std::cout << "kdc u-024" << std::endl;
+#endif
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1d>,
@@ -1083,7 +1083,6 @@ void impl_test_axpby_unification(int const N) {
   }
 }
 
-#if 1 // Aqui
 template <class tScalarA, class tLayoutA, class tScalarX, class tLayoutX,
           class tScalarB, class tLayoutB, class tScalarY, class tLayoutY,
           class Device>
@@ -1130,7 +1129,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 01/36: Ascalar + Bscalar
   // ************************************************************
-  // std::cout << "Starting case 01/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 01/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1160,7 +1161,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 02/36: Ascalar + Br0
   // ************************************************************
-  // std::cout << "Starting case 02/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 02/36" << std::endl;
+#endif
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -1175,7 +1178,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           view_stride_adapter<ViewTypeY> y("Y", N, K);
 
           a = valueA;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
           std::cout << "kdc mvu-001" << std::endl;
+#endif
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_mv_unification_compare<
               tScalarA, tScalarA, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -1195,7 +1200,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 03/36: Ascalar + Br1s_1
   // ************************************************************
-  // std::cout << "Starting case 03/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 03/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1207,7 +1214,6 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
         a = valueA;
-        std::cout << "kdc mvu-002" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, tScalarA, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -1227,7 +1233,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 04/36: Ascalar + Br1s_k
   // ************************************************************
-  // std::cout << "Starting case 04/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 04/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1241,15 +1249,13 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         a = valueA;
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k; // Aqui
+            b.h_view[k] = valueB + k;
           }
-          std::cout << "kdc mvu-003" << std::endl;
-          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
+          Kokkos::deep_copy(b.d_base, b.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
-          std::cout << "kdc mvu-004" << std::endl;
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
         impl_test_axpby_mv_unification_compare<
@@ -1263,7 +1269,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 05/36: Ascalar + Br1d,1
   // ************************************************************
-  // std::cout << "Starting case 05/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 05/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1275,7 +1283,6 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
         a = valueA;
-        std::cout << "kdc mvu-005" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, tScalarA, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -1294,7 +1301,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 06/36: Ascalar + Br1d,k
   // ************************************************************
-  // std::cout << "Starting case 06/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 06/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1308,15 +1317,13 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         a = valueA;
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k; // Aqui
+            b.h_view[k] = valueB + k;
           }
-          std::cout << "kdc mvu-006" << std::endl;
-          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
+          Kokkos::deep_copy(b.d_base, b.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
-          std::cout << "kdc mvu-007" << std::endl;
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
         impl_test_axpby_mv_unification_compare<
@@ -1330,7 +1337,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 07/36: Ar0 + Bscalar
   // ************************************************************w
-  // std::cout << "Starting case 07/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 07/36" << std::endl;
+#endif
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -1344,7 +1353,6 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           tScalarB b;
           view_stride_adapter<ViewTypeY> y("Y", N, K);
 
-          std::cout << "kdc mvu-008" << std::endl;
           Kokkos::deep_copy(a, valueA);
           b = valueB;
           impl_test_axpby_mv_unification_compare<
@@ -1365,7 +1373,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 08/36: Ar0 + Br0
   // ************************************************************
-  // std::cout << "Starting case 08/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 08/36" << std::endl;
+#endif
   if constexpr ((std::is_same_v<tLayoutA, Kokkos::LayoutStride>) ||
                 (std::is_same_v<tLayoutB, Kokkos::LayoutStride>)) {
     // Avoid the test, due to compilation errors
@@ -1380,9 +1390,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           ViewTypeBr0 b("B");
           view_stride_adapter<ViewTypeY> y("Y", N, K);
 
-          std::cout << "kdc mvu-009" << std::endl;
           Kokkos::deep_copy(a, valueA);
-          std::cout << "kdc mvu-010" << std::endl;
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_mv_unification_compare<
               tScalarA, ViewTypeAr0, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -1402,7 +1410,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 09/36: Ar0 + Br1s_1
   // ************************************************************
-  // std::cout << "Starting case 09/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 09/36" << std::endl;
+#endif
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -1416,9 +1426,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           view_stride_adapter<ViewTypeBr1s_1> b("B", 1);
           view_stride_adapter<ViewTypeY> y("Y", N, K);
 
-          std::cout << "kdc mvu-011" << std::endl;
           Kokkos::deep_copy(a, valueA);
-          std::cout << "kdc mvu-012" << std::endl;
           Kokkos::deep_copy(b.d_base, valueB);
           impl_test_axpby_mv_unification_compare<
               tScalarA, ViewTypeAr0, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -1440,7 +1448,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 10/36: Ar0 + Br1s_k
   // ************************************************************
-  // std::cout << "Starting case 10/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 10/36" << std::endl;
+#endif
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -1454,19 +1464,16 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           view_stride_adapter<ViewTypeBr1s_k> b("B", K);
           view_stride_adapter<ViewTypeY> y("Y", N, K);
 
-          std::cout << "kdc mvu-013" << std::endl;
           Kokkos::deep_copy(a, valueA);
           if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
             for (int k(0); k < K; ++k) {
-              b.h_view[k] = valueB + k; // Aqui
+              b.h_view[k] = valueB + k;
             }
-            std::cout << "kdc mvu-014" << std::endl;
-            Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
+            Kokkos::deep_copy(b.d_base, b.h_base);
           } else {
             for (int k(0); k < K; ++k) {
               b.h_base[k] = valueB + k;
             }
-            std::cout << "kdc mvu-015" << std::endl;
             Kokkos::deep_copy(b.d_base, b.h_base);
           }
           impl_test_axpby_mv_unification_compare<
@@ -1482,7 +1489,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 11/36: Ar0 + Br1d,1
   // ************************************************************
-  // std::cout << "Starting case 11/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 11/36" << std::endl;
+#endif
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -1496,9 +1505,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           view_stride_adapter<ViewTypeBr1d> b("B", 1);
           view_stride_adapter<ViewTypeY> y("Y", N, K);
 
-          std::cout << "kdc mvu-016" << std::endl;
           Kokkos::deep_copy(a, valueA);
-          std::cout << "kdc mvu-017" << std::endl;
           Kokkos::deep_copy(b.d_base, valueB);
           impl_test_axpby_mv_unification_compare<
               tScalarA, ViewTypeAr0, view_stride_adapter<ViewTypeX>, tScalarB,
@@ -1519,7 +1526,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 12/36: Ar0 + Br1d,k
   // ************************************************************
-  // std::cout << "Starting case 12/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 12/36" << std::endl;
+#endif
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -1533,19 +1542,16 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           view_stride_adapter<ViewTypeBr1d> b("B", K);
           view_stride_adapter<ViewTypeY> y("Y", N, K);
 
-          std::cout << "kdc mvu-018" << std::endl;
           Kokkos::deep_copy(a, valueA);
           if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
             for (int k(0); k < K; ++k) {
-              b.h_view[k] = valueB + k; // Aqui
+              b.h_view[k] = valueB + k;
             }
-            std::cout << "kdc mvu-019" << std::endl;
-            Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
+            Kokkos::deep_copy(b.d_base, b.h_base);
           } else {
             for (int k(0); k < K; ++k) {
               b.h_base[k] = valueB + k;
             }
-            std::cout << "kdc mvu-020" << std::endl;
             Kokkos::deep_copy(b.d_base, b.h_base);
           }
           impl_test_axpby_mv_unification_compare<
@@ -1560,7 +1566,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 13/36: Ar1s_1 + Bscalar
   // ************************************************************w
-  // std::cout << "Starting case 13/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 13/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1571,7 +1579,6 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         tScalarB b;
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
-        std::cout << "kdc mvu-021" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
         b = valueB;
         impl_test_axpby_mv_unification_compare<
@@ -1593,7 +1600,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 14/36: Ar1s_1 + Br0
   // ************************************************************
-  // std::cout << "Starting case 14/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 14/36" << std::endl;
+#endif
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -1607,9 +1616,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           ViewTypeBr0 b("B");
           view_stride_adapter<ViewTypeY> y("Y", N, K);
 
-          std::cout << "kdc mvu-022" << std::endl;
           Kokkos::deep_copy(a.d_base, valueA);
-          std::cout << "kdc mvu-023" << std::endl;
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
@@ -1631,7 +1638,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 15/36: Ar1s_1 + Br1s_1
   // ************************************************************
-  // std::cout << "Starting case 15/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 15/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1642,9 +1651,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeBr1s_1> b("B", 1);
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
-        std::cout << "kdc mvu-024" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
-        std::cout << "kdc mvu-025" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
@@ -1666,7 +1673,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 16/36: Ar1s_1 + Br1s_k
   // ************************************************************
-  // std::cout << "Starting case 16/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 16/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1677,19 +1686,16 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeBr1s_k> b("B", K);
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
-        std::cout << "kdc mvu-026" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k; // Aqui
+            b.h_view[k] = valueB + k;
           }
-          std::cout << "kdc mvu-027" << std::endl;
-          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
+          Kokkos::deep_copy(b.d_base, b.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
-          std::cout << "kdc mvu-028" << std::endl;
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
         impl_test_axpby_mv_unification_compare<
@@ -1704,7 +1710,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 17/36: Ar1s_1 + Br1d,1
   // ************************************************************
-  // std::cout << "Starting case 17/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 17/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1715,9 +1723,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeBr1d> b("B", 1);
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
-        std::cout << "kdc mvu-029" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
-        std::cout << "kdc mvu-030" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1s_1>,
@@ -1738,7 +1744,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 18/36: Ar1s_1 + Br1d,k
   // ************************************************************
-  // std::cout << "Starting case 18/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 18/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1749,19 +1757,16 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeBr1d> b("B", K);
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
-        std::cout << "kdc mvu-031" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k; // Aqui
+            b.h_view[k] = valueB + k;
           }
-          std::cout << "kdc mvu-032" << std::endl;
-          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
+          Kokkos::deep_copy(b.d_base, b.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
-          std::cout << "kdc mvu-033" << std::endl;
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
         impl_test_axpby_mv_unification_compare<
@@ -1776,7 +1781,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 19/36: Ar1s_k + Bscalar
   // ************************************************************
-  // std::cout << "Starting case 19/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 19/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1789,15 +1796,13 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k; // Aqui
+            a.h_view[k] = valueA + k;
           }
-          std::cout << "kdc mvu-034" << std::endl;
-          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
+          Kokkos::deep_copy(a.d_base, a.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
-          std::cout << "kdc mvu-035" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
         b = valueB;
@@ -1820,7 +1825,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 20/36: Ar1s_k + Br0
   // ************************************************************
-  // std::cout << "Starting case 20/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 20/36" << std::endl;
+#endif
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -1836,18 +1843,15 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
           if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
             for (int k(0); k < K; ++k) {
-              a.h_view[k] = valueA + k; // Aqui
+              a.h_view[k] = valueA + k;
             }
-            std::cout << "kdc mvu-036" << std::endl;
-            Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
+            Kokkos::deep_copy(a.d_base, a.h_base);
           } else {
             for (int k(0); k < K; ++k) {
               a.h_base[k] = valueA + k;
             }
-            std::cout << "kdc mvu-037" << std::endl;
             Kokkos::deep_copy(a.d_base, a.h_base);
           }
-          std::cout << "kdc mvu-038" << std::endl;
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1s_k>,
@@ -1869,7 +1873,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 21/36: Ar1s_k + Br1s_1
   // ************************************************************
-  // std::cout << "Starting case 21/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 21/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1882,18 +1888,15 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k; // Aqui
+            a.h_view[k] = valueA + k;
           }
-          std::cout << "kdc mvu-039" << std::endl;
-          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
+          Kokkos::deep_copy(a.d_base, a.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
-          std::cout << "kdc mvu-040" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
-        std::cout << "kdc mvu-041" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1s_k>,
@@ -1915,7 +1918,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 22/36: Ar1s_k + Br1s_k
   // ************************************************************
-  // std::cout << "Starting case 22/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 22/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1928,29 +1933,25 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k; // Aqui
+            a.h_view[k] = valueA + k;
           }
-          std::cout << "kdc mvu-042" << std::endl;
-          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
+          Kokkos::deep_copy(a.d_base, a.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
-          std::cout << "kdc mvu-043" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
 
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k; // Aqui
+            b.h_view[k] = valueB + k;
           }
-          std::cout << "kdc mvu-044" << std::endl;
-          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
+          Kokkos::deep_copy(b.d_base, b.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
-          std::cout << "kdc mvu-045" << std::endl;
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
         impl_test_axpby_mv_unification_compare<
@@ -1965,7 +1966,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 23/36: Ar1s_k + Br1d,1
   // ************************************************************
-  // std::cout << "Starting case 23/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 23/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -1978,18 +1981,15 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k; // Aqui
+            a.h_view[k] = valueA + k;
           }
-          std::cout << "kdc mvu-046" << std::endl;
-          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
+          Kokkos::deep_copy(a.d_base, a.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
-          std::cout << "kdc mvu-047" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
-        std::cout << "kdc mvu-048" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1s_k>,
@@ -2010,7 +2010,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 24/36: Ar1s_k + Br1d,k
   // ************************************************************
-  // std::cout << "Starting case 24/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 24/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -2023,29 +2025,25 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k; // Aqui
+            a.h_view[k] = valueA + k;
           }
-          std::cout << "kdc mvu-049" << std::endl;
-          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
+          Kokkos::deep_copy(a.d_base, a.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
-          std::cout << "kdc mvu-050" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
 
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k; // Aqui
+            b.h_view[k] = valueB + k;
           }
-          std::cout << "kdc mvu-051" << std::endl;
-          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
+          Kokkos::deep_copy(b.d_base, b.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
-          std::cout << "kdc mvu-052" << std::endl;
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
 
@@ -2061,7 +2059,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 25/36: Ar1d,1 + Bscalar
   // ************************************************************w
-  // std::cout << "Starting case 25/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 25/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -2072,7 +2072,6 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         tScalarB b;
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
-        std::cout << "kdc mvu-053" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
         b = valueB;
         impl_test_axpby_mv_unification_compare<
@@ -2094,7 +2093,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 26/36: Ar1d,1 + Br0
   // ************************************************************
-  // std::cout << "Starting case 26/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 26/36" << std::endl;
+#endif
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -2108,9 +2109,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           ViewTypeBr0 b("B");
           view_stride_adapter<ViewTypeY> y("Y", N, K);
 
-          std::cout << "kdc mvu-054" << std::endl;
           Kokkos::deep_copy(a.d_base, valueA);
-          std::cout << "kdc mvu-055" << std::endl;
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1d>,
@@ -2132,7 +2131,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 27/36: Ar1d,1 + Br1s_1
   // ************************************************************
-  // std::cout << "Starting case 27/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 27/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -2143,9 +2144,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeBr1s_1> b("B", 1);
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
-        std::cout << "kdc mvu-056" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
-        std::cout << "kdc mvu-057" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1d>,
@@ -2167,7 +2166,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 28/36: Ar1d,1 + Br1s_k
   // ************************************************************
-  // std::cout << "Starting case 28/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 28/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -2178,19 +2179,16 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeBr1s_k> b("B", K);
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
-        std::cout << "kdc mvu-058" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k; // Aqui
+            b.h_view[k] = valueB + k;
           }
-          std::cout << "kdc mvu-059" << std::endl;
-          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
+          Kokkos::deep_copy(b.d_base, b.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
-          std::cout << "kdc mvu-060" << std::endl;
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
         impl_test_axpby_mv_unification_compare<
@@ -2205,7 +2203,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 29/36: Ar1d,1 + Br1d,1
   // ************************************************************
-  // std::cout << "Starting case 29/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 29/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -2216,9 +2216,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeBr1d> b("B", 1);
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
-        std::cout << "kdc mvu-061" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
-        std::cout << "kdc mvu-062" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1d>,
@@ -2239,7 +2237,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 30/36: Ar1d,1 + Br1d,k
   // ************************************************************
-  // std::cout << "Starting case 30/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 30/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -2250,19 +2250,16 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         view_stride_adapter<ViewTypeBr1d> b("B", K);
         view_stride_adapter<ViewTypeY> y("Y", N, K);
 
-        std::cout << "kdc mvu-063" << std::endl;
         Kokkos::deep_copy(a.d_base, valueA);
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k; // Aqui
+            b.h_view[k] = valueB + k;
           }
-          std::cout << "kdc mvu-064" << std::endl;
-          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
+          Kokkos::deep_copy(b.d_base, b.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
-          std::cout << "kdc mvu-065" << std::endl;
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
         impl_test_axpby_mv_unification_compare<
@@ -2277,7 +2274,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 31/36: Ar1d,k + Bscalar
   // ************************************************************w
-  // std::cout << "Starting case 31/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 31/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -2290,15 +2289,13 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k; // Aqui
+            a.h_view[k] = valueA + k;
           }
-          std::cout << "kdc mvu-066" << std::endl;
-          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
+          Kokkos::deep_copy(a.d_base, a.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
-          std::cout << "kdc mvu-067" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
         b = valueB;
@@ -2321,7 +2318,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 32/36: Ar1d,k + Br0
   // ************************************************************
-  // std::cout << "Starting case 32/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 32/36" << std::endl;
+#endif
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
     // Avoid the test, due to compilation errors
   } else {
@@ -2337,18 +2336,15 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
           if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
             for (int k(0); k < K; ++k) {
-              a.h_view[k] = valueA + k; // Aqui
+              a.h_view[k] = valueA + k;
             }
-            std::cout << "kdc mvu-068" << std::endl;
-            Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
+            Kokkos::deep_copy(a.d_base, a.h_base);
           } else {
             for (int k(0); k < K; ++k) {
               a.h_base[k] = valueA + k;
             }
-            std::cout << "kdc mvu-069" << std::endl;
             Kokkos::deep_copy(a.d_base, a.h_base);
           }
-          std::cout << "kdc mvu-070" << std::endl;
           Kokkos::deep_copy(b, valueB);
           impl_test_axpby_mv_unification_compare<
               tScalarA, view_stride_adapter<ViewTypeAr1d>,
@@ -2370,7 +2366,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 33/36: Ar1d,k + Br1s_1
   // ************************************************************
-  // std::cout << "Starting case 33/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 33/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -2383,18 +2381,15 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k; // Aqui
+            a.h_view[k] = valueA + k;
           }
-          std::cout << "kdc mvu-071" << std::endl;
-          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
+          Kokkos::deep_copy(a.d_base, a.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
-          std::cout << "kdc mvu-072" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
-        std::cout << "kdc mvu-073" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1d>,
@@ -2416,7 +2411,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 34/36: Ar1d,k + Br1s_k
   // ************************************************************
-  // std::cout << "Starting case 34/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 34/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -2429,29 +2426,25 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k; // Aqui
+            a.h_view[k] = valueA + k;
           }
-          std::cout << "kdc mvu-074" << std::endl;
-          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
+          Kokkos::deep_copy(a.d_base, a.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
-          std::cout << "kdc mvu-075" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
 
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k; // Aqui
+            b.h_view[k] = valueB + k;
           }
-          std::cout << "kdc mvu-076" << std::endl;
-          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
+          Kokkos::deep_copy(b.d_base, b.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
-          std::cout << "kdc mvu-077" << std::endl;
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
 
@@ -2467,7 +2460,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 35/36: Ar1d,k + Br1d,1
   // ************************************************************
-  // std::cout << "Starting case 35/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 35/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -2480,18 +2475,15 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k; // Aqui
+            a.h_view[k] = valueA + k;
           }
-          std::cout << "kdc mvu-078" << std::endl;
-          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
+          Kokkos::deep_copy(a.d_base, a.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
-          std::cout << "kdc mvu-079" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
-        std::cout << "kdc mvu-080" << std::endl;
         Kokkos::deep_copy(b.d_base, valueB);
         impl_test_axpby_mv_unification_compare<
             tScalarA, view_stride_adapter<ViewTypeAr1d>,
@@ -2512,7 +2504,9 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 36/36: Ar1d,k + Br1d,k
   // ************************************************************
-  // std::cout << "Starting case 36/36" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 36/36" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {
@@ -2525,29 +2519,28 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k; // Aqui
+            a.h_view[k] = valueA + k;
           }
-          std::cout << "kdc mvu-081" << std::endl;
-          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
+          Kokkos::deep_copy(a.d_base, a.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
           }
-          std::cout << "kdc mvu-082" << std::endl;
           Kokkos::deep_copy(a.d_base, a.h_base);
         }
 
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k; // Aqui
+            b.h_view[k] = valueB + k;
           }
-          std::cout << "kdc mvu-083" << std::endl;
-          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
+          Kokkos::deep_copy(b.d_base, b.h_base);
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
           }
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
           std::cout << "kdc mvu-084" << std::endl;
+#endif
           Kokkos::deep_copy(b.d_base, b.h_base);
         }
 
@@ -2563,18 +2556,18 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // std::cout << "Leaving impl_test_axpby_mv_unification()" << std::endl;
   // std::cout << "=========================================" << std::endl;
 }
-#endif // Aqui
 
 }  // namespace Test
 
 template <class tScalarA, class tScalarX, class tScalarB, class tScalarY,
           class Device>
 int test_axpby_unification() {
-#if 1 // Aqui
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&      \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "Calling impl_test_axpby_unif(), L-LLL" << std::endl;
+#endif
   Test::impl_test_axpby_unification<
       tScalarA, Kokkos::LayoutLeft, tScalarX, Kokkos::LayoutLeft, tScalarB,
       Kokkos::LayoutLeft, tScalarY, Kokkos::LayoutLeft, Device>(14);
@@ -2583,16 +2576,19 @@ int test_axpby_unification() {
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&       \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "Calling impl_test_axpby_unif(), L-RRR" << std::endl;
+#endif
   Test::impl_test_axpby_unification<
       tScalarA, Kokkos::LayoutRight, tScalarX, Kokkos::LayoutRight, tScalarB,
       Kokkos::LayoutRight, tScalarY, Kokkos::LayoutRight, Device>(14);
 #endif
-#endif // Aqui
 
 #if (!defined(KOKKOSKERNELS_ETI_ONLY) && \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "Calling impl_test_axpby_unif(), L-SSS" << std::endl;
+#endif
   Test::impl_test_axpby_unification<
       tScalarA, Kokkos::LayoutStride, tScalarX, Kokkos::LayoutStride, tScalarB,
       Kokkos::LayoutStride, tScalarY, Kokkos::LayoutStride, Device>(14);
@@ -2600,22 +2596,30 @@ int test_axpby_unification() {
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && \
     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "Calling impl_test_axpby_unif(), L-SLL" << std::endl;
+#endif
   Test::impl_test_axpby_unification<
       tScalarA, Kokkos::LayoutStride, tScalarX, Kokkos::LayoutStride, tScalarB,
       Kokkos::LayoutLeft, tScalarY, Kokkos::LayoutLeft, Device>(14);
 
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "Calling impl_test_axpby_unif(), L-LSS" << std::endl;
+#endif
   Test::impl_test_axpby_unification<
       tScalarA, Kokkos::LayoutLeft, tScalarX, Kokkos::LayoutLeft, tScalarB,
       Kokkos::LayoutStride, tScalarY, Kokkos::LayoutStride, Device>(14);
 
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "Calling impl_test_axpby_unif(), L-SRS" << std::endl;
+#endif
   Test::impl_test_axpby_unification<
       tScalarA, Kokkos::LayoutLeft, tScalarX, Kokkos::LayoutStride, tScalarB,
       Kokkos::LayoutRight, tScalarY, Kokkos::LayoutStride, Device>(14);
 
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "Calling impl_test_axpby_unif(), L-LSR" << std::endl;
+#endif
   Test::impl_test_axpby_unification<
       tScalarA, Kokkos::LayoutStride, tScalarX, Kokkos::LayoutLeft, tScalarB,
       Kokkos::LayoutStride, tScalarY, Kokkos::LayoutRight, Device>(14);
@@ -2623,7 +2627,6 @@ int test_axpby_unification() {
   return 1;
 }
 
-#if 1 // Aqui
 template <class tScalarA, class tScalarX, class tScalarB, class tScalarY,
           class Device>
 int test_axpby_mv_unification() {
@@ -2676,7 +2679,6 @@ int test_axpby_mv_unification() {
 #endif
   return 1;
 }
-#endif // Aqui
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && \
@@ -2686,13 +2688,11 @@ TEST_F(TestCategory, axpby_unification_float) {
   test_axpby_unification<float, float, float, float, TestDevice>();
   Kokkos::Profiling::popRegion();
 }
-#if 1 // Aqui
 TEST_F(TestCategory, axpby_mv_unification_float) {
   Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpby_mv_unification_float");
   test_axpby_mv_unification<float, float, float, float, TestDevice>();
   Kokkos::Profiling::popRegion();
 }
-#endif
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || \
@@ -2702,14 +2702,12 @@ TEST_F(TestCategory, axpby_unification_double) {
   Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpby_unification_double");
   test_axpby_unification<double, double, double, double, TestDevice>();
 }
-#if 1 // Aqui
 TEST_F(TestCategory, axpby_mv_unification_double) {
   Kokkos::Profiling::pushRegion(
       "KokkosBlas::Test::axpby_mv_unification_double");
   test_axpby_mv_unification<double, double, double, double, TestDevice>();
   Kokkos::Profiling::popRegion();
 }
-#endif
 #endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || \
@@ -2723,7 +2721,6 @@ TEST_F(TestCategory, axpby_unification_complex_double) {
                          TestDevice>();
   Kokkos::Profiling::popRegion();
 }
-#if 1 // Aqui
 TEST_F(TestCategory, axpby_mv_unification_complex_double) {
   Kokkos::Profiling::pushRegion(
       "KokkosBlas::Test::axpby_mv_unification_complex_double");
@@ -2732,7 +2729,6 @@ TEST_F(TestCategory, axpby_mv_unification_complex_double) {
                             TestDevice>();
   Kokkos::Profiling::popRegion();
 }
-#endif
 #endif
 
 #if defined(KOKKOSKERNELS_INST_INT) ||   \
@@ -2743,13 +2739,11 @@ TEST_F(TestCategory, axpby_unification_int) {
   test_axpby_unification<int, int, int, int, TestDevice>();
   Kokkos::Profiling::popRegion();
 }
-#if 1 // Aqui
 TEST_F(TestCategory, axpby_mv_unification_int) {
   Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpby_mv_unification_int");
   test_axpby_mv_unification<int, int, int, int, TestDevice>();
   Kokkos::Profiling::popRegion();
 }
-#endif
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && \
@@ -2760,12 +2754,10 @@ TEST_F(TestCategory, axpby_unification_double_int) {
   test_axpby_unification<double, double, int, int, TestDevice>();
   Kokkos::Profiling::popRegion();
 }
-#if 1 // Aqui
 TEST_F(TestCategory, axpby_double_mv_unification_int) {
   Kokkos::Profiling::pushRegion(
       "KokkosBlas::Test::axpby_mv_unification_double_int");
   test_axpby_mv_unification<double, double, int, int, TestDevice>();
   Kokkos::Profiling::popRegion();
 }
-#endif
 #endif

--- a/blas/unit_test/Test_Blas1_axpby_unification.hpp
+++ b/blas/unit_test/Test_Blas1_axpby_unification.hpp
@@ -27,8 +27,8 @@
 //
 // Choices (01)-(03) are selected in the routines TEST_F() at the very
 // bottom of the file, when calling:
-// - either test_axpby_unificationr<...>(),
-// - or test_axpby_mv_unificationr<...>().
+// - either test_axpby_unification<...>(),
+// - or test_axpby_mv_unification<...>().
 //
 // Choices (04)-(05) are selected in routines:
 // - test_axpby_unification<...>(), when calling
@@ -99,7 +99,7 @@ void impl_test_axpby_unification_compare(
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   std::cout << "kdc a-001" << std::endl;
-  Kokkos::deep_copy(x.h_view, x.d_view);
+  Kokkos::deep_copy(x.h_base, x.d_base); // Aqui
 
   {
     ScalarTypeY randStart, randEnd;
@@ -113,7 +113,7 @@ void impl_test_axpby_unification_compare(
   }
   tY org_y("Org_Y", N);
   std::cout << "kdc a-003" << std::endl;
-  Kokkos::deep_copy(org_y.h_view, y.d_view);
+  Kokkos::deep_copy(org_y.h_base, y.d_base); // Aqui
 
   tScalarA valueA(Kokkos::ArithTraits<tScalarA>::zero());
   tScalarB valueB(Kokkos::ArithTraits<tScalarB>::zero());
@@ -136,7 +136,7 @@ void impl_test_axpby_unification_compare(
       KokkosBlas::axpby(a, x.d_view, b, y.d_view);
     } else {
       std::cout << "kdc a-005" << std::endl;
-      Kokkos::deep_copy(b.h_view, b.d_view);
+      Kokkos::deep_copy(b.h_base, b.d_base); // Aqui
       valueB = b.h_view(0);
       KokkosBlas::axpby(a, x.d_view, b.d_view, y.d_view);
     }
@@ -166,13 +166,13 @@ void impl_test_axpby_unification_compare(
       KokkosBlas::axpby(a, x.d_view, b, y.d_view);
     } else {
       std::cout << "kdc a-008" << std::endl;
-      Kokkos::deep_copy(b.h_view, b.d_view);
+      Kokkos::deep_copy(b.h_base, b.d_base); // Aqui
       valueB = b.h_view(0);
       KokkosBlas::axpby(a, x.d_view, b.d_view, y.d_view);
     }
   } else {
     std::cout << "kdc a-008" << std::endl;
-    Kokkos::deep_copy(a.h_view, a.d_view);
+    Kokkos::deep_copy(a.h_base, a.d_base); // Aqui
     valueA = a.h_view(0);
     if constexpr (std::is_same_v<tB, tScalarB>) {
       valueB = b;
@@ -190,14 +190,14 @@ void impl_test_axpby_unification_compare(
       KokkosBlas::axpby(a.d_view, x.d_view, b, y.d_view);
     } else {
       std::cout << "kdc a-010" << std::endl;
-      Kokkos::deep_copy(b.h_view, b.d_view);
+      Kokkos::deep_copy(b.h_base, b.d_base); // Aqui
       valueB = b.h_view(0);
       KokkosBlas::axpby(a.d_view, x.d_view, b.d_view, y.d_view);
     }
   }
 
   std::cout << "kdc a-011" << std::endl;
-  Kokkos::deep_copy(y.h_view, y.d_view);
+  Kokkos::deep_copy(y.h_base, y.d_base); // Aqui
 
   if (testWithNanY == false) {
     for (int i(0); i < N; ++i) {
@@ -238,6 +238,7 @@ void impl_test_axpby_unification_compare(
   }
 }
 
+#if 1 // Aqui
 template <class tScalarA, class tA, class tX, class tScalarB, class tB,
           class tY, class Device>
 void impl_test_axpby_mv_unification_compare(
@@ -261,7 +262,7 @@ void impl_test_axpby_mv_unification_compare(
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   std::cout << "kdc b-001" << std::endl;
-  Kokkos::deep_copy(x.h_view, x.d_view);
+  Kokkos::deep_copy(x.h_base, x.d_base); // Aqui
 
   {
     ScalarTypeY randStart, randEnd;
@@ -275,14 +276,14 @@ void impl_test_axpby_mv_unification_compare(
   }
   tY org_y("Org_Y", N, K);
   std::cout << "kdc b-003" << std::endl;
-  Kokkos::deep_copy(org_y.h_view, y.d_view);
+  Kokkos::deep_copy(org_y.h_base, y.d_base); // Aqui
 
   // Cannot use "if constexpr (isRank1<tA>()) {" because rank-1 variables
   // are passed to current routine with view_stride_adapter<...>
   bool constexpr aIsRank1 = !std::is_same_v<tA, tScalarA> && !isRank0<tA>();
   if constexpr (aIsRank1) {
     std::cout << "kdc b-004" << std::endl;
-    Kokkos::deep_copy(a.h_view, a.d_view);
+    Kokkos::deep_copy(a.h_base, a.d_base); // Aqui
   }
 
   // Cannot use "if constexpr (isRank1<tB>()) {" because rank-1 variables
@@ -290,7 +291,7 @@ void impl_test_axpby_mv_unification_compare(
   bool constexpr bIsRank1 = !std::is_same_v<tB, tScalarB> && !isRank0<tB>();
   if constexpr (bIsRank1) {
     std::cout << "kdc b-005" << std::endl;
-    Kokkos::deep_copy(b.h_view, b.d_view);
+    Kokkos::deep_copy(b.h_base, b.d_base); // Aqui
   }
 
   tScalarA valueA(Kokkos::ArithTraits<tScalarA>::zero());
@@ -366,7 +367,7 @@ void impl_test_axpby_mv_unification_compare(
   }
 
   std::cout << "kdc b-010" << std::endl;
-  Kokkos::deep_copy(y.h_view, y.d_view);
+  Kokkos::deep_copy(y.h_base, y.d_base); // Aqui
 
   if (testWithNanY == false) {
     for (int i(0); i < N; ++i) {
@@ -489,6 +490,7 @@ void impl_test_axpby_mv_unification_compare(
     }
   }
 }
+#endif // Aqui
 
 template <class tScalarA, class tLayoutA, class tScalarX, class tLayoutX,
           class tScalarB, class tLayoutB, class tScalarY, class tLayoutY,
@@ -1081,6 +1083,7 @@ void impl_test_axpby_unification(int const N) {
   }
 }
 
+#if 1 // Aqui
 template <class tScalarA, class tLayoutA, class tScalarX, class tLayoutX,
           class tScalarB, class tLayoutB, class tScalarY, class tLayoutY,
           class Device>
@@ -1238,10 +1241,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         a = valueA;
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k;
+            b.h_view[k] = valueB + k; // Aqui
           }
           std::cout << "kdc mvu-003" << std::endl;
-          Kokkos::deep_copy(b.d_view, b.h_view);
+          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
@@ -1305,10 +1308,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         a = valueA;
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k;
+            b.h_view[k] = valueB + k; // Aqui
           }
           std::cout << "kdc mvu-006" << std::endl;
-          Kokkos::deep_copy(b.d_view, b.h_view);
+          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
@@ -1455,10 +1458,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           Kokkos::deep_copy(a, valueA);
           if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
             for (int k(0); k < K; ++k) {
-              b.h_view[k] = valueB + k;
+              b.h_view[k] = valueB + k; // Aqui
             }
             std::cout << "kdc mvu-014" << std::endl;
-            Kokkos::deep_copy(b.d_view, b.h_view);
+            Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
           } else {
             for (int k(0); k < K; ++k) {
               b.h_base[k] = valueB + k;
@@ -1534,10 +1537,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
           Kokkos::deep_copy(a, valueA);
           if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
             for (int k(0); k < K; ++k) {
-              b.h_view[k] = valueB + k;
+              b.h_view[k] = valueB + k; // Aqui
             }
             std::cout << "kdc mvu-019" << std::endl;
-            Kokkos::deep_copy(b.d_view, b.h_view);
+            Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
           } else {
             for (int k(0); k < K; ++k) {
               b.h_base[k] = valueB + k;
@@ -1678,10 +1681,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         Kokkos::deep_copy(a.d_base, valueA);
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k;
+            b.h_view[k] = valueB + k; // Aqui
           }
           std::cout << "kdc mvu-027" << std::endl;
-          Kokkos::deep_copy(b.d_view, b.h_view);
+          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
@@ -1750,10 +1753,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         Kokkos::deep_copy(a.d_base, valueA);
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k;
+            b.h_view[k] = valueB + k; // Aqui
           }
           std::cout << "kdc mvu-032" << std::endl;
-          Kokkos::deep_copy(b.d_view, b.h_view);
+          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
@@ -1786,10 +1789,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k;
+            a.h_view[k] = valueA + k; // Aqui
           }
           std::cout << "kdc mvu-034" << std::endl;
-          Kokkos::deep_copy(a.d_view, a.h_view);
+          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
@@ -1833,10 +1836,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
           if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
             for (int k(0); k < K; ++k) {
-              a.h_view[k] = valueA + k;
+              a.h_view[k] = valueA + k; // Aqui
             }
             std::cout << "kdc mvu-036" << std::endl;
-            Kokkos::deep_copy(a.d_view, a.h_view);
+            Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
           } else {
             for (int k(0); k < K; ++k) {
               a.h_base[k] = valueA + k;
@@ -1879,10 +1882,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k;
+            a.h_view[k] = valueA + k; // Aqui
           }
           std::cout << "kdc mvu-039" << std::endl;
-          Kokkos::deep_copy(a.d_view, a.h_view);
+          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
@@ -1925,10 +1928,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k;
+            a.h_view[k] = valueA + k; // Aqui
           }
           std::cout << "kdc mvu-042" << std::endl;
-          Kokkos::deep_copy(a.d_view, a.h_view);
+          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
@@ -1939,10 +1942,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k;
+            b.h_view[k] = valueB + k; // Aqui
           }
           std::cout << "kdc mvu-044" << std::endl;
-          Kokkos::deep_copy(b.d_view, b.h_view);
+          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
@@ -1975,10 +1978,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k;
+            a.h_view[k] = valueA + k; // Aqui
           }
           std::cout << "kdc mvu-046" << std::endl;
-          Kokkos::deep_copy(a.d_view, a.h_view);
+          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
@@ -2020,10 +2023,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k;
+            a.h_view[k] = valueA + k; // Aqui
           }
           std::cout << "kdc mvu-049" << std::endl;
-          Kokkos::deep_copy(a.d_view, a.h_view);
+          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
@@ -2034,10 +2037,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k;
+            b.h_view[k] = valueB + k; // Aqui
           }
           std::cout << "kdc mvu-051" << std::endl;
-          Kokkos::deep_copy(b.d_view, b.h_view);
+          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
@@ -2179,10 +2182,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         Kokkos::deep_copy(a.d_base, valueA);
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k;
+            b.h_view[k] = valueB + k; // Aqui
           }
           std::cout << "kdc mvu-059" << std::endl;
-          Kokkos::deep_copy(b.d_view, b.h_view);
+          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
@@ -2251,10 +2254,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
         Kokkos::deep_copy(a.d_base, valueA);
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k;
+            b.h_view[k] = valueB + k; // Aqui
           }
           std::cout << "kdc mvu-064" << std::endl;
-          Kokkos::deep_copy(b.d_view, b.h_view);
+          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
@@ -2287,10 +2290,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k;
+            a.h_view[k] = valueA + k; // Aqui
           }
           std::cout << "kdc mvu-066" << std::endl;
-          Kokkos::deep_copy(a.d_view, a.h_view);
+          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
@@ -2334,10 +2337,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
           if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
             for (int k(0); k < K; ++k) {
-              a.h_view[k] = valueA + k;
+              a.h_view[k] = valueA + k; // Aqui
             }
             std::cout << "kdc mvu-068" << std::endl;
-            Kokkos::deep_copy(a.d_view, a.h_view);
+            Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
           } else {
             for (int k(0); k < K; ++k) {
               a.h_base[k] = valueA + k;
@@ -2380,10 +2383,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k;
+            a.h_view[k] = valueA + k; // Aqui
           }
           std::cout << "kdc mvu-071" << std::endl;
-          Kokkos::deep_copy(a.d_view, a.h_view);
+          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
@@ -2426,10 +2429,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k;
+            a.h_view[k] = valueA + k; // Aqui
           }
           std::cout << "kdc mvu-074" << std::endl;
-          Kokkos::deep_copy(a.d_view, a.h_view);
+          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
@@ -2440,10 +2443,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k;
+            b.h_view[k] = valueB + k; // Aqui
           }
           std::cout << "kdc mvu-076" << std::endl;
-          Kokkos::deep_copy(b.d_view, b.h_view);
+          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
@@ -2477,10 +2480,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k;
+            a.h_view[k] = valueA + k; // Aqui
           }
           std::cout << "kdc mvu-078" << std::endl;
-          Kokkos::deep_copy(a.d_view, a.h_view);
+          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
@@ -2522,10 +2525,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            a.h_view[k] = valueA + k;
+            a.h_view[k] = valueA + k; // Aqui
           }
           std::cout << "kdc mvu-081" << std::endl;
-          Kokkos::deep_copy(a.d_view, a.h_view);
+          Kokkos::deep_copy(a.d_base, a.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             a.h_base[k] = valueA + k;
@@ -2536,10 +2539,10 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
 
         if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
           for (int k(0); k < K; ++k) {
-            b.h_view[k] = valueB + k;
+            b.h_view[k] = valueB + k; // Aqui
           }
           std::cout << "kdc mvu-083" << std::endl;
-          Kokkos::deep_copy(b.d_view, b.h_view);
+          Kokkos::deep_copy(b.d_base, b.h_base); // Aqui
         } else {
           for (int k(0); k < K; ++k) {
             b.h_base[k] = valueB + k;
@@ -2560,15 +2563,18 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // std::cout << "Leaving impl_test_axpby_mv_unification()" << std::endl;
   // std::cout << "=========================================" << std::endl;
 }
+#endif // Aqui
 
 }  // namespace Test
 
 template <class tScalarA, class tScalarX, class tScalarB, class tScalarY,
           class Device>
 int test_axpby_unification() {
+#if 1 // Aqui
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&      \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  std::cout << "Calling impl_test_axpby_unif(), L-LLL" << std::endl;
   Test::impl_test_axpby_unification<
       tScalarA, Kokkos::LayoutLeft, tScalarX, Kokkos::LayoutLeft, tScalarB,
       Kokkos::LayoutLeft, tScalarY, Kokkos::LayoutLeft, Device>(14);
@@ -2577,13 +2583,16 @@ int test_axpby_unification() {
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&       \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  std::cout << "Calling impl_test_axpby_unif(), L-RRR" << std::endl;
   Test::impl_test_axpby_unification<
       tScalarA, Kokkos::LayoutRight, tScalarX, Kokkos::LayoutRight, tScalarB,
       Kokkos::LayoutRight, tScalarY, Kokkos::LayoutRight, Device>(14);
 #endif
+#endif // Aqui
 
 #if (!defined(KOKKOSKERNELS_ETI_ONLY) && \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  std::cout << "Calling impl_test_axpby_unif(), L-SSS" << std::endl;
   Test::impl_test_axpby_unification<
       tScalarA, Kokkos::LayoutStride, tScalarX, Kokkos::LayoutStride, tScalarB,
       Kokkos::LayoutStride, tScalarY, Kokkos::LayoutStride, Device>(14);
@@ -2591,18 +2600,22 @@ int test_axpby_unification() {
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && \
     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
+  std::cout << "Calling impl_test_axpby_unif(), L-SLL" << std::endl;
   Test::impl_test_axpby_unification<
       tScalarA, Kokkos::LayoutStride, tScalarX, Kokkos::LayoutStride, tScalarB,
       Kokkos::LayoutLeft, tScalarY, Kokkos::LayoutLeft, Device>(14);
 
+  std::cout << "Calling impl_test_axpby_unif(), L-LSS" << std::endl;
   Test::impl_test_axpby_unification<
       tScalarA, Kokkos::LayoutLeft, tScalarX, Kokkos::LayoutLeft, tScalarB,
       Kokkos::LayoutStride, tScalarY, Kokkos::LayoutStride, Device>(14);
 
+  std::cout << "Calling impl_test_axpby_unif(), L-SRS" << std::endl;
   Test::impl_test_axpby_unification<
       tScalarA, Kokkos::LayoutLeft, tScalarX, Kokkos::LayoutStride, tScalarB,
       Kokkos::LayoutRight, tScalarY, Kokkos::LayoutStride, Device>(14);
 
+  std::cout << "Calling impl_test_axpby_unif(), L-LSR" << std::endl;
   Test::impl_test_axpby_unification<
       tScalarA, Kokkos::LayoutStride, tScalarX, Kokkos::LayoutLeft, tScalarB,
       Kokkos::LayoutStride, tScalarY, Kokkos::LayoutRight, Device>(14);
@@ -2610,6 +2623,7 @@ int test_axpby_unification() {
   return 1;
 }
 
+#if 1 // Aqui
 template <class tScalarA, class tScalarX, class tScalarB, class tScalarY,
           class Device>
 int test_axpby_mv_unification() {
@@ -2662,6 +2676,7 @@ int test_axpby_mv_unification() {
 #endif
   return 1;
 }
+#endif // Aqui
 
 #if defined(KOKKOSKERNELS_INST_FLOAT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && \
@@ -2671,11 +2686,13 @@ TEST_F(TestCategory, axpby_unification_float) {
   test_axpby_unification<float, float, float, float, TestDevice>();
   Kokkos::Profiling::popRegion();
 }
+#if 1 // Aqui
 TEST_F(TestCategory, axpby_mv_unification_float) {
   Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpby_mv_unification_float");
   test_axpby_mv_unification<float, float, float, float, TestDevice>();
   Kokkos::Profiling::popRegion();
 }
+#endif
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE) || \
@@ -2685,12 +2702,14 @@ TEST_F(TestCategory, axpby_unification_double) {
   Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpby_unification_double");
   test_axpby_unification<double, double, double, double, TestDevice>();
 }
+#if 1 // Aqui
 TEST_F(TestCategory, axpby_mv_unification_double) {
   Kokkos::Profiling::pushRegion(
       "KokkosBlas::Test::axpby_mv_unification_double");
   test_axpby_mv_unification<double, double, double, double, TestDevice>();
   Kokkos::Profiling::popRegion();
 }
+#endif
 #endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || \
@@ -2704,6 +2723,7 @@ TEST_F(TestCategory, axpby_unification_complex_double) {
                          TestDevice>();
   Kokkos::Profiling::popRegion();
 }
+#if 1 // Aqui
 TEST_F(TestCategory, axpby_mv_unification_complex_double) {
   Kokkos::Profiling::pushRegion(
       "KokkosBlas::Test::axpby_mv_unification_complex_double");
@@ -2712,6 +2732,7 @@ TEST_F(TestCategory, axpby_mv_unification_complex_double) {
                             TestDevice>();
   Kokkos::Profiling::popRegion();
 }
+#endif
 #endif
 
 #if defined(KOKKOSKERNELS_INST_INT) ||   \
@@ -2722,11 +2743,13 @@ TEST_F(TestCategory, axpby_unification_int) {
   test_axpby_unification<int, int, int, int, TestDevice>();
   Kokkos::Profiling::popRegion();
 }
+#if 1 // Aqui
 TEST_F(TestCategory, axpby_mv_unification_int) {
   Kokkos::Profiling::pushRegion("KokkosBlas::Test::axpby_mv_unification_int");
   test_axpby_mv_unification<int, int, int, int, TestDevice>();
   Kokkos::Profiling::popRegion();
 }
+#endif
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && \
@@ -2737,10 +2760,12 @@ TEST_F(TestCategory, axpby_unification_double_int) {
   test_axpby_unification<double, double, int, int, TestDevice>();
   Kokkos::Profiling::popRegion();
 }
+#if 1 // Aqui
 TEST_F(TestCategory, axpby_double_mv_unification_int) {
   Kokkos::Profiling::pushRegion(
       "KokkosBlas::Test::axpby_mv_unification_double_int");
   test_axpby_mv_unification<double, double, int, int, TestDevice>();
   Kokkos::Profiling::popRegion();
 }
+#endif
 #endif

--- a/blas/unit_test/Test_Blas1_axpby_unification.hpp
+++ b/blas/unit_test/Test_Blas1_axpby_unification.hpp
@@ -515,7 +515,9 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 01/16: Ascalar + Bscalar
   // ************************************************************
-  // std::cout << "Starting case 01/16" << std::endl;
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  std::cout << "Starting case 01/16" << std::endl;
+#endif
   for (size_t i(0); i < valuesA.size(); ++i) {
     tScalarA const valueA(valuesA[i]);
     for (size_t j(0); j < valuesB.size(); ++j) {

--- a/blas/unit_test/Test_Blas2_ger.hpp
+++ b/blas/unit_test/Test_Blas2_ger.hpp
@@ -404,9 +404,9 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
 
   if (_useAnalyticalResults) {
     this->populateAnalyticalValues(alpha, /*h_x*/x.h_view, /*h_y*/y.h_view, /*h_A*/A.h_view, h_expected);
-    Kokkos::deep_copy(/*x, h_x*/x.d_view,x.h_view);
-    Kokkos::deep_copy(/*y, h_y*/y.d_view,y.h_view);
-    Kokkos::deep_copy(/*A, h_A*/A.d_view,A.h_view);
+    Kokkos::deep_copy(/*x, h_x*/x.d_base,x.h_base);
+    Kokkos::deep_copy(/*y, h_y*/y.d_base,y.h_base);
+    Kokkos::deep_copy(/*A, h_A*/A.d_base,A.h_base);
 
     expectedResultIsKnown = true;
   } else if ((_M == 1) && (_N == 1)) {
@@ -418,9 +418,9 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
 
     /*h_A*/A.h_view(0, 0) = 7;
 
-    Kokkos::deep_copy(/*x, h_x*/x.d_view,x.h_view);
-    Kokkos::deep_copy(/*y, h_y*/y.d_view,y.h_view);
-    Kokkos::deep_copy(/*A, h_A*/A.d_view,A.h_view);
+    Kokkos::deep_copy(/*x, h_x*/x.d_base,x.h_base);
+    Kokkos::deep_copy(/*y, h_y*/y.d_base,y.h_base);
+    Kokkos::deep_copy(/*A, h_A*/A.d_base,A.h_base);
 
     h_expected(0, 0)      = 25;
     expectedResultIsKnown = true;
@@ -435,9 +435,9 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
     /*h_A*/A.h_view(0, 0) = 7;
     /*h_A*/A.h_view(0, 1) = -6;
 
-    Kokkos::deep_copy(/*x, h_x*/x.d_view,x.h_view);
-    Kokkos::deep_copy(/*y, h_y*/y.d_view,y.h_view);
-    Kokkos::deep_copy(/*A, h_A*/A.d_view,A.h_view);
+    Kokkos::deep_copy(/*x, h_x*/x.d_base,x.h_base);
+    Kokkos::deep_copy(/*y, h_y*/y.d_base,y.h_base);
+    Kokkos::deep_copy(/*A, h_A*/A.d_base,A.h_base);
 
     h_expected(0, 0)      = 25;
     h_expected(0, 1)      = 18;
@@ -456,9 +456,9 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
     /*h_A*/A.h_view(1, 0) = 29;
     /*h_A*/A.h_view(1, 1) = 101;
 
-    Kokkos::deep_copy(/*x, h_x*/x.d_view,x.h_view);
-    Kokkos::deep_copy(/*y, h_y*/y.d_view,y.h_view);
-    Kokkos::deep_copy(/*A, h_A*/A.d_view,A.h_view);
+    Kokkos::deep_copy(/*x, h_x*/x.d_base,x.h_base);
+    Kokkos::deep_copy(/*y, h_y*/y.d_base,y.h_base);
+    Kokkos::deep_copy(/*A, h_A*/A.d_base,A.h_base);
 
     h_expected(0, 0)      = -1;
     h_expected(0, 1)      = -1;
@@ -489,9 +489,9 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
       Kokkos::fill_random(A.d_view, rand_pool, randStart, randEnd);
     }
 
-    Kokkos::deep_copy(/*h_x, x*/x.h_view,x.d_view);
-    Kokkos::deep_copy(/*h_y, y*/y.h_view,y.d_view);
-    Kokkos::deep_copy(/*h_A, A*/A.h_view,A.d_view);
+    Kokkos::deep_copy(/*h_x, x*/x.h_base,x.d_base);
+    Kokkos::deep_copy(/*h_y, y*/y.h_base,y.d_base);
+    Kokkos::deep_copy(/*h_A, A*/A.h_base,A.d_base);
   }
 }
 
@@ -1413,7 +1413,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
       << "have thrown a std::exception";
 
   if ((gotStdException == false) && (gotUnknownException == false)) {
-    Kokkos::deep_copy(/*h_A, A*/A.h_view, A.d_view);
+    Kokkos::deep_copy(/*h_A, A*/A.h_base, A.d_base);
 
     this->compareKkGerAgainstExpected(alpha, /*h_A*/A.h_view, h_expected);
   }

--- a/blas/unit_test/Test_Blas2_ger.hpp
+++ b/blas/unit_test/Test_Blas2_ger.hpp
@@ -79,8 +79,10 @@ class GerTester {
   using _KAT_A   = Kokkos::ArithTraits<ScalarA>;
   using _AuxType = typename _KAT_A::mag_type;
 
-  void populateVariables(ScalarA& alpha, view_stride_adapter<_ViewTypeX, false>& x,
-                         view_stride_adapter<_ViewTypeY, false>& y, view_stride_adapter<_ViewTypeA, false>& A,
+  void populateVariables(ScalarA& alpha,
+                         view_stride_adapter<_ViewTypeX, false>& x,
+                         view_stride_adapter<_ViewTypeY, false>& y,
+                         view_stride_adapter<_ViewTypeA, false>& A,
                          _ViewTypeExpected& h_expected,
                          bool& expectedResultIsKnown);
 
@@ -148,10 +150,10 @@ class GerTester {
   T shrinkAngleToZeroTwoPiRange(const T input);
 
   template <class TX, class TY>
-  void callKkGerAndCompareAgainstExpected(const ScalarA& alpha, TX& x, TY& y,
-                                          view_stride_adapter<_ViewTypeA, false>& A,
-                                          const _ViewTypeExpected& h_expected,
-                                          const std::string& situation);
+  void callKkGerAndCompareAgainstExpected(
+      const ScalarA& alpha, TX& x, TY& y,
+      view_stride_adapter<_ViewTypeA, false>& A,
+      const _ViewTypeExpected& h_expected, const std::string& situation);
 
   const bool _A_is_complex;
   const bool _A_is_lr;
@@ -284,8 +286,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
   // ********************************************************************
   // Step 2 of 9: populate alpha, h_x, h_y, h_A, h_expected, x, y, A
   // ********************************************************************
-  this->populateVariables(alpha, x, y, A,
-                          h_expected.d_view,
+  this->populateVariables(alpha, x, y, A, h_expected.d_view,
                           expectedResultIsKnown);
 
   // ********************************************************************
@@ -331,8 +332,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
 
   if (test_x_y) {
     this->callKkGerAndCompareAgainstExpected(
-        alpha, x.d_view, y.d_view, A, h_expected.d_view,
-        "non const {x,y}");
+        alpha, x.d_view, y.d_view, A, h_expected.d_view, "non const {x,y}");
   }
 
   // ********************************************************************
@@ -341,8 +341,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
   if (test_cx_y) {
     Kokkos::deep_copy(A.d_base, org_A.d_base);
 
-    this->callKkGerAndCompareAgainstExpected(alpha, x.d_view_const, y.d_view,
-                                             A,
+    this->callKkGerAndCompareAgainstExpected(alpha, x.d_view_const, y.d_view, A,
                                              h_expected.d_view, "const x");
   }
 
@@ -352,8 +351,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
   if (test_x_cy) {
     Kokkos::deep_copy(A.d_base, org_A.d_base);
 
-    this->callKkGerAndCompareAgainstExpected(alpha, x.d_view, y.d_view_const,
-                                             A,
+    this->callKkGerAndCompareAgainstExpected(alpha, x.d_view, y.d_view_const, A,
                                              h_expected.d_view, "const y");
   }
 
@@ -386,19 +384,22 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
 
 template <class ScalarX, class tLayoutX, class ScalarY, class tLayoutY,
           class ScalarA, class tLayoutA, class Device>
-void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
-               Device>::populateVariables(ScalarA& alpha, view_stride_adapter<_ViewTypeX, false>& x,
-                                          view_stride_adapter<_ViewTypeY, false>& y,
-                                          view_stride_adapter<_ViewTypeA, false>& A,
-                                          _ViewTypeExpected& h_expected,
-                                          bool& expectedResultIsKnown) {
+void GerTester<
+    ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
+    Device>::populateVariables(ScalarA& alpha,
+                               view_stride_adapter<_ViewTypeX, false>& x,
+                               view_stride_adapter<_ViewTypeY, false>& y,
+                               view_stride_adapter<_ViewTypeA, false>& A,
+                               _ViewTypeExpected& h_expected,
+                               bool& expectedResultIsKnown) {
   expectedResultIsKnown = false;
 
   if (_useAnalyticalResults) {
-    this->populateAnalyticalValues(alpha, x.h_view, y.h_view, A.h_view, h_expected);
-    Kokkos::deep_copy(x.d_base,x.h_base);
-    Kokkos::deep_copy(y.d_base,y.h_base);
-    Kokkos::deep_copy(A.d_base,A.h_base);
+    this->populateAnalyticalValues(alpha, x.h_view, y.h_view, A.h_view,
+                                   h_expected);
+    Kokkos::deep_copy(x.d_base, x.h_base);
+    Kokkos::deep_copy(y.d_base, y.h_base);
+    Kokkos::deep_copy(A.d_base, A.h_base);
 
     expectedResultIsKnown = true;
   } else if ((_M == 1) && (_N == 1)) {
@@ -410,9 +411,9 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
 
     A.h_view(0, 0) = 7;
 
-    Kokkos::deep_copy(x.d_base,x.h_base);
-    Kokkos::deep_copy(y.d_base,y.h_base);
-    Kokkos::deep_copy(A.d_base,A.h_base);
+    Kokkos::deep_copy(x.d_base, x.h_base);
+    Kokkos::deep_copy(y.d_base, y.h_base);
+    Kokkos::deep_copy(A.d_base, A.h_base);
 
     h_expected(0, 0)      = 25;
     expectedResultIsKnown = true;
@@ -427,9 +428,9 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
     A.h_view(0, 0) = 7;
     A.h_view(0, 1) = -6;
 
-    Kokkos::deep_copy(x.d_base,x.h_base);
-    Kokkos::deep_copy(y.d_base,y.h_base);
-    Kokkos::deep_copy(A.d_base,A.h_base);
+    Kokkos::deep_copy(x.d_base, x.h_base);
+    Kokkos::deep_copy(y.d_base, y.h_base);
+    Kokkos::deep_copy(A.d_base, A.h_base);
 
     h_expected(0, 0)      = 25;
     h_expected(0, 1)      = 18;
@@ -448,9 +449,9 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
     A.h_view(1, 0) = 29;
     A.h_view(1, 1) = 101;
 
-    Kokkos::deep_copy(x.d_base,x.h_base);
-    Kokkos::deep_copy(y.d_base,y.h_base);
-    Kokkos::deep_copy(A.d_base,A.h_base);
+    Kokkos::deep_copy(x.d_base, x.h_base);
+    Kokkos::deep_copy(y.d_base, y.h_base);
+    Kokkos::deep_copy(A.d_base, A.h_base);
 
     h_expected(0, 0)      = -1;
     h_expected(0, 1)      = -1;
@@ -481,9 +482,9 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
       Kokkos::fill_random(A.d_view, rand_pool, randStart, randEnd);
     }
 
-    Kokkos::deep_copy(x.h_base,x.d_base);
-    Kokkos::deep_copy(y.h_base,y.d_base);
-    Kokkos::deep_copy(A.h_base,A.d_base);
+    Kokkos::deep_copy(x.h_base, x.d_base);
+    Kokkos::deep_copy(y.h_base, y.d_base);
+    Kokkos::deep_copy(A.h_base, A.d_base);
   }
 }
 
@@ -1358,10 +1359,10 @@ template <class ScalarX, class tLayoutX, class ScalarY, class tLayoutY,
 template <class TX, class TY>
 void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
                Device>::
-    callKkGerAndCompareAgainstExpected(const ScalarA& alpha, TX& x, TY& y,
-                                       view_stride_adapter<_ViewTypeA, false>& A,
-                                       const _ViewTypeExpected& h_expected,
-                                       const std::string& situation) {
+    callKkGerAndCompareAgainstExpected(
+        const ScalarA& alpha, TX& x, TY& y,
+        view_stride_adapter<_ViewTypeA, false>& A,
+        const _ViewTypeExpected& h_expected, const std::string& situation) {
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
 #if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(

--- a/blas/unit_test/Test_Blas2_ger.hpp
+++ b/blas/unit_test/Test_Blas2_ger.hpp
@@ -224,7 +224,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
                              const int nonConstConstCombinations,
                              const bool useAnalyticalResults,
                              const bool useHermitianOption) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "Entering GerTester::test()... - - - - - - - - - - - - - - - - "
                "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
                "- - - - - - - - - "
@@ -297,7 +297,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
   // ********************************************************************
   view_stride_adapter<_ViewTypeExpected, true> h_vanilla(
       "vanilla = A + alpha * x * y^{t,h}", _M, _N);
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
 #if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "In Test_Blas2_ger.hpp, computing vanilla A with alpha type = %s\n",
@@ -380,7 +380,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
   EXPECT_ANY_THROW(KokkosBlas::ger("", alpha, x.d_view, y.d_view, A.d_view))
       << "Failed test: kk ger should have thrown an exception for mode ''";
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "Leaving GerTester::test() - - - - - - - - - - - - - - - - - - "
                "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
                "- - - - - - - "
@@ -768,7 +768,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
           }
         }
         if (errorHappened && (numErrorsRealAbs + numErrorsRealRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
           std::cout << "ERROR, i = " << i << ", j = " << j
                     << ": h_expected(i,j).real() = " << h_expected(i, j).real()
                     << ", h_vanilla(i,j).real() = " << h_vanilla(i, j).real()
@@ -802,7 +802,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
           }
         }
         if (errorHappened && (numErrorsImagAbs + numErrorsImagRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
           std::cout << "ERROR, i = " << i << ", j = " << j
                     << ": h_expected(i,j).imag() = " << h_expected(i, j).imag()
                     << ", h_vanilla(i,j).imag() = " << h_vanilla(i, j).imag()
@@ -838,7 +838,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
 
       int numErrorsReal(numErrorsRealAbs + numErrorsRealRel);
       if (numErrorsReal > 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
         std::cout << "WARNING" << msg.str() << std::endl;
 #endif
       }
@@ -869,7 +869,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
 
       int numErrorsImag(numErrorsImagAbs + numErrorsImagRel);
       if (numErrorsImag > 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
         std::cout << "WARNING" << msg.str() << std::endl;
 #endif
       }
@@ -884,7 +884,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
       for (int j(0); j < _N; ++j) {
         if (h_expected(i, j).real() != h_vanilla(i, j).real()) {
           if (numErrorsReal == 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
             std::cout << "ERROR, i = " << i << ", j = " << j
                       << ": h_expected(i,j).real() = "
                       << h_expected(i, j).real()
@@ -897,7 +897,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
 
         if (h_expected(i, j).imag() != h_vanilla(i, j).imag()) {
           if (numErrorsImag == 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
             std::cout << "ERROR, i = " << i << ", j = " << j
                       << ": h_expected(i,j).imag() = "
                       << h_expected(i, j).imag()
@@ -977,7 +977,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
           }
         }
         if (errorHappened && (numErrorsAbs + numErrorsRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
           std::cout << "ERROR, i = " << i << ", j = " << j
                     << ": h_expected(i,j) = " << h_expected(i, j)
                     << ", h_vanilla(i,j) = " << h_vanilla(i, j)
@@ -1011,7 +1011,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
 
       int numErrors(numErrorsAbs + numErrorsRel);
       if (numErrors > 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
         std::cout << "WARNING" << msg.str() << std::endl;
 #endif
       }
@@ -1024,7 +1024,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
       for (int j(0); j < _N; ++j) {
         if (h_expected(i, j) != h_vanilla(i, j)) {
           if (numErrors == 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
             std::cout << "ERROR, i = " << i << ", j = " << j
                       << ": h_expected(i,j) = " << h_expected(i, j)
                       << ", h_vanilla(i,j) = " << h_vanilla(i, j) << std::endl;
@@ -1096,7 +1096,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
         }
       }
       if (errorHappened && (numErrorsRealAbs + numErrorsRealRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
         std::cout
             << "ERROR, i = " << i << ", j = " << j
             << ": h_expected(i,j).real() = " << h_expected(i, j).real()
@@ -1129,7 +1129,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
         }
       }
       if (errorHappened && (numErrorsImagAbs + numErrorsImagRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
         std::cout
             << "ERROR, i = " << i << ", j = " << j
             << ": h_expected(i,j).imag() = " << h_expected(i, j).imag()
@@ -1140,7 +1140,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
       }
     }  // for j
   }    // for i
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
   std::cout
       << "A is " << _M << " by " << _N << ", _A_is_lr = " << _A_is_lr
       << ", _A_is_ll = " << _A_is_ll
@@ -1218,7 +1218,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
 
     int numErrorsReal(numErrorsRealAbs + numErrorsRealRel);
     if (numErrorsReal > 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
       std::cout << "WARNING" << msg.str() << std::endl;
 #endif
     }
@@ -1248,7 +1248,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
 
     int numErrorsImag(numErrorsImagAbs + numErrorsImagRel);
     if (numErrorsImag > 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
       std::cout << "WARNING" << msg.str() << std::endl;
 #endif
     }
@@ -1302,7 +1302,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
         }
       }
       if (errorHappened && (numErrorsAbs + numErrorsRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
         std::cout << "ERROR, i = " << i << ", j = " << j
                   << ": h_expected(i,j) = " << h_expected(i, j)
                   << ", h_A(i,j) = " << h_A(i, j)
@@ -1312,7 +1312,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
       }
     }  // for j
   }    // for i
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "A is " << _M << " by " << _N << ", _A_is_lr = " << _A_is_lr
             << ", _A_is_ll = " << _A_is_ll
             << ", alpha type = " << typeid(alpha).name()
@@ -1353,7 +1353,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
 
     int numErrors(numErrorsAbs + numErrorsRel);
     if (numErrors > 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
       std::cout << "WARNING" << msg.str() << std::endl;
 #endif
     }
@@ -1371,7 +1371,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
                                        /*_ViewTypeA& A, const _HostViewTypeA& h_A,*/
                                        const _ViewTypeExpected& h_expected,
                                        const std::string& situation) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
 #if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "In Test_Blas2_ger.hpp, right before calling KokkosBlas::ger(): "
@@ -1390,13 +1390,13 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
   try {
     KokkosBlas::ger(mode.c_str(), alpha, x, y, /*A*/A.d_view);
   } catch (const std::exception& e) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
     std::cout << "In Test_Blas2_ger, '" << situation
               << "': caught exception, e.what() = " << e.what() << std::endl;
 #endif
     gotStdException = true;
   } catch (...) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
     std::cout << "In Test_Blas2_ger, '" << situation
               << "': caught unknown exception" << std::endl;
 #endif
@@ -1422,7 +1422,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
 }  // namespace Test
 
 template <class ScalarX, class ScalarY, class ScalarA, class Device>
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
 int test_ger(const std::string& caseName) {
 #if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
@@ -1460,7 +1460,7 @@ int test_ger(const std::string& /*caseName*/) {
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&      \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
 #if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+-----------------------------------------------------------------------"
@@ -1505,7 +1505,7 @@ int test_ger(const std::string& /*caseName*/) {
     }
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
 #if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for LAYOUTLEFT\n",
                                 caseName.c_str());
@@ -1527,7 +1527,7 @@ int test_ger(const std::string& /*caseName*/) {
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) &&       \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
 #if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+-----------------------------------------------------------------------"
@@ -1572,7 +1572,7 @@ int test_ger(const std::string& /*caseName*/) {
     }
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
 #if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for LAYOUTRIGHT\n",
                                 caseName.c_str());
@@ -1593,7 +1593,7 @@ int test_ger(const std::string& /*caseName*/) {
 
 #if (!defined(KOKKOSKERNELS_ETI_ONLY) && \
      !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
 #if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+-----------------------------------------------------------------------"
@@ -1635,7 +1635,7 @@ int test_ger(const std::string& /*caseName*/) {
     }
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
 #if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for LAYOUTSTRIDE\n",
                                 caseName.c_str());
@@ -1656,7 +1656,7 @@ int test_ger(const std::string& /*caseName*/) {
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && \
     !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
 #if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF(
       "+-----------------------------------------------------------------------"
@@ -1693,7 +1693,7 @@ int test_ger(const std::string& /*caseName*/) {
     tester.test(1024, 1024, 0);
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
 #if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s for MIXED LAYOUTS\n",
                                 caseName.c_str());
@@ -1712,7 +1712,7 @@ int test_ger(const std::string& /*caseName*/) {
 #endif
 #endif
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if 1 // def HAVE_KOKKOSKERNELS_DEBUG
 #if KOKKOS_VERSION < 40199
   KOKKOS_IMPL_DO_NOT_USE_PRINTF("Finished %s\n", caseName.c_str());
 #else

--- a/blas/unit_test/Test_Blas2_ger.hpp
+++ b/blas/unit_test/Test_Blas2_ger.hpp
@@ -79,10 +79,11 @@ class GerTester {
   using _KAT_A   = Kokkos::ArithTraits<ScalarA>;
   using _AuxType = typename _KAT_A::mag_type;
 
-  void populateVariables(ScalarA& alpha, _HostViewTypeX& h_x,
-                         _HostViewTypeY& h_y, _HostViewTypeA& h_A,
-                         _ViewTypeExpected& h_expected, _ViewTypeX& x,
-                         _ViewTypeY& y, _ViewTypeA& A,
+  void populateVariables(ScalarA& alpha, view_stride_adapter<_ViewTypeX, false>/*_HostViewTypeX& h_x*/& x,
+                         view_stride_adapter<_ViewTypeY, false>& y, view_stride_adapter<_ViewTypeA, false>& A,
+                         /*_HostViewTypeY& h_y, _HostViewTypeA& h_A,*/
+                         _ViewTypeExpected& h_expected, /*_ViewTypeX& x,*/
+                         /*_ViewTypeY& y, _ViewTypeA& A,*/
                          bool& expectedResultIsKnown);
 
   template <class T>
@@ -150,8 +151,9 @@ class GerTester {
 
   template <class TX, class TY>
   void callKkGerAndCompareAgainstExpected(const ScalarA& alpha, TX& x, TY& y,
-                                          _ViewTypeA& A,
-                                          const _HostViewTypeA& h_A,
+                                          view_stride_adapter<_ViewTypeA, false>& A,
+                                          /*_ViewTypeA& A,*/
+                                          /*const _HostViewTypeA& h_A,*/
                                           const _ViewTypeExpected& h_expected,
                                           const std::string& situation);
 
@@ -286,8 +288,8 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
   // ********************************************************************
   // Step 2 of 9: populate alpha, h_x, h_y, h_A, h_expected, x, y, A
   // ********************************************************************
-  this->populateVariables(alpha, x.h_view, y.h_view, A.h_view,
-                          h_expected.d_view, x.d_view, y.d_view, A.d_view,
+  this->populateVariables(alpha, x/*.h_view*/, y/*.h_view*/, A/*.h_view*/,
+                          h_expected.d_view, /*x.d_view, y.d_view, A.d_view,*/
                           expectedResultIsKnown);
 
   // ********************************************************************
@@ -333,7 +335,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
 
   if (test_x_y) {
     this->callKkGerAndCompareAgainstExpected(
-        alpha, x.d_view, y.d_view, A.d_view, A.h_view, h_expected.d_view,
+        alpha, x.d_view, y.d_view, /*A.d_view, A.h_view*/A, h_expected.d_view,
         "non const {x,y}");
   }
 
@@ -344,7 +346,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
     Kokkos::deep_copy(A.d_base, org_A.d_base);
 
     this->callKkGerAndCompareAgainstExpected(alpha, x.d_view_const, y.d_view,
-                                             A.d_view, A.h_view,
+                                             /*A.d_view, A.h_view*/A,
                                              h_expected.d_view, "const x");
   }
 
@@ -355,7 +357,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
     Kokkos::deep_copy(A.d_base, org_A.d_base);
 
     this->callKkGerAndCompareAgainstExpected(alpha, x.d_view, y.d_view_const,
-                                             A.d_view, A.h_view,
+                                             /*A.d_view, A.h_view*/A,
                                              h_expected.d_view, "const y");
   }
 
@@ -366,7 +368,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
     Kokkos::deep_copy(A.d_base, org_A.d_base);
 
     this->callKkGerAndCompareAgainstExpected(alpha, x.d_view_const,
-                                             y.d_view_const, A.d_view, A.h_view,
+                                             y.d_view_const, /*A.d_view, A.h_view*/A,
                                              h_expected.d_view, "const {x,y}");
   }
 
@@ -389,51 +391,53 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
 template <class ScalarX, class tLayoutX, class ScalarY, class tLayoutY,
           class ScalarA, class tLayoutA, class Device>
 void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
-               Device>::populateVariables(ScalarA& alpha, _HostViewTypeX& h_x,
-                                          _HostViewTypeY& h_y,
-                                          _HostViewTypeA& h_A,
+               Device>::populateVariables(ScalarA& alpha, view_stride_adapter<_ViewTypeX, false>/*_HostViewTypeX& h_x*/& x,
+                                          view_stride_adapter<_ViewTypeY, false>& y,
+                                          view_stride_adapter<_ViewTypeA, false>& A,
+                                          /*_HostViewTypeY& h_y,*/
+                                          /*_HostViewTypeA& h_A,*/
                                           _ViewTypeExpected& h_expected,
-                                          _ViewTypeX& x, _ViewTypeY& y,
-                                          _ViewTypeA& A,
+                                          /*_ViewTypeX& x, _ViewTypeY& y,
+                                          _ViewTypeA& A,*/
                                           bool& expectedResultIsKnown) {
   expectedResultIsKnown = false;
 
   if (_useAnalyticalResults) {
-    this->populateAnalyticalValues(alpha, h_x, h_y, h_A, h_expected);
-    Kokkos::deep_copy(x, h_x);
-    Kokkos::deep_copy(y, h_y);
-    Kokkos::deep_copy(A, h_A);
+    this->populateAnalyticalValues(alpha, /*h_x*/x.h_view, /*h_y*/y.h_view, /*h_A*/A.h_view, h_expected);
+    Kokkos::deep_copy(/*x, h_x*/x.d_view,x.h_view);
+    Kokkos::deep_copy(/*y, h_y*/y.d_view,y.h_view);
+    Kokkos::deep_copy(/*A, h_A*/A.d_view,A.h_view);
 
     expectedResultIsKnown = true;
   } else if ((_M == 1) && (_N == 1)) {
     alpha = 3;
 
-    h_x[0] = 2;
+    /*h_x*/x.h_view[0] = 2;
 
-    h_y[0] = 3;
+    /*h_y*/y.h_view[0] = 3;
 
-    h_A(0, 0) = 7;
+    /*h_A*/A.h_view(0, 0) = 7;
 
-    Kokkos::deep_copy(x, h_x);
-    Kokkos::deep_copy(y, h_y);
-    Kokkos::deep_copy(A, h_A);
+    Kokkos::deep_copy(/*x, h_x*/x.d_view,x.h_view);
+    Kokkos::deep_copy(/*y, h_y*/y.d_view,y.h_view);
+    Kokkos::deep_copy(/*A, h_A*/A.d_view,A.h_view);
 
     h_expected(0, 0)      = 25;
     expectedResultIsKnown = true;
   } else if ((_M == 1) && (_N == 2)) {
     alpha = 3;
 
-    h_x[0] = 2;
+    /*h_x*/x.h_view[0] = 2;
 
-    h_y[0] = 3;
-    h_y[1] = 4;
+    /*h_y*/y.h_view[0] = 3;
+    /*h_y*/y.h_view[1] = 4;
 
-    h_A(0, 0) = 7;
-    h_A(0, 1) = -6;
+    /*h_A*/A.h_view(0, 0) = 7;
+    /*h_A*/A.h_view(0, 1) = -6;
 
-    Kokkos::deep_copy(x, h_x);
-    Kokkos::deep_copy(y, h_y);
-    Kokkos::deep_copy(A, h_A);
+    Kokkos::deep_copy(/*x, h_x*/x.d_view,x.h_view);
+    Kokkos::deep_copy(/*y, h_y*/y.d_view,y.h_view);
+    Kokkos::deep_copy(/*A, h_A*/A.d_view,A.h_view);
 
     h_expected(0, 0)      = 25;
     h_expected(0, 1)      = 18;
@@ -441,20 +445,20 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
   } else if ((_M == 2) && (_N == 2)) {
     alpha = 3;
 
-    h_x[0] = 2;
-    h_x[1] = 9;
+    /*h_x*/x.h_view[0] = 2;
+    /*h_x*/x.h_view[1] = 9;
 
-    h_y[0] = -3;
-    h_y[1] = 7;
+    /*h_y*/y.h_view[0] = -3;
+    /*h_y*/y.h_view[1] = 7;
 
-    h_A(0, 0) = 17;
-    h_A(0, 1) = -43;
-    h_A(1, 0) = 29;
-    h_A(1, 1) = 101;
+    /*h_A*/A.h_view(0, 0) = 17;
+    /*h_A*/A.h_view(0, 1) = -43;
+    /*h_A*/A.h_view(1, 0) = 29;
+    /*h_A*/A.h_view(1, 1) = 101;
 
-    Kokkos::deep_copy(x, h_x);
-    Kokkos::deep_copy(y, h_y);
-    Kokkos::deep_copy(A, h_A);
+    Kokkos::deep_copy(/*x, h_x*/x.d_view,x.h_view);
+    Kokkos::deep_copy(/*y, h_y*/y.d_view,y.h_view);
+    Kokkos::deep_copy(/*A, h_A*/A.d_view,A.h_view);
 
     h_expected(0, 0)      = -1;
     h_expected(0, 1)      = -1;
@@ -470,24 +474,24 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
     {
       ScalarX randStart, randEnd;
       Test::getRandomBounds(1.0, randStart, randEnd);
-      Kokkos::fill_random(x, rand_pool, randStart, randEnd);
+      Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
     }
 
     {
       ScalarY randStart, randEnd;
       Test::getRandomBounds(1.0, randStart, randEnd);
-      Kokkos::fill_random(y, rand_pool, randStart, randEnd);
+      Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
     }
 
     {
       ScalarA randStart, randEnd;
       Test::getRandomBounds(1.0, randStart, randEnd);
-      Kokkos::fill_random(A, rand_pool, randStart, randEnd);
+      Kokkos::fill_random(A.d_view, rand_pool, randStart, randEnd);
     }
 
-    Kokkos::deep_copy(h_x, x);
-    Kokkos::deep_copy(h_y, y);
-    Kokkos::deep_copy(h_A, A);
+    Kokkos::deep_copy(/*h_x, x*/x.h_view,x.d_view);
+    Kokkos::deep_copy(/*h_y, y*/y.h_view,y.d_view);
+    Kokkos::deep_copy(/*h_A, A*/A.h_view,A.d_view);
   }
 }
 
@@ -1363,7 +1367,8 @@ template <class TX, class TY>
 void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
                Device>::
     callKkGerAndCompareAgainstExpected(const ScalarA& alpha, TX& x, TY& y,
-                                       _ViewTypeA& A, const _HostViewTypeA& h_A,
+                                       view_stride_adapter<_ViewTypeA, false>& A,
+                                       /*_ViewTypeA& A, const _HostViewTypeA& h_A,*/
                                        const _ViewTypeExpected& h_expected,
                                        const std::string& situation) {
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
@@ -1383,7 +1388,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
   bool gotStdException(false);
   bool gotUnknownException(false);
   try {
-    KokkosBlas::ger(mode.c_str(), alpha, x, y, A);
+    KokkosBlas::ger(mode.c_str(), alpha, x, y, /*A*/A.d_view);
   } catch (const std::exception& e) {
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
     std::cout << "In Test_Blas2_ger, '" << situation
@@ -1408,9 +1413,9 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
       << "have thrown a std::exception";
 
   if ((gotStdException == false) && (gotUnknownException == false)) {
-    Kokkos::deep_copy(h_A, A);
+    Kokkos::deep_copy(/*h_A, A*/A.h_view, A.d_view);
 
-    this->compareKkGerAgainstExpected(alpha, h_A, h_expected);
+    this->compareKkGerAgainstExpected(alpha, /*h_A*/A.h_view, h_expected);
   }
 }
 

--- a/blas/unit_test/Test_Blas2_syr.hpp
+++ b/blas/unit_test/Test_Blas2_syr.hpp
@@ -76,9 +76,12 @@ class SyrTester {
   using _KAT_A   = Kokkos::ArithTraits<ScalarA>;
   using _AuxType = typename _KAT_A::mag_type;
 
-  void populateVariables(ScalarA& alpha, _HostViewTypeX& h_x,
-                         _HostViewTypeA& h_A, _ViewTypeExpected& h_expected,
-                         _ViewTypeX& x, _ViewTypeA& A,
+  void populateVariables(ScalarA& alpha,
+                         view_stride_adapter<_ViewTypeX, false>& x,
+                         view_stride_adapter<_ViewTypeA, false>& A,
+                         /*_HostViewTypeX& h_x,
+                         _HostViewTypeA& h_A,*/ _ViewTypeExpected& h_expected,
+                         /*_ViewTypeX& x, _ViewTypeA& A,*/
                          bool& expectedResultIsKnown);
 
   template <class T>
@@ -146,8 +149,9 @@ class SyrTester {
 
   template <class TX>
   void callKkSyrAndCompareAgainstExpected(const ScalarA& alpha, TX& x,
-                                          _ViewTypeA& A,
-                                          const _HostViewTypeA& h_A,
+                                          view_stride_adapter<_ViewTypeA, false>& A,
+                                          /*_ViewTypeA& A,
+                                          const _HostViewTypeA& h_A,*/
                                           const _ViewTypeExpected& h_expected,
                                           const std::string& situation);
 
@@ -283,8 +287,8 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::test(
   // ********************************************************************
   // Step 2 of 7: populate alpha, h_x, h_A, h_expected, x, A
   // ********************************************************************
-  this->populateVariables(alpha, x.h_view, A.h_view, h_expected.d_view,
-                          x.d_view, A.d_view, expectedResultIsKnown);
+  this->populateVariables(alpha, x/*.h_view*/, A/*.h_view*/, h_expected.d_view,
+                          /*x.d_view, A.d_view,*/ expectedResultIsKnown);
 
   // ********************************************************************
   // Step 3 of 7: populate h_vanilla
@@ -329,7 +333,7 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::test(
 
   if (test_x) {
     this->callKkSyrAndCompareAgainstExpected(
-        alpha, x.d_view, A.d_view, A.h_view, h_expected.d_view, "non const x");
+      alpha, x.d_view, A/*A.d_view, A.h_view*/, h_expected.d_view, "non const x");
 
     if ((_useAnalyticalResults == false) &&  // Just to save run time
         (_kkGerShouldThrowException == false)) {
@@ -344,8 +348,8 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::test(
   if (test_cx) {
     Kokkos::deep_copy(A.d_base, org_A.d_base);
 
-    this->callKkSyrAndCompareAgainstExpected(alpha, x.d_view_const, A.d_view,
-                                             A.h_view, h_expected.d_view,
+    this->callKkSyrAndCompareAgainstExpected(alpha, x.d_view_const, A/*A.d_view,
+                                             A.h_view*/, h_expected.d_view,
                                              "const x");
   }
 
@@ -372,42 +376,44 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::test(
 template <class ScalarX, class tLayoutX, class ScalarA, class tLayoutA,
           class Device>
 void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::populateVariables(
-    ScalarA& alpha, _HostViewTypeX& h_x, _HostViewTypeA& h_A,
-    _ViewTypeExpected& h_expected, _ViewTypeX& x, _ViewTypeA& A,
+    ScalarA& alpha,/*_HostViewTypeX& h_x, _HostViewTypeA& h_A,*/
+    view_stride_adapter<_ViewTypeX, false>& x,
+    view_stride_adapter<_ViewTypeA, false>& A,
+    _ViewTypeExpected& h_expected,/*_ViewTypeX& x, _ViewTypeA& A,*/
     bool& expectedResultIsKnown) {
   expectedResultIsKnown = false;
 
   if (_useAnalyticalResults) {
-    this->populateAnalyticalValues(alpha, h_x, h_A, h_expected);
-    Kokkos::deep_copy(x, h_x);
-    Kokkos::deep_copy(A, h_A);
+    this->populateAnalyticalValues(alpha, x.h_view, A.h_view, /*h_x, h_A,*/ h_expected);
+    Kokkos::deep_copy(/*x, h_x*/x.d_base,x.h_base);
+    Kokkos::deep_copy(/*A, h_A*/A.d_base,A.h_base);
 
     expectedResultIsKnown = true;
   } else if (_N == 1) {
     alpha = 3;
 
-    h_x[0] = 2;
+    x.h_view/*h_x*/[0] = 2;
 
-    h_A(0, 0) = 7;
+    A.h_view/*h_x*/(0, 0) = 7;
 
-    Kokkos::deep_copy(x, h_x);
-    Kokkos::deep_copy(A, h_A);
+    Kokkos::deep_copy(/*x, h_x*/x.d_base,x.h_base);
+    Kokkos::deep_copy(/*A, h_A*/A.d_base,A.h_base);
 
     h_expected(0, 0)      = 19;
     expectedResultIsKnown = true;
   } else if (_N == 2) {
     alpha = 3;
 
-    h_x[0] = -2;
-    h_x[1] = 9;
+    x.h_view/*h_x*/[0] = -2;
+    x.h_view/*h_x*/[1] = 9;
 
-    h_A(0, 0) = 17;
-    h_A(0, 1) = -43;
-    h_A(1, 0) = -43;
-    h_A(1, 1) = 101;
+    A.h_view/*h_x*/(0, 0) = 17;
+    A.h_view/*h_x*/(0, 1) = -43;
+    A.h_view/*h_x*/(1, 0) = -43;
+    A.h_view/*h_x*/(1, 1) = 101;
 
-    Kokkos::deep_copy(x, h_x);
-    Kokkos::deep_copy(A, h_A);
+    Kokkos::deep_copy(/*x, h_x*/x.d_base,x.h_base);
+    Kokkos::deep_copy(/*A, h_A*/A.d_base,A.h_base);
 
     if (_useUpOption) {
       h_expected(0, 0) = 29;
@@ -430,17 +436,17 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::populateVariables(
     {
       ScalarX randStart, randEnd;
       Test::getRandomBounds(1.0, randStart, randEnd);
-      Kokkos::fill_random(x, rand_pool, randStart, randEnd);
+      Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
     }
 
     {
       ScalarA randStart, randEnd;
       Test::getRandomBounds(1.0, randStart, randEnd);
-      Kokkos::fill_random(A, rand_pool, randStart, randEnd);
+      Kokkos::fill_random(A.d_view, rand_pool, randStart, randEnd);
     }
 
-    Kokkos::deep_copy(h_x, x);
-    Kokkos::deep_copy(h_A, A);
+    Kokkos::deep_copy(/*h_x, x*/x.h_base,x.d_base);
+    Kokkos::deep_copy(/*h_A, A*/A.h_base,A.d_base);
 
     if (_useHermitianOption && _A_is_complex) {
       // ****************************************************************
@@ -448,12 +454,12 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::populateVariables(
       // ****************************************************************
       for (int i(0); i < _N; ++i) {
         for (int j(i + 1); j < _N; ++j) {
-          h_A(i, j) = _KAT_A::conj(h_A(j, i));
+          A.h_view/*h_x*/(i, j) = _KAT_A::conj(A.h_view/*h_x*/(j, i));
         }
       }
 
       for (int i(0); i < _N; ++i) {
-        h_A(i, i) = 0.5 * (h_A(i, i) + _KAT_A::conj(h_A(i, i)));
+        A.h_view/*h_x*/(i, i) = 0.5 * (A.h_view/*h_x*/(i, i) + _KAT_A::conj(A.h_view/*h_x*/(i, i)));
       }
     } else {
       // ****************************************************************
@@ -461,18 +467,18 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::populateVariables(
       // ****************************************************************
       for (int i(0); i < _N; ++i) {
         for (int j(i + 1); j < _N; ++j) {
-          h_A(i, j) = h_A(j, i);
+          A.h_view/*h_x*/(i, j) = A.h_view/*h_x*/(j, i);
         }
       }
     }
-    Kokkos::deep_copy(A, h_A);
+    Kokkos::deep_copy(/*A, h_A*/A.d_base,A.h_base);
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
   if (_N <= 2) {
     for (int i(0); i < _M; ++i) {
       for (int j(0); j < _N; ++j) {
-        std::cout << "h_origA(" << i << "," << j << ")=" << h_A(i, j)
+        std::cout << "h_origA(" << i << "," << j << ")=" << A.h_view/*h_x*/(i, j)
                   << std::endl;
       }
     }
@@ -1438,7 +1444,8 @@ template <class ScalarX, class tLayoutX, class ScalarA, class tLayoutA,
 template <class TX>
 void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::
     callKkSyrAndCompareAgainstExpected(const ScalarA& alpha, TX& x,
-                                       _ViewTypeA& A, const _HostViewTypeA& h_A,
+                                       view_stride_adapter<_ViewTypeA, false>& A,
+                                       /*_ViewTypeA& A, const _HostViewTypeA& h_A,*/
                                        const _ViewTypeExpected& h_expected,
                                        const std::string& situation) {
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
@@ -1461,7 +1468,7 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::
   bool gotStdException(false);
   bool gotUnknownException(false);
   try {
-    KokkosBlas::syr(mode.c_str(), uplo.c_str(), alpha, x, A);
+    KokkosBlas::syr(mode.c_str(), uplo.c_str(), alpha, x, A.d_view);
   } catch (const std::exception& e) {
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
     std::cout << "In Test_Blas2_syr, '" << situation
@@ -1486,8 +1493,8 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::
       << "have thrown a std::exception";
 
   if ((gotStdException == false) && (gotUnknownException == false)) {
-    Kokkos::deep_copy(h_A, A);
-    this->compareKkSyrAgainstReference(alpha, h_A, h_expected);
+    Kokkos::deep_copy(/*h_A, A*/A.h_base,A.d_base);
+    this->compareKkSyrAgainstReference(alpha, A.h_view/*h_A*/, h_expected);
   }
 }
 

--- a/blas/unit_test/Test_Blas2_syr.hpp
+++ b/blas/unit_test/Test_Blas2_syr.hpp
@@ -146,10 +146,9 @@ class SyrTester {
   T shrinkAngleToZeroTwoPiRange(const T input);
 
   template <class TX>
-  void callKkSyrAndCompareAgainstExpected(const ScalarA& alpha, TX& x,
-                                          view_stride_adapter<_ViewTypeA, false>& A,
-                                          const _ViewTypeExpected& h_expected,
-                                          const std::string& situation);
+  void callKkSyrAndCompareAgainstExpected(
+      const ScalarA& alpha, TX& x, view_stride_adapter<_ViewTypeA, false>& A,
+      const _ViewTypeExpected& h_expected, const std::string& situation);
 
   template <class TX>
   void callKkGerAndCompareKkSyrAgainstIt(
@@ -328,8 +327,8 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::test(
   Kokkos::deep_copy(org_A.h_view, A.h_view);
 
   if (test_x) {
-    this->callKkSyrAndCompareAgainstExpected(
-      alpha, x.d_view, A, h_expected.d_view, "non const x");
+    this->callKkSyrAndCompareAgainstExpected(alpha, x.d_view, A,
+                                             h_expected.d_view, "non const x");
 
     if ((_useAnalyticalResults == false) &&  // Just to save run time
         (_kkGerShouldThrowException == false)) {
@@ -345,8 +344,7 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::test(
     Kokkos::deep_copy(A.d_base, org_A.d_base);
 
     this->callKkSyrAndCompareAgainstExpected(alpha, x.d_view_const, A,
-                                             h_expected.d_view,
-                                             "const x");
+                                             h_expected.d_view, "const x");
   }
 
   // ********************************************************************
@@ -372,17 +370,15 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::test(
 template <class ScalarX, class tLayoutX, class ScalarA, class tLayoutA,
           class Device>
 void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::populateVariables(
-    ScalarA& alpha,
-    view_stride_adapter<_ViewTypeX, false>& x,
-    view_stride_adapter<_ViewTypeA, false>& A,
-    _ViewTypeExpected& h_expected,
+    ScalarA& alpha, view_stride_adapter<_ViewTypeX, false>& x,
+    view_stride_adapter<_ViewTypeA, false>& A, _ViewTypeExpected& h_expected,
     bool& expectedResultIsKnown) {
   expectedResultIsKnown = false;
 
   if (_useAnalyticalResults) {
     this->populateAnalyticalValues(alpha, x.h_view, A.h_view, h_expected);
-    Kokkos::deep_copy(x.d_base,x.h_base);
-    Kokkos::deep_copy(A.d_base,A.h_base);
+    Kokkos::deep_copy(x.d_base, x.h_base);
+    Kokkos::deep_copy(A.d_base, A.h_base);
 
     expectedResultIsKnown = true;
   } else if (_N == 1) {
@@ -392,8 +388,8 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::populateVariables(
 
     A.h_view(0, 0) = 7;
 
-    Kokkos::deep_copy(x.d_base,x.h_base);
-    Kokkos::deep_copy(A.d_base,A.h_base);
+    Kokkos::deep_copy(x.d_base, x.h_base);
+    Kokkos::deep_copy(A.d_base, A.h_base);
 
     h_expected(0, 0)      = 19;
     expectedResultIsKnown = true;
@@ -408,8 +404,8 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::populateVariables(
     A.h_view(1, 0) = -43;
     A.h_view(1, 1) = 101;
 
-    Kokkos::deep_copy(x.d_base,x.h_base);
-    Kokkos::deep_copy(A.d_base,A.h_base);
+    Kokkos::deep_copy(x.d_base, x.h_base);
+    Kokkos::deep_copy(A.d_base, A.h_base);
 
     if (_useUpOption) {
       h_expected(0, 0) = 29;
@@ -441,8 +437,8 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::populateVariables(
       Kokkos::fill_random(A.d_view, rand_pool, randStart, randEnd);
     }
 
-    Kokkos::deep_copy(x.h_base,x.d_base);
-    Kokkos::deep_copy(A.h_base,A.d_base);
+    Kokkos::deep_copy(x.h_base, x.d_base);
+    Kokkos::deep_copy(A.h_base, A.d_base);
 
     if (_useHermitianOption && _A_is_complex) {
       // ****************************************************************
@@ -467,7 +463,7 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::populateVariables(
         }
       }
     }
-    Kokkos::deep_copy(A.d_base,A.h_base);
+    Kokkos::deep_copy(A.d_base, A.h_base);
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
@@ -1439,10 +1435,9 @@ template <class ScalarX, class tLayoutX, class ScalarA, class tLayoutA,
           class Device>
 template <class TX>
 void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::
-    callKkSyrAndCompareAgainstExpected(const ScalarA& alpha, TX& x,
-                                       view_stride_adapter<_ViewTypeA, false>& A,
-                                       const _ViewTypeExpected& h_expected,
-                                       const std::string& situation) {
+    callKkSyrAndCompareAgainstExpected(
+        const ScalarA& alpha, TX& x, view_stride_adapter<_ViewTypeA, false>& A,
+        const _ViewTypeExpected& h_expected, const std::string& situation) {
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "In Test_Blas2_syr, '" << situation << "', alpha = " << alpha
             << std::endl;
@@ -1488,7 +1483,7 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::
       << "have thrown a std::exception";
 
   if ((gotStdException == false) && (gotUnknownException == false)) {
-    Kokkos::deep_copy(A.h_base,A.d_base);
+    Kokkos::deep_copy(A.h_base, A.d_base);
     this->compareKkSyrAgainstReference(alpha, A.h_view, h_expected);
   }
 }

--- a/blas/unit_test/Test_Blas2_syr2.hpp
+++ b/blas/unit_test/Test_Blas2_syr2.hpp
@@ -502,7 +502,7 @@ void Syr2Tester<
   if (_N <= 2) {
     for (int i(0); i < _M; ++i) {
       for (int j(0); j < _N; ++j) {
-        std::cout << "h_origA(" << i << "," << j << ")=" << A.h_view(i, j)
+        std::cout << "h_origA(" << i << "," << j << ") = " << A.h_view(i, j)
                   << std::endl;
       }
     }
@@ -825,8 +825,8 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
   if (_N <= 2) {
     for (int i(0); i < _M; ++i) {
       for (int j(0); j < _N; ++j) {
-        std::cout << "h_exp(" << i << "," << j << ")=" << h_expected(i, j)
-                  << ", h_van(" << i << "," << j << ")=" << h_vanilla(i, j)
+        std::cout << "h_exp(" << i << "," << j << ") = " << h_expected(i, j)
+                  << ", h_van(" << i << "," << j << ") = " << h_vanilla(i, j)
                   << std::endl;
       }
     }
@@ -1054,8 +1054,8 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
   if (_N <= 2) {
     for (int i(0); i < _M; ++i) {
       for (int j(0); j < _N; ++j) {
-        std::cout << "h_exp(" << i << "," << j << ")=" << h_expected(i, j)
-                  << ", h_van(" << i << "," << j << ")=" << h_vanilla(i, j)
+        std::cout << "h_exp(" << i << "," << j << ") = " << h_expected(i, j)
+                  << ", h_van(" << i << "," << j << ") = " << h_vanilla(i, j)
                   << std::endl;
       }
     }
@@ -1184,8 +1184,8 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
   if (_N <= 2) {
     for (int i(0); i < _M; ++i) {
       for (int j(0); j < _N; ++j) {
-        std::cout << "h_exp(" << i << "," << j << ")=" << h_reference(i, j)
-                  << ", h_A(" << i << "," << j << ")=" << h_A(i, j)
+        std::cout << "h_exp(" << i << "," << j << ") = " << h_reference(i, j)
+                  << ", h_A(" << i << "," << j << ") = " << h_A(i, j)
                   << std::endl;
       }
     }
@@ -1411,8 +1411,8 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::
   if (_N <= 2) {
     for (int i(0); i < _M; ++i) {
       for (int j(0); j < _N; ++j) {
-        std::cout << "h_exp(" << i << "," << j << ")=" << h_reference(i, j)
-                  << ", h_A(" << i << "," << j << ")=" << h_A(i, j)
+        std::cout << "h_exp(" << i << "," << j << ") = " << h_reference(i, j)
+                  << ", h_A(" << i << "," << j << ") = " << h_A(i, j)
                   << std::endl;
       }
     }

--- a/blas/unit_test/Test_Blas2_syr2.hpp
+++ b/blas/unit_test/Test_Blas2_syr2.hpp
@@ -83,13 +83,11 @@ class Syr2Tester {
   using _KAT_A   = Kokkos::ArithTraits<ScalarA>;
   using _AuxType = typename _KAT_A::mag_type;
 
-  void populateVariables(ScalarA& alpha, /*_HostViewTypeX& h_x,
-                         _HostViewTypeY& h_y, _HostViewTypeA& h_A,*/
+  void populateVariables(ScalarA& alpha,
                          view_stride_adapter<_ViewTypeX, false>& x,
                          view_stride_adapter<_ViewTypeY, false>& y,
                          view_stride_adapter<_ViewTypeA, false>& A,
-                         _ViewTypeExpected& h_expected, /*_ViewTypeX& x,
-                         _ViewTypeY& y, _ViewTypeA& A,*/
+                         _ViewTypeExpected& h_expected,
                          bool& expectedResultIsKnown);
 
   template <class T>
@@ -158,8 +156,6 @@ class Syr2Tester {
   template <class TX, class TY>
   void callKkSyr2AndCompareAgainstExpected(const ScalarA& alpha, TX& x, TY& y,
                                            view_stride_adapter<_ViewTypeA, false>& A,
-                                           /*_ViewTypeA& A,
-                                           const _HostViewTypeA& h_A,*/
                                            const _ViewTypeExpected& h_expected,
                                            const std::string& situation);
 
@@ -300,8 +296,8 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
   // ********************************************************************
   // Step 2 of 7: populate alpha, h_x, h_A, h_expected, x, A
   // ********************************************************************
-  this->populateVariables(alpha, x, y, A, /*x.h_view, y.h_view, A.h_view, */
-                          h_expected.d_view, /*x.d_view, y.d_view, A.d_view, */
+  this->populateVariables(alpha, x, y, A,
+                          h_expected.d_view,
                           expectedResultIsKnown);
 
   // ********************************************************************
@@ -341,7 +337,7 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
 
   if (test_x) {
     this->callKkSyr2AndCompareAgainstExpected(alpha, x.d_view, y.d_view,
-                                              A,/*.d_view, A.h_view,*/
+                                              A,
                                               h_expected.d_view, "non const x");
 
     if ((_useAnalyticalResults == false) &&  // Just to save run time
@@ -358,7 +354,7 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
     Kokkos::deep_copy(A.d_base, org_A.d_base);
 
     this->callKkSyr2AndCompareAgainstExpected(
-        alpha, x.d_view_const, y.d_view_const, A,/*.d_view, A.h_view,*/
+        alpha, x.d_view_const, y.d_view_const, A,
         h_expected.d_view, "const x");
   }
 
@@ -389,57 +385,53 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
 template <class ScalarX, class tLayoutX, class ScalarY, class tLayoutY,
           class ScalarA, class tLayoutA, class Device>
 void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
-                Device>::populateVariables(ScalarA& alpha, /*_HostViewTypeX& h_x,
-                                           _HostViewTypeY& h_y,
-                                           _HostViewTypeA& h_A,*/
+                Device>::populateVariables(ScalarA& alpha,
                                            view_stride_adapter<_ViewTypeX, false>& x,
                                            view_stride_adapter<_ViewTypeY, false>& y,
                                            view_stride_adapter<_ViewTypeA, false>& A,
                                            _ViewTypeExpected& h_expected,
-                                           /*_ViewTypeX& x, _ViewTypeY& y,
-                                           _ViewTypeA& A,*/
                                            bool& expectedResultIsKnown) {
   expectedResultIsKnown = false;
 
   if (_useAnalyticalResults) {
-    this->populateAnalyticalValues(alpha, x.h_view, y.h_view, A.h_view, /*h_x, h_y, h_A,*/ h_expected);
-    Kokkos::deep_copy(/*x, h_x*/x.d_base,x.h_base);
-    Kokkos::deep_copy(/*y, h_y*/y.d_base,y.h_base);
-    Kokkos::deep_copy(/*A, h_A*/A.d_base,A.h_base);
+    this->populateAnalyticalValues(alpha, x.h_view, y.h_view, A.h_view, h_expected);
+    Kokkos::deep_copy(x.d_base,x.h_base);
+    Kokkos::deep_copy(y.d_base,y.h_base);
+    Kokkos::deep_copy(A.d_base,A.h_base);
 
     expectedResultIsKnown = true;
   } else if (_N == 1) {
     alpha = 3;
 
-    /*h_x*/x.h_view[0] = 2;
+    x.h_view[0] = 2;
 
-    /*h_y*/y.h_view[0] = 4;
+    y.h_view[0] = 4;
 
-    /*h_A*/A.h_view(0, 0) = 7;
+    A.h_view(0, 0) = 7;
 
-    Kokkos::deep_copy(/*x, h_x*/x.d_base,x.h_base);
-    Kokkos::deep_copy(/*y, h_y*/y.d_base,y.h_base);
-    Kokkos::deep_copy(/*A, h_A*/A.d_base,A.h_base);
+    Kokkos::deep_copy(x.d_base,x.h_base);
+    Kokkos::deep_copy(y.d_base,y.h_base);
+    Kokkos::deep_copy(A.d_base,A.h_base);
 
     h_expected(0, 0)      = 55;
     expectedResultIsKnown = true;
   } else if (_N == 2) {
     alpha = 3;
 
-    /*h_x*/x.h_view[0] = -2;
-    /*h_x*/x.h_view[1] = 9;
+    x.h_view[0] = -2;
+    x.h_view[1] = 9;
 
-    /*h_y*/y.h_view[0] = 5;
-    /*h_y*/y.h_view[1] = -4;
+    y.h_view[0] = 5;
+    y.h_view[1] = -4;
 
-    /*h_A*/A.h_view(0, 0) = 17;
-    /*h_A*/A.h_view(0, 1) = -43;
-    /*h_A*/A.h_view(1, 0) = -43;
-    /*h_A*/A.h_view(1, 1) = 101;
+    A.h_view(0, 0) = 17;
+    A.h_view(0, 1) = -43;
+    A.h_view(1, 0) = -43;
+    A.h_view(1, 1) = 101;
 
-    Kokkos::deep_copy(/*x, h_x*/x.d_base,x.h_base);
-    Kokkos::deep_copy(/*y, h_y*/y.d_base,y.h_base);
-    Kokkos::deep_copy(/*A, h_A*/A.d_base,A.h_base);
+    Kokkos::deep_copy(x.d_base,x.h_base);
+    Kokkos::deep_copy(y.d_base,y.h_base);
+    Kokkos::deep_copy(A.d_base,A.h_base);
 
     if (_useUpOption) {
       h_expected(0, 0) = -43;
@@ -477,9 +469,9 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
       Kokkos::fill_random(A.d_view, rand_pool, randStart, randEnd);
     }
 
-    Kokkos::deep_copy(/*h_x, x*/x.h_base,x.d_base);
-    Kokkos::deep_copy(/*h_y, y*/y.h_base,y.d_base);
-    Kokkos::deep_copy(/*h_A, A*/A.h_base,A.d_base);
+    Kokkos::deep_copy(x.h_base,x.d_base);
+    Kokkos::deep_copy(y.h_base,y.d_base);
+    Kokkos::deep_copy(A.h_base,A.d_base);
 
     if (_useHermitianOption && _A_is_complex) {
       // ****************************************************************
@@ -487,12 +479,12 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
       // ****************************************************************
       for (int i(0); i < _N; ++i) {
         for (int j(i + 1); j < _N; ++j) {
-          /*h_A*/A.h_view(i, j) = _KAT_A::conj(/*h_A*/A.h_view(j, i));
+          A.h_view(i, j) = _KAT_A::conj(A.h_view(j, i));
         }
       }
 
       for (int i(0); i < _N; ++i) {
-        /*h_A*/A.h_view(i, i) = 0.5 * (/*h_A*/A.h_view(i, i) + _KAT_A::conj(/*h_A*/A.h_view(i, i)));
+        A.h_view(i, i) = 0.5 * (A.h_view(i, i) + _KAT_A::conj(A.h_view(i, i)));
       }
     } else {
       // ****************************************************************
@@ -500,18 +492,18 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
       // ****************************************************************
       for (int i(0); i < _N; ++i) {
         for (int j(i + 1); j < _N; ++j) {
-          /*h_A*/A.h_view(i, j) = /*h_A*/A.h_view(j, i);
+          A.h_view(i, j) = A.h_view(j, i);
         }
       }
     }
-    Kokkos::deep_copy(/*A, h_A*/A.d_base,A.h_base);
+    Kokkos::deep_copy(A.d_base,A.h_base);
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
   if (_N <= 2) {
     for (int i(0); i < _M; ++i) {
       for (int j(0); j < _N; ++j) {
-        std::cout << "h_origA(" << i << "," << j << ")=" << /*h_A*/A.h_view(i, j)
+        std::cout << "h_origA(" << i << "," << j << ")=" << A.h_view(i, j)
                   << std::endl;
       }
     }
@@ -1530,8 +1522,6 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
                 Device>::
     callKkSyr2AndCompareAgainstExpected(const ScalarA& alpha, TX& x, TY& y,
                                         view_stride_adapter<_ViewTypeA, false>& A,
-                                        /*_ViewTypeA& A,
-                                        const _HostViewTypeA& h_A,*/
                                         const _ViewTypeExpected& h_expected,
                                         const std::string& situation) {
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
@@ -1573,8 +1563,8 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
       << "have thrown a std::exception";
 
   if ((gotStdException == false) && (gotUnknownException == false)) {
-    Kokkos::deep_copy(/*h_A, A*/A.h_base,A.d_base);
-    this->compareKkSyr2AgainstReference(alpha, /*h_A*/A.h_view, h_expected);
+    Kokkos::deep_copy(A.h_base,A.d_base);
+    this->compareKkSyr2AgainstReference(alpha, A.h_view, h_expected);
   }
 }
 

--- a/blas/unit_test/Test_Blas2_syr2.hpp
+++ b/blas/unit_test/Test_Blas2_syr2.hpp
@@ -154,10 +154,10 @@ class Syr2Tester {
   T shrinkAngleToZeroTwoPiRange(const T input);
 
   template <class TX, class TY>
-  void callKkSyr2AndCompareAgainstExpected(const ScalarA& alpha, TX& x, TY& y,
-                                           view_stride_adapter<_ViewTypeA, false>& A,
-                                           const _ViewTypeExpected& h_expected,
-                                           const std::string& situation);
+  void callKkSyr2AndCompareAgainstExpected(
+      const ScalarA& alpha, TX& x, TY& y,
+      view_stride_adapter<_ViewTypeA, false>& A,
+      const _ViewTypeExpected& h_expected, const std::string& situation);
 
   template <class TX, class TY>
   void callKkGerAndCompareKkSyr2AgainstIt(
@@ -296,8 +296,7 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
   // ********************************************************************
   // Step 2 of 7: populate alpha, h_x, h_A, h_expected, x, A
   // ********************************************************************
-  this->populateVariables(alpha, x, y, A,
-                          h_expected.d_view,
+  this->populateVariables(alpha, x, y, A, h_expected.d_view,
                           expectedResultIsKnown);
 
   // ********************************************************************
@@ -336,8 +335,7 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
   Kokkos::deep_copy(org_A.h_view, A.h_view);
 
   if (test_x) {
-    this->callKkSyr2AndCompareAgainstExpected(alpha, x.d_view, y.d_view,
-                                              A,
+    this->callKkSyr2AndCompareAgainstExpected(alpha, x.d_view, y.d_view, A,
                                               h_expected.d_view, "non const x");
 
     if ((_useAnalyticalResults == false) &&  // Just to save run time
@@ -354,8 +352,7 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
     Kokkos::deep_copy(A.d_base, org_A.d_base);
 
     this->callKkSyr2AndCompareAgainstExpected(
-        alpha, x.d_view_const, y.d_view_const, A,
-        h_expected.d_view, "const x");
+        alpha, x.d_view_const, y.d_view_const, A, h_expected.d_view, "const x");
   }
 
   // ********************************************************************
@@ -384,20 +381,22 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
 
 template <class ScalarX, class tLayoutX, class ScalarY, class tLayoutY,
           class ScalarA, class tLayoutA, class Device>
-void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
-                Device>::populateVariables(ScalarA& alpha,
-                                           view_stride_adapter<_ViewTypeX, false>& x,
-                                           view_stride_adapter<_ViewTypeY, false>& y,
-                                           view_stride_adapter<_ViewTypeA, false>& A,
-                                           _ViewTypeExpected& h_expected,
-                                           bool& expectedResultIsKnown) {
+void Syr2Tester<
+    ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
+    Device>::populateVariables(ScalarA& alpha,
+                               view_stride_adapter<_ViewTypeX, false>& x,
+                               view_stride_adapter<_ViewTypeY, false>& y,
+                               view_stride_adapter<_ViewTypeA, false>& A,
+                               _ViewTypeExpected& h_expected,
+                               bool& expectedResultIsKnown) {
   expectedResultIsKnown = false;
 
   if (_useAnalyticalResults) {
-    this->populateAnalyticalValues(alpha, x.h_view, y.h_view, A.h_view, h_expected);
-    Kokkos::deep_copy(x.d_base,x.h_base);
-    Kokkos::deep_copy(y.d_base,y.h_base);
-    Kokkos::deep_copy(A.d_base,A.h_base);
+    this->populateAnalyticalValues(alpha, x.h_view, y.h_view, A.h_view,
+                                   h_expected);
+    Kokkos::deep_copy(x.d_base, x.h_base);
+    Kokkos::deep_copy(y.d_base, y.h_base);
+    Kokkos::deep_copy(A.d_base, A.h_base);
 
     expectedResultIsKnown = true;
   } else if (_N == 1) {
@@ -409,9 +408,9 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
 
     A.h_view(0, 0) = 7;
 
-    Kokkos::deep_copy(x.d_base,x.h_base);
-    Kokkos::deep_copy(y.d_base,y.h_base);
-    Kokkos::deep_copy(A.d_base,A.h_base);
+    Kokkos::deep_copy(x.d_base, x.h_base);
+    Kokkos::deep_copy(y.d_base, y.h_base);
+    Kokkos::deep_copy(A.d_base, A.h_base);
 
     h_expected(0, 0)      = 55;
     expectedResultIsKnown = true;
@@ -429,9 +428,9 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
     A.h_view(1, 0) = -43;
     A.h_view(1, 1) = 101;
 
-    Kokkos::deep_copy(x.d_base,x.h_base);
-    Kokkos::deep_copy(y.d_base,y.h_base);
-    Kokkos::deep_copy(A.d_base,A.h_base);
+    Kokkos::deep_copy(x.d_base, x.h_base);
+    Kokkos::deep_copy(y.d_base, y.h_base);
+    Kokkos::deep_copy(A.d_base, A.h_base);
 
     if (_useUpOption) {
       h_expected(0, 0) = -43;
@@ -469,9 +468,9 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
       Kokkos::fill_random(A.d_view, rand_pool, randStart, randEnd);
     }
 
-    Kokkos::deep_copy(x.h_base,x.d_base);
-    Kokkos::deep_copy(y.h_base,y.d_base);
-    Kokkos::deep_copy(A.h_base,A.d_base);
+    Kokkos::deep_copy(x.h_base, x.d_base);
+    Kokkos::deep_copy(y.h_base, y.d_base);
+    Kokkos::deep_copy(A.h_base, A.d_base);
 
     if (_useHermitianOption && _A_is_complex) {
       // ****************************************************************
@@ -496,7 +495,7 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
         }
       }
     }
-    Kokkos::deep_copy(A.d_base,A.h_base);
+    Kokkos::deep_copy(A.d_base, A.h_base);
   }
 
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
@@ -1520,10 +1519,10 @@ template <class ScalarX, class tLayoutX, class ScalarY, class tLayoutY,
 template <class TX, class TY>
 void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
                 Device>::
-    callKkSyr2AndCompareAgainstExpected(const ScalarA& alpha, TX& x, TY& y,
-                                        view_stride_adapter<_ViewTypeA, false>& A,
-                                        const _ViewTypeExpected& h_expected,
-                                        const std::string& situation) {
+    callKkSyr2AndCompareAgainstExpected(
+        const ScalarA& alpha, TX& x, TY& y,
+        view_stride_adapter<_ViewTypeA, false>& A,
+        const _ViewTypeExpected& h_expected, const std::string& situation) {
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
   std::cout << "In Test_Blas2_syr2, '" << situation << "', alpha = " << alpha
             << std::endl;
@@ -1563,7 +1562,7 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA,
       << "have thrown a std::exception";
 
   if ((gotStdException == false) && (gotUnknownException == false)) {
-    Kokkos::deep_copy(A.h_base,A.d_base);
+    Kokkos::deep_copy(A.h_base, A.d_base);
     this->compareKkSyr2AgainstReference(alpha, A.h_view, h_expected);
   }
 }


### PR DESCRIPTION
Corrections for ger, syr, syr2, and axpby.

Thanks to Brian Kelley for pointing out that one should have Kokkos::deep_copy(base, base) instead of Kokkos::deep_copy(view,view), when using view_stride_adpater, otherwise we get an error when using Kokkos::LayoutStride.

Compilation and execution at weaver with ETI_ONLY = OFF are now successful.