### PR TITLE
Axpby using less deep copy (solves issue #2080)

### DIFF
--- a/blas/impl/KokkosBlas1_axpby_unification_attempt_traits.hpp
+++ b/blas/impl/KokkosBlas1_axpby_unification_attempt_traits.hpp
@@ -115,9 +115,9 @@ struct AxpbyUnificationAttemptTraits {
   static constexpr bool a_is_scalar = !Kokkos::is_view_v<AV>;
 
  private:
-  static constexpr bool a_is_r0     = Tr0_val<AV>();
-  static constexpr bool a_is_r1s    = Tr1s_val<AV>();
-  static constexpr bool a_is_r1d    = Tr1d_val<AV>();
+  static constexpr bool a_is_r0  = Tr0_val<AV>();
+  static constexpr bool a_is_r1s = Tr1s_val<AV>();
+  static constexpr bool a_is_r1d = Tr1d_val<AV>();
 
   static constexpr bool x_is_r1 = Kokkos::is_view_v<XMV> && (XMV::rank == 1);
   static constexpr bool x_is_r2 = Kokkos::is_view_v<XMV> && (XMV::rank == 2);
@@ -126,9 +126,9 @@ struct AxpbyUnificationAttemptTraits {
   static constexpr bool b_is_scalar = !Kokkos::is_view_v<BV>;
 
  private:
-  static constexpr bool b_is_r0     = Tr0_val<BV>();
-  static constexpr bool b_is_r1s    = Tr1s_val<BV>();
-  static constexpr bool b_is_r1d    = Tr1d_val<BV>();
+  static constexpr bool b_is_r0  = Tr0_val<BV>();
+  static constexpr bool b_is_r1s = Tr1s_val<BV>();
+  static constexpr bool b_is_r1d = Tr1d_val<BV>();
 
   static constexpr bool y_is_r1 = Kokkos::is_view_v<YMV> && (YMV::rank == 1);
   static constexpr bool y_is_r2 = Kokkos::is_view_v<YMV> && (YMV::rank == 2);
@@ -229,7 +229,7 @@ struct AxpbyUnificationAttemptTraits {
       >;
 
   using InternalTypeA_onDevice = std::conditional_t<
-      a_is_scalar && b_is_scalar && onDevice, // Keep 'a' as scalar
+      a_is_scalar && b_is_scalar && onDevice,  // Keep 'a' as scalar
       InternalScalarTypeA,
       Kokkos::View<const InternalScalarTypeA*, InternalLayoutA,
                    typename XMV::device_type,
@@ -287,7 +287,7 @@ struct AxpbyUnificationAttemptTraits {
       >;
 
   using InternalTypeB_onDevice = std::conditional_t<
-      a_is_scalar && b_is_scalar && onDevice, // Keep 'b' as scalar
+      a_is_scalar && b_is_scalar && onDevice,  // Keep 'b' as scalar
       InternalScalarTypeB,
       Kokkos::View<const InternalScalarTypeB*, InternalLayoutB,
                    typename YMV::device_type,
@@ -626,7 +626,9 @@ struct AxpbyUnificationAttemptTraits {
       }
     } else {
       if constexpr (xyRank1Case) {
-        constexpr bool internalTypeA_isOk = internalTypeA_is_r1d || (a_is_scalar && b_is_scalar && internalTypeA_is_scalar);
+        constexpr bool internalTypeA_isOk =
+            internalTypeA_is_r1d ||
+            (a_is_scalar && b_is_scalar && internalTypeA_is_scalar);
         static_assert(
             internalTypeA_isOk,
             "KokkosBlas::Impl::AxpbyUnificationAttemptTraits::performChecks()"
@@ -642,7 +644,9 @@ struct AxpbyUnificationAttemptTraits {
             "KokkosBlas::Impl::AxpbyUnificationAttemptTraits::performChecks()"
             ", onDevice, xyRank1Case: InternalTypeX is wrong");
 
-        constexpr bool internalTypeB_isOk = internalTypeB_is_r1d || (a_is_scalar && b_is_scalar && internalTypeA_is_scalar);
+        constexpr bool internalTypeB_isOk =
+            internalTypeB_is_r1d ||
+            (a_is_scalar && b_is_scalar && internalTypeA_is_scalar);
         static_assert(
             internalTypeB_isOk,
             "KokkosBlas::Impl::AxpbyUnificationAttemptTraits::performChecks()"
@@ -658,7 +662,9 @@ struct AxpbyUnificationAttemptTraits {
             "KokkosBlas::Impl::AxpbyUnificationAttemptTraits::performChecks()"
             ", onDevice, xyRank1Case: InternalTypeY is wrong");
       } else {
-        constexpr bool internalTypeA_isOk = internalTypeA_is_r1d || (a_is_scalar && b_is_scalar && internalTypeA_is_scalar);
+        constexpr bool internalTypeA_isOk =
+            internalTypeA_is_r1d ||
+            (a_is_scalar && b_is_scalar && internalTypeA_is_scalar);
         static_assert(
             internalTypeA_isOk,
             "KokkosBlas::Impl::AxpbyUnificationAttemptTraits::performChecks()"
@@ -674,7 +680,9 @@ struct AxpbyUnificationAttemptTraits {
             "KokkosBlas::Impl::AxpbyUnificationAttemptTraits::performChecks()"
             ", onDevice, xyRank2Case: InternalTypeX is wrong");
 
-        constexpr bool internalTypeB_isOk = internalTypeB_is_r1d || (a_is_scalar && b_is_scalar && internalTypeB_is_scalar);
+        constexpr bool internalTypeB_isOk =
+            internalTypeB_is_r1d ||
+            (a_is_scalar && b_is_scalar && internalTypeB_is_scalar);
         static_assert(
             internalTypeB_isOk,
             "KokkosBlas::Impl::AxpbyUnificationAttemptTraits::performChecks()"
@@ -726,7 +734,8 @@ struct AxpbyUnificationAttemptTraits {
       // - [InternalTypeA, B] = [view<S_a*,1 / m>, view<S_b*,1 / m>]
       // ****************************************************************
       static_assert(
-          internalTypesAB_bothViews || (a_is_scalar && b_is_scalar && internalTypesAB_bothScalars),
+          internalTypesAB_bothViews ||
+              (a_is_scalar && b_is_scalar && internalTypesAB_bothScalars),
           "KokkosBlas::Impl::AxpbyUnificationAttemptTraits::performChecks()"
           ", onDevice, invalid combination of types");
     }

--- a/blas/impl/KokkosBlas1_axpby_unification_attempt_traits.hpp
+++ b/blas/impl/KokkosBlas1_axpby_unification_attempt_traits.hpp
@@ -229,7 +229,7 @@ struct AxpbyUnificationAttemptTraits {
       >;
 
   using InternalTypeA_onDevice = std::conditional_t<
-      a_is_scalar && b_is_scalar && onDevice, // Aqui
+      a_is_scalar && b_is_scalar && onDevice, // Keep 'a' as scalar
       InternalScalarTypeA,
       Kokkos::View<const InternalScalarTypeA*, InternalLayoutA,
                    typename XMV::device_type,
@@ -287,7 +287,7 @@ struct AxpbyUnificationAttemptTraits {
       >;
 
   using InternalTypeB_onDevice = std::conditional_t<
-      a_is_scalar && b_is_scalar && onDevice, // Aqui
+      a_is_scalar && b_is_scalar && onDevice, // Keep 'b' as scalar
       InternalScalarTypeB,
       Kokkos::View<const InternalScalarTypeB*, InternalLayoutB,
                    typename YMV::device_type,
@@ -626,7 +626,7 @@ struct AxpbyUnificationAttemptTraits {
       }
     } else {
       if constexpr (xyRank1Case) {
-        constexpr bool internalTypeA_isOk = internalTypeA_is_r1d || (a_is_scalar && b_is_scalar && internalTypeA_is_scalar); // Aqui
+        constexpr bool internalTypeA_isOk = internalTypeA_is_r1d || (a_is_scalar && b_is_scalar && internalTypeA_is_scalar);
         static_assert(
             internalTypeA_isOk,
             "KokkosBlas::Impl::AxpbyUnificationAttemptTraits::performChecks()"
@@ -642,7 +642,7 @@ struct AxpbyUnificationAttemptTraits {
             "KokkosBlas::Impl::AxpbyUnificationAttemptTraits::performChecks()"
             ", onDevice, xyRank1Case: InternalTypeX is wrong");
 
-        constexpr bool internalTypeB_isOk = internalTypeB_is_r1d || (a_is_scalar && b_is_scalar && internalTypeA_is_scalar); // Aqui
+        constexpr bool internalTypeB_isOk = internalTypeB_is_r1d || (a_is_scalar && b_is_scalar && internalTypeA_is_scalar);
         static_assert(
             internalTypeB_isOk,
             "KokkosBlas::Impl::AxpbyUnificationAttemptTraits::performChecks()"
@@ -658,7 +658,7 @@ struct AxpbyUnificationAttemptTraits {
             "KokkosBlas::Impl::AxpbyUnificationAttemptTraits::performChecks()"
             ", onDevice, xyRank1Case: InternalTypeY is wrong");
       } else {
-        constexpr bool internalTypeA_isOk = internalTypeA_is_r1d || (a_is_scalar && b_is_scalar && internalTypeA_is_scalar); // Aqui
+        constexpr bool internalTypeA_isOk = internalTypeA_is_r1d || (a_is_scalar && b_is_scalar && internalTypeA_is_scalar);
         static_assert(
             internalTypeA_isOk,
             "KokkosBlas::Impl::AxpbyUnificationAttemptTraits::performChecks()"
@@ -674,7 +674,7 @@ struct AxpbyUnificationAttemptTraits {
             "KokkosBlas::Impl::AxpbyUnificationAttemptTraits::performChecks()"
             ", onDevice, xyRank2Case: InternalTypeX is wrong");
 
-        constexpr bool internalTypeB_isOk = internalTypeB_is_r1d || (a_is_scalar && b_is_scalar && internalTypeB_is_scalar); // Aqui
+        constexpr bool internalTypeB_isOk = internalTypeB_is_r1d || (a_is_scalar && b_is_scalar && internalTypeB_is_scalar);
         static_assert(
             internalTypeB_isOk,
             "KokkosBlas::Impl::AxpbyUnificationAttemptTraits::performChecks()"
@@ -715,16 +715,18 @@ struct AxpbyUnificationAttemptTraits {
       // ****************************************************************
       // We are in the 'onDevice' case, with 2 possible subcases:
       //
-      // 1) xyRank1Case, with only one possible situation:
-      // - [InternalTypeA / B] = [view<S_a*,1>, view<S_b*,1>]
+      // 1) xyRank1Case, with the following possible situations:
+      // - [InternalTypeA, B] = [S_a, S_b], or
+      // - [InternalTypeA, B] = [view<S_a*,1>, view<S_b*,1>]
       //
       // or
       //
-      // 2) xyRank2Case, with only one possible situation:
-      // - [InternalTypeA / B] = [view<S_a*,1 / m>, view<S_b*,1 / m>]
+      // 2) xyRank2Case, with the following possible situations:
+      // - [InternalTypeA, B] = [S_a, S_b], or
+      // - [InternalTypeA, B] = [view<S_a*,1 / m>, view<S_b*,1 / m>]
       // ****************************************************************
       static_assert(
-          internalTypesAB_bothViews || (a_is_scalar && b_is_scalar && internalTypesAB_bothScalars), // Aqui
+          internalTypesAB_bothViews || (a_is_scalar && b_is_scalar && internalTypesAB_bothScalars),
           "KokkosBlas::Impl::AxpbyUnificationAttemptTraits::performChecks()"
           ", onDevice, invalid combination of types");
     }

--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -84,9 +84,11 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X,
   InternalTypeY internal_Y = Y;
 
   if constexpr (AxpbyTraits::internalTypesAB_bothScalars) {
-    if constexpr (AxpbyTraits::a_is_scalar && AxpbyTraits::b_is_scalar && AxpbyTraits::onDevice) { // Aqui
-      // Special case: 'a' and 'b' are kept as scalar, eventually changing precision to match the precisions of 'X' and 'Y'
-      std::cout << "Passing in axpby special case" << std::endl;
+    if constexpr (AxpbyTraits::a_is_scalar && AxpbyTraits::b_is_scalar && AxpbyTraits::onDevice) {
+      // ******************************************************************
+      // In this special case, 'a' and 'b' are kept as scalar, evantually
+      // changing precision to match the precisions of 'X' and 'Y'
+      // ******************************************************************
       InternalTypeA internal_a(a);
       InternalTypeA internal_b(b);
 

--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -17,9 +17,9 @@
 #ifndef KOKKOSBLAS1_AXPBY_HPP_
 #define KOKKOSBLAS1_AXPBY_HPP_
 
-//#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
 #include <iostream>
-//#endif
+#endif
 
 #include <KokkosBlas1_axpby_spec.hpp>
 #include <KokkosBlas_serial_axpy.hpp>


### PR DESCRIPTION
For performance reasons, Trilinos has tests that count the number of calls to Kokkos::deep_copy(). The counts increased with the last changes in axpby(), always when X and Y were rank 2 on device (cuda in the current tests) and 'a' and 'b' were scalars. In such cases, I should not make the internal types of 'a' and 'b' to become Kokkos views, but rather make the internal types to be scalars as well. The current PR makes such performance improvement, not only for the situation of X and Y being rank 2 on device, but also for the situation of X and Y being rank 1 on device. The unit tests at the axpby() level were already very thorough, and they all continue to pass (I temporarily put a printout out in the logic change and confirmed that the new logic is being properly exercised).

Thanks to Brian Kelley for explaining me the test results and the necessity of keeping 'a' and 'b' scalars when (i) X and Y are rank-2 or rank-1 on device, and (ii) both inputs 'a' and 'b' are already scalars.