### PR TITLE
Block spiluk follow up

### DIFF
--- a/perf_test/sparse/KokkosSparse_spiluk.cpp
+++ b/perf_test/sparse/KokkosSparse_spiluk.cpp
@@ -144,12 +144,6 @@ int test_spiluk_perf(std::vector<int> tests, std::string afilename, int kin,
 
       // std::cout << "Create handle" << std::endl;
       switch (test) {
-        case LVLSCHED_RP:
-          kh.create_spiluk_handle(SPILUKAlgorithm::SEQLVLSCHD_RP, nrows,
-                                  EXPAND_FACT * nnz * (fill_lev + 1),
-                                  EXPAND_FACT * nnz * (fill_lev + 1));
-          kh.get_spiluk_handle()->print_algorithm();
-          break;
         case LVLSCHED_TP1:
           kh.create_spiluk_handle(SPILUKAlgorithm::SEQLVLSCHD_TP1, nrows,
                                   EXPAND_FACT * nnz * (fill_lev + 1),

--- a/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
@@ -162,7 +162,8 @@ struct IlukWrap {
 
     // multiply_subtract. C -= A * B
     KOKKOS_INLINE_FUNCTION
-    void multiply_subtract(const scalar_t &A, const scalar_t &B, scalar_t &C) const {
+    void multiply_subtract(const scalar_t &A, const scalar_t &B,
+                           scalar_t &C) const {
       C -= A * B;
     }
 
@@ -263,8 +264,7 @@ struct IlukWrap {
     }
 
     KOKKOS_INLINE_FUNCTION
-    void lset(const size_type block,
-              const ABlock &rhs) const {
+    void lset(const size_type block, const ABlock &rhs) const {
       auto lblock = lget(block);
       for (size_type i = 0; i < block_size; ++i) {
         for (size_type j = 0; j < block_size; ++j) {
@@ -280,8 +280,7 @@ struct IlukWrap {
     }
 
     KOKKOS_INLINE_FUNCTION
-    void uset(const size_type block,
-              const ABlock &rhs) const {
+    void uset(const size_type block, const ABlock &rhs) const {
       auto ublock = uget(block);
       for (size_type i = 0; i < block_size; ++i) {
         for (size_type j = 0; j < block_size; ++j) {
@@ -314,33 +313,32 @@ struct IlukWrap {
                                                   const LBlock &B,
                                                   CView &C) const {
       // Use gemm. alpha is hardcoded to -1, beta hardcoded to 1
-      KokkosBatched::SerialGemm<KokkosBatched::Trans::NoTranspose,
-                                KokkosBatched::Trans::NoTranspose,
-                                KokkosBatched::Algo::Gemm::Unblocked>::
-          invoke<scalar_t, LBlock,
-                 UBlock, LBlock>(
-              -1.0, A, B, 1.0, C);
+      KokkosBatched::SerialGemm<
+          KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose,
+          KokkosBatched::Algo::Gemm::Unblocked>::invoke<scalar_t, LBlock,
+                                                        UBlock, LBlock>(
+          -1.0, A, B, 1.0, C);
     }
 
     // lget
     KOKKOS_INLINE_FUNCTION
     LBlock lget(const size_type block) const {
-      return LBlock(
-          L_values.data() + (block * block_items), block_size, block_size);
+      return LBlock(L_values.data() + (block * block_items), block_size,
+                    block_size);
     }
 
     // uget
     KOKKOS_INLINE_FUNCTION
     UBlock uget(const size_type block) const {
-      return UBlock(
-          U_values.data() + (block * block_items), block_size, block_size);
+      return UBlock(U_values.data() + (block * block_items), block_size,
+                    block_size);
     }
 
     // aget
     KOKKOS_INLINE_FUNCTION
     ABlock aget(const size_type block) const {
-      return ABlock(
-          A_values.data() + (block * block_items), block_size, block_size);
+      return ABlock(A_values.data() + (block * block_items), block_size,
+                    block_size);
     }
 
     // uequal

--- a/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
@@ -158,9 +158,6 @@ struct IlukWrap {
 
     // divide. lhs /= rhs
     KOKKOS_INLINE_FUNCTION
-    void divide(scalar_t &lhs, const scalar_t &rhs) const { lhs /= rhs; }
-
-    KOKKOS_INLINE_FUNCTION
     void divide(const member_type &team, scalar_t &lhs,
                 const scalar_t &rhs) const {
       Kokkos::single(Kokkos::PerTeam(team), [&]() { lhs /= rhs; });
@@ -315,17 +312,6 @@ struct IlukWrap {
     }
 
     // divide. lhs /= rhs
-    KOKKOS_INLINE_FUNCTION
-    void divide(const LValuesUnmanaged2DBlockType &lhs,
-                const UValuesUnmanaged2DBlockType &rhs) const {
-      KokkosBatched::SerialTrsm<
-          KokkosBatched::Side::Right, KokkosBatched::Uplo::Upper,
-          KokkosBatched::Trans::NoTranspose,  // not 100% on this
-          KokkosBatched::Diag::NonUnit,
-          KokkosBatched::Algo::Trsm::Unblocked>::  // not 100% on this
-          invoke<scalar_t>(1.0, rhs, lhs);
-    }
-
     KOKKOS_INLINE_FUNCTION
     void divide(const member_type &team, const LValuesUnmanaged2DBlockType &lhs,
                 const UValuesUnmanaged2DBlockType &rhs) const {

--- a/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
@@ -107,6 +107,8 @@ struct IlukWrap {
     WorkViewType iw;
     lno_t lev_start;
 
+    using reftype = scalar_t&;
+
     Common(const ARowMapType &A_row_map_, const AEntriesType &A_entries_,
            const AValuesType &A_values_, const LRowMapType &L_row_map_,
            const LEntriesType &L_entries_, LValuesType &L_values_,
@@ -237,6 +239,8 @@ struct IlukWrap {
             AValuesType>::array_layout,
         typename AValuesType::device_type,
         Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
+
+    using reftype = LValuesUnmanaged2DBlockType;
 
     Common(const ARowMapType &A_row_map_, const AEntriesType &A_entries_,
            const AValuesType &A_values_, const LRowMapType &L_row_map_,
@@ -472,7 +476,7 @@ struct IlukWrap {
               const auto col  = Base::U_entries(kk);
               const auto ipos = Base::iw(my_team, col);
               if (ipos != -1) {
-                auto C = col < rowid ? Base::lget(ipos) : Base::uget(ipos);
+                typename Base::reftype C = col < rowid ? Base::lget(ipos) : Base::uget(ipos);
                 Base::gemm(Base::uget(kk), fact, C);
               }
             });  // end for kk

--- a/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
@@ -565,7 +565,7 @@ struct IlukWrap {
                             L_entries, L_values, U_row_map, U_entries, U_values,
                             tpolicy, "parfor_tp1", level_idx, iw,
                             lev_start + lvl_rowid_start, TPF, TPB,
-                            thandle.is_block_enabled(), block_size);
+                            block_enabled, block_size);
           Kokkos::fence();
           lvl_rowid_start += lvl_nrows_chunk;
         }

--- a/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
@@ -58,7 +58,7 @@ struct IlukWrap {
   using team_policy            = typename IlukHandle::TeamPolicy;
   using member_type            = typename team_policy::member_type;
   using range_policy           = typename IlukHandle::RangePolicy;
-  using sview_1d = typename Kokkos::View<scalar_t *, memory_space>;
+  using sview_1d               = typename Kokkos::View<scalar_t *, memory_space>;
 
   static team_policy get_team_policy(const size_type nrows,
                                      const int team_size) {
@@ -68,6 +68,7 @@ struct IlukWrap {
     } else {
       rv = team_policy(nrows, team_size);
     }
+
     return rv;
   }
 
@@ -80,17 +81,7 @@ struct IlukWrap {
     } else {
       rv = team_policy(exe_space, nrows, team_size);
     }
-    return rv;
-  }
 
-  static range_policy get_range_policy(const lno_t start, const lno_t end) {
-    range_policy rv(start, end);
-    return rv;
-  }
-
-  static range_policy get_range_policy(execution_space exe_space,
-                                       const lno_t start, const lno_t end) {
-    range_policy rv(exe_space, start, end);
     return rv;
   }
 
@@ -115,9 +106,6 @@ struct IlukWrap {
     LevelViewType level_idx;
     WorkViewType iw;
     lno_t lev_start;
-
-    // unblocked does not require any buffer
-    static constexpr size_type BUFF_SIZE = 1;
 
     Common(const ARowMapType &A_row_map_, const AEntriesType &A_entries_,
            const AValuesType &A_values_, const LRowMapType &L_row_map_,
@@ -181,11 +169,10 @@ struct IlukWrap {
     KOKKOS_INLINE_FUNCTION
     void add(scalar_t &lhs, const scalar_t &rhs) const { lhs += rhs; }
 
-    // multiply: return (alpha * lhs) * rhs
+    // gemm, alpha is hardcoded to -1, beta hardcoded to 1
     KOKKOS_INLINE_FUNCTION
-    scalar_t multiply(const scalar_t &alpha, const scalar_t &lhs,
-                      const scalar_t &rhs, scalar_t *) const {
-      return alpha * lhs * rhs;
+    void gemm(const scalar_t &A, const scalar_t &B, scalar_t &C) const {
+      C += -1*A*B;
     }
 
     // lget
@@ -229,9 +216,6 @@ struct IlukWrap {
     size_type block_size;
     size_type block_items;
     sview_1d ones;
-
-    // blocked requires a buffer to store gemm output
-    static constexpr size_type BUFF_SIZE = 128;
 
     using LValuesUnmanaged2DBlockType = Kokkos::View<
         typename LValuesType::value_type **,
@@ -279,7 +263,6 @@ struct IlukWrap {
       Kokkos::deep_copy(ones, 1.0);
       KK_REQUIRE_MSG(block_size > 0,
                      "Tried to use block_size=0 with the blocked Common?");
-      KK_REQUIRE_MSG(block_size <= 11, "Max supported block size is 11");
     }
 
     // lset
@@ -356,20 +339,18 @@ struct IlukWrap {
       KokkosBatched::SerialAxpy::invoke(ones, rhs, lhs);
     }
 
-    // multiply: return (alpha * lhs) * rhs
+    // gemm, alpha is hardcoded to -1, beta hardcoded to 1
+    template <typename CView>
     KOKKOS_INLINE_FUNCTION
-    LValuesUnmanaged2DBlockType multiply(const scalar_t &alpha,
-                                         const UValuesUnmanaged2DBlockType &lhs,
-                                         const LValuesUnmanaged2DBlockType &rhs,
-                                         scalar_t *buff) const {
-      LValuesUnmanaged2DBlockType result(&buff[0], block_size, block_size);
+    void gemm(const UValuesUnmanaged2DBlockType &A,
+              const LValuesUnmanaged2DBlockType &B,
+              CView& C) const {
       KokkosBatched::SerialGemm<KokkosBatched::Trans::NoTranspose,
                                 KokkosBatched::Trans::NoTranspose,
                                 KokkosBatched::Algo::Gemm::Unblocked>::
-          invoke<scalar_t, LValuesUnmanaged2DBlockType,
-                 UValuesUnmanaged2DBlockType, LValuesUnmanaged2DBlockType>(
-              alpha, lhs, rhs, 0.0, result);
-      return result;
+        invoke<scalar_t, LValuesUnmanaged2DBlockType,
+               UValuesUnmanaged2DBlockType, LValuesUnmanaged2DBlockType>(
+                 -1.0, A, B, 1.0, C);
     }
 
     // lget
@@ -412,103 +393,6 @@ struct IlukWrap {
             class LRowMapType, class LEntriesType, class LValuesType,
             class URowMapType, class UEntriesType, class UValuesType,
             bool BlockEnabled>
-  struct ILUKLvlSchedRPNumericFunctor
-      : public Common<ARowMapType, AEntriesType, AValuesType, LRowMapType,
-                      LEntriesType, LValuesType, URowMapType, UEntriesType,
-                      UValuesType, BlockEnabled> {
-    using Base = Common<ARowMapType, AEntriesType, AValuesType, LRowMapType,
-                        LEntriesType, LValuesType, URowMapType, UEntriesType,
-                        UValuesType, BlockEnabled>;
-
-    ILUKLvlSchedRPNumericFunctor(
-        const ARowMapType &A_row_map_, const AEntriesType &A_entries_,
-        const AValuesType &A_values_, const LRowMapType &L_row_map_,
-        const LEntriesType &L_entries_, LValuesType &L_values_,
-        const URowMapType &U_row_map_, const UEntriesType &U_entries_,
-        UValuesType &U_values_, const LevelViewType &level_idx_,
-        WorkViewType &iw_, const lno_t &lev_start_,
-        const size_type &block_size_ = 0)
-        : Base(A_row_map_, A_entries_, A_values_, L_row_map_, L_entries_,
-               L_values_, U_row_map_, U_entries_, U_values_, level_idx_, iw_,
-               lev_start_, block_size_) {}
-
-    KOKKOS_FUNCTION
-    void operator()(const lno_t i) const {
-      scalar_t buff[Base::BUFF_SIZE];
-
-      const auto rowid = Base::level_idx(i);
-      const auto tid   = i - Base::lev_start;
-      auto k1          = Base::L_row_map(rowid);
-      auto k2          = Base::L_row_map(rowid + 1) - 1;
-      Base::lset_id(k2);
-      for (auto k = k1; k < k2; ++k) {
-        const auto col = Base::L_entries(k);
-        Base::lset(k, 0.0);
-        Base::iw(tid, col) = k;
-      }
-
-      k1 = Base::U_row_map(rowid);
-      k2 = Base::U_row_map(rowid + 1);
-      for (auto k = k1; k < k2; ++k) {
-        const auto col = Base::U_entries(k);
-        Base::uset(k, 0.0);
-        Base::iw(tid, col) = k;
-      }
-
-      k1 = Base::A_row_map(rowid);
-      k2 = Base::A_row_map(rowid + 1);
-      for (auto k = k1; k < k2; ++k) {
-        const auto col  = Base::A_entries(k);
-        const auto ipos = Base::iw(tid, col);
-        if (col < rowid) {
-          Base::lset(ipos, Base::aget(k));
-        } else {
-          Base::uset(ipos, Base::aget(k));
-        }
-      }
-
-      // Eliminate prev rows
-      k1 = Base::L_row_map(rowid);
-      k2 = Base::L_row_map(rowid + 1) - 1;
-      for (auto k = k1; k < k2; ++k) {
-        const auto prev_row = Base::L_entries(k);
-        const auto u_diag   = Base::uget(Base::U_row_map(prev_row));
-        Base::divide(Base::lget(k), u_diag);
-        auto fact = Base::lget(k);
-        for (auto kk = Base::U_row_map(prev_row) + 1;
-             kk < Base::U_row_map(prev_row + 1); ++kk) {
-          const auto col  = Base::U_entries(kk);
-          const auto ipos = Base::iw(tid, col);
-          if (ipos == -1) continue;
-          const auto lxu = Base::multiply(-1.0, Base::uget(kk), fact, &buff[0]);
-          if (col < rowid) {
-            Base::add(Base::lget(ipos), lxu);
-          } else {
-            Base::add(Base::uget(ipos), lxu);
-          }
-        }  // end for kk
-      }    // end for k
-
-      const auto ipos = Base::iw(tid, rowid);
-      if (Base::uequal(ipos, 0.0)) {
-        Base::uset(ipos, 1e6);
-      }
-
-      // Reset
-      k1 = Base::L_row_map(rowid);
-      k2 = Base::L_row_map(rowid + 1) - 1;
-      for (auto k = k1; k < k2; ++k) Base::iw(tid, Base::L_entries(k)) = -1;
-
-      k1 = Base::U_row_map(rowid);
-      k2 = Base::U_row_map(rowid + 1);
-      for (auto k = k1; k < k2; ++k) Base::iw(tid, Base::U_entries(k)) = -1;
-    }
-  };
-
-  template <class ARowMapType, class AEntriesType, class AValuesType,
-            class LRowMapType, class LEntriesType, class LValuesType,
-            class URowMapType, class UEntriesType, class UValuesType,
-            bool BlockEnabled>
   struct ILUKLvlSchedTP1NumericFunctor
       : public Common<ARowMapType, AEntriesType, AValuesType, LRowMapType,
                       LEntriesType, LValuesType, URowMapType, UEntriesType,
@@ -539,10 +423,10 @@ struct IlukWrap {
       Base::lset_id(team, k2);
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, k1, k2),
                            [&](const size_type k) {
-                             const auto col = Base::L_entries(k);
-                             Base::lset(k, 0.0);
-                             Base::iw(my_team, col) = k;
-                           });
+        const auto col = Base::L_entries(k);
+        Base::lset(k, 0.0);
+        Base::iw(my_team, col) = k;
+      });
 
       team.team_barrier();
 
@@ -550,10 +434,10 @@ struct IlukWrap {
       k2 = Base::U_row_map(rowid + 1);
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, k1, k2),
                            [&](const size_type k) {
-                             const auto col = Base::U_entries(k);
-                             Base::uset(k, 0.0);
-                             Base::iw(my_team, col) = k;
-                           });
+        const auto col = Base::U_entries(k);
+        Base::uset(k, 0.0);
+        Base::iw(my_team, col) = k;
+      });
 
       team.team_barrier();
 
@@ -562,14 +446,14 @@ struct IlukWrap {
       k2 = Base::A_row_map(rowid + 1);
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, k1, k2),
                            [&](const size_type k) {
-                             const auto col  = Base::A_entries(k);
-                             const auto ipos = Base::iw(my_team, col);
-                             if (col < rowid) {
-                               Base::lset(ipos, Base::aget(k));
-                             } else {
-                               Base::uset(ipos, Base::aget(k));
-                             }
-                           });
+        const auto col  = Base::A_entries(k);
+        const auto ipos = Base::iw(my_team, col);
+        if (col < rowid) {
+          Base::lset(ipos, Base::aget(k));
+        } else {
+          Base::uset(ipos, Base::aget(k));
+        }
+      });
 
       team.team_barrier();
 
@@ -588,13 +472,8 @@ struct IlukWrap {
               const auto col  = Base::U_entries(kk);
               const auto ipos = Base::iw(my_team, col);
               if (ipos != -1) {
-                scalar_t buff[Base::BUFF_SIZE];
-                auto lxu = Base::multiply(-1.0, Base::uget(kk), fact, &buff[0]);
-                if (col < rowid) {
-                  Base::add(Base::lget(ipos), lxu);
-                } else {
-                  Base::add(Base::uget(ipos), lxu);
-                }
+                auto C = col < rowid ? Base::lget(ipos) : Base::uget(ipos);
+                Base::gemm(Base::uget(kk), fact, C);
               }
             });  // end for kk
 
@@ -615,17 +494,17 @@ struct IlukWrap {
       k2 = Base::L_row_map(rowid + 1) - 1;
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, k1, k2),
                            [&](const size_type k) {
-                             const auto col         = Base::L_entries(k);
-                             Base::iw(my_team, col) = -1;
-                           });
+        const auto col = Base::L_entries(k);
+        Base::iw(my_team, col) = -1;
+      });
 
       k1 = Base::U_row_map(rowid);
       k2 = Base::U_row_map(rowid + 1);
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, k1, k2),
                            [&](const size_type k) {
-                             const auto col         = Base::U_entries(k);
-                             Base::iw(my_team, col) = -1;
-                           });
+        const auto col         = Base::U_entries(k);
+        Base::iw(my_team, col) = -1;
+      });
     }
   };
 
@@ -657,14 +536,13 @@ struct IlukWrap {
                            const URowMapType &U_row_map,
                            const UEntriesType &U_entries,
                            UValuesType &U_values) {
-    using RPF = FunctorTypeMacro(ILUKLvlSchedRPNumericFunctor, false);
-    using RPB = FunctorTypeMacro(ILUKLvlSchedRPNumericFunctor, true);
     using TPF = FunctorTypeMacro(ILUKLvlSchedTP1NumericFunctor, false);
     using TPB = FunctorTypeMacro(ILUKLvlSchedTP1NumericFunctor, true);
 
-    size_type nlevels     = thandle.get_num_levels();
-    int team_size         = thandle.get_team_size();
-    const auto block_size = thandle.get_block_size();
+    size_type nlevels        = thandle.get_num_levels();
+    int team_size            = thandle.get_team_size();
+    const auto block_size    = thandle.get_block_size();
+    const auto block_enabled = thandle.is_block_enabled();
 
     LevelHostViewType level_ptr_h = thandle.get_host_level_ptr();
     LevelViewType level_idx       = thandle.get_level_idx();
@@ -672,11 +550,8 @@ struct IlukWrap {
     LevelHostViewType level_nchunks_h, level_nrowsperchunk_h;
     WorkViewType iw;
 
-    if (thandle.get_algorithm() ==
-        KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_TP1) {
-      level_nchunks_h       = thandle.get_level_nchunks();
-      level_nrowsperchunk_h = thandle.get_level_nrowsperchunk();
-    }
+    level_nchunks_h       = thandle.get_level_nchunks();
+    level_nrowsperchunk_h = thandle.get_level_nrowsperchunk();
     iw = thandle.get_iw();
 
     // Main loop must be performed sequential. Question: Try out Cuda's graph
@@ -686,39 +561,27 @@ struct IlukWrap {
       lno_t lev_end   = level_ptr_h(lvl + 1);
 
       if ((lev_end - lev_start) != 0) {
-        if (thandle.get_algorithm() ==
-            KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_RP) {
-          range_policy rpolicy = get_range_policy(lev_start, lev_end);
-          KernelLaunchMacro(A_row_map, A_entries, A_values, L_row_map,
-                            L_entries, L_values, U_row_map, U_entries, U_values,
-                            rpolicy, "parfor_fixed_lvl", level_idx, iw,
-                            lev_start, RPF, RPB, thandle.is_block_enabled(),
-                            block_size);
-        } else if (thandle.get_algorithm() ==
-                   KokkosSparse::Experimental::SPILUKAlgorithm::
-                       SEQLVLSCHD_TP1) {
-          lno_t lvl_rowid_start = 0;
-          lno_t lvl_nrows_chunk;
-          for (int chunkid = 0; chunkid < level_nchunks_h(lvl); chunkid++) {
-            if ((lvl_rowid_start + level_nrowsperchunk_h(lvl)) >
-                (lev_end - lev_start))
-              lvl_nrows_chunk = (lev_end - lev_start) - lvl_rowid_start;
-            else
-              lvl_nrows_chunk = level_nrowsperchunk_h(lvl);
+        lno_t lvl_rowid_start = 0;
+        lno_t lvl_nrows_chunk;
+        for (int chunkid = 0; chunkid < level_nchunks_h(lvl); chunkid++) {
+          if ((lvl_rowid_start + level_nrowsperchunk_h(lvl)) >
+              (lev_end - lev_start))
+            lvl_nrows_chunk = (lev_end - lev_start) - lvl_rowid_start;
+          else
+            lvl_nrows_chunk = level_nrowsperchunk_h(lvl);
 
-            team_policy tpolicy = get_team_policy(lvl_nrows_chunk, team_size);
-            KernelLaunchMacro(A_row_map, A_entries, A_values, L_row_map,
-                              L_entries, L_values, U_row_map, U_entries,
-                              U_values, tpolicy, "parfor_tp1", level_idx, iw,
-                              lev_start + lvl_rowid_start, TPF, TPB,
-                              thandle.is_block_enabled(), block_size);
-            Kokkos::fence();
-            lvl_rowid_start += lvl_nrows_chunk;
-          }
+          team_policy tpolicy =
+            get_team_policy(lvl_nrows_chunk, team_size);
+          KernelLaunchMacro(A_row_map, A_entries, A_values, L_row_map,
+                            L_entries, L_values, U_row_map, U_entries,
+                            U_values, tpolicy, "parfor_tp1", level_idx, iw,
+                            lev_start + lvl_rowid_start, TPF, TPB,
+                            thandle.is_block_enabled(), block_size);
+          Kokkos::fence();
+          lvl_rowid_start += lvl_nrows_chunk;
         }
       }  // end if
     }    // end for lvl
-         //}
 
 // Output check
 #ifdef NUMERIC_OUTPUT_INFO
@@ -781,8 +644,6 @@ struct IlukWrap {
       const std::vector<URowMapType> &U_row_map_v,
       const std::vector<UEntriesType> &U_entries_v,
       std::vector<UValuesType> &U_values_v) {
-    using RPF = FunctorTypeMacro(ILUKLvlSchedRPNumericFunctor, false);
-    using RPB = FunctorTypeMacro(ILUKLvlSchedRPNumericFunctor, true);
     using TPF = FunctorTypeMacro(ILUKLvlSchedTP1NumericFunctor, false);
     using TPB = FunctorTypeMacro(ILUKLvlSchedTP1NumericFunctor, true);
 
@@ -811,110 +672,70 @@ struct IlukWrap {
       if (nlevels_max < nlevels_v[i]) nlevels_max = nlevels_v[i];
     }
 
-    // Assume all streams use the same algorithm
-    if (thandle_v[0]->get_algorithm() ==
-        KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_RP) {
-      // Main loop must be performed sequential
-      for (size_type lvl = 0; lvl < nlevels_max; lvl++) {
-        // Initial work across streams at each level
-        for (int i = 0; i < nstreams; i++) {
-          // Only do this if this stream has this level
-          if (lvl < nlevels_v[i]) {
-            lvl_start_v[i] = lvl_ptr_h_v[i](lvl);
-            lvl_end_v[i]   = lvl_ptr_h_v[i](lvl + 1);
-            if ((lvl_end_v[i] - lvl_start_v[i]) != 0)
-              stream_have_level_v[i] = true;
-            else
-              stream_have_level_v[i] = false;
+    std::vector<LevelHostViewType> lvl_nchunks_h_v(nstreams);
+    std::vector<LevelHostViewType> lvl_nrowsperchunk_h_v(nstreams);
+    std::vector<lno_t> lvl_rowid_start_v(nstreams);
+    std::vector<int> team_size_v(nstreams);
+
+    for (int i = 0; i < nstreams; i++) {
+      lvl_nchunks_h_v[i]       = thandle_v[i]->get_level_nchunks();
+      lvl_nrowsperchunk_h_v[i] = thandle_v[i]->get_level_nrowsperchunk();
+      team_size_v[i]           = thandle_v[i]->get_team_size();
+    }
+
+    // Main loop must be performed sequential
+    for (size_type lvl = 0; lvl < nlevels_max; lvl++) {
+      // Initial work across streams at each level
+      lno_t lvl_nchunks_max = 0;
+      for (int i = 0; i < nstreams; i++) {
+        // Only do this if this stream has this level
+        if (lvl < nlevels_v[i]) {
+          lvl_start_v[i] = lvl_ptr_h_v[i](lvl);
+          lvl_end_v[i]   = lvl_ptr_h_v[i](lvl + 1);
+          if ((lvl_end_v[i] - lvl_start_v[i]) != 0) {
+            stream_have_level_v[i] = true;
+            lvl_rowid_start_v[i]   = 0;
+            if (lvl_nchunks_max < lvl_nchunks_h_v[i](lvl))
+              lvl_nchunks_max = lvl_nchunks_h_v[i](lvl);
           } else
             stream_have_level_v[i] = false;
-        }
+        } else
+          stream_have_level_v[i] = false;
+      }
 
-        // Main work of the level across streams
-        // 1. Launch work on all streams
+      // Main work of the level across streams -- looping through chunnks
+      for (int chunkid = 0; chunkid < lvl_nchunks_max; chunkid++) {
+        // 1. Launch work on all streams (for each chunk)
         for (int i = 0; i < nstreams; i++) {
           // Launch only if stream i-th has this level
           if (stream_have_level_v[i]) {
-            range_policy rpolicy =
-                get_range_policy(execspace_v[i], lvl_start_v[i], lvl_end_v[i]);
-            KernelLaunchMacro(A_row_map_v[i], A_entries_v[i], A_values_v[i],
-                              L_row_map_v[i], L_entries_v[i], L_values_v[i],
-                              U_row_map_v[i], U_entries_v[i], U_values_v[i],
-                              rpolicy, "parfor_rp", lvl_idx_v[i], iw_v[i],
-                              lvl_start_v[i], RPF, RPB, is_block_enabled_v[i],
-                              block_size_v[i]);
-          }  // end if (stream_have_level_v[i])
-        }    // end for streams
-      }      // end for lvl
-    }        // end SEQLVLSCHD_RP
-    else if (thandle_v[0]->get_algorithm() ==
-             KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_TP1) {
-      std::vector<LevelHostViewType> lvl_nchunks_h_v(nstreams);
-      std::vector<LevelHostViewType> lvl_nrowsperchunk_h_v(nstreams);
-      std::vector<lno_t> lvl_rowid_start_v(nstreams);
-      std::vector<int> team_size_v(nstreams);
+            // Launch only if stream i-th has this chunk
+            if (chunkid < lvl_nchunks_h_v[i](lvl)) {
+              // 1.a. Specify number of rows (i.e. number of teams) to launch
+              lno_t lvl_nrows_chunk = 0;
+              if ((lvl_rowid_start_v[i] + lvl_nrowsperchunk_h_v[i](lvl)) >
+                  (lvl_end_v[i] - lvl_start_v[i]))
+                lvl_nrows_chunk =
+                  (lvl_end_v[i] - lvl_start_v[i]) - lvl_rowid_start_v[i];
+              else
+                lvl_nrows_chunk = lvl_nrowsperchunk_h_v[i](lvl);
 
-      for (int i = 0; i < nstreams; i++) {
-        lvl_nchunks_h_v[i]       = thandle_v[i]->get_level_nchunks();
-        lvl_nrowsperchunk_h_v[i] = thandle_v[i]->get_level_nrowsperchunk();
-        team_size_v[i]           = thandle_v[i]->get_team_size();
-      }
-
-      // Main loop must be performed sequential
-      for (size_type lvl = 0; lvl < nlevels_max; lvl++) {
-        // Initial work across streams at each level
-        lno_t lvl_nchunks_max = 0;
-        for (int i = 0; i < nstreams; i++) {
-          // Only do this if this stream has this level
-          if (lvl < nlevels_v[i]) {
-            lvl_start_v[i] = lvl_ptr_h_v[i](lvl);
-            lvl_end_v[i]   = lvl_ptr_h_v[i](lvl + 1);
-            if ((lvl_end_v[i] - lvl_start_v[i]) != 0) {
-              stream_have_level_v[i] = true;
-              lvl_rowid_start_v[i]   = 0;
-              if (lvl_nchunks_max < lvl_nchunks_h_v[i](lvl))
-                lvl_nchunks_max = lvl_nchunks_h_v[i](lvl);
-            } else
-              stream_have_level_v[i] = false;
-          } else
-            stream_have_level_v[i] = false;
-        }
-
-        // Main work of the level across streams -- looping through chunnks
-        for (int chunkid = 0; chunkid < lvl_nchunks_max; chunkid++) {
-          // 1. Launch work on all streams (for each chunk)
-          for (int i = 0; i < nstreams; i++) {
-            // Launch only if stream i-th has this level
-            if (stream_have_level_v[i]) {
-              // Launch only if stream i-th has this chunk
-              if (chunkid < lvl_nchunks_h_v[i](lvl)) {
-                // 1.a. Specify number of rows (i.e. number of teams) to launch
-                lno_t lvl_nrows_chunk = 0;
-                if ((lvl_rowid_start_v[i] + lvl_nrowsperchunk_h_v[i](lvl)) >
-                    (lvl_end_v[i] - lvl_start_v[i]))
-                  lvl_nrows_chunk =
-                      (lvl_end_v[i] - lvl_start_v[i]) - lvl_rowid_start_v[i];
-                else
-                  lvl_nrows_chunk = lvl_nrowsperchunk_h_v[i](lvl);
-
-                // 1.b. Create functor for stream i-th and launch
-                team_policy tpolicy = get_team_policy(
-                    execspace_v[i], lvl_nrows_chunk, team_size_v[i]);
-                KernelLaunchMacro(A_row_map_v[i], A_entries_v[i], A_values_v[i],
-                                  L_row_map_v[i], L_entries_v[i], L_values_v[i],
-                                  U_row_map_v[i], U_entries_v[i], U_values_v[i],
-                                  tpolicy, "parfor_tp1", lvl_idx_v[i], iw_v[i],
-                                  lvl_start_v[i] + lvl_rowid_start_v[i], TPF,
-                                  TPB, is_block_enabled_v[i], block_size_v[i]);
-                // 1.c. Ready to move to next chunk
-                lvl_rowid_start_v[i] += lvl_nrows_chunk;
-              }  // end if (chunkid < lvl_nchunks_h_v[i](lvl))
-            }    // end if (stream_have_level_v[i])
-          }      // end for streams
-        }        // end for chunkid
-      }          // end for lvl
-    }            // end SEQLVLSCHD_TP1
-
+              // 1.b. Create functor for stream i-th and launch
+              team_policy tpolicy = get_team_policy(
+                execspace_v[i], lvl_nrows_chunk, team_size_v[i]);
+              KernelLaunchMacro(A_row_map_v[i], A_entries_v[i], A_values_v[i],
+                                L_row_map_v[i], L_entries_v[i], L_values_v[i],
+                                U_row_map_v[i], U_entries_v[i], U_values_v[i],
+                                tpolicy, "parfor_tp1", lvl_idx_v[i], iw_v[i],
+                                lvl_start_v[i] + lvl_rowid_start_v[i], TPF,
+                                TPB, is_block_enabled_v[i], block_size_v[i]);
+              // 1.c. Ready to move to next chunk
+              lvl_rowid_start_v[i] += lvl_nrows_chunk;
+            }  // end if (chunkid < lvl_nchunks_h_v[i](lvl))
+          }    // end if (stream_have_level_v[i])
+        }      // end for streams
+      }        // end for chunkid
+    }          // end for lvl
   }  // end iluk_numeric_streams
 
 };  // IlukWrap

--- a/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
@@ -58,7 +58,7 @@ struct IlukWrap {
   using team_policy            = typename IlukHandle::TeamPolicy;
   using member_type            = typename team_policy::member_type;
   using range_policy           = typename IlukHandle::RangePolicy;
-  using sview_1d               = typename Kokkos::View<scalar_t *, memory_space>;
+  using sview_1d = typename Kokkos::View<scalar_t *, memory_space>;
 
   static team_policy get_team_policy(const size_type nrows,
                                      const int team_size) {
@@ -107,7 +107,7 @@ struct IlukWrap {
     WorkViewType iw;
     lno_t lev_start;
 
-    using reftype = scalar_t&;
+    using reftype = scalar_t &;
 
     Common(const ARowMapType &A_row_map_, const AEntriesType &A_entries_,
            const AValuesType &A_values_, const LRowMapType &L_row_map_,
@@ -174,7 +174,7 @@ struct IlukWrap {
     // gemm, alpha is hardcoded to -1, beta hardcoded to 1
     KOKKOS_INLINE_FUNCTION
     void gemm(const scalar_t &A, const scalar_t &B, scalar_t &C) const {
-      C += -1*A*B;
+      C += -1 * A * B;
     }
 
     // lget
@@ -345,16 +345,15 @@ struct IlukWrap {
 
     // gemm, alpha is hardcoded to -1, beta hardcoded to 1
     template <typename CView>
-    KOKKOS_INLINE_FUNCTION
-    void gemm(const UValuesUnmanaged2DBlockType &A,
-              const LValuesUnmanaged2DBlockType &B,
-              CView& C) const {
+    KOKKOS_INLINE_FUNCTION void gemm(const UValuesUnmanaged2DBlockType &A,
+                                     const LValuesUnmanaged2DBlockType &B,
+                                     CView &C) const {
       KokkosBatched::SerialGemm<KokkosBatched::Trans::NoTranspose,
                                 KokkosBatched::Trans::NoTranspose,
                                 KokkosBatched::Algo::Gemm::Unblocked>::
-        invoke<scalar_t, LValuesUnmanaged2DBlockType,
-               UValuesUnmanaged2DBlockType, LValuesUnmanaged2DBlockType>(
-                 -1.0, A, B, 1.0, C);
+          invoke<scalar_t, LValuesUnmanaged2DBlockType,
+                 UValuesUnmanaged2DBlockType, LValuesUnmanaged2DBlockType>(
+              -1.0, A, B, 1.0, C);
     }
 
     // lget
@@ -427,10 +426,10 @@ struct IlukWrap {
       Base::lset_id(team, k2);
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, k1, k2),
                            [&](const size_type k) {
-        const auto col = Base::L_entries(k);
-        Base::lset(k, 0.0);
-        Base::iw(my_team, col) = k;
-      });
+                             const auto col = Base::L_entries(k);
+                             Base::lset(k, 0.0);
+                             Base::iw(my_team, col) = k;
+                           });
 
       team.team_barrier();
 
@@ -438,10 +437,10 @@ struct IlukWrap {
       k2 = Base::U_row_map(rowid + 1);
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, k1, k2),
                            [&](const size_type k) {
-        const auto col = Base::U_entries(k);
-        Base::uset(k, 0.0);
-        Base::iw(my_team, col) = k;
-      });
+                             const auto col = Base::U_entries(k);
+                             Base::uset(k, 0.0);
+                             Base::iw(my_team, col) = k;
+                           });
 
       team.team_barrier();
 
@@ -450,14 +449,14 @@ struct IlukWrap {
       k2 = Base::A_row_map(rowid + 1);
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, k1, k2),
                            [&](const size_type k) {
-        const auto col  = Base::A_entries(k);
-        const auto ipos = Base::iw(my_team, col);
-        if (col < rowid) {
-          Base::lset(ipos, Base::aget(k));
-        } else {
-          Base::uset(ipos, Base::aget(k));
-        }
-      });
+                             const auto col  = Base::A_entries(k);
+                             const auto ipos = Base::iw(my_team, col);
+                             if (col < rowid) {
+                               Base::lset(ipos, Base::aget(k));
+                             } else {
+                               Base::uset(ipos, Base::aget(k));
+                             }
+                           });
 
       team.team_barrier();
 
@@ -476,7 +475,8 @@ struct IlukWrap {
               const auto col  = Base::U_entries(kk);
               const auto ipos = Base::iw(my_team, col);
               if (ipos != -1) {
-                typename Base::reftype C = col < rowid ? Base::lget(ipos) : Base::uget(ipos);
+                typename Base::reftype C =
+                    col < rowid ? Base::lget(ipos) : Base::uget(ipos);
                 Base::gemm(Base::uget(kk), fact, C);
               }
             });  // end for kk
@@ -498,17 +498,17 @@ struct IlukWrap {
       k2 = Base::L_row_map(rowid + 1) - 1;
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, k1, k2),
                            [&](const size_type k) {
-        const auto col = Base::L_entries(k);
-        Base::iw(my_team, col) = -1;
-      });
+                             const auto col         = Base::L_entries(k);
+                             Base::iw(my_team, col) = -1;
+                           });
 
       k1 = Base::U_row_map(rowid);
       k2 = Base::U_row_map(rowid + 1);
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, k1, k2),
                            [&](const size_type k) {
-        const auto col         = Base::U_entries(k);
-        Base::iw(my_team, col) = -1;
-      });
+                             const auto col         = Base::U_entries(k);
+                             Base::iw(my_team, col) = -1;
+                           });
     }
   };
 
@@ -556,7 +556,7 @@ struct IlukWrap {
 
     level_nchunks_h       = thandle.get_level_nchunks();
     level_nrowsperchunk_h = thandle.get_level_nrowsperchunk();
-    iw = thandle.get_iw();
+    iw                    = thandle.get_iw();
 
     // Main loop must be performed sequential. Question: Try out Cuda's graph
     // stuff to reduce kernel launch overhead
@@ -574,11 +574,10 @@ struct IlukWrap {
           else
             lvl_nrows_chunk = level_nrowsperchunk_h(lvl);
 
-          team_policy tpolicy =
-            get_team_policy(lvl_nrows_chunk, team_size);
+          team_policy tpolicy = get_team_policy(lvl_nrows_chunk, team_size);
           KernelLaunchMacro(A_row_map, A_entries, A_values, L_row_map,
-                            L_entries, L_values, U_row_map, U_entries,
-                            U_values, tpolicy, "parfor_tp1", level_idx, iw,
+                            L_entries, L_values, U_row_map, U_entries, U_values,
+                            tpolicy, "parfor_tp1", level_idx, iw,
                             lev_start + lvl_rowid_start, TPF, TPB,
                             thandle.is_block_enabled(), block_size);
           Kokkos::fence();
@@ -720,19 +719,19 @@ struct IlukWrap {
               if ((lvl_rowid_start_v[i] + lvl_nrowsperchunk_h_v[i](lvl)) >
                   (lvl_end_v[i] - lvl_start_v[i]))
                 lvl_nrows_chunk =
-                  (lvl_end_v[i] - lvl_start_v[i]) - lvl_rowid_start_v[i];
+                    (lvl_end_v[i] - lvl_start_v[i]) - lvl_rowid_start_v[i];
               else
                 lvl_nrows_chunk = lvl_nrowsperchunk_h_v[i](lvl);
 
               // 1.b. Create functor for stream i-th and launch
               team_policy tpolicy = get_team_policy(
-                execspace_v[i], lvl_nrows_chunk, team_size_v[i]);
+                  execspace_v[i], lvl_nrows_chunk, team_size_v[i]);
               KernelLaunchMacro(A_row_map_v[i], A_entries_v[i], A_values_v[i],
                                 L_row_map_v[i], L_entries_v[i], L_values_v[i],
                                 U_row_map_v[i], U_entries_v[i], U_values_v[i],
                                 tpolicy, "parfor_tp1", lvl_idx_v[i], iw_v[i],
-                                lvl_start_v[i] + lvl_rowid_start_v[i], TPF,
-                                TPB, is_block_enabled_v[i], block_size_v[i]);
+                                lvl_start_v[i] + lvl_rowid_start_v[i], TPF, TPB,
+                                is_block_enabled_v[i], block_size_v[i]);
               // 1.c. Ready to move to next chunk
               lvl_rowid_start_v[i] += lvl_nrows_chunk;
             }  // end if (chunkid < lvl_nchunks_h_v[i](lvl))
@@ -740,7 +739,7 @@ struct IlukWrap {
         }      // end for streams
       }        // end for chunkid
     }          // end for lvl
-  }  // end iluk_numeric_streams
+  }            // end iluk_numeric_streams
 
 };  // IlukWrap
 

--- a/sparse/impl/KokkosSparse_spiluk_symbolic_impl.hpp
+++ b/sparse/impl/KokkosSparse_spiluk_symbolic_impl.hpp
@@ -229,9 +229,7 @@ void iluk_symbolic(IlukHandle& thandle,
                    LEntriesType& L_entries_d, URowMapType& U_row_map_d,
                    UEntriesType& U_entries_d, int nstreams = 1) {
   if (thandle.get_algorithm() ==
-          KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_RP ||
-      thandle.get_algorithm() ==
-          KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_TP1)
+      KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_TP1)
   /*   || thandle.get_algorithm() ==
      KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHED_TP2 )*/
   {
@@ -379,7 +377,7 @@ void iluk_symbolic(IlukHandle& thandle,
         std::ostringstream os;
         os << "KokkosSparse::Experimental::spiluk_symbolic: U_entries's extent "
               "must be larger than "
-           << U_entries_d.extent(0);
+           << U_entries_d.extent(0) << ", must be at least " << cntU + lenu + 1;
         KokkosKernels::Impl::throw_runtime_exception(os.str());
       }
       // U diag entry
@@ -401,7 +399,7 @@ void iluk_symbolic(IlukHandle& thandle,
         std::ostringstream os;
         os << "KokkosSparse::Experimental::spiluk_symbolic: L_entries's extent "
               "must be larger than "
-           << L_entries_d.extent(0);
+           << L_entries_d.extent(0) << ", must be at least " << cntL + lenl + 1;
         KokkosKernels::Impl::throw_runtime_exception(os.str());
       }
       for (size_type k = 0; k < lenl; ++k) {

--- a/sparse/src/KokkosSparse_LUPrec.hpp
+++ b/sparse/src/KokkosSparse_LUPrec.hpp
@@ -24,6 +24,7 @@
 #include <Kokkos_Core.hpp>
 #include <KokkosSparse_spmv.hpp>
 #include <KokkosSparse_sptrsv.hpp>
+#include <KokkosSparse_trsv.hpp>
 
 namespace KokkosSparse {
 namespace Experimental {
@@ -45,8 +46,9 @@ class LUPrec : public KokkosSparse::Experimental::Preconditioner<CRS> {
   using ScalarType = typename std::remove_const<typename CRS::value_type>::type;
   using EXSP       = typename CRS::execution_space;
   using MEMSP      = typename CRS::memory_space;
+  using DEVC       = typename Kokkos::Device<EXSP, MEMSP>;
   using karith     = typename Kokkos::ArithTraits<ScalarType>;
-  using View1d = typename Kokkos::View<ScalarType *, typename CRS::device_type>;
+  using View1d  = typename Kokkos::View<ScalarType *, DEVC>;
 
  private:
   // trsm takes host views
@@ -61,11 +63,11 @@ class LUPrec : public KokkosSparse::Experimental::Preconditioner<CRS> {
   LUPrec(const CRSArg &L, const CRSArg &U)
       : _L(L),
         _U(U),
-        _tmp("LUPrec::_tmp", L.numRows()),
-        _tmp2("LUPrec::_tmp", L.numRows()),
+        _tmp("LUPrec::_tmp", L.numPointRows()),
+        _tmp2("LUPrec::_tmp", L.numPointRows()),
         _khL(),
         _khU() {
-    KK_REQUIRE_MSG(L.numRows() == U.numRows(),
+    KK_REQUIRE_MSG(L.numPointRows() == U.numPointRows(),
                    "LUPrec: L.numRows() != U.numRows()");
 
     _khL.create_sptrsv_handle(SPTRSVAlgorithm::SEQLVLSCHD_TP1, L.numRows(),
@@ -80,22 +82,12 @@ class LUPrec : public KokkosSparse::Experimental::Preconditioner<CRS> {
     _khU.destroy_sptrsv_handle();
   }
 
-  ///// \brief Apply the preconditioner to X, putting the result in Y.
-  /////
-  ///// \tparam XViewType Input vector, as a 1-D Kokkos::View
-  ///// \tparam YViewType Output vector, as a nonconst 1-D Kokkos::View
-  /////
-  ///// \param transM [in] Not used.
-  ///// \param alpha [in] Not used
-  ///// \param beta [in] Not used.
-  /////
-  ///// It takes L and U and the stores U^inv L^inv X in Y
-  //
-  virtual void apply(
-      const Kokkos::View<const ScalarType *, Kokkos::Device<EXSP, MEMSP>> &X,
-      const Kokkos::View<ScalarType *, Kokkos::Device<EXSP, MEMSP>> &Y,
-      const char transM[] = "N", ScalarType alpha = karith::one(),
-      ScalarType beta = karith::zero()) const {
+  template <typename Matrix, typename std::enable_if<is_crs_matrix<Matrix>::value>::type* = nullptr>
+  void apply_impl(
+    const Kokkos::View<const ScalarType *, DEVC> &X,
+    const Kokkos::View<ScalarType *, DEVC> &Y,
+    const char transM[] = "N", ScalarType alpha = karith::one(),
+    ScalarType beta = karith::zero()) const {
     // tmp = trsv(L, x); //Apply L^inv to x
     // y = trsv(U, tmp); //Apply U^inv to tmp
 
@@ -110,6 +102,60 @@ class LUPrec : public KokkosSparse::Experimental::Preconditioner<CRS> {
                  _tmp2);
 
     KokkosBlas::axpby(alpha, _tmp2, beta, Y);
+  }
+
+  template <typename Matrix, typename std::enable_if<is_bsr_matrix<Matrix>::value>::type* = nullptr>
+  void apply_impl(
+      const Kokkos::View<const ScalarType *, DEVC> &X,
+      const Kokkos::View<ScalarType *, DEVC> &Y,
+      const char transM[] = "N", ScalarType alpha = karith::one(),
+      ScalarType beta = karith::zero()) const {
+    // tmp = trsv(L, x); //Apply L^inv to x
+    // y = trsv(U, tmp); //Apply U^inv to tmp
+
+    KK_REQUIRE_MSG(transM[0] == NoTranspose[0],
+                   "LUPrec::apply only supports 'N' for transM");
+
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
+    using Layout = Kokkos::LayoutLeft;
+#else
+    using Layout = Kokkos::LayoutRight;
+#endif
+
+    // trsv is implemented for MV so we need to convert our views
+    using UView2d = typename Kokkos::View<ScalarType **, Layout, DEVC,
+                                          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
+    using UView2dc = typename Kokkos::View<const ScalarType **, Layout, DEVC,
+                                           Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
+    UView2dc X2d(X.data(), X.extent(0), 1);
+    UView2d
+      Y2d(Y.data(), Y.extent(0), 1),
+      tmp2d(_tmp.data(), _tmp.extent(0), 1),
+      tmp22d(_tmp2.data(), _tmp2.extent(0), 1);
+
+    KokkosSparse::trsv("L", "N", "N", _L, X2d, tmp2d);
+    KokkosSparse::trsv("U", "N", "N", _U, tmp2d, tmp22d);
+
+    KokkosBlas::axpby(alpha, _tmp2, beta, Y);
+  }
+
+  ///// \brief Apply the preconditioner to X, putting the result in Y.
+  /////
+  ///// \tparam XViewType Input vector, as a 1-D Kokkos::View
+  ///// \tparam YViewType Output vector, as a nonconst 1-D Kokkos::View
+  /////
+  ///// \param transM [in] Not used.
+  ///// \param alpha [in] Not used
+  ///// \param beta [in] Not used.
+  /////
+  ///// It takes L and U and the stores U^inv L^inv X in Y
+  //
+  virtual void apply(
+      const Kokkos::View<const ScalarType *, DEVC> &X,
+      const Kokkos::View<ScalarType *, DEVC> &Y,
+      const char transM[] = "N", ScalarType alpha = karith::one(),
+      ScalarType beta = karith::zero()) const {
+    apply_impl<CRS>(X, Y, transM, alpha, beta);
   }
   //@}
 

--- a/sparse/src/KokkosSparse_LUPrec.hpp
+++ b/sparse/src/KokkosSparse_LUPrec.hpp
@@ -46,9 +46,9 @@ class LUPrec : public KokkosSparse::Experimental::Preconditioner<CRS> {
   using ScalarType = typename std::remove_const<typename CRS::value_type>::type;
   using EXSP       = typename CRS::execution_space;
   using MEMSP      = typename CRS::memory_space;
-  using DEVC       = typename Kokkos::Device<EXSP, MEMSP>;
+  using DEVICE     = typename Kokkos::Device<EXSP, MEMSP>;
   using karith     = typename Kokkos::ArithTraits<ScalarType>;
-  using View1d     = typename Kokkos::View<ScalarType *, DEVC>;
+  using View1d     = typename Kokkos::View<ScalarType *, DEVICE>;
 
  private:
   // trsm takes host views
@@ -85,8 +85,8 @@ class LUPrec : public KokkosSparse::Experimental::Preconditioner<CRS> {
   template <
       typename Matrix,
       typename std::enable_if<is_crs_matrix<Matrix>::value>::type * = nullptr>
-  void apply_impl(const Kokkos::View<const ScalarType *, DEVC> &X,
-                  const Kokkos::View<ScalarType *, DEVC> &Y,
+  void apply_impl(const Kokkos::View<const ScalarType *, DEVICE> &X,
+                  const Kokkos::View<ScalarType *, DEVICE> &Y,
                   const char transM[] = "N", ScalarType alpha = karith::one(),
                   ScalarType beta = karith::zero()) const {
     // tmp = trsv(L, x); //Apply L^inv to x
@@ -108,8 +108,8 @@ class LUPrec : public KokkosSparse::Experimental::Preconditioner<CRS> {
   template <
       typename Matrix,
       typename std::enable_if<is_bsr_matrix<Matrix>::value>::type * = nullptr>
-  void apply_impl(const Kokkos::View<const ScalarType *, DEVC> &X,
-                  const Kokkos::View<ScalarType *, DEVC> &Y,
+  void apply_impl(const Kokkos::View<const ScalarType *, DEVICE> &X,
+                  const Kokkos::View<ScalarType *, DEVICE> &Y,
                   const char transM[] = "N", ScalarType alpha = karith::one(),
                   ScalarType beta = karith::zero()) const {
     // tmp = trsv(L, x); //Apply L^inv to x
@@ -126,10 +126,10 @@ class LUPrec : public KokkosSparse::Experimental::Preconditioner<CRS> {
 
     // trsv is implemented for MV so we need to convert our views
     using UView2d = typename Kokkos::View<
-        ScalarType **, Layout, DEVC,
+        ScalarType **, Layout, DEVICE,
         Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
     using UView2dc = typename Kokkos::View<
-        const ScalarType **, Layout, DEVC,
+        const ScalarType **, Layout, DEVICE,
         Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
     UView2dc X2d(X.data(), X.extent(0), 1);
     UView2d Y2d(Y.data(), Y.extent(0), 1),
@@ -153,8 +153,8 @@ class LUPrec : public KokkosSparse::Experimental::Preconditioner<CRS> {
   /////
   ///// It takes L and U and the stores U^inv L^inv X in Y
   //
-  virtual void apply(const Kokkos::View<const ScalarType *, DEVC> &X,
-                     const Kokkos::View<ScalarType *, DEVC> &Y,
+  virtual void apply(const Kokkos::View<const ScalarType *, DEVICE> &X,
+                     const Kokkos::View<ScalarType *, DEVICE> &Y,
                      const char transM[] = "N",
                      ScalarType alpha    = karith::one(),
                      ScalarType beta     = karith::zero()) const {

--- a/sparse/src/KokkosSparse_LUPrec.hpp
+++ b/sparse/src/KokkosSparse_LUPrec.hpp
@@ -48,7 +48,7 @@ class LUPrec : public KokkosSparse::Experimental::Preconditioner<CRS> {
   using MEMSP      = typename CRS::memory_space;
   using DEVC       = typename Kokkos::Device<EXSP, MEMSP>;
   using karith     = typename Kokkos::ArithTraits<ScalarType>;
-  using View1d  = typename Kokkos::View<ScalarType *, DEVC>;
+  using View1d     = typename Kokkos::View<ScalarType *, DEVC>;
 
  private:
   // trsm takes host views
@@ -82,12 +82,13 @@ class LUPrec : public KokkosSparse::Experimental::Preconditioner<CRS> {
     _khU.destroy_sptrsv_handle();
   }
 
-  template <typename Matrix, typename std::enable_if<is_crs_matrix<Matrix>::value>::type* = nullptr>
-  void apply_impl(
-    const Kokkos::View<const ScalarType *, DEVC> &X,
-    const Kokkos::View<ScalarType *, DEVC> &Y,
-    const char transM[] = "N", ScalarType alpha = karith::one(),
-    ScalarType beta = karith::zero()) const {
+  template <
+      typename Matrix,
+      typename std::enable_if<is_crs_matrix<Matrix>::value>::type * = nullptr>
+  void apply_impl(const Kokkos::View<const ScalarType *, DEVC> &X,
+                  const Kokkos::View<ScalarType *, DEVC> &Y,
+                  const char transM[] = "N", ScalarType alpha = karith::one(),
+                  ScalarType beta = karith::zero()) const {
     // tmp = trsv(L, x); //Apply L^inv to x
     // y = trsv(U, tmp); //Apply U^inv to tmp
 
@@ -104,12 +105,13 @@ class LUPrec : public KokkosSparse::Experimental::Preconditioner<CRS> {
     KokkosBlas::axpby(alpha, _tmp2, beta, Y);
   }
 
-  template <typename Matrix, typename std::enable_if<is_bsr_matrix<Matrix>::value>::type* = nullptr>
-  void apply_impl(
-      const Kokkos::View<const ScalarType *, DEVC> &X,
-      const Kokkos::View<ScalarType *, DEVC> &Y,
-      const char transM[] = "N", ScalarType alpha = karith::one(),
-      ScalarType beta = karith::zero()) const {
+  template <
+      typename Matrix,
+      typename std::enable_if<is_bsr_matrix<Matrix>::value>::type * = nullptr>
+  void apply_impl(const Kokkos::View<const ScalarType *, DEVC> &X,
+                  const Kokkos::View<ScalarType *, DEVC> &Y,
+                  const char transM[] = "N", ScalarType alpha = karith::one(),
+                  ScalarType beta = karith::zero()) const {
     // tmp = trsv(L, x); //Apply L^inv to x
     // y = trsv(U, tmp); //Apply U^inv to tmp
 
@@ -123,15 +125,16 @@ class LUPrec : public KokkosSparse::Experimental::Preconditioner<CRS> {
 #endif
 
     // trsv is implemented for MV so we need to convert our views
-    using UView2d = typename Kokkos::View<ScalarType **, Layout, DEVC,
-                                          Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
-    using UView2dc = typename Kokkos::View<const ScalarType **, Layout, DEVC,
-                                           Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
+    using UView2d = typename Kokkos::View<
+        ScalarType **, Layout, DEVC,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
+    using UView2dc = typename Kokkos::View<
+        const ScalarType **, Layout, DEVC,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
     UView2dc X2d(X.data(), X.extent(0), 1);
-    UView2d
-      Y2d(Y.data(), Y.extent(0), 1),
-      tmp2d(_tmp.data(), _tmp.extent(0), 1),
-      tmp22d(_tmp2.data(), _tmp2.extent(0), 1);
+    UView2d Y2d(Y.data(), Y.extent(0), 1),
+        tmp2d(_tmp.data(), _tmp.extent(0), 1),
+        tmp22d(_tmp2.data(), _tmp2.extent(0), 1);
 
     KokkosSparse::trsv("L", "N", "N", _L, X2d, tmp2d);
     KokkosSparse::trsv("U", "N", "N", _U, tmp2d, tmp22d);
@@ -150,11 +153,11 @@ class LUPrec : public KokkosSparse::Experimental::Preconditioner<CRS> {
   /////
   ///// It takes L and U and the stores U^inv L^inv X in Y
   //
-  virtual void apply(
-      const Kokkos::View<const ScalarType *, DEVC> &X,
-      const Kokkos::View<ScalarType *, DEVC> &Y,
-      const char transM[] = "N", ScalarType alpha = karith::one(),
-      ScalarType beta = karith::zero()) const {
+  virtual void apply(const Kokkos::View<const ScalarType *, DEVC> &X,
+                     const Kokkos::View<ScalarType *, DEVC> &Y,
+                     const char transM[] = "N",
+                     ScalarType alpha    = karith::one(),
+                     ScalarType beta     = karith::zero()) const {
     apply_impl<CRS>(X, Y, transM, alpha, beta);
   }
   //@}

--- a/sparse/src/KokkosSparse_spiluk_handle.hpp
+++ b/sparse/src/KokkosSparse_spiluk_handle.hpp
@@ -29,7 +29,6 @@ namespace Experimental {
 
 // TP2 algorithm has issues with some offset-ordinal combo to be addressed
 enum class SPILUKAlgorithm {
-  SEQLVLSCHD_RP,
   SEQLVLSCHD_TP1 /*, SEQLVLSCHED_TP2*/
 };
 
@@ -256,9 +255,6 @@ class SPILUKHandle {
   int get_vector_size() const { return this->vector_size; }
 
   void print_algorithm() {
-    if (algm == SPILUKAlgorithm::SEQLVLSCHD_RP)
-      std::cout << "SEQLVLSCHD_RP" << std::endl;
-
     if (algm == SPILUKAlgorithm::SEQLVLSCHD_TP1)
       std::cout << "SEQLVLSCHD_TP1" << std::endl;
 
@@ -268,19 +264,6 @@ class SPILUKHandle {
     int-int ordinal-offset pair" << std::endl;
     }
     */
-  }
-
-  inline SPILUKAlgorithm StringToSPILUKAlgorithm(std::string &name) {
-    if (name == "SPILUK_DEFAULT")
-      return SPILUKAlgorithm::SEQLVLSCHD_RP;
-    else if (name == "SPILUK_RANGEPOLICY")
-      return SPILUKAlgorithm::SEQLVLSCHD_RP;
-    else if (name == "SPILUK_TEAMPOLICY1")
-      return SPILUKAlgorithm::SEQLVLSCHD_TP1;
-    /*else if(name=="SPILUK_TEAMPOLICY2")    return
-     * SPILUKAlgorithm::SEQLVLSCHED_TP2;*/
-    else
-      throw std::runtime_error("Invalid SPILUKAlgorithm name");
   }
 };
 

--- a/sparse/unit_test/Test_Sparse_spiluk.hpp
+++ b/sparse/unit_test/Test_Sparse_spiluk.hpp
@@ -132,8 +132,8 @@ struct SpilukTest {
     return diff_nrm / bb_nrm;
   }
 
-  static bool is_triangular(const RowMapType& drow_map, const EntriesType& dentries, bool check_lower)
-  {
+  static bool is_triangular(const RowMapType& drow_map,
+                            const EntriesType& dentries, bool check_lower) {
     const size_type nrows = drow_map.extent(0) - 1;
 
     auto row_map = Kokkos::create_mirror_view(drow_map);
@@ -143,13 +143,12 @@ struct SpilukTest {
 
     for (size_type row = 0; row < nrows; ++row) {
       const size_type row_nnz_begin = row_map(row);
-      const size_type row_nnz_end   = row_map(row+1);
+      const size_type row_nnz_end   = row_map(row + 1);
       for (size_type nnz = row_nnz_begin; nnz < row_nnz_end; ++nnz) {
         const size_type col = entries(nnz);
         if (col > row && check_lower) {
           return false;
-        }
-        else if (col < row && !check_lower) {
+        } else if (col < row && !check_lower) {
           return false;
         }
       }
@@ -164,8 +163,7 @@ struct SpilukTest {
                            const ValuesType& L_values,
                            const RowMapType& U_row_map,
                            const EntriesType& U_entries,
-                           const ValuesType& U_values,
-                           const lno_t fill_lev) {
+                           const ValuesType& U_values, const lno_t fill_lev) {
     // Checking
     const auto nrows = row_map.extent(0) - 1;
     Crs A("A_Mtx", nrows, nrows, values.extent(0), values, row_map, entries);
@@ -179,7 +177,8 @@ struct SpilukTest {
 
     const auto result = check_result_impl(A, L, U, nrows);
     if (TEST_SPILUK_VERBOSE_LEVEL > 0) {
-      std::cout << "For nrows=" << nrows << ", fill_level=" << fill_lev << ", unblocked had residual: " << result << std::endl;
+      std::cout << "For nrows=" << nrows << ", fill_level=" << fill_lev
+                << ", unblocked had residual: " << result << std::endl;
     }
     if (TEST_SPILUK_VERBOSE_LEVEL > 1) {
       std::cout << "L result" << std::endl;
@@ -198,7 +197,8 @@ struct SpilukTest {
       const ValuesType& values, const RowMapType& L_row_map,
       const EntriesType& L_entries, const ValuesType& L_values,
       const RowMapType& U_row_map, const EntriesType& U_entries,
-      const ValuesType& U_values, const lno_t fill_lev, const size_type block_size) {
+      const ValuesType& U_values, const lno_t fill_lev,
+      const size_type block_size) {
     // Checking
     const auto nrows = row_map.extent(0) - 1;
     Bsr A("A_Mtx", nrows, nrows, values.extent(0), values, row_map, entries,
@@ -213,13 +213,17 @@ struct SpilukTest {
 
     const auto result = check_result_impl(A, L, U, nrows, block_size);
     if (TEST_SPILUK_VERBOSE_LEVEL > 0) {
-      std::cout << "For nrows=" << nrows << ", fill_level=" << fill_lev << ", block_size=" << block_size << " had residual: " << result << std::endl;
+      std::cout << "For nrows=" << nrows << ", fill_level=" << fill_lev
+                << ", block_size=" << block_size << " had residual: " << result
+                << std::endl;
     }
     if (TEST_SPILUK_VERBOSE_LEVEL > 1) {
       std::cout << "L result" << std::endl;
-      print_matrix(decompress_matrix(L_row_map, L_entries, L_values, block_size));
+      print_matrix(
+          decompress_matrix(L_row_map, L_entries, L_values, block_size));
       std::cout << "U result" << std::endl;
-      print_matrix(decompress_matrix(U_row_map, U_entries, U_values, block_size));
+      print_matrix(
+          decompress_matrix(U_row_map, U_entries, U_values, block_size));
     }
 
     if (fill_lev > 1) {
@@ -231,7 +235,8 @@ struct SpilukTest {
                     EntriesType, ValuesType>
   run_and_check_spiluk(KernelHandle& kh, const RowMapType& row_map,
                        const EntriesType& entries, const ValuesType& values,
-                       SPILUKAlgorithm alg, const lno_t fill_lev, const int team_size = -1) {
+                       SPILUKAlgorithm alg, const lno_t fill_lev,
+                       const int team_size = -1) {
     const size_type nrows = row_map.extent(0) - 1;
     kh.create_spiluk_handle(alg, nrows, 40 * nrows, 40 * nrows);
 
@@ -288,10 +293,11 @@ struct SpilukTest {
 
   static std::tuple<RowMapType, EntriesType, ValuesType, RowMapType,
                     EntriesType, ValuesType>
-  run_and_check_spiluk_block(
-      KernelHandle& kh, const RowMapType& row_map, const EntriesType& entries,
-      const ValuesType& values, SPILUKAlgorithm alg, const lno_t fill_lev,
-      const size_type block_size, const int team_size = -1) {
+  run_and_check_spiluk_block(KernelHandle& kh, const RowMapType& row_map,
+                             const EntriesType& entries,
+                             const ValuesType& values, SPILUKAlgorithm alg,
+                             const lno_t fill_lev, const size_type block_size,
+                             const int team_size = -1) {
     const size_type block_items = block_size * block_size;
     const size_type nrows       = row_map.extent(0) - 1;
     kh.create_spiluk_handle(alg, nrows, 40 * nrows, 40 * nrows, block_size);
@@ -332,7 +338,8 @@ struct SpilukTest {
     if (block_size == 1) {
       const auto [L_row_map_u, L_entries_u, L_values_u, U_row_map_u,
                   U_entries_u, U_values_u] =
-          run_and_check_spiluk(kh, row_map, entries, values, alg, fill_lev, team_size);
+          run_and_check_spiluk(kh, row_map, entries, values, alg, fill_lev,
+                               team_size);
 
       EXPECT_NEAR_KK_1DVIEW(L_row_map, L_row_map_u, EPS);
       EXPECT_NEAR_KK_1DVIEW(L_entries, L_entries_u, EPS);
@@ -346,7 +353,8 @@ struct SpilukTest {
     if (team_size != 1) {
       const auto [L_row_map_ts1, L_entries_ts1, L_values_ts1, U_row_map_ts1,
                   U_entries_ts1, U_values_ts1] =
-          run_and_check_spiluk_block(kh, row_map, entries, values, alg, fill_lev, block_size, 1);
+          run_and_check_spiluk_block(kh, row_map, entries, values, alg,
+                                     fill_lev, block_size, 1);
 
       EXPECT_NEAR_KK_1DVIEW(L_row_map, L_row_map_ts1, EPS);
       EXPECT_NEAR_KK_1DVIEW(L_entries, L_entries_ts1, EPS);
@@ -450,7 +458,6 @@ struct SpilukTest {
     Kokkos::deep_copy(values, A.values);
 
     for (lno_t fill_lev = 0; fill_lev < 4; ++fill_lev) {
-
       KernelHandle kh;
 
       run_and_check_spiluk(kh, row_map, entries, values,
@@ -467,19 +474,18 @@ struct SpilukTest {
     EntriesType bentries;
     ValuesType bvalues;
 
-    //const size_type block_size = 10;
+    // const size_type block_size = 10;
 
     size_type nnz = 10 * nrows;
     auto A =
-      KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<Crs>(
-        nrows, nrows, nnz, 0, lno_t(0.01 * nrows), diagDominance);
+        KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<Crs>(
+            nrows, nrows, nnz, 0, lno_t(0.01 * nrows), diagDominance);
 
     KokkosSparse::sort_crs_matrix(A);
 
     std::vector<size_type> block_sizes = {1, 2, 4, 10};
 
     for (auto block_size : block_sizes) {
-
       // Convert to BSR
       Bsr bsr(A, block_size);
 
@@ -492,7 +498,6 @@ struct SpilukTest {
       Kokkos::deep_copy(bvalues, bsr.values);
 
       for (lno_t fill_lev = 0; fill_lev < 4; ++fill_lev) {
-
         KernelHandle kh;
 
         run_and_check_spiluk_block(kh, brow_map, bentries, bvalues,
@@ -603,8 +608,7 @@ struct SpilukTest {
     for (int i = 0; i < nstreams; i++) {
       check_result(A_row_map_v[i], A_entries_v[i], A_values_v[i],
                    L_row_map_v[i], L_entries_v[i], L_values_v[i],
-                   U_row_map_v[i], U_entries_v[i], U_values_v[i],
-                   fill_lev);
+                   U_row_map_v[i], U_entries_v[i], U_values_v[i], fill_lev);
 
       kh_v[i].destroy_spiluk_handle();
     }
@@ -740,8 +744,7 @@ struct SpilukTest {
     }
   }
 
-  static void run_test_spiluk_precond_blocks()
-  {
+  static void run_test_spiluk_precond_blocks() {
     // Test using par_ilut as a preconditioner
     // Does (LU)^inv Ax = (LU)^inv b converge faster than solving Ax=b?
 
@@ -756,8 +759,9 @@ struct SpilukTest {
     constexpr bool verbose       = false;
 
     // Skip test if not on host. trsv only works on host
-    static constexpr bool is_host = std::is_same<
-      execution_space, typename Kokkos::DefaultHostExecutionSpace>::value;
+    static constexpr bool is_host =
+        std::is_same<execution_space,
+                     typename Kokkos::DefaultHostExecutionSpace>::value;
     if (!is_host) {
       return;
     }
@@ -767,15 +771,15 @@ struct SpilukTest {
     ValuesType bvalues;
 
     size_type nnz = 10 * nrows;
-    auto A_unblocked = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<Crs>(
-      nrows, nrows, nnz, 0, lno_t(0.01 * nrows), diagDominance);
+    auto A_unblocked =
+        KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<Crs>(
+            nrows, nrows, nnz, 0, lno_t(0.01 * nrows), diagDominance);
 
     KokkosSparse::sort_crs_matrix(A_unblocked);
 
     std::vector<size_type> block_sizes = {/*1, 2, 4,*/ 10};
 
     for (auto block_size : block_sizes) {
-
       // Convert to BSR
       Bsr A(A_unblocked, block_size);
 
@@ -793,14 +797,13 @@ struct SpilukTest {
       auto gmres_handle = kh.get_gmres_handle();
       gmres_handle->set_verbose(verbose);
       using GMRESHandle =
-        typename std::remove_reference<decltype(*gmres_handle)>::type;
+          typename std::remove_reference<decltype(*gmres_handle)>::type;
 
-      const auto [L_row_map, L_entries, L_values, U_row_map,
-                  U_entries, U_values] =
-        run_and_check_spiluk_block(kh, brow_map, bentries, bvalues,
-                                   SPILUKAlgorithm::SEQLVLSCHD_TP1, fill_lev,
-                                   block_size);
-
+      const auto [L_row_map, L_entries, L_values, U_row_map, U_entries,
+                  U_values] =
+          run_and_check_spiluk_block(kh, brow_map, bentries, bvalues,
+                                     SPILUKAlgorithm::SEQLVLSCHD_TP1, fill_lev,
+                                     block_size);
 
       // Create BSRs
       const auto bnrows = L_row_map.extent(0) - 1;
@@ -865,7 +868,6 @@ struct SpilukTest {
       }
     }
   }
-
 };
 
 }  // namespace Test

--- a/sparse/unit_test/Test_Sparse_spiluk.hpp
+++ b/sparse/unit_test/Test_Sparse_spiluk.hpp
@@ -134,7 +134,7 @@ struct SpilukTest {
 
   static bool is_triangular(const RowMapType& drow_map, const EntriesType& dentries, bool check_lower)
   {
-    const auto nrows = drow_map.extent(0) - 1;
+    const size_type nrows = drow_map.extent(0) - 1;
 
     auto row_map = Kokkos::create_mirror_view(drow_map);
     auto entries = Kokkos::create_mirror_view(dentries);
@@ -142,10 +142,10 @@ struct SpilukTest {
     Kokkos::deep_copy(entries, dentries);
 
     for (size_type row = 0; row < nrows; ++row) {
-      const auto row_nnz_begin = row_map(row);
-      const auto row_nnz_end   = row_map(row+1);
+      const size_type row_nnz_begin = row_map(row);
+      const size_type row_nnz_end   = row_map(row+1);
       for (size_type nnz = row_nnz_begin; nnz < row_nnz_end; ++nnz) {
-        const auto col = entries(nnz);
+        const size_type col = entries(nnz);
         if (col > row && check_lower) {
           return false;
         }

--- a/sparse/unit_test/Test_Sparse_spiluk.hpp
+++ b/sparse/unit_test/Test_Sparse_spiluk.hpp
@@ -755,6 +755,13 @@ struct SpilukTest {
     constexpr auto fill_lev      = 2;
     constexpr bool verbose       = false;
 
+    // Skip test if not on host. trsv only works on host
+    static constexpr bool is_host = std::is_same<
+      execution_space, typename Kokkos::DefaultHostExecutionSpace>::value;
+    if (!is_host) {
+      return;
+    }
+
     RowMapType brow_map;
     EntriesType bentries;
     ValuesType bvalues;
@@ -835,7 +842,7 @@ struct SpilukTest {
         gmres_handle->reset_handle(m, tol);
         gmres_handle->set_verbose(verbose);
 
-        // Make precond
+        // Make precond.
         KokkosSparse::Experimental::LUPrec<Bsr, KernelHandle> myPrec(L, U);
 
         // reset X for next gmres call

--- a/sparse/unit_test/Test_Sparse_spiluk.hpp
+++ b/sparse/unit_test/Test_Sparse_spiluk.hpp
@@ -710,12 +710,10 @@ struct SpilukTest {
 
   template <bool UseBlocks>
   static void run_test_spiluk_precond() {
-    // Test using par_ilut as a preconditioner
+    // Test using spiluk as a preconditioner
     // Does (LU)^inv Ax = (LU)^inv b converge faster than solving Ax=b?
 
     // Create a diagonally dominant sparse matrix to test:
-    //  par_ilut settings max_iters, res_delta_stop, fill_in_limit, and
-    //  async_update are all left as defaults
     using sp_matrix_type = std::conditional_t<UseBlocks, Bsr, Crs>;
 
     constexpr auto nrows         = 5000;

--- a/sparse/unit_test/Test_Sparse_spiluk.hpp
+++ b/sparse/unit_test/Test_Sparse_spiluk.hpp
@@ -120,8 +120,7 @@ struct SpilukTest {
   }
 
   static void check_result(const RowMapType& row_map,
-                           const EntriesType& entries,
-                           const ValuesType& values,
+                           const EntriesType& entries, const ValuesType& values,
                            const RowMapType& L_row_map,
                            const EntriesType& L_entries,
                            const ValuesType& L_values,
@@ -270,14 +269,14 @@ struct SpilukTest {
   }
 
   static void run_test_spiluk_scale() {
-
     // Create a diagonally dominant sparse matrix to test:
     constexpr auto nrows         = 5000;
     constexpr auto diagDominance = 2;
 
     size_type nnz = 10 * nrows;
-    auto A = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<
-      Crs>(nrows, nrows, nnz, 0, lno_t(0.01 * nrows), diagDominance);
+    auto A =
+        KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<Crs>(
+            nrows, nrows, nnz, 0, lno_t(0.01 * nrows), diagDominance);
 
     // Pull out views from CRS
     RowMapType row_map("row_map", A.graph.row_map.extent(0));
@@ -296,7 +295,6 @@ struct SpilukTest {
   }
 
   static void run_test_spiluk_scale_blocks() {
-
     // Create a diagonally dominant sparse matrix to test:
     constexpr auto nrows         = 5000;
     constexpr auto diagDominance = 2;
@@ -308,8 +306,9 @@ struct SpilukTest {
     const size_type block_size = 10;
 
     size_type nnz = 10 * nrows;
-    auto A = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<
-      Crs>(nrows, nrows, nnz, 0, lno_t(0.01 * nrows), diagDominance);
+    auto A =
+        KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<Crs>(
+            nrows, nrows, nnz, 0, lno_t(0.01 * nrows), diagDominance);
 
     // Pull out views from CRS
     Bsr bsr(A, block_size);
@@ -327,7 +326,8 @@ struct SpilukTest {
     KernelHandle kh;
 
     run_and_check_spiluk_block(kh, brow_map, bentries, bvalues,
-                               SPILUKAlgorithm::SEQLVLSCHD_TP1, fill_lev, block_size);
+                               SPILUKAlgorithm::SEQLVLSCHD_TP1, fill_lev,
+                               block_size);
   }
 
   static void run_test_spiluk_streams(SPILUKAlgorithm test_algo, int nstreams) {

--- a/sparse/unit_test/Test_vector_fixtures.hpp
+++ b/sparse/unit_test/Test_vector_fixtures.hpp
@@ -117,7 +117,8 @@ decompress_matrix(const RowMapT& row_map, const EntriesT& entries,
 template <typename RowMapT, typename EntriesT, typename ValuesT>
 std::vector<std::vector<typename ValuesT::non_const_value_type>>
 decompress_matrix(const RowMapT& row_map, const EntriesT& entries,
-                  const ValuesT& values, typename RowMapT::const_value_type block_size) {
+                  const ValuesT& values,
+                  typename RowMapT::const_value_type block_size) {
   using size_type = typename RowMapT::non_const_value_type;
   using scalar_t  = typename ValuesT::non_const_value_type;
 

--- a/sparse/unit_test/Test_vector_fixtures.hpp
+++ b/sparse/unit_test/Test_vector_fixtures.hpp
@@ -183,7 +183,7 @@ template <typename scalar_t>
 void print_matrix(const std::vector<std::vector<scalar_t>>& matrix) {
   for (const auto& row : matrix) {
     for (const auto& item : row) {
-      std::printf("%.2f ", item);
+      std::printf("%.5f ", item);
     }
     std::cout << std::endl;
   }

--- a/sparse/unit_test/Test_vector_fixtures.hpp
+++ b/sparse/unit_test/Test_vector_fixtures.hpp
@@ -117,7 +117,7 @@ decompress_matrix(const RowMapT& row_map, const EntriesT& entries,
 template <typename RowMapT, typename EntriesT, typename ValuesT>
 std::vector<std::vector<typename ValuesT::non_const_value_type>>
 decompress_matrix(const RowMapT& row_map, const EntriesT& entries,
-                  const ValuesT& values, const int block_size) {
+                  const ValuesT& values, typename RowMapT::const_value_type block_size) {
   using size_type = typename RowMapT::non_const_value_type;
   using scalar_t  = typename ValuesT::non_const_value_type;
 


### PR DESCRIPTION
I took a second look at the gemm interface and realized it did exactly what I needed without needing the temporary scratch space, so that resolves one of my main concerns with the previous PR.

I removed support for the range policy algorithm, which cleaned up a bunch of code.

I added some larger-scale testing.

My main concern now is that I'm still seeing highish residuals, even with bigger matrices:
```
For nrows=9, unblocked had residual: 5.21667e-05
For nrows=3, block_size=3 had residual: 0.0266588
For nrows=5000, unblocked had residual: 7.1784e-05
For nrows=500, block_size=10 had residual: 0.0374661
```

I thought, with bigger matrix, the big difference between blocked and unblocked residuals would go away, but that does not appear to be the case. Is there a definitive test I can do to see if there's a mistake in the block impl?

I'd like to resolve this before I move on to performance testing.

Latest changes:
 * Adds a LUPrec test for block spiluk
 * Adds support for Bsrs to LUPrec class

Some Preconditioner data:
```
Without LUPrec, with block_size=1, converged in 12 steps with endres=3.6884e-06
With LUPrec, with block_size=1, and fill_level=0, converged in 3 steps with endres=6.14749e-06
With LUPrec, with block_size=1, and fill_level=1, converged in 2 steps with endres=3.29895e-06
With LUPrec, with block_size=1, and fill_level=2, converged in 2 steps with endres=9.35687e-09
With LUPrec, with block_size=1, and fill_level=3, converged in 1 steps with endres=1.98687e-06
Without LUPrec, with block_size=2, converged in 12 steps with endres=3.6884e-06
With LUPrec, with block_size=2, and fill_level=0, converged in 3 steps with endres=2.71833e-06
With LUPrec, with block_size=2, and fill_level=1, converged in 2 steps with endres=5.76716e-06
With LUPrec, with block_size=2, and fill_level=2, converged in 2 steps with endres=5.48329e-06
With LUPrec, with block_size=2, and fill_level=3, converged in 2 steps with endres=5.48406e-06
Without LUPrec, with block_size=4, converged in 12 steps with endres=3.6884e-06
With LUPrec, with block_size=4, and fill_level=0, converged in 3 steps with endres=2.88088e-07
With LUPrec, with block_size=4, and fill_level=1, converged in 3 steps with endres=7.88296e-08
With LUPrec, with block_size=4, and fill_level=2, converged in 3 steps with endres=7.872e-08
With LUPrec, with block_size=4, and fill_level=3, converged in 3 steps with endres=7.87231e-08
Without LUPrec, with block_size=10, converged in 12 steps with endres=3.6884e-06
With LUPrec, with block_size=10, and fill_level=0, converged in 3 steps with endres=5.58842e-07
With LUPrec, with block_size=10, and fill_level=1, converged in 3 steps with endres=5.34368e-07
With LUPrec, with block_size=10, and fill_level=2, converged in 3 steps with endres=5.34092e-07
With LUPrec, with block_size=10, and fill_level=3, converged in 3 steps with endres=5.34092e-07
```