### PR TITLE
Make spiluk_handle::reset backwards compatible

### DIFF
--- a/sparse/src/KokkosSparse_spiluk_handle.hpp
+++ b/sparse/src/KokkosSparse_spiluk_handle.hpp
@@ -132,21 +132,26 @@ class SPILUKHandle {
         vector_size(-1) {}
 
   void reset_handle(const size_type nrows_, const size_type nnzL_,
-                    const size_type nnzU_, const size_type block_size_) {
+                    const size_type nnzU_, const size_type block_size_ = -1) {
     set_nrows(nrows_);
     set_num_levels(0);
     set_nnzL(nnzL_);
     set_nnzU(nnzU_);
-    set_block_size(block_size_);
+    // user likely does not want to reset block size to 0, so set default
+    // to -1
+    if (block_size_ != static_cast<size_type>(-1)) {
+      set_block_size(block_size_);
+    }
     set_level_maxrows(0);
     set_level_maxrowsperchunk(0);
-    level_list          = nnz_row_view_t("level_list", nrows_),
-    level_idx           = nnz_lno_view_t("level_idx", nrows_),
-    level_ptr           = nnz_lno_view_t("level_ptr", nrows_ + 1),
-    hlevel_ptr          = nnz_lno_view_host_t("hlevel_ptr", nrows_ + 1),
-    level_nchunks       = nnz_lno_view_host_t(),
-    level_nrowsperchunk = nnz_lno_view_host_t(), reset_symbolic_complete(),
+    level_list          = nnz_row_view_t("level_list", nrows_);
+    level_idx           = nnz_lno_view_t("level_idx", nrows_);
+    level_ptr           = nnz_lno_view_t("level_ptr", nrows_ + 1);
+    hlevel_ptr          = nnz_lno_view_host_t("hlevel_ptr", nrows_ + 1);
+    level_nchunks       = nnz_lno_view_host_t();
+    level_nrowsperchunk = nnz_lno_view_host_t();
     iw                  = work_view_t();
+    reset_symbolic_complete();
   }
 
   virtual ~SPILUKHandle(){};

--- a/sparse/src/KokkosSparse_spiluk_handle.hpp
+++ b/sparse/src/KokkosSparse_spiluk_handle.hpp
@@ -131,8 +131,9 @@ class SPILUKHandle {
         team_size(-1),
         vector_size(-1) {}
 
-  void reset_handle(const size_type nrows_, const size_type nnzL_,
-                    const size_type nnzU_, const size_type block_size_ = Kokkos::ArithTraits<size_type>::max()) {
+  void reset_handle(
+      const size_type nrows_, const size_type nnzL_, const size_type nnzU_,
+      const size_type block_size_ = Kokkos::ArithTraits<size_type>::max()) {
     set_nrows(nrows_);
     set_num_levels(0);
     set_nnzL(nnzL_);

--- a/sparse/src/KokkosSparse_spiluk_handle.hpp
+++ b/sparse/src/KokkosSparse_spiluk_handle.hpp
@@ -132,14 +132,14 @@ class SPILUKHandle {
         vector_size(-1) {}
 
   void reset_handle(const size_type nrows_, const size_type nnzL_,
-                    const size_type nnzU_, const size_type block_size_ = -1) {
+                    const size_type nnzU_, const size_type block_size_ = Kokkos::ArithTraits<size_type>::max()) {
     set_nrows(nrows_);
     set_num_levels(0);
     set_nnzL(nnzL_);
     set_nnzU(nnzU_);
     // user likely does not want to reset block size to 0, so set default
     // to -1
-    if (block_size_ != static_cast<size_type>(-1)) {
+    if (block_size_ != Kokkos::ArithTraits<size_type>::max()) {
       set_block_size(block_size_);
     }
     set_level_maxrows(0);

--- a/sparse/src/KokkosSparse_spiluk_handle.hpp
+++ b/sparse/src/KokkosSparse_spiluk_handle.hpp
@@ -139,7 +139,7 @@ class SPILUKHandle {
     set_nnzL(nnzL_);
     set_nnzU(nnzU_);
     // user likely does not want to reset block size to 0, so set default
-    // to -1
+    // to size_type::max
     if (block_size_ != Kokkos::ArithTraits<size_type>::max()) {
       set_block_size(block_size_);
     }


### PR DESCRIPTION
By making block_size default to -1, which means don't change block size.

Also, clean up some strangeness with commas being used to separate statements instead of semincolons.

Fixes #2086 