### PR TITLE
Hands off namespace `Kokkos::Impl` - cleanup couple violations that snuck in

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -629,8 +629,7 @@ KOKKOS_INLINE_FUNCTION auto subview_wrapper(ViewType v, IdxType1 i1,
 #if KOKKOS_VERSION < 40099
 template <class ViewType, class IdxType1>
 KOKKOS_INLINE_FUNCTION auto subview_wrapper(ViewType v, IdxType1 i1,
-                                            Kokkos::Impl::ALL_t i2,
-                                            Kokkos::Impl::ALL_t i3,
+                                            Kokkos::ALL_t i2, Kokkos::ALL_t i3,
                                             const BatchLayout::Left &layout_tag,
                                             const Trans::Transpose) {
   auto sv_nt = subview_wrapper(v, i1, i3, i2, layout_tag);
@@ -674,7 +673,7 @@ KOKKOS_INLINE_FUNCTION auto subview_wrapper(
 #if KOKKOS_VERSION < 40099
 template <class ViewType, class IdxType1>
 KOKKOS_INLINE_FUNCTION auto subview_wrapper(
-    ViewType v, IdxType1 i1, Kokkos::Impl::ALL_t i2, Kokkos::Impl::ALL_t i3,
+    ViewType v, IdxType1 i1, Kokkos::ALL_t i2, Kokkos::ALL_t i3,
     const BatchLayout::Right &layout_tag, const Trans::Transpose &) {
   auto sv_nt = subview_wrapper(v, i1, i3, i2, layout_tag);
 

--- a/sparse/impl/KokkosSparse_coo2crs_impl.hpp
+++ b/sparse/impl/KokkosSparse_coo2crs_impl.hpp
@@ -198,10 +198,10 @@ class Coo2Crs {
 
     auto shallow_copy_to_device = [](UmapType *dst, UmapType const *src,
                                      std::size_t cnt) {
-      std::size_t n = cnt / sizeof(UmapType);
+      std::size_t nn = cnt / sizeof(UmapType);
       Kokkos::deep_copy(
-          Kokkos::View<UmapType *, UmapMemorySpace>(dst, n),
-          Kokkos::View<UmapType const *, Kokkos::HostSpace>(src, n));
+          Kokkos::View<UmapType *, UmapMemorySpace>(dst, nn),
+          Kokkos::View<UmapType const *, Kokkos::HostSpace>(src, nn));
     };
 
     UmapType **umap_ptrs = new UmapType *[m_nrows];

--- a/sparse/impl/KokkosSparse_coo2crs_impl.hpp
+++ b/sparse/impl/KokkosSparse_coo2crs_impl.hpp
@@ -196,8 +196,13 @@ class Coo2Crs {
         reinterpret_cast<UmapType *>(Kokkos::kokkos_malloc<UmapMemorySpace>(
             "m_umaps", m_nrows * sizeof(UmapType)));
 
-    using shallow_copy_to_device =
-        Kokkos::Impl::DeepCopy<UmapMemorySpace, typename Kokkos::HostSpace>;
+    auto shallow_copy_to_device = [](UmapType *dst, UmapType const *src,
+                                     std::size_t cnt) {
+      std::size_t n = cnt / sizeof(UmapType);
+      Kokkos::deep_copy(
+          Kokkos::View<UmapType *, UmapMemorySpace>(dst, n),
+          Kokkos::View<UmapType const *, Kokkos::HostSpace>(src, n));
+    };
 
     UmapType **umap_ptrs = new UmapType *[m_nrows];
     // TODO: use host-level parallel_for with tag rowmapRp1


### PR DESCRIPTION
You know the drill, anything in `Kokkos::Impl::` is considered private details of Kokkos and is subject to change without notice.  This PR fixes a couple violations I found in KokkosKernels as I was auditing Trilinos to see who is being naughty and uses `Kokkos::Impl::DeepCopy` directly.  The 2nd issue was a few occurrences of using `Kokkos::Impl::ALL_t` that reappeared.