### PR TITLE
GMRES: Add support for BSR matrices

### DIFF
--- a/sparse/impl/KokkosSparse_gmres_impl.hpp
+++ b/sparse/impl/KokkosSparse_gmres_impl.hpp
@@ -70,7 +70,7 @@ struct GmresWrap {
     Kokkos::Profiling::pushRegion("GMRES::TotalTime:");
 
     // Store solver options:
-    const auto n          = A.numRows();
+    const auto n          = A.numPointRows();
     const int m           = thandle.get_m();
     const auto maxRestart = thandle.get_max_restart();
     const auto tol        = thandle.get_tol();

--- a/sparse/unit_test/Test_Sparse_gmres.hpp
+++ b/sparse/unit_test/Test_Sparse_gmres.hpp
@@ -48,120 +48,163 @@ struct TolMeta<float> {
   static constexpr float value = 1e-5;  // Lower tolerance for floats
 };
 
+template <typename Crs, typename AType,
+          typename std::enable_if<is_crs_matrix<AType>::value>::type* = nullptr>
+AType get_A(int n, int diagDominance, int) {
+  using lno_t                           = typename Crs::ordinal_type;
+  typename Crs::non_const_size_type nnz = 10 * n;
+  auto A =
+      KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<Crs>(
+          n, n, nnz, 0, lno_t(0.01 * n), diagDominance);
+  KokkosSparse::sort_crs_matrix(A);
+
+  return A;
+}
+
+template <typename Crs, typename AType,
+          typename std::enable_if<is_bsr_matrix<AType>::value>::type* = nullptr>
+AType get_A(int n, int diagDominance, int block_size) {
+  using lno_t                           = typename Crs::ordinal_type;
+  typename Crs::non_const_size_type nnz = 10 * n;
+  auto A_unblocked =
+      KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<Crs>(
+          n, n, nnz, 0, lno_t(0.01 * n), diagDominance);
+  KokkosSparse::sort_crs_matrix(A_unblocked);
+
+  // Convert to BSR
+  AType A(A_unblocked, block_size);
+
+  return A;
+}
+
 template <typename scalar_t, typename lno_t, typename size_type,
           typename device>
-void run_test_gmres() {
-  using exe_space = typename device::execution_space;
-  using mem_space = typename device::memory_space;
-  using sp_matrix_type =
-      KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>;
+struct GmresTest {
+  using RowMapType  = Kokkos::View<size_type*, device>;
+  using EntriesType = Kokkos::View<lno_t*, device>;
+  using ValuesType  = Kokkos::View<scalar_t*, device>;
+  using AT          = Kokkos::ArithTraits<scalar_t>;
+  using exe_space   = typename device::execution_space;
+  using mem_space   = typename device::memory_space;
+
+  using Crs = CrsMatrix<scalar_t, lno_t, device, void, size_type>;
+  using Bsr = BsrMatrix<scalar_t, lno_t, device, void, size_type>;
+
   using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<
       size_type, lno_t, scalar_t, exe_space, mem_space, mem_space>;
   using float_t = typename Kokkos::ArithTraits<scalar_t>::mag_type;
 
-  // Create a diagonally dominant sparse matrix to test:
-  constexpr auto n             = 5000;
-  constexpr auto m             = 15;
-  constexpr auto tol           = TolMeta<float_t>::value;
-  constexpr auto numRows       = n;
-  constexpr auto numCols       = n;
-  constexpr auto diagDominance = 1;
-  constexpr bool verbose       = false;
+  template <bool UseBlocks>
+  static void run_test_gmres() {
+    using sp_matrix_type = std::conditional_t<UseBlocks, Bsr, Crs>;
 
-  typename sp_matrix_type::non_const_size_type nnz = 10 * numRows;
-  auto A = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<
-      sp_matrix_type>(numRows, numCols, nnz, 0, lno_t(0.01 * numRows),
-                      diagDominance);
+    // Create a diagonally dominant sparse matrix to test:
+    constexpr auto n             = 5000;
+    constexpr auto m             = 15;
+    constexpr auto tol           = TolMeta<float_t>::value;
+    constexpr auto diagDominance = 1;
+    constexpr bool verbose       = true;
+    constexpr auto block_size    = UseBlocks ? 10 : 1;
 
-  // Make kernel handles
-  KernelHandle kh;
-  kh.create_gmres_handle(m, tol);
-  auto gmres_handle = kh.get_gmres_handle();
-  using GMRESHandle =
-      typename std::remove_reference<decltype(*gmres_handle)>::type;
-  using ViewVectorType = typename GMRESHandle::nnz_value_view_t;
+    auto A = get_A<Crs, sp_matrix_type>(n, diagDominance, block_size);
 
-  // Set initial vectors:
-  ViewVectorType X("X", n);    // Solution and initial guess
-  ViewVectorType Wj("Wj", n);  // For checking residuals at end.
-  ViewVectorType B(Kokkos::view_alloc(Kokkos::WithoutInitializing, "B"),
-                   n);  // right-hand side vec
-  // Make rhs ones so that results are repeatable:
-  Kokkos::deep_copy(B, 1.0);
+    if (verbose) {
+      std::cout << "Running GMRES test with block_size=" << block_size
+                << std::endl;
+    }
 
-  gmres_handle->set_verbose(verbose);
+    // Make kernel handles
+    KernelHandle kh;
+    kh.create_gmres_handle(m, tol);
+    auto gmres_handle = kh.get_gmres_handle();
+    using GMRESHandle =
+        typename std::remove_reference<decltype(*gmres_handle)>::type;
+    using ViewVectorType = typename GMRESHandle::nnz_value_view_t;
 
-  // Test CGS2
-  {
-    gmres(&kh, A, B, X);
+    // Set initial vectors:
+    ViewVectorType X("X", n);    // Solution and initial guess
+    ViewVectorType Wj("Wj", n);  // For checking residuals at end.
+    ViewVectorType B(Kokkos::view_alloc(Kokkos::WithoutInitializing, "B"),
+                     n);  // right-hand side vec
+    // Make rhs ones so that results are repeatable:
+    Kokkos::deep_copy(B, 1.0);
 
-    // Double check residuals at end of solve:
-    float_t nrmB = KokkosBlas::nrm2(B);
-    KokkosSparse::spmv("N", 1.0, A, X, 0.0, Wj);  // wj = Ax
-    KokkosBlas::axpy(-1.0, Wj, B);                // b = b-Ax.
-    float_t endRes = KokkosBlas::nrm2(B) / nrmB;
-
-    const auto conv_flag = gmres_handle->get_conv_flag_val();
-
-    EXPECT_LT(endRes, gmres_handle->get_tol());
-    EXPECT_EQ(conv_flag, GMRESHandle::Flag::Conv);
-  }
-
-  // Test MGS
-  {
-    gmres_handle->reset_handle(m, tol);
-    gmres_handle->set_ortho(GMRESHandle::Ortho::MGS);
     gmres_handle->set_verbose(verbose);
 
-    // reset X for next gmres call
-    Kokkos::deep_copy(X, 0.0);
+    // Test CGS2
+    {
+      gmres(&kh, A, B, X);
 
-    gmres(&kh, A, B, X);
+      // Double check residuals at end of solve:
+      float_t nrmB = KokkosBlas::nrm2(B);
+      KokkosSparse::spmv("N", 1.0, A, X, 0.0, Wj);  // wj = Ax
+      KokkosBlas::axpy(-1.0, Wj, B);                // b = b-Ax.
+      float_t endRes = KokkosBlas::nrm2(B) / nrmB;
 
-    // Double check residuals at end of solve:
-    float_t nrmB = KokkosBlas::nrm2(B);
-    KokkosSparse::spmv("N", 1.0, A, X, 0.0, Wj);  // wj = Ax
-    KokkosBlas::axpy(-1.0, Wj, B);                // b = b-Ax.
-    float_t endRes = KokkosBlas::nrm2(B) / nrmB;
+      const auto conv_flag = gmres_handle->get_conv_flag_val();
 
-    const auto conv_flag = gmres_handle->get_conv_flag_val();
+      EXPECT_LT(endRes, gmres_handle->get_tol());
+      EXPECT_EQ(conv_flag, GMRESHandle::Flag::Conv);
+    }
 
-    EXPECT_LT(endRes, gmres_handle->get_tol());
-    EXPECT_EQ(conv_flag, GMRESHandle::Flag::Conv);
+    // Test MGS
+    {
+      gmres_handle->reset_handle(m, tol);
+      gmres_handle->set_ortho(GMRESHandle::Ortho::MGS);
+      gmres_handle->set_verbose(verbose);
+
+      // reset X for next gmres call
+      Kokkos::deep_copy(X, 0.0);
+
+      gmres(&kh, A, B, X);
+
+      // Double check residuals at end of solve:
+      float_t nrmB = KokkosBlas::nrm2(B);
+      KokkosSparse::spmv("N", 1.0, A, X, 0.0, Wj);  // wj = Ax
+      KokkosBlas::axpy(-1.0, Wj, B);                // b = b-Ax.
+      float_t endRes = KokkosBlas::nrm2(B) / nrmB;
+
+      const auto conv_flag = gmres_handle->get_conv_flag_val();
+
+      EXPECT_LT(endRes, gmres_handle->get_tol());
+      EXPECT_EQ(conv_flag, GMRESHandle::Flag::Conv);
+    }
+
+    // Test GSS2 with simple preconditioner
+    {
+      gmres_handle->reset_handle(m, tol);
+      gmres_handle->set_verbose(verbose);
+
+      // Make precond
+      KokkosSparse::Experimental::MatrixPrec<sp_matrix_type> myPrec(A);
+
+      // reset X for next gmres call
+      Kokkos::deep_copy(X, 0.0);
+
+      gmres(&kh, A, B, X, &myPrec);
+
+      // Double check residuals at end of solve:
+      float_t nrmB = KokkosBlas::nrm2(B);
+      KokkosSparse::spmv("N", 1.0, A, X, 0.0, Wj);  // wj = Ax
+      KokkosBlas::axpy(-1.0, Wj, B);                // b = b-Ax.
+      float_t endRes = KokkosBlas::nrm2(B) / nrmB;
+
+      const auto conv_flag = gmres_handle->get_conv_flag_val();
+
+      EXPECT_LT(endRes, gmres_handle->get_tol());
+      EXPECT_EQ(conv_flag, GMRESHandle::Flag::Conv);
+    }
   }
-
-  // Test GSS2 with simple preconditioner
-  {
-    gmres_handle->reset_handle(m, tol);
-    gmres_handle->set_verbose(verbose);
-
-    // Make precond
-    KokkosSparse::Experimental::MatrixPrec<sp_matrix_type> myPrec(A);
-
-    // reset X for next gmres call
-    Kokkos::deep_copy(X, 0.0);
-
-    gmres(&kh, A, B, X, &myPrec);
-
-    // Double check residuals at end of solve:
-    float_t nrmB = KokkosBlas::nrm2(B);
-    KokkosSparse::spmv("N", 1.0, A, X, 0.0, Wj);  // wj = Ax
-    KokkosBlas::axpy(-1.0, Wj, B);                // b = b-Ax.
-    float_t endRes = KokkosBlas::nrm2(B) / nrmB;
-
-    const auto conv_flag = gmres_handle->get_conv_flag_val();
-
-    EXPECT_LT(endRes, gmres_handle->get_tol());
-    EXPECT_EQ(conv_flag, GMRESHandle::Flag::Conv);
-  }
-}
+};
 
 }  // namespace Test
 
 template <typename scalar_t, typename lno_t, typename size_type,
           typename device>
 void test_gmres() {
-  Test::run_test_gmres<scalar_t, lno_t, size_type, device>();
+  using TestStruct = Test::GmresTest<scalar_t, lno_t, size_type, device>;
+  TestStruct::template run_test_gmres<false>();
+  TestStruct::template run_test_gmres<true>();
 }
 
 #define KOKKOSKERNELS_EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE)       \


### PR DESCRIPTION
Also, add a test for GMRES + BSR, which required a bit of refactoring of the GMRES test file in order to avoid a ton of code duplication.

A follow on PR will deal with blocked L/U preconditions and sptrsv.