### PR TITLE
Fix Cuda TPL finding

### DIFF
--- a/cmake/Modules/FindTPLCUBLAS.cmake
+++ b/cmake/Modules/FindTPLCUBLAS.cmake
@@ -1,5 +1,5 @@
 if(CUBLAS_LIBRARIES AND CUBLAS_LIBRARY_DIRS AND CUBLAS_INCLUDE_DIRS)
-  kokkoskernels_find_imported(CUBLAS INTERFACE 
+  kokkoskernels_find_imported(CUBLAS INTERFACE
     LIBRARIES ${CUBLAS_LIBRARIES}
     LIBRARY_PATHS ${CUBLAS_LIBRARY_DIRS}
     HEADER_PATHS ${CUBLAS_INCLUDE_DIRS}
@@ -8,19 +8,23 @@ elseif(CUBLAS_LIBRARIES AND CUBLAS_LIBRARY_DIRS)
   kokkoskernels_find_imported(CUBLAS INTERFACE
     LIBRARIES ${CUBLAS_LIBRARIES}
     LIBRARY_PATHS ${CUBLAS_LIBRARY_DIRS}
+    HEADER cublas.h
   )
 elseif(CUBLAS_LIBRARIES)
-  kokkoskernels_find_imported(CUBLAS INTERFACE 
+  kokkoskernels_find_imported(CUBLAS INTERFACE
     LIBRARIES ${CUBLAS_LIBRARIES}
+    HEADER cublas.h
   )
 elseif(CUBLAS_LIBRARY_DIRS)
-  kokkoskernels_find_imported(CUBLAS INTERFACE 
-    LIBRARIES cublas 
+  kokkoskernels_find_imported(CUBLAS INTERFACE
+    LIBRARIES cublas
     LIBRARY_PATHS ${CUBLAS_LIBRARY_DIRS}
+    HEADER cublas.h
   )
 elseif(CUBLAS_ROOT OR KokkosKernels_CUBLAS_ROOT) # nothing specific provided, just ROOT
-  kokkoskernels_find_imported(CUBLAS INTERFACE 
-    LIBRARIES cublas 
+  kokkoskernels_find_imported(CUBLAS INTERFACE
+    LIBRARIES cublas
+    HEADER cublas.h
   )
 else() # backwards-compatible way
   FIND_PACKAGE(CUDA)

--- a/cmake/Modules/FindTPLCUSOLVER.cmake
+++ b/cmake/Modules/FindTPLCUSOLVER.cmake
@@ -1,17 +1,46 @@
-FIND_PACKAGE(CUDA)
-
-INCLUDE(FindPackageHandleStandardArgs)
-IF (NOT CUDA_FOUND)
-  #Important note here: this find Module is named TPLCUSOLVER
-  #The eventual target is named CUSOLVER. To avoid naming conflicts
-  #the find module is called TPLCUSOLVER. This call will cause
-  #the find_package call to fail in a "standard" CMake way
-  FIND_PACKAGE_HANDLE_STANDARD_ARGS(TPLCUSOLVER REQUIRED_VARS CUDA_FOUND)
-ELSE()
-  #The libraries might be empty - OR they might explicitly be not found
-  IF("${CUDA_cusolver_LIBRARY}" MATCHES "NOTFOUND")
-    FIND_PACKAGE_HANDLE_STANDARD_ARGS(TPLCUSOLVER REQUIRED_VARS CUDA_cusolver_LIBRARY)
+if(CUSOLVER_LIBRARIES AND CUSOLVER_LIBRARY_DIRS AND CUSOLVER_INCLUDE_DIRS)
+  kokkoskernels_find_imported(CUSOLVER INTERFACE
+    LIBRARIES ${CUSOLVER_LIBRARIES}
+    LIBRARY_PATHS ${CUSOLVER_LIBRARY_DIRS}
+    HEADER_PATHS ${CUSOLVER_INCLUDE_DIRS}
+  )
+elseif(CUSOLVER_LIBRARIES AND CUSOLVER_LIBRARY_DIRS)
+  kokkoskernels_find_imported(CUSOLVER INTERFACE
+    LIBRARIES ${CUSOLVER_LIBRARIES}
+    LIBRARY_PATHS ${CUSOLVER_LIBRARY_DIRS}
+    HEADER cusolverDn.h
+  )
+elseif(CUSOLVER_LIBRARIES)
+  kokkoskernels_find_imported(CUSOLVER INTERFACE
+    LIBRARIES ${CUSOLVER_LIBRARIES}
+    HEADER cusolverDn.h
+  )
+elseif(CUSOLVER_LIBRARY_DIRS)
+  kokkoskernels_find_imported(CUSOLVER INTERFACE
+    LIBRARIES cusolver
+    LIBRARY_PATHS ${CUSOLVER_LIBRARY_DIRS}
+    HEADER cusolverDn.h
+  )
+elseif(CUSOLVER_ROOT OR KokkosKernels_CUSOLVER_ROOT) # nothing specific provided, just ROOT
+  kokkoskernels_find_imported(CUSOLVER INTERFACE
+    LIBRARIES cusolver
+    HEADER cusolverDn.h
+  )
+else() # backwards-compatible way
+  FIND_PACKAGE(CUDA)
+  INCLUDE(FindPackageHandleStandardArgs)
+  IF (NOT CUDA_FOUND)
+    #Important note here: this find Module is named TPLCUSOLVER
+    #The eventual target is named CUSOLVER. To avoid naming conflicts
+    #the find module is called TPLCUSOLVER. This call will cause
+    #the find_package call to fail in a "standard" CMake way
+    FIND_PACKAGE_HANDLE_STANDARD_ARGS(TPLCUSOLVER REQUIRED_VARS CUDA_FOUND)
   ELSE()
-     KOKKOSKERNELS_CREATE_IMPORTED_TPL(CUSOLVER LIBRARY ${CUDA_cusolver_LIBRARY})
+    #The libraries might be empty - OR they might explicitly be not found
+    IF("${CUDA_cusolver_LIBRARY}" MATCHES "NOTFOUND")
+      FIND_PACKAGE_HANDLE_STANDARD_ARGS(TPLCUSOLVER REQUIRED_VARS CUDA_cusolver_LIBRARY)
+    ELSE()
+      KOKKOSKERNELS_CREATE_IMPORTED_TPL(CUSOLVER INTERFACE LINK_LIBRARIES "${CUDA_cusolver_LIBRARY}")
+    ENDIF()
   ENDIF()
-ENDIF()
+endif()

--- a/cmake/Modules/FindTPLCUSPARSE.cmake
+++ b/cmake/Modules/FindTPLCUSPARSE.cmake
@@ -1,17 +1,46 @@
-FIND_PACKAGE(CUDA)
-
-INCLUDE(FindPackageHandleStandardArgs)
-IF (NOT CUDA_FOUND)
-  #Important note here: this find Module is named TPLCUSPARSE
-  #The eventual target is named CUSPARSE. To avoid naming conflicts
-  #the find module is called TPLCUSPARSE. This call will cause
-  #the find_package call to fail in a "standard" CMake way
-  FIND_PACKAGE_HANDLE_STANDARD_ARGS(TPLCUSPARSE REQUIRED_VARS CUDA_FOUND)
-ELSE()
-  #The libraries might be empty - OR they might explicitly be not found
-  IF("${CUDA_cusparse_LIBRARY}" MATCHES "NOTFOUND")
-    FIND_PACKAGE_HANDLE_STANDARD_ARGS(TPLCUSPARSE REQUIRED_VARS CUDA_cusparse_LIBRARY)
+if(CUSPARSE_LIBRARIES AND CUSPARSE_LIBRARY_DIRS AND CUSPARSE_INCLUDE_DIRS)
+  kokkoskernels_find_imported(CUSPARSE INTERFACE
+    LIBRARIES ${CUSPARSE_LIBRARIES}
+    LIBRARY_PATHS ${CUSPARSE_LIBRARY_DIRS}
+    HEADER_PATHS ${CUSPARSE_INCLUDE_DIRS}
+  )
+elseif(CUSPARSE_LIBRARIES AND CUSPARSE_LIBRARY_DIRS)
+  kokkoskernels_find_imported(CUSPARSE INTERFACE
+    LIBRARIES ${CUSPARSE_LIBRARIES}
+    LIBRARY_PATHS ${CUSPARSE_LIBRARY_DIRS}
+    HEADER cusparse.h
+  )
+elseif(CUSPARSE_LIBRARIES)
+  kokkoskernels_find_imported(CUSPARSE INTERFACE
+    LIBRARIES ${CUSPARSE_LIBRARIES}
+    HEADER cusparse.h
+  )
+elseif(CUSPARSE_LIBRARY_DIRS)
+  kokkoskernels_find_imported(CUSPARSE INTERFACE
+    LIBRARIES cusparse
+    LIBRARY_PATHS ${CUSPARSE_LIBRARY_DIRS}
+    HEADER cusparse.h
+  )
+elseif(CUSPARSE_ROOT OR KokkosKernels_CUSPARSE_ROOT) # nothing specific provided, just ROOT
+  kokkoskernels_find_imported(CUSPARSE INTERFACE
+    LIBRARIES cusparse
+    HEADER cusparse.h
+  )
+else() # backwards-compatible way
+  FIND_PACKAGE(CUDA)
+  INCLUDE(FindPackageHandleStandardArgs)
+  IF (NOT CUDA_FOUND)
+    #Important note here: this find Module is named TPLCUSPARSE
+    #The eventual target is named CUSPARSE. To avoid naming conflicts
+    #the find module is called TPLCUSPARSE. This call will cause
+    #the find_package call to fail in a "standard" CMake way
+    FIND_PACKAGE_HANDLE_STANDARD_ARGS(TPLCUSPARSE REQUIRED_VARS CUDA_FOUND)
   ELSE()
-     KOKKOSKERNELS_CREATE_IMPORTED_TPL(CUSPARSE LIBRARY ${CUDA_cusparse_LIBRARY})
+    #The libraries might be empty - OR they might explicitly be not found
+    IF("${CUDA_cusparse_LIBRARY}" MATCHES "NOTFOUND")
+      FIND_PACKAGE_HANDLE_STANDARD_ARGS(TPLCUSPARSE REQUIRED_VARS CUDA_cusparse_LIBRARY)
+    ELSE()
+      KOKKOSKERNELS_CREATE_IMPORTED_TPL(CUSPARSE INTERFACE LINK_LIBRARIES "${CUDA_cusparse_LIBRARY}")
+    ENDIF()
   ENDIF()
-ENDIF()
+endif()


### PR DESCRIPTION
Fixing issue reported by @jczhang07 

- Allow finding cusparse, cusolver based on manually provided paths
  - This is necessary when using an nvhpc toolchain instead of a standard cuda toolchain
- Set header paths correctly (this is redundant in a cuda installation, in which ``$CUDA_ROOT/include`` is already a system include dir, but needed with nvhpc)

Tested by:
- configuring/building with a normal Cuda toolchain install, using the default paths from ``FIND_PACKAGE(CUDA)``
- configuring/building with a copy of the include/lib in a nonstandard location, by setting ``CUBLAS_ROOT`` etc.
- configuring/building with the nvhpc toolchain, where the headers and libraries can't be found by default