### PR TITLE
Change name of yaml-cpp to yamlcpp (trilinos/Trilinos#12710)

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,7 +1,7 @@
 TRIBITS_PACKAGE_DEFINE_DEPENDENCIES(
         LIB_REQUIRED_PACKAGES Kokkos
         LIB_OPTIONAL_TPLS quadmath MKL BLAS LAPACK METIS SuperLU Cholmod CUBLAS CUSPARSE CUSOLVER ROCBLAS ROCSPARSE
-        TEST_OPTIONAL_TPLS yaml-cpp
+        TEST_OPTIONAL_TPLS yamlcpp
 )
 # NOTE: If you update names in LIB_OPTIONAL_TPLS above, make sure to map those names in
 # the macro 'KOKKOSKERNELS_ADD_TPL_OPTION' that resides in cmake/kokkoskernels_tpls.cmake.

--- a/perf_test/performance/CMakeLists.txt
+++ b/perf_test/performance/CMakeLists.txt
@@ -9,7 +9,7 @@ KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 #don't assert that this is defined anymore
 #ASSERT_DEFINED(TPL_ENABLE_yamlcpp)
 
-IF(TPL_ENABLE_yamlcpp)
+IF(${PACKAGE_NAME}_ENABLE_yamlcpp)
 
   KOKKOSKERNELS_ADD_UNIT_TEST(
     performance_validate

--- a/perf_test/performance/CMakeLists.txt
+++ b/perf_test/performance/CMakeLists.txt
@@ -7,9 +7,9 @@ KOKKOSKERNELS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 # performance_example is a simple example of using it.
 
 #don't assert that this is defined anymore
-#ASSERT_DEFINED(TPL_ENABLE_yaml-cpp)
+#ASSERT_DEFINED(TPL_ENABLE_yamlcpp)
 
-IF(TPL_ENABLE_yaml-cpp)
+IF(TPL_ENABLE_yamlcpp)
 
   KOKKOSKERNELS_ADD_UNIT_TEST(
     performance_validate


### PR DESCRIPTION
@ndellingwood 

Matches the changes made in Trilinos PR:

* trilinos/Trilinos#12710

NOTE: I created these commits using `git format-patch` and `git am` to move the commits from the Trilinos to the kokkos-kernels repo (by apply them on top of the base snapshot commit  9af9fa2999441f93f1b1cc7de2e3ddd0967dd9ec and then rebased on top of 'develop'.  (I had to fix a merge conflict in `cmake/Dependencies.cmake` because of changes on both sides of those branches but they are trivial changes.)
