### PR TITLE
fix: nested namespace holding kk mkl implementation

### DIFF
--- a/sparse/src/KokkosSparse_Utils_mkl.hpp
+++ b/sparse/src/KokkosSparse_Utils_mkl.hpp
@@ -63,7 +63,7 @@ inline void mkl_internal_safe_call(sparse_status_t mkl_status, const char *name,
 }
 
 #define KOKKOSKERNELS_MKL_SAFE_CALL(call) \
-  KokkosSparse::Impl::mkl_internal_safe_call(call, #call, __FILE__, __LINE__)
+  ::KokkosSparse::Impl::mkl_internal_safe_call(call, #call, __FILE__, __LINE__)
 
 inline sparse_operation_t mode_kk_to_mkl(char mode_kk) {
   switch (toupper(mode_kk)) {

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
@@ -32,7 +32,7 @@ namespace Impl {
 #if (__INTEL_MKL__ > 2017)
 // MKL 2018 and above: use new interface: sparse_matrix_t and mkl_sparse_?_mv()
 
-using KokkosSparse::Impl::mode_kk_to_mkl;
+using ::KokkosSparse::Impl::mode_kk_to_mkl;
 
 inline matrix_descr getDescription() {
   matrix_descr A_descr;


### PR DESCRIPTION
This PR fixes a compilation error when compiling Trilinos/kokkos-kernels when both `mkl` and `rocsparse` are enabled.

Compilation errors look like this:

```
/Trilinos-sources/packages/kokkos-kernels/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp:35:7: error: no member named 'mode_kk_to_mkl' in namespace 'KokkosSparse::Experimental::Impl::KokkosSparse::Impl'; did you mean '::KokkosSparse::Impl::mode_kk_to_mkl'?
```

The fix is to add a `::` so as to look for `KokkosSparse::Impl` explicitly in the global namespace.