### PR TITLE
Lapack - SVD: adding quick return when cuSOLVER is skipped

### DIFF
--- a/lapack/unit_test/Test_Lapack_svd.hpp
+++ b/lapack/unit_test/Test_Lapack_svd.hpp
@@ -474,9 +474,6 @@ int impl_test_svd(const int m, const int n) {
   using vector_type =
       Kokkos::View<mag_type*, typename AMatrix::array_layout, Device>;
 
-  std::cout << "Running impl_test_svd with sizes: " << m << "x" << n
-            << std::endl;
-
   const mag_type max_val = 10;
   const mag_type tol     = 1000 * max_val * KAT_S::eps();
 
@@ -499,6 +496,8 @@ int impl_test_svd(const int m, const int n) {
                                Kokkos::Cuda>) {
     if (m >= n) {
       KokkosLapack::svd("A", "A", A, S, U, Vt);
+    } else {
+      return 0;
     }
   } else {
     KokkosLapack::svd("A", "A", A, S, U, Vt);


### PR DESCRIPTION
Currently we still run the tests on U, S and Vt which does not make sense since we actively skip this test because cuSOLVER does not support more columns than rows...

This should fix the problem with CUDA builds reported in issue #2105 