### PR TITLE
Fix for missing STL inclusion

### DIFF
--- a/example/wiki/sparse/KokkosSparse_wiki_bsrmatrix.cpp
+++ b/example/wiki/sparse/KokkosSparse_wiki_bsrmatrix.cpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #include <sstream>
+#include <iostream>
 
 #include "Kokkos_Core.hpp"
 


### PR DESCRIPTION
When building with

KokkosKernels_ENABLE_EXPERIMENTAL=ON

I'm finding that this file is missing an include statement. 