### PR TITLE
CMake: error out in certain case

### DIFF
--- a/graph/unit_test/CMakeLists.txt
+++ b/graph/unit_test/CMakeLists.txt
@@ -10,6 +10,12 @@ KOKKOSKERNELS_INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_C
 #                   #
 #####################
 
+IF (KokkosKernels_TEST_ETI_ONLY)
+  IF (NOT KokkosKernels_INST_DOUBLE AND NOT KokkosKernels_INST_FLOAT)
+    MESSAGE(FATAL_ERROR "Because only ETI'd type combinations are enabled for testing, the Kokkos Kernels graph tests require that double or float is enabled in ETI.")
+  ENDIF ()
+ENDIF ()
+
 #####################
 #                   #
 # Add GPU backends  #


### PR DESCRIPTION
Graph unit tests are unique in that they use default_scalar for the KokkosKernelsHandle. So if test-eti-only is ON, but neither float nor double is instatiated, then error out for the graph unit tests.

Users can still build without float or double if they want, but only if they turn off tests or the graph component.

This resolves the KokkosKernels aspect of this issue: https://github.com/trilinos/Trilinos/issues/12750
Unlike Tpetra, it is perfectly fine to use the KokkosKernels library (and any non-ETI functionality like perftests and examples) with a complex type enabled and its corresponding magnitude type not enabled.