### PR TITLE
Add user tolerance to Serial SVD

### DIFF
--- a/batched/dense/impl/KokkosBatched_SVD_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_SVD_Serial_Impl.hpp
@@ -49,6 +49,34 @@ KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(SVD_USV_Tag, const AViewType &A,
       sigma.data(), sigma.stride(0), work.data());
 }
 
+template <typename AViewType, typename UViewType, typename VViewType,
+          typename SViewType, typename WViewType>
+KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(SVD_USV_Tag, const AViewType &A,
+                                             const UViewType &U,
+                                             const SViewType &sigma,
+                                             const VViewType &Vt,
+                                             const WViewType &work,
+                                             typename AViewType::const_value_type &tol) {
+  static_assert(Kokkos::is_view_v<AViewType> && AViewType::rank == 2,
+                "SVD: A must be a rank-2 view");
+  static_assert(Kokkos::is_view_v<UViewType> && UViewType::rank == 2,
+                "SVD: U must be a rank-2 view");
+  static_assert(Kokkos::is_view_v<SViewType> && SViewType::rank == 1,
+                "SVD: s must be a rank-1 view");
+  static_assert(Kokkos::is_view_v<VViewType> && VViewType::rank == 2,
+                "SVD: V must be a rank-2 view");
+  static_assert(Kokkos::is_view_v<WViewType> && WViewType::rank == 1,
+                "SVD: W must be a rank-1 view");
+  static_assert(
+      !std::is_same_v<typename WViewType::array_layout, Kokkos::LayoutStride>,
+      "SVD: W must be contiguous (not LayoutStride)");
+  using value_type = typename AViewType::non_const_value_type;
+  return KokkosBatched::SerialSVDInternal::invoke<value_type>(
+      A.extent(0), A.extent(1), A.data(), A.stride(0), A.stride(1), U.data(),
+      U.stride(0), U.stride(1), Vt.data(), Vt.stride(0), Vt.stride(1),
+      sigma.data(), sigma.stride(0), work.data(), tol);
+}
+
 // Version which computes only singular values
 template <typename AViewType, typename SViewType, typename WViewType>
 KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(SVD_S_Tag, const AViewType &A,
@@ -69,6 +97,26 @@ KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(SVD_S_Tag, const AViewType &A,
       0, nullptr, 0, 0, sigma.data(), sigma.stride(0), work.data());
 }
 
+// Version which computes only singular values
+template <typename AViewType, typename SViewType, typename WViewType>
+KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(SVD_S_Tag, const AViewType &A,
+                                             const SViewType &sigma,
+                                             const WViewType &work,
+                                             typename AViewType::const_value_type &tol) {
+  static_assert(Kokkos::is_view_v<AViewType> && AViewType::rank == 2,
+                "SVD: A must be a rank-2 view");
+  static_assert(Kokkos::is_view_v<SViewType> && SViewType::rank == 1,
+                "SVD: s must be a rank-1 view");
+  static_assert(Kokkos::is_view_v<WViewType> && WViewType::rank == 1,
+                "SVD: W must be a rank-1 view");
+  static_assert(
+      !std::is_same_v<typename WViewType::array_layout, Kokkos::LayoutStride>,
+      "SVD: W must be contiguous (not LayoutStride)");
+  using value_type = typename AViewType::non_const_value_type;
+  return KokkosBatched::SerialSVDInternal::invoke<value_type>(
+      A.extent(0), A.extent(1), A.data(), A.stride(0), A.stride(1), nullptr, 0,
+      0, nullptr, 0, 0, sigma.data(), sigma.stride(0), work.data(), tol);
+}
 }  // namespace KokkosBatched
 
 #endif

--- a/batched/dense/impl/KokkosBatched_SVD_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_SVD_Serial_Impl.hpp
@@ -24,37 +24,10 @@ namespace KokkosBatched {
 // Version which computes the full factorization
 template <typename AViewType, typename UViewType, typename VViewType,
           typename SViewType, typename WViewType>
-KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(SVD_USV_Tag, const AViewType &A,
-                                             const UViewType &U,
-                                             const SViewType &sigma,
-                                             const VViewType &Vt,
-                                             const WViewType &work) {
-  static_assert(Kokkos::is_view_v<AViewType> && AViewType::rank == 2,
-                "SVD: A must be a rank-2 view");
-  static_assert(Kokkos::is_view_v<UViewType> && UViewType::rank == 2,
-                "SVD: U must be a rank-2 view");
-  static_assert(Kokkos::is_view_v<SViewType> && SViewType::rank == 1,
-                "SVD: s must be a rank-1 view");
-  static_assert(Kokkos::is_view_v<VViewType> && VViewType::rank == 2,
-                "SVD: V must be a rank-2 view");
-  static_assert(Kokkos::is_view_v<WViewType> && WViewType::rank == 1,
-                "SVD: W must be a rank-1 view");
-  static_assert(
-      !std::is_same_v<typename WViewType::array_layout, Kokkos::LayoutStride>,
-      "SVD: W must be contiguous (not LayoutStride)");
-  using value_type = typename AViewType::non_const_value_type;
-  return KokkosBatched::SerialSVDInternal::invoke<value_type>(
-      A.extent(0), A.extent(1), A.data(), A.stride(0), A.stride(1), U.data(),
-      U.stride(0), U.stride(1), Vt.data(), Vt.stride(0), Vt.stride(1),
-      sigma.data(), sigma.stride(0), work.data());
-}
-
-template <typename AViewType, typename UViewType, typename VViewType,
-          typename SViewType, typename WViewType>
 KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(
     SVD_USV_Tag, const AViewType &A, const UViewType &U, const SViewType &sigma,
     const VViewType &Vt, const WViewType &work,
-    typename AViewType::const_value_type &tol) {
+    typename AViewType::const_value_type tol) {
   static_assert(Kokkos::is_view_v<AViewType> && AViewType::rank == 2,
                 "SVD: A must be a rank-2 view");
   static_assert(Kokkos::is_view_v<UViewType> && UViewType::rank == 2,
@@ -77,29 +50,9 @@ KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(
 
 // Version which computes only singular values
 template <typename AViewType, typename SViewType, typename WViewType>
-KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(SVD_S_Tag, const AViewType &A,
-                                             const SViewType &sigma,
-                                             const WViewType &work) {
-  static_assert(Kokkos::is_view_v<AViewType> && AViewType::rank == 2,
-                "SVD: A must be a rank-2 view");
-  static_assert(Kokkos::is_view_v<SViewType> && SViewType::rank == 1,
-                "SVD: s must be a rank-1 view");
-  static_assert(Kokkos::is_view_v<WViewType> && WViewType::rank == 1,
-                "SVD: W must be a rank-1 view");
-  static_assert(
-      !std::is_same_v<typename WViewType::array_layout, Kokkos::LayoutStride>,
-      "SVD: W must be contiguous (not LayoutStride)");
-  using value_type = typename AViewType::non_const_value_type;
-  return KokkosBatched::SerialSVDInternal::invoke<value_type>(
-      A.extent(0), A.extent(1), A.data(), A.stride(0), A.stride(1), nullptr, 0,
-      0, nullptr, 0, 0, sigma.data(), sigma.stride(0), work.data());
-}
-
-// Version which computes only singular values
-template <typename AViewType, typename SViewType, typename WViewType>
 KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(
     SVD_S_Tag, const AViewType &A, const SViewType &sigma,
-    const WViewType &work, typename AViewType::const_value_type &tol) {
+    const WViewType &work, typename AViewType::const_value_type tol) {
   static_assert(Kokkos::is_view_v<AViewType> && AViewType::rank == 2,
                 "SVD: A must be a rank-2 view");
   static_assert(Kokkos::is_view_v<SViewType> && SViewType::rank == 1,
@@ -114,6 +67,7 @@ KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(
       A.extent(0), A.extent(1), A.data(), A.stride(0), A.stride(1), nullptr, 0,
       0, nullptr, 0, 0, sigma.data(), sigma.stride(0), work.data(), tol);
 }
+
 }  // namespace KokkosBatched
 
 #endif

--- a/batched/dense/impl/KokkosBatched_SVD_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_SVD_Serial_Impl.hpp
@@ -51,12 +51,10 @@ KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(SVD_USV_Tag, const AViewType &A,
 
 template <typename AViewType, typename UViewType, typename VViewType,
           typename SViewType, typename WViewType>
-KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(SVD_USV_Tag, const AViewType &A,
-                                             const UViewType &U,
-                                             const SViewType &sigma,
-                                             const VViewType &Vt,
-                                             const WViewType &work,
-                                             typename AViewType::const_value_type &tol) {
+KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(
+    SVD_USV_Tag, const AViewType &A, const UViewType &U, const SViewType &sigma,
+    const VViewType &Vt, const WViewType &work,
+    typename AViewType::const_value_type &tol) {
   static_assert(Kokkos::is_view_v<AViewType> && AViewType::rank == 2,
                 "SVD: A must be a rank-2 view");
   static_assert(Kokkos::is_view_v<UViewType> && UViewType::rank == 2,
@@ -99,10 +97,9 @@ KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(SVD_S_Tag, const AViewType &A,
 
 // Version which computes only singular values
 template <typename AViewType, typename SViewType, typename WViewType>
-KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(SVD_S_Tag, const AViewType &A,
-                                             const SViewType &sigma,
-                                             const WViewType &work,
-                                             typename AViewType::const_value_type &tol) {
+KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(
+    SVD_S_Tag, const AViewType &A, const SViewType &sigma,
+    const WViewType &work, typename AViewType::const_value_type &tol) {
   static_assert(Kokkos::is_view_v<AViewType> && AViewType::rank == 2,
                 "SVD: A must be a rank-2 view");
   static_assert(Kokkos::is_view_v<SViewType> && SViewType::rank == 1,

--- a/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
@@ -237,7 +237,7 @@ struct SerialSVDInternal {
                                              int Bs0, int Bs1, value_type* U,
                                              int Us0, int Us1, value_type* Vt,
                                              int Vts0, int Vts1,
-                                             value_type* sigma, int ss) {
+                                             value_type* sigma, int ss, const value_type& tol) {
     using KAT            = Kokkos::ArithTraits<value_type>;
     const value_type eps = Kokkos::ArithTraits<value_type>::epsilon();
     int p                = 0;
@@ -246,7 +246,8 @@ struct SerialSVDInternal {
       // Zero out tiny superdiagonal entries
       for (int i = 0; i < n - 1; i++) {
         if (fabs(SVDIND(B, i, i + 1)) <
-            eps * (fabs(SVDIND(B, i, i)) + fabs(SVDIND(B, i + 1, i + 1)))) {
+            eps * (fabs(SVDIND(B, i, i)) + fabs(SVDIND(B, i + 1, i + 1))) ||
+            fabs(SVDIND(B, i, i + 1)) < tol) {
           SVDIND(B, i, i + 1) = KAT::zero();
         }
       }
@@ -345,7 +346,7 @@ struct SerialSVDInternal {
                                            int As1, value_type* U, int Us0,
                                            int Us1, value_type* Vt, int Vts0,
                                            int Vts1, value_type* sigma, int ss,
-                                           value_type* work) {
+                                           value_type* work, value_type tol = Kokkos::ArithTraits<value_type>::zero()) {
     // First, if m < n, need to instead compute (V, s, U^T) = A^T.
     // This just means swapping U & Vt, and implicitly transposing A, U and Vt.
     if (m < n) {
@@ -370,7 +371,7 @@ struct SerialSVDInternal {
       return 0;
     }
     bidiagonalize(m, n, A, As0, As1, U, Us0, Us1, Vt, Vts0, Vts1, work);
-    bidiSVD(m, n, A, As0, As1, U, Us0, Us1, Vt, Vts0, Vts1, sigma, ss);
+    bidiSVD(m, n, A, As0, As1, U, Us0, Us1, Vt, Vts0, Vts1, sigma, ss, tol);
     postprocessSVD(m, n, U, Us0, Us1, Vt, Vts0, Vts1, sigma, ss);
     return 0;
   }

--- a/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
@@ -237,7 +237,8 @@ struct SerialSVDInternal {
                                              int Bs0, int Bs1, value_type* U,
                                              int Us0, int Us1, value_type* Vt,
                                              int Vts0, int Vts1,
-                                             value_type* sigma, int ss, const value_type& tol) {
+                                             value_type* sigma, int ss,
+                                             const value_type& tol) {
     using KAT            = Kokkos::ArithTraits<value_type>;
     const value_type eps = Kokkos::ArithTraits<value_type>::epsilon();
     int p                = 0;
@@ -246,7 +247,7 @@ struct SerialSVDInternal {
       // Zero out tiny superdiagonal entries
       for (int i = 0; i < n - 1; i++) {
         if (fabs(SVDIND(B, i, i + 1)) <
-            eps * (fabs(SVDIND(B, i, i)) + fabs(SVDIND(B, i + 1, i + 1))) ||
+                eps * (fabs(SVDIND(B, i, i)) + fabs(SVDIND(B, i + 1, i + 1))) ||
             fabs(SVDIND(B, i, i + 1)) < tol) {
           SVDIND(B, i, i + 1) = KAT::zero();
         }
@@ -342,11 +343,11 @@ struct SerialSVDInternal {
   }
 
   template <typename value_type>
-  KOKKOS_INLINE_FUNCTION static int invoke(int m, int n, value_type* A, int As0,
-                                           int As1, value_type* U, int Us0,
-                                           int Us1, value_type* Vt, int Vts0,
-                                           int Vts1, value_type* sigma, int ss,
-                                           value_type* work, value_type tol = Kokkos::ArithTraits<value_type>::zero()) {
+  KOKKOS_INLINE_FUNCTION static int invoke(
+      int m, int n, value_type* A, int As0, int As1, value_type* U, int Us0,
+      int Us1, value_type* Vt, int Vts0, int Vts1, value_type* sigma, int ss,
+      value_type* work,
+      value_type tol = Kokkos::ArithTraits<value_type>::zero()) {
     // First, if m < n, need to instead compute (V, s, U^T) = A^T.
     // This just means swapping U & Vt, and implicitly transposing A, U and Vt.
     if (m < n) {

--- a/batched/dense/src/KokkosBatched_SVD_Decl.hpp
+++ b/batched/dense/src/KokkosBatched_SVD_Decl.hpp
@@ -63,12 +63,26 @@ struct SerialSVD {
                                            const SViewType &s,
                                            const VtViewType &Vt,
                                            const WViewType &W);
+  template <typename AViewType, typename UViewType, typename VtViewType,
+            typename SViewType, typename WViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(SVD_USV_Tag, const AViewType &A,
+                                           const UViewType &U,
+                                           const SViewType &s,
+                                           const VtViewType &Vt,
+                                           const WViewType &W,
+                                           typename AViewType::const_value_type &tol);
+
 
   // Version which computes only singular values
   template <typename AViewType, typename SViewType, typename WViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(SVD_S_Tag, const AViewType &A,
                                            const SViewType &s,
                                            const WViewType &W);
+  template <typename AViewType, typename SViewType, typename WViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(SVD_S_Tag, const AViewType &A,
+                                           const SViewType &s,
+                                           const WViewType &W,
+                                           typename AViewType::const_value_type &tol);
 };
 
 }  // namespace KokkosBatched

--- a/batched/dense/src/KokkosBatched_SVD_Decl.hpp
+++ b/batched/dense/src/KokkosBatched_SVD_Decl.hpp
@@ -58,27 +58,18 @@ struct SerialSVD {
   // Version to compute full factorization: A == U * diag(s) * Vt
   template <typename AViewType, typename UViewType, typename VtViewType,
             typename SViewType, typename WViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(SVD_USV_Tag, const AViewType &A,
-                                           const UViewType &U,
-                                           const SViewType &s,
-                                           const VtViewType &Vt,
-                                           const WViewType &W);
-  template <typename AViewType, typename UViewType, typename VtViewType,
-            typename SViewType, typename WViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(
       SVD_USV_Tag, const AViewType &A, const UViewType &U, const SViewType &s,
       const VtViewType &Vt, const WViewType &W,
-      typename AViewType::const_value_type &tol);
+      typename AViewType::const_value_type tol =
+          Kokkos::ArithTraits<typename AViewType::value_type>::zero());
 
   // Version which computes only singular values
   template <typename AViewType, typename SViewType, typename WViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(SVD_S_Tag, const AViewType &A,
-                                           const SViewType &s,
-                                           const WViewType &W);
-  template <typename AViewType, typename SViewType, typename WViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(
       SVD_S_Tag, const AViewType &A, const SViewType &s, const WViewType &W,
-      typename AViewType::const_value_type &tol);
+      typename AViewType::const_value_type tol =
+          Kokkos::ArithTraits<typename AViewType::value_type>::zero());
 };
 
 }  // namespace KokkosBatched

--- a/batched/dense/src/KokkosBatched_SVD_Decl.hpp
+++ b/batched/dense/src/KokkosBatched_SVD_Decl.hpp
@@ -65,13 +65,10 @@ struct SerialSVD {
                                            const WViewType &W);
   template <typename AViewType, typename UViewType, typename VtViewType,
             typename SViewType, typename WViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(SVD_USV_Tag, const AViewType &A,
-                                           const UViewType &U,
-                                           const SViewType &s,
-                                           const VtViewType &Vt,
-                                           const WViewType &W,
-                                           typename AViewType::const_value_type &tol);
-
+  KOKKOS_INLINE_FUNCTION static int invoke(
+      SVD_USV_Tag, const AViewType &A, const UViewType &U, const SViewType &s,
+      const VtViewType &Vt, const WViewType &W,
+      typename AViewType::const_value_type &tol);
 
   // Version which computes only singular values
   template <typename AViewType, typename SViewType, typename WViewType>
@@ -79,10 +76,9 @@ struct SerialSVD {
                                            const SViewType &s,
                                            const WViewType &W);
   template <typename AViewType, typename SViewType, typename WViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(SVD_S_Tag, const AViewType &A,
-                                           const SViewType &s,
-                                           const WViewType &W,
-                                           typename AViewType::const_value_type &tol);
+  KOKKOS_INLINE_FUNCTION static int invoke(
+      SVD_S_Tag, const AViewType &A, const SViewType &s, const WViewType &W,
+      typename AViewType::const_value_type &tol);
 };
 
 }  // namespace KokkosBatched


### PR DESCRIPTION


Hi,

I had to re-upload this PR due to some wonkiness in my setup. Apologies for the hassle. The original message is below and I have put the changes on top of the develop branch as requested in the previous PR.

Original message : 
I have have had issues with stalling when attempting to use Serial SVD. The basic behavior is that the superdiagonal entries oscillate around at really small numbers, yet they are still above the threshold checked in bidiSVD to zero them out, resulting in an infinite loop.

This PR introduces a user specified tolerance that can optionally be used to zero out tiny superdiagonal entries in bidiSVD. This change enabled the routine to work without issue for my problems. I ultimately used 2.0 * machine_eps as the tolerance rather than the value used by master.

I am not certain if this is the best strategy to deal with the issue and welcome other ideas on how to improve it.
