### PR TITLE
Increase tolerance on gesv test (Fix #2123)

### DIFF
--- a/lapack/unit_test/Test_Lapack_gesv.hpp
+++ b/lapack/unit_test/Test_Lapack_gesv.hpp
@@ -130,17 +130,17 @@ void impl_test_gesv(const char* mode, const char* padding, int N) {
 
   // Checking vs ref on CPU, this eps is about 10^-9
   typedef typename ats::mag_type mag_type;
-  const mag_type eps = 2.0e7 * ats::epsilon();
+  const mag_type eps = 3.0e7 * ats::epsilon();
   bool test_flag     = true;
   for (int i = 0; i < N; i++) {
     if (ats::abs(h_B(i) - h_X0(i)) > eps) {
       test_flag = false;
-      // printf(
-      //     "    Error %d, pivot %c, padding %c: result( %.15lf ) !="
-      //     "solution( %.15lf ) at (%d), error=%.15e, eps=%.15e\n",
-      //     N, mode[0], padding[0], ats::abs(h_B(i)), ats::abs(h_X0(i)),
-      //     int(i), ats::abs(h_B(i) - h_X0(i)), eps);
-      // break;
+      printf(
+          "    Error %d, pivot %c, padding %c: result( %.15lf ) !="
+          "solution( %.15lf ) at (%d), error=%.15e, eps=%.15e\n",
+          N, mode[0], padding[0], ats::abs(h_B(i)), ats::abs(h_X0(i)), int(i),
+          ats::abs(h_B(i) - h_X0(i)), eps);
+      break;
     }
   }
   ASSERT_EQ(test_flag, true);


### PR DESCRIPTION
Increase tolerance by 50%.

And uncomment the verbose output for when tolerance is exceeded, since that helps debug this sort of issue.
This is only printed at most once so it won't spam the output if the entire vector is wrong.