### PR TITLE
Kokkos Kernels: update version guards to drop old version of Kokkos

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -626,7 +626,6 @@ KOKKOS_INLINE_FUNCTION auto subview_wrapper(ViewType v, IdxType1 i1,
                                             const Trans::NoTranspose) {
   return subview_wrapper(v, i1, i2, i3, layout_tag);
 }
-#if KOKKOS_VERSION < 40099
 template <class ViewType, class IdxType1>
 KOKKOS_INLINE_FUNCTION auto subview_wrapper(ViewType v, IdxType1 i1,
                                             Kokkos::ALL_t i2, Kokkos::ALL_t i3,
@@ -636,17 +635,6 @@ KOKKOS_INLINE_FUNCTION auto subview_wrapper(ViewType v, IdxType1 i1,
 
   return transpose_2d_view(sv_nt, layout_tag);
 }
-#else
-template <class ViewType, class IdxType1>
-KOKKOS_INLINE_FUNCTION auto subview_wrapper(ViewType v, IdxType1 i1,
-                                            Kokkos::ALL_t i2, Kokkos::ALL_t i3,
-                                            const BatchLayout::Left &layout_tag,
-                                            const Trans::Transpose) {
-  auto sv_nt = subview_wrapper(v, i1, i3, i2, layout_tag);
-
-  return transpose_2d_view(sv_nt, layout_tag);
-}
-#endif
 template <class ViewType, class IdxType1, class IdxType2, class IdxType3>
 KOKKOS_INLINE_FUNCTION auto subview_wrapper(ViewType v, IdxType1 i1,
                                             IdxType2 i2, IdxType3 i3,
@@ -670,7 +658,6 @@ KOKKOS_INLINE_FUNCTION auto subview_wrapper(
     const BatchLayout::Right &layout_tag, const Trans::NoTranspose &) {
   return subview_wrapper(v, i1, i2, i3, layout_tag);
 }
-#if KOKKOS_VERSION < 40099
 template <class ViewType, class IdxType1>
 KOKKOS_INLINE_FUNCTION auto subview_wrapper(
     ViewType v, IdxType1 i1, Kokkos::ALL_t i2, Kokkos::ALL_t i3,
@@ -679,16 +666,6 @@ KOKKOS_INLINE_FUNCTION auto subview_wrapper(
 
   return transpose_2d_view(sv_nt, layout_tag);
 }
-#else
-template <class ViewType, class IdxType1>
-KOKKOS_INLINE_FUNCTION auto subview_wrapper(
-    ViewType v, IdxType1 i1, Kokkos::ALL_t i2, Kokkos::ALL_t i3,
-    const BatchLayout::Right &layout_tag, const Trans::Transpose &) {
-  auto sv_nt = subview_wrapper(v, i1, i3, i2, layout_tag);
-
-  return transpose_2d_view(sv_nt, layout_tag);
-}
-#endif
 template <class ViewType, class IdxType1, class IdxType2, class IdxType3>
 KOKKOS_INLINE_FUNCTION auto subview_wrapper(
     ViewType v, IdxType1 i1, IdxType2 i2, IdxType3 i3,

--- a/batched/dense/impl/KokkosBatched_HostLevel_Gemm_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_HostLevel_Gemm_Impl.hpp
@@ -93,11 +93,9 @@ int BatchedGemmImpl(BatchedGemmHandleType *const handle, const ScalarType alpha,
       case BaseKokkosBatchedAlgos::KK_SERIAL:
       case BaseHeuristicAlgos::SQUARE:
       case BaseTplAlgos::ARMPL:
-#if KOKKOS_VERSION > 40099
         assert(A.rank_dynamic() == 3 && "AViewType must have rank 3.");
         assert(B.rank_dynamic() == 3 && "BViewType must have rank 3.");
         assert(C.rank_dynamic() == 3 && "CViewType must have rank 3.");
-#endif
         break;
       default:
         std::ostringstream os;

--- a/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
@@ -55,11 +55,7 @@ struct SerialSVDInternal {
     value_type a = Kokkos::ArithTraits<value_type>::one();
     value_type b = -a11 - a22;
     value_type c = a11 * a22 - a21 * a21;
-#if KOKKOS_VERSION >= 30699
     using Kokkos::sqrt;
-#else
-    using Kokkos::Experimental::sqrt;
-#endif
     value_type sqrtDet = sqrt(b * b - 4 * a * c);
     e1                 = (-b + sqrtDet) / (2 * a);
     e2                 = (-b - sqrtDet) / (2 * a);

--- a/common/impl/KokkosKernels_ViewUtils.hpp
+++ b/common/impl/KokkosKernels_ViewUtils.hpp
@@ -19,11 +19,6 @@
 #include "Kokkos_Core.hpp"
 
 namespace KokkosKernels::Impl {
-// lbv - 07/26/2023:
-// MemoryTraits<T>::impl_value was added
-// in Kokkos 4.1.00 so we should guard
-// the content of this header until v4.3.0
-#if KOKKOS_VERSION >= 40100 || defined(DOXY)
 
 /*! \brief Yields a type that is View with Kokkos::Unmanaged added to the memory
  * traits
@@ -59,7 +54,6 @@ auto make_unmanaged(const View &v) {
   return typename with_unmanaged<View>::type(v);
 }
 
-#endif  // KOKKOS_VERSION >= 40100
 }  // namespace KokkosKernels::Impl
 
 #endif

--- a/sparse/impl/KokkosSparse_coo2crs_impl.hpp
+++ b/sparse/impl/KokkosSparse_coo2crs_impl.hpp
@@ -15,11 +15,6 @@
 //@HEADER
 #ifndef KOKKOSSPARSE_COO2CRS_IMPL_HPP
 #define KOKKOSSPARSE_COO2CRS_IMPL_HPP
-// The unorderedmap changes necessary for this to work
-// have not made it into Kokkos 4.0.00 pr 4.0.01 will
-// need to see if it happens in 4.1.00 to have a final
-// version check here.
-#if KOKKOS_VERSION >= 40099
 
 #include <Kokkos_StdAlgorithms.hpp>
 #include "Kokkos_UnorderedMap.hpp"
@@ -279,7 +274,5 @@ class Coo2Crs {
 };
 }  // namespace Impl
 }  // namespace KokkosSparse
-
-#endif  // KOKKOS_VERSION >= 40099
 
 #endif  // KOKKOSSPARSE_COO2CRS_IMPL_HPP

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl_v42.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl_v42.hpp
@@ -121,11 +121,6 @@ void apply_v42(const typename AMatrix::execution_space &exec,
 
   Kokkos::RangePolicy<execution_space> policy(exec, 0, y.size());
   if constexpr (YVector::rank == 1) {
-// lbv - 07/26/2023:
-// with_unmanaged_t<...> required Kokkos 4.1.0,
-// the content of this header will be guarded
-// until v4.3.0
-#if KOKKOS_VERSION >= 40100 || defined(DOXY)
     // Implementation expects a 2D view, so create an unmanaged 2D view
     // with extent 1 in the second dimension
     using Y2D = KokkosKernels::Impl::with_unmanaged_t<Kokkos::View<
@@ -134,16 +129,6 @@ void apply_v42(const typename AMatrix::execution_space &exec,
     using X2D = KokkosKernels::Impl::with_unmanaged_t<Kokkos::View<
         typename XVector::value_type * [1], typename XVector::array_layout,
         typename XVector::device_type, typename XVector::memory_traits>>;
-#else
-    // Implementation expects a 2D view, so create an unmanaged 2D view
-    // with extent 1 in the second dimension
-    using Y2D = Kokkos::View<
-        typename YVector::value_type * [1], typename YVector::array_layout,
-        typename YVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-    using X2D = Kokkos::View<
-        typename XVector::value_type * [1], typename XVector::array_layout,
-        typename XVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-#endif  // KOKKOS_VERSION >= 40100 || defined(DOXY)
     const Y2D yu(y.data(), y.extent(0), 1);
     const X2D xu(x.data(), x.extent(0), 1);
     BsrSpmvV42NonTrans op(alpha, a, xu, beta, yu);

--- a/sparse/src/KokkosSparse_coo2crs.hpp
+++ b/sparse/src/KokkosSparse_coo2crs.hpp
@@ -16,11 +16,6 @@
 
 #ifndef _KOKKOSSPARSE_COO2CRS_HPP
 #define _KOKKOSSPARSE_COO2CRS_HPP
-// The unorderedmap changes necessary for this to work
-// have not made it into Kokkos 4.0.00 pr 4.0.01 will
-// need to see if it happens in 4.1.00 to have a final
-// version check here.
-#if KOKKOS_VERSION >= 40099 || defined(DOXY)
 
 #include "KokkosSparse_CooMatrix.hpp"
 #include "KokkosSparse_CrsMatrix.hpp"
@@ -99,5 +94,4 @@ auto coo2crs(KokkosSparse::CooMatrix<ScalarType, OrdinalType, DeviceType,
                  cooMatrix.col, cooMatrix.data);
 }
 }  // namespace KokkosSparse
-#endif  // KOKKOS_VERSION >= 40099 || defined(DOXY)
 #endif  //  _KOKKOSSPARSE_COO2CRS_HPP

--- a/sparse/unit_test/Test_Sparse.hpp
+++ b/sparse/unit_test/Test_Sparse.hpp
@@ -16,9 +16,7 @@
 #ifndef TEST_SPARSE_HPP
 #define TEST_SPARSE_HPP
 
-#if KOKKOS_VERSION >= 40099
 #include "Test_Sparse_coo2crs.hpp"
-#endif  // KOKKOS_VERSION >= 40099
 #include "Test_Sparse_crs2coo.hpp"
 #include "Test_Sparse_Controls.hpp"
 #include "Test_Sparse_CrsMatrix.hpp"


### PR DESCRIPTION
Since we are now in the 4.2 series we only support up to 4.1.00. Older version of Kokkos Core will require older version of Kokkos Kernels for compatibility. Once 4.3.00 is out we will move to drop support for the 4.1 series and only keep 4.2 and 4.3 series.