### PR TITLE
Sparse MKL: changing the location of the MKL_SAFE_CALL macro

### DIFF
--- a/sparse/eti/generated_specializations_cpp/spmv/KokkosSparse_spmv_bsrmatrix_eti_spec_inst.cpp.in
+++ b/sparse/eti/generated_specializations_cpp/spmv/KokkosSparse_spmv_bsrmatrix_eti_spec_inst.cpp.in
@@ -19,11 +19,9 @@
 #include "KokkosSparse_spmv_bsrmatrix_spec.hpp"
 
 namespace KokkosSparse {
-namespace Experimental {
 namespace Impl {
 // clang-format off
 @SPARSE_SPMV_BSRMATRIX_ETI_INST_BLOCK@
 // clang-format on
 }  // namespace Impl
-}  // namespace Experimental
 }  // namespace KokkosSparse

--- a/sparse/eti/generated_specializations_cpp/spmv/KokkosSparse_spmv_mv_bsrmatrix_eti_spec_inst.cpp.in
+++ b/sparse/eti/generated_specializations_cpp/spmv/KokkosSparse_spmv_mv_bsrmatrix_eti_spec_inst.cpp.in
@@ -19,11 +19,9 @@
 #include "KokkosSparse_spmv_bsrmatrix_spec.hpp"
 
 namespace KokkosSparse {
-namespace Experimental {
 namespace Impl {
 // clang-format off
 @SPARSE_SPMV_MV_BSRMATRIX_ETI_INST_BLOCK@
 /// // clang-format on
 }  // namespace Impl
-}  // namespace Experimental
 }  // namespace KokkosSparse

--- a/sparse/eti/generated_specializations_hpp/KokkosSparse_spmv_bsrmatrix_eti_spec_avail.hpp.in
+++ b/sparse/eti/generated_specializations_hpp/KokkosSparse_spmv_bsrmatrix_eti_spec_avail.hpp.in
@@ -17,12 +17,10 @@
 #ifndef KOKKOSSPARSE_SPMV_BSRMATRIX_ETI_SPEC_AVAIL_HPP_
 #define KOKKOSSPARSE_SPMV_BSRMATRIX_ETI_SPEC_AVAIL_HPP_
 namespace KokkosSparse {
-namespace Experimental {
 namespace Impl {
 // clang-format off
 @SPARSE_SPMV_BSRMATRIX_ETI_AVAIL_BLOCK@
 // clang-format on
 }  // namespace Impl
-}  // namespace Experimental
 }  // namespace KokkosSparse
 #endif

--- a/sparse/eti/generated_specializations_hpp/KokkosSparse_spmv_mv_bsrmatrix_eti_spec_avail.hpp.in
+++ b/sparse/eti/generated_specializations_hpp/KokkosSparse_spmv_mv_bsrmatrix_eti_spec_avail.hpp.in
@@ -18,12 +18,10 @@
 #define KOKKOSSPARSE_SPMV_MV_BSRMATRIX_ETI_SPEC_AVAIL_HPP_
 
 namespace KokkosSparse {
-namespace Experimental {
 namespace Impl {
 // clang-format off
 @SPARSE_SPMV_MV_BSRMATRIX_ETI_AVAIL_BLOCK@
 // clang-format on
 }  // namespace Impl
-}  // namespace Experimental
 }  // namespace KokkosSparse
 #endif

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
@@ -27,7 +27,6 @@
 #include <mma.h>
 
 namespace KokkosSparse {
-namespace Experimental {
 namespace Impl {
 
 struct BsrMatrixSpMVTensorCoreFunctorParams {
@@ -519,7 +518,6 @@ struct BsrMatrixSpMVTensorCoreDispatcher {
 };
 
 }  // namespace Impl
-}  // namespace Experimental
 }  // namespace KokkosSparse
 
 #endif  // #if CUDA && (VOLTA || AMPERE)
@@ -537,7 +535,6 @@ struct BsrMatrixSpMVTensorCoreDispatcher {
 #include "KokkosKernels_ExecSpaceUtils.hpp"
 
 namespace KokkosSparse {
-namespace Experimental {
 namespace Impl {
 namespace Bsr {
 
@@ -1735,9 +1732,7 @@ void spMatMultiVec_transpose(const execution_space &exec, Handle *handle,
 /* ******************* */
 
 }  // namespace Bsr
-
 }  // namespace Impl
-}  // namespace Experimental
 }  // namespace KokkosSparse
 
 #endif  // KOKKOSSPARSE_IMPL_SPMV_BSRMATRIX_IMPL_HPP_

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -29,7 +29,6 @@
 #endif
 
 namespace KokkosSparse {
-namespace Experimental {
 namespace Impl {
 
 // default is no eti available
@@ -48,7 +47,6 @@ struct spmv_mv_bsrmatrix_eti_spec_avail {
 };
 
 }  // namespace Impl
-}  // namespace Experimental
 }  // namespace KokkosSparse
 
 #define KOKKOSSPARSE_SPMV_BSRMATRIX_ETI_SPEC_AVAIL(                        \
@@ -103,7 +101,6 @@ struct spmv_mv_bsrmatrix_eti_spec_avail {
 #include <generated_specializations_hpp/KokkosSparse_spmv_mv_bsrmatrix_eti_spec_avail.hpp>
 
 namespace KokkosSparse {
-namespace Experimental {
 namespace Impl {
 
 // declaration
@@ -218,7 +215,7 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector,
     {
       // try to use tensor cores if requested
       if (handle->algo == SPMV_BSR_TC) method = Method::TensorCores;
-      if (!KokkosSparse::Experimental::Impl::TensorCoresAvailable<
+      if (!KokkosSparse::Impl::TensorCoresAvailable<
               ExecutionSpace, AMatrix, XVector, YVector>::value) {
         method = Method::Fallback;
       }
@@ -365,7 +362,6 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector,
 #endif  // !defined(KOKKOSKERNELS_ETI_ONLY) ||
         // KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
 }  // namespace Impl
-}  // namespace Experimental
 }  // namespace KokkosSparse
 
 // declare / instantiate the vector version

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -215,8 +215,8 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector,
     {
       // try to use tensor cores if requested
       if (handle->algo == SPMV_BSR_TC) method = Method::TensorCores;
-      if (!KokkosSparse::Impl::TensorCoresAvailable<
-              ExecutionSpace, AMatrix, XVector, YVector>::value) {
+      if (!KokkosSparse::Impl::TensorCoresAvailable<ExecutionSpace, AMatrix,
+                                                    XVector, YVector>::value) {
         method = Method::Fallback;
       }
       // can't use tensor cores unless mode is no-transpose

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -46,9 +46,6 @@ struct spmv_mv_bsrmatrix_eti_spec_avail {
   enum : bool { value = false };
 };
 
-}  // namespace Impl
-}  // namespace KokkosSparse
-
 #define KOKKOSSPARSE_SPMV_BSRMATRIX_ETI_SPEC_AVAIL(                        \
     SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE,  \
     MEM_SPACE_TYPE)                                                        \
@@ -94,6 +91,9 @@ struct spmv_mv_bsrmatrix_eti_spec_avail {
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {             \
     enum : bool { value = true };                                          \
   };
+
+}  // namespace Impl
+}  // namespace KokkosSparse
 
 // Include which ETIs are available
 #include <KokkosSparse_spmv_bsrmatrix_tpl_spec_avail.hpp>

--- a/sparse/src/KokkosSparse_Utils_mkl.hpp
+++ b/sparse/src/KokkosSparse_Utils_mkl.hpp
@@ -62,8 +62,14 @@ inline void mkl_internal_safe_call(sparse_status_t mkl_status, const char *name,
   }
 }
 
+}  // namespace Impl
+}  // namespace KokkosSparse
+
 #define KOKKOSKERNELS_MKL_SAFE_CALL(call) \
   KokkosSparse::Impl::mkl_internal_safe_call(call, #call, __FILE__, __LINE__)
+
+namespace KokkosSparse {
+namespace Impl {
 
 inline sparse_operation_t mode_kk_to_mkl(char mode_kk) {
   switch (toupper(mode_kk)) {

--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -337,13 +337,13 @@ void spmv(const ExecutionSpace& space, Handle* handle, const char mode[],
                 typename AMatrix_Internal::non_const_value_type>::name() +
             "]";
         Kokkos::Profiling::pushRegion(label);
-        Experimental::Impl::SPMV_BSRMATRIX<
+        Impl::SPMV_BSRMATRIX<
             ExecutionSpace, HandleImpl, AMatrix_Internal, XVector_Internal,
             YVector_Internal, false>::spmv_bsrmatrix(space, handle, mode, alpha,
                                                      A_i, x_i, beta, y_i);
         Kokkos::Profiling::popRegion();
       } else {
-        Experimental::Impl::SPMV_BSRMATRIX<
+        Impl::SPMV_BSRMATRIX<
             ExecutionSpace, HandleImpl, AMatrix_Internal, XVector_Internal,
             YVector_Internal>::spmv_bsrmatrix(space, handle, mode, alpha, A_i,
                                               x_i, beta, y_i);

--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -377,7 +377,7 @@ void spmv(const ExecutionSpace& space, Handle* handle, const char mode[],
                 typename AMatrix_Internal::non_const_value_type>::name() +
             "]";
         Kokkos::Profiling::pushRegion(label);
-        Experimental::Impl::SPMV_MV_BSRMATRIX<
+        Impl::SPMV_MV_BSRMATRIX<
             ExecutionSpace, HandleImpl, AMatrix_Internal, XVector_Internal,
             YVector_Internal,
             std::is_integral<
@@ -386,7 +386,7 @@ void spmv(const ExecutionSpace& space, Handle* handle, const char mode[],
                                       beta, y_i);
         Kokkos::Profiling::popRegion();
       } else {
-        Experimental::Impl::SPMV_MV_BSRMATRIX<
+        Impl::SPMV_MV_BSRMATRIX<
             ExecutionSpace, HandleImpl, AMatrix_Internal, XVector_Internal,
             YVector_Internal,
             std::is_integral<typename AMatrix_Internal::const_value_type>::

--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -337,16 +337,17 @@ void spmv(const ExecutionSpace& space, Handle* handle, const char mode[],
                 typename AMatrix_Internal::non_const_value_type>::name() +
             "]";
         Kokkos::Profiling::pushRegion(label);
-        Impl::SPMV_BSRMATRIX<
-            ExecutionSpace, HandleImpl, AMatrix_Internal, XVector_Internal,
-            YVector_Internal, false>::spmv_bsrmatrix(space, handle, mode, alpha,
-                                                     A_i, x_i, beta, y_i);
+        Impl::SPMV_BSRMATRIX<ExecutionSpace, HandleImpl, AMatrix_Internal,
+                             XVector_Internal, YVector_Internal,
+                             false>::spmv_bsrmatrix(space, handle, mode, alpha,
+                                                    A_i, x_i, beta, y_i);
         Kokkos::Profiling::popRegion();
       } else {
-        Impl::SPMV_BSRMATRIX<
-            ExecutionSpace, HandleImpl, AMatrix_Internal, XVector_Internal,
-            YVector_Internal>::spmv_bsrmatrix(space, handle, mode, alpha, A_i,
-                                              x_i, beta, y_i);
+        Impl::SPMV_BSRMATRIX<ExecutionSpace, HandleImpl, AMatrix_Internal,
+                             XVector_Internal,
+                             YVector_Internal>::spmv_bsrmatrix(space, handle,
+                                                               mode, alpha, A_i,
+                                                               x_i, beta, y_i);
       }
     } else {
       /////////////////

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_avail.hpp
@@ -22,7 +22,6 @@
 #endif
 
 namespace KokkosSparse {
-namespace Experimental {
 namespace Impl {
 // Specialization struct which defines whether a specialization exists
 template <class ExecutionSpace, class Handle, class AMatrix, class XVector,
@@ -348,7 +347,6 @@ KOKKOSSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_ROCSPARSE(Kokkos::complex<double>,
 #endif  // defined(KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE)
 
 }  // namespace Impl
-}  // namespace Experimental
 }  // namespace KokkosSparse
 
 #endif  // KOKKOSPARSE_SPMV_BSRMATRIX_TPL_SPEC_AVAIL_HPP_

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
@@ -26,12 +26,9 @@
 #include <mkl.h>
 
 namespace KokkosSparse {
-namespace Experimental {
 namespace Impl {
 
 // MKL 2018 and above: use new interface: sparse_matrix_t and mkl_sparse_?_mv()
-
-using KokkosSparse::Impl::mode_kk_to_mkl;
 
 // Note: Scalar here is the Kokkos type, not the MKL type
 template <typename Scalar, typename Handle>
@@ -338,7 +335,6 @@ KOKKOSSPARSE_SPMV_MV_MKL(Kokkos::complex<double>, Kokkos::OpenMP,
 #undef KOKKOSSPARSE_SPMV_MV_MKL
 
 }  // namespace Impl
-}  // namespace Experimental
 }  // namespace KokkosSparse
 
 #endif  // defined(KOKKOSKERNELS_ENABLE_TPL_MKL) && (__INTEL_MKL__ > 2017)

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
@@ -355,7 +355,6 @@ KOKKOSSPARSE_SPMV_MV_MKL(Kokkos::complex<double>, Kokkos::OpenMP,
 #include "KokkosSparse_Utils_cusparse.hpp"
 
 namespace KokkosSparse {
-namespace Experimental {
 namespace Impl {
 
 template <class Handle, class AMatrix, class XVector, class YVector>
@@ -761,7 +760,6 @@ KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<float>, int, int,
 #undef KOKKOSSPARSE_SPMV_MV_CUSPARSE
 
 }  // namespace Impl
-}  // namespace Experimental
 }  // namespace KokkosSparse
 #endif  // (9000 <= CUDA_VERSION)
 
@@ -777,7 +775,6 @@ KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<float>, int, int,
 #include "KokkosSparse_Utils_rocsparse.hpp"
 
 namespace KokkosSparse {
-namespace Experimental {
 namespace Impl {
 
 template <class Handle, class AMatrix, class XVector, class YVector>
@@ -1097,7 +1094,6 @@ KOKKOSSPARSE_SPMV_ROCSPARSE(Kokkos::complex<double>, rocsparse_int,
 #undef KOKKOSSPARSE_SPMV_ROCSPARSE
 
 }  // namespace Impl
-}  // namespace Experimental
 }  // namespace KokkosSparse
 
 #endif  // defined(KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE)


### PR DESCRIPTION
@maartenarnst
Moving the macro outside of namespaces to ensure that it will be interpreted correctly when called from any other location in the library.

It does not make much sense to guard Impl code in the Experimental namespace and in this case it cleans up a problem with namespace disambiguation for the compiler...

This PR now supersedes PR #2100 which will be closed when this one gets merged.