### PR TITLE
Benchmark: modifying spmv benchmark to fix interface and run range of spmv tests

### DIFF
--- a/perf_test/sparse/KokkosSparse_spmv_benchmark.cpp
+++ b/perf_test/sparse/KokkosSparse_spmv_benchmark.cpp
@@ -35,13 +35,20 @@
 namespace {
 
 struct spmv_parameters {
-  int N, offset;
+  int N, offset, numvecs;
+  std::string mode;
   std::string filename;
   std::string alg;
   std::string tpl;
 
   spmv_parameters(const int N_)
-      : N(N_), offset(0), filename(""), alg(""), tpl("") {}
+      : N(N_),
+        offset(0),
+        numvecs(1),
+        mode(""),
+        filename(""),
+        alg(""),
+        tpl("") {}
 };
 
 void print_options() {
@@ -49,9 +56,11 @@ void print_options() {
 
   std::cerr << perf_test::list_common_options();
 
-  std::cerr
-      << "\t[Optional] --repeat      :: how many times to repeat overall test"
-      << std::endl;
+  std::cerr << "\t[Optional] --mode        :: whether to run a suite of "
+            << "automated test or manually define one (auto, manual)"
+            << std::endl;
+  std::cerr << "\t[Optional] --repeat      :: how many times to repeat overall "
+            << "test" << std::endl;
   std::cerr << "  -n [N]          :: generate a semi-random banded (band size "
                "0.01xN)\n"
                "NxN matrix with average of 10 entries per row."
@@ -59,24 +68,29 @@ void print_options() {
   std::cerr << "\t[Optional] --alg           :: the algorithm to run (default, "
                "native, merge)"
             << std::endl;
-  std::cerr
-      << "\t[Optional] --alg           :: the algorithm to run (classic, merge)"
-      << std::endl;
   std::cerr << "\t[Optional] --TPL       :: when available and compatible with "
                "alg, a TPL can be used (cusparse, rocsparse, MKL)"
             << std::endl;
-  std::cerr
-      << "  -f [file]       : Read in Matrix Market formatted text file 'file'."
-      << std::endl;
+  std::cerr << "  -f [file]       : Read in Matrix Market formatted text file"
+            << " 'file'." << std::endl;
   std::cerr << "  --offset [O]    : Subtract O from every index.\n"
             << "                    Useful in case the matrix market file is "
                "not 0 based."
+            << std::endl;
+  std::cerr << "  --num_vecs      : The number of vectors stored in X and Y"
             << std::endl;
 }  // print_options
 
 void parse_inputs(int argc, char** argv, spmv_parameters& params) {
   for (int i = 1; i < argc; ++i) {
     if (perf_test::check_arg_int(i, argc, argv, "-n", params.N)) {
+      ++i;
+    } else if (perf_test::check_arg_str(i, argc, argv, "--mode", params.alg)) {
+      if ((params.mode != "") && (params.mode != "auto") &&
+          (params.alg != "manual")) {
+        throw std::runtime_error(
+            "--mode can only be an empty string, `auto` or `manual`!");
+      }
       ++i;
     } else if (perf_test::check_arg_str(i, argc, argv, "--alg", params.alg)) {
       if ((params.alg != "") && (params.alg != "default") &&
@@ -93,6 +107,9 @@ void parse_inputs(int argc, char** argv, spmv_parameters& params) {
     } else if (perf_test::check_arg_int(i, argc, argv, "--offset",
                                         params.offset)) {
       ++i;
+    } else if (perf_test::check_arg_int(i, argc, argv, "--num_vecs",
+                                        params.numvecs)) {
+      ++i;
     } else {
       print_options();
       KK_USER_REQUIRE_MSG(false, "Unrecognized command line argument #"
@@ -105,13 +122,21 @@ template <class execution_space>
 void run_spmv(benchmark::State& state, const spmv_parameters& inputs) {
   using matrix_type =
       KokkosSparse::CrsMatrix<double, int, execution_space, void, int>;
-  using mv_type = Kokkos::View<double*, execution_space>;
+  using mv_type = Kokkos::View<double**, execution_space>;
+  using handle_t =
+      KokkosSparse::SPMVHandle<execution_space, matrix_type, mv_type, mv_type>;
 
-  KokkosKernels::Experimental::Controls controls;
-  if ((inputs.alg == "default") || (inputs.alg == "native") ||
-      (inputs.alg == "merge")) {
-    controls.setParameter("algorithm", inputs.alg);
+  KokkosSparse::SPMVAlgorithm spmv_alg;
+  if ((inputs.alg == "default") || (inputs.alg == "")) {
+    spmv_alg = KokkosSparse::SPMVAlgorithm::SPMV_DEFAULT;
+  } else if (inputs.alg == "native") {
+    spmv_alg = KokkosSparse::SPMVAlgorithm::SPMV_NATIVE;
+  } else if (inputs.alg == "merge") {
+    spmv_alg = KokkosSparse::SPMVAlgorithm::SPMV_MERGE_PATH;
+  } else {
+    throw std::runtime_error("invalid spmv algorithm");
   }
+  handle_t handle(spmv_alg);
 
   // Create test matrix
   srand(17312837);
@@ -126,8 +151,8 @@ void run_spmv(benchmark::State& state, const spmv_parameters& inputs) {
   }
 
   // Create input vectors
-  mv_type x("X", A.numRows());
-  mv_type y("Y", A.numCols());
+  mv_type x("X", A.numRows(), inputs.numvecs);
+  mv_type y("Y", A.numCols(), inputs.numvecs);
 
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
   Kokkos::fill_random(x, rand_pool, 10);
@@ -136,7 +161,7 @@ void run_spmv(benchmark::State& state, const spmv_parameters& inputs) {
 
   // Run the actual experiments
   for (auto _ : state) {
-    KokkosSparse::spmv(controls, KokkosSparse::NoTranspose, 1.0, A, x, 0.0, y);
+    KokkosSparse::spmv(&handle, KokkosSparse::NoTranspose, 1.0, A, x, 0.0, y);
     Kokkos::fence();
   }
 }
@@ -159,12 +184,25 @@ int main(int argc, char** argv) {
   spmv_parameters inputs(100000);
   parse_inputs(argc, argv, inputs);
 
-  // Google benchmark will report the wrong n if an input file matrix is used.
-  KokkosKernelsBenchmark::register_benchmark_real_time(
-      bench_name.c_str(), run_spmv<Kokkos::DefaultExecutionSpace>, {"n"},
-      {inputs.N}, common_params.repeat, inputs);
-  benchmark::RunSpecifiedBenchmarks();
+  if ((inputs.mode == "") || (inputs.mode == "auto")) {
+    for (int n : {10000, 20000, 40000, 100000, 250000, 1000000}) {
+      for (int nv : {1, 2, 3, 4, 10}) {
+        inputs.N       = n;
+        inputs.numvecs = nv;
+        KokkosKernelsBenchmark::register_benchmark_real_time(
+            bench_name.c_str(), run_spmv<Kokkos::DefaultExecutionSpace>,
+            {"n", "nv"}, {inputs.N, inputs.numvecs}, common_params.repeat,
+            inputs);
+      }
+    }
+  } else {
+    // Google benchmark will report the wrong n if an input file matrix is used.
+    KokkosKernelsBenchmark::register_benchmark_real_time(
+        bench_name.c_str(), run_spmv<Kokkos::DefaultExecutionSpace>, {"n"},
+        {inputs.N}, common_params.repeat, inputs);
+  }
 
+  benchmark::RunSpecifiedBenchmarks();
   benchmark::Shutdown();
   Kokkos::finalize();
 


### PR DESCRIPTION
First we need to update the interface so that the spmv function uses the new handle and not the control structure.
Second adding a new option: --mode, if set to "" or "auto" the benchmark will run autonomously a suite of tests, if set to "manual", the benchmark is driven by the user.