### PR TITLE
Fix usage of RAII to set cusparse/rocsparse stream

### DIFF
--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
@@ -377,7 +377,7 @@ void spmv_bsr_cusparse(const Kokkos::Cuda& exec, Handle* handle,
   cusparseHandle_t cusparseHandle =
       KokkosKernels::Impl::CusparseSingleton::singleton().cusparseHandle;
   /* Set cuSPARSE to use the given stream until this function exits */
-  KokkosSparse::Impl::TemporarySetCusparseStream(cusparseHandle, exec);
+  KokkosSparse::Impl::TemporarySetCusparseStream tscs(cusparseHandle, exec);
 
   /* Set the operation mode */
   cusparseOperation_t myCusparseOperation;
@@ -492,7 +492,7 @@ void spmv_mv_bsr_cusparse(const Kokkos::Cuda& exec, Handle* handle,
   cusparseHandle_t cusparseHandle =
       KokkosKernels::Impl::CusparseSingleton::singleton().cusparseHandle;
   /* Set cuSPARSE to use the given stream until this function exits */
-  KokkosSparse::Impl::TemporarySetCusparseStream(cusparseHandle, exec);
+  KokkosSparse::Impl::TemporarySetCusparseStream tscs(cusparseHandle, exec);
 
   /* Set the operation mode */
   cusparseOperation_t myCusparseOperation;

--- a/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
@@ -111,7 +111,7 @@ void spmv_mv_cusparse(const Kokkos::Cuda &exec, Handle *handle,
   cusparseHandle_t cusparseHandle =
       KokkosKernels::Impl::CusparseSingleton::singleton().cusparseHandle;
   /* Set cuSPARSE to use the given stream until this function exits */
-  TemporarySetCusparseStream(cusparseHandle, exec);
+  TemporarySetCusparseStream tscs(cusparseHandle, exec);
 
   /* Check that cusparse can handle the types of the input Kokkos::CrsMatrix */
   const cusparseIndexType_t myCusparseOffsetType =

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -41,7 +41,7 @@ void spmv_cusparse(const Kokkos::Cuda& exec, Handle* handle, const char mode[],
   cusparseHandle_t cusparseHandle =
       KokkosKernels::Impl::CusparseSingleton::singleton().cusparseHandle;
   /* Set cuSPARSE to use the given stream until this function exits */
-  TemporarySetCusparseStream(cusparseHandle, exec);
+  TemporarySetCusparseStream tscs(cusparseHandle, exec);
 
   /* Set the operation mode */
   cusparseOperation_t myCusparseOperation;
@@ -389,7 +389,7 @@ void spmv_rocsparse(const Kokkos::HIP& exec, Handle* handle, const char mode[],
   rocsparse_handle rocsparseHandle =
       KokkosKernels::Impl::RocsparseSingleton::singleton().rocsparseHandle;
   /* Set rocsparse to use the given stream until this function exits */
-  TemporarySetRocsparseStream(rocsparseHandle, exec);
+  TemporarySetRocsparseStream tsrs(rocsparseHandle, exec);
 
   /* Set the operation mode */
   rocsparse_operation myRocsparseOperation = mode_kk_to_rocsparse(mode);


### PR DESCRIPTION
Fix usage of RAII to temporarily set the stream for rocsparse, cusparse spmv.

Temporary objects like ``A();`` get destructed immediately. For the object to have scope lifetime, it needs to be a declaration like ``A a();``. This was causing spmv to always execute on the default stream, so there was incorrect timing in the spmv perf test. It only fenced the stream corresponding to default-constructed space instance, which is not necessarily the same.

@kliegeois This is why changing to ``Kokkos::fence()`` instead of ``exec.fence()`` fixed the timings yesterday.

This should definitely be included in 4.3