### PR TITLE
KokkosKernels Utils: cleaning the zero_vector interface

### DIFF
--- a/common/src/KokkosKernels_Utils.hpp
+++ b/common/src/KokkosKernels_Utils.hpp
@@ -890,7 +890,7 @@ void permute_block_vector(typename idx_array_type::value_type num_elements,
 // TODO BMK: clean this up by removing 1st argument. It is unused but
 // its name gives the impression that only num_elements of the vector are
 // zeroed, when really it's always the whole thing.
-template <class ExecSpaceIn, typename value_array_type, typename MyExecSpace>
+template <class ExecSpaceIn, typename value_array_type>
 void zero_vector(ExecSpaceIn &exec_space_in,
                  typename value_array_type::value_type /* num_elements */,
                  value_array_type &vector) {
@@ -906,8 +906,7 @@ void zero_vector(typename value_array_type::value_type /* num_elements */,
   using ne_tmp_t  = typename value_array_type::value_type;
   ne_tmp_t ne_tmp = ne_tmp_t(0);
   MyExecSpace my_exec_space;
-  zero_vector<MyExecSpace, value_array_type, MyExecSpace>(my_exec_space, ne_tmp,
-                                                          vector);
+  zero_vector(my_exec_space, ne_tmp, vector);
 }
 
 template <typename v1, typename v2, typename v3>

--- a/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
+++ b/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
@@ -1548,7 +1548,7 @@ class PointGaussSeidel {
     }
     if (init_zero_x_vector) {
       KokkosKernels::Impl::zero_vector<
-          MyExecSpace, scalar_persistent_work_view2d_t, MyExecSpace>(
+          MyExecSpace, scalar_persistent_work_view2d_t>(
           my_exec_space, num_cols * block_size, Permuted_Xvector);
     } else {
       KokkosKernels::Impl::permute_block_vector<
@@ -1665,7 +1665,7 @@ class PointGaussSeidel {
     }
     if (init_zero_x_vector) {
       KokkosKernels::Impl::zero_vector<
-          MyExecSpace, scalar_persistent_work_view2d_t, MyExecSpace>(
+          MyExecSpace, scalar_persistent_work_view2d_t>(
           my_exec_space, num_cols, Permuted_Xvector);
     } else {
       KokkosKernels::Impl::permute_vector<

--- a/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
+++ b/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
@@ -1547,8 +1547,8 @@ class PointGaussSeidel {
           Permuted_Yvector);
     }
     if (init_zero_x_vector) {
-      KokkosKernels::Impl::zero_vector<
-          MyExecSpace, scalar_persistent_work_view2d_t>(
+      KokkosKernels::Impl::zero_vector<MyExecSpace,
+                                       scalar_persistent_work_view2d_t>(
           my_exec_space, num_cols * block_size, Permuted_Xvector);
     } else {
       KokkosKernels::Impl::permute_block_vector<
@@ -1664,8 +1664,8 @@ class PointGaussSeidel {
           Permuted_Yvector);
     }
     if (init_zero_x_vector) {
-      KokkosKernels::Impl::zero_vector<
-          MyExecSpace, scalar_persistent_work_view2d_t>(
+      KokkosKernels::Impl::zero_vector<MyExecSpace,
+                                       scalar_persistent_work_view2d_t>(
           my_exec_space, num_cols, Permuted_Xvector);
     } else {
       KokkosKernels::Impl::permute_vector<


### PR DESCRIPTION
One of the overload requires an unused template, removing that extraneous template and simplify how that function is called in a second overload.
@ndellingwood  We could add that in the release branch eventually?