### PR TITLE
Use default_size_type as default offset in matrix types

### DIFF
--- a/sparse/src/KokkosSparse_BsrMatrix.hpp
+++ b/sparse/src/KokkosSparse_BsrMatrix.hpp
@@ -34,6 +34,7 @@
 #include "Kokkos_ArithTraits.hpp"
 #include "KokkosSparse_CrsMatrix.hpp"
 #include "KokkosKernels_Error.hpp"
+#include "KokkosKernels_default_types.hpp"
 
 namespace KokkosSparse {
 
@@ -325,9 +326,7 @@ struct BsrRowViewConst {
 /// storage for sparse matrices, as described, for example, in Saad
 /// (2nd ed.).
 template <class ScalarType, class OrdinalType, class Device,
-          class MemoryTraits = void,
-          class SizeType     = typename Kokkos::ViewTraits<OrdinalType*, Device,
-                                                       void, void>::size_type>
+          class MemoryTraits = void, class SizeType = default_size_type>
 class BsrMatrix {
   static_assert(
       std::is_signed<OrdinalType>::value,

--- a/sparse/src/KokkosSparse_CrsMatrix.hpp
+++ b/sparse/src/KokkosSparse_CrsMatrix.hpp
@@ -339,9 +339,7 @@ struct SparseRowViewConst {
 /// storage for sparse matrices, as described, for example, in Saad
 /// (2nd ed.).
 template <class ScalarType, class OrdinalType, class Device,
-          class MemoryTraits = void,
-          class SizeType     = typename Kokkos::ViewTraits<OrdinalType*, Device,
-                                                       void, void>::size_type>
+          class MemoryTraits = void, class SizeType = default_size_type>
 class CrsMatrix {
   static_assert(
       std::is_signed<OrdinalType>::value,

--- a/sparse/src/KokkosSparse_ccs2crs.hpp
+++ b/sparse/src/KokkosSparse_ccs2crs.hpp
@@ -102,6 +102,14 @@ template <class OrdinalType, class SizeType, class ValViewType,
           class ColMapViewType, class RowIdViewType>
 auto ccs2crs(OrdinalType nrows, OrdinalType ncols, SizeType nnz,
              ValViewType vals, ColMapViewType col_map, RowIdViewType row_ids) {
+  static_assert(
+      std::is_same_v<SizeType, typename ColMapViewType::non_const_value_type>,
+      "ccs2crs: SizeType (type of nnz) must match the element type of "
+      "ColMapViewType");
+  static_assert(
+      std::is_same_v<OrdinalType, typename RowIdViewType::non_const_value_type>,
+      "ccs2crs: OrdinalType (type of nrows, ncols) must match the element type "
+      "of RowIdViewType");
   using Ccs2crsType = Impl::Ccs2Crs<OrdinalType, SizeType, ValViewType,
                                     ColMapViewType, RowIdViewType>;
   Ccs2crsType ccs2Crs(nrows, ncols, nnz, vals, col_map, row_ids);

--- a/sparse/src/KokkosSparse_crs2ccs.hpp
+++ b/sparse/src/KokkosSparse_crs2ccs.hpp
@@ -100,6 +100,14 @@ template <class OrdinalType, class SizeType, class ValViewType,
           class RowMapViewType, class ColIdViewType>
 auto crs2ccs(OrdinalType nrows, OrdinalType ncols, SizeType nnz,
              ValViewType vals, RowMapViewType row_map, ColIdViewType col_ids) {
+  static_assert(
+      std::is_same_v<SizeType, typename RowMapViewType::non_const_value_type>,
+      "crs2ccs: SizeType (type of nnz) must match the element type of "
+      "RowMapViewType");
+  static_assert(
+      std::is_same_v<OrdinalType, typename ColIdViewType::non_const_value_type>,
+      "crs2ccs: OrdinalType (type of nrows, ncols) must match the element type "
+      "of ColIdViewType");
   using Crs2ccsType = Impl::Crs2Ccs<OrdinalType, SizeType, ValViewType,
                                     RowMapViewType, ColIdViewType>;
   Crs2ccsType crs2Ccs(nrows, ncols, nnz, vals, row_map, col_ids);

--- a/sparse/src/KokkosSparse_crs2coo.hpp
+++ b/sparse/src/KokkosSparse_crs2coo.hpp
@@ -134,6 +134,14 @@ template <class OrdinalType, class SizeType, class ValViewType,
           class RowMapViewType, class ColIdViewType>
 auto crs2coo(OrdinalType nrows, OrdinalType ncols, SizeType nnz,
              ValViewType vals, RowMapViewType row_map, ColIdViewType col_ids) {
+  static_assert(
+      std::is_same_v<SizeType, typename RowMapViewType::non_const_value_type>,
+      "crs2coo: SizeType (type of nnz) must match the element type of "
+      "RowMapViewType");
+  static_assert(
+      std::is_same_v<OrdinalType, typename ColIdViewType::non_const_value_type>,
+      "crs2coo: OrdinalType (type of nrows, ncols) must match the element type "
+      "of ColIdViewType");
   using Crs2cooType = Impl::Crs2Coo<OrdinalType, SizeType, ValViewType,
                                     RowMapViewType, ColIdViewType>;
   Crs2cooType crs2Coo(nrows, ncols, nnz, vals, row_map, col_ids);

--- a/sparse/unit_test/Test_Sparse_TestUtils_RandCsMat.hpp
+++ b/sparse/unit_test/Test_Sparse_TestUtils_RandCsMat.hpp
@@ -19,11 +19,13 @@
 namespace Test {
 template <class ScalarType, class LayoutType, class ExeSpaceType>
 void doCsMat(size_t m, size_t n, ScalarType min_val, ScalarType max_val) {
+  using RandCs        = RandCsMatrix<ScalarType, LayoutType, ExeSpaceType>;
+  using size_type     = typename RandCs::size_type;
   auto expected_min   = ScalarType(1.0);
   size_t expected_nnz = 0;
-  RandCsMatrix<ScalarType, LayoutType, ExeSpaceType> cm(m, n, min_val, max_val);
+  RandCs cm(m, n, min_val, max_val);
 
-  for (size_t i = 0; i < cm.get_nnz(); ++i)
+  for (size_type i = 0; i < cm.get_nnz(); ++i)
     ASSERT_GE(cm(i), expected_min) << cm.info;
 
   auto map_d = cm.get_map();

--- a/sparse/unit_test/Test_Sparse_spmv_bsr.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv_bsr.hpp
@@ -134,9 +134,9 @@ Bsr bsr_random(const int blockSize, const int blockRows, const int blockCols) {
       rcs(blockRows, blockCols, scalar_type(0), max_a<scalar_type>());
 
   const auto colids = Kokkos::subview(
-      rcs.get_ids(), Kokkos::make_pair(size_t(0), rcs.get_nnz()));
+      rcs.get_ids(), Kokkos::make_pair(size_type(0), rcs.get_nnz()));
   const auto vals = Kokkos::subview(
-      rcs.get_vals(), Kokkos::make_pair(size_t(0), rcs.get_nnz()));
+      rcs.get_vals(), Kokkos::make_pair(size_type(0), rcs.get_nnz()));
   Graph graph(colids, rcs.get_map());
   Crs crs("crs", blockCols, vals, graph);
 

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -643,9 +643,7 @@ class RandCooMat {
 /// \tparam LayoutType
 /// \tparam Device
 template <class ScalarType, class LayoutType, class Device,
-          typename Ordinal = int64_t,
-          typename Size    = typename Kokkos::ViewTraits<Ordinal*, Device, void,
-                                                      void>::size_type>
+          typename Ordinal = int64_t, typename Size = default_size_type>
 class RandCsMatrix {
  public:
   using value_type   = ScalarType;
@@ -765,7 +763,7 @@ class RandCsMatrix {
 
   // O(c), where c is a constant.
   ScalarType operator()(Size idx) { return __vals(idx); }
-  size_t get_nnz() { return size_t(__nnz); }
+  Size get_nnz() { return __nnz; }
   // dimension2: This is either columns for a Crs matrix or rows for a Ccs
   // matrix.
   Ordinal get_dim2() { return __dim2; }


### PR DESCRIPTION
Now a matrix with offset unspecified (like ``CrsMatrix<Scalar, Ordinal, Device>``) will by default always use an ETI'd type combination.

Before the default offset would be the view's size_type, but this could be either size_t or unsigned int.