### PR TITLE
Fix signed/unsigned comparison warning

### DIFF
--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -349,7 +349,7 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector,
                                 const YScalar &beta, const YVector &Y) {
     static_assert(std::is_integral_v<typename AMatrix::non_const_value_type>,
                   "This implementation is only for integer Scalar types.");
-    for (typename AMatrix::non_const_size_type j = 0; j < X.extent(1); ++j) {
+    for (size_t j = 0; j < X.extent(1); ++j) {
       const auto x_j = Kokkos::subview(X, Kokkos::ALL(), j);
       auto y_j       = Kokkos::subview(Y, Kokkos::ALL(), j);
       typedef SPMV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, decltype(x_j),

--- a/sparse/impl/KokkosSparse_spmv_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_spec.hpp
@@ -268,7 +268,7 @@ struct SPMV_MV<ExecutionSpace, Handle, AMatrix, XVector, YVector, true, false,
     static_assert(std::is_integral_v<typename AMatrix::non_const_value_type>,
                   "This implementation is only for integer Scalar types.");
     KokkosKernels::Experimental::Controls defaultControls;
-    for (typename AMatrix::non_const_size_type j = 0; j < x.extent(1); ++j) {
+    for (size_t j = 0; j < x.extent(1); ++j) {
       auto x_j = Kokkos::subview(x, Kokkos::ALL(), j);
       auto y_j = Kokkos::subview(y, Kokkos::ALL(), j);
       typedef SPMV<ExecutionSpace, Handle, AMatrix, decltype(x_j),


### PR DESCRIPTION
This is only hit when spmv is called with integer scalars, which doesn't happen in our CI but does in Tpetra's default ETI.

@ndellingwood This is not critical as Trilinos doesn't build with ``-Werror``, and it's been there a while, but it would still be nice for 4.3