### PR TITLE
SPMV tpl fixes, cusparse workaround

### DIFF
--- a/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_avail.hpp
@@ -52,7 +52,11 @@ non-transpose that produces incorrect result. This is cusparse distributed with
 CUDA 10.1.243. The bug seems to be resolved by CUSPARSE 10301 (present by
 CUDA 10.2.89) */
 
-/* cusparseSpMM also produces incorrect results in some cases for CUDA 11.6.1 */
+/* cusparseSpMM also produces incorrect results for some inputs in CUDA 11.6.1.
+ * (CUSPARSE_VERSION 11702).
+ * ALG1 and ALG3 produce completely incorrect results for one set of inputs.
+ * ALG2 works for that case, but has low numerical accuracy in another case.
+ */
 #if defined(CUSPARSE_VERSION) && (10301 <= CUSPARSE_VERSION) && \
     (CUSPARSE_VERSION != 11702)
 KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(double, int, int,

--- a/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_avail.hpp
@@ -51,7 +51,10 @@ struct spmv_mv_tpl_spec_avail {
 non-transpose that produces incorrect result. This is cusparse distributed with
 CUDA 10.1.243. The bug seems to be resolved by CUSPARSE 10301 (present by
 CUDA 10.2.89) */
-#if defined(CUSPARSE_VERSION) && (10301 <= CUSPARSE_VERSION)
+
+/* cusparseSpMM also produces incorrect results in some cases for CUDA 11.6.1 */
+#if defined(CUSPARSE_VERSION) && (10301 <= CUSPARSE_VERSION) && \
+    (CUSPARSE_VERSION != 11702)
 KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(double, int, int,
                                              Kokkos::LayoutLeft,
                                              Kokkos::LayoutLeft,

--- a/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
@@ -72,9 +72,9 @@ cusparseDnMatDescr_t make_cusparse_dn_mat_descr_t(ViewType &view) {
   // swapped
   bool transpose =
       std::is_same_v<typename ViewType::array_layout, Kokkos::LayoutRight>;
-  const int64_t rows = transpose ? view.extent(1) : view.extent(0);
-  const int64_t cols = transpose ? view.extent(0) : view.extent(1);
-  const int64_t ld   = transpose ? view.stride(0) : view.stride(1);
+  const size_t rows = transpose ? view.extent(1) : view.extent(0);
+  const size_t cols = transpose ? view.extent(0) : view.extent(1);
+  const size_t ld   = transpose ? view.stride(0) : view.stride(1);
 
   // cusparseCreateCsr notes it is safe to const_cast this away for input
   // pointers to a descriptor as long as that descriptor is not an output
@@ -92,8 +92,9 @@ cusparseDnMatDescr_t make_cusparse_dn_mat_descr_t(ViewType &view) {
   const cusparseOrder_t order = CUSPARSE_ORDER_COL;
 
   cusparseDnMatDescr_t descr;
-  KOKKOS_CUSPARSE_SAFE_CALL(
-      cusparseCreateDnMat(&descr, rows, cols, ld, values, valueType, order));
+  KOKKOS_CUSPARSE_SAFE_CALL(cusparseCreateDnMat(
+      &descr, static_cast<int64_t>(rows), static_cast<int64_t>(cols),
+      static_cast<int64_t>(ld), values, valueType, order));
 
   return descr;
 }


### PR DESCRIPTION
- Don't use ``cusparseSpMM`` on CUDA 11.6.1 (aka CUSPARSE_VERSION 11702) because it produces incorrect results for a tiny (2x3) matrix
  - This specific case appears in a Tpetra CrsMatrix unit test
  - Add a test that replicates this
  - Had to change spmv_mv test function a little bit to allow nonsquare matrices
  - Reported the issue, seems to be a corner case with very small inputs, will re-enable the TPL for larger inputs if we find out for certain that it works
- In spmv_mv cusparse wrapper:
  - fix leading dimension (stride) of dense matrix
  - fix dimensions and stride of dense matrix for LayoutRight case, in which the X vector is implicitly transposed
  - add a test for this case (only for eti-only off)