### PR TITLE
KokkosBlas1_axpby.hpp: change debug macro guard for printInformation

### DIFF
--- a/blas/impl/KokkosBlas1_axpby_unification_attempt_traits.hpp
+++ b/blas/impl/KokkosBlas1_axpby_unification_attempt_traits.hpp
@@ -768,7 +768,7 @@ struct AxpbyUnificationAttemptTraits {
   // ********************************************************************
   // Routine to print information on input variables and internal variables
   // ********************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
   static void printInformation(std::ostream& os, std::string const& headerMsg) {
     os << headerMsg << ": AV = "
        << typeid(AV).name()

--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -17,9 +17,9 @@
 #ifndef KOKKOSBLAS1_AXPBY_HPP_
 #define KOKKOSBLAS1_AXPBY_HPP_
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
 #include <iostream>
-#endif
+#endif  // KOKKOSKERNELS_DEBUG_LEVEL
 
 #include <KokkosBlas1_axpby_spec.hpp>
 #include <KokkosBlas_serial_axpy.hpp>
@@ -73,9 +73,9 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X,
   // Perform compile time checks and run time checks.
   // **********************************************************************
   AxpbyTraits::performChecks(a, X, b, Y);
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
   AxpbyTraits::printInformation(std::cout, "axpby(), unif information");
-#endif
+#endif  // KOKKOSKERNELS_DEBUG_LEVEL
 
   // **********************************************************************
   // Call Impl::Axpby<...>::axpby(...)


### PR DESCRIPTION
- resolves test failures in Trilinos (MueLu) that rely on gold file diff comparisons by removing extra output in debug builds