### PR TITLE
Fix #2156

### DIFF
--- a/sparse/src/KokkosSparse_spmv_handle.hpp
+++ b/sparse/src/KokkosSparse_spmv_handle.hpp
@@ -237,9 +237,8 @@ struct SPMVHandleImpl {
   ~SPMVHandleImpl() {
     if (tpl) delete tpl;
   }
-  void set_exec_space(const ExecutionSpace& exec) {
-    if (tpl) tpl->set_exec_space(exec);
-  }
+
+  ImplType* get_impl() { return this; }
 
   /// Get the SPMVAlgorithm used by this handle
   SPMVAlgorithm get_algorithm() const { return this->algo; }

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
@@ -48,6 +48,7 @@ inline void spmv_bsr_mkl(Handle* handle, sparse_operation_t op, Scalar alpha,
     if (!subhandle)
       throw std::runtime_error(
           "KokkosSparse::spmv: subhandle is not set up for MKL BSR");
+    subhandle->set_exec_space(exec);
   } else {
     // Use the default execution space instance, as classic MKL does not use
     // a specific instance.
@@ -127,6 +128,7 @@ inline void spmv_mv_bsr_mkl(Handle* handle, sparse_operation_t op, Scalar alpha,
     if (!subhandle)
       throw std::runtime_error(
           "KokkosSparse::spmv: subhandle is not set up for MKL BSR");
+    subhandle->set_exec_space(exec);
   } else {
     // Use the default execution space instance, as classic MKL does not use
     // a specific instance.
@@ -378,6 +380,7 @@ void spmv_bsr_cusparse(const Kokkos::Cuda& exec, Handle* handle,
     if (!subhandle)
       throw std::runtime_error(
           "KokkosSparse::spmv: subhandle is not set up for cusparse");
+    subhandle->set_exec_space(exec);
   } else {
     /* create and set the subhandle and matrix descriptor */
     subhandle   = new KokkosSparse::Impl::CuSparse9_SpMV_Data(exec);
@@ -505,6 +508,7 @@ void spmv_mv_bsr_cusparse(const Kokkos::Cuda& exec, Handle* handle,
     if (!subhandle)
       throw std::runtime_error(
           "KokkosSparse::spmv: subhandle is not set up for cusparse");
+    subhandle->set_exec_space(exec);
   } else {
     /* create and set the subhandle and matrix descriptor */
     subhandle   = new KokkosSparse::Impl::CuSparse9_SpMV_Data(exec);
@@ -855,6 +859,7 @@ void spmv_bsr_rocsparse(const Kokkos::HIP& exec, Handle* handle,
     if (!subhandle)
       throw std::runtime_error(
           "KokkosSparse::spmv: subhandle is not set up for rocsparse BSR");
+    subhandle->set_exec_space(exec);
   } else {
     subhandle   = new KokkosSparse::Impl::RocSparse_BSR_SpMV_Data(exec);
     handle->tpl = subhandle;

--- a/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
@@ -192,6 +192,7 @@ void spmv_mv_cusparse(const Kokkos::Cuda &exec, Handle *handle,
     if (!subhandle)
       throw std::runtime_error(
           "KokkosSparse::spmv: subhandle is not set up for cusparse");
+    subhandle->set_exec_space(exec);
   } else {
     subhandle   = new KokkosSparse::Impl::CuSparse10_SpMV_Data(exec);
     handle->tpl = subhandle;

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -111,6 +111,7 @@ void spmv_cusparse(const Kokkos::Cuda& exec, Handle* handle, const char mode[],
     if (!subhandle)
       throw std::runtime_error(
           "KokkosSparse::spmv: subhandle is not set up for cusparse");
+    subhandle->set_exec_space(exec);
   } else {
     subhandle   = new KokkosSparse::Impl::CuSparse10_SpMV_Data(exec);
     handle->tpl = subhandle;
@@ -155,6 +156,7 @@ void spmv_cusparse(const Kokkos::Cuda& exec, Handle* handle, const char mode[],
     if (!subhandle)
       throw std::runtime_error(
           "KokkosSparse::spmv: subhandle is not set up for cusparse");
+    subhandle->set_exec_space(exec);
   } else {
     /* create and set the subhandle and matrix descriptor */
     subhandle   = new KokkosSparse::Impl::CuSparse9_SpMV_Data(exec);
@@ -390,6 +392,7 @@ void spmv_rocsparse(const Kokkos::HIP& exec, Handle* handle, const char mode[],
     if (!subhandle)
       throw std::runtime_error(
           "KokkosSparse::spmv: subhandle is not set up for rocsparse CRS");
+    subhandle->set_exec_space(exec);
   } else {
     subhandle   = new KokkosSparse::Impl::RocSparse_CRS_SpMV_Data(exec);
     handle->tpl = subhandle;
@@ -550,6 +553,8 @@ inline void spmv_mkl(Handle* handle, sparse_operation_t op, Scalar alpha,
   MKLScalar* y_mkl       = reinterpret_cast<MKLScalar*>(y);
   if (handle->is_set_up) {
     subhandle = dynamic_cast<Subhandle*>(handle->tpl);
+    // note: classic mkl only runs on synchronous host exec spaces, so no need
+    // to call set_exec_space on the subhandle here
     if (!subhandle)
       throw std::runtime_error(
           "KokkosSparse::spmv: subhandle is not set up for MKL CRS");
@@ -710,6 +715,7 @@ inline void spmv_onemkl(const execution_space& exec, Handle* handle,
     if (!subhandle)
       throw std::runtime_error(
           "KokkosSparse::spmv: subhandle is not set up for OneMKL CRS");
+    subhandle->set_exec_space(exec);
   } else {
     subhandle   = new OneMKL_SpMV_Data(exec);
     handle->tpl = subhandle;


### PR DESCRIPTION
This PR does 2 things:
- spmv: add special path for rank-2 x/y, but where both have 1 column and a TPL is available for rank-1 but not rank-2.

I took this out in the spmv handle refactor because I thought it would make the handle design more difficult. But for BSR matrices on rocSPARSE - we have ``rocsparse_*bsrmv`` but there is no ``rocsparse_*bsrmm``. On MI250x, applying the sparc single_gpu problem speeds up by 35% (rocsparse vs. native). Currently this is the only case where this gets used.

- call ``subhandle->set_exec_space`` correctly in the TPLs to ensure proper synchronization between setup, spmv and cleanup. This only makes a difference in the case that different exec instances are used in different calls, but it is a bugfix because that was supposed to work in the original spmv handle refactor.