### PR TITLE
Updates from feedback runnig Trilinos testing

### DIFF
--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -73,7 +73,7 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X,
   // Perform compile time checks and run time checks.
   // **********************************************************************
   AxpbyTraits::performChecks(a, X, b, Y);
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 1)
   AxpbyTraits::printInformation(std::cout, "axpby(), unif information");
 #endif  // KOKKOSKERNELS_DEBUG_LEVEL
 

--- a/lapack/unit_test/Test_Lapack_svd.hpp
+++ b/lapack/unit_test/Test_Lapack_svd.hpp
@@ -475,7 +475,7 @@ int impl_test_svd(const int m, const int n) {
       Kokkos::View<mag_type*, typename AMatrix::array_layout, Device>;
 
   const mag_type max_val = 10;
-  const mag_type tol     = 1000 * max_val * KAT_S::eps();
+  const mag_type tol     = 2000 * max_val * KAT_S::eps();
 
   AMatrix A("A", m, n), U("U", m, m), Vt("Vt", n, n), Aref("A ref", m, n);
   vector_type S("S", Kokkos::min(m, n));


### PR DESCRIPTION
- Update debug level to > 1 guarding `printInformation(...)` in KokkosBlas1_axpby.hpp to reduce noisy test output
- Loosen tolerance of lapack.svd test to avoid random failures that occur near prior tolerance level