### PR TITLE
Don't try to use space instance in classic MKL spmv

### DIFF
--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
@@ -48,7 +48,8 @@ inline void spmv_bsr_mkl(Handle* handle, sparse_operation_t op, Scalar alpha,
     if (!subhandle)
       throw std::runtime_error(
           "KokkosSparse::spmv: subhandle is not set up for MKL BSR");
-    subhandle->set_exec_space(exec);
+    // note: classic mkl only runs on synchronous host exec spaces, so no need
+    // to call set_exec_space on the subhandle here
   } else {
     // Use the default execution space instance, as classic MKL does not use
     // a specific instance.
@@ -128,7 +129,8 @@ inline void spmv_mv_bsr_mkl(Handle* handle, sparse_operation_t op, Scalar alpha,
     if (!subhandle)
       throw std::runtime_error(
           "KokkosSparse::spmv: subhandle is not set up for MKL BSR");
-    subhandle->set_exec_space(exec);
+    // note: classic mkl only runs on synchronous host exec spaces, so no need
+    // to call set_exec_space on the subhandle here
   } else {
     // Use the default execution space instance, as classic MKL does not use
     // a specific instance.

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -553,11 +553,11 @@ inline void spmv_mkl(Handle* handle, sparse_operation_t op, Scalar alpha,
   MKLScalar* y_mkl       = reinterpret_cast<MKLScalar*>(y);
   if (handle->is_set_up) {
     subhandle = dynamic_cast<Subhandle*>(handle->tpl);
-    // note: classic mkl only runs on synchronous host exec spaces, so no need
-    // to call set_exec_space on the subhandle here
     if (!subhandle)
       throw std::runtime_error(
           "KokkosSparse::spmv: subhandle is not set up for MKL CRS");
+    // note: classic mkl only runs on synchronous host exec spaces, so no need
+    // to call set_exec_space on the subhandle here
   } else {
     // Use the default execution space instance, as classic MKL does not use
     // a specific instance.


### PR DESCRIPTION
Fix #2167.

Classic MKL only runs on synchronous host spaces (serial, openmp) so no need to set an exec space instance in the spmv handle.