### PR TITLE
KokkosLapack_svd_tpl_spec_decl: defer to MKL spec when LAPACK also enabled

### DIFF
--- a/lapack/tpls/KokkosLapack_svd_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_svd_tpl_spec_decl.hpp
@@ -41,7 +41,8 @@ inline void svd_print_specialization() {
 }  // namespace KokkosLapack
 
 // LAPACK
-#ifdef KOKKOSKERNELS_ENABLE_TPL_LAPACK
+#if defined(KOKKOSKERNELS_ENABLE_TPL_LAPACK) && \
+    !defined(KOKKOSKERNELS_ENABLE_TPL_MKL)
 #include "KokkosLapack_Host_tpl.hpp"
 
 namespace KokkosLapack {


### PR DESCRIPTION
Resolves redefintion of struct SVD compilation errors with both MKL and LAPACK are enabled
Reported by @maartenarnst in https://github.com/trilinos/Trilinos/issues/12891