### PR TITLE
magma: fix linker errors for builds without cusolver

### DIFF
--- a/batched/dense/unit_test/Test_Batched_BatchedGemm.hpp
+++ b/batched/dense/unit_test/Test_Batched_BatchedGemm.hpp
@@ -229,7 +229,11 @@ void impl_test_batched_gemm(const int N, const int matAdim1, const int matAdim2,
     ASSERT_EQ(batchedGemmHandleCublas.vecLen, 0);
 #endif
 
-#if defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA)
+    // FIXME temporary workaround to run this magma test only if cublas is not
+    // enabled the design of the BatchedGemmHandle currently does not allow
+    // simultanous testing in this way. See issue #2177
+#if defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA) && \
+    !defined(KOKKOSKERNELS_ENABLE_TPL_CUBLAS)
     magma_queue_t magma_queue;
     BatchedGemmHandle batchedGemmHandleMagma(magma_queue, GemmTplAlgos::MAGMA,
                                              0, 0);

--- a/lapack/CMakeLists.txt
+++ b/lapack/CMakeLists.txt
@@ -34,6 +34,12 @@ IF (KOKKOSKERNELS_ENABLE_TPL_CUSOLVER)
   )
 ENDIF()
 
+IF (KOKKOSKERNELS_ENABLE_TPL_MAGMA)
+  LIST(APPEND SOURCES
+   lapack/tpls/KokkosLapack_Magma_tpl.cpp
+  )
+ENDIF()
+
 ##################
 #                #
 # ETI generation #

--- a/lapack/tpls/KokkosLapack_Magma_tpl.cpp
+++ b/lapack/tpls/KokkosLapack_Magma_tpl.cpp
@@ -15,4 +15,4 @@
 //@HEADER
 #include <Kokkos_Core.hpp>
 #include <KokkosKernels_config.h>
-#include <KokkosLapack_Cuda_tpl.hpp>
+#include <KokkosLapack_Magma_tpl.hpp>


### PR DESCRIPTION
Resolve linker errors in Cuda builds with Magma enabled but Cusolver disabled. I overlooked this with #2178 (my local testing had Cusolver enabled), but was picked up in the nightly build

```
01:35:17 CMakeFiles/KokkosKernels_lapack_cuda.dir/backends/Test_Cuda_Lapack.cpp.o: In function `void KokkosLapack::Impl::magmaGesvWrapper<Kokkos::Cuda, Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, Kokkos::MemoryTraits<1u> >, Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, Kokkos::MemoryTraits<1u> >, Kokkos::View<int*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Serial, Kokkos::HostSpace>, Kokkos::MemoryTraits<1u> > >(Kokkos::Cuda const&, Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, Kokkos::MemoryTraits<1u> > const&, Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, Kokkos::MemoryTraits<1u> > const&, Kokkos::View<int*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Serial, Kokkos::HostSpace>, Kokkos::MemoryTraits<1u> > const&)':
01:35:17 tmpxft_0034f816_00000000-6_Test_Cuda_Lapack.cudafe1.cpp:(.text._ZN12KokkosLapack4Impl16magmaGesvWrapperIN6Kokkos4CudaENS2_4ViewIPPdJNS2_10LayoutLeftENS2_6DeviceIS3_NS2_9CudaSpaceEEENS2_12MemoryTraitsILj1EEEEEESD_NS4_IPiJS7_NS8_INS2_6SerialENS2_9HostSpaceEEESC_EEEEEvRKT_RKT0_RKT1_RKT2_[_ZN12KokkosLapack4Impl16magmaGesvWrapperIN6Kokkos4CudaENS2_4ViewIPPdJNS2_10LayoutLeftENS2_6DeviceIS3_NS2_9CudaSpaceEEENS2_12MemoryTraitsILj1EEEEEESD_NS4_IPiJS7_NS8_INS2_6SerialENS2_9HostSpaceEEESC_EEEEEvRKT_RKT0_RKT1_RKT2_]+0x1cc): undefined reference to `KokkosLapack::Impl::MagmaSingleton::singleton()'
01:35:17 CMakeFiles/KokkosKernels_lapack_cuda.dir/backends/Test_Cuda_Lapack.cpp.o: In function `KokkosLapack::Impl::TRTRI<Kokkos::View<int, Kokkos::LayoutRight, Kokkos::HostSpace, Kokkos::MemoryTraits<1u> >, Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, Kokkos::MemoryTraits<1u> >, true, true>::trtri(Kokkos::View<int, Kokkos::LayoutRight, Kokkos::HostSpace, Kokkos::MemoryTraits<1u> > const&, char const*, char const*, Kokkos::View<double const**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, Kokkos::MemoryTraits<1u> > const&)':
01:35:17 tmpxft_0034f816_00000000-6_Test_Cuda_Lapack.cudafe1.cpp:(.text._ZN12KokkosLapack4Impl5TRTRIIN6Kokkos4ViewIiJNS2_11LayoutRightENS2_9HostSpaceENS2_12MemoryTraitsILj1EEEEEENS3_IPPdJNS2_10LayoutLeftENS2_6DeviceINS2_4CudaENS2_9CudaSpaceEEES7_EEELb1ELb1EE5trtriERKS8_PKcSL_RKNS3_IPPKdJSB_SF_S7_EEE[_ZN12KokkosLapack4Impl5TRTRIIN6Kokkos4ViewIiJNS2_11LayoutRightENS2_9HostSpaceENS2_12MemoryTraitsILj1EEEEEENS3_IPPdJNS2_10LayoutLeftENS2_6DeviceINS2_4CudaENS2_9CudaSpaceEEES7_EEELb1ELb1EE5trtriERKS8_PKcSL_RKNS3_IPPKdJSB_SF_S7_EEE]+0x1b4): undefined reference to `KokkosLapack::Impl::MagmaSingleton::singleton()'
01:35:17 collect2: error: ld returned 1 exit status
```