### PR TITLE
Resolve vortex compilation issue by resolving (potentially) duplicate symbol

### DIFF
--- a/blas/tpls/KokkosBlas2_syr2_tpl_spec_decl_blas.hpp
+++ b/blas/tpls/KokkosBlas2_syr2_tpl_spec_decl_blas.hpp
@@ -163,7 +163,7 @@ namespace Impl {
              ETI_SPEC_AVAIL>::syr2(space, trans, uplo, alpha, X, Y, A);       \
       } else {                                                                \
         if (A_is_ll) {                                                        \
-          HostBlas<std::complex<double>>::zher2(                              \
+          HostBlas<std::complex<double>>::her2(                               \
               uplo[0], N, alpha,                                              \
               reinterpret_cast<const std::complex<double>*>(X.data()), one,   \
               reinterpret_cast<const std::complex<double>*>(Y.data()), one,   \
@@ -220,7 +220,7 @@ namespace Impl {
              ETI_SPEC_AVAIL>::syr2(space, trans, uplo, alpha, X, Y, A);       \
       } else {                                                                \
         if (A_is_ll) {                                                        \
-          HostBlas<std::complex<float>>::cher2(                               \
+          HostBlas<std::complex<float>>::her2(                                \
               uplo[0], N, alpha,                                              \
               reinterpret_cast<const std::complex<float>*>(X.data()), one,    \
               reinterpret_cast<const std::complex<float>*>(Y.data()), one,    \

--- a/blas/tpls/KokkosBlas2_syr_tpl_spec_decl_blas.hpp
+++ b/blas/tpls/KokkosBlas2_syr_tpl_spec_decl_blas.hpp
@@ -139,7 +139,7 @@ namespace Impl {
             space, trans, uplo, alpha, X, A);                                \
       } else {                                                               \
         if (A_is_ll) {                                                       \
-          HostBlas<std::complex<double>>::zher<double>(                      \
+          HostBlas<std::complex<double>>::her<double>(                       \
               uplo[0], N, alpha.real(),                                      \
               reinterpret_cast<const std::complex<double>*>(X.data()), one,  \
               reinterpret_cast<std::complex<double>*>(A.data()), LDA);       \
@@ -188,7 +188,7 @@ namespace Impl {
             space, trans, uplo, alpha, X, A);                                \
       } else {                                                               \
         if (A_is_ll && (alpha.imag() == 0.)) {                               \
-          HostBlas<std::complex<float>>::cher<float>(                        \
+          HostBlas<std::complex<float>>::her<float>(                         \
               uplo[0], N, alpha.real(),                                      \
               reinterpret_cast<const std::complex<float>*>(X.data()), one,   \
               reinterpret_cast<std::complex<float>*>(A.data()), LDA);        \

--- a/blas/tpls/KokkosBlas_Host_tpl.cpp
+++ b/blas/tpls/KokkosBlas_Host_tpl.cpp
@@ -295,10 +295,10 @@ void F77_BLAS_MANGLE(dsyr, DSYR)(const char*, KK_INT*, const double*,
 
 void F77_BLAS_MANGLE(cher, CHER)(const char*, KK_INT*, const float*,
                                  const std::complex<float>*, KK_INT*,
-                                 std::complex<float>*, KK_INT*);
+                                 /* */ std::complex<float>*, KK_INT*);
 void F77_BLAS_MANGLE(zher, ZHER)(const char*, KK_INT*, const double*,
                                  const std::complex<double>*, KK_INT*,
-                                 std::complex<double>*, KK_INT*);
+                                 /* */ std::complex<double>*, KK_INT*);
 
 ///
 /// Syr2
@@ -322,12 +322,12 @@ void F77_BLAS_MANGLE(cher2, CHER2)(const char*, KK_INT*,
                                    const std::complex<float>*,
                                    const std::complex<float>*, KK_INT*,
                                    const std::complex<float>*, KK_INT*,
-                                   std::complex<float>*, KK_INT*);
+                                   /* */ std::complex<float>*, KK_INT*);
 void F77_BLAS_MANGLE(zher2, ZHER2)(const char*, KK_INT*,
                                    const std::complex<double>*,
                                    const std::complex<double>*, KK_INT*,
                                    const std::complex<double>*, KK_INT*,
-                                   std::complex<double>*, KK_INT*);
+                                   /* */ std::complex<double>*, KK_INT*);
 
 ///
 /// Trsv
@@ -901,14 +901,14 @@ void HostBlas<std::complex<float> >::gerc(
 }
 template <>
 template <>
-void HostBlas<std::complex<float> >::cher<float>(
+void HostBlas<std::complex<float> >::her<float>(
     const char uplo, KK_INT n, const float alpha, const std::complex<float>* x,
     KK_INT incx, std::complex<float>* a, KK_INT lda) {
   F77_FUNC_CHER(&uplo, &n, &alpha, (const std::complex<float>*)x, &incx,
                 (std::complex<float>*)a, &lda);
 }
 template <>
-void HostBlas<std::complex<float> >::cher2(
+void HostBlas<std::complex<float> >::her2(
     const char uplo, KK_INT n, const std::complex<float> alpha,
     const std::complex<float>* x, KK_INT incx, const std::complex<float>* y,
     KK_INT incy, std::complex<float>* a, KK_INT lda) {
@@ -1069,15 +1069,17 @@ void HostBlas<std::complex<double> >::gerc(
 }
 template <>
 template <>
-void HostBlas<std::complex<double> >::zher<double>(
-    const char uplo, KK_INT n, const double alpha,
-    const std::complex<double>* x, KK_INT incx, std::complex<double>* a,
-    KK_INT lda) {
+void HostBlas<std::complex<double> >::her<double>(const char uplo, KK_INT n,
+                                                  const double alpha,
+                                                  const std::complex<double>* x,
+                                                  KK_INT incx,
+                                                  std::complex<double>* a,
+                                                  KK_INT lda) {
   F77_FUNC_ZHER(&uplo, &n, &alpha, (const std::complex<double>*)x, &incx,
                 (std::complex<double>*)a, &lda);
 }
 template <>
-void HostBlas<std::complex<double> >::zher2(
+void HostBlas<std::complex<double> >::her2(
     const char uplo, KK_INT n, const std::complex<double> alpha,
     const std::complex<double>* x, KK_INT incx, const std::complex<double>* y,
     KK_INT incy, std::complex<double>* a, KK_INT lda) {

--- a/blas/tpls/KokkosBlas_Host_tpl.hpp
+++ b/blas/tpls/KokkosBlas_Host_tpl.hpp
@@ -90,18 +90,11 @@ struct HostBlas {
                    KK_INT incx, const T *y, KK_INT incy, T *a, KK_INT lda);
 
   template <typename tAlpha>
-  static void cher(const char uplo, KK_INT n, const tAlpha alpha, const T *x,
-                   KK_INT incx, T *a, KK_INT lda);
+  static void her(const char uplo, KK_INT n, const tAlpha alpha, const T *x,
+                  KK_INT incx, T *a, KK_INT lda);
 
-  template <typename tAlpha>
-  static void zher(const char uplo, KK_INT n, const tAlpha alpha, const T *x,
-                   KK_INT incx, T *a, KK_INT lda);
-
-  static void cher2(const char uplo, KK_INT n, const T alpha, const T *x,
-                    KK_INT incx, const T *y, KK_INT incy, T *a, KK_INT lda);
-
-  static void zher2(const char uplo, KK_INT n, const T alpha, const T *x,
-                    KK_INT incx, const T *y, KK_INT incy, T *a, KK_INT lda);
+  static void her2(const char uplo, KK_INT n, const T alpha, const T *x,
+                   KK_INT incx, const T *y, KK_INT incy, T *a, KK_INT lda);
 
   static void trsv(const char uplo, const char transa, const char diag,
                    KK_INT m, const T *a, KK_INT lda,


### PR DESCRIPTION
Stick to pattern of removing leading 'c' or 'z' in method name and relying on the template type