### PR TITLE
workflows/osx.yml: test against most recent kokkos tag

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kokkos/kokkos
-          ref: develop
+          ref: 4.3.00
           path: kokkos
 
       - name: configure_kokkos


### PR DESCRIPTION
- test against most recent kokkos release rather than develop branch, as done with AT CI, to avoid compatibility breakages