### PR TITLE
Sparse - SpGEMM: labeling spgemm_symbolic in TPL layer

### DIFF
--- a/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp
@@ -387,7 +387,7 @@ void spgemm_symbolic_cusparse(KernelHandle *handle, lno_t m, lno_t n, lno_t k,
                                 bool, c_int_view_t row_mapB,                   \
                                 c_int_view_t entriesB, bool,                   \
                                 int_view_t row_mapC, bool computeRowptrs) {    \
-      std::string label = "KokkosSparse::spgemm[TPL_CUSPARSE," +               \
+      std::string label = "KokkosSparse::spgemm_symbolic[TPL_CUSPARSE," +      \
                           Kokkos::ArithTraits<SCALAR>::name() + "]";           \
       Kokkos::Profiling::pushRegion(label);                                    \
       spgemm_symbolic_cusparse(handle->get_spgemm_handle(), m, n, k, row_mapA, \
@@ -549,7 +549,7 @@ void spgemm_symbolic_rocsparse(
                                 bool, c_int_view_t row_mapB,                  \
                                 c_int_view_t entriesB, bool,                  \
                                 int_view_t row_mapC, bool) {                  \
-      std::string label = "KokkosSparse::spgemm[TPL_ROCSPARSE," +             \
+      std::string label = "KokkosSparse::spgemm_symbolic[TPL_ROCSPARSE," +    \
                           Kokkos::ArithTraits<SCALAR>::name() + "]";          \
       Kokkos::Profiling::pushRegion(label);                                   \
       spgemm_symbolic_rocsparse(handle->get_spgemm_handle(), m, n, k,         \


### PR DESCRIPTION
This just improves the readability of the output from the tools as it now has a symbolic matching the numeric phase. Previously we only had spgemm in the label which is a bit confusing as it could be the whole spgemm time i.e. both symbolic and numeric, additionally we had symbolic in the MKL path but not in cusparse, rocsparse...