### PR TITLE
BsrMatrix: Fix HostMirror typedef

### DIFF
--- a/sparse/src/KokkosSparse_BsrMatrix.hpp
+++ b/sparse/src/KokkosSparse_BsrMatrix.hpp
@@ -361,7 +361,8 @@ class BsrMatrix {
   typedef SizeType size_type;
 
   //! Type of a host-memory mirror of the sparse matrix.
-  typedef BsrMatrix<ScalarType, OrdinalType, host_mirror_space, MemoryTraits>
+  typedef BsrMatrix<ScalarType, OrdinalType, host_mirror_space, MemoryTraits,
+                    size_type>
       HostMirror;
   //! Type of the graph structure of the sparse matrix.
   typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, device_type,


### PR DESCRIPTION
It needed to have size_type.

Fixes https://github.com/trilinos/Trilinos/issues/12981

In RBILUK, I was using `local_matrix_host_type` in a few places instead of `local_matrix_device_type`. This exposed a problem where the host type had a different size_type than the device type.