### PR TITLE
Disable cuBLAS dot wrapper

### DIFF
--- a/blas/tpls/KokkosBlas1_dot_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_dot_tpl_spec_avail.hpp
@@ -89,8 +89,14 @@ KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL_BLAS(Kokkos::complex<float>, Kokkos::LayoutLeft,
   KOKKOSBLAS1_DOT_TPL_SPEC(Kokkos::complex<double>, LAYOUT, EXECSPACE, MEMSPACE)
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUBLAS
+// Note BMK: CUBLAS dot is consistently slower than our native dot
+// (measured 11.2, 11.8, 12.0 using perf test, and all are similar)
+// If a future version improves performance, re-enable it here and
+// in the tpl_spec_decl file.
+#if 0
 KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL(Kokkos::LayoutLeft, Kokkos::Cuda,
                                Kokkos::CudaSpace)
+#endif
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_ROCBLAS

--- a/blas/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
@@ -101,6 +101,9 @@ KOKKOSBLAS1_DOT_TPL_SPEC_DECL_BLAS_EXT(false)
 
 // cuBLAS
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUBLAS
+// Disabled because native has better performance.
+// See tpl_spec_avail file for more details
+#if 0
 #include <KokkosBlas_tpl_spec.hpp>
 
 namespace KokkosBlas {
@@ -173,6 +176,7 @@ KOKKOSBLAS1_DOT_TPL_SPEC_DECL_CUBLAS_EXT(true)
 KOKKOSBLAS1_DOT_TPL_SPEC_DECL_CUBLAS_EXT(false)
 }  // namespace Impl
 }  // namespace KokkosBlas
+#endif
 #endif
 
 // rocBLAS


### PR DESCRIPTION
(not deleted, just guarded with ``#if 0`` and comments explaining)

It performs significantly worse than our native impl on 11.2, 11.8 and 12.0 on V100. This is in the dot perf test with a warm-up call.

https://github.com/trilinos/Trilinos/issues/12982 was a symptom of this.
https://github.com/trilinos/Trilinos/pull/13033 is the same patch as this, but directly into Trilinos.