### PR TITLE
Fix logic around merge path with TPLs

### DIFF
--- a/sparse/impl/KokkosSparse_spmv_impl.hpp
+++ b/sparse/impl/KokkosSparse_spmv_impl.hpp
@@ -32,8 +32,6 @@
 namespace KokkosSparse {
 namespace Impl {
 
-constexpr const char* KOKKOSSPARSE_ALG_NATIVE_MERGE = "native-merge";
-
 // This TransposeFunctor is functional, but not necessarily performant.
 template <class execution_space, class AMatrix, class XVector, class YVector,
           bool conjugate>
@@ -609,7 +607,8 @@ static void spmv_beta(const execution_space& exec, Handle* handle,
                       typename YVector::const_value_type& beta,
                       const YVector& y) {
   if (mode[0] == NoTranspose[0]) {
-    if (handle->algo == SPMV_MERGE_PATH) {
+    if (handle->algo == SPMV_MERGE_PATH ||
+        handle->algo == SPMV_NATIVE_MERGE_PATH) {
       SpmvMergeHierarchical<execution_space, AMatrix, XVector, YVector>::spmv(
           exec, mode, alpha, A, x, beta, y);
     } else {
@@ -617,7 +616,8 @@ static void spmv_beta(const execution_space& exec, Handle* handle,
                              dobeta, false>(exec, handle, alpha, A, x, beta, y);
     }
   } else if (mode[0] == Conjugate[0]) {
-    if (handle->algo == SPMV_MERGE_PATH) {
+    if (handle->algo == SPMV_MERGE_PATH ||
+        handle->algo == SPMV_NATIVE_MERGE_PATH) {
       SpmvMergeHierarchical<execution_space, AMatrix, XVector, YVector>::spmv(
           exec, mode, alpha, A, x, beta, y);
     } else {

--- a/sparse/src/KokkosSparse_spmv_handle.hpp
+++ b/sparse/src/KokkosSparse_spmv_handle.hpp
@@ -36,8 +36,11 @@ enum SPMVAlgorithm {
                     /// is only used once.
   SPMV_NATIVE,      /// Use the best KokkosKernels implementation, even if a TPL
                     /// implementation is available.
-  SPMV_MERGE_PATH,  /// Use load-balancing merge path algorithm (for CrsMatrix
-                    /// only)
+  SPMV_MERGE_PATH,  /// Use algorithm optimized for matrices with
+                    /// imbalanced/irregular sparsity patterns (merge path or
+                    /// similar). May call a TPL. For CrsMatrix only.
+  SPMV_NATIVE_MERGE_PATH,  /// Use the KokkosKernels implementation of merge
+                           /// path. For CrsMatrix only.
   SPMV_BSR_V41,  /// Use experimental version 4.1 algorithm (for BsrMatrix only)
   SPMV_BSR_V42,  /// Use experimental version 4.2 algorithm (for BsrMatrix only)
   SPMV_BSR_TC    /// Use experimental tensor core algorithm (for BsrMatrix only)
@@ -59,6 +62,7 @@ inline const char* get_spmv_algorithm_name(SPMVAlgorithm a) {
     case SPMV_FAST_SETUP: return "SPMV_FAST_SETUP";
     case SPMV_NATIVE: return "SPMV_NATIVE";
     case SPMV_MERGE_PATH: return "SPMV_MERGE_PATH";
+    case SPMV_NATIVE_MERGE_PATH: return "SPMV_NATIVE_MERGE_PATH";
     case SPMV_BSR_V41: return "SPMV_BSR_V41";
     case SPMV_BSR_V42: return "SPMV_BSR_V42";
     case SPMV_BSR_TC: return "SPMV_BSR_TC";
@@ -73,10 +77,11 @@ inline const char* get_spmv_algorithm_name(SPMVAlgorithm a) {
 inline bool is_spmv_algorithm_native(SPMVAlgorithm a) {
   switch (a) {
     case SPMV_NATIVE:
-    case SPMV_MERGE_PATH:
+    case SPMV_NATIVE_MERGE_PATH:
     case SPMV_BSR_V41:
     case SPMV_BSR_V42:
     case SPMV_BSR_TC: return true;
+    // DEFAULT, FAST_SETUP and MERGE_PATH may call TPLs
     default: return false;
   }
 }
@@ -351,6 +356,7 @@ struct SPMVHandle
     } else {
       switch (get_algorithm()) {
         case SPMV_MERGE_PATH:
+        case SPMV_NATIVE_MERGE_PATH:
           throw std::invalid_argument(std::string("SPMVHandle: algorithm ") +
                                       get_spmv_algorithm_name(get_algorithm()) +
                                       " cannot be used if A is a BsrMatrix");

--- a/sparse/unit_test/Test_Sparse_spmv.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv.hpp
@@ -518,7 +518,11 @@ template <typename scalar_t, typename lno_t, typename size_type,
 void test_spmv_algorithms(lno_t numRows, size_type nnz, lno_t bandwidth,
                           lno_t row_size_variance, bool heavy) {
   using namespace KokkosSparse;
-  for (SPMVAlgorithm algo : {SPMV_DEFAULT, SPMV_NATIVE, SPMV_MERGE_PATH}) {
+  // Here, SPMV_MERGE_PATH will test a TPL's algorithm for imbalanced matrices
+  // if available (like cuSPARSE ALG2). SPMV_NATIVE_MERGE_PATH will always call
+  // the KokkosKernels implmentation of merge path.
+  for (SPMVAlgorithm algo :
+       {SPMV_DEFAULT, SPMV_NATIVE, SPMV_MERGE_PATH, SPMV_NATIVE_MERGE_PATH}) {
     test_spmv<scalar_t, lno_t, size_type, Device>(algo, numRows, nnz, bandwidth,
                                                   row_size_variance, heavy);
   }


### PR DESCRIPTION
``SPMV_MERGE_PATH`` is not always a native algorithm, so fix logic in ``KokkosSparse::is_spmv_algorithm_native`` for that. Add ``SPMV_NATIVE_MERGE_PATH`` to mean the KK implementation specifically. Test this new option.

Tested on Vortex with CUDA 11.2 - in this version ``SPMV_MERGE_PATH`` means ``CUSPARSE_SPMV_CSR_ALG2`` should be used. Verify that both the TPL and native merge path are used when expected.