### PR TITLE
spgemm unit test: change matrix value distribution

### DIFF
--- a/common/src/KokkosKernels_SimpleUtils.hpp
+++ b/common/src/KokkosKernels_SimpleUtils.hpp
@@ -342,9 +342,9 @@ struct IsRelativelyIdenticalFunctor {
     if (val_diff > mag_type(eps)) {
       Kokkos::printf(
           "Values at index %d, %.6f + %.6fi and %.6f + %.6fi, differ too much "
-          "(eps = %e)\n",
+          "(eps = %e, rel err = %e)\n",
           (int)i, KAT::real(view1(i)), KAT::imag(view1(i)), KAT::real(view2(i)),
-          KAT::imag(view2(i)), eps);
+          KAT::imag(view2(i)), eps, val_diff);
       num_diffs++;
     }
   }


### PR DESCRIPTION
Change the distribution A, B values are sampled from so that values in C can't end up close to 0 (as the result of summing terms that are not very close to 0). The relative error metric in ``is_same_matrix`` is sensitive to this situation.

Fixes #2232, verified on blake