### PR TITLE
.github/workflows: Auto trigger AT2 ci upon review

### DIFF
--- a/.github/workflows/bdw.yml
+++ b/.github/workflows/bdw.yml
@@ -9,6 +9,9 @@ on:
     - '**/*.py'
     - 'docs/**'
     types: [ opened, reopened, synchronize ]
+  pull_request_review:
+    types:
+      - submitted
 
 permissions:
   contents: none

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -10,6 +10,9 @@ on:
     - '**/*.py'
     - 'docs/**'
     types: [ opened, reopened, synchronize ]
+  pull_request_review:
+    types:
+      - submitted
 
 permissions:
   contents: none

--- a/.github/workflows/mi210.yml
+++ b/.github/workflows/mi210.yml
@@ -9,6 +9,9 @@ on:
     - '**/*.py'
     - 'docs/**'
     types: [ opened, reopened, synchronize ]
+  pull_request_review:
+    types:
+      - submitted
 
 permissions:
   contents: none

--- a/.github/workflows/spr.yml
+++ b/.github/workflows/spr.yml
@@ -10,6 +10,9 @@ on: workflow_dispatch
   #  - '**/*.py'
   #  - 'docs/**'
   #  types: [ opened, reopened, synchronize ]
+  #pull_request_review:
+  #  types:
+  #    - submitted
 
 permissions:
   contents: none


### PR DESCRIPTION
Luc, this is ready for review.

Summary of changes:
- Every time a PR review is submitted, the BDW, H100, and MI210 checks will be triggered. These checks should only run upon PR review submission if they have not already passed on the head commit of the source branch in the given PR.