### PR TITLE
Update rocsparse algo defaults

### DIFF
--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -247,13 +247,6 @@ void spmv(const ExecutionSpace& space, Handle* handle, const char mode[],
   YVector_Internal y_i(y);
 
   bool useNative = is_spmv_algorithm_native(handle->get_algorithm());
-  // Also use the native algorithm if SPMV_FAST_SETUP was selected and
-  // rocSPARSE is the possible TPL to use. Native is faster in this case.
-#ifdef KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE
-  if (handle->get_algorithm() == SPMV_FAST_SETUP &&
-      std::is_same_v<ExecutionSpace, Kokkos::HIP>)
-    useNative = true;
-#endif
 
   // Now call the proper implementation depending on isBSR and the rank of X/Y
   if constexpr (!isBSR) {

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -395,7 +395,7 @@ void spmv_rocsparse(const Kokkos::HIP& exec, Handle* handle, const char mode[],
   // Default to using the "stream" algorithm which has almost no setup cost,
   // and performs well for reasonably balanced matrices
   rocsparse_spmv_alg alg = rocsparse_spmv_alg_csr_stream;
-  if(handle->get_algorithm() == SPMV_MERGE_PATH) {
+  if (handle->get_algorithm() == SPMV_MERGE_PATH) {
     // Only use the "adaptive" algorithm if the user has indicated that the
     // matrix is very imbalanced, by asking for merge path. This algorithm
     // has fairly expensive setup


### PR DESCRIPTION
Met with rocSPARSE team last week and asked about the default spmv algorithm having expensive setup phase. We learned that other algorithms might be better for our most common use cases.

This PR now uses the rocsparse default (``rocsparse_spmv_alg_csr_adaptive``) algorithm only when ``SPMV_MERGE_PATH`` is requested, meaning that the user knows their matrix is imbalanced/irregular in nonzeros per row. Otherwise, use the zero-setup-cost algorithm ``rocsparse_spmv_alg_csr_stream``.

In the future, try out ``rocsparse_spmv_alg_csr_lrb`` too. This falls between the other two with cheaper setup than ``adaptive`` but better performance than ``stream`` on imbalanced matrices. It is not available in rocm 6.0.0 which is the newest caraway has installed, so it's not measured here.

Here are some times on 4 matrices, MI250x, rocm 6.0.0.
The test matrices from least to most irregular:
- Laplace (Brick3D) 1M
- Hook_1498
- abnormal_energy (matrix is usually distributed over 16 GPUs for solves, but it does easily fit on an MI250x for just spmv)
- webbase1M

| Time for 1st Call | rocsparse stream | rocsparse adaptive | KK native   |
|-------------------|------------------|--------------------|-------------|
| Laplace           | 0.00013811       | 0.00528309         | 0.000413349 |
| Hook              | 0.000979897      | 0.00923085         | 0.00100469  |
| abnormal_energy   | 0.00890759       | 0.00782657         | 0.0142701   |
| webbase           | 0.00127049       | 0.00526943         | 0.00196793  |

| Time for Avg Call | rocsparse stream | rocsparse adaptive | KK native   |
|-------------------|------------------|--------------------|-------------|
| Laplace           | 0.000135407      | 0.000121666        | 0.000420067 |
| Hook              | 0.000987887      | 0.000614848        | 0.0010059   |
| abnormal_energy   | 0.00902893       | 0.000372222        | 0.0142938   |
| webbase           | 0.0012035        | 8.00082e-05        | 0.00202784  |

General trends:
- KK native is never faster than rocsparse stream. Both have essentially zero setup cost
- For laplace and hook, stream is probably better overall for most users. On laplace, the average time of adaptive only becomes better after 384 calls. For Hook, 25 calls.
- For abnormal energy and webbase, adaptive is better after 1 and 4 calls respectively. Users should use ``SPMV_MERGE_PATH`` for these problems (and Tpetra will choose it automatically).