### PR TITLE
A little sptrsv cleanup before the main block effort

### DIFF
--- a/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
@@ -52,8 +52,6 @@ struct IlukWrap {
   using lno_t                  = typename IlukHandle::nnz_lno_t;
   using size_type              = typename IlukHandle::size_type;
   using scalar_t               = typename IlukHandle::nnz_scalar_t;
-  using HandleDeviceRowMapType = typename IlukHandle::nnz_row_view_t;
-  using HandleDeviceValueType  = typename IlukHandle::nnz_value_view_t;
   using WorkViewType           = typename IlukHandle::work_view_t;
   using LevelHostViewType      = typename IlukHandle::nnz_lno_view_host_t;
   using LevelViewType          = typename IlukHandle::nnz_lno_view_t;

--- a/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
@@ -47,18 +47,18 @@ struct IlukWrap {
   //
   // Useful types
   //
-  using execution_space        = typename IlukHandle::execution_space;
-  using memory_space           = typename IlukHandle::memory_space;
-  using lno_t                  = typename IlukHandle::nnz_lno_t;
-  using size_type              = typename IlukHandle::size_type;
-  using scalar_t               = typename IlukHandle::nnz_scalar_t;
-  using WorkViewType           = typename IlukHandle::work_view_t;
-  using LevelHostViewType      = typename IlukHandle::nnz_lno_view_host_t;
-  using LevelViewType          = typename IlukHandle::nnz_lno_view_t;
-  using karith                 = typename Kokkos::ArithTraits<scalar_t>;
-  using team_policy            = typename IlukHandle::TeamPolicy;
-  using member_type            = typename team_policy::member_type;
-  using range_policy           = typename IlukHandle::RangePolicy;
+  using execution_space   = typename IlukHandle::execution_space;
+  using memory_space      = typename IlukHandle::memory_space;
+  using lno_t             = typename IlukHandle::nnz_lno_t;
+  using size_type         = typename IlukHandle::size_type;
+  using scalar_t          = typename IlukHandle::nnz_scalar_t;
+  using WorkViewType      = typename IlukHandle::work_view_t;
+  using LevelHostViewType = typename IlukHandle::nnz_lno_view_host_t;
+  using LevelViewType     = typename IlukHandle::nnz_lno_view_t;
+  using karith            = typename Kokkos::ArithTraits<scalar_t>;
+  using team_policy       = typename IlukHandle::TeamPolicy;
+  using member_type       = typename team_policy::member_type;
+  using range_policy      = typename IlukHandle::RangePolicy;
 
   static team_policy get_team_policy(const size_type nrows,
                                      const int team_size) {

--- a/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
+++ b/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
@@ -2679,7 +2679,6 @@ struct SptrsvWrap {
     using namespace KokkosSparse::Experimental;
     using device_t            = Kokkos::Device<execution_space, temp_mem_space>;
     using integer_view_host_t = typename TriSolveHandle::integer_view_host_t;
-    using scalar_t            = typename ValuesType::non_const_value_type;
     using row_map_host_view_t = Kokkos::View<size_type *, Kokkos::HostSpace>;
 
     row_map_host_view_t row_map_host;
@@ -3080,7 +3079,6 @@ struct SptrsvWrap {
 #if defined(KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV)
     using namespace KokkosSparse::Experimental;
     using integer_view_host_t = typename TriSolveHandle::integer_view_host_t;
-    using scalar_t            = typename ValuesType::non_const_value_type;
     using row_map_host_view_t = Kokkos::View<size_type *, Kokkos::HostSpace>;
 
     row_map_host_view_t row_map_host;

--- a/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
+++ b/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
@@ -27,15 +27,11 @@
 #include <KokkosSparse_CrsMatrix.hpp>
 
 #ifdef KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV
-
 // Enable supernodal sptrsv
 #include "KokkosBlas3_trsm.hpp"
 #include "KokkosSparse_spmv.hpp"
-
 #include "KokkosBatched_Util.hpp"
-
 #include "KokkosBlas2_team_gemv_spec.hpp"
-
 #include "KokkosBatched_Trsm_Team_Impl.hpp"
 #endif
 
@@ -48,6 +44,11 @@
 #include "cuda_profiler_api.h"
 #endif
 
+#if defined(KOKKOS_ENABLE_CUDA) && 10000 < CUDA_VERSION && \
+    defined(KOKKOSKERNELS_ENABLE_EXP_CUDAGRAPH)
+#define KOKKOSKERNELS_SPTRSV_CUDAGRAPHSUPPORT
+#endif
+
 namespace KokkosSparse {
 namespace Impl {
 namespace Experimental {
@@ -58,77 +59,71 @@ struct SptrsvWrap {
   //
   // Useful types
   //
-  using execution_space        = typename TriSolveHandle::execution_space;
-  using memory_space           = typename TriSolveHandle::memory_space;
-  using lno_t                  = typename TriSolveHandle::nnz_lno_t;
-  using size_type              = typename TriSolveHandle::size_type;
-  using scalar_t               = typename TriSolveHandle::scalar_t;
-  using row_map_t              = typename TriSolveHandle::nnz_row_view_t;
-  using entries_t              = typename TriSolveHandle::nnz_lno_view_t;
-  using values_t               = typename TriSolveHandle::nnz_scalar_view_t;
-  using karith                 = typename Kokkos::ArithTraits<scalar_t>;
-  using team_policy            = typename TriSolveHandle::TeamPolicy;
-  using member_type            = typename team_policy::member_type;
-  using range_policy           = typename TriSolveHandle::RangePolicy;
+  using execution_space = typename TriSolveHandle::execution_space;
+  using memory_space    = typename TriSolveHandle::memory_space;
+  using temp_mem_space  = typename TriSolveHandle::HandleTempMemorySpace;
+  using lno_t           = typename TriSolveHandle::nnz_lno_t;
+  using size_type       = typename TriSolveHandle::size_type;
+  using scalar_t        = typename TriSolveHandle::scalar_t;
+  using row_map_t       = typename TriSolveHandle::nnz_row_view_t;
+  using entries_t       = typename TriSolveHandle::nnz_lno_view_t;
+  using values_t        = typename TriSolveHandle::nnz_scalar_view_t;
+  using work_view_t     = Kokkos::View<scalar_t*,
+                                       Kokkos::Device<execution_space, temp_mem_space>>;
+  using work_view_int_t = Kokkos::View<int*,
+                                       Kokkos::Device<execution_space, temp_mem_space>>;
+  using karith          = typename Kokkos::ArithTraits<scalar_t>;
+  using team_policy     = typename TriSolveHandle::TeamPolicy;
+  using member_type     = typename team_policy::member_type;
+  using range_policy    = typename TriSolveHandle::RangePolicy;
+  using range_type      = Kokkos::pair<int, int>;
 
-#if defined(KOKKOS_ENABLE_CUDA) && 10000 < CUDA_VERSION && \
-    defined(KOKKOSKERNELS_ENABLE_EXP_CUDAGRAPH)
-#define KOKKOSKERNELS_SPTRSV_CUDAGRAPHSUPPORT
-#endif
+  // Tag structs
+  struct UnsortedTag {};
+  struct LargerCutoffTag {};
+  struct UnsortedLargerCutoffTag {};
 
-struct UnsortedTag {};
-
-struct LargerCutoffTag {};
-
-struct UnsortedLargerCutoffTag {};
-
-template <class ViewType>
-static void print_view1d_solve(const ViewType dv, size_t range = 0) {
-  auto v = Kokkos::create_mirror_view(dv);
-  Kokkos::deep_copy(v, dv);
-  std::cout << "Output for view " << v.label() << std::endl;
-  range = range == 0 ? dv.extent(0) : range;
-  for (size_t i = 0; i < range; ++i) {
-    std::cout << "v(" << i << ") = " << v(i) << " , ";
+  template <class ViewType>
+  static void print_view1d_solve(const ViewType dv, size_t range = 0) {
+    auto v = Kokkos::create_mirror_view(dv);
+    Kokkos::deep_copy(v, dv);
+    std::cout << "Output for view " << v.label() << std::endl;
+    range = range == 0 ? dv.extent(0) : range;
+    for (size_t i = 0; i < range; ++i) {
+      std::cout << "v(" << i << ") = " << v(i) << " , ";
+    }
+    std::cout << std::endl;
   }
-  std::cout << std::endl;
-}
 
-// Needed for cudagraphs
-struct EmptyFunctor {
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const int) const {}
-};
+  // Needed for cudagraphs
+  struct EmptyFunctor {
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const int) const {}
+  };
 
-// This functor unifies the lower and upper implementations, the hope is the
-// "is_lowertri" check does not add noticable time on larger problems
-template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
-          class RHSType, class NGBLType>
-struct TriLvlSchedTP1SolverFunctor {
-  typedef typename RowMapType::execution_space execution_space;
-  typedef Kokkos::TeamPolicy<execution_space> policy_type;
-  typedef typename policy_type::member_type member_type;
-  typedef typename EntriesType::non_const_value_type lno_t;
-  typedef typename ValuesType::non_const_value_type scalar_t;
+  // This functor unifies the lower and upper implementations, the hope is the
+  // "is_lowertri" check does not add noticable time on larger problems
+  template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
+            class RHSType>
+  struct TriLvlSchedTP1SolverFunctor {
+    RowMapType row_map;
+    EntriesType entries;
+    ValuesType values;
+    LHSType lhs;
+    RHSType rhs;
+    entries_t nodes_grouped_by_level;
 
-  RowMapType row_map;
-  EntriesType entries;
-  ValuesType values;
-  LHSType lhs;
-  RHSType rhs;
-  NGBLType nodes_grouped_by_level;
+    const bool is_lowertri;
 
-  const bool is_lowertri;
+    long node_count;  // like "block" offset into ngbl, my_league is the "local"
+                      // offset
 
-  long node_count;  // like "block" offset into ngbl, my_league is the "local"
-                    // offset
-
-  TriLvlSchedTP1SolverFunctor(const RowMapType &row_map_,
-                              const EntriesType &entries_,
-                              const ValuesType &values_, LHSType &lhs_,
-                              const RHSType &rhs_,
-                              const NGBLType &nodes_grouped_by_level_,
-                              const bool &is_lowertri_, const long &node_count_)
+    TriLvlSchedTP1SolverFunctor(const RowMapType &row_map_,
+                                const EntriesType &entries_,
+                                const ValuesType &values_, LHSType &lhs_,
+                                const RHSType &rhs_,
+                                const entries_t &nodes_grouped_by_level_,
+                                const bool &is_lowertri_, const long &node_count_)
       : row_map(row_map_),
         entries(entries_),
         values(values_),
@@ -138,18 +133,18 @@ struct TriLvlSchedTP1SolverFunctor {
         is_lowertri(is_lowertri_),
         node_count(node_count_) {}
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const member_type &team) const {
-    auto my_league = team.league_rank();  // map to rowid
-    auto rowid     = nodes_grouped_by_level(my_league + node_count);
-    auto my_rank   = team.team_rank();
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const member_type &team) const {
+      auto my_league = team.league_rank();  // map to rowid
+      auto rowid     = nodes_grouped_by_level(my_league + node_count);
+      auto my_rank   = team.team_rank();
 
-    auto soffset   = row_map(rowid);
-    auto eoffset   = row_map(rowid + 1);
-    auto rhs_rowid = rhs(rowid);
-    scalar_t diff  = scalar_t(0.0);
+      auto soffset   = row_map(rowid);
+      auto eoffset   = row_map(rowid + 1);
+      auto rhs_rowid = rhs(rowid);
+      scalar_t diff  = scalar_t(0.0);
 
-    Kokkos::parallel_reduce(
+      Kokkos::parallel_reduce(
         Kokkos::TeamThreadRange(team, soffset, eoffset),
         [&](const long ptr, scalar_t &tdiff) {
           auto colid = entries(ptr);
@@ -161,31 +156,31 @@ struct TriLvlSchedTP1SolverFunctor {
         },
         diff);
 
-    team.team_barrier();
+      team.team_barrier();
 
-    // At end, finalize rowid == colid
-    // only one thread should do this; can also use Kokkos::single
-    if (my_rank == 0) {
-      // ASSUMPTION: sorted diagonal value located at eoffset - 1
-      lhs(rowid) = is_lowertri ? (rhs_rowid + diff) / values(eoffset - 1)
-                               : (rhs_rowid + diff) / values(soffset);
+      // At end, finalize rowid == colid
+      // only one thread should do this; can also use Kokkos::single
+      if (my_rank == 0) {
+        // ASSUMPTION: sorted diagonal value located at eoffset - 1
+        lhs(rowid) = is_lowertri ? (rhs_rowid + diff) / values(eoffset - 1)
+          : (rhs_rowid + diff) / values(soffset);
+      }
     }
-  }
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const UnsortedTag &, const member_type &team) const {
-    auto my_league = team.league_rank();  // map to rowid
-    auto rowid     = nodes_grouped_by_level(my_league + node_count);
-    auto my_rank   = team.team_rank();
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const UnsortedTag &, const member_type &team) const {
+      auto my_league = team.league_rank();  // map to rowid
+      auto rowid     = nodes_grouped_by_level(my_league + node_count);
+      auto my_rank   = team.team_rank();
 
-    auto soffset   = row_map(rowid);
-    auto eoffset   = row_map(rowid + 1);
-    auto rhs_rowid = rhs(rowid);
-    scalar_t diff  = scalar_t(0.0);
+      auto soffset   = row_map(rowid);
+      auto eoffset   = row_map(rowid + 1);
+      auto rhs_rowid = rhs(rowid);
+      scalar_t diff  = scalar_t(0.0);
 
-    auto diag = -1;
+      auto diag = -1;
 
-    Kokkos::parallel_reduce(
+      Kokkos::parallel_reduce(
         Kokkos::TeamThreadRange(team, soffset, eoffset),
         [&](const long ptr, scalar_t &tdiff) {
           auto colid = entries(ptr);
@@ -197,47 +192,41 @@ struct TriLvlSchedTP1SolverFunctor {
           }
         },
         diff);
-    team.team_barrier();
+      team.team_barrier();
 
-    // At end, finalize rowid == colid
-    // only one thread should do this; can also use Kokkos::single
-    if (my_rank == 0) {
-      lhs(rowid) = (rhs_rowid + diff) / values(diag);
+      // At end, finalize rowid == colid
+      // only one thread should do this; can also use Kokkos::single
+      if (my_rank == 0) {
+        lhs(rowid) = (rhs_rowid + diff) / values(diag);
+      }
     }
-  }
-};
+  };
 
-template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
-          class RHSType, class NGBLType>
-struct TriLvlSchedTP1SolverFunctorDiagValues {
-  typedef typename RowMapType::execution_space execution_space;
-  typedef Kokkos::TeamPolicy<execution_space> policy_type;
-  typedef typename policy_type::member_type member_type;
-  typedef typename EntriesType::non_const_value_type lno_t;
-  typedef typename ValuesType::non_const_value_type scalar_t;
+  template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
+            class RHSType>
+  struct TriLvlSchedTP1SolverFunctorDiagValues {
+    RowMapType row_map;
+    EntriesType entries;
+    ValuesType values;
+    LHSType lhs;
+    RHSType rhs;
+    entries_t nodes_grouped_by_level;
+    ValuesType diagonal_values;  // inserted according to rowid
 
-  RowMapType row_map;
-  EntriesType entries;
-  ValuesType values;
-  LHSType lhs;
-  RHSType rhs;
-  NGBLType nodes_grouped_by_level;
-  ValuesType diagonal_values;  // inserted according to rowid
+    const bool is_lowertri;
 
-  const bool is_lowertri;
+    long node_count;  // like "block" offset into ngbl, my_league is the "local"
+                      // offset
+    long dense_nrows;
 
-  long node_count;  // like "block" offset into ngbl, my_league is the "local"
-                    // offset
-  long dense_nrows;
-
-  TriLvlSchedTP1SolverFunctorDiagValues(const RowMapType &row_map_,
-                                        const EntriesType &entries_,
-                                        const ValuesType &values_,
-                                        LHSType &lhs_, const RHSType &rhs_,
-                                        const NGBLType &nodes_grouped_by_level_,
-                                        const ValuesType &diagonal_values_,
-                                        const bool is_lowertri_,
-                                        long node_count_, long dense_nrows_ = 0)
+    TriLvlSchedTP1SolverFunctorDiagValues(const RowMapType &row_map_,
+                                          const EntriesType &entries_,
+                                          const ValuesType &values_,
+                                          LHSType &lhs_, const RHSType &rhs_,
+                                          const entries_t &nodes_grouped_by_level_,
+                                          const ValuesType &diagonal_values_,
+                                          const bool is_lowertri_,
+                                          long node_count_, long dense_nrows_ = 0)
       : row_map(row_map_),
         entries(entries_),
         values(values_),
@@ -249,18 +238,18 @@ struct TriLvlSchedTP1SolverFunctorDiagValues {
         node_count(node_count_),
         dense_nrows(dense_nrows_) {}
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const member_type &team) const {
-    auto my_league = team.league_rank();  // map to rowid
-    auto rowid     = nodes_grouped_by_level(my_league + node_count);
-    auto my_rank   = team.team_rank();
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const member_type &team) const {
+      auto my_league = team.league_rank();  // map to rowid
+      auto rowid     = nodes_grouped_by_level(my_league + node_count);
+      auto my_rank   = team.team_rank();
 
-    auto soffset   = row_map(rowid);
-    auto eoffset   = row_map(rowid + 1);
-    auto rhs_rowid = rhs(rowid);
-    scalar_t diff  = scalar_t(0.0);
+      auto soffset   = row_map(rowid);
+      auto eoffset   = row_map(rowid + 1);
+      auto rhs_rowid = rhs(rowid);
+      scalar_t diff  = scalar_t(0.0);
 
-    Kokkos::parallel_reduce(
+      Kokkos::parallel_reduce(
         Kokkos::TeamThreadRange(team, soffset, eoffset),
         [&](const long ptr, scalar_t &tdiff) {
           auto colid = entries(ptr);
@@ -271,47 +260,41 @@ struct TriLvlSchedTP1SolverFunctorDiagValues {
         },
         diff);
 
-    team.team_barrier();
+      team.team_barrier();
 
-    // At end, finalize rowid == colid
-    // only one thread should do this; can also use Kokkos::single
-    if (my_rank == 0) {
-      // lhs(rowid) = is_lowertri ? (rhs_rowid+diff)/values(eoffset-1) :
-      // (rhs_rowid+diff)/values(soffset);
-      lhs(rowid) = (rhs_rowid + diff) / diagonal_values(rowid);
+      // At end, finalize rowid == colid
+      // only one thread should do this; can also use Kokkos::single
+      if (my_rank == 0) {
+        // lhs(rowid) = is_lowertri ? (rhs_rowid+diff)/values(eoffset-1) :
+        // (rhs_rowid+diff)/values(soffset);
+        lhs(rowid) = (rhs_rowid + diff) / diagonal_values(rowid);
+      }
     }
-  }
-};
+  };
 
-template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
-          class RHSType, class NGBLType>
-struct TriLvlSchedTP2SolverFunctor {
-  typedef typename RowMapType::execution_space execution_space;
-  typedef Kokkos::TeamPolicy<execution_space> policy_type;
-  typedef typename policy_type::member_type member_type;
-  typedef typename EntriesType::non_const_value_type lno_t;
-  typedef typename ValuesType::non_const_value_type scalar_t;
+  template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
+            class RHSType>
+  struct TriLvlSchedTP2SolverFunctor {
+    RowMapType row_map;
+    EntriesType entries;
+    ValuesType values;
+    LHSType lhs;
+    RHSType rhs;
+    entries_t nodes_grouped_by_level;
 
-  RowMapType row_map;
-  EntriesType entries;
-  ValuesType values;
-  LHSType lhs;
-  RHSType rhs;
-  NGBLType nodes_grouped_by_level;
+    const bool is_lowertri;
+    long node_count;  // like "block" offset into ngbl, my_league is the "local"
+                      // offset
+    long node_groups;
+    long dense_nrows;
 
-  const bool is_lowertri;
-  long node_count;  // like "block" offset into ngbl, my_league is the "local"
-                    // offset
-  long node_groups;
-  long dense_nrows;
-
-  TriLvlSchedTP2SolverFunctor(const RowMapType &row_map_,
-                              const EntriesType &entries_,
-                              const ValuesType &values_, LHSType &lhs_,
-                              const RHSType &rhs_,
-                              const NGBLType &nodes_grouped_by_level_,
-                              const bool is_lowertri_, long node_count_,
-                              long node_groups_ = 0, long dense_nrows_ = 0)
+    TriLvlSchedTP2SolverFunctor(const RowMapType &row_map_,
+                                const EntriesType &entries_,
+                                const ValuesType &values_, LHSType &lhs_,
+                                const RHSType &rhs_,
+                                const entries_t &nodes_grouped_by_level_,
+                                const bool is_lowertri_, long node_count_,
+                                long node_groups_ = 0, long dense_nrows_ = 0)
       : row_map(row_map_),
         entries(entries_),
         values(values_),
@@ -323,13 +306,13 @@ struct TriLvlSchedTP2SolverFunctor {
         node_groups(node_groups_),
         dense_nrows(dense_nrows_) {}
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const member_type &team) const {
-    auto my_league = team.league_rank();  // map to rowid
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const member_type &team) const {
+      auto my_league = team.league_rank();  // map to rowid
 
-    size_t nrows = row_map.extent(0) - 1;
+      size_t nrows = row_map.extent(0) - 1;
 
-    Kokkos::parallel_for(
+      Kokkos::parallel_for(
         Kokkos::TeamThreadRange(team, 0, node_groups), [&](const long ng) {
           auto rowid =
               nodes_grouped_by_level(node_count + my_league * node_groups + ng);
@@ -356,16 +339,16 @@ struct TriLvlSchedTP2SolverFunctor {
           }  // end if
         });  // end TeamThreadRange
 
-    team.team_barrier();
-  }
+      team.team_barrier();
+    }
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const UnsortedTag &, const member_type &team) const {
-    auto my_league = team.league_rank();  // map to rowid
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const UnsortedTag &, const member_type &team) const {
+      auto my_league = team.league_rank();  // map to rowid
 
-    size_t nrows = row_map.extent(0) - 1;
+      size_t nrows = row_map.extent(0) - 1;
 
-    Kokkos::parallel_for(
+      Kokkos::parallel_for(
         Kokkos::TeamThreadRange(team, 0, node_groups), [&](const long ng) {
           auto rowid =
               nodes_grouped_by_level(node_count + my_league * node_groups + ng);
@@ -393,28 +376,27 @@ struct TriLvlSchedTP2SolverFunctor {
           }  // end if
         });  // end TeamThreadRange
 
-    team.team_barrier();
-  }
-};
+      team.team_barrier();
+    }
+  };
 
-// Lower vs Upper Multi-block Functors
+  // Lower vs Upper Multi-block Functors
 
-template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
-          class RHSType, class NGBLType>
-struct LowerTriLvlSchedRPSolverFunctor {
-  typedef typename EntriesType::non_const_value_type lno_t;
-  RowMapType row_map;
-  EntriesType entries;
-  ValuesType values;
-  LHSType lhs;
-  RHSType rhs;
-  NGBLType nodes_grouped_by_level;
+  template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
+            class RHSType>
+  struct LowerTriLvlSchedRPSolverFunctor {
+    RowMapType row_map;
+    EntriesType entries;
+    ValuesType values;
+    LHSType lhs;
+    RHSType rhs;
+    entries_t nodes_grouped_by_level;
 
-  LowerTriLvlSchedRPSolverFunctor(const RowMapType &row_map_,
-                                  const EntriesType &entries_,
-                                  const ValuesType &values_, LHSType &lhs_,
-                                  const RHSType &rhs_,
-                                  const NGBLType &nodes_grouped_by_level_)
+    LowerTriLvlSchedRPSolverFunctor(const RowMapType &row_map_,
+                                    const EntriesType &entries_,
+                                    const ValuesType &values_, LHSType &lhs_,
+                                    const RHSType &rhs_,
+                                    const entries_t &nodes_grouped_by_level_)
       : row_map(row_map_),
         entries(entries_),
         values(values_),
@@ -422,74 +404,68 @@ struct LowerTriLvlSchedRPSolverFunctor {
         rhs(rhs_),
         nodes_grouped_by_level(nodes_grouped_by_level_) {}
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const lno_t i) const {
-    auto rowid = nodes_grouped_by_level(i);
-    // Assuming indices are sorted per row, diag entry is final index in the
-    // list
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const lno_t i) const {
+      auto rowid = nodes_grouped_by_level(i);
+      // Assuming indices are sorted per row, diag entry is final index in the
+      // list
 
-    long soffset   = row_map(rowid);
-    long eoffset   = row_map(rowid + 1);
-    auto rhs_rowid = rhs(rowid);
+      long soffset   = row_map(rowid);
+      long eoffset   = row_map(rowid + 1);
+      auto rhs_rowid = rhs(rowid);
 
-    for (long ptr = soffset; ptr < eoffset; ++ptr) {
-      auto colid = entries(ptr);
-      auto val   = values(ptr);
-      if (colid != rowid) {
-        rhs_rowid = rhs_rowid - val * lhs(colid);
-      } else {
-        lhs(rowid) = rhs_rowid / val;
-      }
-    }  // end for ptr
-  }
+      for (long ptr = soffset; ptr < eoffset; ++ptr) {
+        auto colid = entries(ptr);
+        auto val   = values(ptr);
+        if (colid != rowid) {
+          rhs_rowid = rhs_rowid - val * lhs(colid);
+        } else {
+          lhs(rowid) = rhs_rowid / val;
+        }
+      }  // end for ptr
+    }
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const UnsortedTag &, const lno_t i) const {
-    auto rowid     = nodes_grouped_by_level(i);
-    long soffset   = row_map(rowid);
-    long eoffset   = row_map(rowid + 1);
-    auto rhs_rowid = rhs(rowid);
-    auto diag      = -1;
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const UnsortedTag &, const lno_t i) const {
+      auto rowid     = nodes_grouped_by_level(i);
+      long soffset   = row_map(rowid);
+      long eoffset   = row_map(rowid + 1);
+      auto rhs_rowid = rhs(rowid);
+      auto diag      = -1;
 
-    for (long ptr = soffset; ptr < eoffset; ++ptr) {
-      auto colid = entries(ptr);
-      auto val   = values(ptr);
-      if (colid != rowid) {
-        rhs_rowid = rhs_rowid - val * lhs(colid);
-      } else {
-        diag = ptr;
-      }
-    }  // end for ptr
-    lhs(rowid) = rhs_rowid / values(diag);
-  }
-};
+      for (long ptr = soffset; ptr < eoffset; ++ptr) {
+        auto colid = entries(ptr);
+        auto val   = values(ptr);
+        if (colid != rowid) {
+          rhs_rowid = rhs_rowid - val * lhs(colid);
+        } else {
+          diag = ptr;
+        }
+      }  // end for ptr
+      lhs(rowid) = rhs_rowid / values(diag);
+    }
+  };
 
-template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
-          class RHSType, class NGBLType>
-struct LowerTriLvlSchedTP1SolverFunctor {
-  typedef typename RowMapType::execution_space execution_space;
-  typedef Kokkos::TeamPolicy<execution_space> policy_type;
-  typedef typename policy_type::member_type member_type;
-  typedef typename EntriesType::non_const_value_type lno_t;
-  typedef typename ValuesType::non_const_value_type scalar_t;
+  template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
+            class RHSType>
+  struct LowerTriLvlSchedTP1SolverFunctor {
+    RowMapType row_map;
+    EntriesType entries;
+    ValuesType values;
+    LHSType lhs;
+    RHSType rhs;
+    entries_t nodes_grouped_by_level;
 
-  RowMapType row_map;
-  EntriesType entries;
-  ValuesType values;
-  LHSType lhs;
-  RHSType rhs;
-  NGBLType nodes_grouped_by_level;
+    long node_count;  // like "block" offset into ngbl, my_league is the "local"
+                      // offset
+    long node_groups;
 
-  long node_count;  // like "block" offset into ngbl, my_league is the "local"
-                    // offset
-  long node_groups;
-
-  LowerTriLvlSchedTP1SolverFunctor(const RowMapType &row_map_,
-                                   const EntriesType &entries_,
-                                   const ValuesType &values_, LHSType &lhs_,
-                                   const RHSType &rhs_,
-                                   const NGBLType &nodes_grouped_by_level_,
-                                   long node_count_, long node_groups_ = 0)
+    LowerTriLvlSchedTP1SolverFunctor(const RowMapType &row_map_,
+                                     const EntriesType &entries_,
+                                     const ValuesType &values_, LHSType &lhs_,
+                                     const RHSType &rhs_,
+                                     const entries_t &nodes_grouped_by_level_,
+                                     long node_count_, long node_groups_ = 0)
       : row_map(row_map_),
         entries(entries_),
         values(values_),
@@ -499,18 +475,18 @@ struct LowerTriLvlSchedTP1SolverFunctor {
         node_count(node_count_),
         node_groups(node_groups_) {}
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const member_type &team) const {
-    auto my_league = team.league_rank();  // map to rowid
-    auto rowid     = nodes_grouped_by_level(my_league + node_count);
-    auto my_rank   = team.team_rank();
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const member_type &team) const {
+      auto my_league = team.league_rank();  // map to rowid
+      auto rowid     = nodes_grouped_by_level(my_league + node_count);
+      auto my_rank   = team.team_rank();
 
-    auto soffset   = row_map(rowid);
-    auto eoffset   = row_map(rowid + 1);
-    auto rhs_rowid = rhs(rowid);
-    scalar_t diff  = scalar_t(0.0);
+      auto soffset   = row_map(rowid);
+      auto eoffset   = row_map(rowid + 1);
+      auto rhs_rowid = rhs(rowid);
+      scalar_t diff  = scalar_t(0.0);
 
-    Kokkos::parallel_reduce(
+      Kokkos::parallel_reduce(
         Kokkos::TeamThreadRange(team, soffset, eoffset),
         [&](const long ptr, scalar_t &tdiff) {
           auto colid = entries(ptr);
@@ -521,30 +497,30 @@ struct LowerTriLvlSchedTP1SolverFunctor {
         },
         diff);
 
-    team.team_barrier();
+      team.team_barrier();
 
-    // At end, finalize rowid == colid
-    // only one thread should do this; can also use Kokkos::single
-    if (my_rank == 0) {
-      // ASSUMPTION: sorted diagonal value located at eoffset - 1
-      lhs(rowid) = (rhs_rowid + diff) / values(eoffset - 1);
+      // At end, finalize rowid == colid
+      // only one thread should do this; can also use Kokkos::single
+      if (my_rank == 0) {
+        // ASSUMPTION: sorted diagonal value located at eoffset - 1
+        lhs(rowid) = (rhs_rowid + diff) / values(eoffset - 1);
+      }
     }
-  }
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const UnsortedTag &, const member_type &team) const {
-    auto my_league = team.league_rank();  // map to rowid
-    auto rowid     = nodes_grouped_by_level(my_league + node_count);
-    auto my_rank   = team.team_rank();
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const UnsortedTag &, const member_type &team) const {
+      auto my_league = team.league_rank();  // map to rowid
+      auto rowid     = nodes_grouped_by_level(my_league + node_count);
+      auto my_rank   = team.team_rank();
 
-    auto soffset   = row_map(rowid);
-    auto eoffset   = row_map(rowid + 1);
-    auto rhs_rowid = rhs(rowid);
-    scalar_t diff  = scalar_t(0.0);
+      auto soffset   = row_map(rowid);
+      auto eoffset   = row_map(rowid + 1);
+      auto rhs_rowid = rhs(rowid);
+      scalar_t diff  = scalar_t(0.0);
 
-    auto diag = -1;
+      auto diag = -1;
 
-    Kokkos::parallel_reduce(
+      Kokkos::parallel_reduce(
         Kokkos::TeamThreadRange(team, soffset, eoffset),
         [&](const long ptr, scalar_t &tdiff) {
           auto colid = entries(ptr);
@@ -556,45 +532,39 @@ struct LowerTriLvlSchedTP1SolverFunctor {
           }
         },
         diff);
-    team.team_barrier();
+      team.team_barrier();
 
-    // At end, finalize rowid == colid
-    // only one thread should do this; can also use Kokkos::single
-    if (my_rank == 0) {
-      lhs(rowid) = (rhs_rowid + diff) / values(diag);
+      // At end, finalize rowid == colid
+      // only one thread should do this; can also use Kokkos::single
+      if (my_rank == 0) {
+        lhs(rowid) = (rhs_rowid + diff) / values(diag);
+      }
     }
-  }
-};
+  };
 
-// FIXME CUDA: This algorithm not working with all integral type combos
-// In any case, this serves as a skeleton for 3-level hierarchical parallelism
-// for alg dev
-template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
-          class RHSType, class NGBLType>
-struct LowerTriLvlSchedTP2SolverFunctor {
-  typedef typename RowMapType::execution_space execution_space;
-  typedef Kokkos::TeamPolicy<execution_space> policy_type;
-  typedef typename policy_type::member_type member_type;
-  typedef typename EntriesType::non_const_value_type lno_t;
-  typedef typename ValuesType::non_const_value_type scalar_t;
+  // FIXME CUDA: This algorithm not working with all integral type combos
+  // In any case, this serves as a skeleton for 3-level hierarchical parallelism
+  // for alg dev
+  template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
+            class RHSType>
+  struct LowerTriLvlSchedTP2SolverFunctor {
+    RowMapType row_map;
+    EntriesType entries;
+    ValuesType values;
+    LHSType lhs;
+    RHSType rhs;
+    entries_t nodes_grouped_by_level;
 
-  RowMapType row_map;
-  EntriesType entries;
-  ValuesType values;
-  LHSType lhs;
-  RHSType rhs;
-  NGBLType nodes_grouped_by_level;
+    long node_count;  // like "block" offset into ngbl, my_league is the "local"
+                      // offset
+    long node_groups;
 
-  long node_count;  // like "block" offset into ngbl, my_league is the "local"
-                    // offset
-  long node_groups;
-
-  LowerTriLvlSchedTP2SolverFunctor(const RowMapType &row_map_,
-                                   const EntriesType &entries_,
-                                   const ValuesType &values_, LHSType &lhs_,
-                                   const RHSType &rhs_,
-                                   const NGBLType &nodes_grouped_by_level_,
-                                   long node_count_, long node_groups_ = 0)
+    LowerTriLvlSchedTP2SolverFunctor(const RowMapType &row_map_,
+                                     const EntriesType &entries_,
+                                     const ValuesType &values_, LHSType &lhs_,
+                                     const RHSType &rhs_,
+                                     const entries_t &nodes_grouped_by_level_,
+                                     long node_count_, long node_groups_ = 0)
       : row_map(row_map_),
         entries(entries_),
         values(values_),
@@ -604,13 +574,13 @@ struct LowerTriLvlSchedTP2SolverFunctor {
         node_count(node_count_),
         node_groups(node_groups_) {}
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const member_type &team) const {
-    auto my_league = team.league_rank();  // map to rowid
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const member_type &team) const {
+      auto my_league = team.league_rank();  // map to rowid
 
-    size_t nrows = row_map.extent(0) - 1;
+      size_t nrows = row_map.extent(0) - 1;
 
-    Kokkos::parallel_for(
+      Kokkos::parallel_for(
         Kokkos::TeamThreadRange(team, 0, node_groups), [&](const long ng) {
           auto rowid =
               nodes_grouped_by_level(node_count + my_league * node_groups + ng);
@@ -636,16 +606,16 @@ struct LowerTriLvlSchedTP2SolverFunctor {
           }  // end if
         });  // end TeamThreadRange
 
-    team.team_barrier();
-  }
+      team.team_barrier();
+    }
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const UnsortedTag &, const member_type &team) const {
-    auto my_league = team.league_rank();  // map to rowid
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const UnsortedTag &, const member_type &team) const {
+      auto my_league = team.league_rank();  // map to rowid
 
-    size_t nrows = row_map.extent(0) - 1;
+      size_t nrows = row_map.extent(0) - 1;
 
-    Kokkos::parallel_for(
+      Kokkos::parallel_for(
         Kokkos::TeamThreadRange(team, 0, node_groups), [&](const long ng) {
           auto rowid =
               nodes_grouped_by_level(node_count + my_league * node_groups + ng);
@@ -674,42 +644,30 @@ struct LowerTriLvlSchedTP2SolverFunctor {
           }  // end if
         });  // end TeamThreadRange
 
-    team.team_barrier();
-  }
-};
+      team.team_barrier();
+    }
+  };
 
 #if defined(KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV)
-// -----------------------------------------------------------
-// Helper functors for Lower-triangular solve with SpMV
-template <class LHSType, class NGBLType>
-struct SparseTriSupernodalSpMVFunctor {
-  using execution_space = typename TriSolveHandle::HandleExecSpace;
-  using memory_space    = typename TriSolveHandle::HandleTempMemorySpace;
+  // -----------------------------------------------------------
+  // Helper functors for Lower-triangular solve with SpMV
+  template <class LHSType>
+  struct SparseTriSupernodalSpMVFunctor {
+    int flag;
+    long node_count;
+    entries_t nodes_grouped_by_level;
 
-  using policy_type = Kokkos::TeamPolicy<execution_space>;
-  using member_type = typename policy_type::member_type;
+    const int *supercols;
+    const int *workoffset;
 
-  using scalar_t = typename LHSType::non_const_value_type;
+    LHSType X;
+    work_view_t work;
 
-  using work_view_t =
-      typename Kokkos::View<scalar_t *,
-                            Kokkos::Device<execution_space, memory_space>>;
-
-  int flag;
-  long node_count;
-  NGBLType nodes_grouped_by_level;
-
-  const int *supercols;
-  const int *workoffset;
-
-  LHSType X;
-  work_view_t work;
-
-  // constructor
-  SparseTriSupernodalSpMVFunctor(int flag_, long node_count_,
-                                 const NGBLType &nodes_grouped_by_level_,
-                                 const int *supercols_, const int *workoffset_,
-                                 LHSType &X_, work_view_t work_)
+    // constructor
+    SparseTriSupernodalSpMVFunctor(int flag_, long node_count_,
+                                   const entries_t &nodes_grouped_by_level_,
+                                   const int *supercols_, const int *workoffset_,
+                                   LHSType &X_, work_view_t work_)
       : flag(flag_),
         node_count(node_count_),
         nodes_grouped_by_level(nodes_grouped_by_level_),
@@ -718,105 +676,90 @@ struct SparseTriSupernodalSpMVFunctor {
         X(X_),
         work(work_) {}
 
-  // operator
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const member_type &team) const {
-    const int league_rank = team.league_rank();  // batch id
-    const int team_size   = team.team_size();
-    const int team_rank   = team.team_rank();
-    const scalar_t zero(0.0);
+    // operator
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const member_type &team) const {
+      const int league_rank = team.league_rank();  // batch id
+      const int team_size   = team.team_size();
+      const int team_rank   = team.team_rank();
+      const scalar_t zero(0.0);
 
-    auto s = nodes_grouped_by_level(node_count + league_rank);
+      auto s = nodes_grouped_by_level(node_count + league_rank);
 
-    // copy vector elements for the diagonal to input vector (work)
-    // and zero out the corresponding elements in output (X)
-    int w1 = workoffset[s];
-    int j1 = supercols[s];
-    // number of columns in the s-th supernode column
-    int nscol = supercols[s + 1] - j1;
+      // copy vector elements for the diagonal to input vector (work)
+      // and zero out the corresponding elements in output (X)
+      int w1 = workoffset[s];
+      int j1 = supercols[s];
+      // number of columns in the s-th supernode column
+      int nscol = supercols[s + 1] - j1;
 
-    if (flag == -2) {
-      // copy X to work
-      for (int j = team_rank; j < nscol; j += team_size) {
-        work(w1 + j) = X(j1 + j);
+      if (flag == -2) {
+        // copy X to work
+        for (int j = team_rank; j < nscol; j += team_size) {
+          work(w1 + j) = X(j1 + j);
+        }
+      } else if (flag == -1) {
+        // copy work to X
+        for (int j = team_rank; j < nscol; j += team_size) {
+          X(j1 + j) = work(w1 + j);
+        }
+      } else if (flag == 1) {
+        for (int j = team_rank; j < nscol; j += team_size) {
+          work(w1 + j) = X(j1 + j);
+          X(j1 + j)    = zero;
+        }
+      } else {
+        // reinitialize work to zero
+        for (int j = team_rank; j < nscol; j += team_size) {
+          work(w1 + j) = zero;
+        }
       }
-    } else if (flag == -1) {
-      // copy work to X
-      for (int j = team_rank; j < nscol; j += team_size) {
-        X(j1 + j) = work(w1 + j);
-      }
-    } else if (flag == 1) {
-      for (int j = team_rank; j < nscol; j += team_size) {
-        work(w1 + j) = X(j1 + j);
-        X(j1 + j)    = zero;
-      }
-    } else {
-      // reinitialize work to zero
-      for (int j = team_rank; j < nscol; j += team_size) {
-        work(w1 + j) = zero;
-      }
+      team.team_barrier();
     }
-    team.team_barrier();
-  }
-};
+  };
 
-// -----------------------------------------------------------
-// Functor for Lower-triangular solve
-template <class ColptrView, class RowindType,
-          class ValuesType, class LHSType, class NGBLType>
-struct LowerTriSupernodalFunctor {
-  using execution_space = typename TriSolveHandle::HandleExecSpace;
-  using memory_space    = typename TriSolveHandle::HandleTempMemorySpace;
+  // -----------------------------------------------------------
+  // Functor for Lower-triangular solve
+  template <class ColptrView, class RowindType,
+            class ValuesType, class LHSType>
+  struct LowerTriSupernodalFunctor {
+    const bool unit_diagonal;
+    const bool invert_diagonal;
+    const bool invert_offdiagonal;
+    const int *supercols;
+    ColptrView colptr;
+    RowindType rowind;
+    ValuesType values;
 
-  using policy_type = Kokkos::TeamPolicy<execution_space>;
-  using member_type = typename policy_type::member_type;
+    int level;
+    work_view_int_t kernel_type;
+    work_view_int_t diag_kernel_type;
 
-  using scalar_t = typename ValuesType::non_const_value_type;
+    LHSType X;
 
-  using integer_view_t = Kokkos::View<int *, memory_space>;
-  using work_view_t =
-      typename Kokkos::View<scalar_t *,
-                            Kokkos::Device<execution_space, memory_space>>;
+    work_view_t work;  // needed with gemv for update&scatter
+    work_view_int_t work_offset;
 
-  using range_type = Kokkos::pair<int, int>;
+    entries_t nodes_grouped_by_level;
 
-  const bool unit_diagonal;
-  const bool invert_diagonal;
-  const bool invert_offdiagonal;
-  const int *supercols;
-  ColptrView colptr;
-  RowindType rowind;
-  ValuesType values;
+    long node_count;
 
-  int level;
-  integer_view_t kernel_type;
-  integer_view_t diag_kernel_type;
-
-  LHSType X;
-
-  work_view_t work;  // needed with gemv for update&scatter
-  integer_view_t work_offset;
-
-  NGBLType nodes_grouped_by_level;
-
-  long node_count;
-
-  // constructor
-  LowerTriSupernodalFunctor(  // supernode info
+    // constructor
+    LowerTriSupernodalFunctor(  // supernode info
       const bool unit_diagonal_, const bool invert_diagonal_,
       const bool invert_offdiagonal_, const int *supercols_,
       // L in CSC
       const ColptrView &colptr_, const RowindType &rowind_,
       const ValuesType &values_,
       // options to pick kernel type
-      int level_, integer_view_t &kernel_type_,
-      integer_view_t &diag_kernel_type_,
+      int level_, work_view_int_t &kernel_type_,
+      work_view_int_t &diag_kernel_type_,
       // right-hand-side (input), solution (output)
       LHSType &X_,
       // workspace
-      work_view_t work_, integer_view_t &work_offset_,
+      work_view_t work_, work_view_int_t &work_offset_,
       //
-      const NGBLType &nodes_grouped_by_level_, long node_count_)
+      const entries_t &nodes_grouped_by_level_, long node_count_)
       : unit_diagonal(unit_diagonal_),
         invert_diagonal(invert_diagonal_),
         invert_offdiagonal(invert_offdiagonal_),
@@ -833,199 +776,184 @@ struct LowerTriSupernodalFunctor {
         nodes_grouped_by_level(nodes_grouped_by_level_),
         node_count(node_count_) {}
 
-  // operator
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const member_type &team) const {
-    /* ---------------------------------------------------------------------- */
-    /* get inputs */
-    /* ---------------------------------------------------------------------- */
-    const int league_rank = team.league_rank();  // batch id
-    const int team_size   = team.team_size();
-    const int team_rank   = team.team_rank();
-    const scalar_t zero(0.0);
-    const scalar_t one(1.0);
+    // operator
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const member_type &team) const {
+      /* ---------------------------------------------------------------------- */
+      /* get inputs */
+      /* ---------------------------------------------------------------------- */
+      const int league_rank = team.league_rank();  // batch id
+      const int team_size   = team.team_size();
+      const int team_rank   = team.team_rank();
+      const scalar_t zero(0.0);
+      const scalar_t one(1.0);
 
-    auto s = nodes_grouped_by_level(node_count + league_rank);
+      auto s = nodes_grouped_by_level(node_count + league_rank);
 
-    // supernodal column size
-    const int j1 = supercols[s];
-    const int j2 = supercols[s + 1];
-    // > number of columns in the s-th supernode column
-    const int nscol = j2 - j1;
-    // "total" number of rows in all the supernodes (diagonal+off-diagonal)
-    const int i1    = colptr(j1);
-    const int nsrow = colptr(j1 + 1) - i1;
+      // supernodal column size
+      const int j1 = supercols[s];
+      const int j2 = supercols[s + 1];
+      // > number of columns in the s-th supernode column
+      const int nscol = j2 - j1;
+      // "total" number of rows in all the supernodes (diagonal+off-diagonal)
+      const int i1    = colptr(j1);
+      const int nsrow = colptr(j1 + 1) - i1;
 
-    // create a view for the s-th supernocal column
-    // NOTE: we currently supports only default_layout = LayoutLeft
-    scalar_t *dataL = const_cast<scalar_t *>(values.data());
-    Kokkos::View<scalar_t **, default_layout, memory_space,
-                 Kokkos::MemoryUnmanaged>
+      // create a view for the s-th supernocal column
+      // NOTE: we currently supports only default_layout = LayoutLeft
+      scalar_t *dataL = const_cast<scalar_t *>(values.data());
+      Kokkos::View<scalar_t **, default_layout, temp_mem_space,
+                   Kokkos::MemoryUnmanaged>
         viewL(&dataL[i1], nsrow, nscol);
 
-    // extract part of the solution, corresponding to the diagonal block
-    auto Xj = Kokkos::subview(X, range_type(j1, j2));
+      // extract part of the solution, corresponding to the diagonal block
+      auto Xj = Kokkos::subview(X, range_type(j1, j2));
 
-    // workspace
-    const int workoffset = work_offset(s);
-    auto Z               = Kokkos::subview(
+      // workspace
+      const int workoffset = work_offset(s);
+      auto Z               = Kokkos::subview(
         work, range_type(workoffset + nscol, workoffset + nsrow));
 
-    if (diag_kernel_type(level) != 3) {  // not a device-level TRSM-solve
-      if (invert_offdiagonal) {
-        // combined TRSM solve with diagonal + GEMV update with off-diagonal
-        auto Y = Kokkos::subview(
+      if (diag_kernel_type(level) != 3) {  // not a device-level TRSM-solve
+        if (invert_offdiagonal) {
+          // combined TRSM solve with diagonal + GEMV update with off-diagonal
+          auto Y = Kokkos::subview(
             work,
             range_type(
                 workoffset,
                 workoffset + nsrow));  // needed for gemv instead of trmv/trsv
-        auto Ljj = Kokkos::subview(viewL, range_type(0, nsrow), Kokkos::ALL());
-        KokkosBlas::TeamGemv<member_type, KokkosBlas::Trans::NoTranspose,
-                             KokkosBlas::Algo::Gemv::Unblocked>::invoke(team,
-                                                                        one,
-                                                                        Ljj, Xj,
-                                                                        zero,
-                                                                        Y);
-        team.team_barrier();
-        for (int ii = team_rank; ii < nscol; ii += team_size) {
-          Xj(ii) = Y(ii);
-        }
-        team.team_barrier();
-      } else {
-        /* TRSM with diagonal block */
-        // extract diagonal and off-diagonal blocks of L
-        auto Ljj = Kokkos::subview(viewL, range_type(0, nscol), Kokkos::ALL());
-        if (invert_diagonal) {
-          // workspace
-          auto Y = Kokkos::subview(
+          auto Ljj = Kokkos::subview(viewL, range_type(0, nsrow), Kokkos::ALL());
+          KokkosBlas::TeamGemv<member_type, KokkosBlas::Trans::NoTranspose,
+                               KokkosBlas::Algo::Gemv::Unblocked>::invoke(team,
+                                                                          one,
+                                                                          Ljj, Xj,
+                                                                          zero,
+                                                                          Y);
+          team.team_barrier();
+          for (int ii = team_rank; ii < nscol; ii += team_size) {
+            Xj(ii) = Y(ii);
+          }
+          team.team_barrier();
+        } else {
+          /* TRSM with diagonal block */
+          // extract diagonal and off-diagonal blocks of L
+          auto Ljj = Kokkos::subview(viewL, range_type(0, nscol), Kokkos::ALL());
+          if (invert_diagonal) {
+            // workspace
+            auto Y = Kokkos::subview(
               work,
               range_type(
                   workoffset,
                   workoffset + nscol));  // needed for gemv instead of trmv/trsv
-          for (int ii = team_rank; ii < nscol; ii += team_size) {
-            Y(ii) = Xj(ii);
-          }
-          team.team_barrier();
-          // calling team-level "Unblocked" gemv on small-size diagonal in
-          // KokkosBatched
-          KokkosBlas::TeamGemv<member_type, KokkosBlas::Trans::NoTranspose,
-                               KokkosBlas::Algo::Gemv::Unblocked>::invoke(team,
-                                                                          one,
-                                                                          Ljj,
-                                                                          Y,
-                                                                          zero,
-                                                                          Xj);
-        } else {
-          // NOTE: we currently supports only default_layout = LayoutLeft
-          Kokkos::View<scalar_t **, default_layout, memory_space,
-                       Kokkos::MemoryUnmanaged>
+            for (int ii = team_rank; ii < nscol; ii += team_size) {
+              Y(ii) = Xj(ii);
+            }
+            team.team_barrier();
+            // calling team-level "Unblocked" gemv on small-size diagonal in
+            // KokkosBatched
+            KokkosBlas::TeamGemv<member_type, KokkosBlas::Trans::NoTranspose,
+                                 KokkosBlas::Algo::Gemv::Unblocked>::invoke(team,
+                                                                            one,
+                                                                            Ljj,
+                                                                            Y,
+                                                                            zero,
+                                                                            Xj);
+          } else {
+            // NOTE: we currently supports only default_layout = LayoutLeft
+            Kokkos::View<scalar_t **, default_layout, temp_mem_space,
+                         Kokkos::MemoryUnmanaged>
               Xjj(Xj.data(), nscol, 1);
-          if (unit_diagonal) {
-            KokkosBatched::TeamTrsm<
+            if (unit_diagonal) {
+              KokkosBatched::TeamTrsm<
                 member_type, KokkosBatched::Side::Left,
                 KokkosBatched::Uplo::Lower, KokkosBatched::Trans::NoTranspose,
                 KokkosBatched::Diag::Unit,
                 KokkosBatched::Algo::Trsm::Unblocked>::invoke(team, one, Ljj,
                                                               Xjj);
-          } else {
-            KokkosBatched::TeamTrsm<
+            } else {
+              KokkosBatched::TeamTrsm<
                 member_type, KokkosBatched::Side::Left,
                 KokkosBatched::Uplo::Lower, KokkosBatched::Trans::NoTranspose,
                 KokkosBatched::Diag::NonUnit,
                 KokkosBatched::Algo::Trsm::Unblocked>::invoke(team, one, Ljj,
                                                               Xjj);
+            }
           }
-        }
-        team.team_barrier();
+          team.team_barrier();
 
-        /* GEMM to update with off diagonal blocks */
-        auto Lij =
+          /* GEMM to update with off diagonal blocks */
+          auto Lij =
             Kokkos::subview(viewL, range_type(nscol, nsrow), Kokkos::ALL());
-        KokkosBlas::TeamGemv<member_type, KokkosBatched::Trans::NoTranspose,
-                             KokkosBlas::Algo::Gemv::Unblocked>::invoke(team,
-                                                                        one,
-                                                                        Lij, Xj,
-                                                                        zero,
-                                                                        Z);
-        team.team_barrier();
+          KokkosBlas::TeamGemv<member_type, KokkosBatched::Trans::NoTranspose,
+                               KokkosBlas::Algo::Gemv::Unblocked>::invoke(team,
+                                                                          one,
+                                                                          Lij, Xj,
+                                                                          zero,
+                                                                          Z);
+          team.team_barrier();
+        }
       }
-    }
 
-    /* scatter vectors back into X */
-    int i2 = i1 + nscol;  // offset into rowind
-    int nsrow2 =
+      /* scatter vectors back into X */
+      int i2 = i1 + nscol;  // offset into rowind
+      int nsrow2 =
         nsrow -
         nscol;  // "total" number of rows in all the off-diagonal supernodes
-    Kokkos::View<scalar_t *, memory_space,
-                 Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::Atomic>>
+      Kokkos::View<scalar_t *, temp_mem_space,
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::Atomic>>
         Xatomic(X.data(), X.extent(0));
-    for (int ii = team_rank; ii < nsrow2; ii += team_size) {
-      int i = rowind(i2 + ii);
-      Xatomic(i) -= Z(ii);
+      for (int ii = team_rank; ii < nsrow2; ii += team_size) {
+        int i = rowind(i2 + ii);
+        Xatomic(i) -= Z(ii);
+      }
+      team.team_barrier();
     }
-    team.team_barrier();
-  }
-};
+  };
 
-// -----------------------------------------------------------
-// Functor for Upper-triangular solve in CSR
-template <class ColptrType, class RowindType,
-          class ValuesType, class LHSType, class NGBLType>
-struct UpperTriSupernodalFunctor {
-  using execution_space = typename TriSolveHandle::HandleExecSpace;
-  using memory_space    = typename TriSolveHandle::HandleTempMemorySpace;
-
-  using policy_type = Kokkos::TeamPolicy<execution_space>;
-  using member_type = typename policy_type::member_type;
-
-  using scalar_t = typename ValuesType::non_const_value_type;
-
-  using integer_view_t = Kokkos::View<int *, memory_space>;
-  using work_view_t =
-      typename Kokkos::View<scalar_t *,
-                            Kokkos::Device<execution_space, memory_space>>;
-
-  // NOTE: we currently supports only default_layout = LayoutLeft
-  using SupernodeView =
-      typename Kokkos::View<scalar_t **, default_layout, memory_space,
+  // -----------------------------------------------------------
+  // Functor for Upper-triangular solve in CSR
+  template <class ColptrType, class RowindType,
+            class ValuesType, class LHSType>
+  struct UpperTriSupernodalFunctor {
+    // NOTE: we currently supports only default_layout = LayoutLeft
+    using SupernodeView =
+      typename Kokkos::View<scalar_t **, default_layout, temp_mem_space,
                             Kokkos::MemoryUnmanaged>;
 
-  using range_type = Kokkos::pair<int, int>;
+    bool invert_diagonal;
+    const int *supercols;
+    ColptrType colptr;
+    RowindType rowind;
+    ValuesType values;
 
-  bool invert_diagonal;
-  const int *supercols;
-  ColptrType colptr;
-  RowindType rowind;
-  ValuesType values;
+    int level;
+    work_view_int_t kernel_type;
+    work_view_int_t diag_kernel_type;
 
-  int level;
-  integer_view_t kernel_type;
-  integer_view_t diag_kernel_type;
+    LHSType X;
 
-  LHSType X;
+    work_view_t work;  // needed with gemv for update&scatter
+    work_view_int_t work_offset;
 
-  work_view_t work;  // needed with gemv for update&scatter
-  integer_view_t work_offset;
+    entries_t nodes_grouped_by_level;
 
-  NGBLType nodes_grouped_by_level;
+    long node_count;
 
-  long node_count;
-
-  // constructor
-  UpperTriSupernodalFunctor(  // supernode info
+    // constructor
+    UpperTriSupernodalFunctor(  // supernode info
       bool invert_diagonal_, const int *supercols_,
       // U in CSR
       const ColptrType &colptr_, const RowindType &rowind_,
       const ValuesType &values_,
       // options to pick kernel type
-      int level_, integer_view_t &kernel_type_,
-      integer_view_t &diag_kernel_type_,
+      int level_, work_view_int_t &kernel_type_,
+      work_view_int_t &diag_kernel_type_,
       // right-hand-side (input), solution (output)
       LHSType &X_,
       // workspace
-      work_view_t &work_, integer_view_t &work_offset_,
+      work_view_t &work_, work_view_int_t &work_offset_,
       //
-      const NGBLType &nodes_grouped_by_level_, long node_count_)
+      const entries_t &nodes_grouped_by_level_, long node_count_)
       : invert_diagonal(invert_diagonal_),
         supercols(supercols_),
         colptr(colptr_),
@@ -1040,145 +968,130 @@ struct UpperTriSupernodalFunctor {
         nodes_grouped_by_level(nodes_grouped_by_level_),
         node_count(node_count_) {}
 
-  // operator
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const member_type &team) const {
-    /* ---------------------------------------------------------------------- */
-    /* get inputs */
-    /* ---------------------------------------------------------------------- */
-    const int league_rank = team.league_rank();  // batch id
-    const int team_size   = team.team_size();
-    const int team_rank   = team.team_rank();
-    const scalar_t zero(0.0);
-    const scalar_t one(1.0);
+    // operator
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const member_type &team) const {
+      /* ---------------------------------------------------------------------- */
+      /* get inputs */
+      /* ---------------------------------------------------------------------- */
+      const int league_rank = team.league_rank();  // batch id
+      const int team_size   = team.team_size();
+      const int team_rank   = team.team_rank();
+      const scalar_t zero(0.0);
+      const scalar_t one(1.0);
 
-    auto s = nodes_grouped_by_level(node_count + league_rank);
+      auto s = nodes_grouped_by_level(node_count + league_rank);
 
-    // number of columns in the s-th supernode column
-    int j1    = supercols[s];
-    int j2    = supercols[s + 1];
-    int nscol = j2 - j1;
-    // "total" number of rows in all the supernodes (diagonal+off-diagonal)
-    int i1    = colptr(j1);
-    int nsrow = colptr(j1 + 1) - i1;
+      // number of columns in the s-th supernode column
+      int j1    = supercols[s];
+      int j2    = supercols[s + 1];
+      int nscol = j2 - j1;
+      // "total" number of rows in all the supernodes (diagonal+off-diagonal)
+      int i1    = colptr(j1);
+      int nsrow = colptr(j1 + 1) - i1;
 
-    // create a view of the s-th supernocal row of U
-    scalar_t *dataU = const_cast<scalar_t *>(values.data());
-    SupernodeView viewU(&dataU[i1], nsrow, nscol);
+      // create a view of the s-th supernocal row of U
+      scalar_t *dataU = const_cast<scalar_t *>(values.data());
+      SupernodeView viewU(&dataU[i1], nsrow, nscol);
 
-    // extract part of solution, corresponding to the diagonal block U(s, s)
-    auto Xj       = Kokkos::subview(X, range_type(j1, j2));
-    using Xj_type = decltype(Xj);
+      // extract part of solution, corresponding to the diagonal block U(s, s)
+      auto Xj       = Kokkos::subview(X, range_type(j1, j2));
+      using Xj_type = decltype(Xj);
 
-    // workspaces
-    int workoffset = work_offset(s);
+      // workspaces
+      int workoffset = work_offset(s);
 
-    // "total" number of rows in all the off-diagonal supernodes
-    int nsrow2 = nsrow - nscol;
-    /* gather vector into Z */
-    int i2 = i1 + nscol;  // offset into rowind
-    auto Z = Kokkos::subview(
+      // "total" number of rows in all the off-diagonal supernodes
+      int nsrow2 = nsrow - nscol;
+      /* gather vector into Z */
+      int i2 = i1 + nscol;  // offset into rowind
+      auto Z = Kokkos::subview(
         work,
         range_type(workoffset + nscol,
                    workoffset + nsrow));  // needed with gemv for update&scatter
-    using Z_type = decltype(Z);
-    for (int ii = team_rank; ii < nsrow2; ii += team_size) {
-      int i = rowind(i2 + ii);
-      Z(ii) = X(i);
-    }
-    team.team_barrier();
-    /* GEMM to update with off diagonal blocks, Xj = -Uij^T * Z */
-    if (diag_kernel_type(level) != 3) {
-      // not device-level GEMV-udpate
-      auto Uij =
+      using Z_type = decltype(Z);
+      for (int ii = team_rank; ii < nsrow2; ii += team_size) {
+        int i = rowind(i2 + ii);
+        Z(ii) = X(i);
+      }
+      team.team_barrier();
+      /* GEMM to update with off diagonal blocks, Xj = -Uij^T * Z */
+      if (diag_kernel_type(level) != 3) {
+        // not device-level GEMV-udpate
+        auto Uij =
           Kokkos::subview(viewU, range_type(nscol, nsrow), Kokkos::ALL());
-      using Uij_type = decltype(Uij);
-      KokkosBlas::TeamGemv<member_type, KokkosBatched::Trans::Transpose,
-                           KokkosBlas::Algo::Gemv::Unblocked>::
+        using Uij_type = decltype(Uij);
+        KokkosBlas::TeamGemv<member_type, KokkosBatched::Trans::Transpose,
+                             KokkosBlas::Algo::Gemv::Unblocked>::
           template invoke<const scalar_t, Uij_type, Z_type, Xj_type>(
               team, -one, Uij, Z, one, Xj);
-      team.team_barrier();
+        team.team_barrier();
 
-      /* TRSM with diagonal block */
-      // extract diagonal and off-diagonal blocks of U
-      auto Ujj = Kokkos::subview(viewU, range_type(0, nscol), Kokkos::ALL());
-      using Ujj_type = decltype(Ujj);
+        /* TRSM with diagonal block */
+        // extract diagonal and off-diagonal blocks of U
+        auto Ujj = Kokkos::subview(viewU, range_type(0, nscol), Kokkos::ALL());
+        using Ujj_type = decltype(Ujj);
 
-      if (invert_diagonal) {
-        // workspace
-        auto Y = Kokkos::subview(
+        if (invert_diagonal) {
+          // workspace
+          auto Y = Kokkos::subview(
             work,
             range_type(
                 workoffset,
                 workoffset + nscol));  // needed for gemv instead of trmv/trsv
-        using Y_type = decltype(Y);
-        for (int ii = team_rank; ii < nscol; ii += team_size) {
-          Y(ii) = Xj(ii);
-        }
-        team.team_barrier();
+          using Y_type = decltype(Y);
+          for (int ii = team_rank; ii < nscol; ii += team_size) {
+            Y(ii) = Xj(ii);
+          }
+          team.team_barrier();
 
-        // caling team-level kernel in KokkosBatched on a small-size diagonal
-        KokkosBlas::TeamGemv<member_type, KokkosBatched::Trans::Transpose,
-                             KokkosBlas::Algo::Gemv::Unblocked>::
+          // caling team-level kernel in KokkosBatched on a small-size diagonal
+          KokkosBlas::TeamGemv<member_type, KokkosBatched::Trans::Transpose,
+                               KokkosBlas::Algo::Gemv::Unblocked>::
             template invoke<const scalar_t, Ujj_type, Y_type, Xj_type>(
                 team, one, Ujj, Y, zero, Xj);
-      } else {
-        // NOTE: we currently supports only default_layout = LayoutLeft
-        Kokkos::View<scalar_t **, default_layout, memory_space,
-                     Kokkos::MemoryUnmanaged>
+        } else {
+          // NOTE: we currently supports only default_layout = LayoutLeft
+          Kokkos::View<scalar_t **, default_layout, temp_mem_space,
+                       Kokkos::MemoryUnmanaged>
             Xjj(Xj.data(), nscol, 1);
-        KokkosBatched::TeamTrsm<
+          KokkosBatched::TeamTrsm<
             member_type, KokkosBatched::Side::Left, KokkosBatched::Uplo::Lower,
             KokkosBatched::Trans::Transpose, KokkosBatched::Diag::NonUnit,
             KokkosBatched::Algo::Trsm::Unblocked>::invoke(team, one, Ujj, Xjj);
+        }
+        team.team_barrier();
       }
-      team.team_barrier();
     }
-  }
-};
+  };
 
-// -----------------------------------------------------------
-// Functor for Upper-triangular solve in CSC
-template <class ColptrType, class RowindType,
-          class ValuesType, class LHSType, class NGBLType>
-struct UpperTriTranSupernodalFunctor {
-  using execution_space = typename TriSolveHandle::HandleExecSpace;
-  using memory_space    = typename TriSolveHandle::HandleTempMemorySpace;
+  // -----------------------------------------------------------
+  // Functor for Upper-triangular solve in CSC
+  template <class ColptrType, class RowindType,
+            class ValuesType, class LHSType>
+  struct UpperTriTranSupernodalFunctor {
+    const bool invert_diagonal;
+    const bool invert_offdiagonal;
+    const int *supercols;
+    ColptrType colptr;
+    RowindType rowind;
+    ValuesType values;
 
-  using policy_type = Kokkos::TeamPolicy<execution_space>;
-  using member_type = typename policy_type::member_type;
+    int level;
+    work_view_int_t kernel_type;
+    work_view_int_t diag_kernel_type;
 
-  using scalar_t = typename ValuesType::non_const_value_type;
+    LHSType X;
 
-  using integer_view_t = Kokkos::View<int *, memory_space>;
-  using work_view_t =
-      typename Kokkos::View<scalar_t *,
-                            Kokkos::Device<execution_space, memory_space>>;
+    work_view_t work;  // needed with gemv for update&scatter
+    work_view_int_t work_offset;
 
-  using range_type = Kokkos::pair<int, int>;
+    entries_t nodes_grouped_by_level;
 
-  const bool invert_diagonal;
-  const bool invert_offdiagonal;
-  const int *supercols;
-  ColptrType colptr;
-  RowindType rowind;
-  ValuesType values;
+    long node_count;
 
-  int level;
-  integer_view_t kernel_type;
-  integer_view_t diag_kernel_type;
-
-  LHSType X;
-
-  work_view_t work;  // needed with gemv for update&scatter
-  integer_view_t work_offset;
-
-  NGBLType nodes_grouped_by_level;
-
-  long node_count;
-
-  // constructor
-  UpperTriTranSupernodalFunctor(  // supernode info
+    // constructor
+    UpperTriTranSupernodalFunctor(  // supernode info
       const bool invert_diagonal_, const bool invert_offdiagonal_,
       const int *supercols_,
 
@@ -1186,14 +1099,14 @@ struct UpperTriTranSupernodalFunctor {
       const ColptrType &colptr_, const RowindType &rowind_,
       const ValuesType &values_,
       // options to pick kernel type
-      const int level_, const integer_view_t &kernel_type_,
-      const integer_view_t &diag_kernel_type_,
+      const int level_, const work_view_int_t &kernel_type_,
+      const work_view_int_t &diag_kernel_type_,
       // right-hand-side (input), solution (output)
       const LHSType &X_,
       // workspace
-      const work_view_t &work_, const integer_view_t &work_offset_,
+      const work_view_t &work_, const work_view_int_t &work_offset_,
       //
-      const NGBLType &nodes_grouped_by_level_, const long node_count_)
+      const entries_t &nodes_grouped_by_level_, const long node_count_)
       : invert_diagonal(invert_diagonal_),
         invert_offdiagonal(invert_offdiagonal_),
         supercols(supercols_),
@@ -1209,148 +1122,147 @@ struct UpperTriTranSupernodalFunctor {
         nodes_grouped_by_level(nodes_grouped_by_level_),
         node_count(node_count_) {}
 
-  // operator
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const member_type &team) const {
-    /* ---------------------------------------------------------------------- */
-    /* get inputs */
-    /* ---------------------------------------------------------------------- */
-    const int league_rank = team.league_rank();  // batch id
-    const int team_size   = team.team_size();
-    const int team_rank   = team.team_rank();
-    const scalar_t zero(0.0);
-    const scalar_t one(1.0);
+    // operator
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const member_type &team) const {
+      /* ---------------------------------------------------------------------- */
+      /* get inputs */
+      /* ---------------------------------------------------------------------- */
+      const int league_rank = team.league_rank();  // batch id
+      const int team_size   = team.team_size();
+      const int team_rank   = team.team_rank();
+      const scalar_t zero(0.0);
+      const scalar_t one(1.0);
 
-    auto s = nodes_grouped_by_level(node_count + league_rank);
+      auto s = nodes_grouped_by_level(node_count + league_rank);
 
-    // number of columns in the s-th supernode column
-    const int j1    = supercols[s];
-    const int j2    = supercols[s + 1];
-    const int nscol = j2 - j1;
-    // "total" number of rows in all the supernodes (diagonal+off-diagonal)
-    const int i1    = colptr(j1);
-    const int nsrow = colptr(j1 + 1) - i1;
-    // "total" number of rows in all the off-diagonal supernodes
-    const int nsrow2 = nsrow - nscol;
+      // number of columns in the s-th supernode column
+      const int j1    = supercols[s];
+      const int j2    = supercols[s + 1];
+      const int nscol = j2 - j1;
+      // "total" number of rows in all the supernodes (diagonal+off-diagonal)
+      const int i1    = colptr(j1);
+      const int nsrow = colptr(j1 + 1) - i1;
+      // "total" number of rows in all the off-diagonal supernodes
+      const int nsrow2 = nsrow - nscol;
 
-    // create a view of the s-th supernocal column of U
-    // NOTE: we currently supports only default_layout = LayoutLeft
-    scalar_t *dataU = const_cast<scalar_t *>(values.data());
-    Kokkos::View<scalar_t **, default_layout, memory_space,
-                 Kokkos::MemoryUnmanaged>
+      // create a view of the s-th supernocal column of U
+      // NOTE: we currently supports only default_layout = LayoutLeft
+      scalar_t *dataU = const_cast<scalar_t *>(values.data());
+      Kokkos::View<scalar_t **, default_layout, temp_mem_space,
+                   Kokkos::MemoryUnmanaged>
         viewU(&dataU[i1], nsrow, nscol);
 
-    // extract part of solution, corresponding to the diagonal block U(s, s)
-    auto Xj = Kokkos::subview(X, range_type(j1, j2));
+      // extract part of solution, corresponding to the diagonal block U(s, s)
+      auto Xj = Kokkos::subview(X, range_type(j1, j2));
 
-    // workspaces
-    int workoffset = work_offset(s);
+      // workspaces
+      int workoffset = work_offset(s);
 
-    /* TRSM with diagonal block */
-    if (diag_kernel_type(level) != 3) {
-      // not device-level TRSM-solve
-      if (invert_offdiagonal) {
-        // extract diagonal + off-diagonal blocks of U
-        auto Y = Kokkos::subview(
+      /* TRSM with diagonal block */
+      if (diag_kernel_type(level) != 3) {
+        // not device-level TRSM-solve
+        if (invert_offdiagonal) {
+          // extract diagonal + off-diagonal blocks of U
+          auto Y = Kokkos::subview(
             work,
             range_type(
                 workoffset,
                 workoffset + nsrow));  // needed with gemv for update&scatter
-        auto Uij = Kokkos::subview(viewU, range_type(0, nsrow), Kokkos::ALL());
-        KokkosBlas::TeamGemv<member_type, KokkosBatched::Trans::NoTranspose,
-                             KokkosBlas::Algo::Gemv::Unblocked>::invoke(team,
-                                                                        one,
-                                                                        Uij, Xj,
-                                                                        zero,
-                                                                        Y);
-        team.team_barrier();
+          auto Uij = Kokkos::subview(viewU, range_type(0, nsrow), Kokkos::ALL());
+          KokkosBlas::TeamGemv<member_type, KokkosBatched::Trans::NoTranspose,
+                               KokkosBlas::Algo::Gemv::Unblocked>::invoke(team,
+                                                                          one,
+                                                                          Uij, Xj,
+                                                                          zero,
+                                                                          Y);
+          team.team_barrier();
         // copy the diagonal back to output
-        for (int ii = team_rank; ii < nscol; ii += team_size) {
-          Xj(ii) = Y(ii);
-        }
-      } else {
-        // extract diagonal block of U (stored on top)
-        auto Ujj = Kokkos::subview(viewU, range_type(0, nscol), Kokkos::ALL());
-        if (invert_diagonal) {
-          auto Y = Kokkos::subview(
+          for (int ii = team_rank; ii < nscol; ii += team_size) {
+            Xj(ii) = Y(ii);
+          }
+        } else {
+          // extract diagonal block of U (stored on top)
+          auto Ujj = Kokkos::subview(viewU, range_type(0, nscol), Kokkos::ALL());
+          if (invert_diagonal) {
+            auto Y = Kokkos::subview(
               work,
               range_type(
                   workoffset,
                   workoffset + nscol));  // needed for gemv instead of trmv/trsv
-          for (int ii = team_rank; ii < nscol; ii += team_size) {
-            Y(ii) = Xj(ii);
-          }
-          team.team_barrier();
-          KokkosBlas::TeamGemv<member_type, KokkosBatched::Trans::NoTranspose,
-                               KokkosBlas::Algo::Gemv::Unblocked>::invoke(team,
-                                                                          one,
-                                                                          Ujj,
-                                                                          Y,
-                                                                          zero,
-                                                                          Xj);
-        } else {
-          // NOTE: we currently supports only default_layout = LayoutLeft
-          Kokkos::View<scalar_t **, default_layout, memory_space,
-                       Kokkos::MemoryUnmanaged>
+            for (int ii = team_rank; ii < nscol; ii += team_size) {
+              Y(ii) = Xj(ii);
+            }
+            team.team_barrier();
+            KokkosBlas::TeamGemv<member_type, KokkosBatched::Trans::NoTranspose,
+                                 KokkosBlas::Algo::Gemv::Unblocked>::invoke(team,
+                                                                            one,
+                                                                            Ujj,
+                                                                            Y,
+                                                                            zero,
+                                                                            Xj);
+          } else {
+            // NOTE: we currently supports only default_layout = LayoutLeft
+            Kokkos::View<scalar_t **, default_layout, temp_mem_space,
+                         Kokkos::MemoryUnmanaged>
               Xjj(Xj.data(), nscol, 1);
-          KokkosBatched::TeamTrsm<
+            KokkosBatched::TeamTrsm<
               member_type, KokkosBatched::Side::Left,
               KokkosBatched::Uplo::Upper, KokkosBatched::Trans::NoTranspose,
               KokkosBatched::Diag::NonUnit,
               KokkosBatched::Algo::Trsm::Unblocked>::invoke(team, one, Ujj,
                                                             Xjj);
+          }
         }
-      }
-      team.team_barrier();
-    }
-    if (nsrow2 > 0) {
-      /* GEMM to update off diagonal blocks, Z = Uij * Xj */
-      auto Z = Kokkos::subview(
-          work, range_type(workoffset + nscol, workoffset + nsrow));
-      if (!invert_offdiagonal && diag_kernel_type(level) != 3) {
-        // not device-level TRSM-solve
-        auto Uij =
-            Kokkos::subview(viewU, range_type(nscol, nsrow), Kokkos::ALL());
-        KokkosBlas::TeamGemv<member_type, KokkosBatched::Trans::NoTranspose,
-                             KokkosBlas::Algo::Gemv::Unblocked>::invoke(team,
-                                                                        one,
-                                                                        Uij, Xj,
-                                                                        zero,
-                                                                        Z);
         team.team_barrier();
       }
+      if (nsrow2 > 0) {
+        /* GEMM to update off diagonal blocks, Z = Uij * Xj */
+        auto Z = Kokkos::subview(
+          work, range_type(workoffset + nscol, workoffset + nsrow));
+        if (!invert_offdiagonal && diag_kernel_type(level) != 3) {
+          // not device-level TRSM-solve
+          auto Uij =
+            Kokkos::subview(viewU, range_type(nscol, nsrow), Kokkos::ALL());
+          KokkosBlas::TeamGemv<member_type, KokkosBatched::Trans::NoTranspose,
+                               KokkosBlas::Algo::Gemv::Unblocked>::invoke(team,
+                                                                          one,
+                                                                          Uij, Xj,
+                                                                          zero,
+                                                                          Z);
+          team.team_barrier();
+        }
 
-      /* scatter vector into Z */
-      int i2 = i1 + nscol;  // offset into rowind
-      Kokkos::View<scalar_t *, memory_space,
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::Atomic>>
+        /* scatter vector into Z */
+        int i2 = i1 + nscol;  // offset into rowind
+        Kokkos::View<scalar_t *, temp_mem_space,
+                     Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::Atomic>>
           Xatomic(X.data(), X.extent(0));
-      for (int ii = team_rank; ii < nsrow2; ii += team_size) {
-        int i = rowind(i2 + ii);
-        Xatomic(i) -= Z(ii);
+        for (int ii = team_rank; ii < nsrow2; ii += team_size) {
+          int i = rowind(i2 + ii);
+          Xatomic(i) -= Z(ii);
+        }
+        team.team_barrier();
       }
-      team.team_barrier();
     }
-  }
-};
+  };
 #endif
 
-template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
-          class RHSType, class NGBLType>
-struct UpperTriLvlSchedRPSolverFunctor {
-  typedef typename EntriesType::non_const_value_type lno_t;
-  RowMapType row_map;
-  EntriesType entries;
-  ValuesType values;
-  LHSType lhs;
-  RHSType rhs;
-  NGBLType nodes_grouped_by_level;
+  template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
+            class RHSType>
+  struct UpperTriLvlSchedRPSolverFunctor {
+    RowMapType row_map;
+    EntriesType entries;
+    ValuesType values;
+    LHSType lhs;
+    RHSType rhs;
+    entries_t nodes_grouped_by_level;
 
-  UpperTriLvlSchedRPSolverFunctor(const RowMapType &row_map_,
-                                  const EntriesType &entries_,
-                                  const ValuesType &values_, LHSType &lhs_,
-                                  const RHSType &rhs_,
-                                  const NGBLType &nodes_grouped_by_level_)
+    UpperTriLvlSchedRPSolverFunctor(const RowMapType &row_map_,
+                                    const EntriesType &entries_,
+                                    const ValuesType &values_, LHSType &lhs_,
+                                    const RHSType &rhs_,
+                                    const entries_t &nodes_grouped_by_level_)
       : row_map(row_map_),
         entries(entries_),
         values(values_),
@@ -1358,71 +1270,65 @@ struct UpperTriLvlSchedRPSolverFunctor {
         rhs(rhs_),
         nodes_grouped_by_level(nodes_grouped_by_level_) {}
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const lno_t i) const {
-    auto rowid = nodes_grouped_by_level(i);
-    // Assuming indices are sorted per row, diag entry is final index in the
-    // list
-    long soffset   = row_map(rowid);
-    long eoffset   = row_map(rowid + 1);
-    auto rhs_rowid = rhs(rowid);
-    for (long ptr = eoffset - 1; ptr >= soffset; --ptr) {
-      auto colid = entries(ptr);
-      auto val   = values(ptr);
-      if (colid != rowid) {
-        rhs_rowid = rhs_rowid - val * lhs(colid);
-      } else {
-        lhs(rowid) = rhs_rowid / val;
-      }
-    }  // end for ptr
-  }
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const lno_t i) const {
+      auto rowid = nodes_grouped_by_level(i);
+      // Assuming indices are sorted per row, diag entry is final index in the
+      // list
+      long soffset   = row_map(rowid);
+      long eoffset   = row_map(rowid + 1);
+      auto rhs_rowid = rhs(rowid);
+      for (long ptr = eoffset - 1; ptr >= soffset; --ptr) {
+        auto colid = entries(ptr);
+        auto val   = values(ptr);
+        if (colid != rowid) {
+          rhs_rowid = rhs_rowid - val * lhs(colid);
+        } else {
+          lhs(rowid) = rhs_rowid / val;
+        }
+      }  // end for ptr
+    }
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const UnsortedTag &, const lno_t i) const {
-    auto rowid     = nodes_grouped_by_level(i);
-    long soffset   = row_map(rowid);
-    long eoffset   = row_map(rowid + 1);
-    auto rhs_rowid = rhs(rowid);
-    auto diag      = -1;
-    for (long ptr = eoffset - 1; ptr >= soffset; --ptr) {
-      auto colid = entries(ptr);
-      auto val   = values(ptr);
-      if (colid != rowid) {
-        rhs_rowid = rhs_rowid - val * lhs(colid);
-      } else {
-        diag = ptr;
-      }
-    }  // end for ptr
-    lhs(rowid) = rhs_rowid / values(diag);
-  }
-};
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const UnsortedTag &, const lno_t i) const {
+      auto rowid     = nodes_grouped_by_level(i);
+      long soffset   = row_map(rowid);
+      long eoffset   = row_map(rowid + 1);
+      auto rhs_rowid = rhs(rowid);
+      auto diag      = -1;
+      for (long ptr = eoffset - 1; ptr >= soffset; --ptr) {
+        auto colid = entries(ptr);
+        auto val   = values(ptr);
+        if (colid != rowid) {
+          rhs_rowid = rhs_rowid - val * lhs(colid);
+        } else {
+          diag = ptr;
+        }
+      }  // end for ptr
+      lhs(rowid) = rhs_rowid / values(diag);
+    }
+  };
 
-template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
-          class RHSType, class NGBLType>
-struct UpperTriLvlSchedTP1SolverFunctor {
-  typedef typename RowMapType::execution_space execution_space;
-  typedef Kokkos::TeamPolicy<execution_space> policy_type;
-  typedef typename policy_type::member_type member_type;
-  typedef typename EntriesType::non_const_value_type lno_t;
-  typedef typename ValuesType::non_const_value_type scalar_t;
+  template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
+            class RHSType>
+  struct UpperTriLvlSchedTP1SolverFunctor {
+    RowMapType row_map;
+    EntriesType entries;
+    ValuesType values;
+    LHSType lhs;
+    RHSType rhs;
+    entries_t nodes_grouped_by_level;
 
-  RowMapType row_map;
-  EntriesType entries;
-  ValuesType values;
-  LHSType lhs;
-  RHSType rhs;
-  NGBLType nodes_grouped_by_level;
+    long node_count;  // like "block" offset into ngbl, my_league is the "local"
+                      // offset
+    long node_groups;
 
-  long node_count;  // like "block" offset into ngbl, my_league is the "local"
-                    // offset
-  long node_groups;
-
-  UpperTriLvlSchedTP1SolverFunctor(const RowMapType &row_map_,
-                                   const EntriesType &entries_,
-                                   const ValuesType &values_, LHSType &lhs_,
-                                   const RHSType &rhs_,
-                                   const NGBLType &nodes_grouped_by_level_,
-                                   long node_count_, long node_groups_ = 0)
+    UpperTriLvlSchedTP1SolverFunctor(const RowMapType &row_map_,
+                                     const EntriesType &entries_,
+                                     const ValuesType &values_, LHSType &lhs_,
+                                     const RHSType &rhs_,
+                                     const entries_t &nodes_grouped_by_level_,
+                                     long node_count_, long node_groups_ = 0)
       : row_map(row_map_),
         entries(entries_),
         values(values_),
@@ -1432,18 +1338,18 @@ struct UpperTriLvlSchedTP1SolverFunctor {
         node_count(node_count_),
         node_groups(node_groups_) {}
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const member_type &team) const {
-    auto my_league = team.league_rank();  // map to rowid
-    auto rowid     = nodes_grouped_by_level(my_league + node_count);
-    auto my_rank   = team.team_rank();
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const member_type &team) const {
+      auto my_league = team.league_rank();  // map to rowid
+      auto rowid     = nodes_grouped_by_level(my_league + node_count);
+      auto my_rank   = team.team_rank();
 
-    auto soffset   = row_map(rowid);
-    auto eoffset   = row_map(rowid + 1);
-    auto rhs_rowid = rhs(rowid);
-    scalar_t diff  = scalar_t(0.0);
+      auto soffset   = row_map(rowid);
+      auto eoffset   = row_map(rowid + 1);
+      auto rhs_rowid = rhs(rowid);
+      scalar_t diff  = scalar_t(0.0);
 
-    Kokkos::parallel_reduce(
+      Kokkos::parallel_reduce(
         Kokkos::TeamThreadRange(team, soffset, eoffset),
         [&](const long ptr, scalar_t &tdiff) {
           auto colid = entries(ptr);
@@ -1454,30 +1360,30 @@ struct UpperTriLvlSchedTP1SolverFunctor {
         },
         diff);
 
-    team.team_barrier();
+      team.team_barrier();
 
-    // At end, finalize rowid == colid
-    // only one thread should do this, also can use Kokkos::single
-    if (my_rank == 0) {
-      // ASSUMPTION: sorted diagonal value located at start offset
-      lhs(rowid) = (rhs_rowid + diff) / values(soffset);
+      // At end, finalize rowid == colid
+      // only one thread should do this, also can use Kokkos::single
+      if (my_rank == 0) {
+        // ASSUMPTION: sorted diagonal value located at start offset
+        lhs(rowid) = (rhs_rowid + diff) / values(soffset);
+      }
     }
-  }
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const UnsortedTag &, const member_type &team) const {
-    auto my_league = team.league_rank();  // map to rowid
-    auto rowid     = nodes_grouped_by_level(my_league + node_count);
-    auto my_rank   = team.team_rank();
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const UnsortedTag &, const member_type &team) const {
+      auto my_league = team.league_rank();  // map to rowid
+      auto rowid     = nodes_grouped_by_level(my_league + node_count);
+      auto my_rank   = team.team_rank();
 
-    auto soffset   = row_map(rowid);
-    auto eoffset   = row_map(rowid + 1);
-    auto rhs_rowid = rhs(rowid);
-    scalar_t diff  = scalar_t(0.0);
+      auto soffset   = row_map(rowid);
+      auto eoffset   = row_map(rowid + 1);
+      auto rhs_rowid = rhs(rowid);
+      scalar_t diff  = scalar_t(0.0);
 
-    auto diag = -1;
+      auto diag = -1;
 
-    Kokkos::parallel_reduce(
+      Kokkos::parallel_reduce(
         Kokkos::TeamThreadRange(team, soffset, eoffset),
         [&](const long ptr, scalar_t &tdiff) {
           auto colid = entries(ptr);
@@ -1489,45 +1395,39 @@ struct UpperTriLvlSchedTP1SolverFunctor {
           }
         },
         diff);
-    team.team_barrier();
+      team.team_barrier();
 
-    // At end, finalize rowid == colid
-    // only one thread should do this, also can use Kokkos::single
-    if (my_rank == 0) {
-      lhs(rowid) = (rhs_rowid + diff) / values(diag);
+      // At end, finalize rowid == colid
+      // only one thread should do this, also can use Kokkos::single
+      if (my_rank == 0) {
+        lhs(rowid) = (rhs_rowid + diff) / values(diag);
+      }
     }
-  }
-};
+  };
 
-// FIXME CUDA: This algorithm not working with all integral type combos
-// In any case, this serves as a skeleton for 3-level hierarchical parallelism
-// for alg dev
-template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
-          class RHSType, class NGBLType>
-struct UpperTriLvlSchedTP2SolverFunctor {
-  typedef typename RowMapType::execution_space execution_space;
-  typedef Kokkos::TeamPolicy<execution_space> policy_type;
-  typedef typename policy_type::member_type member_type;
-  typedef typename EntriesType::non_const_value_type lno_t;
-  typedef typename ValuesType::non_const_value_type scalar_t;
+  // FIXME CUDA: This algorithm not working with all integral type combos
+  // In any case, this serves as a skeleton for 3-level hierarchical parallelism
+  // for alg dev
+  template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
+            class RHSType>
+  struct UpperTriLvlSchedTP2SolverFunctor {
+    RowMapType row_map;
+    EntriesType entries;
+    ValuesType values;
+    LHSType lhs;
+    RHSType rhs;
+    entries_t nodes_grouped_by_level;
 
-  RowMapType row_map;
-  EntriesType entries;
-  ValuesType values;
-  LHSType lhs;
-  RHSType rhs;
-  NGBLType nodes_grouped_by_level;
+    long node_count;  // like "block" offset into ngbl, my_league is the "local"
+                      // offset
+    long node_groups;
 
-  long node_count;  // like "block" offset into ngbl, my_league is the "local"
-                    // offset
-  long node_groups;
-
-  UpperTriLvlSchedTP2SolverFunctor(const RowMapType &row_map_,
-                                   const EntriesType &entries_,
-                                   const ValuesType &values_, LHSType &lhs_,
-                                   const RHSType &rhs_,
-                                   const NGBLType &nodes_grouped_by_level_,
-                                   long node_count_, long node_groups_ = 0)
+    UpperTriLvlSchedTP2SolverFunctor(const RowMapType &row_map_,
+                                     const EntriesType &entries_,
+                                     const ValuesType &values_, LHSType &lhs_,
+                                     const RHSType &rhs_,
+                                     const entries_t &nodes_grouped_by_level_,
+                                     long node_count_, long node_groups_ = 0)
       : row_map(row_map_),
         entries(entries_),
         values(values_),
@@ -1537,13 +1437,13 @@ struct UpperTriLvlSchedTP2SolverFunctor {
         node_count(node_count_),
         node_groups(node_groups_) {}
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const member_type &team) const {
-    auto my_league = team.league_rank();  // map to rowid
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const member_type &team) const {
+      auto my_league = team.league_rank();  // map to rowid
 
-    size_t nrows = row_map.extent(0) - 1;
+      size_t nrows = row_map.extent(0) - 1;
 
-    Kokkos::parallel_for(
+      Kokkos::parallel_for(
         Kokkos::TeamThreadRange(team, 0, node_groups), [&](const long ng) {
           auto rowid =
               nodes_grouped_by_level(node_count + my_league * node_groups + ng);
@@ -1569,16 +1469,16 @@ struct UpperTriLvlSchedTP2SolverFunctor {
           }  // end if
         });  // end TeamThreadRange
 
-    team.team_barrier();
-  }
+      team.team_barrier();
+    }
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const UnsortedTag &, const member_type &team) const {
-    auto my_league = team.league_rank();  // map to rowid
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const UnsortedTag &, const member_type &team) const {
+      auto my_league = team.league_rank();  // map to rowid
 
-    size_t nrows = row_map.extent(0) - 1;
+      size_t nrows = row_map.extent(0) - 1;
 
-    Kokkos::parallel_for(
+      Kokkos::parallel_for(
         Kokkos::TeamThreadRange(team, 0, node_groups), [&](const long ng) {
           auto rowid =
               nodes_grouped_by_level(node_count + my_league * node_groups + ng);
@@ -1606,42 +1506,36 @@ struct UpperTriLvlSchedTP2SolverFunctor {
           }  // end if
         });  // end TeamThreadRange
 
-    team.team_barrier();
-  }
-};
+      team.team_barrier();
+    }
+  };
 
-// --------------------------------
-// Single-block functors
-// --------------------------------
+  // --------------------------------
+  // Single-block functors
+  // --------------------------------
 
-template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
-          class RHSType, class NGBLType>
-struct LowerTriLvlSchedTP1SingleBlockFunctor {
-  typedef typename RowMapType::execution_space execution_space;
-  typedef Kokkos::TeamPolicy<execution_space> policy_type;
-  typedef typename policy_type::member_type member_type;
-  typedef typename EntriesType::non_const_value_type lno_t;
-  typedef typename ValuesType::non_const_value_type scalar_t;
+  template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
+            class RHSType>
+  struct LowerTriLvlSchedTP1SingleBlockFunctor {
+    RowMapType row_map;
+    EntriesType entries;
+    ValuesType values;
+    LHSType lhs;
+    RHSType rhs;
+    entries_t nodes_grouped_by_level;
+    entries_t nodes_per_level;
 
-  RowMapType row_map;
-  EntriesType entries;
-  ValuesType values;
-  LHSType lhs;
-  RHSType rhs;
-  NGBLType nodes_grouped_by_level;
-  NGBLType nodes_per_level;
-
-  long node_count;  // like "block" offset into ngbl, my_league is the "local"
-                    // offset
-  long lvl_start;
-  long lvl_end;
-  long cutoff;
-  // team_size: each team can be assigned a row, if there are enough rows...
+    long node_count;  // like "block" offset into ngbl, my_league is the "local"
+                      // offset
+    long lvl_start;
+    long lvl_end;
+    long cutoff;
+    // team_size: each team can be assigned a row, if there are enough rows...
 
   LowerTriLvlSchedTP1SingleBlockFunctor(
       const RowMapType &row_map_, const EntriesType &entries_,
       const ValuesType &values_, LHSType &lhs_, const RHSType &rhs_,
-      const NGBLType &nodes_grouped_by_level_, NGBLType &nodes_per_level_,
+      const entries_t &nodes_grouped_by_level_, entries_t &nodes_per_level_,
       long node_count_, long lvl_start_, long lvl_end_, long cutoff_ = 0)
       : row_map(row_map_),
         entries(entries_),
@@ -1655,141 +1549,26 @@ struct LowerTriLvlSchedTP1SingleBlockFunctor {
         lvl_end(lvl_end_),
         cutoff(cutoff_) {}
 
-  // SingleBlock: Only one block (or league) executing; team_rank used to map
-  // thread to row
+    // SingleBlock: Only one block (or league) executing; team_rank used to map
+    // thread to row
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const member_type &team) const {
-    long mut_node_count = node_count;
-    typename NGBLType::non_const_value_type rowid{0};
-    typename RowMapType::non_const_value_type soffset{0};
-    typename RowMapType::non_const_value_type eoffset{0};
-    typename RHSType::non_const_value_type rhs_val{0};
-    scalar_t diff = scalar_t(0.0);
-    for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
-      auto nodes_this_lvl = nodes_per_level(lvl);
-      int my_rank         = team.team_rank();
-      diff                = scalar_t(0.0);
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const member_type &team) const {
+      long mut_node_count = node_count;
+      typename entries_t::non_const_value_type rowid{0};
+      typename RowMapType::non_const_value_type soffset{0};
+      typename RowMapType::non_const_value_type eoffset{0};
+      typename RHSType::non_const_value_type rhs_val{0};
+      scalar_t diff = scalar_t(0.0);
+      for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
+        auto nodes_this_lvl = nodes_per_level(lvl);
+        int my_rank         = team.team_rank();
+        diff                = scalar_t(0.0);
 
-      if (my_rank < nodes_this_lvl) {
-        // THIS is where the mapping of threadid to rowid happens
-        rowid = nodes_grouped_by_level(my_rank + mut_node_count);
-
-        soffset = row_map(rowid);
-        eoffset = row_map(rowid + 1);
-        rhs_val = rhs(rowid);
-
-#ifdef SERIAL_FOR_LOOP
-        for (auto ptr = soffset; ptr < eoffset; ++ptr) {
-          auto colid = entries(ptr);
-          auto val   = values(ptr);
-          if (colid != rowid) {
-            diff -= val * lhs(colid);
-          }
-        }
-#else
-        auto trange = eoffset - soffset;
-        Kokkos::parallel_reduce(
-            Kokkos::ThreadVectorRange(team, trange),
-            [&](const int loffset, scalar_t &tdiff) {
-              auto ptr   = soffset + loffset;
-              auto colid = entries(ptr);
-              auto val   = values(ptr);
-              if (colid != rowid) {
-                tdiff -= val * lhs(colid);
-              }
-            },
-            diff);
-#endif
-        // ASSUMPTION: sorted diagonal value located at eoffset - 1
-        lhs(rowid) = (rhs_val + diff) / values(eoffset - 1);
-      }  // end if team.team_rank() < nodes_this_lvl
-      {
-        // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
-        // per thread
-        mut_node_count += nodes_this_lvl;
-      }
-      team.team_barrier();
-    }  // end for lvl
-  }    // end operator
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const UnsortedTag &, const member_type &team) const {
-    long mut_node_count = node_count;
-    typename NGBLType::non_const_value_type rowid{0};
-    typename RowMapType::non_const_value_type soffset{0};
-    typename RowMapType::non_const_value_type eoffset{0};
-    typename RHSType::non_const_value_type rhs_val{0};
-    scalar_t diff = scalar_t(0.0);
-    for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
-      auto nodes_this_lvl = nodes_per_level(lvl);
-      int my_rank         = team.team_rank();
-      diff                = scalar_t(0.0);
-
-      if (my_rank < nodes_this_lvl) {
-        // THIS is where the mapping of threadid to rowid happens
-        rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
-        soffset = row_map(rowid);
-        eoffset = row_map(rowid + 1);
-        rhs_val = rhs(rowid);
-
-#ifdef SERIAL_FOR_LOOP
-        for (auto ptr = soffset; ptr < eoffset; ++ptr) {
-          auto colid = entries(ptr);
-          auto val   = values(ptr);
-          if (colid != rowid) {
-            diff -= val * lhs(colid);
-          }
-        }
-#else
-        auto trange = eoffset - soffset;
-        auto diag   = -1;
-
-        Kokkos::parallel_reduce(
-            Kokkos::ThreadVectorRange(team, trange),
-            [&](const int loffset, scalar_t &tdiff) {
-              auto ptr = soffset + loffset;
-
-              auto colid = entries(ptr);
-              auto val   = values(ptr);
-              if (colid != rowid) {
-                tdiff -= val * lhs(colid);
-              } else {
-                diag = ptr;
-              }
-            },
-            diff);
-#endif
-        lhs(rowid) = (rhs_val + diff) / values(diag);
-      }  // end if team.team_rank() < nodes_this_lvl
-      {
-        // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
-        // per thread
-        mut_node_count += nodes_this_lvl;
-      }
-      team.team_barrier();
-    }  // end for lvl
-  }    // end operator
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const LargerCutoffTag &, const member_type &team) const {
-    long mut_node_count = node_count;
-    typename NGBLType::non_const_value_type rowid{0};
-    typename RowMapType::non_const_value_type soffset{0};
-    typename RowMapType::non_const_value_type eoffset{0};
-    typename RHSType::non_const_value_type rhs_val{0};
-    scalar_t diff = scalar_t(0.0);
-    for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
-      auto nodes_this_lvl = nodes_per_level(lvl);
-      int my_team_rank    = team.team_rank();
-      // If cutoff > team_size, then a thread will be responsible for multiple
-      // rows - this may be a helpful scenario depending on occupancy etc.
-      for (int my_rank = my_team_rank; my_rank < cutoff;
-           my_rank += team.team_size()) {
-        diff = scalar_t(0.0);
         if (my_rank < nodes_this_lvl) {
           // THIS is where the mapping of threadid to rowid happens
-          rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
+          rowid = nodes_grouped_by_level(my_rank + mut_node_count);
+
           soffset = row_map(rowid);
           eoffset = row_map(rowid + 1);
           rhs_val = rhs(rowid);
@@ -1805,49 +1584,42 @@ struct LowerTriLvlSchedTP1SingleBlockFunctor {
 #else
           auto trange = eoffset - soffset;
           Kokkos::parallel_reduce(
-              Kokkos::ThreadVectorRange(team, trange),
-              [&](const int loffset, scalar_t &tdiff) {
-                auto ptr   = soffset + loffset;
-                auto colid = entries(ptr);
-                auto val   = values(ptr);
-                if (colid != rowid) {
-                  tdiff -= val * lhs(colid);
-                }
-              },
-              diff);
+            Kokkos::ThreadVectorRange(team, trange),
+            [&](const int loffset, scalar_t &tdiff) {
+              auto ptr   = soffset + loffset;
+              auto colid = entries(ptr);
+              auto val   = values(ptr);
+              if (colid != rowid) {
+                tdiff -= val * lhs(colid);
+              }
+            },
+            diff);
 #endif
-          // ASSUMPTION: sorted diagonal value located at eoffset - 1 for lower
-          // tri, soffset for upper tri
+          // ASSUMPTION: sorted diagonal value located at eoffset - 1
           lhs(rowid) = (rhs_val + diff) / values(eoffset - 1);
         }  // end if team.team_rank() < nodes_this_lvl
-      }    // end for my_rank loop
-      {
-        // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
-        // per thread
-        mut_node_count += nodes_this_lvl;
-      }
-      team.team_barrier();
-    }  // end for lvl
-  }    // end tagged operator
+        {
+          // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
+          // per thread
+          mut_node_count += nodes_this_lvl;
+        }
+        team.team_barrier();
+      }  // end for lvl
+    }    // end operator
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const UnsortedLargerCutoffTag &,
-                  const member_type &team) const {
-    long mut_node_count = node_count;
-    typename NGBLType::non_const_value_type rowid{0};
-    typename RowMapType::non_const_value_type soffset{0};
-    typename RowMapType::non_const_value_type eoffset{0};
-    typename RHSType::non_const_value_type rhs_val{0};
-    scalar_t diff = scalar_t(0.0);
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const UnsortedTag &, const member_type &team) const {
+      long mut_node_count = node_count;
+      typename entries_t::non_const_value_type rowid{0};
+      typename RowMapType::non_const_value_type soffset{0};
+      typename RowMapType::non_const_value_type eoffset{0};
+      typename RHSType::non_const_value_type rhs_val{0};
+      scalar_t diff = scalar_t(0.0);
+      for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
+        auto nodes_this_lvl = nodes_per_level(lvl);
+        int my_rank         = team.team_rank();
+        diff                = scalar_t(0.0);
 
-    for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
-      auto nodes_this_lvl = nodes_per_level(lvl);
-      int my_team_rank    = team.team_rank();
-      // If cutoff > team_size, then a thread will be responsible for multiple
-      // rows - this may be a helpful scenario depending on occupancy etc.
-      for (int my_rank = my_team_rank; my_rank < cutoff;
-           my_rank += team.team_size()) {
-        diff = scalar_t(0.0);
         if (my_rank < nodes_this_lvl) {
           // THIS is where the mapping of threadid to rowid happens
           rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
@@ -1868,6 +1640,128 @@ struct LowerTriLvlSchedTP1SingleBlockFunctor {
           auto diag   = -1;
 
           Kokkos::parallel_reduce(
+            Kokkos::ThreadVectorRange(team, trange),
+            [&](const int loffset, scalar_t &tdiff) {
+              auto ptr = soffset + loffset;
+
+              auto colid = entries(ptr);
+              auto val   = values(ptr);
+              if (colid != rowid) {
+                tdiff -= val * lhs(colid);
+              } else {
+                diag = ptr;
+              }
+            },
+            diff);
+#endif
+          lhs(rowid) = (rhs_val + diff) / values(diag);
+        }  // end if team.team_rank() < nodes_this_lvl
+        {
+          // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
+          // per thread
+          mut_node_count += nodes_this_lvl;
+        }
+        team.team_barrier();
+      }  // end for lvl
+    }    // end operator
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const LargerCutoffTag &, const member_type &team) const {
+      long mut_node_count = node_count;
+      typename entries_t::non_const_value_type rowid{0};
+      typename RowMapType::non_const_value_type soffset{0};
+      typename RowMapType::non_const_value_type eoffset{0};
+      typename RHSType::non_const_value_type rhs_val{0};
+      scalar_t diff = scalar_t(0.0);
+      for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
+        auto nodes_this_lvl = nodes_per_level(lvl);
+        int my_team_rank    = team.team_rank();
+        // If cutoff > team_size, then a thread will be responsible for multiple
+        // rows - this may be a helpful scenario depending on occupancy etc.
+        for (int my_rank = my_team_rank; my_rank < cutoff;
+             my_rank += team.team_size()) {
+          diff = scalar_t(0.0);
+          if (my_rank < nodes_this_lvl) {
+            // THIS is where the mapping of threadid to rowid happens
+            rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
+            soffset = row_map(rowid);
+            eoffset = row_map(rowid + 1);
+            rhs_val = rhs(rowid);
+
+#ifdef SERIAL_FOR_LOOP
+            for (auto ptr = soffset; ptr < eoffset; ++ptr) {
+              auto colid = entries(ptr);
+              auto val   = values(ptr);
+              if (colid != rowid) {
+                diff -= val * lhs(colid);
+              }
+            }
+#else
+            auto trange = eoffset - soffset;
+            Kokkos::parallel_reduce(
+              Kokkos::ThreadVectorRange(team, trange),
+              [&](const int loffset, scalar_t &tdiff) {
+                auto ptr   = soffset + loffset;
+                auto colid = entries(ptr);
+                auto val   = values(ptr);
+                if (colid != rowid) {
+                  tdiff -= val * lhs(colid);
+                }
+              },
+              diff);
+#endif
+            // ASSUMPTION: sorted diagonal value located at eoffset - 1 for lower
+            // tri, soffset for upper tri
+            lhs(rowid) = (rhs_val + diff) / values(eoffset - 1);
+          }  // end if team.team_rank() < nodes_this_lvl
+        }    // end for my_rank loop
+        {
+          // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
+          // per thread
+          mut_node_count += nodes_this_lvl;
+        }
+        team.team_barrier();
+      }  // end for lvl
+    }    // end tagged operator
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const UnsortedLargerCutoffTag &,
+                    const member_type &team) const {
+      long mut_node_count = node_count;
+      typename entries_t::non_const_value_type rowid{0};
+      typename RowMapType::non_const_value_type soffset{0};
+      typename RowMapType::non_const_value_type eoffset{0};
+      typename RHSType::non_const_value_type rhs_val{0};
+      scalar_t diff = scalar_t(0.0);
+
+      for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
+        auto nodes_this_lvl = nodes_per_level(lvl);
+        int my_team_rank    = team.team_rank();
+        // If cutoff > team_size, then a thread will be responsible for multiple
+        // rows - this may be a helpful scenario depending on occupancy etc.
+        for (int my_rank = my_team_rank; my_rank < cutoff;
+             my_rank += team.team_size()) {
+          diff = scalar_t(0.0);
+          if (my_rank < nodes_this_lvl) {
+            // THIS is where the mapping of threadid to rowid happens
+            rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
+            soffset = row_map(rowid);
+            eoffset = row_map(rowid + 1);
+            rhs_val = rhs(rowid);
+
+#ifdef SERIAL_FOR_LOOP
+            for (auto ptr = soffset; ptr < eoffset; ++ptr) {
+              auto colid = entries(ptr);
+              auto val   = values(ptr);
+              if (colid != rowid) {
+                diff -= val * lhs(colid);
+              }
+            }
+#else
+            auto trange = eoffset - soffset;
+            auto diag   = -1;
+
+            Kokkos::parallel_reduce(
               Kokkos::ThreadVectorRange(team, trange),
               [&](const int loffset, scalar_t &tdiff) {
                 auto ptr   = soffset + loffset;
@@ -1881,47 +1775,41 @@ struct LowerTriLvlSchedTP1SingleBlockFunctor {
               },
               diff);
 #endif
-          lhs(rowid) = (rhs_val + diff) / values(diag);
-        }  // end if team.team_rank() < nodes_this_lvl
-      }    // end for my_rank loop
-      {
-        // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
-        // per thread
-        mut_node_count += nodes_this_lvl;
-      }
-      team.team_barrier();
-    }  // end for lvl
-  }    // end tagged operator
-};
+            lhs(rowid) = (rhs_val + diff) / values(diag);
+          }  // end if team.team_rank() < nodes_this_lvl
+        }    // end for my_rank loop
+        {
+          // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
+          // per thread
+          mut_node_count += nodes_this_lvl;
+        }
+        team.team_barrier();
+      }  // end for lvl
+    }    // end tagged operator
+  };
 
-template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
-          class RHSType, class NGBLType>
-struct UpperTriLvlSchedTP1SingleBlockFunctor {
-  typedef typename RowMapType::execution_space execution_space;
-  typedef Kokkos::TeamPolicy<execution_space> policy_type;
-  typedef typename policy_type::member_type member_type;
-  typedef typename EntriesType::non_const_value_type lno_t;
-  typedef typename ValuesType::non_const_value_type scalar_t;
+  template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
+            class RHSType>
+  struct UpperTriLvlSchedTP1SingleBlockFunctor {
+    RowMapType row_map;
+    EntriesType entries;
+    ValuesType values;
+    LHSType lhs;
+    RHSType rhs;
+    entries_t nodes_grouped_by_level;
+    entries_t nodes_per_level;
 
-  RowMapType row_map;
-  EntriesType entries;
-  ValuesType values;
-  LHSType lhs;
-  RHSType rhs;
-  NGBLType nodes_grouped_by_level;
-  NGBLType nodes_per_level;
+    long node_count;  // like "block" offset into ngbl, my_league is the "local"
+    // offset
+    long lvl_start;
+    long lvl_end;
+    long cutoff;
+    // team_size: each team can be assigned a row, if there are enough rows...
 
-  long node_count;  // like "block" offset into ngbl, my_league is the "local"
-                    // offset
-  long lvl_start;
-  long lvl_end;
-  long cutoff;
-  // team_size: each team can be assigned a row, if there are enough rows...
-
-  UpperTriLvlSchedTP1SingleBlockFunctor(
+    UpperTriLvlSchedTP1SingleBlockFunctor(
       const RowMapType &row_map_, const EntriesType &entries_,
       const ValuesType &values_, LHSType &lhs_, const RHSType &rhs_,
-      const NGBLType &nodes_grouped_by_level_, NGBLType &nodes_per_level_,
+      const entries_t &nodes_grouped_by_level_, entries_t &nodes_per_level_,
       long node_count_, long lvl_start_, long lvl_end_, long cutoff_ = 0)
       : row_map(row_map_),
         entries(entries_),
@@ -1935,142 +1823,22 @@ struct UpperTriLvlSchedTP1SingleBlockFunctor {
         lvl_end(lvl_end_),
         cutoff(cutoff_) {}
 
-  // SingleBlock: Only one block (or league) executing; team_rank used to map
-  // thread to row
+    // SingleBlock: Only one block (or league) executing; team_rank used to map
+    // thread to row
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const member_type &team) const {
+      long mut_node_count = node_count;
+      typename entries_t::non_const_value_type rowid{0};
+      typename RowMapType::non_const_value_type soffset{0};
+      typename RowMapType::non_const_value_type eoffset{0};
+      typename RHSType::non_const_value_type rhs_val{0};
+      scalar_t diff = scalar_t(0.0);
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const member_type &team) const {
-    long mut_node_count = node_count;
-    typename NGBLType::non_const_value_type rowid{0};
-    typename RowMapType::non_const_value_type soffset{0};
-    typename RowMapType::non_const_value_type eoffset{0};
-    typename RHSType::non_const_value_type rhs_val{0};
-    scalar_t diff = scalar_t(0.0);
+      for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
+        auto nodes_this_lvl = nodes_per_level(lvl);
+        int my_rank         = team.team_rank();
+        diff                = scalar_t(0.0);
 
-    for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
-      auto nodes_this_lvl = nodes_per_level(lvl);
-      int my_rank         = team.team_rank();
-      diff                = scalar_t(0.0);
-
-      if (my_rank < nodes_this_lvl) {
-        // THIS is where the mapping of threadid to rowid happens
-        rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
-        soffset = row_map(rowid);
-        eoffset = row_map(rowid + 1);
-        rhs_val = rhs(rowid);
-
-#ifdef SERIAL_FOR_LOOP
-        for (auto ptr = soffset; ptr < eoffset; ++ptr) {
-          auto colid = entries(ptr);
-          auto val   = values(ptr);
-          if (colid != rowid) {
-            diff -= val * lhs(colid);
-          }
-        }
-#else
-        auto trange = eoffset - soffset;
-        Kokkos::parallel_reduce(
-            Kokkos::ThreadVectorRange(team, trange),
-            [&](const int loffset, scalar_t &tdiff) {
-              auto ptr   = soffset + loffset;
-              auto colid = entries(ptr);
-              auto val   = values(ptr);
-              if (colid != rowid) {
-                tdiff -= val * lhs(colid);
-              }
-            },
-            diff);
-#endif
-        // ASSUMPTION: sorted diagonal value located at soffset
-        lhs(rowid) = (rhs_val + diff) / values(soffset);
-      }  // end if
-      {
-        // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
-        // each thread
-        mut_node_count += nodes_this_lvl;
-      }
-      team.team_barrier();
-    }  // end for lvl
-  }    // end operator
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const UnsortedTag &, const member_type &team) const {
-    long mut_node_count = node_count;
-    typename NGBLType::non_const_value_type rowid{0};
-    typename RowMapType::non_const_value_type soffset{0};
-    typename RowMapType::non_const_value_type eoffset{0};
-    typename RHSType::non_const_value_type rhs_val{0};
-    scalar_t diff = scalar_t(0.0);
-
-    for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
-      auto nodes_this_lvl = nodes_per_level(lvl);
-      int my_rank         = team.team_rank();
-      diff                = scalar_t(0.0);
-
-      if (my_rank < nodes_this_lvl) {
-        // THIS is where the mapping of threadid to rowid happens
-        rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
-        soffset = row_map(rowid);
-        eoffset = row_map(rowid + 1);
-        rhs_val = rhs(rowid);
-
-#ifdef SERIAL_FOR_LOOP
-        auto diag = -1;
-        for (auto ptr = soffset; ptr < eoffset; ++ptr) {
-          auto colid = entries(ptr);
-          auto val   = values(ptr);
-          if (colid != rowid) {
-            diff -= val * lhs(colid);
-          } else {
-            diag = ptr;
-          }
-        }
-#else
-        auto trange = eoffset - soffset;
-        auto diag   = -1;
-
-        Kokkos::parallel_reduce(
-            Kokkos::ThreadVectorRange(team, trange),
-            [&](const int loffset, scalar_t &tdiff) {
-              auto ptr   = soffset + loffset;
-              auto colid = entries(ptr);
-              auto val   = values(ptr);
-              if (colid != rowid) {
-                tdiff -= val * lhs(colid);
-              } else {
-                diag = ptr;
-              }
-            },
-            diff);
-#endif
-        lhs(rowid) = (rhs_val + diff) / values(diag);
-      }  // end if
-      {
-        // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
-        // each thread
-        mut_node_count += nodes_this_lvl;
-      }
-      team.team_barrier();
-    }  // end for lvl
-  }    // end operator
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const LargerCutoffTag &, const member_type &team) const {
-    long mut_node_count = node_count;
-    typename NGBLType::non_const_value_type rowid{0};
-    typename RowMapType::non_const_value_type soffset{0};
-    typename RowMapType::non_const_value_type eoffset{0};
-    typename RHSType::non_const_value_type rhs_val{0};
-    scalar_t diff = scalar_t(0.0);
-
-    for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
-      auto nodes_this_lvl = nodes_per_level(lvl);
-      int my_team_rank    = team.team_rank();
-      // If cutoff > team_size, then a thread will be responsible for multiple
-      // rows - this may be a helpful scenario depending on occupancy etc.
-      for (int my_rank = my_team_rank; my_rank < cutoff;
-           my_rank += team.team_size()) {
-        diff = scalar_t(0.0);
         if (my_rank < nodes_this_lvl) {
           // THIS is where the mapping of threadid to rowid happens
           rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
@@ -2089,49 +1857,43 @@ struct UpperTriLvlSchedTP1SingleBlockFunctor {
 #else
           auto trange = eoffset - soffset;
           Kokkos::parallel_reduce(
-              Kokkos::ThreadVectorRange(team, trange),
-              [&](const int loffset, scalar_t &tdiff) {
-                auto ptr   = soffset + loffset;
-                auto colid = entries(ptr);
-                auto val   = values(ptr);
-                if (colid != rowid) {
-                  tdiff -= val * lhs(colid);
-                }
-              },
-              diff);
+            Kokkos::ThreadVectorRange(team, trange),
+            [&](const int loffset, scalar_t &tdiff) {
+              auto ptr   = soffset + loffset;
+              auto colid = entries(ptr);
+              auto val   = values(ptr);
+              if (colid != rowid) {
+                tdiff -= val * lhs(colid);
+              }
+            },
+            diff);
 #endif
-          // ASSUMPTION: sorted diagonal value located at eoffset - 1 for lower
-          // tri, soffset for upper tri
+          // ASSUMPTION: sorted diagonal value located at soffset
           lhs(rowid) = (rhs_val + diff) / values(soffset);
-        }  // end if team.team_rank() < nodes_this_lvl
-      }    // end for my_rank loop
-      {
-        // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
-        // per thread
-        mut_node_count += nodes_this_lvl;
-      }
-      team.team_barrier();
-    }  // end for lvl
-  }    // end tagged operator
+        }  // end if
+        {
+          // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
+          // each thread
+          mut_node_count += nodes_this_lvl;
+        }
+        team.team_barrier();
+      }  // end for lvl
+    }    // end operator
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const UnsortedLargerCutoffTag &,
-                  const member_type &team) const {
-    long mut_node_count = node_count;
-    typename NGBLType::non_const_value_type rowid{0};
-    typename RowMapType::non_const_value_type soffset{0};
-    typename RowMapType::non_const_value_type eoffset{0};
-    typename RHSType::non_const_value_type rhs_val{0};
-    scalar_t diff = scalar_t(0.0);
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const UnsortedTag &, const member_type &team) const {
+      long mut_node_count = node_count;
+      typename entries_t::non_const_value_type rowid{0};
+      typename RowMapType::non_const_value_type soffset{0};
+      typename RowMapType::non_const_value_type eoffset{0};
+      typename RHSType::non_const_value_type rhs_val{0};
+      scalar_t diff = scalar_t(0.0);
 
-    for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
-      auto nodes_this_lvl = nodes_per_level(lvl);
-      int my_team_rank    = team.team_rank();
-      // If cutoff > team_size, then a thread will be responsible for multiple
-      // rows - this may be a helpful scenario depending on occupancy etc.
-      for (int my_rank = my_team_rank; my_rank < cutoff;
-           my_rank += team.team_size()) {
-        diff = scalar_t(0.0);
+      for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
+        auto nodes_this_lvl = nodes_per_level(lvl);
+        int my_rank         = team.team_rank();
+        diff                = scalar_t(0.0);
+
         if (my_rank < nodes_this_lvl) {
           // THIS is where the mapping of threadid to rowid happens
           rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
@@ -2153,7 +1915,132 @@ struct UpperTriLvlSchedTP1SingleBlockFunctor {
 #else
           auto trange = eoffset - soffset;
           auto diag   = -1;
+
           Kokkos::parallel_reduce(
+            Kokkos::ThreadVectorRange(team, trange),
+            [&](const int loffset, scalar_t &tdiff) {
+              auto ptr   = soffset + loffset;
+              auto colid = entries(ptr);
+              auto val   = values(ptr);
+              if (colid != rowid) {
+                tdiff -= val * lhs(colid);
+              } else {
+                diag = ptr;
+              }
+            },
+            diff);
+#endif
+          lhs(rowid) = (rhs_val + diff) / values(diag);
+        }  // end if
+        {
+          // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
+          // each thread
+          mut_node_count += nodes_this_lvl;
+        }
+        team.team_barrier();
+      }  // end for lvl
+    }    // end operator
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const LargerCutoffTag &, const member_type &team) const {
+      long mut_node_count = node_count;
+      typename entries_t::non_const_value_type rowid{0};
+      typename RowMapType::non_const_value_type soffset{0};
+      typename RowMapType::non_const_value_type eoffset{0};
+      typename RHSType::non_const_value_type rhs_val{0};
+      scalar_t diff = scalar_t(0.0);
+
+      for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
+        auto nodes_this_lvl = nodes_per_level(lvl);
+        int my_team_rank    = team.team_rank();
+        // If cutoff > team_size, then a thread will be responsible for multiple
+        // rows - this may be a helpful scenario depending on occupancy etc.
+        for (int my_rank = my_team_rank; my_rank < cutoff;
+             my_rank += team.team_size()) {
+          diff = scalar_t(0.0);
+          if (my_rank < nodes_this_lvl) {
+            // THIS is where the mapping of threadid to rowid happens
+            rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
+            soffset = row_map(rowid);
+            eoffset = row_map(rowid + 1);
+            rhs_val = rhs(rowid);
+
+#ifdef SERIAL_FOR_LOOP
+            for (auto ptr = soffset; ptr < eoffset; ++ptr) {
+              auto colid = entries(ptr);
+              auto val   = values(ptr);
+              if (colid != rowid) {
+                diff -= val * lhs(colid);
+              }
+            }
+#else
+            auto trange = eoffset - soffset;
+            Kokkos::parallel_reduce(
+              Kokkos::ThreadVectorRange(team, trange),
+              [&](const int loffset, scalar_t &tdiff) {
+                auto ptr   = soffset + loffset;
+                auto colid = entries(ptr);
+                auto val   = values(ptr);
+                if (colid != rowid) {
+                  tdiff -= val * lhs(colid);
+                }
+              },
+              diff);
+#endif
+            // ASSUMPTION: sorted diagonal value located at eoffset - 1 for lower
+            // tri, soffset for upper tri
+            lhs(rowid) = (rhs_val + diff) / values(soffset);
+          }  // end if team.team_rank() < nodes_this_lvl
+        }    // end for my_rank loop
+        {
+          // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
+          // per thread
+          mut_node_count += nodes_this_lvl;
+        }
+        team.team_barrier();
+      }  // end for lvl
+    }    // end tagged operator
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const UnsortedLargerCutoffTag &,
+                    const member_type &team) const {
+      long mut_node_count = node_count;
+      typename entries_t::non_const_value_type rowid{0};
+      typename RowMapType::non_const_value_type soffset{0};
+      typename RowMapType::non_const_value_type eoffset{0};
+      typename RHSType::non_const_value_type rhs_val{0};
+      scalar_t diff = scalar_t(0.0);
+
+      for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
+        auto nodes_this_lvl = nodes_per_level(lvl);
+        int my_team_rank    = team.team_rank();
+        // If cutoff > team_size, then a thread will be responsible for multiple
+        // rows - this may be a helpful scenario depending on occupancy etc.
+        for (int my_rank = my_team_rank; my_rank < cutoff;
+             my_rank += team.team_size()) {
+          diff = scalar_t(0.0);
+          if (my_rank < nodes_this_lvl) {
+            // THIS is where the mapping of threadid to rowid happens
+            rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
+            soffset = row_map(rowid);
+            eoffset = row_map(rowid + 1);
+            rhs_val = rhs(rowid);
+
+#ifdef SERIAL_FOR_LOOP
+            auto diag = -1;
+            for (auto ptr = soffset; ptr < eoffset; ++ptr) {
+              auto colid = entries(ptr);
+              auto val   = values(ptr);
+              if (colid != rowid) {
+                diff -= val * lhs(colid);
+              } else {
+                diag = ptr;
+              }
+            }
+#else
+            auto trange = eoffset - soffset;
+            auto diag   = -1;
+            Kokkos::parallel_reduce(
               Kokkos::ThreadVectorRange(team, trange),
               [&](const int loffset, scalar_t &tdiff) {
                 auto ptr   = soffset + loffset;
@@ -2167,49 +2054,43 @@ struct UpperTriLvlSchedTP1SingleBlockFunctor {
               },
               diff);
 #endif
-          lhs(rowid) = (rhs_val + diff) / values(diag);
-        }  // end if team.team_rank() < nodes_this_lvl
-      }    // end for my_rank loop
-      {
-        // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
-        // per thread
-        mut_node_count += nodes_this_lvl;
-      }
-      team.team_barrier();
-    }  // end for lvl
-  }    // end tagged operator
-};
+            lhs(rowid) = (rhs_val + diff) / values(diag);
+          }  // end if team.team_rank() < nodes_this_lvl
+        }    // end for my_rank loop
+        {
+          // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
+          // per thread
+          mut_node_count += nodes_this_lvl;
+        }
+        team.team_barrier();
+      }  // end for lvl
+    }    // end tagged operator
+  };
 
-template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
-          class RHSType, class NGBLType>
-struct TriLvlSchedTP1SingleBlockFunctor {
-  typedef typename RowMapType::execution_space execution_space;
-  typedef Kokkos::TeamPolicy<execution_space> policy_type;
-  typedef typename policy_type::member_type member_type;
-  typedef typename EntriesType::non_const_value_type lno_t;
-  typedef typename ValuesType::non_const_value_type scalar_t;
+  template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
+            class RHSType>
+  struct TriLvlSchedTP1SingleBlockFunctor {
+    RowMapType row_map;
+    EntriesType entries;
+    ValuesType values;
+    LHSType lhs;
+    RHSType rhs;
+    entries_t nodes_grouped_by_level;
+    entries_t nodes_per_level;
 
-  RowMapType row_map;
-  EntriesType entries;
-  ValuesType values;
-  LHSType lhs;
-  RHSType rhs;
-  NGBLType nodes_grouped_by_level;
-  NGBLType nodes_per_level;
+    long node_count;  // like "block" offset into ngbl, my_league is the "local"
+                      // offset
+    long lvl_start;
+    long lvl_end;
+    const bool is_lowertri;
+    const int dense_nrows;
+    const int cutoff;
+    // team_size: each team can be assigned a row, if there are enough rows...
 
-  long node_count;  // like "block" offset into ngbl, my_league is the "local"
-                    // offset
-  long lvl_start;
-  long lvl_end;
-  const bool is_lowertri;
-  const int dense_nrows;
-  const int cutoff;
-  // team_size: each team can be assigned a row, if there are enough rows...
-
-  TriLvlSchedTP1SingleBlockFunctor(
+    TriLvlSchedTP1SingleBlockFunctor(
       const RowMapType &row_map_, const EntriesType &entries_,
       const ValuesType &values_, LHSType &lhs_, const RHSType &rhs_,
-      const NGBLType &nodes_grouped_by_level_, NGBLType &nodes_per_level_,
+      const entries_t &nodes_grouped_by_level_, entries_t &nodes_per_level_,
       long node_count_, long lvl_start_, long lvl_end_, const bool is_lower_,
       const int dense_nrows_ = 0, const int cutoff_ = 0)
       : row_map(row_map_),
@@ -2226,146 +2107,23 @@ struct TriLvlSchedTP1SingleBlockFunctor {
         dense_nrows(dense_nrows_),
         cutoff(cutoff_) {}
 
-  // SingleBlock: Only one block (or league) executing; team_rank used to map
-  // thread to row
+    // SingleBlock: Only one block (or league) executing; team_rank used to map
+    // thread to row
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const member_type &team) const {
-    long mut_node_count = node_count;
-    typename NGBLType::non_const_value_type rowid{0};
-    typename RowMapType::non_const_value_type soffset{0};
-    typename RowMapType::non_const_value_type eoffset{0};
-    typename RHSType::non_const_value_type rhs_val{0};
-    scalar_t diff = scalar_t(0.0);
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const member_type &team) const {
+      long mut_node_count = node_count;
+      typename entries_t::non_const_value_type rowid{0};
+      typename RowMapType::non_const_value_type soffset{0};
+      typename RowMapType::non_const_value_type eoffset{0};
+      typename RHSType::non_const_value_type rhs_val{0};
+      scalar_t diff = scalar_t(0.0);
 
-    for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
-      auto nodes_this_lvl = nodes_per_level(lvl);
-      int my_rank         = team.team_rank();
-      diff                = scalar_t(0.0);
+      for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
+        auto nodes_this_lvl = nodes_per_level(lvl);
+        int my_rank         = team.team_rank();
+        diff                = scalar_t(0.0);
 
-      if (my_rank < nodes_this_lvl) {
-        // THIS is where the mapping of threadid to rowid happens
-        rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
-        soffset = row_map(rowid);
-        eoffset = row_map(rowid + 1);
-        rhs_val = rhs(rowid);
-
-#ifdef SERIAL_FOR_LOOP
-        for (auto ptr = soffset; ptr < eoffset; ++ptr) {
-          auto colid = entries(ptr);
-          auto val   = values(ptr);
-          if (colid != rowid) {
-            diff -= val * lhs(colid);
-          }
-        }
-#else
-        auto trange = eoffset - soffset;
-        Kokkos::parallel_reduce(
-            Kokkos::ThreadVectorRange(team, trange),
-            [&](const int loffset, scalar_t &tdiff) {
-              auto ptr   = soffset + loffset;
-              auto colid = entries(ptr);
-              auto val   = values(ptr);
-              if (colid != rowid) {
-                tdiff -= val * lhs(colid);
-              }
-            },
-            diff);
-#endif
-
-        // ASSUMPTION: sorted diagonal value located at eoffset - 1 for lower
-        // tri, soffset for upper tri
-        if (is_lowertri)
-          lhs(rowid) = (rhs_val + diff) / values(eoffset - 1);
-        else
-          lhs(rowid) = (rhs_val + diff) / values(soffset);
-      }  // end if team.team_rank() < nodes_this_lvl
-      {
-        // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
-        // per thread
-        mut_node_count += nodes_this_lvl;
-      }
-      team.team_barrier();
-    }  // end for lvl
-  }    // end operator
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const UnsortedTag &, const member_type &team) const {
-    long mut_node_count = node_count;
-    typename NGBLType::non_const_value_type rowid{0};
-    typename RowMapType::non_const_value_type soffset{0};
-    typename RowMapType::non_const_value_type eoffset{0};
-    typename RHSType::non_const_value_type rhs_val{0};
-    scalar_t diff = scalar_t(0.0);
-
-    for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
-      auto nodes_this_lvl = nodes_per_level(lvl);
-      int my_rank         = team.team_rank();
-      diff                = scalar_t(0.0);
-
-      if (my_rank < nodes_this_lvl) {
-        // THIS is where the mapping of threadid to rowid happens
-        rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
-        soffset = row_map(rowid);
-        eoffset = row_map(rowid + 1);
-        rhs_val = rhs(rowid);
-
-#ifdef SERIAL_FOR_LOOP
-        auto diag = -1;
-        for (auto ptr = soffset; ptr < eoffset; ++ptr) {
-          auto colid = entries(ptr);
-          auto val   = values(ptr);
-          if (colid != rowid) {
-            diff -= val * lhs(colid);
-          } else {
-            diag = ptr;
-          }
-        }
-#else
-        auto trange = eoffset - soffset;
-        auto diag   = -1;
-        Kokkos::parallel_reduce(
-            Kokkos::ThreadVectorRange(team, trange),
-            [&](const int loffset, scalar_t &tdiff) {
-              auto ptr   = soffset + loffset;
-              auto colid = entries(ptr);
-              auto val   = values(ptr);
-              if (colid != rowid) {
-                tdiff -= val * lhs(colid);
-              } else {
-                diag = ptr;
-              }
-            },
-            diff);
-#endif
-        lhs(rowid) = (rhs_val + diff) / values(diag);
-      }  // end if team.team_rank() < nodes_this_lvl
-      {
-        // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
-        // per thread
-        mut_node_count += nodes_this_lvl;
-      }
-      team.team_barrier();
-    }  // end for lvl
-  }    // end operator
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const LargerCutoffTag &, const member_type &team) const {
-    long mut_node_count = node_count;
-    typename NGBLType::non_const_value_type rowid{0};
-    typename RowMapType::non_const_value_type soffset{0};
-    typename RowMapType::non_const_value_type eoffset{0};
-    typename RHSType::non_const_value_type rhs_val{0};
-    scalar_t diff = scalar_t(0.0);
-
-    for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
-      auto nodes_this_lvl = nodes_per_level(lvl);
-      int my_team_rank    = team.team_rank();
-      // If cutoff > team_size, then a thread will be responsible for multiple
-      // rows - this may be a helpful scenario depending on occupancy etc.
-      for (int my_rank = my_team_rank; my_rank < cutoff;
-           my_rank += team.team_size()) {
-        diff = scalar_t(0.0);
         if (my_rank < nodes_this_lvl) {
           // THIS is where the mapping of threadid to rowid happens
           rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
@@ -2384,16 +2142,16 @@ struct TriLvlSchedTP1SingleBlockFunctor {
 #else
           auto trange = eoffset - soffset;
           Kokkos::parallel_reduce(
-              Kokkos::ThreadVectorRange(team, trange),
-              [&](const int loffset, scalar_t &tdiff) {
-                auto ptr   = soffset + loffset;
-                auto colid = entries(ptr);
-                auto val   = values(ptr);
-                if (colid != rowid) {
-                  tdiff -= val * lhs(colid);
-                }
-              },
-              diff);
+            Kokkos::ThreadVectorRange(team, trange),
+            [&](const int loffset, scalar_t &tdiff) {
+              auto ptr   = soffset + loffset;
+              auto colid = entries(ptr);
+              auto val   = values(ptr);
+              if (colid != rowid) {
+                tdiff -= val * lhs(colid);
+              }
+            },
+            diff);
 #endif
 
           // ASSUMPTION: sorted diagonal value located at eoffset - 1 for lower
@@ -2403,34 +2161,29 @@ struct TriLvlSchedTP1SingleBlockFunctor {
           else
             lhs(rowid) = (rhs_val + diff) / values(soffset);
         }  // end if team.team_rank() < nodes_this_lvl
-      }    // end for my_rank loop
-      {
-        // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
-        // per thread
-        mut_node_count += nodes_this_lvl;
-      }
-      team.team_barrier();
-    }  // end for lvl
-  }    // end tagged operator
+        {
+          // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
+          // per thread
+          mut_node_count += nodes_this_lvl;
+        }
+        team.team_barrier();
+      }  // end for lvl
+    }    // end operator
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const UnsortedLargerCutoffTag &,
-                  const member_type &team) const {
-    long mut_node_count = node_count;
-    typename NGBLType::non_const_value_type rowid{0};
-    typename RowMapType::non_const_value_type soffset{0};
-    typename RowMapType::non_const_value_type eoffset{0};
-    typename RHSType::non_const_value_type rhs_val{0};
-    scalar_t diff = scalar_t(0.0);
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const UnsortedTag &, const member_type &team) const {
+      long mut_node_count = node_count;
+      typename entries_t::non_const_value_type rowid{0};
+      typename RowMapType::non_const_value_type soffset{0};
+      typename RowMapType::non_const_value_type eoffset{0};
+      typename RHSType::non_const_value_type rhs_val{0};
+      scalar_t diff = scalar_t(0.0);
 
-    for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
-      auto nodes_this_lvl = nodes_per_level(lvl);
-      int my_team_rank    = team.team_rank();
-      // If cutoff > team_size, then a thread will be responsible for multiple
-      // rows - this may be a helpful scenario depending on occupancy etc.
-      for (int my_rank = my_team_rank; my_rank < cutoff;
-           my_rank += team.team_size()) {
-        diff = scalar_t(0.0);
+      for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
+        auto nodes_this_lvl = nodes_per_level(lvl);
+        int my_rank         = team.team_rank();
+        diff                = scalar_t(0.0);
+
         if (my_rank < nodes_this_lvl) {
           // THIS is where the mapping of threadid to rowid happens
           rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
@@ -2453,6 +2206,134 @@ struct TriLvlSchedTP1SingleBlockFunctor {
           auto trange = eoffset - soffset;
           auto diag   = -1;
           Kokkos::parallel_reduce(
+            Kokkos::ThreadVectorRange(team, trange),
+            [&](const int loffset, scalar_t &tdiff) {
+              auto ptr   = soffset + loffset;
+              auto colid = entries(ptr);
+              auto val   = values(ptr);
+              if (colid != rowid) {
+                tdiff -= val * lhs(colid);
+              } else {
+                diag = ptr;
+              }
+            },
+            diff);
+#endif
+          lhs(rowid) = (rhs_val + diff) / values(diag);
+        }  // end if team.team_rank() < nodes_this_lvl
+        {
+          // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
+          // per thread
+          mut_node_count += nodes_this_lvl;
+        }
+        team.team_barrier();
+      }  // end for lvl
+    }    // end operator
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const LargerCutoffTag &, const member_type &team) const {
+      long mut_node_count = node_count;
+      typename entries_t::non_const_value_type rowid{0};
+      typename RowMapType::non_const_value_type soffset{0};
+      typename RowMapType::non_const_value_type eoffset{0};
+      typename RHSType::non_const_value_type rhs_val{0};
+      scalar_t diff = scalar_t(0.0);
+
+      for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
+        auto nodes_this_lvl = nodes_per_level(lvl);
+        int my_team_rank    = team.team_rank();
+        // If cutoff > team_size, then a thread will be responsible for multiple
+        // rows - this may be a helpful scenario depending on occupancy etc.
+        for (int my_rank = my_team_rank; my_rank < cutoff;
+             my_rank += team.team_size()) {
+          diff = scalar_t(0.0);
+          if (my_rank < nodes_this_lvl) {
+            // THIS is where the mapping of threadid to rowid happens
+            rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
+            soffset = row_map(rowid);
+            eoffset = row_map(rowid + 1);
+            rhs_val = rhs(rowid);
+
+#ifdef SERIAL_FOR_LOOP
+            for (auto ptr = soffset; ptr < eoffset; ++ptr) {
+              auto colid = entries(ptr);
+              auto val   = values(ptr);
+              if (colid != rowid) {
+                diff -= val * lhs(colid);
+              }
+            }
+#else
+            auto trange = eoffset - soffset;
+            Kokkos::parallel_reduce(
+              Kokkos::ThreadVectorRange(team, trange),
+              [&](const int loffset, scalar_t &tdiff) {
+                auto ptr   = soffset + loffset;
+                auto colid = entries(ptr);
+                auto val   = values(ptr);
+                if (colid != rowid) {
+                  tdiff -= val * lhs(colid);
+                }
+              },
+              diff);
+#endif
+
+            // ASSUMPTION: sorted diagonal value located at eoffset - 1 for lower
+            // tri, soffset for upper tri
+            if (is_lowertri)
+              lhs(rowid) = (rhs_val + diff) / values(eoffset - 1);
+            else
+              lhs(rowid) = (rhs_val + diff) / values(soffset);
+          }  // end if team.team_rank() < nodes_this_lvl
+        }    // end for my_rank loop
+        {
+          // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
+          // per thread
+          mut_node_count += nodes_this_lvl;
+        }
+        team.team_barrier();
+      }  // end for lvl
+    }    // end tagged operator
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const UnsortedLargerCutoffTag &,
+                    const member_type &team) const {
+      long mut_node_count = node_count;
+      typename entries_t::non_const_value_type rowid{0};
+      typename RowMapType::non_const_value_type soffset{0};
+      typename RowMapType::non_const_value_type eoffset{0};
+      typename RHSType::non_const_value_type rhs_val{0};
+      scalar_t diff = scalar_t(0.0);
+
+      for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
+        auto nodes_this_lvl = nodes_per_level(lvl);
+        int my_team_rank    = team.team_rank();
+        // If cutoff > team_size, then a thread will be responsible for multiple
+        // rows - this may be a helpful scenario depending on occupancy etc.
+        for (int my_rank = my_team_rank; my_rank < cutoff;
+             my_rank += team.team_size()) {
+          diff = scalar_t(0.0);
+          if (my_rank < nodes_this_lvl) {
+            // THIS is where the mapping of threadid to rowid happens
+            rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
+            soffset = row_map(rowid);
+            eoffset = row_map(rowid + 1);
+            rhs_val = rhs(rowid);
+
+#ifdef SERIAL_FOR_LOOP
+            auto diag = -1;
+            for (auto ptr = soffset; ptr < eoffset; ++ptr) {
+              auto colid = entries(ptr);
+              auto val   = values(ptr);
+              if (colid != rowid) {
+                diff -= val * lhs(colid);
+              } else {
+                diag = ptr;
+              }
+            }
+#else
+            auto trange = eoffset - soffset;
+            auto diag   = -1;
+            Kokkos::parallel_reduce(
               Kokkos::ThreadVectorRange(team, trange),
               [&](const int loffset, scalar_t &tdiff) {
                 auto ptr   = soffset + loffset;
@@ -2466,50 +2347,44 @@ struct TriLvlSchedTP1SingleBlockFunctor {
               },
               diff);
 #endif
-          lhs(rowid) = (rhs_val + diff) / values(diag);
-        }  // end if team.team_rank() < nodes_this_lvl
-      }    // end for my_rank loop
-      {
-        // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
-        // per thread
-        mut_node_count += nodes_this_lvl;
-      }
-      team.team_barrier();
-    }  // end for lvl
-  }    // end tagged operator
-};
+            lhs(rowid) = (rhs_val + diff) / values(diag);
+          }  // end if team.team_rank() < nodes_this_lvl
+        }    // end for my_rank loop
+        {
+          // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
+          // per thread
+          mut_node_count += nodes_this_lvl;
+        }
+        team.team_barrier();
+      }  // end for lvl
+    }    // end tagged operator
+  };
 
-template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
-          class RHSType, class NGBLType>
-struct TriLvlSchedTP1SingleBlockFunctorDiagValues {
-  typedef typename RowMapType::execution_space execution_space;
-  typedef Kokkos::TeamPolicy<execution_space> policy_type;
-  typedef typename policy_type::member_type member_type;
-  typedef typename EntriesType::non_const_value_type lno_t;
-  typedef typename ValuesType::non_const_value_type scalar_t;
+  template <class RowMapType, class EntriesType, class ValuesType, class LHSType,
+            class RHSType>
+  struct TriLvlSchedTP1SingleBlockFunctorDiagValues {
+    RowMapType row_map;
+    EntriesType entries;
+    ValuesType values;
+    LHSType lhs;
+    RHSType rhs;
+    entries_t nodes_grouped_by_level;
+    entries_t nodes_per_level;
+    ValuesType diagonal_values;
 
-  RowMapType row_map;
-  EntriesType entries;
-  ValuesType values;
-  LHSType lhs;
-  RHSType rhs;
-  NGBLType nodes_grouped_by_level;
-  NGBLType nodes_per_level;
-  ValuesType diagonal_values;
+    long node_count;  // like "block" offset into ngbl, my_league is the "local"
+                      // offset
+    long lvl_start;
+    long lvl_end;
+    const bool is_lowertri;
+    const int dense_nrows;
+    const int cutoff;
+    // team_size: each team can be assigned a row, if there are enough rows...
 
-  long node_count;  // like "block" offset into ngbl, my_league is the "local"
-                    // offset
-  long lvl_start;
-  long lvl_end;
-  const bool is_lowertri;
-  const int dense_nrows;
-  const int cutoff;
-  // team_size: each team can be assigned a row, if there are enough rows...
-
-  TriLvlSchedTP1SingleBlockFunctorDiagValues(
+    TriLvlSchedTP1SingleBlockFunctorDiagValues(
       const RowMapType &row_map_, const EntriesType &entries_,
       const ValuesType &values_, LHSType &lhs_, const RHSType &rhs_,
-      const NGBLType &nodes_grouped_by_level_, const NGBLType &nodes_per_level_,
+      const entries_t &nodes_grouped_by_level_, const entries_t &nodes_per_level_,
       const ValuesType &diagonal_values_, long node_count_,
       const long lvl_start_, const long lvl_end_, const bool is_lower_,
       const int dense_nrows_ = 0, const int cutoff_ = 0)
@@ -2528,83 +2403,23 @@ struct TriLvlSchedTP1SingleBlockFunctorDiagValues {
         dense_nrows(dense_nrows_),
         cutoff(cutoff_) {}
 
-  // SingleBlock: Only one block (or league) executing; team_rank used to map
-  // thread to row
+    // SingleBlock: Only one block (or league) executing; team_rank used to map
+    // thread to row
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const member_type &team) const {
-    long mut_node_count = node_count;
-    typename NGBLType::non_const_value_type rowid{0};
-    typename RowMapType::non_const_value_type soffset{0};
-    typename RowMapType::non_const_value_type eoffset{0};
-    typename RHSType::non_const_value_type rhs_val{0};
-    scalar_t diff = scalar_t(0.0);
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const member_type &team) const {
+      long mut_node_count = node_count;
+      typename entries_t::non_const_value_type rowid{0};
+      typename RowMapType::non_const_value_type soffset{0};
+      typename RowMapType::non_const_value_type eoffset{0};
+      typename RHSType::non_const_value_type rhs_val{0};
+      scalar_t diff = scalar_t(0.0);
 
-    for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
-      auto nodes_this_lvl = nodes_per_level(lvl);
-      int my_rank         = team.team_rank();
-      diff                = scalar_t(0.0);
+      for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
+        auto nodes_this_lvl = nodes_per_level(lvl);
+        int my_rank         = team.team_rank();
+        diff                = scalar_t(0.0);
 
-      if (my_rank < nodes_this_lvl) {
-        // THIS is where the mapping of threadid to rowid happens
-        rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
-        soffset = row_map(rowid);
-        eoffset = row_map(rowid + 1);
-        rhs_val = rhs(rowid);
-
-#ifdef SERIAL_FOR_LOOP
-        for (auto ptr = soffset; ptr < eoffset; ++ptr) {
-          auto colid = entries(ptr);
-          auto val   = values(ptr);
-          if (colid != rowid) {
-            diff -= val * lhs(colid);
-          }
-        }
-#else
-        auto trange = eoffset - soffset;
-        Kokkos::parallel_reduce(
-            Kokkos::ThreadVectorRange(team, trange),
-            [&](const int loffset, scalar_t &tdiff) {
-              auto ptr   = soffset + loffset;
-              auto colid = entries(ptr);
-              auto val   = values(ptr);
-
-              if (colid != rowid) {
-                tdiff -= val * lhs(colid);
-              }
-            },
-            diff);
-#endif
-        // ASSUMPTION: sorted diagonal value located at eoffset - 1 for lower
-        // tri, soffset for upper tri
-        lhs(rowid) = (rhs_val + diff) / diagonal_values(rowid);
-      }  // end if team.team_rank() < nodes_this_lvl
-      {
-        // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
-        // per thread
-        mut_node_count += nodes_this_lvl;
-      }
-      team.team_barrier();
-    }  // end for lvl
-  }    // end operator
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const LargerCutoffTag &, const member_type &team) const {
-    long mut_node_count = node_count;
-    typename NGBLType::non_const_value_type rowid{0};
-    typename RowMapType::non_const_value_type soffset{0};
-    typename RowMapType::non_const_value_type eoffset{0};
-    typename RHSType::non_const_value_type rhs_val{0};
-    scalar_t diff = scalar_t(0.0);
-
-    for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
-      auto nodes_this_lvl = nodes_per_level(lvl);
-      int my_team_rank    = team.team_rank();
-      // If cutoff > team_size, then a thread will be responsible for multiple
-      // rows - this may be a helpful scenario depending on occupancy etc.
-      for (int my_rank = my_team_rank; my_rank < cutoff;
-           my_rank += team.team_size()) {
-        diff = scalar_t(0.0);
         if (my_rank < nodes_this_lvl) {
           // THIS is where the mapping of threadid to rowid happens
           rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
@@ -2623,6 +2438,66 @@ struct TriLvlSchedTP1SingleBlockFunctorDiagValues {
 #else
           auto trange = eoffset - soffset;
           Kokkos::parallel_reduce(
+            Kokkos::ThreadVectorRange(team, trange),
+            [&](const int loffset, scalar_t &tdiff) {
+              auto ptr   = soffset + loffset;
+              auto colid = entries(ptr);
+              auto val   = values(ptr);
+
+              if (colid != rowid) {
+                tdiff -= val * lhs(colid);
+              }
+            },
+            diff);
+#endif
+          // ASSUMPTION: sorted diagonal value located at eoffset - 1 for lower
+          // tri, soffset for upper tri
+          lhs(rowid) = (rhs_val + diff) / diagonal_values(rowid);
+        }  // end if team.team_rank() < nodes_this_lvl
+        {
+          // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
+          // per thread
+          mut_node_count += nodes_this_lvl;
+        }
+        team.team_barrier();
+      }  // end for lvl
+    }    // end operator
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const LargerCutoffTag &, const member_type &team) const {
+      long mut_node_count = node_count;
+      typename entries_t::non_const_value_type rowid{0};
+      typename RowMapType::non_const_value_type soffset{0};
+      typename RowMapType::non_const_value_type eoffset{0};
+      typename RHSType::non_const_value_type rhs_val{0};
+      scalar_t diff = scalar_t(0.0);
+
+      for (auto lvl = lvl_start; lvl < lvl_end; ++lvl) {
+        auto nodes_this_lvl = nodes_per_level(lvl);
+        int my_team_rank    = team.team_rank();
+        // If cutoff > team_size, then a thread will be responsible for multiple
+        // rows - this may be a helpful scenario depending on occupancy etc.
+        for (int my_rank = my_team_rank; my_rank < cutoff;
+             my_rank += team.team_size()) {
+          diff = scalar_t(0.0);
+          if (my_rank < nodes_this_lvl) {
+            // THIS is where the mapping of threadid to rowid happens
+            rowid   = nodes_grouped_by_level(my_rank + mut_node_count);
+            soffset = row_map(rowid);
+            eoffset = row_map(rowid + 1);
+            rhs_val = rhs(rowid);
+
+#ifdef SERIAL_FOR_LOOP
+            for (auto ptr = soffset; ptr < eoffset; ++ptr) {
+              auto colid = entries(ptr);
+              auto val   = values(ptr);
+              if (colid != rowid) {
+                diff -= val * lhs(colid);
+              }
+            }
+#else
+            auto trange = eoffset - soffset;
+            Kokkos::parallel_reduce(
               Kokkos::ThreadVectorRange(team, trange),
               [&](const int loffset, scalar_t &tdiff) {
                 auto ptr   = soffset + loffset;
@@ -2634,360 +2509,228 @@ struct TriLvlSchedTP1SingleBlockFunctorDiagValues {
               },
               diff);
 #endif
-          lhs(rowid) = (rhs_val + diff) / diagonal_values(rowid);
-        }  // end if team.team_rank() < nodes_this_lvl
-      }    // end for my_rank loop
-      {
-        // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
-        // per thread
-        mut_node_count += nodes_this_lvl;
-      }
-      team.team_barrier();
-    }  // end for lvl
-  }    // end tagged operator
-};
+            lhs(rowid) = (rhs_val + diff) / diagonal_values(rowid);
+          }  // end if team.team_rank() < nodes_this_lvl
+        }    // end for my_rank loop
+        {
+          // Update mut_node_count from nodes_per_level(lvl) each iteration of lvl
+          // per thread
+          mut_node_count += nodes_this_lvl;
+        }
+        team.team_barrier();
+      }  // end for lvl
+    }    // end tagged operator
+  };
 
 #ifdef KOKKOSKERNELS_SPTRSV_CUDAGRAPHSUPPORT
-template <class SpaceType>
-struct ReturnTeamPolicyType;
-
-#ifdef KOKKOS_ENABLE_SERIAL
-template <>
-struct ReturnTeamPolicyType<Kokkos::Serial> {
-  using PolicyType = Kokkos::TeamPolicy<Kokkos::Serial>;
-
-  static inline PolicyType get_policy(int nt, int ts) {
-    return PolicyType(nt, ts);
-  }
-
-  template <class ExecInstanceType>
-  static inline PolicyType get_policy(int nt, int ts, ExecInstanceType) {
-    return PolicyType(nt, ts);
-    // return PolicyType(ExecInstanceType(),nt,ts);
-  }
-};
-#endif
-#ifdef KOKKOS_ENABLE_OPENMP
-template <>
-struct ReturnTeamPolicyType<Kokkos::OpenMP> {
-  using PolicyType = Kokkos::TeamPolicy<Kokkos::OpenMP>;
-
-  static inline PolicyType get_policy(int nt, int ts) {
-    return PolicyType(nt, ts);
-  }
-
-  template <class ExecInstanceType>
-  static inline PolicyType get_policy(int nt, int ts, ExecInstanceType) {
-    return PolicyType(nt, ts);
-    // return PolicyType(ExecInstanceType(),nt,ts);
-  }
-};
-#endif
-#ifdef KOKKOS_ENABLE_CUDA
-template <>
-struct ReturnTeamPolicyType<Kokkos::Cuda> {
-  using PolicyType = Kokkos::TeamPolicy<Kokkos::Cuda>;
-
-  static inline PolicyType get_policy(int nt, int ts) {
-    return PolicyType(nt, ts);
-  }
-
-  template <class ExecInstanceType>
-  static inline PolicyType get_policy(int nt, int ts, ExecInstanceType stream) {
-    return PolicyType(stream, nt, ts);
-  }
-};
-#endif
-
-template <class SpaceType>
-struct ReturnRangePolicyType;
-
-#ifdef KOKKOS_ENABLE_SERIAL
-template <>
-struct ReturnRangePolicyType<Kokkos::Serial> {
-  using PolicyType = Kokkos::RangePolicy<Kokkos::Serial>;
-
-  static inline PolicyType get_policy(int nt, int ts) {
-    return PolicyType(nt, ts);
-  }
-
-  template <class ExecInstanceType>
-  static inline PolicyType get_policy(int nt, int ts, ExecInstanceType) {
-    return PolicyType(nt, ts);
-    // return PolicyType(ExecInstanceType(),nt,ts);
-  }
-};
-#endif
-#ifdef KOKKOS_ENABLE_OPENMP
-template <>
-struct ReturnRangePolicyType<Kokkos::OpenMP> {
-  using PolicyType = Kokkos::RangePolicy<Kokkos::OpenMP>;
-
-  static inline PolicyType get_policy(int nt, int ts) {
-    return PolicyType(nt, ts);
-  }
-
-  template <class ExecInstanceType>
-  static inline PolicyType get_policy(int nt, int ts, ExecInstanceType) {
-    return PolicyType(nt, ts);
-    // return PolicyType(ExecInstanceType(),nt,ts);
-  }
-};
-#endif
-#ifdef KOKKOS_ENABLE_CUDA
-template <>
-struct ReturnRangePolicyType<Kokkos::Cuda> {
-  using PolicyType = Kokkos::RangePolicy<Kokkos::Cuda>;
-
-  static inline PolicyType get_policy(int nt, int ts) {
-    return PolicyType(nt, ts);
-  }
-
-  template <class ExecInstanceType>
-  static inline PolicyType get_policy(int nt, int ts, ExecInstanceType stream) {
-    return PolicyType(stream, nt, ts);
-  }
-};
-#endif
-#ifdef KOKKOS_ENABLE_HIP
-template <>
-struct ReturnRangePolicyType<Kokkos::HIP> {
-  using PolicyType = Kokkos::RangePolicy<Kokkos::HIP>;
-
-  static inline PolicyType get_policy(int nt, int ts) {
-    return PolicyType(nt, ts);
-  }
-
-  template <class ExecInstanceType>
-  static inline PolicyType get_policy(int nt, int ts, ExecInstanceType stream) {
-    return PolicyType(stream, nt, ts);
-  }
-};
-#endif
-
-template <class RowMapType, class EntriesType,
-          class ValuesType, class RHSType, class LHSType>
-static void lower_tri_solve_cg(TriSolveHandle &thandle, const RowMapType row_map,
-                        const EntriesType entries, const ValuesType values,
-                        const RHSType &rhs, LHSType &lhs) {
-  typedef typename TriSolveHandle::nnz_lno_view_t NGBLType;
-  typedef typename TriSolveHandle::execution_space execution_space;
-  typedef typename TriSolveHandle::size_type size_type;
-  typename TriSolveHandle::SPTRSVcudaGraphWrapperType *lcl_cudagraph =
+  template <class RowMapType, class EntriesType,
+            class ValuesType, class RHSType, class LHSType>
+  static void lower_tri_solve_cg(TriSolveHandle &thandle, const RowMapType row_map,
+                                 const EntriesType entries, const ValuesType values,
+                                 const RHSType &rhs, LHSType &lhs) {
+    typename TriSolveHandle::SPTRSVcudaGraphWrapperType *lcl_cudagraph =
       thandle.get_sptrsvCudaGraph();
 
-  auto nlevels = thandle.get_num_levels();
+    auto nlevels = thandle.get_num_levels();
 
-  auto stream1 = lcl_cudagraph->stream;
-  Kokkos::Cuda cuda1(stream1);
-  auto graph = lcl_cudagraph->cudagraph;
+    auto stream1 = lcl_cudagraph->stream;
+    Kokkos::Cuda cuda1(stream1);
+    auto graph = lcl_cudagraph->cudagraph;
 
-  Kokkos::parallel_for("Init", Kokkos::RangePolicy<execution_space>(0, 1),
-                       EmptyFunctor());
-  Kokkos::Cuda().fence();
-  cudaStreamSynchronize(stream1);
-  // Kokkos::fence();
+    Kokkos::parallel_for("Init", Kokkos::RangePolicy<execution_space>(0, 1),
+                         EmptyFunctor());
+    Kokkos::Cuda().fence();
+    cudaStreamSynchronize(stream1);
+    // Kokkos::fence();
 
-  auto hnodes_per_level       = thandle.get_host_nodes_per_level();
-  auto nodes_grouped_by_level = thandle.get_nodes_grouped_by_level();
+    auto hnodes_per_level       = thandle.get_host_nodes_per_level();
+    auto nodes_grouped_by_level = thandle.get_nodes_grouped_by_level();
 
-  size_type node_count = 0;
+    size_type node_count = 0;
 
-  int team_size = thandle.get_team_size();
-  team_size     = team_size == -1 ? 64 : team_size;
+    int team_size = thandle.get_team_size();
+    team_size     = team_size == -1 ? 64 : team_size;
 
-  // Start capturing stream
-  if (thandle.cudagraphCreated == false) {
-    Kokkos::fence();
-    cudaStreamBeginCapture(stream1, cudaStreamCaptureModeGlobal);
-    {
-      for (int iter = 0; iter < nlevels; ++iter) {
-        size_type lvl_nodes = hnodes_per_level(iter);
+    // Start capturing stream
+    if (thandle.cudagraphCreated == false) {
+      Kokkos::fence();
+      cudaStreamBeginCapture(stream1, cudaStreamCaptureModeGlobal);
+      {
+        for (int iter = 0; iter < nlevels; ++iter) {
+          size_type lvl_nodes = hnodes_per_level(iter);
 
-        using policy_type = ReturnTeamPolicyType<execution_space>;
+          auto policy = std::is_same<execution_space, Kokkos::Cuda>::value
+            ? team_policy(lvl_nodes, team_size, cuda1)
+            : team_policy(lvl_nodes, team_size);
 
-        Kokkos::parallel_for(
+          Kokkos::parallel_for(
             "parfor_l_team_cudagraph",
             Kokkos::Experimental::require(
-                ReturnTeamPolicyType<execution_space>::get_policy(
-                    lvl_nodes, team_size, cuda1),
+                policy,
                 Kokkos::Experimental::WorkItemProperty::HintLightWeight),
             LowerTriLvlSchedTP1SolverFunctor<RowMapType, EntriesType,
-                                             ValuesType, LHSType, RHSType,
-                                             NGBLType>(
+                                             ValuesType, LHSType, RHSType>(
                 row_map, entries, values, lhs, rhs, nodes_grouped_by_level,
                 node_count));
 
-        node_count += hnodes_per_level(iter);
+          node_count += hnodes_per_level(iter);
+        }
       }
+      cudaStreamEndCapture(stream1, &graph);
+
+      // Create graphExec
+      cudaGraphInstantiate(&(lcl_cudagraph->cudagraphinstance), graph, NULL, NULL, 0);
+      thandle.cudagraphCreated = true;
     }
-    cudaStreamEndCapture(stream1, &graph);
+    // Run graph
+    Kokkos::fence();
+    cudaGraphLaunch(lcl_cudagraph->cudagraphinstance, stream1);
 
-    // Create graphExec
-    cudaGraphInstantiate(&(lcl_cudagraph->cudagraphinstance), graph, NULL, NULL,
-                         0);
-    thandle.cudagraphCreated = true;
-  }
-  // Run graph
-  Kokkos::fence();
-  cudaGraphLaunch(lcl_cudagraph->cudagraphinstance, stream1);
+    cudaStreamSynchronize(stream1);
+    Kokkos::fence();
+  }  // end lower_tri_solve_cg
 
-  cudaStreamSynchronize(stream1);
-  Kokkos::fence();
-}  // end lower_tri_solve_cg
-
-template <class RowMapType, class EntriesType,
-          class ValuesType, class RHSType, class LHSType>
-static void upper_tri_solve_cg(TriSolveHandle &thandle, const RowMapType row_map,
-                        const EntriesType entries, const ValuesType values,
-                        const RHSType &rhs, LHSType &lhs) {
-  typedef typename TriSolveHandle::nnz_lno_view_t NGBLType;
-  typedef typename TriSolveHandle::execution_space execution_space;
-  typedef typename TriSolveHandle::size_type size_type;
-  typename TriSolveHandle::SPTRSVcudaGraphWrapperType *lcl_cudagraph =
+  template <class RowMapType, class EntriesType,
+            class ValuesType, class RHSType, class LHSType>
+  static void upper_tri_solve_cg(TriSolveHandle &thandle, const RowMapType row_map,
+                                 const EntriesType entries, const ValuesType values,
+                                 const RHSType &rhs, LHSType &lhs) {
+    typename TriSolveHandle::SPTRSVcudaGraphWrapperType *lcl_cudagraph =
       thandle.get_sptrsvCudaGraph();
 
-  auto nlevels = thandle.get_num_levels();
+    auto nlevels = thandle.get_num_levels();
 
-  auto stream1 = lcl_cudagraph->stream;
-  Kokkos::Cuda cuda1(stream1);
-  auto graph = lcl_cudagraph->cudagraph;
+    auto stream1 = lcl_cudagraph->stream;
+    Kokkos::Cuda cuda1(stream1);
+    auto graph = lcl_cudagraph->cudagraph;
 
-  Kokkos::parallel_for("Init", Kokkos::RangePolicy<execution_space>(0, 1),
-                       EmptyFunctor());
-  Kokkos::Cuda().fence();
-  cudaStreamSynchronize(stream1);
+    Kokkos::parallel_for("Init", Kokkos::RangePolicy<execution_space>(0, 1),
+                         EmptyFunctor());
+    Kokkos::Cuda().fence();
+    cudaStreamSynchronize(stream1);
 
-  auto hnodes_per_level       = thandle.get_host_nodes_per_level();
-  auto nodes_grouped_by_level = thandle.get_nodes_grouped_by_level();
+    auto hnodes_per_level       = thandle.get_host_nodes_per_level();
+    auto nodes_grouped_by_level = thandle.get_nodes_grouped_by_level();
 
-  size_type node_count = 0;
+    size_type node_count = 0;
 
-  int team_size = thandle.get_team_size();
-  team_size     = team_size == -1 ? 64 : team_size;
+    int team_size = thandle.get_team_size();
+    team_size     = team_size == -1 ? 64 : team_size;
 
-  // Start capturing stream
-  if (thandle.cudagraphCreated == false) {
-    Kokkos::fence();
-    cudaStreamBeginCapture(stream1, cudaStreamCaptureModeGlobal);
-    {
-      for (int iter = 0; iter < nlevels; ++iter) {
-        size_type lvl_nodes = hnodes_per_level(iter);
+    // Start capturing stream
+    if (thandle.cudagraphCreated == false) {
+      Kokkos::fence();
+      cudaStreamBeginCapture(stream1, cudaStreamCaptureModeGlobal);
+      {
+        for (int iter = 0; iter < nlevels; ++iter) {
+          size_type lvl_nodes = hnodes_per_level(iter);
 
-        using policy_type = ReturnTeamPolicyType<execution_space>;
+          auto policy = std::is_same<execution_space, Kokkos::Cuda>::value
+            ? team_policy(lvl_nodes, team_size, cuda1)
+            : team_policy(lvl_nodes, team_size);
 
-        Kokkos::parallel_for(
+          Kokkos::parallel_for(
             "parfor_u_team_cudagraph",
             Kokkos::Experimental::require(
-                ReturnTeamPolicyType<execution_space>::get_policy(
-                    lvl_nodes, team_size, cuda1),
+                policy,
                 Kokkos::Experimental::WorkItemProperty::HintLightWeight),
             UpperTriLvlSchedTP1SolverFunctor<RowMapType, EntriesType,
-                                             ValuesType, LHSType, RHSType,
-                                             NGBLType>(
+                                             ValuesType, LHSType, RHSType>(
                 row_map, entries, values, lhs, rhs, nodes_grouped_by_level,
                 node_count));
 
-        node_count += hnodes_per_level(iter);
+          node_count += hnodes_per_level(iter);
+        }
       }
+      cudaStreamEndCapture(stream1, &graph);
+
+      // Create graphExec
+      cudaGraphInstantiate(&(lcl_cudagraph->cudagraphinstance), graph, NULL, NULL, 0);
+      thandle.cudagraphCreated = true;
     }
-    cudaStreamEndCapture(stream1, &graph);
+    // Run graph
+    Kokkos::fence();
+    cudaGraphLaunch(lcl_cudagraph->cudagraphinstance, stream1);
 
-    // Create graphExec
-    cudaGraphInstantiate(&(lcl_cudagraph->cudagraphinstance), graph, NULL, NULL,
-                         0);
-    thandle.cudagraphCreated = true;
-  }
-  // Run graph
-  Kokkos::fence();
-  cudaGraphLaunch(lcl_cudagraph->cudagraphinstance, stream1);
-
-  cudaStreamSynchronize(stream1);
-  Kokkos::fence();
-}  // end upper_tri_solve_cg
+    cudaStreamSynchronize(stream1);
+    Kokkos::fence();
+  }  // end upper_tri_solve_cg
 
 #endif
 
-template <class ExecutionSpace, class RowMapType,
-          class EntriesType, class ValuesType, class RHSType, class LHSType>
-static void lower_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
-                     const RowMapType row_map, const EntriesType entries,
-                     const ValuesType values, const RHSType &rhs,
-                     LHSType &lhs) {
+  template <class RowMapType,
+            class EntriesType, class ValuesType, class RHSType, class LHSType>
+  static void lower_tri_solve(execution_space &space, TriSolveHandle &thandle,
+                              const RowMapType row_map, const EntriesType entries,
+                              const ValuesType values, const RHSType &rhs,
+                              LHSType &lhs) {
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOSPSTRSV_SOLVE_IMPL_PROFILE)
-  cudaProfilerStop();
+    cudaProfilerStop();
 #endif
-  typedef typename TriSolveHandle::size_type size_type;
-  typedef typename TriSolveHandle::nnz_lno_view_t NGBLType;
-
-  auto nlevels = thandle.get_num_levels();
-  // Keep this a host View, create device version and copy to back to host
-  // during scheduling This requires making sure the host view in the handle is
-  // properly updated after the symbolic phase
-  auto nodes_per_level        = thandle.get_nodes_per_level();
-  auto hnodes_per_level       = thandle.get_host_nodes_per_level();
-  auto nodes_grouped_by_level = thandle.get_nodes_grouped_by_level();
+    auto nlevels = thandle.get_num_levels();
+    // Keep this a host View, create device version and copy to back to host
+    // during scheduling This requires making sure the host view in the handle is
+    // properly updated after the symbolic phase
+    auto nodes_per_level        = thandle.get_nodes_per_level();
+    auto hnodes_per_level       = thandle.get_host_nodes_per_level();
+    auto nodes_grouped_by_level = thandle.get_nodes_grouped_by_level();
 
 #if defined(KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV)
-  using namespace KokkosSparse::Experimental;
-  using memory_space        = typename TriSolveHandle::HandleTempMemorySpace;
-  using device_t            = Kokkos::Device<ExecutionSpace, memory_space>;
-  using integer_view_t      = typename TriSolveHandle::integer_view_t;
-  using integer_view_host_t = typename TriSolveHandle::integer_view_host_t;
-  using scalar_t            = typename ValuesType::non_const_value_type;
-  using range_type          = Kokkos::pair<int, int>;
-  using row_map_host_view_t = Kokkos::View<size_type *, Kokkos::HostSpace>;
+    using namespace KokkosSparse::Experimental;
+    using device_t            = Kokkos::Device<execution_space, temp_mem_space>;
+    using integer_view_host_t = typename TriSolveHandle::integer_view_host_t;
+    using scalar_t            = typename ValuesType::non_const_value_type;
+    using row_map_host_view_t = Kokkos::View<size_type *, Kokkos::HostSpace>;
 
-  row_map_host_view_t row_map_host;
+    row_map_host_view_t row_map_host;
 
-  const scalar_t zero(0.0);
-  const scalar_t one(1.0);
+    const scalar_t zero(0.0);
+    const scalar_t one(1.0);
 
-  auto nodes_grouped_by_level_host = thandle.get_host_nodes_grouped_by_level();
+    auto nodes_grouped_by_level_host = thandle.get_host_nodes_grouped_by_level();
 
-  if (thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_NAIVE ||
-      thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_ETREE ||
-      thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_DAG) {
-    Kokkos::deep_copy(nodes_grouped_by_level_host, nodes_grouped_by_level);
+    if (thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_NAIVE ||
+        thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_ETREE ||
+        thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_DAG) {
+      Kokkos::deep_copy(nodes_grouped_by_level_host, nodes_grouped_by_level);
 
-    row_map_host = row_map_host_view_t(
+      row_map_host = row_map_host_view_t(
         Kokkos::view_alloc(Kokkos::WithoutInitializing, "host rowmap"),
         row_map.extent(0));
-    Kokkos::deep_copy(row_map_host, row_map);
-  }
+      Kokkos::deep_copy(row_map_host, row_map);
+    }
 
-  // inversion options
-  const bool invert_diagonal    = thandle.get_invert_diagonal();
-  const bool invert_offdiagonal = thandle.get_invert_offdiagonal();
-  const bool unit_diagonal      = thandle.is_unit_diagonal();
+    // inversion options
+    const bool invert_diagonal    = thandle.get_invert_diagonal();
+    const bool invert_offdiagonal = thandle.get_invert_offdiagonal();
+    const bool unit_diagonal      = thandle.is_unit_diagonal();
 
-  // supernode sizes
-  const int *supercols      = thandle.get_supercols();
-  const int *supercols_host = thandle.get_supercols_host();
+    // supernode sizes
+    const int *supercols      = thandle.get_supercols();
+    const int *supercols_host = thandle.get_supercols_host();
 
-  // kernel types
-  integer_view_t kernel_type      = thandle.get_kernel_type();
-  integer_view_t diag_kernel_type = thandle.get_diag_kernel_type();
+    // kernel types
+    work_view_int_t kernel_type      = thandle.get_kernel_type();
+    work_view_int_t diag_kernel_type = thandle.get_diag_kernel_type();
 
-  integer_view_host_t kernel_type_host = thandle.get_kernel_type_host();
-  integer_view_host_t diag_kernel_type_host =
+    integer_view_host_t kernel_type_host = thandle.get_kernel_type_host();
+    integer_view_host_t diag_kernel_type_host =
       thandle.get_diag_kernel_type_host();
 
-  // workspaces
-  integer_view_t work_offset           = thandle.get_work_offset();
-  integer_view_host_t work_offset_host = thandle.get_work_offset_host();
-  auto work                            = thandle.get_workspace();
+    // workspaces
+    work_view_int_t work_offset          = thandle.get_work_offset();
+    integer_view_host_t work_offset_host = thandle.get_work_offset_host();
+    auto work                            = thandle.get_workspace();
 #endif
 
-  size_type node_count = 0;
+    size_type node_count = 0;
 
 #ifdef profile_supernodal_etree
-  Kokkos::Timer sptrsv_timer;
-  sptrsv_timer.reset();
+    Kokkos::Timer sptrsv_timer;
+    sptrsv_timer.reset();
 #endif
 
-  for (size_type lvl = 0; lvl < nlevels; ++lvl) {
-    {
+    for (size_type lvl = 0; lvl < nlevels; ++lvl) {
       size_type lvl_nodes = hnodes_per_level(lvl);
 
       if (lvl_nodes != 0) {
@@ -2999,27 +2742,24 @@ static void lower_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
           Kokkos::parallel_for(
               "parfor_fixed_lvl",
               Kokkos::Experimental::require(
-                  Kokkos::RangePolicy<ExecutionSpace>(space, node_count,
-                                                      node_count + lvl_nodes),
+                  range_policy(space, node_count, node_count + lvl_nodes),
                   Kokkos::Experimental::WorkItemProperty::HintLightWeight),
               LowerTriLvlSchedRPSolverFunctor<RowMapType, EntriesType,
-                                              ValuesType, LHSType, RHSType,
-                                              NGBLType>(
+                                              ValuesType, LHSType, RHSType>(
                   row_map, entries, values, lhs, rhs, nodes_grouped_by_level));
         } else if (thandle.get_algorithm() ==
                    KokkosSparse::Experimental::SPTRSVAlgorithm::
                        SEQLVLSCHD_TP1) {
-          using team_policy_t = Kokkos::TeamPolicy<ExecutionSpace>;
           int team_size       = thandle.get_team_size();
 
 #ifdef KOKKOSKERNELS_SPTRSV_TRILVLSCHED
           TriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
-                                      LHSType, RHSType, NGBLType>
+                                      LHSType, RHSType>
               tstf(row_map, entries, values, lhs, rhs, nodes_grouped_by_level,
                    true, node_count);
 #else
           LowerTriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
-                                           LHSType, RHSType, NGBLType>
+                                           LHSType, RHSType>
               tstf(row_map, entries, values, lhs, rhs, nodes_grouped_by_level,
                    node_count);
 #endif
@@ -3027,14 +2767,14 @@ static void lower_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
             Kokkos::parallel_for(
                 "parfor_l_team",
                 Kokkos::Experimental::require(
-                    team_policy_t(space, lvl_nodes, Kokkos::AUTO),
+                    team_policy(space, lvl_nodes, Kokkos::AUTO),
                     Kokkos::Experimental::WorkItemProperty::HintLightWeight),
                 tstf);
           else
             Kokkos::parallel_for(
                 "parfor_l_team",
                 Kokkos::Experimental::require(
-                    team_policy_t(space, lvl_nodes, team_size),
+                    team_policy(space, lvl_nodes, team_size),
                     Kokkos::Experimental::WorkItemProperty::HintLightWeight),
                 tstf);
         }
@@ -3070,10 +2810,10 @@ static void lower_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
 
   #ifdef KOKKOSKERNELS_SPTRSV_TRILVLSCHED
           TriLvlSchedTP2SolverFunctor<RowMapType, EntriesType, ValuesType,
-  LHSType, RHSType, NGBLType> tstf(row_map, entries, values, lhs, rhs,
+  LHSType, RHSType> tstf(row_map, entries, values, lhs, rhs,
   nodes_grouped_by_level, true, node_count, vector_size, 0); #else
           LowerTriLvlSchedTP2SolverFunctor<RowMapType, EntriesType, ValuesType,
-  LHSType, RHSType, NGBLType> tstf(row_map, entries, values, lhs, rhs,
+  LHSType, RHSType> tstf(row_map, entries, values, lhs, rhs,
   nodes_grouped_by_level, node_count, node_groups); #endif
           Kokkos::parallel_for("parfor_u_team_vector", tvt_policy_type(
   (int)std::ceil((float)lvl_nodes/(float)node_groups) , team_size, vector_size
@@ -3091,7 +2831,6 @@ static void lower_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
 #endif
 
           // NOTE: we currently supports only default_layout = LayoutLeft
-          using team_policy_type = Kokkos::TeamPolicy<ExecutionSpace>;
           using supernode_view_type =
               Kokkos::View<scalar_t **, default_layout, device_t,
                            Kokkos::MemoryUnmanaged>;
@@ -3103,13 +2842,13 @@ static void lower_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
             if (invert_diagonal && !invert_offdiagonal) {
               // copy diagonals to workspaces
               const int *work_offset_data = work_offset.data();
-              SparseTriSupernodalSpMVFunctor<LHSType, NGBLType>
+              SparseTriSupernodalSpMVFunctor<LHSType>
                   sptrsv_init_functor(-2, node_count, nodes_grouped_by_level,
                                       supercols, work_offset_data, lhs, work);
               Kokkos::parallel_for(
                   "parfor_tri_supernode_spmv",
                   Kokkos::Experimental::require(
-                      team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                      team_policy(space, lvl_nodes, Kokkos::AUTO),
                       Kokkos::Experimental::WorkItemProperty::HintLightWeight),
                   sptrsv_init_functor);
             }
@@ -3194,13 +2933,13 @@ static void lower_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
             if (invert_offdiagonal) {
               // copy diagonals from workspaces
               const int *work_offset_data = work_offset.data();
-              SparseTriSupernodalSpMVFunctor<LHSType, NGBLType>
+              SparseTriSupernodalSpMVFunctor<LHSType>
                   sptrsv_init_functor(-1, node_count, nodes_grouped_by_level,
                                       supercols, work_offset_data, lhs, work);
               Kokkos::parallel_for(
                   "parfor_tri_supernode_spmv",
                   Kokkos::Experimental::require(
-                      team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                      team_policy(space, lvl_nodes, Kokkos::AUTO),
                       Kokkos::Experimental::WorkItemProperty::HintLightWeight),
                   sptrsv_init_functor);
             }
@@ -3208,7 +2947,7 @@ static void lower_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
 
           // launching sparse-triangular solve functor
           LowerTriSupernodalFunctor<RowMapType, EntriesType,
-                                    ValuesType, LHSType, NGBLType>
+                                    ValuesType, LHSType>
               sptrsv_functor(unit_diagonal, invert_diagonal, invert_offdiagonal,
                              supercols, row_map, entries, values, lvl,
                              kernel_type, diag_kernel_type, lhs, work,
@@ -3216,7 +2955,7 @@ static void lower_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
           Kokkos::parallel_for(
               "parfor_lsolve_supernode",
               Kokkos::Experimental::require(
-                  team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                  team_policy(space, lvl_nodes, Kokkos::AUTO),
                   Kokkos::Experimental::WorkItemProperty::HintLightWeight),
               sptrsv_functor);
 
@@ -3238,7 +2977,6 @@ static void lower_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
 #endif
 
           // initialize input & output vectors
-          using team_policy_type = Kokkos::TeamPolicy<ExecutionSpace>;
 
           // update with spmv (one or two SpMV)
           bool transpose_spmv =
@@ -3250,25 +2988,25 @@ static void lower_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
             auto digmat = thandle.get_diagblock(lvl);
             KokkosSparse::spmv(space, tran, one, digmat, lhs, one, work);
             // copy from work to lhs corresponding to diagonal blocks
-            SparseTriSupernodalSpMVFunctor<LHSType, NGBLType>
+            SparseTriSupernodalSpMVFunctor<LHSType>
                 sptrsv_init_functor(-1, node_count, nodes_grouped_by_level,
                                     supercols, supercols, lhs, work);
             Kokkos::parallel_for(
                 "parfor_lsolve_supernode",
                 Kokkos::Experimental::require(
-                    team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                    team_policy(space, lvl_nodes, Kokkos::AUTO),
                     Kokkos::Experimental::WorkItemProperty::HintLightWeight),
                 sptrsv_init_functor);
           } else {
             // copy lhs corresponding to diagonal blocks to work and zero out in
             // lhs
-            SparseTriSupernodalSpMVFunctor<LHSType, NGBLType>
+            SparseTriSupernodalSpMVFunctor<LHSType>
                 sptrsv_init_functor(1, node_count, nodes_grouped_by_level,
                                     supercols, supercols, lhs, work);
             Kokkos::parallel_for(
                 "parfor_lsolve_supernode",
                 Kokkos::Experimental::require(
-                    team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                    team_policy(space, lvl_nodes, Kokkos::AUTO),
                     Kokkos::Experimental::WorkItemProperty::HintLightWeight),
                 sptrsv_init_functor);
           }
@@ -3278,13 +3016,13 @@ static void lower_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
           KokkosSparse::spmv(space, tran, one, submat, work, one, lhs);
 
           // reinitialize workspace
-          SparseTriSupernodalSpMVFunctor<LHSType, NGBLType>
+          SparseTriSupernodalSpMVFunctor<LHSType>
               sptrsv_finalize_functor(0, node_count, nodes_grouped_by_level,
                                       supercols, supercols, lhs, work);
           Kokkos::parallel_for(
               "parfor_lsolve_supernode",
               Kokkos::Experimental::require(
-                  team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                  team_policy(space, lvl_nodes, Kokkos::AUTO),
                   Kokkos::Experimental::WorkItemProperty::HintLightWeight),
               sptrsv_finalize_functor);
 
@@ -3303,164 +3041,155 @@ static void lower_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
         cudaProfilerStop();
 #endif
       }  // end if
-    }    // scope for if-block
-
-  }  // end for lvl
+    }  // end for lvl
 
 #ifdef profile_supernodal_etree
-  Kokkos::fence();
-  double sptrsv_time_seconds = sptrsv_timer.seconds();
-  std::cout << " + Execution space   : " << execution_space::name()
-            << std::endl;
-  std::cout << " + Memory space      : " << memory_space::name() << std::endl;
-  std::cout << " + SpTrsv(lower) time: " << sptrsv_time_seconds << std::endl
-            << std::endl;
+    Kokkos::fence();
+    double sptrsv_time_seconds = sptrsv_timer.seconds();
+    std::cout << " + Execution space   : " << execution_space::name()
+              << std::endl;
+    std::cout << " + Memory space      : " << temp_mem_space::name() << std::endl;
+    std::cout << " + SpTrsv(lower) time: " << sptrsv_time_seconds << std::endl
+              << std::endl;
 #endif
 
-}  // end lower_tri_solve
+  }  // end lower_tri_solve
 
-template <class ExecutionSpace, class RowMapType,
-          class EntriesType, class ValuesType, class RHSType, class LHSType>
-static void upper_tri_solve(ExecutionSpace &space, TriSolveHandle &thandle,
-                     const RowMapType row_map, const EntriesType entries,
-                     const ValuesType values, const RHSType &rhs,
-                     LHSType &lhs) {
+  template <class RowMapType,
+            class EntriesType, class ValuesType, class RHSType, class LHSType>
+  static void upper_tri_solve(execution_space &space, TriSolveHandle &thandle,
+                              const RowMapType row_map, const EntriesType entries,
+                              const ValuesType values, const RHSType &rhs,
+                              LHSType &lhs) {
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOSPSTRSV_SOLVE_IMPL_PROFILE)
-  cudaProfilerStop();
+    cudaProfilerStop();
 #endif
-  using memory_space = typename TriSolveHandle::HandleTempMemorySpace;
-  using device_t     = Kokkos::Device<ExecutionSpace, memory_space>;
-  typedef typename TriSolveHandle::size_type size_type;
-  typedef typename TriSolveHandle::nnz_lno_view_t NGBLType;
+    using device_t = Kokkos::Device<execution_space, temp_mem_space>;
 
-  auto nlevels = thandle.get_num_levels();
-  // Keep this a host View, create device version and copy to back to host
-  // during scheduling This requires making sure the host view in the handle is
-  // properly updated after the symbolic phase
-  auto nodes_per_level  = thandle.get_nodes_per_level();
-  auto hnodes_per_level = thandle.get_host_nodes_per_level();
-  // auto hnodes_per_level = Kokkos::create_mirror_view(nodes_per_level);
-  // Kokkos::deep_copy(hnodes_per_level, nodes_per_level);
+    auto nlevels = thandle.get_num_levels();
+    // Keep this a host View, create device version and copy to back to host
+    // during scheduling This requires making sure the host view in the handle is
+    // properly updated after the symbolic phase
+    auto nodes_per_level  = thandle.get_nodes_per_level();
+    auto hnodes_per_level = thandle.get_host_nodes_per_level();
+    // auto hnodes_per_level = Kokkos::create_mirror_view(nodes_per_level);
+    // Kokkos::deep_copy(hnodes_per_level, nodes_per_level);
 
-  auto nodes_grouped_by_level = thandle.get_nodes_grouped_by_level();
+    auto nodes_grouped_by_level = thandle.get_nodes_grouped_by_level();
 
 #if defined(KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV)
-  using namespace KokkosSparse::Experimental;
-  using integer_view_t      = typename TriSolveHandle::integer_view_t;
-  using integer_view_host_t = typename TriSolveHandle::integer_view_host_t;
-  using scalar_t            = typename ValuesType::non_const_value_type;
-  using range_type          = Kokkos::pair<int, int>;
-  using row_map_host_view_t = Kokkos::View<size_type *, Kokkos::HostSpace>;
+    using namespace KokkosSparse::Experimental;
+    using integer_view_host_t = typename TriSolveHandle::integer_view_host_t;
+    using scalar_t            = typename ValuesType::non_const_value_type;
+    using row_map_host_view_t = Kokkos::View<size_type *, Kokkos::HostSpace>;
 
-  row_map_host_view_t row_map_host;
+    row_map_host_view_t row_map_host;
 
-  const scalar_t zero(0.0);
-  const scalar_t one(1.0);
+    const scalar_t zero(0.0);
+    const scalar_t one(1.0);
 
-  auto nodes_grouped_by_level_host = thandle.get_host_nodes_grouped_by_level();
+    auto nodes_grouped_by_level_host = thandle.get_host_nodes_grouped_by_level();
 
-  if (thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_NAIVE ||
-      thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_ETREE ||
-      thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_DAG) {
-    Kokkos::deep_copy(nodes_grouped_by_level_host, nodes_grouped_by_level);
+    if (thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_NAIVE ||
+        thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_ETREE ||
+        thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_DAG) {
+      Kokkos::deep_copy(nodes_grouped_by_level_host, nodes_grouped_by_level);
 
-    row_map_host = row_map_host_view_t(
+      row_map_host = row_map_host_view_t(
         Kokkos::view_alloc(Kokkos::WithoutInitializing, "host rowmap"),
         row_map.extent(0));
-    Kokkos::deep_copy(row_map_host, row_map);
-  }
+      Kokkos::deep_copy(row_map_host, row_map);
+    }
 
-  // supernode sizes
-  const int *supercols      = thandle.get_supercols();
-  const int *supercols_host = thandle.get_supercols_host();
+    // supernode sizes
+    const int *supercols      = thandle.get_supercols();
+    const int *supercols_host = thandle.get_supercols_host();
 
-  // inversion option
-  const bool invert_diagonal    = thandle.get_invert_diagonal();
-  const bool invert_offdiagonal = thandle.get_invert_offdiagonal();
+    // inversion option
+    const bool invert_diagonal    = thandle.get_invert_diagonal();
+    const bool invert_offdiagonal = thandle.get_invert_offdiagonal();
 
-  // kernel types
-  integer_view_t kernel_type      = thandle.get_kernel_type();
-  integer_view_t diag_kernel_type = thandle.get_diag_kernel_type();
+    // kernel types
+    work_view_int_t kernel_type      = thandle.get_kernel_type();
+    work_view_int_t diag_kernel_type = thandle.get_diag_kernel_type();
 
-  integer_view_host_t kernel_type_host = thandle.get_kernel_type_host();
-  integer_view_host_t diag_kernel_type_host =
+    integer_view_host_t kernel_type_host = thandle.get_kernel_type_host();
+    integer_view_host_t diag_kernel_type_host =
       thandle.get_diag_kernel_type_host();
 
-  // workspace
-  integer_view_t work_offset           = thandle.get_work_offset();
-  integer_view_host_t work_offset_host = thandle.get_work_offset_host();
-  auto work                            = thandle.get_workspace();
+    // workspace
+    work_view_int_t work_offset          = thandle.get_work_offset();
+    integer_view_host_t work_offset_host = thandle.get_work_offset_host();
+    auto work                            = thandle.get_workspace();
 #endif
 
-  size_type node_count = 0;
+    size_type node_count = 0;
 
-// This must stay serial; would be nice to try out Cuda's graph stuff to reduce
-// kernel launch overhead
+    // This must stay serial; would be nice to try out Cuda's graph stuff to reduce
+    // kernel launch overhead
 #ifdef profile_supernodal_etree
-  Kokkos::Timer sptrsv_timer;
-  sptrsv_timer.reset();
+    Kokkos::Timer sptrsv_timer;
+    sptrsv_timer.reset();
 #endif
-  for (size_type lvl = 0; lvl < nlevels; ++lvl) {
-    size_type lvl_nodes = hnodes_per_level(lvl);
+    for (size_type lvl = 0; lvl < nlevels; ++lvl) {
+      size_type lvl_nodes = hnodes_per_level(lvl);
 
-    if (lvl_nodes != 0) {
+      if (lvl_nodes != 0) {
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOSPSTRSV_SOLVE_IMPL_PROFILE)
-      cudaProfilerStart();
+        cudaProfilerStart();
 #endif
 
-      if (thandle.get_algorithm() ==
-          KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_RP) {
-        Kokkos::parallel_for(
+        if (thandle.get_algorithm() ==
+            KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_RP) {
+          Kokkos::parallel_for(
             "parfor_fixed_lvl",
             Kokkos::Experimental::require(
-                Kokkos::RangePolicy<ExecutionSpace>(space, node_count,
-                                                    node_count + lvl_nodes),
+                range_policy(space, node_count, node_count + lvl_nodes),
                 Kokkos::Experimental::WorkItemProperty::HintLightWeight),
             UpperTriLvlSchedRPSolverFunctor<RowMapType, EntriesType, ValuesType,
-                                            LHSType, RHSType, NGBLType>(
+                                            LHSType, RHSType>(
                 row_map, entries, values, lhs, rhs, nodes_grouped_by_level));
-      } else if (thandle.get_algorithm() ==
-                 KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_TP1) {
-        using team_policy_t = Kokkos::TeamPolicy<ExecutionSpace>;
+        } else if (thandle.get_algorithm() ==
+                   KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_TP1) {
 
-        int team_size = thandle.get_team_size();
+          int team_size = thandle.get_team_size();
 
 #ifdef KOKKOSKERNELS_SPTRSV_TRILVLSCHED
-        TriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
-                                    LHSType, RHSType, NGBLType>
+          TriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
+                                      LHSType, RHSType>
             tstf(row_map, entries, values, lhs, rhs, nodes_grouped_by_level,
                  false, node_count);
 #else
-        UpperTriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
-                                         LHSType, RHSType, NGBLType>
+          UpperTriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
+                                           LHSType, RHSType>
             tstf(row_map, entries, values, lhs, rhs, nodes_grouped_by_level,
                  node_count);
 #endif
-        if (team_size == -1)
-          Kokkos::parallel_for(
+          if (team_size == -1)
+            Kokkos::parallel_for(
               "parfor_u_team",
               Kokkos::Experimental::require(
-                  team_policy_t(space, lvl_nodes, Kokkos::AUTO),
+                  team_policy(space, lvl_nodes, Kokkos::AUTO),
                   Kokkos::Experimental::WorkItemProperty::HintLightWeight),
               tstf);
-        else
-          Kokkos::parallel_for(
+          else
+            Kokkos::parallel_for(
               "parfor_u_team",
               Kokkos::Experimental::require(
-                  team_policy_t(space, lvl_nodes, team_size),
+                  team_policy(space, lvl_nodes, team_size),
                   Kokkos::Experimental::WorkItemProperty::HintLightWeight),
               tstf);
-      }
-      // TP2 algorithm has issues with some offset-ordinal combo to be addressed
-      /*
-      else if ( thandle.get_algorithm() ==
-KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHED_TP2 ) { typedef
-Kokkos::TeamPolicy<execution_space> tvt_policy_type;
+        }
+        // TP2 algorithm has issues with some offset-ordinal combo to be addressed
+        /*
+          else if ( thandle.get_algorithm() ==
+          KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHED_TP2 ) { typedef
+          Kokkos::TeamPolicy<execution_space> tvt_policy_type;
 
-        int team_size = thandle.get_team_size();
-        if ( team_size == -1 ) {
+          int team_size = thandle.get_team_size();
+          if ( team_size == -1 ) {
           team_size = std::is_same< typename
-Kokkos::DefaultExecutionSpace::memory_space, Kokkos::HostSpace >::value ? 1 :
+          Kokkos::DefaultExecutionSpace::memory_space, Kokkos::HostSpace >::value ? 1 :
 64;
         }
         int vector_size = thandle.get_team_size();
@@ -3480,10 +3209,10 @@ node_group (thread has full ownership of a node)
 
 #ifdef KOKKOSKERNELS_SPTRSV_TRILVLSCHED
         TriLvlSchedTP2SolverFunctor<RowMapType, EntriesType, ValuesType,
-LHSType, RHSType, NGBLType> tstf(row_map, entries, values, lhs, rhs,
+LHSType, RHSType> tstf(row_map, entries, values, lhs, rhs,
 nodes_grouped_by_level, false, node_count, vector_size, 0); #else
         UpperTriLvlSchedTP2SolverFunctor<RowMapType, EntriesType, ValuesType,
-LHSType, RHSType, NGBLType> tstf(row_map, entries, values, lhs, rhs,
+LHSType, RHSType> tstf(row_map, entries, values, lhs, rhs,
 nodes_grouped_by_level, node_count, node_groups); #endif
 
         Kokkos::parallel_for("parfor_u_team_vector", tvt_policy_type(
@@ -3491,827 +3220,805 @@ nodes_grouped_by_level, node_count, node_groups); #endif
 tstf); } // end elseif
       */
 #if defined(KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV)
-      else if (thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_NAIVE ||
-               thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_ETREE ||
-               thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_DAG) {
+        else if (thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_NAIVE ||
+                 thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_ETREE ||
+                 thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_DAG) {
 
 #ifdef profile_supernodal_etree
-        size_t flops = 0;
-        Kokkos::Timer timer;
-        timer.reset();
+          size_t flops = 0;
+          Kokkos::Timer timer;
+          timer.reset();
 #endif
 
-        using team_policy_type = Kokkos::TeamPolicy<ExecutionSpace>;
-        if (thandle.is_column_major()) {  // U stored in CSC
-          if (diag_kernel_type_host(lvl) == 3) {
-            // using device-level kernels (functor is called to gather the input
-            // into workspace)
-            scalar_t *dataU = const_cast<scalar_t *>(values.data());
+          if (thandle.is_column_major()) {  // U stored in CSC
+            if (diag_kernel_type_host(lvl) == 3) {
+              // using device-level kernels (functor is called to gather the input
+              // into workspace)
+              scalar_t *dataU = const_cast<scalar_t *>(values.data());
 
-            if (invert_diagonal && !invert_offdiagonal) {
-              // copy diagonals to workspaces
-              const int *work_offset_data = work_offset.data();
-              SparseTriSupernodalSpMVFunctor<LHSType, NGBLType>
+              if (invert_diagonal && !invert_offdiagonal) {
+                // copy diagonals to workspaces
+                const int *work_offset_data = work_offset.data();
+                SparseTriSupernodalSpMVFunctor<LHSType>
                   sptrsv_init_functor(-2, node_count, nodes_grouped_by_level,
                                       supercols, work_offset_data, lhs, work);
-              Kokkos::parallel_for(
+                Kokkos::parallel_for(
                   "parfor_tri_supernode_spmv",
                   Kokkos::Experimental::require(
-                      team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                      team_policy(space, lvl_nodes, Kokkos::AUTO),
                       Kokkos::Experimental::WorkItemProperty::HintLightWeight),
                   sptrsv_init_functor);
-            }
-            for (size_type league_rank = 0; league_rank < lvl_nodes;
-                 league_rank++) {
-              auto s = nodes_grouped_by_level_host(node_count + league_rank);
+              }
+              for (size_type league_rank = 0; league_rank < lvl_nodes;
+                   league_rank++) {
+                auto s = nodes_grouped_by_level_host(node_count + league_rank);
 
-              // supernodal column size
-              int j1 = supercols_host[s];
-              int j2 = supercols_host[s + 1];
-              int nscol =
+                // supernodal column size
+                int j1 = supercols_host[s];
+                int j2 = supercols_host[s + 1];
+                int nscol =
                   j2 - j1;  // number of columns in the s-th supernode column
 
-              int i1    = row_map_host(j1);
-              int i2    = row_map_host(j1 + 1);
-              int nsrow = i2 - i1;         // "total" number of rows in all the
-                                           // supernodes (diagonal+off-diagonal)
-              int nsrow2 = nsrow - nscol;  // "total" number of rows in all the
-                                           // off-diagonal supernodes
+                int i1    = row_map_host(j1);
+                int i2    = row_map_host(j1 + 1);
+                int nsrow = i2 - i1;         // "total" number of rows in all the
+                                             // supernodes (diagonal+off-diagonal)
+                int nsrow2 = nsrow - nscol;  // "total" number of rows in all the
+                                             // off-diagonal supernodes
 #ifdef profile_supernodal_etree
-              flops += 2 * (nscol * nsrow);
+                flops += 2 * (nscol * nsrow);
 #endif
 
-              // workspace
-              int workoffset = work_offset_host(s);
+                // workspace
+                int workoffset = work_offset_host(s);
 
               // create a view for the s-th supernocal block column
               // NOTE: we currently supports only default_layout = LayoutLeft
-              Kokkos::View<scalar_t **, default_layout, device_t,
-                           Kokkos::MemoryUnmanaged>
+                Kokkos::View<scalar_t **, default_layout, device_t,
+                             Kokkos::MemoryUnmanaged>
                   viewU(&dataU[i1], nsrow, nscol);
 
-              if (invert_offdiagonal) {
-                auto Uij =
+                if (invert_offdiagonal) {
+                  auto Uij =
                     Kokkos::subview(viewU, range_type(0, nsrow), Kokkos::ALL());
-                auto Xj = Kokkos::subview(lhs, range_type(j1, j2));
-                auto Z  = Kokkos::subview(
+                  auto Xj = Kokkos::subview(lhs, range_type(j1, j2));
+                  auto Z  = Kokkos::subview(
                     work,
                     range_type(
                         workoffset,
                         workoffset +
                             nsrow));  // needed with gemv for update&scatter
-                KokkosBlas::gemv(space, "N", one, Uij, Xj, zero, Z);
-              } else {
-                // extract part of the solution, corresponding to the diagonal
-                // block
-                auto Xj = Kokkos::subview(lhs, range_type(j1, j2));
+                  KokkosBlas::gemv(space, "N", one, Uij, Xj, zero, Z);
+                } else {
+                  // extract part of the solution, corresponding to the diagonal
+                  // block
+                  auto Xj = Kokkos::subview(lhs, range_type(j1, j2));
 
-                // "triangular-solve" to compute Xj
-                // extract the diagonal block of s-th supernocal column of U
-                auto Ujj =
+                  // "triangular-solve" to compute Xj
+                  // extract the diagonal block of s-th supernocal column of U
+                  auto Ujj =
                     Kokkos::subview(viewU, range_type(0, nscol), Kokkos::ALL());
-                if (invert_diagonal) {
-                  auto Y = Kokkos::subview(
+                  if (invert_diagonal) {
+                    auto Y = Kokkos::subview(
                       work,
                       range_type(
                           workoffset,
                           workoffset +
                               nscol));  // needed for gemv instead of trmv/trsv
-                  KokkosBlas::gemv(space, "N", one, Ujj, Y, zero, Xj);
-                } else {
-                  // NOTE: we currently supports only default_layout =
-                  // LayoutLeft
-                  Kokkos::View<scalar_t **, default_layout, device_t,
-                               Kokkos::MemoryUnmanaged>
+                    KokkosBlas::gemv(space, "N", one, Ujj, Y, zero, Xj);
+                  } else {
+                    // NOTE: we currently supports only default_layout =
+                    // LayoutLeft
+                    Kokkos::View<scalar_t **, default_layout, device_t,
+                                 Kokkos::MemoryUnmanaged>
                       Xjj(Xj.data(), nscol, 1);
-                  KokkosBlas::trsm(space, "L", "U", "N", "N", one, Ujj, Xjj);
-                }
-                // update off-diagonal blocks
-                if (nsrow2 > 0) {
-                  // extract the off-diagonal blocks of s-th supernodal column
-                  // of U
-                  auto Uij = Kokkos::subview(viewU, range_type(nscol, nsrow),
-                                             Kokkos::ALL());
-                  auto Z   = Kokkos::subview(
+                    KokkosBlas::trsm(space, "L", "U", "N", "N", one, Ujj, Xjj);
+                  }
+                  // update off-diagonal blocks
+                  if (nsrow2 > 0) {
+                    // extract the off-diagonal blocks of s-th supernodal column
+                    // of U
+                    auto Uij = Kokkos::subview(viewU, range_type(nscol, nsrow),
+                                               Kokkos::ALL());
+                    auto Z   = Kokkos::subview(
                       work,
                       range_type(
                           workoffset + nscol,
                           workoffset + nscol +
                               nsrow2));  // needed with gemv for update&scatter
-                  KokkosBlas::gemv(space, "N", one, Uij, Xj, zero, Z);
+                    KokkosBlas::gemv(space, "N", one, Uij, Xj, zero, Z);
+                  }
                 }
               }
-            }
-            if (invert_offdiagonal) {
-              // copy diagonals from workspaces
-              const int *work_offset_data = work_offset.data();
-              SparseTriSupernodalSpMVFunctor<LHSType, NGBLType>
+              if (invert_offdiagonal) {
+                // copy diagonals from workspaces
+                const int *work_offset_data = work_offset.data();
+                SparseTriSupernodalSpMVFunctor<LHSType>
                   sptrsv_init_functor(-1, node_count, nodes_grouped_by_level,
                                       supercols, work_offset_data, lhs, work);
-              Kokkos::parallel_for(
+                Kokkos::parallel_for(
                   "parfor_tri_supernode_spmv",
                   Kokkos::Experimental::require(
-                      team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                      team_policy(space, lvl_nodes, Kokkos::AUTO),
                       Kokkos::Experimental::WorkItemProperty::HintLightWeight),
                   sptrsv_init_functor);
+              }
             }
-          }
 
-          // launching sparse-triangular solve functor
-          UpperTriTranSupernodalFunctor<RowMapType, EntriesType,
-                                        ValuesType, LHSType, NGBLType>
+            // launching sparse-triangular solve functor
+            UpperTriTranSupernodalFunctor<RowMapType, EntriesType,
+                                          ValuesType, LHSType>
               sptrsv_functor(invert_diagonal, invert_offdiagonal, supercols,
                              row_map, entries, values, lvl, kernel_type,
                              diag_kernel_type, lhs, work, work_offset,
                              nodes_grouped_by_level, node_count);
 
-          using team_policy_t = Kokkos::TeamPolicy<ExecutionSpace>;
-          Kokkos::parallel_for(
+            Kokkos::parallel_for(
               "parfor_usolve_tran_supernode",
               Kokkos::Experimental::require(
-                  team_policy_t(space, lvl_nodes, Kokkos::AUTO),
+                  team_policy(space, lvl_nodes, Kokkos::AUTO),
                   Kokkos::Experimental::WorkItemProperty::HintLightWeight),
               sptrsv_functor);
-        } else {  // U stored in CSR
-          // launching sparse-triangular solve functor
-          UpperTriSupernodalFunctor<RowMapType, EntriesType,
-                                    ValuesType, LHSType, NGBLType>
+          } else {  // U stored in CSR
+            // launching sparse-triangular solve functor
+            UpperTriSupernodalFunctor<RowMapType, EntriesType,
+                                      ValuesType, LHSType>
               sptrsv_functor(invert_diagonal, supercols, row_map, entries,
                              values, lvl, kernel_type, diag_kernel_type, lhs,
                              work, work_offset, nodes_grouped_by_level,
                              node_count);
 
-          using team_policy_t = Kokkos::TeamPolicy<ExecutionSpace>;
-          Kokkos::parallel_for(
+            Kokkos::parallel_for(
               "parfor_usolve_supernode",
               Kokkos::Experimental::require(
-                  team_policy_t(space, lvl_nodes, Kokkos::AUTO),
+                  team_policy(space, lvl_nodes, Kokkos::AUTO),
                   Kokkos::Experimental::WorkItemProperty::HintLightWeight),
               sptrsv_functor);
 
-          if (diag_kernel_type_host(lvl) == 3) {
-            // using device-level kernels (functor is called to gather the input
-            // into workspace)
-            scalar_t *dataU = const_cast<scalar_t *>(values.data());
+            if (diag_kernel_type_host(lvl) == 3) {
+              // using device-level kernels (functor is called to gather the input
+              // into workspace)
+              scalar_t *dataU = const_cast<scalar_t *>(values.data());
 
-            for (size_type league_rank = 0; league_rank < lvl_nodes;
-                 league_rank++) {
-              auto s = nodes_grouped_by_level_host(node_count + league_rank);
+              for (size_type league_rank = 0; league_rank < lvl_nodes;
+                   league_rank++) {
+                auto s = nodes_grouped_by_level_host(node_count + league_rank);
 
-              // supernodal column size
-              int j1 = supercols_host[s];
-              int j2 = supercols_host[s + 1];
-              int nscol =
+                // supernodal column size
+                int j1 = supercols_host[s];
+                int j2 = supercols_host[s + 1];
+                int nscol =
                   j2 - j1;  // number of columns in the s-th supernode column
 
-              // "total" number of rows in all the supernodes
-              // (diagonal+off-diagonal)
-              int i1    = row_map_host(j1);
-              int i2    = row_map_host(j1 + 1);
-              int nsrow = i2 - i1;
-              // "total" number of rows in all the off-diagonal supernodes
-              int nsrow2 = nsrow - nscol;
+                // "total" number of rows in all the supernodes
+                // (diagonal+off-diagonal)
+                int i1    = row_map_host(j1);
+                int i2    = row_map_host(j1 + 1);
+                int nsrow = i2 - i1;
+                // "total" number of rows in all the off-diagonal supernodes
+                int nsrow2 = nsrow - nscol;
 
-              // workspace
-              int workoffset = work_offset_host(s);
+                // workspace
+                int workoffset = work_offset_host(s);
 
-              // create a view for the s-th supernocal block column
-              // NOTE: we currently supports only default_layout = LayoutLeft
-              Kokkos::View<scalar_t **, default_layout, device_t,
-                           Kokkos::MemoryUnmanaged>
+                // create a view for the s-th supernocal block column
+                // NOTE: we currently supports only default_layout = LayoutLeft
+                Kokkos::View<scalar_t **, default_layout, device_t,
+                             Kokkos::MemoryUnmanaged>
                   viewU(&dataU[i1], nsrow, nscol);
 
-              // extract part of the solution, corresponding to the diagonal
-              // block
-              auto Xj = Kokkos::subview(lhs, range_type(j1, j2));
-              auto Y  = Kokkos::subview(
+                // extract part of the solution, corresponding to the diagonal
+                // block
+                auto Xj = Kokkos::subview(lhs, range_type(j1, j2));
+                auto Y  = Kokkos::subview(
                   work,
                   range_type(
                       workoffset,
                       workoffset +
                           nscol));  // needed for gemv instead of trmv/trsv
 
-              // update with off-diagonal blocks
-              if (nsrow2 > 0) {
-                // extract the off-diagonal blocks of s-th supernodal column of
-                // U
-                auto Uij = Kokkos::subview(viewU, range_type(nscol, nsrow),
-                                           Kokkos::ALL());
-                auto Z   = Kokkos::subview(
+                // update with off-diagonal blocks
+                if (nsrow2 > 0) {
+                  // extract the off-diagonal blocks of s-th supernodal column of
+                  // U
+                  auto Uij = Kokkos::subview(viewU, range_type(nscol, nsrow),
+                                             Kokkos::ALL());
+                  auto Z   = Kokkos::subview(
                     work,
                     range_type(
                         workoffset + nscol,
                         workoffset + nscol +
                             nsrow2));  // needed with gemv for update&scatter
-                KokkosBlas::gemv(space, "T", -one, Uij, Z, one, Xj);
-              }
+                  KokkosBlas::gemv(space, "T", -one, Uij, Z, one, Xj);
+                }
 
-              // "triangular-solve" to compute Xj
-              // extract the diagonal block of s-th supernocal column of U
-              auto Ujj =
+                // "triangular-solve" to compute Xj
+                // extract the diagonal block of s-th supernocal column of U
+                auto Ujj =
                   Kokkos::subview(viewU, range_type(0, nscol), Kokkos::ALL());
-              if (invert_diagonal) {
-                KokkosBlas::gemv(space, "T", one, Ujj, Xj, zero, Y);
-              } else {
-                // NOTE: we currently supports only default_layout = LayoutLeft
-                Kokkos::View<scalar_t **, default_layout, device_t,
-                             Kokkos::MemoryUnmanaged>
+                if (invert_diagonal) {
+                  KokkosBlas::gemv(space, "T", one, Ujj, Xj, zero, Y);
+                } else {
+                  // NOTE: we currently supports only default_layout = LayoutLeft
+                  Kokkos::View<scalar_t **, default_layout, device_t,
+                               Kokkos::MemoryUnmanaged>
                     Xjj(Xj.data(), nscol, 1);
-                KokkosBlas::trsm(space, "L", "L", "T", "N", one, Ujj, Xjj);
+                  KokkosBlas::trsm(space, "L", "L", "T", "N", one, Ujj, Xjj);
+                }
               }
-            }
-            if (invert_diagonal) {
-              // copy diagonals from workspaces
-              const int *work_offset_data = work_offset.data();
-              SparseTriSupernodalSpMVFunctor<LHSType, NGBLType>
+              if (invert_diagonal) {
+                // copy diagonals from workspaces
+                const int *work_offset_data = work_offset.data();
+                SparseTriSupernodalSpMVFunctor<LHSType>
                   sptrsv_init_functor(-1, node_count, nodes_grouped_by_level,
                                       supercols, work_offset_data, lhs, work);
-              Kokkos::parallel_for(
+                Kokkos::parallel_for(
                   "parfor_tri_supernode_spmv",
                   Kokkos::Experimental::require(
-                      team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                      team_policy(space, lvl_nodes, Kokkos::AUTO),
                       Kokkos::Experimental::WorkItemProperty::HintLightWeight),
                   sptrsv_init_functor);
+              }
             }
           }
-        }
 #ifdef profile_supernodal_etree
-        Kokkos::fence();
-        double time_seconds = timer.seconds();
-        std::cout << " > SUPERNODAL UpperTri: " << lvl << " " << time_seconds
-                  << " flop count: " << flops
-                  << " kernel-type: " << kernel_type_host(lvl)
-                  << " # of supernodes: " << lvl_nodes << std::endl;
+          Kokkos::fence();
+          double time_seconds = timer.seconds();
+          std::cout << " > SUPERNODAL UpperTri: " << lvl << " " << time_seconds
+                    << " flop count: " << flops
+                    << " kernel-type: " << kernel_type_host(lvl)
+                    << " # of supernodes: " << lvl_nodes << std::endl;
 #endif
-      } else if (thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_SPMV ||
-                 thandle.get_algorithm() ==
-                     SPTRSVAlgorithm::SUPERNODAL_SPMV_DAG) {
+        } else if (thandle.get_algorithm() == SPTRSVAlgorithm::SUPERNODAL_SPMV ||
+                   thandle.get_algorithm() ==
+                   SPTRSVAlgorithm::SUPERNODAL_SPMV_DAG) {
 #ifdef profile_supernodal_etree
-        Kokkos::Timer timer;
-        timer.reset();
+          Kokkos::Timer timer;
+          timer.reset();
 #endif
 
-        // initialize input & output vectors
-        using team_policy_type = Kokkos::TeamPolicy<ExecutionSpace>;
+          // initialize input & output vectors
 
-        // update with one, or two, spmv
-        bool transpose_spmv =
+          // update with one, or two, spmv
+          bool transpose_spmv =
             ((!thandle.transpose_spmv() && thandle.is_column_major()) ||
              (thandle.transpose_spmv() && !thandle.is_column_major()));
-        const char *tran = (transpose_spmv ? "T" : "N");
-        if (!transpose_spmv) {  // U stored in CSR
-          if (!invert_offdiagonal) {
-            // solve with diagonals
-            auto digmat = thandle.get_diagblock(lvl);
-            KokkosSparse::spmv(space, tran, one, digmat, lhs, one, work);
-            // copy from work to lhs corresponding to diagonal blocks
-            SparseTriSupernodalSpMVFunctor<LHSType, NGBLType>
+          const char *tran = (transpose_spmv ? "T" : "N");
+          if (!transpose_spmv) {  // U stored in CSR
+            if (!invert_offdiagonal) {
+              // solve with diagonals
+              auto digmat = thandle.get_diagblock(lvl);
+              KokkosSparse::spmv(space, tran, one, digmat, lhs, one, work);
+              // copy from work to lhs corresponding to diagonal blocks
+              SparseTriSupernodalSpMVFunctor<LHSType>
                 sptrsv_init_functor(-1, node_count, nodes_grouped_by_level,
                                     supercols, supercols, lhs, work);
-            Kokkos::parallel_for(
+              Kokkos::parallel_for(
                 "parfor_lsolve_supernode",
                 Kokkos::Experimental::require(
-                    team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                    team_policy(space, lvl_nodes, Kokkos::AUTO),
                     Kokkos::Experimental::WorkItemProperty::HintLightWeight),
                 sptrsv_init_functor);
-          } else {
-            // zero out lhs corresponding to diagonal blocks in lhs, and copy to
-            // work
-            SparseTriSupernodalSpMVFunctor<LHSType, NGBLType>
+            } else {
+              // zero out lhs corresponding to diagonal blocks in lhs, and copy to
+              // work
+              SparseTriSupernodalSpMVFunctor<LHSType>
                 sptrsv_init_functor(1, node_count, nodes_grouped_by_level,
                                     supercols, supercols, lhs, work);
-            Kokkos::parallel_for(
+              Kokkos::parallel_for(
                 "parfor_lsolve_supernode",
                 Kokkos::Experimental::require(
-                    team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                    team_policy(space, lvl_nodes, Kokkos::AUTO),
                     Kokkos::Experimental::WorkItemProperty::HintLightWeight),
                 sptrsv_init_functor);
-          }
-          // update with off-diagonals (potentiall combined with diagonal
-          // solves)
-          auto submat = thandle.get_submatrix(lvl);
-          KokkosSparse::spmv(space, tran, one, submat, work, one, lhs);
-        } else {
-          if (!invert_offdiagonal) {
-            // zero out lhs corresponding to diagonal blocks in lhs, and copy to
-            // work
-            SparseTriSupernodalSpMVFunctor<LHSType, NGBLType>
-                sptrsv_init_functor(1, node_count, nodes_grouped_by_level,
-                                    supercols, supercols, lhs, work);
-            Kokkos::parallel_for(
-                "parfor_lsolve_supernode",
-                Kokkos::Experimental::require(
-                    team_policy_type(space, lvl_nodes, Kokkos::AUTO),
-                    Kokkos::Experimental::WorkItemProperty::HintLightWeight),
-                sptrsv_init_functor);
-
-            // update with off-diagonals
+            }
+            // update with off-diagonals (potentiall combined with diagonal
+            // solves)
             auto submat = thandle.get_submatrix(lvl);
-            KokkosSparse::spmv(space, tran, one, submat, lhs, one, work);
-
-            // solve with diagonals
-            auto digmat = thandle.get_diagblock(lvl);
-            KokkosSparse::spmv(space, tran, one, digmat, work, one, lhs);
+            KokkosSparse::spmv(space, tran, one, submat, work, one, lhs);
           } else {
-            std::cout << " ** invert_offdiag with U in CSR not supported **"
-                      << std::endl;
+            if (!invert_offdiagonal) {
+              // zero out lhs corresponding to diagonal blocks in lhs, and copy to
+              // work
+              SparseTriSupernodalSpMVFunctor<LHSType>
+                sptrsv_init_functor(1, node_count, nodes_grouped_by_level,
+                                    supercols, supercols, lhs, work);
+              Kokkos::parallel_for(
+                "parfor_lsolve_supernode",
+                Kokkos::Experimental::require(
+                    team_policy(space, lvl_nodes, Kokkos::AUTO),
+                    Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+                sptrsv_init_functor);
+
+              // update with off-diagonals
+              auto submat = thandle.get_submatrix(lvl);
+              KokkosSparse::spmv(space, tran, one, submat, lhs, one, work);
+
+              // solve with diagonals
+              auto digmat = thandle.get_diagblock(lvl);
+              KokkosSparse::spmv(space, tran, one, digmat, work, one, lhs);
+            } else {
+              std::cout << " ** invert_offdiag with U in CSR not supported **"
+                        << std::endl;
+            }
           }
-        }
-        // reinitialize workspace
-        SparseTriSupernodalSpMVFunctor<LHSType, NGBLType>
+          // reinitialize workspace
+          SparseTriSupernodalSpMVFunctor<LHSType>
             sptrsv_finalize_functor(0, node_count, nodes_grouped_by_level,
                                     supercols, supercols, lhs, work);
-        Kokkos::parallel_for(
+          Kokkos::parallel_for(
             "parfor_lsolve_supernode",
             Kokkos::Experimental::require(
-                team_policy_type(space, lvl_nodes, Kokkos::AUTO),
+                team_policy(space, lvl_nodes, Kokkos::AUTO),
                 Kokkos::Experimental::WorkItemProperty::HintLightWeight),
             sptrsv_finalize_functor);
 
 #ifdef profile_supernodal_etree
-        Kokkos::fence();
-        double time_seconds = timer.seconds();
-        std::cout << " > SUPERNODAL UpperTri: " << lvl << " " << time_seconds
-                  << " kernel-type: " << kernel_type_host(lvl)
-                  << " # of supernodes: " << lvl_nodes << std::endl;
+          Kokkos::fence();
+          double time_seconds = timer.seconds();
+          std::cout << " > SUPERNODAL UpperTri: " << lvl << " " << time_seconds
+                    << " kernel-type: " << kernel_type_host(lvl)
+                    << " # of supernodes: " << lvl_nodes << std::endl;
 #endif
-      }
+        }
 #endif
-      node_count += lvl_nodes;
+        node_count += lvl_nodes;
 
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOSPSTRSV_SOLVE_IMPL_PROFILE)
-      cudaProfilerStop();
+        cudaProfilerStop();
 #endif
-    }  // end if
-  }    // end for lvl
+      }  // end if
+    }    // end for lvl
 #ifdef profile_supernodal_etree
-  Kokkos::fence();
-  double sptrsv_time_seconds = sptrsv_timer.seconds();
-  std::cout << " + SpTrsv(uppper) time: " << sptrsv_time_seconds << std::endl
-            << std::endl;
-  std::cout << "  + Execution space    : " << ExecutionSpace::name()
-            << std::endl;
-  std::cout << " + Memory space       : " << memory_space::name() << std::endl;
+    Kokkos::fence();
+    double sptrsv_time_seconds = sptrsv_timer.seconds();
+    std::cout << " + SpTrsv(uppper) time: " << sptrsv_time_seconds << std::endl
+              << std::endl;
+    std::cout << "  + Execution space    : " << execution_space::name()
+              << std::endl;
+    std::cout << " + Memory space       : " << temp_mem_space::name() << std::endl;
 #endif
 
-}  // end upper_tri_solve
+  }  // end upper_tri_solve
 
-template <class ExecutionSpace, class RowMapType,
-          class EntriesType, class ValuesType, class RHSType, class LHSType>
-static void tri_solve_chain(ExecutionSpace &space, TriSolveHandle &thandle,
-                     const RowMapType row_map, const EntriesType entries,
-                     const ValuesType values, const RHSType &rhs, LHSType &lhs,
-                     const bool /*is_lowertri_*/) {
+  template <class RowMapType,
+            class EntriesType, class ValuesType, class RHSType, class LHSType>
+static void tri_solve_chain(execution_space &space, TriSolveHandle &thandle,
+                            const RowMapType row_map, const EntriesType entries,
+                            const ValuesType values, const RHSType &rhs, LHSType &lhs,
+                            const bool /*is_lowertri_*/) {
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOSPSTRSV_SOLVE_IMPL_PROFILE)
-  cudaProfilerStop();
+    cudaProfilerStop();
 #endif
-  typedef typename TriSolveHandle::size_type size_type;
-  typedef typename TriSolveHandle::nnz_lno_view_t NGBLType;
+    // Algorithm is checked before this function is called
+    auto h_chain_ptr            = thandle.get_host_chain_ptr();
+    size_type num_chain_entries = thandle.get_num_chain_entries();
 
-  // Algorithm is checked before this function is called
-  auto h_chain_ptr            = thandle.get_host_chain_ptr();
-  size_type num_chain_entries = thandle.get_num_chain_entries();
+    // Keep this a host View, create device version and copy to back to host
+    // during scheduling This requires making sure the host view in the handle is
+    // properly updated after the symbolic phase
+    auto nodes_per_level  = thandle.get_nodes_per_level();
+    auto hnodes_per_level = thandle.get_host_nodes_per_level();
 
-  // Keep this a host View, create device version and copy to back to host
-  // during scheduling This requires making sure the host view in the handle is
-  // properly updated after the symbolic phase
-  auto nodes_per_level  = thandle.get_nodes_per_level();
-  auto hnodes_per_level = thandle.get_host_nodes_per_level();
+    auto nodes_grouped_by_level = thandle.get_nodes_grouped_by_level();
 
-  auto nodes_grouped_by_level = thandle.get_nodes_grouped_by_level();
+    const bool is_lowertri = thandle.is_lower_tri();
 
-  const bool is_lowertri = thandle.is_lower_tri();
-
-  size_type node_count = 0;
+    size_type node_count = 0;
 
   // REFACTORED to cleanup; next, need debug and timer routines
-  using policy_type = Kokkos::TeamPolicy<ExecutionSpace>;
-  using large_cutoff_policy_type =
-      Kokkos::TeamPolicy<LargerCutoffTag, ExecutionSpace>;
+    using large_cutoff_policy_type =
+      Kokkos::TeamPolicy<LargerCutoffTag, execution_space>;
   /*
     using TP1Functor = TriLvlSchedTP1SolverFunctor<RowMapType, EntriesType,
-    ValuesType, LHSType, RHSType, NGBLType>; using LTP1Functor =
+    ValuesType, LHSType, RHSType>; using LTP1Functor =
     LowerTriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
-    LHSType, RHSType, NGBLType>; using UTP1Functor =
+    LHSType, RHSType>; using UTP1Functor =
     UpperTriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
-    LHSType, RHSType, NGBLType>; using LSingleBlockFunctor =
+    LHSType, RHSType>; using LSingleBlockFunctor =
     LowerTriLvlSchedTP1SingleBlockFunctor<RowMapType, EntriesType, ValuesType,
-    LHSType, RHSType, NGBLType>; using USingleBlockFunctor =
+    LHSType, RHSType>; using USingleBlockFunctor =
     UpperTriLvlSchedTP1SingleBlockFunctor<RowMapType, EntriesType, ValuesType,
-    LHSType, RHSType, NGBLType>;
+    LHSType, RHSType>;
   */
-  using SingleBlockFunctor =
+    using SingleBlockFunctor =
       TriLvlSchedTP1SingleBlockFunctor<RowMapType, EntriesType, ValuesType,
-                                       LHSType, RHSType, NGBLType>;
+                                       LHSType, RHSType>;
 
-  int team_size = thandle.get_team_size();
-  int vector_size =
+    int team_size = thandle.get_team_size();
+    int vector_size =
       thandle.get_vector_size() > 0 ? thandle.get_vector_size() : 1;
 
-  auto cutoff               = thandle.get_chain_threshold();
-  int team_size_singleblock = team_size;
+    auto cutoff               = thandle.get_chain_threshold();
+    int team_size_singleblock = team_size;
 
-  // Enumerate options
-  // ts -1,0 | cu 0 - select default ts == 1
-  // ts -1,0 | cu > 0 - select default ts; restriction: ts <= tsmax (auto)
-  // ts > 0 | cu 0 - set
-  // ts > 0 | cu > 0 - set
-  // Controls ts,cu > 0
-  // co > ts  - not all rows can be mapped to a thread - must call largercutoff
-  // impl co <= ts - okay, kernel must be careful not to access out-of-bounds;
-  // some threads idol
-  if (team_size_singleblock <= 0 && cutoff == 0) {
-    team_size_singleblock = 1;
-    // If cutoff == 0, no single-block calls will be made, team_size_singleblock
-    // is unimportant
-  }
+    // Enumerate options
+    // ts -1,0 | cu 0 - select default ts == 1
+    // ts -1,0 | cu > 0 - select default ts; restriction: ts <= tsmax (auto)
+    // ts > 0 | cu 0 - set
+    // ts > 0 | cu > 0 - set
+    // Controls ts,cu > 0
+    // co > ts  - not all rows can be mapped to a thread - must call largercutoff
+    // impl co <= ts - okay, kernel must be careful not to access out-of-bounds;
+    // some threads idol
+    if (team_size_singleblock <= 0 && cutoff == 0) {
+      team_size_singleblock = 1;
+      // If cutoff == 0, no single-block calls will be made, team_size_singleblock
+      // is unimportant
+    }
 
-  // This is only necessary for Lower,UpperTri functor versions; else,
-  // is_lowertri can be passed as arg to the generic Tri functor...
-  if (is_lowertri) {
-    for (size_type chainlink = 0; chainlink < num_chain_entries; ++chainlink) {
-      size_type schain = h_chain_ptr(chainlink);
-      size_type echain = h_chain_ptr(chainlink + 1);
+    // This is only necessary for Lower,UpperTri functor versions; else,
+    // is_lowertri can be passed as arg to the generic Tri functor...
+    if (is_lowertri) {
+      for (size_type chainlink = 0; chainlink < num_chain_entries; ++chainlink) {
+        size_type schain = h_chain_ptr(chainlink);
+        size_type echain = h_chain_ptr(chainlink + 1);
 
-      if (echain - schain == 1) {
-        // if team_size is -1 (unset), get recommended size from Kokkos
+        if (echain - schain == 1) {
+          // if team_size is -1 (unset), get recommended size from Kokkos
 #ifdef KOKKOSKERNELS_SPTRSV_TRILVLSCHED
-        TriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
-                                    LHSType, RHSType, NGBLType>
+          TriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
+                                      LHSType, RHSType>
             tstf(row_map, entries, values, lhs, rhs, nodes_grouped_by_level,
                  true, node_count);
 #else
-        LowerTriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
-                                         LHSType, RHSType, NGBLType>
+          LowerTriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
+                                           LHSType, RHSType>
             tstf(row_map, entries, values, lhs, rhs, nodes_grouped_by_level,
                  node_count);
 #endif
-        if (team_size == -1) {
-          team_size =
-              policy_type(space, 1, 1, vector_size)
-                  .team_size_recommended(tstf, Kokkos::ParallelForTag());
-        }
+          if (team_size == -1) {
+            team_size =
+              team_policy(space, 1, 1, vector_size)
+              .team_size_recommended(tstf, Kokkos::ParallelForTag());
+          }
 
-        size_type lvl_nodes = hnodes_per_level(schain);  // lvl == echain????
-        Kokkos::parallel_for(
+          size_type lvl_nodes = hnodes_per_level(schain);  // lvl == echain????
+          Kokkos::parallel_for(
             "parfor_l_team_chain1",
             Kokkos::Experimental::require(
-                policy_type(space, lvl_nodes, team_size, vector_size),
+                team_policy(space, lvl_nodes, team_size, vector_size),
                 Kokkos::Experimental::WorkItemProperty::HintLightWeight),
             tstf);
-        node_count += lvl_nodes;
+          node_count += lvl_nodes;
 
-      } else {
-        size_type lvl_nodes = 0;
+        } else {
+          size_type lvl_nodes = 0;
 
-        for (size_type i = schain; i < echain; ++i) {
-          lvl_nodes += hnodes_per_level(i);
-        }
+          for (size_type i = schain; i < echain; ++i) {
+            lvl_nodes += hnodes_per_level(i);
+          }
 
-        if (team_size_singleblock <= 0) {
-          team_size_singleblock =
-              policy_type(space, 1, 1, vector_size)
+          if (team_size_singleblock <= 0) {
+            team_size_singleblock =
+              team_policy(space, 1, 1, vector_size)
                   .team_size_recommended(
                       SingleBlockFunctor(row_map, entries, values, lhs, rhs,
                                          nodes_grouped_by_level,
                                          nodes_per_level, node_count, schain,
                                          echain, is_lowertri),
                       Kokkos::ParallelForTag());
-        }
+          }
 
-        if (cutoff <= team_size_singleblock) {
+          if (cutoff <= team_size_singleblock) {
 #ifdef KOKKOSKERNELS_SPTRSV_TRILVLSCHED
-          TriLvlSchedTP1SingleBlockFunctor<RowMapType, EntriesType, ValuesType,
-                                           LHSType, RHSType, NGBLType>
+            TriLvlSchedTP1SingleBlockFunctor<RowMapType, EntriesType, ValuesType,
+                                             LHSType, RHSType>
               tstf(row_map, entries, values, lhs, rhs, nodes_grouped_by_level,
                    nodes_per_level, node_count, schain, echain, true);
 #else
-          LowerTriLvlSchedTP1SingleBlockFunctor<
-              RowMapType, EntriesType, ValuesType, LHSType, RHSType, NGBLType>
+            LowerTriLvlSchedTP1SingleBlockFunctor<
+              RowMapType, EntriesType, ValuesType, LHSType, RHSType>
               tstf(row_map, entries, values, lhs, rhs, nodes_grouped_by_level,
                    nodes_per_level, node_count, schain, echain);
 #endif
-          Kokkos::parallel_for(
+            Kokkos::parallel_for(
               "parfor_l_team_chainmulti",
               Kokkos::Experimental::require(
-                  policy_type(space, 1, team_size_singleblock, vector_size),
+                  team_policy(space, 1, team_size_singleblock, vector_size),
                   Kokkos::Experimental::WorkItemProperty::HintLightWeight),
               tstf);
-        } else {
-          // team_size_singleblock < cutoff => kernel must allow for a
-          // block-stride internally
+          } else {
+            // team_size_singleblock < cutoff => kernel must allow for a
+            // block-stride internally
 #ifdef KOKKOSKERNELS_SPTRSV_TRILVLSCHED
-          TriLvlSchedTP1SingleBlockFunctor<RowMapType, EntriesType, ValuesType,
-                                           LHSType, RHSType, NGBLType>
+            TriLvlSchedTP1SingleBlockFunctor<RowMapType, EntriesType, ValuesType,
+                                             LHSType, RHSType>
               tstf(row_map, entries, values, lhs, rhs, nodes_grouped_by_level,
                    nodes_per_level, node_count, schain, echain, true, 0,
                    cutoff);
 #else
-          LowerTriLvlSchedTP1SingleBlockFunctor<
-              RowMapType, EntriesType, ValuesType, LHSType, RHSType, NGBLType>
+            LowerTriLvlSchedTP1SingleBlockFunctor<
+              RowMapType, EntriesType, ValuesType, LHSType, RHSType>
               tstf(row_map, entries, values, lhs, rhs, nodes_grouped_by_level,
                    nodes_per_level, node_count, schain, echain, cutoff);
 #endif
-          Kokkos::parallel_for(
+            Kokkos::parallel_for(
               "parfor_l_team_chainmulti_cutoff",
               Kokkos::Experimental::require(
                   large_cutoff_policy_type(1, team_size_singleblock,
                                            vector_size),
                   Kokkos::Experimental::WorkItemProperty::HintLightWeight),
               tstf);
+          }
+          node_count += lvl_nodes;
         }
-        node_count += lvl_nodes;
+        // TODO: space.fence()
+        Kokkos::fence();  // TODO - is this necessary? that is, can the
+                          // parallel_for launch before the s/echain values have
+                          // been updated?
       }
-      // TODO: space.fence()
-      Kokkos::fence();  // TODO - is this necessary? that is, can the
-                        // parallel_for launch before the s/echain values have
-                        // been updated?
-    }
 
-  } else {
-    for (size_type chainlink = 0; chainlink < num_chain_entries; ++chainlink) {
-      size_type schain = h_chain_ptr(chainlink);
-      size_type echain = h_chain_ptr(chainlink + 1);
+    } else {
+      for (size_type chainlink = 0; chainlink < num_chain_entries; ++chainlink) {
+        size_type schain = h_chain_ptr(chainlink);
+        size_type echain = h_chain_ptr(chainlink + 1);
 
-      if (echain - schain == 1) {
-        // if team_size is -1 (unset), get recommended size from Kokkos
+        if (echain - schain == 1) {
+          // if team_size is -1 (unset), get recommended size from Kokkos
 #ifdef KOKKOSKERNELS_SPTRSV_TRILVLSCHED
-        TriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
-                                    LHSType, RHSType, NGBLType>
+          TriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
+                                      LHSType, RHSType>
             tstf(row_map, entries, values, lhs, rhs, nodes_grouped_by_level,
                  is_lowertri, node_count);
 #else
-        UpperTriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
-                                         LHSType, RHSType, NGBLType>
+          UpperTriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
+                                           LHSType, RHSType>
             tstf(row_map, entries, values, lhs, rhs, nodes_grouped_by_level,
                  node_count);
 #endif
-        if (team_size == -1) {
-          team_size =
-              policy_type(space, 1, 1, vector_size)
-                  .team_size_recommended(tstf, Kokkos::ParallelForTag());
-        }
+          if (team_size == -1) {
+            team_size =
+              team_policy(space, 1, 1, vector_size)
+              .team_size_recommended(tstf, Kokkos::ParallelForTag());
+          }
 
-        // TODO To use cudagraph here, need to know how many non-unit chains
-        // there are, create a graph for each and launch accordingly
-        size_type lvl_nodes = hnodes_per_level(schain);  // lvl == echain????
-        Kokkos::parallel_for(
+          // TODO To use cudagraph here, need to know how many non-unit chains
+          // there are, create a graph for each and launch accordingly
+          size_type lvl_nodes = hnodes_per_level(schain);  // lvl == echain????
+          Kokkos::parallel_for(
             "parfor_u_team_chain1",
             Kokkos::Experimental::require(
-                policy_type(space, lvl_nodes, team_size, vector_size),
+                team_policy(space, lvl_nodes, team_size, vector_size),
                 Kokkos::Experimental::WorkItemProperty::HintLightWeight),
             tstf);
-        node_count += lvl_nodes;
+          node_count += lvl_nodes;
 
-      } else {
-        size_type lvl_nodes = 0;
+        } else {
+          size_type lvl_nodes = 0;
 
-        for (size_type i = schain; i < echain; ++i) {
-          lvl_nodes += hnodes_per_level(i);
-        }
+          for (size_type i = schain; i < echain; ++i) {
+            lvl_nodes += hnodes_per_level(i);
+          }
 
-        if (team_size_singleblock <= 0) {
-          // team_size_singleblock = policy_type(1, 1,
-          // 1).team_size_recommended(SingleBlockFunctor(row_map, entries,
-          // values, lhs, rhs, nodes_grouped_by_level, is_lowertri, node_count),
-          // Kokkos::ParallelForTag());
-          team_size_singleblock =
-              policy_type(space, 1, 1, vector_size)
+          if (team_size_singleblock <= 0) {
+            // team_size_singleblock = team_policy(1, 1,
+            // 1).team_size_recommended(SingleBlockFunctor(row_map, entries,
+            // values, lhs, rhs, nodes_grouped_by_level, is_lowertri, node_count),
+            // Kokkos::ParallelForTag());
+            team_size_singleblock =
+              team_policy(space, 1, 1, vector_size)
                   .team_size_recommended(
                       SingleBlockFunctor(row_map, entries, values, lhs, rhs,
                                          nodes_grouped_by_level,
                                          nodes_per_level, node_count, schain,
                                          echain, is_lowertri),
                       Kokkos::ParallelForTag());
-        }
+          }
 
-        if (cutoff <= team_size_singleblock) {
+          if (cutoff <= team_size_singleblock) {
 #ifdef KOKKOSKERNELS_SPTRSV_TRILVLSCHED
-          TriLvlSchedTP1SingleBlockFunctor<RowMapType, EntriesType, ValuesType,
-                                           LHSType, RHSType, NGBLType>
+            TriLvlSchedTP1SingleBlockFunctor<RowMapType, EntriesType, ValuesType,
+                                             LHSType, RHSType>
               tstf(row_map, entries, values, lhs, rhs, nodes_grouped_by_level,
                    nodes_per_level, node_count, schain, echain, is_lowertri);
 #else
-          UpperTriLvlSchedTP1SingleBlockFunctor<
-              RowMapType, EntriesType, ValuesType, LHSType, RHSType, NGBLType>
+            UpperTriLvlSchedTP1SingleBlockFunctor<
+              RowMapType, EntriesType, ValuesType, LHSType, RHSType>
               tstf(row_map, entries, values, lhs, rhs, nodes_grouped_by_level,
                    nodes_per_level, node_count, schain, echain);
 #endif
-          Kokkos::parallel_for(
+            Kokkos::parallel_for(
               "parfor_u_team_chainmulti",
               Kokkos::Experimental::require(
-                  policy_type(space, 1, team_size_singleblock, vector_size),
+                  team_policy(space, 1, team_size_singleblock, vector_size),
                   Kokkos::Experimental::WorkItemProperty::HintLightWeight),
               tstf);
-        } else {
-          // team_size_singleblock < cutoff => kernel must allow for a
-          // block-stride internally
+          } else {
+            // team_size_singleblock < cutoff => kernel must allow for a
+            // block-stride internally
 #ifdef KOKKOSKERNELS_SPTRSV_TRILVLSCHED
-          TriLvlSchedTP1SingleBlockFunctor<RowMapType, EntriesType, ValuesType,
-                                           LHSType, RHSType, NGBLType>
+            TriLvlSchedTP1SingleBlockFunctor<RowMapType, EntriesType, ValuesType,
+                                             LHSType, RHSType>
               tstf(row_map, entries, values, lhs, rhs, nodes_grouped_by_level,
                    nodes_per_level, node_count, schain, echain, is_lowertri, 0,
                    cutoff);
 #else
-          UpperTriLvlSchedTP1SingleBlockFunctor<
-              RowMapType, EntriesType, ValuesType, LHSType, RHSType, NGBLType>
+            UpperTriLvlSchedTP1SingleBlockFunctor<
+              RowMapType, EntriesType, ValuesType, LHSType, RHSType>
               tstf(row_map, entries, values, lhs, rhs, nodes_grouped_by_level,
                    nodes_per_level, node_count, schain, echain, cutoff);
 #endif
-          Kokkos::parallel_for(
+            Kokkos::parallel_for(
               "parfor_u_team_chainmulti_cutoff",
               Kokkos::Experimental::require(
                   large_cutoff_policy_type(1, team_size_singleblock,
                                            vector_size),
                   Kokkos::Experimental::WorkItemProperty::HintLightWeight),
               tstf);
+          }
+          node_count += lvl_nodes;
         }
-        node_count += lvl_nodes;
+        // TODO: space.fence()
+        Kokkos::fence();  // TODO - is this necessary? that is, can the
+                          // parallel_for launch before the s/echain values have
+                          // been updated?
       }
-      // TODO: space.fence()
-      Kokkos::fence();  // TODO - is this necessary? that is, can the
-                        // parallel_for launch before the s/echain values have
-                        // been updated?
     }
-  }
+  }  // end tri_solve_chain
 
-}  // end tri_solve_chain
-
-// --------------------------------
-// Stream interfaces
-// --------------------------------
-
-template <class ExecutionSpace, class RowMapType,
-          class EntriesType, class ValuesType, class RHSType, class LHSType>
-static void lower_tri_solve_streams(const std::vector<ExecutionSpace> &execspace_v,
-                             const std::vector<TriSolveHandle *> &thandle_v,
-                             const std::vector<RowMapType> &row_map_v,
-                             const std::vector<EntriesType> &entries_v,
-                             const std::vector<ValuesType> &values_v,
-                             const std::vector<RHSType> &rhs_v,
-                             std::vector<LHSType> &lhs_v) {
-  // NOTE: Only support SEQLVLSCHD_RP and SEQLVLSCHD_TP1 at this moment
-  using size_type = typename TriSolveHandle::size_type;
-  using NGBLType  = typename TriSolveHandle::nnz_lno_view_t;
-  using nodes_per_level_type =
+  // --------------------------------
+  // Stream interfaces
+  // --------------------------------
+  template <class RowMapType,
+            class EntriesType, class ValuesType, class RHSType, class LHSType>
+  static void lower_tri_solve_streams(const std::vector<execution_space> &execspace_v,
+                                      const std::vector<TriSolveHandle *> &thandle_v,
+                                      const std::vector<RowMapType> &row_map_v,
+                                      const std::vector<EntriesType> &entries_v,
+                                      const std::vector<ValuesType> &values_v,
+                                      const std::vector<RHSType> &rhs_v,
+                                      std::vector<LHSType> &lhs_v) {
+    // NOTE: Only support SEQLVLSCHD_RP and SEQLVLSCHD_TP1 at this moment
+    using nodes_per_level_type =
       typename TriSolveHandle::hostspace_nnz_lno_view_t;
-  using nodes_grouped_by_level_type = typename TriSolveHandle::nnz_lno_view_t;
+    using nodes_grouped_by_level_type = typename TriSolveHandle::nnz_lno_view_t;
 
-  // Create vectors for handles' data in streams
-  int nstreams = execspace_v.size();
-  std::vector<size_type> nlevels_v(nstreams);
-  std::vector<nodes_per_level_type> hnodes_per_level_v(nstreams);
-  std::vector<nodes_grouped_by_level_type> nodes_grouped_by_level_v(nstreams);
-  std::vector<size_type> node_count_v(nstreams);
+    // Create vectors for handles' data in streams
+    int nstreams = execspace_v.size();
+    std::vector<size_type> nlevels_v(nstreams);
+    std::vector<nodes_per_level_type> hnodes_per_level_v(nstreams);
+    std::vector<nodes_grouped_by_level_type> nodes_grouped_by_level_v(nstreams);
+    std::vector<size_type> node_count_v(nstreams);
 
-  // Retrieve data from handles and find max. number of levels among streams
-  size_type nlevels_max = 0;
-  for (int i = 0; i < nstreams; i++) {
-    nlevels_v[i]                = thandle_v[i]->get_num_levels();
-    hnodes_per_level_v[i]       = thandle_v[i]->get_host_nodes_per_level();
-    nodes_grouped_by_level_v[i] = thandle_v[i]->get_nodes_grouped_by_level();
-    node_count_v[i]             = 0;
-    if (nlevels_max < nlevels_v[i]) nlevels_max = nlevels_v[i];
-  }
-
-  // Main loop must be performed sequential
-  for (size_type lvl = 0; lvl < nlevels_max; lvl++) {
-    // 1. Launch work on all streams
+    // Retrieve data from handles and find max. number of levels among streams
+    size_type nlevels_max = 0;
     for (int i = 0; i < nstreams; i++) {
-      // Only if stream i-th still has this level
-      if (lvl < nlevels_v[i]) {
-        size_type lvl_nodes = hnodes_per_level_v[i](lvl);
-        if (lvl_nodes != 0) {
-          if (thandle_v[i]->get_algorithm() ==
-              KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_RP) {
-            Kokkos::parallel_for(
+      nlevels_v[i]                = thandle_v[i]->get_num_levels();
+      hnodes_per_level_v[i]       = thandle_v[i]->get_host_nodes_per_level();
+      nodes_grouped_by_level_v[i] = thandle_v[i]->get_nodes_grouped_by_level();
+      node_count_v[i]             = 0;
+      if (nlevels_max < nlevels_v[i]) nlevels_max = nlevels_v[i];
+    }
+
+    // Main loop must be performed sequential
+    for (size_type lvl = 0; lvl < nlevels_max; lvl++) {
+      // 1. Launch work on all streams
+      for (int i = 0; i < nstreams; i++) {
+        // Only if stream i-th still has this level
+        if (lvl < nlevels_v[i]) {
+          size_type lvl_nodes = hnodes_per_level_v[i](lvl);
+          if (lvl_nodes != 0) {
+            if (thandle_v[i]->get_algorithm() ==
+                KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_RP) {
+              Kokkos::parallel_for(
                 "parfor_fixed_lvl",
-                Kokkos::RangePolicy<ExecutionSpace>(
-                    execspace_v[i], node_count_v[i],
-                    node_count_v[i] + lvl_nodes),
+                range_policy(execspace_v[i], node_count_v[i], node_count_v[i] + lvl_nodes),
                 LowerTriLvlSchedRPSolverFunctor<RowMapType, EntriesType,
-                                                ValuesType, LHSType, RHSType,
-                                                NGBLType>(
+                                                ValuesType, LHSType, RHSType>(
                     row_map_v[i], entries_v[i], values_v[i], lhs_v[i], rhs_v[i],
                     nodes_grouped_by_level_v[i]));
-          } else if (thandle_v[i]->get_algorithm() ==
-                     KokkosSparse::Experimental::SPTRSVAlgorithm::
-                         SEQLVLSCHD_TP1) {
-            using policy_type = Kokkos::TeamPolicy<ExecutionSpace>;
-            int team_size     = thandle_v[i]->get_team_size();
+            } else if (thandle_v[i]->get_algorithm() ==
+                       KokkosSparse::Experimental::SPTRSVAlgorithm::
+                       SEQLVLSCHD_TP1) {
+              int team_size     = thandle_v[i]->get_team_size();
 #ifdef KOKKOSKERNELS_SPTRSV_TRILVLSCHED
-            TriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
-                                        LHSType, RHSType, NGBLType>
+              TriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
+                                          LHSType, RHSType>
                 tstf(row_map_v[i], entries_v[i], values_v[i], lhs_v[i],
                      rhs_v[i], nodes_grouped_by_level_v[i], true,
                      node_count_v[i]);
 #else
-            LowerTriLvlSchedTP1SolverFunctor<
-                RowMapType, EntriesType, ValuesType, LHSType, RHSType, NGBLType>
+              LowerTriLvlSchedTP1SolverFunctor<
+                RowMapType, EntriesType, ValuesType, LHSType, RHSType>
                 tstf(row_map_v[i], entries_v[i], values_v[i], lhs_v[i],
                      rhs_v[i], nodes_grouped_by_level_v[i], node_count_v[i]);
 #endif
-            if (team_size == -1)
-              Kokkos::parallel_for(
+              if (team_size == -1)
+                Kokkos::parallel_for(
                   "parfor_l_team",
-                  policy_type(execspace_v[i], lvl_nodes, Kokkos::AUTO), tstf);
-            else
-              Kokkos::parallel_for(
+                  team_policy(execspace_v[i], lvl_nodes, Kokkos::AUTO), tstf);
+              else
+                Kokkos::parallel_for(
                   "parfor_l_team",
-                  policy_type(execspace_v[i], lvl_nodes, team_size), tstf);
-          }
-          node_count_v[i] += lvl_nodes;
-        }  // end if (lvl_nodes != 0)
-      }    // end if (lvl < nlevels_v[i])
-    }      // end for streams
-  }        // end for lvl
-}  // end lower_tri_solve_streams
+                  team_policy(execspace_v[i], lvl_nodes, team_size), tstf);
+            }
+            node_count_v[i] += lvl_nodes;
+          }  // end if (lvl_nodes != 0)
+        }    // end if (lvl < nlevels_v[i])
+      }      // end for streams
+    }        // end for lvl
+  }  // end lower_tri_solve_streams
 
-template <class ExecutionSpace, class RowMapType,
-          class EntriesType, class ValuesType, class RHSType, class LHSType>
-static void upper_tri_solve_streams(const std::vector<ExecutionSpace> &execspace_v,
-                             const std::vector<TriSolveHandle *> &thandle_v,
-                             const std::vector<RowMapType> &row_map_v,
-                             const std::vector<EntriesType> &entries_v,
-                             const std::vector<ValuesType> &values_v,
-                             const std::vector<RHSType> &rhs_v,
-                             std::vector<LHSType> &lhs_v) {
-  // NOTE: Only support SEQLVLSCHD_RP and SEQLVLSCHD_TP1 at this moment
-  using size_type = typename TriSolveHandle::size_type;
-  using NGBLType  = typename TriSolveHandle::nnz_lno_view_t;
-  using nodes_per_level_type =
+  template <class RowMapType,
+            class EntriesType, class ValuesType, class RHSType, class LHSType>
+  static void upper_tri_solve_streams(const std::vector<execution_space> &execspace_v,
+                                      const std::vector<TriSolveHandle *> &thandle_v,
+                                      const std::vector<RowMapType> &row_map_v,
+                                      const std::vector<EntriesType> &entries_v,
+                                      const std::vector<ValuesType> &values_v,
+                                      const std::vector<RHSType> &rhs_v,
+                                      std::vector<LHSType> &lhs_v) {
+    // NOTE: Only support SEQLVLSCHD_RP and SEQLVLSCHD_TP1 at this moment
+    using nodes_per_level_type =
       typename TriSolveHandle::hostspace_nnz_lno_view_t;
-  using nodes_grouped_by_level_type = typename TriSolveHandle::nnz_lno_view_t;
+    using nodes_grouped_by_level_type = typename TriSolveHandle::nnz_lno_view_t;
 
-  // Create vectors for handles' data in streams
-  int nstreams = execspace_v.size();
-  std::vector<size_type> nlevels_v(nstreams);
-  std::vector<nodes_per_level_type> hnodes_per_level_v(nstreams);
-  std::vector<nodes_grouped_by_level_type> nodes_grouped_by_level_v(nstreams);
-  std::vector<size_type> node_count_v(nstreams);
+    // Create vectors for handles' data in streams
+    int nstreams = execspace_v.size();
+    std::vector<size_type> nlevels_v(nstreams);
+    std::vector<nodes_per_level_type> hnodes_per_level_v(nstreams);
+    std::vector<nodes_grouped_by_level_type> nodes_grouped_by_level_v(nstreams);
+    std::vector<size_type> node_count_v(nstreams);
 
-  // Retrieve data from handles and find max. number of levels among streams
-  size_type nlevels_max = 0;
-  for (int i = 0; i < nstreams; i++) {
-    nlevels_v[i]                = thandle_v[i]->get_num_levels();
-    hnodes_per_level_v[i]       = thandle_v[i]->get_host_nodes_per_level();
-    nodes_grouped_by_level_v[i] = thandle_v[i]->get_nodes_grouped_by_level();
-    node_count_v[i]             = 0;
-    if (nlevels_max < nlevels_v[i]) nlevels_max = nlevels_v[i];
-  }
-
-  // Main loop must be performed sequential
-  for (size_type lvl = 0; lvl < nlevels_max; lvl++) {
-    // 1. Launch work on all streams
+    // Retrieve data from handles and find max. number of levels among streams
+    size_type nlevels_max = 0;
     for (int i = 0; i < nstreams; i++) {
-      // Only if stream i-th still has this level
-      if (lvl < nlevels_v[i]) {
-        size_type lvl_nodes = hnodes_per_level_v[i](lvl);
-        if (lvl_nodes != 0) {
-          if (thandle_v[i]->get_algorithm() ==
-              KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_RP) {
-            Kokkos::parallel_for(
+      nlevels_v[i]                = thandle_v[i]->get_num_levels();
+      hnodes_per_level_v[i]       = thandle_v[i]->get_host_nodes_per_level();
+      nodes_grouped_by_level_v[i] = thandle_v[i]->get_nodes_grouped_by_level();
+      node_count_v[i]             = 0;
+      if (nlevels_max < nlevels_v[i]) nlevels_max = nlevels_v[i];
+    }
+
+    // Main loop must be performed sequential
+    for (size_type lvl = 0; lvl < nlevels_max; lvl++) {
+      // 1. Launch work on all streams
+      for (int i = 0; i < nstreams; i++) {
+        // Only if stream i-th still has this level
+        if (lvl < nlevels_v[i]) {
+          size_type lvl_nodes = hnodes_per_level_v[i](lvl);
+          if (lvl_nodes != 0) {
+            if (thandle_v[i]->get_algorithm() ==
+                KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_RP) {
+              Kokkos::parallel_for(
                 "parfor_fixed_lvl",
-                Kokkos::RangePolicy<ExecutionSpace>(
-                    execspace_v[i], node_count_v[i],
-                    node_count_v[i] + lvl_nodes),
+                range_policy(execspace_v[i], node_count_v[i], node_count_v[i] + lvl_nodes),
                 UpperTriLvlSchedRPSolverFunctor<RowMapType, EntriesType,
-                                                ValuesType, LHSType, RHSType,
-                                                NGBLType>(
+                                                ValuesType, LHSType, RHSType>(
                     row_map_v[i], entries_v[i], values_v[i], lhs_v[i], rhs_v[i],
                     nodes_grouped_by_level_v[i]));
-          } else if (thandle_v[i]->get_algorithm() ==
-                     KokkosSparse::Experimental::SPTRSVAlgorithm::
-                         SEQLVLSCHD_TP1) {
-            using policy_type = Kokkos::TeamPolicy<ExecutionSpace>;
-            int team_size     = thandle_v[i]->get_team_size();
+            } else if (thandle_v[i]->get_algorithm() ==
+                       KokkosSparse::Experimental::SPTRSVAlgorithm::
+                       SEQLVLSCHD_TP1) {
+              int team_size     = thandle_v[i]->get_team_size();
 #ifdef KOKKOSKERNELS_SPTRSV_TRILVLSCHED
-            TriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
-                                        LHSType, RHSType, NGBLType>
+              TriLvlSchedTP1SolverFunctor<RowMapType, EntriesType, ValuesType,
+                                          LHSType, RHSType>
                 tstf(row_map_v[i], entries_v[i], values_v[i], lhs_v[i],
                      rhs_v[i], nodes_grouped_by_level_v[i], false,
                      node_count_v[i]);
 #else
-            UpperTriLvlSchedTP1SolverFunctor<
-                RowMapType, EntriesType, ValuesType, LHSType, RHSType, NGBLType>
+              UpperTriLvlSchedTP1SolverFunctor<
+                RowMapType, EntriesType, ValuesType, LHSType, RHSType>
                 tstf(row_map_v[i], entries_v[i], values_v[i], lhs_v[i],
                      rhs_v[i], nodes_grouped_by_level_v[i], node_count_v[i]);
 #endif
-            if (team_size == -1)
-              Kokkos::parallel_for(
+              if (team_size == -1)
+                Kokkos::parallel_for(
                   "parfor_l_team",
-                  policy_type(execspace_v[i], lvl_nodes, Kokkos::AUTO), tstf);
-            else
-              Kokkos::parallel_for(
+                  team_policy(execspace_v[i], lvl_nodes, Kokkos::AUTO), tstf);
+              else
+                Kokkos::parallel_for(
                   "parfor_l_team",
-                  policy_type(execspace_v[i], lvl_nodes, team_size), tstf);
+                  team_policy(execspace_v[i], lvl_nodes, team_size), tstf);
           }
-          node_count_v[i] += lvl_nodes;
-        }  // end if (lvl_nodes != 0)
-      }    // end if (lvl < nlevels_v[i])
-    }      // end for streams
-  }        // end for lvl
-}  // end upper_tri_solve_streams
+            node_count_v[i] += lvl_nodes;
+          }  // end if (lvl_nodes != 0)
+        }    // end if (lvl < nlevels_v[i])
+      }      // end for streams
+    }        // end for lvl
+  }  // end upper_tri_solve_streams
 
 }; // struct SptrsvWrap
 

--- a/sparse/impl/KokkosSparse_sptrsv_solve_spec.hpp
+++ b/sparse/impl/KokkosSparse_sptrsv_solve_spec.hpp
@@ -120,7 +120,8 @@ struct SPTRSV_SOLVE<ExecutionSpace, KernelHandle, RowMapType, EntriesType,
   static void sptrsv_solve(ExecutionSpace &space, KernelHandle *handle,
                            const RowMapType row_map, const EntriesType entries,
                            const ValuesType values, BType b, XType x) {
-    using Sptrsv = Experimental::SptrsvWrap<typename KernelHandle::SPTRSVHandleType>;
+    using Sptrsv =
+        Experimental::SptrsvWrap<typename KernelHandle::SPTRSVHandleType>;
 
     // Call specific algorithm type
     auto sptrsv_handle = handle->get_sptrsv_handle();
@@ -129,19 +130,20 @@ struct SPTRSV_SOLVE<ExecutionSpace, KernelHandle, RowMapType, EntriesType,
                                       : "KokkosSparse_sptrsv[upper]");
     if (sptrsv_handle->is_lower_tri()) {
       if (sptrsv_handle->is_symbolic_complete() == false) {
-        Experimental::lower_tri_symbolic(space, *sptrsv_handle, row_map, entries);
+        Experimental::lower_tri_symbolic(space, *sptrsv_handle, row_map,
+                                         entries);
       }
       if (sptrsv_handle->get_algorithm() ==
           KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_TP1CHAIN) {
-        Sptrsv::tri_solve_chain(space, *sptrsv_handle, row_map, entries,
-                                values, b, x, true);
+        Sptrsv::tri_solve_chain(space, *sptrsv_handle, row_map, entries, values,
+                                b, x, true);
       } else {
 #ifdef KOKKOSKERNELS_SPTRSV_CUDAGRAPHSUPPORT
         using ExecSpace = typename RowMapType::memory_space::execution_space;
         if (std::is_same<ExecSpace, Kokkos::Cuda>::value)
           // TODO: set stream in thandle's sptrsvCudaGraph
-          Sptrsv::lower_tri_solve_cg(*sptrsv_handle, row_map, entries,
-                                     values, b, x);
+          Sptrsv::lower_tri_solve_cg(*sptrsv_handle, row_map, entries, values,
+                                     b, x);
         else
 #endif
           Sptrsv::lower_tri_solve(space, *sptrsv_handle, row_map, entries,
@@ -149,19 +151,20 @@ struct SPTRSV_SOLVE<ExecutionSpace, KernelHandle, RowMapType, EntriesType,
       }
     } else {
       if (sptrsv_handle->is_symbolic_complete() == false) {
-        Experimental::upper_tri_symbolic(space, *sptrsv_handle, row_map, entries);
+        Experimental::upper_tri_symbolic(space, *sptrsv_handle, row_map,
+                                         entries);
       }
       if (sptrsv_handle->get_algorithm() ==
           KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_TP1CHAIN) {
-        Sptrsv::tri_solve_chain(space, *sptrsv_handle, row_map, entries,
-                                values, b, x, false);
+        Sptrsv::tri_solve_chain(space, *sptrsv_handle, row_map, entries, values,
+                                b, x, false);
       } else {
 #ifdef KOKKOSKERNELS_SPTRSV_CUDAGRAPHSUPPORT
         using ExecSpace = typename RowMapType::memory_space::execution_space;
         if (std::is_same<ExecSpace, Kokkos::Cuda>::value)
           // TODO: set stream in thandle's sptrsvCudaGraph
-          Sptrsv::upper_tri_solve_cg(*sptrsv_handle, row_map, entries,
-                                     values, b, x);
+          Sptrsv::upper_tri_solve_cg(*sptrsv_handle, row_map, entries, values,
+                                     b, x);
         else
 #endif
           Sptrsv::upper_tri_solve(space, *sptrsv_handle, row_map, entries,
@@ -178,7 +181,8 @@ struct SPTRSV_SOLVE<ExecutionSpace, KernelHandle, RowMapType, EntriesType,
       const std::vector<EntriesType> &entries_v,
       const std::vector<ValuesType> &values_v, const std::vector<BType> &b_v,
       std::vector<XType> &x_v) {
-    using Sptrsv = Experimental::SptrsvWrap<typename KernelHandle::SPTRSVHandleType>;
+    using Sptrsv =
+        Experimental::SptrsvWrap<typename KernelHandle::SPTRSVHandleType>;
     // Call specific algorithm type
     // NOTE: Only support SEQLVLSCHD_RP and SEQLVLSCHD_TP1 at this moment
     //       Assume streams have the same either lower or upper matrix type
@@ -198,9 +202,8 @@ struct SPTRSV_SOLVE<ExecutionSpace, KernelHandle, RowMapType, EntriesType,
                                            entries_v[i]);
         }
       }
-      Sptrsv::lower_tri_solve_streams(execspace_v, sptrsv_handle_v,
-                                      row_map_v, entries_v, values_v, b_v,
-                                      x_v);
+      Sptrsv::lower_tri_solve_streams(execspace_v, sptrsv_handle_v, row_map_v,
+                                      entries_v, values_v, b_v, x_v);
     } else {
       for (int i = 0; i < static_cast<int>(execspace_v.size()); i++) {
         if (sptrsv_handle_v[i]->is_symbolic_complete() == false) {
@@ -209,9 +212,8 @@ struct SPTRSV_SOLVE<ExecutionSpace, KernelHandle, RowMapType, EntriesType,
                                            entries_v[i]);
         }
       }
-      Sptrsv::upper_tri_solve_streams(execspace_v, sptrsv_handle_v,
-                                      row_map_v, entries_v, values_v, b_v,
-                                      x_v);
+      Sptrsv::upper_tri_solve_streams(execspace_v, sptrsv_handle_v, row_map_v,
+                                      entries_v, values_v, b_v, x_v);
     }
     Kokkos::Profiling::popRegion();
   }

--- a/sparse/impl/KokkosSparse_sptrsv_solve_spec.hpp
+++ b/sparse/impl/KokkosSparse_sptrsv_solve_spec.hpp
@@ -120,6 +120,8 @@ struct SPTRSV_SOLVE<ExecutionSpace, KernelHandle, RowMapType, EntriesType,
   static void sptrsv_solve(ExecutionSpace &space, KernelHandle *handle,
                            const RowMapType row_map, const EntriesType entries,
                            const ValuesType values, BType b, XType x) {
+    using Sptrsv = Experimental::SptrsvWrap<typename KernelHandle::SPTRSVHandleType>;
+
     // Call specific algorithm type
     auto sptrsv_handle = handle->get_sptrsv_handle();
     Kokkos::Profiling::pushRegion(sptrsv_handle->is_lower_tri()
@@ -127,45 +129,43 @@ struct SPTRSV_SOLVE<ExecutionSpace, KernelHandle, RowMapType, EntriesType,
                                       : "KokkosSparse_sptrsv[upper]");
     if (sptrsv_handle->is_lower_tri()) {
       if (sptrsv_handle->is_symbolic_complete() == false) {
-        Experimental::lower_tri_symbolic(space, *sptrsv_handle, row_map,
-                                         entries);
+        Experimental::lower_tri_symbolic(space, *sptrsv_handle, row_map, entries);
       }
       if (sptrsv_handle->get_algorithm() ==
           KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_TP1CHAIN) {
-        Experimental::tri_solve_chain(space, *sptrsv_handle, row_map, entries,
-                                      values, b, x, true);
+        Sptrsv::tri_solve_chain(space, *sptrsv_handle, row_map, entries,
+                                values, b, x, true);
       } else {
 #ifdef KOKKOSKERNELS_SPTRSV_CUDAGRAPHSUPPORT
         using ExecSpace = typename RowMapType::memory_space::execution_space;
         if (std::is_same<ExecSpace, Kokkos::Cuda>::value)
           // TODO: set stream in thandle's sptrsvCudaGraph
-          Experimental::lower_tri_solve_cg(*sptrsv_handle, row_map, entries,
-                                           values, b, x);
+          Sptrsv::lower_tri_solve_cg(*sptrsv_handle, row_map, entries,
+                                     values, b, x);
         else
 #endif
-          Experimental::lower_tri_solve(space, *sptrsv_handle, row_map, entries,
-                                        values, b, x);
+          Sptrsv::lower_tri_solve(space, *sptrsv_handle, row_map, entries,
+                                  values, b, x);
       }
     } else {
       if (sptrsv_handle->is_symbolic_complete() == false) {
-        Experimental::upper_tri_symbolic(space, *sptrsv_handle, row_map,
-                                         entries);
+        Experimental::upper_tri_symbolic(space, *sptrsv_handle, row_map, entries);
       }
       if (sptrsv_handle->get_algorithm() ==
           KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_TP1CHAIN) {
-        Experimental::tri_solve_chain(space, *sptrsv_handle, row_map, entries,
-                                      values, b, x, false);
+        Sptrsv::tri_solve_chain(space, *sptrsv_handle, row_map, entries,
+                                values, b, x, false);
       } else {
 #ifdef KOKKOSKERNELS_SPTRSV_CUDAGRAPHSUPPORT
         using ExecSpace = typename RowMapType::memory_space::execution_space;
         if (std::is_same<ExecSpace, Kokkos::Cuda>::value)
           // TODO: set stream in thandle's sptrsvCudaGraph
-          Experimental::upper_tri_solve_cg(*sptrsv_handle, row_map, entries,
-                                           values, b, x);
+          Sptrsv::upper_tri_solve_cg(*sptrsv_handle, row_map, entries,
+                                     values, b, x);
         else
 #endif
-          Experimental::upper_tri_solve(space, *sptrsv_handle, row_map, entries,
-                                        values, b, x);
+          Sptrsv::upper_tri_solve(space, *sptrsv_handle, row_map, entries,
+                                  values, b, x);
       }
     }
     Kokkos::Profiling::popRegion();
@@ -178,6 +178,7 @@ struct SPTRSV_SOLVE<ExecutionSpace, KernelHandle, RowMapType, EntriesType,
       const std::vector<EntriesType> &entries_v,
       const std::vector<ValuesType> &values_v, const std::vector<BType> &b_v,
       std::vector<XType> &x_v) {
+    using Sptrsv = Experimental::SptrsvWrap<typename KernelHandle::SPTRSVHandleType>;
     // Call specific algorithm type
     // NOTE: Only support SEQLVLSCHD_RP and SEQLVLSCHD_TP1 at this moment
     //       Assume streams have the same either lower or upper matrix type
@@ -197,9 +198,9 @@ struct SPTRSV_SOLVE<ExecutionSpace, KernelHandle, RowMapType, EntriesType,
                                            entries_v[i]);
         }
       }
-      Experimental::lower_tri_solve_streams(execspace_v, sptrsv_handle_v,
-                                            row_map_v, entries_v, values_v, b_v,
-                                            x_v);
+      Sptrsv::lower_tri_solve_streams(execspace_v, sptrsv_handle_v,
+                                      row_map_v, entries_v, values_v, b_v,
+                                      x_v);
     } else {
       for (int i = 0; i < static_cast<int>(execspace_v.size()); i++) {
         if (sptrsv_handle_v[i]->is_symbolic_complete() == false) {
@@ -208,9 +209,9 @@ struct SPTRSV_SOLVE<ExecutionSpace, KernelHandle, RowMapType, EntriesType,
                                            entries_v[i]);
         }
       }
-      Experimental::upper_tri_solve_streams(execspace_v, sptrsv_handle_v,
-                                            row_map_v, entries_v, values_v, b_v,
-                                            x_v);
+      Sptrsv::upper_tri_solve_streams(execspace_v, sptrsv_handle_v,
+                                      row_map_v, entries_v, values_v, b_v,
+                                      x_v);
     }
     Kokkos::Profiling::popRegion();
   }

--- a/sparse/src/KokkosKernels_Handle.hpp
+++ b/sparse/src/KokkosKernels_Handle.hpp
@@ -837,10 +837,11 @@ class KokkosKernelsHandle {
   SPTRSVHandleType *get_sptrsv_handle() { return this->sptrsvHandle; }
 
   void create_sptrsv_handle(KokkosSparse::Experimental::SPTRSVAlgorithm algm,
-                            size_type nrows, bool lower_tri) {
+                            size_type nrows, bool lower_tri,
+                            size_type block_size = 0) {
     this->destroy_sptrsv_handle();
     this->is_owner_of_the_sptrsv_handle = true;
-    this->sptrsvHandle = new SPTRSVHandleType(algm, nrows, lower_tri);
+    this->sptrsvHandle = new SPTRSVHandleType(algm, nrows, lower_tri, block_size);
     //    this->sptrsvHandle->init_handle(nrows);
     this->sptrsvHandle->set_team_size(this->team_work_size);
     this->sptrsvHandle->set_vector_size(this->vector_size);

--- a/sparse/src/KokkosKernels_Handle.hpp
+++ b/sparse/src/KokkosKernels_Handle.hpp
@@ -841,7 +841,8 @@ class KokkosKernelsHandle {
                             size_type block_size = 0) {
     this->destroy_sptrsv_handle();
     this->is_owner_of_the_sptrsv_handle = true;
-    this->sptrsvHandle = new SPTRSVHandleType(algm, nrows, lower_tri, block_size);
+    this->sptrsvHandle =
+        new SPTRSVHandleType(algm, nrows, lower_tri, block_size);
     //    this->sptrsvHandle->init_handle(nrows);
     this->sptrsvHandle->set_team_size(this->team_work_size);
     this->sptrsvHandle->set_vector_size(this->vector_size);

--- a/sparse/src/KokkosSparse_sptrsv_handle.hpp
+++ b/sparse/src/KokkosSparse_sptrsv_handle.hpp
@@ -76,45 +76,59 @@ class SPTRSVHandle {
   using const_nnz_scalar_t = const scalar_t;
 
   // Row_map type (managed memory)
-  using nnz_row_view_temp_t = typename Kokkos::View<size_type *, HandleTempMemorySpace>;
-  using nnz_row_view_t      = typename Kokkos::View<size_type *, HandlePersistentMemorySpace>;
+  using nnz_row_view_temp_t =
+      typename Kokkos::View<size_type *, HandleTempMemorySpace>;
+  using nnz_row_view_t =
+      typename Kokkos::View<size_type *, HandlePersistentMemorySpace>;
   using host_nnz_row_view_t = typename nnz_row_view_t::HostMirror;
-  using int_row_view_t      = typename Kokkos::View<int *, HandlePersistentMemorySpace>;
-  using int64_row_view_t    = typename Kokkos::View<int64_t *, HandlePersistentMemorySpace>;
+  using int_row_view_t =
+      typename Kokkos::View<int *, HandlePersistentMemorySpace>;
+  using int64_row_view_t =
+      typename Kokkos::View<int64_t *, HandlePersistentMemorySpace>;
   // typedef typename row_lno_persistent_work_view_t::HostMirror
   // row_lno_persistent_work_host_view_t; //Host view type
   using nnz_row_unmanaged_view_t = typename Kokkos::View<
       const size_type *, HandlePersistentMemorySpace,
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;  // for rank1 subviews
+      Kokkos::MemoryTraits<Kokkos::Unmanaged |
+                           Kokkos::RandomAccess>>;  // for rank1 subviews
 
   // values type (managed memory)
-  using nnz_scalar_view_temp_t      = typename Kokkos::View<scalar_t *, HandleTempMemorySpace>;
-  using nnz_scalar_view_t           = typename Kokkos::View<scalar_t *, HandlePersistentMemorySpace>;
+  using nnz_scalar_view_temp_t =
+      typename Kokkos::View<scalar_t *, HandleTempMemorySpace>;
+  using nnz_scalar_view_t =
+      typename Kokkos::View<scalar_t *, HandlePersistentMemorySpace>;
   using host_nnz_scalar_view_t      = typename nnz_scalar_view_t::HostMirror;
   using nnz_scalar_unmanaged_view_t = typename Kokkos::View<
       const scalar_t *, HandlePersistentMemorySpace,
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;  // for rank1 subviews
+      Kokkos::MemoryTraits<Kokkos::Unmanaged |
+                           Kokkos::RandomAccess>>;  // for rank1 subviews
 
   // entries type (managed memory)
-  using nnz_lno_view_temp_t      = typename Kokkos::View<nnz_lno_t *, HandleTempMemorySpace>;
-  using nnz_lno_view_t           = typename Kokkos::View<nnz_lno_t *, HandlePersistentMemorySpace>;
-  using hostspace_nnz_lno_view_t = typename Kokkos::View<nnz_lno_t *, Kokkos::HostSpace>;
+  using nnz_lno_view_temp_t =
+      typename Kokkos::View<nnz_lno_t *, HandleTempMemorySpace>;
+  using nnz_lno_view_t =
+      typename Kokkos::View<nnz_lno_t *, HandlePersistentMemorySpace>;
+  using hostspace_nnz_lno_view_t =
+      typename Kokkos::View<nnz_lno_t *, Kokkos::HostSpace>;
   using host_nnz_lno_view_t      = typename nnz_lno_view_t::HostMirror;
   using nnz_lno_unmanaged_view_t = typename Kokkos::View<
       const nnz_lno_t *, HandlePersistentMemorySpace,
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;  // for rank1 subviews
+      Kokkos::MemoryTraits<Kokkos::Unmanaged |
+                           Kokkos::RandomAccess>>;  // for rank1 subviews
   // typedef typename nnz_lno_persistent_work_view_t::HostMirror
   // nnz_lno_persistent_work_host_view_t; //Host view type
 
-  using signed_integral_t = typename std::make_signed<typename nnz_row_view_t::non_const_value_type>::type;
-  using signed_nnz_lno_view_t = Kokkos::View<signed_integral_t *,
-      typename nnz_row_view_t::array_layout,
-      typename nnz_row_view_t::device_type,
-      typename nnz_row_view_t::memory_traits>;
+  using signed_integral_t = typename std::make_signed<
+      typename nnz_row_view_t::non_const_value_type>::type;
+  using signed_nnz_lno_view_t =
+      Kokkos::View<signed_integral_t *, typename nnz_row_view_t::array_layout,
+                   typename nnz_row_view_t::device_type,
+                   typename nnz_row_view_t::memory_traits>;
 
   using host_signed_nnz_lno_view_t = typename signed_nnz_lno_view_t::HostMirror;
 
-  using mtx_scalar_view_t = typename Kokkos::View<scalar_t **, HandlePersistentMemorySpace>;
+  using mtx_scalar_view_t =
+      typename Kokkos::View<scalar_t **, HandlePersistentMemorySpace>;
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 #if (CUDA_VERSION >= 11030)
@@ -285,7 +299,7 @@ class SPTRSVHandle {
   nnz_lno_view_t nodes_grouped_by_level;
   hostspace_nnz_lno_view_t hnodes_grouped_by_level;  // NEW
   size_type nlevel;
-  size_type block_size; // block_size > 0 implies BSR
+  size_type block_size;  // block_size > 0 implies BSR
 
   int team_size;
   int vector_size;
@@ -413,8 +427,8 @@ class SPTRSVHandle {
 
  public:
   SPTRSVHandle(SPTRSVAlgorithm choice, const size_type nrows_, bool lower_tri_,
-               const size_type block_size_ = 0,
-               bool symbolic_complete_ = false, bool numeric_complete_ = false)
+               const size_type block_size_ = 0, bool symbolic_complete_ = false,
+               bool numeric_complete_ = false)
       :
 #ifdef KOKKOSKERNELS_SPTRSV_CUDAGRAPHSUPPORT
         cudagraphCreated(false),

--- a/sparse/src/KokkosSparse_sptrsv_handle.hpp
+++ b/sparse/src/KokkosSparse_sptrsv_handle.hpp
@@ -56,76 +56,65 @@ template <class size_type_, class lno_t_, class scalar_t_, class ExecutionSpace,
           class TemporaryMemorySpace, class PersistentMemorySpace>
 class SPTRSVHandle {
  public:
-  typedef ExecutionSpace HandleExecSpace;
-  typedef TemporaryMemorySpace HandleTempMemorySpace;
-  typedef PersistentMemorySpace HandlePersistentMemorySpace;
+  using HandleExecSpace             = ExecutionSpace;
+  using HandleTempMemorySpace       = TemporaryMemorySpace;
+  using HandlePersistentMemorySpace = PersistentMemorySpace;
 
-  typedef ExecutionSpace execution_space;
-  typedef HandlePersistentMemorySpace memory_space;
+  using execution_space = ExecutionSpace;
+  using memory_space    = HandlePersistentMemorySpace;
 
-  typedef typename std::remove_const<size_type_>::type size_type;
-  typedef const size_type const_size_type;
+  using TeamPolicy  = Kokkos::TeamPolicy<execution_space>;
+  using RangePolicy = Kokkos::RangePolicy<execution_space>;
 
-  typedef typename std::remove_const<lno_t_>::type nnz_lno_t;
-  typedef const nnz_lno_t const_nnz_lno_t;
+  using size_type       = typename std::remove_const<size_type_>::type;
+  using const_size_type = const size_type;
 
-  typedef typename std::remove_const<scalar_t_>::type scalar_t;
-  typedef const scalar_t const_nnz_scalar_t;
+  using nnz_lno_t       = typename std::remove_const<lno_t_>::type;
+  using const_nnz_lno_t = const nnz_lno_t;
 
-  // row_map type (managed memory)
-  typedef typename Kokkos::View<size_type *, HandleTempMemorySpace>
-      nnz_row_view_temp_t;
-  typedef typename Kokkos::View<size_type *, HandlePersistentMemorySpace>
-      nnz_row_view_t;
-  typedef typename nnz_row_view_t::HostMirror host_nnz_row_view_t;
-  typedef typename Kokkos::View<int *, HandlePersistentMemorySpace>
-      int_row_view_t;
-  typedef typename Kokkos::View<int64_t *, HandlePersistentMemorySpace>
-      int64_row_view_t;
+  using scalar_t           = typename std::remove_const<scalar_t_>::type;
+  using const_nnz_scalar_t = const scalar_t;
+
+  // Row_map type (managed memory)
+  using nnz_row_view_temp_t = typename Kokkos::View<size_type *, HandleTempMemorySpace>;
+  using nnz_row_view_t      = typename Kokkos::View<size_type *, HandlePersistentMemorySpace>;
+  using host_nnz_row_view_t = typename nnz_row_view_t::HostMirror;
+  using int_row_view_t      = typename Kokkos::View<int *, HandlePersistentMemorySpace>;
+  using int64_row_view_t    = typename Kokkos::View<int64_t *, HandlePersistentMemorySpace>;
   // typedef typename row_lno_persistent_work_view_t::HostMirror
   // row_lno_persistent_work_host_view_t; //Host view type
-  typedef typename Kokkos::View<
+  using nnz_row_unmanaged_view_t = typename Kokkos::View<
       const size_type *, HandlePersistentMemorySpace,
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>
-      nnz_row_unmanaged_view_t;  // for rank1 subviews
+      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;  // for rank1 subviews
 
   // values type (managed memory)
-  typedef typename Kokkos::View<scalar_t *, HandleTempMemorySpace>
-      nnz_scalar_view_temp_t;
-  typedef typename Kokkos::View<scalar_t *, HandlePersistentMemorySpace>
-      nnz_scalar_view_t;
-  typedef typename nnz_scalar_view_t::HostMirror host_nnz_scalar_view_t;
-  typedef typename Kokkos::View<
+  using nnz_scalar_view_temp_t      = typename Kokkos::View<scalar_t *, HandleTempMemorySpace>;
+  using nnz_scalar_view_t           = typename Kokkos::View<scalar_t *, HandlePersistentMemorySpace>;
+  using host_nnz_scalar_view_t      = typename nnz_scalar_view_t::HostMirror;
+  using nnz_scalar_unmanaged_view_t = typename Kokkos::View<
       const scalar_t *, HandlePersistentMemorySpace,
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>
-      nnz_scalar_unmanaged_view_t;  // for rank1 subviews
+      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;  // for rank1 subviews
 
   // entries type (managed memory)
-  typedef typename Kokkos::View<nnz_lno_t *, HandleTempMemorySpace>
-      nnz_lno_view_temp_t;
-  typedef typename Kokkos::View<nnz_lno_t *, HandlePersistentMemorySpace>
-      nnz_lno_view_t;
-  typedef typename Kokkos::View<nnz_lno_t *, Kokkos::HostSpace>
-      hostspace_nnz_lno_view_t;
-  typedef typename nnz_lno_view_t::HostMirror host_nnz_lno_view_t;
-  typedef typename Kokkos::View<
+  using nnz_lno_view_temp_t      = typename Kokkos::View<nnz_lno_t *, HandleTempMemorySpace>;
+  using nnz_lno_view_t           = typename Kokkos::View<nnz_lno_t *, HandlePersistentMemorySpace>;
+  using hostspace_nnz_lno_view_t = typename Kokkos::View<nnz_lno_t *, Kokkos::HostSpace>;
+  using host_nnz_lno_view_t      = typename nnz_lno_view_t::HostMirror;
+  using nnz_lno_unmanaged_view_t = typename Kokkos::View<
       const nnz_lno_t *, HandlePersistentMemorySpace,
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>
-      nnz_lno_unmanaged_view_t;  // for rank1 subviews
+      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;  // for rank1 subviews
   // typedef typename nnz_lno_persistent_work_view_t::HostMirror
   // nnz_lno_persistent_work_host_view_t; //Host view type
 
-  typedef typename std::make_signed<
-      typename nnz_row_view_t::non_const_value_type>::type signed_integral_t;
-  typedef Kokkos::View<signed_integral_t *,
-                       typename nnz_row_view_t::array_layout,
-                       typename nnz_row_view_t::device_type,
-                       typename nnz_row_view_t::memory_traits>
-      signed_nnz_lno_view_t;
-  typedef typename signed_nnz_lno_view_t::HostMirror host_signed_nnz_lno_view_t;
+  using signed_integral_t = typename std::make_signed<typename nnz_row_view_t::non_const_value_type>::type;
+  using signed_nnz_lno_view_t = Kokkos::View<signed_integral_t *,
+      typename nnz_row_view_t::array_layout,
+      typename nnz_row_view_t::device_type,
+      typename nnz_row_view_t::memory_traits>;
 
-  typedef typename Kokkos::View<scalar_t **, HandlePersistentMemorySpace>
-      mtx_scalar_view_t;
+  using host_signed_nnz_lno_view_t = typename signed_nnz_lno_view_t::HostMirror;
+
+  using mtx_scalar_view_t = typename Kokkos::View<scalar_t **, HandlePersistentMemorySpace>;
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 #if (CUDA_VERSION >= 11030)
@@ -214,7 +203,7 @@ class SPTRSVHandle {
   };
 #endif
 
-  typedef cuSparseHandleType SPTRSVcuSparseHandleType;
+  using SPTRSVcuSparseHandleType = cuSparseHandleType;
 #endif
 
 #ifdef KOKKOSKERNELS_SPTRSV_CUDAGRAPHSUPPORT
@@ -228,7 +217,7 @@ class SPTRSVHandle {
     //~cudaGraphWrapperType() { }
   };
 
-  typedef cudaGraphWrapperType SPTRSVcudaGraphWrapperType;
+  using SPTRSVcudaGraphWrapperType = cudaGraphWrapperType;
 
   void create_SPTRSVcudaGraphWrapperType() {
     destroy_SPTRSVcudaGraphWrapperType();
@@ -296,6 +285,7 @@ class SPTRSVHandle {
   nnz_lno_view_t nodes_grouped_by_level;
   hostspace_nnz_lno_view_t hnodes_grouped_by_level;  // NEW
   size_type nlevel;
+  size_type block_size; // block_size > 0 implies BSR
 
   int team_size;
   int vector_size;
@@ -423,6 +413,7 @@ class SPTRSVHandle {
 
  public:
   SPTRSVHandle(SPTRSVAlgorithm choice, const size_type nrows_, bool lower_tri_,
+               const size_type block_size_ = 0,
                bool symbolic_complete_ = false, bool numeric_complete_ = false)
       :
 #ifdef KOKKOSKERNELS_SPTRSV_CUDAGRAPHSUPPORT
@@ -438,6 +429,7 @@ class SPTRSVHandle {
         nodes_grouped_by_level(),
         hnodes_grouped_by_level(),
         nlevel(0),
+        block_size(block_size_),
         team_size(-1),
         vector_size(-1),
         stored_diagonal(false),
@@ -1006,6 +998,14 @@ class SPTRSVHandle {
   size_type get_num_levels() const { return nlevel; }
 
   void set_num_levels(size_type nlevels_) { this->nlevel = nlevels_; }
+
+  KOKKOS_INLINE_FUNCTION
+  size_type get_block_size() const { return block_size; }
+
+  KOKKOS_INLINE_FUNCTION
+  void set_block_size(const size_type block_size_) {
+    this->block_size = block_size_;
+  }
 
   void set_symbolic_complete() { this->symbolic_complete = true; }
   void set_symbolic_incomplete() { this->symbolic_complete = false; }


### PR DESCRIPTION
Change list:
1) Change `typedef`s to `using`s in sptrsv handle
2) Add block_size setting to handle (unused for now).
3) sptrsv_solve_impl: Wrap entire thing in a struct templated on Handle. This is a pattern I've used successfully in par_ilut and spiluk. The outer struct uses Handle to build up a set of useful types so they don't have to be defined over and over.
4) Get rid of ReturnTeamPolicyType. What it was providing was simple enough to do with a couple lines of code
5) Remove unused ReturnRangePolicyType

Recommend viewing PR with whitespace changes hidden due to the indentation change in sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp