### PR TITLE
FindTPLROC*: updates to fix export of import targets

### DIFF
--- a/cmake/Modules/FindTPLROCBLAS.cmake
+++ b/cmake/Modules/FindTPLROCBLAS.cmake
@@ -1,13 +1,47 @@
-# MPL: 12/29/2022: CMake regular way to find a package
-FIND_PACKAGE(ROCBLAS)
-if(TARGET roc::rocblas)
-## MPL: 12/29/2022: Variable TPL_ROCBLAS_IMPORTED_NAME follows the requested convention
-## of KokkosKernel (method kokkoskernels_import_tpl of kokkoskernels_tpls.cmake)
-  SET(TPL_ROCBLAS_IMPORTED_NAME roc::rocblas)
-  SET(TPL_IMPORTED_NAME roc::rocblas)
-## MPL: 12/29/2022: A target comming from a TPL must follows the requested convention
-## of KokkosKernel (method kokkoskernels_link_tpl of kokkoskernels_tpls.cmake)
-  ADD_LIBRARY(KokkosKernels::ROCBLAS ALIAS roc::rocblas)
-ELSE()
-  MESSAGE(FATAL_ERROR "Package ROCBLAS requested but not found")
+IF(ROCBLAS_LIBRARIES AND ROCBLAS_LIBRARY_DIRS AND ROCBLAS_INCLUDE_DIRS)
+  kokkoskernels_find_imported(ROCBLAS INTERFACE
+    LIBRARIES ${ROCBLAS_LIBRARIES}
+    LIBRARY_PATHS ${ROCBLAS_LIBRARY_DIRS}
+    HEADER_PATHS ${ROCBLAS_INCLUDE_DIRS}
+  )
+ELSEIF(ROCBLAS_LIBRARIES AND ROCBLAS_LIBRARY_DIRS)
+  kokkoskernels_find_imported(ROCBLAS INTERFACE
+    LIBRARIES ${ROCBLAS_LIBRARIES}
+    LIBRARY_PATHS ${ROCBLAS_LIBRARY_DIRS}
+    HEADER rocblas.h
+  )
+ELSEIF(ROCBLAS_LIBRARIES)
+  kokkoskernels_find_imported(ROCBLAS INTERFACE
+    LIBRARIES ${ROCBLAS_LIBRARIES}
+    HEADER rocblas.h
+  )
+ELSEIF(ROCBLAS_LIBRARY_DIRS)
+  kokkoskernels_find_imported(ROCBLAS INTERFACE
+    LIBRARIES rocblas
+    LIBRARY_PATHS ${ROCBLAS_LIBRARY_DIRS}
+    HEADER rocblas.h
+  )
+ELSEIF(ROCBLAS_ROOT OR KokkosKernels_ROCBLAS_ROOT) # nothing specific provided, just ROOT
+  kokkoskernels_find_imported(ROCBLAS INTERFACE
+    LIBRARIES rocblas
+    HEADER rocblas.h
+  )
+ELSE() # backwards-compatible way
+  FIND_PACKAGE(ROCBLAS)
+  INCLUDE(FindPackageHandleStandardArgs)
+  IF (NOT ROCBLAS_FOUND)
+    #Important note here: this find Module is named TPLROCBLAS
+    #The eventual target is named ROCBLAS. To avoid naming conflicts
+    #the find module is called TPLROCBLAS. This call will cause
+    #the find_package call to fail in a "standard" CMake way
+    FIND_PACKAGE_HANDLE_STANDARD_ARGS(TPLROCBLAS REQUIRED_VARS ROCBLAS_FOUND)
+  ELSE()
+    #The libraries might be empty - OR they might explicitly be not found
+    IF("${ROCBLAS_LIBRARIES}" MATCHES "NOTFOUND")
+      FIND_PACKAGE_HANDLE_STANDARD_ARGS(TPLROCBLAS REQUIRED_VARS ROCBLAS_LIBRARIES)
+    ELSE()
+      KOKKOSKERNELS_CREATE_IMPORTED_TPL(ROCBLAS INTERFACE
+        LINK_LIBRARIES "${ROCBLAS_LIBRARIES}")
+    ENDIF()
+  ENDIF()
 ENDIF()

--- a/cmake/Modules/FindTPLROCSOLVER.cmake
+++ b/cmake/Modules/FindTPLROCSOLVER.cmake
@@ -1,9 +1,48 @@
-# LBV: 11/08/2023: This file follows the partern of FindTPLROCBLAS.cmake/FindTPLROCSPARSE.cmake
-FIND_PACKAGE(ROCSOLVER)
-if(TARGET roc::rocsolver)
-  SET(TPL_ROCSOLVER_IMPORTED_NAME roc::rocsolver)
-  SET(TPL_IMPORTED_NAME roc::rocsolver)
-  ADD_LIBRARY(KokkosKernels::ROCSOLVER ALIAS roc::rocsolver)
-ELSE()
-  MESSAGE(FATAL_ERROR "Package ROCSOLVER requested but not found")
+IF(ROCSOLVER_LIBRARIES AND ROCSOLVER_LIBRARY_DIRS AND ROCSOLVER_INCLUDE_DIRS)
+  kokkoskernels_find_imported(ROCSOLVER INTERFACE
+    LIBRARIES ${ROCSOLVER_LIBRARIES}
+    LIBRARY_PATHS ${ROCSOLVER_LIBRARY_DIRS}
+    HEADER_PATHS ${ROCSOLVER_INCLUDE_DIRS}
+  )
+ELSEIF(ROCSOLVER_LIBRARIES AND ROCSOLVER_LIBRARY_DIRS)
+  kokkoskernels_find_imported(ROCSOLVER INTERFACE
+    LIBRARIES ${ROCSOLVER_LIBRARIES}
+    LIBRARY_PATHS ${ROCSOLVER_LIBRARY_DIRS}
+    HEADER rocsolver.h
+  )
+ELSEIF(ROCSOLVER_LIBRARIES)
+  kokkoskernels_find_imported(ROCSOLVER INTERFACE
+    LIBRARIES ${ROCSOLVER_LIBRARIES}
+    HEADER rocsolver.h
+  )
+ELSEIF(ROCSOLVER_LIBRARY_DIRS)
+  kokkoskernels_find_imported(ROCSOLVER INTERFACE
+    LIBRARIES rocsolver
+    LIBRARY_PATHS ${ROCSOLVER_LIBRARY_DIRS}
+    HEADER rocsolver.h
+  )
+ELSEIF(ROCSOLVER_ROOT OR KokkosKernels_ROCSOLVER_ROOT) # nothing specific provided, just ROOT
+  kokkoskernels_find_imported(ROCSOLVER INTERFACE
+    LIBRARIES rocsolver
+    HEADER rocsolver.h
+  )
+ELSE() # backwards-compatible way
+  FIND_PACKAGE(ROCSOLVER)
+  INCLUDE(FindPackageHandleStandardArgs)
+  IF (NOT ROCSOLVER_FOUND)
+    #Important note here: this find Module is named TPLROCSOLVER
+    #The eventual target is named ROCSOLVER. To avoid naming conflicts
+    #the find module is called TPLROCSOLVER. This call will cause
+    #the find_package call to fail in a "standard" CMake way
+    FIND_PACKAGE_HANDLE_STANDARD_ARGS(TPLROCSOLVER REQUIRED_VARS ROCSOLVER_FOUND)
+  ELSE()
+    #The libraries might be empty - OR they might explicitly be not found
+    IF("${ROCSOLVER_LIBRARIES}" MATCHES "NOTFOUND")
+      FIND_PACKAGE_HANDLE_STANDARD_ARGS(TPLROCSOLVER REQUIRED_VARS ROCSOLVER_LIBRARIES)
+    ELSE()
+      KOKKOSKERNELS_CREATE_IMPORTED_TPL(ROCSOLVER INTERFACE
+        LINK_LIBRARIES "${ROCSOLVER_LIBRARIES}")
+    ENDIF()
+  ENDIF()
 ENDIF()
+


### PR DESCRIPTION
Changes for the Rocm tpls to match the handling as done with the Cuda tpls

Should resolve issue #2238