### PR TITLE
Fix warning about memcpy

### DIFF
--- a/common/src/KokkosKernels_BlockUtils.hpp
+++ b/common/src/KokkosKernels_BlockUtils.hpp
@@ -39,7 +39,7 @@ template <typename size_type, typename value_type>
 KOKKOS_INLINE_FUNCTION void kk_block_set(const size_type block_dim,
                                          value_type *dst,
                                          const value_type *val) {
-  memcpy(dst, val, block_dim * block_dim * sizeof(value_type));
+  memcpy((void *)dst, val, block_dim * block_dim * sizeof(value_type));
 }
 
 // Performs A += B on blocks


### PR DESCRIPTION
When building Stokhos BlockCrs, this util function gave a warning about memcpy modifying a non-trivially-copyable type. Silence it by casting to ``char*``