### PR TITLE
RCM fixes, improvements

### DIFF
--- a/graph/impl/KokkosGraph_BFS_impl.hpp
+++ b/graph/impl/KokkosGraph_BFS_impl.hpp
@@ -54,8 +54,10 @@ struct SerialRCM {
     lno_t periph        = 0;
     size_type periphDeg = entries.extent(0) + 1;
     for (lno_t i = 0; i < numVerts; i++) {
-      lno_t deg = rowmap(i + 1) - rowmap(i);
-      if (deg == 0 || (deg == 1 && entries(rowmap(i)) == i)) continue;
+      size_type deg = rowmap(i + 1) - rowmap(i);
+      if (deg == size_type(0) ||
+          (deg == size_type(1) && entries(rowmap(i)) == i))
+        continue;
       if (deg < periphDeg) {
         periph    = i;
         periphDeg = deg;


### PR DESCRIPTION
- Add a test that replicated an issue where ``findPseudoPeripheral()`` returned -1 as the starting vertex for RCM
- Add a test where the graph has 2 connected components
- Improve choice of starting vertex:
  - Instead of choosing a min-degree starting vertex once, always start (or restart) with the min-degree unlabeled vertex.
  - That way in graphs with multiple connected components, the starting vertex for components other than the 1st one is chosen with the same heuristic, instead of arbitrarily.
- Apply reversing as labels are computed, instead of at the end. This saves a loop over all the labels