### PR TITLE
Implement batched serial pttrf

### DIFF
--- a/batched/dense/impl/KokkosBatched_Pttrf_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrf_Serial_Impl.hpp
@@ -58,7 +58,8 @@ struct SerialPttrf<Algo::Pttrf::Unblocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(const DViewType &d,
                                            const EViewType &e) {
     // Quick return if possible
-    if (d.extent(0) == 0 || e.extent(0) == 0) return 0;
+    if (d.extent(0) == 0) return 0;
+    if (d.extent(0) == 1) return (d(0) < 0 ? 1 : 0);
 
     auto info = checkPttrfInput(d, e);
     if (info) return info;

--- a/batched/dense/impl/KokkosBatched_Pttrf_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrf_Serial_Impl.hpp
@@ -52,20 +52,6 @@ KOKKOS_INLINE_FUNCTION static int checkPttrfInput(
   return 0;
 }
 
-/// \brief Serial Batched Pttrf:
-/// Compute the Cholesky factorization of a real symmetric positive definite
-/// tridiagonal matrix A_l for all l = 0, ..., N
-///
-/// \tparam Input type for the a diagonal matrix, needs to be a 1D view
-/// \tparam EViewType: Input type for the a upper/lower diagonal matrix, needs
-/// to be a 1D view
-///
-/// \param d [in]: n diagonal elements of the diagonal matrix D
-/// \param e [in]: n-1 upper/lower diagonal elements of the diagonal matrix E
-///
-/// No nested parallel_for is used inside of the function.
-///
-
 template <>
 struct SerialPttrf<Algo::Pttrf::Unblocked> {
   template <typename DViewType, typename EViewType>

--- a/batched/dense/impl/KokkosBatched_Pttrf_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrf_Serial_Impl.hpp
@@ -57,6 +57,9 @@ struct SerialPttrf<Algo::Pttrf::Unblocked> {
   template <typename DViewType, typename EViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const DViewType &d,
                                            const EViewType &e) {
+    // Quick return if possible
+    if (d.extent(0) == 0 || e.extent(0) == 0) return 0;
+
     auto info = checkPttrfInput(d, e);
     if (info) return info;
 

--- a/batched/dense/impl/KokkosBatched_Pttrf_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrf_Serial_Impl.hpp
@@ -1,0 +1,86 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+#ifndef KOKKOSBATCHED_PTTRF_SERIAL_IMPL_HPP_
+#define KOKKOSBATCHED_PTTRF_SERIAL_IMPL_HPP_
+
+#include <KokkosBatched_Util.hpp>
+#include "KokkosBatched_Pttrf_Serial_Internal.hpp"
+
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+
+namespace KokkosBatched {
+
+template <typename DViewType, typename EViewType>
+KOKKOS_INLINE_FUNCTION static int checkPttrfInput(
+    [[maybe_unused]] const DViewType &d, [[maybe_unused]] const EViewType &e) {
+  static_assert(Kokkos::is_view<DViewType>::value,
+                "KokkosBatched::pttrf: DViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view<EViewType>::value,
+                "KokkosBatched::pttrf: EViewType is not a Kokkos::View.");
+
+  static_assert(DViewType::rank == 1,
+                "KokkosBatched::pttrf: DViewType must have rank 1.");
+  static_assert(EViewType::rank == 1,
+                "KokkosBatched::pttrf: EViewType must have rank 1.");
+
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+  const int nd = d.extent(0);
+  const int ne = e.extent(0);
+
+  if (ne + 1 != nd) {
+    Kokkos::printf(
+        "KokkosBatched::pttrf: Dimensions of d and e do not match: d: %d, e: "
+        "%d \n"
+        "e.extent(0) must be equal to d.extent(0) - 1\n",
+        nd, ne);
+    return 1;
+  }
+#endif
+  return 0;
+}
+
+/// \brief Serial Batched Pttrf:
+/// Compute the Cholesky factorization of a real symmetric positive definite
+/// tridiagonal matrix A_l for all l = 0, ..., N
+///   using the triangular solve algorithm Tbsv. Ab is an n by n unit, or
+///   non-unit, upper or lower triangular band matrix, with ( k + 1 )
+///   diagonals.
+///
+/// \tparam Input type for the a diagonal matrix, needs to be a 1D view
+/// \tparam EViewType: Input type for the a sub/super diagonal matrix, needs to
+/// be a 1D view
+///
+/// \param d [in]: n diagonal elements of the diagonal matrix D
+/// \param e [in]: n-1 sub/super diagonal elements of the diagonal matrix E
+///
+/// No nested parallel_for is used inside of the function.
+///
+
+template <>
+struct SerialPttrf<Algo::Pttrf::Unblocked> {
+  template <typename DViewType, typename EViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const DViewType &d,
+                                           const EViewType &e) {
+    auto info = checkPttrfInput(d, e);
+    if (info) return info;
+
+    return SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
+        d.extent(0), d.data(), d.stride(0), e.data(), e.stride(0));
+  }
+};
+}  // namespace KokkosBatched
+
+#endif  // KOKKOSBATCHED_PTTRF_SERIAL_IMPL_HPP_

--- a/batched/dense/impl/KokkosBatched_Pttrf_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrf_Serial_Impl.hpp
@@ -55,16 +55,13 @@ KOKKOS_INLINE_FUNCTION static int checkPttrfInput(
 /// \brief Serial Batched Pttrf:
 /// Compute the Cholesky factorization of a real symmetric positive definite
 /// tridiagonal matrix A_l for all l = 0, ..., N
-///   using the triangular solve algorithm Tbsv. Ab is an n by n unit, or
-///   non-unit, upper or lower triangular band matrix, with ( k + 1 )
-///   diagonals.
 ///
 /// \tparam Input type for the a diagonal matrix, needs to be a 1D view
-/// \tparam EViewType: Input type for the a sub/super diagonal matrix, needs to
-/// be a 1D view
+/// \tparam EViewType: Input type for the a upper/lower diagonal matrix, needs
+/// to be a 1D view
 ///
 /// \param d [in]: n diagonal elements of the diagonal matrix D
-/// \param e [in]: n-1 sub/super diagonal elements of the diagonal matrix E
+/// \param e [in]: n-1 upper/lower diagonal elements of the diagonal matrix E
 ///
 /// No nested parallel_for is used inside of the function.
 ///

--- a/batched/dense/impl/KokkosBatched_Pttrf_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrf_Serial_Internal.hpp
@@ -1,0 +1,178 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+#ifndef KOKKOSBATCHED_PTTRF_SERIAL_INTERNAL_HPP_
+#define KOKKOSBATCHED_PTTRF_SERIAL_INTERNAL_HPP_
+
+#include <KokkosBatched_Util.hpp>
+
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+
+namespace KokkosBatched {
+
+template <typename AlgoType>
+struct SerialPttrfInternal {
+  template <typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const int n,
+                                           ValueType *KOKKOS_RESTRICT d,
+                                           const int ds0,
+                                           ValueType *KOKKOS_RESTRICT e,
+                                           const int es0);
+
+  template <typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(
+      const int n, ValueType *KOKKOS_RESTRICT d, const int ds0,
+      Kokkos::complex<ValueType> *KOKKOS_RESTRICT e, const int es0);
+};
+
+///
+/// Real matrix
+///
+template <>
+template <typename ValueType>
+KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
+    const int n, ValueType *KOKKOS_RESTRICT d, const int ds0,
+    ValueType *KOKKOS_RESTRICT e, const int es0) {
+  int info = 0;
+
+  auto update = [&](const int i) {
+    auto ei_tmp = e[i * es0];
+    e[i * es0]  = ei_tmp / d[i * ds0];
+    d[(i + 1) * ds0] -= e[i * es0] * ei_tmp;
+  };
+
+  // Compute the L*D*L' (or U'*D*U) factorization of A.
+  const int i4 = (n - 1) % 4;
+  for (int i = 0; i < i4; i++) {
+    if (d[i] <= 0.0) {
+      info = i + 1;
+      return info;
+    }
+
+    update(i);
+  }  // for (int i = 0; i < i4; i++)
+
+  for (int i = i4; i < n - 4; i += 4) {
+    if (d[i] <= 0.0) {
+      info = i + 1;
+      return info;
+    }
+
+    update(i);
+
+    if (d[i + 1] <= 0.0) {
+      info = i + 2;
+      return info;
+    }
+
+    update(i + 1);
+
+    if (d[i + 2] <= 0.0) {
+      info = i + 3;
+      return info;
+    }
+
+    update(i + 2);
+
+    if (d[i + 3] <= 0.0) {
+      info = i + 4;
+      return info;
+    }
+
+    update(i + 3);
+
+  }  // for (int i = i4; i < n-4; 4)
+
+  if (d[n - 1] <= 0.0) {
+    info = n;
+    return info;
+  }
+
+  return 0;
+}
+
+///
+/// Complex matrix
+///
+
+template <>
+template <typename ValueType>
+KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
+    const int n, ValueType *KOKKOS_RESTRICT d, const int ds0,
+    Kokkos::complex<ValueType> *KOKKOS_RESTRICT e, const int es0) {
+  int info = 0;
+
+  auto update = [&](const int i) {
+    auto eir_tmp     = e[i * es0].real();
+    auto eii_tmp     = e[i * es0].imag();
+    auto f_tmp       = eir_tmp / d[i * ds0];
+    auto g_tmp       = eii_tmp / d[i * ds0];
+    e[i * es0]       = Kokkos::complex<ValueType>(f_tmp, g_tmp);
+    d[(i + 1) * ds0] = d[(i + 1) * ds0] - f_tmp * eir_tmp - g_tmp * eii_tmp;
+  };
+
+  // Compute the L*D*L' (or U'*D*U) factorization of A.
+  const int i4 = (n - 1) % 4;
+  for (int i = 0; i < i4; i++) {
+    if (d[i] <= 0.0) {
+      info = i + 1;
+      return info;
+    }
+
+    update(i);
+  }  // for (int i = 0; i < i4; i++)
+
+  for (int i = i4; i < n - 4; i += 4) {
+    if (d[i] <= 0.0) {
+      info = i + 1;
+      return info;
+    }
+
+    update(i);
+
+    if (d[i + 1] <= 0.0) {
+      info = i + 2;
+      return info;
+    }
+
+    update(i + 1);
+
+    if (d[i + 2] <= 0.0) {
+      info = i + 3;
+      return info;
+    }
+
+    update(i + 2);
+
+    if (d[i + 3] <= 0.0) {
+      info = i + 4;
+      return info;
+    }
+
+    update(i + 3);
+
+  }  // for (int i = i4; i < n-4; 4)
+
+  if (d[n - 1] <= 0.0) {
+    info = n;
+    return info;
+  }
+
+  return 0;
+}
+
+}  // namespace KokkosBatched
+
+#endif  // KOKKOSBATCHED_PTTRF_SERIAL_INTERNAL_HPP_

--- a/batched/dense/impl/KokkosBatched_Pttrf_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrf_Serial_Internal.hpp
@@ -40,6 +40,7 @@ struct SerialPttrfInternal {
 ///
 /// Real matrix
 ///
+
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
@@ -53,52 +54,68 @@ KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
     d[(i + 1) * ds0] -= e[i * es0] * ei_tmp;
   };
 
+  auto check_positive_definitiveness = [&](const int i) {
+    return (d[i] <= 0.0) ? (i + 1) : 0;
+  };
+
   // Compute the L*D*L' (or U'*D*U) factorization of A.
   const int i4 = (n - 1) % 4;
   for (int i = 0; i < i4; i++) {
-    if (d[i] <= 0.0) {
-      info = i + 1;
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+    info = check_positive_definitiveness(i);
+    if (info) {
       return info;
     }
+#endif
 
     update(i);
   }  // for (int i = 0; i < i4; i++)
 
   for (int i = i4; i < n - 4; i += 4) {
-    if (d[i] <= 0.0) {
-      info = i + 1;
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+    info = check_positive_definitiveness(i);
+    if (info) {
       return info;
     }
+#endif
 
     update(i);
 
-    if (d[i + 1] <= 0.0) {
-      info = i + 2;
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+    info = check_positive_definitiveness(i + 1);
+    if (info) {
       return info;
     }
+#endif
 
     update(i + 1);
 
-    if (d[i + 2] <= 0.0) {
-      info = i + 3;
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+    info = check_positive_definitiveness(i + 2);
+    if (info) {
       return info;
     }
+#endif
 
     update(i + 2);
 
-    if (d[i + 3] <= 0.0) {
-      info = i + 4;
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+    info = check_positive_definitiveness(i + 3);
+    if (info) {
       return info;
     }
+#endif
 
     update(i + 3);
 
   }  // for (int i = i4; i < n-4; 4)
 
-  if (d[n - 1] <= 0.0) {
-    info = n;
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+  info = check_positive_definitiveness(n - 1);
+  if (info) {
     return info;
   }
+#endif
 
   return 0;
 }
@@ -123,52 +140,68 @@ KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
     d[(i + 1) * ds0] = d[(i + 1) * ds0] - f_tmp * eir_tmp - g_tmp * eii_tmp;
   };
 
+  auto check_positive_definitiveness = [&](const int i) {
+    return (d[i] <= 0.0) ? (i + 1) : 0;
+  };
+
   // Compute the L*D*L' (or U'*D*U) factorization of A.
   const int i4 = (n - 1) % 4;
   for (int i = 0; i < i4; i++) {
-    if (d[i] <= 0.0) {
-      info = i + 1;
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+    info = check_positive_definitiveness(i);
+    if (info) {
       return info;
     }
+#endif
 
     update(i);
   }  // for (int i = 0; i < i4; i++)
 
   for (int i = i4; i < n - 4; i += 4) {
-    if (d[i] <= 0.0) {
-      info = i + 1;
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+    info = check_positive_definitiveness(i);
+    if (info) {
       return info;
     }
+#endif
 
     update(i);
 
-    if (d[i + 1] <= 0.0) {
-      info = i + 2;
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+    info = check_positive_definitiveness(i + 1);
+    if (info) {
       return info;
     }
+#endif
 
     update(i + 1);
 
-    if (d[i + 2] <= 0.0) {
-      info = i + 3;
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+    info = check_positive_definitiveness(i + 2);
+    if (info) {
       return info;
     }
+#endif
 
     update(i + 2);
 
-    if (d[i + 3] <= 0.0) {
-      info = i + 4;
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+    info = check_positive_definitiveness(i + 3);
+    if (info) {
       return info;
     }
+#endif
 
     update(i + 3);
 
   }  // for (int i = i4; i < n-4; 4)
 
-  if (d[n - 1] <= 0.0) {
-    info = n;
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+  info = check_positive_definitiveness(n - 1);
+  if (info) {
     return info;
   }
+#endif
 
   return 0;
 }

--- a/batched/dense/src/KokkosBatched_Pttrf.hpp
+++ b/batched/dense/src/KokkosBatched_Pttrf.hpp
@@ -23,20 +23,17 @@
 namespace KokkosBatched {
 
 /// \brief Serial Batched Pttrf:
-///
-/// Solve a tridiagonal system of the form Ab_l x_l = b_l for all l = 0, ..., N
-///   using the factorization A = U**H *D*U or A = L*D*L**H computed by pttrf.
-///   D is a diagonal matrix specified in the vector D, U (or L) is a unit
-///   bidiagonal matrix whose superdiagonal (subdiagonal) is specified in the
-///   vector E, and X and B are stored in the vector B.
+/// Compute the Cholesky factorization L*D*L**T (or L*D*L**H) of a real
+/// symmetric (or complex Hermitian) positive definite tridiagonal matrix A_l
+/// for all l = 0, ..., N
 ///
 /// \tparam DViewType: Input type for the a diagonal matrix, needs to be a 1D
-/// view \tparam EViewType: Input type for the a superdiagonal matrix, needs to
-/// be a 1D view \tparam BViewType: Input type for the right-hand side and the
-/// solution, needs to be a 1D view
+/// view
+/// \tparam EViewType: Input type for the a upper/lower diagonal matrix,
+/// needs to be a 1D view
 ///
-/// \param d [in]: n diagonal elements of the diagonal matrix D
-/// \param e [in]: n diagonal elements of the diagonal matrix E
+/// \param d [inout]: n diagonal elements of the diagonal matrix D
+/// \param e [inout]: n-1 upper/lower diagonal elements of the diagonal matrix E
 ///
 /// No nested parallel_for is used inside of the function.
 ///
@@ -52,4 +49,4 @@ struct SerialPttrf {
 
 #include "KokkosBatched_Pttrf_Serial_Impl.hpp"
 
-#endif  // KOKKOSBATCHED_TBSV_HPP_
+#endif  // KOKKOSBATCHED_PTTRF_HPP_

--- a/batched/dense/src/KokkosBatched_Pttrf.hpp
+++ b/batched/dense/src/KokkosBatched_Pttrf.hpp
@@ -1,0 +1,55 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+#ifndef KOKKOSBATCHED_PTTRF_HPP_
+#define KOKKOSBATCHED_PTTRF_HPP_
+
+#include <KokkosBatched_Util.hpp>
+
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+
+namespace KokkosBatched {
+
+/// \brief Serial Batched Pttrf:
+///
+/// Solve a tridiagonal system of the form Ab_l x_l = b_l for all l = 0, ..., N
+///   using the factorization A = U**H *D*U or A = L*D*L**H computed by pttrf.
+///   D is a diagonal matrix specified in the vector D, U (or L) is a unit
+///   bidiagonal matrix whose superdiagonal (subdiagonal) is specified in the
+///   vector E, and X and B are stored in the vector B.
+///
+/// \tparam DViewType: Input type for the a diagonal matrix, needs to be a 1D
+/// view \tparam EViewType: Input type for the a superdiagonal matrix, needs to
+/// be a 1D view \tparam BViewType: Input type for the right-hand side and the
+/// solution, needs to be a 1D view
+///
+/// \param d [in]: n diagonal elements of the diagonal matrix D
+/// \param e [in]: n diagonal elements of the diagonal matrix E
+///
+/// No nested parallel_for is used inside of the function.
+///
+
+template <typename ArgAlgo>
+struct SerialPttrf {
+  template <typename DViewType, typename EViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const DViewType &d,
+                                           const EViewType &e);
+};
+
+}  // namespace KokkosBatched
+
+#include "KokkosBatched_Pttrf_Serial_Impl.hpp"
+
+#endif  // KOKKOSBATCHED_TBSV_HPP_

--- a/batched/dense/unit_test/Test_Batched_Dense.hpp
+++ b/batched/dense/unit_test/Test_Batched_Dense.hpp
@@ -49,6 +49,9 @@
 #include "Test_Batched_SerialTrtri_Real.hpp"
 #include "Test_Batched_SerialTrtri_Complex.hpp"
 #include "Test_Batched_SerialSVD.hpp"
+#include "Test_Batched_SerialPttrf.hpp"
+#include "Test_Batched_SerialPttrf_Real.hpp"
+#include "Test_Batched_SerialPttrf_Complex.hpp"
 
 // Team Kernels
 #include "Test_Batched_TeamAxpy.hpp"

--- a/batched/dense/unit_test/Test_Batched_DenseUtils.hpp
+++ b/batched/dense/unit_test/Test_Batched_DenseUtils.hpp
@@ -114,8 +114,8 @@ void create_banded_triangular_matrix(InViewType& in, OutViewType& out,
 
 template <typename InViewType, typename OutViewType>
 void create_diagonal_matrix(InViewType& in, OutViewType& out, int k = 0) {
-  auto h_in        = Kokkos::create_mirror_view(in);
-  auto h_out       = Kokkos::create_mirror_view(out);
+  auto h_in   = Kokkos::create_mirror_view(in);
+  auto h_out  = Kokkos::create_mirror_view(out);
   const int N = in.extent(0), BlkSize = in.extent(1);
 
   assert(out.extent(0) == in.extent(0));

--- a/batched/dense/unit_test/Test_Batched_DenseUtils.hpp
+++ b/batched/dense/unit_test/Test_Batched_DenseUtils.hpp
@@ -112,6 +112,20 @@ void create_banded_triangular_matrix(InViewType& in, OutViewType& out,
   Kokkos::deep_copy(out, h_out);
 }
 
+/// \brief Create a diagonal matrix from an input vector:
+///
+/// Copies the input vector into the diagonal of the output matrix specified
+/// by the parameter k. k > 0 means that the matrix is upper-diagnoal and
+/// k < 0 means the lower-diagnoal. k = 0 means the diagonal.
+///
+/// \tparam InViewType: Input type for the vector, needs to be a 2D view
+/// \tparam OutViewType: Output type for the matrix, needs to be a 3D view
+///
+/// \param in [in]: Input batched vector, a rank 2 view
+/// \param out [out]: Output batched matrix, where the diagnoal compnent
+/// specified by k is filled with the input vector, a rank 3 view \param k [in]:
+/// The diagonal offset to be filled (default is 0).
+///
 template <typename InViewType, typename OutViewType>
 void create_diagonal_matrix(InViewType& in, OutViewType& out, int k = 0) {
   auto h_in   = Kokkos::create_mirror_view(in);

--- a/batched/dense/unit_test/Test_Batched_DenseUtils.hpp
+++ b/batched/dense/unit_test/Test_Batched_DenseUtils.hpp
@@ -121,7 +121,7 @@ void create_banded_triangular_matrix(InViewType& in, OutViewType& out,
 /// \tparam OutViewType: Output type for the matrix, needs to be a 3D view
 ///
 /// \param in [in]: Input batched vector, a rank 2 view
-/// \param out [inout]: Output batched matrix, where the diagonal compnent
+/// \param out [out]: Output batched matrix, where the diagonal compnent
 /// specified by k is filled with the input vector, a rank 3 view
 /// \param k [in]: The diagonal offset to be filled (default is 0).
 ///
@@ -136,6 +136,10 @@ void create_diagonal_matrix(InViewType& in, OutViewType& out, int k = 0) {
 
   int i1_start = k >= 0 ? 0 : -k;
   int i2_start = k >= 0 ? k : 0;
+
+  // Zero clear the output matrix
+  using ScalarType = typename OutViewType::non_const_value_type;
+  Kokkos::deep_copy(h_out, ScalarType(0.0));
 
   Kokkos::deep_copy(h_in, in);
   for (int i0 = 0; i0 < N; i0++) {

--- a/batched/dense/unit_test/Test_Batched_DenseUtils.hpp
+++ b/batched/dense/unit_test/Test_Batched_DenseUtils.hpp
@@ -135,27 +135,6 @@ void create_diagonal_matrix(InViewType& in, OutViewType& out, int k = 0) {
   Kokkos::deep_copy(out, h_out);
 }
 
-template <typename AViewType, typename BViewType, typename CViewType>
-void add_matrices(AViewType& a, BViewType& b, CViewType& c) {
-  auto h_a = Kokkos::create_mirror_view(a);
-  auto h_b = Kokkos::create_mirror_view(b);
-  auto h_c = Kokkos::create_mirror_view(c);
-
-  Kokkos::deep_copy(h_a, a);
-  Kokkos::deep_copy(h_b, b);
-
-  const int N = a.extent(0), BlkSize = a.extent(1);
-  for (int i0 = 0; i0 < N; i0++) {
-    for (int i1 = 0; i1 < BlkSize; i1++) {
-      for (int i2 = 0; i2 < BlkSize; i2++) {
-        h_c(i0, i1, i2) = h_a(i0, i1, i2) + h_b(i0, i1, i2);
-      }
-    }
-  }
-
-  Kokkos::deep_copy(c, h_c);
-}
-
 }  // namespace KokkosBatched
 
 #endif  // TEST_BATCHED_DENSE_HELPER_HPP

--- a/batched/dense/unit_test/Test_Batched_DenseUtils.hpp
+++ b/batched/dense/unit_test/Test_Batched_DenseUtils.hpp
@@ -113,18 +113,17 @@ void create_banded_triangular_matrix(InViewType& in, OutViewType& out,
 }
 
 /// \brief Create a diagonal matrix from an input vector:
-///
 /// Copies the input vector into the diagonal of the output matrix specified
-/// by the parameter k. k > 0 means that the matrix is upper-diagnoal and
-/// k < 0 means the lower-diagnoal. k = 0 means the diagonal.
+/// by the parameter k. k > 0 means that the matrix is upper-diagonal and
+/// k < 0 means the lower-diagonal. k = 0 means the diagonal.
 ///
 /// \tparam InViewType: Input type for the vector, needs to be a 2D view
 /// \tparam OutViewType: Output type for the matrix, needs to be a 3D view
 ///
 /// \param in [in]: Input batched vector, a rank 2 view
-/// \param out [out]: Output batched matrix, where the diagnoal compnent
-/// specified by k is filled with the input vector, a rank 3 view \param k [in]:
-/// The diagonal offset to be filled (default is 0).
+/// \param out [inout]: Output batched matrix, where the diagonal compnent
+/// specified by k is filled with the input vector, a rank 3 view
+/// \param k [in]: The diagonal offset to be filled (default is 0).
 ///
 template <typename InViewType, typename OutViewType>
 void create_diagonal_matrix(InViewType& in, OutViewType& out, int k = 0) {

--- a/batched/dense/unit_test/Test_Batched_DenseUtils.hpp
+++ b/batched/dense/unit_test/Test_Batched_DenseUtils.hpp
@@ -116,7 +116,6 @@ template <typename InViewType, typename OutViewType>
 void create_diagonal_matrix(InViewType& in, OutViewType& out, int k = 0) {
   auto h_in        = Kokkos::create_mirror_view(in);
   auto h_out       = Kokkos::create_mirror_view(out);
-  using value_type = typename InViewType::non_const_value_type;
   const int N = in.extent(0), BlkSize = in.extent(1);
 
   assert(out.extent(0) == in.extent(0));

--- a/batched/dense/unit_test/Test_Batched_SerialPttrf.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPttrf.hpp
@@ -142,14 +142,14 @@ void impl_test_batched_pttrf(const int N, const int BlkSize) {
   auto h_e_lower = Kokkos::create_mirror_view(e_lower);
   auto h_ones    = Kokkos::create_mirror_view(ones);
 
-  for (std::size_t ib = 0; ib < N; ib++) {
-    for (std::size_t i = 0; i < BlkSize; i++) {
+  for (int ib = 0; ib < N; ib++) {
+    for (int i = 0; i < BlkSize; i++) {
       h_d(ib, i) += static_cast<real_type>(
           BlkSize);  // Add BlkSize to ensure positive definiteness
       h_ones(ib, i) = 1;
     }
 
-    for (std::size_t i = 0; i < BlkSize - 1; i++) {
+    for (int i = 0; i < BlkSize - 1; i++) {
       // FIXME: We cannot use complex conjugate for real type
       h_e_upper(ib, i) =
           Kokkos::ArithTraits<ScalarType>::real(h_e_upper(ib, i));

--- a/batched/dense/unit_test/Test_Batched_SerialPttrf.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPttrf.hpp
@@ -81,7 +81,7 @@ struct Functor_BatchedSerialGemm {
   Functor_BatchedSerialGemm(const ScalarType alpha, const AViewType &a,
                             const BViewType &b, const ScalarType beta,
                             const CViewType &c)
-      : _alpha(alpha), _a(a), _b(b), _beta(beta), _c(c) {}
+      : _a(a), _b(b), _c(c), _alpha(alpha), _beta(beta) {}
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int k) const {

--- a/batched/dense/unit_test/Test_Batched_SerialPttrf.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPttrf.hpp
@@ -43,7 +43,7 @@ struct Functor_BatchedSerialPttrf {
     auto dd = Kokkos::subview(_d, k, Kokkos::ALL());
     auto ee = Kokkos::subview(_e, k, Kokkos::ALL());
 
-    info = KokkosBatched::SerialPttrf<AlgoTagType>::invoke(dd, ee);
+    info += KokkosBatched::SerialPttrf<AlgoTagType>::invoke(dd, ee);
   }
 
   inline int run() {

--- a/batched/dense/unit_test/Test_Batched_SerialPttrf.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPttrf.hpp
@@ -1,0 +1,237 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
+
+#include "KokkosBatched_Util.hpp"
+#include "KokkosBatched_Pttrf.hpp"
+#include "Test_Batched_DenseUtils.hpp"
+
+using namespace KokkosBatched;
+
+namespace Test {
+namespace Pttrf {
+
+template <typename T>
+struct real_type {
+  using type = T;
+};
+
+template <typename T>
+struct real_type<Kokkos::complex<T>> {
+  using type = T;
+};
+
+template <typename DeviceType, typename DViewType, typename EViewType,
+          typename AlgoTagType>
+struct Functor_BatchedSerialPttrf {
+  using execution_space = typename DeviceType::execution_space;
+  DViewType _d;
+  EViewType _e;
+
+  KOKKOS_INLINE_FUNCTION
+  Functor_BatchedSerialPttrf(const DViewType &d, const EViewType &e)
+      : _d(d), _e(e) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int k) const {
+    auto dd = Kokkos::subview(_d, k, Kokkos::ALL());
+    auto ee = Kokkos::subview(_e, k, Kokkos::ALL());
+
+    KokkosBatched::SerialPttrf<AlgoTagType>::invoke(dd, ee);
+  }
+
+  inline void run() {
+    using value_type = typename DViewType::non_const_value_type;
+    std::string name_region("KokkosBatched::Test::SerialPttrf");
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    Kokkos::Profiling::pushRegion(name.c_str());
+    Kokkos::RangePolicy<execution_space> policy(0, _d.extent(0));
+    Kokkos::parallel_for(name.c_str(), policy, *this);
+    Kokkos::Profiling::popRegion();
+  }
+};
+
+template <typename DeviceType, typename ScalarType, typename AViewType,
+          typename BViewType, typename CViewType, typename ArgTransB>
+struct Functor_BatchedSerialGemm {
+  using execution_space = typename DeviceType::execution_space;
+  AViewType _a;
+  BViewType _b;
+  CViewType _c;
+  ScalarType _alpha, _beta;
+
+  KOKKOS_INLINE_FUNCTION
+  Functor_BatchedSerialGemm(const ScalarType alpha, const AViewType &a,
+                            const BViewType &b, const ScalarType beta,
+                            const CViewType &c)
+      : _alpha(alpha), _a(a), _b(b), _beta(beta), _c(c) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int k) const {
+    auto aa = Kokkos::subview(_a, k, Kokkos::ALL(), Kokkos::ALL());
+    auto bb = Kokkos::subview(_b, k, Kokkos::ALL(), Kokkos::ALL());
+    auto cc = Kokkos::subview(_c, k, Kokkos::ALL(), Kokkos::ALL());
+
+    KokkosBatched::SerialGemm<Trans::NoTranspose, ArgTransB,
+                              Algo::Gemm::Unblocked>::invoke(_alpha, aa, bb,
+                                                             _beta, cc);
+  }
+
+  inline void run() {
+    using value_type = typename AViewType::non_const_value_type;
+    std::string name_region("KokkosBatched::Test::SerialPttrf");
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    Kokkos::RangePolicy<execution_space> policy(0, _a.extent(0));
+    Kokkos::parallel_for(name.c_str(), policy, *this);
+  }
+};
+
+template <typename DeviceType, typename ScalarType, typename LayoutType,
+          typename AlgoTagType>
+/// \brief Implementation details of batched pttrf test
+///
+/// \param N [in] Batch size of matrix A
+void impl_test_batched_pttrf_analytical(const int N, const int BlkSize) {
+  using real_type      = typename real_type<ScalarType>::type;
+  using RealView2DType = Kokkos::View<real_type **, LayoutType, DeviceType>;
+  using View2DType     = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
+  using View3DType     = Kokkos::View<ScalarType ***, LayoutType, DeviceType>;
+
+  View3DType A("A", N, BlkSize, BlkSize),
+      A_reconst("A_reconst", N, BlkSize, BlkSize);
+  View3DType EL("EL", N, BlkSize, BlkSize), EU("EU", N, BlkSize, BlkSize),
+      DEU("DEU", N, BlkSize, BlkSize), D("D", N, BlkSize, BlkSize),
+      LD("LD", N, BlkSize, BlkSize), L("L", N, BlkSize, BlkSize),
+      I("I", N, BlkSize, BlkSize);
+  RealView2DType d("d", N, BlkSize),
+      ones("ones", N, BlkSize);       // Diagonal components
+  View2DType e("e", N, BlkSize - 1);  // Sub diagnoal components
+
+  auto h_d    = Kokkos::create_mirror_view(d);
+  auto h_e    = Kokkos::create_mirror_view(e);
+  auto h_ones = Kokkos::create_mirror_view(ones);
+
+  for (int ib = 0; ib < N; ib++) {
+    for (int i = 0; i < BlkSize; i++) {
+      h_d(ib, i)    = 4 + ib;
+      h_ones(ib, i) = 1;
+    }
+
+    for (int i = 0; i < BlkSize - 1; i++) {
+      h_e(ib, i) = 1;
+    }
+  }
+
+  Kokkos::fence();
+
+  Kokkos::deep_copy(d, h_d);
+  Kokkos::deep_copy(e, h_e);
+  Kokkos::deep_copy(ones, h_ones);
+
+  // Reconstruct Tridiaonal matrix A
+  // A = D + EL + EU
+  create_diagonal_matrix(e, EL, -1);
+  create_diagonal_matrix(e, EU, 1);
+  create_diagonal_matrix(d, D);
+
+  add_matrices(D, EU, DEU);
+  add_matrices(DEU, EL, A);
+
+  // Factorize matrix A -> L * D * L.T
+  // d and e are updated by pttrf
+  Functor_BatchedSerialPttrf<DeviceType, RealView2DType, View2DType,
+                             AlgoTagType>(d, e)
+      .run();
+
+  // Reconstruct L and D from factorized matrix
+  create_diagonal_matrix(e, EL, -1);
+  create_diagonal_matrix(d, D);
+  create_diagonal_matrix(ones, I);
+
+  add_matrices(EL, I, L);
+
+  // Reconstruct A by L*D*LT
+  // Gemm to compute L*D -> LD
+  Functor_BatchedSerialGemm<DeviceType, ScalarType, View3DType, View3DType,
+                            View3DType, Trans::NoTranspose>(1.0, L, D, 0.0, LD)
+      .run();
+
+  // Gemm to compute (L*D)*LT -> A_reconst
+  Functor_BatchedSerialGemm<DeviceType, ScalarType, View3DType, View3DType,
+                            View3DType, Trans::Transpose>(1.0, LD, L, 0.0,
+                                                          A_reconst)
+      .run();
+
+  Kokkos::fence();
+
+  // this eps is about 10^-14
+  using ats      = typename Kokkos::ArithTraits<ScalarType>;
+  using mag_type = typename ats::mag_type;
+  mag_type eps   = 1.0e3 * ats::epsilon();
+
+  auto h_A = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A);
+  auto h_A_reconst =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A_reconst);
+
+  // Check A = L*D*L.T
+  for (int ib = 0; ib < N; ib++) {
+    for (int i = 0; i < BlkSize; i++) {
+      for (int j = 0; j < BlkSize; j++) {
+        EXPECT_NEAR_KK(h_A_reconst(ib, i, j), h_A(ib, i, j), eps);
+      }
+    }
+  }
+}
+
+}  // namespace Pttrf
+}  // namespace Test
+
+template <typename DeviceType, typename ScalarType, typename AlgoTagType>
+int test_batched_pttrf() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
+  {
+    using LayoutType = Kokkos::LayoutLeft;
+    for (int i = 2; i < 10; i++) {
+      Test::Pttrf::impl_test_batched_pttrf_analytical<DeviceType, ScalarType,
+                                                      LayoutType, AlgoTagType>(
+          1, i);
+      Test::Pttrf::impl_test_batched_pttrf_analytical<DeviceType, ScalarType,
+                                                      LayoutType, AlgoTagType>(
+          2, i);
+    }
+  }
+#endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
+  {
+    using LayoutType = Kokkos::LayoutRight;
+    for (int i = 2; i < 10; i++) {
+      Test::Pttrf::impl_test_batched_pttrf_analytical<DeviceType, ScalarType,
+                                                      LayoutType, AlgoTagType>(
+          1, i);
+      Test::Pttrf::impl_test_batched_pttrf_analytical<DeviceType, ScalarType,
+                                                      LayoutType, AlgoTagType>(
+          2, i);
+    }
+  }
+#endif
+
+  return 0;
+}

--- a/batched/dense/unit_test/Test_Batched_SerialPttrf.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPttrf.hpp
@@ -147,7 +147,7 @@ void impl_test_batched_pttrf_analytical(const int N, const int BlkSize) {
 
   // Reconstruct Tridiaonal matrix A
   // A = D + EL + EU
-  create_diagonal_matrix(e, EL, -1);
+  create_diagonal_matrix(e, A, -1);  // This is EL, but finally stores A
   create_diagonal_matrix(e, EU, 1);
   create_diagonal_matrix(d, D);
   create_diagonal_matrix(ones, I);

--- a/batched/dense/unit_test/Test_Batched_SerialPttrf_Complex.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPttrf_Complex.hpp
@@ -1,0 +1,31 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_FLOAT)
+TEST_F(TestCategory, test_batched_pttrf_fcomplex) {
+  using algo_tag_type = typename Algo::Pttrf::Unblocked;
+
+  test_batched_pttrf<TestDevice, float, algo_tag_type>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
+TEST_F(TestCategory, test_batched_pttrf_dcomplex) {
+  using algo_tag_type = typename Algo::Pttrf::Unblocked;
+
+  test_batched_pttrf<TestDevice, double, algo_tag_type>();
+}
+#endif

--- a/batched/dense/unit_test/Test_Batched_SerialPttrf_Real.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPttrf_Real.hpp
@@ -1,0 +1,31 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+TEST_F(TestCategory, test_batched_pttrf_float) {
+  using algo_tag_type = typename Algo::Pttrf::Unblocked;
+
+  test_batched_pttrf<TestDevice, float, algo_tag_type>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+TEST_F(TestCategory, test_batched_pttrf_double) {
+  using algo_tag_type = typename Algo::Pttrf::Unblocked;
+
+  test_batched_pttrf<TestDevice, double, algo_tag_type>();
+}
+#endif

--- a/blas/impl/KokkosBlas_util.hpp
+++ b/blas/impl/KokkosBlas_util.hpp
@@ -85,6 +85,7 @@ struct Algo {
   using SolveLU   = Level3;
   using QR        = Level3;
   using UTV       = Level3;
+  using Pttrf     = Level3;
 
   struct Level2 {
     struct Unblocked {};


### PR DESCRIPTION
This PR implements [pttrf](https://netlib.org/lapack/explore-html-3.6.1/d0/d2f/group__double_p_tcomputational_gad408508a4fb3810c23125995dc83ccc1.html) function.

Following files are added:
1. `KokkosBatched_Pttrf_Serial_Impl.hpp`: Internal interfaces
2. `KokkosBatched_Pttrf_Serial_Internal.hpp`: Implementation details
3. `KokkosBatched_Pttrf.hpp`: APIs
4. `Test_Batched_SerialPttrf.hpp`: Unit tests for that

## Detailed description
It computes the `L*D*L**T` factorization of a real symmetric positive definite tridiagonal matrix `A`, where `A` is represented with vectors `D` and `E`.
Here, the matrix has the following shape.
- `D`: `(batch_count, n)`  
   On entry, the `n` diagonal elements of the tridiagonal matrix
   `A`. On exit, the `n` diagonal elements of the diagonal matrix
   `D` from the `L*D*L**T` factorization of `A`.
- `E`: `(batch_count, n-1)`  
   On entry, the `n-1` subdiagonal elements of the tridiagonal matrix
   `A`. On exit, the `n-1` subdiagonal elements of the
   unit bidiagonal factor `L` from the `L*D*L**T` factorization of `A`.
   `E` can also be regarded as the superdiagonal of the unit
   bidiagonal factor `U` from the `U**T*D*U` factorization of `A`.

Example of a single batch of matrix A `n = 10`. In this case, `D` is a length `n` array filled with 4 and `E` is a length `n-1` array filled with 1.

```bash
A
4 1 0 0 0 0 0 0 0 0 
1 4 1 0 0 0 0 0 0 0 
0 1 4 1 0 0 0 0 0 0 
0 0 1 4 1 0 0 0 0 0 
0 0 0 1 4 1 0 0 0 0 
0 0 0 0 1 4 1 0 0 0 
0 0 0 0 0 1 4 1 0 0 
0 0 0 0 0 0 1 4 1 0 
0 0 0 0 0 0 0 1 4 1 
0 0 0 0 0 0 0 0 1 4

D
4 4 4 4 4 4 4 4 4 4

E
1 1 1 1 1 1 1 1 1
```

Parallelization would be made in the following manner. This is efficient only when 
A is given in `LayoutLeft` for GPUs and `LayoutRight` for CPUs (parallelized over batch direction).

```C++
Kokkos::parallel_for('pttrf', 
    Kokkos::RangePolicy<execution_space> policy(0, n),
    [=](const int k) {
        auto dd = Kokkos::subview(_d, k, Kokkos::ALL());
        auto ee = Kokkos::subview(_e, k, Kokkos::ALL());

        KokkosBatched::SerialPttrf<AlgoTagType>::invoke(dd, ee);
    });
```

## Tests
1.  Make a real (complex Hermitian) symmetric positive definite tridiagonal matrix `A` from random `D` and `E`.
Then, factorize `D` and `E` to get `L` and `D` which is supposed to satisfy `A = L * D * L**T` (`A = L * D * L**H`).
Finally, check if  `A = L * D * L**T` (`A = L * D * L**H`). For the moment, complex test is suppressed since we do not have `SerialGemm` with `ConjTranspose`. (Updated 1/July)
1.  Simple and small analytical test, i.e. choose `A` and extract `D` and `E`.
Then, factorize `D` and `E` to get `L` and `D` which is supposed to satisfy `A = L * D * L**T`.
Finally, check if  `A = L * D * L**T`.