### PR TITLE
sparse: spadd_symbolic fences before device values used on host

### DIFF
--- a/sparse/impl/KokkosSparse_spadd_symbolic_impl.hpp
+++ b/sparse/impl/KokkosSparse_spadd_symbolic_impl.hpp
@@ -540,10 +540,7 @@ void spadd_symbolic_impl(
           "KokkosSparse::SpAdd:Symbolic::InputNotSorted::CountEntries",
           range_type(exec, 0, nrows), countEntries);
       KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<execution_space>(
-          exec, nrows + 1, c_rowmap_upperbound);
-      Kokkos::deep_copy(exec, c_nnz_upperbound,
-                        Kokkos::subview(c_rowmap_upperbound, nrows));
-      exec.fence("fence before c_nnz_upperbound used on host");
+          exec, nrows + 1, c_rowmap_upperbound, c_nnz_upperbound);
     }
     ordinal_view_t c_entries_uncompressed(
         Kokkos::view_alloc(exec, Kokkos::WithoutInitializing,

--- a/sparse/impl/KokkosSparse_spadd_symbolic_impl.hpp
+++ b/sparse/impl/KokkosSparse_spadd_symbolic_impl.hpp
@@ -543,6 +543,7 @@ void spadd_symbolic_impl(
           exec, nrows + 1, c_rowmap_upperbound);
       Kokkos::deep_copy(exec, c_nnz_upperbound,
                         Kokkos::subview(c_rowmap_upperbound, nrows));
+      exec.fence("fence before c_nnz_upperbound used on host");
     }
     ordinal_view_t c_entries_uncompressed(
         Kokkos::view_alloc(exec, Kokkos::WithoutInitializing,
@@ -589,6 +590,7 @@ void spadd_symbolic_impl(
   // provide the number of NNZ in C to user through handle
   size_type cmax;
   Kokkos::deep_copy(exec, cmax, Kokkos::subview(c_rowmap, nrows));
+  exec.fence("fence before cmax used on host");
   addHandle->set_c_nnz(cmax);
   addHandle->set_call_symbolic();
   addHandle->set_call_numeric(false);


### PR DESCRIPTION
This fixes some spadd unit test failures on SYCL

Closes https://github.com/kokkos/kokkos-kernels/issues/2257 and https://github.com/kokkos/kokkos-kernels/issues/2258 

Probably partial fix for https://github.com/kokkos/kokkos-kernels/issues/1961