### PR TITLE
sparse: replace macros with constexpr bools

### DIFF
--- a/sparse/impl/KokkosSparse_spadd_symbolic_impl.hpp
+++ b/sparse/impl/KokkosSparse_spadd_symbolic_impl.hpp
@@ -24,10 +24,11 @@
 namespace KokkosSparse {
 namespace Impl {
 
-// Helper macro to check that two types are the same (ignoring const)
-#define SAME_TYPE(A, B)                             \
-  std::is_same<typename std::remove_const<A>::type, \
-               typename std::remove_const<B>::type>::value
+// Two types are the same (ignoring const)
+template <typename T, typename U>
+constexpr bool spadd_symbolic_same_type =
+    std::is_same_v<typename std::remove_const_t<T>,
+                   typename std::remove_const_t<U>>;
 
 // get C rowmap for sorted input
 template <typename size_type, typename ordinal_type, typename ARowPtrsT,
@@ -479,29 +480,34 @@ void spadd_symbolic_impl(
   // Check that A/B/C data types match KernelHandle types, and that C data types
   // are nonconst (doesn't matter if A/B types are const)
   static_assert(
-      SAME_TYPE(typename alno_row_view_t_::non_const_value_type, size_type),
+      spadd_symbolic_same_type<typename alno_row_view_t_::non_const_value_type,
+                               size_type>,
       "add_symbolic: A size_type must match KernelHandle size_type (const "
       "doesn't matter)");
   static_assert(
-      SAME_TYPE(typename blno_row_view_t_::non_const_value_type, size_type),
+      spadd_symbolic_same_type<typename blno_row_view_t_::non_const_value_type,
+                               size_type>,
       "add_symbolic: B size_type must match KernelHandle size_type (const "
       "doesn't matter)");
   static_assert(
-      SAME_TYPE(typename clno_row_view_t_::non_const_value_type, size_type),
+      spadd_symbolic_same_type<typename clno_row_view_t_::non_const_value_type,
+                               size_type>,
       "add_symbolic: C size_type must match KernelHandle size_type)");
-  static_assert(std::is_same<typename clno_row_view_t_::non_const_value_type,
-                             typename clno_row_view_t_::value_type>::value,
+  static_assert(std::is_same_v<typename clno_row_view_t_::non_const_value_type,
+                               typename clno_row_view_t_::value_type>,
                 "add_symbolic: C size_type must not be const");
   static_assert(
-      SAME_TYPE(typename alno_nnz_view_t_::non_const_value_type, ordinal_type),
+      spadd_symbolic_same_type<typename alno_nnz_view_t_::non_const_value_type,
+                               ordinal_type>,
       "add_symbolic: A entry type must match KernelHandle entry type (aka "
       "nnz_lno_t, and const doesn't matter)");
   static_assert(
-      SAME_TYPE(typename blno_nnz_view_t_::non_const_value_type, ordinal_type),
+      spadd_symbolic_same_type<typename blno_nnz_view_t_::non_const_value_type,
+                               ordinal_type>,
       "add_symbolic: B entry type must match KernelHandle entry type (aka "
       "nnz_lno_t, and const doesn't matter)");
-  static_assert(std::is_same<typename clno_row_view_t_::non_const_value_type,
-                             typename clno_row_view_t_::value_type>::value,
+  static_assert(std::is_same_v<typename clno_row_view_t_::non_const_value_type,
+                               typename clno_row_view_t_::value_type>,
                 "add_symbolic: C entry type must not be const");
   // symbolic just needs to compute c_rowmap
   // easy for sorted, but for unsorted is easiest to just compute the whole sum
@@ -593,8 +599,6 @@ void spadd_symbolic_impl(
   addHandle->set_call_symbolic();
   addHandle->set_call_numeric(false);
 }
-
-#undef SAME_TYPE
 
 }  // namespace Impl
 }  // namespace KokkosSparse

--- a/sparse/src/KokkosSparse_par_ilut.hpp
+++ b/sparse/src/KokkosSparse_par_ilut.hpp
@@ -44,9 +44,11 @@
 namespace KokkosSparse {
 namespace Experimental {
 
-#define KOKKOSKERNELS_PAR_ILUT_SAME_TYPE(A, B)      \
-  std::is_same<typename std::remove_const<A>::type, \
-               typename std::remove_const<B>::type>::value
+// Two types are the same (ignoring const)
+template <typename T, typename U>
+constexpr bool parilut_same_type =
+    std::is_same_v<typename std::remove_const_t<T>,
+                   typename std::remove_const_t<U>>;
 
 /// @brief Performs the symbolic phase of par_ilut.
 ///        This is a non-blocking function.
@@ -78,24 +80,24 @@ void par_ilut_symbolic(KernelHandle* handle, ARowMapType& A_rowmap,
   using size_type    = typename KernelHandle::size_type;
   using ordinal_type = typename KernelHandle::nnz_lno_t;
 
-  static_assert(KOKKOSKERNELS_PAR_ILUT_SAME_TYPE(
-                    typename ARowMapType::non_const_value_type, size_type),
-                "par_ilut_symbolic: A size_type must match KernelHandle "
-                "size_type (const doesn't matter)");
-  static_assert(KOKKOSKERNELS_PAR_ILUT_SAME_TYPE(
-                    typename AEntriesType::non_const_value_type, ordinal_type),
+  static_assert(
+      parilut_same_type<typename ARowMapType::non_const_value_type, size_type>,
+      "par_ilut_symbolic: A size_type must match KernelHandle "
+      "size_type (const doesn't matter)");
+  static_assert(parilut_same_type<typename AEntriesType::non_const_value_type,
+                                  ordinal_type>,
                 "par_ilut_symbolic: A entry type must match KernelHandle entry "
                 "type (aka nnz_lno_t, and const doesn't matter)");
 
-  static_assert(KOKKOSKERNELS_PAR_ILUT_SAME_TYPE(
-                    typename LRowMapType::non_const_value_type, size_type),
-                "par_ilut_symbolic: L size_type must match KernelHandle "
-                "size_type (const doesn't matter)");
+  static_assert(
+      parilut_same_type<typename LRowMapType::non_const_value_type, size_type>,
+      "par_ilut_symbolic: L size_type must match KernelHandle "
+      "size_type (const doesn't matter)");
 
-  static_assert(KOKKOSKERNELS_PAR_ILUT_SAME_TYPE(
-                    typename URowMapType::non_const_value_type, size_type),
-                "par_ilut_symbolic: U size_type must match KernelHandle "
-                "size_type (const doesn't matter)");
+  static_assert(
+      parilut_same_type<typename URowMapType::non_const_value_type, size_type>,
+      "par_ilut_symbolic: U size_type must match KernelHandle "
+      "size_type (const doesn't matter)");
 
   static_assert(Kokkos::is_view<ARowMapType>::value,
                 "par_ilut_symbolic: A_rowmap is not a Kokkos::View.");
@@ -118,25 +120,25 @@ void par_ilut_symbolic(KernelHandle* handle, ARowMapType& A_rowmap,
                 "par_ilut_symbolic: A_rowmap, L_rowmap and U_rowmap must all "
                 "have rank 1.");
 
-  static_assert(std::is_same<typename LRowMapType::value_type,
-                             typename LRowMapType::non_const_value_type>::value,
+  static_assert(std::is_same_v<typename LRowMapType::value_type,
+                               typename LRowMapType::non_const_value_type>,
                 "par_ilut_symbolic: The output L_rowmap must be nonconst.");
-  static_assert(std::is_same<typename URowMapType::value_type,
-                             typename URowMapType::non_const_value_type>::value,
+  static_assert(std::is_same_v<typename URowMapType::value_type,
+                               typename URowMapType::non_const_value_type>,
                 "par_ilut_symbolic: The output U_rowmap must be nonconst.");
-  static_assert(std::is_same<typename LRowMapType::device_type,
-                             typename ARowMapType::device_type>::value,
+  static_assert(std::is_same_v<typename LRowMapType::device_type,
+                               typename ARowMapType::device_type>,
                 "par_ilut_symbolic: Views LRowMapType and ARowMapType have "
                 "different device_types.");
-  static_assert(std::is_same<typename LRowMapType::device_type,
-                             typename URowMapType::device_type>::value,
+  static_assert(std::is_same_v<typename LRowMapType::device_type,
+                               typename URowMapType::device_type>,
                 "par_ilut_symbolic: Views LRowMapType and URowMapType have "
                 "different device_types.");
 
   static_assert(
-      std::is_same<
+      std::is_same_v<
           typename LRowMapType::device_type::execution_space,
-          typename KernelHandle::PAR_ILUTHandleType::execution_space>::value,
+          typename KernelHandle::PAR_ILUTHandleType::execution_space>,
       "par_ilut_symbolic: KernelHandle and Views have different execution "
       "spaces.");
 
@@ -165,26 +167,26 @@ void par_ilut_symbolic(KernelHandle* handle, ARowMapType& A_rowmap,
       typename ARowMapType::const_value_type*,
       typename KokkosKernels::Impl::GetUnifiedLayout<ARowMapType>::array_layout,
       typename ARowMapType::device_type,
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
+      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;
 
   using AEntries_Internal = Kokkos::View<
       typename AEntriesType::const_value_type*,
       typename KokkosKernels::Impl::GetUnifiedLayout<
           AEntriesType>::array_layout,
       typename AEntriesType::device_type,
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
+      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;
 
   using LRowMap_Internal = Kokkos::View<
       typename LRowMapType::non_const_value_type*,
       typename KokkosKernels::Impl::GetUnifiedLayout<LRowMapType>::array_layout,
       typename LRowMapType::device_type,
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
+      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;
 
   using URowMap_Internal = Kokkos::View<
       typename URowMapType::non_const_value_type*,
       typename KokkosKernels::Impl::GetUnifiedLayout<URowMapType>::array_layout,
       typename URowMapType::device_type,
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
+      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;
 
   ARowMap_Internal A_rowmap_i   = A_rowmap;
   AEntries_Internal A_entries_i = A_entries;
@@ -240,46 +242,43 @@ void par_ilut_numeric(KernelHandle* handle, ARowMapType& A_rowmap,
   using scalar_type  = typename KernelHandle::nnz_scalar_t;
 
   static_assert(
-      KOKKOSKERNELS_PAR_ILUT_SAME_TYPE(
-          typename ARowMapType::non_const_value_type, size_type),
+      parilut_same_type<typename ARowMapType::non_const_value_type, size_type>,
       "par_ilut_numeric: A size_type must match KernelHandle size_type "
       "(const doesn't matter)");
-  static_assert(KOKKOSKERNELS_PAR_ILUT_SAME_TYPE(
-                    typename AEntriesType::non_const_value_type, ordinal_type),
+  static_assert(parilut_same_type<typename AEntriesType::non_const_value_type,
+                                  ordinal_type>,
                 "par_ilut_numeric: A entry type must match KernelHandle entry "
                 "type (aka nnz_lno_t, and const doesn't matter)");
-  static_assert(KOKKOSKERNELS_PAR_ILUT_SAME_TYPE(
-                    typename AValuesType::value_type, scalar_type),
-                "par_ilut_numeric: A scalar type must match KernelHandle entry "
-                "type (aka nnz_scalar_t, and const doesn't matter)");
+  static_assert(
+      parilut_same_type<typename AValuesType::value_type, scalar_type>,
+      "par_ilut_numeric: A scalar type must match KernelHandle entry "
+      "type (aka nnz_scalar_t, and const doesn't matter)");
 
   static_assert(
-      KOKKOSKERNELS_PAR_ILUT_SAME_TYPE(
-          typename LRowMapType::non_const_value_type, size_type),
+      parilut_same_type<typename LRowMapType::non_const_value_type, size_type>,
       "par_ilut_numeric: L size_type must match KernelHandle size_type "
       "(const doesn't matter)");
-  static_assert(KOKKOSKERNELS_PAR_ILUT_SAME_TYPE(
-                    typename LEntriesType::non_const_value_type, ordinal_type),
+  static_assert(parilut_same_type<typename LEntriesType::non_const_value_type,
+                                  ordinal_type>,
                 "par_ilut_numeric: L entry type must match KernelHandle entry "
                 "type (aka nnz_lno_t, and const doesn't matter)");
-  static_assert(KOKKOSKERNELS_PAR_ILUT_SAME_TYPE(
-                    typename LValuesType::value_type, scalar_type),
-                "par_ilut_numeric: L scalar type must match KernelHandle entry "
-                "type (aka nnz_scalar_t, and const doesn't matter)");
+  static_assert(
+      parilut_same_type<typename LValuesType::value_type, scalar_type>,
+      "par_ilut_numeric: L scalar type must match KernelHandle entry "
+      "type (aka nnz_scalar_t, and const doesn't matter)");
 
   static_assert(
-      KOKKOSKERNELS_PAR_ILUT_SAME_TYPE(
-          typename URowMapType::non_const_value_type, size_type),
+      parilut_same_type<typename URowMapType::non_const_value_type, size_type>,
       "par_ilut_numeric: U size_type must match KernelHandle size_type "
       "(const doesn't matter)");
-  static_assert(KOKKOSKERNELS_PAR_ILUT_SAME_TYPE(
-                    typename UEntriesType::non_const_value_type, ordinal_type),
+  static_assert(parilut_same_type<typename UEntriesType::non_const_value_type,
+                                  ordinal_type>,
                 "par_ilut_numeric: U entry type must match KernelHandle entry "
                 "type (aka nnz_lno_t, and const doesn't matter)");
-  static_assert(KOKKOSKERNELS_PAR_ILUT_SAME_TYPE(
-                    typename UValuesType::value_type, scalar_type),
-                "par_ilut_numeric: U scalar type must match KernelHandle entry "
-                "type (aka nnz_scalar_t, and const doesn't matter)");
+  static_assert(
+      parilut_same_type<typename UValuesType::value_type, scalar_type>,
+      "par_ilut_numeric: U scalar type must match KernelHandle entry "
+      "type (aka nnz_scalar_t, and const doesn't matter)");
 
   static_assert(Kokkos::is_view<ARowMapType>::value,
                 "par_ilut_numeric: A_rowmap is not a Kokkos::View.");
@@ -330,73 +329,71 @@ void par_ilut_numeric(KernelHandle* handle, ARowMapType& A_rowmap,
                 "par_ilut_numeric: A_values, L_values and U_values must all "
                 "have rank 1.");
 
-  static_assert(
-      std::is_same<typename LEntriesType::value_type,
-                   typename LEntriesType::non_const_value_type>::value,
-      "par_ilut_numeric: The output L_entries must be nonconst.");
-  static_assert(std::is_same<typename LValuesType::value_type,
-                             typename LValuesType::non_const_value_type>::value,
+  static_assert(std::is_same_v<typename LEntriesType::value_type,
+                               typename LEntriesType::non_const_value_type>,
+                "par_ilut_numeric: The output L_entries must be nonconst.");
+  static_assert(std::is_same_v<typename LValuesType::value_type,
+                               typename LValuesType::non_const_value_type>,
                 "par_ilut_numeric: The output L_values must be nonconst.");
-  static_assert(
-      std::is_same<typename UEntriesType::value_type,
-                   typename UEntriesType::non_const_value_type>::value,
-      "par_ilut_numeric: The output U_entries must be nonconst.");
-  static_assert(std::is_same<typename UValuesType::value_type,
-                             typename UValuesType::non_const_value_type>::value,
+  static_assert(std::is_same_v<typename UEntriesType::value_type,
+                               typename UEntriesType::non_const_value_type>,
+                "par_ilut_numeric: The output U_entries must be nonconst.");
+  static_assert(std::is_same_v<typename UValuesType::value_type,
+                               typename UValuesType::non_const_value_type>,
                 "par_ilut_numeric: The output U_values must be nonconst.");
 
-  static_assert(std::is_same<typename LRowMapType::device_type,
-                             typename ARowMapType::device_type>::value,
+  static_assert(std::is_same_v<typename LRowMapType::device_type,
+                               typename ARowMapType::device_type>,
                 "par_ilut_numeric: Views LRowMapType and ARowMapType have "
                 "different device_types.");
-  static_assert(std::is_same<typename LEntriesType::device_type,
-                             typename AEntriesType::device_type>::value,
+  static_assert(std::is_same_v<typename LEntriesType::device_type,
+                               typename AEntriesType::device_type>,
                 "par_ilut_numeric: Views LEntriesType and AEntriesType have "
                 "different device_types.");
-  static_assert(std::is_same<typename LValuesType::device_type,
-                             typename AValuesType::device_type>::value,
+  static_assert(std::is_same_v<typename LValuesType::device_type,
+                               typename AValuesType::device_type>,
                 "par_ilut_numeric: Views LValuesType and AValuesType have "
                 "different device_types.");
 
-  static_assert(std::is_same<typename LRowMapType::device_type,
-                             typename URowMapType::device_type>::value,
+  static_assert(std::is_same_v<typename LRowMapType::device_type,
+                               typename URowMapType::device_type>,
                 "par_ilut_numeric: Views LRowMapType and URowMapType have "
                 "different device_types.");
-  static_assert(std::is_same<typename LEntriesType::device_type,
-                             typename UEntriesType::device_type>::value,
+  static_assert(std::is_same_v<typename LEntriesType::device_type,
+                               typename UEntriesType::device_type>,
                 "par_ilut_numeric: Views LEntriesType and UEntriesType have "
                 "different device_types.");
-  static_assert(std::is_same<typename LValuesType::device_type,
-                             typename UValuesType::device_type>::value,
+  static_assert(std::is_same_v<typename LValuesType::device_type,
+                               typename UValuesType::device_type>,
                 "par_ilut_numeric: Views LValuesType and UValuesType have "
                 "different device_types.");
 
   static_assert(
-      std::is_same<
+      std::is_same_v<
           typename LRowMapType::device_type::execution_space,
-          typename KernelHandle::PAR_ILUTHandleType::execution_space>::value,
+          typename KernelHandle::PAR_ILUTHandleType::execution_space>,
       "par_ilut_numeric: KernelHandle and Views have different execution "
       "spaces.");
   static_assert(
-      std::is_same<
+      std::is_same_v<
           typename LEntriesType::device_type::execution_space,
-          typename KernelHandle::PAR_ILUTHandleType::execution_space>::value,
+          typename KernelHandle::PAR_ILUTHandleType::execution_space>,
       "par_ilut_numeric: KernelHandle and Views have different execution "
       "spaces.");
   static_assert(
-      std::is_same<
+      std::is_same_v<
           typename LValuesType::device_type::execution_space,
-          typename KernelHandle::PAR_ILUTHandleType::execution_space>::value,
+          typename KernelHandle::PAR_ILUTHandleType::execution_space>,
       "par_ilut_numeric: KernelHandle and Views have different execution "
       "spaces.");
 
   static_assert(
-      std::is_same<typename LRowMapType::device_type,
-                   typename LEntriesType::device_type>::value,
+      std::is_same_v<typename LRowMapType::device_type,
+                     typename LEntriesType::device_type>,
       "par_ilut_numeric: rowmap and entries have different device types.");
   static_assert(
-      std::is_same<typename LRowMapType::device_type,
-                   typename LValuesType::device_type>::value,
+      std::is_same_v<typename LRowMapType::device_type,
+                     typename LValuesType::device_type>,
       "par_ilut_numeric: rowmap and values have different device types.");
 
   // Check if symbolic has been called
@@ -431,58 +428,58 @@ void par_ilut_numeric(KernelHandle* handle, ARowMapType& A_rowmap,
       typename ARowMapType::const_value_type*,
       typename KokkosKernels::Impl::GetUnifiedLayout<ARowMapType>::array_layout,
       typename ARowMapType::device_type,
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
+      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;
 
   using AEntries_Internal = Kokkos::View<
       typename AEntriesType::const_value_type*,
       typename KokkosKernels::Impl::GetUnifiedLayout<
           AEntriesType>::array_layout,
       typename AEntriesType::device_type,
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
+      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;
 
   using AValues_Internal = Kokkos::View<
       typename AValuesType::const_value_type*,
       typename KokkosKernels::Impl::GetUnifiedLayout<AValuesType>::array_layout,
       typename AValuesType::device_type,
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
+      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;
 
   using LRowMap_Internal = Kokkos::View<
       typename LRowMapType::non_const_value_type*,
       typename KokkosKernels::Impl::GetUnifiedLayout<LRowMapType>::array_layout,
       typename LRowMapType::device_type,
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
+      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;
 
   using LEntries_Internal =
       Kokkos::View<typename LEntriesType::non_const_value_type*,
                    typename KokkosKernels::Impl::GetUnifiedLayout<
                        LEntriesType>::array_layout,
                    typename LEntriesType::device_type,
-                   Kokkos::MemoryTraits<Kokkos::RandomAccess> >;
+                   Kokkos::MemoryTraits<Kokkos::RandomAccess>>;
 
   using LValues_Internal = Kokkos::View<
       typename LValuesType::non_const_value_type*,
       typename KokkosKernels::Impl::GetUnifiedLayout<LValuesType>::array_layout,
       typename LValuesType::device_type,
-      Kokkos::MemoryTraits<Kokkos::RandomAccess> >;
+      Kokkos::MemoryTraits<Kokkos::RandomAccess>>;
 
   using URowMap_Internal = Kokkos::View<
       typename URowMapType::non_const_value_type*,
       typename KokkosKernels::Impl::GetUnifiedLayout<URowMapType>::array_layout,
       typename URowMapType::device_type,
-      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
+      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;
 
   using UEntries_Internal =
       Kokkos::View<typename UEntriesType::non_const_value_type*,
                    typename KokkosKernels::Impl::GetUnifiedLayout<
                        UEntriesType>::array_layout,
                    typename UEntriesType::device_type,
-                   Kokkos::MemoryTraits<Kokkos::RandomAccess> >;
+                   Kokkos::MemoryTraits<Kokkos::RandomAccess>>;
 
   using UValues_Internal = Kokkos::View<
       typename UValuesType::non_const_value_type*,
       typename KokkosKernels::Impl::GetUnifiedLayout<UValuesType>::array_layout,
       typename UValuesType::device_type,
-      Kokkos::MemoryTraits<Kokkos::RandomAccess> >;
+      Kokkos::MemoryTraits<Kokkos::RandomAccess>>;
 
   ARowMap_Internal A_rowmap_i   = A_rowmap;
   AEntries_Internal A_entries_i = A_entries;
@@ -518,7 +515,5 @@ void par_ilut_numeric(KernelHandle* handle, ARowMapType& A_rowmap,
 
 }  // namespace Experimental
 }  // namespace KokkosSparse
-
-#undef KOKKOSKERNELS_PAR_ILUT_SAME_TYPE
 
 #endif  // KOKKOSSPARSE_PAR_ILUT_HPP_


### PR DESCRIPTION
also a few `std::is_same<...>::value` -> `std::is_same_v<...>` along the way