### PR TITLE
Rename `Impl::alignPtr` to `Impl::alignPtrTo`, allow it to infer argument type

### DIFF
--- a/common/src/KokkosKernels_Utils.hpp
+++ b/common/src/KokkosKernels_Utils.hpp
@@ -1528,7 +1528,7 @@ struct array_sum_reduce {
 };
 
 template <typename T, typename InPtr>
-KOKKOS_INLINE_FUNCTION T *alignPtr(InPtr p) {
+KOKKOS_INLINE_FUNCTION T *alignPtrTo(InPtr p) {
   // ugly but computationally free and the "right" way to do this in C++
   std::uintptr_t ptrVal = reinterpret_cast<std::uintptr_t>(p);
   // ptrVal + (align - 1) lands inside the next valid aligned scalar_t,

--- a/common/src/KokkosKernels_Utils.hpp
+++ b/common/src/KokkosKernels_Utils.hpp
@@ -1527,7 +1527,7 @@ struct array_sum_reduce {
   }
 };
 
-template <typename InPtr, typename T>
+template <typename T, typename InPtr>
 KOKKOS_INLINE_FUNCTION T *alignPtr(InPtr p) {
   // ugly but computationally free and the "right" way to do this in C++
   std::uintptr_t ptrVal = reinterpret_cast<std::uintptr_t>(p);

--- a/sparse/impl/KokkosSparse_bspgemm_impl_kkmem.hpp
+++ b/sparse/impl/KokkosSparse_bspgemm_impl_kkmem.hpp
@@ -270,7 +270,7 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     nnz_lno_t *hash_ids = (nnz_lno_t *)(tmp);
     tmp += pow2_hash_size;
 
-    scalar_t *hash_values = KokkosKernels::Impl::alignPtr<scalar_t>(tmp);
+    scalar_t *hash_values = KokkosKernels::Impl::alignPtrTo<scalar_t>(tmp);
 
     BlockAccumulator hm(block_dim, pow2_hash_size, pow2_hash_func, nullptr,
                         nullptr, hash_ids, hash_values);
@@ -412,7 +412,8 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * thread_shmem_key_size;
     // remainder of shmem allocation for vals
-    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
+    scalar_t *vals =
+        KokkosKernels::Impl::alignPtrTo<scalar_t>(all_shared_memory);
 
     BlockAccumulator hm(block_dim, thread_shmem_key_size,
                         thread_shared_memory_hash_func, begins, nexts, keys,
@@ -551,7 +552,8 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     // holds the keys
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * team_cuckoo_key_size;
-    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
+    scalar_t *vals =
+        KokkosKernels::Impl::alignPtrTo<scalar_t>(all_shared_memory);
 
     int thread_rank = teamMember.team_rank();
 
@@ -598,7 +600,7 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
           }
           global_acc_row_keys = (nnz_lno_t *)(tmp);
           global_acc_row_vals =
-              KokkosKernels::Impl::alignPtr<scalar_t>(tmp + pow2_hash_size);
+              KokkosKernels::Impl::alignPtrTo<scalar_t>(tmp + pow2_hash_size);
         }
         // initialize begins.
         {
@@ -880,7 +882,8 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     // holds the keys
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * team_cuckoo_key_size;
-    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
+    scalar_t *vals =
+        KokkosKernels::Impl::alignPtrTo<scalar_t>(all_shared_memory);
 
     int thread_rank = teamMember.team_rank();
 

--- a/sparse/impl/KokkosSparse_bspgemm_impl_kkmem.hpp
+++ b/sparse/impl/KokkosSparse_bspgemm_impl_kkmem.hpp
@@ -270,8 +270,7 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     nnz_lno_t *hash_ids = (nnz_lno_t *)(tmp);
     tmp += pow2_hash_size;
 
-    scalar_t *hash_values =
-        KokkosKernels::Impl::alignPtr<volatile nnz_lno_t *, scalar_t>(tmp);
+    scalar_t *hash_values = KokkosKernels::Impl::alignPtr<scalar_t>(tmp);
 
     BlockAccumulator hm(block_dim, pow2_hash_size, pow2_hash_func, nullptr,
                         nullptr, hash_ids, hash_values);
@@ -413,8 +412,7 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * thread_shmem_key_size;
     // remainder of shmem allocation for vals
-    scalar_t *vals =
-        KokkosKernels::Impl::alignPtr<char *, scalar_t>(all_shared_memory);
+    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
 
     BlockAccumulator hm(block_dim, thread_shmem_key_size,
                         thread_shared_memory_hash_func, begins, nexts, keys,
@@ -553,8 +551,7 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     // holds the keys
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * team_cuckoo_key_size;
-    scalar_t *vals =
-        KokkosKernels::Impl::alignPtr<char *, scalar_t>(all_shared_memory);
+    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
 
     int thread_rank = teamMember.team_rank();
 
@@ -601,8 +598,7 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
           }
           global_acc_row_keys = (nnz_lno_t *)(tmp);
           global_acc_row_vals =
-              KokkosKernels::Impl::alignPtr<volatile nnz_lno_t *, scalar_t>(
-                  tmp + pow2_hash_size);
+              KokkosKernels::Impl::alignPtr<scalar_t>(tmp + pow2_hash_size);
         }
         // initialize begins.
         {
@@ -884,8 +880,7 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     // holds the keys
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * team_cuckoo_key_size;
-    scalar_t *vals =
-        KokkosKernels::Impl::alignPtr<char *, scalar_t>(all_shared_memory);
+    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
 
     int thread_rank = teamMember.team_rank();
 

--- a/sparse/impl/KokkosSparse_bspgemm_impl_speed.hpp
+++ b/sparse/impl/KokkosSparse_bspgemm_impl_speed.hpp
@@ -324,8 +324,7 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     // holds the keys
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * shmem_key_size;
-    scalar_t *vals =
-        KokkosKernels::Impl::alignPtr<char *, scalar_t>(all_shared_memory);
+    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
 
     KokkosKernels::Experimental::BlockHashmapAccumulator<
         nnz_lno_t, nnz_lno_t, scalar_t,

--- a/sparse/impl/KokkosSparse_bspgemm_impl_speed.hpp
+++ b/sparse/impl/KokkosSparse_bspgemm_impl_speed.hpp
@@ -324,7 +324,8 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     // holds the keys
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * shmem_key_size;
-    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
+    scalar_t *vals =
+        KokkosKernels::Impl::alignPtrTo<scalar_t>(all_shared_memory);
 
     KokkosKernels::Experimental::BlockHashmapAccumulator<
         nnz_lno_t, nnz_lno_t, scalar_t,

--- a/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
@@ -261,7 +261,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     nnz_lno_t *hash_ids = (nnz_lno_t *)(tmp);
     tmp += pow2_hash_size;
 
-    scalar_t *hash_values = KokkosKernels::Impl::alignPtr<scalar_t>(tmp);
+    scalar_t *hash_values = KokkosKernels::Impl::alignPtrTo<scalar_t>(tmp);
 
     Kokkos::parallel_for(
         Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end),
@@ -408,7 +408,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
 
     hm2.keys = (nnz_lno_t *)(tmp);
     tmp += max_nnz;
-    hm2.values = KokkosKernels::Impl::alignPtr<scalar_t>(tmp);
+    hm2.values = KokkosKernels::Impl::alignPtrTo<scalar_t>(tmp);
 
     Kokkos::parallel_for(
         Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end),
@@ -495,7 +495,8 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * thread_shmem_key_size;
     // remainder of shmem allocation for vals
-    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
+    scalar_t *vals =
+        KokkosKernels::Impl::alignPtrTo<scalar_t>(all_shared_memory);
 
     KokkosKernels::Experimental::HashmapAccumulator<
         nnz_lno_t, nnz_lno_t, scalar_t,
@@ -635,7 +636,8 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     // holds the keys
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * team_cuckoo_key_size;
-    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
+    scalar_t *vals =
+        KokkosKernels::Impl::alignPtrTo<scalar_t>(all_shared_memory);
 
     int thread_rank = teamMember.team_rank();
 
@@ -682,7 +684,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
           }
           global_acc_row_keys = (nnz_lno_t *)(tmp);
           global_acc_row_vals =
-              KokkosKernels::Impl::alignPtr<scalar_t>(tmp + pow2_hash_size);
+              KokkosKernels::Impl::alignPtrTo<scalar_t>(tmp + pow2_hash_size);
         }
         // initialize begins.
         {
@@ -964,7 +966,8 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     // holds the keys
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * team_cuckoo_key_size;
-    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
+    scalar_t *vals =
+        KokkosKernels::Impl::alignPtrTo<scalar_t>(all_shared_memory);
 
     int thread_rank = teamMember.team_rank();
 

--- a/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
@@ -261,8 +261,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     nnz_lno_t *hash_ids = (nnz_lno_t *)(tmp);
     tmp += pow2_hash_size;
 
-    scalar_t *hash_values =
-        KokkosKernels::Impl::alignPtr<volatile nnz_lno_t *, scalar_t>(tmp);
+    scalar_t *hash_values = KokkosKernels::Impl::alignPtr<scalar_t>(tmp);
 
     Kokkos::parallel_for(
         Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end),
@@ -409,8 +408,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
 
     hm2.keys = (nnz_lno_t *)(tmp);
     tmp += max_nnz;
-    hm2.values =
-        KokkosKernels::Impl::alignPtr<volatile nnz_lno_t *, scalar_t>(tmp);
+    hm2.values = KokkosKernels::Impl::alignPtr<scalar_t>(tmp);
 
     Kokkos::parallel_for(
         Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end),
@@ -497,8 +495,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * thread_shmem_key_size;
     // remainder of shmem allocation for vals
-    scalar_t *vals =
-        KokkosKernels::Impl::alignPtr<char *, scalar_t>(all_shared_memory);
+    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
 
     KokkosKernels::Experimental::HashmapAccumulator<
         nnz_lno_t, nnz_lno_t, scalar_t,
@@ -638,8 +635,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     // holds the keys
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * team_cuckoo_key_size;
-    scalar_t *vals =
-        KokkosKernels::Impl::alignPtr<char *, scalar_t>(all_shared_memory);
+    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
 
     int thread_rank = teamMember.team_rank();
 
@@ -686,8 +682,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
           }
           global_acc_row_keys = (nnz_lno_t *)(tmp);
           global_acc_row_vals =
-              KokkosKernels::Impl::alignPtr<volatile nnz_lno_t *, scalar_t>(
-                  tmp + pow2_hash_size);
+              KokkosKernels::Impl::alignPtr<scalar_t>(tmp + pow2_hash_size);
         }
         // initialize begins.
         {
@@ -969,8 +964,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     // holds the keys
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * team_cuckoo_key_size;
-    scalar_t *vals =
-        KokkosKernels::Impl::alignPtr<char *, scalar_t>(all_shared_memory);
+    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
 
     int thread_rank = teamMember.team_rank();
 

--- a/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
@@ -303,8 +303,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     // holds the keys
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * shmem_key_size;
-    scalar_t *vals =
-        KokkosKernels::Impl::alignPtr<char *, scalar_t>(all_shared_memory);
+    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
 
     KokkosKernels::Experimental::HashmapAccumulator<
         nnz_lno_t, nnz_lno_t, scalar_t,

--- a/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
@@ -303,7 +303,8 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     // holds the keys
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * shmem_key_size;
-    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
+    scalar_t *vals =
+        KokkosKernels::Impl::alignPtrTo<scalar_t>(all_shared_memory);
 
     KokkosKernels::Experimental::HashmapAccumulator<
         nnz_lno_t, nnz_lno_t, scalar_t,

--- a/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
@@ -260,7 +260,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     tmp += max_nnz;
     nnz_lno_t *hash_ids = (nnz_lno_t *)(tmp);
     tmp += pow2_hash_size;
-    scalar_t *hash_values = KokkosKernels::Impl::alignPtr<scalar_t>(tmp);
+    scalar_t *hash_values = KokkosKernels::Impl::alignPtrTo<scalar_t>(tmp);
 
     Kokkos::parallel_for(
         Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end),
@@ -450,7 +450,8 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     all_shared_memory += sizeof(nnz_lno_t) * thread_shmem_key_size;
 
     // Remainder of shmem allocation for vals
-    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
+    scalar_t *vals =
+        KokkosKernels::Impl::alignPtrTo<scalar_t>(all_shared_memory);
 
     // Create the hashmaps
     KokkosKernels::Experimental::HashmapAccumulator<
@@ -607,7 +608,8 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
 
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * team_cuckoo_key_size;
-    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
+    scalar_t *vals =
+        KokkosKernels::Impl::alignPtrTo<scalar_t>(all_shared_memory);
 
     int thread_rank = teamMember.team_rank();
     int vector_rank = 0;
@@ -822,7 +824,8 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
 
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * team_cuckoo_key_size;
-    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
+    scalar_t *vals =
+        KokkosKernels::Impl::alignPtrTo<scalar_t>(all_shared_memory);
 
     int thread_rank = teamMember.team_rank();
     int vector_rank = 0;
@@ -867,7 +870,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
         }
         global_acc_row_keys = (nnz_lno_t *)(tmp);
         global_acc_row_vals =
-            KokkosKernels::Impl::alignPtr<scalar_t>(tmp + pow2_hash_size);
+            KokkosKernels::Impl::alignPtrTo<scalar_t>(tmp + pow2_hash_size);
 
         nnz_lno_t num_threads = pow2_hash_size / vector_size;
         Kokkos::parallel_for(

--- a/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
@@ -260,8 +260,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     tmp += max_nnz;
     nnz_lno_t *hash_ids = (nnz_lno_t *)(tmp);
     tmp += pow2_hash_size;
-    scalar_t *hash_values =
-        KokkosKernels::Impl::alignPtr<volatile nnz_lno_t *, scalar_t>(tmp);
+    scalar_t *hash_values = KokkosKernels::Impl::alignPtr<scalar_t>(tmp);
 
     Kokkos::parallel_for(
         Kokkos::TeamThreadRange(teamMember, team_row_begin, team_row_end),
@@ -451,8 +450,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
     all_shared_memory += sizeof(nnz_lno_t) * thread_shmem_key_size;
 
     // Remainder of shmem allocation for vals
-    scalar_t *vals =
-        KokkosKernels::Impl::alignPtr<char *, scalar_t>(all_shared_memory);
+    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
 
     // Create the hashmaps
     KokkosKernels::Experimental::HashmapAccumulator<
@@ -609,8 +607,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
 
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * team_cuckoo_key_size;
-    scalar_t *vals =
-        KokkosKernels::Impl::alignPtr<char *, scalar_t>(all_shared_memory);
+    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
 
     int thread_rank = teamMember.team_rank();
     int vector_rank = 0;
@@ -825,8 +822,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
 
     nnz_lno_t *keys = (nnz_lno_t *)(all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * team_cuckoo_key_size;
-    scalar_t *vals =
-        KokkosKernels::Impl::alignPtr<char *, scalar_t>(all_shared_memory);
+    scalar_t *vals = KokkosKernels::Impl::alignPtr<scalar_t>(all_shared_memory);
 
     int thread_rank = teamMember.team_rank();
     int vector_rank = 0;
@@ -871,8 +867,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_,
         }
         global_acc_row_keys = (nnz_lno_t *)(tmp);
         global_acc_row_vals =
-            KokkosKernels::Impl::alignPtr<volatile nnz_lno_t *, scalar_t>(
-                tmp + pow2_hash_size);
+            KokkosKernels::Impl::alignPtr<scalar_t>(tmp + pow2_hash_size);
 
         nnz_lno_t num_threads = pow2_hash_size / vector_size;
         Kokkos::parallel_for(


### PR DESCRIPTION
Previously

```c++
In *p1;
Out *p2 = alignPtr<In*, Out>(p1);
```

Now

```c++
In *p1;
Out *p2 = alignPtrTo<Out>(p1); // template argument inferred
```