### PR TITLE
BLAS - gemv: using fallback when mode is 't' or 'c' and onemkl is used

### DIFF
--- a/blas/src/KokkosBlas2_gemv.hpp
+++ b/blas/src/KokkosBlas2_gemv.hpp
@@ -163,9 +163,11 @@ void gemv(const ExecutionSpace& space, const char trans[],
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
 #ifdef KOKKOS_ENABLE_SYCL
   // oneMKL supports both row-major and column-major of A
+  // but only supports oneapi::mkl::transpose::nontrans op
   useFallback =
-      useFallback || !std::is_same_v<typename AViewType::memory_space,
-                                     Kokkos::Experimental::SYCLDeviceUSMSpace>;
+      useFallback || ((tolower(*trans) == 't' || tolower(*trans) == 'c') &&
+                      std::is_same_v<typename AViewType::memory_space,
+                                     Kokkos::Experimental::SYCLDeviceUSMSpace>);
 #endif
 #endif
 


### PR DESCRIPTION
Since onemkl does not support the transpose and conjugate mode at this point we should revert back to native implementation.