### PR TITLE
Sparse - SpMV: removing calls to unsuported oneapi - MKL functions

### DIFF
--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -281,7 +281,7 @@ void spmv(const ExecutionSpace& space, Handle* handle, const char mode[],
 #ifdef KOKKOS_ENABLE_SYCL
       if constexpr (std::is_same_v<ExecutionSpace,
                                    Kokkos::Experimental::SYCL>) {
-        useNative = useNative || (mode[0] == Conjugate[0]);
+        useNative = useNative || (mode[0] != NoTranspose[0]);
       }
 #endif
 #endif


### PR DESCRIPTION
Using native implementation for SYCL spmv if the mode is anything but transpose as the other modes are not implemented, at least in the onemkl we are testing with...