### PR TITLE
Implement batched serial pttrs

### DIFF
--- a/batched/dense/impl/KokkosBatched_Pttrs_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrs_Serial_Impl.hpp
@@ -25,22 +25,16 @@
 namespace KokkosBatched {
 
 template <typename DViewType, typename EViewType, typename BViewType>
-KOKKOS_INLINE_FUNCTION static int checkPttrsInput(
-    [[maybe_unused]] const DViewType &d, [[maybe_unused]] const EViewType &e,
-    [[maybe_unused]] const BViewType &b) {
-  static_assert(Kokkos::is_view_v<DViewType>,
-                "KokkosBatched::pttrs: DViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view_v<EViewType>,
-                "KokkosBatched::pttrs: EViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view_v<BViewType>,
-                "KokkosBatched::pttrs: BViewType is not a Kokkos::View.");
+KOKKOS_INLINE_FUNCTION static int checkPttrsInput([[maybe_unused]] const DViewType &d,
+                                                  [[maybe_unused]] const EViewType &e,
+                                                  [[maybe_unused]] const BViewType &b) {
+  static_assert(Kokkos::is_view_v<DViewType>, "KokkosBatched::pttrs: DViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view_v<EViewType>, "KokkosBatched::pttrs: EViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view_v<BViewType>, "KokkosBatched::pttrs: BViewType is not a Kokkos::View.");
 
-  static_assert(DViewType::rank == 1,
-                "KokkosBatched::pttrs: DViewType must have rank 1.");
-  static_assert(EViewType::rank == 1,
-                "KokkosBatched::pttrs: EViewType must have rank 1.");
-  static_assert(BViewType::rank == 1,
-                "KokkosBatched::pttrs: BViewType must have rank 1.");
+  static_assert(DViewType::rank == 1, "KokkosBatched::pttrs: DViewType must have rank 1.");
+  static_assert(EViewType::rank == 1, "KokkosBatched::pttrs: EViewType must have rank 1.");
+  static_assert(BViewType::rank == 1, "KokkosBatched::pttrs: BViewType must have rank 1.");
 
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
   const int nd  = d.extent(0);
@@ -71,9 +65,7 @@ KOKKOS_INLINE_FUNCTION static int checkPttrsInput(
 template <typename ArgUplo>
 struct SerialPttrs<ArgUplo, Algo::Pttrs::Unblocked> {
   template <typename DViewType, typename EViewType, typename BViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const DViewType &d,
-                                           const EViewType &e,
-                                           const BViewType &b) {
+  KOKKOS_INLINE_FUNCTION static int invoke(const DViewType &d, const EViewType &e, const BViewType &b) {
     // Quick return if possible
     if (d.extent(0) == 0) return 0;
 
@@ -90,8 +82,8 @@ struct SerialPttrs<ArgUplo, Algo::Pttrs::Unblocked> {
 
     // Solve A * X = B using the factorization A = L*D*L**T,
     // overwriting each right hand side vector with its solution.
-    return SerialPttrsInternal<ArgUplo, Algo::Pttrs::Unblocked>::invoke(
-        n, d.data(), d.stride(0), e.data(), e.stride(0), b.data(), b.stride(0));
+    return SerialPttrsInternal<ArgUplo, Algo::Pttrs::Unblocked>::invoke(n, d.data(), d.stride(0), e.data(), e.stride(0),
+                                                                        b.data(), b.stride(0));
   }
 };
 }  // namespace KokkosBatched

--- a/batched/dense/impl/KokkosBatched_Pttrs_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrs_Serial_Impl.hpp
@@ -1,0 +1,101 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+#ifndef KOKKOSBATCHED_PTTRS_SERIAL_IMPL_HPP_
+#define KOKKOSBATCHED_PTTRS_SERIAL_IMPL_HPP_
+
+#include <KokkosBatched_Util.hpp>
+#include <KokkosBlas1_scal.hpp>
+#include "KokkosBatched_Pttrs_Serial_Internal.hpp"
+
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+
+namespace KokkosBatched {
+
+template <typename DViewType, typename EViewType, typename BViewType>
+KOKKOS_INLINE_FUNCTION static int checkPttrsInput(
+    [[maybe_unused]] const DViewType &d, [[maybe_unused]] const EViewType &e,
+    [[maybe_unused]] const BViewType &b) {
+  static_assert(Kokkos::is_view<DViewType>::value,
+                "KokkosBatched::pttrs: DViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view<EViewType>::value,
+                "KokkosBatched::pttrs: EViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view<BViewType>::value,
+                "KokkosBatched::pttrs: BViewType is not a Kokkos::View.");
+
+  static_assert(DViewType::rank == 1,
+                "KokkosBatched::pttrs: DViewType must have rank 1.");
+  static_assert(EViewType::rank == 1,
+                "KokkosBatched::pttrs: EViewType must have rank 1.");
+  static_assert(BViewType::rank == 1,
+                "KokkosBatched::pttrs: BViewType must have rank 1.");
+
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+  const int nd  = d.extent(0);
+  const int ne  = e.extent(0);
+  const int ldb = b.extent(0);
+
+  if (ne + 1 != nd) {
+    Kokkos::printf(
+        "KokkosBatched::pttrs: Dimensions of d and e do not match: d: %d, e: "
+        "%d \n"
+        "e.extent(0) must be equal to d.extent(0) - 1\n",
+        nd, ne);
+    return 1;
+  }
+
+  if (ldb < Kokkos::max(1, nd)) {
+    Kokkos::printf(
+        "KokkosBatched::pttrs: Dimensions of d and b do not match: d: %d, b: "
+        "%d \n"
+        "b.extent(0) must be larger or equal to d.extent(0) \n",
+        ldb, nd);
+    return 1;
+  }
+#endif
+  return 0;
+}
+
+template <typename ArgUplo>
+struct SerialPttrs<ArgUplo, Algo::Pttrs::Unblocked> {
+  template <typename DViewType, typename EViewType, typename BViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const DViewType &d,
+                                           const EViewType &e,
+                                           const BViewType &b) {
+    // Quick return if possible
+    if (d.extent(0) == 0) return 0;
+
+    auto info = checkPttrsInput(d, e, b);
+    if (info) return info;
+
+    using ScalarType = typename DViewType::non_const_value_type;
+    int n            = d.extent(0);
+    int ldb          = b.extent(0);
+
+    if (n == 1) {
+      const ScalarType alpha = 1.0 / d(0);
+      return KokkosBlas::SerialScale::invoke(alpha, b);
+    }
+
+    // Solve A * X = B using the factorization A = L*D*L**T,
+    // overwriting each right hand side vector with its solution.
+    return SerialPttrsInternal<ArgUplo, Algo::Pttrs::Unblocked>::invoke(
+        n, d.data(), d.stride(0), e.data(), e.stride(0), b.data(), b.stride(0),
+        ldb);
+  }
+};
+}  // namespace KokkosBatched
+
+#endif  // KOKKOSBATCHED_PTTRS_SERIAL_IMPL_HPP_

--- a/batched/dense/impl/KokkosBatched_Pttrs_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrs_Serial_Impl.hpp
@@ -28,11 +28,11 @@ template <typename DViewType, typename EViewType, typename BViewType>
 KOKKOS_INLINE_FUNCTION static int checkPttrsInput(
     [[maybe_unused]] const DViewType &d, [[maybe_unused]] const EViewType &e,
     [[maybe_unused]] const BViewType &b) {
-  static_assert(Kokkos::is_view<DViewType>::value,
+  static_assert(Kokkos::is_view_v<DViewType>,
                 "KokkosBatched::pttrs: DViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<EViewType>::value,
+  static_assert(Kokkos::is_view_v<EViewType>,
                 "KokkosBatched::pttrs: EViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<BViewType>::value,
+  static_assert(Kokkos::is_view_v<BViewType>,
                 "KokkosBatched::pttrs: BViewType is not a Kokkos::View.");
 
   static_assert(DViewType::rank == 1,
@@ -82,7 +82,6 @@ struct SerialPttrs<ArgUplo, Algo::Pttrs::Unblocked> {
 
     using ScalarType = typename DViewType::non_const_value_type;
     int n            = d.extent(0);
-    int ldb          = b.extent(0);
 
     if (n == 1) {
       const ScalarType alpha = 1.0 / d(0);
@@ -92,8 +91,7 @@ struct SerialPttrs<ArgUplo, Algo::Pttrs::Unblocked> {
     // Solve A * X = B using the factorization A = L*D*L**T,
     // overwriting each right hand side vector with its solution.
     return SerialPttrsInternal<ArgUplo, Algo::Pttrs::Unblocked>::invoke(
-        n, d.data(), d.stride(0), e.data(), e.stride(0), b.data(), b.stride(0),
-        ldb);
+        n, d.data(), d.stride(0), e.data(), e.stride(0), b.data(), b.stride(0));
   }
 };
 }  // namespace KokkosBatched

--- a/batched/dense/impl/KokkosBatched_Pttrs_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrs_Serial_Internal.hpp
@@ -28,48 +28,25 @@ struct SerialPttrsInternal {
   KOKKOS_INLINE_FUNCTION static int invoke(
       const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0,
       const ValueType *KOKKOS_RESTRICT e, const int es0,
-      ValueType *KOKKOS_RESTRICT b, const int bs0, const int ldb);
+      ValueType *KOKKOS_RESTRICT b, const int bs0);
 
   template <typename ValueType>
   KOKKOS_INLINE_FUNCTION static int invoke(
       const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0,
       const Kokkos::complex<ValueType> *KOKKOS_RESTRICT e, const int es0,
-      Kokkos::complex<ValueType> *KOKKOS_RESTRICT b, const int bs0,
-      const int ldb);
+      Kokkos::complex<ValueType> *KOKKOS_RESTRICT b, const int bs0);
 };
 
 ///
 /// Real matrix
 ///
 
-template <>
+template <typename ArgUplo, typename AlgoType>
 template <typename ValueType>
-KOKKOS_INLINE_FUNCTION int
-SerialPttrsInternal<Uplo::Lower, Algo::Pttrs::Unblocked>::invoke(
+KOKKOS_INLINE_FUNCTION int SerialPttrsInternal<ArgUplo, AlgoType>::invoke(
     const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0,
     const ValueType *KOKKOS_RESTRICT e, const int es0,
-    ValueType *KOKKOS_RESTRICT b, const int bs0, const int ldb) {
-  // Solve A * X = B using the factorization L * D * L**T
-  for (int i = 1; i < n; i++) {
-    b[i * bs0] -= e[(i - 1) * es0] * b[(i - 1) * bs0];
-  }
-
-  b[(n - 1) * bs0] /= d[(n - 1) * ds0];
-
-  for (int i = n - 2; i >= 0; i--) {
-    b[i * bs0] = b[i * bs0] / d[i * ds0] - b[(i + 1) * bs0] * e[i * es0];
-  }
-
-  return 0;
-}
-
-template <>
-template <typename ValueType>
-KOKKOS_INLINE_FUNCTION int
-SerialPttrsInternal<Uplo::Upper, Algo::Pttrs::Unblocked>::invoke(
-    const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0,
-    const ValueType *KOKKOS_RESTRICT e, const int es0,
-    ValueType *KOKKOS_RESTRICT b, const int bs0, const int ldb) {
+    ValueType *KOKKOS_RESTRICT b, const int bs0) {
   // Solve A * X = B using the factorization L * D * L**T
   for (int i = 1; i < n; i++) {
     b[i * bs0] -= e[(i - 1) * es0] * b[(i - 1) * bs0];
@@ -88,37 +65,39 @@ SerialPttrsInternal<Uplo::Upper, Algo::Pttrs::Unblocked>::invoke(
 /// Complex matrix
 ///
 
-template <>
+template <typename ArgUplo, typename AlgoType>
 template <typename ValueType>
-KOKKOS_INLINE_FUNCTION int
-SerialPttrsInternal<Uplo::Lower, Algo::Pttrs::Unblocked>::invoke(
+KOKKOS_INLINE_FUNCTION int SerialPttrsInternal<ArgUplo, AlgoType>::invoke(
     const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0,
     const Kokkos::complex<ValueType> *KOKKOS_RESTRICT e, const int es0,
-    Kokkos::complex<ValueType> *KOKKOS_RESTRICT b, const int bs0,
-    const int ldb) {
+    Kokkos::complex<ValueType> *KOKKOS_RESTRICT b, const int bs0) {
   // Solve A * X = B using the factorization L * D * L**H
   for (int i = 1; i < n; i++) {
-    b[i * bs0] -= e[(i - 1) * es0] * b[(i - 1) * bs0];
+    auto tmp_e = std::is_same_v<ArgUplo, Uplo::Upper>
+                     ? Kokkos::conj(e[(i - 1) * es0])
+                     : e[(i - 1) * es0];
+    b[i * bs0] -= tmp_e * b[(i - 1) * bs0];
   }
 
   b[(n - 1) * bs0] /= d[(n - 1) * ds0];
 
   for (int i = n - 2; i >= 0; i--) {
-    b[i * bs0] =
-        b[i * bs0] / d[i * ds0] - b[(i + 1) * bs0] * Kokkos::conj(e[i * es0]);
+    auto tmp_e = std::is_same_v<ArgUplo, Uplo::Lower> ? Kokkos::conj(e[i * es0])
+                                                      : e[i * es0];
+    b[i * bs0] = b[i * bs0] / d[i * ds0] - b[(i + 1) * bs0] * tmp_e;
   }
 
   return 0;
 }
 
+/*
 template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int
 SerialPttrsInternal<Uplo::Upper, Algo::Pttrs::Unblocked>::invoke(
     const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0,
     const Kokkos::complex<ValueType> *KOKKOS_RESTRICT e, const int es0,
-    Kokkos::complex<ValueType> *KOKKOS_RESTRICT b, const int bs0,
-    const int ldb) {
+    Kokkos::complex<ValueType> *KOKKOS_RESTRICT b, const int bs0) {
   // Solve A * X = B using the factorization A = U**H * D * U
   for (int i = 1; i < n; i++) {
     b[i * bs0] -= Kokkos::conj(e[(i - 1) * es0]) * b[(i - 1) * bs0];
@@ -132,6 +111,7 @@ SerialPttrsInternal<Uplo::Upper, Algo::Pttrs::Unblocked>::invoke(
 
   return 0;
 }
+*/
 
 }  // namespace KokkosBatched
 

--- a/batched/dense/impl/KokkosBatched_Pttrs_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrs_Serial_Internal.hpp
@@ -1,0 +1,138 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+#ifndef KOKKOSBATCHED_PTTRS_SERIAL_INTERNAL_HPP_
+#define KOKKOSBATCHED_PTTRS_SERIAL_INTERNAL_HPP_
+
+#include <KokkosBatched_Util.hpp>
+
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+
+namespace KokkosBatched {
+
+template <typename ArgUplo, typename AlgoType>
+struct SerialPttrsInternal {
+  template <typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(
+      const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0,
+      const ValueType *KOKKOS_RESTRICT e, const int es0,
+      ValueType *KOKKOS_RESTRICT b, const int bs0, const int ldb);
+
+  template <typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(
+      const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0,
+      const Kokkos::complex<ValueType> *KOKKOS_RESTRICT e, const int es0,
+      Kokkos::complex<ValueType> *KOKKOS_RESTRICT b, const int bs0,
+      const int ldb);
+};
+
+///
+/// Real matrix
+///
+
+template <>
+template <typename ValueType>
+KOKKOS_INLINE_FUNCTION int
+SerialPttrsInternal<Uplo::Lower, Algo::Pttrs::Unblocked>::invoke(
+    const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0,
+    const ValueType *KOKKOS_RESTRICT e, const int es0,
+    ValueType *KOKKOS_RESTRICT b, const int bs0, const int ldb) {
+  // Solve A * X = B using the factorization L * D * L**T
+  for (int i = 1; i < n; i++) {
+    b[i * bs0] -= e[(i - 1) * es0] * b[(i - 1) * bs0];
+  }
+
+  b[(n - 1) * bs0] /= d[(n - 1) * ds0];
+
+  for (int i = n - 2; i >= 0; i--) {
+    b[i * bs0] = b[i * bs0] / d[i * ds0] - b[(i + 1) * bs0] * e[i * es0];
+  }
+
+  return 0;
+}
+
+template <>
+template <typename ValueType>
+KOKKOS_INLINE_FUNCTION int
+SerialPttrsInternal<Uplo::Upper, Algo::Pttrs::Unblocked>::invoke(
+    const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0,
+    const ValueType *KOKKOS_RESTRICT e, const int es0,
+    ValueType *KOKKOS_RESTRICT b, const int bs0, const int ldb) {
+  // Solve A * X = B using the factorization L * D * L**T
+  for (int i = 1; i < n; i++) {
+    b[i * bs0] -= e[(i - 1) * es0] * b[(i - 1) * bs0];
+  }
+
+  b[(n - 1) * bs0] /= d[(n - 1) * ds0];
+
+  for (int i = n - 2; i >= 0; i--) {
+    b[i * bs0] = b[i * bs0] / d[i * ds0] - b[(i + 1) * bs0] * e[i * es0];
+  }
+
+  return 0;
+}
+
+///
+/// Complex matrix
+///
+
+template <>
+template <typename ValueType>
+KOKKOS_INLINE_FUNCTION int
+SerialPttrsInternal<Uplo::Lower, Algo::Pttrs::Unblocked>::invoke(
+    const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0,
+    const Kokkos::complex<ValueType> *KOKKOS_RESTRICT e, const int es0,
+    Kokkos::complex<ValueType> *KOKKOS_RESTRICT b, const int bs0,
+    const int ldb) {
+  // Solve A * X = B using the factorization L * D * L**H
+  for (int i = 1; i < n; i++) {
+    b[i * bs0] -= e[(i - 1) * es0] * b[(i - 1) * bs0];
+  }
+
+  b[(n - 1) * bs0] /= d[(n - 1) * ds0];
+
+  for (int i = n - 2; i >= 0; i--) {
+    b[i * bs0] =
+        b[i * bs0] / d[i * ds0] - b[(i + 1) * bs0] * Kokkos::conj(e[i * es0]);
+  }
+
+  return 0;
+}
+
+template <>
+template <typename ValueType>
+KOKKOS_INLINE_FUNCTION int
+SerialPttrsInternal<Uplo::Upper, Algo::Pttrs::Unblocked>::invoke(
+    const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0,
+    const Kokkos::complex<ValueType> *KOKKOS_RESTRICT e, const int es0,
+    Kokkos::complex<ValueType> *KOKKOS_RESTRICT b, const int bs0,
+    const int ldb) {
+  // Solve A * X = B using the factorization A = U**H * D * U
+  for (int i = 1; i < n; i++) {
+    b[i * bs0] -= Kokkos::conj(e[(i - 1) * es0]) * b[(i - 1) * bs0];
+  }
+
+  b[(n - 1) * bs0] /= d[(n - 1) * ds0];
+
+  for (int i = n - 2; i >= 0; i--) {
+    b[i * bs0] = b[i * bs0] / d[i * ds0] - b[(i + 1) * bs0] * e[i * es0];
+  }
+
+  return 0;
+}
+
+}  // namespace KokkosBatched
+
+#endif  // KOKKOSBATCHED_PTTRS_SERIAL_INTERNAL_HPP_

--- a/batched/dense/impl/KokkosBatched_Pttrs_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrs_Serial_Internal.hpp
@@ -25,16 +25,14 @@ namespace KokkosBatched {
 template <typename ArgUplo, typename AlgoType>
 struct SerialPttrsInternal {
   template <typename ValueType>
-  KOKKOS_INLINE_FUNCTION static int invoke(
-      const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0,
-      const ValueType *KOKKOS_RESTRICT e, const int es0,
-      ValueType *KOKKOS_RESTRICT b, const int bs0);
+  KOKKOS_INLINE_FUNCTION static int invoke(const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0,
+                                           const ValueType *KOKKOS_RESTRICT e, const int es0,
+                                           ValueType *KOKKOS_RESTRICT b, const int bs0);
 
   template <typename ValueType>
-  KOKKOS_INLINE_FUNCTION static int invoke(
-      const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0,
-      const Kokkos::complex<ValueType> *KOKKOS_RESTRICT e, const int es0,
-      Kokkos::complex<ValueType> *KOKKOS_RESTRICT b, const int bs0);
+  KOKKOS_INLINE_FUNCTION static int invoke(const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0,
+                                           const Kokkos::complex<ValueType> *KOKKOS_RESTRICT e, const int es0,
+                                           Kokkos::complex<ValueType> *KOKKOS_RESTRICT b, const int bs0);
 };
 
 ///
@@ -44,8 +42,7 @@ struct SerialPttrsInternal {
 template <typename ArgUplo, typename AlgoType>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialPttrsInternal<ArgUplo, AlgoType>::invoke(
-    const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0,
-    const ValueType *KOKKOS_RESTRICT e, const int es0,
+    const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0, const ValueType *KOKKOS_RESTRICT e, const int es0,
     ValueType *KOKKOS_RESTRICT b, const int bs0) {
   // Solve A * X = B using the factorization L * D * L**T
   for (int i = 1; i < n; i++) {
@@ -68,50 +65,23 @@ KOKKOS_INLINE_FUNCTION int SerialPttrsInternal<ArgUplo, AlgoType>::invoke(
 template <typename ArgUplo, typename AlgoType>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialPttrsInternal<ArgUplo, AlgoType>::invoke(
-    const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0,
-    const Kokkos::complex<ValueType> *KOKKOS_RESTRICT e, const int es0,
-    Kokkos::complex<ValueType> *KOKKOS_RESTRICT b, const int bs0) {
+    const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0, const Kokkos::complex<ValueType> *KOKKOS_RESTRICT e,
+    const int es0, Kokkos::complex<ValueType> *KOKKOS_RESTRICT b, const int bs0) {
   // Solve A * X = B using the factorization L * D * L**H
   for (int i = 1; i < n; i++) {
-    auto tmp_e = std::is_same_v<ArgUplo, Uplo::Upper>
-                     ? Kokkos::conj(e[(i - 1) * es0])
-                     : e[(i - 1) * es0];
+    auto tmp_e = std::is_same_v<ArgUplo, Uplo::Upper> ? Kokkos::conj(e[(i - 1) * es0]) : e[(i - 1) * es0];
     b[i * bs0] -= tmp_e * b[(i - 1) * bs0];
   }
 
   b[(n - 1) * bs0] /= d[(n - 1) * ds0];
 
   for (int i = n - 2; i >= 0; i--) {
-    auto tmp_e = std::is_same_v<ArgUplo, Uplo::Lower> ? Kokkos::conj(e[i * es0])
-                                                      : e[i * es0];
+    auto tmp_e = std::is_same_v<ArgUplo, Uplo::Lower> ? Kokkos::conj(e[i * es0]) : e[i * es0];
     b[i * bs0] = b[i * bs0] / d[i * ds0] - b[(i + 1) * bs0] * tmp_e;
   }
 
   return 0;
 }
-
-/*
-template <>
-template <typename ValueType>
-KOKKOS_INLINE_FUNCTION int
-SerialPttrsInternal<Uplo::Upper, Algo::Pttrs::Unblocked>::invoke(
-    const int n, const ValueType *KOKKOS_RESTRICT d, const int ds0,
-    const Kokkos::complex<ValueType> *KOKKOS_RESTRICT e, const int es0,
-    Kokkos::complex<ValueType> *KOKKOS_RESTRICT b, const int bs0) {
-  // Solve A * X = B using the factorization A = U**H * D * U
-  for (int i = 1; i < n; i++) {
-    b[i * bs0] -= Kokkos::conj(e[(i - 1) * es0]) * b[(i - 1) * bs0];
-  }
-
-  b[(n - 1) * bs0] /= d[(n - 1) * ds0];
-
-  for (int i = n - 2; i >= 0; i--) {
-    b[i * bs0] = b[i * bs0] / d[i * ds0] - b[(i + 1) * bs0] * e[i * es0];
-  }
-
-  return 0;
-}
-*/
 
 }  // namespace KokkosBatched
 

--- a/batched/dense/src/KokkosBatched_Pttrs.hpp
+++ b/batched/dense/src/KokkosBatched_Pttrs.hpp
@@ -44,9 +44,7 @@ namespace KokkosBatched {
 template <typename ArgUplo, typename ArgAlgo>
 struct SerialPttrs {
   template <typename DViewType, typename EViewType, typename BViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const DViewType &d,
-                                           const EViewType &e,
-                                           const BViewType &b);
+  KOKKOS_INLINE_FUNCTION static int invoke(const DViewType &d, const EViewType &e, const BViewType &b);
 };
 
 }  // namespace KokkosBatched

--- a/batched/dense/src/KokkosBatched_Pttrs.hpp
+++ b/batched/dense/src/KokkosBatched_Pttrs.hpp
@@ -1,0 +1,56 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+#ifndef KOKKOSBATCHED_PTTRS_HPP_
+#define KOKKOSBATCHED_PTTRS_HPP_
+
+#include <KokkosBatched_Util.hpp>
+
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+
+namespace KokkosBatched {
+
+/// \brief Serial Batched Pttrs:
+/// Solve Ab_l x_l = b_l for all l = 0, ..., N
+///   using the factorization A = U**H * D * U or A = L * D * L**H computed by
+///   Pttrf.
+///
+/// \tparam DViewType: Input type for the a diagonal matrix, needs to be a 1D
+/// view
+/// \tparam EViewType: Input type for the a upper/lower diagonal matrix,
+/// needs to be a 1D view
+/// \tparam BViewType: Input type for the right-hand side and the solution,
+/// needs to be a 1D view
+///
+/// \param d [in]: n diagonal elements of the diagonal matrix D
+/// \param e [in]: n-1 upper/lower diagonal elements of the diagonal matrix E
+/// \param b [inout]: right-hand side and the solution, a rank 1 view
+///
+/// No nested parallel_for is used inside of the function.
+///
+
+template <typename ArgUplo, typename ArgAlgo>
+struct SerialPttrs {
+  template <typename DViewType, typename EViewType, typename BViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const DViewType &d,
+                                           const EViewType &e,
+                                           const BViewType &b);
+};
+
+}  // namespace KokkosBatched
+
+#include "KokkosBatched_Pttrs_Serial_Impl.hpp"
+
+#endif  // KOKKOSBATCHED_PTTRS_HPP_

--- a/batched/dense/unit_test/Test_Batched_Dense.hpp
+++ b/batched/dense/unit_test/Test_Batched_Dense.hpp
@@ -52,6 +52,9 @@
 #include "Test_Batched_SerialPttrf.hpp"
 #include "Test_Batched_SerialPttrf_Real.hpp"
 #include "Test_Batched_SerialPttrf_Complex.hpp"
+#include "Test_Batched_SerialPttrs.hpp"
+#include "Test_Batched_SerialPttrs_Real.hpp"
+#include "Test_Batched_SerialPttrs_Complex.hpp"
 
 // Team Kernels
 #include "Test_Batched_TeamAxpy.hpp"

--- a/batched/dense/unit_test/Test_Batched_SerialPttrs.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPttrs.hpp
@@ -1,0 +1,474 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
+
+#include "KokkosBatched_Util.hpp"
+#include "KokkosBatched_Pttrs.hpp"
+#include "Test_Batched_DenseUtils.hpp"
+
+using namespace KokkosBatched;
+
+namespace Test {
+namespace Pttrs {
+
+template <typename U>
+struct ParamTag {
+  using uplo = U;
+};
+
+template <typename DeviceType, typename DViewType, typename EViewType,
+          typename AlgoTagType>
+struct Functor_BatchedSerialPttrf {
+  using execution_space = typename DeviceType::execution_space;
+  DViewType _d;
+  EViewType _e;
+
+  KOKKOS_INLINE_FUNCTION
+  Functor_BatchedSerialPttrf(const DViewType &d, const EViewType &e)
+      : _d(d), _e(e) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int k) const {
+    auto dd = Kokkos::subview(_d, k, Kokkos::ALL());
+    auto ee = Kokkos::subview(_e, k, Kokkos::ALL());
+
+    KokkosBatched::SerialPttrf<AlgoTagType>::invoke(dd, ee);
+  }
+
+  inline void run() {
+    using value_type = typename EViewType::non_const_value_type;
+    std::string name_region("KokkosBatched::Test::SerialPttrs");
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    Kokkos::RangePolicy<execution_space> policy(0, _d.extent(0));
+    Kokkos::parallel_for(name.c_str(), policy, *this);
+  }
+};
+
+template <typename DeviceType, typename DViewType, typename EViewType,
+          typename BViewType, typename ParamTagType, typename AlgoTagType>
+struct Functor_BatchedSerialPttrs {
+  using execution_space = typename DeviceType::execution_space;
+  DViewType _d;
+  EViewType _e;
+  BViewType _b;
+
+  KOKKOS_INLINE_FUNCTION
+  Functor_BatchedSerialPttrs(const DViewType &d, const EViewType &e,
+                             const BViewType &b)
+      : _d(d), _e(e), _b(b) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const ParamTagType &, const int k, int &info) const {
+    auto dd = Kokkos::subview(_d, k, Kokkos::ALL());
+    auto ee = Kokkos::subview(_e, k, Kokkos::ALL());
+    auto bb = Kokkos::subview(_b, k, Kokkos::ALL());
+
+    info += KokkosBatched::SerialPttrs<typename ParamTagType::uplo,
+                                       AlgoTagType>::invoke(dd, ee, bb);
+  }
+
+  inline int run() {
+    using value_type = typename BViewType::non_const_value_type;
+    std::string name_region("KokkosBatched::Test::SerialPttrs");
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    int info_sum                      = 0;
+    Kokkos::Profiling::pushRegion(name.c_str());
+    Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, _d.extent(0));
+    Kokkos::parallel_reduce(name.c_str(), policy, *this, info_sum);
+    Kokkos::Profiling::popRegion();
+    return info_sum;
+  }
+};
+
+template <typename DeviceType, typename ScalarType, typename AViewType,
+          typename xViewType, typename yViewType>
+struct Functor_BatchedSerialGemv {
+  using execution_space = typename DeviceType::execution_space;
+  AViewType _a;
+  xViewType _x;
+  yViewType _y;
+  ScalarType _alpha, _beta;
+
+  KOKKOS_INLINE_FUNCTION
+  Functor_BatchedSerialGemv(const ScalarType alpha, const AViewType &a,
+                            const xViewType &x, const ScalarType beta,
+                            const yViewType &y)
+      : _a(a), _x(x), _y(y), _alpha(alpha), _beta(beta) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int k) const {
+    auto aa = Kokkos::subview(_a, k, Kokkos::ALL(), Kokkos::ALL());
+    auto xx = Kokkos::subview(_x, k, Kokkos::ALL());
+    auto yy = Kokkos::subview(_y, k, Kokkos::ALL());
+
+    KokkosBlas::SerialGemv<Trans::NoTranspose, Algo::Gemv::Unblocked>::invoke(
+        _alpha, aa, xx, _beta, yy);
+  }
+
+  inline void run() {
+    using value_type = typename AViewType::non_const_value_type;
+    std::string name_region("KokkosBatched::Test::SerialPttrs");
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    Kokkos::RangePolicy<execution_space> policy(0, _a.extent(0));
+    Kokkos::parallel_for(name.c_str(), policy, *this);
+  }
+};
+
+template <typename DeviceType, typename ScalarType, typename AViewType,
+          typename BViewType, typename CViewType, typename ArgTransB>
+struct Functor_BatchedSerialGemm {
+  using execution_space = typename DeviceType::execution_space;
+  AViewType _a;
+  BViewType _b;
+  CViewType _c;
+  ScalarType _alpha, _beta;
+
+  KOKKOS_INLINE_FUNCTION
+  Functor_BatchedSerialGemm(const ScalarType alpha, const AViewType &a,
+                            const BViewType &b, const ScalarType beta,
+                            const CViewType &c)
+      : _a(a), _b(b), _c(c), _alpha(alpha), _beta(beta) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int k) const {
+    auto aa = Kokkos::subview(_a, k, Kokkos::ALL(), Kokkos::ALL());
+    auto bb = Kokkos::subview(_b, k, Kokkos::ALL(), Kokkos::ALL());
+    auto cc = Kokkos::subview(_c, k, Kokkos::ALL(), Kokkos::ALL());
+
+    KokkosBatched::SerialGemm<Trans::NoTranspose, ArgTransB,
+                              Algo::Gemm::Unblocked>::invoke(_alpha, aa, bb,
+                                                             _beta, cc);
+  }
+
+  inline void run() {
+    using value_type = typename AViewType::non_const_value_type;
+    std::string name_region("KokkosBatched::Test::SerialPttrs");
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    Kokkos::RangePolicy<execution_space> policy(0, _a.extent(0));
+    Kokkos::parallel_for(name.c_str(), policy, *this);
+  }
+};
+
+template <typename DeviceType, typename ScalarType, typename LayoutType,
+          typename ParamTagType, typename AlgoTagType>
+/// \brief Implementation details of batched pttrs test
+///        Confirm A * x = b, where
+///        A: [[4, 1],
+///            [1, 4]]
+///        b: [1, 1]
+///        x: [1/5, 1/5]
+///
+///        This corresponds to the following system of equations:
+///        4 x0 +   x1 = 1
+///          x0 + 4 x1 = 1
+///
+/// \param N [in] Batch size of RHS (banded matrix can also be batched matrix)
+/// \param k [in] Number of superdiagonals or subdiagonals of matrix A
+/// \param BlkSize [in] Block size of matrix A
+void impl_test_batched_pttrs_analytical(const int N) {
+  using ats            = typename Kokkos::ArithTraits<ScalarType>;
+  using RealType       = typename ats::mag_type;
+  using RealView2DType = Kokkos::View<RealType **, LayoutType, DeviceType>;
+  using View2DType     = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
+
+  constexpr int BlkSize = 2;
+  RealView2DType d(Kokkos::view_alloc("d", Kokkos::WithoutInitializing), N,
+                   BlkSize);  // Diagonal components
+  View2DType e(Kokkos::view_alloc("e", Kokkos::WithoutInitializing), N,
+               BlkSize - 1);  // Upper and lower diagonal components (identical)
+  View2DType x(Kokkos::view_alloc("x", Kokkos::WithoutInitializing), N,
+               BlkSize);  // Solutions
+
+  Kokkos::deep_copy(d, RealType(4.0));
+  Kokkos::deep_copy(e, ScalarType(1.0));
+  Kokkos::deep_copy(x, ScalarType(1.0));  // This initialy stores b
+
+  // Factorize matrix A -> L * D * L**H
+  // d and e are updated by pttrf
+  Functor_BatchedSerialPttrf<DeviceType, RealView2DType, View2DType,
+                             AlgoTagType>(d, e)
+      .run();
+
+  // pttrs (Note, d and e must be factorized by pttrf)
+  auto info =
+      Functor_BatchedSerialPttrs<DeviceType, RealView2DType, View2DType,
+                                 View2DType, ParamTagType, AlgoTagType>(d, e, x)
+          .run();
+
+  Kokkos::fence();
+
+  EXPECT_EQ(info, 0);
+
+  // this eps is about 10^-14
+  RealType eps = 1.0e3 * ats::epsilon();
+
+  auto h_x = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), x);
+
+  // Check x = [1/5, 1/5]
+  for (int ib = 0; ib < N; ib++) {
+    for (int i = 0; i < BlkSize; i++) {
+      EXPECT_NEAR_KK(h_x(ib, i), ScalarType(1.0 / 5.0), eps);
+    }
+  }
+}
+
+template <typename DeviceType, typename ScalarType, typename LayoutType,
+          typename ParamTagType, typename AlgoTagType>
+/// \brief Implementation details of batched pttrs test
+///
+/// \param N [in] Batch size of RHS (banded matrix can also be batched matrix)
+/// \param k [in] Number of superdiagonals or subdiagonals of matrix A
+/// \param BlkSize [in] Block size of matrix A
+void impl_test_batched_pttrs(const int N, const int BlkSize) {
+  using ats            = typename Kokkos::ArithTraits<ScalarType>;
+  using RealType       = typename ats::mag_type;
+  using RealView2DType = Kokkos::View<RealType **, LayoutType, DeviceType>;
+  using View2DType     = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
+  using View3DType     = Kokkos::View<ScalarType ***, LayoutType, DeviceType>;
+
+  View3DType A("A", N, BlkSize, BlkSize), EL("EL", N, BlkSize, BlkSize),
+      EU("EU", N, BlkSize, BlkSize), D("D", N, BlkSize, BlkSize),
+      I("I", N, BlkSize, BlkSize);
+  RealView2DType d(Kokkos::view_alloc("d", Kokkos::WithoutInitializing), N,
+                   BlkSize),  // Diagonal components
+      ones(Kokkos::view_alloc("ones", Kokkos::WithoutInitializing), N, BlkSize);
+  View2DType e_upper("e_upper", N, BlkSize - 1),
+      e_lower("e_lower", N,
+              BlkSize - 1);  // upper and lower diagonal components
+  View2DType x("x", N, BlkSize), b_ref("x_ref", N, BlkSize),
+      b("b", N, BlkSize);  // Solutions
+
+  using execution_space = typename DeviceType::execution_space;
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
+  RealType realRandStart, realRandEnd;
+  ScalarType randStart, randEnd;
+
+  KokkosKernels::Impl::getRandomBounds(1.0, realRandStart, realRandEnd);
+  KokkosKernels::Impl::getRandomBounds(1.0, randStart, randEnd);
+
+  // Add BlkSize to ensure positive definiteness
+  Kokkos::fill_random(d, rand_pool, realRandStart + BlkSize,
+                      realRandEnd + BlkSize);
+  Kokkos::fill_random(e_upper, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(x, rand_pool, randStart, randEnd);
+
+  auto h_e_upper =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e_upper);
+  auto h_e_lower = Kokkos::create_mirror_view(e_lower);
+
+  for (int ib = 0; ib < N; ib++) {
+    for (int i = 0; i < BlkSize - 1; i++) {
+      // Fill the lower diagonal with conjugate of the upper diagonal
+      h_e_lower(ib, i) =
+          Kokkos::ArithTraits<ScalarType>::conj(h_e_upper(ib, i));
+    }
+  }
+
+  Kokkos::deep_copy(e_lower, h_e_lower);
+  Kokkos::deep_copy(b_ref, x);
+  Kokkos::deep_copy(ones, RealType(1.0));
+
+  // Reconstruct Tridiagonal matrix A
+  // A = D + EL + EU
+  create_diagonal_matrix(e_lower, EL, -1);
+  create_diagonal_matrix(e_upper, EU, 1);
+  create_diagonal_matrix(d, D);
+  create_diagonal_matrix(ones, I);
+
+  // Matrix matrix addition by Gemm
+  // D + EU by D * I + EU (result stored in EU)
+  Functor_BatchedSerialGemm<DeviceType, ScalarType, View3DType, View3DType,
+                            View3DType, Trans::NoTranspose>(1.0, D, I, 1.0, EU)
+      .run();
+
+  // Copy EL to A
+  Kokkos::deep_copy(A, EL);
+
+  // EU + EL by EU * I + A (result stored in A)
+  Functor_BatchedSerialGemm<DeviceType, ScalarType, View3DType, View3DType,
+                            View3DType, Trans::NoTranspose>(1.0, EU, I, 1.0, A)
+      .run();
+
+  Kokkos::fence();
+
+  int info = 0;
+  if (std::is_same_v<typename ParamTagType::uplo, KokkosBatched::Uplo::Upper>) {
+    // Factorize matrix A -> U**H * D * U
+    // d and e are updated by pttrf
+    Functor_BatchedSerialPttrf<DeviceType, RealView2DType, View2DType,
+                               AlgoTagType>(d, e_upper)
+        .run();
+
+    // pttrs (Note, d and e must be factorized by pttrf)
+    info = Functor_BatchedSerialPttrs<DeviceType, RealView2DType, View2DType,
+                                      View2DType, ParamTagType, AlgoTagType>(
+               d, e_upper, x)
+               .run();
+  } else {
+    // Factorize matrix A -> L * D * L**H
+    // d and e are updated by pttrf
+    Functor_BatchedSerialPttrf<DeviceType, RealView2DType, View2DType,
+                               AlgoTagType>(d, e_lower)
+        .run();
+
+    // pttrs (Note, d and e must be factorized by pttrf)
+    info = Functor_BatchedSerialPttrs<DeviceType, RealView2DType, View2DType,
+                                      View2DType, ParamTagType, AlgoTagType>(
+               d, e_lower, x)
+               .run();
+  }
+
+  Kokkos::fence();
+
+  EXPECT_EQ(info, 0);
+
+  // Gemv to compute b = A * x, this should be identical to b_ref
+  Functor_BatchedSerialGemv<DeviceType, ScalarType, View3DType, View2DType,
+                            View2DType>(1.0, A, x, 0.0, b)
+      .run();
+
+  // this eps is about 10^-14
+  RealType eps = 1.0e3 * ats::epsilon();
+
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_b_ref =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_ref);
+
+  // Check A * x = b_ref
+  for (int ib = 0; ib < N; ib++) {
+    for (int i = 0; i < BlkSize; i++) {
+      EXPECT_NEAR_KK(h_b(ib, i), h_b_ref(ib, i), eps);
+    }
+  }
+}
+
+template <typename DeviceType, typename ScalarType, typename LayoutType,
+          typename ParamTagType, typename AlgoTagType>
+/// \brief Implementation details of batched pttrs test for early return
+///        BlkSize must be 0 or 1
+///
+/// \param N [in] Batch size of RHS (banded matrix can also be batched matrix)
+/// \param k [in] Number of superdiagonals or subdiagonals of matrix A
+/// \param BlkSize [in] Block size of matrix A
+void impl_test_batched_pttrs_quick_return(const int N, const int BlkSize) {
+  using ats            = typename Kokkos::ArithTraits<ScalarType>;
+  using RealType       = typename ats::mag_type;
+  using RealView2DType = Kokkos::View<RealType **, LayoutType, DeviceType>;
+  using View2DType     = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
+
+  if (BlkSize > 1) return;
+
+  const int BlkSize_minus_1 = BlkSize > 0 ? BlkSize - 1 : 0;
+
+  RealView2DType d(Kokkos::view_alloc("d", Kokkos::WithoutInitializing), N,
+                   BlkSize);  // Diagonal components
+  View2DType e(Kokkos::view_alloc("e", Kokkos::WithoutInitializing), N,
+               BlkSize_minus_1);  // lower diagonal components
+  View2DType x("x", N, BlkSize);  // Solutions
+
+  const RealType reference_value = 4.0;
+
+  Kokkos::deep_copy(d, reference_value);
+  Kokkos::deep_copy(e, ScalarType(1.0));
+  Kokkos::deep_copy(x, ScalarType(1.0));
+
+  // Factorize matrix A -> U**H * D * U or L * D * L**H
+  // d and e are updated by pttrf
+  Functor_BatchedSerialPttrf<DeviceType, RealView2DType, View2DType,
+                             AlgoTagType>(d, e)
+      .run();
+
+  // pttrs (Note, d and e must be factorized by pttrf)
+  auto info =
+      Functor_BatchedSerialPttrs<DeviceType, RealView2DType, View2DType,
+                                 View2DType, ParamTagType, AlgoTagType>(d, e, x)
+          .run();
+
+  Kokkos::fence();
+
+  EXPECT_EQ(info, 0);
+
+  // this eps is about 10^-14
+  RealType eps = 1.0e3 * ats::epsilon();
+
+  auto h_x = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), x);
+
+  // Check x = x_ref
+  for (int ib = 0; ib < N; ib++) {
+    for (int i = 0; i < BlkSize; i++) {
+      EXPECT_NEAR_KK(h_x(ib, i), ScalarType(1.0 / reference_value), eps);
+    }
+  }
+}
+
+}  // namespace Pttrs
+}  // namespace Test
+
+template <typename DeviceType, typename ScalarType, typename ParamTagType,
+          typename AlgoTagType>
+int test_batched_pttrs() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
+  {
+    using LayoutType = Kokkos::LayoutLeft;
+    Test::Pttrs::impl_test_batched_pttrs_analytical<
+        DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1);
+    Test::Pttrs::impl_test_batched_pttrs_analytical<
+        DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2);
+    for (int i = 0; i < 2; i++) {
+      Test::Pttrs::impl_test_batched_pttrs_quick_return<
+          DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1, i);
+      Test::Pttrs::impl_test_batched_pttrs_quick_return<
+          DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2, i);
+    }
+    for (int i = 2; i < 10; i++) {
+      Test::Pttrs::impl_test_batched_pttrs<DeviceType, ScalarType, LayoutType,
+                                           ParamTagType, AlgoTagType>(1, i);
+      Test::Pttrs::impl_test_batched_pttrs<DeviceType, ScalarType, LayoutType,
+                                           ParamTagType, AlgoTagType>(2, i);
+    }
+  }
+#endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
+  {
+    using LayoutType = Kokkos::LayoutRight;
+    Test::Pttrs::impl_test_batched_pttrs_analytical<
+        DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1);
+    Test::Pttrs::impl_test_batched_pttrs_analytical<
+        DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2);
+    for (int i = 0; i < 2; i++) {
+      Test::Pttrs::impl_test_batched_pttrs_quick_return<
+          DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1, i);
+      Test::Pttrs::impl_test_batched_pttrs_quick_return<
+          DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2, i);
+    }
+    for (int i = 2; i < 10; i++) {
+      Test::Pttrs::impl_test_batched_pttrs<DeviceType, ScalarType, LayoutType,
+                                           ParamTagType, AlgoTagType>(1, i);
+      Test::Pttrs::impl_test_batched_pttrs<DeviceType, ScalarType, LayoutType,
+                                           ParamTagType, AlgoTagType>(2, i);
+    }
+  }
+#endif
+
+  return 0;
+}

--- a/batched/dense/unit_test/Test_Batched_SerialPttrs.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPttrs.hpp
@@ -32,16 +32,14 @@ struct ParamTag {
   using uplo = U;
 };
 
-template <typename DeviceType, typename DViewType, typename EViewType,
-          typename AlgoTagType>
+template <typename DeviceType, typename DViewType, typename EViewType, typename AlgoTagType>
 struct Functor_BatchedSerialPttrf {
   using execution_space = typename DeviceType::execution_space;
   DViewType _d;
   EViewType _e;
 
   KOKKOS_INLINE_FUNCTION
-  Functor_BatchedSerialPttrf(const DViewType &d, const EViewType &e)
-      : _d(d), _e(e) {}
+  Functor_BatchedSerialPttrf(const DViewType &d, const EViewType &e) : _d(d), _e(e) {}
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int k) const {
@@ -61,8 +59,8 @@ struct Functor_BatchedSerialPttrf {
   }
 };
 
-template <typename DeviceType, typename DViewType, typename EViewType,
-          typename BViewType, typename ParamTagType, typename AlgoTagType>
+template <typename DeviceType, typename DViewType, typename EViewType, typename BViewType, typename ParamTagType,
+          typename AlgoTagType>
 struct Functor_BatchedSerialPttrs {
   using execution_space = typename DeviceType::execution_space;
   DViewType _d;
@@ -70,9 +68,7 @@ struct Functor_BatchedSerialPttrs {
   BViewType _b;
 
   KOKKOS_INLINE_FUNCTION
-  Functor_BatchedSerialPttrs(const DViewType &d, const EViewType &e,
-                             const BViewType &b)
-      : _d(d), _e(e), _b(b) {}
+  Functor_BatchedSerialPttrs(const DViewType &d, const EViewType &e, const BViewType &b) : _d(d), _e(e), _b(b) {}
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const ParamTagType &, const int k, int &info) const {
@@ -80,8 +76,7 @@ struct Functor_BatchedSerialPttrs {
     auto ee = Kokkos::subview(_e, k, Kokkos::ALL());
     auto bb = Kokkos::subview(_b, k, Kokkos::ALL());
 
-    info += KokkosBatched::SerialPttrs<typename ParamTagType::uplo,
-                                       AlgoTagType>::invoke(dd, ee, bb);
+    info += KokkosBatched::SerialPttrs<typename ParamTagType::uplo, AlgoTagType>::invoke(dd, ee, bb);
   }
 
   inline int run() {
@@ -98,8 +93,7 @@ struct Functor_BatchedSerialPttrs {
   }
 };
 
-template <typename DeviceType, typename ScalarType, typename AViewType,
-          typename xViewType, typename yViewType>
+template <typename DeviceType, typename ScalarType, typename AViewType, typename xViewType, typename yViewType>
 struct Functor_BatchedSerialGemv {
   using execution_space = typename DeviceType::execution_space;
   AViewType _a;
@@ -108,8 +102,7 @@ struct Functor_BatchedSerialGemv {
   ScalarType _alpha, _beta;
 
   KOKKOS_INLINE_FUNCTION
-  Functor_BatchedSerialGemv(const ScalarType alpha, const AViewType &a,
-                            const xViewType &x, const ScalarType beta,
+  Functor_BatchedSerialGemv(const ScalarType alpha, const AViewType &a, const xViewType &x, const ScalarType beta,
                             const yViewType &y)
       : _a(a), _x(x), _y(y), _alpha(alpha), _beta(beta) {}
 
@@ -119,8 +112,7 @@ struct Functor_BatchedSerialGemv {
     auto xx = Kokkos::subview(_x, k, Kokkos::ALL());
     auto yy = Kokkos::subview(_y, k, Kokkos::ALL());
 
-    KokkosBlas::SerialGemv<Trans::NoTranspose, Algo::Gemv::Unblocked>::invoke(
-        _alpha, aa, xx, _beta, yy);
+    KokkosBlas::SerialGemv<Trans::NoTranspose, Algo::Gemv::Unblocked>::invoke(_alpha, aa, xx, _beta, yy);
   }
 
   inline void run() {
@@ -133,8 +125,8 @@ struct Functor_BatchedSerialGemv {
   }
 };
 
-template <typename DeviceType, typename ScalarType, typename AViewType,
-          typename BViewType, typename CViewType, typename ArgTransB>
+template <typename DeviceType, typename ScalarType, typename AViewType, typename BViewType, typename CViewType,
+          typename ArgTransB>
 struct Functor_BatchedSerialGemm {
   using execution_space = typename DeviceType::execution_space;
   AViewType _a;
@@ -143,8 +135,7 @@ struct Functor_BatchedSerialGemm {
   ScalarType _alpha, _beta;
 
   KOKKOS_INLINE_FUNCTION
-  Functor_BatchedSerialGemm(const ScalarType alpha, const AViewType &a,
-                            const BViewType &b, const ScalarType beta,
+  Functor_BatchedSerialGemm(const ScalarType alpha, const AViewType &a, const BViewType &b, const ScalarType beta,
                             const CViewType &c)
       : _a(a), _b(b), _c(c), _alpha(alpha), _beta(beta) {}
 
@@ -154,9 +145,7 @@ struct Functor_BatchedSerialGemm {
     auto bb = Kokkos::subview(_b, k, Kokkos::ALL(), Kokkos::ALL());
     auto cc = Kokkos::subview(_c, k, Kokkos::ALL(), Kokkos::ALL());
 
-    KokkosBatched::SerialGemm<Trans::NoTranspose, ArgTransB,
-                              Algo::Gemm::Unblocked>::invoke(_alpha, aa, bb,
-                                                             _beta, cc);
+    KokkosBatched::SerialGemm<Trans::NoTranspose, ArgTransB, Algo::Gemm::Unblocked>::invoke(_alpha, aa, bb, _beta, cc);
   }
 
   inline void run() {
@@ -169,8 +158,7 @@ struct Functor_BatchedSerialGemm {
   }
 };
 
-template <typename DeviceType, typename ScalarType, typename LayoutType,
-          typename ParamTagType, typename AlgoTagType>
+template <typename DeviceType, typename ScalarType, typename LayoutType, typename ParamTagType, typename AlgoTagType>
 /// \brief Implementation details of batched pttrs test
 ///        Confirm A * x = b, where
 ///        A: [[4, 1],
@@ -205,14 +193,11 @@ void impl_test_batched_pttrs_analytical(const int N) {
 
   // Factorize matrix A -> L * D * L**H
   // d and e are updated by pttrf
-  Functor_BatchedSerialPttrf<DeviceType, RealView2DType, View2DType,
-                             AlgoTagType>(d, e)
-      .run();
+  Functor_BatchedSerialPttrf<DeviceType, RealView2DType, View2DType, AlgoTagType>(d, e).run();
 
   // pttrs (Note, d and e must be factorized by pttrf)
   auto info =
-      Functor_BatchedSerialPttrs<DeviceType, RealView2DType, View2DType,
-                                 View2DType, ParamTagType, AlgoTagType>(d, e, x)
+      Functor_BatchedSerialPttrs<DeviceType, RealView2DType, View2DType, View2DType, ParamTagType, AlgoTagType>(d, e, x)
           .run();
 
   Kokkos::fence();
@@ -232,8 +217,7 @@ void impl_test_batched_pttrs_analytical(const int N) {
   }
 }
 
-template <typename DeviceType, typename ScalarType, typename LayoutType,
-          typename ParamTagType, typename AlgoTagType>
+template <typename DeviceType, typename ScalarType, typename LayoutType, typename ParamTagType, typename AlgoTagType>
 /// \brief Implementation details of batched pttrs test
 ///
 /// \param N [in] Batch size of RHS (banded matrix can also be batched matrix)
@@ -246,17 +230,14 @@ void impl_test_batched_pttrs(const int N, const int BlkSize) {
   using View2DType     = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
   using View3DType     = Kokkos::View<ScalarType ***, LayoutType, DeviceType>;
 
-  View3DType A("A", N, BlkSize, BlkSize), EL("EL", N, BlkSize, BlkSize),
-      EU("EU", N, BlkSize, BlkSize), D("D", N, BlkSize, BlkSize),
-      I("I", N, BlkSize, BlkSize);
+  View3DType A("A", N, BlkSize, BlkSize), EL("EL", N, BlkSize, BlkSize), EU("EU", N, BlkSize, BlkSize),
+      D("D", N, BlkSize, BlkSize), I("I", N, BlkSize, BlkSize);
   RealView2DType d(Kokkos::view_alloc("d", Kokkos::WithoutInitializing), N,
                    BlkSize),  // Diagonal components
       ones(Kokkos::view_alloc("ones", Kokkos::WithoutInitializing), N, BlkSize);
-  View2DType e_upper("e_upper", N, BlkSize - 1),
-      e_lower("e_lower", N,
-              BlkSize - 1);  // upper and lower diagonal components
-  View2DType x("x", N, BlkSize), b_ref("x_ref", N, BlkSize),
-      b("b", N, BlkSize);  // Solutions
+  View2DType e_upper("e_upper", N, BlkSize - 1), e_lower("e_lower", N,
+                                                         BlkSize - 1);            // upper and lower diagonal components
+  View2DType x("x", N, BlkSize), b_ref("x_ref", N, BlkSize), b("b", N, BlkSize);  // Solutions
 
   using execution_space = typename DeviceType::execution_space;
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
@@ -267,20 +248,17 @@ void impl_test_batched_pttrs(const int N, const int BlkSize) {
   KokkosKernels::Impl::getRandomBounds(1.0, randStart, randEnd);
 
   // Add BlkSize to ensure positive definiteness
-  Kokkos::fill_random(d, rand_pool, realRandStart + BlkSize,
-                      realRandEnd + BlkSize);
+  Kokkos::fill_random(d, rand_pool, realRandStart + BlkSize, realRandEnd + BlkSize);
   Kokkos::fill_random(e_upper, rand_pool, randStart, randEnd);
   Kokkos::fill_random(x, rand_pool, randStart, randEnd);
 
-  auto h_e_upper =
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e_upper);
+  auto h_e_upper = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), e_upper);
   auto h_e_lower = Kokkos::create_mirror_view(e_lower);
 
   for (int ib = 0; ib < N; ib++) {
     for (int i = 0; i < BlkSize - 1; i++) {
       // Fill the lower diagonal with conjugate of the upper diagonal
-      h_e_lower(ib, i) =
-          Kokkos::ArithTraits<ScalarType>::conj(h_e_upper(ib, i));
+      h_e_lower(ib, i) = Kokkos::ArithTraits<ScalarType>::conj(h_e_upper(ib, i));
     }
   }
 
@@ -297,16 +275,16 @@ void impl_test_batched_pttrs(const int N, const int BlkSize) {
 
   // Matrix matrix addition by Gemm
   // D + EU by D * I + EU (result stored in EU)
-  Functor_BatchedSerialGemm<DeviceType, ScalarType, View3DType, View3DType,
-                            View3DType, Trans::NoTranspose>(1.0, D, I, 1.0, EU)
+  Functor_BatchedSerialGemm<DeviceType, ScalarType, View3DType, View3DType, View3DType, Trans::NoTranspose>(1.0, D, I,
+                                                                                                            1.0, EU)
       .run();
 
   // Copy EL to A
   Kokkos::deep_copy(A, EL);
 
   // EU + EL by EU * I + A (result stored in A)
-  Functor_BatchedSerialGemm<DeviceType, ScalarType, View3DType, View3DType,
-                            View3DType, Trans::NoTranspose>(1.0, EU, I, 1.0, A)
+  Functor_BatchedSerialGemm<DeviceType, ScalarType, View3DType, View3DType, View3DType, Trans::NoTranspose>(1.0, EU, I,
+                                                                                                            1.0, A)
       .run();
 
   Kokkos::fence();
@@ -315,25 +293,19 @@ void impl_test_batched_pttrs(const int N, const int BlkSize) {
   if (std::is_same_v<typename ParamTagType::uplo, KokkosBatched::Uplo::Upper>) {
     // Factorize matrix A -> U**H * D * U
     // d and e are updated by pttrf
-    Functor_BatchedSerialPttrf<DeviceType, RealView2DType, View2DType,
-                               AlgoTagType>(d, e_upper)
-        .run();
+    Functor_BatchedSerialPttrf<DeviceType, RealView2DType, View2DType, AlgoTagType>(d, e_upper).run();
 
     // pttrs (Note, d and e must be factorized by pttrf)
-    info = Functor_BatchedSerialPttrs<DeviceType, RealView2DType, View2DType,
-                                      View2DType, ParamTagType, AlgoTagType>(
+    info = Functor_BatchedSerialPttrs<DeviceType, RealView2DType, View2DType, View2DType, ParamTagType, AlgoTagType>(
                d, e_upper, x)
                .run();
   } else {
     // Factorize matrix A -> L * D * L**H
     // d and e are updated by pttrf
-    Functor_BatchedSerialPttrf<DeviceType, RealView2DType, View2DType,
-                               AlgoTagType>(d, e_lower)
-        .run();
+    Functor_BatchedSerialPttrf<DeviceType, RealView2DType, View2DType, AlgoTagType>(d, e_lower).run();
 
     // pttrs (Note, d and e must be factorized by pttrf)
-    info = Functor_BatchedSerialPttrs<DeviceType, RealView2DType, View2DType,
-                                      View2DType, ParamTagType, AlgoTagType>(
+    info = Functor_BatchedSerialPttrs<DeviceType, RealView2DType, View2DType, View2DType, ParamTagType, AlgoTagType>(
                d, e_lower, x)
                .run();
   }
@@ -343,16 +315,13 @@ void impl_test_batched_pttrs(const int N, const int BlkSize) {
   EXPECT_EQ(info, 0);
 
   // Gemv to compute b = A * x, this should be identical to b_ref
-  Functor_BatchedSerialGemv<DeviceType, ScalarType, View3DType, View2DType,
-                            View2DType>(1.0, A, x, 0.0, b)
-      .run();
+  Functor_BatchedSerialGemv<DeviceType, ScalarType, View3DType, View2DType, View2DType>(1.0, A, x, 0.0, b).run();
 
   // this eps is about 10^-14
   RealType eps = 1.0e3 * ats::epsilon();
 
-  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
-  auto h_b_ref =
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_ref);
+  auto h_b     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+  auto h_b_ref = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_ref);
 
   // Check A * x = b_ref
   for (int ib = 0; ib < N; ib++) {
@@ -362,8 +331,7 @@ void impl_test_batched_pttrs(const int N, const int BlkSize) {
   }
 }
 
-template <typename DeviceType, typename ScalarType, typename LayoutType,
-          typename ParamTagType, typename AlgoTagType>
+template <typename DeviceType, typename ScalarType, typename LayoutType, typename ParamTagType, typename AlgoTagType>
 /// \brief Implementation details of batched pttrs test for early return
 ///        BlkSize must be 0 or 1
 ///
@@ -394,14 +362,11 @@ void impl_test_batched_pttrs_quick_return(const int N, const int BlkSize) {
 
   // Factorize matrix A -> U**H * D * U or L * D * L**H
   // d and e are updated by pttrf
-  Functor_BatchedSerialPttrf<DeviceType, RealView2DType, View2DType,
-                             AlgoTagType>(d, e)
-      .run();
+  Functor_BatchedSerialPttrf<DeviceType, RealView2DType, View2DType, AlgoTagType>(d, e).run();
 
   // pttrs (Note, d and e must be factorized by pttrf)
   auto info =
-      Functor_BatchedSerialPttrs<DeviceType, RealView2DType, View2DType,
-                                 View2DType, ParamTagType, AlgoTagType>(d, e, x)
+      Functor_BatchedSerialPttrs<DeviceType, RealView2DType, View2DType, View2DType, ParamTagType, AlgoTagType>(d, e, x)
           .run();
 
   Kokkos::fence();
@@ -424,48 +389,39 @@ void impl_test_batched_pttrs_quick_return(const int N, const int BlkSize) {
 }  // namespace Pttrs
 }  // namespace Test
 
-template <typename DeviceType, typename ScalarType, typename ParamTagType,
-          typename AlgoTagType>
+template <typename DeviceType, typename ScalarType, typename ParamTagType, typename AlgoTagType>
 int test_batched_pttrs() {
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
   {
     using LayoutType = Kokkos::LayoutLeft;
-    Test::Pttrs::impl_test_batched_pttrs_analytical<
-        DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1);
-    Test::Pttrs::impl_test_batched_pttrs_analytical<
-        DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2);
+    Test::Pttrs::impl_test_batched_pttrs_analytical<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1);
+    Test::Pttrs::impl_test_batched_pttrs_analytical<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2);
     for (int i = 0; i < 2; i++) {
-      Test::Pttrs::impl_test_batched_pttrs_quick_return<
-          DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1, i);
-      Test::Pttrs::impl_test_batched_pttrs_quick_return<
-          DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2, i);
+      Test::Pttrs::impl_test_batched_pttrs_quick_return<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(
+          1, i);
+      Test::Pttrs::impl_test_batched_pttrs_quick_return<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(
+          2, i);
     }
     for (int i = 2; i < 10; i++) {
-      Test::Pttrs::impl_test_batched_pttrs<DeviceType, ScalarType, LayoutType,
-                                           ParamTagType, AlgoTagType>(1, i);
-      Test::Pttrs::impl_test_batched_pttrs<DeviceType, ScalarType, LayoutType,
-                                           ParamTagType, AlgoTagType>(2, i);
+      Test::Pttrs::impl_test_batched_pttrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1, i);
+      Test::Pttrs::impl_test_batched_pttrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2, i);
     }
   }
 #endif
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
   {
     using LayoutType = Kokkos::LayoutRight;
-    Test::Pttrs::impl_test_batched_pttrs_analytical<
-        DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1);
-    Test::Pttrs::impl_test_batched_pttrs_analytical<
-        DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2);
+    Test::Pttrs::impl_test_batched_pttrs_analytical<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1);
+    Test::Pttrs::impl_test_batched_pttrs_analytical<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2);
     for (int i = 0; i < 2; i++) {
-      Test::Pttrs::impl_test_batched_pttrs_quick_return<
-          DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1, i);
-      Test::Pttrs::impl_test_batched_pttrs_quick_return<
-          DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2, i);
+      Test::Pttrs::impl_test_batched_pttrs_quick_return<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(
+          1, i);
+      Test::Pttrs::impl_test_batched_pttrs_quick_return<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(
+          2, i);
     }
     for (int i = 2; i < 10; i++) {
-      Test::Pttrs::impl_test_batched_pttrs<DeviceType, ScalarType, LayoutType,
-                                           ParamTagType, AlgoTagType>(1, i);
-      Test::Pttrs::impl_test_batched_pttrs<DeviceType, ScalarType, LayoutType,
-                                           ParamTagType, AlgoTagType>(2, i);
+      Test::Pttrs::impl_test_batched_pttrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1, i);
+      Test::Pttrs::impl_test_batched_pttrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2, i);
     }
   }
 #endif

--- a/batched/dense/unit_test/Test_Batched_SerialPttrs_Complex.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPttrs_Complex.hpp
@@ -1,0 +1,47 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_FLOAT)
+TEST_F(TestCategory, test_batched_pttrs_l_fcomplex) {
+  using algo_tag_type  = typename Algo::Pttrs::Unblocked;
+  using param_tag_type = ::Test::Pttrs::ParamTag<Uplo::Lower>;
+
+  test_batched_pttrs<TestDevice, Kokkos::complex<float>, param_tag_type,
+                     algo_tag_type>();
+}
+TEST_F(TestCategory, test_batched_pttrs_u_fcomplex) {
+  using algo_tag_type  = typename Algo::Pttrs::Unblocked;
+  using param_tag_type = ::Test::Pttrs::ParamTag<Uplo::Upper>;
+  test_batched_pttrs<TestDevice, Kokkos::complex<float>, param_tag_type,
+                     algo_tag_type>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
+TEST_F(TestCategory, test_batched_pttrs_l_dcomplex) {
+  using algo_tag_type  = typename Algo::Pttrs::Unblocked;
+  using param_tag_type = ::Test::Pttrs::ParamTag<Uplo::Lower>;
+
+  test_batched_pttrs<TestDevice, Kokkos::complex<double>, param_tag_type,
+                     algo_tag_type>();
+}
+TEST_F(TestCategory, test_batched_pttrs_u_dcomplex) {
+  using algo_tag_type  = typename Algo::Pttrs::Unblocked;
+  using param_tag_type = ::Test::Pttrs::ParamTag<Uplo::Upper>;
+  test_batched_pttrs<TestDevice, Kokkos::complex<double>, param_tag_type,
+                     algo_tag_type>();
+}
+#endif

--- a/batched/dense/unit_test/Test_Batched_SerialPttrs_Complex.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPttrs_Complex.hpp
@@ -19,14 +19,12 @@ TEST_F(TestCategory, test_batched_pttrs_l_fcomplex) {
   using algo_tag_type  = typename Algo::Pttrs::Unblocked;
   using param_tag_type = ::Test::Pttrs::ParamTag<Uplo::Lower>;
 
-  test_batched_pttrs<TestDevice, Kokkos::complex<float>, param_tag_type,
-                     algo_tag_type>();
+  test_batched_pttrs<TestDevice, Kokkos::complex<float>, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, test_batched_pttrs_u_fcomplex) {
   using algo_tag_type  = typename Algo::Pttrs::Unblocked;
   using param_tag_type = ::Test::Pttrs::ParamTag<Uplo::Upper>;
-  test_batched_pttrs<TestDevice, Kokkos::complex<float>, param_tag_type,
-                     algo_tag_type>();
+  test_batched_pttrs<TestDevice, Kokkos::complex<float>, param_tag_type, algo_tag_type>();
 }
 #endif
 
@@ -35,13 +33,11 @@ TEST_F(TestCategory, test_batched_pttrs_l_dcomplex) {
   using algo_tag_type  = typename Algo::Pttrs::Unblocked;
   using param_tag_type = ::Test::Pttrs::ParamTag<Uplo::Lower>;
 
-  test_batched_pttrs<TestDevice, Kokkos::complex<double>, param_tag_type,
-                     algo_tag_type>();
+  test_batched_pttrs<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, test_batched_pttrs_u_dcomplex) {
   using algo_tag_type  = typename Algo::Pttrs::Unblocked;
   using param_tag_type = ::Test::Pttrs::ParamTag<Uplo::Upper>;
-  test_batched_pttrs<TestDevice, Kokkos::complex<double>, param_tag_type,
-                     algo_tag_type>();
+  test_batched_pttrs<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
 }
 #endif

--- a/batched/dense/unit_test/Test_Batched_SerialPttrs_Real.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPttrs_Real.hpp
@@ -1,0 +1,43 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+TEST_F(TestCategory, test_batched_pttrs_l_float) {
+  using algo_tag_type  = typename Algo::Pttrs::Unblocked;
+  using param_tag_type = ::Test::Pttrs::ParamTag<Uplo::Lower>;
+
+  test_batched_pttrs<TestDevice, float, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, test_batched_pttrs_u_float) {
+  using algo_tag_type  = typename Algo::Pttrs::Unblocked;
+  using param_tag_type = ::Test::Pttrs::ParamTag<Uplo::Upper>;
+  test_batched_pttrs<TestDevice, float, param_tag_type, algo_tag_type>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+TEST_F(TestCategory, test_batched_pttrs_l_double) {
+  using algo_tag_type  = typename Algo::Pttrs::Unblocked;
+  using param_tag_type = ::Test::Pttrs::ParamTag<Uplo::Lower>;
+
+  test_batched_pttrs<TestDevice, double, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, test_batched_pttrs_u_double) {
+  using algo_tag_type  = typename Algo::Pttrs::Unblocked;
+  using param_tag_type = ::Test::Pttrs::ParamTag<Uplo::Upper>;
+  test_batched_pttrs<TestDevice, double, param_tag_type, algo_tag_type>();
+}
+#endif

--- a/blas/impl/KokkosBlas_util.hpp
+++ b/blas/impl/KokkosBlas_util.hpp
@@ -86,6 +86,7 @@ struct Algo {
   using QR        = Level3;
   using UTV       = Level3;
   using Pttrf     = Level3;
+  using Pttrs     = Level3;
 
   struct Level2 {
     struct Unblocked {};


### PR DESCRIPTION
This PR implements [pttrs](https://www.netlib.org/lapack//explore-html/d9/dc9/group__pttrs_ga969bdf7ff1290319fa68fd84b2bc2928.html) function.

Following files are added:
1. `KokkosBatched_Pttrs_Serial_Impl.hpp`: Internal interfaces
2. `KokkosBatched_Pttrs_Serial_Internal.hpp`: Implementation details
3. `KokkosBatched_Pttrs.hpp`: APIs
4. `Test_Batched_SerialPttrs.hpp`: Unit tests for that

## Detailed description

It solves the equation `A * x = b`, where `A` is a real symmetric (complex Hermitian) positive definite tridiagonal matrix `A`, represented by vectors `D` and `E`. 
Before solving the factorization `A = U**H * D * U` or `A = L * D * L**H` must be computed by Pttrf.

Here, the matrix has the following shape.
- `D`: `(batch_count, n)`  
   On entry, the `n` diagonal elements of the tridiagonal matrix
   `A`. On exit, the `n` diagonal elements of the diagonal matrix
   `D` from the `L*D*L**T` factorization of `A`.
- `E`: `(batch_count, n-1)`  
   On entry, the `n-1` subdiagonal elements of the tridiagonal matrix
   `A`. On exit, the `n-1` subdiagonal elements of the
   unit bidiagonal factor `L` from the `L*D*L**T` factorization of `A`.
   `E` can also be regarded as the superdiagonal of the unit
   bidiagonal factor `U` from the `U**T*D*U` factorization of `A`.
- `B`: `(batch_count, n)`  
   On entry, it contains the n element `n` right-hand side vector `b`. On exit, the solution vectors `x`.


Example of a single batch of matrix A `n = 10`. In this case, `D` is a length `n` array filled with 4 and `E` is a length `n-1` array filled with 1.

```bash
A
4 1 0 0 0 0 0 0 0 0 
1 4 1 0 0 0 0 0 0 0 
0 1 4 1 0 0 0 0 0 0 
0 0 1 4 1 0 0 0 0 0 
0 0 0 1 4 1 0 0 0 0 
0 0 0 0 1 4 1 0 0 0 
0 0 0 0 0 1 4 1 0 0 
0 0 0 0 0 0 1 4 1 0 
0 0 0 0 0 0 0 1 4 1 
0 0 0 0 0 0 0 0 1 4

D
4 4 4 4 4 4 4 4 4 4

E
1 1 1 1 1 1 1 1 1
```

Parallelization would be made in the following manner. This is efficient only when 
A is given in `LayoutLeft` for GPUs and `LayoutRight` for CPUs (parallelized over batch direction).

```C++
Kokkos::parallel_for('pttrs', 
    Kokkos::RangePolicy<execution_space> policy(0, n),
    [=](const int k) {
        auto dd = Kokkos::subview(_d, k, Kokkos::ALL());
        auto ee = Kokkos::subview(_e, k, Kokkos::ALL());
        auto bb = Kokkos::subview(_b, k, Kokkos::ALL());

        KokkosBatched::SerialPttrs<Uplo::Lower, AlgoTagType>::invoke(dd, ee, bb);
    });
```

## Tests

1.  Simple and small analytical test to solve the following system of equations using `pttrf` and `pttrs`. Check if `x = (1/5, 1/5)`.

    ```bash
    4 x0 +   x1 = 1
      x0 + 4 x1 = 1

    (x0, x1) = (1/5, 1/5)
    ``` 

2.  Make a real (complex Hermitian) symmetric positive definite tridiagonal matrix `A` from random `D` and `E` for `n >= 2`.
Then, factorize `D` and `E` with `pttrf` to get `L` and `D` which satisfies `A = L * D * L**T` (`A = L * D * L**H`).
Then, solve `A * x = b` with `pttrs` to get `x`, while keeping a copy of `b` as a reference.
Finally, check if `A * x = b` is satisfied.

1.  Quick return test for `n = 0` and `n = 1`. Solve `A * x = b` with `pttrf` and `pttrs`. Confirm that `x = b / A(0, 0)` is satisfied for `n = 1`. For `n = 0`, it is confirmed that `info` returns `0`.
