### PR TITLE
Add big reformat commits to ignore revs for blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -15,3 +15,5 @@
 #  git blame --ignore-revs-file=.git-blame-ignore-revs $file
 #
 # List skips here:
+985c3a9e7343c2f612560024cae4d968f800c8ac
+0ffb820881335beb0e78463c19988a0c61044705


### PR DESCRIPTION
Now that we know what the sha is for the recent big reformat, we can add it to the skip list. I also added Evan's old commit that was also a big reformat commit.