### PR TITLE
Make sure clang is using a newer GCC on weaver

### DIFF
--- a/scripts/cm_test_all_sandia
+++ b/scripts/cm_test_all_sandia
@@ -593,7 +593,7 @@ elif [ "$MACHINE" = "weaver" ]; then
   SKIP_HWLOC=True
 
   GCC93_MODULE_TPL_LIST="cmake/3.23.1,<COMPILER_NAME>/<COMPILER_VERSION>,openblas/0.3.20/gcc/9.3.0,gcc/9.3.0"
-  CLANG13_MODULE_TPL_LIST="cmake/3.23.1,<COMPILER_NAME>/<COMPILER_VERSION>,openblas/0.3.20/gcc/9.3.0,cuda/10.1.243"
+  CLANG13_MODULE_TPL_LIST="cmake/3.23.1,<COMPILER_NAME>/<COMPILER_VERSION>,openblas/0.3.20/gcc/9.3.0,cuda/10.1.243,gcc/9.3.0"
 
   BASE_MODULE_LIST="cmake/3.23.1,<COMPILER_NAME>/<COMPILER_VERSION>"
   # Cuda/11 modules available rhel8 queue (rhel8 OS); gcc/8.3.1 load by default


### PR DESCRIPTION
It's clear from the name of the AT job GCC930_Light_Tpls_GCC930_Tpls_CLANG13CUDA10 that the intent was to use gcc-9.3 but gcc-7.4.0 was the one actually being used because the clang-13 module loads that gcc.

Before this PR:
```
% source reload_modules.sh 
% module list

Currently Loaded Modules:
  1) cmake/3.23.1   2) binutils/2.30.0   3) gcc/7.4.0   4) clang/13.0.0   5) openblas/0.3.20/gcc/9.3.0   6) cuda/10.1.243
```

After this PR:
```
% source reload_modules.sh 
% module list

Currently Loaded Modules:
  1) cmake/3.23.1   2) clang/13.0.0   3) openblas/0.3.20/gcc/9.3.0   4) cuda/10.1.243   5) binutils/2.30.0   6) gcc/9.3.0
```

Even better news, this change fixes that sptrsv test that has been driving me crazy!