### PR TITLE
Sparse - coo2csr: deactivating test on PVC

### DIFF
--- a/sparse/unit_test/Test_Sparse_coo2crs.hpp
+++ b/sparse/unit_test/Test_Sparse_coo2crs.hpp
@@ -214,6 +214,11 @@ void doAllCoo2Crs(size_t m, size_t n) {
 }
 
 TEST_F(TestCategory, sparse_coo2crs) {
+  if constexpr (std::is_same_v<typename TestDevice::execution_space, Kokkos::Experimental::SYCL>) {
+    std::cout << "Not running coo2csr on SYCL execution space" << std::endl;
+    return;
+  }
+
   uint64_t ticks = std::chrono::high_resolution_clock::now().time_since_epoch().count() % UINT32_MAX;
   std::srand(ticks);
 
@@ -241,6 +246,11 @@ TEST_F(TestCategory, sparse_coo2crs) {
 }
 
 TEST_F(TestCategory, sparse_coo2crs_staticMatrix_edgeCases) {
+  if constexpr (std::is_same_v<typename TestDevice::execution_space, Kokkos::Experimental::SYCL>) {
+    std::cout << "Not running coo2csr on SYCL execution space" << std::endl;
+    return;
+  }
+
   int m = 4;
   int n = 4;
   long long staticRow[16]{0, 1, 3, 2, 3, 2, 2, 2, 0, 0, 0, 1, 2, 0, 3, 0};

--- a/sparse/unit_test/Test_Sparse_coo2crs.hpp
+++ b/sparse/unit_test/Test_Sparse_coo2crs.hpp
@@ -214,10 +214,12 @@ void doAllCoo2Crs(size_t m, size_t n) {
 }
 
 TEST_F(TestCategory, sparse_coo2crs) {
+#if defined(KOKKOS_ENABLE_SYCL)
   if constexpr (std::is_same_v<typename TestDevice::execution_space, Kokkos::Experimental::SYCL>) {
     std::cout << "Not running coo2csr on SYCL execution space" << std::endl;
     return;
   }
+#endif
 
   uint64_t ticks = std::chrono::high_resolution_clock::now().time_since_epoch().count() % UINT32_MAX;
   std::srand(ticks);
@@ -246,10 +248,12 @@ TEST_F(TestCategory, sparse_coo2crs) {
 }
 
 TEST_F(TestCategory, sparse_coo2crs_staticMatrix_edgeCases) {
+#if defined(KOKKOS_ENABLE_SYCL)
   if constexpr (std::is_same_v<typename TestDevice::execution_space, Kokkos::Experimental::SYCL>) {
     std::cout << "Not running coo2csr on SYCL execution space" << std::endl;
     return;
   }
+#endif
 
   int m = 4;
   int n = 4;


### PR DESCRIPTION
With this test deactivated everything in Kokkos Kernels passes. Let us confirm that with a nightly build and potentially create of SYCL CI-build.