### PR TITLE
SpAdd handle: delete sort_option getter/setter

### DIFF
--- a/sparse/src/KokkosSparse_spadd_handle.hpp
+++ b/sparse/src/KokkosSparse_spadd_handle.hpp
@@ -102,10 +102,6 @@ class SPADDHandle {
    */
   size_type get_c_nnz() { return this->result_nnz_size; }
 
-  void set_sort_option(int option) { this->sort_option = option; }
-
-  int get_sort_option() { return this->sort_option; }
-
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
   SpaddCusparseData cusparseData;
 #endif


### PR DESCRIPTION
From way back in #122, the SpAdd handle had the functions ``get_sort_option()`` and ``set_sort_option()`` copy-pasted from spgemm. But these try to use the member ``bool sort_option``, which never existed. Somehow these functions never produced compile errors until someone tried to call them.