### PR TITLE
Don't error out if graph unit tests disabled

### DIFF
--- a/graph/unit_test/CMakeLists.txt
+++ b/graph/unit_test/CMakeLists.txt
@@ -10,11 +10,16 @@ KOKKOSKERNELS_INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_C
 #                   #
 #####################
 
+SET(KK_ENABLE_GRAPH_TESTS ON)
+
 IF (KokkosKernels_TEST_ETI_ONLY)
   IF (NOT KokkosKernels_INST_DOUBLE AND NOT KokkosKernels_INST_FLOAT)
-    MESSAGE(FATAL_ERROR "Because only ETI'd type combinations are enabled for testing, the Kokkos Kernels graph tests require that double or float is enabled in ETI.")
+    MESSAGE(WARNING "Because only ETI'd type combinations are enabled for testing, the Kokkos Kernels graph tests require that double or float is enabled in ETI.")
+    SET(KK_ENABLE_GRAPH_TESTS OFF)
   ENDIF ()
 ENDIF ()
+
+IF(KK_ENABLE_GRAPH_TESTS)
 
 #####################
 #                   #
@@ -97,4 +102,4 @@ IF (KOKKOS_ENABLE_THREADS)
     COMPONENTS graph
   )
 ENDIF ()
-
+ENDIF ()


### PR DESCRIPTION
Graph unit tests, with TEST_ETI_ONLY=ON, require double and/or float to be enabled as scalars. Instead of erroring out the configure, just give a warning and disable the graph tests.

This way, a simple configuration like below will succeed with just the warning. This is useful in case the user only wants to build the perf tests/examples without ETI.
```
../kokkos-kernels/cm_generate_makefile.bash \
  --no-default-eti
```