### PR TITLE
Restore size_t as default offset, in Tribits builds

### DIFF
--- a/cmake/kokkoskernels_eti_offsets.cmake
+++ b/cmake/kokkoskernels_eti_offsets.cmake
@@ -1,5 +1,15 @@
-SET(KOKKOSKERNELS_INST_OFFSET_SIZE_T_DEFAULT OFF)
-SET(KOKKOSKERNELS_INST_OFFSET_INT_DEFAULT ${KOKKOSKERNELS_ADD_DEFAULT_ETI})
+IF(KOKKOSKERNELS_HAS_TRILINOS)
+  # In a Trilinos build, size_t is the default offset because this is what Tpetra uses
+  # TODO: update this when Tpetra can use different offsets
+  SET(KOKKOSKERNELS_INST_OFFSET_SIZE_T_DEFAULT ${KOKKOSKERNELS_ADD_DEFAULT_ETI})
+  SET(KOKKOSKERNELS_INST_OFFSET_INT_DEFAULT OFF)
+ELSE()
+  # But in a standalone KokkosKernels build, int is the default offset type
+  # This provides the maximum TPL compatibility
+  SET(KOKKOSKERNELS_INST_OFFSET_SIZE_T_DEFAULT OFF)
+  SET(KOKKOSKERNELS_INST_OFFSET_INT_DEFAULT ${KOKKOSKERNELS_ADD_DEFAULT_ETI})
+ENDIF()
+
 SET(OFFSETS
   OFFSET_INT
   OFFSET_SIZE_T
@@ -12,14 +22,14 @@ KOKKOSKERNELS_ADD_OPTION(
   INST_OFFSET_INT
   ${KOKKOSKERNELS_INST_OFFSET_INT_DEFAULT}
   BOOL
-  "Whether to pre instantiate kernels for the offset type int.  This option is KokkosKernels_INST_OFFSET_INT=OFF by default. Default: OFF"
+  "Whether to pre instantiate kernels for the offset type int.  This option is KokkosKernels_INST_OFFSET_INT=OFF by default. Default: ${KOKKOSKERNELS_INST_OFFSET_INT_DEFAULT}"
   )
 
 KOKKOSKERNELS_ADD_OPTION(
   INST_OFFSET_SIZE_T
   ${KOKKOSKERNELS_INST_OFFSET_SIZE_T_DEFAULT}
   BOOL
-  "Whether to pre instantiate kernels for the offset type size_t.  This option is KokkosKernels_INST_OFFSET_SIZE_T=ON by default. Default: ON"
+  "Whether to pre instantiate kernels for the offset type size_t.  This option is KokkosKernels_INST_OFFSET_SIZE_T=ON by default. Default: ${KOKKOSKERNELS_INST_OFFSET_SIZE_T_DEFAULT}"
   )
 
 IF (KOKKOSKERNELS_INST_OFFSET_INT)


### PR DESCRIPTION
If building KokkosKernels standalone, leave int as the default offset (this was the case since #2140). But if building KokkosKernels as a Trilinos/Tribits package, then make size_t the default offset because this is what the Tpetra stack currently uses.

There will be an identical non-release patch into Trilinos, and this should also be included in the next release.