### PR TITLE
Remove review trigger and group github-{BDW,H100,MI201} under github-AT2

### DIFF
--- a/.github/workflows/at2.yml
+++ b/.github/workflows/at2.yml
@@ -1,0 +1,29 @@
+name: github-AT2
+
+on: 
+  pull_request:
+    paths-ignore:
+    - '**/*.rst'
+    - '**/*.md'
+    - '**/requirements.txt'
+    - '**/*.py'
+    - 'docs/**'
+    types: [ opened, reopened, synchronize ]
+
+permissions:
+  contents: none
+
+# Cancels any in progress 'workflow' associated with this PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mi210:
+    uses: ./.github/workflows/mi210.yml
+  h100:
+    uses: ./.github/workflows/h100.yml
+  bdw:
+    uses: ./.github/workflows/bdw.yml
+  #spr:
+    #uses: ./.github/workflows/spr.yml

--- a/.github/workflows/bdw.yml
+++ b/.github/workflows/bdw.yml
@@ -1,25 +1,7 @@
-name: github-BDW
+name: Reusable BDW workflow
 
 on:
-  pull_request:
-    paths-ignore:
-    - '**/*.rst'
-    - '**/*.md'
-    - '**/requirements.txt'
-    - '**/*.py'
-    - 'docs/**'
-    types: [ opened, reopened, synchronize ]
-  pull_request_review:
-    types:
-      - submitted
-
-permissions:
-  contents: none
-
-# Cancels any in progress 'workflow' associated with this PR
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  workflow_call
 
 jobs:
 #  PR_BDW_GNU1020_OPENMP_LEFT_REL_NOETI:

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -1,26 +1,7 @@
-name: github-H100
+name: Reusable H100 workflow
 
-# Only allow manual runs until at2 runners are available.
 on:
-  pull_request:
-    paths-ignore:
-    - '**/*.rst'
-    - '**/*.md'
-    - '**/requirements.txt'
-    - '**/*.py'
-    - 'docs/**'
-    types: [ opened, reopened, synchronize ]
-  pull_request_review:
-    types:
-      - submitted
-
-permissions:
-  contents: none
-
-# Cancels any in progress 'workflow' associated with this PR
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  workflow_call
 
 jobs:
   PR_HOPPER90_CUDA1180_CUDA_LEFT_RIGHT_REL:

--- a/.github/workflows/mi210.yml
+++ b/.github/workflows/mi210.yml
@@ -1,25 +1,7 @@
-name: github-MI210
+name: Reusable MI210 workflow
 
-on: 
-  pull_request:
-    paths-ignore:
-    - '**/*.rst'
-    - '**/*.md'
-    - '**/requirements.txt'
-    - '**/*.py'
-    - 'docs/**'
-    types: [ opened, reopened, synchronize ]
-  pull_request_review:
-    types:
-      - submitted
-
-permissions:
-  contents: none
-
-# Cancels any in progress 'workflow' associated with this PR
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on:
+  workflow_call
 
 jobs:
 #  PR_VEGA90A_ROCM561_HIP_SERIAL_LEFT_REL:

--- a/.github/workflows/spr.yml
+++ b/.github/workflows/spr.yml
@@ -1,26 +1,7 @@
-name: github-SPR
+name: Reusable SPR workflow
 
-# Only allow manual runs until at2 runners are available.
-on: workflow_dispatch
-  #pull_request:
-  #  paths-ignore:
-  #  - '**/*.rst'
-  #  - '**/*.md'
-  #  - '**/requirements.txt'
-  #  - '**/*.py'
-  #  - 'docs/**'
-  #  types: [ opened, reopened, synchronize ]
-  #pull_request_review:
-  #  types:
-  #    - submitted
-
-permissions:
-  contents: none
-
-# Cancels any in progress 'workflow' associated with this PR
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on:
+  workflow_call
 
 jobs:
   PR_SPR_ONEAPI202310_OPENMP_LEFT_MKLBLAS_MKLLAPACK_REL:


### PR DESCRIPTION
- New reviewer workflow is:
    1-review
    2-approve if everything looks good
    3-scroll to bottom of PR with CI statuses
    4-click details on one of the github-AT2 jobs
    5-click re-run all jobs

Anyone on the approved team can do this. PRs authored by and with commits solely from approved team members will still auto-run without a reviewer.
