### PR TITLE
Add MAGMA TPL support for GESV on HIP backend

### DIFF
--- a/lapack/tpls/KokkosLapack_gesv_tpl_spec_avail.hpp
+++ b/lapack/tpls/KokkosLapack_gesv_tpl_spec_avail.hpp
@@ -52,23 +52,30 @@ KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_LAPACK(Kokkos::complex<float>, Kokkos::LayoutLe
 
 namespace KokkosLapack {
 namespace Impl {
-#define KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(SCALAR, LAYOUT, MEMSPACE)                                       \
+#define KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(SCALAR, LAYOUT, EXECSPACE, MEMSPACE)                            \
   template <>                                                                                                  \
   struct gesv_tpl_spec_avail<                                                                                  \
-      Kokkos::Cuda,                                                                                            \
-      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                                   \
+      EXECSPACE,                                                                                               \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEMSPACE>,                                      \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                  \
-      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                                   \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEMSPACE>,                                      \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                  \
       Kokkos::View<magma_int_t*, LAYOUT, Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {                                               \
     enum : bool { value = true };                                                                              \
   };
-
-KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(double, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(float, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+#if defined(KOKKOS_ENABLE_CUDA)
+KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(double, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace)
+KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(float, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace)
+KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace)
+KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace)
+#endif
+#if defined(KOKKOS_ENABLE_HIP)
+KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(double, Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::HIPSpace)
+KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(float, Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::HIPSpace)
+KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::HIPSpace)
+KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::HIPSpace)
+#endif
 }  // namespace Impl
 }  // namespace KokkosLapack
 #endif  // KOKKOSKERNELS_ENABLE_TPL_MAGMA

--- a/lapack/tpls/KokkosLapack_gesv_tpl_spec_avail.hpp
+++ b/lapack/tpls/KokkosLapack_gesv_tpl_spec_avail.hpp
@@ -52,17 +52,15 @@ KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_LAPACK(Kokkos::complex<float>, Kokkos::LayoutLe
 
 namespace KokkosLapack {
 namespace Impl {
-#define KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(SCALAR, LAYOUT, EXECSPACE, MEMSPACE)                            \
-  template <>                                                                                                  \
-  struct gesv_tpl_spec_avail<                                                                                  \
-      EXECSPACE,                                                                                               \
-      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEMSPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                  \
-      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEMSPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                  \
-      Kokkos::View<magma_int_t*, LAYOUT, Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>, \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {                                               \
-    enum : bool { value = true };                                                                              \
+#define KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(SCALAR, LAYOUT, EXECSPACE, MEMSPACE)                                  \
+  template <>                                                                                                        \
+  struct gesv_tpl_spec_avail<                                                                                        \
+      EXECSPACE,                                                                                                     \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+      Kokkos::View<magma_int_t*, LAYOUT, Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>,       \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {                                                     \
+    enum : bool { value = true };                                                                                    \
   };
 #if defined(KOKKOS_ENABLE_CUDA)
 KOKKOSLAPACK_GESV_TPL_SPEC_AVAIL_MAGMA(double, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace)

--- a/lapack/tpls/KokkosLapack_gesv_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_gesv_tpl_spec_decl.hpp
@@ -197,37 +197,36 @@ void magmaGesvWrapper(const ExecSpace& space, const AViewType& A, const BViewTyp
   Kokkos::Profiling::popRegion();
 }
 
-#define KOKKOSLAPACK_GESV_MAGMA(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE)                                                 \
-  template <>                                                                                                          \
-  struct GESV<EXEC_SPACE,                                                                                              \
-              Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                    \
-                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                   \
-              Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                    \
-                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                   \
-              Kokkos::View<magma_int_t*, LAYOUT, Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>, \
-                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                   \
-              true,                                                                                                    \
-              gesv_eti_spec_avail<EXEC_SPACE,                                                                          \
-                                  Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                \
-                                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                               \
-                                  Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                \
-                                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                               \
-                                  Kokkos::View<magma_int_t*, LAYOUT,                                                   \
-                                               Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>,   \
-                                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                     \
-    using AViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                            \
-                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                           \
-    using BViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                            \
-                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                           \
-    using PViewType =                                                                                                  \
-        Kokkos::View<magma_int_t*, LAYOUT, Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>,       \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                         \
-                                                                                                                       \
-    static void gesv(const EXEC_SPACE& space, const AViewType& A, const BViewType& B, const PViewType& IPIV) {       \
-      magmaGesvWrapper(space, A, B, IPIV);                                                                             \
-    }                                                                                                                  \
+#define KOKKOSLAPACK_GESV_MAGMA(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE)                                                \
+  template <>                                                                                                         \
+  struct GESV<                                                                                                        \
+      EXEC_SPACE,                                                                                                     \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+      Kokkos::View<magma_int_t*, LAYOUT, Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>,        \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
+      true,                                                                                                           \
+      gesv_eti_spec_avail<                                                                                            \
+          EXEC_SPACE,                                                                                                 \
+          Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                       \
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                      \
+          Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                       \
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                      \
+          Kokkos::View<magma_int_t*, LAYOUT, Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>,    \
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                                            \
+    using AViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                           \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                          \
+    using BViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                           \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                          \
+    using PViewType =                                                                                                 \
+        Kokkos::View<magma_int_t*, LAYOUT, Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>,      \
+                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                        \
+                                                                                                                      \
+    static void gesv(const EXEC_SPACE& space, const AViewType& A, const BViewType& B, const PViewType& IPIV) {        \
+      magmaGesvWrapper(space, A, B, IPIV);                                                                            \
+    }                                                                                                                 \
   };
-  
+
 #if defined(KOKKOS_ENABLE_CUDA)
 KOKKOSLAPACK_GESV_MAGMA(float, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace)
 KOKKOSLAPACK_GESV_MAGMA(double, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace)

--- a/lapack/tpls/KokkosLapack_gesv_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_gesv_tpl_spec_decl.hpp
@@ -197,42 +197,49 @@ void magmaGesvWrapper(const ExecSpace& space, const AViewType& A, const BViewTyp
   Kokkos::Profiling::popRegion();
 }
 
-#define KOKKOSLAPACK_GESV_MAGMA(SCALAR, LAYOUT, MEM_SPACE)                                                             \
+#define KOKKOSLAPACK_GESV_MAGMA(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE)                                                 \
   template <>                                                                                                          \
-  struct GESV<Kokkos::Cuda,                                                                                            \
-              Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                  \
+  struct GESV<EXEC_SPACE,                                                                                              \
+              Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                    \
                            Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                   \
-              Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                  \
+              Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                    \
                            Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                   \
               Kokkos::View<magma_int_t*, LAYOUT, Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>, \
                            Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                   \
               true,                                                                                                    \
-              gesv_eti_spec_avail<Kokkos::Cuda,                                                                        \
-                                  Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,              \
+              gesv_eti_spec_avail<EXEC_SPACE,                                                                          \
+                                  Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                \
                                                Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                               \
-                                  Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,              \
+                                  Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                \
                                                Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                               \
                                   Kokkos::View<magma_int_t*, LAYOUT,                                                   \
                                                Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>,   \
                                                Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                     \
-    using AViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                          \
+    using AViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                            \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                           \
-    using BViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                          \
+    using BViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                            \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                           \
     using PViewType =                                                                                                  \
         Kokkos::View<magma_int_t*, LAYOUT, Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>,       \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                         \
                                                                                                                        \
-    static void gesv(const Kokkos::Cuda& space, const AViewType& A, const BViewType& B, const PViewType& IPIV) {       \
+    static void gesv(const EXEC_SPACE& space, const AViewType& A, const BViewType& B, const PViewType& IPIV) {       \
       magmaGesvWrapper(space, A, B, IPIV);                                                                             \
     }                                                                                                                  \
   };
-
-KOKKOSLAPACK_GESV_MAGMA(float, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-KOKKOSLAPACK_GESV_MAGMA(double, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-KOKKOSLAPACK_GESV_MAGMA(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-KOKKOSLAPACK_GESV_MAGMA(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-
+  
+#if defined(KOKKOS_ENABLE_CUDA)
+KOKKOSLAPACK_GESV_MAGMA(float, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace)
+KOKKOSLAPACK_GESV_MAGMA(double, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace)
+KOKKOSLAPACK_GESV_MAGMA(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace)
+KOKKOSLAPACK_GESV_MAGMA(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace)
+#endif
+#if defined(KOKKOS_ENABLE_HIP)
+KOKKOSLAPACK_GESV_MAGMA(float, Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::HIPSpace)
+KOKKOSLAPACK_GESV_MAGMA(double, Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::HIPSpace)
+KOKKOSLAPACK_GESV_MAGMA(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::HIPSpace)
+KOKKOSLAPACK_GESV_MAGMA(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::HIPSpace)
+#endif
 }  // namespace Impl
 }  // namespace KokkosLapack
 #endif  // KOKKOSKERNELS_ENABLE_TPL_MAGMA

--- a/lapack/unit_test/Test_Lapack_gesv.hpp
+++ b/lapack/unit_test/Test_Lapack_gesv.hpp
@@ -233,9 +233,9 @@ void impl_test_gesv_mrhs(const char* mode, const char* padding, int N, int nrhs)
   // Get the solution vector.
   Kokkos::deep_copy(h_B, B);
 
-  // Checking vs ref on CPU, this eps is about 10^-9
+  // Checking vs ref on CPU, this eps is about 10^-8
   typedef typename ats::mag_type mag_type;
-  const mag_type eps = 1.0e7 * ats::epsilon();
+  const mag_type eps = 1.0e8 * ats::epsilon();
   bool test_flag     = true;
   for (int j = 0; j < nrhs; j++) {
     for (int i = 0; i < N; i++) {

--- a/lapack/unit_test/Test_Lapack_gesv.hpp
+++ b/lapack/unit_test/Test_Lapack_gesv.hpp
@@ -16,11 +16,11 @@
 
 // only enable this test where KokkosLapack supports gesv:
 // CUDA+(MAGMA or CUSOLVER), HIP+(MAGMA or ROCSOLVER) and HOST+LAPACK
-#if (defined(TEST_CUDA_LAPACK_CPP) &&                                                            \
-     (defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA) || defined(KOKKOSKERNELS_ENABLE_TPL_CUSOLVER))) || \
-    (defined(TEST_HIP_LAPACK_CPP) &&                                                             \
-     (defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA) || defined(KOKKOSKERNELS_ENABLE_TPL_ROCSOLVER)))|| \
-    (defined(KOKKOSKERNELS_ENABLE_TPL_LAPACK) &&                                                 \
+#if (defined(TEST_CUDA_LAPACK_CPP) &&                                                             \
+     (defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA) || defined(KOKKOSKERNELS_ENABLE_TPL_CUSOLVER))) ||  \
+    (defined(TEST_HIP_LAPACK_CPP) &&                                                              \
+     (defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA) || defined(KOKKOSKERNELS_ENABLE_TPL_ROCSOLVER))) || \
+    (defined(KOKKOSKERNELS_ENABLE_TPL_LAPACK) &&                                                  \
      (defined(TEST_OPENMP_LAPACK_CPP) || defined(TEST_SERIAL_LAPACK_CPP) || defined(TEST_THREADS_LAPACK_CPP)))
 
 #include <gtest/gtest.h>

--- a/lapack/unit_test/Test_Lapack_gesv.hpp
+++ b/lapack/unit_test/Test_Lapack_gesv.hpp
@@ -15,10 +15,11 @@
 //@HEADER
 
 // only enable this test where KokkosLapack supports gesv:
-// CUDA+(MAGMA or CUSOLVER), HIP+ROCSOLVER and HOST+LAPACK
+// CUDA+(MAGMA or CUSOLVER), HIP+(MAGMA or ROCSOLVER) and HOST+LAPACK
 #if (defined(TEST_CUDA_LAPACK_CPP) &&                                                            \
      (defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA) || defined(KOKKOSKERNELS_ENABLE_TPL_CUSOLVER))) || \
-    (defined(TEST_HIP_LAPACK_CPP) && defined(KOKKOSKERNELS_ENABLE_TPL_ROCSOLVER)) ||             \
+    (defined(TEST_HIP_LAPACK_CPP) &&                                                             \
+     (defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA) || defined(KOKKOSKERNELS_ENABLE_TPL_ROCSOLVER)))|| \
     (defined(KOKKOSKERNELS_ENABLE_TPL_LAPACK) &&                                                 \
      (defined(TEST_OPENMP_LAPACK_CPP) || defined(TEST_SERIAL_LAPACK_CPP) || defined(TEST_THREADS_LAPACK_CPP)))
 
@@ -97,8 +98,13 @@ void impl_test_gesv(const char* mode, const char* padding, int N) {
     bool notpl_runtime_err   = false;
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MAGMA   // have MAGMA TPL
 #ifdef KOKKOSKERNELS_ENABLE_TPL_LAPACK  // and have LAPACK TPL
+#if defined(KOKKOS_ENABLE_CUDA)
     nopivot_runtime_err = (!std::is_same<typename Device::memory_space, Kokkos::CudaSpace>::value) &&
                           (ipiv.extent(0) == 0) && (ipiv.data() == nullptr);
+#elif defined(KOKKOS_ENABLE_HIP)
+    nopivot_runtime_err = (!std::is_same<typename Device::memory_space, Kokkos::HIPSpace>::value) &&
+                          (ipiv.extent(0) == 0) && (ipiv.data() == nullptr);
+#endif
     notpl_runtime_err = false;
 #else
     notpl_runtime_err = true;
@@ -200,8 +206,13 @@ void impl_test_gesv_mrhs(const char* mode, const char* padding, int N, int nrhs)
     bool notpl_runtime_err   = false;
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MAGMA   // have MAGMA TPL
 #ifdef KOKKOSKERNELS_ENABLE_TPL_LAPACK  // and have LAPACK TPL
+#if defined(KOKKOS_ENABLE_CUDA)
     nopivot_runtime_err = (!std::is_same<typename Device::memory_space, Kokkos::CudaSpace>::value) &&
                           (ipiv.extent(0) == 0) && (ipiv.data() == nullptr);
+#elif defined(KOKKOS_ENABLE_HIP)
+    nopivot_runtime_err = (!std::is_same<typename Device::memory_space, Kokkos::HIPSpace>::value) &&
+                          (ipiv.extent(0) == 0) && (ipiv.data() == nullptr);
+#endif
     notpl_runtime_err = false;
 #else
     notpl_runtime_err = true;
@@ -273,6 +284,19 @@ int test_gesv(const char* mode) {
     Test::impl_test_gesv<view_type_a_ll, view_type_b_ll, Device, true>(&mode[0], "Y",
                                                                        179);  // padding
   }
+#elif defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA) && defined(KOKKOS_ENABLE_HIP)
+  if constexpr (std::is_same_v<Kokkos::HIP, typename Device::execution_space>) {
+    Test::impl_test_gesv<view_type_a_ll, view_type_b_ll, Device, true>(&mode[0], "N", 2);     // no padding
+    Test::impl_test_gesv<view_type_a_ll, view_type_b_ll, Device, true>(&mode[0], "N", 13);    // no padding
+    Test::impl_test_gesv<view_type_a_ll, view_type_b_ll, Device, true>(&mode[0], "N", 179);   // no padding
+    Test::impl_test_gesv<view_type_a_ll, view_type_b_ll, Device, true>(&mode[0], "N", 64);    // no padding
+    Test::impl_test_gesv<view_type_a_ll, view_type_b_ll, Device, true>(&mode[0], "N", 1024);  // no padding
+
+    Test::impl_test_gesv<view_type_a_ll, view_type_b_ll, Device, true>(&mode[0], "Y",
+                                                                       13);  // padding
+    Test::impl_test_gesv<view_type_a_ll, view_type_b_ll, Device, true>(&mode[0], "Y",
+                                                                       179);  // padding
+  }
 #endif
 #endif
 
@@ -301,6 +325,17 @@ int test_gesv_mrhs(const char* mode) {
 // When appropriate run MAGMA specific tests
 #elif defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA) && defined(KOKKOS_ENABLE_CUDA)
   if constexpr (std::is_same_v<Kokkos::Cuda, typename Device::execution_space>) {
+    Test::impl_test_gesv_mrhs<view_type_a_ll, view_type_b_ll, Device, true>(&mode[0], "N", 2, 5);     // no padding
+    Test::impl_test_gesv_mrhs<view_type_a_ll, view_type_b_ll, Device, true>(&mode[0], "N", 13, 5);    // no padding
+    Test::impl_test_gesv_mrhs<view_type_a_ll, view_type_b_ll, Device, true>(&mode[0], "N", 179, 5);   // no padding
+    Test::impl_test_gesv_mrhs<view_type_a_ll, view_type_b_ll, Device, true>(&mode[0], "N", 64, 5);    // no padding
+    Test::impl_test_gesv_mrhs<view_type_a_ll, view_type_b_ll, Device, true>(&mode[0], "N", 1024, 5);  // no padding
+
+    Test::impl_test_gesv_mrhs<view_type_a_ll, view_type_b_ll, Device, true>(&mode[0], "Y", 13, 5);   // padding
+    Test::impl_test_gesv_mrhs<view_type_a_ll, view_type_b_ll, Device, true>(&mode[0], "Y", 179, 5);  // padding
+  }
+#elif defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA) && defined(KOKKOS_ENABLE_HIP)
+  if constexpr (std::is_same_v<Kokkos::HIP, typename Device::execution_space>) {
     Test::impl_test_gesv_mrhs<view_type_a_ll, view_type_b_ll, Device, true>(&mode[0], "N", 2, 5);     // no padding
     Test::impl_test_gesv_mrhs<view_type_a_ll, view_type_b_ll, Device, true>(&mode[0], "N", 13, 5);    // no padding
     Test::impl_test_gesv_mrhs<view_type_a_ll, view_type_b_ll, Device, true>(&mode[0], "N", 179, 5);   // no padding


### PR DESCRIPTION
This PR is to add small changes for MAGMA TPL GESV support for HIP backend in addition to CUDA backend. This is needed by Gemma's SPCAPACK to prepare for its run on El Capitan. It should be noted that SPCAPACK has relied on MAGMA for some LAPACK functionalities. We will look at rocSOLVER in another PR.