### PR TITLE
AT-2: adding non-TPL build for HIP backend

### DIFF
--- a/.github/workflows/mi210.yml
+++ b/.github/workflows/mi210.yml
@@ -107,12 +107,12 @@ jobs:
           mkdir -p kokkos/{build,install}
           cd kokkos/build
           HIPCC=$(which hipcc)
-          cmake -S /kokkos \
-            -B kokkos/build \
+          cmake -S "$GITHUB_WORKSPACE/kokkos" \
+            -B "$GITHUB_WORKSPACE/kokkos/build" \
             -D CMAKE_CXX_COMPILER=$HIPCC \
             -D CMAKE_CXX_FLAGS=-O3 \
             -D CMAKE_EXE_LINKER_FLAGS= \
-            -D CMAKE_INSTALL_PREFIX=kokkos/install \
+            -D CMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/kokkos/install" \
             -D CMAKE_VERBOSE_MAKEFILE=ON \
             -D CMAKE_CXX_EXTENSIONS=OFF \
             -D CMAKE_CXX_STANDARD=17 \
@@ -135,15 +135,15 @@ jobs:
           mkdir -p kokkos-kernels/{build,install}
           cd kokkos-kernels/build
           HIPCC=$(which hipcc)
-          cmake -S kokkos-kernels \
-            -B kokkos-kernels/build \
+          cmake -S "$GITHUB_WORKSPACE/kokkos-kernels" \
+            -B "$GITHUB_WORKSPACE/kokkos-kernels/build" \
             -D CMAKE_CXX_COMPILER=$HIPCC \
             -D CMAKE_CXX_FLAGS="-O3 -I$ROCM_CORE_ROOT/include" \
-            -D CMAKE_INSTALL_PREFIX="kokkos-kernels/install" \
+            -D CMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/kokkos-kernels/install" \
             -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=OFF \
             -D CMAKE_EXE_LINKER_FLAGS="" \
             -D BUILD_SHARED_LIBS=OFF \
-            -D Kokkos_ROOT="kokkos/install" \
+            -D Kokkos_ROOT="$GITHUB_WORKSPACE/kokkos/install" \
             -D KokkosKernels_INST_COMPLEX_DOUBLE=ON \
             -D KokkosKernels_INST_DOUBLE=ON \
             -D KokkosKernels_INST_ORDINAL_INT=ON \

--- a/.github/workflows/mi210.yml
+++ b/.github/workflows/mi210.yml
@@ -33,7 +33,7 @@ jobs:
             -D CMAKE_CXX_COMPILER=$HIPCC \
             -D CMAKE_CXX_FLAGS="-O3" \
             -D CMAKE_EXE_LINKER_FLAGS= \
-            -D CMAKE_INSTALL_PREFIX="kokkos/install" \
+            -D CMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/kokkos/install" \
             -D CMAKE_VERBOSE_MAKEFILE=ON \
             -D CMAKE_CXX_EXTENSIONS=OFF \
             -D CMAKE_CXX_STANDARD=17 \

--- a/.github/workflows/mi210.yml
+++ b/.github/workflows/mi210.yml
@@ -28,7 +28,7 @@ jobs:
           mkdir "$GITHUB_WORKSPACE/kokkos/install"
           cd "$GITHUB_WORKSPACE/kokkos/build"
           HIPCC=$(which hipcc)
-          cmake -S "$GITHUB_WORKSPACE/kokkos" \
+          cmake -S $GITHUB_WORKSPACE/kokkos" \
             -B "$GITHUB_WORKSPACE/kokkos/build" \
             -D CMAKE_CXX_COMPILER=$HIPCC \
             -D CMAKE_CXX_FLAGS="-O3" \
@@ -48,7 +48,7 @@ jobs:
             -D Kokkos_ENABLE_DEPRECATION_WARNINGS=OFF
 
       - name: build_and_install_kokkos
-        working-directory: "$GITHUB_WORKSPACEkokkos/build"
+        working-directory: $GITHUB_WORKSPACE/kokkos/build
         run: make -j16 install
 
       - name: configure_kokkos_kernels

--- a/.github/workflows/mi210.yml
+++ b/.github/workflows/mi210.yml
@@ -48,7 +48,7 @@ jobs:
             -D Kokkos_ENABLE_DEPRECATION_WARNINGS=OFF
 
       - name: build_and_install_kokkos
-        working-directory: $GITHUB_WORKSPACE/kokkos/build
+        working-directory: kokkos/build
         run: make -j16 install
 
       - name: configure_kokkos_kernels

--- a/.github/workflows/mi210.yml
+++ b/.github/workflows/mi210.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           echo "GITHUB_WORKSPACE = $GITHUB_WORKSPACE"
           mkdir "$GITHUB_WORKSPACE/kokkos/build"
-	  mkdir "$GITHUB_WORKSPACE/kokkos/install"
+          mkdir "$GITHUB_WORKSPACE/kokkos/install"
           cd "$GITHUB_WORKSPACE/kokkos/build"
           HIPCC=$(which hipcc)
           cmake -S "$GITHUB_WORKSPACE/kokkos" \

--- a/.github/workflows/mi210.yml
+++ b/.github/workflows/mi210.yml
@@ -23,11 +23,12 @@ jobs:
 
       - name: configure_kokkos
         run: |
-          mkdir -p kokkos/{build,install}
-          cd kokkos/build
+	  echo "GITHUB_WORKSPACE = $GITHUB_WORKSPACE"
+          mkdir -p "$GITHUB_WORKSPACE/kokkos/{build,install}"
+          cd "$GITHUB_WORKSPACE/kokkos/build"
           HIPCC=$(which hipcc)
-          cmake -S "kokkos" \
-            -B "kokkos/build" \
+          cmake -S "$GITHUB_WORKSPACE/kokkos" \
+            -B "$GITHUB_WORKSPACE/kokkos/build" \
             -D CMAKE_CXX_COMPILER=$HIPCC \
             -D CMAKE_CXX_FLAGS="-O3" \
             -D CMAKE_EXE_LINKER_FLAGS= \
@@ -46,23 +47,23 @@ jobs:
             -D Kokkos_ENABLE_DEPRECATION_WARNINGS=OFF
 
       - name: build_and_install_kokkos
-        working-directory: kokkos/build
+        working-directory: "$GITHUB_WORKSPACEkokkos/build"
         run: make -j16 install
 
       - name: configure_kokkos_kernels
         run: |
-          mkdir -p kokkos-kernels/{build,install}
-          cd kokkos-kernels/build
+          mkdir -p "$GITHUB_WORKSPACE/kokkos-kernels/{build,install}"
+          cd "$GITHUB_WORKSPACE/kokkos-kernels/build"
           HIPCC=$(which hipcc)
-          cmake -S "kokkos-kernels" \
-            -B "kokkos-kernels/build" \
+          cmake -S "$GITHUB_WORKSPACE/kokkos-kernels" \
+            -B "$GITHUB_WORKSPACE/kokkos-kernels/build" \
             -D CMAKE_CXX_COMPILER=$HIPCC \
             -D CMAKE_CXX_FLAGS="-O3 " \
             -D CMAKE_INSTALL_PREFIX= \
             -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=OFF \
             -D CMAKE_EXE_LINKER_FLAGS="" \
             -D BUILD_SHARED_LIBS=OFF \
-            -D Kokkos_ROOT="kokkos/install" \
+            -D Kokkos_ROOT="$GITHUB_WORKSPACE/kokkos/install" \
             -D KokkosKernels_ENABLE_TESTS=ON \
             -D KokkosKernels_ENABLE_EXAMPLES:BOOL=ON \
             -D KokkosKernels_ENABLE_PERFTESTS=ON \
@@ -75,11 +76,11 @@ jobs:
             -D KokkosKernels_ENABLE_DOCS=OFF
 
       - name: build
-        working-directory: kokkos-kernels/build
+        working-directory: "$GITHUB_WORKSPACE/kokkos-kernels/build"
         run: make -j12 all
 
       - name: test
-        working-directory: kokkos-kernels/build
+        working-directory: "$GITHUB_WORKSPACE/kokkos-kernels/build"
         run: ctest --output-on-failure -V --timeout 3600
 
   PR_VEGA90A_ROCM561_HIP_SERIAL_LEFT_TPLS:

--- a/.github/workflows/mi210.yml
+++ b/.github/workflows/mi210.yml
@@ -26,12 +26,12 @@ jobs:
           mkdir -p kokkos/{build,install}
           cd kokkos/build
           HIPCC=$(which hipcc)
-          cmake -S "/kokkos" \
-            -B "/kokkos/build" \
+          cmake -S "kokkos" \
+            -B "kokkos/build" \
             -D CMAKE_CXX_COMPILER=$HIPCC \
             -D CMAKE_CXX_FLAGS="-O3" \
             -D CMAKE_EXE_LINKER_FLAGS= \
-            -D CMAKE_INSTALL_PREFIX="/kokkos/install" \
+            -D CMAKE_INSTALL_PREFIX="kokkos/install" \
             -D CMAKE_VERBOSE_MAKEFILE=ON \
             -D CMAKE_CXX_EXTENSIONS=OFF \
             -D CMAKE_CXX_STANDARD=17 \
@@ -54,15 +54,15 @@ jobs:
           mkdir -p kokkos-kernels/{build,install}
           cd kokkos-kernels/build
           HIPCC=$(which hipcc)
-          cmake -S "/kokkos-kernels" \
-            -B "/kokkos-kernels/build" \
+          cmake -S "kokkos-kernels" \
+            -B "kokkos-kernels/build" \
             -D CMAKE_CXX_COMPILER=$HIPCC \
             -D CMAKE_CXX_FLAGS="-O3 " \
             -D CMAKE_INSTALL_PREFIX= \
             -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=OFF \
             -D CMAKE_EXE_LINKER_FLAGS="" \
             -D BUILD_SHARED_LIBS=OFF \
-            -D Kokkos_ROOT="/kokkos/install" \
+            -D Kokkos_ROOT="kokkos/install" \
             -D KokkosKernels_ENABLE_TESTS=ON \
             -D KokkosKernels_ENABLE_EXAMPLES:BOOL=ON \
             -D KokkosKernels_ENABLE_PERFTESTS=ON \
@@ -105,11 +105,11 @@ jobs:
           cd kokkos/build
           HIPCC=$(which hipcc)
           cmake -S /kokkos \
-            -B /kokkos/build \
+            -B kokkos/build \
             -D CMAKE_CXX_COMPILER=$HIPCC \
             -D CMAKE_CXX_FLAGS=-O3 \
             -D CMAKE_EXE_LINKER_FLAGS= \
-            -D CMAKE_INSTALL_PREFIX=/kokkos/install \
+            -D CMAKE_INSTALL_PREFIX=kokkos/install \
             -D CMAKE_VERBOSE_MAKEFILE=ON \
             -D CMAKE_CXX_EXTENSIONS=OFF \
             -D CMAKE_CXX_STANDARD=17 \
@@ -132,15 +132,15 @@ jobs:
           mkdir -p kokkos-kernels/{build,install}
           cd kokkos-kernels/build
           HIPCC=$(which hipcc)
-          cmake -S /kokkos-kernels \
-            -B /kokkos-kernels/build \
+          cmake -S kokkos-kernels \
+            -B kokkos-kernels/build \
             -D CMAKE_CXX_COMPILER=$HIPCC \
             -D CMAKE_CXX_FLAGS="-O3 -I$ROCM_CORE_ROOT/include" \
-            -D CMAKE_INSTALL_PREFIX="/kokkos-kernels/install" \
+            -D CMAKE_INSTALL_PREFIX="kokkos-kernels/install" \
             -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=OFF \
             -D CMAKE_EXE_LINKER_FLAGS="" \
             -D BUILD_SHARED_LIBS=OFF \
-            -D Kokkos_ROOT="/kokkos/install" \
+            -D Kokkos_ROOT="kokkos/install" \
             -D KokkosKernels_INST_COMPLEX_DOUBLE=ON \
             -D KokkosKernels_INST_DOUBLE=ON \
             -D KokkosKernels_INST_ORDINAL_INT=ON \

--- a/.github/workflows/mi210.yml
+++ b/.github/workflows/mi210.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   PR_VEGA90A_ROCM561_HIP_SERIAL_LEFT:
     name: PR_VEGA90A_ROCM561_HIP_SERIAL_LEFT
-    runs-on: [kk-env-hip-5.6.1-latest]
+    runs-on: [kk-env-openblas-0.3.23-hip-5.6.1-latest]
     
     steps:
       - name: checkout_kokkos_kernels

--- a/.github/workflows/mi210.yml
+++ b/.github/workflows/mi210.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: configure_kokkos
         run: |
-	  echo "GITHUB_WORKSPACE = $GITHUB_WORKSPACE"
+          echo "GITHUB_WORKSPACE = $GITHUB_WORKSPACE"
           mkdir -p "$GITHUB_WORKSPACE/kokkos/{build,install}"
           cd "$GITHUB_WORKSPACE/kokkos/build"
           HIPCC=$(which hipcc)

--- a/.github/workflows/mi210.yml
+++ b/.github/workflows/mi210.yml
@@ -28,7 +28,7 @@ jobs:
           HIPCC=$(which hipcc)
           cmake -S "/kokkos" \
             -B "/kokkos/build" \
-	    -D CMAKE_CXX_COMPILER=$HIPCC \
+            -D CMAKE_CXX_COMPILER=$HIPCC \
             -D CMAKE_CXX_FLAGS="-O3" \
             -D CMAKE_EXE_LINKER_FLAGS= \
             -D CMAKE_INSTALL_PREFIX="/kokkos/install" \
@@ -55,7 +55,7 @@ jobs:
           cd kokkos-kernels/build
           HIPCC=$(which hipcc)
           cmake -S "/kokkos-kernels" \
-	    -B "/kokkos-kernels/build" \
+            -B "/kokkos-kernels/build" \
             -D CMAKE_CXX_COMPILER=$HIPCC \
             -D CMAKE_CXX_FLAGS="-O3 " \
             -D CMAKE_INSTALL_PREFIX= \

--- a/.github/workflows/mi210.yml
+++ b/.github/workflows/mi210.yml
@@ -53,7 +53,8 @@ jobs:
 
       - name: configure_kokkos_kernels
         run: |
-          mkdir -p "$GITHUB_WORKSPACE/kokkos-kernels/{build,install}"
+          mkdir "$GITHUB_WORKSPACE/kokkos-kernels/build"
+          mkdir "$GITHUB_WORKSPACE/kokkos-kernels/install"
           cd "$GITHUB_WORKSPACE/kokkos-kernels/build"
           HIPCC=$(which hipcc)
           cmake -S "$GITHUB_WORKSPACE/kokkos-kernels" \
@@ -77,11 +78,11 @@ jobs:
             -D KokkosKernels_ENABLE_DOCS=OFF
 
       - name: build
-        working-directory: "$GITHUB_WORKSPACE/kokkos-kernels/build"
+        working-directory: kokkos-kernels/build
         run: make -j12 all
 
       - name: test
-        working-directory: "$GITHUB_WORKSPACE/kokkos-kernels/build"
+        working-directory: kokkos-kernels/build
         run: ctest --output-on-failure -V --timeout 3600
 
   PR_VEGA90A_ROCM561_HIP_SERIAL_LEFT_TPLS:

--- a/.github/workflows/mi210.yml
+++ b/.github/workflows/mi210.yml
@@ -24,7 +24,8 @@ jobs:
       - name: configure_kokkos
         run: |
           echo "GITHUB_WORKSPACE = $GITHUB_WORKSPACE"
-          mkdir -p "$GITHUB_WORKSPACE/kokkos/{build,install}"
+          mkdir "$GITHUB_WORKSPACE/kokkos/build"
+	  mkdir "$GITHUB_WORKSPACE/kokkos/install"
           cd "$GITHUB_WORKSPACE/kokkos/build"
           HIPCC=$(which hipcc)
           cmake -S "$GITHUB_WORKSPACE/kokkos" \

--- a/.github/workflows/mi210.yml
+++ b/.github/workflows/mi210.yml
@@ -28,7 +28,7 @@ jobs:
           mkdir "$GITHUB_WORKSPACE/kokkos/install"
           cd "$GITHUB_WORKSPACE/kokkos/build"
           HIPCC=$(which hipcc)
-          cmake -S $GITHUB_WORKSPACE/kokkos" \
+          cmake -S "$GITHUB_WORKSPACE/kokkos" \
             -B "$GITHUB_WORKSPACE/kokkos/build" \
             -D CMAKE_CXX_COMPILER=$HIPCC \
             -D CMAKE_CXX_FLAGS="-O3" \

--- a/.github/workflows/mi210.yml
+++ b/.github/workflows/mi210.yml
@@ -4,90 +4,86 @@ on:
   workflow_call
 
 jobs:
-#  PR_VEGA90A_ROCM561_HIP_SERIAL_LEFT_REL:
-#    name: PR_VEGA90A_ROCM561_HIP_SERIAL_LEFT_REL
-#    runs-on: [kk-env-hip-5.6.1-latest]
-#    
-#    steps:
-#      - name: checkout_kokkos_kernels
-#        uses: actions/checkout@v4
-#        with:
-#          path: kokkos-kernels
-#
-#      - name: checkout_kokkos
-#        uses: actions/checkout@v4
-#        with:
-#          repository: kokkos/kokkos
-#          ref: ${{ github.base_ref }}
-#          path: kokkos
-#
-#      - name: configure_kokkos
-#        run: |
-#          mkdir -p kokkos/{build,install}
-#          cd kokkos/build
-#          HIPCC=$(which hipcc)
-#          cmake -DCMAKE_CXX_COMPILER=$HIPCC \
-#            -DCMAKE_CXX_FLAGS=-O3 \
-#            -DCMAKE_EXE_LINKER_FLAGS= \
-#            -DCMAKE_INSTALL_PREFIX=$PWD/../install \
-#            -DKokkos_ENABLE_SERIAL=ON \
-#            -DKokkos_ENABLE_HIP=ON \
-#            -DKokkos_ARCH_VEGA90A=ON \
-#            -DKokkos_ENABLE_TESTS=OFF \
-#            -DKokkos_ENABLE_EXAMPLES=OFF \
-#            -DCMAKE_VERBOSE_MAKEFILE=ON \
-#            -DCMAKE_CXX_EXTENSIONS=OFF \
-#            -DCMAKE_CXX_STANDARD=17 \
-#            -DBUILD_SHARED_LIBS=OFF \
-#            -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
-#            -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF \
-#            -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
-#            ..
-#
-#      - name: build_and_install_kokkos
-#        working-directory: kokkos/build
-#        run: make -j16 install
-#
-#      - name: configure_kokkos_kernels
-#        run: |
-#          mkdir -p kokkos-kernels/{build,install}
-#          cd kokkos-kernels/build
-#          HIPCC=$(which hipcc)
-#          cmake -DCMAKE_CXX_COMPILER=$HIPCC \
-#            -DKokkos_DIR=$PWD/../../kokkos/install/lib64/cmake/Kokkos \
-#            -DCMAKE_CXX_FLAGS="-O3 " \
-#            -DCMAKE_INSTALL_PREFIX= \
-#            -DKokkosKernels_ENABLE_TESTS_AND_PERFSUITE=OFF \
-#            -DKokkosKernels_ENABLE_TESTS=ON \
-#            -DKokkosKernels_ENABLE_PERFTESTS=ON \
-#            -DKokkosKernels_ENABLE_EXAMPLES:BOOL=ON \
-#            -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=OFF \
-#            -DKokkosKernels_INST_COMPLEX_DOUBLE=ON \
-#            -DKokkosKernels_INST_DOUBLE=ON \
-#            -DKokkosKernels_INST_ORDINAL_INT=ON \
-#            -DKokkosKernels_INST_OFFSET_SIZE_T=ON \
-#            -DKokkosKernels_INST_OFFSET_INT=ON \
-#            -DKokkosKernels_INST_LAYOUTLEFT=ON \
-#            -DKokkosKernels_ENABLE_TPL_ROCSPARSE=OFF \
-#            -DKokkosKernels_ENABLE_TPL_ROCBLAS=OFF \
-#            -DKokkosKernels_ENABLE_TPL_CUSOLVER=OFF \
-#            -DKokkosKernels_ENABLE_TPL_CUSPARSE=OFF \
-#            -DKokkosKernels_ENABLE_TPL_CUBLAS=OFF \
-#            -DCMAKE_EXE_LINKER_FLAGS="" \
-#            -DBUILD_SHARED_LIBS=OFF \
-#            -DKokkosKernels_ENABLE_DOCS=OFF \
-#            ..
-#
-#      - name: build
-#        working-directory: kokkos-kernels/build
-#        run: make -j12 all
-#
-#      - name: test
-#        working-directory: kokkos-kernels/build
-#        run: ctest --output-on-failure -V --timeout 3600
+  PR_VEGA90A_ROCM561_HIP_SERIAL_LEFT:
+    name: PR_VEGA90A_ROCM561_HIP_SERIAL_LEFT
+    runs-on: [kk-env-hip-5.6.1-latest]
+    
+    steps:
+      - name: checkout_kokkos_kernels
+        uses: actions/checkout@v4
+        with:
+          path: kokkos-kernels
 
-  PR_VEGA908_ROCM561_HIP_SERIAL_LEFT_OPENBLAS_REL:
-    name: PR_VEGA908_ROCM561_HIP_SERIAL_LEFT_OPENBLAS_REL
+      - name: checkout_kokkos
+        uses: actions/checkout@v4
+        with:
+          repository: kokkos/kokkos
+          ref: ${{ github.base_ref }}
+          path: kokkos
+
+      - name: configure_kokkos
+        run: |
+          mkdir -p kokkos/{build,install}
+          cd kokkos/build
+          HIPCC=$(which hipcc)
+          cmake -S "/kokkos" \
+            -B "/kokkos/build" \
+	    -D CMAKE_CXX_COMPILER=$HIPCC \
+            -D CMAKE_CXX_FLAGS="-O3" \
+            -D CMAKE_EXE_LINKER_FLAGS= \
+            -D CMAKE_INSTALL_PREFIX="/kokkos/install" \
+            -D CMAKE_VERBOSE_MAKEFILE=ON \
+            -D CMAKE_CXX_EXTENSIONS=OFF \
+            -D CMAKE_CXX_STANDARD=17 \
+            -D BUILD_SHARED_LIBS=OFF \
+            -D Kokkos_ENABLE_SERIAL=ON \
+            -D Kokkos_ENABLE_HIP=ON \
+            -D Kokkos_ARCH_VEGA90A=ON \
+            -D Kokkos_ENABLE_TESTS=OFF \
+            -D Kokkos_ENABLE_EXAMPLES=OFF \
+            -D Kokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
+            -D Kokkos_ENABLE_DEPRECATED_CODE_4=OFF \
+            -D Kokkos_ENABLE_DEPRECATION_WARNINGS=OFF
+
+      - name: build_and_install_kokkos
+        working-directory: kokkos/build
+        run: make -j16 install
+
+      - name: configure_kokkos_kernels
+        run: |
+          mkdir -p kokkos-kernels/{build,install}
+          cd kokkos-kernels/build
+          HIPCC=$(which hipcc)
+          cmake -S "/kokkos-kernels" \
+	    -B "/kokkos-kernels/build" \
+            -D CMAKE_CXX_COMPILER=$HIPCC \
+            -D CMAKE_CXX_FLAGS="-O3 " \
+            -D CMAKE_INSTALL_PREFIX= \
+            -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=OFF \
+            -D CMAKE_EXE_LINKER_FLAGS="" \
+            -D BUILD_SHARED_LIBS=OFF \
+            -D Kokkos_ROOT="/kokkos/install" \
+            -D KokkosKernels_ENABLE_TESTS=ON \
+            -D KokkosKernels_ENABLE_EXAMPLES:BOOL=ON \
+            -D KokkosKernels_ENABLE_PERFTESTS=ON \
+            -D KokkosKernels_INST_COMPLEX_DOUBLE=ON \
+            -D KokkosKernels_INST_DOUBLE=ON \
+            -D KokkosKernels_INST_ORDINAL_INT=ON \
+            -D KokkosKernels_INST_OFFSET_SIZE_T=ON \
+            -D KokkosKernels_INST_OFFSET_INT=ON \
+            -D KokkosKernels_INST_LAYOUTLEFT=ON \
+            -D KokkosKernels_ENABLE_DOCS=OFF
+
+      - name: build
+        working-directory: kokkos-kernels/build
+        run: make -j12 all
+
+      - name: test
+        working-directory: kokkos-kernels/build
+        run: ctest --output-on-failure -V --timeout 3600
+
+  PR_VEGA90A_ROCM561_HIP_SERIAL_LEFT_TPLS:
+    name: PR_VEGA90A_ROCM561_HIP_SERIAL_LEFT_TPLS
     runs-on: [kk-env-openblas-0.3.23-hip-5.6.1-latest]
     
     steps:
@@ -108,23 +104,24 @@ jobs:
           mkdir -p kokkos/{build,install}
           cd kokkos/build
           HIPCC=$(which hipcc)
-          cmake -DCMAKE_CXX_COMPILER=$HIPCC \
-            -DCMAKE_CXX_FLAGS=-O3 \
-            -DCMAKE_EXE_LINKER_FLAGS= \
-            -DCMAKE_INSTALL_PREFIX=$PWD/../install \
-            -DKokkos_ENABLE_SERIAL=ON \
-            -DKokkos_ENABLE_HIP=ON \
-            -DKokkos_ARCH_VEGA90A=ON \
-            -DKokkos_ENABLE_TESTS=OFF \
-            -DKokkos_ENABLE_EXAMPLES=OFF \
-            -DCMAKE_VERBOSE_MAKEFILE=ON \
-            -DCMAKE_CXX_EXTENSIONS=OFF \
-            -DCMAKE_CXX_STANDARD=17 \
-            -DBUILD_SHARED_LIBS=OFF \
-            -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
-            -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF \
-            -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
-            ..
+          cmake -S /kokkos \
+            -B /kokkos/build \
+            -D CMAKE_CXX_COMPILER=$HIPCC \
+            -D CMAKE_CXX_FLAGS=-O3 \
+            -D CMAKE_EXE_LINKER_FLAGS= \
+            -D CMAKE_INSTALL_PREFIX=/kokkos/install \
+            -D CMAKE_VERBOSE_MAKEFILE=ON \
+            -D CMAKE_CXX_EXTENSIONS=OFF \
+            -D CMAKE_CXX_STANDARD=17 \
+            -D BUILD_SHARED_LIBS=OFF \
+            -D Kokkos_ENABLE_SERIAL=ON \
+            -D Kokkos_ENABLE_HIP=ON \
+            -D Kokkos_ARCH_VEGA90A=ON \
+            -D Kokkos_ENABLE_TESTS=OFF \
+            -D Kokkos_ENABLE_EXAMPLES=OFF \
+            -D Kokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
+            -D Kokkos_ENABLE_DEPRECATED_CODE_4=OFF \
+            -D Kokkos_ENABLE_DEPRECATION_WARNINGS=OFF
 
       - name: build_and_install_kokkos
         working-directory: kokkos/build
@@ -135,32 +132,30 @@ jobs:
           mkdir -p kokkos-kernels/{build,install}
           cd kokkos-kernels/build
           HIPCC=$(which hipcc)
-          cmake -DCMAKE_CXX_COMPILER=$HIPCC \
-            -DKokkos_DIR=$PWD/../../kokkos/install/lib64/cmake/Kokkos \
-            -DCMAKE_CXX_FLAGS="-O3 -I$ROCM_CORE_ROOT/include" \
-            -DCMAKE_INSTALL_PREFIX= \
-            -DKokkosKernels_ENABLE_TESTS_AND_PERFSUITE=OFF \
-            -DKokkosKernels_ENABLE_TESTS=ON \
-            -DKokkosKernels_ENABLE_PERFTESTS=ON \
-            -DKokkosKernels_ENABLE_EXAMPLES:BOOL=ON \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=OFF \
-            -DKokkosKernels_INST_COMPLEX_DOUBLE=ON \
-            -DKokkosKernels_INST_DOUBLE=ON \
-            -DKokkosKernels_INST_ORDINAL_INT=ON \
-            -DKokkosKernels_INST_OFFSET_SIZE_T=ON \
-            -DKokkosKernels_INST_OFFSET_INT=ON \
-            -DKokkosKernels_INST_LAYOUTLEFT=ON \
-            -DKokkosKernels_ENABLE_TPL_CUSOLVER=OFF \
-            -DKokkosKernels_ENABLE_TPL_CUSPARSE=OFF \
-            -DKokkosKernels_ENABLE_TPL_ROCSOLVER=ON \
-            -DKokkosKernels_ENABLE_TPL_ROCSPARSE=ON \
-            -DKokkosKernels_ENABLE_TPL_ROCBLAS=ON \
-            -DKokkosKernels_ENABLE_TPL_BLAS=ON \
-            -DKokkosKernels_ENABLE_TPL_CUBLAS=OFF \
-            -DCMAKE_EXE_LINKER_FLAGS="" \
-            -DBUILD_SHARED_LIBS=OFF \
-            -DKokkosKernels_ENABLE_DOCS=OFF \
-            ..
+          cmake -S /kokkos-kernels \
+            -B /kokkos-kernels/build \
+            -D CMAKE_CXX_COMPILER=$HIPCC \
+            -D CMAKE_CXX_FLAGS="-O3 -I$ROCM_CORE_ROOT/include" \
+            -D CMAKE_INSTALL_PREFIX="/kokkos-kernels/install" \
+            -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=OFF \
+            -D CMAKE_EXE_LINKER_FLAGS="" \
+            -D BUILD_SHARED_LIBS=OFF \
+            -D Kokkos_ROOT="/kokkos/install" \
+            -D KokkosKernels_INST_COMPLEX_DOUBLE=ON \
+            -D KokkosKernels_INST_DOUBLE=ON \
+            -D KokkosKernels_INST_ORDINAL_INT=ON \
+            -D KokkosKernels_INST_OFFSET_SIZE_T=ON \
+            -D KokkosKernels_INST_OFFSET_INT=ON \
+            -D KokkosKernels_INST_LAYOUTLEFT=ON \
+            -D KokkosKernels_ENABLE_TPL_ROCSOLVER=ON \
+            -D KokkosKernels_ENABLE_TPL_ROCSPARSE=ON \
+            -D KokkosKernels_ENABLE_TPL_ROCBLAS=ON \
+            -D KokkosKernels_ENABLE_TPL_BLAS=ON \
+            -D KokkosKernels_ENABLE_TESTS=ON \
+            -D KokkosKernels_ENABLE_PERFTESTS=ON \
+            -D KokkosKernels_ENABLE_EXAMPLES:BOOL=ON \
+            -D KokkosKernels_ENABLE_TESTS_AND_PERFSUITE=OFF \
+            -D KokkosKernels_ENABLE_DOCS=OFF
 
       - name: build
         working-directory: kokkos-kernels/build


### PR DESCRIPTION
Clean-up a few things in the mi210 workflow as well should make it a little bit more readable and maintainable.