### PR TITLE
implement batched serial pbtrs

### DIFF
--- a/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Impl.hpp
@@ -70,7 +70,7 @@ struct SerialPbtrs<Uplo::Lower, Algo::Pbtrs::Unblocked> {
 
     const int kd = A.extent(0) - 1;
     return KokkosBatched::Impl::SerialPbtrsInternalLower<Algo::Pbtrs::Unblocked>::invoke(
-        A.extent(1), x.extent(0), A.data(), A.stride_0(), A.stride_1(), x.data(), x.stride_0(), kd);
+        A.extent(1), A.data(), A.stride_0(), A.stride_1(), x.data(), x.stride_0(), kd);
   }
 };
 
@@ -86,7 +86,7 @@ struct SerialPbtrs<Uplo::Upper, Algo::Pbtrs::Unblocked> {
 
     const int kd = A.extent(0) - 1;
     return KokkosBatched::Impl::SerialPbtrsInternalUpper<Algo::Pbtrs::Unblocked>::invoke(
-        A.extent(1), x.extent(0), A.data(), A.stride_0(), A.stride_1(), x.data(), x.stride_0(), kd);
+        A.extent(1), A.data(), A.stride_0(), A.stride_1(), x.data(), x.stride_0(), kd);
   }
 };
 

--- a/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Impl.hpp
@@ -35,6 +35,15 @@ KOKKOS_INLINE_FUNCTION static int checkPbtrsInput([[maybe_unused]] const AViewTy
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
   const int ldb = x.extent(0);
   const int lda = A.extent(0), n = A.extent(1);
+  const int kd = lda - 1;
+  if (kd < 0) {
+    Kokkos::printf(
+        "KokkosBatched::pbtrs: leading dimension of A must not be less than 1: %d, A: "
+        "%d "
+        "x %d \n",
+        lda, n);
+    return 1;
+  }
   if (ldb < Kokkos::max(1, n)) {
     Kokkos::printf(
         "KokkosBatched::pbtrs: Dimensions of x and A do not match: x: %d, A: "

--- a/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Impl.hpp
@@ -1,0 +1,84 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+#ifndef KOKKOSBATCHED_PBTRS_SERIAL_IMPL_HPP_
+#define KOKKOSBATCHED_PBTRS_SERIAL_IMPL_HPP_
+
+#include <KokkosBatched_Util.hpp>
+#include "KokkosBatched_Pbtrs_Serial_Internal.hpp"
+
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+
+namespace KokkosBatched {
+
+template <typename AViewType, typename XViewType>
+KOKKOS_INLINE_FUNCTION static int checkPbtrsInput([[maybe_unused]] const AViewType &A,
+                                                  [[maybe_unused]] const XViewType &x) {
+  static_assert(Kokkos::is_view_v<AViewType>, "KokkosBatched::pbtrs: AViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view_v<XViewType>, "KokkosBatched::pbtrs: XViewType is not a Kokkos::View.");
+  static_assert(AViewType::rank == 2, "KokkosBatched::pbtrs: AViewType must have rank 2.");
+  static_assert(XViewType::rank == 1, "KokkosBatched::pbtrs: XViewType must have rank 1.");
+
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+  const int ldb = x.extent(0);
+  const int lda = A.extent(0), n = A.extent(1);
+  if (ldb < Kokkos::max(1, n)) {
+    Kokkos::printf(
+        "KokkosBatched::pbtrs: Dimensions of x and A do not match: x: %d, A: "
+        "%d "
+        "x %d \n"
+        "x.extent(0) must be larger or equal to A.extent(1) \n",
+        ldb, lda, n);
+    return 1;
+  }
+#endif
+  return 0;
+}
+
+//// Lower ////
+template <>
+struct SerialPbtrs<Uplo::Lower, Algo::Pbtrs::Unblocked> {
+  template <typename AViewType, typename XViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const XViewType &x) {
+    // Quick return if possible
+    if (A.extent(1) == 0) return 0;
+    auto info = checkPbtrsInput(A, x);
+    if (info) return info;
+
+    const int kd = A.extent(0) - 1;
+    return SerialPbtrsInternalLower<Algo::Pbtrs::Unblocked>::invoke(A.extent(1), x.extent(0), A.data(), A.stride_0(),
+                                                                    A.stride_1(), x.data(), x.stride_0(), kd);
+  }
+};
+
+//// Upper ////
+template <>
+struct SerialPbtrs<Uplo::Upper, Algo::Pbtrs::Unblocked> {
+  template <typename AViewType, typename XViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const XViewType &x) {
+    // Quick return if possible
+    if (A.extent(1) == 0) return 0;
+    auto info = checkPbtrsInput(A, x);
+    if (info) return info;
+
+    const int kd = A.extent(0) - 1;
+    return SerialPbtrsInternalUpper<Algo::Pbtrs::Unblocked>::invoke(A.extent(1), x.extent(0), A.data(), A.stride_0(),
+                                                                    A.stride_1(), x.data(), x.stride_0(), kd);
+  }
+};
+
+}  // namespace KokkosBatched
+
+#endif  // KOKKOSBATCHED_PBTRS_SERIAL_IMPL_HPP_

--- a/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Impl.hpp
@@ -22,6 +22,7 @@
 /// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
 
 namespace KokkosBatched {
+namespace Impl {
 
 template <typename AViewType, typename XViewType>
 KOKKOS_INLINE_FUNCTION static int checkPbtrsInput([[maybe_unused]] const AViewType &A,
@@ -46,6 +47,7 @@ KOKKOS_INLINE_FUNCTION static int checkPbtrsInput([[maybe_unused]] const AViewTy
 #endif
   return 0;
 }
+}  // namespace Impl
 
 //// Lower ////
 template <>
@@ -54,12 +56,12 @@ struct SerialPbtrs<Uplo::Lower, Algo::Pbtrs::Unblocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const XViewType &x) {
     // Quick return if possible
     if (A.extent(1) == 0) return 0;
-    auto info = checkPbtrsInput(A, x);
+    auto info = KokkosBatched::Impl::checkPbtrsInput(A, x);
     if (info) return info;
 
     const int kd = A.extent(0) - 1;
-    return SerialPbtrsInternalLower<Algo::Pbtrs::Unblocked>::invoke(A.extent(1), x.extent(0), A.data(), A.stride_0(),
-                                                                    A.stride_1(), x.data(), x.stride_0(), kd);
+    return KokkosBatched::Impl::SerialPbtrsInternalLower<Algo::Pbtrs::Unblocked>::invoke(
+        A.extent(1), x.extent(0), A.data(), A.stride_0(), A.stride_1(), x.data(), x.stride_0(), kd);
   }
 };
 
@@ -70,12 +72,12 @@ struct SerialPbtrs<Uplo::Upper, Algo::Pbtrs::Unblocked> {
   KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const XViewType &x) {
     // Quick return if possible
     if (A.extent(1) == 0) return 0;
-    auto info = checkPbtrsInput(A, x);
+    auto info = KokkosBatched::Impl::checkPbtrsInput(A, x);
     if (info) return info;
 
     const int kd = A.extent(0) - 1;
-    return SerialPbtrsInternalUpper<Algo::Pbtrs::Unblocked>::invoke(A.extent(1), x.extent(0), A.data(), A.stride_0(),
-                                                                    A.stride_1(), x.data(), x.stride_0(), kd);
+    return KokkosBatched::Impl::SerialPbtrsInternalUpper<Algo::Pbtrs::Unblocked>::invoke(
+        A.extent(1), x.extent(0), A.data(), A.stride_0(), A.stride_1(), x.data(), x.stride_0(), kd);
   }
 };
 

--- a/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Internal.hpp
@@ -21,6 +21,7 @@
 #include "KokkosBatched_Tbsv_Serial_Internal.hpp"
 
 namespace KokkosBatched {
+namespace Impl {
 
 ///
 /// Serial Internal Impl
@@ -84,6 +85,7 @@ KOKKOS_INLINE_FUNCTION int SerialPbtrsInternalUpper<Algo::Pbtrs::Unblocked>::inv
   return 0;
 }
 
+}  // namespace Impl
 }  // namespace KokkosBatched
 
 #endif  // KOKKOSBATCHED_PBTRS_SERIAL_INTERNAL_HPP_

--- a/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Internal.hpp
@@ -34,14 +34,14 @@ namespace Impl {
 template <typename AlgoType>
 struct SerialPbtrsInternalLower {
   template <typename ValueType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const int an, const int xm, const ValueType *KOKKOS_RESTRICT A,
-                                           const int as0, const int as1,
+  KOKKOS_INLINE_FUNCTION static int invoke(const int an, const ValueType *KOKKOS_RESTRICT A, const int as0,
+                                           const int as1,
                                            /**/ ValueType *KOKKOS_RESTRICT x, const int xs0, const int kd);
 };
 
 template <>
 template <typename ValueType>
-KOKKOS_INLINE_FUNCTION int SerialPbtrsInternalLower<Algo::Pbtrs::Unblocked>::invoke(const int an, const int xm,
+KOKKOS_INLINE_FUNCTION int SerialPbtrsInternalLower<Algo::Pbtrs::Unblocked>::invoke(const int an,
                                                                                     const ValueType *KOKKOS_RESTRICT A,
                                                                                     const int as0, const int as1,
                                                                                     /**/ ValueType *KOKKOS_RESTRICT x,
@@ -63,14 +63,14 @@ KOKKOS_INLINE_FUNCTION int SerialPbtrsInternalLower<Algo::Pbtrs::Unblocked>::inv
 template <typename AlgoType>
 struct SerialPbtrsInternalUpper {
   template <typename ValueType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const int an, const int xm, const ValueType *KOKKOS_RESTRICT A,
-                                           const int as0, const int as1,
+  KOKKOS_INLINE_FUNCTION static int invoke(const int an, const ValueType *KOKKOS_RESTRICT A, const int as0,
+                                           const int as1,
                                            /**/ ValueType *KOKKOS_RESTRICT x, const int xs0, const int kd);
 };
 
 template <>
 template <typename ValueType>
-KOKKOS_INLINE_FUNCTION int SerialPbtrsInternalUpper<Algo::Pbtrs::Unblocked>::invoke(const int an, const int xm,
+KOKKOS_INLINE_FUNCTION int SerialPbtrsInternalUpper<Algo::Pbtrs::Unblocked>::invoke(const int an,
                                                                                     const ValueType *KOKKOS_RESTRICT A,
                                                                                     const int as0, const int as1,
                                                                                     /**/ ValueType *KOKKOS_RESTRICT x,

--- a/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Internal.hpp
@@ -1,0 +1,89 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOSBATCHED_PBTRS_SERIAL_INTERNAL_HPP_
+#define KOKKOSBATCHED_PBTRS_SERIAL_INTERNAL_HPP_
+
+#include "KokkosBatched_Util.hpp"
+#include "KokkosBatched_Tbsv_Serial_Internal.hpp"
+
+namespace KokkosBatched {
+
+///
+/// Serial Internal Impl
+/// ====================
+
+///
+/// Lower
+///
+
+template <typename AlgoType>
+struct SerialPbtrsInternalLower {
+  template <typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const int an, const int xm, const ValueType *KOKKOS_RESTRICT A,
+                                           const int as0, const int as1,
+                                           /**/ ValueType *KOKKOS_RESTRICT x, const int xs0, const int kd);
+};
+
+template <>
+template <typename ValueType>
+KOKKOS_INLINE_FUNCTION int SerialPbtrsInternalLower<Algo::Pbtrs::Unblocked>::invoke(const int an, const int xm,
+                                                                                    const ValueType *KOKKOS_RESTRICT A,
+                                                                                    const int as0, const int as1,
+                                                                                    /**/ ValueType *KOKKOS_RESTRICT x,
+                                                                                    const int xs0, const int kd) {
+  // Solve L*X = B, overwriting B with X.
+  SerialTbsvInternalLower<Algo::Tbsv::Unblocked>::invoke(false, an, A, as0, as1, x, xs0, kd);
+
+  // Solve L**T *X = B, overwriting B with X.
+  constexpr bool do_conj = Kokkos::ArithTraits<ValueType>::is_complex;
+  SerialTbsvInternalLowerTranspose<Algo::Tbsv::Unblocked>::invoke(false, do_conj, an, A, as0, as1, x, xs0, kd);
+
+  return 0;
+}
+
+///
+/// Upper
+///
+
+template <typename AlgoType>
+struct SerialPbtrsInternalUpper {
+  template <typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const int an, const int xm, const ValueType *KOKKOS_RESTRICT A,
+                                           const int as0, const int as1,
+                                           /**/ ValueType *KOKKOS_RESTRICT x, const int xs0, const int kd);
+};
+
+template <>
+template <typename ValueType>
+KOKKOS_INLINE_FUNCTION int SerialPbtrsInternalUpper<Algo::Pbtrs::Unblocked>::invoke(const int an, const int xm,
+                                                                                    const ValueType *KOKKOS_RESTRICT A,
+                                                                                    const int as0, const int as1,
+                                                                                    /**/ ValueType *KOKKOS_RESTRICT x,
+                                                                                    const int xs0, const int kd) {
+  // Solve U**T *X = B, overwriting B with X.
+  constexpr bool do_conj = Kokkos::ArithTraits<ValueType>::is_complex;
+  SerialTbsvInternalUpperTranspose<Algo::Tbsv::Unblocked>::invoke(false, do_conj, an, A, as0, as1, x, xs0, kd);
+
+  // Solve U*X = B, overwriting B with X.
+  SerialTbsvInternalUpper<Algo::Tbsv::Unblocked>::invoke(false, an, A, as0, as1, x, xs0, kd);
+
+  return 0;
+}
+
+}  // namespace KokkosBatched
+
+#endif  // KOKKOSBATCHED_PBTRS_SERIAL_INTERNAL_HPP_

--- a/batched/dense/src/KokkosBatched_Pbtrs.hpp
+++ b/batched/dense/src/KokkosBatched_Pbtrs.hpp
@@ -23,18 +23,19 @@
 namespace KokkosBatched {
 
 /// \brief Serial Batched Pbtrs:
-/// Compute the Cholesky factorization U**H * U (or L * L**H) of a real
-/// symmetric (or complex Hermitian) positive definite banded matrix A_l
-/// for all l = 0, ...,
-/// The factorization has the form
-///    A = U**T * U ,  if ArgUplo = KokkosBatched::Uplo::Upper, or
-///    A = L  * L**T,  if ArgUplo = KokkosBatched::Uplo::Lower,
-/// where U is an upper triangular matrix, U**T is the transpose of U, and
-/// L is lower triangular.
-/// This is the unblocked version of the algorithm, calling Level 2 BLAS.
+/// Solve Ab_l x_l = b_l for all l = 0, ..., N
+///   using the Cholesky factorization A = U**H * U or A = L * L**H computed by
+///   Pbtrf.
+/// The matrix has the form
+///    A = U**H * U ,  if ArgUplo = KokkosBatched::Uplo::Upper, or
+///    A = L  * L**H,  if ArgUplo = KokkosBatched::Uplo::Lower,
+/// where U is an upper triangular matrix, U**H is the transpose of U, and
+/// L is lower triangular matrix, L**H is the transpose of L.
 ///
 /// \tparam ABViewType: Input type for a banded matrix, needs to be a 2D
 /// view
+/// \tparam BViewType: Input type for a right-hand side and the solution,
+/// needs to be a 1D view
 ///
 /// \param ab [in]: ab is a ldab by n banded matrix, with ( kd + 1 ) diagonals
 /// \param b  [inout]: right-hand side and the solution, a rank 1 view

--- a/batched/dense/src/KokkosBatched_Pbtrs.hpp
+++ b/batched/dense/src/KokkosBatched_Pbtrs.hpp
@@ -1,0 +1,55 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+#ifndef KOKKOSBATCHED_PBTRS_HPP_
+#define KOKKOSBATCHED_PBTRS_HPP_
+
+#include <KokkosBatched_Util.hpp>
+
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+
+namespace KokkosBatched {
+
+/// \brief Serial Batched Pbtrs:
+/// Compute the Cholesky factorization U**H * U (or L * L**H) of a real
+/// symmetric (or complex Hermitian) positive definite banded matrix A_l
+/// for all l = 0, ...,
+/// The factorization has the form
+///    A = U**T * U ,  if ArgUplo = KokkosBatched::Uplo::Upper, or
+///    A = L  * L**T,  if ArgUplo = KokkosBatched::Uplo::Lower,
+/// where U is an upper triangular matrix, U**T is the transpose of U, and
+/// L is lower triangular.
+/// This is the unblocked version of the algorithm, calling Level 2 BLAS.
+///
+/// \tparam ABViewType: Input type for a banded matrix, needs to be a 2D
+/// view
+///
+/// \param ab [in]: ab is a ldab by n banded matrix, with ( kd + 1 ) diagonals
+/// \param b  [inout]: right-hand side and the solution, a rank 1 view
+///
+/// No nested parallel_for is used inside of the function.
+///
+
+template <typename ArgUplo, typename ArgAlgo>
+struct SerialPbtrs {
+  template <typename ABViewType, typename BViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const ABViewType &ab, const BViewType &b);
+};
+
+}  // namespace KokkosBatched
+
+#include "KokkosBatched_Pbtrs_Serial_Impl.hpp"
+
+#endif  // KOKKOSBATCHED_PBTRS_HPP_

--- a/batched/dense/unit_test/Test_Batched_Dense.hpp
+++ b/batched/dense/unit_test/Test_Batched_Dense.hpp
@@ -58,6 +58,9 @@
 #include "Test_Batched_SerialPbtrf.hpp"
 #include "Test_Batched_SerialPbtrf_Real.hpp"
 #include "Test_Batched_SerialPbtrf_Complex.hpp"
+#include "Test_Batched_SerialPbtrs.hpp"
+#include "Test_Batched_SerialPbtrs_Real.hpp"
+#include "Test_Batched_SerialPbtrs_Complex.hpp"
 #include "Test_Batched_SerialLaswp.hpp"
 
 // Team Kernels

--- a/batched/dense/unit_test/Test_Batched_SerialPbtrs.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPbtrs.hpp
@@ -1,0 +1,323 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
+
+#include "KokkosBatched_Util.hpp"
+#include "KokkosBatched_Pbtrf.hpp"
+#include "KokkosBatched_Pbtrs.hpp"
+#include "Test_Batched_DenseUtils.hpp"
+
+using namespace KokkosBatched;
+
+namespace Test {
+namespace Pbtrs {
+
+template <typename U>
+struct ParamTag {
+  using uplo = U;
+};
+
+template <typename DeviceType, typename ABViewType, typename ParamTagType, typename AlgoTagType>
+struct Functor_BatchedSerialPbtrf {
+  using execution_space = typename DeviceType::execution_space;
+  ABViewType _ab;
+
+  KOKKOS_INLINE_FUNCTION
+  Functor_BatchedSerialPbtrf(const ABViewType &ab) : _ab(ab) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const ParamTagType &, const int k) const {
+    auto sub_ab = Kokkos::subview(_ab, k, Kokkos::ALL(), Kokkos::ALL());
+
+    KokkosBatched::SerialPbtrf<typename ParamTagType::uplo, AlgoTagType>::invoke(sub_ab);
+  }
+
+  inline void run() {
+    using value_type = typename ABViewType::non_const_value_type;
+    std::string name_region("KokkosBatched::Test::SerialPbtrs");
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, _ab.extent(0));
+    Kokkos::parallel_for(name.c_str(), policy, *this, info_sum);
+  }
+};
+
+template <typename DeviceType, typename ABViewType, typename BViewType,
+          typename ParamTagType, typename AlgoTagType>
+struct Functor_BatchedSerialPbtrs {
+  using execution_space = typename DeviceType::execution_space;
+  ABViewType _ab;
+  BViewType _b;
+
+  KOKKOS_INLINE_FUNCTION
+  Functor_BatchedSerialPbtrs(const ABViewType &ab, const BViewType &b)
+      : _ab(ab), _b(b) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const ParamTagType &, const int k, int &info) const {
+    auto sub_ab = Kokkos::subview(_ab, k, Kokkos::ALL(), Kokkos::ALL());
+    auto bb = Kokkos::subview(_b, k, Kokkos::ALL());
+
+    info += KokkosBatched::SerialPbtrs<typename ParamTagType::uplo,
+                                 AlgoTagType>::invoke(sub_ab, bb);
+  }
+
+  inline int run() {
+    using value_type = typename ABViewType::non_const_value_type;
+    std::string name_region("KokkosBatched::Test::SerialPbtrs");
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    int info_sum                      = 0;
+    Kokkos::Profiling::pushRegion(name.c_str());
+    Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, _b.extent(0));
+    Kokkos::parallel_reduce(name.c_str(), policy, *this, info_sum);
+    Kokkos::Profiling::popRegion();
+    return info_sum;
+  }
+};
+
+template <typename DeviceType, typename ScalarType, typename AViewType, typename BViewType, typename CViewType,
+          typename ArgTransA, typename ArgTransB>
+struct Functor_BatchedSerialGemm {
+  using execution_space = typename DeviceType::execution_space;
+  AViewType _a;
+  BViewType _b;
+  CViewType _c;
+  ScalarType _alpha, _beta;
+
+  KOKKOS_INLINE_FUNCTION
+  Functor_BatchedSerialGemm(const ScalarType alpha, const AViewType &a, const BViewType &b, const ScalarType beta,
+                            const CViewType &c)
+      : _a(a), _b(b), _c(c), _alpha(alpha), _beta(beta) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int k) const {
+    auto aa = Kokkos::subview(_a, k, Kokkos::ALL(), Kokkos::ALL());
+    auto bb = Kokkos::subview(_b, k, Kokkos::ALL(), Kokkos::ALL());
+    auto cc = Kokkos::subview(_c, k, Kokkos::ALL(), Kokkos::ALL());
+
+    KokkosBatched::SerialGemm<ArgTransA, ArgTransB, Algo::Gemm::Unblocked>::invoke(_alpha, aa, bb, _beta, cc);
+  }
+
+  inline void run() {
+    using value_type = typename AViewType::non_const_value_type;
+    std::string name_region("KokkosBatched::Test::SerialPbtrf");
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    Kokkos::RangePolicy<execution_space> policy(0, _a.extent(0));
+    Kokkos::parallel_for(name.c_str(), policy, *this);
+  }
+};
+
+template <typename DeviceType, typename ScalarType, typename LayoutType,
+          typename ParamTagType, typename AlgoTagType>
+/// \brief Implementation details of batched pbtrs test
+///        Confirm A * x = b, where
+///        A: [[4, 1, 0],
+///            [1, 4, 1],
+///            [0, 1, 4]]
+///        b: [1, 1, 1]
+///        x: [3/14, 1/7, 3/14]
+///
+///        This corresponds to the following system of equations:
+///        4 x0 +   x1        = 1
+///          x0 + 4 x1 +   x2 = 1
+///                 x1 + 4 x2 = 1
+/// \param N [in] Batch size of RHS (banded matrix can also be batched matrix)
+/// \param k [in] Number of superdiagonals or subdiagonals of matrix A
+/// \param BlkSize [in] Block size of matrix A
+void impl_test_batched_pbtrs_analytical(const int N) {
+  using ats        = typename Kokkos::ArithTraits<ScalarType>;
+  using RealType   = typename ats::mag_type;
+  using View2DType = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
+  using View3DType = Kokkos::View<ScalarType ***, LayoutType, DeviceType>;
+
+  constexpr int BlkSize = 3, k = 1;
+  View3DType A("A", N, BlkSize, BlkSize),
+      A_reconst("A_reconst", N, BlkSize, BlkSize);
+  View3DType Ab("Ab", N, k + 1, BlkSize);  // Banded matrix
+  View2DType x0("x0", N, BlkSize), x_ref("x_ref", N, BlkSize),
+      y0("y0", N, BlkSize);  // Solutions
+
+  auto h_A_reconst = Kokkos::create_mirror_view(A_reconst);
+  auto h_x_ref     = Kokkos::create_mirror_view(x_ref);
+
+  for (int ib = 0; ib < N; ib++) {
+    for (int i = 0; i < BlkSize; i++) {
+      for (int j = 0; j < BlkSize; j++) {
+        h_A_reconst(ib, i, j) = i == j ? 4.0 : 1.0;
+      }
+    }
+
+    h_x_ref(ib, 0) = 3.0 / 14.0;
+    h_x_ref(ib, 1) = 1.0 / 7.0;
+    h_x_ref(ib, 2) = 3.0 / 14.0;
+  }
+
+  Kokkos::fence();
+
+  Kokkos::deep_copy(x0, ScalarType(1.0));
+  Kokkos::deep_copy(A_reconst, h_A_reconst);
+
+  // Create banded triangluar matrix in normal and banded storage
+  using ArgUplo = typename ParamTagType::uplo;
+  create_banded_pds_matrix<View3DType, View3DType, ArgUplo>(A_reconst, A, k,
+                                                            false);
+  create_banded_triangular_matrix<View3DType, View3DType, ArgUplo>(A_reconst,
+                                                                   Ab, k, true);
+
+  // Factorize with Pbtrf: A = U**H * U or A = L * L**H
+  Functor_BatchedSerialPbtrf<DeviceType, View3DType, ParamTagType, AlgoTagType>(
+      Ab)
+      .run();
+
+  // pbtrs (Note, Ab is a factorized matrix of A)
+  auto info = Functor_BatchedSerialPbtrs<DeviceType, View3DType, View2DType, ParamTagType,
+                             AlgoTagType>(Ab, x0)
+      .run();
+
+  Kokkos::fence();
+  EXPECT_EQ(info, 0);
+
+  // this eps is about 10^-14
+  RealType eps = 1.0e3 * ats::epsilon();
+  auto h_x0    = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), x0);
+
+  // Check x0 = x1
+  for (int ib = 0; ib < N; ib++) {
+    for (int i = 0; i < BlkSize; i++) {
+      for (int j = 0; j < BlkSize; j++) {
+        EXPECT_NEAR_KK(h_x0(ib, i, j), h_x_ref(ib, i, j), eps);
+      }
+    }
+  }
+}
+
+template <typename DeviceType, typename ScalarType, typename LayoutType,
+          typename ParamTagType, typename AlgoTagType>
+/// \brief Implementation details of batched pbtrs test
+///        Confirm A * x = b, where
+///
+/// \param N [in] Batch size of RHS (banded matrix can also be batched matrix)
+/// \param k [in] Number of superdiagonals or subdiagonals of matrix A
+/// \param BlkSize [in] Block size of matrix A
+void impl_test_batched_pbtrs(const int N, const int k, const int BlkSize) {
+  using ats        = typename Kokkos::ArithTraits<ScalarType>;
+  using RealType   = typename ats::mag_type;
+  using View2DType = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
+  using View3DType = Kokkos::View<ScalarType ***, LayoutType, DeviceType>;
+
+  View3DType A("A", N, BlkSize, BlkSize),
+      A_reconst("A_reconst", N, BlkSize, BlkSize);
+  View3DType Ab("Ab", N, k + 1, BlkSize);  // Banded matrix
+  View2DType x0("x0", N, BlkSize), x_ref("x_ref", N, BlkSize),
+      y0("y0", N, BlkSize);  // Solutions
+
+  using execution_space = typename DeviceType::execution_space;
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
+  ScalarType randStart, randEnd;
+
+  // Initialize A_reconst with random matrix
+  KokkosKernels::Impl::getRandomBounds(1.0, randStart, randEnd);
+  Kokkos::fill_random(A, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(x0, rand_pool, randStart, randEnd);
+  Kokkos::deep_copy(x_ref, x0);
+
+  // Make the matrix Positive Definite Symmetric and Diagonal dominant
+  random_to_pds(A, A_reconst);
+  Kokkos::deep_copy(A, ScalarType(0.0));
+
+  // Create banded triangluar matrix in normal and banded storage
+  using ArgUplo = typename ParamTagType::uplo;
+  create_banded_pds_matrix<View3DType, View3DType, ArgUplo>(A_reconst, A, k,
+                                                            false);
+
+  create_banded_triangular_matrix<View3DType, View3DType, ArgUplo>(A_reconst,
+                                                                   Ab, k, true);
+
+  Kokkos::fence();
+
+  // Factorize with Pbtrf: A = U**H * U or A = L * L**H
+  Functor_BatchedSerialPbtrf<DeviceType, View3DType, ParamTagType, AlgoTagType>(
+      Ab)
+      .run();
+
+  // pbtrs (Note, Ab is a factorized matrix of A)
+  auto info = Functor_BatchedSerialPbtrs<DeviceType, View3DType, View2DType, ParamTagType,
+                             AlgoTagType>(Ab, x0)
+      .run();
+
+  Kokkos::fence();
+  EXPECT_EQ(info, 0);
+
+  // Gemv to compute A*x0, this should be identical to x_ref
+  Functor_BatchedSerialGemv<DeviceType, ScalarType, View3DType, View2DType,
+                            View2DType>(1.0, A, x0, 0.0, y0)
+      .run();
+
+  Kokkos::fence();
+
+  // this eps is about 10^-14
+  RealType eps = 1.0e3 * ats::epsilon();
+
+  auto h_y0    = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), y0);
+  auto h_x_ref = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), x_ref);
+
+  // Check A * x0 = x_ref
+  for (int ib = 0; ib < N; ib++) {
+    for (int i = 0; i < BlkSize; i++) {
+      for (int j = 0; j < BlkSize; j++) {
+        EXPECT_NEAR_KK(h_y0(ib, i, j), h_x_ref(ib, i, j), eps);
+      }
+    }
+  }
+}
+
+}  // namespace Pbtrs
+}  // namespace Test
+
+template <typename DeviceType, typename ScalarType, typename ParamTagType, typename AlgoTagType>
+int test_batched_pbtrs() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
+  {
+    using LayoutType = Kokkos::LayoutLeft;
+    Test::pbtrs::impl_test_batched_pbtrs_analytical<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1);
+    Test::Pbtrs::impl_test_batched_pbtrs_analytical<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2);
+    for (int i = 0; i < 10; i++) {
+      int k = 1;
+      Test::pbtrs::impl_test_batched_pbtrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1, k, i);
+      Test::pbtrs::impl_test_batched_pbtrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2, k, i);
+    }
+  }
+#endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
+  {
+    using LayoutType = Kokkos::LayoutRight;
+    Test::Pbtrs::impl_test_batched_pbtrs_analytical<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1);
+    Test::Pbtrs::impl_test_batched_pbtrs_analytical<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2);
+    for (int i = 0; i < 10; i++) {
+      int k = 1;
+      Test::Pbtrs::impl_test_batched_pbtrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1, k, i);
+      Test::Pbtrs::impl_test_batched_pbtrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2, k, i);
+    }
+  }
+#endif
+
+  return 0;
+}

--- a/batched/dense/unit_test/Test_Batched_SerialPbtrs.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPbtrs.hpp
@@ -189,7 +189,7 @@ void impl_test_batched_pbtrs_analytical(const int N) {
   // Check x0 = x1
   for (int ib = 0; ib < N; ib++) {
     for (int i = 0; i < BlkSize; i++) {
-      EXPECT_NEAR_KK(h_x0(ib, i), h_x_ref(ib, i), eps);
+      Test::EXPECT_NEAR_KK_REL(h_x0(ib, i), h_x_ref(ib, i), eps);
     }
   }
 }
@@ -256,7 +256,7 @@ void impl_test_batched_pbtrs(const int N, const int k, const int BlkSize) {
   // Check A * x0 = x_ref
   for (int ib = 0; ib < N; ib++) {
     for (int i = 0; i < BlkSize; i++) {
-      EXPECT_NEAR_KK(h_y0(ib, i), h_x_ref(ib, i), eps);
+      Test::EXPECT_NEAR_KK_REL(h_y0(ib, i), h_x_ref(ib, i), eps);
     }
   }
 }

--- a/batched/dense/unit_test/Test_Batched_SerialPbtrs_Complex.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPbtrs_Complex.hpp
@@ -1,0 +1,45 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_FLOAT)
+TEST_F(TestCategory, test_batched_pbtrs_l_fcomplex) {
+  using algo_tag_type  = typename Algo::Pbtrs::Unblocked;
+  using param_tag_type = ::Test::Pbtrs::ParamTag<Uplo::Lower>;
+
+  test_batched_pbtrs<TestDevice, Kokkos::complex<float>, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, test_batched_pbtrs_u_fcomplex) {
+  using algo_tag_type  = typename Algo::Pbtrs::Unblocked;
+  using param_tag_type = ::Test::Pbtrs::ParamTag<Uplo::Upper>;
+
+  test_batched_pbtrs<TestDevice, Kokkos::complex<float>, param_tag_type, algo_tag_type>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
+TEST_F(TestCategory, test_batched_pbtrs_l_dcomplex) {
+  using algo_tag_type  = typename Algo::Pbtrs::Unblocked;
+  using param_tag_type = ::Test::Pbtrs::ParamTag<Uplo::Lower>;
+
+  test_batched_pbtrs<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, test_batched_pbtrs_u_dcomplex) {
+  using algo_tag_type  = typename Algo::Pbtrs::Unblocked;
+  using param_tag_type = ::Test::Pbtrs::ParamTag<Uplo::Upper>;
+
+  test_batched_pbtrs<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
+}
+#endif

--- a/batched/dense/unit_test/Test_Batched_SerialPbtrs_Real.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPbtrs_Real.hpp
@@ -1,0 +1,45 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+TEST_F(TestCategory, test_batched_pbtrs_l_float) {
+  using algo_tag_type  = typename Algo::Pbtrs::Unblocked;
+  using param_tag_type = ::Test::Pbtrs::ParamTag<Uplo::Lower>;
+
+  test_batched_pbtrs<TestDevice, float, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, test_batched_pbtrs_u_float) {
+  using algo_tag_type  = typename Algo::Pbtrs::Unblocked;
+  using param_tag_type = ::Test::Pbtrs::ParamTag<Uplo::Upper>;
+
+  test_batched_pbtrs<TestDevice, float, param_tag_type, algo_tag_type>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+TEST_F(TestCategory, test_batched_pbtrs_l_double) {
+  using algo_tag_type  = typename Algo::Pbtrs::Unblocked;
+  using param_tag_type = ::Test::Pbtrs::ParamTag<Uplo::Lower>;
+
+  test_batched_pbtrs<TestDevice, double, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, test_batched_pbtrs_u_double) {
+  using algo_tag_type  = typename Algo::Pbtrs::Unblocked;
+  using param_tag_type = ::Test::Pbtrs::ParamTag<Uplo::Upper>;
+
+  test_batched_pbtrs<TestDevice, double, param_tag_type, algo_tag_type>();
+}
+#endif

--- a/blas/impl/KokkosBlas_util.hpp
+++ b/blas/impl/KokkosBlas_util.hpp
@@ -120,6 +120,7 @@ struct Algo {
   using ApplyQ = Level2;
   using Tbsv   = Level2;
   using Pbtrf  = Level2;
+  using Pbtrs  = Level2;
 };
 
 namespace Impl {


### PR DESCRIPTION
This PR implements [pbtrs](https://www.netlib.org/lapack/explore-html/db/dec/group__pbtrs_ga1ccbe62287933e8bf693cc0e506d167f.html) function.

Following files are added:
1. `KokkosBatched_Pbtrs_Serial_Impl.hpp`: Internal interfaces
2. `KokkosBatched_Pbtrs_Serial_Internal.hpp`: Implementation details
3. `KokkosBatched_Pbtrs.hpp`: APIs
4. `Test_Batched_SerialPbtrs.hpp`: Unit tests for that

## Detailed description
It solves the equation `A * x = b`, where `A` is a real symmetric (complex Hermitian) positive definite band matrix `A`, where `A` is stored in a [band storage](https://www.netlib.org/lapack/lug/node124.html).
Before solving, the Cholesky factorization `A = U**H*U` or `A = L*L**H`  must be computed by Pbtrf.

Here, the matrix has the following shape.
- `A`: `(batch_count, ldab, n)`  
  On entry, the upper or lower triangle of the symmetric band
  matrix A, stored in the first KD+1 rows of the array. On exit, the triangular factor `U` or `L` from the
  Cholesky factorization `A = U**H*U` or `A = L*L**H` of the band
  matrix `A`, in the same storage format as `A`
- `B`: `(batch_count, n)`  
   On entry, it contains the n element `n` right-hand side vector `b`. On exit, the solution vectors `x`.

Example of a single batch of matrix A `n = 10`.

```bash
A
4 1 0 0 0 0 0 0 0 0 
1 4 1 0 0 0 0 0 0 0 
0 1 4 1 0 0 0 0 0 0 
0 0 1 4 1 0 0 0 0 0 
0 0 0 1 4 1 0 0 0 0 
0 0 0 0 1 4 1 0 0 0 
0 0 0 0 0 1 4 1 0 0 
0 0 0 0 0 0 1 4 1 0 
0 0 0 0 0 0 0 1 4 1 
0 0 0 0 0 0 0 0 1 4

AB (upper)
0 1 1 1 1 1 1 1 1 1 
4 4 4 4 4 4 4 4 4 4

AB (lower)
4 4 4 4 4 4 4 4 4 4
1 1 1 1 1 1 1 1 1 0
```

Parallelization would be made in the following manner. This is efficient only when 
A is given in `LayoutLeft` for GPUs and `LayoutRight` for CPUs (parallelized over batch direction).

```C++
Kokkos::parallel_for('pbtrs', 
    Kokkos::RangePolicy<execution_space> policy(0, n),
    [=](const int k) {
        auto aa = Kokkos::subview(_a, k, Kokkos::ALL(), Kokkos::ALL());
        auto bb = Kokkos::subview(_b, k, Kokkos::ALL());

        KokkosBatched::SerialPbtrs<AlgoTagType>::invoke(aa, bb);
    });
```

## Tests
1.  Confirm `A * x = b` for analytical case, where
```bash
A: [[4, 1, 0],
    [1, 4, 1],
    [0, 1, 4]]
b: [1, 1, 1]
x: [3/14, 1/7, 3/14]
```

2. Make a real (complex Hermitian) symmetric positive definite banded matrix from random and keep it in a full (called `A`) or banded storage (called `AB`). Firstly, factorize `AB` in banded storage to get `U` or `L` by `pbtrf`. Then, solve `AB * x = b` with `pbtrs` to get `x`, while keeping the original `b` in `x_ref`. Finally confirm that `A * x` is equal to `b (=x_ref)` using GEMV.
