### PR TITLE
put default types in KokkosKernels namespace

### DIFF
--- a/blas/src/KokkosBlas1_dot.hpp
+++ b/blas/src/KokkosBlas1_dot.hpp
@@ -77,9 +77,9 @@ typename Kokkos::Details::InnerProductSpaceTraits<typename XVector::non_const_va
   // These special cases are to maintain accuracy.
   using result_type = typename KokkosBlas::Impl::DotAccumulatingScalar<dot_type>::type;
   using RVector_Internal =
-      Kokkos::View<dot_type, default_layout, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-  using RVector_Result =
-      Kokkos::View<result_type, default_layout, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+      Kokkos::View<dot_type, KokkosKernels::default_layout, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using RVector_Result = Kokkos::View<result_type, KokkosKernels::default_layout, Kokkos::HostSpace,
+                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
   XVector_Internal X = x;
   YVector_Internal Y = y;

--- a/blas/src/KokkosBlas1_nrm1.hpp
+++ b/blas/src/KokkosBlas1_nrm1.hpp
@@ -49,8 +49,8 @@ typename Kokkos::Details::InnerProductSpaceTraits<typename XVector::non_const_va
                                         typename KokkosKernels::Impl::GetUnifiedLayout<XVector>::array_layout,
                                         typename XVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
 
-  using RVector_Internal =
-      Kokkos::View<mag_type, default_layout, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+  using RVector_Internal = Kokkos::View<mag_type, KokkosKernels::default_layout, Kokkos::HostSpace,
+                                        Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
 
   mag_type result;
   RVector_Internal R = RVector_Internal(&result);

--- a/blas/src/KokkosBlas1_nrm2_squared.hpp
+++ b/blas/src/KokkosBlas1_nrm2_squared.hpp
@@ -55,7 +55,8 @@ typename Kokkos::Details::InnerProductSpaceTraits<typename XVector::non_const_va
                        typename XVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       XVector_Internal;
 
-  typedef Kokkos::View<mag_type, default_layout, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+  typedef Kokkos::View<mag_type, KokkosKernels::default_layout, Kokkos::HostSpace,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >
       RVector_Internal;
 
   mag_type result;

--- a/common/src/KokkosKernels_default_types.hpp
+++ b/common/src/KokkosKernels_default_types.hpp
@@ -30,58 +30,58 @@
   }
 
 #if defined(KOKKOSKERNELS_INST_ORDINAL_INT)
-using default_lno_t = int;
+KK_IMPL_MAKE_TYPE_ALIAS(default_lno_t, int)
 #elif defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T)
-using default_lno_t     = int64_t;
+KK_IMPL_MAKE_TYPE_ALIAS(default_lno_t, int64_t)
 #else
 // Non-ETI build: default to int
-using default_lno_t = int;
+KK_IMPL_MAKE_TYPE_ALIAS(default_lno_t, int)
 #endif
 // Prefer int as the default offset type, because cuSPARSE doesn't support
 // size_t for rowptrs.
 #if defined(KOKKOSKERNELS_INST_OFFSET_INT)
-using default_size_type = int;
+KK_IMPL_MAKE_TYPE_ALIAS(default_size_type, int)
 #elif defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)
-using default_size_type = size_t;
+KK_IMPL_MAKE_TYPE_ALIAS(default_size_type, size_t)
 #else
 // Non-ETI build: default to int
-using default_size_type = int;
+KK_IMPL_MAKE_TYPE_ALIAS(default_size_type, int)
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
-using default_layout = Kokkos::LayoutLeft;
+KK_IMPL_MAKE_TYPE_ALIAS(default_layout, Kokkos::LayoutLeft)
 #elif defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
-using default_layout    = Kokkos::LayoutRight;
+KK_IMPL_MAKE_TYPE_ALIAS(default_layout, Kokkos::LayoutRight)
 #else
-using default_layout    = Kokkos::LayoutLeft;
+KK_IMPL_MAKE_TYPE_ALIAS(default_layout, Kokkos::LayoutLeft)
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE)
-using default_scalar = double;
+KK_IMPL_MAKE_TYPE_ALIAS(default_scalar, double)
 #elif defined(KOKKOSKERNELS_INST_FLOAT)
-using default_scalar    = float;
+KK_IMPL_MAKE_TYPE_ALIAS(default_scalar, float)
 #elif defined(KOKKOSKERNELS_INST_HALF)
-using default_scalar    = Kokkos::Experimental::half_t;
+KK_IMPL_MAKE_TYPE_ALIAS(default_scalar, Kokkos::Experimental::half_t)
 #elif defined(KOKKOSKERNELS_INST_BHALF)
-using default_scalar = Kokkos::Experimental::bhalf_t;
+KK_IMPL_MAKE_TYPE_ALIAS(default_scalar, Kokkos::Experimental::bhalf_t)
 #else
-using default_scalar = double;
+KK_IMPL_MAKE_TYPE_ALIAS(default_scalar, double)
 #endif
 
 #if defined(KOKKOS_ENABLE_CUDA)
-using default_device = Kokkos::Cuda;
+KK_IMPL_MAKE_TYPE_ALIAS(default_device, Kokkos::Cuda)
 #elif defined(KOKKOS_ENABLE_HIP)
-using default_device    = Kokkos::HIP;
+KK_IMPL_MAKE_TYPE_ALIAS(default_device, Kokkos::HIP)
 #elif defined(KOKKOS_ENABLE_OPENMPTARGET)
-using default_device    = Kokkos::Experimental::OpenMPTarget;
+KK_IMPL_MAKE_TYPE_ALIAS(default_device, Kokkos::Experimental::OpenMPTarget)
 #elif defined(KOKKOS_ENABLE_OPENMP)
-using default_device = Kokkos::OpenMP;
+KK_IMPL_MAKE_TYPE_ALIAS(default_device, Kokkos::OpenMP)
 #elif defined(KOKKOS_ENABLE_THREADS)
-using default_device = Kokkos::Threads;
+KK_IMPL_MAKE_TYPE_ALIAS(default_device, Kokkos::Threads)
 #else
-using default_device = Kokkos::Serial;
+KK_IMPL_MAKE_TYPE_ALIAS(default_device, Kokkos::Serial)
 #endif
 
-}  // namespace KokkosKernels
+#undef KK_IMPL_MAKE_TYPE_ALIAS
 
 #endif  // KOKKOSKERNELS_DEFAULT_TYPES_H

--- a/common/src/KokkosKernels_default_types.hpp
+++ b/common/src/KokkosKernels_default_types.hpp
@@ -20,6 +20,15 @@
 #include "Kokkos_Core.hpp"         //for LayoutLeft/LayoutRight
 #include <KokkosKernels_config.h>  //for all the ETI #cmakedefine macros
 
+// define a deprecated symbol = type in the global namespace
+// and a non-deprecated version in Kokkos Kernels
+// these deprecations were done in 4.4.
+#define KK_IMPL_MAKE_TYPE_ALIAS(symbol, type)                            \
+  using symbol [[deprecated("use KokkosKernels::" #symbol ".")]] = type; \
+  namespace KokkosKernels {                                              \
+  using symbol = type;                                                   \
+  }
+
 #if defined(KOKKOSKERNELS_INST_ORDINAL_INT)
 using default_lno_t = int;
 #elif defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T)
@@ -72,5 +81,7 @@ using default_device = Kokkos::Threads;
 #else
 using default_device = Kokkos::Serial;
 #endif
+
+}  // namespace KokkosKernels
 
 #endif  // KOKKOSKERNELS_DEFAULT_TYPES_H

--- a/common/unit_test/Test_Common_IOUtils.hpp
+++ b/common/unit_test/Test_Common_IOUtils.hpp
@@ -42,7 +42,7 @@ class ViewPrintHelper {
 
 template <typename exec_space>
 void testPrintView() {
-  using scalar_t   = default_scalar;
+  using scalar_t   = KokkosKernels::default_scalar;
   using Unmanaged  = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
   using rank0_view = Kokkos::View<scalar_t, Kokkos::HostSpace, Unmanaged>;
   using rank1_view = Kokkos::View<scalar_t *, Kokkos::HostSpace, Unmanaged>;

--- a/example/half/xpy.cpp
+++ b/example/half/xpy.cpp
@@ -94,7 +94,7 @@ int main(int argc, char **argv) {
     return 1;
   }
   using LayoutType = Kokkos::LayoutLeft;
-  using DeviceType = default_device;
+  using DeviceType = KokkosKernels::default_device;
   size_t n         = atoi(argv[1]);
   bool time_only   = static_cast<bool>(atoi(argv[2]));
   do_xpy<float, DeviceType, LayoutType>(n, time_only);

--- a/example/wiki/graph/KokkosGraph_wiki_9pt_stencil.hpp
+++ b/example/wiki/graph/KokkosGraph_wiki_9pt_stencil.hpp
@@ -25,16 +25,16 @@
 #include <cmath>
 #include <sstream>
 
-using Ordinal     = default_lno_t;
-using Offset      = default_size_type;
-using Layout      = default_layout;
+using Ordinal     = KokkosKernels::default_lno_t;
+using Offset      = KokkosKernels::default_size_type;
+using Layout      = KokkosKernels::default_layout;
 using ExecSpace   = Kokkos::DefaultExecutionSpace;
 using DeviceSpace = typename ExecSpace::memory_space;
 using Kokkos::HostSpace;
 using RowmapType  = Kokkos::View<Offset*, DeviceSpace>;
 using ColindsType = Kokkos::View<Ordinal*, DeviceSpace>;
-using Handle = KokkosKernels::Experimental::KokkosKernelsHandle<Offset, Ordinal, default_scalar, ExecSpace, DeviceSpace,
-                                                                DeviceSpace>;
+using Handle      = KokkosKernels::Experimental::KokkosKernelsHandle<Offset, Ordinal, KokkosKernels::default_scalar,
+                                                                ExecSpace, DeviceSpace, DeviceSpace>;
 
 namespace GraphDemo {
 Ordinal gridX       = 15;

--- a/example/wiki/sparse/KokkosSparse_wiki_bsrmatrix.cpp
+++ b/example/wiki/sparse/KokkosSparse_wiki_bsrmatrix.cpp
@@ -23,10 +23,10 @@
 #include "KokkosSparse_BsrMatrix.hpp"
 #include "KokkosSparse_CrsMatrix.hpp"
 
-using Scalar  = default_scalar;
-using Ordinal = default_lno_t;
-using Offset  = default_size_type;
-using Layout  = default_layout;
+using Scalar  = KokkosKernels::default_scalar;
+using Ordinal = KokkosKernels::default_lno_t;
+using Offset  = KokkosKernels::default_size_type;
+using Layout  = KokkosKernels::default_layout;
 
 int main() {
   Kokkos::initialize();

--- a/example/wiki/sparse/KokkosSparse_wiki_bsrmatrix_2.cpp
+++ b/example/wiki/sparse/KokkosSparse_wiki_bsrmatrix_2.cpp
@@ -23,10 +23,10 @@
 #include "KokkosKernels_default_types.hpp"
 #include "KokkosSparse_BsrMatrix.hpp"
 
-using Scalar  = default_scalar;
-using Ordinal = default_lno_t;
-using Offset  = default_size_type;
-using Layout  = default_layout;
+using Scalar  = KokkosKernels::default_scalar;
+using Ordinal = KokkosKernels::default_lno_t;
+using Offset  = KokkosKernels::default_size_type;
+using Layout  = KokkosKernels::default_layout;
 
 template <class bsrmatrix_type>
 struct bsr_fill {

--- a/example/wiki/sparse/KokkosSparse_wiki_crsmatrix.cpp
+++ b/example/wiki/sparse/KokkosSparse_wiki_crsmatrix.cpp
@@ -21,10 +21,10 @@
 #include "KokkosSparse_CrsMatrix.hpp"
 #include "KokkosSparse_spmv.hpp"
 
-using Scalar  = default_scalar;
-using Ordinal = default_lno_t;
-using Offset  = default_size_type;
-using Layout  = default_layout;
+using Scalar  = KokkosKernels::default_scalar;
+using Ordinal = KokkosKernels::default_lno_t;
+using Offset  = KokkosKernels::default_size_type;
+using Layout  = KokkosKernels::default_layout;
 
 int main() {
   Kokkos::initialize();

--- a/example/wiki/sparse/KokkosSparse_wiki_gauss_seidel.cpp
+++ b/example/wiki/sparse/KokkosSparse_wiki_gauss_seidel.cpp
@@ -30,17 +30,17 @@
 
 // Helper to print out colors in the shape of the grid
 int main() {
-  using Scalar    = default_scalar;
+  using Scalar    = KokkosKernels::default_scalar;
   using Mag       = Kokkos::ArithTraits<Scalar>::mag_type;
-  using Ordinal   = default_lno_t;
-  using Offset    = default_size_type;
+  using Ordinal   = KokkosKernels::default_lno_t;
+  using Offset    = KokkosKernels::default_size_type;
   using ExecSpace = Kokkos::DefaultExecutionSpace;
   using MemSpace  = typename ExecSpace::memory_space;
   using Device    = Kokkos::Device<ExecSpace, MemSpace>;
-  using Handle =
-      KokkosKernels::Experimental::KokkosKernelsHandle<Offset, Ordinal, default_scalar, ExecSpace, MemSpace, MemSpace>;
-  using Matrix              = KokkosSparse::CrsMatrix<Scalar, Ordinal, Device, void, Offset>;
-  using Vector              = typename Matrix::values_type;
+  using Handle    = KokkosKernels::Experimental::KokkosKernelsHandle<Offset, Ordinal, KokkosKernels::default_scalar,
+                                                                  ExecSpace, MemSpace, MemSpace>;
+  using Matrix    = KokkosSparse::CrsMatrix<Scalar, Ordinal, Device, void, Offset>;
+  using Vector    = typename Matrix::values_type;
   constexpr Ordinal numRows = 10000;
   const Scalar one          = Kokkos::ArithTraits<Scalar>::one();
   const Mag magOne          = Kokkos::ArithTraits<Mag>::one();

--- a/example/wiki/sparse/KokkosSparse_wiki_spadd.cpp
+++ b/example/wiki/sparse/KokkosSparse_wiki_spadd.cpp
@@ -20,10 +20,10 @@
 
 #include "KokkosKernels_Test_Structured_Matrix.hpp"
 
-using Scalar  = default_scalar;
-using Ordinal = default_lno_t;
-using Offset  = default_size_type;
-using Layout  = default_layout;
+using Scalar  = KokkosKernels::default_scalar;
+using Ordinal = KokkosKernels::default_lno_t;
+using Offset  = KokkosKernels::default_size_type;
+using Layout  = KokkosKernels::default_layout;
 
 int main() {
   Kokkos::initialize();

--- a/example/wiki/sparse/KokkosSparse_wiki_spgemm.cpp
+++ b/example/wiki/sparse/KokkosSparse_wiki_spgemm.cpp
@@ -20,10 +20,10 @@
 
 #include "KokkosKernels_Test_Structured_Matrix.hpp"
 
-using Scalar  = default_scalar;
-using Ordinal = default_lno_t;
-using Offset  = default_size_type;
-using Layout  = default_layout;
+using Scalar  = KokkosKernels::default_scalar;
+using Ordinal = KokkosKernels::default_lno_t;
+using Offset  = KokkosKernels::default_size_type;
+using Layout  = KokkosKernels::default_layout;
 
 int main() {
   Kokkos::initialize();

--- a/example/wiki/sparse/KokkosSparse_wiki_spmv.cpp
+++ b/example/wiki/sparse/KokkosSparse_wiki_spmv.cpp
@@ -21,10 +21,10 @@
 
 #include "KokkosKernels_Test_Structured_Matrix.hpp"
 
-using Scalar  = default_scalar;
-using Ordinal = default_lno_t;
-using Offset  = default_size_type;
-using Layout  = default_layout;
+using Scalar  = KokkosKernels::default_scalar;
+using Ordinal = KokkosKernels::default_lno_t;
+using Offset  = KokkosKernels::default_size_type;
+using Layout  = KokkosKernels::default_layout;
 
 template <class Yvector>
 struct check_spmv_functor {

--- a/graph/unit_test/Test_Graph_graph_color.hpp
+++ b/graph/unit_test/Test_Graph_graph_color.hpp
@@ -169,30 +169,30 @@ void test_coloring(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size
   // device::execution_space::finalize();
 }
 
-#define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE)                                        \
-  TEST_F(TestCategory, graph##_##graph_color##_##SCALAR##_##ORDINAL##_##OFFSET##_##DEVICE) { \
-    test_coloring<SCALAR, ORDINAL, OFFSET, DEVICE>(50000, 50000 * 30, 200, 10);              \
-    test_coloring<SCALAR, ORDINAL, OFFSET, DEVICE>(50000, 50000 * 30, 100, 10);              \
+#define EXECUTE_TEST(ORDINAL, OFFSET, DEVICE)                                                          \
+  TEST_F(TestCategory, graph##_##graph_color##_default_scalar_##ORDINAL##_##OFFSET##_##DEVICE) {       \
+    test_coloring<KokkosKernels::default_scalar, ORDINAL, OFFSET, DEVICE>(50000, 50000 * 30, 200, 10); \
+    test_coloring<KokkosKernels::default_scalar, ORDINAL, OFFSET, DEVICE>(50000, 50000 * 30, 100, 10); \
   }
 
 #if (defined(KOKKOSKERNELS_INST_ORDINAL_INT) && defined(KOKKOSKERNELS_INST_OFFSET_INT)) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-EXECUTE_TEST(default_scalar, int, int, TestDevice)
+EXECUTE_TEST(int, int, TestDevice)
 #endif
 
 #if (defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T) && defined(KOKKOSKERNELS_INST_OFFSET_INT)) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-EXECUTE_TEST(default_scalar, int64_t, int, TestDevice)
+EXECUTE_TEST(int64_t, int, TestDevice)
 #endif
 
 #if (defined(KOKKOSKERNELS_INST_ORDINAL_INT) && defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-EXECUTE_TEST(default_scalar, int, size_t, TestDevice)
+EXECUTE_TEST(int, size_t, TestDevice)
 #endif
 
 #if (defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T) && defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-EXECUTE_TEST(default_scalar, int64_t, size_t, TestDevice)
+EXECUTE_TEST(int64_t, size_t, TestDevice)
 #endif
 
 #undef EXECUTE_TEST

--- a/graph/unit_test/Test_Graph_graph_color_deterministic.hpp
+++ b/graph/unit_test/Test_Graph_graph_color_deterministic.hpp
@@ -222,30 +222,30 @@ void test_coloring_deterministic(lno_t numRows, size_type nnz) {
   }
 }
 
-#define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE)                                                      \
-  TEST_F(TestCategory, graph##_##graph_color_deterministic##_##SCALAR##_##ORDINAL##_##OFFSET##_##DEVICE) { \
-    test_coloring_deterministic<SCALAR, ORDINAL, OFFSET, DEVICE>(18, 74);                                  \
-    test_coloring_deterministic<SCALAR, ORDINAL, OFFSET, DEVICE>(18, 74);                                  \
+#define EXECUTE_TEST(ORDINAL, OFFSET, DEVICE)                                                                  \
+  TEST_F(TestCategory, graph##_##graph_color_deterministic##_default_scalar_##ORDINAL##_##OFFSET##_##DEVICE) { \
+    test_coloring_deterministic<KokkosKernels::default_scalar, ORDINAL, OFFSET, DEVICE>(18, 74);               \
+    test_coloring_deterministic<KokkosKernels::default_scalar, ORDINAL, OFFSET, DEVICE>(18, 74);               \
   }
 
 #if (defined(KOKKOSKERNELS_INST_ORDINAL_INT) && defined(KOKKOSKERNELS_INST_OFFSET_INT)) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-EXECUTE_TEST(default_scalar, int, int, TestDevice)
+EXECUTE_TEST(int, int, TestDevice)
 #endif
 
 #if (defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T) && defined(KOKKOSKERNELS_INST_OFFSET_INT)) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-EXECUTE_TEST(default_scalar, int64_t, int, TestDevice)
+EXECUTE_TEST(int64_t, int, TestDevice)
 #endif
 
 #if (defined(KOKKOSKERNELS_INST_ORDINAL_INT) && defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-EXECUTE_TEST(default_scalar, int, size_t, TestDevice)
+EXECUTE_TEST(int, size_t, TestDevice)
 #endif
 
 #if (defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T) && defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-EXECUTE_TEST(default_scalar, int64_t, size_t, TestDevice)
+EXECUTE_TEST(int64_t, size_t, TestDevice)
 #endif
 
 #undef EXECUTE_TEST

--- a/graph/unit_test/Test_Graph_rcm.hpp
+++ b/graph/unit_test/Test_Graph_rcm.hpp
@@ -119,7 +119,7 @@ void test_rcm(const rowmap_t& rowmap, const entries_t& entries, bool expectBandw
 
 template <typename lno_t, typename size_type, typename device>
 void test_rcm_zerorows() {
-  using graph_t   = Kokkos::StaticCrsGraph<lno_t, default_layout, device, void, size_type>;
+  using graph_t   = Kokkos::StaticCrsGraph<lno_t, KokkosKernels::default_layout, device, void, size_type>;
   using rowmap_t  = typename graph_t::row_map_type::non_const_type;
   using entries_t = typename graph_t::entries_type::non_const_type;
   rowmap_t rowmap;
@@ -129,7 +129,7 @@ void test_rcm_zerorows() {
 
 template <typename lno_t, typename size_type, typename device>
 void test_rcm_7pt(lno_t gridX, lno_t gridY, lno_t gridZ, bool expectBandwidthReduced) {
-  using graph_t   = Kokkos::StaticCrsGraph<lno_t, default_layout, device, void, size_type>;
+  using graph_t   = Kokkos::StaticCrsGraph<lno_t, KokkosKernels::default_layout, device, void, size_type>;
   using rowmap_t  = typename graph_t::row_map_type::non_const_type;
   using entries_t = typename graph_t::entries_type::non_const_type;
   rowmap_t rowmap;
@@ -140,7 +140,7 @@ void test_rcm_7pt(lno_t gridX, lno_t gridY, lno_t gridZ, bool expectBandwidthRed
 
 template <typename lno_t, typename size_type, typename device>
 void test_rcm_4clique() {
-  using graph_t   = Kokkos::StaticCrsGraph<lno_t, default_layout, device, void, size_type>;
+  using graph_t   = Kokkos::StaticCrsGraph<lno_t, KokkosKernels::default_layout, device, void, size_type>;
   using rowmap_t  = typename graph_t::row_map_type::non_const_type;
   using entries_t = typename graph_t::entries_type::non_const_type;
   rowmap_t rowmap("rowmap", 5);
@@ -156,7 +156,7 @@ void test_rcm_4clique() {
 
 template <typename lno_t, typename size_type, typename device>
 void test_rcm_multiple_components() {
-  using graph_t   = Kokkos::StaticCrsGraph<lno_t, default_layout, device, void, size_type>;
+  using graph_t   = Kokkos::StaticCrsGraph<lno_t, KokkosKernels::default_layout, device, void, size_type>;
   using rowmap_t  = typename graph_t::row_map_type::non_const_type;
   using entries_t = typename graph_t::entries_type::non_const_type;
   // Generate a single 3D grid first

--- a/perf_test/blas/blas3/KokkosBlas3_common.hpp
+++ b/perf_test/blas/blas3/KokkosBlas3_common.hpp
@@ -42,14 +42,14 @@
 /************************ blas routine structure definitions **********/
 struct perf_test_trmm_args {
   std::string trmm_args;
-  default_scalar alpha;
+  KokkosKernels::default_scalar alpha;
 };
 typedef struct perf_test_trmm_args pt_trmm_args_t;
 
 struct perf_test_gemm_args {
   std::string gemm_args;  //[N,T,C][N,T,C] for transA and transB
-  default_scalar alpha;
-  default_scalar beta;
+  KokkosKernels::default_scalar alpha;
+  KokkosKernels::default_scalar beta;
 };
 typedef struct perf_test_gemm_args pt_gemm_args_t;
 // ADD MORE BLAS3 ROUTINE ARG STRUCTS HERE.

--- a/perf_test/blas/blas3/KokkosBlas3_perf_test.cpp
+++ b/perf_test/blas/blas3/KokkosBlas3_perf_test.cpp
@@ -301,12 +301,12 @@ int main(int argc, char **argv) {
         double alpha, beta;
         if (sscanf(optarg, "%lf,%lf", &alpha, &beta) != 2) __blas3_perf_test_input_error(argv, ret, optarg);
 
-        options.blas_args.gemm.alpha = static_cast<default_scalar>(alpha);
-        options.blas_args.gemm.beta  = static_cast<default_scalar>(beta);
+        options.blas_args.gemm.alpha = static_cast<KokkosKernels::default_scalar>(alpha);
+        options.blas_args.gemm.beta  = static_cast<KokkosKernels::default_scalar>(beta);
         break;
       case 'a':
         // printf("optarg=%s. %d\n", optarg, strncasecmp(optarg, "blas", 4));
-        options.blas_args.trmm.alpha = (default_scalar)atof(optarg);
+        options.blas_args.trmm.alpha = (KokkosKernels::default_scalar)atof(optarg);
         break;
       case 'l':
         for (i = 0; i < LOOP_N; i++) {

--- a/perf_test/blas/blas3/KokkosBlas_trtri_perf_test.hpp
+++ b/perf_test/blas/blas3/KokkosBlas_trtri_perf_test.hpp
@@ -59,8 +59,9 @@ static inline double __trtri_impl_flop_count(double a_m, double /*a_n*/) {
   double flop_count = 0;
   double flops_per_div, flops_per_mul, flops_per_add;
 
-  if (std::is_same<double, default_scalar>::value || std::is_same<float, default_scalar>::value ||
-      std::is_same<Kokkos::Experimental::half_t, default_scalar>::value) {
+  if (std::is_same<double, KokkosKernels::default_scalar>::value ||
+      std::is_same<float, KokkosKernels::default_scalar>::value ||
+      std::is_same<Kokkos::Experimental::half_t, KokkosKernels::default_scalar>::value) {
     flops_per_div = 1;
     flops_per_mul = 1;
     flops_per_add = 1;
@@ -93,8 +94,9 @@ static inline double __trtri_flop_count(double a_m, double a_n) {
     exit(255);
   }
 
-  if (std::is_same<double, default_scalar>::value || std::is_same<float, default_scalar>::value ||
-      std::is_same<Kokkos::Experimental::half_t, default_scalar>::value) {
+  if (std::is_same<double, KokkosKernels::default_scalar>::value ||
+      std::is_same<float, KokkosKernels::default_scalar>::value ||
+      std::is_same<Kokkos::Experimental::half_t, KokkosKernels::default_scalar>::value) {
     flops_per_mul = 1;
     flops_per_add = 1;
   } else {
@@ -110,7 +112,7 @@ static inline double __trtri_flop_count(double a_m, double a_n) {
   return flops;
 }
 
-using view_type_3d = Kokkos::View<default_scalar***, default_layout, default_device>;
+using view_type_3d = Kokkos::View<KokkosKernels::default_scalar***, default_layout, default_device>;
 struct trtri_args {
   char uplo, diag;
   view_type_3d A;
@@ -145,8 +147,9 @@ static void __print_trtri_perf_test_options(options_t options) {
   printf("options.n         = %d\n", options.n);
   printf("options.blas_args.trtri.trtri_args = %s\n", options.blas_args.trtri.trtri_args.c_str());
   printf("options.out_file  = %s\n", options.out_file.c_str());
-  std::cout << "SCALAR:" << typeid(default_scalar).name() << ", LAYOUT:" << typeid(default_layout).name()
-            << ", DEVICE:." << typeid(default_device).name() << std::endl;
+  std::cout << "SCALAR:" << typeid(KokkosKernels::default_scalar).name()
+            << ", LAYOUT:" << typeid(KokkosKernels::default_layout).name() << ", DEVICE:."
+            << typeid(KokkosKernels::default_device).name() << std::endl;
 #else
 static void __print_trtri_perf_test_options(options_t) {
 #endif  // TRTRI_PERF_TEST_DEBUG
@@ -456,8 +459,9 @@ void __do_loop_and_invoke(options_t options, void (*fn)(options_t, trtri_args_t)
   STATUS;
 
   __print_trtri_perf_test_options(options);
-  std::cout << "SCALAR:" << typeid(default_scalar).name() << ", LAYOUT:" << typeid(default_layout).name()
-            << ", DEVICE:." << typeid(default_device).name() << std::endl;
+  std::cout << "SCALAR:" << typeid(KokkosKernels::default_scalar).name()
+            << ", LAYOUT:" << typeid(KokkosKernels::default_layout).name() << ", DEVICE:."
+            << typeid(KokkosKernels::default_device).name() << std::endl;
 
   options.out[0] << trtri_csv_header_str << std::endl;
 
@@ -465,7 +469,8 @@ void __do_loop_and_invoke(options_t options, void (*fn)(options_t, trtri_args_t)
                                  cur_dims.b.m <= options.stop.b.m && cur_dims.b.n <= options.stop.b.n;
        cur_dims.a.m += options.step, cur_dims.a.n += options.step, cur_dims.b.m += options.step,
       cur_dims.b.n += options.step) {
-    trtri_args = __do_setup<default_scalar, view_type_3d, default_device>(options, cur_dims);
+    trtri_args =
+        __do_setup<KokkosKernels::default_scalar, view_type_3d, KokkosKernels::default_device>(options, cur_dims);
     fn(options, trtri_args);
   }
   return;
@@ -474,25 +479,26 @@ void __do_loop_and_invoke(options_t options, void (*fn)(options_t, trtri_args_t)
 /*************************** External fns **************************/
 void do_trtri_serial_blas(options_t options) {
   STATUS;
-  __do_loop_and_invoke(options, __do_trtri_serial_blas<default_scalar, view_type_3d, default_device>);
+  __do_loop_and_invoke(options, __do_trtri_serial_blas<KokkosKernels::default_scalar, view_type_3d, default_device>);
   return;
 }
 
 void do_trtri_serial_batched(options_t options) {
   STATUS;
-  __do_loop_and_invoke(options, __do_trtri_serial_batched<default_scalar, view_type_3d, default_device>);
+  __do_loop_and_invoke(options, __do_trtri_serial_batched<KokkosKernels::default_scalar, view_type_3d, default_device>);
   return;
 }
 
 void do_trtri_parallel_blas(options_t options) {
   STATUS;
-  __do_loop_and_invoke(options, __do_trtri_parallel_blas<default_scalar, view_type_3d, default_device>);
+  __do_loop_and_invoke(options, __do_trtri_parallel_blas<KokkosKernels::default_scalar, view_type_3d, default_device>);
   return;
 }
 
 void do_trtri_parallel_batched(options_t options) {
   STATUS;
-  __do_loop_and_invoke(options, __do_trtri_parallel_batched<default_scalar, view_type_3d, default_device>);
+  __do_loop_and_invoke(options,
+                       __do_trtri_parallel_batched<KokkosKernels::default_scalar, view_type_3d, default_device>);
   return;
 }
 

--- a/perf_test/blas/blas3/KokkosBlas_trtri_perf_test.hpp
+++ b/perf_test/blas/blas3/KokkosBlas_trtri_perf_test.hpp
@@ -112,7 +112,8 @@ static inline double __trtri_flop_count(double a_m, double a_n) {
   return flops;
 }
 
-using view_type_3d = Kokkos::View<KokkosKernels::default_scalar***, default_layout, default_device>;
+using view_type_3d =
+    Kokkos::View<KokkosKernels::default_scalar***, KokkosKernels::default_layout, KokkosKernels::default_device>;
 struct trtri_args {
   char uplo, diag;
   view_type_3d A;
@@ -479,26 +480,29 @@ void __do_loop_and_invoke(options_t options, void (*fn)(options_t, trtri_args_t)
 /*************************** External fns **************************/
 void do_trtri_serial_blas(options_t options) {
   STATUS;
-  __do_loop_and_invoke(options, __do_trtri_serial_blas<KokkosKernels::default_scalar, view_type_3d, default_device>);
+  __do_loop_and_invoke(
+      options, __do_trtri_serial_blas<KokkosKernels::default_scalar, view_type_3d, KokkosKernels::default_device>);
   return;
 }
 
 void do_trtri_serial_batched(options_t options) {
   STATUS;
-  __do_loop_and_invoke(options, __do_trtri_serial_batched<KokkosKernels::default_scalar, view_type_3d, default_device>);
+  __do_loop_and_invoke(
+      options, __do_trtri_serial_batched<KokkosKernels::default_scalar, view_type_3d, KokkosKernels::default_device>);
   return;
 }
 
 void do_trtri_parallel_blas(options_t options) {
   STATUS;
-  __do_loop_and_invoke(options, __do_trtri_parallel_blas<KokkosKernels::default_scalar, view_type_3d, default_device>);
+  __do_loop_and_invoke(
+      options, __do_trtri_parallel_blas<KokkosKernels::default_scalar, view_type_3d, KokkosKernels::default_device>);
   return;
 }
 
 void do_trtri_parallel_batched(options_t options) {
   STATUS;
-  __do_loop_and_invoke(options,
-                       __do_trtri_parallel_batched<KokkosKernels::default_scalar, view_type_3d, default_device>);
+  __do_loop_and_invoke(
+      options, __do_trtri_parallel_batched<KokkosKernels::default_scalar, view_type_3d, KokkosKernels::default_device>);
   return;
 }
 

--- a/perf_test/graph/KokkosGraph_color_d2.cpp
+++ b/perf_test/graph/KokkosGraph_color_d2.cpp
@@ -69,9 +69,9 @@ struct D2Parameters {
   }
 };
 
-typedef default_scalar kk_scalar_t;
-typedef default_size_type kk_size_type;
-typedef default_lno_t kk_lno_t;
+using kk_scalar_t  = KokkosKernels::default_scalar;
+using kk_size_type = KokkosKernels::default_size_type;
+using kk_lno_t     = KokkosKernels::default_lno_t;
 
 using KokkosKernels::Impl::xorshiftHash;
 

--- a/perf_test/graph/KokkosGraph_mis_d2.cpp
+++ b/perf_test/graph/KokkosGraph_mis_d2.cpp
@@ -202,14 +202,15 @@ int parse_inputs(MIS2Parameters& params, int argc, char** argv) {
 
 template <typename device_t>
 void run_mis2(const MIS2Parameters& params) {
-  using size_type  = default_size_type;
-  using lno_t      = default_lno_t;
-  using exec_space = typename device_t::execution_space;
-  using mem_space  = typename device_t::memory_space;
-  using crsMat_t   = typename KokkosSparse::CrsMatrix<default_scalar, lno_t, device_t, void, size_type>;
-  using lno_view_t = typename crsMat_t::index_type::non_const_type;
-  using KKH = KokkosKernels::Experimental::KokkosKernelsHandle<size_type, lno_t, default_scalar, exec_space, mem_space,
-                                                               mem_space>;
+  using size_type   = KokkosKernels::default_size_type;
+  using lno_t       = KokkosKernels::default_lno_t;
+  using scalar_type = KokkosKernels::default_scalar;
+  using exec_space  = typename device_t::execution_space;
+  using mem_space   = typename device_t::memory_space;
+  using crsMat_t    = typename KokkosSparse::CrsMatrix<scalar_type, lno_t, device_t, void, size_type>;
+  using lno_view_t  = typename crsMat_t::index_type::non_const_type;
+  using KKH =
+      KokkosKernels::Experimental::KokkosKernelsHandle<size_type, lno_t, scalar_type, exec_space, mem_space, mem_space>;
 
   Kokkos::Timer t;
   crsMat_t A_in = KokkosSparse::Impl::read_kokkos_crst_matrix<crsMat_t>(params.mtx_file);
@@ -219,7 +220,7 @@ void run_mis2(const MIS2Parameters& params) {
   crsMat_t At_in = KokkosSparse::Impl::transpose_matrix(A_in);
   crsMat_t A;
   KKH kkh;
-  const default_scalar one = Kokkos::ArithTraits<default_scalar>::one();
+  const scalar_type one = Kokkos::ArithTraits<scalar_type>::one();
   kkh.create_spadd_handle(false);
   KokkosSparse::spadd_symbolic(&kkh, A_in, At_in, A);
   KokkosSparse::spadd_numeric(&kkh, one, A_in, one, At_in, A);

--- a/perf_test/graph/KokkosGraph_triangle.cpp
+++ b/perf_test/graph/KokkosGraph_triangle.cpp
@@ -230,9 +230,9 @@ void run_experiment(int argc, char **argv, perf_test::CommonInputParams) {
   using namespace KokkosSparse;
   using mem_space = typename exec_space::memory_space;
   using device_t  = Kokkos::Device<exec_space, mem_space>;
-  using lno_t     = default_lno_t;
-  using size_type = default_size_type;
-  using graph_t   = Kokkos::StaticCrsGraph<lno_t, default_layout, device_t, void, size_type>;
+  using lno_t     = KokkosKernels::default_lno_t;
+  using size_type = KokkosKernels::default_size_type;
+  using graph_t   = Kokkos::StaticCrsGraph<lno_t, KokkosKernels::default_layout, device_t, void, size_type>;
   using KernelHandle =
       KokkosKernels::Experimental::KokkosKernelsHandle<size_type, lno_t, lno_t, exec_space, mem_space, mem_space>;
 

--- a/perf_test/sparse/KokkosSparse_gs.cpp
+++ b/perf_test/sparse/KokkosSparse_gs.cpp
@@ -151,9 +151,9 @@ crsMat_t generateLongRowMatrix(const GS_Parameters& params) {
 
 template <typename device_t>
 void runGS(const GS_Parameters& params) {
-  typedef default_scalar scalar_t;
-  typedef default_lno_t lno_t;
-  typedef default_size_type size_type;
+  using scalar_t  = KokkosKernels::default_scalar;
+  using lno_t     = KokkosKernels::default_lno_t;
+  using size_type = KokkosKernels::default_size_type;
   typedef typename device_t::execution_space exec_space;
   typedef typename device_t::memory_space mem_space;
   typedef KokkosKernels::Experimental::KokkosKernelsHandle<size_type, lno_t, scalar_t, exec_space, mem_space, mem_space>

--- a/perf_test/sparse/KokkosSparse_kk_spmv.cpp
+++ b/perf_test/sparse/KokkosSparse_kk_spmv.cpp
@@ -32,9 +32,9 @@
 #include <KokkosSparse_spmv.hpp>
 #include "KokkosKernels_default_types.hpp"
 
-using Scalar  = default_scalar;
-using Ordinal = default_lno_t;
-using Offset  = default_size_type;
+using Scalar  = KokkosKernels::default_scalar;
+using Ordinal = KokkosKernels::default_lno_t;
+using Offset  = KokkosKernels::default_size_type;
 using KAT     = Kokkos::ArithTraits<Scalar>;
 
 struct SPMVBenchmarking {

--- a/perf_test/sparse/KokkosSparse_kk_spmv.cpp
+++ b/perf_test/sparse/KokkosSparse_kk_spmv.cpp
@@ -200,7 +200,7 @@ void print_help() {
 int main(int argc, char** argv) {
   SPMVBenchmarking sb;
   char layout;
-  if (std::is_same<default_layout, Kokkos::LayoutLeft>::value)
+  if (std::is_same<KokkosKernels::default_layout, Kokkos::LayoutLeft>::value)
     layout = 'L';
   else
     layout = 'R';

--- a/perf_test/sparse/KokkosSparse_par_ilut.cpp
+++ b/perf_test/sparse/KokkosSparse_par_ilut.cpp
@@ -54,9 +54,9 @@ using KokkosSparse::Experimental::spiluk_symbolic;
 using KokkosSparse::Experimental::SPILUKAlgorithm;
 
 // Build up useful types
-using scalar_t  = default_scalar;
-using lno_t     = default_lno_t;
-using size_type = default_size_type;
+using scalar_t  = KokkosKernels::default_scalar;
+using lno_t     = KokkosKernels::default_lno_t;
+using size_type = KokkosKernels::default_size_type;
 using exe_space = Kokkos::DefaultExecutionSpace;
 using mem_space = typename exe_space::memory_space;
 using device    = Kokkos::Device<exe_space, mem_space>;

--- a/perf_test/sparse/KokkosSparse_pcg.cpp
+++ b/perf_test/sparse/KokkosSparse_pcg.cpp
@@ -27,14 +27,15 @@
 #define MAXVAL 1
 
 template <typename scalar_view_t>
-scalar_view_t create_x_vector(default_lno_t nv, default_scalar max_value = 1.0) {
+scalar_view_t create_x_vector(KokkosKernels::default_lno_t nv, KokkosKernels::default_scalar max_value = 1.0) {
   scalar_view_t kok_x("X", nv);
 
   typename scalar_view_t::HostMirror h_x = Kokkos::create_mirror_view(kok_x);
 
-  for (default_lno_t i = 0; i < nv; ++i) {
-    default_scalar r = static_cast<default_scalar>(rand()) / static_cast<default_scalar>(RAND_MAX / max_value);
-    h_x(i)           = r;
+  for (KokkosKernels::default_lno_t i = 0; i < nv; ++i) {
+    KokkosKernels::default_scalar r = static_cast<KokkosKernels::default_scalar>(rand()) /
+                                      static_cast<KokkosKernels::default_scalar>(RAND_MAX / max_value);
+    h_x(i) = r;
   }
   Kokkos::deep_copy(kok_x, h_x);
   return kok_x;
@@ -57,9 +58,9 @@ void run_experiment(crsMat_t crsmat, int clusterSize, bool useSequential) {
   typedef typename lno_view_t::value_type size_type;
   typedef typename scalar_view_t::value_type scalar_t;
 
-  default_lno_t nv             = crsmat.numRows();
-  scalar_view_t kok_x_original = create_x_vector<scalar_view_t>(nv, MAXVAL);
-  scalar_view_t kok_b_vector   = create_y_vector(crsmat, kok_x_original);
+  KokkosKernels::default_lno_t nv = crsmat.numRows();
+  scalar_view_t kok_x_original    = create_x_vector<scalar_view_t>(nv, MAXVAL);
+  scalar_view_t kok_b_vector      = create_y_vector(crsmat, kok_x_original);
 
   // create X vector
   scalar_view_t kok_x_vector("kok_x_vector", nv);
@@ -220,13 +221,15 @@ enum {
 
 template <typename execution_space>
 void run_pcg(int *cmdline, const char *mtx_file) {
-  default_lno_t nv = 0, ne = 0;
-  default_lno_t *xadj, *adj;
-  default_scalar *ew;
+  using lno_t = KokkosKernels::default_lno_t;
+  lno_t nv = 0, ne = 0;
+  lno_t *xadj, *adj;
+  KokkosKernels::default_scalar *ew;
 
-  KokkosSparse::Impl::read_matrix<default_lno_t, default_lno_t, default_scalar>(&nv, &ne, &xadj, &adj, &ew, mtx_file);
+  KokkosSparse::Impl::read_matrix<lno_t, lno_t, KokkosKernels::default_scalar>(&nv, &ne, &xadj, &adj, &ew, mtx_file);
 
-  typedef typename KokkosSparse::CrsMatrix<default_scalar, default_lno_t, execution_space, void, default_size_type>
+  typedef typename KokkosSparse::CrsMatrix<KokkosKernels::default_scalar, lno_t, execution_space, void,
+                                           KokkosKernels::default_size_type>
       crsMat_t;
 
   typedef typename crsMat_t::StaticCrsGraphType graph_t;
@@ -243,11 +246,11 @@ void run_pcg(int *cmdline, const char *mtx_file) {
     typename cols_view_t::HostMirror hc    = Kokkos::create_mirror_view(columns_view);
     typename values_view_t::HostMirror hv  = Kokkos::create_mirror_view(values_view);
 
-    for (default_lno_t i = 0; i <= nv; ++i) {
+    for (lno_t i = 0; i <= nv; ++i) {
       hr(i) = xadj[i];
     }
 
-    for (default_lno_t i = 0; i < ne; ++i) {
+    for (lno_t i = 0; i < ne; ++i) {
       hc(i) = adj[i];
       hv(i) = ew[i];
     }

--- a/perf_test/sparse/KokkosSparse_sort_crs.cpp
+++ b/perf_test/sparse/KokkosSparse_sort_crs.cpp
@@ -57,9 +57,9 @@ void run_experiment(int argc, char** argv, const CommonInputParams& common_param
 
   using mem_space = typename exec_space::memory_space;
   using device_t  = typename Kokkos::Device<exec_space, mem_space>;
-  using size_type = default_size_type;
-  using lno_t     = default_lno_t;
-  using scalar_t  = default_scalar;
+  using size_type = KokkosKernels::default_size_type;
+  using lno_t     = KokkosKernels::default_lno_t;
+  using scalar_t  = KokkosKernels::default_scalar;
   using crsMat_t  = KokkosSparse::CrsMatrix<scalar_t, lno_t, device_t, void, size_type>;
 
   using graph_t = typename crsMat_t::StaticCrsGraphType;

--- a/perf_test/sparse/KokkosSparse_spadd.cpp
+++ b/perf_test/sparse/KokkosSparse_spadd.cpp
@@ -129,9 +129,9 @@ void run_experiment(int argc, char** argv, CommonInputParams) {
 
   using mem_space = typename exec_space::memory_space;
   using device_t  = typename Kokkos::Device<exec_space, mem_space>;
-  using size_type = default_size_type;
-  using lno_t     = default_lno_t;
-  using scalar_t  = default_scalar;
+  using size_type = KokkosKernels::default_size_type;
+  using lno_t     = KokkosKernels::default_lno_t;
+  using scalar_t  = KokkosKernels::default_scalar;
   using crsMat_t  = KokkosSparse::CrsMatrix<scalar_t, lno_t, device_t, void, size_type>;
 
   using KernelHandle =

--- a/perf_test/sparse/KokkosSparse_spgemm.cpp
+++ b/perf_test/sparse/KokkosSparse_spgemm.cpp
@@ -253,9 +253,9 @@ void run_spgemm(int argc, char** argv, perf_test::CommonInputParams) {
   using namespace KokkosSparse::Experimental;
 
   using MemSpace  = typename ExecSpace::memory_space;
-  using size_type = default_size_type;
-  using lno_t     = default_lno_t;
-  using scalar_t  = default_scalar;
+  using size_type = KokkosKernels::default_size_type;
+  using lno_t     = KokkosKernels::default_lno_t;
+  using scalar_t  = KokkosKernels::default_scalar;
   using device_t  = Kokkos::Device<ExecSpace, MemSpace>;
   using crsMat_t  = typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device_t, void, size_type>;
   using KernelHandle =

--- a/perf_test/sparse/KokkosSparse_spgemm_jacobi.cpp
+++ b/perf_test/sparse/KokkosSparse_spgemm_jacobi.cpp
@@ -201,9 +201,9 @@ int parse_inputs(KokkosKernels::Experiment::Parameters& params, int argc, char**
 }
 
 int main(int argc, char** argv) {
-  using size_type = default_size_type;
-  using lno_t     = default_lno_t;
-  using scalar_t  = default_scalar;
+  using size_type = KokkosKernels::default_size_type;
+  using lno_t     = KokkosKernels::default_lno_t;
+  using scalar_t  = KokkosKernels::default_scalar;
 
   KokkosKernels::Experiment::Parameters params;
 

--- a/perf_test/sparse/KokkosSparse_spiluk.cpp
+++ b/perf_test/sparse/KokkosSparse_spiluk.cpp
@@ -54,7 +54,7 @@ enum { DEFAULT, CUSPARSE, LVLSCHED_RP, LVLSCHED_TP1 /*, LVLSCHED_TP2*/ };
 
 int test_spiluk_perf(std::vector<int> tests, std::string afilename, int kin, int team_size, int /*vector_length*/,
                      /*int idx_offset,*/ int loop) {
-  typedef default_scalar scalar_t;
+  using scalar_t = KokkosKernels::default_scalar;
   typedef int lno_t;
   typedef int size_type;
   typedef Kokkos::DefaultExecutionSpace execution_space;

--- a/perf_test/sparse/KokkosSparse_spmv_merge.cpp
+++ b/perf_test/sparse/KokkosSparse_spmv_merge.cpp
@@ -154,8 +154,8 @@ void print_help() {
 }
 
 int main(int argc, char** argv) {
-  using Scalar = default_scalar;
-  using lno_t  = default_lno_t;
+  using Scalar = KokkosKernels::default_scalar;
+  using lno_t  = KokkosKernels::default_lno_t;
 
   bool compare         = false;
   lno_t loop           = 100;

--- a/perf_test/sparse/KokkosSparse_spmv_struct.cpp
+++ b/perf_test/sparse/KokkosSparse_spmv_struct.cpp
@@ -151,9 +151,9 @@ int main(int argc, char **argv) {
 
   Kokkos::initialize(argc, argv);
   {
-    typedef default_size_type size_type;
-    typedef default_lno_t lno_t;
-    typedef default_scalar Scalar;
+    using size_type = KokkosKernels::default_size_type;
+    using lno_t     = KokkosKernels::default_lno_t;
+    using Scalar    = KokkosKernels::default_scalar;
     typedef KokkosSparse::CrsMatrix<Scalar, lno_t, Kokkos::DefaultExecutionSpace, void, size_type> matrix_type;
     typedef typename Kokkos::View<Scalar **, Kokkos::LayoutLeft> mv_type;
     // typedef typename

--- a/perf_test/sparse/KokkosSparse_spmv_test.hpp
+++ b/perf_test/sparse/KokkosSparse_spmv_test.hpp
@@ -54,10 +54,10 @@ void armpl_matvec(AType /*A*/, XType x, YType y, spmv_additional_data* data);
 enum { KOKKOS, MKL, ARMPL, CUSPARSE, KK_KERNELS, KK_KERNELS_INSP, KK_INSP, OMP_STATIC, OMP_DYNAMIC, OMP_INSP };
 enum { AUTO, DYNAMIC, STATIC };
 
-using Scalar  = default_scalar;
-using Ordinal = default_lno_t;
-using Offset  = default_size_type;
-using Layout  = default_layout;
+using Scalar  = KokkosKernels::default_scalar;
+using Ordinal = KokkosKernels::default_lno_t;
+using Offset  = KokkosKernels::default_size_type;
+using Layout  = KokkosKernels::default_layout;
 
 #ifdef KOKKOSKERNELS_ENABLE_TESTS_AND_PERFSUITE
 std::vector<rajaperf::KernelBase*> make_spmv_kernel_base(const rajaperf::RunParams& params);

--- a/perf_test/sparse/KokkosSparse_sptrsv.cpp
+++ b/perf_test/sparse/KokkosSparse_sptrsv.cpp
@@ -98,9 +98,9 @@ void check_entries_sorted(const RowMapType drow_map, const EntriesType dentries)
 int test_sptrsv_perf(std::vector<int> tests, const std::string &lfilename, const std::string &ufilename,
                      const int team_size, const int vector_length, const int /*idx_offset*/, const int loop,
                      const int chain_threshold = 0, const float /*dense_row_percent*/ = -1.0) {
-  typedef default_scalar scalar_t;
-  typedef default_lno_t lno_t;
-  typedef default_size_type size_type;
+  using scalar_t  = KokkosKernels::default_scalar;
+  using lno_t     = KokkosKernels::default_lno_t;
+  using size_type = KokkosKernels::default_size_type;
   typedef Kokkos::DefaultExecutionSpace execution_space;
   typedef typename execution_space::memory_space memory_space;
 

--- a/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
+++ b/sparse/impl/KokkosSparse_sptrsv_solve_impl.hpp
@@ -817,10 +817,10 @@ struct SptrsvWrap {
       const int nsrow = colptr(j1 + 1) - i1;
 
       // create a view for the s-th supernocal column
-      // NOTE: we currently supports only default_layout = LayoutLeft
+      // NOTE: we currently supports only KokkosKernels::default_layout = LayoutLeft
       scalar_t *dataL = const_cast<scalar_t *>(values.data());
-      Kokkos::View<scalar_t **, default_layout, temp_mem_space, Kokkos::MemoryUnmanaged> viewL(&dataL[i1], nsrow,
-                                                                                               nscol);
+      Kokkos::View<scalar_t **, KokkosKernels::default_layout, temp_mem_space, Kokkos::MemoryUnmanaged> viewL(
+          &dataL[i1], nsrow, nscol);
 
       // extract part of the solution, corresponding to the diagonal block
       auto Xj = Kokkos::subview(X, range_type(j1, j2));
@@ -859,8 +859,9 @@ struct SptrsvWrap {
             KokkosBlas::TeamGemv<member_type, KokkosBlas::Trans::NoTranspose,
                                  KokkosBlas::Algo::Gemv::Unblocked>::invoke(team, one, Ljj, Y, zero, Xj);
           } else {
-            // NOTE: we currently supports only default_layout = LayoutLeft
-            Kokkos::View<scalar_t **, default_layout, temp_mem_space, Kokkos::MemoryUnmanaged> Xjj(Xj.data(), nscol, 1);
+            // NOTE: we currently supports only KokkosKernels::default_layout = LayoutLeft
+            Kokkos::View<scalar_t **, KokkosKernels::default_layout, temp_mem_space, Kokkos::MemoryUnmanaged> Xjj(
+                Xj.data(), nscol, 1);
             if (unit_diagonal) {
               KokkosBatched::TeamTrsm<member_type, KokkosBatched::Side::Left, KokkosBatched::Uplo::Lower,
                                       KokkosBatched::Trans::NoTranspose, KokkosBatched::Diag::Unit,
@@ -898,8 +899,9 @@ struct SptrsvWrap {
   // Functor for Upper-triangular solve in CSR
   template <class ColptrType, class RowindType, class ValuesType, class LHSType>
   struct UpperTriSupernodalFunctor {
-    // NOTE: we currently supports only default_layout = LayoutLeft
-    using SupernodeView = typename Kokkos::View<scalar_t **, default_layout, temp_mem_space, Kokkos::MemoryUnmanaged>;
+    // NOTE: we currently supports only KokkosKernels::default_layout = LayoutLeft
+    using SupernodeView =
+        typename Kokkos::View<scalar_t **, KokkosKernels::default_layout, temp_mem_space, Kokkos::MemoryUnmanaged>;
 
     bool invert_diagonal;
     const int *supercols;
@@ -1022,8 +1024,9 @@ struct SptrsvWrap {
           KokkosBlas::TeamGemv<member_type, KokkosBatched::Trans::Transpose, KokkosBlas::Algo::Gemv::Unblocked>::
               template invoke<const scalar_t, Ujj_type, Y_type, Xj_type>(team, one, Ujj, Y, zero, Xj);
         } else {
-          // NOTE: we currently supports only default_layout = LayoutLeft
-          Kokkos::View<scalar_t **, default_layout, temp_mem_space, Kokkos::MemoryUnmanaged> Xjj(Xj.data(), nscol, 1);
+          // NOTE: we currently supports only KokkosKernels::default_layout = LayoutLeft
+          Kokkos::View<scalar_t **, KokkosKernels::default_layout, temp_mem_space, Kokkos::MemoryUnmanaged> Xjj(
+              Xj.data(), nscol, 1);
           KokkosBatched::TeamTrsm<member_type, KokkosBatched::Side::Left, KokkosBatched::Uplo::Lower,
                                   KokkosBatched::Trans::Transpose, KokkosBatched::Diag::NonUnit,
                                   KokkosBatched::Algo::Trsm::Unblocked>::invoke(team, one, Ujj, Xjj);
@@ -1113,10 +1116,10 @@ struct SptrsvWrap {
       const int nsrow2 = nsrow - nscol;
 
       // create a view of the s-th supernocal column of U
-      // NOTE: we currently supports only default_layout = LayoutLeft
+      // NOTE: we currently supports only KokkosKernels::default_layout = LayoutLeft
       scalar_t *dataU = const_cast<scalar_t *>(values.data());
-      Kokkos::View<scalar_t **, default_layout, temp_mem_space, Kokkos::MemoryUnmanaged> viewU(&dataU[i1], nsrow,
-                                                                                               nscol);
+      Kokkos::View<scalar_t **, KokkosKernels::default_layout, temp_mem_space, Kokkos::MemoryUnmanaged> viewU(
+          &dataU[i1], nsrow, nscol);
 
       // extract part of solution, corresponding to the diagonal block U(s, s)
       auto Xj = Kokkos::subview(X, range_type(j1, j2));
@@ -1152,8 +1155,9 @@ struct SptrsvWrap {
             KokkosBlas::TeamGemv<member_type, KokkosBatched::Trans::NoTranspose,
                                  KokkosBlas::Algo::Gemv::Unblocked>::invoke(team, one, Ujj, Y, zero, Xj);
           } else {
-            // NOTE: we currently supports only default_layout = LayoutLeft
-            Kokkos::View<scalar_t **, default_layout, temp_mem_space, Kokkos::MemoryUnmanaged> Xjj(Xj.data(), nscol, 1);
+            // NOTE: we currently supports only KokkosKernels::default_layout = LayoutLeft
+            Kokkos::View<scalar_t **, KokkosKernels::default_layout, temp_mem_space, Kokkos::MemoryUnmanaged> Xjj(
+                Xj.data(), nscol, 1);
             KokkosBatched::TeamTrsm<member_type, KokkosBatched::Side::Left, KokkosBatched::Uplo::Upper,
                                     KokkosBatched::Trans::NoTranspose, KokkosBatched::Diag::NonUnit,
                                     KokkosBatched::Algo::Trsm::Unblocked>::invoke(team, one, Ujj, Xjj);
@@ -1363,8 +1367,9 @@ struct SptrsvWrap {
           timer.reset();
 #endif
 
-          // NOTE: we currently supports only default_layout = LayoutLeft
-          using supernode_view_type = Kokkos::View<scalar_t **, default_layout, device_t, Kokkos::MemoryUnmanaged>;
+          // NOTE: we currently supports only KokkosKernels::default_layout = LayoutLeft
+          using supernode_view_type =
+              Kokkos::View<scalar_t **, KokkosKernels::default_layout, device_t, Kokkos::MemoryUnmanaged>;
           if (diag_kernel_type_host(lvl) == 3) {
             // using device-level kernels (functor is called to scatter the
             // results)
@@ -1423,9 +1428,10 @@ struct SptrsvWrap {
                   KokkosBlas::gemv(space, "N", one, Ljj, Y, zero, Xj);
                 } else {
                   char unit_diag = (unit_diagonal ? 'U' : 'N');
-                  // NOTE: we currently supports only default_layout =
+                  // NOTE: we currently supports only KokkosKernels::default_layout =
                   // LayoutLeft
-                  Kokkos::View<scalar_t **, default_layout, device_t, Kokkos::MemoryUnmanaged> Xjj(Xj.data(), nscol, 1);
+                  Kokkos::View<scalar_t **, KokkosKernels::default_layout, device_t, Kokkos::MemoryUnmanaged> Xjj(
+                      Xj.data(), nscol, 1);
                   KokkosBlas::trsm(space, "L", "L", "N", &unit_diag, one, Ljj, Xjj);
                   // TODO: space.fence();
                   Kokkos::fence();
@@ -1695,9 +1701,9 @@ struct SptrsvWrap {
                 int workoffset = work_offset_host(s);
 
                 // create a view for the s-th supernocal block column
-                // NOTE: we currently supports only default_layout = LayoutLeft
-                Kokkos::View<scalar_t **, default_layout, device_t, Kokkos::MemoryUnmanaged> viewU(&dataU[i1], nsrow,
-                                                                                                   nscol);
+                // NOTE: we currently supports only KokkosKernels::default_layout = LayoutLeft
+                Kokkos::View<scalar_t **, KokkosKernels::default_layout, device_t, Kokkos::MemoryUnmanaged> viewU(
+                    &dataU[i1], nsrow, nscol);
 
                 if (invert_offdiagonal) {
                   auto Uij = Kokkos::subview(viewU, range_type(0, nsrow), Kokkos::ALL());
@@ -1720,10 +1726,10 @@ struct SptrsvWrap {
                                                                                      // instead of trmv/trsv
                     KokkosBlas::gemv(space, "N", one, Ujj, Y, zero, Xj);
                   } else {
-                    // NOTE: we currently supports only default_layout =
+                    // NOTE: we currently supports only KokkosKernels::default_layout =
                     // LayoutLeft
-                    Kokkos::View<scalar_t **, default_layout, device_t, Kokkos::MemoryUnmanaged> Xjj(Xj.data(), nscol,
-                                                                                                     1);
+                    Kokkos::View<scalar_t **, KokkosKernels::default_layout, device_t, Kokkos::MemoryUnmanaged> Xjj(
+                        Xj.data(), nscol, 1);
                     KokkosBlas::trsm(space, "L", "U", "N", "N", one, Ujj, Xjj);
                   }
                   // update off-diagonal blocks
@@ -1796,9 +1802,9 @@ struct SptrsvWrap {
                 int workoffset = work_offset_host(s);
 
                 // create a view for the s-th supernocal block column
-                // NOTE: we currently supports only default_layout = LayoutLeft
-                Kokkos::View<scalar_t **, default_layout, device_t, Kokkos::MemoryUnmanaged> viewU(&dataU[i1], nsrow,
-                                                                                                   nscol);
+                // NOTE: we currently supports only KokkosKernels::default_layout = LayoutLeft
+                Kokkos::View<scalar_t **, KokkosKernels::default_layout, device_t, Kokkos::MemoryUnmanaged> viewU(
+                    &dataU[i1], nsrow, nscol);
 
                 // extract part of the solution, corresponding to the diagonal
                 // block
@@ -1824,9 +1830,10 @@ struct SptrsvWrap {
                 if (invert_diagonal) {
                   KokkosBlas::gemv(space, "T", one, Ujj, Xj, zero, Y);
                 } else {
-                  // NOTE: we currently supports only default_layout =
+                  // NOTE: we currently supports only KokkosKernels::default_layout =
                   // LayoutLeft
-                  Kokkos::View<scalar_t **, default_layout, device_t, Kokkos::MemoryUnmanaged> Xjj(Xj.data(), nscol, 1);
+                  Kokkos::View<scalar_t **, KokkosKernels::default_layout, device_t, Kokkos::MemoryUnmanaged> Xjj(
+                      Xj.data(), nscol, 1);
                   KokkosBlas::trsm(space, "L", "L", "T", "N", one, Ujj, Xjj);
                 }
               }

--- a/sparse/src/KokkosKernels_Handle.hpp
+++ b/sparse/src/KokkosKernels_Handle.hpp
@@ -223,7 +223,7 @@ class KokkosKernelsHandle {
       typename size_type_persistent_work_view_t::HostMirror size_type_persistent_work_host_view_t;  // Host view type
   typedef typename Kokkos::View<nnz_scalar_t *, HandleTempMemorySpace> scalar_temp_work_view_t;
   typedef typename Kokkos::View<nnz_scalar_t *, HandlePersistentMemorySpace> scalar_persistent_work_view_t;
-  typedef typename Kokkos::View<nnz_scalar_t **, default_layout, HandlePersistentMemorySpace>
+  typedef typename Kokkos::View<nnz_scalar_t **, KokkosKernels::default_layout, HandlePersistentMemorySpace>
       scalar_persistent_work_view2d_t;
   typedef typename Kokkos::View<nnz_lno_t *, HandleTempMemorySpace> nnz_lno_temp_work_view_t;
   typedef typename Kokkos::View<nnz_lno_t *, HandlePersistentMemorySpace> nnz_lno_persistent_work_view_t;

--- a/sparse/src/KokkosSparse_BsrMatrix.hpp
+++ b/sparse/src/KokkosSparse_BsrMatrix.hpp
@@ -300,7 +300,7 @@ struct BsrRowViewConst {
 /// storage for sparse matrices, as described, for example, in Saad
 /// (2nd ed.).
 template <class ScalarType, class OrdinalType, class Device, class MemoryTraits = void,
-          class SizeType = default_size_type>
+          class SizeType = KokkosKernels::default_size_type>
 class BsrMatrix {
   static_assert(std::is_signed<OrdinalType>::value, "BsrMatrix requires that OrdinalType is a signed integer type.");
   static_assert(Kokkos::is_memory_traits_v<MemoryTraits> || std::is_void_v<MemoryTraits>,

--- a/sparse/src/KokkosSparse_CcsMatrix.hpp
+++ b/sparse/src/KokkosSparse_CcsMatrix.hpp
@@ -142,7 +142,7 @@ class CcsMatrix {
   //! Type of each (column) index in the matrix.
   typedef OrdinalType ordinal_type;
   //! Type of the graph structure of the sparse matrix - consistent with Kokkos.
-  typedef Kokkos::StaticCcsGraph<ordinal_type, default_layout, device_type, memory_traits, size_type>
+  typedef Kokkos::StaticCcsGraph<ordinal_type, KokkosKernels::default_layout, device_type, memory_traits, size_type>
       staticccsgraph_type;
   //! Type of the "column map" (which contains the offset for each column's
   //! data).

--- a/sparse/src/KokkosSparse_CrsMatrix.hpp
+++ b/sparse/src/KokkosSparse_CrsMatrix.hpp
@@ -315,7 +315,7 @@ struct SparseRowViewConst {
 /// storage for sparse matrices, as described, for example, in Saad
 /// (2nd ed.).
 template <class ScalarType, class OrdinalType, class Device, class MemoryTraits = void,
-          class SizeType = default_size_type>
+          class SizeType = KokkosKernels::default_size_type>
 class CrsMatrix {
   static_assert(std::is_signed<OrdinalType>::value, "CrsMatrix requires that OrdinalType is a signed integer type.");
 
@@ -344,10 +344,10 @@ class CrsMatrix {
   //! Type of a host-memory mirror of the sparse matrix.
   typedef CrsMatrix<ScalarType, OrdinalType, host_mirror_space, MemoryTraits, SizeType> HostMirror;
   //! Type of the graph structure of the sparse matrix.
-  typedef Kokkos::StaticCrsGraph<ordinal_type, default_layout, device_type, memory_traits, size_type>
+  typedef Kokkos::StaticCrsGraph<ordinal_type, KokkosKernels::default_layout, device_type, memory_traits, size_type>
       StaticCrsGraphType;
   //! Type of the graph structure of the sparse matrix - consistent with Kokkos.
-  typedef Kokkos::StaticCrsGraph<ordinal_type, default_layout, device_type, memory_traits, size_type>
+  typedef Kokkos::StaticCrsGraph<ordinal_type, KokkosKernels::default_layout, device_type, memory_traits, size_type>
       staticcrsgraph_type;
   //! Type of column indices in the sparse matrix.
   typedef typename staticcrsgraph_type::entries_type index_type;

--- a/sparse/src/KokkosSparse_gauss_seidel_handle.hpp
+++ b/sparse/src/KokkosSparse_gauss_seidel_handle.hpp
@@ -208,7 +208,7 @@ class PointGaussSeidelHandle : public GaussSeidelHandle<size_type_, lno_t_, scal
 
   typedef typename Kokkos::View<nnz_scalar_t *, HandleTempMemorySpace> scalar_temp_work_view_t;
   typedef typename Kokkos::View<nnz_scalar_t *, HandlePersistentMemorySpace> scalar_persistent_work_view_t;
-  typedef typename Kokkos::View<nnz_scalar_t **, default_layout, HandlePersistentMemorySpace>
+  typedef typename Kokkos::View<nnz_scalar_t **, KokkosKernels::default_layout, HandlePersistentMemorySpace>
       scalar_persistent_work_view2d_t;
   typedef typename scalar_persistent_work_view_t::HostMirror scalar_persistent_work_host_view_t;  // Host view type
 
@@ -532,7 +532,7 @@ class TwoStageGaussSeidelHandle
   using const_ordinal_t = typename const_entries_view_t::value_type;
   using const_scalar_t  = typename const_values_view_t::value_type;
 
-  using vector_view_t = Kokkos::View<scalar_t **, default_layout, device_t>;
+  using vector_view_t = Kokkos::View<scalar_t **, KokkosKernels::default_layout, device_t>;
 
   using GSHandle = GaussSeidelHandle<input_size_t, input_ordinal_t, input_scalar_t, ExecutionSpace,
                                      TemporaryMemorySpace, PersistentMemorySpace>;

--- a/sparse/src/KokkosSparse_sptrsv_supernode.hpp
+++ b/sparse/src/KokkosSparse_sptrsv_supernode.hpp
@@ -1358,8 +1358,9 @@ void invert_supernodal_columns(KernelHandle *kernelHandle, bool unit_diag, int n
       char uplo_char = (lower ? 'L' : 'U');
       char diag_char = (unit_diag ? 'U' : 'N');
 
-      // NOTE: we currently supports only default_layout = LayoutLeft
-      Kokkos::View<scalar_t **, default_layout, memory_space, Kokkos::MemoryUnmanaged> viewL(&hv(nnzD), nsrow, nscol);
+      // NOTE: we currently supports only KokkosKernels::default_layout = LayoutLeft
+      Kokkos::View<scalar_t **, KokkosKernels::default_layout, memory_space, Kokkos::MemoryUnmanaged> viewL(
+          &hv(nnzD), nsrow, nscol);
       auto Ljj = Kokkos::subview(viewL, range_type(0, nscol), Kokkos::ALL());
 
 #ifdef KOKKOS_SPTRSV_SUPERNODE_PROFILE
@@ -1403,7 +1404,7 @@ void invert_supernodal_columns(KernelHandle *kernelHandle, bool unit_diag, int n
           Kokkos::deep_copy(dViewL, viewL);
 #endif
 
-          // NOTE: we currently supports only default_layout = LayoutLeft
+          // NOTE: we currently supports only KokkosKernels::default_layout = LayoutLeft
           auto dViewLjj = Kokkos::subview(dViewL, range_type(0, nscol), Kokkos::ALL());
           auto dViewLij = Kokkos::subview(dViewL, range_type(nscol, nsrow), Kokkos::ALL());
 

--- a/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_avail.hpp
@@ -45,23 +45,23 @@ struct spgemm_numeric_tpl_spec_avail {
   struct spgemm_numeric_tpl_spec_avail<                                                                            \
       KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR, Kokkos::Cuda, MEMSPACE, \
                                                        MEMSPACE>,                                                  \
-      Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                            \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,             \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                      \
-      Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                            \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,             \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                      \
-      Kokkos::View<const SCALAR *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                         \
+      Kokkos::View<const SCALAR *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,          \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                      \
-      Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                            \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,             \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                      \
-      Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                            \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,             \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                      \
-      Kokkos::View<const SCALAR *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                         \
+      Kokkos::View<const SCALAR *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,          \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                      \
-      Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                            \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,             \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                      \
-      Kokkos::View<int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                                  \
+      Kokkos::View<int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                   \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                      \
-      Kokkos::View<SCALAR *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                               \
+      Kokkos::View<SCALAR *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {                                                   \
     enum : bool { value = true };                                                                                  \
   };
@@ -80,30 +80,30 @@ SPGEMM_NUMERIC_AVAIL_CUSPARSE_S(Kokkos::complex<double>)
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE
-#define SPGEMM_NUMERIC_AVAIL_ROCSPARSE(SCALAR)                                                          \
-  template <>                                                                                           \
-  struct spgemm_numeric_tpl_spec_avail<                                                                 \
-      KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR, Kokkos::HIP, \
-                                                       Kokkos::HIPSpace, Kokkos::HIPSpace>,             \
-      Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,          \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                           \
-      Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,          \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                           \
-      Kokkos::View<const SCALAR *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                           \
-      Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,          \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                           \
-      Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,          \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                           \
-      Kokkos::View<const SCALAR *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                           \
-      Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,          \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                           \
-      Kokkos::View<int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,                \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                           \
-      Kokkos::View<SCALAR *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,             \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {                                        \
-    enum : bool { value = true };                                                                       \
+#define SPGEMM_NUMERIC_AVAIL_ROCSPARSE(SCALAR)                                                                   \
+  template <>                                                                                                    \
+  struct spgemm_numeric_tpl_spec_avail<                                                                          \
+      KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR, Kokkos::HIP,          \
+                                                       Kokkos::HIPSpace, Kokkos::HIPSpace>,                      \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                    \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                    \
+      Kokkos::View<const SCALAR *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                    \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                    \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                    \
+      Kokkos::View<const SCALAR *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                    \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                    \
+      Kokkos::View<int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,          \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                    \
+      Kokkos::View<SCALAR *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,       \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {                                                 \
+    enum : bool { value = true };                                                                                \
   };
 
 SPGEMM_NUMERIC_AVAIL_ROCSPARSE(float)
@@ -113,30 +113,30 @@ SPGEMM_NUMERIC_AVAIL_ROCSPARSE(Kokkos::complex<double>)
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
-#define SPGEMM_NUMERIC_AVAIL_MKL(SCALAR, EXEC)                                                           \
-  template <>                                                                                            \
-  struct spgemm_numeric_tpl_spec_avail<                                                                  \
-      KokkosKernels::Experimental::KokkosKernelsHandle<const MKL_INT, const MKL_INT, const SCALAR, EXEC, \
-                                                       Kokkos::HostSpace, Kokkos::HostSpace>,            \
-      Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,             \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                            \
-      Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,             \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                            \
-      Kokkos::View<const SCALAR *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,              \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                            \
-      Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,             \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                            \
-      Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,             \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                            \
-      Kokkos::View<const SCALAR *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,              \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                            \
-      Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,             \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                            \
-      Kokkos::View<MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,                   \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                            \
-      Kokkos::View<SCALAR *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,                    \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {                                         \
-    enum : bool { value = true };                                                                        \
+#define SPGEMM_NUMERIC_AVAIL_MKL(SCALAR, EXEC)                                                              \
+  template <>                                                                                               \
+  struct spgemm_numeric_tpl_spec_avail<                                                                     \
+      KokkosKernels::Experimental::KokkosKernelsHandle<const MKL_INT, const MKL_INT, const SCALAR, EXEC,    \
+                                                       Kokkos::HostSpace, Kokkos::HostSpace>,               \
+      Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                               \
+      Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                               \
+      Kokkos::View<const SCALAR *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                               \
+      Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                               \
+      Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                               \
+      Kokkos::View<const SCALAR *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,  \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                               \
+      Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                               \
+      Kokkos::View<MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,       \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                               \
+      Kokkos::View<SCALAR *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,        \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {                                            \
+    enum : bool { value = true };                                                                           \
   };
 
 #define SPGEMM_NUMERIC_AVAIL_MKL_E(EXEC)                 \

--- a/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_decl.hpp
@@ -191,50 +191,53 @@ void spgemm_numeric_cusparse(KernelHandle *handle, lno_t m, lno_t n, lno_t k, co
 
 #endif
 
-#define SPGEMM_NUMERIC_DECL_CUSPARSE(SCALAR, MEMSPACE, TPL_AVAIL)                                                    \
-  template <>                                                                                                        \
-  struct SPGEMM_NUMERIC<KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR,         \
-                                                                         Kokkos::Cuda, MEMSPACE, MEMSPACE>,          \
-                        Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,            \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                       \
-                        Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,            \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                       \
-                        Kokkos::View<const SCALAR *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,         \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                       \
-                        Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,            \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                       \
-                        Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,            \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                       \
-                        Kokkos::View<const SCALAR *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,         \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                       \
-                        Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,            \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                       \
-                        Kokkos::View<int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                  \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                       \
-                        Kokkos::View<SCALAR *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,               \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                       \
-                        true, TPL_AVAIL> {                                                                           \
-    using KernelHandle    = KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR,     \
-                                                                          Kokkos::Cuda, MEMSPACE, MEMSPACE>;      \
-    using c_int_view_t    = Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,        \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                   \
-    using int_view_t      = Kokkos::View<int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,              \
-                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                   \
-    using c_scalar_view_t = Kokkos::View<const SCALAR *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,     \
-                                         Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                   \
-    using scalar_view_t   = Kokkos::View<SCALAR *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,           \
-                                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                   \
-    static void spgemm_numeric(KernelHandle *handle, typename KernelHandle::nnz_lno_t m,                             \
-                               typename KernelHandle::nnz_lno_t n, typename KernelHandle::nnz_lno_t k,               \
-                               c_int_view_t row_mapA, c_int_view_t entriesA, c_scalar_view_t valuesA, bool,          \
-                               c_int_view_t row_mapB, c_int_view_t entriesB, c_scalar_view_t valuesB, bool,          \
-                               c_int_view_t row_mapC, int_view_t entriesC, scalar_view_t valuesC) {                  \
-      std::string label = "KokkosSparse::spgemm_numeric[TPL_CUSPARSE," + Kokkos::ArithTraits<SCALAR>::name() + "]";  \
-      Kokkos::Profiling::pushRegion(label);                                                                          \
-      spgemm_numeric_cusparse(handle->get_spgemm_handle(), m, n, k, row_mapA, entriesA, valuesA, row_mapB, entriesB, \
-                              valuesB, row_mapC, entriesC, valuesC);                                                 \
-      Kokkos::Profiling::popRegion();                                                                                \
-    }                                                                                                                \
+#define SPGEMM_NUMERIC_DECL_CUSPARSE(SCALAR, MEMSPACE, TPL_AVAIL)                                                      \
+  template <>                                                                                                          \
+  struct SPGEMM_NUMERIC<KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR,           \
+                                                                         Kokkos::Cuda, MEMSPACE, MEMSPACE>,            \
+                        Kokkos::View<const int *, KokkosKernels::default_layout,                                       \
+                                     Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+                        Kokkos::View<const int *, KokkosKernels::default_layout,                                       \
+                                     Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+                        Kokkos::View<const SCALAR *, KokkosKernels::default_layout,                                    \
+                                     Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+                        Kokkos::View<const int *, KokkosKernels::default_layout,                                       \
+                                     Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+                        Kokkos::View<const int *, KokkosKernels::default_layout,                                       \
+                                     Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+                        Kokkos::View<const SCALAR *, KokkosKernels::default_layout,                                    \
+                                     Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+                        Kokkos::View<const int *, KokkosKernels::default_layout,                                       \
+                                     Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+                        Kokkos::View<int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,     \
+                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                         \
+                        Kokkos::View<SCALAR *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,  \
+                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                         \
+                        true, TPL_AVAIL> {                                                                             \
+    using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR,          \
+                                                                          Kokkos::Cuda, MEMSPACE, MEMSPACE>;           \
+    using c_int_view_t =                                                                                               \
+        Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,               \
+                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                         \
+    using int_view_t = Kokkos::View<int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,      \
+                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                          \
+    using c_scalar_view_t =                                                                                            \
+        Kokkos::View<const SCALAR *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,            \
+                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                         \
+    using scalar_view_t =                                                                                              \
+        Kokkos::View<SCALAR *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                  \
+                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                         \
+    static void spgemm_numeric(KernelHandle *handle, typename KernelHandle::nnz_lno_t m,                               \
+                               typename KernelHandle::nnz_lno_t n, typename KernelHandle::nnz_lno_t k,                 \
+                               c_int_view_t row_mapA, c_int_view_t entriesA, c_scalar_view_t valuesA, bool,            \
+                               c_int_view_t row_mapB, c_int_view_t entriesB, c_scalar_view_t valuesB, bool,            \
+                               c_int_view_t row_mapC, int_view_t entriesC, scalar_view_t valuesC) {                    \
+      std::string label = "KokkosSparse::spgemm_numeric[TPL_CUSPARSE," + Kokkos::ArithTraits<SCALAR>::name() + "]";    \
+      Kokkos::Profiling::pushRegion(label);                                                                            \
+      spgemm_numeric_cusparse(handle->get_spgemm_handle(), m, n, k, row_mapA, entriesA, valuesA, row_mapB, entriesB,   \
+                              valuesB, row_mapC, entriesC, valuesC);                                                   \
+      Kokkos::Profiling::popRegion();                                                                                  \
+    }                                                                                                                  \
   };
 
 #define SPGEMM_NUMERIC_DECL_CUSPARSE_S(SCALAR, TPL_AVAIL)            \
@@ -326,39 +329,43 @@ void spgemm_numeric_rocsparse(KernelHandle *handle, typename KernelHandle::nnz_l
 
 #define SPGEMM_NUMERIC_DECL_ROCSPARSE(SCALAR, TPL_AVAIL)                                                              \
   template <>                                                                                                         \
-  struct SPGEMM_NUMERIC<KokkosKernels::Experimental::KokkosKernelsHandle<                                             \
-                            const int, const int, const SCALAR, Kokkos::HIP, Kokkos::HIPSpace, Kokkos::HIPSpace>,     \
-                        Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,      \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-                        Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,      \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-                        Kokkos::View<const SCALAR *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,   \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-                        Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,      \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-                        Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,      \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-                        Kokkos::View<const SCALAR *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,   \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-                        Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,      \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-                        Kokkos::View<int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,            \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-                        Kokkos::View<SCALAR *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,         \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-                        true, TPL_AVAIL> {                                                                            \
+  struct SPGEMM_NUMERIC<                                                                                              \
+      KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR, Kokkos::HIP,               \
+                                                       Kokkos::HIPSpace, Kokkos::HIPSpace>,                           \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,         \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,         \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
+      Kokkos::View<const SCALAR *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,      \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,         \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,         \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
+      Kokkos::View<const SCALAR *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,      \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,         \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
+      Kokkos::View<int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,               \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
+      Kokkos::View<SCALAR *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
+      true, TPL_AVAIL> {                                                                                              \
     using KernelHandle =                                                                                              \
         KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR, Kokkos::HIP,             \
                                                          Kokkos::HIPSpace, Kokkos::HIPSpace>;                         \
-    using c_int_view_t = Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,     \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                       \
-    using int_view_t   = Kokkos::View<int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,           \
-                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                       \
-    using c_scalar_view_t =                                                                                           \
-        Kokkos::View<const SCALAR *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,                   \
+    using c_int_view_t =                                                                                              \
+        Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,       \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                        \
-    using scalar_view_t = Kokkos::View<SCALAR *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,       \
-                                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                      \
+    using int_view_t =                                                                                                \
+        Kokkos::View<int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,             \
+                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                        \
+    using c_scalar_view_t =                                                                                           \
+        Kokkos::View<const SCALAR *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,    \
+                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                        \
+    using scalar_view_t =                                                                                             \
+        Kokkos::View<SCALAR *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,          \
+                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                        \
     static void spgemm_numeric(KernelHandle *handle, typename KernelHandle::nnz_lno_t m,                              \
                                typename KernelHandle::nnz_lno_t n, typename KernelHandle::nnz_lno_t k,                \
                                c_int_view_t row_mapA, c_int_view_t entriesA, c_scalar_view_t valuesA, bool,           \
@@ -437,50 +444,54 @@ void spgemm_numeric_mkl(KernelHandle *handle, typename KernelHandle::nnz_lno_t m
   handle->set_computed_entries();
 }
 
-#define SPGEMM_NUMERIC_DECL_MKL(SCALAR, EXEC, TPL_AVAIL)                                                                  \
-  template <>                                                                                                             \
-  struct SPGEMM_NUMERIC<KokkosKernels::Experimental::KokkosKernelsHandle<const MKL_INT, const MKL_INT, const SCALAR,      \
-                                                                         EXEC, Kokkos::HostSpace, Kokkos::HostSpace>,     \
-                        Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                            \
-                        Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                            \
-                        Kokkos::View<const SCALAR *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,             \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                            \
-                        Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                            \
-                        Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                            \
-                        Kokkos::View<const SCALAR *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,             \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                            \
-                        Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                            \
-                        Kokkos::View<MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,                  \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                            \
-                        Kokkos::View<SCALAR *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,                   \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                            \
-                        true, TPL_AVAIL> {                                                                                \
-    using KernelHandle    = KokkosKernels::Experimental::KokkosKernelsHandle<const MKL_INT, const MKL_INT, const SCALAR,  \
+#define SPGEMM_NUMERIC_DECL_MKL(SCALAR, EXEC, TPL_AVAIL)                                                               \
+  template <>                                                                                                          \
+  struct SPGEMM_NUMERIC<                                                                                               \
+      KokkosKernels::Experimental::KokkosKernelsHandle<const MKL_INT, const MKL_INT, const SCALAR, EXEC,               \
+                                                       Kokkos::HostSpace, Kokkos::HostSpace>,                          \
+      Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      Kokkos::View<const SCALAR *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,             \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      Kokkos::View<const SCALAR *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,             \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      Kokkos::View<MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,                  \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      Kokkos::View<SCALAR *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,                   \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      true, TPL_AVAIL> {                                                                                               \
+    using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<const MKL_INT, const MKL_INT, const SCALAR,  \
                                                                           EXEC, Kokkos::HostSpace, Kokkos::HostSpace>; \
-    using c_int_view_t    = Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,        \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                        \
-    using int_view_t      = Kokkos::View<MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,              \
-                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                        \
-    using c_scalar_view_t = Kokkos::View<const SCALAR *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,         \
-                                         Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                        \
-    using scalar_view_t   = Kokkos::View<SCALAR *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,               \
-                                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                        \
-    static void spgemm_numeric(KernelHandle *handle, typename KernelHandle::nnz_lno_t m,                                  \
-                               typename KernelHandle::nnz_lno_t n, typename KernelHandle::nnz_lno_t k,                    \
-                               c_int_view_t row_mapA, c_int_view_t entriesA, c_scalar_view_t valuesA, bool,               \
-                               c_int_view_t row_mapB, c_int_view_t entriesB, c_scalar_view_t valuesB, bool,               \
-                               c_int_view_t row_mapC, int_view_t entriesC, scalar_view_t valuesC) {                       \
-      std::string label = "KokkosSparse::spgemm_numeric[TPL_MKL," + Kokkos::ArithTraits<SCALAR>::name() + "]";            \
-      Kokkos::Profiling::pushRegion(label);                                                                               \
-      spgemm_numeric_mkl(handle->get_spgemm_handle(), m, n, k, row_mapA, entriesA, valuesA, row_mapB, entriesB,           \
-                         valuesB, row_mapC, entriesC, valuesC);                                                           \
-      Kokkos::Profiling::popRegion();                                                                                     \
-    }                                                                                                                     \
+    using c_int_view_t =                                                                                               \
+        Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,          \
+                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                         \
+    using int_view_t = Kokkos::View<MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
+                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                          \
+    using c_scalar_view_t =                                                                                            \
+        Kokkos::View<const SCALAR *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,           \
+                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                         \
+    using scalar_view_t =                                                                                              \
+        Kokkos::View<SCALAR *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,                 \
+                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                         \
+    static void spgemm_numeric(KernelHandle *handle, typename KernelHandle::nnz_lno_t m,                               \
+                               typename KernelHandle::nnz_lno_t n, typename KernelHandle::nnz_lno_t k,                 \
+                               c_int_view_t row_mapA, c_int_view_t entriesA, c_scalar_view_t valuesA, bool,            \
+                               c_int_view_t row_mapB, c_int_view_t entriesB, c_scalar_view_t valuesB, bool,            \
+                               c_int_view_t row_mapC, int_view_t entriesC, scalar_view_t valuesC) {                    \
+      std::string label = "KokkosSparse::spgemm_numeric[TPL_MKL," + Kokkos::ArithTraits<SCALAR>::name() + "]";         \
+      Kokkos::Profiling::pushRegion(label);                                                                            \
+      spgemm_numeric_mkl(handle->get_spgemm_handle(), m, n, k, row_mapA, entriesA, valuesA, row_mapB, entriesB,        \
+                         valuesB, row_mapC, entriesC, valuesC);                                                        \
+      Kokkos::Profiling::popRegion();                                                                                  \
+    }                                                                                                                  \
   };
 
 #define SPGEMM_NUMERIC_DECL_MKL_SE(SCALAR, EXEC) \

--- a/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_avail.hpp
@@ -44,15 +44,15 @@ struct spgemm_symbolic_tpl_spec_avail {
   struct spgemm_symbolic_tpl_spec_avail<                                                                           \
       KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR, Kokkos::Cuda, MEMSPACE, \
                                                        MEMSPACE>,                                                  \
-      Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                            \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,             \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                      \
-      Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                            \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,             \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                      \
-      Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                            \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,             \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                      \
-      Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                            \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,             \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                      \
-      Kokkos::View<int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                                  \
+      Kokkos::View<int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                   \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {                                                   \
     enum : bool { value = true };                                                                                  \
   };
@@ -70,22 +70,22 @@ SPGEMM_SYMBOLIC_AVAIL_CUSPARSE_S(Kokkos::complex<double>)
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE
-#define SPGEMM_SYMBOLIC_AVAIL_ROCSPARSE(SCALAR)                                                         \
-  template <>                                                                                           \
-  struct spgemm_symbolic_tpl_spec_avail<                                                                \
-      KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR, Kokkos::HIP, \
-                                                       Kokkos::HIPSpace, Kokkos::HIPSpace>,             \
-      Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,          \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                           \
-      Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,          \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                           \
-      Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,          \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                           \
-      Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,          \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                           \
-      Kokkos::View<int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,                \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {                                        \
-    enum : bool { value = true };                                                                       \
+#define SPGEMM_SYMBOLIC_AVAIL_ROCSPARSE(SCALAR)                                                               \
+  template <>                                                                                                 \
+  struct spgemm_symbolic_tpl_spec_avail<                                                                      \
+      KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR, Kokkos::HIP,       \
+                                                       Kokkos::HIPSpace, Kokkos::HIPSpace>,                   \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                 \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                 \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                 \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                 \
+      Kokkos::View<int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,       \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {                                              \
+    enum : bool { value = true };                                                                             \
   };
 
 SPGEMM_SYMBOLIC_AVAIL_ROCSPARSE(float)
@@ -95,22 +95,22 @@ SPGEMM_SYMBOLIC_AVAIL_ROCSPARSE(Kokkos::complex<double>)
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
-#define SPGEMM_SYMBOLIC_AVAIL_MKL(SCALAR, EXEC)                                                          \
-  template <>                                                                                            \
-  struct spgemm_symbolic_tpl_spec_avail<                                                                 \
-      KokkosKernels::Experimental::KokkosKernelsHandle<const MKL_INT, const MKL_INT, const SCALAR, EXEC, \
-                                                       Kokkos::HostSpace, Kokkos::HostSpace>,            \
-      Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,             \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                            \
-      Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,             \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                            \
-      Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,             \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                            \
-      Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,             \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                            \
-      Kokkos::View<MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,                   \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {                                         \
-    enum : bool { value = true };                                                                        \
+#define SPGEMM_SYMBOLIC_AVAIL_MKL(SCALAR, EXEC)                                                             \
+  template <>                                                                                               \
+  struct spgemm_symbolic_tpl_spec_avail<                                                                    \
+      KokkosKernels::Experimental::KokkosKernelsHandle<const MKL_INT, const MKL_INT, const SCALAR, EXEC,    \
+                                                       Kokkos::HostSpace, Kokkos::HostSpace>,               \
+      Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                               \
+      Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                               \
+      Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                               \
+      Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                               \
+      Kokkos::View<MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,       \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {                                            \
+    enum : bool { value = true };                                                                           \
   };
 
 #define SPGEMM_SYMBOLIC_AVAIL_MKL_E(EXEC)                 \

--- a/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp
@@ -313,25 +313,27 @@ void spgemm_symbolic_cusparse(KernelHandle *handle, lno_t m, lno_t n, lno_t k, c
 
 #define SPGEMM_SYMBOLIC_DECL_CUSPARSE(SCALAR, MEMSPACE, TPL_AVAIL)                                                     \
   template <>                                                                                                          \
-  struct SPGEMM_SYMBOLIC<KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR,          \
-                                                                          Kokkos::Cuda, MEMSPACE, MEMSPACE>,           \
-                         Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,             \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-                         Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,             \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-                         Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,             \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-                         Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,             \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-                         Kokkos::View<int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                   \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-                         true, TPL_AVAIL> {                                                                            \
+  struct SPGEMM_SYMBOLIC<                                                                                              \
+      KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR, Kokkos::Cuda, MEMSPACE,     \
+                                                       MEMSPACE>,                                                      \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                 \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                 \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                 \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                 \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      Kokkos::View<int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                       \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      true, TPL_AVAIL> {                                                                                               \
     using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR,          \
                                                                           Kokkos::Cuda, MEMSPACE, MEMSPACE>;           \
-    using c_int_view_t = Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,             \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                        \
-    using int_view_t   = Kokkos::View<int *, default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                   \
-                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                        \
+    using c_int_view_t =                                                                                               \
+        Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,               \
+                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                         \
+    using int_view_t = Kokkos::View<int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,      \
+                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                          \
     static void spgemm_symbolic(KernelHandle *handle, typename KernelHandle::nnz_lno_t m,                              \
                                 typename KernelHandle::nnz_lno_t n, typename KernelHandle::nnz_lno_t k,                \
                                 c_int_view_t row_mapA, c_int_view_t entriesA, bool, c_int_view_t row_mapB,             \
@@ -440,26 +442,29 @@ void spgemm_symbolic_rocsparse(KernelHandle *handle, typename KernelHandle::nnz_
 
 #define SPGEMM_SYMBOLIC_DECL_ROCSPARSE(SCALAR, TPL_AVAIL)                                                             \
   template <>                                                                                                         \
-  struct SPGEMM_SYMBOLIC<KokkosKernels::Experimental::KokkosKernelsHandle<                                            \
-                             const int, const int, const SCALAR, Kokkos::HIP, Kokkos::HIPSpace, Kokkos::HIPSpace>,    \
-                         Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,     \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                       \
-                         Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,     \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                       \
-                         Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,     \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                       \
-                         Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,     \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                       \
-                         Kokkos::View<int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,           \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                       \
-                         true, TPL_AVAIL> {                                                                           \
+  struct SPGEMM_SYMBOLIC<                                                                                             \
+      KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR, Kokkos::HIP,               \
+                                                       Kokkos::HIPSpace, Kokkos::HIPSpace>,                           \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,         \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,         \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,         \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
+      Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,         \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
+      Kokkos::View<int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,               \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
+      true, TPL_AVAIL> {                                                                                              \
     using KernelHandle =                                                                                              \
         KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR, Kokkos::HIP,             \
                                                          Kokkos::HIPSpace, Kokkos::HIPSpace>;                         \
-    using c_int_view_t = Kokkos::View<const int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,     \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                       \
-    using int_view_t   = Kokkos::View<int *, default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,           \
-                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                       \
+    using c_int_view_t =                                                                                              \
+        Kokkos::View<const int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,       \
+                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                        \
+    using int_view_t =                                                                                                \
+        Kokkos::View<int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,             \
+                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                        \
     static void spgemm_symbolic(KernelHandle *handle, typename KernelHandle::nnz_lno_t m,                             \
                                 typename KernelHandle::nnz_lno_t n, typename KernelHandle::nnz_lno_t k,               \
                                 c_int_view_t row_mapA, c_int_view_t entriesA, bool, c_int_view_t row_mapB,            \
@@ -529,25 +534,27 @@ void spgemm_symbolic_mkl(KernelHandle *handle, typename KernelHandle::nnz_lno_t 
 
 #define SPGEMM_SYMBOLIC_DECL_MKL(SCALAR, EXEC, TPL_AVAIL)                                                              \
   template <>                                                                                                          \
-  struct SPGEMM_SYMBOLIC<KokkosKernels::Experimental::KokkosKernelsHandle<const MKL_INT, const MKL_INT, const SCALAR,  \
-                                                                          EXEC, Kokkos::HostSpace, Kokkos::HostSpace>, \
-                         Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,        \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-                         Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,        \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-                         Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,        \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-                         Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,        \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-                         Kokkos::View<MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,              \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-                         true, TPL_AVAIL> {                                                                            \
+  struct SPGEMM_SYMBOLIC<                                                                                              \
+      KokkosKernels::Experimental::KokkosKernelsHandle<const MKL_INT, const MKL_INT, const SCALAR, EXEC,               \
+                                                       Kokkos::HostSpace, Kokkos::HostSpace>,                          \
+      Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      Kokkos::View<MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,                  \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      true, TPL_AVAIL> {                                                                                               \
     using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<const MKL_INT, const MKL_INT, const SCALAR,  \
                                                                           EXEC, Kokkos::HostSpace, Kokkos::HostSpace>; \
-    using c_int_view_t = Kokkos::View<const MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,        \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                        \
-    using int_view_t   = Kokkos::View<MKL_INT *, default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,              \
-                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                        \
+    using c_int_view_t =                                                                                               \
+        Kokkos::View<const MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,          \
+                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                         \
+    using int_view_t = Kokkos::View<MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
+                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                          \
     static void spgemm_symbolic(KernelHandle *handle, typename KernelHandle::nnz_lno_t m,                              \
                                 typename KernelHandle::nnz_lno_t n, typename KernelHandle::nnz_lno_t k,                \
                                 c_int_view_t row_mapA, c_int_view_t entriesA, bool, c_int_view_t row_mapB,             \

--- a/sparse/unit_test/Test_Sparse_SortCrs.hpp
+++ b/sparse/unit_test/Test_Sparse_SortCrs.hpp
@@ -42,11 +42,11 @@ enum : int {
 }
 
 template <typename device_t>
-void testSortCRS(default_lno_t numRows, default_lno_t numCols, default_size_type nnz, bool doValues,
-                 bool doStructInterface, int howExecSpecified) {
-  using scalar_t   = default_scalar;
-  using lno_t      = default_lno_t;
-  using size_type  = default_size_type;
+void testSortCRS(KokkosKernels::default_lno_t numRows, KokkosKernels::default_lno_t numCols,
+                 KokkosKernels::default_size_type nnz, bool doValues, bool doStructInterface, int howExecSpecified) {
+  using scalar_t   = KokkosKernels::default_scalar;
+  using lno_t      = KokkosKernels::default_lno_t;
+  using size_type  = KokkosKernels::default_size_type;
   using exec_space = typename device_t::execution_space;
   using crsMat_t   = KokkosSparse::CrsMatrix<scalar_t, lno_t, device_t, void, size_type>;
   // Create a random matrix on device
@@ -135,9 +135,9 @@ void testSortCRS(default_lno_t numRows, default_lno_t numCols, default_size_type
 template <typename device_t>
 void testSortCRSUnmanaged(bool doValues, bool doStructInterface) {
   // This test is about bug #960.
-  using scalar_t   = default_scalar;
-  using lno_t      = default_lno_t;
-  using size_type  = default_size_type;
+  using scalar_t   = KokkosKernels::default_scalar;
+  using lno_t      = KokkosKernels::default_lno_t;
+  using size_type  = KokkosKernels::default_size_type;
   using exec_space = typename device_t::execution_space;
   using crsMat_t =
       KokkosSparse::CrsMatrix<scalar_t, lno_t, device_t, Kokkos::MemoryTraits<Kokkos::Unmanaged>, size_type>;
@@ -175,9 +175,9 @@ void testSortCRSUnmanaged(bool doValues, bool doStructInterface) {
 
 template <typename device_t>
 void testSortAndMerge(bool justGraph, int howExecSpecified, bool doStructInterface, bool inPlace, int testCase) {
-  using size_type  = default_size_type;
-  using lno_t      = default_lno_t;
-  using scalar_t   = default_scalar;
+  using size_type  = KokkosKernels::default_size_type;
+  using lno_t      = KokkosKernels::default_lno_t;
+  using scalar_t   = KokkosKernels::default_scalar;
   using exec_space = typename device_t::execution_space;
   using crsMat_t   = KokkosSparse::CrsMatrix<scalar_t, lno_t, device_t, void, size_type>;
   using graph_t    = typename crsMat_t::staticcrsgraph_type;

--- a/sparse/unit_test/Test_Sparse_Transpose.hpp
+++ b/sparse/unit_test/Test_Sparse_Transpose.hpp
@@ -44,9 +44,9 @@ template <typename device_t>
 void testTranspose(int numRows, int numCols, bool doValues) {
   using exec_space  = typename device_t::execution_space;
   using range_pol   = Kokkos::RangePolicy<exec_space>;
-  using scalar_t    = default_scalar;
-  using lno_t       = default_lno_t;
-  using size_type   = default_size_type;
+  using scalar_t    = KokkosKernels::default_scalar;
+  using lno_t       = KokkosKernels::default_lno_t;
+  using size_type   = KokkosKernels::default_size_type;
   using crsMat_t    = typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device_t, void, size_type>;
   using c_rowmap_t  = typename crsMat_t::row_map_type;
   using c_entries_t = typename crsMat_t::index_type;
@@ -106,7 +106,7 @@ template <class bsrMat_t>
 void CompareBsrMatrices(bsrMat_t& A, bsrMat_t& B) {
   using exec_space  = typename bsrMat_t::execution_space;
   using range_pol   = Kokkos::RangePolicy<exec_space>;
-  using size_type   = default_size_type;
+  using size_type   = KokkosKernels::default_size_type;
   using c_rowmap_t  = typename bsrMat_t::row_map_type;
   using c_entries_t = typename bsrMat_t::index_type;
   using values_t    = typename bsrMat_t::values_type::non_const_type;
@@ -133,9 +133,9 @@ void CompareBsrMatrices(bsrMat_t& A, bsrMat_t& B) {
 
 template <typename device_t>
 void testTransposeBsrRef() {
-  using scalar_t  = default_scalar;
-  using lno_t     = default_lno_t;
-  using size_type = default_size_type;
+  using scalar_t  = KokkosKernels::default_scalar;
+  using lno_t     = KokkosKernels::default_lno_t;
+  using size_type = KokkosKernels::default_size_type;
   using bsrMat_t  = typename KokkosSparse::Experimental::BsrMatrix<scalar_t, lno_t, device_t, void, size_type>;
   using rowmap_t  = typename bsrMat_t::row_map_type::non_const_type;
   using entries_t = typename bsrMat_t::index_type::non_const_type;
@@ -199,9 +199,9 @@ void testTransposeBsrRef() {
 
 template <typename device_t>
 void testTransposeBsr(int numRows, int numCols, int blockSize) {
-  using scalar_t    = default_scalar;
-  using lno_t       = default_lno_t;
-  using size_type   = default_size_type;
+  using scalar_t    = KokkosKernels::default_scalar;
+  using lno_t       = KokkosKernels::default_lno_t;
+  using size_type   = KokkosKernels::default_size_type;
   using exec_space  = typename device_t::execution_space;
   using bsrMat_t    = typename KokkosSparse::Experimental::BsrMatrix<scalar_t, lno_t, device_t, void, size_type>;
   using c_rowmap_t  = typename bsrMat_t::row_map_type;

--- a/sparse/unit_test/Test_Sparse_block_gauss_seidel.hpp
+++ b/sparse/unit_test/Test_Sparse_block_gauss_seidel.hpp
@@ -220,7 +220,7 @@ void test_block_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth
   typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
   typedef typename crsMat_t::StaticCrsGraphType::row_map_type::non_const_type lno_view_t;
   typedef typename crsMat_t::StaticCrsGraphType::entries_type::non_const_type lno_nnz_view_t;
-  typedef Kokkos::View<scalar_t**, default_layout, device> scalar_view2d_t;
+  typedef Kokkos::View<scalar_t**, KokkosKernels::default_layout, device> scalar_view2d_t;
   typedef typename Kokkos::ArithTraits<scalar_t>::mag_type mag_t;
 
   lno_t numCols = numRows;

--- a/sparse/unit_test/Test_Sparse_gauss_seidel.hpp
+++ b/sparse/unit_test/Test_Sparse_gauss_seidel.hpp
@@ -248,8 +248,8 @@ void test_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth, lno_
   using namespace Test;
   srand(245);
   typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type> crsMat_t;
-  typedef Kokkos::View<scalar_t **, default_layout, device> scalar_view2d_t;
-  typedef Kokkos::View<scalar_t **, default_layout, Kokkos::HostSpace> host_scalar_view2d_t;
+  typedef Kokkos::View<scalar_t **, KokkosKernels::default_layout, device> scalar_view2d_t;
+  typedef Kokkos::View<scalar_t **, KokkosKernels::default_layout, Kokkos::HostSpace> host_scalar_view2d_t;
   typedef typename Kokkos::ArithTraits<scalar_t>::mag_type mag_t;
 
   lno_t numCols      = numRows;

--- a/sparse/unit_test/Test_Sparse_removeCrsMatrixZeros.hpp
+++ b/sparse/unit_test/Test_Sparse_removeCrsMatrixZeros.hpp
@@ -217,7 +217,8 @@ void getTestInput(int test, Matrix& A, Matrix& Afiltered_ref) {
 
 void testRemoveCrsMatrixZeros(int testCase) {
   using namespace TestRemoveCrsMatrixZeros;
-  using Matrix = KokkosSparse::CrsMatrix<default_scalar, default_lno_t, TestDevice, void, default_size_type>;
+  using Matrix = KokkosSparse::CrsMatrix<KokkosKernels::default_scalar, KokkosKernels::default_lno_t, TestDevice, void,
+                                         KokkosKernels::default_size_type>;
   Matrix A, Afiltered_ref;
   getTestInput<Matrix>(testCase, A, Afiltered_ref);
   Matrix Afiltered_actual = KokkosSparse::removeCrsMatrixZeros(A);

--- a/sparse/unit_test/Test_Sparse_spmv.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv.hpp
@@ -864,9 +864,9 @@ void test_github_issue_101() {
   // vectors.  Include a little extra in case the implementers decide
   // to strip-mine that.
   constexpr int numVecs = 22;
-  Kokkos::View<double **, default_layout, DeviceType> X("X", numCols, numVecs);
+  Kokkos::View<double **, KokkosKernels::default_layout, DeviceType> X("X", numCols, numVecs);
   Kokkos::deep_copy(X, static_cast<double>(1.0));
-  Kokkos::View<double **, default_layout, DeviceType> Y("Y", numRows, numVecs);
+  Kokkos::View<double **, KokkosKernels::default_layout, DeviceType> Y("Y", numRows, numVecs);
   auto Y_h = Kokkos::create_mirror_view(Y);  // we'll want this later
 
   // Start with the easy test case, where the matrix and the vectors

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -561,7 +561,7 @@ class RandCooMat {
 /// \tparam LayoutType
 /// \tparam Device
 template <class ScalarType, class LayoutType, class Device, typename Ordinal = int64_t,
-          typename Size = default_size_type>
+          typename Size = KokkosKernels::default_size_type>
 class RandCsMatrix {
  public:
   using value_type   = ScalarType;


### PR DESCRIPTION
This moves everything defined in `common/src/KokkosKernels_default_types.hpp` to the `KokkosKernels` namespace. The rest of the changes are just search-replace style modifications to accommodate that.

Potential fix for https://github.com/kokkos/kokkos-kernels/issues/2335