### PR TITLE
batched - dense: Testing and fixing Serial QR

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -265,6 +265,18 @@ struct Side {
   struct Right {};
 };
 
+template <class T>
+struct is_side : std::false_type {};
+
+template <>
+struct is_side<Side::Left> : std::true_type {};
+
+template <>
+struct is_side<Side::Right> : std::true_type {};
+
+template <class T>
+constexpr bool is_side_v = is_side<T>::value;
+
 struct Uplo {
   struct Upper {};
   struct Lower {};

--- a/batched/dense/impl/KokkosBatched_ApplyHouseholder_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_ApplyHouseholder_Serial_Internal.hpp
@@ -34,8 +34,8 @@ struct SerialApplyLeftHouseholderInternal {
                                            /* */ ValueType* u2, const int u2s,
                                            /* */ ValueType* a1t, const int a1ts,
                                            /* */ ValueType* A2, const int as0, const int as1,
-                                           /* */ ValueType* w1t) {
-    typedef ValueType value_type;
+                                           /* */ ValueType* w1t, const int ws0) {
+    using value_type = ValueType;
 
     /// u2  m x 1
     /// a1t 1 x n
@@ -54,15 +54,15 @@ struct SerialApplyLeftHouseholderInternal {
     for (int j = 0; j < n; ++j) {
       value_type tmp = a1t[j * a1ts];
       for (int i = 0; i < m; ++i) tmp += Kokkos::ArithTraits<value_type>::conj(u2[i * u2s]) * A2[i * as0 + j * as1];
-      w1t[j] = tmp * inv_tau;  // /= (*tau);
+      w1t[j * ws0] = tmp * inv_tau;  // /= (*tau);
     }
 
     // a1t -= w1t    (axpy)
-    for (int j = 0; j < n; ++j) a1t[j * a1ts] -= w1t[j];
+    for (int j = 0; j < n; ++j) a1t[j * a1ts] -= w1t[j * ws0];
 
     // A2  -= u2 w1t (ger)
     for (int j = 0; j < n; ++j)
-      for (int i = 0; i < m; ++i) A2[i * as0 + j * as1] -= u2[i * u2s] * w1t[j];
+      for (int i = 0; i < m; ++i) A2[i * as0 + j * as1] -= u2[i * u2s] * w1t[j * ws0];
 
     return 0;
   }
@@ -74,8 +74,8 @@ struct SerialApplyRightHouseholderInternal {
                                            /* */ ValueType* u2, const int u2s,
                                            /* */ ValueType* a1, const int a1s,
                                            /* */ ValueType* A2, const int as0, const int as1,
-                                           /* */ ValueType* w1) {
-    typedef ValueType value_type;
+                                           /* */ ValueType* w1, const int ws0) {
+    using value_type = ValueType;
     /// u2 n x 1
     /// a1 m x 1
     /// A2 m x n
@@ -93,15 +93,16 @@ struct SerialApplyRightHouseholderInternal {
     for (int i = 0; i < m; ++i) {
       value_type tmp = a1[i * a1s];
       for (int j = 0; j < n; ++j) tmp += A2[i * as0 + j * as1] * u2[j * u2s];
-      w1[i] = tmp * inv_tau;  // \= (*tau);
+      w1[i * ws0] = tmp * inv_tau;  // \= (*tau);
     }
 
     // a1 -= w1 (axpy)
-    for (int i = 0; i < m; ++i) a1[i * a1s] -= w1[i];
+    for (int i = 0; i < m; ++i) a1[i * a1s] -= w1[i * ws0];
 
     // A2 -= w1 * u2' (ger with conjugate)
     for (int j = 0; j < n; ++j)
-      for (int i = 0; i < m; ++i) A2[i * as0 + j * as1] -= w1[i] * Kokkos::ArithTraits<ValueType>::conj(u2[j * u2s]);
+      for (int i = 0; i < m; ++i)
+        A2[i * as0 + j * as1] -= w1[i * ws0] * Kokkos::ArithTraits<ValueType>::conj(u2[j * u2s]);
 
     return 0;
   }

--- a/batched/dense/impl/KokkosBatched_ApplyHouseholder_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_ApplyHouseholder_Serial_Internal.hpp
@@ -101,8 +101,7 @@ struct SerialApplyRightHouseholderInternal {
 
     // A2 -= w1 * u2' (ger with conjugate)
     for (int j = 0; j < n; ++j)
-      for (int i = 0; i < m; ++i)
-        A2[i * as0 + j * as1] -= w1[i] * Kokkos::ArithTraits<ValueType>::conj(u2[j * u2s]);
+      for (int i = 0; i < m; ++i) A2[i * as0 + j * as1] -= w1[i] * Kokkos::ArithTraits<ValueType>::conj(u2[j * u2s]);
 
     return 0;
   }

--- a/batched/dense/impl/KokkosBatched_ApplyHouseholder_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_ApplyHouseholder_Serial_Internal.hpp
@@ -34,7 +34,7 @@ struct SerialApplyLeftHouseholderInternal {
                                            /* */ ValueType* u2, const int u2s,
                                            /* */ ValueType* a1t, const int a1ts,
                                            /* */ ValueType* A2, const int as0, const int as1,
-                                           /* */ ValueType* w1t, const int ws0) {
+                                           /* */ ValueType* w1t) {
     using value_type = ValueType;
 
     /// u2  m x 1
@@ -54,15 +54,15 @@ struct SerialApplyLeftHouseholderInternal {
     for (int j = 0; j < n; ++j) {
       value_type tmp = a1t[j * a1ts];
       for (int i = 0; i < m; ++i) tmp += Kokkos::ArithTraits<value_type>::conj(u2[i * u2s]) * A2[i * as0 + j * as1];
-      w1t[j * ws0] = tmp * inv_tau;  // /= (*tau);
+      w1t[j] = tmp * inv_tau;  // /= (*tau);
     }
 
     // a1t -= w1t    (axpy)
-    for (int j = 0; j < n; ++j) a1t[j * a1ts] -= w1t[j * ws0];
+    for (int j = 0; j < n; ++j) a1t[j * a1ts] -= w1t[j];
 
     // A2  -= u2 w1t (ger)
     for (int j = 0; j < n; ++j)
-      for (int i = 0; i < m; ++i) A2[i * as0 + j * as1] -= u2[i * u2s] * w1t[j * ws0];
+      for (int i = 0; i < m; ++i) A2[i * as0 + j * as1] -= u2[i * u2s] * w1t[j];
 
     return 0;
   }
@@ -74,7 +74,7 @@ struct SerialApplyRightHouseholderInternal {
                                            /* */ ValueType* u2, const int u2s,
                                            /* */ ValueType* a1, const int a1s,
                                            /* */ ValueType* A2, const int as0, const int as1,
-                                           /* */ ValueType* w1, const int ws0) {
+                                           /* */ ValueType* w1) {
     using value_type = ValueType;
     /// u2 n x 1
     /// a1 m x 1
@@ -93,16 +93,16 @@ struct SerialApplyRightHouseholderInternal {
     for (int i = 0; i < m; ++i) {
       value_type tmp = a1[i * a1s];
       for (int j = 0; j < n; ++j) tmp += A2[i * as0 + j * as1] * u2[j * u2s];
-      w1[i * ws0] = tmp * inv_tau;  // \= (*tau);
+      w1[i] = tmp * inv_tau;  // \= (*tau);
     }
 
     // a1 -= w1 (axpy)
-    for (int i = 0; i < m; ++i) a1[i * a1s] -= w1[i * ws0];
+    for (int i = 0; i < m; ++i) a1[i * a1s] -= w1[i];
 
     // A2 -= w1 * u2' (ger with conjugate)
     for (int j = 0; j < n; ++j)
       for (int i = 0; i < m; ++i)
-        A2[i * as0 + j * as1] -= w1[i * ws0] * Kokkos::ArithTraits<ValueType>::conj(u2[j * u2s]);
+        A2[i * as0 + j * as1] -= w1[i] * Kokkos::ArithTraits<ValueType>::conj(u2[j * u2s]);
 
     return 0;
   }

--- a/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Impl.hpp
@@ -33,7 +33,7 @@ KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Left, Trans::NoTranspose, Algo::Ap
     const AViewType &A, const tViewType &t, const BViewType &B, const wViewType &w) {
   return SerialApplyQ_LeftForwardInternal::invoke(B.extent(0), B.extent(1), A.extent(1), A.data(), A.stride_0(),
                                                   A.stride_1(), t.data(), t.stride_0(), B.data(), B.stride_0(),
-                                                  B.stride_1(), w.data(), w.stride_0());
+                                                  B.stride_1(), w.data());
 }
 
 template <>
@@ -42,7 +42,7 @@ KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Left, Trans::Transpose, Algo::Appl
     const AViewType &A, const tViewType &t, const BViewType &B, const wViewType &w) {
   return SerialApplyQ_LeftBackwardInternal::invoke(B.extent(0), B.extent(1), A.extent(1), A.data(), A.stride_0(),
                                                    A.stride_1(), t.data(), t.stride_0(), B.data(), B.stride_0(),
-                                                   B.stride_1(), w.data(), w.stride_0());
+                                                   B.stride_1(), w.data());
 }
 
 template <>
@@ -51,7 +51,7 @@ KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Right, Trans::NoTranspose, Algo::A
     const AViewType &A, const tViewType &t, const BViewType &B, const wViewType &w) {
   return SerialApplyQ_RightForwardInternal::invoke(B.extent(0), B.extent(1), A.extent(1), A.data(), A.stride_0(),
                                                    A.stride_1(), t.data(), t.stride_0(), B.data(), B.stride_0(),
-                                                   B.stride_1(), w.data(), w.strid_0());
+                                                   B.stride_1(), w.data());
 }
 
 }  // namespace KokkosBatched

--- a/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Impl.hpp
@@ -31,25 +31,25 @@ template <>
 template <typename AViewType, typename tViewType, typename BViewType, typename wViewType>
 KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Left, Trans::NoTranspose, Algo::ApplyQ::Unblocked>::invoke(
     const AViewType &A, const tViewType &t, const BViewType &B, const wViewType &w) {
-  static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::SerialQR::invoke: AViewType must be a Kokkos::View");
-  static_assert(AViewType::rank() == 2, "KokkosBatched::SerialQR::invoke: AViewType must have rank 2");
+  static_assert(Kokkos::is_view_v<AViewType>, "KokkosBatched::SerialApplyQ::invoke: AViewType must be a Kokkos::View");
+  static_assert(AViewType::rank() == 2, "KokkosBatched::SerialApplyQ::invoke: AViewType must have rank 2");
 
-  static_assert(Kokkos::is_view<tViewType>::value, "KokkosBatched::SerialQR::invoke: tViewType must be a Kokkos::View");
-  static_assert(tViewType::rank() == 1, "KokkosBatched::SerialQR::invoke: tViewType must have rank 1");
+  static_assert(Kokkos::is_view_v<tViewType>, "KokkosBatched::SerialApplyQ::invoke: tViewType must be a Kokkos::View");
+  static_assert(tViewType::rank() == 1, "KokkosBatched::SerialApplyQ::invoke: tViewType must have rank 1");
 
-  static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::SerialQR::invoke: BViewType must be a Kokkos::View");
-  static_assert(BViewType::rank() == 2, "KokkosBatched::SerialQR::invoke: BViewType must have rank 2");
+  static_assert(Kokkos::is_view_v<BViewType>, "KokkosBatched::SerialApplyQ::invoke: BViewType must be a Kokkos::View");
+  static_assert(BViewType::rank() == 2, "KokkosBatched::SerialApplyQ::invoke: BViewType must have rank 2");
 
-  static_assert(Kokkos::is_view<wViewType>::value, "KokkosBatched::SerialQR::invoke: wViewType must be a Kokkos::View");
-  static_assert(wViewType::rank() == 1, "KokkosBatched::SerialQR::invoke: wViewType must have rank 1");
+  static_assert(Kokkos::is_view_v<wViewType>, "KokkosBatched::SerialApplyQ::invoke: wViewType must be a Kokkos::View");
+  static_assert(wViewType::rank() == 1, "KokkosBatched::SerialApplyQ::invoke: wViewType must have rank 1");
 
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
   if (!w.span_is_contiguous()) {
-    Kokkos::printf("KokkosBatched::SerialQR::invoke: w must have a contiguous span.");
+    Kokkos::printf("KokkosBatched::SerialApplyQ::invoke: w must have a contiguous span.");
     return 1;
   }
   if (A.extent_int(1) != t.extent_int(0)) {
-    Kokkos::printf("KokkosBatched::SerialQR::invoke: A.extent(1) is different from t.extent(0).");
+    Kokkos::printf("KokkosBatched::SerialApplyQ::invoke: A.extent(1) is different from t.extent(0).");
     return 1;
   }
 #endif
@@ -63,25 +63,25 @@ template <>
 template <typename AViewType, typename tViewType, typename BViewType, typename wViewType>
 KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Left, Trans::Transpose, Algo::ApplyQ::Unblocked>::invoke(
     const AViewType &A, const tViewType &t, const BViewType &B, const wViewType &w) {
-  static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::SerialQR::invoke: AViewType must be a Kokkos::View");
-  static_assert(AViewType::rank() == 2, "KokkosBatched::SerialQR::invoke: AViewType must have rank 2");
+  static_assert(Kokkos::is_view_v<AViewType>, "KokkosBatched::SerialApplyQ::invoke: AViewType must be a Kokkos::View");
+  static_assert(AViewType::rank() == 2, "KokkosBatched::SerialApplyQ::invoke: AViewType must have rank 2");
 
-  static_assert(Kokkos::is_view<tViewType>::value, "KokkosBatched::SerialQR::invoke: tViewType must be a Kokkos::View");
-  static_assert(tViewType::rank() == 1, "KokkosBatched::SerialQR::invoke: tViewType must have rank 1");
+  static_assert(Kokkos::is_view_v<tViewType>, "KokkosBatched::SerialApplyQ::invoke: tViewType must be a Kokkos::View");
+  static_assert(tViewType::rank() == 1, "KokkosBatched::SerialApplyQ::invoke: tViewType must have rank 1");
 
-  static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::SerialQR::invoke: BViewType must be a Kokkos::View");
-  static_assert(BViewType::rank() == 2, "KokkosBatched::SerialQR::invoke: BViewType must have rank 2");
+  static_assert(Kokkos::is_view_v<BViewType>, "KokkosBatched::SerialApplyQ::invoke: BViewType must be a Kokkos::View");
+  static_assert(BViewType::rank() == 2, "KokkosBatched::SerialApplyQ::invoke: BViewType must have rank 2");
 
-  static_assert(Kokkos::is_view<wViewType>::value, "KokkosBatched::SerialQR::invoke: wViewType must be a Kokkos::View");
-  static_assert(wViewType::rank() == 1, "KokkosBatched::SerialQR::invoke: wViewType must have rank 1");
+  static_assert(Kokkos::is_view_v<wViewType>, "KokkosBatched::SerialApplyQ::invoke: wViewType must be a Kokkos::View");
+  static_assert(wViewType::rank() == 1, "KokkosBatched::SerialApplyQ::invoke: wViewType must have rank 1");
 
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
   if (!w.span_is_contiguous()) {
-    Kokkos::printf("KokkosBatched::SerialQR::invoke: w must have a contiguous span.");
+    Kokkos::printf("KokkosBatched::SerialApplyQ::invoke: w must have a contiguous span.");
     return 1;
   }
   if (A.extent_int(1) != t.extent_int(0)) {
-    Kokkos::printf("KokkosBatched::SerialQR::invoke: A.extent(1) is different from t.extent(0).");
+    Kokkos::printf("KokkosBatched::SerialApplyQ::invoke: A.extent(1) is different from t.extent(0).");
     return 1;
   }
 #endif
@@ -95,25 +95,25 @@ template <>
 template <typename AViewType, typename tViewType, typename BViewType, typename wViewType>
 KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Right, Trans::NoTranspose, Algo::ApplyQ::Unblocked>::invoke(
     const AViewType &A, const tViewType &t, const BViewType &B, const wViewType &w) {
-  static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::SerialQR::invoke: AViewType must be a Kokkos::View");
-  static_assert(AViewType::rank() == 2, "KokkosBatched::SerialQR::invoke: AViewType must have rank 2");
+  static_assert(Kokkos::is_view_v<AViewType>, "KokkosBatched::SerialApplyQ::invoke: AViewType must be a Kokkos::View");
+  static_assert(AViewType::rank() == 2, "KokkosBatched::SerialApplyQ::invoke: AViewType must have rank 2");
 
-  static_assert(Kokkos::is_view<tViewType>::value, "KokkosBatched::SerialQR::invoke: tViewType must be a Kokkos::View");
-  static_assert(tViewType::rank() == 1, "KokkosBatched::SerialQR::invoke: tViewType must have rank 1");
+  static_assert(Kokkos::is_view_v<tViewType>, "KokkosBatched::SerialApplyQ::invoke: tViewType must be a Kokkos::View");
+  static_assert(tViewType::rank() == 1, "KokkosBatched::SerialApplyQ::invoke: tViewType must have rank 1");
 
-  static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::SerialQR::invoke: BViewType must be a Kokkos::View");
-  static_assert(BViewType::rank() == 2, "KokkosBatched::SerialQR::invoke: BViewType must have rank 2");
+  static_assert(Kokkos::is_view_v<BViewType>, "KokkosBatched::SerialApplyQ::invoke: BViewType must be a Kokkos::View");
+  static_assert(BViewType::rank() == 2, "KokkosBatched::SerialApplyQ::invoke: BViewType must have rank 2");
 
-  static_assert(Kokkos::is_view<wViewType>::value, "KokkosBatched::SerialQR::invoke: wViewType must be a Kokkos::View");
-  static_assert(wViewType::rank() == 1, "KokkosBatched::SerialQR::invoke: wViewType must have rank 1");
+  static_assert(Kokkos::is_view_v<wViewType>, "KokkosBatched::SerialApplyQ::invoke: wViewType must be a Kokkos::View");
+  static_assert(wViewType::rank() == 1, "KokkosBatched::SerialApplyQ::invoke: wViewType must have rank 1");
 
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
   if (!w.span_is_contiguous()) {
-    Kokkos::printf("KokkosBatched::SerialQR::invoke: w must have a contiguous span.");
+    Kokkos::printf("KokkosBatched::SerialApplyQ::invoke: w must have a contiguous span.");
     return 1;
   }
   if (A.extent_int(1) != t.extent_int(0)) {
-    Kokkos::printf("KokkosBatched::SerialQR::invoke: A.extent(1) is different from t.extent(0).");
+    Kokkos::printf("KokkosBatched::SerialApplyQ::invoke: A.extent(1) is different from t.extent(0).");
     return 1;
   }
 #endif

--- a/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Impl.hpp
@@ -31,6 +31,37 @@ template <>
 template <typename AViewType, typename tViewType, typename BViewType, typename wViewType>
 KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Left, Trans::NoTranspose, Algo::ApplyQ::Unblocked>::invoke(
     const AViewType &A, const tViewType &t, const BViewType &B, const wViewType &w) {
+  static_assert(Kokkos::is_view<AViewType>::value,
+		"KokkosBatched::SerialQR::invoke: AViewType must be a Kokkos::View");
+  static_assert(AViewType::rank() == 2,
+		"KokkosBatched::SerialQR::invoke: AViewType must have rank 2");
+
+  static_assert(Kokkos::is_view<tViewType>::value,
+		"KokkosBatched::SerialQR::invoke: tViewType must be a Kokkos::View");
+  static_assert(tViewType::rank() == 1,
+		"KokkosBatched::SerialQR::invoke: tViewType must have rank 1");
+
+  static_assert(Kokkos::is_view<BViewType>::value,
+		"KokkosBatched::SerialQR::invoke: BViewType must be a Kokkos::View");
+  static_assert(BViewType::rank() == 2,
+		"KokkosBatched::SerialQR::invoke: BViewType must have rank 2");
+
+  static_assert(Kokkos::is_view<wViewType>::value,
+		"KokkosBatched::SerialQR::invoke: wViewType must be a Kokkos::View");
+  static_assert(wViewType::rank() == 1,
+		"KokkosBatched::SerialQR::invoke: wViewType must have rank 1");
+
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+  if(!w.span_is_contiguous()) {
+    Kokkos::printf("KokkosBatched::SerialQR::invoke: w must have a contiguous span.");
+    return 1;
+  }
+  if(A.extent_int(1) != t.extent_int(0)) {
+    Kokkos::printf("KokkosBatched::SerialQR::invoke: A.extent(1) is different from t.extent(0).");
+    return 1;
+  }
+#endif
+
   return SerialApplyQ_LeftForwardInternal::invoke(B.extent(0), B.extent(1), A.extent(1), A.data(), A.stride_0(),
                                                   A.stride_1(), t.data(), t.stride_0(), B.data(), B.stride_0(),
                                                   B.stride_1(), w.data());
@@ -40,6 +71,37 @@ template <>
 template <typename AViewType, typename tViewType, typename BViewType, typename wViewType>
 KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Left, Trans::Transpose, Algo::ApplyQ::Unblocked>::invoke(
     const AViewType &A, const tViewType &t, const BViewType &B, const wViewType &w) {
+  static_assert(Kokkos::is_view<AViewType>::value,
+		"KokkosBatched::SerialQR::invoke: AViewType must be a Kokkos::View");
+  static_assert(AViewType::rank() == 2,
+		"KokkosBatched::SerialQR::invoke: AViewType must have rank 2");
+
+  static_assert(Kokkos::is_view<tViewType>::value,
+		"KokkosBatched::SerialQR::invoke: tViewType must be a Kokkos::View");
+  static_assert(tViewType::rank() == 1,
+		"KokkosBatched::SerialQR::invoke: tViewType must have rank 1");
+
+  static_assert(Kokkos::is_view<BViewType>::value,
+		"KokkosBatched::SerialQR::invoke: BViewType must be a Kokkos::View");
+  static_assert(BViewType::rank() == 2,
+		"KokkosBatched::SerialQR::invoke: BViewType must have rank 2");
+
+  static_assert(Kokkos::is_view<wViewType>::value,
+		"KokkosBatched::SerialQR::invoke: wViewType must be a Kokkos::View");
+  static_assert(wViewType::rank() == 1,
+		"KokkosBatched::SerialQR::invoke: wViewType must have rank 1");
+
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+  if(!w.span_is_contiguous()) {
+    Kokkos::printf("KokkosBatched::SerialQR::invoke: w must have a contiguous span.");
+    return 1;
+  }
+  if(A.extent_int(1) != t.extent_int(0)) {
+    Kokkos::printf("KokkosBatched::SerialQR::invoke: A.extent(1) is different from t.extent(0).");
+    return 1;
+  }
+#endif
+
   return SerialApplyQ_LeftBackwardInternal::invoke(B.extent(0), B.extent(1), A.extent(1), A.data(), A.stride_0(),
                                                    A.stride_1(), t.data(), t.stride_0(), B.data(), B.stride_0(),
                                                    B.stride_1(), w.data());
@@ -49,6 +111,37 @@ template <>
 template <typename AViewType, typename tViewType, typename BViewType, typename wViewType>
 KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Right, Trans::NoTranspose, Algo::ApplyQ::Unblocked>::invoke(
     const AViewType &A, const tViewType &t, const BViewType &B, const wViewType &w) {
+  static_assert(Kokkos::is_view<AViewType>::value,
+		"KokkosBatched::SerialQR::invoke: AViewType must be a Kokkos::View");
+  static_assert(AViewType::rank() == 2,
+		"KokkosBatched::SerialQR::invoke: AViewType must have rank 2");
+
+  static_assert(Kokkos::is_view<tViewType>::value,
+		"KokkosBatched::SerialQR::invoke: tViewType must be a Kokkos::View");
+  static_assert(tViewType::rank() == 1,
+		"KokkosBatched::SerialQR::invoke: tViewType must have rank 1");
+
+  static_assert(Kokkos::is_view<BViewType>::value,
+		"KokkosBatched::SerialQR::invoke: BViewType must be a Kokkos::View");
+  static_assert(BViewType::rank() == 2,
+		"KokkosBatched::SerialQR::invoke: BViewType must have rank 2");
+
+  static_assert(Kokkos::is_view<wViewType>::value,
+		"KokkosBatched::SerialQR::invoke: wViewType must be a Kokkos::View");
+  static_assert(wViewType::rank() == 1,
+		"KokkosBatched::SerialQR::invoke: wViewType must have rank 1");
+
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+  if(!w.span_is_contiguous()) {
+    Kokkos::printf("KokkosBatched::SerialQR::invoke: w must have a contiguous span.");
+    return 1;
+  }
+  if(A.extent_int(1) != t.extent_int(0)) {
+    Kokkos::printf("KokkosBatched::SerialQR::invoke: A.extent(1) is different from t.extent(0).");
+    return 1;
+  }
+#endif
+
   return SerialApplyQ_RightForwardInternal::invoke(B.extent(0), B.extent(1), A.extent(1), A.data(), A.stride_0(),
                                                    A.stride_1(), t.data(), t.stride_0(), B.data(), B.stride_0(),
                                                    B.stride_1(), w.data());

--- a/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Impl.hpp
@@ -31,32 +31,24 @@ template <>
 template <typename AViewType, typename tViewType, typename BViewType, typename wViewType>
 KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Left, Trans::NoTranspose, Algo::ApplyQ::Unblocked>::invoke(
     const AViewType &A, const tViewType &t, const BViewType &B, const wViewType &w) {
-  static_assert(Kokkos::is_view<AViewType>::value,
-		"KokkosBatched::SerialQR::invoke: AViewType must be a Kokkos::View");
-  static_assert(AViewType::rank() == 2,
-		"KokkosBatched::SerialQR::invoke: AViewType must have rank 2");
+  static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::SerialQR::invoke: AViewType must be a Kokkos::View");
+  static_assert(AViewType::rank() == 2, "KokkosBatched::SerialQR::invoke: AViewType must have rank 2");
 
-  static_assert(Kokkos::is_view<tViewType>::value,
-		"KokkosBatched::SerialQR::invoke: tViewType must be a Kokkos::View");
-  static_assert(tViewType::rank() == 1,
-		"KokkosBatched::SerialQR::invoke: tViewType must have rank 1");
+  static_assert(Kokkos::is_view<tViewType>::value, "KokkosBatched::SerialQR::invoke: tViewType must be a Kokkos::View");
+  static_assert(tViewType::rank() == 1, "KokkosBatched::SerialQR::invoke: tViewType must have rank 1");
 
-  static_assert(Kokkos::is_view<BViewType>::value,
-		"KokkosBatched::SerialQR::invoke: BViewType must be a Kokkos::View");
-  static_assert(BViewType::rank() == 2,
-		"KokkosBatched::SerialQR::invoke: BViewType must have rank 2");
+  static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::SerialQR::invoke: BViewType must be a Kokkos::View");
+  static_assert(BViewType::rank() == 2, "KokkosBatched::SerialQR::invoke: BViewType must have rank 2");
 
-  static_assert(Kokkos::is_view<wViewType>::value,
-		"KokkosBatched::SerialQR::invoke: wViewType must be a Kokkos::View");
-  static_assert(wViewType::rank() == 1,
-		"KokkosBatched::SerialQR::invoke: wViewType must have rank 1");
+  static_assert(Kokkos::is_view<wViewType>::value, "KokkosBatched::SerialQR::invoke: wViewType must be a Kokkos::View");
+  static_assert(wViewType::rank() == 1, "KokkosBatched::SerialQR::invoke: wViewType must have rank 1");
 
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-  if(!w.span_is_contiguous()) {
+  if (!w.span_is_contiguous()) {
     Kokkos::printf("KokkosBatched::SerialQR::invoke: w must have a contiguous span.");
     return 1;
   }
-  if(A.extent_int(1) != t.extent_int(0)) {
+  if (A.extent_int(1) != t.extent_int(0)) {
     Kokkos::printf("KokkosBatched::SerialQR::invoke: A.extent(1) is different from t.extent(0).");
     return 1;
   }
@@ -71,32 +63,24 @@ template <>
 template <typename AViewType, typename tViewType, typename BViewType, typename wViewType>
 KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Left, Trans::Transpose, Algo::ApplyQ::Unblocked>::invoke(
     const AViewType &A, const tViewType &t, const BViewType &B, const wViewType &w) {
-  static_assert(Kokkos::is_view<AViewType>::value,
-		"KokkosBatched::SerialQR::invoke: AViewType must be a Kokkos::View");
-  static_assert(AViewType::rank() == 2,
-		"KokkosBatched::SerialQR::invoke: AViewType must have rank 2");
+  static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::SerialQR::invoke: AViewType must be a Kokkos::View");
+  static_assert(AViewType::rank() == 2, "KokkosBatched::SerialQR::invoke: AViewType must have rank 2");
 
-  static_assert(Kokkos::is_view<tViewType>::value,
-		"KokkosBatched::SerialQR::invoke: tViewType must be a Kokkos::View");
-  static_assert(tViewType::rank() == 1,
-		"KokkosBatched::SerialQR::invoke: tViewType must have rank 1");
+  static_assert(Kokkos::is_view<tViewType>::value, "KokkosBatched::SerialQR::invoke: tViewType must be a Kokkos::View");
+  static_assert(tViewType::rank() == 1, "KokkosBatched::SerialQR::invoke: tViewType must have rank 1");
 
-  static_assert(Kokkos::is_view<BViewType>::value,
-		"KokkosBatched::SerialQR::invoke: BViewType must be a Kokkos::View");
-  static_assert(BViewType::rank() == 2,
-		"KokkosBatched::SerialQR::invoke: BViewType must have rank 2");
+  static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::SerialQR::invoke: BViewType must be a Kokkos::View");
+  static_assert(BViewType::rank() == 2, "KokkosBatched::SerialQR::invoke: BViewType must have rank 2");
 
-  static_assert(Kokkos::is_view<wViewType>::value,
-		"KokkosBatched::SerialQR::invoke: wViewType must be a Kokkos::View");
-  static_assert(wViewType::rank() == 1,
-		"KokkosBatched::SerialQR::invoke: wViewType must have rank 1");
+  static_assert(Kokkos::is_view<wViewType>::value, "KokkosBatched::SerialQR::invoke: wViewType must be a Kokkos::View");
+  static_assert(wViewType::rank() == 1, "KokkosBatched::SerialQR::invoke: wViewType must have rank 1");
 
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-  if(!w.span_is_contiguous()) {
+  if (!w.span_is_contiguous()) {
     Kokkos::printf("KokkosBatched::SerialQR::invoke: w must have a contiguous span.");
     return 1;
   }
-  if(A.extent_int(1) != t.extent_int(0)) {
+  if (A.extent_int(1) != t.extent_int(0)) {
     Kokkos::printf("KokkosBatched::SerialQR::invoke: A.extent(1) is different from t.extent(0).");
     return 1;
   }
@@ -111,32 +95,24 @@ template <>
 template <typename AViewType, typename tViewType, typename BViewType, typename wViewType>
 KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Right, Trans::NoTranspose, Algo::ApplyQ::Unblocked>::invoke(
     const AViewType &A, const tViewType &t, const BViewType &B, const wViewType &w) {
-  static_assert(Kokkos::is_view<AViewType>::value,
-		"KokkosBatched::SerialQR::invoke: AViewType must be a Kokkos::View");
-  static_assert(AViewType::rank() == 2,
-		"KokkosBatched::SerialQR::invoke: AViewType must have rank 2");
+  static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::SerialQR::invoke: AViewType must be a Kokkos::View");
+  static_assert(AViewType::rank() == 2, "KokkosBatched::SerialQR::invoke: AViewType must have rank 2");
 
-  static_assert(Kokkos::is_view<tViewType>::value,
-		"KokkosBatched::SerialQR::invoke: tViewType must be a Kokkos::View");
-  static_assert(tViewType::rank() == 1,
-		"KokkosBatched::SerialQR::invoke: tViewType must have rank 1");
+  static_assert(Kokkos::is_view<tViewType>::value, "KokkosBatched::SerialQR::invoke: tViewType must be a Kokkos::View");
+  static_assert(tViewType::rank() == 1, "KokkosBatched::SerialQR::invoke: tViewType must have rank 1");
 
-  static_assert(Kokkos::is_view<BViewType>::value,
-		"KokkosBatched::SerialQR::invoke: BViewType must be a Kokkos::View");
-  static_assert(BViewType::rank() == 2,
-		"KokkosBatched::SerialQR::invoke: BViewType must have rank 2");
+  static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::SerialQR::invoke: BViewType must be a Kokkos::View");
+  static_assert(BViewType::rank() == 2, "KokkosBatched::SerialQR::invoke: BViewType must have rank 2");
 
-  static_assert(Kokkos::is_view<wViewType>::value,
-		"KokkosBatched::SerialQR::invoke: wViewType must be a Kokkos::View");
-  static_assert(wViewType::rank() == 1,
-		"KokkosBatched::SerialQR::invoke: wViewType must have rank 1");
+  static_assert(Kokkos::is_view<wViewType>::value, "KokkosBatched::SerialQR::invoke: wViewType must be a Kokkos::View");
+  static_assert(wViewType::rank() == 1, "KokkosBatched::SerialQR::invoke: wViewType must have rank 1");
 
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-  if(!w.span_is_contiguous()) {
+  if (!w.span_is_contiguous()) {
     Kokkos::printf("KokkosBatched::SerialQR::invoke: w must have a contiguous span.");
     return 1;
   }
-  if(A.extent_int(1) != t.extent_int(0)) {
+  if (A.extent_int(1) != t.extent_int(0)) {
     Kokkos::printf("KokkosBatched::SerialQR::invoke: A.extent(1) is different from t.extent(0).");
     return 1;
   }

--- a/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Impl.hpp
@@ -33,7 +33,7 @@ KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Left, Trans::NoTranspose, Algo::Ap
     const AViewType &A, const tViewType &t, const BViewType &B, const wViewType &w) {
   return SerialApplyQ_LeftForwardInternal::invoke(B.extent(0), B.extent(1), A.extent(1), A.data(), A.stride_0(),
                                                   A.stride_1(), t.data(), t.stride_0(), B.data(), B.stride_0(),
-                                                  B.stride_1(), w.data());
+                                                  B.stride_1(), w.data(), w.stride_0());
 }
 
 template <>
@@ -42,7 +42,7 @@ KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Left, Trans::Transpose, Algo::Appl
     const AViewType &A, const tViewType &t, const BViewType &B, const wViewType &w) {
   return SerialApplyQ_LeftBackwardInternal::invoke(B.extent(0), B.extent(1), A.extent(1), A.data(), A.stride_0(),
                                                    A.stride_1(), t.data(), t.stride_0(), B.data(), B.stride_0(),
-                                                   B.stride_1(), w.data());
+                                                   B.stride_1(), w.data(), w.stride_0());
 }
 
 template <>
@@ -51,7 +51,7 @@ KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Right, Trans::NoTranspose, Algo::A
     const AViewType &A, const tViewType &t, const BViewType &B, const wViewType &w) {
   return SerialApplyQ_RightForwardInternal::invoke(B.extent(0), B.extent(1), A.extent(1), A.data(), A.stride_0(),
                                                    A.stride_1(), t.data(), t.stride_0(), B.data(), B.stride_0(),
-                                                   B.stride_1(), w.data());
+                                                   B.stride_1(), w.data(), w.strid_0());
 }
 
 }  // namespace KokkosBatched

--- a/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Internal.hpp
@@ -36,8 +36,8 @@ struct SerialApplyQ_LeftForwardInternal {
                                            /* */ ValueType *A, const int as0, const int as1,
                                            /* */ ValueType *t, const int ts,
                                            /* */ ValueType *B, const int bs0, const int bs1,
-                                           /* */ ValueType *w, const int ws) {
-    typedef ValueType value_type;
+                                           /* */ ValueType *w) {
+    using value_type = ValueType;
 
     /// Given a matrix A that includes a series of householder vectors,
     /// it applies a unitary matrix Q to B from left without transpose
@@ -73,7 +73,7 @@ struct SerialApplyQ_LeftForwardInternal {
       /// -----------------------------------------------------
       // left apply householder to partitioned B1 and B2
       SerialApplyLeftHouseholderInternal::invoke(m_A2, n, tau, A_part3x3.A21, as0, B_part3x1.A1, bs1, B_part3x1.A2, bs0,
-                                                 bs1, w, ws);
+                                                 bs1, w);
 
       /// -----------------------------------------------------
       A_part2x2.mergeToABR(A_part3x3);
@@ -90,8 +90,8 @@ struct SerialApplyQ_LeftBackwardInternal {
                                            /* */ ValueType *A, const int as0, const int as1,
                                            /* */ ValueType *t, const int ts,
                                            /* */ ValueType *B, const int bs0, const int bs1,
-                                           /* */ ValueType *w, const int ws) {
-    typedef ValueType value_type;
+                                           /* */ ValueType *w) {
+    using value_type = ValueType;
 
     /// Given a matrix A that includes a series of householder vectors,
     /// it applies a unitary matrix Q to B from left with transpose
@@ -127,7 +127,7 @@ struct SerialApplyQ_LeftBackwardInternal {
       /// -----------------------------------------------------
       // left apply householder to partitioned B1 and B2
       SerialApplyLeftHouseholderInternal::invoke(m_A2, n, tau, A_part3x3.A21, as0, B_part3x1.A1, bs1, B_part3x1.A2, bs0,
-                                                 bs1, w, ws);
+                                                 bs1, w);
       /// -----------------------------------------------------
       A_part2x2.mergeToATL(A_part3x3);
       t_part2x1.mergeToAT(t_part3x1);
@@ -143,8 +143,8 @@ struct SerialApplyQ_RightForwardInternal {
                                            /* */ ValueType *A, const int as0, const int as1,
                                            /* */ ValueType *t, const int ts,
                                            /* */ ValueType *B, const int bs0, const int bs1,
-                                           /* */ ValueType *w, const int ws) {
-    typedef ValueType value_type;
+                                           /* */ ValueType *w) {
+    using value_type = ValueType;
 
     /// Given a matrix A that includes a series of householder vectors,
     /// it applies a unitary matrix Q to B from left without transpose
@@ -180,7 +180,7 @@ struct SerialApplyQ_RightForwardInternal {
       /// -----------------------------------------------------
       // right apply householder to partitioned B1 and B2
       SerialApplyRightHouseholderInternal::invoke(m, n_B2, tau, A_part3x3.A21, as0, B_part1x3.A1, bs0, B_part1x3.A2,
-                                                  bs0, bs1, w, ws);
+                                                  bs0, bs1, w);
       /// -----------------------------------------------------
       A_part2x2.mergeToATL(A_part3x3);
       t_part2x1.mergeToAT(t_part3x1);

--- a/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Internal.hpp
@@ -36,7 +36,7 @@ struct SerialApplyQ_LeftForwardInternal {
                                            /* */ ValueType *A, const int as0, const int as1,
                                            /* */ ValueType *t, const int ts,
                                            /* */ ValueType *B, const int bs0, const int bs1,
-                                           /* */ ValueType *w) {
+                                           /* */ ValueType *w, const int ws) {
     typedef ValueType value_type;
 
     /// Given a matrix A that includes a series of householder vectors,
@@ -73,7 +73,7 @@ struct SerialApplyQ_LeftForwardInternal {
       /// -----------------------------------------------------
       // left apply householder to partitioned B1 and B2
       SerialApplyLeftHouseholderInternal::invoke(m_A2, n, tau, A_part3x3.A21, as0, B_part3x1.A1, bs1, B_part3x1.A2, bs0,
-                                                 bs1, w);
+                                                 bs1, w, ws);
 
       /// -----------------------------------------------------
       A_part2x2.mergeToABR(A_part3x3);
@@ -90,11 +90,11 @@ struct SerialApplyQ_LeftBackwardInternal {
                                            /* */ ValueType *A, const int as0, const int as1,
                                            /* */ ValueType *t, const int ts,
                                            /* */ ValueType *B, const int bs0, const int bs1,
-                                           /* */ ValueType *w) {
+                                           /* */ ValueType *w, const int ws) {
     typedef ValueType value_type;
 
     /// Given a matrix A that includes a series of householder vectors,
-    /// it applies a unitary matrix Q to B from left without transpose
+    /// it applies a unitary matrix Q to B from left with transpose
     ///   B = Q^H B = (H(k-1) H(k-2) ... H0) B
     /// where
     ///   A is m x k (holding H0, H1 ... H(k-1)
@@ -127,8 +127,7 @@ struct SerialApplyQ_LeftBackwardInternal {
       /// -----------------------------------------------------
       // left apply householder to partitioned B1 and B2
       SerialApplyLeftHouseholderInternal::invoke(m_A2, n, tau, A_part3x3.A21, as0, B_part3x1.A1, bs1, B_part3x1.A2, bs0,
-                                                 bs1, w);
-
+                                                 bs1, w, ws);
       /// -----------------------------------------------------
       A_part2x2.mergeToATL(A_part3x3);
       t_part2x1.mergeToAT(t_part3x1);
@@ -144,7 +143,7 @@ struct SerialApplyQ_RightForwardInternal {
                                            /* */ ValueType *A, const int as0, const int as1,
                                            /* */ ValueType *t, const int ts,
                                            /* */ ValueType *B, const int bs0, const int bs1,
-                                           /* */ ValueType *w) {
+                                           /* */ ValueType *w, const int ws) {
     typedef ValueType value_type;
 
     /// Given a matrix A that includes a series of householder vectors,
@@ -181,7 +180,7 @@ struct SerialApplyQ_RightForwardInternal {
       /// -----------------------------------------------------
       // right apply householder to partitioned B1 and B2
       SerialApplyRightHouseholderInternal::invoke(m, n_B2, tau, A_part3x3.A21, as0, B_part1x3.A1, bs0, B_part1x3.A2,
-                                                  bs0, bs1, w);
+                                                  bs0, bs1, w, ws);
       /// -----------------------------------------------------
       A_part2x2.mergeToATL(A_part3x3);
       t_part2x1.mergeToAT(t_part3x1);

--- a/batched/dense/impl/KokkosBatched_Householder_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Householder_Serial_Internal.hpp
@@ -46,7 +46,7 @@ struct SerialLeftHouseholderInternal {
     mag_type norm_x2_square(0);
     for (int i = 0; i < m_x2; ++i) {
       const auto x2_at_i = x2[i * x2s];
-      norm_x2_square += x2_at_i * x2_at_i;
+      norm_x2_square += Kokkos::abs(x2_at_i) * Kokkos::abs(x2_at_i);
     }
 
     /// if norm_x2 is zero, return with trivial values
@@ -64,7 +64,7 @@ struct SerialLeftHouseholderInternal {
     const mag_type norm_x = Kokkos::ArithTraits<mag_type>::sqrt(norm_x2_square + norm_chi1 * norm_chi1);
 
     /// compute alpha
-    const mag_type alpha = (*chi1 < 0 ? one : minus_one) * norm_x;
+    const mag_type alpha = (*chi1 < Kokkos::ArithTraits<value_type>::zero() ? one : minus_one) * norm_x;
 
     /// overwrite x2 with u2
     const value_type chi1_minus_alpha     = *chi1 - alpha;
@@ -75,7 +75,7 @@ struct SerialLeftHouseholderInternal {
     // SerialScaleInternal::invoke(m_x2, inv_chi1_minus_alpha, x2, x2s);
 
     /// compute tau
-    const mag_type chi1_minus_alpha_square = chi1_minus_alpha * chi1_minus_alpha;
+    const mag_type chi1_minus_alpha_square = Kokkos::abs(chi1_minus_alpha) * Kokkos::abs(chi1_minus_alpha);
     *tau                                   = half + half * (norm_x2_square / chi1_minus_alpha_square);
 
     /// overwrite chi1 with alpha

--- a/batched/dense/impl/KokkosBatched_QR_FormQ_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_QR_FormQ_Serial_Internal.hpp
@@ -37,8 +37,8 @@ struct SerialQR_FormQ_Internal {
                                            /* */ ValueType* A, const int as0, const int as1,
                                            /* */ ValueType* t, const int ts,
                                            /* */ ValueType* Q, const int qs0, const int qs1,
-                                           /* */ ValueType* w, const bool is_Q_zero = false) {
-    typedef ValueType value_type;
+                                           /* */ ValueType* w, const int ws, const bool is_Q_zero = false) {
+    using value_type = ValueType;
 
     /// Given a matrix A that includes QR factorization
     /// it forms a unitary matrix Q
@@ -49,12 +49,16 @@ struct SerialQR_FormQ_Internal {
     ///   B is m x m
 
     // set identity
-    if (is_Q_zero)
-      SerialSetInternal::invoke(m, value_type(1), Q, qs0 + qs1);
-    else
-      SerialSetIdentityInternal::invoke(m, Q, qs0, qs1);
+    if (is_Q_zero) {
+      for (int idx = 0; idx < m; ++idx) {
+        Q[(qs0 + qs1) * idx] = value_type(1);
+        // SerialSetInternal::invoke(m, value_type(1), Q, qs0 + qs1);
+      }
+    } else {
+      SerialSetIdentityInternal::invoke(m, m, Q, qs0, qs1);
+    }
 
-    return SerialApplyQ_LeftNoTransForwardInternal ::invoke(m, m, k, A, as0, as1, t, ts, Q, qs0, qs1, w);
+    return SerialApplyQ_LeftForwardInternal::invoke(m, m, k, A, as0, as1, t, ts, Q, qs0, qs1, w, ws);
   }
 };
 

--- a/batched/dense/impl/KokkosBatched_QR_FormQ_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_QR_FormQ_Serial_Internal.hpp
@@ -37,7 +37,7 @@ struct SerialQR_FormQ_Internal {
                                            /* */ ValueType* A, const int as0, const int as1,
                                            /* */ ValueType* t, const int ts,
                                            /* */ ValueType* Q, const int qs0, const int qs1,
-                                           /* */ ValueType* w, const int ws, const bool is_Q_zero = false) {
+                                           /* */ ValueType* w, const bool is_Q_zero = false) {
     using value_type = ValueType;
 
     /// Given a matrix A that includes QR factorization
@@ -58,7 +58,7 @@ struct SerialQR_FormQ_Internal {
       SerialSetIdentityInternal::invoke(m, m, Q, qs0, qs1);
     }
 
-    return SerialApplyQ_LeftForwardInternal::invoke(m, m, k, A, as0, as1, t, ts, Q, qs0, qs1, w, ws);
+    return SerialApplyQ_LeftForwardInternal::invoke(m, m, k, A, as0, as1, t, ts, Q, qs0, qs1, w);
   }
 };
 

--- a/batched/dense/impl/KokkosBatched_QR_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_QR_Serial_Impl.hpp
@@ -31,13 +31,13 @@ template <>
 template <typename AViewType, typename tViewType, typename wViewType>
 KOKKOS_INLINE_FUNCTION int SerialQR<Algo::QR::Unblocked>::invoke(const AViewType &A, const tViewType &t,
                                                                  const wViewType &w) {
-  static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::SerialQR::invoke: AViewType must be a Kokkos::View");
+  static_assert(Kokkos::is_view_v<AViewType>, "KokkosBatched::SerialQR::invoke: AViewType must be a Kokkos::View");
   static_assert(AViewType::rank() == 2, "KokkosBatched::SerialQR::invoke: AViewType must have rank 2");
 
-  static_assert(Kokkos::is_view<tViewType>::value, "KokkosBatched::SerialQR::invoke: tViewType must be a Kokkos::View");
+  static_assert(Kokkos::is_view_v<tViewType>, "KokkosBatched::SerialQR::invoke: tViewType must be a Kokkos::View");
   static_assert(tViewType::rank() == 1, "KokkosBatched::SerialQR::invoke: tViewType must have rank 1");
 
-  static_assert(Kokkos::is_view<wViewType>::value, "KokkosBatched::SerialQR::invoke: wViewType must be a Kokkos::View");
+  static_assert(Kokkos::is_view_v<wViewType>, "KokkosBatched::SerialQR::invoke: wViewType must be a Kokkos::View");
   static_assert(wViewType::rank() == 1, "KokkosBatched::SerialQR::invoke: wViewType must have rank 1");
 
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)

--- a/batched/dense/impl/KokkosBatched_QR_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_QR_Serial_Impl.hpp
@@ -58,8 +58,8 @@ KOKKOS_INLINE_FUNCTION int SerialQR<Algo::QR::Unblocked>::invoke(const AViewType
 #endif
 
 
-  return SerialQR_Internal::invoke(A.extent(0), A.extent(1), A.data(), A.stride_0(), A.stride_1(), t.data(),
-                                   t.stride_0(), w.data());
+  return Impl::SerialQR_Internal::invoke(A.extent(0), A.extent(1), A.data(), A.stride_0(), A.stride_1(), t.data(),
+					 t.stride_0(), w.data());
 }
 
 }  // namespace KokkosBatched

--- a/batched/dense/impl/KokkosBatched_QR_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_QR_Serial_Impl.hpp
@@ -31,35 +31,28 @@ template <>
 template <typename AViewType, typename tViewType, typename wViewType>
 KOKKOS_INLINE_FUNCTION int SerialQR<Algo::QR::Unblocked>::invoke(const AViewType &A, const tViewType &t,
                                                                  const wViewType &w) {
-  static_assert(Kokkos::is_view<AViewType>::value,
-		"KokkosBatched::SerialQR::invoke: AViewType must be a Kokkos::View");
-  static_assert(AViewType::rank() == 2,
-		"KokkosBatched::SerialQR::invoke: AViewType must have rank 2");
+  static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::SerialQR::invoke: AViewType must be a Kokkos::View");
+  static_assert(AViewType::rank() == 2, "KokkosBatched::SerialQR::invoke: AViewType must have rank 2");
 
-  static_assert(Kokkos::is_view<tViewType>::value,
-		"KokkosBatched::SerialQR::invoke: tViewType must be a Kokkos::View");
-  static_assert(tViewType::rank() == 1,
-		"KokkosBatched::SerialQR::invoke: tViewType must have rank 1");
+  static_assert(Kokkos::is_view<tViewType>::value, "KokkosBatched::SerialQR::invoke: tViewType must be a Kokkos::View");
+  static_assert(tViewType::rank() == 1, "KokkosBatched::SerialQR::invoke: tViewType must have rank 1");
 
-  static_assert(Kokkos::is_view<wViewType>::value,
-		"KokkosBatched::SerialQR::invoke: wViewType must be a Kokkos::View");
-  static_assert(wViewType::rank() == 1,
-		"KokkosBatched::SerialQR::invoke: wViewType must have rank 1");
+  static_assert(Kokkos::is_view<wViewType>::value, "KokkosBatched::SerialQR::invoke: wViewType must be a Kokkos::View");
+  static_assert(wViewType::rank() == 1, "KokkosBatched::SerialQR::invoke: wViewType must have rank 1");
 
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-  if(!w.span_is_contiguous()) {
+  if (!w.span_is_contiguous()) {
     Kokkos::printf("KokkosBatched::SerialQR::invoke: w must have a contiguous span.");
     return 1;
   }
-  if(A.extent_int(1) != t.extent_int(0)) {
+  if (A.extent_int(1) != t.extent_int(0)) {
     Kokkos::printf("KokkosBatched::SerialQR::invoke: A.extent(1) is different from t.extent(0).");
     return 1;
   }
 #endif
 
-
   return Impl::SerialQR_Internal::invoke(A.extent(0), A.extent(1), A.data(), A.stride_0(), A.stride_1(), t.data(),
-					 t.stride_0(), w.data());
+                                         t.stride_0(), w.data());
 }
 
 }  // namespace KokkosBatched

--- a/batched/dense/impl/KokkosBatched_QR_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_QR_Serial_Impl.hpp
@@ -32,7 +32,7 @@ template <typename AViewType, typename tViewType, typename wViewType>
 KOKKOS_INLINE_FUNCTION int SerialQR<Algo::QR::Unblocked>::invoke(const AViewType &A, const tViewType &t,
                                                                  const wViewType &w) {
   return SerialQR_Internal::invoke(A.extent(0), A.extent(1), A.data(), A.stride_0(), A.stride_1(), t.data(),
-                                   t.stride_0(), w.data(), w.stride_0());
+                                   t.stride_0(), w.data());
 }
 
 }  // namespace KokkosBatched

--- a/batched/dense/impl/KokkosBatched_QR_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_QR_Serial_Impl.hpp
@@ -31,6 +31,33 @@ template <>
 template <typename AViewType, typename tViewType, typename wViewType>
 KOKKOS_INLINE_FUNCTION int SerialQR<Algo::QR::Unblocked>::invoke(const AViewType &A, const tViewType &t,
                                                                  const wViewType &w) {
+  static_assert(Kokkos::is_view<AViewType>::value,
+		"KokkosBatched::SerialQR::invoke: AViewType must be a Kokkos::View");
+  static_assert(AViewType::rank() == 2,
+		"KokkosBatched::SerialQR::invoke: AViewType must have rank 2");
+
+  static_assert(Kokkos::is_view<tViewType>::value,
+		"KokkosBatched::SerialQR::invoke: tViewType must be a Kokkos::View");
+  static_assert(tViewType::rank() == 1,
+		"KokkosBatched::SerialQR::invoke: tViewType must have rank 1");
+
+  static_assert(Kokkos::is_view<wViewType>::value,
+		"KokkosBatched::SerialQR::invoke: wViewType must be a Kokkos::View");
+  static_assert(wViewType::rank() == 1,
+		"KokkosBatched::SerialQR::invoke: wViewType must have rank 1");
+
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+  if(!w.span_is_contiguous()) {
+    Kokkos::printf("KokkosBatched::SerialQR::invoke: w must have a contiguous span.");
+    return 1;
+  }
+  if(A.extent_int(1) != t.extent_int(0)) {
+    Kokkos::printf("KokkosBatched::SerialQR::invoke: A.extent(1) is different from t.extent(0).");
+    return 1;
+  }
+#endif
+
+
   return SerialQR_Internal::invoke(A.extent(0), A.extent(1), A.data(), A.stride_0(), A.stride_1(), t.data(),
                                    t.stride_0(), w.data());
 }

--- a/batched/dense/impl/KokkosBatched_QR_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_QR_Serial_Impl.hpp
@@ -32,7 +32,7 @@ template <typename AViewType, typename tViewType, typename wViewType>
 KOKKOS_INLINE_FUNCTION int SerialQR<Algo::QR::Unblocked>::invoke(const AViewType &A, const tViewType &t,
                                                                  const wViewType &w) {
   return SerialQR_Internal::invoke(A.extent(0), A.extent(1), A.data(), A.stride_0(), A.stride_1(), t.data(),
-                                   t.stride_0(), w.data());
+                                   t.stride_0(), w.data(), w.stride_0());
 }
 
 }  // namespace KokkosBatched

--- a/batched/dense/impl/KokkosBatched_QR_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_QR_Serial_Internal.hpp
@@ -24,6 +24,7 @@
 
 namespace KokkosBatched {
 
+namespace Impl {
 ///
 /// Serial Internal Impl
 /// ====================
@@ -77,6 +78,8 @@ struct SerialQR_Internal {
     return 0;
   }
 };
+
+}  // namespace Impl
 
 }  // end namespace KokkosBatched
 

--- a/batched/dense/impl/KokkosBatched_QR_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_QR_Serial_Internal.hpp
@@ -36,7 +36,7 @@ struct SerialQR_Internal {
                                            const int n,  // n = NumCols(A)
                                            /* */ ValueType *A, const int as0, const int as1,
                                            /* */ ValueType *t, const int ts,
-                                           /* */ ValueType *w) {
+                                           /* */ ValueType *w, const int ws) {
     typedef ValueType value_type;
 
     /// Given a matrix A, it computes QR decomposition of the matrix
@@ -53,7 +53,7 @@ struct SerialQR_Internal {
     A_part2x2.partWithATL(A, m, n, 0, 0);
     t_part2x1.partWithAT(t, m, 0);
 
-    for (int m_atl = 0; m_atl < m; ++m_atl) {
+    for (int m_atl = 0; m_atl < Kokkos::min(m, n); ++m_atl) {
       // part 2x2 into 3x3
       A_part3x3.partWithABR(A_part2x2, 1, 1);
       const int m_A22 = m - m_atl - 1;
@@ -69,7 +69,7 @@ struct SerialQR_Internal {
 
       // left apply householder to A22
       SerialApplyLeftHouseholderInternal::invoke(m_A22, n_A22, tau, A_part3x3.A21, as0, A_part3x3.A12, as1,
-                                                 A_part3x3.A22, as0, as1, w);
+                                                 A_part3x3.A22, as0, as1, w, ws);
       /// -----------------------------------------------------
       A_part2x2.mergeToATL(A_part3x3);
       t_part2x1.mergeToAT(t_part3x1);

--- a/batched/dense/impl/KokkosBatched_QR_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_QR_Serial_Internal.hpp
@@ -36,8 +36,8 @@ struct SerialQR_Internal {
                                            const int n,  // n = NumCols(A)
                                            /* */ ValueType *A, const int as0, const int as1,
                                            /* */ ValueType *t, const int ts,
-                                           /* */ ValueType *w, const int ws) {
-    typedef ValueType value_type;
+                                           /* */ ValueType *w) {
+    using value_type = ValueType;
 
     /// Given a matrix A, it computes QR decomposition of the matrix
     ///  - t is to store tau and w is for workspace
@@ -69,7 +69,7 @@ struct SerialQR_Internal {
 
       // left apply householder to A22
       SerialApplyLeftHouseholderInternal::invoke(m_A22, n_A22, tau, A_part3x3.A21, as0, A_part3x3.A12, as1,
-                                                 A_part3x3.A22, as0, as1, w, ws);
+                                                 A_part3x3.A22, as0, as1, w);
       /// -----------------------------------------------------
       A_part2x2.mergeToATL(A_part3x3);
       t_part2x1.mergeToAT(t_part3x1);

--- a/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
@@ -179,9 +179,8 @@ struct SerialSVDInternal {
             As0, As1, work);
       }
       if (U) {
-        KokkosBatched::SerialApplyRightHouseholderInternal::invoke<value_type>(m, m - i - 1, &tau, &SVDIND(A, i + 1, i),
-                                                                               As0, &SVDIND(U, 0, i), Us0,
-                                                                               &SVDIND(U, 0, i + 1), Us0, Us1, work);
+        KokkosBatched::SerialApplyRightHouseholderInternal::invoke<value_type>(
+            m, m - i - 1, &tau, &SVDIND(A, i + 1, i), As0, &SVDIND(U, 0, i), Us0, &SVDIND(U, 0, i + 1), Us0, Us1, work);
       }
       // Zero out A subdiag explicitly (NOTE: may not be necessary...)
       for (int j = i + 1; j < m; j++) {

--- a/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
@@ -176,11 +176,12 @@ struct SerialSVDInternal {
       if (n - i > 1) {
         KokkosBatched::SerialApplyLeftHouseholderInternal::invoke<value_type>(
             m - i - 1, n - i - 1, &tau, &SVDIND(A, i + 1, i), As0, &SVDIND(A, i, i + 1), As1, &SVDIND(A, i + 1, i + 1),
-            As0, As1, work);
+            As0, As1, work, 1);
       }
       if (U) {
-        KokkosBatched::SerialApplyRightHouseholderInternal::invoke<value_type>(
-            m, m - i - 1, &tau, &SVDIND(A, i + 1, i), As0, &SVDIND(U, 0, i), Us0, &SVDIND(U, 0, i + 1), Us0, Us1, work);
+        KokkosBatched::SerialApplyRightHouseholderInternal::invoke<value_type>(m, m - i - 1, &tau, &SVDIND(A, i + 1, i),
+                                                                               As0, &SVDIND(U, 0, i), Us0,
+                                                                               &SVDIND(U, 0, i + 1), Us0, Us1, work, 1);
       }
       // Zero out A subdiag explicitly (NOTE: may not be necessary...)
       for (int j = i + 1; j < m; j++) {
@@ -193,12 +194,12 @@ struct SerialSVDInternal {
         if (m - i > 1) {
           KokkosBatched::SerialApplyRightHouseholderInternal::invoke<value_type>(
               m - i - 1, n - i - 2, &tau, &SVDIND(A, i, i + 2), As1, &SVDIND(A, i + 1, i + 1), As0,
-              &SVDIND(A, i + 1, i + 2), As0, As1, work);
+              &SVDIND(A, i + 1, i + 2), As0, As1, work, 1);
         }
         if (Vt) {
           KokkosBatched::SerialApplyLeftHouseholderInternal::invoke<value_type>(
               n - i - 2, n, &tau, &SVDIND(A, i, i + 2), As1, &SVDIND(Vt, i + 1, 0), Vts1, &SVDIND(Vt, i + 2, 0), Vts0,
-              Vts1, work);
+              Vts1, work, 1);
         }
         // Zero out A superdiag row explicitly
         for (int j = i + 2; j < n; j++) {

--- a/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
@@ -176,12 +176,12 @@ struct SerialSVDInternal {
       if (n - i > 1) {
         KokkosBatched::SerialApplyLeftHouseholderInternal::invoke<value_type>(
             m - i - 1, n - i - 1, &tau, &SVDIND(A, i + 1, i), As0, &SVDIND(A, i, i + 1), As1, &SVDIND(A, i + 1, i + 1),
-            As0, As1, work, 1);
+            As0, As1, work);
       }
       if (U) {
         KokkosBatched::SerialApplyRightHouseholderInternal::invoke<value_type>(m, m - i - 1, &tau, &SVDIND(A, i + 1, i),
                                                                                As0, &SVDIND(U, 0, i), Us0,
-                                                                               &SVDIND(U, 0, i + 1), Us0, Us1, work, 1);
+                                                                               &SVDIND(U, 0, i + 1), Us0, Us1, work);
       }
       // Zero out A subdiag explicitly (NOTE: may not be necessary...)
       for (int j = i + 1; j < m; j++) {
@@ -194,12 +194,12 @@ struct SerialSVDInternal {
         if (m - i > 1) {
           KokkosBatched::SerialApplyRightHouseholderInternal::invoke<value_type>(
               m - i - 1, n - i - 2, &tau, &SVDIND(A, i, i + 2), As1, &SVDIND(A, i + 1, i + 1), As0,
-              &SVDIND(A, i + 1, i + 2), As0, As1, work, 1);
+              &SVDIND(A, i + 1, i + 2), As0, As1, work);
         }
         if (Vt) {
           KokkosBatched::SerialApplyLeftHouseholderInternal::invoke<value_type>(
               n - i - 2, n, &tau, &SVDIND(A, i, i + 2), As1, &SVDIND(Vt, i + 1, 0), Vts1, &SVDIND(Vt, i + 2, 0), Vts0,
-              Vts1, work, 1);
+              Vts1, work);
         }
         // Zero out A superdiag row explicitly
         for (int j = i + 2; j < n; j++) {

--- a/batched/dense/src/KokkosBatched_ApplyQ_Decl.hpp
+++ b/batched/dense/src/KokkosBatched_ApplyQ_Decl.hpp
@@ -28,6 +28,11 @@ namespace KokkosBatched {
 
 template <typename ArgSide, typename ArgTrans, typename ArgAlgo>
 struct SerialApplyQ {
+  static_assert(is_side_v<ArgSide>, "KokkosBatched::SerialApplyQ: ArgSide must be a KokkosBatched::Side.");
+  static_assert(KokkosBlas::is_trans_v<ArgTrans>, "KokkosBatched::SerialApplyQ: ArgTrans must be a KokkosBlas::Trans.");
+  static_assert(KokkosBlas::is_level2_v<ArgAlgo>,
+                "KokkosBatched::SerialApplyQ: ArgAlgo must be a KokkosBlas::Algo::Level2.");
+
   template <typename AViewType, typename tViewType, typename BViewType, typename wViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const tViewType &t, const BViewType &B,
                                            const wViewType &w);
@@ -39,6 +44,11 @@ struct SerialApplyQ {
 
 template <typename MemberType, typename ArgSide, typename ArgTrans, typename ArgAlgo>
 struct TeamApplyQ {
+  static_assert(is_side_v<ArgSide>, "KokkosBatched::SerialApplyQ: ArgSide must be a KokkosBatched::Side.");
+  static_assert(KokkosBlas::is_trans_v<ArgTrans>, "KokkosBatched::SerialApplyQ: ArgTrans must be a KokkosBlas::Trans.");
+  static_assert(KokkosBlas::is_level2_v<ArgAlgo>,
+                "KokkosBatched::SerialApplyQ: ArgAlgo must be a KokkosBlas::Algo::Level2.");
+
   template <typename AViewType, typename tViewType, typename BViewType, typename wViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const tViewType &t,
                                            const BViewType &B, const wViewType &w);
@@ -50,6 +60,11 @@ struct TeamApplyQ {
 
 template <typename MemberType, typename ArgSide, typename ArgTrans, typename ArgAlgo>
 struct TeamVectorApplyQ {
+  static_assert(is_side_v<ArgSide>, "KokkosBatched::SerialApplyQ: ArgSide must be a KokkosBatched::Side.");
+  static_assert(KokkosBlas::is_trans_v<ArgTrans>, "KokkosBatched::SerialApplyQ: ArgTrans must be a KokkosBlas::Trans.");
+  static_assert(KokkosBlas::is_level2_v<ArgAlgo>,
+                "KokkosBatched::SerialApplyQ: ArgAlgo must be a KokkosBlas::Algo::Level2.");
+
   template <typename AViewType, typename tViewType, typename BViewType, typename wViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const tViewType &t,
                                            const BViewType &B, const wViewType &w);
@@ -60,6 +75,11 @@ struct TeamVectorApplyQ {
 ///
 template <typename MemberType, typename ArgSide, typename ArgTrans, typename ArgMode, typename ArgAlgo>
 struct ApplyQ {
+  static_assert(is_side_v<ArgSide>, "KokkosBatched::ApplyQ: ArgSide must be a KokkosBatched::Side.");
+  static_assert(KokkosBlas::is_trans_v<ArgTrans>, "KokkosBatched::ApplyQ: ArgTrans must be a KokkosBlas::Trans.");
+  static_assert(KokkosBlas::is_mode_v<ArgMode>, "KokkosBatched::ApplyQ: ArgMode must be a KokkosBlas::Mode.");
+  static_assert(KokkosBlas::is_level2_v<ArgAlgo>, "KokkosBatched::ApplyQ: ArgAlgo must be a KokkosBlas::Algo::Level2.");
+
   template <typename AViewType, typename tViewType, typename BViewType, typename wViewType>
   KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const tViewType &t,
                                                 const BViewType &B, const wViewType &w) {

--- a/batched/dense/src/KokkosBatched_ApplyQ_Decl.hpp
+++ b/batched/dense/src/KokkosBatched_ApplyQ_Decl.hpp
@@ -64,11 +64,11 @@ struct ApplyQ {
   KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const tViewType &t,
                                                 const BViewType &B, const wViewType &w) {
     int r_val = 0;
-    if (std::is_same<ArgMode, Mode::Serial>::value) {
+    if constexpr (std::is_same_v<ArgMode, Mode::Serial>) {
       r_val = SerialApplyQ<ArgSide, ArgTrans, ArgAlgo>::invoke(A, t, B, w);
-    } else if (std::is_same<ArgMode, Mode::Team>::value) {
+    } else if constexpr (std::is_same_v<ArgMode, Mode::Team>) {
       r_val = TeamApplyQ<MemberType, ArgSide, ArgTrans, ArgAlgo>::invoke(member, A, t, B, w);
-    } else if (std::is_same<ArgMode, Mode::Team>::value) {
+    } else if constexpr (std::is_same_v<ArgMode, Mode::TeamVector>) {
       r_val = TeamVectorApplyQ<MemberType, ArgSide, ArgTrans, ArgAlgo>::invoke(member, A, t, B, w);
     }
     return r_val;

--- a/batched/dense/src/KokkosBatched_QR_Decl.hpp
+++ b/batched/dense/src/KokkosBatched_QR_Decl.hpp
@@ -66,11 +66,11 @@ struct QR {
   KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const tViewType &t,
                                                 const wViewType &w) {
     int r_val = 0;
-    if (std::is_same<ArgMode, Mode::Serial>::value) {
+    if constexpr (std::is_same_v<ArgMode, Mode::Serial>) {
       r_val = SerialQR<ArgAlgo>::invoke(A, t, w);
-    } else if (std::is_same<ArgMode, Mode::Team>::value) {
+    } else if constexpr (std::is_same_v<ArgMode, Mode::Team>) {
       r_val = TeamQR<MemberType, ArgAlgo>::invoke(member, A, t, w);
-    } else if (std::is_same<ArgMode, Mode::TeamVector>::value) {
+    } else if constexpr (std::is_same_v<ArgMode, Mode::TeamVector>) {
       r_val = TeamVectorQR<MemberType, ArgAlgo>::invoke(member, A, t, w);
     }
     return r_val;

--- a/batched/dense/unit_test/Test_Batched_Dense.hpp
+++ b/batched/dense/unit_test/Test_Batched_Dense.hpp
@@ -30,6 +30,7 @@
 #include "Test_Batched_SerialLU.hpp"
 #include "Test_Batched_SerialLU_Real.hpp"
 #include "Test_Batched_SerialLU_Complex.hpp"
+#include "Test_Batched_SerialQR.hpp"
 #include "Test_Batched_SerialSolveLU.hpp"
 #include "Test_Batched_SerialSolveLU_Real.hpp"
 #include "Test_Batched_SerialSolveLU_Complex.hpp"

--- a/batched/dense/unit_test/Test_Batched_SerialQR.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialQR.hpp
@@ -117,7 +117,7 @@ struct qrFunctor {
     // Store identity in Q
     for (int rowIdx = 0; rowIdx < Q.extent_int(0); ++rowIdx) {
       for (int colIdx = 0; colIdx < Q.extent_int(1); ++colIdx) {
-	Q(rowIdx, colIdx)  = (rowIdx == colIdx) ? SC_one : Kokkos::ArithTraits<Scalar>::zero();
+	Q(rowIdx, colIdx) = (rowIdx == colIdx) ? SC_one : Kokkos::ArithTraits<Scalar>::zero();
       }
     }
 

--- a/batched/dense/unit_test/Test_Batched_SerialQR.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialQR.hpp
@@ -117,7 +117,7 @@ struct qrFunctor {
     // Store identity in Q
     for (int rowIdx = 0; rowIdx < Q.extent_int(0); ++rowIdx) {
       for (int colIdx = 0; colIdx < Q.extent_int(1); ++colIdx) {
-	Q(rowIdx, colIdx) = (rowIdx == colIdx) ? SC_one : Kokkos::ArithTraits<Scalar>::zero();
+        Q(rowIdx, colIdx) = (rowIdx == colIdx) ? SC_one : Kokkos::ArithTraits<Scalar>::zero();
       }
     }
 

--- a/batched/dense/unit_test/Test_Batched_SerialQR.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialQR.hpp
@@ -1,0 +1,511 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+/// \author Luc Berger-Vergiat (lberg@sandia.gov)
+/// \author Cameron Smith (smithc11@rpi.edu)
+
+#include "gtest/gtest.h"
+#include <random>
+
+#include <KokkosBatched_QR_Decl.hpp>      // KokkosBatched::QR
+#include "KokkosBatched_ApplyQ_Decl.hpp"  // KokkosBatched::ApplyQ
+#include "KokkosBatched_QR_FormQ_Serial_Internal.hpp"
+#include <KokkosBatched_Util.hpp>  // KokkosBlas::Algo
+#include "KokkosBatched_Gemm_Decl.hpp"
+#include <Kokkos_Core.hpp>
+
+template <class MatricesType, class TauViewType, class TmpViewType, class ErrorViewType>
+struct qrFunctor {
+  using Scalar = typename MatricesType::value_type;
+
+  MatricesType As;
+  TauViewType taus;
+  TmpViewType ws;
+  MatricesType Qs, Qts, Is, Bs;
+  ErrorViewType error;
+
+  Scalar max_val;
+
+  qrFunctor(MatricesType As_, TauViewType taus_, TmpViewType ws_, MatricesType Qs_, MatricesType Qts_,
+            MatricesType Is_, MatricesType Bs_, ErrorViewType error_, Scalar max_val_)
+    : As(As_), taus(taus_), ws(ws_), Qs(Qs_), Qts(Qts_), Is(Is_), Bs(Bs_), error(error_), max_val(max_val_) {}
+
+  KOKKOS_FUNCTION
+  void operator()(const int matIdx) const {
+
+    const int max_rows_cols = Kokkos::max(As.extent_int(1), As.extent_int(2));
+
+    auto A   = Kokkos::subview(As, matIdx, Kokkos::ALL, Kokkos::ALL);
+    auto tau = Kokkos::subview(taus, matIdx, Kokkos::ALL);
+    auto w   = Kokkos::subview(ws, Kokkos::pair<int, int>(matIdx * max_rows_cols, (matIdx + 1) * max_rows_cols));
+    auto Q   = Kokkos::subview(Qs, matIdx, Kokkos::ALL, Kokkos::ALL);
+    auto Qt  = Kokkos::subview(Qts, matIdx, Kokkos::ALL, Kokkos::ALL);
+    auto I   = Kokkos::subview(Is, matIdx, Kokkos::ALL, Kokkos::ALL);
+    auto B   = Kokkos::subview(Bs, matIdx, Kokkos::ALL, Kokkos::ALL);
+
+    const Scalar SC_one = Kokkos::ArithTraits<Scalar>::one();
+    const Scalar tol    = Kokkos::ArithTraits<Scalar>::eps() * max_rows_cols * max_rows_cols * max_val;
+
+    int error_lcl = 0;
+
+    for (int idx = 0; idx < w.extent_int(0); ++idx) { w(idx) = 0.0; }
+    KokkosBatched::SerialQR<KokkosBlas::Algo::QR::Unblocked>::invoke(A, tau, w);
+
+    // Store identity in Q and Qt
+    for (int diagIdx = 0; diagIdx < Q.extent_int(0); ++diagIdx) {
+      Q(diagIdx, diagIdx)  = SC_one;
+      Qt(diagIdx, diagIdx) = SC_one;
+    }
+
+    // Call ApplyQ on Q
+    for (int idx = 0; idx < w.extent_int(0); ++idx) { w(idx) = 0.0; }
+    KokkosBatched::SerialApplyQ<Side::Left, Trans::NoTranspose, Algo::ApplyQ::Unblocked>::invoke(A, tau, Q, w);
+
+    // Copy Q into I
+    for(int rowIdx = 0; rowIdx < Q.extent_int(0); ++rowIdx) {
+      for(int colIdx = 0; colIdx < Q.extent_int(1); ++colIdx) {
+	I(rowIdx, colIdx) = Q(rowIdx, colIdx);
+      }
+    }
+
+    // Call ApplyQ with transpose mode on Qt
+    for (int idx = 0; idx < w.extent_int(0); ++idx) { w(idx) = 0.0; }
+    KokkosBatched::SerialApplyQ<Side::Left, Trans::Transpose, Algo::ApplyQ::Unblocked>::invoke(A, tau, Qt, w);
+
+    // Call ApplyQ with transpose mode on I
+    for (int idx = 0; idx < w.extent_int(0); ++idx) { w(idx) = 0.0; }
+    KokkosBatched::SerialApplyQ<Side::Left, Trans::Transpose, Algo::ApplyQ::Unblocked>::invoke(A, tau, I, w);
+
+    // At this point I stores Q'Q
+    // which should be the identity matrix
+    for (int rowIdx = 0; rowIdx < I.extent_int(0); ++rowIdx) {
+      for (int colIdx = 0; colIdx < I.extent_int(1); ++colIdx) {
+	if (Kokkos::abs(Q(rowIdx, colIdx) - Qt(colIdx, rowIdx)) > tol) { ++error_lcl; }
+        if (rowIdx == colIdx) {
+          if (Kokkos::abs(I(rowIdx, colIdx) - SC_one) > tol) {
+            error_lcl += 1;
+            // Kokkos::printf("matIdx=%d, Q(%d, %d)=%e instead of 1.0.\n", matIdx, rowIdx, colIdx, I(rowIdx, colIdx));
+          }
+        } else {
+          if (Kokkos::abs(I(rowIdx, colIdx)) > tol) {
+            error_lcl += 1;
+            // Kokkos::printf("matIdx=%d, Q(%d, %d)=%e instead of 0.0.\n", matIdx, rowIdx, colIdx, I(rowIdx, colIdx));
+          }
+        }
+      }
+    }
+
+    // Apply Q' to B which holds a copy of the orginal A
+    // Afterwards B should hold a copy of R and be zero below its diagonal
+    for (int idx = 0; idx < w.extent_int(0); ++idx) { w(idx) = 0.0; }
+    KokkosBatched::SerialApplyQ<Side::Left, Trans::Transpose, Algo::ApplyQ::Unblocked>::invoke(A, tau, B, w);
+    for (int rowIdx = 0; rowIdx < B.extent_int(0); ++rowIdx) {
+      for (int colIdx = 0; colIdx < B.extent_int(1); ++colIdx) {
+        if (rowIdx <= colIdx) {
+          if (Kokkos::abs(B(rowIdx, colIdx) - A(rowIdx, colIdx)) > tol * Kokkos::abs(A(rowIdx, colIdx))) {
+            error_lcl += 1;
+            // Kokkos::printf("B stores R\nmatIdx=%d, B(%d, %d)=%e instead of %e.\n", matIdx, rowIdx, colIdx,
+            //                B(rowIdx, colIdx), A(rowIdx, colIdx));
+          }
+        } else {
+          if (Kokkos::abs(B(rowIdx, colIdx)) > tol) {
+            error_lcl += 1;
+            // Kokkos::printf("B stores R\nmatIdx=%d, B(%d, %d)=%e instead of 0.0.\n", matIdx, rowIdx, colIdx,
+            //                B(rowIdx, colIdx));
+          }
+        }
+      }
+    }
+    error(matIdx) = error_lcl;
+  }
+};
+
+template <class Device, class Scalar, class AlgoTagType>
+void test_QR_square() {
+  // Analytical test with a rectangular matrix
+  //     [12, -51,   4]              [150, -69,  58]        [14,  21, -14]
+  // A = [ 6, 167, -68]    Q = 1/175 [ 75, 158,  -6]    R = [ 0, 175, -70]
+  //     [-4,  24, -41]              [-50,  30, 165]        [ 0,   0, -35]
+  //
+  // Expected outputs:
+  //                         [ -5,  -3]
+  // tau = [5/8, 10/18]  A = [1/2,   5]
+  //                         [  0, 1/3]
+  //
+
+  using MatrixViewType    = Kokkos::View<Scalar**>;
+  using ColVectorViewType = Kokkos::View<Scalar*>;
+  using ColWorkViewType   = Kokkos::View<Scalar*>;
+
+  const Scalar tol = 20 * Kokkos::ArithTraits<Scalar>::eps();
+  constexpr int m = 3, n = 3;
+
+  MatrixViewType A("A", m, n), B("B", m, n), Q("Q", m, m);
+  ColVectorViewType t("t", n);
+  ColWorkViewType w("w", n);
+
+  typename MatrixViewType::HostMirror A_h = Kokkos::create_mirror_view(A);
+  A_h(0, 0)                               = 12;
+  A_h(0, 1)                               = -51;
+  A_h(0, 2)                               = 4;
+  A_h(1, 0)                               = 6;
+  A_h(1, 1)                               = 167;
+  A_h(1, 2)                               = -68;
+  A_h(2, 0)                               = -4;
+  A_h(2, 1)                               = 24;
+  A_h(2, 2)                               = -41;
+
+  Kokkos::deep_copy(A, A_h);
+  Kokkos::deep_copy(B, A_h);
+
+  Kokkos::parallel_for(
+      "serialQR", 1, KOKKOS_LAMBDA(int) {
+        // compute the QR factorization of A and store the results in A and t
+        // (tau) - see the lapack dgeqp3(...) documentation:
+        // www.netlib.org/lapack/explore-html-3.6.1/dd/d9a/group__double_g_ecomputational_ga1b0500f49e03d2771b797c6e88adabbb.html
+        KokkosBatched::SerialQR<AlgoTagType>::invoke(A, t, w);
+      });
+
+  Kokkos::fence();
+  Kokkos::deep_copy(A_h, A);
+  typename ColVectorViewType::HostMirror tau = Kokkos::create_mirror_view(t);
+  Kokkos::deep_copy(tau, t);
+
+  Test::EXPECT_NEAR_KK_REL(A_h(0, 0), static_cast<Scalar>(-14), tol);
+  Test::EXPECT_NEAR_KK_REL(A_h(0, 1), static_cast<Scalar>(-21), tol);
+  Test::EXPECT_NEAR_KK_REL(A_h(0, 2), static_cast<Scalar>(14), tol);
+  Test::EXPECT_NEAR_KK_REL(A_h(1, 0), static_cast<Scalar>(6. / 26.), tol);
+  Test::EXPECT_NEAR_KK_REL(A_h(1, 1), static_cast<Scalar>(-175), tol);
+  Test::EXPECT_NEAR_KK_REL(A_h(1, 2), static_cast<Scalar>(70), tol);
+  Test::EXPECT_NEAR_KK_REL(A_h(2, 0), static_cast<Scalar>(-4.0 / 26.0), tol);
+  // Test::EXPECT_NEAR_KK_REL(A_h(2, 1),   35.0, tol);      // Analytical expression too painful to compute...
+  Test::EXPECT_NEAR_KK_REL(A_h(2, 2), static_cast<Scalar>(35), tol);
+
+  Test::EXPECT_NEAR_KK_REL(tau(0), static_cast<Scalar>(7. / 13.), tol);
+  // Test::EXPECT_NEAR_KK_REL(tau(1), 25. / 32., tol);      // Analytical expression too painful to compute...
+  Test::EXPECT_NEAR_KK_REL(tau(2), static_cast<Scalar>(1. / 2.), tol);
+
+  Kokkos::parallel_for(
+      "serialApplyQ", 1, KOKKOS_LAMBDA(int) {
+        KokkosBatched::SerialApplyQ<Side::Left, Trans::Transpose, Algo::ApplyQ::Unblocked>::invoke(A, t, B, w);
+      });
+  typename MatrixViewType::HostMirror B_h = Kokkos::create_mirror_view(B);
+  Kokkos::deep_copy(B_h, B);
+
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-14), B_h(0, 0), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-21), B_h(0, 1), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(14), B_h(0, 2), tol);
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0), B_h(1, 0), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-175), B_h(1, 1), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(70), B_h(1, 2), tol);
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0), B_h(2, 0), tol);
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0), B_h(2, 1), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(35), B_h(2, 2), tol);
+
+  Kokkos::parallel_for(
+      "serialFormQ", 1, KOKKOS_LAMBDA(int) {
+        KokkosBatched::SerialQR_FormQ_Internal::invoke(m, n, A.data(), A.stride(0), A.stride(1), t.data(), t.stride(0),
+                                                       Q.data(), Q.stride(0), Q.stride(1), w.data(), w.stride(0));
+      });
+  typename MatrixViewType::HostMirror Q_h = Kokkos::create_mirror_view(Q);
+  Kokkos::deep_copy(Q_h, Q);
+
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-6. / 7.), Q_h(0, 0), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(69. / 175.), Q_h(0, 1), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-58. / 175.), Q_h(0, 2), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-3. / 7.), Q_h(1, 0), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-158. / 175.), Q_h(1, 1), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(6. / 175.), Q_h(1, 2), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(2. / 7.), Q_h(2, 0), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-6. / 35.), Q_h(2, 1), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-33. / 35.), Q_h(2, 2), tol);
+
+  Kokkos::parallel_for(
+      "serialApplyQ", 1, KOKKOS_LAMBDA(int) {
+        KokkosBatched::SerialApplyQ<Side::Left, Trans::Transpose, Algo::ApplyQ::Unblocked>::invoke(A, t, Q, w);
+      });
+  Kokkos::deep_copy(Q_h, Q);
+
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.), Q_h(0, 0), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.), Q_h(1, 1), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.), Q_h(2, 2), tol);
+
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 1), tol);
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 2), tol);
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(1, 0), tol);
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(1, 2), tol);
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 0), tol);
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 1), tol);
+}
+
+template <class Device, class Scalar, class AlgoTagType>
+void test_QR_rectangular() {
+  // Analytical test with a rectangular matrix
+  //     [3,  5]        [-0.60, -0.64,  0.48]        [-5, -3]
+  // A = [4,  0]    Q = [-0.80, -0.48, -0.36]    R = [ 0,  5]
+  //     [0, -3]        [ 0.00, -0.60, -0.80]        [ 0,  0]
+  //
+  // Expected outputs:
+  //                         [ -5,  -3]
+  // tau = [5/8, 10/18]  A = [1/2,   5]
+  //                         [  0, 1/3]
+  //
+
+  using MatrixViewType    = Kokkos::View<Scalar**>;
+  using ColVectorViewType = Kokkos::View<Scalar*>;
+  using ColWorkViewType   = Kokkos::View<Scalar*>;
+
+  const Scalar tol = 10 * Kokkos::ArithTraits<Scalar>::eps();
+  constexpr int m = 3, n = 2;
+
+  MatrixViewType A("A", m, n), B("B", m, n), Q("Q", m, m);
+  ColVectorViewType t("t", n);
+  ColWorkViewType w("w", Kokkos::max(m, n));
+
+  typename MatrixViewType::HostMirror A_h = Kokkos::create_mirror_view(A);
+  A_h(0, 0)                               = 3;
+  A_h(0, 1)                               = 5;
+  A_h(1, 0)                               = 4;
+  A_h(1, 1)                               = 0;
+  A_h(2, 0)                               = 0;
+  A_h(2, 1)                               = -3;
+
+  Kokkos::deep_copy(A, A_h);
+  Kokkos::deep_copy(B, A_h);
+
+  Kokkos::parallel_for(
+      "serialQR", 1, KOKKOS_LAMBDA(int) {
+        // compute the QR factorization of A and store the results in A and t
+        // (tau) - see the lapack dgeqp3(...) documentation:
+        // www.netlib.org/lapack/explore-html-3.6.1/dd/d9a/group__double_g_ecomputational_ga1b0500f49e03d2771b797c6e88adabbb.html
+        KokkosBatched::SerialQR<AlgoTagType>::invoke(A, t, w);
+      });
+
+  Kokkos::fence();
+  Kokkos::deep_copy(A_h, A);
+  typename ColVectorViewType::HostMirror tau = Kokkos::create_mirror_view(t);
+  Kokkos::deep_copy(tau, t);
+
+  Test::EXPECT_NEAR_KK_REL(A_h(0, 0), static_cast<Scalar>(-5.0), tol);
+  Test::EXPECT_NEAR_KK_REL(A_h(0, 1), static_cast<Scalar>(-3.0), tol);
+  Test::EXPECT_NEAR_KK_REL(A_h(1, 0), static_cast<Scalar>(0.5), tol);
+  Test::EXPECT_NEAR_KK_REL(A_h(1, 1), static_cast<Scalar>(5.0), tol);
+  Test::EXPECT_NEAR_KK(A_h(2, 0), static_cast<Scalar>(0.), tol);
+  Test::EXPECT_NEAR_KK_REL(A_h(2, 1), static_cast<Scalar>(1. / 3.), tol);
+
+  Test::EXPECT_NEAR_KK_REL(tau(0), static_cast<Scalar>(5. / 8.), tol);
+  Test::EXPECT_NEAR_KK_REL(tau(1), static_cast<Scalar>(10. / 18.), tol);
+
+  Kokkos::parallel_for(
+      "serialApplyQ", 1, KOKKOS_LAMBDA(int) {
+        KokkosBatched::SerialApplyQ<Side::Left, Trans::Transpose, Algo::ApplyQ::Unblocked>::invoke(A, t, B, w);
+      });
+  typename MatrixViewType::HostMirror B_h = Kokkos::create_mirror_view(B);
+  Kokkos::deep_copy(B_h, B);
+
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-5.0), B_h(0, 0), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-3.0), B_h(0, 1), tol);
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), B_h(1, 0), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(5.0), B_h(1, 1), tol);
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), B_h(2, 0), tol);
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), B_h(2, 1), tol);
+
+  Kokkos::parallel_for(
+      "serialFormQ", 1, KOKKOS_LAMBDA(int) {
+        KokkosBatched::SerialQR_FormQ_Internal::invoke(m, n, A.data(), A.stride(0), A.stride(1), t.data(), t.stride(0),
+                                                       Q.data(), Q.stride(0), Q.stride(1), w.data(), w.stride(0));
+      });
+  typename MatrixViewType::HostMirror Q_h = Kokkos::create_mirror_view(Q);
+  Kokkos::deep_copy(Q_h, Q);
+
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(0, 0), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.64), Q_h(0, 1), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.48), Q_h(0, 2), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.80), Q_h(1, 0), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.48), Q_h(1, 1), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.36), Q_h(1, 2), tol);
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 0), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(2, 1), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.80), Q_h(2, 2), tol);
+
+  Kokkos::deep_copy(Q_h, 0.0);
+  Q_h(0, 0) = 1.0;
+  Q_h(1, 1) = 1.0;
+  Q_h(2, 2) = 1.0;
+  Kokkos::deep_copy(Q, Q_h);
+  Kokkos::deep_copy(w, 0.0);
+  Kokkos::parallel_for(
+      "serialApplyQ", 1, KOKKOS_LAMBDA(int) {
+        KokkosBatched::SerialApplyQ<Side::Left, Trans::Transpose, Algo::ApplyQ::Unblocked>::invoke(A, t, Q, w);
+      });
+  Kokkos::deep_copy(Q_h, Q);
+
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(0, 0), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.64), Q_h(1, 0), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.48), Q_h(2, 0), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.80), Q_h(0, 1), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.48), Q_h(1, 1), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.36), Q_h(2, 1), tol);
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 2), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(1, 2), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.80), Q_h(2, 2), tol);
+
+  Kokkos::deep_copy(Q_h, 0.0);
+  Q_h(0, 0) = 1.0;
+  Q_h(1, 1) = 1.0;
+  Q_h(2, 2) = 1.0;
+  Kokkos::deep_copy(Q, Q_h);
+  Kokkos::deep_copy(w, 0.0);
+  Kokkos::parallel_for(
+      "serialApplyQ", 1, KOKKOS_LAMBDA(int) {
+        KokkosBatched::SerialApplyQ<Side::Left, Trans::NoTranspose, Algo::ApplyQ::Unblocked>::invoke(A, t, Q, w);
+      });
+  Kokkos::deep_copy(Q_h, Q);
+
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(0, 0), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.64), Q_h(0, 1), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.48), Q_h(0, 2), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.80), Q_h(1, 0), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.48), Q_h(1, 1), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.36), Q_h(1, 2), tol);
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 0), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(2, 1), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.80), Q_h(2, 2), tol);
+
+  Kokkos::parallel_for(
+      "serialApplyQ", 1, KOKKOS_LAMBDA(int) {
+        KokkosBatched::SerialApplyQ<Side::Left, Trans::Transpose, Algo::ApplyQ::Unblocked>::invoke(A, t, Q, w);
+      });
+  Kokkos::deep_copy(Q_h, Q);
+
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.0), Q_h(0, 0), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.0), Q_h(1, 1), tol);
+  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.0), Q_h(2, 2), tol);
+
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 1), tol);
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 2), tol);
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(1, 0), tol);
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(1, 2), tol);
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 0), tol);
+  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 1), tol);
+}
+
+template <class Device, class Scalar, class AlgoTagType>
+void test_QR_batch(const int numMat, const int numRows, const int numCols) {
+  // Generate a batch of matrices
+  // Compute QR factorization
+  // Verify that R is triangular
+  // Verify that Q is unitary
+  // Check that Q*R = A
+
+  using ExecutionSpace = typename Device::execution_space;
+
+  {
+    Kokkos::View<Scalar**, ExecutionSpace> tau("tau", numMat, numCols);
+    Kokkos::View<Scalar*, ExecutionSpace> tmp("work buffer", numMat*Kokkos::max(numRows, numCols));
+    Kokkos::View<Scalar***, ExecutionSpace> As("A matrices", numMat, numRows, numCols);
+    Kokkos::View<Scalar***, ExecutionSpace> Bs("B matrices", numMat, numRows, numCols);
+    Kokkos::View<Scalar***, ExecutionSpace> Qs("Q matrices", numMat, numRows, numRows);
+    Kokkos::View<Scalar***, ExecutionSpace> Qts("Q transpose matrices", numMat, numRows, numRows);
+    Kokkos::View<Scalar***, ExecutionSpace> Is("Identity matrices", numMat, numRows, numRows);
+    Kokkos::View<int*, ExecutionSpace> error("global number of error", numMat);
+
+    Kokkos::Random_XorShift64_Pool<ExecutionSpace> rand_pool(2718);
+    constexpr double max_val = 1000;
+    {
+      Scalar randStart, randEnd;
+      Test::getRandomBounds(max_val, randStart, randEnd);
+      Kokkos::fill_random(ExecutionSpace{}, As, rand_pool, randStart, randEnd);
+    }
+    Kokkos::fence();
+    Kokkos::deep_copy(Bs, As);
+
+    typename Kokkos::View<Scalar***, ExecutionSpace>::HostMirror As_h = Kokkos::create_mirror_view(As);
+    Kokkos::deep_copy(As_h, As);
+
+    qrFunctor myFunc(As, tau, tmp, Qs, Qts, Is, Bs, error, max_val);
+    Kokkos::parallel_for("KokkosBatched::test_QR_batch", Kokkos::RangePolicy<ExecutionSpace>(0, numMat), myFunc);
+    Kokkos::fence();
+
+    typename Kokkos::View<int*, ExecutionSpace>::HostMirror error_h = Kokkos::create_mirror_view(error);
+    Kokkos::deep_copy(error_h, error);
+
+    int global_error = 0;
+    for(int matIdx = 0; matIdx < numMat; ++matIdx) {
+      global_error += error_h(matIdx);
+    }
+    EXPECT_EQ(global_error, 0);
+  }
+}
+
+template <class Device, class Scalar, class AlgoTagType>
+void test_QR_batch(const int numMat, const int numRows) {
+  test_QR_batch<Device, Scalar, AlgoTagType>(numMat, numRows, numRows);
+}
+
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+TEST_F(TestCategory, serial_qr_square_analytic_float) {
+  typedef KokkosBlas::Algo::QR::Unblocked AlgoTagType;
+  test_QR_square<TestDevice, float, AlgoTagType>();
+}
+TEST_F(TestCategory, serial_qr_rectangular_analytic_float) {
+  typedef KokkosBlas::Algo::QR::Unblocked AlgoTagType;
+  test_QR_rectangular<TestDevice, float, AlgoTagType>();
+}
+TEST_F(TestCategory, serial_qr_batch_float) {
+  typedef KokkosBlas::Algo::QR::Unblocked AlgoTagType;
+  test_QR_batch<TestDevice, float, AlgoTagType>(314, 36);
+  test_QR_batch<TestDevice, float, AlgoTagType>(10, 42, 36);
+  test_QR_batch<TestDevice, float, AlgoTagType>(100, 42, 36);
+  test_QR_batch<TestDevice, float, AlgoTagType>(200, 42, 36);
+  test_QR_batch<TestDevice, float, AlgoTagType>(250, 42, 36);
+  test_QR_batch<TestDevice, float, AlgoTagType>(300, 42, 36);
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+TEST_F(TestCategory, serial_qr_square_analytic_double) {
+  typedef KokkosBlas::Algo::QR::Unblocked AlgoTagType;
+  test_QR_square<TestDevice, double, AlgoTagType>();
+}
+TEST_F(TestCategory, serial_qr_rectangular_analytic_double) {
+  typedef KokkosBlas::Algo::QR::Unblocked AlgoTagType;
+  test_QR_rectangular<TestDevice, double, AlgoTagType>();
+}
+TEST_F(TestCategory, serial_qr_batch_double) {
+  typedef KokkosBlas::Algo::QR::Unblocked AlgoTagType;
+  test_QR_batch<TestDevice, double, AlgoTagType>(314, 36);
+  test_QR_batch<TestDevice, double, AlgoTagType>(10, 42, 36);
+  test_QR_batch<TestDevice, double, AlgoTagType>(100, 42, 36);
+  test_QR_batch<TestDevice, double, AlgoTagType>(200, 42, 36);
+  test_QR_batch<TestDevice, double, AlgoTagType>(250, 42, 36);
+  test_QR_batch<TestDevice, double, AlgoTagType>(300, 42, 36);
+}
+#endif
+
+// #if defined(KOKKOSKERNELS_INST_COMPLEX_FLOAT)
+// TEST_F(TestCategory, batched_scalar_serial_qr_scomplex) {
+//   typedef KokkosBlas::Algo::QR::Unblocked AlgoTagType;
+//   test_QR_rectangular<TestDevice, Kokkos::complex<float>, AlgoTagType>();
+// }
+// #endif
+
+// #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
+// TEST_F(TestCategory, batched_scalar_serial_qr_dcomplex) {
+//   typedef KokkosBlas::Algo::QR::Unblocked AlgoTagType;
+//   test_QR_rectangular<TestDevice, Kokkos::complex<double>, AlgoTagType>();
+// }
+// #endif

--- a/batched/dense/unit_test/Test_Batched_SerialQR.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialQR.hpp
@@ -501,15 +501,43 @@ TEST_F(TestCategory, serial_qr_batch_double) {
 #endif
 
 // #if defined(KOKKOSKERNELS_INST_COMPLEX_FLOAT)
-// TEST_F(TestCategory, batched_scalar_serial_qr_scomplex) {
+// TEST_F(TestCategory, serial_qr_square_analytic_scomplex) {
+//   typedef KokkosBlas::Algo::QR::Unblocked AlgoTagType;
+//   test_QR_square<TestDevice, Kokkos::complex<float>, AlgoTagType>();
+// }
+// TEST_F(TestCategory, serial_qr_rectangular_analytic_scomplex) {
 //   typedef KokkosBlas::Algo::QR::Unblocked AlgoTagType;
 //   test_QR_rectangular<TestDevice, Kokkos::complex<float>, AlgoTagType>();
 // }
+// TEST_F(TestCategory, serial_qr_batch_scomplex) {
+//   typedef KokkosBlas::Algo::QR::Unblocked AlgoTagType;
+//   test_QR_batch<TestDevice, Kokkos::complex<float>, AlgoTagType>(314, 36);
+//   test_QR_batch<TestDevice, Kokkos::complex<float>, AlgoTagType>(10, 42, 36);
+//   test_QR_batch<TestDevice, Kokkos::complex<float>, AlgoTagType>(100, 42, 36);
+//   test_QR_batch<TestDevice, Kokkos::complex<float>, AlgoTagType>(200, 42, 36);
+//   test_QR_batch<TestDevice, Kokkos::complex<float>, AlgoTagType>(250, 42, 36);
+//   test_QR_batch<TestDevice, Kokkos::complex<float>, AlgoTagType>(300, 42, 36);
+// }
 // #endif
 
+// These algorithms are not implemented correctly for complex numbers
+// we can look at this in a second step...
 // #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
-// TEST_F(TestCategory, batched_scalar_serial_qr_dcomplex) {
+// TEST_F(TestCategory, serial_qr_square_analytic_dcomplex) {
+//   typedef KokkosBlas::Algo::QR::Unblocked AlgoTagType;
+//   test_QR_square<TestDevice, Kokkos::complex<double>, AlgoTagType>();
+// }
+// TEST_F(TestCategory, serial_qr_rectangular_analytic_dcomplex) {
 //   typedef KokkosBlas::Algo::QR::Unblocked AlgoTagType;
 //   test_QR_rectangular<TestDevice, Kokkos::complex<double>, AlgoTagType>();
+// }
+// TEST_F(TestCategory, serial_qr_batch_dcomplex) {
+//   typedef KokkosBlas::Algo::QR::Unblocked AlgoTagType;
+//   test_QR_batch<TestDevice, Kokkos::complex<double>, AlgoTagType>(314, 36);
+//   test_QR_batch<TestDevice, Kokkos::complex<double>, AlgoTagType>(10, 42, 36);
+//   test_QR_batch<TestDevice, Kokkos::complex<double>, AlgoTagType>(100, 42, 36);
+//   test_QR_batch<TestDevice, Kokkos::complex<double>, AlgoTagType>(200, 42, 36);
+//   test_QR_batch<TestDevice, Kokkos::complex<double>, AlgoTagType>(250, 42, 36);
+//   test_QR_batch<TestDevice, Kokkos::complex<double>, AlgoTagType>(300, 42, 36);
 // }
 // #endif

--- a/batched/dense/unit_test/Test_Batched_SerialQR.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialQR.hpp
@@ -96,12 +96,10 @@ struct qrFunctor {
         if (rowIdx == colIdx) {
           if (Kokkos::abs(I(rowIdx, colIdx) - SC_one) > tol) {
             error_lcl += 1;
-            // Kokkos::printf("matIdx=%d, Q(%d, %d)=%e instead of 1.0.\n", matIdx, rowIdx, colIdx, I(rowIdx, colIdx));
           }
         } else {
           if (Kokkos::abs(I(rowIdx, colIdx)) > tol) {
             error_lcl += 1;
-            // Kokkos::printf("matIdx=%d, Q(%d, %d)=%e instead of 0.0.\n", matIdx, rowIdx, colIdx, I(rowIdx, colIdx));
           }
         }
       }
@@ -116,14 +114,10 @@ struct qrFunctor {
         if (rowIdx <= colIdx) {
           if (Kokkos::abs(B(rowIdx, colIdx) - A(rowIdx, colIdx)) > tol * Kokkos::abs(A(rowIdx, colIdx))) {
             error_lcl += 1;
-            // Kokkos::printf("B stores R\nmatIdx=%d, B(%d, %d)=%e instead of %e.\n", matIdx, rowIdx, colIdx,
-            //                B(rowIdx, colIdx), A(rowIdx, colIdx));
           }
         } else {
           if (Kokkos::abs(B(rowIdx, colIdx)) > tol) {
             error_lcl += 1;
-            // Kokkos::printf("B stores R\nmatIdx=%d, B(%d, %d)=%e instead of 0.0.\n", matIdx, rowIdx, colIdx,
-            //                B(rowIdx, colIdx));
           }
         }
       }

--- a/blas/impl/KokkosBlas_util.hpp
+++ b/blas/impl/KokkosBlas_util.hpp
@@ -59,11 +59,41 @@ struct Mode {
   };
 };
 
+template <class T>
+struct is_mode : std::false_type {};
+
+template <>
+struct is_mode<Mode::Serial> : std::true_type {};
+
+template <>
+struct is_mode<Mode::Team> : std::true_type {};
+
+template <>
+struct is_mode<Mode::TeamVector> : std::true_type {};
+
+template <class T>
+static constexpr bool is_mode_v = is_mode<T>::value;
+
 struct Trans {
   struct Transpose {};
   struct NoTranspose {};
   struct ConjTranspose {};
 };
+
+template <class T>
+struct is_trans : std::false_type {};
+
+template <>
+struct is_trans<Trans::Transpose> : std::true_type {};
+
+template <>
+struct is_trans<Trans::NoTranspose> : std::true_type {};
+
+template <>
+struct is_trans<Trans::ConjTranspose> : std::true_type {};
+
+template <class T>
+static constexpr bool is_trans_v = is_trans<T>::value;
 
 struct Algo {
   struct Level3 {
@@ -148,6 +178,24 @@ struct Algo {
   using Pbtrf  = Level2;
   using Pbtrs  = Level2;
 };
+
+template <class T>
+struct is_level2 : std::false_type {};
+
+template <>
+struct is_level2<Algo::Level2::Unblocked> : std::true_type {};
+
+template <>
+struct is_level2<Algo::Level2::Blocked> : std::true_type {};
+
+template <>
+struct is_level2<Algo::Level2::MKL> : std::true_type {};
+
+template <>
+struct is_level2<Algo::Level2::CompactMKL> : std::true_type {};
+
+template <class T>
+static constexpr bool is_level2_v = is_level2<T>::value;
 
 namespace Impl {
 


### PR DESCRIPTION
The serial QR algorithms does not have unit-tests and is failing for non square matrices. See issue #2328.
This first commit fixes the issue with rectangular matrices and adds a basic test for that use case.
Next will work on adding a test that exercises the interfaces on multiple matrices of different sizes within a parallel_for. Finally equivalent tests will be added for the square case as well.

Tasks:

- [x] analytical test on rectangular matrix (SerialQR, ApplyQ, FormQ, Q*Q^t=I)
  - [x] SerialQR
  - [x] ApplyQ
  - [x] FormQ
- [x] multiple variable size rectangular matrices (same API as above)
  - [x] SerialQR
  - [x] ApplyQ
  - [x] FormQ
- [x] analytical test on square matrix
  - [x] SerialQR
  - [x] ApplyQ
  - [x] FormQ
- [x] multiple variable size square matrices
  - [x] SerialQR
  - [x] ApplyQ
  - [x] FormQ