### PR TITLE
Fix #2344: SVD hanging

### DIFF
--- a/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
@@ -265,7 +265,7 @@ struct SerialSVDInternal {
             // new entry is introduced by the Givens.
             svdZeroLastColumn(Bsub, nsub, Bs0, Bs1, n, Vtsub, Vts0, Vts1);
           } else if (SVDIND(B, i, i + 1) != KAT::zero()) {
-            svdZeroRow(i - p, B, n, Bs0, Bs1, U, m, Us0, Us1);
+            svdZeroRow(i - p, Bsub, nsub, Bs0, Bs1, Usub, m, Us0, Us1);
           }
         }
       }

--- a/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
@@ -51,11 +51,10 @@ struct SerialSVDInternal {
   template <typename value_type>
   KOKKOS_INLINE_FUNCTION static void symEigen2x2(value_type a11, value_type a21, value_type a22, value_type& e1,
                                                  value_type& e2) {
-    value_type a = Kokkos::ArithTraits<value_type>::one();
-    value_type b = -a11 - a22;
-    value_type c = a11 * a22 - a21 * a21;
-    using Kokkos::sqrt;
-    value_type sqrtDet = sqrt(b * b - 4 * a * c);
+    value_type a       = Kokkos::ArithTraits<value_type>::one();
+    value_type b       = -a11 - a22;
+    value_type c       = a11 * a22 - a21 * a21;
+    value_type sqrtDet = Kokkos::sqrt(b * b - 4 * a * c);
     e1                 = (-b + sqrtDet) / (2 * a);
     e2                 = (-b - sqrtDet) / (2 * a);
   }
@@ -78,7 +77,7 @@ struct SerialSVDInternal {
     value_type e1, e2, mu;
     symEigen2x2(dm * dm + fmm1 * fmm1, dm * fm, target, e1, e2);
     // the shift is the eigenvalue closer to the last diagonal entry of B^T*B
-    if (fabs(e1 - target) < fabs(e2 - target))
+    if (Kokkos::abs(e1 - target) < Kokkos::abs(e2 - target))
       mu = e1;
     else
       mu = e2;
@@ -124,7 +123,7 @@ struct SerialSVDInternal {
   // Assumes i is not the last row.
   // U is m*m, B is n*n
   template <typename value_type>
-  KOKKOS_INLINE_FUNCTION static void svdZeroRow(int i, value_type* B, int n, int Bs0, int Bs1, value_type* U, int m,
+  KOKKOS_INLINE_FUNCTION static void svdZeroRow(int i, value_type* B, int n, int Bs0, int Bs1, value_type* U, int Um,
                                                 int Us0, int Us1) {
     Kokkos::pair<value_type, value_type> G;
     for (int j = i + 1; j < n; j++) {
@@ -138,17 +137,16 @@ struct SerialSVDInternal {
                                                                          &SVDIND(B, j, j + 1), Bs1);
       }
       if (U) {
-        KokkosBatched::SerialApplyRightGivensInternal::invoke<value_type>(G, m, &SVDIND(U, 0, i), Us0, &SVDIND(U, 0, j),
-                                                                          Us0);
+        KokkosBatched::SerialApplyRightGivensInternal::invoke<value_type>(G, Um, &SVDIND(U, 0, i), Us0,
+                                                                          &SVDIND(U, 0, j), Us0);
       }
     }
   }
 
   template <typename value_type>
-  KOKKOS_INLINE_FUNCTION static void svdZeroLastColumn(value_type* B, int n, int Bs0, int Bs1, value_type* Vt, int Vts0,
-                                                       int Vts1) {
-    // Deal with B(n-1, n-1) = 0, by chasing the superdiagonal nonzero up the
-    // last column.
+  KOKKOS_INLINE_FUNCTION static void svdZeroLastColumn(value_type* B, int n, int Bs0, int Bs1, int vn, value_type* Vt,
+                                                       int Vts0, int Vts1) {
+    // Deal with B(n-1, n-1) = 0, by chasing the superdiagonal nonzero up the last column.
     Kokkos::pair<value_type, value_type> G;
     for (int j = n - 2; j >= 0; j--) {
       KokkosBatched::SerialGivensInternal::invoke<value_type>(SVDIND(B, j, j), SVDIND(B, j, n - 1), &G,
@@ -159,7 +157,7 @@ struct SerialSVDInternal {
                                                                           &SVDIND(B, j - 1, j), Bs0);
       }
       if (Vt) {
-        KokkosBatched::SerialApplyLeftGivensInternal::invoke<value_type>(G, n, &SVDIND(Vt, n - 1, 0), Vts1,
+        KokkosBatched::SerialApplyLeftGivensInternal::invoke<value_type>(G, vn, &SVDIND(Vt, n - 1, 0), Vts1,
                                                                          &SVDIND(Vt, j, 0), Vts1);
       }
     }
@@ -224,8 +222,9 @@ struct SerialSVDInternal {
     while (true) {
       // Zero out tiny superdiagonal entries
       for (int i = 0; i < n - 1; i++) {
-        if (fabs(SVDIND(B, i, i + 1)) < eps * (fabs(SVDIND(B, i, i)) + fabs(SVDIND(B, i + 1, i + 1))) ||
-            fabs(SVDIND(B, i, i + 1)) < tol) {
+        if (Kokkos::abs(SVDIND(B, i, i + 1)) <
+                eps * (Kokkos::abs(SVDIND(B, i, i)) + Kokkos::abs(SVDIND(B, i + 1, i + 1))) ||
+            Kokkos::abs(SVDIND(B, i, i + 1)) < tol) {
           SVDIND(B, i, i + 1) = KAT::zero();
         }
       }
@@ -246,25 +245,32 @@ struct SerialSVDInternal {
       for (p = q - 1; p > 0; p--) {
         if (SVDIND(B, p - 1, p) == KAT::zero()) break;
       }
+      value_type* Bsub  = &SVDIND(B, p, p);
+      value_type* Usub  = &SVDIND(U, 0, p);
+      value_type* Vtsub = &SVDIND(Vt, p, 0);
+      int nsub          = q - p;
       // If there are zero diagonals in this range, eliminate the entire row
       //(effectively decoupling into two subproblems)
       for (int i = q - 1; i >= p; i--) {
         if (SVDIND(B, i, i) == KAT::zero()) {
-          if (i == n - 1) {
+          if (i == q - 1) {
             // Last diagonal entry being 0 is a special case.
             // Zero out the superdiagonal above it.
-            // Deal with B(n-1, n-1) = 0, by chasing the superdiagonal nonzero
-            // up the last column.
-            svdZeroLastColumn(B, n, Bs0, Bs1, Vt, Vts0, Vts1);
+            // Deal with B(q-1, q-1) = 0, by chasing the superdiagonal nonzero
+            // B(q-2, q-1) up the last column.
+            //
+            // Once that nonzero reaches B(p, q-1), we are either at the top of B
+            // (if p == 0) or the superdiag above B(p, p) is zero.
+            // In either case, the chase stops after eliminating B(p, q-1) because no
+            // new entry is introduced by the Givens.
+            svdZeroLastColumn(Bsub, nsub, Bs0, Bs1, n, Vtsub, Vts0, Vts1);
           } else if (SVDIND(B, i, i + 1) != KAT::zero()) {
-            svdZeroRow(i, B, n, Bs0, Bs1, U, m, Us0, Us1);
+            svdZeroRow(i - p, B, n, Bs0, Bs1, U, m, Us0, Us1);
           }
         }
-        continue;
       }
-      int nsub = q - p;
       // B22 is nsub * nsub, Usub is m * nsub, and Vtsub is nsub * n
-      svdStep(&SVDIND(B, p, p), &SVDIND(U, 0, p), &SVDIND(Vt, p, 0), m, n, nsub, Bs0, Bs1, Us0, Us1, Vts0, Vts1);
+      svdStep(Bsub, Usub, Vtsub, m, n, nsub, Bs0, Bs1, Us0, Us1, Vts0, Vts1);
     }
     for (int i = 0; i < n; i++) {
       sigma[i * ss] = SVDIND(B, i, i);

--- a/batched/dense/unit_test/Test_Batched_SerialSVD.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialSVD.hpp
@@ -509,9 +509,6 @@ void testSpecialCases() {
     auto Vthost    = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), Vt);
     auto sigmaHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), sigma);
 
-    std::cout << "Ran svd on test case " << i << ", singular values:\n";
-    KokkosKernels::Impl::print_1Dview(std::cout, sigmaHost);
-
     // Verify the SVD is correct
     verifySVD(Acopy, Uhost, Vthost, sigmaHost);
   }

--- a/batched/dense/unit_test/Test_Batched_SerialSVD.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialSVD.hpp
@@ -432,7 +432,7 @@ Kokkos::View<Scalar**, Layout, Device> getTestCase(int testCase) {
   int m, n;
   switch (testCase) {
     case 0:
-      // Issue #2344 case: 3x3 matrix with rank 2
+      // Issue #2344 case 1
       m           = 3;
       n           = 3;
       Ahost       = MatrixHost("A0", m, n);
@@ -470,6 +470,7 @@ Kokkos::View<Scalar**, Layout, Device> getTestCase(int testCase) {
       Ahost(4, 4) = 0;
       break;
     case 4: {
+      // Issue #2344 case 2
       m           = 3;
       n           = 4;
       Ahost       = MatrixHost("A4", m, n);

--- a/batched/dense/unit_test/Test_Batched_SerialSVD.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialSVD.hpp
@@ -429,11 +429,11 @@ void testIssue1786() {
 
 // Generate specific test cases
 template <typename Scalar, typename Layout, typename Device>
-Kokkos::View<Scalar**, Layout, Device> getTestCase(int i) {
+Kokkos::View<Scalar**, Layout, Device> getTestCase(int testCase) {
   using MatrixHost = Kokkos::View<Scalar**, Layout, Kokkos::HostSpace>;
   MatrixHost Ahost;
   int m, n;
-  switch (i) {
+  switch (testCase) {
     case 0:
       // Issue #2344 case: 3x3 matrix with rank 2
       m           = 3;

--- a/example/wiki/sparse/KokkosSparse_wiki_spadd.cpp
+++ b/example/wiki/sparse/KokkosSparse_wiki_spadd.cpp
@@ -1,78 +1,68 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
 #include "Kokkos_Core.hpp"
+#include "KokkosBatched_SVD_Decl.hpp"
 
-#include "KokkosKernels_default_types.hpp"
-#include "KokkosSparse_spadd.hpp"
+template <typename ExecSpace>
+void call_svd_in_parallel_for() {
+  Kokkos::TeamPolicy<ExecSpace> team_pol(1, Kokkos::AUTO);
+  using ScratchMatrix = Kokkos::View<double[3][3], typename ExecSpace::scratch_memory_space>;
+  using ScratchVector = Kokkos::View<double[3], typename ExecSpace::scratch_memory_space>;
+  team_pol.set_scratch_size(0, Kokkos::PerThread(3 * ScratchMatrix::shmem_size() + 3 * ScratchVector::shmem_size()));
+  Kokkos::parallel_for(
+      team_pol, KOKKOS_LAMBDA(const typename Kokkos::TeamPolicy<ExecSpace>::member_type &team) {
+        ScratchMatrix A(team.thread_scratch(0));
+        ScratchMatrix U(team.thread_scratch(0));
+        ScratchMatrix V(team.thread_scratch(0));
+        ScratchVector S(team.thread_scratch(0));
+        ScratchVector work(team.thread_scratch(0));
 
-#include "KokkosKernels_Test_Structured_Matrix.hpp"
+        Kokkos::single(Kokkos::PerTeam(team), [&]() {
+          printf("A = %p\n", A.data());
+          printf("U = %p\n", U.data());
+          printf("V = %p\n", V.data());
+          printf("S = %p\n", S.data());
+          printf("work = %p\n", work.data());
 
-using Scalar  = default_scalar;
-using Ordinal = default_lno_t;
-using Offset  = default_size_type;
-using Layout  = default_layout;
+          A(0, 0) = 0.000000;
+          A(1, 0) = 3.58442287931538747e-02;
+          A(2, 0) = 0.000000;
+          A(0, 1) = 0.000000;
+          A(1, 1) = 3.81743062695684907e-02;
+          A(2, 1) = 0.000000;
+          A(0, 2) = 0.000000;
+          A(1, 2) = 0.000000;
+          A(2, 2) = -5.55555555555555733e-02;
 
-int main() {
-  Kokkos::initialize();
+          KokkosBatched::SerialSVD::invoke(KokkosBatched::SVD_USV_Tag{}, A, U, S, V, work);
 
-  using device_type =
-      typename Kokkos::Device<Kokkos::DefaultExecutionSpace, typename Kokkos::DefaultExecutionSpace::memory_space>;
-  using execution_space = typename device_type::execution_space;
-  using memory_space    = typename device_type::memory_space;
-  using matrix_type     = typename KokkosSparse::CrsMatrix<Scalar, Ordinal, device_type, void, Offset>;
+          printf("S = {%.16f %.16f %.16f}\n", S(0), S(1), S(2));
+          printf("A(0) = {%.16f %.16f %.16f}\n", A(0, 0), A(0, 1), A(0, 2));
+          printf("A(1) = {%.16f %.16f %.16f}\n", A(1, 0), A(1, 1), A(1, 2));
+          printf("A(2) = {%.16f %.16f %.16f}\n", A(2, 0), A(2, 1), A(2, 2));
+          printf("U(0) = {%.16f %.16f %.16f}\n", U(0, 0), U(0, 1), U(0, 2));
+          printf("U(1) = {%.16f %.16f %.16f}\n", U(1, 0), U(1, 1), U(1, 2));
+          printf("U(2) = {%.16f %.16f %.16f}\n", U(2, 0), U(2, 1), U(2, 2));
+          printf("V(0) = {%.16f %.16f %.16f}\n", V(0, 0), V(0, 1), V(0, 2));
+          printf("V(1) = {%.16f %.16f %.16f}\n", V(1, 0), V(1, 1), V(1, 2));
+          printf("V(2) = {%.16f %.16f %.16f}\n", V(2, 0), V(2, 1), V(2, 2));
+        });
+      });
+}
 
-  int return_value = 0;
+int main(int argc, char **argv) {
+  Kokkos::initialize(argc, argv);
 
   {
-    // The mat_structure view is used to generate a matrix using
-    // finite difference (FD) or finite element (FE) discretization
-    // on a cartesian grid.
-    // Each row corresponds to an axis (x, y and z)
-    // In each row the first entry is the number of grid point in
-    // that direction, the second and third entries are used to apply
-    // BCs in that direction.
-    Kokkos::View<Ordinal* [3], Kokkos::HostSpace> mat_structure("Matrix Structure", 2);
-    mat_structure(0, 0) = 10;  // Request 10 grid point in 'x' direction
-    mat_structure(0, 1) = 1;   // Add BC to the left
-    mat_structure(0, 2) = 1;   // Add BC to the right
-    mat_structure(1, 0) = 10;  // Request 10 grid point in 'y' direction
-    mat_structure(1, 1) = 1;   // Add BC to the bottom
-    mat_structure(1, 2) = 1;   // Add BC to the top
+    printf("Running on host\n");
+    call_svd_in_parallel_for<Kokkos::DefaultHostExecutionSpace>();
+    Kokkos::fence();
+    printf("Done\n");
 
-    matrix_type A = Test::generate_structured_matrix2D<matrix_type>("FD", mat_structure);
-    matrix_type B = Test::generate_structured_matrix2D<matrix_type>("FE", mat_structure);
-    matrix_type C;
-
-    // Create KokkosKernelHandle
-    using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<Offset, Ordinal, Scalar, execution_space,
-                                                                          memory_space, memory_space>;
-    KernelHandle kh;
-    kh.create_spadd_handle(false);
-
-    const Scalar alpha = 2.5;
-    const Scalar beta  = 1.2;
-
-    KokkosSparse::spadd_symbolic(&kh, A, B, C);
-    KokkosSparse::spadd_numeric(&kh, alpha, A, beta, B, C);
-    kh.destroy_spadd_handle();
-
-    std::cout << "spadd was performed correctly!" << std::endl;
+    printf("Running on device\n");
+    call_svd_in_parallel_for<Kokkos::DefaultExecutionSpace>();
+    Kokkos::fence();
+    printf("Done\n");
   }
 
   Kokkos::finalize();
-
-  return return_value;
+  return 0;
 }


### PR DESCRIPTION
Fix #2344, where SVD would hang due to one of the edge cases not being handled correctly.
Add tests (including the reproducer from the issue) which together exercise the two main edge cases.

Also did some miscellaneous cleanup like replace fabs (C math function) with ``Kokkos::abs``.