### PR TITLE
sparse_sort_crs: fix column shuffle indices

### DIFF
--- a/perf_test/sparse/KokkosSparse_sort_crs.cpp
+++ b/perf_test/sparse/KokkosSparse_sort_crs.cpp
@@ -79,8 +79,10 @@ void run_experiment(int argc, char** argv, const CommonInputParams& common_param
   // Randomly shuffle the entries within each row, so that the rows aren't
   // already sorted. Leave the values alone; this changes the matrix numerically
   // but this doesn't affect sorting.
+  std::random_device rd;
+  std::mt19937 g(rd());
   for (lno_t i = 0; i < m; i++) {
-    std::random_shuffle(entriesHost.data() + i, entriesHost.data() + i + 1);
+    std::shuffle(entriesHost.data() + i, entriesHost.data() + i + 1, g);
   }
   Kokkos::deep_copy(shuffledEntries, entriesHost);
   exec_space exec;

--- a/perf_test/sparse/KokkosSparse_sort_crs.cpp
+++ b/perf_test/sparse/KokkosSparse_sort_crs.cpp
@@ -82,7 +82,9 @@ void run_experiment(int argc, char** argv, const CommonInputParams& common_param
   std::random_device rd;
   std::mt19937 g(rd());
   for (lno_t i = 0; i < m; i++) {
-    std::shuffle(entriesHost.data() + i, entriesHost.data() + i + 1, g);
+    const size_type rowBegin = rowmapHost(i);
+    const size_type rowEnd   = rowmapHost(i + 1);
+    std::shuffle(entriesHost.data() + rowBegin, entriesHost.data() + rowEnd, g);
   }
   Kokkos::deep_copy(shuffledEntries, entriesHost);
   exec_space exec;


### PR DESCRIPTION
also: random_shuffle is deprecated / removed