### PR TITLE
Modify validity checks for output views sizes in svd

### DIFF
--- a/lapack/src/KokkosLapack_svd.hpp
+++ b/lapack/src/KokkosLapack_svd.hpp
@@ -127,17 +127,31 @@ void svd(const ExecutionSpace& space, const char jobu[], const char jobvt[], con
     is_extent_invalid = true;
     os << "KokkosLapack::svd: S has extent " << S.extent(0) << ", instead of " << rankA << ".\n";
   }
-  if ((jobu[0] == 'A') || (jobu[0] == 'a') || (jobu[0] == 'S') || (jobu[0] == 's')) {
+  if ((jobu[0] == 'A') || (jobu[0] == 'a')) {
     if (U.extent_int(0) != m || U.extent_int(1) != m) {
       is_extent_invalid = true;
       os << "KokkosLapack::svd: U has extents (" << U.extent(0) << ", " << U.extent(1) << ") instead of (" << m << ", "
          << m << ").\n";
     }
   }
-  if ((jobvt[0] == 'A') || (jobvt[0] == 'a') || (jobvt[0] == 'S') || (jobvt[0] == 's')) {
+  if ((jobu[0] == 'S') || (jobu[0] == 's')) {
+    if (U.extent_int(0) != m || U.extent_int(1) != std::min(m,n)) {
+      is_extent_invalid = true;
+      os << "KokkosLapack::svd: U has extents (" << U.extent(0) << ", " << U.extent(1) << ") instead of (" << m << ", "
+         << std::min(m,n) << ").\n";
+    }
+  }
+  if ((jobvt[0] == 'A') || (jobvt[0] == 'a')) {
     if (Vt.extent_int(0) != n || Vt.extent_int(1) != n) {
       is_extent_invalid = true;
       os << "KokkosLapack::svd: V has extents (" << Vt.extent(0) << ", " << Vt.extent(1) << ") instead of (" << n
+         << ", " << n << ").\n";
+    }
+  }
+  if ((jobvt[0] == 'S') || (jobvt[0] == 's')) {
+    if (Vt.extent_int(0) != std::min(m,n) || Vt.extent_int(1) != n) {
+      is_extent_invalid = true;
+      os << "KokkosLapack::svd: V has extents (" << Vt.extent(0) << ", " << Vt.extent(1) << ") instead of (" << std::min(m,n)
          << ", " << n << ").\n";
     }
   }

--- a/lapack/src/KokkosLapack_svd.hpp
+++ b/lapack/src/KokkosLapack_svd.hpp
@@ -135,10 +135,10 @@ void svd(const ExecutionSpace& space, const char jobu[], const char jobvt[], con
     }
   }
   if ((jobu[0] == 'S') || (jobu[0] == 's')) {
-    if (U.extent_int(0) != m || U.extent_int(1) != std::min(m,n)) {
+    if (U.extent_int(0) != m || U.extent_int(1) != std::min(m, n)) {
       is_extent_invalid = true;
       os << "KokkosLapack::svd: U has extents (" << U.extent(0) << ", " << U.extent(1) << ") instead of (" << m << ", "
-         << std::min(m,n) << ").\n";
+         << std::min(m, n) << ").\n";
     }
   }
   if ((jobvt[0] == 'A') || (jobvt[0] == 'a')) {
@@ -149,9 +149,9 @@ void svd(const ExecutionSpace& space, const char jobu[], const char jobvt[], con
     }
   }
   if ((jobvt[0] == 'S') || (jobvt[0] == 's')) {
-    if (Vt.extent_int(0) != std::min(m,n) || Vt.extent_int(1) != n) {
+    if (Vt.extent_int(0) != std::min(m, n) || Vt.extent_int(1) != n) {
       is_extent_invalid = true;
-      os << "KokkosLapack::svd: V has extents (" << Vt.extent(0) << ", " << Vt.extent(1) << ") instead of (" << std::min(m,n)
+      os << "KokkosLapack::svd: V has extents (" << Vt.extent(0) << ", " << Vt.extent(1) << ") instead of (" << std::min(m, n)
          << ", " << n << ").\n";
     }
   }

--- a/lapack/src/KokkosLapack_svd.hpp
+++ b/lapack/src/KokkosLapack_svd.hpp
@@ -151,8 +151,8 @@ void svd(const ExecutionSpace& space, const char jobu[], const char jobvt[], con
   if ((jobvt[0] == 'S') || (jobvt[0] == 's')) {
     if (Vt.extent_int(0) != std::min(m, n) || Vt.extent_int(1) != n) {
       is_extent_invalid = true;
-      os << "KokkosLapack::svd: V has extents (" << Vt.extent(0) << ", " << Vt.extent(1) << ") instead of (" << std::min(m, n)
-         << ", " << n << ").\n";
+      os << "KokkosLapack::svd: V has extents (" << Vt.extent(0) << ", " << Vt.extent(1) << ") instead of ("
+         << std::min(m, n) << ", " << n << ").\n";
     }
   }
   if (is_extent_invalid) {


### PR DESCRIPTION
This PR has minor changes for validity checks for output views U and Vt, as follows:

- if ```jobu``` = 'S', ```U``` has sizes of M x min(M,N)
- if ```jobvt``` = 'S', ```Vt``` has sizes of min(M,N) x N

(see: https://www.netlib.org/lapack/explore-3.1.1-html/zgesvd.f.html)