### PR TITLE
`kk_is_gpu_exec_space()` -> `is_gpu_exec_space_v`

### DIFF
--- a/batched/dense/impl/KokkosBatched_Gemm_Team_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemm_Team_Internal.hpp
@@ -115,7 +115,7 @@ KOKKOS_INLINE_FUNCTION int TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
       Kokkos::parallel_for(Kokkos::TeamThreadRange(member, mq * nq), [&](const int &ij) {
         int i, j;
         // note: the condition is constexpr
-        if (KokkosKernels::Impl::kk_is_gpu_exec_space<typename MemberType::execution_space>()) {
+        if (KokkosKernels::Impl::is_gpu_exec_space_v<typename MemberType::execution_space>) {
           i = ij % mq * mb;
           j = ij / mq * nb;
         } else {

--- a/batched/dense/impl/KokkosBatched_HostLevel_Gemm_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_HostLevel_Gemm_Impl.hpp
@@ -128,7 +128,7 @@ int BatchedGemmImpl(BatchedGemmHandleType *const handle, const ScalarType alpha,
   using layout_type        = typename CViewType::array_layout;
   using exec_space         = typename CViewType::execution_space;
   constexpr bool is_vector = KokkosBatched::is_vector<view_scalar_type>::value;
-  constexpr bool on_gpu    = KokkosKernels::Impl::kk_is_gpu_exec_space<exec_space>();
+  constexpr bool on_gpu    = KokkosKernels::Impl::is_gpu_exec_space_v<exec_space>;
   constexpr bool on_x86_64 = KokkosKernels::Impl::kk_is_x86_64_mem_space<typename exec_space::memory_space>();
   constexpr bool on_a64fx  = KokkosKernels::Impl::kk_is_a64fx_mem_space<typename exec_space::memory_space>();
   bool out_of_range        = false;

--- a/batched/dense/impl/KokkosBatched_Trsm_Team_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsm_Team_Internal.hpp
@@ -192,7 +192,7 @@ KOKKOS_INLINE_FUNCTION int TeamTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::inv
 
       Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, iend * jend), [&](const int &ij) {
         int i, j;
-        if (KokkosKernels::Impl::kk_is_gpu_exec_space<typename MemberType::execution_space>()) {
+        if (KokkosKernels::Impl::is_gpu_exec_space_v<typename MemberType::execution_space>) {
           i = ij % iend;
           j = ij / iend;
         } else {

--- a/blas/impl/KokkosBlas1_axpby_unification_attempt_traits.hpp
+++ b/blas/impl/KokkosBlas1_axpby_unification_attempt_traits.hpp
@@ -103,7 +103,7 @@ struct AxpbyUnificationAttemptTraits {
   // - type names begin with upper case letters
   // ********************************************************************
  public:
-  static constexpr bool onDevice = KokkosKernels::Impl::kk_is_gpu_exec_space<tExecSpace>();
+  static constexpr bool onDevice = KokkosKernels::Impl::is_gpu_exec_space_v<tExecSpace>;
 
  private:
   static constexpr bool onHost = !onDevice;

--- a/blas/impl/KokkosBlas2_gemv_impl.hpp
+++ b/blas/impl/KokkosBlas2_gemv_impl.hpp
@@ -623,7 +623,7 @@ void twoLevelGemv(const ExecutionSpace& space, const char trans[], typename AVie
 // depending on whether execution space is CPU or GPU. enable_if makes sure
 // unused kernels are not instantiated.
 template <class ExecutionSpace, class AViewType, class XViewType, class YViewType, class IndexType,
-          typename std::enable_if<!KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>()>::type* = nullptr>
+          typename std::enable_if<!KokkosKernels::Impl::is_gpu_exec_space_v<ExecutionSpace>>::type* = nullptr>
 void generalGemvImpl(const ExecutionSpace& space, const char trans[], typename AViewType::const_value_type& alpha,
                      const AViewType& A, const XViewType& x, typename YViewType::const_value_type& beta,
                      const YViewType& y) {
@@ -631,7 +631,7 @@ void generalGemvImpl(const ExecutionSpace& space, const char trans[], typename A
 }
 
 template <class ExecutionSpace, class AViewType, class XViewType, class YViewType, class IndexType,
-          typename std::enable_if<KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>()>::type* = nullptr>
+          typename std::enable_if<KokkosKernels::Impl::is_gpu_exec_space_v<ExecutionSpace>>::type* = nullptr>
 void generalGemvImpl(const ExecutionSpace& space, const char trans[], typename AViewType::const_value_type& alpha,
                      const AViewType& A, const XViewType& x, typename YViewType::const_value_type& beta,
                      const YViewType& y) {

--- a/blas/impl/KokkosBlas2_ger_impl.hpp
+++ b/blas/impl/KokkosBlas2_ger_impl.hpp
@@ -208,14 +208,14 @@ void teamParallelGer(const ExecutionSpace& space, const char trans[], const type
 // The 'enable_if' makes sure unused kernels are not instantiated.
 
 template <class ExecutionSpace, class XViewType, class YViewType, class AViewType, class IndexType,
-          typename std::enable_if<!KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>()>::type* = nullptr>
+          typename std::enable_if<!KokkosKernels::Impl::is_gpu_exec_space_v<ExecutionSpace>>::type* = nullptr>
 void generalGerImpl(const ExecutionSpace& space, const char trans[], const typename AViewType::const_value_type& alpha,
                     const XViewType& x, const YViewType& y, const AViewType& A) {
   threadParallelGer(space, trans, alpha, x, y, A);
 }
 
 template <class ExecutionSpace, class XViewType, class YViewType, class AViewType, class IndexType,
-          typename std::enable_if<KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>()>::type* = nullptr>
+          typename std::enable_if<KokkosKernels::Impl::is_gpu_exec_space_v<ExecutionSpace>>::type* = nullptr>
 void generalGerImpl(const ExecutionSpace& space, const char trans[], const typename AViewType::const_value_type& alpha,
                     const XViewType& x, const YViewType& y, const AViewType& A) {
   teamParallelGer(space, trans, alpha, x, y, A);

--- a/blas/impl/KokkosBlas2_syr2_impl.hpp
+++ b/blas/impl/KokkosBlas2_syr2_impl.hpp
@@ -292,7 +292,7 @@ void teamParallelSyr2(const ExecutionSpace& space, const typename AViewType::con
 
 template <class ExecutionSpace, class XViewType, class YViewType, class AViewType, class IndexType, bool tJustTranspose,
           bool tJustUp,
-          typename std::enable_if<!KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>()>::type* = nullptr>
+          typename std::enable_if<!KokkosKernels::Impl::is_gpu_exec_space_v<ExecutionSpace>>::type* = nullptr>
 void generalSyr2Impl(const ExecutionSpace& space, const typename AViewType::const_value_type& alpha, const XViewType& x,
                      const YViewType& y, const AViewType& A) {
   threadParallelSyr2<ExecutionSpace, XViewType, YViewType, AViewType, IndexType, tJustTranspose, tJustUp>(space, alpha,
@@ -301,7 +301,7 @@ void generalSyr2Impl(const ExecutionSpace& space, const typename AViewType::cons
 
 template <class ExecutionSpace, class XViewType, class YViewType, class AViewType, class IndexType, bool tJustTranspose,
           bool tJustUp,
-          typename std::enable_if<KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>()>::type* = nullptr>
+          typename std::enable_if<KokkosKernels::Impl::is_gpu_exec_space_v<ExecutionSpace>>::type* = nullptr>
 void generalSyr2Impl(const ExecutionSpace& space, const typename AViewType::const_value_type& alpha, const XViewType& x,
                      const YViewType& y, const AViewType& A) {
   teamParallelSyr2<ExecutionSpace, XViewType, YViewType, AViewType, IndexType, tJustTranspose, tJustUp>(space, alpha, x,

--- a/blas/impl/KokkosBlas2_syr_impl.hpp
+++ b/blas/impl/KokkosBlas2_syr_impl.hpp
@@ -206,14 +206,14 @@ void teamParallelSyr(const ExecutionSpace& space, const typename AViewType::cons
 // The 'enable_if' makes sure unused kernels are not instantiated.
 
 template <class ExecutionSpace, class XViewType, class AViewType, class IndexType, bool tJustTranspose, bool tJustUp,
-          typename std::enable_if<!KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>()>::type* = nullptr>
+          typename std::enable_if<!KokkosKernels::Impl::is_gpu_exec_space_v<ExecutionSpace>>::type* = nullptr>
 void generalSyrImpl(const ExecutionSpace& space, const typename AViewType::const_value_type& alpha, const XViewType& x,
                     const AViewType& A) {
   threadParallelSyr<ExecutionSpace, XViewType, AViewType, IndexType, tJustTranspose, tJustUp>(space, alpha, x, A);
 }
 
 template <class ExecutionSpace, class XViewType, class AViewType, class IndexType, bool tJustTranspose, bool tJustUp,
-          typename std::enable_if<KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>()>::type* = nullptr>
+          typename std::enable_if<KokkosKernels::Impl::is_gpu_exec_space_v<ExecutionSpace>>::type* = nullptr>
 void generalSyrImpl(const ExecutionSpace& space, const typename AViewType::const_value_type& alpha, const XViewType& x,
                     const AViewType& A) {
   teamParallelSyr<ExecutionSpace, XViewType, AViewType, IndexType, tJustTranspose, tJustUp>(space, alpha, x, A);

--- a/blas/impl/KokkosBlas3_gemm_spec.hpp
+++ b/blas/impl/KokkosBlas3_gemm_spec.hpp
@@ -104,7 +104,7 @@ struct GEMM {
     const int M = static_cast<int>(C.extent(0));
     const int N = static_cast<int>(C.extent(1));
 
-    const bool is_device_space = KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>();
+    const bool is_device_space = KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>;
     const bool A_is_lr         = std::is_same<Kokkos::LayoutRight, typename AViewType::array_layout>::value;
     const bool A_is_tr         = ((transA[0] == 'T') || (transA[0] == 't') || (transA[0] == 'C') || (transA[0] == 'c'));
     const bool B_is_tr         = ((transB[0] == 'T') || (transB[0] == 't') || (transB[0] == 'C') || (transB[0] == 'c'));

--- a/blas/unit_test/Test_Blas2_ger.hpp
+++ b/blas/unit_test/Test_Blas2_ger.hpp
@@ -153,7 +153,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::GerT
                     std::is_same<ScalarA, Kokkos::complex<double>>::value),
       _A_is_lr(std::is_same<tLayoutA, Kokkos::LayoutRight>::value),
       _A_is_ll(std::is_same<tLayoutA, Kokkos::LayoutLeft>::value),
-      _testIsGpu(KokkosKernels::Impl::kk_is_gpu_exec_space<typename Device::execution_space>())
+      _testIsGpu(KokkosKernels::Impl::is_gpu_exec_space_v<typename Device::execution_space>)
 #ifdef KOKKOSKERNELS_ENABLE_TPL_BLAS
       ,
       _vanillaUsesDifferentOrderOfOps(_A_is_lr && _testIsGpu)

--- a/blas/unit_test/Test_Blas2_syr.hpp
+++ b/blas/unit_test/Test_Blas2_syr.hpp
@@ -153,7 +153,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::SyrTester()
                     std::is_same<ScalarA, Kokkos::complex<double>>::value),
       _A_is_lr(std::is_same<tLayoutA, Kokkos::LayoutRight>::value),
       _A_is_ll(std::is_same<tLayoutA, Kokkos::LayoutLeft>::value),
-      _testIsGpu(KokkosKernels::Impl::kk_is_gpu_exec_space<typename Device::execution_space>())
+      _testIsGpu(KokkosKernels::Impl::is_gpu_exec_space_v<typename Device::execution_space>)
 #ifdef KOKKOSKERNELS_ENABLE_TPL_BLAS
       ,
       _vanillaUsesDifferentOrderOfOps(_A_is_lr)

--- a/blas/unit_test/Test_Blas2_syr2.hpp
+++ b/blas/unit_test/Test_Blas2_syr2.hpp
@@ -164,7 +164,7 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::Syr
                     std::is_same<ScalarA, Kokkos::complex<double>>::value),
       _A_is_lr(std::is_same<tLayoutA, Kokkos::LayoutRight>::value),
       _A_is_ll(std::is_same<tLayoutA, Kokkos::LayoutLeft>::value),
-      _testIsGpu(KokkosKernels::Impl::kk_is_gpu_exec_space<typename Device::execution_space>())
+      _testIsGpu(KokkosKernels::Impl::is_gpu_exec_space_v<typename Device::execution_space>)
 #ifdef KOKKOSKERNELS_ENABLE_TPL_BLAS
       ,
       _vanillaUsesDifferentOrderOfOps(_A_is_lr)

--- a/common/src/KokkosKernels_ExecSpaceUtils.hpp
+++ b/common/src/KokkosKernels_ExecSpaceUtils.hpp
@@ -78,29 +78,21 @@ KOKKOS_FORCEINLINE_FUNCTION ExecSpaceType kk_get_exec_space_type() {
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename ExecutionSpace>
-constexpr KOKKOS_INLINE_FUNCTION bool kk_is_gpu_exec_space() {
-  return false;
-}
+constexpr inline bool is_gpu_exec_space_v = false;
 
 #ifdef KOKKOS_ENABLE_CUDA
 template <>
-constexpr KOKKOS_INLINE_FUNCTION bool kk_is_gpu_exec_space<Kokkos::Cuda>() {
-  return true;
-}
+constexpr inline bool is_gpu_exec_space_v<Kokkos::Cuda> = true;
 #endif
 
 #ifdef KOKKOS_ENABLE_HIP
 template <>
-constexpr KOKKOS_INLINE_FUNCTION bool kk_is_gpu_exec_space<Kokkos::HIP>() {
-  return true;
-}
+constexpr inline bool is_gpu_exec_space_v<Kokkos::HIP> = true;
 #endif
 
 #ifdef KOKKOS_ENABLE_SYCL
 template <>
-constexpr KOKKOS_INLINE_FUNCTION bool kk_is_gpu_exec_space<Kokkos::Experimental::SYCL>() {
-  return true;
-}
+constexpr inline bool is_gpu_exec_space_v<Kokkos::Experimental::SYCL> = true;
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/common/src/KokkosKernels_Sorting.hpp
+++ b/common/src/KokkosKernels_Sorting.hpp
@@ -19,7 +19,7 @@
 #include "Kokkos_Core.hpp"
 #include "Kokkos_Sort.hpp"
 #include "KokkosKernels_SimpleUtils.hpp"     //for kk_exclusive_parallel_prefix_sum
-#include "KokkosKernels_ExecSpaceUtils.hpp"  //for kk_is_gpu_exec_space
+#include "KokkosKernels_ExecSpaceUtils.hpp"  //for is_gpu_exec_space
 #include <type_traits>
 
 namespace KokkosKernels {

--- a/common/src/KokkosKernels_Utils.hpp
+++ b/common/src/KokkosKernels_Utils.hpp
@@ -58,7 +58,7 @@ void get_suggested_vector_size(int &suggested_vector_size_, idx nr, idx nnz) {
 template <typename team_policy_t, typename Functor, typename ParallelTag = Kokkos::ParallelForTag>
 int get_suggested_team_size(Functor &f, int vector_size) {
   using execution_space = typename team_policy_t::traits::execution_space;
-  if (kk_is_gpu_exec_space<execution_space>()) {
+  if (is_gpu_exec_space_v<execution_space>) {
     team_policy_t temp(1, 1, vector_size);
     return temp.team_size_recommended(f, ParallelTag());
   } else
@@ -68,7 +68,7 @@ int get_suggested_team_size(Functor &f, int vector_size) {
 template <typename team_policy_t, typename Functor, typename ParallelTag = Kokkos::ParallelForTag>
 int get_suggested_team_size(Functor &f, int vector_size, size_t sharedPerTeam, size_t sharedPerThread) {
   using execution_space = typename team_policy_t::traits::execution_space;
-  if (kk_is_gpu_exec_space<execution_space>()) {
+  if (is_gpu_exec_space_v<execution_space>) {
     team_policy_t temp = team_policy_t(1, 1, vector_size)
                              .set_scratch_size(0, Kokkos::PerTeam(sharedPerTeam), Kokkos::PerThread(sharedPerThread));
     return temp.team_size_recommended(f, ParallelTag());

--- a/common/unit_test/Test_Common_LowerBound.hpp
+++ b/common/unit_test/Test_Common_LowerBound.hpp
@@ -117,7 +117,7 @@ void test_lower_bound_team(const std::vector<T> &_haystack, const T _needle) {
 
   // test lower_bound search
   const int leagueSize = 1;
-  const int teamSize   = KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>() ? 64 : 1;
+  const int teamSize   = KokkosKernels::Impl::is_gpu_exec_space_v<execution_space> ? 64 : 1;
   int errCount;
   Kokkos::parallel_reduce(Policy(leagueSize, teamSize),
                           TeamLowerBoundFunctor<Member, view_t>(expected, haystack, _needle), errCount);

--- a/common/unit_test/Test_Common_UpperBound.hpp
+++ b/common/unit_test/Test_Common_UpperBound.hpp
@@ -117,7 +117,7 @@ void test_upper_bound_team(const std::vector<T> &_haystack, const T _needle) {
 
   // test upper_bound search
   const int leagueSize = 1;
-  const int teamSize   = KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>() ? 64 : 1;
+  const int teamSize   = KokkosKernels::Impl::is_gpu_exec_space_v<execution_space> ? 64 : 1;
   int errCount;
   Kokkos::parallel_reduce(Policy(leagueSize, teamSize),
                           TeamUpperBoundFunctor<Member, view_t>(expected, haystack, _needle), errCount);

--- a/graph/impl/KokkosGraph_Distance2MIS_impl.hpp
+++ b/graph/impl/KokkosGraph_Distance2MIS_impl.hpp
@@ -317,7 +317,7 @@ struct D2_MIS_RandomPriority {
     KokkosKernels::Impl::sequential_fill(colWorklist);
     worklist_t thirdWorklist = Kokkos::subview(allWorklists, Kokkos::ALL(), 2);
     auto execSpaceEnum       = KokkosKernels::Impl::kk_get_exec_space_type<exec_space>();
-    bool useTeams    = KokkosKernels::Impl::kk_is_gpu_exec_space<exec_space>() && (entries.extent(0) / numVerts >= 16);
+    bool useTeams    = KokkosKernels::Impl::is_gpu_exec_space_v<exec_space> && (entries.extent(0) / numVerts >= 16);
     int vectorLength = KokkosKernels::Impl::kk_get_suggested_vector_size(numVerts, entries.extent(0), execSpaceEnum);
     int round        = 0;
     lno_t rowWorkLen = numVerts;
@@ -396,7 +396,7 @@ struct D2_MIS_RandomPriority {
     Kokkos::deep_copy(rowStatus, ~(status_t(0)));
     worklist_t thirdWorklist = Kokkos::subview(allWorklists, Kokkos::ALL(), 2);
     auto execSpaceEnum       = KokkosKernels::Impl::kk_get_exec_space_type<exec_space>();
-    bool useTeams    = KokkosKernels::Impl::kk_is_gpu_exec_space<exec_space>() && (entries.extent(0) / numVerts >= 16);
+    bool useTeams    = KokkosKernels::Impl::is_gpu_exec_space_v<exec_space> && (entries.extent(0) / numVerts >= 16);
     int vectorLength = KokkosKernels::Impl::kk_get_suggested_vector_size(numVerts, entries.extent(0), execSpaceEnum);
     int round        = 0;
     int refreshColTeamSize = 0;

--- a/graph/src/KokkosGraph_CoarsenConstruct.hpp
+++ b/graph/src/KokkosGraph_CoarsenConstruct.hpp
@@ -96,7 +96,7 @@ typename entries_t::non_const_value_type sort_low_degree_rows_crs_matrix(
     const typename entries_t::non_const_value_type degreeLimit) {
   using lno_t    = typename entries_t::non_const_value_type;
   using team_pol = Kokkos::TeamPolicy<execution_space>;
-  bool useRadix  = !KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>();
+  bool useRadix  = !KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>;
   Impl::SortLowDegreeCrsMatrixFunctor<execution_space, rowmap_t, entries_t, values_t> funct(useRadix, rowmap, entries,
                                                                                             values, degreeLimit);
   lno_t numRows   = rowmap.extent(0) ? rowmap.extent(0) - 1 : 0;

--- a/graph/src/KokkosGraph_Distance1ColorHandle.hpp
+++ b/graph/src/KokkosGraph_Distance1ColorHandle.hpp
@@ -226,7 +226,7 @@ class GraphColoringHandle {
 #ifdef VERBOSE
       std::cout << ExecutionSpace::name() << " Execution Space, Default Algorithm: COLORING_VBBIT\n";
 #endif
-    } else if (KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>()) {
+    } else if (KokkosKernels::Impl::is_gpu_exec_space_v<ExecutionSpace>) {
       this->coloring_algorithm_type = COLORING_EB;
 #ifdef VERBOSE
       std::cout << ExecutionSpace::name() << " Execution Space, Default Algorithm: COLORING_EB\n";
@@ -402,7 +402,7 @@ class GraphColoringHandle {
       size_type_temp_work_view_t lower_count("LowerXADJ", nv + 1);
       size_type new_num_edge = 0;
       typedef Kokkos::RangePolicy<ExecutionSpace> my_exec_space;
-      if (KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>()) {
+      if (KokkosKernels::Impl::is_gpu_exec_space_v<ExecutionSpace>) {
         int teamSizeMax = 0;
         int vector_size = 0;
 

--- a/perf_test/graph/KokkosGraph_triangle.cpp
+++ b/perf_test/graph/KokkosGraph_triangle.cpp
@@ -236,7 +236,7 @@ void run_experiment(int argc, char **argv, perf_test::CommonInputParams) {
   using KernelHandle =
       KokkosKernels::Experimental::KokkosKernelsHandle<size_type, lno_t, lno_t, exec_space, mem_space, mem_space>;
 
-  if (KokkosKernels::Impl::kk_is_gpu_exec_space<exec_space>()) {
+  if (KokkosKernels::Impl::is_gpu_exec_space_v<exec_space>) {
     std::cerr << "** Triangle counting is currently not supported on GPU backends.\n";
     return;
   }

--- a/perf_test/sparse/KokkosSparse_block_pcg.cpp
+++ b/perf_test/sparse/KokkosSparse_block_pcg.cpp
@@ -62,7 +62,7 @@ crsMat_t create_crs_matrix(char *mtx_bin_file) {
     cols_view_t columns_view("colsmap_view", ne);
     values_view_t values_view("values_view", ne);
 
-    if (KokkosKernels::Impl::kk_is_gpu_exec_space<myExecSpace>()) {
+    if (KokkosKernels::Impl::is_gpu_exec_space_v<myExecSpace>) {
       typename row_map_view_t::HostMirror hr = Kokkos::create_mirror_view(rowmap_view);
       typename cols_view_t::HostMirror hc    = Kokkos::create_mirror_view(columns_view);
       typename values_view_t::HostMirror hv  = Kokkos::create_mirror_view(values_view);

--- a/perf_test/sparse/KokkosSparse_par_ilut.cpp
+++ b/perf_test/sparse/KokkosSparse_par_ilut.cpp
@@ -126,7 +126,7 @@ void run_par_ilut_test(benchmark::State& state, KernelHandle& kh, const sp_matri
 
 #ifdef USE_GINKGO
 ///////////////////////////////////////////////////////////////////////////////
-static constexpr bool IS_GPU = KokkosKernels::Impl::kk_is_gpu_exec_space<exe_space>();
+static constexpr bool IS_GPU = KokkosKernels::Impl::is_gpu_exec_space_v<exe_space>;
 
 using ginkgo_exec = std::conditional_t<IS_GPU, gko::CudaExecutor, gko::OmpExecutor>;
 
@@ -277,7 +277,7 @@ int test_par_ilut_perf(const std::string& matrix_file, int rows, int nnz_per_row
 
   // Now that we have A, we can set team_size
   if (team_size == -1) {
-    team_size = KokkosKernels::Impl::kk_is_gpu_exec_space<exe_space>() ? nnz_per_row : 1;
+    team_size = KokkosKernels::Impl::is_gpu_exec_space_v<exe_space> ? nnz_per_row : 1;
   }
 
   KokkosSparse::sort_crs_matrix(A);

--- a/sparse/impl/KokkosSparse_bspgemm_impl.hpp
+++ b/sparse/impl/KokkosSparse_bspgemm_impl.hpp
@@ -91,7 +91,7 @@ class KokkosBSPGEMM : public KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_v
   static constexpr size_t scalarAlignPad =
       (alignof(scalar_t) > alignof(nnz_lno_t)) ? (alignof(scalar_t) - alignof(nnz_lno_t)) : 0;
 
-  static constexpr bool exec_gpu = KokkosKernels::Impl::kk_is_gpu_exec_space<MyExecSpace>();
+  static constexpr bool exec_gpu = KokkosKernels::Impl::is_gpu_exec_space_v<MyExecSpace>;
 
  private:
   nnz_lno_t block_dim;

--- a/sparse/impl/KokkosSparse_bspgemm_impl_kkmem.hpp
+++ b/sparse/impl/KokkosSparse_bspgemm_impl_kkmem.hpp
@@ -1063,7 +1063,7 @@ void KokkosBSPGEMM<
 
   // choose parameters
   if (this->spgemm_algorithm == SPGEMM_KK || SPGEMM_KK_LP == this->spgemm_algorithm) {
-    if (KokkosKernels::Impl::kk_is_gpu_exec_space<MyExecSpace>()) {
+    if (KokkosKernels::Impl::is_gpu_exec_space_v<MyExecSpace>) {
       // then chose the best method and parameters.
       size_type average_row_nnz = 0;
       size_t average_row_flops  = 0;
@@ -1201,7 +1201,7 @@ void KokkosBSPGEMM<
   // END OF SHARED MEMORY SIZE CALCULATIONS
 
   // required memory for L2
-  if (KokkosKernels::Impl::kk_is_gpu_exec_space<typename HandleType::HandleExecSpace>()) {
+  if (KokkosKernels::Impl::is_gpu_exec_space_v<typename HandleType::HandleExecSpace>) {
     if (algorithm_to_run == SPGEMM_KK_MEMORY_SPREADTEAM) {
       tmp_max_nnz = 1;
     } else if (algorithm_to_run == SPGEMM_KK_MEMORY_BIGSPREADTEAM) {
@@ -1251,7 +1251,7 @@ void KokkosBSPGEMM<
 
   KokkosKernels::Impl::PoolType my_pool_type = KokkosKernels::Impl::OneThread2OneChunk;
 
-  if (KokkosKernels::Impl::kk_is_gpu_exec_space<MyExecSpace>()) {
+  if (KokkosKernels::Impl::is_gpu_exec_space_v<MyExecSpace>) {
     my_pool_type = KokkosKernels::Impl::ManyThread2OneChunk;
   }
 
@@ -1282,7 +1282,7 @@ void KokkosBSPGEMM<
   }
   timer1.reset();
 
-  if (KokkosKernels::Impl::kk_is_gpu_exec_space<MyExecSpace>()) {
+  if (KokkosKernels::Impl::is_gpu_exec_space_v<MyExecSpace>) {
     if (algorithm_to_run == SPGEMM_KK_MEMORY_SPREADTEAM) {
       if (thread_shmem_key_size <= 0) {
         std::cout << "KokkosBSPGEMM_numeric_hash SPGEMM_KK_MEMORY_SPREADTEAM: "

--- a/sparse/impl/KokkosSparse_bspgemm_impl_speed.hpp
+++ b/sparse/impl/KokkosSparse_bspgemm_impl_speed.hpp
@@ -451,7 +451,7 @@ void KokkosBSPGEMM<
 
   Kokkos::Timer numeric_speed_timer_with_free;
 
-  if (KokkosKernels::Impl::kk_is_gpu_exec_space<typename HandleType::HandleExecSpace>()) {
+  if (KokkosKernels::Impl::is_gpu_exec_space_v<typename HandleType::HandleExecSpace>) {
     // allocate memory for begins and next to be used by the hashmap
     nnz_lno_temp_work_view_t beginsC(Kokkos::view_alloc(Kokkos::WithoutInitializing, "C keys"), valuesC_.extent(0));
     nnz_lno_temp_work_view_t nextsC(Kokkos::view_alloc(Kokkos::WithoutInitializing, "C nexts"), valuesC_.extent(0));

--- a/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
+++ b/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
@@ -514,7 +514,7 @@ class PointGaussSeidel {
             });
 
 #if KOKKOSSPARSE_IMPL_PRINTDEBUG
-            if (!KokkosKernels::Impl::kk_is_gpu_exec_space<typename team_member_t::execution_space>() &&
+            if (!KokkosKernels::Impl::is_gpu_exec_space_v<typename team_member_t::execution_space> &&
                 (ii == 0 || (block_size == 1 && ii < 2))) {
               std::cout << "\n\n\nrow:" << ii * block_size + i;
               std::cout << "\nneighbors:";
@@ -897,7 +897,7 @@ class PointGaussSeidel {
       nnz_lno_t num_values_in_l2 = 0;
       nnz_lno_t num_big_rows     = 0;
 
-      if (!KokkosKernels::Impl::kk_is_gpu_exec_space<MyExecSpace>()) {
+      if (!KokkosKernels::Impl::is_gpu_exec_space_v<MyExecSpace>) {
         // again, if it is on CPUs, we make L1 as big as we need.
         size_t l1mem = 1;
         while (l1mem < level_1_mem) {
@@ -937,7 +937,7 @@ class PointGaussSeidel {
               KOKKOSKERNELS_MACRO_MIN(num_large_rows, (size_type)(my_exec_space.concurrency() / suggested_vector_size));
           // std::cout << "num_big_rows:" << num_big_rows << std::endl;
 
-          if (KokkosKernels::Impl::kk_is_gpu_exec_space<MyExecSpace>()) {
+          if (KokkosKernels::Impl::is_gpu_exec_space_v<MyExecSpace>) {
             // check if we have enough memory for this. lower the concurrency if
             // we do not have enugh memory.
             size_t free_byte;
@@ -1208,7 +1208,7 @@ class PointGaussSeidel {
       // this!!!!!!!!!!!!!!!!!! change fill_matrix_numeric so that they store
       // the internal matrix as above. the rest will wok fine.
 
-      if (KokkosKernels::Impl::kk_is_gpu_exec_space<MyExecSpace>()) {
+      if (KokkosKernels::Impl::is_gpu_exec_space_v<MyExecSpace>) {
         Kokkos::parallel_for("KokkosSparse::GaussSeidel::Team_fill_matrix_numeric",
                              team_policy_t(my_exec_space, (num_rows + rows_per_team - 1) / rows_per_team,
                                            suggested_team_size, suggested_vector_size),
@@ -1239,7 +1239,7 @@ class PointGaussSeidel {
         Get_Matrix_Diagonals gmd(newxadj_, newadj_, permuted_adj_vals, permuted_inverse_diagonal, this->num_rows,
                                  rows_per_team, block_size, block_matrix_size);
 
-        if (KokkosKernels::Impl::kk_is_gpu_exec_space<MyExecSpace>() || block_size > 1) {
+        if (KokkosKernels::Impl::is_gpu_exec_space_v<MyExecSpace> || block_size > 1) {
           Kokkos::parallel_for("KokkosSparse::GaussSeidel::team_get_matrix_diagonals",
                                team_policy_t(my_exec_space, (num_rows + rows_per_team - 1) / rows_per_team,
                                              suggested_team_size, suggested_vector_size),

--- a/sparse/impl/KokkosSparse_spadd_symbolic_impl.hpp
+++ b/sparse/impl/KokkosSparse_spadd_symbolic_impl.hpp
@@ -342,7 +342,7 @@ template <typename execution_space, typename KernelHandle, typename alno_row_vie
 void runSortedCountEntries(
     const execution_space& exec, const alno_row_view_t_& a_rowmap, const alno_nnz_view_t_& a_entries,
     const blno_row_view_t_& b_rowmap, const blno_nnz_view_t_& b_entries, const clno_row_view_t_& c_rowmap,
-    typename std::enable_if<!KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>()>::type* = nullptr) {
+    typename std::enable_if<!KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>>::type* = nullptr) {
   using size_type    = typename KernelHandle::size_type;
   using ordinal_type = typename KernelHandle::nnz_lno_t;
   using range_type   = Kokkos::RangePolicy<execution_space>;
@@ -361,7 +361,7 @@ template <typename execution_space, typename KernelHandle, typename alno_row_vie
 void runSortedCountEntries(
     const execution_space& exec, const alno_row_view_t_& a_rowmap, const alno_nnz_view_t_& a_entries,
     const blno_row_view_t_& b_rowmap, const blno_nnz_view_t_& b_entries, const clno_row_view_t_& c_rowmap,
-    typename std::enable_if<KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>()>::type* = nullptr) {
+    typename std::enable_if<KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>>::type* = nullptr) {
   using size_type     = typename KernelHandle::size_type;
   using ordinal_type  = typename KernelHandle::nnz_lno_t;
   using RangePol      = Kokkos::RangePolicy<execution_space>;

--- a/sparse/impl/KokkosSparse_spgemm_impl.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl.hpp
@@ -650,7 +650,7 @@ class KokkosSPGEMM {
   // chunk (no contention)
   template <typename Pool>
   size_t compute_num_pool_chunks(size_t chunk_bytes, size_t ideal_num_chunks) {
-    if (!KokkosKernels::Impl::kk_is_gpu_exec_space<typename Pool::execution_space>()) return ideal_num_chunks;
+    if (!KokkosKernels::Impl::is_gpu_exec_space_v<typename Pool::execution_space>) return ideal_num_chunks;
     size_t free_byte, total_byte;
     KokkosKernels::Impl::kk_get_free_total_memory<typename Pool::memory_space>(free_byte, total_byte);
     size_t required_size = ideal_num_chunks * chunk_bytes;

--- a/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
@@ -652,7 +652,7 @@ bool KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_vie
                                                                            bool compress_in_single_step) {
   // get the execution space type.
   KokkosKernels::Impl::ExecSpaceType lcl_my_exec_space = this->handle->get_handle_exec_space();
-  constexpr bool exec_gpu                              = KokkosKernels::Impl::kk_is_gpu_exec_space<MyExecSpace>();
+  constexpr bool exec_gpu                              = KokkosKernels::Impl::is_gpu_exec_space_v<MyExecSpace>;
   // get the suggested vectorlane size based on the execution space, and average
   // number of nnzs per row.
   int suggested_vector_size = this->handle->get_suggested_vector_size(n, nnz);
@@ -723,7 +723,7 @@ bool KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_vie
 
   timer1.reset();
   // bool compression_applied = false;
-  if (KokkosKernels::Impl::kk_is_gpu_exec_space<typename HandleType::HandleExecSpace>()) {
+  if (KokkosKernels::Impl::is_gpu_exec_space_v<typename HandleType::HandleExecSpace>) {
 #ifndef KOKKOSKERNELSMOREMEM
     size_type max_row_nnz = 0;
     KokkosKernels::Impl::view_reduce_maxsizerow<in_row_view_t, MyExecSpace>(n, in_row_map, max_row_nnz);

--- a/sparse/impl/KokkosSparse_spgemm_impl_def.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_def.hpp
@@ -60,7 +60,7 @@ void KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_vie
 
     bool compress_in_single_step = this->handle->get_spgemm_handle()->get_compression_step();
     // compress in single step if it is GPU.
-    if (KokkosKernels::Impl::kk_is_gpu_exec_space<MyExecSpace>()) compress_in_single_step = true;
+    if (KokkosKernels::Impl::is_gpu_exec_space_v<MyExecSpace>) compress_in_single_step = true;
 
     // compressed B fields.
     row_lno_temp_work_view_t new_row_mapB(Kokkos::view_alloc(Kokkos::WithoutInitializing, "new row map"), n + 1);

--- a/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
@@ -1169,7 +1169,7 @@ void KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_vie
 
   // choose parameters
   if (this->spgemm_algorithm == SPGEMM_KK || SPGEMM_KK_LP == this->spgemm_algorithm) {
-    if (KokkosKernels::Impl::kk_is_gpu_exec_space<MyExecSpace>()) {
+    if (KokkosKernels::Impl::is_gpu_exec_space_v<MyExecSpace>) {
       // then chose the best method and parameters.
       size_type average_row_nnz = 0;
       size_t average_row_flops  = 0;
@@ -1308,7 +1308,7 @@ void KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_vie
   // END OF SHARED MEMORY SIZE CALCULATIONS
 
   // required memory for L2
-  if (KokkosKernels::Impl::kk_is_gpu_exec_space<typename HandleType::HandleExecSpace>()) {
+  if (KokkosKernels::Impl::is_gpu_exec_space_v<typename HandleType::HandleExecSpace>) {
     if (algorithm_to_run == SPGEMM_KK_MEMORY_SPREADTEAM) {
       tmp_max_nnz = 1;
     } else if (algorithm_to_run == SPGEMM_KK_MEMORY_BIGSPREADTEAM) {
@@ -1358,7 +1358,7 @@ void KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_vie
 
   KokkosKernels::Impl::PoolType my_pool_type = KokkosKernels::Impl::OneThread2OneChunk;
 
-  if (KokkosKernels::Impl::kk_is_gpu_exec_space<MyExecSpace>()) {
+  if (KokkosKernels::Impl::is_gpu_exec_space_v<MyExecSpace>) {
     my_pool_type = KokkosKernels::Impl::ManyThread2OneChunk;
   }
 
@@ -1390,7 +1390,7 @@ void KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_vie
   }
   timer1.reset();
 
-  if (KokkosKernels::Impl::kk_is_gpu_exec_space<MyExecSpace>()) {
+  if (KokkosKernels::Impl::is_gpu_exec_space_v<MyExecSpace>) {
     if (algorithm_to_run == SPGEMM_KK_MEMORY_SPREADTEAM) {
       if (thread_shmem_key_size <= 0) {
         std::cout << "KokkosSPGEMM_numeric_hash SPGEMM_KK_MEMORY_SPREADTEAM: "
@@ -1516,7 +1516,7 @@ void KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_vie
   }
 
   KokkosKernels::Impl::PoolType my_pool_type = KokkosKernels::Impl::OneThread2OneChunk;
-  if (KokkosKernels::Impl::kk_is_gpu_exec_space<my_exec_space>()) {
+  if (KokkosKernels::Impl::is_gpu_exec_space_v<my_exec_space>) {
     my_pool_type = KokkosKernels::Impl::ManyThread2OneChunk;
   }
 
@@ -1548,7 +1548,7 @@ void KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_vie
   }
   timer1.reset();
 
-  if (KokkosKernels::Impl::kk_is_gpu_exec_space<my_exec_space>()) {
+  if (KokkosKernels::Impl::is_gpu_exec_space_v<my_exec_space>) {
     Kokkos::parallel_for(
         "KOKKOSPARSE::SPGEMM::SPGEMM_KK_MEMORY2",
         gpu_team_policy_t(a_row_cnt / team_row_chunk_size + 1, suggested_team_size, suggested_vector_size), sc);

--- a/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
@@ -428,7 +428,7 @@ void KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_vie
 
   Kokkos::Timer numeric_speed_timer_with_free;
 
-  if (KokkosKernels::Impl::kk_is_gpu_exec_space<typename HandleType::HandleExecSpace>()) {
+  if (KokkosKernels::Impl::is_gpu_exec_space_v<typename HandleType::HandleExecSpace>) {
     // allocate memory for begins and next to be used by the hashmap
     nnz_lno_temp_work_view_t beginsC(Kokkos::view_alloc(Kokkos::WithoutInitializing, "C keys"), valuesC_.extent(0));
     nnz_lno_temp_work_view_t nextsC(Kokkos::view_alloc(Kokkos::WithoutInitializing, "C nexts"), valuesC_.extent(0));

--- a/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
@@ -1281,7 +1281,7 @@ void KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_vie
                                                                    b_nnz_view_t entriesb_, c_row_view_t rowmapC,
                                                                    nnz_lno_t maxNumRoughNonzeros) {
   SPGEMMAlgorithm current_spgemm_algorithm             = this->spgemm_algorithm;
-  constexpr bool exec_gpu                              = KokkosKernels::Impl::kk_is_gpu_exec_space<MyExecSpace>();
+  constexpr bool exec_gpu                              = KokkosKernels::Impl::is_gpu_exec_space_v<MyExecSpace>;
   KokkosKernels::Impl::ExecSpaceType lcl_my_exec_space = this->handle->get_handle_exec_space();
   if (exec_gpu) {
     current_spgemm_algorithm = SPGEMM_KK_MEMORY;
@@ -1523,7 +1523,7 @@ void KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_vie
                                                                        c_row_view_t rowmapC,
                                                                        nnz_lno_t maxNumRoughNonzeros) {
   SPGEMMAlgorithm current_spgemm_algorithm = this->spgemm_algorithm;
-  constexpr bool exec_gpu = KokkosKernels::Impl::kk_is_gpu_exec_space<typename HandleType::HandleExecSpace>();
+  constexpr bool exec_gpu = KokkosKernels::Impl::is_gpu_exec_space_v<typename HandleType::HandleExecSpace>;
   KokkosKernels::Impl::ExecSpaceType lcl_my_exec_space = this->handle->get_handle_exec_space();
   if (exec_gpu) {
     current_spgemm_algorithm = SPGEMM_KK_MEMORY;

--- a/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_triangle.hpp
@@ -1165,7 +1165,7 @@ void KokkosSPGEMM<
                                              nnz_lno_t *entriesC,  // null if it is symbolic, otherwise not null!
                                              struct_visit_t visit_applier) {
   bool apply_compression  = this->handle->get_spgemm_handle()->get_compression();
-  constexpr bool exec_gpu = KokkosKernels::Impl::kk_is_gpu_exec_space<MyExecSpace>();
+  constexpr bool exec_gpu = KokkosKernels::Impl::is_gpu_exec_space_v<MyExecSpace>;
 
   const nnz_lno_t *min_result_row_for_each_row = this->handle->get_spgemm_handle()->get_min_col_of_row().data();
   nnz_lno_t max_row_size                       = this->handle->get_spgemm_handle()->get_max_result_nnz(
@@ -1468,7 +1468,7 @@ template <typename HandleType, typename a_row_view_t_, typename a_lno_nnz_view_t
           typename b_lno_row_view_t_, typename b_lno_nnz_view_t_, typename b_scalar_nnz_view_t_>
 void KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_view_t_, b_lno_row_view_t_,
                   b_lno_nnz_view_t_, b_scalar_nnz_view_t_>::KokkosSPGEMM_symbolic_triangle_setup() {
-  constexpr bool exec_gpu = KokkosKernels::Impl::kk_is_gpu_exec_space<MyExecSpace>();
+  constexpr bool exec_gpu = KokkosKernels::Impl::is_gpu_exec_space_v<MyExecSpace>;
   nnz_lno_t n             = this->row_mapB.extent(0) - 1;
   size_type nnz           = this->entriesB.extent(0);
 

--- a/sparse/impl/KokkosSparse_spgemm_impl_triangle_no_compression.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_triangle_no_compression.hpp
@@ -778,7 +778,7 @@ void KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_vie
   const int num_left_side_nnz_per_row          = 2;
   const nnz_lno_t *min_result_row_for_each_row = this->handle->get_spgemm_handle()->get_min_col_of_row().data();
   nnz_lno_t max_row_size                       = this->handle->get_spgemm_handle()->get_max_result_nnz();
-  constexpr bool exec_gpu                      = KokkosKernels::Impl::kk_is_gpu_exec_space<MyExecSpace>();
+  constexpr bool exec_gpu                      = KokkosKernels::Impl::is_gpu_exec_space_v<MyExecSpace>;
 
   typedef KokkosKernels::Impl::UniformMemoryPool<MyTempMemorySpace, nnz_lno_t> pool_memory_space;
   int suggested_vector_size = this->handle->get_suggested_vector_size(this->b_row_cnt, bnnz);

--- a/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
@@ -1088,7 +1088,7 @@ void KokkosSPGEMM<
                                                          dinv_view_t dinv,
                                                          KokkosKernels::Impl::ExecSpaceType lcl_my_exec_space) {
   using pool_memory_space = KokkosKernels::Impl::UniformMemoryPool<MyTempMemorySpace, nnz_lno_t>;
-  constexpr bool exec_gpu = KokkosKernels::Impl::kk_is_gpu_exec_space<MyExecSpace>();
+  constexpr bool exec_gpu = KokkosKernels::Impl::is_gpu_exec_space_v<MyExecSpace>;
   if (KOKKOSKERNELS_VERBOSE) {
     std::cout << "\tSPARSE ACC MODE" << std::endl;
   }

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_impl.hpp
@@ -589,7 +589,7 @@ struct BSR_GEMV_Functor {
 //
 template <class Handle, class AT, class AO, class AD, class AS, class AlphaType, class XVector, class BetaType,
           class YVector,
-          typename std::enable_if<!KokkosKernels::Impl::kk_is_gpu_exec_space<typename YVector::execution_space>()>::type
+          typename std::enable_if<!KokkosKernels::Impl::is_gpu_exec_space_v<typename YVector::execution_space>>::type
               * = nullptr>
 void spMatVec_no_transpose(
     const typename AD::execution_space &exec, Handle *handle, const AlphaType &alpha,
@@ -636,8 +636,8 @@ void spMatVec_no_transpose(
 //
 template <class Handle, class AT, class AO, class AD, class AS, class AlphaType, class XVector, class BetaType,
           class YVector,
-          typename std::enable_if<KokkosKernels::Impl::kk_is_gpu_exec_space<typename YVector::execution_space>()>::type
-              * = nullptr>
+          typename std::enable_if<KokkosKernels::Impl::is_gpu_exec_space_v<typename YVector::execution_space>>::type * =
+              nullptr>
 void spMatVec_no_transpose(
     const typename AD::execution_space &exec, Handle *handle, const AlphaType &alpha,
     const KokkosSparse::Experimental::BsrMatrix<AT, AO, AD, Kokkos::MemoryTraits<Kokkos::Unmanaged>, AS> &A,
@@ -839,7 +839,7 @@ struct BSR_GEMV_Transpose_Functor {
 /// trivial serial impl used)
 template <class Handle, class AT, class AO, class AD, class AS, class AlphaType, class XVector, class BetaType,
           class YVector,
-          typename std::enable_if<!KokkosKernels::Impl::kk_is_gpu_exec_space<typename YVector::execution_space>()>::type
+          typename std::enable_if<!KokkosKernels::Impl::is_gpu_exec_space_v<typename YVector::execution_space>>::type
               * = nullptr>
 void spMatVec_transpose(
     const typename AD::execution_space &exec, Handle *handle, const AlphaType &alpha,
@@ -885,8 +885,8 @@ void spMatVec_transpose(
 // spMatVec_transpose: version for GPU execution spaces (TeamPolicy used)
 //
 template <class Handle, class AMatrix, class AlphaType, class XVector, class BetaType, class YVector,
-          typename std::enable_if<KokkosKernels::Impl::kk_is_gpu_exec_space<typename YVector::execution_space>()>::type
-              * = nullptr>
+          typename std::enable_if<KokkosKernels::Impl::is_gpu_exec_space_v<typename YVector::execution_space>>::type * =
+              nullptr>
 void spMatVec_transpose(const typename AMatrix::execution_space &exec, Handle *handle, const AlphaType &alpha,
                         const AMatrix &A, const XVector &x, const BetaType &beta, YVector &y, bool useConjugate) {
   if (A.numRows() <= 0) {
@@ -1093,7 +1093,7 @@ struct BSR_GEMM_Functor {
 //
 template <class Handle, class AT, class AO, class AD, class AS, class AlphaType, class XVector, class BetaType,
           class YVector,
-          typename std::enable_if<!KokkosKernels::Impl::kk_is_gpu_exec_space<typename YVector::execution_space>()>::type
+          typename std::enable_if<!KokkosKernels::Impl::is_gpu_exec_space_v<typename YVector::execution_space>>::type
               * = nullptr>
 void spMatMultiVec_no_transpose(
     const typename AD::execution_space &exec, Handle *handle, const AlphaType &alpha,
@@ -1139,8 +1139,8 @@ void spMatMultiVec_no_transpose(
 //
 template <class Handle, class AT, class AO, class AD, class AS, class AlphaType, class XVector, class BetaType,
           class YVector,
-          typename std::enable_if<KokkosKernels::Impl::kk_is_gpu_exec_space<typename YVector::execution_space>()>::type
-              * = nullptr>
+          typename std::enable_if<KokkosKernels::Impl::is_gpu_exec_space_v<typename YVector::execution_space>>::type * =
+              nullptr>
 void spMatMultiVec_no_transpose(
     const typename AD::execution_space &exec, Handle *handle, const AlphaType &alpha,
     const KokkosSparse::Experimental::BsrMatrix<AT, AO, AD, Kokkos::MemoryTraits<Kokkos::Unmanaged>, AS> &A,
@@ -1352,7 +1352,7 @@ struct BSR_GEMM_Transpose_Functor {
 /// (RangePolicy or trivial serial impl used)
 template <class execution_space, class Handle, class AT, class AO, class AD, class AS, class AlphaType, class XVector,
           class BetaType, class YVector,
-          typename std::enable_if<!KokkosKernels::Impl::kk_is_gpu_exec_space<typename YVector::execution_space>()>::type
+          typename std::enable_if<!KokkosKernels::Impl::is_gpu_exec_space_v<typename YVector::execution_space>>::type
               * = nullptr>
 void spMatMultiVec_transpose(
     const execution_space &exec, Handle *handle, const AlphaType &alpha,
@@ -1391,7 +1391,7 @@ void spMatMultiVec_transpose(
 //
 template <class execution_space, class Handle, class AMatrix, class AlphaType, class XVector, class BetaType,
           class YVector,
-          typename std::enable_if<KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>()>::type * = nullptr>
+          typename std::enable_if<KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>>::type * = nullptr>
 void spMatMultiVec_transpose(const execution_space &exec, Handle *handle, const AlphaType &alpha, const AMatrix &A,
                              const XVector &x, const BetaType &beta, YVector &y, bool useConjugate) {
   if (A.numRows() <= 0) {

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -134,7 +134,7 @@ struct SPMV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector, false, 
     }
 
     // use V42 if possible
-    if (KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>() || handle->algo == SPMV_BSR_V42) {
+    if (KokkosKernels::Impl::is_gpu_exec_space_v<ExecutionSpace> || handle->algo == SPMV_BSR_V42) {
       if (modeIsNoTrans) {
         ::KokkosSparse::Impl::apply_v42(space, alpha, A, X, beta, Y);
         return;
@@ -258,7 +258,7 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector, fals
     }
 
     // use V42 if possible
-    if (KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>() || handle->algo == SPMV_BSR_V42) {
+    if (KokkosKernels::Impl::is_gpu_exec_space_v<ExecutionSpace> || handle->algo == SPMV_BSR_V42) {
       if (modeIsNoTrans) {
         ::KokkosSparse::Impl::apply_v42(space, alpha, A, X, beta, Y);
         return;

--- a/sparse/impl/KokkosSparse_spmv_impl.hpp
+++ b/sparse/impl/KokkosSparse_spmv_impl.hpp
@@ -187,7 +187,7 @@ int64_t spmv_launch_parameters(int64_t numRows, int64_t nnz, int64_t rows_per_th
 
   // Determine rows per thread
   if (rows_per_thread < 1) {
-    if (KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>())
+    if (KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>)
       rows_per_thread = 1;
     else {
       if (nnz_per_row < 20 && nnz > 5000000) {
@@ -198,7 +198,7 @@ int64_t spmv_launch_parameters(int64_t numRows, int64_t nnz, int64_t rows_per_th
   }
 
   if (team_size < 1) {
-    if (KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>()) {
+    if (KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>) {
       team_size = 256 / vector_length;
     } else {
       team_size = 1;
@@ -220,7 +220,7 @@ int64_t spmv_launch_parameters(int64_t numRows, int64_t nnz, int64_t rows_per_th
 // spmv_beta_no_transpose: version for CPU execution spaces (RangePolicy or
 // trivial serial impl used)
 template <class execution_space, class Handle, class AMatrix, class XVector, class YVector, int dobeta, bool conjugate,
-          typename std::enable_if<!KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>()>::type* = nullptr>
+          typename std::enable_if<!KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>>::type* = nullptr>
 static void spmv_beta_no_transpose(const execution_space& exec, Handle* handle,
                                    typename YVector::const_value_type& alpha, const AMatrix& A, const XVector& x,
                                    typename YVector::const_value_type& beta, const YVector& y) {
@@ -334,7 +334,7 @@ static void spmv_beta_no_transpose(const execution_space& exec, Handle* handle,
 
 // spmv_beta_no_transpose: version for GPU execution spaces (TeamPolicy used)
 template <class execution_space, class Handle, class AMatrix, class XVector, class YVector, int dobeta, bool conjugate,
-          typename std::enable_if<KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>()>::type* = nullptr>
+          typename std::enable_if<KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>>::type* = nullptr>
 static void spmv_beta_no_transpose(const execution_space& exec, Handle* handle,
                                    typename YVector::const_value_type& alpha, const AMatrix& A, const XVector& x,
                                    typename YVector::const_value_type& beta, const YVector& y) {
@@ -380,7 +380,7 @@ static void spmv_beta_no_transpose(const execution_space& exec, Handle* handle,
 // spmv_beta_transpose: version for CPU execution spaces (RangePolicy or trivial
 // serial impl used)
 template <class execution_space, class AMatrix, class XVector, class YVector, int dobeta, bool conjugate,
-          typename std::enable_if<!KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>()>::type* = nullptr>
+          typename std::enable_if<!KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>>::type* = nullptr>
 static void spmv_beta_transpose(const execution_space& exec, typename YVector::const_value_type& alpha,
                                 const AMatrix& A, const XVector& x, typename YVector::const_value_type& beta,
                                 const YVector& y) {
@@ -460,7 +460,7 @@ static void spmv_beta_transpose(const execution_space& exec, typename YVector::c
 
 // spmv_beta_transpose: version for GPU execution spaces (TeamPolicy used)
 template <class execution_space, class AMatrix, class XVector, class YVector, int dobeta, bool conjugate,
-          typename std::enable_if<KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>()>::type* = nullptr>
+          typename std::enable_if<KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>>::type* = nullptr>
 static void spmv_beta_transpose(const execution_space& exec, typename YVector::const_value_type& alpha,
                                 const AMatrix& A, const XVector& x, typename YVector::const_value_type& beta,
                                 const YVector& y) {
@@ -1005,7 +1005,7 @@ struct SPMV_MV_LayoutLeft_Functor {
 // spmv_alpha_beta_mv_no_transpose: version for CPU execution spaces
 // (RangePolicy)
 template <class execution_space, class AMatrix, class XVector, class YVector, int doalpha, int dobeta, bool conjugate,
-          typename std::enable_if<!KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>()>::type* = nullptr>
+          typename std::enable_if<!KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>>::type* = nullptr>
 static void spmv_alpha_beta_mv_no_transpose(const execution_space& exec,
                                             const typename YVector::non_const_value_type& alpha, const AMatrix& A,
                                             const XVector& x, const typename YVector::non_const_value_type& beta,
@@ -1054,7 +1054,7 @@ static void spmv_alpha_beta_mv_no_transpose(const execution_space& exec,
 // spmv_alpha_beta_mv_no_transpose: version for GPU execution spaces
 // (TeamPolicy)
 template <class execution_space, class AMatrix, class XVector, class YVector, int doalpha, int dobeta, bool conjugate,
-          typename std::enable_if<KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>()>::type* = nullptr>
+          typename std::enable_if<KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>>::type* = nullptr>
 static void spmv_alpha_beta_mv_no_transpose(const execution_space& exec,
                                             const typename YVector::non_const_value_type& alpha, const AMatrix& A,
                                             const XVector& x, const typename YVector::non_const_value_type& beta,
@@ -1119,7 +1119,7 @@ static void spmv_alpha_beta_mv_no_transpose(const execution_space& exec,
 
 // spmv_alpha_beta_mv_transpose: version for CPU execution spaces (RangePolicy)
 template <class execution_space, class AMatrix, class XVector, class YVector, int doalpha, int dobeta, bool conjugate,
-          typename std::enable_if<!KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>()>::type* = nullptr>
+          typename std::enable_if<!KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>>::type* = nullptr>
 static void spmv_alpha_beta_mv_transpose(const execution_space& exec,
                                          const typename YVector::non_const_value_type& alpha, const AMatrix& A,
                                          const XVector& x, const typename YVector::non_const_value_type& beta,
@@ -1160,7 +1160,7 @@ static void spmv_alpha_beta_mv_transpose(const execution_space& exec,
 
 // spmv_alpha_beta_mv_transpose: version for GPU execution spaces (TeamPolicy)
 template <class execution_space, class AMatrix, class XVector, class YVector, int doalpha, int dobeta, bool conjugate,
-          typename std::enable_if<KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>()>::type* = nullptr>
+          typename std::enable_if<KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>>::type* = nullptr>
 static void spmv_alpha_beta_mv_transpose(const execution_space& exec,
                                          const typename YVector::non_const_value_type& alpha, const AMatrix& A,
                                          const XVector& x, const typename YVector::non_const_value_type& beta,

--- a/sparse/impl/KokkosSparse_spmv_impl_merge.hpp
+++ b/sparse/impl/KokkosSparse_spmv_impl_merge.hpp
@@ -291,7 +291,7 @@ struct SpmvMergeHierarchical {
     const A_size_type pathLength = A.numRows() + A.nnz();
     A_size_type pathLengthThreadChunk;
     int teamSize;
-    if constexpr (KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>()) {
+    if constexpr (KokkosKernels::Impl::is_gpu_exec_space_v<ExecutionSpace>) {
       pathLengthThreadChunk = 4;
       teamSize              = 128;
     } else {
@@ -315,7 +315,7 @@ struct SpmvMergeHierarchical {
       using GpuOp         = SpmvMergeImplFunctor<true, true, false, CONJ>;
       using CpuOp         = SpmvMergeImplFunctor<false, false, false, CONJ>;
       using Op =
-          typename std::conditional<KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>(), GpuOp, CpuOp>::type;
+          typename std::conditional<KokkosKernels::Impl::is_gpu_exec_space_v<ExecutionSpace>, GpuOp, CpuOp>::type;
       Op op(alpha, A, x, y, pathLengthThreadChunk);
       Kokkos::parallel_for("SpmvMergeHierarchical::spmv", policy, op);
     } else if (KokkosSparse::Conjugate[0] == mode[0]) {
@@ -323,7 +323,7 @@ struct SpmvMergeHierarchical {
       using GpuOp         = SpmvMergeImplFunctor<true, true, false, CONJ>;
       using CpuOp         = SpmvMergeImplFunctor<false, false, false, CONJ>;
       using Op =
-          typename std::conditional<KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>(), GpuOp, CpuOp>::type;
+          typename std::conditional<KokkosKernels::Impl::is_gpu_exec_space_v<ExecutionSpace>, GpuOp, CpuOp>::type;
       Op op(alpha, A, x, y, pathLengthThreadChunk);
       Kokkos::parallel_for("SpmvMergeHierarchical::spmv", policy, op);
     } else {

--- a/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
+++ b/sparse/impl/KokkosSparse_spmv_struct_impl.hpp
@@ -617,7 +617,7 @@ int64_t spmv_struct_launch_parameters(int64_t numInterior, int64_t nnz, int nnz_
 
   // Determine rows per thread
   if (rows_per_thread < 1) {
-    if (KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>())
+    if (KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>)
       rows_per_thread = 1;
     else {
       if (nnz_per_row < 20 && numInterior * nnz_per_row > 5000000) {
@@ -628,7 +628,7 @@ int64_t spmv_struct_launch_parameters(int64_t numInterior, int64_t nnz, int nnz_
   }
 
   if (team_size < 1) {
-    if (KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>()) {
+    if (KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>) {
       team_size = 128 / vector_length;
     } else {
       team_size = 1;

--- a/sparse/src/KokkosSparse_SortCrs.hpp
+++ b/sparse/src/KokkosSparse_SortCrs.hpp
@@ -63,7 +63,7 @@ void sort_crs_matrix(const execution_space& exec, const rowmap_t& rowmap, const 
     return;
   }
   Ordinal numRows = rowmap.extent(0) ? rowmap.extent(0) - 1 : 0;
-  if constexpr (!KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>()) {
+  if constexpr (!KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>) {
     // On CPUs, use a sequential radix sort within each row.
     Kokkos::parallel_for("sort_crs_matrix[CPU,radix]",
                          Kokkos::RangePolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>(exec, 0, numRows),
@@ -240,7 +240,7 @@ void sort_crs_graph(const execution_space& exec, const rowmap_t& rowmap, const e
   if (entries.extent(0) <= size_t(1)) {
     return;
   }
-  if constexpr (!KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>()) {
+  if constexpr (!KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>) {
     // If on CPU, sort each row independently. Don't need to know numCols for
     // this.
     Kokkos::parallel_for("sort_crs_graph[CPU,radix]",

--- a/sparse/src/KokkosSparse_Utils.hpp
+++ b/sparse/src/KokkosSparse_Utils.hpp
@@ -983,7 +983,7 @@ struct LowerTriangularMatrix {
 
                            // TODO: Write GPU (vector-level) version here:
                            /*
-                           if(kk_is_gpu_exec_space<ExecutionSpace>())
+                           if(is_gpu_exec_space_v<ExecutionSpace>)
                            {
                              Kokkos::parallel_for(
                                  Kokkos::ThreadVectorRange(teamMember, read_left_work),

--- a/sparse/src/KokkosSparse_gauss_seidel_handle.hpp
+++ b/sparse/src/KokkosSparse_gauss_seidel_handle.hpp
@@ -283,7 +283,7 @@ class PointGaussSeidelHandle : public GaussSeidelHandle<size_type_, lno_t_, scal
   nnz_lno_t get_block_size() const { return this->block_size; }
 
   void choose_default_algorithm() {
-    if (KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>())
+    if (KokkosKernels::Impl::is_gpu_exec_space_v<ExecutionSpace>)
       this->algorithm_type = GS_TEAM;
     else
       this->algorithm_type = GS_PERMUTED;
@@ -492,7 +492,7 @@ class ClusterGaussSeidelHandle : public GaussSeidelHandle<size_type_, lno_t_, sc
     return inverse_diagonal;
   }
 
-  bool use_teams() const { return KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>(); }
+  bool use_teams() const { return KokkosKernels::Impl::is_gpu_exec_space_v<ExecutionSpace>; }
 
   ~ClusterGaussSeidelHandle() = default;
 

--- a/sparse/src/KokkosSparse_spgemm_handle.hpp
+++ b/sparse/src/KokkosSparse_spgemm_handle.hpp
@@ -671,7 +671,7 @@ class SPGEMMHandle {
     // them in the handle
     suggested_vector_size_ = KokkosKernels::Impl::kk_get_suggested_vector_size(
         nr, nnz, KokkosKernels::Impl::kk_get_exec_space_type<ExecutionSpace>());
-    if (KokkosKernels::Impl::kk_is_gpu_exec_space<ExecutionSpace>())
+    if (KokkosKernels::Impl::is_gpu_exec_space_v<ExecutionSpace>)
       suggested_team_size_ = max_allowed_team_size / suggested_vector_size_;
     else
       suggested_team_size = max_allowed_team_size;

--- a/sparse/unit_test/Test_Sparse_bspgemm.hpp
+++ b/sparse/unit_test/Test_Sparse_bspgemm.hpp
@@ -169,7 +169,7 @@ void test_bspgemm(lno_t blkDim, lno_t m, lno_t k, lno_t n, size_type nnz, lno_t 
       SPGEMM_KK, SPGEMM_KK_MEMORY /* alias SPGEMM_KK_MEMSPEED */, SPGEMM_KK_SPEED /* alias SPGEMM_KK_DENSE */
   };
 
-  if (!KokkosKernels::Impl::kk_is_gpu_exec_space<typename device::execution_space>()) {
+  if (!KokkosKernels::Impl::is_gpu_exec_space_v<typename device::execution_space>) {
     // SPGEMM_KK_LP is useful on CPU to cover MultiCoreTag4 functor
     // (otherwise skipped) but on GPU it's same as SPGEMM_KK, so we can skip it.
     algorithms.push_back(SPGEMM_KK_LP);

--- a/sparse/unit_test/Test_Sparse_spmv_bsr.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv_bsr.hpp
@@ -366,7 +366,7 @@ void test_spmv_combos(const char *mode, const Bsr &a, const Crs &acrs, size_t ma
 
   // Tensor core algorithm temporarily disabled, fails on V100
   /*
-  if constexpr (KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>()) {
+  if constexpr (KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>) {
 #if defined(KOKKOS_ENABLE_CUDA)
     if constexpr (std::is_same_v<execution_space, Kokkos::Cuda>) {
 #if defined(KOKKOS_ARCH_AMPERE) || defined(KOKKOS_ARCH_VOLTA)
@@ -607,7 +607,7 @@ void test_spm_mv_combos(const char *mode, const Bsr &a, const Crs &acrs, size_t 
 
   // Tensor core algorithm temporarily disabled, fails on V100
   /*
-  if constexpr (KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>()) {
+  if constexpr (KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>) {
 #if defined(KOKKOS_ENABLE_CUDA)
     if constexpr (std::is_same_v<execution_space, Kokkos::Cuda>) {
 #if defined(KOKKOS_ARCH_AMPERE) || defined(KOKKOS_ARCH_VOLTA)


### PR DESCRIPTION
* `kk` prefix is unnecessary because of the `KokkosKernels::Impl` namespace
* replace function with `inline constexpr bool` for simplicity.