### PR TITLE
workflows: fixing some action versions using current sha

### DIFF
--- a/.github/workflows/bdw.yml
+++ b/.github/workflows/bdw.yml
@@ -261,12 +261,12 @@ jobs:
 
     steps:
       - name: checkout_kokkos_kernels
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           path: kokkos-kernels
 
       - name: checkout_kokkos
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           repository: kokkos/kokkos
           ref: ${{ github.base_ref }}

--- a/.github/workflows/mi210.yml
+++ b/.github/workflows/mi210.yml
@@ -13,12 +13,12 @@ jobs:
     
     steps:
       - name: checkout_kokkos_kernels
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           path: kokkos-kernels
 
       - name: checkout_kokkos
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           repository: kokkos/kokkos
           ref: ${{ github.base_ref }}


### PR DESCRIPTION
For some reason depandabot only tried to bump the version without using a sha so I'm switching to sha and hoping it will keep it up to date!