### PR TITLE
gemm perf_test: print matrix sizes

### DIFF
--- a/perf_test/blas/blas3/KokkosBlas3_gemm_standalone_perf_test.cpp
+++ b/perf_test/blas/blas3/KokkosBlas3_gemm_standalone_perf_test.cpp
@@ -103,7 +103,8 @@ template <typename ExecSpace>
 void run(int m, int n, int k, int repeat) {
   using LL = Kokkos::LayoutLeft;
   using LR = Kokkos::LayoutRight;
-  std::cout << "** Running GEMM experiments (" << ExecSpace::name() << ") **\n";
+  std::cout << "** Running GEMM experiments (" << ExecSpace::name() << " m=" << m << " n=" << n << " k=" << k
+            << ") **\n";
   std::cout << "Running: A LayoutLeft, B LayoutLeft  : ";
   runImpl<ExecSpace, LL, LL>(m, n, k, repeat);
   std::cout << "Running: A LayoutLeft, B LayoutRight : ";


### PR DESCRIPTION
Useful information for a performance test to show.