### PR TITLE
workflows: fixing dependency for checkout action in volta70.yml

### DIFF
--- a/.github/workflows/bdw.yml
+++ b/.github/workflows/bdw.yml
@@ -13,12 +13,12 @@ jobs:
 #    
 #    steps:
 #      - name: checkout_kokkos_kernels
-#        uses: actions/checkout@v3
+#        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 #        with:
 #          path: kokkos-kernels
 #
 #      - name: checkout_kokkos
-#        uses: actions/checkout@v3
+#        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 #        with:
 #          repository: kokkos/kokkos
 #          ref: ${{ github.base_ref }}
@@ -94,12 +94,12 @@ jobs:
 #
 #    steps:
 #      - name: checkout_kokkos_kernels
-#        uses: actions/checkout@v3
+#        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 #        with:
 #          path: kokkos-kernels
 #
 #      - name: checkout_kokkos
-#        uses: actions/checkout@v3
+#        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 #        with:
 #          repository: kokkos/kokkos
 #          ref: ${{ github.base_ref }}

--- a/.github/workflows/volta70.yml
+++ b/.github/workflows/volta70.yml
@@ -10,12 +10,12 @@ jobs:
     
     steps:
       - name: checkout_kokkos_kernels
-        uses: actions/checkout@v3
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           path: kokkos-kernels
 
       - name: checkout_kokkos
-        uses: actions/checkout@v3
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           repository: kokkos/kokkos
           ref: 4.4.00
@@ -76,12 +76,12 @@ jobs:
     
     steps:
       - name: checkout_kokkos_kernels
-        uses: actions/checkout@v3
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           path: kokkos-kernels
 
       - name: checkout_kokkos
-        uses: actions/checkout@v3
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           repository: kokkos/kokkos
           ref: 4.4.00


### PR DESCRIPTION
We are pinning the action used by sha to avoid potential security issues.
This showed up in our code scanning alerts: https://github.com/kokkos/kokkos-kernels/security/code-scanning