### PR TITLE
workflows: limit the permissions in volta70 build

### DIFF
--- a/.github/workflows/volta70.yml
+++ b/.github/workflows/volta70.yml
@@ -3,6 +3,9 @@ name: Reusable VOLTA70 workflow
 on:
   workflow_call
 
+permissions:
+  contents: none
+
 jobs:
   PR_VOLTA70_CUDA1122_CUDA_LEFT_RIGHT_REL:
     name: PR_VOLTA70_CUDA1122_CUDA_LEFT_RIGHT_REL


### PR DESCRIPTION
Reducing the permissions keeps the workflow and repository safe from potential malicious deeds.