### PR TITLE
Do not specify template argument when using Kokkos atomics

### DIFF
--- a/common/src/KokkosKernels_HashmapAccumulator.hpp
+++ b/common/src/KokkosKernels_HashmapAccumulator.hpp
@@ -516,7 +516,7 @@ struct HashmapAccumulator {
           Kokkos::atomic_add(values + hash, value);
           return __insert_success;
         } else if (keys[hash] == -1) {
-          if (Kokkos::atomic_compare_exchange_strong<key_type>(keys + hash, -1, key)) {
+          if (Kokkos::atomic_compare_exchange_strong(keys + hash, -1, key)) {
             // should only be here if we used a new hash
             used_hashes[Kokkos::atomic_fetch_add(used_hash_size, size_type(1))] = hash;
             Kokkos::atomic_add(values + hash, value);

--- a/graph/impl/KokkosGraph_Distance1Color_impl.hpp
+++ b/graph/impl/KokkosGraph_Distance1Color_impl.hpp
@@ -2529,7 +2529,7 @@ class GraphColor_EB : public GraphColor<HandleType, in_row_index_view_type_, in_
         if (src_col_set == dest_col_set) {
           // atomic or, as no threads owns 'dst' (neither src)
           nnz_lno_t uncolored_vertex = dst_col ? src_id : dst_id;
-          Kokkos::atomic_fetch_or<color_t>(&(color_ban(uncolored_vertex)), src_col | dst_col);
+          Kokkos::atomic_fetch_or(&(color_ban(uncolored_vertex)), src_col | dst_col);
           edge_conflict_marker(work_index) = 0;
         }
       }
@@ -2616,7 +2616,7 @@ class GraphColor_EB : public GraphColor<HandleType, in_row_index_view_type_, in_
                 // idx smaller_index = src_id;
                 // then both have been colored tentavitely. propoagate the color
                 // of src to dst.
-                Kokkos::atomic_fetch_or<color_t>(&(tentative_color_ban(smaller_index)), -src_col);
+                Kokkos::atomic_fetch_or(&(tentative_color_ban(smaller_index)), -src_col);
                 nnz_lno_t banned_colors  = ~(color_ban(smaller_index) | tentative_color_ban(smaller_index));
                 nnz_lno_t larger_col     = banned_colors & (-banned_colors);
                 kokcolors(smaller_index) = -(larger_col);
@@ -2625,16 +2625,14 @@ class GraphColor_EB : public GraphColor<HandleType, in_row_index_view_type_, in_
               // if src is tentavily colored, and dst is not colored,
               // then we send the color information to dst's tentative_ban.
 
-              // Kokkos::atomic_fetch_or<color_type>(&(color_ban(dst_id)),
-              // -src_col);
-              Kokkos::atomic_fetch_or<color_t>(&(tentative_color_ban(dst_id)), -src_col);
+              // Kokkos::atomic_fetch_or(&(color_ban(dst_id)), -src_col);
+              Kokkos::atomic_fetch_or(&(tentative_color_ban(dst_id)), -src_col);
             } else if (dst_col != 0) {
               // if it is dst tentatively colors, but src is not colored,
               // then we send the dst color info to src's tentative_ban
 
-              // Kokkos::atomic_fetch_or<color_type>(&(color_ban(src_id)),
-              // -dst_col);
-              Kokkos::atomic_fetch_or<color_t>(&(tentative_color_ban(src_id)), -dst_col);
+              // Kokkos::atomic_fetch_or(&(color_ban(src_id)), -dst_col);
+              Kokkos::atomic_fetch_or(&(tentative_color_ban(src_id)), -dst_col);
             } else {
               // idx smaller_index = src_id < dst_id > 0 ? src_id: dst_id;
               // idx larger_index = src_id < dst_id > 0 ? dst_id : src_id;
@@ -2660,9 +2658,8 @@ class GraphColor_EB : public GraphColor<HandleType, in_row_index_view_type_, in_
               // set it to minus of the color, as it is tentative coloring.
               kokcolors(smaller_index) = -(src_col);
               // send the color information to dst's tentative color ban.
-              Kokkos::atomic_fetch_or<color_t>(&(tentative_color_ban(larger_index)), src_col);
-              // Kokkos::atomic_fetch_or<color_type>(&(color_ban(dst_id)),
-              // src_col);
+              Kokkos::atomic_fetch_or(&(tentative_color_ban(larger_index)), src_col);
+              // Kokkos::atomic_fetch_or(&(color_ban(dst_id)), src_col);
             }
           }
         }

--- a/graph/impl/KokkosGraph_ExplicitCoarsening_impl.hpp
+++ b/graph/impl/KokkosGraph_ExplicitCoarsening_impl.hpp
@@ -98,7 +98,7 @@ struct ExplicitGraphCoarsening {
     KOKKOS_INLINE_FUNCTION bool insert(lno_t cluster, lno_t nei, int* table) const {
       unsigned h = xorshiftHash(nei);
       for (unsigned i = h; i < h + 2; i++) {
-        if (Kokkos::atomic_compare_exchange_strong<int>(&table[i % tableSize()], cluster, nei)) return true;
+        if (Kokkos::atomic_compare_exchange_strong(&table[i % tableSize()], cluster, nei)) return true;
       }
       return false;
     }


### PR DESCRIPTION
Let Function Template Argument Deduction do its job, do not interfere.