### PR TITLE
Prefer `atomic_assign(ptr, val) -> atomic_store(ptr, val)`

### DIFF
--- a/common/unit_test/Test_Common_float128.hpp
+++ b/common/unit_test/Test_Common_float128.hpp
@@ -131,8 +131,8 @@ void testfloat128() {
   }
 
   // Assign to the first entry, atomically.
-  Kokkos::atomic_assign(&view(0), z);
-  cout << "view(0) after atomic_assign (z) = " << view(0) << endl;
+  Kokkos::atomic_store(&view(0), z);
+  cout << "view(0) after atomic_store (z) = " << view(0) << endl;
   if (view(0) != z) {
     success = false;
   }

--- a/sparse/src/KokkosSparse_BsrMatrix.hpp
+++ b/sparse/src/KokkosSparse_BsrMatrix.hpp
@@ -967,7 +967,7 @@ class BsrMatrix {
             case BsrMatrix::valueOperation::ASSIGN: {
               for (ordinal_type lcol = 0; lcol < block_size; ++lcol) {
                 if (force_atomic) {
-                  Kokkos::atomic_assign(&(local_row_values[lcol]), vals[offset_into_vals + lrow * block_size + lcol]);
+                  Kokkos::atomic_store(&(local_row_values[lcol]), vals[offset_into_vals + lrow * block_size + lcol]);
                 } else {
                   local_row_values[lcol] = vals[offset_into_vals + lrow * block_size + lcol];
                 }

--- a/sparse/src/KokkosSparse_CrsMatrix.hpp
+++ b/sparse/src/KokkosSparse_CrsMatrix.hpp
@@ -611,7 +611,7 @@ class CrsMatrix {
       const ordinal_type offset = findRelOffset(&(row_view.colidx(0)), length, cols[i], hint, is_sorted);
       if (offset != length) {
         if (force_atomic) {
-          Kokkos::atomic_assign(&(row_view.value(offset)), vals[i]);
+          Kokkos::atomic_store(&(row_view.value(offset)), vals[i]);
         } else {
           row_view.value(offset) = vals[i];
         }


### PR DESCRIPTION
We are looking at deprecating atomic_assign() https://github.com/kokkos/kokkos/issues/7449 Use atomic_store() instead.