### PR TITLE
Prefer `expected == atomic_compare_exchange(ptr, expected, desired)`

### DIFF
--- a/common/src/KokkosKernels_HashmapAccumulator.hpp
+++ b/common/src/KokkosKernels_HashmapAccumulator.hpp
@@ -516,7 +516,7 @@ struct HashmapAccumulator {
           Kokkos::atomic_add(values + hash, value);
           return __insert_success;
         } else if (keys[hash] == -1) {
-          if (Kokkos::atomic_compare_exchange_strong(keys + hash, -1, key)) {
+          if (-1 == Kokkos::atomic_compare_exchange(keys + hash, -1, key)) {
             // should only be here if we used a new hash
             used_hashes[Kokkos::atomic_fetch_add(used_hash_size, size_type(1))] = hash;
             Kokkos::atomic_add(values + hash, value);

--- a/common/src/KokkosKernels_Uniform_Initialized_MemoryPool.hpp
+++ b/common/src/KokkosKernels_Uniform_Initialized_MemoryPool.hpp
@@ -294,7 +294,7 @@ class UniformMemoryPool {
   data_type *get_arbitrary_free_chunk(const size_t &thread_index, const size_t max_tries) const {
     size_t chunk_index = thread_index & modular_num_chunks;
     size_t num_try     = 0;
-    while (!Kokkos::atomic_compare_exchange_strong(pchunk_locks + chunk_index, 0, 1)) {
+    while (0 != Kokkos::atomic_compare_exchange(pchunk_locks + chunk_index, 0, 1)) {
       chunk_index = (chunk_index + 1) & modular_num_chunks;
       ++num_try;
       if (num_try > max_tries) {

--- a/graph/impl/KokkosGraph_ExplicitCoarsening_impl.hpp
+++ b/graph/impl/KokkosGraph_ExplicitCoarsening_impl.hpp
@@ -98,7 +98,7 @@ struct ExplicitGraphCoarsening {
     KOKKOS_INLINE_FUNCTION bool insert(lno_t cluster, lno_t nei, int* table) const {
       unsigned h = xorshiftHash(nei);
       for (unsigned i = h; i < h + 2; i++) {
-        if (Kokkos::atomic_compare_exchange_strong(&table[i % tableSize()], cluster, nei)) return true;
+        if (cluster == Kokkos::atomic_compare_exchange(&table[i % tableSize()], cluster, nei)) return true;
       }
       return false;
     }

--- a/graph/src/KokkosGraph_CoarsenHeuristics.hpp
+++ b/graph/src/KokkosGraph_CoarsenHeuristics.hpp
@@ -86,7 +86,7 @@ class coarsen_heuristics {
             if (bucket >= t_buckets) bucket -= t_buckets;
             if (buckets(bucket) == ORD_MAX) {
               // attempt to insert into bucket
-              if (Kokkos::atomic_compare_exchange_strong(&buckets(bucket), ORD_MAX, i)) {
+              if (ORD_MAX == Kokkos::atomic_compare_exchange(&buckets(bucket), ORD_MAX, i)) {
                 break;
               }
             }
@@ -140,8 +140,8 @@ class coarsen_heuristics {
             // need to enforce an ordering condition to allow hard-stall
             // conditions to be broken
             if (condition ^ swap) {
-              if (Kokkos::atomic_compare_exchange_strong(&match(u), ORD_MAX, v)) {
-                if (u == v || Kokkos::atomic_compare_exchange_strong(&match(v), ORD_MAX, u)) {
+              if (ORD_MAX == Kokkos::atomic_compare_exchange(&match(u), ORD_MAX, v)) {
+                if (u == v || ORD_MAX == Kokkos::atomic_compare_exchange(&match(v), ORD_MAX, u)) {
                   ordinal_t cv = Kokkos::atomic_fetch_add(&nvertices_coarse(), 1);
                   vcmap(u)     = cv;
                   vcmap(v)     = cv;
@@ -201,8 +201,8 @@ class coarsen_heuristics {
             // need to enforce an ordering condition to allow hard-stall
             // conditions to be broken
             if (condition ^ swap) {
-              if (Kokkos::atomic_compare_exchange_strong(&match(u), ORD_MAX, v)) {
-                if (u == v || Kokkos::atomic_compare_exchange_strong(&match(v), ORD_MAX, u)) {
+              if (ORD_MAX == Kokkos::atomic_compare_exchange(&match(u), ORD_MAX, v)) {
+                if (u == v || ORD_MAX == Kokkos::atomic_compare_exchange(&match(v), ORD_MAX, u)) {
                   ordinal_t cv = u;
                   if (v < u) {
                     cv = v;
@@ -859,8 +859,8 @@ class coarsen_heuristics {
             // need to enforce an ordering condition to allow hard-stall
             // conditions to be broken
             if (condition ^ swap) {
-              if (Kokkos::atomic_compare_exchange_strong(&match(u), ORD_MAX, v)) {
-                if (u == v || Kokkos::atomic_compare_exchange_strong(&match(v), ORD_MAX, u)) {
+              if (ORD_MAX == Kokkos::atomic_compare_exchange(&match(u), ORD_MAX, v)) {
+                if (u == v || ORD_MAX == Kokkos::atomic_compare_exchange(&match(v), ORD_MAX, u)) {
                   // u == v avoids problems if there is a self-loop edge
                   ordinal_t cv = Kokkos::atomic_fetch_add(&nvertices_coarse(), 1);
                   vcmap(u)     = cv;
@@ -1084,8 +1084,8 @@ class coarsen_heuristics {
                   // need to enforce an ordering condition to allow hard-stall
                   // conditions to be broken
                   if (condition ^ swap) {
-                    if (Kokkos::atomic_compare_exchange_strong(&match(u), ORD_MAX, v)) {
-                      if (Kokkos::atomic_compare_exchange_strong(&match(v), ORD_MAX, u)) {
+                    if (ORD_MAX == Kokkos::atomic_compare_exchange(&match(u), ORD_MAX, v)) {
+                      if (ORD_MAX == Kokkos::atomic_compare_exchange(&match(v), ORD_MAX, u)) {
                         ordinal_t cv = Kokkos::atomic_fetch_add(&nvertices_coarse(), 1);
                         vcmap(u)     = cv;
                         vcmap(v)     = cv;

--- a/sparse/impl/KokkosSparse_bspgemm_impl_kkmem.hpp
+++ b/sparse/impl/KokkosSparse_bspgemm_impl_kkmem.hpp
@@ -607,7 +607,7 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
               if (!insert_is_on) {
                 try_to_insert = false;
                 break;
-              } else if (Kokkos::atomic_compare_exchange_strong(keys + trial, init_value, my_b_col)) {
+              } else if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                 kk_vector_block_add_mul(block_dim, vals + trial * block_size, a_val, b_val);
                 Kokkos::atomic_inc(used_hash_sizes);
                 if (used_hash_sizes[0] > max_first_level_hash_size) insert_is_on = false;
@@ -629,7 +629,7 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
               } else if (keys[trial] == init_value) {
                 if (!insert_is_on) {
                   break;
-                } else if (Kokkos::atomic_compare_exchange_strong(keys + trial, init_value, my_b_col)) {
+                } else if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                   kk_vector_block_add_mul(block_dim, vals + trial * block_size, a_val, b_val);
                   Kokkos::atomic_inc(used_hash_sizes);
                   if (used_hash_sizes[0] > max_first_level_hash_size) insert_is_on = false;
@@ -651,7 +651,8 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
                   fail = 0;
                   break;
                 } else if (global_acc_row_keys[trial] == init_value) {
-                  if (Kokkos::atomic_compare_exchange_strong(global_acc_row_keys + trial, init_value, my_b_col)) {
+                  if (init_value ==
+                      Kokkos::atomic_compare_exchange(global_acc_row_keys + trial, init_value, my_b_col)) {
                     kk_vector_block_add_mul(block_dim, global_acc_row_vals + trial * block_size, a_val, b_val);
                     // Kokkos::atomic_inc(used_hash_sizes + 1);
                     // c_row_vals[trial] = my_b_val;
@@ -669,7 +670,8 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
                     kk_vector_block_add_mul(block_dim, global_acc_row_vals + trial * block_size, a_val, b_val);
                     break;
                   } else if (global_acc_row_keys[trial] == init_value) {
-                    if (Kokkos::atomic_compare_exchange_strong(global_acc_row_keys + trial, init_value, my_b_col)) {
+                    if (init_value ==
+                        Kokkos::atomic_compare_exchange(global_acc_row_keys + trial, init_value, my_b_col)) {
                       // Kokkos::atomic_inc(used_hash_sizes + 1);
                       kk_vector_block_add_mul(block_dim, global_acc_row_vals + trial * block_size, a_val, b_val);
                       // c_row_vals[trial] = my_b_val;
@@ -877,7 +879,7 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
               fail = 0;
               break;
             } else if (keys[trial] == init_value) {
-              if (Kokkos::atomic_compare_exchange_strong(keys + trial, init_value, my_b_col)) {
+              if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                 kk_vector_block_add_mul(block_dim, vals + trial * block_size, a_val, b_val);
                 fail = 0;
                 break;
@@ -893,7 +895,7 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
                 fail = 0;
                 break;
               } else if (keys[trial] == init_value) {
-                if (Kokkos::atomic_compare_exchange_strong(keys + trial, init_value, my_b_col)) {
+                if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                   kk_vector_block_add_mul(block_dim, vals + trial * block_size, a_val, b_val);
                   fail = 0;
                   break;

--- a/sparse/impl/KokkosSparse_partitioning_impl.hpp
+++ b/sparse/impl/KokkosSparse_partitioning_impl.hpp
@@ -113,7 +113,7 @@ struct BalloonClustering {
       auto state = randPool.get_state();
       do {
         root = state.rand(numRows);
-      } while (!Kokkos::atomic_compare_exchange_strong(&vertClusters(root), numClusters, i));
+      } while (numClusters != Kokkos::atomic_compare_exchange(&vertClusters(root), numClusters, i));
       randPool.free_state(state);
       distances(root) = 0;
       pressure(root)  = 1;

--- a/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
@@ -523,7 +523,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
             Kokkos::atomic_fetch_or(result_vals + new_hash, n_set);
             break;
           } else if (result_keys[new_hash] == r) {
-            if (Kokkos::atomic_compare_exchange_strong(result_keys + new_hash, r, n_set_index)) {
+            if (r == Kokkos::atomic_compare_exchange(result_keys + new_hash, r, n_set_index)) {
               // MD 4/4/18: on these architectures there can be divergence in
               // the warp. once the keys are set, some other vector lane might
               // be doing a fetch_or before we set with n_set. Therefore it is

--- a/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
@@ -687,12 +687,11 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
             if (keys[trial] == my_b_col) {
               Kokkos::atomic_add(vals + trial, my_b_val);
               fail = 0;
-              break;
             } else if (keys[trial] == init_value) {
               if (!insert_is_on) {
                 try_to_insert = false;
                 break;
-              } else if (Kokkos::atomic_compare_exchange_strong(keys + trial, init_value, my_b_col)) {
+              } else if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                 Kokkos::atomic_add(vals + trial, my_b_val);
                 Kokkos::atomic_inc(used_hash_sizes);
                 if (used_hash_sizes[0] > max_first_level_hash_size) insert_is_on = false;
@@ -714,7 +713,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
               } else if (keys[trial] == init_value) {
                 if (!insert_is_on) {
                   break;
-                } else if (Kokkos::atomic_compare_exchange_strong(keys + trial, init_value, my_b_col)) {
+                } else if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                   Kokkos::atomic_add(vals + trial, my_b_val);
                   Kokkos::atomic_inc(used_hash_sizes);
                   if (used_hash_sizes[0] > max_first_level_hash_size) insert_is_on = false;
@@ -737,7 +736,8 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
                   fail = 0;
                   break;
                 } else if (global_acc_row_keys[trial] == init_value) {
-                  if (Kokkos::atomic_compare_exchange_strong(global_acc_row_keys + trial, init_value, my_b_col)) {
+                  if (init_value ==
+                      Kokkos::atomic_compare_exchange(global_acc_row_keys + trial, init_value, my_b_col)) {
                     Kokkos::atomic_add(global_acc_row_vals + trial, my_b_val);
                     // Kokkos::atomic_inc(used_hash_sizes + 1);
                     // c_row_vals[trial] = my_b_val;
@@ -756,7 +756,8 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
 
                     break;
                   } else if (global_acc_row_keys[trial] == init_value) {
-                    if (Kokkos::atomic_compare_exchange_strong(global_acc_row_keys + trial, init_value, my_b_col)) {
+                    if (init_value ==
+                        Kokkos::atomic_compare_exchange(global_acc_row_keys + trial, init_value, my_b_col)) {
                       // Kokkos::atomic_inc(used_hash_sizes + 1);
                       Kokkos::atomic_add(global_acc_row_vals + trial, my_b_val);
                       // c_row_vals[trial] = my_b_val;
@@ -976,7 +977,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
               fail = 0;
               break;
             } else if (keys[trial] == init_value) {
-              if (Kokkos::atomic_compare_exchange_strong(keys + trial, init_value, my_b_col)) {
+              if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                 Kokkos::atomic_add(vals + trial, my_b_val);
                 fail = 0;
                 break;
@@ -992,7 +993,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
                 fail = 0;
                 break;
               } else if (keys[trial] == init_value) {
-                if (Kokkos::atomic_compare_exchange_strong(keys + trial, init_value, my_b_col)) {
+                if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                   Kokkos::atomic_add(vals + trial, my_b_val);
                   fail = 0;
                   break;

--- a/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
@@ -687,6 +687,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
             if (keys[trial] == my_b_col) {
               Kokkos::atomic_add(vals + trial, my_b_val);
               fail = 0;
+              break;
             } else if (keys[trial] == init_value) {
               if (!insert_is_on) {
                 try_to_insert = false;

--- a/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
@@ -591,7 +591,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
             fail = 0;
             break;
           } else if (keys[trial] == init_value) {
-            if (Kokkos::atomic_compare_exchange_strong(keys + trial, init_value, my_b_col)) {
+            if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
               Kokkos::atomic_add(vals + trial, my_b_val);
               fail = 0;
               break;
@@ -608,7 +608,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
               fail = 0;
               break;
             } else if (keys[trial] == init_value) {
-              if (Kokkos::atomic_compare_exchange_strong(keys + trial, init_value, my_b_col)) {
+              if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                 Kokkos::atomic_add(vals + trial, my_b_val);
                 fail = 0;
                 break;
@@ -668,7 +668,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
             fail = 0;
             break;
           } else if (keys[trial] == init_value) {
-            if (Kokkos::atomic_compare_exchange_strong(keys + trial, init_value, my_b_col)) {
+            if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
               Kokkos::atomic_add(vals + trial, my_b_val);
               fail = 0;
               break;
@@ -685,7 +685,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
               fail = 0;
               break;
             } else if (keys[trial] == init_value) {
-              if (Kokkos::atomic_compare_exchange_strong(keys + trial, init_value, my_b_col)) {
+              if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                 Kokkos::atomic_add(vals + trial, my_b_val);
                 fail = 0;
                 break;
@@ -812,7 +812,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
             if (!insert_is_on) {
               try_to_insert = false;
               break;
-            } else if (Kokkos::atomic_compare_exchange_strong(keys + trial, init_value, my_b_col)) {
+            } else if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
               Kokkos::atomic_add(vals + trial, my_b_val);
               Kokkos::atomic_inc(used_hash_sizes);
               if (used_hash_sizes[0] > max_first_level_hash_size) insert_is_on = false;
@@ -835,7 +835,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
             } else if (keys[trial] == init_value) {
               if (!insert_is_on) {
                 break;
-              } else if (Kokkos::atomic_compare_exchange_strong(keys + trial, init_value, my_b_col)) {
+              } else if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                 Kokkos::atomic_add(vals + trial, my_b_val);
                 Kokkos::atomic_inc(used_hash_sizes);
                 if (used_hash_sizes[0] > max_first_level_hash_size) insert_is_on = false;
@@ -856,7 +856,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
                 fail = 0;
                 break;
               } else if (global_acc_row_keys[trial] == init_value) {
-                if (Kokkos::atomic_compare_exchange_strong(global_acc_row_keys + trial, init_value, my_b_col)) {
+                if (init_value == Kokkos::atomic_compare_exchange(global_acc_row_keys + trial, init_value, my_b_col)) {
                   Kokkos::atomic_add(global_acc_row_vals + trial, my_b_val);
                   fail = 0;
                   break;
@@ -872,7 +872,8 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
                   Kokkos::atomic_add(global_acc_row_vals + trial, my_b_val);
                   break;
                 } else if (global_acc_row_keys[trial] == init_value) {
-                  if (Kokkos::atomic_compare_exchange_strong(global_acc_row_keys + trial, init_value, my_b_col)) {
+                  if (init_value ==
+                      Kokkos::atomic_compare_exchange(global_acc_row_keys + trial, init_value, my_b_col)) {
                     Kokkos::atomic_add(global_acc_row_vals + trial, my_b_val);
                     break;
                   }
@@ -937,7 +938,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
             if (!insert_is_on) {
               try_to_insert = false;
               break;
-            } else if (Kokkos::atomic_compare_exchange_strong(keys + trial, init_value, my_b_col)) {
+            } else if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
               Kokkos::atomic_add(vals + trial, my_b_val);
               Kokkos::atomic_inc(used_hash_sizes);
               if (used_hash_sizes[0] > max_first_level_hash_size) insert_is_on = false;
@@ -960,7 +961,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
             } else if (keys[trial] == init_value) {
               if (!insert_is_on) {
                 break;
-              } else if (Kokkos::atomic_compare_exchange_strong(keys + trial, init_value, my_b_col)) {
+              } else if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                 Kokkos::atomic_add(vals + trial, my_b_val);
                 Kokkos::atomic_inc(used_hash_sizes);
                 if (used_hash_sizes[0] > max_first_level_hash_size) insert_is_on = false;
@@ -980,7 +981,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
                 fail = 0;
                 break;
               } else if (global_acc_row_keys[trial] == init_value) {
-                if (Kokkos::atomic_compare_exchange_strong(global_acc_row_keys + trial, init_value, my_b_col)) {
+                if (init_value == Kokkos::atomic_compare_exchange(global_acc_row_keys + trial, init_value, my_b_col)) {
                   Kokkos::atomic_add(global_acc_row_vals + trial, my_b_val);
                   fail = 0;
                   break;
@@ -995,7 +996,8 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
                   Kokkos::atomic_add(global_acc_row_vals + trial, my_b_val);
                   break;
                 } else if (global_acc_row_keys[trial] == init_value) {
-                  if (Kokkos::atomic_compare_exchange_strong(global_acc_row_keys + trial, init_value, my_b_col)) {
+                  if (init_value ==
+                      Kokkos::atomic_compare_exchange(global_acc_row_keys + trial, init_value, my_b_col)) {
                     Kokkos::atomic_add(global_acc_row_vals + trial, my_b_val);
                     break;
                   }


### PR DESCRIPTION
Rewrote `atomic_compare_exchange_strong(ptr, expected, desired)` as `expected == atomic_compare_exchange(ptr, expected, desired)` as `atomic_compare_exchange_strong` is on its way to be deprecated/removed (see https://github.com/kokkos/kokkos/pull/7458)