### PR TITLE
workflows: adding variable to set kokkos version to test against

### DIFF
--- a/.github/workflows/at2.yml
+++ b/.github/workflows/at2.yml
@@ -18,14 +18,27 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  KOKKOS_VERSION: 4.4.01
+
 jobs:
   mi210:
     uses: ./.github/workflows/mi210.yml
+    with:
+      kokkos_version: 4.4.01
   h100:
     uses: ./.github/workflows/h100.yml
+    with:
+      kokkos_version: 4.4.01
   bdw:
     uses: ./.github/workflows/bdw.yml
+    with:
+      kokkos_version: 4.4.01
   spr:
     uses: ./.github/workflows/spr.yml
+    with:
+      kokkos_version: 4.4.01
   volta70:
     uses: ./.github/workflows/volta70.yml
+    with:
+      kokkos_version: 4.4.01

--- a/.github/workflows/bdw.yml
+++ b/.github/workflows/bdw.yml
@@ -1,10 +1,16 @@
 name: Reusable BDW workflow
 
-on:
-  workflow_call
-
 permissions:
   contents: none
+
+on:
+  workflow_call:
+    inputs:
+      kokkos_version:
+        description: 'The Kokkos Core version to build'
+        default: ''
+        required: true
+        type: string
 
 jobs:
 #  PR_BDW_GNU1020_OPENMP_LEFT_REL_NOETI:
@@ -21,7 +27,7 @@ jobs:
 #        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 #        with:
 #          repository: kokkos/kokkos
-#          ref: ${{ github.base_ref }}
+#          ref: ${{ inputs.kokkos_version }}
 #          path: kokkos
 #
 #      - name: configure_kokkos
@@ -102,7 +108,7 @@ jobs:
 #        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 #        with:
 #          repository: kokkos/kokkos
-#          ref: ${{ github.base_ref }}
+#          ref: ${{ inputs.kokkos_version }}
 #          path: kokkos
 #
 #      - name: configure_kokkos
@@ -184,7 +190,7 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           repository: kokkos/kokkos
-          ref: ${{ github.base_ref }}
+          ref: ${{ inputs.kokkos_version }}
           path: kokkos
 
       - name: configure_kokkos
@@ -269,7 +275,7 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           repository: kokkos/kokkos
-          ref: ${{ github.base_ref }}
+          ref: ${{ inputs.kokkos_version }}
           path: kokkos
 
       - name: configure_kokkos

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -1,10 +1,16 @@
 name: Reusable H100 workflow
 
-on:
-  workflow_call
-
 permissions:
   contents: none
+
+on:
+  workflow_call:
+    inputs:
+      kokkos_version:
+        description: 'The Kokkos Core version to build'
+        default: ''
+        required: true
+        type: string
 
 jobs:
   PR_HOPPER90_CUDA1180_CUDA_LEFT_RIGHT_REL:
@@ -21,7 +27,7 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           repository: kokkos/kokkos
-          ref: ${{ github.base_ref }}
+          ref: ${{ inputs.kokkos_version }}
           path: kokkos
 
       - name: configure_kokkos

--- a/.github/workflows/mi210.yml
+++ b/.github/workflows/mi210.yml
@@ -1,10 +1,16 @@
 name: Reusable MI210 workflow
 
-on:
-  workflow_call
-
 permissions:
   contents: none
+
+on:
+  workflow_call:
+    inputs:
+      kokkos_version:
+        description: 'The Kokkos Core version to build'
+        default: ''
+        required: true
+        type: string
 
 jobs:
   PR_VEGA90A_ROCM561_HIP_SERIAL_LEFT:
@@ -21,7 +27,7 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           repository: kokkos/kokkos
-          ref: ${{ github.base_ref }}
+          ref: ${{ inputs.kokkos_version }}
           path: kokkos
 
       - name: configure_kokkos
@@ -102,7 +108,7 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           repository: kokkos/kokkos
-          ref: ${{ github.base_ref }}
+          ref: ${{ inputs.kokkos_version }}
           path: kokkos
 
       - name: configure_kokkos

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  KOKKOS_VERSION: 4.4.01
+  kokkos_version: 4.4.01
 
 jobs:
   check-pr-labels:
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           repository: kokkos/kokkos
-          ref: $KOKKOS_VERSION
+          ref: ${{ env.kokkos_version }}
           path: kokkos
 
       - name: configure_kokkos

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  KOKKOS_VERSION: 4.4.01
+
 jobs:
   check-pr-labels:
     runs-on: [ubuntu-latest]
@@ -58,7 +61,7 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           repository: kokkos/kokkos
-          ref: 4.3.01
+          ref: $KOKKOS_VERSION
           path: kokkos
 
       - name: configure_kokkos

--- a/.github/workflows/spr.yml
+++ b/.github/workflows/spr.yml
@@ -1,10 +1,16 @@
 name: Reusable SPR workflow
 
-on:
-  workflow_call
-
 permissions:
   contents: none
+
+on:
+  workflow_call:
+    inputs:
+      kokkos_version:
+        description: 'The Kokkos Core version to build'
+        default: ''
+        required: true
+        type: string
 
 jobs:
   PR_SPR_ONEAPI202310_OPENMP_LEFT_MKLBLAS_MKLLAPACK_REL:
@@ -21,7 +27,7 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           repository: kokkos/kokkos
-          ref: 4.3.01
+          ref: ${{ inputs.kokkos_version }}
           path: kokkos
 
       - name: configure

--- a/.github/workflows/volta70.yml
+++ b/.github/workflows/volta70.yml
@@ -1,10 +1,16 @@
 name: Reusable VOLTA70 workflow
 
-on:
-  workflow_call
-
 permissions:
   contents: none
+
+on:
+  workflow_call:
+    inputs:
+      kokkos_version:
+        description: 'The Kokkos Core version to build'
+        default: ''
+        required: true
+        type: string
 
 jobs:
   PR_VOLTA70_CUDA1122_CUDA_LEFT_RIGHT_REL:
@@ -21,7 +27,7 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           repository: kokkos/kokkos
-          ref: 4.4.00
+          ref: ${{ inputs.kokkos_version }}
           path: kokkos
 
       - name: configure_kokkos
@@ -87,7 +93,7 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           repository: kokkos/kokkos
-          ref: 4.4.00
+          ref: ${{ inputs.kokkos_version }}
           path: kokkos
 
       - name: configure_kokkos


### PR DESCRIPTION
The variable is set directly in at2.yml so it can be uniformly applied to all the "sub-workflows" making maintenance when a new release of kokkos comes out easier.