### PR TITLE
deprecate `__KOKKOSBATCHED_PROMOTION__`

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -19,7 +19,19 @@
 /// \author Kyungjoo Kim (kyukim@sandia.gov)
 
 // no experimental name space guard for trilinos
-#define __KOKKOSBATCHED_PROMOTION__ 1
+
+#ifdef _MSC_VER
+#define __KOKKOSBATCHED_PROMOTION___DEPRECATED_MACRO \
+  (__pragma(message("warning: __KOKKOSBATCHED_PROMOTION__ is deprecated and will be removed in a future version")) 1)
+#else
+#define __KOKKOSBATCHED_PROMOTION___DEPRECATED_MACRO                                                              \
+  (__extension__({                                                                                                \
+    _Pragma("GCC warning \"__KOKKOSBATCHED_PROMOTION__ is deprecated and will be removed in a future version\""); \
+    1;                                                                                                            \
+  }))
+#endif
+
+#define __KOKKOSBATCHED_PROMOTION__ __KOKKOSBATCHED_PROMOTION___DEPRECATED_MACRO
 
 #include <iomanip>
 #include <random>

--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -21,17 +21,17 @@
 // no experimental name space guard for trilinos
 
 #ifdef _MSC_VER
-#define __KOKKOSBATCHED_PROMOTION___DEPRECATED_MACRO \
+#define KOKKOSBATCHED_IMPL_PROMOTION \
   (__pragma(message("warning: __KOKKOSBATCHED_PROMOTION__ is deprecated and will be removed in a future version")) 1)
 #else
-#define __KOKKOSBATCHED_PROMOTION___DEPRECATED_MACRO                                                              \
+#define KOKKOSBATCHED_IMPL_PROMOTION                                                                              \
   (__extension__({                                                                                                \
     _Pragma("GCC warning \"__KOKKOSBATCHED_PROMOTION__ is deprecated and will be removed in a future version\""); \
     1;                                                                                                            \
   }))
 #endif
 
-#define __KOKKOSBATCHED_PROMOTION__ __KOKKOSBATCHED_PROMOTION___DEPRECATED_MACRO
+#define __KOKKOSBATCHED_PROMOTION__ KOKKOSBATCHED_IMPL_PROMOTION
 
 #include <iomanip>
 #include <random>


### PR DESCRIPTION
Fix for https://github.com/kokkos/kokkos-kernels/issues/2374: this macro is a reserved identifier, so it needs to go. See also https://github.com/kokkos/kokkos-kernels/issues/2364

It has no uses in Trilinos, but I'm deprecating this rather than outright removing it because the comment hints at some trilinos integration thing.