### PR TITLE
workflow: Actually using the KOKKOS_VERSION variable

### DIFF
--- a/.github/workflows/at2.yml
+++ b/.github/workflows/at2.yml
@@ -25,20 +25,20 @@ jobs:
   mi210:
     uses: ./.github/workflows/mi210.yml
     with:
-      kokkos_version: 4.4.01
+      kokkos_version: ${{ env.KOKKOS_VERSION }}
   h100:
     uses: ./.github/workflows/h100.yml
     with:
-      kokkos_version: 4.4.01
+      kokkos_version: ${{ env.KOKKOS_VERSION }}
   bdw:
     uses: ./.github/workflows/bdw.yml
     with:
-      kokkos_version: 4.4.01
+      kokkos_version: ${{ env.KOKKOS_VERSION }}
   spr:
     uses: ./.github/workflows/spr.yml
     with:
-      kokkos_version: 4.4.01
+      kokkos_version: ${{ env.KOKKOS_VERSION }}
   volta70:
     uses: ./.github/workflows/volta70.yml
     with:
-      kokkos_version: 4.4.01
+      kokkos_version: ${{ env.KOKKOS_VERSION }}

--- a/.github/workflows/at2.yml
+++ b/.github/workflows/at2.yml
@@ -18,27 +18,26 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  KOKKOS_VERSION: 4.4.01
-
 jobs:
+  env:
+    kokkos_version: 4.4.01
   mi210:
     uses: ./.github/workflows/mi210.yml
     with:
-      kokkos_version: ${{ env.KOKKOS_VERSION }}
+      kokkos_version: ${{ env.kokkos_version }}
   h100:
     uses: ./.github/workflows/h100.yml
     with:
-      kokkos_version: ${{ env.KOKKOS_VERSION }}
+      kokkos_version: ${{ env.kokkos_version }}
   bdw:
     uses: ./.github/workflows/bdw.yml
     with:
-      kokkos_version: ${{ env.KOKKOS_VERSION }}
+      kokkos_version: ${{ env.kokkos_version }}
   spr:
     uses: ./.github/workflows/spr.yml
     with:
-      kokkos_version: ${{ env.KOKKOS_VERSION }}
+      kokkos_version: ${{ env.kokkos_version }}
   volta70:
     uses: ./.github/workflows/volta70.yml
     with:
-      kokkos_version: ${{ env.KOKKOS_VERSION }}
+      kokkos_version: ${{ env.kokkos_version }}


### PR DESCRIPTION
Currently the version is still hardcoded for each job in at2.yml Now switching to use the control variable so all the jobs can be in sync and switched at once for easier maintenance.