### PR TITLE
Fixing potential overflow issue in inner product trait

### DIFF
--- a/batched/dense/impl/KokkosBatched_HostLevel_Gemm_DblBuf_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_HostLevel_Gemm_DblBuf_Impl.hpp
@@ -249,8 +249,7 @@ class BatchedDblBufGemm {
     CViewType __C;
     ScalarType __alpha, __beta;
     int __k;
-    size_t __n_sub_tiles;
-    unsigned __tiles_per_col, __tiles_per_row;
+    size_t __n_sub_tiles, __tiles_per_col, __tiles_per_row;
 
    public:
     size_t get_n_sub_tiles() { return __n_sub_tiles; }
@@ -283,8 +282,8 @@ class BatchedDblBufGemm {
       // with '!!'. This extra tile will hang off the edge of the 2-rank matrix.
       // For cases where tiles hang off the edge, we over-compute 0s within
       // registers via a conditional bounds check selected at compile-time.
-      __tiles_per_row = ei.__c_m / TILE_M + !!((unsigned)ei.__c_m % TILE_M);
-      __tiles_per_col = ei.__c_n / TILE_N + !!((unsigned)ei.__c_n % TILE_N);
+      __tiles_per_row = ei.__c_m / TILE_M + !!((size_t)ei.__c_m % TILE_M);
+      __tiles_per_col = ei.__c_n / TILE_N + !!((size_t)ei.__c_n % TILE_N);
 
       __n_sub_tiles = __tiles_per_row * __tiles_per_col;
     }

--- a/common/src/Kokkos_InnerProductSpaceTraits.hpp
+++ b/common/src/Kokkos_InnerProductSpaceTraits.hpp
@@ -238,13 +238,12 @@ KOKKOS_INLINE_FUNCTION void updateDot(ResultType& sum, const InputType1& x, cons
 
 KOKKOS_INLINE_FUNCTION void updateDot(double& sum, const double x, const double y) { sum += x * y; }
 
-KOKKOS_INLINE_FUNCTION void updateDot(double& sum, const float x, const float y) { sum += x * y; }
+KOKKOS_INLINE_FUNCTION void updateDot(double& sum, const float x, const float y) { sum += static_cast<double>(x) * y; }
 
 // This exists because complex<float> += complex<double> is not defined.
 KOKKOS_INLINE_FUNCTION void updateDot(Kokkos::complex<double>& sum, const Kokkos::complex<float> x,
                                       const Kokkos::complex<float> y) {
-  const auto tmp = Kokkos::conj(x) * y;
-  sum += Kokkos::complex<double>(tmp.real(), tmp.imag());
+  sum += Kokkos::conj(Kokkos::complex<double>(x)) * Kokkos::complex<double>(y);
 }
 
 // This exists in case people call the overload of KokkosBlas::dot

--- a/sparse/src/KokkosSparse_BsrMatrix.hpp
+++ b/sparse/src/KokkosSparse_BsrMatrix.hpp
@@ -529,7 +529,9 @@ class BsrMatrix {
       auto it = blocks.find(block);
       if (it == blocks.end()) {
         std::vector<Entry> entries = {entry};
-        entries.reserve(blockDim_ * blockDim_);
+        entries.reserve(
+            static_cast<typename std::common_type_t<typename std::vector<Entry>::size_type, ordinal_type>>(blockDim_) *
+            blockDim_);
         blocks[block] = std::move(entries);  // new block with entry
       } else {
         it->second.push_back(entry);  // add entry to block
@@ -724,9 +726,9 @@ class BsrMatrix {
     Kokkos::deep_copy(h_crs_values, crs_mtx.values);
 
     typename values_type::HostMirror h_values = Kokkos::create_mirror_view(values);
-    if (h_values.extent(0) < size_t(numBlocks * blockDim_ * blockDim_)) {
-      Kokkos::resize(h_values, numBlocks * blockDim_ * blockDim_);
-      Kokkos::resize(values, numBlocks * blockDim_ * blockDim_);
+    if (h_values.extent(0) < static_cast<size_t>(numBlocks) * blockDim_ * blockDim_) {
+      Kokkos::resize(h_values, static_cast<size_t>(numBlocks) * blockDim_ * blockDim_);
+      Kokkos::resize(values, static_cast<size_t>(numBlocks) * blockDim_ * blockDim_);
     }
     Kokkos::deep_copy(h_values, 0);
 

--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -119,8 +119,8 @@ void spmv(const ExecutionSpace& space, Handle* handle, const char mode[], const 
     m = A.numRows();
     n = A.numCols();
   } else {
-    m = A.numRows() * A.blockDim();
-    n = A.numCols() * A.blockDim();
+    m = static_cast<size_t>(A.numRows()) * A.blockDim();
+    n = static_cast<size_t>(A.numCols()) * A.blockDim();
   }
 
   if ((mode[0] == NoTranspose[0]) || (mode[0] == Conjugate[0])) {

--- a/sparse/unit_test/Test_Sparse_spmv_bsr.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv_bsr.hpp
@@ -316,8 +316,8 @@ auto random_vecs_for_spmv(const char *mode, const Bsr &a, const bool nans = fals
   using execution_space = typename Bsr::execution_space;
   using policy_type     = Kokkos::RangePolicy<typename vector_type::execution_space>;
 
-  size_t nx = a.numCols() * a.blockDim();
-  size_t ny = a.numRows() * a.blockDim();
+  size_t nx = static_cast<size_t>(a.numCols()) * a.blockDim();
+  size_t ny = static_cast<size_t>(a.numRows()) * a.blockDim();
   if (mode_is_transpose(mode)) {
     std::swap(nx, ny);
   }
@@ -557,8 +557,8 @@ auto random_multivecs_for_spm_mv(const char *mode, const Bsr &a, const size_t nu
   using execution_space = typename Bsr::execution_space;
   using policy_type     = Kokkos::RangePolicy<typename vector_type::execution_space>;
 
-  size_t nx = a.numCols() * a.blockDim();
-  size_t ny = a.numRows() * a.blockDim();
+  size_t nx = static_cast<size_t>(a.numCols()) * a.blockDim();
+  size_t ny = static_cast<size_t>(a.numRows()) * a.blockDim();
   if (mode_is_transpose(mode)) {
     std::swap(nx, ny);
   }


### PR DESCRIPTION
When result type is double and inputs are floats, one input has to be cast to double so the multiplication operator for double is used instead of the float multiplication operator that could overflow for valid double values.

@csiefer2 this should take care of the security issue you reported.