### PR TITLE
Deprecate __KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -74,7 +74,23 @@
 
 #include "mkl_version.h"
 #if __INTEL_MKL__ >= 2018
-#define __KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__ 1
+
+#if defined(KOKKOS_COMPILER_MSVC)
+#define KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED \
+  (__pragma(message(                                \
+      "warning: __KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__ is deprecated and will be removed in a future version")) 1)
+#elif defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
+#define KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED                                                                   \
+  (__extension__({                                                                                                    \
+    _Pragma(                                                                                                          \
+        "warning: __KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__ is deprecated and will be removed in a future version"); \
+    1;                                                                                                                \
+  }))
+#else
+#define KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED 1  // no good way to deprecate?
+#endif
+#define __KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__ KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED
+
 #define __KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__ 1
 #include "mkl.h"
 // #include "mkl_types.h"

--- a/batched/dense/impl/KokkosBatched_Gemm_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemm_Serial_Impl.hpp
@@ -36,7 +36,7 @@ namespace KokkosBatched {
 /// NT/NT
 ///
 
-#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__) && \
+#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
     defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
 template <>
 template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
@@ -95,7 +95,7 @@ KOKKOS_INLINE_FUNCTION int SerialGemm<Trans::NoTranspose, Trans::NoTranspose, Al
 /// T/NT
 ///
 
-#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__) && \
+#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
     defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
 template <>
 template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
@@ -154,7 +154,7 @@ KOKKOS_INLINE_FUNCTION int SerialGemm<Trans::Transpose, Trans::NoTranspose, Algo
 /// NT/T
 ///
 
-#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__) && \
+#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
     defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
 template <>
 template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
@@ -213,7 +213,7 @@ KOKKOS_INLINE_FUNCTION int SerialGemm<Trans::NoTranspose, Trans::Transpose, Algo
 /// T/T
 ///
 
-#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__) && \
+#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
     defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
 template <>
 template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>

--- a/batched/dense/impl/KokkosBatched_InverseLU_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_InverseLU_Serial_Impl.hpp
@@ -32,7 +32,7 @@ namespace KokkosBatched {
 /// InverseLU no piv
 ///
 
-#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__) && \
+#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
     defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
 template <>
 template <typename AViewType, typename WViewType>

--- a/batched/dense/impl/KokkosBatched_LU_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_LU_Serial_Impl.hpp
@@ -31,7 +31,7 @@ namespace KokkosBatched {
 /// SerialLU no piv
 ///
 
-#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__) && \
+#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
     defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
 template <>
 template <typename AViewType>

--- a/batched/dense/impl/KokkosBatched_Trsm_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsm_Serial_Impl.hpp
@@ -29,7 +29,7 @@ namespace KokkosBatched {
 /// B := inv(tril(A)) (alpha*B)
 /// A(m x m), B(m x n)
 
-#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__) && \
+#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
     defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
 template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::Trsm::CompactMKL> {
@@ -88,7 +88,7 @@ struct SerialTrsm<Side::Left, Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::Tr
 ///
 /// B := (alpha*B) inv(triu(A))
 /// A(n x n), B(m x n)
-#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__) && \
+#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
     defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
 template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::Trsm::CompactMKL> {
@@ -167,7 +167,7 @@ struct SerialTrsm<Side::Right, Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trs
 ///
 /// B := inv(triu(A)) (alpha*B)
 /// A(m x m), B(m x n)
-#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__) && \
+#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
     defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
 template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::Trsm::CompactMKL> {
@@ -227,7 +227,7 @@ struct SerialTrsm<Side::Left, Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::Tr
 /// B := inv(tril(AT)) (alpha*B)
 /// A(m x m), B(m x n)
 
-#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__) && \
+#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
     defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
 template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trsm::CompactMKL> {
@@ -285,7 +285,7 @@ struct SerialTrsm<Side::Left, Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trsm
 ///
 /// B := inv(triu(AT)) (alpha*B)
 /// A(m x m), B(m x n)
-#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__) && \
+#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
     defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
 template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trsm::CompactMKL> {

--- a/batched/dense/impl/KokkosBatched_Trsv_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsv_Serial_Impl.hpp
@@ -38,7 +38,7 @@ namespace KokkosBatched {
 /// L/NT
 ///
 
-#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__) && \
+#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
     defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
 template <typename ArgDiag>
 struct SerialTrsv<Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::Trsv::CompactMKL> {
@@ -94,7 +94,7 @@ struct SerialTrsv<Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::Trsv::Blocked>
 /// L/T
 ///
 
-#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__) && \
+#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
     defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
 template <typename ArgDiag>
 struct SerialTrsv<Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trsv::CompactMKL> {
@@ -150,7 +150,7 @@ struct SerialTrsv<Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trsv::Blocked> {
 /// U/NT
 ///
 
-#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__) && \
+#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
     defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
 template <typename ArgDiag>
 struct SerialTrsv<Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::Trsv::CompactMKL> {
@@ -206,7 +206,7 @@ struct SerialTrsv<Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::Trsv::Blocked>
 /// U/T
 ///
 
-#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__) && \
+#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
     defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
 template <typename ArgDiag>
 struct SerialTrsv<Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trsv::CompactMKL> {

--- a/perf_test/blas/blas3/KokkosBlas3_gemm_perf_test.hpp
+++ b/perf_test/blas/blas3/KokkosBlas3_gemm_perf_test.hpp
@@ -1975,7 +1975,7 @@ void do_gemm_serial_simd_batched_blocked_parallel(options_t options) {
   return;
 }
 
-#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__) && \
+#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
     defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
 void do_gemm_serial_batched_compact_mkl_parallel(options_t options) {
   STATUS;
@@ -1994,9 +1994,9 @@ void do_gemm_serial_batched_compact_mkl_parallel(options_t) {
 #if !defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL)
   std::cerr << std::string(__func__) << " disabled since KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL is undefined."
             << std::endl;
-#elif !defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__)
+#elif !defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED)
   std::cerr << std::string(__func__)
-            << " disabled since __KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__ is "
+            << " disabled since KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED is "
                "undefined."
             << std::endl;
 #elif !defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)


### PR DESCRIPTION
In favor of KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED

Once piece of https://github.com/kokkos/kokkos-kernels/issues/2364 at a time.