### PR TITLE
SerialInverseLU: fix overflow in integer multiplication

### DIFF
--- a/batched/dense/unit_test/Test_Batched_SerialInverseLU.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialInverseLU.hpp
@@ -143,7 +143,7 @@ void impl_test_batched_inverselu(const int N, const int BlkSize) {
   /// randomized input testing views
   AViewType a0("a0", N, BlkSize, BlkSize);
   AViewType a1("a1", N, BlkSize, BlkSize);
-  WViewType w("w", N, BlkSize * BlkSize);
+  WViewType w("w", N, BlkSize * static_cast<size_t>(BlkSize));
   AViewType c0("c0", N, BlkSize, BlkSize);
 
   Kokkos::Random_XorShift64_Pool<typename DeviceType::execution_space> random(13718);


### PR DESCRIPTION
Last one of a series of fixes to clean-up the CodeQL safety issues, after that we should be all clean!