### PR TITLE
Fix remaining UB sanitizer errors

### DIFF
--- a/common/src/KokkosKernels_Utils.hpp
+++ b/common/src/KokkosKernels_Utils.hpp
@@ -495,8 +495,9 @@ struct Reverse_Map_Scale_Init {
     typedef typename std::remove_reference<decltype(reverse_map_xadj(0))>::type atomic_incr_type;
     forward_type fm = forward_map[ii];
     fm              = fm << multiply_shift_for_scale;
-    fm += ii >> division_shift_for_bucket;
-    Kokkos::atomic_fetch_add(&(reverse_map_xadj(fm)), atomic_incr_type(1));
+    // Avoid shift by a negative number of bits (division_shift_for_bucket may be positive or negative)
+    size_t adjust = (division_shift_for_bucket >= 0) ? (ii >> division_shift_for_bucket) : (ii << (-division_shift_for_bucket));
+    Kokkos::atomic_fetch_add(&(reverse_map_xadj(fm + adjust)), atomic_incr_type(1));
   }
 };
 
@@ -526,8 +527,9 @@ struct Fill_Reverse_Scale_Map {
     forward_type fm = forward_map[ii];
 
     fm = fm << multiply_shift_for_scale;
-    fm += ii >> division_shift_for_bucket;
-    const reverse_type future_index = Kokkos::atomic_fetch_add(&(reverse_map_xadj(fm - 1)), atomic_incr_type(1));
+    // Avoid shift by a negative number of bits (division_shift_for_bucket may be positive or negative)
+    size_t adjust = (division_shift_for_bucket >= 0) ? (ii >> division_shift_for_bucket) : (ii << (-division_shift_for_bucket));
+    const reverse_type future_index = Kokkos::atomic_fetch_add(&(reverse_map_xadj(fm + adjust - 1)), atomic_incr_type(1));
     reverse_map_adj(future_index)   = ii;
   }
 };
@@ -541,7 +543,6 @@ struct StridedCopy {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const size_t &ii) const {
-    // std::cout << "ii:" << ii << " ii * stride:" << ii * stride << std::endl;
     to[ii] = from[(ii + 1) * stride - 1];
   }
 };
@@ -586,9 +587,11 @@ void create_reverse_map(MyExecSpace my_exec_space,
                                        num_forward_elements);
 
   if (num_reverse_elements < MINIMUM_TO_ATOMIC) {
+    // Number of reverse elements (e.g. colors) is small, so counting and filling with atomics would cause high contention.
+    // So expand each bucket into many sub-buckets.
     const lno_t scale_size                = 1024;
     const lno_t multiply_shift_for_scale  = 10;
-    const lno_t division_shift_for_bucket = lno_t(ceil(log(double(num_forward_elements) / scale_size) / log(2)));
+    const lno_t division_shift_for_bucket = num_forward_elements ? Kokkos::ceil(Kokkos::log2(double(num_forward_elements) / scale_size)) : 0;
     // const lno_t bucket_range_size = pow(2, division_shift_for_bucket);
 
     // coloring indices are base-1. we end up using not using element 1.
@@ -600,20 +603,16 @@ void create_reverse_map(MyExecSpace my_exec_space,
         forward_map, tmp_color_xadj, multiply_shift_for_scale, division_shift_for_bucket);
     Kokkos::parallel_for("KokkosKernels::Common::ReverseMapScaleInit",
                          range_policy_t(my_exec_space, 0, num_forward_elements), rmi);
-    my_exec_space.fence();
 
     inclusive_parallel_prefix_sum<reverse_array_type, MyExecSpace>(my_exec_space, tmp_reverse_size + 1, tmp_color_xadj);
-    my_exec_space.fence();
 
     Kokkos::parallel_for(
         "KokkosKernels::Common::StridedCopy", range_policy_t(my_exec_space, 0, num_reverse_elements + 1),
         StridedCopy<reverse_array_type, reverse_array_type>(tmp_color_xadj, reverse_map_xadj, scale_size));
-    my_exec_space.fence();
     Fill_Reverse_Scale_Map<forward_array_type, reverse_array_type> frm(
         forward_map, tmp_color_xadj, reverse_map_adj, multiply_shift_for_scale, division_shift_for_bucket);
     Kokkos::parallel_for("KokkosKernels::Common::FillReverseMap",
                          range_policy_t(my_exec_space, 0, num_forward_elements), frm);
-    my_exec_space.fence();
   } else
   // atomic implementation.
   {
@@ -624,18 +623,15 @@ void create_reverse_map(MyExecSpace my_exec_space,
 
     Kokkos::parallel_for("KokkosKernels::Common::ReverseMapInit",
                          range_policy_t(my_exec_space, 0, num_forward_elements), rmi);
-    my_exec_space.fence();
-    // print_1Dview(reverse_map_xadj);
 
     inclusive_parallel_prefix_sum<reverse_array_type, MyExecSpace>(my_exec_space, num_reverse_elements + 1,
                                                                    reverse_map_xadj);
     Kokkos::deep_copy(my_exec_space, tmp_color_xadj, reverse_map_xadj);
-    my_exec_space.fence();
     Fill_Reverse_Map<forward_array_type, reverse_array_type> frm(forward_map, tmp_color_xadj, reverse_map_adj);
     Kokkos::parallel_for("KokkosKernels::Common::FillReverseMap",
                          range_policy_t(my_exec_space, 0, num_forward_elements), frm);
-    my_exec_space.fence();
   }
+  my_exec_space.fence();
 }
 
 template <typename forward_array_type, typename reverse_array_type,

--- a/common/src/KokkosKernels_Utils.hpp
+++ b/common/src/KokkosKernels_Utils.hpp
@@ -496,7 +496,8 @@ struct Reverse_Map_Scale_Init {
     forward_type fm = forward_map[ii];
     fm              = fm << multiply_shift_for_scale;
     // Avoid shift by a negative number of bits (division_shift_for_bucket may be positive or negative)
-    size_t adjust = (division_shift_for_bucket >= 0) ? (ii >> division_shift_for_bucket) : (ii << (-division_shift_for_bucket));
+    size_t adjust =
+        (division_shift_for_bucket >= 0) ? (ii >> division_shift_for_bucket) : (ii << (-division_shift_for_bucket));
     Kokkos::atomic_fetch_add(&(reverse_map_xadj(fm + adjust)), atomic_incr_type(1));
   }
 };
@@ -528,9 +529,11 @@ struct Fill_Reverse_Scale_Map {
 
     fm = fm << multiply_shift_for_scale;
     // Avoid shift by a negative number of bits (division_shift_for_bucket may be positive or negative)
-    size_t adjust = (division_shift_for_bucket >= 0) ? (ii >> division_shift_for_bucket) : (ii << (-division_shift_for_bucket));
-    const reverse_type future_index = Kokkos::atomic_fetch_add(&(reverse_map_xadj(fm + adjust - 1)), atomic_incr_type(1));
-    reverse_map_adj(future_index)   = ii;
+    size_t adjust =
+        (division_shift_for_bucket >= 0) ? (ii >> division_shift_for_bucket) : (ii << (-division_shift_for_bucket));
+    const reverse_type future_index =
+        Kokkos::atomic_fetch_add(&(reverse_map_xadj(fm + adjust - 1)), atomic_incr_type(1));
+    reverse_map_adj(future_index) = ii;
   }
 };
 
@@ -542,9 +545,7 @@ struct StridedCopy {
   StridedCopy(const from_view_t from_, to_view_t to_, size_t stride_) : from(from_), to(to_), stride(stride_) {}
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const size_t &ii) const {
-    to[ii] = from[(ii + 1) * stride - 1];
-  }
+  void operator()(const size_t &ii) const { to[ii] = from[(ii + 1) * stride - 1]; }
 };
 
 /**
@@ -587,11 +588,12 @@ void create_reverse_map(MyExecSpace my_exec_space,
                                        num_forward_elements);
 
   if (num_reverse_elements < MINIMUM_TO_ATOMIC) {
-    // Number of reverse elements (e.g. colors) is small, so counting and filling with atomics would cause high contention.
-    // So expand each bucket into many sub-buckets.
-    const lno_t scale_size                = 1024;
-    const lno_t multiply_shift_for_scale  = 10;
-    const lno_t division_shift_for_bucket = num_forward_elements ? Kokkos::ceil(Kokkos::log2(double(num_forward_elements) / scale_size)) : 0;
+    // Number of reverse elements (e.g. colors) is small, so counting and filling with atomics would cause high
+    // contention. So expand each bucket into many sub-buckets.
+    const lno_t scale_size               = 1024;
+    const lno_t multiply_shift_for_scale = 10;
+    const lno_t division_shift_for_bucket =
+        num_forward_elements ? Kokkos::ceil(Kokkos::log2(double(num_forward_elements) / scale_size)) : 0;
     // const lno_t bucket_range_size = pow(2, division_shift_for_bucket);
 
     // coloring indices are base-1. we end up using not using element 1.

--- a/graph/impl/KokkosGraph_Distance2Color_impl.hpp
+++ b/graph/impl/KokkosGraph_Distance2Color_impl.hpp
@@ -1200,7 +1200,7 @@ class GraphColorDistance2 {
                 if (vid_d1 != vid) {
                   const color_type color        = _colors(vid_d1);
                   const color_type color_offset = color - offset;
-                  if (color && color_offset <= VBBIT_D2_COLORING_FORBIDDEN_SIZE) {
+                  if (color && color_offset < VBBIT_D2_COLORING_FORBIDDEN_SIZE) {
                     // if it is in the current range, then add the color to the
                     // banned colors
                     if (color > offset) {

--- a/graph/src/KokkosGraph_CoarsenConstruct.hpp
+++ b/graph/src/KokkosGraph_CoarsenConstruct.hpp
@@ -177,7 +177,7 @@ class coarse_builder {
     matrix_t mtx;
     vtx_view_t vtx_wgts;
     matrix_t interp_mtx;
-    int level = 0;
+    int level            = 0;
     bool uniform_weights = false;
   };
 

--- a/graph/src/KokkosGraph_CoarsenConstruct.hpp
+++ b/graph/src/KokkosGraph_CoarsenConstruct.hpp
@@ -177,8 +177,8 @@ class coarse_builder {
     matrix_t mtx;
     vtx_view_t vtx_wgts;
     matrix_t interp_mtx;
-    int level;
-    bool uniform_weights;
+    int level = 0;
+    bool uniform_weights = false;
   };
 
   // define behavior-controlling enums

--- a/sparse/unit_test/Test_Sparse_replaceSumInto.hpp
+++ b/sparse/unit_test/Test_Sparse_replaceSumInto.hpp
@@ -19,11 +19,6 @@
 #include <gtest/gtest.h>
 #include "KokkosSparse_CrsMatrix.hpp"
 
-// #ifndef kokkos_complex_double
-// #define kokkos_complex_double Kokkos::complex<double>
-// #define kokkos_complex_float Kokkos::complex<float>
-// #endif
-
 typedef Kokkos::complex<double> kokkos_complex_double;
 typedef Kokkos::complex<float> kokkos_complex_float;
 
@@ -40,8 +35,8 @@ class ModifyEvenNumberedRows {
   typedef typename CrsMatrixType::ordinal_type ordinal_type;
   typedef typename CrsMatrixType::value_type value_type;
 
-  ModifyEvenNumberedRows(const CrsMatrixType& A, const bool replace, const bool sorted, const bool /*atomic*/)
-      : A_(A), replace_(replace), sorted_(sorted) {}
+  ModifyEvenNumberedRows(const CrsMatrixType& A, const bool replace, const bool sorted, const bool atomic)
+      : A_(A), replace_(replace), sorted_(sorted), atomic_(atomic) {}
 
   KOKKOS_FUNCTION void operator()(const ordinal_type& lclRow) const {
     if (lclRow % static_cast<ordinal_type>(2) == 0) {

--- a/sparse/unit_test/Test_Sparse_replaceSumIntoLonger.hpp
+++ b/sparse/unit_test/Test_Sparse_replaceSumIntoLonger.hpp
@@ -41,8 +41,8 @@ class ModifyEntries {
   // The type of the reduction result.
   typedef ordinal_type value_type;
 
-  ModifyEntries(const CrsMatrixType& A, const bool replace, const bool sorted, const bool /*atomic*/)
-      : A_(A), replace_(replace), sorted_(sorted) {}
+  ModifyEntries(const CrsMatrixType& A, const bool replace, const bool sorted, const bool atomic)
+      : A_(A), replace_(replace), sorted_(sorted), atomic_(atomic) {}
 
   KOKKOS_FUNCTION void operator()(const ordinal_type& lclRow, ordinal_type& numModified) const {
     typedef Kokkos::ArithTraits<scalar_type> KAT;


### PR DESCRIPTION
Fix errors with ubsan. Now all tests pass in a configuration like the new ubuntu-asan-ubsan-ci build.

- replaceSumInto tests: initialize ``bool atomic_`` member
- Fix some issues with create_reverse_map  
    - Avoid shifting by negative number of bits (works in practice on tested architectures, but it's technically UB)
    - Use ``Kokkos::log2`` to simplify an expression
    - Avoid computing ``log2(0)``
    - Take out redundant fences
- Graph coarsening: Initialize bool member of struct. If uninitialized, its memory can contain any 8-bit value, not just 0 or 1.
- D2 coloring, VBBIT: fix color interval test. The forbidden colors considered at a time should be ``[color_offset, color_offset+64)`` with an exclusive upper bound. This matches the logic in VB.