### PR TITLE
Ode sycl fix

### DIFF
--- a/ode/unit_test/Test_ODE_RK_counts.hpp
+++ b/ode/unit_test/Test_ODE_RK_counts.hpp
@@ -134,8 +134,12 @@ void test_RK_count() {
     Test::RK_Count<RK>(TestDevice(), TestProblem::EnrightD2(), 1.e-5, 0.0, 590);
   }
   Test::RK_Count<RK>(TestDevice(), TestProblem::EnrightD4(), 1.e-5, 1.e-9, 932);
+#if defined(KOKKOS_ENABLE_SYCL)
   if constexpr ((RK != KokkosODE::Experimental::RK_type::RKF12) &&
                 !std::is_same_v<typename TestDevice::execution_space, Kokkos::Experimental::SYCL>) {
+#else
+  if constexpr (RK != KokkosODE::Experimental::RK_type::RKF12) {
+#endif
     Test::RK_Count<RK>(TestDevice(), TestProblem::KKStiffChemistry(), 1e-5, 0.0, 1);
   }
 }

--- a/ode/unit_test/Test_ODE_RK_counts.hpp
+++ b/ode/unit_test/Test_ODE_RK_counts.hpp
@@ -134,7 +134,7 @@ void test_RK_count() {
     Test::RK_Count<RK>(TestDevice(), TestProblem::EnrightD2(), 1.e-5, 0.0, 590);
   }
   Test::RK_Count<RK>(TestDevice(), TestProblem::EnrightD4(), 1.e-5, 1.e-9, 932);
-  if constexpr (RK != KokkosODE::Experimental::RK_type::RKF12) {
+  if constexpr ((RK != KokkosODE::Experimental::RK_type::RKF12) && !std::is_same_v<typename TestDevice::execution_space, Kokkos::Experimental::SYCL>) {
     Test::RK_Count<RK>(TestDevice(), TestProblem::KKStiffChemistry(), 1e-5, 0.0, 1);
   }
 }

--- a/ode/unit_test/Test_ODE_RK_counts.hpp
+++ b/ode/unit_test/Test_ODE_RK_counts.hpp
@@ -134,7 +134,8 @@ void test_RK_count() {
     Test::RK_Count<RK>(TestDevice(), TestProblem::EnrightD2(), 1.e-5, 0.0, 590);
   }
   Test::RK_Count<RK>(TestDevice(), TestProblem::EnrightD4(), 1.e-5, 1.e-9, 932);
-  if constexpr ((RK != KokkosODE::Experimental::RK_type::RKF12) && !std::is_same_v<typename TestDevice::execution_space, Kokkos::Experimental::SYCL>) {
+  if constexpr ((RK != KokkosODE::Experimental::RK_type::RKF12) &&
+                !std::is_same_v<typename TestDevice::execution_space, Kokkos::Experimental::SYCL>) {
     Test::RK_Count<RK>(TestDevice(), TestProblem::KKStiffChemistry(), 1e-5, 0.0, 1);
   }
 }


### PR DESCRIPTION
Excluding the Henderson autocatalytic ODE from the set of tests on the SYCL backend. This fails on Blake PVC node while it passes on Aurora. The issue could be related to the hardware or the toolchain, hard to diagnose at this point...