### PR TITLE
gtest: add cast to remove sign-compare comparison warning

### DIFF
--- a/tpls/gtest/gtest/gtest.h
+++ b/tpls/gtest/gtest/gtest.h
@@ -11424,7 +11424,7 @@ AssertionResult CmpHelperEQ(const char* lhs_expression,
                             const char* rhs_expression,
                             const T1& lhs,
                             const T2& rhs) {
-  if (lhs == rhs) {
+  if (lhs == T1(rhs)) {
     return AssertionSuccess();
   }
 


### PR DESCRIPTION
Resolve `error: comparison of integer expressions of different signedness: 'const long unsigned int' and 'const long int' [-Werror=sign-compare]`

The warning is triggering -Werror in Trilinos nightly integration builds