### PR TITLE
Only search for kokkos if it is not already found

### DIFF
--- a/cmake/KokkosKernelsConfig.cmake.in
+++ b/cmake/KokkosKernelsConfig.cmake.in
@@ -7,7 +7,9 @@ include(CMakeFindDependencyMacro)
 
 @KOKKOSKERNELS_TPL_EXPORTS@
 
-find_dependency(Kokkos HINTS @Kokkos_DIR@)
+IF(NOT Kokkos_FOUND)
+  find_dependency(Kokkos HINTS @Kokkos_DIR@)
+ENDIF()
 
 INCLUDE("${KokkosKernels_CMAKE_DIR}/KokkosKernelsTargets.cmake")
 


### PR DESCRIPTION
This proposes a partial fix for #2424 Nevertheless, I am not yet sure if we are actually want to go that way

What is the problem:
Kokkos misuses the `component` feature of CMake to specify if the compiler Kokkos defines as `CXX_COMPILER` will be launched globally. The default is a global set on everything in the directory. But Kokkos allows to specify `separable_compilation` as a required component which disables this behavior. Nevertheless, because of the logic that CMake uses to aggregate `find_package/dependency` commands (see [here](https://cmake.org/cmake/help/latest/module/CMakeFindDependencyMacro.html)), we overwrite the user choice if `separable_compilation` was specified.

If we guard for an already found Kokkos we allow the user to use the separable compilation feature like:
```
find_package(Kokkos COMPONENTS separable_compilation)
find_package(KokkosKernels)

add_executable(example_with_kokkos example_with_kokkos.cpp)
kokkos_compilation(TARGET example_with_kokkos) #this sets the compiler for the target to the appropriate one
target_link_libraries(example_with_kokkos PRIVATE Kokkos::kokkos Kokkos::kokkoskernels)

add_executable(example_without_kokkos foobar.cpp)
...

```

Alternative solution:
Kokkos sets the compiler only for the current scope ... so putting your kokkos files in a subdirectory with its own targets and link Kokkos in `PRIVATE` mode will allow to compile all other directories how the user prefers. Nevertheless this will not work if Kokkos is exposed in the other directories.

What do we need to discuss:

- [ ] does this work with kokkos/kokkos-kernels as part of trilinos
- [ ] This is a misuse of `components` in CMake ... Kokkos core should think about if this should stay this way.


