### PR TITLE
cleanup: remove unused KOKKOSBATCHED_IMPL_PROMOTION and deprecated __KOKKOSBATCHED_PROMOTION__

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -18,23 +18,6 @@
 
 /// \author Kyungjoo Kim (kyukim@sandia.gov)
 
-// no experimental name space guard for trilinos
-
-#if defined(KOKKOS_COMPILER_MSVC)
-#define KOKKOSBATCHED_IMPL_PROMOTION \
-  (__pragma(message("warning: __KOKKOSBATCHED_PROMOTION__ is deprecated and will be removed in a future version")) 1)
-#elif defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
-#define KOKKOSBATCHED_IMPL_PROMOTION                                                                              \
-  (__extension__({                                                                                                \
-    _Pragma("GCC warning \"__KOKKOSBATCHED_PROMOTION__ is deprecated and will be removed in a future version\""); \
-    1;                                                                                                            \
-  }))
-#else
-#define KOKKOSBATCHED_IMPL_PROMOTION 1  // no good way to deprecate?
-#endif
-
-#define __KOKKOSBATCHED_PROMOTION__ KOKKOSBATCHED_IMPL_PROMOTION
-
 #include <iomanip>
 #include <random>
 #include <string>


### PR DESCRIPTION
Deprecated in 4.5.00 via https://github.com/kokkos/kokkos-kernels/pull/2392

Also the replacement is unused and in the IMPL namespace, so remove it