### PR TITLE
fix: alias for serial trsv

### DIFF
--- a/batched/dense/src/KokkosBatched_Trsv_Decl.hpp
+++ b/batched/dense/src/KokkosBatched_Trsv_Decl.hpp
@@ -76,11 +76,11 @@ struct Trsv {
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const bViewType &b) {
     int r_val = 0;
-    if (std::is_same<ArgMode, Mode::Serial>::value) {
+    if (std::is_same_v<ArgMode, Mode::Serial>) {
       r_val = SerialTrsv<ArgUplo, ArgTrans, ArgDiag, ArgAlgo>::invoke(alpha, A, b);
-    } else if (std::is_same<ArgMode, Mode::Team>::value) {
+    } else if (std::is_same_v<ArgMode, Mode::Team>) {
       r_val = TeamTrsv<MemberType, ArgUplo, ArgTrans, ArgDiag, ArgAlgo>::invoke(member, alpha, A, b);
-    } else if (std::is_same<ArgMode, Mode::TeamVector>::value) {
+    } else if (std::is_same_v<ArgMode, Mode::TeamVector>) {
       r_val = TeamVectorTrsv<MemberType, ArgUplo, ArgTrans, ArgDiag, ArgAlgo>::invoke(member, alpha, A, b);
     }
     return r_val;
@@ -93,17 +93,29 @@ struct Trsv {
 #include "KokkosBatched_Trsv_Team_Impl.hpp"
 #include "KokkosBatched_Trsv_TeamVector_Impl.hpp"
 
-#define KOKKOSBATCHED_SERIAL_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS) \
-  KokkosBatched::SerialTrsvInternalLower<ALGOTYPE>::invoke(DIAG::use_unit_diag, M, ALPHA, A, AS0, AS1, B, BS)
+#define KOKKOSBATCHED_SERIAL_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS)  \
+  KokkosBatched::Impl::SerialTrsvInternalLower<ALGOTYPE>::invoke(DIAG::use_unit_diag, false, M, ALPHA, A, AS0, AS1, B, \
+                                                                 BS)
 
-#define KOKKOSBATCHED_SERIAL_TRSV_LOWER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS) \
-  KokkosBatched::SerialTrsvInternalUpper<ALGOTYPE>::invoke(DIAG::use_unit_diag, N, ALPHA, A, AS1, AS0, B, BS)
+#define KOKKOSBATCHED_SERIAL_TRSV_LOWER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS)     \
+  KokkosBatched::Impl::SerialTrsvInternalUpper<ALGOTYPE>::invoke(DIAG::use_unit_diag, false, N, ALPHA, A, AS1, AS0, B, \
+                                                                 BS)
 
-#define KOKKOSBATCHED_SERIAL_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS) \
-  KokkosBatched::SerialTrsvInternalUpper<ALGOTYPE>::invoke(DIAG::use_unit_diag, M, ALPHA, A, AS0, AS1, B, BS)
+#define KOKKOSBATCHED_SERIAL_TRSV_LOWER_CONJTRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS) \
+  KokkosBatched::Impl::SerialTrsvInternalUpper<ALGOTYPE>::invoke(DIAG::use_unit_diag, true, N, ALPHA, A, AS1, AS0, B,  \
+                                                                 BS)
 
-#define KOKKOSBATCHED_SERIAL_TRSV_UPPER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS) \
-  KokkosBatched::SerialTrsvInternalLower<ALGOTYPE>::invoke(DIAG::use_unit_diag, N, ALPHA, A, AS1, AS0, B, BS)
+#define KOKKOSBATCHED_SERIAL_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS)  \
+  KokkosBatched::Impl::SerialTrsvInternalUpper<ALGOTYPE>::invoke(DIAG::use_unit_diag, false, M, ALPHA, A, AS0, AS1, B, \
+                                                                 BS)
+
+#define KOKKOSBATCHED_SERIAL_TRSV_UPPER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS)     \
+  KokkosBatched::Impl::SerialTrsvInternalLower<ALGOTYPE>::invoke(DIAG::use_unit_diag, false, N, ALPHA, A, AS1, AS0, B, \
+                                                                 BS)
+
+#define KOKKOSBATCHED_SERIAL_TRSV_UPPER_CONJTRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS) \
+  KokkosBatched::Impl::SerialTrsvInternalLower<ALGOTYPE>::invoke(DIAG::use_unit_diag, true, N, ALPHA, A, AS1, AS0, B,  \
+                                                                 BS)
 
 #define KOKKOSBATCHED_TEAM_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, \
                                                                    B, BS)                                            \
@@ -143,46 +155,46 @@ struct Trsv {
 
 #define KOKKOSBATCHED_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(MODETYPE, ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0,   \
                                                               AS1, B, BS)                                              \
-  if (std::is_same<MODETYPE, KokkosBatched::Mode::Serial>::value) {                                                    \
+  if (std::is_same_v<MODETYPE, KokkosBatched::Mode::Serial>) {                                                         \
     KOKKOSBATCHED_SERIAL_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS);     \
-  } else if (std::is_same<MODETYPE, KokkosBatched::Mode::Team>::value) {                                               \
+  } else if (std::is_same_v<MODETYPE, KokkosBatched::Mode::Team>) {                                                    \
     KOKKOSBATCHED_TEAM_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, B,    \
                                                                BS);                                                    \
-  } else if (std::is_same<MODETYPE, KokkosBatched::Mode::TeamVector>::value) {                                         \
+  } else if (std::is_same_v<MODETYPE, KokkosBatched::Mode::TeamVector>) {                                              \
     KOKKOSBATCHED_TEAMVECTOR_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, \
                                                                      B, BS);                                           \
   }
 
 #define KOKKOSBATCHED_TRSV_LOWER_TRANSPOSE_INTERNAL_INVOKE(MODETYPE, ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, \
                                                            B, BS)                                                      \
-  if (std::is_same<MODETYPE, KokkosBatched::Mode::Serial>::value) {                                                    \
+  if (std::is_same_v<MODETYPE, KokkosBatched::Mode::Serial>) {                                                         \
     KOKKOSBATCHED_SERIAL_TRSV_LOWER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS);        \
-  } else if (std::is_same<MODETYPE, KokkosBatched::Mode::Team>::value) {                                               \
+  } else if (std::is_same_v<MODETYPE, KokkosBatched::Mode::Team>) {                                                    \
     KOKKOSBATCHED_TEAM_TRSV_LOWER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS);  \
-  } else if (std::is_same<MODETYPE, KokkosBatched::Mode::TeamVector>::value) {                                         \
+  } else if (std::is_same_v<MODETYPE, KokkosBatched::Mode::TeamVector>) {                                              \
     KOKKOSBATCHED_TEAMVECTOR_TRSV_LOWER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, B, \
                                                                   BS);                                                 \
   }
 
 #define KOKKOSBATCHED_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE(MODETYPE, ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0,   \
                                                               AS1, B, BS)                                              \
-  if (std::is_same<MODETYPE, KokkosBatched::Mode::Serial>::value) {                                                    \
+  if (std::is_same_v<MODETYPE, KokkosBatched::Mode::Serial>) {                                                         \
     KOKKOSBATCHED_SERIAL_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS);     \
-  } else if (std::is_same<MODETYPE, KokkosBatched::Mode::Team>::value) {                                               \
+  } else if (std::is_same_v<MODETYPE, KokkosBatched::Mode::Team>) {                                                    \
     KOKKOSBATCHED_TEAM_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, B,    \
                                                                BS);                                                    \
-  } else if (std::is_same<MODETYPE, KokkosBatched::Mode::TeamVector>::value) {                                         \
+  } else if (std::is_same_v<MODETYPE, KokkosBatched::Mode::TeamVector>) {                                              \
     KOKKOSBATCHED_TEAMVECTOR_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, \
                                                                      B, BS);                                           \
   }
 
 #define KOKKOSBATCHED_TRSV_UPPER_TRANSPOSE_INTERNAL_INVOKE(MODETYPE, ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, \
                                                            B, BS)                                                      \
-  if (std::is_same<MODETYPE, KokkosBatched::Mode::Serial>::value) {                                                    \
+  if (std::is_same_v<MODETYPE, KokkosBatched::Mode::Serial>) {                                                         \
     KOKKOSBATCHED_SERIAL_TRSV_UPPER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS);        \
-  } else if (std::is_same<MODETYPE, KokkosBatched::Mode::Team>::value) {                                               \
+  } else if (std::is_same_v<MODETYPE, KokkosBatched::Mode::Team>) {                                                    \
     KOKKOSBATCHED_TEAM_TRSV_UPPER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS);  \
-  } else if (std::is_same<MODETYPE, KokkosBatched::Mode::TeamVector>::value) {                                         \
+  } else if (std::is_same_v<MODETYPE, KokkosBatched::Mode::TeamVector>) {                                              \
     KOKKOSBATCHED_TEAMVECTOR_TRSV_UPPER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, B, \
                                                                   BS);                                                 \
   }


### PR DESCRIPTION
Fixes #2456

Because we moved the implementation details of `SerialTrsv` under `Impl` namespace, the definitions of aliases should also be updated