### PR TITLE
Deprecated remarks to trsv serial impl

### DIFF
--- a/batched/dense/impl/KokkosBatched_Trsv_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsv_Serial_Internal.hpp
@@ -216,26 +216,24 @@ KOKKOS_INLINE_FUNCTION int SerialTrsvInternalUpper<Algo::Trsv::Blocked>::invoke(
 }  // namespace Impl
 
 template <typename AlgoType>
-struct [[deprecated("Use KokkosBatched::SerialTrsv instead")]] SerialTrsvInternalLower{
-    template <typename ScalarType, typename ValueType>
-    KOKKOS_INLINE_FUNCTION static int invoke(const bool use_unit_diag, const int m, const ScalarType alpha,
-                                             const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
-                                             /**/ ValueType *KOKKOS_RESTRICT b, const int bs0){
-        return Impl::SerialTrsvInternalLower<AlgoType>::invoke(use_unit_diag, false, m, alpha, A, as0, as1, b, bs0);
-}  // namespace KokkosBatched
-}
-;
+struct [[deprecated("Use KokkosBatched::SerialTrsv instead")]] SerialTrsvInternalLower {
+  template <typename ScalarType, typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const bool use_unit_diag, const int m, const ScalarType alpha,
+                                           const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+                                           /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
+    return Impl::SerialTrsvInternalLower<AlgoType>::invoke(use_unit_diag, false, m, alpha, A, as0, as1, b, bs0);
+  }
+};
 
 template <typename AlgoType>
-struct [[deprecated("Use KokkosBatched::SerialTrsv instead")]] SerialTrsvInternalUpper{
-    template <typename ScalarType, typename ValueType>
-    KOKKOS_INLINE_FUNCTION static int invoke(const bool use_unit_diag, const int m, const ScalarType alpha,
-                                             const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
-                                             /**/ ValueType *KOKKOS_RESTRICT b, const int bs0){
-        return Impl::SerialTrsvInternalUpper<AlgoType>::invoke(use_unit_diag, false, m, alpha, A, as0, as1, b, bs0);
-}
-}
-;
+struct [[deprecated("Use KokkosBatched::SerialTrsv instead")]] SerialTrsvInternalUpper {
+  template <typename ScalarType, typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const bool use_unit_diag, const int m, const ScalarType alpha,
+                                           const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+                                           /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
+    return Impl::SerialTrsvInternalUpper<AlgoType>::invoke(use_unit_diag, false, m, alpha, A, as0, as1, b, bs0);
+  }
+};
 
 }  // namespace KokkosBatched
 

--- a/batched/dense/impl/KokkosBatched_Trsv_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsv_Serial_Internal.hpp
@@ -108,7 +108,7 @@ KOKKOS_INLINE_FUNCTION int SerialTrsvInternalLower<Algo::Trsv::Blocked>::invoke(
 
       // trsm update
       const ValueType *KOKKOS_RESTRICT Ap = A + p * as0 + p * as1;
-      /**/ ValueType *KOKKOS_RESTRICT bp  = b + p * bs0;
+      /**/ ValueType *KOKKOS_RESTRICT bp    = b + p * bs0;
 
       if (use_unit_diag)
         trsm_u.serial_invoke(Ap, pb, 1, bp);
@@ -154,8 +154,8 @@ KOKKOS_INLINE_FUNCTION int SerialTrsvInternalUpper<Algo::Trsv::Unblocked>::invok
     for (int p = (m - 1); p >= 0; --p) {
       const int iend = p;
 
-      const ValueType *KOKKOS_RESTRICT a01  = A + p * as1;
-      /**/ ValueType *KOKKOS_RESTRICT beta1 = b + p * bs0;
+      const ValueType *KOKKOS_RESTRICT a01 = A + p * as1;
+      /**/ ValueType *KOKKOS_RESTRICT beta1  = b + p * bs0;
 
       // with KOKKOS_RESTRICT a compiler assumes that the pointer is not
       // accessed by others op(/=) uses this pointer and changes the associated
@@ -198,7 +198,7 @@ KOKKOS_INLINE_FUNCTION int SerialTrsvInternalUpper<Algo::Trsv::Blocked>::invoke(
 
       // trsm update
       const ValueType *KOKKOS_RESTRICT Ap = A + p * as0 + p * as1;
-      /**/ ValueType *KOKKOS_RESTRICT bp  = b + p * bs0;
+      /**/ ValueType *KOKKOS_RESTRICT bp    = b + p * bs0;
 
       if (use_unit_diag)
         trsm_u.serial_invoke(Ap, pb, 1, bp);
@@ -214,6 +214,29 @@ KOKKOS_INLINE_FUNCTION int SerialTrsvInternalUpper<Algo::Trsv::Blocked>::invoke(
 }
 
 }  // namespace Impl
+
+template <typename AlgoType>
+struct [[deprecated("Use KokkosBatched::SerialTrsv instead")]] SerialTrsvInternalLower{
+    template <typename ScalarType, typename ValueType>
+    KOKKOS_INLINE_FUNCTION static int invoke(const bool use_unit_diag, const int m, const ScalarType alpha,
+                                             const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+                                             /**/ ValueType *KOKKOS_RESTRICT b, const int bs0){
+        return Impl::SerialTrsvInternalLower<AlgoType>::invoke(use_unit_diag, false, m, alpha, A, as0, as1, b, bs0);
+}  // namespace KokkosBatched
+}
+;
+
+template <typename AlgoType>
+struct [[deprecated("Use KokkosBatched::SerialTrsv instead")]] SerialTrsvInternalUpper{
+    template <typename ScalarType, typename ValueType>
+    KOKKOS_INLINE_FUNCTION static int invoke(const bool use_unit_diag, const int m, const ScalarType alpha,
+                                             const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+                                             /**/ ValueType *KOKKOS_RESTRICT b, const int bs0){
+        return Impl::SerialTrsvInternalUpper<AlgoType>::invoke(use_unit_diag, false, m, alpha, A, as0, as1, b, bs0);
+}
+}
+;
+
 }  // namespace KokkosBatched
 
 #endif

--- a/batched/dense/impl/KokkosBatched_Trsv_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsv_Serial_Internal.hpp
@@ -108,7 +108,7 @@ KOKKOS_INLINE_FUNCTION int SerialTrsvInternalLower<Algo::Trsv::Blocked>::invoke(
 
       // trsm update
       const ValueType *KOKKOS_RESTRICT Ap = A + p * as0 + p * as1;
-      /**/ ValueType *KOKKOS_RESTRICT bp    = b + p * bs0;
+      /**/ ValueType *KOKKOS_RESTRICT bp  = b + p * bs0;
 
       if (use_unit_diag)
         trsm_u.serial_invoke(Ap, pb, 1, bp);
@@ -154,8 +154,8 @@ KOKKOS_INLINE_FUNCTION int SerialTrsvInternalUpper<Algo::Trsv::Unblocked>::invok
     for (int p = (m - 1); p >= 0; --p) {
       const int iend = p;
 
-      const ValueType *KOKKOS_RESTRICT a01 = A + p * as1;
-      /**/ ValueType *KOKKOS_RESTRICT beta1  = b + p * bs0;
+      const ValueType *KOKKOS_RESTRICT a01  = A + p * as1;
+      /**/ ValueType *KOKKOS_RESTRICT beta1 = b + p * bs0;
 
       // with KOKKOS_RESTRICT a compiler assumes that the pointer is not
       // accessed by others op(/=) uses this pointer and changes the associated
@@ -198,7 +198,7 @@ KOKKOS_INLINE_FUNCTION int SerialTrsvInternalUpper<Algo::Trsv::Blocked>::invoke(
 
       // trsm update
       const ValueType *KOKKOS_RESTRICT Ap = A + p * as0 + p * as1;
-      /**/ ValueType *KOKKOS_RESTRICT bp    = b + p * bs0;
+      /**/ ValueType *KOKKOS_RESTRICT bp  = b + p * bs0;
 
       if (use_unit_diag)
         trsm_u.serial_invoke(Ap, pb, 1, bp);

--- a/batched/dense/src/KokkosBatched_Trsv_Decl.hpp
+++ b/batched/dense/src/KokkosBatched_Trsv_Decl.hpp
@@ -76,11 +76,11 @@ struct Trsv {
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const bViewType &b) {
     int r_val = 0;
-    if (std::is_same_v<ArgMode, Mode::Serial>) {
+    if constexpr (std::is_same_v<ArgMode, Mode::Serial>) {
       r_val = SerialTrsv<ArgUplo, ArgTrans, ArgDiag, ArgAlgo>::invoke(alpha, A, b);
-    } else if (std::is_same_v<ArgMode, Mode::Team>) {
+    } else if constexpr (std::is_same_v<ArgMode, Mode::Team>) {
       r_val = TeamTrsv<MemberType, ArgUplo, ArgTrans, ArgDiag, ArgAlgo>::invoke(member, alpha, A, b);
-    } else if (std::is_same_v<ArgMode, Mode::TeamVector>) {
+    } else if constexpr (std::is_same_v<ArgMode, Mode::TeamVector>) {
       r_val = TeamVectorTrsv<MemberType, ArgUplo, ArgTrans, ArgDiag, ArgAlgo>::invoke(member, alpha, A, b);
     }
     return r_val;
@@ -155,46 +155,46 @@ struct Trsv {
 
 #define KOKKOSBATCHED_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(MODETYPE, ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0,   \
                                                               AS1, B, BS)                                              \
-  if (std::is_same_v<MODETYPE, KokkosBatched::Mode::Serial>) {                                                         \
+  if constexpr (std::is_same_v<MODETYPE, KokkosBatched::Mode::Serial>) {                                               \
     KOKKOSBATCHED_SERIAL_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS);     \
-  } else if (std::is_same_v<MODETYPE, KokkosBatched::Mode::Team>) {                                                    \
+  } else if constexpr (std::is_same_v<MODETYPE, KokkosBatched::Mode::Team>) {                                          \
     KOKKOSBATCHED_TEAM_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, B,    \
                                                                BS);                                                    \
-  } else if (std::is_same_v<MODETYPE, KokkosBatched::Mode::TeamVector>) {                                              \
+  } else if constexpr (std::is_same_v<MODETYPE, KokkosBatched::Mode::TeamVector>) {                                    \
     KOKKOSBATCHED_TEAMVECTOR_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, \
                                                                      B, BS);                                           \
   }
 
 #define KOKKOSBATCHED_TRSV_LOWER_TRANSPOSE_INTERNAL_INVOKE(MODETYPE, ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, \
                                                            B, BS)                                                      \
-  if (std::is_same_v<MODETYPE, KokkosBatched::Mode::Serial>) {                                                         \
+  if constexpr (std::is_same_v<MODETYPE, KokkosBatched::Mode::Serial>) {                                               \
     KOKKOSBATCHED_SERIAL_TRSV_LOWER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS);        \
-  } else if (std::is_same_v<MODETYPE, KokkosBatched::Mode::Team>) {                                                    \
+  } else if constexpr (std::is_same_v<MODETYPE, KokkosBatched::Mode::Team>) {                                          \
     KOKKOSBATCHED_TEAM_TRSV_LOWER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS);  \
-  } else if (std::is_same_v<MODETYPE, KokkosBatched::Mode::TeamVector>) {                                              \
+  } else if constexpr (std::is_same_v<MODETYPE, KokkosBatched::Mode::TeamVector>) {                                    \
     KOKKOSBATCHED_TEAMVECTOR_TRSV_LOWER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, B, \
                                                                   BS);                                                 \
   }
 
 #define KOKKOSBATCHED_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE(MODETYPE, ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0,   \
                                                               AS1, B, BS)                                              \
-  if (std::is_same_v<MODETYPE, KokkosBatched::Mode::Serial>) {                                                         \
+  if constexpr (std::is_same_v<MODETYPE, KokkosBatched::Mode::Serial>) {                                               \
     KOKKOSBATCHED_SERIAL_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS);     \
-  } else if (std::is_same_v<MODETYPE, KokkosBatched::Mode::Team>) {                                                    \
+  } else if constexpr (std::is_same_v<MODETYPE, KokkosBatched::Mode::Team>) {                                          \
     KOKKOSBATCHED_TEAM_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, B,    \
                                                                BS);                                                    \
-  } else if (std::is_same_v<MODETYPE, KokkosBatched::Mode::TeamVector>) {                                              \
+  } else if constexpr (std::is_same_v<MODETYPE, KokkosBatched::Mode::TeamVector>) {                                    \
     KOKKOSBATCHED_TEAMVECTOR_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, \
                                                                      B, BS);                                           \
   }
 
 #define KOKKOSBATCHED_TRSV_UPPER_TRANSPOSE_INTERNAL_INVOKE(MODETYPE, ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, \
                                                            B, BS)                                                      \
-  if (std::is_same_v<MODETYPE, KokkosBatched::Mode::Serial>) {                                                         \
+  if constexpr (std::is_same_v<MODETYPE, KokkosBatched::Mode::Serial>) {                                               \
     KOKKOSBATCHED_SERIAL_TRSV_UPPER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS);        \
-  } else if (std::is_same_v<MODETYPE, KokkosBatched::Mode::Team>) {                                                    \
+  } else if constexpr (std::is_same_v<MODETYPE, KokkosBatched::Mode::Team>) {                                          \
     KOKKOSBATCHED_TEAM_TRSV_UPPER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, B, BS);  \
-  } else if (std::is_same_v<MODETYPE, KokkosBatched::Mode::TeamVector>) {                                              \
+  } else if constexpr (std::is_same_v<MODETYPE, KokkosBatched::Mode::TeamVector>) {                                    \
     KOKKOSBATCHED_TEAMVECTOR_TRSV_UPPER_TRANSPOSE_INTERNAL_INVOKE(ALGOTYPE, MEMBER, DIAG, M, N, ALPHA, A, AS0, AS1, B, \
                                                                   BS);                                                 \
   }


### PR DESCRIPTION
Improves #2456 

- [x] Add deprecated remarks to the older interfaces that are implementation details
- [x] Use `if constexpr` for selective interface because the check can be made at compile time