### PR TITLE
Fix -Werror in a couple wiki examples

### DIFF
--- a/example/wiki/blas/KokkosBlas1_wiki_rotg_rot.cpp
+++ b/example/wiki/blas/KokkosBlas1_wiki_rotg_rot.cpp
@@ -11,7 +11,7 @@ using Vector          = Kokkos::View<Scalar*, execution_space>;
 using ScalarView      = Kokkos::View<Scalar, execution_space>;
 
 int main(int argc, char* argv[]) {
-  Kokkos::initialize();
+  Kokkos::initialize(argc, argv);
   {
     const int N = 10;
     Vector x("x", N);

--- a/example/wiki/blas/KokkosBlas1_wiki_rotmg_rotm.cpp
+++ b/example/wiki/blas/KokkosBlas1_wiki_rotmg_rotm.cpp
@@ -12,7 +12,7 @@ using ParamView       = Kokkos::View<Scalar[5], execution_space>;
 using ScalarView      = Kokkos::View<Scalar, execution_space>;
 
 int main(int argc, char* argv[]) {
-  Kokkos::initialize();
+  Kokkos::initialize(argc, argv);
   {
     const int N = 10;
     Vector x("x", N);


### PR DESCRIPTION
Resolves warnings error: unused parameter 'argc'
[-Werror=unused-parameter] etc.