### PR TITLE
Refactor serial tbsv implementation details and tests

### DIFF
--- a/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Internal.hpp
@@ -17,6 +17,7 @@
 #ifndef KOKKOSBATCHED_PBTRS_SERIAL_INTERNAL_HPP_
 #define KOKKOSBATCHED_PBTRS_SERIAL_INTERNAL_HPP_
 
+#include "KokkosBlas_util.hpp"
 #include "KokkosBatched_Util.hpp"
 #include "KokkosBatched_Tbsv_Serial_Internal.hpp"
 
@@ -50,8 +51,9 @@ KOKKOS_INLINE_FUNCTION int SerialPbtrsInternalLower<Algo::Pbtrs::Unblocked>::inv
   SerialTbsvInternalLower<Algo::Tbsv::Unblocked>::invoke(false, an, A, as0, as1, x, xs0, kd);
 
   // Solve L**T *X = B, overwriting B with X.
-  constexpr bool do_conj = Kokkos::ArithTraits<ValueType>::is_complex;
-  SerialTbsvInternalLowerTranspose<Algo::Tbsv::Unblocked>::invoke(false, do_conj, an, A, as0, as1, x, xs0, kd);
+  using op =
+      std::conditional_t<Kokkos::ArithTraits<ValueType>::is_complex, KokkosBlas::Impl::OpConj, KokkosBlas::Impl::OpID>;
+  SerialTbsvInternalLowerTranspose<Algo::Tbsv::Unblocked>::invoke(op(), false, an, A, as0, as1, x, xs0, kd);
 
   return 0;
 }
@@ -76,8 +78,9 @@ KOKKOS_INLINE_FUNCTION int SerialPbtrsInternalUpper<Algo::Pbtrs::Unblocked>::inv
                                                                                     /**/ ValueType *KOKKOS_RESTRICT x,
                                                                                     const int xs0, const int kd) {
   // Solve U**T *X = B, overwriting B with X.
-  constexpr bool do_conj = Kokkos::ArithTraits<ValueType>::is_complex;
-  SerialTbsvInternalUpperTranspose<Algo::Tbsv::Unblocked>::invoke(false, do_conj, an, A, as0, as1, x, xs0, kd);
+  using op =
+      std::conditional_t<Kokkos::ArithTraits<ValueType>::is_complex, KokkosBlas::Impl::OpConj, KokkosBlas::Impl::OpID>;
+  SerialTbsvInternalUpperTranspose<Algo::Tbsv::Unblocked>::invoke(op(), false, an, A, as0, as1, x, xs0, kd);
 
   // Solve U*X = B, overwriting B with X.
   SerialTbsvInternalUpper<Algo::Tbsv::Unblocked>::invoke(false, an, A, as0, as1, x, xs0, kd);

--- a/batched/dense/impl/KokkosBatched_Tbsv_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Tbsv_Serial_Impl.hpp
@@ -19,16 +19,17 @@
 
 /// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
 
+#include "KokkosBlas_util.hpp"
 #include "KokkosBatched_Util.hpp"
 #include "KokkosBatched_Tbsv_Serial_Internal.hpp"
 
 namespace KokkosBatched {
-
+namespace Impl {
 template <typename AViewType, typename XViewType>
 KOKKOS_INLINE_FUNCTION static int checkTbsvInput([[maybe_unused]] const AViewType &A,
                                                  [[maybe_unused]] const XViewType &x, [[maybe_unused]] const int k) {
-  static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::tbsv: AViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::tbsv: XViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view_v<AViewType>, "KokkosBatched::tbsv: AViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view_v<XViewType>, "KokkosBatched::tbsv: XViewType is not a Kokkos::View.");
   static_assert(AViewType::rank == 2, "KokkosBatched::tbsv: AViewType must have rank 2.");
   static_assert(XViewType::rank == 1, "KokkosBatched::tbsv: XViewType must have rank 1.");
 
@@ -63,15 +64,17 @@ KOKKOS_INLINE_FUNCTION static int checkTbsvInput([[maybe_unused]] const AViewTyp
   return 0;
 }
 
+}  // namespace Impl
+
 //// Lower non-transpose ////
 template <typename ArgDiag>
 struct SerialTbsv<Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::Tbsv::Unblocked> {
   template <typename AViewType, typename XViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const XViewType &x, const int k) {
-    auto info = checkTbsvInput(A, x, k);
+    auto info = Impl::checkTbsvInput(A, x, k);
     if (info) return info;
 
-    return SerialTbsvInternalLower<Algo::Tbsv::Unblocked>::invoke(
+    return Impl::SerialTbsvInternalLower<Algo::Tbsv::Unblocked>::invoke(
         ArgDiag::use_unit_diag, A.extent(1), A.data(), A.stride_0(), A.stride_1(), x.data(), x.stride_0(), k);
   }
 };
@@ -81,11 +84,12 @@ template <typename ArgDiag>
 struct SerialTbsv<Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Tbsv::Unblocked> {
   template <typename AViewType, typename XViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const XViewType &x, const int k) {
-    auto info = checkTbsvInput(A, x, k);
+    auto info = Impl::checkTbsvInput(A, x, k);
     if (info) return info;
 
-    return SerialTbsvInternalLowerTranspose<Algo::Tbsv::Unblocked>::invoke(
-        ArgDiag::use_unit_diag, false, A.extent(1), A.data(), A.stride_0(), A.stride_1(), x.data(), x.stride_0(), k);
+    return Impl::SerialTbsvInternalLowerTranspose<Algo::Tbsv::Unblocked>::invoke(
+        KokkosBlas::Impl::OpID(), ArgDiag::use_unit_diag, A.extent(1), A.data(), A.stride_0(), A.stride_1(), x.data(),
+        x.stride_0(), k);
   }
 };
 
@@ -94,11 +98,12 @@ template <typename ArgDiag>
 struct SerialTbsv<Uplo::Lower, Trans::ConjTranspose, ArgDiag, Algo::Tbsv::Unblocked> {
   template <typename AViewType, typename XViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const XViewType &x, const int k) {
-    auto info = checkTbsvInput(A, x, k);
+    auto info = Impl::checkTbsvInput(A, x, k);
     if (info) return info;
 
-    return SerialTbsvInternalLowerTranspose<Algo::Tbsv::Unblocked>::invoke(
-        ArgDiag::use_unit_diag, true, A.extent(1), A.data(), A.stride_0(), A.stride_1(), x.data(), x.stride_0(), k);
+    return Impl::SerialTbsvInternalLowerTranspose<Algo::Tbsv::Unblocked>::invoke(
+        KokkosBlas::Impl::OpConj(), ArgDiag::use_unit_diag, A.extent(1), A.data(), A.stride_0(), A.stride_1(), x.data(),
+        x.stride_0(), k);
   }
 };
 
@@ -107,10 +112,10 @@ template <typename ArgDiag>
 struct SerialTbsv<Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::Tbsv::Unblocked> {
   template <typename AViewType, typename XViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const XViewType &x, const int k) {
-    auto info = checkTbsvInput(A, x, k);
+    auto info = Impl::checkTbsvInput(A, x, k);
     if (info) return info;
 
-    return SerialTbsvInternalUpper<Algo::Tbsv::Unblocked>::invoke(
+    return Impl::SerialTbsvInternalUpper<Algo::Tbsv::Unblocked>::invoke(
         ArgDiag::use_unit_diag, A.extent(1), A.data(), A.stride_0(), A.stride_1(), x.data(), x.stride_0(), k);
   }
 };
@@ -120,11 +125,12 @@ template <typename ArgDiag>
 struct SerialTbsv<Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Tbsv::Unblocked> {
   template <typename AViewType, typename XViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const XViewType &x, const int k) {
-    auto info = checkTbsvInput(A, x, k);
+    auto info = Impl::checkTbsvInput(A, x, k);
     if (info) return info;
 
-    return SerialTbsvInternalUpperTranspose<Algo::Tbsv::Unblocked>::invoke(
-        ArgDiag::use_unit_diag, false, A.extent(1), A.data(), A.stride_0(), A.stride_1(), x.data(), x.stride_0(), k);
+    return Impl::SerialTbsvInternalUpperTranspose<Algo::Tbsv::Unblocked>::invoke(
+        KokkosBlas::Impl::OpID(), ArgDiag::use_unit_diag, A.extent(1), A.data(), A.stride_0(), A.stride_1(), x.data(),
+        x.stride_0(), k);
   }
 };
 
@@ -133,11 +139,12 @@ template <typename ArgDiag>
 struct SerialTbsv<Uplo::Upper, Trans::ConjTranspose, ArgDiag, Algo::Tbsv::Unblocked> {
   template <typename AViewType, typename XViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const XViewType &x, const int k) {
-    auto info = checkTbsvInput(A, x, k);
+    auto info = Impl::checkTbsvInput(A, x, k);
     if (info) return info;
 
-    return SerialTbsvInternalUpperTranspose<Algo::Tbsv::Unblocked>::invoke(
-        ArgDiag::use_unit_diag, true, A.extent(1), A.data(), A.stride_0(), A.stride_1(), x.data(), x.stride_0(), k);
+    return Impl::SerialTbsvInternalUpperTranspose<Algo::Tbsv::Unblocked>::invoke(
+        KokkosBlas::Impl::OpConj(), ArgDiag::use_unit_diag, A.extent(1), A.data(), A.stride_0(), A.stride_1(), x.data(),
+        x.stride_0(), k);
   }
 };
 

--- a/batched/dense/impl/KokkosBatched_Tbsv_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Tbsv_Serial_Internal.hpp
@@ -22,13 +22,13 @@
 #include "KokkosBatched_Util.hpp"
 
 namespace KokkosBatched {
-
+namespace Impl {
 ///
 /// Serial Internal Impl
 /// ====================
 
 ///
-/// Lower, Non-Transpose
+/// Lower
 ///
 
 template <typename AlgoType>
@@ -70,41 +70,29 @@ KOKKOS_INLINE_FUNCTION int SerialTbsvInternalLower<Algo::Tbsv::Unblocked>::invok
 
 template <typename AlgoType>
 struct SerialTbsvInternalLowerTranspose {
-  template <typename ValueType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const bool use_unit_diag, const bool do_conj, const int an,
+  template <typename Op, typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(Op op, const bool use_unit_diag, const int an,
                                            const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
                                            /**/ ValueType *KOKKOS_RESTRICT x, const int xs0, const int k);
 };
 
 template <>
-template <typename ValueType>
+template <typename Op, typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialTbsvInternalLowerTranspose<Algo::Tbsv::Unblocked>::invoke(
-    const bool use_unit_diag, const bool do_conj, const int an, const ValueType *KOKKOS_RESTRICT A, const int as0,
-    const int as1,
+    Op op, const bool use_unit_diag, const int an, const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
     /**/ ValueType *KOKKOS_RESTRICT x, const int xs0, const int k) {
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
 #endif
   for (int j = an - 1; j >= 0; --j) {
     auto temp = x[j * xs0];
-
-    if (do_conj) {
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
 #endif
-      for (int i = Kokkos::min(an - 1, j + k); i > j; --i) {
-        temp -= Kokkos::ArithTraits<ValueType>::conj(A[(i - j) * as0 + j * as1]) * x[i * xs0];
-      }
-      if (!use_unit_diag) temp = temp / Kokkos::ArithTraits<ValueType>::conj(A[0 + j * as1]);
-    } else {
-#if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
-#pragma unroll
-#endif
-      for (int i = Kokkos::min(an - 1, j + k); i > j; --i) {
-        temp -= A[(i - j) * as0 + j * as1] * x[i * xs0];
-      }
-      if (!use_unit_diag) temp = temp / A[0 + j * as1];
+    for (int i = Kokkos::min(an - 1, j + k); i > j; --i) {
+      temp -= op(A[(i - j) * as0 + j * as1]) * x[i * xs0];
     }
+    if (!use_unit_diag) temp = temp / op(A[0 + j * as1]);
     x[j * xs0] = temp;
   }
 
@@ -112,7 +100,7 @@ KOKKOS_INLINE_FUNCTION int SerialTbsvInternalLowerTranspose<Algo::Tbsv::Unblocke
 }
 
 ///
-/// Upper, Non-Transpose
+/// Upper
 ///
 
 template <typename AlgoType>
@@ -154,46 +142,36 @@ KOKKOS_INLINE_FUNCTION int SerialTbsvInternalUpper<Algo::Tbsv::Unblocked>::invok
 
 template <typename AlgoType>
 struct SerialTbsvInternalUpperTranspose {
-  template <typename ValueType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const bool use_unit_diag, const bool do_conj, const int an,
+  template <typename Op, typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(Op op, const bool use_unit_diag, const int an,
                                            const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
                                            /**/ ValueType *KOKKOS_RESTRICT x, const int xs0, const int k);
 };
 
 template <>
-template <typename ValueType>
+template <typename Op, typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialTbsvInternalUpperTranspose<Algo::Tbsv::Unblocked>::invoke(
-    const bool use_unit_diag, const bool do_conj, const int an, const ValueType *KOKKOS_RESTRICT A, const int as0,
-    const int as1,
+    Op op, const bool use_unit_diag, const int an, const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
     /**/ ValueType *KOKKOS_RESTRICT x, const int xs0, const int k) {
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
 #endif
   for (int j = 0; j < an; j++) {
     auto temp = x[j * xs0];
-    if (do_conj) {
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
 #endif
-      for (int i = Kokkos::max(0, j - k); i < j; ++i) {
-        temp -= Kokkos::ArithTraits<ValueType>::conj(A[(i + k - j) * as0 + j * as1]) * x[i * xs0];
-      }
-      if (!use_unit_diag) temp = temp / Kokkos::ArithTraits<ValueType>::conj(A[k * as0 + j * as1]);
-    } else {
-#if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
-#pragma unroll
-#endif
-      for (int i = Kokkos::max(0, j - k); i < j; ++i) {
-        temp -= A[(i + k - j) * as0 + j * as1] * x[i * xs0];
-      }
-      if (!use_unit_diag) temp = temp / A[k * as0 + j * as1];
+    for (int i = Kokkos::max(0, j - k); i < j; ++i) {
+      temp -= op(A[(i + k - j) * as0 + j * as1]) * x[i * xs0];
     }
+    if (!use_unit_diag) temp = temp / op(A[k * as0 + j * as1]);
     x[j * xs0] = temp;
   }
 
   return 0;
 }
 
+}  // namespace Impl
 }  // namespace KokkosBatched
 
 #endif  // KOKKOSBATCHED_TBSV_SERIAL_INTERNAL_HPP_

--- a/batched/dense/src/KokkosBatched_Tbsv.hpp
+++ b/batched/dense/src/KokkosBatched_Tbsv.hpp
@@ -29,6 +29,15 @@ namespace KokkosBatched {
 ///   non-unit, upper or lower triangular band matrix, with ( k + 1 )
 ///   diagonals.
 ///
+/// \tparam ArgUplo: Type indicating whether A is the upper (Uplo::Upper) or lower (Uplo::Lower) triangular matrix
+/// \tparam ArgTrans: Type indicating the equations to be solved as follows
+///  - ArgTrans::NoTranspose:   A * X = B
+///  - ArgTrans::Transpose:     A**T * X = B
+///  - ArgTrans::ConjTranspose: A**H * X = B
+/// \tparam ArgDiag: Type indicating whether A is the unit (Diag::Unit) or non-unit (Diag::NonUnit) triangular matrix
+/// \tparam ArgAlgo: Type indicating the blocked (KokkosBatched::Algo::Tbsv::Blocked) or unblocked
+/// (KokkosBatched::Algo::Tbsv::Unblocked) algorithm to be used
+///
 /// \tparam AViewType: Input type for the matrix, needs to be a 2D view
 /// \tparam XViewType: Input type for the right-hand side and the solution,
 /// needs to be a 1D view
@@ -43,6 +52,16 @@ namespace KokkosBatched {
 
 template <typename ArgUplo, typename ArgTrans, typename ArgDiag, typename ArgAlgo>
 struct SerialTbsv {
+  static_assert(
+      std::is_same_v<ArgUplo, Uplo::Upper> || std::is_same_v<ArgUplo, Uplo::Lower>,
+      "KokkosBatched::tbsv: Use Uplo::Upper for upper triangular matrix or Uplo::Lower for lower triangular matrix");
+  static_assert(std::is_same_v<ArgTrans, Trans::NoTranspose> || std::is_same_v<ArgTrans, Trans::Transpose> ||
+                    std::is_same_v<ArgTrans, Trans::ConjTranspose>,
+                "KokkosBatched::tbsv: Use Trans::NoTranspose, Trans::Transpose or Trans::ConjTranspose");
+  static_assert(
+      std::is_same_v<ArgDiag, Diag::Unit> || std::is_same_v<ArgDiag, Diag::NonUnit>,
+      "KokkosBatched::tbsv: Use Diag::Unit for unit triangular matrix or Diag::NonUnit for non-unit triangular matrix");
+  static_assert(std::is_same_v<ArgAlgo, Algo::Tbsv::Unblocked>, "KokkosBatched::tbsv: Use Algo::Tbsv::Unblocked");
   template <typename AViewType, typename XViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const XViewType &X, const int k);
 };

--- a/batched/dense/unit_test/Test_Batched_SerialTbsv.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTbsv.hpp
@@ -143,7 +143,7 @@ void impl_test_batched_tbsv(const int N, const int k, const int BlkSize) {
   auto h_x1 = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), x1);
   for (int i = 0; i < N; i++) {
     for (int j = 0; j < BlkSize; j++) {
-      EXPECT_NEAR_KK(h_x0(i, j), h_x1(i, j), eps);
+      Test::EXPECT_NEAR_KK_REL(h_x0(i, j), h_x1(i, j), eps);
     }
   }
 }
@@ -252,7 +252,7 @@ void impl_test_batched_tbsv_analytical(const std::size_t N) {
   auto h_x_ref = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), x_ref);
   for (std::size_t ib = 0; ib < N; ib++) {
     for (std::size_t j = 0; j < BlkSize; j++) {
-      Test::EXPECT_NEAR_KK_REL(h_x0(ib, j), h_x_ref(ib, j), eps);
+      EXPECT_NEAR_KK(h_x0(ib, j), h_x_ref(ib, j), eps);
     }
   }
 
@@ -261,7 +261,7 @@ void impl_test_batched_tbsv_analytical(const std::size_t N) {
   Kokkos::deep_copy(h_x0, x0);
   for (std::size_t ib = 0; ib < N; ib++) {
     for (std::size_t j = 0; j < BlkSize; j++) {
-      Test::EXPECT_NEAR_KK_REL(h_x0(ib, j), h_x_ref(ib, j), eps);
+      EXPECT_NEAR_KK(h_x0(ib, j), h_x_ref(ib, j), eps);
     }
   }
 }

--- a/batched/dense/unit_test/Test_Batched_SerialTbsv.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTbsv.hpp
@@ -22,8 +22,6 @@
 #include "KokkosBatched_Tbsv.hpp"
 #include "Test_Batched_DenseUtils.hpp"
 
-using namespace KokkosBatched;
-
 namespace Test {
 namespace Tbsv {
 
@@ -38,22 +36,22 @@ template <typename DeviceType, typename AViewType, typename BViewType, typename 
           typename AlgoTagType>
 struct Functor_BatchedSerialTrsv {
   using execution_space = typename DeviceType::execution_space;
-  AViewType _a;
-  BViewType _b;
+  AViewType m_a;
+  BViewType m_b;
 
-  ScalarType _alpha;
+  ScalarType m_alpha;
 
   KOKKOS_INLINE_FUNCTION
   Functor_BatchedSerialTrsv(const ScalarType alpha, const AViewType &a, const BViewType &b)
-      : _a(a), _b(b), _alpha(alpha) {}
+      : m_a(a), m_b(b), m_alpha(alpha) {}
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const ParamTagType &, const int k) const {
-    auto aa = Kokkos::subview(_a, k, Kokkos::ALL(), Kokkos::ALL());
-    auto bb = Kokkos::subview(_b, k, Kokkos::ALL());
+    auto aa = Kokkos::subview(m_a, k, Kokkos::ALL(), Kokkos::ALL());
+    auto bb = Kokkos::subview(m_b, k, Kokkos::ALL());
 
     KokkosBatched::SerialTrsv<typename ParamTagType::uplo, typename ParamTagType::trans, typename ParamTagType::diag,
-                              AlgoTagType>::invoke(_alpha, aa, bb);
+                              AlgoTagType>::invoke(m_alpha, aa, bb);
   }
 
   inline void run() {
@@ -61,7 +59,7 @@ struct Functor_BatchedSerialTrsv {
     std::string name_region("KokkosBatched::Test::SerialTbsv");
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
-    Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, _b.extent(0));
+    Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, m_b.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
   }
 };
@@ -69,20 +67,20 @@ struct Functor_BatchedSerialTrsv {
 template <typename DeviceType, typename AViewType, typename BViewType, typename ParamTagType, typename AlgoTagType>
 struct Functor_BatchedSerialTbsv {
   using execution_space = typename DeviceType::execution_space;
-  AViewType _a;
-  BViewType _b;
-  int _k;
+  AViewType m_a;
+  BViewType m_b;
+  int m_k;
 
   KOKKOS_INLINE_FUNCTION
-  Functor_BatchedSerialTbsv(const AViewType &a, const BViewType &b, const int k) : _a(a), _b(b), _k(k) {}
+  Functor_BatchedSerialTbsv(const AViewType &a, const BViewType &b, const int k) : m_a(a), m_b(b), m_k(k) {}
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const ParamTagType &, const int k) const {
-    auto aa = Kokkos::subview(_a, k, Kokkos::ALL(), Kokkos::ALL());
-    auto bb = Kokkos::subview(_b, k, Kokkos::ALL());
+    auto aa = Kokkos::subview(m_a, k, Kokkos::ALL(), Kokkos::ALL());
+    auto bb = Kokkos::subview(m_b, k, Kokkos::ALL());
 
     KokkosBatched::SerialTbsv<typename ParamTagType::uplo, typename ParamTagType::trans, typename ParamTagType::diag,
-                              AlgoTagType>::invoke(aa, bb, _k);
+                              AlgoTagType>::invoke(aa, bb, m_k);
   }
 
   inline void run() {
@@ -91,7 +89,7 @@ struct Functor_BatchedSerialTbsv {
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, _b.extent(0));
+    Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, m_b.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }
@@ -126,8 +124,8 @@ void impl_test_batched_tbsv(const int N, const int k, const int BlkSize) {
   create_banded_triangular_matrix<View3DType, View3DType, typename ParamTagType::uplo>(Ref, Ab, k, true);
 
   // Reference trsv
-  Functor_BatchedSerialTrsv<DeviceType, View3DType, View2DType, ScalarType, ParamTagType, Algo::Trsv::Unblocked>(1.0, A,
-                                                                                                                 x0)
+  Functor_BatchedSerialTrsv<DeviceType, View3DType, View2DType, ScalarType, ParamTagType,
+                            KokkosBatched::Algo::Trsv::Unblocked>(1.0, A, x0)
       .run();
 
   // tbsv
@@ -185,8 +183,8 @@ void impl_test_batched_tbsv_analytical(const std::size_t N) {
         }
 
         if (std::is_same_v<typename ParamTagType::uplo, KokkosBatched::Uplo::Upper>) {
-          if (std::is_same_v<typename ParamTagType::trans, Trans::NoTranspose>) {
-            if (std::is_same_v<typename ParamTagType::diag, Diag::NonUnit>) {
+          if (std::is_same_v<typename ParamTagType::trans, KokkosBatched::Trans::NoTranspose>) {
+            if (std::is_same_v<typename ParamTagType::diag, KokkosBatched::Diag::NonUnit>) {
               x_ref(ib, 0) = 1.0 / 2.0;
               x_ref(ib, 1) = 1.0 / 6.0;
               x_ref(ib, 2) = 1.0 / 3.0;
@@ -196,7 +194,7 @@ void impl_test_batched_tbsv_analytical(const std::size_t N) {
               x_ref(ib, 2) = 1.0;
             }
           } else {
-            if (std::is_same_v<typename ParamTagType::diag, Diag::NonUnit>) {
+            if (std::is_same_v<typename ParamTagType::diag, KokkosBatched::Diag::NonUnit>) {
               x_ref(ib, 0) = 1.0;
               x_ref(ib, 1) = 0.0;
               x_ref(ib, 2) = 0.0;
@@ -207,8 +205,8 @@ void impl_test_batched_tbsv_analytical(const std::size_t N) {
             }
           }
         } else {
-          if (std::is_same_v<typename ParamTagType::trans, Trans::NoTranspose>) {
-            if (std::is_same_v<typename ParamTagType::diag, Diag::NonUnit>) {
+          if (std::is_same_v<typename ParamTagType::trans, KokkosBatched::Trans::NoTranspose>) {
+            if (std::is_same_v<typename ParamTagType::diag, KokkosBatched::Diag::NonUnit>) {
               x_ref(ib, 0) = 1.0;
               x_ref(ib, 1) = -1.0 / 2.0;
               x_ref(ib, 2) = -1.0 / 6.0;
@@ -218,7 +216,7 @@ void impl_test_batched_tbsv_analytical(const std::size_t N) {
               x_ref(ib, 2) = 1.0;
             }
           } else {
-            if (std::is_same_v<typename ParamTagType::diag, Diag::NonUnit>) {
+            if (std::is_same_v<typename ParamTagType::diag, KokkosBatched::Diag::NonUnit>) {
               x_ref(ib, 0) = 0.0;
               x_ref(ib, 1) = 0.0;
               x_ref(ib, 2) = 1.0 / 3.0;
@@ -245,37 +243,25 @@ void impl_test_batched_tbsv_analytical(const std::size_t N) {
 
   Kokkos::fence();
 
-  // Check x0 = x_ref and x1 = x_ref
-  // Firstly, prepare contiguous views on host
-  auto h_x0 = Kokkos::create_mirror_view(x0);
-  auto h_x1 = Kokkos::create_mirror_view(x0);
-
-  Kokkos::deep_copy(h_x0, x0);
-
-  // Pack x1 into x0 for contiguous storage
-  Kokkos::parallel_for(
-      "KokkosBatched::Test::SerialTbsv::Copy", policy, KOKKOS_LAMBDA(const std::size_t ib) {
-        for (std::size_t j = 0; j < BlkSize; j++) {
-          x0(ib, j) = x1(ib, j);
-        }
-      });
-
-  Kokkos::fence();
-  Kokkos::deep_copy(h_x1, x0);
-
-  // this eps is about 10^-14
+  // Check x0 = x_ref
   using ats      = typename Kokkos::ArithTraits<ScalarType>;
   using mag_type = typename ats::mag_type;
   mag_type eps   = 1.0e3 * ats::epsilon();
 
+  auto h_x0    = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), x0);
   auto h_x_ref = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), x_ref);
   for (std::size_t ib = 0; ib < N; ib++) {
     for (std::size_t j = 0; j < BlkSize; j++) {
-      // Check x0 = x_ref
       EXPECT_NEAR_KK(h_x0(ib, j), h_x_ref(ib, j), eps);
+    }
+  }
 
-      // Check x1 = x_ref
-      EXPECT_NEAR_KK(h_x1(ib, j), h_x_ref(ib, j), eps);
+  // Testing for strided views x1, reusing x0
+  Kokkos::deep_copy(x0, x1);
+  Kokkos::deep_copy(h_x0, x0);
+  for (std::size_t ib = 0; ib < N; ib++) {
+    for (std::size_t j = 0; j < BlkSize; j++) {
+      EXPECT_NEAR_KK(h_x0(ib, j), h_x_ref(ib, j), eps);
     }
   }
 }
@@ -293,6 +279,7 @@ int test_batched_tbsv() {
     Test::Tbsv::impl_test_batched_tbsv<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(0, 1, 10);
     for (int i = 0; i < 10; i++) {
       Test::Tbsv::impl_test_batched_tbsv<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1, 1, i);
+      Test::Tbsv::impl_test_batched_tbsv<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2, 1, i);
     }
   }
 #endif
@@ -304,6 +291,7 @@ int test_batched_tbsv() {
     Test::Tbsv::impl_test_batched_tbsv<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(0, 1, 10);
     for (int i = 0; i < 10; i++) {
       Test::Tbsv::impl_test_batched_tbsv<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1, 1, i);
+      Test::Tbsv::impl_test_batched_tbsv<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2, 1, i);
     }
   }
 #endif

--- a/batched/dense/unit_test/Test_Batched_SerialTbsv.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTbsv.hpp
@@ -252,7 +252,7 @@ void impl_test_batched_tbsv_analytical(const std::size_t N) {
   auto h_x_ref = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), x_ref);
   for (std::size_t ib = 0; ib < N; ib++) {
     for (std::size_t j = 0; j < BlkSize; j++) {
-      EXPECT_NEAR_KK(h_x0(ib, j), h_x_ref(ib, j), eps);
+      Test::EXPECT_NEAR_KK_REL(h_x0(ib, j), h_x_ref(ib, j), eps);
     }
   }
 
@@ -261,7 +261,7 @@ void impl_test_batched_tbsv_analytical(const std::size_t N) {
   Kokkos::deep_copy(h_x0, x0);
   for (std::size_t ib = 0; ib < N; ib++) {
     for (std::size_t j = 0; j < BlkSize; j++) {
-      EXPECT_NEAR_KK(h_x0(ib, j), h_x_ref(ib, j), eps);
+      Test::EXPECT_NEAR_KK_REL(h_x0(ib, j), h_x_ref(ib, j), eps);
     }
   }
 }

--- a/batched/dense/unit_test/Test_Batched_SerialTbsv_Complex.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTbsv_Complex.hpp
@@ -14,91 +14,184 @@
 //
 //@HEADER
 
-#if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
+#if defined(KOKKOSKERNELS_INST_COMPLEX_FLOAT)
 // NO TRANSPOSE
-TEST_F(TestCategory, batched_serial_tbsv_l_nt_u_dcomplex) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Lower, Trans::NoTranspose, Diag::Unit>;
+TEST_F(TestCategory, batched_serial_tbsv_l_nt_u_fcomplex) {
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::NoTranspose, KokkosBatched::Diag::Unit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
+
+  test_batched_tbsv<TestDevice, Kokkos::complex<float>, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, batched_serial_tbsv_l_nt_n_fcomplex) {
+  using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::NoTranspose,
+                                                KokkosBatched::Diag::NonUnit>;
+  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+
+  test_batched_tbsv<TestDevice, Kokkos::complex<float>, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, batched_serial_tbsv_u_nt_u_fcomplex) {
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::NoTranspose, KokkosBatched::Diag::Unit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
+
+  test_batched_tbsv<TestDevice, Kokkos::complex<float>, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, batched_serial_tbsv_u_nt_n_fcomplex) {
+  using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::NoTranspose,
+                                                KokkosBatched::Diag::NonUnit>;
+  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+
+  test_batched_tbsv<TestDevice, Kokkos::complex<float>, param_tag_type, algo_tag_type>();
+}
+// TRANSPOSE
+TEST_F(TestCategory, batched_serial_tbsv_l_t_u_fcomplex) {
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::Transpose, KokkosBatched::Diag::Unit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
+
+  test_batched_tbsv<TestDevice, Kokkos::complex<float>, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, batched_serial_tbsv_l_t_n_fcomplex) {
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::Transpose, KokkosBatched::Diag::NonUnit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
+
+  test_batched_tbsv<TestDevice, Kokkos::complex<float>, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, batched_serial_tbsv_u_t_u_fcomplex) {
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::Transpose, KokkosBatched::Diag::Unit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
+
+  test_batched_tbsv<TestDevice, Kokkos::complex<float>, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, batched_serial_tbsv_u_t_n_fcomplex) {
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::Transpose, KokkosBatched::Diag::NonUnit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
+
+  test_batched_tbsv<TestDevice, Kokkos::complex<float>, param_tag_type, algo_tag_type>();
+}
+
+// CONJUGATE TRANSPOSE
+TEST_F(TestCategory, batched_serial_tbsv_l_ct_u_dcomplex) {
+  using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::ConjTranspose,
+                                                KokkosBatched::Diag::Unit>;
   using algo_tag_type  = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
 }
+TEST_F(TestCategory, batched_serial_tbsv_l_ct_n_dcomplex) {
+  using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::ConjTranspose,
+                                                KokkosBatched::Diag::NonUnit>;
+  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+
+  test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, batched_serial_tbsv_u_ct_u_dcomplex) {
+  using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::ConjTranspose,
+                                                KokkosBatched::Diag::Unit>;
+  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+
+  test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, batched_serial_tbsv_u_ct_n_dcomplex) {
+  using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::ConjTranspose,
+                                                KokkosBatched::Diag::NonUnit>;
+  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+
+  test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
+// NO TRANSPOSE
+TEST_F(TestCategory, batched_serial_tbsv_l_nt_u_dcomplex) {
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::NoTranspose, KokkosBatched::Diag::Unit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
+
+  test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
+}
 TEST_F(TestCategory, batched_serial_tbsv_l_nt_n_dcomplex) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Lower, Trans::NoTranspose, Diag::NonUnit>;
+  using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::NoTranspose,
+                                                KokkosBatched::Diag::NonUnit>;
   using algo_tag_type  = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_u_nt_u_dcomplex) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Upper, Trans::NoTranspose, Diag::Unit>;
-  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::NoTranspose, KokkosBatched::Diag::Unit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_u_nt_n_dcomplex) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Upper, Trans::NoTranspose, Diag::NonUnit>;
+  using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::NoTranspose,
+                                                KokkosBatched::Diag::NonUnit>;
   using algo_tag_type  = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
 }
 // TRANSPOSE
 TEST_F(TestCategory, batched_serial_tbsv_l_t_u_dcomplex) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Lower, Trans::Transpose, Diag::Unit>;
-  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::Transpose, KokkosBatched::Diag::Unit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_l_t_n_dcomplex) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Lower, Trans::Transpose, Diag::NonUnit>;
-  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::Transpose, KokkosBatched::Diag::NonUnit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_u_t_u_dcomplex) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Upper, Trans::Transpose, Diag::Unit>;
-  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::Transpose, KokkosBatched::Diag::Unit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_u_t_n_dcomplex) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Upper, Trans::Transpose, Diag::NonUnit>;
-  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::Transpose, KokkosBatched::Diag::NonUnit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
 }
 
-/* [FIXME] These tests need Trans::ConjTranspose in trsv.
 // CONJUGATE TRANSPOSE
 TEST_F(TestCategory, batched_serial_tbsv_l_ct_u_dcomplex) {
-  using param_tag_type =
-      ::Test::Tbsv::ParamTag<Uplo::Lower, Trans::ConjTranspose, Diag::Unit>;
-  using algo_tag_type = typename Algo::Tbsv::Unblocked;
+  using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::ConjTranspose,
+                                                KokkosBatched::Diag::Unit>;
+  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
 
-  test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type,
-                    algo_tag_type>();
+  test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_l_ct_n_dcomplex) {
-  using param_tag_type =
-      ::Test::Tbsv::ParamTag<Uplo::Lower, Trans::ConjTranspose, Diag::NonUnit>;
-  using algo_tag_type = typename Algo::Tbsv::Unblocked;
+  using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::ConjTranspose,
+                                                KokkosBatched::Diag::NonUnit>;
+  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
 
-  test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type,
-                    algo_tag_type>();
+  test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_u_ct_u_dcomplex) {
-  using param_tag_type =
-      ::Test::Tbsv::ParamTag<Uplo::Upper, Trans::ConjTranspose, Diag::Unit>;
-  using algo_tag_type = typename Algo::Tbsv::Unblocked;
+  using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::ConjTranspose,
+                                                KokkosBatched::Diag::Unit>;
+  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
 
-  test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type,
-                    algo_tag_type>();
+  test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_u_ct_n_dcomplex) {
-  using param_tag_type =
-      ::Test::Tbsv::ParamTag<Uplo::Upper, Trans::ConjTranspose, Diag::NonUnit>;
-  using algo_tag_type = typename Algo::Tbsv::Unblocked;
+  using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::ConjTranspose,
+                                                KokkosBatched::Diag::NonUnit>;
+  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
 
-  test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type,
-                    algo_tag_type>();
+  test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
 }
-*/
 #endif

--- a/batched/dense/unit_test/Test_Batched_SerialTbsv_Complex.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTbsv_Complex.hpp
@@ -75,33 +75,33 @@ TEST_F(TestCategory, batched_serial_tbsv_u_t_n_fcomplex) {
 }
 
 // CONJUGATE TRANSPOSE
-TEST_F(TestCategory, batched_serial_tbsv_l_ct_u_dcomplex) {
+TEST_F(TestCategory, batched_serial_tbsv_l_c_u_fcomplex) {
   using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::ConjTranspose,
                                                 KokkosBatched::Diag::Unit>;
   using algo_tag_type  = typename Algo::Tbsv::Unblocked;
 
-  test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
+  test_batched_tbsv<TestDevice, Kokkos::complex<float>, param_tag_type, algo_tag_type>();
 }
-TEST_F(TestCategory, batched_serial_tbsv_l_ct_n_dcomplex) {
+TEST_F(TestCategory, batched_serial_tbsv_l_c_n_fcomplex) {
   using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::ConjTranspose,
                                                 KokkosBatched::Diag::NonUnit>;
   using algo_tag_type  = typename Algo::Tbsv::Unblocked;
 
-  test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
+  test_batched_tbsv<TestDevice, Kokkos::complex<float>, param_tag_type, algo_tag_type>();
 }
-TEST_F(TestCategory, batched_serial_tbsv_u_ct_u_dcomplex) {
+TEST_F(TestCategory, batched_serial_tbsv_u_c_u_fcomplex) {
   using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::ConjTranspose,
                                                 KokkosBatched::Diag::Unit>;
   using algo_tag_type  = typename Algo::Tbsv::Unblocked;
 
-  test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
+  test_batched_tbsv<TestDevice, Kokkos::complex<float>, param_tag_type, algo_tag_type>();
 }
-TEST_F(TestCategory, batched_serial_tbsv_u_ct_n_dcomplex) {
+TEST_F(TestCategory, batched_serial_tbsv_u_c_n_fcomplex) {
   using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::ConjTranspose,
                                                 KokkosBatched::Diag::NonUnit>;
   using algo_tag_type  = typename Algo::Tbsv::Unblocked;
 
-  test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
+  test_batched_tbsv<TestDevice, Kokkos::complex<float>, param_tag_type, algo_tag_type>();
 }
 #endif
 
@@ -166,28 +166,28 @@ TEST_F(TestCategory, batched_serial_tbsv_u_t_n_dcomplex) {
 }
 
 // CONJUGATE TRANSPOSE
-TEST_F(TestCategory, batched_serial_tbsv_l_ct_u_dcomplex) {
+TEST_F(TestCategory, batched_serial_tbsv_l_c_u_dcomplex) {
   using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::ConjTranspose,
                                                 KokkosBatched::Diag::Unit>;
   using algo_tag_type  = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
 }
-TEST_F(TestCategory, batched_serial_tbsv_l_ct_n_dcomplex) {
+TEST_F(TestCategory, batched_serial_tbsv_l_c_n_dcomplex) {
   using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::ConjTranspose,
                                                 KokkosBatched::Diag::NonUnit>;
   using algo_tag_type  = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
 }
-TEST_F(TestCategory, batched_serial_tbsv_u_ct_u_dcomplex) {
+TEST_F(TestCategory, batched_serial_tbsv_u_c_u_dcomplex) {
   using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::ConjTranspose,
                                                 KokkosBatched::Diag::Unit>;
   using algo_tag_type  = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
 }
-TEST_F(TestCategory, batched_serial_tbsv_u_ct_n_dcomplex) {
+TEST_F(TestCategory, batched_serial_tbsv_u_c_n_dcomplex) {
   using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::ConjTranspose,
                                                 KokkosBatched::Diag::NonUnit>;
   using algo_tag_type  = typename Algo::Tbsv::Unblocked;

--- a/batched/dense/unit_test/Test_Batched_SerialTbsv_Real.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTbsv_Real.hpp
@@ -17,51 +17,59 @@
 #if defined(KOKKOSKERNELS_INST_FLOAT)
 // NO TRANSPOSE
 TEST_F(TestCategory, batched_serial_tbsv_l_nt_u_float) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Lower, Trans::NoTranspose, Diag::Unit>;
-  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::NoTranspose, KokkosBatched::Diag::Unit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, float, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_l_nt_n_float) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Lower, Trans::NoTranspose, Diag::NonUnit>;
+  using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::NoTranspose,
+                                                KokkosBatched::Diag::NonUnit>;
   using algo_tag_type  = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, float, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_u_nt_u_float) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Upper, Trans::NoTranspose, Diag::Unit>;
-  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::NoTranspose, KokkosBatched::Diag::Unit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, float, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_u_nt_n_float) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Upper, Trans::NoTranspose, Diag::NonUnit>;
+  using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::NoTranspose,
+                                                KokkosBatched::Diag::NonUnit>;
   using algo_tag_type  = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, float, param_tag_type, algo_tag_type>();
 }
 // TRANSPOSE
 TEST_F(TestCategory, batched_serial_tbsv_l_t_u_float) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Lower, Trans::Transpose, Diag::Unit>;
-  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::Transpose, KokkosBatched::Diag::Unit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, float, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_l_t_n_float) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Lower, Trans::Transpose, Diag::NonUnit>;
-  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::Transpose, KokkosBatched::Diag::NonUnit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, float, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_u_t_u_float) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Upper, Trans::Transpose, Diag::Unit>;
-  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::Transpose, KokkosBatched::Diag::Unit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, float, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_u_t_n_float) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Upper, Trans::Transpose, Diag::NonUnit>;
-  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::Transpose, KokkosBatched::Diag::NonUnit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, float, param_tag_type, algo_tag_type>();
 }
@@ -70,51 +78,59 @@ TEST_F(TestCategory, batched_serial_tbsv_u_t_n_float) {
 #if defined(KOKKOSKERNELS_INST_DOUBLE)
 // NO TRANSPOSE
 TEST_F(TestCategory, batched_serial_tbsv_l_nt_u_double) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Lower, Trans::NoTranspose, Diag::Unit>;
-  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::NoTranspose, KokkosBatched::Diag::Unit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, double, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_l_nt_n_double) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Lower, Trans::NoTranspose, Diag::NonUnit>;
+  using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::NoTranspose,
+                                                KokkosBatched::Diag::NonUnit>;
   using algo_tag_type  = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, double, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_u_nt_u_double) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Upper, Trans::NoTranspose, Diag::Unit>;
-  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::NoTranspose, KokkosBatched::Diag::Unit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, double, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_u_nt_n_double) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Upper, Trans::NoTranspose, Diag::NonUnit>;
+  using param_tag_type = ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::NoTranspose,
+                                                KokkosBatched::Diag::NonUnit>;
   using algo_tag_type  = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, double, param_tag_type, algo_tag_type>();
 }
 // TRANSPOSE
 TEST_F(TestCategory, batched_serial_tbsv_l_t_u_double) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Lower, Trans::Transpose, Diag::Unit>;
-  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::Transpose, KokkosBatched::Diag::Unit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, double, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_l_t_n_double) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Lower, Trans::Transpose, Diag::NonUnit>;
-  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::Transpose, KokkosBatched::Diag::NonUnit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, double, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_u_t_u_double) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Upper, Trans::Transpose, Diag::Unit>;
-  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::Transpose, KokkosBatched::Diag::Unit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, double, param_tag_type, algo_tag_type>();
 }
 TEST_F(TestCategory, batched_serial_tbsv_u_t_n_double) {
-  using param_tag_type = ::Test::Tbsv::ParamTag<Uplo::Upper, Trans::Transpose, Diag::NonUnit>;
-  using algo_tag_type  = typename Algo::Tbsv::Unblocked;
+  using param_tag_type =
+      ::Test::Tbsv::ParamTag<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::Transpose, KokkosBatched::Diag::NonUnit>;
+  using algo_tag_type = typename Algo::Tbsv::Unblocked;
 
   test_batched_tbsv<TestDevice, double, param_tag_type, algo_tag_type>();
 }


### PR DESCRIPTION
This PR aims at improving the implementation and testing of serial tbsv.

 - [x] Moving implementation details into `Impl` namespace.
 - [x] Use `OpID` and `OpConj` for `conj` operations instead of `do_conj` variable
 - [x] Use `Kokkos::is_view_v<AViewType>` instead of `Kokkos::is_view<AViewType>::value`
 - [x] Covering all the unit-tests for all the combinations of `Non-Trans/Trans/ConjTrans`
 - [x] Remove `using namespace KokkosBatched` from the test code
 - [x] Rename variables starting from underscores in the test code  

Added based on the discussions in #2497
- [X] Add docstring and assertion for `Arg` template parameters