### PR TITLE
fix: getrs serial internal implementations

### DIFF
--- a/batched/dense/impl/KokkosBatched_Getrs_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Getrs_Serial_Internal.hpp
@@ -30,48 +30,46 @@ struct SerialGetrsInternal {
 
 //// Non-transpose ////
 template <>
-struct SerialGetrsInternal<Trans::NoTranspose, Algo::Getrs::Unblocked> {
-  template <typename AViewType, typename PivViewType, typename BViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const PivViewType &piv, const BViewType &b) {
-    KokkosBatched::SerialLaswp<Direct::Forward>::invoke(piv, b);
-    KokkosBatched::SerialTrsm<Side::Left, Uplo::Lower, Trans::NoTranspose, Diag::Unit, Algo::Trsm::Unblocked>::invoke(
-        1.0, A, b);
-    KokkosBatched::SerialTrsm<Side::Left, Uplo::Upper, Trans::NoTranspose, Diag::NonUnit,
-                              Algo::Trsm::Unblocked>::invoke(1.0, A, b);
+template <typename AViewType, typename PivViewType, typename BViewType>
+KOKKOS_INLINE_FUNCTION int SerialGetrsInternal<Trans::NoTranspose, Algo::Getrs::Unblocked>::invoke(
+    const AViewType &A, const PivViewType &piv, const BViewType &b) {
+  KokkosBatched::SerialLaswp<Direct::Forward>::invoke(piv, b);
+  KokkosBatched::SerialTrsm<Side::Left, Uplo::Lower, Trans::NoTranspose, Diag::Unit, Algo::Trsm::Unblocked>::invoke(
+      1.0, A, b);
+  KokkosBatched::SerialTrsm<Side::Left, Uplo::Upper, Trans::NoTranspose, Diag::NonUnit, Algo::Trsm::Unblocked>::invoke(
+      1.0, A, b);
 
-    return 0;
-  }
-};
+  return 0;
+}
 
 //// Transpose ////
 template <>
-struct SerialGetrsInternal<Trans::Transpose, Algo::Getrs::Unblocked> {
-  template <typename AViewType, typename PivViewType, typename BViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const PivViewType &piv, const BViewType &b) {
-    KokkosBatched::SerialTrsm<Side::Left, Uplo::Upper, Trans::Transpose, Diag::NonUnit, Algo::Trsm::Unblocked>::invoke(
-        1.0, A, b);
-    KokkosBatched::SerialTrsm<Side::Left, Uplo::Lower, Trans::Transpose, Diag::Unit, Algo::Trsm::Unblocked>::invoke(
-        1.0, A, b);
-    KokkosBatched::SerialLaswp<Direct::Backward>::invoke(piv, b);
+template <typename AViewType, typename PivViewType, typename BViewType>
+KOKKOS_INLINE_FUNCTION int SerialGetrsInternal<Trans::Transpose, Algo::Getrs::Unblocked>::invoke(const AViewType &A,
+                                                                                                 const PivViewType &piv,
+                                                                                                 const BViewType &b) {
+  KokkosBatched::SerialTrsm<Side::Left, Uplo::Upper, Trans::Transpose, Diag::NonUnit, Algo::Trsm::Unblocked>::invoke(
+      1.0, A, b);
+  KokkosBatched::SerialTrsm<Side::Left, Uplo::Lower, Trans::Transpose, Diag::Unit, Algo::Trsm::Unblocked>::invoke(1.0,
+                                                                                                                  A, b);
+  KokkosBatched::SerialLaswp<Direct::Backward>::invoke(piv, b);
 
-    return 0;
-  }
-};
+  return 0;
+}
 
 //// Conj-Transpose ////
 template <>
-struct SerialGetrsInternal<Trans::ConjTranspose, Algo::Getrs::Unblocked> {
-  template <typename AViewType, typename PivViewType, typename BViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const PivViewType &piv, const BViewType &b) {
-    KokkosBatched::SerialTrsm<Side::Left, Uplo::Upper, Trans::ConjTranspose, Diag::NonUnit,
-                              Algo::Trsm::Unblocked>::invoke(1.0, A, b);
-    KokkosBatched::SerialTrsm<Side::Left, Uplo::Lower, Trans::ConjTranspose, Diag::Unit, Algo::Trsm::Unblocked>::invoke(
-        1.0, A, b);
-    KokkosBatched::SerialLaswp<Direct::Backward>::invoke(piv, b);
+template <typename AViewType, typename PivViewType, typename BViewType>
+KOKKOS_INLINE_FUNCTION int SerialGetrsInternal<Trans::ConjTranspose, Algo::Getrs::Unblocked>::invoke(
+    const AViewType &A, const PivViewType &piv, const BViewType &b) {
+  KokkosBatched::SerialTrsm<Side::Left, Uplo::Upper, Trans::ConjTranspose, Diag::NonUnit,
+                            Algo::Trsm::Unblocked>::invoke(1.0, A, b);
+  KokkosBatched::SerialTrsm<Side::Left, Uplo::Lower, Trans::ConjTranspose, Diag::Unit, Algo::Trsm::Unblocked>::invoke(
+      1.0, A, b);
+  KokkosBatched::SerialLaswp<Direct::Backward>::invoke(piv, b);
 
-    return 0;
-  }
-};
+  return 0;
+}
 
 }  // namespace Impl
 }  // namespace KokkosBatched

--- a/batched/dense/impl/KokkosBatched_Laswp_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Laswp_Serial_Impl.hpp
@@ -83,7 +83,7 @@ struct SerialLaswp<Direct::Forward> {
 template <>
 struct SerialLaswp<Direct::Backward> {
   template <typename PivViewType, typename AViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const PivViewType piv, const AViewType &A) {
+  KOKKOS_INLINE_FUNCTION static int invoke(const PivViewType &piv, const AViewType &A) {
     auto info = KokkosBatched::Impl::checkLaswpInput(piv, A);
     if (info) return info;
 

--- a/batched/dense/impl/KokkosBatched_Laswp_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Laswp_Serial_Internal.hpp
@@ -96,6 +96,15 @@ struct SerialLaswpVectorBackwardInternal {
                                            /* */ ValueType *KOKKOS_RESTRICT A, const int as0) {
     for (int i = (plen - 1); i >= 0; --i) {
       const int piv = p[i * ps0];
+
+// On H100 with Cuda 12.0.0, the compiler seems to apply
+// an aggressive optimization which crashes this function
+// Insert unnecessary operation to disallow optimization
+#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_ARCH_HOPPER90)
+#if CUDA_VERSION == 12000
+      if (piv < 0) return 0;
+#endif
+#endif
       if (piv != i) {
         const int idx_i = i * as0, idx_p = piv * as0;
         const ValueType tmp = A[idx_i];

--- a/batched/dense/unit_test/Test_Batched_SerialGetrs.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialGetrs.hpp
@@ -23,8 +23,6 @@
 #include <KokkosBatched_Getrs.hpp>
 #include "Test_Batched_DenseUtils.hpp"
 
-using namespace KokkosBatched;
-
 namespace Test {
 namespace Getrs {
 


### PR DESCRIPTION
Fixes #2485 

- [x] unit-test passes with H100 and Cuda 12.0.0. There seems to be a compiler bug in Cuda 12.0.0 which applies an aggressive loop unroll that crashes the `SerialLaswpVectorBackwardInternal`. This can be avoided by disallowing the loop unrolling inside this function. I did not observe failures for other Cuda versions.
- [x] Remove `using namespace KokkosBatched` from `getrs` unit-test

@cwpearson 
It seems fine on my env, but could you please test on your side?