### PR TITLE
Sparse - SpTRSV: moving kenerls out of Experimental

### DIFF
--- a/perf_test/sparse/KokkosSparse_sptrsv.cpp
+++ b/perf_test/sparse/KokkosSparse_sptrsv.cpp
@@ -270,16 +270,16 @@ int test_sptrsv_perf(std::vector<int> tests, const std::string &lfilename, const
         timer.reset();
         if (test == CUSPARSE_K) {
           printf("cusparsek symbolic\n");
-          sptrsv_symbolic(&kh, row_map, entries, values);
+          KokkosSparse::sptrsv_symbolic(&kh, row_map, entries, values);
           printf("  finished cusparsek symbolic\n");
         } else {
-          sptrsv_symbolic(&kh, row_map, entries);
+          KokkosSparse::sptrsv_symbolic(&kh, row_map, entries);
         }
         std::cout << "LTRI Symbolic Time: " << timer.seconds() << std::endl;
 
         // std::cout << "TriSolve Solve" << std::endl;
         timer.reset();
-        sptrsv_solve(&kh, row_map, entries, values, rhs, lhs);
+        KokkosSparse::sptrsv_solve(&kh, row_map, entries, values, rhs, lhs);
         Kokkos::fence();
         std::cout << "LTRI Solve Time: " << timer.seconds() << std::endl;
 
@@ -377,7 +377,7 @@ int test_sptrsv_perf(std::vector<int> tests, const std::string &lfilename, const
 #ifdef CHECKALLRUNRESULTS
           Kokkos::deep_copy(lhs, 0, 0);
 #endif
-          sptrsv_solve(&kh, row_map, entries, values, rhs, lhs);
+          KokkosSparse::sptrsv_solve(&kh, row_map, entries, values, rhs, lhs);
 #ifdef CHECKALLRUNRESULTS
           {
             scalar_t sum = 0.0;
@@ -633,12 +633,12 @@ int test_sptrsv_perf(std::vector<int> tests, const std::string &lfilename, const
       Kokkos::Timer timer;
       if (test != CUSPARSE) {
         timer.reset();
-        sptrsv_symbolic(&kh, row_map, entries);
+        KokkosSparse::sptrsv_symbolic(&kh, row_map, entries);
         std::cout << "UTRI Symbolic Time: " << timer.seconds() << std::endl;
 
         // std::cout << "TriSolve Solve" << std::endl;
         timer.reset();
-        sptrsv_solve(&kh, row_map, entries, values, rhs, lhs);
+        KokkosSparse::sptrsv_solve(&kh, row_map, entries, values, rhs, lhs);
         Kokkos::fence();
         std::cout << "UTRI Solve Time: " << timer.seconds() << std::endl;
 
@@ -735,7 +735,7 @@ int test_sptrsv_perf(std::vector<int> tests, const std::string &lfilename, const
 #ifdef CHECKALLRUNRESULTS
           Kokkos::deep_copy(lhs, 0, 0);
 #endif
-          sptrsv_solve(&kh, row_map, entries, values, rhs, lhs);
+          KokkosSparse::sptrsv_solve(&kh, row_map, entries, values, rhs, lhs);
 #ifdef CHECKALLRUNRESULTS
           {
             scalar_t sum = 0.0;

--- a/sparse/impl/KokkosSparse_twostage_gauss_seidel_impl.hpp
+++ b/sparse/impl/KokkosSparse_twostage_gauss_seidel_impl.hpp
@@ -688,8 +688,8 @@ class TwostageGaussSeidel {
       auto sptrsv_algo = handle->get_gs_sptrsvL_handle()->get_sptrsv_handle()->get_algorithm();
       if (sptrsv_algo != SPTRSVAlgorithm::SPTRSV_CUSPARSE) {  // symbolic with CuSparse needs
                                                               // values
-        sptrsv_symbolic(handle->get_gs_sptrsvL_handle(), rowmap_viewL, crsmatL.graph.entries);
-        sptrsv_symbolic(handle->get_gs_sptrsvU_handle(), rowmap_viewU, crsmatU.graph.entries);
+	KokkosSparse::sptrsv_symbolic(handle->get_gs_sptrsvL_handle(), rowmap_viewL, crsmatL.graph.entries);
+        KokkosSparse::sptrsv_symbolic(handle->get_gs_sptrsvU_handle(), rowmap_viewU, crsmatU.graph.entries);
       }
     }
   }
@@ -763,8 +763,8 @@ class TwostageGaussSeidel {
             rowmap_viewU, column_viewU, values_viewU);
 
         // now do symbolic
-        sptrsv_symbolic(handle->get_gs_sptrsvL_handle(), rowmap_viewL, crsmatL.graph.entries, values_viewL);
-        sptrsv_symbolic(handle->get_gs_sptrsvU_handle(), rowmap_viewU, crsmatU.graph.entries, values_viewU);
+        KokkosSparse::sptrsv_symbolic(handle->get_gs_sptrsvL_handle(), rowmap_viewL, crsmatL.graph.entries, values_viewL);
+        KokkosSparse::sptrsv_symbolic(handle->get_gs_sptrsvU_handle(), rowmap_viewU, crsmatU.graph.entries, values_viewU);
       }
     }
   }
@@ -895,7 +895,7 @@ class TwostageGaussSeidel {
             auto localZj = Kokkos::subview(localZ, Kokkos::ALL(), range_type(j, j + 1));
             single_vector_view_t Rj(localRj.data(), num_rows);
             single_vector_view_t Zj(localZj.data(), num_rows);
-            sptrsv_solve(handle->get_gs_sptrsvL_handle(), crsmatL.graph.row_map, crsmatL.graph.entries, crsmatL.values,
+            KokkosSparse::sptrsv_solve(handle->get_gs_sptrsvL_handle(), crsmatL.graph.row_map, crsmatL.graph.entries, crsmatL.values,
                          Rj, Zj);
           }
         } else {
@@ -907,7 +907,7 @@ class TwostageGaussSeidel {
             auto localZj = Kokkos::subview(localZ, Kokkos::ALL(), range_type(j, j + 1));
             single_vector_view_t Rj(localRj.data(), num_rows);
             single_vector_view_t Zj(localZj.data(), num_rows);
-            sptrsv_solve(handle->get_gs_sptrsvU_handle(), crsmatU.graph.row_map, crsmatU.graph.entries, crsmatU.values,
+            KokkosSparse::sptrsv_solve(handle->get_gs_sptrsvU_handle(), crsmatU.graph.row_map, crsmatU.graph.entries, crsmatU.values,
                          Rj, Zj);
           }
         }

--- a/sparse/impl/KokkosSparse_twostage_gauss_seidel_impl.hpp
+++ b/sparse/impl/KokkosSparse_twostage_gauss_seidel_impl.hpp
@@ -688,7 +688,7 @@ class TwostageGaussSeidel {
       auto sptrsv_algo = handle->get_gs_sptrsvL_handle()->get_sptrsv_handle()->get_algorithm();
       if (sptrsv_algo != SPTRSVAlgorithm::SPTRSV_CUSPARSE) {  // symbolic with CuSparse needs
                                                               // values
-	KokkosSparse::sptrsv_symbolic(handle->get_gs_sptrsvL_handle(), rowmap_viewL, crsmatL.graph.entries);
+        KokkosSparse::sptrsv_symbolic(handle->get_gs_sptrsvL_handle(), rowmap_viewL, crsmatL.graph.entries);
         KokkosSparse::sptrsv_symbolic(handle->get_gs_sptrsvU_handle(), rowmap_viewU, crsmatU.graph.entries);
       }
     }
@@ -763,8 +763,10 @@ class TwostageGaussSeidel {
             rowmap_viewU, column_viewU, values_viewU);
 
         // now do symbolic
-        KokkosSparse::sptrsv_symbolic(handle->get_gs_sptrsvL_handle(), rowmap_viewL, crsmatL.graph.entries, values_viewL);
-        KokkosSparse::sptrsv_symbolic(handle->get_gs_sptrsvU_handle(), rowmap_viewU, crsmatU.graph.entries, values_viewU);
+        KokkosSparse::sptrsv_symbolic(handle->get_gs_sptrsvL_handle(), rowmap_viewL, crsmatL.graph.entries,
+                                      values_viewL);
+        KokkosSparse::sptrsv_symbolic(handle->get_gs_sptrsvU_handle(), rowmap_viewU, crsmatU.graph.entries,
+                                      values_viewU);
       }
     }
   }
@@ -895,8 +897,8 @@ class TwostageGaussSeidel {
             auto localZj = Kokkos::subview(localZ, Kokkos::ALL(), range_type(j, j + 1));
             single_vector_view_t Rj(localRj.data(), num_rows);
             single_vector_view_t Zj(localZj.data(), num_rows);
-            KokkosSparse::sptrsv_solve(handle->get_gs_sptrsvL_handle(), crsmatL.graph.row_map, crsmatL.graph.entries, crsmatL.values,
-                         Rj, Zj);
+            KokkosSparse::sptrsv_solve(handle->get_gs_sptrsvL_handle(), crsmatL.graph.row_map, crsmatL.graph.entries,
+                                       crsmatL.values, Rj, Zj);
           }
         } else {
           using namespace KokkosSparse::Experimental;
@@ -907,8 +909,8 @@ class TwostageGaussSeidel {
             auto localZj = Kokkos::subview(localZ, Kokkos::ALL(), range_type(j, j + 1));
             single_vector_view_t Rj(localRj.data(), num_rows);
             single_vector_view_t Zj(localZj.data(), num_rows);
-            KokkosSparse::sptrsv_solve(handle->get_gs_sptrsvU_handle(), crsmatU.graph.row_map, crsmatU.graph.entries, crsmatU.values,
-                         Rj, Zj);
+            KokkosSparse::sptrsv_solve(handle->get_gs_sptrsvU_handle(), crsmatU.graph.row_map, crsmatU.graph.entries,
+                                       crsmatU.values, Rj, Zj);
           }
         }
 

--- a/sparse/src/KokkosSparse_LUPrec.hpp
+++ b/sparse/src/KokkosSparse_LUPrec.hpp
@@ -91,11 +91,11 @@ class LUPrec : public KokkosSparse::Experimental::Preconditioner<CRS> {
                      ScalarType beta = karith::zero()) const {
     KK_REQUIRE_MSG(transM[0] == NoTranspose[0], "LUPrec::apply only supports 'N' for transM");
 
-    sptrsv_symbolic(&_khL, _L.graph.row_map, _L.graph.entries);
-    sptrsv_solve(&_khL, _L.graph.row_map, _L.graph.entries, _L.values, X, _tmp);
+    KokkosSparse::sptrsv_symbolic(&_khL, _L.graph.row_map, _L.graph.entries);
+    KokkosSparse::sptrsv_solve(&_khL, _L.graph.row_map, _L.graph.entries, _L.values, X, _tmp);
 
-    sptrsv_symbolic(&_khU, _U.graph.row_map, _U.graph.entries);
-    sptrsv_solve(&_khU, _U.graph.row_map, _U.graph.entries, _U.values, _tmp, _tmp2);
+    KokkosSparse::sptrsv_symbolic(&_khU, _U.graph.row_map, _U.graph.entries);
+    KokkosSparse::sptrsv_solve(&_khU, _U.graph.row_map, _U.graph.entries, _U.values, _tmp, _tmp2);
 
     KokkosBlas::axpby(alpha, _tmp2, beta, Y);
   }

--- a/sparse/src/KokkosSparse_sptrsv.hpp
+++ b/sparse/src/KokkosSparse_sptrsv.hpp
@@ -34,7 +34,6 @@
 #include "KokkosSparse_sptrsv_cuSPARSE_impl.hpp"
 
 namespace KokkosSparse {
-namespace Experimental {
 
 #define KOKKOSKERNELS_SPTRSV_SAME_TYPE(A, B) \
   std::is_same<typename std::remove_const<A>::type, typename std::remove_const<B>::type>::value
@@ -211,16 +210,16 @@ void sptrsv_symbolic(ExecutionSpace &space, KernelHandle *handle, lno_row_view_t
                                                                    false);
     } else {
       (void)values;
-      KokkosSparse::Experimental::sptrsv_symbolic(space, handle, rowmap, entries);
+      KokkosSparse::sptrsv_symbolic(space, handle, rowmap, entries);
     }
 
 #else  // We better go to the native implementation
     (void)values;
-    KokkosSparse::Experimental::sptrsv_symbolic(space, handle, rowmap, entries);
+    KokkosSparse::sptrsv_symbolic(space, handle, rowmap, entries);
 #endif
   } else {
     (void)values;
-    KokkosSparse::Experimental::sptrsv_symbolic(space, handle, rowmap, entries);
+    KokkosSparse::sptrsv_symbolic(space, handle, rowmap, entries);
   }
 #ifdef KK_TRISOLVE_TIMERS
   std::cout << "     + sptrsv_symbolic time = " << timer_sptrsv.seconds() << std::endl;
@@ -412,6 +411,8 @@ void sptrsv_solve(KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ 
   sptrsv_solve(my_exec_space, handle, rowmap, entries, values, b, x);
 }
 
+namespace Experimental {
+
 #if defined(KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV) || defined(DOXY)
 /**
  * @brief Supernodal sptrsv solve phase of x for linear system Ax=b
@@ -445,10 +446,10 @@ void sptrsv_solve(ExecutionSpace &space, KernelHandle *handle, XType x, XType b)
     Kokkos::deep_copy(space, x, b);
 
     // the fifth argument (i.e., first x) is not used
-    sptrsv_solve(space, handle, row_map, entries, values, x, x);
+    KokkosSparse::sptrsv_solve(space, handle, row_map, entries, values, x, x);
   } else {
     // the fifth argument (i.e., first x) is not used
-    sptrsv_solve(space, handle, row_map, entries, values, b, b);
+    KokkosSparse::sptrsv_solve(space, handle, row_map, entries, values, b, b);
 
     // apply backward pivoting
     Kokkos::deep_copy(space, x, b);
@@ -700,6 +701,49 @@ void sptrsv_solve_streams(const std::vector<ExecutionSpace> &execspace_v, const 
   }
 
 }  // sptrsv_solve_streams
+
+template <typename ExecutionSpace, typename KernelHandle, typename lno_row_view_t_, typename lno_nnz_view_t_>
+[[deprecated("sptrsv_symbolic was promoted out of Experimental, please use KokkosSparse::sptrsv_symbolic instead.")]]
+void sptrsv_symbolic(const ExecutionSpace &space, KernelHandle *handle, lno_row_view_t_ rowmap,
+                     lno_nnz_view_t_ entries) {
+  KokkosSparse::sptrsv_symbolic(space, handle, rowmap, entries);
+}
+
+template <typename KernelHandle, typename lno_row_view_t_, typename lno_nnz_view_t_>
+[[deprecated("sptrsv_symbolic was promoted out of Experimental, please use KokkosSparse::sptrsv_symbolic instead.")]]
+void sptrsv_symbolic(KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries) {
+  KokkosSparse::sptrsv_symbolic(handle, rowmap, entries);
+}
+
+template <typename ExecutionSpace, typename KernelHandle, typename lno_row_view_t_, typename lno_nnz_view_t_,
+          typename scalar_nnz_view_t_>
+[[deprecated("sptrsv_symbolic was promoted out of Experimental, please use KokkosSparse::sptrsv_symbolic instead.")]]
+void sptrsv_symbolic(ExecutionSpace &space, KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries,
+                     scalar_nnz_view_t_ values) {
+  KokkosSparse::sptrsv_symbolic(space, handle, rowmap, entries, values);
+}
+
+template <typename KernelHandle, typename lno_row_view_t_, typename lno_nnz_view_t_, typename scalar_nnz_view_t_>
+[[deprecated("sptrsv_symbolic was promoted out of Experimental, please use KokkosSparse::sptrsv_symbolic instead.")]]
+void sptrsv_symbolic(KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries, scalar_nnz_view_t_ values) {
+  KokkosSparse::sptrsv_symbolic(handle, rowmap, entries, values);
+}
+
+template <typename ExecutionSpace, typename KernelHandle, typename lno_row_view_t_, typename lno_nnz_view_t_,
+          typename scalar_nnz_view_t_, class BType, class XType>
+[[deprecated("sptrsv_solve was promoted out of Experimental, please use KokkosSparse::sptrsv_symbolic instead.")]]
+void sptrsv_solve(ExecutionSpace &space, KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries,
+                  scalar_nnz_view_t_ values, BType b, XType x) {
+  KokkosSparse::sptrsv_solve(space, handle, rowmap, entries, values, b, x);
+}
+
+template <typename KernelHandle, typename lno_row_view_t_, typename lno_nnz_view_t_, typename scalar_nnz_view_t_,
+          class BType, class XType>
+[[deprecated("sptrsv_solve was promoted out of Experimental, please use KokkosSparse::sptrsv_symbolic instead.")]]
+void sptrsv_solve(KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries, scalar_nnz_view_t_ values,
+                  BType b, XType x) {
+  KokkosSparse::sptrsv_solve(handle, rowmap, entries, values, b, x);
+}
 
 }  // namespace Experimental
 }  // namespace KokkosSparse

--- a/sparse/src/KokkosSparse_sptrsv.hpp
+++ b/sparse/src/KokkosSparse_sptrsv.hpp
@@ -702,48 +702,53 @@ void sptrsv_solve_streams(const std::vector<ExecutionSpace> &execspace_v, const 
 
 }  // sptrsv_solve_streams
 
+#if !defined(DOXY)
 template <typename ExecutionSpace, typename KernelHandle, typename lno_row_view_t_, typename lno_nnz_view_t_>
-[[deprecated("sptrsv_symbolic was promoted out of Experimental, please use KokkosSparse::sptrsv_symbolic instead.")]]
-void sptrsv_symbolic(const ExecutionSpace &space, KernelHandle *handle, lno_row_view_t_ rowmap,
-                     lno_nnz_view_t_ entries) {
+[[deprecated(
+    "sptrsv_symbolic was promoted out of Experimental, please use KokkosSparse::sptrsv_symbolic instead.")]] void
+sptrsv_symbolic(const ExecutionSpace &space, KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries) {
   KokkosSparse::sptrsv_symbolic(space, handle, rowmap, entries);
 }
 
 template <typename KernelHandle, typename lno_row_view_t_, typename lno_nnz_view_t_>
-[[deprecated("sptrsv_symbolic was promoted out of Experimental, please use KokkosSparse::sptrsv_symbolic instead.")]]
-void sptrsv_symbolic(KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries) {
+[[deprecated(
+    "sptrsv_symbolic was promoted out of Experimental, please use KokkosSparse::sptrsv_symbolic instead.")]] void
+sptrsv_symbolic(KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries) {
   KokkosSparse::sptrsv_symbolic(handle, rowmap, entries);
 }
 
 template <typename ExecutionSpace, typename KernelHandle, typename lno_row_view_t_, typename lno_nnz_view_t_,
           typename scalar_nnz_view_t_>
-[[deprecated("sptrsv_symbolic was promoted out of Experimental, please use KokkosSparse::sptrsv_symbolic instead.")]]
-void sptrsv_symbolic(ExecutionSpace &space, KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries,
-                     scalar_nnz_view_t_ values) {
+[[deprecated(
+    "sptrsv_symbolic was promoted out of Experimental, please use KokkosSparse::sptrsv_symbolic instead.")]] void
+sptrsv_symbolic(ExecutionSpace &space, KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries,
+                scalar_nnz_view_t_ values) {
   KokkosSparse::sptrsv_symbolic(space, handle, rowmap, entries, values);
 }
 
 template <typename KernelHandle, typename lno_row_view_t_, typename lno_nnz_view_t_, typename scalar_nnz_view_t_>
-[[deprecated("sptrsv_symbolic was promoted out of Experimental, please use KokkosSparse::sptrsv_symbolic instead.")]]
-void sptrsv_symbolic(KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries, scalar_nnz_view_t_ values) {
+[[deprecated(
+    "sptrsv_symbolic was promoted out of Experimental, please use KokkosSparse::sptrsv_symbolic instead.")]] void
+sptrsv_symbolic(KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries, scalar_nnz_view_t_ values) {
   KokkosSparse::sptrsv_symbolic(handle, rowmap, entries, values);
 }
 
 template <typename ExecutionSpace, typename KernelHandle, typename lno_row_view_t_, typename lno_nnz_view_t_,
           typename scalar_nnz_view_t_, class BType, class XType>
-[[deprecated("sptrsv_solve was promoted out of Experimental, please use KokkosSparse::sptrsv_symbolic instead.")]]
-void sptrsv_solve(ExecutionSpace &space, KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries,
-                  scalar_nnz_view_t_ values, BType b, XType x) {
+[[deprecated("sptrsv_solve was promoted out of Experimental, please use KokkosSparse::sptrsv_symbolic instead.")]] void
+sptrsv_solve(ExecutionSpace &space, KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries,
+             scalar_nnz_view_t_ values, BType b, XType x) {
   KokkosSparse::sptrsv_solve(space, handle, rowmap, entries, values, b, x);
 }
 
 template <typename KernelHandle, typename lno_row_view_t_, typename lno_nnz_view_t_, typename scalar_nnz_view_t_,
           class BType, class XType>
-[[deprecated("sptrsv_solve was promoted out of Experimental, please use KokkosSparse::sptrsv_symbolic instead.")]]
-void sptrsv_solve(KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries, scalar_nnz_view_t_ values,
-                  BType b, XType x) {
+[[deprecated("sptrsv_solve was promoted out of Experimental, please use KokkosSparse::sptrsv_symbolic instead.")]] void
+sptrsv_solve(KernelHandle *handle, lno_row_view_t_ rowmap, lno_nnz_view_t_ entries, scalar_nnz_view_t_ values, BType b,
+             XType x) {
   KokkosSparse::sptrsv_solve(handle, rowmap, entries, values, b, x);
 }
+#endif
 
 }  // namespace Experimental
 }  // namespace KokkosSparse

--- a/sparse/src/KokkosSparse_sptrsv_supernode.hpp
+++ b/sparse/src/KokkosSparse_sptrsv_supernode.hpp
@@ -1049,7 +1049,7 @@ void sptrsv_supernodal_symbolic(int nsuper, int *supercols, int *etree, host_gra
   tic.reset();
   std::cout << std::endl;
 #endif
-  sptrsv_symbolic(kernelHandleL, row_mapL, entriesL);
+  KokkosSparse::sptrsv_symbolic(kernelHandleL, row_mapL, entriesL);
 #ifdef KOKKOS_SPTRSV_SUPERNODE_PROFILE
   time_seconds = tic.seconds();
   std::cout << " > Lower-TRI: " << std::endl;
@@ -1061,7 +1061,7 @@ void sptrsv_supernodal_symbolic(int nsuper, int *supercols, int *etree, host_gra
   // do symbolic for U solve on the host
   auto row_mapU = graphU.row_map;
   auto entriesU = graphU.entries;
-  sptrsv_symbolic(kernelHandleU, row_mapU, entriesU);
+  KokkosSparse::sptrsv_symbolic(kernelHandleU, row_mapU, entriesU);
 #ifdef KOKKOS_SPTRSV_SUPERNODE_PROFILE
   time_seconds = tic.seconds();
   std::cout << " > Upper-TRI: " << std::endl;

--- a/sparse/unit_test/Test_Sparse_sptrsv.hpp
+++ b/sparse/unit_test/Test_Sparse_sptrsv.hpp
@@ -209,10 +209,10 @@ struct SptrsvTest {
         kh.get_sptrsv_handle()->reset_chain_threshold(chain_threshold);
       }
 
-      sptrsv_symbolic(&kh, row_map, entries, values);
+      KokkosSparse::sptrsv_symbolic(&kh, row_map, entries, values);
       Kokkos::fence();
 
-      sptrsv_solve(&kh, row_map, entries, values, rhs, lhs);
+      KokkosSparse::sptrsv_solve(&kh, row_map, entries, values, rhs, lhs);
       Kokkos::fence();
 
       scalar_t sum = 0.0;
@@ -588,7 +588,7 @@ struct SptrsvTest {
       kh_ptr_v[i] = &kh_v[i];
 
       // Symbolic phase
-      sptrsv_symbolic(kh_ptr_v[i], row_map_v[i], entries_v[i], values_v[i]);
+      KokkosSparse::sptrsv_symbolic(kh_ptr_v[i], row_map_v[i], entries_v[i], values_v[i]);
       Kokkos::fence();
     }  // Done handle creation and sptrsv_symbolic on all streams
 


### PR DESCRIPTION
Moving the generic SpTRSV kenrels out of experimental but keeping the supernodal and stream variants in experimental as they are less tested and more recent respectively.