### PR TITLE
Adding ctest config for cdash submissions

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,0 +1,4 @@
+set(CTEST_PROJECT_NAME Kokkos Kernels)
+set(CTEST_NIGHTLY_START_TIME 01:00:00 UTC)
+set(CTEST_SUBMIT_URL https://my.cdash.org/submit.php?project=Kokkos+Kernels)
+set(CTEST_DROP_SITE_CDASH TRUE)


### PR DESCRIPTION
As explained in the title, this will allow us to submit to a public cdash [here](https://my.cdash.org/index.php?project=Kokkos+Kernels) for jobs on machines that permit it.