### PR TITLE
SYCL: Fix Test_Common_AlignPtrTo.hpp

### DIFF
--- a/common/unit_test/Test_Common_AlignPtrTo.hpp
+++ b/common/unit_test/Test_Common_AlignPtrTo.hpp
@@ -132,7 +132,15 @@ void test_alignPtrTo() {
       Kokkos::RangePolicy<ExecSpace>(space, 0, teamSize),
       KOKKOS_LAMBDA(int i, int &lerr) { lerr += (results(i) != i); }, errs);
 
+#if defined(KOKKOS_COMPILER_INTEL_LLVM) && KOKKOS_COMPILER_INTEL_LLVM < 20250000
+  if constexpr ((1 == TEST_FN) || (4 == TEST_FN)) {
+    EXPECT_EQ(0, errs);
+  } else {
+    EXPECT_NE(0, errs);
+  }
+#else
   EXPECT_EQ(0, errs);
+#endif
 }
 
 TEST_F(TestCategory, common_AlignPtrTo_0) { test_alignPtrTo<0, TestDevice>(); }

--- a/common/unit_test/Test_Common_AlignPtrTo.hpp
+++ b/common/unit_test/Test_Common_AlignPtrTo.hpp
@@ -132,11 +132,16 @@ void test_alignPtrTo() {
       Kokkos::RangePolicy<ExecSpace>(space, 0, teamSize),
       KOKKOS_LAMBDA(int i, int &lerr) { lerr += (results(i) != i); }, errs);
 
-#if defined(KOKKOS_COMPILER_INTEL_LLVM) && KOKKOS_COMPILER_INTEL_LLVM < 20250000
-  if constexpr ((1 == TEST_FN) || (4 == TEST_FN)) {
-    EXPECT_EQ(0, errs);
+// if SYCL is enabled, only TEST_FN 1 and 4 should work with older compiler versions
+#if defined(KOKKOS_ENABLE_SYCL) && KOKKOS_COMPILER_INTEL_LLVM < 20250000
+  if constexpr (std::is_same_v<ExecSpace, Kokkos::Experimental::SYCL>) {
+    if constexpr ((1 == TEST_FN) || (4 == TEST_FN)) {
+      EXPECT_EQ(0, errs);
+    } else {
+      EXPECT_NE(0, errs);
+    }
   } else {
-    EXPECT_NE(0, errs);
+    EXPECT_EQ(0, errs);
   }
 #else
   EXPECT_EQ(0, errs);

--- a/common/unit_test/Test_Common_AlignPtrTo.hpp
+++ b/common/unit_test/Test_Common_AlignPtrTo.hpp
@@ -132,20 +132,7 @@ void test_alignPtrTo() {
       Kokkos::RangePolicy<ExecSpace>(space, 0, teamSize),
       KOKKOS_LAMBDA(int i, int &lerr) { lerr += (results(i) != i); }, errs);
 
-// if SYCL is enabled, only TEST_FN 1 and 4 should work
-#if defined(KOKKOS_ENABLE_SYCL)
-  if constexpr (std::is_same_v<ExecSpace, Kokkos::Experimental::SYCL>) {
-    if constexpr ((1 == TEST_FN) || (4 == TEST_FN)) {
-      EXPECT_EQ(0, errs);
-    } else {
-      EXPECT_NE(0, errs);
-    }
-  } else {
-    EXPECT_EQ(0, errs);
-  }
-#else
   EXPECT_EQ(0, errs);
-#endif
 }
 
 TEST_F(TestCategory, common_AlignPtrTo_0) { test_alignPtrTo<0, TestDevice>(); }


### PR DESCRIPTION
According to https://my.cdash.org/tests/255304660, this works with recent `oneAPI` compiler versions.