### PR TITLE
SYCL - SIMD: preventing AVX512 code to be compiled when targeting GPU

### DIFF
--- a/batched/dense/src/KokkosBatched_Vector_SIMD.hpp
+++ b/batched/dense/src/KokkosBatched_Vector_SIMD.hpp
@@ -22,7 +22,7 @@
 #include <KokkosBatched_Vector.hpp>
 #include "KokkosKernels_Macros.hpp"
 
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || defined(SYCL_LANGUAGE_VERSION)
 #undef __KOKKOSBATCHED_ENABLE_AVX__
 #else
 // compiler bug with AVX in some architectures

--- a/batched/dense/src/KokkosBatched_Vector_SIMD.hpp
+++ b/batched/dense/src/KokkosBatched_Vector_SIMD.hpp
@@ -22,7 +22,7 @@
 #include <KokkosBatched_Vector.hpp>
 #include "KokkosKernels_Macros.hpp"
 
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || defined(SYCL_LANGUAGE_VERSION)
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || defined(__SYCL_DEVICE_ONLY__)
 #undef __KOKKOSBATCHED_ENABLE_AVX__
 #else
 // compiler bug with AVX in some architectures


### PR DESCRIPTION
There is a check missing to verify that we are not trying to compile AVX512 intrinsic in GPU code which is obviously not a good idea.