### PR TITLE
Reverting build_requirements to previous versions

### DIFF
--- a/docs/build_requirements.txt
+++ b/docs/build_requirements.txt
@@ -1,6 +1,6 @@
-Sphinx==8.2.3
-furo==2024.8.6
-myst-parser==4.0.1
-sphinx-copybutton==0.5.2
-sphinx-design==0.6.1
+Sphinx==6.2.1
+furo==2024.4.27
+myst-parser==3.0.1
+sphinx-copybutton==0.5.0
+sphinx-design==0.5.0
 m2r2==0.3.2


### PR DESCRIPTION
Next week when dependabot asks to update the versions of our documentation tools let's ask it to stop tracking them for the time being as the new suggested versions are failing...