### PR TITLE
Fixing issue with pragma unroll in laswp

### DIFF
--- a/batched/dense/impl/KokkosBatched_Laswp_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Laswp_Serial_Internal.hpp
@@ -97,9 +97,11 @@ struct SerialLaswpVectorBackwardInternal {
 // On H100 with Cuda 12.0.0, the compiler seems to apply
 // an aggressive optimization which crashes this function
 // Disabling loop unrolling fixes the issue
+#if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_ARCH_HOPPER90)
 #if CUDA_VERSION >= 12000 && CUDA_VERSION < 12100
 #pragma unroll 1
+#endif
 #endif
 #endif
     for (int i = (plen - 1); i >= 0; --i) {


### PR DESCRIPTION
The current guards are not appropriately working on Blake.
Adding the standard Kokkos guard for pragma unroll does the job