### PR TITLE
don't run clang-tidy on google benchmark code

### DIFF
--- a/cmake/kokkoskernels_benchmarks.cmake
+++ b/cmake/kokkoskernels_benchmarks.cmake
@@ -42,6 +42,12 @@ ELSE()
     FetchContent_MakeAvailable(googlebenchmark)
     LIST(POP_BACK CMAKE_MESSAGE_INDENT)
 
+    # remove the CXX_CLANG_TIDY property from google benchmark
+    # when we're running clang-tidy we don't care if google benchmark passes or not
+    SET_PROPERTY(TARGET benchmark PROPERTY CXX_CLANG_TIDY "")
+    SET_PROPERTY(TARGET benchmark_main PROPERTY CXX_CLANG_TIDY "")
+
+    # disable warnings for google benchmark
     TARGET_COMPILE_OPTIONS(benchmark PRIVATE -w)
     TARGET_COMPILE_OPTIONS(benchmark_main PRIVATE -w)
 ENDIF()


### PR DESCRIPTION
In anticipation of eventually having CI for clang-tidy, let's not run it on third-party code