### PR TITLE
Add nightlyt tests on Frontier

### DIFF
--- a/.gitlab/olcf-gitlab-ci.yml
+++ b/.gitlab/olcf-gitlab-ci.yml
@@ -1,0 +1,36 @@
+stages:
+  - test
+
+hipcc:
+  stage: test
+  tags: [frontier, shell]
+  id_tokens:
+    OLCF_ID_TOKEN:
+      aud: https://code.olcf.ornl.gov
+  variables:
+    OLCF_SERVICE_ACCOUNT: ums018_auser
+  script:
+    - module load rocm/6.3.1
+    - export CRAYPE_LINK_TYPE=dynamic
+    - export CMAKE_BUILD_PARALLEL_LEVEL=48
+    - git clone https://github.com/kokkos/kokkos.git
+    - cd kokkos
+    - cmake -B build_hip -DCMAKE_CXX_COMPILER=hipcc -DKokkos_ENABLE_HIP=ON -DCMAKE_INSTALL_PREFIX=${PWD}/install
+    - cmake --build build_hip --target install
+    - cd ../..
+    - cmake -S${PWD}/kokkos-kernels -B${PWD}/kokkos-kernels/build 
+      -DCMAKE_CXX_COMPILER=hipcc 
+      -DCMAKE_INSTALL_PREFIX=${PWD}/kokkos-kernels/install 
+      -DCMAKE_BUILD_TYPE="Release" 
+      -DCMAKE_VERBOSE_MAKEFILE=ON 
+      -DSITE=OLCF-Frontier 
+      -DKokkos_ROOT=${PWD}/kokkos-kernels/kokkos/install 
+      -DKokkosKernels_ENABLE_TPL_ROCSOLVER=ON 
+      -DKokkosKernels_ENABLE_TPL_ROCSPARSE=ON
+      -DKokkosKernels_ENABLE_TPL_ROCBLAS=ON 
+      -DKokkosKernels_ENABLE_TESTS=ON 
+      -DKokkosKernels_ENABLE_EXAMPLES:BOOL=ON 
+      -DKokkosKernels_ENABLE_PERFTESTS=OFF 
+      -DKokkosKernels_ENABLE_BENCHMARK:BOOL=OFF 
+      -DKokkosKernels_INST_COMPLEX_DOUBLE=ON
+    - ctest -V --test-dir ${PWD}/kokkos-kernels/build -D Nightly


### PR DESCRIPTION
This adds the configuration to run nightly tests on Frontier. I've tried it on a local branch and it works (see https://my.cdash.org/index.php?project=Kokkos+Kernels). Once this is merged, I will update the configuration on OLCF side to mirror this repo instead of mine. I do get an error message because the coverage is not working. Is there a way to disable it? I get an email about it every time the tests are running