### PR TITLE
Implement batched serial gbtrs

### DIFF
--- a/batched/dense/impl/KokkosBatched_Gbtrs_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gbtrs_Serial_Impl.hpp
@@ -30,12 +30,14 @@ KOKKOS_INLINE_FUNCTION static int checkGbtrsInput([[maybe_unused]] const AViewTy
   static_assert(Kokkos::is_view_v<AViewType>, "KokkosBatched::gbtrs: AViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view_v<PivViewType>, "KokkosBatched::gbtrs: PivViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view_v<BViewType>, "KokkosBatched::gbtrs: BViewType is not a Kokkos::View.");
-  static_assert(AViewType::rank == 2, "KokkosBatched::gbtrs: AViewType must have rank 2.");
-  static_assert(PivViewType::rank == 1, "KokkosBatched::gbtrs: PivViewType must have rank 1.");
-  static_assert(BViewType::rank == 1, "KokkosBatched::gbtrs: BViewType must have rank 1.");
+  static_assert(AViewType::rank() == 2, "KokkosBatched::gbtrs: AViewType must have rank 2.");
+  static_assert(PivViewType::rank() == 1, "KokkosBatched::gbtrs: PivViewType must have rank 1.");
+  static_assert(BViewType::rank() == 1, "KokkosBatched::gbtrs: BViewType must have rank 1.");
   using PivValueType = typename PivViewType::non_const_value_type;
   static_assert(std::is_integral_v<PivValueType>,
                 "KokkosBatched::gbtrs: value type of PivViewType must be an integral type.");
+  static_assert(std::is_same_v<typename BViewType::value_type, typename BViewType::non_const_value_type>,
+                "KokkosBatched::gbtrs: BViewType must have non-const value type.");
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
   if (kl < 0) {
     Kokkos::printf(
@@ -58,7 +60,7 @@ KOKKOS_INLINE_FUNCTION static int checkGbtrsInput([[maybe_unused]] const AViewTy
   const int lda = A.extent(0), n = A.extent(1);
   if (lda < (2 * kl + ku + 1)) {
     Kokkos::printf(
-        "KokkosBatched::gbtrs: leading dimension of A must be smaller than 2 * "
+        "KokkosBatched::gbtrs: leading dimension of A must not be smaller than 2 * "
         "kl + ku + 1: "
         "lda = %d, kl = %d, ku = %d\n",
         lda, kl, ku);
@@ -68,7 +70,7 @@ KOKKOS_INLINE_FUNCTION static int checkGbtrsInput([[maybe_unused]] const AViewTy
   const int ldb = b.extent(0);
   if (ldb < Kokkos::max(1, n)) {
     Kokkos::printf(
-        "KokkosBatched::gbtrs: leading dimension of b must be smaller than "
+        "KokkosBatched::gbtrs: leading dimension of b must not be smaller than "
         "max(1, n): "
         "ldb = %d, n = %d\n",
         ldb, n);

--- a/batched/dense/impl/KokkosBatched_Gbtrs_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gbtrs_Serial_Impl.hpp
@@ -76,7 +76,7 @@ KOKKOS_INLINE_FUNCTION static int checkGbtrsInput([[maybe_unused]] const AViewTy
     return 1;
   }
 
-  const int npiv = ipiv.extent(0);
+  const int npiv = ipiv.extent_int(0);
   if (npiv != n) {
     Kokkos::printf(
         "KokkosBatched::gbtrs: the dimension of the ipiv array must "

--- a/batched/dense/impl/KokkosBatched_Gbtrs_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gbtrs_Serial_Impl.hpp
@@ -33,6 +33,9 @@ KOKKOS_INLINE_FUNCTION static int checkGbtrsInput([[maybe_unused]] const AViewTy
   static_assert(AViewType::rank == 2, "KokkosBatched::gbtrs: AViewType must have rank 2.");
   static_assert(PivViewType::rank == 1, "KokkosBatched::gbtrs: PivViewType must have rank 1.");
   static_assert(BViewType::rank == 1, "KokkosBatched::gbtrs: BViewType must have rank 1.");
+  using PivValueType = typename PivViewType::non_const_value_type;
+  static_assert(std::is_integral_v<PivValueType>,
+                "KokkosBatched::gbtrs: value type of PivViewType must be an integral type.");
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
   if (kl < 0) {
     Kokkos::printf(

--- a/batched/dense/impl/KokkosBatched_Gbtrs_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Gbtrs_Serial_Internal.hpp
@@ -1,0 +1,148 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOSBATCHED_GBTRS_SERIAL_INTERNAL_HPP_
+#define KOKKOSBATCHED_GBTRS_SERIAL_INTERNAL_HPP_
+
+#include <Kokkos_Swap.hpp>
+#include <KokkosBatched_Util.hpp>
+#include <KokkosBlas_util.hpp>
+#include <KokkosBlas2_gemv.hpp>
+#include <KokkosBatched_Tbsv.hpp>
+#include <KokkosBatched_Lacgv.hpp>
+
+namespace KokkosBatched {
+namespace Impl {
+template <typename ArgTrans, typename ArgAlgo>
+struct SerialGbtrsInternal {
+  template <typename AViewType, typename PivViewType, typename BViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const PivViewType &piv, const BViewType &b, const int kl,
+                                           const int ku);
+};
+
+//// Non-transpose ////
+template <>
+template <typename AViewType, typename PivViewType, typename BViewType>
+KOKKOS_INLINE_FUNCTION int SerialGbtrsInternal<Trans::NoTranspose, Algo::Gbtrs::Unblocked>::invoke(
+    const AViewType &A, const PivViewType &piv, const BViewType &b, const int kl, const int ku) {
+  const int n  = A.extent(1);
+  bool lnoti   = kl > 0;
+  const int kd = ku + kl + 1;
+  if (lnoti) {
+    for (int j = 0; j < n - 1; ++j) {
+      const int lm = Kokkos::min(kl, n - j - 1);
+      auto l       = piv(j);
+      // If pivot index is not j, swap rows l and j in b
+      if (l != j) {
+        Kokkos::kokkos_swap(b(l), b(j));
+      }
+
+      // Perform a rank-1 update of the remaining part of the current column
+      // (ger)
+      for (int i = 0; i < lm; ++i) {
+        b(j + 1 + i) = b(j + 1 + i) - A(kd + i, j) * b(j);
+      }
+    }
+  }
+
+  // Solve U*X = b for each right hand side, overwriting B with X.
+  KokkosBatched::SerialTbsv<Uplo::Upper, Trans::NoTranspose, Diag::NonUnit, Algo::Trsv::Unblocked>::invoke(A, b,
+                                                                                                           kl + ku);
+
+  return 0;
+}
+
+//// Transpose ////
+template <>
+template <typename AViewType, typename PivViewType, typename BViewType>
+KOKKOS_INLINE_FUNCTION int SerialGbtrsInternal<Trans::Transpose, Algo::Gbtrs::Unblocked>::invoke(
+    const AViewType &A, const PivViewType &piv, const BViewType &b, const int kl, const int ku) {
+  const int n  = A.extent(1);
+  bool lnoti   = kl > 0;
+  const int kd = ku + kl + 1;
+
+  // Solve U*X = b for each right hand side, overwriting B with X.
+  KokkosBatched::SerialTbsv<Uplo::Upper, Trans::Transpose, Diag::NonUnit, Algo::Tbsv::Unblocked>::invoke(A, b, kl + ku);
+
+  if (lnoti) {
+    for (int j = n - 2; j >= 0; --j) {
+      const int lm = Kokkos::min(kl, n - j - 1);
+
+      // Gemv transposed
+      auto a = Kokkos::subview(b, Kokkos::pair(j + 1, j + 1 + lm));
+      auto x = Kokkos::subview(A, Kokkos::pair(kd, kd + lm), j);
+      auto y = Kokkos::subview(b, Kokkos::pair(j, j + lm));
+
+      KokkosBlas::Impl::SerialGemvInternal<Algo::Gemv::Unblocked>::invoke(1, a.extent(0), -1.0, a.data(), a.stride_0(),
+                                                                          a.stride_0(), x.data(), x.stride_0(), 1.0,
+                                                                          y.data(), y.stride_0());
+
+      // If pivot index is not j, swap rows l and j in b
+      auto l = piv(j);
+      if (l != j) {
+        Kokkos::kokkos_swap(b(l), b(j));
+      }
+    }
+  }
+
+  return 0;
+}
+
+//// Conj-Transpose ////
+template <>
+template <typename AViewType, typename PivViewType, typename BViewType>
+KOKKOS_INLINE_FUNCTION int SerialGbtrsInternal<Trans::ConjTranspose, Algo::Gbtrs::Unblocked>::invoke(
+    const AViewType &A, const PivViewType &piv, const BViewType &b, const int kl, const int ku) {
+  const int n  = A.extent(1);
+  bool lnoti   = kl > 0;
+  const int kd = ku + kl + 1;
+
+  // Solve U*X = b for each right hand side, overwriting B with X.
+  KokkosBatched::SerialTbsv<Uplo::Upper, Trans::ConjTranspose, Diag::NonUnit, Algo::Tbsv::Unblocked>::invoke(A, b,
+                                                                                                             kl + ku);
+
+  if (lnoti) {
+    for (int j = n - 2; j >= 0; --j) {
+      const int lm = Kokkos::min(kl, n - j - 1);
+
+      // Gemv transposed
+      auto a = Kokkos::subview(b, Kokkos::pair(j + 1, j + 1 + lm));
+      auto x = Kokkos::subview(A, Kokkos::pair(kd, kd + lm), j);
+      auto y = Kokkos::subview(b, Kokkos::pair(j, j + lm));
+
+      SerialLacgv::invoke(y);
+
+      KokkosBlas::Impl::SerialGemvInternal<Algo::Gemv::Unblocked>::invoke(
+          KokkosBlas::Impl::OpConj(), 1, a.extent(0), -1.0, a.data(), a.stride_0(), a.stride_0(), x.data(),
+          x.stride_0(), 1.0, y.data(), y.stride_0());
+
+      SerialLacgv::invoke(y);
+
+      // If pivot index is not j, swap rows l and j in b
+      auto l = piv(j);
+      if (l != j) {
+        Kokkos::kokkos_swap(b(l), b(j));
+      }
+    }
+  }
+
+  return 0;
+}
+
+}  // namespace Impl
+}  // namespace KokkosBatched
+
+#endif  // KOKKOSBATCHED_GBTRS_SERIAL_INTERNAL_HPP_

--- a/batched/dense/impl/KokkosBatched_Gbtrs_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Gbtrs_Serial_Internal.hpp
@@ -123,13 +123,11 @@ KOKKOS_INLINE_FUNCTION int SerialGbtrsInternal<Trans::ConjTranspose, Algo::Gbtrs
       auto x = Kokkos::subview(A, Kokkos::pair(kd, kd + lm), j);
       auto y = Kokkos::subview(b, Kokkos::pair(j, j + lm));
 
-      SerialLacgv::invoke(y);
-
+      b(j) = Kokkos::ArithTraits<ValueType>::conj(b(j));
       KokkosBlas::Impl::SerialGemvInternal<Algo::Gemv::Unblocked>::invoke(
           KokkosBlas::Impl::OpConj(), 1, a.extent(0), -1.0, a.data(), a.stride_0(), a.stride_0(), x.data(),
           x.stride_0(), 1.0, y.data(), y.stride_0());
-
-      SerialLacgv::invoke(y);
+      b(j) = Kokkos::ArithTraits<ValueType>::conj(b(j));
 
       // If pivot index is not j, swap rows l and j in b
       auto l = piv(j);

--- a/batched/dense/src/KokkosBatched_Gbtrs.hpp
+++ b/batched/dense/src/KokkosBatched_Gbtrs.hpp
@@ -1,0 +1,68 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+#ifndef KOKKOSBATCHED_GBTRS_HPP_
+#define KOKKOSBATCHED_GBTRS_HPP_
+
+#include <KokkosBatched_Util.hpp>
+
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+
+namespace KokkosBatched {
+
+/// \brief Serial Batched Gbtrs:
+///
+/// Solve a system of linear equations
+///   A * X = B or A**T * X = B or A**H * X = B
+///   with a general band matrix A using the LU factorization computed
+///   by gbtrf.
+/// \tparam ArgTrans: Type indicating whether the A (Trans::NoTranspose), or A**T (Trans::Transpose) or A**H
+/// (Trans::ConjTranspose) is used. \tparam ArgAlgo: Type indicating the blocked (KokkosBatched::Algo::Gbtrs::Blocked)
+/// or unblocked (KokkosBatched::Algo::Gbtrs::Unblocked) algorithm to be used
+///
+/// \tparam AViewType: Input type for the matrix, needs to be a 2D view
+/// \tparam PivViewType: Integer type for pivot indices, needs to be a 1D view
+/// \tparam BViewType: Input type for the right-hand side and the solution,
+/// needs to be a 1D view
+///
+/// \param A [in]: A is a ldab by n banded matrix.
+/// Details of the LU factorization of the band matrix A, as computed by
+/// gbtrf. U is stored as an upper triangular band matrix with KL+KU
+/// superdiagonals in rows 1 to KL+KU+1, and the multipliers used during
+/// the factorization are stored in rows KL+KU+2 to 2*KL+KU+1.
+/// \param piv [in]: The pivot indices; for 1 <= i <= N, row i of the matrix
+/// was interchanged with row piv(i).
+/// \param b [inout]: right-hand side and the solution
+/// \param kl [in]: kl specifies the number of subdiagonals within the band
+/// of A. kl >= 0
+/// \param ku [in]: ku specifies the number of superdiagonals within the band
+/// of A. ku >= 0
+///
+/// No nested parallel_for is used inside of the function.
+///
+
+template <typename ArgTrans, typename ArgAlgo>
+struct SerialGbtrs {
+  static_assert(KokkosBlas::is_trans_v<ArgTrans>, "KokkosBatched::SerialGbtrs: ArgTrans must be a KokkosBlas::Trans.");
+  static_assert(std::is_same_v<ArgAlgo, Algo::Gbtrs::Unblocked>, "KokkosBatched::gbtrs: Use Algo::Gbtrs::Unblocked");
+  template <typename AViewType, typename PivViewType, typename BViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const PivViewType &piv, const BViewType &b, const int kl,
+                                           const int ku);
+};
+}  // namespace KokkosBatched
+
+#include "KokkosBatched_Gbtrs_Serial_Impl.hpp"
+
+#endif  // KOKKOSBATCHED_GBTRS_HPP_

--- a/batched/dense/src/KokkosBatched_Gbtrs.hpp
+++ b/batched/dense/src/KokkosBatched_Gbtrs.hpp
@@ -26,29 +26,24 @@ namespace KokkosBatched {
 ///
 /// Solve a system of linear equations
 ///   A * X = B or A**T * X = B or A**H * X = B
-///   with a general band matrix A using the LU factorization computed
-///   by gbtrf.
+///   with a general band matrix A using the LU factorization computed by gbtrf.
 /// \tparam ArgTrans: Type indicating whether the A (Trans::NoTranspose), or A**T (Trans::Transpose) or A**H
-/// (Trans::ConjTranspose) is used. \tparam ArgAlgo: Type indicating the blocked (KokkosBatched::Algo::Gbtrs::Blocked)
-/// or unblocked (KokkosBatched::Algo::Gbtrs::Unblocked) algorithm to be used
+/// (Trans::ConjTranspose) is used.
+/// \tparam ArgAlgo: Type indicating the blocked (KokkosBatched::Algo::Gbtrs::Blocked) or unblocked
+/// (KokkosBatched::Algo::Gbtrs::Unblocked) algorithm to be used
 ///
 /// \tparam AViewType: Input type for the matrix, needs to be a 2D view
 /// \tparam PivViewType: Integer type for pivot indices, needs to be a 1D view
-/// \tparam BViewType: Input type for the right-hand side and the solution,
-/// needs to be a 1D view
+/// \tparam BViewType: Input type for the right-hand side and the solution, needs to be a 1D view
 ///
 /// \param A [in]: A is a ldab by n banded matrix.
-/// Details of the LU factorization of the band matrix A, as computed by
-/// gbtrf. U is stored as an upper triangular band matrix with KL+KU
-/// superdiagonals in rows 1 to KL+KU+1, and the multipliers used during
-/// the factorization are stored in rows KL+KU+2 to 2*KL+KU+1.
-/// \param piv [in]: The pivot indices; for 1 <= i <= N, row i of the matrix
-/// was interchanged with row piv(i).
+/// Details of the LU factorization of the band matrix A, as computed by gbtrf. U is stored as an upper triangular band
+/// matrix with KL+KU superdiagonals in rows 1 to KL+KU+1, and the multipliers used during the factorization are stored
+/// in rows KL+KU+2 to 2*KL+KU+1.
+/// \param piv [in]: The pivot indices; for 1 <= i <= N, row i of the matrix was interchanged with row piv(i).
 /// \param b [inout]: right-hand side and the solution
-/// \param kl [in]: kl specifies the number of subdiagonals within the band
-/// of A. kl >= 0
-/// \param ku [in]: ku specifies the number of superdiagonals within the band
-/// of A. ku >= 0
+/// \param kl [in]: kl specifies the number of subdiagonals within the band of A. kl >= 0
+/// \param ku [in]: ku specifies the number of superdiagonals within the band of A. ku >= 0
 ///
 /// No nested parallel_for is used inside of the function.
 ///

--- a/batched/dense/unit_test/Test_Batched_Dense.hpp
+++ b/batched/dense/unit_test/Test_Batched_Dense.hpp
@@ -64,6 +64,7 @@
 #include "Test_Batched_SerialSyr.hpp"
 #include "Test_Batched_SerialLacgv.hpp"
 #include "Test_Batched_SerialGbtrf.hpp"
+#include "Test_Batched_SerialGbtrs.hpp"
 
 // Team Kernels
 #include "Test_Batched_TeamAxpy.hpp"

--- a/batched/dense/unit_test/Test_Batched_SerialGbtrs.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialGbtrs.hpp
@@ -1,0 +1,407 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
+#include <KokkosBlas2_gemv.hpp>
+#include <KokkosBatched_Util.hpp>
+#include <KokkosBatched_Gbtrf.hpp>
+#include <KokkosBatched_Gbtrs.hpp>
+#include "Test_Batched_DenseUtils.hpp"
+
+namespace Test {
+namespace Gbtrs {
+
+template <typename T>
+struct ParamTag {
+  using trans = T;
+};
+
+template <typename DeviceType, typename ABViewType, typename PivViewType>
+struct Functor_BatchedSerialGbtrf {
+  using execution_space = typename DeviceType::execution_space;
+  ABViewType m_ab;
+  PivViewType m_ipiv;
+  int m_kl, m_ku;
+
+  KOKKOS_INLINE_FUNCTION
+  Functor_BatchedSerialGbtrf(const ABViewType &ab, const PivViewType &ipiv, int kl, int ku)
+      : m_ab(ab), m_ipiv(ipiv), m_kl(kl), m_ku(ku) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int k) const {
+    auto ab   = Kokkos::subview(m_ab, k, Kokkos::ALL(), Kokkos::ALL());
+    auto ipiv = Kokkos::subview(m_ipiv, k, Kokkos::ALL());
+
+    KokkosBatched::SerialGbtrf<Algo::Gbtrf::Unblocked>::invoke(ab, ipiv, m_kl, m_ku);
+  }
+
+  inline void run() {
+    using value_type = typename ABViewType::non_const_value_type;
+    std::string name_region("KokkosBatched::Test::SerialGbtrs");
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    Kokkos::RangePolicy<execution_space> policy(0, m_ab.extent(0));
+    Kokkos::parallel_for(name.c_str(), policy, *this);
+  }
+};
+
+template <typename DeviceType, typename AViewType, typename BViewType, typename PivViewType, typename ParamTagType,
+          typename AlgoTagType>
+struct Functor_BatchedSerialGbtrs {
+  using execution_space = typename DeviceType::execution_space;
+  AViewType m_a;
+  BViewType m_b;
+  PivViewType m_ipiv;
+  int m_kl, m_ku;
+
+  KOKKOS_INLINE_FUNCTION
+  Functor_BatchedSerialGbtrs(const AViewType &a, const PivViewType &ipiv, const BViewType &b, int kl, int ku)
+      : m_a(a), m_b(b), m_ipiv(ipiv), m_kl(kl), m_ku(ku) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const ParamTagType &, const int k, int &info) const {
+    auto aa   = Kokkos::subview(m_a, k, Kokkos::ALL(), Kokkos::ALL());
+    auto bb   = Kokkos::subview(m_b, k, Kokkos::ALL());
+    auto ipiv = Kokkos::subview(m_ipiv, k, Kokkos::ALL());
+
+    info += KokkosBatched::SerialGbtrs<typename ParamTagType::trans, AlgoTagType>::invoke(aa, ipiv, bb, m_kl, m_ku);
+  }
+
+  inline int run() {
+    using value_type = typename AViewType::non_const_value_type;
+    std::string name_region("KokkosBatched::Test::SerialGbtrs");
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    int info_sum                      = 0;
+    Kokkos::Profiling::pushRegion(name.c_str());
+    Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, m_b.extent(0));
+    Kokkos::parallel_reduce(name.c_str(), policy, *this, info_sum);
+    Kokkos::Profiling::popRegion();
+    return info_sum;
+  }
+};
+
+template <typename DeviceType, typename ScalarType, typename AViewType, typename xViewType, typename yViewType,
+          typename ParamTagType>
+struct Functor_BatchedSerialGemv {
+  using execution_space = typename DeviceType::execution_space;
+  AViewType m_a;
+  xViewType m_x;
+  yViewType m_y;
+  ScalarType m_alpha, m_beta;
+
+  KOKKOS_INLINE_FUNCTION
+  Functor_BatchedSerialGemv(const ScalarType alpha, const AViewType &a, const xViewType &x, const ScalarType beta,
+                            const yViewType &y)
+      : m_alpha(alpha), m_a(a), m_x(x), m_beta(beta), m_y(y) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const ParamTagType &, const int k) const {
+    auto aa = Kokkos::subview(m_a, k, Kokkos::ALL(), Kokkos::ALL());
+    auto xx = Kokkos::subview(m_x, k, Kokkos::ALL());
+    auto yy = Kokkos::subview(m_y, k, Kokkos::ALL());
+
+    KokkosBlas::SerialGemv<typename ParamTagType::trans, Algo::Gemv::Unblocked>::invoke(m_alpha, aa, xx, m_beta, yy);
+  }
+
+  inline void run() {
+    using value_type = typename AViewType::non_const_value_type;
+    std::string name_region("KokkosBatched::Test::SerialGbtrs");
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, m_x.extent(0));
+    Kokkos::parallel_for(name.c_str(), policy, *this);
+  }
+};
+
+/// \brief Implementation details of batched gbtrs test
+///        Confirm A * x = b, where
+///        A: [[1, -3, -2,  0],
+///            [-1, 1, -3, -2],
+///            [2, -1,  1, -3],
+///            [0,  2, -1,  1]]
+///        b: [1, 1, 1, 1]
+///        x: [67/81, 22/81, -40/81, -1/27] or [-1/27, -40/81, 22/81, 67/81]
+///
+///        This corresponds to the following system of equations:
+///          x0 - 3 x1 - 2 x2        = 1
+///        - x0 +   x1 - 3 x2 - 2 x3 = 1
+///        2 x0 -   x1 +   x3 - 3 x3 = 1
+///               2 x1 -   x2 +   x3 = 1
+///
+/// We confirm this with the factorized matrix LUB and pivot given by
+///       LUB: [[0,       0,    0,    0],
+///             [0,       0,    0,   -3],
+///             [0,       0,    1,  1.5],
+///             [0,      -1, -2.5, -3.2],
+///             [2,    -2.5,   -3,  5.4],
+///             [-0.5, -0.2,    1,    0],
+///             [0.5,  -0.8,    0,    0]]
+///       piv: [2, 2, 2, 3]
+///
+/// \param N [in] Batch size of RHS
+template <typename DeviceType, typename ScalarType, typename LayoutType, typename ParamTagType, typename AlgoTagType>
+void impl_test_batched_gbtrs_analytical(const int N) {
+  using ats         = typename Kokkos::ArithTraits<ScalarType>;
+  using RealType    = typename ats::mag_type;
+  using View2DType  = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
+  using View3DType  = Kokkos::View<ScalarType ***, LayoutType, DeviceType>;
+  using PivViewType = Kokkos::View<int **, LayoutType, DeviceType>;
+
+  const int BlkSize = 4, kl = 2, ku = 2;
+  const int ldab = 2 * kl + ku + 1;
+  View3DType AB("AB", N, ldab, BlkSize);                        // Banded matrix
+  View2DType x0("x0", N, BlkSize), x_ref("x_ref", N, BlkSize);  // Solutions
+  PivViewType ipiv("ipiv", N, BlkSize);
+
+  using ArgTrans = typename ParamTagType::trans;
+  auto h_AB      = Kokkos::create_mirror_view(AB);
+  auto h_ipiv    = Kokkos::create_mirror_view(ipiv);
+  auto h_x_ref   = Kokkos::create_mirror_view(x_ref);
+  for (int ib = 0; ib < N; ib++) {
+    h_AB(ib, 1, 3) = -3.0;
+    h_AB(ib, 2, 2) = 1.0;
+    h_AB(ib, 2, 3) = 1.5;
+    h_AB(ib, 3, 1) = -1.0;
+    h_AB(ib, 3, 2) = -2.5;
+    h_AB(ib, 3, 3) = -3.2;
+    h_AB(ib, 4, 0) = 2.0;
+    h_AB(ib, 4, 1) = -2.5;
+    h_AB(ib, 4, 2) = -3.0;
+    h_AB(ib, 4, 3) = 5.4;
+    h_AB(ib, 5, 0) = -0.5;
+    h_AB(ib, 5, 1) = -0.2;
+    h_AB(ib, 5, 2) = 1.0;
+    h_AB(ib, 6, 0) = 0.5;
+    h_AB(ib, 6, 1) = -0.8;
+
+    h_ipiv(ib, 0) = 2;
+    h_ipiv(ib, 1) = 2;
+    h_ipiv(ib, 2) = 2;
+    h_ipiv(ib, 3) = 3;
+    if (std::is_same_v<ArgTrans, KokkosBatched::Trans::NoTranspose>) {
+      h_x_ref(ib, 0) = 67.0 / 81.0;
+      h_x_ref(ib, 1) = 22.0 / 81.0;
+      h_x_ref(ib, 2) = -40.0 / 81.0;
+      h_x_ref(ib, 3) = -1.0 / 27.0;
+    } else {
+      h_x_ref(ib, 0) = -1.0 / 27.0;
+      h_x_ref(ib, 1) = -40.0 / 81.0;
+      h_x_ref(ib, 2) = 22.0 / 81.0;
+      h_x_ref(ib, 3) = 67.0 / 81.0;
+    }
+  }
+
+  Kokkos::fence();
+
+  Kokkos::deep_copy(AB, h_AB);
+  Kokkos::deep_copy(ipiv, h_ipiv);
+  Kokkos::deep_copy(x0, ScalarType(1.0));
+
+  // gbtrs (Note, Ab is a factorized matrix of A)
+  auto info = Functor_BatchedSerialGbtrs<DeviceType, View3DType, View2DType, PivViewType, ParamTagType, AlgoTagType>(
+                  AB, ipiv, x0, kl, ku)
+                  .run();
+
+  Kokkos::fence();
+  EXPECT_EQ(info, 0);
+
+  // this eps is about 10^-14
+  RealType eps = 1.0e3 * ats::epsilon();
+  auto h_x0    = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), x0);
+
+  // Check x0 = [67/81, 22/81, -40/81, -1/27] or [-1/27, -40/81, 22/81, 67/81]
+  for (int ib = 0; ib < N; ib++) {
+    for (int i = 0; i < BlkSize; i++) {
+      EXPECT_NEAR_KK(h_x0(ib, i), h_x_ref(ib, i), eps);
+    }
+  }
+}
+
+/// \brief Implementation details of batched gbtrs test
+///        Confirm A * x = b, or A**T * x = b, or A**H * x = b, where
+/// \param N [in] Batch size of RHS
+/// \param k [in] Number of superdiagonals and subdiagonals of matrix A
+/// \param BlkSize [in] Block size of matrix A
+template <typename DeviceType, typename ScalarType, typename LayoutType, typename ParamTagType, typename AlgoTagType>
+void impl_test_batched_gbtrs(const int N, const int k, const int BlkSize) {
+  using ats         = typename Kokkos::ArithTraits<ScalarType>;
+  using RealType    = typename ats::mag_type;
+  using View2DType  = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
+  using View3DType  = Kokkos::View<ScalarType ***, LayoutType, DeviceType>;
+  using PivViewType = Kokkos::View<int **, LayoutType, DeviceType>;
+
+  const int kl = k, ku = k;
+  const int ldab = 2 * kl + ku + 1;
+  View3DType A("A", N, BlkSize, BlkSize), tmp_A("tmp_A", N, BlkSize, BlkSize),
+      AB("AB", N, ldab, BlkSize);                                                     // Banded matrix
+  View2DType x0("x0", N, BlkSize), x_ref("x_ref", N, BlkSize), y0("y0", N, BlkSize);  // Solutions
+  PivViewType ipiv("ipiv", N, BlkSize);
+
+  // Create a random matrix A and make it Positive Definite Symmetric
+  using execution_space = typename DeviceType::execution_space;
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
+  ScalarType randStart, randEnd;
+
+  // Initialize tmp_A with random matrix
+  KokkosKernels::Impl::getRandomBounds(1.0, randStart, randEnd);
+  Kokkos::fill_random(A, rand_pool, randStart, randEnd);
+
+  // Make the matrix Positive Definite Symmetric and Diagonal dominant
+  random_to_pds(A, tmp_A);
+  Kokkos::deep_copy(A, ScalarType(0.0));
+
+  dense_to_banded(tmp_A, AB, kl, ku);  // In banded storage
+  banded_to_dense(AB, A, kl, ku);      // In conventional storage
+
+  Kokkos::fence();
+
+  // Create an initial solution vector x0 = [1, 1, 1, ...]
+  Kokkos::deep_copy(x0, ScalarType(1.0));
+
+  // gbtrf to factorize matrix A = P * L * U
+  Functor_BatchedSerialGbtrf<DeviceType, View3DType, PivViewType>(AB, ipiv, kl, ku).run();
+
+  // gbtrs (Note, Ab is a factorized matrix of A)
+  auto info = Functor_BatchedSerialGbtrs<DeviceType, View3DType, View2DType, PivViewType, ParamTagType, AlgoTagType>(
+                  AB, ipiv, x0, kl, ku)
+                  .run();
+  Kokkos::fence();
+  EXPECT_EQ(info, 0);
+
+  // Gemv to compute A*x0, this should be identical to x_ref
+  Functor_BatchedSerialGemv<DeviceType, ScalarType, View3DType, View2DType, View2DType, ParamTagType>(1.0, A, x0, 0.0,
+                                                                                                      y0)
+      .run();
+
+  // this eps is about 10^-14
+  RealType eps = 1.0e3 * ats::epsilon();
+
+  // Check A * x0 = x_ref
+  auto h_y0 = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), y0);
+  for (int ib = 0; ib < N; ib++) {
+    for (int i = 0; i < BlkSize; i++) {
+      EXPECT_NEAR_KK(h_y0(ib, i), ScalarType(1.0), eps);
+    }
+  }
+}
+
+}  // namespace Gbtrs
+}  // namespace Test
+
+template <typename DeviceType, typename ScalarType, typename ParamTagType, typename AlgoTagType>
+int test_batched_gbtrs() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
+  {
+    using LayoutType = Kokkos::LayoutLeft;
+    Test::Gbtrs::impl_test_batched_gbtrs_analytical<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1);
+    Test::Gbtrs::impl_test_batched_gbtrs_analytical<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2);
+    for (int i = 0; i < 10; i++) {
+      int k = 1;
+      Test::Gbtrs::impl_test_batched_gbtrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1, k, i);
+      Test::Gbtrs::impl_test_batched_gbtrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2, k, i);
+    }
+  }
+#endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
+  {
+    using LayoutType = Kokkos::LayoutRight;
+    Test::Gbtrs::impl_test_batched_gbtrs_analytical<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1);
+    Test::Gbtrs::impl_test_batched_gbtrs_analytical<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2);
+    for (int i = 0; i < 10; i++) {
+      int k = 1;
+      Test::Gbtrs::impl_test_batched_gbtrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1, k, i);
+      Test::Gbtrs::impl_test_batched_gbtrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2, k, i);
+    }
+  }
+#endif
+
+  return 0;
+}
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+TEST_F(TestCategory, test_batched_gbtrs_nt_float) {
+  using param_tag_type = ::Test::Gbtrs::ParamTag<Trans::NoTranspose>;
+  using algo_tag_type  = typename Algo::Gbtrs::Unblocked;
+
+  test_batched_gbtrs<TestDevice, float, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, test_batched_gbtrs_t_float) {
+  using param_tag_type = ::Test::Gbtrs::ParamTag<Trans::Transpose>;
+  using algo_tag_type  = typename Algo::Gbtrs::Unblocked;
+
+  test_batched_gbtrs<TestDevice, float, param_tag_type, algo_tag_type>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+TEST_F(TestCategory, test_batched_gbtrs_nt_double) {
+  using param_tag_type = ::Test::Gbtrs::ParamTag<Trans::NoTranspose>;
+  using algo_tag_type  = typename Algo::Gbtrs::Unblocked;
+
+  test_batched_gbtrs<TestDevice, double, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, test_batched_gbtrs_t_double) {
+  using param_tag_type = ::Test::Gbtrs::ParamTag<Trans::Transpose>;
+  using algo_tag_type  = typename Algo::Gbtrs::Unblocked;
+
+  test_batched_gbtrs<TestDevice, double, param_tag_type, algo_tag_type>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_FLOAT)
+TEST_F(TestCategory, test_batched_gbtrs_nt_fcomplex) {
+  using param_tag_type = ::Test::Gbtrs::ParamTag<Trans::NoTranspose>;
+  using algo_tag_type  = typename Algo::Gbtrs::Unblocked;
+
+  test_batched_gbtrs<TestDevice, Kokkos::complex<float>, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, test_batched_gbtrs_t_fcomplex) {
+  using param_tag_type = ::Test::Gbtrs::ParamTag<Trans::Transpose>;
+  using algo_tag_type  = typename Algo::Gbtrs::Unblocked;
+
+  test_batched_gbtrs<TestDevice, Kokkos::complex<float>, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, test_batched_gbtrs_c_fcomplex) {
+  using param_tag_type = ::Test::Gbtrs::ParamTag<Trans::ConjTranspose>;
+  using algo_tag_type  = typename Algo::Gbtrs::Unblocked;
+
+  test_batched_gbtrs<TestDevice, Kokkos::complex<float>, param_tag_type, algo_tag_type>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
+TEST_F(TestCategory, test_batched_gbtrs_nt_dcomplex) {
+  using param_tag_type = ::Test::Gbtrs::ParamTag<Trans::NoTranspose>;
+  using algo_tag_type  = typename Algo::Gbtrs::Unblocked;
+
+  test_batched_gbtrs<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, test_batched_gbtrs_t_dcomplex) {
+  using param_tag_type = ::Test::Gbtrs::ParamTag<Trans::Transpose>;
+  using algo_tag_type  = typename Algo::Gbtrs::Unblocked;
+
+  test_batched_gbtrs<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
+}
+TEST_F(TestCategory, test_batched_gbtrs_c_dcomplex) {
+  using param_tag_type = ::Test::Gbtrs::ParamTag<Trans::ConjTranspose>;
+  using algo_tag_type  = typename Algo::Gbtrs::Unblocked;
+
+  test_batched_gbtrs<TestDevice, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
+}
+#endif

--- a/batched/dense/unit_test/Test_Batched_SerialGbtrs.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialGbtrs.hpp
@@ -249,8 +249,8 @@ void impl_test_batched_gbtrs(const int N, const int k, const int BlkSize) {
   const int kl = k, ku = k;
   const int ldab = 2 * kl + ku + 1;
   View3DType A("A", N, BlkSize, BlkSize), tmp_A("tmp_A", N, BlkSize, BlkSize),
-      AB("AB", N, ldab, BlkSize);                                                     // Banded matrix
-  View2DType x0("x0", N, BlkSize), x_ref("x_ref", N, BlkSize), y0("y0", N, BlkSize);  // Solutions
+      AB("AB", N, ldab, BlkSize);                         // Banded matrix
+  View2DType x0("x0", N, BlkSize), y0("y0", N, BlkSize);  // Solutions
   PivViewType ipiv("ipiv", N, BlkSize);
 
   // Create a random matrix A and make it Positive Definite Symmetric

--- a/batched/dense/unit_test/Test_Batched_SerialGbtrs.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialGbtrs.hpp
@@ -260,11 +260,7 @@ void impl_test_batched_gbtrs(const int N, const int k, const int BlkSize) {
 
   // Initialize tmp_A with random matrix
   KokkosKernels::Impl::getRandomBounds(1.0, randStart, randEnd);
-  Kokkos::fill_random(A, rand_pool, randStart, randEnd);
-
-  // Make the matrix Positive Definite Symmetric and Diagonal dominant
-  random_to_pds(A, tmp_A);
-  Kokkos::deep_copy(A, ScalarType(0.0));
+  Kokkos::fill_random(tmp_A, rand_pool, randStart, randEnd);
 
   dense_to_banded(tmp_A, AB, kl, ku);  // In banded storage
   banded_to_dense(AB, A, kl, ku);      // In conventional storage

--- a/batched/dense/unit_test/Test_Batched_SerialGbtrs.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialGbtrs.hpp
@@ -108,7 +108,7 @@ struct Functor_BatchedSerialGemv {
   KOKKOS_INLINE_FUNCTION
   Functor_BatchedSerialGemv(const ScalarType alpha, const AViewType &a, const xViewType &x, const ScalarType beta,
                             const yViewType &y)
-      : m_alpha(alpha), m_a(a), m_x(x), m_beta(beta), m_y(y) {}
+      : m_a(a), m_x(x), m_y(y), m_alpha(alpha), m_beta(beta) {}
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const ParamTagType &, const int k) const {

--- a/batched/dense/unit_test/Test_Batched_SerialGbtrs.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialGbtrs.hpp
@@ -305,24 +305,30 @@ int test_batched_gbtrs() {
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
   {
     using LayoutType = Kokkos::LayoutLeft;
+    Test::Gbtrs::impl_test_batched_gbtrs_analytical<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(0);
     Test::Gbtrs::impl_test_batched_gbtrs_analytical<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1);
     Test::Gbtrs::impl_test_batched_gbtrs_analytical<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2);
     for (int i = 0; i < 10; i++) {
-      int k = 1;
-      Test::Gbtrs::impl_test_batched_gbtrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1, k, i);
-      Test::Gbtrs::impl_test_batched_gbtrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2, k, i);
+      for (int k = 1; k < 4; k++) {
+        Test::Gbtrs::impl_test_batched_gbtrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(0, k, i);
+        Test::Gbtrs::impl_test_batched_gbtrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1, k, i);
+        Test::Gbtrs::impl_test_batched_gbtrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2, k, i);
+      }
     }
   }
 #endif
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
   {
     using LayoutType = Kokkos::LayoutRight;
+    Test::Gbtrs::impl_test_batched_gbtrs_analytical<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(0);
     Test::Gbtrs::impl_test_batched_gbtrs_analytical<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1);
     Test::Gbtrs::impl_test_batched_gbtrs_analytical<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2);
     for (int i = 0; i < 10; i++) {
-      int k = 1;
-      Test::Gbtrs::impl_test_batched_gbtrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1, k, i);
-      Test::Gbtrs::impl_test_batched_gbtrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2, k, i);
+      for (int k = 1; k < 4; k++) {
+        Test::Gbtrs::impl_test_batched_gbtrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(0, k, i);
+        Test::Gbtrs::impl_test_batched_gbtrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(1, k, i);
+        Test::Gbtrs::impl_test_batched_gbtrs<DeviceType, ScalarType, LayoutType, ParamTagType, AlgoTagType>(2, k, i);
+      }
     }
   }
 #endif

--- a/blas/impl/KokkosBlas_util.hpp
+++ b/blas/impl/KokkosBlas_util.hpp
@@ -144,6 +144,7 @@ struct Algo {
   using Getrf     = Level3;
   using Getrs     = Level3;
   using Gbtrf     = Level3;
+  using Gbtrs     = Level3;
 
   struct Level2 {
     struct Unblocked {};


### PR DESCRIPTION
This PR implements [gbtrs](https://www.netlib.org/lapack/explore-html/d1/dd7/group__gbtrs_ga21ed607226c9690cadc991f15435fa74.html) function.

Following files are added:
1. `KokkosBatched_Gbtrs_Serial_Impl.hpp`: Internal interfaces
2. `KokkosBatched_Gbtrs_Serial_Internal.hpp`: Implementation details
3. `KokkosBatched_Gbtrs.hpp`: APIs
4. `Test_Batched_SerialGbtrs.hpp`: Unit tests for that

## Detailed description
It solves a general band matrix `A` using the LU factorization computed by gbtrf.
Here, the matrix has the following shape.
- `A`: `(batch_count, lab, n)`  
The factorized band matrix by gbtrf. The factors L and U from the factorization where U is stored as an upper triangular band matrix with KL+KU superdiagonals in rows 0 to KL+KU, and the multipliers used during the factorization are stored in rows KL+KU+1 to 2*KL+KU.
- `IPIV`: `(batch_count, n)`
  The pivot indices from gbtrf. for `0 <= i < n`, row `i` of the matrix was interchanged with row IPIV(i).
- kl: The number of subdiagonals within the band of A. kl >= 0
- ku: The number of superdiagonals within the band of A. ku >= 0

Parallelization would be made in the following manner. This is efficient only when 
A is given in `LayoutLeft` for GPUs and `LayoutRight` for CPUs (parallelized over batch direction).

```C++
Kokkos::parallel_for('gbtrs', 
    Kokkos::RangePolicy<execution_space> policy(0, n),
    [=](const int k) {
        auto aa = Kokkos::subview(m_a, k, Kokkos::ALL(), Kokkos::ALL());
        auto ipiv = Kokkos::subview(m_ipiv, k, Kokkos::ALL());
        auto bb   = Kokkos::subview(m_b, k, Kokkos::ALL());

        KokkosBatched::SerialGbtrs<Trans, AlgoTagType>::invoke(aa, ipiv, bb);
    });
```

## Tests
1.  Make a random band matrix from random `A`. Represent `A` in band storage `AB` and factorize it with `gbtrf`, followed by solving `AB * x = b` by `gbtrs` to get `x`. Note `b` is filled with ones. Finally, confirm that `A * x` is equal to b (ones) using `gemv`.
1.  Simple and small analytical test, i.e. choose `A` as follows to confirm `A * x = b`, where
```bash
A = [[1. -3. -2. 0.],
     [-1. 1 -3 -2],
     [2. -1. 1. -3],
     [0. 2. -1. 1.]]
b: [1, 1, 1, 1]
x: [67/81, 22/81, -40/81, -1/27] (A * x = b) or [-1/27, -40/81, 22/81, 67/81] (A**T * x = b)
```

We confirm this with the factorized matrix `LUB` and pivot given by
```bash
LUB: [[0,       0,    0,    0],
      [0,       0,    0,   -3],
      [0,       0,    1,  1.5],
      [0,      -1, -2.5, -3.2],
      [2,    -2.5,   -3,  5.4],
      [-0.5, -0.2,    1,    0],
      [0.5,  -0.8,    0,    0]]
piv = [2 2 2 3]
```