### PR TITLE
remove log-style printf from NewtonSolve

### DIFF
--- a/ode/impl/KokkosODE_Newton_impl.hpp
+++ b/ode/impl/KokkosODE_Newton_impl.hpp
@@ -93,7 +93,6 @@ KOKKOS_FUNCTION KokkosODE::Experimental::newton_solver_status NewtonSolve(
     }
 
     if (linSolverStat == 1) {
-      Kokkos::printf("NewtonFunctor: Linear solve gesv returned failure! \n");
       return newton_solver_status::LIN_SOLVE_FAIL;
     }
 


### PR DESCRIPTION
The caller can see that this failed by inspecting the returned code and decide what to do.