### PR TITLE
Assume independent thread scheduling for Blackwell

### DIFF
--- a/common/src/KokkosKernels_Macros.hpp
+++ b/common/src/KokkosKernels_Macros.hpp
@@ -98,7 +98,7 @@
 // architecture with "independent thread scheduling" (Volta70 and up). This
 // requires some extra logic in HashmapAccumulator to avoid data races.
 #if defined(KOKKOS_ARCH_VOLTA) || defined(KOKKOS_ARCH_TURING75) || defined(KOKKOS_ARCH_AMPERE) || \
-    defined(KOKKOS_ARCH_ADA89) || defined(KOKKOS_ARCH_HOPPER)
+    defined(KOKKOS_ARCH_ADA89) || defined(KOKKOS_ARCH_HOPPER) || defined(KOKKOS_ARCH_BLACKWELL)
 #define KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
 #endif
 


### PR DESCRIPTION
Like all CUDA architectures since Volta, Blackwell has independent thread scheduling. I don't have access to any hardware to test this but it probably fixes SpGEMM on Blackwell (https://github.com/trilinos/Trilinos/issues/13907).