### PR TITLE
unit test for KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS

### DIFF
--- a/common/unit_test/Test_Common.hpp
+++ b/common/unit_test/Test_Common.hpp
@@ -21,6 +21,7 @@
 // #include<Test_Common_float128.hpp>
 #include <Test_Common_set_bit_count.hpp>
 #include <Test_Common_Sorting.hpp>
+#include <Test_Common_CudaIndependentThreads.hpp>
 #include <Test_Common_IOUtils.hpp>
 #include <Test_Common_Error.hpp>
 #include <Test_Common_Version.hpp>

--- a/common/unit_test/Test_Common_CudaIndependentThreads.hpp
+++ b/common/unit_test/Test_Common_CudaIndependentThreads.hpp
@@ -21,7 +21,7 @@
 #define TEST_COMMON_CUDAINDEPENDENTTHREADSCHEDULING
 
 #include <Kokkos_Core.hpp>
-#include <KokkosKernels_config.h>
+#include <KokkosKernels_Macros.hpp>
 
 void test_version_info() {
 #ifdef KOKKOS_ENABLE_CUDA

--- a/common/unit_test/Test_Common_CudaIndependentThreads.hpp
+++ b/common/unit_test/Test_Common_CudaIndependentThreads.hpp
@@ -41,19 +41,19 @@ void test_version_info() {
 #endif
   } else if (7 == deviceProp.major) {  // VOLTA, TURING75
 #ifndef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
-    FAIL() << "KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS not set, but found a GPU with compute capability is 7.x";
+    FAIL() << "KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS not set, but found a GPU with compute capability 7.x";
 #endif
   } else if (8 == deviceProp.major) {  // AMPERE, ADA
 #ifndef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
-    FAIL() << "KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS not set, but found a GPU with compute capability is 8.x";
+    FAIL() << "KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS not set, but found a GPU with compute capability 8.x";
 #endif
   } else if (9 == deviceProp.major) {  // HOPPER
 #ifndef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
-    FAIL() << "KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS not set, but found a GPU with compute capability is 9.x";
+    FAIL() << "KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS not set, but found a GPU with compute capability 9.x";
 #endif
   } else if (10 == deviceProp.major && 0 == deviceProp.minor) {  // BLACKWELL
 #ifndef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
-    FAIL() << "KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS not set, but found a GPU with compute capability is 10.x";
+    FAIL() << "KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS not set, but found a GPU with compute capability 10.x";
 #endif
   } else {
     FAIL() << "Internal Kokkos Kernels error, please report this. Ensure KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS is "

--- a/common/unit_test/Test_Common_CudaIndependentThreads.hpp
+++ b/common/unit_test/Test_Common_CudaIndependentThreads.hpp
@@ -57,11 +57,11 @@ void test_cuda_independent_threads() {
 #endif
   } else {
     FAIL() << "Kokkos Kernels developer error, please report this. Ensure KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS is "
-              "updated for this GPU architecture, and add the corresponding case to this test."
+              "updated for this GPU architecture, and add the corresponding case to this test.";
   }
 
 #else   // KOKKOS_ENABLE_CUDA
-  GTEST_SKIP() << "CUDA backend not enabled."
+  GTEST_SKIP() << "CUDA backend not enabled.";
 #endif  // KOKKOS_ENABLE_CUDA
 }
 

--- a/common/unit_test/Test_Common_CudaIndependentThreads.hpp
+++ b/common/unit_test/Test_Common_CudaIndependentThreads.hpp
@@ -32,7 +32,7 @@ void test_cuda_independent_threads() {
   // retrieve device properties
   cudaDeviceProp deviceProp;
   cudaError_t err = cudaGetDeviceProperties(&deviceProp, device);
-  GTEST_ASSERT(err == cudaSuccess);
+  ASSERT_EQ(err, cudaSuccess);  // no point in continuing if this fails
 
   // no independent thread scheduling for CC < 7.x
   if (deviceProp.major < 7) {

--- a/common/unit_test/Test_Common_CudaIndependentThreads.hpp
+++ b/common/unit_test/Test_Common_CudaIndependentThreads.hpp
@@ -1,0 +1,70 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+/// \file Test_Common_IndependentThreadScheduling.hpp
+/// \brief Tests that KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS is set appropriately for known architectures
+
+#ifndef TEST_COMMON_CUDAINDEPENDENTTHREADSCHEDULING
+#define TEST_COMMON_CUDAINDEPENDENTTHREADSCHEDULING
+
+#include <Kokkos_Core.hpp>
+#include <KokkosKernels_config.h>
+
+void test_version_info() {
+#ifdef KOKKOS_ENABLE_CUDA
+
+  // pull device off of default CUDA execution space
+  const int device = Kokkos::Cuda{}.cuda_device();
+
+  // retrieve device properties
+  cudaDeviceProp deviceProp;
+  cudaError_t err = cudaGetDeviceProperties(&deviceProp, device);
+  GTEST_ASSERT(err == cudaSuccess);
+
+  // no independent thread scheduling for CC < 7.x
+  if (deviceProp.major < 7) {
+#ifdef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+    FAIL() << "KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS set, but found a GPU with compute capability < 70";
+#endif
+  } else if (7 == deviceProp.major) {  // VOLTA, TURING75
+#ifndef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+    FAIL() << "KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS not set, but found a GPU with compute capability is 7.x";
+#endif
+  } else if (8 == deviceProp.major) {  // AMPERE, ADA
+#ifndef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+    FAIL() << "KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS not set, but found a GPU with compute capability is 8.x";
+#endif
+  } else if (9 == deviceProp.major) {  // HOPPER
+#ifndef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+    FAIL() << "KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS not set, but found a GPU with compute capability is 9.x";
+#endif
+  } else if (10 == deviceProp.major && 0 == deviceProp.minor) {  // BLACKWELL
+#ifndef KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS
+    FAIL() << "KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS not set, but found a GPU with compute capability is 10.x";
+#endif
+  } else {
+    FAIL() << "Internal Kokkos Kernels error, please report this. Ensure KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS is "
+              "updated for this GPU architecture, and add the corresponding case to this test."
+  }
+
+#else   // KOKKOS_ENABLE_CUDA
+  GTEST_SKIP() << "CUDA backend not enabled."
+#endif  // KOKKOS_ENABLE_CUDA
+}
+
+TEST_F(TestCategory, common_version) { test_version_info(); }
+
+#endif  // TEST_COMMON_CUDAINDEPENDENTTHREADSCHEDULING

--- a/common/unit_test/Test_Common_CudaIndependentThreads.hpp
+++ b/common/unit_test/Test_Common_CudaIndependentThreads.hpp
@@ -23,7 +23,7 @@
 #include <Kokkos_Core.hpp>
 #include <KokkosKernels_Macros.hpp>
 
-void test_version_info() {
+void test_cuda_independent_threads() {
 #ifdef KOKKOS_ENABLE_CUDA
 
   // pull device off of default CUDA execution space
@@ -65,6 +65,6 @@ void test_version_info() {
 #endif  // KOKKOS_ENABLE_CUDA
 }
 
-TEST_F(TestCategory, common_version) { test_version_info(); }
+TEST_F(TestCategory, common_cudaindependentthreads) { test_cuda_independent_threads(); }
 
 #endif  // TEST_COMMON_CUDAINDEPENDENTTHREADSCHEDULING

--- a/common/unit_test/Test_Common_CudaIndependentThreads.hpp
+++ b/common/unit_test/Test_Common_CudaIndependentThreads.hpp
@@ -56,7 +56,7 @@ void test_version_info() {
     FAIL() << "KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS not set, but found a GPU with compute capability 10.x";
 #endif
   } else {
-    FAIL() << "Internal Kokkos Kernels error, please report this. Ensure KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS is "
+    FAIL() << "Kokkos Kernels developer error, please report this. Ensure KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS is "
               "updated for this GPU architecture, and add the corresponding case to this test."
   }
 


### PR DESCRIPTION
Make sure we update KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS for new GPU architectures.

Follow up after https://github.com/kokkos/kokkos-kernels/pull/2558