### PR TITLE
replace uses of get_suggested_vector__size with kk_get_suggested_vector_size

### DIFF
--- a/common/src/KokkosKernels_Utils.hpp
+++ b/common/src/KokkosKernels_Utils.hpp
@@ -36,10 +36,6 @@ ExecSpaceType get_exec_space_type() {
   return kk_get_exec_space_type<ExecutionSpace>();
 }
 
-inline int get_suggested_vector__size(size_t nr, size_t nnz, ExecSpaceType exec_space) {
-  return kk_get_suggested_vector_size(nr, nnz, exec_space);
-}
-
 template <typename in_lno_view_t, typename out_lno_view_t, typename MyExecSpace>
 void get_histogram(typename in_lno_view_t::size_type in_elements, in_lno_view_t in_view,
                    out_lno_view_t histogram /*must be initialized with 0s*/) {

--- a/sparse/impl/KokkosSparse_spgemm_impl_memaccess.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_memaccess.hpp
@@ -335,7 +335,7 @@ void KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_vie
 
   /*
   isGPU = true;
-  vectorlane = get_suggested_vector__size(b_row_cnt, entriesB.extent(0),
+  vectorlane = kk_get_suggested_vector_size(b_row_cnt, entriesB.extent(0),
   KokkosKernels::Impl::Exec_CUDA); cache_line_size = 32 * 8; cache_size =
   cache_line_size * 7;
   */


### PR DESCRIPTION
* `get_suggested_vector__size` is a reserved ID
* it seems like an unneeded wrapper

Partial fix for https://github.com/kokkos/kokkos-kernels/issues/2364