### PR TITLE
ConjTrans support for batched team gemm

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -744,5 +744,41 @@ KOKKOS_INLINE_FUNCTION void fma_bounds_check(ViewType v, SizeType m, SizeType n,
   v(m, n) = fma_alpha(reg_c, alpha, alpha_tag);
 }
 
+namespace Impl {
+template <typename ViewType>
+KOKKOS_INLINE_FUNCTION int get_extent_int(const ViewType &v, const int r) {
+  static_assert(Kokkos::is_view_v<ViewType>, "KokkosBatched: ViewType is not a Kokkos::View.");
+  constexpr std::size_t V_rank = ViewType::rank();
+  static_assert(V_rank <= 2, "KokkosBatched: ViewType must have rank 0, 1 or 2.");
+
+  if (r == 0) {
+    int V_extent_0 = V_rank == 0 ? 0 : v.extent_int(0);
+    return V_extent_0;
+  } else if (r == 1) {
+    int V_extent_1 = V_rank == 0 ? 0 : V_rank == 1 ? 1 : v.extent_int(1);
+    return V_extent_1;
+  } else {
+    return -1;
+  }
+}
+
+template <typename ViewType>
+KOKKOS_INLINE_FUNCTION std::size_t get_stride(const ViewType &v, const int r) {
+  static_assert(Kokkos::is_view_v<ViewType>, "KokkosBatched: ViewType is not a Kokkos::View.");
+  constexpr std::size_t V_rank = ViewType::rank();
+  static_assert(V_rank <= 2, "KokkosBatched: ViewType must have rank 0, 1 or 2.");
+
+  if (r == 0) {
+    std::size_t V_stride_0 = V_rank == 0 ? 0 : v.stride(0);
+    return V_stride_0;
+  } else if (r == 1) {
+    std::size_t V_stride_1 = V_rank == 0 ? 0 : V_rank == 1 ? 1 : v.stride(1);
+    return V_stride_1;
+  } else {
+    return 0;
+  }
+}
+}  // namespace Impl
+
 }  // namespace KokkosBatched
 #endif  // KOKKOSBATCHED_UTIL_HPP

--- a/batched/dense/impl/KokkosBatched_Gemm_Common_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemm_Common_Impl.hpp
@@ -29,9 +29,12 @@ KOKKOS_INLINE_FUNCTION static int checkGemmInput([[maybe_unused]] const AViewTyp
   static_assert(Kokkos::is_view_v<BViewType>, "KokkosBatched::gemm: BViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view_v<CViewType>, "KokkosBatched::gemm: CViewType is not a Kokkos::View.");
 
-  static_assert(AViewType::rank <= 2, "KokkosBatched::gemm: AViewType must have rank 0, 1 or 2.");
-  static_assert(BViewType::rank <= 2, "KokkosBatched::gemm: BViewType must have rank 0, 1 or 2.");
-  static_assert(CViewType::rank <= 2, "KokkosBatched::gemm: CViewType must have rank 0, 1 or 2.");
+  static_assert(AViewType::rank() <= 2, "KokkosBatched::gemm: AViewType must have rank 0, 1 or 2.");
+  static_assert(BViewType::rank() <= 2, "KokkosBatched::gemm: BViewType must have rank 0, 1 or 2.");
+  static_assert(CViewType::rank() <= 2, "KokkosBatched::gemm: CViewType must have rank 0, 1 or 2.");
+
+  static_assert(std::is_same_v<typename CViewType::value_type, typename CViewType::non_const_value_type>,
+                "KokkosBatched::gemm: CViewType must have non-const value type.");
 
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
   const int m = C.extent(0), n = C.extent(1);

--- a/batched/dense/impl/KokkosBatched_Gemm_Common_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemm_Common_Impl.hpp
@@ -1,0 +1,79 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+#ifndef KOKKOSBATCHED_GEMM_COMMON_IMPL_HPP
+#define KOKKOSBATCHED_GEMM_COMMON_IMPL_HPP
+
+#include "KokkosBlas_util.hpp"
+#include "KokkosBatched_Util.hpp"
+
+namespace KokkosBatched {
+namespace Impl {
+template <typename ArgTransA, typename ArgTransB, typename AViewType, typename BViewType, typename CViewType>
+KOKKOS_INLINE_FUNCTION static int checkGemmInput([[maybe_unused]] const AViewType &A,
+                                                 [[maybe_unused]] const BViewType &B,
+                                                 [[maybe_unused]] const CViewType &C) {
+  static_assert(Kokkos::is_view_v<AViewType>, "KokkosBatched::gemm: AViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view_v<BViewType>, "KokkosBatched::gemm: BViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view_v<CViewType>, "KokkosBatched::gemm: CViewType is not a Kokkos::View.");
+
+  static_assert(AViewType::rank <= 2, "KokkosBatched::gemm: AViewType must have rank 0, 1 or 2.");
+  static_assert(BViewType::rank <= 2, "KokkosBatched::gemm: BViewType must have rank 0, 1 or 2.");
+  static_assert(CViewType::rank <= 2, "KokkosBatched::gemm: CViewType must have rank 0, 1 or 2.");
+
+#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+  const int m = C.extent(0), n = C.extent(1);
+  const int lda = A.extent(0);
+  const int ldb = B.extent(0);
+
+  const int ka = std::is_same_v<ArgTransA, Trans::NoTranspose> ? A.extent(1) : A.extent(0);
+  const int kb = std::is_same_v<ArgTransB, Trans::NoTranspose> ? B.extent(0) : B.extent(1);
+
+  if (ka != kb) {
+    Kokkos::printf(
+        "KokkosBatched::gemm: Dimensions of A and B do not match: A: %d x %d, "
+        "B: %d x %d\n",
+        A.extent(0), A.extent(1), B.extent(0), B.extent(1));
+    return 1;
+  }
+
+  const int nrowa = std::is_same_v<ArgTransA, Trans::NoTranspose> ? m : ka;
+  const int nrowb = std::is_same_v<ArgTransB, Trans::NoTranspose> ? kb : n;
+
+  if (lda < Kokkos::max(1, nrowa)) {
+    Kokkos::printf(
+        "KokkosBatched::gemm: leading dimension of A must not be smaller than "
+        "max(1, nrowa): "
+        "lda = %d, nrowa = %d\n",
+        lda, nrowa);
+    return 1;
+  }
+  if (ldb < Kokkos::max(1, nrowb)) {
+    Kokkos::printf(
+        "KokkosBatched::gemm: leading dimension of B must not be smaller than "
+        "max(1, nrowb): "
+        "ldb = %d, nrowb = %d\n",
+        ldb, nrowb);
+    return 1;
+  }
+
+#endif
+
+  return 0;
+}
+}  // namespace Impl
+}  // namespace KokkosBatched
+
+#endif

--- a/batched/dense/impl/KokkosBatched_Gemm_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemm_Serial_Impl.hpp
@@ -18,64 +18,10 @@
 
 #include "KokkosBlas_util.hpp"
 #include "KokkosBatched_Util.hpp"
+#include "KokkosBatched_Gemm_Common_Impl.hpp"
 #include "KokkosBatched_Gemm_Serial_Internal.hpp"
 
 namespace KokkosBatched {
-namespace Impl {
-template <typename ArgTransA, typename ArgTransB, typename AViewType, typename BViewType, typename CViewType>
-KOKKOS_INLINE_FUNCTION static int checkGemmInput([[maybe_unused]] const AViewType &A,
-                                                 [[maybe_unused]] const BViewType &B,
-                                                 [[maybe_unused]] const CViewType &C) {
-  static_assert(Kokkos::is_view_v<AViewType>, "KokkosBatched::gemm: AViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view_v<BViewType>, "KokkosBatched::gemm: BViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view_v<CViewType>, "KokkosBatched::gemm: CViewType is not a Kokkos::View.");
-
-  static_assert(AViewType::rank <= 2, "KokkosBatched::gemm: AViewType must have rank 0, 1 or 2.");
-  static_assert(BViewType::rank <= 2, "KokkosBatched::gemm: BViewType must have rank 0, 1 or 2.");
-  static_assert(CViewType::rank <= 2, "KokkosBatched::gemm: CViewType must have rank 0, 1 or 2.");
-
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
-  const int m = C.extent(0), n = C.extent(1);
-  const int lda = A.extent(0);
-  const int ldb = B.extent(0);
-
-  const int ka = std::is_same_v<ArgTransA, Trans::NoTranspose> ? A.extent(1) : A.extent(0);
-  const int kb = std::is_same_v<ArgTransB, Trans::NoTranspose> ? B.extent(0) : B.extent(1);
-
-  if (ka != kb) {
-    Kokkos::printf(
-        "KokkosBatched::gemm: Dimensions of A and B do not match: A: %d x %d, "
-        "B: %d x %d\n",
-        A.extent(0), A.extent(1), B.extent(0), B.extent(1));
-    return 1;
-  }
-
-  const int nrowa = std::is_same_v<ArgTransA, Trans::NoTranspose> ? m : ka;
-  const int nrowb = std::is_same_v<ArgTransB, Trans::NoTranspose> ? kb : n;
-
-  if (lda < Kokkos::max(1, nrowa)) {
-    Kokkos::printf(
-        "KokkosBatched::gemm: leading dimension of A must not be smaller than "
-        "max(1, nrowa): "
-        "lda = %d, nrowa = %d\n",
-        lda, nrowa);
-    return 1;
-  }
-  if (ldb < Kokkos::max(1, nrowb)) {
-    Kokkos::printf(
-        "KokkosBatched::gemm: leading dimension of B must not be smaller than "
-        "max(1, nrowb): "
-        "ldb = %d, nrowb = %d\n",
-        ldb, nrowb);
-    return 1;
-  }
-
-#endif
-
-  return 0;
-}
-}  // namespace Impl
-
 ///
 /// Serial Impl
 /// ===========

--- a/batched/dense/impl/KokkosBatched_Gemm_Team_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemm_Team_Impl.hpp
@@ -17,8 +17,11 @@
 #define KOKKOSBATCHED_GEMM_TEAM_IMPL_HPP
 
 /// \author Kyungjoo Kim (kyukim@sandia.gov)
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
 
+#include "KokkosBlas_util.hpp"
 #include "KokkosBatched_Util.hpp"
+#include "KokkosBatched_Gemm_Common_Impl.hpp"
 #include "KokkosBatched_Gemm_Team_Internal.hpp"
 
 namespace KokkosBatched {
@@ -26,14 +29,6 @@ namespace KokkosBatched {
 ///
 /// Team Impl
 /// =========
-
-///
-/// Implemented:
-/// NT/NT, T/NT, NT/T, T/T
-///
-/// Not yet implemented (ConjTranspose)
-/// CT/NT, NT/CT, CT/CT
-///
 
 ///
 /// NT/NT
@@ -44,11 +39,19 @@ struct TeamGemm<MemberType, Trans::NoTranspose, Trans::NoTranspose, Algo::Gemm::
   template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B, const ScalarType beta, const CViewType &C) {
+    // Quick return if possible
+    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(1);
+    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+    auto info = Impl::checkGemmInput<Trans::NoTranspose, Trans::NoTranspose>(A, B, C);
+    if (info) return info;
+
     // C = beta C + alpha A B
     // C (m x n), A(m x k), B(k x n)
-    return TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(member, C.extent(0), C.extent(1), A.extent(1), alpha,
-                                                           A.data(), A.stride_0(), A.stride_1(), B.data(), B.stride_0(),
-                                                           B.stride_1(), beta, C.data(), C.stride_0(), C.stride_1());
+    return Impl::TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
+        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(1), alpha,
+        A.data(), A.stride_0(), A.stride_1(), B.data(), B.stride_0(), B.stride_1(), beta, C.data(), C.stride_0(),
+        C.stride_1());
   }
 };
 
@@ -57,11 +60,19 @@ struct TeamGemm<MemberType, Trans::NoTranspose, Trans::NoTranspose, Algo::Gemm::
   template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B, const ScalarType beta, const CViewType &C) {
+    // Quick return if possible
+    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(1);
+    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+    auto info = Impl::checkGemmInput<Trans::NoTranspose, Trans::NoTranspose>(A, B, C);
+    if (info) return info;
+
     // C = beta C + alpha A B
     // C (m x n), A(m x k), B(k x n)
-    return TeamGemmInternal<Algo::Gemm::Blocked>::invoke(member, C.extent(0), C.extent(1), A.extent(1), alpha, A.data(),
-                                                         A.stride_0(), A.stride_1(), B.data(), B.stride_0(),
-                                                         B.stride_1(), beta, C.data(), C.stride_0(), C.stride_1());
+    return Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
+        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(1), alpha,
+        A.data(), A.stride_0(), A.stride_1(), B.data(), B.stride_0(), B.stride_1(), beta, C.data(), C.stride_0(),
+        C.stride_1());
   }
 };
 
@@ -74,11 +85,19 @@ struct TeamGemm<MemberType, Trans::Transpose, Trans::NoTranspose, Algo::Gemm::Un
   template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B, const ScalarType beta, const CViewType &C) {
-    // C = beta C + alpha A B
-    // C (m x n), A(m x k), B(k x n)
-    return TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(member, C.extent(0), C.extent(1), A.extent(0), alpha,
-                                                           A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_0(),
-                                                           B.stride_1(), beta, C.data(), C.stride_0(), C.stride_1());
+    // Quick return if possible
+    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
+    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+    auto info = Impl::checkGemmInput<Trans::Transpose, Trans::NoTranspose>(A, B, C);
+    if (info) return info;
+
+    // C = beta C + alpha A^T B
+    // C (m x n), A(k x m), B(k x n)
+    return Impl::TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
+        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(0), alpha,
+        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_0(), B.stride_1(), beta, C.data(), C.stride_0(),
+        C.stride_1());
   }
 };
 
@@ -87,11 +106,65 @@ struct TeamGemm<MemberType, Trans::Transpose, Trans::NoTranspose, Algo::Gemm::Bl
   template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B, const ScalarType beta, const CViewType &C) {
-    // C = beta C + alpha A B
-    // C (m x n), A(m x k), B(k x n)
-    return TeamGemmInternal<Algo::Gemm::Blocked>::invoke(member, C.extent(0), C.extent(1), A.extent(0), alpha, A.data(),
-                                                         A.stride_1(), A.stride_0(), B.data(), B.stride_0(),
-                                                         B.stride_1(), beta, C.data(), C.stride_0(), C.stride_1());
+    // Quick return if possible
+    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
+    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+    auto info = Impl::checkGemmInput<Trans::Transpose, Trans::NoTranspose>(A, B, C);
+    if (info) return info;
+
+    // C = beta C + alpha A^T B
+    // C (m x n), A(k x m), B(k x n)
+    return Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
+        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(0), alpha,
+        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_0(), B.stride_1(), beta, C.data(), C.stride_0(),
+        C.stride_1());
+  }
+};
+
+///
+/// C/NT
+///
+
+template <typename MemberType>
+struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::NoTranspose, Algo::Gemm::Unblocked> {
+  template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
+                                           const BViewType &B, const ScalarType beta, const CViewType &C) {
+    // Quick return if possible
+    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
+    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+    auto info = Impl::checkGemmInput<Trans::ConjTranspose, Trans::NoTranspose>(A, B, C);
+    if (info) return info;
+
+    // C = beta C + alpha A^H B
+    // C (m x n), A(k x m), B(k x n)
+    return Impl::TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
+        member, KokkosBlas::Impl::OpConj(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(0), alpha,
+        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_0(), B.stride_1(), beta, C.data(), C.stride_0(),
+        C.stride_1());
+  }
+};
+
+template <typename MemberType>
+struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::NoTranspose, Algo::Gemm::Blocked> {
+  template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
+                                           const BViewType &B, const ScalarType beta, const CViewType &C) {
+    // Quick return if possible
+    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
+    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+    auto info = Impl::checkGemmInput<Trans::ConjTranspose, Trans::NoTranspose>(A, B, C);
+    if (info) return info;
+
+    // C = beta C + alpha A^H B
+    // C (m x n), A(k x m), B(k x n)
+    return Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
+        member, KokkosBlas::Impl::OpConj(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(0), alpha,
+        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_0(), B.stride_1(), beta, C.data(), C.stride_0(),
+        C.stride_1());
   }
 };
 
@@ -104,11 +177,19 @@ struct TeamGemm<MemberType, Trans::NoTranspose, Trans::Transpose, Algo::Gemm::Un
   template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B, const ScalarType beta, const CViewType &C) {
-    // C = beta C + alpha A B
-    // C (m x n), A(m x k), B(k x n)
-    return TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(member, C.extent(0), C.extent(1), A.extent(1), alpha,
-                                                           A.data(), A.stride_0(), A.stride_1(), B.data(), B.stride_1(),
-                                                           B.stride_0(), beta, C.data(), C.stride_0(), C.stride_1());
+    // Quick return if possible
+    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(1);
+    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+    auto info = Impl::checkGemmInput<Trans::NoTranspose, Trans::Transpose>(A, B, C);
+    if (info) return info;
+
+    // C = beta C + alpha A B^T
+    // C (m x n), A(m x k), B(n x k)
+    return Impl::TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
+        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(1), alpha,
+        A.data(), A.stride_0(), A.stride_1(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
+        C.stride_1());
   }
 };
 
@@ -117,11 +198,19 @@ struct TeamGemm<MemberType, Trans::NoTranspose, Trans::Transpose, Algo::Gemm::Bl
   template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B, const ScalarType beta, const CViewType &C) {
-    // C = beta C + alpha A B
-    // C (m x n), A(m x k), B(k x n)
-    return TeamGemmInternal<Algo::Gemm::Blocked>::invoke(member, C.extent(0), C.extent(1), A.extent(1), alpha, A.data(),
-                                                         A.stride_0(), A.stride_1(), B.data(), B.stride_1(),
-                                                         B.stride_0(), beta, C.data(), C.stride_0(), C.stride_1());
+    // Quick return if possible
+    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(1);
+    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+    auto info = Impl::checkGemmInput<Trans::NoTranspose, Trans::Transpose>(A, B, C);
+    if (info) return info;
+
+    // C = beta C + alpha A B^T
+    // C (m x n), A(m x k), B(n x k)
+    return Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
+        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(1), alpha,
+        A.data(), A.stride_0(), A.stride_1(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
+        C.stride_1());
   }
 };
 
@@ -134,11 +223,19 @@ struct TeamGemm<MemberType, Trans::Transpose, Trans::Transpose, Algo::Gemm::Unbl
   template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B, const ScalarType beta, const CViewType &C) {
-    // C = beta C + alpha A B
-    // C (m x n), A(m x k), B(k x n)
-    return TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(member, C.extent(0), C.extent(1), A.extent(0), alpha,
-                                                           A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_1(),
-                                                           B.stride_0(), beta, C.data(), C.stride_0(), C.stride_1());
+    // Quick return if possible
+    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
+    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+    auto info = Impl::checkGemmInput<Trans::Transpose, Trans::Transpose>(A, B, C);
+    if (info) return info;
+
+    // C = beta C + alpha A^T B^T
+    // C (m x n), A(k x m), B(n x k)
+    return Impl::TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
+        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(0), alpha,
+        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
+        C.stride_1());
   }
 };
 
@@ -147,11 +244,203 @@ struct TeamGemm<MemberType, Trans::Transpose, Trans::Transpose, Algo::Gemm::Bloc
   template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B, const ScalarType beta, const CViewType &C) {
-    // C = beta C + alpha A B
-    // C (m x n), A(m x k), B(k x n)
-    return TeamGemmInternal<Algo::Gemm::Blocked>::invoke(member, C.extent(0), C.extent(1), A.extent(0), alpha, A.data(),
-                                                         A.stride_1(), A.stride_0(), B.data(), B.stride_1(),
-                                                         B.stride_0(), beta, C.data(), C.stride_0(), C.stride_1());
+    // Quick return if possible
+    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
+    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+    auto info = Impl::checkGemmInput<Trans::Transpose, Trans::Transpose>(A, B, C);
+    if (info) return info;
+
+    // C = beta C + alpha A^T B^T
+    // C (m x n), A(k x m), B(n x k)
+    return Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
+        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(0), alpha,
+        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
+        C.stride_1());
+  }
+};
+
+///
+/// C/T
+///
+
+template <typename MemberType>
+struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::Transpose, Algo::Gemm::Unblocked> {
+  template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
+                                           const BViewType &B, const ScalarType beta, const CViewType &C) {
+    // Quick return if possible
+    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
+    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+    auto info = Impl::checkGemmInput<Trans::ConjTranspose, Trans::Transpose>(A, B, C);
+    if (info) return info;
+
+    // C = beta C + alpha A^H B^T
+    // C (m x n), A(k x m), B(n x k)
+    return Impl::TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
+        member, KokkosBlas::Impl::OpConj(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(0), alpha,
+        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
+        C.stride_1());
+  }
+};
+
+template <typename MemberType>
+struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::Transpose, Algo::Gemm::Blocked> {
+  template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
+                                           const BViewType &B, const ScalarType beta, const CViewType &C) {
+    // Quick return if possible
+    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
+    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+    auto info = Impl::checkGemmInput<Trans::ConjTranspose, Trans::Transpose>(A, B, C);
+    if (info) return info;
+
+    // C = beta C + alpha A^H B^T
+    // C (m x n), A(k x m), B(n x k)
+    return Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
+        member, KokkosBlas::Impl::OpConj(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(0), alpha,
+        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
+        C.stride_1());
+  }
+};
+
+///
+/// NT/C
+///
+
+template <typename MemberType>
+struct TeamGemm<MemberType, Trans::NoTranspose, Trans::ConjTranspose, Algo::Gemm::Unblocked> {
+  template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
+                                           const BViewType &B, const ScalarType beta, const CViewType &C) {
+    // Quick return if possible
+    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(1);
+    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+    auto info = Impl::checkGemmInput<Trans::NoTranspose, Trans::ConjTranspose>(A, B, C);
+    if (info) return info;
+
+    // C = beta C + alpha A B^H
+    // C (m x n), A(m x k), B(n x k)
+    return Impl::TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
+        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpConj(), C.extent(0), C.extent(1), A.extent(1), alpha,
+        A.data(), A.stride_0(), A.stride_1(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
+        C.stride_1());
+  }
+};
+
+template <typename MemberType>
+struct TeamGemm<MemberType, Trans::NoTranspose, Trans::ConjTranspose, Algo::Gemm::Blocked> {
+  template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
+                                           const BViewType &B, const ScalarType beta, const CViewType &C) {
+    // Quick return if possible
+    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(1);
+    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+    auto info = Impl::checkGemmInput<Trans::NoTranspose, Trans::ConjTranspose>(A, B, C);
+    if (info) return info;
+
+    // C = beta C + alpha A B^H
+    // C (m x n), A(m x k), B(n x k)
+    return Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
+        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpConj(), C.extent(0), C.extent(1), A.extent(1), alpha,
+        A.data(), A.stride_0(), A.stride_1(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
+        C.stride_1());
+  }
+};
+
+///
+/// T/C
+///
+
+template <typename MemberType>
+struct TeamGemm<MemberType, Trans::Transpose, Trans::ConjTranspose, Algo::Gemm::Unblocked> {
+  template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
+                                           const BViewType &B, const ScalarType beta, const CViewType &C) {
+    // Quick return if possible
+    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
+    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+    auto info = Impl::checkGemmInput<Trans::Transpose, Trans::ConjTranspose>(A, B, C);
+    if (info) return info;
+
+    // C = beta C + alpha A^T B^H
+    // C (m x n), A(k x m), B(n x k)
+    return Impl::TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
+        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpConj(), C.extent(0), C.extent(1), A.extent(0), alpha,
+        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
+        C.stride_1());
+  }
+};
+
+template <typename MemberType>
+struct TeamGemm<MemberType, Trans::Transpose, Trans::ConjTranspose, Algo::Gemm::Blocked> {
+  template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
+                                           const BViewType &B, const ScalarType beta, const CViewType &C) {
+    // Quick return if possible
+    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
+    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+    auto info = Impl::checkGemmInput<Trans::Transpose, Trans::Transpose>(A, B, C);
+    if (info) return info;
+
+    // C = beta C + alpha A^T B^H
+    // C (m x n), A(k x m), B(n x k)
+    return Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
+        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpConj(), C.extent(0), C.extent(1), A.extent(0), alpha,
+        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
+        C.stride_1());
+  }
+};
+
+///
+/// C/C
+///
+
+template <typename MemberType>
+struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::ConjTranspose, Algo::Gemm::Unblocked> {
+  template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
+                                           const BViewType &B, const ScalarType beta, const CViewType &C) {
+    // Quick return if possible
+    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
+    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+    auto info = Impl::checkGemmInput<Trans::ConjTranspose, Trans::ConjTranspose>(A, B, C);
+    if (info) return info;
+
+    // C = beta C + alpha A^H B^H
+    // C (m x n), A(k x m), B(n x k)
+    return Impl::TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
+        member, KokkosBlas::Impl::OpConj(), KokkosBlas::Impl::OpConj(), C.extent(0), C.extent(1), A.extent(0), alpha,
+        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
+        C.stride_1());
+  }
+};
+
+template <typename MemberType>
+struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::ConjTranspose, Algo::Gemm::Blocked> {
+  template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
+                                           const BViewType &B, const ScalarType beta, const CViewType &C) {
+    // Quick return if possible
+    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
+    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+    auto info = Impl::checkGemmInput<Trans::ConjTranspose, Trans::ConjTranspose>(A, B, C);
+    if (info) return info;
+
+    // C = beta C + alpha A^H B^H
+    // C (m x n), A(k x m), B(n x k)
+    return Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
+        member, KokkosBlas::Impl::OpConj(), KokkosBlas::Impl::OpConj(), C.extent(0), C.extent(1), A.extent(0), alpha,
+        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
+        C.stride_1());
   }
 };
 

--- a/batched/dense/impl/KokkosBatched_Gemm_Team_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemm_Team_Impl.hpp
@@ -34,13 +34,20 @@ namespace KokkosBatched {
 /// NT/NT
 ///
 
-template <typename MemberType>
-struct TeamGemm<MemberType, Trans::NoTranspose, Trans::NoTranspose, Algo::Gemm::Unblocked> {
+template <typename MemberType, typename ArgAlgo>
+struct TeamGemm<MemberType, Trans::NoTranspose, Trans::NoTranspose, ArgAlgo> {
   template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B, const ScalarType beta, const CViewType &C) {
+    const int A_extent_1 = Impl::get_extent_int(A, 1);
+    const int C_extent_0 = Impl::get_extent_int(C, 0), C_extent_1 = Impl::get_extent_int(C, 1);
+
+    const std::size_t A_stride_0 = Impl::get_stride(A, 0), A_stride_1 = Impl::get_stride(A, 1);
+    const std::size_t B_stride_0 = Impl::get_stride(B, 0), B_stride_1 = Impl::get_stride(B, 1);
+    const std::size_t C_stride_0 = Impl::get_stride(C, 0), C_stride_1 = Impl::get_stride(C, 1);
+
     // Quick return if possible
-    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(1);
+    const int m = C_extent_0, n = C_extent_1, k = A_extent_1;
     if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::NoTranspose, Trans::NoTranspose>(A, B, C);
@@ -48,31 +55,9 @@ struct TeamGemm<MemberType, Trans::NoTranspose, Trans::NoTranspose, Algo::Gemm::
 
     // C = beta C + alpha A B
     // C (m x n), A(m x k), B(k x n)
-    return Impl::TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
-        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(1), alpha,
-        A.data(), A.stride_0(), A.stride_1(), B.data(), B.stride_0(), B.stride_1(), beta, C.data(), C.stride_0(),
-        C.stride_1());
-  }
-};
-
-template <typename MemberType>
-struct TeamGemm<MemberType, Trans::NoTranspose, Trans::NoTranspose, Algo::Gemm::Blocked> {
-  template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
-                                           const BViewType &B, const ScalarType beta, const CViewType &C) {
-    // Quick return if possible
-    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(1);
-    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
-
-    auto info = Impl::checkGemmInput<Trans::NoTranspose, Trans::NoTranspose>(A, B, C);
-    if (info) return info;
-
-    // C = beta C + alpha A B
-    // C (m x n), A(m x k), B(k x n)
-    return Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
-        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(1), alpha,
-        A.data(), A.stride_0(), A.stride_1(), B.data(), B.stride_0(), B.stride_1(), beta, C.data(), C.stride_0(),
-        C.stride_1());
+    return Impl::TeamGemmInternal<ArgAlgo>::invoke(
+        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C_extent_0, C_extent_1, A_extent_1, alpha, A.data(),
+        A_stride_0, A_stride_1, B.data(), B_stride_0, B_stride_1, beta, C.data(), C_stride_0, C_stride_1);
   }
 };
 
@@ -80,13 +65,20 @@ struct TeamGemm<MemberType, Trans::NoTranspose, Trans::NoTranspose, Algo::Gemm::
 /// T/NT
 ///
 
-template <typename MemberType>
-struct TeamGemm<MemberType, Trans::Transpose, Trans::NoTranspose, Algo::Gemm::Unblocked> {
+template <typename MemberType, typename ArgAlgo>
+struct TeamGemm<MemberType, Trans::Transpose, Trans::NoTranspose, ArgAlgo> {
   template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B, const ScalarType beta, const CViewType &C) {
+    const int A_extent_0 = Impl::get_extent_int(A, 0);
+    const int C_extent_0 = Impl::get_extent_int(C, 0), C_extent_1 = Impl::get_extent_int(C, 1);
+
+    const std::size_t A_stride_0 = Impl::get_stride(A, 0), A_stride_1 = Impl::get_stride(A, 1);
+    const std::size_t B_stride_0 = Impl::get_stride(B, 0), B_stride_1 = Impl::get_stride(B, 1);
+    const std::size_t C_stride_0 = Impl::get_stride(C, 0), C_stride_1 = Impl::get_stride(C, 1);
+
     // Quick return if possible
-    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
+    const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
     if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::Transpose, Trans::NoTranspose>(A, B, C);
@@ -94,31 +86,9 @@ struct TeamGemm<MemberType, Trans::Transpose, Trans::NoTranspose, Algo::Gemm::Un
 
     // C = beta C + alpha A^T B
     // C (m x n), A(k x m), B(k x n)
-    return Impl::TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
-        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(0), alpha,
-        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_0(), B.stride_1(), beta, C.data(), C.stride_0(),
-        C.stride_1());
-  }
-};
-
-template <typename MemberType>
-struct TeamGemm<MemberType, Trans::Transpose, Trans::NoTranspose, Algo::Gemm::Blocked> {
-  template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
-                                           const BViewType &B, const ScalarType beta, const CViewType &C) {
-    // Quick return if possible
-    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
-    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
-
-    auto info = Impl::checkGemmInput<Trans::Transpose, Trans::NoTranspose>(A, B, C);
-    if (info) return info;
-
-    // C = beta C + alpha A^T B
-    // C (m x n), A(k x m), B(k x n)
-    return Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
-        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(0), alpha,
-        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_0(), B.stride_1(), beta, C.data(), C.stride_0(),
-        C.stride_1());
+    return Impl::TeamGemmInternal<ArgAlgo>::invoke(
+        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C_extent_0, C_extent_1, A_extent_0, alpha, A.data(),
+        A_stride_1, A_stride_0, B.data(), B_stride_0, B_stride_1, beta, C.data(), C_stride_0, C_stride_1);
   }
 };
 
@@ -126,13 +96,20 @@ struct TeamGemm<MemberType, Trans::Transpose, Trans::NoTranspose, Algo::Gemm::Bl
 /// C/NT
 ///
 
-template <typename MemberType>
-struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::NoTranspose, Algo::Gemm::Unblocked> {
+template <typename MemberType, typename ArgAlgo>
+struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::NoTranspose, ArgAlgo> {
   template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B, const ScalarType beta, const CViewType &C) {
+    const int A_extent_0 = Impl::get_extent_int(A, 0);
+    const int C_extent_0 = Impl::get_extent_int(C, 0), C_extent_1 = Impl::get_extent_int(C, 1);
+
+    const std::size_t A_stride_0 = Impl::get_stride(A, 0), A_stride_1 = Impl::get_stride(A, 1);
+    const std::size_t B_stride_0 = Impl::get_stride(B, 0), B_stride_1 = Impl::get_stride(B, 1);
+    const std::size_t C_stride_0 = Impl::get_stride(C, 0), C_stride_1 = Impl::get_stride(C, 1);
+
     // Quick return if possible
-    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
+    const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
     if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::ConjTranspose, Trans::NoTranspose>(A, B, C);
@@ -140,31 +117,9 @@ struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::NoTranspose, Algo::Gemm
 
     // C = beta C + alpha A^H B
     // C (m x n), A(k x m), B(k x n)
-    return Impl::TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
-        member, KokkosBlas::Impl::OpConj(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(0), alpha,
-        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_0(), B.stride_1(), beta, C.data(), C.stride_0(),
-        C.stride_1());
-  }
-};
-
-template <typename MemberType>
-struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::NoTranspose, Algo::Gemm::Blocked> {
-  template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
-                                           const BViewType &B, const ScalarType beta, const CViewType &C) {
-    // Quick return if possible
-    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
-    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
-
-    auto info = Impl::checkGemmInput<Trans::ConjTranspose, Trans::NoTranspose>(A, B, C);
-    if (info) return info;
-
-    // C = beta C + alpha A^H B
-    // C (m x n), A(k x m), B(k x n)
-    return Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
-        member, KokkosBlas::Impl::OpConj(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(0), alpha,
-        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_0(), B.stride_1(), beta, C.data(), C.stride_0(),
-        C.stride_1());
+    return Impl::TeamGemmInternal<ArgAlgo>::invoke(
+        member, KokkosBlas::Impl::OpConj(), KokkosBlas::Impl::OpID(), C_extent_0, C_extent_1, A_extent_0, alpha,
+        A.data(), A_stride_1, A_stride_0, B.data(), B_stride_0, B_stride_1, beta, C.data(), C_stride_0, C_stride_1);
   }
 };
 
@@ -172,13 +127,20 @@ struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::NoTranspose, Algo::Gemm
 /// NT/T
 ///
 
-template <typename MemberType>
-struct TeamGemm<MemberType, Trans::NoTranspose, Trans::Transpose, Algo::Gemm::Unblocked> {
+template <typename MemberType, typename ArgAlgo>
+struct TeamGemm<MemberType, Trans::NoTranspose, Trans::Transpose, ArgAlgo> {
   template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B, const ScalarType beta, const CViewType &C) {
+    const int A_extent_1 = Impl::get_extent_int(A, 1);
+    const int C_extent_0 = Impl::get_extent_int(C, 0), C_extent_1 = Impl::get_extent_int(C, 1);
+
+    const std::size_t A_stride_0 = Impl::get_stride(A, 0), A_stride_1 = Impl::get_stride(A, 1);
+    const std::size_t B_stride_0 = Impl::get_stride(B, 0), B_stride_1 = Impl::get_stride(B, 1);
+    const std::size_t C_stride_0 = Impl::get_stride(C, 0), C_stride_1 = Impl::get_stride(C, 1);
+
     // Quick return if possible
-    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(1);
+    const int m = C_extent_0, n = C_extent_1, k = A_extent_1;
     if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::NoTranspose, Trans::Transpose>(A, B, C);
@@ -186,31 +148,9 @@ struct TeamGemm<MemberType, Trans::NoTranspose, Trans::Transpose, Algo::Gemm::Un
 
     // C = beta C + alpha A B^T
     // C (m x n), A(m x k), B(n x k)
-    return Impl::TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
-        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(1), alpha,
-        A.data(), A.stride_0(), A.stride_1(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
-        C.stride_1());
-  }
-};
-
-template <typename MemberType>
-struct TeamGemm<MemberType, Trans::NoTranspose, Trans::Transpose, Algo::Gemm::Blocked> {
-  template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
-                                           const BViewType &B, const ScalarType beta, const CViewType &C) {
-    // Quick return if possible
-    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(1);
-    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
-
-    auto info = Impl::checkGemmInput<Trans::NoTranspose, Trans::Transpose>(A, B, C);
-    if (info) return info;
-
-    // C = beta C + alpha A B^T
-    // C (m x n), A(m x k), B(n x k)
-    return Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
-        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(1), alpha,
-        A.data(), A.stride_0(), A.stride_1(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
-        C.stride_1());
+    return Impl::TeamGemmInternal<ArgAlgo>::invoke(
+        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C_extent_0, C_extent_1, A_extent_1, alpha, A.data(),
+        A_stride_0, A_stride_1, B.data(), B_stride_1, B_stride_0, beta, C.data(), C_stride_0, C_stride_1);
   }
 };
 
@@ -218,13 +158,20 @@ struct TeamGemm<MemberType, Trans::NoTranspose, Trans::Transpose, Algo::Gemm::Bl
 /// T/T
 ///
 
-template <typename MemberType>
-struct TeamGemm<MemberType, Trans::Transpose, Trans::Transpose, Algo::Gemm::Unblocked> {
+template <typename MemberType, typename ArgAlgo>
+struct TeamGemm<MemberType, Trans::Transpose, Trans::Transpose, ArgAlgo> {
   template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B, const ScalarType beta, const CViewType &C) {
+    const int A_extent_0 = Impl::get_extent_int(A, 0);
+    const int C_extent_0 = Impl::get_extent_int(C, 0), C_extent_1 = Impl::get_extent_int(C, 1);
+
+    const std::size_t A_stride_0 = Impl::get_stride(A, 0), A_stride_1 = Impl::get_stride(A, 1);
+    const std::size_t B_stride_0 = Impl::get_stride(B, 0), B_stride_1 = Impl::get_stride(B, 1);
+    const std::size_t C_stride_0 = Impl::get_stride(C, 0), C_stride_1 = Impl::get_stride(C, 1);
+
     // Quick return if possible
-    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
+    const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
     if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::Transpose, Trans::Transpose>(A, B, C);
@@ -232,31 +179,9 @@ struct TeamGemm<MemberType, Trans::Transpose, Trans::Transpose, Algo::Gemm::Unbl
 
     // C = beta C + alpha A^T B^T
     // C (m x n), A(k x m), B(n x k)
-    return Impl::TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
-        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(0), alpha,
-        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
-        C.stride_1());
-  }
-};
-
-template <typename MemberType>
-struct TeamGemm<MemberType, Trans::Transpose, Trans::Transpose, Algo::Gemm::Blocked> {
-  template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
-                                           const BViewType &B, const ScalarType beta, const CViewType &C) {
-    // Quick return if possible
-    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
-    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
-
-    auto info = Impl::checkGemmInput<Trans::Transpose, Trans::Transpose>(A, B, C);
-    if (info) return info;
-
-    // C = beta C + alpha A^T B^T
-    // C (m x n), A(k x m), B(n x k)
-    return Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
-        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(0), alpha,
-        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
-        C.stride_1());
+    return Impl::TeamGemmInternal<ArgAlgo>::invoke(
+        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), C_extent_0, C_extent_1, A_extent_0, alpha, A.data(),
+        A_stride_1, A_stride_0, B.data(), B_stride_1, B_stride_0, beta, C.data(), C_stride_0, C_stride_1);
   }
 };
 
@@ -264,13 +189,20 @@ struct TeamGemm<MemberType, Trans::Transpose, Trans::Transpose, Algo::Gemm::Bloc
 /// C/T
 ///
 
-template <typename MemberType>
-struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::Transpose, Algo::Gemm::Unblocked> {
+template <typename MemberType, typename ArgAlgo>
+struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::Transpose, ArgAlgo> {
   template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B, const ScalarType beta, const CViewType &C) {
+    const int A_extent_0 = Impl::get_extent_int(A, 0);
+    const int C_extent_0 = Impl::get_extent_int(C, 0), C_extent_1 = Impl::get_extent_int(C, 1);
+
+    const std::size_t A_stride_0 = Impl::get_stride(A, 0), A_stride_1 = Impl::get_stride(A, 1);
+    const std::size_t B_stride_0 = Impl::get_stride(B, 0), B_stride_1 = Impl::get_stride(B, 1);
+    const std::size_t C_stride_0 = Impl::get_stride(C, 0), C_stride_1 = Impl::get_stride(C, 1);
+
     // Quick return if possible
-    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
+    const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
     if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::ConjTranspose, Trans::Transpose>(A, B, C);
@@ -278,31 +210,9 @@ struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::Transpose, Algo::Gemm::
 
     // C = beta C + alpha A^H B^T
     // C (m x n), A(k x m), B(n x k)
-    return Impl::TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
-        member, KokkosBlas::Impl::OpConj(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(0), alpha,
-        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
-        C.stride_1());
-  }
-};
-
-template <typename MemberType>
-struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::Transpose, Algo::Gemm::Blocked> {
-  template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
-                                           const BViewType &B, const ScalarType beta, const CViewType &C) {
-    // Quick return if possible
-    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
-    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
-
-    auto info = Impl::checkGemmInput<Trans::ConjTranspose, Trans::Transpose>(A, B, C);
-    if (info) return info;
-
-    // C = beta C + alpha A^H B^T
-    // C (m x n), A(k x m), B(n x k)
-    return Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
-        member, KokkosBlas::Impl::OpConj(), KokkosBlas::Impl::OpID(), C.extent(0), C.extent(1), A.extent(0), alpha,
-        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
-        C.stride_1());
+    return Impl::TeamGemmInternal<ArgAlgo>::invoke(
+        member, KokkosBlas::Impl::OpConj(), KokkosBlas::Impl::OpID(), C_extent_0, C_extent_1, A_extent_0, alpha,
+        A.data(), A_stride_1, A_stride_0, B.data(), B_stride_1, B_stride_0, beta, C.data(), C_stride_0, C_stride_1);
   }
 };
 
@@ -310,13 +220,20 @@ struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::Transpose, Algo::Gemm::
 /// NT/C
 ///
 
-template <typename MemberType>
-struct TeamGemm<MemberType, Trans::NoTranspose, Trans::ConjTranspose, Algo::Gemm::Unblocked> {
+template <typename MemberType, typename ArgAlgo>
+struct TeamGemm<MemberType, Trans::NoTranspose, Trans::ConjTranspose, ArgAlgo> {
   template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B, const ScalarType beta, const CViewType &C) {
+    const int A_extent_1 = Impl::get_extent_int(A, 1);
+    const int C_extent_0 = Impl::get_extent_int(C, 0), C_extent_1 = Impl::get_extent_int(C, 1);
+
+    const std::size_t A_stride_0 = Impl::get_stride(A, 0), A_stride_1 = Impl::get_stride(A, 1);
+    const std::size_t B_stride_0 = Impl::get_stride(B, 0), B_stride_1 = Impl::get_stride(B, 1);
+    const std::size_t C_stride_0 = Impl::get_stride(C, 0), C_stride_1 = Impl::get_stride(C, 1);
+
     // Quick return if possible
-    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(1);
+    const int m = C_extent_0, n = C_extent_1, k = A_extent_1;
     if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::NoTranspose, Trans::ConjTranspose>(A, B, C);
@@ -324,31 +241,9 @@ struct TeamGemm<MemberType, Trans::NoTranspose, Trans::ConjTranspose, Algo::Gemm
 
     // C = beta C + alpha A B^H
     // C (m x n), A(m x k), B(n x k)
-    return Impl::TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
-        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpConj(), C.extent(0), C.extent(1), A.extent(1), alpha,
-        A.data(), A.stride_0(), A.stride_1(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
-        C.stride_1());
-  }
-};
-
-template <typename MemberType>
-struct TeamGemm<MemberType, Trans::NoTranspose, Trans::ConjTranspose, Algo::Gemm::Blocked> {
-  template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
-                                           const BViewType &B, const ScalarType beta, const CViewType &C) {
-    // Quick return if possible
-    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(1);
-    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
-
-    auto info = Impl::checkGemmInput<Trans::NoTranspose, Trans::ConjTranspose>(A, B, C);
-    if (info) return info;
-
-    // C = beta C + alpha A B^H
-    // C (m x n), A(m x k), B(n x k)
-    return Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
-        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpConj(), C.extent(0), C.extent(1), A.extent(1), alpha,
-        A.data(), A.stride_0(), A.stride_1(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
-        C.stride_1());
+    return Impl::TeamGemmInternal<ArgAlgo>::invoke(
+        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpConj(), C_extent_0, C_extent_1, A_extent_1, alpha,
+        A.data(), A_stride_0, A_stride_1, B.data(), B_stride_1, B_stride_0, beta, C.data(), C_stride_0, C_stride_1);
   }
 };
 
@@ -356,13 +251,20 @@ struct TeamGemm<MemberType, Trans::NoTranspose, Trans::ConjTranspose, Algo::Gemm
 /// T/C
 ///
 
-template <typename MemberType>
-struct TeamGemm<MemberType, Trans::Transpose, Trans::ConjTranspose, Algo::Gemm::Unblocked> {
+template <typename MemberType, typename ArgAlgo>
+struct TeamGemm<MemberType, Trans::Transpose, Trans::ConjTranspose, ArgAlgo> {
   template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B, const ScalarType beta, const CViewType &C) {
+    const int A_extent_0 = Impl::get_extent_int(A, 0);
+    const int C_extent_0 = Impl::get_extent_int(C, 0), C_extent_1 = Impl::get_extent_int(C, 1);
+
+    const std::size_t A_stride_0 = Impl::get_stride(A, 0), A_stride_1 = Impl::get_stride(A, 1);
+    const std::size_t B_stride_0 = Impl::get_stride(B, 0), B_stride_1 = Impl::get_stride(B, 1);
+    const std::size_t C_stride_0 = Impl::get_stride(C, 0), C_stride_1 = Impl::get_stride(C, 1);
+
     // Quick return if possible
-    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
+    const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
     if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::Transpose, Trans::ConjTranspose>(A, B, C);
@@ -370,31 +272,9 @@ struct TeamGemm<MemberType, Trans::Transpose, Trans::ConjTranspose, Algo::Gemm::
 
     // C = beta C + alpha A^T B^H
     // C (m x n), A(k x m), B(n x k)
-    return Impl::TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
-        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpConj(), C.extent(0), C.extent(1), A.extent(0), alpha,
-        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
-        C.stride_1());
-  }
-};
-
-template <typename MemberType>
-struct TeamGemm<MemberType, Trans::Transpose, Trans::ConjTranspose, Algo::Gemm::Blocked> {
-  template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
-                                           const BViewType &B, const ScalarType beta, const CViewType &C) {
-    // Quick return if possible
-    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
-    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
-
-    auto info = Impl::checkGemmInput<Trans::Transpose, Trans::Transpose>(A, B, C);
-    if (info) return info;
-
-    // C = beta C + alpha A^T B^H
-    // C (m x n), A(k x m), B(n x k)
-    return Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
-        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpConj(), C.extent(0), C.extent(1), A.extent(0), alpha,
-        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
-        C.stride_1());
+    return Impl::TeamGemmInternal<ArgAlgo>::invoke(
+        member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpConj(), C_extent_0, C_extent_1, A_extent_0, alpha,
+        A.data(), A_stride_1, A_stride_0, B.data(), B_stride_1, B_stride_0, beta, C.data(), C_stride_0, C_stride_1);
   }
 };
 
@@ -402,13 +282,20 @@ struct TeamGemm<MemberType, Trans::Transpose, Trans::ConjTranspose, Algo::Gemm::
 /// C/C
 ///
 
-template <typename MemberType>
-struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::ConjTranspose, Algo::Gemm::Unblocked> {
+template <typename MemberType, typename ArgAlgo>
+struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::ConjTranspose, ArgAlgo> {
   template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B, const ScalarType beta, const CViewType &C) {
+    const int A_extent_0 = Impl::get_extent_int(A, 0);
+    const int C_extent_0 = Impl::get_extent_int(C, 0), C_extent_1 = Impl::get_extent_int(C, 1);
+
+    const std::size_t A_stride_0 = Impl::get_stride(A, 0), A_stride_1 = Impl::get_stride(A, 1);
+    const std::size_t B_stride_0 = Impl::get_stride(B, 0), B_stride_1 = Impl::get_stride(B, 1);
+    const std::size_t C_stride_0 = Impl::get_stride(C, 0), C_stride_1 = Impl::get_stride(C, 1);
+
     // Quick return if possible
-    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
+    const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
     if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::ConjTranspose, Trans::ConjTranspose>(A, B, C);
@@ -416,31 +303,9 @@ struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::ConjTranspose, Algo::Ge
 
     // C = beta C + alpha A^H B^H
     // C (m x n), A(k x m), B(n x k)
-    return Impl::TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
-        member, KokkosBlas::Impl::OpConj(), KokkosBlas::Impl::OpConj(), C.extent(0), C.extent(1), A.extent(0), alpha,
-        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
-        C.stride_1());
-  }
-};
-
-template <typename MemberType>
-struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::ConjTranspose, Algo::Gemm::Blocked> {
-  template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
-                                           const BViewType &B, const ScalarType beta, const CViewType &C) {
-    // Quick return if possible
-    const int m = C.extent_int(0), n = C.extent_int(1), k = A.extent_int(0);
-    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
-
-    auto info = Impl::checkGemmInput<Trans::ConjTranspose, Trans::ConjTranspose>(A, B, C);
-    if (info) return info;
-
-    // C = beta C + alpha A^H B^H
-    // C (m x n), A(k x m), B(n x k)
-    return Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
-        member, KokkosBlas::Impl::OpConj(), KokkosBlas::Impl::OpConj(), C.extent(0), C.extent(1), A.extent(0), alpha,
-        A.data(), A.stride_1(), A.stride_0(), B.data(), B.stride_1(), B.stride_0(), beta, C.data(), C.stride_0(),
-        C.stride_1());
+    return Impl::TeamGemmInternal<ArgAlgo>::invoke(
+        member, KokkosBlas::Impl::OpConj(), KokkosBlas::Impl::OpConj(), C_extent_0, C_extent_1, A_extent_0, alpha,
+        A.data(), A_stride_1, A_stride_0, B.data(), B_stride_1, B_stride_0, beta, C.data(), C_stride_0, C_stride_1);
   }
 };
 

--- a/batched/dense/impl/KokkosBatched_LU_Team_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_LU_Team_Internal.hpp
@@ -18,6 +18,7 @@
 
 /// \author Kyungjoo Kim (kyukim@sandia.gov)
 
+#include "KokkosBlas_util.hpp"
 #include "KokkosBatched_Util.hpp"
 #include "KokkosBatched_Vector.hpp"
 #include "KokkosBatched_InnerLU_Serial_Impl.hpp"
@@ -138,8 +139,9 @@ KOKKOS_INLINE_FUNCTION int TeamLU_Internal<Algo::LU::Blocked>::invoke(
       member.team_barrier();
 
       // gemm update
-      TeamGemmInternal<Algo::Gemm::Blocked>::invoke(member, m_abr, n_abr, pb, minus_one, Ap + mb * as0, as0, as1,
-                                                    Ap + mb * as1, as0, as1, one, Ap + mb * as0 + mb * as1, as0, as1);
+      KokkosBatched::Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
+          member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), m_abr, n_abr, pb, minus_one, Ap + mb * as0, as0,
+          as1, Ap + mb * as1, as0, as1, one, Ap + mb * as0 + mb * as1, as0, as1);
     }
   };
 

--- a/batched/dense/impl/KokkosBatched_Trsm_Team_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsm_Team_Internal.hpp
@@ -18,6 +18,7 @@
 
 /// \author Kyungjoo Kim (kyukim@sandia.gov)
 
+#include "KokkosBlas_util.hpp"
 #include "KokkosBatched_Util.hpp"
 #include "KokkosKernels_ExecSpaceUtils.hpp"
 
@@ -133,8 +134,9 @@ KOKKOS_INLINE_FUNCTION int TeamTrsmInternalLeftLower<Algo::Trsm::Blocked>::invok
         member.team_barrier();
 
         // gemm update
-        TeamGemmInternal<Algo::Gemm::Blocked>::invoke(member, ib - p - pb, jb, pb, minus_one, Ap + pb * as0, as0, as1,
-                                                      Bp, bs0, bs1, one, Bp + pb * bs0, bs0, bs1);
+        KokkosBatched::Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
+            member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), ib - p - pb, jb, pb, minus_one, Ap + pb * as0,
+            as0, as1, Bp, bs0, bs1, one, Bp + pb * bs0, bs0, bs1);
       }
     };
 
@@ -251,8 +253,9 @@ KOKKOS_INLINE_FUNCTION int TeamTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invok
         member.team_barrier();
 
         // gemm update
-        TeamGemmInternal<Algo::Gemm::Blocked>::invoke(member, p, jb, pb, minus_one, Ap - p * as0, as0, as1, Bp, bs0,
-                                                      bs1, one, BB, bs0, bs1);
+        KokkosBatched::Impl::TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
+            member, KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), p, jb, pb, minus_one, Ap - p * as0, as0, as1,
+            Bp, bs0, bs1, one, BB, bs0, bs1);
       }
     };
 

--- a/batched/dense/src/KokkosBatched_Gemm_Decl.hpp
+++ b/batched/dense/src/KokkosBatched_Gemm_Decl.hpp
@@ -19,23 +19,96 @@
 #include "KokkosBatched_Vector.hpp"
 
 namespace KokkosBatched {
-///
-/// Serial Gemm
-///
 
+/// \brief Serial Batched Gemm:
+///
+/// performs one of the matrix-matrix operations
+///   C := alpha*op( A )*op( B ) + beta*C,
+/// where op( X ) is one of
+///   op( X ) = X   or   op( X ) = X**T   or   op( X ) = X**H,
+///   alpha and beta are scalars, and A, B and C are matrices, with op( A ) an m by k matrix,
+///   op( B ) a k by n matrix and C an m by n matrix.
+///
+/// \tparam ArgTransA: Type indicating whether the A (Trans::NoTranspose), or A**T (Trans::Transpose) or A**H
+/// (Trans::ConjTranspose) is used.
+/// \tparam ArgTransB: Type indicating whether the B (Trans::NoTranspose), or B**T (Trans::Transpose) or B**H
+/// (Trans::ConjTranspose) is used.
+/// \tparam ArgAlgo: Type indicating the blocked (KokkosBatched::Algo::Gemm::Blocked) or unblocked
+/// (KokkosBatched::Algo::Gemm::Unblocked) algorithm to be used
 template <typename ArgTransA, typename ArgTransB, typename ArgAlgo>
 struct SerialGemm {
+  static_assert(KokkosBlas::is_trans_v<ArgTransA>, "KokkosBatched::SerialGemm: ArgTransA must be a KokkosBlas::Trans.");
+  static_assert(KokkosBlas::is_trans_v<ArgTransB>, "KokkosBatched::SerialGemm: ArgTransB must be a KokkosBlas::Trans.");
+#if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
+    defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
+  static_assert(std::is_same_v<ArgAlgo, Algo::Gemm::Unblocked> || std::is_same_v<ArgAlgo, Algo::Gemm::Blocked> ||
+                    std::is_same_v<ArgAlgo, Algo::Gemm::CompactMKL>,
+                "KokkosBatched::Gemm: Use Algo::Gemm::Unblocked or Algo::Gemm::Blocked or Algo::Gemm::CompactMKL");
+#else
+  static_assert(std::is_same_v<ArgAlgo, Algo::Gemm::Unblocked> || std::is_same_v<ArgAlgo, Algo::Gemm::Blocked>,
+                "KokkosBatched::Gemm: Use Algo::Gemm::Unblocked or Algo::Gemm::Blocked");
+#endif
+
+  /// \tparam ScalarType: Scalar type of alpha and beta
+  /// \tparam AViewType: Input type for the matrix A, needs to be a 0D-2D view
+  /// \tparam BViewType: Input type for the matrix B, needs to be a 0D-2D view
+  /// \tparam CViewType: Input/Output type for the matrix C, needs to be a 0D-2D view
+  ///
+  /// \param alpha [in]: Scalar alpha
+  /// \param A [in]: A is a dimension ( lda, ka ) matrix, where ka is k when ArgTransA = Trans::NoTranspose, and is m
+  /// otherwise.
+  /// \param B [in]: B is a dimension ( ldb, kb ) matrix, where kb is n when ArgTransB = Trans::NoTranspose, and is k
+  /// otherwise.
+  /// \param beta [in]: Scalar beta
+  /// \param C [inout]: C is a dimension ( ldc, n ) matrix. Before entry, the leading m by n part of the array C
+  /// must contain the matrix C, except when beta is zero, in which case C need not be set on entry. On exit, the array
+  /// C is overwritten by the m by n matrix ( alpha*op( A )*op( B ) + beta*C )
+  ///
+  /// No nested parallel_for is used inside of the function.
+  ///
   template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B,
                                            const ScalarType beta, const CViewType &C);
 };
 
+/// \brief Team Batched Gemm:
 ///
-/// Team Gemm
-///
-
+/// performs one of the matrix-matrix operations
+///   C := alpha*op( A )*op( B ) + beta*C,
+/// where op( X ) is one of
+///   op( X ) = X   or   op( X ) = X**T   or   op( X ) = X**H,
+///   alpha and beta are scalars, and A, B and C are matrices, with op( A ) an m by k matrix,
+///   op( B ) a k by n matrix and C an m by n matrix.
+/// \tparam MemberType: Member type of the Kokkos team policy
+/// \tparam ArgTransA: Type indicating whether the A (Trans::NoTranspose), or A**T (Trans::Transpose) or A**H
+/// (Trans::ConjTranspose) is used.
+/// \tparam ArgTransB: Type indicating whether the B (Trans::NoTranspose), or B**T (Trans::Transpose) or B**H
+/// (Trans::ConjTranspose) is used.
+/// \tparam ArgAlgo: Type indicating the blocked (KokkosBatched::Algo::Gemm::Blocked) or unblocked
+/// (KokkosBatched::Algo::Gemm::Unblocked) algorithm to be used
 template <typename MemberType, typename ArgTransA, typename ArgTransB, typename ArgAlgo>
 struct TeamGemm {
+  static_assert(KokkosBlas::is_trans_v<ArgTransA>, "KokkosBatched::TeamGemm: ArgTransA must be a KokkosBlas::Trans.");
+  static_assert(KokkosBlas::is_trans_v<ArgTransB>, "KokkosBatched::TeamGemm: ArgTransB must be a KokkosBlas::Trans.");
+  static_assert(std::is_same_v<ArgAlgo, Algo::Gemm::Unblocked> || std::is_same_v<ArgAlgo, Algo::Gemm::Blocked>,
+                "KokkosBatched::Gemm: Use Algo::Gemm::Unblocked or Algo::Gemm::Blocked");
+
+  /// \tparam ScalarType: Scalar type of alpha and beta
+  /// \tparam AViewType: Input type for the matrix A, needs to be a 0D-2D view
+  /// \tparam BViewType: Input type for the matrix B, needs to be a 0D-2D view
+  /// \tparam CViewType: Input/Output type for the matrix C, needs to be a 0D-2D view
+  ///
+  /// \param alpha [in]: Scalar alpha
+  /// \param A [in]: A is a dimension ( lda, ka ) matrix, where ka is k when ArgTransA = Trans::NoTranspose, and is m
+  /// otherwise.
+  /// \param B [in]: B is a dimension ( ldb, kb ) matrix, where kb is n when ArgTransB = Trans::NoTranspose, and is k
+  /// otherwise.
+  /// \param beta [in]: Scalar beta
+  /// \param C [inout]: C is a dimension ( ldc, n ) matrix. Before entry, the leading m by n part of the array C
+  /// must contain the matrix C, except when beta is zero, in which case C need not be set on entry. On exit, the array
+  /// C is overwritten by the m by n matrix ( alpha*op( A )*op( B ) + beta*C )
+  ///
+  /// Team thread parallelization is used inside of the function.
   template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B, const ScalarType beta, const CViewType &C);

--- a/batched/dense/unit_test/Test_Batched_TeamGemm.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamGemm.hpp
@@ -94,6 +94,7 @@ struct Functor_TestBatchedTeamGemm {
 /// \tparam BViewType View type for matrix B
 /// \tparam CViewType View type for matrix C
 /// \tparam ErrorBoundViewType [out] View type for the error bound
+/// \tparam ScalarType Type for scalar alpha and beta
 
 /// \param A [in] Input matrix A
 /// \param B [in] Input matrix B
@@ -103,9 +104,9 @@ struct Functor_TestBatchedTeamGemm {
 /// \param beta [in] Scalar multiplier for matrix C
 /// \param eps [in] Machine precision
 template <typename ArgTransA, typename ArgTransB, typename AViewType, typename BViewType, typename CViewType,
-          typename ErrorBoundViewType>
+          typename ErrorBoundViewType, typename ScalarType>
 void gemm_error_bound(const AViewType &A, const BViewType &B, const CViewType &C, const ErrorBoundViewType &error_bound,
-                      double alpha, double beta, double eps) {
+                      ScalarType alpha, ScalarType beta, double eps) {
   using value_type = typename AViewType::non_const_value_type;
   using ats        = Kokkos::ArithTraits<value_type>;
   using mag_type   = typename ats::mag_type;
@@ -173,6 +174,7 @@ void impl_test_batched_teamgemm(const int N, const int matAdim1, const int matAd
   using ViewType        = Kokkos::View<ValueType ***, LayoutType, DeviceType>;
   using FP64Type     = std::conditional_t<Kokkos::ArithTraits<ValueType>::is_complex, Kokkos::complex<double>, double>;
   using ViewFP64Type = Kokkos::View<FP64Type ***, LayoutType, DeviceType>;
+  using ErrorViewFP64Type = Kokkos::View<double ***, LayoutType, DeviceType>;
 
   /// randomized input testing views
   ScalarType alpha = ScalarType(1.5), beta = ScalarType(3.0);
@@ -180,7 +182,8 @@ void impl_test_batched_teamgemm(const int N, const int matAdim1, const int matAd
 
   ViewType A("A", N, matAdim1, matAdim2), B("B", N, matBdim1, matBdim2), C("C", N, matCdim1, matCdim2);
   ViewFP64Type A_fp64("A_fp64", N, matAdim1, matAdim2), B_fp64("B_fp64", N, matBdim1, matBdim2),
-      C_fp64("C_fp64", N, matCdim1, matCdim2), ErrorBound("ErrorBound", N, matCdim1, matCdim2);
+      C_fp64("C_fp64", N, matCdim1, matCdim2);
+  ErrorViewFP64Type ErrorBound("ErrorBound", N, matCdim1, matCdim2);
 
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 

--- a/batched/dense/unit_test/Test_Batched_TeamGemm.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamGemm.hpp
@@ -14,215 +14,292 @@
 //
 //@HEADER
 /// \author Kyungjoo Kim (kyukim@sandia.gov)
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
 
 #include "gtest/gtest.h"
 #include "Kokkos_Core.hpp"
 #include "Kokkos_Random.hpp"
-
-// #include "KokkosBatched_Vector.hpp"
-
 #include "KokkosBatched_Gemm_Decl.hpp"
 #include "KokkosBatched_Gemm_Serial_Impl.hpp"
 #include "KokkosBatched_Gemm_Team_Impl.hpp"
 
 #include "KokkosKernels_TestUtils.hpp"
 
-using namespace KokkosBatched;
-
 namespace Test {
 namespace TeamGemm {
 
 template <typename TA, typename TB>
 struct ParamTag {
-  typedef TA transA;
-  typedef TB transB;
+  using transA = TA;
+  using transB = TB;
 };
 
 template <typename DeviceType, typename ViewType, typename ScalarType, typename ParamTagType, typename AlgoTagType>
 struct Functor_TestBatchedTeamGemm {
   using execution_space = typename DeviceType::execution_space;
-  ViewType _a, _b, _c;
-
-  ScalarType _alpha, _beta;
+  ViewType m_a, m_b, m_c;
+  ScalarType m_alpha, m_beta;
 
   KOKKOS_INLINE_FUNCTION
   Functor_TestBatchedTeamGemm(const ScalarType alpha, const ViewType &a, const ViewType &b, const ScalarType beta,
                               const ViewType &c)
-      : _a(a), _b(b), _c(c), _alpha(alpha), _beta(beta) {}
+      : m_a(a), m_b(b), m_c(c), m_alpha(alpha), m_beta(beta) {}
 
   template <typename MemberType>
   KOKKOS_INLINE_FUNCTION void operator()(const ParamTagType &, const MemberType &member) const {
     const int k = member.league_rank();
 
-    auto aa = Kokkos::subview(_a, k, Kokkos::ALL(), Kokkos::ALL());
-    auto bb = Kokkos::subview(_b, k, Kokkos::ALL(), Kokkos::ALL());
-    auto cc = Kokkos::subview(_c, k, Kokkos::ALL(), Kokkos::ALL());
+    auto aa = Kokkos::subview(m_a, k, Kokkos::ALL(), Kokkos::ALL());
+    auto bb = Kokkos::subview(m_b, k, Kokkos::ALL(), Kokkos::ALL());
+    auto cc = Kokkos::subview(m_c, k, Kokkos::ALL(), Kokkos::ALL());
 
     KokkosBatched::TeamGemm<MemberType, typename ParamTagType::transA, typename ParamTagType::transB,
-                            AlgoTagType>::invoke(member, _alpha, aa, bb, _beta, cc);
+                            AlgoTagType>::invoke(member, m_alpha, aa, bb, m_beta, cc);
   }
 
   inline void run() {
-    typedef typename ViewType::value_type value_type;
+    using value_type = typename ViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::TeamGemm");
     const std::string name_value_type = Test::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
-    const int league_size = _c.extent(0);
+    const int league_size = m_c.extent(0);
     Kokkos::TeamPolicy<execution_space, ParamTagType> policy(league_size, Kokkos::AUTO);
     Kokkos::parallel_for(name.c_str(), policy, *this);
     Kokkos::Profiling::popRegion();
   }
 };
 
-template <typename DeviceType, typename ViewType, typename ScalarType, typename ParamTagType, typename AlgoTagType>
+/// \brief Compute the error bound for the GEMM operation
+/// C = alpha * op(A) * op(B) + beta * C
+/// The error bound with machine precison eps is computed as follows:
+/// 1. Error analysis of Matrix Multiplication D = op(A) * op(B)
+///    delta [D (i, j)] <= gamma_k * E (i, j)
+///    where E (i, j) = \sum_{k=1}^{ka} (A' (i, k) * B' (k, j)),
+///    A' = op(A), B' = op(B), gamma_k = ka * eps / (1 - ka * eps)
+/// 2. Error from Scaling by alpha
+///    delta [alpha * D (i, j)] <= gamma_k * |alpha| * E (i, j) + eps * |alpha * D (i, j)|
+/// 3. Error from Scaling by beta
+///    delta [beta * C (i, j)] <= eps * |beta * C (i, j)|
+/// 4. Error from the addition operation
+///    delta [beta * C (i, j) + alpha * D (i, j)]
+///    <= eps * |beta * C (i, j) + alpha * D (i, j)|
+///    <= eps * (|beta * C (i, j)| + |alpha * D (i, j)|)
+/// 5. Final error bound
+///    delta [C (i, j)] <= gamma_k * |alpha| * E (i, j) + 2 * eps * (|beta * C (i, j)| + |alpha * D (i, j)|)
+///
+/// \tparam ArgTransA Transpose option for matrix A
+/// \tparam ArgTransB Transpose option for matrix B
+/// \tparam AViewType View type for matrix A
+/// \tparam BViewType View type for matrix B
+/// \tparam CViewType View type for matrix C
+/// \tparam ErrorBoundViewType [out] View type for the error bound
+
+/// \param A [in] Input matrix A
+/// \param B [in] Input matrix B
+/// \param C [in] Input matrix C
+/// \param error_bound [out] Output matrix for the error bound
+/// \param alpha [in] Scalar multiplier for matrix A
+/// \param beta [in] Scalar multiplier for matrix C
+/// \param eps [in] Machine precision
+template <typename ArgTransA, typename ArgTransB, typename AViewType, typename BViewType, typename CViewType,
+          typename ErrorBoundViewType>
+void gemm_error_bound(const AViewType &A, const BViewType &B, const CViewType &C, const ErrorBoundViewType &error_bound,
+                      double alpha, double beta, double eps) {
+  using value_type = typename AViewType::non_const_value_type;
+  using ats        = Kokkos::ArithTraits<value_type>;
+  using mag_type   = typename ats::mag_type;
+  const int nb     = C.extent_int(0);
+  const int m      = C.extent_int(1);
+  const int n      = C.extent_int(2);
+  const int ka     = std::is_same_v<ArgTransA, Trans::NoTranspose> ? A.extent(2) : A.extent(1);
+
+  auto h_A           = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A);
+  auto h_B           = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), B);
+  auto h_C           = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), C);
+  auto h_error_bound = Kokkos::create_mirror_view(error_bound);
+
+  for (int ib = 0; ib < nb; ib++) {
+    for (int i = 0; i < m; i++) {
+      for (int j = 0; j < n; j++) {
+        mag_type sum = 0;
+        if (std::is_same_v<ArgTransA, Trans::NoTranspose>) {
+          if (std::is_same_v<ArgTransB, Trans::NoTranspose>) {
+            for (int ii = 0; ii < A.extent_int(2); ii++) {
+              sum += ats::abs(alpha * h_A(ib, i, ii) * h_B(ib, ii, j));
+            }
+          } else {
+            for (int ii = 0; ii < A.extent_int(2); ii++) {
+              sum += ats::abs(alpha * h_A(ib, i, ii) * h_B(ib, j, ii));
+            }
+          }
+        } else {
+          if (std::is_same_v<ArgTransB, Trans::NoTranspose>) {
+            for (int ii = 0; ii < A.extent_int(1); ii++) {
+              sum += ats::abs(alpha * h_A(ib, ii, i) * h_B(ib, ii, j));
+            }
+          } else {
+            for (int ii = 0; ii < A.extent_int(1); ii++) {
+              sum += ats::abs(alpha * h_A(ib, ii, i) * h_B(ib, j, ii));
+            }
+          }
+        }
+        mag_type gamma_k        = static_cast<mag_type>(ka) * eps / (1.0 - static_cast<mag_type>(ka) * eps);
+        h_error_bound(ib, i, j) = gamma_k * ats::abs(alpha) * ats::abs(sum) +
+                                  2 * eps * (ats::abs(beta * h_C(ib, i, j)) + ats::abs(alpha * sum));
+      }
+    }
+  }
+  Kokkos::deep_copy(error_bound, h_error_bound);
+}
+
+/// \brief Implementation details of batched team gemm test
+/// \param N [in] Batch size of matrices
+/// \param matAdim1 [in] Number of rows of matrix A
+/// \param matAdim2 [in] Number of columns of matrix A
+/// \param matBdim1 [in] Number of rows of matrix B
+/// \param matBdim2 [in] Number of columns of matrix B
+/// \param matCdim1 [in] Number of rows of matrix C
+/// \param matCdim2 [in] Number of columns of matrix C
+template <typename DeviceType, typename ValueType, typename ScalarType, typename LayoutType, typename ParamTagType,
+          typename AlgoTagType>
 void impl_test_batched_teamgemm(const int N, const int matAdim1, const int matAdim2, const int matBdim1,
                                 const int matBdim2, const int matCdim1, const int matCdim2) {
+  using execution_space = typename DeviceType::execution_space;
   using transA          = typename ParamTagType::transA;
   using transB          = typename ParamTagType::transB;
   using execution_space = typename DeviceType::execution_space;
-  using value_type      = typename ViewType::value_type;
-  using ats             = Kokkos::ArithTraits<value_type>;
+  using ats             = Kokkos::ArithTraits<ValueType>;
+  using ViewType        = Kokkos::View<ValueType ***, LayoutType, DeviceType>;
+  using FP64Type     = std::conditional_t<Kokkos::ArithTraits<ValueType>::is_complex, Kokkos::complex<double>, double>;
+  using ViewFP64Type = Kokkos::View<FP64Type ***, LayoutType, DeviceType>;
 
   /// randomized input testing views
   ScalarType alpha = ScalarType(1.5), beta = ScalarType(3.0);
+  FP64Type alpha_fp64 = FP64Type(1.5), beta_fp64 = FP64Type(3.0);
 
-  ViewType a_expected("a_expected", N, matAdim1, matAdim2), a_actual("a_actual", N, matAdim1, matAdim2),
-      b_expected("b_expected", N, matBdim1, matBdim2), b_actual("b_actual", N, matBdim1, matBdim2),
-      c_expected("c_expected", N, matCdim1, matCdim2), c_actual("c_actual", N, matCdim1, matCdim2);
+  ViewType A("A", N, matAdim1, matAdim2), B("B", N, matBdim1, matBdim2), C("C", N, matCdim1, matCdim2);
+  ViewFP64Type A_fp64("A_fp64", N, matAdim1, matAdim2), B_fp64("B_fp64", N, matBdim1, matBdim2),
+      C_fp64("C_fp64", N, matCdim1, matCdim2), ErrorBound("ErrorBound", N, matCdim1, matCdim2);
 
-  Kokkos::Random_XorShift64_Pool<typename DeviceType::execution_space> random(13718);
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
-  Kokkos::fill_random(a_expected, random, value_type(1.0));
-  Kokkos::fill_random(b_expected, random, value_type(1.0));
-  Kokkos::fill_random(c_expected, random, value_type(1.0));
+  // Data in given precision
+  ScalarType randStart, randEnd;
+  KokkosKernels::Impl::getRandomBounds(1.0, randStart, randEnd);
+  Kokkos::fill_random(A, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(B, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(C, rand_pool, randStart, randEnd);
 
-  Kokkos::fence();
+  Kokkos::deep_copy(A_fp64, A);
+  Kokkos::deep_copy(B_fp64, B);
+  Kokkos::deep_copy(C_fp64, C);
 
-  Kokkos::deep_copy(a_actual, a_expected);
-  Kokkos::deep_copy(b_actual, b_expected);
-  Kokkos::deep_copy(c_actual, c_expected);
+  Functor_BatchedVanillaGEMM<ViewFP64Type, ViewFP64Type, ViewFP64Type, execution_space> vgemm;
+  vgemm.A_t   = !std::is_same<transA, KokkosBatched::Trans::NoTranspose>::value;
+  vgemm.B_t   = !std::is_same<transB, KokkosBatched::Trans::NoTranspose>::value;
+  vgemm.A_c   = std::is_same_v<transA, KokkosBatched::Trans::ConjTranspose>;
+  vgemm.B_c   = std::is_same_v<transB, KokkosBatched::Trans::ConjTranspose>;
+  vgemm.A     = A_fp64;
+  vgemm.B     = B_fp64;
+  vgemm.C     = C_fp64;
+  vgemm.alpha = alpha_fp64;
+  vgemm.beta  = beta_fp64;
+  vgemm.run();  // Compute C_fp64 (reference)
 
-  Functor_BatchedVanillaGEMM<ViewType, ViewType, ViewType, execution_space> vgemm;
-  vgemm.A_t = std::is_same<transA, Trans::Transpose>::value;
-  vgemm.B_t = std::is_same<transB, Trans::Transpose>::value;
-  vgemm.A_c = vgemm.B_c = false;
-  vgemm.A               = a_expected;
-  vgemm.B               = b_expected;
-  vgemm.C               = c_expected;
-  vgemm.alpha           = alpha;
-  vgemm.beta            = beta;
-  vgemm.run();  // Compute c_expected
+  // Compute using gemm API in given precision
+  Functor_TestBatchedTeamGemm<DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(alpha, A, B, beta, C).run();
 
-  Functor_TestBatchedTeamGemm<DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(alpha, a_actual, b_actual,
-                                                                                           beta, c_actual)
-      .run();
+  // Machine precision for the value type
+  double eps = static_cast<double>(ats::epsilon());
+  gemm_error_bound<transA, transB>(A_fp64, B_fp64, C_fp64, ErrorBound, alpha_fp64, beta_fp64, eps);
 
-  Kokkos::fence();
-
-  typename ViewType::HostMirror c_expected_host = Kokkos::create_mirror_view(c_expected);
-  typename ViewType::HostMirror c_actual_host   = Kokkos::create_mirror_view(c_actual);
-
-  // Copy to host for comparision
-  Kokkos::deep_copy(c_expected_host, c_expected);
-  Kokkos::deep_copy(c_actual_host, c_actual);
-
-  using mag_type = typename ats::mag_type;
-  mag_type sum(1), diff(0);
-  mag_type eps = ats::epsilon();
-
-  eps *= std::is_same<value_type, Kokkos::Experimental::half_t>::value ||
-                 std::is_same<value_type, Kokkos::Experimental::bhalf_t>::value
-             ? 4
-             : 1e3;
-
-  for (int k = 0; k < N; ++k)
-    for (int i = 0; i < matCdim1; ++i)
+  auto h_C          = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), C);
+  auto h_C_fp64     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), C_fp64);
+  auto h_ErrorBound = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), ErrorBound);
+  for (int k = 0; k < N; ++k) {
+    for (int i = 0; i < matCdim1; ++i) {
       for (int j = 0; j < matCdim2; ++j) {
-        sum += ats::abs(c_expected_host(k, i, j));
-        diff += ats::abs(c_expected_host(k, i, j) - c_actual_host(k, i, j));
+        double actual_err  = Kokkos::abs(h_C(k, i, j) - h_C_fp64(k, i, j));
+        double error_bound = h_ErrorBound(k, i, j);
+        EXPECT_NEAR_KK(actual_err, 0, error_bound);
       }
-  EXPECT_NEAR_KK(diff / sum, 0, eps);
+    }
+  }
 }
 }  // namespace TeamGemm
 }  // namespace Test
 
-// void (*impl_test)(const int, const int, const int, const int, const int,
-// const int, const int)
 template <typename DeviceType, typename ValueType, typename ScalarType, typename ParamTagType, typename AlgoTagType>
 int test_batched_teamgemm() {
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
   {
-    typedef Kokkos::View<ValueType ***, Kokkos::LayoutLeft, DeviceType> ViewType;
-    Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
-        0, 10, 10, 10, 10, 10, 10);
+    using LayoutType = Kokkos::LayoutLeft;
+    Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
+                                               AlgoTagType>(0, 10, 10, 10, 10, 10, 10);
     for (int i = 0; i < 10; ++i) {
-      // printf("Testing: LayoutLeft,  Blksize %d\n", i);
-      Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
-          1024, i, i, i, i, i, i);
+      Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
+                                                 AlgoTagType>(1024, i, i, i, i, i, i);
     }
     for (int i = 0; i < 10; ++i) {
-      // printf("Testing: LayoutLeft,  Blksize %d\n", i);
       int dimM = i;
       int dimN = 2 * i;
       int dimK = 3 * i;
-      if ((std::is_same<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>::value) &&
-          (std::is_same<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>::value)) {
-        Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
-            1024, dimM, dimK, dimK, dimN, dimM, dimN);
+      if ((std::is_same_v<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>)&&(
+              std::is_same_v<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>)) {
+        Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
+                                                   AlgoTagType>(1024, dimM, dimK, dimK, dimN, dimM, dimN);
       }
-      if ((std::is_same<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>::value) &&
-          (std::is_same<typename ParamTagType::transB, KokkosBatched::Trans::Transpose>::value)) {
-        Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
-            1024, dimM, dimK, dimN, dimK, dimM, dimN);
+      if ((std::is_same_v<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>)&&(
+              !std::is_same_v<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>)) {
+        Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
+                                                   AlgoTagType>(1024, dimM, dimK, dimN, dimK, dimM, dimN);
       }
-      if ((std::is_same<typename ParamTagType::transA, KokkosBatched::Trans::Transpose>::value) &&
-          (std::is_same<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>::value)) {
-        Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
-            1024, dimK, dimM, dimK, dimN, dimM, dimN);
+      if ((!std::is_same_v<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>)&&(
+              std::is_same_v<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>)) {
+        Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
+                                                   AlgoTagType>(1024, dimK, dimM, dimK, dimN, dimM, dimN);
       }
-      if ((std::is_same<typename ParamTagType::transA, KokkosBatched::Trans::Transpose>::value) &&
-          (std::is_same<typename ParamTagType::transB, KokkosBatched::Trans::Transpose>::value)) {
-        Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
-            1024, dimK, dimM, dimN, dimK, dimM, dimN);
+      if ((!std::is_same_v<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>)&&(
+              !std::is_same_v<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>)) {
+        Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
+                                                   AlgoTagType>(1024, dimK, dimM, dimN, dimK, dimM, dimN);
       }
     }
   }
 #endif
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
   {
-    typedef Kokkos::View<ValueType ***, Kokkos::LayoutRight, DeviceType> ViewType;
-    Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
-        0, 10, 10, 10, 10, 10, 10);
+    using LayoutType = Kokkos::LayoutRight;
+    Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
+                                               AlgoTagType>(0, 10, 10, 10, 10, 10, 10);
     for (int i = 0; i < 10; ++i) {
-      // printf("Testing: LayoutRight, Blksize %d\n", i);
-      Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
-          1024, i, i, i, i, i, i);
+      Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
+                                                 AlgoTagType>(1024, i, i, i, i, i, i);
     }
     for (int i = 0; i < 10; ++i) {
-      // printf("Testing: LayoutLeft,  Blksize %d\n", i);
       int dimM = i;
       int dimN = 2 * i;
       int dimK = 3 * i;
-      if ((std::is_same<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>::value) &&
-          (std::is_same<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>::value)) {
-        Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
-            1024, dimM, dimK, dimK, dimN, dimM, dimN);
+      if ((std::is_same_v<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>)&&(
+              std::is_same_v<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>)) {
+        Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
+                                                   AlgoTagType>(1024, dimM, dimK, dimK, dimN, dimM, dimN);
       }
-      if ((std::is_same<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>::value) &&
-          (std::is_same<typename ParamTagType::transB, KokkosBatched::Trans::Transpose>::value)) {
-        Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
-            1024, dimM, dimK, dimN, dimK, dimM, dimN);
+      if ((std::is_same_v<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>)&&(
+              !std::is_same_v<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>)) {
+        Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
+                                                   AlgoTagType>(1024, dimM, dimK, dimN, dimK, dimM, dimN);
       }
-      if ((std::is_same<typename ParamTagType::transA, KokkosBatched::Trans::Transpose>::value) &&
-          (std::is_same<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>::value)) {
-        Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
-            1024, dimK, dimM, dimK, dimN, dimM, dimN);
+      if ((!std::is_same_v<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>)&&(
+              std::is_same_v<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>)) {
+        Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
+                                                   AlgoTagType>(1024, dimK, dimM, dimK, dimN, dimM, dimN);
       }
-      if ((std::is_same<typename ParamTagType::transA, KokkosBatched::Trans::Transpose>::value) &&
-          (std::is_same<typename ParamTagType::transB, KokkosBatched::Trans::Transpose>::value)) {
-        Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ViewType, ScalarType, ParamTagType, AlgoTagType>(
-            1024, dimK, dimM, dimN, dimK, dimM, dimN);
+      if ((!std::is_same_v<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>)&&(
+              !std::is_same_v<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>)) {
+        Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
+                                                   AlgoTagType>(1024, dimK, dimM, dimN, dimK, dimM, dimN);
       }
     }
   }

--- a/batched/dense/unit_test/Test_Batched_TeamGemm_Complex.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamGemm_Complex.hpp
@@ -13,73 +13,296 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //@HEADER
+#if defined(KOKKOSKERNELS_INST_COMPLEX_FLOAT)
+
+/// fcomplex, fcomplex
+
+TEST_F(TestCategory, batched_scalar_team_gemm_nt_nt_fcomplex_fcomplex) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_t_nt_fcomplex_fcomplex) {
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::NoTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_c_nt_fcomplex_fcomplex) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::ConjTranspose, KokkosBatched::Trans::NoTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_nt_t_fcomplex_fcomplex) {
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::Transpose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_t_t_fcomplex_fcomplex) {
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::Transpose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_c_t_fcomplex_fcomplex) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::ConjTranspose, KokkosBatched::Trans::Transpose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_nt_c_fcomplex_fcomplex) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::ConjTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_t_c_fcomplex_fcomplex) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::ConjTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_c_c_fcomplex_fcomplex) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::ConjTranspose, KokkosBatched::Trans::ConjTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+
+/// fcomplex, float
+TEST_F(TestCategory, batched_scalar_team_gemm_nt_nt_fcomplex_float) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, float, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, float, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_t_nt_fcomplex_float) {
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::NoTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, float, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, float, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_c_nt_fcomplex_float) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::ConjTranspose, KokkosBatched::Trans::NoTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, float, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, float, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_nt_t_fcomplex_float) {
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::Transpose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, float, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, float, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_t_t_fcomplex_float) {
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::Transpose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, float, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, float, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_c_t_fcomplex_float) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::ConjTranspose, KokkosBatched::Trans::Transpose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, float, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, float, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_nt_c_fcomplex_float) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::ConjTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, float, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, float, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_t_c_fcomplex_float) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::ConjTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, float, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, float, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_c_c_fcomplex_float) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::ConjTranspose, KokkosBatched::Trans::ConjTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, float, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<float>, float, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+
+#endif
 
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
 
 /// dcomplex, dcomplex
 
 TEST_F(TestCategory, batched_scalar_team_gemm_nt_nt_dcomplex_dcomplex) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::NoTranspose, Trans::NoTranspose> param_tag_type;
-  typedef Algo::Gemm::Blocked algo_tag_type;
-  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_t_nt_dcomplex_dcomplex) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::Transpose, Trans::NoTranspose> param_tag_type;
-  typedef Algo::Gemm::Blocked algo_tag_type;
-  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::NoTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_c_nt_dcomplex_dcomplex) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::ConjTranspose, KokkosBatched::Trans::NoTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_nt_t_dcomplex_dcomplex) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::NoTranspose, Trans::Transpose> param_tag_type;
-  typedef Algo::Gemm::Blocked algo_tag_type;
-  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::Transpose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_t_t_dcomplex_dcomplex) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::Transpose, Trans::Transpose> param_tag_type;
-  typedef Algo::Gemm::Blocked algo_tag_type;
-  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type, algo_tag_type>();
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::Transpose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
 }
-// TEST_F( TestCategory, batched_scalar_team_gemm_ct_nt_dcomplex_dcomplex ) {
-//   typedef ::Test::TeamGemm::ParamTag<Trans::ConjTranspose,Trans::NoTranspose>
-//   param_tag_type; typedef Algo::Gemm::Blocked algo_tag_type;
-//   test_batched_teamgemm<TestDevice,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
-// }
-// TEST_F( TestCategory, batched_scalar_team_gemm_nt_ct_dcomplex_dcomplex ) {
-//   typedef ::Test::TeamGemm::ParamTag<Trans::NoTranspose,Trans::ConjTranspose>
-//   param_tag_type; typedef Algo::Gemm::Blocked algo_tag_type;
-//   test_batched_teamgemm<TestDevice,Kokkos::complex<double>,Kokkos::complex<double>,param_tag_type,algo_tag_type>();
-// }
+TEST_F(TestCategory, batched_scalar_team_gemm_c_t_dcomplex_dcomplex) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::ConjTranspose, KokkosBatched::Trans::Transpose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_nt_c_dcomplex_dcomplex) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::ConjTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_t_c_dcomplex_dcomplex) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::ConjTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_c_c_dcomplex_dcomplex) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::ConjTranspose, KokkosBatched::Trans::ConjTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
 
 /// dcomplex, double
-
 TEST_F(TestCategory, batched_scalar_team_gemm_nt_nt_dcomplex_double) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::NoTranspose, Trans::NoTranspose> param_tag_type;
-  typedef Algo::Gemm::Blocked algo_tag_type;
-  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type, algo_tag_type>();
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_t_nt_dcomplex_double) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::Transpose, Trans::NoTranspose> param_tag_type;
-  typedef Algo::Gemm::Blocked algo_tag_type;
-  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type, algo_tag_type>();
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::NoTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_c_nt_dcomplex_double) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::ConjTranspose, KokkosBatched::Trans::NoTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_nt_t_dcomplex_double) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::NoTranspose, Trans::Transpose> param_tag_type;
-  typedef Algo::Gemm::Blocked algo_tag_type;
-  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type, algo_tag_type>();
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::Transpose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_t_t_dcomplex_double) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::Transpose, Trans::Transpose> param_tag_type;
-  typedef Algo::Gemm::Blocked algo_tag_type;
-  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type, algo_tag_type>();
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::Transpose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
 }
-// TEST_F( TestCategory, batched_scalar_team_gemm_ct_nt_dcomplex_double ) {
-//   typedef ::Test::TeamGemm::ParamTag<Trans::ConjTranspose,Trans::NoTranspose>
-//   param_tag_type; typedef Algo::Gemm::Blocked algo_tag_type;
-//   test_batched_teamgemm<TestDevice,Kokkos::complex<double>,double,param_tag_type,algo_tag_type>();
-// }
-// TEST_F( TestCategory, batched_scalar_team_gemm_nt_ct_dcomplex_double ) {
-//   typedef ::Test::TeamGemm::ParamTag<Trans::NoTranspose,Trans::ConjTranspose>
-//   param_tag_type; typedef Algo::Gemm::Blocked algo_tag_type;
-//   test_batched_teamgemm<TestDevice,Kokkos::complex<double>,double,param_tag_type,algo_tag_type>();
-// }
+TEST_F(TestCategory, batched_scalar_team_gemm_c_t_dcomplex_double) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::ConjTranspose, KokkosBatched::Trans::Transpose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_nt_c_dcomplex_double) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::ConjTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_t_c_dcomplex_double) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::ConjTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
+TEST_F(TestCategory, batched_scalar_team_gemm_c_c_dcomplex_double) {
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::ConjTranspose, KokkosBatched::Trans::ConjTranspose>;
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, Kokkos::complex<double>, double, param_tag_type,
+                        KokkosBatched::Algo::Gemm::Unblocked>();
+}
 
 #endif

--- a/batched/dense/unit_test/Test_Batched_TeamGemm_Real.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamGemm_Real.hpp
@@ -15,7 +15,8 @@
 //@HEADER
 #if defined(KOKKOS_BHALF_T_IS_FLOAT)
 TEST_F(TestCategory, batched_scalar_team_gemm_nt_nt_bhalf_bhalf) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::NoTranspose, Trans::NoTranspose> param_tag_type;
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose>;
 
   test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
@@ -23,7 +24,7 @@ TEST_F(TestCategory, batched_scalar_team_gemm_nt_nt_bhalf_bhalf) {
                         Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_t_nt_bhalf_bhalf) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::Transpose, Trans::NoTranspose> param_tag_type;
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::NoTranspose>;
 
   test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
@@ -31,7 +32,7 @@ TEST_F(TestCategory, batched_scalar_team_gemm_t_nt_bhalf_bhalf) {
                         Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_nt_t_bhalf_bhalf) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::NoTranspose, Trans::Transpose> param_tag_type;
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::Transpose>;
 
   test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
@@ -39,7 +40,7 @@ TEST_F(TestCategory, batched_scalar_team_gemm_nt_t_bhalf_bhalf) {
                         Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_t_t_bhalf_bhalf) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::Transpose, Trans::Transpose> param_tag_type;
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::Transpose>;
 
   test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
@@ -50,7 +51,8 @@ TEST_F(TestCategory, batched_scalar_team_gemm_t_t_bhalf_bhalf) {
 
 #if defined(KOKKOS_HALF_T_IS_FLOAT)
 TEST_F(TestCategory, batched_scalar_team_gemm_nt_nt_half_half) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::NoTranspose, Trans::NoTranspose> param_tag_type;
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose>;
 
   test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
@@ -58,7 +60,7 @@ TEST_F(TestCategory, batched_scalar_team_gemm_nt_nt_half_half) {
                         Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_t_nt_half_half) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::Transpose, Trans::NoTranspose> param_tag_type;
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::NoTranspose>;
 
   test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
@@ -66,7 +68,7 @@ TEST_F(TestCategory, batched_scalar_team_gemm_t_nt_half_half) {
                         Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_nt_t_half_half) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::NoTranspose, Trans::Transpose> param_tag_type;
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::Transpose>;
 
   test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
@@ -74,7 +76,7 @@ TEST_F(TestCategory, batched_scalar_team_gemm_nt_t_half_half) {
                         Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_t_t_half_half) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::Transpose, Trans::Transpose> param_tag_type;
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::Transpose>;
 
   test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
@@ -85,46 +87,48 @@ TEST_F(TestCategory, batched_scalar_team_gemm_t_t_half_half) {
 
 #if defined(KOKKOSKERNELS_INST_FLOAT)
 TEST_F(TestCategory, batched_scalar_team_gemm_nt_nt_float_float) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::NoTranspose, Trans::NoTranspose> param_tag_type;
-  typedef Algo::Gemm::Blocked algo_tag_type;
-  test_batched_teamgemm<TestDevice, float, float, param_tag_type, algo_tag_type>();
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose>;
+  test_batched_teamgemm<TestDevice, float, float, param_tag_type, KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, float, float, param_tag_type, KokkosBatched::Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_t_nt_float_float) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::Transpose, Trans::NoTranspose> param_tag_type;
-  typedef Algo::Gemm::Blocked algo_tag_type;
-  test_batched_teamgemm<TestDevice, float, float, param_tag_type, algo_tag_type>();
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::NoTranspose>;
+  test_batched_teamgemm<TestDevice, float, float, param_tag_type, KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, float, float, param_tag_type, KokkosBatched::Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_nt_t_float_float) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::NoTranspose, Trans::Transpose> param_tag_type;
-  typedef Algo::Gemm::Blocked algo_tag_type;
-  test_batched_teamgemm<TestDevice, float, float, param_tag_type, algo_tag_type>();
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::Transpose>;
+  test_batched_teamgemm<TestDevice, float, float, param_tag_type, KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, float, float, param_tag_type, KokkosBatched::Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_t_t_float_float) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::Transpose, Trans::Transpose> param_tag_type;
-  typedef Algo::Gemm::Blocked algo_tag_type;
-  test_batched_teamgemm<TestDevice, float, float, param_tag_type, algo_tag_type>();
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::Transpose>;
+  test_batched_teamgemm<TestDevice, float, float, param_tag_type, KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, float, float, param_tag_type, KokkosBatched::Algo::Gemm::Unblocked>();
 }
 #endif
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE)
 TEST_F(TestCategory, batched_scalar_team_gemm_nt_nt_double_double) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::NoTranspose, Trans::NoTranspose> param_tag_type;
-  typedef Algo::Gemm::Blocked algo_tag_type;
-  test_batched_teamgemm<TestDevice, double, double, param_tag_type, algo_tag_type>();
+  using param_tag_type =
+      ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose>;
+  test_batched_teamgemm<TestDevice, double, double, param_tag_type, KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, double, double, param_tag_type, KokkosBatched::Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_t_nt_double_double) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::Transpose, Trans::NoTranspose> param_tag_type;
-  typedef Algo::Gemm::Blocked algo_tag_type;
-  test_batched_teamgemm<TestDevice, double, double, param_tag_type, algo_tag_type>();
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::NoTranspose>;
+  test_batched_teamgemm<TestDevice, double, double, param_tag_type, KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, double, double, param_tag_type, KokkosBatched::Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_nt_t_double_double) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::NoTranspose, Trans::Transpose> param_tag_type;
-  typedef Algo::Gemm::Blocked algo_tag_type;
-  test_batched_teamgemm<TestDevice, double, double, param_tag_type, algo_tag_type>();
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::Transpose>;
+  test_batched_teamgemm<TestDevice, double, double, param_tag_type, KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, double, double, param_tag_type, KokkosBatched::Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_t_t_double_double) {
-  typedef ::Test::TeamGemm::ParamTag<Trans::Transpose, Trans::Transpose> param_tag_type;
-  typedef Algo::Gemm::Blocked algo_tag_type;
-  test_batched_teamgemm<TestDevice, double, double, param_tag_type, algo_tag_type>();
+  using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::Transpose>;
+  test_batched_teamgemm<TestDevice, double, double, param_tag_type, KokkosBatched::Algo::Gemm::Blocked>();
+  test_batched_teamgemm<TestDevice, double, double, param_tag_type, KokkosBatched::Algo::Gemm::Unblocked>();
 }
 #endif


### PR DESCRIPTION
This PR aims at improving the implementation and testing of team Gemm (see also #2469).

 - [x] Moving implementation details into `Impl` namespace
 - [x] Check function has been moved to  `KokkosBatched_Gemm_Common_Impl.hpp`
 - [x] Add all the specializations of the combinations of `Non-Trans/Trans/ConjTrans`
 - [x] Add a check function of input to force A, B, C are rank 0, 1, 2 `Kokkos::View`
 - [x] Covering all the unit-tests for all the combinations of `Non-Trans/Trans/ConjTrans`
 - [x] Remove `using namespace KokkosBatched` from the test code
 - [x] Rename variables starting from underscores in the test code 
 - [x] Deprecated warnings for the older implementation details under `KokkosBatched` namespace
 - [x] As a preliminary attempt, an error bound analysis for Gemm operation is introduced

Updated 1/May
- [x] Introduce a helper to avoid illegal usage of stride method
- [x] Merge blocked and unblocked versions 