### PR TITLE
Fix illegal use of stride

### DIFF
--- a/batched/dense/impl/KokkosBatched_ApplyQ_TeamVector_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_ApplyQ_TeamVector_Impl.hpp
@@ -32,9 +32,19 @@ struct TeamVectorApplyQ<MemberType, Side::Left, Trans::NoTranspose, Algo::ApplyQ
   template <typename AViewType, typename tViewType, typename BViewType, typename wViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const tViewType &t,
                                            const BViewType &B, const wViewType &w) {
-    return TeamVectorApplyQ_LeftForwardInternal::invoke(member, B.extent(0), B.extent(1), A.extent(1), A.data(),
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
+    return TeamVectorApplyQ_LeftForwardInternal::invoke(member, B.extent(0), B_extent_1, A.extent(1), A.data(),
                                                         A.stride_0(), A.stride_1(), t.data(), t.stride_0(), B.data(),
-                                                        B.stride_0(), B.stride_1(), w.data());
+                                                        B.stride_0(), B_stride_1, w.data());
   }
 };
 
@@ -43,9 +53,19 @@ struct TeamVectorApplyQ<MemberType, Side::Left, Trans::Transpose, Algo::ApplyQ::
   template <typename AViewType, typename tViewType, typename BViewType, typename wViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const tViewType &t,
                                            const BViewType &B, const wViewType &w) {
-    return TeamVectorApplyQ_LeftBackwardInternal::invoke(member, B.extent(0), B.extent(1), A.extent(1), A.data(),
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
+    return TeamVectorApplyQ_LeftBackwardInternal::invoke(member, B.extent(0), B_extent_1, A.extent(1), A.data(),
                                                          A.stride_0(), A.stride_1(), t.data(), t.stride_0(), B.data(),
-                                                         B.stride_0(), B.stride_1(), w.data());
+                                                         B.stride_0(), B_stride_1, w.data());
   }
 };
 
@@ -54,9 +74,19 @@ struct TeamVectorApplyQ<MemberType, Side::Right, Trans::NoTranspose, Algo::Apply
   template <typename AViewType, typename tViewType, typename BViewType, typename wViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const tViewType &t,
                                            const BViewType &B, const wViewType &w) {
-    return TeamVectorApplyQ_RightForwardInternal::invoke(member, B.extent(0), B.extent(1), A.extent(1), A.data(),
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
+    return TeamVectorApplyQ_RightForwardInternal::invoke(member, B.extent(0), B_extent_1, A.extent(1), A.data(),
                                                          A.stride_0(), A.stride_1(), t.data(), t.stride_0(), B.data(),
-                                                         B.stride_0(), B.stride_1(), w.data());
+                                                         B.stride_0(), B_stride_1, w.data());
   }
 };
 

--- a/batched/dense/impl/KokkosBatched_Trsm_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsm_Serial_Impl.hpp
@@ -61,10 +61,20 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
     typedef typename BViewType::value_type vector_type;
     // typedef typename vector_type::value_type value_type;
 
-    const int m = B.extent(0), n = B.extent(1);
+    const int m = B.extent(0), n = B_extent_1;
 
     static_assert(is_vector<vector_type>::value, "value type is not vector type");
     static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8,
@@ -73,14 +83,14 @@ struct SerialTrsm<Side::Left, Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::Tr
 
     // no error check
     int r_val = 0;
-    if (A.stride_0() == 1 && B.stride_0() == 1) {
+    if (A.stride(0) == 1 && B.stride(0) == 1) {
       mkl_dtrsm_compact(MKL_COL_MAJOR, MKL_LEFT, MKL_LOWER, MKL_NOTRANS,
                         ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT, m, n, alpha, (const double *)A.data(),
-                        A.stride_1(), (double *)B.data(), B.stride_1(), format, (MKL_INT)vector_type::vector_length);
-    } else if (A.stride_1() == 1 && B.stride_1() == 1) {
+                        A.stride(1), (double *)B.data(), B_stride_1, format, (MKL_INT)vector_type::vector_length);
+    } else if (A.stride(1) == 1 && B_stride_1 == 1) {
       mkl_dtrsm_compact(MKL_ROW_MAJOR, MKL_LEFT, MKL_LOWER, MKL_NOTRANS,
                         ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT, m, n, alpha, (const double *)A.data(),
-                        A.stride_0(), (double *)B.data(), B.stride_0(), format, (MKL_INT)vector_type::vector_length);
+                        A.stride(0), (double *)B.data(), B.stride(0), format, (MKL_INT)vector_type::vector_length);
     } else {
       r_val = -1;
     }
@@ -93,15 +103,22 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::Trsm::Unblocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
     // Quick return if possible
-    if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
 
     return KokkosBatched::Impl::SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
-        ArgDiag::use_unit_diag, false, B.extent(0), B.extent(1), alpha, A.data(), A.stride_0(), A.stride_1(), B.data(),
-        B.stride_0(), B.stride_1());
+        ArgDiag::use_unit_diag, false, B.extent(0), B_extent_1, alpha, A.data(), A.stride(0), A.stride(1), B.data(),
+        B.stride(0), B_stride_1);
   }
 };
 
@@ -109,15 +126,23 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::Trsm::Blocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
     // Quick return if possible
-    if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
 
+    static_assert(AViewType::rank() == 2 && BViewType::rank() == 2);
     return KokkosBatched::Impl::SerialTrsmInternalLeftLower<Algo::Trsm::Blocked>::invoke(
-        ArgDiag::use_unit_diag, false, B.extent(0), B.extent(1), alpha, A.data(), A.stride_0(), A.stride_1(), B.data(),
-        B.stride_0(), B.stride_1());
+        ArgDiag::use_unit_diag, false, B.extent(0), B_extent_1, alpha, A.data(), A.stride(0), A.stride(1), B.data(),
+        B.stride(0), B_stride_1);
   }
 };
 
@@ -132,26 +157,37 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
     typedef typename BViewType::value_type vector_type;
     // typedef typename vector_type::value_type value_type;
 
-    const int m = B.extent(0), n = B.extent(1);
+    const int m = B.extent(0), n = B_extent_1;
 
     static_assert(is_vector<vector_type>::value, "value type is not vector type");
     static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8,
                   "AVX, AVX2 and AVX512 is supported");
+    static_assert(AViewType::rank() == 2 && BViewType::rank() == 2);
     const MKL_COMPACT_PACK format = vector_type::vector_length == 8 ? MKL_COMPACT_AVX512 : MKL_COMPACT_AVX;
 
     // no error check
     int r_val = 0;
-    if (A.stride_0() == 1 && B.stride_0() == 1) {
+    if (A.stride(0) == 1 && B.stride(0) == 1) {
       mkl_dtrsm_compact(MKL_COL_MAJOR, MKL_LEFT, MKL_UPPER, MKL_NOTRANS,
                         ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT, m, n, alpha, (const double *)A.data(),
-                        A.stride_1(), (double *)B.data(), B.stride_1(), format, (MKL_INT)vector_type::vector_length);
-    } else if (A.stride_1() == 1 && B.stride_1() == 1) {
+                        A.stride(1), (double *)B.data(), B_stride_1, format, (MKL_INT)vector_type::vector_length);
+    } else if (A.stride(1) == 1 && B_stride_1 == 1) {
       mkl_dtrsm_compact(MKL_ROW_MAJOR, MKL_LEFT, MKL_UPPER, MKL_NOTRANS,
                         ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT, m, n, alpha, (const double *)A.data(),
-                        A.stride_0(), (double *)B.data(), B.stride_0(), format, (MKL_INT)vector_type::vector_length);
+                        A.stride(0), (double *)B.data(), B.stride(0), format, (MKL_INT)vector_type::vector_length);
     } else {
       r_val = -1;
     }
@@ -164,15 +200,22 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::Trsm::Unblocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
     // Quick return if possible
-    if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
 
     return KokkosBatched::Impl::SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
-        ArgDiag::use_unit_diag, false, B.extent(0), B.extent(1), alpha, A.data(), A.stride_0(), A.stride_1(), B.data(),
-        B.stride_0(), B.stride_1());
+        ArgDiag::use_unit_diag, false, B.extent(0), B_extent_1, alpha, A.data(), A.stride(0), A.stride(1), B.data(),
+        B.stride(0), B_stride_1);
   }
 };
 
@@ -180,15 +223,22 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::Trsm::Blocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
     // Quick return if possible
-    if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
 
     return KokkosBatched::Impl::SerialTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(
-        ArgDiag::use_unit_diag, false, B.extent(0), B.extent(1), alpha, A.data(), A.stride_0(), A.stride_1(), B.data(),
-        B.stride_0(), B.stride_1());
+        ArgDiag::use_unit_diag, false, B.extent(0), B_extent_1, alpha, A.data(), A.stride(0), A.stride(1), B.data(),
+        B.stride(0), B_stride_1);
   }
 };
 
@@ -204,10 +254,20 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
     typedef typename BViewType::value_type vector_type;
     // typedef typename vector_type::value_type value_type;
 
-    const int m = B.extent(0), n = B.extent(1);
+    const int m = B.extent(0), n = B_extent_1;
 
     static_assert(is_vector<vector_type>::value, "value type is not vector type");
     static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8,
@@ -216,13 +276,13 @@ struct SerialTrsm<Side::Left, Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trsm
 
     // no error check
     int r_val = 0;
-    if (A.stride_0() == 1 && B.stride_0() == 1) {
+    if (A.stride(0) == 1 && B.stride(0) == 1) {
       mkl_dtrsm_compact(MKL_COL_MAJOR, MKL_LEFT, MKL_LOWER, MKL_TRANS, ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT,
-                        m, n, alpha, (const double *)A.data(), A.stride_1(), (double *)B.data(), B.stride_1(), format,
+                        m, n, alpha, (const double *)A.data(), A.stride(1), (double *)B.data(), B_stride_1, format,
                         (MKL_INT)vector_type::vector_length);
-    } else if (A.stride_1() == 1 && B.stride_1() == 1) {
+    } else if (A.stride(1) == 1 && B_stride_1 == 1) {
       mkl_dtrsm_compact(MKL_ROW_MAJOR, MKL_LEFT, MKL_LOWER, MKL_TRANS, ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT,
-                        m, n, alpha, (const double *)A.data(), A.stride_0(), (double *)B.data(), B.stride_0(), format,
+                        m, n, alpha, (const double *)A.data(), A.stride(0), (double *)B.data(), B.stride(0), format,
                         (MKL_INT)vector_type::vector_length);
     } else {
       r_val = -1;
@@ -236,15 +296,22 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trsm::Unblocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
     // Quick return if possible
-    if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
 
     return KokkosBatched::Impl::SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
-        ArgDiag::use_unit_diag, false, B.extent(0), B.extent(1), alpha, A.data(), A.stride_1(), A.stride_0(), B.data(),
-        B.stride_0(), B.stride_1());
+        ArgDiag::use_unit_diag, false, B.extent(0), B_extent_1, alpha, A.data(), A.stride(1), A.stride(0), B.data(),
+        B.stride(0), B_stride_1);
   }
 };
 
@@ -252,15 +319,22 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trsm::Blocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
     // Quick return if possible
-    if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
 
     return KokkosBatched::Impl::SerialTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(
-        ArgDiag::use_unit_diag, false, B.extent(0), B.extent(1), alpha, A.data(), A.stride_1(), A.stride_0(), B.data(),
-        B.stride_0(), B.stride_1());
+        ArgDiag::use_unit_diag, false, B.extent(0), B_extent_1, alpha, A.data(), A.stride(1), A.stride(0), B.data(),
+        B.stride(0), B_stride_1);
   }
 };
 
@@ -275,10 +349,20 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
     typedef typename BViewType::value_type vector_type;
     // typedef typename vector_type::value_type value_type;
 
-    const int m = B.extent(0), n = B.extent(1);
+    const int m = B.extent(0), n = B_extent_1;
 
     static_assert(is_vector<vector_type>::value, "value type is not vector type");
     static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8,
@@ -287,13 +371,13 @@ struct SerialTrsm<Side::Left, Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trsm
 
     // no error check
     int r_val = 0;
-    if (A.stride_0() == 1 && B.stride_0() == 1) {
+    if (A.stride(0) == 1 && B.stride(0) == 1) {
       mkl_dtrsm_compact(MKL_COL_MAJOR, MKL_LEFT, MKL_UPPER, MKL_TRANS, ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT,
-                        m, n, alpha, (const double *)A.data(), A.stride_1(), (double *)B.data(), B.stride_1(), format,
+                        m, n, alpha, (const double *)A.data(), A.stride(1), (double *)B.data(), B_stride_1, format,
                         (MKL_INT)vector_type::vector_length);
-    } else if (A.stride_1() == 1 && B.stride_1() == 1) {
+    } else if (A.stride(1) == 1 && B_stride_1 == 1) {
       mkl_dtrsm_compact(MKL_ROW_MAJOR, MKL_LEFT, MKL_UPPER, MKL_TRANS, ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT,
-                        m, n, alpha, (const double *)A.data(), A.stride_0(), (double *)B.data(), B.stride_0(), format,
+                        m, n, alpha, (const double *)A.data(), A.stride(0), (double *)B.data(), B.stride(0), format,
                         (MKL_INT)vector_type::vector_length);
     } else {
       r_val = -1;
@@ -307,15 +391,22 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trsm::Unblocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
     // Quick return if possible
-    if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
 
     return KokkosBatched::Impl::SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
-        ArgDiag::use_unit_diag, false, B.extent(0), B.extent(1), alpha, A.data(), A.stride_1(), A.stride_0(), B.data(),
-        B.stride_0(), B.stride_1());
+        ArgDiag::use_unit_diag, false, B.extent(0), B_extent_1, alpha, A.data(), A.stride(1), A.stride(0), B.data(),
+        B.stride(0), B_stride_1);
   }
 };
 
@@ -323,15 +414,22 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trsm::Blocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
     // Quick return if possible
-    if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
 
     return KokkosBatched::Impl::SerialTrsmInternalLeftLower<Algo::Trsm::Blocked>::invoke(
-        ArgDiag::use_unit_diag, false, B.extent(0), B.extent(1), alpha, A.data(), A.stride_1(), A.stride_0(), B.data(),
-        B.stride_0(), B.stride_1());
+        ArgDiag::use_unit_diag, false, B.extent(0), B_extent_1, alpha, A.data(), A.stride(1), A.stride(0), B.data(),
+        B.stride(0), B_stride_1);
   }
 };
 
@@ -347,10 +445,20 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Lower, Trans::ConjTranspose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
     typedef typename BViewType::value_type vector_type;
     // typedef typename vector_type::value_type value_type;
 
-    const int m = B.extent(0), n = B.extent(1);
+    const int m = B.extent(0), n = B_extent_1;
 
     static_assert(is_vector<vector_type>::value, "value type is not vector type");
     static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8,
@@ -359,14 +467,14 @@ struct SerialTrsm<Side::Left, Uplo::Lower, Trans::ConjTranspose, ArgDiag, Algo::
 
     // no error check
     int r_val = 0;
-    if (A.stride_0() == 1 && B.stride_0() == 1) {
+    if (A.stride(0) == 1 && B.stride(0) == 1) {
       mkl_dtrsm_compact(MKL_COL_MAJOR, MKL_LEFT, MKL_LOWER, MKL_CONJTRANS,
                         ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT, m, n, alpha, (const double *)A.data(),
-                        A.stride_1(), (double *)B.data(), B.stride_1(), format, (MKL_INT)vector_type::vector_length);
-    } else if (A.stride_1() == 1 && B.stride_1() == 1) {
+                        A.stride(1), (double *)B.data(), B_stride_1, format, (MKL_INT)vector_type::vector_length);
+    } else if (A.stride(1) == 1 && B_stride_1 == 1) {
       mkl_dtrsm_compact(MKL_ROW_MAJOR, MKL_LEFT, MKL_LOWER, MKL_CONJTRANS,
                         ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT, m, n, alpha, (const double *)A.data(),
-                        A.stride_0(), (double *)B.data(), B.stride_0(), format, (MKL_INT)vector_type::vector_length);
+                        A.stride(0), (double *)B.data(), B.stride(0), format, (MKL_INT)vector_type::vector_length);
     } else {
       r_val = -1;
     }
@@ -379,15 +487,22 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Lower, Trans::ConjTranspose, ArgDiag, Algo::Trsm::Unblocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
     // Quick return if possible
-    if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
 
     return KokkosBatched::Impl::SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
-        ArgDiag::use_unit_diag, true, B.extent(0), B.extent(1), alpha, A.data(), A.stride_1(), A.stride_0(), B.data(),
-        B.stride_0(), B.stride_1());
+        ArgDiag::use_unit_diag, true, B.extent(0), B_extent_1, alpha, A.data(), A.stride(1), A.stride(0), B.data(),
+        B.stride(0), B_stride_1);
   }
 };
 
@@ -404,10 +519,20 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Upper, Trans::ConjTranspose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
     typedef typename BViewType::value_type vector_type;
     // typedef typename vector_type::value_type value_type;
 
-    const int m = B.extent(0), n = B.extent(1);
+    const int m = B.extent(0), n = B_extent_1;
 
     static_assert(is_vector<vector_type>::value, "value type is not vector type");
     static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8,
@@ -416,14 +541,14 @@ struct SerialTrsm<Side::Left, Uplo::Upper, Trans::ConjTranspose, ArgDiag, Algo::
 
     // no error check
     int r_val = 0;
-    if (A.stride_0() == 1 && B.stride_0() == 1) {
+    if (A.stride(0) == 1 && B.stride(0) == 1) {
       mkl_dtrsm_compact(MKL_COL_MAJOR, MKL_LEFT, MKL_UPPER, MKL_CONJTRANS,
                         ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT, m, n, alpha, (const double *)A.data(),
-                        A.stride_1(), (double *)B.data(), B.stride_1(), format, (MKL_INT)vector_type::vector_length);
-    } else if (A.stride_1() == 1 && B.stride_1() == 1) {
+                        A.stride(1), (double *)B.data(), B_stride_1, format, (MKL_INT)vector_type::vector_length);
+    } else if (A.stride(1) == 1 && B_stride_1 == 1) {
       mkl_dtrsm_compact(MKL_ROW_MAJOR, MKL_LEFT, MKL_UPPER, MKL_CONJTRANS,
                         ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT, m, n, alpha, (const double *)A.data(),
-                        A.stride_0(), (double *)B.data(), B.stride_0(), format, (MKL_INT)vector_type::vector_length);
+                        A.stride(0), (double *)B.data(), B.stride(0), format, (MKL_INT)vector_type::vector_length);
     } else {
       r_val = -1;
     }
@@ -436,15 +561,22 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Upper, Trans::ConjTranspose, ArgDiag, Algo::Trsm::Unblocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
     // Quick return if possible
-    if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
 
     return KokkosBatched::Impl::SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
-        ArgDiag::use_unit_diag, true, B.extent(0), B.extent(1), alpha, A.data(), A.stride_1(), A.stride_0(), B.data(),
-        B.stride_0(), B.stride_1());
+        ArgDiag::use_unit_diag, true, B.extent(0), B_extent_1, alpha, A.data(), A.stride(1), A.stride(0), B.data(),
+        B.stride(0), B_stride_1);
   }
 };
 
@@ -462,6 +594,7 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2 && BViewType::rank() == 2);
     typedef typename BViewType::value_type vector_type;
     // typedef typename vector_type::value_type value_type;
 
@@ -474,14 +607,14 @@ struct SerialTrsm<Side::Right, Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::T
 
     // no error check
     int r_val = 0;
-    if (A.stride_0() == 1 && B.stride_0() == 1) {
+    if (A.stride(0) == 1 && B.stride(0) == 1) {
       mkl_dtrsm_compact(MKL_COL_MAJOR, MKL_RIGHT, MKL_LOWER, MKL_NOTRANS,
                         ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT, m, n, alpha, (const double *)A.data(),
-                        A.stride_1(), (double *)B.data(), B.stride_1(), format, (MKL_INT)vector_type::vector_length);
-    } else if (A.stride_1() == 1 && B.stride_1() == 1) {
+                        A.stride(1), (double *)B.data(), B.stride_1(), format, (MKL_INT)vector_type::vector_length);
+    } else if (A.stride(1) == 1 && B.stride_1() == 1) {
       mkl_dtrsm_compact(MKL_ROW_MAJOR, MKL_RIGHT, MKL_LOWER, MKL_NOTRANS,
                         ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT, m, n, alpha, (const double *)A.data(),
-                        A.stride_0(), (double *)B.data(), B.stride_0(), format, (MKL_INT)vector_type::vector_length);
+                        A.stride(0), (double *)B.data(), B.stride(0), format, (MKL_INT)vector_type::vector_length);
     } else {
       r_val = -1;
     }
@@ -494,6 +627,7 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::Trsm::Unblocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2 && BViewType::rank() == 2);
     // Quick return if possible
     if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
 
@@ -501,8 +635,8 @@ struct SerialTrsm<Side::Right, Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::T
     if (info) return info;
 
     return KokkosBatched::Impl::SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
-        ArgDiag::use_unit_diag, false, B.extent(1), B.extent(0), alpha, A.data(), A.stride_1(), A.stride_0(), B.data(),
-        B.stride_1(), B.stride_0());
+        ArgDiag::use_unit_diag, false, B.extent(1), B.extent(0), alpha, A.data(), A.stride(1), A.stride(0), B.data(),
+        B.stride_1(), B.stride(0));
   }
 };
 
@@ -510,6 +644,7 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::Trsm::Blocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2 && BViewType::rank() == 2);
     // Quick return if possible
     if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
 
@@ -517,8 +652,8 @@ struct SerialTrsm<Side::Right, Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::T
     if (info) return info;
 
     return KokkosBatched::Impl::SerialTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(
-        ArgDiag::use_unit_diag, false, B.extent(1), B.extent(0), alpha, A.data(), A.stride_1(), A.stride_0(), B.data(),
-        B.stride_1(), B.stride_0());
+        ArgDiag::use_unit_diag, false, B.extent(1), B.extent(0), alpha, A.data(), A.stride(1), A.stride(0), B.data(),
+        B.stride_1(), B.stride(0));
   }
 };
 
@@ -533,6 +668,7 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2 && BViewType::rank() == 2);
     typedef typename BViewType::value_type vector_type;
     // typedef typename vector_type::value_type value_type;
 
@@ -545,14 +681,14 @@ struct SerialTrsm<Side::Right, Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::T
 
     // no error check
     int r_val = 0;
-    if (A.stride_0() == 1 && B.stride_0() == 1) {
+    if (A.stride(0) == 1 && B.stride(0) == 1) {
       mkl_dtrsm_compact(MKL_COL_MAJOR, MKL_RIGHT, MKL_UPPER, MKL_NOTRANS,
                         ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT, m, n, alpha, (const double *)A.data(),
-                        A.stride_1(), (double *)B.data(), B.stride_1(), format, (MKL_INT)vector_type::vector_length);
-    } else if (A.stride_1() == 1 && B.stride_1() == 1) {
+                        A.stride(1), (double *)B.data(), B.stride_1(), format, (MKL_INT)vector_type::vector_length);
+    } else if (A.stride(1) == 1 && B.stride_1() == 1) {
       mkl_dtrsm_compact(MKL_ROW_MAJOR, MKL_RIGHT, MKL_UPPER, MKL_NOTRANS,
                         ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT, m, n, alpha, (const double *)A.data(),
-                        A.stride_0(), (double *)B.data(), B.stride_0(), format, (MKL_INT)vector_type::vector_length);
+                        A.stride(0), (double *)B.data(), B.stride(0), format, (MKL_INT)vector_type::vector_length);
     } else {
       r_val = -1;
     }
@@ -565,6 +701,7 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::Trsm::Unblocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2 && BViewType::rank() == 2);
     // Quick return if possible
     if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
 
@@ -572,8 +709,8 @@ struct SerialTrsm<Side::Right, Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::T
     if (info) return info;
 
     return KokkosBatched::Impl::SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
-        ArgDiag::use_unit_diag, false, B.extent(1), B.extent(0), alpha, A.data(), A.stride_1(), A.stride_0(), B.data(),
-        B.stride_1(), B.stride_0());
+        ArgDiag::use_unit_diag, false, B.extent(1), B.extent(0), alpha, A.data(), A.stride(1), A.stride(0), B.data(),
+        B.stride_1(), B.stride(0));
   }
 };
 
@@ -581,6 +718,7 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::Trsm::Blocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2 && BViewType::rank() == 2);
     // Quick return if possible
     if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
 
@@ -588,8 +726,8 @@ struct SerialTrsm<Side::Right, Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::T
     if (info) return info;
 
     return KokkosBatched::Impl::SerialTrsmInternalLeftLower<Algo::Trsm::Blocked>::invoke(
-        ArgDiag::use_unit_diag, false, B.extent(1), B.extent(0), alpha, A.data(), A.stride_1(), A.stride_0(), B.data(),
-        B.stride_1(), B.stride_0());
+        ArgDiag::use_unit_diag, false, B.extent(1), B.extent(0), alpha, A.data(), A.stride(1), A.stride(0), B.data(),
+        B.stride_1(), B.stride(0));
   }
 };
 
@@ -605,6 +743,7 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2 && BViewType::rank() == 2);
     typedef typename BViewType::value_type vector_type;
     // typedef typename vector_type::value_type value_type;
 
@@ -617,13 +756,13 @@ struct SerialTrsm<Side::Right, Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trs
 
     // no error check
     int r_val = 0;
-    if (A.stride_0() == 1 && B.stride_0() == 1) {
+    if (A.stride(0) == 1 && B.stride(0) == 1) {
       mkl_dtrsm_compact(MKL_COL_MAJOR, MKL_RIGHT, MKL_LOWER, MKL_TRANS, ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT,
-                        m, n, alpha, (const double *)A.data(), A.stride_1(), (double *)B.data(), B.stride_1(), format,
+                        m, n, alpha, (const double *)A.data(), A.stride(1), (double *)B.data(), B.stride_1(), format,
                         (MKL_INT)vector_type::vector_length);
-    } else if (A.stride_1() == 1 && B.stride_1() == 1) {
+    } else if (A.stride(1) == 1 && B.stride_1() == 1) {
       mkl_dtrsm_compact(MKL_ROW_MAJOR, MKL_RIGHT, MKL_LOWER, MKL_TRANS, ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT,
-                        m, n, alpha, (const double *)A.data(), A.stride_0(), (double *)B.data(), B.stride_0(), format,
+                        m, n, alpha, (const double *)A.data(), A.stride(0), (double *)B.data(), B.stride(0), format,
                         (MKL_INT)vector_type::vector_length);
     } else {
       r_val = -1;
@@ -637,6 +776,7 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trsm::Unblocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2 && BViewType::rank() == 2);
     // Quick return if possible
     if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
 
@@ -644,8 +784,8 @@ struct SerialTrsm<Side::Right, Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trs
     if (info) return info;
 
     return KokkosBatched::Impl::SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
-        ArgDiag::use_unit_diag, false, B.extent(1), B.extent(0), alpha, A.data(), A.stride_0(), A.stride_1(), B.data(),
-        B.stride_1(), B.stride_0());
+        ArgDiag::use_unit_diag, false, B.extent(1), B.extent(0), alpha, A.data(), A.stride(0), A.stride(1), B.data(),
+        B.stride_1(), B.stride(0));
   }
 };
 
@@ -653,6 +793,7 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trsm::Blocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2 && BViewType::rank() == 2);
     // Quick return if possible
     if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
 
@@ -660,8 +801,8 @@ struct SerialTrsm<Side::Right, Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trs
     if (info) return info;
 
     return KokkosBatched::Impl::SerialTrsmInternalLeftLower<Algo::Trsm::Blocked>::invoke(
-        ArgDiag::use_unit_diag, false, B.extent(1), B.extent(0), alpha, A.data(), A.stride_0(), A.stride_1(), B.data(),
-        B.stride_1(), B.stride_0());
+        ArgDiag::use_unit_diag, false, B.extent(1), B.extent(0), alpha, A.data(), A.stride(0), A.stride(1), B.data(),
+        B.stride_1(), B.stride(0));
   }
 };
 
@@ -676,6 +817,7 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2 && BViewType::rank() == 2);
     typedef typename BViewType::value_type vector_type;
     // typedef typename vector_type::value_type value_type;
 
@@ -688,13 +830,13 @@ struct SerialTrsm<Side::Right, Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trs
 
     // no error check
     int r_val = 0;
-    if (A.stride_0() == 1 && B.stride_0() == 1) {
+    if (A.stride(0) == 1 && B.stride(0) == 1) {
       mkl_dtrsm_compact(MKL_COL_MAJOR, MKL_RIGHT, MKL_UPPER, MKL_TRANS, ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT,
-                        m, n, alpha, (const double *)A.data(), A.stride_1(), (double *)B.data(), B.stride_1(), format,
+                        m, n, alpha, (const double *)A.data(), A.stride(1), (double *)B.data(), B.stride_1(), format,
                         (MKL_INT)vector_type::vector_length);
-    } else if (A.stride_1() == 1 && B.stride_1() == 1) {
+    } else if (A.stride(1) == 1 && B.stride_1() == 1) {
       mkl_dtrsm_compact(MKL_ROW_MAJOR, MKL_RIGHT, MKL_UPPER, MKL_TRANS, ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT,
-                        m, n, alpha, (const double *)A.data(), A.stride_0(), (double *)B.data(), B.stride_0(), format,
+                        m, n, alpha, (const double *)A.data(), A.stride(0), (double *)B.data(), B.stride(0), format,
                         (MKL_INT)vector_type::vector_length);
     } else {
       r_val = -1;
@@ -708,6 +850,7 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trsm::Unblocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2 && BViewType::rank() == 2);
     // Quick return if possible
     if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
 
@@ -715,8 +858,8 @@ struct SerialTrsm<Side::Right, Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trs
     if (info) return info;
 
     return KokkosBatched::Impl::SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
-        ArgDiag::use_unit_diag, false, B.extent(1), B.extent(0), alpha, A.data(), A.stride_0(), A.stride_1(), B.data(),
-        B.stride_1(), B.stride_0());
+        ArgDiag::use_unit_diag, false, B.extent(1), B.extent(0), alpha, A.data(), A.stride(0), A.stride(1), B.data(),
+        B.stride_1(), B.stride(0));
   }
 };
 
@@ -724,6 +867,7 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trsm::Blocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2 && BViewType::rank() == 2);
     // Quick return if possible
     if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
 
@@ -731,8 +875,8 @@ struct SerialTrsm<Side::Right, Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trs
     if (info) return info;
 
     return KokkosBatched::Impl::SerialTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(
-        ArgDiag::use_unit_diag, false, B.extent(1), B.extent(0), alpha, A.data(), A.stride_0(), A.stride_1(), B.data(),
-        B.stride_1(), B.stride_0());
+        ArgDiag::use_unit_diag, false, B.extent(1), B.extent(0), alpha, A.data(), A.stride(0), A.stride(1), B.data(),
+        B.stride_1(), B.stride(0));
   }
 };
 
@@ -748,6 +892,7 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Lower, Trans::ConjTranspose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2 && BViewType::rank() == 2);
     typedef typename BViewType::value_type vector_type;
     // typedef typename vector_type::value_type value_type;
 
@@ -760,14 +905,14 @@ struct SerialTrsm<Side::Right, Uplo::Lower, Trans::ConjTranspose, ArgDiag, Algo:
 
     // no error check
     int r_val = 0;
-    if (A.stride_0() == 1 && B.stride_0() == 1) {
+    if (A.stride(0) == 1 && B.stride(0) == 1) {
       mkl_dtrsm_compact(MKL_COL_MAJOR, MKL_RIGHT, MKL_LOWER, MKL_CONJTRANS,
                         ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT, m, n, alpha, (const double *)A.data(),
-                        A.stride_1(), (double *)B.data(), B.stride_1(), format, (MKL_INT)vector_type::vector_length);
-    } else if (A.stride_1() == 1 && B.stride_1() == 1) {
+                        A.stride(1), (double *)B.data(), B.stride_1(), format, (MKL_INT)vector_type::vector_length);
+    } else if (A.stride(1) == 1 && B.stride_1() == 1) {
       mkl_dtrsm_compact(MKL_ROW_MAJOR, MKL_RIGHT, MKL_LOWER, MKL_CONJTRANS,
                         ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT, m, n, alpha, (const double *)A.data(),
-                        A.stride_0(), (double *)B.data(), B.stride_0(), format, (MKL_INT)vector_type::vector_length);
+                        A.stride(0), (double *)B.data(), B.stride(0), format, (MKL_INT)vector_type::vector_length);
     } else {
       r_val = -1;
     }
@@ -780,6 +925,7 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Lower, Trans::ConjTranspose, ArgDiag, Algo::Trsm::Unblocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2 && BViewType::rank() == 2);
     // Quick return if possible
     if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
 
@@ -787,8 +933,8 @@ struct SerialTrsm<Side::Right, Uplo::Lower, Trans::ConjTranspose, ArgDiag, Algo:
     if (info) return info;
 
     return KokkosBatched::Impl::SerialTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
-        ArgDiag::use_unit_diag, true, B.extent(1), B.extent(0), alpha, A.data(), A.stride_0(), A.stride_1(), B.data(),
-        B.stride_1(), B.stride_0());
+        ArgDiag::use_unit_diag, true, B.extent(1), B.extent(0), alpha, A.data(), A.stride(0), A.stride(1), B.data(),
+        B.stride_1(), B.stride(0));
   }
 };
 
@@ -805,6 +951,7 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Upper, Trans::ConjTranspose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2 && BViewType::rank() == 2);
     typedef typename BViewType::value_type vector_type;
     // typedef typename vector_type::value_type value_type;
 
@@ -817,14 +964,14 @@ struct SerialTrsm<Side::Right, Uplo::Upper, Trans::ConjTranspose, ArgDiag, Algo:
 
     // no error check
     int r_val = 0;
-    if (A.stride_0() == 1 && B.stride_0() == 1) {
+    if (A.stride(0) == 1 && B.stride(0) == 1) {
       mkl_dtrsm_compact(MKL_COL_MAJOR, MKL_RIGHT, MKL_UPPER, MKL_CONJTRANS,
                         ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT, m, n, alpha, (const double *)A.data(),
-                        A.stride_1(), (double *)B.data(), B.stride_1(), format, (MKL_INT)vector_type::vector_length);
-    } else if (A.stride_1() == 1 && B.stride_1() == 1) {
+                        A.stride(1), (double *)B.data(), B.stride_1(), format, (MKL_INT)vector_type::vector_length);
+    } else if (A.stride(1) == 1 && B.stride_1() == 1) {
       mkl_dtrsm_compact(MKL_ROW_MAJOR, MKL_RIGHT, MKL_UPPER, MKL_CONJTRANS,
                         ArgDiag::use_unit_diag ? MKL_UNIT : MKL_NONUNIT, m, n, alpha, (const double *)A.data(),
-                        A.stride_0(), (double *)B.data(), B.stride_0(), format, (MKL_INT)vector_type::vector_length);
+                        A.stride(0), (double *)B.data(), B.stride(0), format, (MKL_INT)vector_type::vector_length);
     } else {
       r_val = -1;
     }
@@ -837,6 +984,7 @@ template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Upper, Trans::ConjTranspose, ArgDiag, Algo::Trsm::Unblocked> {
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const BViewType &B) {
+    static_assert(AViewType::rank() == 2 && BViewType::rank() == 2);
     // Quick return if possible
     if (B.extent(0) == 0 || B.extent(1) == 0) return 0;
 
@@ -844,8 +992,8 @@ struct SerialTrsm<Side::Right, Uplo::Upper, Trans::ConjTranspose, ArgDiag, Algo:
     if (info) return info;
 
     return KokkosBatched::Impl::SerialTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
-        ArgDiag::use_unit_diag, true, B.extent(1), B.extent(0), alpha, A.data(), A.stride_0(), A.stride_1(), B.data(),
-        B.stride_1(), B.stride_0());
+        ArgDiag::use_unit_diag, true, B.extent(1), B.extent(0), alpha, A.data(), A.stride(0), A.stride(1), B.data(),
+        B.stride_1(), B.stride(0));
   }
 };
 

--- a/batched/dense/impl/KokkosBatched_Trsm_TeamVector_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsm_TeamVector_Impl.hpp
@@ -38,9 +38,19 @@ struct TeamVectorTrsm<MemberType, Side::Left, Uplo::Lower, Trans::NoTranspose, A
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
     return TeamVectorTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
-        member, ArgDiag::use_unit_diag, B.extent(0), B.extent(1), alpha, A.data(), A.stride_0(), A.stride_1(), B.data(),
-        B.stride_0(), B.stride_1());
+        member, ArgDiag::use_unit_diag, B.extent(0), B_extent_1, alpha, A.data(), A.stride_0(), A.stride_1(), B.data(),
+        B.stride_0(), B_stride_1);
   }
 };
 
@@ -55,9 +65,19 @@ struct TeamVectorTrsm<MemberType, Side::Right, Uplo::Upper, Trans::NoTranspose, 
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
     return TeamVectorTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
-        member, ArgDiag::use_unit_diag, B.extent(1), B.extent(0), alpha, A.data(), A.stride_1(), A.stride_0(), B.data(),
-        B.stride_1(), B.stride_0());
+        member, ArgDiag::use_unit_diag, B_extent_1, B.extent(0), alpha, A.data(), A.stride_1(), A.stride_0(), B.data(),
+        B_stride_1, B.stride_0());
   }
 };
 
@@ -72,9 +92,19 @@ struct TeamVectorTrsm<MemberType, Side::Left, Uplo::Upper, Trans::NoTranspose, A
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
     return TeamVectorTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
-        member, ArgDiag::use_unit_diag, B.extent(0), B.extent(1), alpha, A.data(), A.stride_0(), A.stride_1(), B.data(),
-        B.stride_0(), B.stride_1());
+        member, ArgDiag::use_unit_diag, B.extent(0), B_extent_1, alpha, A.data(), A.stride_0(), A.stride_1(), B.data(),
+        B.stride_0(), B_stride_1);
   }
 };
 
@@ -89,9 +119,19 @@ struct TeamVectorTrsm<MemberType, Side::Left, Uplo::Lower, Trans::Transpose, Arg
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
     return TeamVectorTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(
-        member, ArgDiag::use_unit_diag, B.extent(0), B.extent(1), alpha, A.data(), A.stride_1(), A.stride_0(), B.data(),
-        B.stride_0(), B.stride_1());
+        member, ArgDiag::use_unit_diag, B.extent(0), B_extent_1, alpha, A.data(), A.stride_1(), A.stride_0(), B.data(),
+        B.stride_0(), B_stride_1);
   }
 };
 
@@ -106,9 +146,19 @@ struct TeamVectorTrsm<MemberType, Side::Left, Uplo::Upper, Trans::Transpose, Arg
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
     return TeamVectorTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(
-        member, ArgDiag::use_unit_diag, B.extent(0), B.extent(1), alpha, A.data(), A.stride_1(), A.stride_0(), B.data(),
-        B.stride_0(), B.stride_1());
+        member, ArgDiag::use_unit_diag, B.extent(0), B_extent_1, alpha, A.data(), A.stride_1(), A.stride_0(), B.data(),
+        B.stride_0(), B_stride_1);
   }
 };
 

--- a/batched/dense/impl/KokkosBatched_Trsm_Team_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsm_Team_Impl.hpp
@@ -38,9 +38,19 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Lower, Trans::NoTranspose, ArgDiag
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
     return TeamTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(member, ArgDiag::use_unit_diag, B.extent(0),
-                                                                    B.extent(1), alpha, A.data(), A.stride_0(),
-                                                                    A.stride_1(), B.data(), B.stride_0(), B.stride_1());
+                                                                    B_extent_1, alpha, A.data(), A.stride_0(),
+                                                                    A.stride_1(), B.data(), B.stride_0(), B_stride_1);
   }
 };
 
@@ -49,9 +59,19 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Lower, Trans::NoTranspose, ArgDiag
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
     return TeamTrsmInternalLeftLower<Algo::Trsm::Blocked>::invoke(member, ArgDiag::use_unit_diag, B.extent(0),
-                                                                  B.extent(1), alpha, A.data(), A.stride_0(),
-                                                                  A.stride_1(), B.data(), B.stride_0(), B.stride_1());
+                                                                  B_extent_1, alpha, A.data(), A.stride_0(),
+                                                                  A.stride_1(), B.data(), B.stride_0(), B_stride_1);
   }
 };
 
@@ -66,9 +86,19 @@ struct TeamTrsm<MemberType, Side::Right, Uplo::Upper, Trans::NoTranspose, ArgDia
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    return TeamTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(member, ArgDiag::use_unit_diag, B.extent(1),
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
+    return TeamTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(member, ArgDiag::use_unit_diag, B_extent_1,
                                                                     B.extent(0), alpha, A.data(), A.stride_1(),
-                                                                    A.stride_0(), B.data(), B.stride_1(), B.stride_0());
+                                                                    A.stride_0(), B.data(), B_stride_1, B.stride_0());
   }
 };
 
@@ -77,9 +107,19 @@ struct TeamTrsm<MemberType, Side::Right, Uplo::Upper, Trans::NoTranspose, ArgDia
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    return TeamTrsmInternalLeftLower<Algo::Trsm::Blocked>::invoke(member, ArgDiag::use_unit_diag, B.extent(1),
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
+    return TeamTrsmInternalLeftLower<Algo::Trsm::Blocked>::invoke(member, ArgDiag::use_unit_diag, B_extent_1,
                                                                   B.extent(0), alpha, A.data(), A.stride_1(),
-                                                                  A.stride_0(), B.data(), B.stride_1(), B.stride_0());
+                                                                  A.stride_0(), B.data(), B_stride_1, B.stride_0());
   }
 };
 
@@ -94,9 +134,19 @@ struct TeamTrsm<MemberType, Side::Right, Uplo::Lower, Trans::NoTranspose, ArgDia
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    return TeamTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(member, ArgDiag::use_unit_diag, B.extent(1),
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
+    return TeamTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(member, ArgDiag::use_unit_diag, B_extent_1,
                                                                     B.extent(0), alpha, A.data(), A.stride_1(),
-                                                                    A.stride_0(), B.data(), B.stride_1(), B.stride_0());
+                                                                    A.stride_0(), B.data(), B_stride_1, B.stride_0());
   }
 };
 
@@ -105,9 +155,19 @@ struct TeamTrsm<MemberType, Side::Right, Uplo::Lower, Trans::NoTranspose, ArgDia
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    return TeamTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(member, ArgDiag::use_unit_diag, B.extent(1),
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
+    return TeamTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(member, ArgDiag::use_unit_diag, B_extent_1,
                                                                   B.extent(0), alpha, A.data(), A.stride_1(),
-                                                                  A.stride_0(), B.data(), B.stride_1(), B.stride_0());
+                                                                  A.stride_0(), B.data(), B_stride_1, B.stride_0());
   }
 };
 
@@ -122,9 +182,19 @@ struct TeamTrsm<MemberType, Side::Right, Uplo::Upper, Trans::Transpose, ArgDiag,
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    return TeamTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(member, ArgDiag::use_unit_diag, B.extent(1),
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
+    return TeamTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(member, ArgDiag::use_unit_diag, B_extent_1,
                                                                     B.extent(0), alpha, A.data(), A.stride_0(),
-                                                                    A.stride_1(), B.data(), B.stride_1(), B.stride_0());
+                                                                    A.stride_1(), B.data(), B_stride_1, B.stride_0());
   }
 };
 
@@ -133,9 +203,19 @@ struct TeamTrsm<MemberType, Side::Right, Uplo::Upper, Trans::Transpose, ArgDiag,
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    return TeamTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(member, ArgDiag::use_unit_diag, B.extent(1),
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
+    return TeamTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(member, ArgDiag::use_unit_diag, B_extent_1,
                                                                   B.extent(0), alpha, A.data(), A.stride_0(),
-                                                                  A.stride_1(), B.data(), B.stride_1(), B.stride_0());
+                                                                  A.stride_1(), B.data(), B_stride_1, B.stride_0());
   }
 };
 
@@ -150,9 +230,19 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Upper, Trans::NoTranspose, ArgDiag
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
     return TeamTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(member, ArgDiag::use_unit_diag, B.extent(0),
-                                                                    B.extent(1), alpha, A.data(), A.stride_0(),
-                                                                    A.stride_1(), B.data(), B.stride_0(), B.stride_1());
+                                                                    B_extent_1, alpha, A.data(), A.stride_0(),
+                                                                    A.stride_1(), B.data(), B.stride_0(), B_stride_1);
   }
 };
 
@@ -161,9 +251,19 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Upper, Trans::NoTranspose, ArgDiag
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
     return TeamTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(member, ArgDiag::use_unit_diag, B.extent(0),
-                                                                  B.extent(1), alpha, A.data(), A.stride_0(),
-                                                                  A.stride_1(), B.data(), B.stride_0(), B.stride_1());
+                                                                  B_extent_1, alpha, A.data(), A.stride_0(),
+                                                                  A.stride_1(), B.data(), B.stride_0(), B_stride_1);
   }
 };
 
@@ -178,9 +278,19 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Lower, Trans::Transpose, ArgDiag, 
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
     return TeamTrsmInternalLeftUpper<Algo::Trsm::Unblocked>::invoke(member, ArgDiag::use_unit_diag, B.extent(0),
-                                                                    B.extent(1), alpha, A.data(), A.stride_1(),
-                                                                    A.stride_0(), B.data(), B.stride_0(), B.stride_1());
+                                                                    B_extent_1, alpha, A.data(), A.stride_1(),
+                                                                    A.stride_0(), B.data(), B.stride_0(), B_stride_1);
   }
 };
 
@@ -189,9 +299,19 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Lower, Trans::Transpose, ArgDiag, 
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
     return TeamTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invoke(member, ArgDiag::use_unit_diag, B.extent(0),
-                                                                  B.extent(1), alpha, A.data(), A.stride_1(),
-                                                                  A.stride_0(), B.data(), B.stride_0(), B.stride_1());
+                                                                  B_extent_1, alpha, A.data(), A.stride_1(),
+                                                                  A.stride_0(), B.data(), B.stride_0(), B_stride_1);
   }
 };
 
@@ -206,9 +326,19 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Upper, Trans::Transpose, ArgDiag, 
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
     return TeamTrsmInternalLeftLower<Algo::Trsm::Unblocked>::invoke(member, ArgDiag::use_unit_diag, B.extent(0),
-                                                                    B.extent(1), alpha, A.data(), A.stride_1(),
-                                                                    A.stride_0(), B.data(), B.stride_0(), B.stride_1());
+                                                                    B_extent_1, alpha, A.data(), A.stride_1(),
+                                                                    A.stride_0(), B.data(), B.stride_0(), B_stride_1);
   }
 };
 
@@ -217,9 +347,19 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Upper, Trans::Transpose, ArgDiag, 
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
+    static_assert(AViewType::rank() == 2);
+    constexpr size_t B_rank = BViewType::rank();
+    static_assert(B_rank == 1 || B_rank == 2);
+
+    // Quick return if possible
+    if (B.size() == 0) return 0;
+
+    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+
     return TeamTrsmInternalLeftLower<Algo::Trsm::Blocked>::invoke(member, ArgDiag::use_unit_diag, B.extent(0),
-                                                                  B.extent(1), alpha, A.data(), A.stride_1(),
-                                                                  A.stride_0(), B.data(), B.stride_0(), B.stride_1());
+                                                                  B_extent_1, alpha, A.data(), A.stride_1(),
+                                                                  A.stride_0(), B.data(), B.stride_0(), B_stride_1);
   }
 };
 

--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -316,9 +316,11 @@ KOKKOS_FUNCTION void serial_axpy(const scalar_type alpha, const XMV X, YMV Y) {
     Kokkos::abort("KokkosBlas::serial_axpy: X and Y dimensions do not match");
   }
 #endif  // KOKKOSKERNELS_DEBUG_LEVEL
-
-  return Impl::serial_axpy_mv(X.extent(0), X.extent(1), alpha, X.data(), Y.data(), X.stride_0(), X.stride_1(),
-                              Y.stride_0(), Y.stride_1());
+  if constexpr (XMV::rank() == 1)
+    return Impl::serial_axpy(X.extent(0), alpha, X.data(), Y.data(), X.stride(0), Y.stride(0));
+  else
+    return Impl::serial_axpy_mv(X.extent(0), X.extent(1), alpha, X.data(), Y.data(), X.stride(0), X.stride(1),
+                                Y.stride(0), Y.stride(1));
 }
 
 }  // namespace KokkosBlas

--- a/blas/src/KokkosBlas1_nrm2.hpp
+++ b/blas/src/KokkosBlas1_nrm2.hpp
@@ -215,8 +215,10 @@ KOKKOS_INLINE_FUNCTION int serial_nrm2(const XMV X, const RV& R) {
     return 1;
   }
 #endif  // KOKKOSKERNELS_DEBUG_LEVEL
-
-  Impl::serial_nrm2(X.extent(0), X.extent(1), X.data(), X.stride_0(), X.stride_1(), R.data(), R.stride_0());
+  if constexpr (XMV::rank() == 1)
+    Impl::serial_nrm2(X.extent(0), X.data(), X.stride(0), R.data());
+  else
+    Impl::serial_nrm2(X.extent(0), X.extent(1), X.data(), X.stride(0), X.stride(1), R.data(), R.stride(0));
   return 0;
 }
 

--- a/blas/src/KokkosBlas1_scal.hpp
+++ b/blas/src/KokkosBlas1_scal.hpp
@@ -122,7 +122,10 @@ void scal(const RMV& R, const AV& a, const XMV& X) {
 struct SerialScale {
   template <typename ScalarType, typename AViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType& A) {
-    return Impl::SerialScaleInternal::invoke(A.extent(0), A.extent(1), alpha, A.data(), A.stride_0(), A.stride_1());
+    if constexpr (AViewType::rank() == 1)
+      return Impl::SerialScaleInternal::invoke(A.extent(0), alpha, A.data(), A.stride(0));
+    else
+      return Impl::SerialScaleInternal::invoke(A.extent(0), A.extent(1), alpha, A.data(), A.stride(0), A.stride(1));
   }
 };
 
@@ -134,8 +137,11 @@ template <typename MemberType>
 struct TeamScale {
   template <typename ScalarType, typename AViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member, const ScalarType alpha, const AViewType& A) {
-    return Impl::TeamScaleInternal::invoke(member, A.extent(0), A.extent(1), alpha, A.data(), A.stride_0(),
-                                           A.stride_1());
+    if constexpr (AViewType::rank() == 1)
+      return Impl::TeamScaleInternal::invoke(member, A.extent(0), alpha, A.data(), A.stride_0());
+    else
+      return Impl::TeamScaleInternal::invoke(member, A.extent(0), A.extent(1), alpha, A.data(), A.stride(0),
+                                             A.stride(1));
   }
 };
 
@@ -147,8 +153,11 @@ template <typename MemberType>
 struct TeamVectorScale {
   template <typename ScalarType, typename AViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType& member, const ScalarType alpha, const AViewType& A) {
-    return Impl::TeamVectorScaleInternal::invoke(member, A.extent(0), A.extent(1), alpha, A.data(), A.stride_0(),
-                                                 A.stride_1());
+    if constexpr (AViewType::rank() == 1)
+      return Impl::TeamVectorScaleInternal::invoke(member, A.extent(0), alpha, A.data(), A.stride(0));
+    else
+      return Impl::TeamVectorScaleInternal::invoke(member, A.extent(0), A.extent(1), alpha, A.data(), A.stride(0),
+                                                   A.stride(1));
   }
 };
 

--- a/blas/src/KokkosBlas1_set.hpp
+++ b/blas/src/KokkosBlas1_set.hpp
@@ -28,7 +28,10 @@ namespace KokkosBlas {
 struct SerialSet {
   template <typename ScalarType, typename AViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A) {
-    return Impl::SerialSetInternal::invoke(A.extent(0), A.extent(1), alpha, A.data(), A.stride_0(), A.stride_1());
+    if constexpr (AViewType::rank() == 1)
+      return Impl::SerialSetInternal::invoke(A.extent(0), alpha, A.data(), A.stride(0));
+    else
+      return Impl::SerialSetInternal::invoke(A.extent(0), A.extent(1), alpha, A.data(), A.stride(0), A.stride(1));
   }
 };
 
@@ -40,7 +43,10 @@ template <typename MemberType>
 struct TeamSet {
   template <typename ScalarType, typename AViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A) {
-    return Impl::TeamSetInternal::invoke(member, A.extent(0), A.extent(1), alpha, A.data(), A.stride_0(), A.stride_1());
+    if constexpr (AViewType::rank() == 1)
+      return Impl::TeamSetInternal::invoke(member, A.extent(0), alpha, A.data(), A.stride(0));
+    else
+      return Impl::TeamSetInternal::invoke(member, A.extent(0), A.extent(1), alpha, A.data(), A.stride(0), A.stride(1));
   }
 };
 
@@ -52,8 +58,11 @@ template <typename MemberType>
 struct TeamVectorSet {
   template <typename ScalarType, typename AViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A) {
-    return Impl::TeamVectorSetInternal::invoke(member, A.extent(0), A.extent(1), alpha, A.data(), A.stride_0(),
-                                               A.stride_1());
+    if constexpr (AViewType::rank() == 1)
+      return Impl::TeamVectorSetInternal::invoke(member, A.extent(0), alpha, A.data(), A.stride(0));
+    else
+      return Impl::TeamVectorSetInternal::invoke(member, A.extent(0), A.extent(1), alpha, A.data(), A.stride(0),
+                                                 A.stride(1));
   }
 };
 


### PR DESCRIPTION
This is the initial fix for the illegal use of View::stride (and actually also View::extent going forward) reported in #2592 and #2591. I only worked on Serial on my Mac laptop. Let's see which other backends trigger stuff which fail in the testing. 