### PR TITLE
blas(dot): modernize `DotFunctor`

### DIFF
--- a/blas/impl/KokkosBlas1_dot_impl.hpp
+++ b/blas/impl/KokkosBlas1_dot_impl.hpp
@@ -30,7 +30,7 @@ namespace Impl {
 /// \tparam YVector Type of the second vector y; 1-D View
 /// \tparam SizeType Type of the row index used in the dot product.
 ///   For best performance, use int instead of size_t here.
-template <class execution_space, class AV, class XVector, class YVector, typename SizeType>
+template <class AV, class XVector, class YVector, typename SizeType>
 struct DotFunctor {
   typedef SizeType size_type;
   typedef typename AV::non_const_value_type avalue_type;
@@ -40,10 +40,9 @@ struct DotFunctor {
   XVector m_x;
   YVector m_y;
 
-  DotFunctor(const XVector& x, const YVector& y) : m_x(x), m_y(y) {}
-
-  void run(const char* label, const execution_space& space, AV result) {
-    Kokkos::RangePolicy<execution_space, size_type> policy(space, 0, m_x.extent(0));
+  template <typename Exec>
+  void run(const char* label, const Exec& exec, AV result) const {
+    Kokkos::RangePolicy<Exec, size_type> policy(exec, 0, m_x.extent(0));
     Kokkos::parallel_reduce(label, policy, *this, result);
   }
 

--- a/blas/impl/KokkosBlas1_dot_spec.hpp
+++ b/blas/impl/KokkosBlas1_dot_spec.hpp
@@ -227,11 +227,11 @@ struct Dot<execution_space, RV, XV, YV, 1, 1, false, KOKKOSKERNELS_IMPL_COMPILE_
 
     if (numElems < static_cast<size_type>(INT_MAX)) {
       typedef int index_type;
-      DotFunctor<execution_space, RV, XV, YV, index_type> f(X, Y);
+      DotFunctor<RV, XV, YV, index_type> f{X, Y};
       f.run("KokkosBlas::dot<1D>", space, R);
     } else {
       typedef int64_t index_type;
-      DotFunctor<execution_space, RV, XV, YV, index_type> f(X, Y);
+      DotFunctor<RV, XV, YV, index_type> f{X, Y};
       f.run("KokkosBlas::dot<1D>", space, R);
     }
     Kokkos::Profiling::popRegion();
@@ -289,11 +289,11 @@ struct DotSpecialAccumulator<execution_space, RV, XV, YV, KOKKOSKERNELS_IMPL_COM
 
     if (numElems < static_cast<size_type>(INT_MAX)) {
       typedef int index_type;
-      DotFunctor<execution_space, RV_Result, XV, YV, index_type> f(X, Y);
+      DotFunctor<RV_Result, XV, YV, index_type> f{X, Y};
       f.run("KokkosBlas::dot<1D>", space, R);
     } else {
       typedef int64_t index_type;
-      DotFunctor<execution_space, RV_Result, XV, YV, index_type> f(X, Y);
+      DotFunctor<RV_Result, XV, YV, index_type> f{X, Y};
       f.run("KokkosBlas::dot<1D>", space, R);
     }
     Kokkos::Profiling::popRegion();
@@ -347,11 +347,11 @@ struct Dot<execution_space, RV, XV, YV, X_Rank, Y_Rank, false, KOKKOSKERNELS_IMP
       auto Y0 = getFirstColumn(Y);
       if (numRows < static_cast<size_type>(INT_MAX)) {
         typedef int index_type;
-        DotFunctor<execution_space, decltype(R0), decltype(X0), decltype(Y0), index_type> f(X0, Y0);
+        DotFunctor<decltype(R0), decltype(X0), decltype(Y0), index_type> f{X0, Y0};
         f.run("KokkosBlas::dot<1D>", space, R0);
       } else {
         typedef int64_t index_type;
-        DotFunctor<execution_space, decltype(R0), decltype(X0), decltype(Y0), index_type> f(X0, Y0);
+        DotFunctor<decltype(R0), decltype(X0), decltype(Y0), index_type> f{X0, Y0};
         f.run("KokkosBlas::dot<1D>", space, R0);
       }
     } else {


### PR DESCRIPTION
This PR modernizes `KokkosBlas::Impl::DotFunctor`:
1. It's an aggregate, no need to explicitly define a constructor.
2. Remove `execution_space` from the `struct` template  arguments and move it to the template arguments of `run`.