### PR TITLE
Avoid using pointers with Kokkos::single

### DIFF
--- a/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
+++ b/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
@@ -335,12 +335,11 @@ class PointGaussSeidel {
         // if the current row size is larger than shared memory size,
         // than allocate l2 vector.
         if (row.size() > num_max_vals_in_l1) {
-          volatile nnz_scalar_t* tmp = NULL;
-          while (tmp == NULL) {
+          uintptr_t tmp = 0;
+          while (tmp == 0) {
             Kokkos::single(
                 Kokkos::PerThread(teamMember),
-                [&](volatile nnz_scalar_t*& memptr) { memptr = (volatile nnz_scalar_t*)(pool.allocate_chunk(ii)); },
-                tmp);
+                [&](uintptr_t& memptr) { memptr = reinterpret_cast<uintptr_t>(pool.allocate_chunk(ii)); }, tmp);
           }
           all_global_memory = (nnz_scalar_t*)tmp;
           l1_val_size       = num_max_vals_in_l1 * block_size;

--- a/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_compression.hpp
@@ -573,13 +573,11 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
       if (overall_num_unsuccess) {
         // then we allocate second level memory using memory pool.
         if (!l2_allocated) {
-          volatile nnz_lno_t *tmp = NULL;
-          while (tmp == NULL) {
+          uintptr_t tmp = 0;
+          while (tmp == 0) {
             Kokkos::single(
                 Kokkos::PerThread(teamMember),
-                [&](volatile nnz_lno_t *&memptr) {
-                  memptr = (volatile nnz_lno_t *)(memory_space.allocate_chunk(row_ind));
-                },
+                [&](uintptr_t &memptr) { memptr = reinterpret_cast<uintptr_t>(memory_space.allocate_chunk(row_ind)); },
                 tmp);
           }
           globally_used_hash_indices = (nnz_lno_t *)tmp;

--- a/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_symbolic.hpp
@@ -455,13 +455,12 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
         if (overall_num_unsuccess) {
           // printf("row:%d\n", row_index);
           if (!is_global_alloced) {
-            volatile nnz_lno_t *tmp = NULL;
-            size_t tid              = get_thread_id(row_index);
-            while (tmp == NULL) {
+            uintptr_t tmp = 0;
+            size_t tid    = get_thread_id(row_index);
+            while (tmp == 0) {
               Kokkos::single(
                   Kokkos::PerThread(teamMember),
-                  [&](volatile nnz_lno_t *&memptr) { memptr = (volatile nnz_lno_t *)(m_space.allocate_chunk(tid)); },
-                  tmp);
+                  [&](uintptr_t &memptr) { memptr = reinterpret_cast<uintptr_t>(m_space.allocate_chunk(tid)); }, tmp);
             }
             is_global_alloced = true;
 
@@ -1000,13 +999,12 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
         if (overall_num_unsuccess) {
           // printf("row:%d\n", row_index);
           if (!is_global_alloced) {
-            volatile nnz_lno_t *tmp = NULL;
-            size_t tid              = get_thread_id(row_index);
-            while (tmp == NULL) {
+            uintptr_t tmp = 0;
+            size_t tid    = get_thread_id(row_index);
+            while (tmp == 0) {
               Kokkos::single(
                   Kokkos::PerThread(teamMember),
-                  [&](volatile nnz_lno_t *&memptr) { memptr = (volatile nnz_lno_t *)(m_space.allocate_chunk(tid)); },
-                  tmp);
+                  [&](uintptr_t &memptr) { memptr = reinterpret_cast<uintptr_t>(m_space.allocate_chunk(tid)); }, tmp);
             }
             is_global_alloced = true;
 
@@ -2393,13 +2391,12 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
         if (overall_num_unsuccess) {
           // printf("row:%d\n", row_index);
           if (!is_global_alloced) {
-            volatile nnz_lno_t *tmp = NULL;
-            size_t tid              = get_thread_id(row_index);
-            while (tmp == NULL) {
+            uintptr_t tmp = 0;
+            size_t tid    = get_thread_id(row_index);
+            while (tmp == 0) {
               Kokkos::single(
                   Kokkos::PerThread(teamMember),
-                  [&](volatile nnz_lno_t *&memptr) { memptr = (volatile nnz_lno_t *)(m_space.allocate_chunk(tid)); },
-                  tmp);
+                  [&](uintptr_t &memptr) { memptr = reinterpret_cast<uintptr_t>(m_space.allocate_chunk(tid)); }, tmp);
             }
             is_global_alloced = true;
 

--- a/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_jacobi_sparseacc_impl.hpp
@@ -424,15 +424,13 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
           // TODO: HashmapAccumulator should encapsulate growing the linked
           // lists.
           if (global_memory_hash_size > thread_shmem_key_size) {
-            volatile nnz_lno_t *tmp = NULL;
-            size_t tid              = row_index;
+            uintptr_t tmp = 0;
+            size_t tid    = row_index;
 
-            while (tmp == NULL) {
+            while (tmp == 0) {
               Kokkos::single(
                   Kokkos::PerThread(teamMember),
-                  [&](volatile nnz_lno_t *&memptr) {
-                    memptr = (volatile nnz_lno_t *)(memory_space.allocate_chunk(tid));
-                  },
+                  [&](uintptr_t &memptr) { memptr = reinterpret_cast<uintptr_t>(memory_space.allocate_chunk(tid)); },
                   tmp);
             }
 
@@ -751,20 +749,19 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
       scalar_t *c_row_vals           = valuesC.data() + c_row_begin;
       nnz_lno_t *global_acc_row_keys = c_row;
       scalar_t *global_acc_row_vals  = c_row_vals;
-      volatile nnz_lno_t *tmp        = NULL;
+      uintptr_t tmp                  = 0;
 
       // Initialize hashmaps
       if (c_row_size > max_first_level_hash_size) {
-        while (tmp == NULL) {
+        while (tmp == 0) {
           Kokkos::single(
               Kokkos::PerTeam(teamMember),
-              [&](volatile nnz_lno_t *&memptr) {
-                memptr = (volatile nnz_lno_t *)(memory_space.allocate_chunk(row_index));
-              },
+              [&](uintptr_t &memptr) { memptr = reinterpret_cast<uintptr_t>(memory_space.allocate_chunk(row_index)); },
               tmp);
         }
         global_acc_row_keys = (nnz_lno_t *)(tmp);
-        global_acc_row_vals = KokkosKernels::Impl::alignPtrTo<scalar_t>(tmp + pow2_hash_size);
+        global_acc_row_vals =
+            KokkosKernels::Impl::alignPtrTo<scalar_t>(reinterpret_cast<nnz_lno_t *>(tmp) + pow2_hash_size);
 
         nnz_lno_t num_threads = pow2_hash_size / vector_size;
         Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, num_threads), [&](nnz_lno_t teamind) {
@@ -1013,7 +1010,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
 
       teamMember.team_barrier();
 
-      if (tmp != NULL) {
+      if (tmp != 0) {
         for (nnz_lno_t my_index = vector_shift; my_index < pow2_hash_size; my_index += bs) {
           nnz_lno_t my_b_col = global_acc_row_keys[my_index];
           if (my_b_col != init_value) {


### PR DESCRIPTION
oneAPI 2025.0.5 became the default compiler for `Aurora`. 

Unfortunately, it can't deal with pointers in `sycl::select_from_group` which ends up being called for `Kokkos::single` with a scalar input. `Kokkos Kernels` only checks that the value returned after calling `Kokkos::single` is distributed after `allocate_chunk` is called. Since, we never really care about the dereferenced value, we might as well just `reinterpret_cast` to `uintptr_t` instead. This is also the reason why using a pointer to `volatile` should never be necessary.