### PR TITLE
Workflows: removing rocm 5.6.1 from at2

### DIFF
--- a/.github/workflows/at2.yml
+++ b/.github/workflows/at2.yml
@@ -22,10 +22,6 @@ env:
   KOKKOS_VERSION: 4.6.00
 
 jobs:
-  mi210:
-    uses: ./.github/workflows/mi210.yml
-    with:
-      kokkos_version: 4.6.00
   h100:
     uses: ./.github/workflows/h100.yml
     with:


### PR DESCRIPTION
This older rocm toolchain is very slow compared to the new rocm 6.2.1 so it is disabled in favor of that newer version.