### PR TITLE
Lapack - SVD: Unifying SVector layout to LayoutLeft

### DIFF
--- a/docs/source/API/lapack/gesvd.rst
+++ b/docs/source/API/lapack/gesvd.rst
@@ -53,6 +53,7 @@ Type Requirements
 - the vector of singular values has the following requirements:
 
   - ``Kokkos::is_view_v<SVector> && SVector::rank() == 1 && Kokkos::SpaceAccessibility<ExecutionSpace, typename SVector::memory_space>::accessible``
+  - ``std::is_same_v<typename SVector::array_layout, Kokkos::LayoutStride> && S.span_is_contiguous()`` only contiguous strided spans are allowed.
 
 .. note::
 

--- a/lapack/src/KokkosLapack_svd.hpp
+++ b/lapack/src/KokkosLapack_svd.hpp
@@ -162,17 +162,25 @@ void svd(const ExecutionSpace& space, const char jobu[], const char jobvt[], con
 #if defined(KOKKOSKERNELS_ENABLE_TPL_CUSOLVER)
   if (std::is_same_v<ExecutionSpace, Kokkos::Cuda> && (A.extent(0) < A.extent(1))) {
     throw std::runtime_error(
-        "CUSOLVER does not support SVD for matrices with more columns "
-        "than rows, you can transpose you matrix first then compute "
-        "SVD of that transpose: At=VSUt, and swap the output U and Vt"
-        " and transpose them to recover the desired SVD.");
+        "KokkosLapack::svd: CUSOLVER does not support SVD for matrices"
+        " with more columns than rows, you can transpose you matrix first"
+        " then compute SVD of that transpose: At=VSUt, and swap the output"
+        " U and Vt and transpose them to recover the desired SVD.");
   }
 #endif
+
+  // Do some more checks on SVector before picking a unique layout for it
+  // as it is a rank-1 view.
+  if constexpr (std::is_same_v<typename SVector::array_layout, Kokkos::LayoutStride>) {
+    if(!S.span_is_contiguous()) {
+      throw std::runtime_error("KokkosLapack::svd: S does not have a contiguous span.");
+    }
+  }
 
   using AMatrix_Internal = Kokkos::View<typename AMatrix::non_const_value_type**, typename AMatrix::array_layout,
                                         typename AMatrix::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
-  using SVector_Internal = Kokkos::View<typename SVector::non_const_value_type*, typename SVector::array_layout,
+  using SVector_Internal = Kokkos::View<typename SVector::non_const_value_type*, Kokkos::LayoutLeft,
                                         typename SVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
   using UMatrix_Internal = Kokkos::View<typename UMatrix::non_const_value_type**, typename UMatrix::array_layout,

--- a/lapack/src/KokkosLapack_svd.hpp
+++ b/lapack/src/KokkosLapack_svd.hpp
@@ -172,7 +172,7 @@ void svd(const ExecutionSpace& space, const char jobu[], const char jobvt[], con
   // Do some more checks on SVector before picking a unique layout for it
   // as it is a rank-1 view.
   if constexpr (std::is_same_v<typename SVector::array_layout, Kokkos::LayoutStride>) {
-    if(!S.span_is_contiguous()) {
+    if (!S.span_is_contiguous()) {
       throw std::runtime_error("KokkosLapack::svd: S does not have a contiguous span.");
     }
   }

--- a/lapack/tpls/KokkosLapack_svd_tpl_spec_avail.hpp
+++ b/lapack/tpls/KokkosLapack_svd_tpl_spec_avail.hpp
@@ -33,7 +33,7 @@ struct svd_tpl_spec_avail {
       EXECSPACE,                                                                                                 \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                               \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                     \
-      Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, LAYOUT, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>, \
+		   Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                     \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                               \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                     \
@@ -72,7 +72,7 @@ KOKKOSLAPACK_SVD_TPL_SPEC_AVAIL_LAPACK(Kokkos::complex<double>, Kokkos::LayoutLe
   struct svd_tpl_spec_avail<                                                                                           \
       Kokkos::Cuda,                                                                                                    \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-      Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,             \
+      Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                                           \
@@ -100,7 +100,7 @@ KOKKOSLAPACK_SVD_TPL_SPEC_AVAIL_CUSOLVER(Kokkos::complex<double>, Kokkos::Layout
   struct svd_tpl_spec_avail<                                                                                          \
       Kokkos::HIP,                                                                                                    \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-      Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>,             \
+      Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::HIP, MEMSPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>,                                           \

--- a/lapack/tpls/KokkosLapack_svd_tpl_spec_avail.hpp
+++ b/lapack/tpls/KokkosLapack_svd_tpl_spec_avail.hpp
@@ -27,19 +27,19 @@ struct svd_tpl_spec_avail {
 
 // LAPACK
 #if defined(KOKKOSKERNELS_ENABLE_TPL_LAPACK) || defined(KOKKOSKERNELS_ENABLE_TPL_MKL)
-#define KOKKOSLAPACK_SVD_TPL_SPEC_AVAIL_LAPACK(SCALAR, LAYOUT, EXECSPACE)                                        \
-  template <>                                                                                                    \
-  struct svd_tpl_spec_avail<                                                                                     \
-      EXECSPACE,                                                                                                 \
-      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                               \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                     \
-		   Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>, \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                     \
-      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                               \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                     \
-      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                               \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                                                   \
-    enum : bool { value = true };                                                                                \
+#define KOKKOSLAPACK_SVD_TPL_SPEC_AVAIL_LAPACK(SCALAR, LAYOUT, EXECSPACE)                                  \
+  template <>                                                                                              \
+  struct svd_tpl_spec_avail<                                                                               \
+      EXECSPACE,                                                                                           \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                         \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                               \
+      Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                             \
+                   Kokkos::Device<EXECSPACE, Kokkos::HostSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                         \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                               \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                         \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                                             \
+    enum : bool { value = true };                                                                          \
   };
 
 #if defined(KOKKOS_ENABLE_SERIAL)

--- a/lapack/tpls/KokkosLapack_svd_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_svd_tpl_spec_decl.hpp
@@ -123,8 +123,8 @@ void lapackSvdWrapper(const ExecutionSpace& /* space */, const char jobu[], cons
     using AMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                      \
                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
     using SVector =                                                                                                    \
-        Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,    \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                         \
+        Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                                       \
+                     Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;          \
     using UMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                      \
                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
     using VMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                      \
@@ -247,8 +247,8 @@ void mklSvdWrapper(const ExecutionSpace& /* space */, const char jobu[], const c
     using AMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                      \
                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
     using SVector =                                                                                                    \
-        Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,    \
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                         \
+        Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                                       \
+                     Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;          \
     using UMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                      \
                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
     using VMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                      \
@@ -362,45 +362,45 @@ void cusolverSvdWrapper(const ExecutionSpace& space, const char jobu[], const ch
   KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnSetStream(s.handle, NULL));
 }
 
-#define KOKKOSLAPACK_SVD_CUSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                           \
-  template <>                                                                                                          \
-  struct SVD<Kokkos::Cuda,                                                                                             \
-             Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                   \
-                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
-             Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,     \
-                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
-             Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                   \
-                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
-             Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                   \
-                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
-             true,                                                                                                     \
-             svd_eti_spec_avail<                                                                                       \
-                 Kokkos::Cuda,                                                                                         \
-                 Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                               \
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
-                 Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, \
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
-                 Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                               \
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
-                 Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                               \
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                                      \
-    using AMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                            \
-                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
-    using SVector = Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                                       \
-                                 Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;    \
-    using UMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                            \
-                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
-    using VMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                            \
-                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
-                                                                                                                       \
-    static void svd(const Kokkos::Cuda& space, const char jobu[], const char jobvt[], const AMatrix& A,                \
-                    const SVector& S, const UMatrix& U, const VMatrix& Vt) {                                           \
-      Kokkos::Profiling::pushRegion("KokkosLapack::svd[TPL_CUSOLVER," #SCALAR "]");                                    \
-      svd_print_specialization<Kokkos::Cuda, AMatrix, SVector, UMatrix, VMatrix>();                                    \
-                                                                                                                       \
-      cusolverSvdWrapper(space, jobu, jobvt, A, S, U, Vt);                                                             \
-      Kokkos::Profiling::popRegion();                                                                                  \
-    }                                                                                                                  \
+#define KOKKOSLAPACK_SVD_CUSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                        \
+  template <>                                                                                                       \
+  struct SVD<Kokkos::Cuda,                                                                                          \
+             Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                \
+                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                 \
+             Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                               \
+                          Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,        \
+             Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                \
+                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                 \
+             Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                \
+                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                 \
+             true,                                                                                                  \
+             svd_eti_spec_avail<                                                                                    \
+                 Kokkos::Cuda,                                                                                      \
+                 Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                            \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                             \
+                 Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                           \
+                              Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,    \
+                 Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                            \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                             \
+                 Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                            \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                                   \
+    using AMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
+                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                          \
+    using SVector = Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                        \
+                                 Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
+    using UMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
+                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                          \
+    using VMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
+                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                          \
+                                                                                                                    \
+    static void svd(const Kokkos::Cuda& space, const char jobu[], const char jobvt[], const AMatrix& A,             \
+                    const SVector& S, const UMatrix& U, const VMatrix& Vt) {                                        \
+      Kokkos::Profiling::pushRegion("KokkosLapack::svd[TPL_CUSOLVER," #SCALAR "]");                                 \
+      svd_print_specialization<Kokkos::Cuda, AMatrix, SVector, UMatrix, VMatrix>();                                 \
+                                                                                                                    \
+      cusolverSvdWrapper(space, jobu, jobvt, A, S, U, Vt);                                                          \
+      Kokkos::Profiling::popRegion();                                                                               \
+    }                                                                                                               \
   };
 
 KOKKOSLAPACK_SVD_CUSOLVER(float, Kokkos::LayoutLeft, Kokkos::CudaSpace)
@@ -504,7 +504,7 @@ void rocsolverSvdWrapper(const ExecutionSpace& space, const char jobu[], const c
   struct SVD<                                                                                                          \
       Kokkos::HIP,                                                                                                     \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-      Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,             \
+      Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
@@ -513,15 +513,15 @@ void rocsolverSvdWrapper(const ExecutionSpace& space, const char jobu[], const c
           Kokkos::HIP,                                                                                                 \
           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                                       \
                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                       \
-          Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,         \
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                       \
+          Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                                     \
+                       Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,               \
           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                                       \
                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                       \
           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                                       \
                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                                             \
     using AMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                             \
                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
-    using SVector = Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                                       \
+    using SVector = Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                           \
                                  Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;     \
     using UMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                             \
                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \

--- a/lapack/tpls/KokkosLapack_svd_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_svd_tpl_spec_decl.hpp
@@ -103,7 +103,7 @@ void lapackSvdWrapper(const ExecutionSpace& /* space */, const char jobu[], cons
   struct SVD<EXEC_SPACE,                                                                                               \
              Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                             \
                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
-             Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, LAYOUT,                                              \
+             Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                                  \
                           Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
              Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                             \
                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
@@ -114,7 +114,7 @@ void lapackSvdWrapper(const ExecutionSpace& /* space */, const char jobu[], cons
                  EXEC_SPACE,                                                                                           \
                  Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                         \
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
-                 Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, LAYOUT,                                          \
+                 Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                              \
                               Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
                  Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                         \
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
@@ -123,7 +123,7 @@ void lapackSvdWrapper(const ExecutionSpace& /* space */, const char jobu[], cons
     using AMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                      \
                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
     using SVector =                                                                                                    \
-        Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,    \
+        Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,    \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                         \
     using UMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                      \
                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
@@ -227,7 +227,7 @@ void mklSvdWrapper(const ExecutionSpace& /* space */, const char jobu[], const c
   struct SVD<EXEC_SPACE,                                                                                               \
              Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                             \
                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
-             Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, LAYOUT,                                              \
+             Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                                  \
                           Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
              Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                             \
                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
@@ -238,7 +238,7 @@ void mklSvdWrapper(const ExecutionSpace& /* space */, const char jobu[], const c
                  EXEC_SPACE,                                                                                           \
                  Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                         \
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
-                 Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, LAYOUT,                                          \
+                 Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                              \
                               Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
                  Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                         \
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
@@ -247,7 +247,7 @@ void mklSvdWrapper(const ExecutionSpace& /* space */, const char jobu[], const c
     using AMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                      \
                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
     using SVector =                                                                                                    \
-        Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,    \
+        Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,    \
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                                         \
     using UMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                      \
                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
@@ -367,7 +367,7 @@ void cusolverSvdWrapper(const ExecutionSpace& space, const char jobu[], const ch
   struct SVD<Kokkos::Cuda,                                                                                             \
              Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                   \
                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
-             Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,     \
+             Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,     \
                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
              Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                   \
                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
@@ -378,7 +378,7 @@ void cusolverSvdWrapper(const ExecutionSpace& space, const char jobu[], const ch
                  Kokkos::Cuda,                                                                                         \
                  Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                               \
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
-                 Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, \
+                 Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, \
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
                  Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                               \
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
@@ -386,7 +386,7 @@ void cusolverSvdWrapper(const ExecutionSpace& space, const char jobu[], const ch
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                                      \
     using AMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                            \
                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
-    using SVector = Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, LAYOUT,                                       \
+    using SVector = Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                                       \
                                  Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;    \
     using UMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                            \
                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
@@ -504,7 +504,7 @@ void rocsolverSvdWrapper(const ExecutionSpace& space, const char jobu[], const c
   struct SVD<                                                                                                          \
       Kokkos::HIP,                                                                                                     \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-      Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,             \
+      Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,             \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
@@ -513,7 +513,7 @@ void rocsolverSvdWrapper(const ExecutionSpace& space, const char jobu[], const c
           Kokkos::HIP,                                                                                                 \
           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                                       \
                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                       \
-          Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,         \
+          Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,         \
                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                       \
           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                                       \
                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                       \
@@ -521,7 +521,7 @@ void rocsolverSvdWrapper(const ExecutionSpace& space, const char jobu[], const c
                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                                             \
     using AMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                             \
                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
-    using SVector = Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, LAYOUT,                                       \
+    using SVector = Kokkos::View<Kokkos::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                                       \
                                  Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;     \
     using UMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                             \
                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \


### PR DESCRIPTION
This reduces ETI and allows users to use any valid layout and still hit the ETI target.