### PR TITLE
Fix team Gemm quick return

### DIFF
--- a/batched/dense/impl/KokkosBatched_Gemm_Team_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemm_Team_Impl.hpp
@@ -48,7 +48,7 @@ struct TeamGemm<MemberType, Trans::NoTranspose, Trans::NoTranspose, ArgAlgo> {
 
     // Quick return if possible
     const int m = C_extent_0, n = C_extent_1, k = A_extent_1;
-    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+    if (m == 0 || n == 0 || k == 0 || (alpha == ScalarType(0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::NoTranspose, Trans::NoTranspose>(A, B, C);
     if (info) return info;
@@ -79,7 +79,7 @@ struct TeamGemm<MemberType, Trans::Transpose, Trans::NoTranspose, ArgAlgo> {
 
     // Quick return if possible
     const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
-    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+    if (m == 0 || n == 0 || k == 0 || (alpha == ScalarType(0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::Transpose, Trans::NoTranspose>(A, B, C);
     if (info) return info;
@@ -110,7 +110,7 @@ struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::NoTranspose, ArgAlgo> {
 
     // Quick return if possible
     const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
-    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+    if (m == 0 || n == 0 || k == 0 || (alpha == ScalarType(0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::ConjTranspose, Trans::NoTranspose>(A, B, C);
     if (info) return info;
@@ -141,7 +141,7 @@ struct TeamGemm<MemberType, Trans::NoTranspose, Trans::Transpose, ArgAlgo> {
 
     // Quick return if possible
     const int m = C_extent_0, n = C_extent_1, k = A_extent_1;
-    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+    if (m == 0 || n == 0 || k == 0 || (alpha == ScalarType(0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::NoTranspose, Trans::Transpose>(A, B, C);
     if (info) return info;
@@ -172,7 +172,7 @@ struct TeamGemm<MemberType, Trans::Transpose, Trans::Transpose, ArgAlgo> {
 
     // Quick return if possible
     const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
-    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+    if (m == 0 || n == 0 || k == 0 || (alpha == ScalarType(0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::Transpose, Trans::Transpose>(A, B, C);
     if (info) return info;
@@ -203,7 +203,7 @@ struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::Transpose, ArgAlgo> {
 
     // Quick return if possible
     const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
-    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+    if (m == 0 || n == 0 || k == 0 || (alpha == ScalarType(0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::ConjTranspose, Trans::Transpose>(A, B, C);
     if (info) return info;
@@ -234,7 +234,7 @@ struct TeamGemm<MemberType, Trans::NoTranspose, Trans::ConjTranspose, ArgAlgo> {
 
     // Quick return if possible
     const int m = C_extent_0, n = C_extent_1, k = A_extent_1;
-    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+    if (m == 0 || n == 0 || k == 0 || (alpha == ScalarType(0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::NoTranspose, Trans::ConjTranspose>(A, B, C);
     if (info) return info;
@@ -265,7 +265,7 @@ struct TeamGemm<MemberType, Trans::Transpose, Trans::ConjTranspose, ArgAlgo> {
 
     // Quick return if possible
     const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
-    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+    if (m == 0 || n == 0 || k == 0 || (alpha == ScalarType(0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::Transpose, Trans::ConjTranspose>(A, B, C);
     if (info) return info;
@@ -296,7 +296,7 @@ struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::ConjTranspose, ArgAlgo>
 
     // Quick return if possible
     const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
-    if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+    if (m == 0 || n == 0 || k == 0 || (alpha == ScalarType(0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::ConjTranspose, Trans::ConjTranspose>(A, B, C);
     if (info) return info;


### PR DESCRIPTION
This may fix #2622

Previously, quick return condition was incorrect for `k==0` case. 