### PR TITLE
Improve TPL singletons

### DIFF
--- a/blas/tpls/KokkosBlas_Cuda_tpl.hpp
+++ b/blas/tpls/KokkosBlas_Cuda_tpl.hpp
@@ -13,6 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //@HEADER
+
 #ifndef KOKKOSBLAS_CUDA_TPL_HPP_
 #define KOKKOSBLAS_CUDA_TPL_HPP_
 
@@ -27,22 +28,18 @@ CudaBlasSingleton::CudaBlasSingleton() {
   if (stat != CUBLAS_STATUS_SUCCESS) Kokkos::abort("CUBLAS initialization failed\n");
 }
 
-CudaBlasSingleton& CudaBlasSingleton::singleton() {
-  std::unique_ptr<CudaBlasSingleton>& instance = get_instance();
-  if (!instance) {
-    instance = std::make_unique<CudaBlasSingleton>();
-    Kokkos::push_finalize_hook([&]() {
-      cublasDestroy(instance->handle);
-      instance.reset();
-    });
-  }
-  return *instance;
+CudaBlasSingleton::~CudaBlasSingleton() {
+  cublasDestroy(handle);
 }
 
-bool CudaBlasSingleton::is_initialized() { return get_instance() != nullptr; }
+CudaBlasSingleton& CudaBlasSingleton::singleton() {
+  return get_instance().get();
+}
 
-std::unique_ptr<CudaBlasSingleton>& CudaBlasSingleton::get_instance() {
-  static std::unique_ptr<CudaBlasSingleton> s;
+bool CudaBlasSingleton::is_initialized() { return get_instance(); }
+
+KokkosKernels::Impl::Singleton<CudaBlasSingleton>& CudaBlasSingleton::get_instance() {
+  static KokkosKernels::Impl::Singleton<CudaBlasSingleton> s;
   return s;
 }
 

--- a/blas/tpls/KokkosBlas_Magma_tpl.hpp
+++ b/blas/tpls/KokkosBlas_Magma_tpl.hpp
@@ -27,22 +27,18 @@ MagmaSingleton::MagmaSingleton() {
   if (stat != MAGMA_SUCCESS) Kokkos::abort("MAGMA initialization failed\n");
 }
 
-MagmaSingleton& MagmaSingleton::singleton() {
-  std::unique_ptr<MagmaSingleton>& instance = get_instance();
-  if (!instance) {
-    instance = std::make_unique<MagmaSingleton>();
-    Kokkos::push_finalize_hook([&]() {
-      magma_finalize();
-      instance.reset();
-    });
-  }
-  return *instance;
+MagmaSingleton::~MagmaSingleton() {
+  magma_finalize();
 }
 
-bool MagmaSingleton::is_initialized() { return get_instance() != nullptr; }
+MagmaSingleton& MagmaSingleton::singleton() {
+  return get_instance().get();
+}
 
-std::unique_ptr<MagmaSingleton>& MagmaSingleton::get_instance() {
-  static std::unique_ptr<MagmaSingleton> s;
+bool MagmaSingleton::is_initialized() { return get_instance(); }
+
+KokkosKernels::Impl::Singleton<MagmaSingleton>& MagmaSingleton::get_instance() {
+  static KokkosKernels::Impl::Singleton<MagmaSingleton> s;
   return s;
 }
 

--- a/blas/tpls/KokkosBlas_Rocm_tpl.hpp
+++ b/blas/tpls/KokkosBlas_Rocm_tpl.hpp
@@ -23,23 +23,16 @@ namespace KokkosBlas {
 namespace Impl {
 
 RocBlasSingleton::RocBlasSingleton() { KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocblas_create_handle(&handle)); }
+RocBlasSingleton::~RocBlasSingleton() { KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocblas_destroy_handle(handle)); }
 
 RocBlasSingleton& RocBlasSingleton::singleton() {
-  std::unique_ptr<RocBlasSingleton>& instance = get_instance();
-  if (!instance) {
-    instance = std::make_unique<RocBlasSingleton>();
-    Kokkos::push_finalize_hook([&]() {
-      KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocblas_destroy_handle(instance->handle));
-      instance.reset();
-    });
-  }
-  return *instance;
+  return get_instance().get();
 }
 
-bool RocBlasSingleton::is_initialized() { return get_instance() != nullptr; }
+bool RocBlasSingleton::is_initialized() { return get_instance(); }
 
-std::unique_ptr<RocBlasSingleton>& RocBlasSingleton::get_instance() {
-  static std::unique_ptr<RocBlasSingleton> s;
+KokkosKernels::Impl::Singleton<RocBlasSingleton>& RocBlasSingleton::get_instance() {
+  static KokkosKernels::Impl::Singleton<RocBlasSingleton> s;
   return s;
 }
 

--- a/blas/tpls/KokkosBlas_magma.hpp
+++ b/blas/tpls/KokkosBlas_magma.hpp
@@ -17,6 +17,8 @@
 #ifndef KOKKOSBLAS_MAGMA_HPP_
 #define KOKKOSBLAS_MAGMA_HPP_
 
+#include "KokkosKernels_Singleton.hpp"
+
 // If LAPACK TPL is enabled, it is preferred over magma's LAPACK
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MAGMA
 #include "magma_v2.h"
@@ -26,12 +28,13 @@ namespace Impl {
 
 struct MagmaSingleton {
   MagmaSingleton();
+  ~MagmaSingleton();
 
   static bool is_initialized();
   static MagmaSingleton& singleton();
 
  private:
-  static std::unique_ptr<MagmaSingleton>& get_instance();
+  static KokkosKernels::Impl::Singleton<MagmaSingleton>& get_instance();
 };
 
 }  // namespace Impl

--- a/blas/tpls/KokkosBlas_tpl_spec.hpp
+++ b/blas/tpls/KokkosBlas_tpl_spec.hpp
@@ -17,6 +17,8 @@
 #ifndef KOKKOSBLAS_TPL_SPEC_HPP_
 #define KOKKOSBLAS_TPL_SPEC_HPP_
 
+#include "KokkosKernels_Singleton.hpp"
+
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUBLAS
 #include "cuda_runtime.h"
 #include "cublas_v2.h"
@@ -28,12 +30,13 @@ struct CudaBlasSingleton {
   cublasHandle_t handle;
 
   CudaBlasSingleton();
+  ~CudaBlasSingleton();
 
   static bool is_initialized();
   static CudaBlasSingleton& singleton();
 
  private:
-  static std::unique_ptr<CudaBlasSingleton>& get_instance();
+  static KokkosKernels::Impl::Singleton<CudaBlasSingleton>& get_instance();
 };
 
 inline void cublas_internal_error_throw(cublasStatus_t cublasState, const char* name, const char* file,
@@ -115,13 +118,14 @@ struct RocBlasSingleton {
   rocblas_handle handle;
 
   RocBlasSingleton();
+  ~RocBlasSingleton();
 
   static bool is_initialized();
 
   static RocBlasSingleton& singleton();
 
  private:
-  static std::unique_ptr<RocBlasSingleton>& get_instance();
+  static KokkosKernels::Impl::Singleton<RocBlasSingleton>& get_instance();
 };
 
 inline void rocblas_internal_error_throw(rocblas_status rocblasState, const char* name, const char* file,

--- a/common/src/KokkosKernels_Singleton.hpp
+++ b/common/src/KokkosKernels_Singleton.hpp
@@ -1,0 +1,59 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOSKERNELS_SINGLETON_HPP
+#define KOKKOSKERNELS_SINGLETON_HPP
+
+#include <Kokkos_Core.hpp>
+
+namespace KokkosKernels {
+namespace Impl { 
+
+// Singleton structure for a default-constructible type.
+// If initialized, the object will be destructed only during Kokkos::finalize.
+// This is safe to use as a global/static variable type.
+//   This is unlike std::unique_ptr, whose destructor frees the object but doesn't
+//   set its internal pointer to null. This can cause a double-free error when Kokkos::finalize
+//   tries to free the same object later.
+template<typename T>
+struct Singleton
+{
+  void init() {
+    if(!ptr) {
+      ptr = new T();
+      Kokkos::push_finalize_hook([this]() {
+        delete this->ptr;
+        this->ptr = nullptr;
+      });
+    }
+  }
+
+  operator bool() const {
+    return ptr != nullptr;
+  }
+
+  T& get() {
+    init();
+    return *ptr;
+  }
+
+  T* ptr = nullptr;
+};
+
+}
+}
+
+#endif

--- a/common/unit_test/CMakeLists.txt
+++ b/common/unit_test/CMakeLists.txt
@@ -105,3 +105,10 @@ KOKKOSKERNELS_ADD_UNIT_TEST(
   COMPONENTS common
 )
 
+# Testing singletons with atexit(Kokkos::finalize)
+# which is also not backend specific
+KOKKOSKERNELS_ADD_UNIT_TEST(
+  common_atexit_finalize
+  SOURCES Test_Common_atexit_finalize.cpp
+  COMPONENTS common
+)

--- a/common/unit_test/Test_Common_EagerInitialize.cpp
+++ b/common/unit_test/Test_Common_EagerInitialize.cpp
@@ -14,9 +14,6 @@
 //
 //@HEADER
 
-#ifndef KK_EAGERINIT_TEST_HPP
-#define KK_EAGERINIT_TEST_HPP
-
 #include <iostream>
 #include "Kokkos_Core.hpp"
 #include "KokkosKernels_config.h"
@@ -110,4 +107,3 @@ int main() {
   return 0;
 }
 
-#endif

--- a/common/unit_test/Test_Common_atexit_finalize.cpp
+++ b/common/unit_test/Test_Common_atexit_finalize.cpp
@@ -1,0 +1,31 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <iostream>
+#include <cstdlib>
+#include "Kokkos_Core.hpp"
+#include "KokkosKernels_config.h"
+#include "KokkosKernels_EagerInitialize.hpp"
+
+int main() {
+  Kokkos::initialize();
+  // Schedule Kokkos::finalize to run when the program exits.
+  std::atexit(Kokkos::finalize);
+  // Now initialize all TPL singletons.
+  // The test checks that program exits normally in this case.
+  KokkosKernels::eager_initialize();
+  return 0;
+}

--- a/lapack/tpls/KokkosLapack_Cuda_tpl.hpp
+++ b/lapack/tpls/KokkosLapack_Cuda_tpl.hpp
@@ -27,22 +27,18 @@ CudaLapackSingleton::CudaLapackSingleton() {
   if (stat != CUSOLVER_STATUS_SUCCESS) Kokkos::abort("CUSOLVER initialization failed\n");
 }
 
-CudaLapackSingleton& CudaLapackSingleton::singleton() {
-  std::unique_ptr<CudaLapackSingleton>& instance = get_instance();
-  if (!instance) {
-    instance = std::make_unique<CudaLapackSingleton>();
-    Kokkos::push_finalize_hook([&]() {
-      cusolverDnDestroy(instance->handle);
-      instance.reset();
-    });
-  }
-  return *instance;
+CudaLapackSingleton::~CudaLapackSingleton() {
+  cusolverDnDestroy(handle);
 }
 
-bool CudaLapackSingleton::is_initialized() { return get_instance() != nullptr; }
+CudaLapackSingleton& CudaLapackSingleton::singleton() {
+  return get_instance().get();
+}
 
-std::unique_ptr<CudaLapackSingleton>& CudaLapackSingleton::get_instance() {
-  static std::unique_ptr<CudaLapackSingleton> s;
+bool CudaLapackSingleton::is_initialized() { return get_instance(); }
+
+KokkosKernels::Impl::Singleton<CudaLapackSingleton>& CudaLapackSingleton::get_instance() {
+  static KokkosKernels::Impl::Singleton<CudaLapackSingleton> s;
   return s;
 }
 

--- a/lapack/tpls/KokkosLapack_Magma_tpl.hpp
+++ b/lapack/tpls/KokkosLapack_Magma_tpl.hpp
@@ -17,8 +17,13 @@
 #define KOKKOSLAPACK_MAGMA_TPL_HPP_
 
 #if defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA)
+
 #include <KokkosLapack_magma.hpp>
 
+// If BLAS is enabled, then we will only use the
+// KokkosBlas::Impl::MagmaSingleton. Don't redefine the KokkosLapack::
+// version here.
+#ifndef KOKKOSKERNELS_ENABLE_COMPONENT_BLAS
 namespace KokkosLapack {
 namespace Impl {
 
@@ -27,27 +32,25 @@ MagmaSingleton::MagmaSingleton() {
   if (stat != MAGMA_SUCCESS) Kokkos::abort("MAGMA initialization failed\n");
 }
 
-MagmaSingleton& MagmaSingleton::singleton() {
-  std::unique_ptr<MagmaSingleton>& instance = get_instance();
-  if (!instance) {
-    instance = std::make_unique<MagmaSingleton>();
-    Kokkos::push_finalize_hook([&]() {
-      magma_finalize();
-      instance.reset();
-    });
-  }
-  return *instance;
+MagmaSingleton::~MagmaSingleton() {
+  magma_finalize();
 }
 
-bool MagmaSingleton::is_initialized() { return get_instance() != nullptr; }
+MagmaSingleton& MagmaSingleton::singleton() {
+  return get_instance().get();
+}
 
-std::unique_ptr<MagmaSingleton>& MagmaSingleton::get_instance() {
-  static std::unique_ptr<MagmaSingleton> s;
+bool MagmaSingleton::is_initialized() { return get_instance(); }
+
+KokkosKernels::Impl::Singleton<MagmaSingleton>& MagmaSingleton::get_instance() {
+  static KokkosKernels::Impl::Singleton<MagmaSingleton> s;
   return s;
 }
 
 }  // namespace Impl
 }  // namespace KokkosLapack
+#endif
+
 #endif  // defined(KOKKOSKERNELS_ENABLE_TPL_MAGMA)
 
 #endif  // KOKKOSLAPACK_MAGMA_TPL_HPP_

--- a/lapack/tpls/KokkosLapack_cusolver.hpp
+++ b/lapack/tpls/KokkosLapack_cusolver.hpp
@@ -17,6 +17,8 @@
 #ifndef KOKKOSLAPACK_CUSOLVER_HPP_
 #define KOKKOSLAPACK_CUSOLVER_HPP_
 
+#include "KokkosKernels_Singleton.hpp"
+
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSOLVER
 #include <cusolverDn.h>
 
@@ -30,13 +32,14 @@ struct CudaLapackSingleton {
   cusolverDnHandle_t handle;
 
   CudaLapackSingleton();
+  ~CudaLapackSingleton();
 
   static CudaLapackSingleton& singleton();
 
   static bool is_initialized();
 
  private:
-  static std::unique_ptr<CudaLapackSingleton>& get_instance();
+  static KokkosKernels::Impl::Singleton<CudaLapackSingleton>& get_instance();
 };
 
 inline void cusolver_internal_error_throw(cusolverStatus_t cusolverStatus, const char* name, const char* file,

--- a/lapack/tpls/KokkosLapack_magma.hpp
+++ b/lapack/tpls/KokkosLapack_magma.hpp
@@ -17,8 +17,27 @@
 #ifndef KOKKOSLAPACK_MAGMA_HPP_
 #define KOKKOSLAPACK_MAGMA_HPP_
 
+#include <KokkosKernels_config.h>
+#include "KokkosKernels_Singleton.hpp"
+
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MAGMA
 #include "magma_v2.h"
+
+#ifdef KOKKOSKERNELS_ENABLE_COMPONENT_BLAS
+
+// If both BLAS and LAPACK components are enabled,
+// don't use two separate singletons for MAGMA
+// (both would try to call the same magma_init/magma_finalize).
+//
+// Instead use the KokkosBlas::Impl::MagmaSingleton for both.
+#include "KokkosBlas_magma.hpp"
+
+namespace KokkosLapack {
+namespace Impl {
+using KokkosBlas::Impl::MagmaSingleton;
+}
+}
+#else
 
 namespace KokkosLapack {
 namespace Impl {
@@ -28,17 +47,19 @@ namespace Impl {
 // included when using cusolverDn.
 struct MagmaSingleton {
   MagmaSingleton();
+  ~MagmaSingleton();
 
   static MagmaSingleton& singleton();
 
   static bool is_initialized();
 
  private:
-  static std::unique_ptr<MagmaSingleton>& get_instance();
+  static KokkosKernels::Impl::Singleton<MagmaSingleton>& get_instance();
 };
 
 }  // namespace Impl
 }  // namespace KokkosLapack
+#endif
 #endif
 
 #endif  // KOKKOSLAPACK_MAGMA_HPP_

--- a/sparse/tpls/KokkosKernels_tpl_handles_decl.hpp
+++ b/sparse/tpls/KokkosKernels_tpl_handles_decl.hpp
@@ -18,6 +18,7 @@
 #define KOKKOSKERNELS_TPL_HANDLES_DECL_HPP_
 
 #include "KokkosBlas_tpl_spec.hpp"
+#include "KokkosKernels_Singleton.hpp"
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 #include "KokkosSparse_Utils_cusparse.hpp"
@@ -29,12 +30,13 @@ struct CusparseSingleton {
   cusparseHandle_t cusparseHandle;
 
   CusparseSingleton();
+  ~CusparseSingleton();
 
   static bool is_initialized();
   static CusparseSingleton& singleton();
 
  private:
-  static std::unique_ptr<CusparseSingleton>& get_instance();
+  static KokkosKernels::Impl::Singleton<CusparseSingleton>& get_instance();
 };
 
 }  // namespace Impl
@@ -51,12 +53,13 @@ struct RocsparseSingleton {
   rocsparse_handle rocsparseHandle;
 
   RocsparseSingleton();
+  ~RocsparseSingleton();
 
   static bool is_initialized();
   static RocsparseSingleton& singleton();
 
  private:
-  static std::unique_ptr<RocsparseSingleton>& get_instance();
+  static KokkosKernels::Impl::Singleton<RocsparseSingleton>& get_instance();
 };
 
 }  // namespace Impl

--- a/sparse/tpls/KokkosKernels_tpl_handles_def.hpp
+++ b/sparse/tpls/KokkosKernels_tpl_handles_def.hpp
@@ -26,23 +26,16 @@ namespace KokkosKernels {
 namespace Impl {
 
 CusparseSingleton::CusparseSingleton() { KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseCreate(&cusparseHandle)); }
+CusparseSingleton::~CusparseSingleton() { KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseDestroy(cusparseHandle)); }
 
 CusparseSingleton& CusparseSingleton::singleton() {
-  std::unique_ptr<CusparseSingleton>& instance = get_instance();
-  if (!instance) {
-    instance = std::make_unique<CusparseSingleton>();
-    Kokkos::push_finalize_hook([&]() {
-      KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseDestroy(instance->cusparseHandle));
-      instance.reset();
-    });
-  }
-  return *instance;
+  return get_instance().get();
 }
 
-bool CusparseSingleton::is_initialized() { return get_instance() != nullptr; }
+bool CusparseSingleton::is_initialized() { return get_instance(); }
 
-std::unique_ptr<CusparseSingleton>& CusparseSingleton::get_instance() {
-  static std::unique_ptr<CusparseSingleton> s;
+KokkosKernels::Impl::Singleton<CusparseSingleton>& CusparseSingleton::get_instance() {
+  static KokkosKernels::Impl::Singleton<CusparseSingleton> s;
   return s;
 }
 
@@ -60,22 +53,18 @@ RocsparseSingleton::RocsparseSingleton() {
   KOKKOSSPARSE_IMPL_ROCSPARSE_SAFE_CALL(rocsparse_create_handle(&rocsparseHandle));
 }
 
-RocsparseSingleton& RocsparseSingleton::singleton() {
-  std::unique_ptr<RocsparseSingleton>& instance = get_instance();
-  if (!instance) {
-    instance = std::make_unique<RocsparseSingleton>();
-    Kokkos::push_finalize_hook([&]() {
-      KOKKOSSPARSE_IMPL_ROCSPARSE_SAFE_CALL(rocsparse_destroy_handle(instance->rocsparseHandle));
-      instance.reset();
-    });
-  }
-  return *instance;
+RocsparseSingleton::~RocsparseSingleton() {
+  KOKKOSSPARSE_IMPL_ROCSPARSE_SAFE_CALL(rocsparse_destroy_handle(rocsparseHandle));
 }
 
-bool RocsparseSingleton::is_initialized() { return get_instance() != nullptr; }
+RocsparseSingleton& RocsparseSingleton::singleton() {
+  return get_instance().get();
+}
 
-std::unique_ptr<RocsparseSingleton>& RocsparseSingleton::get_instance() {
-  static std::unique_ptr<RocsparseSingleton> s;
+bool RocsparseSingleton::is_initialized() { return get_instance(); }
+
+KokkosKernels::Impl::Singleton<RocsparseSingleton>& RocsparseSingleton::get_instance() {
+  static KokkosKernels::Impl::Singleton<RocsparseSingleton> s;
   return s;
 }
 


### PR DESCRIPTION
Add a simple smart-pointer class ``KokkosKernels::Impl::Singleton<T>`` which is kind of like ``std::unique_ptr``, except its object is freed by ``Kokkos::finalize`` instead of its destructor.

Compared to unique_ptr, this fixes a double-free bug in programs which called ``Kokkos::finalize`` as an atexit hook. In this situation the unique_ptr could be destroyed before Kokkos::finalize, so our Kokkos::finalize hook would try to free it again. This PR adds a test in common for this case.

This also reduces some duplicate code in the TPL singletons. The logic to check initialized, construct object and push finalize hook was the same in all of them. Now this is put in ``Singleton<T>::get()``.