### PR TITLE
Add certifi==2025.4.26 to docs `build_requirements.txt`

### DIFF
--- a/docs/build_requirements.txt
+++ b/docs/build_requirements.txt
@@ -190,3 +190,8 @@ typing_extensions==4.13.2 \
 urllib3==2.4.0 \
   --hash=sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466 \
   --hash=sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813
+
+# transitive requirement, automatically installed in GA but no hash provided
+# by requests package
+certifi==2025.4.26 \
+  --hash=sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3

--- a/docs/build_requirements.txt
+++ b/docs/build_requirements.txt
@@ -194,4 +194,5 @@ urllib3==2.4.0 \
 # transitive requirement, automatically installed in GA but no hash provided
 # by requests package
 certifi==2025.4.26 \
+  --hash=sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6 \
   --hash=sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3


### PR DESCRIPTION
certifi is required by requests==2.32.2, but requests does not provide a hash. This causes our --require-hashes to fail, but we don't catch it on github because certifi is pre-installed there.

Fix for https://github.com/kokkos/kokkos-kernels/issues/2600