### PR TITLE
Remove redundant `ADD_LIBRARY(Kokkos::kokkoskernels)`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,7 +358,6 @@ ELSE()
   IF (KOKKOSKERNELS_HAS_TRILINOS)
     #no linking commands required - tribits does this
   ELSE()
-    ADD_LIBRARY(Kokkos::kokkoskernels ALIAS kokkoskernels)
     # Address kokkos/kokkos-kernels#1749
     ADD_LIBRARY(KokkosKernels::kokkoskernels ALIAS kokkoskernels)
     # all_libs target is required for TriBITS-compliance


### PR DESCRIPTION
* CMakeLists.txt calls `KOKKOSKERNELS_ADD_LIBRARY(kokkoskernels)` and then `ADD_LIBRARY(Kokkos::kokkoskernels ALIAS kokkoskernels)`
* `KOKKOSKERNELS_ADD_LIBRARY` forwards to `KOKKOSKERNELS_INTERNAL_ADD_LIBRARY`
* `KOKKOSKERNELS_INTERNAL_ADD_LIBRARY` always calls `ADD_LIBRARY(Kokkos::kokkoskernels ALIAS kokkoskernels)`

Fix for #2631 