### PR TITLE
Warn about __KOKKOSBATCHED_PROMOTION__ deprecation

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -20,20 +20,21 @@
 
 // no experimental name space guard for trilinos
 
+#define KOKKOSBATCHED_IMPL_PROMOTION 1
+
 #if defined(KOKKOS_COMPILER_MSVC)
-#define KOKKOSBATCHED_IMPL_PROMOTION \
-  (__pragma(message("warning: __KOKKOSBATCHED_PROMOTION__ is deprecated and will be removed in a future version")) 1)
+#define __KOKKOSBATCHED_PROMOTION__                                                                                \
+  (__pragma(message("warning: __KOKKOSBATCHED_PROMOTION__ is deprecated and will be removed in a future version")) \
+       KOKKOSBATCHED_IMPL_PROMOTION)
 #elif defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
-#define KOKKOSBATCHED_IMPL_PROMOTION                                                                              \
+#define __KOKKOSBATCHED_PROMOTION__                                                                               \
   (__extension__({                                                                                                \
     _Pragma("GCC warning \"__KOKKOSBATCHED_PROMOTION__ is deprecated and will be removed in a future version\""); \
-    1;                                                                                                            \
+    KOKKOSBATCHED_IMPL_PROMOTION;                                                                                 \
   }))
 #else
-#define KOKKOSBATCHED_IMPL_PROMOTION 1  // no good way to deprecate?
+#define __KOKKOSBATCHED_PROMOTION__ KOKKOSBATCHED_IMPL_PROMOTION  // no good way to deprecate?
 #endif
-
-#define __KOKKOSBATCHED_PROMOTION__ KOKKOSBATCHED_IMPL_PROMOTION
 
 #include <iomanip>
 #include <random>


### PR DESCRIPTION
#2392 incorrectly printed the warning message when the replacement `KOKKOSBATCHED_IMPL_PROMOTION` was used, rather than the intended behavior of when the deprecated` `__KOKKOSBATCHED_PROMOTION__` was used.

The fact that no one complained probably means this wasn't actually used anywhere.