### PR TITLE
Use old Kokkos::StaticCrsGraph interface when deprecated code enabled

### DIFF
--- a/sparse/src/KokkosSparse_BsrMatrix.hpp
+++ b/sparse/src/KokkosSparse_BsrMatrix.hpp
@@ -393,7 +393,18 @@ class BsrMatrix {
   //! Copy constructor (shallow copy).
   template <typename SType, typename OType, class DType, class MTType, typename IType>
   explicit BsrMatrix(const BsrMatrix<SType, OType, DType, MTType, IType>& B)
-      : graph(B.graph), values(B.values), dev_config(B.dev_config), numCols_(B.numCols()), blockDim_(B.blockDim()) {}
+      :
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+        graph(B.graph.entries, B.graph.row_map),
+#else
+        graph(B.graph),
+#endif
+
+        values(B.values),
+        dev_config(B.dev_config),
+        numCols_(B.numCols()),
+        blockDim_(B.blockDim()) {
+  }
 
   /// \brief Construct with a graph that will be shared.
   ///

--- a/sparse/src/KokkosSparse_CrsMatrix.hpp
+++ b/sparse/src/KokkosSparse_CrsMatrix.hpp
@@ -412,7 +412,16 @@ class CrsMatrix {
   //! Copy constructor (shallow copy).
   template <typename InScalar, typename InOrdinal, class InDevice, class InMemTraits, typename InSizeType>
   KOKKOS_INLINE_FUNCTION CrsMatrix(const CrsMatrix<InScalar, InOrdinal, InDevice, InMemTraits, InSizeType>& B)
-      : graph(B.graph), values(B.values), numCols_(B.numCols()), dev_config(B.dev_config) {}
+      :
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+        graph(B.graph.entries, B.graph.row_map),
+#else
+        graph(B.graph),
+#endif
+        values(B.values),
+        numCols_(B.numCols()),
+        dev_config(B.dev_config) {
+  }
 
   //! Deep copy constructor (can cross spaces)
   template <typename InScalar, typename InOrdinal, typename InDevice, typename InMemTraits, typename InSizeType>
@@ -453,7 +462,15 @@ class CrsMatrix {
   CrsMatrix(const std::string& label,
             const StaticCrsGraph<InOrdinal, InLayout, InDevice, InMemTraits, InSizeType>& graph_,
             const OrdinalType& ncols)
-      : graph(graph_), values(label, graph_.entries.extent(0)), numCols_(ncols) {}
+      :
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+        graph(graph_.entries, graph_.row_map),
+#else
+        graph(graph_),
+#endif
+        values(label, graph_.entries.extent(0)),
+        numCols_(ncols) {
+  }
 
   /// \brief Constructor that accepts a a static graph, and values.
   ///
@@ -466,7 +483,16 @@ class CrsMatrix {
   template <typename InOrdinal, typename InLayout, typename InDevice, typename InMemTraits, typename InSizeType>
   CrsMatrix(const std::string&, const OrdinalType& ncols, const values_type& vals,
             const StaticCrsGraph<InOrdinal, InLayout, InDevice, InMemTraits, InSizeType>& graph_)
-      : graph(graph_), values(vals), numCols_(ncols) {}
+      :
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+        graph(graph_.entries, graph_.row_map),
+#else
+        graph(graph_),
+#endif
+
+        values(vals),
+        numCols_(ncols) {
+  }
 
   /// \brief Constructor that copies raw arrays of host data in
   ///   3-array CRS (compressed row storage) format.


### PR DESCRIPTION
Fix for https://github.com/kokkos/kokkos-kernels/issues/2661