### PR TITLE
Uses BLAS1 axpy execution space for internal deep_copy and fill operations

### DIFF
--- a/blas/impl/KokkosBlas1_axpby_unification_attempt_traits.hpp
+++ b/blas/impl/KokkosBlas1_axpby_unification_attempt_traits.hpp
@@ -754,8 +754,7 @@ size_t getStrideInCoefficient(T const& coeff) {
 // --------------------------------
 
 template <typename ExecSpace, class T_in, class T_out>
-static void populateRank1Stride1ViewWithScalarOrNonStrideView(const ExecSpace& exec, T_in const& coeff_in,
-                                                              T_out& coeff_out) {
+static void fill_rank1_view(const ExecSpace& exec, T_in const& coeff_in, T_out& coeff_out) {
   // ***********************************************************************
   // 'coeff_out' is assumed to be rank-1, of LayoutLeft or LayoutRight
   //
@@ -785,7 +784,7 @@ static void populateRank1Stride1ViewWithScalarOrNonStrideView(const ExecSpace& e
     // *********************************************************************
     if (coeff_out.extent(0) != coeff_in.extent(0)) {
       std::ostringstream msg;
-      msg << "In populateRank1Stride1ViewWithScalarOrNonStrideView()"
+      msg << "In fill_rank1_view()"
           << ": 'in' and 'out' should have the same extent(0)"
           << ", T_in = " << typeid(T_in).name() << ", coeff_in.label() = " << coeff_in.label()
           << ", coeff_in.extent(0) = " << coeff_in.extent(0) << ", T_out = " << typeid(T_out).name()
@@ -803,7 +802,7 @@ static void populateRank1Stride1ViewWithScalarOrNonStrideView(const ExecSpace& e
       Kokkos::deep_copy(exec, coeff_out, scalarValue);
     } else {
       std::ostringstream msg;
-      msg << "In populateRank1Stride1ViewWithScalarOrNonStrideView()"
+      msg << "In fill_rank1_view()"
           << ": scalar types 'in' and 'out' should be the same"
           << ", T_in = " << typeid(T_in).name() << ", ScalarInType = " << typeid(ScalarInType).name()
           << ", coeff_in.label() = " << coeff_in.label() << ", coeff_in.extent(0) = " << coeff_in.extent(0)
@@ -812,7 +811,7 @@ static void populateRank1Stride1ViewWithScalarOrNonStrideView(const ExecSpace& e
       KokkosKernels::Impl::throw_runtime_exception(msg.str());
     }
   }
-}  // populateRank1Stride1ViewWithScalarOrNonStrideView()
+}  // fill_rank1_view()
 
 }  // namespace Impl
 }  // namespace KokkosBlas

--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -14,8 +14,8 @@
 //
 //@HEADER
 
-#ifndef KOKKOSBLAS1_AXPBY_HPP_
-#define KOKKOSBLAS1_AXPBY_HPP_
+#ifndef KOKKOSBLAS1_AXPBY_HPP
+#define KOKKOSBLAS1_AXPBY_HPP
 
 #if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
 #include <iostream>
@@ -325,4 +325,4 @@ KOKKOS_FUNCTION void serial_axpy(const scalar_type alpha, const XMV X, YMV Y) {
 
 }  // namespace KokkosBlas
 
-#endif
+#endif  // KOKKOSBLAS1_AXPBY_HPP

--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -136,7 +136,7 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
       if constexpr (AxpbyTraits::atInputLayoutA_isStride) {
         Kokkos::deep_copy(exec_space, managed_a, a);
       } else {
-        Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(exec_space, a, managed_a);
+        Impl::fill_rank1_view(exec_space, a, managed_a);
       }
       internal_a = managed_a;
 
@@ -148,7 +148,7 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
         if constexpr (AxpbyTraits::atInputLayoutB_isStride) {
           Kokkos::deep_copy(exec_space, managed_b, b);
         } else {
-          Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(exec_space, b, managed_b);
+          Impl::fill_rank1_view(exec_space, b, managed_b);
         }
         internal_b = managed_b;
 
@@ -165,7 +165,7 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
         if constexpr (AxpbyTraits::atInputLayoutB_isStride) {
           Kokkos::deep_copy(exec_space, managed_b, b);
         } else {
-          Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(exec_space, b, managed_b);
+          Impl::fill_rank1_view(exec_space, b, managed_b);
         }
         internal_b = managed_b;
 
@@ -183,7 +183,7 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
       if constexpr (AxpbyTraits::atInputLayoutA_isStride) {
         Kokkos::deep_copy(exec_space, managed_a, a);
       } else {
-        Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(exec_space, a, managed_a);
+        Impl::fill_rank1_view(exec_space, a, managed_a);
       }
       internal_a = managed_a;
 
@@ -195,7 +195,7 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
         if constexpr (AxpbyTraits::atInputLayoutB_isStride) {
           Kokkos::deep_copy(exec_space, managed_b, b);
         } else {
-          Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(exec_space, b, managed_b);
+          Impl::fill_rank1_view(exec_space, b, managed_b);
         }
         internal_b = managed_b;
 
@@ -212,7 +212,7 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
         if constexpr (AxpbyTraits::atInputLayoutB_isStride) {
           Kokkos::deep_copy(exec_space, managed_b, b);
         } else {
-          Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(exec_space, b, managed_b);
+          Impl::fill_rank1_view(exec_space, b, managed_b);
         }
         internal_b = managed_b;
 

--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -136,7 +136,7 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
       if constexpr (AxpbyTraits::atInputLayoutA_isStride) {
         Kokkos::deep_copy(exec_space, managed_a, a);
       } else {
-        Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(a, managed_a);
+        Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(exec_space, a, managed_a);
       }
       internal_a = managed_a;
 
@@ -148,7 +148,7 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
         if constexpr (AxpbyTraits::atInputLayoutB_isStride) {
           Kokkos::deep_copy(exec_space, managed_b, b);
         } else {
-          Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(b, managed_b);
+          Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(exec_space, b, managed_b);
         }
         internal_b = managed_b;
 
@@ -165,7 +165,7 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
         if constexpr (AxpbyTraits::atInputLayoutB_isStride) {
           Kokkos::deep_copy(exec_space, managed_b, b);
         } else {
-          Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(b, managed_b);
+          Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(exec_space, b, managed_b);
         }
         internal_b = managed_b;
 
@@ -183,7 +183,7 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
       if constexpr (AxpbyTraits::atInputLayoutA_isStride) {
         Kokkos::deep_copy(exec_space, managed_a, a);
       } else {
-        Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(a, managed_a);
+        Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(exec_space, a, managed_a);
       }
       internal_a = managed_a;
 
@@ -195,7 +195,7 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
         if constexpr (AxpbyTraits::atInputLayoutB_isStride) {
           Kokkos::deep_copy(exec_space, managed_b, b);
         } else {
-          Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(b, managed_b);
+          Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(exec_space, b, managed_b);
         }
         internal_b = managed_b;
 
@@ -212,7 +212,7 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
         if constexpr (AxpbyTraits::atInputLayoutB_isStride) {
           Kokkos::deep_copy(exec_space, managed_b, b);
         } else {
-          Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(b, managed_b);
+          Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(exec_space, b, managed_b);
         }
         internal_b = managed_b;
 

--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -134,7 +134,7 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
       // ******************************************************************
       typename AxpbyTraits::InternalTypeA_managed managed_a("managed_a", layoutStrideA);
       if constexpr (AxpbyTraits::atInputLayoutA_isStride) {
-        Kokkos::deep_copy(managed_a, a);
+        Kokkos::deep_copy(exec_space, managed_a, a);
       } else {
         Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(a, managed_a);
       }
@@ -146,7 +146,7 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
         // ****************************************************************
         typename AxpbyTraits::InternalTypeB_managed managed_b("managed_b", layoutStrideB);
         if constexpr (AxpbyTraits::atInputLayoutB_isStride) {
-          Kokkos::deep_copy(managed_b, b);
+          Kokkos::deep_copy(exec_space, managed_b, b);
         } else {
           Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(b, managed_b);
         }
@@ -163,7 +163,7 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
         // ****************************************************************
         typename AxpbyTraits::InternalTypeB_managed managed_b("managed_b", numScalarsB);
         if constexpr (AxpbyTraits::atInputLayoutB_isStride) {
-          Kokkos::deep_copy(managed_b, b);
+          Kokkos::deep_copy(exec_space, managed_b, b);
         } else {
           Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(b, managed_b);
         }
@@ -181,7 +181,7 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
       // ******************************************************************
       typename AxpbyTraits::InternalTypeA_managed managed_a("managed_a", numScalarsA);
       if constexpr (AxpbyTraits::atInputLayoutA_isStride) {
-        Kokkos::deep_copy(managed_a, a);
+        Kokkos::deep_copy(exec_space, managed_a, a);
       } else {
         Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(a, managed_a);
       }
@@ -193,7 +193,7 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
         // ****************************************************************
         typename AxpbyTraits::InternalTypeB_managed managed_b("managed_b", layoutStrideB);
         if constexpr (AxpbyTraits::atInputLayoutB_isStride) {
-          Kokkos::deep_copy(managed_b, b);
+          Kokkos::deep_copy(exec_space, managed_b, b);
         } else {
           Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(b, managed_b);
         }
@@ -210,7 +210,7 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
         // ****************************************************************
         typename AxpbyTraits::InternalTypeB_managed managed_b("managed_b", numScalarsB);
         if constexpr (AxpbyTraits::atInputLayoutB_isStride) {
-          Kokkos::deep_copy(managed_b, b);
+          Kokkos::deep_copy(exec_space, managed_b, b);
         } else {
           Impl::populateRank1Stride1ViewWithScalarOrNonStrideView(b, managed_b);
         }


### PR DESCRIPTION
- [x] Merge #2662 first

Partial fix for https://github.com/kokkos/kokkos-kernels/issues/2434

* Uses the provided execution space for BLAS1 axpy for internal deep_copy and fill operations. Also rename `Impl::populateRank1Stride1ViewWithScalarOrNonStrideView`
