### PR TITLE
CrsMatrix / BsrMatrix: set row_block_offsets when using deprecated StaticCrsGraph

### DIFF
--- a/sparse/src/KokkosSparse_BsrMatrix.hpp
+++ b/sparse/src/KokkosSparse_BsrMatrix.hpp
@@ -404,6 +404,9 @@ class BsrMatrix {
         dev_config(B.dev_config),
         numCols_(B.numCols()),
         blockDim_(B.blockDim()) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+    graph.row_block_offsets = B.graph.row_block_offsets;
+#endif
   }
 
   /// \brief Construct with a graph that will be shared.

--- a/sparse/src/KokkosSparse_CrsMatrix.hpp
+++ b/sparse/src/KokkosSparse_CrsMatrix.hpp
@@ -421,6 +421,9 @@ class CrsMatrix {
         values(B.values),
         numCols_(B.numCols()),
         dev_config(B.dev_config) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+    graph.row_block_offsets = B.graph.row_block_offsets;
+#endif
   }
 
   //! Deep copy constructor (can cross spaces)


### PR DESCRIPTION
Potential fix for #2662 