### PR TITLE
Fix the behavior of extent(r) for r > rank in TeamGEMM

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -772,13 +772,13 @@ KOKKOS_INLINE_FUNCTION int get_extent_int(const ViewType &v, const int r) {
   static_assert(V_rank <= 2, "KokkosBatched: ViewType must have rank 0, 1 or 2.");
 
   if (r == 0) {
-    int V_extent_0 = V_rank == 0 ? 0 : v.extent_int(0);
+    int V_extent_0 = V_rank == 0 ? 1 : v.extent_int(0);
     return V_extent_0;
   } else if (r == 1) {
-    int V_extent_1 = V_rank == 0 ? 0 : V_rank == 1 ? 1 : v.extent_int(1);
+    int V_extent_1 = V_rank == 0 || V_rank == 1 ? 1 : v.extent_int(1);
     return V_extent_1;
   } else {
-    return -1;
+    return 1;
   }
 }
 

--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -775,7 +775,7 @@ KOKKOS_INLINE_FUNCTION int get_extent_int(const ViewType &v, const int r) {
     int V_extent_0 = V_rank == 0 ? 1 : v.extent_int(0);
     return V_extent_0;
   } else if (r == 1) {
-    int V_extent_1 = V_rank == 0 || V_rank == 1 ? 1 : v.extent_int(1);
+    int V_extent_1 = (V_rank == 0 || V_rank == 1) ? 1 : v.extent_int(1);
     return V_extent_1;
   } else {
     return 1;

--- a/batched/dense/impl/KokkosBatched_Gemm_Team_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemm_Team_Impl.hpp
@@ -47,8 +47,8 @@ struct TeamGemm<MemberType, Trans::NoTranspose, Trans::NoTranspose, ArgAlgo> {
     const std::size_t C_stride_0 = Impl::get_stride(C, 0), C_stride_1 = Impl::get_stride(C, 1);
 
     // Quick return if possible
-    const int m = C_extent_0, n = C_extent_1, k = A_extent_1;
-    if (m == 0 || n == 0 || k == 0 || (alpha == ScalarType(0) && beta == ScalarType(1))) return 0;
+    // const int m = C_extent_0, n = C_extent_1, k = A_extent_1;
+    // if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::NoTranspose, Trans::NoTranspose>(A, B, C);
     if (info) return info;
@@ -78,8 +78,8 @@ struct TeamGemm<MemberType, Trans::Transpose, Trans::NoTranspose, ArgAlgo> {
     const std::size_t C_stride_0 = Impl::get_stride(C, 0), C_stride_1 = Impl::get_stride(C, 1);
 
     // Quick return if possible
-    const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
-    if (m == 0 || n == 0 || k == 0 || (alpha == ScalarType(0) && beta == ScalarType(1))) return 0;
+    // const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
+    // if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::Transpose, Trans::NoTranspose>(A, B, C);
     if (info) return info;
@@ -109,8 +109,8 @@ struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::NoTranspose, ArgAlgo> {
     const std::size_t C_stride_0 = Impl::get_stride(C, 0), C_stride_1 = Impl::get_stride(C, 1);
 
     // Quick return if possible
-    const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
-    if (m == 0 || n == 0 || k == 0 || (alpha == ScalarType(0) && beta == ScalarType(1))) return 0;
+    // const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
+    // if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::ConjTranspose, Trans::NoTranspose>(A, B, C);
     if (info) return info;
@@ -140,8 +140,8 @@ struct TeamGemm<MemberType, Trans::NoTranspose, Trans::Transpose, ArgAlgo> {
     const std::size_t C_stride_0 = Impl::get_stride(C, 0), C_stride_1 = Impl::get_stride(C, 1);
 
     // Quick return if possible
-    const int m = C_extent_0, n = C_extent_1, k = A_extent_1;
-    if (m == 0 || n == 0 || k == 0 || (alpha == ScalarType(0) && beta == ScalarType(1))) return 0;
+    // const int m = C_extent_0, n = C_extent_1, k = A_extent_1;
+    // if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::NoTranspose, Trans::Transpose>(A, B, C);
     if (info) return info;
@@ -171,8 +171,8 @@ struct TeamGemm<MemberType, Trans::Transpose, Trans::Transpose, ArgAlgo> {
     const std::size_t C_stride_0 = Impl::get_stride(C, 0), C_stride_1 = Impl::get_stride(C, 1);
 
     // Quick return if possible
-    const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
-    if (m == 0 || n == 0 || k == 0 || (alpha == ScalarType(0) && beta == ScalarType(1))) return 0;
+    // const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
+    // if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::Transpose, Trans::Transpose>(A, B, C);
     if (info) return info;
@@ -202,8 +202,8 @@ struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::Transpose, ArgAlgo> {
     const std::size_t C_stride_0 = Impl::get_stride(C, 0), C_stride_1 = Impl::get_stride(C, 1);
 
     // Quick return if possible
-    const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
-    if (m == 0 || n == 0 || k == 0 || (alpha == ScalarType(0) && beta == ScalarType(1))) return 0;
+    // const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
+    // if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::ConjTranspose, Trans::Transpose>(A, B, C);
     if (info) return info;
@@ -233,8 +233,8 @@ struct TeamGemm<MemberType, Trans::NoTranspose, Trans::ConjTranspose, ArgAlgo> {
     const std::size_t C_stride_0 = Impl::get_stride(C, 0), C_stride_1 = Impl::get_stride(C, 1);
 
     // Quick return if possible
-    const int m = C_extent_0, n = C_extent_1, k = A_extent_1;
-    if (m == 0 || n == 0 || k == 0 || (alpha == ScalarType(0) && beta == ScalarType(1))) return 0;
+    // const int m = C_extent_0, n = C_extent_1, k = A_extent_1;
+    // if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::NoTranspose, Trans::ConjTranspose>(A, B, C);
     if (info) return info;
@@ -264,8 +264,8 @@ struct TeamGemm<MemberType, Trans::Transpose, Trans::ConjTranspose, ArgAlgo> {
     const std::size_t C_stride_0 = Impl::get_stride(C, 0), C_stride_1 = Impl::get_stride(C, 1);
 
     // Quick return if possible
-    const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
-    if (m == 0 || n == 0 || k == 0 || (alpha == ScalarType(0) && beta == ScalarType(1))) return 0;
+    // const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
+    // if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::Transpose, Trans::ConjTranspose>(A, B, C);
     if (info) return info;
@@ -295,8 +295,8 @@ struct TeamGemm<MemberType, Trans::ConjTranspose, Trans::ConjTranspose, ArgAlgo>
     const std::size_t C_stride_0 = Impl::get_stride(C, 0), C_stride_1 = Impl::get_stride(C, 1);
 
     // Quick return if possible
-    const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
-    if (m == 0 || n == 0 || k == 0 || (alpha == ScalarType(0) && beta == ScalarType(1))) return 0;
+    // const int m = C_extent_0, n = C_extent_1, k = A_extent_0;
+    // if (m == 0 || n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
 
     auto info = Impl::checkGemmInput<Trans::ConjTranspose, Trans::ConjTranspose>(A, B, C);
     if (info) return info;

--- a/batched/dense/impl/KokkosBatched_Gemm_Team_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemm_Team_Internal.hpp
@@ -62,6 +62,8 @@ KOKKOS_INLINE_FUNCTION int TeamGemmInternal<Algo::Gemm::Unblocked>::invoke(
     KokkosBlas::Impl::TeamScaleInternal::invoke(member, m, n, beta, C, cs0, cs1);
 
   if (alpha != ScalarType(0.0)) {
+    if (m <= 0 || n <= 0 || k <= 0) return 0;
+
     if (beta != one) member.team_barrier();
 
     // assume layout right for batched computation
@@ -98,6 +100,8 @@ KOKKOS_INLINE_FUNCTION int TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
     KokkosBlas::Impl::TeamScaleInternal::invoke(member, m, n, beta, C, cs0, cs1);
 
   if (alpha != ScalarType(0.0)) {
+    if (m <= 0 || n <= 0 || k <= 0) return 0;
+
     if (beta != one) member.team_barrier();
 
     ///


### PR DESCRIPTION
May partially resolve #2622 
After looking at the bahaviors of older versions, I found that
`extent(r)` for r > rank should return `1`

This PR fixes the behavior.