### PR TITLE
Update partition_space() call to match Kokkos core changes

### DIFF
--- a/sparse/unit_test/Test_Sparse_spmv.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv.hpp
@@ -1013,7 +1013,7 @@ void test_spmv_all_interfaces_light() {
   execution_space space;
   std::vector<execution_space> space_partitions;
   if (space.concurrency() > 1) {
-    space_partitions = Kokkos::Experimental::partition_space(space, 1, 1);
+    space_partitions = Kokkos::Experimental::partition_space(space, std::vector<int>(2, 1));
     space            = space_partitions[1];
   }
 


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos-kernels/issues/2679. Recent changes in Kokkos core (see https://github.com/kokkos/kokkos/pull/8114) altered the return type of `partition_space(space, 1, 1)` from `std::vector` to `std::array`. Change to calling `partition_space()` which takes a vector of weights, and has `std::vector` return type.