### PR TITLE
fix: constexpr condition to test long double complex type

### DIFF
--- a/common/src/Kokkos_ArithTraits.hpp
+++ b/common/src/Kokkos_ArithTraits.hpp
@@ -1087,7 +1087,7 @@ class ArithTraits<std::complex<RealFloatType>> {
 #ifdef KOKKOS_ENABLE_SYCL
   template <typename Dummy = RealFloatType>
   static bool isInf(const std::complex<Dummy>& x) {
-    if constexpr (std::is_same_v<Dummy, std::complex<long double>>) {
+    if constexpr (std::is_same_v<Dummy, long double>) {
       Kokkos::abort("isInf not available for std::complex<long double>!\n");
       return true;
     } else {
@@ -1106,7 +1106,7 @@ class ArithTraits<std::complex<RealFloatType>> {
 #ifdef KOKKOS_ENABLE_SYCL
   template <typename Dummy = RealFloatType>
   static bool isNan(const std::complex<Dummy>& x) {
-    if constexpr (std::is_same_v<Dummy, std::complex<long double>>) {
+    if constexpr (std::is_same_v<Dummy, long double>) {
       Kokkos::abort("isNan not available for std::complex<long double>!\n");
       return true;
     } else {


### PR DESCRIPTION
This PR aims at fixing the if constexpr condition to error out `std::complex<long double>` type for SYCL backend.