### PR TITLE
Batched - SVD: adding iteration limits

### DIFF
--- a/batched/dense/impl/KokkosBatched_SVD_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_SVD_Serial_Impl.hpp
@@ -25,7 +25,7 @@ namespace KokkosBatched {
 template <typename AViewType, typename UViewType, typename VViewType, typename SViewType, typename WViewType>
 KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(SVD_USV_Tag, const AViewType &A, const UViewType &U,
                                              const SViewType &sigma, const VViewType &Vt, const WViewType &work,
-                                             typename AViewType::const_value_type tol) {
+                                             typename AViewType::const_value_type tol, int max_iters) {
   static_assert(Kokkos::is_view_v<AViewType> && AViewType::rank == 2, "SVD: A must be a rank-2 view");
   static_assert(Kokkos::is_view_v<UViewType> && UViewType::rank == 2, "SVD: U must be a rank-2 view");
   static_assert(Kokkos::is_view_v<SViewType> && SViewType::rank == 1, "SVD: s must be a rank-1 view");
@@ -36,13 +36,13 @@ KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(SVD_USV_Tag, const AViewType &A, co
   using value_type = typename AViewType::non_const_value_type;
   return KokkosBatched::SerialSVDInternal::invoke<value_type>(
       A.extent(0), A.extent(1), A.data(), A.stride(0), A.stride(1), U.data(), U.stride(0), U.stride(1), Vt.data(),
-      Vt.stride(0), Vt.stride(1), sigma.data(), sigma.stride(0), work.data(), tol);
+      Vt.stride(0), Vt.stride(1), sigma.data(), sigma.stride(0), work.data(), tol, max_iters);
 }
 
 // Version which computes only singular values
 template <typename AViewType, typename SViewType, typename WViewType>
 KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(SVD_S_Tag, const AViewType &A, const SViewType &sigma,
-                                             const WViewType &work, typename AViewType::const_value_type tol) {
+                                             const WViewType &work, typename AViewType::const_value_type tol, int max_iters) {
   static_assert(Kokkos::is_view_v<AViewType> && AViewType::rank == 2, "SVD: A must be a rank-2 view");
   static_assert(Kokkos::is_view_v<SViewType> && SViewType::rank == 1, "SVD: s must be a rank-1 view");
   static_assert(Kokkos::is_view_v<WViewType> && WViewType::rank == 1, "SVD: W must be a rank-1 view");
@@ -51,7 +51,7 @@ KOKKOS_INLINE_FUNCTION int SerialSVD::invoke(SVD_S_Tag, const AViewType &A, cons
   using value_type = typename AViewType::non_const_value_type;
   return KokkosBatched::SerialSVDInternal::invoke<value_type>(A.extent(0), A.extent(1), A.data(), A.stride(0),
                                                               A.stride(1), nullptr, 0, 0, nullptr, 0, 0, sigma.data(),
-                                                              sigma.stride(0), work.data(), tol);
+                                                              sigma.stride(0), work.data(), tol, max_iters);
 }
 
 }  // namespace KokkosBatched

--- a/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
@@ -212,14 +212,14 @@ struct SerialSVDInternal {
   // U and Vt to maintain the product U*B*Vt. At the end, the singular values
   // are copied to sigma.
   template <typename value_type>
-  KOKKOS_INLINE_FUNCTION static void bidiSVD(int m, int n, value_type* B, int Bs0, int Bs1, value_type* U, int Us0,
+  KOKKOS_INLINE_FUNCTION static int bidiSVD(int m, int n, value_type* B, int Bs0, int Bs1, value_type* U, int Us0,
                                              int Us1, value_type* Vt, int Vts0, int Vts1, value_type* sigma, int ss,
-                                             const value_type& tol) {
+                                             const value_type& tol, int max_iters) {
     using KAT            = Kokkos::ArithTraits<value_type>;
     const value_type eps = Kokkos::ArithTraits<value_type>::epsilon();
     int p                = 0;
     int q                = 0;
-    while (true) {
+    for(int iters = 0; iters < max_iters; ++iters) {
       // Zero out tiny superdiagonal entries
       for (int i = 0; i < n - 1; i++) {
         if (Kokkos::abs(SVDIND(B, i, i + 1)) <
@@ -271,10 +271,16 @@ struct SerialSVDInternal {
       }
       // B22 is nsub * nsub, Usub is m * nsub, and Vtsub is nsub * n
       svdStep(Bsub, Usub, Vtsub, m, n, nsub, Bs0, Bs1, Us0, Us1, Vts0, Vts1);
+
+      if( iters++ == max_iters ) {
+        return -1;
+      }
     }
     for (int i = 0; i < n; i++) {
       sigma[i * ss] = SVDIND(B, i, i);
     }
+
+    return 0;
   }
 
   // Convert SVD into conventional form: singular values positive and in
@@ -322,7 +328,8 @@ struct SerialSVDInternal {
   template <typename value_type>
   KOKKOS_INLINE_FUNCTION static int invoke(int m, int n, value_type* A, int As0, int As1, value_type* U, int Us0,
                                            int Us1, value_type* Vt, int Vts0, int Vts1, value_type* sigma, int ss,
-                                           value_type* work, value_type tol = Kokkos::ArithTraits<value_type>::zero()) {
+                                           value_type* work, value_type tol = Kokkos::ArithTraits<value_type>::zero(),
+                                           int max_iters = 1000000000) {
     // First, if m < n, need to instead compute (V, s, U^T) = A^T.
     // This just means swapping U & Vt, and implicitly transposing A, U and Vt.
     if (m < n) {
@@ -345,9 +352,9 @@ struct SerialSVDInternal {
       return 0;
     }
     bidiagonalize(m, n, A, As0, As1, U, Us0, Us1, Vt, Vts0, Vts1, work);
-    bidiSVD(m, n, A, As0, As1, U, Us0, Us1, Vt, Vts0, Vts1, sigma, ss, tol);
+    int iter_err = bidiSVD(m, n, A, As0, As1, U, Us0, Us1, Vt, Vts0, Vts1, sigma, ss, tol, max_iters);
     postprocessSVD(m, n, U, Us0, Us1, Vt, Vts0, Vts1, sigma, ss);
-    return 0;
+    return iter_err;
   }
 };
 

--- a/batched/dense/src/KokkosBatched_SVD_Decl.hpp
+++ b/batched/dense/src/KokkosBatched_SVD_Decl.hpp
@@ -59,13 +59,13 @@ struct SerialSVD {
   template <typename AViewType, typename UViewType, typename VtViewType, typename SViewType, typename WViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(
       SVD_USV_Tag, const AViewType &A, const UViewType &U, const SViewType &s, const VtViewType &Vt, const WViewType &W,
-      typename AViewType::const_value_type tol = Kokkos::ArithTraits<typename AViewType::value_type>::zero());
+      typename AViewType::const_value_type tol = Kokkos::ArithTraits<typename AViewType::value_type>::zero(), int max_iters = 1000000000);
 
   // Version which computes only singular values
   template <typename AViewType, typename SViewType, typename WViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(
       SVD_S_Tag, const AViewType &A, const SViewType &s, const WViewType &W,
-      typename AViewType::const_value_type tol = Kokkos::ArithTraits<typename AViewType::value_type>::zero());
+      typename AViewType::const_value_type tol = Kokkos::ArithTraits<typename AViewType::value_type>::zero(), int max_iters = 1000000000);
 };
 
 }  // namespace KokkosBatched

--- a/batched/dense/unit_test/Test_Batched_SerialSVD.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialSVD.hpp
@@ -497,6 +497,27 @@ Kokkos::View<Scalar**, Layout, Device> getTestCase(int testCase) {
       Ahost = MatrixHost("A5", m, n);
       break;
     }
+    case 6: {
+      m           = 3;
+      n           = 6;
+      Ahost       = MatrixHost("A6", m, n);
+      Ahost(0, 0) = -2.3588494081694974e-03;
+      Ahost(0, 1) = -2.3602176428346553e-03;
+      Ahost(0, 2) = -3.3360574050870077e-03;
+      Ahost(0, 3) = -2.3589487578561312e-03;
+      Ahost(0, 4) = -3.3359167956075490e-03;
+      Ahost(0, 5) = -3.3378517656821728e-03;
+      Ahost(1, 0) = 3.3359168246290603e-03;
+      Ahost(1, 1) = 3.3378518006490351e-03;
+      Ahost(1, 3) = 3.3360573263032968e-03;
+      Ahost(2, 0) = -2.3588494081695022e-03;
+      Ahost(2, 1) = -2.3602176428346587e-03;
+      Ahost(2, 2) = 3.3360574050869769e-03;
+      Ahost(2, 3) = -2.3589487578561286e-03;
+      Ahost(2, 4) = 3.3359167956075399e-03;
+      Ahost(2, 5) = 3.3378517656821581e-03;
+      break;
+    }
     default: throw std::runtime_error("Test case out of bounds.");
   }
   Kokkos::View<Scalar**, Layout, Device> A(Ahost.label(), m, n);
@@ -509,7 +530,7 @@ void testSpecialCases() {
   using Matrix    = Kokkos::View<Scalar**, Layout, Device>;
   using Vector    = Kokkos::View<Scalar*, Device>;
   using ExecSpace = typename Device::execution_space;
-  for (int i = 0; i < 6; i++) {
+  for (int i = 0; i < 7; i++) {
     Matrix A = getTestCase<Scalar, Layout, Device>(i);
     int m    = A.extent(0);
     int n    = A.extent(1);


### PR DESCRIPTION
To avoid hangs in batched SVD due to non-convergence of the eigenvalues, we add a check on the number of iterations and report a failure if the max number of iterations is reached.
The fix and matrix were propose in issue #2650