### PR TITLE
First implementation of recursive coordinate bisection (RCB) in graph

### DIFF
--- a/graph/impl/KokkosGraph_RCB_impl.hpp
+++ b/graph/impl/KokkosGraph_RCB_impl.hpp
@@ -59,6 +59,7 @@ struct UpdatePermAndMeshFunctor {
   ordinal_t p1_size;
   ordinal_t offset;
   ordinal_t N;  // length of reverse_perm_bisect
+  ordinal_t ndim;
 
   UpdatePermAndMeshFunctor(const perm_view_type1 &reverse_perm_bisect_, const perm_view_type1 &prev_reverse_perm_,
                            perm_view_type2 &perm_, perm_view_type2 &reverse_perm_,
@@ -72,7 +73,8 @@ struct UpdatePermAndMeshFunctor {
         coordinates_new(coordinates_new_),
         p1_size(p1_size_),
         offset(offset_) {
-    N = static_cast<ordinal_t>(reverse_perm_bisect.extent(0));
+    N    = static_cast<ordinal_t>(reverse_perm_bisect.extent(0));
+    ndim = static_cast<ordinal_t>(coordinates_orig.extent(1));
   }
   KOKKOS_INLINE_FUNCTION void operator()(ordinal_t i) const {
     // orig_lcl_idx: 0 --> (N-1)
@@ -98,9 +100,9 @@ struct UpdatePermAndMeshFunctor {
     reverse_perm(new_gbl_idx) = gbl_orig_idx;
 
     // Update coordinates with bisecting results
-    coordinates_new(new_lcl_idx, 0) = coordinates_orig(orig_lcl_idx, 0);
-    coordinates_new(new_lcl_idx, 1) = coordinates_orig(orig_lcl_idx, 1);
-    coordinates_new(new_lcl_idx, 2) = coordinates_orig(orig_lcl_idx, 2);
+    for (ordinal_t j = 0; j < ndim; j++) {
+      coordinates_new(new_lcl_idx, j) = coordinates_orig(orig_lcl_idx, j);
+    }
   }
 };
 

--- a/graph/impl/KokkosGraph_RCB_impl.hpp
+++ b/graph/impl/KokkosGraph_RCB_impl.hpp
@@ -32,9 +32,7 @@ struct FillOneIncrementFunctor {
   perm_view_type A;
 
   FillOneIncrementFunctor(perm_view_type &A_) : A(A_) {}
-  KOKKOS_INLINE_FUNCTION void operator()(ordinal_t i) const {
-    A(i) = i;
-  }
+  KOKKOS_INLINE_FUNCTION void operator()(ordinal_t i) const { A(i) = i; }
 };
 
 template <typename reducer_type, typename view_type, typename ordinal_t>
@@ -52,45 +50,39 @@ struct MinMaxReducerFunctor {
 template <typename perm_view_type1, typename perm_view_type2, typename coors_view_type>
 struct UpdatePermAndMeshFunctor {
   using ordinal_t = typename perm_view_type1::value_type;
-  perm_view_type1 reverse_perm_bisect; // a subview
-  perm_view_type1 prev_reverse_perm;   // a subview
-  perm_view_type2 perm;                // a full-length view
-  perm_view_type2 reverse_perm;        // a full-length view
-  coors_view_type coordinates_orig;    // a subview
-  coors_view_type coordinates_new;     // a subview
+  perm_view_type1 reverse_perm_bisect;  // a subview
+  perm_view_type1 prev_reverse_perm;    // a subview
+  perm_view_type2 perm;                 // a full-length view
+  perm_view_type2 reverse_perm;         // a full-length view
+  coors_view_type coordinates_orig;     // a subview
+  coors_view_type coordinates_new;      // a subview
   ordinal_t p1_size;
   ordinal_t offset;
-  ordinal_t N; // length of reverse_perm_bisect
+  ordinal_t N;  // length of reverse_perm_bisect
 
-  UpdatePermAndMeshFunctor(const perm_view_type1 &reverse_perm_bisect_,
-                           const perm_view_type1 &prev_reverse_perm_,
-                                 perm_view_type2 &perm_,
-                                 perm_view_type2 &reverse_perm_,
-                           const coors_view_type &coordinates_orig_,
-                                 coors_view_type &coordinates_new_,
-                           const ordinal_t       &p1_size_,
-                           const ordinal_t       &offset_)
-    : reverse_perm_bisect(reverse_perm_bisect_),
-      prev_reverse_perm(prev_reverse_perm_),
-      perm(perm_),
-      reverse_perm(reverse_perm_),
-      coordinates_orig(coordinates_orig_),
-      coordinates_new(coordinates_new_),
-      p1_size(p1_size_),
-      offset(offset_)
-    {
-      N = static_cast<ordinal_t>(reverse_perm_bisect.extent(0));
-    }
+  UpdatePermAndMeshFunctor(const perm_view_type1 &reverse_perm_bisect_, const perm_view_type1 &prev_reverse_perm_,
+                           perm_view_type2 &perm_, perm_view_type2 &reverse_perm_,
+                           const coors_view_type &coordinates_orig_, coors_view_type &coordinates_new_,
+                           const ordinal_t &p1_size_, const ordinal_t &offset_)
+      : reverse_perm_bisect(reverse_perm_bisect_),
+        prev_reverse_perm(prev_reverse_perm_),
+        perm(perm_),
+        reverse_perm(reverse_perm_),
+        coordinates_orig(coordinates_orig_),
+        coordinates_new(coordinates_new_),
+        p1_size(p1_size_),
+        offset(offset_) {
+    N = static_cast<ordinal_t>(reverse_perm_bisect.extent(0));
+  }
   KOKKOS_INLINE_FUNCTION void operator()(ordinal_t i) const {
     // orig_lcl_idx: 0 --> (N-1)
     ordinal_t orig_lcl_idx = reverse_perm_bisect(i);
 
     // new_lcl_idx: 0 --> (N-1)
     ordinal_t new_lcl_idx;
-	if (i < p1_size) {
+    if (i < p1_size) {
       new_lcl_idx = i;
-    }
-    else {
+    } else {
       new_lcl_idx = (N - 1 - i) + p1_size;
     }
     // Calculate new_gbl_idx by adding an offset
@@ -106,17 +98,17 @@ struct UpdatePermAndMeshFunctor {
     reverse_perm(new_gbl_idx) = gbl_orig_idx;
 
     // Update coordinates with bisecting results
-    coordinates_new(new_lcl_idx,0) = coordinates_orig(orig_lcl_idx,0);
-    coordinates_new(new_lcl_idx,1) = coordinates_orig(orig_lcl_idx,1);
-    coordinates_new(new_lcl_idx,2) = coordinates_orig(orig_lcl_idx,2);
+    coordinates_new(new_lcl_idx, 0) = coordinates_orig(orig_lcl_idx, 0);
+    coordinates_new(new_lcl_idx, 1) = coordinates_orig(orig_lcl_idx, 1);
+    coordinates_new(new_lcl_idx, 2) = coordinates_orig(orig_lcl_idx, 2);
   }
 };
 
 template <typename view_type, typename value_type>
 void find_min_max(const view_type &A, value_type &min_val, value_type &max_val) {
   using execution_space = typename view_type::device_type::execution_space;
-  using reducer_type = Kokkos::MinMax<value_type>;
-  size_t n_elements = static_cast<size_t>(A.extent(0));
+  using reducer_type    = Kokkos::MinMax<value_type>;
+  size_t n_elements     = static_cast<size_t>(A.extent(0));
   if (n_elements == 0) {
     min_val = static_cast<value_type>(0);
     max_val = static_cast<value_type>(0);
@@ -133,10 +125,9 @@ void find_min_max(const view_type &A, value_type &min_val, value_type &max_val) 
  * @brief Bisect and assign partition indices to coordinate list
  */
 template <typename coors_view_type, typename value_type, typename index_view_type, typename ordinal_type>
-inline
-void bisect( const coors_view_type &coors_1d, const value_type &init_min_val, const value_type &init_max_val,
-             index_view_type &reverse_perm_bisect, ordinal_type &p1_size, ordinal_type &p2_size) {
-  ordinal_type N = static_cast<ordinal_type>(coors_1d.extent(0));
+inline void bisect(const coors_view_type &coors_1d, const value_type &init_min_val, const value_type &init_max_val,
+                   index_view_type &reverse_perm_bisect, ordinal_type &p1_size, ordinal_type &p2_size) {
+  ordinal_type N     = static_cast<ordinal_type>(coors_1d.extent(0));
   value_type min_val = init_min_val;
   value_type max_val = init_max_val;
   value_type p1_weight, p2_weight;
@@ -144,15 +135,14 @@ void bisect( const coors_view_type &coors_1d, const value_type &init_min_val, co
   value_type curr_weight_ratio;
   while (1) {
     value_type mid_point = (max_val + min_val) / 2.0;
-    p1_size = 0;
-    p2_size = 0;
+    p1_size              = 0;
+    p2_size              = 0;
     // Use one array "reverse_perm_bisect" to store indices of both partitions
     for (ordinal_type i = 0; i < N; i++) {
-      if (coors_1d(i) > mid_point) { // partition 1: store forward
+      if (coors_1d(i) > mid_point) {  // partition 1: store forward
         reverse_perm_bisect(p1_size) = i;
         p1_size++;
-      }
-      else { // partition 2: store backward
+      } else {  // partition 2: store backward
         reverse_perm_bisect(N - 1 - p2_size) = i;
         p2_size++;
       }
@@ -160,15 +150,19 @@ void bisect( const coors_view_type &coors_1d, const value_type &init_min_val, co
     p1_weight = static_cast<value_type>(p1_size);
     p2_weight = static_cast<value_type>(p2_size);
 
-    curr_weight_ratio = std::max(p1_weight,p2_weight)/std::min(p1_weight,p2_weight);
+    curr_weight_ratio = std::max(p1_weight, p2_weight) / std::min(p1_weight, p2_weight);
 
-    if (curr_weight_ratio < 1.1) break;
-    else if (curr_weight_ratio == prev_weight_ratio) break;
+    if (curr_weight_ratio < 1.1)
+      break;
+    else if (curr_weight_ratio == prev_weight_ratio)
+      break;
     else {
       // Update min_val or max_val to calculate a new mid_point
       // Idea: shift mid_point to the heavier partition
-      if (p1_weight > p2_weight) min_val = mid_point;
-      else max_val = mid_point;
+      if (p1_weight > p2_weight)
+        min_val = mid_point;
+      else
+        max_val = mid_point;
       prev_weight_ratio = curr_weight_ratio;
     }
   }

--- a/graph/impl/KokkosGraph_RCB_impl.hpp
+++ b/graph/impl/KokkosGraph_RCB_impl.hpp
@@ -1,0 +1,180 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOSGRAPH_RCB_IMPL_HPP
+#define KOKKOSGRAPH_RCB_IMPL_HPP
+
+#include "Kokkos_Core.hpp"
+#include "KokkosKernels_Utils.hpp"
+#include <vector>
+#include <algorithm>
+
+namespace KokkosGraph {
+namespace Experimental {
+namespace Impl {
+
+template <typename perm_view_type>
+struct FillOneIncrementFunctor {
+  using ordinal_t = typename perm_view_type::value_type;
+  perm_view_type A;
+
+  FillOneIncrementFunctor(perm_view_type &A_) : A(A_) {}
+  KOKKOS_INLINE_FUNCTION void operator()(ordinal_t i) const {
+    A(i) = i;
+  }
+};
+
+template <typename reducer_type, typename view_type, typename ordinal_t>
+struct MinMaxReducerFunctor {
+  using reducer_value_type = typename reducer_type::value_type;
+  view_type A;
+  MinMaxReducerFunctor(const view_type &A_) : A(A_) {}
+  KOKKOS_INLINE_FUNCTION void operator()(ordinal_t i, reducer_value_type &lminmax) const {
+    typename view_type::value_type val = A(i);
+    if (val < lminmax.min_val) lminmax.min_val = val;
+    if (val > lminmax.max_val) lminmax.max_val = val;
+  }
+};
+
+template <typename perm_view_type1, typename perm_view_type2, typename coors_view_type>
+struct UpdatePermAndMeshFunctor {
+  using ordinal_t = typename perm_view_type1::value_type;
+  perm_view_type1 reverse_perm_bisect; // a subview
+  perm_view_type1 prev_reverse_perm;   // a subview
+  perm_view_type2 perm;                // a full-length view
+  perm_view_type2 reverse_perm;        // a full-length view
+  coors_view_type coordinates_orig;    // a subview
+  coors_view_type coordinates_new;     // a subview
+  ordinal_t p1_size;
+  ordinal_t offset;
+  ordinal_t N; // length of reverse_perm_bisect
+
+  UpdatePermAndMeshFunctor(const perm_view_type1 &reverse_perm_bisect_,
+                           const perm_view_type1 &prev_reverse_perm_,
+                                 perm_view_type2 &perm_,
+                                 perm_view_type2 &reverse_perm_,
+                           const coors_view_type &coordinates_orig_,
+                                 coors_view_type &coordinates_new_,
+                           const ordinal_t       &p1_size_,
+                           const ordinal_t       &offset_)
+    : reverse_perm_bisect(reverse_perm_bisect_),
+      prev_reverse_perm(prev_reverse_perm_),
+      perm(perm_),
+      reverse_perm(reverse_perm_),
+      coordinates_orig(coordinates_orig_),
+      coordinates_new(coordinates_new_),
+      p1_size(p1_size_),
+      offset(offset_)
+    {
+      N = static_cast<ordinal_t>(reverse_perm_bisect.extent(0));
+    }
+  KOKKOS_INLINE_FUNCTION void operator()(ordinal_t i) const {
+    // orig_lcl_idx: 0 --> (N-1)
+    ordinal_t orig_lcl_idx = reverse_perm_bisect(i);
+
+    // new_lcl_idx: 0 --> (N-1)
+    ordinal_t new_lcl_idx;
+	if (i < p1_size) {
+      new_lcl_idx = i;
+    }
+    else {
+      new_lcl_idx = (N - 1 - i) + p1_size;
+    }
+    // Calculate new_gbl_idx by adding an offset
+    ordinal_t new_gbl_idx = new_lcl_idx + offset;
+
+    // Retrieve gbl_orig_idx
+    ordinal_t gbl_orig_idx = prev_reverse_perm(orig_lcl_idx);
+
+    // Update perm at gbl_orig_idx location
+    perm(gbl_orig_idx) = new_gbl_idx;
+
+    // Update reverse_perm at new_gbl_idx location
+    reverse_perm(new_gbl_idx) = gbl_orig_idx;
+
+    // Update coordinates with bisecting results
+    coordinates_new(new_lcl_idx,0) = coordinates_orig(orig_lcl_idx,0);
+    coordinates_new(new_lcl_idx,1) = coordinates_orig(orig_lcl_idx,1);
+    coordinates_new(new_lcl_idx,2) = coordinates_orig(orig_lcl_idx,2);
+  }
+};
+
+template <typename view_type, typename value_type>
+void find_min_max(const view_type &A, value_type &min_val, value_type &max_val) {
+  using execution_space = typename view_type::device_type::execution_space;
+  using reducer_type = Kokkos::MinMax<value_type>;
+  size_t n_elements = static_cast<size_t>(A.extent(0));
+  if (n_elements == 0) {
+    min_val = static_cast<value_type>(0);
+    max_val = static_cast<value_type>(0);
+    return;
+  }
+  typename reducer_type::value_type result;
+  Kokkos::parallel_reduce(Kokkos::RangePolicy<execution_space>(0, n_elements),
+                          MinMaxReducerFunctor<reducer_type, view_type, size_t>(A), reducer_type(result));
+  min_val = result.min_val;
+  max_val = result.max_val;
+}
+
+/**
+ * @brief Bisect and assign partition indices to coordinate list
+ */
+template <typename coors_view_type, typename value_type, typename index_view_type, typename ordinal_type>
+inline
+void bisect( const coors_view_type &coors_1d, const value_type &init_min_val, const value_type &init_max_val,
+             index_view_type &reverse_perm_bisect, ordinal_type &p1_size, ordinal_type &p2_size) {
+  ordinal_type N = static_cast<ordinal_type>(coors_1d.extent(0));
+  value_type min_val = init_min_val;
+  value_type max_val = init_max_val;
+  value_type p1_weight, p2_weight;
+  value_type prev_weight_ratio = 0;
+  value_type curr_weight_ratio;
+  while (1) {
+    value_type mid_point = (max_val + min_val) / 2.0;
+    p1_size = 0;
+    p2_size = 0;
+    // Use one array "reverse_perm_bisect" to store indices of both partitions
+    for (ordinal_type i = 0; i < N; i++) {
+      if (coors_1d(i) > mid_point) { // partition 1: store forward
+        reverse_perm_bisect(p1_size) = i;
+        p1_size++;
+      }
+      else { // partition 2: store backward
+        reverse_perm_bisect(N - 1 - p2_size) = i;
+        p2_size++;
+      }
+    }
+    p1_weight = static_cast<value_type>(p1_size);
+    p2_weight = static_cast<value_type>(p2_size);
+
+    curr_weight_ratio = std::max(p1_weight,p2_weight)/std::min(p1_weight,p2_weight);
+
+    if (curr_weight_ratio < 1.1) break;
+    else if (curr_weight_ratio == prev_weight_ratio) break;
+    else {
+      // Update min_val or max_val to calculate a new mid_point
+      // Idea: shift mid_point to the heavier partition
+      if (p1_weight > p2_weight) min_val = mid_point;
+      else max_val = mid_point;
+      prev_weight_ratio = curr_weight_ratio;
+    }
+  }
+}
+
+}  // namespace Impl
+}  // namespace Experimental
+}  // namespace KokkosGraph
+#endif

--- a/graph/src/KokkosGraph_RCB.hpp
+++ b/graph/src/KokkosGraph_RCB.hpp
@@ -30,14 +30,15 @@ namespace Experimental {
 // the RCB order to the original order
 
 template <typename coors_view_type, typename perm_view_type, typename ordinal_type>
-std::vector<ordinal_type>
-recursive_coordinate_bisection(coors_view_type &coordinates, perm_view_type &perm, perm_view_type &reverse_perm, const ordinal_type &n_levels) {
+std::vector<ordinal_type> recursive_coordinate_bisection(coors_view_type &coordinates, perm_view_type &perm,
+                                                         perm_view_type &reverse_perm, const ordinal_type &n_levels) {
   using execution_space = typename coors_view_type::device_type::execution_space;
   using scalar_t        = typename coors_view_type::value_type;
 
   if (n_levels < 2) {
     std::ostringstream os;
-    os << "KokkosGraph::Experimental::recursive_coordinate_bisection only works with more than 1 level of bisection (i.e., 2 partitions).";
+    os << "KokkosGraph::Experimental::recursive_coordinate_bisection only works with more than 1 level of bisection "
+          "(i.e., 2 partitions).";
     KokkosKernels::Impl::throw_runtime_exception(os.str());
   }
 
@@ -45,52 +46,61 @@ recursive_coordinate_bisection(coors_view_type &coordinates, perm_view_type &per
   ordinal_type ndim = static_cast<ordinal_type>(coordinates.extent(1));
 
   // Allocate coordinates views on device memory
-  coors_view_type coordinates_bisect (Kokkos::view_alloc(Kokkos::WithoutInitializing, "coordinates_bisect"), N, ndim);
-  perm_view_type  reverse_perm_bisect(Kokkos::view_alloc(Kokkos::WithoutInitializing, "reverse_perm_bisect"), N);
-  perm_view_type  prev_reverse_perm  (Kokkos::view_alloc(Kokkos::WithoutInitializing, "prev_reverse_perm"), N);
+  coors_view_type coordinates_bisect(Kokkos::view_alloc(Kokkos::WithoutInitializing, "coordinates_bisect"), N, ndim);
+  perm_view_type reverse_perm_bisect(Kokkos::view_alloc(Kokkos::WithoutInitializing, "reverse_perm_bisect"), N);
+  perm_view_type prev_reverse_perm(Kokkos::view_alloc(Kokkos::WithoutInitializing, "prev_reverse_perm"), N);
 
   // Create host mirrors of device views
-  typename coors_view_type::HostMirror h_coordinates         = Kokkos::create_mirror_view( coordinates );
-  typename perm_view_type::HostMirror  h_perm                = Kokkos::create_mirror_view( perm );
-  typename perm_view_type::HostMirror  h_reverse_perm        = Kokkos::create_mirror_view( reverse_perm );
-  typename perm_view_type::HostMirror  h_reverse_perm_bisect = Kokkos::create_mirror_view( reverse_perm_bisect );
+  typename coors_view_type::HostMirror h_coordinates        = Kokkos::create_mirror_view(coordinates);
+  typename perm_view_type::HostMirror h_perm                = Kokkos::create_mirror_view(perm);
+  typename perm_view_type::HostMirror h_reverse_perm        = Kokkos::create_mirror_view(reverse_perm);
+  typename perm_view_type::HostMirror h_reverse_perm_bisect = Kokkos::create_mirror_view(reverse_perm_bisect);
 
   // Copy coordinates from device memory to host memory because bisecting is currently executed on host
-  Kokkos::deep_copy( h_coordinates, coordinates );
+  Kokkos::deep_copy(h_coordinates, coordinates);
 
   // Initialize
-  Kokkos::parallel_for(Kokkos::RangePolicy<execution_space, ordinal_type>(0, N), Impl::FillOneIncrementFunctor<perm_view_type>(perm));
-  Kokkos::deep_copy( reverse_perm, perm );
+  Kokkos::parallel_for(Kokkos::RangePolicy<execution_space, ordinal_type>(0, N),
+                       Impl::FillOneIncrementFunctor<perm_view_type>(perm));
+  Kokkos::deep_copy(reverse_perm, perm);
 
-  ordinal_type n_partitions = 1; // number of partitions at the previous level (initial value is 1, i.e., starting with the entire mesh points)
-  ordinal_type max_n_partitions = static_cast <ordinal_type>(std::pow(2, n_levels - 1));
-  std::vector<ordinal_type> partition_sizes(max_n_partitions); // contain the number of basis functions (or elements) per partition in the previous level
-  partition_sizes[0] = N; // starting with the entire mesh points
+  ordinal_type n_partitions =
+      1;  // number of partitions at the previous level (initial value is 1, i.e., starting with the entire mesh points)
+  ordinal_type max_n_partitions = static_cast<ordinal_type>(std::pow(2, n_levels - 1));
+  std::vector<ordinal_type> partition_sizes(
+      max_n_partitions);   // contain the number of basis functions (or elements) per partition in the previous level
+  partition_sizes[0] = N;  // starting with the entire mesh points
   std::vector<ordinal_type> partition_sizes_tmp(max_n_partitions);
 
   // Start RCB
-  for (ordinal_type lvl = 1; lvl < n_levels; lvl++)  { // skip level 0 and start from level 1
-    ordinal_type coordinates_offset = 0; // always start from beginning of the mesh points
-    ordinal_type cnt_partitions = 0;
+  for (ordinal_type lvl = 1; lvl < n_levels; lvl++) {  // skip level 0 and start from level 1
+    ordinal_type coordinates_offset = 0;               // always start from beginning of the mesh points
+    ordinal_type cnt_partitions     = 0;
 
     // Keep a copy of reverse permutation list
-    Kokkos::deep_copy( prev_reverse_perm, reverse_perm );
+    Kokkos::deep_copy(prev_reverse_perm, reverse_perm);
 
-    for (ordinal_type p = 0; p < n_partitions; p++) { // go through each partition of previous level and do bisecting
+    for (ordinal_type p = 0; p < n_partitions; p++) {  // go through each partition of previous level and do bisecting
       if (p > 0) {
         // Calculate coordinates offset of the current partition based on the previous partition
         coordinates_offset += partition_sizes[p - 1];
       }
 
-      ordinal_type N0 = partition_sizes[p]; // partiion size (or length)
+      ordinal_type N0      = partition_sizes[p];  // partiion size (or length)
       ordinal_type p1_size = 0;
       ordinal_type p2_size = 0;
-      auto sub_coordinates           = Kokkos::subview(coordinates,           Kokkos::make_pair(coordinates_offset, coordinates_offset + N0), Kokkos::ALL());
-      auto sub_h_coordinates         = Kokkos::subview(h_coordinates,         Kokkos::make_pair(coordinates_offset, coordinates_offset + N0), Kokkos::ALL());
-      auto sub_coordinates_bisect    = Kokkos::subview(coordinates_bisect,    Kokkos::make_pair(coordinates_offset, coordinates_offset + N0), Kokkos::ALL());
-      auto sub_reverse_perm_bisect   = Kokkos::subview(reverse_perm_bisect,   Kokkos::make_pair(coordinates_offset, coordinates_offset + N0));
-      auto sub_prev_reverse_perm     = Kokkos::subview(prev_reverse_perm,     Kokkos::make_pair(coordinates_offset, coordinates_offset + N0));
-      auto sub_h_reverse_perm_bisect = Kokkos::subview(h_reverse_perm_bisect, Kokkos::make_pair(coordinates_offset, coordinates_offset + N0));
+      auto sub_coordinates =
+          Kokkos::subview(coordinates, Kokkos::make_pair(coordinates_offset, coordinates_offset + N0), Kokkos::ALL());
+      auto sub_h_coordinates =
+          Kokkos::subview(h_coordinates, Kokkos::make_pair(coordinates_offset, coordinates_offset + N0), Kokkos::ALL());
+      auto sub_coordinates_bisect = Kokkos::subview(
+          coordinates_bisect, Kokkos::make_pair(coordinates_offset, coordinates_offset + N0), Kokkos::ALL());
+      auto sub_reverse_perm_bisect =
+          Kokkos::subview(reverse_perm_bisect, Kokkos::make_pair(coordinates_offset, coordinates_offset + N0));
+      auto sub_prev_reverse_perm =
+          Kokkos::subview(prev_reverse_perm, Kokkos::make_pair(coordinates_offset, coordinates_offset + N0));
+      auto sub_h_reverse_perm_bisect =
+          Kokkos::subview(h_reverse_perm_bisect, Kokkos::make_pair(coordinates_offset, coordinates_offset + N0));
 
       // Find min, max, and span of each dimension
       scalar_t x_min, x_max, y_min, y_max, z_min, z_max;
@@ -98,52 +108,45 @@ recursive_coordinate_bisection(coors_view_type &coordinates, perm_view_type &per
       scalar_t y_span = 0.0;
       scalar_t z_span = 0.0;
 
-      auto x_coors = Kokkos::subview (sub_coordinates, Kokkos::ALL(), 0);
+      auto x_coors = Kokkos::subview(sub_coordinates, Kokkos::ALL(), 0);
       Impl::find_min_max(x_coors, x_min, x_max);
       x_span = x_max - x_min;
 
       if (ndim > 1) {
-        auto y_coors = Kokkos::subview (sub_coordinates, Kokkos::ALL(), 1);
+        auto y_coors = Kokkos::subview(sub_coordinates, Kokkos::ALL(), 1);
         Impl::find_min_max(y_coors, y_min, y_max);
         y_span = y_max - y_min;
       }
 
       if (ndim > 2) {
-        auto z_coors = Kokkos::subview (sub_coordinates, Kokkos::ALL(), 2);
+        auto z_coors = Kokkos::subview(sub_coordinates, Kokkos::ALL(), 2);
         Impl::find_min_max(z_coors, z_min, z_max);
         z_span = z_max - z_min;
       }
 
       // Bisect partition on the most elongated dimension (host execution, for now)
       if ((x_span >= y_span) && (x_span >= z_span)) {
-        auto h_x_coors = Kokkos::subview (sub_h_coordinates, Kokkos::ALL(), 0);
+        auto h_x_coors = Kokkos::subview(sub_h_coordinates, Kokkos::ALL(), 0);
         Impl::bisect(h_x_coors, x_min, x_max, sub_h_reverse_perm_bisect, p1_size, p2_size);
-      }
-      else if ((y_span >= x_span) && (y_span >= z_span)) {
-        auto h_y_coors = Kokkos::subview (sub_h_coordinates, Kokkos::ALL(), 1);
+      } else if ((y_span >= x_span) && (y_span >= z_span)) {
+        auto h_y_coors = Kokkos::subview(sub_h_coordinates, Kokkos::ALL(), 1);
         Impl::bisect(h_y_coors, y_min, y_max, sub_h_reverse_perm_bisect, p1_size, p2_size);
-      }
-      else {
-        auto h_z_coors = Kokkos::subview (sub_h_coordinates, Kokkos::ALL(), 2);
+      } else {
+        auto h_z_coors = Kokkos::subview(sub_h_coordinates, Kokkos::ALL(), 2);
         Impl::bisect(h_z_coors, z_min, z_max, sub_h_reverse_perm_bisect, p1_size, p2_size);
       }
 
-      Kokkos::deep_copy( sub_reverse_perm_bisect, sub_h_reverse_perm_bisect );
+      Kokkos::deep_copy(sub_reverse_perm_bisect, sub_h_reverse_perm_bisect);
 
       // Update global permutation and reverse permutation lists and shuffle coordinates using bisecting results
-      Impl::UpdatePermAndMeshFunctor<decltype(sub_reverse_perm_bisect),
-                                     perm_view_type,
-                                     decltype(sub_coordinates)> func(sub_reverse_perm_bisect,
-                                                                     sub_prev_reverse_perm,
-                                                                     perm,
-                                                                     reverse_perm,
-                                                                     sub_coordinates,
-                                                                     sub_coordinates_bisect,
-                                                                     p1_size, coordinates_offset);
+      Impl::UpdatePermAndMeshFunctor<decltype(sub_reverse_perm_bisect), perm_view_type, decltype(sub_coordinates)> func(
+          sub_reverse_perm_bisect, sub_prev_reverse_perm, perm, reverse_perm, sub_coordinates, sub_coordinates_bisect,
+          p1_size, coordinates_offset);
       Kokkos::RangePolicy<execution_space, ordinal_type> policy(0, N0);
       Kokkos::parallel_for(policy, func);
 
-      //std::cout << "    Level " << lvl << ", bisecting partition " << p << " (size: " << N0 << ") of level " << (lvl - 1) << ": 1st sub-partition's size " << p1_size << ", 2nd sub-partition's size " << p2_size << std::endl;
+      // std::cout << "    Level " << lvl << ", bisecting partition " << p << " (size: " << N0 << ") of level " << (lvl
+      // - 1) << ": 1st sub-partition's size " << p1_size << ", 2nd sub-partition's size " << p2_size << std::endl;
 
       if (p1_size != 0) {
         partition_sizes_tmp[cnt_partitions] = p1_size;
@@ -153,21 +156,20 @@ recursive_coordinate_bisection(coors_view_type &coordinates, perm_view_type &per
         partition_sizes_tmp[cnt_partitions] = p2_size;
         cnt_partitions++;
       }
-    } // end Partition loop
+    }  // end Partition loop
 
     // Update coordinates
-    Kokkos::deep_copy( coordinates,   coordinates_bisect );
-    Kokkos::deep_copy( h_coordinates, coordinates_bisect );
+    Kokkos::deep_copy(coordinates, coordinates_bisect);
+    Kokkos::deep_copy(h_coordinates, coordinates_bisect);
 
     // Update the number of partitions of this level (used for bisections in the next level)
     n_partitions = cnt_partitions;
 
     // Update partition sizes of this level (used for bisections in the next level)
     std::copy(partition_sizes_tmp.begin(), partition_sizes_tmp.end(), partition_sizes.begin());
-  } // end Level loop
+  }  // end Level loop
 
-  if (n_partitions < max_n_partitions)
-    partition_sizes.resize(n_partitions);
+  if (n_partitions < max_n_partitions) partition_sizes.resize(n_partitions);
 
   return partition_sizes;
 }

--- a/graph/src/KokkosGraph_RCB.hpp
+++ b/graph/src/KokkosGraph_RCB.hpp
@@ -1,0 +1,178 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOSGRAPH_RCB_HPP
+#define KOKKOSGRAPH_RCB_HPP
+
+#include "KokkosGraph_RCB_impl.hpp"
+
+namespace KokkosGraph {
+namespace Experimental {
+
+// The recursive coordinate bisection (RCB) algorithm partitions the graph
+// according to the coordinates of the mesh points. This function returns
+// a vector containing sizes of partitions, the coordinate list (organized in RCB
+// order), a permutation array describing the mapping from the original order
+// to RCB order, and a reverse permutation array describing the mapping from
+// the RCB order to the original order
+
+template <typename coors_view_type, typename perm_view_type, typename ordinal_type>
+std::vector<ordinal_type>
+recursive_coordinate_bisection(coors_view_type &coordinates, perm_view_type &perm, perm_view_type &reverse_perm, const ordinal_type &n_levels) {
+  using execution_space = typename coors_view_type::device_type::execution_space;
+  using scalar_t        = typename coors_view_type::value_type;
+
+  if (n_levels < 2) {
+    std::ostringstream os;
+    os << "KokkosGraph::Experimental::recursive_coordinate_bisection only works with more than 1 level of bisection (i.e., 2 partitions).";
+    KokkosKernels::Impl::throw_runtime_exception(os.str());
+  }
+
+  ordinal_type N    = static_cast<ordinal_type>(coordinates.extent(0));
+  ordinal_type ndim = static_cast<ordinal_type>(coordinates.extent(1));
+
+  // Allocate coordinates views on device memory
+  coors_view_type coordinates_bisect (Kokkos::view_alloc(Kokkos::WithoutInitializing, "coordinates_bisect"), N, ndim);
+  perm_view_type  reverse_perm_bisect(Kokkos::view_alloc(Kokkos::WithoutInitializing, "reverse_perm_bisect"), N);
+  perm_view_type  prev_reverse_perm  (Kokkos::view_alloc(Kokkos::WithoutInitializing, "prev_reverse_perm"), N);
+
+  // Create host mirrors of device views
+  typename coors_view_type::HostMirror h_coordinates         = Kokkos::create_mirror_view( coordinates );
+  typename perm_view_type::HostMirror  h_perm                = Kokkos::create_mirror_view( perm );
+  typename perm_view_type::HostMirror  h_reverse_perm        = Kokkos::create_mirror_view( reverse_perm );
+  typename perm_view_type::HostMirror  h_reverse_perm_bisect = Kokkos::create_mirror_view( reverse_perm_bisect );
+
+  // Copy coordinates from device memory to host memory because bisecting is currently executed on host
+  Kokkos::deep_copy( h_coordinates, coordinates );
+
+  // Initialize
+  Kokkos::parallel_for(Kokkos::RangePolicy<execution_space, ordinal_type>(0, N), Impl::FillOneIncrementFunctor<perm_view_type>(perm));
+  Kokkos::deep_copy( reverse_perm, perm );
+
+  ordinal_type n_partitions = 1; // number of partitions at the previous level (initial value is 1, i.e., starting with the entire mesh points)
+  ordinal_type max_n_partitions = static_cast <ordinal_type>(std::pow(2, n_levels - 1));
+  std::vector<ordinal_type> partition_sizes(max_n_partitions); // contain the number of basis functions (or elements) per partition in the previous level
+  partition_sizes[0] = N; // starting with the entire mesh points
+  std::vector<ordinal_type> partition_sizes_tmp(max_n_partitions);
+
+  // Start RCB
+  for (ordinal_type lvl = 1; lvl < n_levels; lvl++)  { // skip level 0 and start from level 1
+    ordinal_type coordinates_offset = 0; // always start from beginning of the mesh points
+    ordinal_type cnt_partitions = 0;
+
+    // Keep a copy of reverse permutation list
+    Kokkos::deep_copy( prev_reverse_perm, reverse_perm );
+
+    for (ordinal_type p = 0; p < n_partitions; p++) { // go through each partition of previous level and do bisecting
+      if (p > 0) {
+        // Calculate coordinates offset of the current partition based on the previous partition
+        coordinates_offset += partition_sizes[p - 1];
+      }
+
+      ordinal_type N0 = partition_sizes[p]; // partiion size (or length)
+      ordinal_type p1_size = 0;
+      ordinal_type p2_size = 0;
+      auto sub_coordinates           = Kokkos::subview(coordinates,           Kokkos::make_pair(coordinates_offset, coordinates_offset + N0), Kokkos::ALL());
+      auto sub_h_coordinates         = Kokkos::subview(h_coordinates,         Kokkos::make_pair(coordinates_offset, coordinates_offset + N0), Kokkos::ALL());
+      auto sub_coordinates_bisect    = Kokkos::subview(coordinates_bisect,    Kokkos::make_pair(coordinates_offset, coordinates_offset + N0), Kokkos::ALL());
+      auto sub_reverse_perm_bisect   = Kokkos::subview(reverse_perm_bisect,   Kokkos::make_pair(coordinates_offset, coordinates_offset + N0));
+      auto sub_prev_reverse_perm     = Kokkos::subview(prev_reverse_perm,     Kokkos::make_pair(coordinates_offset, coordinates_offset + N0));
+      auto sub_h_reverse_perm_bisect = Kokkos::subview(h_reverse_perm_bisect, Kokkos::make_pair(coordinates_offset, coordinates_offset + N0));
+
+      // Find min, max, and span of each dimension
+      scalar_t x_min, x_max, y_min, y_max, z_min, z_max;
+      scalar_t x_span = 0.0;
+      scalar_t y_span = 0.0;
+      scalar_t z_span = 0.0;
+
+      auto x_coors = Kokkos::subview (sub_coordinates, Kokkos::ALL(), 0);
+      Impl::find_min_max(x_coors, x_min, x_max);
+      x_span = x_max - x_min;
+
+      if (ndim > 1) {
+        auto y_coors = Kokkos::subview (sub_coordinates, Kokkos::ALL(), 1);
+        Impl::find_min_max(y_coors, y_min, y_max);
+        y_span = y_max - y_min;
+      }
+
+      if (ndim > 2) {
+        auto z_coors = Kokkos::subview (sub_coordinates, Kokkos::ALL(), 2);
+        Impl::find_min_max(z_coors, z_min, z_max);
+        z_span = z_max - z_min;
+      }
+
+      // Bisect partition on the most elongated dimension (host execution, for now)
+      if ((x_span >= y_span) && (x_span >= z_span)) {
+        auto h_x_coors = Kokkos::subview (sub_h_coordinates, Kokkos::ALL(), 0);
+        Impl::bisect(h_x_coors, x_min, x_max, sub_h_reverse_perm_bisect, p1_size, p2_size);
+      }
+      else if ((y_span >= x_span) && (y_span >= z_span)) {
+        auto h_y_coors = Kokkos::subview (sub_h_coordinates, Kokkos::ALL(), 1);
+        Impl::bisect(h_y_coors, y_min, y_max, sub_h_reverse_perm_bisect, p1_size, p2_size);
+      }
+      else {
+        auto h_z_coors = Kokkos::subview (sub_h_coordinates, Kokkos::ALL(), 2);
+        Impl::bisect(h_z_coors, z_min, z_max, sub_h_reverse_perm_bisect, p1_size, p2_size);
+      }
+
+      Kokkos::deep_copy( sub_reverse_perm_bisect, sub_h_reverse_perm_bisect );
+
+      // Update global permutation and reverse permutation lists and shuffle coordinates using bisecting results
+      Impl::UpdatePermAndMeshFunctor<decltype(sub_reverse_perm_bisect),
+                                     perm_view_type,
+                                     decltype(sub_coordinates)> func(sub_reverse_perm_bisect,
+                                                                     sub_prev_reverse_perm,
+                                                                     perm,
+                                                                     reverse_perm,
+                                                                     sub_coordinates,
+                                                                     sub_coordinates_bisect,
+                                                                     p1_size, coordinates_offset);
+      Kokkos::RangePolicy<execution_space, ordinal_type> policy(0, N0);
+      Kokkos::parallel_for(policy, func);
+
+      //std::cout << "    Level " << lvl << ", bisecting partition " << p << " (size: " << N0 << ") of level " << (lvl - 1) << ": 1st sub-partition's size " << p1_size << ", 2nd sub-partition's size " << p2_size << std::endl;
+
+      if (p1_size != 0) {
+        partition_sizes_tmp[cnt_partitions] = p1_size;
+        cnt_partitions++;
+      }
+      if (p2_size != 0) {
+        partition_sizes_tmp[cnt_partitions] = p2_size;
+        cnt_partitions++;
+      }
+    } // end Partition loop
+
+    // Update coordinates
+    Kokkos::deep_copy( coordinates,   coordinates_bisect );
+    Kokkos::deep_copy( h_coordinates, coordinates_bisect );
+
+    // Update the number of partitions of this level (used for bisections in the next level)
+    n_partitions = cnt_partitions;
+
+    // Update partition sizes of this level (used for bisections in the next level)
+    std::copy(partition_sizes_tmp.begin(), partition_sizes_tmp.end(), partition_sizes.begin());
+  } // end Level loop
+
+  if (n_partitions < max_n_partitions)
+    partition_sizes.resize(n_partitions);
+
+  return partition_sizes;
+}
+
+}  // namespace Experimental
+}  // namespace KokkosGraph
+
+#endif

--- a/graph/unit_test/Test_Graph.hpp
+++ b/graph/unit_test/Test_Graph.hpp
@@ -24,5 +24,6 @@
 #include "Test_Graph_coarsen.hpp"
 #endif
 #include "Test_Graph_rcm.hpp"
+#include "Test_Graph_rcb.hpp"
 
 #endif  // TEST_GRAPH_HPP

--- a/graph/unit_test/Test_Graph_rcb.hpp
+++ b/graph/unit_test/Test_Graph_rcb.hpp
@@ -149,7 +149,8 @@ void test_rcb(lno_t ndim, lno_t np) {
   lno_t n_coordinates = static_cast<lno_t>(coordinates.extent(0));
   perm_view_t perm_rcb("perm_rcb", n_coordinates);
   perm_view_t reverse_perm_rcb("reverse_perm_rcb", n_coordinates);
-  auto h_coordinates = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), coordinates);
+  auto h_coordinates = Kokkos::create_mirror(coordinates);
+  Kokkos::deep_copy(h_coordinates, coordinates);
 
   lno_t n_levels = static_cast<lno_t>(std::log2(static_cast<double>(np)) + 1);
 

--- a/graph/unit_test/Test_Graph_rcb.hpp
+++ b/graph/unit_test/Test_Graph_rcb.hpp
@@ -177,22 +177,14 @@ void test_rcb(lno_t ndim, lno_t np) {
   ASSERT_TRUE(dif_flag);
 
   for (lno_t i = 0; i < n_coordinates; i++) {
-    ASSERT_EQ(h_coordinates(i, 0), h_coordinates_perm(h_perm_rcb(i), 0));
-    if (ndim > 1) {
-      ASSERT_EQ(h_coordinates(i, 1), h_coordinates_perm(h_perm_rcb(i), 1));
-    }
-    if (ndim > 2) {
-      ASSERT_EQ(h_coordinates(i, 2), h_coordinates_perm(h_perm_rcb(i), 2));
+    for (lno_t j = 0; j < ndim; j++) {
+      ASSERT_EQ(h_coordinates(i, j), h_coordinates_perm(h_perm_rcb(i), j));
     }
   }
 
   for (lno_t i = 0; i < n_coordinates; i++) {
-    ASSERT_EQ(h_coordinates_perm(i, 0), h_coordinates(h_reverse_perm_rcb(i), 0));
-    if (ndim > 1) {
-      ASSERT_EQ(h_coordinates_perm(i, 1), h_coordinates(h_reverse_perm_rcb(i), 1));
-    }
-    if (ndim > 2) {
-      ASSERT_EQ(h_coordinates_perm(i, 2), h_coordinates(h_reverse_perm_rcb(i), 2));
+    for (lno_t j = 0; j < ndim; j++) {
+      ASSERT_EQ(h_coordinates_perm(i, j), h_coordinates(h_reverse_perm_rcb(i), j));
     }
   }
 

--- a/graph/unit_test/Test_Graph_rcb.hpp
+++ b/graph/unit_test/Test_Graph_rcb.hpp
@@ -31,19 +31,19 @@ coors_view_t generate_coordinates_1d() {
   scalar_t x_min = 0;
 
   int n_pts_per_dim = 121;
-  int n_spaces = n_pts_per_dim - 1;
+  int n_spaces      = n_pts_per_dim - 1;
 
   int n_pts = n_pts_per_dim;
 
-  scalar_t dx = (x_max-x_min)/n_spaces;
+  scalar_t dx = (x_max - x_min) / n_spaces;
 
   coors_view_t coordinates(Kokkos::view_alloc(Kokkos::WithoutInitializing, "coordinates"), n_pts, 1);
   auto h_coordinates = Kokkos::create_mirror_view(coordinates);
 
   int cnt = 0;
-  for (int kk = 0; kk < n_pts_per_dim; kk++) { // x
-    scalar_t x = x_min + kk * dx;
-    h_coordinates(cnt,0) = x;
+  for (int kk = 0; kk < n_pts_per_dim; kk++) {  // x
+    scalar_t x            = x_min + kk * dx;
+    h_coordinates(cnt, 0) = x;
     cnt++;
   }
 
@@ -63,23 +63,23 @@ coors_view_t generate_coordinates_2d() {
   scalar_t y_min = 0;
 
   int n_pts_per_dim = 11;
-  int n_spaces = n_pts_per_dim - 1;
+  int n_spaces      = n_pts_per_dim - 1;
 
   int n_pts = n_pts_per_dim * n_pts_per_dim;
 
-  scalar_t dx = (x_max-x_min)/n_spaces;
-  scalar_t dy = (y_max-y_min)/n_spaces;
+  scalar_t dx = (x_max - x_min) / n_spaces;
+  scalar_t dy = (y_max - y_min) / n_spaces;
 
   coors_view_t coordinates(Kokkos::view_alloc(Kokkos::WithoutInitializing, "coordinates"), n_pts, 2);
   auto h_coordinates = Kokkos::create_mirror_view(coordinates);
 
   int cnt = 0;
-  for (int jj = 0; jj < n_pts_per_dim; jj++) { // y
-    scalar_t y = y_min +jj * dy;
-    for (int kk = 0; kk < n_pts_per_dim; kk++) { // x
-      scalar_t x = x_min + kk * dx;
-      h_coordinates(cnt,0) = x;
-      h_coordinates(cnt,1) = y;
+  for (int jj = 0; jj < n_pts_per_dim; jj++) {  // y
+    scalar_t y = y_min + jj * dy;
+    for (int kk = 0; kk < n_pts_per_dim; kk++) {  // x
+      scalar_t x            = x_min + kk * dx;
+      h_coordinates(cnt, 0) = x;
+      h_coordinates(cnt, 1) = y;
       cnt++;
     }
   }
@@ -102,27 +102,27 @@ coors_view_t generate_coordinates_3d() {
   scalar_t z_min = 0;
 
   int n_pts_per_dim = 5;
-  int n_spaces = n_pts_per_dim - 1;
+  int n_spaces      = n_pts_per_dim - 1;
 
   int n_pts = n_pts_per_dim * n_pts_per_dim * n_pts_per_dim;
 
-  scalar_t dx = (x_max-x_min)/n_spaces;
-  scalar_t dy = (y_max-y_min)/n_spaces;
-  scalar_t dz = (z_max-z_min)/n_spaces;
+  scalar_t dx = (x_max - x_min) / n_spaces;
+  scalar_t dy = (y_max - y_min) / n_spaces;
+  scalar_t dz = (z_max - z_min) / n_spaces;
 
   coors_view_t coordinates(Kokkos::view_alloc(Kokkos::WithoutInitializing, "coordinates"), n_pts, 3);
   auto h_coordinates = Kokkos::create_mirror_view(coordinates);
 
   int cnt = 0;
-  for (int ii = 0; ii < n_pts_per_dim; ii++) { // z
+  for (int ii = 0; ii < n_pts_per_dim; ii++) {  // z
     scalar_t z = z_min + ii * dz;
-    for (int jj = 0; jj < n_pts_per_dim; jj++) { // y
-      scalar_t y = y_min +jj * dy;
-      for (int kk = 0; kk < n_pts_per_dim; kk++) { // x
-        scalar_t x = x_min + kk * dx;
-        h_coordinates(cnt,0) = x;
-        h_coordinates(cnt,1) = y;
-        h_coordinates(cnt,2) = z;
+    for (int jj = 0; jj < n_pts_per_dim; jj++) {  // y
+      scalar_t y = y_min + jj * dy;
+      for (int kk = 0; kk < n_pts_per_dim; kk++) {  // x
+        scalar_t x            = x_min + kk * dx;
+        h_coordinates(cnt, 0) = x;
+        h_coordinates(cnt, 1) = y;
+        h_coordinates(cnt, 2) = z;
         cnt++;
       }
     }
@@ -154,7 +154,8 @@ void test_rcb(lno_t ndim, lno_t np) {
   lno_t n_levels = static_cast<lno_t>(std::log2(static_cast<double>(np)) + 1);
 
   // Run RCB
-  std::vector<lno_t> partition_sizes = KokkosGraph::Experimental::recursive_coordinate_bisection(coordinates, perm_rcb, reverse_perm_rcb, n_levels);
+  std::vector<lno_t> partition_sizes =
+      KokkosGraph::Experimental::recursive_coordinate_bisection(coordinates, perm_rcb, reverse_perm_rcb, n_levels);
 
   // Check partition sizes
   lno_t sum_partition_sizes = 0;
@@ -164,7 +165,7 @@ void test_rcb(lno_t ndim, lno_t np) {
   ASSERT_EQ(sum_partition_sizes, n_coordinates);
 
   // Check permutations
-  auto h_perm_rcb = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), perm_rcb);
+  auto h_perm_rcb         = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), perm_rcb);
   auto h_reverse_perm_rcb = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), reverse_perm_rcb);
   auto h_coordinates_perm = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), coordinates);
 
@@ -176,19 +177,15 @@ void test_rcb(lno_t ndim, lno_t np) {
   ASSERT_TRUE(dif_flag);
 
   for (lno_t i = 0; i < n_coordinates; i++) {
-    ASSERT_EQ(h_coordinates(i,0), h_coordinates_perm(h_perm_rcb(i),0));
-    if (ndim > 1)
-      ASSERT_EQ(h_coordinates(i,1), h_coordinates_perm(h_perm_rcb(i),1));
-    if (ndim > 2)
-      ASSERT_EQ(h_coordinates(i,2), h_coordinates_perm(h_perm_rcb(i),2));
+    ASSERT_EQ(h_coordinates(i, 0), h_coordinates_perm(h_perm_rcb(i), 0));
+    if (ndim > 1) ASSERT_EQ(h_coordinates(i, 1), h_coordinates_perm(h_perm_rcb(i), 1));
+    if (ndim > 2) ASSERT_EQ(h_coordinates(i, 2), h_coordinates_perm(h_perm_rcb(i), 2));
   }
 
   for (lno_t i = 0; i < n_coordinates; i++) {
-    ASSERT_EQ(h_coordinates_perm(i,0), h_coordinates(h_reverse_perm_rcb(i),0));
-    if (ndim > 1)
-      ASSERT_EQ(h_coordinates_perm(i,1), h_coordinates(h_reverse_perm_rcb(i),1));
-    if (ndim > 2)
-      ASSERT_EQ(h_coordinates_perm(i,2), h_coordinates(h_reverse_perm_rcb(i),2));
+    ASSERT_EQ(h_coordinates_perm(i, 0), h_coordinates(h_reverse_perm_rcb(i), 0));
+    if (ndim > 1) ASSERT_EQ(h_coordinates_perm(i, 1), h_coordinates(h_reverse_perm_rcb(i), 1));
+    if (ndim > 2) ASSERT_EQ(h_coordinates_perm(i, 2), h_coordinates(h_reverse_perm_rcb(i), 2));
   }
 
   // Run RCB on RCB-reordered coordinates. Output permutation and reverse permutation are supposed to be identical

--- a/graph/unit_test/Test_Graph_rcb.hpp
+++ b/graph/unit_test/Test_Graph_rcb.hpp
@@ -178,14 +178,22 @@ void test_rcb(lno_t ndim, lno_t np) {
 
   for (lno_t i = 0; i < n_coordinates; i++) {
     ASSERT_EQ(h_coordinates(i, 0), h_coordinates_perm(h_perm_rcb(i), 0));
-    if (ndim > 1) ASSERT_EQ(h_coordinates(i, 1), h_coordinates_perm(h_perm_rcb(i), 1));
-    if (ndim > 2) ASSERT_EQ(h_coordinates(i, 2), h_coordinates_perm(h_perm_rcb(i), 2));
+    if (ndim > 1) {
+      ASSERT_EQ(h_coordinates(i, 1), h_coordinates_perm(h_perm_rcb(i), 1));
+    }
+    if (ndim > 2) {
+      ASSERT_EQ(h_coordinates(i, 2), h_coordinates_perm(h_perm_rcb(i), 2));
+    }
   }
 
   for (lno_t i = 0; i < n_coordinates; i++) {
     ASSERT_EQ(h_coordinates_perm(i, 0), h_coordinates(h_reverse_perm_rcb(i), 0));
-    if (ndim > 1) ASSERT_EQ(h_coordinates_perm(i, 1), h_coordinates(h_reverse_perm_rcb(i), 1));
-    if (ndim > 2) ASSERT_EQ(h_coordinates_perm(i, 2), h_coordinates(h_reverse_perm_rcb(i), 2));
+    if (ndim > 1) {
+      ASSERT_EQ(h_coordinates_perm(i, 1), h_coordinates(h_reverse_perm_rcb(i), 1));
+    }
+    if (ndim > 2) {
+      ASSERT_EQ(h_coordinates_perm(i, 2), h_coordinates(h_reverse_perm_rcb(i), 2));
+    }
   }
 
   // Run RCB on RCB-reordered coordinates. Output permutation and reverse permutation are supposed to be identical

--- a/graph/unit_test/Test_Graph_rcb.hpp
+++ b/graph/unit_test/Test_Graph_rcb.hpp
@@ -1,0 +1,241 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+
+#include "KokkosGraph_RCB.hpp"
+
+#include <cmath>
+#include <vector>
+
+// Generate 1-D coordinates on a line
+template <typename coors_view_t>
+coors_view_t generate_coordinates_1d() {
+  using scalar_t = typename coors_view_t::value_type;
+
+  scalar_t x_max = 1.1;
+  scalar_t x_min = 0;
+
+  int n_pts_per_dim = 121;
+  int n_spaces = n_pts_per_dim - 1;
+
+  int n_pts = n_pts_per_dim;
+
+  scalar_t dx = (x_max-x_min)/n_spaces;
+
+  coors_view_t coordinates(Kokkos::view_alloc(Kokkos::WithoutInitializing, "coordinates"), n_pts, 1);
+  auto h_coordinates = Kokkos::create_mirror_view(coordinates);
+
+  int cnt = 0;
+  for (int kk = 0; kk < n_pts_per_dim; kk++) { // x
+    scalar_t x = x_min + kk * dx;
+    h_coordinates(cnt,0) = x;
+    cnt++;
+  }
+
+  Kokkos::deep_copy(coordinates, h_coordinates);
+
+  return coordinates;
+}
+
+// Generate 2-D coordinates in a rectangular
+template <typename coors_view_t>
+coors_view_t generate_coordinates_2d() {
+  using scalar_t = typename coors_view_t::value_type;
+
+  scalar_t x_max = 1.1;
+  scalar_t x_min = 0;
+  scalar_t y_max = 1.05;
+  scalar_t y_min = 0;
+
+  int n_pts_per_dim = 11;
+  int n_spaces = n_pts_per_dim - 1;
+
+  int n_pts = n_pts_per_dim * n_pts_per_dim;
+
+  scalar_t dx = (x_max-x_min)/n_spaces;
+  scalar_t dy = (y_max-y_min)/n_spaces;
+
+  coors_view_t coordinates(Kokkos::view_alloc(Kokkos::WithoutInitializing, "coordinates"), n_pts, 2);
+  auto h_coordinates = Kokkos::create_mirror_view(coordinates);
+
+  int cnt = 0;
+  for (int jj = 0; jj < n_pts_per_dim; jj++) { // y
+    scalar_t y = y_min +jj * dy;
+    for (int kk = 0; kk < n_pts_per_dim; kk++) { // x
+      scalar_t x = x_min + kk * dx;
+      h_coordinates(cnt,0) = x;
+      h_coordinates(cnt,1) = y;
+      cnt++;
+    }
+  }
+
+  Kokkos::deep_copy(coordinates, h_coordinates);
+
+  return coordinates;
+}
+
+// Generate 3-D coordinates in a cuboid
+template <typename coors_view_t>
+coors_view_t generate_coordinates_3d() {
+  using scalar_t = typename coors_view_t::value_type;
+
+  scalar_t x_max = 1.1;
+  scalar_t x_min = 0;
+  scalar_t y_max = 1.05;
+  scalar_t y_min = 0;
+  scalar_t z_max = 1.0;
+  scalar_t z_min = 0;
+
+  int n_pts_per_dim = 5;
+  int n_spaces = n_pts_per_dim - 1;
+
+  int n_pts = n_pts_per_dim * n_pts_per_dim * n_pts_per_dim;
+
+  scalar_t dx = (x_max-x_min)/n_spaces;
+  scalar_t dy = (y_max-y_min)/n_spaces;
+  scalar_t dz = (z_max-z_min)/n_spaces;
+
+  coors_view_t coordinates(Kokkos::view_alloc(Kokkos::WithoutInitializing, "coordinates"), n_pts, 3);
+  auto h_coordinates = Kokkos::create_mirror_view(coordinates);
+
+  int cnt = 0;
+  for (int ii = 0; ii < n_pts_per_dim; ii++) { // z
+    scalar_t z = z_min + ii * dz;
+    for (int jj = 0; jj < n_pts_per_dim; jj++) { // y
+      scalar_t y = y_min +jj * dy;
+      for (int kk = 0; kk < n_pts_per_dim; kk++) { // x
+        scalar_t x = x_min + kk * dx;
+        h_coordinates(cnt,0) = x;
+        h_coordinates(cnt,1) = y;
+        h_coordinates(cnt,2) = z;
+        cnt++;
+      }
+    }
+  }
+
+  Kokkos::deep_copy(coordinates, h_coordinates);
+
+  return coordinates;
+}
+
+template <typename scalar_t, typename lno_t, typename device>
+void test_rcb(lno_t ndim, lno_t np) {
+  using coors_view_t = Kokkos::View<scalar_t**, Kokkos::LayoutLeft>;
+  using perm_view_t  = Kokkos::View<lno_t*, Kokkos::LayoutLeft>;
+
+  coors_view_t coordinates;
+  if (ndim == 1)
+    coordinates = generate_coordinates_1d<coors_view_t>();
+  else if (ndim == 2)
+    coordinates = generate_coordinates_2d<coors_view_t>();
+  else
+    coordinates = generate_coordinates_3d<coors_view_t>();
+
+  lno_t n_coordinates = static_cast<lno_t>(coordinates.extent(0));
+  perm_view_t perm_rcb("perm_rcb", n_coordinates);
+  perm_view_t reverse_perm_rcb("reverse_perm_rcb", n_coordinates);
+  auto h_coordinates = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), coordinates);
+
+  lno_t n_levels = static_cast<lno_t>(std::log2(static_cast<double>(np)) + 1);
+
+  // Run RCB
+  std::vector<lno_t> partition_sizes = KokkosGraph::Experimental::recursive_coordinate_bisection(coordinates, perm_rcb, reverse_perm_rcb, n_levels);
+
+  // Check partition sizes
+  lno_t sum_partition_sizes = 0;
+  for (lno_t i = 0; i < static_cast<lno_t>(partition_sizes.size()); i++) {
+    sum_partition_sizes += partition_sizes[i];
+  }
+  ASSERT_EQ(sum_partition_sizes, n_coordinates);
+
+  // Check permutations
+  auto h_perm_rcb = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), perm_rcb);
+  auto h_reverse_perm_rcb = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), reverse_perm_rcb);
+  auto h_coordinates_perm = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), coordinates);
+
+  // Output permutation and reverse permutation should be different
+  bool dif_flag = false;
+  for (lno_t i = 0; i < n_coordinates; i++) {
+    if (h_perm_rcb(i) != h_reverse_perm_rcb(i)) dif_flag = true;
+  }
+  ASSERT_TRUE(dif_flag);
+
+  for (lno_t i = 0; i < n_coordinates; i++) {
+    ASSERT_EQ(h_coordinates(i,0), h_coordinates_perm(h_perm_rcb(i),0));
+    if (ndim > 1)
+      ASSERT_EQ(h_coordinates(i,1), h_coordinates_perm(h_perm_rcb(i),1));
+    if (ndim > 2)
+      ASSERT_EQ(h_coordinates(i,2), h_coordinates_perm(h_perm_rcb(i),2));
+  }
+
+  for (lno_t i = 0; i < n_coordinates; i++) {
+    ASSERT_EQ(h_coordinates_perm(i,0), h_coordinates(h_reverse_perm_rcb(i),0));
+    if (ndim > 1)
+      ASSERT_EQ(h_coordinates_perm(i,1), h_coordinates(h_reverse_perm_rcb(i),1));
+    if (ndim > 2)
+      ASSERT_EQ(h_coordinates_perm(i,2), h_coordinates(h_reverse_perm_rcb(i),2));
+  }
+
+  // Run RCB on RCB-reordered coordinates. Output permutation and reverse permutation are supposed to be identical
+  KokkosGraph::Experimental::recursive_coordinate_bisection(coordinates, perm_rcb, reverse_perm_rcb, n_levels);
+
+  Kokkos::deep_copy(h_perm_rcb, perm_rcb);
+  Kokkos::deep_copy(h_reverse_perm_rcb, reverse_perm_rcb);
+
+  for (lno_t i = 0; i < n_coordinates; i++) {
+    ASSERT_EQ(h_perm_rcb(i), h_reverse_perm_rcb(i));
+  }
+}
+
+#define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE)                                \
+  TEST_F(TestCategory, graph##_##rcb##_##SCALAR##_##ORDINAL##_##OFFSET##_##DEVICE) { \
+    test_rcb<SCALAR, ORDINAL, DEVICE>(1, 2);                                         \
+    test_rcb<SCALAR, ORDINAL, DEVICE>(1, 4);                                         \
+    test_rcb<SCALAR, ORDINAL, DEVICE>(1, 8);                                         \
+    test_rcb<SCALAR, ORDINAL, DEVICE>(1, 16);                                        \
+    test_rcb<SCALAR, ORDINAL, DEVICE>(2, 2);                                         \
+    test_rcb<SCALAR, ORDINAL, DEVICE>(2, 4);                                         \
+    test_rcb<SCALAR, ORDINAL, DEVICE>(2, 8);                                         \
+    test_rcb<SCALAR, ORDINAL, DEVICE>(2, 16);                                        \
+    test_rcb<SCALAR, ORDINAL, DEVICE>(3, 2);                                         \
+    test_rcb<SCALAR, ORDINAL, DEVICE>(3, 4);                                         \
+    test_rcb<SCALAR, ORDINAL, DEVICE>(3, 8);                                         \
+    test_rcb<SCALAR, ORDINAL, DEVICE>(3, 16);                                        \
+  }
+
+#if (defined(KOKKOSKERNELS_INST_ORDINAL_INT) && defined(KOKKOSKERNELS_INST_OFFSET_INT)) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+EXECUTE_TEST(double, int, int, TestDevice)
+#endif
+
+#if (defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T) && defined(KOKKOSKERNELS_INST_OFFSET_INT)) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+EXECUTE_TEST(double, int64_t, int, TestDevice)
+#endif
+
+#if (defined(KOKKOSKERNELS_INST_ORDINAL_INT) && defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+EXECUTE_TEST(double, int, size_t, TestDevice)
+#endif
+
+#if (defined(KOKKOSKERNELS_INST_ORDINAL_INT64_T) && defined(KOKKOSKERNELS_INST_OFFSET_SIZE_T)) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+EXECUTE_TEST(double, int64_t, size_t, TestDevice)
+#endif
+
+#undef EXECUTE_TEST

--- a/sparse/src/KokkosSparse_Utils.hpp
+++ b/sparse/src/KokkosSparse_Utils.hpp
@@ -463,7 +463,7 @@ struct TransposeBsrMatrix {
         Avalues(valuesA),
         tArow_map(row_mapAt),
         tAentries(entriesAt),
-        tAvalues(valuesAt) {};
+        tAvalues(valuesAt){};
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int tArowIdx) const {
@@ -2110,8 +2110,8 @@ kk_extract_diagonal_blocks_crsmatrix_sequential(const crsMat_t &A, std::vector<c
 
         blk_row_start += blk_nrows;
       }  // for (ordinal_type i = 0; i < n_blocks; i++)
-    }  // A_nrows >= 1
-  }  // n_blocks > 1
+    }    // A_nrows >= 1
+  }      // n_blocks > 1
   return perm_v;
 }
 
@@ -2262,8 +2262,8 @@ void kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(const crsMat_t &A,
         // Shift to the next diagonal block
         blk_row_start += blk_nrows;
       }  // for (ordinal_type i = 0; i < n_blocks; i++)
-    }  // A_nrows >= 1
-  }  // n_blocks > 1
+    }    // A_nrows >= 1
+  }      // n_blocks > 1
 }
 
 }  // namespace Impl

--- a/sparse/src/KokkosSparse_Utils.hpp
+++ b/sparse/src/KokkosSparse_Utils.hpp
@@ -26,6 +26,7 @@
 #include "KokkosSparse_BsrMatrix.hpp"
 #include "Kokkos_Bitset.hpp"
 #include "KokkosGraph_RCM.hpp"
+#include "KokkosGraph_RCB.hpp"
 
 #ifdef KOKKOSKERNELS_HAVE_PARALLEL_GNUSORT
 #include <parallel/algorithm>
@@ -2112,6 +2113,148 @@ kk_extract_diagonal_blocks_crsmatrix_sequential(const crsMat_t &A, std::vector<c
     }    // A_nrows >= 1
   }      // n_blocks > 1
   return perm_v;
+}
+
+/**
+ * @brief Apply RCB to the coordinates associated with the rows/columns of a crs matrix then perform matrix permutation using the RCB ordering while extract the diagonal blocks corresponding to the RCB partitions. This is a blocking function that runs on the host.
+ *
+ * @tparam crsMat_t The type of the CRS matrix.
+ * @tparam coor_view_type The type of coordinate list.
+ * @tparam perm_view_type The type of permutation array.
+ * @param A [in] The square CrsMatrix. It is expected that column indices are in ascending order
+ * @param coors [in] The 1/2/3-D coordinates associated with the rows/columns of A
+ * @param DiagBlk_v [out] The vector of the extracted CRS diagonal blocks
+ * (1 <= the number of diagonal blocks <= A_nrows, which is also the number of partitions in the RCB and has to be a power of 2)
+ * @param perm_rcb [out] The permutation array describing the mapping from the original ordering to RCB ordering
+ *
+ * Usage example:
+ *   kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(A_in, coors, diagBlk_out, perm);
+ */
+template <typename crsMat_t, typename coor_view_type, typename perm_view_type>
+void
+kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(const crsMat_t &A, coor_view_type &coors, std::vector<crsMat_t> &DiagBlk_v, perm_view_type &perm_rcb) {
+  using row_map_type     = typename crsMat_t::row_map_type;
+  using entries_type     = typename crsMat_t::index_type;
+  using values_type      = typename crsMat_t::values_type;
+  using graph_t          = typename crsMat_t::StaticCrsGraphType;
+  using out_row_map_type = typename graph_t::row_map_type::non_const_type;
+  using out_entries_type = typename graph_t::entries_type::non_const_type;
+  using out_values_type  = typename crsMat_t::values_type::non_const_type;
+
+  using ordinal_type = typename crsMat_t::non_const_ordinal_type;
+  using size_type    = typename crsMat_t::non_const_size_type;
+
+  row_map_type A_row_map = A.graph.row_map;
+  entries_type A_entries = A.graph.entries;
+  values_type  A_values  = A.values;
+
+  auto A_row_map_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A_row_map);
+  auto A_entries_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A_entries);
+  auto A_values_h  = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A_values);
+
+  ordinal_type A_nrows  = static_cast<ordinal_type>(A.numRows());
+  ordinal_type A_ncols  = static_cast<ordinal_type>(A.numCols());
+  ordinal_type n_blocks = static_cast<ordinal_type>(DiagBlk_v.size());
+
+  if (A_nrows != A_ncols) {
+    std::ostringstream os;
+    os << "The diagonal block extraction only works with square matrices -- "
+          "matrix A: "
+       << A_nrows << " x " << A_ncols;
+    throw std::runtime_error(os.str());
+  }
+
+  if (n_blocks == 1) {
+    // One block case: simply shallow copy A to DiagBlk_v[0]
+    DiagBlk_v[0] = crsMat_t(A);
+    Kokkos::parallel_for( Kokkos::RangePolicy<typename perm_view_type::device_type::execution_space>(0, static_cast<int>(A_nrows)), KOKKOS_LAMBDA ( const ordinal_type& i ) {
+      perm_rcb(i) = i;
+    });
+  } else {
+    // n_blocks > 1
+    if (A_nrows == 0) {
+      // Degenerate case: A is an empty matrix
+      for (ordinal_type i = 0; i < n_blocks; i++) {
+        DiagBlk_v[i] = crsMat_t();
+      }
+    } else {
+      // A_nrows >= 1
+      if ((n_blocks < 1) || (A_nrows < n_blocks)) {
+        std::ostringstream os;
+        os << "The number of diagonal blocks (" << n_blocks
+           << ") should be >=1 and <= the number of rows of the matrix A (" << A_nrows << ")";
+        throw std::runtime_error(os.str());
+      }
+
+      if (static_cast<ordinal_type>(std::pow(2, static_cast<int>(std::log2(n_blocks)))) != n_blocks) {
+        std::ostringstream os;
+        os << "The number of diagonal blocks (" << n_blocks << ") must be a power of 2";
+        throw std::runtime_error(os.str());
+	  }
+
+      // Perform RCB on the coordinates associated with the row/col indices first
+      perm_view_type reverse_perm_rcb(Kokkos::view_alloc(Kokkos::WithoutInitializing, "reverse_perm_rcb"), A_nrows);
+      ordinal_type n_levels = static_cast<ordinal_type>(std::log2(static_cast<double>(n_blocks)) + 1);
+      std::vector<ordinal_type> partition_sizes = KokkosGraph::Experimental::recursive_coordinate_bisection<coor_view_type, perm_view_type, ordinal_type>(coors, perm_rcb, reverse_perm_rcb, n_levels);
+
+      auto h_perm_rcb = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), perm_rcb);
+      auto h_reverse_perm_rcb = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), reverse_perm_rcb);
+
+      ordinal_type blk_row_start = 0;     // first row index of i-th diagonal block
+      ordinal_type blk_col_start = 0;     // first col index of i-th diagonal block
+      ordinal_type blk_nrows, blk_ncols;  // Nrows, Ncols of i-th diagonal block
+
+      for (ordinal_type i = 0; i < n_blocks; i++) {
+        blk_nrows = partition_sizes[i];
+        blk_ncols = blk_nrows;
+        blk_col_start = blk_row_start;
+
+        // First round: count non-zeros of block i, fill row map vector of block i, and store mapping from new column indices to locations on the original entries
+        out_row_map_type row_map(Kokkos::view_alloc(Kokkos::WithoutInitializing, "row_map"), blk_nrows + 1);
+        auto row_map_h = Kokkos::create_mirror_view(row_map);
+        std::vector<std::map<ordinal_type, size_type>> colIdx_entryIdx_rcb(blk_nrows);
+        size_type blk_nnz = 0;
+        for (ordinal_type ii = 0; ii < blk_nrows; ii++) { // ii: reordered index
+          row_map_h(ii) = blk_nnz;
+          ordinal_type origRow = h_reverse_perm_rcb(blk_row_start + ii); // get the original row idx of the reordered row idx ii
+          for (size_type j = A_row_map_h(origRow); j < A_row_map_h(origRow + 1); j++) {
+            ordinal_type origColId = A_entries_h(j);
+            ordinal_type newColId = h_perm_rcb(origColId);  // get the reordered col idx of the original col idx
+            if ((newColId >= blk_col_start) && (newColId < (blk_col_start + blk_ncols))) {
+              colIdx_entryIdx_rcb[ii][newColId - blk_col_start] = j;
+              blk_nnz++;
+            }
+          }
+        }
+        row_map_h(blk_nrows) = blk_nnz;
+
+        // Second round: fill entries and values of block i
+        out_entries_type entries(Kokkos::view_alloc(Kokkos::WithoutInitializing, "entries"), blk_nnz);
+        out_values_type  values (Kokkos::view_alloc(Kokkos::WithoutInitializing, "values"),  blk_nnz);
+        auto entries_h = Kokkos::create_mirror_view(entries);
+        auto values_h = Kokkos::create_mirror_view(values);
+        blk_nnz = 0;
+        for (ordinal_type ii = 0; ii < blk_nrows; ii++) {
+          for (typename std::map<ordinal_type, size_type>::iterator it = colIdx_entryIdx_rcb[ii].begin(); it != colIdx_entryIdx_rcb[ii].end(); ++it) {
+            entries_h(blk_nnz) = it->first;
+            values_h(blk_nnz)  = A_values_h(it->second);
+            blk_nnz++;
+          }
+        }
+
+        // Copy H->D
+        Kokkos::deep_copy(row_map, row_map_h);
+        Kokkos::deep_copy(entries, entries_h);
+        Kokkos::deep_copy(values, values_h);
+
+        // Create CRS matrix for this block
+        DiagBlk_v[i] = crsMat_t("CrsMatrix", blk_nrows, blk_ncols, blk_nnz, values, row_map, entries);
+
+        // Shift to the next diagonal block
+        blk_row_start += blk_nrows;
+      }  // for (ordinal_type i = 0; i < n_blocks; i++)
+    }    // A_nrows >= 1
+  }      // n_blocks > 1
 }
 
 }  // namespace Impl

--- a/sparse/unit_test/Test_Sparse.hpp
+++ b/sparse/unit_test/Test_Sparse.hpp
@@ -43,6 +43,7 @@
 #include "Test_Sparse_crs2ccs.hpp"
 #include "Test_Sparse_removeCrsMatrixZeros.hpp"
 #include "Test_Sparse_extractCrsDiagonalBlocks.hpp"
+#include "Test_Sparse_extractCrsDiagonalBlocksRCB.hpp"
 #include "Test_Sparse_StaticCrsGraph.hpp"
 
 // TPL specific tests, these require

--- a/sparse/unit_test/Test_Sparse_extractCrsDiagonalBlocksRCB.hpp
+++ b/sparse/unit_test/Test_Sparse_extractCrsDiagonalBlocksRCB.hpp
@@ -1,0 +1,200 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include "KokkosSparse_Utils.hpp"
+#include "KokkosKernels_TestUtils.hpp"
+
+namespace Test {
+template <typename coors_view_t>
+typename coors_view_t::value_type
+generate_3d_coordinates_for_sparse_rows(int n_pts_per_dim, coors_view_t &coordinates) {
+  using scalar_t = typename coors_view_t::value_type;
+
+  scalar_t x_max = 1.1;
+  scalar_t x_min = 0;
+  scalar_t y_max = 1.05;
+  scalar_t y_min = 0;
+  scalar_t z_max = 1.0;
+  scalar_t z_min = 0;
+
+  int n_spaces = n_pts_per_dim - 1;
+
+  scalar_t dx = (x_max-x_min)/n_spaces;
+  scalar_t dy = (y_max-y_min)/n_spaces;
+  scalar_t dz = (z_max-z_min)/n_spaces;
+
+  auto h_coordinates = Kokkos::create_mirror_view(coordinates);
+
+  int cnt = 0;
+  for (int ii = 0; ii < n_pts_per_dim; ii++) { // z
+    scalar_t z = z_min + ii * dz;
+    for (int jj = 0; jj < n_pts_per_dim; jj++) { // y
+      scalar_t y = y_min +jj * dy;
+      for (int kk = 0; kk < n_pts_per_dim; kk++) { // x
+        scalar_t x = x_min + kk * dx;
+        h_coordinates(cnt,0) = x;
+        h_coordinates(cnt,1) = y;
+        h_coordinates(cnt,2) = z;
+        cnt++;
+      }
+    }
+  }
+
+  Kokkos::deep_copy(coordinates, h_coordinates);
+
+  return dx;
+}
+
+template <typename scalar_t, typename lno_t, typename size_type, typename device>
+void run_test_extract_diagonal_blocks_rcb(lno_t n_pts_per_dim, lno_t nblocks) {
+  using RowMapType       = Kokkos::View<size_type *, device>;
+  using EntriesType      = Kokkos::View<lno_t *, device>;
+  using ValuesType       = Kokkos::View<scalar_t *, device>;
+  using magnitude_t      = typename Kokkos::ArithTraits<scalar_t>::mag_type;
+  using CoorsViewType    = Kokkos::View<magnitude_t **, device>;
+  using PermViewType     = Kokkos::View<lno_t *, device>;
+  using CoorsViewType_hm = typename CoorsViewType::HostMirror;
+  using PermViewType_hm  = typename PermViewType::HostMirror;
+  using crsMat_t         = KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>;  
+
+  crsMat_t A;
+  std::vector<crsMat_t> DiagBlks(nblocks);
+
+  // Generate coordinates
+  lno_t n_coordinates = n_pts_per_dim * n_pts_per_dim * n_pts_per_dim;
+  CoorsViewType coordinates(Kokkos::view_alloc(Kokkos::WithoutInitializing, "coordinates"), n_coordinates, 3);
+  CoorsViewType_hm h_coordinates = Kokkos::create_mirror(coordinates);
+  magnitude_t dx = generate_3d_coordinates_for_sparse_rows<CoorsViewType_hm>(n_pts_per_dim, h_coordinates);
+  Kokkos::deep_copy(coordinates, h_coordinates);
+
+  // Generate test matrix consisting of near interactions calculated based on coordinates
+  lno_t nrows = n_coordinates;
+  RowMapType row_map(Kokkos::view_alloc(Kokkos::WithoutInitializing, "row_map"), nrows + 1);
+  auto h_row_map = Kokkos::create_mirror_view(row_map);
+
+  std::vector<std::pair<lno_t,lno_t>> near_indices;
+  lno_t nnz = 0;
+  for (lno_t i = 0; i < nrows; i++) {
+    h_row_map(i) = nnz;
+    for (lno_t j = 0; j < nrows; j++) {
+      magnitude_t distance = sqrt(pow(h_coordinates(i,0) - h_coordinates(j,0), 2.0) +
+                                  pow(h_coordinates(i,1) - h_coordinates(j,1), 2.0) +
+                                  pow(h_coordinates(i,2) - h_coordinates(j,2), 2.0));
+      if (distance <= dx) {
+        nnz++;
+        near_indices.push_back(std::make_pair(i,j));
+      }
+    }
+  }
+  h_row_map(nrows) = nnz;
+
+  EntriesType entries(Kokkos::view_alloc(Kokkos::WithoutInitializing, "entries"), nnz);
+  ValuesType values(Kokkos::view_alloc(Kokkos::WithoutInitializing, "values"), nnz);
+  auto h_entries = Kokkos::create_mirror_view(entries);
+  auto h_values  = Kokkos::create_mirror_view(values);
+  
+  for (lno_t ii = 0; ii < nnz; ii++) {
+    lno_t i = near_indices[ii].first;
+    lno_t j = near_indices[ii].second;
+    h_entries(ii) = j;
+    h_values(ii) = i*10 + j + 1;
+  }
+
+  // Copy from host to device
+  Kokkos::deep_copy(row_map, h_row_map);
+  Kokkos::deep_copy(entries, h_entries);
+  Kokkos::deep_copy(values, h_values);
+
+  // Construct a CRS matrix
+  A = crsMat_t("CrsMatrix", nrows, nrows, nnz, values, row_map, entries);
+
+  // Extract diagonal blocks
+  PermViewType perm_rcb(Kokkos::view_alloc(Kokkos::WithoutInitializing, "perm_rcb"), n_coordinates);
+  KokkosSparse::Impl::kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(A, coordinates, DiagBlks, perm_rcb);  
+
+  // Checking results
+  lno_t numRows = 0;
+  lno_t numCols = 0;
+  for (lno_t i = 0; i < nblocks; i++) {
+    numRows += DiagBlks[i].numRows();
+    numCols += DiagBlks[i].numCols();
+  }
+
+  ASSERT_EQ(numRows, nrows);
+  ASSERT_EQ(numCols, nrows);
+  
+  lno_t n_levels = static_cast<lno_t>(std::log2(static_cast<double>(nblocks)) + 1);
+  PermViewType_hm perm_rcb_ref(Kokkos::view_alloc(Kokkos::WithoutInitializing, "perm_rcb_ref"), n_coordinates);
+  PermViewType_hm reverse_perm_rcb_ref(Kokkos::view_alloc(Kokkos::WithoutInitializing, "reverse_perm_rcb_ref"), n_coordinates);
+  std::vector<lno_t> partition_sizes = KokkosGraph::Experimental::recursive_coordinate_bisection(h_coordinates, perm_rcb_ref, reverse_perm_rcb_ref, n_levels);
+
+  std::map<lno_t, scalar_t> colIdx_Value_rcb;
+
+  lno_t blk_size;
+  lno_t blk_start = 0;
+  for (lno_t i = 0; i < nblocks; i++) { // block loop
+    auto h_row_map_diagblk = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), DiagBlks[i].graph.row_map);
+    auto h_entries_diagblk = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), DiagBlks[i].graph.entries);
+    auto h_values_diagblk  = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), DiagBlks[i].values);
+
+    ASSERT_EQ(static_cast<lno_t>(DiagBlks[i].numRows()), partition_sizes[i]);
+
+    blk_size = partition_sizes[i];
+    size_type blk_nnz = 0;
+    for (lno_t ii = 0; ii < blk_size; ii++) { // row loop in each block
+      ASSERT_EQ(h_row_map_diagblk(ii), blk_nnz);
+      colIdx_Value_rcb.clear();
+      lno_t origRow = reverse_perm_rcb_ref(blk_start + ii);  // get the original row idx of the reordered row idx, ii
+      for (size_type j = h_row_map(origRow); j < h_row_map(origRow + 1); j++) {
+        lno_t origEi = h_entries(j);
+        scalar_t origV = h_values(j);
+        lno_t Ei = perm_rcb_ref(origEi);  // get the reordered col idx of the
+                                          // original col idx, origEi
+        colIdx_Value_rcb[Ei] = origV;
+      }
+      for (typename std::map<lno_t, scalar_t>::iterator it = colIdx_Value_rcb.begin(); it != colIdx_Value_rcb.end(); ++it) {
+        if ((it->first >= blk_start) && (it->first < (blk_start + blk_size))) {
+          ASSERT_EQ(h_entries_diagblk(blk_nnz) + blk_start, it->first);
+          ASSERT_EQ(h_values_diagblk(blk_nnz), it->second);
+          blk_nnz++;
+        }
+      }
+    } // row loop in each block
+    blk_start += DiagBlks[i].numCols();
+  } // block loop
+}
+}  // namespace Test
+
+template <typename scalar_t, typename lno_t, typename size_type, typename device>
+void test_extract_diagonal_blocks_rcb() {
+  Test::run_test_extract_diagonal_blocks_rcb<scalar_t, lno_t, size_type, device>(5, 2);
+  Test::run_test_extract_diagonal_blocks_rcb<scalar_t, lno_t, size_type, device>(5, 4);
+  Test::run_test_extract_diagonal_blocks_rcb<scalar_t, lno_t, size_type, device>(5, 8);
+  Test::run_test_extract_diagonal_blocks_rcb<scalar_t, lno_t, size_type, device>(5, 16);
+  Test::run_test_extract_diagonal_blocks_rcb<scalar_t, lno_t, size_type, device>(9, 2);
+  Test::run_test_extract_diagonal_blocks_rcb<scalar_t, lno_t, size_type, device>(9, 4);
+  Test::run_test_extract_diagonal_blocks_rcb<scalar_t, lno_t, size_type, device>(9, 8);
+  Test::run_test_extract_diagonal_blocks_rcb<scalar_t, lno_t, size_type, device>(9, 16);
+}
+
+#define KOKKOSKERNELS_EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE)                                       \
+  TEST_F(TestCategory, sparse##_##extract_diagonal_blocks_rcb##_##SCALAR##_##ORDINAL##_##OFFSET##_##DEVICE) { \
+    test_extract_diagonal_blocks_rcb<SCALAR, ORDINAL, OFFSET, DEVICE>();                                      \
+  }
+
+#include <Test_Common_Test_All_Type_Combos.hpp>
+
+#undef KOKKOSKERNELS_EXECUTE_TEST


### PR DESCRIPTION
In this PR, I added a very first implementation of RCB to the Graph component. Optimizations will be addressed in upcoming PRs.
I also added a utility function to extract diagonal blocks (in CSR format) after RCB reordering the original CSR matrix. This is for generating input matrices for use in KK stream SPILUK.