### PR TITLE
Fix for trilinos 14277: don't pollute global namespace

### DIFF
--- a/example/wiki/blas/KokkosBlas1_wiki_rotg_rot.cpp
+++ b/example/wiki/blas/KokkosBlas1_wiki_rotg_rot.cpp
@@ -5,12 +5,12 @@
 #include "KokkosBlas1_rot.hpp"
 #include "KokkosKernels_PrintUtils.hpp"
 
-using execution_space = Kokkos::DefaultExecutionSpace;
-using Scalar          = double;
-using Vector          = Kokkos::View<Scalar*, execution_space>;
-using ScalarView      = Kokkos::View<Scalar, execution_space>;
-
 int main(int argc, char* argv[]) {
+  using execution_space = Kokkos::DefaultExecutionSpace;
+  using Scalar          = double;
+  using Vector          = Kokkos::View<Scalar*, execution_space>;
+  using ScalarView      = Kokkos::View<Scalar, execution_space>;
+
   Kokkos::initialize(argc, argv);
   {
     const int N = 10;

--- a/example/wiki/blas/KokkosBlas1_wiki_rotmg_rotm.cpp
+++ b/example/wiki/blas/KokkosBlas1_wiki_rotmg_rotm.cpp
@@ -5,13 +5,13 @@
 #include "KokkosBlas1_rotm.hpp"
 #include "KokkosKernels_PrintUtils.hpp"
 
-using execution_space = Kokkos::DefaultExecutionSpace;
-using Scalar          = double;
-using Vector          = Kokkos::View<Scalar*, execution_space>;
-using ParamView       = Kokkos::View<Scalar[5], execution_space>;
-using ScalarView      = Kokkos::View<Scalar, execution_space>;
-
 int main(int argc, char* argv[]) {
+  using execution_space = Kokkos::DefaultExecutionSpace;
+  using Scalar          = double;
+  using Vector          = Kokkos::View<Scalar*, execution_space>;
+  using ParamView       = Kokkos::View<Scalar[5], execution_space>;
+  using ScalarView      = Kokkos::View<Scalar, execution_space>;
+
   Kokkos::initialize(argc, argv);
   {
     const int N = 10;


### PR DESCRIPTION
Probable fix for https://github.com/trilinos/Trilinos/issues/14277

I couldn't actually reproduce it locally, but here's an example:

https://godbolt.org/z/h9Ez4Knsv