### PR TITLE
CI: adding new build to test previous minor release

### DIFF
--- a/.github/workflows/at2.yml
+++ b/.github/workflows/at2.yml
@@ -34,6 +34,7 @@ jobs:
     uses: ./.github/workflows/v100_kumquat.yml
     with:
       kokkos_version: 4.7.00
+      kokkos_previous_version: 4.6.02
   bdw:
     uses: ./.github/workflows/bdw.yml
     with:

--- a/.github/workflows/v100_kumquat.yml
+++ b/.github/workflows/v100_kumquat.yml
@@ -18,6 +18,11 @@ on:
         default: ''
         required: true
         type: string
+      kokkos_previous_version:
+        description: 'The last release of the previous minor series'
+        default: ''
+        required: true
+        type: string
 
 jobs:
   PR_VOLTA70_CUDA1262_CUDA_LEFT_REL:

--- a/.github/workflows/v100_kumquat.yml
+++ b/.github/workflows/v100_kumquat.yml
@@ -209,11 +209,11 @@ jobs:
             -DBUILD_SHARED_LIBS=OFF \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_COMPILER=$(realpath kokkos)/bin/nvcc_wrapper \
-	    -DCMAKE_CXX_STANDARD=20 \
+            -DCMAKE_CXX_STANDARD=20 \
             -DKokkos_ROOT=kokkos/install \
             -DKokkosKernels_ENABLE_TESTS=ON \
             -DKokkosKernels_ENABLE_EXAMPLES=ON \
-	    -DKokkosKernels_ENABLE_BENCHMARKS=ON \
+            -DKokkosKernels_ENABLE_BENCHMARKS=ON \
             -DKokkosKernels_ENABLE_DOCS=OFF
 
       - name: build_kokkos_kernels

--- a/.github/workflows/v100_kumquat.yml
+++ b/.github/workflows/v100_kumquat.yml
@@ -138,17 +138,16 @@ jobs:
         run: |
           mkdir -p kokkos-kernels/{build,install}
           cmake -S kokkos-kernels -B kokkos-kernels/build \
+            -DBUILD_SHARED_LIBS=OFF \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_COMPILER=$(realpath kokkos)/bin/nvcc_wrapper \
             -DKokkos_ROOT=kokkos/install \
-            -DKokkosKernels_ENABLE_TESTS_AND_PERFSUITE=OFF \
             -DKokkosKernels_ENABLE_TESTS=ON \
-            -DKokkosKernels_ENABLE_PERFTESTS=ON \
             -DKokkosKernels_ENABLE_EXAMPLES=ON \
+            -DKokkosKernels_ENABLE_PERFTESTS=ON \
             -DKokkosKernels_ENABLE_TPL_CUSOLVER=OFF \
             -DKokkosKernels_ENABLE_TPL_CUSPARSE=OFF \
             -DKokkosKernels_ENABLE_TPL_CUBLAS=OFF \
-            -DBUILD_SHARED_LIBS=OFF \
             -DKokkosKernels_ENABLE_DOCS=OFF
 
       - name: build_kokkos_kernels
@@ -159,3 +158,70 @@ jobs:
       - name: test
         working-directory: kokkos-kernels/build
         run: ctest --output-on-failure -V --timeout 3600
+
+  PR_VOLTA70_CUDA1200_CUDA_LEFT_PREVIOUS_MINOR_REL:
+    name: PR_VOLTA70_CUDA1200_CUDA_LEFT_REL
+    runs-on: [kumquat-cuda-12.0.0-openblas-0.3.28]
+
+    steps:
+      - name: nvidia-smi
+        run: nvidia-smi
+
+      - name: cuda-visible-devices
+        run: echo $CUDA_VISIBLE_DEVICES
+
+      - name: checkout_kokkos_kernels
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: kokkos-kernels
+
+      - name: checkout_kokkos
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: kokkos/kokkos
+          ref: ${{ inputs.kokkos_previous_version }}
+          path: kokkos
+
+      - name: configure_kokkos
+        run: |
+          mkdir -p kokkos/{build,install}
+          cmake -S kokkos -B kokkos/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER=$(realpath kokkos)/bin/nvcc_wrapper \
+            -DCMAKE_INSTALL_PREFIX=kokkos/install \
+            -DKokkos_ENABLE_CUDA=ON \
+            -DKokkos_ARCH_VOLTA70=ON \
+            -DKokkos_ENABLE_TESTS=OFF \
+            -DKokkos_ENABLE_EXAMPLES=OFF \
+            -DCMAKE_CXX_EXTENSIONS=OFF \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF
+
+      - name: build_and_install_kokkos
+        working-directory: kokkos/build
+        # kumquat has 96 CPUs
+        run: cmake --build . --parallel 24 --target install
+
+      - name: configure_kokkos_kernels
+        run: |
+          mkdir -p kokkos-kernels/{build,install}
+          cmake -S kokkos-kernels -B kokkos-kernels/build \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER=$(realpath kokkos)/bin/nvcc_wrapper \
+	    -DCMAKE_CXX_STANDARD=20 \
+            -DKokkos_ROOT=kokkos/install \
+            -DKokkosKernels_ENABLE_TESTS=ON \
+            -DKokkosKernels_ENABLE_EXAMPLES=ON \
+	    -DKokkosKernels_ENABLE_BENCHMARKS=ON \
+            -DKokkosKernels_ENABLE_DOCS=OFF
+
+      - name: build_kokkos_kernels
+        working-directory: kokkos-kernels/build
+        # kumquat has 96 CPUs
+        run: cmake --build . --parallel 24 --target all
+
+      - name: test
+        working-directory: kokkos-kernels/build
+        run: ctest --output-on-failure -V --timeout 3600
+


### PR DESCRIPTION
This will allow us to check that both the current and previous minor release of Kokkos Core and compatible with Kokkos Kernels' develop branch.