### PR TITLE
cusparse spmv_mv: use native fallback if y not 16B aligned

### DIFF
--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -278,6 +278,12 @@ void spmv(const ExecutionSpace& space, Handle* handle, const char mode[], const 
       if constexpr (std::is_same_v<ExecutionSpace, Kokkos::Cuda>) {
         useNative = useNative || (Conjugate[0] == mode[0]);
       }
+      // cuSPARSE 12 requires that the output (y) vector is 16-byte aligned for
+      // all scalar types
+#if defined(CUSPARSE_VER_MAJOR) && (CUSPARSE_VER_MAJOR == 12)
+      uintptr_t yptr = uintptr_t((void*)y.data());
+      if (yptr % 16 != 0) useNative = true;
+#endif
 #endif
 #ifdef KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE
       if constexpr (std::is_same_v<ExecutionSpace, Kokkos::HIP>) {


### PR DESCRIPTION
This is the same workaround as #1889, but now for the spmv mv (rank-2) case.

Also add a new spmv test that replicates this kind of issue for both rank-1 and rank-2 cases.