### PR TITLE
Avoid using `Kokkos::reduction_identity`

### DIFF
--- a/batched/dense/unit_test/Test_Batched_DenseUtils.hpp
+++ b/batched/dense/unit_test/Test_Batched_DenseUtils.hpp
@@ -22,7 +22,7 @@ namespace KokkosBatched {
 template <typename MatrixViewType, typename VectorViewType>
 void create_tridiagonal_batched_matrices(const MatrixViewType& A, const VectorViewType& B) {
   Kokkos::Random_XorShift64_Pool<typename VectorViewType::device_type::execution_space> random(13718);
-  Kokkos::fill_random(B, random, Kokkos::reduction_identity<typename VectorViewType::value_type>::prod());
+  Kokkos::fill_random(B, random, 1);
 
   auto A_host = Kokkos::create_mirror_view(A);
 

--- a/batched/sparse/unit_test/Test_Batched_SparseUtils.hpp
+++ b/batched/sparse/unit_test/Test_Batched_SparseUtils.hpp
@@ -22,8 +22,8 @@ void create_tridiagonal_batched_matrices(const int nnz, const int BlkSize, const
                                          const IntView &c, const VectorViewType &D, const VectorViewType &X,
                                          const VectorViewType &B) {
   Kokkos::Random_XorShift64_Pool<typename VectorViewType::device_type::execution_space> random(13718);
-  Kokkos::fill_random(X, random, Kokkos::reduction_identity<typename VectorViewType::value_type>::prod());
-  Kokkos::fill_random(B, random, Kokkos::reduction_identity<typename VectorViewType::value_type>::prod());
+  Kokkos::fill_random(X, random, 1);
+  Kokkos::fill_random(B, random, 1);
 
   auto D_host = Kokkos::create_mirror_view(D);
   auto r_host = Kokkos::create_mirror_view(r);

--- a/example/batched_solve/examples_helper.hpp
+++ b/example/batched_solve/examples_helper.hpp
@@ -72,8 +72,8 @@ void create_saddle_point_matrices(const MatrixViewType &A, const VectorViewType 
   MatrixViewType xs("xs", N, n_1, n_dim);
   VectorViewType ys("ys", N, n_1);
 
-  Kokkos::fill_random(xs, random, Kokkos::reduction_identity<typename MatrixViewType::value_type>::prod());
-  Kokkos::fill_random(ys, random, Kokkos::reduction_identity<typename VectorViewType::value_type>::prod());
+  Kokkos::fill_random(xs, random, 1);
+  Kokkos::fill_random(ys, random, 1);
 
   auto xs_host = Kokkos::create_mirror_view(xs);
   auto ys_host = Kokkos::create_mirror_view(ys);
@@ -121,8 +121,8 @@ void create_tridiagonal_batched_matrices(const int nnz, const int BlkSize, const
                                          const IntView &c, const VectorViewType &D, const VectorViewType &X,
                                          const VectorViewType &B) {
   Kokkos::Random_XorShift64_Pool<typename VectorViewType::device_type::execution_space> random(13718);
-  Kokkos::fill_random(X, random, Kokkos::reduction_identity<typename VectorViewType::value_type>::prod());
-  Kokkos::fill_random(B, random, Kokkos::reduction_identity<typename VectorViewType::value_type>::prod());
+  Kokkos::fill_random(X, random, 1);
+  Kokkos::fill_random(B, random, 1);
 
   auto D_host = Kokkos::create_mirror_view(D);
   auto r_host = Kokkos::create_mirror_view(r);

--- a/perf_test/sparse/KokkosSparse_gs.cpp
+++ b/perf_test/sparse/KokkosSparse_gs.cpp
@@ -106,7 +106,7 @@ crsMat_t generateLongRowMatrix(const GS_Parameters& params) {
   // head)
   std::vector<lno_t> longRowEntries(numRows);
   for (lno_t i = 0; i < numRows; i++) longRowEntries[i] = i;
-  const scalar_t one = Kokkos::reduction_identity<scalar_t>::prod();
+  const scalar_t one = 1;
   for (lno_t i = 0; i < numRows; i++) {
     shortRowEntries.clear();
     bool rowIsLong = rowLengths[i] > params.nnzPerRow;
@@ -302,7 +302,7 @@ void runGS(const GS_Parameters& params) {
     scalar_view_t res("Ax-b", blk_nrows);
     Kokkos::deep_copy(instances[i], res, b[i]);
     double bnorm   = KokkosBlas::nrm2(instances[i], b[i]);
-    scalar_t alpha = Kokkos::reduction_identity<scalar_t>::prod();
+    scalar_t alpha = 1;
     scalar_t beta  = -alpha;
     KokkosSparse::spmv<exec_space, scalar_t, crsMat_t, scalar_view_t, scalar_t, scalar_view_t>(instances[i], "N", alpha,
                                                                                                blk_A, x[i], beta, res);

--- a/sparse/impl/KokkosSparse_mdf_impl.hpp
+++ b/sparse/impl/KokkosSparse_mdf_impl.hpp
@@ -144,8 +144,8 @@ struct MDF_discarded_fill_norm {
 
     KOKKOS_INLINE_FUNCTION
     static void init(value_type& val) {
-      val.discarded_norm = Kokkos::reduction_identity<scalar_mag_type>::sum();
-      val.numFillEntries = Kokkos::reduction_identity<ordinal_type>::sum();
+      val.discarded_norm = 0;
+      val.numFillEntries = 0;
       val.diag_val       = KAS::zero();
     }
 


### PR DESCRIPTION
It is intended as a customization point for enabling builtin reducers with user-defined types, and we generally don't want it to appear in user code.