### PR TITLE
Move CUDA 12.0.0 jobs to 12.2.2

### DIFF
--- a/.github/workflows/v100_kumquat.yml
+++ b/.github/workflows/v100_kumquat.yml
@@ -181,7 +181,7 @@ jobs:
         run: ctest --output-on-failure -V --timeout 3600
 
   PR_VOLTA70_CUDA1222_CUDA_LEFT_PREVIOUS_MINOR_REL:
-    name: PR_VOLTA70_CUDA1222_CUDA_LEFT_REL
+    name: PR_VOLTA70_CUDA1222_CUDA_LEFT_REL_PREVIOUS_MINOR_REL
     runs-on: [kumquat-cuda-12.2.2-openblas-0.3.29]
 
     steps:

--- a/.github/workflows/v100_kumquat.yml
+++ b/.github/workflows/v100_kumquat.yml
@@ -107,9 +107,9 @@ jobs:
         working-directory: kokkos-kernels/build
         run: ctest --output-on-failure -V --timeout 3600
 
-  PR_VOLTA70_CUDA1200_CUDA_LEFT_REL:
-    name: PR_VOLTA70_CUDA1200_CUDA_LEFT_REL
-    runs-on: [kumquat-cuda-12.0.0-openblas-0.3.28]
+  PR_VOLTA70_CUDA1222_CUDA_LEFT_REL:
+    name: PR_VOLTA70_CUDA1222_CUDA_LEFT_REL
+    runs-on: [kumquat-cuda-12.2.2-openblas-0.3.29]
 
     steps:
       - name: nvidia-smi
@@ -180,9 +180,9 @@ jobs:
         working-directory: kokkos-kernels/build
         run: ctest --output-on-failure -V --timeout 3600
 
-  PR_VOLTA70_CUDA1200_CUDA_LEFT_PREVIOUS_MINOR_REL:
-    name: PR_VOLTA70_CUDA1200_CUDA_LEFT_REL
-    runs-on: [kumquat-cuda-12.0.0-openblas-0.3.28]
+  PR_VOLTA70_CUDA1222_CUDA_LEFT_PREVIOUS_MINOR_REL:
+    name: PR_VOLTA70_CUDA1222_CUDA_LEFT_REL
+    runs-on: [kumquat-cuda-12.2.2-openblas-0.3.29]
 
     steps:
       - name: nvidia-smi


### PR DESCRIPTION
Kokkos 5 will not support 12.0.0

Already set up the 12.2.2 runner on Kumquat, will retire the 12.0.0 runner once this merges.