### PR TITLE
added check for git submodule checkout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,19 @@ IF (NOT KOKKOSKERNELS_HAS_TRILINOS)
     set(BLT_CODE_CHECK_TARGET_NAME "fix-for-blt" CACHE STRING "Docstring")
     set(INFRASTRUCTURE_ONLY ON CACHE BOOL "Only build the RAJAPerf infrastructure, no builtin kernels")
     add_definitions("-DRAJAPERF_INFRASTRUCTURE_ONLY")
+    # Check if this directory is empty,
+    # Populate submodule if possible - Fail gracefully otherwise
+    file(GLOB_RECURSE FILE_LIST "tpls/rajaperf/*.*")
+    list(LENGTH FILE_LIST RES_LEN)
+    IF(RES_LEN EQUAL 0)
+    # directory is empty - cannot find the submodule
+    # throw an error to the user so they know, and do not build tests
+      message(SEND_ERROR "Perftools submodule not found -- run `git submodule update --init --recursive` in a terminal to update submodules, then try again. ")
+      set(KokkosKernels_ENABLE_PERFTESTS OFF CACHE BOOL "Building tests and Perfsuite switched off." FORCE)
+    ELSE()
+      add_subdirectory(tpls/rajaperf)
+      include_directories(tpls/rajaperf/src)
+      set(KokkosKernels_ENABLE_PERFTESTS ON CACHE BOOL "Whether to build tests including Perfsuite. Default: OFF" FORCE)
     add_subdirectory(tpls/rajaperf)
     include_directories(tpls/rajaperf/src)
     set(KokkosKernels_ENABLE_PERFTESTS ON CACHE BOOL "Whether to build tests including Perfsuite. Default: OFF" FORCE)


### PR DESCRIPTION
Fixes #2777

Added code in [CMakeLists.txt](CMakeLists.txt) to check if the rajaperf submodule has been checked out.

If the compile-time flag -DKokkosKernels_ENABLE_TESTS_AND_PERFSUITE=ON is set and the submodule does not exist, the flag is switched off, and the user is informed to run `git submodule update --init --recursive` to download the submodule first. The compilation is allowed to proceed so the build does not fail.