### PR TITLE
Require `KOKKOS_ENABLE_DEPRECATED_CODE_5` to be defined for including `<Kokkos_ArithTraits.hpp>`

### DIFF
--- a/common/src/Kokkos_ArithTraits.hpp
+++ b/common/src/Kokkos_ArithTraits.hpp
@@ -22,6 +22,10 @@
 
 #include <KokkosKernels_ArithTraits.hpp>
 
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_5
+static_assert(false, "this header is deprecated, include <KokkosKernels_ArithTraits.hpp> instead");
+#endif
+
 namespace Kokkos {
 template <typename T>
 using ArithTraits [[deprecated("Use KokkosKernels::ArithTraits from KokkosKernels_ArithTraits.hpp header instead")]] =

--- a/common/src/Kokkos_ArithTraits.hpp
+++ b/common/src/Kokkos_ArithTraits.hpp
@@ -23,7 +23,7 @@
 #include <KokkosKernels_ArithTraits.hpp>
 
 #ifndef KOKKOS_ENABLE_DEPRECATED_CODE_5
-static_assert(false, "this header is deprecated, include <KokkosKernels_ArithTraits.hpp> instead");
+static_assert(false, "Header `Kokkos_ArithTraits.hpp` is deprecated, include `KokkosKernels_ArithTraits.hpp` instead");
 #endif
 
 namespace Kokkos {


### PR DESCRIPTION
Error out at compile-time otherwise