### PR TITLE
Kokkos Batched InnerTrsm: Allocate in inner scope to avoid warnings with Sacado types

### DIFF
--- a/batched/dense/impl/KokkosBatched_InnerTrsm_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_InnerTrsm_Serial_Impl.hpp
@@ -26,7 +26,14 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<5>::serial_invoke(const Va
                   a_40 = A[4 * _as0 + 0 * _as1], a_41 = A[4 * _as0 + 1 * _as1], a_42 = A[4 * _as0 + 2 * _as1],
                   a_43 = A[4 * _as0 + 3 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p, ValueType &b_3p, ValueType &b_4p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[5];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+    auto &b_3p = b_p[3];
+    auto &b_4p = b_p[4];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -63,8 +70,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<5>::serial_invoke(const Va
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[5];
-    trsv(p, b_p[0], b_p[1], b_p[2], b_p[3], b_p[4]);
+    trsv(p);
   }
   return 0;
 }
@@ -78,7 +84,13 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<4>::serial_invoke(const Va
   const ValueType a_10 = A[1 * _as0 + 0 * _as1], a_20 = A[2 * _as0 + 0 * _as1], a_21 = A[2 * _as0 + 1 * _as1],
                   a_30 = A[3 * _as0 + 0 * _as1], a_31 = A[3 * _as0 + 1 * _as1], a_32 = A[3 * _as0 + 2 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p, ValueType &b_3p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[4];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+    auto &b_3p = b_p[3];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -107,8 +119,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<4>::serial_invoke(const Va
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[4];
-    trsv(p, b_p[0], b_p[1], b_p[2], b_p[3]);
+    trsv(p);
   }
   return 0;
 }
@@ -121,7 +132,12 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<3>::serial_invoke(const Va
 
   const ValueType a_10 = A[1 * _as0 + 0 * _as1], a_20 = A[2 * _as0 + 0 * _as1], a_21 = A[2 * _as0 + 1 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[3];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -143,8 +159,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<3>::serial_invoke(const Va
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[3];
-    trsv(p, b_p[0], b_p[1], b_p[2]);
+    trsv(p);
   }
   return 0;
 }
@@ -157,7 +172,11 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<2>::serial_invoke(const Va
 
   const ValueType a_10 = A[1 * _as0 + 0 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[2];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -173,8 +192,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<2>::serial_invoke(const Va
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[2];
-    trsv(p, b_p[0], b_p[1]);
+    trsv(p);
   }
 
   return 0;
@@ -354,7 +372,14 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<5>::serial_invoke(const
                   inv_a_33 = static_cast<ValueType>(1.0) / A[3 * _as0 + 3 * _as1],
                   inv_a_44 = static_cast<ValueType>(1.0) / A[4 * _as0 + 4 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p, ValueType &b_3p, ValueType &b_4p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[5];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+    auto &b_3p = b_p[3];
+    auto &b_4p = b_p[4];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -399,8 +424,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<5>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[5];
-    trsv(p, b_p[0], b_p[1], b_p[2], b_p[3], b_p[4]);
+    trsv(p);
   }
 
   return 0;
@@ -427,7 +451,13 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<4>::serial_invoke(const
                   inv_a_22 = static_cast<ValueType>(1.0) / A[2 * _as0 + 2 * _as1],
                   inv_a_33 = static_cast<ValueType>(1.0) / A[3 * _as0 + 3 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p, ValueType &b_3p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[4];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+    auto &b_3p = b_p[3];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -463,8 +493,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<4>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[4];
-    trsv(p, b_p[0], b_p[1], b_p[2], b_p[3]);
+    trsv(p);
   }
 
   return 0;
@@ -488,7 +517,12 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<3>::serial_invoke(const
                   inv_a_11 = static_cast<ValueType>(1.0) / A[1 * _as0 + 1 * _as1],
                   inv_a_22 = static_cast<ValueType>(1.0) / A[2 * _as0 + 2 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[3];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -516,8 +550,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<3>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[3];
-    trsv(p, b_p[0], b_p[1], b_p[2]);
+    trsv(p);
   }
 
   return 0;
@@ -539,7 +572,11 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<2>::serial_invoke(const
   const ValueType inv_a_00 = static_cast<ValueType>(1.0) / A[0 * _as0 + 0 * _as1],
                   inv_a_11 = static_cast<ValueType>(1.0) / A[1 * _as0 + 1 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[2];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -560,8 +597,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<2>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[2];
-    trsv(p, b_p[0], b_p[1]);
+    trsv(p);
   }
 
   return 0;
@@ -579,7 +615,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<1>::serial_invoke(const
 
   const ValueType inv_a_00 = static_cast<ValueType>(1.0) / A[0 * _as0 + 0 * _as1];
 
-  auto trsv = [&](const int p, ValueType & /* b_0p */) {
+  auto trsv = [&](const int p) {
     B[0 * _bs0 + p * _bs1] *= inv_a_00; /* b_0p /= a_00;*/
   };
 
@@ -587,8 +623,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<1>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p;
-    trsv(p, b_p);
+    trsv(p);
   }
 
   return 0;
@@ -762,7 +797,14 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<5>::serial_invoke(const Va
                   /**/ a_23 = A[2 * _as0 + 3 * _as1], a_24 = A[2 * _as0 + 4 * _as1],
                   /**/ a_34 = A[3 * _as0 + 4 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p, ValueType &b_3p, ValueType &b_4p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[5];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+    auto &b_3p = b_p[3];
+    auto &b_4p = b_p[4];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -799,8 +841,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<5>::serial_invoke(const Va
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[5];
-    trsv(p, b_p[0], b_p[1], b_p[2], b_p[3], b_p[4]);
+    trsv(p);
   }
 
   return 0;
@@ -816,7 +857,13 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<4>::serial_invoke(const Va
                   /**/ a_12 = A[1 * _as0 + 2 * _as1], a_13 = A[1 * _as0 + 3 * _as1],
                   /**/ a_23 = A[2 * _as0 + 3 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p, ValueType &b_3p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[4];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+    auto &b_3p = b_p[3];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -845,8 +892,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<4>::serial_invoke(const Va
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[4];
-    trsv(p, b_p[0], b_p[1], b_p[2], b_p[3]);
+    trsv(p);
   }
 
   return 0;
@@ -861,7 +907,12 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<3>::serial_invoke(const Va
   const ValueType a_01 = A[0 * _as0 + 1 * _as1], a_02 = A[0 * _as0 + 2 * _as1],
                   /**/ a_12 = A[1 * _as0 + 2 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[3];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -883,8 +934,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<3>::serial_invoke(const Va
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[3];
-    trsv(p, b_p[0], b_p[1], b_p[2]);
+    trsv(p);
   }
 
   return 0;
@@ -898,7 +948,11 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<2>::serial_invoke(const Va
 
   const ValueType a_01 = A[0 * _as0 + 1 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[2];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -914,8 +968,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<2>::serial_invoke(const Va
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[2];
-    trsv(p, b_p[0], b_p[1]);
+    trsv(p);
   }
 
   return 0;
@@ -1096,7 +1149,14 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<5>::serial_invoke(const
                   inv_a_33 = static_cast<ValueType>(1.0) / A[3 * _as0 + 3 * _as1],
                   inv_a_44 = static_cast<ValueType>(1.0) / A[4 * _as0 + 4 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p, ValueType &b_3p, ValueType &b_4p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[5];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+    auto &b_3p = b_p[3];
+    auto &b_4p = b_p[4];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -1141,8 +1201,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<5>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[5];
-    trsv(p, b_p[0], b_p[1], b_p[2], b_p[3], b_p[4]);
+    trsv(p);
   }
 
   return 0;
@@ -1170,7 +1229,13 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<4>::serial_invoke(const
                   inv_a_22 = static_cast<ValueType>(1.0) / A[2 * _as0 + 2 * _as1],
                   inv_a_33 = static_cast<ValueType>(1.0) / A[3 * _as0 + 3 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p, ValueType &b_3p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[4];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+    auto &b_3p = b_p[3];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -1206,8 +1271,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<4>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[4];
-    trsv(p, b_p[0], b_p[1], b_p[2], b_p[3]);
+    trsv(p);
   }
 
   return 0;
@@ -1232,7 +1296,12 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<3>::serial_invoke(const
                   inv_a_11 = static_cast<ValueType>(1.0) / A[1 * _as0 + 1 * _as1],
                   inv_a_22 = static_cast<ValueType>(1.0) / A[2 * _as0 + 2 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[3];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -1260,8 +1329,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<3>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[3];
-    trsv(p, b_p[0], b_p[1], b_p[2]);
+    trsv(p);
   }
 
   return 0;
@@ -1283,7 +1351,11 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<2>::serial_invoke(const
   const ValueType inv_a_00 = static_cast<ValueType>(1.0) / A[0 * _as0 + 0 * _as1],
                   inv_a_11 = static_cast<ValueType>(1.0) / A[1 * _as0 + 1 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[2];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -1304,8 +1376,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<2>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[2];
-    trsv(p, b_p[0], b_p[1]);
+    trsv(p);
   }
 
   return 0;
@@ -1323,7 +1394,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<1>::serial_invoke(const
 
   const ValueType inv_a_00 = static_cast<ValueType>(1.0) / A[0 * _as0 + 0 * _as1];
 
-  auto trsv = [&](const int p, ValueType & /* b_0p */) {
+  auto trsv = [&](const int p) {
     // 0 iteration
     B[0 * _bs0 + p * _bs1] *= inv_a_00; /* b_0p /= a_00; */
   };
@@ -1332,8 +1403,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<1>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p;
-    trsv(p, b_p);
+    trsv(p);
   }
 
   return 0;


### PR DESCRIPTION
I was getting warnings like this:
```
In member function 'Sacado::MP::Vector<S>& Sacado::MP::Vector<S>::operator-=(const Sacado::MP::Expr<S>&) [with S = Sacado::MP::MultiplicationOp<Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> >, Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> > >; Storage = Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP>]',
    inlined from 'KokkosBatched::InnerTrsmLeftLowerUnitDiag<4>::serial_invoke<Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> > >(const Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> >*, int, Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> >*)::<lambda(int, Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> >&, Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> >&, Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> >&, Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> >&)>' at /workspace/trilinos/source/packages/kokkos-kernels/batched/dense/impl/KokkosBatched_InnerTrsm_Serial_Impl.hpp:104:10,
    inlined from 'int KokkosBatched::InnerTrsmLeftLowerUnitDiag<bmn>::serial_invoke(const ValueType*, int, ValueType*) [with ValueType = Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> >; int bmn = 4]' at /workspace/trilinos/source/packages/kokkos-kernels/batched/dense/impl/KokkosBatched_InnerTrsm_Serial_Impl.hpp:124:9:
/workspace/trilinos/source/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector.hpp:1295:18: warning: 'b_p' may be used uninitialized [-Wmaybe-uninitialized]
 1295 |             s[i] -= x.fastAccessCoeff(i);
      |             ~~~~~^~~~~~~~~~~~~~~~~~~~~~~
/workspace/trilinos/source/packages/kokkos-kernels/batched/dense/impl/KokkosBatched_InnerTrsm_Serial_Impl.hpp: In function 'int KokkosBatched::InnerTrsmLeftLowerUnitDiag<bmn>::serial_invoke(const ValueType*, int, ValueType*) [with ValueType = Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> >; int bmn = 4]':
/workspace/trilinos/source/packages/kokkos-kernels/batched/dense/impl/KokkosBatched_InnerTrsm_Serial_Impl.hpp:123:15: note: 'b_p' declared here
  123 |     ValueType b_p[4];
```

Changing the scope for the allocation convinces the compiler that this is ok.