### PR TITLE
Adding benchmark build and run on Aurora

### DIFF
--- a/.gitlab/alcf-gitlab-ci.yml
+++ b/.gitlab/alcf-gitlab-ci.yml
@@ -99,7 +99,8 @@ Aurora:
             -DKokkosKernels_ENABLE_TESTS:BOOL=ON
             -DKokkosKernels_ENABLE_EXAMPLES:BOOL=ON
             -DKokkosKernels_ENABLE_PERFTESTS:BOOL=OFF
-            -DKokkosKernels_ENABLE_BENCHMARK:BOOL=OFF
+            -DKokkosKernels_ENABLE_BENCHMARKS:BOOL=ON
+            -DKokkosKernels_RUN_BENCHMARKS:BOOL=ON
             -DKokkosKernels_ENABLE_TPL_MKL=ON
     - export CMAKE_BUILD_PARALLEL_LEVEL=48
     - export ZES_ENABLE_SYSMAN=1


### PR DESCRIPTION
This will allow us to eventually collect performance data on that platform as well as Polaris. Next step will be uploading data in a github repository...