### PR TITLE
Workflow: adding longer time for Polaris tests

### DIFF
--- a/.gitlab/alcf-gitlab-ci.yml
+++ b/.gitlab/alcf-gitlab-ci.yml
@@ -7,7 +7,7 @@ include:
 Polaris:
   extends: .polaris-batch-runner
   variables:
-    ANL_POLARIS_SCHEDULER_PARAMETERS: "-q debug -A kokkos_math -l select=1,walltime=60:00,filesystems=home"
+    ANL_POLARIS_SCHEDULER_PARAMETERS: "-q debug -A kokkos_math -l select=1,walltime=90:00,filesystems=home"
   script:
     - module use /soft/modulefiles
     - module load PrgEnv-gnu


### PR DESCRIPTION
It is a bit surprising that the build and run is so slow on Polaris but let's see if 90 minutes is enough for the next round of testing