### PR TITLE
Batched: Remove deprecated macros

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -9,21 +9,6 @@
 
 #define KOKKOSBATCHED_IMPL_PROMOTION 1
 
-#if defined(KOKKOS_COMPILER_MSVC)
-#define __KOKKOSBATCHED_PROMOTION__ /*NOLINT(bugprone-reserved-identifier)*/                                       \
-  (__pragma(message("warning: __KOKKOSBATCHED_PROMOTION__ is deprecated and will be removed in a future version")) \
-       KOKKOSBATCHED_IMPL_PROMOTION)
-#elif defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
-#define __KOKKOSBATCHED_PROMOTION__ /*NOLINT(bugprone-reserved-identifier)*/                                      \
-  (__extension__({                                                                                                \
-    _Pragma("GCC warning \"__KOKKOSBATCHED_PROMOTION__ is deprecated and will be removed in a future version\""); \
-    KOKKOSBATCHED_IMPL_PROMOTION;                                                                                 \
-  }))
-#else
-// no good way to deprecate
-#define __KOKKOSBATCHED_PROMOTION__ KOKKOSBATCHED_IMPL_PROMOTION  // NOLINT(bugprone-reserved-identifier)
-#endif
-
 #include <iomanip>
 #include <random>
 #include <string>
@@ -45,59 +30,13 @@
 
 // TPL macros
 #if defined(KOKKOSKERNELS_ENABLE_TPL_MKL)
-
-#if defined(KOKKOS_COMPILER_MSVC)
-#define KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL \
-  (__pragma(                                \
-      message("warning: __KOKKOSBATCHED_ENABLE_INTEL_MKL__ is deprecated and will be removed in a future version")) 1)
-#elif defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
-#define KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL                                                                       \
-  (__extension__({                                                                                                \
-    _Pragma("warning: __KOKKOSBATCHED_ENABLE_INTEL_MKL__ is deprecated and will be removed in a future version"); \
-    1;                                                                                                            \
-  }))
-#else
 #define KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL 1  // no good way to deprecate?
-#endif
-#define __KOKKOSBATCHED_ENABLE_INTEL_MKL__ KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL
 
 #include "mkl_version.h"
 #if __INTEL_MKL__ >= 2018
 
-#if defined(KOKKOS_COMPILER_MSVC)
-#define KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED \
-  (__pragma(message(                                \
-      "warning: __KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__ is deprecated and will be removed in a future version")) 1)
-#elif defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
-#define KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED                                                                   \
-  (__extension__({                                                                                                    \
-    _Pragma(                                                                                                          \
-        "warning: __KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__ is deprecated and will be removed in a future version"); \
-    1;                                                                                                                \
-  }))
-#else
-#define KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED 1  // no good way to deprecate?
-#endif
-#define __KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__ KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED
-
+#define KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED 1
 #define KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED 1
-#if defined(KOKKOS_COMPILER_MSVC)
-#define __KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__                                                      \
-  (                                                                                                             \
-      __pragma(message("warning: __KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__ is deprecated and will be " \
-                       "removed in a future version")) KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED)
-#elif defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
-#define __KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__                                                    \
-  (__extension__({                                                                                            \
-    _Pragma(                                                                                                  \
-        "\"__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__ is deprecated and will be removed in a future " \
-        "version\"");                                                                                         \
-    KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED;                                                      \
-  }))
-#else
-#define __KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__ \
-  KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED  // no good way to deprecate?
-#endif
 
 #include "mkl.h"
 // #include "mkl_types.h"
@@ -106,22 +45,6 @@
 
 #if defined(KOKKOSKERNELS_ENABLE_TPL_LAPACKE)
 #define KOKKOSBATCHED_IMPL_ENABLE_LAPACKE 1
-#if defined(KOKKOS_COMPILER_MSVC)
-#define __KOKKOSBATCHED_ENABLE_LAPACKE__                                                      \
-  (                                                                                           \
-      __pragma(message("warning: __KOKKOSBATCHED_ENABLE_LAPACKE__ is deprecated and will be " \
-                       "removed in a future version")) KOKKOSBATCHED_IMPL_ENABLE_LAPACKE)
-#elif defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
-#define __KOKKOSBATCHED_ENABLE_LAPACKE__                                                    \
-  (__extension__({                                                                          \
-    _Pragma(                                                                                \
-        "\"__KOKKOSBATCHED_ENABLE_LAPACKE__ is deprecated and will be removed in a future " \
-        "version\"");                                                                       \
-    KOKKOSBATCHED_IMPL_ENABLE_LAPACKE;                                                      \
-  }))
-#else
-#define __KOKKOSBATCHED_ENABLE_LAPACKE__ KOKKOSBATCHED_IMPL_ENABLE_LAPACKE  // no good way to deprecate?
-#endif
 
 #include "lapacke.h"
 #endif

--- a/batched/dense/impl/KokkosBatched_Gemm_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemm_Serial_Impl.hpp
@@ -164,7 +164,7 @@ KOKKOS_INLINE_FUNCTION int SerialGemm<Trans::Transpose, Trans::NoTranspose, Algo
 ///
 
 #if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
-    defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
+    defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED)
 template <>
 template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
 KOKKOS_INLINE_FUNCTION int SerialGemm<Trans::ConjTranspose, Trans::NoTranspose, Algo::Gemm::CompactMKL>::invoke(
@@ -383,7 +383,7 @@ KOKKOS_INLINE_FUNCTION int SerialGemm<Trans::Transpose, Trans::Transpose, Algo::
 ///
 
 #if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
-    defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
+    defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED)
 template <>
 template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
 KOKKOS_INLINE_FUNCTION int SerialGemm<Trans::ConjTranspose, Trans::Transpose, Algo::Gemm::CompactMKL>::invoke(
@@ -456,7 +456,7 @@ KOKKOS_INLINE_FUNCTION int SerialGemm<Trans::ConjTranspose, Trans::Transpose, Al
 ///
 
 #if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
-    defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
+    defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED)
 template <>
 template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
 KOKKOS_INLINE_FUNCTION int SerialGemm<Trans::NoTranspose, Trans::ConjTranspose, Algo::Gemm::CompactMKL>::invoke(
@@ -529,7 +529,7 @@ KOKKOS_INLINE_FUNCTION int SerialGemm<Trans::NoTranspose, Trans::ConjTranspose, 
 ///
 
 #if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
-    defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
+    defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED)
 template <>
 template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
 KOKKOS_INLINE_FUNCTION int SerialGemm<Trans::Transpose, Trans::ConjTranspose, Algo::Gemm::CompactMKL>::invoke(
@@ -602,7 +602,7 @@ KOKKOS_INLINE_FUNCTION int SerialGemm<Trans::Transpose, Trans::ConjTranspose, Al
 ///
 
 #if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
-    defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
+    defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED)
 template <>
 template <typename ScalarType, typename AViewType, typename BViewType, typename CViewType>
 KOKKOS_INLINE_FUNCTION int SerialGemm<Trans::ConjTranspose, Trans::ConjTranspose, Algo::Gemm::CompactMKL>::invoke(

--- a/batched/dense/impl/KokkosBatched_Trsm_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsm_Serial_Impl.hpp
@@ -427,7 +427,7 @@ struct SerialTrsm<Side::Left, Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trsm
 /// A(m x m), B(m x n)
 
 #if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
-    defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
+    defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED)
 template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Lower, Trans::ConjTranspose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>
@@ -501,7 +501,7 @@ struct SerialTrsm<Side::Left, Uplo::Lower, Trans::ConjTranspose, ArgDiag, Algo::
 /// B := inv(triu(AH)) (alpha*B)
 /// A(m x m), B(m x n)
 #if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
-    defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
+    defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED)
 template <typename ArgDiag>
 struct SerialTrsm<Side::Left, Uplo::Upper, Trans::ConjTranspose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>
@@ -576,7 +576,7 @@ struct SerialTrsm<Side::Left, Uplo::Upper, Trans::ConjTranspose, ArgDiag, Algo::
 /// A(n x n), B(m x n)
 
 #if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
-    defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
+    defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED)
 template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>
@@ -650,7 +650,7 @@ struct SerialTrsm<Side::Right, Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::T
 /// B := (alpha*B) inv(triu(A))
 /// A(n x n), B(m x n)
 #if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
-    defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
+    defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED)
 template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>
@@ -725,7 +725,7 @@ struct SerialTrsm<Side::Right, Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::T
 /// A(n x n), B(m x n)
 
 #if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
-    defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
+    defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED)
 template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>
@@ -799,7 +799,7 @@ struct SerialTrsm<Side::Right, Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trs
 /// B := (alpha*B) inv(triu(AT))
 /// A(n x n), B(m x n)
 #if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
-    defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
+    defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED)
 template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>
@@ -874,7 +874,7 @@ struct SerialTrsm<Side::Right, Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trs
 /// A(n x n), B(m x n)
 
 #if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
-    defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
+    defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED)
 template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Lower, Trans::ConjTranspose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>
@@ -933,7 +933,7 @@ struct SerialTrsm<Side::Right, Uplo::Lower, Trans::ConjTranspose, ArgDiag, Algo:
 /// B := (alpha*B) inv(triu(AH))
 /// A(n x n), B(m x n)
 #if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
-    defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
+    defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED)
 template <typename ArgDiag>
 struct SerialTrsm<Side::Right, Uplo::Upper, Trans::ConjTranspose, ArgDiag, Algo::Trsm::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename BViewType>

--- a/batched/dense/impl/KokkosBatched_Trsv_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsv_Serial_Impl.hpp
@@ -197,7 +197,7 @@ struct SerialTrsv<Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trsv::Blocked> {
 
 //// Lower conjugate-transpose ////
 #if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
-    defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
+    defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED)
 template <typename ArgDiag>
 struct SerialTrsv<Uplo::Lower, Trans::ConjTranspose, ArgDiag, Algo::Trsv::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename bViewType>
@@ -410,7 +410,7 @@ struct SerialTrsv<Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trsv::Blocked> {
 
 //// Upper conjugate-transpose ////
 #if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
-    defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
+    defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED)
 template <typename ArgDiag>
 struct SerialTrsv<Uplo::Upper, Trans::ConjTranspose, ArgDiag, Algo::Trsv::CompactMKL> {
   template <typename ScalarType, typename AViewType, typename bViewType>

--- a/batched/dense/src/KokkosBatched_Gemm_Decl.hpp
+++ b/batched/dense/src/KokkosBatched_Gemm_Decl.hpp
@@ -27,7 +27,7 @@ struct SerialGemm {
   static_assert(KokkosBlas::is_trans_v<ArgTransA>, "KokkosBatched::SerialGemm: ArgTransA must be a KokkosBlas::Trans.");
   static_assert(KokkosBlas::is_trans_v<ArgTransB>, "KokkosBatched::SerialGemm: ArgTransB must be a KokkosBlas::Trans.");
 #if defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL) && defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_BATCHED) && \
-    defined(__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__)
+    defined(KOKKOSBATCHED_IMPL_ENABLE_INTEL_MKL_COMPACT_BATCHED)
   static_assert(std::is_same_v<ArgAlgo, Algo::Gemm::Unblocked> || std::is_same_v<ArgAlgo, Algo::Gemm::Blocked> ||
                     std::is_same_v<ArgAlgo, Algo::Gemm::CompactMKL>,
                 "KokkosBatched::Gemm: Use Algo::Gemm::Unblocked or Algo::Gemm::Blocked or Algo::Gemm::CompactMKL");

--- a/docs/source/deprecation_page.rst
+++ b/docs/source/deprecation_page.rst
@@ -1,17 +1,8 @@
 Deprecations
 ############
 
-Deprecated in Kokkos Kernels 4.X
-================================
+..
+  (Formatting to list future deprecations)
+  Deprecated in Kokkos Kernels 5.X
+  ================================
 
-Deprecated in Kokkos Kernels 4.5
---------------------------------
-
-The following macros are deprecated as they ignore the standard or Kokkos' reserved names:
-
-- ``__KOKKOSBATCHED_ENABLE_LAPACKE__``
-- ``__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__``
-- ``__KOKKOSBATCHED_PROMOTION__``
-- ``__KOKKOSBATCHED_ENABLE_INTEL_MKL__``
-- ``__KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__``
-- ``__KOKKOSBATCHED_ENABLE_AVX__``


### PR DESCRIPTION
Remove these macros that were deprecated in 4.x versions:
- ``__KOKKOSBATCHED_ENABLE_LAPACKE__``
- ``__KOKKOSBATCHED_ENABLE_INTEL_MKL_COMPACT_BATCHED__``
- ``__KOKKOSBATCHED_PROMOTION__``
- ``__KOKKOSBATCHED_ENABLE_INTEL_MKL__``
- ``__KOKKOSBATCHED_ENABLE_INTEL_MKL_BATCHED__``

``__KOKKOSBATCHED_ENABLE_AVX__`` was already removed from the code, but was still on the deprecations page of the documentation.

 This should be included in the 5.0 release if possible.