### PR TITLE
CI - gcc/1050: adding new action with c++20

### DIFF
--- a/.github/workflows/bdw.yml
+++ b/.github/workflows/bdw.yml
@@ -252,3 +252,81 @@ jobs:
       - name: test
         working-directory: kokkos-kernels/build
         run: ctest --output-on-failure -V --timeout 3600
+
+  PR_BDW_GNU1050_OPENMP_SERIAL_LEFT_OPENBLAS_REL:
+    name: PR_BDW_GNU1050_OPENMP_SERIAL_LEFT_OPENBLAS_REL
+    runs-on: [kk-env-openblas-0.3.21-gcc-10.2.0-latest]
+    
+    steps:
+      - name: checkout_kokkos_kernels
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          path: kokkos-kernels
+
+      - name: checkout_kokkos
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: kokkos/kokkos
+          ref: ${{ inputs.kokkos_version }}
+          path: kokkos
+
+      - name: configure_kokkos
+        run: |
+          mkdir -p kokkos/{build,install}
+          cd kokkos/build
+
+          cmake \
+	    -S "$PWD/.." \
+	    -B "$PWD" \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DCMAKE_CXX_COMPILER=g++ \
+            -DCMAKE_CXX_FLAGS=-O3 \
+            -DCMAKE_INSTALL_PREFIX=$PWD/../install \
+            -DCMAKE_VERBOSE_MAKEFILE=ON \
+            -DCMAKE_CXX_EXTENSIONS=OFF \
+            -DCMAKE_CXX_STANDARD=20 \
+            -DKokkos_ENABLE_SERIAL=ON \
+            -DKokkos_ENABLE_OPENMP=ON \
+            -DKokkos_ARCH_BDW=ON \
+            -DKokkos_ENABLE_TESTS=OFF \
+            -DKokkos_ENABLE_EXAMPLES=OFF \
+            -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
+            -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF \
+            -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF
+
+      - name: build_and_install_kokkos
+        working-directory: kokkos/build
+        run: make -j12 install
+
+      - name: configure_kokkos_kernels
+        run: |
+          mkdir -p kokkos-kernels/{build,install}
+          cd kokkos-kernels/build
+
+          cmake \
+            -S "$PWD/.." \
+            -B "$PWD" \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DCMAKE_CXX_COMPILER=g++ \
+            -DCMAKE_CXX_FLAGS="-O3 " \
+            -DCMAKE_CXX_STANDARD=20 \
+            -DKokkos_ROOT=$PWD/../../kokkos/install \
+            -DKokkosKernels_ENABLE_TESTS_AND_PERFSUITE=OFF \
+            -DKokkosKernels_ENABLE_TESTS=ON \
+            -DKokkosKernels_ENABLE_EXAMPLES:BOOL=ON \
+            -DKokkosKernels_INST_COMPLEX_DOUBLE=ON \
+            -DKokkosKernels_INST_DOUBLE=ON \
+            -DKokkosKernels_INST_ORDINAL_INT=ON \
+            -DKokkosKernels_INST_OFFSET_SIZE_T=ON \
+            -DKokkosKernels_INST_OFFSET_INT=ON \
+            -DKokkosKernels_INST_LAYOUTLEFT=ON \
+            -DKokkosKernels_ENABLE_TPL_BLAS=ON \
+            -DKokkosKernels_ENABLE_DOCS=OFF
+
+      - name: build_kokkos_kernels
+        working-directory: kokkos-kernels/build
+        run: make -j12 all
+
+      - name: test
+        working-directory: kokkos-kernels/build
+        run: ctest --output-on-failure -V --timeout 3600

--- a/.github/workflows/bdw.yml
+++ b/.github/workflows/bdw.yml
@@ -253,9 +253,9 @@ jobs:
         working-directory: kokkos-kernels/build
         run: ctest --output-on-failure -V --timeout 3600
 
-  PR_BDW_GNU1050_OPENMP_SERIAL_LEFT_OPENBLAS_REL:
-    name: PR_BDW_GNU1050_OPENMP_SERIAL_LEFT_OPENBLAS_REL
-    runs-on: [kk-env-openblas-0.3.21-gcc-10.2.0-latest]
+  PR_GNU1050_OPENMP_SERIAL_LEFT_OPENBLAS_REL:
+    name: PR_GNU1050_OPENMP_SERIAL_LEFT_OPENBLAS_REL
+    runs-on: [gcc-10.5.0_openblas-0.3.30_x86-64]
     
     steps:
       - name: checkout_kokkos_kernels
@@ -287,7 +287,7 @@ jobs:
             -DCMAKE_CXX_STANDARD=20 \
             -DKokkos_ENABLE_SERIAL=ON \
             -DKokkos_ENABLE_OPENMP=ON \
-            -DKokkos_ARCH_BDW=ON \
+	    -DKokkos_ENABLE_ARCH_NATIVE=ON \
             -DKokkos_ENABLE_TESTS=OFF \
             -DKokkos_ENABLE_EXAMPLES=OFF \
             -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
@@ -309,6 +309,7 @@ jobs:
             -DBUILD_SHARED_LIBS=OFF \
             -DCMAKE_CXX_COMPILER=g++ \
             -DCMAKE_CXX_FLAGS="-O3 " \
+            -DCMAKE_CXX_EXTENSIONS=OFF \
             -DCMAKE_CXX_STANDARD=20 \
             -DKokkos_ROOT=$PWD/../../kokkos/install \
             -DKokkosKernels_ENABLE_TESTS_AND_PERFSUITE=OFF \

--- a/.github/workflows/bdw.yml
+++ b/.github/workflows/bdw.yml
@@ -276,8 +276,8 @@ jobs:
           cd kokkos/build
 
           cmake \
-	    -S "$PWD/.." \
-	    -B "$PWD" \
+            -S "$PWD/.." \
+            -B "$PWD" \
             -DBUILD_SHARED_LIBS=OFF \
             -DCMAKE_CXX_COMPILER=g++ \
             -DCMAKE_CXX_FLAGS=-O3 \
@@ -287,7 +287,7 @@ jobs:
             -DCMAKE_CXX_STANDARD=20 \
             -DKokkos_ENABLE_SERIAL=ON \
             -DKokkos_ENABLE_OPENMP=ON \
-	    -DKokkos_ENABLE_ARCH_NATIVE=ON \
+            -DKokkos_ENABLE_ARCH_NATIVE=ON \
             -DKokkos_ENABLE_TESTS=OFF \
             -DKokkos_ENABLE_EXAMPLES=OFF \
             -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \

--- a/.github/workflows/bdw.yml
+++ b/.github/workflows/bdw.yml
@@ -279,7 +279,7 @@ jobs:
             -S "$PWD/.." \
             -B "$PWD" \
             -DBUILD_SHARED_LIBS=OFF \
-            -DCMAKE_CXX_COMPILER=g++ \
+            -DCMAKE_CXX_COMPILER=$(spack location -i gcc@10.5.0)/bin/g++ \
             -DCMAKE_CXX_FLAGS=-O3 \
             -DCMAKE_INSTALL_PREFIX=$PWD/../install \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
@@ -287,7 +287,7 @@ jobs:
             -DCMAKE_CXX_STANDARD=20 \
             -DKokkos_ENABLE_SERIAL=ON \
             -DKokkos_ENABLE_OPENMP=ON \
-            -DKokkos_ENABLE_ARCH_NATIVE=ON \
+            -DKokkos_ARCH_NATIVE=ON \
             -DKokkos_ENABLE_TESTS=OFF \
             -DKokkos_ENABLE_EXAMPLES=OFF \
             -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
@@ -307,7 +307,9 @@ jobs:
             -S "$PWD/.." \
             -B "$PWD" \
             -DBUILD_SHARED_LIBS=OFF \
-            -DCMAKE_CXX_COMPILER=g++ \
+            -DCMAKE_C_COMPILER=$(spack location -i gcc@10.5.0)/bin/gcc \
+            -DCMAKE_CXX_COMPILER=$(spack location -i gcc@10.5.0)/bin/g++ \
+            -DCMAKE_Fortran_COMPILER=$(spack location -i gcc@10.5.0)/bin/gfortran \
             -DCMAKE_CXX_FLAGS="-O3 " \
             -DCMAKE_CXX_EXTENSIONS=OFF \
             -DCMAKE_CXX_STANDARD=20 \


### PR DESCRIPTION
This updates the image we are running on to a new one with gcc/10.5 which allows us to turn on c++20 with Kokkos Core : ) Also cleaning up a few things as well and will likely add some compiler warnings here as we are only testing with them on in our osx CI...