### PR TITLE
Improve performance of par_ilut and improve benchmark

### DIFF
--- a/benchmarks/sparse/KokkosSparse_par_ilut.cpp
+++ b/benchmarks/sparse/KokkosSparse_par_ilut.cpp
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <cstdio>
-
+#include <chrono>
 #include <ctime>
 #include <cstring>
 #include <cstdlib>
@@ -15,6 +15,8 @@
 
 #include "KokkosSparse_Utils.hpp"
 #include "KokkosSparse_spiluk.hpp"
+#include "KokkosSparse_gmres.hpp"
+#include "KokkosSparse_LUPrec.hpp"
 #include "KokkosSparse_par_ilut.hpp"
 #include "KokkosSparse_spmv.hpp"
 #include "KokkosBlas1_nrm2.hpp"
@@ -33,6 +35,7 @@
 
 namespace {
 
+using KokkosSparse::Experimental::gmres;
 using KokkosSparse::Experimental::par_ilut_numeric;
 using KokkosSparse::Experimental::par_ilut_symbolic;
 
@@ -41,24 +44,147 @@ using KokkosSparse::spiluk_symbolic;
 using KokkosSparse::Experimental::SPILUKAlgorithm;
 
 // Build up useful types
-using scalar_t  = KokkosKernels::default_scalar;
-using lno_t     = KokkosKernels::default_lno_t;
-using size_type = KokkosKernels::default_size_type;
-using exe_space = Kokkos::DefaultExecutionSpace;
-using mem_space = typename exe_space::memory_space;
-using device    = Kokkos::Device<exe_space, mem_space>;
-
-using RowMapType  = Kokkos::View<size_type*, device>;
-using EntriesType = Kokkos::View<lno_t*, device>;
-using ValuesType  = Kokkos::View<scalar_t*, device>;
-
-using sp_matrix_type = KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>;
-using KernelHandle =
-    KokkosKernels::Experimental::KokkosKernelsHandle<size_type, lno_t, scalar_t, exe_space, mem_space, mem_space>;
-using float_t = typename KokkosKernels::ArithTraits<scalar_t>::mag_type;
+using scalar_t    = KokkosKernels::default_scalar;
+using lno_t       = KokkosKernels::default_lno_t;
+using size_type_t = lno_t;  // ginkgo does not have the concept of size_type separate from ordinal type
+using exe_space_t = Kokkos::DefaultExecutionSpace;
+using rpolicy_t   = Kokkos::RangePolicy<exe_space_t>;
+using mem_space_t = typename exe_space_t::memory_space;
+using device_t    = Kokkos::Device<exe_space_t, mem_space_t>;
+using rows_t      = Kokkos::View<size_type_t*, device_t>;
+using entries_t   = Kokkos::View<lno_t*, device_t>;
+using values_t    = Kokkos::View<scalar_t*, device_t>;
+using result_t    = std::tuple<rows_t, entries_t, values_t, rows_t, entries_t, values_t>;  // full result
+using lu_result_t = std::tuple<rows_t, entries_t, values_t>;                               // result for one of L or U
+using sp_matrix_t = KokkosSparse::CrsMatrix<scalar_t, lno_t, device_t, void, size_type_t>;
+using float_t     = typename KokkosKernels::ArithTraits<scalar_t>::mag_type;
+using kkhandle_t  = KokkosKernels::Experimental::KokkosKernelsHandle<size_type_t, lno_t, scalar_t, exe_space_t,
+                                                                    mem_space_t, mem_space_t>;
 
 ///////////////////////////////////////////////////////////////////////////////
-void run_par_ilut_test(benchmark::State& state, KernelHandle& kh, const sp_matrix_type& A, int& num_iters)
+auto try_lu_prec(kkhandle_t& kh, const sp_matrix_t& A, const result_t& results, const bool do_baseline = false)
+///////////////////////////////////////////////////////////////////////////////
+{
+  // Unpack
+  auto [l_row_map, l_entries, l_values, u_row_map, u_entries, u_values] = results;
+
+  const int rows     = l_row_map.size() - 1;
+  constexpr auto m   = 15;
+  constexpr auto tol = 1e-8;
+
+  // Create gmres handle
+  kh.create_gmres_handle(m, tol);
+  auto gmres_handle = kh.get_gmres_handle();
+  gmres_handle->set_verbose(false);
+  using GMRESHandle    = typename std::remove_reference<decltype(*gmres_handle)>::type;
+  using ViewVectorType = typename GMRESHandle::nnz_value_view_t;
+
+  // Create CRSs
+  sp_matrix_t L("L", rows, rows, l_values.extent(0), l_values, l_row_map, l_entries),
+      U("U", rows, rows, u_values.extent(0), u_values, u_row_map, u_entries);
+
+  // Set initial vectors:
+  ViewVectorType X("X", rows);    // Solution and initial guess
+  ViewVectorType Wj("Wj", rows);  // For checking residuals at end.
+  ViewVectorType B(Kokkos::view_alloc(Kokkos::WithoutInitializing, "B"),
+                   rows);  // right-hand side vec
+  // Make rhs ones so that results are repeatable:
+  Kokkos::deep_copy(B, 1.0);
+
+  int num_iters_plain(9999), num_iters_precond(0);
+
+  // Solve Ax = b
+  if (do_baseline) {
+    auto start = std::chrono::steady_clock::now();
+    gmres(&kh, A, B, X);
+
+    // Double check residuals at end of solve:
+    float_t nrmB = KokkosBlas::nrm2(B);
+    KokkosSparse::spmv("N", 1.0, A, X, 0.0, Wj);  // wj = Ax
+    KokkosBlas::axpy(-1.0, Wj, B);                // b = b-Ax.
+    float_t endRes = KokkosBlas::nrm2(B) / nrmB;
+
+    const auto conv_flag = gmres_handle->get_conv_flag_val();
+    num_iters_plain      = gmres_handle->get_num_iters();
+
+    KK_REQUIRE(num_iters_plain > 0);
+    if (conv_flag == GMRESHandle::Flag::Conv || endRes < gmres_handle->get_tol()) {
+      std::cout << "WARNING: baseline did not converge" << std::endl;
+    }
+    auto end                                       = std::chrono::steady_clock::now();
+    std::chrono::duration<double> seconds_duration = end - start;
+    std::cout << "Baseline gmres took " << seconds_duration.count() << " seconds" << std::endl;
+  }
+
+  // Solve Ax = b with LU preconditioner.
+  {
+    auto start = std::chrono::steady_clock::now();
+    gmres_handle->reset_handle(m, tol);
+    gmres_handle->set_verbose(false);
+
+    // Make precond
+    KokkosSparse::Experimental::LUPrec<sp_matrix_t, kkhandle_t> myPrec(L, U);
+
+    // reset X for next gmres call
+    Kokkos::deep_copy(X, 0.0);
+
+    gmres(&kh, A, B, X, &myPrec);
+
+    // Double check residuals at end of solve:
+    float_t nrmB = KokkosBlas::nrm2(B);
+    KokkosSparse::spmv("N", 1.0, A, X, 0.0, Wj);  // wj = Ax
+    KokkosBlas::axpy(-1.0, Wj, B);                // b = b-Ax.
+    float_t endRes = KokkosBlas::nrm2(B) / nrmB;
+
+    const auto conv_flag = gmres_handle->get_conv_flag_val();
+    num_iters_precond    = gmres_handle->get_num_iters();
+
+    KK_REQUIRE(endRes < gmres_handle->get_tol());
+    KK_REQUIRE(conv_flag == GMRESHandle::Flag::Conv);
+    KK_REQUIRE(num_iters_precond < num_iters_plain);
+
+    auto end                                       = std::chrono::steady_clock::now();
+    std::chrono::duration<double> seconds_duration = end - start;
+    std::cout << "LUPrec gmres took " << seconds_duration.count() << " seconds" << std::endl;
+  }
+
+  return std::tuple<int, int>{num_iters_plain, num_iters_precond};
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename GkoMtxT>
+lu_result_t copy_to_kokkos_and_dealloc(GkoMtxT& factor, const int nrows)
+///////////////////////////////////////////////////////////////////////////////
+{
+  lno_t* rows      = const_cast<lno_t*>(factor->get_const_row_ptrs());
+  lno_t* entries   = const_cast<lno_t*>(factor->get_const_col_idxs());
+  scalar_t* values = const_cast<scalar_t*>(factor->get_const_values());
+
+  const auto nnz = factor->get_num_stored_elements();
+
+  // Allocate kokkos views
+  rows_t vrow_map("row_map", nrows + 1);
+  entries_t ventries("entries", nnz);
+  values_t vvalues("values", nnz);
+
+  Kokkos::parallel_for(
+      "cp rows", rpolicy_t(0, nrows + 1), KOKKOS_LAMBDA(const int row) { vrow_map(row) = rows[row]; });
+
+  Kokkos::parallel_for(
+      "cp entries", rpolicy_t(0, nnz), KOKKOS_LAMBDA(const int i) {
+        ventries(i) = entries[i];
+        vvalues(i)  = values[i];
+      });
+
+  // Deallocate factor to save memory
+  factor = GkoMtxT();
+
+  return lu_result_t{vrow_map, ventries, vvalues};
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void run_par_ilut_test(benchmark::State& state, kkhandle_t& kh, const sp_matrix_t& A, int& num_iters, result_t& result,
+                       bool validate = false, bool compare = false)
 ///////////////////////////////////////////////////////////////////////////////
 {
   const int rows = state.range(0);
@@ -71,21 +197,25 @@ void run_par_ilut_test(benchmark::State& state, KernelHandle& kh, const sp_matri
   auto A_values  = A.values;
 
   // Allocate L and U CRS views as outputs
-  RowMapType L_row_map("L_row_map", rows + 1);
-  RowMapType U_row_map("U_row_map", rows + 1);
+  rows_t L_row_map("L_row_map", rows + 1);
+  rows_t U_row_map("U_row_map", rows + 1);
 
   // Initial L/U approximations for A
-  EntriesType L_entries("L_entries", 0);
-  ValuesType L_values("L_values", 0);
-  EntriesType U_entries("U_entries", 0);
-  ValuesType U_values("U_values", 0);
+  entries_t L_entries("L_entries", 0);
+  values_t L_values("L_values", 0);
+  entries_t U_entries("U_entries", 0);
+  values_t U_values("U_values", 0);
 
   for (auto _ : state) {
+    // Reset inputs
+    Kokkos::deep_copy(L_row_map, 0);
+    Kokkos::deep_copy(U_row_map, 0);
+
     state.ResumeTiming();
     par_ilut_symbolic(&kh, A_row_map, A_entries, L_row_map, U_row_map);
 
-    size_type nnzL = par_ilut_handle->get_nnzL();
-    size_type nnzU = par_ilut_handle->get_nnzU();
+    size_type_t nnzL = par_ilut_handle->get_nnzL();
+    size_type_t nnzU = par_ilut_handle->get_nnzU();
 
     Kokkos::resize(L_entries, nnzL);
     Kokkos::resize(U_entries, nnzU);
@@ -104,16 +234,27 @@ void run_par_ilut_test(benchmark::State& state, KernelHandle& kh, const sp_matri
     // Check worked
     num_iters = par_ilut_handle->get_num_iters();
     KK_REQUIRE_MSG(num_iters < par_ilut_handle->get_max_iter(), "par_ilut hit max iters");
+  }
 
-    // Reset inputs
-    Kokkos::deep_copy(L_row_map, 0);
-    Kokkos::deep_copy(U_row_map, 0);
+  result = {L_row_map, L_entries, L_values, U_row_map, U_entries, U_values};
+
+  if (validate) {
+    auto [plain, pr] = try_lu_prec(kh, A, result, true /*do a baseline (no prec) run*/);
+    std::cout << "LUPrec results: " << std::endl;
+    std::cout << "  num iters no prec: " << plain << std::endl;
+    std::cout << "  num iters par_ilut: " << pr << std::endl;
+  }
+
+  // If we want to compare results, we store the results. This can dramatically increase the memory
+  // requirement.
+  if (!compare) {
+    result = result_t();
   }
 }
 
 #ifdef USE_GINKGO
 ///////////////////////////////////////////////////////////////////////////////
-static constexpr bool IS_GPU = KokkosKernels::Impl::is_gpu_exec_space_v<exe_space>;
+static constexpr bool IS_GPU = KokkosKernels::Impl::is_gpu_exec_space_v<exe_space_t>;
 
 using ginkgo_exec = std::conditional_t<IS_GPU, gko::CudaExecutor, gko::OmpExecutor>;
 
@@ -133,9 +274,14 @@ std::shared_ptr<gko::CudaExecutor> get_ginkgo_exec<gko::CudaExecutor>() {
 ///////////////////////////////////////////////////////////////////////////////
 
 ///////////////////////////////////////////////////////////////////////////////
-void run_par_ilut_test_ginkgo(benchmark::State& state, KernelHandle& kh, const sp_matrix_type& A, const int& num_iters)
+void run_par_ilut_test_ginkgo(benchmark::State& state, kkhandle_t& kh, sp_matrix_t& A, const int& num_iters,
+                              result_t& result, bool validate = false, bool compare = false)
 ///////////////////////////////////////////////////////////////////////////////
 {
+  using gko_par_ilut_t   = typename gko::factorization::ParIlut<scalar_t, lno_t>;
+  using gko_matrix_t     = typename gko_par_ilut_t::matrix_type;
+  using gko_matrix_ptr_t = typename std::shared_ptr<const gko_matrix_t>;
+
   const int rows = state.range(0);
 
   auto par_ilut_handle = kh.get_par_ilut_handle();
@@ -149,40 +295,63 @@ void run_par_ilut_test_ginkgo(benchmark::State& state, KernelHandle& kh, const s
 
   auto exec = get_ginkgo_exec<ginkgo_exec>();
 
-  // ginkgo does not differentiate between index type and size type. We need
-  // to convert A_row_map to lno_t.
-  EntriesType A_row_map_cp("A_row_map_cp", rows + 1);
-  Kokkos::deep_copy(A_row_map_cp, A_row_map);
+  gko_matrix_ptr_t l_factor, u_factor;
 
-  // Populate mtx
-  auto a_mtx_uniq = mtx::create_const(exec, gko::dim<2>(rows, rows),
-                                      gko::array<scalar_t>::const_view(exec, A_values.extent(0), A_values.data()),
-                                      gko::array<lno_t>::const_view(exec, A_entries.extent(0), A_entries.data()),
-                                      gko::array<lno_t>::const_view(exec, A_row_map_cp.extent(0), A_row_map_cp.data()));
+  {
+    // Populate mtx
+    auto a_mtx_uniq = gko_matrix_t::create_const(
+        exec, gko::dim<2>(rows, rows), gko::array<scalar_t>::const_view(exec, A_values.extent(0), A_values.data()),
+        gko::array<lno_t>::const_view(exec, A_entries.extent(0), A_entries.data()),
+        gko::array<lno_t>::const_view(exec, A_row_map.extent(0), A_row_map.data()));
 
-  std::shared_ptr<const mtx> a_mtx = std::move(a_mtx_uniq);
+    gko_matrix_ptr_t a_mtx = std::move(a_mtx_uniq);
 
-  for (auto _ : state) {
-    auto fact = gko::factorization::ParIlut<scalar_t, lno_t>::build()
-                    .with_fill_in_limit(par_ilut_handle->get_fill_in_limit())
-                    .with_approximate_select(false)
-                    .with_iterations(num_iters)
-                    .on(exec)
-                    ->generate(a_mtx);
+    for (auto _ : state) {
+      state.ResumeTiming();
+      auto fact = gko::factorization::ParIlut<scalar_t, lno_t>::build()
+                      .with_fill_in_limit(par_ilut_handle->get_fill_in_limit())
+                      .with_approximate_select(false)
+                      .with_iterations(num_iters)
+                      .on(exec)
+                      ->generate(a_mtx);
+      state.PauseTiming();
+
+      // Store for later use
+      l_factor = fact->get_l_factor();
+      u_factor = fact->get_u_factor();
+    }
+  }  // This should deallocate all the gko stuff except for l and u factors
+
+  // As we copy data over to kokkos, we need to be very careful not to use too much memory
+  auto [L_row_map, L_entries, L_values] = copy_to_kokkos_and_dealloc(l_factor, rows);
+  auto [U_row_map, U_entries, U_values] = copy_to_kokkos_and_dealloc(u_factor, rows);
+
+  result = {L_row_map, L_entries, L_values, U_row_map, U_entries, U_values};
+
+  if (validate) {
+    auto [plain, pr] = try_lu_prec(kh, A, result);
+    std::cout << "LUPrec results: " << std::endl;
+    std::cout << "  num iters ginkgo: " << pr << std::endl;
+  }
+
+  // If we want to compare results, we store the results. This can dramatically increase the memory
+  // requirement.
+  if (!compare) {
+    result = result_t();
   }
 }
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-void run_spiluk_test(benchmark::State& state, KernelHandle& kh, const sp_matrix_type& A, const int& team_size,
-                     const bool measure_symbolic)
+void run_spiluk_test(benchmark::State& state, kkhandle_t& kh, const sp_matrix_t& A, const int& team_size,
+                     const bool measure_symbolic, result_t& result, bool validate = false, bool compare = false)
 ///////////////////////////////////////////////////////////////////////////////
 {
   const int rows = state.range(0);
 
-  constexpr int EXPAND_FACT  = 10;
-  const lno_t fill_lev       = 2;
-  const size_type handle_nnz = EXPAND_FACT * A.nnz() * (fill_lev + 1);
+  constexpr int EXPAND_FACT    = 4;  // Be careful with this. Too high of a value can make you run out of mem
+  const lno_t fill_lev         = 2;
+  const size_type_t handle_nnz = EXPAND_FACT * A.nnz() * (fill_lev + 1);
   kh.create_spiluk_handle(SPILUKAlgorithm::SEQLVLSCHD_TP1, rows, handle_nnz, handle_nnz);
   auto spiluk_handle = kh.get_spiluk_handle();
   spiluk_handle->set_team_size(team_size);
@@ -193,16 +362,28 @@ void run_spiluk_test(benchmark::State& state, KernelHandle& kh, const sp_matrix_
   auto A_values  = A.values;
 
   // Allocate L and U CRS views as outputs
-  RowMapType L_row_map("L_row_map", rows + 1);
-  RowMapType U_row_map("U_row_map", rows + 1);
+  rows_t L_row_map("L_row_map", rows + 1);
+  rows_t U_row_map("U_row_map", rows + 1);
 
   // Initial L/U approximations for A
-  EntriesType L_entries("L_entries", handle_nnz);
-  ValuesType L_values("L_values", handle_nnz);
-  EntriesType U_entries("U_entries", handle_nnz);
-  ValuesType U_values("U_values", handle_nnz);
+  entries_t L_entries("L_entries", handle_nnz);
+  values_t L_values("L_values", handle_nnz);
+  entries_t U_entries("U_entries", handle_nnz);
+  values_t U_values("U_values", handle_nnz);
 
   for (auto _ : state) {
+    // Reset inputs
+    Kokkos::deep_copy(L_row_map, 0);
+    Kokkos::deep_copy(U_row_map, 0);
+    Kokkos::deep_copy(L_entries, 0);
+    Kokkos::deep_copy(U_entries, 0);
+    Kokkos::deep_copy(L_values, 0);
+    Kokkos::deep_copy(U_values, 0);
+    Kokkos::resize(L_entries, handle_nnz);
+    Kokkos::resize(U_entries, handle_nnz);
+
+    spiluk_handle->reset_handle(rows, handle_nnz, handle_nnz);
+
     if (measure_symbolic) {
       state.ResumeTiming();
     }
@@ -210,8 +391,8 @@ void run_spiluk_test(benchmark::State& state, KernelHandle& kh, const sp_matrix_
     Kokkos::fence();
     state.PauseTiming();
 
-    const size_type nnzL = spiluk_handle->get_nnzL();
-    const size_type nnzU = spiluk_handle->get_nnzU();
+    const size_type_t nnzL = spiluk_handle->get_nnzL();
+    const size_type_t nnzU = spiluk_handle->get_nnzU();
 
     Kokkos::resize(L_entries, nnzL);
     Kokkos::resize(U_entries, nnzU);
@@ -225,49 +406,53 @@ void run_spiluk_test(benchmark::State& state, KernelHandle& kh, const sp_matrix_
       Kokkos::fence();
       state.PauseTiming();
     }
+  }
+  result = {L_row_map, L_entries, L_values, U_row_map, U_entries, U_values};
 
-    // Reset inputs
-    Kokkos::deep_copy(L_row_map, 0);
-    Kokkos::deep_copy(U_row_map, 0);
-    Kokkos::deep_copy(L_entries, 0);
-    Kokkos::deep_copy(U_entries, 0);
-    Kokkos::deep_copy(L_values, 0);
-    Kokkos::deep_copy(U_values, 0);
-    Kokkos::resize(L_entries, handle_nnz);
-    Kokkos::resize(U_entries, handle_nnz);
+  if (validate && !measure_symbolic) {
+    auto [plain, pr] = try_lu_prec(kh, A, result);
+    std::cout << "LUPrec results: " << std::endl;
+    std::cout << "  num iters spiluk: " << pr << std::endl;
+  }
 
-    spiluk_handle->reset_handle(rows, handle_nnz, handle_nnz);
+  // If we want to compare results, we store the results. This can dramatically increase the memory
+  // requirement.
+  if (!compare) {
+    result = result_t();
   }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-int test_par_ilut_perf(const std::string& matrix_file, int rows, int nnz_per_row, const int bandwidth, int team_size,
-                       const int loop, const int test)
+int run_ilu_perf_tests(const std::string& matrix_file, int rows, int nnz_per_row, const int bandwidth, int team_size,
+                       const int loop, const int test, const bool validate)
 ///////////////////////////////////////////////////////////////////////////////
 {
-  KernelHandle kh;
+  kkhandle_t kh;
   kh.create_par_ilut_handle();
 
   // Generate or read A
-  sp_matrix_type A;
+  auto start = std::chrono::steady_clock::now();
+  sp_matrix_t A;
   if (matrix_file == "") {
-    size_type nnz                 = rows * nnz_per_row;
+    size_type_t nnz               = rows * nnz_per_row;
     const lno_t row_size_variance = 0;
     const scalar_t diag_dominance = 1;
-    A                             = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<sp_matrix_type>(
+    A                             = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<sp_matrix_t>(
         rows, rows, nnz, row_size_variance, bandwidth, diag_dominance);
   } else {
-    A           = KokkosSparse::Impl::read_kokkos_crst_matrix<sp_matrix_type>(matrix_file.c_str());
+    A           = KokkosSparse::Impl::read_kokkos_crst_matrix<sp_matrix_t>(matrix_file.c_str());
     rows        = A.numRows();
     nnz_per_row = A.nnz() / rows;
   }
+  KokkosSparse::sort_crs_matrix(A);
+
+  auto end                                       = std::chrono::steady_clock::now();
+  std::chrono::duration<double> seconds_duration = end - start;
 
   // Now that we have A, we can set team_size
   if (team_size == -1) {
-    team_size = KokkosKernels::Impl::is_gpu_exec_space_v<exe_space> ? nnz_per_row : 1;
+    team_size = KokkosKernels::Impl::is_gpu_exec_space_v<exe_space_t> ? nnz_per_row : 1;
   }
-
-  KokkosSparse::sort_crs_matrix(A);
 
   // Make handles
   auto par_ilut_handle = kh.get_par_ilut_handle();
@@ -277,37 +462,48 @@ int test_par_ilut_perf(const std::string& matrix_file, int rows, int nnz_per_row
   const auto default_policy = par_ilut_handle->get_default_team_policy();
 
   // Report test config to user
+  std::cout << "A generated/read in " << seconds_duration.count() << " seconds" << std::endl;
   if (matrix_file == "") {
-    std::cout << "Testing par_ilut with rows=" << rows << "\n  nnz_per_row=" << nnz_per_row
-              << "\n  bandwidth=" << bandwidth;
+    std::cout << "Testing ILU with rows=" << rows << "\n  nnz_per_row=" << nnz_per_row << "\n  bandwidth=" << bandwidth;
   } else {
-    std::cout << "Testing par_ilut with input matrix=" << matrix_file;
+    std::cout << "Testing ILU with input matrix=" << matrix_file;
   }
   std::cout << "\n  total nnz=" << A.nnz() << "\n  league_size=" << default_policy.league_size()
             << "\n  team_size=" << default_policy.team_size()
-            << "\n  concurrent teams=" << exe_space().concurrency() / default_policy.team_size() << "\n  loop=" << loop
-            << std::endl;
+            << "\n  concurrent teams=" << exe_space_t().concurrency() / default_policy.team_size()
+            << "\n  loop=" << loop << std::endl;
 
   std::string name     = "KokkosSparse_par_ilut";
   int num_iters        = 6;
   const auto arg_names = std::vector<std::string>{"rows"};
   const auto args      = std::vector<int64_t>{rows};
 
+  result_t parilut_results, ginkgo_results, spiluk_results;
+
   if (test & 1) {
-    auto plambda = [&](benchmark::State& state) { run_par_ilut_test(state, kh, A, num_iters); };
-    KokkosKernelsBenchmark::register_benchmark_real_time((name + "_par_ilut").c_str(), plambda, arg_names, args, loop);
+    auto plambda = [&](benchmark::State& state) {
+      run_par_ilut_test(state, kh, A, num_iters, parilut_results, validate);
+    };
+    auto r = KokkosKernelsBenchmark::register_benchmark_real_time((name + "_par_ilut").c_str(), plambda, arg_names,
+                                                                  args, loop);
   }
 
-#ifdef USE_GINKGO
   if (test & 2) {
-    auto glambda = [&](benchmark::State& state) { run_par_ilut_test_ginkgo(state, kh, A, num_iters); };
+#ifdef USE_GINKGO
+    auto glambda = [&](benchmark::State& state) {
+      run_par_ilut_test_ginkgo(state, kh, A, num_iters, ginkgo_results, validate);
+    };
     KokkosKernelsBenchmark::register_benchmark_real_time((name + "_gingko").c_str(), glambda, arg_names, args, loop);
-  }
+#else
+    KK_REQUIRE_MSG(false, "Requested ginkgo perf test but it is not enabled");
 #endif
+  }
 
   if (test & 4) {
-    auto s1lambda = [&](benchmark::State& state) { run_spiluk_test(state, kh, A, team_size, true); };
-    auto s2lambda = [&](benchmark::State& state) { run_spiluk_test(state, kh, A, team_size, false); };
+    auto s1lambda = [&](benchmark::State& state) { run_spiluk_test(state, kh, A, team_size, true, spiluk_results); };
+    auto s2lambda = [&](benchmark::State& state) {
+      run_spiluk_test(state, kh, A, team_size, false, spiluk_results, validate);
+    };
     KokkosKernelsBenchmark::register_benchmark_real_time((name + "_spiluk_symbolic").c_str(), s1lambda, arg_names, args,
                                                          loop);
 
@@ -330,6 +526,8 @@ void print_help_par_ilut()
   printf("  -n [N]  : generate a semi-random banded NxN matrix.\n");
   printf("  -z [Z]  : number nnz per row. Default is min(1%% of N, 50).\n");
   printf("  -b [B]  : bandwidth per row. Default is max(2 * n^(1/2), nnz).\n");
+  printf("  -v      : Validate ILU results by doing luprec+gmres.\n");
+  printf("  -C      : Do not print context.\n");
   printf(
       "  -ts [T] : Number of threads per team. Default is 1 on OpenMP, "
       "nnz_per_row on CUDA\n");
@@ -363,7 +561,13 @@ int main(int argc, char** argv)
   int nnz_per_row   = -1;  // depends on other options, so don't set to default yet
   int bandwidth     = -1;
   int team_size     = -1;
-  int test          = 7;
+#ifdef USE_GINKGO
+  int test = 7;  // Default to all if ginkgo is enabled
+#else
+  int test = 5;  // Default to par_ilut and spiluk
+#endif
+  bool validate   = false;
+  bool no_context = false;
 
   std::map<std::string, int*> option_map = {
       {"-n", &rows}, {"-z", &nnz_per_row}, {"-b", &bandwidth}, {"-ts", &team_size}, {"-t", &test}};
@@ -384,6 +588,10 @@ int main(int argc, char** argv)
       return 0;
     } else if ((strcmp(argv[i], "-f") == 0)) {
       mfile = argv[++i];
+    } else if ((strcmp(argv[i], "-v") == 0)) {
+      validate = true;
+    } else if ((strcmp(argv[i], "-C") == 0)) {
+      no_context = true;
     } else {
       handle_int_arg(argc, argv, i, option_map);
     }
@@ -406,16 +614,19 @@ int main(int argc, char** argv)
     nnz_per_row = std::min(rows / 100, 50);
   }
   if (bandwidth == -1) {
-    bandwidth = std::max(2 * (int)std::sqrt(rows), 2 * nnz_per_row);
+    // bandwidth = std::max(2 * (int)std::sqrt(rows), 2 * nnz_per_row) / 2;
+    bandwidth = nnz_per_row * 8;
   }
 
   Kokkos::initialize(argc, argv);
   {
     benchmark::Initialize(&argc, argv);
     benchmark::SetDefaultTimeUnit(benchmark::kSecond);
-    KokkosKernelsBenchmark::add_benchmark_context(true);
+    if (!no_context) {
+      KokkosKernelsBenchmark::add_benchmark_context(true);
+    }
 
-    test_par_ilut_perf(mfile, rows, nnz_per_row, bandwidth, team_size, common_params.repeat, test);
+    run_ilu_perf_tests(mfile, rows, nnz_per_row, bandwidth, team_size, common_params.repeat, test, validate);
 
     benchmark::Shutdown();
   }

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -495,7 +495,7 @@ struct IlutWrap {
     float_t result;
     Kokkos::sort(values_copy_d, AbsComparator{});
     Kokkos::parallel_reduce(
-        range_policy(0, 1), KOKKOS_LAMBDA(const int, scalar_t& lsum) { lsum = karith::abs(values_copy_d(rank)); },
+        range_policy(0, 1), KOKKOS_LAMBDA(const int, float_t& lsum) { lsum = karith::abs(values_copy_d(rank)); },
         result);
 
     return result;

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -16,11 +16,25 @@
 #include <KokkosSparse_SortCrs.hpp>
 #include <KokkosKernels_Utils.hpp>
 
+#include <chrono>
 #include <limits>
 
 namespace KokkosSparse {
 namespace Impl {
 namespace Experimental {
+
+// Resize a view without allocating or initializing if possible.
+template <typename ViewT>
+inline void resize_no_preserve(ViewT& view, const size_t new_size) {
+  // const auto curr_size = view.size();
+  // if (curr_size >= new_size) {
+  //   return Kokkos::subview(view, Kokkos::make_pair(0, new_size));
+  // }
+  // else {
+  Kokkos::realloc(Kokkos::WithoutInitializing, view, new_size);
+  //   return view;
+  // }
+}
 
 template <class IlutHandle>
 struct IlutWrap {
@@ -31,6 +45,7 @@ struct IlutWrap {
   using index_t                 = typename IlutHandle::nnz_lno_t;
   using size_type               = typename IlutHandle::size_type;
   using scalar_t                = typename IlutHandle::nnz_scalar_t;
+  using float_t                 = typename IlutHandle::float_t;
   using HandleDeviceEntriesType = typename IlutHandle::nnz_lno_view_t;
   using HandleDeviceRowMapType  = typename IlutHandle::nnz_row_view_t;
   using HandleDeviceValueType   = typename IlutHandle::nnz_value_view_t;
@@ -71,8 +86,8 @@ struct IlutWrap {
                                   LU_row_map);
 
     const size_type lu_nnz_size = kh.get_spgemm_handle()->get_c_nnz();
-    Kokkos::resize(LU_entries, lu_nnz_size);
-    Kokkos::resize(LU_values, lu_nnz_size);
+    resize_no_preserve(LU_entries, lu_nnz_size);
+    resize_no_preserve(LU_values, lu_nnz_size);
 
     KokkosSparse::spgemm_numeric(&kh, nrows, nrows, nrows, L_row_map, L_entries, L_values, false, U_row_map, U_entries,
                                  U_values, false, LU_row_map, LU_entries, LU_values);
@@ -96,8 +111,8 @@ struct IlutWrap {
     // Need to reset t_row_map
     Kokkos::deep_copy(t_row_map, 0);
 
-    Kokkos::resize(t_entries, entries.extent(0));
-    Kokkos::resize(t_values, values.extent(0));
+    resize_no_preserve(t_entries, entries.extent(0));
+    resize_no_preserve(t_values, values.extent(0));
 
     KokkosSparse::Impl::transpose_matrix<HandleDeviceRowMapType, HandleDeviceEntriesType, HandleDeviceValueType,
                                          HandleDeviceRowMapType, HandleDeviceEntriesType, HandleDeviceValueType,
@@ -225,10 +240,10 @@ struct IlutWrap {
     const size_type l_new_nnz_tot = prefix_sum(L_new_row_map);
     const size_type u_new_nnz_tot = prefix_sum(U_new_row_map);
 
-    Kokkos::resize(L_new_entries, l_new_nnz_tot);
-    Kokkos::resize(U_new_entries, u_new_nnz_tot);
-    Kokkos::resize(L_new_values, l_new_nnz_tot);
-    Kokkos::resize(U_new_values, u_new_nnz_tot);
+    resize_no_preserve(L_new_entries, l_new_nnz_tot);
+    resize_no_preserve(U_new_entries, u_new_nnz_tot);
+    resize_no_preserve(L_new_values, l_new_nnz_tot);
+    resize_no_preserve(U_new_values, u_new_nnz_tot);
 
     constexpr auto sentinel = std::numeric_limits<size_type>::max();
 
@@ -461,28 +476,33 @@ struct IlutWrap {
     }
   }
 
+  struct AbsComparator {
+    KOKKOS_INLINE_FUNCTION
+    bool operator()(const scalar_t& a, const scalar_t& b) const { return karith::abs(a) < karith::abs(b); }
+  };
+
   /**
    * Select threshold based on filter rank. Do all this on host
    */
   template <class ValuesType, class ValuesCopyType>
-  static typename IlutHandle::float_t threshold_select(ValuesType& values, const typename IlutHandle::nnz_lno_t rank,
-                                                       ValuesCopyType& values_copy) {
+  static float_t threshold_select(ValuesType& values, const typename IlutHandle::nnz_lno_t rank,
+                                  ValuesCopyType& values_copy_d) {
     const index_t size = values.extent(0);
 
-    Kokkos::resize(values_copy, size);
-    Kokkos::deep_copy(values_copy, values);
+    resize_no_preserve(values_copy_d, size);
+    Kokkos::deep_copy(values_copy_d, values);
 
-    auto begin  = values_copy.data();
-    auto target = begin + rank;
-    auto end    = begin + size;
-    std::nth_element(begin, target, end, [](scalar_t a, scalar_t b) { return karith::abs(a) < karith::abs(b); });
+    float_t result;
+    Kokkos::sort(values_copy_d, AbsComparator{});
+    Kokkos::parallel_reduce(
+        range_policy(0, 1), KOKKOS_LAMBDA(const int, scalar_t& lsum) { lsum = karith::abs(values_copy_d(rank)); },
+        result);
 
-    return karith::abs(values_copy(rank));
+    return result;
   }
 
   template <class IRowMapType, class IEntriesType, class IValuesType, class ORowMapType>
   struct ThresholdFilterCountFunctor {
-    using float_t = typename IlutHandle::float_t;
     ThresholdFilterCountFunctor(const float_t threshold_, const IRowMapType& I_row_map_, const IEntriesType& I_entries_,
                                 const IValuesType& I_values_, const ORowMapType& O_row_map_)
         : threshold(threshold_),
@@ -520,7 +540,6 @@ struct IlutWrap {
   template <class IRowMapType, class IEntriesType, class IValuesType, class ORowMapType, class OEntriesType,
             class OValuesType>
   struct ThresholdFilterAssignFunctor {
-    using float_t = typename IlutHandle::float_t;
     ThresholdFilterAssignFunctor(const float_t threshold_, const IRowMapType& I_row_map_,
                                  const IEntriesType& I_entries_, const IValuesType& I_values_,
                                  const ORowMapType& O_row_map_, const OEntriesType& O_entries_,
@@ -562,9 +581,9 @@ struct IlutWrap {
    */
   template <class IRowMapType, class IEntriesType, class IValuesType, class ORowMapType, class OEntriesType,
             class OValuesType>
-  static void threshold_filter(IlutHandle& ih, const typename IlutHandle::float_t threshold,
-                               const IRowMapType& I_row_map, const IEntriesType& I_entries, const IValuesType& I_values,
-                               ORowMapType& O_row_map, OEntriesType& O_entries, OValuesType& O_values) {
+  static void threshold_filter(IlutHandle& ih, const float_t threshold, const IRowMapType& I_row_map,
+                               const IEntriesType& I_entries, const IValuesType& I_values, ORowMapType& O_row_map,
+                               OEntriesType& O_entries, OValuesType& O_values) {
     const auto policy     = ih.get_default_team_policy();
     const size_type nrows = ih.get_nrows();
 
@@ -574,8 +593,8 @@ struct IlutWrap {
 
     const auto new_nnz = prefix_sum(O_row_map);
 
-    Kokkos::resize(O_entries, new_nnz);
-    Kokkos::resize(O_values, new_nnz);
+    resize_no_preserve(O_entries, new_nnz);
+    resize_no_preserve(O_values, new_nnz);
 
     Kokkos::parallel_for(
         "threshold_filter assign", range_policy(0, nrows),
@@ -608,13 +627,13 @@ struct IlutWrap {
     // use that for exec!
     typename KHandle::HandleExecSpace exec{};
     if (R_row_map.size() == 0) {
-      Kokkos::resize(exec, R_row_map, A_row_map.size());
+      resize_no_preserve(R_row_map, A_row_map.size());
     }
     KokkosSparse::spadd_symbolic(exec, &kh, m, n, A_row_map, A_entries, LU_row_map, LU_entries, R_row_map);
 
     const size_type r_nnz = addHandle->get_c_nnz();
-    Kokkos::resize(exec, R_entries, r_nnz);
-    Kokkos::resize(exec, R_values, r_nnz);
+    resize_no_preserve(R_entries, r_nnz);
+    resize_no_preserve(R_values, r_nnz);
 
     KokkosSparse::spadd_numeric(exec, &kh, m, n, A_row_map, A_entries, A_values, 1., LU_row_map, LU_entries, LU_values,
                                 -1., R_row_map, R_entries, R_values);
@@ -748,7 +767,6 @@ struct IlutWrap {
     HandleDeviceRowMapType R_row_map;
     HandleDeviceEntriesType LU_entries, L_new_entries, U_new_entries, Ut_new_entries, R_entries;
     HandleDeviceValueType LU_values, L_new_values, U_new_values, Ut_new_values, V_copy_d, R_values;
-    auto V_copy = Kokkos::create_mirror_view(V_copy_d);
 
     size_type itr                  = 0;
     scalar_t curr_residual         = std::numeric_limits<scalar_t>::max();
@@ -796,8 +814,8 @@ struct IlutWrap {
         const auto l_filter_rank = std::max(static_cast<index_t>(0), l_nnz - l_nnz_limit - 1);
         const auto u_filter_rank = std::max(static_cast<index_t>(0), u_nnz - u_nnz_limit - 1);
 
-        const auto l_threshold = threshold_select(L_new_values, l_filter_rank, V_copy);
-        const auto u_threshold = threshold_select(U_new_values, u_filter_rank, V_copy);
+        const auto l_threshold = threshold_select(L_new_values, l_filter_rank, V_copy_d);
+        const auto u_threshold = threshold_select(U_new_values, u_filter_rank, V_copy_d);
 
         threshold_filter(thandle, l_threshold, L_new_row_map, L_new_entries, L_new_values, L_row_map, L_entries,
                          L_values);

--- a/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_par_ilut_numeric_impl.hpp
@@ -23,19 +23,6 @@ namespace KokkosSparse {
 namespace Impl {
 namespace Experimental {
 
-// Resize a view without allocating or initializing if possible.
-template <typename ViewT>
-inline void resize_no_preserve(ViewT& view, const size_t new_size) {
-  // const auto curr_size = view.size();
-  // if (curr_size >= new_size) {
-  //   return Kokkos::subview(view, Kokkos::make_pair(0, new_size));
-  // }
-  // else {
-  Kokkos::realloc(Kokkos::WithoutInitializing, view, new_size);
-  //   return view;
-  // }
-}
-
 template <class IlutHandle>
 struct IlutWrap {
   //
@@ -86,8 +73,8 @@ struct IlutWrap {
                                   LU_row_map);
 
     const size_type lu_nnz_size = kh.get_spgemm_handle()->get_c_nnz();
-    resize_no_preserve(LU_entries, lu_nnz_size);
-    resize_no_preserve(LU_values, lu_nnz_size);
+    Kokkos::realloc(Kokkos::WithoutInitializing, LU_entries, lu_nnz_size);
+    Kokkos::realloc(Kokkos::WithoutInitializing, LU_values, lu_nnz_size);
 
     KokkosSparse::spgemm_numeric(&kh, nrows, nrows, nrows, L_row_map, L_entries, L_values, false, U_row_map, U_entries,
                                  U_values, false, LU_row_map, LU_entries, LU_values);
@@ -111,8 +98,8 @@ struct IlutWrap {
     // Need to reset t_row_map
     Kokkos::deep_copy(t_row_map, 0);
 
-    resize_no_preserve(t_entries, entries.extent(0));
-    resize_no_preserve(t_values, values.extent(0));
+    Kokkos::realloc(Kokkos::WithoutInitializing, t_entries, entries.extent(0));
+    Kokkos::realloc(Kokkos::WithoutInitializing, t_values, values.extent(0));
 
     KokkosSparse::Impl::transpose_matrix<HandleDeviceRowMapType, HandleDeviceEntriesType, HandleDeviceValueType,
                                          HandleDeviceRowMapType, HandleDeviceEntriesType, HandleDeviceValueType,
@@ -240,10 +227,10 @@ struct IlutWrap {
     const size_type l_new_nnz_tot = prefix_sum(L_new_row_map);
     const size_type u_new_nnz_tot = prefix_sum(U_new_row_map);
 
-    resize_no_preserve(L_new_entries, l_new_nnz_tot);
-    resize_no_preserve(U_new_entries, u_new_nnz_tot);
-    resize_no_preserve(L_new_values, l_new_nnz_tot);
-    resize_no_preserve(U_new_values, u_new_nnz_tot);
+    Kokkos::realloc(Kokkos::WithoutInitializing, L_new_entries, l_new_nnz_tot);
+    Kokkos::realloc(Kokkos::WithoutInitializing, U_new_entries, u_new_nnz_tot);
+    Kokkos::realloc(Kokkos::WithoutInitializing, L_new_values, l_new_nnz_tot);
+    Kokkos::realloc(Kokkos::WithoutInitializing, U_new_values, u_new_nnz_tot);
 
     constexpr auto sentinel = std::numeric_limits<size_type>::max();
 
@@ -489,7 +476,7 @@ struct IlutWrap {
                                   ValuesCopyType& values_copy_d) {
     const index_t size = values.extent(0);
 
-    resize_no_preserve(values_copy_d, size);
+    Kokkos::realloc(Kokkos::WithoutInitializing, values_copy_d, size);
     Kokkos::deep_copy(values_copy_d, values);
 
     float_t result;
@@ -593,8 +580,8 @@ struct IlutWrap {
 
     const auto new_nnz = prefix_sum(O_row_map);
 
-    resize_no_preserve(O_entries, new_nnz);
-    resize_no_preserve(O_values, new_nnz);
+    Kokkos::realloc(Kokkos::WithoutInitializing, O_entries, new_nnz);
+    Kokkos::realloc(Kokkos::WithoutInitializing, O_values, new_nnz);
 
     Kokkos::parallel_for(
         "threshold_filter assign", range_policy(0, nrows),
@@ -627,13 +614,13 @@ struct IlutWrap {
     // use that for exec!
     typename KHandle::HandleExecSpace exec{};
     if (R_row_map.size() == 0) {
-      resize_no_preserve(R_row_map, A_row_map.size());
+      Kokkos::realloc(Kokkos::WithoutInitializing, R_row_map, A_row_map.size());
     }
     KokkosSparse::spadd_symbolic(exec, &kh, m, n, A_row_map, A_entries, LU_row_map, LU_entries, R_row_map);
 
     const size_type r_nnz = addHandle->get_c_nnz();
-    resize_no_preserve(R_entries, r_nnz);
-    resize_no_preserve(R_values, r_nnz);
+    Kokkos::realloc(Kokkos::WithoutInitializing, R_entries, r_nnz);
+    Kokkos::realloc(Kokkos::WithoutInitializing, R_values, r_nnz);
 
     KokkosSparse::spadd_numeric(exec, &kh, m, n, A_row_map, A_entries, A_values, 1., LU_row_map, LU_entries, LU_values,
                                 -1., R_row_map, R_entries, R_values);

--- a/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
+++ b/sparse/impl/KokkosSparse_spiluk_numeric_impl.hpp
@@ -42,10 +42,8 @@ struct IlukWrap {
   using WorkViewType      = typename IlukHandle::work_view_t;
   using LevelHostViewType = typename IlukHandle::nnz_lno_view_host_t;
   using LevelViewType     = typename IlukHandle::nnz_lno_view_t;
-  using karith            = typename KokkosKernels::ArithTraits<scalar_t>;
   using team_policy       = typename IlukHandle::TeamPolicy;
   using member_type       = typename team_policy::member_type;
-  using range_policy      = typename IlukHandle::RangePolicy;
 
   static team_policy get_team_policy(const size_type nrows, const int team_size) {
     team_policy rv;

--- a/sparse/src/KokkosSparse_gmres.hpp
+++ b/sparse/src/KokkosSparse_gmres.hpp
@@ -41,7 +41,8 @@ namespace Experimental {
 /// @param X
 /// @param precond
 template <typename KernelHandle, typename AMatrix, typename BType, typename XType>
-void gmres(KernelHandle* handle, AMatrix& A, BType& B, XType& X, Preconditioner<AMatrix>* precond = nullptr) {
+void gmres(KernelHandle* handle, AMatrix& A, BType& B, XType& X,
+           Preconditioner<std::remove_const_t<AMatrix>>* precond = nullptr) {
   using scalar_type  = typename KernelHandle::nnz_scalar_t;
   using size_type    = typename KernelHandle::size_type;
   using ordinal_type = typename KernelHandle::nnz_lno_t;
@@ -120,12 +121,12 @@ void gmres(KernelHandle* handle, AMatrix& A, BType& B, XType& X, Preconditioner<
   using B_Internal =
       Kokkos::View<typename BType::const_value_type*,
                    typename KokkosKernels::Impl::GetUnifiedLayout<BType>::array_layout, typename BType::device_type,
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;
 
   using X_Internal =
       Kokkos::View<typename XType::non_const_value_type*,
                    typename KokkosKernels::Impl::GetUnifiedLayout<XType>::array_layout, typename XType::device_type,
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess> >;
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;
 
   using Precond_Internal = Preconditioner<AMatrix_Internal>;
 


### PR DESCRIPTION
Main change: threshold_select was doing a small piece of par_ilut on host. I assumed based on the code and ginkgo's OMP implementation that the computational cost of this piece would be trivial, but it was actually very expensive. Instead of relying on std::nth_element, just make a copy of values and sort based on the absolute value. This requires a bit more device memory, but is 20 times faster, so I think this is well worth it.

Secondary change: various improvements to the par_ilut benchmark. The main improvements are the ability to validate the ILU via gmres+luprec and efforts to reduce memory usage so you can benchmark larger matrices.