### PR TITLE
Avoid calls to potentially non-static member function `::rank` in the case of `Kokkos::DynRankView` types

### DIFF
--- a/batched/dense/impl/KokkosBatched_Trsm_Team_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsm_Team_Impl.hpp
@@ -25,9 +25,7 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Lower, Trans::NoTranspose, ArgDiag
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    static_assert(AViewType::rank() == 2);
-    constexpr size_t B_rank = BViewType::rank();
-    static_assert(B_rank == 1 || B_rank == 2);
+    const size_t B_rank = B.rank();
 
     // Quick return if possible
     if (B.size() == 0) return 0;
@@ -46,9 +44,7 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Lower, Trans::NoTranspose, ArgDiag
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    static_assert(AViewType::rank() == 2);
-    constexpr size_t B_rank = BViewType::rank();
-    static_assert(B_rank == 1 || B_rank == 2);
+    const size_t B_rank = B.rank();
 
     // Quick return if possible
     if (B.size() == 0) return 0;
@@ -73,9 +69,7 @@ struct TeamTrsm<MemberType, Side::Right, Uplo::Upper, Trans::NoTranspose, ArgDia
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    static_assert(AViewType::rank() == 2);
-    constexpr size_t B_rank = BViewType::rank();
-    static_assert(B_rank == 1 || B_rank == 2);
+    const size_t B_rank = B.rank();
 
     // Quick return if possible
     if (B.size() == 0) return 0;
@@ -94,9 +88,7 @@ struct TeamTrsm<MemberType, Side::Right, Uplo::Upper, Trans::NoTranspose, ArgDia
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    static_assert(AViewType::rank() == 2);
-    constexpr size_t B_rank = BViewType::rank();
-    static_assert(B_rank == 1 || B_rank == 2);
+    const size_t B_rank = B.rank();
 
     // Quick return if possible
     if (B.size() == 0) return 0;
@@ -121,9 +113,7 @@ struct TeamTrsm<MemberType, Side::Right, Uplo::Lower, Trans::NoTranspose, ArgDia
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    static_assert(AViewType::rank() == 2);
-    constexpr size_t B_rank = BViewType::rank();
-    static_assert(B_rank == 1 || B_rank == 2);
+    const size_t B_rank = B.rank();
 
     // Quick return if possible
     if (B.size() == 0) return 0;
@@ -142,9 +132,7 @@ struct TeamTrsm<MemberType, Side::Right, Uplo::Lower, Trans::NoTranspose, ArgDia
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    static_assert(AViewType::rank() == 2);
-    constexpr size_t B_rank = BViewType::rank();
-    static_assert(B_rank == 1 || B_rank == 2);
+    const size_t B_rank = B.rank();
 
     // Quick return if possible
     if (B.size() == 0) return 0;
@@ -169,9 +157,7 @@ struct TeamTrsm<MemberType, Side::Right, Uplo::Upper, Trans::Transpose, ArgDiag,
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    static_assert(AViewType::rank() == 2);
-    constexpr size_t B_rank = BViewType::rank();
-    static_assert(B_rank == 1 || B_rank == 2);
+    const size_t B_rank = B.rank();
 
     // Quick return if possible
     if (B.size() == 0) return 0;
@@ -190,9 +176,7 @@ struct TeamTrsm<MemberType, Side::Right, Uplo::Upper, Trans::Transpose, ArgDiag,
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    static_assert(AViewType::rank() == 2);
-    constexpr size_t B_rank = BViewType::rank();
-    static_assert(B_rank == 1 || B_rank == 2);
+    const size_t B_rank = B.rank();
 
     // Quick return if possible
     if (B.size() == 0) return 0;
@@ -217,9 +201,7 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Upper, Trans::NoTranspose, ArgDiag
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    static_assert(AViewType::rank() == 2);
-    constexpr size_t B_rank = BViewType::rank();
-    static_assert(B_rank == 1 || B_rank == 2);
+    const size_t B_rank = B.rank();
 
     // Quick return if possible
     if (B.size() == 0) return 0;
@@ -238,9 +220,7 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Upper, Trans::NoTranspose, ArgDiag
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    static_assert(AViewType::rank() == 2);
-    constexpr size_t B_rank = BViewType::rank();
-    static_assert(B_rank == 1 || B_rank == 2);
+    const size_t B_rank = B.rank();
 
     // Quick return if possible
     if (B.size() == 0) return 0;
@@ -265,9 +245,7 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Lower, Trans::Transpose, ArgDiag, 
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    static_assert(AViewType::rank() == 2);
-    constexpr size_t B_rank = BViewType::rank();
-    static_assert(B_rank == 1 || B_rank == 2);
+    const size_t B_rank = B.rank();
 
     // Quick return if possible
     if (B.size() == 0) return 0;
@@ -286,9 +264,7 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Lower, Trans::Transpose, ArgDiag, 
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    static_assert(AViewType::rank() == 2);
-    constexpr size_t B_rank = BViewType::rank();
-    static_assert(B_rank == 1 || B_rank == 2);
+    const size_t B_rank = B.rank();
 
     // Quick return if possible
     if (B.size() == 0) return 0;
@@ -313,9 +289,7 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Upper, Trans::Transpose, ArgDiag, 
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    static_assert(AViewType::rank() == 2);
-    constexpr size_t B_rank = BViewType::rank();
-    static_assert(B_rank == 1 || B_rank == 2);
+    const size_t B_rank = B.rank();
 
     // Quick return if possible
     if (B.size() == 0) return 0;
@@ -334,9 +308,7 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Upper, Trans::Transpose, ArgDiag, 
   template <typename ScalarType, typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
                                            const BViewType &B) {
-    static_assert(AViewType::rank() == 2);
-    constexpr size_t B_rank = BViewType::rank();
-    static_assert(B_rank == 1 || B_rank == 2);
+    const size_t B_rank = B.rank();
 
     // Quick return if possible
     if (B.size() == 0) return 0;


### PR DESCRIPTION
Closes https://github.com/kokkos/kokkos-kernels/issues/2850

@lucbv 