### PR TITLE
worflow - release: update versioning scheme

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    tags: '[0-9]+.[0-9]+.[0-9][0-9]'
+    tags: '[0-9]+.[0-9]+.[0-9]+'
   
 
 permissions: read-all
@@ -43,7 +43,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       # Upload provenance to a new release


### PR DESCRIPTION
Small change to reflect the new versioning scheme that will no longer assume two digits for the patch numer.
Also pin the dependency on slsa by hash