### PR TITLE
Sparse - SellMatrix: adding SELL sparse matrix format

### DIFF
--- a/sparse/src/KokkosSparse_SellMatrix.hpp
+++ b/sparse/src/KokkosSparse_SellMatrix.hpp
@@ -58,21 +58,21 @@ class SellMatrix {
   //! Type of the view containing the offset to each slice of the matrix.
   using offsets_type = Kokkos::View<size_type*, Kokkos::LayoutRight, device_type, MemoryTraits>;
   //! Const version of the type of the offsets_type in the sparse matrix.
-  using const_offsets_type = typename offsets_type::const_value_type;
+  using const_offset_type = typename offsets_type::const_value_type;
   //! Nonconst version of the type of the entries in the sparse matrix.
-  using non_const_offsets_type = typename offsets_type::non_const_value_type;
+  using non_const_offset_type = typename offsets_type::non_const_value_type;
   //! Type of the view containing the column indices of the matrix entries.
   using entries_type = Kokkos::View<ordinal_type*, Kokkos::LayoutRight, device_type, MemoryTraits>;
   //! Const version of the type of the column indices in the sparse matrix.
-  using const_entries_type = typename entries_type::const_value_type;
+  using const_entry_type = typename entries_type::const_value_type;
   //! Nonconst version of the type of the column indices in the sparse matrix.
-  using non_const_entries_type = typename entries_type::non_const_value_type;
+  using non_const_entry_type = typename entries_type::non_const_value_type;
   //! Type of the view containing the values of the matrix entries.
   using values_type = Kokkos::View<value_type*, Kokkos::LayoutRight, device_type, MemoryTraits>;
   //! Const version of the type of the entries in the sparse matrix.
-  using const_values_type = typename values_type::const_value_type;
+  using const_value_type = typename values_type::const_value_type;
   //! Nonconst version of the type of the entries in the sparse matrix.
-  using non_const_values_type = typename values_type::non_const_value_type;
+  using non_const_value_type = typename values_type::non_const_value_type;
 
   //! Type of a host-memory mirror of the sparse matrix.
   using host_mirror_type = SellMatrix<ScalarType, OrdinalType, host_mirror_space, MemoryTraits, SizeType>;

--- a/sparse/src/KokkosSparse_SellMatrix.hpp
+++ b/sparse/src/KokkosSparse_SellMatrix.hpp
@@ -45,13 +45,13 @@ class SellMatrix {
   //! Type of the matrix's memory space.
   using memory_space = typename Device::memory_space;
   //! Canonical device type
-  using device_type = Kokkos::Device<execution_space, memory_space>;
+  using device_type   = Kokkos::Device<execution_space, memory_space>;
   using memory_traits = MemoryTraits;
 
   //! Type of each value in the matrix.
   using value_type = ScalarType;
   //! Type of each (column) index in the matrix.
-  using ordinal_type  = OrdinalType;
+  using ordinal_type = OrdinalType;
   //! Type of the offsets used in the track the start and end of each slice.
   using size_type = SizeType;
 

--- a/sparse/src/KokkosSparse_SellMatrix.hpp
+++ b/sparse/src/KokkosSparse_SellMatrix.hpp
@@ -46,28 +46,33 @@ class SellMatrix {
   using memory_space = typename Device::memory_space;
   //! Canonical device type
   using device_type = Kokkos::Device<execution_space, memory_space>;
+  using memory_traits = MemoryTraits;
 
   //! Type of each value in the matrix.
   using value_type = ScalarType;
   //! Type of each (column) index in the matrix.
   using ordinal_type  = OrdinalType;
-  using memory_traits = MemoryTraits;
-  /// \brief Type of each entry of the "row map."
-  ///
-  /// The "row map" corresponds to the \c ptr array of row offsets in
-  /// compressed sparse row (CSR) storage.
+  //! Type of the offsets used in the track the start and end of each slice.
   using size_type = SizeType;
 
   //! Type of the view containing the offset to each slice of the matrix.
   using offsets_type = Kokkos::View<size_type*, Kokkos::LayoutRight, device_type, MemoryTraits>;
+  //! Const version of the type of the offsets_type in the sparse matrix.
+  using const_offsets_type = typename offsets_type::const_value_type;
+  //! Nonconst version of the type of the entries in the sparse matrix.
+  using non_const_offsets_type = typename offsets_type::non_const_value_type;
   //! Type of the view containing the column indices of the matrix entries.
   using entries_type = Kokkos::View<ordinal_type*, Kokkos::LayoutRight, device_type, MemoryTraits>;
+  //! Const version of the type of the column indices in the sparse matrix.
+  using const_entries_type = typename entries_type::const_value_type;
+  //! Nonconst version of the type of the column indices in the sparse matrix.
+  using non_const_entries_type = typename entries_type::non_const_value_type;
   //! Type of the view containing the values of the matrix entries.
   using values_type = Kokkos::View<value_type*, Kokkos::LayoutRight, device_type, MemoryTraits>;
   //! Const version of the type of the entries in the sparse matrix.
-  using const_value_type = typename values_type::const_value_type;
+  using const_values_type = typename values_type::const_value_type;
   //! Nonconst version of the type of the entries in the sparse matrix.
-  using non_const_value_type = typename values_type::non_const_value_type;
+  using non_const_values_type = typename values_type::non_const_value_type;
 
   //! Type of a host-memory mirror of the sparse matrix.
   using host_mirror_type = SellMatrix<ScalarType, OrdinalType, host_mirror_space, MemoryTraits, SizeType>;

--- a/sparse/src/KokkosSparse_SellMatrix.hpp
+++ b/sparse/src/KokkosSparse_SellMatrix.hpp
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+/// \file KokkosSparse_SellMatrix.hpp
+/// \brief Local sparse sliced ellpack matrix interface
+///
+/// This file provides KokkosSparse::SellMatrix.  This implements
+/// a parse matrix stored in sliced ellpack ("Sell") format.
+
+#ifndef KOKKOSSPARSE_SELLMATRIX_HPP_
+#define KOKKOSSPARSE_SELLMATRIX_HPP_
+
+#include <sstream>
+#include <stdexcept>
+
+#include "Kokkos_Core.hpp"
+
+namespace KokkosSparse {
+namespace Experimental {
+
+/// \class SellMatrix
+/// \brief Sliced ell format implementation of a sparse matrix.
+/// \tparam ScalarType The type of entries in the sparse matrix.
+/// \tparam OrdinalType The type of column indices in the sparse matrix.
+/// \tparam Device The Kokkos Device type.
+/// \tparam MemoryTraits Traits describing how Kokkos manages and
+///   accesses data.  The default parameter suffices for most users.
+///
+/// "SellMatrix" stands for "sliced ELLPACK" matrix. This format is defined,
+/// among other places here: https://doi.org/10.1007/978-3-642-11515-8_10
+template <class ScalarType, class OrdinalType, class Device, class MemoryTraits = void,
+          class SizeType = KokkosKernels::default_size_type>
+class SellMatrix {
+  static_assert(std::is_signed<OrdinalType>::value, "SellMatrix requires that OrdinalType is a signed integer type.");
+
+ private:
+  using host_mirror_space = typename Kokkos::ViewTraits<ScalarType*, Device, void, MemoryTraits>::host_mirror_space;
+
+ public:
+  //! @name Typedefs
+  //@{
+
+  //! Type of the matrix's execution space.
+  using execution_space = typename Device::execution_space;
+  //! Type of the matrix's memory space.
+  using memory_space = typename Device::memory_space;
+  //! Canonical device type
+  using device_type = Kokkos::Device<execution_space, memory_space>;
+
+  //! Type of each value in the matrix.
+  using value_type = ScalarType;
+  //! Type of each (column) index in the matrix.
+  using ordinal_type  = OrdinalType;
+  using memory_traits = MemoryTraits;
+  /// \brief Type of each entry of the "row map."
+  ///
+  /// The "row map" corresponds to the \c ptr array of row offsets in
+  /// compressed sparse row (CSR) storage.
+  using size_type = SizeType;
+
+  //! Type of the view containing the offset to each slice of the matrix.
+  using offsets_type = Kokkos::View<size_type*, Kokkos::LayoutRight, device_type, MemoryTraits>;
+  //! Type of the view containing the column indices of the matrix entries.
+  using entries_type = Kokkos::View<ordinal_type*, Kokkos::LayoutRight, device_type, MemoryTraits>;
+  //! Type of the view containing the values of the matrix entries.
+  using values_type = Kokkos::View<value_type*, Kokkos::LayoutRight, device_type, MemoryTraits>;
+  //! Const version of the type of the entries in the sparse matrix.
+  using const_value_type = typename values_type::const_value_type;
+  //! Nonconst version of the type of the entries in the sparse matrix.
+  using non_const_value_type = typename values_type::non_const_value_type;
+
+  //! Type of a host-memory mirror of the sparse matrix.
+  using host_mirror_type = SellMatrix<ScalarType, OrdinalType, host_mirror_space, MemoryTraits, SizeType>;
+
+  //! Type of a const version of the sparse matrix.
+  using const_type = SellMatrix<const_value_type, ordinal_type, device_type, memory_traits, size_type>;
+
+  //@}
+
+  //! Number of rows of the matrix.
+  ordinal_type num_rows;
+  //! Number of columns of the matrix.
+  ordinal_type num_cols;
+  //! Number of non-zero values in the matrix.
+  size_type nnz;
+  //! Number of non-zero in the matrix including padding.
+  size_type sell_nnz;
+  //! Number of rows per slice.
+  ordinal_type num_rows_per_slice;
+  //! Number of slices in the matrix.
+  ordinal_type num_slices;
+  //! Rank-1 view of the offsets for each slice in the sparse matrix.
+  offsets_type slice_offsets;
+  //! Rank-1 view of column indices of the sparse matrix.
+  entries_type entries;
+  //! Rank-1 view of values of the sparse matrix.
+  values_type values;
+
+  //! @name Constructors and destructor
+  //@{
+
+  /// \brief Default constructor that constructs an empty matrix
+  KOKKOS_INLINE_FUNCTION SellMatrix() {}
+
+  /// \brief Constructor
+  SellMatrix(const OrdinalType nrows, const OrdinalType ncols, const SizeType nnz_, const SizeType padded_nnz,
+             const OrdinalType rows_per_slice, const offsets_type& sliceOffsets, const entries_type& cols,
+             const values_type& vals)
+      : num_rows(nrows),
+        num_cols(ncols),
+        nnz(nnz_),
+        sell_nnz(padded_nnz),
+        num_rows_per_slice(rows_per_slice),
+        num_slices((nrows + num_rows_per_slice - 1) / num_rows_per_slice),
+        slice_offsets(sliceOffsets),
+        entries(cols),
+        values(vals) {
+    // Perform input validation
+    if (num_rows_per_slice < num_rows) {  // This requirement should go away once we support proper sell not only ell.
+      std::ostringstream os;
+      os << "KokkosSparse::SellMatrix: rows_per_slice(" << rows_per_slice << ") < nrows(" << nrows
+         << ") which is not supported currently as we only allow one slice that holds the total matrix.";
+      throw std::invalid_argument(os.str());
+    }
+    // Checking that the size of slice_offsets is constistent with the number of slices
+    if (num_slices != static_cast<ordinal_type>(slice_offsets.extent(0) - 1)) {
+      std::ostringstream os;
+      os << "KokkosSparse::SellMatrix: sliceOffsets.extent(0)=" << slice_offsets.extent(0)
+         << ", is not equal to num_slices(" << num_slices << ") + 1.";
+      throw std::invalid_argument(os.str());
+    }
+    // The number of values stored in the sell matrix inclues padding so should be larger than nnz
+    if (sell_nnz < nnz) {
+      std::ostringstream os;
+      os << "KokkosSparse::SellMatrix: padded_nz(" << sell_nnz << ") cannot be less than nnz(" << nnz << ").";
+      throw std::invalid_argument(os.str());
+    }
+    // Make sure that extent of the entries and values views match the number of non-zeros in the sell matrix
+    if ((static_cast<size_type>(entries.extent(0)) != sell_nnz) ||
+        (static_cast<size_type>(values.extent_int(0)) != sell_nnz)) {
+      std::ostringstream os;
+      os << "KokkosSparse::SellMatrix: entries.extent(0)=" << entries.extent(0)
+         << ", values.extent(0)=" << values.extent(0) << " and padded_nnz=" << sell_nnz << " must all be equal.";
+      throw std::invalid_argument(os.str());
+    }
+  }
+
+  //@}
+};
+
+/// \class is_sell_matrix
+/// \brief is_sell_matrix<T>::value is true if T is a SellMatrix<...>, false
+/// otherwise
+template <typename>
+struct is_sell_matrix : public std::false_type {};
+template <typename... P>
+struct is_sell_matrix<SellMatrix<P...>> : public std::true_type {};
+template <typename... P>
+struct is_sell_matrix<const SellMatrix<P...>> : public std::true_type {};
+
+/// \brief Equivalent to is_crs_matrix<T>::value.
+template <typename T>
+inline constexpr bool is_sell_matrix_v = is_sell_matrix<T>::value;
+
+}  // namespace Experimental
+}  // namespace KokkosSparse
+#endif  // KOKKOSSPARSE_SELLMATRIX_HPP_

--- a/sparse/unit_test/Test_Sparse.hpp
+++ b/sparse/unit_test/Test_Sparse.hpp
@@ -7,6 +7,7 @@
 #include "Test_Sparse_crs2coo.hpp"
 #include "Test_Sparse_Controls.hpp"
 #include "Test_Sparse_CrsMatrix.hpp"
+#include "Test_Sparse_SellMatrix.hpp"
 #include "Test_Sparse_mdf.hpp"
 #include "Test_Sparse_findRelOffset.hpp"
 #include "Test_Sparse_gauss_seidel.hpp"

--- a/sparse/unit_test/Test_Sparse_SellMatrix.hpp
+++ b/sparse/unit_test/Test_Sparse_SellMatrix.hpp
@@ -99,25 +99,30 @@ void SellConstructor() {
 
   // Number of rows larger than rows_per_slice
   // This one should be removed once we support multiple slices
-  EXPECT_THROW({
-      SellMatrixType A_bad_nrows(nrows + 1, ncols, nnz, sell_nnz, rows_per_slice, slice_offsets, colinds, values);
-    }, std::invalid_argument);
+  EXPECT_THROW(
+      { SellMatrixType A_bad_nrows(nrows + 1, ncols, nnz, sell_nnz, rows_per_slice, slice_offsets, colinds, values); },
+      std::invalid_argument);
 
   // Mismatch between slice_offsets.extent(0) and number of slices
-  EXPECT_THROW({
-      offsets_type bad_slice_offsets("slice offsets", nslices + 2);
-      SellMatrixType A_bad_nrows(nrows, ncols, nnz, sell_nnz, rows_per_slice, bad_slice_offsets, colinds, values);
-    }, std::invalid_argument);
+  EXPECT_THROW(
+      {
+        offsets_type bad_slice_offsets("slice offsets", nslices + 2);
+        SellMatrixType A_bad_nrows(nrows, ncols, nnz, sell_nnz, rows_per_slice, bad_slice_offsets, colinds, values);
+      },
+      std::invalid_argument);
 
   // nnz is larger than sell_nnz
-  EXPECT_THROW({
-      SellMatrixType A_bad_nrows(nrows, ncols, nnz + sell_nnz + 1, sell_nnz, rows_per_slice, slice_offsets, colinds, values);
-    }, std::invalid_argument);
+  EXPECT_THROW(
+      {
+        SellMatrixType A_bad_nrows(nrows, ncols, nnz + sell_nnz + 1, sell_nnz, rows_per_slice, slice_offsets, colinds,
+                                   values);
+      },
+      std::invalid_argument);
 
   // Mismatch between sell_nnz and size of colinds and values
-  EXPECT_THROW({
-      SellMatrixType A_bad_nrows(nrows, ncols, nnz, sell_nnz - 1, rows_per_slice, slice_offsets, colinds, values);
-    }, std::invalid_argument);
+  EXPECT_THROW(
+      { SellMatrixType A_bad_nrows(nrows, ncols, nnz, sell_nnz - 1, rows_per_slice, slice_offsets, colinds, values); },
+      std::invalid_argument);
 }
 }  // namespace Test
 

--- a/sparse/unit_test/Test_Sparse_SellMatrix.hpp
+++ b/sparse/unit_test/Test_Sparse_SellMatrix.hpp
@@ -93,7 +93,31 @@ void SellConstructor() {
 
   SellMatrixType A(nrows, ncols, nnz, sell_nnz, rows_per_slice, slice_offsets, colinds, values);
 
-  std::cout << "A.num_slices = " << A.num_slices << std::endl;
+  EXPECT_EQ(A.num_slices, 1);
+
+  // Test for bad input detection
+
+  // Number of rows larger than rows_per_slice
+  // This one should be removed once we support multiple slices
+  EXPECT_THROW({
+      SellMatrixType A_bad_nrows(nrows + 1, ncols, nnz, sell_nnz, rows_per_slice, slice_offsets, colinds, values);
+    }, std::invalid_argument);
+
+  // Mismatch between slice_offsets.extent(0) and number of slices
+  EXPECT_THROW({
+      offsets_type bad_slice_offsets("slice offsets", nslices + 2);
+      SellMatrixType A_bad_nrows(nrows, ncols, nnz, sell_nnz, rows_per_slice, bad_slice_offsets, colinds, values);
+    }, std::invalid_argument);
+
+  // nnz is larger than sell_nnz
+  EXPECT_THROW({
+      SellMatrixType A_bad_nrows(nrows, ncols, nnz + sell_nnz + 1, sell_nnz, rows_per_slice, slice_offsets, colinds, values);
+    }, std::invalid_argument);
+
+  // Mismatch between sell_nnz and size of colinds and values
+  EXPECT_THROW({
+      SellMatrixType A_bad_nrows(nrows, ncols, nnz, sell_nnz - 1, rows_per_slice, slice_offsets, colinds, values);
+    }, std::invalid_argument);
 }
 }  // namespace Test
 

--- a/sparse/unit_test/Test_Sparse_SellMatrix.hpp
+++ b/sparse/unit_test/Test_Sparse_SellMatrix.hpp
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <iostream>
+
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include "KokkosSparse_SellMatrix.hpp"
+#include "KokkosKernels_ArithTraits.hpp"
+
+namespace Test {
+
+template <class SellMatrixType>
+void SellConstructor() {
+  using ordinal_type = typename SellMatrixType::ordinal_type;
+  using size_type    = typename SellMatrixType::size_type;
+  using value_type   = typename SellMatrixType::value_type;
+
+  using KAT = KokkosKernels::ArithTraits<value_type>;
+
+  using offsets_type = typename SellMatrixType::offsets_type;
+  using entries_type = typename SellMatrixType::entries_type;
+  using values_type  = typename SellMatrixType::values_type;
+
+  //     [ 2 -1               ]             [ 0  1 -1]            [ 2.0 -1.0  0.0]
+  //     [-1  2 -1            ]             [ 0  1  2]            [-1.0  2.0 -1.0]
+  //     [   -1  2 -1         ]             [ 1  2  3]            [-1.0  2.0 -1.0]
+  // A = [      -1  2 -1      ]   colinds = [ 2  3  4]   values = [-1.0  2.0 -1.0]
+  //     [         -1  2 -1   ]             [ 3  4  5]            [-1.0  2.0 -1.0]
+  //     [            -1  2 -1]             [ 4  5  6]            [-1.0  2.0 -1.0]
+  //     [               -1  2]             [ 5  6 -1]            [-1.0  2.0  0.0]
+
+  constexpr ordinal_type nrows = 7, ncols = 7, rows_per_slice = 7, nslices = 1;
+  constexpr size_type nnz = 19, sell_nnz = 21;
+
+  offsets_type slice_offsets("slice offsets", nslices + 1);
+  typename offsets_type::host_mirror_type slice_offsets_h = Kokkos::create_mirror_view(slice_offsets);
+  slice_offsets_h(1)                                      = sell_nnz;
+  Kokkos::deep_copy(slice_offsets, slice_offsets_h);
+
+  entries_type colinds("column indices", sell_nnz);
+  typename entries_type::host_mirror_type colinds_h = Kokkos::create_mirror_view(colinds);
+  colinds_h(0)                                      = 0;
+  colinds_h(7)                                      = 1;
+  colinds_h(14)                                     = -1;
+  colinds_h(1)                                      = 0;
+  colinds_h(8)                                      = 1;
+  colinds_h(15)                                     = 2;
+  colinds_h(2)                                      = 1;
+  colinds_h(9)                                      = 2;
+  colinds_h(16)                                     = 3;
+  colinds_h(3)                                      = 2;
+  colinds_h(10)                                     = 3;
+  colinds_h(17)                                     = 4;
+  colinds_h(4)                                      = 3;
+  colinds_h(11)                                     = 4;
+  colinds_h(17)                                     = 5;
+  colinds_h(5)                                      = 4;
+  colinds_h(12)                                     = 5;
+  colinds_h(19)                                     = 6;
+  colinds_h(6)                                      = 5;
+  colinds_h(13)                                     = 6;
+  colinds_h(20)                                     = -1;
+  Kokkos::deep_copy(colinds, colinds_h);
+
+  values_type values("values", sell_nnz);
+  typename values_type::host_mirror_type values_h = Kokkos::create_mirror_view(values);
+  const value_type zero                           = KAT::zero();
+  const value_type one                            = KAT::one();
+  const value_type two                            = KAT::one() + KAT::one();
+  values_h(0)                                     = two;
+  values_h(7)                                     = -one;
+  values_h(14)                                    = zero;
+  values_h(1)                                     = -one;
+  values_h(8)                                     = two;
+  values_h(15)                                    = -one;
+  values_h(2)                                     = -one;
+  values_h(9)                                     = two;
+  values_h(16)                                    = -one;
+  values_h(3)                                     = -one;
+  values_h(10)                                    = two;
+  values_h(17)                                    = -one;
+  values_h(4)                                     = -one;
+  values_h(11)                                    = two;
+  values_h(18)                                    = -one;
+  values_h(5)                                     = -one;
+  values_h(12)                                    = two;
+  values_h(19)                                    = -one;
+  values_h(6)                                     = -one;
+  values_h(13)                                    = two;
+  values_h(20)                                    = zero;
+  Kokkos::deep_copy(values, values_h);
+
+  SellMatrixType A(nrows, ncols, nnz, sell_nnz, rows_per_slice, slice_offsets, colinds, values);
+
+  std::cout << "A.num_slices = " << A.num_slices << std::endl;
+}
+}  // namespace Test
+
+template <typename Scalar, typename Ordinal, typename Offset, class Device>
+void testSellMatrix() {
+  using sell_matrix_type = KokkosSparse::Experimental::SellMatrix<Scalar, Ordinal, Device, void, Offset>;
+  Test::SellConstructor<sell_matrix_type>();
+}
+
+#define KOKKOSKERNELS_EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE)                          \
+  TEST_F(TestCategory, sparse##_##sellmatrix##_##SCALAR##_##ORDINAL##_##OFFSET##_##DEVICE) { \
+    testSellMatrix<SCALAR, ORDINAL, OFFSET, DEVICE>();                                       \
+  }
+
+#include <Test_Common_Test_All_Type_Combos.hpp>
+
+#undef KOKKOSKERNELS_EXECUTE_TEST


### PR DESCRIPTION
The SELL sparse matrix format is helpful when a matrix has a well balanced number of non-zeros per row and can leverage that structure to perform faster matrix-vector operations.