### PR TITLE
Fix SYCL issues with MKL on Aurora

### DIFF
--- a/benchmarks/blas/KokkosBlas3_gemm_benchmark.cpp
+++ b/benchmarks/blas/KokkosBlas3_gemm_benchmark.cpp
@@ -124,7 +124,7 @@ int main(int argc, char** argv) {
   // or -1, for no such selection
   const int device_id = params.use_cuda
                             ? params.use_cuda - 1
-                            : (params.use_sycl ? params.use_sycl - 1 : (params.use_hip ? params.use_hip - 1 : -1));
+                            : (params.use_sycl ? params.use_sycl - 1 : (params.use_hip ? params.use_hip - 1 : 0));
 
   Kokkos::initialize(Kokkos::InitializationSettings().set_num_threads(num_threads).set_device_id(device_id));
   benchmark::Initialize(&argc, argv);

--- a/blas/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
@@ -224,8 +224,10 @@ namespace Impl {
       if (numElems <= static_cast<size_type>(std::numeric_limits<std::int64_t>::max())) {                             \
         dot_print_specialization<RV, XV, XV>();                                                                       \
         const std::int64_t N = static_cast<std::int64_t>(numElems);                                                   \
+        Kokkos::View<typename RV::value_type, MEMSPACE> device_result("device_result");                               \
         TPL_DOT(exec.sycl_queue(), N, reinterpret_cast<const TPL_TYPE*>(X.data()), 1,                                 \
-                reinterpret_cast<const TPL_TYPE*>(Y.data()), 1, reinterpret_cast<TPL_TYPE*>(&R()));                   \
+                reinterpret_cast<const TPL_TYPE*>(Y.data()), 1, reinterpret_cast<TPL_TYPE*>(device_result.data()));   \
+        Kokkos::deep_copy(R, device_result);                                                                          \
       } else {                                                                                                        \
         Dot<EXECSPACE, RV, XV, XV, 1, 1, false, ETI_SPEC_AVAIL>::dot(exec, R, X, Y);                                  \
       }                                                                                                               \

--- a/blas/tpls/KokkosBlas1_nrm2_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_nrm2_tpl_spec_decl.hpp
@@ -303,7 +303,9 @@ namespace Impl {
       if (numElems <= static_cast<size_type>(std::numeric_limits<std::int64_t>::max())) {                              \
         nrm2_print_specialization<RV, XV>();                                                                           \
         const std::int64_t N = static_cast<std::int64_t>(numElems);                                                    \
-        TPL_NRM2(space.sycl_queue(), N, reinterpret_cast<const TPL_TYPE*>(X.data()), 1, &R());                         \
+        Kokkos::View<typename RV::value_type, MEMSPACE> device_result("device_result");                                \
+        TPL_NRM2(space.sycl_queue(), N, reinterpret_cast<const TPL_TYPE*>(X.data()), 1, device_result.data());         \
+        Kokkos::deep_copy(R, device_result);                                                                           \
         if (!take_sqrt) R() = R() * R();                                                                               \
       } else {                                                                                                         \
         Nrm2<EXECSPACE, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm2(space, R, X, take_sqrt);                               \

--- a/perf_test/blas/blas1/KokkosBlas_team_dot_perf_test.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_team_dot_perf_test.cpp
@@ -136,7 +136,7 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  const int device_id = params.use_cuda - 1;
+  const int device_id = params.use_cuda > 0 ? params.use_cuda - 1 : 0;
 
   const int num_threads = std::max(params.use_openmp, params.use_threads);
 

--- a/perf_test/blas/blas3/KokkosBlas3_gemm_standalone_perf_test.cpp
+++ b/perf_test/blas/blas3/KokkosBlas3_gemm_standalone_perf_test.cpp
@@ -110,7 +110,7 @@ int main(int argc, char** argv) {
   }
   const int num_threads = params.use_openmp;  // Assumption is that use_openmp variable is provided
                                               // as number of threads
-  const int device_id = params.use_cuda - 1;
+  const int device_id = params.use_cuda > 0 ? params.use_cuda - 1 : 0;
 
   Kokkos::initialize(Kokkos::InitializationSettings().set_num_threads(num_threads).set_device_id(device_id));
 


### PR DESCRIPTION
This fixes some of the failing Aurora unit tests.
After this, I'm still seeing
```
The following tests FAILED:
	  5 - batched_dla_sycl (Timeout)
	 11 - blas_sycl (Subprocess aborted)
	 17 - sparse_sycl (Subprocess aborted)
	 18 - blocksparse_sycl (Subprocess aborted)
```