### PR TITLE
Sparse - SpMV: removing cusparse < 11500 path

### DIFF
--- a/sparse/src/KokkosSparse_Utils_cusparse.hpp
+++ b/sparse/src/KokkosSparse_Utils_cusparse.hpp
@@ -15,29 +15,7 @@ namespace Impl {
 inline void cusparse_internal_error_throw(cusparseStatus_t cusparseStatus, const char* name, const char* file,
                                           const int line) {
   std::ostringstream out;
-#if defined(CUSPARSE_VERSION) && (10300 <= CUSPARSE_VERSION)
   out << name << " error( " << cusparseGetErrorName(cusparseStatus) << "): " << cusparseGetErrorString(cusparseStatus);
-#else
-  out << name << " error( ";
-  switch (cusparseStatus) {
-    case CUSPARSE_STATUS_NOT_INITIALIZED:
-      out << "CUSPARSE_STATUS_NOT_INITIALIZED): cusparse handle was not "
-             "created correctly.";
-      break;
-    case CUSPARSE_STATUS_ALLOC_FAILED:
-      out << "CUSPARSE_STATUS_ALLOC_FAILED): you might tried to allocate too "
-             "much memory";
-      break;
-    case CUSPARSE_STATUS_INVALID_VALUE: out << "CUSPARSE_STATUS_INVALID_VALUE)"; break;
-    case CUSPARSE_STATUS_ARCH_MISMATCH: out << "CUSPARSE_STATUS_ARCH_MISMATCH)"; break;
-    case CUSPARSE_STATUS_MAPPING_ERROR: out << "CUSPARSE_STATUS_MAPPING_ERROR)"; break;
-    case CUSPARSE_STATUS_EXECUTION_FAILED: out << "CUSPARSE_STATUS_EXECUTION_FAILED)"; break;
-    case CUSPARSE_STATUS_INTERNAL_ERROR: out << "CUSPARSE_STATUS_INTERNAL_ERROR)"; break;
-    case CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED: out << "CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED)"; break;
-    case CUSPARSE_STATUS_ZERO_PIVOT: out << "CUSPARSE_STATUS_ZERO_PIVOT)"; break;
-    default: out << "unrecognized error code): this is bad!"; break;
-  }
-#endif  // CUSPARSE_VERSION
   if (file) {
     out << " " << file << ":" << line;
   }
@@ -97,8 +75,6 @@ inline cudaDataType cuda_data_type_from<Kokkos::complex<double>>() {
   return CUDA_C_64F;
 }
 
-#if defined(CUSPARSE_VERSION) && (10300 <= CUSPARSE_VERSION)
-
 template <typename T>
 cusparseIndexType_t cusparse_index_type_t_from() {
 #define AS_STR_LITERAL_IMPL_(x) #x
@@ -131,7 +107,6 @@ template <>
 inline cusparseIndexType_t cusparse_index_type_t_from<unsigned short>() {
   return CUSPARSE_INDEX_16U;
 }
-#endif
 
 // Set the stream on the given cuSPARSE handle when this object
 // is constructed, and reset to the default stream when this object is

--- a/sparse/src/KokkosSparse_spmv_handle.hpp
+++ b/sparse/src/KokkosSparse_spmv_handle.hpp
@@ -103,14 +103,7 @@ struct CuSparse10_SpMV_Data : public TPL_SpMV_Data<Kokkos::Cuda> {
   ~CuSparse10_SpMV_Data() {
     // Prefer cudaFreeAsync on the stream that last executed a spmv, but
     // async memory management was introduced in 11.2
-#if (CUDA_VERSION >= 11020)
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFreeAsync(buffer, exec.cuda_stream()));
-#else
-    // Fence here to ensure spmv is not still using buffer
-    // (cudaFree does not do a device synchronize)
-    exec.fence();
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(buffer));
-#endif
     KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseDestroySpMat(mat));
   }
 

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
@@ -257,7 +257,6 @@ KOKKOSSPARSE_SPMV_MV_MKL(Kokkos::complex<double>, Kokkos::OpenMP)
 // - Only CUSPARSE_OPERATION_NON_TRANSPOSE is supported
 // - Only CUSPARSE_MATRIX_TYPE_GENERAL is supported.
 //
-#if (9000 <= CUDA_VERSION)
 
 #include "KokkosSparse_Utils_cusparse.hpp"
 
@@ -553,7 +552,6 @@ KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::CudaUVMS
 
 }  // namespace Impl
 }  // namespace KokkosSparse
-#endif  // (9000 <= CUDA_VERSION)
 
 #endif  // KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 

--- a/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_avail.hpp
@@ -27,17 +27,12 @@ struct spmv_mv_tpl_spec_avail {
     enum : bool { value = true };                                                                                    \
   };
 
-/* CUSPARSE_VERSION 10300 and lower seem to have a bug in cusparseSpMM
-non-transpose that produces incorrect result. This is cusparse distributed with
-CUDA 10.1.243. The bug seems to be resolved by CUSPARSE 10301 (present by
-CUDA 10.2.89) */
-
 /* cusparseSpMM also produces incorrect results for some inputs in CUDA 11.6.1.
  * (CUSPARSE_VERSION 11702).
  * ALG1 and ALG3 produce completely incorrect results for one set of inputs.
  * ALG2 works for that case, but has low numerical accuracy in another case.
  */
-#if defined(CUSPARSE_VERSION) && (10301 <= CUSPARSE_VERSION) && (CUSPARSE_VERSION != 11702)
+#if defined(CUSPARSE_VERSION) && (CUSPARSE_VERSION != 11702)
 KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(double, int, int, Kokkos::LayoutLeft, Kokkos::LayoutLeft,
                                              Kokkos::CudaSpace)
 KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(double, int, int, Kokkos::LayoutRight, Kokkos::LayoutLeft,
@@ -89,7 +84,7 @@ KOKKOSSPARSE_SPMV_MV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::Experimental::half_t, int, 
                                              Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
 
 #endif
-#endif  // defined(CUSPARSE_VERSION) && (10300 <= CUSPARSE_VERSION)
+#endif  // defined(CUSPARSE_VERSION) && (CUSPARSE_VERSION != 11702)
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE

--- a/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
@@ -9,13 +9,11 @@
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 
-/* CUSPARSE_VERSION < 10301 either doesn't have cusparseSpMM
-   or the non-tranpose version produces incorrect results.
-
-   Version 11702 corresponds to CUDA 11.6.1, which also produces incorrect
+/* 
+   Version 11702 corresponds to CUDA 11.6.1, which produces incorrect
    results. 11701 (CUDA 11.6.0) is OK.
 */
-#if defined(CUSPARSE_VERSION) && (10301 <= CUSPARSE_VERSION) && (CUSPARSE_VERSION != 11702)
+#if defined(CUSPARSE_VERSION) && (CUSPARSE_VERSION != 11702)
 #include "cusparse.h"
 #include "KokkosSparse_Utils_cusparse.hpp"
 
@@ -35,17 +33,10 @@ template <typename AScalar, typename XScalar = AScalar, typename YScalar = AScal
 cudaDataType compute_type() {
   return cuda_data_type_from<AScalar>();
 }
-#if CUSPARSE_VERSION >= 11501
 template <>
 inline cudaDataType compute_type<Kokkos::Experimental::half_t>() {
   return CUDA_R_32F;
 }
-#else
-template <>
-inline cudaDataType compute_type<Kokkos::Experimental::half_t>() {
-  return cuda_data_type_from<Kokkos::Experimental::half_t>();
-}
-#endif
 
 /*! \brief convert a 2D view to a cusparseDnMatDescr_t
 
@@ -131,13 +122,7 @@ void spmv_mv_cusparse(const Kokkos::Cuda &exec, Handle *handle, const char mode[
   cusparseDnMatDescr_t vecY = make_cusparse_dn_mat_descr_t(y);
   cusparseOperation_t opB   = xIsLL ? CUSPARSE_OPERATION_NON_TRANSPOSE : CUSPARSE_OPERATION_TRANSPOSE;
 
-// CUSPARSE_MM_ALG_DEFAULT was deprecated in CUDA 11.0.1 / cuSPARSE 11.0.0 and
-// removed in CUDA 12.0.0 / cuSPARSE 12.0.0
-#if CUSPARSE_VERSION < 11000
-  cusparseSpMMAlg_t algo = CUSPARSE_MM_ALG_DEFAULT;
-#else
   cusparseSpMMAlg_t algo = CUSPARSE_SPMM_ALG_DEFAULT;
-#endif
 
   // the precision of the SpMV
   const cudaDataType computeType = compute_type<value_type, x_value_type, y_value_type>();
@@ -264,7 +249,7 @@ KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::Experimental::half_t, int, int, Kokkos::La
 
 }  // namespace Impl
 }  // namespace KokkosSparse
-#endif  // defined(CUSPARSE_VERSION) && (10301 <= CUSPARSE_VERSION)
+#endif  // defined(CUSPARSE_VERSION) && (CUSPARSE_VERSION != 11702)
 #endif  // KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 
 // rocSPARSE

--- a/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
@@ -9,7 +9,7 @@
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 
-/* 
+/*
    Version 11702 corresponds to CUDA 11.6.1, which produces incorrect
    results. 11701 (CUDA 11.6.0) is OK.
 */

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
@@ -34,8 +34,6 @@ struct spmv_tpl_spec_avail {
     enum : bool { value = true };                                                                                   \
   };
 
-#if (9000 <= CUDA_VERSION)
-
 KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int, int, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
 KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int, int, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
 KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
@@ -63,11 +61,6 @@ KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, int, Kokk
                                           Kokkos::CudaUVMSpace)
 KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight,
                                           Kokkos::CudaUVMSpace)
-
-// CUDA_VERSION by itself cannot determine whether the generic cuSPARSE API is
-// available: cuSPARSE version 10.1.105 does not have the generic API, but it
-// comes with the same CUDA_VERSION (10010) as 10.1.243 which does.
-#if defined(CUSPARSE_VERSION) && (10300 <= CUSPARSE_VERSION)
 
 // Can enable int64/size_t.
 // TODO: if Nvidia ever supports int/size_t, add that too.
@@ -105,8 +98,6 @@ KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int64_t, size_
 KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int64_t, size_t, Kokkos::LayoutRight,
                                           Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
 
-#endif  // CUSPARSE >= 10.3 (nested, implies >= 9.0)
-#endif  // CUDA/CUSPARSE >= 9.0?
 #endif  // KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 
 #undef KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -70,15 +70,7 @@ void spmv_cusparse(const Kokkos::Cuda& exec, Handle* handle, const char mode[],
   KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseCreateDnVec(&vecX, x.extent_int(0), (void*)x.data(), myCudaDataType));
   KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseCreateDnVec(&vecY, y.extent_int(0), (void*)y.data(), myCudaDataType));
 
-  // Prior to CUDA 11.2.1, ALG2 was more performant than default for imbalanced
-  // matrices. After 11.2.1, the default is performant for imbalanced matrices,
-  // and ALG2 now means something else. CUDA >= 11.2.1 corresponds to
-  // CUSPARSE_VERSION >= 11402.
-  const bool useAlg2 = false;
-
-  // In CUDA 11.2.0, the algorithm enums were renamed.
-  // This corresponds to CUSPARSE_VERSION >= 11400.
-  cusparseSpMVAlg_t algo = useAlg2 ? CUSPARSE_SPMV_CSR_ALG2 : CUSPARSE_SPMV_ALG_DEFAULT;
+  cusparseSpMVAlg_t algo = CUSPARSE_SPMV_ALG_DEFAULT;
 
   KokkosSparse::Impl::CuSparse10_SpMV_Data* subhandle;
 
@@ -114,59 +106,6 @@ void spmv_cusparse(const Kokkos::Cuda& exec, Handle* handle, const char mode[],
 
   KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(vecX));
   KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(vecY));
-
-  KokkosSparse::Impl::CuSparse9_SpMV_Data* subhandle;
-
-  if (handle->tpl_rank1) {
-    subhandle = dynamic_cast<KokkosSparse::Impl::CuSparse9_SpMV_Data*>(handle->tpl_rank1);
-    if (!subhandle) throw std::runtime_error("KokkosSparse::spmv: subhandle is not set up for cusparse");
-    subhandle->set_exec_space(exec);
-  } else {
-    /* create and set the subhandle and matrix descriptor */
-    subhandle                 = new KokkosSparse::Impl::CuSparse9_SpMV_Data(exec);
-    handle->tpl_rank1         = subhandle;
-    cusparseMatDescr_t descrA = 0;
-    KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseCreateMatDescr(&subhandle->mat));
-    KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSetMatType(subhandle->mat, CUSPARSE_MATRIX_TYPE_GENERAL));
-    KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSetMatIndexBase(subhandle->mat, CUSPARSE_INDEX_BASE_ZERO));
-  }
-
-  /* perform the actual SpMV operation */
-  static_assert(std::is_same_v<int, offset_type>,
-                "With cuSPARSE pre-10.0, offset type must be int. Something wrong with "
-                "TPL avail logic.");
-  if constexpr (std::is_same_v<value_type, float>) {
-    KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseScsrmv(
-        cusparseHandle, myCusparseOperation, A.numRows(), A.numCols(), A.nnz(), reinterpret_cast<float const*>(&alpha),
-        subhandle->mat, reinterpret_cast<float const*>(A.values.data()), A.graph.row_map.data(), A.graph.entries.data(),
-        reinterpret_cast<float const*>(x.data()), reinterpret_cast<float const*>(&beta),
-        reinterpret_cast<float*>(y.data())));
-
-  } else if constexpr (std::is_same_v<value_type, double>) {
-    KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseDcsrmv(
-        cusparseHandle, myCusparseOperation, A.numRows(), A.numCols(), A.nnz(), reinterpret_cast<double const*>(&alpha),
-        subhandle->mat, reinterpret_cast<double const*>(A.values.data()), A.graph.row_map.data(),
-        A.graph.entries.data(), reinterpret_cast<double const*>(x.data()), reinterpret_cast<double const*>(&beta),
-        reinterpret_cast<double*>(y.data())));
-  } else if constexpr (std::is_same_v<value_type, Kokkos::complex<float>>) {
-    KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseCcsrmv(
-        cusparseHandle, myCusparseOperation, A.numRows(), A.numCols(), A.nnz(),
-        reinterpret_cast<cuComplex const*>(&alpha), subhandle->mat, reinterpret_cast<cuComplex const*>(A.values.data()),
-        A.graph.row_map.data(), A.graph.entries.data(), reinterpret_cast<cuComplex const*>(x.data()),
-        reinterpret_cast<cuComplex const*>(&beta), reinterpret_cast<cuComplex*>(y.data())));
-  } else if constexpr (std::is_same_v<value_type, Kokkos::complex<double>>) {
-    KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(
-        cusparseZcsrmv(cusparseHandle, myCusparseOperation, A.numRows(), A.numCols(), A.nnz(),
-                       reinterpret_cast<cuDoubleComplex const*>(&alpha), subhandle->mat,
-                       reinterpret_cast<cuDoubleComplex const*>(A.values.data()), A.graph.row_map.data(),
-                       A.graph.entries.data(), reinterpret_cast<cuDoubleComplex const*>(x.data()),
-                       reinterpret_cast<cuDoubleComplex const*>(&beta), reinterpret_cast<cuDoubleComplex*>(y.data())));
-  } else {
-    static_assert(
-      static_assert(KokkosKernels::Impl::always_false_v<value_type>,
-        "Trying to call cusparse SpMV with a scalar type not float/double, "
-        "nor complex of either!");
-  }
 }
 
 #define KOKKOSSPARSE_SPMV_CUSPARSE(SCALAR, ORDINAL, OFFSET, LAYOUT, SPACE)                                          \

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -45,10 +45,6 @@ void spmv_cusparse(const Kokkos::Cuda& exec, Handle* handle, const char mode[],
       !KokkosKernels::ArithTraits<value_type>::isComplex)
     myCusparseOperation = CUSPARSE_OPERATION_TRANSPOSE;
 
-// Hopefully this corresponds to CUDA reelase 10.1, which is the first to
-// include the "generic" API
-#if defined(CUSPARSE_VERSION) && (10300 <= CUSPARSE_VERSION)
-
   using entry_type = typename AMatrix::non_const_ordinal_type;
 
   cudaDataType myCudaDataType;
@@ -78,19 +74,11 @@ void spmv_cusparse(const Kokkos::Cuda& exec, Handle* handle, const char mode[],
   // matrices. After 11.2.1, the default is performant for imbalanced matrices,
   // and ALG2 now means something else. CUDA >= 11.2.1 corresponds to
   // CUSPARSE_VERSION >= 11402.
-#if CUSPARSE_VERSION >= 11402
   const bool useAlg2 = false;
-#else
-  const bool useAlg2     = handle->get_algorithm() == SPMV_MERGE_PATH;
-#endif
 
   // In CUDA 11.2.0, the algorithm enums were renamed.
   // This corresponds to CUSPARSE_VERSION >= 11400.
-#if CUSPARSE_VERSION >= 11400
   cusparseSpMVAlg_t algo = useAlg2 ? CUSPARSE_SPMV_CSR_ALG2 : CUSPARSE_SPMV_ALG_DEFAULT;
-#else
-  cusparseSpMVAlg_t algo = useAlg2 ? CUSPARSE_CSRMV_ALG2 : CUSPARSE_MV_ALG_DEFAULT;
-#endif
 
   KokkosSparse::Impl::CuSparse10_SpMV_Data* subhandle;
 
@@ -126,8 +114,6 @@ void spmv_cusparse(const Kokkos::Cuda& exec, Handle* handle, const char mode[],
 
   KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(vecX));
   KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(vecY));
-
-#elif (9000 <= CUDA_VERSION)
 
   KokkosSparse::Impl::CuSparse9_SpMV_Data* subhandle;
 
@@ -181,7 +167,6 @@ void spmv_cusparse(const Kokkos::Cuda& exec, Handle* handle, const char mode[],
         "Trying to call cusparse SpMV with a scalar type not float/double, "
         "nor complex of either!");
   }
-#endif  // CUDA_VERSION
 }
 
 #define KOKKOSSPARSE_SPMV_CUSPARSE(SCALAR, ORDINAL, OFFSET, LAYOUT, SPACE)                                          \
@@ -212,7 +197,6 @@ void spmv_cusparse(const Kokkos::Cuda& exec, Handle* handle, const char mode[],
     }                                                                                                               \
   };
 
-#if (9000 <= CUDA_VERSION)
 KOKKOSSPARSE_SPMV_CUSPARSE(double, int, int, Kokkos::LayoutLeft, Kokkos::CudaSpace)
 KOKKOSSPARSE_SPMV_CUSPARSE(double, int, int, Kokkos::LayoutRight, Kokkos::CudaSpace)
 KOKKOSSPARSE_SPMV_CUSPARSE(float, int, int, Kokkos::LayoutLeft, Kokkos::CudaSpace)
@@ -229,8 +213,6 @@ KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::LayoutLeft
 KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
 KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
 KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-
-#if defined(CUSPARSE_VERSION) && (10300 <= CUSPARSE_VERSION)
 KOKKOSSPARSE_SPMV_CUSPARSE(double, int64_t, size_t, Kokkos::LayoutLeft, Kokkos::CudaSpace)
 KOKKOSSPARSE_SPMV_CUSPARSE(double, int64_t, size_t, Kokkos::LayoutRight, Kokkos::CudaSpace)
 KOKKOSSPARSE_SPMV_CUSPARSE(float, int64_t, size_t, Kokkos::LayoutLeft, Kokkos::CudaSpace)
@@ -247,8 +229,6 @@ KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int64_t, size_t, Kokkos::Lay
 KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int64_t, size_t, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
 KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>, int64_t, size_t, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
 KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>, int64_t, size_t, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
-#endif  // defined(CUSPARSE_VERSION) && (10300 <= CUSPARSE_VERSION)
-#endif  // 9000 <= CUDA_VERSION
 
 #undef KOKKOSSPARSE_SPMV_CUSPARSE
 


### PR DESCRIPTION
With the new compiler requirements the oldest supported version of cusparse is that 11500 that comes with cuda-clang 15.0.0