### PR TITLE
Benchmark: cleaning up some compiler warnings

### DIFF
--- a/benchmarks/lapack/KokkosLapack_SVD_benchmark.cpp
+++ b/benchmarks/lapack/KokkosLapack_SVD_benchmark.cpp
@@ -16,7 +16,7 @@ struct svd_parameters {
   bool verbose;
 
   svd_parameters(const int numRows_, const int numCols_, const bool verbose_)
-      : numRows(numRows_), numCols(numCols_), verbose(verbose_){}
+      : numRows(numRows_), numCols(numCols_), verbose(verbose_) {}
 };
 
 void print_options() {

--- a/benchmarks/lapack/KokkosLapack_SVD_benchmark.cpp
+++ b/benchmarks/lapack/KokkosLapack_SVD_benchmark.cpp
@@ -16,7 +16,7 @@ struct svd_parameters {
   bool verbose;
 
   svd_parameters(const int numRows_, const int numCols_, const bool verbose_)
-      : numRows(numRows_), numCols(numCols_), verbose(verbose_){};
+      : numRows(numRows_), numCols(numCols_), verbose(verbose_){}
 };
 
 void print_options() {

--- a/benchmarks/ode/KokkosODE_BDF.cpp
+++ b/benchmarks/ode/KokkosODE_BDF.cpp
@@ -84,7 +84,7 @@ struct bdf_input_parameters {
   bool verbose;
 
   bdf_input_parameters(const int num_odes_, const int repeat_, const bool verbose_)
-      : num_odes(num_odes_), repeat(repeat_), verbose(verbose_){};
+      : num_odes(num_odes_), repeat(repeat_), verbose(verbose_){}
 };
 
 template <class execution_space>

--- a/benchmarks/ode/KokkosODE_BDF.cpp
+++ b/benchmarks/ode/KokkosODE_BDF.cpp
@@ -84,7 +84,7 @@ struct bdf_input_parameters {
   bool verbose;
 
   bdf_input_parameters(const int num_odes_, const int repeat_, const bool verbose_)
-      : num_odes(num_odes_), repeat(repeat_), verbose(verbose_){}
+      : num_odes(num_odes_), repeat(repeat_), verbose(verbose_) {}
 };
 
 template <class execution_space>

--- a/benchmarks/ode/KokkosODE_RK.cpp
+++ b/benchmarks/ode/KokkosODE_RK.cpp
@@ -23,7 +23,7 @@ struct chem_model_1 {
   const double tstart, tend, T0, T1;
 
   chem_model_1(const double tstart_ = 0, const double tend_ = 300, const double T0_ = 300, const double T1_ = 800)
-      : tstart(tstart_), tend(tend_), T0(T0_), T1(T1_){};
+      : tstart(tstart_), tend(tend_), T0(T0_), T1(T1_){}
 
   template <class vec_type1, class vec_type2>
   KOKKOS_FUNCTION void evaluate_function(const double t, const double /*dt*/, const vec_type1& y,
@@ -52,7 +52,7 @@ struct chem_model_2 {
   const double tstart, tend, T0, T1;
 
   chem_model_2(const double tstart_ = 0, const double tend_ = 2000, const double T0_ = 300, const double T1_ = 1000)
-      : tstart(tstart_), tend(tend_), T0(T0_), T1(T1_){};
+      : tstart(tstart_), tend(tend_), T0(T0_), T1(T1_){}
 
   template <class vec_type1, class vec_type2>
   KOKKOS_FUNCTION void evaluate_function(const double t, const double /*dt*/, const vec_type1& y,
@@ -129,7 +129,7 @@ struct rk_input_parameters {
   bool verbose;
 
   rk_input_parameters(const int num_odes_, const int model_, const int repeat_, const bool verbose_)
-      : num_odes(num_odes_), model(model_), repeat(repeat_), verbose(verbose_){};
+      : num_odes(num_odes_), model(model_), repeat(repeat_), verbose(verbose_){}
 };
 
 }  // namespace

--- a/benchmarks/ode/KokkosODE_RK.cpp
+++ b/benchmarks/ode/KokkosODE_RK.cpp
@@ -23,7 +23,7 @@ struct chem_model_1 {
   const double tstart, tend, T0, T1;
 
   chem_model_1(const double tstart_ = 0, const double tend_ = 300, const double T0_ = 300, const double T1_ = 800)
-      : tstart(tstart_), tend(tend_), T0(T0_), T1(T1_){}
+      : tstart(tstart_), tend(tend_), T0(T0_), T1(T1_) {}
 
   template <class vec_type1, class vec_type2>
   KOKKOS_FUNCTION void evaluate_function(const double t, const double /*dt*/, const vec_type1& y,
@@ -52,7 +52,7 @@ struct chem_model_2 {
   const double tstart, tend, T0, T1;
 
   chem_model_2(const double tstart_ = 0, const double tend_ = 2000, const double T0_ = 300, const double T1_ = 1000)
-      : tstart(tstart_), tend(tend_), T0(T0_), T1(T1_){}
+      : tstart(tstart_), tend(tend_), T0(T0_), T1(T1_) {}
 
   template <class vec_type1, class vec_type2>
   KOKKOS_FUNCTION void evaluate_function(const double t, const double /*dt*/, const vec_type1& y,
@@ -129,7 +129,7 @@ struct rk_input_parameters {
   bool verbose;
 
   rk_input_parameters(const int num_odes_, const int model_, const int repeat_, const bool verbose_)
-      : num_odes(num_odes_), model(model_), repeat(repeat_), verbose(verbose_){}
+      : num_odes(num_odes_), model(model_), repeat(repeat_), verbose(verbose_) {}
 };
 
 }  // namespace

--- a/benchmarks/sparse/KokkosSparse_par_ilut.cpp
+++ b/benchmarks/sparse/KokkosSparse_par_ilut.cpp
@@ -495,8 +495,7 @@ int run_ilu_perf_tests(const std::string& matrix_file, int rows, int nnz_per_row
     auto plambda = [&](benchmark::State& state) {
       run_par_ilut_test(state, kh, A, num_iters, parilut_results, validate, gmres_max_subspace);
     };
-    KokkosKernelsBenchmark::register_benchmark_real_time((name + "_par_ilut").c_str(), plambda, arg_names,
-                                                                  args, loop);
+    KokkosKernelsBenchmark::register_benchmark_real_time((name + "_par_ilut").c_str(), plambda, arg_names, args, loop);
   }
 
   if (test & 2) {

--- a/benchmarks/sparse/KokkosSparse_par_ilut.cpp
+++ b/benchmarks/sparse/KokkosSparse_par_ilut.cpp
@@ -495,7 +495,7 @@ int run_ilu_perf_tests(const std::string& matrix_file, int rows, int nnz_per_row
     auto plambda = [&](benchmark::State& state) {
       run_par_ilut_test(state, kh, A, num_iters, parilut_results, validate, gmres_max_subspace);
     };
-    auto r = KokkosKernelsBenchmark::register_benchmark_real_time((name + "_par_ilut").c_str(), plambda, arg_names,
+    KokkosKernelsBenchmark::register_benchmark_real_time((name + "_par_ilut").c_str(), plambda, arg_names,
                                                                   args, loop);
   }
 


### PR DESCRIPTION
These are getting caught by the new options to trigger warnings and warngings as error.