### PR TITLE
Refactor batched copy

### DIFF
--- a/batched/dense/impl/KokkosBatched_Copy_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Copy_Impl.hpp
@@ -4,11 +4,51 @@
 #define KOKKOSBATCHED_COPY_IMPL_HPP
 
 /// \author Kyungjoo Kim (kyukim@sandia.gov)
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
 
+#include "KokkosBlas_util.hpp"
 #include "KokkosBatched_Util.hpp"
 #include "KokkosBatched_Copy_Internal.hpp"
 
 namespace KokkosBatched {
+namespace Impl {
+
+template <typename ArgTrans, typename AViewType, typename BViewType>
+KOKKOS_INLINE_FUNCTION static int checkCopyInput([[maybe_unused]] const AViewType &A,
+                                                 [[maybe_unused]] const BViewType &B) {
+  static_assert(Kokkos::is_view_v<AViewType>, "KokkosBatched::copy: AViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view_v<BViewType>, "KokkosBatched::copy: BViewType is not a Kokkos::View.");
+  static_assert(AViewType::rank() == BViewType::rank(),
+                "KokkosBatched::copy: AViewType and BViewType must have the same rank.");
+  static_assert(AViewType::rank() == 1 || AViewType::rank() == 2,
+                "KokkosBatched::copy: Only rank 1 and rank 2 views are supported.");
+  static_assert(std::is_same_v<typename BViewType::value_type, typename BViewType::non_const_value_type>,
+                "KokkosBatched::copy: The value_type of BViewType must have non-const value type.");
+
+#ifndef NDEBUG
+  if constexpr (AViewType::rank() == 1) {
+    if (A.extent_int(0) != B.extent_int(0)) {
+      Kokkos::printf(
+          "KokkosBatched::copy: Dimensions of A and B do not match: A: %d, "
+          "B: %d\n",
+          A.extent_int(0), B.extent_int(0));
+      return 1;
+    }
+  } else {
+    const int m_A = std::is_same_v<ArgTrans, Trans::NoTranspose> ? A.extent_int(0) : A.extent_int(1);
+    const int n_A = std::is_same_v<ArgTrans, Trans::NoTranspose> ? A.extent_int(1) : A.extent_int(0);
+    if (m_A != B.extent_int(0) || n_A != B.extent_int(1)) {
+      Kokkos::printf(
+          "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x %d, "
+          "B: %d x %d\n",
+          A.extent_int(0), A.extent_int(1), B.extent_int(0), B.extent_int(1));
+      return 1;
+    }
+  }
+#endif
+  return 0;
+}
+}  // namespace Impl
 
 ///
 /// Serial Impl
@@ -16,135 +56,87 @@ namespace KokkosBatched {
 
 template <>
 template <typename AViewType, typename BViewType>
-KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::NoTranspose, 1>::invoke(const AViewType &A, const BViewType &B) {
-  return SerialCopyInternal::invoke(A.extent(0), A.data(), A.stride(0), B.data(), B.stride(0));
-}
+KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::NoTranspose>::invoke(const AViewType &A, const BViewType &B) {
+  auto info = Impl::checkCopyInput<Trans::NoTranspose>(A, B);
+  if (info) return info;
 
-template <>
-template <typename AViewType, typename BViewType>
-KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::Transpose, 1>::invoke(const AViewType &A, const BViewType &B) {
-  return SerialCopyInternal::invoke(A.extent(0), A.data(), A.stride(0), B.data(), B.stride(0));
-}
-
-template <>
-template <typename AViewType, typename BViewType>
-KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::NoTranspose, 2>::invoke(const AViewType &A, const BViewType &B) {
-  static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::copy: AViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::copy: BViewType is not a Kokkos::View.");
-  static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
-  static_assert(BViewType::rank == 2, "KokkosBatched::copy: BViewType must have rank 2.");
-
-#ifndef NDEBUG
-  // Check compatibility of dimensions at run time.
-  if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
-    Kokkos::printf(
-        "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x %d, "
-        "B: %d x %d\n",
-        (int)A.extent(0), (int)A.extent(1), (int)B.extent(0), (int)B.extent(1));
-    return 1;
+  if constexpr (AViewType::rank() == 1) {
+    return Impl::SerialCopyInternal::invoke(KokkosBlas::Impl::OpID(), A.extent(0), A.data(), A.stride(0), B.data(),
+                                            B.stride(0));
+  } else {
+    return Impl::SerialCopyInternal::invoke(KokkosBlas::Impl::OpID(), A.extent(0), A.extent(1), A.data(), A.stride(0),
+                                            A.stride(1), B.data(), B.stride(0), B.stride(1));
   }
-#endif
-  return SerialCopyInternal::invoke(A.extent(0), A.extent(1), A.data(), A.stride(0), A.stride(1), B.data(), B.stride(0),
-                                    B.stride(1));
 }
 
 template <>
 template <typename AViewType, typename BViewType>
-KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::Transpose, 2>::invoke(const AViewType &A, const BViewType &B) {
-  static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::copy: AViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::copy: BViewType is not a Kokkos::View.");
-  static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
-  static_assert(BViewType::rank == 2, "KokkosBatched::copy: BViewType must have rank 2.");
+KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::Transpose>::invoke(const AViewType &A, const BViewType &B) {
+  auto info = Impl::checkCopyInput<Trans::Transpose>(A, B);
+  if (info) return info;
 
-#ifndef NDEBUG
-  // Check compatibility of dimensions at run time.
-  if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
-    Kokkos::printf(
-        "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x %d, "
-        "B: %d x %d\n",
-        (int)A.extent(0), (int)A.extent(1), (int)B.extent(0), (int)B.extent(1));
-    return 1;
+  if constexpr (AViewType::rank() == 1) {
+    return Impl::SerialCopyInternal::invoke(KokkosBlas::Impl::OpID(), A.extent(0), A.data(), A.stride(0), B.data(),
+                                            B.stride(0));
+  } else {
+    return Impl::SerialCopyInternal::invoke(KokkosBlas::Impl::OpID(), A.extent(1), A.extent(0), A.data(), A.stride(1),
+                                            A.stride(0), B.data(), B.stride(0), B.stride(1));
   }
-#endif
-  return SerialCopyInternal::invoke(A.extent(1), A.extent(0), A.data(), A.stride(1), A.stride(0), B.data(), B.stride(0),
-                                    B.stride(1));
+}
+
+template <>
+template <typename AViewType, typename BViewType>
+KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::ConjTranspose>::invoke(const AViewType &A, const BViewType &B) {
+  auto info = Impl::checkCopyInput<Trans::ConjTranspose>(A, B);
+  if (info) return info;
+
+  if constexpr (AViewType::rank() == 1) {
+    return Impl::SerialCopyInternal::invoke(KokkosBlas::Impl::OpConj(), A.extent(0), A.data(), A.stride(0), B.data(),
+                                            B.stride(0));
+  } else {
+    return Impl::SerialCopyInternal::invoke(KokkosBlas::Impl::OpConj(), A.extent(1), A.extent(0), A.data(), A.stride(1),
+                                            A.stride(0), B.data(), B.stride(0), B.stride(1));
+  }
 }
 
 ///
 /// Team Impl
 /// =========
-
 template <typename MemberType>
-struct TeamCopy<MemberType, Trans::NoTranspose, 1> {
+struct TeamCopy<MemberType, Trans::NoTranspose> {
   template <typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
-    return TeamCopyInternal::invoke(member, A.extent(0), A.data(), A.stride(0), B.data(), B.stride(0));
+    auto info = Impl::checkCopyInput<Trans::NoTranspose>(A, B);
+    if (info) return info;
+
+    if constexpr (AViewType::rank() == 1) {
+      return Impl::TeamCopyInternal::invoke(member, A.extent(0), A.data(), A.stride(0), B.data(), B.stride(0));
+    } else {
+      if (A.extent(0) == 1) {
+        return Impl::TeamCopyInternal::invoke(member, A.extent(1), A.data(), A.stride(0), B.data(), B.stride(0));
+      }
+      return Impl::TeamCopyInternal::invoke(member, A.extent(0), A.extent(1), A.data(), A.stride(0), A.stride(1),
+                                            B.data(), B.stride(0), B.stride(1));
+    }
   }
 };
 
 template <typename MemberType>
-struct TeamCopy<MemberType, Trans::Transpose, 1> {
+struct TeamCopy<MemberType, Trans::Transpose> {
   template <typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
-    return TeamCopyInternal::invoke(member, A.extent(0), A.data(), A.stride(0), B.data(), B.stride(0));
-  }
-};
+    auto info = Impl::checkCopyInput<Trans::Transpose>(A, B);
+    if (info) return info;
 
-template <typename MemberType>
-struct TeamCopy<MemberType, Trans::NoTranspose, 2> {
-  template <typename AViewType, typename BViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
-    static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::copy: AViewType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::copy: BViewType is not a Kokkos::View.");
-    static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
-    static_assert(BViewType::rank == 2, "KokkosBatched::copy: BViewType must have rank 2.");
-
-#ifndef NDEBUG
-    // Check compatibility of dimensions at run time.
-    if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
-      Kokkos::printf(
-          "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
-          "%d, "
-          "B: %d x %d\n",
-          (int)A.extent(0), (int)A.extent(1), (int)B.extent(0), (int)B.extent(1));
-      return 1;
+    if constexpr (AViewType::rank() == 1) {
+      return Impl::TeamCopyInternal::invoke(member, A.extent(0), A.data(), A.stride(0), B.data(), B.stride(0));
+    } else {
+      if (A.extent(1) == 1) {
+        return Impl::TeamCopyInternal::invoke(member, A.extent(0), A.data(), A.stride(0), B.data(), B.stride(0));
+      }
+      return Impl::TeamCopyInternal::invoke(member, A.extent(0), A.extent(1), A.data(), A.stride(0), A.stride(1),
+                                            B.data(), B.stride(0), B.stride(1));
     }
-#endif
-    if (A.extent(0) == 1) {
-      return TeamCopy<MemberType, Trans::NoTranspose, 1>::invoke(member, Kokkos::subview(A, 0, Kokkos::ALL),
-                                                                 Kokkos::subview(B, 0, Kokkos::ALL));
-    }
-    return TeamCopyInternal::invoke(member, A.extent(0), A.extent(1), A.data(), A.stride(0), A.stride(1), B.data(),
-                                    B.stride(0), B.stride(1));
-  }
-};
-
-template <typename MemberType>
-struct TeamCopy<MemberType, Trans::Transpose, 2> {
-  template <typename AViewType, typename BViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
-    static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::copy: AViewType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::copy: BViewType is not a Kokkos::View.");
-    static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
-    static_assert(BViewType::rank == 2, "KokkosBatched::copy: BViewType must have rank 2.");
-
-#ifndef NDEBUG
-    // Check compatibility of dimensions at run time.
-    if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
-      Kokkos::printf(
-          "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
-          "%d, "
-          "B: %d x %d\n",
-          (int)A.extent(0), (int)A.extent(1), (int)B.extent(0), (int)B.extent(1));
-      return 1;
-    }
-#endif
-    if (A.extent(1) == 1) {
-      return TeamCopy<MemberType, Trans::Transpose, 1>::invoke(member, Kokkos::subview(A, Kokkos::ALL, 0),
-                                                               Kokkos::subview(B, Kokkos::ALL, 0));
-    }
-    return TeamCopyInternal::invoke(member, A.extent(1), A.extent(0), A.data(), A.stride(1), A.stride(0), B.data(),
-                                    B.stride(0), B.stride(1));
   }
 };
 
@@ -153,76 +145,40 @@ struct TeamCopy<MemberType, Trans::Transpose, 2> {
 /// =========
 
 template <typename MemberType>
-struct TeamVectorCopy<MemberType, Trans::NoTranspose, 1> {
+struct TeamVectorCopy<MemberType, Trans::NoTranspose> {
   template <typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
-    return TeamVectorCopyInternal::invoke(member, A.extent(0), A.data(), A.stride(0), B.data(), B.stride(0));
+    auto info = Impl::checkCopyInput<Trans::NoTranspose>(A, B);
+    if (info) return info;
+
+    if constexpr (AViewType::rank() == 1) {
+      return Impl::TeamVectorCopyInternal::invoke(member, A.extent(0), A.data(), A.stride(0), B.data(), B.stride(0));
+    } else {
+      if (A.extent(0) == 1) {
+        return Impl::TeamVectorCopyInternal::invoke(member, A.extent(1), A.data(), A.stride(0), B.data(), B.stride(0));
+      }
+      return Impl::TeamVectorCopyInternal::invoke(member, A.extent(0), A.extent(1), A.data(), A.stride(0), A.stride(1),
+                                                  B.data(), B.stride(0), B.stride(1));
+    }
   }
 };
 
 template <typename MemberType>
-struct TeamVectorCopy<MemberType, Trans::Transpose, 1> {
+struct TeamVectorCopy<MemberType, Trans::Transpose> {
   template <typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
-    return TeamVectorCopyInternal::invoke(member, A.extent(0), A.data(), A.stride(0), B.data(), B.stride(0));
-  }
-};
+    auto info = Impl::checkCopyInput<Trans::NoTranspose>(A, B);
+    if (info) return info;
 
-template <typename MemberType>
-struct TeamVectorCopy<MemberType, Trans::NoTranspose, 2> {
-  template <typename AViewType, typename BViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
-    static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::copy: AViewType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::copy: BViewType is not a Kokkos::View.");
-    static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
-    static_assert(BViewType::rank == 2, "KokkosBatched::copy: BViewType must have rank 2.");
-
-#ifndef NDEBUG
-    // Check compatibility of dimensions at run time.
-    if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
-      Kokkos::printf(
-          "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
-          "%d, "
-          "B: %d x %d\n",
-          (int)A.extent(0), (int)A.extent(1), (int)B.extent(0), (int)B.extent(1));
-      return 1;
+    if constexpr (AViewType::rank() == 1) {
+      return Impl::TeamVectorCopyInternal::invoke(member, A.extent(0), A.data(), A.stride(0), B.data(), B.stride(0));
+    } else {
+      if (A.extent(1) == 1) {
+        return Impl::TeamVectorCopyInternal::invoke(member, A.extent(0), A.data(), A.stride(0), B.data(), B.stride(0));
+      }
+      return Impl::TeamVectorCopyInternal::invoke(member, A.extent(0), A.extent(1), A.data(), A.stride(0), A.stride(1),
+                                                  B.data(), B.stride(0), B.stride(1));
     }
-#endif
-    if (A.extent(0) == 1) {
-      return TeamVectorCopy<MemberType, Trans::NoTranspose, 1>::invoke(member, Kokkos::subview(A, 0, Kokkos::ALL),
-                                                                       Kokkos::subview(B, 0, Kokkos::ALL));
-    }
-    return TeamVectorCopyInternal::invoke(member, A.extent(0), A.extent(1), A.data(), A.stride(0), A.stride(1),
-                                          B.data(), B.stride(0), B.stride(1));
-  }
-};
-
-template <typename MemberType>
-struct TeamVectorCopy<MemberType, Trans::Transpose, 2> {
-  template <typename AViewType, typename BViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
-    static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::copy: AViewType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::copy: BViewType is not a Kokkos::View.");
-    static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
-    static_assert(BViewType::rank == 2, "KokkosBatched::copy: BViewType must have rank 2.");
-
-#ifndef NDEBUG
-    // Check compatibility of dimensions at run time.
-    if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
-      Kokkos::printf(
-          "KokkosBatched::copy: Dimensions of A and B do not match: A: %d x "
-          "%d, "
-          "B: %d x %d\n",
-          (int)A.extent(0), (int)A.extent(1), (int)B.extent(0), (int)B.extent(1));
-      return 1;
-    }
-#endif
-    if (A.extent(1) == 1) {
-      return TeamVectorCopy<MemberType, Trans::NoTranspose, 1>::invoke(member, Kokkos::subview(A, Kokkos::ALL, 0),
-                                                                       Kokkos::subview(B, Kokkos::ALL, 0));
-    }
-    return TeamVectorCopyInternal::invoke(member, A.extent(1), A.extent(0), A.data(), A.stride(1), A.stride(0),
-                                          B.data(), B.stride(0), B.stride(1));
   }
 };
 

--- a/batched/dense/impl/KokkosBatched_Copy_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Copy_Impl.hpp
@@ -60,6 +60,9 @@ KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::NoTranspose>::invoke(const AViewTyp
   auto info = Impl::checkCopyInput<Trans::NoTranspose>(A, B);
   if (info) return info;
 
+  // Quick return if possible
+  if (A.size() == 0 || B.size() == 0) return 0;
+
   if constexpr (AViewType::rank() == 1) {
     return Impl::SerialCopyInternal::invoke(KokkosBlas::Impl::OpID(), A.extent(0), A.data(), A.stride(0), B.data(),
                                             B.stride(0));
@@ -75,6 +78,9 @@ KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::Transpose>::invoke(const AViewType 
   auto info = Impl::checkCopyInput<Trans::Transpose>(A, B);
   if (info) return info;
 
+  // Quick return if possible
+  if (A.size() == 0 || B.size() == 0) return 0;
+
   if constexpr (AViewType::rank() == 1) {
     return Impl::SerialCopyInternal::invoke(KokkosBlas::Impl::OpID(), A.extent(0), A.data(), A.stride(0), B.data(),
                                             B.stride(0));
@@ -89,6 +95,9 @@ template <typename AViewType, typename BViewType>
 KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::ConjTranspose>::invoke(const AViewType &A, const BViewType &B) {
   auto info = Impl::checkCopyInput<Trans::ConjTranspose>(A, B);
   if (info) return info;
+
+  // Quick return if possible
+  if (A.size() == 0 || B.size() == 0) return 0;
 
   if constexpr (AViewType::rank() == 1) {
     return Impl::SerialCopyInternal::invoke(KokkosBlas::Impl::OpConj(), A.extent(0), A.data(), A.stride(0), B.data(),
@@ -109,6 +118,9 @@ struct TeamCopy<MemberType, Trans::NoTranspose> {
     auto info = Impl::checkCopyInput<Trans::NoTranspose>(A, B);
     if (info) return info;
 
+    // Quick return if possible
+    if (A.size() == 0 || B.size() == 0) return 0;
+
     if constexpr (AViewType::rank() == 1) {
       return Impl::TeamCopyInternal::invoke(member, A.extent(0), A.data(), A.stride(0), B.data(), B.stride(0));
     } else {
@@ -127,6 +139,9 @@ struct TeamCopy<MemberType, Trans::Transpose> {
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
     auto info = Impl::checkCopyInput<Trans::Transpose>(A, B);
     if (info) return info;
+
+    // Quick return if possible
+    if (A.size() == 0 || B.size() == 0) return 0;
 
     if constexpr (AViewType::rank() == 1) {
       return Impl::TeamCopyInternal::invoke(member, A.extent(0), A.data(), A.stride(0), B.data(), B.stride(0));
@@ -151,6 +166,9 @@ struct TeamVectorCopy<MemberType, Trans::NoTranspose> {
     auto info = Impl::checkCopyInput<Trans::NoTranspose>(A, B);
     if (info) return info;
 
+    // Quick return if possible
+    if (A.size() == 0 || B.size() == 0) return 0;
+
     if constexpr (AViewType::rank() == 1) {
       return Impl::TeamVectorCopyInternal::invoke(member, A.extent(0), A.data(), A.stride(0), B.data(), B.stride(0));
     } else {
@@ -169,6 +187,9 @@ struct TeamVectorCopy<MemberType, Trans::Transpose> {
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
     auto info = Impl::checkCopyInput<Trans::NoTranspose>(A, B);
     if (info) return info;
+
+    // Quick return if possible
+    if (A.size() == 0 || B.size() == 0) return 0;
 
     if constexpr (AViewType::rank() == 1) {
       return Impl::TeamVectorCopyInternal::invoke(member, A.extent(0), A.data(), A.stride(0), B.data(), B.stride(0));

--- a/batched/dense/impl/KokkosBatched_Copy_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Copy_Internal.hpp
@@ -4,34 +4,36 @@
 #define KOKKOSBATCHED_COPY_INTERNAL_HPP
 
 /// \author Kyungjoo Kim (kyukim@sandia.gov)
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
 
+#include "KokkosBlas_util.hpp"
 #include "KokkosBatched_Util.hpp"
 
 namespace KokkosBatched {
-
+namespace Impl {
 ///
 /// Serial Internal Impl
 /// ====================
 
 struct SerialCopyInternal {
-  template <typename ValueType>
-  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const int m, const ValueType *KOKKOS_RESTRICT A, const int as0,
+  template <typename Op, typename ValueType>
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(Op op, const int m, const ValueType *KOKKOS_RESTRICT A, const int as0,
                                                 /* */ ValueType *KOKKOS_RESTRICT B, const int bs0) {
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
 #endif
-    for (int i = 0; i < m; ++i) B[i * bs0] = A[i * as0];
+    for (int i = 0; i < m; ++i) B[i * bs0] = op(A[i * as0]);
 
     return 0;
   }
-  template <typename ValueType>
-  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const int m, const int n, const ValueType *KOKKOS_RESTRICT A,
+  template <typename Op, typename ValueType>
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(Op op, const int m, const int n, const ValueType *KOKKOS_RESTRICT A,
                                                 const int as0, const int as1,
                                                 /* */ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
     if (as1 < as0)
-      for (int i = 0; i < m; ++i) invoke(n, A + i * as0, as1, B + i * bs0, bs1);
+      for (int i = 0; i < m; ++i) invoke(op, n, A + i * as0, as1, B + i * bs0, bs1);
     else
-      for (int j = 0; j < n; ++j) invoke(m, A + j * as1, as0, B + j * bs1, bs0);
+      for (int j = 0; j < n; ++j) invoke(op, m, A + j * as1, as0, B + j * bs1, bs0);
     return 0;
   }
 };
@@ -53,11 +55,13 @@ struct TeamCopyInternal {
                                                 const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
                                                 /* */ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
     if (m >= n) {
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, m),
-                           [&](const int &i) { SerialCopyInternal::invoke(n, A + i * as0, as1, B + i * bs0, bs1); });
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, m), [&](const int &i) {
+        SerialCopyInternal::invoke(KokkosBlas::Impl::OpID(), n, A + i * as0, as1, B + i * bs0, bs1);
+      });
     } else {
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n),
-                           [&](const int &j) { SerialCopyInternal::invoke(m, A + j * as1, as0, B + j * bs1, bs0); });
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int &j) {
+        SerialCopyInternal::invoke(KokkosBlas::Impl::OpID(), m, A + j * as1, as0, B + j * bs1, bs0);
+      });
     }
     // member.team_barrier();
     return 0;
@@ -93,6 +97,52 @@ struct TeamVectorCopyInternal {
     }
     // member.team_barrier();
     return 0;
+  }
+};
+
+}  // end namespace Impl
+
+struct [[deprecated("Use KokkosBatched::SerialCopy instead")]] SerialCopyInternal {
+  template <typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const int m, const ValueType *KOKKOS_RESTRICT A, const int as0,
+                                           /* */ ValueType *KOKKOS_RESTRICT B, const int bs0) {
+    return Impl::SerialCopyInternal::invoke(KokkosBlas::Impl::OpID(), m, A, as0, B, bs0);
+  }
+  template <typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const int m, const int n, const ValueType *KOKKOS_RESTRICT A, const int as0,
+                                           const int as1,
+                                           /* */ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
+    return Impl::SerialCopyInternal::invoke(KokkosBlas::Impl::OpID(), m, n, A, as0, as1, B, bs0, bs1);
+  }
+};
+
+struct [[deprecated("Use KokkosBatched::TeamCopy instead")]] TeamCopyInternal {
+  template <typename MemberType, typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const int m, const ValueType *KOKKOS_RESTRICT A,
+                                           const int as0,
+                                           /* */ ValueType *KOKKOS_RESTRICT B, const int bs0) {
+    return Impl::TeamCopyInternal::invoke(member, m, A, as0, B, bs0);
+  }
+  template <typename MemberType, typename ValueType>
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member, const int m, const int n,
+                                                const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+                                                /* */ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
+    return Impl::TeamCopyInternal::invoke(member, m, n, A, as0, as1, B, bs0, bs1);
+  }
+};
+
+struct [[deprecated("Use KokkosBatched::TeamVectorCopy instead")]] TeamVectorCopyInternal {
+  template <typename MemberType, typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const int m, const ValueType *KOKKOS_RESTRICT A,
+                                           const int as0,
+                                           /* */ ValueType *KOKKOS_RESTRICT B, const int bs0) {
+    return Impl::TeamVectorCopyInternal::invoke(member, m, A, as0, B, bs0);
+  }
+  template <typename MemberType, typename ValueType>
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member, const int m, const int n,
+                                                const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+                                                /* */ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
+    return Impl::TeamVectorCopyInternal::invoke(member, m, n, A, as0, as1, B, bs0, bs1);
   }
 };
 

--- a/batched/dense/impl/KokkosBatched_Gesv_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gesv_Impl.hpp
@@ -416,7 +416,7 @@ struct SerialGesv<Gesv::NoPivoting> {
 
     int r_val = SerialLU<Algo::Level3::Unblocked>::invoke(A);
 
-    if (r_val == 0) r_val = SerialCopy<Trans::NoTranspose, 1>::invoke(Y, X);
+    if (r_val == 0) r_val = SerialCopy<Trans::NoTranspose>::invoke(Y, X);
 
     if (r_val == 0)
       r_val = SerialTrsm<Side::Left, Uplo::Lower, Trans::NoTranspose, Diag::Unit, Algo::Level3::Unblocked>::invoke(
@@ -523,7 +523,7 @@ struct TeamGesv<MemberType, Gesv::NoPivoting> {
     member.team_barrier();
 
     if (r_val == 0) {
-      TeamCopy<MemberType, Trans::NoTranspose, 1>::invoke(member, Y, X);
+      TeamCopy<MemberType, Trans::NoTranspose>::invoke(member, Y, X);
       member.team_barrier();
     }
 
@@ -637,7 +637,7 @@ struct TeamVectorGesv<MemberType, Gesv::NoPivoting> {
     member.team_barrier();
 
     if (r_val == 0) {
-      TeamVectorCopy<MemberType, Trans::NoTranspose, 1>::invoke(member, Y, X);
+      TeamVectorCopy<MemberType, Trans::NoTranspose>::invoke(member, Y, X);
       member.team_barrier();
     }
 

--- a/batched/dense/src/KokkosBatched_Copy_Decl.hpp
+++ b/batched/dense/src/KokkosBatched_Copy_Decl.hpp
@@ -10,6 +10,14 @@
 
 namespace KokkosBatched {
 
+template <bool>
+struct SerialCopy_Deprecated_Warning {};
+
+template <>
+struct [[deprecated(
+    "KokkosBatched::SerialCopy<ArgTrans, rank> is deprecated. Please use "
+    "KokkosBatched::SerialCopy<ArgTrans> instead.")]] SerialCopy_Deprecated_Warning<true> {};
+
 /// \brief Serial Batched Copy:
 /// Performs B = Op(A)
 /// where Op is one of NoTranspose, Transpose, ConjTranspose
@@ -18,11 +26,7 @@ namespace KokkosBatched {
 /// \tparam ArgTrans: one of NoTranspose, Transpose, ConjTranspose
 /// \tparam Args: (deprecated) rank information
 template <typename ArgTrans = Trans::NoTranspose, class... Args>
-struct SerialCopy {
-  static constexpr size_t size = sizeof...(Args);
-  static_assert(size == 0,
-                "KokkosBatched::SerialCopy<ArgTrans, rank> is deprecated. Please use "
-                "KokkosBatched::SerialCopy<ArgTrans> instead.");
+struct SerialCopy : SerialCopy_Deprecated_Warning<sizeof...(Args) != 0> {
   static_assert(KokkosBlas::is_trans_v<ArgTrans>, "KokkosBatched::SerialCopy: ArgTrans must be a KokkosBlas::Trans.");
 
   /// \brief invoke the SerialCopy
@@ -34,6 +38,14 @@ struct SerialCopy {
   KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const BViewType &B);
 };
 
+template <bool>
+struct TeamCopy_Deprecated_Warning {};
+
+template <>
+struct [[deprecated(
+    "KokkosBatched::TeamCopy<ArgTrans, rank> is deprecated. Please use "
+    "KokkosBatched::TeamCopy<ArgTrans> instead.")]] TeamCopy_Deprecated_Warning<true> {};
+
 /// \brief Team Batched Copy:
 /// Performs B = Op(A)
 /// where Op is one of NoTranspose, Transpose, ConjTranspose
@@ -43,11 +55,7 @@ struct SerialCopy {
 /// \tparam ArgTrans: one of NoTranspose, Transpose, ConjTranspose
 /// \tparam Args: (deprecated) rank information
 template <typename MemberType, typename ArgTrans = Trans::NoTranspose, class... Args>
-struct TeamCopy {
-  static constexpr size_t size = sizeof...(Args);
-  static_assert(size == 0,
-                "KokkosBatched::TeamCopy<MemberType, ArgTrans, rank> is deprecated. Please use "
-                "KokkosBatched::TeamCopy<MemberType, ArgTrans> instead.");
+struct TeamCopy : TeamCopy_Deprecated_Warning<sizeof...(Args) != 0> {
   static_assert(KokkosBlas::is_trans_v<ArgTrans>, "KokkosBatched::TeamCopy: ArgTrans must be a KokkosBlas::Trans.");
 
   /// \brief invoke the TeamCopy
@@ -60,6 +68,14 @@ struct TeamCopy {
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B);
 };
 
+template <bool>
+struct TeamVectorCopy_Deprecated_Warning {};
+
+template <>
+struct [[deprecated(
+    "KokkosBatched::TeamVectorCopy<ArgTrans, rank> is deprecated. Please use "
+    "KokkosBatched::TeamVectorCopy<ArgTrans> instead.")]] TeamVectorCopy_Deprecated_Warning<true> {};
+
 /// \brief TeamVector Batched Copy:
 /// Performs B = Op(A)
 /// where Op is one of NoTranspose, Transpose, ConjTranspose
@@ -69,11 +85,7 @@ struct TeamCopy {
 /// \tparam ArgTrans: one of NoTranspose, Transpose, ConjTranspose
 /// \tparam Args: (deprecated) rank information
 template <typename MemberType, typename ArgTrans = Trans::NoTranspose, class... Args>
-struct TeamVectorCopy {
-  static constexpr size_t size = sizeof...(Args);
-  static_assert(size == 0,
-                "KokkosBatched::TeamVectorCopy<MemberType, ArgTrans, rank> is deprecated. Please use "
-                "KokkosBatched::TeamVectorCopy<MemberType, ArgTrans> instead.");
+struct TeamVectorCopy : TeamVectorCopy_Deprecated_Warning<sizeof...(Args) != 0> {
   static_assert(KokkosBlas::is_trans_v<ArgTrans>,
                 "KokkosBatched::TeamVectorCopy: ArgTrans must be a KokkosBlas::Trans.");
 
@@ -87,6 +99,14 @@ struct TeamVectorCopy {
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B);
 };
 
+template <bool>
+struct Copy_Deprecated_Warning {};
+
+template <>
+struct [[deprecated(
+    "KokkosBatched::Copy<MemberType, ArgTrans, rank> is deprecated. Please use "
+    "KokkosBatched::Copy<MemberType, ArgTrans> instead.")]] Copy_Deprecated_Warning<true> {};
+
 /// \brief General Copy:
 /// Performs B = Op(A)
 /// where Op is one of NoTranspose, Transpose, ConjTranspose
@@ -97,11 +117,8 @@ struct TeamVectorCopy {
 /// \tparam ArgMode: one of Mode::Serial, Mode::Team, Mode::TeamVector
 /// \tparam Args: (deprecated) rank information
 template <typename MemberType, typename ArgTrans, typename ArgMode, class... Args>
-struct Copy {
-  static constexpr size_t size = sizeof...(Args);
-  static_assert(size == 0,
-                "KokkosBatched::Copy<MemberType, ArgTrans, ArgMode, rank> is deprecated. Please use "
-                "KokkosBatched::Copy<MemberType, ArgTrans, ArgMode> instead.");
+struct Copy : Copy_Deprecated_Warning<sizeof...(Args) != 0> {
+  static_assert(KokkosBlas::is_trans_v<ArgTrans>, "KokkosBatched::Copy: ArgTrans must be a KokkosBlas::Trans.");
 
   /// \brief invoke the Copy
   /// \tparam AViewType: Kokkos::View type for A

--- a/batched/dense/src/KokkosBatched_Copy_Decl.hpp
+++ b/batched/dense/src/KokkosBatched_Copy_Decl.hpp
@@ -25,7 +25,7 @@ struct [[deprecated(
 ///
 /// \tparam ArgTrans: one of NoTranspose, Transpose, ConjTranspose
 /// \tparam Args: (deprecated) rank information
-template <typename ArgTrans = Trans::NoTranspose, class... Args>
+template <typename ArgTrans = Trans::NoTranspose, int... Args>
 struct SerialCopy : SerialCopy_Deprecated_Warning<sizeof...(Args) != 0> {
   static_assert(KokkosBlas::is_trans_v<ArgTrans>, "KokkosBatched::SerialCopy: ArgTrans must be a KokkosBlas::Trans.");
 
@@ -54,7 +54,7 @@ struct [[deprecated(
 /// \tparam MemberType: Kokkos::TeamPolicy member type
 /// \tparam ArgTrans: one of NoTranspose, Transpose, ConjTranspose
 /// \tparam Args: (deprecated) rank information
-template <typename MemberType, typename ArgTrans = Trans::NoTranspose, class... Args>
+template <typename MemberType, typename ArgTrans = Trans::NoTranspose, int... Args>
 struct TeamCopy : TeamCopy_Deprecated_Warning<sizeof...(Args) != 0> {
   static_assert(KokkosBlas::is_trans_v<ArgTrans>, "KokkosBatched::TeamCopy: ArgTrans must be a KokkosBlas::Trans.");
 
@@ -84,7 +84,7 @@ struct [[deprecated(
 /// \tparam MemberType: Kokkos::TeamPolicy member type
 /// \tparam ArgTrans: one of NoTranspose, Transpose, ConjTranspose
 /// \tparam Args: (deprecated) rank information
-template <typename MemberType, typename ArgTrans = Trans::NoTranspose, class... Args>
+template <typename MemberType, typename ArgTrans = Trans::NoTranspose, int... Args>
 struct TeamVectorCopy : TeamVectorCopy_Deprecated_Warning<sizeof...(Args) != 0> {
   static_assert(KokkosBlas::is_trans_v<ArgTrans>,
                 "KokkosBatched::TeamVectorCopy: ArgTrans must be a KokkosBlas::Trans.");
@@ -116,7 +116,7 @@ struct [[deprecated(
 /// \tparam ArgTrans: one of NoTranspose, Transpose, ConjTranspose
 /// \tparam ArgMode: one of Mode::Serial, Mode::Team, Mode::TeamVector
 /// \tparam Args: (deprecated) rank information
-template <typename MemberType, typename ArgTrans, typename ArgMode, class... Args>
+template <typename MemberType, typename ArgTrans, typename ArgMode, int... Args>
 struct Copy : Copy_Deprecated_Warning<sizeof...(Args) != 0> {
   static_assert(KokkosBlas::is_trans_v<ArgTrans>, "KokkosBatched::Copy: ArgTrans must be a KokkosBlas::Trans.");
 

--- a/batched/dense/src/KokkosBatched_Copy_Decl.hpp
+++ b/batched/dense/src/KokkosBatched_Copy_Decl.hpp
@@ -4,55 +4,120 @@
 #define KOKKOSBATCHED_COPY_DECL_HPP
 
 /// \author Kyungjoo Kim (kyukim@sandia.gov)
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
 
 #include "KokkosBatched_Util.hpp"
 
 namespace KokkosBatched {
 
+/// \brief Serial Batched Copy:
+/// Performs B = Op(A)
+/// where Op is one of NoTranspose, Transpose, ConjTranspose
+/// A and B are 1D or 2D views
 ///
-/// Serial Copy
-///
-
-template <typename ArgTrans = Trans::NoTranspose, int rank = 2>
+/// \tparam ArgTrans: one of NoTranspose, Transpose, ConjTranspose
+/// \tparam Args: (deprecated) rank information
+template <typename ArgTrans = Trans::NoTranspose, class... Args>
 struct SerialCopy {
+  static constexpr size_t size = sizeof...(Args);
+  static_assert(size == 0,
+                "KokkosBatched::SerialCopy<ArgTrans, rank> is deprecated. Please use "
+                "KokkosBatched::SerialCopy<ArgTrans> instead.");
+  static_assert(KokkosBlas::is_trans_v<ArgTrans>, "KokkosBatched::SerialCopy: ArgTrans must be a KokkosBlas::Trans.");
+
+  /// \brief invoke the SerialCopy
+  /// \tparam AViewType: Kokkos::View type for A
+  /// \tparam BViewType: Kokkos::View type for B
+  /// \param[in] A Input view A
+  /// \param[out] B Output view B
   template <typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const BViewType &B);
 };
 
+/// \brief Team Batched Copy:
+/// Performs B = Op(A)
+/// where Op is one of NoTranspose, Transpose, ConjTranspose
+/// A and B are 1D or 2D views
 ///
-/// Team Copy
-///
-
-template <typename MemberType, typename ArgTrans = Trans::NoTranspose, int rank = 2>
+/// \tparam MemberType: Kokkos::TeamPolicy member type
+/// \tparam ArgTrans: one of NoTranspose, Transpose, ConjTranspose
+/// \tparam Args: (deprecated) rank information
+template <typename MemberType, typename ArgTrans = Trans::NoTranspose, class... Args>
 struct TeamCopy {
+  static constexpr size_t size = sizeof...(Args);
+  static_assert(size == 0,
+                "KokkosBatched::TeamCopy<MemberType, ArgTrans, rank> is deprecated. Please use "
+                "KokkosBatched::TeamCopy<MemberType, ArgTrans> instead.");
+  static_assert(KokkosBlas::is_trans_v<ArgTrans>, "KokkosBatched::TeamCopy: ArgTrans must be a KokkosBlas::Trans.");
+
+  /// \brief invoke the TeamCopy
+  /// \tparam AViewType: Kokkos::View type for A
+  /// \tparam BViewType: Kokkos::View type for B
+  /// \param[in] member Kokkos::TeamPolicy member
+  /// \param[in] A Input view A
+  /// \param[out] B Output view B
   template <typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B);
 };
 
+/// \brief TeamVector Batched Copy:
+/// Performs B = Op(A)
+/// where Op is one of NoTranspose, Transpose, ConjTranspose
+/// A and B are 1D or 2D views
 ///
-/// TeamVector Copy
-///
-
-template <typename MemberType, typename ArgTrans = Trans::NoTranspose, int rank = 2>
+/// \tparam MemberType: Kokkos::TeamPolicy member type
+/// \tparam ArgTrans: one of NoTranspose, Transpose, ConjTranspose
+/// \tparam Args: (deprecated) rank information
+template <typename MemberType, typename ArgTrans = Trans::NoTranspose, class... Args>
 struct TeamVectorCopy {
+  static constexpr size_t size = sizeof...(Args);
+  static_assert(size == 0,
+                "KokkosBatched::TeamVectorCopy<MemberType, ArgTrans, rank> is deprecated. Please use "
+                "KokkosBatched::TeamVectorCopy<MemberType, ArgTrans> instead.");
+  static_assert(KokkosBlas::is_trans_v<ArgTrans>,
+                "KokkosBatched::TeamVectorCopy: ArgTrans must be a KokkosBlas::Trans.");
+
+  /// \brief invoke the TeamVectorCopy
+  /// \tparam AViewType: Kokkos::View type for A
+  /// \tparam BViewType: Kokkos::View type for B
+  /// \param[in] member Kokkos::TeamPolicy member
+  /// \param[in] A Input view A
+  /// \param[out] B Output view B
   template <typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B);
 };
 
-///
-/// Selective Interface
-///
-template <typename MemberType, typename ArgTrans, typename ArgMode, int rank = 2>
+/// \brief General Copy:
+/// Performs B = Op(A)
+/// where Op is one of NoTranspose, Transpose, ConjTranspose
+/// A and B are 1D or 2D views
+/// Dispatches to SerialCopy, TeamCopy, or TeamVectorCopy based on ArgMode
+/// \tparam MemberType: Kokkos::TeamPolicy member type
+/// \tparam ArgTrans: one of NoTranspose, Transpose, ConjTranspose
+/// \tparam ArgMode: one of Mode::Serial, Mode::Team, Mode::TeamVector
+/// \tparam Args: (deprecated) rank information
+template <typename MemberType, typename ArgTrans, typename ArgMode, class... Args>
 struct Copy {
+  static constexpr size_t size = sizeof...(Args);
+  static_assert(size == 0,
+                "KokkosBatched::Copy<MemberType, ArgTrans, ArgMode, rank> is deprecated. Please use "
+                "KokkosBatched::Copy<MemberType, ArgTrans, ArgMode> instead.");
+
+  /// \brief invoke the Copy
+  /// \tparam AViewType: Kokkos::View type for A
+  /// \tparam BViewType: Kokkos::View type for B
+  /// \param[in] member Kokkos::TeamPolicy member
+  /// \param[in] A Input view A
+  /// \param[out] B Output view B
   template <typename AViewType, typename BViewType>
   KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
     int r_val = 0;
-    if (std::is_same<ArgMode, Mode::Serial>::value) {
-      r_val = SerialCopy<ArgTrans, rank>::invoke(A, B);
-    } else if (std::is_same<ArgMode, Mode::Team>::value) {
-      r_val = TeamCopy<MemberType, ArgTrans, rank>::invoke(member, A, B);
-    } else if (std::is_same<ArgMode, Mode::TeamVector>::value) {
-      r_val = TeamVectorCopy<MemberType, ArgTrans, rank>::invoke(member, A, B);
+    if constexpr (std::is_same_v<ArgMode, Mode::Serial>) {
+      r_val = SerialCopy<ArgTrans>::invoke(A, B);
+    } else if constexpr (std::is_same_v<ArgMode, Mode::Team>) {
+      r_val = TeamCopy<MemberType, ArgTrans>::invoke(member, A, B);
+    } else if constexpr (std::is_same_v<ArgMode, Mode::TeamVector>) {
+      r_val = TeamVectorCopy<MemberType, ArgTrans>::invoke(member, A, B);
     }
     return r_val;
   }
@@ -75,9 +140,9 @@ struct Copy {
   KokkosBatched::TeamCopyInternal ::invoke(MEMBER, M, A, AS, B, BS)
 
 #define KOKKOSBATCHED_COPY_VECTOR_NO_TRANSPOSE_INTERNAL_INVOKE(MODETYPE, MEMBER, M, A, AS, B, BS) \
-  if (std::is_same<MODETYPE, KokkosBatched::Mode::Serial>::value) {                               \
+  if constexpr (std::is_same_v<MODETYPE, KokkosBatched::Mode::Serial>) {                          \
     KOKKOSBATCHED_SERIAL_COPY_VECTOR_INTERNAL_INVOKE(M, A, AS, B, BS);                            \
-  } else if (std::is_same<MODETYPE, KokkosBatched::Mode::Team>::value) {                          \
+  } else if constexpr (std::is_same_v<MODETYPE, KokkosBatched::Mode::Team>) {                     \
     KOKKOSBATCHED_TEAM_COPY_VECTOR_NO_TRANSPOSE_INTERNAL_INVOKE(MEMBER, M, A, AS, B, BS);         \
   }
 

--- a/batched/dense/unit_test/Test_Batched_Dense.hpp
+++ b/batched/dense/unit_test/Test_Batched_Dense.hpp
@@ -5,6 +5,7 @@
 
 // Serial kernels
 #include "Test_Batched_SerialAxpy.hpp"
+#include "Test_Batched_SerialCopy.hpp"
 #include "Test_Batched_SerialEigendecomposition.hpp"
 #include "Test_Batched_SerialEigendecomposition_Real.hpp"
 #include "Test_Batched_SerialGesv.hpp"

--- a/batched/dense/unit_test/Test_Batched_SerialCopy.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialCopy.hpp
@@ -88,10 +88,6 @@ void impl_test_batched_copy_analytical(const std::size_t N) {
   StridedView3DType A1_s("A1_s", layout1), B1_s("B1_s", layout2);
 
   // Initialize A0 and A1
-  using Op = std::conditional_t<std::is_same_v<ArgTrans, KokkosBatched::Trans::ConjTranspose>, KokkosBlas::Impl::OpConj,
-                                KokkosBlas::Impl::OpID>;
-  Op op;
-
   auto h_A0     = Kokkos::create_mirror_view(A0);
   auto h_A1     = Kokkos::create_mirror_view(A1);
   auto h_Ref_B1 = Kokkos::create_mirror_view(Ref_B1);
@@ -111,14 +107,13 @@ void impl_test_batched_copy_analytical(const std::size_t N) {
     for (std::size_t i = 0; i < h_Ref_B1.extent(1); i++) {
       for (std::size_t j = 0; j < h_Ref_B1.extent(2); j++) {
         h_Ref_B1(ib, i, j) =
-            std::is_same_v<ArgTrans, KokkosBatched::Trans::NoTranspose> ? h_A1(ib, i, j) : op(h_A1(ib, j, i));
+            std::is_same_v<ArgTrans, KokkosBatched::Trans::NoTranspose> ? h_A1(ib, i, j) : h_A1(ib, j, i);
       }
     }
   }
   Kokkos::deep_copy(A0, h_A0);
   Kokkos::deep_copy(A1, h_A1);
   Kokkos::deep_copy(Ref_B0, A0);
-  Kokkos::deep_copy(Ref_B1, h_Ref_B1);
 
   // Strided views can be copied only on the same device
   Kokkos::deep_copy(A0_s, A0);
@@ -207,10 +202,15 @@ void impl_test_batched_copy(const std::size_t N, const std::size_t m_A, const st
                                 KokkosBlas::Impl::OpID>;
   Op op;
 
+  auto h_A0     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, A0);
   auto h_A1     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, A1);
+  auto h_Ref_B0 = Kokkos::create_mirror_view(Ref_B0);
   auto h_Ref_B1 = Kokkos::create_mirror_view(Ref_B1);
 
   for (std::size_t ib = 0; ib < N; ib++) {
+    for (std::size_t j = 0; j < h_Ref_B0.extent(1); j++) {
+      h_Ref_B0(ib, j) = op(h_A0(ib, j));
+    }
     for (std::size_t i = 0; i < h_Ref_B1.extent(1); i++) {
       for (std::size_t j = 0; j < h_Ref_B1.extent(2); j++) {
         h_Ref_B1(ib, i, j) =
@@ -218,8 +218,6 @@ void impl_test_batched_copy(const std::size_t N, const std::size_t m_A, const st
       }
     }
   }
-  Kokkos::deep_copy(Ref_B0, A0);
-  Kokkos::deep_copy(Ref_B1, h_Ref_B1);
 
   // Copy operations
   auto info0 = Functor_TestBatchedSerialCopy<DeviceType, View2DType, View2DType, ArgTrans>(A0, B0).run();
@@ -228,10 +226,9 @@ void impl_test_batched_copy(const std::size_t N, const std::size_t m_A, const st
   EXPECT_EQ(info0, 0);
   EXPECT_EQ(info1, 0);
 
-  RealType eps  = 1.0e1 * ats::epsilon();
-  auto h_B0     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, B0);
-  auto h_B1     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, B1);
-  auto h_Ref_B0 = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, Ref_B0);
+  RealType eps = 1.0e1 * ats::epsilon();
+  auto h_B0    = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, B0);
+  auto h_B1    = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, B1);
 
   // Check if B0 and B1 are same as Ref_B0 and Ref_B1
   for (std::size_t ib = 0; ib < h_B0.extent(0); ib++) {

--- a/batched/dense/unit_test/Test_Batched_SerialCopy.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialCopy.hpp
@@ -88,6 +88,10 @@ void impl_test_batched_copy_analytical(const std::size_t N) {
   StridedView3DType A1_s("A1_s", layout1), B1_s("B1_s", layout2);
 
   // Initialize A0 and A1
+  using Op = std::conditional_t<std::is_same_v<ArgTrans, KokkosBatched::Trans::ConjTranspose>, KokkosBlas::Impl::OpConj,
+                                KokkosBlas::Impl::OpID>;
+  Op op;
+
   auto h_A0     = Kokkos::create_mirror_view(A0);
   auto h_A1     = Kokkos::create_mirror_view(A1);
   auto h_Ref_B1 = Kokkos::create_mirror_view(Ref_B1);
@@ -107,7 +111,7 @@ void impl_test_batched_copy_analytical(const std::size_t N) {
     for (std::size_t i = 0; i < h_Ref_B1.extent(1); i++) {
       for (std::size_t j = 0; j < h_Ref_B1.extent(2); j++) {
         h_Ref_B1(ib, i, j) =
-            std::is_same_v<ArgTrans, KokkosBatched::Trans::NoTranspose> ? h_A1(ib, i, j) : h_A1(ib, j, i);
+            std::is_same_v<ArgTrans, KokkosBatched::Trans::NoTranspose> ? h_A1(ib, i, j) : op(h_A1(ib, j, i));
       }
     }
   }
@@ -139,13 +143,13 @@ void impl_test_batched_copy_analytical(const std::size_t N) {
   auto h_Ref_B0 = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, Ref_B0);
 
   // Check if B0 and B1 are same as Ref_B0 and Ref_B1
-  for (std::size_t ib = 0; ib < N; ib++) {
-    for (std::size_t j = 0; j < 3; j++) {
-      // EXPECT_NEAR_KK(ats::abs(h_B0(ib, j) - h_Ref_B0(ib, j)), eps);
+  for (std::size_t ib = 0; ib < h_B0.extent(0); ib++) {
+    for (std::size_t j = 0; j < h_B0.extent(1); j++) {
+      EXPECT_NEAR_KK(h_B0(ib, j), h_Ref_B0(ib, j), eps);
     }
     for (std::size_t i = 0; i < h_B1.extent(1); i++) {
       for (std::size_t j = 0; j < h_B1.extent(2); j++) {
-        // EXPECT_NEAR_KK(ats::abs(h_B1(ib, i, j) - h_Ref_B1(ib, i, j)), eps);
+        EXPECT_NEAR_KK(h_B1(ib, i, j), h_Ref_B1(ib, i, j), eps);
       }
     }
   }
@@ -155,13 +159,13 @@ void impl_test_batched_copy_analytical(const std::size_t N) {
   Kokkos::deep_copy(B1, B1_s);
   Kokkos::deep_copy(h_B0, B0);
   Kokkos::deep_copy(h_B1, B1);
-  for (std::size_t ib = 0; ib < N; ib++) {
-    for (std::size_t j = 0; j < 3; j++) {
-      // EXPECT_NEAR_KK(ats::abs(h_B0(ib, j) - h_Ref_B0(ib, j)), eps);
+  for (std::size_t ib = 0; ib < h_B0.extent(0); ib++) {
+    for (std::size_t j = 0; j < h_B0.extent(1); j++) {
+      EXPECT_NEAR_KK(h_B0(ib, j), h_Ref_B0(ib, j), eps);
     }
     for (std::size_t i = 0; i < h_B1.extent(1); i++) {
       for (std::size_t j = 0; j < h_B1.extent(2); j++) {
-        // EXPECT_NEAR_KK(ats::abs(h_B1(ib, i, j) - h_Ref_B1(ib, i, j)), eps);
+        EXPECT_NEAR_KK(h_B1(ib, i, j), h_Ref_B1(ib, i, j), eps);
       }
     }
   }
@@ -180,12 +184,10 @@ void impl_test_batched_copy_analytical(const std::size_t N) {
 /// \param[in] n_A Number of columns of matrix A
 template <typename DeviceType, typename ScalarType, typename LayoutType, typename ArgTrans>
 void impl_test_batched_copy(const std::size_t N, const std::size_t m_A, const std::size_t n_A) {
-  using ats               = typename KokkosKernels::ArithTraits<ScalarType>;
-  using RealType          = typename ats::mag_type;
-  using View2DType        = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
-  using View3DType        = Kokkos::View<ScalarType ***, LayoutType, DeviceType>;
-  using StridedView2DType = Kokkos::View<ScalarType **, Kokkos::LayoutStride, DeviceType>;
-  using StridedView3DType = Kokkos::View<ScalarType ***, Kokkos::LayoutStride, DeviceType>;
+  using ats        = typename KokkosKernels::ArithTraits<ScalarType>;
+  using RealType   = typename ats::mag_type;
+  using View2DType = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
+  using View3DType = Kokkos::View<ScalarType ***, LayoutType, DeviceType>;
 
   const std::size_t m_B = std::is_same_v<ArgTrans, KokkosBatched::Trans::NoTranspose> ? m_A : n_A;
   const std::size_t n_B = std::is_same_v<ArgTrans, KokkosBatched::Trans::NoTranspose> ? n_A : m_A;
@@ -201,6 +203,10 @@ void impl_test_batched_copy(const std::size_t N, const std::size_t m_A, const st
   Kokkos::fill_random(A0, rand_pool, randStart, randEnd);
   Kokkos::fill_random(A1, rand_pool, randStart, randEnd);
 
+  using Op = std::conditional_t<std::is_same_v<ArgTrans, KokkosBatched::Trans::ConjTranspose>, KokkosBlas::Impl::OpConj,
+                                KokkosBlas::Impl::OpID>;
+  Op op;
+
   auto h_A1     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, A1);
   auto h_Ref_B1 = Kokkos::create_mirror_view(Ref_B1);
 
@@ -208,7 +214,7 @@ void impl_test_batched_copy(const std::size_t N, const std::size_t m_A, const st
     for (std::size_t i = 0; i < h_Ref_B1.extent(1); i++) {
       for (std::size_t j = 0; j < h_Ref_B1.extent(2); j++) {
         h_Ref_B1(ib, i, j) =
-            std::is_same_v<ArgTrans, KokkosBatched::Trans::NoTranspose> ? h_A1(ib, i, j) : h_A1(ib, j, i);
+            std::is_same_v<ArgTrans, KokkosBatched::Trans::NoTranspose> ? h_A1(ib, i, j) : op(h_A1(ib, j, i));
       }
     }
   }
@@ -228,13 +234,13 @@ void impl_test_batched_copy(const std::size_t N, const std::size_t m_A, const st
   auto h_Ref_B0 = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, Ref_B0);
 
   // Check if B0 and B1 are same as Ref_B0 and Ref_B1
-  for (std::size_t ib = 0; ib < N; ib++) {
+  for (std::size_t ib = 0; ib < h_B0.extent(0); ib++) {
     for (std::size_t j = 0; j < h_B0.extent(1); j++) {
-      // EXPECT_NEAR_KK(ats::abs(h_B0(ib, j) - h_Ref_B0(ib, j)), eps);
+      EXPECT_NEAR_KK(h_B0(ib, j), h_Ref_B0(ib, j), eps);
     }
     for (std::size_t i = 0; i < h_B1.extent(1); i++) {
       for (std::size_t j = 0; j < h_B1.extent(2); j++) {
-        // EXPECT_NEAR_KK(ats::abs(h_B1(ib, i, j) - h_Ref_B1(ib, i, j)), eps);
+        EXPECT_NEAR_KK(h_B1(ib, i, j), h_Ref_B1(ib, i, j), eps);
       }
     }
   }

--- a/batched/dense/unit_test/Test_Batched_SerialCopy.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialCopy.hpp
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+
+#include "gtest/gtest.h"
+#include "Kokkos_Core.hpp"
+#include "Kokkos_Random.hpp"
+
+#include "KokkosBatched_Copy_Decl.hpp"
+#include "KokkosKernels_TestUtils.hpp"
+
+namespace Test {
+namespace Copy {
+
+template <typename DeviceType, typename AViewType, typename BViewType, typename ArgTrans>
+struct Functor_TestBatchedSerialCopy {
+  using execution_space = typename DeviceType::execution_space;
+  const AViewType m_A;
+  const BViewType m_B;
+
+  Functor_TestBatchedSerialCopy(const AViewType &A, const BViewType &B) : m_A(A), m_B(B) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int k, int &info) const {
+    if constexpr (AViewType::rank() == 3) {
+      auto sub_A = Kokkos::subview(m_A, k, Kokkos::ALL, Kokkos::ALL);
+      auto sub_B = Kokkos::subview(m_B, k, Kokkos::ALL, Kokkos::ALL);
+      info += KokkosBatched::SerialCopy<ArgTrans>::invoke(sub_A, sub_B);
+    } else {
+      auto sub_A = Kokkos::subview(m_A, k, Kokkos::ALL);
+      auto sub_B = Kokkos::subview(m_B, k, Kokkos::ALL);
+      info += KokkosBatched::SerialCopy<ArgTrans>::invoke(sub_A, sub_B);
+    }
+  }
+
+  inline int run() {
+    using value_type = typename AViewType::non_const_value_type;
+    std::string name_region("KokkosBatched::Test::SerialCopy");
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    int info_sum                      = 0;
+    Kokkos::Profiling::pushRegion(name.c_str());
+    Kokkos::RangePolicy<execution_space> policy(0, m_A.extent(0));
+    Kokkos::parallel_reduce(name.c_str(), policy, *this, info_sum);
+    Kokkos::Profiling::popRegion();
+    return info_sum;
+  }
+};
+
+/// \brief Implementation details of batched copy analytical test
+///        Confirm B == A or B == A^T or A^H
+///
+/// A0: [[1],[2],[3]]
+/// B0: [[1],[2],[3]] if no transpose
+/// B0: [[1,2,3]] if transpose or conjugate transpose
+///
+/// A1: [[1,2,3],[4,5,6]]
+/// B1: [[1,2,3],[4,5,6]] if no transpose
+/// B1: [[1,4],[2,5],[3,6]] if transpose or conjugate transpose
+/// \tparam DeviceType Kokkos device type
+/// \tparam ScalarType Value type of input/output views
+/// \tparam LayoutType Layout type of input/output views
+/// \tparam ArgTrans Type indicating whether the transpose (Trans::Transpose) or conjugate transpose
+/// (Trans::ConjTranspose) of A is used
+/// \param[in] N Batch size of matrices
+template <typename DeviceType, typename ScalarType, typename LayoutType, typename ArgTrans>
+void impl_test_batched_copy_analytical(const std::size_t N) {
+  using ats               = typename KokkosKernels::ArithTraits<ScalarType>;
+  using RealType          = typename ats::mag_type;
+  using View2DType        = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
+  using View3DType        = Kokkos::View<ScalarType ***, LayoutType, DeviceType>;
+  using StridedView2DType = Kokkos::View<ScalarType **, Kokkos::LayoutStride, DeviceType>;
+  using StridedView3DType = Kokkos::View<ScalarType ***, Kokkos::LayoutStride, DeviceType>;
+
+  const std::size_t m = std::is_same_v<ArgTrans, KokkosBatched::Trans::NoTranspose> ? 2 : 3;
+  const std::size_t n = std::is_same_v<ArgTrans, KokkosBatched::Trans::NoTranspose> ? 3 : 2;
+  View2DType A0("A0", N, 3), B0("B0", N, 3), Ref_B0("Ref_B0", N, 3);
+  View3DType A1("A1", N, 2, 3), B1("B1", N, m, n), Ref_B1("Ref_B1", N, m, n);
+
+  // Testing with strided views
+  const std::size_t stride = 2;
+  Kokkos::LayoutStride layout0{N, stride, 3, N * stride};
+  StridedView2DType A0_s("A0_s", layout0), B0_s("B0_s", layout0);
+
+  Kokkos::LayoutStride layout1{N, stride, 2, N * stride, 3, N * stride * 2},
+      layout2{N, stride, m, N * stride, n, N * stride * m};
+
+  StridedView3DType A1_s("A1_s", layout1), B1_s("B1_s", layout2);
+
+  // Initialize A0 and A1
+  auto h_A0     = Kokkos::create_mirror_view(A0);
+  auto h_A1     = Kokkos::create_mirror_view(A1);
+  auto h_Ref_B1 = Kokkos::create_mirror_view(Ref_B1);
+
+  for (std::size_t ib = 0; ib < N; ib++) {
+    h_A0(ib, 0) = 1.0;
+    h_A0(ib, 1) = 2.0;
+    h_A0(ib, 2) = 3.0;
+
+    h_A1(ib, 0, 0) = 1.0;
+    h_A1(ib, 0, 1) = 2.0;
+    h_A1(ib, 0, 2) = 3.0;
+    h_A1(ib, 1, 0) = 4.0;
+    h_A1(ib, 1, 1) = 5.0;
+    h_A1(ib, 1, 2) = 6.0;
+
+    for (std::size_t i = 0; i < h_Ref_B1.extent(1); i++) {
+      for (std::size_t j = 0; j < h_Ref_B1.extent(2); j++) {
+        h_Ref_B1(ib, i, j) =
+            std::is_same_v<ArgTrans, KokkosBatched::Trans::NoTranspose> ? h_A1(ib, i, j) : h_A1(ib, j, i);
+      }
+    }
+  }
+  Kokkos::deep_copy(A0, h_A0);
+  Kokkos::deep_copy(A1, h_A1);
+  Kokkos::deep_copy(Ref_B0, A0);
+  Kokkos::deep_copy(Ref_B1, h_Ref_B1);
+
+  // Strided views can be copied only on the same device
+  Kokkos::deep_copy(A0_s, A0);
+  Kokkos::deep_copy(A1_s, A1);
+
+  auto info0 = Functor_TestBatchedSerialCopy<DeviceType, View2DType, View2DType, ArgTrans>(A0, B0).run();
+  auto info1 = Functor_TestBatchedSerialCopy<DeviceType, View3DType, View3DType, ArgTrans>(A1, B1).run();
+
+  EXPECT_EQ(info0, 0);
+  EXPECT_EQ(info1, 0);
+
+  // For strided views
+  info0 = Functor_TestBatchedSerialCopy<DeviceType, StridedView2DType, StridedView2DType, ArgTrans>(A0_s, B0_s).run();
+  info1 = Functor_TestBatchedSerialCopy<DeviceType, StridedView3DType, StridedView3DType, ArgTrans>(A1_s, B1_s).run();
+
+  EXPECT_EQ(info0, 0);
+  EXPECT_EQ(info1, 0);
+
+  RealType eps  = 1.0e1 * ats::epsilon();
+  auto h_B0     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, B0);
+  auto h_B1     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, B1);
+  auto h_Ref_B0 = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, Ref_B0);
+
+  // Check if B0 and B1 are same as Ref_B0 and Ref_B1
+  for (std::size_t ib = 0; ib < N; ib++) {
+    for (std::size_t j = 0; j < 3; j++) {
+      // EXPECT_NEAR_KK(ats::abs(h_B0(ib, j) - h_Ref_B0(ib, j)), eps);
+    }
+    for (std::size_t i = 0; i < h_B1.extent(1); i++) {
+      for (std::size_t j = 0; j < h_B1.extent(2); j++) {
+        // EXPECT_NEAR_KK(ats::abs(h_B1(ib, i, j) - h_Ref_B1(ib, i, j)), eps);
+      }
+    }
+  }
+
+  // Testing for strided views, reusing B0 and B1
+  Kokkos::deep_copy(B0, B0_s);
+  Kokkos::deep_copy(B1, B1_s);
+  Kokkos::deep_copy(h_B0, B0);
+  Kokkos::deep_copy(h_B1, B1);
+  for (std::size_t ib = 0; ib < N; ib++) {
+    for (std::size_t j = 0; j < 3; j++) {
+      // EXPECT_NEAR_KK(ats::abs(h_B0(ib, j) - h_Ref_B0(ib, j)), eps);
+    }
+    for (std::size_t i = 0; i < h_B1.extent(1); i++) {
+      for (std::size_t j = 0; j < h_B1.extent(2); j++) {
+        // EXPECT_NEAR_KK(ats::abs(h_B1(ib, i, j) - h_Ref_B1(ib, i, j)), eps);
+      }
+    }
+  }
+}
+
+/// \brief Implementation details of batched copy test
+///        Confirm B == A or B == A^T or A^H
+///
+/// \tparam DeviceType Kokkos device type
+/// \tparam ScalarType Value type of input/output views
+/// \tparam LayoutType Layout type of input/output views
+/// \tparam ArgTrans Type indicating whether the transpose (Trans::Transpose) or conjugate transpose
+/// (Trans::ConjTranspose) of A is used
+/// \param[in] N Batch size of matrices
+/// \param[in] m_A Number of rows of matrix A
+/// \param[in] n_A Number of columns of matrix A
+template <typename DeviceType, typename ScalarType, typename LayoutType, typename ArgTrans>
+void impl_test_batched_copy(const std::size_t N, const std::size_t m_A, const std::size_t n_A) {
+  using ats               = typename KokkosKernels::ArithTraits<ScalarType>;
+  using RealType          = typename ats::mag_type;
+  using View2DType        = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
+  using View3DType        = Kokkos::View<ScalarType ***, LayoutType, DeviceType>;
+  using StridedView2DType = Kokkos::View<ScalarType **, Kokkos::LayoutStride, DeviceType>;
+  using StridedView3DType = Kokkos::View<ScalarType ***, Kokkos::LayoutStride, DeviceType>;
+
+  const std::size_t m_B = std::is_same_v<ArgTrans, KokkosBatched::Trans::NoTranspose> ? m_A : n_A;
+  const std::size_t n_B = std::is_same_v<ArgTrans, KokkosBatched::Trans::NoTranspose> ? n_A : m_A;
+  View2DType A0("A0", N, m_A), B0("B0", N, m_A), Ref_B0("Ref_B0", N, m_A);
+  View3DType A1("A1", N, m_A, n_A), B1("B1", N, m_B, n_B), Ref_B1("Ref_B1", N, m_B, n_B);
+
+  // Initialize A0 and A1 with random numbers
+  using execution_space = typename DeviceType::execution_space;
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
+  ScalarType randStart, randEnd;
+
+  KokkosKernels::Impl::getRandomBounds(1.0, randStart, randEnd);
+  Kokkos::fill_random(A0, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(A1, rand_pool, randStart, randEnd);
+
+  auto h_A1     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, A1);
+  auto h_Ref_B1 = Kokkos::create_mirror_view(Ref_B1);
+
+  for (std::size_t ib = 0; ib < N; ib++) {
+    for (std::size_t i = 0; i < h_Ref_B1.extent(1); i++) {
+      for (std::size_t j = 0; j < h_Ref_B1.extent(2); j++) {
+        h_Ref_B1(ib, i, j) =
+            std::is_same_v<ArgTrans, KokkosBatched::Trans::NoTranspose> ? h_A1(ib, i, j) : h_A1(ib, j, i);
+      }
+    }
+  }
+  Kokkos::deep_copy(Ref_B0, A0);
+  Kokkos::deep_copy(Ref_B1, h_Ref_B1);
+
+  // Copy operations
+  auto info0 = Functor_TestBatchedSerialCopy<DeviceType, View2DType, View2DType, ArgTrans>(A0, B0).run();
+  auto info1 = Functor_TestBatchedSerialCopy<DeviceType, View3DType, View3DType, ArgTrans>(A1, B1).run();
+
+  EXPECT_EQ(info0, 0);
+  EXPECT_EQ(info1, 0);
+
+  RealType eps  = 1.0e1 * ats::epsilon();
+  auto h_B0     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, B0);
+  auto h_B1     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, B1);
+  auto h_Ref_B0 = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, Ref_B0);
+
+  // Check if B0 and B1 are same as Ref_B0 and Ref_B1
+  for (std::size_t ib = 0; ib < N; ib++) {
+    for (std::size_t j = 0; j < h_B0.extent(1); j++) {
+      // EXPECT_NEAR_KK(ats::abs(h_B0(ib, j) - h_Ref_B0(ib, j)), eps);
+    }
+    for (std::size_t i = 0; i < h_B1.extent(1); i++) {
+      for (std::size_t j = 0; j < h_B1.extent(2); j++) {
+        // EXPECT_NEAR_KK(ats::abs(h_B1(ib, i, j) - h_Ref_B1(ib, i, j)), eps);
+      }
+    }
+  }
+}
+
+}  // namespace Copy
+}  // namespace Test
+
+template <typename DeviceType, typename ScalarType, typename ArgTrans>
+int test_batched_copy() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
+  {
+    using LayoutType = Kokkos::LayoutLeft;
+    Test::Copy::impl_test_batched_copy_analytical<DeviceType, ScalarType, LayoutType, ArgTrans>(1);
+    Test::Copy::impl_test_batched_copy_analytical<DeviceType, ScalarType, LayoutType, ArgTrans>(10);
+
+    for (std::size_t ib = 0; ib < 5; ib++) {
+      const std::size_t m = ib;
+      const std::size_t n = 2 * ib;
+      Test::Copy::impl_test_batched_copy<DeviceType, ScalarType, LayoutType, ArgTrans>(ib, m, n);
+    }
+  }
+#endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
+  {
+    using LayoutType = Kokkos::LayoutRight;
+    Test::Copy::impl_test_batched_copy_analytical<DeviceType, ScalarType, LayoutType, ArgTrans>(1);
+    Test::Copy::impl_test_batched_copy_analytical<DeviceType, ScalarType, LayoutType, ArgTrans>(10);
+
+    for (std::size_t ib = 0; ib < 5; ib++) {
+      const std::size_t m = ib;
+      const std::size_t n = 2 * ib;
+      Test::Copy::impl_test_batched_copy<DeviceType, ScalarType, LayoutType, ArgTrans>(ib, m, n);
+    }
+  }
+#endif
+
+  return 0;
+}
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+TEST_F(TestCategory, test_batched_copy_nt_float) {
+  test_batched_copy<TestDevice, float, KokkosBatched::Trans::NoTranspose>();
+}
+TEST_F(TestCategory, test_batched_copy_t_float) {
+  test_batched_copy<TestDevice, float, KokkosBatched::Trans::Transpose>();
+}
+TEST_F(TestCategory, test_batched_copy_c_float) {
+  test_batched_copy<TestDevice, float, KokkosBatched::Trans::ConjTranspose>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+TEST_F(TestCategory, test_batched_copy_nt_double) {
+  test_batched_copy<TestDevice, double, KokkosBatched::Trans::NoTranspose>();
+}
+TEST_F(TestCategory, test_batched_copy_t_double) {
+  test_batched_copy<TestDevice, double, KokkosBatched::Trans::Transpose>();
+}
+TEST_F(TestCategory, test_batched_copy_c_double) {
+  test_batched_copy<TestDevice, double, KokkosBatched::Trans::ConjTranspose>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_FLOAT)
+TEST_F(TestCategory, test_batched_copy_nt_fcomplex) {
+  test_batched_copy<TestDevice, Kokkos::complex<float>, KokkosBatched::Trans::NoTranspose>();
+}
+TEST_F(TestCategory, test_batched_copy_t_fcomplex) {
+  test_batched_copy<TestDevice, Kokkos::complex<float>, KokkosBatched::Trans::Transpose>();
+}
+TEST_F(TestCategory, test_batched_copy_c_fcomplex) {
+  test_batched_copy<TestDevice, Kokkos::complex<float>, KokkosBatched::Trans::ConjTranspose>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
+TEST_F(TestCategory, test_batched_copy_nt_dcomplex) {
+  test_batched_copy<TestDevice, Kokkos::complex<double>, KokkosBatched::Trans::NoTranspose>();
+}
+TEST_F(TestCategory, test_batched_copy_t_dcomplex) {
+  test_batched_copy<TestDevice, Kokkos::complex<double>, KokkosBatched::Trans::Transpose>();
+}
+TEST_F(TestCategory, test_batched_copy_c_dcomplex) {
+  test_batched_copy<TestDevice, Kokkos::complex<double>, KokkosBatched::Trans::ConjTranspose>();
+}
+#endif

--- a/batched/dense/unit_test/Test_Batched_TeamVectorQR.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorQR.hpp
@@ -61,7 +61,7 @@ struct Functor_TestBatchedTeamVectorQR {
     member.team_barrier();
 
     /// xx = bb;
-    TeamVectorCopy<MemberType, Trans::NoTranspose, 1>::invoke(member, bb, xx);
+    TeamVectorCopy<MemberType, Trans::NoTranspose>::invoke(member, bb, xx);
     member.team_barrier();
 
     /// xx = Q^{T}xx;

--- a/batched/dense/unit_test/Test_Batched_TeamVectorQR_WithColumnPivoting.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorQR_WithColumnPivoting.hpp
@@ -66,7 +66,7 @@ struct Functor_TestBatchedTeamVectorQR_WithColumnPivoting {
     member.team_barrier();
 
     /// xx = bb;
-    TeamVectorCopy<MemberType, Trans::NoTranspose, 1>::invoke(member, bb, xx);
+    TeamVectorCopy<MemberType, Trans::NoTranspose>::invoke(member, bb, xx);
     member.team_barrier();
 
     /// xx = Q^{T} xx;

--- a/batched/sparse/impl/KokkosBatched_CG_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_CG_TeamVector_Impl.hpp
@@ -34,7 +34,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorCG<MemberType>::invoke(const MemberType& me
   const size_t maximum_iteration = handle.get_max_iteration();
   const MagnitudeType tolerance  = handle.get_tolerance();
 
-  using TeamVectorCopy1D = TeamVectorCopy<MemberType, Trans::NoTranspose, 1>;
+  using TeamVectorCopy1D = TeamVectorCopy<MemberType, Trans::NoTranspose>;
 
   const OrdinalType numMatrices = X.extent(0);
   const OrdinalType numRows     = X.extent(1);

--- a/batched/sparse/impl/KokkosBatched_CG_Team_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_CG_Team_Impl.hpp
@@ -33,7 +33,7 @@ KOKKOS_INLINE_FUNCTION int TeamCG<MemberType>::invoke(const MemberType& member, 
   size_t maximum_iteration      = handle.get_max_iteration();
   const MagnitudeType tolerance = handle.get_tolerance();
 
-  using TeamCopy1D = TeamCopy<MemberType, Trans::NoTranspose, 1>;
+  using TeamCopy1D = TeamCopy<MemberType, Trans::NoTranspose>;
 
   const OrdinalType numMatrices = X.extent(0);
   const OrdinalType numRows     = X.extent(1);

--- a/batched/sparse/impl/KokkosBatched_GMRES_Serial_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_GMRES_Serial_Impl.hpp
@@ -31,9 +31,6 @@ KOKKOS_INLINE_FUNCTION int SerialGMRES::invoke(const OperatorType& A, const Vect
   typedef typename KokkosKernels::ArithTraits<typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
   typedef KokkosKernels::ArithTraits<MagnitudeType> ATM;
 
-  using SerialCopy1D = SerialCopy<Trans::NoTranspose, 1>;
-  using SerialCopy2D = SerialCopy<Trans::NoTranspose, 2>;
-
   const OrdinalType numMatrices = X.extent(0);
   const OrdinalType numRows     = X.extent(1);
 
@@ -76,7 +73,7 @@ KOKKOS_INLINE_FUNCTION int SerialGMRES::invoke(const OperatorType& A, const Vect
   auto tmp  = Kokkos::subview(handle.tmp_view, Kokkos::make_pair(first_matrix, last_matrix), offset_tmp);
 
   // Deep copy of b into r_0:
-  SerialCopy2D::invoke(B, W);
+  SerialCopy<Trans::NoTranspose>::invoke(B, W);
 
   // r_0 := b - A x_0
   A.template apply<Trans::NoTranspose>(X, W, -1, 1);
@@ -134,7 +131,7 @@ KOKKOS_INLINE_FUNCTION int SerialGMRES::invoke(const OperatorType& A, const Vect
       for (size_t i = 0; i < j + 1; ++i) {
         auto V_i = Kokkos::subview(V_view, Kokkos::ALL, i, Kokkos::ALL);
         SerialDot<Trans::NoTranspose>::invoke(W, V_i, tmp);
-        SerialCopy1D::invoke(tmp, Kokkos::subview(H_view, Kokkos::ALL, j, i));
+        SerialCopy<Trans::NoTranspose>::invoke(tmp, Kokkos::subview(H_view, Kokkos::ALL, j, i));
         for (OrdinalType ii = 0; ii < numMatrices; ++ii) tmp(ii) = -tmp(ii);
 
         SerialAxpy::invoke(tmp, V_i, W);
@@ -235,7 +232,7 @@ KOKKOS_INLINE_FUNCTION int SerialGMRES::invoke(const OperatorType& A, const Vect
   }
 
   if (handle.get_compute_last_residual()) {
-    SerialCopy2D::invoke(B, W);
+    SerialCopy<Trans::NoTranspose>::invoke(B, W);
     A.template apply<Trans::NoTranspose>(X, W, -1, 1);
     P.template apply<Trans::NoTranspose, 1>(W, W);
     SerialDot<Trans::NoTranspose>::invoke(W, W, tmp);

--- a/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
@@ -38,7 +38,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::invoke(const MemberType&
   typedef typename KokkosKernels::ArithTraits<typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
   typedef KokkosKernels::ArithTraits<MagnitudeType> ATM;
 
-  using TeamVectorCopy1D = TeamVectorCopy<MemberType, Trans::NoTranspose, 1>;
+  using TeamVectorCopy1D = TeamVectorCopy<MemberType, Trans::NoTranspose>;
 
   const OrdinalType numMatrices = X.extent(0);
   const OrdinalType numRows     = X.extent(1);

--- a/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
@@ -36,7 +36,7 @@ KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::invoke(const MemberType& membe
   typedef typename KokkosKernels::ArithTraits<typename VectorViewType::non_const_value_type>::mag_type MagnitudeType;
   typedef KokkosKernels::ArithTraits<MagnitudeType> ATM;
 
-  using TeamCopy1D = TeamCopy<MemberType, Trans::NoTranspose, 1>;
+  using TeamCopy1D = TeamCopy<MemberType, Trans::NoTranspose>;
 
   const OrdinalType numMatrices = X.extent(0);
   const OrdinalType numRows     = X.extent(1);

--- a/example/batched_solve/team_GMRES.cpp
+++ b/example/batched_solve/team_GMRES.cpp
@@ -68,7 +68,7 @@ struct Functor_TestBatchedTeamVectorGMRES {
   KOKKOS_INLINE_FUNCTION void operator()(const MemberType &member) const {
     const int first_matrix = _handle.first_index(member.league_rank());
     const int last_matrix  = _handle.last_index(member.league_rank());
-    using TeamVectorCopy1D = KokkosBatched::TeamVectorCopy<MemberType, KokkosBatched::Trans::NoTranspose, 1>;
+    using TeamVectorCopy1D = KokkosBatched::TeamVectorCopy<MemberType, KokkosBatched::Trans::NoTranspose>;
 
     auto d = Kokkos::subview(_values, Kokkos::make_pair(first_matrix, last_matrix), Kokkos::ALL);
     auto x = Kokkos::subview(X_, Kokkos::make_pair(first_matrix, last_matrix), Kokkos::ALL);

--- a/perf_test/batched/sparse/CG/Functor_TestBatchedTeamVectorCG_2.hpp
+++ b/perf_test/batched/sparse/CG/Functor_TestBatchedTeamVectorCG_2.hpp
@@ -31,7 +31,7 @@ struct Functor_TestBatchedTeamVectorCG_2 {
     const int first_matrix = _handle.first_index(member.league_rank());
     const int last_matrix  = _handle.last_index(member.league_rank());
 
-    using TeamVectorCopy1D = KokkosBatched::TeamVectorCopy<MemberType, KokkosBatched::Trans::NoTranspose, 1>;
+    using TeamVectorCopy1D = KokkosBatched::TeamVectorCopy<MemberType, KokkosBatched::Trans::NoTranspose>;
 
     auto d = Kokkos::subview(_D, Kokkos::make_pair(first_matrix, last_matrix), Kokkos::ALL);
     auto x = Kokkos::subview(_X, Kokkos::make_pair(first_matrix, last_matrix), Kokkos::ALL);

--- a/perf_test/batched/sparse/CG/Functor_TestBatchedTeamVectorCG_3.hpp
+++ b/perf_test/batched/sparse/CG/Functor_TestBatchedTeamVectorCG_3.hpp
@@ -31,7 +31,7 @@ struct Functor_TestBatchedTeamVectorCG_3 {
     const int first_matrix = _handle.first_index(member.league_rank());
     const int last_matrix  = _handle.last_index(member.league_rank());
 
-    using TeamVectorCopy1D = KokkosBatched::TeamVectorCopy<MemberType, KokkosBatched::Trans::NoTranspose, 1>;
+    using TeamVectorCopy1D = KokkosBatched::TeamVectorCopy<MemberType, KokkosBatched::Trans::NoTranspose>;
 
     auto d = Kokkos::subview(_D, Kokkos::make_pair(first_matrix, last_matrix), Kokkos::ALL);
     auto x = Kokkos::subview(_X, Kokkos::make_pair(first_matrix, last_matrix), Kokkos::ALL);

--- a/perf_test/batched/sparse/GMRES/Functor_TestBatchedTeamVectorGMRES_2.hpp
+++ b/perf_test/batched/sparse/GMRES/Functor_TestBatchedTeamVectorGMRES_2.hpp
@@ -66,7 +66,7 @@ struct Functor_TestBatchedTeamVectorGMRES_2 {
     const int first_matrix = _handle.first_index(member.league_rank());
     const int last_matrix  = _handle.last_index(member.league_rank());
 
-    using TeamVectorCopy1D = KokkosBatched::TeamVectorCopy<MemberType, KokkosBatched::Trans::NoTranspose, 1>;
+    using TeamVectorCopy1D = KokkosBatched::TeamVectorCopy<MemberType, KokkosBatched::Trans::NoTranspose>;
 
     auto d = Kokkos::subview(_D, Kokkos::make_pair(first_matrix, last_matrix), Kokkos::ALL);
     auto x = Kokkos::subview(_X, Kokkos::make_pair(first_matrix, last_matrix), Kokkos::ALL);

--- a/perf_test/batched/sparse/GMRES/Functor_TestBatchedTeamVectorGMRES_3.hpp
+++ b/perf_test/batched/sparse/GMRES/Functor_TestBatchedTeamVectorGMRES_3.hpp
@@ -66,7 +66,7 @@ struct Functor_TestBatchedTeamVectorGMRES_3 {
     const int first_matrix = _handle.first_index(member.league_rank());
     const int last_matrix  = _handle.last_index(member.league_rank());
 
-    using TeamVectorCopy1D = KokkosBatched::TeamVectorCopy<MemberType, KokkosBatched::Trans::NoTranspose, 1>;
+    using TeamVectorCopy1D = KokkosBatched::TeamVectorCopy<MemberType, KokkosBatched::Trans::NoTranspose>;
 
     auto d = Kokkos::subview(_D, Kokkos::make_pair(first_matrix, last_matrix), Kokkos::ALL);
     auto x = Kokkos::subview(_X, Kokkos::make_pair(first_matrix, last_matrix), Kokkos::ALL);


### PR DESCRIPTION
This PR aims at improving the implementation and adding unit-tests of serial `copy`.

 - [x] Adding unit-tests for `SerialCopy`
 - [x] Remove the `rank` argument from the API. `rank` is derived from `View` rank.
 - [x] Moving implementation details inside `Impl` namespace. 
 - [x] Supporting `ConjTrans` operator
 - [x] Add docstring and assertion for `Arg` template parameters
 
Current API
```C++
template <typename ArgTrans = Trans::NoTranspose, int rank = 2>
struct SerialCopy {
  template <typename AViewType, typename BViewType>
  KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const BViewType &B);
};
```

New API

```C++
/// \brief Serial Batched Copy:
/// Performs B = Op(A)
/// where Op is one of NoTranspose, Transpose, ConjTranspose
/// A and B are 1D or 2D views
///
/// \tparam ArgTrans: one of NoTranspose, Transpose, ConjTranspose
/// \tparam Args: (deprecated) rank information
template <typename ArgTrans = Trans::NoTranspose, class... Args>
struct SerialCopy {
  static constexpr size_t size = sizeof...(Args);
  static_assert(size == 0,
                "KokkosBatched::SerialCopy<ArgTrans, rank> is deprecated. Please use "
                "KokkosBatched::SerialCopy<ArgTrans> instead.");
  static_assert(KokkosBlas::is_trans_v<ArgTrans>, "KokkosBatched::SerialCopy: ArgTrans must be a KokkosBlas::Trans.");

  /// \brief invoke the SerialCopy
  /// \tparam AViewType: Kokkos::View type for A
  /// \tparam BViewType: Kokkos::View type for B
  /// \param[in] A Input view A
  /// \param[out] B Output view B
  template <typename AViewType, typename BViewType>
  KOKKOS_INLINE_FUNCTION static int invoke(const AViewType &A, const BViewType &B);
};
```