### PR TITLE
Refactor KK debug guards

### DIFF
--- a/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Impl.hpp
@@ -30,7 +30,7 @@ KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Left, Trans::NoTranspose, Algo::Ap
   static_assert(Kokkos::is_view_v<wViewType>, "KokkosBatched::SerialApplyQ::invoke: wViewType must be a Kokkos::View");
   static_assert(wViewType::rank() == 1, "KokkosBatched::SerialApplyQ::invoke: wViewType must have rank 1");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   if (!w.span_is_contiguous()) {
     Kokkos::printf("KokkosBatched::SerialApplyQ::invoke: w must have a contiguous span.");
     return 1;
@@ -62,7 +62,7 @@ KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Left, Trans::Transpose, Algo::Appl
   static_assert(Kokkos::is_view_v<wViewType>, "KokkosBatched::SerialApplyQ::invoke: wViewType must be a Kokkos::View");
   static_assert(wViewType::rank() == 1, "KokkosBatched::SerialApplyQ::invoke: wViewType must have rank 1");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   if (!w.span_is_contiguous()) {
     Kokkos::printf("KokkosBatched::SerialApplyQ::invoke: w must have a contiguous span.");
     return 1;
@@ -94,7 +94,7 @@ KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Right, Trans::NoTranspose, Algo::A
   static_assert(Kokkos::is_view_v<wViewType>, "KokkosBatched::SerialApplyQ::invoke: wViewType must be a Kokkos::View");
   static_assert(wViewType::rank() == 1, "KokkosBatched::SerialApplyQ::invoke: wViewType must have rank 1");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   if (!w.span_is_contiguous()) {
     Kokkos::printf("KokkosBatched::SerialApplyQ::invoke: w must have a contiguous span.");
     return 1;

--- a/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Impl.hpp
@@ -30,7 +30,7 @@ KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Left, Trans::NoTranspose, Algo::Ap
   static_assert(Kokkos::is_view_v<wViewType>, "KokkosBatched::SerialApplyQ::invoke: wViewType must be a Kokkos::View");
   static_assert(wViewType::rank() == 1, "KokkosBatched::SerialApplyQ::invoke: wViewType must have rank 1");
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   if (!w.span_is_contiguous()) {
     Kokkos::printf("KokkosBatched::SerialApplyQ::invoke: w must have a contiguous span.");
     return 1;
@@ -62,7 +62,7 @@ KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Left, Trans::Transpose, Algo::Appl
   static_assert(Kokkos::is_view_v<wViewType>, "KokkosBatched::SerialApplyQ::invoke: wViewType must be a Kokkos::View");
   static_assert(wViewType::rank() == 1, "KokkosBatched::SerialApplyQ::invoke: wViewType must have rank 1");
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   if (!w.span_is_contiguous()) {
     Kokkos::printf("KokkosBatched::SerialApplyQ::invoke: w must have a contiguous span.");
     return 1;
@@ -94,7 +94,7 @@ KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Right, Trans::NoTranspose, Algo::A
   static_assert(Kokkos::is_view_v<wViewType>, "KokkosBatched::SerialApplyQ::invoke: wViewType must be a Kokkos::View");
   static_assert(wViewType::rank() == 1, "KokkosBatched::SerialApplyQ::invoke: wViewType must have rank 1");
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   if (!w.span_is_contiguous()) {
     Kokkos::printf("KokkosBatched::SerialApplyQ::invoke: w must have a contiguous span.");
     return 1;

--- a/batched/dense/impl/KokkosBatched_Axpy_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Axpy_Impl.hpp
@@ -22,7 +22,7 @@ KOKKOS_INLINE_FUNCTION static int checkAxpyInput([[maybe_unused]] const alphaVie
     static_assert(XViewType::rank == 2, "KokkosBatched::axpy: XViewType must have rank 2.");
     static_assert(YViewType::rank == 2, "KokkosBatched::axpy: YViewType must have rank 2.");
     static_assert(alphaViewType::rank == 1, "KokkosBatched::axpy: alphaViewType must have rank 1.");
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     // Check compatibility of dimensions at run time.
     if (X.extent_int(0) != Y.extent_int(0) || X.extent_int(1) != Y.extent_int(1)) {
       Kokkos::printf(
@@ -42,7 +42,7 @@ KOKKOS_INLINE_FUNCTION static int checkAxpyInput([[maybe_unused]] const alphaVie
   } else {
     static_assert(XViewType::rank == 1, "KokkosBatched::axpy: XViewType must have rank 1 if alpha is a scalar.");
     static_assert(YViewType::rank == 1, "KokkosBatched::axpy: YViewType must have rank 1 if alpha is a scalar.");
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     // Check compatibility of dimensions at run time.
     if (X.extent_int(0) != Y.extent_int(0)) {
       Kokkos::printf(

--- a/batched/dense/impl/KokkosBatched_Axpy_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Axpy_Impl.hpp
@@ -22,7 +22,7 @@ KOKKOS_INLINE_FUNCTION static int checkAxpyInput([[maybe_unused]] const alphaVie
     static_assert(XViewType::rank == 2, "KokkosBatched::axpy: XViewType must have rank 2.");
     static_assert(YViewType::rank == 2, "KokkosBatched::axpy: YViewType must have rank 2.");
     static_assert(alphaViewType::rank == 1, "KokkosBatched::axpy: alphaViewType must have rank 1.");
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (X.extent_int(0) != Y.extent_int(0) || X.extent_int(1) != Y.extent_int(1)) {
       Kokkos::printf(
@@ -42,7 +42,7 @@ KOKKOS_INLINE_FUNCTION static int checkAxpyInput([[maybe_unused]] const alphaVie
   } else {
     static_assert(XViewType::rank == 1, "KokkosBatched::axpy: XViewType must have rank 1 if alpha is a scalar.");
     static_assert(YViewType::rank == 1, "KokkosBatched::axpy: YViewType must have rank 1 if alpha is a scalar.");
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (X.extent_int(0) != Y.extent_int(0)) {
       Kokkos::printf(

--- a/batched/dense/impl/KokkosBatched_Copy_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Copy_Impl.hpp
@@ -34,7 +34,7 @@ KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::NoTranspose, 2>::invoke(const AView
   static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
   static_assert(BViewType::rank == 2, "KokkosBatched::copy: BViewType must have rank 2.");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   // Check compatibility of dimensions at run time.
   if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
     Kokkos::printf(
@@ -56,7 +56,7 @@ KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::Transpose, 2>::invoke(const AViewTy
   static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
   static_assert(BViewType::rank == 2, "KokkosBatched::copy: BViewType must have rank 2.");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   // Check compatibility of dimensions at run time.
   if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
     Kokkos::printf(
@@ -99,7 +99,7 @@ struct TeamCopy<MemberType, Trans::NoTranspose, 2> {
     static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
     static_assert(BViewType::rank == 2, "KokkosBatched::copy: BViewType must have rank 2.");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
       Kokkos::printf(
@@ -128,7 +128,7 @@ struct TeamCopy<MemberType, Trans::Transpose, 2> {
     static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
     static_assert(BViewType::rank == 2, "KokkosBatched::copy: BViewType must have rank 2.");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
       Kokkos::printf(
@@ -177,7 +177,7 @@ struct TeamVectorCopy<MemberType, Trans::NoTranspose, 2> {
     static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
     static_assert(BViewType::rank == 2, "KokkosBatched::copy: BViewType must have rank 2.");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
       Kokkos::printf(
@@ -206,7 +206,7 @@ struct TeamVectorCopy<MemberType, Trans::Transpose, 2> {
     static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
     static_assert(BViewType::rank == 2, "KokkosBatched::copy: BViewType must have rank 2.");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
       Kokkos::printf(

--- a/batched/dense/impl/KokkosBatched_Copy_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Copy_Impl.hpp
@@ -29,12 +29,12 @@ KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::Transpose, 1>::invoke(const AViewTy
 template <>
 template <typename AViewType, typename BViewType>
 KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::NoTranspose, 2>::invoke(const AViewType &A, const BViewType &B) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::copy: AViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::copy: BViewType is not a Kokkos::View.");
   static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
   static_assert(BViewType::rank == 2, "KokkosBatched::copy: BViewType must have rank 2.");
 
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   // Check compatibility of dimensions at run time.
   if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
     Kokkos::printf(
@@ -51,12 +51,12 @@ KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::NoTranspose, 2>::invoke(const AView
 template <>
 template <typename AViewType, typename BViewType>
 KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::Transpose, 2>::invoke(const AViewType &A, const BViewType &B) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::copy: AViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::copy: BViewType is not a Kokkos::View.");
   static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
   static_assert(BViewType::rank == 2, "KokkosBatched::copy: BViewType must have rank 2.");
 
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   // Check compatibility of dimensions at run time.
   if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
     Kokkos::printf(
@@ -94,12 +94,12 @@ template <typename MemberType>
 struct TeamCopy<MemberType, Trans::NoTranspose, 2> {
   template <typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::copy: AViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::copy: BViewType is not a Kokkos::View.");
     static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
     static_assert(BViewType::rank == 2, "KokkosBatched::copy: BViewType must have rank 2.");
 
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
       Kokkos::printf(
@@ -123,12 +123,12 @@ template <typename MemberType>
 struct TeamCopy<MemberType, Trans::Transpose, 2> {
   template <typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::copy: AViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::copy: BViewType is not a Kokkos::View.");
     static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
     static_assert(BViewType::rank == 2, "KokkosBatched::copy: BViewType must have rank 2.");
 
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
       Kokkos::printf(
@@ -172,12 +172,12 @@ template <typename MemberType>
 struct TeamVectorCopy<MemberType, Trans::NoTranspose, 2> {
   template <typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::copy: AViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::copy: BViewType is not a Kokkos::View.");
     static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
     static_assert(BViewType::rank == 2, "KokkosBatched::copy: BViewType must have rank 2.");
 
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
       Kokkos::printf(
@@ -201,12 +201,12 @@ template <typename MemberType>
 struct TeamVectorCopy<MemberType, Trans::Transpose, 2> {
   template <typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::copy: AViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::copy: BViewType is not a Kokkos::View.");
     static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
     static_assert(BViewType::rank == 2, "KokkosBatched::copy: BViewType must have rank 2.");
 
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != B.extent(0) || A.extent(1) != B.extent(1)) {
       Kokkos::printf(

--- a/batched/dense/impl/KokkosBatched_Copy_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Copy_Impl.hpp
@@ -29,7 +29,7 @@ KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::Transpose, 1>::invoke(const AViewTy
 template <>
 template <typename AViewType, typename BViewType>
 KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::NoTranspose, 2>::invoke(const AViewType &A, const BViewType &B) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::copy: AViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::copy: BViewType is not a Kokkos::View.");
   static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
@@ -51,7 +51,7 @@ KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::NoTranspose, 2>::invoke(const AView
 template <>
 template <typename AViewType, typename BViewType>
 KOKKOS_INLINE_FUNCTION int SerialCopy<Trans::Transpose, 2>::invoke(const AViewType &A, const BViewType &B) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::copy: AViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::copy: BViewType is not a Kokkos::View.");
   static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
@@ -94,7 +94,7 @@ template <typename MemberType>
 struct TeamCopy<MemberType, Trans::NoTranspose, 2> {
   template <typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::copy: AViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::copy: BViewType is not a Kokkos::View.");
     static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
@@ -123,7 +123,7 @@ template <typename MemberType>
 struct TeamCopy<MemberType, Trans::Transpose, 2> {
   template <typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::copy: AViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::copy: BViewType is not a Kokkos::View.");
     static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
@@ -172,7 +172,7 @@ template <typename MemberType>
 struct TeamVectorCopy<MemberType, Trans::NoTranspose, 2> {
   template <typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::copy: AViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::copy: BViewType is not a Kokkos::View.");
     static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");
@@ -201,7 +201,7 @@ template <typename MemberType>
 struct TeamVectorCopy<MemberType, Trans::Transpose, 2> {
   template <typename AViewType, typename BViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const AViewType &A, const BViewType &B) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<AViewType>::value, "KokkosBatched::copy: AViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<BViewType>::value, "KokkosBatched::copy: BViewType is not a Kokkos::View.");
     static_assert(AViewType::rank == 2, "KokkosBatched::copy: AViewType must have rank 2.");

--- a/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
@@ -150,7 +150,7 @@ template <>
 struct SerialDot<Trans::Transpose> {
   template <typename XViewType, typename YViewType, typename NormViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const XViewType &X, const YViewType &Y, const NormViewType &dot) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::dot: XViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::dot: YViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<NormViewType>::value, "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
@@ -186,7 +186,7 @@ template <>
 struct SerialDot<Trans::NoTranspose> {
   template <typename XViewType, typename YViewType, typename NormViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const XViewType &X, const YViewType &Y, const NormViewType &dot) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::dot: XViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::dot: YViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<NormViewType>::value, "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
@@ -226,7 +226,7 @@ struct TeamDot<MemberType, Trans::Transpose> {
   template <typename XViewType, typename YViewType, typename NormViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &X, const YViewType &Y,
                                            const NormViewType &dot) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::dot: XViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::dot: YViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<NormViewType>::value, "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
@@ -270,7 +270,7 @@ struct TeamDot<MemberType, Trans::NoTranspose> {
   template <typename XViewType, typename YViewType, typename NormViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &X, const YViewType &Y,
                                            const NormViewType &dot) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::dot: XViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::dot: YViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<NormViewType>::value, "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
@@ -317,7 +317,7 @@ struct TeamVectorDot<MemberType, Trans::Transpose> {
   template <typename XViewType, typename YViewType, typename NormViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &X, const YViewType &Y,
                                            const NormViewType &dot) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::dot: XViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::dot: YViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<NormViewType>::value, "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
@@ -361,7 +361,7 @@ struct TeamVectorDot<MemberType, Trans::NoTranspose> {
   template <typename XViewType, typename YViewType, typename NormViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &X, const YViewType &Y,
                                            const NormViewType &dot) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::dot: XViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::dot: YViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<NormViewType>::value, "KokkosBatched::dot: NormViewType is not a Kokkos::View.");

--- a/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
@@ -150,7 +150,6 @@ template <>
 struct SerialDot<Trans::Transpose> {
   template <typename XViewType, typename YViewType, typename NormViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const XViewType &X, const YViewType &Y, const NormViewType &dot) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::dot: XViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::dot: YViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<NormViewType>::value, "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
@@ -158,6 +157,7 @@ struct SerialDot<Trans::Transpose> {
     static_assert(YViewType::rank == 2, "KokkosBatched::dot: YViewType must have rank 2.");
     static_assert(NormViewType::rank == 1, "KokkosBatched::dot: NormViewType must have rank 1.");
 
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
       Kokkos::printf(
@@ -186,7 +186,6 @@ template <>
 struct SerialDot<Trans::NoTranspose> {
   template <typename XViewType, typename YViewType, typename NormViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const XViewType &X, const YViewType &Y, const NormViewType &dot) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::dot: XViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::dot: YViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<NormViewType>::value, "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
@@ -194,6 +193,7 @@ struct SerialDot<Trans::NoTranspose> {
     static_assert(YViewType::rank == 2, "KokkosBatched::dot: YViewType must have rank 2.");
     static_assert(NormViewType::rank == 1, "KokkosBatched::dot: NormViewType must have rank 1.");
 
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
       Kokkos::printf(
@@ -226,7 +226,6 @@ struct TeamDot<MemberType, Trans::Transpose> {
   template <typename XViewType, typename YViewType, typename NormViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &X, const YViewType &Y,
                                            const NormViewType &dot) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::dot: XViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::dot: YViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<NormViewType>::value, "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
@@ -234,6 +233,7 @@ struct TeamDot<MemberType, Trans::Transpose> {
     static_assert(YViewType::rank == 2, "KokkosBatched::dot: YViewType must have rank 2.");
     static_assert(NormViewType::rank == 1, "KokkosBatched::dot: NormViewType must have rank 1.");
 
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
       Kokkos::printf(
@@ -270,7 +270,6 @@ struct TeamDot<MemberType, Trans::NoTranspose> {
   template <typename XViewType, typename YViewType, typename NormViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &X, const YViewType &Y,
                                            const NormViewType &dot) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::dot: XViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::dot: YViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<NormViewType>::value, "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
@@ -278,6 +277,7 @@ struct TeamDot<MemberType, Trans::NoTranspose> {
     static_assert(YViewType::rank == 2, "KokkosBatched::dot: YViewType must have rank 2.");
     static_assert(NormViewType::rank == 1, "KokkosBatched::dot: NormViewType must have rank 1.");
 
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
       Kokkos::printf(
@@ -317,7 +317,6 @@ struct TeamVectorDot<MemberType, Trans::Transpose> {
   template <typename XViewType, typename YViewType, typename NormViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &X, const YViewType &Y,
                                            const NormViewType &dot) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::dot: XViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::dot: YViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<NormViewType>::value, "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
@@ -325,6 +324,7 @@ struct TeamVectorDot<MemberType, Trans::Transpose> {
     static_assert(YViewType::rank == 2, "KokkosBatched::dot: YViewType must have rank 2.");
     static_assert(NormViewType::rank == 1, "KokkosBatched::dot: NormViewType must have rank 1.");
 
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
       Kokkos::printf(
@@ -361,7 +361,6 @@ struct TeamVectorDot<MemberType, Trans::NoTranspose> {
   template <typename XViewType, typename YViewType, typename NormViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &X, const YViewType &Y,
                                            const NormViewType &dot) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::dot: XViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::dot: YViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<NormViewType>::value, "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
@@ -369,6 +368,7 @@ struct TeamVectorDot<MemberType, Trans::NoTranspose> {
     static_assert(YViewType::rank == 2, "KokkosBatched::dot: YViewType must have rank 2.");
     static_assert(NormViewType::rank == 1, "KokkosBatched::dot: NormViewType must have rank 1.");
 
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
       Kokkos::printf(

--- a/batched/dense/impl/KokkosBatched_Gbtrf_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gbtrf_Serial_Impl.hpp
@@ -18,7 +18,7 @@ KOKKOS_INLINE_FUNCTION static int checkGbtrfInput([[maybe_unused]] const ABViewT
   static_assert(Kokkos::is_view_v<PivViewType>, "KokkosBatched::gbtrf: PivViewType is not a Kokkos::View.");
   static_assert(ABViewType::rank == 2, "KokkosBatched::gbtrf: ABViewType must have rank 2.");
   static_assert(PivViewType::rank == 1, "KokkosBatched::gbtrf: PivViewType must have rank 1.");
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   const int n    = AB.extent(1);
   const int npiv = ipiv.extent(0);
   if (npiv != Kokkos::min(m, n)) {

--- a/batched/dense/impl/KokkosBatched_Gbtrf_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gbtrf_Serial_Impl.hpp
@@ -18,7 +18,7 @@ KOKKOS_INLINE_FUNCTION static int checkGbtrfInput([[maybe_unused]] const ABViewT
   static_assert(Kokkos::is_view_v<PivViewType>, "KokkosBatched::gbtrf: PivViewType is not a Kokkos::View.");
   static_assert(ABViewType::rank == 2, "KokkosBatched::gbtrf: ABViewType must have rank 2.");
   static_assert(PivViewType::rank == 1, "KokkosBatched::gbtrf: PivViewType must have rank 1.");
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   const int n    = AB.extent(1);
   const int npiv = ipiv.extent(0);
   if (npiv != Kokkos::min(m, n)) {

--- a/batched/dense/impl/KokkosBatched_Gbtrs_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gbtrs_Serial_Impl.hpp
@@ -25,7 +25,7 @@ KOKKOS_INLINE_FUNCTION static int checkGbtrsInput([[maybe_unused]] const AViewTy
                 "KokkosBatched::gbtrs: Value type of PivViewType must be an integral type.");
   static_assert(std::is_same_v<typename BViewType::value_type, typename BViewType::non_const_value_type>,
                 "KokkosBatched::gbtrs: BViewType must have non-const value type.");
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   if (kl < 0) {
     Kokkos::printf(
         "KokkosBatched::gbtrs: input parameter kl must not be less than 0: kl "

--- a/batched/dense/impl/KokkosBatched_Gbtrs_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gbtrs_Serial_Impl.hpp
@@ -25,7 +25,7 @@ KOKKOS_INLINE_FUNCTION static int checkGbtrsInput([[maybe_unused]] const AViewTy
                 "KokkosBatched::gbtrs: Value type of PivViewType must be an integral type.");
   static_assert(std::is_same_v<typename BViewType::value_type, typename BViewType::non_const_value_type>,
                 "KokkosBatched::gbtrs: BViewType must have non-const value type.");
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   if (kl < 0) {
     Kokkos::printf(
         "KokkosBatched::gbtrs: input parameter kl must not be less than 0: kl "

--- a/batched/dense/impl/KokkosBatched_Gemm_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemm_Serial_Impl.hpp
@@ -21,7 +21,7 @@ KOKKOS_INLINE_FUNCTION static int checkGemmInput([[maybe_unused]] const AViewTyp
   static_assert(BViewType::rank <= 2, "KokkosBatched::gemm: BViewType must have rank 0, 1 or 2.");
   static_assert(CViewType::rank <= 2, "KokkosBatched::gemm: CViewType must have rank 0, 1 or 2.");
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   const int m = C.extent(0), n = C.extent(1);
   const int lda = A.extent(0);
   const int ldb = B.extent(0);

--- a/batched/dense/impl/KokkosBatched_Gemm_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemm_Serial_Impl.hpp
@@ -21,7 +21,7 @@ KOKKOS_INLINE_FUNCTION static int checkGemmInput([[maybe_unused]] const AViewTyp
   static_assert(BViewType::rank <= 2, "KokkosBatched::gemm: BViewType must have rank 0, 1 or 2.");
   static_assert(CViewType::rank <= 2, "KokkosBatched::gemm: CViewType must have rank 0, 1 or 2.");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   const int m = C.extent(0), n = C.extent(1);
   const int lda = A.extent(0);
   const int ldb = B.extent(0);

--- a/batched/dense/impl/KokkosBatched_Ger_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Ger_Serial_Impl.hpp
@@ -19,7 +19,7 @@ KOKKOS_INLINE_FUNCTION static int checkGerInput([[maybe_unused]] const XViewType
   static_assert(XViewType::rank == 1, "KokkosBatched::ger: XViewType must have rank 1.");
   static_assert(YViewType::rank == 1, "KokkosBatched::ger: YViewType must have rank 1.");
   static_assert(AViewType::rank == 2, "KokkosBatched::ger: AViewType must have rank 2.");
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   const int lda = A.extent_int(0), n = A.extent_int(1);
   const int m = x.extent_int(0);
   if (m < 0) {

--- a/batched/dense/impl/KokkosBatched_Ger_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Ger_Serial_Impl.hpp
@@ -19,7 +19,7 @@ KOKKOS_INLINE_FUNCTION static int checkGerInput([[maybe_unused]] const XViewType
   static_assert(XViewType::rank == 1, "KokkosBatched::ger: XViewType must have rank 1.");
   static_assert(YViewType::rank == 1, "KokkosBatched::ger: YViewType must have rank 1.");
   static_assert(AViewType::rank == 2, "KokkosBatched::ger: AViewType must have rank 2.");
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   const int lda = A.extent_int(0), n = A.extent_int(1);
   const int m = x.extent_int(0);
   if (m < 0) {

--- a/batched/dense/impl/KokkosBatched_Gesv_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gesv_Impl.hpp
@@ -334,7 +334,6 @@ struct SerialGesv<Gesv::StaticPivoting> {
   template <typename MatrixType, typename XVectorType, typename YVectorType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MatrixType A, const XVectorType X, const YVectorType Y,
                                            const MatrixType tmp) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<MatrixType>::value, "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<XVectorType>::value, "KokkosBatched::gesv: XVectorType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<YVectorType>::value, "KokkosBatched::gesv: YVectorType is not a Kokkos::View.");
@@ -342,8 +341,8 @@ struct SerialGesv<Gesv::StaticPivoting> {
     static_assert(XVectorType::rank == 1, "KokkosBatched::gesv: XVectorType must have rank 1.");
     static_assert(YVectorType::rank == 1, "KokkosBatched::gesv: YVectorType must have rank 1.");
 
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
-
     if (A.extent(0) != tmp.extent(0) || A.extent(1) + 4 != tmp.extent(1)) {
       Kokkos::printf(
           "KokkosBatched::gesv: dimensions of A and tmp do not match: A: "
@@ -397,7 +396,6 @@ struct SerialGesv<Gesv::NoPivoting> {
   template <typename MatrixType, typename XVectorType, typename YVectorType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MatrixType A, const XVectorType X, const YVectorType Y,
                                            const MatrixType /*tmp*/) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<MatrixType>::value, "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<XVectorType>::value, "KokkosBatched::gesv: XVectorType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<YVectorType>::value, "KokkosBatched::gesv: YVectorType is not a Kokkos::View.");
@@ -405,8 +403,8 @@ struct SerialGesv<Gesv::NoPivoting> {
     static_assert(XVectorType::rank == 1, "KokkosBatched::gesv: XVectorType must have rank 1.");
     static_assert(YVectorType::rank == 1, "KokkosBatched::gesv: YVectorType must have rank 1.");
 
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
-
     if (A.extent(0) != X.extent(0) || A.extent(1) != X.extent(0) || A.extent(0) != Y.extent(0)) {
       Kokkos::printf(
           "KokkosBatched::gesv: dimensions of A and X and Y do not match: A: "
@@ -441,12 +439,12 @@ struct TeamGesv<MemberType, Gesv::StaticPivoting> {
   template <typename MatrixType, typename VectorType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const MatrixType A, const VectorType X,
                                            const VectorType Y) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<MatrixType>::value, "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<VectorType>::value, "KokkosBatched::gesv: VectorType is not a Kokkos::View.");
     static_assert(MatrixType::rank == 2, "KokkosBatched::gesv: MatrixType must have rank 2.");
     static_assert(VectorType::rank == 1, "KokkosBatched::gesv: VectorType must have rank 1.");
 
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != X.extent(0) || A.extent(1) != X.extent(0) || A.extent(0) != Y.extent(0)) {
       Kokkos::printf(
@@ -505,12 +503,12 @@ struct TeamGesv<MemberType, Gesv::NoPivoting> {
   template <typename MatrixType, typename VectorType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const MatrixType A, const VectorType X,
                                            const VectorType Y) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<MatrixType>::value, "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<VectorType>::value, "KokkosBatched::gesv: VectorType is not a Kokkos::View.");
     static_assert(MatrixType::rank == 2, "KokkosBatched::gesv: MatrixType must have rank 2.");
     static_assert(VectorType::rank == 1, "KokkosBatched::gesv: VectorType must have rank 1.");
 
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != X.extent(0) || A.extent(1) != X.extent(0) || A.extent(0) != Y.extent(0)) {
       Kokkos::printf(
@@ -554,12 +552,12 @@ struct TeamVectorGesv<MemberType, Gesv::StaticPivoting> {
   template <typename MatrixType, typename VectorType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const MatrixType A, const VectorType X,
                                            const VectorType Y) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<MatrixType>::value, "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<VectorType>::value, "KokkosBatched::gesv: VectorType is not a Kokkos::View.");
     static_assert(MatrixType::rank == 2, "KokkosBatched::gesv: MatrixType must have rank 2.");
     static_assert(VectorType::rank == 1, "KokkosBatched::gesv: VectorType must have rank 1.");
 
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != X.extent(0) || A.extent(1) != X.extent(0) || A.extent(0) != Y.extent(0)) {
       Kokkos::printf(
@@ -619,12 +617,12 @@ struct TeamVectorGesv<MemberType, Gesv::NoPivoting> {
   template <typename MatrixType, typename VectorType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const MatrixType A, const VectorType X,
                                            const VectorType Y) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<MatrixType>::value, "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<VectorType>::value, "KokkosBatched::gesv: VectorType is not a Kokkos::View.");
     static_assert(MatrixType::rank == 2, "KokkosBatched::gesv: MatrixType must have rank 2.");
     static_assert(VectorType::rank == 1, "KokkosBatched::gesv: VectorType must have rank 1.");
 
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (A.extent(0) != X.extent(0) || A.extent(1) != X.extent(0) || A.extent(0) != Y.extent(0)) {
       Kokkos::printf(

--- a/batched/dense/impl/KokkosBatched_Gesv_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Gesv_Impl.hpp
@@ -334,7 +334,7 @@ struct SerialGesv<Gesv::StaticPivoting> {
   template <typename MatrixType, typename XVectorType, typename YVectorType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MatrixType A, const XVectorType X, const YVectorType Y,
                                            const MatrixType tmp) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<MatrixType>::value, "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<XVectorType>::value, "KokkosBatched::gesv: XVectorType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<YVectorType>::value, "KokkosBatched::gesv: YVectorType is not a Kokkos::View.");
@@ -397,7 +397,7 @@ struct SerialGesv<Gesv::NoPivoting> {
   template <typename MatrixType, typename XVectorType, typename YVectorType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MatrixType A, const XVectorType X, const YVectorType Y,
                                            const MatrixType /*tmp*/) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<MatrixType>::value, "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<XVectorType>::value, "KokkosBatched::gesv: XVectorType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<YVectorType>::value, "KokkosBatched::gesv: YVectorType is not a Kokkos::View.");
@@ -441,7 +441,7 @@ struct TeamGesv<MemberType, Gesv::StaticPivoting> {
   template <typename MatrixType, typename VectorType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const MatrixType A, const VectorType X,
                                            const VectorType Y) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<MatrixType>::value, "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<VectorType>::value, "KokkosBatched::gesv: VectorType is not a Kokkos::View.");
     static_assert(MatrixType::rank == 2, "KokkosBatched::gesv: MatrixType must have rank 2.");
@@ -505,7 +505,7 @@ struct TeamGesv<MemberType, Gesv::NoPivoting> {
   template <typename MatrixType, typename VectorType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const MatrixType A, const VectorType X,
                                            const VectorType Y) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<MatrixType>::value, "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<VectorType>::value, "KokkosBatched::gesv: VectorType is not a Kokkos::View.");
     static_assert(MatrixType::rank == 2, "KokkosBatched::gesv: MatrixType must have rank 2.");
@@ -554,7 +554,7 @@ struct TeamVectorGesv<MemberType, Gesv::StaticPivoting> {
   template <typename MatrixType, typename VectorType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const MatrixType A, const VectorType X,
                                            const VectorType Y) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<MatrixType>::value, "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<VectorType>::value, "KokkosBatched::gesv: VectorType is not a Kokkos::View.");
     static_assert(MatrixType::rank == 2, "KokkosBatched::gesv: MatrixType must have rank 2.");
@@ -619,7 +619,7 @@ struct TeamVectorGesv<MemberType, Gesv::NoPivoting> {
   template <typename MatrixType, typename VectorType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const MatrixType A, const VectorType X,
                                            const VectorType Y) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<MatrixType>::value, "KokkosBatched::gesv: MatrixType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<VectorType>::value, "KokkosBatched::gesv: VectorType is not a Kokkos::View.");
     static_assert(MatrixType::rank == 2, "KokkosBatched::gesv: MatrixType must have rank 2.");

--- a/batched/dense/impl/KokkosBatched_Getrf_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Getrf_Serial_Impl.hpp
@@ -16,7 +16,7 @@ KOKKOS_INLINE_FUNCTION static int checkGetrfInput([[maybe_unused]] const AViewTy
   static_assert(Kokkos::is_view_v<PivViewType>, "KokkosBatched::getrf: PivViewType is not a Kokkos::View.");
   static_assert(AViewType::rank == 2, "KokkosBatched::getrf: AViewType must have rank 2.");
   static_assert(PivViewType::rank == 1, "KokkosBatched::getrf: PivViewType must have rank 1.");
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   const int m = A.extent(0), n = A.extent(1);
   const int npiv = ipiv.extent(0);
   if (npiv != Kokkos::min(m, n)) {

--- a/batched/dense/impl/KokkosBatched_Getrf_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Getrf_Serial_Impl.hpp
@@ -16,7 +16,7 @@ KOKKOS_INLINE_FUNCTION static int checkGetrfInput([[maybe_unused]] const AViewTy
   static_assert(Kokkos::is_view_v<PivViewType>, "KokkosBatched::getrf: PivViewType is not a Kokkos::View.");
   static_assert(AViewType::rank == 2, "KokkosBatched::getrf: AViewType must have rank 2.");
   static_assert(PivViewType::rank == 1, "KokkosBatched::getrf: PivViewType must have rank 1.");
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   const int m = A.extent(0), n = A.extent(1);
   const int npiv = ipiv.extent(0);
   if (npiv != Kokkos::min(m, n)) {

--- a/batched/dense/impl/KokkosBatched_Getrf_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Getrf_Serial_Internal.hpp
@@ -28,7 +28,7 @@ struct Stack {
 
   KOKKOS_INLINE_FUNCTION
   void push(int values[]) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     if (m_top >= STACK_SIZE - 1) {
       Kokkos::printf("Stack overflow: Cannot push, the stack is full.\n");
       return;
@@ -43,7 +43,7 @@ struct Stack {
 
   KOKKOS_INLINE_FUNCTION
   void pop(int values[]) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     if (m_top < 0) {
       // Check if the stack is empty
       Kokkos::printf("Stack underflow: Cannot pop, the stack is empty.");

--- a/batched/dense/impl/KokkosBatched_Getrf_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Getrf_Serial_Internal.hpp
@@ -28,7 +28,7 @@ struct Stack {
 
   KOKKOS_INLINE_FUNCTION
   void push(int values[]) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     if (m_top >= STACK_SIZE - 1) {
       Kokkos::printf("Stack overflow: Cannot push, the stack is full.\n");
       return;
@@ -43,7 +43,7 @@ struct Stack {
 
   KOKKOS_INLINE_FUNCTION
   void pop(int values[]) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     if (m_top < 0) {
       // Check if the stack is empty
       Kokkos::printf("Stack underflow: Cannot pop, the stack is empty.");

--- a/batched/dense/impl/KokkosBatched_Getrs_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Getrs_Serial_Impl.hpp
@@ -16,7 +16,7 @@ KOKKOS_INLINE_FUNCTION static int checkGetrsInput([[maybe_unused]] const AViewTy
   static_assert(Kokkos::is_view_v<BViewType>, "KokkosBatched::getrs: BViewType is not a Kokkos::View.");
   static_assert(AViewType::rank == 2, "KokkosBatched::getrs: AViewType must have rank 2.");
   static_assert(BViewType::rank == 1, "KokkosBatched::getrs: BViewType must have rank 1.");
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   const int lda = A.extent(0), n = A.extent(1);
   if (lda < Kokkos::max(1, n)) {
     Kokkos::printf(

--- a/batched/dense/impl/KokkosBatched_Getrs_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Getrs_Serial_Impl.hpp
@@ -16,7 +16,7 @@ KOKKOS_INLINE_FUNCTION static int checkGetrsInput([[maybe_unused]] const AViewTy
   static_assert(Kokkos::is_view_v<BViewType>, "KokkosBatched::getrs: BViewType is not a Kokkos::View.");
   static_assert(AViewType::rank == 2, "KokkosBatched::getrs: AViewType must have rank 2.");
   static_assert(BViewType::rank == 1, "KokkosBatched::getrs: BViewType must have rank 1.");
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   const int lda = A.extent(0), n = A.extent(1);
   if (lda < Kokkos::max(1, n)) {
     Kokkos::printf(

--- a/batched/dense/impl/KokkosBatched_HadamardProduct_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_HadamardProduct_Impl.hpp
@@ -68,7 +68,6 @@ struct TeamVectorHadamardProductInternal {
 /// ===========
 template <typename XViewType, typename YViewType, typename VViewType>
 KOKKOS_INLINE_FUNCTION int SerialHadamardProduct::invoke(const XViewType& X, const YViewType& Y, const VViewType& V) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::HadamardProduct: XViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::HadamardProduct: YViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<VViewType>::value, "KokkosBatched::HadamardProduct: VViewType is not a Kokkos::View.");
@@ -76,6 +75,7 @@ KOKKOS_INLINE_FUNCTION int SerialHadamardProduct::invoke(const XViewType& X, con
   static_assert(YViewType::rank == 2, "KokkosBatched::HadamardProduct: YViewType must have rank 2.");
   static_assert(VViewType::rank == 2, "KokkosBatched::HadamardProduct: VViewType must have rank 2.");
 
+#ifndef NDEBUG
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
     Kokkos::printf(
@@ -108,7 +108,6 @@ template <typename MemberType>
 template <typename XViewType, typename YViewType, typename VViewType>
 KOKKOS_INLINE_FUNCTION int TeamHadamardProduct<MemberType>::invoke(const MemberType& member, const XViewType& X,
                                                                    const YViewType& Y, const VViewType& V) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::HadamardProduct: XViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::HadamardProduct: YViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<VViewType>::value, "KokkosBatched::HadamardProduct: VViewType is not a Kokkos::View.");
@@ -116,6 +115,7 @@ KOKKOS_INLINE_FUNCTION int TeamHadamardProduct<MemberType>::invoke(const MemberT
   static_assert(YViewType::rank == 2, "KokkosBatched::HadamardProduct: YViewType must have rank 2.");
   static_assert(VViewType::rank == 2, "KokkosBatched::HadamardProduct: VViewType must have rank 2.");
 
+#ifndef NDEBUG
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
     Kokkos::printf(
@@ -149,7 +149,6 @@ template <typename MemberType>
 template <typename XViewType, typename YViewType, typename VViewType>
 KOKKOS_INLINE_FUNCTION int TeamVectorHadamardProduct<MemberType>::invoke(const MemberType& member, const XViewType& X,
                                                                          const YViewType& Y, const VViewType& V) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::HadamardProduct: XViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::HadamardProduct: YViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<VViewType>::value, "KokkosBatched::HadamardProduct: VViewType is not a Kokkos::View.");
@@ -157,6 +156,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorHadamardProduct<MemberType>::invoke(const M
   static_assert(YViewType::rank == 2, "KokkosBatched::HadamardProduct: YViewType must have rank 2.");
   static_assert(VViewType::rank == 2, "KokkosBatched::HadamardProduct: VViewType must have rank 2.");
 
+#ifndef NDEBUG
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
     Kokkos::printf(

--- a/batched/dense/impl/KokkosBatched_HadamardProduct_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_HadamardProduct_Impl.hpp
@@ -68,7 +68,7 @@ struct TeamVectorHadamardProductInternal {
 /// ===========
 template <typename XViewType, typename YViewType, typename VViewType>
 KOKKOS_INLINE_FUNCTION int SerialHadamardProduct::invoke(const XViewType& X, const YViewType& Y, const VViewType& V) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::HadamardProduct: XViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::HadamardProduct: YViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<VViewType>::value, "KokkosBatched::HadamardProduct: VViewType is not a Kokkos::View.");
@@ -108,7 +108,7 @@ template <typename MemberType>
 template <typename XViewType, typename YViewType, typename VViewType>
 KOKKOS_INLINE_FUNCTION int TeamHadamardProduct<MemberType>::invoke(const MemberType& member, const XViewType& X,
                                                                    const YViewType& Y, const VViewType& V) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::HadamardProduct: XViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::HadamardProduct: YViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<VViewType>::value, "KokkosBatched::HadamardProduct: VViewType is not a Kokkos::View.");
@@ -149,7 +149,7 @@ template <typename MemberType>
 template <typename XViewType, typename YViewType, typename VViewType>
 KOKKOS_INLINE_FUNCTION int TeamVectorHadamardProduct<MemberType>::invoke(const MemberType& member, const XViewType& X,
                                                                          const YViewType& Y, const VViewType& V) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::HadamardProduct: XViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::HadamardProduct: YViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<VViewType>::value, "KokkosBatched::HadamardProduct: VViewType is not a Kokkos::View.");

--- a/batched/dense/impl/KokkosBatched_Laswp_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Laswp_Serial_Impl.hpp
@@ -13,13 +13,14 @@ namespace KokkosBatched {
 namespace Impl {
 
 template <typename PivViewType, typename AViewType>
-KOKKOS_INLINE_FUNCTION static int checkLaswpInput(const PivViewType &piv, const AViewType &A) {
+KOKKOS_INLINE_FUNCTION static int checkLaswpInput([[maybe_unused]] const PivViewType &piv,
+                                                  [[maybe_unused]] const AViewType &A) {
   static_assert(Kokkos::is_view_v<PivViewType>, "KokkosBatched::laswp: PivViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view_v<AViewType>, "KokkosBatched::laswp: AViewType is not a Kokkos::View.");
   static_assert(AViewType::rank == 1 || AViewType::rank == 2, "KokkosBatched::laswp: AViewType must have rank 1 or 2.");
   static_assert(PivViewType::rank == 1, "KokkosBatched::laswp: PivViewType must have rank 1.");
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   const int npiv = piv.extent(0);
   const int lda  = A.extent(0);
   if (npiv > lda) {

--- a/batched/dense/impl/KokkosBatched_Laswp_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Laswp_Serial_Impl.hpp
@@ -20,7 +20,7 @@ KOKKOS_INLINE_FUNCTION static int checkLaswpInput([[maybe_unused]] const PivView
   static_assert(AViewType::rank == 1 || AViewType::rank == 2, "KokkosBatched::laswp: AViewType must have rank 1 or 2.");
   static_assert(PivViewType::rank == 1, "KokkosBatched::laswp: PivViewType must have rank 1.");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   const int npiv = piv.extent(0);
   const int lda  = A.extent(0);
   if (npiv > lda) {

--- a/batched/dense/impl/KokkosBatched_Pbtrf_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pbtrf_Serial_Impl.hpp
@@ -15,7 +15,7 @@ KOKKOS_INLINE_FUNCTION static int checkPbtrfInput([[maybe_unused]] const ABViewT
   static_assert(Kokkos::is_view_v<ABViewType>, "KokkosBatched::pbtrf: ABViewType is not a Kokkos::View.");
   static_assert(ABViewType::rank == 2, "KokkosBatched::pbtrf: ABViewType must have rank 2.");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   const int kd = Ab.extent(0) - 1;
   if (kd < 0) {
     Kokkos::printf(

--- a/batched/dense/impl/KokkosBatched_Pbtrf_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pbtrf_Serial_Impl.hpp
@@ -15,7 +15,7 @@ KOKKOS_INLINE_FUNCTION static int checkPbtrfInput([[maybe_unused]] const ABViewT
   static_assert(Kokkos::is_view_v<ABViewType>, "KokkosBatched::pbtrf: ABViewType is not a Kokkos::View.");
   static_assert(ABViewType::rank == 2, "KokkosBatched::pbtrf: ABViewType must have rank 2.");
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   const int kd = Ab.extent(0) - 1;
   if (kd < 0) {
     Kokkos::printf(

--- a/batched/dense/impl/KokkosBatched_Pbtrf_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Pbtrf_Serial_Internal.hpp
@@ -39,7 +39,7 @@ KOKKOS_INLINE_FUNCTION int SerialPbtrfInternalLower<Algo::Pbtrf::Unblocked>::inv
     auto a_jj = KokkosKernels::ArithTraits<ValueType>::real(AB[0 * as0 + j * as1]);
 
     // Check if L (j, j) is positive definite
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     if (a_jj <= 0) {
       return j + 1;
     }
@@ -92,7 +92,7 @@ KOKKOS_INLINE_FUNCTION int SerialPbtrfInternalUpper<Algo::Pbtrf::Unblocked>::inv
     auto a_jj = KokkosKernels::ArithTraits<ValueType>::real(AB[kd * as0 + j * as1]);
 
     // Check if U (j,j) is positive definite
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     if (a_jj <= 0) {
       return j + 1;
     }

--- a/batched/dense/impl/KokkosBatched_Pbtrf_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Pbtrf_Serial_Internal.hpp
@@ -39,7 +39,7 @@ KOKKOS_INLINE_FUNCTION int SerialPbtrfInternalLower<Algo::Pbtrf::Unblocked>::inv
     auto a_jj = KokkosKernels::ArithTraits<ValueType>::real(AB[0 * as0 + j * as1]);
 
     // Check if L (j, j) is positive definite
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     if (a_jj <= 0) {
       return j + 1;
     }
@@ -92,7 +92,7 @@ KOKKOS_INLINE_FUNCTION int SerialPbtrfInternalUpper<Algo::Pbtrf::Unblocked>::inv
     auto a_jj = KokkosKernels::ArithTraits<ValueType>::real(AB[kd * as0 + j * as1]);
 
     // Check if U (j,j) is positive definite
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     if (a_jj <= 0) {
       return j + 1;
     }

--- a/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Impl.hpp
@@ -19,7 +19,7 @@ KOKKOS_INLINE_FUNCTION static int checkPbtrsInput([[maybe_unused]] const AViewTy
   static_assert(AViewType::rank == 2, "KokkosBatched::pbtrs: AViewType must have rank 2.");
   static_assert(XViewType::rank == 1, "KokkosBatched::pbtrs: XViewType must have rank 1.");
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   const int ldb = x.extent(0);
   const int lda = A.extent(0), n = A.extent(1);
   const int kd = lda - 1;

--- a/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pbtrs_Serial_Impl.hpp
@@ -19,7 +19,7 @@ KOKKOS_INLINE_FUNCTION static int checkPbtrsInput([[maybe_unused]] const AViewTy
   static_assert(AViewType::rank == 2, "KokkosBatched::pbtrs: AViewType must have rank 2.");
   static_assert(XViewType::rank == 1, "KokkosBatched::pbtrs: XViewType must have rank 1.");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   const int ldb = x.extent(0);
   const int lda = A.extent(0), n = A.extent(1);
   const int kd = lda - 1;

--- a/batched/dense/impl/KokkosBatched_Pttrf_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrf_Serial_Impl.hpp
@@ -19,7 +19,7 @@ KOKKOS_INLINE_FUNCTION static int checkPttrfInput([[maybe_unused]] const DViewTy
   static_assert(DViewType::rank == 1, "KokkosBatched::pttrf: DViewType must have rank 1.");
   static_assert(EViewType::rank == 1, "KokkosBatched::pttrf: EViewType must have rank 1.");
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   const int nd = d.extent(0);
   const int ne = e.extent(0);
 

--- a/batched/dense/impl/KokkosBatched_Pttrf_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrf_Serial_Impl.hpp
@@ -19,7 +19,7 @@ KOKKOS_INLINE_FUNCTION static int checkPttrfInput([[maybe_unused]] const DViewTy
   static_assert(DViewType::rank == 1, "KokkosBatched::pttrf: DViewType must have rank 1.");
   static_assert(EViewType::rank == 1, "KokkosBatched::pttrf: EViewType must have rank 1.");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   const int nd = d.extent(0);
   const int ne = e.extent(0);
 

--- a/batched/dense/impl/KokkosBatched_Pttrf_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrf_Serial_Internal.hpp
@@ -28,7 +28,6 @@ template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
     const int n, ValueType *KOKKOS_RESTRICT d, const int ds0, ValueType *KOKKOS_RESTRICT e, const int es0) {
-
   auto update = [&](const int i) {
     auto ei_tmp = e[i * es0];
     e[i * es0]  = ei_tmp / d[i * ds0];
@@ -101,7 +100,6 @@ template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
     const int n, ValueType *KOKKOS_RESTRICT d, const int ds0, Kokkos::complex<ValueType> *KOKKOS_RESTRICT e,
     const int es0) {
-
   auto update = [&](const int i) {
     auto eir_tmp     = e[i * es0].real();
     auto eii_tmp     = e[i * es0].imag();

--- a/batched/dense/impl/KokkosBatched_Pttrf_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrf_Serial_Internal.hpp
@@ -28,7 +28,13 @@ template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
     const int n, ValueType *KOKKOS_RESTRICT d, const int ds0, ValueType *KOKKOS_RESTRICT e, const int es0) {
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   int info = 0;
+
+  auto check_positive_definitiveness = [&](const int i) {
+    return (d[i] <= KokkosKernels::ArithTraits<ValueType>::zero()) ? (i + 1) : 0;
+  };
+#endif
 
   auto update = [&](const int i) {
     auto ei_tmp = e[i * es0];
@@ -36,14 +42,10 @@ KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
     d[(i + 1) * ds0] -= e[i * es0] * ei_tmp;
   };
 
-  auto check_positive_definitiveness = [&](const int i) {
-    return (d[i] <= KokkosKernels::ArithTraits<ValueType>::zero()) ? (i + 1) : 0;
-  };
-
   // Compute the L*D*L' (or U'*D*U) factorization of A.
   const int i4 = (n - 1) % 4;
   for (int i = 0; i < i4; i++) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     info = check_positive_definitiveness(i);
     if (info) return info;
 #endif
@@ -52,28 +54,28 @@ KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
   }  // for (int i = 0; i < i4; i++)
 
   for (int i = i4; i < n - 4; i += 4) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     info = check_positive_definitiveness(i);
     if (info) return info;
 #endif
 
     update(i);
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     info = check_positive_definitiveness(i + 1);
     if (info) return info;
 #endif
 
     update(i + 1);
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     info = check_positive_definitiveness(i + 2);
     if (info) return info;
 #endif
 
     update(i + 2);
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     info = check_positive_definitiveness(i + 3);
     if (info) return info;
 #endif
@@ -81,7 +83,7 @@ KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
     update(i + 3);
   }  // for (int i = i4; i < n-4; 4)
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   info = check_positive_definitiveness(n - 1);
   if (info) return info;
 #endif
@@ -98,7 +100,13 @@ template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
     const int n, ValueType *KOKKOS_RESTRICT d, const int ds0, Kokkos::complex<ValueType> *KOKKOS_RESTRICT e,
     const int es0) {
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   int info = 0;
+
+  auto check_positive_definitiveness = [&](const int i) {
+    return (d[i] <= KokkosKernels::ArithTraits<ValueType>::zero()) ? (i + 1) : 0;
+  };
+#endif
 
   auto update = [&](const int i) {
     auto eir_tmp     = e[i * es0].real();
@@ -109,14 +117,10 @@ KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
     d[(i + 1) * ds0] = d[(i + 1) * ds0] - f_tmp * eir_tmp - g_tmp * eii_tmp;
   };
 
-  auto check_positive_definitiveness = [&](const int i) {
-    return (d[i] <= KokkosKernels::ArithTraits<ValueType>::zero()) ? (i + 1) : 0;
-  };
-
   // Compute the L*D*L' (or U'*D*U) factorization of A.
   const int i4 = (n - 1) % 4;
   for (int i = 0; i < i4; i++) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     info = check_positive_definitiveness(i);
     if (info) return info;
 #endif
@@ -125,28 +129,28 @@ KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
   }  // for (int i = 0; i < i4; i++)
 
   for (int i = i4; i < n - 4; i += 4) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     info = check_positive_definitiveness(i);
     if (info) return info;
 #endif
 
     update(i);
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     info = check_positive_definitiveness(i + 1);
     if (info) return info;
 #endif
 
     update(i + 1);
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     info = check_positive_definitiveness(i + 2);
     if (info) return info;
 #endif
 
     update(i + 2);
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     info = check_positive_definitiveness(i + 3);
     if (info) return info;
 #endif
@@ -154,7 +158,7 @@ KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
     update(i + 3);
   }  // for (int i = i4; i < n-4; 4)
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   info = check_positive_definitiveness(n - 1);
   if (info) return info;
 #endif

--- a/batched/dense/impl/KokkosBatched_Pttrf_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrf_Serial_Internal.hpp
@@ -28,6 +28,13 @@ template <>
 template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
     const int n, ValueType *KOKKOS_RESTRICT d, const int ds0, ValueType *KOKKOS_RESTRICT e, const int es0) {
+
+  auto update = [&](const int i) {
+    auto ei_tmp = e[i * es0];
+    e[i * es0]  = ei_tmp / d[i * ds0];
+    d[(i + 1) * ds0] -= e[i * es0] * ei_tmp;
+  };
+
 #ifdef HAVE_KOKKOSKERNELS_DEBUG
   int info = 0;
 
@@ -35,12 +42,6 @@ KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
     return (d[i] <= KokkosKernels::ArithTraits<ValueType>::zero()) ? (i + 1) : 0;
   };
 #endif
-
-  auto update = [&](const int i) {
-    auto ei_tmp = e[i * es0];
-    e[i * es0]  = ei_tmp / d[i * ds0];
-    d[(i + 1) * ds0] -= e[i * es0] * ei_tmp;
-  };
 
   // Compute the L*D*L' (or U'*D*U) factorization of A.
   const int i4 = (n - 1) % 4;
@@ -100,13 +101,6 @@ template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
     const int n, ValueType *KOKKOS_RESTRICT d, const int ds0, Kokkos::complex<ValueType> *KOKKOS_RESTRICT e,
     const int es0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
-  int info = 0;
-
-  auto check_positive_definitiveness = [&](const int i) {
-    return (d[i] <= KokkosKernels::ArithTraits<ValueType>::zero()) ? (i + 1) : 0;
-  };
-#endif
 
   auto update = [&](const int i) {
     auto eir_tmp     = e[i * es0].real();
@@ -116,6 +110,14 @@ KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
     e[i * es0]       = Kokkos::complex<ValueType>(f_tmp, g_tmp);
     d[(i + 1) * ds0] = d[(i + 1) * ds0] - f_tmp * eir_tmp - g_tmp * eii_tmp;
   };
+
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
+  int info = 0;
+
+  auto check_positive_definitiveness = [&](const int i) {
+    return (d[i] <= KokkosKernels::ArithTraits<ValueType>::zero()) ? (i + 1) : 0;
+  };
+#endif
 
   // Compute the L*D*L' (or U'*D*U) factorization of A.
   const int i4 = (n - 1) % 4;

--- a/batched/dense/impl/KokkosBatched_Pttrf_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrf_Serial_Internal.hpp
@@ -35,7 +35,7 @@ KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
     d[(i + 1) * ds0] -= e[i * es0] * ei_tmp;
   };
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   int info = 0;
 
   auto check_positive_definitiveness = [&](const int i) {
@@ -46,7 +46,7 @@ KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
   // Compute the L*D*L' (or U'*D*U) factorization of A.
   const int i4 = (n - 1) % 4;
   for (int i = 0; i < i4; i++) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     info = check_positive_definitiveness(i);
     if (info) return info;
 #endif
@@ -55,28 +55,28 @@ KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
   }  // for (int i = 0; i < i4; i++)
 
   for (int i = i4; i < n - 4; i += 4) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     info = check_positive_definitiveness(i);
     if (info) return info;
 #endif
 
     update(i);
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     info = check_positive_definitiveness(i + 1);
     if (info) return info;
 #endif
 
     update(i + 1);
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     info = check_positive_definitiveness(i + 2);
     if (info) return info;
 #endif
 
     update(i + 2);
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     info = check_positive_definitiveness(i + 3);
     if (info) return info;
 #endif
@@ -84,7 +84,7 @@ KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
     update(i + 3);
   }  // for (int i = i4; i < n-4; 4)
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   info = check_positive_definitiveness(n - 1);
   if (info) return info;
 #endif
@@ -111,7 +111,7 @@ KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
     d[(i + 1) * ds0] = d[(i + 1) * ds0] - f_tmp * eir_tmp - g_tmp * eii_tmp;
   };
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   int info = 0;
 
   auto check_positive_definitiveness = [&](const int i) {
@@ -122,7 +122,7 @@ KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
   // Compute the L*D*L' (or U'*D*U) factorization of A.
   const int i4 = (n - 1) % 4;
   for (int i = 0; i < i4; i++) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     info = check_positive_definitiveness(i);
     if (info) return info;
 #endif
@@ -131,28 +131,28 @@ KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
   }  // for (int i = 0; i < i4; i++)
 
   for (int i = i4; i < n - 4; i += 4) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     info = check_positive_definitiveness(i);
     if (info) return info;
 #endif
 
     update(i);
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     info = check_positive_definitiveness(i + 1);
     if (info) return info;
 #endif
 
     update(i + 1);
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     info = check_positive_definitiveness(i + 2);
     if (info) return info;
 #endif
 
     update(i + 2);
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     info = check_positive_definitiveness(i + 3);
     if (info) return info;
 #endif
@@ -160,7 +160,7 @@ KOKKOS_INLINE_FUNCTION int SerialPttrfInternal<Algo::Pttrf::Unblocked>::invoke(
     update(i + 3);
   }  // for (int i = i4; i < n-4; 4)
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   info = check_positive_definitiveness(n - 1);
   if (info) return info;
 #endif

--- a/batched/dense/impl/KokkosBatched_Pttrs_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrs_Serial_Impl.hpp
@@ -26,7 +26,7 @@ KOKKOS_INLINE_FUNCTION static int checkPttrsInput([[maybe_unused]] const DViewTy
   static_assert(std::is_same_v<typename BViewType::value_type, typename BViewType::non_const_value_type>,
                 "KokkosBatched::pttrs: BViewType must have non-const value type.");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   const int nd  = d.extent_int(0);
   const int ne  = e.extent_int(0);
   const int ldb = b.extent_int(0);

--- a/batched/dense/impl/KokkosBatched_Pttrs_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Pttrs_Serial_Impl.hpp
@@ -26,7 +26,7 @@ KOKKOS_INLINE_FUNCTION static int checkPttrsInput([[maybe_unused]] const DViewTy
   static_assert(std::is_same_v<typename BViewType::value_type, typename BViewType::non_const_value_type>,
                 "KokkosBatched::pttrs: BViewType must have non-const value type.");
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   const int nd  = d.extent_int(0);
   const int ne  = e.extent_int(0);
   const int ldb = b.extent_int(0);

--- a/batched/dense/impl/KokkosBatched_QR_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_QR_Serial_Impl.hpp
@@ -27,7 +27,7 @@ KOKKOS_INLINE_FUNCTION int SerialQR<Algo::QR::Unblocked>::invoke(const AViewType
   static_assert(Kokkos::is_view_v<wViewType>, "KokkosBatched::SerialQR::invoke: wViewType must be a Kokkos::View");
   static_assert(wViewType::rank() == 1, "KokkosBatched::SerialQR::invoke: wViewType must have rank 1");
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   if (!w.span_is_contiguous()) {
     Kokkos::printf("KokkosBatched::SerialQR::invoke: w must have a contiguous span.");
     return 1;

--- a/batched/dense/impl/KokkosBatched_QR_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_QR_Serial_Impl.hpp
@@ -27,7 +27,7 @@ KOKKOS_INLINE_FUNCTION int SerialQR<Algo::QR::Unblocked>::invoke(const AViewType
   static_assert(Kokkos::is_view_v<wViewType>, "KokkosBatched::SerialQR::invoke: wViewType must be a Kokkos::View");
   static_assert(wViewType::rank() == 1, "KokkosBatched::SerialQR::invoke: wViewType must have rank 1");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   if (!w.span_is_contiguous()) {
     Kokkos::printf("KokkosBatched::SerialQR::invoke: w must have a contiguous span.");
     return 1;

--- a/batched/dense/impl/KokkosBatched_Syr_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Syr_Serial_Impl.hpp
@@ -17,7 +17,7 @@ KOKKOS_INLINE_FUNCTION static int checkSyrInput([[maybe_unused]] const XViewType
   static_assert(Kokkos::is_view_v<AViewType>, "KokkosBatched::syr: AViewType is not a Kokkos::View.");
   static_assert(XViewType::rank == 1, "KokkosBatched::syr: XViewType must have rank 1.");
   static_assert(AViewType::rank == 2, "KokkosBatched::syr: AViewType must have rank 2.");
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   const int lda = A.extent_int(0), n = A.extent_int(1);
 
   if (n < 0) {

--- a/batched/dense/impl/KokkosBatched_Syr_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Syr_Serial_Impl.hpp
@@ -17,7 +17,7 @@ KOKKOS_INLINE_FUNCTION static int checkSyrInput([[maybe_unused]] const XViewType
   static_assert(Kokkos::is_view_v<AViewType>, "KokkosBatched::syr: AViewType is not a Kokkos::View.");
   static_assert(XViewType::rank == 1, "KokkosBatched::syr: XViewType must have rank 1.");
   static_assert(AViewType::rank == 2, "KokkosBatched::syr: AViewType must have rank 2.");
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   const int lda = A.extent_int(0), n = A.extent_int(1);
 
   if (n < 0) {

--- a/batched/dense/impl/KokkosBatched_Tbsv_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Tbsv_Serial_Impl.hpp
@@ -20,7 +20,7 @@ KOKKOS_INLINE_FUNCTION static int checkTbsvInput([[maybe_unused]] const AViewTyp
   static_assert(AViewType::rank == 2, "KokkosBatched::tbsv: AViewType must have rank 2.");
   static_assert(XViewType::rank == 1, "KokkosBatched::tbsv: XViewType must have rank 1.");
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   if (k < 0) {
     Kokkos::printf(
         "KokkosBatched::tbsv: input parameter k must not be less than 0: k = "

--- a/batched/dense/impl/KokkosBatched_Tbsv_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Tbsv_Serial_Impl.hpp
@@ -20,7 +20,7 @@ KOKKOS_INLINE_FUNCTION static int checkTbsvInput([[maybe_unused]] const AViewTyp
   static_assert(AViewType::rank == 2, "KokkosBatched::tbsv: AViewType must have rank 2.");
   static_assert(XViewType::rank == 1, "KokkosBatched::tbsv: XViewType must have rank 1.");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   if (k < 0) {
     Kokkos::printf(
         "KokkosBatched::tbsv: input parameter k must not be less than 0: k = "

--- a/batched/dense/impl/KokkosBatched_Trsm_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsm_Serial_Impl.hpp
@@ -18,7 +18,7 @@ KOKKOS_INLINE_FUNCTION static int checkTrsmInput([[maybe_unused]] const AViewTyp
   static_assert(Kokkos::is_view_v<BViewType>, "KokkosBatched::trsm: BViewType is not a Kokkos::View.");
   static_assert(AViewType::rank == 2, "KokkosBatched::trsm: AViewType must have rank 2.");
   static_assert(BViewType::rank == 1 || BViewType::rank == 2, "KokkosBatched::trsm: BViewType must have rank 1 or 2.");
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   const int m = B.extent(0), n = B.extent(1);
   const int nrowa = std::is_same_v<ArgSide, Side::Left> ? m : n;
   const int lda   = A.extent(0);

--- a/batched/dense/impl/KokkosBatched_Trsm_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsm_Serial_Impl.hpp
@@ -18,7 +18,7 @@ KOKKOS_INLINE_FUNCTION static int checkTrsmInput([[maybe_unused]] const AViewTyp
   static_assert(Kokkos::is_view_v<BViewType>, "KokkosBatched::trsm: BViewType is not a Kokkos::View.");
   static_assert(AViewType::rank == 2, "KokkosBatched::trsm: AViewType must have rank 2.");
   static_assert(BViewType::rank == 1 || BViewType::rank == 2, "KokkosBatched::trsm: BViewType must have rank 1 or 2.");
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   const int m = B.extent(0), n = B.extent(1);
   const int nrowa = std::is_same_v<ArgSide, Side::Left> ? m : n;
   const int lda   = A.extent(0);

--- a/batched/dense/impl/KokkosBatched_Trsv_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsv_Serial_Impl.hpp
@@ -19,7 +19,7 @@ KOKKOS_INLINE_FUNCTION static int checkTrsvInput([[maybe_unused]] const AViewTyp
                 "KokkosBatched::trsv: AViewType must be either a Kokkos::View or a Kokkos::DynRankView.");
   static_assert(Kokkos::is_view_v<bViewType> || Kokkos::is_dyn_rank_view_v<bViewType>,
                 "KokkosBatched::trsv: bViewType must be either a Kokkos::View or a Kokkos::DynRankView.");
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   if (A.rank() != 2) {
     Kokkos::printf(
         "KokkosBatched::trsv: A must be a rank 2 View."

--- a/batched/dense/impl/KokkosBatched_Trsv_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsv_Serial_Impl.hpp
@@ -19,7 +19,7 @@ KOKKOS_INLINE_FUNCTION static int checkTrsvInput([[maybe_unused]] const AViewTyp
                 "KokkosBatched::trsv: AViewType must be either a Kokkos::View or a Kokkos::DynRankView.");
   static_assert(Kokkos::is_view_v<bViewType> || Kokkos::is_dyn_rank_view_v<bViewType>,
                 "KokkosBatched::trsv: bViewType must be either a Kokkos::View or a Kokkos::DynRankView.");
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   if (A.rank() != 2) {
     Kokkos::printf(
         "KokkosBatched::trsv: A must be a rank 2 View."

--- a/batched/dense/impl/KokkosBatched_Xpay_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Xpay_Impl.hpp
@@ -155,7 +155,7 @@ struct TeamVectorXpayInternal {
 /// ===========
 template <typename ViewType, typename alphaViewType>
 KOKKOS_INLINE_FUNCTION int SerialXpay::invoke(const alphaViewType& alpha, const ViewType& X, const ViewType& Y) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<ViewType>::value, "KokkosBatched::xpay: ViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<alphaViewType>::value, "KokkosBatched::xpay: alphaViewType is not a Kokkos::View.");
   static_assert(ViewType::rank == 2, "KokkosBatched::xpay: ViewType must have rank 2.");
@@ -192,7 +192,7 @@ template <typename MemberType>
 template <typename ViewType, typename alphaViewType>
 KOKKOS_INLINE_FUNCTION int TeamXpay<MemberType>::invoke(const MemberType& member, const alphaViewType& alpha,
                                                         const ViewType& X, const ViewType& Y) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<ViewType>::value, "KokkosBatched::xpay: ViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<alphaViewType>::value, "KokkosBatched::xpay: alphaViewType is not a Kokkos::View.");
   static_assert(ViewType::rank == 2, "KokkosBatched::xpay: ViewType must have rank 2.");
@@ -229,7 +229,7 @@ template <typename MemberType>
 template <typename ViewType, typename alphaViewType>
 KOKKOS_INLINE_FUNCTION int TeamVectorXpay<MemberType>::invoke(const MemberType& member, const alphaViewType& alpha,
                                                               const ViewType& X, const ViewType& Y) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<ViewType>::value, "KokkosBatched::xpay: ViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<alphaViewType>::value, "KokkosBatched::xpay: alphaViewType is not a Kokkos::View.");
   static_assert(ViewType::rank == 2, "KokkosBatched::xpay: ViewType must have rank 2.");

--- a/batched/dense/impl/KokkosBatched_Xpay_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Xpay_Impl.hpp
@@ -155,12 +155,12 @@ struct TeamVectorXpayInternal {
 /// ===========
 template <typename ViewType, typename alphaViewType>
 KOKKOS_INLINE_FUNCTION int SerialXpay::invoke(const alphaViewType& alpha, const ViewType& X, const ViewType& Y) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<ViewType>::value, "KokkosBatched::xpay: ViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<alphaViewType>::value, "KokkosBatched::xpay: alphaViewType is not a Kokkos::View.");
   static_assert(ViewType::rank == 2, "KokkosBatched::xpay: ViewType must have rank 2.");
   static_assert(alphaViewType::rank == 1, "KokkosBatched::xpay: alphaViewType must have rank 1.");
 
+#ifndef NDEBUG
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
     Kokkos::printf(
@@ -192,12 +192,12 @@ template <typename MemberType>
 template <typename ViewType, typename alphaViewType>
 KOKKOS_INLINE_FUNCTION int TeamXpay<MemberType>::invoke(const MemberType& member, const alphaViewType& alpha,
                                                         const ViewType& X, const ViewType& Y) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<ViewType>::value, "KokkosBatched::xpay: ViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<alphaViewType>::value, "KokkosBatched::xpay: alphaViewType is not a Kokkos::View.");
   static_assert(ViewType::rank == 2, "KokkosBatched::xpay: ViewType must have rank 2.");
   static_assert(alphaViewType::rank == 1, "KokkosBatched::xpay: alphaViewType must have rank 1.");
 
+#ifndef NDEBUG
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
     Kokkos::printf(
@@ -229,12 +229,12 @@ template <typename MemberType>
 template <typename ViewType, typename alphaViewType>
 KOKKOS_INLINE_FUNCTION int TeamVectorXpay<MemberType>::invoke(const MemberType& member, const alphaViewType& alpha,
                                                               const ViewType& X, const ViewType& Y) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<ViewType>::value, "KokkosBatched::xpay: ViewType is not a Kokkos::View.");
   static_assert(Kokkos::is_view<alphaViewType>::value, "KokkosBatched::xpay: alphaViewType is not a Kokkos::View.");
   static_assert(ViewType::rank == 2, "KokkosBatched::xpay: ViewType must have rank 2.");
   static_assert(alphaViewType::rank == 1, "KokkosBatched::xpay: alphaViewType must have rank 1.");
 
+#ifndef NDEBUG
   // Check compatibility of dimensions at run time.
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
     Kokkos::printf(

--- a/batched/sparse/impl/KokkosBatched_Spmv_Serial_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_Serial_Impl.hpp
@@ -89,7 +89,7 @@ struct SerialSpmv<Trans::NoTranspose> {
   KOKKOS_INLINE_FUNCTION static int invoke(const alphaViewType& alpha, const ValuesViewType& values,
                                            const IntView& row_ptr, const IntView& colIndices, const xViewType& X,
                                            const betaViewType& beta, const yViewType& Y) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<ValuesViewType>::value, "KokkosBatched::spmv: ValuesViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<IntView>::value, "KokkosBatched::spmv: IntView is not a Kokkos::View.");
     static_assert(Kokkos::is_view<xViewType>::value, "KokkosBatched::spmv: xViewType is not a Kokkos::View.");
@@ -164,7 +164,7 @@ struct SerialSpmv<Trans::NoTranspose> {
       const ValuesViewType& values, const IntView& row_ptr, const IntView& colIndices, const xViewType& X,
       const typename KokkosKernels::ArithTraits<typename ValuesViewType::non_const_value_type>::mag_type& beta,
       const yViewType& Y) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<ValuesViewType>::value, "KokkosBatched::spmv: ValuesViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<IntView>::value, "KokkosBatched::spmv: IntView is not a Kokkos::View.");
     static_assert(Kokkos::is_view<xViewType>::value, "KokkosBatched::spmv: xViewType is not a Kokkos::View.");

--- a/batched/sparse/impl/KokkosBatched_Spmv_Serial_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_Serial_Impl.hpp
@@ -89,7 +89,6 @@ struct SerialSpmv<Trans::NoTranspose> {
   KOKKOS_INLINE_FUNCTION static int invoke(const alphaViewType& alpha, const ValuesViewType& values,
                                            const IntView& row_ptr, const IntView& colIndices, const xViewType& X,
                                            const betaViewType& beta, const yViewType& Y) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<ValuesViewType>::value, "KokkosBatched::spmv: ValuesViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<IntView>::value, "KokkosBatched::spmv: IntView is not a Kokkos::View.");
     static_assert(Kokkos::is_view<xViewType>::value, "KokkosBatched::spmv: xViewType is not a Kokkos::View.");
@@ -104,6 +103,7 @@ struct SerialSpmv<Trans::NoTranspose> {
     static_assert(alphaViewType::rank == 1, "KokkosBatched::spmv: alphaViewType must have rank 1.");
     static_assert(betaViewType::rank == 1, "KokkosBatched::spmv: betaViewType must have rank 1.");
 
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
       Kokkos::printf(
@@ -164,7 +164,6 @@ struct SerialSpmv<Trans::NoTranspose> {
       const ValuesViewType& values, const IntView& row_ptr, const IntView& colIndices, const xViewType& X,
       const typename KokkosKernels::ArithTraits<typename ValuesViewType::non_const_value_type>::mag_type& beta,
       const yViewType& Y) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<ValuesViewType>::value, "KokkosBatched::spmv: ValuesViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<IntView>::value, "KokkosBatched::spmv: IntView is not a Kokkos::View.");
     static_assert(Kokkos::is_view<xViewType>::value, "KokkosBatched::spmv: xViewType is not a Kokkos::View.");
@@ -175,6 +174,7 @@ struct SerialSpmv<Trans::NoTranspose> {
     static_assert(xViewType::rank == 2, "KokkosBatched::spmv: xViewType must have rank 2.");
     static_assert(yViewType::rank == 2, "KokkosBatched::spmv: yViewType must have rank 2.");
 
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
       Kokkos::printf(

--- a/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
@@ -240,7 +240,6 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
                                            const ValuesViewType& values, const IntView& row_ptr,
                                            const IntView& colIndices, const xViewType& X, const betaViewType& beta,
                                            const yViewType& Y) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<ValuesViewType>::value, "KokkosBatched::spmv: ValuesViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<IntView>::value, "KokkosBatched::spmv: IntView is not a Kokkos::View.");
     static_assert(Kokkos::is_view<xViewType>::value, "KokkosBatched::spmv: xViewType is not a Kokkos::View.");
@@ -257,6 +256,7 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
     static_assert(alphaViewType::rank == 1, "KokkosBatched::spmv: alphaViewType must have rank 1.");
     static_assert(betaViewType::rank == 1, "KokkosBatched::spmv: betaViewType must have rank 1.");
 
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
       Kokkos::printf(
@@ -323,7 +323,6 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
       const ValuesViewType& values, const IntView& row_ptr, const IntView& colIndices, const xViewType& X,
       const typename KokkosKernels::ArithTraits<typename ValuesViewType::non_const_value_type>::mag_type& beta,
       const yViewType& Y) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<ValuesViewType>::value, "KokkosBatched::spmv: ValuesViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<IntView>::value, "KokkosBatched::spmv: IntView is not a Kokkos::View.");
     static_assert(Kokkos::is_view<xViewType>::value, "KokkosBatched::spmv: xViewType is not a Kokkos::View.");
@@ -334,6 +333,7 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
     static_assert(xViewType::rank == 2, "KokkosBatched::spmv: xViewType must have rank 2.");
     static_assert(yViewType::rank == 2, "KokkosBatched::spmv: yViewType must have rank 2.");
 
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
       Kokkos::printf(

--- a/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_TeamVector_Impl.hpp
@@ -240,7 +240,7 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
                                            const ValuesViewType& values, const IntView& row_ptr,
                                            const IntView& colIndices, const xViewType& X, const betaViewType& beta,
                                            const yViewType& Y) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<ValuesViewType>::value, "KokkosBatched::spmv: ValuesViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<IntView>::value, "KokkosBatched::spmv: IntView is not a Kokkos::View.");
     static_assert(Kokkos::is_view<xViewType>::value, "KokkosBatched::spmv: xViewType is not a Kokkos::View.");
@@ -323,7 +323,7 @@ struct TeamVectorSpmv<MemberType, Trans::NoTranspose, N_team> {
       const ValuesViewType& values, const IntView& row_ptr, const IntView& colIndices, const xViewType& X,
       const typename KokkosKernels::ArithTraits<typename ValuesViewType::non_const_value_type>::mag_type& beta,
       const yViewType& Y) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<ValuesViewType>::value, "KokkosBatched::spmv: ValuesViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<IntView>::value, "KokkosBatched::spmv: IntView is not a Kokkos::View.");
     static_assert(Kokkos::is_view<xViewType>::value, "KokkosBatched::spmv: xViewType is not a Kokkos::View.");

--- a/batched/sparse/impl/KokkosBatched_Spmv_Team_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_Team_Impl.hpp
@@ -117,7 +117,6 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
                                            const ValuesViewType& values, const IntView& row_ptr,
                                            const IntView& colIndices, const xViewType& X, const betaViewType& beta,
                                            const yViewType& Y) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<ValuesViewType>::value, "KokkosBatched::spmv: ValuesViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<IntView>::value, "KokkosBatched::spmv: IntView is not a Kokkos::View.");
     static_assert(Kokkos::is_view<xViewType>::value, "KokkosBatched::spmv: xViewType is not a Kokkos::View.");
@@ -132,6 +131,7 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
     static_assert(alphaViewType::rank == 1, "KokkosBatched::spmv: alphaViewType must have rank 1.");
     static_assert(betaViewType::rank == 1, "KokkosBatched::spmv: betaViewType must have rank 1.");
 
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
       Kokkos::printf(
@@ -198,7 +198,6 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
       const ValuesViewType& values, const IntView& row_ptr, const IntView& colIndices, const xViewType& X,
       const typename KokkosKernels::ArithTraits<typename ValuesViewType::non_const_value_type>::mag_type& beta,
       const yViewType& Y) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<ValuesViewType>::value, "KokkosBatched::spmv: ValuesViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<IntView>::value, "KokkosBatched::spmv: IntView is not a Kokkos::View.");
     static_assert(Kokkos::is_view<xViewType>::value, "KokkosBatched::spmv: xViewType is not a Kokkos::View.");
@@ -209,6 +208,7 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
     static_assert(xViewType::rank == 2, "KokkosBatched::spmv: xViewType must have rank 2.");
     static_assert(yViewType::rank == 2, "KokkosBatched::spmv: yViewType must have rank 2.");
 
+#ifndef NDEBUG
     // Check compatibility of dimensions at run time.
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
       Kokkos::printf(

--- a/batched/sparse/impl/KokkosBatched_Spmv_Team_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_Spmv_Team_Impl.hpp
@@ -117,7 +117,7 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
                                            const ValuesViewType& values, const IntView& row_ptr,
                                            const IntView& colIndices, const xViewType& X, const betaViewType& beta,
                                            const yViewType& Y) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<ValuesViewType>::value, "KokkosBatched::spmv: ValuesViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<IntView>::value, "KokkosBatched::spmv: IntView is not a Kokkos::View.");
     static_assert(Kokkos::is_view<xViewType>::value, "KokkosBatched::spmv: xViewType is not a Kokkos::View.");
@@ -198,7 +198,7 @@ struct TeamSpmv<MemberType, Trans::NoTranspose> {
       const ValuesViewType& values, const IntView& row_ptr, const IntView& colIndices, const xViewType& X,
       const typename KokkosKernels::ArithTraits<typename ValuesViewType::non_const_value_type>::mag_type& beta,
       const yViewType& Y) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
     static_assert(Kokkos::is_view<ValuesViewType>::value, "KokkosBatched::spmv: ValuesViewType is not a Kokkos::View.");
     static_assert(Kokkos::is_view<IntView>::value, "KokkosBatched::spmv: IntView is not a Kokkos::View.");
     static_assert(Kokkos::is_view<xViewType>::value, "KokkosBatched::spmv: xViewType is not a Kokkos::View.");

--- a/blas/impl/KokkosBlas1_axpby_unification_attempt_traits.hpp
+++ b/blas/impl/KokkosBlas1_axpby_unification_attempt_traits.hpp
@@ -639,7 +639,7 @@ struct AxpbyUnificationAttemptTraits {
   // ********************************************************************
   // Routine to print information on input variables and internal variables
   // ********************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   static void printInformation(std::ostream& os, std::string const& headerMsg) {
     os << headerMsg << ": AV = "
        << typeid(AV).name()

--- a/blas/impl/KokkosBlas1_axpby_unification_attempt_traits.hpp
+++ b/blas/impl/KokkosBlas1_axpby_unification_attempt_traits.hpp
@@ -639,7 +639,7 @@ struct AxpbyUnificationAttemptTraits {
   // ********************************************************************
   // Routine to print information on input variables and internal variables
   // ********************************************************************
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static void printInformation(std::ostream& os, std::string const& headerMsg) {
     os << headerMsg << ": AV = "
        << typeid(AV).name()

--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -4,9 +4,9 @@
 #ifndef KOKKOSBLAS1_AXPBY_HPP
 #define KOKKOSBLAS1_AXPBY_HPP
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
 #include <iostream>
-#endif  // HAVE_KOKKOSKERNELS_DEBUG
+#endif  // NDEBUG
 
 #include <KokkosBlas1_axpby_spec.hpp>
 #include <KokkosBlas_serial_axpy.hpp>
@@ -58,9 +58,6 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
   // Perform compile time checks and run time checks.
   // **********************************************************************
   AxpbyTraits::performChecks(a, X, b, Y);
-#if HAVE_KOKKOSKERNELS_DEBUG
-  AxpbyTraits::printInformation(std::cout, "axpby(), unif information");
-#endif  // HAVE_KOKKOSKERNELS_DEBUG
 
   // **********************************************************************
   // Call Impl::Axpby<...>::axpby(...)
@@ -293,16 +290,16 @@ void axpy(const AV& a, const XMV& X, const YMV& Y) {
 ///
 template <class scalar_type, class XMV, class YMV>
 KOKKOS_FUNCTION void serial_axpy(const scalar_type alpha, const XMV X, YMV Y) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<XMV>::value, "KokkosBlas::serial_axpy: XMV is not a Kokkos::View");
   static_assert(Kokkos::is_view<YMV>::value, "KokkosBlas::serial_axpy: YMV is not a Kokkos::View");
   static_assert(XMV::rank == 1 || XMV::rank == 2, "KokkosBlas::serial_axpy: XMV must have rank 1 or 2.");
   static_assert(XMV::rank == YMV::rank, "KokkosBlas::serial_axpy: XMV and YMV must have the same rank.");
 
+#ifndef NDEBUG
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
     Kokkos::abort("KokkosBlas::serial_axpy: X and Y dimensions do not match");
   }
-#endif  // HAVE_KOKKOSKERNELS_DEBUG
+#endif  // NDEBUG
   if constexpr (XMV::rank() == 1)
     return Impl::serial_axpy(X.extent(0), alpha, X.data(), Y.data(), X.stride(0), Y.stride(0));
   else

--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -4,10 +4,6 @@
 #ifndef KOKKOSBLAS1_AXPBY_HPP
 #define KOKKOSBLAS1_AXPBY_HPP
 
-#ifndef NDEBUG
-#include <iostream>
-#endif  // NDEBUG
-
 #include <KokkosBlas1_axpby_spec.hpp>
 #include <KokkosBlas_serial_axpy.hpp>
 #include <KokkosKernels_helpers.hpp>

--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -4,9 +4,9 @@
 #ifndef KOKKOSBLAS1_AXPBY_HPP
 #define KOKKOSBLAS1_AXPBY_HPP
 
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
 #include <iostream>
-#endif  // KOKKOSKERNELS_DEBUG_LEVEL
+#endif  // HAVE_KOKKOSKERNELS_DEBUG
 
 #include <KokkosBlas1_axpby_spec.hpp>
 #include <KokkosBlas_serial_axpy.hpp>
@@ -58,9 +58,9 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
   // Perform compile time checks and run time checks.
   // **********************************************************************
   AxpbyTraits::performChecks(a, X, b, Y);
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 1)
+#if HAVE_KOKKOSKERNELS_DEBUG
   AxpbyTraits::printInformation(std::cout, "axpby(), unif information");
-#endif  // KOKKOSKERNELS_DEBUG_LEVEL
+#endif  // HAVE_KOKKOSKERNELS_DEBUG
 
   // **********************************************************************
   // Call Impl::Axpby<...>::axpby(...)
@@ -293,7 +293,7 @@ void axpy(const AV& a, const XMV& X, const YMV& Y) {
 ///
 template <class scalar_type, class XMV, class YMV>
 KOKKOS_FUNCTION void serial_axpy(const scalar_type alpha, const XMV X, YMV Y) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<XMV>::value, "KokkosBlas::serial_axpy: XMV is not a Kokkos::View");
   static_assert(Kokkos::is_view<YMV>::value, "KokkosBlas::serial_axpy: YMV is not a Kokkos::View");
   static_assert(XMV::rank == 1 || XMV::rank == 2, "KokkosBlas::serial_axpy: XMV must have rank 1 or 2.");
@@ -302,7 +302,7 @@ KOKKOS_FUNCTION void serial_axpy(const scalar_type alpha, const XMV X, YMV Y) {
   if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
     Kokkos::abort("KokkosBlas::serial_axpy: X and Y dimensions do not match");
   }
-#endif  // KOKKOSKERNELS_DEBUG_LEVEL
+#endif  // HAVE_KOKKOSKERNELS_DEBUG
   if constexpr (XMV::rank() == 1)
     return Impl::serial_axpy(X.extent(0), alpha, X.data(), Y.data(), X.stride(0), Y.stride(0));
   else

--- a/blas/src/KokkosBlas1_nrm2.hpp
+++ b/blas/src/KokkosBlas1_nrm2.hpp
@@ -167,10 +167,8 @@ void nrm2(const RV& R, const XMV& X, typename std::enable_if<Kokkos::is_view<RV>
 template <class XMV>
 KOKKOS_INLINE_FUNCTION typename Kokkos::Details::InnerProductSpaceTraits<typename XMV::non_const_value_type>::mag_type
 serial_nrm2(const XMV X) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<XMV>::value, "KokkosBlas::serial_nrm2: XMV is not a Kokkos::View");
   static_assert(XMV::rank == 1, "KokkosBlas::serial_nrm2: XMV must have rank 1");
-#endif  // HAVE_KOKKOSKERNELS_DEBUG
 
   return Impl::serial_nrm2(X.extent(0), X.data(), X.stride(0));
 }
@@ -178,7 +176,6 @@ serial_nrm2(const XMV X) {
 template <class RV, class XMV>
 KOKKOS_INLINE_FUNCTION int serial_nrm2(const XMV X, const RV& R) {
 // Do some compile time check when debug is enabled
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<XMV>::value, "KokkosBlas::serial_nrm2: XMV is not a Kokkos::View");
   static_assert(Kokkos::is_view<RV>::value, "KokkosBlas::serial_nrm2: RV is not a Kokkos::View");
   static_assert(std::is_same<typename RV::value_type, typename RV::non_const_value_type>::value,
@@ -189,6 +186,7 @@ KOKKOS_INLINE_FUNCTION int serial_nrm2(const XMV X, const RV& R) {
                 "KokkosBlas::serial_nrm2: "
                 "RV and XMV must either have rank 0 and 1 or rank 1 and 2.");
 
+#ifndef NDEBUG
   using norm_type = typename Kokkos::Details::InnerProductSpaceTraits<typename XMV::non_const_value_type>::mag_type;
   static_assert(std::is_same<typename RV::non_const_value_type, norm_type>::value,
                 "KokkosBlas::serial_nrm2: RV must have same value_type as"
@@ -201,7 +199,7 @@ KOKKOS_INLINE_FUNCTION int serial_nrm2(const XMV X, const RV& R) {
         R.extent_int(0), X.extent_int(0), X.extent_int(1));
     return 1;
   }
-#endif  // HAVE_KOKKOSKERNELS_DEBUG
+#endif  // NDEBUG
   if constexpr (XMV::rank() == 1)
     Impl::serial_nrm2(X.extent(0), X.data(), X.stride(0), R.data());
   else

--- a/blas/src/KokkosBlas1_nrm2.hpp
+++ b/blas/src/KokkosBlas1_nrm2.hpp
@@ -175,7 +175,7 @@ serial_nrm2(const XMV X) {
 
 template <class RV, class XMV>
 KOKKOS_INLINE_FUNCTION int serial_nrm2(const XMV X, const RV& R) {
-// Do some compile time check when debug is enabled
+  // Do some compile time check when debug is enabled
   static_assert(Kokkos::is_view<XMV>::value, "KokkosBlas::serial_nrm2: XMV is not a Kokkos::View");
   static_assert(Kokkos::is_view<RV>::value, "KokkosBlas::serial_nrm2: RV is not a Kokkos::View");
   static_assert(std::is_same<typename RV::value_type, typename RV::non_const_value_type>::value,

--- a/blas/src/KokkosBlas1_nrm2.hpp
+++ b/blas/src/KokkosBlas1_nrm2.hpp
@@ -167,10 +167,10 @@ void nrm2(const RV& R, const XMV& X, typename std::enable_if<Kokkos::is_view<RV>
 template <class XMV>
 KOKKOS_INLINE_FUNCTION typename Kokkos::Details::InnerProductSpaceTraits<typename XMV::non_const_value_type>::mag_type
 serial_nrm2(const XMV X) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<XMV>::value, "KokkosBlas::serial_nrm2: XMV is not a Kokkos::View");
   static_assert(XMV::rank == 1, "KokkosBlas::serial_nrm2: XMV must have rank 1");
-#endif  // KOKKOSKERNELS_DEBUG_LEVEL
+#endif  // HAVE_KOKKOSKERNELS_DEBUG
 
   return Impl::serial_nrm2(X.extent(0), X.data(), X.stride(0));
 }
@@ -178,7 +178,7 @@ serial_nrm2(const XMV X) {
 template <class RV, class XMV>
 KOKKOS_INLINE_FUNCTION int serial_nrm2(const XMV X, const RV& R) {
 // Do some compile time check when debug is enabled
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<XMV>::value, "KokkosBlas::serial_nrm2: XMV is not a Kokkos::View");
   static_assert(Kokkos::is_view<RV>::value, "KokkosBlas::serial_nrm2: RV is not a Kokkos::View");
   static_assert(std::is_same<typename RV::value_type, typename RV::non_const_value_type>::value,
@@ -201,7 +201,7 @@ KOKKOS_INLINE_FUNCTION int serial_nrm2(const XMV X, const RV& R) {
         R.extent_int(0), X.extent_int(0), X.extent_int(1));
     return 1;
   }
-#endif  // KOKKOSKERNELS_DEBUG_LEVEL
+#endif  // HAVE_KOKKOSKERNELS_DEBUG
   if constexpr (XMV::rank() == 1)
     Impl::serial_nrm2(X.extent(0), X.data(), X.stride(0), R.data());
   else

--- a/blas/src/KokkosBlas3_gemm.hpp
+++ b/blas/src/KokkosBlas3_gemm.hpp
@@ -83,7 +83,6 @@ template <class execution_space, class AViewType, class BViewType, class CViewTy
 void gemm(const execution_space& space, const char transA[], const char transB[],
           typename AViewType::const_value_type& alpha, const AViewType& A, const BViewType& B,
           typename CViewType::const_value_type& beta, const CViewType& C) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_execution_space_v<execution_space>,
                 "KokkosBlas::gemm: execution_space must be a valid Kokkos "
                 "execution space");
@@ -100,6 +99,7 @@ void gemm(const execution_space& space, const char transA[], const char transB[]
   static_assert(Kokkos::SpaceAccessibility<execution_space, typename CViewType::memory_space>::accessible,
                 "KokkosBlas::gemm: CViewType must be accessible from execution_space");
 
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   // Check validity of transpose argument
   bool valid_transA = (transA[0] == 'N') || (transA[0] == 'n') || (transA[0] == 'T') || (transA[0] == 't') ||
                       (transA[0] == 'C') || (transA[0] == 'c');

--- a/blas/src/KokkosBlas3_gemm.hpp
+++ b/blas/src/KokkosBlas3_gemm.hpp
@@ -83,7 +83,7 @@ template <class execution_space, class AViewType, class BViewType, class CViewTy
 void gemm(const execution_space& space, const char transA[], const char transB[],
           typename AViewType::const_value_type& alpha, const AViewType& A, const BViewType& B,
           typename CViewType::const_value_type& beta, const CViewType& C) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_execution_space_v<execution_space>,
                 "KokkosBlas::gemm: execution_space must be a valid Kokkos "
                 "execution space");
@@ -133,7 +133,7 @@ void gemm(const execution_space& space, const char transA[], const char transB[]
        << " B: " << B.extent(0) << " x " << B.extent(1) << " C: " << C.extent(0) << " x " << C.extent(1);
     KokkosKernels::Impl::throw_runtime_exception(os.str());
   }
-#endif  // KOKKOSKERNELS_DEBUG_LEVEL > 0
+#endif  // HAVE_KOKKOSKERNELS_DEBUG
 
   // Return if C matrix is degenerated
   if ((C.extent(0) == 0) || (C.extent(1) == 0)) {

--- a/blas/src/KokkosBlas3_gemm.hpp
+++ b/blas/src/KokkosBlas3_gemm.hpp
@@ -99,7 +99,7 @@ void gemm(const execution_space& space, const char transA[], const char transB[]
   static_assert(Kokkos::SpaceAccessibility<execution_space, typename CViewType::memory_space>::accessible,
                 "KokkosBlas::gemm: CViewType must be accessible from execution_space");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   // Check validity of transpose argument
   bool valid_transA = (transA[0] == 'N') || (transA[0] == 'n') || (transA[0] == 'T') || (transA[0] == 't') ||
                       (transA[0] == 'C') || (transA[0] == 'c');
@@ -133,7 +133,7 @@ void gemm(const execution_space& space, const char transA[], const char transB[]
        << " B: " << B.extent(0) << " x " << B.extent(1) << " C: " << C.extent(0) << " x " << C.extent(1);
     KokkosKernels::Impl::throw_runtime_exception(os.str());
   }
-#endif  // HAVE_KOKKOSKERNELS_DEBUG
+#endif  // NDEBUG
 
   // Return if C matrix is degenerated
   if ((C.extent(0) == 0) || (C.extent(1) == 0)) {

--- a/blas/unit_test/Test_Blas1_axpby_unification.hpp
+++ b/blas/unit_test/Test_Blas1_axpby_unification.hpp
@@ -460,7 +460,7 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 01/16: Ascalar + Bscalar
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 01/16" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -490,7 +490,7 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 02/16: Ascalar + Br0
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 02/16" << std::endl;
 #endif
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
@@ -527,7 +527,7 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 03/16: Ascalar + Br1s_1
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 03/16" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -557,7 +557,7 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 04/16: Ascalar + Br1d
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 04/16" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -587,7 +587,7 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 05/16: Ar0 + Bscalar
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 05/16" << std::endl;
 #endif
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
@@ -621,7 +621,7 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 06/16: Ar0 + Br0
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 06/16" << std::endl;
 #endif
   if constexpr ((std::is_same_v<tLayoutA, Kokkos::LayoutStride>) || (std::is_same_v<tLayoutB, Kokkos::LayoutStride>)) {
@@ -655,7 +655,7 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 07/16: Ar0 + Br1s_1
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 07/16" << std::endl;
 #endif
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
@@ -689,7 +689,7 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 08/16: Ar0 + Br1d
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 08/16" << std::endl;
 #endif
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
@@ -723,7 +723,7 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 09/16: Ar1s_1 + Bscalar
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 09/16" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -755,7 +755,7 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 10/16: Ar1s_1 + Br0
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 10/16" << std::endl;
 #endif
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
@@ -791,7 +791,7 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 11/16: Ar1s_1 + Br1s_1
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 11/16" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -823,7 +823,7 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 12/16: Ar1s_1 + Br1d
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 12/16" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -855,7 +855,7 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 13/16: Ar1d + Bscalar
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 13/16" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -886,7 +886,7 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 14/16: Ar1d + Br0
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 14/16" << std::endl;
 #endif
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
@@ -922,7 +922,7 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 15/16: Ar1d + Br1s_1
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 15/16" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -954,7 +954,7 @@ void impl_test_axpby_unification(int const N) {
   // ************************************************************
   // Case 16/16: Ar1d + Br1d
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 16/16" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -1025,7 +1025,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 01/36: Ascalar + Bscalar
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 01/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -1055,7 +1055,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 02/36: Ascalar + Br0
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 02/36" << std::endl;
 #endif
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
@@ -1089,7 +1089,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 03/36: Ascalar + Br1s_1
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 03/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -1119,7 +1119,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 04/36: Ascalar + Br1s_k
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 04/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -1154,7 +1154,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 05/36: Ascalar + Br1d,1
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 05/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -1184,7 +1184,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 06/36: Ascalar + Br1d,k
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 06/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -1219,7 +1219,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 07/36: Ar0 + Bscalar
   // ************************************************************w
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 07/36" << std::endl;
 #endif
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
@@ -1253,7 +1253,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 08/36: Ar0 + Br0
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 08/36" << std::endl;
 #endif
   if constexpr ((std::is_same_v<tLayoutA, Kokkos::LayoutStride>) || (std::is_same_v<tLayoutB, Kokkos::LayoutStride>)) {
@@ -1287,7 +1287,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 09/36: Ar0 + Br1s_1
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 09/36" << std::endl;
 #endif
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
@@ -1321,7 +1321,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 10/36: Ar0 + Br1s_k
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 10/36" << std::endl;
 #endif
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
@@ -1360,7 +1360,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 11/36: Ar0 + Br1d,1
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 11/36" << std::endl;
 #endif
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
@@ -1394,7 +1394,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 12/36: Ar0 + Br1d,k
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 12/36" << std::endl;
 #endif
   if constexpr (std::is_same_v<tLayoutA, Kokkos::LayoutStride>) {
@@ -1433,7 +1433,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 13/36: Ar1s_1 + Bscalar
   // ************************************************************w
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 13/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -1465,7 +1465,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 14/36: Ar1s_1 + Br0
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 14/36" << std::endl;
 #endif
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
@@ -1501,7 +1501,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 15/36: Ar1s_1 + Br1s_1
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 15/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -1533,7 +1533,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 16/36: Ar1s_1 + Br1s_k
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 16/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -1569,7 +1569,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 17/36: Ar1s_1 + Br1d,1
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 17/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -1601,7 +1601,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 18/36: Ar1s_1 + Br1d,k
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 18/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -1637,7 +1637,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 19/36: Ar1s_k + Bscalar
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 19/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -1679,7 +1679,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 20/36: Ar1s_k + Br0
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 20/36" << std::endl;
 #endif
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
@@ -1725,7 +1725,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 21/36: Ar1s_k + Br1s_1
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 21/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -1767,7 +1767,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 22/36: Ar1s_k + Br1s_k
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 22/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -1814,7 +1814,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 23/36: Ar1s_k + Br1d,1
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 23/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -1856,7 +1856,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 24/36: Ar1s_k + Br1d,k
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 24/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -1904,7 +1904,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 25/36: Ar1d,1 + Bscalar
   // ************************************************************w
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 25/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -1936,7 +1936,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 26/36: Ar1d,1 + Br0
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 26/36" << std::endl;
 #endif
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
@@ -1972,7 +1972,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 27/36: Ar1d,1 + Br1s_1
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 27/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -2004,7 +2004,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 28/36: Ar1d,1 + Br1s_k
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 28/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -2040,7 +2040,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 29/36: Ar1d,1 + Br1d,1
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 29/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -2072,7 +2072,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 30/36: Ar1d,1 + Br1d,k
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 30/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -2108,7 +2108,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 31/36: Ar1d,k + Bscalar
   // ************************************************************w
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 31/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -2150,7 +2150,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 32/36: Ar1d,k + Br0
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 32/36" << std::endl;
 #endif
   if constexpr (std::is_same_v<tLayoutB, Kokkos::LayoutStride>) {
@@ -2196,7 +2196,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 33/36: Ar1d,k + Br1s_1
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 33/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -2238,7 +2238,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 34/36: Ar1d,k + Br1s_k
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 34/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -2286,7 +2286,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 35/36: Ar1d,k + Br1d,1
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 35/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -2328,7 +2328,7 @@ void impl_test_axpby_mv_unification(int const N, int const K) {
   // ************************************************************
   // Case 36/36: Ar1d,k + Br1d,k
   // ************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Starting case 36/36" << std::endl;
 #endif
   for (size_t i(0); i < valuesA.size(); ++i) {
@@ -2383,7 +2383,7 @@ template <class tScalarA, class tScalarX, class tScalarB, class tScalarY, class 
 int test_axpby_unification() {
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Calling impl_test_axpby_unif(), L-LLL" << std::endl;
 #endif
   Test::impl_test_axpby_unification<tScalarA, Kokkos::LayoutLeft, tScalarX, Kokkos::LayoutLeft, tScalarB,
@@ -2392,7 +2392,7 @@ int test_axpby_unification() {
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Calling impl_test_axpby_unif(), L-RRR" << std::endl;
 #endif
   Test::impl_test_axpby_unification<tScalarA, Kokkos::LayoutRight, tScalarX, Kokkos::LayoutRight, tScalarB,
@@ -2400,7 +2400,7 @@ int test_axpby_unification() {
 #endif
 
 #if (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Calling impl_test_axpby_unif(), L-SSS" << std::endl;
 #endif
   Test::impl_test_axpby_unification<tScalarA, Kokkos::LayoutStride, tScalarX, Kokkos::LayoutStride, tScalarB,
@@ -2408,25 +2408,25 @@ int test_axpby_unification() {
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Calling impl_test_axpby_unif(), L-SLL" << std::endl;
 #endif
   Test::impl_test_axpby_unification<tScalarA, Kokkos::LayoutStride, tScalarX, Kokkos::LayoutStride, tScalarB,
                                     Kokkos::LayoutLeft, tScalarY, Kokkos::LayoutLeft, Device>(14);
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Calling impl_test_axpby_unif(), L-LSS" << std::endl;
 #endif
   Test::impl_test_axpby_unification<tScalarA, Kokkos::LayoutLeft, tScalarX, Kokkos::LayoutLeft, tScalarB,
                                     Kokkos::LayoutStride, tScalarY, Kokkos::LayoutStride, Device>(14);
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Calling impl_test_axpby_unif(), L-SRS" << std::endl;
 #endif
   Test::impl_test_axpby_unification<tScalarA, Kokkos::LayoutLeft, tScalarX, Kokkos::LayoutStride, tScalarB,
                                     Kokkos::LayoutRight, tScalarY, Kokkos::LayoutStride, Device>(14);
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Calling impl_test_axpby_unif(), L-LSR" << std::endl;
 #endif
   Test::impl_test_axpby_unification<tScalarA, Kokkos::LayoutStride, tScalarX, Kokkos::LayoutLeft, tScalarB,

--- a/blas/unit_test/Test_Blas2_ger.hpp
+++ b/blas/unit_test/Test_Blas2_ger.hpp
@@ -175,7 +175,7 @@ template <class ScalarX, class tLayoutX, class ScalarY, class tLayoutY, class Sc
 void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::test(
     const int M, const int N, const int nonConstConstCombinations, const bool useAnalyticalResults,
     const bool useHermitianOption) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Entering GerTester::test()... - - - - - - - - - - - - - - - - "
                "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
                "- - - - - - - - - "
@@ -231,7 +231,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>:
   // Step 3 of 9: populate h_vanilla
   // ********************************************************************
   view_stride_adapter<_ViewTypeExpected, true> h_vanilla("vanilla = A + alpha * x * y^{t,h}", _M, _N);
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf("In Test_Blas2_ger.hpp, computing vanilla A with alpha type = %s\n", typeid(alpha).name());
 #endif
   this->populateVanillaValues(alpha, x.h_view, y.h_view, A.h_view, h_vanilla.d_view);
@@ -297,7 +297,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>:
   EXPECT_ANY_THROW(KokkosBlas::ger("", alpha, x.d_view, y.d_view, A.d_view))
       << "Failed test: kk ger should have thrown an exception for mode ''";
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Leaving GerTester::test() - - - - - - - - - - - - - - - - - - "
                "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
                "- - - - - - - "
@@ -642,7 +642,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::comp
           }
         }
         if (errorHappened && (numErrorsRealAbs + numErrorsRealRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
           std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j).real() = " << h_expected(i, j).real()
                     << ", h_vanilla(i,j).real() = " << h_vanilla(i, j).real()
                     << ", _KAT_A::abs(h_expected(i,j).real() - "
@@ -674,7 +674,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::comp
           }
         }
         if (errorHappened && (numErrorsImagAbs + numErrorsImagRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
           std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j).imag() = " << h_expected(i, j).imag()
                     << ", h_vanilla(i,j).imag() = " << h_vanilla(i, j).imag()
                     << ", _KAT_A::abs(h_expected(i,j).imag() - "
@@ -699,7 +699,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::comp
 
       int numErrorsReal(numErrorsRealAbs + numErrorsRealRel);
       if (numErrorsReal > 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
         std::cout << "WARNING" << msg.str() << std::endl;
 #endif
       }
@@ -720,7 +720,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::comp
 
       int numErrorsImag(numErrorsImagAbs + numErrorsImagRel);
       if (numErrorsImag > 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
         std::cout << "WARNING" << msg.str() << std::endl;
 #endif
       }
@@ -734,7 +734,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::comp
       for (int j(0); j < _N; ++j) {
         if (h_expected(i, j).real() != h_vanilla(i, j).real()) {
           if (numErrorsReal == 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
             std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j).real() = " << h_expected(i, j).real()
                       << ", h_vanilla(i,j).real() = " << h_vanilla(i, j).real() << std::endl;
 #endif
@@ -744,7 +744,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::comp
 
         if (h_expected(i, j).imag() != h_vanilla(i, j).imag()) {
           if (numErrorsImag == 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
             std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j).imag() = " << h_expected(i, j).imag()
                       << ", h_vanilla(i,j).imag() = " << h_vanilla(i, j).imag() << std::endl;
 #endif
@@ -812,7 +812,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::comp
           }
         }
         if (errorHappened && (numErrorsAbs + numErrorsRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
           std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j) = " << h_expected(i, j)
                     << ", h_vanilla(i,j) = " << h_vanilla(i, j)
                     << ", _KAT_A::abs(h_expected(i,j) - h_vanilla(i,j)) = " << diff
@@ -835,7 +835,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::comp
 
       int numErrors(numErrorsAbs + numErrorsRel);
       if (numErrors > 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
         std::cout << "WARNING" << msg.str() << std::endl;
 #endif
       }
@@ -848,7 +848,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::comp
       for (int j(0); j < _N; ++j) {
         if (h_expected(i, j) != h_vanilla(i, j)) {
           if (numErrors == 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
             std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j) = " << h_expected(i, j)
                       << ", h_vanilla(i,j) = " << h_vanilla(i, j) << std::endl;
 #endif
@@ -912,7 +912,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::comp
         }
       }
       if (errorHappened && (numErrorsRealAbs + numErrorsRealRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
         std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j).real() = " << h_expected(i, j).real()
                   << ", h_A(i,j).real() = " << h_A(i, j).real()
                   << ", _KAT_A::abs(h_expected(i,j).real() - h_A(i,j).real()) = " << diff
@@ -943,7 +943,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::comp
         }
       }
       if (errorHappened && (numErrorsImagAbs + numErrorsImagRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
         std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j).imag() = " << h_expected(i, j).imag()
                   << ", h_A(i,j).imag() = " << h_A(i, j).imag()
                   << ", _KAT_A::abs(h_expected(i,j).imag() - h_A(i,j).imag()) = " << diff
@@ -952,7 +952,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::comp
       }
     }  // for j
   }    // for i
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "A is " << _M << " by " << _N << ", _A_is_lr = " << _A_is_lr << ", _A_is_ll = " << _A_is_ll
             << ", alpha type = " << typeid(alpha).name() << ", _useHermitianOption = " << _useHermitianOption
             << ", numErrorsRealAbs = " << numErrorsRealAbs << ", numErrorsRealRel = " << numErrorsRealRel
@@ -998,7 +998,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::comp
 
     int numErrorsReal(numErrorsRealAbs + numErrorsRealRel);
     if (numErrorsReal > 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
       std::cout << "WARNING" << msg.str() << std::endl;
 #endif
     }
@@ -1019,7 +1019,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::comp
 
     int numErrorsImag(numErrorsImagAbs + numErrorsImagRel);
     if (numErrorsImag > 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
       std::cout << "WARNING" << msg.str() << std::endl;
 #endif
     }
@@ -1069,7 +1069,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::comp
         }
       }
       if (errorHappened && (numErrorsAbs + numErrorsRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
         std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j) = " << h_expected(i, j)
                   << ", h_A(i,j) = " << h_A(i, j) << ", _KAT_A::abs(h_expected(i,j) - h_A(i,j)) = " << diff
                   << ", diffThreshold = " << diffThreshold << std::endl;
@@ -1077,7 +1077,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::comp
       }
     }  // for j
   }    // for i
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "A is " << _M << " by " << _N << ", _A_is_lr = " << _A_is_lr << ", _A_is_ll = " << _A_is_ll
             << ", alpha type = " << typeid(alpha).name() << ", _useHermitianOption = " << _useHermitianOption
             << ", numErrorsAbs = " << numErrorsAbs << ", numErrorsRel = " << numErrorsRel
@@ -1101,7 +1101,7 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::comp
 
     int numErrors(numErrorsAbs + numErrorsRel);
     if (numErrors > 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
       std::cout << "WARNING" << msg.str() << std::endl;
 #endif
     }
@@ -1114,7 +1114,7 @@ template <class TX, class TY>
 void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::callKkGerAndCompareAgainstExpected(
     const ScalarA& alpha, TX& x, TY& y, view_stride_adapter<_ViewTypeA, false>& A, const _ViewTypeExpected& h_expected,
     const std::string& situation) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf(
       "In Test_Blas2_ger.hpp, right before calling KokkosBlas::ger(): "
       "ViewTypeA = %s, _kkGerShouldThrowException=%d\n",
@@ -1126,12 +1126,12 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>:
   try {
     KokkosBlas::ger(mode.c_str(), alpha, x, y, A.d_view);
   } catch (const std::exception& e) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "In Test_Blas2_ger, '" << situation << "': caught exception, e.what() = " << e.what() << std::endl;
 #endif
     gotStdException = true;
   } catch (...) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "In Test_Blas2_ger, '" << situation << "': caught unknown exception" << std::endl;
 #endif
     gotUnknownException = true;
@@ -1154,7 +1154,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>:
 }  // namespace Test
 
 template <class ScalarX, class ScalarY, class ScalarA, class Device>
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
 int test_ger(const std::string& caseName) {
   Kokkos::printf(
       "+======================================================================="
@@ -1176,7 +1176,7 @@ int test_ger(const std::string& /*caseName*/) {
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
@@ -1209,7 +1209,7 @@ int test_ger(const std::string& /*caseName*/) {
     }
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf("Finished %s for LAYOUTLEFT\n", caseName.c_str());
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
@@ -1219,7 +1219,7 @@ int test_ger(const std::string& /*caseName*/) {
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
@@ -1252,7 +1252,7 @@ int test_ger(const std::string& /*caseName*/) {
     }
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf("Finished %s for LAYOUTRIGHT\n", caseName.c_str());
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
@@ -1261,7 +1261,7 @@ int test_ger(const std::string& /*caseName*/) {
 #endif
 
 #if (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
@@ -1291,7 +1291,7 @@ int test_ger(const std::string& /*caseName*/) {
     }
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf("Finished %s for LAYOUTSTRIDE\n", caseName.c_str());
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
@@ -1300,7 +1300,7 @@ int test_ger(const std::string& /*caseName*/) {
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
@@ -1324,7 +1324,7 @@ int test_ger(const std::string& /*caseName*/) {
     tester.test(1024, 1024, 0);
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf("Finished %s for MIXED LAYOUTS\n", caseName.c_str());
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
@@ -1332,7 +1332,7 @@ int test_ger(const std::string& /*caseName*/) {
 #endif
 #endif
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf("Finished %s\n", caseName.c_str());
   Kokkos::printf(
       "+======================================================================="

--- a/blas/unit_test/Test_Blas2_syr.hpp
+++ b/blas/unit_test/Test_Blas2_syr.hpp
@@ -178,7 +178,7 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::test(const int N, 
                                                                    const bool useAnalyticalResults,
                                                                    const bool useHermitianOption,
                                                                    const bool useUpOption) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Entering SyrTester::test()... - - - - - - - - - - - - - - - - "
                "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
                "- - - - - - - - - "
@@ -237,7 +237,7 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::test(const int N, 
   // Step 3 of 7: populate h_vanilla
   // ********************************************************************
   view_stride_adapter<_ViewTypeExpected, true> h_vanilla("vanilla = A + alpha * x * x^{t,h}", _M, _N);
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf("In Test_Blas2_syr.hpp, computing vanilla A with alpha type = %s\n", typeid(alpha).name());
 #endif
   this->populateVanillaValues(alpha, x.h_view, A.h_view, h_vanilla.d_view);
@@ -294,7 +294,7 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::test(const int N, 
   EXPECT_ANY_THROW(KokkosBlas::syr("T", "", alpha, x.d_view, A.d_view))
       << "Failed test: kk syr should have thrown an exception for uplo ''";
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Leaving SyrTester::test() - - - - - - - - - - - - - - - - - - "
                "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
                "- - - - - - - "
@@ -398,7 +398,7 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::populateVariables(
     Kokkos::deep_copy(A.d_base, A.h_base);
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   if (_N <= 2) {
     for (int i(0); i < _M; ++i) {
       for (int j(0); j < _N; ++j) {
@@ -635,7 +635,7 @@ typename std::enable_if<
     std::is_same<T, Kokkos::complex<float>>::value || std::is_same<T, Kokkos::complex<double>>::value, void>::type
 SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareVanillaAgainstExpected(
     const T& alpha, const _ViewTypeExpected& h_vanilla, const _ViewTypeExpected& h_expected) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   if (_N <= 2) {
     for (int i(0); i < _M; ++i) {
       for (int j(0); j < _N; ++j) {
@@ -687,7 +687,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareVanillaAgainstEx
           }
         }
         if (errorHappened && (numErrorsRealAbs + numErrorsRealRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
           std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j).real() = " << h_expected(i, j).real()
                     << ", h_vanilla(i,j).real() = " << h_vanilla(i, j).real()
                     << ", _KAT_A::abs(h_expected(i,j).real() - "
@@ -719,7 +719,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareVanillaAgainstEx
           }
         }
         if (errorHappened && (numErrorsImagAbs + numErrorsImagRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
           std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j).imag() = " << h_expected(i, j).imag()
                     << ", h_vanilla(i,j).imag() = " << h_vanilla(i, j).imag()
                     << ", _KAT_A::abs(h_expected(i,j).imag() - "
@@ -745,7 +745,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareVanillaAgainstEx
 
       int numErrorsReal(numErrorsRealAbs + numErrorsRealRel);
       if (numErrorsReal > 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
         std::cout << "WARNING" << msg.str() << std::endl;
 #endif
       }
@@ -766,7 +766,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareVanillaAgainstEx
 
       int numErrorsImag(numErrorsImagAbs + numErrorsImagRel);
       if (numErrorsImag > 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
         std::cout << "WARNING" << msg.str() << std::endl;
 #endif
       }
@@ -780,7 +780,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareVanillaAgainstEx
       for (int j(0); j < _N; ++j) {
         if (h_expected(i, j).real() != h_vanilla(i, j).real()) {
           if (numErrorsReal == 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
             std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j).real() = " << h_expected(i, j).real()
                       << ", h_vanilla(i,j).real() = " << h_vanilla(i, j).real() << std::endl;
 #endif
@@ -790,7 +790,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareVanillaAgainstEx
 
         if (h_expected(i, j).imag() != h_vanilla(i, j).imag()) {
           if (numErrorsImag == 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
             std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j).imag() = " << h_expected(i, j).imag()
                       << ", h_vanilla(i,j).imag() = " << h_vanilla(i, j).imag() << std::endl;
 #endif
@@ -826,7 +826,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareVanillaAgainstEx
   if (_N <= 2) {
     for (int i(0); i < _M; ++i) {
       for (int j(0); j < _N; ++j) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
         std::cout << "h_exp(" << i << "," << j << ")=" << h_expected(i, j) << ", h_van(" << i << "," << j
                   << ")=" << h_vanilla(i, j) << std::endl;
 #endif
@@ -871,7 +871,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareVanillaAgainstEx
           }
         }
         if (errorHappened && (numErrorsAbs + numErrorsRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
           std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j) = " << h_expected(i, j)
                     << ", h_vanilla(i,j) = " << h_vanilla(i, j)
                     << ", _KAT_A::abs(h_expected(i,j) - h_vanilla(i,j)) = " << diff
@@ -895,7 +895,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareVanillaAgainstEx
 
       int numErrors(numErrorsAbs + numErrorsRel);
       if (numErrors > 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
         std::cout << "WARNING" << msg.str() << std::endl;
 #endif
       }
@@ -908,7 +908,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareVanillaAgainstEx
       for (int j(0); j < _N; ++j) {
         if (h_expected(i, j) != h_vanilla(i, j)) {
           if (numErrors == 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
             std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j) = " << h_expected(i, j)
                       << ", h_vanilla(i,j) = " << h_vanilla(i, j) << std::endl;
 #endif
@@ -936,7 +936,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareKkSyrAgainstRefe
   if (_N <= 2) {
     for (int i(0); i < _M; ++i) {
       for (int j(0); j < _N; ++j) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
         std::cout << "h_exp(" << i << "," << j << ")=" << h_reference(i, j) << ", h_A(" << i << "," << j
                   << ")=" << h_A(i, j) << std::endl;
 #endif
@@ -984,7 +984,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareKkSyrAgainstRefe
         }
       }
       if (errorHappened && (numErrorsRealAbs + numErrorsRealRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
         std::cout << "ERROR, i = " << i << ", j = " << j << ": h_reference(i,j).real() = " << h_reference(i, j).real()
                   << ", h_A(i,j).real() = " << h_A(i, j).real()
                   << ", _KAT_A::abs(h_reference(i,j).real() - h_A(i,j).real()) = " << diff
@@ -1015,7 +1015,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareKkSyrAgainstRefe
         }
       }
       if (errorHappened && (numErrorsImagAbs + numErrorsImagRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
         std::cout << "ERROR, i = " << i << ", j = " << j << ": h_reference(i,j).imag() = " << h_reference(i, j).imag()
                   << ", h_A(i,j).imag() = " << h_A(i, j).imag()
                   << ", _KAT_A::abs(h_reference(i,j).imag() - h_A(i,j).imag()) = " << diff
@@ -1025,7 +1025,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareKkSyrAgainstRefe
     }  // for j
   }    // for i
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "A is " << _M << " by " << _N << ", _A_is_lr = " << _A_is_lr << ", _A_is_ll = " << _A_is_ll
             << ", alpha type = " << typeid(alpha).name() << ", _useHermitianOption = " << _useHermitianOption
             << ", _useUpOption = " << _useUpOption << ", numErrorsRealAbs = " << numErrorsRealAbs
@@ -1072,7 +1072,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareKkSyrAgainstRefe
 
     int numErrorsReal(numErrorsRealAbs + numErrorsRealRel);
     if (numErrorsReal > 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
       std::cout << "WARNING" << msg.str() << std::endl;
 #endif
     }
@@ -1093,7 +1093,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareKkSyrAgainstRefe
 
     int numErrorsImag(numErrorsImagAbs + numErrorsImagRel);
     if (numErrorsImag > 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
       std::cout << "WARNING" << msg.str() << std::endl;
 #endif
     }
@@ -1108,7 +1108,7 @@ typename std::enable_if<
     !std::is_same<T, Kokkos::complex<float>>::value && !std::is_same<T, Kokkos::complex<double>>::value, void>::type
 SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareKkSyrAgainstReference(
     const T& alpha, const _HostViewTypeA& h_A, const _ViewTypeExpected& h_reference) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   if (_N <= 2) {
     for (int i(0); i < _M; ++i) {
       for (int j(0); j < _N; ++j) {
@@ -1153,7 +1153,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareKkSyrAgainstRefe
         }
       }
       if (errorHappened && (numErrorsAbs + numErrorsRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
         std::cout << "ERROR, i = " << i << ", j = " << j << ": h_reference(i,j) = " << h_reference(i, j)
                   << ", h_A(i,j) = " << h_A(i, j) << ", _KAT_A::abs(h_reference(i,j) - h_A(i,j)) = " << diff
                   << ", diffThreshold = " << diffThreshold << std::endl;
@@ -1161,7 +1161,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareKkSyrAgainstRefe
       }
     }  // for j
   }    // for i
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "A is " << _M << " by " << _N << ", _A_is_lr = " << _A_is_lr << ", _A_is_ll = " << _A_is_ll
             << ", alpha type = " << typeid(alpha).name() << ", _useHermitianOption = " << _useHermitianOption
             << ", _useUpOption = " << _useUpOption << ", numErrorsAbs = " << numErrorsAbs
@@ -1186,7 +1186,7 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareKkSyrAgainstRefe
 
     int numErrors(numErrorsAbs + numErrorsRel);
     if (numErrors > 0) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
       std::cout << "WARNING" << msg.str() << std::endl;
 #endif
     }
@@ -1199,7 +1199,7 @@ template <class TX>
 void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::callKkSyrAndCompareAgainstExpected(
     const ScalarA& alpha, TX& x, view_stride_adapter<_ViewTypeA, false>& A, const _ViewTypeExpected& h_expected,
     const std::string& situation) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "In Test_Blas2_syr, '" << situation << "', alpha = " << alpha << std::endl;
   Kokkos::printf(
       "In Test_Blas2_syr.hpp, right before calling KokkosBlas::syr(): "
@@ -1213,12 +1213,12 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::callKkSyrAndCompar
   try {
     KokkosBlas::syr(mode.c_str(), uplo.c_str(), alpha, x, A.d_view);
   } catch (const std::exception& e) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "In Test_Blas2_syr, '" << situation << "': caught exception, e.what() = " << e.what() << std::endl;
 #endif
     gotStdException = true;
   } catch (...) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "In Test_Blas2_syr, '" << situation << "': caught unknown exception" << std::endl;
 #endif
     gotUnknownException = true;
@@ -1248,7 +1248,7 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::callKkGerAndCompar
   // ********************************************************************
   // Call ger()
   // ********************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "In Test_Blas2_syr, '" << situation << "', alpha = " << alpha << std::endl;
   Kokkos::printf(
       "In Test_Blas2_syr.hpp, right before calling KokkosBlas::ger(): "
@@ -1261,13 +1261,13 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::callKkGerAndCompar
   try {
     KokkosBlas::ger(mode.c_str(), alpha, x, x, A_ger.d_view);
   } catch (const std::exception& e) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "In Test_Blas2_syr, '" << situation << "', ger() call: caught exception, e.what() = " << e.what()
               << std::endl;
 #endif
     gotStdException = true;
   } catch (...) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "In Test_Blas2_syr, '" << situation << "', ger() call: caught unknown exception" << std::endl;
 #endif
     gotUnknownException = true;
@@ -1310,7 +1310,7 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::callKkGerAndCompar
 }  // namespace Test
 
 template <class ScalarX, class ScalarA, class Device>
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
 int test_syr(const std::string& caseName) {
   Kokkos::printf(
       "+======================================================================="
@@ -1329,7 +1329,7 @@ int test_syr(const std::string& /*caseName*/) {
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
@@ -1361,7 +1361,7 @@ int test_syr(const std::string& /*caseName*/) {
     tester.test(2131, 0);
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf("Finished %s for LAYOUTLEFT\n", caseName.c_str());
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
@@ -1371,7 +1371,7 @@ int test_syr(const std::string& /*caseName*/) {
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
@@ -1403,7 +1403,7 @@ int test_syr(const std::string& /*caseName*/) {
     tester.test(2131, 0);
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf("Finished %s for LAYOUTRIGHT\n", caseName.c_str());
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
@@ -1413,7 +1413,7 @@ int test_syr(const std::string& /*caseName*/) {
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
@@ -1445,7 +1445,7 @@ int test_syr(const std::string& /*caseName*/) {
     tester.test(2131, 0);
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf("Finished %s for LAYOUTSTRIDE\n", caseName.c_str());
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
@@ -1454,7 +1454,7 @@ int test_syr(const std::string& /*caseName*/) {
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
       "---\n");
@@ -1482,7 +1482,7 @@ int test_syr(const std::string& /*caseName*/) {
     tester.test(1024, 0);
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf("Finished %s for MIXED LAYOUTS\n", caseName.c_str());
   Kokkos::printf(
       "+-----------------------------------------------------------------------"
@@ -1490,7 +1490,7 @@ int test_syr(const std::string& /*caseName*/) {
 #endif
 #endif
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   Kokkos::printf("Finished %s\n", caseName.c_str());
   Kokkos::printf(
       "+======================================================================="

--- a/blas/unit_test/Test_Blas2_syr2.hpp
+++ b/blas/unit_test/Test_Blas2_syr2.hpp
@@ -188,7 +188,7 @@ template <class ScalarX, class tLayoutX, class ScalarY, class tLayoutY, class Sc
 void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::test(
     const int N, const int nonConstConstCombinations, const bool useAnalyticalResults, const bool useHermitianOption,
     const bool useUpOption) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Entering Syr2Tester::test()... - - - - - - - - - - - - - - - - "
                "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
                "- - - - - - - - - "
@@ -249,7 +249,7 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>
   // Step 3 of 7: populate h_vanilla
   // ********************************************************************
   view_stride_adapter<_ViewTypeExpected, true> h_vanilla("vanilla = A + alpha * x * x^{t,h}", _M, _N);
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "In Test_Blas2_syr2.hpp, computing vanilla A with alpha type = " << typeid(alpha).name() << std::endl;
 #endif
   this->populateVanillaValues(alpha, x.h_view, y.h_view, A.h_view, h_vanilla.d_view);
@@ -306,7 +306,7 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>
   EXPECT_ANY_THROW(KokkosBlas::syr2("T", "", alpha, x.d_view, y.d_view, A.d_view))
       << "Failed test: kk syr2 should have thrown an exception for uplo ''";
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Leaving Syr2Tester::test() - - - - - - - - - - - - - - - - - - "
                "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
                "- - - - - - - "
@@ -425,7 +425,7 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>
     Kokkos::deep_copy(A.d_base, A.h_base);
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   if (_N <= 2) {
     for (int i(0); i < _M; ++i) {
       for (int j(0); j < _N; ++j) {
@@ -694,7 +694,7 @@ typename std::enable_if<
     std::is_same<T, Kokkos::complex<float>>::value || std::is_same<T, Kokkos::complex<double>>::value, void>::type
 Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::compareVanillaAgainstExpected(
     const T& alpha, const _ViewTypeExpected& h_vanilla, const _ViewTypeExpected& h_expected) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   if (_N <= 2) {
     for (int i(0); i < _M; ++i) {
       for (int j(0); j < _N; ++j) {
@@ -746,7 +746,7 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::com
           }
         }
         if (errorHappened && (numErrorsRealAbs + numErrorsRealRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
           std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j).real() = " << h_expected(i, j).real()
                     << ", h_vanilla(i,j).real() = " << h_vanilla(i, j).real()
                     << ", _KAT_A::abs(h_expected(i,j).real() - "
@@ -777,7 +777,7 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::com
           }
         }
         if (errorHappened && (numErrorsImagAbs + numErrorsImagRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
           std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j).imag() = " << h_expected(i, j).imag()
                     << ", h_vanilla(i,j).imag() = " << h_vanilla(i, j).imag()
                     << ", _KAT_A::abs(h_expected(i,j).imag() - "
@@ -802,7 +802,7 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::com
           << ", maxNumErrorsAllowed = " << maxNumErrorsAllowed;
 
       int numErrorsReal(numErrorsRealAbs + numErrorsRealRel);
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
       if (numErrorsReal > 0) {
         std::cout << "WARNING" << msg.str() << std::endl;
       }
@@ -823,7 +823,7 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::com
           << ", maxNumErrorsAllowed = " << maxNumErrorsAllowed;
 
       int numErrorsImag(numErrorsImagAbs + numErrorsImagRel);
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
       if (numErrorsImag > 0) {
         std::cout << "WARNING" << msg.str() << std::endl;
       }
@@ -837,7 +837,7 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::com
     for (int i(0); i < _M; ++i) {
       for (int j(0); j < _N; ++j) {
         if (h_expected(i, j).real() != h_vanilla(i, j).real()) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
           if (numErrorsReal == 0) {
             std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j).real() = " << h_expected(i, j).real()
                       << ", h_vanilla(i,j).real() = " << h_vanilla(i, j).real() << std::endl;
@@ -847,7 +847,7 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::com
         }
 
         if (h_expected(i, j).imag() != h_vanilla(i, j).imag()) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
           if (numErrorsImag == 0) {
             std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j).imag() = " << h_expected(i, j).imag()
                       << ", h_vanilla(i,j).imag() = " << h_vanilla(i, j).imag() << std::endl;
@@ -881,7 +881,7 @@ typename std::enable_if<
     !std::is_same<T, Kokkos::complex<float>>::value && !std::is_same<T, Kokkos::complex<double>>::value, void>::type
 Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::compareVanillaAgainstExpected(
     const T& alpha, const _ViewTypeExpected& h_vanilla, const _ViewTypeExpected& h_expected) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   if (_N <= 2) {
     for (int i(0); i < _M; ++i) {
       for (int j(0); j < _N; ++j) {
@@ -928,7 +928,7 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::com
           }
         }
         if (errorHappened && (numErrorsAbs + numErrorsRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
           std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j) = " << h_expected(i, j)
                     << ", h_vanilla(i,j) = " << h_vanilla(i, j)
                     << ", _KAT_A::abs(h_expected(i,j) - h_vanilla(i,j)) = " << diff
@@ -951,7 +951,7 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::com
           << ", maxNumErrorsAllowed = " << maxNumErrorsAllowed;
 
       int numErrors(numErrorsAbs + numErrorsRel);
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
       if (numErrors > 0) {
         std::cout << "WARNING" << msg.str() << std::endl;
       }
@@ -964,7 +964,7 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::com
     for (int i(0); i < _M; ++i) {
       for (int j(0); j < _N; ++j) {
         if (h_expected(i, j) != h_vanilla(i, j)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
           if (numErrors == 0) {
             std::cout << "ERROR, i = " << i << ", j = " << j << ": h_expected(i,j) = " << h_expected(i, j)
                       << ", h_vanilla(i,j) = " << h_vanilla(i, j) << std::endl;
@@ -990,7 +990,7 @@ typename std::enable_if<
     std::is_same<T, Kokkos::complex<float>>::value || std::is_same<T, Kokkos::complex<double>>::value, void>::type
 Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::compareKkSyr2AgainstReference(
     const T& alpha, const _HostViewTypeA& h_A, const _ViewTypeExpected& h_reference) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   if (_N <= 2) {
     for (int i(0); i < _M; ++i) {
       for (int j(0); j < _N; ++j) {
@@ -1040,7 +1040,7 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::com
         }
       }
       if (errorHappened && (numErrorsRealAbs + numErrorsRealRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
         std::cout << "ERROR, i = " << i << ", j = " << j << ": h_reference(i,j).real() = " << h_reference(i, j).real()
                   << ", h_A(i,j).real() = " << h_A(i, j).real()
                   << ", _KAT_A::abs(h_reference(i,j).real() - h_A(i,j).real()) = " << diff
@@ -1070,7 +1070,7 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::com
         }
       }
       if (errorHappened && (numErrorsImagAbs + numErrorsImagRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
         std::cout << "ERROR, i = " << i << ", j = " << j << ": h_reference(i,j).imag() = " << h_reference(i, j).imag()
                   << ", h_A(i,j).imag() = " << h_A(i, j).imag()
                   << ", _KAT_A::abs(h_reference(i,j).imag() - h_A(i,j).imag()) = " << diff
@@ -1080,7 +1080,7 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::com
     }  // for j
   }    // for i
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "A is " << _M << " by " << _N << ", _A_is_lr = " << _A_is_lr << ", _A_is_ll = " << _A_is_ll
             << ", alpha type = " << typeid(alpha).name() << ", _useHermitianOption = " << _useHermitianOption
             << ", _useUpOption = " << _useUpOption << ", numErrorsRealAbs = " << numErrorsRealAbs
@@ -1126,7 +1126,7 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::com
         << ", maxNumErrorsAllowed = " << maxNumErrorsAllowed;
 
     int numErrorsReal(numErrorsRealAbs + numErrorsRealRel);
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     if (numErrorsReal > 0) {
       std::cout << "WARNING" << msg.str() << std::endl;
     }
@@ -1147,7 +1147,7 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::com
         << ", maxNumErrorsAllowed = " << maxNumErrorsAllowed;
 
     int numErrorsImag(numErrorsImagAbs + numErrorsImagRel);
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     if (numErrorsImag > 0) {
       std::cout << "WARNING" << msg.str() << std::endl;
     }
@@ -1163,7 +1163,7 @@ typename std::enable_if<
     !std::is_same<T, Kokkos::complex<float>>::value && !std::is_same<T, Kokkos::complex<double>>::value, void>::type
 Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::compareKkSyr2AgainstReference(
     const T& alpha, const _HostViewTypeA& h_A, const _ViewTypeExpected& h_reference) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   if (_N <= 2) {
     for (int i(0); i < _M; ++i) {
       for (int j(0); j < _N; ++j) {
@@ -1208,7 +1208,7 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::com
         }
       }
       if (errorHappened && (numErrorsAbs + numErrorsRel == 1)) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
         std::cout << "ERROR, i = " << i << ", j = " << j << ": h_reference(i,j) = " << h_reference(i, j)
                   << ", h_A(i,j) = " << h_A(i, j) << ", _KAT_A::abs(h_reference(i,j) - h_A(i,j)) = " << diff
                   << ", diffThreshold = " << diffThreshold << std::endl;
@@ -1216,7 +1216,7 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::com
       }
     }  // for j
   }    // for i
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "A is " << _M << " by " << _N << ", _A_is_lr = " << _A_is_lr << ", _A_is_ll = " << _A_is_ll
             << ", alpha type = " << typeid(alpha).name() << ", _useHermitianOption = " << _useHermitianOption
             << ", _useUpOption = " << _useUpOption << ", numErrorsAbs = " << numErrorsAbs
@@ -1240,7 +1240,7 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::com
         << ", maxNumErrorsAllowed = " << maxNumErrorsAllowed;
 
     int numErrors(numErrorsAbs + numErrorsRel);
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     if (numErrors > 0) {
       std::cout << "WARNING" << msg.str() << std::endl;
     }
@@ -1254,7 +1254,7 @@ template <class TX, class TY>
 void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::callKkSyr2AndCompareAgainstExpected(
     const ScalarA& alpha, TX& x, TY& y, view_stride_adapter<_ViewTypeA, false>& A, const _ViewTypeExpected& h_expected,
     const std::string& situation) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "In Test_Blas2_syr2, '" << situation << "', alpha = " << alpha << std::endl;
   std::cout << "In Test_Blas2_syr2.hpp, right before calling KokkosBlas::syr2()"
             << ": ViewTypeA = " << typeid(_ViewTypeA).name()
@@ -1268,12 +1268,12 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>
     KokkosBlas::syr2(mode.c_str(), uplo.c_str(), alpha, x, y, A.d_view);
     Kokkos::fence();
   } catch (const std::exception& e) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "In Test_Blas2_syr2, '" << situation << "': caught exception, e.what() = " << e.what() << std::endl;
 #endif
     gotStdException = true;
   } catch (...) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "In Test_Blas2_syr2, '" << situation << "': caught unknown exception" << std::endl;
 #endif
     gotUnknownException = true;
@@ -1303,7 +1303,7 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>
   // ********************************************************************
   // Call ger()
   // ********************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "In Test_Blas2_syr2, '" << situation << "', alpha = " << alpha << std::endl;
   std::cout << "In Test_Blas2_syr2.hpp, right before calling KokkosBlas::ger()"
             << ": ViewTypeA = " << typeid(_ViewTypeA).name()
@@ -1316,13 +1316,13 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>
     KokkosBlas::ger(mode.c_str(), alpha, x, y, A_ger.d_view);
     Kokkos::fence();
   } catch (const std::exception& e) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "In Test_Blas2_syr2, '" << situation << "', ger() call 1: caught exception, e.what() = " << e.what()
               << std::endl;
 #endif
     gotStdException = true;
   } catch (...) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "In Test_Blas2_syr2, '" << situation << "', ger() call 1: caught unknown exception" << std::endl;
 #endif
     gotUnknownException = true;
@@ -1337,7 +1337,7 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>
   // ********************************************************************
   // Call ger() again
   // ********************************************************************
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "In Test_Blas2_syr2.hpp, right before calling KokkosBlas::ger() again";
 #endif
   try {
@@ -1348,13 +1348,13 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>
     }
     Kokkos::fence();
   } catch (const std::exception& e) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "In Test_Blas2_syr2, '" << situation << "', ger() call 2: caught exception, e.what() = " << e.what()
               << std::endl;
 #endif
     gotStdException = true;
   } catch (...) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "In Test_Blas2_syr2, '" << situation << "', ger() call 2: caught unknown exception" << std::endl;
 #endif
     gotUnknownException = true;
@@ -1398,7 +1398,7 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>
 }  // namespace Test
 
 template <class ScalarX, class ScalarY, class ScalarA, class Device>
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
 int test_syr2(const std::string& caseName) {
   std::cout << "+=============================================================="
                "============"
@@ -1420,7 +1420,7 @@ int test_syr2(const std::string& /*caseName*/) {
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "+--------------------------------------------------------------"
                "------------"
             << std::endl;
@@ -1453,7 +1453,7 @@ int test_syr2(const std::string& /*caseName*/) {
     tester.test(2131, 0);
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Finished " << caseName << " for LAYOUTLEFT" << std::endl;
   std::cout << "+--------------------------------------------------------------"
                "------------"
@@ -1463,7 +1463,7 @@ int test_syr2(const std::string& /*caseName*/) {
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "+--------------------------------------------------------------"
                "------------"
             << std::endl;
@@ -1496,7 +1496,7 @@ int test_syr2(const std::string& /*caseName*/) {
     tester.test(2131, 0);
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Finished " << caseName << " for LAYOUTRIGHT" << std::endl;
   std::cout << "+--------------------------------------------------------------"
                "------------"
@@ -1506,7 +1506,7 @@ int test_syr2(const std::string& /*caseName*/) {
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "+--------------------------------------------------------------"
                "------------"
             << std::endl;
@@ -1540,7 +1540,7 @@ int test_syr2(const std::string& /*caseName*/) {
     tester.test(2131, 0);
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Finished " << caseName << " for LAYOUTSTRIDE" << std::endl;
   std::cout << "+--------------------------------------------------------------"
                "------------"
@@ -1549,7 +1549,7 @@ int test_syr2(const std::string& /*caseName*/) {
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "+--------------------------------------------------------------"
                "------------"
             << std::endl;
@@ -1579,7 +1579,7 @@ int test_syr2(const std::string& /*caseName*/) {
     tester.test(1024, 0);
   }
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Finished " << caseName << " for MIXED LAYOUTS" << std::endl;
   std::cout << "+--------------------------------------------------------------"
                "------------"
@@ -1587,7 +1587,7 @@ int test_syr2(const std::string& /*caseName*/) {
 #endif
 #endif
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Finished " << caseName << std::endl;
   std::cout << "+=============================================================="
                "============"

--- a/common/src/KokkosKernels_Macros.hpp
+++ b/common/src/KokkosKernels_Macros.hpp
@@ -11,11 +11,6 @@
 #include <KokkosKernels_config.h>
 /****** END macros populated by CMake ******/
 
-/****** BEGIN other helper macros ******/
-#ifndef KOKKOSKERNELS_DEBUG_LEVEL
-#define KOKKOSKERNELS_DEBUG_LEVEL 1
-#endif
-
 // If KOKKOSKERNELS_ENABLE_OMP_SIMD is defined, it's legal to place
 // "#pragma omp simd" before a for loop. It's never defined if a GPU-type device
 // is enabled, since in that case, Kokkos::ThreadVectorRange should be used

--- a/example/batched_solve/static_pivoting.cpp
+++ b/example/batched_solve/static_pivoting.cpp
@@ -3,8 +3,6 @@
 
 #include <fstream>
 
-#define KOKKOSKERNELS_DEBUG_LEVEL 0
-
 #include "Kokkos_Core.hpp"
 #include "Kokkos_Timer.hpp"
 #include "Kokkos_Random.hpp"

--- a/example/batched_solve/team_GMRES.cpp
+++ b/example/batched_solve/team_GMRES.cpp
@@ -3,8 +3,6 @@
 
 #include <fstream>
 
-#define KOKKOSKERNELS_DEBUG_LEVEL 0
-
 #include "Kokkos_Core.hpp"
 #include "Kokkos_Timer.hpp"
 #include "Kokkos_Random.hpp"

--- a/ode/unit_test/Test_ODE_BDF.hpp
+++ b/ode/unit_test/Test_ODE_BDF.hpp
@@ -199,7 +199,7 @@ void test_BDF_Logistic() {
   scalar_type measured_order;
 
   // Test BDF1
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
   std::cout << "\nBDF1 convergence test" << std::endl;
 #endif
   for (int idx = 0; idx < num_tests; idx++) {
@@ -220,13 +220,13 @@ void test_BDF_Logistic() {
   }
   measured_order = Kokkos::pow(errors[num_tests - 1] / errors[0], 1.0 / (num_tests - 1));
   EXPECT_NEAR_KK_REL(measured_order, 2.0, 0.15);
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
   std::cout << "expected ratio: 2, actual ratio: " << measured_order
             << ", order error=" << Kokkos::abs(measured_order - 2.0) / 2.0 << std::endl;
 #endif
 
   // Test BDF2
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
   std::cout << "\nBDF2 convergence test" << std::endl;
 #endif
   for (int idx = 0; idx < num_tests; idx++) {
@@ -245,13 +245,13 @@ void test_BDF_Logistic() {
   }
   measured_order = Kokkos::pow(errors[num_tests - 1] / errors[0], 1.0 / (num_tests - 1));
   EXPECT_NEAR_KK_REL(measured_order, 4.0, 0.15);
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
   std::cout << "expected ratio: 4, actual ratio: " << measured_order
             << ", order error=" << Kokkos::abs(measured_order - 4.0) / 4.0 << std::endl;
 #endif
 
   // Test BDF3
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
   std::cout << "\nBDF3 convergence test" << std::endl;
 #endif
   for (int idx = 0; idx < num_tests; idx++) {
@@ -270,13 +270,13 @@ void test_BDF_Logistic() {
   }
   measured_order = Kokkos::pow(errors[num_tests - 1] / errors[0], 1.0 / (num_tests - 1));
   EXPECT_NEAR_KK_REL(measured_order, 8.0, 0.15);
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
   std::cout << "expected ratio: 8, actual ratio: " << measured_order
             << ", order error=" << Kokkos::abs(measured_order - 8.0) / 8.0 << std::endl;
 #endif
 
   // Test BDF4
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
   std::cout << "\nBDF4 convergence test" << std::endl;
 #endif
   for (int idx = 0; idx < num_tests; idx++) {
@@ -294,13 +294,13 @@ void test_BDF_Logistic() {
     errors[idx] = Kokkos::abs(y_new_h(0) - 1 / (1 + Kokkos::exp(-t_end))) / Kokkos::abs(1 / (1 + Kokkos::exp(-t_end)));
   }
   measured_order = Kokkos::pow(errors[num_tests - 1] / errors[0], 1.0 / (num_tests - 1));
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
   std::cout << "expected ratio: 16, actual ratio: " << measured_order
             << ", order error=" << Kokkos::abs(measured_order - 16.0) / 16.0 << std::endl;
 #endif
 
   // Test BDF5
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
   std::cout << "\nBDF5 convergence test" << std::endl;
 #endif
   for (int idx = 0; idx < num_tests; idx++) {
@@ -318,7 +318,7 @@ void test_BDF_Logistic() {
     errors[idx] = Kokkos::abs(y_new_h(0) - 1 / (1 + Kokkos::exp(-t_end))) / Kokkos::abs(1 / (1 + Kokkos::exp(-t_end)));
   }
   measured_order = Kokkos::pow(errors[num_tests - 1] / errors[0], 1.0 / (num_tests - 1));
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
   std::cout << "expected ratio: 32, actual ratio: " << measured_order
             << ", order error=" << Kokkos::abs(measured_order - 32.0) / 32.0 << std::endl;
 #endif

--- a/ode/unit_test/Test_ODE_Newton.hpp
+++ b/ode/unit_test/Test_ODE_Newton.hpp
@@ -93,7 +93,7 @@ void run_newton_test(const system_type& mySys, KokkosODE::Experimental::Newton_p
 
   Kokkos::deep_copy(x_h, x);
   Kokkos::deep_copy(r_h, rhs);
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   std::cout << "Non-linear problem solution and residual:" << std::endl;
   std::cout << "  [(";
   for (int eqIdx = 0; eqIdx < mySys.neqs; ++eqIdx) {
@@ -193,7 +193,7 @@ void test_newton_status() {
   QuadraticEquation<Device, scalar_type> my_system{};
 
   scalar_type initial_value[3] = {1.0, -0.5, 0.5};
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   scalar_type solution[3] = {2.0, -1.0, 0.0};
 #endif
   newton_solver_status newton_status[3] = {newton_solver_status::NLS_SUCCESS, newton_solver_status::NLS_DIVERGENCE,
@@ -216,7 +216,7 @@ void test_newton_status() {
     Kokkos::deep_copy(status_h, status);
     EXPECT_TRUE(status_h(0) == newton_status[idx]);
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     Kokkos::deep_copy(x_h, x);
     Kokkos::deep_copy(r_h, rhs);
     printf("Non-linear problem solution and residual with initial value %f:\n", initial_value[idx]);
@@ -243,7 +243,7 @@ void test_simple_problems() {
     // Test the Newton solver on a quadratci equation
     // with two different initial guess that lead to
     // the two solutions of the equation.
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "\nStarting Quadratic Equation problem" << std::endl;
 #endif
     using system_type = QuadraticEquation<Device, scalar_type>;
@@ -252,28 +252,28 @@ void test_simple_problems() {
     for (int idx = 0; idx < 2; ++idx) {
       run_newton_test<system_type, Device, scalar_type>(mySys, params, &(initial_value[idx]), &(solution[idx]));
     }
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "Finished Quadratic Equation problem" << std::endl;
 #endif
   }
 
   {
     // Test the Newton solver on a trigonometric equation
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "\nStarting Trigonometric Equation problem" << std::endl;
 #endif
     using system_type = TrigonometricEquation<Device, scalar_type>;
     system_type mySys{};
     scalar_type initial_value[1] = {0.1}, solution[1] = {0.739085};
     run_newton_test<system_type, Device, scalar_type>(mySys, params, initial_value, solution);
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "Finished Trigonometric Equation problem" << std::endl;
 #endif
   }
 
   {
     // Test the Newton solver on a logarithmic equation
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "\nStarting Logarithmic Equation problem" << std::endl;
 #endif
     using system_type = LogarithmicEquation<Device, scalar_type>;
@@ -281,7 +281,7 @@ void test_simple_problems() {
     scalar_type initial_value[1] = {static_cast<scalar_type>(0.5)},
                 solution[1]      = {static_cast<scalar_type>(1.0) / static_cast<scalar_type>(7.0)};
     run_newton_test<system_type, Device, scalar_type>(mySys, params, initial_value, solution);
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "Finished Logarithmic Equation problem" << std::endl;
 #endif
   }
@@ -374,7 +374,7 @@ void test_simple_systems() {
 
   {
     // First problem: intersection of two circles
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "\nStarting Circles Intersetcion problem" << std::endl;
 #endif
     using system_type = CirclesIntersections<Device, scalar_type>;
@@ -382,14 +382,14 @@ void test_simple_systems() {
     scalar_type initial_values[2] = {1.5, 1.5};
     scalar_type solution[2]       = {10.75 / 6, 0.8887803753};
     run_newton_test<system_type, Device, scalar_type>(mySys, params, initial_values, solution);
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "Finished Circles Intersetcion problem" << std::endl;
 #endif
   }
 
   {
     // Second problem: circle / hyperbola intersection
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "\nStarting Circle/Hyperbola Intersetcion problem" << std::endl;
 #endif
     using system_type = CircleHyperbolaIntersection<Device, scalar_type>;
@@ -401,7 +401,7 @@ void test_simple_systems() {
             Kokkos::sqrt(static_cast<scalar_type>(4 + Kokkos::sqrt(static_cast<scalar_type>(12.0)) / 2)),
         Kokkos::sqrt(static_cast<scalar_type>((4 + Kokkos::sqrt(static_cast<scalar_type>(12.0))) / 2))};
     run_newton_test<system_type, Device, scalar_type>(mySys, params, init_vals, solutions);
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
     std::cout << "Finished Circle/Hyperbola Intersetcion problem" << std::endl;
 #endif
   }

--- a/ode/unit_test/Test_ODE_RK.hpp
+++ b/ode/unit_test/Test_ODE_RK.hpp
@@ -122,7 +122,7 @@ void test_method(const std::string label, ode_type& my_ode, const scalar_type& t
 
   EXPECT_EQ(solver_type::order(), order);
   EXPECT_EQ(solver_type::num_stages(), num_stages);
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
   std::cout << "\n" << label << std::endl;
   std::cout << "  order: " << solver_type::order() << std::endl;
   std::cout << "  number of stages: " << solver_type::num_stages() << std::endl;
@@ -132,14 +132,14 @@ void test_method(const std::string label, ode_type& my_ode, const scalar_type& t
   for (int stageIdx = 0; stageIdx < solver_type::num_stages(); ++stageIdx) {
     EXPECT_NEAR_KK(ks(0, stageIdx), kstack_h(stageIdx, 0), 1e-8);
     EXPECT_NEAR_KK(ks(1, stageIdx), kstack_h(stageIdx, 1), 1e-8);
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
     std::cout << "  k" << stageIdx << "={" << kstack_h(stageIdx, 0) << ", " << kstack_h(stageIdx, 1) << "}"
               << std::endl;
 #endif
   }
   EXPECT_NEAR_KK(sol(0), y_new_h(0), 1e-8);
   EXPECT_NEAR_KK(sol(1), y_new_h(1), 1e-8);
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
   std::cout << "  y={" << y_new_h(0) << ", " << y_new_h(1) << "}" << std::endl;
   std::cout << "  error={" << Kokkos::abs(y_new_h(0) - y_ref_h(0)) / Kokkos::abs(y_ref_h(0)) << ", "
             << Kokkos::abs(y_new_h(1) - y_ref_h(1)) / Kokkos::abs(y_ref_h(1)) << "}" << std::endl;
@@ -189,7 +189,7 @@ void test_RK() {
     Kokkos::parallel_for(my_policy, wrapper);
 
     Kokkos::deep_copy(y_ref_h, y_ref);
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
     std::cout << "\nAnalytical solution" << std::endl;
     std::cout << "  y={" << y_ref_h(0) << ", " << y_ref_h(1) << "}" << std::endl;
 #endif
@@ -302,7 +302,7 @@ void test_rate(ode_type& my_ode, const scalar_type& tstart, const scalar_type& t
     Kokkos::deep_copy(y_new_h, y_new);
     error(idx) = Kokkos::abs(y_new_h(0) - y_ref_h(0)) / Kokkos::abs(y_ref_h(0));
 
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
     scalar_type dt = (tend - tstart) / num_steps(idx);
     std::cout << "count=" << count(0) << ", dt=" << dt << ", error=" << error(idx) << ", solution: {" << y_new_h(0)
               << ", " << y_new_h(1) << "}" << std::endl;
@@ -358,7 +358,7 @@ void test_convergence_rate() {
     Kokkos::parallel_for(my_policy, wrapper);
 
     Kokkos::deep_copy(y_ref_h, y_ref);
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
     std::cout << "\nAnalytical solution" << std::endl;
     std::cout << "  y={" << y_ref_h(0) << ", " << y_ref_h(1) << "}" << std::endl;
 #endif
@@ -374,7 +374,7 @@ void test_convergence_rate() {
     double actual_ratio = error(idx + 1) / error(idx);
     EXPECT_NEAR_KK_REL(actual_ratio, expected_ratio, 0.15);
 
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
     double rel_ratio_diff = Kokkos::abs(actual_ratio - expected_ratio) / Kokkos::abs(expected_ratio);
     std::cout << "error ratio: " << actual_ratio << ", expected ratio: " << expected_ratio
               << ", rel diff: " << rel_ratio_diff << std::endl;
@@ -391,7 +391,7 @@ void test_convergence_rate() {
     double actual_ratio = error(idx + 1) / error(idx);
     EXPECT_NEAR_KK_REL(actual_ratio, expected_ratio, 0.05);
 
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
     double rel_ratio_diff = Kokkos::abs(actual_ratio - expected_ratio) / Kokkos::abs(expected_ratio);
     std::cout << "error ratio: " << actual_ratio << ", expected ratio: " << expected_ratio
               << ", rel diff: " << rel_ratio_diff << std::endl;
@@ -408,7 +408,7 @@ void test_convergence_rate() {
     double actual_ratio = error(idx + 1) / error(idx);
     EXPECT_NEAR_KK_REL(actual_ratio, expected_ratio, 0.05);
 
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
     double rel_ratio_diff = Kokkos::abs(actual_ratio - expected_ratio) / Kokkos::abs(expected_ratio);
     std::cout << "error ratio: " << actual_ratio << ", expected ratio: " << expected_ratio
               << ", rel diff: " << rel_ratio_diff << std::endl;
@@ -458,7 +458,7 @@ void test_adaptivity() {
     Kokkos::parallel_for(my_policy, wrapper);
 
     Kokkos::deep_copy(y_ref_h, y_ref);
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
     std::cout << "\nAnalytical solution" << std::endl;
     std::cout << "  y={" << y_ref_h(0) << ", " << y_ref_h(1) << "}" << std::endl;
 #endif
@@ -477,7 +477,7 @@ void test_adaptivity() {
 
   auto y_new_h = Kokkos::create_mirror(y_new);
   Kokkos::deep_copy(y_new_h, y_new);
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
   std::cout << "Results: " << std::endl;
   std::cout << "  y_ref={ ";
   for (int idx = 0; idx < y_ref_h.extent_int(0); ++idx) {
@@ -494,13 +494,13 @@ void test_adaptivity() {
 #endif
 
   for (int idx = 0; idx < y_new_h.extent_int(0); ++idx) {
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
     error = Kokkos::abs(y_new_h(idx) - y_ref_h(idx)) / Kokkos::abs(y_ref_h(idx));
     std::cout << error << " ";
 #endif
     EXPECT_NEAR_KK_REL(y_new_h(idx), y_ref_h(idx), 1e-7);
   }
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
   std::cout << "}" << std::endl;
 #endif
 

--- a/ode/unit_test/Test_ODE_RK_chem.hpp
+++ b/ode/unit_test/Test_ODE_RK_chem.hpp
@@ -107,7 +107,7 @@ void test_chem() {
 
     auto y_new_h = Kokkos::create_mirror(y_new);
     Kokkos::deep_copy(y_new_h, y_new);
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
     const double dt = (chem_model.tend - chem_model.tstart) / params.num_steps;
     std::cout << "\nChem model 1" << std::endl;
     std::cout << "  t0=" << chem_model.tstart << ", tn=" << chem_model.tend << std::endl;
@@ -149,7 +149,7 @@ void test_chem() {
 
     auto y_new_h = Kokkos::create_mirror(y_new);
     Kokkos::deep_copy(y_new_h, y_new);
-#if defined(HAVE_KOKKOSKERNELS_DEBUG)
+#ifndef NDEBUG
     const double dt = (chem_model.tend - chem_model.tstart) / params.num_steps;
     std::cout << "\nChem model 2" << std::endl;
     std::cout << "  t0=" << chem_model.tstart << ", tn=" << chem_model.tend << std::endl;

--- a/perf_test/batched/sparse/GMRES/KokkosBatched_Test_GMRES.cpp
+++ b/perf_test/batched/sparse/GMRES/KokkosBatched_Test_GMRES.cpp
@@ -3,8 +3,6 @@
 
 #include <fstream>
 
-#define KOKKOSKERNELS_DEBUG_LEVEL 0
-
 /// Kokkos headers
 #include "Kokkos_Core.hpp"
 

--- a/perf_test/batched/sparse/cusolver/KokkosBatched_Test_cusolverDn.cpp
+++ b/perf_test/batched/sparse/cusolver/KokkosBatched_Test_cusolverDn.cpp
@@ -3,8 +3,6 @@
 
 #include <fstream>
 
-#define KOKKOSKERNELS_DEBUG_LEVEL 0
-
 /// Kokkos headers
 #include "Kokkos_Core.hpp"
 #include "Kokkos_Timer.hpp"

--- a/perf_test/batched/sparse/cusolver/KokkosBatched_Test_cusolverSp.cpp
+++ b/perf_test/batched/sparse/cusolver/KokkosBatched_Test_cusolverSp.cpp
@@ -3,8 +3,6 @@
 
 #include <fstream>
 
-#define KOKKOSKERNELS_DEBUG_LEVEL 0
-
 /// Kokkos headers
 #include "Kokkos_Core.hpp"
 #include "Kokkos_Timer.hpp"

--- a/sparse/src/KokkosSparse_coo2crs.hpp
+++ b/sparse/src/KokkosSparse_coo2crs.hpp
@@ -27,14 +27,12 @@ namespace KokkosSparse {
 // clang-format on
 template <class DimType, class RowViewType, class ColViewType, class DataViewType>
 auto coo2crs(DimType m, DimType n, RowViewType row, ColViewType col, DataViewType data) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<RowViewType>::value, "RowViewType must be a Kokkos::View.");
   static_assert(Kokkos::is_view<ColViewType>::value, "CalViewType must be a Kokkos::View.");
   static_assert(Kokkos::is_view<DataViewType>::value, "DataViewType must be a Kokkos::View.");
   static_assert(static_cast<int>(RowViewType::rank) == 1, "RowViewType must have rank 1.");
   static_assert(static_cast<int>(ColViewType::rank) == 1, "ColViewType must have rank 1.");
   static_assert(static_cast<int>(DataViewType::rank) == 1, "DataViewType must have rank 1.");
-#endif
 
   static_assert(std::is_integral<typename RowViewType::value_type>::value,
                 "RowViewType::value_type must be an integral.");

--- a/sparse/src/KokkosSparse_coo2crs.hpp
+++ b/sparse/src/KokkosSparse_coo2crs.hpp
@@ -27,7 +27,7 @@ namespace KokkosSparse {
 // clang-format on
 template <class DimType, class RowViewType, class ColViewType, class DataViewType>
 auto coo2crs(DimType m, DimType n, RowViewType row, ColViewType col, DataViewType data) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<RowViewType>::value, "RowViewType must be a Kokkos::View.");
   static_assert(Kokkos::is_view<ColViewType>::value, "CalViewType must be a Kokkos::View.");
   static_assert(Kokkos::is_view<DataViewType>::value, "DataViewType must be a Kokkos::View.");

--- a/sparse/src/KokkosSparse_spmv_team.hpp
+++ b/sparse/src/KokkosSparse_spmv_team.hpp
@@ -29,7 +29,7 @@ int KOKKOS_INLINE_FUNCTION team_spmv(const TeamType &team, const ScalarType &alp
   static_assert(static_cast<int>(xViewType::rank) == 1, "xViewType must have rank 1.");
   static_assert(static_cast<int>(yViewType::rank) == 1, "yViewType must have rank 1.");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   // Check compatibility of dimensions at run time.
   if (values.extent(0) != colIndices.extent(0)) {
     Kokkos::printf(
@@ -46,7 +46,7 @@ int KOKKOS_INLINE_FUNCTION team_spmv(const TeamType &team, const ScalarType &alp
         (int)x.extent(0), (int)y.extent(0), (int)row_ptr.extent(0));
     return 1;
   }
-#endif  // HAVE_KOKKOSKERNELS_DEBUG
+#endif  // NDEBUG
 
   if (dobeta == 1)
     return KokkosSparse::TeamSpmv<TeamType>::template invoke<ScalarType, ValuesViewType, IntView, xViewType, yViewType,
@@ -71,7 +71,7 @@ int KOKKOS_INLINE_FUNCTION team_vector_spmv(const TeamType &team, const ScalarTy
   static_assert(static_cast<int>(xViewType::rank) == 1, "xViewType must have rank 1.");
   static_assert(static_cast<int>(yViewType::rank) == 1, "yViewType must have rank 1.");
 
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
+#ifndef NDEBUG
   // Check compatibility of dimensions at run time.
   if (values.extent(0) != colIndices.extent(0)) {
     Kokkos::printf(
@@ -88,7 +88,7 @@ int KOKKOS_INLINE_FUNCTION team_vector_spmv(const TeamType &team, const ScalarTy
         (int)x.extent(0), (int)y.extent(0), (int)row_ptr.extent(0));
     return 1;
   }
-#endif  // HAVE_KOKKOSKERNELS_DEBUG
+#endif  // NDEBUG
 
   if (dobeta == 1)
     return KokkosSparse::TeamVectorSpmv<TeamType>::template invoke<ScalarType, ValuesViewType, IntView, xViewType,

--- a/sparse/src/KokkosSparse_spmv_team.hpp
+++ b/sparse/src/KokkosSparse_spmv_team.hpp
@@ -20,7 +20,6 @@ template <class TeamType, class ScalarType, class ValuesViewType, class IntView,
 int KOKKOS_INLINE_FUNCTION team_spmv(const TeamType &team, const ScalarType &alpha, const ValuesViewType &values,
                                      const IntView &row_ptr, const IntView &colIndices, const xViewType &x,
                                      const ScalarType &beta, const yViewType &y, const int dobeta) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<ValuesViewType>::value, "ValuesViewType must be a Kokkos::View.");
   static_assert(Kokkos::is_view<IntView>::value, "IntView must be a Kokkos::View.");
   static_assert(Kokkos::is_view<xViewType>::value, "xViewType must be a Kokkos::View.");
@@ -30,6 +29,7 @@ int KOKKOS_INLINE_FUNCTION team_spmv(const TeamType &team, const ScalarType &alp
   static_assert(static_cast<int>(xViewType::rank) == 1, "xViewType must have rank 1.");
   static_assert(static_cast<int>(yViewType::rank) == 1, "yViewType must have rank 1.");
 
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   // Check compatibility of dimensions at run time.
   if (values.extent(0) != colIndices.extent(0)) {
     Kokkos::printf(
@@ -62,7 +62,6 @@ template <class TeamType, class ScalarType, class ValuesViewType, class IntView,
 int KOKKOS_INLINE_FUNCTION team_vector_spmv(const TeamType &team, const ScalarType &alpha, const ValuesViewType &values,
                                             const IntView &row_ptr, const IntView &colIndices, const xViewType &x,
                                             const ScalarType &beta, const yViewType &y, const int dobeta) {
-#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<ValuesViewType>::value, "ValuesViewType must be a Kokkos::View.");
   static_assert(Kokkos::is_view<IntView>::value, "IntView must be a Kokkos::View.");
   static_assert(Kokkos::is_view<xViewType>::value, "xViewType must be a Kokkos::View.");
@@ -72,6 +71,7 @@ int KOKKOS_INLINE_FUNCTION team_vector_spmv(const TeamType &team, const ScalarTy
   static_assert(static_cast<int>(xViewType::rank) == 1, "xViewType must have rank 1.");
   static_assert(static_cast<int>(yViewType::rank) == 1, "yViewType must have rank 1.");
 
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   // Check compatibility of dimensions at run time.
   if (values.extent(0) != colIndices.extent(0)) {
     Kokkos::printf(

--- a/sparse/src/KokkosSparse_spmv_team.hpp
+++ b/sparse/src/KokkosSparse_spmv_team.hpp
@@ -20,7 +20,7 @@ template <class TeamType, class ScalarType, class ValuesViewType, class IntView,
 int KOKKOS_INLINE_FUNCTION team_spmv(const TeamType &team, const ScalarType &alpha, const ValuesViewType &values,
                                      const IntView &row_ptr, const IntView &colIndices, const xViewType &x,
                                      const ScalarType &beta, const yViewType &y, const int dobeta) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<ValuesViewType>::value, "ValuesViewType must be a Kokkos::View.");
   static_assert(Kokkos::is_view<IntView>::value, "IntView must be a Kokkos::View.");
   static_assert(Kokkos::is_view<xViewType>::value, "xViewType must be a Kokkos::View.");
@@ -46,7 +46,7 @@ int KOKKOS_INLINE_FUNCTION team_spmv(const TeamType &team, const ScalarType &alp
         (int)x.extent(0), (int)y.extent(0), (int)row_ptr.extent(0));
     return 1;
   }
-#endif  // KOKKOSKERNELS_DEBUG_LEVEL
+#endif  // HAVE_KOKKOSKERNELS_DEBUG
 
   if (dobeta == 1)
     return KokkosSparse::TeamSpmv<TeamType>::template invoke<ScalarType, ValuesViewType, IntView, xViewType, yViewType,
@@ -62,7 +62,7 @@ template <class TeamType, class ScalarType, class ValuesViewType, class IntView,
 int KOKKOS_INLINE_FUNCTION team_vector_spmv(const TeamType &team, const ScalarType &alpha, const ValuesViewType &values,
                                             const IntView &row_ptr, const IntView &colIndices, const xViewType &x,
                                             const ScalarType &beta, const yViewType &y, const int dobeta) {
-#if (KOKKOSKERNELS_DEBUG_LEVEL > 0)
+#ifdef HAVE_KOKKOSKERNELS_DEBUG
   static_assert(Kokkos::is_view<ValuesViewType>::value, "ValuesViewType must be a Kokkos::View.");
   static_assert(Kokkos::is_view<IntView>::value, "IntView must be a Kokkos::View.");
   static_assert(Kokkos::is_view<xViewType>::value, "xViewType must be a Kokkos::View.");
@@ -88,7 +88,7 @@ int KOKKOS_INLINE_FUNCTION team_vector_spmv(const TeamType &team, const ScalarTy
         (int)x.extent(0), (int)y.extent(0), (int)row_ptr.extent(0));
     return 1;
   }
-#endif  // KOKKOSKERNELS_DEBUG_LEVEL
+#endif  // HAVE_KOKKOSKERNELS_DEBUG
 
   if (dobeta == 1)
     return KokkosSparse::TeamVectorSpmv<TeamType>::template invoke<ScalarType, ValuesViewType, IntView, xViewType,


### PR DESCRIPTION
We had a mix of HAVE_KOKKOSKERNELS_DEBUG and KOKKOSKERNELS_DEBUG_LEVEL>0 as cpp guards for debug segments. The latter was not configurable from cmake. The former is not on for standalone builds, so I just changed everything to `$ifndef NDEBUG`.

This PR also rearranges all debug cpp checks to never guard `static_asserts`. We always want the static asserts on.

Fixes #2899 