### PR TITLE
Fix Cuda debug builds

### DIFF
--- a/.github/workflows/h100_lychee.yml
+++ b/.github/workflows/h100_lychee.yml
@@ -20,8 +20,8 @@ on:
         type: string
 
 jobs:
-  PR_HOPPER90_CUDA1262_CUDA_LEFT_RIGHT_REL:
-    name: PR_HOPPER90_CUDA1262_CUDA_LEFT_RIGHT_REL
+  PR_HOPPER90_CUDA1262_CUDA_LEFT_RIGHT_DEBUG:
+    name: PR_HOPPER90_CUDA1262_CUDA_LEFT_RIGHT_DEBUG
     runs-on: [lychee-cuda-12.6.2-openblas-0.3.28]
     
     steps:
@@ -66,7 +66,7 @@ jobs:
         run: |
           mkdir -p kokkos-kernels/{build,install}
           cmake -S kokkos-kernels -B kokkos-kernels/build \
-            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_CXX_COMPILER=$(realpath kokkos)/bin/nvcc_wrapper \
             -DKokkos_ROOT=kokkos/install \
             -DKokkosKernels_ENABLE_TESTS_AND_PERFSUITE=OFF \

--- a/.github/workflows/h100_lychee.yml
+++ b/.github/workflows/h100_lychee.yml
@@ -89,6 +89,75 @@ jobs:
         working-directory: kokkos-kernels/build
         run: ctest --output-on-failure -V --timeout 3600
 
+  PR_HOPPER90_CUDA1262_CUDA_LEFT_RIGHT_REL:
+    name: PR_HOPPER90_CUDA1262_CUDA_LEFT_RIGHT_REL
+    runs-on: [lychee-cuda-12.6.2-openblas-0.3.28]
+    
+    steps:
+      - name: nvidia-smi
+        run: nvidia-smi
+
+      - name: cuda-visible-devices
+        run: echo $CUDA_VISIBLE_DEVICES
+
+      - name: checkout_kokkos_kernels
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: kokkos-kernels
+
+      - name: checkout_kokkos
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: kokkos/kokkos
+          ref: ${{ inputs.kokkos_version }}
+          path: kokkos
+
+      - name: configure_kokkos
+        run: |
+          mkdir -p kokkos/{build,install}
+          cmake -S kokkos -B kokkos/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER=$(realpath kokkos)/bin/nvcc_wrapper \
+            -DCMAKE_INSTALL_PREFIX=kokkos/install \
+            -DKokkos_ENABLE_CUDA=ON \
+            -DKokkos_ARCH_HOPPER90=ON \
+            -DKokkos_ENABLE_TESTS=OFF \
+            -DKokkos_ENABLE_EXAMPLES=OFF \
+            -DCMAKE_CXX_EXTENSIONS=OFF \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DKokkos_ENABLE_DEPRECATED_CODE_5=OFF
+
+      - name: build_and_install_kokkos
+        working-directory: kokkos/build
+        run: make -j56 install
+
+      - name: configure_kokkos_kernels
+        run: |
+          mkdir -p kokkos-kernels/{build,install}
+          cmake -S kokkos-kernels -B kokkos-kernels/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER=$(realpath kokkos)/bin/nvcc_wrapper \
+            -DKokkos_ROOT=kokkos/install \
+            -DKokkosKernels_ENABLE_TESTS_AND_PERFSUITE=OFF \
+            -DKokkosKernels_ENABLE_TESTS=ON \
+            -DKokkosKernels_ENABLE_PERFTESTS=ON \
+            -DKokkosKernels_ENABLE_EXAMPLES=ON \
+            -DKokkosKernels_ENABLE_TPL_CUSOLVER=OFF \
+            -DKokkosKernels_ENABLE_TPL_CUSPARSE=OFF \
+            -DKokkosKernels_ENABLE_TPL_CUBLAS=OFF \
+            -DKokkosKernels_INST_LAYOUTRIGHT=ON \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DKokkosKernels_ENABLE_DOCS=OFF
+
+      - name: build_kokkos_kernels
+        working-directory: kokkos-kernels/build
+        # lychee has 224 CPUs
+        run: make -j56 all
+
+      - name: test
+        working-directory: kokkos-kernels/build
+        run: ctest --output-on-failure -V --timeout 3600
+
   PR_HOPPER90_CUDA1262_CUDA_LEFT_RIGHT_TPLS_REL:
     name: PR_HOPPER90_CUDA1262_CUDA_LEFT_RIGHT_TPLS_REL
     runs-on: [lychee-cuda-12.6.2-openblas-0.3.28]

--- a/ode/unit_test/Test_ODE_Newton.hpp
+++ b/ode/unit_test/Test_ODE_Newton.hpp
@@ -98,10 +98,10 @@ void run_newton_test(const system_type& mySys, KokkosODE::Experimental::Newton_p
   std::cout << "  [(";
   for (int eqIdx = 0; eqIdx < mySys.neqs; ++eqIdx) {
     std::cout << " " << x_h(eqIdx);
-  }
-  std::cout << " ), " << KokkosBlas::serial_nrm2(rhs) << ", (";
-  for (int eqIdx = 0; eqIdx < mySys.neqs; ++eqIdx) {
-    std::cout << " " << Kokkos::abs(x_h(eqIdx) - solution[eqIdx]) / Kokkos::abs(solution[eqIdx]);
+    if (Kokkos::abs(solution[eqIdx]) > 0)
+      std::cout << ", " << Kokkos::abs(x_h(eqIdx) - solution[eqIdx]) / Kokkos::abs(solution[eqIdx]);
+    else
+      std::cout << ", " << Kokkos::abs(x_h(eqIdx) - solution[eqIdx]);
   }
   std::cout << " )]" << std::endl;
 #else

--- a/ode/unit_test/Test_ODE_RK.hpp
+++ b/ode/unit_test/Test_ODE_RK.hpp
@@ -304,7 +304,9 @@ void test_rate(ode_type& my_ode, const scalar_type& tstart, const scalar_type& t
 
 #ifndef NDEBUG
     scalar_type dt = (tend - tstart) / num_steps(idx);
-    std::cout << "count=" << count(0) << ", dt=" << dt << ", error=" << error(idx) << ", solution: {" << y_new_h(0)
+    auto h_count   = Kokkos::create_mirror_view(count);
+    Kokkos::deep_copy(h_count, count);
+    std::cout << "h_count=" << h_count(0) << ", dt=" << dt << ", error=" << error(idx) << ", solution: {" << y_new_h(0)
               << ", " << y_new_h(1) << "}" << std::endl;
 #endif
   }


### PR DESCRIPTION
Fix unit test errors

1. `Cuda.RK_conv_rate`

```
03:53:26 [ RUN      ] Cuda.RK_conv_rate
03:53:26 
03:53:26 Analytical solution
03:53:26   y={-0.0982989, -1.13423}
03:53:26 count=Kokkos::View ERROR: attempt to access inaccessible memory space (label="time step count")
```

2. `Cuda.Newton_simple` segfaults
caused by passing `rhs` instead of `r_h` to `KokkosBlas::serial_nrm2`; cleaned up output to couple solution and residual for each iteration

I also converted the `PR_HOPPER90_CUDA1262_CUDA_LEFT_RIGHT_REL` CI job to a Debug build, the first run of the PR will indicate the cost for a Debug job. For comparison, in PR https://github.com/kokkos/kokkos-kernels/pull/2917 `PR_HOPPER90_CUDA1262_CUDA_LEFT_RIGHT_REL` ran for ~15 min see [here](https://github.com/kokkos/kokkos-kernels/actions/runs/21372466807/job/62242018519)