### PR TITLE
workflows: updates after 5.0.2 release

### DIFF
--- a/.github/workflows/at2.yml
+++ b/.github/workflows/at2.yml
@@ -19,23 +19,23 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  KOKKOS_VERSION: 5.0.1
+  KOKKOS_VERSION: 5.0.2
 
 jobs:
   h100_lychee:
     uses: ./.github/workflows/h100_lychee.yml
     with:
-      kokkos_version: 5.0.1
+      kokkos_version: 5.0.2
   v100_kumquat:
     uses: ./.github/workflows/v100_kumquat.yml
     with:
-      kokkos_version: 5.0.1
+      kokkos_version: 5.0.2
       kokkos_previous_version: 4.7.02
   host:
     uses: ./.github/workflows/host.yml
     with:
-      kokkos_version: 5.0.1
+      kokkos_version: 5.0.2
   mi210:
     uses: ./.github/workflows/mi210.yml
     with:
-      kokkos_version: 5.0.1
+      kokkos_version: 5.0.2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,7 @@ jobs:
       with:
         repository: 'kokkos/kokkos'
         path: 'kokkos'
-        ref: '5.0.1'
+        ref: '5.0.2'
 
     - name: configure_kokkos
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  kokkos_version: 5.0.1
+  kokkos_version: 5.0.2
 
 jobs:
   check-pr-labels:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  kokkos_version: 5.0.1
+  kokkos_version: 5.0.2
 
 jobs:
   check-pr-labels:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       # Upload provenance to a new release


### PR DESCRIPTION
Mostly bumping up the Kokkos Core version to build against Also reverting the from sha to version for the slsa verifier so we don't get into troubles for the next release.