### PR TITLE
docs: adding wiki example for axpy and including it in docs

### DIFF
--- a/docs/source/API/blas/blas1_axpy.rst
+++ b/docs/source/API/blas/blas1_axpy.rst
@@ -52,33 +52,11 @@ Type Requirements
 Example
 =======
 
-.. code:: c++
+.. literalinclude:: ../../../../example/wiki/blas/KokkosBlas1_wiki_axpy.cpp
+  :language: c++
 
-  #include<Kokkos_Core.hpp>
-  #include<KokkosBlas1_axpby.hpp>
+output:
 
-  int main(int argc, char* argv[]) {
-    Kokkos::initialize();
-    {
+.. code::
 
-      int N = atoi(argv[1]);
-
-      Kokkos::View<double*> x("X",N);
-      Kokkos::View<double*> y("Y",N);
-      Kokkos::deep_copy(x,3.0);
-      Kokkos::deep_copy(y,2.0);
-
-      double alpha = 1.5;
-
-      KokkosBlas::axpy(alpha,x,y);
-
-      double sum = 0.0;
-      Kokkos::parallel_reduce("CheckValue", N, KOKKOS_LAMBDA (const int& i, double& lsum) {
-        lsum += y(i);
-      },sum);
-
-      printf("Sum: %lf Expected: %lf Diff: %e\n",sum,1.0*N*(2.0+1.5*3.0),sum-1.0*N);
-    }
-
-    Kokkos::finalize();
-  }
+  Sum: 65, Expected: 65, Diff: 0

--- a/example/wiki/blas/CMakeLists.txt
+++ b/example/wiki/blas/CMakeLists.txt
@@ -3,6 +3,7 @@ kokkoskernels_include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 kokkoskernels_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../../test_common)
 
+kokkoskernels_add_executable_and_test(wiki_blas1_axpy        SOURCES KokkosBlas1_wiki_axpy.cpp)
 kokkoskernels_add_executable_and_test(wiki_blas1_dot         SOURCES KokkosBlas1_wiki_dot.cpp)
 kokkoskernels_add_executable_and_test(wiki_blas1_iamax       SOURCES KokkosBlas1_wiki_iamax.cpp)
 kokkoskernels_add_executable_and_test(wiki_blas1_nrm1        SOURCES KokkosBlas1_wiki_nrm1.cpp)

--- a/example/wiki/blas/KokkosBlas1_wiki_axpy.cpp
+++ b/example/wiki/blas/KokkosBlas1_wiki_axpy.cpp
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#include<Kokkos_Core.hpp>
-#include<KokkosBlas1_axpby.hpp>
+#include <Kokkos_Core.hpp>
+#include <KokkosBlas1_axpby.hpp>
 
 #include <iostream>
 
@@ -10,25 +10,24 @@ int main(int argc, char* argv[]) {
   Kokkos::initialize(argc, argv);
   {
     int N = 10;
-    if(argc > 1) {
+    if (argc > 1) {
       N = atoi(argv[1]);
     }
 
-    Kokkos::View<double*> x("X",N);
-    Kokkos::View<double*> y("Y",N);
-    Kokkos::deep_copy(x,3.0);
-    Kokkos::deep_copy(y,2.0);
+    Kokkos::View<double*> x("X", N);
+    Kokkos::View<double*> y("Y", N);
+    Kokkos::deep_copy(x, 3.0);
+    Kokkos::deep_copy(y, 2.0);
 
     double alpha = 1.5;
 
-    KokkosBlas::axpy(alpha,x,y);
+    KokkosBlas::axpy(alpha, x, y);
 
     double sum = 0.0;
-    Kokkos::parallel_reduce("CheckValue", N, KOKKOS_LAMBDA (const int& i, double& lsum) {
-        lsum += y(i);
-      },sum);
+    Kokkos::parallel_reduce(
+        "CheckValue", N, KOKKOS_LAMBDA(const int& i, double& lsum) { lsum += y(i); }, sum);
 
-    const double expected = N*(2.0+1.5*3.0);
+    const double expected = N * (2.0 + 1.5 * 3.0);
     std::cout << "Sum: " << sum << ", Expected: " << expected << ", Diff: " << sum - expected << std::endl;
   }
 

--- a/example/wiki/blas/KokkosBlas1_wiki_axpy.cpp
+++ b/example/wiki/blas/KokkosBlas1_wiki_axpy.cpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include<Kokkos_Core.hpp>
+#include<KokkosBlas1_axpby.hpp>
+
+#include <iostream>
+
+int main(int argc, char* argv[]) {
+  Kokkos::initialize(argc, argv);
+  {
+    int N = 10;
+    if(argc > 1) {
+      N = atoi(argv[1]);
+    }
+
+    Kokkos::View<double*> x("X",N);
+    Kokkos::View<double*> y("Y",N);
+    Kokkos::deep_copy(x,3.0);
+    Kokkos::deep_copy(y,2.0);
+
+    double alpha = 1.5;
+
+    KokkosBlas::axpy(alpha,x,y);
+
+    double sum = 0.0;
+    Kokkos::parallel_reduce("CheckValue", N, KOKKOS_LAMBDA (const int& i, double& lsum) {
+        lsum += y(i);
+      },sum);
+
+    const double expected = N*(2.0+1.5*3.0);
+    std::cout << "Sum: " << sum << ", Expected: " << expected << ", Diff: " << sum - expected << std::endl;
+  }
+
+  Kokkos::finalize();
+}


### PR DESCRIPTION
Moving the code for the axpy example into a properly tested example and including it back to documentation with `literalinclude` directive.
Also fixing the math mistake in the verification piece at the end of the code.

@cmakrides-hpe thanks for reporting this issue!