### PR TITLE
Don't use KOKKOS_IF_ON_HOST/DEVICE in a constexpr way in `mb`

### DIFF
--- a/batched/dense/impl/KokkosBatched_Gemm_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemm_Serial_Internal.hpp
@@ -72,9 +72,6 @@ KOKKOS_INLINE_FUNCTION int SerialGemmInternal<Algo::Gemm::Blocked>::invoke(
   // C = beta C + alpha A B
   // C (m x n), A(m x k), B(k x n)
 
-  constexpr int mbAlgo = Algo::Gemm::Blocked::Impl::mb();
-  constexpr int nbAlgo = Algo::Gemm::Blocked::Impl::mb();
-
   const ScalarType one(1.0), zero(0.0);
 
   if (beta == zero)
@@ -86,43 +83,50 @@ KOKKOS_INLINE_FUNCTION int SerialGemmInternal<Algo::Gemm::Blocked>::invoke(
     if (m <= 0 || n <= 0 || k <= 0) return 0;
     const ValueType alpha_value(alpha);
 
-    InnerGemmFixC<mbAlgo, nbAlgo> inner(as0, as1, bs0, bs1, cs0, cs1);
-    auto gemm = [&](const int ib, const int jb, const int pb, const ValueType *KOKKOS_RESTRICT AA,
-                    const ValueType *KOKKOS_RESTRICT BB,
-                    /**/ ValueType *KOKKOS_RESTRICT CC) {
-      const int mb = mbAlgo, nb = nbAlgo;
-      for (int i = 0; i < ib; i += mb)
-        for (int j = 0; j < jb; j += nb)
-          inner.serial_invoke(opA, opB, alpha_value, AA + i * as0, BB + j * bs1, (i + mb) > ib ? (ib - i) : mb,
-                              (j + nb) > jb ? (jb - j) : nb, pb, CC + i * cs0 + j * cs1);
+    auto host_or_device = [&](auto tag) {
+      constexpr int mb = Algo::Gemm::Blocked::Impl::mb<decltype(tag)>();
+      constexpr int nb = Algo::Gemm::Blocked::Impl::mb<decltype(tag)>();
+      InnerGemmFixC<mb, nb> inner(as0, as1, bs0, bs1, cs0, cs1);
+      auto gemm = [&](const int ib, const int jb, const int pb, const ValueType *KOKKOS_RESTRICT AA,
+                      const ValueType *KOKKOS_RESTRICT BB,
+                      /**/ ValueType *KOKKOS_RESTRICT CC) {
+        for (int i = 0; i < ib; i += mb)
+          for (int j = 0; j < jb; j += nb)
+            inner.serial_invoke(opA, opB, alpha_value, AA + i * as0, BB + j * bs1, (i + mb) > ib ? (ib - i) : mb,
+                                (j + nb) > jb ? (jb - j) : nb, pb, CC + i * cs0 + j * cs1);
+      };
+
+      const bool is_small = true;  //(m*n*k <= 64*64*64);
+      if (is_small) {
+        gemm(m, n, k, A, B, C);
+      } else {
+        // // cache blocking
+        // const int
+        //   nc = nb*10, kc = mb*4, mc = mb*4;
+
+        // for (int jj=0;jj<n;jj+=nc) {
+        //   const int tj = n-jj, jb = (tj < nc ? tj : nc);
+        //   for (int pp=0;pp<k;pp+=kc) {
+        //     const int tp = k-pp, pb = (tp < kc ? tp : kc);
+        //     //const int pb = k, pp = 0;
+        //     for (int ii=0;ii<m;ii+=mc) {
+        //       const int ti = m-ii, ib = (ti < mc ? ti : mc);
+
+        //       const ValueType *KOKKOS_RESTRICT AA = A+ii*as0+pp*as1;
+        //       const ValueType *KOKKOS_RESTRICT BB = B+pp*bs0+jj*bs1;
+        //       /**/  ValueType *KOKKOS_RESTRICT CC = C+ii*cs0+jj*cs1;
+
+        //       gemm(ib, jb, pb, AA, BB, CC);
+        //     } // for ii
+        //   } // for pp
+        // } // for jj
+      }
     };
 
-    const bool is_small = true;  //(m*n*k <= 64*64*64);
-    if (is_small) {
-      gemm(m, n, k, A, B, C);
-    } else {
-      // // cache blocking
-      // const int
-      //   nc = nb*10, kc = mb*4, mc = mb*4;
-
-      // for (int jj=0;jj<n;jj+=nc) {
-      //   const int tj = n-jj, jb = (tj < nc ? tj : nc);
-      //   for (int pp=0;pp<k;pp+=kc) {
-      //     const int tp = k-pp, pb = (tp < kc ? tp : kc);
-      //     //const int pb = k, pp = 0;
-      //     for (int ii=0;ii<m;ii+=mc) {
-      //       const int ti = m-ii, ib = (ti < mc ? ti : mc);
-
-      //       const ValueType *KOKKOS_RESTRICT AA = A+ii*as0+pp*as1;
-      //       const ValueType *KOKKOS_RESTRICT BB = B+pp*bs0+jj*bs1;
-      //       /**/  ValueType *KOKKOS_RESTRICT CC = C+ii*cs0+jj*cs1;
-
-      //       gemm(ib, jb, pb, AA, BB, CC);
-      //     } // for ii
-      //   } // for pp
-      // } // for jj
-    }
+    KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
+    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
   }
+
   return 0;
 }
 

--- a/batched/dense/impl/KokkosBatched_Gemm_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemm_Serial_Internal.hpp
@@ -123,8 +123,8 @@ KOKKOS_INLINE_FUNCTION int SerialGemmInternal<Algo::Gemm::Blocked>::invoke(
       }
     };
 
-    KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
-    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
+    KOKKOS_IF_ON_HOST((host_or_device(Algo::Gemm::Blocked::Impl::Host{});))
+    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Gemm::Blocked::Impl::Device{});))
   }
 
   return 0;

--- a/batched/dense/impl/KokkosBatched_Gemm_Team_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemm_Team_Internal.hpp
@@ -136,8 +136,8 @@ KOKKOS_INLINE_FUNCTION int TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
         // } // for jj
       }
     };
-    KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
-    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
+    KOKKOS_IF_ON_HOST((host_or_device(Algo::Gemm::Blocked::Impl::Host{});))
+    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Gemm::Blocked::Impl::Device{});))
   }
   return 0;
 }

--- a/batched/dense/impl/KokkosBatched_Gemm_Team_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemm_Team_Internal.hpp
@@ -73,9 +73,6 @@ KOKKOS_INLINE_FUNCTION int TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
   // C = beta C + alpha A B
   // C (m x n), A(m x k), B(k x n)
 
-  constexpr int mbAlgo = Algo::Gemm::Blocked::Impl::mb();
-  constexpr int nbAlgo = Algo::Gemm::Blocked::Impl::mb();
-
   const ScalarType one(1.0), zero(0.0);
 
   if (beta == zero)
@@ -88,57 +85,59 @@ KOKKOS_INLINE_FUNCTION int TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
 
     if (beta != one) member.team_barrier();
 
-    ///
-    /// GPU case: team size is large and blocksize (mb,nb) is small
-    InnerGemmFixC<mbAlgo, nbAlgo> inner(as0, as1, bs0, bs1, cs0, cs1);
-    auto gemm = [&](const int ib, const int jb, const int pb, const ValueType *KOKKOS_RESTRICT AA,
-                    const ValueType *KOKKOS_RESTRICT BB,
-                    /**/ ValueType *KOKKOS_RESTRICT CC) {
-      // Made this non-const in order to WORKAROUND issue #349
-      int mb = mbAlgo, mp = (ib % mb), mq = (ib / mb) + (mp > 0), nb = nbAlgo, np = (jb % nb),
-          nq = (jb / nb) + (np > 0);
+    auto host_or_device = [&](auto tag) {
+      constexpr int mb = Algo::Gemm::Blocked::Impl::mb<decltype(tag)>();
+      constexpr int nb = Algo::Gemm::Blocked::Impl::mb<decltype(tag)>();
+      InnerGemmFixC<mb, nb> inner(as0, as1, bs0, bs1, cs0, cs1);
+      auto gemm = [&](const int ib, const int jb, const int pb, const ValueType *KOKKOS_RESTRICT AA,
+                      const ValueType *KOKKOS_RESTRICT BB,
+                      /**/ ValueType *KOKKOS_RESTRICT CC) {
+        int mp = (ib % mb), mq = (ib / mb) + (mp > 0), np = (jb % nb), nq = (jb / nb) + (np > 0);
 
-      // square tiling
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, mq * nq), [&](const int &ij) {
-        int i, j;
-        // note: the condition is constexpr
-        if (KokkosKernels::Impl::is_gpu_exec_space_v<typename MemberType::execution_space>) {
-          i = ij % mq * mb;
-          j = ij / mq * nb;
-        } else {
-          i = ij / nq * mb;
-          j = ij % nq * nb;
-        }
-        inner.serial_invoke(KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), alpha, AA + i * as0, BB + j * bs1,
-                            (i + mb) > ib ? mp : mb, (j + nb) > jb ? np : nb, pb, CC + i * cs0 + j * cs1);
-      });
+        // square tiling
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, mq * nq), [&](const int &ij) {
+          int i, j;
+          // note: the condition is constexpr
+          if (KokkosKernels::Impl::is_gpu_exec_space_v<typename MemberType::execution_space>) {
+            i = ij % mq * mb;
+            j = ij / mq * nb;
+          } else {
+            i = ij / nq * mb;
+            j = ij % nq * nb;
+          }
+          inner.serial_invoke(KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), alpha, AA + i * as0, BB + j * bs1,
+                              (i + mb) > ib ? mp : mb, (j + nb) > jb ? np : nb, pb, CC + i * cs0 + j * cs1);
+        });
+      };
+
+      const bool is_small = true;  //(m*n*k <= 64*64*64);
+      if (is_small) {
+        gemm(m, n, k, A, B, C);
+      } else {
+        // // cache blocking
+        // const int
+        //   nc = nb*10, kc = mb*4, mc = mb*4;
+
+        // for (int jj=0;jj<n;jj+=nc) {
+        //   const int tj = n-jj, jb = (tj < nc ? tj : nc);
+        //   for (int pp=0;pp<k;pp+=kc) {
+        //     const int tp = k-pp, pb = (tp < kc ? tp : kc);
+        //     //const int pb = k, pp = 0;
+        //     for (int ii=0;ii<m;ii+=mc) {
+        //       const int ti = m-ii, ib = (ti < mc ? ti : mc);
+
+        //       const ValueType *KOKKOS_RESTRICT AA = A+ii*as0+pp*as1;
+        //       const ValueType *KOKKOS_RESTRICT BB = B+pp*bs0+jj*bs1;
+        //       /**/  ValueType *KOKKOS_RESTRICT CC = C+ii*cs0+jj*cs1;
+
+        //       gemm(ib, jb, pb, AA, BB, CC);
+        //     } // for ii
+        //   } // for pp
+        // } // for jj
+      }
     };
-
-    const bool is_small = true;  //(m*n*k <= 64*64*64);
-    if (is_small) {
-      gemm(m, n, k, A, B, C);
-    } else {
-      // // cache blocking
-      // const int
-      //   nc = nb*10, kc = mb*4, mc = mb*4;
-
-      // for (int jj=0;jj<n;jj+=nc) {
-      //   const int tj = n-jj, jb = (tj < nc ? tj : nc);
-      //   for (int pp=0;pp<k;pp+=kc) {
-      //     const int tp = k-pp, pb = (tp < kc ? tp : kc);
-      //     //const int pb = k, pp = 0;
-      //     for (int ii=0;ii<m;ii+=mc) {
-      //       const int ti = m-ii, ib = (ti < mc ? ti : mc);
-
-      //       const ValueType *KOKKOS_RESTRICT AA = A+ii*as0+pp*as1;
-      //       const ValueType *KOKKOS_RESTRICT BB = B+pp*bs0+jj*bs1;
-      //       /**/  ValueType *KOKKOS_RESTRICT CC = C+ii*cs0+jj*cs1;
-
-      //       gemm(ib, jb, pb, AA, BB, CC);
-      //     } // for ii
-      //   } // for pp
-      // } // for jj
-    }
+    KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
+    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
   }
   return 0;
 }

--- a/batched/dense/impl/KokkosBatched_LU_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_LU_Serial_Internal.hpp
@@ -71,41 +71,42 @@ template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialLU_Internal<Algo::LU::Blocked>::invoke(
     const int m, const int n, ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
     const typename MagnitudeScalarType<ValueType>::type /*tiny*/) {
-  constexpr int mbAlgo = Algo::LU::Blocked::Impl::mb();
   const typename MagnitudeScalarType<ValueType>::type one(1.0), minus_one(-1.0);
 
   const int k = (m < n ? m : n);
   if (k <= 0) return 0;
 
-  InnerLU<mbAlgo> lu(as0, as1);
-
-  InnerTrsmLeftLowerUnitDiag<mbAlgo> trsm_llu(as0, as1, as0, as1);
-  InnerTrsmLeftLowerNonUnitDiag<mbAlgo> trsm_run(as1, as0, as1, as0);
-
   auto lu_factorize = [&](const int ib, const int jb, ValueType *KOKKOS_RESTRICT AA) {
-    const int mb = mbAlgo;
-    const int kb = ib < jb ? ib : jb;
-    for (int p = 0; p < kb; p += mb) {
-      const int pb = (p + mb) > kb ? (kb - p) : mb;
+    auto host_or_device = [&](auto tag) {
+      constexpr int mb = Algo::LU::Blocked::Impl::mb<decltype(tag)>();
+      InnerLU<mb> lu(as0, as1);
+      InnerTrsmLeftLowerUnitDiag<mb> trsm_llu(as0, as1, as0, as1);
+      InnerTrsmLeftLowerNonUnitDiag<mb> trsm_run(as1, as0, as1, as0);
+      const int kb = ib < jb ? ib : jb;
+      for (int p = 0; p < kb; p += mb) {
+        const int pb = (p + mb) > kb ? (kb - p) : mb;
 
-      // diagonal block
-      ValueType *KOKKOS_RESTRICT Ap = AA + p * as0 + p * as1;
+        // diagonal block
+        ValueType *KOKKOS_RESTRICT Ap = AA + p * as0 + p * as1;
 
-      // lu on a block
-      lu.serial_invoke(pb, Ap);
+        // lu on a block
+        lu.serial_invoke(pb, Ap);
 
-      // dimension ABR
-      const int m_abr = ib - p - mb, n_abr = jb - p - mb;
+        // dimension ABR
+        const int m_abr = ib - p - mb, n_abr = jb - p - mb;
 
-      // trsm update
-      trsm_llu.serial_invoke(Ap, pb, n_abr, Ap + mb * as1);
-      trsm_run.serial_invoke(Ap, pb, m_abr, Ap + mb * as0);
+        // trsm update
+        trsm_llu.serial_invoke(Ap, pb, n_abr, Ap + mb * as1);
+        trsm_run.serial_invoke(Ap, pb, m_abr, Ap + mb * as0);
 
-      // gemm update
-      Impl::SerialGemmInternal<Algo::Gemm::Blocked>::invoke(
-          KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), m_abr, n_abr, pb, minus_one, Ap + mb * as0, as0, as1,
-          Ap + mb * as1, as0, as1, one, Ap + mb * as0 + mb * as1, as0, as1);
-    }
+        // gemm update
+        Impl::SerialGemmInternal<Algo::Gemm::Blocked>::invoke(
+            KokkosBlas::Impl::OpID(), KokkosBlas::Impl::OpID(), m_abr, n_abr, pb, minus_one, Ap + mb * as0, as0, as1,
+            Ap + mb * as1, as0, as1, one, Ap + mb * as0 + mb * as1, as0, as1);
+      }
+    };
+    KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
+    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
   };
 
   const bool is_small = true;  //(m*n <= 64*64);

--- a/batched/dense/impl/KokkosBatched_LU_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_LU_Serial_Internal.hpp
@@ -105,8 +105,8 @@ KOKKOS_INLINE_FUNCTION int SerialLU_Internal<Algo::LU::Blocked>::invoke(
             Ap + mb * as1, as0, as1, one, Ap + mb * as0 + mb * as1, as0, as1);
       }
     };
-    KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
-    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
+    KOKKOS_IF_ON_HOST((host_or_device(Algo::LU::Blocked::Impl::Host{});))
+    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::LU::Blocked::Impl::Device{});))
   };
 
   const bool is_small = true;  //(m*n <= 64*64);

--- a/batched/dense/impl/KokkosBatched_LU_Team_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_LU_Team_Internal.hpp
@@ -128,8 +128,8 @@ KOKKOS_INLINE_FUNCTION int TeamLU_Internal<Algo::LU::Blocked>::invoke(
                                                       Ap + mb * as1, as0, as1, one, Ap + mb * as0 + mb * as1, as0, as1);
       }
     };
-    KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
-    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
+    KOKKOS_IF_ON_HOST((host_or_device(Algo::LU::Blocked::Impl::Host{});))
+    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::LU::Blocked::Impl::Device{});))
   };
 
   const bool is_small = true;  //(m*n <= 64*64);

--- a/batched/dense/impl/KokkosBatched_LU_Team_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_LU_Team_Internal.hpp
@@ -79,55 +79,57 @@ template <typename MemberType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int TeamLU_Internal<Algo::LU::Blocked>::invoke(
     const MemberType &member, const int m, const int n, ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
     const typename MagnitudeScalarType<ValueType>::type /*tiny*/) {
-  constexpr int mbAlgo = Algo::LU::Blocked::Impl::mb();
-
   const int k = (m < n ? m : n);
   if (k <= 0) return 0;
 
   const typename MagnitudeScalarType<ValueType>::type one(1.0), minus_one(-1.0);
 
-  InnerLU<mbAlgo> lu(as0, as1);
-
-  InnerTrsmLeftLowerUnitDiag<mbAlgo> trsm_llu(as0, as1, as0, as1);
-  InnerTrsmLeftLowerNonUnitDiag<mbAlgo> trsm_run(as1, as0, as1, as0);
   auto lu_factorize = [&](const int ib, const int jb, ValueType *KOKKOS_RESTRICT AA) {
     const int tsize = member.team_size();
-    // Made this non-const in order to WORKAROUND issue #349
-    int mb = mbAlgo;
-    int nb = ((jb - mb) + (ib - mb)) > 0 ? ((jb - mb) + (ib - mb)) / tsize + (((jb - mb) + (ib - mb)) % tsize > 0) : 1;
-    const int kb = ib < jb ? ib : jb;
 
-    for (int p = 0; p < kb; p += mb) {
-      const int pb = (p + mb) > kb ? (kb - p) : mb;
+    auto host_or_device = [&](auto tag) {
+      constexpr int mb = Algo::LU::Blocked::Impl::mb<decltype(tag)>();
+      InnerLU<mb> lu(as0, as1);
+      InnerTrsmLeftLowerUnitDiag<mb> trsm_llu(as0, as1, as0, as1);
+      InnerTrsmLeftLowerNonUnitDiag<mb> trsm_run(as1, as0, as1, as0);
+      int nb =
+          ((jb - mb) + (ib - mb)) > 0 ? ((jb - mb) + (ib - mb)) / tsize + (((jb - mb) + (ib - mb)) % tsize > 0) : 1;
+      const int kb = ib < jb ? ib : jb;
 
-      // diagonal block
-      ValueType *KOKKOS_RESTRICT Ap = AA + p * as0 + p * as1;
+      for (int p = 0; p < kb; p += mb) {
+        const int pb = (p + mb) > kb ? (kb - p) : mb;
 
-      // lu on a block
-      member.team_barrier();
-      if (member.team_rank() == 0) lu.serial_invoke(pb, Ap);
-      member.team_barrier();
+        // diagonal block
+        ValueType *KOKKOS_RESTRICT Ap = AA + p * as0 + p * as1;
 
-      // Made this non-const in order to WORKAROUND issue #349
-      int m_abr = ib - p - mb, n_abr = jb - p - mb, mp_abr = m_abr % nb, np_abr = n_abr % nb,
-          mq_abr = (m_abr / nb) + (mp_abr > 0), nq_abr = (n_abr / nb) + (np_abr > 0);
+        // lu on a block
+        member.team_barrier();
+        if (member.team_rank() == 0) lu.serial_invoke(pb, Ap);
+        member.team_barrier();
 
-      // trsm update
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, mq_abr + nq_abr), [&](const int &ij) {
-        if (ij < nq_abr) {
-          const int j = (ij)*nb, qb = (j + nb) > n_abr ? np_abr : nb;
-          trsm_llu.serial_invoke(Ap, pb, qb, Ap + (j + mb) * as1);
-        } else {
-          const int i = (ij - nq_abr) * nb, qb = (i + nb) > m_abr ? mp_abr : nb;
-          trsm_run.serial_invoke(Ap, pb, qb, Ap + (i + mb) * as0);
-        }
-      });
-      member.team_barrier();
+        // Made this non-const in order to WORKAROUND issue #349
+        int m_abr = ib - p - mb, n_abr = jb - p - mb, mp_abr = m_abr % nb, np_abr = n_abr % nb,
+            mq_abr = (m_abr / nb) + (mp_abr > 0), nq_abr = (n_abr / nb) + (np_abr > 0);
 
-      // gemm update
-      TeamGemmInternal<Algo::Gemm::Blocked>::invoke(member, m_abr, n_abr, pb, minus_one, Ap + mb * as0, as0, as1,
-                                                    Ap + mb * as1, as0, as1, one, Ap + mb * as0 + mb * as1, as0, as1);
-    }
+        // trsm update
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, mq_abr + nq_abr), [&](const int &ij) {
+          if (ij < nq_abr) {
+            const int j = (ij)*nb, qb = (j + nb) > n_abr ? np_abr : nb;
+            trsm_llu.serial_invoke(Ap, pb, qb, Ap + (j + mb) * as1);
+          } else {
+            const int i = (ij - nq_abr) * nb, qb = (i + nb) > m_abr ? mp_abr : nb;
+            trsm_run.serial_invoke(Ap, pb, qb, Ap + (i + mb) * as0);
+          }
+        });
+        member.team_barrier();
+
+        // gemm update
+        TeamGemmInternal<Algo::Gemm::Blocked>::invoke(member, m_abr, n_abr, pb, minus_one, Ap + mb * as0, as0, as1,
+                                                      Ap + mb * as1, as0, as1, one, Ap + mb * as0 + mb * as1, as0, as1);
+      }
+    };
+    KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
+    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
   };
 
   const bool is_small = true;  //(m*n <= 64*64);

--- a/batched/dense/impl/KokkosBatched_Trsm_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsm_Serial_Internal.hpp
@@ -113,8 +113,8 @@ KOKKOS_INLINE_FUNCTION int SerialTrsmInternalLeftLower<Algo::Trsm::Blocked>::inv
           }
         }
       };
-      KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
-      KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
+      KOKKOS_IF_ON_HOST((host_or_device(Algo::Trsm::Blocked::Impl::Host{});))
+      KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Trsm::Blocked::Impl::Device{});))
     };
 
     const bool is_small = true;  //(m*n <= 64*64);
@@ -222,8 +222,8 @@ KOKKOS_INLINE_FUNCTION int SerialTrsmInternalLeftUpper<Algo::Trsm::Blocked>::inv
           }
         }
       };
-      KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
-      KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
+      KOKKOS_IF_ON_HOST((host_or_device(Algo::Trsm::Blocked::Impl::Host{});))
+      KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Trsm::Blocked::Impl::Device{});))
     };
 
     const bool is_small = (m * n <= 64 * 64);

--- a/batched/dense/impl/KokkosBatched_Trsm_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsm_Serial_Internal.hpp
@@ -79,8 +79,6 @@ KOKKOS_INLINE_FUNCTION int SerialTrsmInternalLeftLower<Algo::Trsm::Blocked>::inv
     const bool use_unit_diag, const bool /*do_conj*/, const int m, const int n, const ScalarType alpha,
     const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
     /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
-  constexpr int mbAlgo = Algo::Trsm::Blocked::Impl::mb();
-
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
   if (alpha == zero)
@@ -88,31 +86,35 @@ KOKKOS_INLINE_FUNCTION int SerialTrsmInternalLeftLower<Algo::Trsm::Blocked>::inv
   else {
     if (alpha != one) KokkosBlas::Impl::SerialScaleInternal::invoke(m, n, alpha, B, bs0, bs1);
 
-    InnerTrsmLeftLowerUnitDiag<mbAlgo> trsm_u(as0, as1, bs0, bs1);
-    InnerTrsmLeftLowerNonUnitDiag<mbAlgo> trsm_n(as0, as1, bs0, bs1);
-
-    InnerGemmFixA<mbAlgo, mbAlgo> gemm(as0, as1, bs0, bs1, bs0, bs1);
     auto trsm = [&](const int ib, const int jb, const ValueType *KOKKOS_RESTRICT AA,
                     /**/ ValueType *KOKKOS_RESTRICT BB) {
-      const int mb = mbAlgo;
-      for (int p = 0; p < ib; p += mb) {
-        const int pb = (p + mb) > ib ? (ib - p) : mb;
+      auto host_or_device = [&](auto tag) {
+        constexpr int mb = Algo::Trsm::Blocked::Impl::mb<decltype(tag)>();
+        InnerTrsmLeftLowerUnitDiag<mb> trsm_u(as0, as1, bs0, bs1);
+        InnerTrsmLeftLowerNonUnitDiag<mb> trsm_n(as0, as1, bs0, bs1);
+        InnerGemmFixA<mb, mb> gemm(as0, as1, bs0, bs1, bs0, bs1);
 
-        // trsm update
-        const ValueType *KOKKOS_RESTRICT Ap = AA + p * as0 + p * as1;
-        /**/ ValueType *KOKKOS_RESTRICT Bp  = BB + p * bs0;
+        for (int p = 0; p < ib; p += mb) {
+          const int pb = (p + mb) > ib ? (ib - p) : mb;
 
-        if (use_unit_diag)
-          trsm_u.serial_invoke(Ap, pb, jb, Bp);
-        else
-          trsm_n.serial_invoke(Ap, pb, jb, Bp);
+          // trsm update
+          const ValueType *KOKKOS_RESTRICT Ap = AA + p * as0 + p * as1;
+          /**/ ValueType *KOKKOS_RESTRICT Bp  = BB + p * bs0;
 
-        // gemm update
-        for (int i = p + mb; i < ib; i += mb) {
-          const int mm = (i + mb) > ib ? (ib - i) : mb;
-          gemm.serial_invoke(minus_one, AA + i * as0 + p * as1, BB + p * bs0, mm, jb, pb, BB + i * bs0);
+          if (use_unit_diag)
+            trsm_u.serial_invoke(Ap, pb, jb, Bp);
+          else
+            trsm_n.serial_invoke(Ap, pb, jb, Bp);
+
+          // gemm update
+          for (int i = p + mb; i < ib; i += mb) {
+            const int mm = (i + mb) > ib ? (ib - i) : mb;
+            gemm.serial_invoke(minus_one, AA + i * as0 + p * as1, BB + p * bs0, mm, jb, pb, BB + i * bs0);
+          }
         }
-      }
+      };
+      KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
+      KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
     };
 
     const bool is_small = true;  //(m*n <= 64*64);
@@ -189,38 +191,39 @@ KOKKOS_INLINE_FUNCTION int SerialTrsmInternalLeftUpper<Algo::Trsm::Blocked>::inv
     /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
-  constexpr int mbAlgo = Algo::Trsm::Blocked::Impl::mb();
-
   if (alpha == zero)
     KokkosBlas::Impl::SerialSetInternal::invoke(m, n, zero, B, bs0, bs1);
   else {
     if (alpha != one) KokkosBlas::Impl::SerialScaleInternal::invoke(m, n, alpha, B, bs0, bs1);
 
-    InnerTrsmLeftUpperUnitDiag<mbAlgo> trsm_u(as0, as1, bs0, bs1);
-    InnerTrsmLeftUpperNonUnitDiag<mbAlgo> trsm_n(as0, as1, bs0, bs1);
-
-    InnerGemmFixA<mbAlgo, mbAlgo> gemm(as0, as1, bs0, bs1, bs0, bs1);
-
     auto trsm = [&](const int ib, const int jb, const ValueType *KOKKOS_RESTRICT AA,
                     /**/ ValueType *KOKKOS_RESTRICT BB) {
-      const int mb = mbAlgo;
-      for (int pp = 0; pp < ib; pp += mb) {
-        const int ptmp = ib - pp - mb, p = ptmp < 0 ? 0 : ptmp, pb = mb + (ptmp < 0) * ptmp;
+      auto host_or_device = [&](auto tag) {
+        constexpr int mb = Algo::Trsm::Blocked::Impl::mb<decltype(tag)>();
+        InnerTrsmLeftUpperUnitDiag<mb> trsm_u(as0, as1, bs0, bs1);
+        InnerTrsmLeftUpperNonUnitDiag<mb> trsm_n(as0, as1, bs0, bs1);
+        InnerGemmFixA<mb, mb> gemm(as0, as1, bs0, bs1, bs0, bs1);
+        for (int pp = 0; pp < ib; pp += mb) {
+          const int ptmp = ib - pp - mb, p = ptmp < 0 ? 0 : ptmp, pb = mb + (ptmp < 0) * ptmp;
 
-        // trsm update
-        const ValueType *KOKKOS_RESTRICT Ap = AA + p * as0 + p * as1;
-        /**/ ValueType *KOKKOS_RESTRICT Bp  = BB + p * bs0;
+          // trsm update
+          const ValueType *KOKKOS_RESTRICT Ap = AA + p * as0 + p * as1;
+          /**/ ValueType *KOKKOS_RESTRICT Bp  = BB + p * bs0;
 
-        if (use_unit_diag)
-          trsm_u.serial_invoke(Ap, pb, jb, Bp);
-        else
-          trsm_n.serial_invoke(Ap, pb, jb, Bp);
+          if (use_unit_diag)
+            trsm_u.serial_invoke(Ap, pb, jb, Bp);
+          else
+            trsm_n.serial_invoke(Ap, pb, jb, Bp);
 
-        // gemm update
-        for (int i = 0; i < p; i += mb) {
-          gemm.serial_invoke(minus_one, AA + i * as0 + p * as1, Bp, (i + mb) > p ? (p - i) : mb, jb, pb, BB + i * bs0);
+          // gemm update
+          for (int i = 0; i < p; i += mb) {
+            gemm.serial_invoke(minus_one, AA + i * as0 + p * as1, Bp, (i + mb) > p ? (p - i) : mb, jb, pb,
+                               BB + i * bs0);
+          }
         }
-      }
+      };
+      KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
+      KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
     };
 
     const bool is_small = (m * n <= 64 * 64);

--- a/batched/dense/impl/KokkosBatched_Trsm_Team_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsm_Team_Internal.hpp
@@ -74,8 +74,6 @@ KOKKOS_INLINE_FUNCTION int TeamTrsmInternalLeftLower<Algo::Trsm::Blocked>::invok
     const MemberType &member, const bool use_unit_diag, const int m, const int n, const ScalarType alpha,
     const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
     /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
-  constexpr int mbAlgo = Algo::Trsm::Blocked::Impl::mb();
-
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
   // note that parallel range is different ( m*n vs m-1*n);
@@ -90,39 +88,44 @@ KOKKOS_INLINE_FUNCTION int TeamTrsmInternalLeftLower<Algo::Trsm::Blocked>::invok
 
     ///
     /// case GPU: team size is large and blocksize (mb,nb) is small
-    InnerTrsmLeftLowerUnitDiag<mbAlgo> trsm_u(as0, as1, bs0, bs1);
-    InnerTrsmLeftLowerNonUnitDiag<mbAlgo> trsm_n(as0, as1, bs0, bs1);
 
     auto trsm = [&](const int ib, const int jb, const ValueType *KOKKOS_RESTRICT AA,
                     /**/ ValueType *KOKKOS_RESTRICT BB) {
-      const int mb    = mbAlgo;
-      const int tsize = member.team_size();
-      // Made this non-const in order to WORKAROUND issue #349
-      int nb = (jb / tsize + jb % tsize > 0);
-      int np = jb % nb;
-      for (int p = 0; p < ib; p += mb) {
+      auto host_or_device = [&](auto tag) {
+        constexpr int mb = Algo::Trsm::Blocked::Impl::mb<decltype(tag)>();
+        InnerTrsmLeftLowerUnitDiag<mb> trsm_u(as0, as1, bs0, bs1);
+        InnerTrsmLeftLowerNonUnitDiag<mb> trsm_n(as0, as1, bs0, bs1);
+
+        const int tsize = member.team_size();
         // Made this non-const in order to WORKAROUND issue #349
-        int pb = ((p + mb) > ib ? (ib - p) : mb);
-
-        // trsm update
-        const ValueType *KOKKOS_RESTRICT Ap = AA + p * as0 + p * as1;
-        /**/ ValueType *KOKKOS_RESTRICT Bp  = BB + p * bs0;
-
-        member.team_barrier();
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, (jb / nb) + (np > 0)), [&](const int jj) {
+        int nb = (jb / tsize + jb % tsize > 0);
+        int np = jb % nb;
+        for (int p = 0; p < ib; p += mb) {
           // Made this non-const in order to WORKAROUND issue #349
-          int j = jj * nb, qb = (j + nb) > jb ? np : nb;
-          if (use_unit_diag)
-            trsm_u.serial_invoke(Ap, pb, qb, Bp + j * bs1);
-          else
-            trsm_n.serial_invoke(Ap, pb, qb, Bp + j * bs1);
-        });
-        member.team_barrier();
+          int pb = ((p + mb) > ib ? (ib - p) : mb);
 
-        // gemm update
-        TeamGemmInternal<Algo::Gemm::Blocked>::invoke(member, ib - p - pb, jb, pb, minus_one, Ap + pb * as0, as0, as1,
-                                                      Bp, bs0, bs1, one, Bp + pb * bs0, bs0, bs1);
-      }
+          // trsm update
+          const ValueType *KOKKOS_RESTRICT Ap = AA + p * as0 + p * as1;
+          /**/ ValueType *KOKKOS_RESTRICT Bp  = BB + p * bs0;
+
+          member.team_barrier();
+          Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, (jb / nb) + (np > 0)), [&](const int jj) {
+            // Made this non-const in order to WORKAROUND issue #349
+            int j = jj * nb, qb = (j + nb) > jb ? np : nb;
+            if (use_unit_diag)
+              trsm_u.serial_invoke(Ap, pb, qb, Bp + j * bs1);
+            else
+              trsm_n.serial_invoke(Ap, pb, qb, Bp + j * bs1);
+          });
+          member.team_barrier();
+
+          // gemm update
+          TeamGemmInternal<Algo::Gemm::Blocked>::invoke(member, ib - p - pb, jb, pb, minus_one, Ap + pb * as0, as0, as1,
+                                                        Bp, bs0, bs1, one, Bp + pb * bs0, bs0, bs1);
+        }
+      };
+      KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
+      KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
     };
 
     const bool is_small = true;  //(m*n <= 64*64);
@@ -199,8 +202,6 @@ KOKKOS_INLINE_FUNCTION int TeamTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invok
     const MemberType &member, const bool use_unit_diag, const int m, const int n, const ScalarType alpha,
     const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
     /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
-  constexpr int mbAlgo = Algo::Trsm::Blocked::Impl::mb();
-
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
   // note that parallel range is different ( m*n vs m-1*n);
@@ -210,37 +211,41 @@ KOKKOS_INLINE_FUNCTION int TeamTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invok
     if (alpha != one) KokkosBlas::Impl::TeamScaleInternal::invoke(member, m, n, alpha, B, bs0, bs1);
     if (m <= 0 || n <= 0) return 0;
 
-    InnerTrsmLeftUpperUnitDiag<mbAlgo> trsm_u(as0, as1, bs0, bs1);
-    InnerTrsmLeftUpperNonUnitDiag<mbAlgo> trsm_n(as0, as1, bs0, bs1);
-
     auto trsm = [&](const int ib, const int jb, const ValueType *KOKKOS_RESTRICT AA,
                     /**/ ValueType *KOKKOS_RESTRICT BB) {
-      const int mb    = mbAlgo;  //(ib <=5 ? ib : mbAlgo);
-      const int tsize = member.team_size();
-      // Made this non-const in order to WORKAROUND issue #349
-      int nb = (jb / tsize + jb % tsize > 0);
-      int np = jb % nb;
-      for (int pp = 0; pp < ib; pp += mb) {
-        const int ptmp = (ib - pp - mb), p = (ptmp < 0 ? 0 : ptmp), pb = (mb + (ptmp < 0) * ptmp);
+      auto host_or_device = [&](auto tag) {
+        constexpr int mb = Algo::Trsm::Blocked::Impl::mb<decltype(tag)>();
+        InnerTrsmLeftUpperUnitDiag<mb> trsm_u(as0, as1, bs0, bs1);
+        InnerTrsmLeftUpperNonUnitDiag<mb> trsm_n(as0, as1, bs0, bs1);
 
-        // trsm update
-        const ValueType *KOKKOS_RESTRICT Ap = AA + p * as0 + p * as1;
-        /**/ ValueType *KOKKOS_RESTRICT Bp  = BB + p * bs0;
+        const int tsize = member.team_size();
+        // Made this non-const in order to WORKAROUND issue #349
+        int nb = (jb / tsize + jb % tsize > 0);
+        int np = jb % nb;
+        for (int pp = 0; pp < ib; pp += mb) {
+          const int ptmp = (ib - pp - mb), p = (ptmp < 0 ? 0 : ptmp), pb = (mb + (ptmp < 0) * ptmp);
 
-        member.team_barrier();
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, (jb / nb) + (np > 0)), [&](const int &jj) {
-          const int j = jj * nb, qb = (j + nb) > jb ? np : nb;
-          if (use_unit_diag)
-            trsm_u.serial_invoke(Ap, pb, qb, Bp + j * bs1);
-          else
-            trsm_n.serial_invoke(Ap, pb, qb, Bp + j * bs1);
-        });
-        member.team_barrier();
+          // trsm update
+          const ValueType *KOKKOS_RESTRICT Ap = AA + p * as0 + p * as1;
+          /**/ ValueType *KOKKOS_RESTRICT Bp  = BB + p * bs0;
 
-        // gemm update
-        TeamGemmInternal<Algo::Gemm::Blocked>::invoke(member, p, jb, pb, minus_one, Ap - p * as0, as0, as1, Bp, bs0,
-                                                      bs1, one, BB, bs0, bs1);
-      }
+          member.team_barrier();
+          Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, (jb / nb) + (np > 0)), [&](const int &jj) {
+            const int j = jj * nb, qb = (j + nb) > jb ? np : nb;
+            if (use_unit_diag)
+              trsm_u.serial_invoke(Ap, pb, qb, Bp + j * bs1);
+            else
+              trsm_n.serial_invoke(Ap, pb, qb, Bp + j * bs1);
+          });
+          member.team_barrier();
+
+          // gemm update
+          TeamGemmInternal<Algo::Gemm::Blocked>::invoke(member, p, jb, pb, minus_one, Ap - p * as0, as0, as1, Bp, bs0,
+                                                        bs1, one, BB, bs0, bs1);
+        }
+      };
+      KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
+      KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
     };
 
     const bool is_small = true;  //(m*n <= 64*64);

--- a/batched/dense/impl/KokkosBatched_Trsm_Team_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsm_Team_Internal.hpp
@@ -124,8 +124,8 @@ KOKKOS_INLINE_FUNCTION int TeamTrsmInternalLeftLower<Algo::Trsm::Blocked>::invok
                                                         Bp, bs0, bs1, one, Bp + pb * bs0, bs0, bs1);
         }
       };
-      KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
-      KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
+      KOKKOS_IF_ON_HOST((host_or_device(Algo::Trsm::Blocked::Impl::Host{});))
+      KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Trsm::Blocked::Impl::Device{});))
     };
 
     const bool is_small = true;  //(m*n <= 64*64);
@@ -244,8 +244,8 @@ KOKKOS_INLINE_FUNCTION int TeamTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invok
                                                         bs1, one, BB, bs0, bs1);
         }
       };
-      KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
-      KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
+      KOKKOS_IF_ON_HOST((host_or_device(Algo::Trsm::Blocked::Impl::Host{});))
+      KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Trsm::Blocked::Impl::Device{});))
     };
 
     const bool is_small = true;  //(m*n <= 64*64);

--- a/batched/dense/impl/KokkosBatched_Trsv_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsv_Serial_Internal.hpp
@@ -195,8 +195,8 @@ KOKKOS_INLINE_FUNCTION int SerialTrsvInternalUpper<Algo::Trsv::Blocked>::invoke(
                                                                           bs0, one, b, bs0);
       }
     };
-    KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
-    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
+    KOKKOS_IF_ON_HOST((host_or_device(Algo::Trsm::Blocked::Impl::Host{});))
+    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Trsm::Blocked::Impl::Device{});))
   }
   return 0;
 }

--- a/batched/dense/impl/KokkosBatched_Trsv_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsv_Serial_Internal.hpp
@@ -77,35 +77,34 @@ KOKKOS_INLINE_FUNCTION int SerialTrsvInternalLower<Algo::Trsv::Blocked>::invoke(
     /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
-  constexpr int mbAlgo = Algo::Trsv::Blocked::Impl::mb();
-
   if (alpha == zero)
     KokkosBlas::Impl::SerialSetInternal::invoke(m, zero, b, bs0);
   else {
     if (alpha != one) KokkosBlas::Impl::SerialScaleInternal::invoke(m, alpha, b, bs0);
     if (m <= 0) return 0;
 
-    /// case GPU: team size is large and blocksize (mb,nb) is small
-    InnerTrsmLeftLowerUnitDiag<mbAlgo> trsm_u(as0, as1, bs0, 0);
-    InnerTrsmLeftLowerNonUnitDiag<mbAlgo> trsm_n(as0, as1, bs0, 0);
+    auto host_or_device = [&](auto tag) {
+      constexpr int mb = Algo::Trsv::Blocked::Impl::mb<decltype(tag)>();
+      InnerTrsmLeftLowerUnitDiag<mb> trsm_u(as0, as1, bs0, 0);
+      InnerTrsmLeftLowerNonUnitDiag<mb> trsm_n(as0, as1, bs0, 0);
 
-    const int mb = mbAlgo;
-    for (int p = 0; p < m; p += mb) {
-      const int pb = ((p + mb) > m ? (m - p) : mb);
+      for (int p = 0; p < m; p += mb) {
+        const int pb = ((p + mb) > m ? (m - p) : mb);
 
-      // trsm update
-      const ValueType *KOKKOS_RESTRICT Ap = A + p * as0 + p * as1;
-      /**/ ValueType *KOKKOS_RESTRICT bp  = b + p * bs0;
+        // trsm update
+        const ValueType *KOKKOS_RESTRICT Ap = A + p * as0 + p * as1;
+        /**/ ValueType *KOKKOS_RESTRICT bp  = b + p * bs0;
 
-      if (use_unit_diag)
-        trsm_u.serial_invoke(Ap, pb, 1, bp);
-      else
-        trsm_n.serial_invoke(Ap, pb, 1, bp);
+        if (use_unit_diag)
+          trsm_u.serial_invoke(Ap, pb, 1, bp);
+        else
+          trsm_n.serial_invoke(Ap, pb, 1, bp);
 
-      // gemv update
-      KokkosBlas::Impl::SerialGemvInternal<Algo::Gemv::Blocked>::invoke(m - p - pb, pb, minus_one, Ap + pb * as0, as0,
-                                                                        as1, bp, bs0, one, bp + pb * bs0, bs0);
-    }
+        // gemv update
+        KokkosBlas::Impl::SerialGemvInternal<Algo::Gemv::Blocked>::invoke(m - p - pb, pb, minus_one, Ap + pb * as0, as0,
+                                                                          as1, bp, bs0, one, bp + pb * bs0, bs0);
+      }
+    };
   }
   return 0;
 }
@@ -167,8 +166,6 @@ KOKKOS_INLINE_FUNCTION int SerialTrsvInternalUpper<Algo::Trsv::Blocked>::invoke(
     /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
-  constexpr int mbAlgo = Algo::Trsm::Blocked::Impl::mb();
-
   // note that parallel range is different ( m*n vs m-1*n);
   if (alpha == zero)
     KokkosBlas::Impl::SerialSetInternal::invoke(m, zero, b, bs0);
@@ -176,26 +173,30 @@ KOKKOS_INLINE_FUNCTION int SerialTrsvInternalUpper<Algo::Trsv::Blocked>::invoke(
     if (alpha != one) KokkosBlas::Impl::SerialScaleInternal::invoke(m, alpha, b, bs0);
     if (m <= 0) return 0;
 
-    InnerTrsmLeftUpperUnitDiag<mbAlgo> trsm_u(as0, as1, bs0, 0);
-    InnerTrsmLeftUpperNonUnitDiag<mbAlgo> trsm_n(as0, as1, bs0, 0);
+    auto host_or_device = [&](auto tag) {
+      constexpr int mb = Algo::Trsm::Blocked::Impl::mb<decltype(tag)>();
+      InnerTrsmLeftUpperUnitDiag<mb> trsm_u(as0, as1, bs0, 0);
+      InnerTrsmLeftUpperNonUnitDiag<mb> trsm_n(as0, as1, bs0, 0);
 
-    const int mb = mbAlgo;
-    for (int pp = 0; pp < m; pp += mb) {
-      const int ptmp = (m - pp - mb), p = (ptmp < 0 ? 0 : ptmp), pb = (mb + (ptmp < 0) * ptmp);
+      for (int pp = 0; pp < m; pp += mb) {
+        const int ptmp = (m - pp - mb), p = (ptmp < 0 ? 0 : ptmp), pb = (mb + (ptmp < 0) * ptmp);
 
-      // trsm update
-      const ValueType *KOKKOS_RESTRICT Ap = A + p * as0 + p * as1;
-      /**/ ValueType *KOKKOS_RESTRICT bp  = b + p * bs0;
+        // trsm update
+        const ValueType *KOKKOS_RESTRICT Ap = A + p * as0 + p * as1;
+        /**/ ValueType *KOKKOS_RESTRICT bp  = b + p * bs0;
 
-      if (use_unit_diag)
-        trsm_u.serial_invoke(Ap, pb, 1, bp);
-      else
-        trsm_n.serial_invoke(Ap, pb, 1, bp);
+        if (use_unit_diag)
+          trsm_u.serial_invoke(Ap, pb, 1, bp);
+        else
+          trsm_n.serial_invoke(Ap, pb, 1, bp);
 
-      // gemv update
-      KokkosBlas::Impl::SerialGemvInternal<Algo::Gemv::Blocked>::invoke(p, pb, minus_one, Ap - p * as0, as0, as1, bp,
-                                                                        bs0, one, b, bs0);
-    }
+        // gemv update
+        KokkosBlas::Impl::SerialGemvInternal<Algo::Gemv::Blocked>::invoke(p, pb, minus_one, Ap - p * as0, as0, as1, bp,
+                                                                          bs0, one, b, bs0);
+      }
+    };
+    KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
+    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
   }
   return 0;
 }

--- a/batched/dense/impl/KokkosBatched_Trsv_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsv_Serial_Internal.hpp
@@ -105,6 +105,8 @@ KOKKOS_INLINE_FUNCTION int SerialTrsvInternalLower<Algo::Trsv::Blocked>::invoke(
                                                                           as1, bp, bs0, one, bp + pb * bs0, bs0);
       }
     };
+    KOKKOS_IF_ON_HOST((host_or_device(Algo::Trsv::Blocked::Impl::Host{});))
+    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Trsv::Blocked::Impl::Device{});))
   }
   return 0;
 }

--- a/batched/dense/impl/KokkosBatched_Trsv_Team_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsv_Team_Internal.hpp
@@ -80,40 +80,41 @@ KOKKOS_INLINE_FUNCTION int TeamTrsvInternalLower<Algo::Trsv::Blocked>::invoke(
     /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
-  constexpr int mbAlgo = Algo::Trsv::Blocked::Impl::mb();
-
   if (alpha == zero)
     KokkosBlas::Impl::TeamSetInternal::invoke(member, m, zero, b, bs0);
   else {
     if (alpha != one) KokkosBlas::Impl::TeamScaleInternal::invoke(member, m, alpha, b, bs0);
     if (m <= 0) return 0;
 
-    /// case GPU: team size is large and blocksize (mb,nb) is small
-    InnerTrsmLeftLowerUnitDiag<mbAlgo> trsm_u(as0, as1, bs0, 0);
-    InnerTrsmLeftLowerNonUnitDiag<mbAlgo> trsm_n(as0, as1, bs0, 0);
+    auto host_or_device = [&](auto tag) {
+      constexpr int mb = Algo::Trsv::Blocked::Impl::mb<decltype(tag)>();
+      InnerTrsmLeftLowerUnitDiag<mb> trsm_u(as0, as1, bs0, 0);
+      InnerTrsmLeftLowerNonUnitDiag<mb> trsm_n(as0, as1, bs0, 0);
 
-    const int mb = mbAlgo;
-    // const int tsize = member.team_size();
-    for (int p = 0; p < m; p += mb) {
-      const int pb = ((p + mb) > m ? (m - p) : mb);
+      // const int tsize = member.team_size();
+      for (int p = 0; p < m; p += mb) {
+        const int pb = ((p + mb) > m ? (m - p) : mb);
 
-      // trsm update
-      const ValueType *KOKKOS_RESTRICT Ap = A + p * as0 + p * as1;
-      /**/ ValueType *KOKKOS_RESTRICT bp  = b + p * bs0;
+        // trsm update
+        const ValueType *KOKKOS_RESTRICT Ap = A + p * as0 + p * as1;
+        /**/ ValueType *KOKKOS_RESTRICT bp  = b + p * bs0;
 
-      member.team_barrier();
-      if (member.team_rank() == 0) {
-        if (use_unit_diag)
-          trsm_u.serial_invoke(Ap, pb, 1, bp);
-        else
-          trsm_n.serial_invoke(Ap, pb, 1, bp);
+        member.team_barrier();
+        if (member.team_rank() == 0) {
+          if (use_unit_diag)
+            trsm_u.serial_invoke(Ap, pb, 1, bp);
+          else
+            trsm_n.serial_invoke(Ap, pb, 1, bp);
+        }
+
+        // gemv update
+        member.team_barrier();
+        KokkosBlas::Impl::TeamGemvInternal<Algo::Gemv::Blocked>::invoke(
+            member, m - p - pb, pb, minus_one, Ap + pb * as0, as0, as1, bp, 1, one, bp + pb * bs0, bs0);
       }
-
-      // gemv update
-      member.team_barrier();
-      KokkosBlas::Impl::TeamGemvInternal<Algo::Gemv::Blocked>::invoke(member, m - p - pb, pb, minus_one, Ap + pb * as0,
-                                                                      as0, as1, bp, 1, one, bp + pb * bs0, bs0);
-    }
+    };
+    KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
+    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
   }
   return 0;
 }
@@ -180,8 +181,6 @@ KOKKOS_INLINE_FUNCTION int TeamTrsvInternalUpper<Algo::Trsv::Blocked>::invoke(
     /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
-  constexpr int mbAlgo = Algo::Trsm::Blocked::Impl::mb();
-
   // note that parallel range is different ( m*n vs m-1*n);
   if (alpha == zero)
     KokkosBlas::Impl::TeamSetInternal::invoke(member, m, zero, b, bs0);
@@ -189,30 +188,35 @@ KOKKOS_INLINE_FUNCTION int TeamTrsvInternalUpper<Algo::Trsv::Blocked>::invoke(
     if (alpha != one) KokkosBlas::Impl::TeamScaleInternal::invoke(member, m, alpha, b, bs0);
     if (m <= 0) return 0;
 
-    InnerTrsmLeftUpperUnitDiag<mbAlgo> trsm_u(as0, as1, bs0, 0);
-    InnerTrsmLeftUpperNonUnitDiag<mbAlgo> trsm_n(as0, as1, bs0, 0);
+    auto host_or_device = [&](auto tag) {
+      constexpr int mb = Algo::Trsm::Blocked::Impl::mb<decltype(tag)>();
+      /// case GPU: team size is large and blocksize (mb,nb) is small
+      InnerTrsmLeftUpperUnitDiag<mb> trsm_u(as0, as1, bs0, 0);
+      InnerTrsmLeftUpperNonUnitDiag<mb> trsm_n(as0, as1, bs0, 0);
 
-    const int mb = mbAlgo;
-    for (int pp = 0; pp < m; pp += mb) {
-      const int ptmp = (m - pp - mb), p = (ptmp < 0 ? 0 : ptmp), pb = (mb + (ptmp < 0) * ptmp);
+      for (int pp = 0; pp < m; pp += mb) {
+        const int ptmp = (m - pp - mb), p = (ptmp < 0 ? 0 : ptmp), pb = (mb + (ptmp < 0) * ptmp);
 
-      // trsm update
-      const ValueType *KOKKOS_RESTRICT Ap = A + p * as0 + p * as1;
-      /**/ ValueType *KOKKOS_RESTRICT bp  = b + p * bs0;
+        // trsm update
+        const ValueType *KOKKOS_RESTRICT Ap = A + p * as0 + p * as1;
+        /**/ ValueType *KOKKOS_RESTRICT bp  = b + p * bs0;
 
-      member.team_barrier();
-      if (member.team_rank() == 0) {
-        if (use_unit_diag)
-          trsm_u.serial_invoke(Ap, pb, 1, bp);
-        else
-          trsm_n.serial_invoke(Ap, pb, 1, bp);
+        member.team_barrier();
+        if (member.team_rank() == 0) {
+          if (use_unit_diag)
+            trsm_u.serial_invoke(Ap, pb, 1, bp);
+          else
+            trsm_n.serial_invoke(Ap, pb, 1, bp);
+        }
+
+        // gemv update
+        member.team_barrier();
+        KokkosBlas::Impl::TeamGemvInternal<Algo::Gemv::Unblocked>::invoke(member, p, pb, minus_one, Ap - p * as0, as0,
+                                                                          as1, bp, 1, one, b, bs0);
       }
-
-      // gemv update
-      member.team_barrier();
-      KokkosBlas::Impl::TeamGemvInternal<Algo::Gemv::Unblocked>::invoke(member, p, pb, minus_one, Ap - p * as0, as0,
-                                                                        as1, bp, 1, one, b, bs0);
-    }
+    };
+    KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
+    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
   }
   return 0;
 }

--- a/batched/dense/impl/KokkosBatched_Trsv_Team_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsv_Team_Internal.hpp
@@ -113,8 +113,8 @@ KOKKOS_INLINE_FUNCTION int TeamTrsvInternalLower<Algo::Trsv::Blocked>::invoke(
             member, m - p - pb, pb, minus_one, Ap + pb * as0, as0, as1, bp, 1, one, bp + pb * bs0, bs0);
       }
     };
-    KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
-    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
+    KOKKOS_IF_ON_HOST((host_or_device(Algo::Trsv::Blocked::Impl::Host{});))
+    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Trsv::Blocked::Impl::Device{});))
   }
   return 0;
 }
@@ -215,8 +215,8 @@ KOKKOS_INLINE_FUNCTION int TeamTrsvInternalUpper<Algo::Trsv::Blocked>::invoke(
                                                                           as1, bp, 1, one, b, bs0);
       }
     };
-    KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
-    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
+    KOKKOS_IF_ON_HOST((host_or_device(Algo::Trsm::Blocked::Impl::Host{});))
+    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Trsm::Blocked::Impl::Device{});))
   }
   return 0;
 }

--- a/blas/impl/KokkosBlas2_serial_gemv_internal.hpp
+++ b/blas/impl/KokkosBlas2_serial_gemv_internal.hpp
@@ -97,8 +97,8 @@ KOKKOS_INLINE_FUNCTION int SerialGemvInternal<Algo::Gemv::Blocked>::invoke(
       for (int i = 0; i < m; i += mb)
         inner.template serial_invoke<OpA>(alpha, A + i * as0, x, (i + mb) > m ? (m - i) : mb, n, y + i * ys0);
     };
-    KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
-    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
+    KOKKOS_IF_ON_HOST((host_or_device(Algo::Gemv::Blocked::Impl::Host{});))
+    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Gemv::Blocked::Impl::Device{});))
   }
   return 0;
 }

--- a/blas/impl/KokkosBlas2_serial_gemv_internal.hpp
+++ b/blas/impl/KokkosBlas2_serial_gemv_internal.hpp
@@ -82,8 +82,6 @@ KOKKOS_INLINE_FUNCTION int SerialGemvInternal<Algo::Gemv::Blocked>::invoke(
   // y = beta y + alpha A x
   // y (m), A(m x n), B(n)
 
-  constexpr int mbAlgo = Algo::Gemv::Blocked::Impl::mb();
-
   if (beta == zero)
     Impl::SerialSetInternal::invoke(m, zero, y, ys0);
   else if (beta != one)
@@ -92,10 +90,15 @@ KOKKOS_INLINE_FUNCTION int SerialGemvInternal<Algo::Gemv::Blocked>::invoke(
   if (alpha != zero) {
     if (m <= 0 || n <= 0) return 0;
 
-    Impl::InnerMultipleDotProduct<mbAlgo> inner(as0, as1, xs0, ys0);
-    const int mb = mbAlgo;
-    for (int i = 0; i < m; i += mb)
-      inner.serial_invoke<OpA>(alpha, A + i * as0, x, (i + mb) > m ? (m - i) : mb, n, y + i * ys0);
+    auto host_or_device = [&](auto tag) {
+      constexpr int mbAlgo = Algo::Gemv::Blocked::Impl::mb<decltype(tag)>();
+      Impl::InnerMultipleDotProduct<mbAlgo> inner(as0, as1, xs0, ys0);
+      const int mb = mbAlgo;
+      for (int i = 0; i < m; i += mb)
+        inner.template serial_invoke<OpA>(alpha, A + i * as0, x, (i + mb) > m ? (m - i) : mb, n, y + i * ys0);
+    };
+    KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
+    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
   }
   return 0;
 }

--- a/blas/impl/KokkosBlas2_team_gemv_impl.hpp
+++ b/blas/impl/KokkosBlas2_team_gemv_impl.hpp
@@ -127,8 +127,8 @@ KOKKOS_INLINE_FUNCTION int TeamGemvInternal<Algo::Gemv::Blocked>::invoke(
         inner.template serial_invoke<OpA>(alpha, A + i * as0, x, (i + mb) > m ? (m - i) : mb, n, y + i * ys0);
       });
     };
-    KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
-    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
+    KOKKOS_IF_ON_HOST((host_or_device(Algo::Gemv::Blocked::Impl::Host{});))
+    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Gemv::Blocked::Impl::Device{});))
 
     member.team_barrier();
   }

--- a/blas/impl/KokkosBlas2_team_gemv_impl.hpp
+++ b/blas/impl/KokkosBlas2_team_gemv_impl.hpp
@@ -104,8 +104,6 @@ KOKKOS_INLINE_FUNCTION int TeamGemvInternal<Algo::Gemv::Blocked>::invoke(
   // y = beta y + alpha A x
   // y (m), A(m x n), B(n)
 
-  constexpr int mbAlgo = Algo::Gemv::Blocked::Impl::mb();
-
   if (beta == zero)
     KokkosBlas::Impl::TeamSetInternal::invoke(member, m, zero, y, ys0);
   else if (beta != one)
@@ -116,16 +114,22 @@ KOKKOS_INLINE_FUNCTION int TeamGemvInternal<Algo::Gemv::Blocked>::invoke(
 
     if (beta != one) member.team_barrier();
 
-    KokkosBlas::Impl::InnerMultipleDotProduct<mbAlgo> inner(as0, as1, xs0, ys0);
-    const int tsize = member.team_size();
-    const int mb_a = m / tsize + (m % tsize > 0), mb_b = mbAlgo;
-    // Made this non-const in order to WORKAROUND issue #349
-    int mb = mb_a < mb_b ? mb_a : mb_b, mp = m % mb;
+    auto host_or_device = [&](auto tag) {
+      constexpr int mbAlgo = Algo::Gemv::Blocked::Impl::mb<decltype(tag)>();
+      KokkosBlas::Impl::InnerMultipleDotProduct<mbAlgo> inner(as0, as1, xs0, ys0);
+      const int tsize = member.team_size();
+      const int mb_a = m / tsize + (m % tsize > 0), mb_b = mbAlgo;
+      // Made this non-const in order to WORKAROUND issue #349
+      int mb = mb_a < mb_b ? mb_a : mb_b, mp = m % mb;
 
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(member, (m / mb) + (mp > 0)), [&](const int &ii) {
-      const int i = ii * mb;
-      inner.serial_invoke<OpA>(alpha, A + i * as0, x, (i + mb) > m ? (m - i) : mb, n, y + i * ys0);
-    });
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, (m / mb) + (mp > 0)), [&](const int &ii) {
+        const int i = ii * mb;
+        inner.template serial_invoke<OpA>(alpha, A + i * as0, x, (i + mb) > m ? (m - i) : mb, n, y + i * ys0);
+      });
+    };
+    KOKKOS_IF_ON_HOST((host_or_device(Algo::Host{});))
+    KOKKOS_IF_ON_DEVICE((host_or_device(Algo::Device{});))
+
     member.team_barrier();
   }
 

--- a/blas/impl/KokkosBlas_util.hpp
+++ b/blas/impl/KokkosBlas_util.hpp
@@ -101,16 +101,13 @@ struct Algo {
         // - space (gpu vs host)
         // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
         template <typename Where>
-        static constexpr KOKKOS_FUNCTION int mb();
-
-        template <>
-        constexpr KOKKOS_FUNCTION int mb<Host>() {
-          return 4;
-        }
-
-        template <>
-        constexpr KOKKOS_FUNCTION int mb<Device>() {
-          return 2;
+          requires std::is_same_v<Where, Host> || std::is_same_v<Where, Device>
+        constexpr static KOKKOS_INLINE_FUNCTION int mb() {
+          if constexpr (std::is_same_v<Where, Host>) {
+            return 4;
+          } else {
+            return 2;
+          }
         }
       };
 
@@ -172,16 +169,13 @@ struct Algo {
         // - space (cuda vs host)ß
         // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
         template <typename Where>
-        static constexpr KOKKOS_FUNCTION int mb();
-
-        template <>
-        constexpr KOKKOS_FUNCTION int mb<Host>() {
-          return 4;
-        }
-
-        template <>
-        constexpr KOKKOS_FUNCTION int mb<Device>() {
-          return 1;
+          requires std::is_same_v<Where, Host> || std::is_same_v<Where, Device>
+        constexpr static KOKKOS_INLINE_FUNCTION int mb() {
+          if constexpr (std::is_same_v<Where, Host>) {
+            return 4;
+          } else {
+            return 1;
+          }
         }
       };  // Impl
 

--- a/blas/impl/KokkosBlas_util.hpp
+++ b/blas/impl/KokkosBlas_util.hpp
@@ -117,7 +117,7 @@ struct Algo {
       // - team policy (smaller) or range policy (bigger)
       // - space (gpu vs host)
       // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
-      [[deprecated]] static constexpr KOKKOS_FUNCTION int mb() {
+      [[deprecated("Do not use: implementation detail")]] static constexpr KOKKOS_FUNCTION int mb() {
         KOKKOS_IF_ON_HOST((return Impl::mb<Impl::Host>();))
         KOKKOS_IF_ON_DEVICE((return Impl::mb<Impl::Device>();))
       }
@@ -185,7 +185,7 @@ struct Algo {
       // - team policy (smaller) or range policy (bigger)
       // - space (cuda vs host)
       // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
-      [[deprecated]] static constexpr KOKKOS_FUNCTION int mb() {
+      [[deprecated("Do not use: implementation detail")]] static constexpr KOKKOS_FUNCTION int mb() {
         KOKKOS_IF_ON_HOST((return Impl::mb<Impl::Host>();))
         KOKKOS_IF_ON_DEVICE((return Impl::mb<Impl::Device>();))
       }

--- a/blas/impl/KokkosBlas_util.hpp
+++ b/blas/impl/KokkosBlas_util.hpp
@@ -83,6 +83,9 @@ template <class T>
 static constexpr bool is_trans_v = is_trans<T>::value;
 
 struct Algo {
+  struct Host {};
+  struct Device {};
+
   struct Level3 {
     struct Unblocked {
       static const char* name() { return "Unblocked"; }
@@ -91,15 +94,23 @@ struct Algo {
       static const char* name() { return "Blocked"; }
 
       struct Impl {
-        // TODO:: for now harwire the blocksizes; this should reflect
+        // TODO:: for now hardwire the blocksizes; this should reflect
         // register blocking (not about team parallelism).
         // this mb should vary according to
         // - team policy (smaller) or range policy (bigger)
         // - space (gpu vs host)
         // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
-        static constexpr KOKKOS_FUNCTION int mb() {
-          KOKKOS_IF_ON_HOST((return 4;))
-          KOKKOS_IF_ON_DEVICE((return 2;))
+        template <typename Where>
+        static constexpr KOKKOS_FUNCTION int mb();
+
+        template <>
+        constexpr KOKKOS_FUNCTION int mb<Host>() {
+          return 4;
+        }
+
+        template <>
+        constexpr KOKKOS_FUNCTION int mb<Device>() {
+          return 2;
         }
       };
 
@@ -109,7 +120,10 @@ struct Algo {
       // - team policy (smaller) or range policy (bigger)
       // - space (gpu vs host)
       // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
-      [[deprecated]] static constexpr KOKKOS_FUNCTION int mb() { return Impl::mb(); }
+      [[deprecated]] static constexpr KOKKOS_FUNCTION int mb() {
+        KOKKOS_IF_ON_HOST((return Impl::mb<Host>();))
+        KOKKOS_IF_ON_DEVICE((return Impl::mb<Device>();))
+      }
     };
     struct MKL {
       static const char* name() { return "MKL"; }
@@ -154,9 +168,17 @@ struct Algo {
         // - team policy (smaller) or range policy (bigger)
         // - space (cuda vs host)ß
         // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
-        static constexpr KOKKOS_FUNCTION int mb() {
-          KOKKOS_IF_ON_HOST((return 4;))
-          KOKKOS_IF_ON_DEVICE((return 1;))
+        template <typename Where>
+        static constexpr KOKKOS_FUNCTION int mb();
+
+        template <>
+        constexpr KOKKOS_FUNCTION int mb<Host>() {
+          return 4;
+        }
+
+        template <>
+        constexpr KOKKOS_FUNCTION int mb<Device>() {
+          return 1;
         }
       };  // Impl
 
@@ -166,7 +188,10 @@ struct Algo {
       // - team policy (smaller) or range policy (bigger)
       // - space (cuda vs host)
       // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
-      [[deprecated]] static constexpr KOKKOS_FUNCTION int mb() { return Impl::mb(); }
+      [[deprecated]] static constexpr KOKKOS_FUNCTION int mb() {
+        KOKKOS_IF_ON_HOST((return Impl::mb<Host>();))
+        KOKKOS_IF_ON_DEVICE((return Impl::mb<Device>();))
+      }
     };
     struct MKL {};
     struct CompactMKL {};

--- a/blas/impl/KokkosBlas_util.hpp
+++ b/blas/impl/KokkosBlas_util.hpp
@@ -83,9 +83,6 @@ template <class T>
 static constexpr bool is_trans_v = is_trans<T>::value;
 
 struct Algo {
-  struct Host {};
-  struct Device {};
-
   struct Level3 {
     struct Unblocked {
       static const char* name() { return "Unblocked"; }
@@ -94,6 +91,9 @@ struct Algo {
       static const char* name() { return "Blocked"; }
 
       struct Impl {
+        struct Host {};
+        struct Device {};
+
         // TODO:: for now hardwire the blocksizes; this should reflect
         // register blocking (not about team parallelism).
         // this mb should vary according to
@@ -121,8 +121,8 @@ struct Algo {
       // - space (gpu vs host)
       // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
       [[deprecated]] static constexpr KOKKOS_FUNCTION int mb() {
-        KOKKOS_IF_ON_HOST((return Impl::mb<Host>();))
-        KOKKOS_IF_ON_DEVICE((return Impl::mb<Device>();))
+        KOKKOS_IF_ON_HOST((return Impl::mb<Impl::Host>();))
+        KOKKOS_IF_ON_DEVICE((return Impl::mb<Impl::Device>();))
       }
     };
     struct MKL {
@@ -162,6 +162,9 @@ struct Algo {
     struct Unblocked {};
     struct Blocked {
       struct Impl {
+        struct Host {};
+        struct Device {};
+
         // TODO:: for now hardwire the blocksizes; this should reflect
         // register blocking (not about team parallelism).
         // this mb should vary according to
@@ -189,8 +192,8 @@ struct Algo {
       // - space (cuda vs host)
       // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
       [[deprecated]] static constexpr KOKKOS_FUNCTION int mb() {
-        KOKKOS_IF_ON_HOST((return Impl::mb<Host>();))
-        KOKKOS_IF_ON_DEVICE((return Impl::mb<Device>();))
+        KOKKOS_IF_ON_HOST((return Impl::mb<Impl::Host>();))
+        KOKKOS_IF_ON_DEVICE((return Impl::mb<Impl::Device>();))
       }
     };
     struct MKL {};


### PR DESCRIPTION
Fix for #2942

The basic transformation is from this

```c++
static constexpr KOKKOS_FUNCTION int mb() { 
  KOKKOS_IF_ON_HOST((return 4;)) 
  KOKKOS_IF_ON_DEVICE((return 2;)) 
} 

// called inside a parallel region
KOKKOS_INLINE_FUNCTION int foo() {
  constexpr int B = mb();
  GEMM<B> g();
  g.invoke();
}
```

to this

```c++
// now, each call to `mb` is the same from host and device side
struct Host{};
struct Device{};

template <typename Where>
constexpr static KOKKOS_INLINE_FUNCTION int mb() {
  if constexpr (std::is_same_v<Where, Host>) {
    return 4;
  } else {
    return 2;
  }
}

// dispatch specialized for host or device is always self-consistent
KOKKOS_INLINE_FUNCTION int foo() {
  auto host_or_device = [&](auto tag) {
    constexpr int B = mb<decltype(tag)>();
    GEMM<B> g();
    g.invoke();
  };

  KOKKOS_IF_ON_HOST((host_or_device(Host{});))
  KOKKOS_IF_ON_DEVICE((host_or_device(Device{});))
}
```