### PR TITLE
Add Blas Concepts

### DIFF
--- a/blas/impl/KokkosBlas_Concepts.hpp
+++ b/blas/impl/KokkosBlas_Concepts.hpp
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOSBLAS_CONCEPTS_HPP
+#define KOKKOSBLAS_CONCEPTS_HPP
+
+#include "KokkosBlas_util.hpp"
+
+namespace KokkosBlas {
+
+template <typename T>
+concept TransposeOperation = is_trans_v<T>;
+
+template <typename T>
+concept BlasLevel2 = is_level2_v<T>;
+
+template <typename T>
+concept BlasLevel3 = is_level3_v<T>;
+
+}  // namespace KokkosBlas
+
+#endif  // KOKKOSBLAS_CONCEPTS_HPP

--- a/blas/impl/KokkosBlas_Concepts.hpp
+++ b/blas/impl/KokkosBlas_Concepts.hpp
@@ -4,6 +4,7 @@
 #ifndef KOKKOSBLAS_CONCEPTS_HPP
 #define KOKKOSBLAS_CONCEPTS_HPP
 
+#include <concepts>
 #include "KokkosBlas_util.hpp"
 
 namespace KokkosBlas {

--- a/blas/impl/KokkosBlas_util.hpp
+++ b/blas/impl/KokkosBlas_util.hpp
@@ -190,6 +190,24 @@ struct Algo {
 };
 
 template <class T>
+struct is_level3 : std::false_type {};
+
+template <>
+struct is_level3<Algo::Level3::Unblocked> : std::true_type {};
+
+template <>
+struct is_level3<Algo::Level3::Blocked> : std::true_type {};
+
+template <>
+struct is_level3<Algo::Level3::MKL> : std::true_type {};
+
+template <>
+struct is_level3<Algo::Level3::CompactMKL> : std::true_type {};
+
+template <class T>
+static constexpr bool is_level3_v = is_level3<T>::value;
+
+template <class T>
 struct is_level2 : std::false_type {};
 
 template <>

--- a/blas/unit_test/Test_Blas.hpp
+++ b/blas/unit_test/Test_Blas.hpp
@@ -3,6 +3,9 @@
 #ifndef TEST_BLAS_HPP
 #define TEST_BLAS_HPP
 
+// Blas concepts
+#include "Test_Blas_Concepts.hpp"
+
 // Blas 1
 #include "Test_Blas1_abs.hpp"
 #include "Test_Blas1_asum.hpp"

--- a/blas/unit_test/Test_Blas_Concepts.hpp
+++ b/blas/unit_test/Test_Blas_Concepts.hpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+#ifndef TEST_BLAS_CONCEPTS_HPP
+#define TEST_BLAS_CONCEPTS_HPP
+
+#include <gtest/gtest.h>
+#include "KokkosBlas_Concepts.hpp"
+#include <KokkosKernels_TestUtils.hpp>
+
+namespace Test {
+void test_blas_concepts() {
+  // Check that the concepts compile for valid types
+  static_assert(KokkosBlas::TransposeOperation<KokkosBlas::Trans::Transpose>);
+  static_assert(KokkosBlas::TransposeOperation<KokkosBlas::Trans::NoTranspose>);
+  static_assert(KokkosBlas::TransposeOperation<KokkosBlas::Trans::ConjTranspose>);
+
+  // Check for level 2 concepts
+  static_assert(KokkosBlas::BlasLevel2<KokkosBlas::Algo::Level2::Unblocked>);
+  static_assert(KokkosBlas::BlasLevel2<KokkosBlas::Algo::Level2::Blocked>);
+  static_assert(KokkosBlas::BlasLevel2<KokkosBlas::Algo::Level2::MKL>);
+  static_assert(KokkosBlas::BlasLevel2<KokkosBlas::Algo::Level2::CompactMKL>);
+
+  static_assert(!KokkosBlas::BlasLevel2<KokkosBlas::Algo::Level3::Unblocked>);
+  static_assert(!KokkosBlas::BlasLevel2<KokkosBlas::Algo::Level3::Blocked>);
+  static_assert(!KokkosBlas::BlasLevel2<KokkosBlas::Algo::Level3::MKL>);
+  static_assert(!KokkosBlas::BlasLevel2<KokkosBlas::Algo::Level3::CompactMKL>);
+
+  // Check for level 3 concepts
+  static_assert(KokkosBlas::BlasLevel3<KokkosBlas::Algo::Level3::Unblocked>);
+  static_assert(KokkosBlas::BlasLevel3<KokkosBlas::Algo::Level3::Blocked>);
+  static_assert(KokkosBlas::BlasLevel3<KokkosBlas::Algo::Level3::MKL>);
+  static_assert(KokkosBlas::BlasLevel3<KokkosBlas::Algo::Level3::CompactMKL>);
+
+  static_assert(!KokkosBlas::BlasLevel3<KokkosBlas::Algo::Level2::Unblocked>);
+  static_assert(!KokkosBlas::BlasLevel3<KokkosBlas::Algo::Level2::Blocked>);
+  static_assert(!KokkosBlas::BlasLevel3<KokkosBlas::Algo::Level2::MKL>);
+  static_assert(!KokkosBlas::BlasLevel3<KokkosBlas::Algo::Level2::CompactMKL>);
+}
+}  // namespace Test
+
+TEST_F(TestCategory, blas_concepts) { ::Test::test_blas_concepts(); }
+
+#endif  // TEST_BLAS_CONCEPTS_HPP

--- a/blas/unit_test/Test_Blas_Concepts.hpp
+++ b/blas/unit_test/Test_Blas_Concepts.hpp
@@ -8,6 +8,10 @@
 #include <KokkosKernels_TestUtils.hpp>
 
 namespace Test {
+
+template <KokkosBlas::TransposeOperation ArgTrans>
+struct DummyFunctor {};
+
 void test_blas_concepts() {
   // Check that the concepts compile for valid types
   static_assert(KokkosBlas::TransposeOperation<KokkosBlas::Trans::Transpose>);
@@ -36,8 +40,15 @@ void test_blas_concepts() {
   static_assert(!KokkosBlas::BlasLevel3<KokkosBlas::Algo::Level2::MKL>);
   static_assert(!KokkosBlas::BlasLevel3<KokkosBlas::Algo::Level2::CompactMKL>);
 }
+
+void test_concepts_in_functor() {
+  [[maybe_unused]] DummyFunctor<KokkosBlas::Trans::NoTranspose> dummy_no_trans;
+  [[maybe_unused]] DummyFunctor<KokkosBlas::Trans::Transpose> dummy_trans;
+  [[maybe_unused]] DummyFunctor<KokkosBlas::Trans::ConjTranspose> dummy_conj_trans;
+}
 }  // namespace Test
 
 TEST_F(TestCategory, blas_concepts) { ::Test::test_blas_concepts(); }
+TEST_F(TestCategory, concepts_in_functor) { ::Test::test_concepts_in_functor(); }
 
 #endif  // TEST_BLAS_CONCEPTS_HPP


### PR DESCRIPTION
This PR introduces concepts from `KokkosBlas` traits which are planed to be used in `KokkosBatched`.
Currently, we only have the following concepts.
Similar concepts should be defined for `KokkosBatched`

```C++
template <typename T>
concept TransposeOperation = is_trans_v<T>;

template <typename T>
concept BlasLevel2 = is_level2_v<T>;

template <typename T>
concept BlasLevel3 = is_level3_v<T>;
```