### PR TITLE
SortCRS: pick between shell/radix automatically; speed up radix

### DIFF
--- a/common/src/KokkosKernels_Sorting.hpp
+++ b/common/src/KokkosKernels_Sorting.hpp
@@ -216,9 +216,16 @@ KOKKOS_INLINE_FUNCTION void SerialRadixSort(ValueType* values, ValueType* values
   static_assert(std::is_integral<ValueType>::value && std::is_unsigned<ValueType>::value,
                 "radixSort can only be run on unsigned integers.");
   if (n <= 1) return;
-  ValueType maxVal = 0;
+  // sort 4 bits at a time, into 16 buckets
+  constexpr ValueType mask = 0xF;
+  // Find the maximum value so we know how many passes to run,
+  // and at the same time do the first round of counting buckets
+  ValueType maxVal  = 0;
+  Ordinal count[16] = {0};
   for (Ordinal i = 0; i < n; i++) {
-    if (maxVal < values[i]) maxVal = values[i];
+    auto val = values[i];
+    count[val & mask]++;
+    if (maxVal < val) maxVal = val;
   }
   // determine how many significant bits the data has
   int passes = 0;
@@ -228,46 +235,43 @@ KOKKOS_INLINE_FUNCTION void SerialRadixSort(ValueType* values, ValueType* values
   }
   // Is the data currently held in values (false) or valuesAux (true)?
   bool inAux = false;
-  // sort 4 bits at a time, into 16 buckets
-  ValueType mask = 0xF;
   // maskPos counts the low bit index of mask (0, 4, 8, ...)
   Ordinal maskPos = 0;
+  Ordinal offset[16];
   for (int p = 0; p < passes; p++) {
-    // Count the number of elements in each bucket
-    Ordinal count[16] = {0};
-    Ordinal offset[17];
-    if (!inAux) {
-      for (Ordinal i = 0; i < n; i++) {
-        count[(values[i] & mask) >> maskPos]++;
-      }
-    } else {
-      for (Ordinal i = 0; i < n; i++) {
-        count[(valuesAux[i] & mask) >> maskPos]++;
-      }
-    }
     offset[0] = 0;
     // get offset as the prefix sum for count
-    for (Ordinal i = 0; i < 16; i++) {
+    for (Ordinal i = 0; i < 15; i++) {
       offset[i + 1] = offset[i] + count[i];
+      count[i]      = 0;
     }
     // now for each element in [lo, hi), move it to its offset in the other
     // buffer this branch should be ok because whichBuf is the same on all
     // threads
     if (!inAux) {
       for (Ordinal i = 0; i < n; i++) {
-        Ordinal bucket                                = (values[i] & mask) >> maskPos;
-        valuesAux[offset[bucket + 1] - count[bucket]] = values[i];
-        count[bucket]--;
+        auto val                  = values[i];
+        Ordinal bucket            = (val >> maskPos) & mask;
+        valuesAux[offset[bucket]] = val;
+        offset[bucket]++;
+        if (p < passes - 1) {
+          Ordinal nextBucket = (val >> (maskPos + 4)) & mask;
+          count[nextBucket]++;
+        }
       }
     } else {
       for (Ordinal i = 0; i < n; i++) {
-        Ordinal bucket                             = (valuesAux[i] & mask) >> maskPos;
-        values[offset[bucket + 1] - count[bucket]] = valuesAux[i];
-        count[bucket]--;
+        auto val               = valuesAux[i];
+        Ordinal bucket         = (val >> maskPos) & mask;
+        values[offset[bucket]] = valuesAux[i];
+        offset[bucket]++;
+        if (p < passes - 1) {
+          Ordinal nextBucket = (val >> (maskPos + 4)) & mask;
+          count[nextBucket]++;
+        }
       }
     }
     inAux = !inAux;
-    mask  = mask << 4;
     maskPos += 4;
   }
   // Move values back into main array if they are currently in aux.
@@ -290,10 +294,18 @@ KOKKOS_INLINE_FUNCTION void SerialRadixSort2(ValueType* values, ValueType* value
   static_assert(std::is_integral<ValueType>::value && std::is_unsigned<ValueType>::value,
                 "radixSort can only be run on unsigned integers.");
   if (n <= 1) return;
-  ValueType maxVal = 0;
+  // sort 4 bits at a time, into 16 buckets
+  constexpr ValueType mask = 0xF;
+  // Find the maximum value so we know how many passes to run,
+  // and at the same time do the first round of counting buckets
+  ValueType maxVal  = 0;
+  Ordinal count[16] = {0};
   for (Ordinal i = 0; i < n; i++) {
-    if (maxVal < values[i]) maxVal = values[i];
+    auto val = values[i];
+    count[val & mask]++;
+    if (maxVal < val) maxVal = val;
   }
+  // determine how many significant bits the data has
   int passes = 0;
   while (maxVal) {
     maxVal >>= 4;
@@ -301,48 +313,45 @@ KOKKOS_INLINE_FUNCTION void SerialRadixSort2(ValueType* values, ValueType* value
   }
   // Is the data currently held in values (false) or valuesAux (true)?
   bool inAux = false;
-  // sort 4 bits at a time, into 16 buckets
-  ValueType mask = 0xF;
   // maskPos counts the low bit index of mask (0, 4, 8, ...)
   Ordinal maskPos = 0;
+  Ordinal offset[16];
   for (int p = 0; p < passes; p++) {
-    // Count the number of elements in each bucket
-    Ordinal count[16] = {0};
-    Ordinal offset[17];
-    if (!inAux) {
-      for (Ordinal i = 0; i < n; i++) {
-        count[(values[i] & mask) >> maskPos]++;
-      }
-    } else {
-      for (Ordinal i = 0; i < n; i++) {
-        count[(valuesAux[i] & mask) >> maskPos]++;
-      }
-    }
     offset[0] = 0;
     // get offset as the prefix sum for count
-    for (Ordinal i = 0; i < 16; i++) {
+    for (Ordinal i = 0; i < 15; i++) {
       offset[i + 1] = offset[i] + count[i];
+      count[i]      = 0;
     }
     // now for each element in [lo, hi), move it to its offset in the other
     // buffer this branch should be ok because whichBuf is the same on all
     // threads
     if (!inAux) {
       for (Ordinal i = 0; i < n; i++) {
-        Ordinal bucket                                = (values[i] & mask) >> maskPos;
-        valuesAux[offset[bucket + 1] - count[bucket]] = values[i];
-        permAux[offset[bucket + 1] - count[bucket]]   = perm[i];
-        count[bucket]--;
+        auto val                  = values[i];
+        Ordinal bucket            = (val >> maskPos) & mask;
+        valuesAux[offset[bucket]] = val;
+        permAux[offset[bucket]]   = perm[i];
+        offset[bucket]++;
+        if (p < passes - 1) {
+          Ordinal nextBucket = (val >> (maskPos + 4)) & mask;
+          count[nextBucket]++;
+        }
       }
     } else {
       for (Ordinal i = 0; i < n; i++) {
-        Ordinal bucket                             = (valuesAux[i] & mask) >> maskPos;
-        values[offset[bucket + 1] - count[bucket]] = valuesAux[i];
-        perm[offset[bucket + 1] - count[bucket]]   = permAux[i];
-        count[bucket]--;
+        auto val               = valuesAux[i];
+        Ordinal bucket         = (val >> maskPos) & mask;
+        values[offset[bucket]] = valuesAux[i];
+        perm[offset[bucket]]   = permAux[i];
+        offset[bucket]++;
+        if (p < passes - 1) {
+          Ordinal nextBucket = (val >> (maskPos + 4)) & mask;
+          count[nextBucket]++;
+        }
       }
     }
     inAux = !inAux;
-    mask  = mask << 4;
     maskPos += 4;
   }
   // Move values back into main array if they are currently in aux.

--- a/common/unit_test/Test_Common_Sorting.hpp
+++ b/common/unit_test/Test_Common_Sorting.hpp
@@ -187,6 +187,23 @@ void testSerialRadixSort(size_t k, size_t subArraySize) {
   }
 }
 
+template <typename Key>
+void testSerialRadixSortToRange(size_t n, size_t maxKey) {
+  std::vector<Key> keys(n, 0);
+  if (maxKey) {
+    for (size_t i = 0; i < n; i++) {
+      keys[i] = rand() % maxKey;
+    }
+  }
+  std::vector<Key> keysGold = keys;
+  std::vector<Key> keysAux(n);
+  std::sort(keysGold.begin(), keysGold.end());
+  KokkosKernels::SerialRadixSort<int, Key>(keys.data(), keysAux.data(), n);
+  for (size_t i = 0; i < n; i++) {
+    ASSERT_EQ(keys[i], keysGold[i]);
+  }
+}
+
 template <typename Device, typename Key, typename Value>
 void testSerialRadixSort2(size_t k, size_t subArraySize) {
   // Create a view of randomized data
@@ -334,6 +351,13 @@ TEST_F(TestCategory, common_serial_radix) {
   for (size_t arrayMax = 0; arrayMax < 1000; arrayMax = 1 + 4 * arrayMax) {
     testSerialRadixSort<TestDevice, char>(numArrays, arrayMax);
     testSerialRadixSort<TestDevice, int>(numArrays, arrayMax);
+  }
+  // For more thorough testing, test with a range of maximum keys and data types,
+  // since max key determines how many passes the algorithm takes.
+  for (int maxKey = 0; maxKey < 255; maxKey++) testSerialRadixSortToRange<unsigned char>(253, maxKey);
+  for (size_t maxKey = 0; maxKey < size_t(4e9); maxKey = (maxKey + 1) * 2) {
+    testSerialRadixSortToRange<unsigned int>(127, maxKey);
+    testSerialRadixSortToRange<size_t>(128, maxKey);
   }
 }
 

--- a/docs/source/API/sparse/sort_crs.rst
+++ b/docs/source/API/sparse/sort_crs.rst
@@ -13,15 +13,17 @@ SortAlgorithm Enum
     PARALLEL_THREAD_LEVEL,
     BULK_SORT,
     RADIX,
-    SHELL
+    SHELL,
+    STDSORT
   };
 
 The `SortAlgorithm` enum specifies the sorting strategy to use for CRS matrices and graphs. The available options are:
 
 - `DEFAULT`: Automatically selects the best sorting strategy based on the execution space and matrix properties.
-- `SHELL`: Shell sort, only available on CPU. Default selection on CPU.
+- `SHELL`: Shell sort, only available on CPU.
 - `RADIX`: Radix sort, only available on CPU.
-- `PARALLEL_THREAD_LEVEL`: Forces parallel thread-level sorting within each row.
+- `STDSORT`: Use std::sort. This is only available for sorting graphs on CPU.
+- `PARALLEL_THREAD_LEVEL`: Forces parallel thread-level sorting within each row. Only available on GPU.
 - `BULK_SORT`: Order all entries in the matrix/graph using a single sort-by-key. This is the default algorithm for highly imbalanced matrices or graphs.
 
 Functions

--- a/sparse/impl/KokkosSparse_sort_crs_impl.hpp
+++ b/sparse/impl/KokkosSparse_sort_crs_impl.hpp
@@ -24,37 +24,31 @@ struct MatrixShellSortFunctor {
   }
 
   KOKKOS_FUNCTION void operator()(const size_t i) const {
-    const size_t nnz   = ind_.extent(0);
-    const size_t start = ptr_(i);
+    const size_t start   = ptr_(i);
+    const ordinal_type n = static_cast<ordinal_type>(ptr_(i + 1) - start);
+    ordinal_type m       = 1;
+    while (m < n) m = m * 3 + 1;
+    m /= 3;
 
-    if (start < nnz) {
-      const size_t NumEntries = ptr_(i + 1) - start;
-
-      const ordinal_type n = static_cast<ordinal_type>(NumEntries);
-      ordinal_type m       = 1;
-      while (m < n) m = m * 3 + 1;
-      m /= 3;
-
-      while (m > 0) {
-        ordinal_type max = n - m;
-        for (ordinal_type j = 0; j < max; j++) {
-          for (ordinal_type k = j; k >= 0; k -= m) {
-            const size_t sk = start + k;
-            if (ind_(sk + m) >= ind_(sk)) {
-              break;
-            }
-            if constexpr (permute_values_array) {
-              const scalar_type dtemp = val_(sk + m);
-              val_(sk + m)            = val_(sk);
-              val_(sk)                = dtemp;
-            }
-            const ordinal_type itemp = ind_(sk + m);
-            ind_(sk + m)             = ind_(sk);
-            ind_(sk)                 = itemp;
+    while (m > 0) {
+      ordinal_type max = n - m;
+      for (ordinal_type j = 0; j < max; j++) {
+        for (ordinal_type k = j; k >= 0; k -= m) {
+          const size_t sk = start + k;
+          if (ind_(sk + m) >= ind_(sk)) {
+            break;
           }
+          if constexpr (permute_values_array) {
+            const scalar_type dtemp = val_(sk + m);
+            val_(sk + m)            = val_(sk);
+            val_(sk)                = dtemp;
+          }
+          const ordinal_type itemp = ind_(sk + m);
+          ind_(sk + m)             = ind_(sk);
+          ind_(sk)                 = itemp;
         }
-        m = m / 3;
       }
+      m = m / 3;
     }
   }
 
@@ -132,33 +126,44 @@ struct GraphShellSortFunctor {
   }
 
   KOKKOS_FUNCTION void operator()(const size_t i) const {
-    const size_t nnz   = ind_.extent(0);
     const size_t start = ptr_(i);
 
-    if (start < nnz) {
-      const size_t NumEntries = ptr_(i + 1) - start;
+    const ordinal_type n = static_cast<ordinal_type>(ptr_(i + 1) - start);
+    ordinal_type m       = 1;
+    while (m < n) m = m * 3 + 1;
+    m /= 3;
 
-      const ordinal_type n = static_cast<ordinal_type>(NumEntries);
-      ordinal_type m       = 1;
-      while (m < n) m = m * 3 + 1;
-      m /= 3;
-
-      while (m > 0) {
-        ordinal_type max = n - m;
-        for (ordinal_type j = 0; j < max; j++) {
-          for (ordinal_type k = j; k >= 0; k -= m) {
-            const size_t sk = start + k;
-            if (ind_(sk + m) >= ind_(sk)) {
-              break;
-            }
-            const ordinal_type itemp = ind_(sk + m);
-            ind_(sk + m)             = ind_(sk);
-            ind_(sk)                 = itemp;
+    while (m > 0) {
+      ordinal_type max = n - m;
+      for (ordinal_type j = 0; j < max; j++) {
+        for (ordinal_type k = j; k >= 0; k -= m) {
+          const size_t sk = start + k;
+          if (ind_(sk + m) >= ind_(sk)) {
+            break;
           }
+          const ordinal_type itemp = ind_(sk + m);
+          ind_(sk + m)             = ind_(sk);
+          ind_(sk)                 = itemp;
         }
-        m = m / 3;
       }
+      m = m / 3;
     }
+  }
+
+  rowmap_t ptr_;
+  entries_t ind_;
+};
+
+template <typename rowmap_t, typename entries_t>
+struct GraphStdSortFunctor {
+  typedef typename entries_t::non_const_value_type ordinal_type;
+
+  GraphStdSortFunctor(const rowmap_t& ptr, const entries_t& ind) : ptr_(ptr), ind_(ind) {}
+
+  void operator()(const size_t i) const {
+    const size_t start = ptr_(i);
+    const size_t end   = ptr_(i + 1);
+    std::sort(ind_.data() + start, ind_.data() + end);
   }
 
   rowmap_t ptr_;

--- a/sparse/src/KokkosSparse_SortCrs.hpp
+++ b/sparse/src/KokkosSparse_SortCrs.hpp
@@ -55,7 +55,8 @@ void sort_crs_matrix(const execution_space& exec, const rowmap_t& rowmap, const 
   Ordinal numRows = rowmap.extent(0) ? rowmap.extent(0) - 1 : 0;
   if constexpr (!KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>) {
     if (option == SortAlgorithm::DEFAULT) {
-      option = SortAlgorithm::SHELL;
+      Ordinal nnzPerRow = entries.extent(0) / numRows;
+      option            = (nnzPerRow < 20) ? SortAlgorithm::SHELL : SortAlgorithm::RADIX;
     } else if ((option != SortAlgorithm::RADIX) && (option != SortAlgorithm::SHELL)) {
       throw std::invalid_argument("sort_csr_matrix: Only RADIX and SHELL sort are available on CPU.");
     }
@@ -224,7 +225,8 @@ void sort_crs_graph(const execution_space& exec, const rowmap_t& rowmap, const e
     // If on CPU, sort each row independently. Don't need to know numCols for
     // this.
     if (option == SortAlgorithm::DEFAULT) {
-      option = SortAlgorithm::SHELL;
+      Ordinal nnzPerRow = entries.extent(0) / numRows;
+      option            = (nnzPerRow < 20) ? SortAlgorithm::SHELL : SortAlgorithm::RADIX;
     } else if ((option != SortAlgorithm::RADIX) && (option != SortAlgorithm::SHELL)) {
       throw std::invalid_argument("sort_csr_graph: Only RADIX and SHELL sort are available on CPU.");
     }

--- a/sparse/src/KokkosSparse_SortCrs.hpp
+++ b/sparse/src/KokkosSparse_SortCrs.hpp
@@ -23,7 +23,7 @@ namespace KokkosSparse {
 // duplicated entries in A, A is sorted and returned (instead of a newly
 // allocated matrix).
 
-enum class SortAlgorithm { DEFAULT, PARALLEL_THREAD_LEVEL, BULK_SORT, RADIX, SHELL };
+enum class SortAlgorithm { DEFAULT, PARALLEL_THREAD_LEVEL, BULK_SORT, RADIX, SHELL, STDSORT };
 
 // Sort a CRS matrix: within each row, sort entries ascending by column.
 // At the same time, permute the values.
@@ -58,7 +58,8 @@ void sort_crs_matrix(const execution_space& exec, const rowmap_t& rowmap, const 
       Ordinal nnzPerRow = entries.extent(0) / numRows;
       option            = (nnzPerRow < 20) ? SortAlgorithm::SHELL : SortAlgorithm::RADIX;
     } else if ((option != SortAlgorithm::RADIX) && (option != SortAlgorithm::SHELL)) {
-      throw std::invalid_argument("sort_csr_matrix: Only RADIX and SHELL sort are available on CPU.");
+      throw std::invalid_argument(
+          "sort_csr_matrix: Only RADIX and SHELL sort are available on CPU for matrix sorting.");
     }
 
     if (option == SortAlgorithm::RADIX)
@@ -226,19 +227,25 @@ void sort_crs_graph(const execution_space& exec, const rowmap_t& rowmap, const e
     // this.
     if (option == SortAlgorithm::DEFAULT) {
       Ordinal nnzPerRow = entries.extent(0) / numRows;
-      option            = (nnzPerRow < 20) ? SortAlgorithm::SHELL : SortAlgorithm::RADIX;
-    } else if ((option != SortAlgorithm::RADIX) && (option != SortAlgorithm::SHELL)) {
-      throw std::invalid_argument("sort_csr_graph: Only RADIX and SHELL sort are available on CPU.");
+      option            = (nnzPerRow < 30) ? SortAlgorithm::STDSORT : SortAlgorithm::RADIX;
+    } else if ((option != SortAlgorithm::RADIX) && (option != SortAlgorithm::SHELL) &&
+               (option != SortAlgorithm::STDSORT)) {
+      throw std::invalid_argument(
+          "sort_csr_graph: Only RADIX, SHELL and STDSORT are available on CPU for sorting graphs.");
     }
 
     if (option == SortAlgorithm::RADIX)
       Kokkos::parallel_for("sort_crs_graph[CPU,radix]",
                            Kokkos::RangePolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>(exec, 0, numRows),
                            Impl::GraphRadixSortFunctor<rowmap_t, entries_t>(rowmap, entries));
-    else
+    else if (option == SortAlgorithm::SHELL)
       Kokkos::parallel_for("sort_crs_graph[CPU,shell]",
                            Kokkos::RangePolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>(exec, 0, numRows),
                            Impl::GraphShellSortFunctor<rowmap_t, entries_t>(rowmap, entries));
+    else
+      Kokkos::parallel_for("sort_crs_graph[CPU,std::sort]",
+                           Kokkos::RangePolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>(exec, 0, numRows),
+                           Impl::GraphStdSortFunctor<rowmap_t, entries_t>(rowmap, entries));
   } else {
     // On GPUs:
     //   If the graph is highly imbalanced AND the dimensions are not too large


### PR DESCRIPTION
- Add STDSORT as a sorting algorithm option for graphs on CPU
  - ``std::sort`` has no sort-by-key version, which is why this is only available for graphs
- Change behavior of DEFAULT SortCrs algorithm on CPUs
  - If it's a matrix with < 20 entries per row on average, use shell sort
  - Otherwise use radix
  - If it's a graph with < 30 entries per row, use std::sort
  - Otherwise use radix
- Improve radix implementation (take half as many passes through data) and testing

For matrices, there is a more conservative cutoff of 20 entries/row, even though radix is often now faster for shuffled inputs of fewer entries/row, for 2 reasons:
- shell is faster when the matrix is already sorted or almost sorted, while radix takes the same amount of time for any input permutation. The numbers below are for randomly shuffled input.
- radix gets slower with the log of maximum key (aka column, when sorting CRS).

These two properties can't be measured in constant time like nnz/row, so they're not used in the heuristic.

Here are some timings (serial backend, 50k rows, N approx entries per row, CrsMatrix):

Eclipse (Broadwell):

| N  | Radix (old) | Shell      | Radix (new) | Default (new) |
|----|-------------|------------|-------------|---------------|
| 10 | 0.0115071   | 0.00811405 | 0.0055027   |  0.00834978   |
| 20 | 0.0168709   | 0.0234198  | 0.00954263  |  0.0229293   |
| 30 | 0.0196942   | 0.0416072  | 0.0136842   |   0.0150321   |
| 40 | 0.0239652   | 0.0616507  | 0.0188068   |   0.0196313   |

Blake (Granite rapids):

| N  | Radix (old) | Shell      | Radix (new) | Default (new) |
|----|-------------|------------|-------------|---------------|
| 10 |  0.0182581  | 0.00507935  |   0.0110481 |   0.00506758  |
| 20 |  0.020158  |  0.0156176 | 0.0104301  |    0.015632  |
| 30 | 0.037822   |  0.0280926 |  0.0119157  |   0.0123646   |
| 40 |  0.0433125  |  0.0409841 |  0.0152853  |   0.0151538   |