### PR TITLE
Deprecate `Level2::Blocked::mb` and `Level3::Blocked::mb`

### DIFF
--- a/batched/dense/impl/KokkosBatched_Gemm_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemm_Serial_Internal.hpp
@@ -72,8 +72,8 @@ KOKKOS_INLINE_FUNCTION int SerialGemmInternal<Algo::Gemm::Blocked>::invoke(
   // C = beta C + alpha A B
   // C (m x n), A(m x k), B(k x n)
 
-  constexpr int mbAlgo = Algo::Gemm::Blocked::mb();
-  constexpr int nbAlgo = Algo::Gemm::Blocked::mb();
+  constexpr int mbAlgo = Algo::Gemm::Blocked::Impl::mb();
+  constexpr int nbAlgo = Algo::Gemm::Blocked::Impl::mb();
 
   const ScalarType one(1.0), zero(0.0);
 

--- a/batched/dense/impl/KokkosBatched_Gemm_Team_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Gemm_Team_Internal.hpp
@@ -73,8 +73,8 @@ KOKKOS_INLINE_FUNCTION int TeamGemmInternal<Algo::Gemm::Blocked>::invoke(
   // C = beta C + alpha A B
   // C (m x n), A(m x k), B(k x n)
 
-  constexpr int mbAlgo = Algo::Gemm::Blocked::mb();
-  constexpr int nbAlgo = Algo::Gemm::Blocked::mb();
+  constexpr int mbAlgo = Algo::Gemm::Blocked::Impl::mb();
+  constexpr int nbAlgo = Algo::Gemm::Blocked::Impl::mb();
 
   const ScalarType one(1.0), zero(0.0);
 

--- a/batched/dense/impl/KokkosBatched_LU_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_LU_Serial_Internal.hpp
@@ -71,7 +71,7 @@ template <typename ValueType>
 KOKKOS_INLINE_FUNCTION int SerialLU_Internal<Algo::LU::Blocked>::invoke(
     const int m, const int n, ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
     const typename MagnitudeScalarType<ValueType>::type /*tiny*/) {
-  constexpr int mbAlgo = Algo::LU::Blocked::mb();
+  constexpr int mbAlgo = Algo::LU::Blocked::Impl::mb();
   const typename MagnitudeScalarType<ValueType>::type one(1.0), minus_one(-1.0);
 
   const int k = (m < n ? m : n);

--- a/batched/dense/impl/KokkosBatched_LU_Team_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_LU_Team_Internal.hpp
@@ -79,7 +79,7 @@ template <typename MemberType, typename ValueType>
 KOKKOS_INLINE_FUNCTION int TeamLU_Internal<Algo::LU::Blocked>::invoke(
     const MemberType &member, const int m, const int n, ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
     const typename MagnitudeScalarType<ValueType>::type /*tiny*/) {
-  constexpr int mbAlgo = Algo::LU::Blocked::mb();
+  constexpr int mbAlgo = Algo::LU::Blocked::Impl::mb();
 
   const int k = (m < n ? m : n);
   if (k <= 0) return 0;

--- a/batched/dense/impl/KokkosBatched_Trsm_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsm_Serial_Internal.hpp
@@ -79,7 +79,7 @@ KOKKOS_INLINE_FUNCTION int SerialTrsmInternalLeftLower<Algo::Trsm::Blocked>::inv
     const bool use_unit_diag, const bool /*do_conj*/, const int m, const int n, const ScalarType alpha,
     const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
     /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
-  constexpr int mbAlgo = Algo::Trsm::Blocked::mb();
+  constexpr int mbAlgo = Algo::Trsm::Blocked::Impl::mb();
 
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
@@ -189,7 +189,7 @@ KOKKOS_INLINE_FUNCTION int SerialTrsmInternalLeftUpper<Algo::Trsm::Blocked>::inv
     /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
-  constexpr int mbAlgo = Algo::Trsm::Blocked::mb();
+  constexpr int mbAlgo = Algo::Trsm::Blocked::Impl::mb();
 
   if (alpha == zero)
     KokkosBlas::Impl::SerialSetInternal::invoke(m, n, zero, B, bs0, bs1);

--- a/batched/dense/impl/KokkosBatched_Trsm_Team_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsm_Team_Internal.hpp
@@ -74,7 +74,7 @@ KOKKOS_INLINE_FUNCTION int TeamTrsmInternalLeftLower<Algo::Trsm::Blocked>::invok
     const MemberType &member, const bool use_unit_diag, const int m, const int n, const ScalarType alpha,
     const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
     /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
-  constexpr int mbAlgo = Algo::Trsm::Blocked::mb();
+  constexpr int mbAlgo = Algo::Trsm::Blocked::Impl::mb();
 
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
@@ -199,7 +199,7 @@ KOKKOS_INLINE_FUNCTION int TeamTrsmInternalLeftUpper<Algo::Trsm::Blocked>::invok
     const MemberType &member, const bool use_unit_diag, const int m, const int n, const ScalarType alpha,
     const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
     /**/ ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1) {
-  constexpr int mbAlgo = Algo::Trsm::Blocked::mb();
+  constexpr int mbAlgo = Algo::Trsm::Blocked::Impl::mb();
 
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 

--- a/batched/dense/impl/KokkosBatched_Trsv_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsv_Serial_Internal.hpp
@@ -77,7 +77,7 @@ KOKKOS_INLINE_FUNCTION int SerialTrsvInternalLower<Algo::Trsv::Blocked>::invoke(
     /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
-  constexpr int mbAlgo = Algo::Trsv::Blocked::mb();
+  constexpr int mbAlgo = Algo::Trsv::Blocked::Impl::mb();
 
   if (alpha == zero)
     KokkosBlas::Impl::SerialSetInternal::invoke(m, zero, b, bs0);
@@ -167,7 +167,7 @@ KOKKOS_INLINE_FUNCTION int SerialTrsvInternalUpper<Algo::Trsv::Blocked>::invoke(
     /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
-  constexpr int mbAlgo = Algo::Trsm::Blocked::mb();
+  constexpr int mbAlgo = Algo::Trsm::Blocked::Impl::mb();
 
   // note that parallel range is different ( m*n vs m-1*n);
   if (alpha == zero)

--- a/batched/dense/impl/KokkosBatched_Trsv_Team_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsv_Team_Internal.hpp
@@ -80,7 +80,7 @@ KOKKOS_INLINE_FUNCTION int TeamTrsvInternalLower<Algo::Trsv::Blocked>::invoke(
     /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
-  constexpr int mbAlgo = Algo::Trsv::Blocked::mb();
+  constexpr int mbAlgo = Algo::Trsv::Blocked::Impl::mb();
 
   if (alpha == zero)
     KokkosBlas::Impl::TeamSetInternal::invoke(member, m, zero, b, bs0);
@@ -180,7 +180,7 @@ KOKKOS_INLINE_FUNCTION int TeamTrsvInternalUpper<Algo::Trsv::Blocked>::invoke(
     /**/ ValueType *KOKKOS_RESTRICT b, const int bs0) {
   const ScalarType one(1.0), zero(0.0), minus_one(-1.0);
 
-  constexpr int mbAlgo = Algo::Trsm::Blocked::mb();
+  constexpr int mbAlgo = Algo::Trsm::Blocked::Impl::mb();
 
   // note that parallel range is different ( m*n vs m-1*n);
   if (alpha == zero)

--- a/blas/impl/KokkosBlas2_serial_gemv_internal.hpp
+++ b/blas/impl/KokkosBlas2_serial_gemv_internal.hpp
@@ -82,7 +82,7 @@ KOKKOS_INLINE_FUNCTION int SerialGemvInternal<Algo::Gemv::Blocked>::invoke(
   // y = beta y + alpha A x
   // y (m), A(m x n), B(n)
 
-  constexpr int mbAlgo = Algo::Gemv::Blocked::mb();
+  constexpr int mbAlgo = Algo::Gemv::Blocked::Impl::mb();
 
   if (beta == zero)
     Impl::SerialSetInternal::invoke(m, zero, y, ys0);

--- a/blas/impl/KokkosBlas2_team_gemv_impl.hpp
+++ b/blas/impl/KokkosBlas2_team_gemv_impl.hpp
@@ -104,7 +104,7 @@ KOKKOS_INLINE_FUNCTION int TeamGemvInternal<Algo::Gemv::Blocked>::invoke(
   // y = beta y + alpha A x
   // y (m), A(m x n), B(n)
 
-  constexpr int mbAlgo = Algo::Gemv::Blocked::mb();
+  constexpr int mbAlgo = Algo::Gemv::Blocked::Impl::mb();
 
   if (beta == zero)
     KokkosBlas::Impl::TeamSetInternal::invoke(member, m, zero, y, ys0);

--- a/blas/impl/KokkosBlas_util.hpp
+++ b/blas/impl/KokkosBlas_util.hpp
@@ -36,13 +36,13 @@ struct OpReal {
 
 struct Mode {
   struct Serial {
-    static const char *name() { return "Serial"; }
+    static const char* name() { return "Serial"; }
   };
   struct Team {
-    static const char *name() { return "Team"; }
+    static const char* name() { return "Team"; }
   };
   struct TeamVector {
-    static const char *name() { return "TeamVector"; }
+    static const char* name() { return "TeamVector"; }
   };
 };
 
@@ -85,26 +85,37 @@ static constexpr bool is_trans_v = is_trans<T>::value;
 struct Algo {
   struct Level3 {
     struct Unblocked {
-      static const char *name() { return "Unblocked"; }
+      static const char* name() { return "Unblocked"; }
     };
     struct Blocked {
-      static const char *name() { return "Blocked"; }
+      static const char* name() { return "Blocked"; }
+
+      struct Impl {
+        // TODO:: for now harwire the blocksizes; this should reflect
+        // register blocking (not about team parallelism).
+        // this mb should vary according to
+        // - team policy (smaller) or range policy (bigger)
+        // - space (gpu vs host)
+        // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
+        static constexpr KOKKOS_FUNCTION int mb() {
+          KOKKOS_IF_ON_HOST((return 4;))
+          KOKKOS_IF_ON_DEVICE((return 2;))
+        }
+      };
+
       // TODO:: for now harwire the blocksizes; this should reflect
       // register blocking (not about team parallelism).
       // this mb should vary according to
       // - team policy (smaller) or range policy (bigger)
       // - space (gpu vs host)
       // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
-      static constexpr KOKKOS_FUNCTION int mb() {
-        KOKKOS_IF_ON_HOST((return 4;))
-        KOKKOS_IF_ON_DEVICE((return 2;))
-      }
+      [[deprecated]] static constexpr KOKKOS_FUNCTION int mb() { return Impl::mb(); }
     };
     struct MKL {
-      static const char *name() { return "MKL"; }
+      static const char* name() { return "MKL"; }
     };
     struct CompactMKL {
-      static const char *name() { return "CompactMKL"; }
+      static const char* name() { return "CompactMKL"; }
     };
 
     // When this is first developed, unblocked algorithm is a naive
@@ -136,16 +147,26 @@ struct Algo {
   struct Level2 {
     struct Unblocked {};
     struct Blocked {
+      struct Impl {
+        // TODO:: for now hardwire the blocksizes; this should reflect
+        // register blocking (not about team parallelism).
+        // this mb should vary according to
+        // - team policy (smaller) or range policy (bigger)
+        // - space (cuda vs host)ß
+        // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
+        static constexpr KOKKOS_FUNCTION int mb() {
+          KOKKOS_IF_ON_HOST((return 4;))
+          KOKKOS_IF_ON_DEVICE((return 1;))
+        }
+      };  // Impl
+
       // TODO:: for now hardwire the blocksizes; this should reflect
       // register blocking (not about team parallelism).
       // this mb should vary according to
       // - team policy (smaller) or range policy (bigger)
       // - space (cuda vs host)
       // - blocksize input (blk <= 4 mb = 2, otherwise mb = 4), etc.
-      static constexpr KOKKOS_FUNCTION int mb() {
-        KOKKOS_IF_ON_HOST((return 4;))
-        KOKKOS_IF_ON_DEVICE((return 1;))
-      }
+      [[deprecated]] static constexpr KOKKOS_FUNCTION int mb() { return Impl::mb(); }
     };
     struct MKL {};
     struct CompactMKL {};
@@ -201,7 +222,7 @@ namespace Impl {
 // Output params:
 //  * teamsPerReduction: number of teams to use for each reduction
 template <typename ExecSpace, typename size_type>
-void multipleReductionWorkDistribution(size_type length, size_type numReductions, size_type &teamsPerDot) {
+void multipleReductionWorkDistribution(size_type length, size_type numReductions, size_type& teamsPerDot) {
   constexpr size_type workPerTeam = 4096;                                    // Amount of work per team
   size_type appxNumTeams          = (length * numReductions) / workPerTeam;  // Estimation for appxNumTeams
 
@@ -228,7 +249,7 @@ void multipleReductionWorkDistribution(size_type length, size_type numReductions
 
 template <class RV>
 struct TakeSqrtFunctor {
-  TakeSqrtFunctor(const RV &r_) : r(r_) {}
+  TakeSqrtFunctor(const RV& r_) : r(r_) {}
 
   KOKKOS_INLINE_FUNCTION void operator()(int i) const {
     r(i) = KokkosKernels::ArithTraits<typename RV::non_const_value_type>::sqrt(r(i));


### PR DESCRIPTION
No replacement. Move into an `Impl` namespace.

Chances are no one was using these.