### PR TITLE
Enforce capitalization of `KokkosKernels_` CMake options

### DIFF
--- a/cmake/fake_tribits.cmake
+++ b/cmake/fake_tribits.cmake
@@ -45,7 +45,7 @@ function(kokkoskernels_add_option SUFFIX DEFAULT TYPE DOCSTRING)
       if("${OPT_UC}" STREQUAL "${UC_NAME}")
         if(NOT "${opt}" STREQUAL "${CAMEL_NAME}")
           message(FATAL_ERROR
-            "You provded ${opt} but Kokkos Kernels understands ${CAMEL_NAME}. Please delete your CMakeCache.txt and change option to -D${CAMEL_NAME}=${${opt}}. This is now enforced to avoid hard-to-debug CMake cache inconsistencies.")
+            "You provided ${opt} but Kokkos Kernels understands ${CAMEL_NAME}. Please delete your CMakeCache.txt and change option to -D${CAMEL_NAME}=${${opt}}. This is now enforced to avoid hard-to-debug CMake cache inconsistencies.")
         endif()
       endif()
     endif()

--- a/cmake/fake_tribits.cmake
+++ b/cmake/fake_tribits.cmake
@@ -36,12 +36,17 @@ function(kokkoskernels_add_option SUFFIX DEFAULT TYPE DOCSTRING)
   set(${CAMEL_NAME} ${DEFAULT} CACHE ${TYPE} ${DOCSTRING})
 
   #I don't love doing it this way because it's N^2 in number options, but cest la vie
+  get_cmake_property(KOKKOSKERNELS_GIVEN_VARIABLES VARIABLES)
   foreach(opt ${KOKKOSKERNELS_GIVEN_VARIABLES})
     string(TOUPPER ${opt} OPT_UC)
-    if("${OPT_UC}" STREQUAL "${UC_NAME}")
-      if(NOT "${opt}" STREQUAL "${CAMEL_NAME}")
-        message(FATAL_ERROR
-          "Matching option found for ${CAMEL_NAME} with the wrong case ${opt}. Please delete your CMakeCache.txt and change option to -D${CAMEL_NAME}=${${opt}}. This is now enforced to avoid hard-to-debug CMake cache inconsistencies.")
+    # only care if it starts with KokkosKernels
+    string(FIND ${OPT_UC} KOKKOSKERNELS IDX)
+    if(${IDX} EQUAL 0)
+      if("${OPT_UC}" STREQUAL "${UC_NAME}")
+        if(NOT "${opt}" STREQUAL "${CAMEL_NAME}")
+          message(FATAL_ERROR
+            "You provded ${opt} but Kokkos Kernels understands ${CAMEL_NAME}. Please delete your CMakeCache.txt and change option to -D${CAMEL_NAME}=${${opt}}. This is now enforced to avoid hard-to-debug CMake cache inconsistencies.")
+        endif()
       endif()
     endif()
   endforeach()


### PR DESCRIPTION
I suspect this was always supposed to work this way, but the initial implementation forgot to load the set variables, so it was iterating over an empty list.

* reword the error so it's a bit clearer
* Only check variables prefixed with some capitalization of `KokkosKernels`

e.g.

```bash
# should be -DKokkosKernels_ENABLE_BENCHMARKS
$ cmake -D KOKKOSKERNELS_ENABLE_BENCHMARKS=ON
```

Before:
```bash
-- The project name is: KokkosKernels
[configures happily]
```

Now:
```bash
-- The project name is: KokkosKernels
CMake Error at cmake/fake_tribits.cmake:47 (message):
  You provded KOKKOSKERNELS_ENABLE_BENCHMARKS but Kokkos Kernels understands
  KokkosKernels_ENABLE_BENCHMARKS.  Please delete your CMakeCache.txt and
  change option to -DKokkosKernels_ENABLE_BENCHMARKS=ON.  This is now
  enforced to avoid hard-to-debug CMake cache inconsistencies.
Call Stack (most recent call first):
  CMakeLists.txt:64 (kokkoskernels_add_option)
```