### PR TITLE
Avoid calling RCB in each kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential

### DIFF
--- a/docs/source/API/sparse-index.rst
+++ b/docs/source/API/sparse-index.rst
@@ -95,6 +95,6 @@ Linear Solver / Preconditioners
 Utility Functions
 =================
 
-- Apply RCB to the coordinates associated with rows/columns of a crs matrix then extract the diagonal blocks corresponding to the RCB partitions
+- Extract the diagonal blocks corresponding to the RCB partitions from a crs matrix (this function must be called after applying RCB to the coordinates associated with the rows/columns of the crs matrix)
 
   - :doc:`extract_diagonal_blocks_rcb <sparse/extract_diagonal_blocks_rcb>`

--- a/docs/source/API/sparse/extract_diagonal_blocks_rcb.rst
+++ b/docs/source/API/sparse/extract_diagonal_blocks_rcb.rst
@@ -5,42 +5,45 @@ Defined in header: :code:`KokkosSparse_Utils.hpp`
 
 .. code:: c++
 
-  template <typename crsMat_t, typename coor_view_type, typename perm_view_type>
-  void kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(const crsMat_t &A, coor_view_type &coors,
-                                                                std::vector<crsMat_t> &DiagBlk_v, perm_view_type &perm_rcb);
+  template <typename crsMat_t, typename perm_view_type>
+  void kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(
+      const crsMat_t &A, const perm_view_type &perm_rcb, const perm_view_type &reverse_perm_rcb,
+      const std::vector<typename crsMat_t::non_const_ordinal_type> partition_sizes_rcb,
+      std::vector<crsMat_t> &DiagBlk_v);
 
-Extract diagonal blocks from a square CRS matrix after applying RCB to the coordinates associated with the rows/columns of the CRS matrix.
+Extract diagonal blocks from a square CRS matrix using the pre-run RCB partition information. This function must be called after applying RCB to the coordinates associated with
+ * the rows/columns of the CRS matrix.
 
-The number of diagonal blocks is used as the number of partitions for RCB.
+The number of diagonal blocks is the number of partitions for RCB.
 
-The function will return
-
-1. a vector of diagonal blocks corresponding to the RCB partitions, and
-2. a permutation array describing the mapping from the original order to RCB order.
+The function will return a vector of diagonal blocks corresponding to the RCB partitions.
 
 The function will throw a runtime exception if any of the following conditions are not met:
 
 - the sparse matrix ``A`` is not square
 - the size of the vector of diagonal blocks ``DiagBlk_v`` is not set or is larger than the number of rows in ``A``
 - the size of the vector of diagonal blocks ``DiagBlk_v`` is not a power of 2
+- the size of the vector ``DiagBlk_v`` is not equal to the size of the vector ``partition_sizes_rcb``
+- the size of the permutation array ``perm_rcb`` is not equal to the number of rows in ``A``
+- the size of the reverse permutation array ``reverse_perm_rcb`` is not equal to the number of rows in ``A``
 
 Parameters
 ==========
 
 :A: the input square CRS matrix (it is expected that column indices are in ascending order).
 
-:coors: 1/2/3-D coordinates associated with the rows of A.
+:perm_rcb: 1-D array describing the mapping from the original order to RCB order.
+
+:reverse_perm_rcb: 1-D array describing the mapping from the RCB order to original order.
+
+:partition_sizes_rcb: the vector containing sizes of RCB partitions
 
 :DiagBlk_v: the vector of the extracted CRS diagonal blocks.
-
-:perm_rcb: 1-D array describing the mapping from the original order to RCB order.
 
 Type Requirements
 =================
 
 - ``crsMat_t`` must be a Kokkos Kernels `CrsMatrix <https://kokkos.org/kokkos-kernels/docs/API/sparse/crs_matrix.html>`_
-
-- ``coor_view_type`` must be a Kokkos `View <https://kokkos.org/kokkos-core-wiki/API/core/view/view.html>`_ of rank 2
 
 - ``perm_view_type`` must be a Kokkos `View <https://kokkos.org/kokkos-core-wiki/API/core/view/view.html>`_ of rank 1
 

--- a/docs/source/API/sparse/extract_diagonal_blocks_rcb.rst
+++ b/docs/source/API/sparse/extract_diagonal_blocks_rcb.rst
@@ -11,8 +11,7 @@ Defined in header: :code:`KokkosSparse_Utils.hpp`
       const std::vector<typename crsMat_t::non_const_ordinal_type> partition_sizes_rcb,
       std::vector<crsMat_t> &DiagBlk_v);
 
-Extract diagonal blocks from a square CRS matrix using the pre-run RCB partition information. This function must be called after applying RCB to the coordinates associated with
- * the rows/columns of the CRS matrix.
+Extract diagonal blocks from a square CRS matrix using the pre-run RCB partition information. This function must be called after applying RCB to the coordinates associated with the rows/columns of the CRS matrix.
 
 The number of diagonal blocks is the number of partitions for RCB.
 

--- a/docs/source/API/sparse/extract_diagonal_blocks_rcb.rst
+++ b/docs/source/API/sparse/extract_diagonal_blocks_rcb.rst
@@ -17,7 +17,7 @@ The number of diagonal blocks is the number of partitions for RCB.
 
 The function will return a vector of diagonal blocks corresponding to the RCB partitions.
 
-The function will throw a runtime exception if any of the following conditions are not met:
+The function will throw a runtime exception if any of the following conditions are true:
 
 - the sparse matrix ``A`` is not square
 - the size of the vector of diagonal blocks ``DiagBlk_v`` is not set or is larger than the number of rows in ``A``

--- a/sparse/src/KokkosSparse_Utils.hpp
+++ b/sparse/src/KokkosSparse_Utils.hpp
@@ -2097,7 +2097,7 @@ kk_extract_diagonal_blocks_crsmatrix_sequential(const crsMat_t &A, std::vector<c
  * @param perm_rcb [in] The permutation array describing the mapping from the original ordering to RCB ordering
  * @param reverse_perm_rcb [in] The reverse permutation array describing the mapping from the RCB ordering to original
  * ordering
- * @param partition_sizes_rcb [in] The vector containing sizes of RCB partitions 
+ * @param partition_sizes_rcb [in] The vector containing sizes of RCB partitions
  * @param DiagBlk_v [out] The vector of the extracted CRS diagonal blocks
  * (1 <= the number of diagonal blocks <= A_nrows, which is also the number of partitions in the RCB and has to be a
  * power of 2)
@@ -2106,10 +2106,10 @@ kk_extract_diagonal_blocks_crsmatrix_sequential(const crsMat_t &A, std::vector<c
  *   kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(A_in, perm, reverse_perm, partition_sizes, diagBlk_out);
  */
 template <typename crsMat_t, typename perm_view_type>
-void kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(const crsMat_t &A, const perm_view_type &perm_rcb,
-                                                              const perm_view_type &reverse_perm_rcb,
-                                                              const std::vector<typename crsMat_t::non_const_ordinal_type> partition_sizes_rcb,
-                                                              std::vector<crsMat_t> &DiagBlk_v) {
+void kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(
+    const crsMat_t &A, const perm_view_type &perm_rcb, const perm_view_type &reverse_perm_rcb,
+    const std::vector<typename crsMat_t::non_const_ordinal_type> partition_sizes_rcb,
+    std::vector<crsMat_t> &DiagBlk_v) {
   using row_map_type     = typename crsMat_t::row_map_type;
   using entries_type     = typename crsMat_t::index_type;
   using values_type      = typename crsMat_t::values_type;
@@ -2175,19 +2175,22 @@ void kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(const crsMat_t &A,
 
       if (static_cast<ordinal_type>(partition_sizes_rcb.size()) != n_blocks) {
         std::ostringstream os;
-        os << "The number of diagonal blocks (" << n_blocks << ") must be equal to the number of partitions (" << partition_sizes_rcb.size() << ')';
+        os << "The number of diagonal blocks (" << n_blocks << ") must be equal to the number of partitions ("
+           << partition_sizes_rcb.size() << ')';
         throw std::runtime_error(os.str());
       }
 
       if (static_cast<ordinal_type>(perm_rcb.extent(0)) != A_nrows) {
         std::ostringstream os;
-        os << "The size of the permutation array (" << perm_rcb.extent(0) << ") must be equal to the number of rows of the matrix A (" << A_nrows << ')';
+        os << "The size of the permutation array (" << perm_rcb.extent(0)
+           << ") must be equal to the number of rows of the matrix A (" << A_nrows << ')';
         throw std::runtime_error(os.str());
       }
 
       if (static_cast<ordinal_type>(reverse_perm_rcb.extent(0)) != A_nrows) {
         std::ostringstream os;
-        os << "The size of the reverse permutation array (" << reverse_perm_rcb.extent(0) << ") must be equal to the number of rows of the matrix A (" << A_nrows << ')';
+        os << "The size of the reverse permutation array (" << reverse_perm_rcb.extent(0)
+           << ") must be equal to the number of rows of the matrix A (" << A_nrows << ')';
         throw std::runtime_error(os.str());
       }
 

--- a/sparse/src/KokkosSparse_Utils.hpp
+++ b/sparse/src/KokkosSparse_Utils.hpp
@@ -2087,27 +2087,29 @@ kk_extract_diagonal_blocks_crsmatrix_sequential(const crsMat_t &A, std::vector<c
 }
 
 /**
- * @brief Apply RCB to the coordinates associated with the rows/columns of a crs matrix then perform matrix permutation
- * using the RCB ordering while extract the diagonal blocks corresponding to the RCB partitions. This is a blocking
- * function that runs on the host.
+ * @brief Extract the diagonal blocks corresponding to the RCB partitions from a crs matrix. This is a blocking
+ * function that runs on the host. This function must be called after applying RCB to the coordinates associated with
+ * the rows/columns of the crs matrix.
  *
  * @tparam crsMat_t The type of the CRS matrix.
- * @tparam coor_view_type The type of coordinate list.
  * @tparam perm_view_type The type of permutation array.
  * @param A [in] The square CrsMatrix. It is expected that column indices are in ascending order
- * @param coors [in] The 1/2/3-D coordinates associated with the rows/columns of A
+ * @param perm_rcb [in] The permutation array describing the mapping from the original ordering to RCB ordering
+ * @param reverse_perm_rcb [in] The reverse permutation array describing the mapping from the RCB ordering to original
+ * ordering
+ * @param partition_sizes_rcb [in] The vector containing sizes of RCB partitions 
  * @param DiagBlk_v [out] The vector of the extracted CRS diagonal blocks
  * (1 <= the number of diagonal blocks <= A_nrows, which is also the number of partitions in the RCB and has to be a
  * power of 2)
- * @param perm_rcb [out] The permutation array describing the mapping from the original ordering to RCB ordering
  *
  * Usage example:
- *   kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(A_in, coors, diagBlk_out, perm);
+ *   kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(A_in, perm, reverse_perm, partition_sizes, diagBlk_out);
  */
-template <typename crsMat_t, typename coor_view_type, typename perm_view_type>
-void kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(const crsMat_t &A, coor_view_type &coors,
-                                                              std::vector<crsMat_t> &DiagBlk_v,
-                                                              perm_view_type &perm_rcb) {
+template <typename crsMat_t, typename perm_view_type>
+void kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(const crsMat_t &A, const perm_view_type &perm_rcb,
+                                                              const perm_view_type &reverse_perm_rcb,
+                                                              const std::vector<typename crsMat_t::non_const_ordinal_type> partition_sizes_rcb,
+                                                              std::vector<crsMat_t> &DiagBlk_v) {
   using row_map_type     = typename crsMat_t::row_map_type;
   using entries_type     = typename crsMat_t::index_type;
   using values_type      = typename crsMat_t::values_type;
@@ -2119,15 +2121,10 @@ void kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(const crsMat_t &A,
   using ordinal_type = typename crsMat_t::non_const_ordinal_type;
   using size_type    = typename crsMat_t::non_const_size_type;
 
-  static_assert(Kokkos::is_view_v<coor_view_type>,
-                "KokkosSparse::Impl::kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential: coor_view_type must be "
-                "a Kokkos::View.");
   static_assert(Kokkos::is_view_v<perm_view_type>,
                 "KokkosSparse::Impl::kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential: perm_view_type must be "
                 "a Kokkos::View.");
 
-  static_assert(static_cast<int>(coor_view_type::rank()) == 2,
-                "KokkosSparse::Impl::recursive_coordinate_bisection: coor_view_type must have rank 2.");
   static_assert(static_cast<int>(perm_view_type::rank()) == 1,
                 "KokkosSparse::Impl::recursive_coordinate_bisection: perm_view_type must have rank 1.");
 
@@ -2154,9 +2151,6 @@ void kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(const crsMat_t &A,
   if (n_blocks == 1) {
     // One block case: simply shallow copy A to DiagBlk_v[0]
     DiagBlk_v[0] = crsMat_t(A);
-    Kokkos::parallel_for(
-        Kokkos::RangePolicy<typename perm_view_type::device_type::execution_space>(0, static_cast<int>(A_nrows)),
-        KOKKOS_LAMBDA(const ordinal_type &i) { perm_rcb(i) = i; });
   } else {
     // n_blocks > 1
     if (A_nrows == 0) {
@@ -2179,13 +2173,25 @@ void kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(const crsMat_t &A,
         throw std::runtime_error(os.str());
       }
 
-      // Perform RCB on the coordinates associated with the row/col indices first
-      perm_view_type reverse_perm_rcb(Kokkos::view_alloc(Kokkos::WithoutInitializing, "reverse_perm_rcb"), A_nrows);
-      ordinal_type n_levels = static_cast<ordinal_type>(std::log2(static_cast<double>(n_blocks)) + 1);
-      std::vector<ordinal_type> partition_sizes =
-          KokkosGraph::Experimental::recursive_coordinate_bisection<coor_view_type, perm_view_type>(
-              coors, perm_rcb, reverse_perm_rcb, n_levels);
+      if (static_cast<ordinal_type>(partition_sizes_rcb.size()) != n_blocks) {
+        std::ostringstream os;
+        os << "The number of diagonal blocks (" << n_blocks << ") must be equal to the number of partitions (" << partition_sizes_rcb.size() << ')';
+        throw std::runtime_error(os.str());
+      }
 
+      if (static_cast<ordinal_type>(perm_rcb.extent(0)) != A_nrows) {
+        std::ostringstream os;
+        os << "The size of the permutation array (" << perm_rcb.extent(0) << ") must be equal to the number of rows of the matrix A (" << A_nrows << ')';
+        throw std::runtime_error(os.str());
+      }
+
+      if (static_cast<ordinal_type>(reverse_perm_rcb.extent(0)) != A_nrows) {
+        std::ostringstream os;
+        os << "The size of the reverse permutation array (" << reverse_perm_rcb.extent(0) << ") must be equal to the number of rows of the matrix A (" << A_nrows << ')';
+        throw std::runtime_error(os.str());
+      }
+
+      // Permute and extract
       auto h_perm_rcb         = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), perm_rcb);
       auto h_reverse_perm_rcb = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), reverse_perm_rcb);
 
@@ -2194,7 +2200,7 @@ void kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(const crsMat_t &A,
       ordinal_type blk_nrows, blk_ncols;  // Nrows, Ncols of i-th diagonal block
 
       for (ordinal_type i = 0; i < n_blocks; i++) {
-        blk_nrows     = partition_sizes[i];
+        blk_nrows     = partition_sizes_rcb[i];
         blk_ncols     = blk_nrows;
         blk_col_start = blk_row_start;
 

--- a/sparse/unit_test/Test_Sparse_extractCrsDiagonalBlocksRCB.hpp
+++ b/sparse/unit_test/Test_Sparse_extractCrsDiagonalBlocksRCB.hpp
@@ -61,8 +61,8 @@ void run_test_extract_diagonal_blocks_rcb(lno_t n_pts_per_dim, lno_t nblocks) {
   // Generate coordinates
   lno_t n_coordinates = n_pts_per_dim * n_pts_per_dim * n_pts_per_dim;
   CoorsViewType coordinates(Kokkos::view_alloc(Kokkos::WithoutInitializing, "coordinates"), n_coordinates, 3);
-  CoorsViewType_hm h_coordinates = Kokkos::create_mirror(coordinates);
-  magnitude_t dx = generate_3d_coordinates_for_sparse_rows<CoorsViewType_hm>(n_pts_per_dim, h_coordinates);
+  auto h_coordinates = Kokkos::create_mirror(coordinates);
+  magnitude_t dx = generate_3d_coordinates_for_sparse_rows(n_pts_per_dim, h_coordinates);
   Kokkos::deep_copy(coordinates, h_coordinates);
 
   // Generate test matrix consisting of near interactions calculated based on coordinates

--- a/sparse/unit_test/Test_Sparse_extractCrsDiagonalBlocksRCB.hpp
+++ b/sparse/unit_test/Test_Sparse_extractCrsDiagonalBlocksRCB.hpp
@@ -53,8 +53,6 @@ void run_test_extract_diagonal_blocks_rcb(lno_t n_pts_per_dim, lno_t nblocks) {
   using magnitude_t      = typename KokkosKernels::ArithTraits<scalar_t>::mag_type;
   using CoorsViewType    = Kokkos::View<magnitude_t **, device>;
   using PermViewType     = Kokkos::View<lno_t *, device>;
-  using CoorsViewType_hm = typename CoorsViewType::host_mirror_type;
-  using PermViewType_hm  = typename PermViewType::host_mirror_type;
   using crsMat_t         = KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>;
 
   crsMat_t A;
@@ -110,7 +108,11 @@ void run_test_extract_diagonal_blocks_rcb(lno_t n_pts_per_dim, lno_t nblocks) {
 
   // Extract diagonal blocks
   PermViewType perm_rcb(Kokkos::view_alloc(Kokkos::WithoutInitializing, "perm_rcb"), n_coordinates);
-  KokkosSparse::Impl::kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(A, coordinates, DiagBlks, perm_rcb);
+  PermViewType reverse_perm_rcb(Kokkos::view_alloc(Kokkos::WithoutInitializing, "reverse_perm_rcb"), n_coordinates);
+  lno_t n_levels = static_cast<lno_t>(std::log2(static_cast<double>(nblocks)) + 1);
+  std::vector<lno_t> partition_sizes = KokkosGraph::Experimental::recursive_coordinate_bisection(coordinates, perm_rcb, reverse_perm_rcb, n_levels);
+
+  KokkosSparse::Impl::kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(A, perm_rcb, reverse_perm_rcb, partition_sizes, DiagBlks);
 
   // Checking results
   lno_t numRows = 0;
@@ -123,12 +125,8 @@ void run_test_extract_diagonal_blocks_rcb(lno_t n_pts_per_dim, lno_t nblocks) {
   ASSERT_EQ(numRows, nrows);
   ASSERT_EQ(numCols, nrows);
 
-  lno_t n_levels = static_cast<lno_t>(std::log2(static_cast<double>(nblocks)) + 1);
-  PermViewType_hm perm_rcb_ref(Kokkos::view_alloc(Kokkos::WithoutInitializing, "perm_rcb_ref"), n_coordinates);
-  PermViewType_hm reverse_perm_rcb_ref(Kokkos::view_alloc(Kokkos::WithoutInitializing, "reverse_perm_rcb_ref"),
-                                       n_coordinates);
-  std::vector<lno_t> partition_sizes = KokkosGraph::Experimental::recursive_coordinate_bisection(
-      h_coordinates, perm_rcb_ref, reverse_perm_rcb_ref, n_levels);
+  auto h_perm_rcb         = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), perm_rcb);
+  auto h_reverse_perm_rcb = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), reverse_perm_rcb);
 
   std::map<lno_t, scalar_t> colIdx_Value_rcb;
 
@@ -146,12 +144,12 @@ void run_test_extract_diagonal_blocks_rcb(lno_t n_pts_per_dim, lno_t nblocks) {
     for (lno_t ii = 0; ii < blk_size; ii++) {  // row loop in each block
       ASSERT_EQ(h_row_map_diagblk(ii), blk_nnz);
       colIdx_Value_rcb.clear();
-      lno_t origRow = reverse_perm_rcb_ref(blk_start + ii);  // get the original row idx of the reordered row idx, ii
+      lno_t origRow = h_reverse_perm_rcb(blk_start + ii);  // get the original row idx of the reordered row idx, ii
       for (size_type j = h_row_map(origRow); j < h_row_map(origRow + 1); j++) {
         lno_t origEi   = h_entries(j);
         scalar_t origV = h_values(j);
-        lno_t Ei       = perm_rcb_ref(origEi);  // get the reordered col idx of the
-                                                // original col idx, origEi
+        lno_t Ei       = h_perm_rcb(origEi);  // get the reordered col idx of the
+                                              // original col idx, origEi
         colIdx_Value_rcb[Ei] = origV;
       }
       for (typename std::map<lno_t, scalar_t>::iterator it = colIdx_Value_rcb.begin(); it != colIdx_Value_rcb.end();

--- a/sparse/unit_test/Test_Sparse_extractCrsDiagonalBlocksRCB.hpp
+++ b/sparse/unit_test/Test_Sparse_extractCrsDiagonalBlocksRCB.hpp
@@ -47,13 +47,13 @@ typename coors_view_t::value_type generate_3d_coordinates_for_sparse_rows(int n_
 
 template <typename scalar_t, typename lno_t, typename size_type, typename device>
 void run_test_extract_diagonal_blocks_rcb(lno_t n_pts_per_dim, lno_t nblocks) {
-  using RowMapType       = Kokkos::View<size_type *, device>;
-  using EntriesType      = Kokkos::View<lno_t *, device>;
-  using ValuesType       = Kokkos::View<scalar_t *, device>;
-  using magnitude_t      = typename KokkosKernels::ArithTraits<scalar_t>::mag_type;
-  using CoorsViewType    = Kokkos::View<magnitude_t **, device>;
-  using PermViewType     = Kokkos::View<lno_t *, device>;
-  using crsMat_t         = KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>;
+  using RowMapType    = Kokkos::View<size_type *, device>;
+  using EntriesType   = Kokkos::View<lno_t *, device>;
+  using ValuesType    = Kokkos::View<scalar_t *, device>;
+  using magnitude_t   = typename KokkosKernels::ArithTraits<scalar_t>::mag_type;
+  using CoorsViewType = Kokkos::View<magnitude_t **, device>;
+  using PermViewType  = Kokkos::View<lno_t *, device>;
+  using crsMat_t      = KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type>;
 
   crsMat_t A;
   std::vector<crsMat_t> DiagBlks(nblocks);
@@ -110,9 +110,11 @@ void run_test_extract_diagonal_blocks_rcb(lno_t n_pts_per_dim, lno_t nblocks) {
   PermViewType perm_rcb(Kokkos::view_alloc(Kokkos::WithoutInitializing, "perm_rcb"), n_coordinates);
   PermViewType reverse_perm_rcb(Kokkos::view_alloc(Kokkos::WithoutInitializing, "reverse_perm_rcb"), n_coordinates);
   lno_t n_levels = static_cast<lno_t>(std::log2(static_cast<double>(nblocks)) + 1);
-  std::vector<lno_t> partition_sizes = KokkosGraph::Experimental::recursive_coordinate_bisection(coordinates, perm_rcb, reverse_perm_rcb, n_levels);
+  std::vector<lno_t> partition_sizes =
+      KokkosGraph::Experimental::recursive_coordinate_bisection(coordinates, perm_rcb, reverse_perm_rcb, n_levels);
 
-  KokkosSparse::Impl::kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(A, perm_rcb, reverse_perm_rcb, partition_sizes, DiagBlks);
+  KokkosSparse::Impl::kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(A, perm_rcb, reverse_perm_rcb,
+                                                                               partition_sizes, DiagBlks);
 
   // Checking results
   lno_t numRows = 0;

--- a/sparse/unit_test/Test_Sparse_extractCrsDiagonalBlocksRCB.hpp
+++ b/sparse/unit_test/Test_Sparse_extractCrsDiagonalBlocksRCB.hpp
@@ -62,7 +62,7 @@ void run_test_extract_diagonal_blocks_rcb(lno_t n_pts_per_dim, lno_t nblocks) {
   lno_t n_coordinates = n_pts_per_dim * n_pts_per_dim * n_pts_per_dim;
   CoorsViewType coordinates(Kokkos::view_alloc(Kokkos::WithoutInitializing, "coordinates"), n_coordinates, 3);
   auto h_coordinates = Kokkos::create_mirror(coordinates);
-  magnitude_t dx = generate_3d_coordinates_for_sparse_rows(n_pts_per_dim, h_coordinates);
+  magnitude_t dx     = generate_3d_coordinates_for_sparse_rows(n_pts_per_dim, h_coordinates);
   Kokkos::deep_copy(coordinates, h_coordinates);
 
   // Generate test matrix consisting of near interactions calculated based on coordinates


### PR DESCRIPTION
This PR is to avoid calling the ```recursive_coordinate_bisection()``` in the diagonal blocks extraction function. Instead, the RCB ordering information is given as inputs. With this, the RCB ordering information can be computed once and re-used in successive extraction function calls.