### PR TITLE
Benchmark - Spmv: fixing a small bug in input parsing

### DIFF
--- a/benchmarks/sparse/KokkosSparse_spmv_benchmark.cpp
+++ b/benchmarks/sparse/KokkosSparse_spmv_benchmark.cpp
@@ -63,7 +63,7 @@ void parse_inputs(int argc, char** argv, spmv_parameters& params) {
   for (int i = 1; i < argc; ++i) {
     if (benchmark::check_arg_int(i, argc, argv, "-n", params.N)) {
       ++i;
-    } else if (benchmark::check_arg_str(i, argc, argv, "--mode", params.alg)) {
+    } else if (benchmark::check_arg_str(i, argc, argv, "--mode", params.mode)) {
       if ((params.mode != "") && (params.mode != "auto") && (params.mode != "manual")) {
         throw std::runtime_error("--mode can only be an empty string, `auto` or `manual`!");
       }

--- a/benchmarks/sparse/KokkosSparse_spmv_benchmark.cpp
+++ b/benchmarks/sparse/KokkosSparse_spmv_benchmark.cpp
@@ -64,7 +64,7 @@ void parse_inputs(int argc, char** argv, spmv_parameters& params) {
     if (benchmark::check_arg_int(i, argc, argv, "-n", params.N)) {
       ++i;
     } else if (benchmark::check_arg_str(i, argc, argv, "--mode", params.alg)) {
-      if ((params.mode != "") && (params.mode != "auto") && (params.alg != "manual")) {
+      if ((params.mode != "") && (params.mode != "auto") && (params.mode != "manual")) {
         throw std::runtime_error("--mode can only be an empty string, `auto` or `manual`!");
       }
       ++i;


### PR DESCRIPTION
Without the proper parsing for --mode=manual it is hard to do simple runs with matrix market files. This should remedy that problem.