### PR TITLE
AT2 - Kumquat: disabling the CI on V100

### DIFF
--- a/.github/workflows/at2.yml
+++ b/.github/workflows/at2.yml
@@ -26,11 +26,11 @@ jobs:
     uses: ./.github/workflows/h100_lychee.yml
     with:
       kokkos_version: 5.0.2
-  v100_kumquat:
-    uses: ./.github/workflows/v100_kumquat.yml
-    with:
-      kokkos_version: 5.0.2
-      kokkos_previous_version: 4.7.02
+  # v100_kumquat:
+  #   uses: ./.github/workflows/v100_kumquat.yml
+  #   with:
+  #     kokkos_version: 5.0.2
+  #     kokkos_previous_version: 4.7.02
   host:
     uses: ./.github/workflows/host.yml
     with:


### PR DESCRIPTION
Since we have maintenance on this machine for an undefinite amount of time we are disabling these checks for the time being.