### PR TITLE
Deprecate KOKKOSKERNELS_ENABLE_HOST_ONLY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [5.0.2](https://github.com/kokkos/kokkos-kernels/tree/5.0.2)
 [Full Changelog](https://github.com/kokkos/kokkos-kernels/compare/5.0.1...5.0.2)
 
+### Deprecations:
+- Deprecate unused `KOKKOSKERNELS_ENABLE_HOST_ONLY` macro
+
 ### Bug and Warning Fixes:
 - Cleanup warning and warning system [\#2861](https://github.com/kokkos/kokkos-kernels/pull/2861)
 - Batched - Vector: marking defaulted method properly [\#2908](https://github.com/kokkos/kokkos-kernels/pull/2908)

--- a/cmake/KokkosKernels_config.h.in
+++ b/cmake/KokkosKernels_config.h.in
@@ -159,6 +159,9 @@
 /* Whether MKL is providing the BLAS and LAPACK implementation */
 #cmakedefine MKL_PROVIDES_BLAS_LAPACK
 
+/* KOKKOSKERNELS_ENABLE_HOST_ONLY is deprecated and will be removed in a future
+ * release. There is no replacement.
+ */
 #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && \
     !defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ENABLE_OPENMPTARGET)
 #define KOKKOSKERNELS_ENABLE_HOST_ONLY

--- a/docs/source/deprecation_page.rst
+++ b/docs/source/deprecation_page.rst
@@ -6,3 +6,11 @@ Deprecations
   Deprecated in Kokkos Kernels 5.X
   ================================
 
+Deprecated in Kokkos Kernels 5.0.2
+===================================
+
+``KOKKOSKERNELS_ENABLE_HOST_ONLY``
+----------------------------------
+
+The ``KOKKOSKERNELS_ENABLE_HOST_ONLY`` macro (defined in ``KokkosKernels_config.h`` when no device backend is enabled) is deprecated with no replacement.
+It is not used in Kokkos Kernels or Trilinos and will be removed in a future release.


### PR DESCRIPTION
This thing is not used by us or Trilinos.