### PR TITLE
Remove #2489 from CHANGELOG.md in 4.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,6 @@
 ### New Features
 
 #### Batched updates
-- Implement batched serial gbtrf [\#2489](https://github.com/kokkos/kokkos-kernels/pull/2489)
 - Implement batched serial gbtrs [\#2539](https://github.com/kokkos/kokkos-kernels/pull/2539)
 
 ### Enhancements:


### PR DESCRIPTION
This #2489 is already found in 4.6 release.

https://github.com/kokkos/kokkos-kernels/blob/a27524567367d2b53ee4c35ebf1e4fde6659ef58/CHANGELOG.md?plain=1#L201-L214