### PR TITLE
swap: add missing include

### DIFF
--- a/blas/src/KokkosBlas1_swap.hpp
+++ b/blas/src/KokkosBlas1_swap.hpp
@@ -4,6 +4,7 @@
 #ifndef KOKKOSBLAS1_SWAP_HPP_
 #define KOKKOSBLAS1_SWAP_HPP_
 
+#include <KokkosKernels_helpers.hpp>
 #include <KokkosBlas1_swap_spec.hpp>
 
 namespace KokkosBlas {


### PR DESCRIPTION
We'd have to rejigger our entire unit test harness to catch this kind of thing.

Fixes https://github.com/kokkos/kokkos-kernels/issues/2983