### PR TITLE
Fix for illegal instruction error on AMD gfx1000+ in debug (-O0) builds

### DIFF
--- a/cmake/kokkos_backends.cmake
+++ b/cmake/kokkos_backends.cmake
@@ -16,3 +16,5 @@ check_kokkos_backend(OPENMPTARGET)
 check_kokkos_backend(CUDA)
 check_kokkos_backend(HIP)
 check_kokkos_backend(SYCL)
+
+include(cmake/kokkoskernels_backendFixes.cmake)

--- a/cmake/kokkoskernels_backendFixes.cmake
+++ b/cmake/kokkoskernels_backendFixes.cmake
@@ -1,0 +1,21 @@
+
+# On recent AMD GPUs (gfx1000+), the following error can occur 
+# for builds with optimisation level 0 (-O0, like debug builds):
+#   error: Illegal instruction detected: 
+#   Invalid dpp_ctrl value: wavefront shifts are not supported on GFX10+
+# The ROCm team is aware, but an upstream fix may be far off.
+# See https://github.com/ROCm/ROCm/issues/5826
+# The recommended workaround is to replace -O0 with -Og,
+# but since that can negatively affect debugging in some instances
+# (see, for example, https://stackoverflow.com/q/63386189),
+# we restrict this change specifically to the affected architectures.
+if(KOKKOS_ENABLE_HIP)
+	if(Kokkos_ARCH MATCHES "AMD_GFX([0-9]+).*")
+		# the issue affects "gfx10+" according to the error message
+		if(CMAKE_MATCH_1 GREATER 1000)
+			message(STATUS "Detected gfx10+ arch (${Kokkos_ARCH}).")
+			message(STATUS "Appending -Og -g to debug build flags (see https://github.com/ROCm/ROCm/issues/5826).")
+			set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Og -g")
+		endif()
+	endif()
+endif()


### PR DESCRIPTION
When trying a debug build on my RX 9070 XT, I got the output

```
error: Illegal instruction detected: 
Invalid dpp_ctrl value: wavefront shifts are not supported on GFX10+
```

which matches a known ROCm issue: https://github.com/ROCm/ROCm/issues/5826
The workaround proposed there is to change `-O0` to `-Og`, which is exactly what this PR does: For HIP builds with `Kokkos_ARCH=AMD_GFX1000` or higher, the CMAKE_CXX_FLAGS_DEBUG are appended with `-0g -g`.

I hope this workaround becomes obsolete soon, as this should really be fixed in ROCm, rather than in downstream code.