### PR TITLE
Update LICENSE file to Apache 2 w/llvm

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,15 +1,5 @@
- ************************************************************************
- 
-                        Kokkos v. 4.0
-       Copyright (2022) National Technology & Engineering
-               Solutions of Sandia, LLC (NTESS).
- 
- Under the terms of Contract DE-NA0003525 with NTESS,
- the U.S. Government retains certain rights in this software.
-
-
  ==============================================================================
- Kokkos is under the Apache License v2.0 with LLVM Exceptions:
+ Kokkos Kernels is under the Apache License v2.0 with LLVM Exceptions:
  ==============================================================================
 
                                  Apache License
@@ -231,8 +221,7 @@
  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
- Questions? Contact: 
-   Siva Rajamanickam (srajama@sandia.gov)
+ Questions? Contact:
    Luc Berger-Vergiat (lberge@sandia.gov)
 
  ************************************************************************


### PR DESCRIPTION
The files all have the right header, but `LICENSE` was still for Kokkos 4