### PR TITLE
Add spiluk example from docs to build

### DIFF
--- a/docs/source/API/sparse/spiluk_numeric.rst
+++ b/docs/source/API/sparse/spiluk_numeric.rst
@@ -83,6 +83,6 @@ Example
 
 .. literalinclude:: ../../../../example/sparse/KokkosSparse_example_spiluk.cpp
   :language: c++
-  :lines: 14-
+  :lines: 3-
 
 

--- a/docs/source/API/sparse/spiluk_numeric.rst
+++ b/docs/source/API/sparse/spiluk_numeric.rst
@@ -81,73 +81,8 @@ Two main requirements are that the types of the ``rowmap``, ``entries`` and ``va
 Example
 =======
 
-.. code:: c++
-
-  #include <Kokkos_Core.hpp>
-  #include <KokkosSparse_CrsMatrix.hpp>
-  #include <KokkosSparse_spiluk.hpp>
-  #include <KokkosKernels_IOUtils.hpp>
-
-  int main(int argc, char* argv[]) {
-    Kokkos::initialize();
-    {
-
-      using scalar_t  = double;
-      using lno_t     = int;
-      using size_type = int;
-      using crsMat_t  = typename KokkosSparse::CrsMatrix<scalar_t, lno_t, Kokkos::DefaultExecutionSpace, void, size_type>;
-
-      using graph_t         = typename crsmat_t::StaticCrsGraphType;
-      using lno_view_t      = typename graph_t::row_map_type::non_const_type;
-      using lno_nnz_view_t  = typename graph_t::entries_type::non_const_type;
-      using scalar_view_t   = typename crsmat_t::values_type::non_const_type;
-
-      using ViewVectorType  = Kokkos::View<scalar_t*>;
-      using execution_space = typename ViewVectorType::device_type::execution_space;
-      using memory_space    = typename ViewVectorType::device_type::memory_space;
-
-      using KernelHandle    = KokkosKernels::Experimental::KokkosKernelsHandle <size_type, lno_t, scalar_t, execution_space, memory_space, memory_space>;
-
-      // Read and fill matrix
-      crsmat_t A        = KokkosKernels::Impl::read_kokkos_crst_matrix<crsmat_t>("mtx filename");
-      graph_t  graph    = A.graph;
-      const size_type N = graph.numRows();
-      typename KernelHandle::const_nnz_lno_t fill_lev = lno_t(2) ;
-      const size_type nnzA = A.graph.entries.extent(0);
-
-      // Create KokkosKernelHandle with an spiluk algorithm, limited by configuration at compile-time and set via the handle
-      // Some options: {SEQLVLSCHD_RP, SEQLVLSCHD_TP1}
-      KernelHandle kh;
-
-      //kh.create_spiluk_handle(KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_RP, N, EXPAND_FACT*nnzA*(fill_lev+1), EXPAND_FACT*nnzA*(fill_lev+1));
-      kh.create_spiluk_handle(KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_TP1, N, EXPAND_FACT*nnzA*(fill_lev+1), EXPAND_FACT*nnzA*(fill_lev+1));
-
-      auto spiluk_handle = kh.get_spiluk_handle();
-
-      lno_view_t     L_row_map("L_row_map", N + 1);
-      lno_nnz_view_t L_entries("L_entries", spiluk_handle->get_nnzL());
-      scalar_view_t  L_values ("L_values",  spiluk_handle->get_nnzL());
-      lno_view_t     U_row_map("U_row_map", N + 1);
-      lno_nnz_view_t U_entries("U_entries", spiluk_handle->get_nnzU());
-      scalar_view_t  U_values ("U_values",  spiluk_handle->get_nnzU());
-
-      KokkosSparse::Experimental::spiluk_symbolic(&kh, fill_lev, A.graph.row_map, A.graph.entries, 
-                                                  L_row_map, L_entries, U_row_map, U_entries);
-
-      Kokkos::resize(L_entries, spiluk_handle->get_nnzL());
-      Kokkos::resize(L_values,  spiluk_handle->get_nnzL());
-      Kokkos::resize(U_entries, spiluk_handle->get_nnzU());
-      Kokkos::resize(U_values,  spiluk_handle->get_nnzU());
-
-      spiluk_handle->set_team_size(16);
-	  
-      KokkosSparse::Experimental::spiluk_numeric(&kh, fill_lev, 
-                                                 A.graph.row_map, A.graph.entries, A.values, 
-                                                 L_row_map, L_entries, L_values, U_row_map, U_entries, U_values );
-
-      kh.destroy_spiluk_handle();
-    }
-    Kokkos::finalize();
-  }
+.. literalinclude:: ../../../../example/sparse/KokkosSparse_example_spiluk.cpp
+  :language: c++
+  :lines: 14-
 
 

--- a/docs/source/API/sparse/spiluk_symbolic.rst
+++ b/docs/source/API/sparse/spiluk_symbolic.rst
@@ -72,73 +72,8 @@ Two main requirements are that the types of the ``rowmap`` and ``entries`` shoul
 Example
 =======
 
-.. code:: c++
-
-  #include <Kokkos_Core.hpp>
-  #include <KokkosSparse_CrsMatrix.hpp>
-  #include <KokkosSparse_spiluk.hpp>
-  #include <KokkosKernels_IOUtils.hpp>
-
-  int main(int argc, char* argv[]) {
-    Kokkos::initialize();
-    {
-
-      using scalar_t  = double;
-      using lno_t     = int;
-      using size_type = int;
-      using crsMat_t  = typename KokkosSparse::CrsMatrix<scalar_t, lno_t, Kokkos::DefaultExecutionSpace, void, size_type>;
-
-      using graph_t         = typename crsmat_t::StaticCrsGraphType;
-      using lno_view_t      = typename graph_t::row_map_type::non_const_type;
-      using lno_nnz_view_t  = typename graph_t::entries_type::non_const_type;
-      using scalar_view_t   = typename crsmat_t::values_type::non_const_type;
-
-      using ViewVectorType  = Kokkos::View<scalar_t*>;
-      using execution_space = typename ViewVectorType::device_type::execution_space;
-      using memory_space    = typename ViewVectorType::device_type::memory_space;
-
-      using KernelHandle    = KokkosKernels::Experimental::KokkosKernelsHandle <size_type, lno_t, scalar_t, execution_space, memory_space, memory_space>;
-
-      // Read and fill matrix
-      crsmat_t A        = KokkosKernels::Impl::read_kokkos_crst_matrix<crsmat_t>("mtx filename");
-      graph_t  graph    = A.graph;
-      const size_type N = graph.numRows();
-      typename KernelHandle::const_nnz_lno_t fill_lev = lno_t(2) ;
-      const size_type nnzA = A.graph.entries.extent(0);
-
-      // Create KokkosKernelHandle with an spiluk algorithm, limited by configuration at compile-time and set via the handle
-      // Some options: {SEQLVLSCHD_RP, SEQLVLSCHD_TP1}
-      KernelHandle kh;
-
-      //kh.create_spiluk_handle(KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_RP, N, EXPAND_FACT*nnzA*(fill_lev+1), EXPAND_FACT*nnzA*(fill_lev+1));
-      kh.create_spiluk_handle(KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_TP1, N, EXPAND_FACT*nnzA*(fill_lev+1), EXPAND_FACT*nnzA*(fill_lev+1));
-
-      auto spiluk_handle = kh.get_spiluk_handle();
-
-      lno_view_t     L_row_map("L_row_map", N + 1);
-      lno_nnz_view_t L_entries("L_entries", spiluk_handle->get_nnzL());
-      scalar_view_t  L_values ("L_values",  spiluk_handle->get_nnzL());
-      lno_view_t     U_row_map("U_row_map", N + 1);
-      lno_nnz_view_t U_entries("U_entries", spiluk_handle->get_nnzU());
-      scalar_view_t  U_values ("U_values",  spiluk_handle->get_nnzU());
-
-      KokkosSparse::Experimental::spiluk_symbolic(&kh, fill_lev, A.graph.row_map, A.graph.entries, 
-                                                  L_row_map, L_entries, U_row_map, U_entries);
-
-      Kokkos::resize(L_entries, spiluk_handle->get_nnzL());
-      Kokkos::resize(L_values,  spiluk_handle->get_nnzL());
-      Kokkos::resize(U_entries, spiluk_handle->get_nnzU());
-      Kokkos::resize(U_values,  spiluk_handle->get_nnzU());
-
-      spiluk_handle->set_team_size(16);
-	  
-      KokkosSparse::Experimental::spiluk_numeric(&kh, fill_lev, 
-                                                 A.graph.row_map, A.graph.entries, A.values, 
-                                                 L_row_map, L_entries, L_values, U_row_map, U_entries, U_values );
-
-      kh.destroy_spiluk_handle();
-    }
-    Kokkos::finalize();
-  }
+.. literalinclude:: ../../../../example/sparse/KokkosSparse_example_spiluk.cpp
+  :language: c++
+  :lines: 14-
 
 

--- a/docs/source/API/sparse/spiluk_symbolic.rst
+++ b/docs/source/API/sparse/spiluk_symbolic.rst
@@ -74,6 +74,6 @@ Example
 
 .. literalinclude:: ../../../../example/sparse/KokkosSparse_example_spiluk.cpp
   :language: c++
-  :lines: 14-
+  :lines: 3-
 
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -4,6 +4,7 @@ kokkoskernels_include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 kokkoskernels_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../test_common)
 
 #ADD_SUBDIRECTORY(graph)
+add_subdirectory(sparse)
 add_subdirectory(wiki)
 add_subdirectory(gmres)
 add_subdirectory(batched_solve)

--- a/example/sparse/CMakeLists.txt
+++ b/example/sparse/CMakeLists.txt
@@ -1,0 +1,4 @@
+kokkoskernels_include_directories(${CMAKE_CURRENT_BINARY_DIR})
+kokkoskernels_include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+
+kokkoskernels_add_executable_and_test(sparse_spiluk SOURCES KokkosSparse_example_spiluk.cpp)

--- a/example/sparse/KokkosSparse_example_spiluk.cpp
+++ b/example/sparse/KokkosSparse_example_spiluk.cpp
@@ -11,7 +11,7 @@
 #include "KokkosSparse_spmv.hpp"
 #include "KokkosBlas1_nrm2.hpp"
 
-int main() {
+int main(int argc, char *argv[]) {
   using Scalar  = KokkosKernels::default_scalar;
   using Ordinal = KokkosKernels::default_lno_t;
   using Offset  = KokkosKernels::default_size_type;
@@ -26,35 +26,63 @@ int main() {
   using Handle =
       KokkosKernels::Experimental::KokkosKernelsHandle<Offset, Ordinal, Scalar, ExecSpace, MemSpace, MemSpace>;
 
+  std::string filename;
+  Ordinal fillLevel = 2;
+
+  for (int i = 1; i < argc; ++i) {
+    const std::string token = argv[i];
+    if (token == "--filename" || token == "-f") {
+      filename = argv[++i];
+    } else if (token == "--fill-level" || token == "-l") {
+      fillLevel = std::atoi(argv[++i]);
+    } else if (token == "--help" || token == "-h") {
+      std::cout << "KokkosSparse spiluk example options:\n"
+                << "  --filename,   -f <file>  : Path to a MatrixMarket (.mtx) sparse matrix file\n"
+                << "                             (if omitted, a synthetic matrix is generated)\n"
+                << "  --fill-level, -l <level> : ILU(k) fill level (default: 2)\n"
+                << "  --help,       -h         : Print this message\n"
+                << "Example: ./KokkosSparse_example_spiluk -f mymatrix.mtx -l 3\n";
+      return 0;
+    }
+  }
+
   const Scalar zero = KokkosKernels::ArithTraits<Scalar>::zero();
   const Scalar one  = KokkosKernels::ArithTraits<Scalar>::one();
   int return_value  = 0;
 
   Kokkos::initialize();
   {
-    // Generate a diagonally dominant sparse matrix A to factorize.
-    // The matrix has 5000 rows and approximately 10 nonzeros per row.
-    const Ordinal numRows      = 5000;
-    Offset nnz                 = numRows * 10;
-    const Ordinal bandwidth    = static_cast<Ordinal>(0.05 * numRows);
-    const Scalar diagDominance = 2 * one;
-    Matrix A = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<Matrix>(numRows, numRows, nnz, 0,
-                                                                                         bandwidth, diagDominance);
+    Matrix A;
+    if (filename.empty()) {
+      const Ordinal numRows      = 5000;
+      Offset nnz                 = numRows * 10;
+      const Ordinal bandwidth    = static_cast<Ordinal>(0.05 * numRows);
+      const Scalar diagDominance = 2 * one;
+      std::cout << "No filename provided; generating a " << numRows << "x" << numRows
+                << " diagonally dominant sparse matrix.\n";
+      A = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<Matrix>(numRows, numRows, nnz, 0, bandwidth,
+                                                                                    diagDominance);
+    } else {
+      // Read the sparse matrix A from a MatrixMarket file.
+      std::cout << "Reading matrix from file: " << filename << "\n";
+      A = KokkosSparse::Impl::read_kokkos_crst_matrix<Matrix>(filename.c_str());
+    }
 
-    // spiluk requires the matrix entries to be sorted within each row.
+    // spiluk requires sorted column indices within each row.
     KokkosSparse::sort_crs_matrix(A);
 
-    // Level of fill controls how many additional nonzeros appear in L and U.
-    // Higher fill levels give a more accurate factorization at greater cost.
-    const Ordinal fillLevel = 2;
+    const Ordinal numRows = A.numRows();
 
-    // A conservative upper bound on the number of nonzeros in L and U.
-    // spiluk will resize these after the symbolic phase determines the exact count.
-    const Offset nnzLU = static_cast<Offset>(5) * nnz * (fillLevel + 1);
+    const Offset nnz = A.nnz();
+    std::cout << "Matrix: " << numRows << " x " << A.numCols() << ", nnz=" << nnz << "\n";
 
-    // Create the KokkosKernels handle and an spiluk sub-handle.
+    // Conservative upper bound for nnz in L and U.
+    constexpr Offset expand_fact = 5;
+    const Offset nnzLU           = expand_fact * nnz * (fillLevel + 1);
+
     // SEQLVLSCHD_TP1 uses a team-parallel level-scheduling algorithm.
     Handle kh;
+    // kh.create_spiluk_handle(KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_RP, numRows, nnzLU, nnzLU);
     kh.create_spiluk_handle(KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_TP1, numRows, nnzLU, nnzLU);
 
     // Allocate output row maps and initial entry arrays for L and U.
@@ -63,10 +91,7 @@ int main() {
     Entries L_entries("L_entries", kh.get_spiluk_handle()->get_nnzL());
     Entries U_entries("U_entries", kh.get_spiluk_handle()->get_nnzU());
 
-    // --- Symbolic phase ---
     // Determines the sparsity pattern (row maps and entries) of L and U.
-    // After this call, spiluk_handle->get_nnzL() and get_nnzU() hold
-    // the exact nonzero counts.
     KokkosSparse::spiluk_symbolic(&kh, fillLevel, A.graph.row_map, A.graph.entries, L_row_map, L_entries, U_row_map,
                                   U_entries);
 
@@ -78,7 +103,6 @@ int main() {
     Values L_values("L_values", kh.get_spiluk_handle()->get_nnzL());
     Values U_values("U_values", kh.get_spiluk_handle()->get_nnzU());
 
-    // --- Numeric phase ---
     // Computes the values of L and U given the sparsity pattern from symbolic.
     KokkosSparse::spiluk_numeric(&kh, fillLevel, A.graph.row_map, A.graph.entries, A.values, L_row_map, L_entries,
                                  L_values, U_row_map, U_entries, U_values);

--- a/example/sparse/KokkosSparse_example_spiluk.cpp
+++ b/example/sparse/KokkosSparse_example_spiluk.cpp
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+#include "Kokkos_Core.hpp"
+
+#include "KokkosKernels_default_types.hpp"
+#include "KokkosKernels_Handle.hpp"
+#include "KokkosSparse_CrsMatrix.hpp"
+#include "KokkosSparse_IOUtils.hpp"
+#include "KokkosSparse_SortCrs.hpp"
+#include "KokkosSparse_spiluk.hpp"
+#include "KokkosSparse_spmv.hpp"
+#include "KokkosBlas1_nrm2.hpp"
+
+int main() {
+  using Scalar  = KokkosKernels::default_scalar;
+  using Ordinal = KokkosKernels::default_lno_t;
+  using Offset  = KokkosKernels::default_size_type;
+
+  using ExecSpace = Kokkos::DefaultExecutionSpace;
+  using MemSpace  = typename ExecSpace::memory_space;
+  using Device    = Kokkos::Device<ExecSpace, MemSpace>;
+  using Matrix    = KokkosSparse::CrsMatrix<Scalar, Ordinal, Device, void, Offset>;
+  using RowMap    = typename Matrix::StaticCrsGraphType::row_map_type::non_const_type;
+  using Entries   = typename Matrix::StaticCrsGraphType::entries_type::non_const_type;
+  using Values    = typename Matrix::values_type::non_const_type;
+  using Handle =
+      KokkosKernels::Experimental::KokkosKernelsHandle<Offset, Ordinal, Scalar, ExecSpace, MemSpace, MemSpace>;
+
+  const Scalar zero = KokkosKernels::ArithTraits<Scalar>::zero();
+  const Scalar one  = KokkosKernels::ArithTraits<Scalar>::one();
+  int return_value  = 0;
+
+  Kokkos::initialize();
+  {
+    // Generate a diagonally dominant sparse matrix A to factorize.
+    // The matrix has 5000 rows and approximately 10 nonzeros per row.
+    const Ordinal numRows      = 5000;
+    Offset nnz                 = numRows * 10;
+    const Ordinal bandwidth    = static_cast<Ordinal>(0.05 * numRows);
+    const Scalar diagDominance = 2 * one;
+    Matrix A = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<Matrix>(numRows, numRows, nnz, 0,
+                                                                                         bandwidth, diagDominance);
+
+    // spiluk requires the matrix entries to be sorted within each row.
+    KokkosSparse::sort_crs_matrix(A);
+
+    // Level of fill controls how many additional nonzeros appear in L and U.
+    // Higher fill levels give a more accurate factorization at greater cost.
+    const Ordinal fillLevel = 2;
+
+    // A conservative upper bound on the number of nonzeros in L and U.
+    // spiluk will resize these after the symbolic phase determines the exact count.
+    const Offset nnzLU = static_cast<Offset>(5) * nnz * (fillLevel + 1);
+
+    // Create the KokkosKernels handle and an spiluk sub-handle.
+    // SEQLVLSCHD_TP1 uses a team-parallel level-scheduling algorithm.
+    Handle kh;
+    kh.create_spiluk_handle(KokkosSparse::Experimental::SPILUKAlgorithm::SEQLVLSCHD_TP1, numRows, nnzLU, nnzLU);
+
+    // Allocate output row maps and initial entry arrays for L and U.
+    RowMap L_row_map("L_row_map", numRows + 1);
+    RowMap U_row_map("U_row_map", numRows + 1);
+    Entries L_entries("L_entries", kh.get_spiluk_handle()->get_nnzL());
+    Entries U_entries("U_entries", kh.get_spiluk_handle()->get_nnzU());
+
+    // --- Symbolic phase ---
+    // Determines the sparsity pattern (row maps and entries) of L and U.
+    // After this call, spiluk_handle->get_nnzL() and get_nnzU() hold
+    // the exact nonzero counts.
+    KokkosSparse::spiluk_symbolic(&kh, fillLevel, A.graph.row_map, A.graph.entries, L_row_map, L_entries, U_row_map,
+                                  U_entries);
+
+    Kokkos::fence();
+
+    // Resize entry and value arrays to the exact sizes found by symbolic.
+    Kokkos::resize(L_entries, kh.get_spiluk_handle()->get_nnzL());
+    Kokkos::resize(U_entries, kh.get_spiluk_handle()->get_nnzU());
+    Values L_values("L_values", kh.get_spiluk_handle()->get_nnzL());
+    Values U_values("U_values", kh.get_spiluk_handle()->get_nnzU());
+
+    // --- Numeric phase ---
+    // Computes the values of L and U given the sparsity pattern from symbolic.
+    KokkosSparse::spiluk_numeric(&kh, fillLevel, A.graph.row_map, A.graph.entries, A.values, L_row_map, L_entries,
+                                 L_values, U_row_map, U_entries, U_values);
+
+    Kokkos::fence();
+
+    // Save nonzero counts before destroying the handle.
+    const Offset nnzL = kh.get_spiluk_handle()->get_nnzL();
+    const Offset nnzU = kh.get_spiluk_handle()->get_nnzU();
+
+    kh.destroy_spiluk_handle();
+
+    // Verify the factorization: compute ||L*U*e - A*e|| / ||A*e||
+    // where e is the all-ones vector.
+    const Matrix L("L", numRows, numRows, nnzL, L_values, L_row_map, L_entries);
+    const Matrix U("U", numRows, numRows, nnzU, U_values, U_row_map, U_entries);
+
+    Values e("e", numRows);
+    Values Ae("Ae", numRows);
+    Values Ue("Ue", numRows);
+    Kokkos::deep_copy(e, one);
+
+    // Ae = A*e
+    KokkosSparse::spmv("N", one, A, e, zero, Ae);
+    using mag_t   = typename KokkosKernels::ArithTraits<Scalar>::mag_type;
+    mag_t Ae_norm = KokkosBlas::nrm2(Ae);
+
+    // Ue = U*e, then Ae = L*(U*e) - A*e (residual)
+    KokkosSparse::spmv("N", one, U, e, zero, Ue);
+    KokkosSparse::spmv("N", one, L, Ue, -one, Ae);
+    mag_t res_norm = KokkosBlas::nrm2(Ae);
+    mag_t rel_res  = res_norm / Ae_norm;
+
+    std::cout << "spiluk (fill level=" << fillLevel << "): "
+              << "nnzL=" << nnzL << ", nnzU=" << nnzU << "\n";
+    std::cout << "  ||L*U*e - A*e|| / ||A*e|| = " << rel_res << "\n";
+
+    const bool success = rel_res < 1e-3;
+    if (success) {
+      std::cout << "  SUCCESS: factorization residual is within tolerance.\n";
+    } else {
+      std::cout << "  FAILURE: factorization residual exceeds tolerance.\n";
+    }
+
+    return_value = success ? 0 : 1;
+  }
+
+  Kokkos::finalize();
+  return return_value;
+}


### PR DESCRIPTION
The documented spiluk example had rotted a bit. This also modifies it a bit so it can run directly:

- Fix typo in type alias `crsMat_t` -> `crsmat_t`
- `EXPAND_FACT` used but never defined
- `L_values` and `U_values` allocated before spiluk_symbolic and then never resized
- `spiluk_symbolic` and `_numeric` no longer in `Experimental` 
- Check results the same way the unit test does: `||L*U*e - A*e|| / ||A*e||` should be small