### PR TITLE
[5.1.0] Cherry-pick #3000 Move diagonal blocks extraction functions into Experimental namespace

### DIFF
--- a/docs/source/API/sparse/extract_diagonal_blocks_rcb.rst
+++ b/docs/source/API/sparse/extract_diagonal_blocks_rcb.rst
@@ -1,5 +1,5 @@
-KokkosSparse::Impl::kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential
-############################################################################
+KokkosSparse::Experimental::kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential
+####################################################################################
 
 Defined in header: :code:`KokkosSparse_Utils.hpp`
 

--- a/docs/source/API/sparse/extract_diagonal_blocks_rcb_deprecated.rst
+++ b/docs/source/API/sparse/extract_diagonal_blocks_rcb_deprecated.rst
@@ -1,5 +1,5 @@
-KokkosSparse::Impl::kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential
-############################################################################
+KokkosSparse::Experimental::kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential
+####################################################################################
 
 Defined in header: :code:`KokkosSparse_Utils.hpp`
 

--- a/perf_test/sparse/KokkosSparse_gs.cpp
+++ b/perf_test/sparse/KokkosSparse_gs.cpp
@@ -189,7 +189,7 @@ void runGS(const GS_Parameters& params) {
          numericComputeTimeTotal = 0, applyLaunchTimeTotal = 0, applyComputeTimeTotal = 0;
 
   timer.reset();
-  KokkosSparse::Impl::kk_extract_diagonal_blocks_crsmatrix_sequential(A, DiagBlks);
+  KokkosSparse::Experimental::kk_extract_diagonal_blocks_crsmatrix_sequential(A, DiagBlks);
   Kokkos::fence();
   blockExtractionTime = timer.seconds();
 

--- a/sparse/src/KokkosSparse_Utils.hpp
+++ b/sparse/src/KokkosSparse_Utils.hpp
@@ -1902,6 +1902,10 @@ void kk_extract_subblock_crsmatrix_sequential(const entries_type &A_entries, con
   blk_row_map(blk_nrows) = blk_nnz;  // last element
 }
 
+}  // namespace Impl
+
+namespace Experimental {
+
 /**
  * @brief Extract the diagonal blocks out of a crs matrix.
  * This is a blocking function that runs on the host.
@@ -2011,7 +2015,7 @@ kk_extract_diagonal_blocks_crsmatrix_sequential(const crsMat_t &A, std::vector<c
         offset_view1d_type last(Kokkos::view_alloc(Kokkos::WithoutInitializing, "last"),
                                 blk_nrows);  // last position per row
 
-        kk_find_nnz_first_last_indices_subblock_crsmatrix_sequential(
+        KokkosSparse::Impl::kk_find_nnz_first_last_indices_subblock_crsmatrix_sequential(
             A_row_map_h, A_entries_h, blk_row_start, blk_col_start, blk_nrows, blk_ncols, blk_nnz, first, last);
 
         // Second round: extract
@@ -2023,8 +2027,8 @@ kk_extract_diagonal_blocks_crsmatrix_sequential(const crsMat_t &A, std::vector<c
         out_entries_hostmirror_type entries_h(Kokkos::view_alloc(Kokkos::WithoutInitializing, "entries_h"), blk_nnz);
         out_values_hostmirror_type values_h(Kokkos::view_alloc(Kokkos::WithoutInitializing, "values_h"), blk_nnz);
 
-        kk_extract_subblock_crsmatrix_sequential(A_entries_h, A_values_h, blk_col_start, blk_nrows, blk_nnz, first,
-                                                 last, row_map_h, entries_h, values_h);
+        KokkosSparse::Impl::kk_extract_subblock_crsmatrix_sequential(
+            A_entries_h, A_values_h, blk_col_start, blk_nrows, blk_nnz, first, last, row_map_h, entries_h, values_h);
 
         if (!UseRCMReordering) {
           Kokkos::deep_copy(row_map, row_map_h);
@@ -2423,7 +2427,7 @@ void kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(
   }      // n_blocks > 1
 }
 
-}  // namespace Impl
+}  // namespace Experimental
 
 using Impl::isCrsGraphSorted;
 using Impl::removeCrsMatrixZeros;

--- a/sparse/unit_test/Test_Sparse_extractCrsDiagonalBlocks.hpp
+++ b/sparse/unit_test/Test_Sparse_extractCrsDiagonalBlocks.hpp
@@ -70,9 +70,9 @@ void run_test_extract_diagonal_blocks(int nrows, int nblocks) {
   }
 
   // Extract
-  KokkosSparse::Impl::kk_extract_diagonal_blocks_crsmatrix_sequential(A, DiagBlks);
+  KokkosSparse::Experimental::kk_extract_diagonal_blocks_crsmatrix_sequential(A, DiagBlks);
 
-  auto perm = KokkosSparse::Impl::kk_extract_diagonal_blocks_crsmatrix_sequential(A, DiagBlks_rcm, true);
+  auto perm = KokkosSparse::Experimental::kk_extract_diagonal_blocks_crsmatrix_sequential(A, DiagBlks_rcm, true);
 
   // Checking
   lno_t numRows = 0;

--- a/sparse/unit_test/Test_Sparse_extractCrsDiagonalBlocksRCB.hpp
+++ b/sparse/unit_test/Test_Sparse_extractCrsDiagonalBlocksRCB.hpp
@@ -111,7 +111,8 @@ void run_test_extract_diagonal_blocks_rcb_deprecated(lno_t n_pts_per_dim, lno_t 
 
   // Extract diagonal blocks
   PermViewType perm_rcb(Kokkos::view_alloc(Kokkos::WithoutInitializing, "perm_rcb"), n_coordinates);
-  KokkosSparse::Impl::kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(A, coordinates, DiagBlks, perm_rcb);
+  KokkosSparse::Experimental::kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(A, coordinates, DiagBlks,
+                                                                                       perm_rcb);
 
   // Checking results
   lno_t numRows = 0;
@@ -237,8 +238,8 @@ void run_test_extract_diagonal_blocks_rcb(lno_t n_pts_per_dim, lno_t nblocks) {
   std::vector<lno_t> partition_sizes =
       KokkosGraph::Experimental::recursive_coordinate_bisection(coordinates, perm_rcb, reverse_perm_rcb, n_levels);
 
-  KokkosSparse::Impl::kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(A, perm_rcb, reverse_perm_rcb,
-                                                                               partition_sizes, DiagBlks);
+  KokkosSparse::Experimental::kk_extract_diagonal_blocks_crsmatrix_with_rcb_sequential(A, perm_rcb, reverse_perm_rcb,
+                                                                                       partition_sizes, DiagBlks);
 
   // Checking results
   lno_t numRows = 0;


### PR DESCRIPTION
Cherry-pick #3000

* Move diagonal blocks extraction functions to Experimental namespace



* Apply clang format



* Update docs



* Change Impl to Experimental namespace



---------