### PR TITLE
[5.1.0] Cherry-pick #2996 Common - ExecUtils: fix pre-processor warning

### DIFF
--- a/common/src/KokkosKernels_ExecSpaceUtils.hpp
+++ b/common/src/KokkosKernels_ExecSpaceUtils.hpp
@@ -91,7 +91,7 @@ constexpr KOKKOS_INLINE_FUNCTION bool kk_is_x86_64_mem_space() {
   return false;
 }
 
-#if __x86_64__
+#if defined(__x86_64__)
 template <>
 constexpr KOKKOS_INLINE_FUNCTION bool kk_is_x86_64_mem_space<Kokkos::HostSpace>() {
   return true;


### PR DESCRIPTION
We have a direct call to #if __x86_64__ which really should be