### PR TITLE
LAPACK SVD test 

### DIFF
--- a/lapack/unit_test/Test_Lapack_svd.hpp
+++ b/lapack/unit_test/Test_Lapack_svd.hpp
@@ -42,10 +42,12 @@ void check_triple_product(const AMatrix& A, const SVector& S, const UMatrix& U, 
   Kokkos::deep_copy(M_h, M);
   for (int rowIdx = 0; rowIdx < A.extent_int(0); ++rowIdx) {
     for (int colIdx = 0; colIdx < A.extent_int(1); ++colIdx) {
-      if (tol < Kokkos::abs(A_h(rowIdx, colIdx))) {
-        EXPECT_NEAR_KK_REL(A_h(rowIdx, colIdx), M_h(rowIdx, colIdx), tol);
+      if (1000 * tol < Kokkos::abs(A_h(rowIdx, colIdx))) {
+        EXPECT_NEAR_KK_REL(A_h(rowIdx, colIdx), M_h(rowIdx, colIdx), tol,
+                           "Value in SVD triple product did not match original matrix");
       } else {
-        EXPECT_NEAR_KK(A_h(rowIdx, colIdx), M_h(rowIdx, colIdx), tol);
+        EXPECT_NEAR_KK(A_h(rowIdx, colIdx), M_h(rowIdx, colIdx), tol,
+                       "Value in SVD triple product did not match original matrix");
       }
     }
   }
@@ -66,9 +68,11 @@ void check_unitary_orthogonal_matrix(
   for (int rowIdx = 0; rowIdx < M.extent_int(0); ++rowIdx) {
     for (int colIdx = 0; colIdx < M.extent_int(0); ++colIdx) {
       if (rowIdx == colIdx) {
-        EXPECT_NEAR_KK_REL(I0_h(rowIdx, colIdx), KokkosKernels::ArithTraits<scalar_type>::one(), tol);
+        EXPECT_NEAR_KK_REL(I0_h(rowIdx, colIdx), KokkosKernels::ArithTraits<scalar_type>::one(), tol,
+                           "Matrix of left or right singular vectors is not unitary; diagonal of MM^H is not 1");
       } else {
-        EXPECT_NEAR_KK(I0_h(rowIdx, colIdx), KokkosKernels::ArithTraits<scalar_type>::zero(), tol);
+        EXPECT_NEAR_KK(I0_h(rowIdx, colIdx), KokkosKernels::ArithTraits<scalar_type>::zero(), tol,
+                       "Matrix of left or right singular vectors is not unitary; off-diagonal of MM^H is not 0");
       }
     }
   }
@@ -80,9 +84,11 @@ void check_unitary_orthogonal_matrix(
   for (int rowIdx = 0; rowIdx < M.extent_int(1); ++rowIdx) {
     for (int colIdx = 0; colIdx < M.extent_int(1); ++colIdx) {
       if (rowIdx == colIdx) {
-        EXPECT_NEAR_KK_REL(I1_h(rowIdx, colIdx), KokkosKernels::ArithTraits<scalar_type>::one(), tol);
+        EXPECT_NEAR_KK_REL(I1_h(rowIdx, colIdx), KokkosKernels::ArithTraits<scalar_type>::one(), tol,
+                           "Matrix of left or right singular vectors is not unitary; diagonal of M^HM is not 1");
       } else {
-        EXPECT_NEAR_KK(I1_h(rowIdx, colIdx), KokkosKernels::ArithTraits<scalar_type>::zero(), tol);
+        EXPECT_NEAR_KK(I1_h(rowIdx, colIdx), KokkosKernels::ArithTraits<scalar_type>::zero(), tol,
+                       "Matrix of left or right singular vectors is not unitary; off-diagonal of M^HM is not 0");
       }
     }
   }


### PR DESCRIPTION
SVD tests: expand the interval around 0 where we switch to an absolute tolerance, instead of relative tolerance, for checking that the triple product U*S*V^t equals the original matrix. Values close to 0 in this product can be the result of summing larger magnitude values that happen to cancel out, so they are less accurate according to relative tolerance.

With my system's host LAPACK, I replicated a failure like #2966 after about ~1000 repetitions of the test. After this change, I ran for ~200k repetitions and it didn't fail, so this should be a reasonable fix.