### PR TITLE
Graph - Coarsening: check for max vector size

### DIFF
--- a/graph/impl/KokkosGraph_ExplicitCoarsening_impl.hpp
+++ b/graph/impl/KokkosGraph_ExplicitCoarsening_impl.hpp
@@ -223,6 +223,7 @@ struct ExplicitGraphCoarsening {
     // distinct clusters
     int vectorSize = KokkosKernels::Impl::kk_get_suggested_vector_size(
         numFineVerts, fineEntries.extent(0), KokkosKernels::Impl::kk_get_exec_space_type<exec_space>());
+    vectorSize = (vectorSize < team_pol::vector_length_max() ? vectorSize : team_pol::vector_length_max());
     bitset_t crossClusterEdgeMask(fineEntries.extent(0));
     size_type numClusterEdges;
     {


### PR DESCRIPTION
check that vector size is lower than vector_length_max when constructing the team_policy. Somewhat surprising that this was not revealed earlier during testing?