### PR TITLE
Remove KOKKOS_ENABLE_CUDA_LAMBDA checks

### DIFF
--- a/blas/unit_test/Test_Blas1_team_abs.hpp
+++ b/blas/unit_test/Test_Blas1_team_abs.hpp
@@ -1,10 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
-// Note: Luc Berger-Vergiat 04/14/21
-//       This tests uses KOKKOS_LAMBDA so we need
-//       to make sure that these are enabled in
-//       the CUDA backend before including this test.
-#if !defined(TEST_CUDA_BLAS_CPP) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
@@ -274,5 +269,3 @@ TEST_F( TestCategory, team_abs_double_mv_int ) {
     test_team_abs_mv<double,int,TestDevice> ();
 }
 #endif*/
-
-#endif  // Check for lambda availability in CUDA backend

--- a/blas/unit_test/Test_Blas1_team_axpby.hpp
+++ b/blas/unit_test/Test_Blas1_team_axpby.hpp
@@ -1,10 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
-// Note: Luc Berger-Vergiat 04/14/21
-//       This tests uses KOKKOS_LAMBDA so we need
-//       to make sure that these are enabled in
-//       the CUDA backend before including this test.
-#if !defined(TEST_CUDA_BLAS_CPP) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
@@ -273,5 +268,3 @@ TEST_F(TestCategory, team_axpby_mv_int) { test_team_axpby_mv<int, int, TestDevic
 TEST_F(TestCategory, team_axpby_double_int) { test_team_axpby<double, int, TestDevice>(); }
 TEST_F(TestCategory, team_axpby_double_mv_int) { test_team_axpby_mv<double, int, TestDevice>(); }
 #endif
-
-#endif  // check for lambda availability in CUDA backend

--- a/blas/unit_test/Test_Blas1_team_axpy.hpp
+++ b/blas/unit_test/Test_Blas1_team_axpy.hpp
@@ -1,10 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
-// Note: Luc Berger-Vergiat 04/14/21
-//       This tests uses KOKKOS_LAMBDA so we need
-//       to make sure that these are enabled in
-//       the CUDA backend before including this test.
-#if !defined(TEST_CUDA_BLAS_CPP) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
@@ -266,5 +261,3 @@ TEST_F(TestCategory, team_axpy_mv_int) { test_team_axpy_mv<int, int, TestDevice>
 TEST_F(TestCategory, team_axpy_double_int) { test_team_axpy<double, int, TestDevice>(); }
 TEST_F(TestCategory, team_axpy_double_mv_int) { test_team_axpy_mv<double, int, TestDevice>(); }
 #endif
-
-#endif  // Check for lambda availability in CUDA backend

--- a/blas/unit_test/Test_Blas1_team_dot.hpp
+++ b/blas/unit_test/Test_Blas1_team_dot.hpp
@@ -1,10 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
-// Note: Luc Berger-Vergiat 04/14/21
-//       This tests uses KOKKOS_LAMBDA so we need
-//       to make sure that these are enabled in
-//       the CUDA backend before including this test.
-#if !defined(TEST_CUDA_BLAS_CPP) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
@@ -324,5 +319,3 @@ TEST_F( TestCategory, team_dot_mv_double_int ) {
     test_team_dot_mv<double,int,TestDevice> ();
 }
 #endif*/
-
-#endif  // Check for lambda availability in CUDA backend

--- a/blas/unit_test/Test_Blas1_team_mult.hpp
+++ b/blas/unit_test/Test_Blas1_team_mult.hpp
@@ -1,10 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
-// Note: Luc Berger-Vergiat 04/14/21
-//       This tests uses KOKKOS_LAMBDA so we need
-//       to make sure that these are enabled in
-//       the CUDA backend before including this test.
-#if !defined(TEST_CUDA_BLAS_CPP) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
@@ -314,5 +309,3 @@ TEST_F(TestCategory, team_mult_mv_int) { test_team_mult_mv<int, int, int, TestDe
 TEST_F(TestCategory, team_mult_double_int) { test_team_mult<double, int, float, TestDevice>(); }
 TEST_F(TestCategory, team_mult_double_mv_int) { test_team_mult_mv<double, int, float, TestDevice>(); }
 #endif
-
-#endif  // Check for lambda availability in CUDA backend

--- a/blas/unit_test/Test_Blas1_team_nrm2.hpp
+++ b/blas/unit_test/Test_Blas1_team_nrm2.hpp
@@ -1,10 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
-// Note: Luc Berger-Vergiat 04/14/21
-//       This tests uses KOKKOS_LAMBDA so we need
-//       to make sure that these are enabled in
-//       the CUDA backend before including this test.
-#if !defined(TEST_CUDA_BLAS_CPP) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
@@ -124,5 +119,3 @@ TEST_F(TestCategory, team_nrm2_complex_double) { test_team_nrm2<Kokkos::complex<
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F(TestCategory, team_nrm2_int) { test_team_nrm2<int, TestDevice>(); }
 #endif
-
-#endif  // Check for lambda availability in CUDA backend

--- a/blas/unit_test/Test_Blas1_team_scal.hpp
+++ b/blas/unit_test/Test_Blas1_team_scal.hpp
@@ -1,10 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
-// Note: Luc Berger-Vergiat 04/14/21
-//       This tests uses KOKKOS_LAMBDA so we need
-//       to make sure that these are enabled in
-//       the CUDA backend before including this test.
-#if !defined(TEST_CUDA_BLAS_CPP) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
@@ -328,5 +323,3 @@ TEST_F(TestCategory, team_scal_mv_int) { test_team_scal_mv<int, int, TestDevice>
 TEST_F(TestCategory, team_scal_double_int) { test_team_scal<double, int, TestDevice>(); }
 TEST_F(TestCategory, team_scal_double_mv_int) { test_team_scal_mv<double, int, TestDevice>(); }
 #endif
-
-#endif  // Check for lambda availability in CUDA backend

--- a/blas/unit_test/Test_Blas1_team_update.hpp
+++ b/blas/unit_test/Test_Blas1_team_update.hpp
@@ -1,10 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
-// Note: Luc Berger-Vergiat 04/14/21
-//       This tests uses KOKKOS_LAMBDA so we need
-//       to make sure that these are enabled in
-//       the CUDA backend before including this test.
-#if !defined(TEST_CUDA_BLAS_CPP) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
@@ -314,5 +309,3 @@ TEST_F(TestCategory, team_update_mv_int) { test_team_update_mv<int, int, int, Te
 TEST_F(TestCategory, team_update_double_int) { test_team_update<double, int, float, TestDevice>(); }
 TEST_F(TestCategory, team_update_double_mv_int) { test_team_update_mv<double, int, float, TestDevice>(); }
 #endif
-
-#endif  // Check for lambda availability in CUDA backend

--- a/blas/unit_test/Test_Blas2_team_gemv.hpp
+++ b/blas/unit_test/Test_Blas2_team_gemv.hpp
@@ -1,10 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
-// Note: Luc Berger-Vergiat 04/14/21
-//       This tests uses KOKKOS_LAMBDA so we need
-//       to make sure that these are enabled in
-//       the CUDA backend before including this test.
-#if !defined(TEST_CUDA_BLAS_CPP) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 
 #include <KokkosBlas_util.hpp>
 #include <KokkosKernels_TestUtils.hpp>  // for test/inst guards
@@ -72,5 +67,3 @@ TEST_TEAM_CASE2(alphabeta, Kokkos::complex<double>, double)
 #undef TEST_TEAM_CASE4
 #undef TEST_TEAM_CASE2
 #undef TEST_TEAM_CASE
-
-#endif  // Check for lambda availability on CUDA backend

--- a/blas/unit_test/Test_Blas2_teamvector_gemv.hpp
+++ b/blas/unit_test/Test_Blas2_teamvector_gemv.hpp
@@ -1,10 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
-// Note: Luc Berger-Vergiat 04/14/21
-//       This tests uses KOKKOS_LAMBDA so we need
-//       to make sure that these are enabled in
-//       the CUDA backend before including this test.
-#if !defined(TEST_CUDA_BLAS_CPP) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 
 #include <KokkosBlas_util.hpp>
 #include <KokkosKernels_TestUtils.hpp>  // for test/inst guards
@@ -73,5 +68,3 @@ TEST_TEAMVECTOR_CASE2(alphabeta, Kokkos::complex<double>, double)
 #undef TEST_TEAMVECTOR_CASE4
 #undef TEST_TEAMVECTOR_CASE2
 #undef TEST_TEAMVECTOR_CASE
-
-#endif  // Check for lambda availability on CUDA backend

--- a/graph/src/KokkosGraph_CoarsenConstruct.hpp
+++ b/graph/src/KokkosGraph_CoarsenConstruct.hpp
@@ -2,8 +2,6 @@
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #pragma once
-// exclude from Cuda builds without lambdas enabled
-#if !defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 #include <list>
 #include <limits>
 #include <Kokkos_Core.hpp>
@@ -1712,5 +1710,3 @@ class coarse_builder {
 
 }  // end namespace Experimental
 }  // end namespace KokkosGraph
-// exclude from Cuda builds without lambdas enabled
-#endif

--- a/graph/src/KokkosGraph_CoarsenHeuristics.hpp
+++ b/graph/src/KokkosGraph_CoarsenHeuristics.hpp
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 #pragma once
-// exclude from Cuda builds without lambdas enabled
-#if !defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 #include <limits>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Random.hpp>
@@ -1123,5 +1121,3 @@ class coarsen_heuristics {
 
 }  // end namespace Experimental
 }  // end namespace KokkosGraph
-// exclude from Cuda builds without lambdas enabled
-#endif

--- a/graph/unit_test/Test_Graph.hpp
+++ b/graph/unit_test/Test_Graph.hpp
@@ -7,9 +7,7 @@
 #include "Test_Graph_graph_color_distance2.hpp"
 #include "Test_Graph_graph_color.hpp"
 #include "Test_Graph_mis2.hpp"
-#if !defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_LAMBDA)
 #include "Test_Graph_coarsen.hpp"
-#endif
 #include "Test_Graph_rcm.hpp"
 #include "Test_Graph_rcb.hpp"
 


### PR DESCRIPTION
Kokkos always enables cuda lambda when the CUDA backend is enabled so we do not need to check for it anymore.
This was used in batched tests and graph coarsening.