### PR TITLE
Improve matrix market and batched sparse file readers to handle bad I/O

### DIFF
--- a/perf_test/batched/sparse/KokkosBatched_Test_Sparse_Helper.hpp
+++ b/perf_test/batched/sparse/KokkosBatched_Test_Sparse_Helper.hpp
@@ -1,6 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <vector>
+
 template <class XType>
 void writeArrayToMM(std::string name, const XType x) {
   std::ofstream myfile;
@@ -25,17 +34,30 @@ void writeArrayToMM(std::string name, const XType x) {
 
 void readSizesFromMM(std::string name, int &nrows, int &ncols, int &nnz, int &N) {
   std::ifstream input(name);
+  if (!input.is_open()) {
+    std::cerr << "readSizesFromMM: could not open \"" << name << "\"\n";
+    std::exit(EXIT_FAILURE);
+  }
+
   while (input.peek() == '%') input.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
   std::string line_sizes;
-
-  getline(input, line_sizes);
+  if (!std::getline(input, line_sizes)) {
+    std::cerr << "readSizesFromMM: could not read dimensions line from \"" << name << "\"\n";
+    std::exit(EXIT_FAILURE);
+  }
 
   std::stringstream iss(line_sizes);
 
   int number;
   std::vector<int> sizes;
   while (iss >> number) sizes.push_back(number);
+
+  if (sizes.size() < 2u) {
+    std::cerr << "readSizesFromMM: expected at least 2 integers on the first data line of \"" << name
+              << "\" (after Matrix Market comments), found " << sizes.size() << "\n";
+    std::exit(EXIT_FAILURE);
+  }
 
   nrows = sizes[0];
   ncols = sizes[1];
@@ -51,14 +73,28 @@ void readSizesFromMM(std::string name, int &nrows, int &ncols, int &nnz, int &N)
 template <class XType>
 void readArrayFromMM(std::string name, const XType &x) {
   std::ifstream input(name);
+  if (!input.is_open()) {
+    std::cerr << "readArrayFromMM: could not open \"" << name << "\"\n";
+    std::exit(EXIT_FAILURE);
+  }
 
   while (input.peek() == '%') input.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
   input.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+  if (input.fail()) {
+    std::cerr << "readArrayFromMM: failed skipping header in \"" << name << "\"\n";
+    std::exit(EXIT_FAILURE);
+  }
 
   typename XType::host_mirror_type x_h = Kokkos::create_mirror_view(x);
 
-  for (size_t i = 0; i < x_h.extent(0); ++i)
-    for (size_t j = 0; j < x_h.extent(1); ++j) input >> x_h(i, j);
+  for (size_t i = 0; i < x_h.extent(0); ++i) {
+    for (size_t j = 0; j < x_h.extent(1); ++j) {
+      if (!(input >> x_h(i, j))) {
+        std::cerr << "readArrayFromMM: failed reading entry (" << i << "," << j << ") from \"" << name << "\"\n";
+        std::exit(EXIT_FAILURE);
+      }
+    }
+  }
 
   input.close();
 
@@ -68,9 +104,17 @@ void readArrayFromMM(std::string name, const XType &x) {
 template <class AType>
 void readDenseFromMM(std::string name, const AType &A) {
   std::ifstream input(name);
+  if (!input.is_open()) {
+    std::cerr << "readDenseFromMM: could not open \"" << name << "\"\n";
+    std::exit(EXIT_FAILURE);
+  }
 
   while (input.peek() == '%') input.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
   input.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+  if (input.fail()) {
+    std::cerr << "readDenseFromMM: failed skipping header in \"" << name << "\"\n";
+    std::exit(EXIT_FAILURE);
+  }
 
   typename AType::host_mirror_type A_h = Kokkos::create_mirror_view(A);
 
@@ -83,11 +127,20 @@ void readDenseFromMM(std::string name, const AType &A) {
   readSizesFromMM(name, Blk, nrows, nnz, N);
 
   for (int i = 0; i < nnz; ++i) {
-    input >> read_row >> read_col;
+    if (!(input >> read_row >> read_col)) {
+      std::cerr << "readDenseFromMM: failed reading row/column indices for entry " << i << " from \"" << name << "\"\n";
+      std::exit(EXIT_FAILURE);
+    }
     --read_row;
     --read_col;
 
-    for (int j = 0; j < N; ++j) input >> A_h(j, read_row, read_col);
+    for (int j = 0; j < N; ++j) {
+      if (!(input >> A_h(j, read_row, read_col))) {
+        std::cerr << "readDenseFromMM: failed reading values for entry " << i << ", batch index " << j << " from \""
+                  << name << "\"\n";
+        std::exit(EXIT_FAILURE);
+      }
+    }
   }
 
   input.close();
@@ -98,9 +151,17 @@ void readDenseFromMM(std::string name, const AType &A) {
 template <class VType, class IntType>
 void readCRSFromMM(std::string name, const VType &V, const IntType &r, const IntType &c) {
   std::ifstream input(name);
+  if (!input.is_open()) {
+    std::cerr << "readCRSFromMM: could not open \"" << name << "\"\n";
+    std::exit(EXIT_FAILURE);
+  }
 
   while (input.peek() == '%') input.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
   input.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+  if (input.fail()) {
+    std::cerr << "readCRSFromMM: failed skipping header in \"" << name << "\"\n";
+    std::exit(EXIT_FAILURE);
+  }
 
   typename VType::host_mirror_type V_h   = Kokkos::create_mirror_view(V);
   typename IntType::host_mirror_type r_h = Kokkos::create_mirror_view(r);
@@ -115,7 +176,10 @@ void readCRSFromMM(std::string name, const VType &V, const IntType &r, const Int
   r_h(0) = 0;
 
   for (size_t i = 0; i < nnz; ++i) {
-    input >> read_row >> c_h(i);
+    if (!(input >> read_row >> c_h(i))) {
+      std::cerr << "readCRSFromMM: failed reading row/column for NZ " << i << " from \"" << name << "\"\n";
+      std::exit(EXIT_FAILURE);
+    }
     --read_row;
     --c_h(i);
     for (int tmp_row = current_row + 1; tmp_row <= read_row; ++tmp_row) r_h(tmp_row) = i;
@@ -123,8 +187,15 @@ void readCRSFromMM(std::string name, const VType &V, const IntType &r, const Int
 
     // if (VType::rank == 1)
     //  input >> V_h(i);
-    if (VType::rank == 2)
-      for (size_t j = 0; j < V_h.extent(0); ++j) input >> V_h(j, i);
+    if (VType::rank == 2) {
+      for (size_t j = 0; j < V_h.extent(0); ++j) {
+        if (!(input >> V_h(j, i))) {
+          std::cerr << "readCRSFromMM: failed reading value (batch " << j << ", NZ " << i << ") from \"" << name
+                    << "\"\n";
+          std::exit(EXIT_FAILURE);
+        }
+      }
+    }
   }
 
   r_h(nrows) = nnz;

--- a/perf_test/sparse/spmv/matrix_market.hpp
+++ b/perf_test/sparse/spmv/matrix_market.hpp
@@ -5,6 +5,7 @@
 #define MATRIX_MARKET_HPP_
 
 #include <cstdio>
+#include <cstddef>
 #include <cstring>
 #include <cstdlib>
 #include <limits>
@@ -48,6 +49,10 @@ int SparseMatrix_MatrixMarket_read(const char* filename, OrdinalType& nrows, Ord
                                    ScalarType*& values, OrdinalType*& rowPtr, OrdinalType*& colInd, bool sort,
                                    OrdinalType idx_offset = 0) {
   FILE* file = fopen(filename, "r");
+  if (!file) {
+    fprintf(stderr, "SparseMatrix_MatrixMarket_read: could not open \"%s\"\n", filename);
+    return -1;
+  }
   char line[512];
   line[0]         = '%';
   int count       = -1;
@@ -56,7 +61,12 @@ int SparseMatrix_MatrixMarket_read(const char* filename, OrdinalType& nrows, Ord
   int nlines;
 
   while (line[0] == '%') {
-    fgets(line, 511, file);
+    if (!fgets(line, 511, file)) {
+      fprintf(stderr, "SparseMatrix_MatrixMarket_read: unexpected EOF in header of \"%s\"\n", filename);
+      fclose(file);
+      return -1;
+    }
+    line[511] = '\0';
     count++;
     if (count == 0) {
       symmetric = strstr(line, "symmetric");
@@ -64,10 +74,23 @@ int SparseMatrix_MatrixMarket_read(const char* filename, OrdinalType& nrows, Ord
     }
   }
   rewind(file);
-  for (int i = 0; i < count; i++) fgets(line, 511, file);
-  fscanf(file, "%i", &nrows);
-  fscanf(file, "%i", &ncols);
-  fscanf(file, "%i", &nlines);
+  for (int i = 0; i < count; i++) {
+    if (!fgets(line, 511, file)) {
+      fprintf(stderr, "SparseMatrix_MatrixMarket_read: unexpected EOF rewinding \"%s\"\n", filename);
+      fclose(file);
+      return -1;
+    }
+  }
+  if (fscanf(file, "%i", &nrows) != 1 || fscanf(file, "%i", &ncols) != 1 || fscanf(file, "%i", &nlines) != 1) {
+    fprintf(stderr, "SparseMatrix_MatrixMarket_read: invalid dimension line in \"%s\"\n", filename);
+    fclose(file);
+    return -1;
+  }
+  if (nrows <= 0 || ncols <= 0 || nlines < 0) {
+    fprintf(stderr, "SparseMatrix_MatrixMarket_read: non-positive dimensions in \"%s\"\n", filename);
+    fclose(file);
+    return -1;
+  }
   printf("Matrix dimension: %i %i %i %s %s\n", nrows, ncols, nlines, symmetric ? "Symmetric" : "General",
          pattern ? "Pattern" : "Real");
 
@@ -152,6 +175,7 @@ int SparseMatrix_MatrixMarket_read(const char* filename, OrdinalType& nrows, Ord
 
   printf("%lu Spans: %lu %lu %lu\n", (size_t)nnz, min_span, max_span, ave_span / nrows);
   if (sort) Impl::SparseGraph_SortRows<OrdinalType>(nrows, rowPtr, colInd);
+  fclose(file);
   return nnz;
 }
 
@@ -161,6 +185,7 @@ int SparseMatrix_WriteBinaryFormat(const char* filename, OrdinalType& nrows, Ord
                                    OrdinalType idx_offset = 0) {
   nnz = SparseMatrix_MatrixMarket_read<ScalarType, OrdinalType>(filename, nrows, ncols, nnz, values, rowPtr, colInd,
                                                                 sort, idx_offset);
+  if (nnz < 0) return -1;
 
   char* filename_row   = new char[strlen(filename) + 5];
   char* filename_col   = new char[strlen(filename) + 5];
@@ -178,8 +203,24 @@ int SparseMatrix_WriteBinaryFormat(const char* filename, OrdinalType& nrows, Ord
   FILE* ColFile   = fopen(filename_col, "w");
   FILE* ValsFile  = fopen(filename_vals, "w");
   FILE* DescrFile = fopen(filename_descr, "w");
+  if (!RowFile || !ColFile || !ValsFile || !DescrFile) {
+    fprintf(stderr, "SparseMatrix_WriteBinaryFormat: could not open output file(s) for \"%s\"\n", filename);
+    if (RowFile) fclose(RowFile);
+    if (ColFile) fclose(ColFile);
+    if (ValsFile) fclose(ValsFile);
+    if (DescrFile) fclose(DescrFile);
+    return -1;
+  }
 
   FILE* file = fopen(filename, "r");
+  if (!file) {
+    fprintf(stderr, "SparseMatrix_WriteBinaryFormat: could not reopen \"%s\" for description copy\n", filename);
+    fclose(RowFile);
+    fclose(ColFile);
+    fclose(ValsFile);
+    fclose(DescrFile);
+    return -1;
+  }
   char line[512];
   line[0]   = '%';
   int count = -1;
@@ -187,7 +228,15 @@ int SparseMatrix_WriteBinaryFormat(const char* filename, OrdinalType& nrows, Ord
   // int nlines;
 
   while (line[0] == '%') {
-    fgets(line, 511, file);
+    if (!fgets(line, 511, file)) {
+      fprintf(stderr, "SparseMatrix_WriteBinaryFormat: unexpected EOF in \"%s\"\n", filename);
+      fclose(file);
+      fclose(RowFile);
+      fclose(ColFile);
+      fclose(ValsFile);
+      fclose(DescrFile);
+      return -1;
+    }
     line[511] = 0;
     count++;
     // if(count==0) symmetric=strstr(line,"symmetric");
@@ -198,6 +247,7 @@ int SparseMatrix_WriteBinaryFormat(const char* filename, OrdinalType& nrows, Ord
       fprintf(DescrFile, "%i %i %i\n", nrows, ncols, nnz);
   }
   fprintf(DescrFile, "\n");
+  fclose(file);
 
   fwrite(rowPtr, sizeof(OrdinalType), nrows + 1, RowFile);
   fwrite(colInd, sizeof(OrdinalType), nnz, ColFile);
@@ -238,6 +288,11 @@ int SparseMatrix_ReadBinaryFormat(const char* filename, OrdinalType& nrows, Ordi
   strcpy(filename_descr, filename);
   strcat(filename_descr, "_descr");
   FILE* file = fopen(filename_descr, "r");
+  if (!file) {
+    fprintf(stderr, "SparseMatrix_ReadBinaryFormat: could not open \"%s\"\n", filename_descr);
+    delete[] filename_descr;
+    return -1;
+  }
   char line[512];
   line[0]         = '%';
   int count       = -1;
@@ -245,18 +300,41 @@ int SparseMatrix_ReadBinaryFormat(const char* filename, OrdinalType& nrows, Ordi
   // int nlines;
 
   while (line[0] == '%') {
-    fgets(line, 511, file);
+    if (!fgets(line, 511, file)) {
+      fprintf(stderr, "SparseMatrix_ReadBinaryFormat: unexpected EOF in \"%s\"\n", filename_descr);
+      fclose(file);
+      delete[] filename_descr;
+      return -1;
+    }
+    line[511] = '\0';
     count++;
     if (count == 0) symmetric = strstr(line, "symmetric");
   }
   rewind(file);
-  for (int i = 0; i < count; i++) fgets(line, 511, file);
-  fscanf(file, "%i", &nrows);
-  fscanf(file, "%i", &ncols);
-  fscanf(file, "%i", &nnz);
+  for (int i = 0; i < count; i++) {
+    if (!fgets(line, 511, file)) {
+      fprintf(stderr, "SparseMatrix_ReadBinaryFormat: unexpected EOF rewinding \"%s\"\n", filename_descr);
+      fclose(file);
+      delete[] filename_descr;
+      return -1;
+    }
+  }
+  if (fscanf(file, "%i", &nrows) != 1 || fscanf(file, "%i", &ncols) != 1 || fscanf(file, "%i", &nnz) != 1) {
+    fprintf(stderr, "SparseMatrix_ReadBinaryFormat: invalid dimension line in \"%s\"\n", filename_descr);
+    fclose(file);
+    delete[] filename_descr;
+    return -1;
+  }
+  if (nrows <= 0 || ncols <= 0 || nnz < 0) {
+    fprintf(stderr, "SparseMatrix_ReadBinaryFormat: non-positive dimensions in \"%s\"\n", filename_descr);
+    fclose(file);
+    delete[] filename_descr;
+    return -1;
+  }
   printf("Matrix dimension: %i %i %i %s\n", nrows, ncols, nnz, symmetric ? "Symmetric" : "General");
 
   fclose(file);
+  delete[] filename_descr;
 
   char* filename_row  = new char[strlen(filename) + 5];
   char* filename_col  = new char[strlen(filename) + 5];
@@ -271,24 +349,60 @@ int SparseMatrix_ReadBinaryFormat(const char* filename, OrdinalType& nrows, Ordi
   FILE* ColFile  = fopen(filename_col, "r");
   FILE* ValsFile = fopen(filename_vals, "r");
 
-  bool read_values = false;
-  if (ValsFile == NULL) read_values = false;
+  const bool read_values = (ValsFile != NULL);
+
+  if (!RowFile || !ColFile) {
+    fprintf(stderr, "SparseMatrix_ReadBinaryFormat: could not open row/col binary for \"%s\"\n", filename);
+    if (RowFile) fclose(RowFile);
+    if (ColFile) fclose(ColFile);
+    if (ValsFile) fclose(ValsFile);
+    delete[] filename_row;
+    delete[] filename_col;
+    delete[] filename_vals;
+    return -1;
+  }
 
   values = new ScalarType[nnz];
   rowPtr = new OrdinalType[nrows + 1];
   colInd = new OrdinalType[nnz];
 
-  fread(rowPtr, sizeof(OrdinalType), nrows + 1, RowFile);
-  fread(colInd, sizeof(OrdinalType), nnz, ColFile);
+  if (fread(rowPtr, sizeof(OrdinalType), nrows + 1, RowFile) != static_cast<size_t>(nrows + 1) ||
+      fread(colInd, sizeof(OrdinalType), nnz, ColFile) != static_cast<size_t>(nnz)) {
+    fprintf(stderr, "SparseMatrix_ReadBinaryFormat: short read row/col data for \"%s\"\n", filename);
+    delete[] values;
+    delete[] rowPtr;
+    delete[] colInd;
+    fclose(RowFile);
+    fclose(ColFile);
+    if (ValsFile) fclose(ValsFile);
+    delete[] filename_row;
+    delete[] filename_col;
+    delete[] filename_vals;
+    return -1;
+  }
 
-  if (read_values) fclose(RowFile);
+  fclose(RowFile);
   fclose(ColFile);
   if (read_values) {
-    fread(values, sizeof(ScalarType), nnz, ValsFile);
+    if (fread(values, sizeof(ScalarType), nnz, ValsFile) != static_cast<size_t>(nnz)) {
+      fprintf(stderr, "SparseMatrix_ReadBinaryFormat: short read values for \"%s\"\n", filename);
+      delete[] values;
+      delete[] rowPtr;
+      delete[] colInd;
+      fclose(ValsFile);
+      delete[] filename_row;
+      delete[] filename_col;
+      delete[] filename_vals;
+      return -1;
+    }
     fclose(ValsFile);
   } else {
     for (int i = 0; i < nnz; i++) values[i] = 0.001 * (rand() % 1000);
   }
+
+  delete[] filename_row;
+  delete[] filename_col;
+  delete[] filename_vals;
 
   size_t min_span = nrows + 1;
   size_t max_span = 0;

--- a/perf_test/sparse/spmv/matrix_market.hpp
+++ b/perf_test/sparse/spmv/matrix_market.hpp
@@ -6,6 +6,8 @@
 
 #include <cstdio>
 #include <cstddef>
+#include <array>
+#include <memory>
 #include <cstring>
 #include <cstdlib>
 #include <limits>
@@ -48,12 +50,12 @@ template <typename ScalarType, typename OrdinalType>
 int SparseMatrix_MatrixMarket_read(const char* filename, OrdinalType& nrows, OrdinalType& ncols, OrdinalType& nnz,
                                    ScalarType*& values, OrdinalType*& rowPtr, OrdinalType*& colInd, bool sort,
                                    OrdinalType idx_offset = 0) {
-  FILE* file = fopen(filename, "r");
+  auto file = std::unique_ptr<FILE, decltype(&fclose)>(fopen(filename, "r"), &fclose);
   if (!file) {
     fprintf(stderr, "SparseMatrix_MatrixMarket_read: could not open \"%s\"\n", filename);
     return -1;
   }
-  char line[512];
+  std::array<char, 512> line{};
   line[0]         = '%';
   int count       = -1;
   char* symmetric = NULL;
@@ -61,34 +63,30 @@ int SparseMatrix_MatrixMarket_read(const char* filename, OrdinalType& nrows, Ord
   int nlines;
 
   while (line[0] == '%') {
-    if (!fgets(line, 511, file)) {
+    if (!fgets(line.data(), static_cast<int>(line.size()), file.get())) {
       fprintf(stderr, "SparseMatrix_MatrixMarket_read: unexpected EOF in header of \"%s\"\n", filename);
-      fclose(file);
       return -1;
     }
-    line[511] = '\0';
     count++;
     if (count == 0) {
-      symmetric = strstr(line, "symmetric");
-      pattern   = strstr(line, "pattern");
+      symmetric = strstr(line.data(), "symmetric");
+      pattern   = strstr(line.data(), "pattern");
     }
   }
-  rewind(file);
+  rewind(file.get());
   for (int i = 0; i < count; i++) {
-    if (!fgets(line, 511, file)) {
+    if (!fgets(line.data(), static_cast<int>(line.size()), file.get())) {
       fprintf(stderr, "SparseMatrix_MatrixMarket_read: unexpected EOF rewinding \"%s\"\n", filename);
-      fclose(file);
       return -1;
     }
   }
-  if (fscanf(file, "%i", &nrows) != 1 || fscanf(file, "%i", &ncols) != 1 || fscanf(file, "%i", &nlines) != 1) {
+  if (fscanf(file.get(), "%i", &nrows) != 1 || fscanf(file.get(), "%i", &ncols) != 1 ||
+      fscanf(file.get(), "%i", &nlines) != 1) {
     fprintf(stderr, "SparseMatrix_MatrixMarket_read: invalid dimension line in \"%s\"\n", filename);
-    fclose(file);
     return -1;
   }
   if (nrows <= 0 || ncols <= 0 || nlines < 0) {
     fprintf(stderr, "SparseMatrix_MatrixMarket_read: non-positive dimensions in \"%s\"\n", filename);
-    fclose(file);
     return -1;
   }
   printf("Matrix dimension: %i %i %i %s %s\n", nrows, ncols, nlines, symmetric ? "Symmetric" : "General",
@@ -108,10 +106,10 @@ int SparseMatrix_MatrixMarket_read(const char* filename, OrdinalType& nrows, Ord
   nnz = 0;
   for (int ii = 0; ii < nlines; ii++) {
     if (pattern) {
-      fscanf(file, "%i %i", &rowIndtmp[nnz], &colIndtmp[nnz]);
+      fscanf(file.get(), "%i %i", &rowIndtmp[nnz], &colIndtmp[nnz]);
       valuestmp[nnz] = (1.0 * (ii % nrows)) / ncols;
     } else
-      fscanf(file, "%i %i %le", &rowIndtmp[nnz], &colIndtmp[nnz], &valuestmp[nnz]);
+      fscanf(file.get(), "%i %i %le", &rowIndtmp[nnz], &colIndtmp[nnz], &valuestmp[nnz]);
     if (ii < 10 || ii > nlines - 10)
       printf("Read: %i %i %i %le\n", nnz, rowIndtmp[nnz], colIndtmp[nnz], valuestmp[nnz]);
     rowIndtmp[nnz] -= idx_offset;
@@ -175,7 +173,6 @@ int SparseMatrix_MatrixMarket_read(const char* filename, OrdinalType& nrows, Ord
 
   printf("%lu Spans: %lu %lu %lu\n", (size_t)nnz, min_span, max_span, ave_span / nrows);
   if (sort) Impl::SparseGraph_SortRows<OrdinalType>(nrows, rowPtr, colInd);
-  fclose(file);
   return nnz;
 }
 
@@ -212,7 +209,7 @@ int SparseMatrix_WriteBinaryFormat(const char* filename, OrdinalType& nrows, Ord
     return -1;
   }
 
-  FILE* file = fopen(filename, "r");
+  auto file = std::unique_ptr<FILE, decltype(&fclose)>(fopen(filename, "r"), &fclose);
   if (!file) {
     fprintf(stderr, "SparseMatrix_WriteBinaryFormat: could not reopen \"%s\" for description copy\n", filename);
     fclose(RowFile);
@@ -221,33 +218,30 @@ int SparseMatrix_WriteBinaryFormat(const char* filename, OrdinalType& nrows, Ord
     fclose(DescrFile);
     return -1;
   }
-  char line[512];
+  std::array<char, 512> line{};
   line[0]   = '%';
   int count = -1;
   // char* symmetric = NULL;
   // int nlines;
 
   while (line[0] == '%') {
-    if (!fgets(line, 511, file)) {
+    if (!fgets(line.data(), static_cast<int>(line.size()), file.get())) {
       fprintf(stderr, "SparseMatrix_WriteBinaryFormat: unexpected EOF in \"%s\"\n", filename);
-      fclose(file);
       fclose(RowFile);
       fclose(ColFile);
       fclose(ValsFile);
       fclose(DescrFile);
       return -1;
     }
-    line[511] = 0;
     count++;
     // if(count==0) symmetric=strstr(line,"symmetric");
 
     if (line[0] == '%')
-      fprintf(DescrFile, "%s", line);
+      fprintf(DescrFile, "%s", line.data());
     else
       fprintf(DescrFile, "%i %i %i\n", nrows, ncols, nnz);
   }
   fprintf(DescrFile, "\n");
-  fclose(file);
 
   fwrite(rowPtr, sizeof(OrdinalType), nrows + 1, RowFile);
   fwrite(colInd, sizeof(OrdinalType), nnz, ColFile);
@@ -287,53 +281,48 @@ int SparseMatrix_ReadBinaryFormat(const char* filename, OrdinalType& nrows, Ordi
   char* filename_descr = new char[strlen(filename) + 7];
   strcpy(filename_descr, filename);
   strcat(filename_descr, "_descr");
-  FILE* file = fopen(filename_descr, "r");
+  auto file = std::unique_ptr<FILE, decltype(&fclose)>(fopen(filename_descr, "r"), &fclose);
   if (!file) {
     fprintf(stderr, "SparseMatrix_ReadBinaryFormat: could not open \"%s\"\n", filename_descr);
     delete[] filename_descr;
     return -1;
   }
-  char line[512];
+  std::array<char, 512> line{};
   line[0]         = '%';
   int count       = -1;
   char* symmetric = NULL;
   // int nlines;
 
   while (line[0] == '%') {
-    if (!fgets(line, 511, file)) {
+    if (!fgets(line.data(), static_cast<int>(line.size()), file.get())) {
       fprintf(stderr, "SparseMatrix_ReadBinaryFormat: unexpected EOF in \"%s\"\n", filename_descr);
-      fclose(file);
       delete[] filename_descr;
       return -1;
     }
-    line[511] = '\0';
     count++;
-    if (count == 0) symmetric = strstr(line, "symmetric");
+    if (count == 0) symmetric = strstr(line.data(), "symmetric");
   }
-  rewind(file);
+  rewind(file.get());
   for (int i = 0; i < count; i++) {
-    if (!fgets(line, 511, file)) {
+    if (!fgets(line.data(), static_cast<int>(line.size()), file.get())) {
       fprintf(stderr, "SparseMatrix_ReadBinaryFormat: unexpected EOF rewinding \"%s\"\n", filename_descr);
-      fclose(file);
       delete[] filename_descr;
       return -1;
     }
   }
-  if (fscanf(file, "%i", &nrows) != 1 || fscanf(file, "%i", &ncols) != 1 || fscanf(file, "%i", &nnz) != 1) {
+  if (fscanf(file.get(), "%i", &nrows) != 1 || fscanf(file.get(), "%i", &ncols) != 1 ||
+      fscanf(file.get(), "%i", &nnz) != 1) {
     fprintf(stderr, "SparseMatrix_ReadBinaryFormat: invalid dimension line in \"%s\"\n", filename_descr);
-    fclose(file);
     delete[] filename_descr;
     return -1;
   }
   if (nrows <= 0 || ncols <= 0 || nnz < 0) {
     fprintf(stderr, "SparseMatrix_ReadBinaryFormat: non-positive dimensions in \"%s\"\n", filename_descr);
-    fclose(file);
     delete[] filename_descr;
     return -1;
   }
   printf("Matrix dimension: %i %i %i %s\n", nrows, ncols, nnz, symmetric ? "Symmetric" : "General");
 
-  fclose(file);
   delete[] filename_descr;
 
   char* filename_row  = new char[strlen(filename) + 5];

--- a/perf_test/test_crsmatrix.cpp
+++ b/perf_test/test_crsmatrix.cpp
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 #include <cstdio>
 #include <cstddef>
+#include <array>
+#include <memory>
 
 #include <ctime>
 #include <cstring>
@@ -26,12 +28,12 @@ typedef int LocalOrdinalType;
 template <typename ScalarType, typename OrdinalType>
 int SparseMatrix_MatrixMarket_read(const char* filename, OrdinalType& nrows, OrdinalType& ncols, OrdinalType& nnz,
                                    ScalarType*& values, OrdinalType*& rowPtr, OrdinalType*& colInd) {
-  FILE* file = fopen(filename, "r");
+  auto file = std::unique_ptr<FILE, decltype(&fclose)>(fopen(filename, "r"), &fclose);
   if (!file) {
     fprintf(stderr, "SparseMatrix_MatrixMarket_read: could not open \"%s\"\n", filename);
     return -1;
   }
-  char line[512];
+  std::array<char, 512> line{};
   line[0]         = '%';
   int count       = -1;
   char* symmetric = NULL;
@@ -49,31 +51,27 @@ int SparseMatrix_MatrixMarket_read(const char* filename, OrdinalType& nrows, Ord
     newFileSize = fread (buffer,1,fileSize,file);*/
 
   while (line[0] == '%') {
-    if (!fgets(line, 511, file)) {
+    if (!fgets(line.data(), static_cast<int>(line.size()), file.get())) {
       fprintf(stderr, "SparseMatrix_MatrixMarket_read: unexpected EOF in header of \"%s\"\n", filename);
-      fclose(file);
       return -1;
     }
-    line[511] = '\0';
     count++;
-    if (count == 0) symmetric = strstr(line, "symmetric");
+    if (count == 0) symmetric = strstr(line.data(), "symmetric");
   }
-  rewind(file);
+  rewind(file.get());
   for (int i = 0; i < count; i++) {
-    if (!fgets(line, 511, file)) {
+    if (!fgets(line.data(), static_cast<int>(line.size()), file.get())) {
       fprintf(stderr, "SparseMatrix_MatrixMarket_read: unexpected EOF rewinding \"%s\"\n", filename);
-      fclose(file);
       return -1;
     }
   }
-  if (fscanf(file, "%i", &nrows) != 1 || fscanf(file, "%i", &ncols) != 1 || fscanf(file, "%i", &nlines) != 1) {
+  if (fscanf(file.get(), "%i", &nrows) != 1 || fscanf(file.get(), "%i", &ncols) != 1 ||
+      fscanf(file.get(), "%i", &nlines) != 1) {
     fprintf(stderr, "SparseMatrix_MatrixMarket_read: invalid dimension line in \"%s\"\n", filename);
-    fclose(file);
     return -1;
   }
   if (nrows <= 0 || ncols <= 0 || nlines < 0) {
     fprintf(stderr, "SparseMatrix_MatrixMarket_read: non-positive dimensions in \"%s\"\n", filename);
-    fclose(file);
     return -1;
   }
   printf("Matrix dimension: %i %i %i %s\n", nrows, ncols, nlines, symmetric ? "Symmetric" : "General");
@@ -90,7 +88,7 @@ int SparseMatrix_MatrixMarket_read(const char* filename, OrdinalType& nrows, Ord
   for (int i = 0; i < nrows; i++) lastEntryWithRowInd[i] = -1;
   nnz = 0;
   for (int ii = 0; ii < nlines; ii++) {
-    fscanf(file, "%i %i %le", &rowIndtmp[nnz], &colIndtmp[nnz], &valuestmp[nnz]);
+    fscanf(file.get(), "%i %i %le", &rowIndtmp[nnz], &colIndtmp[nnz], &valuestmp[nnz]);
     priorEntrySameRowInd[nnz]               = lastEntryWithRowInd[rowIndtmp[nnz] - 1];
     lastEntryWithRowInd[rowIndtmp[nnz] - 1] = nnz;
     if ((symmetric) && (rowIndtmp[nnz] != colIndtmp[nnz])) {
@@ -126,7 +124,6 @@ int SparseMatrix_MatrixMarket_read(const char* filename, OrdinalType& nrows, Ord
   delete[] rowIndtmp;
   delete[] priorEntrySameRowInd;
   delete[] lastEntryWithRowInd;
-  fclose(file);
   return nnz;
 }
 
@@ -157,47 +154,43 @@ int SparseMatrix_ReadBinaryGraph(const char* filename, OrdinalType& nrows, Ordin
   char* filename_descr = new char[strlen(filename) + 7];
   strcpy(filename_descr, filename);
   strcat(filename_descr, "_descr");
-  FILE* file = fopen(filename_descr, "r");
+  auto file = std::unique_ptr<FILE, decltype(&fclose)>(fopen(filename_descr, "r"), &fclose);
   if (!file) {
     fprintf(stderr, "SparseMatrix_ReadBinaryGraph: could not open \"%s\"\n", filename_descr);
     delete[] filename_descr;
     return -1;
   }
-  char line[512];
+  std::array<char, 512> line{};
   line[0]         = '%';
   int count       = -1;
   char* symmetric = NULL;
   int nlines;
 
   while (line[0] == '%') {
-    if (!fgets(line, 511, file)) {
+    if (!fgets(line.data(), static_cast<int>(line.size()), file.get())) {
       fprintf(stderr, "SparseMatrix_ReadBinaryGraph: unexpected EOF in \"%s\"\n", filename_descr);
-      fclose(file);
       delete[] filename_descr;
       return -1;
     }
-    line[511] = '\0';
     count++;
-    if (count == 0) symmetric = strstr(line, "symmetric");
+    if (count == 0) symmetric = strstr(line.data(), "symmetric");
   }
-  rewind(file);
+  rewind(file.get());
   for (int i = 0; i < count; i++) {
-    if (!fgets(line, 511, file)) {
+    if (!fgets(line.data(), static_cast<int>(line.size()), file.get())) {
       fprintf(stderr, "SparseMatrix_ReadBinaryGraph: unexpected EOF rewinding \"%s\"\n", filename_descr);
-      fclose(file);
       delete[] filename_descr;
       return -1;
     }
   }
-  if (fscanf(file, "%i", &nrows) != 1 || fscanf(file, "%i", &ncols) != 1 || fscanf(file, "%i", &nlines) != 1) {
+  if (fscanf(file.get(), "%i", &nrows) != 1 || fscanf(file.get(), "%i", &ncols) != 1 ||
+      fscanf(file.get(), "%i", &nlines) != 1) {
     fprintf(stderr, "SparseMatrix_ReadBinaryGraph: invalid dimension line in \"%s\"\n", filename_descr);
-    fclose(file);
     delete[] filename_descr;
     return -1;
   }
   if (nrows <= 0 || ncols <= 0 || nlines < 0) {
     fprintf(stderr, "SparseMatrix_ReadBinaryGraph: non-positive dimensions in \"%s\"\n", filename_descr);
-    fclose(file);
     delete[] filename_descr;
     return -1;
   }
@@ -206,7 +199,6 @@ int SparseMatrix_ReadBinaryGraph(const char* filename, OrdinalType& nrows, Ordin
     nnz = nlines * 2;
   else
     nnz = nlines;
-  fclose(file);
   delete[] filename_descr;
 
   char* filename_row = new char[strlen(filename) + 5];

--- a/perf_test/test_crsmatrix.cpp
+++ b/perf_test/test_crsmatrix.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 #include <cstdio>
+#include <cstddef>
 
 #include <ctime>
 #include <cstring>
@@ -26,6 +27,10 @@ template <typename ScalarType, typename OrdinalType>
 int SparseMatrix_MatrixMarket_read(const char* filename, OrdinalType& nrows, OrdinalType& ncols, OrdinalType& nnz,
                                    ScalarType*& values, OrdinalType*& rowPtr, OrdinalType*& colInd) {
   FILE* file = fopen(filename, "r");
+  if (!file) {
+    fprintf(stderr, "SparseMatrix_MatrixMarket_read: could not open \"%s\"\n", filename);
+    return -1;
+  }
   char line[512];
   line[0]         = '%';
   int count       = -1;
@@ -44,15 +49,33 @@ int SparseMatrix_MatrixMarket_read(const char* filename, OrdinalType& nrows, Ord
     newFileSize = fread (buffer,1,fileSize,file);*/
 
   while (line[0] == '%') {
-    fgets(line, 511, file);
+    if (!fgets(line, 511, file)) {
+      fprintf(stderr, "SparseMatrix_MatrixMarket_read: unexpected EOF in header of \"%s\"\n", filename);
+      fclose(file);
+      return -1;
+    }
+    line[511] = '\0';
     count++;
     if (count == 0) symmetric = strstr(line, "symmetric");
   }
   rewind(file);
-  for (int i = 0; i < count; i++) fgets(line, 511, file);
-  fscanf(file, "%i", &nrows);
-  fscanf(file, "%i", &ncols);
-  fscanf(file, "%i", &nlines);
+  for (int i = 0; i < count; i++) {
+    if (!fgets(line, 511, file)) {
+      fprintf(stderr, "SparseMatrix_MatrixMarket_read: unexpected EOF rewinding \"%s\"\n", filename);
+      fclose(file);
+      return -1;
+    }
+  }
+  if (fscanf(file, "%i", &nrows) != 1 || fscanf(file, "%i", &ncols) != 1 || fscanf(file, "%i", &nlines) != 1) {
+    fprintf(stderr, "SparseMatrix_MatrixMarket_read: invalid dimension line in \"%s\"\n", filename);
+    fclose(file);
+    return -1;
+  }
+  if (nrows <= 0 || ncols <= 0 || nlines < 0) {
+    fprintf(stderr, "SparseMatrix_MatrixMarket_read: non-positive dimensions in \"%s\"\n", filename);
+    fclose(file);
+    return -1;
+  }
   printf("Matrix dimension: %i %i %i %s\n", nrows, ncols, nlines, symmetric ? "Symmetric" : "General");
   if (symmetric)
     nnz = nlines * 2;
@@ -103,6 +126,7 @@ int SparseMatrix_MatrixMarket_read(const char* filename, OrdinalType& nrows, Ord
   delete[] rowIndtmp;
   delete[] priorEntrySameRowInd;
   delete[] lastEntryWithRowInd;
+  fclose(file);
   return nnz;
 }
 
@@ -110,6 +134,7 @@ template <typename ScalarType, typename OrdinalType>
 int SparseMatrix_ExtractBinaryGraph(const char* filename, OrdinalType& nrows, OrdinalType& ncols, OrdinalType& nnz,
                                     ScalarType*& values, OrdinalType*& rowPtr, OrdinalType*& colInd) {
   nnz = SparseMatrix_MatrixMarket_read<ScalarType, OrdinalType>(filename, nrows, ncols, nnz, values, rowPtr, colInd);
+  if (nnz < 0) return -1;
   char* filename_row = new char[strlen(filename) + 5];
   char* filename_col = new char[strlen(filename) + 5];
   strcpy(filename_row, filename);
@@ -133,6 +158,11 @@ int SparseMatrix_ReadBinaryGraph(const char* filename, OrdinalType& nrows, Ordin
   strcpy(filename_descr, filename);
   strcat(filename_descr, "_descr");
   FILE* file = fopen(filename_descr, "r");
+  if (!file) {
+    fprintf(stderr, "SparseMatrix_ReadBinaryGraph: could not open \"%s\"\n", filename_descr);
+    delete[] filename_descr;
+    return -1;
+  }
   char line[512];
   line[0]         = '%';
   int count       = -1;
@@ -140,21 +170,44 @@ int SparseMatrix_ReadBinaryGraph(const char* filename, OrdinalType& nrows, Ordin
   int nlines;
 
   while (line[0] == '%') {
-    fgets(line, 511, file);
+    if (!fgets(line, 511, file)) {
+      fprintf(stderr, "SparseMatrix_ReadBinaryGraph: unexpected EOF in \"%s\"\n", filename_descr);
+      fclose(file);
+      delete[] filename_descr;
+      return -1;
+    }
+    line[511] = '\0';
     count++;
     if (count == 0) symmetric = strstr(line, "symmetric");
   }
   rewind(file);
-  for (int i = 0; i < count; i++) fgets(line, 511, file);
-  fscanf(file, "%i", &nrows);
-  fscanf(file, "%i", &ncols);
-  fscanf(file, "%i", &nlines);
+  for (int i = 0; i < count; i++) {
+    if (!fgets(line, 511, file)) {
+      fprintf(stderr, "SparseMatrix_ReadBinaryGraph: unexpected EOF rewinding \"%s\"\n", filename_descr);
+      fclose(file);
+      delete[] filename_descr;
+      return -1;
+    }
+  }
+  if (fscanf(file, "%i", &nrows) != 1 || fscanf(file, "%i", &ncols) != 1 || fscanf(file, "%i", &nlines) != 1) {
+    fprintf(stderr, "SparseMatrix_ReadBinaryGraph: invalid dimension line in \"%s\"\n", filename_descr);
+    fclose(file);
+    delete[] filename_descr;
+    return -1;
+  }
+  if (nrows <= 0 || ncols <= 0 || nlines < 0) {
+    fprintf(stderr, "SparseMatrix_ReadBinaryGraph: non-positive dimensions in \"%s\"\n", filename_descr);
+    fclose(file);
+    delete[] filename_descr;
+    return -1;
+  }
   printf("Matrix dimension: %i %i %i %s\n", nrows, ncols, nlines, symmetric ? "Symmetric" : "General");
   if (symmetric)
     nnz = nlines * 2;
   else
     nnz = nlines;
   fclose(file);
+  delete[] filename_descr;
 
   char* filename_row = new char[strlen(filename) + 5];
   char* filename_col = new char[strlen(filename) + 5];
@@ -164,15 +217,35 @@ int SparseMatrix_ReadBinaryGraph(const char* filename, OrdinalType& nrows, Ordin
   strcat(filename_col, "_col");
   FILE* RowFile = fopen(filename_row, "r");
   FILE* ColFile = fopen(filename_col, "r");
+  if (!RowFile || !ColFile) {
+    fprintf(stderr, "SparseMatrix_ReadBinaryGraph: could not open row/col binary for \"%s\"\n", filename);
+    if (RowFile) fclose(RowFile);
+    if (ColFile) fclose(ColFile);
+    delete[] filename_row;
+    delete[] filename_col;
+    return -1;
+  }
 
   values = new ScalarType[nnz];
   rowPtr = new OrdinalType[nrows + 1];
   colInd = new OrdinalType[nnz];
 
-  fread(rowPtr, sizeof(OrdinalType), nrows + 1, RowFile);
-  fread(colInd, sizeof(OrdinalType), nnz, ColFile);
+  if (fread(rowPtr, sizeof(OrdinalType), nrows + 1, RowFile) != static_cast<size_t>(nrows + 1) ||
+      fread(colInd, sizeof(OrdinalType), nnz, ColFile) != static_cast<size_t>(nnz)) {
+    fprintf(stderr, "SparseMatrix_ReadBinaryGraph: short read row/col data for \"%s\"\n", filename);
+    delete[] values;
+    delete[] rowPtr;
+    delete[] colInd;
+    fclose(RowFile);
+    fclose(ColFile);
+    delete[] filename_row;
+    delete[] filename_col;
+    return -1;
+  }
   fclose(RowFile);
   fclose(ColFile);
+  delete[] filename_row;
+  delete[] filename_col;
   return nnz;
 }
 
@@ -223,6 +296,11 @@ int test_crs_matrix_test(LocalOrdinalType numRows, LocalOrdinalType numCols, Loc
     nnz = SparseMatrix_MatrixMarket_read<Scalar, LocalOrdinalType>(filename, numRows, numCols, nnz, val, row, col);
   else
     nnz = SparseMatrix_ReadBinaryGraph<Scalar, LocalOrdinalType>(filename, numRows, numCols, nnz, val, row, col);
+
+  if (nnz < 0) {
+    fprintf(stderr, "test_crs_matrix_test: failed to read matrix from \"%s\"\n", filename ? filename : "");
+    return -1;
+  }
 
   matrix_type A("CRS::A", numRows, numCols, nnz, val, row, col, false);
 
@@ -336,6 +414,11 @@ int test_crs_matrix_test_singlevec(int numRows, int numCols, int nnz, int test, 
     nnz = SparseMatrix_MatrixMarket_read<Scalar, int>(filename, numRows, numCols, nnz, val, row, col);
   else
     nnz = SparseMatrix_ReadBinaryGraph<Scalar, int>(filename, numRows, numCols, nnz, val, row, col);
+
+  if (nnz < 0) {
+    fprintf(stderr, "test_crs_matrix_test_singlevec: failed to read matrix from \"%s\"\n", filename ? filename : "");
+    return -1;
+  }
 
   matrix_type A("CRS::A", numRows, numCols, nnz, val, row, col, false);
 

--- a/sparse/src/KokkosSparse_IOUtils.hpp
+++ b/sparse/src/KokkosSparse_IOUtils.hpp
@@ -937,18 +937,31 @@ int read_mtx(const char *fileName, lno_t *nrows, lno_t *ncols, size_type *ne, si
   if (mtx_field == UNDEFINED_FIELD) throw std::runtime_error("MatrixMarket file header is missing the field type.");
   if (mtx_sym == UNDEFINED_SYMMETRY) throw std::runtime_error("MatrixMarket file header is missing the symmetry type.");
 
-  while (1) {
-    getline(mmf, fline);
-    if (fline[0] != '%') break;
+  while (mmf) {
+    if (!std::getline(mmf, fline)) {
+      throw std::runtime_error("MatrixMarket file: unexpected EOF before dimension line.");
+    }
+    if (!fline.empty() && fline[0] == '%') continue;
+    break;
+  }
+  if (fline.empty()) {
+    throw std::runtime_error("MatrixMarket file: empty dimension line.");
   }
   std::stringstream ss(fline);
   lno_t nr = 0, nc = 0;
   size_type nnz = 0;
   ss >> nr >> nc;
-  if (mtx_format == COORDINATE)
+  if (ss.fail() || nr <= 0 || nc <= 0) {
+    throw std::runtime_error("MatrixMarket file: invalid or missing row/column dimensions on size line.");
+  }
+  if (mtx_format == COORDINATE) {
     ss >> nnz;
-  else
+    if (ss.fail()) {
+      throw std::runtime_error("MatrixMarket file: coordinate format requires nnz on size line.");
+    }
+  } else {
     nnz = static_cast<size_type>(nr) * nc;
+  }
   size_type numEdges = nnz;
   symmetrize         = symmetrize || mtx_sym != GENERAL;
   if (symmetrize && nr != nc) {
@@ -983,6 +996,9 @@ int read_mtx(const char *fileName, lno_t *nrows, lno_t *ncols, size_type *ne, si
     } else {
       // In coordinate format, row and col of each entry is read from file
       ss2 >> s >> d;
+      if (ss2.fail()) {
+        throw std::runtime_error("MatrixMarket file: failed parsing a coordinate-format entry line.");
+      }
     }
     if (mtx_field == PATTERN)
       w = 1;


### PR DESCRIPTION
Validates file opens, header/size lines, and stream extraction before using parsed dimensions or indexing into empty containers. This removes undefined behavior (e.g. empty vectors, empty strings, failed fgets) that segfaults when inputs are missing or malformed. 