### PR TITLE
Batched: allowing dynrankview in get_extent get_stride

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -685,7 +685,7 @@ KOKKOS_INLINE_FUNCTION int get_extent_int(const ViewType &v, const int r) {
   } else if constexpr (Kokkos::is_dyn_rank_view_v<ViewType>) {
     KOKKOS_EXPECTS((v.rank() <= 2));
   } else {
-    static_assert(false, "KokkosBatched: ViewType must be a Kokkos::View or a Kokkos::DynRankView");
+    static_assert(Kokkos::is_view_v<ViewType> || Kokkos::is_dyn_rank_view_v<ViewType>, "KokkosBatched: ViewType must be a Kokkos::View or a Kokkos::DynRankView");
   }
 
   const std::size_t V_rank = v.rank();
@@ -709,7 +709,8 @@ KOKKOS_INLINE_FUNCTION std::size_t get_stride(const ViewType &v, const int r) {
   } else if constexpr (Kokkos::is_dyn_rank_view_v<ViewType>) {
     KOKKOS_EXPECTS((v.rank() <= 2));
   } else {
-    static_assert(false, "KokkosBatched: ViewType must be a Kokkos::View or a Kokkos::DynRankView");
+    static_assert(Kokkos::is_view_v<ViewType> || Kokkos::is_dyn_rank_view_v<ViewType>,
+		  "KokkosBatched: ViewType must be a Kokkos::View or a Kokkos::DynRankView");
   }
 
   const std::size_t V_rank = v.rank();

--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -22,6 +22,7 @@
 #include <iostream>
 
 #include "Kokkos_Complex.hpp"
+#include "Kokkos_DynRankView.hpp"
 
 #include "KokkosKernels_config.h"
 #include "KokkosKernels_Macros.hpp"
@@ -677,9 +678,16 @@ KOKKOS_INLINE_FUNCTION void fma_bounds_check(ViewType v, SizeType m, SizeType n,
 namespace Impl {
 template <typename ViewType>
 KOKKOS_INLINE_FUNCTION int get_extent_int(const ViewType &v, const int r) {
-  static_assert(Kokkos::is_view_v<ViewType>, "KokkosBatched: ViewType is not a Kokkos::View.");
-  constexpr std::size_t V_rank = ViewType::rank();
-  static_assert(V_rank <= 2, "KokkosBatched: ViewType must have rank 0, 1 or 2.");
+  // Check for view and dynrankview
+  if constexpr (Kokkos::is_view_v<ViewType>) {
+    static_assert(ViewType::rank() <= 2, "KokkosBatched: ViewType must have rank 0, 1 or 2.");
+  } else if constexpr (Kokkos::is_dyn_rank_view_v<ViewType>) {
+    if (v.rank() > 2) {
+      throw std::runtime_error("KokkosBatched: ViewType must have rank 0, 1 or 2.");
+    }
+  }
+  
+  const std::size_t V_rank = v.rank();
 
   if (r == 0) {
     int V_extent_0 = V_rank < 1 ? 1 : v.extent_int(0);
@@ -694,9 +702,16 @@ KOKKOS_INLINE_FUNCTION int get_extent_int(const ViewType &v, const int r) {
 
 template <typename ViewType>
 KOKKOS_INLINE_FUNCTION std::size_t get_stride(const ViewType &v, const int r) {
-  static_assert(Kokkos::is_view_v<ViewType>, "KokkosBatched: ViewType is not a Kokkos::View.");
-  constexpr std::size_t V_rank = ViewType::rank();
-  static_assert(V_rank <= 2, "KokkosBatched: ViewType must have rank 0, 1 or 2.");
+  // Check for view and dynrankview
+  if constexpr (Kokkos::is_view_v<ViewType>) {
+    static_assert(ViewType::rank() <= 2, "KokkosBatched: ViewType must have rank 0, 1 or 2.");
+  } else if constexpr (Kokkos::is_dyn_rank_view_v<ViewType>) {
+    if (v.rank() > 2) {
+      throw std::runtime_error("KokkosBatched: ViewType must have rank 0, 1 or 2.");
+    }
+  }
+  
+  const std::size_t V_rank = v.rank();
 
   if (r == 0) {
     std::size_t V_stride_0 = V_rank < 1 ? 1 : v.stride(0);

--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -681,10 +681,8 @@ KOKKOS_INLINE_FUNCTION int get_extent_int(const ViewType &v, const int r) {
   // Check for view and dynrankview
   if constexpr (Kokkos::is_view_v<ViewType>) {
     static_assert(ViewType::rank() <= 2, "KokkosBatched: ViewType must have rank 0, 1 or 2.");
-  } else if constexpr (Kokkos::is_dyn_rank_view_v<ViewType>) {
-    if (v.rank() > 2) {
-      throw std::runtime_error("KokkosBatched: ViewType must have rank 0, 1 or 2.");
-    }
+  } else {
+    `static_assert(Kokkos::is_dyn_rank_view_v<ViewType>, "KokkosBatched: ViewType must be a Kokkos::View or a Kokkos::DynRankView");`
   }
   
   const std::size_t V_rank = v.rank();

--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -703,7 +703,7 @@ KOKKOS_INLINE_FUNCTION std::size_t get_stride(const ViewType &v, const int r) {
   // Check for view and dynrankview
   if constexpr (Kokkos::is_view_v<ViewType>) {
     static_assert(ViewType::rank() <= 2, "KokkosBatched: ViewType must have rank 0, 1 or 2.");
-  } else if constexpr () {
+  } else {
     static_assert(Kokkos::is_dyn_rank_view_v<ViewType>, "KokkosBatched: ViewType must be a Kokkos::View or a Kokkos::DynRankView");
   }
   

--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -685,7 +685,8 @@ KOKKOS_INLINE_FUNCTION int get_extent_int(const ViewType &v, const int r) {
   } else if constexpr (Kokkos::is_dyn_rank_view_v<ViewType>) {
     KOKKOS_EXPECTS((v.rank() <= 2));
   } else {
-    static_assert(Kokkos::is_view_v<ViewType> || Kokkos::is_dyn_rank_view_v<ViewType>, "KokkosBatched: ViewType must be a Kokkos::View or a Kokkos::DynRankView");
+    static_assert(Kokkos::is_view_v<ViewType> || Kokkos::is_dyn_rank_view_v<ViewType>,
+                  "KokkosBatched: ViewType must be a Kokkos::View or a Kokkos::DynRankView");
   }
 
   const std::size_t V_rank = v.rank();
@@ -710,7 +711,7 @@ KOKKOS_INLINE_FUNCTION std::size_t get_stride(const ViewType &v, const int r) {
     KOKKOS_EXPECTS((v.rank() <= 2));
   } else {
     static_assert(Kokkos::is_view_v<ViewType> || Kokkos::is_dyn_rank_view_v<ViewType>,
-		  "KokkosBatched: ViewType must be a Kokkos::View or a Kokkos::DynRankView");
+                  "KokkosBatched: ViewType must be a Kokkos::View or a Kokkos::DynRankView");
   }
 
   const std::size_t V_rank = v.rank();

--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -682,7 +682,7 @@ KOKKOS_INLINE_FUNCTION int get_extent_int(const ViewType &v, const int r) {
   if constexpr (Kokkos::is_view_v<ViewType>) {
     static_assert(ViewType::rank() <= 2, "KokkosBatched: ViewType must have rank 0, 1 or 2.");
   } else {
-    `static_assert(Kokkos::is_dyn_rank_view_v<ViewType>, "KokkosBatched: ViewType must be a Kokkos::View or a Kokkos::DynRankView");`
+    static_assert(Kokkos::is_dyn_rank_view_v<ViewType>, "KokkosBatched: ViewType must be a Kokkos::View or a Kokkos::DynRankView");
   }
   
   const std::size_t V_rank = v.rank();

--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -703,10 +703,8 @@ KOKKOS_INLINE_FUNCTION std::size_t get_stride(const ViewType &v, const int r) {
   // Check for view and dynrankview
   if constexpr (Kokkos::is_view_v<ViewType>) {
     static_assert(ViewType::rank() <= 2, "KokkosBatched: ViewType must have rank 0, 1 or 2.");
-  } else if constexpr (Kokkos::is_dyn_rank_view_v<ViewType>) {
-    if (v.rank() > 2) {
-      throw std::runtime_error("KokkosBatched: ViewType must have rank 0, 1 or 2.");
-    }
+  } else if constexpr () {
+    static_assert(Kokkos::is_dyn_rank_view_v<ViewType>, "KokkosBatched: ViewType must be a Kokkos::View or a Kokkos::DynRankView");
   }
   
   const std::size_t V_rank = v.rank();

--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -21,6 +21,7 @@
 #include <complex>
 #include <iostream>
 
+#include <Kokkos_Assert.hpp>
 #include "Kokkos_Complex.hpp"
 #include "Kokkos_DynRankView.hpp"
 
@@ -681,10 +682,12 @@ KOKKOS_INLINE_FUNCTION int get_extent_int(const ViewType &v, const int r) {
   // Check for view and dynrankview
   if constexpr (Kokkos::is_view_v<ViewType>) {
     static_assert(ViewType::rank() <= 2, "KokkosBatched: ViewType must have rank 0, 1 or 2.");
+  } else if constexpr (Kokkos::is_dyn_rank_view_v<ViewType>) {
+    KOKKOS_EXPECTS((v.rank() <= 2));
   } else {
-    static_assert(Kokkos::is_dyn_rank_view_v<ViewType>, "KokkosBatched: ViewType must be a Kokkos::View or a Kokkos::DynRankView");
+    static_assert(false, "KokkosBatched: ViewType must be a Kokkos::View or a Kokkos::DynRankView");
   }
-  
+
   const std::size_t V_rank = v.rank();
 
   if (r == 0) {
@@ -703,10 +706,12 @@ KOKKOS_INLINE_FUNCTION std::size_t get_stride(const ViewType &v, const int r) {
   // Check for view and dynrankview
   if constexpr (Kokkos::is_view_v<ViewType>) {
     static_assert(ViewType::rank() <= 2, "KokkosBatched: ViewType must have rank 0, 1 or 2.");
+  } else if constexpr (Kokkos::is_dyn_rank_view_v<ViewType>) {
+    KOKKOS_EXPECTS((v.rank() <= 2));
   } else {
-    static_assert(Kokkos::is_dyn_rank_view_v<ViewType>, "KokkosBatched: ViewType must be a Kokkos::View or a Kokkos::DynRankView");
+    static_assert(false, "KokkosBatched: ViewType must be a Kokkos::View or a Kokkos::DynRankView");
   }
-  
+
   const std::size_t V_rank = v.rank();
 
   if (r == 0) {


### PR DESCRIPTION
Supersedes #3034 @japlews 
Some downstream libraries and applications like Intrepid2 use dynamic rank views and we need to allow them to get passed in as input parameters.