### PR TITLE
Accomodate cuSPARSE 12.7 deprecations

### DIFF
--- a/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_decl.hpp
@@ -23,9 +23,11 @@ namespace KokkosSparse {
 namespace Impl {
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
-#if (CUDA_VERSION >= 11040)
+#if (CUDA_VERSION >= 11040) && (!defined(CUSPARSE_VERSION) || (CUSPARSE_VERSION < 12700))
 
-// 11.4+ supports generic API with reuse (full symbolic/numeric separation)
+// CUDA 11.4+ supports generic API with reuse (full symbolic/numeric
+// separation). Newer cuSPARSE versions deprecate the SpGEMMreuse entry points,
+// so those versions use the non-reuse generic path below instead.
 template <typename KernelHandle, typename lno_t, typename ConstRowMapType, typename ConstEntriesType,
           typename ConstValuesType, typename EntriesType, typename ValuesType>
 void spgemm_numeric_cusparse(KernelHandle *handle, lno_t /*m*/, lno_t /*n*/, lno_t /*k*/,
@@ -96,7 +98,8 @@ void spgemm_numeric_cusparse(KernelHandle *handle, lno_t /*m*/, lno_t /*n*/, lno
 }
 
 #elif (CUDA_VERSION >= 11000)
-// 11.0-11.3 supports only the generic API, but not reuse.
+// CUDA 11.0-11.3 supports only the generic API, but not reuse.
+// cuSPARSE versions that deprecate SpGEMMreuse also take this path.
 template <typename KernelHandle, typename lno_t, typename ConstRowMapType, typename ConstEntriesType,
           typename ConstValuesType, typename EntriesType, typename ValuesType>
 void spgemm_numeric_cusparse(KernelHandle *handle, lno_t /*m*/, lno_t /*n*/, lno_t /*k*/,

--- a/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp
@@ -29,9 +29,11 @@ namespace Impl {
 // offsets and ordinals independently as either 16, 32 or 64-bit integers,
 // cusparse will just fail at runtime if you don't use 32 for both.
 
-#if (CUDA_VERSION >= 11040)
-// 11.4+ supports generic API with reuse (full symbolic/numeric separation)
-// However, its "symbolic" (cusparseSpGEMMreuse_nnz) does not populate C's
+#if (CUDA_VERSION >= 11040) && (!defined(CUSPARSE_VERSION) || (CUSPARSE_VERSION < 12700))
+// CUDA 11.4+ added generic API structure reuse (full symbolic/numeric
+// separation). Newer cuSPARSE versions deprecate the SpGEMMreuse entry points,
+// so those versions take the non-reuse generic path below instead.
+// Also note: its "symbolic" (cusparseSpGEMMreuse_nnz) does not populate C's
 // rowptrs.
 template <typename KernelHandle, typename lno_t, typename ConstRowMapType, typename ConstEntriesType,
           typename RowMapType>
@@ -152,7 +154,8 @@ void spgemm_symbolic_cusparse(KernelHandle *handle, lno_t m, lno_t n, lno_t k, c
 }
 
 #elif (CUDA_VERSION >= 11000)
-// 11.0-11.3 supports only the generic API, but not reuse.
+// CUDA 11.0-11.3 supports only the generic API, but not reuse.
+// cuSPARSE versions that deprecate SpGEMMreuse also take this path.
 template <typename KernelHandle, typename lno_t, typename ConstRowMapType, typename ConstEntriesType,
           typename RowMapType>
 void spgemm_symbolic_cusparse(KernelHandle *handle, lno_t m, lno_t n, lno_t k, const ConstRowMapType &row_mapA,

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
@@ -263,6 +263,42 @@ KOKKOSSPARSE_SPMV_MV_MKL(Kokkos::complex<double>, Kokkos::OpenMP)
 namespace KokkosSparse {
 namespace Impl {
 
+#if defined(CUSPARSE_VERSION) && (CUSPARSE_VERSION >= 12500)
+template <class AMatrix>
+void create_cusparse_bsr_descr(cusparseSpMatDescr_t* descr, const AMatrix& A) {
+  using offset_type = typename AMatrix::non_const_size_type;
+  using entry_type  = typename AMatrix::non_const_ordinal_type;
+  using value_type  = typename AMatrix::non_const_value_type;
+
+  static_assert(std::is_same_v<typename AMatrix::block_layout_type, Kokkos::LayoutRight>,
+                "KokkosSparse::BsrMatrix blocks must be layout-right for cuSPARSE");
+
+  void* rowOffsets = static_cast<void*>(const_cast<offset_type*>(A.graph.row_map.data()));
+  void* colIndices = static_cast<void*>(const_cast<entry_type*>(A.graph.entries.data()));
+  void* values     = static_cast<void*>(const_cast<value_type*>(A.values.data()));
+
+  KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(
+      cusparseCreateBsr(descr, A.numRows(), A.numCols(), A.nnz(), A.blockDim(), A.blockDim(), rowOffsets, colIndices,
+                        values, cusparse_index_type_t_from<offset_type>(), cusparse_index_type_t_from<entry_type>(),
+                        CUSPARSE_INDEX_BASE_ZERO, cuda_data_type_from<value_type>(), CUSPARSE_ORDER_ROW));
+}
+
+template <class ViewType>
+cusparseDnMatDescr_t create_cusparse_layoutleft_dnmat(const ViewType& view) {
+  static_assert(ViewType::rank == 2, "cuSPARSE dense matrix descriptors require rank-2 views");
+  static_assert(std::is_same_v<typename ViewType::array_layout, Kokkos::LayoutLeft>,
+                "cuSPARSE BSR SpMM only instantiates LayoutLeft multivectors");
+
+  cusparseDnMatDescr_t descr;
+  void* values = static_cast<void*>(const_cast<typename ViewType::non_const_value_type*>(view.data()));
+  KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(
+      cusparseCreateDnMat(&descr, static_cast<int64_t>(view.extent(0)), static_cast<int64_t>(view.extent(1)),
+                          static_cast<int64_t>(view.stride(1)), values,
+                          cuda_data_type_from<typename ViewType::non_const_value_type>(), CUSPARSE_ORDER_COL));
+  return descr;
+}
+#endif
+
 template <class Handle, class AMatrix, class XVector, class YVector>
 void spmv_bsr_cusparse(const Kokkos::Cuda& exec, Handle* handle, const char mode[],
                        typename YVector::const_value_type& alpha, const AMatrix& A, const XVector& x,
@@ -286,6 +322,40 @@ void spmv_bsr_cusparse(const Kokkos::Cuda& exec, Handle* handle, const char mode
     }
   }
 
+#if defined(CUSPARSE_VERSION) && (CUSPARSE_VERSION >= 12700)
+  const cudaDataType valueType = cuda_data_type_from<value_type>();
+  cusparseDnVecDescr_t vecX, vecY;
+  KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseCreateDnVec(&vecX, x.extent_int(0), (void*)x.data(), valueType));
+  KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseCreateDnVec(&vecY, y.extent_int(0), (void*)y.data(), valueType));
+
+  cusparseSpMVAlg_t algo = CUSPARSE_SPMV_BSR_ALG1;
+  KokkosSparse::Impl::CuSparse10_SpMV_Data* subhandle;
+
+  if (handle->tpl_rank1) {
+    subhandle = dynamic_cast<KokkosSparse::Impl::CuSparse10_SpMV_Data*>(handle->tpl_rank1);
+    if (!subhandle) throw std::runtime_error("KokkosSparse::spmv: subhandle is not set up for generic cuSPARSE BSR");
+    subhandle->set_exec_space(exec);
+  } else {
+    subhandle         = new KokkosSparse::Impl::CuSparse10_SpMV_Data(exec);
+    handle->tpl_rank1 = subhandle;
+
+    create_cusparse_bsr_descr(&subhandle->mat, A);
+    KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSpMV_bufferSize(cusparseHandle, myCusparseOperation, &alpha,
+                                                                 subhandle->mat, vecX, &beta, vecY, valueType, algo,
+                                                                 &subhandle->bufferSize));
+#if (CUDA_VERSION >= 11020)
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMallocAsync(&subhandle->buffer, subhandle->bufferSize, exec.cuda_stream()));
+#else
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc(&subhandle->buffer, subhandle->bufferSize));
+#endif
+  }
+
+  KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSpMV(cusparseHandle, myCusparseOperation, &alpha, subhandle->mat, vecX,
+                                                    &beta, vecY, valueType, algo, subhandle->buffer));
+
+  KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(vecX));
+  KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(vecY));
+#else
   KokkosSparse::Impl::CuSparse9_SpMV_Data* subhandle;
 
   if (handle->tpl_rank1) {
@@ -337,6 +407,7 @@ void spmv_bsr_cusparse(const Kokkos::Cuda& exec, Handle* handle, const char mode
                   "Trying to call cusparse[*]bsrmv with a scalar type not "
                   "float/double, nor complex of either!");
   }
+#endif
 }
 
 // Reference
@@ -390,6 +461,40 @@ void spmv_mv_bsr_cusparse(const Kokkos::Cuda& exec, Handle* handle, const char m
                     std::is_same_v<typename YVector::array_layout, Kokkos::LayoutLeft>,
                 "cuSPARSE requires both X and Y to be LayoutLeft.");
 
+#if defined(CUSPARSE_VERSION) && (CUSPARSE_VERSION >= 12500)
+  const cudaDataType valueType = cuda_data_type_from<value_type>();
+  cusparseDnMatDescr_t vecX    = create_cusparse_layoutleft_dnmat(x);
+  cusparseDnMatDescr_t vecY    = create_cusparse_layoutleft_dnmat(y);
+
+  cusparseSpMMAlg_t algo = CUSPARSE_SPMM_BSR_ALG1;
+  KokkosSparse::Impl::CuSparse10_SpMV_Data* subhandle;
+
+  if (handle->tpl_rank2) {
+    subhandle = dynamic_cast<KokkosSparse::Impl::CuSparse10_SpMV_Data*>(handle->tpl_rank2);
+    if (!subhandle) throw std::runtime_error("KokkosSparse::spmv: subhandle is not set up for generic cuSPARSE BSR");
+    subhandle->set_exec_space(exec);
+  } else {
+    subhandle         = new KokkosSparse::Impl::CuSparse10_SpMV_Data(exec);
+    handle->tpl_rank2 = subhandle;
+
+    create_cusparse_bsr_descr(&subhandle->mat, A);
+    KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(
+        cusparseSpMM_bufferSize(cusparseHandle, myCusparseOperation, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha,
+                                subhandle->mat, vecX, &beta, vecY, valueType, algo, &subhandle->bufferSize));
+#if (CUDA_VERSION >= 11020)
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMallocAsync(&subhandle->buffer, subhandle->bufferSize, exec.cuda_stream()));
+#else
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc(&subhandle->buffer, subhandle->bufferSize));
+#endif
+  }
+
+  KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSpMM(cusparseHandle, myCusparseOperation,
+                                                    CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, subhandle->mat, vecX,
+                                                    &beta, vecY, valueType, algo, subhandle->buffer));
+
+  KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseDestroyDnMat(vecX));
+  KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseDestroyDnMat(vecY));
+#else
   KokkosSparse::Impl::CuSparse9_SpMV_Data* subhandle;
 
   if (handle->tpl_rank2) {
@@ -443,6 +548,7 @@ void spmv_mv_bsr_cusparse(const Kokkos::Cuda& exec, Handle* handle, const char m
                   "Trying to call cusparse[*]bsrmm with a scalar type not "
                   "float/double, nor complex of either!");
   }
+#endif
 }
 
 #define KOKKOSSPARSE_SPMV_CUSPARSE(SCALAR, ORDINAL, OFFSET, LAYOUT, SPACE)                                         \


### PR DESCRIPTION
- `SpGEMMreuse` stuff: https://docs.nvidia.com/cuda/cusparse/index.html?highlight=cusparseSpGEMMreuse#cusparsespgemmreuse-deprecated
- Non-generic BSR spmv , e.g. `cusparseSbsrmv`: https://docs.nvidia.com/cuda/cusparse/index.html?highlight=cusparseSbsrmv#cusparse-t-bsrmv-deprecated
   - generic spmv available in 12.7
   - generic spmm available in 12.5