### PR TITLE
Add batched rotg

### DIFF
--- a/batched/dense/impl/KokkosBatched_Rotg_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Rotg_Impl.hpp
@@ -12,13 +12,15 @@ namespace KokkosBatched {
 /// \brief invoke Rotg for scalars
 /// constructs a plane rotation such that
 /// [[c,         s],  * [[a],  = [[r],
-///  [-conjg(s), c]]    [b],]     [0]]
+///  [-conjg(s), c]]     [b]]     [0]]
 ///
 /// \tparam SViewType 0-D View type containing a nonconst real or complex scalar
 /// \tparam MViewType 0-D View type containing a nonconst real/magnitude-typed scalar
 ///
 /// \param[in,out] a: On entry, the scalar a. On exit, it is overwritten by r, the nonzero element of the rotated
-/// vector. \param[in,out] b: The scalar b (real or complex). \param[out] c: cosine of the rotation (real scalar)
+/// vector.
+/// \param[in,out] b: The scalar b (real or complex).
+/// \param[out] c: cosine of the rotation (real scalar)
 /// \param[out] s: sine of the rotation (real or complex scalar)
 ///
 template <class SViewType, class MViewType>

--- a/batched/dense/impl/KokkosBatched_Rotg_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Rotg_Impl.hpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOSBATCHED_ROTG_IMPL_HPP_
+#define KOKKOSBATCHED_ROTG_IMPL_HPP_
+
+#include <KokkosBlas_util.hpp>
+#include <KokkosBatched_Util.hpp>
+#include "KokkosBlas1_rotg_impl.hpp"
+
+namespace KokkosBatched {
+/// \brief invoke Rotg for scalars
+/// constructs a plane rotation such that
+/// [[c,         s],  * [[a],  = [[r],
+///  [-conjg(s), c]]    [b],]     [0]]
+///
+/// \tparam SViewType 0-D View type containing a nonconst real or complex scalar
+/// \tparam MViewType 0-D View type containing a nonconst real/magnitude-typed scalar
+///
+/// \param[in,out] a: On entry, the scalar a. On exit, it is overwritten by r, the nonzero element of the rotated
+/// vector. \param[in,out] b: The scalar b (real or complex). \param[out] c: cosine of the rotation (real scalar)
+/// \param[out] s: sine of the rotation (real or complex scalar)
+///
+template <class SViewType, class MViewType>
+KOKKOS_INLINE_FUNCTION int Rotg::invoke(const SViewType &a, const SViewType &b, const MViewType &c,
+                                        const SViewType &s) {
+  static_assert(Kokkos::is_view_v<SViewType>, "KokkosBatched::rotg: SViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view_v<MViewType>, "KokkosBatched::rotg: MViewType is not a Kokkos::View.");
+  static_assert(SViewType::rank() == 0, "KokkosBatched::rotg: SViewType must have rank 0.");
+  static_assert(MViewType::rank() == 0, "KokkosBatched::rotg: MViewType must have rank 0.");
+  static_assert(std::is_same_v<typename SViewType::value_type, typename SViewType::non_const_value_type>,
+                "KokkosBatched::rotg: SViewType must have non-const value type.");
+  static_assert(std::is_same_v<typename MViewType::value_type, typename MViewType::non_const_value_type>,
+                "KokkosBatched::rotg: MViewType must have non-const value type.");
+  using MagnitudeType = typename MViewType::non_const_value_type;
+  static_assert(!KokkosKernels::ArithTraits<MagnitudeType>::is_complex, "KokkosBatched::rotg: MViewType must be real.");
+  KokkosBlas::Impl::rotg_impl(a.data(), b.data(), c.data(), s.data());
+  return 0;
+}
+
+}  // namespace KokkosBatched
+
+#endif  // KOKKOSBATCHED_ROTG_IMPL_HPP_

--- a/batched/dense/src/KokkosBatched_Rotg.hpp
+++ b/batched/dense/src/KokkosBatched_Rotg.hpp
@@ -10,13 +10,15 @@ namespace KokkosBatched {
 /// \brief Device callable Rotg:
 /// constructs a plane rotation such that
 /// [[c,         s],  * [[a],  = [[r],
-///  [-conjg(s), c]]     [b],]    [0]]
+///  [-conjg(s), c]]     [b]]     [0]]
 ///
 /// \tparam SViewType 0-D View type containing a nonconst real or complex scalar
 /// \tparam MViewType 0-D View type containing a nonconst real/magnitude-typed scalar
 ///
 /// \param[in,out] a: On entry, the scalar a. On exit, it is overwritten by r, the nonzero element of the rotated
-/// vector. \param[in,out] b: The scalar b (real or complex). \param[out] c: cosine of the rotation (real scalar)
+/// vector.
+/// \param[in,out] b: The scalar b (real or complex).
+/// \param[out] c: cosine of the rotation (real scalar)
 /// \param[out] s: sine of the rotation (real or complex scalar)
 ///
 struct Rotg {

--- a/batched/dense/src/KokkosBatched_Rotg.hpp
+++ b/batched/dense/src/KokkosBatched_Rotg.hpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+#ifndef KOKKOSBATCHED_ROTG_HPP_
+#define KOKKOSBATCHED_ROTG_HPP_
+
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+
+namespace KokkosBatched {
+
+/// \brief Device callable Rotg:
+/// constructs a plane rotation such that
+/// [[c,         s],  * [[a],  = [[r],
+///  [-conjg(s), c]]     [b],]    [0]]
+///
+/// \tparam SViewType 0-D View type containing a nonconst real or complex scalar
+/// \tparam MViewType 0-D View type containing a nonconst real/magnitude-typed scalar
+///
+/// \param[in,out] a: On entry, the scalar a. On exit, it is overwritten by r, the nonzero element of the rotated
+/// vector. \param[in,out] b: The scalar b (real or complex). \param[out] c: cosine of the rotation (real scalar)
+/// \param[out] s: sine of the rotation (real or complex scalar)
+///
+struct Rotg {
+  template <class SViewType, class MViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const SViewType &a, const SViewType &b, const MViewType &c,
+                                           const SViewType &s);
+};
+
+}  // namespace KokkosBatched
+
+#include "KokkosBatched_Rotg_Impl.hpp"
+
+#endif  // KOKKOSBATCHED_ROTG_HPP_

--- a/batched/dense/unit_test/Test_Batched_Dense.hpp
+++ b/batched/dense/unit_test/Test_Batched_Dense.hpp
@@ -7,6 +7,7 @@
 #include "Test_Batched_SerialAxpy.hpp"
 #include "Test_Batched_Copy.hpp"
 #include "Test_Batched_Rot.hpp"
+#include "Test_Batched_Rotg.hpp"
 #include "Test_Batched_SerialEigendecomposition.hpp"
 #include "Test_Batched_SerialEigendecomposition_Real.hpp"
 #include "Test_Batched_SerialGesv.hpp"

--- a/batched/dense/unit_test/Test_Batched_Rotg.hpp
+++ b/batched/dense/unit_test/Test_Batched_Rotg.hpp
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
+#include <KokkosBatched_Rotg.hpp>
+
+namespace Test {
+namespace Rotg {
+
+template <typename DeviceType, typename SViewType, typename MViewType>
+struct Functor_BatchedRotg {
+  using execution_space = typename DeviceType::execution_space;
+  SViewType m_a;
+  SViewType m_b;
+  MViewType m_c;
+  SViewType m_s;
+
+  Functor_BatchedRotg(const SViewType &a, const SViewType &b, const MViewType &c, const SViewType &s)
+      : m_a(a), m_b(b), m_c(c), m_s(s) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int k) const {
+    auto sub_a = Kokkos::subview(m_a, k);
+    auto sub_b = Kokkos::subview(m_b, k);
+    auto sub_c = Kokkos::subview(m_c, k);
+    auto sub_s = Kokkos::subview(m_s, k);
+    KokkosBatched::Rotg::invoke(sub_a, sub_b, sub_c, sub_s);
+  }
+
+  inline void run() {
+    using value_type = typename SViewType::non_const_value_type;
+    std::string name_region("KokkosBatched::Test::Rotg");
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    Kokkos::Profiling::pushRegion(name.c_str());
+    Kokkos::RangePolicy<execution_space> policy(0, m_a.extent(0));
+    Kokkos::parallel_for(name.c_str(), policy, *this);
+    Kokkos::Profiling::popRegion();
+  }
+};
+
+template <typename DeviceType, typename LayoutType, typename SType, typename MType>
+void impl_test_batched_rotg_analytical(const std::size_t Nb, SType a_in, SType b_in, MType c_ref, SType s_ref) {
+  using ats       = typename KokkosKernels::ArithTraits<SType>;
+  using SViewType = Kokkos::View<SType *, LayoutType, DeviceType>;
+  using MViewType = Kokkos::View<MType *, LayoutType, DeviceType>;
+
+  SViewType a("a", Nb), b("b", Nb), s("s", Nb);
+  MViewType c("c", Nb);
+
+  Kokkos::deep_copy(a, a_in);
+  Kokkos::deep_copy(b, b_in);
+
+  Functor_BatchedRotg<DeviceType, SViewType, MViewType>(a, b, c, s).run();
+
+  auto h_a = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, a);
+  auto h_b = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, b);
+  auto h_c = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, c);
+  auto h_s = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, s);
+
+  typename ats::mag_type eps = 1.0e1 * ats::epsilon();
+  for (std::size_t i = 0; i < Nb; i++) {
+    // Check if the computed c and s satisfy the Givens rotation properties
+    EXPECT_NEAR_KK(h_c(i), c_ref, eps);
+    EXPECT_NEAR_KK(h_s(i), s_ref, eps);
+    auto rotation_norm = h_c(i) * h_c(i) + Kokkos::abs(h_s(i)) * Kokkos::abs(h_s(i));
+    EXPECT_NEAR_KK(rotation_norm, 1.0, eps);
+
+    // Check if the rotated values satisfy the expected relationships
+    // For the given a_in and b_in, the expected rotated values are:
+    // r = c*a_in + s*b_in should be approximately equal to sqrt(a_in^2 + b_in^2)
+    // z = c*b_in - conj(s)*a should be approximately zero
+    using Op = std::conditional_t<KokkosKernels::ArithTraits<SType>::is_complex, KokkosBlas::Impl::OpConj,
+                                  KokkosBlas::Impl::OpID>;
+    Op op;
+    auto r = h_c(i) * a_in + h_s(i) * b_in;
+    auto z = h_c(i) * b_in - op(h_s(i)) * a_in;
+
+    SType r_ref = Kokkos::sqrt(Kokkos::abs(a_in) * Kokkos::abs(a_in) + Kokkos::abs(b_in) * Kokkos::abs(b_in));
+    if constexpr (KokkosKernels::ArithTraits<SType>::is_complex) {
+      if (Kokkos::abs(a_in) == KokkosKernels::ArithTraits<SType>::zero()) {
+        r_ref = Kokkos::abs(b_in);
+      } else {
+        r_ref *= a_in / Kokkos::abs(a_in);
+      }
+    } else {
+      auto sign = (Kokkos::abs(a_in) > Kokkos::abs(b_in)) ? a_in : b_in;
+      r_ref     = Kokkos::copysign(r_ref, sign);
+    }
+    EXPECT_NEAR_KK(r, r_ref, eps);
+    EXPECT_NEAR_KK(z, 0.0, eps);
+
+    auto a_ref = r_ref;
+    auto b_ref = b_in;
+
+    // b is updated only for the real case
+    if constexpr (!KokkosKernels::ArithTraits<SType>::is_complex) {
+      if (Kokkos::abs(a_in) > Kokkos::abs(b_in)) {
+        b_ref = h_s(i);
+      } else if (h_c(i) != 0) {
+        b_ref = KokkosKernels::ArithTraits<SType>::one() / h_c(i);
+      } else {
+        b_ref = KokkosKernels::ArithTraits<SType>::one();
+      }
+    }
+
+    EXPECT_NEAR_KK(h_a(i), a_ref, eps);
+    EXPECT_NEAR_KK(h_b(i), b_ref, eps);
+  }
+}
+
+template <typename DeviceType, typename LayoutType, typename SType, typename MType>
+void impl_test_batched_rotg_random(const std::size_t Nb) {
+  using ats       = typename KokkosKernels::ArithTraits<SType>;
+  using SViewType = Kokkos::View<SType *, LayoutType, DeviceType>;
+  using MViewType = Kokkos::View<MType *, LayoutType, DeviceType>;
+
+  SViewType a("a", Nb), b("b", Nb), s("s", Nb), a_init("a_init", Nb), b_init("b_init", Nb);
+  MViewType c("c", Nb);
+
+  using execution_space = typename DeviceType::execution_space;
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
+  SType randStart, randEnd;
+
+  KokkosKernels::Impl::getRandomBounds(1.0, randStart, randEnd);
+  Kokkos::fill_random(a_init, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(b_init, rand_pool, randStart, randEnd);
+
+  Kokkos::deep_copy(a, a_init);
+  Kokkos::deep_copy(b, b_init);
+
+  Functor_BatchedRotg<DeviceType, SViewType, MViewType>(a, b, c, s).run();
+
+  auto h_a      = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, a);
+  auto h_b      = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, b);
+  auto h_c      = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, c);
+  auto h_s      = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, s);
+  auto h_a_init = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, a_init);
+  auto h_b_init = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, b_init);
+
+  typename ats::mag_type eps = 1.0e1 * ats::epsilon();
+  for (std::size_t i = 0; i < Nb; i++) {
+    // Check if the computed c and s satisfy the Givens rotation properties
+    auto rotation_norm = h_c(i) * h_c(i) + Kokkos::abs(h_s(i)) * Kokkos::abs(h_s(i));
+    EXPECT_NEAR_KK(rotation_norm, 1.0, eps);
+
+    // Check if the rotated values satisfy the expected relationships
+    // For the given a_in and b_in, the expected rotated values are:
+    // r = c*a_in + s*b_in should be approximately equal to sqrt(a_in^2 + b_in^2)
+    // z = c*b_in - conj(s)*a should be approximately zero
+    using Op = std::conditional_t<KokkosKernels::ArithTraits<SType>::is_complex, KokkosBlas::Impl::OpConj,
+                                  KokkosBlas::Impl::OpID>;
+    Op op;
+    auto r      = h_c(i) * h_a_init(i) + h_s(i) * h_b_init(i);
+    auto z      = h_c(i) * h_b_init(i) - op(h_s(i)) * h_a_init(i);
+    SType r_ref = Kokkos::sqrt(Kokkos::abs(h_a_init(i)) * Kokkos::abs(h_a_init(i)) +
+                               Kokkos::abs(h_b_init(i)) * Kokkos::abs(h_b_init(i)));
+    if constexpr (KokkosKernels::ArithTraits<SType>::is_complex) {
+      if (Kokkos::abs(h_a_init(i)) == KokkosKernels::ArithTraits<SType>::zero()) {
+        r_ref = Kokkos::abs(h_b_init(i));
+      } else {
+        r_ref *= h_a_init(i) / Kokkos::abs(h_a_init(i));
+      }
+    } else {
+      auto sign = (Kokkos::abs(h_a_init(i)) > Kokkos::abs(h_b_init(i))) ? h_a_init(i) : h_b_init(i);
+      r_ref     = Kokkos::copysign(r_ref, sign);
+    }
+    EXPECT_NEAR_KK(r, r_ref, eps);
+    EXPECT_NEAR_KK(z, 0.0, eps);
+
+    auto a_ref = r_ref;
+    auto b_ref = h_b_init(i);
+
+    // b is updated only for the real case
+    if constexpr (!KokkosKernels::ArithTraits<SType>::is_complex) {
+      if (Kokkos::abs(h_a_init(i)) > Kokkos::abs(h_b_init(i))) {
+        b_ref = h_s(i);
+      } else if (h_c(i) != 0) {
+        b_ref = KokkosKernels::ArithTraits<SType>::one() / h_c(i);
+      } else {
+        b_ref = KokkosKernels::ArithTraits<SType>::one();
+      }
+    }
+
+    EXPECT_NEAR_KK(h_a(i), a_ref, eps);
+    EXPECT_NEAR_KK(h_b(i), b_ref, eps);
+  }
+}
+
+template <typename DeviceType, typename SType, typename LayoutType>
+void impl_test_batched_rotg(const std::size_t Nb) {
+  using MType = typename KokkosKernels::ArithTraits<SType>::mag_type;
+  // Test with analytical values
+  constexpr auto pi = Kokkos::numbers::pi_v<MType>;
+  MType c_ref       = Kokkos::cos(pi / 6.0);
+  SType s_ref       = Kokkos::sin(pi / 6.0);
+  SType r           = 2.5;  // scaling factor
+  if constexpr (KokkosKernels::ArithTraits<SType>::is_complex) {
+    r = SType(2.5, 2.0);
+  }
+  SType a_in = r * c_ref;
+  SType b_in = r * s_ref;
+  impl_test_batched_rotg_analytical<DeviceType, LayoutType, SType, MType>(Nb, a_in, b_in, c_ref, s_ref);
+
+  // Test with a == 0
+  a_in  = SType(0);
+  b_in  = 3.0;
+  c_ref = 0.0;
+  s_ref = 1.0;
+  if constexpr (KokkosKernels::ArithTraits<SType>::is_complex) {
+    b_in  = SType(3.0, 4.0);
+    s_ref = SType(0.6, -0.8);  // s_ref should be conj(b_in) / |b_in| when a == 0
+  }
+  impl_test_batched_rotg_analytical<DeviceType, LayoutType, SType, MType>(Nb, a_in, b_in, c_ref, s_ref);
+
+  // Test with b == 0
+  a_in  = 4.0;
+  b_in  = 0.0;
+  c_ref = 1.0;
+  s_ref = 0.0;
+  if constexpr (KokkosKernels::ArithTraits<SType>::is_complex) {
+    a_in = SType(4.0, 5.0);
+  }
+  impl_test_batched_rotg_analytical<DeviceType, LayoutType, SType, MType>(Nb, a_in, b_in, c_ref, s_ref);
+
+  // Test with random values
+  impl_test_batched_rotg_random<DeviceType, LayoutType, SType, MType>(Nb);
+}
+
+}  // namespace Rotg
+}  // namespace Test
+
+template <typename DeviceType, typename ScalarType>
+int test_batched_rotg() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
+  {
+    using LayoutType = Kokkos::LayoutLeft;
+    for (int i = 1; i < 3; i++) {
+      Test::Rotg::impl_test_batched_rotg<DeviceType, ScalarType, LayoutType>(i);
+    }
+  }
+#endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
+  {
+    using LayoutType = Kokkos::LayoutRight;
+    for (int i = 1; i < 3; i++) {
+      Test::Rotg::impl_test_batched_rotg<DeviceType, ScalarType, LayoutType>(i);
+    }
+  }
+#endif
+
+  return 0;
+}
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+TEST_F(TestCategory, test_batched_rotg_float) { test_batched_rotg<TestDevice, float>(); }
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+TEST_F(TestCategory, test_batched_rotg_double) { test_batched_rotg<TestDevice, double>(); }
+#endif
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_FLOAT)
+TEST_F(TestCategory, test_batched_rotg_fcomplex) { test_batched_rotg<TestDevice, Kokkos::complex<float>>(); }
+#endif
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
+TEST_F(TestCategory, test_batched_rotg_dcomplex) { test_batched_rotg<TestDevice, Kokkos::complex<double>>(); }
+#endif

--- a/blas/impl/KokkosBlas1_rotg_impl.hpp
+++ b/blas/impl/KokkosBlas1_rotg_impl.hpp
@@ -10,62 +10,87 @@
 namespace KokkosBlas {
 namespace Impl {
 
-template <class Scalar, class Magnitude,
-          typename std::enable_if<!KokkosKernels::ArithTraits<Scalar>::is_complex, bool>::type = true>
-KOKKOS_INLINE_FUNCTION void rotg_impl(Scalar* a, Scalar* b, Magnitude* c, Scalar* s) {
-  const Scalar one  = KokkosKernels::ArithTraits<Scalar>::one();
-  const Scalar zero = KokkosKernels::ArithTraits<Scalar>::zero();
+/// \brief Compute Givens rotation coefficients for real scalars.
+/// \tparam Scalar The real scalar type for a and b
+/// \tparam Magnitude The real scalar type for c
+/// \param[in,out] a The first scalar, overwritten by the first rotation coefficient
+/// \param[in,out] b The second scalar, overwritten by the second rotation coefficient
+/// \param[out] c The cosine of the rotation
+/// \param[out] s The sine of the rotation
+template <class Scalar, class Magnitude>
+  requires(!KokkosKernels::ArithTraits<Scalar>::is_complex)
+KOKKOS_INLINE_FUNCTION void rotg_impl(Scalar* KOKKOS_RESTRICT a, Scalar* KOKKOS_RESTRICT b,
+                                      Magnitude* KOKKOS_RESTRICT c, Scalar* KOKKOS_RESTRICT s) {
+  const Scalar one   = KokkosKernels::ArithTraits<Scalar>::one();
+  const Scalar zero  = KokkosKernels::ArithTraits<Scalar>::zero();
+  const Scalar anorm = Kokkos::abs(*a);
+  const Scalar bnorm = Kokkos::abs(*b);
 
-  const Scalar numerical_scaling = Kokkos::abs(*a) + Kokkos::abs(*b);
-  if (numerical_scaling == zero) {
+  if (bnorm == zero) {
     *c = one;
     *s = zero;
-    *a = zero;
     *b = zero;
-  } else {
-    const Scalar scaled_a = *a / numerical_scaling;
-    const Scalar scaled_b = *b / numerical_scaling;
-    Scalar norm           = Kokkos::sqrt(scaled_a * scaled_a + scaled_b * scaled_b) * numerical_scaling;
-    Scalar sign           = Kokkos::abs(*a) > Kokkos::abs(*b) ? *a : *b;
-    norm                  = Kokkos::copysign(norm, sign);
-    *c                    = *a / norm;
-    *s                    = *b / norm;
-
-    Scalar z = one;
-    if (Kokkos::abs(*a) > Kokkos::abs(*b)) {
-      z = *s;
-    }
-    if ((Kokkos::abs(*b) >= Kokkos::abs(*a)) && (*c != zero)) {
-      z = one / *c;
-    }
-    *a = norm;
-    *b = z;
+    return;
   }
+
+  if (anorm == zero) {
+    *c = zero;
+    *s = one;
+    *a = bnorm;
+    *b = one;
+    return;
+  }
+
+  const Scalar scale = anorm + bnorm;
+  const Scalar sign  = anorm > bnorm ? *a : *b;
+  Scalar norm        = scale * Kokkos::hypot(*a / scale, *b / scale);
+  norm               = Kokkos::copysign(norm, sign);
+
+  *c = *a / norm;
+  *s = *b / norm;
+  if (anorm > bnorm) {
+    *b = *s;
+  } else if (*c != zero) {
+    *b = one / *c;
+  } else {
+    *b = one;
+  }
+  *a = norm;
 }
 
-template <class Scalar, class Magnitude,
-          typename std::enable_if<KokkosKernels::ArithTraits<Scalar>::is_complex, bool>::type = true>
-KOKKOS_INLINE_FUNCTION void rotg_impl(Scalar* a, Scalar* b, Magnitude* c, Scalar* s) {
-  using mag_type = typename KokkosKernels::ArithTraits<Scalar>::mag_type;
+/// \brief Compute Givens rotation coefficients for complex scalars.
+/// \tparam Scalar The complex scalar type for a and b
+/// \tparam Magnitude The real scalar type for c
+/// \param[in,out] a The first scalar, overwritten by the first rotation coefficient
+/// \param[in] b The second scalar
+/// \param[out] c The cosine of the rotation
+/// \param[out] s The sine of the rotation
+template <class Scalar, class Magnitude>
+  requires KokkosKernels::ArithTraits<Scalar>::is_complex
+KOKKOS_INLINE_FUNCTION void rotg_impl(Scalar* KOKKOS_RESTRICT a, const Scalar* KOKKOS_RESTRICT b,
+                                      Magnitude* KOKKOS_RESTRICT c, Scalar* KOKKOS_RESTRICT s) {
+  using mag_type    = typename KokkosKernels::ArithTraits<Scalar>::mag_type;
+  const Scalar zero = KokkosKernels::ArithTraits<Scalar>::zero();
 
-  const Scalar one        = KokkosKernels::ArithTraits<Scalar>::one();
-  const Scalar zero       = KokkosKernels::ArithTraits<Scalar>::zero();
-  const mag_type mag_zero = KokkosKernels::ArithTraits<mag_type>::zero();
-
-  const mag_type numerical_scaling = Kokkos::abs(*a) + Kokkos::abs(*b);
-  if (Kokkos::abs(*a) == zero) {
-    *c = mag_zero;
-    *s = one;
-    *a = *b;
-  } else {
-    const Scalar scaled_a = Kokkos::abs(*a / numerical_scaling);
-    const Scalar scaled_b = Kokkos::abs(*b / numerical_scaling);
-    mag_type norm         = Kokkos::abs(Kokkos::sqrt(scaled_a * scaled_a + scaled_b * scaled_b)) * numerical_scaling;
-    Scalar unit_a         = *a / Kokkos::abs(*a);
-    *c                    = Kokkos::abs(*a) / norm;
-    *s                    = unit_a * Kokkos::conj(*b) / norm;
-    *a                    = unit_a * norm;
+  if (Kokkos::abs(*b) == zero) {
+    *c = KokkosKernels::ArithTraits<mag_type>::one();
+    *s = zero;
+    return;
   }
+
+  if (Kokkos::abs(*a) == zero) {
+    *c = KokkosKernels::ArithTraits<mag_type>::zero();
+    *s = Kokkos::conj(*b) / Kokkos::abs(*b);
+    *a = Scalar(Kokkos::abs(*b));
+    return;
+  }
+
+  const mag_type scale = Kokkos::abs(*a) + Kokkos::abs(*b);
+  const mag_type norm  = scale * Kokkos::hypot(Kokkos::abs(*a) / scale, Kokkos::abs(*b) / scale);
+  const Scalar unit_a  = *a / Kokkos::abs(*a);
+  *c                   = Kokkos::abs(*a) / norm;
+  *s                   = unit_a * Kokkos::conj(*b) / norm;
+  *a                   = unit_a * norm;
 }
 
 template <class SViewType, class MViewType>


### PR DESCRIPTION
This PR aims at adding a batched interface for [rotg](https://www.netlib.org/lapack/explore-html/d7/dc5/group__rotg_gaafa91c51f75df6c3f2182032a221c2db.html#gaafa91c51f75df6c3f2182032a221c2db). 
Discussing points

1. Should we update the `b` value? It is updated only by (s/d)rotg but not with (c/z)rotg. It is unclear this value can be used in reality. 
2. Should we manage more carefully the cases for extremely small `a` and `b`?  This kernel can overflow in the current implementation.

- [x] Refactor `rotg_impl` under blas
- [x] Add batched interface `Rotg`. `SerialRotg` and `TeamRotg` are not added because this kernel works only on scalars without any parallelization
- [x] Tests introduced under batched (under blas tests are commented out for some reason)