### PR TITLE
Add option to conjugate values to sparse matrix transpose

### DIFF
--- a/sparse/src/KokkosSparse_Utils.hpp
+++ b/sparse/src/KokkosSparse_Utils.hpp
@@ -4,6 +4,7 @@
 #define KOKKOSKERNELS_SPARSEUTILS_HPP
 #include <vector>
 
+#include "KokkosKernels_ArithTraits.hpp"
 #include "Kokkos_Core.hpp"
 #include "KokkosKernels_SimpleUtils.hpp"
 #include "KokkosKernels_IOUtils.hpp"
@@ -230,7 +231,8 @@ void kk_create_bsr_from_bsr_formatted_point_crs(int block_size, size_t num_rows,
 }
 
 template <typename in_row_view_t, typename in_nnz_view_t, typename in_scalar_view_t, typename out_row_view_t,
-          typename out_nnz_view_t, typename out_scalar_view_t, typename MyExecSpace, bool transpose_values>
+          typename out_nnz_view_t, typename out_scalar_view_t, typename MyExecSpace, bool transpose_values,
+          bool conjugate_values>
 struct TransposeMatrix {
   struct CountTag {};
   struct FillTag {};
@@ -243,6 +245,8 @@ struct TransposeMatrix {
 
   using nnz_lno_t = typename in_nnz_view_t::non_const_value_type;
   using size_type = typename in_row_view_t::non_const_value_type;
+
+  using KAT = KokkosKernels::ArithTraits<typename in_scalar_view_t::non_const_value_type>;
 
   nnz_lno_t num_rows;
   nnz_lno_t num_cols;
@@ -306,7 +310,11 @@ struct TransposeMatrix {
 
                              t_adj(pos) = row_index;
                              if constexpr (transpose_values) {
-                               t_vals(pos) = vals[adjind];
+                               if constexpr (conjugate_values) {
+                                 t_vals(pos) = KAT::conj(vals[adjind]);
+                               } else {
+                                 t_vals(pos) = vals[adjind];
+                               }
                              }
                            });
                            //}
@@ -319,18 +327,10 @@ template <typename in_row_view_t, typename in_nnz_view_t, typename in_scalar_vie
 void transpose_matrix(typename in_nnz_view_t::non_const_value_type num_rows,
                       typename in_nnz_view_t::non_const_value_type num_cols, in_row_view_t xadj, in_nnz_view_t adj,
                       in_scalar_view_t vals,
-                      out_row_view_t t_xadj,    // pre-allocated -- initialized with 0
-                      out_nnz_view_t t_adj,     // pre-allocated -- no need for initialize
-                      out_scalar_view_t t_vals  // pre-allocated -- no need for initialize
-) {
-  // create the functor for transpose.
-  typedef TransposeMatrix<in_row_view_t, in_nnz_view_t, in_scalar_view_t, out_row_view_t, out_nnz_view_t,
-                          out_scalar_view_t, MyExecSpace, true>
-      TransposeFunctor_t;
-
-  typedef typename TransposeFunctor_t::team_count_policy_t count_tp_t;
-  typedef typename TransposeFunctor_t::team_fill_policy_t fill_tp_t;
-
+                      out_row_view_t t_xadj,     // pre-allocated -- initialized with 0
+                      out_nnz_view_t t_adj,      // pre-allocated -- no need for initialize
+                      out_scalar_view_t t_vals,  // pre-allocated -- no need for initialize
+                      const bool conjugate_values = false) {
   typename in_row_view_t::non_const_value_type nnz = adj.extent(0);
 
   // determine vector lanes per thread
@@ -340,21 +340,48 @@ void transpose_matrix(typename in_nnz_view_t::non_const_value_type num_rows,
   // determine threads per team
   int team_size = kk_get_suggested_team_size(thread_size, KokkosKernels::Impl::kk_get_exec_space_type<MyExecSpace>());
 
-  TransposeFunctor_t tm(num_rows, num_cols, xadj, adj, vals, t_xadj, t_adj, t_vals, team_size);
+  if (!conjugate_values) {
+    // create the functor for transpose.
+    typedef TransposeMatrix<in_row_view_t, in_nnz_view_t, in_scalar_view_t, out_row_view_t, out_nnz_view_t,
+                            out_scalar_view_t, MyExecSpace, true, false>
+        TransposeFunctor_t;
 
-  Kokkos::parallel_for("KokkosSparse::Impl::transpose_matrix::S0",
-                       count_tp_t((num_rows + team_size - 1) / team_size, team_size, thread_size), tm);
+    typedef typename TransposeFunctor_t::team_count_policy_t count_tp_t;
+    typedef typename TransposeFunctor_t::team_fill_policy_t fill_tp_t;
 
-  KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<MyExecSpace>(num_cols + 1, t_xadj);
+    TransposeFunctor_t tm(num_rows, num_cols, xadj, adj, vals, t_xadj, t_adj, t_vals, team_size);
 
-  Kokkos::parallel_for("KokkosSparse::Impl::transpose_matrix::S1",
-                       fill_tp_t((num_rows + team_size - 1) / team_size, team_size, thread_size), tm);
+    Kokkos::parallel_for("KokkosSparse::Impl::transpose_matrix::S0",
+                         count_tp_t((num_rows + team_size - 1) / team_size, team_size, thread_size), tm);
 
+    KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<MyExecSpace>(num_cols + 1, t_xadj);
+
+    Kokkos::parallel_for("KokkosSparse::Impl::transpose_matrix::S1",
+                         fill_tp_t((num_rows + team_size - 1) / team_size, team_size, thread_size), tm);
+  } else {
+    // create the functor for transpose.
+    typedef TransposeMatrix<in_row_view_t, in_nnz_view_t, in_scalar_view_t, out_row_view_t, out_nnz_view_t,
+                            out_scalar_view_t, MyExecSpace, true, true>
+        TransposeFunctor_t;
+
+    typedef typename TransposeFunctor_t::team_count_policy_t count_tp_t;
+    typedef typename TransposeFunctor_t::team_fill_policy_t fill_tp_t;
+
+    TransposeFunctor_t tm(num_rows, num_cols, xadj, adj, vals, t_xadj, t_adj, t_vals, team_size);
+
+    Kokkos::parallel_for("KokkosSparse::Impl::transpose_matrix::S0",
+                         count_tp_t((num_rows + team_size - 1) / team_size, team_size, thread_size), tm);
+
+    KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<MyExecSpace>(num_cols + 1, t_xadj);
+
+    Kokkos::parallel_for("KokkosSparse::Impl::transpose_matrix::S1",
+                         fill_tp_t((num_rows + team_size - 1) / team_size, team_size, thread_size), tm);
+  }
   MyExecSpace().fence();
 }
 
 template <typename crsMat_t>
-crsMat_t transpose_matrix(const crsMat_t &A) {
+crsMat_t transpose_matrix(const crsMat_t &A, const bool conjugate_values = false) {
   // Allocate views and call the other version of transpose_matrix
   using c_rowmap_t  = typename crsMat_t::row_map_type;
   using c_entries_t = typename crsMat_t::index_type;
@@ -367,7 +394,7 @@ crsMat_t transpose_matrix(const crsMat_t &A) {
   values_t AT_values(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Transpose values"), A.nnz());
   transpose_matrix<c_rowmap_t, c_entries_t, c_values_t, rowmap_t, entries_t, values_t, rowmap_t,
                    typename crsMat_t::execution_space>(A.numRows(), A.numCols(), A.graph.row_map, A.graph.entries,
-                                                       A.values, AT_rowmap, AT_entries, AT_values);
+                                                       A.values, AT_rowmap, AT_entries, AT_values, conjugate_values);
   // And construct the transpose crsMat_t
   return crsMat_t("Transpose", A.numCols(), A.numRows(), A.nnz(), AT_values, AT_rowmap, AT_entries);
 }
@@ -384,7 +411,7 @@ void transpose_graph(typename in_nnz_view_t::non_const_value_type num_rows,
 
   // create the functor for transpose.
   typedef TransposeMatrix<in_row_view_t, in_nnz_view_t, in_nnz_view_t, out_row_view_t, out_nnz_view_t, out_nnz_view_t,
-                          MyExecSpace, false>
+                          MyExecSpace, false, false>
       TransposeFunctor_t;
 
   typedef typename TransposeFunctor_t::team_count_policy_t count_tp_t;

--- a/sparse/unit_test/Test_Sparse_Transpose.hpp
+++ b/sparse/unit_test/Test_Sparse_Transpose.hpp
@@ -14,6 +14,7 @@
 #include <KokkosKernels_default_types.hpp>
 #include <KokkosSparse_CrsMatrix.hpp>
 #include <KokkosSparse_SortCrs.hpp>
+#include "KokkosKernels_ArithTraits.hpp"
 
 template <typename size_type, typename V>
 struct ExactCompare {
@@ -27,11 +28,10 @@ struct ExactCompare {
   V v2;
 };
 
-template <typename device_t>
+template <typename device_t, typename scalar_t>
 void testTranspose(int numRows, int numCols, bool doValues) {
   using exec_space  = typename device_t::execution_space;
   using range_pol   = Kokkos::RangePolicy<exec_space>;
-  using scalar_t    = KokkosKernels::default_scalar;
   using lno_t       = KokkosKernels::default_lno_t;
   using size_type   = KokkosKernels::default_size_type;
   using crsMat_t    = typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device_t, void, size_type>;
@@ -86,6 +86,43 @@ void testTranspose(int numRows, int numCols, bool doValues) {
     Kokkos::parallel_reduce(range_pol(0, input_mat.nnz()),
                             ExactCompare<size_type, values_t>(input_mat.values, tt_values), valuesDiffs);
     EXPECT_EQ(size_type(0), valuesDiffs);
+  }
+
+  if constexpr (std::is_same<scalar_t, kokkos_complex_double>::value) {
+    using KAT = KokkosKernels::ArithTraits<scalar_t>;
+    if (doValues && KAT::isComplex) {
+      // sort the non-conjugated transpose
+      KokkosSparse::sort_crs_matrix<exec_space, c_rowmap_t, entries_t, values_t>(t_rowmap, t_entries, t_values);
+      auto j = scalar_t(0, 1);
+      // Multiply input values by j.
+      // Copy tranpose matrix data and apply conjugation.
+      rowmap_t t_rowmap_conj("Rowmap^H", numCols + 1);
+      entries_t t_entries_conj(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Entries^T"),
+                               input_mat.graph.entries.extent(0));
+      values_t t_values_conj(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Values^H"), input_mat.values.extent(0));
+      values_t t_values_conj_correct(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Values^H"),
+                                     input_mat.values.extent(0));
+      Kokkos::parallel_for(
+          range_pol(0, input_mat.nnz()), KOKKOS_LAMBDA(const size_type i) {
+            input_mat.values(i)      = j * input_mat.values(i);
+            t_values_conj_correct(i) = KAT::conj(j * t_values(i));
+          });
+      // Transpose matrix with conjugation
+      KokkosSparse::Impl::transpose_matrix<c_rowmap_t, c_entries_t, c_values_t, rowmap_t, entries_t, values_t, rowmap_t,
+                                           exec_space>(numRows, numCols, input_mat.graph.row_map,
+                                                       input_mat.graph.entries, input_mat.values, t_rowmap_conj,
+                                                       t_entries_conj, t_values_conj, true);
+      // sort the conjugated transpose
+      KokkosSparse::sort_crs_matrix<exec_space, c_rowmap_t, entries_t, values_t>(t_rowmap_conj, t_entries_conj,
+                                                                                 t_values_conj);
+      {
+        // Check values
+        size_type valuesDiffs;
+        Kokkos::parallel_reduce(range_pol(0, input_mat.nnz()),
+                                ExactCompare<size_type, values_t>(t_values_conj, t_values_conj_correct), valuesDiffs);
+        EXPECT_EQ(size_type(0), valuesDiffs);
+      }
+    }
   }
 }
 
@@ -231,27 +268,37 @@ void testTransposeBsr(int numRows, int numCols, int blockSize) {
 
 TEST_F(TestCategory, sparse_transpose_matrix) {
   // Test both matrix and graph transpose with various sizes
-  testTranspose<TestDevice>(0, 0, true);
-  testTranspose<TestDevice>(100, 0, true);
-  testTranspose<TestDevice>(0, 100, true);
-  testTranspose<TestDevice>(100, 100, true);
-  testTranspose<TestDevice>(500, 50, true);
-  testTranspose<TestDevice>(50, 500, true);
-  testTranspose<TestDevice>(4000, 2000, true);
-  testTranspose<TestDevice>(2000, 4000, true);
-  testTranspose<TestDevice>(2000, 2000, true);
+  testTranspose<TestDevice, KokkosKernels::default_scalar>(0, 0, true);
+  testTranspose<TestDevice, KokkosKernels::default_scalar>(100, 0, true);
+  testTranspose<TestDevice, KokkosKernels::default_scalar>(0, 100, true);
+  testTranspose<TestDevice, KokkosKernels::default_scalar>(100, 100, true);
+  testTranspose<TestDevice, KokkosKernels::default_scalar>(500, 50, true);
+  testTranspose<TestDevice, KokkosKernels::default_scalar>(50, 500, true);
+  testTranspose<TestDevice, KokkosKernels::default_scalar>(4000, 2000, true);
+  testTranspose<TestDevice, KokkosKernels::default_scalar>(2000, 4000, true);
+  testTranspose<TestDevice, KokkosKernels::default_scalar>(2000, 2000, true);
+
+  testTranspose<TestDevice, kokkos_complex_double>(0, 0, true);
+  testTranspose<TestDevice, kokkos_complex_double>(100, 0, true);
+  testTranspose<TestDevice, kokkos_complex_double>(0, 100, true);
+  testTranspose<TestDevice, kokkos_complex_double>(100, 100, true);
+  testTranspose<TestDevice, kokkos_complex_double>(500, 50, true);
+  testTranspose<TestDevice, kokkos_complex_double>(50, 500, true);
+  testTranspose<TestDevice, kokkos_complex_double>(4000, 2000, true);
+  testTranspose<TestDevice, kokkos_complex_double>(2000, 4000, true);
+  testTranspose<TestDevice, kokkos_complex_double>(2000, 2000, true);
 }
 
 TEST_F(TestCategory, sparse_transpose_graph) {
-  testTranspose<TestDevice>(0, 0, false);
-  testTranspose<TestDevice>(100, 0, false);
-  testTranspose<TestDevice>(0, 100, false);
-  testTranspose<TestDevice>(100, 100, false);
-  testTranspose<TestDevice>(500, 50, false);
-  testTranspose<TestDevice>(50, 500, false);
-  testTranspose<TestDevice>(4000, 2000, false);
-  testTranspose<TestDevice>(2000, 4000, false);
-  testTranspose<TestDevice>(2000, 2000, false);
+  testTranspose<TestDevice, KokkosKernels::default_scalar>(0, 0, false);
+  testTranspose<TestDevice, KokkosKernels::default_scalar>(100, 0, false);
+  testTranspose<TestDevice, KokkosKernels::default_scalar>(0, 100, false);
+  testTranspose<TestDevice, KokkosKernels::default_scalar>(100, 100, false);
+  testTranspose<TestDevice, KokkosKernels::default_scalar>(500, 50, false);
+  testTranspose<TestDevice, KokkosKernels::default_scalar>(50, 500, false);
+  testTranspose<TestDevice, KokkosKernels::default_scalar>(4000, 2000, false);
+  testTranspose<TestDevice, KokkosKernels::default_scalar>(2000, 4000, false);
+  testTranspose<TestDevice, KokkosKernels::default_scalar>(2000, 2000, false);
 }
 
 TEST_F(TestCategory, sparse_transpose_bsr_matrix) {


### PR DESCRIPTION
Adds an optional parameter to the sparse matrix transpose that allows to conjugate the values at the same time. The default behavior does not change. 

#3035

Also see https://github.com/trilinos/Trilinos/pull/15201