### PR TITLE
Benchmarks: fixing command line parameters for backend

### DIFF
--- a/benchmarks/KokkosKernels_benchmark_utilities.hpp
+++ b/benchmarks/KokkosKernels_benchmark_utilities.hpp
@@ -14,11 +14,12 @@
 namespace benchmark {
 
 struct CommonInputParams {
-  int use_cuda    = 0;
-  int use_hip     = 0;
-  int use_sycl    = 0;
-  int use_openmp  = 0;
-  int use_threads = 0;
+  bool use_cuda    = false;
+  bool use_hip     = false;
+  bool use_sycl    = false;
+  bool use_openmp  = false;
+  bool use_threads = false;
+  bool use_serial  = false;
 
   int repeat      = 0;
   bool print_help = false;
@@ -26,48 +27,50 @@ struct CommonInputParams {
 
 std::string list_common_options() {
   std::ostringstream common_options;
-  common_options << "\t[Required] Backend: the available backends are:\n"
+  common_options << "\t[Required]:\n"
+                 << "\t[Optional]:\n"
+                 << "\t The following backends are available because Kokkos was "
+                    "configured with them:\n"
 #ifdef KOKKOS_ENABLE_THREADS
-                 << "\t\t'--threads [numThreads]'\n"
+                 << "\t\t'--threads'\n"
 #endif
 #ifdef KOKKOS_ENABLE_OPENMP
-                 << "\t\t'--openmp [numThreads]'\n"
+                 << "\t\t'--openmp'\n"
 #endif
 #ifdef KOKKOS_ENABLE_CUDA
-                 << "\t\t'--cuda [deviceIndex]'\n"
+                 << "\t\t'--cuda'\n"
 #endif
 #ifdef KOKKOS_ENABLE_HIP
-                 << "\t\t'--hip [deviceIndex]'\n"
+                 << "\t\t'--hip'\n"
 #endif
 #ifdef KOKKOS_ENABLE_SYCL
-                 << "\t\t'--sycl [deviceIndex]'\n"
+                 << "\t\t'--sycl'\n"
 #endif
 #ifdef KOKKOS_ENABLE_SERIAL
-                 << "\t\tIf no parallel backend is requested, Serial will be used.\n"
+                 << "\t\t'--serial'\n"
 #endif
                  << "\n"
                  << "\t The following backends are not available because Kokkos was not "
                     "configured with them:\n"
 #ifndef KOKKOS_ENABLE_THREADS
-                 << "\t\t'--threads [numThreads]'\n"
+                 << "\t\t'--threads'\n"
 #endif
 #ifndef KOKKOS_ENABLE_OPENMP
-                 << "\t\t'--openmp [numThreads]'\n"
+                 << "\t\t'--openmp'\n"
 #endif
 #ifndef KOKKOS_ENABLE_CUDA
-                 << "\t\t'--cuda [deviceIndex]'\n"
+                 << "\t\t'--cuda'\n"
 #endif
 #ifndef KOKKOS_ENABLE_HIP
-                 << "\t\t'--hip [deviceIndex]'\n"
+                 << "\t\t'--hip'\n"
 #endif
 #ifndef KOKKOS_ENABLE_SYCL
-                 << "\t\t'--sycl [deviceIndex]'\n"
+                 << "\t\t'--sycl'\n"
 #endif
 #ifndef KOKKOS_ENABLE_SERIAL
-                 << "\t\tSerial is not enabled so a parallel backend must be selected.\n"
+                 << "\t\t'--serial'\n"
 #endif
                  << "\n"
-                 << "\t[Optional]:\n"
                  << "\t\t'-h', '--help': show available options\n\n";
 
   return common_options.str();
@@ -165,28 +168,24 @@ bool check_arg_str(int const i, int const argc, char** argv, char const* name, s
 void parse_common_options(int& argc, char** argv, CommonInputParams& params) {
   // Skip the program name, start with argIdx=1
   int argIdx = 1;
-  // Note: after parsing a GPU device ID, always add 1 to it.
-  // If e.g. params.use_cuda is 0, that means CUDA will not be used at all.
-  // But if it's N, then it means run on CUDA device N-1.
   while (argIdx < argc) {
     // How many flags to delete from argc/argv
     // 0: not a common option, so leave it
-    // 1: a bool parameter like '-h'
-    // 2: a parameter followed by a value, like "--cuda 0"
+    // 1: a bool parameter like '-h or --cuda'
+    // 2: a parameter followed by a value, like "--repeat 3"
     int remove_flags = 0;
-    if (check_arg_int(argIdx, argc, argv, "--threads", params.use_threads)) {
-      remove_flags = 2;
-    } else if (check_arg_int(argIdx, argc, argv, "--openmp", params.use_openmp)) {
-      remove_flags = 2;
-    } else if (check_arg_int(argIdx, argc, argv, "--cuda", params.use_cuda)) {
-      params.use_cuda++;
-      remove_flags = 2;
-    } else if (check_arg_int(argIdx, argc, argv, "--hip", params.use_hip)) {
-      params.use_hip++;
-      remove_flags = 2;
-    } else if (check_arg_int(argIdx, argc, argv, "--sycl", params.use_sycl)) {
-      params.use_sycl++;
-      remove_flags = 2;
+    if (check_arg_bool(argIdx, argc, argv, "--threads", params.use_threads)) {
+      remove_flags = 1;
+    } else if (check_arg_bool(argIdx, argc, argv, "--openmp", params.use_openmp)) {
+      remove_flags = 1;
+    } else if (check_arg_bool(argIdx, argc, argv, "--cuda", params.use_cuda)) {
+      remove_flags = 1;
+    } else if (check_arg_bool(argIdx, argc, argv, "--hip", params.use_hip)) {
+      remove_flags = 1;
+    } else if (check_arg_bool(argIdx, argc, argv, "--sycl", params.use_sycl)) {
+      remove_flags = 1;
+    } else if (check_arg_bool(argIdx, argc, argv, "--serial", params.use_serial)) {
+      remove_flags = 1;
     } else if (check_arg_int(argIdx, argc, argv, "--repeat", params.repeat)) {
       remove_flags = 2;
     } else if (check_arg_bool(argIdx, argc, argv, "-h", params.print_help) ||

--- a/benchmarks/blas/KokkosBlas2_gemv_benchmark.cpp
+++ b/benchmarks/blas/KokkosBlas2_gemv_benchmark.cpp
@@ -132,11 +132,20 @@ int main(int argc, char** argv) {
 
   const auto params = blas2_gemv_params::get_params(argc, argv);
 
+  if (params.use_serial) {
+#if defined(KOKKOS_ENABLE_SERIAL)
+    run<Kokkos::Serial>(params);
+#else
+    std::cout << "ERROR:  Serial requested, but not available.\n";
+    return 1;
+#endif
+  }
+
   if (params.use_threads) {
 #if defined(KOKKOS_ENABLE_THREADS)
     run<Kokkos::Threads>(params);
 #else
-    std::cout << "ERROR:  PThreads requested, but not available.\n";
+    std::cout << "ERROR:  Threads requested, but not available.\n";
     return 1;
 #endif
   }
@@ -177,14 +186,8 @@ int main(int argc, char** argv) {
 #endif
   }
 
-  // use serial if no backend is specified
-  if (!params.use_cuda and !params.use_hip and !params.use_openmp and !params.use_sycl and !params.use_threads) {
-#if defined(KOKKOS_ENABLE_SERIAL)
-    run<Kokkos::Serial>(params);
-#else
-    std::cout << "ERROR: Serial device requested, but not available.\n";
-    return 1;
-#endif
+  if (!params.use_serial and !params.use_threads and !params.use_openmp and !params.use_cuda and !params.use_hip and !params.use_sycl) {
+    run<Kokkos::DefaultExecutionSpace>(params);
   }
 
   benchmark::RunSpecifiedBenchmarks();

--- a/benchmarks/blas/KokkosBlas2_gemv_benchmark.cpp
+++ b/benchmarks/blas/KokkosBlas2_gemv_benchmark.cpp
@@ -186,7 +186,8 @@ int main(int argc, char** argv) {
 #endif
   }
 
-  if (!params.use_serial and !params.use_threads and !params.use_openmp and !params.use_cuda and !params.use_hip and !params.use_sycl) {
+  if (!params.use_serial and !params.use_threads and !params.use_openmp and !params.use_cuda and !params.use_hip and
+      !params.use_sycl) {
     run<Kokkos::DefaultExecutionSpace>(params);
   }
 

--- a/benchmarks/blas/KokkosBlas2_ger_benchmark.cpp
+++ b/benchmarks/blas/KokkosBlas2_ger_benchmark.cpp
@@ -234,13 +234,20 @@ int main(int argc, char** argv) {
 
   const auto params = blas2_ger_params::get_params(argc, argv);
 
-  // std::cout << "In main(): params.repeat = " << params.repeat << std::endl;
+  if (params.use_serial) {
+#if defined(KOKKOS_ENABLE_SERIAL)
+    run<Kokkos::Serial>(params);
+#else
+    std::cout << "ERROR: Serial requested, but not available.\n";
+    return 1;
+#endif
+  }
 
   if (params.use_threads) {
 #if defined(KOKKOS_ENABLE_THREADS)
     run<Kokkos::Threads>(params);
 #else
-    std::cout << "ERROR: PThreads requested, but not available.\n";
+    std::cout << "ERROR: Threads requested, but not available.\n";
     return 1;
 #endif
   }
@@ -281,14 +288,8 @@ int main(int argc, char** argv) {
 #endif
   }
 
-  // use serial if no backend is specified
-  if (!params.use_cuda && !params.use_hip && !params.use_openmp && !params.use_sycl && !params.use_threads) {
-#if defined(KOKKOS_ENABLE_SERIAL)
-    run<Kokkos::Serial>(params);
-#else
-    std::cout << "ERROR: Serial device requested, but not available.\n";
-    return 1;
-#endif
+  if (!params.use_cuda && !params.use_hip && !params.use_sycl && !params.use_openmp && !params.use_threads && !params.use_serial) {
+    run<Kokkos::DefaultExecutionSpace>(params);
   }
 
   benchmark::RunSpecifiedBenchmarks();

--- a/benchmarks/blas/KokkosBlas2_ger_benchmark.cpp
+++ b/benchmarks/blas/KokkosBlas2_ger_benchmark.cpp
@@ -288,7 +288,8 @@ int main(int argc, char** argv) {
 #endif
   }
 
-  if (!params.use_cuda && !params.use_hip && !params.use_sycl && !params.use_openmp && !params.use_threads && !params.use_serial) {
+  if (!params.use_cuda && !params.use_hip && !params.use_sycl && !params.use_openmp && !params.use_threads &&
+      !params.use_serial) {
     run<Kokkos::DefaultExecutionSpace>(params);
   }
 

--- a/benchmarks/blas/KokkosBlas3_gemm_benchmark.cpp
+++ b/benchmarks/blas/KokkosBlas3_gemm_benchmark.cpp
@@ -175,7 +175,8 @@ int main(int argc, char** argv) {
 #endif
   }
 
-  if (!params.use_cuda && !params.use_hip && !params.use_sycl && !params.use_openmp && !params.use_threads && !params.use_serial) {
+  if (!params.use_cuda && !params.use_hip && !params.use_sycl && !params.use_openmp && !params.use_threads &&
+      !params.use_serial) {
     run<Kokkos::DefaultExecutionSpace>(params);
   }
 

--- a/benchmarks/blas/KokkosBlas3_gemm_benchmark.cpp
+++ b/benchmarks/blas/KokkosBlas3_gemm_benchmark.cpp
@@ -112,30 +112,29 @@ void run(const blas3_gemm_params& params) {
 }
 
 int main(int argc, char** argv) {
-  const auto params     = blas3_gemm_params::get_params(argc, argv);
-  const int num_threads = params.use_openmp;
-
-  // the common parameter parser takes the requested device ID and
-  // adds 1 to it (e.g. --cuda 0 -> params.use_cuda = 1)
-  // this is presumably so that 0 can be a sentinel value,
-  // even though device ID 0 is valid
-  // here, we use CUDA, SYCL, or HIP, whichever is set first, to
-  // choose which device Kokkos should initialize on
-  // or -1, for no such selection
-  const int device_id = params.use_cuda
-                            ? params.use_cuda - 1
-                            : (params.use_sycl ? params.use_sycl - 1 : (params.use_hip ? params.use_hip - 1 : 0));
-
-  Kokkos::initialize(Kokkos::InitializationSettings().set_num_threads(num_threads).set_device_id(device_id));
+  // Ask Kokkos and benchmark to parse their command line arguments
+  Kokkos::initialize(argc, argv);
   benchmark::Initialize(&argc, argv);
   benchmark::SetDefaultTimeUnit(benchmark::kSecond);
   KokkosKernelsBenchmark::add_benchmark_context(true);
+
+  // Now look for command line arguments specific to this benchmark
+  const auto params = blas3_gemm_params::get_params(argc, argv);
+
+  if (params.use_serial) {
+#if defined(KOKKOS_ENABLE_SERIAL)
+    run<Kokkos::Serial>(params);
+#else
+    std::cout << "ERROR: Serial device requested, but not available.\n";
+    return 1;
+#endif
+  }
 
   if (params.use_threads) {
 #if defined(KOKKOS_ENABLE_THREADS)
     run<Kokkos::Threads>(params);
 #else
-    std::cout << "ERROR:  PThreads requested, but not available.\n";
+    std::cout << "ERROR:  Threads requested, but not available.\n";
     return 1;
 #endif
   }
@@ -176,14 +175,8 @@ int main(int argc, char** argv) {
 #endif
   }
 
-  // use serial if no backend is specified
-  if (!params.use_cuda and !params.use_hip and !params.use_openmp and !params.use_sycl and !params.use_threads) {
-#if defined(KOKKOS_ENABLE_SERIAL)
-    run<Kokkos::Serial>(params);
-#else
-    std::cout << "ERROR: Serial device requested, but not available.\n";
-    return 1;
-#endif
+  if (!params.use_cuda && !params.use_hip && !params.use_sycl && !params.use_openmp && !params.use_threads && !params.use_serial) {
+    run<Kokkos::DefaultExecutionSpace>(params);
   }
 
   benchmark::RunSpecifiedBenchmarks();

--- a/benchmarks/lapack/KokkosLapack_SVD_benchmark.cpp
+++ b/benchmarks/lapack/KokkosLapack_SVD_benchmark.cpp
@@ -29,7 +29,7 @@ void print_options() {
   std::cerr << "\t[Optional] --n           :: number of columns of A" << std::endl;
 }  // print_options
 
-int parse_inputs(svd_parameters& params, int argc, char** argv) {
+int parse_inputs(int argc, char** argv, svd_parameters& params) {
   for (int i = 1; i < argc; ++i) {
     if (benchmark::check_arg_int(i, argc, argv, "--m", params.numRows)) {
       ++i;
@@ -80,8 +80,8 @@ int main(int argc, char** argv) {
 
   benchmark::CommonInputParams common_params;
   benchmark::parse_common_options(argc, argv, common_params);
-  svd_parameters svd_params(0, 0, false);
-  parse_inputs(svd_params, argc, argv);
+  svd_parameters svd_params(100, 100, false);
+  parse_inputs(argc, argv, svd_params);
 
   std::string bench_name = "KokkosLapack_SVD";
 


### PR DESCRIPTION
The goal is to rely on kokkos existing clp to decide on which device to run and how many threads to use. Now the user only needs to specify a backend if they want a specific one to be run, otherwise we use the default execution space to decide.

Also small fix for svd benchmark that sets the default matrix size to 100x100 instead of 0x0

These changes should help us make progress on issue #2946
