### PR TITLE
Add long double support to MagnitudeScalarType

### DIFF
--- a/batched/dense/src/KokkosBatched_Vector.hpp
+++ b/batched/dense/src/KokkosBatched_Vector.hpp
@@ -199,6 +199,10 @@ struct MagnitudeScalarType<double> {
   typedef double type;
 };
 template <>
+struct MagnitudeScalarType<long double> {
+  typedef long double type;
+};
+template <>
 struct MagnitudeScalarType<Kokkos::complex<float>> {
   typedef float type;
 };

--- a/batched/dense/src/KokkosBatched_Vector.hpp
+++ b/batched/dense/src/KokkosBatched_Vector.hpp
@@ -220,6 +220,10 @@ struct MagnitudeScalarType<Vector<SIMD<double>, l>> {
   typedef double type;
 };
 template <int l>
+struct MagnitudeScalarType<Vector<SIMD<long double>, l>> {
+  typedef long double type;
+};
+template <int l>
 struct MagnitudeScalarType<Vector<SIMD<Kokkos::complex<float>>, l>> {
   typedef float type;
 };


### PR DESCRIPTION
With this change, I was able to get the par_ilut benchmark to run with long doubles.