### PR TITLE
SpGEMM: cusparse algorithm selection

### DIFF
--- a/sparse/impl/KokkosSparse_spgemm_noreuse_spec.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_noreuse_spec.hpp
@@ -53,7 +53,8 @@ template <class CMatrix, class AMatrix, class BMatrix,
           bool tpl_spec_avail = spgemm_noreuse_tpl_spec_avail<CMatrix, AMatrix, BMatrix>::value,
           bool eti_spec_avail = spgemm_noreuse_eti_spec_avail<CMatrix, AMatrix, BMatrix>::value>
 struct SPGEMM_NOREUSE {
-  static CMatrix spgemm_noreuse(const AMatrix& A, bool transA, const BMatrix& B, bool transB);
+  static CMatrix spgemm_noreuse(KokkosSparse::SPGEMMAlgorithm algo, const AMatrix& A, bool transA, const BMatrix& B,
+                                bool transB);
 };
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
@@ -61,7 +62,8 @@ struct SPGEMM_NOREUSE {
 // Unification layer
 template <class CMatrix, class AMatrix, class BMatrix>
 struct SPGEMM_NOREUSE<CMatrix, AMatrix, BMatrix, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
-  static CMatrix spgemm_noreuse(const AMatrix& A, bool transA, const BMatrix& B, bool transB) {
+  static CMatrix spgemm_noreuse(KokkosSparse::SPGEMMAlgorithm algo, const AMatrix& A, bool transA, const BMatrix& B,
+                                bool transB) {
     using device_t    = typename CMatrix::device_type;
     using scalar_t    = typename CMatrix::value_type;
     using ordinal_t   = typename CMatrix::ordinal_type;
@@ -72,7 +74,7 @@ struct SPGEMM_NOREUSE<CMatrix, AMatrix, BMatrix, false, KOKKOSKERNELS_IMPL_COMPI
     KokkosKernels::Experimental::KokkosKernelsHandle<size_type, ordinal_t, scalar_t, typename device_t::execution_space,
                                                      typename device_t::memory_space, typename device_t::memory_space>
         kh;
-    kh.create_spgemm_handle();
+    kh.create_spgemm_handle(algo);
     // A is m*n, B is n*k, C is m*k
     ordinal_t m = A.numRows();
     ordinal_t n = B.numRows();

--- a/sparse/src/KokkosSparse_spgemm.hpp
+++ b/sparse/src/KokkosSparse_spgemm.hpp
@@ -145,17 +145,20 @@ void block_spgemm_numeric(KernelHandle& kh, const AMatrix& A, const bool Amode, 
 ///
 /// @brief
 ///
-/// @tparam CMatrix
-/// @tparam AMatrix
-/// @tparam BMatrix
-/// @param A
-/// @param Amode
-/// @param B
-/// @param Bmode
-/// @return CMatrix
+/// @tparam CMatrix Result matrix type.
+/// @tparam AMatrix Left input matrix type.
+/// @tparam BMatrix Right input matrix type.
+/// @param algo Algorithm to use.
+/// @param A Left input matrix.
+/// @param Amode Whether to transpose A (only Amode == false is currently supported)
+/// @param B Right input matrix.
+/// @param Bmode Whether to transpose B (only Bmode == false is currently supported)
+/// @param algo Algorithm option to use.
+/// @return CMatrix Product A*B.
 ///
 template <class CMatrix, class AMatrix, class BMatrix>
-CMatrix spgemm(const AMatrix& A, const bool Amode, const BMatrix& B, const bool Bmode) {
+CMatrix spgemm(KokkosSparse::SPGEMMAlgorithm algo, const AMatrix& A, const bool Amode, const BMatrix& B,
+               const bool Bmode) {
   // Canonicalize the matrix types:
   //  - Make A,B have const values and entries.
   //  - Make all views in A,B unmanaged, but otherwise default memory traits
@@ -201,7 +204,25 @@ CMatrix spgemm(const AMatrix& A, const bool Amode, const BMatrix& B, const bool 
   }
   return CMatrix(
       KokkosSparse::Impl::SPGEMM_NOREUSE<CMatrix_Internal, AMatrix_Internal, BMatrix_Internal>::spgemm_noreuse(
-          A_internal, Amode, B_internal, Bmode));
+          algo, A_internal, Amode, B_internal, Bmode));
+}
+
+///
+/// @brief
+///
+/// @tparam CMatrix Result matrix type.
+/// @tparam AMatrix Left input matrix type.
+/// @tparam BMatrix Right input matrix type.
+/// @param A Left input matrix.
+/// @param Amode Whether to transpose A (only Amode == false is currently supported)
+/// @param B Right input matrix.
+/// @param Bmode Whether to transpose B (only Bmode == false is currently supported)
+/// @param algo Algorithm option to use.
+/// @return CMatrix Product A*B.
+///
+template <class CMatrix, class AMatrix, class BMatrix>
+CMatrix spgemm(const AMatrix& A, const bool Amode, const BMatrix& B, const bool Bmode) {
+  return spgemm<CMatrix, AMatrix, BMatrix>(KokkosSparse::SPGEMM_DEFAULT, A, Amode, B, Bmode);
 }
 
 }  // namespace KokkosSparse

--- a/sparse/src/KokkosSparse_spgemm_handle.hpp
+++ b/sparse/src/KokkosSparse_spgemm_handle.hpp
@@ -61,8 +61,29 @@ enum SPGEMMAlgorithm {
   SPGEMM_KK_MEMORY_SPREADTEAM,
   SPGEMM_KK_MEMORY_BIGSPREADTEAM,
   SPGEMM_KK_MEMORY2,
-  SPGEMM_KK_MEMSPEED
+  SPGEMM_KK_MEMSPEED,
+  // Algorithms for specific TPLs
+  SPGEMM_CUSPARSE_DETERMINISTIC,     // Used in SPGEMMreuse, until deprecated in CUDA 13.2.1 (aka cusparse 12.7.10).
+  SPGEMM_CUSPARSE_NONDETERMINISTIC,  //
+  SPGEMM_CUSPARSE_ALG1,              // Added for SPGEMM (non-reuse) in CUDA 12.0.1 (aka cusparse 12.0.1)
+  SPGEMM_CUSPARSE_ALG2,              //
+  SPGEMM_CUSPARSE_ALG3               //
 };
+
+namespace Impl {
+// Helpers to categorize algorithm choices
+inline bool isCuSparseSpgemmAlgorithm(SPGEMMAlgorithm alg) {
+  switch (alg) {
+    case SPGEMM_CUSPARSE_DETERMINISTIC:
+    case SPGEMM_CUSPARSE_NONDETERMINISTIC:
+    case SPGEMM_CUSPARSE_ALG1:
+    case SPGEMM_CUSPARSE_ALG2:
+    case SPGEMM_CUSPARSE_ALG3: return true;
+    default:;
+  }
+  return false;
+}
+}  // namespace Impl
 
 enum SPGEMMAccumulator {
   SPGEMM_ACC_DEFAULT,
@@ -131,11 +152,9 @@ class SPGEMMHandle {
       rocsparse_destroy_mat_descr(descr_D);
     }
   };
-
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
-#if (CUDA_VERSION >= 11000)
   struct cuSparseSpgemmHandleType {
     KokkosKernels::Experimental::Controls kkControls;
     cusparseHandle_t cusparseHandle;
@@ -151,12 +170,56 @@ class SPGEMMHandle {
     size_t bufferSize3, bufferSize4, bufferSize5;
     void *buffer3, *buffer4, *buffer5;
 
-    cuSparseSpgemmHandleType(bool transposeA, bool transposeB) {
+    // If algKK names a cuSparse SpGEMM/SpGEMMreuse algorithm, throw exception if it is not
+    // supported by this version.
+    //
+    // If algCusparse is non-null, also set *algCusparse to the corresponding cuSPARSE algorithm.
+    static void checkAlgorithm(SPGEMMAlgorithm algKK, cusparseSpGEMMAlg_t *algCusparse = nullptr) {
+      cusparseSpGEMMAlg_t result = CUSPARSE_SPGEMM_DEFAULT;
+      switch (algKK) {
+#if (CUSPARSE_VERSION < 12710)
+        // Note: 'determinitic' is the spelling used in cuSPARSE!
+        case SPGEMM_CUSPARSE_DETERMINISTIC: result = CUSPARSE_SPGEMM_CSR_ALG_DETERMINITIC; break;
+        case SPGEMM_CUSPARSE_NONDETERMINISTIC: result = CUSPARSE_SPGEMM_CSR_ALG_NONDETERMINITIC; break;
+#else
+        case SPGEMM_CUSPARSE_DETERMINISTIC:
+        case SPGEMM_CUSPARSE_NONDETERMINISTIC: {
+          std::ostringstream out;
+          out << "cuSPARSE SpGEMMreuse algorithms\n";
+          out << "KokkosSparse::SPGEMM_CUSPARSE_DETERMINISTIC (CUSPARSE_SPGEMM_CSR_ALG_DETERMINITIC) and\n";
+          out << "KokkosSparse::SPGEMM_CUSPARSE_NONDETERMINISTIC (CUSPARSE_SPGEMM_CSR_ALG_NONDETERMINITIC)\n";
+          out << "are deprecated starting in cuSPARSE 12.7.10 (corresponding to CUDA 13.2.1) and not supported by "
+                 "KokkosKernels";
+          throw std::invalid_argument(out.str());
+        }
+#endif
+#if (CUSPARSE_VERSION >= 12001)
+        case SPGEMM_CUSPARSE_ALG1: result = CUSPARSE_SPGEMM_ALG1; break;
+        case SPGEMM_CUSPARSE_ALG2: result = CUSPARSE_SPGEMM_ALG2; break;
+        case SPGEMM_CUSPARSE_ALG3: result = CUSPARSE_SPGEMM_ALG3; break;
+#else
+        case SPGEMM_CUSPARSE_ALG1:
+        case SPGEMM_CUSPARSE_ALG2:
+        case SPGEMM_CUSPARSE_ALG3: {
+          std::ostringstream out;
+          out << "cuSPARSE SpGEMM algorithms KokkosSparse::SPGEMM_CUSPARSE_ALG1, KokkosSparse::SPGEMM_CUSPARSE_ALG2\n";
+          out << "and KokkosSparse::SPGEMM_CUSPARSE_ALG3 are not supported in this version of cuSPARSE";
+          throw std::invalid_argument(out.str());
+        }
+#endif
+        default:;
+      }
+      if (algCusparse) *algCusparse = result;
+    }
+
+    cuSparseSpgemmHandleType(SPGEMMAlgorithm algKK, bool transposeA, bool transposeB) {
       opA        = transposeA ? CUSPARSE_OPERATION_TRANSPOSE : CUSPARSE_OPERATION_NON_TRANSPOSE;
       opB        = transposeB ? CUSPARSE_OPERATION_TRANSPOSE : CUSPARSE_OPERATION_NON_TRANSPOSE;
       scalarType = Impl::cuda_data_type_from<nnz_scalar_t>();
 
-      alg         = CUSPARSE_SPGEMM_DEFAULT;
+      // Validate algKK and (if valid) set this->alg to the corresponding cuSPARSE algorithm enum.
+      checkAlgorithm(algKK, &alg);
+
       bufferSize3 = bufferSize4 = bufferSize5 = 0;
       buffer3 = buffer4 = buffer5 = nullptr;
 
@@ -174,24 +237,6 @@ class SPGEMMHandle {
       KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(buffer5));
     }
   };
-#else
-  struct cuSparseSpgemmHandleType {
-    cusparseHandle_t cusparseHandle;
-    // Descriptor for any general matrix with index base 0
-    cusparseMatDescr_t generalDescr;
-
-    cuSparseSpgemmHandleType(bool /* transposeA */, bool /* transposeB */) {
-      KokkosKernels::Experimental::Controls kkControls;
-      // Get singleton cusparse handle from default controls
-      cusparseHandle = kkControls.getCusparseHandle();
-
-      KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseCreateMatDescr(&generalDescr));
-      KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSetMatType(generalDescr, CUSPARSE_MATRIX_TYPE_GENERAL));
-      KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSetMatIndexBase(generalDescr, CUSPARSE_INDEX_BASE_ZERO));
-    }
-    ~cuSparseSpgemmHandleType() { KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseDestroyMatDescr(generalDescr)); }
-  };
-#endif
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
@@ -402,8 +447,8 @@ class SPGEMMHandle {
   /**
    * \brief Default constructor.
    */
-  SPGEMMHandle(SPGEMMAlgorithm gs = SPGEMM_DEFAULT)
-      : algorithm_type(gs),
+  SPGEMMHandle(SPGEMMAlgorithm alg = SPGEMM_DEFAULT)
+      : algorithm_type(alg),
         accumulator_type(SPGEMM_ACC_DEFAULT),
         result_nnz_size(0),
         called_symbolic(false),
@@ -473,7 +518,15 @@ class SPGEMMHandle {
         mkl_spgemm_handle(nullptr)
 #endif
   {
-    if (gs == SPGEMM_DEFAULT) {
+    if (Impl::isCuSparseSpgemmAlgorithm(alg)) {
+#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+      // Check that the algorithm is supported by this version of cuSPARSE
+      cuSparseSpgemmHandleType::checkAlgorithm(alg);
+#else
+      throw std::invalid_argument("SPGEMMHandle: a cuSPARSE algorithm was selected but cuSPARSE is not enabled");
+#endif
+    }
+    if (alg == SPGEMM_DEFAULT) {
       this->choose_default_algorithm();
     }
   }
@@ -510,7 +563,7 @@ class SPGEMMHandle {
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
   void create_cusparse_spgemm_handle(bool transA, bool transB) {
     this->destroy_cusparse_spgemm_handle();
-    this->cusparse_spgemm_handle = new cuSparseSpgemmHandleType(transA, transB);
+    this->cusparse_spgemm_handle = new cuSparseSpgemmHandleType(get_algorithm_type(), transA, transB);
   }
   void destroy_cusparse_spgemm_handle() {
     if (this->cusparse_spgemm_handle != nullptr) {
@@ -621,7 +674,7 @@ class SPGEMMHandle {
   nnz_lno_t get_max_compresed_result_nnz() const { return this->max_nnz_compressed_result; }
 
   // setters
-  void set_algorithm_type(const SPGEMMAlgorithm &sgs_algo) { this->algorithm_type = sgs_algo; }
+  void set_algorithm_type(const SPGEMMAlgorithm &algo) { this->algorithm_type = algo; }
   void set_call_symbolic(bool call = true) { this->called_symbolic = call; }
   void set_computed_rowptrs() { this->computed_rowptrs = true; }
   void set_computed_rowflops() { this->computed_rowflops = true; }

--- a/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_decl.hpp
@@ -4,6 +4,8 @@
 #ifndef KOKKOSPARSE_SPGEMM_NOREUSE_TPL_SPEC_DECL_HPP_
 #define KOKKOSPARSE_SPGEMM_NOREUSE_TPL_SPEC_DECL_HPP_
 
+#include "KokkosSparse_spgemm_handle.hpp"
+
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 #include "cusparse.h"
 #include "KokkosSparse_Utils_cusparse.hpp"
@@ -17,11 +19,12 @@
 namespace KokkosSparse {
 namespace Impl {
 
-#if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) && (CUDA_VERSION >= 11000)
+#if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE)
 
 template <typename Matrix, typename MatrixConst>
-Matrix spgemm_noreuse_cusparse(const MatrixConst &A, const MatrixConst &B) {
-  using Scalar                = typename Matrix::value_type;
+Matrix spgemm_noreuse_cusparse(KokkosSparse::SPGEMMAlgorithm algo, const MatrixConst &A, const MatrixConst &B) {
+  using Scalar = typename Matrix::value_type;
+  using Handle = KokkosSparse::SPGEMMHandle<int, int, Scalar, Kokkos::Cuda, Kokkos::CudaSpace, Kokkos::CudaSpace>;
   cudaDataType cudaScalarType = Impl::cuda_data_type_from<Scalar>();
   KokkosKernels::Experimental::Controls kkControls;
   cusparseHandle_t cusparseHandle = kkControls.getCusparseHandle();
@@ -29,6 +32,8 @@ Matrix spgemm_noreuse_cusparse(const MatrixConst &A, const MatrixConst &B) {
   cusparseSpMatDescr_t descr_A, descr_B, descr_C;
   cusparseSpGEMMDescr_t spgemmDescr;
   cusparseSpGEMMAlg_t alg = CUSPARSE_SPGEMM_DEFAULT;
+  // Validate algo for the current version of cuSPARSE, and convert to the correct cusparse algo.
+  Handle::cuSparseSpgemmHandleType::checkAlgorithm(algo, &alg);
   size_t bufferSize1 = 0, bufferSize2 = 0;
   void *buffer1 = nullptr, *buffer2 = nullptr;
   // A is m*n, B is n*k, C is m*k
@@ -107,11 +112,11 @@ Matrix spgemm_noreuse_cusparse(const MatrixConst &A, const MatrixConst &B) {
     using ConstMatrix = KokkosSparse::CrsMatrix<const SCALAR, const int, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,   \
                                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>, const int>;               \
     static KokkosSparse::CrsMatrix<SCALAR, int, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, void, int> spgemm_noreuse( \
-        const ConstMatrix &A, bool, const ConstMatrix &B, bool) {                                                  \
+        KokkosSparse::SPGEMMAlgorithm algo, const ConstMatrix &A, bool, const ConstMatrix &B, bool) {              \
       std::string label =                                                                                          \
           "KokkosSparse::spgemm_noreuse[TPL_CUSPARSE," + KokkosKernels::ArithTraits<SCALAR>::name() + "]";         \
       Kokkos::Profiling::pushRegion(label);                                                                        \
-      Matrix C = spgemm_noreuse_cusparse<Matrix>(A, B);                                                            \
+      Matrix C = spgemm_noreuse_cusparse<Matrix>(algo, A, B);                                                      \
       Kokkos::Profiling::popRegion();                                                                              \
       return C;                                                                                                    \
     }                                                                                                              \
@@ -198,7 +203,7 @@ Matrix spgemm_noreuse_mkl(const MatrixConst &A, const MatrixConst &B) {
     using ConstMatrix = KokkosSparse::CrsMatrix<const SCALAR, const MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
                                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>;              \
     static KokkosSparse::CrsMatrix<SCALAR, MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, void, MKL_INT>           \
-    spgemm_noreuse(const ConstMatrix &A, bool, const ConstMatrix &B, bool) {                                          \
+    spgemm_noreuse(KokkosSparse::SPGEMMAlgorithm, const ConstMatrix &A, bool, const ConstMatrix &B, bool) {           \
       std::string label = "KokkosSparse::spgemm_noreuse[TPL_MKL," + KokkosKernels::ArithTraits<SCALAR>::name() + "]"; \
       Kokkos::Profiling::pushRegion(label);                                                                           \
       Matrix C = spgemm_noreuse_mkl<Matrix>(A, B);                                                                    \

--- a/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_decl.hpp
@@ -23,9 +23,9 @@ namespace KokkosSparse {
 namespace Impl {
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
-#if (CUDA_VERSION >= 11040) && (!defined(CUSPARSE_VERSION) || (CUSPARSE_VERSION < 12700))
+#if (CUSPARSE_VERSION < 12710)
 
-// CUDA 11.4+ supports generic API with reuse (full symbolic/numeric
+// CUDA 11.x and 12.x support generic API with reuse (full symbolic/numeric
 // separation). Newer cuSPARSE versions deprecate the SpGEMMreuse entry points,
 // so those versions use the non-reuse generic path below instead.
 template <typename KernelHandle, typename lno_t, typename ConstRowMapType, typename ConstEntriesType,
@@ -97,9 +97,9 @@ void spgemm_numeric_cusparse(KernelHandle *handle, lno_t /*m*/, lno_t /*n*/, lno
   handle->set_call_numeric();
 }
 
-#elif (CUDA_VERSION >= 11000)
-// CUDA 11.0-11.3 supports only the generic API, but not reuse.
-// cuSPARSE versions that deprecate SpGEMMreuse also take this path.
+#else
+
+// cuSPARSE versions that deprecate SpGEMMreuse use this SpGEMM interface instead.
 template <typename KernelHandle, typename lno_t, typename ConstRowMapType, typename ConstEntriesType,
           typename ConstValuesType, typename EntriesType, typename ValuesType>
 void spgemm_numeric_cusparse(KernelHandle *handle, lno_t /*m*/, lno_t /*n*/, lno_t /*k*/,
@@ -126,58 +126,6 @@ void spgemm_numeric_cusparse(KernelHandle *handle, lno_t /*m*/, lno_t /*n*/, lno
   handle->set_computed_entries();
   handle->set_call_numeric();
 }
-
-#else
-
-// Generic (using overloads) wrapper for cusparseXcsrgemm (where X is S, D, C,
-// or Z). Accepts Kokkos types (e.g. Kokkos::complex<float>) for Scalar and
-// handles casting to cuSparse types internally.
-
-#define CUSPARSE_XCSRGEMM_SPEC(KokkosType, CusparseType, Abbreviation)                                                 \
-  inline cusparseStatus_t cusparseXcsrgemm(                                                                            \
-      cusparseHandle_t handle, cusparseOperation_t transA, cusparseOperation_t transB, int m, int n, int k,            \
-      const cusparseMatDescr_t descrA, const int nnzA, const KokkosType *csrSortedValA, const int *csrSortedRowPtrA,   \
-      const int *csrSortedColIndA, const cusparseMatDescr_t descrB, const int nnzB, const KokkosType *csrSortedValB,   \
-      const int *csrSortedRowPtrB, const int *csrSortedColIndB, const cusparseMatDescr_t descrC,                       \
-      KokkosType *csrSortedValC, const int *csrSortedRowPtrC, int *csrSortedColIndC) {                                 \
-    return cusparse##Abbreviation##csrgemm(                                                                            \
-        handle, transA, transB, m, n, k, descrA, nnzA, reinterpret_cast<const CusparseType *>(csrSortedValA),          \
-        csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, reinterpret_cast<const CusparseType *>(csrSortedValB),       \
-        csrSortedRowPtrB, csrSortedColIndB, descrC, reinterpret_cast<CusparseType *>(csrSortedValC), csrSortedRowPtrC, \
-        csrSortedColIndC);                                                                                             \
-  }
-
-CUSPARSE_XCSRGEMM_SPEC(float, float, S)
-CUSPARSE_XCSRGEMM_SPEC(double, double, D)
-CUSPARSE_XCSRGEMM_SPEC(Kokkos::complex<float>, cuComplex, C)
-CUSPARSE_XCSRGEMM_SPEC(Kokkos::complex<double>, cuDoubleComplex, Z)
-
-#undef CUSPARSE_XCSRGEMM_SPEC
-
-// 10.x supports the pre-generic interface.
-template <typename KernelHandle, typename lno_t, typename ConstRowMapType, typename ConstEntriesType,
-          typename ConstValuesType, typename EntriesType, typename ValuesType>
-void spgemm_numeric_cusparse(KernelHandle *handle, lno_t m, lno_t n, lno_t k, const ConstRowMapType &row_mapA,
-                             const ConstEntriesType &entriesA, const ConstValuesType &valuesA,
-                             const ConstRowMapType &row_mapB, const ConstEntriesType &entriesB,
-                             const ConstValuesType &valuesB, const ConstRowMapType &row_mapC,
-                             const EntriesType &entriesC, const ValuesType &valuesC) {
-  auto h = handle->get_cusparse_spgemm_handle();
-
-  int nnzA = entriesA.extent(0);
-  int nnzB = entriesB.extent(0);
-
-  // Only call numeric if C actually has entries
-  if (handle->get_c_nnz()) {
-    KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseXcsrgemm(
-        h->cusparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE, CUSPARSE_OPERATION_NON_TRANSPOSE, m, k, n, h->generalDescr,
-        nnzA, valuesA.data(), row_mapA.data(), entriesA.data(), h->generalDescr, nnzB, valuesB.data(), row_mapB.data(),
-        entriesB.data(), h->generalDescr, valuesC.data(), row_mapC.data(), entriesC.data()));
-  }
-  handle->set_computed_entries();
-  handle->set_call_numeric();
-}
-
 #endif
 
 #define SPGEMM_NUMERIC_DECL_CUSPARSE(SCALAR, MEMSPACE, TPL_AVAIL)                                                      \

--- a/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp
@@ -29,8 +29,8 @@ namespace Impl {
 // offsets and ordinals independently as either 16, 32 or 64-bit integers,
 // cusparse will just fail at runtime if you don't use 32 for both.
 
-#if (CUDA_VERSION >= 11040) && (!defined(CUSPARSE_VERSION) || (CUSPARSE_VERSION < 12700))
-// CUDA 11.4+ added generic API structure reuse (full symbolic/numeric
+#if (CUSPARSE_VERSION < 12710)
+// CUDA 11.x and 12.x have spgemm generic API with structure reuse (full symbolic/numeric
 // separation). Newer cuSPARSE versions deprecate the SpGEMMreuse entry points,
 // so those versions take the non-reuse generic path below instead.
 // Also note: its "symbolic" (cusparseSpGEMMreuse_nnz) does not populate C's
@@ -153,9 +153,8 @@ void spgemm_symbolic_cusparse(KernelHandle *handle, lno_t m, lno_t n, lno_t k, c
   }
 }
 
-#elif (CUDA_VERSION >= 11000)
-// CUDA 11.0-11.3 supports only the generic API, but not reuse.
-// cuSPARSE versions that deprecate SpGEMMreuse also take this path.
+#else
+// cuSPARSE versions that deprecate SpGEMMreuse use this SpGEMM interface instead.
 template <typename KernelHandle, typename lno_t, typename ConstRowMapType, typename ConstEntriesType,
           typename RowMapType>
 void spgemm_symbolic_cusparse(KernelHandle *handle, lno_t m, lno_t n, lno_t k, const ConstRowMapType &row_mapA,
@@ -256,49 +255,6 @@ void spgemm_symbolic_cusparse(KernelHandle *handle, lno_t m, lno_t n, lno_t k, c
   }
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(dummyValues_AB));
 }
-
-#else
-// 10.x supports the pre-generic interface (cusparseXcsrgemmNnz). It always
-// populates C rowptrs.
-template <typename KernelHandle, typename lno_t, typename ConstRowMapType, typename ConstEntriesType,
-          typename RowMapType>
-void spgemm_symbolic_cusparse(KernelHandle *handle, lno_t m, lno_t n, lno_t k, const ConstRowMapType &row_mapA,
-                              const ConstEntriesType &entriesA, const ConstRowMapType &row_mapB,
-                              const ConstEntriesType &entriesB, const RowMapType &row_mapC, bool /* computeRowptrs */) {
-  // using scalar_type = typename KernelHandle::nnz_scalar_t;
-  using size_type = typename KernelHandle::size_type;
-  if (handle->are_rowptrs_computed()) return;
-  handle->create_cusparse_spgemm_handle(false, false);
-  auto h   = handle->get_cusparse_spgemm_handle();
-  int nnzA = entriesA.extent(0);
-  int nnzB = entriesB.extent(0);
-
-  int baseC, nnzC;
-  int *nnzTotalDevHostPtr = &nnzC;
-
-  // In empty (zero entries) matrix case, cusparse does not populate rowptrs to
-  // zeros
-  if (m == 0 || n == 0 || k == 0 || entriesA.extent(0) == size_type(0) || entriesB.extent(0) == size_type(0)) {
-    Kokkos::deep_copy(typename KernelHandle::HandleExecSpace(), row_mapC, size_type(0));
-    nnzC = 0;
-  } else {
-    KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(
-        cusparseXcsrgemmNnz(h->cusparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE, CUSPARSE_OPERATION_NON_TRANSPOSE, m, k,
-                            n, h->generalDescr, nnzA, row_mapA.data(), entriesA.data(), h->generalDescr, nnzB,
-                            row_mapB.data(), entriesB.data(), h->generalDescr, row_mapC.data(), nnzTotalDevHostPtr));
-    if (nullptr != nnzTotalDevHostPtr) {
-      nnzC = *nnzTotalDevHostPtr;
-    } else {
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemcpy(&nnzC, row_mapC.data() + m, sizeof(int), cudaMemcpyDeviceToHost));
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemcpy(&baseC, row_mapC.data(), sizeof(int), cudaMemcpyDeviceToHost));
-      nnzC -= baseC;
-    }
-  }
-  handle->set_c_nnz(nnzC);
-  handle->set_call_symbolic();
-  handle->set_computed_rowptrs();
-}
-
 #endif
 
 #define SPGEMM_SYMBOLIC_DECL_CUSPARSE(SCALAR, MEMSPACE, TPL_AVAIL)                                                     \

--- a/sparse/unit_test/Test_Sparse_spgemm.hpp
+++ b/sparse/unit_test/Test_Sparse_spgemm.hpp
@@ -14,9 +14,6 @@
 #include "KokkosSparse_spgemm.hpp"
 #include "KokkosSparse_CrsMatrix.hpp"
 
-#include <gtest/gtest.h>
-#include <Kokkos_Core.hpp>
-
 #include <KokkosKernels_IOUtils.hpp>
 #include <KokkosSparse_IOUtils.hpp>
 
@@ -231,11 +228,26 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth, lno_
   if (callMode == spgemm_noreuse) {
     // No-reuse interface always uses the default algorithm
     algorithms = {SPGEMM_KK};
+#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+    // Also test available cuSPARSE algorithms for non-reuse interface
+#if (CUSPARSE_VERSION >= 12001)
+    algorithms.push_back(SPGEMM_CUSPARSE_ALG1);
+    algorithms.push_back(SPGEMM_CUSPARSE_ALG2);
+    algorithms.push_back(SPGEMM_CUSPARSE_ALG3);
+#endif
+#endif
   } else {
     algorithms = {
         SPGEMM_KK, SPGEMM_KK_LP, SPGEMM_KK_MEMORY /* alias SPGEMM_KK_MEMSPEED */,
         SPGEMM_KK_SPEED /* alias SPGEMM_KK_DENSE */
     };
+#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+    // Also test available cuSPARSE algorithms for reuse interface
+#if (CUSPARSE_VERSION < 12710)
+    algorithms.push_back(SPGEMM_CUSPARSE_DETERMINISTIC);
+    algorithms.push_back(SPGEMM_CUSPARSE_NONDETERMINISTIC);
+#endif
+#endif
   }
 
   for (auto spgemm_algorithm : algorithms) {
@@ -248,6 +260,11 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth, lno_
       case SPGEMM_KK_MEMSPEED: algo = "SPGEMM_KK_MEMSPEED"; break;
       case SPGEMM_KK_SPEED: algo = "SPGEMM_KK_SPEED"; break;
       case SPGEMM_KK_MEMORY: algo = "SPGEMM_KK_MEMORY"; break;
+      case SPGEMM_CUSPARSE_DETERMINISTIC: algo = "SPGEMM_CUSPARSE_DETERMINISTIC"; break;
+      case SPGEMM_CUSPARSE_NONDETERMINISTIC: algo = "SPGEMM_CUSPARSE_NONDETERMINISTIC"; break;
+      case SPGEMM_CUSPARSE_ALG1: algo = "SPGEMM_CUSPARSE_ALG1"; break;
+      case SPGEMM_CUSPARSE_ALG2: algo = "SPGEMM_CUSPARSE_ALG2"; break;
+      case SPGEMM_CUSPARSE_ALG3: algo = "SPGEMM_CUSPARSE_ALG3"; break;
       default: algo = "!!! UNKNOWN ALGO !!!";
     }
 


### PR DESCRIPTION
Allow for specifying cusparse algorithms for reuse and non-reuse. The user's choice is checked to make sure it's supported and not deprecated in the current cusparse version.

This PR adds these new values for ``KokkosSparse::SPGEMMAlgorithm``.
SpGEMMreuse algos (until CUDA 13.2.1):
```
SPGEMM_CUSPARSE_DETERMINISTIC
SPGEMM_CUSPARSE_NONDETERMINISTIC
```
SpGEMM algos (spgemm without a handle since CUDA 12.0.1, and spgemm with a handle since CUDA 13.2.1):
```
SPGEMM_CUSPARSE_ALG1
SPGEMM_CUSPARSE_ALG2
SPGEMM_CUSPARSE_ALG3
```

Adds feature requested in #2445.