### PR TITLE
cuSPARSE spmv/spmm preprocess

### DIFF
--- a/perf_test/sparse/KokkosSparse_kk_spmv.cpp
+++ b/perf_test/sparse/KokkosSparse_kk_spmv.cpp
@@ -36,6 +36,7 @@ struct SPMVBenchmarking {
   std::string filename = "";
   bool flush_cache     = false;
   bool non_reuse       = false;
+  bool new_handle      = false;
 
   // Using the parameters above, run and time spmv where x and y use the given
   // memory layout.
@@ -94,8 +95,9 @@ struct SPMVBenchmarking {
     // Create handles for both rank-1 and rank-2 cases,
     // even though only 1 will get used below (depending on num_vecs)
 
-    KokkosSparse::SPMVHandle<Kokkos::DefaultExecutionSpace, matrix_type, decltype(x0), decltype(y0)> handle_rank1;
-    KokkosSparse::SPMVHandle<Kokkos::DefaultExecutionSpace, matrix_type, mv_type, mv_type> handle_rank2;
+    using HandleRank1 =
+        KokkosSparse::SPMVHandle<Kokkos::DefaultExecutionSpace, matrix_type, decltype(x0), decltype(y0)>;
+    using HandleRank2 = KokkosSparse::SPMVHandle<Kokkos::DefaultExecutionSpace, matrix_type, mv_type, mv_type>;
     // Assuming that 1GB is enough to fully clear the L3 cache of a CPU, or the
     // L2 of a GPU. (Some AMD EPYC chips have 768 MB L3)
     Kokkos::View<char*, Kokkos::DefaultExecutionSpace> cacheFlushData;
@@ -105,6 +107,9 @@ struct SPMVBenchmarking {
 
     Kokkos::DefaultExecutionSpace space;
 
+    std::shared_ptr<HandleRank1> handle_rank1 = std::make_shared<HandleRank1>();
+    std::shared_ptr<HandleRank2> handle_rank2 = std::make_shared<HandleRank2>();
+
     // Do 5 warm up calls (not timed). This will also initialize the handle.
     for (int i = 0; i < 5; i++) {
       if (num_vecs == 1) {
@@ -112,15 +117,14 @@ struct SPMVBenchmarking {
         if (non_reuse)
           KokkosSparse::spmv(space, &mode, 1.0, A, x0, beta, y0);
         else
-          KokkosSparse::spmv(space, &handle_rank1, &mode, 1.0, A, x0, beta, y0);
+          KokkosSparse::spmv(space, handle_rank1.get(), &mode, 1.0, A, x0, beta, y0);
       } else {
         // rank-2
         if (non_reuse)
           KokkosSparse::spmv(space, &mode, 1.0, A, x, beta, y);
         else
-          KokkosSparse::spmv(space, &handle_rank2, &mode, 1.0, A, x, beta, y);
+          KokkosSparse::spmv(space, handle_rank2.get(), &mode, 1.0, A, x, beta, y);
       }
-      space.fence();
     }
 
     double totalTime = 0;
@@ -138,14 +142,26 @@ struct SPMVBenchmarking {
         // run the rank-1 version
         if (non_reuse)
           KokkosSparse::spmv(space, &mode, 1.0, A, x0, beta, y0);
-        else
-          KokkosSparse::spmv(space, &handle_rank1, &mode, 1.0, A, x0, beta, y0);
+        else {
+          if (new_handle) {
+            // Destroy handle and re-create new one
+            handle_rank1.reset();
+            handle_rank1 = std::make_shared<HandleRank1>();
+          }
+          KokkosSparse::spmv(space, handle_rank1.get(), &mode, 1.0, A, x0, beta, y0);
+        }
       } else {
         // rank-2
         if (non_reuse)
           KokkosSparse::spmv(space, &mode, 1.0, A, x, beta, y);
-        else
-          KokkosSparse::spmv(space, &handle_rank2, &mode, 1.0, A, x, beta, y);
+        else {
+          if (new_handle) {
+            // Destroy handle and re-create new one
+            handle_rank2.reset();
+            handle_rank2 = std::make_shared<HandleRank2>();
+          }
+          KokkosSparse::spmv(space, handle_rank2.get(), &mode, 1.0, A, x, beta, y);
+        }
       }
       space.fence();
       totalTime += timer.seconds();
@@ -179,9 +195,8 @@ void print_help() {
   printf(
       "  --flush               : Flush the cache between each spmv call "
       "(slow!)\n");
-  printf(
-      "  --non-reuse           : Use non-reuse interface (without "
-      "SPMVHandle)\n");
+  printf("  --non-reuse           : Use non-reuse interface (without SPMVHandle)\n");
+  printf("  --new-handle          : Run each spmv with a new handle to measure first-time setup cost\n");
 }
 
 int main(int argc, char** argv) {
@@ -242,6 +257,10 @@ int main(int argc, char** argv) {
     }
     if ((strcmp(argv[i], "--non-reuse") == 0)) {
       sb.non_reuse = true;
+      continue;
+    }
+    if ((strcmp(argv[i], "--new-handle") == 0)) {
+      sb.new_handle = true;
       continue;
     }
     if ((strcmp(argv[i], "--help") == 0) || (strcmp(argv[i], "-h") == 0)) {

--- a/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
@@ -158,6 +158,11 @@ void spmv_mv_cusparse(const Kokkos::Cuda &exec, Handle *handle, const char mode[
                                                                  &subhandle->bufferSize));
 
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc(&subhandle->buffer, subhandle->bufferSize));
+    // Call the optional preprocess, unless we know the handle will not be reused
+    if (handle->get_algorithm() != SPMV_FAST_SETUP) {
+      KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSpMM_preprocess(
+          cusparseHandle, opA, opB, &alpha, subhandle->mat, vecX, &beta, vecY, computeType, algo, subhandle->buffer));
+    }
   }
 
   KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSpMM(cusparseHandle, opA, opB, &alpha, subhandle->mat, vecX, &beta, vecY,

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -98,6 +98,15 @@ void spmv_cusparse(const Kokkos::Cuda& exec, Handle* handle, const char mode[],
 #else
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc(&subhandle->buffer, subhandle->bufferSize));
 #endif
+    // Call the optional preprocess, unless we know the handle will not be reused
+    // cusparseSpMV_preprocess was added in cuSPARSE 12.3 (included with CUDA 12.4.0)
+#if (CUSPARSE_VERSION >= 12300)
+    if (handle->get_algorithm() != SPMV_FAST_SETUP) {
+      KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSpMV_preprocess(cusparseHandle, myCusparseOperation, &alpha,
+                                                                   subhandle->mat, vecX, &beta, vecY, myCudaDataType,
+                                                                   algo, subhandle->buffer));
+    }
+#endif
   }
 
   /* perform SpMV */


### PR DESCRIPTION
If we are using a spmv handle for reuse, and using cuSPARSE, call the optional preprocess function to optimize the future spmv/spmm calls. For SpMM this has been available since before CUDA 11.8 (oldest kokkos supported version) and for SpMV, since CUDA 12.4.0.

Also improve the kk_spmv performance test by adding a ``--new-handle`` flag. When this is passed in, a new spmv handle is created on every call to help measure the one-time setup cost of different algorithms. This was used to measure the setup values below.

These results are from Hops H100 with CUDA 12.9. They are all times in seconds and averaged over 1000 repetitions.
SpMV:

|                 | Setup Before | Setup With Preprocess | Reuse Before | Reuse With Preprocess |
|-----------------|--------------|-----------------------|--------------|-----------------------|
| Elasticity3D_60 | 0.00021713   | 0.000216869           | 0.000214423  | 0.000208639           |
| Laplace3D_100   | 5.65189e-05  | 5.65395e-05           | 5.40707e-05  | 4.70214e-05           |
| circuit5M       | 0.000398333  | 0.000398156           | 0.000394993  | 0.000381233           |
| momentum        | 0.000185225  | 0.000184659           | 0.000182083  | 0.000169173           |

SpMM with 4 vectors:
|                 | Setup Before | Setup With Preprocess | Reuse Before | Reuse With Preprocess |
|-----------------|--------------|-----------------------|--------------|-----------------------|
| Elasticity3D_60 | 0.00105127   | 0.00105669            | 0.00103953   | 0.00104006            |
| Laplace3D_100   | 0.000200441  | 0.000204137           | 0.000190426  | 0.000190091           |
| circuit5M       | 0.00180931   | 0.00181741            | 0.00180038   | 0.00180027            |
| momentum        | 0.000687568  | 0.000694562           | 0.000677078  | 0.000677038           |

To summarize this:
- the actual preprocess call costs basically nothing
- for SpMV it can make a nice improvement (almost 15% for Laplace3D_100)
- for SpMM it seems to make very little difference.

I used a printout to check that cusparseSpMM_preprocess is actually getting called in this 4-vector experiment.