### PR TITLE
Small fix for the config on Auraro

### DIFF
--- a/.gitlab/alcf-gitlab-ci.yml
+++ b/.gitlab/alcf-gitlab-ci.yml
@@ -82,7 +82,7 @@ Aurora:
             -DKokkos_ARCH_NATIVE=ON
             -DKokkos_ENABLE_SYCL=ON
             -DKokkos_ARCH_INTEL_PVC=ON
-            -DKokkos_ENABLE_DEPRECATED_CODE_4=ON
+            -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF
     - cmake --build kokkos/build --parallel
     - cmake --install kokkos/build --prefix kokkos-install
     - cmake -B kokkos-kernels_build


### PR DESCRIPTION
We currently have build failures due to missing StaticCrsGraph header in Kokkos which is fair since that header has been removed and should not be relied on being there anymore.