### PR TITLE
Use Intel extension to query SYCL device free memory

### DIFF
--- a/common/src/KokkosKernels_ExecSpaceUtils.hpp
+++ b/common/src/KokkosKernels_ExecSpaceUtils.hpp
@@ -182,41 +182,22 @@ inline void kk_get_free_total_memory<Kokkos::HIPManagedSpace>(size_t& free_mem, 
 }
 #endif
 
-// FIXME_SYCL Use compiler extension instead of low level interface when
-// available. Also, we assume to query memory associated with the default queue.
+// Note: we are querying memory associated with the default SYCL queue.
 #if defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_ARCH_INTEL_GPU)
 template <>
 inline void kk_get_free_total_memory<Kokkos::Experimental::SYCLDeviceUSMSpace>(size_t& free_mem, size_t& total_mem,
                                                                                int n_streams) {
   sycl::queue queue;
-  sycl::device device    = queue.get_device();
-  auto level_zero_handle = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(device);
+  sycl::device device = queue.get_device();
 
-  uint32_t n_memory_modules = 0;
-  zesDeviceEnumMemoryModules(level_zero_handle, &n_memory_modules, nullptr);
-
-  if (n_memory_modules == 0) {
+  if (!device.has(sycl::aspect::ext_intel_free_memory)) {
     throw std::runtime_error(
-        "Error: No memory modules for the SYCL backend found. Make sure that "
-        "ZES_ENABLE_SYSMAN=1 is set at run time!");
+        "Error: the current SYCL backend does not support the required Intel extensions for measuring free device "
+        "memory.");
   }
 
-  total_mem = 0;
-  free_mem  = 0;
-  std::vector<zes_mem_handle_t> mem_handles(n_memory_modules);
-  zesDeviceEnumMemoryModules(level_zero_handle, &n_memory_modules, mem_handles.data());
-
-  for (auto& mem_handle : mem_handles) {
-    zes_mem_properties_t memory_properties{ZES_STRUCTURE_TYPE_MEM_PROPERTIES};
-    zesMemoryGetProperties(mem_handle, &memory_properties);
-    // Only report HBM which zeMemAllocDevice allocates from.
-    if (memory_properties.type != ZES_MEM_TYPE_HBM) continue;
-
-    zes_mem_state_t memory_states{ZES_STRUCTURE_TYPE_MEM_STATE};
-    zesMemoryGetState(mem_handle, &memory_states);
-    total_mem += memory_states.size;
-    free_mem += memory_states.free;
-  }
+  free_mem  = device.get_info<sycl::ext::intel::info::device::free_memory>();
+  total_mem = device.get_info<sycl::info::device::global_mem_size>();
   free_mem /= n_streams;
   total_mem /= n_streams;
 }


### PR DESCRIPTION
This way we don't have to call the level-zero API directly.

Resolves #1062.