### PR TITLE
spgemm algorithm choice and TPL fixes

### DIFF
--- a/sparse/src/KokkosSparse_spgemm.hpp
+++ b/sparse/src/KokkosSparse_spgemm.hpp
@@ -202,9 +202,15 @@ CMatrix spgemm(KokkosSparse::SPGEMMAlgorithm algo, const AMatrix& A, const bool 
     typename CMatrix::values_type valuesC;
     return CMatrix("C", Crows, Ccols, 0, valuesC, row_mapC, entriesC);
   }
-  return CMatrix(
-      KokkosSparse::Impl::SPGEMM_NOREUSE<CMatrix_Internal, AMatrix_Internal, BMatrix_Internal>::spgemm_noreuse(
-          algo, A_internal, Amode, B_internal, Bmode));
+  if (Impl::is_spgemm_algorithm_native(algo)) {
+    return CMatrix(
+        KokkosSparse::Impl::SPGEMM_NOREUSE<CMatrix_Internal, AMatrix_Internal, BMatrix_Internal, false>::spgemm_noreuse(
+            algo, A_internal, Amode, B_internal, Bmode));
+  } else {
+    return CMatrix(
+        KokkosSparse::Impl::SPGEMM_NOREUSE<CMatrix_Internal, AMatrix_Internal, BMatrix_Internal>::spgemm_noreuse(
+            algo, A_internal, Amode, B_internal, Bmode));
+  }
 }
 
 ///

--- a/sparse/src/KokkosSparse_spgemm_handle.hpp
+++ b/sparse/src/KokkosSparse_spgemm_handle.hpp
@@ -72,7 +72,7 @@ enum SPGEMMAlgorithm {
 
 namespace Impl {
 // Helpers to categorize algorithm choices
-inline bool isCuSparseSpgemmAlgorithm(SPGEMMAlgorithm alg) {
+inline bool is_cusparse_spgemm_algorithm(SPGEMMAlgorithm alg) {
   switch (alg) {
     case SPGEMM_CUSPARSE_DETERMINISTIC:
     case SPGEMM_CUSPARSE_NONDETERMINISTIC:
@@ -82,6 +82,13 @@ inline bool isCuSparseSpgemmAlgorithm(SPGEMMAlgorithm alg) {
     default:;
   }
   return false;
+}
+
+/// Return true if the given algorithm is always a native (KokkosKernels)
+/// implementation, and false if it may be implemented by a TPL.
+inline bool is_spgemm_algorithm_native(SPGEMMAlgorithm a) {
+  if (a == SPGEMM_DEFAULT || is_cusparse_spgemm_algorithm(a)) return false;
+  return true;
 }
 }  // namespace Impl
 
@@ -518,7 +525,7 @@ class SPGEMMHandle {
         mkl_spgemm_handle(nullptr)
 #endif
   {
-    if (Impl::isCuSparseSpgemmAlgorithm(alg)) {
+    if (Impl::is_cusparse_spgemm_algorithm(alg)) {
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
       // Check that the algorithm is supported by this version of cuSPARSE
       cuSparseSpgemmHandleType::checkAlgorithm(alg);

--- a/sparse/src/KokkosSparse_spgemm_numeric.hpp
+++ b/sparse/src/KokkosSparse_spgemm_numeric.hpp
@@ -175,18 +175,6 @@ void spgemm_numeric(KernelHandle *handle, typename KernelHandle::const_nnz_lno_t
   Internal_clno_nnz_view_t_ nonconst_c_l(entriesC.data(), entriesC.extent(0));
   Internal_cscalar_nnz_view_t_ nonconst_c_s(valuesC.data(), valuesC.extent(0));
 
-  if (block_dim > 1) {
-    KokkosSparse::Impl::BSPGEMM_NUMERIC<
-        const_handle_type, Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_,
-        Internal_blno_row_view_t_, Internal_blno_nnz_view_t_, Internal_bscalar_nnz_view_t_, Internal_clno_row_view_t_,
-        Internal_clno_nnz_view_t_, Internal_cscalar_nnz_view_t_>::bspgemm_numeric(&tmp_handle, m, n, k, block_dim,
-                                                                                  const_a_r, const_a_l, const_a_s,
-                                                                                  transposeA, const_b_r, const_b_l,
-                                                                                  const_b_s, transposeB, const_c_r,
-                                                                                  nonconst_c_l, nonconst_c_s);
-    return;
-  }
-
   auto spgemmHandle = tmp_handle.get_spgemm_handle();
 
   if (!spgemmHandle) {
@@ -205,7 +193,32 @@ void spgemm_numeric(KernelHandle *handle, typename KernelHandle::const_nnz_lno_t
 
   auto algo = spgemmHandle->get_algorithm_type();
 
-  if (algo == SPGEMM_DEBUG || algo == SPGEMM_SERIAL) {
+  if (block_dim > 1) {
+    if (Impl::is_spgemm_algorithm_native(algo)) {
+      KokkosSparse::Impl::BSPGEMM_NUMERIC<
+          const_handle_type, Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_,
+          Internal_blno_row_view_t_, Internal_blno_nnz_view_t_, Internal_bscalar_nnz_view_t_, Internal_clno_row_view_t_,
+          Internal_clno_nnz_view_t_, Internal_cscalar_nnz_view_t_, false>::bspgemm_numeric(&tmp_handle, m, n, k,
+                                                                                           block_dim, const_a_r,
+                                                                                           const_a_l, const_a_s,
+                                                                                           transposeA, const_b_r,
+                                                                                           const_b_l, const_b_s,
+                                                                                           transposeB, const_c_r,
+                                                                                           nonconst_c_l, nonconst_c_s);
+    } else {
+      KokkosSparse::Impl::BSPGEMM_NUMERIC<
+          const_handle_type, Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_,
+          Internal_blno_row_view_t_, Internal_blno_nnz_view_t_, Internal_bscalar_nnz_view_t_, Internal_clno_row_view_t_,
+          Internal_clno_nnz_view_t_, Internal_cscalar_nnz_view_t_>::bspgemm_numeric(&tmp_handle, m, n, k, block_dim,
+                                                                                    const_a_r, const_a_l, const_a_s,
+                                                                                    transposeA, const_b_r, const_b_l,
+                                                                                    const_b_s, transposeB, const_c_r,
+                                                                                    nonconst_c_l, nonconst_c_s);
+    }
+    return;
+  }
+
+  if (Impl::is_spgemm_algorithm_native(algo)) {
     // Never call a TPL if serial/debug is requested (this is needed for
     // testing)
     KokkosSparse::Impl::SPGEMM_NUMERIC<

--- a/sparse/src/KokkosSparse_spgemm_symbolic.hpp
+++ b/sparse/src/KokkosSparse_spgemm_symbolic.hpp
@@ -148,9 +148,7 @@ void spgemm_symbolic(KernelHandle *handle, typename KernelHandle::const_nnz_lno_
 
   auto algo = spgemmHandle->get_algorithm_type();
 
-  if (algo == SPGEMM_DEBUG || algo == SPGEMM_SERIAL) {
-    // Never call a TPL if serial/debug is requested (this is needed for
-    // testing)
+  if (Impl::is_spgemm_algorithm_native(algo)) {
     KokkosSparse::Impl::SPGEMM_SYMBOLIC<const_handle_type,  // KernelHandle,
                                         Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_blno_row_view_t_,
                                         Internal_blno_nnz_view_t_, Internal_clno_row_view_t_,

--- a/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_decl.hpp
@@ -34,8 +34,9 @@ Matrix spgemm_noreuse_cusparse(KokkosSparse::SPGEMMAlgorithm algo, const MatrixC
   cusparseSpGEMMAlg_t alg = CUSPARSE_SPGEMM_DEFAULT;
   // Validate algo for the current version of cuSPARSE, and convert to the correct cusparse algo.
   Handle::cuSparseSpgemmHandleType::checkAlgorithm(algo, &alg);
-  size_t bufferSize1 = 0, bufferSize2 = 0;
-  void *buffer1 = nullptr, *buffer2 = nullptr;
+  bool needEstimateMemory = algo == SPGEMM_CUSPARSE_ALG2 || algo == SPGEMM_CUSPARSE_ALG3;
+  size_t bufferSize1 = 0, bufferSize2 = 0, bufferSize3 = 0;
+  void *buffer1 = nullptr, *buffer2 = nullptr, *buffer3 = nullptr;
   // A is m*n, B is n*k, C is m*k
   int m            = A.numRows();
   int n            = B.numRows();
@@ -68,12 +69,28 @@ Matrix spgemm_noreuse_cusparse(KokkosSparse::SPGEMMAlgorithm algo, const MatrixC
                                                                      &beta, descr_C, cudaScalarType, alg, spgemmDescr,
                                                                      &bufferSize1, buffer1));
 
-  //----------------------------------------------------------------------
-  // query compute buffer size, allocate, then call again with buffer.
+  if (needEstimateMemory) {
+    constexpr float chunk_fraction = 0.25;
+    // First estimateMemory call computes the size for buffer3
+    KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSpGEMM_estimateMemory(cusparseHandle, op, op, &alpha, descr_A, descr_B,
+                                                                       &beta, descr_C, cudaScalarType, alg, spgemmDescr,
+                                                                       chunk_fraction, &bufferSize3, NULL, NULL));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void **)&buffer3, bufferSize3));
 
-  KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSpGEMM_compute(cusparseHandle, op, op, &alpha, descr_A, descr_B, &beta,
-                                                              descr_C, cudaScalarType, alg, spgemmDescr, &bufferSize2,
-                                                              nullptr));
+    // Second estimateMemory call computes bufferSize2
+    KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(
+        cusparseSpGEMM_estimateMemory(cusparseHandle, op, op, &alpha, descr_A, descr_B, &beta, descr_C, cudaScalarType,
+                                      alg, spgemmDescr, chunk_fraction, &bufferSize3, buffer3, &bufferSize2));
+    // buffer3 is not used again
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(buffer3));
+    buffer3 = nullptr;
+  } else {
+    // First compute call computes bufferSize2
+    KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSpGEMM_compute(cusparseHandle, op, op, &alpha, descr_A, descr_B, &beta,
+                                                                descr_C, cudaScalarType, alg, spgemmDescr, &bufferSize2,
+                                                                nullptr));
+  }
+
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void **)&buffer2, bufferSize2));
   KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSpGEMM_compute(cusparseHandle, op, op, &alpha, descr_A, descr_B, &beta,
                                                               descr_C, cudaScalarType, alg, spgemmDescr, &bufferSize2,

--- a/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_decl.hpp
@@ -117,12 +117,12 @@ void spgemm_numeric_cusparse(KernelHandle *handle, lno_t /*m*/, lno_t /*n*/, lno
       cusparseCsrSetPointers(h->descr_C, (void *)row_mapC.data(), (void *)entriesC.data(), (void *)valuesC.data()));
   const auto alpha = KokkosKernels::ArithTraits<scalar_type>::one();
   const auto beta  = KokkosKernels::ArithTraits<scalar_type>::zero();
-  KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(
-      cusparseSpGEMM_compute(h->cusparseHandle, h->opA, h->opB, &alpha, h->descr_A, h->descr_B, &beta, h->descr_C,
-                             h->scalarType, CUSPARSE_SPGEMM_DEFAULT, h->spgemmDescr, &h->bufferSize4, h->buffer4));
+  KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSpGEMM_compute(h->cusparseHandle, h->opA, h->opB, &alpha, h->descr_A,
+                                                              h->descr_B, &beta, h->descr_C, h->scalarType, h->alg,
+                                                              h->spgemmDescr, &h->bufferSize4, h->buffer4));
   KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSpGEMM_copy(h->cusparseHandle, h->opA, h->opB, &alpha, h->descr_A,
-                                                           h->descr_B, &beta, h->descr_C, h->scalarType,
-                                                           CUSPARSE_SPGEMM_DEFAULT, h->spgemmDescr));
+                                                           h->descr_B, &beta, h->descr_C, h->scalarType, h->alg,
+                                                           h->spgemmDescr));
   handle->set_computed_entries();
   handle->set_call_numeric();
 }

--- a/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp
@@ -45,7 +45,8 @@ void spgemm_symbolic_cusparse(KernelHandle *handle, lno_t m, lno_t n, lno_t k, c
   // computeRowptrs=false, and then again with computeRowptrs=true will not
   // duplicate any work.
   if (!handle->is_symbolic_called()) {
-    handle->create_cusparse_spgemm_handle(false, false);
+    // Note: this uses the algorithm choice in handle.
+    handle->create_cusparse_spgemm_handle(/* transA */ false, /* transB */ false);
     auto h = handle->get_cusparse_spgemm_handle();
 
     // Follow
@@ -160,14 +161,17 @@ template <typename KernelHandle, typename lno_t, typename ConstRowMapType, typen
 void spgemm_symbolic_cusparse(KernelHandle *handle, lno_t m, lno_t n, lno_t k, const ConstRowMapType &row_mapA,
                               const ConstEntriesType &entriesA, const ConstRowMapType &row_mapB,
                               const ConstEntriesType &entriesB, const RowMapType &row_mapC, bool computeRowptrs) {
-  using scalar_type      = typename KernelHandle::nnz_scalar_t;
-  using ordinal_type     = typename KernelHandle::nnz_lno_t;
-  const auto alpha       = KokkosKernels::ArithTraits<scalar_type>::one();
-  const auto beta        = KokkosKernels::ArithTraits<scalar_type>::zero();
-  void *dummyValues_AB   = nullptr;
-  bool firstSymbolicCall = false;
+  using scalar_type       = typename KernelHandle::nnz_scalar_t;
+  using ordinal_type      = typename KernelHandle::nnz_lno_t;
+  const auto alpha        = KokkosKernels::ArithTraits<scalar_type>::one();
+  const auto beta         = KokkosKernels::ArithTraits<scalar_type>::zero();
+  void *dummyValues_AB    = nullptr;
+  bool firstSymbolicCall  = false;
+  auto algKK              = handle->get_algorithm_type();
+  bool needEstimateMemory = algKK == SPGEMM_CUSPARSE_ALG2 || algKK == SPGEMM_CUSPARSE_ALG3;
   if (!handle->is_symbolic_called()) {
-    handle->create_cusparse_spgemm_handle(false, false);
+    // Note: this uses the algorithm choice in handle.
+    handle->create_cusparse_spgemm_handle(/* transA */ false, /* transB */ false);
     auto h = handle->get_cusparse_spgemm_handle();
 
     // Follow
@@ -205,16 +209,36 @@ void spgemm_symbolic_cusparse(KernelHandle *handle, lno_t m, lno_t n, lno_t k, c
         cusparseSpGEMM_workEstimation(h->cusparseHandle, h->opA, h->opB, &alpha, h->descr_A, h->descr_B, &beta,
                                       h->descr_C, h->scalarType, h->alg, h->spgemmDescr, &h->bufferSize3, h->buffer3));
 
+    if (needEstimateMemory) {
+      constexpr float chunk_fraction = 0.25;
+      // First estimateMemory call computes the size for tempBuffer
+      size_t tempBufferSize = 0;
+      KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSpGEMM_estimateMemory(
+          h->cusparseHandle, h->opA, h->opB, &alpha, h->descr_A, h->descr_B, &beta, h->descr_C, h->scalarType, h->alg,
+          h->spgemmDescr, chunk_fraction, &tempBufferSize, NULL, NULL));
+
+      void *tempBuffer = nullptr;
+      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void **)&tempBuffer, tempBufferSize));
+
+      // Second estimateMemory call computes bufferSize4
+      KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSpGEMM_estimateMemory(
+          h->cusparseHandle, h->opA, h->opB, &alpha, h->descr_A, h->descr_B, &beta, h->descr_C, h->scalarType, h->alg,
+          h->spgemmDescr, chunk_fraction, &tempBufferSize, tempBuffer, &h->bufferSize4));
+      // Done with tempBuffer
+      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(tempBuffer));
+    } else {
+      // First compute call computes bufferSize4
+      KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSpGEMM_compute(h->cusparseHandle, h->opA, h->opB, &alpha, h->descr_A,
+                                                                  h->descr_B, &beta, h->descr_C, h->scalarType, h->alg,
+                                                                  h->spgemmDescr, &h->bufferSize4, nullptr));
+    }
     //----------------------------------------------------------------------
     // query compute buffer size, allocate, then call again with buffer.
 
-    KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(
-        cusparseSpGEMM_compute(h->cusparseHandle, h->opA, h->opB, &alpha, h->descr_A, h->descr_B, &beta, h->descr_C,
-                               h->scalarType, CUSPARSE_SPGEMM_DEFAULT, h->spgemmDescr, &h->bufferSize4, nullptr));
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void **)&h->buffer4, h->bufferSize4));
-    KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(
-        cusparseSpGEMM_compute(h->cusparseHandle, h->opA, h->opB, &alpha, h->descr_A, h->descr_B, &beta, h->descr_C,
-                               h->scalarType, CUSPARSE_SPGEMM_DEFAULT, h->spgemmDescr, &h->bufferSize4, h->buffer4));
+    KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSpGEMM_compute(h->cusparseHandle, h->opA, h->opB, &alpha, h->descr_A,
+                                                                h->descr_B, &beta, h->descr_C, h->scalarType, h->alg,
+                                                                h->spgemmDescr, &h->bufferSize4, h->buffer4));
     int64_t C_nrow, C_ncol, C_nnz;
     KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSpMatGetSize(h->descr_C, &C_nrow, &C_ncol, &C_nnz));
     if (C_nnz > std::numeric_limits<int>::max()) {
@@ -246,8 +270,8 @@ void spgemm_symbolic_cusparse(KernelHandle *handle, lno_t m, lno_t n, lno_t k, c
         cusparseCsrSetPointers(h->descr_C, (void *)row_mapC.data(), dummyEntries_C, dummyValues_C));
 
     KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(cusparseSpGEMM_copy(h->cusparseHandle, h->opA, h->opB, &alpha, h->descr_A,
-                                                             h->descr_B, &beta, h->descr_C, h->scalarType,
-                                                             CUSPARSE_SPGEMM_DEFAULT, h->spgemmDescr));
+                                                             h->descr_B, &beta, h->descr_C, h->scalarType, h->alg,
+                                                             h->spgemmDescr));
 
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(dummyValues_C));
     KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(dummyEntries_C));

--- a/sparse/unit_test/Test_Sparse_spgemm.hpp
+++ b/sparse/unit_test/Test_Sparse_spgemm.hpp
@@ -56,8 +56,8 @@ void randomize_matrix_values(const Values &v) {
 }
 
 template <typename crsMat_t>
-void run_spgemm_noreuse(crsMat_t A, crsMat_t B, crsMat_t &C) {
-  C = KokkosSparse::spgemm<crsMat_t>(A, false, B, false);
+void run_spgemm_noreuse(KokkosSparse::SPGEMMAlgorithm algo, crsMat_t A, crsMat_t B, crsMat_t &C) {
+  C = KokkosSparse::spgemm<crsMat_t>(algo, A, false, B, false);
 }
 
 template <typename crsMat_t, typename device>
@@ -227,7 +227,7 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth, lno_
   std::vector<SPGEMMAlgorithm> algorithms;
   if (callMode == spgemm_noreuse) {
     // No-reuse interface always uses the default algorithm
-    algorithms = {SPGEMM_KK};
+    algorithms = {SPGEMM_DEFAULT, SPGEMM_KK};
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
     // Also test available cuSPARSE algorithms for non-reuse interface
 #if (CUSPARSE_VERSION >= 12001)
@@ -238,7 +238,7 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth, lno_
 #endif
   } else {
     algorithms = {
-        SPGEMM_KK, SPGEMM_KK_LP, SPGEMM_KK_MEMORY /* alias SPGEMM_KK_MEMSPEED */,
+        SPGEMM_DEFAULT, SPGEMM_KK, SPGEMM_KK_LP, SPGEMM_KK_MEMORY /* alias SPGEMM_KK_MEMSPEED */,
         SPGEMM_KK_SPEED /* alias SPGEMM_KK_DENSE */
     };
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
@@ -246,6 +246,10 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth, lno_
 #if (CUSPARSE_VERSION < 12710)
     algorithms.push_back(SPGEMM_CUSPARSE_DETERMINISTIC);
     algorithms.push_back(SPGEMM_CUSPARSE_NONDETERMINISTIC);
+#else
+    algorithms.push_back(SPGEMM_CUSPARSE_ALG1);
+    algorithms.push_back(SPGEMM_CUSPARSE_ALG2);
+    algorithms.push_back(SPGEMM_CUSPARSE_ALG3);
 #endif
 #endif
   }
@@ -255,6 +259,7 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth, lno_
     bool is_expected_to_fail = false;
 
     switch (spgemm_algorithm) {
+      case SPGEMM_DEFAULT: algo = "SPGEMM_DEFAULT"; break;
       case SPGEMM_KK: algo = "SPGEMM_KK"; break;
       case SPGEMM_KK_LP: algo = "SPGEMM_KK_LP"; break;
       case SPGEMM_KK_MEMSPEED: algo = "SPGEMM_KK_MEMSPEED"; break;
@@ -281,7 +286,7 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth, lno_
         case spgemm_reuse_matrix:
           res = run_spgemm<crsMat_t, device>(A, B, spgemm_algorithm, output_mat, testReuse);
           break;
-        case spgemm_noreuse: run_spgemm_noreuse(A, B, output_mat); break;
+        case spgemm_noreuse: run_spgemm_noreuse(spgemm_algorithm, A, B, output_mat); break;
       }
     } catch (const char *message) {
       EXPECT_TRUE(is_expected_to_fail) << algo << ": " << message;


### PR DESCRIPTION
Following #3060, this improves and fixes a couple of things:

- fix cusparse spgemm ALG2/ALG3 wrappers that need ``cusparseSpGEMM_estimateMemory`` to be called during symbolic. Also fix the unit test to actually run these, which is why this wasn't caught before.
- call the native impl when user requests a native-only algo

One question is what to do when the user requests a certain cuSPARSE algorithm, but cuSPARSE is not available for the given types (like double/int/size_t). Here, I follow what sptrsv does and silently go back to native so the computation can proceed. I prefer this since we don't provide a good way for users to query what type combinations are supported (``eti_spec_avail<...>`` is an ``Impl::`` thing).

Two other options would be to throw or print a warning in debug builds.