### PR TITLE
[BLAS][Windows] Fix non-portable rand()/RAND_MAX usage in test_gauss_seidel_long_rows; Reformatted file

### DIFF
--- a/sparse/unit_test/Test_Sparse_gauss_seidel.hpp
+++ b/sparse/unit_test/Test_Sparse_gauss_seidel.hpp
@@ -620,7 +620,7 @@ void test_gauss_seidel_streams_rank1(lno_t numRows, size_type nnz, lno_t bandwid
   using const_lno_t     = const lno_t;
   using const_scalar_t  = const scalar_t;
   using KernelHandle    = KokkosKernelsHandle<const_size_type, const_lno_t, const_scalar_t, execution_space,
-                                              typename device::memory_space, typename device::memory_space>;
+                                           typename device::memory_space, typename device::memory_space>;
   srand(245);
   lno_t numCols                         = numRows;
   typename crsMat_t::value_type m_omega = omega;

--- a/sparse/unit_test/Test_Sparse_gauss_seidel.hpp
+++ b/sparse/unit_test/Test_Sparse_gauss_seidel.hpp
@@ -45,7 +45,7 @@ namespace Test {
 
 // Run GS on the given vectors, where the handle is already set up.
 template <typename Handle, typename crsMat_t, typename vec_t>
-void run_gauss_seidel(Handle &kh, crsMat_t input_mat, vec_t x_vector, vec_t y_vector, bool is_symmetric_graph,
+void run_gauss_seidel(Handle& kh, crsMat_t input_mat, vec_t x_vector, vec_t y_vector, bool is_symmetric_graph,
                       typename crsMat_t::value_type omega,
                       int apply_type = 0  // 0 for symmetric, 1 for forward, 2 for backward.
 ) {
@@ -122,9 +122,9 @@ void run_gauss_seidel(crsMat_t input_mat, GSAlgorithm gs_algorithm, vec_t x_vect
 }
 
 template <typename ExecSpace, typename Handle, typename crsMat_t, typename vec_t>
-void run_gauss_seidel_streams(std::vector<ExecSpace> &instances, std::vector<Handle> &kh,
-                              std::vector<crsMat_t> &input_mat, std::vector<vec_t> &x_vector,
-                              std::vector<vec_t> &y_vector, bool is_symmetric_graph,
+void run_gauss_seidel_streams(std::vector<ExecSpace>& instances, std::vector<Handle>& kh,
+                              std::vector<crsMat_t>& input_mat, std::vector<vec_t>& x_vector,
+                              std::vector<vec_t>& y_vector, bool is_symmetric_graph,
                               typename crsMat_t::value_type omega,
                               int apply_type,  // 0 for symmetric, 1 for forward, 2 for backward.
                               int nstreams = 1) {
@@ -243,8 +243,8 @@ void test_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth, lno_
   using namespace Test;
   srand(245);
   typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type> crsMat_t;
-  typedef Kokkos::View<scalar_t **, KokkosKernels::default_layout, device> scalar_view2d_t;
-  typedef Kokkos::View<scalar_t **, KokkosKernels::default_layout, Kokkos::HostSpace> host_scalar_view2d_t;
+  typedef Kokkos::View<scalar_t**, KokkosKernels::default_layout, device> scalar_view2d_t;
+  typedef Kokkos::View<scalar_t**, KokkosKernels::default_layout, Kokkos::HostSpace> host_scalar_view2d_t;
   typedef typename KokkosKernels::ArithTraits<scalar_t>::mag_type mag_t;
 
   lno_t numCols      = numRows;
@@ -377,7 +377,7 @@ void test_sequential_sor(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t ro
   // initial solution is zero
   Kokkos::deep_copy(x_host, zero);
   // get the inverse diagonal (only needed on host)
-  Kokkos::View<scalar_t *, Kokkos::HostSpace> invDiag("diag^-1", numRows);
+  Kokkos::View<scalar_t*, Kokkos::HostSpace> invDiag("diag^-1", numRows);
   for (lno_t i = 0; i < numRows; i++) {
     for (size_type j = rowmap(i); j < rowmap(i + 1); j++) {
       if (entries(j) == i) invDiag(i) = one / values(j);
@@ -497,7 +497,9 @@ void test_gauss_seidel_long_rows(lno_t numRows, lno_t numLongRows, lno_t nnzPerS
   typedef typename crsMat_t::row_map_type::non_const_type rowmap_view_t;
   typedef typename KokkosKernels::ArithTraits<scalar_t>::mag_type mag_t;
   const scalar_t one = KokkosKernels::ArithTraits<scalar_t>::one();
-  srand(245);
+  // Host matrix generation: avoid MSVC's RAND_MAX==32767 and rand()%N, which skew
+  // off-diagonals and break diagonal dominance vs POSIX rand(). Use a portable RNG.
+  std::mt19937 rng(245u);
   std::vector<size_type> rowmap = {0};
   std::vector<lno_t> entries;
   std::vector<scalar_t> values;
@@ -508,22 +510,23 @@ void test_gauss_seidel_long_rows(lno_t numRows, lno_t numLongRows, lno_t nnzPerS
     else
       rowLengths.push_back(nnzPerShortRow);
   }
-  std::shuffle(rowLengths.begin(), rowLengths.end(), std::mt19937(std::random_device()()));
+  std::shuffle(rowLengths.begin(), rowLengths.end(), rng);
   size_type totalEntries = 0;
-  int randSteps          = 1000000;
   scalar_t offDiagBase;
   {
     scalar_t unused;
     Test::getRandomBounds(0.6, unused, offDiagBase);
   }
+  std::uniform_int_distribution<lno_t> colDist(0, numRows - 1);
+  std::uniform_real_distribution<double> offDiagCoeffDist(-0.3, 0.3);
   for (lno_t i = 0; i < numRows; i++) {
     for (lno_t ent = 0; ent < rowLengths[i]; ent++) {
       if (ent == 0) {
         entries.push_back(i);
         values.push_back(2.5 * one);
       } else {
-        entries.push_back(rand() % numRows);
-        values.push_back((-0.3 + (0.6 * (rand() % randSteps) / randSteps)) * offDiagBase);
+        entries.push_back(colDist(rng));
+        values.push_back(static_cast<scalar_t>(offDiagCoeffDist(rng)) * offDiagBase);
       }
     }
     totalEntries += rowLengths[i];
@@ -532,9 +535,9 @@ void test_gauss_seidel_long_rows(lno_t numRows, lno_t numLongRows, lno_t nnzPerS
   scalar_view_t valuesView(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Values"), totalEntries);
   entries_view_t entriesView(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Entries"), totalEntries);
   rowmap_view_t rowmapView(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Rowmap"), numRows + 1);
-  Kokkos::deep_copy(valuesView, Kokkos::View<scalar_t *, Kokkos::HostSpace>(values.data(), totalEntries));
-  Kokkos::deep_copy(entriesView, Kokkos::View<lno_t *, Kokkos::HostSpace>(entries.data(), totalEntries));
-  Kokkos::deep_copy(rowmapView, Kokkos::View<size_type *, Kokkos::HostSpace>(rowmap.data(), numRows + 1));
+  Kokkos::deep_copy(valuesView, Kokkos::View<scalar_t*, Kokkos::HostSpace>(values.data(), totalEntries));
+  Kokkos::deep_copy(entriesView, Kokkos::View<lno_t*, Kokkos::HostSpace>(entries.data(), totalEntries));
+  Kokkos::deep_copy(rowmapView, Kokkos::View<size_type*, Kokkos::HostSpace>(rowmap.data(), numRows + 1));
   crsMat_t input_mat("A", numRows, numRows, totalEntries, valuesView, rowmapView, entriesView);
   input_mat = KokkosSparse::sort_and_merge_matrix(input_mat);
   if (symmetric) {
@@ -617,7 +620,7 @@ void test_gauss_seidel_streams_rank1(lno_t numRows, size_type nnz, lno_t bandwid
   using const_lno_t     = const lno_t;
   using const_scalar_t  = const scalar_t;
   using KernelHandle    = KokkosKernelsHandle<const_size_type, const_lno_t, const_scalar_t, execution_space,
-                                           typename device::memory_space, typename device::memory_space>;
+                                              typename device::memory_space, typename device::memory_space>;
   srand(245);
   lno_t numCols                         = numRows;
   typename crsMat_t::value_type m_omega = omega;


### PR DESCRIPTION
## Motivation

Eliminate issues with compiling on Windows platform. On MSVC, `RAND_MAX` is `32767` (vs `2^31-1` on POSIX), so `rand() % 1000000` only produces values in [0, 32767]. This collapses all off-diagonal entries into (-0.300, -0.280), violating diagonal dominance for long rows and causing Gauss-Seidel to diverge.
Additionally, `std::shuffle` used `std::random_device()` as seed, making the test non-deterministic across runs.

## Related Issues

- Trilinos [Issue 14816](https://github.com/trilinos/Trilinos/issues/14816)

## References

- [Cppreference C rand](https://en.cppreference.com/c/numeric/random/rand)
- [MSDN RAND_MAX](https://learn.microsoft.com/en-us/cpp/c-runtime-library/rand-max?view=msvc-170)
- [Sources of stdlib.h for Linux](https://github.com/openbsd/src/blob/master/include/stdlib.h#L83)
- [Stackoverflow discussion](https://stackoverflow.com/questions/55698041/why-rand-max-differs-on-the-same-machine-in-linux-from-windows)

## Testing

> Copied from [Trilinos#14816](https://github.com/trilinos/Trilinos/issues/14816)

**NOTE**: Tested inside Trilinos, not directly from upstream of develop in kokkos-kernels!
sha1: 41f49245f6f94a7018583033d35bb4713331224e

### Before

Full log of ctest: [ctest-output-win64.log](https://github.com/user-attachments/files/27513822/ctest-output-win64.log)

```cmd
D:\Develop\Trilinos\build\packages\kokkos-kernels\sparse\unit_test>set PATH=D:\Develop\Trilinos\build\packages\kokkos\core\src;D:\Develop\Trilinos\build\packages\kokkos\containers\src;D:\Develop\Trilinos\build\packages\kokkos-kernels;%PATH%
D:\Develop\Trilinos\build\packages\kokkos-kernels\sparse\unit_test>KokkosKernels_sparse_serial.exe --gtest_filter="serial.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice"
Kokkos::OpenMP::initialize WARNING: OMP_PROC_BIND environment variable not set
  In general, for best performance with OpenMP 4.0 or better set OMP_PROC_BIND=spread and OMP_PLACES=threads
  For best performance with OpenMP 3.1 set OMP_PROC_BIND=true
  For unit testing set OMP_PROC_BIND=false

Note: Google Test filter = serial.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from serial
[ RUN      ] serial.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice
D:\Develop\Trilinos\packages\kokkos-kernels\sparse\unit_test\Test_Sparse_gauss_seidel.hpp(569): error: Expected: (result_norm_res) < (0.25 * initial_norm_res), actual: 2.63714e+06 vs 32.5596
[  FAILED  ] serial.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice (13 ms)
[----------] 1 test from serial (14 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (17 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] serial.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice

 1 FAILED TEST

D:\Develop\Trilinos\build\packages\kokkos-kernels\sparse\unit_test>KokkosKernels_sparse_openmp.exe --gtest_filter="openmp.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice"
Kokkos::OpenMP::initialize WARNING: OMP_PROC_BIND environment variable not set
  In general, for best performance with OpenMP 4.0 or better set OMP_PROC_BIND=spread and OMP_PLACES=threads
  For best performance with OpenMP 3.1 set OMP_PROC_BIND=true
  For unit testing set OMP_PROC_BIND=false

Note: Google Test filter = openmp.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from openmp
[ RUN      ] openmp.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice
D:\Develop\Trilinos\packages\kokkos-kernels\sparse\unit_test\Test_Sparse_gauss_seidel.hpp(569): error: Expected: (result_norm_res) < (0.25 * initial_norm_res), actual: 1.84658e+06 vs 32.5596
[  FAILED  ] openmp.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice (43 ms)
[----------] 1 test from openmp (44 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (46 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] openmp.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice

 1 FAILED TEST

D:\Develop\Trilinos\build\packages\kokkos-kernels\sparse\unit_test>for /L %i in (1,1,5) do (KokkosKernels_sparse_serial.exe --gtest_filter="serial.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice" 2>&1 | findstr "actual")

D:\Develop\Trilinos\build\packages\kokkos-kernels\sparse\unit_test>(KokkosKernels_sparse_serial.exe --gtest_filter="serial.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice"   2>&1  | findstr "actual" )
D:\Develop\Trilinos\packages\kokkos-kernels\sparse\unit_test\Test_Sparse_gauss_seidel.hpp(569): error: Expected: (result_norm_res) < (0.25 * initial_norm_res), actual: 1.43901e+06 vs 32.5596

D:\Develop\Trilinos\build\packages\kokkos-kernels\sparse\unit_test>(KokkosKernels_sparse_serial.exe --gtest_filter="serial.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice"   2>&1  | findstr "actual" )
D:\Develop\Trilinos\packages\kokkos-kernels\sparse\unit_test\Test_Sparse_gauss_seidel.hpp(569): error: Expected: (result_norm_res) < (0.25 * initial_norm_res), actual: 3.31529e+06 vs 32.5596

D:\Develop\Trilinos\build\packages\kokkos-kernels\sparse\unit_test>(KokkosKernels_sparse_serial.exe --gtest_filter="serial.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice"   2>&1  | findstr "actual" )
D:\Develop\Trilinos\packages\kokkos-kernels\sparse\unit_test\Test_Sparse_gauss_seidel.hpp(569): error: Expected: (result_norm_res) < (0.25 * initial_norm_res), actual: 3.20342e+06 vs 32.5596

D:\Develop\Trilinos\build\packages\kokkos-kernels\sparse\unit_test>(KokkosKernels_sparse_serial.exe --gtest_filter="serial.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice"   2>&1  | findstr "actual" )
D:\Develop\Trilinos\packages\kokkos-kernels\sparse\unit_test\Test_Sparse_gauss_seidel.hpp(569): error: Expected: (result_norm_res) < (0.25 * initial_norm_res), actual: 4.07912e+06 vs 32.5596

D:\Develop\Trilinos\build\packages\kokkos-kernels\sparse\unit_test>(KokkosKernels_sparse_serial.exe --gtest_filter="serial.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice"   2>&1  | findstr "actual" )
D:\Develop\Trilinos\packages\kokkos-kernels\sparse\unit_test\Test_Sparse_gauss_seidel.hpp(569): error: Expected: (result_norm_res) < (0.25 * initial_norm_res), actual: 2.21833e+06 vs 32.5596

D:\Develop\Trilinos\build\packages\kokkos-kernels\sparse\unit_test>
```

### After


```cmd
D:\Develop\Trilinos\build\packages\kokkos-kernels\sparse\unit_test>set PATH=D:\Develop\Trilinos\build\packages\kokkos\core\src;D:\Develop\Trilinos\build\packages\kokkos\containers\src;D:\Develop\Trilinos\build\packages\kokkos-kernels;%PATH%

D:\Develop\Trilinos\build\packages\kokkos-kernels\sparse\unit_test>KokkosKernels_sparse_serial.exe --gtest_filter="serial.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice" && KokkosKernels_sparse_openmp.exe --gtest_filter="openmp.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice"
Kokkos::OpenMP::initialize WARNING: OMP_PROC_BIND environment variable not set
  In general, for best performance with OpenMP 4.0 or better set OMP_PROC_BIND=spread and OMP_PLACES=threads
  For best performance with OpenMP 3.1 set OMP_PROC_BIND=true
  For unit testing set OMP_PROC_BIND=false

Note: Google Test filter = serial.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from serial
[ RUN      ] serial.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice
[       OK ] serial.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice (7 ms)
[----------] 1 test from serial (8 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (11 ms total)
[  PASSED  ] 1 test.
Kokkos::OpenMP::initialize WARNING: OMP_PROC_BIND environment variable not set
  In general, for best performance with OpenMP 4.0 or better set OMP_PROC_BIND=spread and OMP_PLACES=threads
  For best performance with OpenMP 3.1 set OMP_PROC_BIND=true
  For unit testing set OMP_PROC_BIND=false

Note: Google Test filter = openmp.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from openmp
[ RUN      ] openmp.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice
[       OK ] openmp.sparse_gauss_seidel_long_rows_double_int_size_t_TestDevice (40 ms)
[----------] 1 test from openmp (41 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (42 ms total)
[  PASSED  ] 1 test.

D:\Develop\Trilinos\build\packages\kokkos-kernels\sparse\unit_test>
```

#### Full testing Kokkos & Kokkos-Kernels

```cmd
ctest -V --output-on-failure
...
100% tests passed, 0 tests failed out of 88

Subproject Time Summary:
Kokkos           = 1204.80 sec*proc (42 tests)
KokkosKernels    = 423.62 sec*proc (43 tests)

Total Test time (real) = 1631.63 sec
```

