### PR TITLE
Implement batched serial/team/teamvector rotm

### DIFF
--- a/batched/dense/impl/KokkosBatched_Rotm_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Rotm_Impl.hpp
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOSBATCHED_ROTM_IMPL_HPP_
+#define KOKKOSBATCHED_ROTM_IMPL_HPP_
+
+#include <KokkosBlas_util.hpp>
+#include <KokkosBatched_Util.hpp>
+#include "KokkosBatched_Rotm_Internal.hpp"
+
+namespace KokkosBatched {
+namespace Impl {
+template <typename XViewType, typename YViewType, typename ParamViewType>
+KOKKOS_INLINE_FUNCTION static int checkRotmInput([[maybe_unused]] const XViewType &x,
+                                                 [[maybe_unused]] const YViewType &y,
+                                                 [[maybe_unused]] const ParamViewType &param) {
+  static_assert(Kokkos::is_view_v<XViewType>, "KokkosBatched::rot: XViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view_v<YViewType>, "KokkosBatched::rot: YViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view_v<ParamViewType>, "KokkosBatched::rot: ParamViewType is not a Kokkos::View.");
+  static_assert(XViewType::rank() == 1, "KokkosBatched::rot: XViewType must have rank 1.");
+  static_assert(YViewType::rank() == 1, "KokkosBatched::rot: YViewType must have rank 1.");
+  static_assert(ParamViewType::rank() == 1, "KokkosBatched::rot: ParamViewType must have rank 1.");
+  static_assert(std::is_same_v<typename XViewType::value_type, typename XViewType::non_const_value_type>,
+                "KokkosBatched::rot: XViewType must have non-const value type.");
+  static_assert(std::is_same_v<typename YViewType::value_type, typename YViewType::non_const_value_type>,
+                "KokkosBatched::rot: YViewType must have non-const value type.");
+  using x_value_type     = typename XViewType::non_const_value_type;
+  using y_value_type     = typename YViewType::non_const_value_type;
+  using param_value_type = typename ParamViewType::non_const_value_type;
+
+  static_assert(!KokkosKernels::ArithTraits<x_value_type>::is_complex &&
+                    !KokkosKernels::ArithTraits<y_value_type>::is_complex &&
+                    !KokkosKernels::ArithTraits<param_value_type>::is_complex,
+                "KokkosBatched::rotm: Complex types are not supported for Rotm.");
+
+#ifndef NDEBUG
+  const int n = x.extent_int(0);
+
+  if (y.extent_int(0) != n) {
+    Kokkos::printf(
+        "KokkosBatched::rotm: x and y must have the same length: x length "
+        "= "
+        "%d, y length = %d\n",
+        n, y.extent_int(0));
+    return 1;
+  }
+
+  // We handle flag as a template parameter, so we only need to check that the length of param is 4, but not the value
+  // of flag
+  if (param.extent_int(0) != 4) {
+    Kokkos::printf("KokkosBatched::rotm: param must have length 4: param length = %d\n", param.extent_int(0));
+    return 1;
+  }
+#endif
+  return 0;
+}
+}  // namespace Impl
+
+///
+/// Serial Impl
+/// ===========
+
+template <int Flag>
+template <typename XViewType, typename YViewType, typename ParamViewType>
+KOKKOS_INLINE_FUNCTION int SerialRotm<Flag>::invoke(const XViewType &x, const YViewType &y,
+                                                    const ParamViewType &param) {
+  // Quick return if possible
+  const int n = x.extent_int(0);
+  if (n == 0) return 0;
+
+  auto info = Impl::checkRotmInput(x, y, param);
+  if (info) return info;
+
+  if constexpr (Flag == -2) {
+    // flag == -2.0: identity, no need to do anything
+    return 0;
+  } else {
+    return Impl::SerialRotmInternal<Flag>::invoke(n, x.data(), x.stride(0), y.data(), y.stride(0), param.data(),
+                                                  param.stride(0));
+  }
+}
+
+///
+/// Team Impl
+/// ===========
+
+template <typename MemberType, int Flag>
+template <typename XViewType, typename YViewType, typename ParamViewType>
+KOKKOS_INLINE_FUNCTION int TeamRotm<MemberType, Flag>::invoke(const MemberType &member, const XViewType &x,
+                                                              const YViewType &y, const ParamViewType &param) {
+  // Quick return if possible
+  const int n = x.extent_int(0);
+  if (n == 0) return 0;
+
+  auto info = Impl::checkRotmInput(x, y, param);
+  if (info) return info;
+
+  if constexpr (Flag == -2) {
+    // flag == -2.0: identity, no need to do anything
+    return 0;
+  } else {
+    return Impl::TeamRotmInternal<Flag>::invoke(member, n, x.data(), x.stride(0), y.data(), y.stride(0), param.data(),
+                                                param.stride(0));
+  }
+}
+
+///
+/// TeamVector Impl
+/// ===============
+
+template <typename MemberType, int Flag>
+template <typename XViewType, typename YViewType, typename ParamViewType>
+KOKKOS_INLINE_FUNCTION int TeamVectorRotm<MemberType, Flag>::invoke(const MemberType &member, const XViewType &x,
+                                                                    const YViewType &y, const ParamViewType &param) {
+  // Quick return if possible
+  const int n = x.extent_int(0);
+  if (n == 0) return 0;
+
+  auto info = Impl::checkRotmInput(x, y, param);
+  if (info) return info;
+
+  if constexpr (Flag == -2) {
+    // flag == -2.0: identity, no need to do anything
+    return 0;
+  } else {
+    return Impl::TeamVectorRotmInternal<Flag>::invoke(member, n, x.data(), x.stride(0), y.data(), y.stride(0),
+                                                      param.data(), param.stride(0));
+  }
+}
+
+}  // namespace KokkosBatched
+
+#endif  // KOKKOSBATCHED_ROTM_IMPL_HPP_

--- a/batched/dense/impl/KokkosBatched_Rotm_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Rotm_Impl.hpp
@@ -14,16 +14,16 @@ template <typename XViewType, typename YViewType, typename ParamViewType>
 KOKKOS_INLINE_FUNCTION static int checkRotmInput([[maybe_unused]] const XViewType &x,
                                                  [[maybe_unused]] const YViewType &y,
                                                  [[maybe_unused]] const ParamViewType &param) {
-  static_assert(Kokkos::is_view_v<XViewType>, "KokkosBatched::rot: XViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view_v<YViewType>, "KokkosBatched::rot: YViewType is not a Kokkos::View.");
-  static_assert(Kokkos::is_view_v<ParamViewType>, "KokkosBatched::rot: ParamViewType is not a Kokkos::View.");
-  static_assert(XViewType::rank() == 1, "KokkosBatched::rot: XViewType must have rank 1.");
-  static_assert(YViewType::rank() == 1, "KokkosBatched::rot: YViewType must have rank 1.");
-  static_assert(ParamViewType::rank() == 1, "KokkosBatched::rot: ParamViewType must have rank 1.");
+  static_assert(Kokkos::is_view_v<XViewType>, "KokkosBatched::rotm: XViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view_v<YViewType>, "KokkosBatched::rotm: YViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view_v<ParamViewType>, "KokkosBatched::rotm: ParamViewType is not a Kokkos::View.");
+  static_assert(XViewType::rank() == 1, "KokkosBatched::rotm: XViewType must have rank 1.");
+  static_assert(YViewType::rank() == 1, "KokkosBatched::rotm: YViewType must have rank 1.");
+  static_assert(ParamViewType::rank() == 1, "KokkosBatched::rotm: ParamViewType must have rank 1.");
   static_assert(std::is_same_v<typename XViewType::value_type, typename XViewType::non_const_value_type>,
-                "KokkosBatched::rot: XViewType must have non-const value type.");
+                "KokkosBatched::rotm: XViewType must have non-const value type.");
   static_assert(std::is_same_v<typename YViewType::value_type, typename YViewType::non_const_value_type>,
-                "KokkosBatched::rot: YViewType must have non-const value type.");
+                "KokkosBatched::rotm: YViewType must have non-const value type.");
   using x_value_type     = typename XViewType::non_const_value_type;
   using y_value_type     = typename YViewType::non_const_value_type;
   using param_value_type = typename ParamViewType::non_const_value_type;

--- a/batched/dense/impl/KokkosBatched_Rotm_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Rotm_Impl.hpp
@@ -71,13 +71,12 @@ KOKKOS_INLINE_FUNCTION int SerialRotm<Flag>::invoke(const XViewType &x, const YV
   auto info = Impl::checkRotmInput(x, y, param);
   if (info) return info;
 
-  if constexpr (Flag == -2) {
+  if constexpr (Flag != -2) {
     // flag == -2.0: identity, no need to do anything
-    return 0;
-  } else {
-    return Impl::SerialRotmInternal<Flag>::invoke(n, x.data(), x.stride(0), y.data(), y.stride(0), param.data(),
-                                                  param.stride(0));
+    Impl::SerialRotmInternal<Flag>::invoke(n, x.data(), x.stride(0), y.data(), y.stride(0), param.data(),
+                                           param.stride(0));
   }
+  return 0;
 }
 
 ///
@@ -95,13 +94,12 @@ KOKKOS_INLINE_FUNCTION int TeamRotm<MemberType, Flag>::invoke(const MemberType &
   auto info = Impl::checkRotmInput(x, y, param);
   if (info) return info;
 
-  if constexpr (Flag == -2) {
+  if constexpr (Flag != -2) {
     // flag == -2.0: identity, no need to do anything
-    return 0;
-  } else {
-    return Impl::TeamRotmInternal<Flag>::invoke(member, n, x.data(), x.stride(0), y.data(), y.stride(0), param.data(),
-                                                param.stride(0));
+    Impl::TeamRotmInternal<Flag>::invoke(member, n, x.data(), x.stride(0), y.data(), y.stride(0), param.data(),
+                                         param.stride(0));
   }
+  return 0;
 }
 
 ///
@@ -119,13 +117,12 @@ KOKKOS_INLINE_FUNCTION int TeamVectorRotm<MemberType, Flag>::invoke(const Member
   auto info = Impl::checkRotmInput(x, y, param);
   if (info) return info;
 
-  if constexpr (Flag == -2) {
+  if constexpr (Flag != -2) {
     // flag == -2.0: identity, no need to do anything
-    return 0;
-  } else {
-    return Impl::TeamVectorRotmInternal<Flag>::invoke(member, n, x.data(), x.stride(0), y.data(), y.stride(0),
-                                                      param.data(), param.stride(0));
+    Impl::TeamVectorRotmInternal<Flag>::invoke(member, n, x.data(), x.stride(0), y.data(), y.stride(0), param.data(),
+                                               param.stride(0));
   }
+  return 0;
 }
 
 }  // namespace KokkosBatched

--- a/batched/dense/impl/KokkosBatched_Rotm_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Rotm_Internal.hpp
@@ -15,16 +15,16 @@ namespace Impl {
 template <int Flag>
 struct SerialRotmInternal {
   template <typename ValueType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const int n, ValueType *KOKKOS_RESTRICT x, const int xs0,
-                                           ValueType *KOKKOS_RESTRICT y, const int ys0,
-                                           const ValueType *KOKKOS_RESTRICT param, const int ps0);
+  KOKKOS_INLINE_FUNCTION static void invoke(const int n, ValueType *KOKKOS_RESTRICT x, const int xs0,
+                                            ValueType *KOKKOS_RESTRICT y, const int ys0,
+                                            const ValueType *KOKKOS_RESTRICT param, const int ps0);
 };
 
 template <int Flag>
 template <typename ValueType>
-KOKKOS_INLINE_FUNCTION int SerialRotmInternal<Flag>::invoke(const int n, ValueType *KOKKOS_RESTRICT x, const int xs0,
-                                                            ValueType *KOKKOS_RESTRICT y, const int ys0,
-                                                            const ValueType *KOKKOS_RESTRICT param, const int ps0) {
+KOKKOS_INLINE_FUNCTION void SerialRotmInternal<Flag>::invoke(const int n, ValueType *KOKKOS_RESTRICT x, const int xs0,
+                                                             ValueType *KOKKOS_RESTRICT y, const int ys0,
+                                                             const ValueType *KOKKOS_RESTRICT param, const int ps0) {
   if constexpr (Flag == -1) {
     // flag == -1.0: [[h11, h12], [h21, h22]]
     auto h11 = param[0 * ps0];
@@ -56,7 +56,6 @@ KOKKOS_INLINE_FUNCTION int SerialRotmInternal<Flag>::invoke(const int n, ValueTy
     }
   }
   // Checks for flag == -2.0 (identity) are done in the checkRotmInput function, so we don't need to handle it here.
-  return 0;
 }
 
 ///
@@ -66,17 +65,17 @@ KOKKOS_INLINE_FUNCTION int SerialRotmInternal<Flag>::invoke(const int n, ValueTy
 template <int Flag>
 struct TeamRotmInternal {
   template <typename MemberType, typename ValueType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const int n, ValueType *KOKKOS_RESTRICT x,
-                                           const int xs0, ValueType *KOKKOS_RESTRICT y, const int ys0,
-                                           const ValueType *KOKKOS_RESTRICT param, const int ps0);
+  KOKKOS_INLINE_FUNCTION static void invoke(const MemberType &member, const int n, ValueType *KOKKOS_RESTRICT x,
+                                            const int xs0, ValueType *KOKKOS_RESTRICT y, const int ys0,
+                                            const ValueType *KOKKOS_RESTRICT param, const int ps0);
 };
 
 template <int Flag>
 template <typename MemberType, typename ValueType>
-KOKKOS_INLINE_FUNCTION int TeamRotmInternal<Flag>::invoke(const MemberType &member, const int n,
-                                                          ValueType *KOKKOS_RESTRICT x, const int xs0,
-                                                          ValueType *KOKKOS_RESTRICT y, const int ys0,
-                                                          const ValueType *KOKKOS_RESTRICT param, const int ps0) {
+KOKKOS_INLINE_FUNCTION void TeamRotmInternal<Flag>::invoke(const MemberType &member, const int n,
+                                                           ValueType *KOKKOS_RESTRICT x, const int xs0,
+                                                           ValueType *KOKKOS_RESTRICT y, const int ys0,
+                                                           const ValueType *KOKKOS_RESTRICT param, const int ps0) {
   if constexpr (Flag == -1) {
     // flag == -1.0: [[h11, h12], [h21, h22]]
     auto h11 = param[0 * ps0];
@@ -107,8 +106,6 @@ KOKKOS_INLINE_FUNCTION int TeamRotmInternal<Flag>::invoke(const MemberType &memb
       x[i * xs0] = temp;
     });
   }
-
-  return 0;
 }
 
 ///
@@ -117,17 +114,18 @@ KOKKOS_INLINE_FUNCTION int TeamRotmInternal<Flag>::invoke(const MemberType &memb
 template <int Flag>
 struct TeamVectorRotmInternal {
   template <typename MemberType, typename ValueType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const int n, ValueType *KOKKOS_RESTRICT x,
-                                           const int xs0, ValueType *KOKKOS_RESTRICT y, const int ys0,
-                                           const ValueType *KOKKOS_RESTRICT param, const int ps0);
+  KOKKOS_INLINE_FUNCTION static void invoke(const MemberType &member, const int n, ValueType *KOKKOS_RESTRICT x,
+                                            const int xs0, ValueType *KOKKOS_RESTRICT y, const int ys0,
+                                            const ValueType *KOKKOS_RESTRICT param, const int ps0);
 };
 
 template <int Flag>
 template <typename MemberType, typename ValueType>
-KOKKOS_INLINE_FUNCTION int TeamVectorRotmInternal<Flag>::invoke(const MemberType &member, const int n,
-                                                                ValueType *KOKKOS_RESTRICT x, const int xs0,
-                                                                ValueType *KOKKOS_RESTRICT y, const int ys0,
-                                                                const ValueType *KOKKOS_RESTRICT param, const int ps0) {
+KOKKOS_INLINE_FUNCTION void TeamVectorRotmInternal<Flag>::invoke(const MemberType &member, const int n,
+                                                                 ValueType *KOKKOS_RESTRICT x, const int xs0,
+                                                                 ValueType *KOKKOS_RESTRICT y, const int ys0,
+                                                                 const ValueType *KOKKOS_RESTRICT param,
+                                                                 const int ps0) {
   if constexpr (Flag == -1) {
     // flag == -1.0: [[h11, h12], [h21, h22]]
     auto h11 = param[0 * ps0];
@@ -158,7 +156,6 @@ KOKKOS_INLINE_FUNCTION int TeamVectorRotmInternal<Flag>::invoke(const MemberType
       x[i * xs0] = temp;
     });
   }
-  return 0;
 }
 
 }  // namespace Impl

--- a/batched/dense/impl/KokkosBatched_Rotm_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Rotm_Internal.hpp
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOSBATCHED_ROTM_INTERNAL_HPP_
+#define KOKKOSBATCHED_ROTM_INTERNAL_HPP_
+
+#include <KokkosBatched_Util.hpp>
+
+namespace KokkosBatched {
+namespace Impl {
+
+///
+/// Serial Internal Impl
+/// ====================
+template <int Flag>
+struct SerialRotmInternal {
+  template <typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const int n, ValueType *KOKKOS_RESTRICT x, const int xs0,
+                                           ValueType *KOKKOS_RESTRICT y, const int ys0,
+                                           const ValueType *KOKKOS_RESTRICT param, const int ps0);
+};
+
+template <int Flag>
+template <typename ValueType>
+KOKKOS_INLINE_FUNCTION int SerialRotmInternal<Flag>::invoke(const int n, ValueType *KOKKOS_RESTRICT x, const int xs0,
+                                                            ValueType *KOKKOS_RESTRICT y, const int ys0,
+                                                            const ValueType *KOKKOS_RESTRICT param, const int ps0) {
+  if constexpr (Flag == -1) {
+    // flag == -1.0: [[h11, h12], [h21, h22]]
+    auto h11 = param[0 * ps0];
+    auto h21 = param[1 * ps0];
+    auto h12 = param[2 * ps0];
+    auto h22 = param[3 * ps0];
+    for (int i = 0; i < n; ++i) {
+      auto temp  = h11 * x[i * xs0] + h12 * y[i * ys0];
+      y[i * ys0] = h21 * x[i * xs0] + h22 * y[i * ys0];
+      x[i * xs0] = temp;
+    }
+  } else if constexpr (Flag == 0) {
+    // flag == 0.0: [[1, h12], [h21, 1]]
+    auto h12 = param[2 * ps0];
+    auto h21 = param[1 * ps0];
+    for (int i = 0; i < n; ++i) {
+      auto temp  = x[i * xs0] + h12 * y[i * ys0];
+      y[i * ys0] = h21 * x[i * xs0] + y[i * ys0];
+      x[i * xs0] = temp;
+    }
+  } else if constexpr (Flag == 1) {
+    // flag == 1.0: [[h11, 1], [-1, h22]]
+    auto h11 = param[0 * ps0];
+    auto h22 = param[3 * ps0];
+    for (int i = 0; i < n; ++i) {
+      auto temp  = h11 * x[i * xs0] + y[i * ys0];
+      y[i * ys0] = -x[i * xs0] + h22 * y[i * ys0];
+      x[i * xs0] = temp;
+    }
+  }
+  // Checks for flag == -2.0 (identity) are done in the checkRotmInput function, so we don't need to handle it here.
+  return 0;
+};
+
+///
+/// Team Internal Impl
+///
+/// ==================
+template <int Flag>
+struct TeamRotmInternal {
+  template <typename MemberType, typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const int n, ValueType *KOKKOS_RESTRICT x,
+                                           const int xs0, ValueType *KOKKOS_RESTRICT y, const int ys0,
+                                           const ValueType *KOKKOS_RESTRICT param, const int ps0);
+};
+
+template <int Flag>
+template <typename MemberType, typename ValueType>
+KOKKOS_INLINE_FUNCTION int TeamRotmInternal<Flag>::invoke(const MemberType &member, const int n,
+                                                          ValueType *KOKKOS_RESTRICT x, const int xs0,
+                                                          ValueType *KOKKOS_RESTRICT y, const int ys0,
+                                                          const ValueType *KOKKOS_RESTRICT param, const int ps0) {
+  if constexpr (Flag == -1) {
+    // flag == -1.0: [[h11, h12], [h21, h22]]
+    auto h11 = param[0 * ps0];
+    auto h21 = param[1 * ps0];
+    auto h12 = param[2 * ps0];
+    auto h22 = param[3 * ps0];
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int &i) {
+      auto temp  = h11 * x[i * xs0] + h12 * y[i * ys0];
+      y[i * ys0] = h21 * x[i * xs0] + h22 * y[i * ys0];
+      x[i * xs0] = temp;
+    });
+  } else if constexpr (Flag == 0) {
+    // flag == 0.0: [[1, h12], [h21, 1]]
+    auto h12 = param[2 * ps0];
+    auto h21 = param[1 * ps0];
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int &i) {
+      auto temp  = x[i * xs0] + h12 * y[i * ys0];
+      y[i * ys0] = h21 * x[i * xs0] + y[i * ys0];
+      x[i * xs0] = temp;
+    });
+  } else if constexpr (Flag == 1) {
+    // flag == 1.0: [[h11, 1], [-1, h22]]
+    auto h11 = param[0 * ps0];
+    auto h22 = param[3 * ps0];
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int &i) {
+      auto temp  = h11 * x[i * xs0] + y[i * ys0];
+      y[i * ys0] = -x[i * xs0] + h22 * y[i * ys0];
+      x[i * xs0] = temp;
+    });
+  }
+
+  return 0;
+}
+
+///
+/// TeamVector Internal Impl
+/// ========================
+template <int Flag>
+struct TeamVectorRotmInternal {
+  template <typename MemberType, typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const int n, ValueType *KOKKOS_RESTRICT x,
+                                           const int xs0, ValueType *KOKKOS_RESTRICT y, const int ys0,
+                                           const ValueType *KOKKOS_RESTRICT param, const int ps0);
+};
+
+template <int Flag>
+template <typename MemberType, typename ValueType>
+KOKKOS_INLINE_FUNCTION int TeamVectorRotmInternal<Flag>::invoke(const MemberType &member, const int n,
+                                                                ValueType *KOKKOS_RESTRICT x, const int xs0,
+                                                                ValueType *KOKKOS_RESTRICT y, const int ys0,
+                                                                const ValueType *KOKKOS_RESTRICT param, const int ps0) {
+  if constexpr (Flag == -1) {
+    // flag == -1.0: [[h11, h12], [h21, h22]]
+    auto h11 = param[0 * ps0];
+    auto h21 = param[1 * ps0];
+    auto h12 = param[2 * ps0];
+    auto h22 = param[3 * ps0];
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n), [&](const int &i) {
+      auto temp  = h11 * x[i * xs0] + h12 * y[i * ys0];
+      y[i * ys0] = h21 * x[i * xs0] + h22 * y[i * ys0];
+      x[i * xs0] = temp;
+    });
+  } else if constexpr (Flag == 0) {
+    // flag == 0.0: [[1, h12], [h21, 1]]
+    auto h12 = param[2 * ps0];
+    auto h21 = param[1 * ps0];
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n), [&](const int &i) {
+      auto temp  = x[i * xs0] + h12 * y[i * ys0];
+      y[i * ys0] = h21 * x[i * xs0] + y[i * ys0];
+      x[i * xs0] = temp;
+    });
+  } else if constexpr (Flag == 1) {
+    // flag == 1.0: [[h11, 1], [-1, h22]]
+    auto h11 = param[0 * ps0];
+    auto h22 = param[3 * ps0];
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n), [&](const int &i) {
+      auto temp  = h11 * x[i * xs0] + y[i * ys0];
+      y[i * ys0] = -x[i * xs0] + h22 * y[i * ys0];
+      x[i * xs0] = temp;
+    });
+  }
+  return 0;
+}
+
+}  // namespace Impl
+}  // namespace KokkosBatched
+
+#endif  // KOKKOSBATCHED_ROTM_INTERNAL_HPP_

--- a/batched/dense/impl/KokkosBatched_Rotm_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Rotm_Internal.hpp
@@ -57,7 +57,7 @@ KOKKOS_INLINE_FUNCTION int SerialRotmInternal<Flag>::invoke(const int n, ValueTy
   }
   // Checks for flag == -2.0 (identity) are done in the checkRotmInput function, so we don't need to handle it here.
   return 0;
-};
+}
 
 ///
 /// Team Internal Impl

--- a/batched/dense/src/KokkosBatched_Rotm.hpp
+++ b/batched/dense/src/KokkosBatched_Rotm.hpp
@@ -19,24 +19,25 @@ namespace KokkosBatched {
 /// [[h11, h12],  [[1, h12],    [[h11, 1],    [[1, 0],
 ///  [h21, h22]]   [h21, 1]]     [[-1, h12]]   [[0, 1]]
 ///
-/// param is a length 5 vector containing the parameters of the modified Givens rotation:
+/// param is a length 4 vector containing the parameters of the modified Givens rotation:
 /// param(0) = flag, param(1) = h11, param(2) = h21, param(3) = h12, param(4) = h22
 ///
-/// \tparam XViewType: Input/output type for the vector x, needs to be a 1D view
-/// \tparam YViewType: Input/output type for the vector y, needs to be a 1D view
-/// \tparam ParamViewType: Input type for the param vector, needs to be a 1D view of length 5
-///
-/// \param[in,out] x: x is a length n vector, a rank 1 view
-/// \param[in,out] y: y is a length n vector, a rank 1 view
-/// \param[in] param: param is a length 5 vector, a rank 1 view, containing the parameters of the modified Givens
-/// rotation:
-///
-/// No nested parallel_for is used inside of the function.
-///
+/// \tparam Flag: A compile-time integer parameter that determines the structure of the rotation matrix H. Valid values
+/// are -1, 0, 1, and -2.
 template <int Flag>
 struct SerialRotm {
   static_assert(Flag == -1 || Flag == 0 || Flag == 1 || Flag == -2,
                 "KokkosBatched::SerialRotm: Invalid flag value. Flag must be one of -1, 0, 1, or -2.");
+
+  /// \brief Invokes the SerialRotm functor. No nested parallel_for is used inside of the function.
+  /// \tparam XViewType: Input/output type for the vector x, needs to be a 1D view
+  /// \tparam YViewType: Input/output type for the vector y, needs to be a 1D view
+  /// \tparam ParamViewType: Input type for the param vector, needs to be a 1D view of length 4
+  ///
+  /// \param[in,out] x: x is a length n vector, a rank 1 view
+  /// \param[in,out] y: y is a length n vector, a rank 1 view
+  /// \param[in] param: param is a length 4 vector, a rank 1 view, containing the parameters of the modified Givens
+  /// rotation:
   template <typename XViewType, typename YViewType, typename ParamViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const XViewType &x, const YViewType &y, const ParamViewType &param);
 };
@@ -51,25 +52,26 @@ struct SerialRotm {
 /// [[h11, h12],  [[1, h12],    [[h11, 1],    [[1, 0],
 ///  [h21, h22]]   [h21, 1]]     [[-1, h12]]   [[0, 1]]
 ///
-/// param is a length 5 vector containing the parameters of the modified Givens rotation:
+/// param is a length 4 vector containing the parameters of the modified Givens rotation:
 /// param(0) = flag, param(1) = h11, param(2) = h21, param(3) = h12, param(4) = h22
 ///
 /// \tparam MemberType: TeamPolicy member type
-/// \tparam XViewType: Input/output type for the vector x, needs to be a 1D view
-/// \tparam YViewType: Input/output type for the vector y, needs to be a 1D view
-/// \tparam ParamViewType: Input type for the param vector, needs to be a 1D view of length 5
-///
-/// \param[in,out] x: x is a length n vector, a rank 1 view
-/// \param[in,out] y: y is a length n vector, a rank 1 view
-/// \param[in] param: param is a length 5 vector, a rank 1 view, containing the parameters of the modified Givens
-/// rotation:
-///
-/// A nested parallel_for with TeamThreadRange is used.
-///
+/// \tparam Flag: A compile-time integer parameter that determines the structure of the rotation matrix H. Valid values
+/// are -1, 0, 1, and -2.
 template <typename MemberType, int Flag>
 struct TeamRotm {
   static_assert(Flag == -1 || Flag == 0 || Flag == 1 || Flag == -2,
                 "KokkosBatched::TeamRotm: Invalid flag value. Flag must be one of -1, 0, 1, or -2.");
+
+  /// \brief Invokes the TeamRotm functor. A nested parallel_for with TeamThreadRange is used.
+  /// \tparam XViewType: Input/output type for the vector x, needs to be a 1D view
+  /// \tparam YViewType: Input/output type for the vector y, needs to be a 1D view
+  /// \tparam ParamViewType: Input type for the param vector, needs to be a 1D view of length 4
+  ///
+  /// \param[in,out] x: x is a length n vector, a rank 1 view
+  /// \param[in,out] y: y is a length n vector, a rank 1 view
+  /// \param[in] param: param is a length 4 vector, a rank 1 view, containing the parameters of the modified Givens
+  /// rotation:
   template <typename XViewType, typename YViewType, typename ParamViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &x, const YViewType &y,
                                            const ParamViewType &param);
@@ -85,25 +87,28 @@ struct TeamRotm {
 /// [[h11, h12],  [[1, h12],    [[h11, 1],    [[1, 0],
 ///  [h21, h22]]   [h21, 1]]     [[-1, h12]]   [[0, 1]]
 ///
-/// param is a length 5 vector containing the parameters of the modified Givens rotation:
+/// param is a length 4 vector containing the parameters of the modified Givens rotation:
 /// param(0) = flag, param(1) = h11, param(2) = h21, param(3) = h12, param(4) = h22
 ///
 /// \tparam MemberType: TeamPolicy member type
-/// \tparam XViewType: Input/output type for the vector x, needs to be a 1D view
-/// \tparam YViewType: Input/output type for the vector y, needs to be a 1D view
-/// \tparam ParamViewType: Input type for the param vector, needs to be a 1D view of length 5
-///
-/// \param[in,out] x: x is a length n vector, a rank 1 view
-/// \param[in,out] y: y is a length n vector, a rank 1 view
-/// \param[in] param: param is a length 5 vector, a rank 1 view, containing the parameters of the modified Givens
-/// rotation:
-///
-/// A nested parallel_for with TeamVectorRange is used.
+/// \tparam Flag: A compile-time integer parameter that determines the structure of the rotation matrix H. Valid values
+/// are -1, 0, 1, and -2.
 ///
 template <typename MemberType, int Flag>
 struct TeamVectorRotm {
   static_assert(Flag == -1 || Flag == 0 || Flag == 1 || Flag == -2,
                 "KokkosBatched::TeamVectorRotm: Invalid flag value. Flag must be one of -1, 0, 1, or -2.");
+
+  /// \brief Invokes the TeamVectorRotm functor. A nested parallel_for with TeamVectorRange is used.
+  /// \tparam MemberType: TeamPolicy member type
+  /// \tparam XViewType: Input/output type for the vector x, needs to be a 1D view
+  /// \tparam YViewType: Input/output type for the vector y, needs to be a 1D view
+  /// \tparam ParamViewType: Input type for the param vector, needs to be a 1D view of length 4
+  ///
+  /// \param[in,out] x: x is a length n vector, a rank 1 view
+  /// \param[in,out] y: y is a length n vector, a rank 1 view
+  /// \param[in] param: param is a length 4 vector, a rank 1 view, containing the parameters of the modified Givens
+  /// rotation:
   template <typename XViewType, typename YViewType, typename ParamViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &x, const YViewType &y,
                                            const ParamViewType &param);

--- a/batched/dense/src/KokkosBatched_Rotm.hpp
+++ b/batched/dense/src/KokkosBatched_Rotm.hpp
@@ -20,10 +20,10 @@ namespace KokkosBatched {
 ///  [h21, h22]]   [h21, 1]]     [[-1, h12]]   [[0, 1]]
 ///
 /// param is a length 4 vector containing the parameters of the modified Givens rotation:
-/// param(0) = flag, param(1) = h11, param(2) = h21, param(3) = h12, param(4) = h22
+/// param(0) = h11, param(1) = h21, param(2) = h12, param(3) = h22
 ///
 /// \tparam Flag: A compile-time integer parameter that determines the structure of the rotation matrix H. Valid values
-/// are -1, 0, 1, and -2.
+/// are -1, 0, 1, and -2
 template <int Flag>
 struct SerialRotm {
   static_assert(Flag == -1 || Flag == 0 || Flag == 1 || Flag == -2,
@@ -37,7 +37,7 @@ struct SerialRotm {
   /// \param[in,out] x: x is a length n vector, a rank 1 view
   /// \param[in,out] y: y is a length n vector, a rank 1 view
   /// \param[in] param: param is a length 4 vector, a rank 1 view, containing the parameters of the modified Givens
-  /// rotation:
+  /// rotation
   template <typename XViewType, typename YViewType, typename ParamViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const XViewType &x, const YViewType &y, const ParamViewType &param);
 };
@@ -53,11 +53,11 @@ struct SerialRotm {
 ///  [h21, h22]]   [h21, 1]]     [[-1, h12]]   [[0, 1]]
 ///
 /// param is a length 4 vector containing the parameters of the modified Givens rotation:
-/// param(0) = flag, param(1) = h11, param(2) = h21, param(3) = h12, param(4) = h22
+/// param(0) = h11, param(1) = h21, param(2) = h12, param(3) = h22
 ///
 /// \tparam MemberType: TeamPolicy member type
 /// \tparam Flag: A compile-time integer parameter that determines the structure of the rotation matrix H. Valid values
-/// are -1, 0, 1, and -2.
+/// are -1, 0, 1, and -2
 template <typename MemberType, int Flag>
 struct TeamRotm {
   static_assert(Flag == -1 || Flag == 0 || Flag == 1 || Flag == -2,
@@ -71,7 +71,7 @@ struct TeamRotm {
   /// \param[in,out] x: x is a length n vector, a rank 1 view
   /// \param[in,out] y: y is a length n vector, a rank 1 view
   /// \param[in] param: param is a length 4 vector, a rank 1 view, containing the parameters of the modified Givens
-  /// rotation:
+  /// rotation
   template <typename XViewType, typename YViewType, typename ParamViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &x, const YViewType &y,
                                            const ParamViewType &param);
@@ -88,12 +88,11 @@ struct TeamRotm {
 ///  [h21, h22]]   [h21, 1]]     [[-1, h12]]   [[0, 1]]
 ///
 /// param is a length 4 vector containing the parameters of the modified Givens rotation:
-/// param(0) = flag, param(1) = h11, param(2) = h21, param(3) = h12, param(4) = h22
+/// param(0) = h11, param(1) = h21, param(2) = h12, param(3) = h22
 ///
 /// \tparam MemberType: TeamPolicy member type
 /// \tparam Flag: A compile-time integer parameter that determines the structure of the rotation matrix H. Valid values
 /// are -1, 0, 1, and -2.
-///
 template <typename MemberType, int Flag>
 struct TeamVectorRotm {
   static_assert(Flag == -1 || Flag == 0 || Flag == 1 || Flag == -2,
@@ -108,7 +107,7 @@ struct TeamVectorRotm {
   /// \param[in,out] x: x is a length n vector, a rank 1 view
   /// \param[in,out] y: y is a length n vector, a rank 1 view
   /// \param[in] param: param is a length 4 vector, a rank 1 view, containing the parameters of the modified Givens
-  /// rotation:
+  /// rotation
   template <typename XViewType, typename YViewType, typename ParamViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &x, const YViewType &y,
                                            const ParamViewType &param);

--- a/batched/dense/src/KokkosBatched_Rotm.hpp
+++ b/batched/dense/src/KokkosBatched_Rotm.hpp
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+#ifndef KOKKOSBATCHED_ROTM_HPP_
+#define KOKKOSBATCHED_ROTM_HPP_
+
+#include <KokkosBatched_Util.hpp>
+
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+
+namespace KokkosBatched {
+
+/// \brief Serial Batched Rotm:
+/// Applies the modified Givens rotation to vectors x and y:
+///  x(i) := h11*x(i) + h12*y(i)
+///  y(i) := h21*x(i) + h22*y(i)
+///
+/// The matrix H is given by
+/// flag == -1.0  flag ==  0.0  flag ==  1.0  flag == -2.0
+/// [[h11, h12],  [[1, h12],    [[h11, 1],    [[1, 0],
+///  [h21, h22]]   [h21, 1]]     [[-1, h12]]   [[0, 1]]
+///
+/// param is a length 5 vector containing the parameters of the modified Givens rotation:
+/// param(0) = flag, param(1) = h11, param(2) = h21, param(3) = h12, param(4) = h22
+///
+/// \tparam XViewType: Input/output type for the vector x, needs to be a 1D view
+/// \tparam YViewType: Input/output type for the vector y, needs to be a 1D view
+/// \tparam ParamViewType: Input type for the param vector, needs to be a 1D view of length 5
+///
+/// \param[in,out] x: x is a length n vector, a rank 1 view
+/// \param[in,out] y: y is a length n vector, a rank 1 view
+/// \param[in] param: param is a length 5 vector, a rank 1 view, containing the parameters of the modified Givens
+/// rotation:
+///
+/// No nested parallel_for is used inside of the function.
+///
+template <int Flag>
+struct SerialRotm {
+  static_assert(Flag == -1 || Flag == 0 || Flag == 1 || Flag == -2,
+                "KokkosBatched::SerialRotm: Invalid flag value. Flag must be one of -1, 0, 1, or -2.");
+  template <typename XViewType, typename YViewType, typename ParamViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const XViewType &x, const YViewType &y, const ParamViewType &param);
+};
+
+/// \brief Team Batched Rotm:
+/// Applies the modified Givens rotation to vectors x and y:
+///  x(i) := h11*x(i) + h12*y(i)
+///  y(i) := h21*x(i) + h22*y(i)
+///
+/// The matrix H is given by
+/// flag == -1.0  flag ==  0.0  flag ==  1.0  flag == -2.0
+/// [[h11, h12],  [[1, h12],    [[h11, 1],    [[1, 0],
+///  [h21, h22]]   [h21, 1]]     [[-1, h12]]   [[0, 1]]
+///
+/// param is a length 5 vector containing the parameters of the modified Givens rotation:
+/// param(0) = flag, param(1) = h11, param(2) = h21, param(3) = h12, param(4) = h22
+///
+/// \tparam MemberType: TeamPolicy member type
+/// \tparam XViewType: Input/output type for the vector x, needs to be a 1D view
+/// \tparam YViewType: Input/output type for the vector y, needs to be a 1D view
+/// \tparam ParamViewType: Input type for the param vector, needs to be a 1D view of length 5
+///
+/// \param[in,out] x: x is a length n vector, a rank 1 view
+/// \param[in,out] y: y is a length n vector, a rank 1 view
+/// \param[in] param: param is a length 5 vector, a rank 1 view, containing the parameters of the modified Givens
+/// rotation:
+///
+/// A nested parallel_for with TeamThreadRange is used.
+///
+template <typename MemberType, int Flag>
+struct TeamRotm {
+  static_assert(Flag == -1 || Flag == 0 || Flag == 1 || Flag == -2,
+                "KokkosBatched::TeamRotm: Invalid flag value. Flag must be one of -1, 0, 1, or -2.");
+  template <typename XViewType, typename YViewType, typename ParamViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &x, const YViewType &y,
+                                           const ParamViewType &param);
+};
+
+/// \brief TeamVector Batched Rotm:
+/// Applies the modified Givens rotation to vectors x and y:
+///  x(i) := h11*x(i) + h12*y(i)
+///  y(i) := h21*x(i) + h22*y(i)
+///
+/// The matrix H is given by
+/// flag == -1.0  flag ==  0.0  flag ==  1.0  flag == -2.0
+/// [[h11, h12],  [[1, h12],    [[h11, 1],    [[1, 0],
+///  [h21, h22]]   [h21, 1]]     [[-1, h12]]   [[0, 1]]
+///
+/// param is a length 5 vector containing the parameters of the modified Givens rotation:
+/// param(0) = flag, param(1) = h11, param(2) = h21, param(3) = h12, param(4) = h22
+///
+/// \tparam MemberType: TeamPolicy member type
+/// \tparam XViewType: Input/output type for the vector x, needs to be a 1D view
+/// \tparam YViewType: Input/output type for the vector y, needs to be a 1D view
+/// \tparam ParamViewType: Input type for the param vector, needs to be a 1D view of length 5
+///
+/// \param[in,out] x: x is a length n vector, a rank 1 view
+/// \param[in,out] y: y is a length n vector, a rank 1 view
+/// \param[in] param: param is a length 5 vector, a rank 1 view, containing the parameters of the modified Givens
+/// rotation:
+///
+/// A nested parallel_for with TeamVectorRange is used.
+///
+template <typename MemberType, int Flag>
+struct TeamVectorRotm {
+  static_assert(Flag == -1 || Flag == 0 || Flag == 1 || Flag == -2,
+                "KokkosBatched::TeamVectorRotm: Invalid flag value. Flag must be one of -1, 0, 1, or -2.");
+  template <typename XViewType, typename YViewType, typename ParamViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &x, const YViewType &y,
+                                           const ParamViewType &param);
+};
+
+}  // namespace KokkosBatched
+
+#include "KokkosBatched_Rotm_Impl.hpp"
+
+#endif  // KOKKOSBATCHED_ROTM_HPP_

--- a/batched/dense/unit_test/Test_Batched_Dense.hpp
+++ b/batched/dense/unit_test/Test_Batched_Dense.hpp
@@ -8,6 +8,7 @@
 #include "Test_Batched_Copy.hpp"
 #include "Test_Batched_Rot.hpp"
 #include "Test_Batched_Rotg.hpp"
+#include "Test_Batched_Rotm.hpp"
 #include "Test_Batched_SerialEigendecomposition.hpp"
 #include "Test_Batched_SerialEigendecomposition_Real.hpp"
 #include "Test_Batched_SerialGesv.hpp"

--- a/batched/dense/unit_test/Test_Batched_Rotm.hpp
+++ b/batched/dense/unit_test/Test_Batched_Rotm.hpp
@@ -1,0 +1,429 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
+#include <KokkosBatched_Util.hpp>
+#include <KokkosBatched_Rotm.hpp>
+#include "Test_Batched_DenseUtils.hpp"
+
+namespace Test {
+namespace Rotm {
+
+template <typename DeviceType, typename XViewType, typename YViewType, typename ParamViewType, int Flag>
+struct Functor_BatchedSerialRotm {
+  using execution_space = typename DeviceType::execution_space;
+  XViewType m_x;
+  YViewType m_y;
+  ParamViewType m_param;
+
+  Functor_BatchedSerialRotm(const XViewType &x, const YViewType &y, const ParamViewType &param)
+      : m_x(x), m_y(y), m_param(param) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int k, int &info) const {
+    auto sub_x     = Kokkos::subview(m_x, k, Kokkos::ALL());
+    auto sub_y     = Kokkos::subview(m_y, k, Kokkos::ALL());
+    auto sub_param = Kokkos::subview(m_param, k, Kokkos::ALL());
+
+    info += KokkosBatched::SerialRotm<Flag>::invoke(sub_x, sub_y, sub_param);
+  }
+
+  inline int run() {
+    using value_type = typename XViewType::non_const_value_type;
+    std::string name_region("KokkosBatched::Test::SerialRotm");
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    int info_sum                      = 0;
+    Kokkos::Profiling::pushRegion(name.c_str());
+    Kokkos::RangePolicy<execution_space> policy(0, m_x.extent(0));
+    Kokkos::parallel_reduce(name.c_str(), policy, *this, info_sum);
+    Kokkos::Profiling::popRegion();
+    return info_sum;
+  }
+};
+
+template <typename DeviceType, typename XViewType, typename YViewType, typename ParamViewType, int Flag,
+          typename ArgMode>
+struct Functor_BatchedTeamRotm {
+  using execution_space = typename DeviceType::execution_space;
+  XViewType m_x;
+  YViewType m_y;
+  ParamViewType m_param;
+
+  Functor_BatchedTeamRotm(const XViewType &x, const YViewType &y, const ParamViewType &param)
+      : m_x(x), m_y(y), m_param(param) {}
+
+  template <typename MemberType>
+  KOKKOS_INLINE_FUNCTION void operator()(const MemberType &member) const {
+    const int k    = member.league_rank();
+    auto sub_x     = Kokkos::subview(m_x, k, Kokkos::ALL());
+    auto sub_y     = Kokkos::subview(m_y, k, Kokkos::ALL());
+    auto sub_param = Kokkos::subview(m_param, k, Kokkos::ALL());
+    if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::Team>) {
+      KokkosBatched::TeamRotm<MemberType, Flag>::invoke(member, sub_x, sub_y, sub_param);
+    } else if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::TeamVector>) {
+      KokkosBatched::TeamVectorRotm<MemberType, Flag>::invoke(member, sub_x, sub_y, sub_param);
+    }
+  }
+
+  inline void run() {
+    using value_type                  = typename XViewType::non_const_value_type;
+    std::string name_region           = std::is_same_v<ArgMode, KokkosBatched::Mode::Team>
+                                            ? "KokkosBatched::Test::TeamRotm"
+                                            : "KokkosBatched::Test::TeamVectorRotm";
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    Kokkos::Profiling::pushRegion(name.c_str());
+    const int league_size = m_x.extent_int(0);
+    Kokkos::TeamPolicy<execution_space> policy(league_size, Kokkos::AUTO);
+    Kokkos::parallel_for(name.c_str(), policy, *this);
+    Kokkos::Profiling::popRegion();
+  }
+};
+
+/// \brief Implementation details of batched rotm analytical test
+/// Applies the modified Givens rotation to vectors x and y:
+///  x(i) := h11*x(i) + h12*y(i)
+///  y(i) := h21*x(i) + h22*y(i)
+///
+/// The matrix H is given by
+/// flag == -1.0  flag ==  0.0  flag ==  1.0  flag == -2.0
+/// [[h11, h12],  [[1, h12],    [[h11, 1],    [[1, 0],
+///  [h21, h22]]   [h21, 1]]     [[-1, h12]]   [[0, 1]]
+///
+///  x: [1, 2, 3]
+///  y: [4, 5, 6]
+///  param: [h11, h21, h12, h22] = [2, 0.5, -1, 3]
+///
+/// flag == -1.0        flag ==  0.0   flag ==  1.0   flag == -2.0
+/// x: [-2, -1, 0]      [-3, -3, -3]   [6, 9, 12]     [1, 2, 3]
+/// y: [12.5, 16, 19.5] [4.5, 6, 7.5]  [11, 13, 15]   [4, 5, 6]
+///
+/// \tparam DeviceType Kokkos device type
+/// \tparam ScalarType Kokkos scalar type
+/// \tparam LayoutType Kokkos layout type for the views
+/// \tparam Flag: one of -1, 0, 1, or -2, specifying the values of h11, h21, h12, and h22 as described above
+/// \tparam ArgMode: one of Mode::Serial, Mode::Team, Mode::TeamVector
+///
+/// \param[in] Nb Batch size of vectors
+template <typename DeviceType, typename ScalarType, typename LayoutType, int Flag, typename ArgMode>
+void impl_test_batched_rotm_analytical(const std::size_t Nb) {
+  using ats               = typename KokkosKernels::ArithTraits<ScalarType>;
+  using RealType          = typename ats::mag_type;
+  using View2DType        = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
+  using StridedView2DType = Kokkos::View<ScalarType **, Kokkos::LayoutStride, DeviceType>;
+
+  const std::size_t N = 3;
+  View2DType x("x", Nb, N), y("y", Nb, N);
+  View2DType param("param", Nb, 4);
+  View2DType x_ref("x_ref", Nb, N), y_ref("y_ref", Nb, N);
+
+  const std::size_t incx = 2;
+  // Testing incx argument with strided views
+  Kokkos::LayoutStride layout{Nb, incx, N, Nb * incx};
+  StridedView2DType x_s("x_s", layout), y_s("y_s", layout);
+
+  auto h_x     = Kokkos::create_mirror_view(x);
+  auto h_y     = Kokkos::create_mirror_view(y);
+  auto h_x_ref = Kokkos::create_mirror_view(x_ref);
+  auto h_y_ref = Kokkos::create_mirror_view(y_ref);
+  auto h_param = Kokkos::create_mirror_view(param);
+
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    h_param(ib, 0) = static_cast<ScalarType>(2);
+    h_param(ib, 1) = static_cast<ScalarType>(0.5);
+    h_param(ib, 2) = static_cast<ScalarType>(-1);
+    h_param(ib, 3) = static_cast<ScalarType>(3);
+
+    h_x(ib, 0) = ScalarType(1);
+    h_x(ib, 1) = ScalarType(2);
+    h_x(ib, 2) = ScalarType(3);
+
+    h_y(ib, 0) = ScalarType(4);
+    h_y(ib, 1) = ScalarType(5);
+    h_y(ib, 2) = ScalarType(6);
+    if constexpr (Flag == -1) {
+      h_x_ref(ib, 0) = ScalarType(-2);
+      h_x_ref(ib, 1) = ScalarType(-1);
+      h_x_ref(ib, 2) = ScalarType(0);
+
+      h_y_ref(ib, 0) = ScalarType(12.5);
+      h_y_ref(ib, 1) = ScalarType(16);
+      h_y_ref(ib, 2) = ScalarType(19.5);
+    } else if constexpr (Flag == 0) {
+      h_x_ref(ib, 0) = ScalarType(-3);
+      h_x_ref(ib, 1) = ScalarType(-3);
+      h_x_ref(ib, 2) = ScalarType(-3);
+
+      h_y_ref(ib, 0) = ScalarType(4.5);
+      h_y_ref(ib, 1) = ScalarType(6);
+      h_y_ref(ib, 2) = ScalarType(7.5);
+    } else if constexpr (Flag == 1) {
+      h_x_ref(ib, 0) = ScalarType(6);
+      h_x_ref(ib, 1) = ScalarType(9);
+      h_x_ref(ib, 2) = ScalarType(12);
+
+      h_y_ref(ib, 0) = ScalarType(11);
+      h_y_ref(ib, 1) = ScalarType(13);
+      h_y_ref(ib, 2) = ScalarType(15);
+    } else if constexpr (Flag == -2) {
+      h_x_ref(ib, 0) = ScalarType(1);
+      h_x_ref(ib, 1) = ScalarType(2);
+      h_x_ref(ib, 2) = ScalarType(3);
+
+      h_y_ref(ib, 0) = ScalarType(4);
+      h_y_ref(ib, 1) = ScalarType(5);
+      h_y_ref(ib, 2) = ScalarType(6);
+    }
+  }
+
+  Kokkos::deep_copy(x, h_x);
+  Kokkos::deep_copy(y, h_y);
+  Kokkos::deep_copy(param, h_param);
+
+  // Deep copy to strided views
+  Kokkos::deep_copy(x_s, x);
+  Kokkos::deep_copy(y_s, y);
+
+  if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::Serial>) {
+    auto info = Functor_BatchedSerialRotm<DeviceType, View2DType, View2DType, View2DType, Flag>(x, y, param).run();
+    EXPECT_EQ(info, 0);
+  } else {
+    Functor_BatchedTeamRotm<DeviceType, View2DType, View2DType, View2DType, Flag, ArgMode>(x, y, param).run();
+  }
+
+  // With strided views
+  if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::Serial>) {
+    auto info =
+        Functor_BatchedSerialRotm<DeviceType, StridedView2DType, StridedView2DType, View2DType, Flag>(x_s, y_s, param)
+            .run();
+    EXPECT_EQ(info, 0);
+  } else {
+    Functor_BatchedTeamRotm<DeviceType, StridedView2DType, StridedView2DType, View2DType, Flag, ArgMode>(x_s, y_s,
+                                                                                                         param)
+        .run();
+  }
+
+  RealType eps = 1.0e1 * ats::epsilon();
+  Kokkos::deep_copy(h_x, x);
+  Kokkos::deep_copy(h_y, y);
+
+  // Check if x(i) := h11*x(i) + h12*y(i)
+  //          y(i) := h21*x(i) + h22*y(i)
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    for (std::size_t i = 0; i < N; i++) {
+      EXPECT_NEAR_KK(h_x(ib, i), h_x_ref(ib, i), eps);
+      EXPECT_NEAR_KK(h_y(ib, i), h_y_ref(ib, i), eps);
+    }
+  }
+
+  // Testing for strided views x_s and y_s, reusing x and y
+  Kokkos::deep_copy(x, x_s);
+  Kokkos::deep_copy(y, y_s);
+  Kokkos::deep_copy(h_x, x);
+  Kokkos::deep_copy(h_y, y);
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    for (std::size_t i = 0; i < N; i++) {
+      EXPECT_NEAR_KK(h_x(ib, i), h_x_ref(ib, i), eps);
+      EXPECT_NEAR_KK(h_y(ib, i), h_y_ref(ib, i), eps);
+    }
+  }
+}
+
+/// \brief Implementation details of batched rotm test
+///
+/// \tparam DeviceType Kokkos device type
+/// \tparam ScalarType Kokkos scalar type
+/// \tparam LayoutType Kokkos layout type for the views
+/// \tparam Flag: one of -1, 0, 1, or -2, specifying the values of h11, h21, h12, and h22 as described above
+/// \tparam ArgMode: one of Mode::Serial, Mode::Team, Mode::TeamVector
+///
+/// \param[in] Nb Batch size of vectors
+/// \param[in] N Length of vectors x and y
+template <typename DeviceType, typename ScalarType, typename LayoutType, int Flag, typename ArgMode>
+void impl_test_batched_rotm(const std::size_t Nb, const std::size_t N) {
+  using ats               = typename KokkosKernels::ArithTraits<ScalarType>;
+  using RealType          = typename ats::mag_type;
+  using View2DType        = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
+  using StridedView2DType = Kokkos::View<ScalarType **, Kokkos::LayoutStride, DeviceType>;
+
+  View2DType x("x", Nb, N), y("y", Nb, N), param("param", Nb, 4);
+  View2DType x_ref("x_ref", Nb, N), y_ref("y_ref", Nb, N);
+
+  const std::size_t incx = 2;
+  // Testing incx argument with strided views
+  Kokkos::LayoutStride layout{Nb, incx, N, Nb * incx};
+  StridedView2DType x_s("x_s", layout), y_s("y_s", layout);
+
+  // Create random x and y
+  using execution_space = typename DeviceType::execution_space;
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
+  ScalarType randStart, randEnd;
+
+  KokkosKernels::Impl::getRandomBounds(1.0, randStart, randEnd);
+  Kokkos::fill_random(x, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(y, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(param, rand_pool, randStart, randEnd);
+
+  // Save copies for reference
+  Kokkos::deep_copy(x_ref, x);
+  Kokkos::deep_copy(y_ref, y);
+
+  // Deep copy to strided views
+  Kokkos::deep_copy(x_s, x);
+  Kokkos::deep_copy(y_s, y);
+
+  // Run rotm on (x, y)
+  if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::Serial>) {
+    auto info = Functor_BatchedSerialRotm<DeviceType, View2DType, View2DType, View2DType, Flag>(x, y, param).run();
+    EXPECT_EQ(info, 0);
+  } else {
+    Functor_BatchedTeamRotm<DeviceType, View2DType, View2DType, View2DType, Flag, ArgMode>(x, y, param).run();
+  }
+
+  // With strided views
+  if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::Serial>) {
+    auto info =
+        Functor_BatchedSerialRotm<DeviceType, StridedView2DType, StridedView2DType, View2DType, Flag>(x_s, y_s, param)
+            .run();
+    EXPECT_EQ(info, 0);
+  } else {
+    Functor_BatchedTeamRotm<DeviceType, StridedView2DType, StridedView2DType, View2DType, Flag, ArgMode>(x_s, y_s,
+                                                                                                         param)
+        .run();
+  }
+
+  // Make a reference at host
+  auto h_x_ref = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, x_ref);
+  auto h_y_ref = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, y_ref);
+  auto h_param = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, param);
+
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    for (std::size_t i = 0; i < N; i++) {
+      // No modification is needed for flag == -2, as the reference is the same as the input
+      if constexpr (Flag == -1) {
+        auto temp      = h_param(ib, 0) * h_x_ref(ib, i) + h_param(ib, 2) * h_y_ref(ib, i);
+        h_y_ref(ib, i) = h_param(ib, 1) * h_x_ref(ib, i) + h_param(ib, 3) * h_y_ref(ib, i);
+        h_x_ref(ib, i) = temp;
+      } else if constexpr (Flag == 0) {
+        auto temp      = h_x_ref(ib, i) + h_param(ib, 2) * h_y_ref(ib, i);
+        h_y_ref(ib, i) = h_param(ib, 1) * h_x_ref(ib, i) + h_y_ref(ib, i);
+        h_x_ref(ib, i) = temp;
+      } else if constexpr (Flag == 1) {
+        auto temp      = h_param(ib, 0) * h_x_ref(ib, i) + h_y_ref(ib, i);
+        h_y_ref(ib, i) = -1.0 * h_x_ref(ib, i) + h_param(ib, 3) * h_y_ref(ib, i);
+        h_x_ref(ib, i) = temp;
+      }
+    }
+  }
+
+  RealType eps = 1.0e1 * ats::epsilon();
+  auto h_x     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, x);
+  auto h_y     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, y);
+
+  // Check if x(i) := h11*x(i) + h12*y(i)
+  //          y(i) := h21*x(i) + h22*y(i)
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    for (std::size_t i = 0; i < N; i++) {
+      EXPECT_NEAR_KK(h_x(ib, i), h_x_ref(ib, i), eps);
+      EXPECT_NEAR_KK(h_y(ib, i), h_y_ref(ib, i), eps);
+    }
+  }
+
+  // Testing for strided views x_s and y_s, reusing x and y
+  Kokkos::deep_copy(x, x_s);
+  Kokkos::deep_copy(y, y_s);
+  Kokkos::deep_copy(h_x, x);
+  Kokkos::deep_copy(h_y, y);
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    for (std::size_t i = 0; i < N; i++) {
+      EXPECT_NEAR_KK(h_x(ib, i), h_x_ref(ib, i), eps);
+      EXPECT_NEAR_KK(h_y(ib, i), h_y_ref(ib, i), eps);
+    }
+  }
+}
+
+}  // namespace Rotm
+}  // namespace Test
+
+template <typename DeviceType, typename ScalarType, int Flag, typename ArgMode>
+int test_batched_rotm() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
+  {
+    using LayoutType = Kokkos::LayoutLeft;
+    Test::Rotm::impl_test_batched_rotm_analytical<DeviceType, ScalarType, LayoutType, Flag, ArgMode>(1);
+    Test::Rotm::impl_test_batched_rotm_analytical<DeviceType, ScalarType, LayoutType, Flag, ArgMode>(2);
+    for (int i = 0; i < 10; i++) {
+      Test::Rotm::impl_test_batched_rotm<DeviceType, ScalarType, LayoutType, Flag, ArgMode>(1, i);
+      Test::Rotm::impl_test_batched_rotm<DeviceType, ScalarType, LayoutType, Flag, ArgMode>(2, i);
+    }
+  }
+#endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
+  {
+    using LayoutType = Kokkos::LayoutRight;
+    Test::Rotm::impl_test_batched_rotm_analytical<DeviceType, ScalarType, LayoutType, Flag, ArgMode>(1);
+    Test::Rotm::impl_test_batched_rotm_analytical<DeviceType, ScalarType, LayoutType, Flag, ArgMode>(2);
+    for (int i = 0; i < 10; i++) {
+      Test::Rotm::impl_test_batched_rotm<DeviceType, ScalarType, LayoutType, Flag, ArgMode>(1, i);
+      Test::Rotm::impl_test_batched_rotm<DeviceType, ScalarType, LayoutType, Flag, ArgMode>(2, i);
+    }
+  }
+#endif
+
+  return 0;
+}
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+// Serial
+TEST_F(TestCategory, test_batched_serial_rotm_float) {
+  test_batched_rotm<TestDevice, float, -1, KokkosBatched::Mode::Serial>();
+  test_batched_rotm<TestDevice, float, 0, KokkosBatched::Mode::Serial>();
+  test_batched_rotm<TestDevice, float, 1, KokkosBatched::Mode::Serial>();
+  test_batched_rotm<TestDevice, float, -2, KokkosBatched::Mode::Serial>();
+}
+
+// Team
+TEST_F(TestCategory, test_batched_team_rotm_float) {
+  test_batched_rotm<TestDevice, float, -1, KokkosBatched::Mode::Team>();
+  test_batched_rotm<TestDevice, float, 0, KokkosBatched::Mode::Team>();
+  test_batched_rotm<TestDevice, float, 1, KokkosBatched::Mode::Team>();
+  test_batched_rotm<TestDevice, float, -2, KokkosBatched::Mode::Team>();
+}
+
+// TeamVector
+TEST_F(TestCategory, test_batched_teamvector_rotm_float) {
+  test_batched_rotm<TestDevice, float, -1, KokkosBatched::Mode::TeamVector>();
+  test_batched_rotm<TestDevice, float, 0, KokkosBatched::Mode::TeamVector>();
+  test_batched_rotm<TestDevice, float, 1, KokkosBatched::Mode::TeamVector>();
+  test_batched_rotm<TestDevice, float, -2, KokkosBatched::Mode::TeamVector>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+// Serial
+TEST_F(TestCategory, test_batched_serial_rotm_double) {
+  test_batched_rotm<TestDevice, double, -1, KokkosBatched::Mode::Serial>();
+  test_batched_rotm<TestDevice, double, 0, KokkosBatched::Mode::Serial>();
+  test_batched_rotm<TestDevice, double, 1, KokkosBatched::Mode::Serial>();
+  test_batched_rotm<TestDevice, double, -2, KokkosBatched::Mode::Serial>();
+}
+
+// Team
+TEST_F(TestCategory, test_batched_team_rotm_double) {
+  test_batched_rotm<TestDevice, double, -1, KokkosBatched::Mode::Team>();
+  test_batched_rotm<TestDevice, double, 0, KokkosBatched::Mode::Team>();
+  test_batched_rotm<TestDevice, double, 1, KokkosBatched::Mode::Team>();
+  test_batched_rotm<TestDevice, double, -2, KokkosBatched::Mode::Team>();
+}
+
+// TeamVector
+TEST_F(TestCategory, test_batched_teamvector_rotm_double) {
+  test_batched_rotm<TestDevice, double, -1, KokkosBatched::Mode::TeamVector>();
+  test_batched_rotm<TestDevice, double, 0, KokkosBatched::Mode::TeamVector>();
+  test_batched_rotm<TestDevice, double, 1, KokkosBatched::Mode::TeamVector>();
+  test_batched_rotm<TestDevice, double, -2, KokkosBatched::Mode::TeamVector>();
+}
+#endif


### PR DESCRIPTION
This PR implements [rotm](https://www.netlib.org/lapack/explore-html/dc/d23/group__rotm_ga4ffe410ec9e3ba6d5632fd16500c45c2.html#ga4ffe410ec9e3ba6d5632fd16500c45c2) function.

`KokkosBatched_Rotm.hpp` has also been slightly modified to support all of `{s,d}rotm`. The flag parameter must be given by a template parameter and thus params only contains 4 elements. `Flag` must be one of {1, 0, -1, -2}, otherwise it fails to compile.

Following files are added:
1. `KokkosBatched_Rotm_Impl.hpp`: Internal interfaces
2. `KokkosBatched_Rotm_Internal.hpp`: Implementation details
3. `KokkosBatched_Rotm.hpp`: APIs
4. `Test_Batched_Rotm.hpp`: Unit tests for that

## Detailed description

Applies the modified Givens rotation to vectors x and y (`{s,d}rotm`):
```
/// The matrix H is given by
/// flag == -1.0  flag ==  0.0  flag ==  1.0  flag == -2.0
/// [[h11, h12],  [[1, h12],    [[h11, 1],    [[1, 0],
///  [h21, h22]]   [h21, 1]]     [[-1, h12]]   [[0, 1]]
x(i) := h11*x(i) + h12*y(i)
y(i) := h21*x(i) + h22*y(i)
```

```C++
Kokkos::parallel_for('rotm', 
    Kokkos::RangePolicy<execution_space> policy(0, n),
    [=](const int k) {
      auto sub_x = Kokkos::subview(m_x, k, Kokkos::ALL());
      auto sub_y = Kokkos::subview(m_y, k, Kokkos::ALL());
      auto sub_param = Kokkos::subview(m_param, k, Kokkos::ALL());

      KokkosBatched::SerialRotm<1>::invoke(sub_x, sub_y, sub_param);
    });
```

## Tests
1.  Analytical tests over `{1,0,-1,-2}` and `{float/double}` and `{LayoutLeft/LayoutRight}`
2. Randomized tests over `{1,0,-1,-2}` and `{float/double}` and `{LayoutLeft/LayoutRight}`