### PR TITLE
Move CPP stuff not derived directly from CMake vars out of KokkosKernels_config.h.in

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -26,7 +26,6 @@
 #include "Kokkos_DynRankView.hpp"
 
 #include "KokkosKernels_config.h"
-#include "KokkosKernels_Macros.hpp"
 #include "KokkosKernels_SimpleUtils.hpp"
 #include "KokkosBlas_util.hpp"
 

--- a/batched/dense/impl/KokkosBatched_Vector_SIMD_Arith.hpp
+++ b/batched/dense/impl/KokkosBatched_Vector_SIMD_Arith.hpp
@@ -6,7 +6,7 @@
 /// \author Kyungjoo Kim (kyukim@sandia.gov)
 
 #include "Kokkos_Complex.hpp"
-#include "KokkosKernels_Macros.hpp"
+#include "KokkosKernels_config.h"
 
 namespace KokkosBatched {
 

--- a/batched/dense/src/KokkosBatched_Vector_SIMD.hpp
+++ b/batched/dense/src/KokkosBatched_Vector_SIMD.hpp
@@ -7,7 +7,7 @@
 
 #include <Kokkos_Complex.hpp>
 #include <KokkosBatched_Vector.hpp>
-#include "KokkosKernels_Macros.hpp"
+#include "KokkosKernels_config.h"
 
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || defined(__SYCL_DEVICE_ONLY__)
 // compiler bug with AVX in some architectures

--- a/blas/impl/KokkosBlas3_gemm_impl.hpp
+++ b/blas/impl/KokkosBlas3_gemm_impl.hpp
@@ -5,7 +5,7 @@
 #define KOKKOSBLAS3_GEMM_IMPL_HPP_
 
 #include <Kokkos_Core.hpp>
-#include "KokkosKernels_Macros.hpp"
+#include "KokkosKernels_config.h"
 
 #ifdef KOKKOS_ENABLE_CXX14
 #ifdef KOKKOS_COMPILER_GNU

--- a/blas/src/KokkosBlas3_gemm.hpp
+++ b/blas/src/KokkosBlas3_gemm.hpp
@@ -5,7 +5,7 @@
 
 /// \file KokkosBlas3_gemm.hpp
 
-#include <KokkosKernels_Macros.hpp>
+#include <KokkosKernels_config.h>
 #include <KokkosBlas3_gemm_spec.hpp>
 #include <KokkosBlas2_gemv.hpp>
 #include <KokkosBlas1_scal.hpp>

--- a/blas/src/KokkosBlas3_trmm.hpp
+++ b/blas/src/KokkosBlas3_trmm.hpp
@@ -5,7 +5,7 @@
 
 /// \file KokkosBlas3_trmm.hpp
 
-#include "KokkosKernels_Macros.hpp"
+#include "KokkosKernels_config.h"
 #include "KokkosBlas3_trmm_spec.hpp"
 #include "KokkosKernels_helpers.hpp"
 #include "KokkosKernels_Error.hpp"

--- a/blas/src/KokkosBlas3_trsm.hpp
+++ b/blas/src/KokkosBlas3_trsm.hpp
@@ -5,7 +5,7 @@
 
 /// \file KokkosBlas3_trsm.hpp
 
-#include "KokkosKernels_Macros.hpp"
+#include "KokkosKernels_config.h"
 #include "KokkosBlas3_trsm_spec.hpp"
 #include "KokkosKernels_helpers.hpp"
 #include "KokkosKernels_Error.hpp"

--- a/cmake/KokkosKernels_config.h.in
+++ b/cmake/KokkosKernels_config.h.in
@@ -82,13 +82,6 @@
 #cmakedefine KOKKOSKERNELS_INST_COMPLEX_DOUBLE
 /* Whether to build kernels for scalar type complex<float> */
 #cmakedefine KOKKOSKERNELS_INST_COMPLEX_FLOAT
-#if defined KOKKOSKERNELS_INST_COMPLEX_DOUBLE
-#define KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_
-#endif
-#if defined KOKKOSKERNELS_INST_COMPLEX_FLOAT
-#define KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_
-#endif
-
 /* Whether to build kernels for multivectors of LayoutLeft */
 #cmakedefine KOKKOSKERNELS_INST_LAYOUTLEFT
 /* Whether to build kernels for multivectors of LayoutRight */
@@ -147,25 +140,8 @@
 
 #cmakedefine KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV
 
-/* if MKL or ARMPL, BLAS is also defined */
-#if defined(KOKKOSKERNELS_ENABLE_TPL_MKL) || \
-    defined(KOKKOSKERNELS_ENABLE_TPL_ARMPL) || \
-    defined(KOKKOSKERNELS_ENABLE_TPL_ACCELERATE)
-#if !defined(KOKKOSKERNELS_ENABLE_TPL_BLAS)
-#define KOKKOSKERNELS_ENABLE_TPL_BLAS
-#endif
-#endif
-
 /* Whether MKL is providing the BLAS and LAPACK implementation */
 #cmakedefine MKL_PROVIDES_BLAS_LAPACK
-
-/* KOKKOSKERNELS_ENABLE_HOST_ONLY is deprecated and will be removed in a future
- * release. There is no replacement.
- */
-#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && \
-    !defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ENABLE_OPENMPTARGET)
-#define KOKKOSKERNELS_ENABLE_HOST_ONLY
-#endif
 
 /*
  * "Optimization level" for computational kernels in this subpackage.
@@ -174,11 +150,7 @@
  * mean both better performance overall, and more uniform performance
  * for corner cases.
  */
-#define KOKKOSLINALG_OPT_LEVEL @KokkosLinAlg_Opt_Level @
-
-#ifndef KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
-#define KOKKOSKERNELS_IMPL_COMPILE_LIBRARY false
-#endif
+#define KOKKOSLINALG_OPT_LEVEL @KokkosLinAlg_Opt_Level@
 
 /* Enabled components */
 #cmakedefine KOKKOSKERNELS_ENABLE_COMPONENT_BATCHED

--- a/cmake/KokkosKernels_config.h.in
+++ b/cmake/KokkosKernels_config.h.in
@@ -160,4 +160,6 @@
 #cmakedefine KOKKOSKERNELS_ENABLE_COMPONENT_GRAPH
 #cmakedefine KOKKOSKERNELS_ENABLE_COMPONENT_ODE
 
+#include "KokkosKernels_Macros.hpp"
+
 #endif  // KOKKOSKERNELS_CONFIG_H

--- a/common/src/KokkosKernels_HashmapAccumulator.hpp
+++ b/common/src/KokkosKernels_HashmapAccumulator.hpp
@@ -3,7 +3,7 @@
 #ifndef KOKKOSKERNELS_HASHMAPACCUMULATOR_HPP
 #define KOKKOSKERNELS_HASHMAPACCUMULATOR_HPP
 #include <Kokkos_Atomic.hpp>
-#include "KokkosKernels_Macros.hpp"
+#include "KokkosKernels_config.h"
 #include <atomic>
 
 namespace KokkosKernels {

--- a/common/src/KokkosKernels_Macros.hpp
+++ b/common/src/KokkosKernels_Macros.hpp
@@ -11,6 +11,33 @@
 #include <KokkosKernels_config.h>
 /****** END macros populated by CMake ******/
 
+// Aliases for Kokkos complex types (derived from KOKKOSKERNELS_INST_COMPLEX_*)
+#if defined KOKKOSKERNELS_INST_COMPLEX_DOUBLE
+#define KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_
+#endif
+#if defined KOKKOSKERNELS_INST_COMPLEX_FLOAT
+#define KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_
+#endif
+
+// If MKL, ARMPL, or ACCELERATE is enabled, BLAS is implicitly available too.
+#if defined(KOKKOSKERNELS_ENABLE_TPL_MKL) || defined(KOKKOSKERNELS_ENABLE_TPL_ARMPL) || \
+    defined(KOKKOSKERNELS_ENABLE_TPL_ACCELERATE)
+#if !defined(KOKKOSKERNELS_ENABLE_TPL_BLAS)
+#define KOKKOSKERNELS_ENABLE_TPL_BLAS
+#endif
+#endif
+
+// KOKKOSKERNELS_ENABLE_HOST_ONLY is deprecated and will be removed in a future
+// release. There is no replacement.
+#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_SYCL) && \
+    !defined(KOKKOS_ENABLE_OPENMPTARGET)
+#define KOKKOSKERNELS_ENABLE_HOST_ONLY
+#endif
+
+#ifndef KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
+#define KOKKOSKERNELS_IMPL_COMPILE_LIBRARY false
+#endif
+
 // If KOKKOSKERNELS_ENABLE_OMP_SIMD is defined, it's legal to place
 // "#pragma omp simd" before a for loop. It's never defined if a GPU-type device
 // is enabled, since in that case, Kokkos::ThreadVectorRange should be used
@@ -74,7 +101,6 @@
 #else
 #define KOKKOSKERNELS_GNU_COMPILER_FENCE
 #endif  // KOKKOS_COMPILER_GNU
-/******* END other helper macros *******/
 
 // define KOKKOSKERNELS_CUDA_INDEPENDENT_THREADS if we are targeting a CUDA
 // architecture with "independent thread scheduling" (Volta70 and up). This

--- a/common/unit_test/Test_Common_CudaIndependentThreads.hpp
+++ b/common/unit_test/Test_Common_CudaIndependentThreads.hpp
@@ -8,7 +8,7 @@
 #define TEST_COMMON_CUDAINDEPENDENTTHREADSCHEDULING
 
 #include <Kokkos_Core.hpp>
-#include <KokkosKernels_Macros.hpp>
+#include <KokkosKernels_config.h>
 
 void test_cuda_independent_threads() {
 #ifdef KOKKOS_ENABLE_CUDA

--- a/lapack/src/KokkosLapack_trtri.hpp
+++ b/lapack/src/KokkosLapack_trtri.hpp
@@ -5,7 +5,7 @@
 
 /// \file KokkosLapack_trtri.hpp
 
-#include "KokkosKernels_Macros.hpp"
+#include "KokkosKernels_config.h"
 #include "KokkosLapack_trtri_spec.hpp"
 #include "KokkosKernels_helpers.hpp"
 #include <sstream>

--- a/sparse/src/KokkosSparse_CcsMatrix.hpp
+++ b/sparse/src/KokkosSparse_CcsMatrix.hpp
@@ -18,7 +18,7 @@
 #include "KokkosSparse_findRelOffset.hpp"
 #include "KokkosSparse_StaticCcsGraph.hpp"
 #include "KokkosKernels_default_types.hpp"
-#include "KokkosKernels_Macros.hpp"
+#include "KokkosKernels_config.h"
 
 namespace KokkosSparse {
 /// \class CcsMatrix

--- a/sparse/src/KokkosSparse_CrsMatrix.hpp
+++ b/sparse/src/KokkosSparse_CrsMatrix.hpp
@@ -18,7 +18,7 @@
 #include "KokkosSparse_findRelOffset.hpp"
 #include "KokkosSparse_StaticCrsGraph.hpp"
 #include "KokkosKernels_default_types.hpp"
-#include "KokkosKernels_Macros.hpp"
+#include "KokkosKernels_config.h"
 
 namespace KokkosSparse {
 //! String that tells sparse kernels to use the transpose of the matrix.


### PR DESCRIPTION
KokkosKernels_config.h becomes the basic include that clients should include (it was already far more commonly included), not KokkosKernels_Macros.hpp

Fixes #944 
