### PR TITLE
Remove old code

### DIFF
--- a/blas/impl/KokkosBlas3_gemm_impl.hpp
+++ b/blas/impl/KokkosBlas3_gemm_impl.hpp
@@ -5,6 +5,7 @@
 #define KOKKOSBLAS3_GEMM_IMPL_HPP_
 
 #include <Kokkos_Core.hpp>
+#include <KokkosKernels_Macros.hpp>
 
 namespace KokkosBlas {
 namespace Impl {

--- a/blas/impl/KokkosBlas3_gemm_impl.hpp
+++ b/blas/impl/KokkosBlas3_gemm_impl.hpp
@@ -5,15 +5,6 @@
 #define KOKKOSBLAS3_GEMM_IMPL_HPP_
 
 #include <Kokkos_Core.hpp>
-#include "KokkosKernels_Macros.hpp"
-
-#ifdef KOKKOS_ENABLE_CXX14
-#ifdef KOKKOS_COMPILER_GNU
-#if KOKKOS_COMPILER_GNU <= 740
-#define KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-#endif
-#endif
-#endif
 
 namespace KokkosBlas {
 namespace Impl {
@@ -56,26 +47,16 @@ struct impl_deep_copy_matrix_block<TeamHandle, ViewTypeScratch, ViewType, Layout
                    const int& offset_j) {
     if (offset_i + blockDim_i <= A.extent_int(0) && offset_j + blockDim_j <= A.extent_int(1)) {
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, blockDim_j), [&](const int j) {
-#ifndef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
         const int idx_j = offset_j + j;
-#endif
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, blockDim_i), [&](const int i) {
-#ifdef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-          const int idx_j = offset_j + j;
-#endif
           const int idx_i = offset_i + i;
           A_scr(i, j)     = A(idx_i, idx_j);
         });
       });
     } else {
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, blockDim_j), [&](const int j) {
-#ifndef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
         int idx_j = offset_j + j;
-#endif
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, blockDim_i), [&](const int i) {
-#ifdef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-          int idx_j = offset_j + j;
-#endif
           const int idx_i = offset_i + i;
           A_scr(i, j)     = idx_i < A.extent_int(0) && idx_j < A.extent_int(1) ? A(idx_i, idx_j) : ATV::zero();
         });
@@ -103,13 +84,8 @@ struct impl_deep_copy_matrix_block<TeamHandle, ViewTypeScratch, ViewType, Kokkos
       });
     } else {
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, blockDim_i), [&](const int i) {
-#ifndef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
         int idx_i = offset_i + i;
-#endif
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, blockDim_j), [&](const int j) {
-#ifdef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-          int idx_i = offset_i + i;
-#endif
           const int idx_j = offset_j + j;
           A_scr(i, j)     = idx_i < A.extent_int(0) && idx_j < A.extent_int(1) ? A(idx_i, idx_j) : ATV::zero();
         });
@@ -128,26 +104,16 @@ struct impl_deep_copy_matrix_block<TeamHandle, ViewTypeScratch, ViewType, Layout
                    const int& offset_j) {
     if (offset_i + blockDim_i <= A.extent_int(1) && offset_j + blockDim_j <= A.extent_int(0)) {
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, blockDim_j), [&](const int j) {
-#ifndef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
         const int idx_j = offset_j + j;
-#endif
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, blockDim_i), [&](const int i) {
-#ifdef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-          const int idx_j = offset_j + j;
-#endif
           const int idx_i = offset_i + i;
           A_scr(i, j)     = A(idx_j, idx_i);
         });
       });
     } else {
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, blockDim_j), [&](const int j) {
-#ifndef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
         int idx_j = offset_j + j;
-#endif
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, blockDim_i), [&](const int i) {
-#ifdef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-          int idx_j = offset_j + j;
-#endif
           const int idx_i = offset_i + i;
           A_scr(i, j)     = idx_i < A.extent_int(1) && idx_j < A.extent_int(0) ? A(idx_j, idx_i) : ATV::zero();
         });
@@ -167,26 +133,16 @@ struct impl_deep_copy_matrix_block<TeamHandle, ViewTypeScratch, ViewType, Kokkos
                    const int& offset_j) {
     if (offset_i + blockDim_i <= A.extent_int(1) && offset_j + blockDim_j <= A.extent_int(0)) {
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, blockDim_i), [&](const int i) {
-#ifndef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
         const int idx_i = offset_i + i;
-#endif
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, blockDim_j), [&](const int j) {
-#ifdef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-          const int idx_i = offset_i + i;
-#endif
           const int idx_j = offset_j + j;
           A_scr(i, j)     = A(idx_j, idx_i);
         });
       });
     } else {
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, blockDim_i), [&](const int i) {
-#ifndef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
         int idx_i = offset_i + i;
-#endif
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, blockDim_j), [&](const int j) {
-#ifdef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-          int idx_i = offset_i + i;
-#endif
           const int idx_j = offset_j + j;
           A_scr(i, j)     = idx_i < A.extent_int(1) && idx_j < A.extent_int(0) ? A(idx_j, idx_i) : ATV::zero();
         });
@@ -205,26 +161,16 @@ struct impl_deep_copy_matrix_block<TeamHandle, ViewTypeScratch, ViewType, Layout
                    const int& offset_j) {
     if (offset_i + blockDim_i <= A.extent_int(1) && offset_j + blockDim_j <= A.extent_int(0)) {
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, blockDim_j), [&](const int j) {
-#ifndef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
         const int idx_j = offset_j + j;
-#endif
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, blockDim_i), [&](const int i) {
-#ifdef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-          const int idx_j = offset_j + j;
-#endif
           const int idx_i = offset_i + i;
           A_scr(i, j)     = ATV::conj(A(idx_j, idx_i));
         });
       });
     } else {
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, blockDim_j), [&](const int j) {
-#ifndef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
         int idx_j = offset_j + j;
-#endif
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, blockDim_i), [&](const int i) {
-#ifdef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-          int idx_j = offset_j + j;
-#endif
           const int idx_i = offset_i + i;
           A_scr(i, j) = idx_i < A.extent_int(1) && idx_j < A.extent_int(0) ? ATV::conj(A(idx_j, idx_i)) : ATV::zero();
         });
@@ -244,26 +190,16 @@ struct impl_deep_copy_matrix_block<TeamHandle, ViewTypeScratch, ViewType, Kokkos
                    const int& offset_j) {
     if (offset_i + blockDim_i <= A.extent_int(1) && offset_j + blockDim_j <= A.extent_int(0)) {
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, blockDim_i), [&](const int i) {
-#ifndef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
         const int idx_i = offset_i + i;
-#endif
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, blockDim_j), [&](const int j) {
-#ifdef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-          const int idx_i = offset_i + i;
-#endif
           const int idx_j = offset_j + j;
           A_scr(i, j)     = ATV::conj(A(idx_j, idx_i));
         });
       });
     } else {
       Kokkos::parallel_for(Kokkos::TeamThreadRange(team, blockDim_i), [&](const int i) {
-#ifndef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
         int idx_i = offset_i + i;
-#endif
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, blockDim_j), [&](const int j) {
-#ifdef KOKKOSKERNELS_IMPL_BATCHED_GEMM_GCC_CXX14_WORKAROUND
-          int idx_i = offset_i + i;
-#endif
           const int idx_j = offset_j + j;
           A_scr(i, j) = idx_i < A.extent_int(1) && idx_j < A.extent_int(0) ? ATV::conj(A(idx_j, idx_i)) : ATV::zero();
         });
@@ -366,16 +302,9 @@ template <class TeamHandle, class ViewTypeA, class ViewTypeB, class ViewTypeC>
 KOKKOS_INLINE_FUNCTION void impl_team_gemm_block(const TeamHandle& team, const ViewTypeC& C, const ViewTypeA& A,
                                                  const ViewTypeB& B) {
   typedef typename ViewTypeC::non_const_value_type ScalarC;
-// GNU COMPILER BUG WORKAROUND
-#if defined(KOKKOS_COMPILER_GNU) && (!defined(__CUDA_ARCH__) || !defined(__HIP_DEVICE_COMPILE__))
-  int blockA0 = A.extent_int(0);
-  int blockA1 = A.extent_int(1);
-  int blockB1 = B.extent_int(1);
-#else
   const int blockA0 = A.extent_int(0);
   const int blockA1 = A.extent_int(1);
   const int blockB1 = B.extent_int(1);
-#endif
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team, blockA0), [&](const int i) {
 #ifndef KOKKOSKERNELS_ENABLE_OMP_SIMD
     Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, blockB1 / 4), [&](const int B_j) {

--- a/blas/src/KokkosBlas3_gemm.hpp
+++ b/blas/src/KokkosBlas3_gemm.hpp
@@ -5,7 +5,6 @@
 
 /// \file KokkosBlas3_gemm.hpp
 
-#include <KokkosKernels_Macros.hpp>
 #include <KokkosBlas3_gemm_spec.hpp>
 #include <KokkosBlas2_gemv.hpp>
 #include <KokkosBlas1_scal.hpp>

--- a/blas/src/KokkosBlas3_trmm.hpp
+++ b/blas/src/KokkosBlas3_trmm.hpp
@@ -5,7 +5,6 @@
 
 /// \file KokkosBlas3_trmm.hpp
 
-#include "KokkosKernels_Macros.hpp"
 #include "KokkosBlas3_trmm_spec.hpp"
 #include "KokkosKernels_helpers.hpp"
 #include "KokkosKernels_Error.hpp"

--- a/blas/src/KokkosBlas3_trsm.hpp
+++ b/blas/src/KokkosBlas3_trsm.hpp
@@ -5,7 +5,6 @@
 
 /// \file KokkosBlas3_trsm.hpp
 
-#include "KokkosKernels_Macros.hpp"
 #include "KokkosBlas3_trsm_spec.hpp"
 #include "KokkosKernels_helpers.hpp"
 #include "KokkosKernels_Error.hpp"

--- a/common/src/KokkosKernels_Macros.hpp
+++ b/common/src/KokkosKernels_Macros.hpp
@@ -53,22 +53,6 @@
 #endif
 #endif
 
-// Macro that tells GCC not to worry if a variable isn't being used.
-// Generalized attributes were not implemented in GCC until 4.8:
-//
-// https://gcc.gnu.org/gcc-4.7/cxx0x_status.html
-// https://gcc.gnu.org/gcc-4.8/cxx0x_status.html
-//
-// Thus, we can't use [[unused]]; we have to use the older GCC syntax
-// for variable attributes.  Be careful also of compilers that define
-// the __GNUC__ macro but might not necessarily actually be GCC
-// compliant.
-#if defined(__GNUC__) && !defined(KOKKOSKERNELS_UNUSED_ATTRIBUTE)
-#define KOKKOSKERNELS_UNUSED_ATTRIBUTE __attribute__((unused))
-#else
-#define KOKKOSKERNELS_UNUSED_ATTRIBUTE
-#endif  // __GNUC__
-
 #if defined(KOKKOS_COMPILER_GNU)
 #define KOKKOSKERNELS_GNU_COMPILER_FENCE __sync_synchronize();
 #else

--- a/lapack/src/KokkosLapack_trtri.hpp
+++ b/lapack/src/KokkosLapack_trtri.hpp
@@ -5,7 +5,6 @@
 
 /// \file KokkosLapack_trtri.hpp
 
-#include "KokkosKernels_Macros.hpp"
 #include "KokkosLapack_trtri_spec.hpp"
 #include "KokkosKernels_helpers.hpp"
 #include <sstream>

--- a/sparse/src/KokkosSparse_CcsMatrix.hpp
+++ b/sparse/src/KokkosSparse_CcsMatrix.hpp
@@ -18,7 +18,6 @@
 #include "KokkosSparse_findRelOffset.hpp"
 #include "KokkosSparse_StaticCcsGraph.hpp"
 #include "KokkosKernels_default_types.hpp"
-#include "KokkosKernels_Macros.hpp"
 
 namespace KokkosSparse {
 /// \class CcsMatrix

--- a/sparse/src/KokkosSparse_CrsMatrix.hpp
+++ b/sparse/src/KokkosSparse_CrsMatrix.hpp
@@ -18,20 +18,19 @@
 #include "KokkosSparse_findRelOffset.hpp"
 #include "KokkosSparse_StaticCrsGraph.hpp"
 #include "KokkosKernels_default_types.hpp"
-#include "KokkosKernels_Macros.hpp"
 
 namespace KokkosSparse {
 //! String that tells sparse kernels to use the transpose of the matrix.
-static char KOKKOSKERNELS_UNUSED_ATTRIBUTE Transpose[] = "T";
+[[maybe_unused]] static char Transpose[] = "T";
 /// \brief String that tells sparse kernels to use the conjugate (NOT
 ///   transpose) of the matrix.
-static char KOKKOSKERNELS_UNUSED_ATTRIBUTE Conjugate[] = "C";
+[[maybe_unused]] static char Conjugate[] = "C";
 /// \brief String that tells sparse kernels to use the conjugate
 ///   transpose of the matrix.
-static char KOKKOSKERNELS_UNUSED_ATTRIBUTE ConjugateTranspose[] = "H";
+[[maybe_unused]] static char ConjugateTranspose[] = "H";
 /// \brief String that tells sparse kernels not to use the transpose
 ///   or conjugate of the matrix.
-static char KOKKOSKERNELS_UNUSED_ATTRIBUTE NoTranspose[] = "N";
+[[maybe_unused]] static char NoTranspose[] = "N";
 
 template <class DeviceType>
 inline int RowsPerThread(const int NNZPerRow) {


### PR DESCRIPTION
Removing a few old macros that are no longer required mostly because compiler bugs have been fixed and also because the current minimum requirements of GCC 10.4 is high enough for full c++14,17,20 support!