### PR TITLE
docs - examples: adding examples for abs, scal, swap

### DIFF
--- a/docs/source/API/blas/blas1_abs.rst
+++ b/docs/source/API/blas/blas1_abs.rst
@@ -41,3 +41,18 @@ Type Requirements
 
   - ``Kokkos::SpaceAccessibility<execution_space, typename XMV::memory_space>::accessible``
   - ``XMV::rank == RMV::rank``
+
+Example
+=======
+
+.. literalinclude:: ../../../../example/docs/blas/KokkosBlas1_docs_abs.cpp
+  :language: c++
+
+output:
+
+.. code::
+
+   orignal values:
+      x: {0, -1, -2, 3, -4}
+   final values:
+      y: {0, 1, 2, 3, 4}

--- a/docs/source/API/blas/blas1_scal.rst
+++ b/docs/source/API/blas/blas1_scal.rst
@@ -43,3 +43,18 @@ Type Requirements
 
   - ``Kokkos::SpaceAccessibility<execution_space, typename RMV::memory_space>::accessible == true``
   - ``RMV::rank == XMV::rank``
+
+Example
+=======
+
+.. literalinclude:: ../../../../example/docs/blas/KokkosBlas1_docs_scal.cpp
+  :language: c++
+
+output:
+
+.. code::
+
+   orignal values:
+      {-3, -3, -3, -3, -3}
+   final values:
+      {6, 6, 6, 6, 6}

--- a/docs/source/API/blas/blas1_swap.rst
+++ b/docs/source/API/blas/blas1_swap.rst
@@ -41,3 +41,20 @@ Type Requirements
 
   - ``std::is_same_v<typename YVector::value_type, typename YVector::non_const_value_type == true``
   - ``Kokkos::SpaceAccessibility<execution_space, typename YVector::memory_space>::accessible == true``
+
+Example
+=======
+
+.. literalinclude:: ../../../../example/docs/blas/KokkosBlas1_docs_swap.cpp
+  :language: c++
+
+output:
+
+.. code::
+
+   orignal values:
+      x: {0, 1, 2, 3, 4}
+      y: {9, 8, 7, 6, 5}
+   final values:
+      x: {9, 8, 7, 6, 5}
+      y: {0, 1, 2, 3, 4}

--- a/example/docs/CMakeLists.txt
+++ b/example/docs/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(blas)
 add_subdirectory(lapack)

--- a/example/docs/blas/CMakeLists.txt
+++ b/example/docs/blas/CMakeLists.txt
@@ -1,0 +1,8 @@
+kokkoskernels_include_directories(${CMAKE_CURRENT_BINARY_DIR})
+kokkoskernels_include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+
+kokkoskernels_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../../test_common)
+
+kokkoskernels_add_executable_and_test(docs_blas1_abs         SOURCES KokkosBlas1_docs_abs.cpp)
+kokkoskernels_add_executable_and_test(docs_blas1_scal        SOURCES KokkosBlas1_docs_scal.cpp)
+kokkoskernels_add_executable_and_test(docs_blas1_swap        SOURCES KokkosBlas1_docs_swap.cpp)

--- a/example/docs/blas/KokkosBlas1_docs_abs.cpp
+++ b/example/docs/blas/KokkosBlas1_docs_abs.cpp
@@ -1,0 +1,24 @@
+#include <iostream>
+#include <Kokkos_Core.hpp>
+#include <KokkosBlas1_abs.hpp>
+
+int main(void) {
+  Kokkos::initialize();
+  {
+    Kokkos::View<double*> x("x", 5), y("y", 5);
+    auto h_x = Kokkos::create_mirror_view(x);
+    h_x(0) = 0.0; h_x(1) = -1.0; h_x(2) = -2.0; h_x(3) = 3.0; h_x(4) = -4.0;
+
+    std::cout << "orignal values:\n"
+	      << "   x: {" << h_x(0) << ", " << h_x(1) << ", " << h_x(2) << ", " << h_x(3) << ", " << h_x(4) << "}" << std::endl;
+    Kokkos::deep_copy(x, h_x);
+
+    KokkosBlas::abs(y, x);
+
+    auto h_y = Kokkos::create_mirror_view(y);
+    Kokkos::deep_copy(h_y, y);
+    std::cout << "final values:\n"
+	      << "   y: {" << h_y(0) << ", " << h_y(1) << ", " << h_y(2) << ", " << h_y(3) << ", " << h_y(4) << "}" << std::endl;
+  }
+  Kokkos::finalize();
+}

--- a/example/docs/blas/KokkosBlas1_docs_abs.cpp
+++ b/example/docs/blas/KokkosBlas1_docs_abs.cpp
@@ -7,10 +7,15 @@ int main(void) {
   {
     Kokkos::View<double*> x("x", 5), y("y", 5);
     auto h_x = Kokkos::create_mirror_view(x);
-    h_x(0) = 0.0; h_x(1) = -1.0; h_x(2) = -2.0; h_x(3) = 3.0; h_x(4) = -4.0;
+    h_x(0)   = 0.0;
+    h_x(1)   = -1.0;
+    h_x(2)   = -2.0;
+    h_x(3)   = 3.0;
+    h_x(4)   = -4.0;
 
     std::cout << "orignal values:\n"
-	      << "   x: {" << h_x(0) << ", " << h_x(1) << ", " << h_x(2) << ", " << h_x(3) << ", " << h_x(4) << "}" << std::endl;
+              << "   x: {" << h_x(0) << ", " << h_x(1) << ", " << h_x(2) << ", " << h_x(3) << ", " << h_x(4) << "}"
+              << std::endl;
     Kokkos::deep_copy(x, h_x);
 
     KokkosBlas::abs(y, x);
@@ -18,7 +23,8 @@ int main(void) {
     auto h_y = Kokkos::create_mirror_view(y);
     Kokkos::deep_copy(h_y, y);
     std::cout << "final values:\n"
-	      << "   y: {" << h_y(0) << ", " << h_y(1) << ", " << h_y(2) << ", " << h_y(3) << ", " << h_y(4) << "}" << std::endl;
+              << "   y: {" << h_y(0) << ", " << h_y(1) << ", " << h_y(2) << ", " << h_y(3) << ", " << h_y(4) << "}"
+              << std::endl;
   }
   Kokkos::finalize();
 }

--- a/example/docs/blas/KokkosBlas1_docs_scal.cpp
+++ b/example/docs/blas/KokkosBlas1_docs_scal.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+#include <Kokkos_Core.hpp>
+#include <KokkosBlas1_scal.hpp>
+
+int main(void) {
+  Kokkos::initialize();
+  {
+    Kokkos::View<double*> x("X", 5);
+    auto h_x = Kokkos::create_mirror_view(x);
+    Kokkos::deep_copy(h_x, -3.0);
+    std::cout << "orignal values:\n"
+	      << "   {" << h_x(0) << ", " << h_x(1) << ", " << h_x(2) << ", " << h_x(3) << ", " << h_x(4) << "}" << std::endl;
+    Kokkos::deep_copy(x, h_x);
+
+    KokkosBlas::scal(x, -2.0, x);
+    Kokkos::deep_copy(h_x, x);
+
+    std::cout << "final values:\n"
+	      << "   {" << h_x(0) << ", " << h_x(1) << ", " << h_x(2) << ", " << h_x(3) << ", " << h_x(4) << "}" << std::endl;
+  }
+  Kokkos::finalize();
+}

--- a/example/docs/blas/KokkosBlas1_docs_scal.cpp
+++ b/example/docs/blas/KokkosBlas1_docs_scal.cpp
@@ -9,14 +9,16 @@ int main(void) {
     auto h_x = Kokkos::create_mirror_view(x);
     Kokkos::deep_copy(h_x, -3.0);
     std::cout << "orignal values:\n"
-	      << "   {" << h_x(0) << ", " << h_x(1) << ", " << h_x(2) << ", " << h_x(3) << ", " << h_x(4) << "}" << std::endl;
+              << "   {" << h_x(0) << ", " << h_x(1) << ", " << h_x(2) << ", " << h_x(3) << ", " << h_x(4) << "}"
+              << std::endl;
     Kokkos::deep_copy(x, h_x);
 
     KokkosBlas::scal(x, -2.0, x);
     Kokkos::deep_copy(h_x, x);
 
     std::cout << "final values:\n"
-	      << "   {" << h_x(0) << ", " << h_x(1) << ", " << h_x(2) << ", " << h_x(3) << ", " << h_x(4) << "}" << std::endl;
+              << "   {" << h_x(0) << ", " << h_x(1) << ", " << h_x(2) << ", " << h_x(3) << ", " << h_x(4) << "}"
+              << std::endl;
   }
   Kokkos::finalize();
 }

--- a/example/docs/blas/KokkosBlas1_docs_swap.cpp
+++ b/example/docs/blas/KokkosBlas1_docs_swap.cpp
@@ -8,12 +8,21 @@ int main(void) {
     Kokkos::View<double*> x("x", 5), y("y", 5);
     auto h_x = Kokkos::create_mirror_view(x);
     auto h_y = Kokkos::create_mirror_view(y);
-    h_x(0) = 0.0; h_x(1) = 1.0; h_x(2) = 2.0; h_x(3) = 3.0; h_x(4) = 4.0;
-    h_y(0) = 9.0; h_y(1) = 8.0; h_y(2) = 7.0; h_y(3) = 6.0; h_y(4) = 5.0;
+    h_x(0)   = 0.0;
+    h_x(1)   = 1.0;
+    h_x(2)   = 2.0;
+    h_x(3)   = 3.0;
+    h_x(4)   = 4.0;
+    h_y(0)   = 9.0;
+    h_y(1)   = 8.0;
+    h_y(2)   = 7.0;
+    h_y(3)   = 6.0;
+    h_y(4)   = 5.0;
 
     std::cout << "orignal values:\n"
-	      << "   x: {" << h_x(0) << ", " << h_x(1) << ", " << h_x(2) << ", " << h_x(3) << ", " << h_x(4) << "}\n"
-	      << "   y: {" << h_y(0) << ", " << h_y(1) << ", " << h_y(2) << ", " << h_y(3) << ", " << h_y(4) << "}" << std::endl;
+              << "   x: {" << h_x(0) << ", " << h_x(1) << ", " << h_x(2) << ", " << h_x(3) << ", " << h_x(4) << "}\n"
+              << "   y: {" << h_y(0) << ", " << h_y(1) << ", " << h_y(2) << ", " << h_y(3) << ", " << h_y(4) << "}"
+              << std::endl;
     Kokkos::deep_copy(x, h_x);
     Kokkos::deep_copy(y, h_y);
 
@@ -22,8 +31,9 @@ int main(void) {
     Kokkos::deep_copy(h_y, y);
 
     std::cout << "final values:\n"
-	      << "   x: {" << h_x(0) << ", " << h_x(1) << ", " << h_x(2) << ", " << h_x(3) << ", " << h_x(4) << "}\n"
-	      << "   y: {" << h_y(0) << ", " << h_y(1) << ", " << h_y(2) << ", " << h_y(3) << ", " << h_y(4) << "}" << std::endl;
+              << "   x: {" << h_x(0) << ", " << h_x(1) << ", " << h_x(2) << ", " << h_x(3) << ", " << h_x(4) << "}\n"
+              << "   y: {" << h_y(0) << ", " << h_y(1) << ", " << h_y(2) << ", " << h_y(3) << ", " << h_y(4) << "}"
+              << std::endl;
   }
   Kokkos::finalize();
 }

--- a/example/docs/blas/KokkosBlas1_docs_swap.cpp
+++ b/example/docs/blas/KokkosBlas1_docs_swap.cpp
@@ -1,0 +1,29 @@
+#include <iostream>
+#include <Kokkos_Core.hpp>
+#include <KokkosBlas1_swap.hpp>
+
+int main(void) {
+  Kokkos::initialize();
+  {
+    Kokkos::View<double*> x("x", 5), y("y", 5);
+    auto h_x = Kokkos::create_mirror_view(x);
+    auto h_y = Kokkos::create_mirror_view(y);
+    h_x(0) = 0.0; h_x(1) = 1.0; h_x(2) = 2.0; h_x(3) = 3.0; h_x(4) = 4.0;
+    h_y(0) = 9.0; h_y(1) = 8.0; h_y(2) = 7.0; h_y(3) = 6.0; h_y(4) = 5.0;
+
+    std::cout << "orignal values:\n"
+	      << "   x: {" << h_x(0) << ", " << h_x(1) << ", " << h_x(2) << ", " << h_x(3) << ", " << h_x(4) << "}\n"
+	      << "   y: {" << h_y(0) << ", " << h_y(1) << ", " << h_y(2) << ", " << h_y(3) << ", " << h_y(4) << "}" << std::endl;
+    Kokkos::deep_copy(x, h_x);
+    Kokkos::deep_copy(y, h_y);
+
+    KokkosBlas::swap(x, y);
+    Kokkos::deep_copy(h_x, x);
+    Kokkos::deep_copy(h_y, y);
+
+    std::cout << "final values:\n"
+	      << "   x: {" << h_x(0) << ", " << h_x(1) << ", " << h_x(2) << ", " << h_x(3) << ", " << h_x(4) << "}\n"
+	      << "   y: {" << h_y(0) << ", " << h_y(1) << ", " << h_y(2) << ", " << h_y(3) << ", " << h_y(4) << "}" << std::endl;
+  }
+  Kokkos::finalize();
+}


### PR DESCRIPTION
This is a simple addition to make the examples for our documented kernels more complete.