### PR TITLE
Add batched rotmg

### DIFF
--- a/batched/dense/impl/KokkosBatched_Rotmg_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Rotmg_Impl.hpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOSBATCHED_ROTMG_IMPL_HPP_
+#define KOKKOSBATCHED_ROTMG_IMPL_HPP_
+
+#include <KokkosBlas_util.hpp>
+#include <KokkosBatched_Util.hpp>
+#include "KokkosBlas1_rotmg_impl.hpp"
+
+namespace KokkosBatched {
+/// \brief invoke Rotmg
+/// constructs a modified Givens transformation matrix H which zeros the second component of the 2-vector [sqrt(d1)*x1,
+/// sqrt(d2)*y1]**T, where d1, d2, x1, y1 are scalars. The first component of the rotated vector is stored in d1. The
+/// elements of H are stored in the array param. The matrix H is given by flag == -1.0  flag ==  0.0  flag ==  1.0  flag
+/// == -2.0
+/// [[h11, h12],  [[1, h12],    [[h11, 1],    [[1, 0],
+///  [h21, h22]]   [h21, 1]]     [[-1, h12]]   [[0, 1]]
+///
+/// \tparam DXViewType 0-D View type containing a nonconst real scalar
+/// \tparam YViewType 0-D View type containing a real scalar
+/// \tparam PViewType 1-D View type containing a nonconst real scalar
+///
+/// \param[in,out] d1: On entry, the scalar d1. On exit, square of x scaling factor to be applied after rotm.
+/// \param[in,out] d2: On entry, the scalar d2. On exit, square of y scaling factor to be applied after rotm.
+/// \param[in,out] x1: On entry, element from first vector to rotate. On exit, the rotated element before scaling.
+/// \param[in] y1: On entry, element from second vector to rotate.
+/// \param[out] param: The array containing the elements of the modified Givens transformation matrix H.
+///
+template <class DXViewType, class YViewType, class PViewType>
+KOKKOS_INLINE_FUNCTION int Rotmg::invoke(const DXViewType &d1, const DXViewType &d2, const DXViewType &x1,
+                                         const YViewType &y1, const PViewType &param) {
+  static_assert(Kokkos::is_view_v<DXViewType>, "KokkosBatched::rotmg: DXViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view_v<YViewType>, "KokkosBatched::rotmg: YViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view_v<PViewType>, "KokkosBatched::rotmg: PViewType is not a Kokkos::View.");
+  static_assert(DXViewType::rank() == 0, "KokkosBatched::rotmg: DXViewType must have rank 0.");
+  static_assert(YViewType::rank() == 0, "KokkosBatched::rotmg: YViewType must have rank 0.");
+  static_assert(PViewType::rank() == 1, "KokkosBatched::rotmg: PViewType must have rank 1.");
+  static_assert(std::is_same_v<typename DXViewType::value_type, typename DXViewType::non_const_value_type>,
+                "KokkosBatched::rotmg: DXViewType must have non-const value type.");
+  static_assert(std::is_same_v<typename YViewType::value_type, typename YViewType::non_const_value_type>,
+                "KokkosBatched::rotmg: YViewType must have non-const value type.");
+  static_assert(std::is_same_v<typename PViewType::value_type, typename PViewType::non_const_value_type>,
+                "KokkosBatched::rotmg: PViewType must have non-const value type.");
+  using x_value_type = typename DXViewType::non_const_value_type;
+  using y_value_type = typename YViewType::non_const_value_type;
+  using p_value_type = typename PViewType::non_const_value_type;
+  static_assert(!KokkosKernels::ArithTraits<x_value_type>::is_complex &&
+                    !KokkosKernels::ArithTraits<y_value_type>::is_complex &&
+                    !KokkosKernels::ArithTraits<p_value_type>::is_complex,
+                "KokkosBatched::rotmg: Complex types are not supported for Rotmg.");
+#ifndef NDEBUG
+  // param should include flag, h11, h21, h12, h22
+  if (param.extent_int(0) != 5) {
+    Kokkos::printf("KokkosBatched::rotmg: param must have length 5: param length = %d\n", param.extent_int(0));
+    return 1;
+  }
+#endif
+  KokkosBlas::Impl::rotmg_impl(d1.data(), d2.data(), x1.data(), y1.data(), param.data(), param.stride(0));
+  return 0;
+}
+
+}  // namespace KokkosBatched
+
+#endif  // KOKKOSBATCHED_ROTMG_IMPL_HPP_

--- a/batched/dense/impl/KokkosBatched_Rotmg_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Rotmg_Impl.hpp
@@ -57,7 +57,7 @@ KOKKOS_INLINE_FUNCTION int Rotmg::invoke(const DXViewType &d1, const DXViewType 
     return 1;
   }
 #endif
-  KokkosBlas::Impl::rotmg_impl(d1.data(), d2.data(), x1.data(), y1.data(), param.data(), param.stride(0));
+  KokkosBlas::Impl::rotmg_impl(d1, d2, x1, y1, param);
   return 0;
 }
 

--- a/batched/dense/impl/KokkosBatched_Rotmg_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Rotmg_Impl.hpp
@@ -10,13 +10,14 @@
 
 namespace KokkosBatched {
 /// \brief invoke Rotmg
-/// constructs a modified Givens transformation matrix H which zeros the second component of the 2-vector [sqrt(d1)*x1,
-/// sqrt(d2)*y1]**T, where d1, d2, x1, y1 are scalars. The first component of the rotated vector is stored in d1. The
-/// elements of H are stored in the array param. The matrix H is given by flag == -1.0  flag ==  0.0  flag ==  1.0  flag
-/// == -2.0
+/// constructs a modified Givens transformation matrix H which zeros the second component of the 2-vector
+/// [sqrt(d1)*x1, sqrt(d2)*y1]**T, where d1, d2, x1, y1 are scalars. The first component of the rotated vector is stored
+/// in d1. The elements of H are stored in the array param.
+///
+/// The matrix H is given by
+/// flag == -1.0  flag ==  0.0  flag ==  1.0  flag == -2.0
 /// [[h11, h12],  [[1, h12],    [[h11, 1],    [[1, 0],
 ///  [h21, h22]]   [h21, 1]]     [[-1, h12]]   [[0, 1]]
-///
 /// \tparam DXViewType 0-D View type containing a nonconst real scalar
 /// \tparam YViewType 0-D View type containing a real scalar
 /// \tparam PViewType 1-D View type containing a nonconst real scalar

--- a/batched/dense/src/KokkosBatched_Rotmg.hpp
+++ b/batched/dense/src/KokkosBatched_Rotmg.hpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+#ifndef KOKKOSBATCHED_ROTMG_HPP_
+#define KOKKOSBATCHED_ROTMG_HPP_
+
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+
+namespace KokkosBatched {
+
+/// \brief Device callable Rotmg:
+/// constructs a modified Givens transformation matrix H which zeros the second component of the 2-vector [sqrt(d1)*x1,
+/// sqrt(d2)*y1]**T, where d1, d2, x1, y1 are scalars. The first component of the rotated vector is stored in d1. The
+/// elements of H are stored in the array param. The matrix H is given by flag == -1.0  flag ==  0.0  flag ==  1.0  flag
+/// == -2.0
+/// [[h11, h12],  [[1, h12],    [[h11, 1],    [[1, 0],
+///  [h21, h22]]   [h21, 1]]     [[-1, h12]]   [[0, 1]]
+struct Rotmg {
+  /// \tparam DXViewType 0-D View type containing a nonconst real scalar
+  /// \tparam YViewType 0-D View type containing a real scalar
+  /// \tparam PViewType 1-D View type containing a nonconst real scalar
+  ///
+  /// \param[in,out] d1: On entry, the scalar d1. On exit, square of x scaling factor to be applied after rotm.
+  /// \param[in,out] d2: On entry, the scalar d2. On exit, square of y scaling factor to be applied after rotm.
+  /// \param[in,out] x1: On entry, element from first vector to rotate. On exit, the rotated element before scaling.
+  /// \param[in] y1: On entry, element from second vector to rotate.
+  /// \param[out] param: The array containing the elements of the modified Givens transformation matrix H.
+  template <class DXViewType, class YViewType, class PViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const DXViewType &d1, const DXViewType &d2, const DXViewType &x1,
+                                           const YViewType &y1, const PViewType &param);
+};
+
+}  // namespace KokkosBatched
+
+#include "KokkosBatched_Rotmg_Impl.hpp"
+
+#endif  // KOKKOSBATCHED_ROTMG_HPP_

--- a/batched/dense/src/KokkosBatched_Rotmg.hpp
+++ b/batched/dense/src/KokkosBatched_Rotmg.hpp
@@ -8,10 +8,12 @@
 namespace KokkosBatched {
 
 /// \brief Device callable Rotmg:
-/// constructs a modified Givens transformation matrix H which zeros the second component of the 2-vector [sqrt(d1)*x1,
-/// sqrt(d2)*y1]**T, where d1, d2, x1, y1 are scalars. The first component of the rotated vector is stored in d1. The
-/// elements of H are stored in the array param. The matrix H is given by flag == -1.0  flag ==  0.0  flag ==  1.0  flag
-/// == -2.0
+/// constructs a modified Givens transformation matrix H which zeros the second component of the 2-vector
+/// [sqrt(d1)*x1, sqrt(d2)*y1]**T, where d1, d2, x1, y1 are scalars. The first component of the rotated vector is stored
+/// in d1. The elements of H are stored in the array param.
+///
+/// The matrix H is given by
+/// flag == -1.0  flag ==  0.0  flag ==  1.0  flag == -2.0
 /// [[h11, h12],  [[1, h12],    [[h11, 1],    [[1, 0],
 ///  [h21, h22]]   [h21, 1]]     [[-1, h12]]   [[0, 1]]
 struct Rotmg {

--- a/batched/dense/unit_test/Test_Batched_Dense.hpp
+++ b/batched/dense/unit_test/Test_Batched_Dense.hpp
@@ -9,6 +9,7 @@
 #include "Test_Batched_Rot.hpp"
 #include "Test_Batched_Rotg.hpp"
 #include "Test_Batched_Rotm.hpp"
+#include "Test_Batched_Rotmg.hpp"
 #include "Test_Batched_SerialEigendecomposition.hpp"
 #include "Test_Batched_SerialEigendecomposition_Real.hpp"
 #include "Test_Batched_SerialGesv.hpp"

--- a/batched/dense/unit_test/Test_Batched_Rotmg.hpp
+++ b/batched/dense/unit_test/Test_Batched_Rotmg.hpp
@@ -86,7 +86,7 @@ template <typename DeviceType, typename SType, typename LayoutType>
 void impl_test_batched_rotmg(const std::size_t Nb) {
   // Test with analytical values
   SType d1_in, d2_in, x1_in, y1_in;
-  SType ref[5];
+  SType ref[8];  // d1, d2, x1, flag, h11, h21, h12, h22
 
   // flag == -2 case (p2 == 0 branch)
   // where p2 = d2 * y1^2

--- a/batched/dense/unit_test/Test_Batched_Rotmg.hpp
+++ b/batched/dense/unit_test/Test_Batched_Rotmg.hpp
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
+#include <KokkosBatched_Rotmg.hpp>
+
+namespace Test {
+namespace Rotmg {
+
+template <typename DeviceType, typename DXViewType, typename YViewType, typename PViewType>
+struct Functor_BatchedRotmg {
+  using execution_space = typename DeviceType::execution_space;
+  DXViewType m_d1;
+  DXViewType m_d2;
+  DXViewType m_x1;
+  YViewType m_y1;
+  PViewType m_param;
+
+  Functor_BatchedRotmg(const DXViewType &d1, const DXViewType &d2, const DXViewType &x1, const YViewType &y1,
+                       const PViewType &param)
+      : m_d1(d1), m_d2(d2), m_x1(x1), m_y1(y1), m_param(param) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int k) const {
+    auto sub_d1    = Kokkos::subview(m_d1, k);
+    auto sub_d2    = Kokkos::subview(m_d2, k);
+    auto sub_x1    = Kokkos::subview(m_x1, k);
+    auto sub_y1    = Kokkos::subview(m_y1, k);
+    auto sub_param = Kokkos::subview(m_param, k, Kokkos::ALL());
+    KokkosBatched::Rotmg::invoke(sub_d1, sub_d2, sub_x1, sub_y1, sub_param);
+  }
+
+  inline void run() {
+    using value_type = typename DXViewType::non_const_value_type;
+    std::string name_region("KokkosBatched::Test::Rotmg");
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    Kokkos::Profiling::pushRegion(name.c_str());
+    Kokkos::RangePolicy<execution_space> policy(0, m_d1.extent(0));
+    Kokkos::parallel_for(name.c_str(), policy, *this);
+    Kokkos::Profiling::popRegion();
+  }
+};
+
+template <typename DeviceType, typename LayoutType, typename DXType, typename YType, typename PType>
+void impl_test_batched_rotmg_analytical(const std::size_t Nb, DXType d1_in, DXType d2_in, DXType x1_in, YType y1_in,
+                                        const DXType ref[8]) {
+  using ats        = typename KokkosKernels::ArithTraits<DXType>;
+  using DXViewType = Kokkos::View<DXType *, LayoutType, DeviceType>;
+  using YViewType  = Kokkos::View<YType *, LayoutType, DeviceType>;
+  using PViewType  = Kokkos::View<PType **, LayoutType, DeviceType>;
+
+  DXViewType d1("d1", Nb), d2("d2", Nb), x1("x1", Nb);
+  YViewType y1("y1", Nb);
+  PViewType param("param", Nb, 5);
+
+  Kokkos::deep_copy(d1, d1_in);
+  Kokkos::deep_copy(d2, d2_in);
+  Kokkos::deep_copy(x1, x1_in);
+  Kokkos::deep_copy(y1, y1_in);
+
+  Functor_BatchedRotmg<DeviceType, DXViewType, YViewType, PViewType>(d1, d2, x1, y1, param).run();
+
+  auto h_d1    = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, d1);
+  auto h_d2    = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, d2);
+  auto h_x1    = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, x1);
+  auto h_y1    = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, y1);
+  auto h_param = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, param);
+
+  typename ats::mag_type eps = 1.0e1 * ats::epsilon();
+  for (std::size_t i = 0; i < Nb; i++) {
+    EXPECT_NEAR_KK_REL(h_d1(i), ref[0], eps, "rotmg: d1 does not match reference");
+    EXPECT_NEAR_KK_REL(h_d2(i), ref[1], eps, "rotmg: d2 does not match reference");
+    EXPECT_NEAR_KK_REL(h_x1(i), ref[2], eps, "rotmg: x1 does not match reference");
+    EXPECT_NEAR_KK_REL(h_param(i, 0), ref[3], eps, "rotmg: param[0] (flag) does not match reference");
+    EXPECT_NEAR_KK_REL(h_param(i, 1), ref[4], eps, "rotmg: param[1] (h11) does not match reference");
+    EXPECT_NEAR_KK_REL(h_param(i, 2), ref[5], eps, "rotmg: param[2] (h21) does not match reference");
+    EXPECT_NEAR_KK_REL(h_param(i, 3), ref[6], eps, "rotmg: param[3] (h12) does not match reference");
+    EXPECT_NEAR_KK_REL(h_param(i, 4), ref[7], eps, "rotmg: param[4] (h22) does not match reference");
+  }
+}
+
+template <typename DeviceType, typename SType, typename LayoutType>
+void impl_test_batched_rotmg(const std::size_t Nb) {
+  // Test with analytical values
+  SType d1_in, d2_in, x1_in, y1_in;
+  SType ref[5];
+
+  // flag == -2 case (p2 == 0 branch)
+  // where p2 = d2 * y1^2
+  d1_in  = SType(1.0);
+  d2_in  = SType(2.0);
+  x1_in  = SType(3.0);
+  y1_in  = SType(0.0);
+  ref[0] = SType(1.0);   // d1
+  ref[1] = SType(2.0);   // d2
+  ref[2] = SType(3.0);   // x1
+  ref[3] = SType(-2.0);  // flag
+  ref[4] = SType(0.0);   // h11
+  ref[5] = SType(0.0);   // h21
+  ref[6] = SType(0.0);   // h12
+  ref[7] = SType(0.0);   // h22
+  impl_test_batched_rotmg_analytical<DeviceType, LayoutType, SType, SType, SType>(Nb, d1_in, d2_in, x1_in, y1_in, ref);
+
+  // flag == -1 case (d1 < 0 branch)
+  d1_in  = SType(-1.0);
+  d2_in  = SType(2.0);
+  x1_in  = SType(3.0);
+  y1_in  = SType(4.0);
+  ref[0] = SType(0.0);   // d1
+  ref[1] = SType(0.0);   // d2
+  ref[2] = SType(0.0);   // x1
+  ref[3] = SType(-1.0);  // flag
+  ref[4] = SType(0.0);   // h11
+  ref[5] = SType(0.0);   // h21
+  ref[6] = SType(0.0);   // h12
+  ref[7] = SType(0.0);   // h22
+  impl_test_batched_rotmg_analytical<DeviceType, LayoutType, SType, SType, SType>(Nb, d1_in, d2_in, x1_in, y1_in, ref);
+
+  // flag == 0 case (abs(q1) > abs(q2) branch)
+  // where q1 = d1 * x1^2 and q2 = d2 * y1^2
+  d1_in = SType(10.0);
+  d2_in = SType(1.0);
+  x1_in = SType(5.0);
+  y1_in = SType(1.0);
+
+  auto p1  = d1_in * x1_in;
+  auto p2  = d2_in * y1_in;
+  auto h21 = -y1_in / x1_in;
+  auto h12 = p2 / p1;
+  auto u   = 1.0 - h12 * h21;
+  ref[0]   = d1_in / u;   // d1
+  ref[1]   = d2_in / u;   // d2
+  ref[2]   = x1_in * u;   // x1
+  ref[3]   = SType(0.0);  // flag
+  ref[4]   = SType(0.0);  // h11
+  ref[5]   = h21;         // h21
+  ref[6]   = h12;         // h12
+  ref[7]   = SType(0.0);  // h22
+  impl_test_batched_rotmg_analytical<DeviceType, LayoutType, SType, SType, SType>(Nb, d1_in, d2_in, x1_in, y1_in, ref);
+
+  // flag == 1 case (abs(q1) <= abs(q2) branch)
+  // where q1 = d1 * x1^2 and q2 = d2 * y1^2
+  d1_in    = SType(1.0);
+  d2_in    = SType(10.0);
+  x1_in    = SType(1.0);
+  y1_in    = SType(5.0);
+  p1       = d1_in * x1_in;
+  p2       = d2_in * y1_in;
+  auto h11 = p1 / p2;
+  auto h22 = x1_in / y1_in;
+  u        = 1.0 + h11 * h22;
+  ref[0]   = d2_in / u;   // d1
+  ref[1]   = d1_in / u;   // d2
+  ref[2]   = y1_in * u;   // x1
+  ref[3]   = SType(1.0);  // flag
+  ref[4]   = h11;         // h11
+  ref[5]   = SType(0.0);  // h21
+  ref[6]   = SType(0.0);  // h12
+  ref[7]   = h22;         // h22
+  impl_test_batched_rotmg_analytical<DeviceType, LayoutType, SType, SType, SType>(Nb, d1_in, d2_in, x1_in, y1_in, ref);
+
+  // small d1 case (|q1| > |q2| with d1 scaled up by gam^2)
+  constexpr SType gam = SType(4096.0);
+  d1_in               = SType(6.0e-10);
+  d2_in               = SType(2.0e-2);
+  x1_in               = SType(1.0e5);
+  y1_in               = SType(10.0);
+  p1                  = d1_in * x1_in;
+  p2                  = d2_in * y1_in;
+  h21                 = -1.0e-4;                  // -y1_in / x1_in
+  h12                 = 1.0 / 3.0 * 1.0e4;        // (d2_in * y1_in) / (d1_in * x1_in)
+  u                   = 4.0 / 3.0;                // 1.0 - h12 * h21
+  ref[0]              = 4.5e-10 * gam * gam;      // (d1_in / u) * (gam * gam);
+  ref[1]              = 1.5e-2;                   // (d2_in / u)
+  ref[2]              = 4.0 / 3.0 * 1.0e5 / gam;  // (x1 * u / gam)
+  ref[3]              = SType(-1.0);              // flag
+  ref[4]              = 1.0 / gam;                // h11
+  ref[5]              = h21;                      // h21
+  ref[6]              = 1.0e4 / (3.0 * gam);      // h12 / gam
+  ref[7]              = SType(1.0);               // h22
+
+  impl_test_batched_rotmg_analytical<DeviceType, LayoutType, SType, SType, SType>(Nb, d1_in, d2_in, x1_in, y1_in, ref);
+
+  // big d1 case (|q1| > |q2| with d1 scaled down by gam^2)
+  d1_in  = SType(6.0e10);
+  d2_in  = SType(2.0e-2);
+  x1_in  = SType(1.0e-5);
+  y1_in  = SType(10.0);
+  p1     = d1_in * x1_in;
+  p2     = d2_in * y1_in;
+  h21    = -1.0e6;                    // -y1_in / x1_in
+  h12    = 1.0 / 3.0 * 1.0e-6;        // (d2_in * y1_in) / (d1_in * x1_in)
+  u      = 4.0 / 3.0;                 // 1.0 - h12 * h21
+  ref[0] = 4.5e10 / (gam * gam);      // (d1_in / u) * (gam * gam);
+  ref[1] = 1.5e-2;                    // (d2_in / u)
+  ref[2] = 4.0 / 3.0 * 1.0e-5 * gam;  // (x1 * u * gam)
+  ref[3] = SType(-1.0);               // flag
+  ref[4] = 1.0 * gam;                 // h11
+  ref[5] = h21;                       // h21
+  ref[6] = h12 * gam;                 // h12 * gam
+  ref[7] = SType(1.0);                // h22
+
+  impl_test_batched_rotmg_analytical<DeviceType, LayoutType, SType, SType, SType>(Nb, d1_in, d2_in, x1_in, y1_in, ref);
+
+  // small d1 case (|q1| <= |q2| with d1 scaled up by gam^2)
+  d1_in  = SType(2.0e-10);
+  d2_in  = SType(4.0e-2);
+  x1_in  = SType(1.0e5);
+  y1_in  = SType(10.0);
+  p1     = d1_in * x1_in;
+  p2     = d2_in * y1_in;
+  h11    = 5.0e-5;                             // (d1_in * x1_in) / (d2_in * y1_in)
+  h22    = 1.0e4;                              // (x1_in / y1_in)
+  u      = 1.5;                                // 1.0 + h11 * h22
+  ref[0] = 8.0 / 3.0 * 1.0e-2;                 // (d2_in / u)
+  ref[1] = 4.0 / 3.0 * 1.0e-10 * (gam * gam);  // (d1_in / u) * (gam * gam);
+  ref[2] = 15;                                 // (x1 * u)
+  ref[3] = SType(-1.0);                        // flag
+  ref[4] = h11;                                // h11
+  ref[5] = SType(-1.0) / gam;                  // 1.0 / gam
+  ref[6] = SType(1.0);                         // h12
+  ref[7] = h22 / gam;                          // h22 / gam
+
+  impl_test_batched_rotmg_analytical<DeviceType, LayoutType, SType, SType, SType>(Nb, d1_in, d2_in, x1_in, y1_in, ref);
+
+  // big d1 case (|q1| <= |q2| with d1 scaled down by gam^2)
+  d1_in  = SType(2.0e10);
+  d2_in  = SType(4.0e-2);
+  x1_in  = SType(1.0e-5);
+  y1_in  = SType(10.0);
+  p1     = d1_in * x1_in;
+  p2     = d2_in * y1_in;
+  h11    = 5.0e5;                             // (d1_in * x1_in) / (d2_in * y1_in)
+  h22    = 1.0e-6;                            // (x1_in / y1_in)
+  u      = 1.5;                               // 1.0 + h11 * h22
+  ref[0] = 8.0 / 3.0 * 1.0e-2;                // (d2_in / u)
+  ref[1] = 4.0 / 3.0 * 1.0e10 / (gam * gam);  // (d1_in / u) / (gam * gam);
+  ref[2] = 15;                                // (x1 * u)
+  ref[3] = SType(-1.0);                       // flag
+  ref[4] = h11;                               // h11
+  ref[5] = -gam;                              // h21
+  ref[6] = SType(1.0);                        // h12
+  ref[7] = h22 * gam;                         // h22 / gam
+
+  impl_test_batched_rotmg_analytical<DeviceType, LayoutType, SType, SType, SType>(Nb, d1_in, d2_in, x1_in, y1_in, ref);
+}
+
+}  // namespace Rotmg
+}  // namespace Test
+
+template <typename DeviceType, typename ScalarType>
+int test_batched_rotmg() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
+  {
+    using LayoutType = Kokkos::LayoutLeft;
+    for (int i = 1; i < 3; i++) {
+      Test::Rotmg::impl_test_batched_rotmg<DeviceType, ScalarType, LayoutType>(i);
+    }
+  }
+#endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
+  {
+    using LayoutType = Kokkos::LayoutRight;
+    for (int i = 1; i < 3; i++) {
+      Test::Rotmg::impl_test_batched_rotmg<DeviceType, ScalarType, LayoutType>(i);
+    }
+  }
+#endif
+
+  return 0;
+}
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+TEST_F(TestCategory, test_batched_rotmg_float) { test_batched_rotmg<TestDevice, float>(); }
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+TEST_F(TestCategory, test_batched_rotmg_double) { test_batched_rotmg<TestDevice, double>(); }
+#endif

--- a/blas/impl/KokkosBlas1_rotmg_impl.hpp
+++ b/blas/impl/KokkosBlas1_rotmg_impl.hpp
@@ -11,10 +11,9 @@
 namespace KokkosBlas {
 namespace Impl {
 
-template <class Scalar, class YType, class PType>
-KOKKOS_INLINE_FUNCTION void rotmg_impl(Scalar* KOKKOS_RESTRICT d1, Scalar* KOKKOS_RESTRICT d2,
-                                       Scalar* KOKKOS_RESTRICT x1, const YType* KOKKOS_RESTRICT y1,
-                                       PType* KOKKOS_RESTRICT param, const int ps) {
+template <class DXView, class YView, class PView>
+KOKKOS_INLINE_FUNCTION void rotmg_impl(DXView d1, DXView d2, DXView x1, const YView y1, PView param) {
+  using Scalar      = typename DXView::non_const_value_type;
   const Scalar one  = KokkosKernels::ArithTraits<Scalar>::one();
   const Scalar zero = KokkosKernels::ArithTraits<Scalar>::zero();
 
@@ -26,14 +25,14 @@ KOKKOS_INLINE_FUNCTION void rotmg_impl(Scalar* KOKKOS_RESTRICT d1, Scalar* KOKKO
   Scalar h11 = zero, h12 = zero, h21 = zero, h22 = zero;
 
   // Quick exit if d1 negative
-  if (*d1 < zero) {
+  if (d1() < zero) {
     flag = -one;
 
-    *d1 = zero;
-    *d2 = zero;
-    *x1 = zero;
+    d1() = zero;
+    d2() = zero;
+    x1() = zero;
   } else {
-    Scalar p2 = (*d2) * (*y1);
+    Scalar p2 = d2() * y1();
 
     // Trivial case p2 == 0
     if (p2 == zero) {
@@ -43,18 +42,18 @@ KOKKOS_INLINE_FUNCTION void rotmg_impl(Scalar* KOKKOS_RESTRICT d1, Scalar* KOKKO
     }
 
     // General case
-    Scalar p1 = (*d1) * (*x1);
-    Scalar q1 = p1 * (*x1);
-    Scalar q2 = p2 * (*y1);
+    Scalar p1 = d1() * x1();
+    Scalar q1 = p1 * x1();
+    Scalar q2 = p2 * y1();
     if (Kokkos::abs(q1) > Kokkos::abs(q2)) {
-      h21      = -(*y1) / (*x1);
+      h21      = -y1() / x1();
       h12      = p2 / p1;
       Scalar u = one - h12 * h21;
       if (u > zero) {
         flag = zero;
-        *d1  = *d1 / u;
-        *d2  = *d2 / u;
-        *x1  = *x1 * u;
+        d1() = d1() / u;
+        d2() = d2() / u;
+        x1() = x1() * u;
       } else {
         flag = -one;
         h11  = zero;
@@ -62,9 +61,9 @@ KOKKOS_INLINE_FUNCTION void rotmg_impl(Scalar* KOKKOS_RESTRICT d1, Scalar* KOKKO
         h21  = zero;
         h22  = zero;
 
-        *d1 = zero;
-        *d2 = zero;
-        *x1 = zero;
+        d1() = zero;
+        d2() = zero;
+        x1() = zero;
       }
     } else {
       if (q2 < 0) {
@@ -74,24 +73,24 @@ KOKKOS_INLINE_FUNCTION void rotmg_impl(Scalar* KOKKOS_RESTRICT d1, Scalar* KOKKO
         h21  = zero;
         h22  = zero;
 
-        *d1 = zero;
-        *d2 = zero;
-        *x1 = zero;
+        d1() = zero;
+        d2() = zero;
+        x1() = zero;
       } else {
         flag       = one;
         h11        = p1 / p2;
-        h22        = *x1 / *y1;
+        h22        = x1() / y1();
         Scalar u   = one + h11 * h22;
-        Scalar tmp = *d2 / u;
-        *d2        = *d1 / u;
-        *d1        = tmp;
-        *x1        = *y1 * u;
+        Scalar tmp = d2() / u;
+        d2()       = d1() / u;
+        d1()       = tmp;
+        x1()       = y1() * u;
       }
     }
 
     // Rescale d1, h11 and h12
-    if (*d1 != zero) {
-      while ((*d1 <= gammasqinv) || (*d1 >= gammasq)) {
+    if (d1() != zero) {
+      while ((d1() <= gammasqinv) || (d1() >= gammasq)) {
         if (flag == zero) {
           h11  = one;
           h22  = one;
@@ -102,23 +101,23 @@ KOKKOS_INLINE_FUNCTION void rotmg_impl(Scalar* KOKKOS_RESTRICT d1, Scalar* KOKKO
           flag = -one;
         }
 
-        if (*d1 <= gammasqinv) {
-          *d1 = *d1 * gammasq;
-          *x1 = *x1 / gamma;
-          h11 = h11 / gamma;
-          h12 = h12 / gamma;
+        if (d1() <= gammasqinv) {
+          d1() = d1() * gammasq;
+          x1() = x1() / gamma;
+          h11  = h11 / gamma;
+          h12  = h12 / gamma;
         } else {
-          *d1 = *d1 / gammasq;
-          *x1 = *x1 * gamma;
-          h11 = h11 * gamma;
-          h12 = h12 * gamma;
+          d1() = d1() / gammasq;
+          x1() = x1() * gamma;
+          h11  = h11 * gamma;
+          h12  = h12 * gamma;
         }
       }
     }
 
     // Rescale d2, h21 and h22
-    if (*d2 != zero) {
-      while ((Kokkos::abs(*d2) <= gammasqinv) || (Kokkos::abs(*d2) >= gammasq)) {
+    if (d2() != zero) {
+      while ((Kokkos::abs(d2()) <= gammasqinv) || (Kokkos::abs(d2()) >= gammasq)) {
         if (flag == zero) {
           h11  = one;
           h22  = one;
@@ -129,14 +128,14 @@ KOKKOS_INLINE_FUNCTION void rotmg_impl(Scalar* KOKKOS_RESTRICT d1, Scalar* KOKKO
           flag = -one;
         }
 
-        if (Kokkos::abs(*d2) <= gammasqinv) {
-          *d2 = *d2 * gammasq;
-          h21 = h21 / gamma;
-          h22 = h22 / gamma;
+        if (Kokkos::abs(d2()) <= gammasqinv) {
+          d2() = d2() * gammasq;
+          h21  = h21 / gamma;
+          h22  = h22 / gamma;
         } else {
-          *d2 = *d2 / gammasq;
-          h21 = h21 * gamma;
-          h22 = h22 * gamma;
+          d2() = d2() / gammasq;
+          h21  = h21 * gamma;
+          h22  = h22 * gamma;
         }
       }
     }
@@ -144,18 +143,18 @@ KOKKOS_INLINE_FUNCTION void rotmg_impl(Scalar* KOKKOS_RESTRICT d1, Scalar* KOKKO
 
   // Setup output parameters
   if (flag < zero) {
-    param[1 * ps] = h11;
-    param[2 * ps] = h21;
-    param[3 * ps] = h12;
-    param[4 * ps] = h22;
+    param(1) = h11;
+    param(2) = h21;
+    param(3) = h12;
+    param(4) = h22;
   } else if (flag == zero) {
-    param[2 * ps] = h21;
-    param[3 * ps] = h12;
+    param(2) = h21;
+    param(3) = h12;
   } else {
-    param[1 * ps] = h11;
-    param[4 * ps] = h22;
+    param(1) = h11;
+    param(4) = h22;
   }
-  param[0] = flag;
+  param(0) = flag;
 }
 
 template <class DXView, class YView, class PView>
@@ -170,9 +169,7 @@ struct rotmg_functor {
       : d1(d1_), d2(d2_), x1(x1_), y1(y1_), param(param_) {}
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const int) const {
-    rotmg_impl(d1.data(), d2.data(), x1.data(), y1.data(), param.data(), param.stride(0));
-  }
+  void operator()(const int) const { rotmg_impl(d1, d2, x1, y1, param); }
 };
 
 template <class execution_space, class DXView, class YView, class PView>

--- a/blas/impl/KokkosBlas1_rotmg_impl.hpp
+++ b/blas/impl/KokkosBlas1_rotmg_impl.hpp
@@ -11,11 +11,10 @@
 namespace KokkosBlas {
 namespace Impl {
 
-template <class DXView, class YView, class PView>
-KOKKOS_INLINE_FUNCTION void rotmg_impl(DXView const& d1, DXView const& d2, DXView const& x1, YView const& y1,
-                                       PView const& param) {
-  using Scalar = typename DXView::non_const_value_type;
-
+template <class Scalar, class YType, class PType>
+KOKKOS_INLINE_FUNCTION void rotmg_impl(Scalar* KOKKOS_RESTRICT d1, Scalar* KOKKOS_RESTRICT d2,
+                                       Scalar* KOKKOS_RESTRICT x1, const YType* KOKKOS_RESTRICT y1,
+                                       PType* KOKKOS_RESTRICT param, const int ps) {
   const Scalar one  = KokkosKernels::ArithTraits<Scalar>::one();
   const Scalar zero = KokkosKernels::ArithTraits<Scalar>::zero();
 
@@ -27,35 +26,35 @@ KOKKOS_INLINE_FUNCTION void rotmg_impl(DXView const& d1, DXView const& d2, DXVie
   Scalar h11 = zero, h12 = zero, h21 = zero, h22 = zero;
 
   // Quick exit if d1 negative
-  if (d1() < 0) {
+  if (*d1 < zero) {
     flag = -one;
 
-    d1() = zero;
-    d2() = zero;
-    x1() = zero;
+    *d1 = zero;
+    *d2 = zero;
+    *x1 = zero;
   } else {
-    Scalar p2 = d2() * y1();
+    Scalar p2 = (*d2) * (*y1);
 
     // Trivial case p2 == 0
     if (p2 == zero) {
       flag     = -(one + one);
-      param(0) = flag;
+      param[0] = flag;
       return;
     }
 
     // General case
-    Scalar p1 = d1() * x1();
-    Scalar q1 = p1 * x1();
-    Scalar q2 = p2 * y1();
+    Scalar p1 = (*d1) * (*x1);
+    Scalar q1 = p1 * (*x1);
+    Scalar q2 = p2 * (*y1);
     if (Kokkos::abs(q1) > Kokkos::abs(q2)) {
-      h21      = -y1() / x1();
+      h21      = -(*y1) / (*x1);
       h12      = p2 / p1;
       Scalar u = one - h12 * h21;
       if (u > zero) {
         flag = zero;
-        d1() = d1() / u;
-        d2() = d2() / u;
-        x1() = x1() * u;
+        *d1  = *d1 / u;
+        *d2  = *d2 / u;
+        *x1  = *x1 * u;
       } else {
         flag = -one;
         h11  = zero;
@@ -63,9 +62,9 @@ KOKKOS_INLINE_FUNCTION void rotmg_impl(DXView const& d1, DXView const& d2, DXVie
         h21  = zero;
         h22  = zero;
 
-        d1() = zero;
-        d2() = zero;
-        x1() = zero;
+        *d1 = zero;
+        *d2 = zero;
+        *x1 = zero;
       }
     } else {
       if (q2 < 0) {
@@ -75,24 +74,24 @@ KOKKOS_INLINE_FUNCTION void rotmg_impl(DXView const& d1, DXView const& d2, DXVie
         h21  = zero;
         h22  = zero;
 
-        d1() = zero;
-        d2() = zero;
-        x1() = zero;
+        *d1 = zero;
+        *d2 = zero;
+        *x1 = zero;
       } else {
         flag       = one;
         h11        = p1 / p2;
-        h22        = x1() / y1();
+        h22        = *x1 / *y1;
         Scalar u   = one + h11 * h22;
-        Scalar tmp = d2() / u;
-        d2()       = d1() / u;
-        d1()       = tmp;
-        x1()       = y1() * u;
+        Scalar tmp = *d2 / u;
+        *d2        = *d1 / u;
+        *d1        = tmp;
+        *x1        = *y1 * u;
       }
     }
 
     // Rescale d1, h11 and h12
-    if (d1() != zero) {
-      while ((d1() <= gammasqinv) || (d1() >= gammasq)) {
+    if (*d1 != zero) {
+      while ((*d1 <= gammasqinv) || (*d1 >= gammasq)) {
         if (flag == zero) {
           h11  = one;
           h22  = one;
@@ -103,23 +102,23 @@ KOKKOS_INLINE_FUNCTION void rotmg_impl(DXView const& d1, DXView const& d2, DXVie
           flag = -one;
         }
 
-        if (d1() <= gammasqinv) {
-          d1() = d1() * gammasq;
-          x1() = x1() / gamma;
-          h11  = h11 / gamma;
-          h12  = h12 / gamma;
+        if (*d1 <= gammasqinv) {
+          *d1 = *d1 * gammasq;
+          *x1 = *x1 / gamma;
+          h11 = h11 / gamma;
+          h12 = h12 / gamma;
         } else {
-          d1() = d1() / gammasq;
-          x1() = x1() * gamma;
-          h11  = h11 * gamma;
-          h12  = h12 * gamma;
+          *d1 = *d1 / gammasq;
+          *x1 = *x1 * gamma;
+          h11 = h11 * gamma;
+          h12 = h12 * gamma;
         }
       }
     }
 
     // Rescale d2, h21 and h22
-    if (d2() != zero) {
-      while ((Kokkos::abs(d2()) <= gammasqinv) || (Kokkos::abs(d2()) >= gammasq)) {
+    if (*d2 != zero) {
+      while ((Kokkos::abs(*d2) <= gammasqinv) || (Kokkos::abs(*d2) >= gammasq)) {
         if (flag == zero) {
           h11  = one;
           h22  = one;
@@ -130,33 +129,33 @@ KOKKOS_INLINE_FUNCTION void rotmg_impl(DXView const& d1, DXView const& d2, DXVie
           flag = -one;
         }
 
-        if (Kokkos::abs(d2()) <= gammasqinv) {
-          d2() = d2() * gammasq;
-          h21  = h21 / gamma;
-          h22  = h22 / gamma;
+        if (Kokkos::abs(*d2) <= gammasqinv) {
+          *d2 = *d2 * gammasq;
+          h21 = h21 / gamma;
+          h22 = h22 / gamma;
         } else {
-          d2() = d2() / gammasq;
-          h21  = h21 * gamma;
-          h22  = h22 * gamma;
+          *d2 = *d2 / gammasq;
+          h21 = h21 * gamma;
+          h22 = h22 * gamma;
         }
       }
     }
-
-    // Setup output parameters
-    if (flag < zero) {
-      param(1) = h11;
-      param(2) = h21;
-      param(3) = h12;
-      param(4) = h22;
-    } else if (flag == zero) {
-      param(2) = h21;
-      param(3) = h12;
-    } else {
-      param(1) = h11;
-      param(4) = h22;
-    }
-    param(0) = flag;
   }
+
+  // Setup output parameters
+  if (flag < zero) {
+    param[1 * ps] = h11;
+    param[2 * ps] = h21;
+    param[3 * ps] = h12;
+    param[4 * ps] = h22;
+  } else if (flag == zero) {
+    param[2 * ps] = h21;
+    param[3 * ps] = h12;
+  } else {
+    param[1 * ps] = h11;
+    param[4 * ps] = h22;
+  }
+  param[0] = flag;
 }
 
 template <class DXView, class YView, class PView>
@@ -171,7 +170,9 @@ struct rotmg_functor {
       : d1(d1_), d2(d2_), x1(x1_), y1(y1_), param(param_) {}
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const int) const { rotmg_impl(d1, d2, x1, y1, param); }
+  void operator()(const int) const {
+    rotmg_impl(d1.data(), d2.data(), x1.data(), y1.data(), param.data(), param.stride(0));
+  }
 };
 
 template <class execution_space, class DXView, class YView, class PView>

--- a/blas/impl/KokkosBlas1_rotmg_impl.hpp
+++ b/blas/impl/KokkosBlas1_rotmg_impl.hpp
@@ -37,7 +37,7 @@ KOKKOS_INLINE_FUNCTION void rotmg_impl(DXView d1, DXView d2, DXView x1, const YV
     // Trivial case p2 == 0
     if (p2 == zero) {
       flag     = -(one + one);
-      param[0] = flag;
+      param(0) = flag;
       return;
     }
 


### PR DESCRIPTION
This PR aims at adding a batched interface for [rotmg](https://www.netlib.org/lapack/explore-html/d3/dd5/group__rotmg_gaebf62f1c90f0829a0a762a7f8918213f.html#gaebf62f1c90f0829a0a762a7f8918213f). 

- [x] Refactor `rotmg_impl` under blas. Fixed the behavior for `d1 < 0`.
- [x] Add batched interface `Rotmg`. `SerialRotmg` and `TeamRotmg` are not added because this kernel works only on scalars without any parallelization
- [x] Tests introduced under batched. Some corner case (`d1 < 0`) is not covered 