### PR TITLE
Make batched rotm to align with rotmg

### DIFF
--- a/batched/dense/impl/KokkosBatched_Rotm_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Rotm_Impl.hpp
@@ -45,10 +45,9 @@ KOKKOS_INLINE_FUNCTION static int checkRotmInput([[maybe_unused]] const XViewTyp
     return 1;
   }
 
-  // We handle flag as a template parameter, so we only need to check that the length of param is 4, but not the value
-  // of flag
-  if (param.extent_int(0) != 4) {
-    Kokkos::printf("KokkosBatched::rotm: param must have length 4: param length = %d\n", param.extent_int(0));
+  // param must have length 5: param(0) = flag, param(1) = h11, param(2) = h21, param(3) = h12, param(4) = h22
+  if (param.extent_int(0) != 5) {
+    Kokkos::printf("KokkosBatched::rotm: param must have length 5: param length = %d\n", param.extent_int(0));
     return 1;
   }
 #endif
@@ -60,10 +59,8 @@ KOKKOS_INLINE_FUNCTION static int checkRotmInput([[maybe_unused]] const XViewTyp
 /// Serial Impl
 /// ===========
 
-template <int Flag>
 template <typename XViewType, typename YViewType, typename ParamViewType>
-KOKKOS_INLINE_FUNCTION int SerialRotm<Flag>::invoke(const XViewType &x, const YViewType &y,
-                                                    const ParamViewType &param) {
+KOKKOS_INLINE_FUNCTION int SerialRotm::invoke(const XViewType &x, const YViewType &y, const ParamViewType &param) {
   // Quick return if possible
   const int n = x.extent_int(0);
   if (n == 0) return 0;
@@ -71,10 +68,29 @@ KOKKOS_INLINE_FUNCTION int SerialRotm<Flag>::invoke(const XViewType &x, const YV
   auto info = Impl::checkRotmInput(x, y, param);
   if (info) return info;
 
-  if constexpr (Flag != -2) {
+  using ScalarType      = typename XViewType::non_const_value_type;
+  const ScalarType flag = param(0);
+  const ScalarType zero = KokkosKernels::ArithTraits<ScalarType>::zero();
+  const ScalarType one  = KokkosKernels::ArithTraits<ScalarType>::one();
+  const ScalarType two  = one + one;
+
+  if (flag == -two) {
     // flag == -2.0: identity, no need to do anything
-    Impl::SerialRotmInternal<Flag>::invoke(n, x.data(), x.stride(0), y.data(), y.stride(0), param.data(),
-                                           param.stride(0));
+  } else if (flag == -one) {
+    Impl::SerialRotmInternal<-1>::invoke(n, x.data(), x.stride(0), y.data(), y.stride(0), param.data(),
+                                         param.stride(0));
+  } else if (flag == zero) {
+    Impl::SerialRotmInternal<0>::invoke(n, x.data(), x.stride(0), y.data(), y.stride(0), param.data(), param.stride(0));
+  } else if (flag == one) {
+    Impl::SerialRotmInternal<1>::invoke(n, x.data(), x.stride(0), y.data(), y.stride(0), param.data(), param.stride(0));
+  } else {
+#ifndef NDEBUG
+    // Invalid flag value
+    Kokkos::printf(
+        "KokkosBatched::SerialRotm: Invalid flag value. Flag must be one of -1, 0, 1, or -2. Flag value = %f\n",
+        static_cast<double>(flag));
+#endif
+    return 1;
   }
   return 0;
 }
@@ -83,10 +99,10 @@ KOKKOS_INLINE_FUNCTION int SerialRotm<Flag>::invoke(const XViewType &x, const YV
 /// Team Impl
 /// ===========
 
-template <typename MemberType, int Flag>
+template <typename MemberType>
 template <typename XViewType, typename YViewType, typename ParamViewType>
-KOKKOS_INLINE_FUNCTION int TeamRotm<MemberType, Flag>::invoke(const MemberType &member, const XViewType &x,
-                                                              const YViewType &y, const ParamViewType &param) {
+KOKKOS_INLINE_FUNCTION int TeamRotm<MemberType>::invoke(const MemberType &member, const XViewType &x,
+                                                        const YViewType &y, const ParamViewType &param) {
   // Quick return if possible
   const int n = x.extent_int(0);
   if (n == 0) return 0;
@@ -94,10 +110,31 @@ KOKKOS_INLINE_FUNCTION int TeamRotm<MemberType, Flag>::invoke(const MemberType &
   auto info = Impl::checkRotmInput(x, y, param);
   if (info) return info;
 
-  if constexpr (Flag != -2) {
+  using ScalarType      = typename XViewType::non_const_value_type;
+  const ScalarType flag = param(0);
+  const ScalarType zero = KokkosKernels::ArithTraits<ScalarType>::zero();
+  const ScalarType one  = KokkosKernels::ArithTraits<ScalarType>::one();
+  const ScalarType two  = one + one;
+
+  if (flag == -two) {
     // flag == -2.0: identity, no need to do anything
-    Impl::TeamRotmInternal<Flag>::invoke(member, n, x.data(), x.stride(0), y.data(), y.stride(0), param.data(),
-                                         param.stride(0));
+  } else if (flag == -one) {
+    Impl::TeamRotmInternal<-1>::invoke(member, n, x.data(), x.stride(0), y.data(), y.stride(0), param.data(),
+                                       param.stride(0));
+  } else if (flag == zero) {
+    Impl::TeamRotmInternal<0>::invoke(member, n, x.data(), x.stride(0), y.data(), y.stride(0), param.data(),
+                                      param.stride(0));
+  } else if (flag == one) {
+    Impl::TeamRotmInternal<1>::invoke(member, n, x.data(), x.stride(0), y.data(), y.stride(0), param.data(),
+                                      param.stride(0));
+  } else {
+#ifndef NDEBUG
+    // Invalid flag value
+    Kokkos::printf(
+        "KokkosBatched::TeamRotm: Invalid flag value. Flag must be one of -1, 0, 1, or -2. Flag value = %f\n",
+        static_cast<double>(flag));
+#endif
+    return 1;
   }
   return 0;
 }
@@ -106,10 +143,10 @@ KOKKOS_INLINE_FUNCTION int TeamRotm<MemberType, Flag>::invoke(const MemberType &
 /// TeamVector Impl
 /// ===============
 
-template <typename MemberType, int Flag>
+template <typename MemberType>
 template <typename XViewType, typename YViewType, typename ParamViewType>
-KOKKOS_INLINE_FUNCTION int TeamVectorRotm<MemberType, Flag>::invoke(const MemberType &member, const XViewType &x,
-                                                                    const YViewType &y, const ParamViewType &param) {
+KOKKOS_INLINE_FUNCTION int TeamVectorRotm<MemberType>::invoke(const MemberType &member, const XViewType &x,
+                                                              const YViewType &y, const ParamViewType &param) {
   // Quick return if possible
   const int n = x.extent_int(0);
   if (n == 0) return 0;
@@ -117,10 +154,31 @@ KOKKOS_INLINE_FUNCTION int TeamVectorRotm<MemberType, Flag>::invoke(const Member
   auto info = Impl::checkRotmInput(x, y, param);
   if (info) return info;
 
-  if constexpr (Flag != -2) {
+  using ScalarType      = typename XViewType::non_const_value_type;
+  const ScalarType flag = param(0);
+  const ScalarType zero = KokkosKernels::ArithTraits<ScalarType>::zero();
+  const ScalarType one  = KokkosKernels::ArithTraits<ScalarType>::one();
+  const ScalarType two  = one + one;
+
+  if (flag == -two) {
     // flag == -2.0: identity, no need to do anything
-    Impl::TeamVectorRotmInternal<Flag>::invoke(member, n, x.data(), x.stride(0), y.data(), y.stride(0), param.data(),
-                                               param.stride(0));
+  } else if (flag == -one) {
+    Impl::TeamVectorRotmInternal<-1>::invoke(member, n, x.data(), x.stride(0), y.data(), y.stride(0), param.data(),
+                                             param.stride(0));
+  } else if (flag == zero) {
+    Impl::TeamVectorRotmInternal<0>::invoke(member, n, x.data(), x.stride(0), y.data(), y.stride(0), param.data(),
+                                            param.stride(0));
+  } else if (flag == one) {
+    Impl::TeamVectorRotmInternal<1>::invoke(member, n, x.data(), x.stride(0), y.data(), y.stride(0), param.data(),
+                                            param.stride(0));
+  } else {
+#ifndef NDEBUG
+    // Invalid flag value
+    Kokkos::printf(
+        "KokkosBatched::TeamVectorRotm: Invalid flag value. Flag must be one of -1, 0, 1, or -2. Flag value = %f\n",
+        static_cast<double>(flag));
+#endif
+    return 1;
   }
   return 0;
 }

--- a/batched/dense/impl/KokkosBatched_Rotm_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Rotm_Internal.hpp
@@ -27,10 +27,10 @@ KOKKOS_INLINE_FUNCTION void SerialRotmInternal<Flag>::invoke(const int n, ValueT
                                                              const ValueType *KOKKOS_RESTRICT param, const int ps0) {
   if constexpr (Flag == -1) {
     // flag == -1.0: [[h11, h12], [h21, h22]]
-    auto h11 = param[0 * ps0];
-    auto h21 = param[1 * ps0];
-    auto h12 = param[2 * ps0];
-    auto h22 = param[3 * ps0];
+    auto h11 = param[1 * ps0];
+    auto h21 = param[2 * ps0];
+    auto h12 = param[3 * ps0];
+    auto h22 = param[4 * ps0];
     for (int i = 0; i < n; ++i) {
       auto temp  = h11 * x[i * xs0] + h12 * y[i * ys0];
       y[i * ys0] = h21 * x[i * xs0] + h22 * y[i * ys0];
@@ -38,8 +38,8 @@ KOKKOS_INLINE_FUNCTION void SerialRotmInternal<Flag>::invoke(const int n, ValueT
     }
   } else if constexpr (Flag == 0) {
     // flag == 0.0: [[1, h12], [h21, 1]]
-    auto h12 = param[2 * ps0];
-    auto h21 = param[1 * ps0];
+    auto h12 = param[3 * ps0];
+    auto h21 = param[2 * ps0];
     for (int i = 0; i < n; ++i) {
       auto temp  = x[i * xs0] + h12 * y[i * ys0];
       y[i * ys0] = h21 * x[i * xs0] + y[i * ys0];
@@ -47,8 +47,8 @@ KOKKOS_INLINE_FUNCTION void SerialRotmInternal<Flag>::invoke(const int n, ValueT
     }
   } else if constexpr (Flag == 1) {
     // flag == 1.0: [[h11, 1], [-1, h22]]
-    auto h11 = param[0 * ps0];
-    auto h22 = param[3 * ps0];
+    auto h11 = param[1 * ps0];
+    auto h22 = param[4 * ps0];
     for (int i = 0; i < n; ++i) {
       auto temp  = h11 * x[i * xs0] + y[i * ys0];
       y[i * ys0] = -x[i * xs0] + h22 * y[i * ys0];
@@ -78,10 +78,10 @@ KOKKOS_INLINE_FUNCTION void TeamRotmInternal<Flag>::invoke(const MemberType &mem
                                                            const ValueType *KOKKOS_RESTRICT param, const int ps0) {
   if constexpr (Flag == -1) {
     // flag == -1.0: [[h11, h12], [h21, h22]]
-    auto h11 = param[0 * ps0];
-    auto h21 = param[1 * ps0];
-    auto h12 = param[2 * ps0];
-    auto h22 = param[3 * ps0];
+    auto h11 = param[1 * ps0];
+    auto h21 = param[2 * ps0];
+    auto h12 = param[3 * ps0];
+    auto h22 = param[4 * ps0];
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int &i) {
       auto temp  = h11 * x[i * xs0] + h12 * y[i * ys0];
       y[i * ys0] = h21 * x[i * xs0] + h22 * y[i * ys0];
@@ -89,8 +89,8 @@ KOKKOS_INLINE_FUNCTION void TeamRotmInternal<Flag>::invoke(const MemberType &mem
     });
   } else if constexpr (Flag == 0) {
     // flag == 0.0: [[1, h12], [h21, 1]]
-    auto h12 = param[2 * ps0];
-    auto h21 = param[1 * ps0];
+    auto h12 = param[3 * ps0];
+    auto h21 = param[2 * ps0];
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int &i) {
       auto temp  = x[i * xs0] + h12 * y[i * ys0];
       y[i * ys0] = h21 * x[i * xs0] + y[i * ys0];
@@ -98,8 +98,8 @@ KOKKOS_INLINE_FUNCTION void TeamRotmInternal<Flag>::invoke(const MemberType &mem
     });
   } else if constexpr (Flag == 1) {
     // flag == 1.0: [[h11, 1], [-1, h22]]
-    auto h11 = param[0 * ps0];
-    auto h22 = param[3 * ps0];
+    auto h11 = param[1 * ps0];
+    auto h22 = param[4 * ps0];
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int &i) {
       auto temp  = h11 * x[i * xs0] + y[i * ys0];
       y[i * ys0] = -x[i * xs0] + h22 * y[i * ys0];
@@ -128,10 +128,10 @@ KOKKOS_INLINE_FUNCTION void TeamVectorRotmInternal<Flag>::invoke(const MemberTyp
                                                                  const int ps0) {
   if constexpr (Flag == -1) {
     // flag == -1.0: [[h11, h12], [h21, h22]]
-    auto h11 = param[0 * ps0];
-    auto h21 = param[1 * ps0];
-    auto h12 = param[2 * ps0];
-    auto h22 = param[3 * ps0];
+    auto h11 = param[1 * ps0];
+    auto h21 = param[2 * ps0];
+    auto h12 = param[3 * ps0];
+    auto h22 = param[4 * ps0];
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n), [&](const int &i) {
       auto temp  = h11 * x[i * xs0] + h12 * y[i * ys0];
       y[i * ys0] = h21 * x[i * xs0] + h22 * y[i * ys0];
@@ -139,8 +139,8 @@ KOKKOS_INLINE_FUNCTION void TeamVectorRotmInternal<Flag>::invoke(const MemberTyp
     });
   } else if constexpr (Flag == 0) {
     // flag == 0.0: [[1, h12], [h21, 1]]
-    auto h12 = param[2 * ps0];
-    auto h21 = param[1 * ps0];
+    auto h12 = param[3 * ps0];
+    auto h21 = param[2 * ps0];
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n), [&](const int &i) {
       auto temp  = x[i * xs0] + h12 * y[i * ys0];
       y[i * ys0] = h21 * x[i * xs0] + y[i * ys0];
@@ -148,8 +148,8 @@ KOKKOS_INLINE_FUNCTION void TeamVectorRotmInternal<Flag>::invoke(const MemberTyp
     });
   } else if constexpr (Flag == 1) {
     // flag == 1.0: [[h11, 1], [-1, h22]]
-    auto h11 = param[0 * ps0];
-    auto h22 = param[3 * ps0];
+    auto h11 = param[1 * ps0];
+    auto h22 = param[4 * ps0];
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n), [&](const int &i) {
       auto temp  = h11 * x[i * xs0] + y[i * ys0];
       y[i * ys0] = -x[i * xs0] + h22 * y[i * ys0];

--- a/batched/dense/src/KokkosBatched_Rotm.hpp
+++ b/batched/dense/src/KokkosBatched_Rotm.hpp
@@ -19,24 +19,18 @@ namespace KokkosBatched {
 /// [[h11, h12],  [[1, h12],    [[h11, 1],    [[1, 0],
 ///  [h21, h22]]   [h21, 1]]     [[-1, h12]]   [[0, 1]]
 ///
-/// param is a length 4 vector containing the parameters of the modified Givens rotation:
-/// param(0) = h11, param(1) = h21, param(2) = h12, param(3) = h22
+/// param is a length 5 vector containing the parameters of the modified Givens rotation:
+/// param(0) = flag, param(1) = h11, param(2) = h21, param(3) = h12, param(4) = h22
 ///
-/// \tparam Flag: A compile-time integer parameter that determines the structure of the rotation matrix H. Valid values
-/// are -1, 0, 1, and -2
-template <int Flag>
 struct SerialRotm {
-  static_assert(Flag == -1 || Flag == 0 || Flag == 1 || Flag == -2,
-                "KokkosBatched::SerialRotm: Invalid flag value. Flag must be one of -1, 0, 1, or -2.");
-
   /// \brief Invokes the SerialRotm functor. No nested parallel_for is used inside of the function.
   /// \tparam XViewType: Input/output type for the vector x, needs to be a 1D view
   /// \tparam YViewType: Input/output type for the vector y, needs to be a 1D view
-  /// \tparam ParamViewType: Input type for the param vector, needs to be a 1D view of length 4
+  /// \tparam ParamViewType: Input type for the param vector, needs to be a 1D view of length 5
   ///
   /// \param[in,out] x: x is a length n vector, a rank 1 view
   /// \param[in,out] y: y is a length n vector, a rank 1 view
-  /// \param[in] param: param is a length 4 vector, a rank 1 view, containing the parameters of the modified Givens
+  /// \param[in] param: param is a length 5 vector, a rank 1 view, containing the parameters of the modified Givens
   /// rotation
   template <typename XViewType, typename YViewType, typename ParamViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const XViewType &x, const YViewType &y, const ParamViewType &param);
@@ -52,25 +46,20 @@ struct SerialRotm {
 /// [[h11, h12],  [[1, h12],    [[h11, 1],    [[1, 0],
 ///  [h21, h22]]   [h21, 1]]     [[-1, h12]]   [[0, 1]]
 ///
-/// param is a length 4 vector containing the parameters of the modified Givens rotation:
-/// param(0) = h11, param(1) = h21, param(2) = h12, param(3) = h22
+/// param is a length 5 vector containing the parameters of the modified Givens rotation:
+/// param(0) = flag, param(1) = h11, param(2) = h21, param(3) = h12, param(4) = h22
 ///
 /// \tparam MemberType: TeamPolicy member type
-/// \tparam Flag: A compile-time integer parameter that determines the structure of the rotation matrix H. Valid values
-/// are -1, 0, 1, and -2
-template <typename MemberType, int Flag>
+template <typename MemberType>
 struct TeamRotm {
-  static_assert(Flag == -1 || Flag == 0 || Flag == 1 || Flag == -2,
-                "KokkosBatched::TeamRotm: Invalid flag value. Flag must be one of -1, 0, 1, or -2.");
-
   /// \brief Invokes the TeamRotm functor. A nested parallel_for with TeamThreadRange is used.
   /// \tparam XViewType: Input/output type for the vector x, needs to be a 1D view
   /// \tparam YViewType: Input/output type for the vector y, needs to be a 1D view
-  /// \tparam ParamViewType: Input type for the param vector, needs to be a 1D view of length 4
+  /// \tparam ParamViewType: Input type for the param vector, needs to be a 1D view of length 5
   ///
   /// \param[in,out] x: x is a length n vector, a rank 1 view
   /// \param[in,out] y: y is a length n vector, a rank 1 view
-  /// \param[in] param: param is a length 4 vector, a rank 1 view, containing the parameters of the modified Givens
+  /// \param[in] param: param is a length 5 vector, a rank 1 view, containing the parameters of the modified Givens
   /// rotation
   template <typename XViewType, typename YViewType, typename ParamViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &x, const YViewType &y,
@@ -87,26 +76,21 @@ struct TeamRotm {
 /// [[h11, h12],  [[1, h12],    [[h11, 1],    [[1, 0],
 ///  [h21, h22]]   [h21, 1]]     [[-1, h12]]   [[0, 1]]
 ///
-/// param is a length 4 vector containing the parameters of the modified Givens rotation:
-/// param(0) = h11, param(1) = h21, param(2) = h12, param(3) = h22
+/// param is a length 5 vector containing the parameters of the modified Givens rotation:
+/// param(0) = flag, param(1) = h11, param(2) = h21, param(3) = h12, param(4) = h22
 ///
 /// \tparam MemberType: TeamPolicy member type
-/// \tparam Flag: A compile-time integer parameter that determines the structure of the rotation matrix H. Valid values
-/// are -1, 0, 1, and -2.
-template <typename MemberType, int Flag>
+template <typename MemberType>
 struct TeamVectorRotm {
-  static_assert(Flag == -1 || Flag == 0 || Flag == 1 || Flag == -2,
-                "KokkosBatched::TeamVectorRotm: Invalid flag value. Flag must be one of -1, 0, 1, or -2.");
-
   /// \brief Invokes the TeamVectorRotm functor. A nested parallel_for with TeamVectorRange is used.
   /// \tparam MemberType: TeamPolicy member type
   /// \tparam XViewType: Input/output type for the vector x, needs to be a 1D view
   /// \tparam YViewType: Input/output type for the vector y, needs to be a 1D view
-  /// \tparam ParamViewType: Input type for the param vector, needs to be a 1D view of length 4
+  /// \tparam ParamViewType: Input type for the param vector, needs to be a 1D view of length 5
   ///
   /// \param[in,out] x: x is a length n vector, a rank 1 view
   /// \param[in,out] y: y is a length n vector, a rank 1 view
-  /// \param[in] param: param is a length 4 vector, a rank 1 view, containing the parameters of the modified Givens
+  /// \param[in] param: param is a length 5 vector, a rank 1 view, containing the parameters of the modified Givens
   /// rotation
   template <typename XViewType, typename YViewType, typename ParamViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &x, const YViewType &y,

--- a/batched/dense/unit_test/Test_Batched_Rotm.hpp
+++ b/batched/dense/unit_test/Test_Batched_Rotm.hpp
@@ -11,7 +11,7 @@
 namespace Test {
 namespace Rotm {
 
-template <typename DeviceType, typename XViewType, typename YViewType, typename ParamViewType, int Flag>
+template <typename DeviceType, typename XViewType, typename YViewType, typename ParamViewType>
 struct Functor_BatchedSerialRotm {
   using execution_space = typename DeviceType::execution_space;
   XViewType m_x;
@@ -27,7 +27,7 @@ struct Functor_BatchedSerialRotm {
     auto sub_y     = Kokkos::subview(m_y, k, Kokkos::ALL());
     auto sub_param = Kokkos::subview(m_param, k, Kokkos::ALL());
 
-    info += KokkosBatched::SerialRotm<Flag>::invoke(sub_x, sub_y, sub_param);
+    info += KokkosBatched::SerialRotm::invoke(sub_x, sub_y, sub_param);
   }
 
   inline int run() {
@@ -44,8 +44,7 @@ struct Functor_BatchedSerialRotm {
   }
 };
 
-template <typename DeviceType, typename XViewType, typename YViewType, typename ParamViewType, int Flag,
-          typename ArgMode>
+template <typename DeviceType, typename XViewType, typename YViewType, typename ParamViewType, typename ArgMode>
 struct Functor_BatchedTeamRotm {
   using execution_space = typename DeviceType::execution_space;
   XViewType m_x;
@@ -62,9 +61,9 @@ struct Functor_BatchedTeamRotm {
     auto sub_y     = Kokkos::subview(m_y, k, Kokkos::ALL());
     auto sub_param = Kokkos::subview(m_param, k, Kokkos::ALL());
     if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::Team>) {
-      KokkosBatched::TeamRotm<MemberType, Flag>::invoke(member, sub_x, sub_y, sub_param);
+      KokkosBatched::TeamRotm<MemberType>::invoke(member, sub_x, sub_y, sub_param);
     } else if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::TeamVector>) {
-      KokkosBatched::TeamVectorRotm<MemberType, Flag>::invoke(member, sub_x, sub_y, sub_param);
+      KokkosBatched::TeamVectorRotm<MemberType>::invoke(member, sub_x, sub_y, sub_param);
     }
   }
 
@@ -117,7 +116,7 @@ void impl_test_batched_rotm_analytical(const std::size_t Nb) {
 
   const std::size_t N = 3;
   View2DType x("x", Nb, N), y("y", Nb, N);
-  View2DType param("param", Nb, 4);
+  View2DType param("param", Nb, 5);
   View2DType x_ref("x_ref", Nb, N), y_ref("y_ref", Nb, N);
 
   const std::size_t incx = 2;
@@ -132,10 +131,11 @@ void impl_test_batched_rotm_analytical(const std::size_t Nb) {
   auto h_param = Kokkos::create_mirror_view(param);
 
   for (std::size_t ib = 0; ib < Nb; ib++) {
-    h_param(ib, 0) = static_cast<ScalarType>(2);
-    h_param(ib, 1) = static_cast<ScalarType>(0.5);
-    h_param(ib, 2) = static_cast<ScalarType>(-1);
-    h_param(ib, 3) = static_cast<ScalarType>(3);
+    h_param(ib, 0) = static_cast<ScalarType>(Flag);
+    h_param(ib, 1) = static_cast<ScalarType>(2);
+    h_param(ib, 2) = static_cast<ScalarType>(0.5);
+    h_param(ib, 3) = static_cast<ScalarType>(-1);
+    h_param(ib, 4) = static_cast<ScalarType>(3);
 
     h_x(ib, 0) = ScalarType(1);
     h_x(ib, 1) = ScalarType(2);
@@ -188,21 +188,19 @@ void impl_test_batched_rotm_analytical(const std::size_t Nb) {
   Kokkos::deep_copy(y_s, y);
 
   if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::Serial>) {
-    auto info = Functor_BatchedSerialRotm<DeviceType, View2DType, View2DType, View2DType, Flag>(x, y, param).run();
+    auto info = Functor_BatchedSerialRotm<DeviceType, View2DType, View2DType, View2DType>(x, y, param).run();
     EXPECT_EQ(info, 0);
   } else {
-    Functor_BatchedTeamRotm<DeviceType, View2DType, View2DType, View2DType, Flag, ArgMode>(x, y, param).run();
+    Functor_BatchedTeamRotm<DeviceType, View2DType, View2DType, View2DType, ArgMode>(x, y, param).run();
   }
 
   // With strided views
   if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::Serial>) {
     auto info =
-        Functor_BatchedSerialRotm<DeviceType, StridedView2DType, StridedView2DType, View2DType, Flag>(x_s, y_s, param)
-            .run();
+        Functor_BatchedSerialRotm<DeviceType, StridedView2DType, StridedView2DType, View2DType>(x_s, y_s, param).run();
     EXPECT_EQ(info, 0);
   } else {
-    Functor_BatchedTeamRotm<DeviceType, StridedView2DType, StridedView2DType, View2DType, Flag, ArgMode>(x_s, y_s,
-                                                                                                         param)
+    Functor_BatchedTeamRotm<DeviceType, StridedView2DType, StridedView2DType, View2DType, ArgMode>(x_s, y_s, param)
         .run();
   }
 
@@ -249,7 +247,7 @@ void impl_test_batched_rotm(const std::size_t Nb, const std::size_t N) {
   using View2DType        = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
   using StridedView2DType = Kokkos::View<ScalarType **, Kokkos::LayoutStride, DeviceType>;
 
-  View2DType x("x", Nb, N), y("y", Nb, N), param("param", Nb, 4);
+  View2DType x("x", Nb, N), y("y", Nb, N), param("param", Nb, 5);
   View2DType x_ref("x_ref", Nb, N), y_ref("y_ref", Nb, N);
 
   const std::size_t incx = 2;
@@ -267,6 +265,10 @@ void impl_test_batched_rotm(const std::size_t Nb, const std::size_t N) {
   Kokkos::fill_random(y, rand_pool, randStart, randEnd);
   Kokkos::fill_random(param, rand_pool, randStart, randEnd);
 
+  // Set the flag value in param
+  auto sub_param = Kokkos::subview(param, Kokkos::ALL(), 0);
+  Kokkos::deep_copy(sub_param, static_cast<ScalarType>(Flag));
+
   // Save copies for reference
   Kokkos::deep_copy(x_ref, x);
   Kokkos::deep_copy(y_ref, y);
@@ -277,21 +279,19 @@ void impl_test_batched_rotm(const std::size_t Nb, const std::size_t N) {
 
   // Run rotm on (x, y)
   if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::Serial>) {
-    auto info = Functor_BatchedSerialRotm<DeviceType, View2DType, View2DType, View2DType, Flag>(x, y, param).run();
+    auto info = Functor_BatchedSerialRotm<DeviceType, View2DType, View2DType, View2DType>(x, y, param).run();
     EXPECT_EQ(info, 0);
   } else {
-    Functor_BatchedTeamRotm<DeviceType, View2DType, View2DType, View2DType, Flag, ArgMode>(x, y, param).run();
+    Functor_BatchedTeamRotm<DeviceType, View2DType, View2DType, View2DType, ArgMode>(x, y, param).run();
   }
 
   // With strided views
   if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::Serial>) {
     auto info =
-        Functor_BatchedSerialRotm<DeviceType, StridedView2DType, StridedView2DType, View2DType, Flag>(x_s, y_s, param)
-            .run();
+        Functor_BatchedSerialRotm<DeviceType, StridedView2DType, StridedView2DType, View2DType>(x_s, y_s, param).run();
     EXPECT_EQ(info, 0);
   } else {
-    Functor_BatchedTeamRotm<DeviceType, StridedView2DType, StridedView2DType, View2DType, Flag, ArgMode>(x_s, y_s,
-                                                                                                         param)
+    Functor_BatchedTeamRotm<DeviceType, StridedView2DType, StridedView2DType, View2DType, ArgMode>(x_s, y_s, param)
         .run();
   }
 
@@ -304,16 +304,16 @@ void impl_test_batched_rotm(const std::size_t Nb, const std::size_t N) {
     for (std::size_t i = 0; i < N; i++) {
       // No modification is needed for flag == -2, as the reference is the same as the input
       if constexpr (Flag == -1) {
-        auto temp      = h_param(ib, 0) * h_x_ref(ib, i) + h_param(ib, 2) * h_y_ref(ib, i);
-        h_y_ref(ib, i) = h_param(ib, 1) * h_x_ref(ib, i) + h_param(ib, 3) * h_y_ref(ib, i);
+        auto temp      = h_param(ib, 1) * h_x_ref(ib, i) + h_param(ib, 3) * h_y_ref(ib, i);
+        h_y_ref(ib, i) = h_param(ib, 2) * h_x_ref(ib, i) + h_param(ib, 4) * h_y_ref(ib, i);
         h_x_ref(ib, i) = temp;
       } else if constexpr (Flag == 0) {
-        auto temp      = h_x_ref(ib, i) + h_param(ib, 2) * h_y_ref(ib, i);
-        h_y_ref(ib, i) = h_param(ib, 1) * h_x_ref(ib, i) + h_y_ref(ib, i);
+        auto temp      = h_x_ref(ib, i) + h_param(ib, 3) * h_y_ref(ib, i);
+        h_y_ref(ib, i) = h_param(ib, 2) * h_x_ref(ib, i) + h_y_ref(ib, i);
         h_x_ref(ib, i) = temp;
       } else if constexpr (Flag == 1) {
-        auto temp      = h_param(ib, 0) * h_x_ref(ib, i) + h_y_ref(ib, i);
-        h_y_ref(ib, i) = -1.0 * h_x_ref(ib, i) + h_param(ib, 3) * h_y_ref(ib, i);
+        auto temp      = h_param(ib, 1) * h_x_ref(ib, i) + h_y_ref(ib, i);
+        h_y_ref(ib, i) = -1.0 * h_x_ref(ib, i) + h_param(ib, 4) * h_y_ref(ib, i);
         h_x_ref(ib, i) = temp;
       }
     }


### PR DESCRIPTION
To align with [Rotmg](#3088), we need to make `Flag` a runtime parameter included in param variable.
This way we can use them like

```C++
    Kokkos::parallel_for(
        "rotm/rotmg", policy, KOKKOS_LAMBDA(int ib) {
          auto sub_d1 = Kokkos::subview(d1, ib);
          auto sub_d2 = Kokkos::subview(d2, ib);
          auto sub_x1 = Kokkos::subview(x1, ib);
          auto sub_y1 = Kokkos::subview(y1, ib);
          auto sub_param = Kokkos::subview(param, ib, Kokkos::ALL());
          KokkosBatched::Rotmg::invoke(sub_d1, sub_d2, sub_x1, sub_y1, sub_param);

          auto sub_X = Kokkos::subview(X, ib, Kokkos::ALL());
          auto sub_Y = Kokkos::subview(Y, ib, Kokkos::ALL());
          KokkosBatched::SerialRotm::invoke(sub_X, sub_Y, sub_param);
        });
```