### PR TITLE
Fix batched rotmg

### DIFF
--- a/batched/dense/unit_test/Test_Batched_Rotmg.hpp
+++ b/batched/dense/unit_test/Test_Batched_Rotmg.hpp
@@ -194,7 +194,7 @@ void impl_test_batched_rotmg(const std::size_t Nb) {
   h21    = -1.0e6;                    // -y1_in / x1_in
   h12    = 1.0 / 3.0 * 1.0e-6;        // (d2_in * y1_in) / (d1_in * x1_in)
   u      = 4.0 / 3.0;                 // 1.0 - h12 * h21
-  ref[0] = 4.5e10 / (gam * gam);      // (d1_in / u) * (gam * gam);
+  ref[0] = 4.5e10 / (gam * gam);      // (d1_in / u) / (gam * gam);
   ref[1] = 1.5e-2;                    // (d2_in / u)
   ref[2] = 4.0 / 3.0 * 1.0e-5 * gam;  // (x1 * u * gam)
   ref[3] = SType(-1.0);               // flag

--- a/blas/impl/KokkosBlas1_rotmg_impl.hpp
+++ b/blas/impl/KokkosBlas1_rotmg_impl.hpp
@@ -12,7 +12,8 @@ namespace KokkosBlas {
 namespace Impl {
 
 template <class DXView, class YView, class PView>
-KOKKOS_INLINE_FUNCTION void rotmg_impl(DXView d1, DXView d2, DXView x1, const YView y1, PView param) {
+KOKKOS_INLINE_FUNCTION void rotmg_impl(DXView const& d1, DXView const& d2, DXView const& x1, YView const& y1,
+                                       PView const& param) {
   using Scalar      = typename DXView::non_const_value_type;
   const Scalar one  = KokkosKernels::ArithTraits<Scalar>::one();
   const Scalar zero = KokkosKernels::ArithTraits<Scalar>::zero();


### PR DESCRIPTION
- [x] Make input arguments of `rotmg_impl` const Views.
- [x] Small fix in comments in unit-test for `rotmg`.