### PR TITLE
Refactor batched dot

### DIFF
--- a/batched/dense/impl/KokkosBatched_Dot_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Dot_Impl.hpp
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+#ifndef KOKKOSBATCHED_DOT_IMPL_HPP
+#define KOKKOSBATCHED_DOT_IMPL_HPP
+
+/// \author Kyungjoo Kim (kyukim@sandia.gov)
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+
+#include "KokkosBatched_Util.hpp"
+#include "KokkosBatched_Dot_Internal.hpp"
+// #include "KokkosBlas1_team_dot.hpp"
+
+namespace KokkosBatched {
+namespace Impl {
+template <int First, int... Rest>
+struct ExtractAxis {
+  static constexpr int value = First;
+};
+
+template <int Axis, typename XViewType, typename YViewType, typename NormViewType>
+KOKKOS_INLINE_FUNCTION static int checkDotInput([[maybe_unused]] const XViewType &x,
+                                                [[maybe_unused]] const YViewType &y,
+                                                [[maybe_unused]] const NormViewType &dot) {
+  static_assert(Kokkos::is_view_v<XViewType>, "KokkosBatched::dot: XViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view_v<YViewType>, "KokkosBatched::dot: YViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view_v<NormViewType>, "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
+  static_assert(XViewType::rank() == 1 || XViewType::rank() == 2,
+                "KokkosBatched::dot: XViewType must have rank 1 or 2.");
+  static_assert(YViewType::rank() == 1 || YViewType::rank() == 2,
+                "KokkosBatched::dot: YViewType must have rank 1 or 2.");
+  static_assert(NormViewType::rank() == 0 || NormViewType::rank() == 1,
+                "KokkosBatched::dot: NormViewType must have rank 0 or 1.");
+  static_assert(XViewType::rank() == YViewType::rank() && XViewType::rank() == NormViewType::rank() + 1,
+                "KokkosBatched::dot: XViewType and YViewType must have the same rank and must be one rank higher than "
+                "NormViewType.");
+  static_assert(Axis < XViewType::rank(), "KokkosBatched::dot: Axis must be less than the rank of XViewType.");
+#ifndef NDEBUG
+  if constexpr (XViewType::rank() == 2) {
+    const int x0 = x.extent_int(0), x1 = x.extent_int(1);
+    const int y0 = y.extent_int(0), y1 = y.extent_int(1);
+    const int dot0 = dot.extent_int(0);
+
+    if (x0 != y0 || x1 != y1) {
+      Kokkos::printf(
+          "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
+          "Y: %d x %d\n",
+          x0, x1, y0, y1);
+      return 1;
+    }
+
+    if (dot0 != (Axis == 0 ? x1 : x0)) {
+      Kokkos::printf(
+          "KokkosBatched::dot: Dimension of dot does not match the dimension of X and Y: "
+          "dot: %d, expected: %d\n",
+          dot0, Axis == 0 ? x1 : x0);
+      return 1;
+    }
+  } else {
+    if (y.extent_int(0) != x.extent_int(0)) {
+      Kokkos::printf(
+          "KokkosBatched::dot: x and y must have the same length: x length "
+          "= "
+          "%d, y length = %d\n",
+          x.extent_int(0), y.extent_int(0));
+      return 1;
+    }
+  }
+#endif
+  return 0;
+}
+}  // namespace Impl
+
+///
+/// Serial Internal Impl
+/// ====================
+template <typename ArgTrans, int... Args>
+template <typename XViewType, typename YViewType, typename NormViewType>
+KOKKOS_INLINE_FUNCTION int SerialDot<ArgTrans, Args...>::invoke(const XViewType &X, const YViewType &Y,
+                                                                const NormViewType &dot) {
+  // Quick return if possible
+  const int n = X.size();
+  if (n == 0) return 0;
+
+  if constexpr (sizeof...(Args) == 1) {
+    constexpr int Axis = Impl::ExtractAxis<Args...>::value;
+
+    auto info = Impl::checkDotInput<Axis>(X, Y, dot);
+    if (info) return info;
+
+    using op = std::conditional_t<std::is_same_v<ArgTrans, Trans::ConjTranspose>, KokkosBlas::Impl::OpConj,
+                                  KokkosBlas::Impl::OpID>;
+
+    if constexpr (XViewType::rank() == 1) {
+      return Impl::SerialDotInternal::invoke(op(), X.extent(0), X.data(), X.stride(0), Y.data(), Y.stride(0),
+                                             dot.data());
+    } else {
+      if constexpr (Axis == 0) {
+        // Axis 0 (row-based) : C(j) = op(A(:,j))*B(:,j)
+        return Impl::SerialDotInternal::invoke(op(), X.extent(0), X.extent(1), X.data(), X.stride(0), X.stride(1),
+                                               Y.data(), Y.stride(0), Y.stride(1), dot.data(), dot.stride(0));
+
+      } else {
+        // Axis 1 (column-based) : C(i) = op(A(i,:))*B(i,:)
+        return Impl::SerialDotInternal::invoke(op(), X.extent(1), X.extent(0), X.data(), X.stride(1), X.stride(0),
+                                               Y.data(), Y.stride(1), Y.stride(0), dot.data(), dot.stride(0));
+      }
+    }
+  } else {
+    // Old API
+    if constexpr (std::is_same_v<ArgTrans, Trans::Transpose>) {
+      // Axis 0 (row-based) : C(j) = conj(A(:,j))*B(:,j)
+      return Impl::SerialDotInternal::invoke(KokkosBlas::Impl::OpConj(), X.extent(0), X.extent(1), X.data(),
+                                             X.stride(0), X.stride(1), Y.data(), Y.stride(0), Y.stride(1), dot.data(),
+                                             dot.stride(0));
+
+    } else {
+      // Axis 1 (column-based) : C(i) = conj(A(i,:))*B(i,:)
+      return Impl::SerialDotInternal::invoke(KokkosBlas::Impl::OpConj(), X.extent(1), X.extent(0), X.data(),
+                                             X.stride(1), X.stride(0), Y.data(), Y.stride(1), Y.stride(0), dot.data(),
+                                             dot.stride(0));
+    }
+  }
+}
+
+///
+/// Team Impl
+/// ===============
+
+template <typename MemberType, typename ArgTrans, int... Args>
+template <typename XViewType, typename YViewType, typename NormViewType>
+KOKKOS_INLINE_FUNCTION int TeamDot<MemberType, ArgTrans, Args...>::invoke(const MemberType &member, const XViewType &X,
+                                                                          const YViewType &Y, const NormViewType &dot) {
+  // Quick return if possible
+  const int n = X.size();
+  if (n == 0) return 0;
+
+  if constexpr (sizeof...(Args) == 1) {
+    constexpr int Axis = Impl::ExtractAxis<Args...>::value;
+    auto info          = Impl::checkDotInput<Axis>(X, Y, dot);
+    if (info) return info;
+
+    using op = std::conditional_t<std::is_same_v<ArgTrans, Trans::ConjTranspose>, KokkosBlas::Impl::OpConj,
+                                  KokkosBlas::Impl::OpID>;
+
+    if constexpr (XViewType::rank() == 1) {
+      return Impl::TeamDotInternal::invoke(member, op(), X.extent(0), X.data(), X.stride(0), Y.data(), Y.stride(0),
+                                           dot.data());
+    } else {
+      if constexpr (Axis == 0) {
+        // Axis 0 (row-based) : C(j) = op(A(:,j))*B(:,j)
+        if (X.extent(1) == 1) {
+          return Impl::TeamDotInternal::invoke(member, op(), X.extent(0), X.data(), X.stride(0), Y.data(), Y.stride(0),
+                                               dot.data());
+        }
+        return Impl::TeamDotInternal::invoke(member, op(), X.extent(0), X.extent(1), X.data(), X.stride(0), X.stride(1),
+                                             Y.data(), Y.stride(0), Y.stride(1), dot.data(), dot.stride(0));
+      } else {
+        // Axis 1 (column-based) : C(i) = op(A(i,:))*B(i,:)
+        if (X.extent(0) == 1) {
+          return Impl::TeamDotInternal::invoke(member, op(), X.extent(1), X.data(), X.stride(1), Y.data(), Y.stride(1),
+                                               dot.data());
+        }
+        return Impl::TeamDotInternal::invoke(member, op(), X.extent(1), X.extent(0), X.data(), X.stride(1), X.stride(0),
+                                             Y.data(), Y.stride(1), Y.stride(0), dot.data(), dot.stride(0));
+      }
+    }
+  } else {
+    // Old API
+    if constexpr (std::is_same_v<ArgTrans, Trans::Transpose>) {
+      // Axis 0 (row-based) : C(j) = conj(A(:,j))*B(:,j)
+      return Impl::TeamDotInternal::invoke(member, KokkosBlas::Impl::OpConj(), X.extent(0), X.extent(1), X.data(),
+                                           X.stride(0), X.stride(1), Y.data(), Y.stride(0), Y.stride(1), dot.data(),
+                                           dot.stride(0));
+
+    } else {
+      // Axis 1 (column-based) : C(i) = conj(A(i,:))*B(i,:)
+      return Impl::TeamDotInternal::invoke(member, KokkosBlas::Impl::OpConj(), X.extent(1), X.extent(0), X.data(),
+                                           X.stride(1), X.stride(0), Y.data(), Y.stride(1), Y.stride(0), dot.data(),
+                                           dot.stride(0));
+    }
+  }
+}
+///
+/// TeamVector Impl
+/// ===============
+
+template <typename MemberType, typename ArgTrans, int... Args>
+template <typename XViewType, typename YViewType, typename NormViewType>
+KOKKOS_INLINE_FUNCTION int TeamVectorDot<MemberType, ArgTrans, Args...>::invoke(const MemberType &member,
+                                                                                const XViewType &X, const YViewType &Y,
+                                                                                const NormViewType &dot) {
+  // Quick return if possible
+  const int n = X.size();
+  if (n == 0) return 0;
+
+  if constexpr (sizeof...(Args) == 1) {
+    constexpr int Axis = Impl::ExtractAxis<Args...>::value;
+    auto info          = Impl::checkDotInput<Axis>(X, Y, dot);
+    if (info) return info;
+
+    using op = std::conditional_t<std::is_same_v<ArgTrans, Trans::ConjTranspose>, KokkosBlas::Impl::OpConj,
+                                  KokkosBlas::Impl::OpID>;
+
+    if constexpr (XViewType::rank() == 1) {
+      return Impl::TeamVectorDotInternal::invoke(member, op(), X.extent(0), X.data(), X.stride(0), Y.data(),
+                                                 Y.stride(0), dot.data());
+    } else {
+      if constexpr (Axis == 0) {
+        // Axis 0 (row-based) : C(j) = op(A(:,j))*B(:,j)
+        if (X.extent(1) == 1) {
+          return Impl::TeamVectorDotInternal::invoke(member, op(), X.extent(0), X.data(), X.stride(0), Y.data(),
+                                                     Y.stride(0), dot.data());
+        }
+        return Impl::TeamVectorDotInternal::invoke(member, op(), X.extent(0), X.extent(1), X.data(), X.stride(0),
+                                                   X.stride(1), Y.data(), Y.stride(0), Y.stride(1), dot.data(),
+                                                   dot.stride(0));
+      } else {
+        // Axis 1 (column-based) : C(i) = op(A(i,:))*B(i,:)
+        if (X.extent(0) == 1) {
+          return Impl::TeamVectorDotInternal::invoke(member, op(), X.extent(1), X.data(), X.stride(1), Y.data(),
+                                                     Y.stride(1), dot.data());
+        }
+        return Impl::TeamVectorDotInternal::invoke(member, op(), X.extent(1), X.extent(0), X.data(), X.stride(1),
+                                                   X.stride(0), Y.data(), Y.stride(1), Y.stride(0), dot.data(),
+                                                   dot.stride(0));
+      }
+    }
+  } else {
+    // Old API
+    if constexpr (std::is_same_v<ArgTrans, Trans::Transpose>) {
+      // Axis 0 (row-based) : C(j) = conj(A(:,j))*B(:,j)
+      return Impl::TeamVectorDotInternal::invoke(member, KokkosBlas::Impl::OpConj(), X.extent(0), X.extent(1), X.data(),
+                                                 X.stride(0), X.stride(1), Y.data(), Y.stride(0), Y.stride(1),
+                                                 dot.data(), dot.stride(0));
+
+    } else {
+      // Axis 1 (column-based) : C(i) = conj(A(i,:))*B(i,:)
+      return Impl::TeamVectorDotInternal::invoke(member, KokkosBlas::Impl::OpConj(), X.extent(1), X.extent(0), X.data(),
+                                                 X.stride(1), X.stride(0), Y.data(), Y.stride(1), Y.stride(0),
+                                                 dot.data(), dot.stride(0));
+    }
+  }
+}
+
+}  // end namespace KokkosBatched
+
+#endif

--- a/batched/dense/impl/KokkosBatched_Dot_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Dot_Impl.hpp
@@ -8,7 +8,6 @@
 
 #include "KokkosBatched_Util.hpp"
 #include "KokkosBatched_Dot_Internal.hpp"
-// #include "KokkosBlas1_team_dot.hpp"
 
 namespace KokkosBatched {
 namespace Impl {

--- a/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
@@ -4,11 +4,12 @@
 #define KOKKOSBATCHED_DOT_INTERNAL_HPP
 
 /// \author Kyungjoo Kim (kyukim@sandia.gov)
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
 
 #include "KokkosBatched_Util.hpp"
-#include "KokkosBlas1_team_dot.hpp"
 
 namespace KokkosBatched {
+namespace Impl {
 
 ///
 /// Serial Internal Impl
@@ -17,30 +18,29 @@ namespace KokkosBatched {
 struct SerialDotInternal {
   // i \in [0,m)
   // C = conj(A(:))*B(:)
-  template <typename ValueType, typename MagnitudeType>
-  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const int m, const ValueType *KOKKOS_RESTRICT A, const int as0,
+  template <typename Op, typename ValueType, typename MagnitudeType>
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(Op op, const int m, const ValueType *KOKKOS_RESTRICT A, const int as0,
                                                 const ValueType *KOKKOS_RESTRICT B, const int bs0,
                                                 /* */ MagnitudeType *KOKKOS_RESTRICT C) {
-    using ats = KokkosKernels::ArithTraits<ValueType>;
-    C[0]      = ValueType(0);
+    C[0] = ValueType(0);
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #pragma unroll
 #endif
     for (int i = 0; i < m; ++i) {
       const int idx_a = i * as0, idx_b = i * bs0;
-      C[0] += ats::conj(A[idx_a]) * B[idx_b];
+      C[0] += op(A[idx_a]) * B[idx_b];
     }
     return 0;
   }
 
   // j \in [0,n), i \in [0,m)
   // C(j) = conj(A(:,j))*B(:,j)
-  template <typename ValueType, typename MagnitudeType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const int m, const int n, const ValueType *KOKKOS_RESTRICT A, const int as0,
-                                           const int as1, const ValueType *KOKKOS_RESTRICT B, const int bs0,
-                                           const int bs1,
+  template <typename Op, typename ValueType, typename MagnitudeType>
+  KOKKOS_INLINE_FUNCTION static int invoke(Op op, const int m, const int n, const ValueType *KOKKOS_RESTRICT A,
+                                           const int as0, const int as1, const ValueType *KOKKOS_RESTRICT B,
+                                           const int bs0, const int bs1,
                                            /* */ MagnitudeType *KOKKOS_RESTRICT C, const int cs) {
-    for (int j = 0; j < n; ++j) invoke(m, A + j * as1, as0, B + j * bs1, bs0, C + j * cs);
+    for (int j = 0; j < n; ++j) invoke(op, m, A + j * as1, as0, B + j * bs1, bs0, C + j * cs);
     return 0;
   }
 };
@@ -52,18 +52,17 @@ struct SerialDotInternal {
 // i \in [0,m)
 // C = conj(A(:))*B(:)
 struct TeamDotInternal {
-  template <typename MemberType, typename ValueType, typename MagnitudeType>
-  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member, const int m,
+  template <typename MemberType, typename Op, typename ValueType, typename MagnitudeType>
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member, Op op, const int m,
                                                 const ValueType *KOKKOS_RESTRICT A, const int as0,
                                                 const ValueType *KOKKOS_RESTRICT B, const int bs0,
                                                 /* */ MagnitudeType *KOKKOS_RESTRICT C) {
-    using ats = KokkosKernels::ArithTraits<ValueType>;
     ValueType t(0);
     Kokkos::parallel_reduce(
         Kokkos::TeamThreadRange(member, m),
         [&](const int &i, ValueType &update) {
           const int idx_a = i * as0, idx_b = i * bs0;
-          update += ats::conj(A[idx_a]) * B[idx_b];
+          update += op(A[idx_a]) * B[idx_b];
         },
         t);
     Kokkos::single(Kokkos::PerThread(member), [&]() { C[0] = t; });
@@ -72,19 +71,18 @@ struct TeamDotInternal {
 
   // j \in [0,n), i \in [0,m)
   // C(j) = conj(A(:,j))*B(:,j)
-  template <typename MemberType, typename ValueType, typename MagnitudeType>
-  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member, const int m, const int n,
+  template <typename MemberType, typename Op, typename ValueType, typename MagnitudeType>
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member, Op op, const int m, const int n,
                                                 const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
                                                 const ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1,
                                                 /* */ MagnitudeType *KOKKOS_RESTRICT C, const int cs) {
-    using ats = KokkosKernels::ArithTraits<ValueType>;
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int &j) {
       ValueType t(0);
       const ValueType *KOKKOS_RESTRICT A_at_j = A + j * as1;
       const ValueType *KOKKOS_RESTRICT B_at_j = B + j * bs1;
       for (int i = 0; i < m; ++i) {
         const int idx_a = i * as0, idx_b = i * bs0;
-        t += ats::conj(A_at_j[idx_a]) * B_at_j[idx_b];
+        t += op(A_at_j[idx_a]) * B_at_j[idx_b];
       }
       Kokkos::single(Kokkos::PerThread(member), [&]() { C[j * cs] = t; });
     });
@@ -99,18 +97,17 @@ struct TeamDotInternal {
 // i \in [0,m)
 // C = conj(A(:))*B(:)
 struct TeamVectorDotInternal {
-  template <typename MemberType, typename ValueType, typename MagnitudeType>
-  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member, const int m,
+  template <typename MemberType, typename Op, typename ValueType, typename MagnitudeType>
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member, Op op, const int m,
                                                 const ValueType *KOKKOS_RESTRICT A, const int as0,
                                                 const ValueType *KOKKOS_RESTRICT B, const int bs0,
                                                 /* */ MagnitudeType *KOKKOS_RESTRICT C) {
-    using ats = KokkosKernels::ArithTraits<ValueType>;
     ValueType t(0);
     Kokkos::parallel_reduce(
         Kokkos::TeamVectorRange(member, m),
         [&](const int &i, ValueType &update) {
           const int idx_a = i * as0, idx_b = i * bs0;
-          update += ats::conj(A[idx_a]) * B[idx_b];
+          update += op(A[idx_a]) * B[idx_b];
         },
         t);
     Kokkos::single(Kokkos::PerThread(member), [&]() { C[0] = t; });
@@ -119,12 +116,11 @@ struct TeamVectorDotInternal {
 
   // j \in [0,n), i \in [0,m)
   // C(j) = conj(A(:,j))*B(:,j)
-  template <typename MemberType, typename ValueType, typename MagnitudeType>
-  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member, const int m, const int n,
+  template <typename MemberType, typename Op, typename ValueType, typename MagnitudeType>
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member, Op op, const int m, const int n,
                                                 const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
                                                 const ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1,
                                                 /* */ MagnitudeType *KOKKOS_RESTRICT C, const int cs) {
-    using ats = KokkosKernels::ArithTraits<ValueType>;
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int &j) {
       ValueType t(0);
       const ValueType *KOKKOS_RESTRICT A_at_j = A + j * as1;
@@ -133,7 +129,7 @@ struct TeamVectorDotInternal {
           Kokkos::ThreadVectorRange(member, m),
           [&](const int &i, ValueType &update) {
             const int idx_a = i * as0, idx_b = i * bs0;
-            update += ats::conj(A_at_j[idx_a]) * B_at_j[idx_b];
+            update += op(A_at_j[idx_a]) * B_at_j[idx_b];
           },
           t);
       Kokkos::single(Kokkos::PerThread(member), [&]() { C[j * cs] = t; });
@@ -141,264 +137,61 @@ struct TeamVectorDotInternal {
     return 0;
   }
 };
+}  // namespace Impl
 
-///
-/// Serial Impl
-/// ===========
+struct [[deprecated("Use KokkosBatched::SerialDot instead")]] SerialDotInternal {
+  template <typename ValueType, typename MagnitudeType>
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const int m, const ValueType *KOKKOS_RESTRICT A, const int as0,
+                                                const ValueType *KOKKOS_RESTRICT B, const int bs0,
+                                                /* */ MagnitudeType *KOKKOS_RESTRICT C) {
+    return Impl::SerialDotInternal::invoke(KokkosBlas::Impl::OpID(), m, A, as0, B, bs0, C);
+  }
 
-template <>
-struct SerialDot<Trans::Transpose> {
-  template <typename XViewType, typename YViewType, typename NormViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const XViewType &X, const YViewType &Y, const NormViewType &dot) {
-    static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::dot: XViewType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::dot: YViewType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<NormViewType>::value, "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
-    static_assert(XViewType::rank == 2, "KokkosBatched::dot: XViewType must have rank 2.");
-    static_assert(YViewType::rank == 2, "KokkosBatched::dot: YViewType must have rank 2.");
-    static_assert(NormViewType::rank == 1, "KokkosBatched::dot: NormViewType must have rank 1.");
-
-#ifndef NDEBUG
-    // Check compatibility of dimensions at run time.
-    if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      Kokkos::printf(
-          "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
-          "Y: %d x %d\n",
-          (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
-      return 1;
-    }
-    if (X.extent(1) != dot.extent(0)) {
-      Kokkos::printf(
-          "KokkosBatched::dot: Second dimension of X and alpha do not match: "
-          "X: "
-          "%d x %d, dot: %d\n",
-          (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
-      return 1;
-    }
-#endif
-    return SerialDotInternal::template invoke<typename XViewType::non_const_value_type,
-                                              typename NormViewType::non_const_value_type>(
-        X.extent(0), X.extent(1), X.data(), X.stride(0), X.stride(1), Y.data(), Y.stride(0), Y.stride(1), dot.data(),
-        dot.stride(0));
+  template <typename ValueType, typename MagnitudeType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const int m, const int n, const ValueType *KOKKOS_RESTRICT A, const int as0,
+                                           const int as1, const ValueType *KOKKOS_RESTRICT B, const int bs0,
+                                           const int bs1,
+                                           /* */ MagnitudeType *KOKKOS_RESTRICT C, const int cs) {
+    return Impl::SerialDotInternal::invoke(KokkosBlas::Impl::OpID(), m, n, A, as0, as1, B, bs0, bs1, C, cs);
   }
 };
 
-template <>
-struct SerialDot<Trans::NoTranspose> {
-  template <typename XViewType, typename YViewType, typename NormViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const XViewType &X, const YViewType &Y, const NormViewType &dot) {
-    static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::dot: XViewType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::dot: YViewType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<NormViewType>::value, "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
-    static_assert(XViewType::rank == 2, "KokkosBatched::dot: XViewType must have rank 2.");
-    static_assert(YViewType::rank == 2, "KokkosBatched::dot: YViewType must have rank 2.");
-    static_assert(NormViewType::rank == 1, "KokkosBatched::dot: NormViewType must have rank 1.");
+struct [[deprecated("Use KokkosBatched::TeamDot instead")]] TeamDotInternal {
+  template <typename MemberType, typename ValueType, typename MagnitudeType>
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member, const int m,
+                                                const ValueType *KOKKOS_RESTRICT A, const int as0,
+                                                const ValueType *KOKKOS_RESTRICT B, const int bs0,
+                                                /* */ MagnitudeType *KOKKOS_RESTRICT C) {
+    return Impl::TeamDotInternal::invoke(member, KokkosBlas::Impl::OpID(), m, A, as0, B, bs0, C);
+  }
 
-#ifndef NDEBUG
-    // Check compatibility of dimensions at run time.
-    if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      Kokkos::printf(
-          "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
-          "Y: %d x %d\n",
-          (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
-      return 1;
-    }
-    if (X.extent(0) != dot.extent(0)) {
-      Kokkos::printf(
-          "KokkosBatched::dot: First dimension of X and alpha do not match: X: "
-          "%d x %d, dot: %d\n",
-          (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
-      return 1;
-    }
-#endif
-    return SerialDotInternal::template invoke<typename XViewType::non_const_value_type,
-                                              typename NormViewType::non_const_value_type>(
-        X.extent(1), X.extent(0), X.data(), X.stride(1), X.stride(0), Y.data(), Y.stride(1), Y.stride(0), dot.data(),
-        dot.stride(0));
+  template <typename MemberType, typename ValueType, typename MagnitudeType>
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member, const int m, const int n,
+                                                const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+                                                const ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1,
+                                                /* */ MagnitudeType *KOKKOS_RESTRICT C, const int cs) {
+    return Impl::TeamDotInternal::invoke(member, KokkosBlas::Impl::OpID(), m, n, A, as0, as1, B, bs0, bs1, C, cs);
   }
 };
 
-///
-/// Team Impl
-/// ===============
+struct [[deprecated("Use KokkosBatched::TeamVectorDot instead")]] TeamVectorDotInternal {
+  template <typename MemberType, typename ValueType, typename MagnitudeType>
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member, const int m,
+                                                const ValueType *KOKKOS_RESTRICT A, const int as0,
+                                                const ValueType *KOKKOS_RESTRICT B, const int bs0,
+                                                /* */ MagnitudeType *KOKKOS_RESTRICT C) {
+    return Impl::TeamVectorDotInternal::invoke(member, KokkosBlas::Impl::OpID(), m, A, as0, B, bs0, C);
+  }
 
-template <typename MemberType>
-struct TeamDot<MemberType, Trans::Transpose> {
-  template <typename XViewType, typename YViewType, typename NormViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &X, const YViewType &Y,
-                                           const NormViewType &dot) {
-    static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::dot: XViewType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::dot: YViewType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<NormViewType>::value, "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
-    static_assert(XViewType::rank == 2, "KokkosBatched::dot: XViewType must have rank 2.");
-    static_assert(YViewType::rank == 2, "KokkosBatched::dot: YViewType must have rank 2.");
-    static_assert(NormViewType::rank == 1, "KokkosBatched::dot: NormViewType must have rank 1.");
-
-#ifndef NDEBUG
-    // Check compatibility of dimensions at run time.
-    if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      Kokkos::printf(
-          "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
-          "Y: %d x %d\n",
-          (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
-      return 1;
-    }
-    if (X.extent(1) != dot.extent(0)) {
-      Kokkos::printf(
-          "KokkosBatched::dot: Second dimension of X and alpha do not match: "
-          "X: "
-          "%d x %d, dot: %d\n",
-          (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
-      return 1;
-    }
-#endif
-
-    if (X.extent(1) == 1) {
-      dot(0) =
-          KokkosBlas::Experimental::dot(member, Kokkos::subview(X, Kokkos::ALL, 0), Kokkos::subview(Y, Kokkos::ALL, 0));
-      return 0;
-    }
-
-    return TeamDotInternal::template invoke<MemberType, typename XViewType::non_const_value_type,
-                                            typename NormViewType::non_const_value_type>(
-        member, X.extent(0), X.extent(1), X.data(), X.stride(0), X.stride(1), Y.data(), Y.stride(0), Y.stride(1),
-        dot.data(), dot.stride(0));
+  template <typename MemberType, typename ValueType, typename MagnitudeType>
+  KOKKOS_FORCEINLINE_FUNCTION static int invoke(const MemberType &member, const int m, const int n,
+                                                const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
+                                                const ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1,
+                                                /* */ MagnitudeType *KOKKOS_RESTRICT C, const int cs) {
+    return Impl::TeamVectorDotInternal::invoke(member, KokkosBlas::Impl::OpID(), m, n, A, as0, as1, B, bs0, bs1, C, cs);
   }
 };
 
-template <typename MemberType>
-struct TeamDot<MemberType, Trans::NoTranspose> {
-  template <typename XViewType, typename YViewType, typename NormViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &X, const YViewType &Y,
-                                           const NormViewType &dot) {
-    static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::dot: XViewType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::dot: YViewType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<NormViewType>::value, "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
-    static_assert(XViewType::rank == 2, "KokkosBatched::dot: XViewType must have rank 2.");
-    static_assert(YViewType::rank == 2, "KokkosBatched::dot: YViewType must have rank 2.");
-    static_assert(NormViewType::rank == 1, "KokkosBatched::dot: NormViewType must have rank 1.");
-
-#ifndef NDEBUG
-    // Check compatibility of dimensions at run time.
-    if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      Kokkos::printf(
-          "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
-          "Y: %d x %d\n",
-          (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
-      return 1;
-    }
-    if (X.extent(0) != dot.extent(0)) {
-      Kokkos::printf(
-          "KokkosBatched::dot: First dimension of X and alpha do not match: X: "
-          "%d x %d, dot: %d\n",
-          (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
-      return 1;
-    }
-#endif
-
-    if (X.extent(0) == 1) {
-      dot(0) =
-          KokkosBlas::Experimental::dot(member, Kokkos::subview(X, 0, Kokkos::ALL), Kokkos::subview(Y, 0, Kokkos::ALL));
-      return 0;
-    }
-
-    return TeamDotInternal::template invoke<MemberType, typename XViewType::non_const_value_type,
-                                            typename NormViewType::non_const_value_type>(
-        member, X.extent(1), X.extent(0), X.data(), X.stride(1), X.stride(0), Y.data(), Y.stride(1), Y.stride(0),
-        dot.data(), dot.stride(0));
-  }
-};
-
-///
-/// TeamVector Impl
-/// ===============
-
-template <typename MemberType>
-struct TeamVectorDot<MemberType, Trans::Transpose> {
-  template <typename XViewType, typename YViewType, typename NormViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &X, const YViewType &Y,
-                                           const NormViewType &dot) {
-    static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::dot: XViewType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::dot: YViewType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<NormViewType>::value, "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
-    static_assert(XViewType::rank == 2, "KokkosBatched::dot: XViewType must have rank 2.");
-    static_assert(YViewType::rank == 2, "KokkosBatched::dot: YViewType must have rank 2.");
-    static_assert(NormViewType::rank == 1, "KokkosBatched::dot: NormViewType must have rank 1.");
-
-#ifndef NDEBUG
-    // Check compatibility of dimensions at run time.
-    if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      Kokkos::printf(
-          "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
-          "Y: %d x %d\n",
-          (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
-      return 1;
-    }
-    if (X.extent(1) != dot.extent(0)) {
-      Kokkos::printf(
-          "KokkosBatched::dot: Second dimension of X and alpha do not match: "
-          "X: "
-          "%d x %d, dot: %d\n",
-          (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
-      return 1;
-    }
-#endif
-
-    if (X.extent(1) == 1) {
-      dot(0) =
-          KokkosBlas::Experimental::dot(member, Kokkos::subview(X, Kokkos::ALL, 0), Kokkos::subview(Y, Kokkos::ALL, 0));
-      return 0;
-    }
-
-    return TeamVectorDotInternal::template invoke<MemberType, typename XViewType::non_const_value_type,
-                                                  typename NormViewType::non_const_value_type>(
-        member, X.extent(0), X.extent(1), X.data(), X.stride(0), X.stride(1), Y.data(), Y.stride(0), Y.stride(1),
-        dot.data(), dot.stride(0));
-  }
-};
-
-template <typename MemberType>
-struct TeamVectorDot<MemberType, Trans::NoTranspose> {
-  template <typename XViewType, typename YViewType, typename NormViewType>
-  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &X, const YViewType &Y,
-                                           const NormViewType &dot) {
-    static_assert(Kokkos::is_view<XViewType>::value, "KokkosBatched::dot: XViewType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<YViewType>::value, "KokkosBatched::dot: YViewType is not a Kokkos::View.");
-    static_assert(Kokkos::is_view<NormViewType>::value, "KokkosBatched::dot: NormViewType is not a Kokkos::View.");
-    static_assert(XViewType::rank == 2, "KokkosBatched::dot: XViewType must have rank 2.");
-    static_assert(YViewType::rank == 2, "KokkosBatched::dot: YViewType must have rank 2.");
-    static_assert(NormViewType::rank == 1, "KokkosBatched::dot: NormViewType must have rank 1.");
-
-#ifndef NDEBUG
-    // Check compatibility of dimensions at run time.
-    if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-      Kokkos::printf(
-          "KokkosBatched::dot: Dimensions of X and Y do not match: X: %d x %d, "
-          "Y: %d x %d\n",
-          (int)X.extent(0), (int)X.extent(1), (int)Y.extent(0), (int)Y.extent(1));
-      return 1;
-    }
-    if (X.extent(0) != dot.extent(0)) {
-      Kokkos::printf(
-          "KokkosBatched::dot: First dimension of X and alpha do not match: X: "
-          "%d x %d, dot: %d\n",
-          (int)X.extent(0), (int)X.extent(1), (int)dot.extent(0));
-      return 1;
-    }
-#endif
-
-    if (X.extent(0) == 1) {
-      dot(0) =
-          KokkosBlas::Experimental::dot(member, Kokkos::subview(X, 0, Kokkos::ALL), Kokkos::subview(Y, 0, Kokkos::ALL));
-      return 0;
-    }
-
-    return TeamVectorDotInternal::template invoke<MemberType, typename XViewType::non_const_value_type,
-                                                  typename NormViewType::non_const_value_type>(
-        member, X.extent(1), X.extent(0), X.data(), X.stride(1), X.stride(0), Y.data(), Y.stride(1), Y.stride(0),
-        dot.data(), dot.stride(0));
-  }
-};
-
-}  // end namespace KokkosBatched
+}  // namespace KokkosBatched
 
 #endif

--- a/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Dot_Internal.hpp
@@ -144,7 +144,7 @@ struct [[deprecated("Use KokkosBatched::SerialDot instead")]] SerialDotInternal 
   KOKKOS_FORCEINLINE_FUNCTION static int invoke(const int m, const ValueType *KOKKOS_RESTRICT A, const int as0,
                                                 const ValueType *KOKKOS_RESTRICT B, const int bs0,
                                                 /* */ MagnitudeType *KOKKOS_RESTRICT C) {
-    return Impl::SerialDotInternal::invoke(KokkosBlas::Impl::OpID(), m, A, as0, B, bs0, C);
+    return Impl::SerialDotInternal::invoke(KokkosBlas::Impl::OpConj(), m, A, as0, B, bs0, C);
   }
 
   template <typename ValueType, typename MagnitudeType>
@@ -152,7 +152,7 @@ struct [[deprecated("Use KokkosBatched::SerialDot instead")]] SerialDotInternal 
                                            const int as1, const ValueType *KOKKOS_RESTRICT B, const int bs0,
                                            const int bs1,
                                            /* */ MagnitudeType *KOKKOS_RESTRICT C, const int cs) {
-    return Impl::SerialDotInternal::invoke(KokkosBlas::Impl::OpID(), m, n, A, as0, as1, B, bs0, bs1, C, cs);
+    return Impl::SerialDotInternal::invoke(KokkosBlas::Impl::OpConj(), m, n, A, as0, as1, B, bs0, bs1, C, cs);
   }
 };
 
@@ -162,7 +162,7 @@ struct [[deprecated("Use KokkosBatched::TeamDot instead")]] TeamDotInternal {
                                                 const ValueType *KOKKOS_RESTRICT A, const int as0,
                                                 const ValueType *KOKKOS_RESTRICT B, const int bs0,
                                                 /* */ MagnitudeType *KOKKOS_RESTRICT C) {
-    return Impl::TeamDotInternal::invoke(member, KokkosBlas::Impl::OpID(), m, A, as0, B, bs0, C);
+    return Impl::TeamDotInternal::invoke(member, KokkosBlas::Impl::OpConj(), m, A, as0, B, bs0, C);
   }
 
   template <typename MemberType, typename ValueType, typename MagnitudeType>
@@ -170,7 +170,7 @@ struct [[deprecated("Use KokkosBatched::TeamDot instead")]] TeamDotInternal {
                                                 const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
                                                 const ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1,
                                                 /* */ MagnitudeType *KOKKOS_RESTRICT C, const int cs) {
-    return Impl::TeamDotInternal::invoke(member, KokkosBlas::Impl::OpID(), m, n, A, as0, as1, B, bs0, bs1, C, cs);
+    return Impl::TeamDotInternal::invoke(member, KokkosBlas::Impl::OpConj(), m, n, A, as0, as1, B, bs0, bs1, C, cs);
   }
 };
 
@@ -180,7 +180,7 @@ struct [[deprecated("Use KokkosBatched::TeamVectorDot instead")]] TeamVectorDotI
                                                 const ValueType *KOKKOS_RESTRICT A, const int as0,
                                                 const ValueType *KOKKOS_RESTRICT B, const int bs0,
                                                 /* */ MagnitudeType *KOKKOS_RESTRICT C) {
-    return Impl::TeamVectorDotInternal::invoke(member, KokkosBlas::Impl::OpID(), m, A, as0, B, bs0, C);
+    return Impl::TeamVectorDotInternal::invoke(member, KokkosBlas::Impl::OpConj(), m, A, as0, B, bs0, C);
   }
 
   template <typename MemberType, typename ValueType, typename MagnitudeType>
@@ -188,7 +188,8 @@ struct [[deprecated("Use KokkosBatched::TeamVectorDot instead")]] TeamVectorDotI
                                                 const ValueType *KOKKOS_RESTRICT A, const int as0, const int as1,
                                                 const ValueType *KOKKOS_RESTRICT B, const int bs0, const int bs1,
                                                 /* */ MagnitudeType *KOKKOS_RESTRICT C, const int cs) {
-    return Impl::TeamVectorDotInternal::invoke(member, KokkosBlas::Impl::OpID(), m, n, A, as0, as1, B, bs0, bs1, C, cs);
+    return Impl::TeamVectorDotInternal::invoke(member, KokkosBlas::Impl::OpConj(), m, n, A, as0, as1, B, bs0, bs1, C,
+                                               cs);
   }
 };
 

--- a/batched/dense/impl/KokkosBatched_QR_WithColumnPivoting_TeamVector_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_QR_WithColumnPivoting_TeamVector_Internal.hpp
@@ -6,6 +6,7 @@
 /// \author Kyungjoo Kim (kyukim@sandia.gov)
 
 #include "KokkosBatched_Util.hpp"
+#include "KokkosBlas_util.hpp"
 
 #include "KokkosBatched_FindAmax_Internal.hpp"
 #include "KokkosBatched_Dot.hpp"
@@ -83,7 +84,7 @@ struct TeamVectorQR_WithColumnPivotingInternal {
     norm_part1x2.partWithAL(norm, n, 0);
 
     // compute initial column norms (replaced by dot product)
-    TeamVectorDotInternal::invoke(member, m, n, A, as0, as1, A, as0, as1, norm, 1);
+    Impl::TeamVectorDotInternal::invoke(member, KokkosBlas::Impl::OpConj(), m, n, A, as0, as1, A, as0, as1, norm, 1);
     member.team_barrier();
 
     const bool finish_when_rank_found = (matrix_rank == -1);

--- a/batched/dense/src/KokkosBatched_Dot.hpp
+++ b/batched/dense/src/KokkosBatched_Dot.hpp
@@ -4,106 +4,124 @@
 #define KOKKOSBATCHED_DOT_HPP
 
 /// \author Kim Liegeois (knliege@sandia.gov)
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
 
 #include "KokkosBatched_Util.hpp"
-#include "KokkosBatched_Vector.hpp"
 
 namespace KokkosBatched {
 
+template <bool>
+struct SerialDot_Deprecated_Warning {};
+
+template <>
+struct [[deprecated(
+    "KokkosBatched::SerialDot<ArgTrans> is deprecated. Please use "
+    "KokkosBatched::SerialDot<ArgTrans, Axis> instead.")]] SerialDot_Deprecated_Warning<true> {};
+
 /// \brief Serial Batched DOT:
 ///
-/// Depending on the ArgTrans template, the dot product is
-/// row-based (ArgTrans == Trans::NoTranspose):
+/// Depending on the Axis template, the dot product is
+/// row-based (Axis == 0):
+/// C(j) = op(A(:,j))*B(:,j)
 ///
-///   dot_l <- (x_l:, y_l:) for all l = 1, ..., N
-/// where:
-///   * N is the second dimension of X.
+/// Or column-based (Axis == 1):
+/// C(i) = op(A(i,:))*B(i,:)
 ///
-/// Or column-based:
-///   dot_l <- (x_:l, y_:l) for all l = 1, ..., n
-/// where:
-///   * n is the second dimension of X.
-///
-/// \tparam ArgTrans: type of dot product (Trans::NoTranspose by default)
-/// \tparam XViewType: Input type for X, needs to be a 2D view
-/// \tparam YViewType: Input type for Y, needs to be a 2D view
-/// \tparam alphaViewType: Input type for alpha, needs to be a 1D view
-///
-/// \param X [in]: Input vector X, a rank 2 view
-/// \param Y [in]: Input vector Y, a rank 2 view
-/// \param dot [out]: Computed dot product, a rank 1 view
+/// For 1D case, C = op(A(:))*B(:)
 ///
 /// No nested parallel_for is used inside of the function.
-///
-
-template <typename ArgTrans = Trans::NoTranspose>
-struct SerialDot {
+/// \tparam ArgTrans: whether to apply transpose or conjugate transpose to the input views
+/// \tparam Axis: type of dot product (0 for row-based, 1 for column-based)
+template <typename ArgTrans = Trans::Transpose, int... Args>
+struct SerialDot : SerialDot_Deprecated_Warning<sizeof...(Args) == 0> {
+  static_assert(KokkosBlas::is_trans_v<ArgTrans>, "KokkosBatched::SerialDot: ArgTrans must be a KokkosBlas::Trans.");
+  /// \tparam XViewType: Input type for X, needs to be a 1D or 2D view
+  /// \tparam YViewType: Input type for Y, needs to be a 1D or 2D view
+  /// \tparam NormViewType: Input type for alpha, needs to be a 0D or 1D view
+  ///
+  /// \param[in] X : Input vector X, a rank 1 or 2 view
+  /// \param[in] Y : Input vector Y, a rank 1 or 2 view
+  /// \param[out] dot : Computed dot product, a rank 0 or 1 view
   template <typename XViewType, typename YViewType, typename NormViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const XViewType &X, const YViewType &Y, const NormViewType &dot);
 };
 
+template <bool>
+struct TeamDot_Deprecated_Warning {};
+
+template <>
+struct [[deprecated(
+    "KokkosBatched::TeamDot<ArgTrans> is deprecated. Please use "
+    "KokkosBatched::TeamDot<ArgTrans, Axis> instead.")]] TeamDot_Deprecated_Warning<true> {};
+
 /// \brief Team Batched DOT:
 ///
-/// Depending on the ArgTrans template, the dot product is
-/// row-based (ArgTrans == Trans::NoTranspose):
+/// Depending on the Axis template, the dot product is
+/// row-based (Axis == 0):
+/// C(j) = op(A(:,j))*B(:,j)
 ///
-///   dot_l <- (x_l:, y_l:) for all l = 1, ..., N
-/// where:
-///   * N is the second dimension of X.
+/// Or column-based (Axis == 1):
+/// C(i) = op(A(i,:))*B(i,:)
 ///
-/// Or column-based:
-///   dot_l <- (x_:l, y_:l) for all l = 1, ..., n
-/// where:
-///   * n is the second dimension of X.
+/// For 1D case, C = op(A(:))*B(:)
 ///
-/// \tparam ArgTrans: type of dot product (Trans::NoTranspose by default)
-/// \tparam XViewType: Input type for X, needs to be a 2D view
-/// \tparam YViewType: Input type for Y, needs to be a 2D view
-/// \tparam alphaViewType: Input type for alpha, needs to be a 1D view
-///
-/// \param X [in]: Input vector X, a rank 2 view
-/// \param Y [in]: Input vector Y, a rank 2 view
-/// \param dot [out]: Computed dot product, a rank 1 view
-///
-/// A nested parallel_for with TeamThreadRange is used.
-///
-
-template <typename MemberType, typename ArgTrans = Trans::NoTranspose>
-struct TeamDot {
+/// \tparam MemberType: Kokkos TeamPolicy member type
+/// \tparam ArgTrans: whether to apply transpose or conjugate transpose to the input views
+/// \tparam Axis: type of dot product (0 for row-based, 1 for column-based)
+template <typename MemberType, typename ArgTrans = Trans::Transpose, int... Args>
+struct TeamDot : TeamDot_Deprecated_Warning<sizeof...(Args) == 0> {
+  static_assert(KokkosBlas::is_trans_v<ArgTrans>, "KokkosBatched::TeamDot: ArgTrans must be a KokkosBlas::Trans.");
+  /// \tparam XViewType: Input type for X, needs to be a 1D or 2D view
+  /// \tparam YViewType: Input type for Y, needs to be a 1D or 2D view
+  /// \tparam NormViewType: Input type for alpha, needs to be a 0D or 1D view
+  ///
+  /// \param[in] member : Kokkos TeamPolicy member type
+  /// \param[in] X : Input vector X, a rank 1 or 2 view
+  /// \param[in] Y : Input vector Y, a rank 1 or 2 view
+  /// \param[out] dot : Computed dot product, a rank 0 or 1 view
+  ///
+  /// A nested parallel_for with TeamThreadRange is used.
   template <typename XViewType, typename YViewType, typename NormViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &X, const YViewType &Y,
                                            const NormViewType &dot);
 };
 
+template <bool>
+struct TeamVectorDot_Deprecated_Warning {};
+
+template <>
+struct [[deprecated(
+    "KokkosBatched::TeamVectorDot<ArgTrans> is deprecated. Please use "
+    "KokkosBatched::TeamVectorDot<ArgTrans, Axis> instead.")]] TeamVectorDot_Deprecated_Warning<true> {};
+
 /// \brief TeamVector Batched DOT:
 ///
-/// Depending on the ArgTrans template, the dot product is
-/// row-based (ArgTrans == Trans::NoTranspose):
+/// Depending on the Axis template, the dot product is
+/// row-based (Axis == 0):
+/// C(j) = op(A(:,j))*B(:,j)
 ///
-///   dot_l <- (x_l:, y_l:) for all l = 1, ..., N
-/// where:
-///   * N is the second dimension of X.
+/// Or column-based (Axis == 1):
+/// C(i) = op(A(i,:))*B(i,:)
 ///
-/// Or column-based:
-///   dot_l <- (x_:l, y_:l) for all l = 1, ..., n
-/// where:
-///   * n is the second dimension of X.
-///
-/// \tparam ArgTrans: type of dot product (Trans::NoTranspose by default)
-/// \tparam XViewType: Input type for X, needs to be a 2D view
-/// \tparam YViewType: Input type for Y, needs to be a 2D view
-/// \tparam alphaViewType: Input type for alpha, needs to be a 1D view
-///
-/// \param X [in]: Input vector X, a rank 2 view
-/// \param Y [in]: Input vector Y, a rank 2 view
-/// \param dot [out]: Computed dot product, a rank 1 view
+/// For 1D case, C = op(A(:))*B(:)
 ///
 /// Two nested parallel_for with both TeamThreadRange and ThreadVectorRange
 /// (or one with TeamVectorRange) are used inside.
 ///
-
-template <typename MemberType, typename ArgTrans = Trans::NoTranspose>
-struct TeamVectorDot {
+/// \tparam MemberType: Kokkos TeamPolicy member type
+/// \tparam ArgTrans: whether to apply transpose or conjugate transpose to the input views
+/// \tparam Axis: type of dot product (0 for row-based, 1 for column-based)
+template <typename MemberType, typename ArgTrans = Trans::Transpose, int... Args>
+struct TeamVectorDot : TeamVectorDot_Deprecated_Warning<sizeof...(Args) == 0> {
+  static_assert(KokkosBlas::is_trans_v<ArgTrans>,
+                "KokkosBatched::TeamVectorDot: ArgTrans must be a KokkosBlas::Trans.");
+  /// \tparam XViewType: Input type for X, needs to be a 1D or 2D view
+  /// \tparam YViewType: Input type for Y, needs to be a 1D or 2D view
+  /// \tparam NormViewType: Input type for alpha, needs to be a 0D or 1D view
+  ///
+  /// \param[in] X : Input vector X, a rank 1 or 2 view
+  /// \param[in] Y : Input vector Y, a rank 1 or 2 view
+  /// \param[out] dot : Computed dot product, a rank 0 or 1 view
   template <typename XViewType, typename YViewType, typename NormViewType>
   KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &X, const YViewType &Y,
                                            const NormViewType &dot);
@@ -111,6 +129,6 @@ struct TeamVectorDot {
 
 }  // namespace KokkosBatched
 
-#include "KokkosBatched_Dot_Internal.hpp"
+#include "KokkosBatched_Dot_Impl.hpp"
 
 #endif

--- a/batched/dense/unit_test/Test_Batched_Dense.hpp
+++ b/batched/dense/unit_test/Test_Batched_Dense.hpp
@@ -6,6 +6,7 @@
 // Serial kernels
 #include "Test_Batched_SerialAxpy.hpp"
 #include "Test_Batched_Copy.hpp"
+#include "Test_Batched_Dot.hpp"
 #include "Test_Batched_Rot.hpp"
 #include "Test_Batched_Rotg.hpp"
 #include "Test_Batched_Rotm.hpp"

--- a/batched/dense/unit_test/Test_Batched_Dot.hpp
+++ b/batched/dense/unit_test/Test_Batched_Dot.hpp
@@ -318,24 +318,24 @@ void impl_test_batched_dot(const std::size_t Nb, const std::size_t m, const std:
   auto h_ref_dot1_ax1 = Kokkos::create_mirror_view(ref_dot1_ax1);
 
   for (std::size_t ib = 0; ib < Nb; ib++) {
-    ScalarType dot0 = 0;
+    ScalarType tmp_dot0 = 0;
     for (std::size_t j = 0; j < n; j++) {
-      dot0 += op(h_x0(ib, j)) * h_y0(ib, j);
+      tmp_dot0 += op(h_x0(ib, j)) * h_y0(ib, j);
     }
-    h_ref_dot0(ib) = dot0;
+    h_ref_dot0(ib) = tmp_dot0;
     for (std::size_t j = 0; j < n; j++) {
-      ScalarType dot1 = 0;
+      ScalarType tmp_dot1 = 0;
       for (std::size_t i = 0; i < m; i++) {
-        dot1 += op(h_x1(ib, i, j)) * h_y1(ib, i, j);
+        tmp_dot1 += op(h_x1(ib, i, j)) * h_y1(ib, i, j);
       }
-      h_ref_dot1_ax0(ib, j) = dot1;
+      h_ref_dot1_ax0(ib, j) = tmp_dot1;
     }
     for (std::size_t j = 0; j < m; j++) {
-      ScalarType dot1 = 0;
+      ScalarType tmp_dot1 = 0;
       for (std::size_t i = 0; i < n; i++) {
-        dot1 += op(h_x1(ib, j, i)) * h_y1(ib, j, i);
+        tmp_dot1 += op(h_x1(ib, j, i)) * h_y1(ib, j, i);
       }
-      h_ref_dot1_ax1(ib, j) = dot1;
+      h_ref_dot1_ax1(ib, j) = tmp_dot1;
     }
   }
 

--- a/batched/dense/unit_test/Test_Batched_Dot.hpp
+++ b/batched/dense/unit_test/Test_Batched_Dot.hpp
@@ -1,0 +1,514 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
+#include <KokkosBatched_Util.hpp>
+#include <KokkosBatched_Dot.hpp>
+#include "Test_Batched_DenseUtils.hpp"
+
+namespace Test {
+namespace Dot {
+
+template <typename DeviceType, typename ArgTrans, int Axis, typename XViewType, typename YViewType,
+          typename NormViewType>
+struct Functor_BatchedSerialDot {
+  using execution_space = typename DeviceType::execution_space;
+  XViewType m_x;
+  YViewType m_y;
+  NormViewType m_dot;
+
+  Functor_BatchedSerialDot(const XViewType &x, const YViewType &y, const NormViewType &dot)
+      : m_x(x), m_y(y), m_dot(dot) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int k, int &info) const {
+    if constexpr (XViewType::rank() == 2) {
+      auto sub_x   = Kokkos::subview(m_x, k, Kokkos::ALL());
+      auto sub_y   = Kokkos::subview(m_y, k, Kokkos::ALL());
+      auto sub_dot = Kokkos::subview(m_dot, k);
+
+      info += KokkosBatched::SerialDot<ArgTrans, Axis>::invoke(sub_x, sub_y, sub_dot);
+    } else {
+      auto sub_x   = Kokkos::subview(m_x, k, Kokkos::ALL(), Kokkos::ALL());
+      auto sub_y   = Kokkos::subview(m_y, k, Kokkos::ALL(), Kokkos::ALL());
+      auto sub_dot = Kokkos::subview(m_dot, k, Kokkos::ALL());
+
+      info += KokkosBatched::SerialDot<ArgTrans, Axis>::invoke(sub_x, sub_y, sub_dot);
+    }
+  }
+
+  inline int run() {
+    using value_type = typename XViewType::non_const_value_type;
+    std::string name_region("KokkosBatched::Test::SerialDot");
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    int info_sum                      = 0;
+    Kokkos::Profiling::pushRegion(name.c_str());
+    Kokkos::RangePolicy<execution_space> policy(0, m_x.extent(0));
+    Kokkos::parallel_reduce(name.c_str(), policy, *this, info_sum);
+    Kokkos::Profiling::popRegion();
+    return info_sum;
+  }
+};
+
+template <typename DeviceType, typename ArgTrans, int Axis, typename XViewType, typename YViewType,
+          typename NormViewType, typename ArgMode>
+struct Functor_BatchedTeamDot {
+  using execution_space = typename DeviceType::execution_space;
+  XViewType m_x;
+  YViewType m_y;
+  NormViewType m_dot;
+
+  Functor_BatchedTeamDot(const XViewType &x, const YViewType &y, const NormViewType &dot)
+      : m_x(x), m_y(y), m_dot(dot) {}
+
+  template <typename MemberType>
+  KOKKOS_INLINE_FUNCTION void operator()(const MemberType &member) const {
+    const int k = member.league_rank();
+    if constexpr (XViewType::rank() == 2) {
+      auto sub_x   = Kokkos::subview(m_x, k, Kokkos::ALL());
+      auto sub_y   = Kokkos::subview(m_y, k, Kokkos::ALL());
+      auto sub_dot = Kokkos::subview(m_dot, k);
+
+      if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::Team>) {
+        KokkosBatched::TeamDot<MemberType, ArgTrans, Axis>::invoke(member, sub_x, sub_y, sub_dot);
+      } else if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::TeamVector>) {
+        KokkosBatched::TeamVectorDot<MemberType, ArgTrans, Axis>::invoke(member, sub_x, sub_y, sub_dot);
+      }
+    } else {
+      auto sub_x   = Kokkos::subview(m_x, k, Kokkos::ALL(), Kokkos::ALL());
+      auto sub_y   = Kokkos::subview(m_y, k, Kokkos::ALL(), Kokkos::ALL());
+      auto sub_dot = Kokkos::subview(m_dot, k, Kokkos::ALL());
+
+      if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::Team>) {
+        KokkosBatched::TeamDot<MemberType, ArgTrans, Axis>::invoke(member, sub_x, sub_y, sub_dot);
+      } else if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::TeamVector>) {
+        KokkosBatched::TeamVectorDot<MemberType, ArgTrans, Axis>::invoke(member, sub_x, sub_y, sub_dot);
+      }
+    }
+  }
+
+  inline void run() {
+    using value_type        = typename XViewType::non_const_value_type;
+    std::string name_region = std::is_same_v<ArgMode, KokkosBatched::Mode::Team> ? "KokkosBatched::Test::TeamDot"
+                                                                                 : "KokkosBatched::Test::TeamVectorDot";
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    Kokkos::Profiling::pushRegion(name.c_str());
+    const int league_size = m_x.extent_int(0);
+    Kokkos::TeamPolicy<execution_space> policy(league_size, Kokkos::AUTO);
+    Kokkos::parallel_for(name.c_str(), policy, *this);
+    Kokkos::Profiling::popRegion();
+  }
+};
+
+/// \brief Implementation details of batched dot analytical test
+///        to confirm the dot product is computed correctly
+///        x0: [1, 2, 3]
+///        y0: [4, 5, 6]
+///        dot0: 32
+///
+///        x1: [[1, 2, 3],
+///             [4, 5, 6]]
+///        y1: [[4, 5, 6],
+///             [7, 8, 9]]
+///        dot1-ax0: [32, 50, 72]
+///        dot1-ax1: [32, 77]
+///
+/// \param Nb [in] Batch size of vectors
+template <typename DeviceType, typename ScalarType, typename LayoutType, typename ArgTrans, typename ArgMode>
+void impl_test_batched_dot_analytical(const std::size_t Nb) {
+  using ats               = typename KokkosKernels::ArithTraits<ScalarType>;
+  using RealType          = typename ats::mag_type;
+  using View1DType        = Kokkos::View<ScalarType *, LayoutType, DeviceType>;
+  using View2DType        = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
+  using View3DType        = Kokkos::View<ScalarType ***, LayoutType, DeviceType>;
+  using StridedView2DType = Kokkos::View<ScalarType **, Kokkos::LayoutStride, DeviceType>;
+  using StridedView3DType = Kokkos::View<ScalarType ***, Kokkos::LayoutStride, DeviceType>;
+
+  const std::size_t m = 2, n = 3;
+  View2DType x0("x0", Nb, n), y0("y0", Nb, n);
+  View3DType x1("x1", Nb, m, n), y1("y1", Nb, m, n);
+  View1DType dot0("dot0", Nb), ref_dot0("ref_dot0", Nb);
+  View2DType dot1_ax0("dot1_ax0", Nb, n), dot1_ax1("dot1_ax1", Nb, m), ref_dot1_ax0("ref_dot1_ax0", Nb, n),
+      ref_dot1_ax1("ref_dot1_ax1", Nb, m);
+
+  // Testing incx/incy argument with strided views
+  const std::size_t incx = 2, incy = 2;
+  Kokkos::LayoutStride layout_x0{Nb, incx, n, Nb * incx}, layout_y0{Nb, incy, n, Nb * incy};
+  Kokkos::LayoutStride layout_x1{Nb, incx, m, Nb * incx, n, Nb * incx * m},
+      layout_y1{Nb, incy, m, Nb * incy, n, Nb * incy * m};
+  StridedView2DType x0_s("x_s", layout_x0), y0_s("y_s", layout_y0);
+  StridedView3DType x1_s("x_s", layout_x1), y1_s("y_s", layout_y1);
+  View1DType dot0_s("dot_s", Nb);
+  View2DType dot1_ax0_s("dot1_ax0_s", Nb, n), dot1_ax1_s("dot1_ax1_s", Nb, m);
+
+  auto h_x0           = Kokkos::create_mirror_view(x0);
+  auto h_y0           = Kokkos::create_mirror_view(y0);
+  auto h_ref_dot0     = Kokkos::create_mirror_view(ref_dot0);
+  auto h_x1           = Kokkos::create_mirror_view(x1);
+  auto h_y1           = Kokkos::create_mirror_view(y1);
+  auto h_ref_dot1_ax0 = Kokkos::create_mirror_view(ref_dot1_ax0);
+  auto h_ref_dot1_ax1 = Kokkos::create_mirror_view(ref_dot1_ax1);
+
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    h_x0(ib, 0)    = static_cast<ScalarType>(1);
+    h_x0(ib, 1)    = static_cast<ScalarType>(2);
+    h_x0(ib, 2)    = static_cast<ScalarType>(3);
+    h_y0(ib, 0)    = static_cast<ScalarType>(4);
+    h_y0(ib, 1)    = static_cast<ScalarType>(5);
+    h_y0(ib, 2)    = static_cast<ScalarType>(6);
+    h_ref_dot0(ib) = ScalarType(32);  // dot0 = 1*4 + 2*5 + 3*6 = 32
+
+    h_x1(ib, 0, 0)        = static_cast<ScalarType>(1);
+    h_x1(ib, 0, 1)        = static_cast<ScalarType>(2);
+    h_x1(ib, 0, 2)        = static_cast<ScalarType>(3);
+    h_x1(ib, 1, 0)        = static_cast<ScalarType>(4);
+    h_x1(ib, 1, 1)        = static_cast<ScalarType>(5);
+    h_x1(ib, 1, 2)        = static_cast<ScalarType>(6);
+    h_y1(ib, 0, 0)        = static_cast<ScalarType>(4);
+    h_y1(ib, 0, 1)        = static_cast<ScalarType>(5);
+    h_y1(ib, 0, 2)        = static_cast<ScalarType>(6);
+    h_y1(ib, 1, 0)        = static_cast<ScalarType>(7);
+    h_y1(ib, 1, 1)        = static_cast<ScalarType>(8);
+    h_y1(ib, 1, 2)        = static_cast<ScalarType>(9);
+    h_ref_dot1_ax0(ib, 0) = ScalarType(32);   // dot1_ax0(0) = 1*4 + 4*7 = 32
+    h_ref_dot1_ax0(ib, 1) = ScalarType(50);   // dot1_ax0(1) = 2*5 + 5*8 = 50
+    h_ref_dot1_ax0(ib, 2) = ScalarType(72);   // dot1_ax0(2) = 3*6 + 6*9 = 72
+    h_ref_dot1_ax1(ib, 0) = ScalarType(32);   // dot1_ax1(0) = 1*4 + 2*5 + 3*6 = 32
+    h_ref_dot1_ax1(ib, 1) = ScalarType(122);  // dot1_ax1(1) = 4*7 + 5*8 + 6*9 = 122
+  }
+
+  Kokkos::deep_copy(x0, h_x0);
+  Kokkos::deep_copy(y0, h_y0);
+  Kokkos::deep_copy(x1, h_x1);
+  Kokkos::deep_copy(y1, h_y1);
+
+  // Deep copy to strided views
+  Kokkos::deep_copy(x0_s, x0);
+  Kokkos::deep_copy(y0_s, y0);
+  Kokkos::deep_copy(x1_s, x1);
+  Kokkos::deep_copy(y1_s, y1);
+
+  if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::Serial>) {
+    // 1D case
+    auto info0 =
+        Functor_BatchedSerialDot<DeviceType, ArgTrans, 0, View2DType, View2DType, View1DType>(x0, y0, dot0).run();
+    EXPECT_EQ(info0, 0);
+
+    // With strided views
+    info0 = Functor_BatchedSerialDot<DeviceType, ArgTrans, 0, StridedView2DType, StridedView2DType, View1DType>(
+                x0_s, y0_s, dot0_s)
+                .run();
+    EXPECT_EQ(info0, 0);
+
+    // 2D case: axis 0
+    auto info1_ax0 =
+        Functor_BatchedSerialDot<DeviceType, ArgTrans, 0, View3DType, View3DType, View2DType>(x1, y1, dot1_ax0).run();
+    EXPECT_EQ(info1_ax0, 0);
+
+    // 2D case: axis 1
+    auto info1_ax1 =
+        Functor_BatchedSerialDot<DeviceType, ArgTrans, 1, View3DType, View3DType, View2DType>(x1, y1, dot1_ax1).run();
+    EXPECT_EQ(info1_ax1, 0);
+
+    // With strided views
+    info1_ax0 = Functor_BatchedSerialDot<DeviceType, ArgTrans, 0, StridedView3DType, StridedView3DType, View2DType>(
+                    x1_s, y1_s, dot1_ax0_s)
+                    .run();
+    EXPECT_EQ(info1_ax0, 0);
+
+    info1_ax1 = Functor_BatchedSerialDot<DeviceType, ArgTrans, 1, StridedView3DType, StridedView3DType, View2DType>(
+                    x1_s, y1_s, dot1_ax1_s)
+                    .run();
+    EXPECT_EQ(info1_ax1, 0);
+  } else {
+    // 1D case
+    Functor_BatchedTeamDot<DeviceType, ArgTrans, 0, View2DType, View2DType, View1DType, ArgMode>(x0, y0, dot0).run();
+
+    // With strided views
+    Functor_BatchedTeamDot<DeviceType, ArgTrans, 0, StridedView2DType, StridedView2DType, View1DType, ArgMode>(
+        x0_s, y0_s, dot0_s)
+        .run();
+
+    // 2D case: axis 0
+    Functor_BatchedTeamDot<DeviceType, ArgTrans, 0, View3DType, View3DType, View2DType, ArgMode>(x1, y1, dot1_ax0)
+        .run();
+
+    // 2D case: axis 1
+    Functor_BatchedTeamDot<DeviceType, ArgTrans, 1, View3DType, View3DType, View2DType, ArgMode>(x1, y1, dot1_ax1)
+        .run();
+
+    // With strided views
+    Functor_BatchedTeamDot<DeviceType, ArgTrans, 0, StridedView3DType, StridedView3DType, View2DType, ArgMode>(
+        x1_s, y1_s, dot1_ax0_s)
+        .run();
+
+    Functor_BatchedTeamDot<DeviceType, ArgTrans, 1, StridedView3DType, StridedView3DType, View2DType, ArgMode>(
+        x1_s, y1_s, dot1_ax1_s)
+        .run();
+  }
+
+  RealType eps      = 1.0e1 * ats::epsilon();
+  auto h_dot0       = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, dot0);
+  auto h_dot0_s     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, dot0_s);
+  auto h_dot1_ax0   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, dot1_ax0);
+  auto h_dot1_ax1   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, dot1_ax1);
+  auto h_dot1_ax0_s = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, dot1_ax0_s);
+  auto h_dot1_ax1_s = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, dot1_ax1_s);
+
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    EXPECT_NEAR_KK(h_dot0(ib), h_ref_dot0(ib), eps);
+    EXPECT_NEAR_KK(h_dot0_s(ib), h_ref_dot0(ib), eps);
+    for (std::size_t j = 0; j < n; j++) {
+      EXPECT_NEAR_KK(h_dot1_ax0(ib, j), h_ref_dot1_ax0(ib, j), eps);
+      EXPECT_NEAR_KK(h_dot1_ax0_s(ib, j), h_ref_dot1_ax0(ib, j), eps);
+    }
+    for (std::size_t j = 0; j < m; j++) {
+      EXPECT_NEAR_KK(h_dot1_ax1(ib, j), h_ref_dot1_ax1(ib, j), eps);
+      EXPECT_NEAR_KK(h_dot1_ax1_s(ib, j), h_ref_dot1_ax1(ib, j), eps);
+    }
+  }
+}
+
+/// \brief Implementation details of batched dot test
+///        Confirm dot = X^T * Y or X^H * Y
+///
+/// \param[in] Nb Batch size of vectors
+/// \param[in] m  Number of rows
+/// \param[in] n  Number of columns
+template <typename DeviceType, typename ScalarType, typename LayoutType, typename ArgTrans, typename ArgMode>
+void impl_test_batched_dot(const std::size_t Nb, const std::size_t m, const std::size_t n) {
+  using ats        = typename KokkosKernels::ArithTraits<ScalarType>;
+  using RealType   = typename ats::mag_type;
+  using View1DType = Kokkos::View<ScalarType *, LayoutType, DeviceType>;
+  using View2DType = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
+  using View3DType = Kokkos::View<ScalarType ***, LayoutType, DeviceType>;
+
+  View2DType x0("x0", Nb, n), y0("y0", Nb, n);
+  View3DType x1("x1", Nb, m, n), y1("y1", Nb, m, n);
+  View1DType dot0("dot0", Nb), ref_dot0("ref_dot0", Nb);
+  View2DType dot1_ax0("dot1_ax0", Nb, n), dot1_ax1("dot1_ax1", Nb, m), ref_dot1_ax0("ref_dot1_ax0", Nb, n),
+      ref_dot1_ax1("ref_dot1_ax1", Nb, m);
+
+  // Create random vectors x and y
+  using execution_space = typename DeviceType::execution_space;
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
+  ScalarType randStart, randEnd;
+
+  KokkosKernels::Impl::getRandomBounds(1.0, randStart, randEnd);
+  Kokkos::fill_random(x0, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(y0, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(x1, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(y1, rand_pool, randStart, randEnd);
+
+  using Op = std::conditional_t<std::is_same_v<ArgTrans, KokkosBatched::Trans::ConjTranspose>, KokkosBlas::Impl::OpConj,
+                                KokkosBlas::Impl::OpID>;
+  Op op;
+
+  // Make a reference
+  auto h_x0           = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, x0);
+  auto h_y0           = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, y0);
+  auto h_ref_dot0     = Kokkos::create_mirror_view(ref_dot0);
+  auto h_x1           = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, x1);
+  auto h_y1           = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, y1);
+  auto h_ref_dot1_ax0 = Kokkos::create_mirror_view(ref_dot1_ax0);
+  auto h_ref_dot1_ax1 = Kokkos::create_mirror_view(ref_dot1_ax1);
+
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    ScalarType dot0 = 0;
+    for (std::size_t j = 0; j < n; j++) {
+      dot0 += op(h_x0(ib, j)) * h_y0(ib, j);
+    }
+    h_ref_dot0(ib) = dot0;
+    for (std::size_t j = 0; j < n; j++) {
+      ScalarType dot1 = 0;
+      for (std::size_t i = 0; i < m; i++) {
+        dot1 += op(h_x1(ib, i, j)) * h_y1(ib, i, j);
+      }
+      h_ref_dot1_ax0(ib, j) = dot1;
+    }
+    for (std::size_t j = 0; j < m; j++) {
+      ScalarType dot1 = 0;
+      for (std::size_t i = 0; i < n; i++) {
+        dot1 += op(h_x1(ib, j, i)) * h_y1(ib, j, i);
+      }
+      h_ref_dot1_ax1(ib, j) = dot1;
+    }
+  }
+
+  // Dot operation
+  if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::Serial>) {
+    auto info0 =
+        Functor_BatchedSerialDot<DeviceType, ArgTrans, 0, View2DType, View2DType, View1DType>(x0, y0, dot0).run();
+    EXPECT_EQ(info0, 0);
+    auto info1_ax0 =
+        Functor_BatchedSerialDot<DeviceType, ArgTrans, 0, View3DType, View3DType, View2DType>(x1, y1, dot1_ax0).run();
+    EXPECT_EQ(info1_ax0, 0);
+    auto info1_ax1 =
+        Functor_BatchedSerialDot<DeviceType, ArgTrans, 1, View3DType, View3DType, View2DType>(x1, y1, dot1_ax1).run();
+    EXPECT_EQ(info1_ax1, 0);
+  } else {
+    Functor_BatchedTeamDot<DeviceType, ArgTrans, 0, View2DType, View2DType, View1DType, ArgMode>(x0, y0, dot0).run();
+    Functor_BatchedTeamDot<DeviceType, ArgTrans, 0, View3DType, View3DType, View2DType, ArgMode>(x1, y1, dot1_ax0)
+        .run();
+    Functor_BatchedTeamDot<DeviceType, ArgTrans, 1, View3DType, View3DType, View2DType, ArgMode>(x1, y1, dot1_ax1)
+        .run();
+  }
+
+  RealType eps    = 1.0e1 * ats::epsilon();
+  auto h_dot0     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, dot0);
+  auto h_dot1_ax0 = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, dot1_ax0);
+  auto h_dot1_ax1 = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, dot1_ax1);
+
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    EXPECT_NEAR_KK(h_dot0(ib), h_ref_dot0(ib), eps);
+    for (std::size_t j = 0; j < n; j++) {
+      EXPECT_NEAR_KK(h_dot1_ax0(ib, j), h_ref_dot1_ax0(ib, j), eps);
+    }
+    for (std::size_t j = 0; j < m; j++) {
+      EXPECT_NEAR_KK(h_dot1_ax1(ib, j), h_ref_dot1_ax1(ib, j), eps);
+    }
+  }
+}
+
+}  // namespace Dot
+}  // namespace Test
+
+template <typename DeviceType, typename ScalarType, typename ArgTrans, typename ArgMode>
+int test_batched_dot() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
+  {
+    using LayoutType = Kokkos::LayoutLeft;
+    Test::Dot::impl_test_batched_dot_analytical<DeviceType, ScalarType, LayoutType, ArgTrans, ArgMode>(1);
+    Test::Dot::impl_test_batched_dot_analytical<DeviceType, ScalarType, LayoutType, ArgTrans, ArgMode>(2);
+    for (std::size_t i = 0; i < 3; i++) {
+      for (std::size_t j = 0; j < 3; j++) {
+        Test::Dot::impl_test_batched_dot<DeviceType, ScalarType, LayoutType, ArgTrans, ArgMode>(1, i, j);
+        Test::Dot::impl_test_batched_dot<DeviceType, ScalarType, LayoutType, ArgTrans, ArgMode>(2, i, j);
+      }
+    }
+  }
+#endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
+  {
+    using LayoutType = Kokkos::LayoutRight;
+    Test::Dot::impl_test_batched_dot_analytical<DeviceType, ScalarType, LayoutType, ArgTrans, ArgMode>(1);
+    Test::Dot::impl_test_batched_dot_analytical<DeviceType, ScalarType, LayoutType, ArgTrans, ArgMode>(2);
+    for (std::size_t i = 0; i < 3; i++) {
+      for (std::size_t j = 0; j < 3; j++) {
+        Test::Dot::impl_test_batched_dot<DeviceType, ScalarType, LayoutType, ArgTrans, ArgMode>(1, i, j);
+        Test::Dot::impl_test_batched_dot<DeviceType, ScalarType, LayoutType, ArgTrans, ArgMode>(2, i, j);
+      }
+    }
+  }
+#endif
+
+  return 0;
+}
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+// Serial
+TEST_F(TestCategory, test_batched_serial_dot_t_float) {
+  test_batched_dot<TestDevice, float, Trans::Transpose, KokkosBatched::Mode::Serial>();
+}
+TEST_F(TestCategory, test_batched_serial_dot_c_float) {
+  test_batched_dot<TestDevice, float, Trans::ConjTranspose, KokkosBatched::Mode::Serial>();
+}
+
+// Team
+TEST_F(TestCategory, test_batched_team_dot_t_float) {
+  test_batched_dot<TestDevice, float, Trans::Transpose, KokkosBatched::Mode::Team>();
+}
+TEST_F(TestCategory, test_batched_team_dot_c_float) {
+  test_batched_dot<TestDevice, float, Trans::ConjTranspose, KokkosBatched::Mode::Team>();
+}
+
+// TeamVector
+TEST_F(TestCategory, test_batched_team_vector_dot_t_float) {
+  test_batched_dot<TestDevice, float, Trans::Transpose, KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_team_vector_dot_c_float) {
+  test_batched_dot<TestDevice, float, Trans::ConjTranspose, KokkosBatched::Mode::TeamVector>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+// Serial
+TEST_F(TestCategory, test_batched_serial_dot_t_double) {
+  test_batched_dot<TestDevice, double, Trans::Transpose, KokkosBatched::Mode::Serial>();
+}
+TEST_F(TestCategory, test_batched_serial_dot_c_double) {
+  test_batched_dot<TestDevice, double, Trans::ConjTranspose, KokkosBatched::Mode::Serial>();
+}
+
+// Team
+TEST_F(TestCategory, test_batched_team_dot_t_double) {
+  test_batched_dot<TestDevice, double, Trans::Transpose, KokkosBatched::Mode::Team>();
+}
+TEST_F(TestCategory, test_batched_team_dot_c_double) {
+  test_batched_dot<TestDevice, double, Trans::ConjTranspose, KokkosBatched::Mode::Team>();
+}
+
+// TeamVector
+TEST_F(TestCategory, test_batched_team_vector_dot_t_double) {
+  test_batched_dot<TestDevice, double, Trans::Transpose, KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_team_vector_dot_c_double) {
+  test_batched_dot<TestDevice, double, Trans::ConjTranspose, KokkosBatched::Mode::TeamVector>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_FLOAT)
+// Serial
+TEST_F(TestCategory, test_batched_serial_dot_t_fcomplex) {
+  test_batched_dot<TestDevice, Kokkos::complex<float>, Trans::Transpose, KokkosBatched::Mode::Serial>();
+}
+TEST_F(TestCategory, test_batched_serial_dot_c_fcomplex) {
+  test_batched_dot<TestDevice, Kokkos::complex<float>, Trans::ConjTranspose, KokkosBatched::Mode::Serial>();
+}
+
+// Team
+TEST_F(TestCategory, test_batched_team_dot_t_fcomplex) {
+  test_batched_dot<TestDevice, Kokkos::complex<float>, Trans::Transpose, KokkosBatched::Mode::Team>();
+}
+TEST_F(TestCategory, test_batched_team_dot_c_fcomplex) {
+  test_batched_dot<TestDevice, Kokkos::complex<float>, Trans::ConjTranspose, KokkosBatched::Mode::Team>();
+}
+
+// TeamVector
+TEST_F(TestCategory, test_batched_team_vector_dot_t_fcomplex) {
+  test_batched_dot<TestDevice, Kokkos::complex<float>, Trans::Transpose, KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_team_vector_dot_c_fcomplex) {
+  test_batched_dot<TestDevice, Kokkos::complex<float>, Trans::ConjTranspose, KokkosBatched::Mode::TeamVector>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
+// Serial
+TEST_F(TestCategory, test_batched_serial_dot_t_dcomplex) {
+  test_batched_dot<TestDevice, Kokkos::complex<double>, Trans::Transpose, KokkosBatched::Mode::Serial>();
+}
+TEST_F(TestCategory, test_batched_serial_dot_c_dcomplex) {
+  test_batched_dot<TestDevice, Kokkos::complex<double>, Trans::ConjTranspose, KokkosBatched::Mode::Serial>();
+}
+
+// Team
+TEST_F(TestCategory, test_batched_team_dot_t_dcomplex) {
+  test_batched_dot<TestDevice, Kokkos::complex<double>, Trans::Transpose, KokkosBatched::Mode::Team>();
+}
+TEST_F(TestCategory, test_batched_team_dot_c_dcomplex) {
+  test_batched_dot<TestDevice, Kokkos::complex<double>, Trans::ConjTranspose, KokkosBatched::Mode::Team>();
+}
+
+// TeamVector
+TEST_F(TestCategory, test_batched_team_vector_dot_t_dcomplex) {
+  test_batched_dot<TestDevice, Kokkos::complex<double>, Trans::Transpose, KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_team_vector_dot_c_dcomplex) {
+  test_batched_dot<TestDevice, Kokkos::complex<double>, Trans::ConjTranspose, KokkosBatched::Mode::TeamVector>();
+}
+#endif

--- a/batched/dense/unit_test/Test_Batched_SerialGesv.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialGesv.hpp
@@ -91,7 +91,7 @@ void impl_test_batched_gesv(const int N, const int BlkSize) {
         -1, Kokkos::subview(A_host, l, Kokkos::ALL, Kokkos::ALL), Kokkos::subview(X_host, l, Kokkos::ALL), 1,
         Kokkos::subview(B_host, l, Kokkos::ALL));
 
-  KokkosBatched::SerialDot<Trans::NoTranspose>::invoke(B_host, B_host, sqr_norm_j_host);
+  KokkosBatched::SerialDot<Trans::ConjTranspose, 1>::invoke(B_host, B_host, sqr_norm_j_host);
 
   const MagnitudeType eps = 1.0e3 * ats::epsilon();
 

--- a/batched/dense/unit_test/Test_Batched_TeamGesv.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamGesv.hpp
@@ -99,7 +99,7 @@ void impl_test_batched_gesv(const int N, const int BlkSize) {
         -1, Kokkos::subview(A_host, l, Kokkos::ALL, Kokkos::ALL), Kokkos::subview(X_host, l, Kokkos::ALL), 1,
         Kokkos::subview(B_host, l, Kokkos::ALL));
 
-  KokkosBatched::SerialDot<Trans::NoTranspose>::invoke(B_host, B_host, sqr_norm_j_host);
+  KokkosBatched::SerialDot<Trans::ConjTranspose, 1>::invoke(B_host, B_host, sqr_norm_j_host);
 
   const MagnitudeType eps = 1.0e3 * ats::epsilon();
 

--- a/batched/dense/unit_test/Test_Batched_TeamVectorGesv.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorGesv.hpp
@@ -100,7 +100,7 @@ void impl_test_batched_gesv(const int N, const int BlkSize) {
         -1, Kokkos::subview(A_host, l, Kokkos::ALL, Kokkos::ALL), Kokkos::subview(X_host, l, Kokkos::ALL), 1,
         Kokkos::subview(B_host, l, Kokkos::ALL));
 
-  KokkosBatched::SerialDot<Trans::NoTranspose>::invoke(B_host, B_host, sqr_norm_j_host);
+  KokkosBatched::SerialDot<Trans::ConjTranspose, 1>::invoke(B_host, B_host, sqr_norm_j_host);
 
   const MagnitudeType eps = 1.0e3 * ats::epsilon();
 

--- a/batched/sparse/impl/KokkosBatched_CG_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_CG_TeamVector_Impl.hpp
@@ -67,7 +67,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorCG<MemberType>::invoke(const MemberType& me
   // Deep copy of r_0 into p_0:
   TeamVectorCopy<MemberType>::invoke(member, R, P);
 
-  TeamVectorDot<MemberType, Trans::Transpose, 1>::invoke(member, R, R, sqr_norm_0);
+  TeamVectorDot<MemberType, Trans::ConjTranspose, 1>::invoke(member, R, R, sqr_norm_0);
   member.team_barrier();
 
   Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
@@ -83,7 +83,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorCG<MemberType>::invoke(const MemberType& me
     A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, P, Q);
     member.team_barrier();
 
-    TeamVectorDot<MemberType, Trans::Transpose, 1>::invoke(member, P, Q, tmp);
+    TeamVectorDot<MemberType, Trans::ConjTranspose, 1>::invoke(member, P, Q, tmp);
     member.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
@@ -102,7 +102,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorCG<MemberType>::invoke(const MemberType& me
     TeamVectorAxpy<MemberType>::invoke(member, alpha, Q, R);
     member.team_barrier();
 
-    TeamVectorDot<MemberType, Trans::Transpose, 1>::invoke(member, R, R, tmp);
+    TeamVectorDot<MemberType, Trans::ConjTranspose, 1>::invoke(member, R, R, tmp);
     member.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),

--- a/batched/sparse/impl/KokkosBatched_CG_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_CG_TeamVector_Impl.hpp
@@ -67,7 +67,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorCG<MemberType>::invoke(const MemberType& me
   // Deep copy of r_0 into p_0:
   TeamVectorCopy<MemberType>::invoke(member, R, P);
 
-  TeamVectorDot<MemberType>::invoke(member, R, R, sqr_norm_0);
+  TeamVectorDot<MemberType, Trans::Transpose, 1>::invoke(member, R, R, sqr_norm_0);
   member.team_barrier();
 
   Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
@@ -83,7 +83,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorCG<MemberType>::invoke(const MemberType& me
     A.template apply<Trans::NoTranspose, Mode::TeamVector>(member, P, Q);
     member.team_barrier();
 
-    TeamVectorDot<MemberType>::invoke(member, P, Q, tmp);
+    TeamVectorDot<MemberType, Trans::Transpose, 1>::invoke(member, P, Q, tmp);
     member.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),
@@ -102,7 +102,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorCG<MemberType>::invoke(const MemberType& me
     TeamVectorAxpy<MemberType>::invoke(member, alpha, Q, R);
     member.team_barrier();
 
-    TeamVectorDot<MemberType>::invoke(member, R, R, tmp);
+    TeamVectorDot<MemberType, Trans::Transpose, 1>::invoke(member, R, R, tmp);
     member.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices),

--- a/batched/sparse/impl/KokkosBatched_CG_Team_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_CG_Team_Impl.hpp
@@ -66,7 +66,7 @@ KOKKOS_INLINE_FUNCTION int TeamCG<MemberType>::invoke(const MemberType& member, 
   // Deep copy of r_0 into p_0:
   TeamCopy<MemberType>::invoke(member, R, P);
 
-  TeamDot<MemberType, Trans::Transpose, 1>::invoke(member, R, R, sqr_norm_0);
+  TeamDot<MemberType, Trans::ConjTranspose, 1>::invoke(member, R, R, sqr_norm_0);
   member.team_barrier();
 
   Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
@@ -82,7 +82,7 @@ KOKKOS_INLINE_FUNCTION int TeamCG<MemberType>::invoke(const MemberType& member, 
     A.template apply<Trans::NoTranspose, Mode::Team>(member, P, Q);
     member.team_barrier();
 
-    TeamDot<MemberType, Trans::Transpose, 1>::invoke(member, P, Q, tmp);
+    TeamDot<MemberType, Trans::ConjTranspose, 1>::invoke(member, P, Q, tmp);
     member.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
@@ -101,7 +101,7 @@ KOKKOS_INLINE_FUNCTION int TeamCG<MemberType>::invoke(const MemberType& member, 
     TeamAxpy<MemberType>::invoke(member, alpha, Q, R);
     member.team_barrier();
 
-    TeamDot<MemberType, Trans::Transpose, 1>::invoke(member, R, R, tmp);
+    TeamDot<MemberType, Trans::ConjTranspose, 1>::invoke(member, R, R, tmp);
     member.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),

--- a/batched/sparse/impl/KokkosBatched_CG_Team_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_CG_Team_Impl.hpp
@@ -66,7 +66,7 @@ KOKKOS_INLINE_FUNCTION int TeamCG<MemberType>::invoke(const MemberType& member, 
   // Deep copy of r_0 into p_0:
   TeamCopy<MemberType>::invoke(member, R, P);
 
-  TeamDot<MemberType>::invoke(member, R, R, sqr_norm_0);
+  TeamDot<MemberType, Trans::Transpose, 1>::invoke(member, R, R, sqr_norm_0);
   member.team_barrier();
 
   Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
@@ -82,7 +82,7 @@ KOKKOS_INLINE_FUNCTION int TeamCG<MemberType>::invoke(const MemberType& member, 
     A.template apply<Trans::NoTranspose, Mode::Team>(member, P, Q);
     member.team_barrier();
 
-    TeamDot<MemberType>::invoke(member, P, Q, tmp);
+    TeamDot<MemberType, Trans::Transpose, 1>::invoke(member, P, Q, tmp);
     member.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),
@@ -101,7 +101,7 @@ KOKKOS_INLINE_FUNCTION int TeamCG<MemberType>::invoke(const MemberType& member, 
     TeamAxpy<MemberType>::invoke(member, alpha, Q, R);
     member.team_barrier();
 
-    TeamDot<MemberType>::invoke(member, R, R, tmp);
+    TeamDot<MemberType, Trans::Transpose, 1>::invoke(member, R, R, tmp);
     member.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices),

--- a/batched/sparse/impl/KokkosBatched_GMRES_Serial_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_GMRES_Serial_Impl.hpp
@@ -235,7 +235,7 @@ KOKKOS_INLINE_FUNCTION int SerialGMRES::invoke(const OperatorType& A, const Vect
     SerialCopy<Trans::NoTranspose>::invoke(B, W);
     A.template apply<Trans::NoTranspose>(X, W, -1, 1);
     P.template apply<Trans::NoTranspose, 1>(W, W);
-    SerialDot<Trans::NoTranspose>::invoke(W, W, tmp);
+    SerialDot<Trans::ConjTranspose, 1>::invoke(W, W, tmp);
 
     for (OrdinalType i = 0; i < numMatrices; ++i) {
       tmp(i) = ATM::sqrt(tmp(i));

--- a/batched/sparse/impl/KokkosBatched_GMRES_Serial_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_GMRES_Serial_Impl.hpp
@@ -80,7 +80,7 @@ KOKKOS_INLINE_FUNCTION int SerialGMRES::invoke(const OperatorType& A, const Vect
 
   P.template apply<Trans::NoTranspose, 1>(W, W);
 
-  SerialDot<Trans::NoTranspose>::invoke(W, W, tmp);
+  SerialDot<Trans::ConjTranspose, 1>::invoke(W, W, tmp);
 
   for (OrdinalType i = 0; i < numMatrices; ++i) {
     tmp(i) = ATM::sqrt(tmp(i));
@@ -130,7 +130,7 @@ KOKKOS_INLINE_FUNCTION int SerialGMRES::invoke(const OperatorType& A, const Vect
     if (handle.get_ortho_strategy() == 1) {
       for (size_t i = 0; i < j + 1; ++i) {
         auto V_i = Kokkos::subview(V_view, Kokkos::ALL, i, Kokkos::ALL);
-        SerialDot<Trans::NoTranspose>::invoke(W, V_i, tmp);
+        SerialDot<Trans::ConjTranspose, 1>::invoke(W, V_i, tmp);
         SerialCopy<Trans::NoTranspose>::invoke(tmp, Kokkos::subview(H_view, Kokkos::ALL, j, i));
         for (OrdinalType ii = 0; ii < numMatrices; ++ii) tmp(ii) = -tmp(ii);
 
@@ -138,7 +138,7 @@ KOKKOS_INLINE_FUNCTION int SerialGMRES::invoke(const OperatorType& A, const Vect
       }
     }
 
-    SerialDot<Trans::NoTranspose>::invoke(W, W, tmp);
+    SerialDot<Trans::ConjTranspose, 1>::invoke(W, W, tmp);
 
     for (OrdinalType i = 0; i < numMatrices; ++i) {
       H_view(i, j, j + 1) = ATM::sqrt(tmp(i));

--- a/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
@@ -85,7 +85,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::invoke(const MemberType&
   P.template apply<Trans::NoTranspose, Mode::TeamVector, 1>(member, W, W);
   member.team_barrier();
 
-  TeamVectorDot<MemberType, Trans::Transpose, 1>::invoke(member, W, W, tmp);
+  TeamVectorDot<MemberType, Trans::ConjTranspose, 1>::invoke(member, W, W, tmp);
   member.team_barrier();
 
   Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices), [&](const OrdinalType& i) {
@@ -153,7 +153,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::invoke(const MemberType&
       }
     }
 
-    TeamVectorDot<MemberType, Trans::Transpose, 1>::invoke(member, W, W, tmp);
+    TeamVectorDot<MemberType, Trans::ConjTranspose, 1>::invoke(member, W, W, tmp);
     member.team_barrier();
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices), [&](const OrdinalType& i) {
       H_view(i, j, j + 1) = ATM::sqrt(tmp(i));
@@ -260,7 +260,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::invoke(const MemberType&
     member.team_barrier();
     P.template apply<Trans::NoTranspose, Mode::TeamVector, 1>(member, W, W);
     member.team_barrier();
-    TeamVectorDot<MemberType, Trans::Transpose, 1>::invoke(member, W, W, tmp);
+    TeamVectorDot<MemberType, Trans::ConjTranspose, 1>::invoke(member, W, W, tmp);
     member.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices), [&](const OrdinalType& i) {

--- a/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
@@ -85,7 +85,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::invoke(const MemberType&
   P.template apply<Trans::NoTranspose, Mode::TeamVector, 1>(member, W, W);
   member.team_barrier();
 
-  TeamVectorDot<MemberType>::invoke(member, W, W, tmp);
+  TeamVectorDot<MemberType, Trans::Transpose, 1>::invoke(member, W, W, tmp);
   member.team_barrier();
 
   Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices), [&](const OrdinalType& i) {
@@ -153,7 +153,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::invoke(const MemberType&
       }
     }
 
-    TeamVectorDot<MemberType>::invoke(member, W, W, tmp);
+    TeamVectorDot<MemberType, Trans::Transpose, 1>::invoke(member, W, W, tmp);
     member.team_barrier();
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices), [&](const OrdinalType& i) {
       H_view(i, j, j + 1) = ATM::sqrt(tmp(i));
@@ -260,7 +260,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::invoke(const MemberType&
     member.team_barrier();
     P.template apply<Trans::NoTranspose, Mode::TeamVector, 1>(member, W, W);
     member.team_barrier();
-    TeamVectorDot<MemberType>::invoke(member, W, W, tmp);
+    TeamVectorDot<MemberType, Trans::Transpose, 1>::invoke(member, W, W, tmp);
     member.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamVectorRange(member, 0, numMatrices), [&](const OrdinalType& i) {

--- a/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_GMRES_TeamVector_Impl.hpp
@@ -139,7 +139,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorGMRES<MemberType>::invoke(const MemberType&
     if (handle.get_ortho_strategy() == 1) {
       for (size_t i = 0; i < j + 1; ++i) {
         auto V_i = Kokkos::subview(V_view, Kokkos::ALL, i, Kokkos::ALL);
-        TeamVectorDot<MemberType>::invoke(member, W, V_i, tmp);
+        TeamVectorDot<MemberType, Trans::ConjTranspose, 1>::invoke(member, W, V_i, tmp);
         member.team_barrier();
         TeamVectorCopy1D::invoke(member, tmp, Kokkos::subview(H_view, Kokkos::ALL, j, i));
         member.team_barrier();

--- a/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
@@ -83,7 +83,7 @@ KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::invoke(const MemberType& membe
   P.template apply<Trans::NoTranspose, Mode::Team, 1>(member, W, W);
   member.team_barrier();
 
-  TeamDot<MemberType>::invoke(member, W, W, tmp);
+  TeamDot<MemberType, Trans::Transpose, 1>::invoke(member, W, W, tmp);
   member.team_barrier();
 
   Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices), [&](const OrdinalType& i) {
@@ -137,7 +137,7 @@ KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::invoke(const MemberType& membe
     if (handle.get_ortho_strategy() == 1) {
       for (size_t i = 0; i < j + 1; ++i) {
         auto V_i = Kokkos::subview(V_view, Kokkos::ALL, i, Kokkos::ALL);
-        TeamDot<MemberType>::invoke(member, W, V_i, tmp);
+        TeamDot<MemberType, Trans::Transpose, 1>::invoke(member, W, V_i, tmp);
         member.team_barrier();
         TeamCopy1D::invoke(member, tmp, Kokkos::subview(H_view, Kokkos::ALL, j, i));
         member.team_barrier();
@@ -151,7 +151,7 @@ KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::invoke(const MemberType& membe
       }
     }
 
-    TeamDot<MemberType>::invoke(member, W, W, tmp);
+    TeamDot<MemberType, Trans::Transpose, 1>::invoke(member, W, W, tmp);
     member.team_barrier();
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices), [&](const OrdinalType& i) {
       H_view(i, j, j + 1) = ATM::sqrt(tmp(i));
@@ -258,7 +258,7 @@ KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::invoke(const MemberType& membe
     member.team_barrier();
     P.template apply<Trans::NoTranspose, Mode::Team, 1>(member, W, W);
     member.team_barrier();
-    TeamDot<MemberType>::invoke(member, W, W, tmp);
+    TeamDot<MemberType, Trans::Transpose, 1>::invoke(member, W, W, tmp);
     member.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices), [&](const OrdinalType& i) {

--- a/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
+++ b/batched/sparse/impl/KokkosBatched_GMRES_Team_Impl.hpp
@@ -83,7 +83,7 @@ KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::invoke(const MemberType& membe
   P.template apply<Trans::NoTranspose, Mode::Team, 1>(member, W, W);
   member.team_barrier();
 
-  TeamDot<MemberType, Trans::Transpose, 1>::invoke(member, W, W, tmp);
+  TeamDot<MemberType, Trans::ConjTranspose, 1>::invoke(member, W, W, tmp);
   member.team_barrier();
 
   Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices), [&](const OrdinalType& i) {
@@ -137,7 +137,7 @@ KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::invoke(const MemberType& membe
     if (handle.get_ortho_strategy() == 1) {
       for (size_t i = 0; i < j + 1; ++i) {
         auto V_i = Kokkos::subview(V_view, Kokkos::ALL, i, Kokkos::ALL);
-        TeamDot<MemberType, Trans::Transpose, 1>::invoke(member, W, V_i, tmp);
+        TeamDot<MemberType, Trans::ConjTranspose, 1>::invoke(member, W, V_i, tmp);
         member.team_barrier();
         TeamCopy1D::invoke(member, tmp, Kokkos::subview(H_view, Kokkos::ALL, j, i));
         member.team_barrier();
@@ -151,7 +151,7 @@ KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::invoke(const MemberType& membe
       }
     }
 
-    TeamDot<MemberType, Trans::Transpose, 1>::invoke(member, W, W, tmp);
+    TeamDot<MemberType, Trans::ConjTranspose, 1>::invoke(member, W, W, tmp);
     member.team_barrier();
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices), [&](const OrdinalType& i) {
       H_view(i, j, j + 1) = ATM::sqrt(tmp(i));
@@ -258,7 +258,7 @@ KOKKOS_INLINE_FUNCTION int TeamGMRES<MemberType>::invoke(const MemberType& membe
     member.team_barrier();
     P.template apply<Trans::NoTranspose, Mode::Team, 1>(member, W, W);
     member.team_barrier();
-    TeamDot<MemberType, Trans::Transpose, 1>::invoke(member, W, W, tmp);
+    TeamDot<MemberType, Trans::ConjTranspose, 1>::invoke(member, W, W, tmp);
     member.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(member, 0, numMatrices), [&](const OrdinalType& i) {

--- a/batched/sparse/unit_test/Test_Batched_SerialGMRES.hpp
+++ b/batched/sparse/unit_test/Test_Batched_SerialGMRES.hpp
@@ -159,7 +159,7 @@ void impl_test_batched_GMRES(const int N, const int BlkSize, const int N_team) {
       typename ValuesViewType::host_mirror_type, typename IntView::host_mirror_type,
       typename VectorViewType::host_mirror_type, typename VectorViewType::host_mirror_type, 1>(
       -1, D_host, r_host, c_host, X_host, 1, R_host);
-  KokkosBatched::SerialDot<Trans::NoTranspose>::invoke(R_host, R_host, sqr_norm_0_host);
+  KokkosBatched::SerialDot<Trans::ConjTranspose, 1>::invoke(R_host, R_host, sqr_norm_0_host);
   Functor_TestBatchedSerialGMRES<DeviceType, ValuesViewType, IntView, VectorViewType, KrylovHandleType>(
       D, r, c, X, B, Diag, N_team, handle)
       .run();
@@ -174,7 +174,7 @@ void impl_test_batched_GMRES(const int N, const int BlkSize, const int N_team) {
       typename ValuesViewType::host_mirror_type, typename IntView::host_mirror_type,
       typename VectorViewType::host_mirror_type, typename VectorViewType::host_mirror_type, 1>(
       -1, D_host, r_host, c_host, X_host, 1, R_host);
-  KokkosBatched::SerialDot<Trans::NoTranspose>::invoke(R_host, R_host, sqr_norm_j_host);
+  KokkosBatched::SerialDot<Trans::ConjTranspose, 1>::invoke(R_host, R_host, sqr_norm_j_host);
 
   const MagnitudeType eps = 1.0e5 * ats::epsilon();
 

--- a/batched/sparse/unit_test/Test_Batched_TeamCG.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamCG.hpp
@@ -123,7 +123,7 @@ void impl_test_batched_CG(const int N, const int BlkSize, const int N_team) {
       typename ValuesViewType::host_mirror_type, typename IntView::host_mirror_type,
       typename VectorViewType::host_mirror_type, typename VectorViewType::host_mirror_type, 1>(
       -1, D_host, r_host, c_host, X_host, 1, R_host);
-  KokkosBatched::SerialDot<Trans::NoTranspose>::invoke(R_host, R_host, sqr_norm_0_host);
+  KokkosBatched::SerialDot<Trans::ConjTranspose, 1>::invoke(R_host, R_host, sqr_norm_0_host);
   Functor_TestBatchedTeamCG<DeviceType, ValuesViewType, IntView, VectorViewType, KrylovHandleType>(D, r, c, X, B,
                                                                                                    N_team)
       .run();
@@ -138,7 +138,7 @@ void impl_test_batched_CG(const int N, const int BlkSize, const int N_team) {
       typename ValuesViewType::host_mirror_type, typename IntView::host_mirror_type,
       typename VectorViewType::host_mirror_type, typename VectorViewType::host_mirror_type, 1>(
       -1, D_host, r_host, c_host, X_host, 1, R_host);
-  KokkosBatched::SerialDot<Trans::NoTranspose>::invoke(R_host, R_host, sqr_norm_j_host);
+  KokkosBatched::SerialDot<Trans::ConjTranspose, 1>::invoke(R_host, R_host, sqr_norm_j_host);
 
   const MagnitudeType eps = 1.0e3 * ats::epsilon();
 

--- a/batched/sparse/unit_test/Test_Batched_TeamGMRES.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamGMRES.hpp
@@ -180,7 +180,7 @@ void impl_test_batched_GMRES(const int N, const int BlkSize, const int N_team) {
       typename ValuesViewType::host_mirror_type, typename IntView::host_mirror_type,
       typename VectorViewType::host_mirror_type, typename VectorViewType::host_mirror_type, 1>(
       -1, D_host, r_host, c_host, X_host, 1, R_host);
-  KokkosBatched::SerialDot<Trans::NoTranspose>::invoke(R_host, R_host, sqr_norm_0_host);
+  KokkosBatched::SerialDot<Trans::ConjTranspose, 1>::invoke(R_host, R_host, sqr_norm_0_host);
   Functor_TestBatchedTeamGMRES<DeviceType, ValuesViewType, IntView, VectorViewType, KrylovHandleType>(
       D, r, c, X, B, Diag, N_team, handle)
       .run();
@@ -195,7 +195,7 @@ void impl_test_batched_GMRES(const int N, const int BlkSize, const int N_team) {
       typename ValuesViewType::host_mirror_type, typename IntView::host_mirror_type,
       typename VectorViewType::host_mirror_type, typename VectorViewType::host_mirror_type, 1>(
       -1, D_host, r_host, c_host, X_host, 1, R_host);
-  KokkosBatched::SerialDot<Trans::NoTranspose>::invoke(R_host, R_host, sqr_norm_j_host);
+  KokkosBatched::SerialDot<Trans::ConjTranspose, 1>::invoke(R_host, R_host, sqr_norm_j_host);
 
   const MagnitudeType eps = 1.0e5 * ats::epsilon();
 

--- a/batched/sparse/unit_test/Test_Batched_TeamVectorCG.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamVectorCG.hpp
@@ -123,7 +123,7 @@ void impl_test_batched_CG(const int N, const int BlkSize, const int N_team) {
       typename ValuesViewType::host_mirror_type, typename IntView::host_mirror_type,
       typename VectorViewType::host_mirror_type, typename VectorViewType::host_mirror_type, 1>(
       -1, D_host, r_host, c_host, X_host, 1, R_host);
-  KokkosBatched::SerialDot<Trans::Transpose, 1>::invoke(R_host, R_host, sqr_norm_0_host);
+  KokkosBatched::SerialDot<Trans::ConjTranspose, 1>::invoke(R_host, R_host, sqr_norm_0_host);
   Functor_TestBatchedTeamVectorCG<DeviceType, ValuesViewType, IntView, VectorViewType, KrylovHandleType>(D, r, c, X, B,
                                                                                                          N_team)
       .run();
@@ -138,7 +138,7 @@ void impl_test_batched_CG(const int N, const int BlkSize, const int N_team) {
       typename ValuesViewType::host_mirror_type, typename IntView::host_mirror_type,
       typename VectorViewType::host_mirror_type, typename VectorViewType::host_mirror_type, 1>(
       -1, D_host, r_host, c_host, X_host, 1, R_host);
-  KokkosBatched::SerialDot<Trans::Transpose, 1>::invoke(R_host, R_host, sqr_norm_j_host);
+  KokkosBatched::SerialDot<Trans::ConjTranspose, 1>::invoke(R_host, R_host, sqr_norm_j_host);
 
   const MagnitudeType eps = 1.0e3 * ats::epsilon();
 

--- a/batched/sparse/unit_test/Test_Batched_TeamVectorCG.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamVectorCG.hpp
@@ -123,7 +123,7 @@ void impl_test_batched_CG(const int N, const int BlkSize, const int N_team) {
       typename ValuesViewType::host_mirror_type, typename IntView::host_mirror_type,
       typename VectorViewType::host_mirror_type, typename VectorViewType::host_mirror_type, 1>(
       -1, D_host, r_host, c_host, X_host, 1, R_host);
-  KokkosBatched::SerialDot<Trans::NoTranspose>::invoke(R_host, R_host, sqr_norm_0_host);
+  KokkosBatched::SerialDot<Trans::Transpose, 1>::invoke(R_host, R_host, sqr_norm_0_host);
   Functor_TestBatchedTeamVectorCG<DeviceType, ValuesViewType, IntView, VectorViewType, KrylovHandleType>(D, r, c, X, B,
                                                                                                          N_team)
       .run();
@@ -138,7 +138,7 @@ void impl_test_batched_CG(const int N, const int BlkSize, const int N_team) {
       typename ValuesViewType::host_mirror_type, typename IntView::host_mirror_type,
       typename VectorViewType::host_mirror_type, typename VectorViewType::host_mirror_type, 1>(
       -1, D_host, r_host, c_host, X_host, 1, R_host);
-  KokkosBatched::SerialDot<Trans::NoTranspose>::invoke(R_host, R_host, sqr_norm_j_host);
+  KokkosBatched::SerialDot<Trans::Transpose, 1>::invoke(R_host, R_host, sqr_norm_j_host);
 
   const MagnitudeType eps = 1.0e3 * ats::epsilon();
 

--- a/batched/sparse/unit_test/Test_Batched_TeamVectorGMRES.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamVectorGMRES.hpp
@@ -180,7 +180,7 @@ void impl_test_batched_GMRES(const int N, const int BlkSize, const int N_team) {
       typename ValuesViewType::host_mirror_type, typename IntView::host_mirror_type,
       typename VectorViewType::host_mirror_type, typename VectorViewType::host_mirror_type, 1>(
       -1, D_host, r_host, c_host, X_host, 1, R_host);
-  KokkosBatched::SerialDot<Trans::NoTranspose>::invoke(R_host, R_host, sqr_norm_0_host);
+  KokkosBatched::SerialDot<Trans::ConjTranspose, 1>::invoke(R_host, R_host, sqr_norm_0_host);
   Functor_TestBatchedTeamVectorGMRES<DeviceType, ValuesViewType, IntView, VectorViewType, KrylovHandleType>(
       D, r, c, X, B, Diag, N_team, handle)
       .run();
@@ -195,7 +195,7 @@ void impl_test_batched_GMRES(const int N, const int BlkSize, const int N_team) {
       typename ValuesViewType::host_mirror_type, typename IntView::host_mirror_type,
       typename VectorViewType::host_mirror_type, typename VectorViewType::host_mirror_type, 1>(
       -1, D_host, r_host, c_host, X_host, 1, R_host);
-  KokkosBatched::SerialDot<Trans::NoTranspose>::invoke(R_host, R_host, sqr_norm_j_host);
+  KokkosBatched::SerialDot<Trans::ConjTranspose, 1>::invoke(R_host, R_host, sqr_norm_j_host);
 
   const MagnitudeType eps = 1.0e5 * ats::epsilon();
 


### PR DESCRIPTION
This PR aims at refactoring batched dot API.

- [x] 1D extension of dot API
- [x] Support all dot operations except for `sdsdot` 
- [x] Use axis to specify the operation rather than using `NoTranspose` tag
- [x] Deprecate older APIs 
- [x] Add unit-tests 

Current API supports 2D dot operations and performs reduction by row (or column) if `ArgTrans == NoTranspose` (or `ArgTrans == Transpose`). In addition it only performs `X^H * Y` (do not support cdotu or zdotu). The usage of `NoTranspose` is tricky since dot operation should be either `X^T * Y` (Transpose) or `X^H * Y` (ConjTrans).

I have refactored the API to perform 1D dot if the input is 1D. For 2D Views, we performs reduction by row (or column) if Axis==0 (or Axis==1). 

```C++
// Old API
SerialDot<NoTranspose>::invoke()

// New API
SerialDot<Transpose, 1>::invoke()

// Old API
SerialDot<Transpose>::invoke()

// New API
SerialDot<Transpose, 0>::invoke()
```

New API supports all the operations (cdotc, cdotu, ddot, dsdot, sdot, zdotc, zdotu) for 1D/2D Views except for [sdsdot](https://www.netlib.org/lapack/explore-html/d1/dcc/group__dot_ga5e09e98ca27006a197d7c5fa49a9da4b.html#ga5e09e98ca27006a197d7c5fa49a9da4b) which returns float result with dot product accumulated in double.