### PR TITLE
Add batched norm

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -240,6 +240,12 @@ struct Diag {
   };
 };
 
+struct Norm {
+  struct L1 {};
+  struct L2 {};
+  struct LInf {};
+};
+
 /// BatchLayout class used to specify where the batch dimension is
 /// allocated in the input views for host-level Batched BLAS/LAPACK routines.
 struct BatchLayout {

--- a/batched/dense/impl/KokkosBatched_Nrm_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Nrm_Impl.hpp
@@ -33,6 +33,7 @@ KOKKOS_INLINE_FUNCTION int SerialNrm<NrmType>::invoke(const XViewType &x, const 
   const int n = x.extent_int(0);
   if (n == 0) {
     norm() = KokkosKernels::ArithTraits<typename NormViewType::non_const_value_type>::zero();
+    return 0;
   }
   Impl::SerialNrmInternal<NrmType>::invoke(n, x.data(), x.stride(0), norm.data());
   return 0;
@@ -50,6 +51,7 @@ KOKKOS_INLINE_FUNCTION int TeamNrm<MemberType, NrmType>::invoke(const MemberType
   const int n = x.extent_int(0);
   if (n == 0) {
     norm() = KokkosKernels::ArithTraits<typename NormViewType::non_const_value_type>::zero();
+    return 0;
   }
   Impl::TeamNrmInternal<MemberType, NrmType>::invoke(member, n, x.data(), x.stride(0), norm.data());
   return 0;
@@ -68,6 +70,7 @@ KOKKOS_INLINE_FUNCTION int TeamVectorNrm<MemberType, NrmType>::invoke(const Memb
   const int n = x.extent_int(0);
   if (n == 0) {
     norm() = KokkosKernels::ArithTraits<typename NormViewType::non_const_value_type>::zero();
+    return 0;
   }
   Impl::TeamVectorNrmInternal<MemberType, NrmType>::invoke(member, n, x.data(), x.stride(0), norm.data());
   return 0;

--- a/batched/dense/impl/KokkosBatched_Nrm_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Nrm_Impl.hpp
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOSBATCHED_NRM_IMPL_HPP_
+#define KOKKOSBATCHED_NRM_IMPL_HPP_
+
+#include <KokkosBlas_util.hpp>
+#include <KokkosBatched_Util.hpp>
+#include "KokkosBatched_Nrm_Internal.hpp"
+
+namespace KokkosBatched {
+namespace Impl {
+template <typename XViewType, typename NormViewType>
+KOKKOS_INLINE_FUNCTION static void checkNrmInput(const XViewType & /* x */, const NormViewType & /* norm */) {
+  static_assert(Kokkos::is_view_v<XViewType>, "KokkosBatched::nrm: XViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view_v<NormViewType>, "KokkosBatched::nrm: NormViewType is not a Kokkos::View.");
+  static_assert(XViewType::rank() == 1, "KokkosBatched::nrm: XViewType must have rank 1.");
+  static_assert(NormViewType::rank() == 0, "KokkosBatched::nrm: NormViewType must have rank 0.");
+  static_assert(std::is_same_v<typename NormViewType::value_type, typename NormViewType::non_const_value_type>,
+                "KokkosBatched::nrm: NormViewType must have non-const value type.");
+  static_assert(!KokkosKernels::ArithTraits<typename NormViewType::non_const_value_type>::is_complex,
+                "KokkosBatched::nrm: NormViewType must be real.");
+}
+}  // namespace Impl
+
+///
+/// Serial Impl
+/// ===========
+template <typename NrmType>
+template <typename XViewType, typename NormViewType>
+KOKKOS_INLINE_FUNCTION int SerialNrm<NrmType>::invoke(const XViewType &x, const NormViewType &norm) {
+  Impl::checkNrmInput(x, norm);
+  const int n = x.extent_int(0);
+  if (n == 0) {
+    norm() = KokkosKernels::ArithTraits<typename NormViewType::non_const_value_type>::zero();
+  }
+  Impl::SerialNrmInternal<NrmType>::invoke(n, x.data(), x.stride(0), norm.data());
+  return 0;
+}
+
+///
+/// Team Impl
+/// =========
+
+template <typename MemberType, typename NrmType>
+template <typename XViewType, typename NormViewType>
+KOKKOS_INLINE_FUNCTION int TeamNrm<MemberType, NrmType>::invoke(const MemberType &member, const XViewType &x,
+                                                                const NormViewType &norm) {
+  Impl::checkNrmInput(x, norm);
+  const int n = x.extent_int(0);
+  if (n == 0) {
+    norm() = KokkosKernels::ArithTraits<typename NormViewType::non_const_value_type>::zero();
+  }
+  Impl::TeamNrmInternal<MemberType, NrmType>::invoke(member, n, x.data(), x.stride(0), norm.data());
+  return 0;
+}
+
+///
+/// TeamVector Impl
+/// ===============
+
+template <typename MemberType, typename NrmType>
+template <typename XViewType, typename NormViewType>
+KOKKOS_INLINE_FUNCTION int TeamVectorNrm<MemberType, NrmType>::invoke(const MemberType &member, const XViewType &x,
+                                                                      const NormViewType &norm) {
+  Impl::checkNrmInput(x, norm);
+
+  const int n = x.extent_int(0);
+  if (n == 0) {
+    norm() = KokkosKernels::ArithTraits<typename NormViewType::non_const_value_type>::zero();
+  }
+  Impl::TeamVectorNrmInternal<MemberType, NrmType>::invoke(member, n, x.data(), x.stride(0), norm.data());
+  return 0;
+}
+
+}  // namespace KokkosBatched
+
+#endif  // KOKKOSBATCHED_NRM_IMPL_HPP_

--- a/batched/dense/impl/KokkosBatched_Nrm_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Nrm_Internal.hpp
@@ -9,13 +9,22 @@
 namespace KokkosBatched {
 namespace Impl {
 
-template <typename ValueType, typename NrmValueType>
-KOKKOS_INLINE_FUNCTION NrmValueType l1_norm(const ValueType &x) {
+template <typename NrmValueType, typename ValueType>
+KOKKOS_INLINE_FUNCTION NrmValueType asum(const ValueType &x) {
   if constexpr (KokkosKernels::ArithTraits<ValueType>::is_complex) {
     return KokkosKernels::ArithTraits<NrmValueType>::abs(KokkosKernels::ArithTraits<ValueType>::real(x)) +
            KokkosKernels::ArithTraits<NrmValueType>::abs(KokkosKernels::ArithTraits<ValueType>::imag(x));
   } else {
     return KokkosKernels::ArithTraits<NrmValueType>::abs(x);
+  }
+}
+
+template <typename NrmValueType, typename ValueType>
+KOKKOS_INLINE_FUNCTION NrmValueType square(const ValueType &x) {
+  if constexpr (KokkosKernels::ArithTraits<ValueType>::is_complex) {
+    return KokkosKernels::ArithTraits<ValueType>::conj(x) * x;
+  } else {
+    return x * x;
   }
 }
 
@@ -37,12 +46,11 @@ KOKKOS_INLINE_FUNCTION void SerialNrmInternal<NrmType>::invoke(const int n, cons
 
   if constexpr (std::is_same_v<NrmType, Norm::L1>) {
     for (int i = 0; i < n; ++i) {
-      nrm += l1_norm<ValueType, NrmValueType>(x[i * xs0]);
+      nrm += asum<NrmValueType>(x[i * xs0]);
     }
   } else if constexpr (std::is_same_v<NrmType, Norm::L2>) {
     for (int i = 0; i < n; ++i) {
-      const NrmValueType abs_val = KokkosKernels::ArithTraits<ValueType>::abs(x[i * xs0]);
-      nrm += abs_val * abs_val;
+      nrm += square<NrmValueType>(x[i * xs0]);
     }
     nrm = KokkosKernels::ArithTraits<NrmValueType>::sqrt(nrm);
   } else if constexpr (std::is_same_v<NrmType, Norm::LInf>) {
@@ -76,16 +84,11 @@ KOKKOS_INLINE_FUNCTION void TeamNrmInternal<MemberType, NrmType>::invoke(const M
   if constexpr (std::is_same_v<NrmType, Norm::L1>) {
     Kokkos::parallel_reduce(
         Kokkos::TeamThreadRange(member, n),
-        [&](const int i, NrmValueType &thread_nrm) { thread_nrm += l1_norm<ValueType, NrmValueType>(x[i * xs0]); },
-        nrm);
+        [&](const int i, NrmValueType &thread_nrm) { thread_nrm += asum<NrmValueType>(x[i * xs0]); }, nrm);
   } else if constexpr (std::is_same_v<NrmType, Norm::L2>) {
     Kokkos::parallel_reduce(
         Kokkos::TeamThreadRange(member, n),
-        [&](const int i, NrmValueType &thread_nrm) {
-          const NrmValueType abs_val = KokkosKernels::ArithTraits<ValueType>::abs(x[i * xs0]);
-          thread_nrm += abs_val * abs_val;
-        },
-        nrm);
+        [&](const int i, NrmValueType &thread_nrm) { thread_nrm += square<NrmValueType>(x[i * xs0]); }, nrm);
     nrm = KokkosKernels::ArithTraits<NrmValueType>::sqrt(nrm);
   } else if constexpr (std::is_same_v<NrmType, Norm::LInf>) {
     Kokkos::Max<NrmValueType, typename MemberType::execution_space> max_nrm(nrm);
@@ -122,16 +125,11 @@ KOKKOS_INLINE_FUNCTION void TeamVectorNrmInternal<MemberType, NrmType>::invoke(c
   if constexpr (std::is_same_v<NrmType, Norm::L1>) {
     Kokkos::parallel_reduce(
         Kokkos::TeamVectorRange(member, n),
-        [&](const int i, NrmValueType &thread_nrm) { thread_nrm += l1_norm<ValueType, NrmValueType>(x[i * xs0]); },
-        nrm);
+        [&](const int i, NrmValueType &thread_nrm) { thread_nrm += asum<NrmValueType>(x[i * xs0]); }, nrm);
   } else if constexpr (std::is_same_v<NrmType, Norm::L2>) {
     Kokkos::parallel_reduce(
         Kokkos::TeamVectorRange(member, n),
-        [&](const int i, NrmValueType &thread_nrm) {
-          const NrmValueType abs_val = KokkosKernels::ArithTraits<ValueType>::abs(x[i * xs0]);
-          thread_nrm += abs_val * abs_val;
-        },
-        nrm);
+        [&](const int i, NrmValueType &thread_nrm) { thread_nrm += square<NrmValueType>(x[i * xs0]); }, nrm);
     nrm = KokkosKernels::ArithTraits<NrmValueType>::sqrt(nrm);
   } else if constexpr (std::is_same_v<NrmType, Norm::LInf>) {
     Kokkos::Max<NrmValueType, typename MemberType::execution_space> max_nrm(nrm);

--- a/batched/dense/impl/KokkosBatched_Nrm_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Nrm_Internal.hpp
@@ -22,7 +22,7 @@ KOKKOS_INLINE_FUNCTION NrmValueType asum(const ValueType &x) {
 template <typename NrmValueType, typename ValueType>
 KOKKOS_INLINE_FUNCTION NrmValueType square(const ValueType &x) {
   if constexpr (KokkosKernels::ArithTraits<ValueType>::is_complex) {
-    return KokkosKernels::ArithTraits<NrmValueType>::real(KokkosKernels::ArithTraits<ValueType>::conj(x) * x);
+    return KokkosKernels::ArithTraits<ValueType>::real(KokkosKernels::ArithTraits<ValueType>::conj(x) * x);
   } else {
     return x * x;
   }

--- a/batched/dense/impl/KokkosBatched_Nrm_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Nrm_Internal.hpp
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOSBATCHED_NRM_INTERNAL_HPP_
+#define KOKKOSBATCHED_NRM_INTERNAL_HPP_
+
+#include <KokkosBatched_Util.hpp>
+
+namespace KokkosBatched {
+namespace Impl {
+
+template <typename ValueType, typename NrmValueType>
+KOKKOS_INLINE_FUNCTION NrmValueType l1_norm(const ValueType &x) {
+  if constexpr (KokkosKernels::ArithTraits<ValueType>::is_complex) {
+    return KokkosKernels::ArithTraits<NrmValueType>::abs(KokkosKernels::ArithTraits<ValueType>::real(x)) +
+           KokkosKernels::ArithTraits<NrmValueType>::abs(KokkosKernels::ArithTraits<ValueType>::imag(x));
+  } else {
+    return KokkosKernels::ArithTraits<NrmValueType>::abs(x);
+  }
+}
+
+///
+/// Serial Internal Impl
+/// ====================
+template <typename NrmType>
+struct SerialNrmInternal {
+  template <typename ValueType, typename NrmValueType>
+  KOKKOS_INLINE_FUNCTION static void invoke(const int n, const ValueType *KOKKOS_RESTRICT x, const int xs0,
+                                            NrmValueType *KOKKOS_RESTRICT norm);
+};
+
+template <typename NrmType>
+template <typename ValueType, typename NrmValueType>
+KOKKOS_INLINE_FUNCTION void SerialNrmInternal<NrmType>::invoke(const int n, const ValueType *KOKKOS_RESTRICT x,
+                                                               const int xs0, NrmValueType *KOKKOS_RESTRICT norm) {
+  NrmValueType nrm = 0;
+
+  if constexpr (std::is_same_v<NrmType, Norm::L1>) {
+    for (int i = 0; i < n; ++i) {
+      nrm += l1_norm<ValueType, NrmValueType>(x[i * xs0]);
+    }
+  } else if constexpr (std::is_same_v<NrmType, Norm::L2>) {
+    for (int i = 0; i < n; ++i) {
+      const NrmValueType abs_val = KokkosKernels::ArithTraits<ValueType>::abs(x[i * xs0]);
+      nrm += abs_val * abs_val;
+    }
+    nrm = KokkosKernels::ArithTraits<NrmValueType>::sqrt(nrm);
+  } else if constexpr (std::is_same_v<NrmType, Norm::LInf>) {
+    for (int i = 0; i < n; ++i) {
+      const NrmValueType abs_val = KokkosKernels::ArithTraits<ValueType>::abs(x[i * xs0]);
+      if (abs_val > nrm) nrm = abs_val;
+    }
+  }
+
+  *norm = nrm;
+}
+
+///
+/// Team Internal Impl
+/// ==================
+template <typename MemberType, typename NrmType>
+struct TeamNrmInternal {
+  template <typename ValueType, typename NrmValueType>
+  KOKKOS_INLINE_FUNCTION static void invoke(const MemberType &member, const int n, const ValueType *KOKKOS_RESTRICT x,
+                                            const int xs0, NrmValueType *KOKKOS_RESTRICT norm);
+};
+
+template <typename MemberType, typename NrmType>
+template <typename ValueType, typename NrmValueType>
+KOKKOS_INLINE_FUNCTION void TeamNrmInternal<MemberType, NrmType>::invoke(const MemberType &member, const int n,
+                                                                         const ValueType *KOKKOS_RESTRICT x,
+                                                                         const int xs0,
+                                                                         NrmValueType *KOKKOS_RESTRICT norm) {
+  NrmValueType nrm = 0;
+
+  if constexpr (std::is_same_v<NrmType, Norm::L1>) {
+    Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(member, n),
+        [&](const int i, NrmValueType &thread_nrm) { thread_nrm += l1_norm<ValueType, NrmValueType>(x[i * xs0]); },
+        nrm);
+  } else if constexpr (std::is_same_v<NrmType, Norm::L2>) {
+    Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(member, n),
+        [&](const int i, NrmValueType &thread_nrm) {
+          const NrmValueType abs_val = KokkosKernels::ArithTraits<ValueType>::abs(x[i * xs0]);
+          thread_nrm += abs_val * abs_val;
+        },
+        nrm);
+    nrm = KokkosKernels::ArithTraits<NrmValueType>::sqrt(nrm);
+  } else if constexpr (std::is_same_v<NrmType, Norm::LInf>) {
+    Kokkos::Max<NrmValueType, typename MemberType::execution_space> max_nrm(nrm);
+    Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(member, n),
+        [&](const int i, NrmValueType &thread_nrm) {
+          const NrmValueType abs_val = KokkosKernels::ArithTraits<ValueType>::abs(x[i * xs0]);
+          if (abs_val > thread_nrm) thread_nrm = abs_val;
+        },
+        max_nrm);
+  }
+
+  *norm = nrm;
+}
+
+///
+/// TeamVector Internal Impl
+/// ==================
+template <typename MemberType, typename NrmType>
+struct TeamVectorNrmInternal {
+  template <typename ValueType, typename NrmValueType>
+  KOKKOS_INLINE_FUNCTION static void invoke(const MemberType &member, const int n, const ValueType *KOKKOS_RESTRICT x,
+                                            const int xs0, NrmValueType *KOKKOS_RESTRICT norm);
+};
+
+template <typename MemberType, typename NrmType>
+template <typename ValueType, typename NrmValueType>
+KOKKOS_INLINE_FUNCTION void TeamVectorNrmInternal<MemberType, NrmType>::invoke(const MemberType &member, const int n,
+                                                                               const ValueType *KOKKOS_RESTRICT x,
+                                                                               const int xs0,
+                                                                               NrmValueType *KOKKOS_RESTRICT norm) {
+  NrmValueType nrm = 0;
+
+  if constexpr (std::is_same_v<NrmType, Norm::L1>) {
+    Kokkos::parallel_reduce(
+        Kokkos::TeamVectorRange(member, n),
+        [&](const int i, NrmValueType &thread_nrm) { thread_nrm += l1_norm<ValueType, NrmValueType>(x[i * xs0]); },
+        nrm);
+  } else if constexpr (std::is_same_v<NrmType, Norm::L2>) {
+    Kokkos::parallel_reduce(
+        Kokkos::TeamVectorRange(member, n),
+        [&](const int i, NrmValueType &thread_nrm) {
+          const NrmValueType abs_val = KokkosKernels::ArithTraits<ValueType>::abs(x[i * xs0]);
+          thread_nrm += abs_val * abs_val;
+        },
+        nrm);
+    nrm = KokkosKernels::ArithTraits<NrmValueType>::sqrt(nrm);
+  } else if constexpr (std::is_same_v<NrmType, Norm::LInf>) {
+    Kokkos::Max<NrmValueType, typename MemberType::execution_space> max_nrm(nrm);
+    Kokkos::parallel_reduce(
+        Kokkos::TeamVectorRange(member, n),
+        [&](const int i, NrmValueType &thread_nrm) {
+          const NrmValueType abs_val = KokkosKernels::ArithTraits<ValueType>::abs(x[i * xs0]);
+          if (abs_val > thread_nrm) thread_nrm = abs_val;
+        },
+        max_nrm);
+  }
+  *norm = nrm;
+}
+
+}  // namespace Impl
+}  // namespace KokkosBatched
+
+#endif  // KOKKOSBATCHED_NRM_INTERNAL_HPP_

--- a/batched/dense/impl/KokkosBatched_Nrm_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Nrm_Internal.hpp
@@ -22,7 +22,7 @@ KOKKOS_INLINE_FUNCTION NrmValueType asum(const ValueType &x) {
 template <typename NrmValueType, typename ValueType>
 KOKKOS_INLINE_FUNCTION NrmValueType square(const ValueType &x) {
   if constexpr (KokkosKernels::ArithTraits<ValueType>::is_complex) {
-    return KokkosKernels::ArithTraits<ValueType>::conj(x) * x;
+    return KokkosKernels::ArithTraits<NrmValueType>::real(KokkosKernels::ArithTraits<ValueType>::conj(x) * x);
   } else {
     return x * x;
   }

--- a/batched/dense/src/KokkosBatched_Nrm.hpp
+++ b/batched/dense/src/KokkosBatched_Nrm.hpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+#ifndef KOKKOSBATCHED_NRM_HPP_
+#define KOKKOSBATCHED_NRM_HPP_
+
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+
+namespace KokkosBatched {
+/// \brief Serial Batched nrm:
+/// If NrmType == Norm::L1, compute L1 norm of each vector in the batch
+/// If NrmType == Norm::L2, compute L2 norm of each vector in the batch
+/// If NrmType == Norm::LInf, compute Linf norm of each vector in the batch
+/// No nested parallel_for is used inside of the function.
+/// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf
+template <typename NrmType>
+struct SerialNrm {
+  /// \tparam XViewType: Type for input X, needs to be a 1D view
+  /// \tparam NormViewType: Type for output norm, needs to be a 0D view
+  ///
+  /// \param[in] x Input view of shape (N)
+  /// \param[out] norm Output view of shape () to store the computed norms
+  template <typename XViewType, typename NormViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const XViewType &x, const NormViewType &norm);
+};
+
+/// \brief Team Batched nrm:
+/// If NrmType == Norm::L1, compute L1 norm of each vector in the batch
+/// If NrmType == Norm::L2, compute L2 norm of each vector in the batch
+/// If NrmType == Norm::LInf, compute Linf norm of each vector in the batch
+/// A nested parallel_for with TeamThreadRange is used.
+/// \tparam MemberType: Kokkos TeamPolicy member type
+/// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf
+template <typename MemberType, typename NrmType>
+struct TeamNrm {
+  /// \tparam XViewType: Type for input X, needs to be a 1D view
+  /// \tparam NormViewType: Type for output norm, needs to be a 0D view
+  ///
+  /// \param[in] member : Kokkos TeamPolicy member type
+  /// \param[in] x Input view of shape (N)
+  /// \param[out] norm Output view of shape () to store the computed norms
+  template <typename XViewType, typename NormViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &x, const NormViewType &norm);
+};
+
+/// \brief Team Batched nrm:
+/// If NrmType == Norm::L1, compute L1 norm of each vector in the batch
+/// If NrmType == Norm::L2, compute L2 norm of each vector in the batch
+/// If NrmType == Norm::LInf, compute Linf norm of each vector in the batch
+/// A nested parallel_for with TeamVectorRange is used.
+/// \tparam MemberType: Kokkos TeamPolicy member type
+/// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf
+template <typename MemberType, typename NrmType>
+struct TeamVectorNrm {
+  /// \tparam XViewType: Type for input X, needs to be a 1D view
+  /// \tparam NormViewType: Type for output norm, needs to be a 0D view
+  ///
+  /// \param[in] member : Kokkos TeamPolicy member type
+  /// \param[in] x Input view of shape (N)
+  /// \param[out] norm Output view of shape () to store the computed norms
+  template <typename XViewType, typename NormViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &x, const NormViewType &norm);
+};
+
+}  // namespace KokkosBatched
+
+#include "KokkosBatched_Nrm_Impl.hpp"
+
+#endif  // KOKKOSBATCHED_NRM_HPP_

--- a/batched/dense/src/KokkosBatched_Nrm.hpp
+++ b/batched/dense/src/KokkosBatched_Nrm.hpp
@@ -14,6 +14,9 @@ namespace KokkosBatched {
 /// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf
 template <typename NrmType>
 struct SerialNrm {
+  static_assert(std::is_same_v<NrmType, Norm::L1> || std::is_same_v<NrmType, Norm::L2> ||
+                    std::is_same_v<NrmType, Norm::LInf>,
+                "KokkosBatched::SerialNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf");
   /// \tparam XViewType: Type for input X, needs to be a 1D view
   /// \tparam NormViewType: Type for output norm, needs to be a 0D view
   ///
@@ -32,6 +35,9 @@ struct SerialNrm {
 /// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf
 template <typename MemberType, typename NrmType>
 struct TeamNrm {
+  static_assert(std::is_same_v<NrmType, Norm::L1> || std::is_same_v<NrmType, Norm::L2> ||
+                    std::is_same_v<NrmType, Norm::LInf>,
+                "KokkosBatched::TeamNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf");
   /// \tparam XViewType: Type for input X, needs to be a 1D view
   /// \tparam NormViewType: Type for output norm, needs to be a 0D view
   ///
@@ -51,6 +57,9 @@ struct TeamNrm {
 /// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf
 template <typename MemberType, typename NrmType>
 struct TeamVectorNrm {
+  static_assert(std::is_same_v<NrmType, Norm::L1> || std::is_same_v<NrmType, Norm::L2> ||
+                    std::is_same_v<NrmType, Norm::LInf>,
+                "KokkosBatched::TeamVectorNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf");
   /// \tparam XViewType: Type for input X, needs to be a 1D view
   /// \tparam NormViewType: Type for output norm, needs to be a 0D view
   ///

--- a/batched/dense/unit_test/Test_Batched_Dense.hpp
+++ b/batched/dense/unit_test/Test_Batched_Dense.hpp
@@ -7,6 +7,7 @@
 #include "Test_Batched_SerialAxpy.hpp"
 #include "Test_Batched_Copy.hpp"
 #include "Test_Batched_Dot.hpp"
+#include "Test_Batched_Nrm.hpp"
 #include "Test_Batched_Rot.hpp"
 #include "Test_Batched_Rotg.hpp"
 #include "Test_Batched_Rotm.hpp"

--- a/batched/dense/unit_test/Test_Batched_Nrm.hpp
+++ b/batched/dense/unit_test/Test_Batched_Nrm.hpp
@@ -1,0 +1,394 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
+#include <KokkosBatched_Util.hpp>
+#include <KokkosBatched_Nrm.hpp>
+#include "Test_Batched_DenseUtils.hpp"
+
+namespace Test {
+namespace Nrm {
+
+template <typename DeviceType, typename XViewType, typename NormViewType, typename ArgNorm, typename ArgMode>
+struct Functor_BatchedNrm {
+  using execution_space = typename DeviceType::execution_space;
+  using member_type     = Kokkos::TeamPolicy<execution_space>::member_type;
+  XViewType m_x;
+  NormViewType m_norm;
+
+  Functor_BatchedNrm(const XViewType &x, const NormViewType &norm) : m_x(x), m_norm(norm) {}
+
+  KOKKOS_INLINE_FUNCTION void operator()(const member_type &member, int &info) const {
+    const int k   = member.league_rank();
+    auto sub_x    = Kokkos::subview(m_x, k, Kokkos::ALL());
+    auto sub_norm = Kokkos::subview(m_norm, k);
+    if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::Serial>) {
+      info += KokkosBatched::SerialNrm<ArgNorm>::invoke(sub_x, sub_norm);
+    } else if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::Team>) {
+      info += KokkosBatched::TeamNrm<member_type, ArgNorm>::invoke(member, sub_x, sub_norm);
+    } else if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::TeamVector>) {
+      info += KokkosBatched::TeamVectorNrm<member_type, ArgNorm>::invoke(member, sub_x, sub_norm);
+    }
+  }
+
+  inline int run() {
+    using value_type        = typename XViewType::non_const_value_type;
+    std::string name_region = std::is_same_v<ArgMode, KokkosBatched::Mode::Serial> ? "KokkosBatched::Test::SerialNrm"
+                              : std::is_same_v<ArgMode, KokkosBatched::Mode::Team>
+                                  ? "KokkosBatched::Test::TeamNrm"
+                                  : "KokkosBatched::Test::TeamVectorNrm";
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    int info_sum                      = 0;
+    Kokkos::Profiling::pushRegion(name.c_str());
+    const int league_size = m_x.extent_int(0);
+    Kokkos::TeamPolicy<execution_space> policy(league_size, Kokkos::AUTO);
+    Kokkos::parallel_reduce(name.c_str(), policy, *this, info_sum);
+    Kokkos::Profiling::popRegion();
+    return info_sum;
+  }
+};
+
+/// \brief Implementation details of batched nrm analytical test
+/// x = [1, 3, 5]
+/// z = [1 + 2j, 3 + 4j, 5 + 6j]
+/// L1 norm: x: 9, z: 21
+/// L2 norm: x: sqrt(1^2 + 3^2 + 5^2) = sqrt(35), z: sqrt((1^2 + 2^2) + (3^2 + 4^2) + (5^2 + 6^2)) = sqrt(91)
+/// Linf norm: x: 5, z: sqrt(5^2 + 6^2) = sqrt(61)
+///
+/// \tparam DeviceType Kokkos device type
+/// \tparam ScalarType Kokkos scalar type
+/// \tparam LayoutType Kokkos layout type for the views
+/// \tparam ArgNorm: one of L1, L2, Linf
+/// \tparam ArgMode: one of Mode::Serial, Mode::Team, Mode::TeamVector
+///
+/// \param[in] Nb Batch size of vectors
+template <typename DeviceType, typename ScalarType, typename LayoutType, typename ArgNorm, typename ArgMode>
+void impl_test_batched_nrm_analytical(const std::size_t Nb) {
+  using ats               = typename KokkosKernels::ArithTraits<ScalarType>;
+  using RealType          = typename ats::mag_type;
+  using NormViewType      = Kokkos::View<RealType *, LayoutType, DeviceType>;
+  using View2DType        = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
+  using StridedView2DType = Kokkos::View<ScalarType **, Kokkos::LayoutStride, DeviceType>;
+
+  const std::size_t N = 3;
+  View2DType x("x", Nb, N);
+  NormViewType norm("norm", Nb), norm_s("norm_s", Nb), norm_ref("norm_ref", Nb);
+
+  const std::size_t incx = 2;
+  // Testing incx argument with strided views
+  Kokkos::LayoutStride layout{Nb, incx, N, Nb * incx};
+  StridedView2DType x_s("x_s", layout);
+
+  auto h_x        = Kokkos::create_mirror_view(x);
+  auto h_norm_ref = Kokkos::create_mirror_view(norm_ref);
+
+  constexpr bool is_complex = KokkosKernels::ArithTraits<ScalarType>::is_complex;
+
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    if constexpr (is_complex) {
+      h_x(ib, 0) = ScalarType(1, 2);
+      h_x(ib, 1) = ScalarType(3, 4);
+      h_x(ib, 2) = ScalarType(5, 6);
+
+      // L1 norm: 21, L2 norm: sqrt(91), Linf norm: sqrt(61)
+      h_norm_ref(ib) = std::is_same_v<ArgNorm, Norm::L1>     ? RealType(21)
+                       : std::is_same_v<ArgNorm, Norm::L2>   ? Kokkos::sqrt(RealType(91))
+                       : std::is_same_v<ArgNorm, Norm::LInf> ? Kokkos::sqrt(RealType(61))
+                                                             : RealType(-1);
+    } else {
+      h_x(ib, 0) = ScalarType(1);
+      h_x(ib, 1) = ScalarType(3);
+      h_x(ib, 2) = ScalarType(5);
+
+      // L1 norm: 9, L2 norm: sqrt(35), Linf norm: 5
+      h_norm_ref(ib) = std::is_same_v<ArgNorm, Norm::L1>     ? RealType(9)
+                       : std::is_same_v<ArgNorm, Norm::L2>   ? ats::sqrt(RealType(35))
+                       : std::is_same_v<ArgNorm, Norm::LInf> ? RealType(5)
+                                                             : RealType(-1);
+    }
+  }
+
+  Kokkos::deep_copy(x, h_x);
+
+  // Deep copy to strided views
+  Kokkos::deep_copy(x_s, x);
+
+  auto info = Functor_BatchedNrm<DeviceType, View2DType, NormViewType, ArgNorm, ArgMode>(x, norm).run();
+  EXPECT_EQ(info, 0);
+
+  // With strided views
+  info = Functor_BatchedNrm<DeviceType, StridedView2DType, NormViewType, ArgNorm, ArgMode>(x_s, norm_s).run();
+  EXPECT_EQ(info, 0);
+
+  RealType eps  = 1.0e1 * ats::epsilon();
+  auto h_norm   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, norm);
+  auto h_norm_s = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, norm_s);
+
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    KK_EXPECT_NEAR(h_norm(ib), h_norm_ref(ib), eps);
+    KK_EXPECT_NEAR(h_norm_s(ib), h_norm_ref(ib), eps);
+  }
+}
+
+/// \brief Implementation details of batched nrm test
+///
+/// \tparam DeviceType Kokkos device type
+/// \tparam ScalarType Kokkos scalar type
+/// \tparam LayoutType Kokkos layout type for the views
+/// \tparam ArgNorm: one of L1, L2, Linf
+/// \tparam ArgMode: one of Mode::Serial, Mode::Team, Mode::TeamVector
+///
+/// \param[in] Nb Batch size of vectors
+/// \param[in] N Length of the vector x
+template <typename DeviceType, typename ScalarType, typename LayoutType, typename ArgNorm, typename ArgMode>
+void impl_test_batched_nrm(const std::size_t Nb, const std::size_t N) {
+  using ats               = typename KokkosKernels::ArithTraits<ScalarType>;
+  using RealType          = typename ats::mag_type;
+  using NormViewType      = Kokkos::View<RealType *, LayoutType, DeviceType>;
+  using View2DType        = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
+  using StridedView2DType = Kokkos::View<ScalarType **, Kokkos::LayoutStride, DeviceType>;
+
+  View2DType x("x", Nb, N);
+  NormViewType norm("norm", Nb), norm_s("norm_s", Nb), norm_ref("norm_ref", Nb);
+
+  const std::size_t incx = 2;
+  // Testing incx argument with strided views
+  Kokkos::LayoutStride layout{Nb, incx, N, Nb * incx};
+  StridedView2DType x_s("x_s", layout);
+
+  // Create random x
+  using execution_space = typename DeviceType::execution_space;
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
+  ScalarType randStart, randEnd;
+
+  KokkosKernels::Impl::getRandomBounds(1.0, randStart, randEnd);
+  Kokkos::fill_random(x, rand_pool, randStart, randEnd);
+
+  // Deep copy to strided views
+  Kokkos::deep_copy(x_s, x);
+
+  auto info = Functor_BatchedNrm<DeviceType, View2DType, NormViewType, ArgNorm, ArgMode>(x, norm).run();
+  EXPECT_EQ(info, 0);
+
+  // With strided views
+  info = Functor_BatchedNrm<DeviceType, StridedView2DType, NormViewType, ArgNorm, ArgMode>(x_s, norm_s).run();
+  EXPECT_EQ(info, 0);
+
+  auto asum = [](const ScalarType &val) {
+    if constexpr (ats::is_complex) {
+      return ats::abs(val.real()) + ats::abs(val.imag());
+    } else {
+      return ats::abs(val);
+    }
+  };
+
+  // Make a reference at host
+  auto h_x        = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, x);
+  auto h_norm_ref = Kokkos::create_mirror_view(norm_ref);
+
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    RealType norm_tmp = 0;
+    if constexpr (std::is_same_v<ArgNorm, Norm::L1>) {
+      for (std::size_t i = 0; i < N; i++) {
+        norm_tmp += asum(h_x(ib, i));
+      }
+    } else if constexpr (std::is_same_v<ArgNorm, Norm::L2>) {
+      for (std::size_t i = 0; i < N; i++) {
+        const auto abs_val = ats::abs(h_x(ib, i));
+        norm_tmp += abs_val * abs_val;
+      }
+      norm_tmp = Kokkos::sqrt(norm_tmp);
+    } else if constexpr (std::is_same_v<ArgNorm, Norm::LInf>) {
+      for (std::size_t i = 0; i < N; i++) {
+        const auto abs_val = ats::abs(h_x(ib, i));
+        if (abs_val > norm_tmp) norm_tmp = abs_val;
+      }
+    }
+    h_norm_ref(ib) = norm_tmp;
+  }
+
+  RealType eps  = 1.0e1 * ats::epsilon();
+  auto h_norm   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, norm);
+  auto h_norm_s = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, norm_s);
+
+  // Check if norm is correct
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    KK_EXPECT_NEAR(h_norm(ib), h_norm_ref(ib), eps);
+    KK_EXPECT_NEAR(h_norm_s(ib), h_norm_ref(ib), eps);
+  }
+}
+
+}  // namespace Nrm
+}  // namespace Test
+
+template <typename DeviceType, typename ScalarType, typename ArgNorm, typename ArgMode>
+int test_batched_nrm() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
+  {
+    using LayoutType = Kokkos::LayoutLeft;
+    Test::Nrm::impl_test_batched_nrm_analytical<DeviceType, ScalarType, LayoutType, ArgNorm, ArgMode>(1);
+    Test::Nrm::impl_test_batched_nrm_analytical<DeviceType, ScalarType, LayoutType, ArgNorm, ArgMode>(2);
+    for (int i = 0; i < 5; i++) {
+      Test::Nrm::impl_test_batched_nrm<DeviceType, ScalarType, LayoutType, ArgNorm, ArgMode>(1, i);
+      Test::Nrm::impl_test_batched_nrm<DeviceType, ScalarType, LayoutType, ArgNorm, ArgMode>(2, i);
+    }
+  }
+#endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
+  {
+    using LayoutType = Kokkos::LayoutRight;
+    Test::Nrm::impl_test_batched_nrm_analytical<DeviceType, ScalarType, LayoutType, ArgNorm, ArgMode>(1);
+    Test::Nrm::impl_test_batched_nrm_analytical<DeviceType, ScalarType, LayoutType, ArgNorm, ArgMode>(2);
+    for (int i = 0; i < 5; i++) {
+      Test::Nrm::impl_test_batched_nrm<DeviceType, ScalarType, LayoutType, ArgNorm, ArgMode>(1, i);
+      Test::Nrm::impl_test_batched_nrm<DeviceType, ScalarType, LayoutType, ArgNorm, ArgMode>(2, i);
+    }
+  }
+#endif
+
+  return 0;
+}
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+// Serial
+TEST_F(TestCategory, test_batched_serial_nrm_l1_float) {
+  test_batched_nrm<TestDevice, float, KokkosBatched::Norm::L1, KokkosBatched::Mode::Serial>();
+}
+TEST_F(TestCategory, test_batched_serial_nrm_l2_float) {
+  test_batched_nrm<TestDevice, float, KokkosBatched::Norm::L2, KokkosBatched::Mode::Serial>();
+}
+
+TEST_F(TestCategory, test_batched_serial_nrm_linf_float) {
+  test_batched_nrm<TestDevice, float, KokkosBatched::Norm::LInf, KokkosBatched::Mode::Serial>();
+}
+
+// Team
+TEST_F(TestCategory, test_batched_team_nrm_l1_float) {
+  test_batched_nrm<TestDevice, float, KokkosBatched::Norm::L1, KokkosBatched::Mode::Team>();
+}
+TEST_F(TestCategory, test_batched_team_nrm_l2_float) {
+  test_batched_nrm<TestDevice, float, KokkosBatched::Norm::L2, KokkosBatched::Mode::Team>();
+}
+TEST_F(TestCategory, test_batched_team_nrm_linf_float) {
+  test_batched_nrm<TestDevice, float, KokkosBatched::Norm::LInf, KokkosBatched::Mode::Team>();
+}
+
+// TeamVector
+TEST_F(TestCategory, test_batched_teamvector_nrm_l1_float) {
+  test_batched_nrm<TestDevice, float, KokkosBatched::Norm::L1, KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_teamvector_nrm_l2_float) {
+  test_batched_nrm<TestDevice, float, KokkosBatched::Norm::L2, KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_teamvector_nrm_linf_float) {
+  test_batched_nrm<TestDevice, float, KokkosBatched::Norm::LInf, KokkosBatched::Mode::TeamVector>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+// Serial
+TEST_F(TestCategory, test_batched_serial_nrm_l1_double) {
+  test_batched_nrm<TestDevice, double, KokkosBatched::Norm::L1, KokkosBatched::Mode::Serial>();
+}
+TEST_F(TestCategory, test_batched_serial_nrm_l2_double) {
+  test_batched_nrm<TestDevice, double, KokkosBatched::Norm::L2, KokkosBatched::Mode::Serial>();
+}
+TEST_F(TestCategory, test_batched_serial_nrm_linf_double) {
+  test_batched_nrm<TestDevice, double, KokkosBatched::Norm::LInf, KokkosBatched::Mode::Serial>();
+}
+
+// Team
+TEST_F(TestCategory, test_batched_team_nrm_l1_double) {
+  test_batched_nrm<TestDevice, double, KokkosBatched::Norm::L1, KokkosBatched::Mode::Team>();
+}
+TEST_F(TestCategory, test_batched_team_nrm_l2_double) {
+  test_batched_nrm<TestDevice, double, KokkosBatched::Norm::L2, KokkosBatched::Mode::Team>();
+}
+TEST_F(TestCategory, test_batched_team_nrm_linf_double) {
+  test_batched_nrm<TestDevice, double, KokkosBatched::Norm::LInf, KokkosBatched::Mode::Team>();
+}
+
+// TeamVector
+TEST_F(TestCategory, test_batched_teamvector_nrm_l1_double) {
+  test_batched_nrm<TestDevice, double, KokkosBatched::Norm::L1, KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_teamvector_nrm_l2_double) {
+  test_batched_nrm<TestDevice, double, KokkosBatched::Norm::L2, KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_teamvector_nrm_linf_double) {
+  test_batched_nrm<TestDevice, double, KokkosBatched::Norm::LInf, KokkosBatched::Mode::TeamVector>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_FLOAT)
+// Serial
+TEST_F(TestCategory, test_batched_serial_nrm_l1_fcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::L1, KokkosBatched::Mode::Serial>();
+}
+TEST_F(TestCategory, test_batched_serial_nrm_l2_fcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::L2, KokkosBatched::Mode::Serial>();
+}
+TEST_F(TestCategory, test_batched_serial_nrm_linf_fcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::LInf, KokkosBatched::Mode::Serial>();
+}
+
+// Team
+TEST_F(TestCategory, test_batched_team_nrm_l1_fcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::L1, KokkosBatched::Mode::Team>();
+}
+TEST_F(TestCategory, test_batched_team_nrm_l2_fcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::L2, KokkosBatched::Mode::Team>();
+}
+TEST_F(TestCategory, test_batched_team_nrm_linf_fcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::LInf, KokkosBatched::Mode::Team>();
+}
+
+// TeamVector
+TEST_F(TestCategory, test_batched_teamvector_nrm_l1_fcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::L1, KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_teamvector_nrm_l2_fcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::L2, KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_teamvector_nrm_linf_fcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::LInf, KokkosBatched::Mode::TeamVector>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
+// Serial
+TEST_F(TestCategory, test_batched_serial_nrm_l1_dcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::L1, KokkosBatched::Mode::Serial>();
+}
+TEST_F(TestCategory, test_batched_serial_nrm_l2_dcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::L2, KokkosBatched::Mode::Serial>();
+}
+TEST_F(TestCategory, test_batched_serial_nrm_linf_dcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::LInf, KokkosBatched::Mode::Serial>();
+}
+
+// Team
+TEST_F(TestCategory, test_batched_team_nrm_l1_dcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::L1, KokkosBatched::Mode::Team>();
+}
+TEST_F(TestCategory, test_batched_team_nrm_l2_dcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::L2, KokkosBatched::Mode::Team>();
+}
+TEST_F(TestCategory, test_batched_team_nrm_linf_dcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::LInf, KokkosBatched::Mode::Team>();
+}
+
+// TeamVector
+TEST_F(TestCategory, test_batched_teamvector_nrm_l1_dcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::L1, KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_teamvector_nrm_l2_dcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::L2, KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_teamvector_nrm_linf_dcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::LInf, KokkosBatched::Mode::TeamVector>();
+}
+#endif


### PR DESCRIPTION
This PR aims at adding batched norm API.

- [x] Adding a new tag to specify norm type `Norm::L1`, `Norm::L2`, `Norm::LInf`
- [x] Support norm operations [dnrm2](https://www.netlib.org/blas/dnrm2.f90) and [dasum](https://www.netlib.org/blas/dasum.f)
- [x] Add unit-tests 
- [x] Improve unit-testing tools (should be done in a separate [PR](#3121)) 
- [x] Fix LInf Team/TeamVector tests

