### PR TITLE
Implement a macro version of GTEST like helper

### DIFF
--- a/batched/dense/unit_test/Test_Batched_BatchedGemm.hpp
+++ b/batched/dense/unit_test/Test_Batched_BatchedGemm.hpp
@@ -65,8 +65,9 @@ void impl_test_batched_gemm_with_handle(BatchedGemmHandle* batchedGemmHandle, co
     // Check for DblBuf runtime errors related to team_size
     try {
       fmsg = kk_failure_str(__FILE__, __FUNCTION__, __LINE__);
-      Impl::BatchedDblBufGemm<transA, transB, batchLayout, BatchedGemmHandle, ScalarType, decltype(a_actual),
-                              decltype(b_actual), decltype(c_actual), BoundsCheck::Yes, AlphaTag::No, 65536, 1, 65536>(
+      KokkosBatched::Impl::BatchedDblBufGemm<transA, transB, batchLayout, BatchedGemmHandle, ScalarType,
+                                             decltype(a_actual), decltype(b_actual), decltype(c_actual),
+                                             BoundsCheck::Yes, AlphaTag::No, 65536, 1, 65536>(
           batchedGemmHandle, alpha, a_actual, b_actual, beta, c_actual)
           .invoke();
       FAIL() << (fmsg + fmsg_rhs);
@@ -76,9 +77,10 @@ void impl_test_batched_gemm_with_handle(BatchedGemmHandle* batchedGemmHandle, co
     // Check for DblBuf runtime errors related to vector_len
     try {
       fmsg = kk_failure_str(__FILE__, __FUNCTION__, __LINE__);
-      Impl::BatchedDblBufGemm<transA, transB, batchLayout, BatchedGemmHandle, ScalarType, decltype(a_actual),
-                              decltype(b_actual), decltype(c_actual), BoundsCheck::No, AlphaTag::No, 65536, 65536 * 2,
-                              65536>(batchedGemmHandle, alpha, a_actual, b_actual, beta, c_actual)
+      KokkosBatched::Impl::BatchedDblBufGemm<transA, transB, batchLayout, BatchedGemmHandle, ScalarType,
+                                             decltype(a_actual), decltype(b_actual), decltype(c_actual),
+                                             BoundsCheck::No, AlphaTag::No, 65536, 65536 * 2, 65536>(
+          batchedGemmHandle, alpha, a_actual, b_actual, beta, c_actual)
           .invoke();
       FAIL() << (fmsg + fmsg_rhs);
     } catch (const std::runtime_error& error) {

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -44,6 +44,34 @@
 
 namespace Test {
 
+namespace Impl {
+
+template <class Scalar1, class Scalar2, class Scalar3>
+::testing::AssertionResult kk_expect_near_pred_format(const char* expr1, const char* expr2, const char* expr3,
+                                                      const Scalar1& val1, const Scalar2& val2, const Scalar3& tol) {
+  using scalar1_type = typename std::remove_cv<typename std::remove_reference<Scalar1>::type>::type;
+  using scalar3_type = typename std::remove_cv<typename std::remove_reference<Scalar3>::type>::type;
+  using AT1          = KokkosKernels::ArithTraits<scalar1_type>;
+  using AT3          = KokkosKernels::ArithTraits<scalar3_type>;
+
+  const double abs_diff = static_cast<double>(AT1::abs(val1 - val2));
+  const double abs_tol  = static_cast<double>(AT3::abs(tol));
+
+  if (abs_diff <= abs_tol) {
+    return ::testing::AssertionSuccess();
+  }
+
+  return ::testing::AssertionFailure() << "The difference between " << expr1 << " and " << expr2 << " is " << abs_diff
+                                       << ", which exceeds " << expr3 << ", where\n"
+                                       << expr1 << " evaluates to " << ::testing::PrintToString(val1) << ",\n"
+                                       << expr2 << " evaluates to " << ::testing::PrintToString(val2) << ", and\n"
+                                       << expr3 << " evaluates to " << ::testing::PrintToString(tol) << ".";
+}
+
+}  // namespace Impl
+
+#define KK_EXPECT_NEAR(val1, val2, tol) EXPECT_PRED_FORMAT3(::Test::Impl::kk_expect_near_pred_format, val1, val2, tol)
+
 // Utility class for testing kernels with rank-1 and rank-2 views that may be
 // LayoutStride. Simplifies making a LayoutStride view of a given size that is
 // actually noncontiguous, and host-device transfers for checking results on


### PR DESCRIPTION
Currently, we are using `EXPECT_NEAR_KK` in unit-tests. However, this is a function rather than a macro, so it will always print the following message if a test fails. I need to modify `Test_Batched_BatchedGemm.hpp`, as it tries to find `BatchedDblBufGemm` under `Test::Impl`.

```
/work/04/jh220036a/i18048/tests/blas-routines/kokkos-kernels/test_common/KokkosKernels_TestUtils.hpp:127: Failure
Expected: ((double)AT1::abs(val1 - val2)) <= ((double)AT3::abs(tol)), actual: inf vs 1.19209e-06
```

With new macro `KK_EXPECT_NEAR`, we have more details about the failure like

```
/work/04/jh220036a/i18048/tests/blas-routines/kokkos-kernels/batched/dense/unit_test/Test_Batched_Nrm.hpp:220: Failure
The difference between h_norm(ib) and h_norm_ref(ib) is inf, which exceeds eps, where
h_norm(ib) evaluates to -inf,
h_norm_ref(ib) evaluates to 0, and
eps evaluates to 1.19209e-06.
```