### PR TITLE
add missing typename for llvm/15.0.7

### DIFF
--- a/batched/dense/unit_test/Test_Batched_Nrm.hpp
+++ b/batched/dense/unit_test/Test_Batched_Nrm.hpp
@@ -14,7 +14,7 @@ namespace Nrm {
 template <typename DeviceType, typename XViewType, typename NormViewType, typename ArgNorm, typename ArgMode>
 struct Functor_BatchedNrm {
   using execution_space = typename DeviceType::execution_space;
-  using member_type     = Kokkos::TeamPolicy<execution_space>::member_type;
+  using member_type     = typename Kokkos::TeamPolicy<execution_space>::member_type;
   XViewType m_x;
   NormViewType m_norm;
 


### PR DESCRIPTION
detected during nightly Trilinos integration testing with llvm/15.0.7 with deprecated code off; resolves error of type:

18:23:20 /home/jenkins/blake-new/workspace/KokkosEco_Trilinos_Blake_LLVM1507_Serial_debug-new_view-dep_code5_off/Trilinos/kokkos-kernels/batched/dense/unit_test/Test_Batched_Nrm.hpp:17:27: error: missing 'typename' prior to dependent type name 'Kokkos::TeamPolicy<execution_space>::member_type'